### PR TITLE
🌿 Gardener: Consolidate Widget Defaults

### DIFF
--- a/.Jules/gardener.md
+++ b/.Jules/gardener.md
@@ -23,3 +23,8 @@
 **Weed:** `Sidebar.tsx` was over 1400 lines and contained a large inner component definition (`SortableDashboardItem`) and duplicated background fetching logic found in `useBackgrounds`.
 **Root Cause:** Component grew organically as features were added (boards, backgrounds, widgets) without separating concerns.
 **Plan:** Extract sub-components and leverage existing hooks to reduce file size and improve readability/maintainability.
+
+## 2025-06-03 - [Consolidate Widget Defaults]
+**Weed:** Redundant default configuration logic in `utils/widgetHelpers.ts` (`getDefaultWidgetConfig`) duplicating `config/widgetDefaults.ts`.
+**Root Cause:** Two sources of truth for widget defaults, leading to potential inconsistencies (e.g., `checklist` default config mismatch).
+**Plan:** Remove `getDefaultWidgetConfig` and refactor consumers (`StudentApp.tsx`, tests) to use the centralized `WIDGET_DEFAULTS`.

--- a/components/student/StudentApp.tsx
+++ b/components/student/StudentApp.tsx
@@ -5,8 +5,8 @@ import { useLiveSession } from '../../hooks/useLiveSession';
 import { StudentLobby } from './StudentLobby';
 import { WidgetRenderer } from '../widgets/WidgetRenderer';
 import { Snowflake, Radio } from 'lucide-react';
