### PR TITLE
Review Request: dev-paul

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -84,7 +84,8 @@ service cloud.firestore {
     // Authors and admins can update or delete.
     match /shared_boards/{shareId} {
       allow read: if request.auth != null;
-      allow create: if request.auth != null;
+      allow create: if request.auth != null &&
+        request.resource.data.originalAuthor == request.auth.uid;
       allow update, delete: if request.auth != null &&
         (get(resource.data, 'originalAuthor', null) == request.auth.uid || isAdmin());
     }


### PR DESCRIPTION
### What Changed
- Added explicit Firestore security rules for the `instructional_routines` collection, allowing all authenticated users to read and restricting write access to admins.
- Added security rules for the `shared_boards` collection to enable public read access and authenticated creation, while restricting updates and deletions to the original author or admins.

### Why
- Fixed a 'permission-denied' error in the Instructional Routines widget caused by missing collection-level security rules.
- Preemptively secured the `shared_boards` collection to ensure student view functionality works correctly with Firebase security enforcement.