### PR TITLE
🌿 Gardener: Refactor Sidebar into subcomponents

### DIFF
--- a/components/layout/DashboardView.tsx
+++ b/components/layout/DashboardView.tsx
@@ -2,7 +2,7 @@ import React, { useMemo } from 'react';
 import { useDashboard } from '../../context/useDashboard';
 import { useAuth } from '../../context/useAuth';
 import { useLiveSession } from '../../hooks/useLiveSession';
-import { Sidebar } from './Sidebar';
+import { Sidebar } from './sidebar/Sidebar';
 import { Dock } from './Dock';
 import { WidgetRenderer } from '../widgets/WidgetRenderer';
 import { AlertCircle, CheckCircle2, Info } from 'lucide-react';

--- a/components/layout/sidebar/Sidebar.tsx
+++ b/components/layout/sidebar/Sidebar.tsx
@@ -1,6 +1,5 @@
 import React, { useState, useRef, useEffect, useMemo } from 'react';
 import {
-  Save,
   Plus,
   X,
   Menu,
@@ -24,6 +23,7 @@ import {
   Trash2,
   Cloud,
   CloudCheck,
+  Save,
 } from 'lucide-react';
 import {
   DndContext,
@@ -40,21 +40,17 @@ import {
   sortableKeyboardCoordinates,
   verticalListSortingStrategy,
 } from '@dnd-kit/sortable';
-import { useDashboard } from '../../context/useDashboard';
-import { useAuth } from '../../context/useAuth';
-import { useStorage } from '../../hooks/useStorage';
-import { useBackgrounds } from '../../hooks/useBackgrounds';
-import {
-  Dashboard,
-  GlobalFontFamily,
-  GlobalStyle,
-  DEFAULT_GLOBAL_STYLE,
-} from '../../types';
-import { TOOLS } from '../../config/tools';
-import { getWidgetGradeLevels } from '../../config/widgetGradeLevels';
-import { AdminSettings } from '../admin/AdminSettings';
-import { GlassCard } from '../common/GlassCard';
+import { useDashboard } from '../../../context/useDashboard';
+import { useAuth } from '../../../context/useAuth';
+import { useStorage } from '../../../hooks/useStorage';
+import { useBackgrounds } from '../../../hooks/useBackgrounds';
+import { Dashboard } from '../../../types';
+import { TOOLS } from '../../../config/tools';
+import { getWidgetGradeLevels } from '../../../config/widgetGradeLevels';
+import { AdminSettings } from '../../admin/AdminSettings';
+import { GlassCard } from '../../common/GlassCard';
 import { SortableDashboardItem } from './SortableDashboardItem';
+import { StylePanel } from './StylePanel';
 
 interface DashboardData {
   name: string;
@@ -69,121 +65,6 @@ const GRADE_FILTER_OPTIONS = [
   { value: '6-8', label: '6-8' },
   { value: '9-12', label: '9-12' },
 ] as const;
-
-const FONT_OPTIONS: { id: GlobalFontFamily; label: string; font: string }[] = [
-  { id: 'sans', label: 'Modern Sans', font: 'font-sans' },
-  { id: 'serif', label: 'Classic Serif', font: 'font-serif' },
-  { id: 'rounded', label: 'Soft Rounded', font: 'font-rounded' },
-  { id: 'handwritten', label: 'Handwritten', font: 'font-handwritten' },
-  { id: 'comic', label: 'Comic Style', font: 'font-comic' },
-  { id: 'fun', label: 'Playful Fun', font: 'font-fun' },
-  { id: 'slab', label: 'Classic Slab', font: 'font-slab' },
-  { id: 'retro', label: '8-Bit Retro', font: 'font-retro' },
-  { id: 'marker', label: 'Permanent Marker', font: 'font-marker' },
-  { id: 'cursive', label: 'Elegant Cursive', font: 'font-cursive' },
-  { id: 'mono', label: 'Digital Mono', font: 'font-mono' },
-];
-
-const StylePreview = ({
-  pendingStyle,
-  background,
-  className = '',
-}: {
-  pendingStyle: GlobalStyle;
-  background?: string;
-  className?: string;
-}) => {
-  return (
-    <div
-      className={`relative aspect-[16/9] rounded-2xl overflow-hidden border border-slate-200 bg-slate-100 shadow-2xl flex flex-col items-center justify-center p-6 gap-6 transition-all duration-500 ${className}`}
-    >
-      <div
-        className="absolute inset-0 opacity-20"
-        style={{
-          backgroundImage: background?.startsWith('http')
-            ? `url(${background})`
-            : undefined,
-          backgroundColor: background?.startsWith('bg-')
-            ? undefined
-            : background,
-          backgroundSize: 'cover',
-          backgroundPosition: 'center',
-        }}
-      />
-
-      {/* Window Preview */}
-      <div
-        className={`relative z-10 w-full p-4 border border-white/30 shadow-lg backdrop-blur-md transition-all duration-300 ${
-          pendingStyle.windowBorderRadius === 'none'
-            ? 'rounded-none'
-            : `rounded-${pendingStyle.windowBorderRadius}`
-        }`}
-        style={{
-          backgroundColor: `rgba(255, 255, 255, ${pendingStyle.windowTransparency})`,
-        }}
-      >
-        <div
-          className={`text-center space-y-1 font-${pendingStyle.fontFamily}`}
-        >
-          <div className="text-[10px] font-black uppercase text-slate-400 tracking-widest leading-none mb-1">
-            Window Preview
-          </div>
-          <div className="text-sm leading-tight text-slate-800">
-            The quick brown fox jumps over the lazy dog.
-          </div>
-        </div>
-      </div>
-
-      {/* Dock Preview */}
-      <div
-        className={`relative z-10 px-6 py-2 border border-white/30 shadow-lg backdrop-blur-md flex flex-col items-center gap-2 transition-all duration-300 ${
-          pendingStyle.dockBorderRadius === 'none'
-            ? 'rounded-none'
-            : pendingStyle.dockBorderRadius === 'full'
-              ? 'rounded-full'
-              : `rounded-${pendingStyle.dockBorderRadius}`
-        }`}
-        style={{
-          backgroundColor: `rgba(255, 255, 255, ${pendingStyle.dockTransparency})`,
-        }}
-      >
-        <div className="text-[10px] font-black uppercase text-slate-400 tracking-widest leading-none">
-          Dock Preview
-        </div>
-        <div className="flex items-center gap-4">
-          <div className="flex flex-col items-center gap-1">
-            <div className="w-6 h-6 bg-brand-blue-primary rounded-lg shadow-sm" />
-            <span
-              className={`text-[8px] uppercase tracking-tighter whitespace-nowrap transition-all duration-300 font-${pendingStyle.fontFamily}`}
-              style={{
-                color: pendingStyle.dockTextColor,
-                textShadow: pendingStyle.dockTextShadow
-                  ? '0 1px 2px rgba(0,0,0,0.5)'
-                  : 'none',
-              }}
-            >
-              Icon
-            </span>
-          </div>
-          <div className="flex flex-col items-center gap-1">
-            <div className="w-6 h-6 bg-brand-red-primary rounded-lg shadow-sm" />
-            <span
-              className={`text-[8px] uppercase tracking-tighter whitespace-nowrap transition-all duration-300 font-${pendingStyle.fontFamily}`}
-              style={{
-                color: pendingStyle.dockTextColor,
-                textShadow: pendingStyle.dockTextShadow
-                  ? '0 1px 2px rgba(0,0,0,0.5)'
-                  : 'none',
-              }}
-            >
-              Label
-            </span>
-          </div>
-        </div>
-      </div>
-    </div>
-  );
-};
 
 type MenuSection =
   | 'main'
@@ -257,19 +138,6 @@ export const Sidebar: React.FC = () => {
   const [designTab, setDesignTab] = useState<
     'presets' | 'colors' | 'gradients'
   >('presets');
-
-  const [styleTab, setStyleTab] = useState<'window' | 'dock'>('window');
-  const [isFontMenuOpen, setIsFontMenuOpen] = useState(false);
-
-  const [pendingStyle, setPendingStyle] =
-    useState<GlobalStyle>(DEFAULT_GLOBAL_STYLE);
-
-  // Initialize pending style when sidebar opens or section changes to 'style'
-  useEffect(() => {
-    if (activeSection === 'style' && activeDashboard) {
-      setPendingStyle(activeDashboard.globalStyle ?? DEFAULT_GLOBAL_STYLE);
-    }
-  }, [activeSection, activeDashboard]);
 
   const sensors = useSensors(
     useSensor(PointerSensor, {
@@ -1070,320 +938,13 @@ export const Sidebar: React.FC = () => {
                 </div>
               </div>
 
-              {/* STYLE SECTION */}
-              <div
-                className={`absolute inset-0 flex flex-col transition-all duration-300 ease-in-out ${
-                  activeSection === 'style'
-                    ? 'translate-x-0 opacity-100 visible'
-                    : 'translate-x-full opacity-0 invisible'
-                }`}
-              >
-                {/* TABS & MOBILE PREVIEW */}
-                <div className="bg-white border-b border-slate-100 sticky top-0 z-20 flex flex-col">
-                  {/* Mobile Preview only */}
-                  <div className="lg:hidden p-4 pb-0">
-                    <StylePreview
-                      pendingStyle={pendingStyle}
-                      background={activeDashboard?.background}
-                    />
-                  </div>
-
-                  {/* Sub-tabs */}
-                  <div className="p-4">
-                    <div className="flex bg-slate-100 p-0.5 rounded-lg text-[10px] font-bold uppercase tracking-widest">
-                      <button
-                        onClick={() => setStyleTab('window')}
-                        className={`flex-1 py-1.5 rounded-md flex items-center justify-center gap-2 transition-all ${
-                          styleTab === 'window'
-                            ? 'bg-white shadow-sm text-brand-blue-primary'
-                            : 'text-slate-500'
-                        }`}
-                      >
-                        <Maximize className="w-3.5 h-3.5" /> Window
-                      </button>
-
-                      <button
-                        onClick={() => setStyleTab('dock')}
-                        className={`flex-1 py-1.5 rounded-md flex items-center justify-center gap-2 transition-all ${
-                          styleTab === 'dock'
-                            ? 'bg-white shadow-sm text-brand-blue-primary'
-                            : 'text-slate-500'
-                        }`}
-                      >
-                        <Minimize className="w-3.5 h-3.5 rotate-90" /> Dock
-                      </button>
-                    </div>
-                  </div>
-                </div>
-
-                <div className="flex-1 overflow-y-auto p-4 space-y-6 custom-scrollbar pb-40">
-                  {/* Global Font Family - Always visible */}
-                  <div className="space-y-3">
-                    <div className="flex justify-between items-center px-1">
-                      <h3 className="text-[10px] font-bold text-slate-400 uppercase tracking-widest">
-                        Typography
-                      </h3>
-                      <button
-                        onClick={() => setIsFontMenuOpen(!isFontMenuOpen)}
-                        className="text-[9px] font-bold uppercase text-brand-blue-primary"
-                      >
-                        {isFontMenuOpen ? 'Close' : 'Change'}
-                      </button>
-                    </div>
-
-                    <div className="relative">
-                      {/* Selected Font */}
-                      <button
-                        onClick={() => setIsFontMenuOpen(!isFontMenuOpen)}
-                        className="w-full flex items-center justify-between p-3 rounded-lg border bg-white border-slate-200 text-slate-800"
-                      >
-                        <span
-                          className={`text-sm font-bold font-${pendingStyle.fontFamily}`}
-                        >
-                          {
-                            FONT_OPTIONS.find(
-                              (f) => f.id === pendingStyle.fontFamily
-                            )?.label
-                          }
-                        </span>
-                        <ChevronRight
-                          className={`w-4 h-4 transition-transform ${isFontMenuOpen ? 'rotate-90' : ''}`}
-                        />
-                      </button>
-
-                      {/* Collapsible Font List */}
-                      <div
-                        className={`overflow-hidden transition-all duration-300 ${
-                          isFontMenuOpen ? 'max-h-96 mt-2' : 'max-h-0'
-                        }`}
-                      >
-                        <div className="grid grid-cols-1 gap-1 p-1 bg-slate-50 rounded-xl border border-slate-200">
-                          {FONT_OPTIONS.map((f) => (
-                            <button
-                              key={f.id}
-                              onClick={() => {
-                                setPendingStyle({
-                                  ...pendingStyle,
-                                  fontFamily: f.id,
-                                });
-                                setIsFontMenuOpen(false);
-                              }}
-                              className={`w-full flex items-center justify-between p-2.5 rounded-md transition-all ${
-                                pendingStyle.fontFamily === f.id
-                                  ? 'bg-brand-blue-primary text-white shadow-sm'
-                                  : 'bg-white hover:bg-slate-50 text-slate-600'
-                              }`}
-                            >
-                              <span className={`text-xs font-bold ${f.font}`}>
-                                {f.label}
-                              </span>
-                              {pendingStyle.fontFamily === f.id && (
-                                <CheckSquare className="w-3.5 h-3.5 text-white" />
-                              )}
-                            </button>
-                          ))}
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-
-                  {styleTab === 'window' ? (
-                    <div className="space-y-6 animate-in fade-in slide-in-from-left-2 duration-300">
-                      {/* Window Transparency */}
-                      <div className="space-y-3">
-                        <div className="flex justify-between items-center px-1">
-                          <h3 className="text-[10px] font-bold text-slate-400 uppercase tracking-widest">
-                            Transparency
-                          </h3>
-                          <span className="text-[10px] font-mono font-bold text-brand-blue-primary">
-                            {Math.round(pendingStyle.windowTransparency * 100)}%
-                          </span>
-                        </div>
-                        <input
-                          type="range"
-                          min="0.05"
-                          max="1"
-                          step="0.05"
-                          value={pendingStyle.windowTransparency}
-                          onChange={(e) =>
-                            setPendingStyle({
-                              ...pendingStyle,
-                              windowTransparency: parseFloat(e.target.value),
-                            })
-                          }
-                          className="w-full h-1.5 bg-slate-200 rounded-full appearance-none cursor-pointer accent-brand-blue-primary"
-                        />
-                      </div>
-
-                      {/* Window Corners */}
-                      <div className="space-y-3">
-                        <h3 className="text-[10px] font-bold text-slate-400 uppercase tracking-widest px-1">
-                          Corners
-                        </h3>
-                        <div className="flex bg-slate-100 p-0.5 rounded-lg">
-                          {[
-                            { id: 'none', label: 'Square' },
-                            { id: 'lg', label: 'Soft' },
-                            { id: '2xl', label: 'Round' },
-                            { id: '3xl', label: 'Extra' },
-                          ].map((r) => (
-                            <button
-                              key={r.id}
-                              onClick={() =>
-                                setPendingStyle({
-                                  ...pendingStyle,
-                                  windowBorderRadius:
-                                    r.id as GlobalStyle['windowBorderRadius'],
-                                })
-                              }
-                              className={`flex-1 py-1.5 rounded-md text-[9px] font-bold uppercase transition-all ${
-                                pendingStyle.windowBorderRadius === r.id
-                                  ? 'bg-white shadow-sm text-brand-blue-primary'
-                                  : 'text-slate-500'
-                              }`}
-                            >
-                              {r.label}
-                            </button>
-                          ))}
-                        </div>
-                      </div>
-                    </div>
-                  ) : (
-                    <div className="space-y-6 animate-in fade-in slide-in-from-right-2 duration-300">
-                      {/* Dock Transparency */}
-                      <div className="space-y-3">
-                        <div className="flex justify-between items-center px-1">
-                          <h3 className="text-[10px] font-bold text-slate-400 uppercase tracking-widest">
-                            Transparency
-                          </h3>
-                          <span className="text-[10px] font-mono font-bold text-brand-blue-primary">
-                            {Math.round(pendingStyle.dockTransparency * 100)}%
-                          </span>
-                        </div>
-                        <input
-                          type="range"
-                          min="0.05"
-                          max="1"
-                          step="0.05"
-                          value={pendingStyle.dockTransparency}
-                          onChange={(e) =>
-                            setPendingStyle({
-                              ...pendingStyle,
-                              dockTransparency: parseFloat(e.target.value),
-                            })
-                          }
-                          className="w-full h-1.5 bg-slate-200 rounded-full appearance-none cursor-pointer accent-brand-blue-primary"
-                        />
-                      </div>
-
-                      {/* Dock Corners */}
-                      <div className="space-y-3">
-                        <h3 className="text-[10px] font-bold text-slate-400 uppercase tracking-widest px-1">
-                          Corners
-                        </h3>
-                        <div className="flex bg-slate-100 p-0.5 rounded-lg">
-                          {[
-                            { id: 'none', label: 'Square' },
-                            { id: 'lg', label: 'Soft' },
-                            { id: '2xl', label: 'Round' },
-                            { id: 'full', label: 'Full' },
-                          ].map((r) => (
-                            <button
-                              key={r.id}
-                              onClick={() =>
-                                setPendingStyle({
-                                  ...pendingStyle,
-                                  dockBorderRadius:
-                                    r.id as GlobalStyle['dockBorderRadius'],
-                                })
-                              }
-                              className={`flex-1 py-1.5 rounded-md text-[9px] font-bold uppercase transition-all ${
-                                pendingStyle.dockBorderRadius === r.id
-                                  ? 'bg-white shadow-sm text-brand-blue-primary'
-                                  : 'text-slate-500'
-                              }`}
-                            >
-                              {r.label}
-                            </button>
-                          ))}
-                        </div>
-                      </div>
-
-                      {/* Dock Text Style */}
-                      <div className="space-y-3">
-                        <h3 className="text-[10px] font-bold text-slate-400 uppercase tracking-widest px-1">
-                          Dock Text
-                        </h3>
-                        <div className="flex flex-col gap-3">
-                          <div className="flex items-center gap-3 bg-white p-2 rounded-lg border border-slate-100">
-                            <input
-                              type="color"
-                              value={pendingStyle.dockTextColor}
-                              onChange={(e) =>
-                                setPendingStyle({
-                                  ...pendingStyle,
-                                  dockTextColor: e.target.value,
-                                })
-                              }
-                              className="w-8 h-8 rounded-md border border-slate-200 bg-white cursor-pointer"
-                            />
-                            <span className="text-[11px] font-bold text-slate-600 uppercase">
-                              Text Color
-                            </span>
-                          </div>
-
-                          <button
-                            onClick={() =>
-                              setPendingStyle({
-                                ...pendingStyle,
-                                dockTextShadow: !pendingStyle.dockTextShadow,
-                              })
-                            }
-                            className={`flex items-center justify-between p-3 rounded-lg border transition-all ${
-                              pendingStyle.dockTextShadow
-                                ? 'bg-white border-brand-blue-primary text-brand-blue-dark shadow-sm'
-                                : 'bg-white border-slate-100 text-slate-500'
-                            }`}
-                          >
-                            <span className="text-[11px] font-bold uppercase tracking-wider">
-                              Text Shadow
-                            </span>
-                            {pendingStyle.dockTextShadow && (
-                              <CheckSquare className="w-4 h-4 text-brand-blue-primary" />
-                            )}
-                          </button>
-                        </div>
-                      </div>
-                    </div>
-                  )}
-                </div>
-
-                {/* ACTION BUTTONS */}
-                <div className="mt-auto p-4 bg-white border-t border-slate-100 flex gap-2">
-                  <button
-                    onClick={() => {
-                      setGlobalStyle(pendingStyle);
-                      addToast('Global style applied', 'success');
-                    }}
-                    className="flex-1 flex items-center justify-center gap-2 py-2.5 bg-brand-blue-primary text-white rounded-xl font-bold text-[10px] uppercase tracking-widest shadow-sm hover:bg-brand-blue-dark transition-all"
-                  >
-                    <Save className="w-3.5 h-3.5" /> Save
-                  </button>
-
-                  <button
-                    onClick={() => {
-                      if (activeDashboard) {
-                        setPendingStyle(
-                          activeDashboard.globalStyle ?? DEFAULT_GLOBAL_STYLE
-                        );
-                      }
-                    }}
-                    className="flex-1 py-2.5 bg-slate-100 text-slate-500 rounded-xl font-bold text-[10px] uppercase tracking-widest hover:bg-slate-200 transition-all"
-                  >
-                    Discard
-                  </button>
-                </div>
-              </div>
+              {/* STYLE SECTION - REPLACED */}
+              <StylePanel
+                isVisible={activeSection === 'style'}
+                activeDashboard={activeDashboard}
+                setGlobalStyle={setGlobalStyle}
+                addToast={addToast}
+              />
 
               {/* SETTINGS SECTION */}
               <div
@@ -1529,27 +1090,6 @@ export const Sidebar: React.FC = () => {
               </div>
             </footer>
           </div>
-
-          {/* Attached Style Preview for Desktop */}
-          {activeSection === 'style' && (
-            <div className="hidden lg:flex flex-col justify-center p-12 animate-in fade-in slide-in-from-left-8 duration-500 pointer-events-none">
-              <div className="w-[450px] pointer-events-auto">
-                <div className="flex flex-col gap-3 mb-6 drop-shadow-2xl">
-                  <h3 className="text-sm font-black text-white uppercase tracking-[0.3em] drop-shadow-lg">
-                    Style Preview
-                  </h3>
-                  <div className="h-1 w-12 bg-white/50 rounded-full" />
-                </div>
-                <StylePreview
-                  pendingStyle={pendingStyle}
-                  background={activeDashboard?.background}
-                />
-                <p className="mt-6 text-[10px] font-bold text-white/60 uppercase tracking-[0.2em] text-center drop-shadow-md">
-                  Preview updates live as you adjust settings
-                </p>
-              </div>
-            </div>
-          )}
         </div>
       )}
     </>

--- a/components/layout/sidebar/SortableDashboardItem.tsx
+++ b/components/layout/sidebar/SortableDashboardItem.tsx
@@ -2,8 +2,8 @@ import React from 'react';
 import { GripVertical, Star, Pencil, Copy, Share2, Trash2 } from 'lucide-react';
 import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
-import { Dashboard } from '../../types';
-import { Z_INDEX } from '../../config/zIndex';
+import { Dashboard } from '../../../types';
+import { Z_INDEX } from '../../../config/zIndex';
 
 interface SortableDashboardItemProps {
   db: Dashboard;

--- a/components/layout/sidebar/StylePanel.tsx
+++ b/components/layout/sidebar/StylePanel.tsx
@@ -1,0 +1,409 @@
+import React, { useState } from 'react';
+import { createPortal } from 'react-dom';
+import {
+  Save,
+  CheckSquare,
+  ChevronRight,
+  Maximize,
+  Minimize,
+} from 'lucide-react';
+import {
+  Dashboard,
+  GlobalFontFamily,
+  GlobalStyle,
+  DEFAULT_GLOBAL_STYLE,
+} from '../../../types';
+import { Z_INDEX } from '../../../config/zIndex';
+import { StylePreview } from './StylePreview';
+
+const FONT_OPTIONS: { id: GlobalFontFamily; label: string; font: string }[] = [
+  { id: 'sans', label: 'Modern Sans', font: 'font-sans' },
+  { id: 'serif', label: 'Classic Serif', font: 'font-serif' },
+  { id: 'rounded', label: 'Soft Rounded', font: 'font-rounded' },
+  { id: 'handwritten', label: 'Handwritten', font: 'font-handwritten' },
+  { id: 'comic', label: 'Comic Style', font: 'font-comic' },
+  { id: 'fun', label: 'Playful Fun', font: 'font-fun' },
+  { id: 'slab', label: 'Classic Slab', font: 'font-slab' },
+  { id: 'retro', label: '8-Bit Retro', font: 'font-retro' },
+  { id: 'marker', label: 'Permanent Marker', font: 'font-marker' },
+  { id: 'cursive', label: 'Elegant Cursive', font: 'font-cursive' },
+  { id: 'mono', label: 'Digital Mono', font: 'font-mono' },
+];
+
+interface StylePanelProps {
+  isVisible: boolean;
+  activeDashboard: Dashboard | null | undefined;
+  setGlobalStyle: (style: GlobalStyle) => void;
+  addToast: (message: string, type: 'success' | 'error' | 'info') => void;
+}
+
+export const StylePanel: React.FC<StylePanelProps> = ({
+  isVisible,
+  activeDashboard,
+  setGlobalStyle,
+  addToast,
+}) => {
+  const [styleTab, setStyleTab] = useState<'window' | 'dock'>('window');
+  const [isFontMenuOpen, setIsFontMenuOpen] = useState(false);
+  const [pendingStyle, setPendingStyle] =
+    useState<GlobalStyle>(DEFAULT_GLOBAL_STYLE);
+
+  // State adjustment pattern to reset pendingStyle when opening
+  const [prevIsVisible, setPrevIsVisible] = useState(isVisible);
+  const [prevDashboardId, setPrevDashboardId] = useState(activeDashboard?.id);
+
+  if (isVisible && !prevIsVisible) {
+    setPrevIsVisible(true);
+    setPendingStyle(activeDashboard?.globalStyle ?? DEFAULT_GLOBAL_STYLE);
+  } else if (!isVisible && prevIsVisible) {
+    setPrevIsVisible(false);
+  }
+
+  if (activeDashboard?.id !== prevDashboardId) {
+    setPrevDashboardId(activeDashboard?.id);
+    if (isVisible) {
+      setPendingStyle(activeDashboard?.globalStyle ?? DEFAULT_GLOBAL_STYLE);
+    }
+  }
+
+  return (
+    <div
+      className={`absolute inset-0 flex flex-col transition-all duration-300 ease-in-out ${
+        isVisible
+          ? 'translate-x-0 opacity-100 visible'
+          : 'translate-x-full opacity-0 invisible'
+      }`}
+    >
+      {/* TABS & MOBILE PREVIEW */}
+      <div className="bg-white border-b border-slate-100 sticky top-0 z-20 flex flex-col">
+        {/* Mobile Preview only */}
+        <div className="lg:hidden p-4 pb-0">
+          <StylePreview
+            pendingStyle={pendingStyle}
+            background={activeDashboard?.background}
+          />
+        </div>
+
+        {/* Sub-tabs */}
+        <div className="p-4">
+          <div className="flex bg-slate-100 p-0.5 rounded-lg text-[10px] font-bold uppercase tracking-widest">
+            <button
+              onClick={() => setStyleTab('window')}
+              className={`flex-1 py-1.5 rounded-md flex items-center justify-center gap-2 transition-all ${
+                styleTab === 'window'
+                  ? 'bg-white shadow-sm text-brand-blue-primary'
+                  : 'text-slate-500'
+              }`}
+            >
+              <Maximize className="w-3.5 h-3.5" /> Window
+            </button>
+
+            <button
+              onClick={() => setStyleTab('dock')}
+              className={`flex-1 py-1.5 rounded-md flex items-center justify-center gap-2 transition-all ${
+                styleTab === 'dock'
+                  ? 'bg-white shadow-sm text-brand-blue-primary'
+                  : 'text-slate-500'
+              }`}
+            >
+              <Minimize className="w-3.5 h-3.5 rotate-90" /> Dock
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <div className="flex-1 overflow-y-auto p-4 space-y-6 custom-scrollbar pb-40">
+        {/* Global Font Family - Always visible */}
+        <div className="space-y-3">
+          <div className="flex justify-between items-center px-1">
+            <h3 className="text-[10px] font-bold text-slate-400 uppercase tracking-widest">
+              Typography
+            </h3>
+            <button
+              onClick={() => setIsFontMenuOpen(!isFontMenuOpen)}
+              className="text-[9px] font-bold uppercase text-brand-blue-primary"
+            >
+              {isFontMenuOpen ? 'Close' : 'Change'}
+            </button>
+          </div>
+
+          <div className="relative">
+            {/* Selected Font */}
+            <button
+              onClick={() => setIsFontMenuOpen(!isFontMenuOpen)}
+              className="w-full flex items-center justify-between p-3 rounded-lg border bg-white border-slate-200 text-slate-800"
+            >
+              <span
+                className={`text-sm font-bold font-${pendingStyle.fontFamily}`}
+              >
+                {
+                  FONT_OPTIONS.find((f) => f.id === pendingStyle.fontFamily)
+                    ?.label
+                }
+              </span>
+              <ChevronRight
+                className={`w-4 h-4 transition-transform ${isFontMenuOpen ? 'rotate-90' : ''}`}
+              />
+            </button>
+
+            {/* Collapsible Font List */}
+            <div
+              className={`overflow-hidden transition-all duration-300 ${
+                isFontMenuOpen ? 'max-h-96 mt-2' : 'max-h-0'
+              }`}
+            >
+              <div className="grid grid-cols-1 gap-1 p-1 bg-slate-50 rounded-xl border border-slate-200">
+                {FONT_OPTIONS.map((f) => (
+                  <button
+                    key={f.id}
+                    onClick={() => {
+                      setPendingStyle({
+                        ...pendingStyle,
+                        fontFamily: f.id,
+                      });
+                      setIsFontMenuOpen(false);
+                    }}
+                    className={`w-full flex items-center justify-between p-2.5 rounded-md transition-all ${
+                      pendingStyle.fontFamily === f.id
+                        ? 'bg-brand-blue-primary text-white shadow-sm'
+                        : 'bg-white hover:bg-slate-50 text-slate-600'
+                    }`}
+                  >
+                    <span className={`text-xs font-bold ${f.font}`}>
+                      {f.label}
+                    </span>
+                    {pendingStyle.fontFamily === f.id && (
+                      <CheckSquare className="w-3.5 h-3.5 text-white" />
+                    )}
+                  </button>
+                ))}
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {styleTab === 'window' ? (
+          <div className="space-y-6 animate-in fade-in slide-in-from-left-2 duration-300">
+            {/* Window Transparency */}
+            <div className="space-y-3">
+              <div className="flex justify-between items-center px-1">
+                <h3 className="text-[10px] font-bold text-slate-400 uppercase tracking-widest">
+                  Transparency
+                </h3>
+                <span className="text-[10px] font-mono font-bold text-brand-blue-primary">
+                  {Math.round(pendingStyle.windowTransparency * 100)}%
+                </span>
+              </div>
+              <input
+                type="range"
+                min="0.05"
+                max="1"
+                step="0.05"
+                value={pendingStyle.windowTransparency}
+                onChange={(e) =>
+                  setPendingStyle({
+                    ...pendingStyle,
+                    windowTransparency: parseFloat(e.target.value),
+                  })
+                }
+                className="w-full h-1.5 bg-slate-200 rounded-full appearance-none cursor-pointer accent-brand-blue-primary"
+              />
+            </div>
+
+            {/* Window Corners */}
+            <div className="space-y-3">
+              <h3 className="text-[10px] font-bold text-slate-400 uppercase tracking-widest px-1">
+                Corners
+              </h3>
+              <div className="flex bg-slate-100 p-0.5 rounded-lg">
+                {[
+                  { id: 'none', label: 'Square' },
+                  { id: 'lg', label: 'Soft' },
+                  { id: '2xl', label: 'Round' },
+                  { id: '3xl', label: 'Extra' },
+                ].map((r) => (
+                  <button
+                    key={r.id}
+                    onClick={() =>
+                      setPendingStyle({
+                        ...pendingStyle,
+                        windowBorderRadius:
+                          r.id as GlobalStyle['windowBorderRadius'],
+                      })
+                    }
+                    className={`flex-1 py-1.5 rounded-md text-[9px] font-bold uppercase transition-all ${
+                      pendingStyle.windowBorderRadius === r.id
+                        ? 'bg-white shadow-sm text-brand-blue-primary'
+                        : 'text-slate-500'
+                    }`}
+                  >
+                    {r.label}
+                  </button>
+                ))}
+              </div>
+            </div>
+          </div>
+        ) : (
+          <div className="space-y-6 animate-in fade-in slide-in-from-right-2 duration-300">
+            {/* Dock Transparency */}
+            <div className="space-y-3">
+              <div className="flex justify-between items-center px-1">
+                <h3 className="text-[10px] font-bold text-slate-400 uppercase tracking-widest">
+                  Transparency
+                </h3>
+                <span className="text-[10px] font-mono font-bold text-brand-blue-primary">
+                  {Math.round(pendingStyle.dockTransparency * 100)}%
+                </span>
+              </div>
+              <input
+                type="range"
+                min="0.05"
+                max="1"
+                step="0.05"
+                value={pendingStyle.dockTransparency}
+                onChange={(e) =>
+                  setPendingStyle({
+                    ...pendingStyle,
+                    dockTransparency: parseFloat(e.target.value),
+                  })
+                }
+                className="w-full h-1.5 bg-slate-200 rounded-full appearance-none cursor-pointer accent-brand-blue-primary"
+              />
+            </div>
+
+            {/* Dock Corners */}
+            <div className="space-y-3">
+              <h3 className="text-[10px] font-bold text-slate-400 uppercase tracking-widest px-1">
+                Corners
+              </h3>
+              <div className="flex bg-slate-100 p-0.5 rounded-lg">
+                {[
+                  { id: 'none', label: 'Square' },
+                  { id: 'lg', label: 'Soft' },
+                  { id: '2xl', label: 'Round' },
+                  { id: 'full', label: 'Full' },
+                ].map((r) => (
+                  <button
+                    key={r.id}
+                    onClick={() =>
+                      setPendingStyle({
+                        ...pendingStyle,
+                        dockBorderRadius:
+                          r.id as GlobalStyle['dockBorderRadius'],
+                      })
+                    }
+                    className={`flex-1 py-1.5 rounded-md text-[9px] font-bold uppercase transition-all ${
+                      pendingStyle.dockBorderRadius === r.id
+                        ? 'bg-white shadow-sm text-brand-blue-primary'
+                        : 'text-slate-500'
+                    }`}
+                  >
+                    {r.label}
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            {/* Dock Text Style */}
+            <div className="space-y-3">
+              <h3 className="text-[10px] font-bold text-slate-400 uppercase tracking-widest px-1">
+                Dock Text
+              </h3>
+              <div className="flex flex-col gap-3">
+                <div className="flex items-center gap-3 bg-white p-2 rounded-lg border border-slate-100">
+                  <input
+                    type="color"
+                    value={pendingStyle.dockTextColor}
+                    onChange={(e) =>
+                      setPendingStyle({
+                        ...pendingStyle,
+                        dockTextColor: e.target.value,
+                      })
+                    }
+                    className="w-8 h-8 rounded-md border border-slate-200 bg-white cursor-pointer"
+                  />
+                  <span className="text-[11px] font-bold text-slate-600 uppercase">
+                    Text Color
+                  </span>
+                </div>
+
+                <button
+                  onClick={() =>
+                    setPendingStyle({
+                      ...pendingStyle,
+                      dockTextShadow: !pendingStyle.dockTextShadow,
+                    })
+                  }
+                  className={`flex items-center justify-between p-3 rounded-lg border transition-all ${
+                    pendingStyle.dockTextShadow
+                      ? 'bg-white border-brand-blue-primary text-brand-blue-dark shadow-sm'
+                      : 'bg-white border-slate-100 text-slate-500'
+                  }`}
+                >
+                  <span className="text-[11px] font-bold uppercase tracking-wider">
+                    Text Shadow
+                  </span>
+                  {pendingStyle.dockTextShadow && (
+                    <CheckSquare className="w-4 h-4 text-brand-blue-primary" />
+                  )}
+                </button>
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* ACTION BUTTONS */}
+      <div className="mt-auto p-4 bg-white border-t border-slate-100 flex gap-2">
+        <button
+          onClick={() => {
+            setGlobalStyle(pendingStyle);
+            addToast('Global style applied', 'success');
+          }}
+          className="flex-1 flex items-center justify-center gap-2 py-2.5 bg-brand-blue-primary text-white rounded-xl font-bold text-[10px] uppercase tracking-widest shadow-sm hover:bg-brand-blue-dark transition-all"
+        >
+          <Save className="w-3.5 h-3.5" /> Save
+        </button>
+
+        <button
+          onClick={() => {
+            if (activeDashboard) {
+              setPendingStyle(
+                activeDashboard.globalStyle ?? DEFAULT_GLOBAL_STYLE
+              );
+            }
+          }}
+          className="flex-1 py-2.5 bg-slate-100 text-slate-500 rounded-xl font-bold text-[10px] uppercase tracking-widest hover:bg-slate-200 transition-all"
+        >
+          Discard
+        </button>
+      </div>
+
+      {/* Attached Style Preview for Desktop */}
+      {isVisible &&
+        createPortal(
+          <div
+            className="hidden lg:flex flex-col justify-center p-12 animate-in fade-in slide-in-from-left-8 duration-500 pointer-events-none fixed left-72 top-0 bottom-0"
+            style={{ zIndex: Z_INDEX.modal }}
+          >
+            <div className="w-[450px] pointer-events-auto">
+              <div className="flex flex-col gap-3 mb-6 drop-shadow-2xl">
+                <h3 className="text-sm font-black text-white uppercase tracking-[0.3em] drop-shadow-lg">
+                  Style Preview
+                </h3>
+                <div className="h-1 w-12 bg-white/50 rounded-full" />
+              </div>
+              <StylePreview
+                pendingStyle={pendingStyle}
+                background={activeDashboard?.background}
+              />
+              <p className="mt-6 text-[10px] font-bold text-white/60 uppercase tracking-[0.2em] text-center drop-shadow-md">
+                Preview updates live as you adjust settings
+              </p>
+            </div>
+          </div>,
+          document.body
+        )}
+    </div>
+  );
+};

--- a/components/layout/sidebar/StylePreview.tsx
+++ b/components/layout/sidebar/StylePreview.tsx
@@ -1,0 +1,103 @@
+import React from 'react';
+import { GlobalStyle } from '../../../types';
+
+export const StylePreview = ({
+  pendingStyle,
+  background,
+  className = '',
+}: {
+  pendingStyle: GlobalStyle;
+  background?: string;
+  className?: string;
+}) => {
+  return (
+    <div
+      className={`relative aspect-[16/9] rounded-2xl overflow-hidden border border-slate-200 bg-slate-100 shadow-2xl flex flex-col items-center justify-center p-6 gap-6 transition-all duration-500 ${className}`}
+    >
+      <div
+        className="absolute inset-0 opacity-20"
+        style={{
+          backgroundImage: background?.startsWith('http')
+            ? `url(${background})`
+            : undefined,
+          backgroundColor: background?.startsWith('bg-')
+            ? undefined
+            : background,
+          backgroundSize: 'cover',
+          backgroundPosition: 'center',
+        }}
+      />
+
+      {/* Window Preview */}
+      <div
+        className={`relative z-10 w-full p-4 border border-white/30 shadow-lg backdrop-blur-md transition-all duration-300 ${
+          pendingStyle.windowBorderRadius === 'none'
+            ? 'rounded-none'
+            : `rounded-${pendingStyle.windowBorderRadius}`
+        }`}
+        style={{
+          backgroundColor: `rgba(255, 255, 255, ${pendingStyle.windowTransparency})`,
+        }}
+      >
+        <div
+          className={`text-center space-y-1 font-${pendingStyle.fontFamily}`}
+        >
+          <div className="text-[10px] font-black uppercase text-slate-400 tracking-widest leading-none mb-1">
+            Window Preview
+          </div>
+          <div className="text-sm leading-tight text-slate-800">
+            The quick brown fox jumps over the lazy dog.
+          </div>
+        </div>
+      </div>
+
+      {/* Dock Preview */}
+      <div
+        className={`relative z-10 px-6 py-2 border border-white/30 shadow-lg backdrop-blur-md flex flex-col items-center gap-2 transition-all duration-300 ${
+          pendingStyle.dockBorderRadius === 'none'
+            ? 'rounded-none'
+            : pendingStyle.dockBorderRadius === 'full'
+              ? 'rounded-full'
+              : `rounded-${pendingStyle.dockBorderRadius}`
+        }`}
+        style={{
+          backgroundColor: `rgba(255, 255, 255, ${pendingStyle.dockTransparency})`,
+        }}
+      >
+        <div className="text-[10px] font-black uppercase text-slate-400 tracking-widest leading-none">
+          Dock Preview
+        </div>
+        <div className="flex items-center gap-4">
+          <div className="flex flex-col items-center gap-1">
+            <div className="w-6 h-6 bg-brand-blue-primary rounded-lg shadow-sm" />
+            <span
+              className={`text-[8px] uppercase tracking-tighter whitespace-nowrap transition-all duration-300 font-${pendingStyle.fontFamily}`}
+              style={{
+                color: pendingStyle.dockTextColor,
+                textShadow: pendingStyle.dockTextShadow
+                  ? '0 1px 2px rgba(0,0,0,0.5)'
+                  : 'none',
+              }}
+            >
+              Icon
+            </span>
+          </div>
+          <div className="flex flex-col items-center gap-1">
+            <div className="w-6 h-6 bg-brand-red-primary rounded-lg shadow-sm" />
+            <span
+              className={`text-[8px] uppercase tracking-tighter whitespace-nowrap transition-all duration-300 font-${pendingStyle.fontFamily}`}
+              style={{
+                color: pendingStyle.dockTextColor,
+                textShadow: pendingStyle.dockTextShadow
+                  ? '0 1px 2px rgba(0,0,0,0.5)'
+                  : 'none',
+              }}
+            >
+              Label
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/tests/components/layout/DashboardView.test.tsx
+++ b/tests/components/layout/DashboardView.test.tsx
@@ -20,7 +20,7 @@ vi.mock('../../../hooks/useLiveSession', () => ({
 }));
 
 // Mock child components
-vi.mock('../../../components/layout/Sidebar', () => ({
+vi.mock('../../../components/layout/sidebar/Sidebar', () => ({
   Sidebar: () => <div data-testid="sidebar">Sidebar</div>,
 }));
 vi.mock('../../../components/layout/Dock', () => ({


### PR DESCRIPTION
Refactored `components/layout/Sidebar.tsx` (1500+ lines) into a `sidebar/` directory with `Sidebar.tsx`, `StylePanel.tsx`, `StylePreview.tsx`, and moved `SortableDashboardItem.tsx` there.
Extracted complex "Style" tab logic and state management into `StylePanel`.
Fixed visual regression where the desktop style preview was clipped by using `React.createPortal`.
Updated tests and imports.
Verified with lint, type checks, and unit tests.

---
*PR created automatically by Jules for task [16735489773042984474](https://jules.google.com/task/16735489773042984474) started by @OPS-PIvers*