-import { WidgetData, DEFAULT_GLOBAL_STYLE } from '../../types';
-import { getDefaultWidgetConfig } from '../../utils/widgetHelpers';
+import { WidgetData, DEFAULT_GLOBAL_STYLE, WidgetConfig } from '../../types';
+import { WIDGET_DEFAULTS } from '../../config/widgetDefaults';
 
 const noop = () => undefined;
 const asyncNoop = async () => {
@@ -204,7 +204,9 @@ export const StudentApp = () => {
     flipped: false,
     config:
       session.activeWidgetConfig ??
-      getDefaultWidgetConfig(session.activeWidgetType ?? 'clock'),
+      (WIDGET_DEFAULTS[session.activeWidgetType ?? 'clock']
+        ?.config as WidgetConfig) ??
+      {},
     isLive: true,
   };
 

--- a/utils/widgetHelpers.test.ts
+++ b/utils/widgetHelpers.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import { getTitle, getDefaultWidgetConfig } from './widgetHelpers';
+import { getTitle } from './widgetHelpers';
+import { WIDGET_DEFAULTS } from '../config/widgetDefaults';
 import { WidgetData, TimeToolConfig, WidgetType } from '../types';
 
 describe('widgetHelpers', () => {
@@ -43,28 +44,31 @@ describe('widgetHelpers', () => {
     });
   });
 
-  describe('getDefaultWidgetConfig', () => {
-    it('returns correct defaults for time-tool', () => {
-      const config = getDefaultWidgetConfig('time-tool') as TimeToolConfig;
+  describe('WIDGET_DEFAULTS', () => {
+    it('contains correct defaults for time-tool', () => {
+      const config = WIDGET_DEFAULTS['time-tool']?.config as TimeToolConfig;
       expect(config.mode).toBe('timer');
     });
 
-    it('returns correct defaults for miniApp', () => {
-      const config = getDefaultWidgetConfig('miniApp');
+    it('contains correct defaults for miniApp', () => {
+      const config = WIDGET_DEFAULTS['miniApp']?.config;
       expect(config).toHaveProperty('activeApp', null);
     });
 
-    it('returns correct defaults for checklist', () => {
-      const config = getDefaultWidgetConfig('checklist');
-      expect(config).toEqual({ items: [] });
+    it('contains correct defaults for checklist', () => {
+      const config = WIDGET_DEFAULTS['checklist']?.config;
+      expect(config).toMatchObject({
+        items: [],
+        mode: 'manual',
+      });
     });
 
-    it('returns empty object for traffic', () => {
-      const config = getDefaultWidgetConfig('traffic');
+    it('contains empty config for traffic', () => {
+      const config = WIDGET_DEFAULTS['traffic']?.config;
       expect(config).toEqual({});
     });
 
-    it('returns defaults for all supported widget types', () => {
+    it('contains defaults for all supported widget types', () => {
       const types: WidgetType[] = [
         'clock',
         'traffic',
@@ -90,9 +94,10 @@ describe('widgetHelpers', () => {
         'miniApp',
       ];
       types.forEach((type) => {
-        const config = getDefaultWidgetConfig(type);
-        expect(config).toBeDefined();
-        expect(typeof config).toBe('object');
+        const defaults = WIDGET_DEFAULTS[type];
+        expect(defaults).toBeDefined();
+        expect(defaults?.config).toBeDefined();
+        expect(typeof defaults?.config).toBe('object');
       });
     });
   });

--- a/utils/widgetHelpers.ts
+++ b/utils/widgetHelpers.ts
@@ -1,5 +1,4 @@
-import { WidgetData, WidgetType, WidgetConfig } from '../types';
-import { STICKY_NOTE_COLORS } from '../config/colors';
+import { WidgetData } from '../types';
 
 export const getTitle = (widget: WidgetData): string => {
   if (widget.customTitle) return widget.customTitle;
@@ -15,84 +14,4 @@ export const getTitle = (widget: WidgetData): string => {
   if (widget.type === 'sticker') return 'Sticker';
   if (widget.type === 'seating-chart') return 'Seating Chart';
   return widget.type.charAt(0).toUpperCase() + widget.type.slice(1);
-};
-
-/**
- * Get the default configuration for a widget type.
- * Returns an empty object for widgets that don't require configuration.
- */
-export const getDefaultWidgetConfig = (type: WidgetType): WidgetConfig => {
-  const defaults: Record<WidgetType, WidgetConfig> = {
-    clock: { format24: true, showSeconds: true },
-    'time-tool': {
-      mode: 'timer',
-      visualType: 'digital',
-      theme: 'light',
-      duration: 600,
-      elapsedTime: 600,
-      isRunning: false,
-      selectedSound: 'Gong',
-    },
-    traffic: {},
-    text: {
-      content: 'Double click to edit...',
-      bgColor: STICKY_NOTE_COLORS.yellow,
-      fontSize: 18,
-    },
-    checklist: { items: [] },
-    random: { firstNames: '', lastNames: '', mode: 'single' },
-    dice: { count: 1 },
-    sound: { sensitivity: 1, visual: 'thermometer' },
-    drawing: { mode: 'window', paths: [] },
-    qr: { url: 'https://google.com' },
-    embed: { url: '' },
-    poll: {
-      question: 'Vote now!',
-      options: [
-        { label: 'Option A', votes: 0 },
-        { label: 'Option B', votes: 0 },
-      ],
-    },
-    webcam: {},
-    scoreboard: { scoreA: 0, scoreB: 0, teamA: 'Team 1', teamB: 'Team 2' },
-    workSymbols: { voiceLevel: null, workMode: null },
-    weather: { temp: 72, condition: 'sunny' },
-    schedule: { items: [] },
-    calendar: { events: [] },
-    lunchCount: {
-      schoolSite: 'schumann-elementary',
-      isManualMode: false,
-      manualHotLunch: '',
-      manualBentoBox: '',
-      roster: [],
-      assignments: {},
-      recipient: '',
-    },
-    classes: {},
-    instructionalRoutines: {
-      selectedRoutineId: null,
-      customSteps: [],
-      favorites: [],
-      scaleMultiplier: 1,
-    },
-    miniApp: {
-      activeApp: null,
-    },
-    materials: {
-      selectedItems: [],
-      activeItems: [],
-    },
-    stickers: { uploadedUrls: [] },
-    sticker: { url: '', rotation: 0, size: 150 },
-    'seating-chart': {
-      furniture: [],
-      assignments: {},
-      gridSize: 20,
-    },
-    catalyst: { activeTab: 'attention' },
-    'catalyst-instruction': { routineId: '', stepIndex: 0 },
-    'catalyst-visual': { routineId: '', stepIndex: 0 },
-  };
-
-  return defaults[type];
 };


### PR DESCRIPTION
🧹 What was cleaned: "Removed redundant `getDefaultWidgetConfig` function from `utils/widgetHelpers.ts` and refactored `components/student/StudentApp.tsx` to use `WIDGET_DEFAULTS` from `config/widgetDefaults.ts`."
📉 Complexity Score: "Removed duplicate logic source, ensuring single source of truth."
🛡️ Safety: "Verified via Test Suite (updated `utils/widgetHelpers.test.ts`)"

---
*PR created automatically by Jules for task [5674024839994287264](https://jules.google.com/task/5674024839994287264) started by @OPS-PIvers*