### PR TITLE
⚡ Bolt: Optimization mapping in WidgetLibrary

### DIFF
--- a/components/layout/dock/WidgetLibrary.tsx
+++ b/components/layout/dock/WidgetLibrary.tsx
@@ -34,6 +34,10 @@ import { useClickOutside } from '@/hooks/useClickOutside';
 import { useDialog } from '@/context/useDialog';
 import { useDashboard } from '@/context/useDashboard';
 
+// O(1) Lookup Map for TOOLS optimization.
+// Extracted outside the component to prevent recreating the map on every mount.
+const TOOLS_MAP = new Map(TOOLS.map((t) => [t.type, t]));
+
 interface WidgetLibraryProps {
   onToggle: (type: WidgetType | InternalToolType) => void;
   visibleTools: (WidgetType | InternalToolType)[];
@@ -207,7 +211,8 @@ export const WidgetLibrary = forwardRef<HTMLDivElement, WidgetLibraryProps>(
     // Filter tools: must be accessible AND NOT already in the dock,
     // and in normal mode must match the user's selected buildings
     const availableTools = effectiveOrder
-      .map((type) => TOOLS.find((t) => t.type === type))
+      // Replaced TOOLS.find with TOOLS_MAP.get to eliminate O(N^2) complexity in rendering loop.
+      .map((type) => TOOLS_MAP.get(type))
       .filter((tool): tool is (typeof TOOLS)[0] => {
         if (!tool) return false;
         if (!canAccess(tool.type)) return false;

--- a/components/layout/dock/WidgetLibrary.tsx
+++ b/components/layout/dock/WidgetLibrary.tsx
@@ -36,7 +36,9 @@ import { useDashboard } from '@/context/useDashboard';
 
 // O(1) Lookup Map for TOOLS optimization.
 // Extracted outside the component to prevent recreating the map on every mount.
-const TOOLS_MAP = new Map(TOOLS.map((t) => [t.type, t]));
+const TOOLS_MAP = new Map<WidgetType | InternalToolType, (typeof TOOLS)[0]>(
+  TOOLS.map((t) => [t.type, t])
+);
 
 interface WidgetLibraryProps {
   onToggle: (type: WidgetType | InternalToolType) => void;
@@ -210,23 +212,34 @@ export const WidgetLibrary = forwardRef<HTMLDivElement, WidgetLibraryProps>(
 
     // Filter tools: must be accessible AND NOT already in the dock,
     // and in normal mode must match the user's selected buildings
-    const availableTools = effectiveOrder
-      // Replaced TOOLS.find with TOOLS_MAP.get to eliminate O(N^2) complexity in rendering loop.
-      .map((type) => TOOLS_MAP.get(type))
-      .filter((tool): tool is (typeof TOOLS)[0] => {
-        if (!tool) return false;
-        if (!canAccess(tool.type)) return false;
-        // Hide if already in the dock
-        if (visibleTools.includes(tool.type)) return false;
-        // In normal (non-edit) mode, apply building-based grade-level filter
-        if (
-          !isEditMode &&
-          matchesUserBuilding &&
-          !matchesUserBuilding(tool.type)
-        )
-          return false;
-        return true;
-      });
+    const availableTools = useMemo(() => {
+      const visibleToolsSet = new Set(visibleTools);
+      return (
+        effectiveOrder
+          // Replaced TOOLS.find with TOOLS_MAP.get to eliminate O(N^2) complexity in rendering loop.
+          .map((type) => TOOLS_MAP.get(type))
+          .filter((tool): tool is (typeof TOOLS)[0] => {
+            if (!tool) return false;
+            if (!canAccess(tool.type)) return false;
+            // Hide if already in the dock
+            if (visibleToolsSet.has(tool.type)) return false;
+            // In normal (non-edit) mode, apply building-based grade-level filter
+            if (
+              !isEditMode &&
+              matchesUserBuilding &&
+              !matchesUserBuilding(tool.type)
+            )
+              return false;
+            return true;
+          })
+      );
+    }, [
+      effectiveOrder,
+      visibleTools,
+      canAccess,
+      isEditMode,
+      matchesUserBuilding,
+    ]);
 
     return createPortal(
       <div className="fixed inset-0 z-modal flex items-center justify-center p-4 animate-in fade-in duration-200 pointer-events-none">


### PR DESCRIPTION
💡 What: Extracted `TOOLS_MAP` outside the component to prevent recreating the map on every mount and eliminated an O(N^2) complexity in the rendering loop by replacing `.find` with `.get`.
🎯 Why: Iterating over `effectiveOrder` and finding tools inside an array creates an O(N^2) complexity in the render loop which hurts frame rates and could block the main thread.
📊 Impact: Reduces computational complexity to O(N).
🔬 Measurement: Verify changes locally or by running the test suite (`pnpm run type-check:all && pnpm lint && pnpm format:check`).

---
*PR created automatically by Jules for task [15296762745359661561](https://jules.google.com/task/15296762745359661561) started by @OPS-PIvers*