### PR TITLE
📐 Unifier: Standardized Bloom's Taxonomy Styles

### DIFF
--- a/.Jules/unifier.md
+++ b/.Jules/unifier.md
@@ -39,3 +39,8 @@
 
 **Drift:** The Style Panel contained inconsistent micro-typography with hardcoded values (9px, 10px, 11px) mixing hierarchies.
 **Fix:** Standardized all micro-labels to `text-xxs` (10px) and `text-xxxs` (8px) using system tokens.
+
+## 2026-01-28 - [Bloom's Taxonomy Styling]
+
+**Drift:** Found inline styles with hardcoded hex values (e.g., `#1e293b`, `#2d3f89`) in `InstructionalRoutinesWidget.tsx` for Bloom's Taxonomy resources, bypassing the design system.
+**Fix:** Refactored to use Tailwind utility classes and semantic tokens (`text-slate-800`, `text-brand-blue-primary`) and consolidated duplicated logic.

--- a/components/widgets/DrawingWidget.tsx
+++ b/components/widgets/DrawingWidget.tsx
@@ -195,8 +195,7 @@ export const DrawingWidget: React.FC<{
       // Ensure styles are set (in case they were lost or reset)
       setContextStyles(ctx);
 
-      const prev =
-        currentPathRef.current[currentPathRef.current.length - 2];
+      const prev = currentPathRef.current[currentPathRef.current.length - 2];
       ctx.beginPath();
       ctx.moveTo(prev.x, prev.y);
       ctx.lineTo(pos.x, pos.y);

--- a/components/widgets/InstructionalRoutinesWidget.tsx
+++ b/components/widgets/InstructionalRoutinesWidget.tsx
@@ -600,25 +600,24 @@ export const InstructionalRoutinesWidget: React.FC<{ widget: WidgetData }> = ({
     const title =
       type === 'keyWords' ? "Bloom's Key Words" : "Bloom's Sentence Starters";
 
-    let content = `<h3 style="font-weight: 900; margin-bottom: 0.5em; text-transform: uppercase; color: #1e293b;">${title}</h3>`;
+    let content = `<h3 class="font-black mb-[0.5em] uppercase text-slate-800">${title}</h3>`;
 
-    if (type === 'keyWords') {
-      BLOOMS_DATA.keyWords.forEach((levelGroup) => {
-        content += `<h4 style="font-weight: 800; margin-top: 1em; margin-bottom: 0.25em; color: #2d3f89; font-size: 0.9em;">${levelGroup.level}</h4><ul style="padding-left: 1.2em; list-style-type: disc; color: #475569; font-size: 0.85em;">`;
-        levelGroup.words.forEach((item) => {
-          content += `<li>${item}</li>`;
-        });
-        content += `</ul>`;
+    const data =
+      type === 'keyWords' ? BLOOMS_DATA.keyWords : BLOOMS_DATA.questionStarters;
+
+    data.forEach((levelGroup) => {
+      const items =
+        type === 'keyWords'
+          ? (levelGroup as (typeof BLOOMS_DATA.keyWords)[number]).words
+          : (levelGroup as (typeof BLOOMS_DATA.questionStarters)[number])
+              .starters;
+
+      content += `<h4 class="font-extrabold mt-[1em] mb-[0.25em] text-brand-blue-primary text-[0.9em]">${levelGroup.level}</h4><ul class="pl-[1.2em] list-disc text-slate-600 text-[0.85em]">`;
+      items.forEach((item) => {
+        content += `<li>${item}</li>`;
       });
-    } else {
-      BLOOMS_DATA.questionStarters.forEach((levelGroup) => {
-        content += `<h4 style="font-weight: 800; margin-top: 1em; margin-bottom: 0.25em; color: #2d3f89; font-size: 0.9em;">${levelGroup.level}</h4><ul style="padding-left: 1.2em; list-style-type: disc; color: #475569; font-size: 0.85em;">`;
-        levelGroup.starters.forEach((item) => {
-          content += `<li>${item}</li>`;
-        });
-        content += `</ul>`;
-      });
-    }
+      content += `</ul>`;
+    });
 
     addWidget('text', {
       config: {

--- a/verify_blooms.py
+++ b/verify_blooms.py
@@ -1,0 +1,61 @@
+from playwright.sync_api import sync_playwright, expect
+import time
+
+def run():
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=True)
+        # Use a large viewport to ensure widgets fit
+        page = browser.new_page(viewport={"width": 1920, "height": 1080})
+
+        # 1. Open Dashboard
+        print("Navigating to dashboard...")
+        page.goto("http://localhost:3000")
+
+        # Wait for dashboard to load (look for the Dock or similar)
+        # The 'Open Tools' button is a good indicator
+        print("Waiting for dashboard load...")
+        open_tools_btn = page.get_by_title("Open Tools")
+        open_tools_btn.wait_for()
+
+        # 2. Open Dock
+        print("Opening dock...")
+        open_tools_btn.click()
+
+        # 3. Add Instructional Routines Widget
+        print("Adding Instructional Routines widget...")
+        routines_btn = page.get_by_text("Routines", exact=True) # exact=True to avoid partial matches
+        routines_btn.click(force=True)
+
+        # 4. Wait for widget to appear
+        # The widget title usually appears
+        print("Waiting for widget...")
+        page.get_by_text("Library (ALL)").wait_for()
+
+        # 5. Select Bloom's Taxonomy
+        print("Selecting Bloom's Taxonomy...")
+        # It's a button with text "Bloom's Taxonomy"
+        page.get_by_text("BLOOM'S TAXONOMY").click()
+        # Note: The text is uppercase in the UI (font-black uppercase leading-tight)
+
+        # 6. Click Key Words
+        print("Clicking Key Words...")
+        page.get_by_role("button", name="Key Words").click()
+
+        # 7. Wait for Text Widget with content
+        print("Waiting for Text Widget...")
+        # The new widget should contain "Bloom's Key Words"
+        # We look for the h3 with that text.
+        header = page.get_by_role("heading", name="Bloom's Key Words")
+        header.wait_for()
+
+        # 8. Take Screenshot
+        print("Taking screenshot...")
+        # We can try to screenshot just the new widget if we can find it, or the whole page.
+        # Let's screenshot the whole page to show context.
+        page.screenshot(path="/home/jules/verification/blooms_verification.png")
+
+        print("Verification complete.")
+        browser.close()
+
+if __name__ == "__main__":
+    run()


### PR DESCRIPTION
📉 Debt Removed: Replaced inline styles and hardcoded hex values in `InstructionalRoutinesWidget.tsx` with standard Tailwind classes.
🧱 Component Used: Utilized `TextWidget`'s existing scalable HTML rendering but with standardized classes.
📸 Before/After: Replaced hardcoded `#1e293b` with `text-slate-800`, `#2d3f89` with `text-brand-blue-primary`, and manual style strings with Tailwind utility classes.
Verified with Playwright.

---
*PR created automatically by Jules for task [10678600386523258095](https://jules.google.com/task/10678600386523258095) started by @OPS-PIvers*