### PR TITLE
📐 Unifier: Standardized Card Containers

### DIFF
--- a/.Jules/unifier.md
+++ b/.Jules/unifier.md
@@ -201,3 +201,8 @@ Unifier is responsible for maintaining a consistent look and feel across all Spa
 
 **Drift:** Various components were hardcoding `zIndex: 10`, `zIndex: 50`, or `zIndex: 100` during drag operations (e.g., `isDragging ? 10 : 'auto'`), ignoring the centralized registry and creating inconsistent stacking.
 **Fix:** Created a new standard token `Z_INDEX.itemDragging = 50` in `config/zIndex.ts`, exported it to `tailwind.config.js` as `item-dragging`, and updated all sortable items to use this semantic token.
+
+## 2026-04-08 - Standardized Card Containers in Admin Panels
+
+**Drift:** Discovered 19 hardcoded instances of the pattern `<div className="bg-slate-50 rounded-xl border border-slate-200 p-4">` acting as settings container wrappers across almost all widget configuration panels in `components/admin/`. This bypassed the existing design system component.
+**Fix:** Refactored all 19 instances to use the centralized `<Card rounded="xl" className="bg-slate-50">` component, enforcing consistent shadow, border, and padding rendering across the entire admin dashboard architecture.

--- a/components/admin/BreathingConfigurationPanel.tsx
+++ b/components/admin/BreathingConfigurationPanel.tsx
@@ -75,7 +75,7 @@ export const BreathingConfigurationPanel: React.FC<
         />
       </div>
 
-      <Card rounded="xl" className="bg-slate-50 space-y-4">
+      <Card rounded="xl" shadow="none" className="bg-slate-50 space-y-4">
         <p className="text-xxs text-slate-500 leading-tight">
           These defaults will pre-configure the Breathing widget when a teacher
           in <b>{BUILDINGS.find((b) => b.id === selectedBuildingId)?.name}</b>{' '}

--- a/components/admin/BreathingConfigurationPanel.tsx
+++ b/components/admin/BreathingConfigurationPanel.tsx
@@ -8,6 +8,7 @@ import {
 } from '@/types';
 import { WIDGET_PALETTE } from '@/config/colors';
 import { SettingsLabel } from '@/components/common/SettingsLabel';
+import { Card } from '@/components/common/Card';
 
 interface BreathingConfigurationPanelProps {
   config: BreathingGlobalConfig;
@@ -74,7 +75,7 @@ export const BreathingConfigurationPanel: React.FC<
         />
       </div>
 
-      <div className="bg-slate-50 rounded-xl border border-slate-200 p-4 space-y-4">
+      <Card rounded="xl" className="bg-slate-50 space-y-4">
         <p className="text-xxs text-slate-500 leading-tight">
           These defaults will pre-configure the Breathing widget when a teacher
           in <b>{BUILDINGS.find((b) => b.id === selectedBuildingId)?.name}</b>{' '}
@@ -163,7 +164,7 @@ export const BreathingConfigurationPanel: React.FC<
             ))}
           </div>
         </div>
-      </div>
+      </Card>
     </div>
   );
 };

--- a/components/admin/ChecklistConfigurationPanel.tsx
+++ b/components/admin/ChecklistConfigurationPanel.tsx
@@ -7,6 +7,7 @@ import {
   ChecklistDefaultItem,
 } from '@/types';
 import { Plus, Trash2, GripVertical } from 'lucide-react';
+import { Card } from '@/components/common/Card';
 
 interface ChecklistConfigurationPanelProps {
   config: ChecklistGlobalConfig;
@@ -92,7 +93,7 @@ export const ChecklistConfigurationPanel: React.FC<
         />
       </div>
 
-      <div className="bg-slate-50 rounded-xl border border-slate-200 p-4 space-y-4">
+      <Card rounded="xl" className="bg-slate-50 space-y-4">
         <p className="text-xxs text-slate-500 leading-tight">
           These defaults will pre-populate the Checklist widget when a teacher
           in <b>{BUILDINGS.find((b) => b.id === selectedBuildingId)?.name}</b>{' '}
@@ -183,7 +184,7 @@ export const ChecklistConfigurationPanel: React.FC<
             </button>
           </div>
         </div>
-      </div>
+      </Card>
     </div>
   );
 };

--- a/components/admin/ChecklistConfigurationPanel.tsx
+++ b/components/admin/ChecklistConfigurationPanel.tsx
@@ -93,7 +93,7 @@ export const ChecklistConfigurationPanel: React.FC<
         />
       </div>
 
-      <Card rounded="xl" className="bg-slate-50 space-y-4">
+      <Card rounded="xl" shadow="none" className="bg-slate-50 space-y-4">
         <p className="text-xxs text-slate-500 leading-tight">
           These defaults will pre-populate the Checklist widget when a teacher
           in <b>{BUILDINGS.find((b) => b.id === selectedBuildingId)?.name}</b>{' '}

--- a/components/admin/ClockConfigurationPanel.tsx
+++ b/components/admin/ClockConfigurationPanel.tsx
@@ -5,6 +5,7 @@ import { ClockGlobalConfig, BuildingClockDefaults } from '@/types';
 import { Toggle } from '../common/Toggle';
 import { STANDARD_COLORS } from '@/config/colors';
 import { SettingsLabel } from '@/components/common/SettingsLabel';
+import { Card } from '@/components/common/Card';
 
 interface ClockConfigurationPanelProps {
   config: ClockGlobalConfig;
@@ -56,7 +57,7 @@ export const ClockConfigurationPanel: React.FC<
         />
       </div>
 
-      <div className="bg-slate-50 rounded-xl border border-slate-200 p-4 space-y-4">
+      <Card rounded="xl" className="bg-slate-50 space-y-4">
         <p className="text-xxs text-slate-500 leading-tight">
           These defaults will pre-configure the Clock widget when a teacher in{' '}
           <b>{BUILDINGS.find((b) => b.id === selectedBuildingId)?.name}</b> adds
@@ -133,7 +134,7 @@ export const ClockConfigurationPanel: React.FC<
             )}
           </div>
         </div>
-      </div>
+      </Card>
     </div>
   );
 };

--- a/components/admin/ClockConfigurationPanel.tsx
+++ b/components/admin/ClockConfigurationPanel.tsx
@@ -57,7 +57,7 @@ export const ClockConfigurationPanel: React.FC<
         />
       </div>
 
-      <Card rounded="xl" className="bg-slate-50 space-y-4">
+      <Card rounded="xl" shadow="none" className="bg-slate-50 space-y-4">
         <p className="text-xxs text-slate-500 leading-tight">
           These defaults will pre-configure the Clock widget when a teacher in{' '}
           <b>{BUILDINGS.find((b) => b.id === selectedBuildingId)?.name}</b> adds

--- a/components/admin/DiceConfigurationPanel.tsx
+++ b/components/admin/DiceConfigurationPanel.tsx
@@ -54,7 +54,7 @@ export const DiceConfigurationPanel: React.FC<DiceConfigurationPanelProps> = ({
         />
       </div>
 
-      <Card rounded="xl" className="bg-slate-50 space-y-4">
+      <Card rounded="xl" shadow="none" className="bg-slate-50 space-y-4">
         <p className="text-xxs text-slate-500 leading-tight">
           These defaults will pre-configure the Dice widget when a teacher in{' '}
           <b>{BUILDINGS.find((b) => b.id === selectedBuildingId)?.name}</b> adds

--- a/components/admin/DiceConfigurationPanel.tsx
+++ b/components/admin/DiceConfigurationPanel.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { BUILDINGS } from '@/config/buildings';
 import { BuildingSelector } from './BuildingSelector';
 import { DiceGlobalConfig, BuildingDiceDefaults } from '@/types';
+import { Card } from '@/components/common/Card';
 
 interface DiceConfigurationPanelProps {
   config: DiceGlobalConfig;
@@ -53,7 +54,7 @@ export const DiceConfigurationPanel: React.FC<DiceConfigurationPanelProps> = ({
         />
       </div>
 
-      <div className="bg-slate-50 rounded-xl border border-slate-200 p-4 space-y-4">
+      <Card rounded="xl" className="bg-slate-50 space-y-4">
         <p className="text-xxs text-slate-500 leading-tight">
           These defaults will pre-configure the Dice widget when a teacher in{' '}
           <b>{BUILDINGS.find((b) => b.id === selectedBuildingId)?.name}</b> adds
@@ -84,7 +85,7 @@ export const DiceConfigurationPanel: React.FC<DiceConfigurationPanelProps> = ({
             Widget default: 1 die
           </p>
         </div>
-      </div>
+      </Card>
     </div>
   );
 };

--- a/components/admin/DrawingConfigurationPanel.tsx
+++ b/components/admin/DrawingConfigurationPanel.tsx
@@ -4,6 +4,7 @@ import { BuildingSelector } from './BuildingSelector';
 import { DrawingGlobalConfig, BuildingDrawingDefaults } from '@/types';
 import { WIDGET_PALETTE } from '@/config/colors';
 import { Maximize, Minimize, Pencil, Palette } from 'lucide-react';
+import { Card } from '@/components/common/Card';
 
 interface DrawingConfigurationPanelProps {
   config: DrawingGlobalConfig;
@@ -73,7 +74,7 @@ export const DrawingConfigurationPanel: React.FC<
         />
       </div>
 
-      <div className="bg-slate-50 rounded-xl border border-slate-200 p-4 space-y-6">
+      <Card rounded="xl" className="bg-slate-50 space-y-6">
         <p className="text-xxs text-slate-500 leading-tight">
           These defaults will pre-configure the Drawing widget when a teacher in{' '}
           <b>{BUILDINGS.find((b) => b.id === selectedBuildingId)?.name}</b> adds
@@ -156,7 +157,7 @@ export const DrawingConfigurationPanel: React.FC<
             ))}
           </div>
         </div>
-      </div>
+      </Card>
     </div>
   );
 };

--- a/components/admin/DrawingConfigurationPanel.tsx
+++ b/components/admin/DrawingConfigurationPanel.tsx
@@ -74,7 +74,7 @@ export const DrawingConfigurationPanel: React.FC<
         />
       </div>
 
-      <Card rounded="xl" className="bg-slate-50 space-y-6">
+      <Card rounded="xl" shadow="none" className="bg-slate-50 space-y-6">
         <p className="text-xxs text-slate-500 leading-tight">
           These defaults will pre-configure the Drawing widget when a teacher in{' '}
           <b>{BUILDINGS.find((b) => b.id === selectedBuildingId)?.name}</b> adds

--- a/components/admin/EmbedConfigurationPanel.tsx
+++ b/components/admin/EmbedConfigurationPanel.tsx
@@ -4,6 +4,7 @@ import { BuildingSelector } from './BuildingSelector';
 import { EmbedGlobalConfig, BuildingEmbedDefaults } from '@/types';
 import { Plus, Trash2, Settings2 } from 'lucide-react';
 import { Toggle } from '@/components/common/Toggle';
+import { Card } from '@/components/common/Card';
 
 interface EmbedConfigurationPanelProps {
   config: EmbedGlobalConfig;
@@ -99,7 +100,7 @@ export const EmbedConfigurationPanel: React.FC<
         />
       </div>
 
-      <div className="bg-slate-50 rounded-xl border border-slate-200 p-4 space-y-4">
+      <Card rounded="xl" className="bg-slate-50 space-y-4">
         <p className="text-xxs text-slate-500 leading-tight">
           Users in{' '}
           <b>{BUILDINGS.find((b) => b.id === selectedBuildingId)?.name}</b> will
@@ -176,7 +177,7 @@ export const EmbedConfigurationPanel: React.FC<
             )}
           </div>
         </div>
-      </div>
+      </Card>
     </div>
   );
 };

--- a/components/admin/EmbedConfigurationPanel.tsx
+++ b/components/admin/EmbedConfigurationPanel.tsx
@@ -100,7 +100,7 @@ export const EmbedConfigurationPanel: React.FC<
         />
       </div>
 
-      <Card rounded="xl" className="bg-slate-50 space-y-4">
+      <Card rounded="xl" shadow="none" className="bg-slate-50 space-y-4">
         <p className="text-xxs text-slate-500 leading-tight">
           Users in{' '}
           <b>{BUILDINGS.find((b) => b.id === selectedBuildingId)?.name}</b> will

--- a/components/admin/ExpectationsConfigurationPanel.tsx
+++ b/components/admin/ExpectationsConfigurationPanel.tsx
@@ -184,7 +184,7 @@ export const ExpectationsConfigurationPanel: React.FC<
         />
       </div>
 
-      <Card rounded="xl" className="bg-slate-50">
+      <Card rounded="xl" shadow="none" className="bg-slate-50">
         {renderOptionEditor(
           'Volume Options',
           VOLUME_OPTIONS as OptionBase[],

--- a/components/admin/ExpectationsConfigurationPanel.tsx
+++ b/components/admin/ExpectationsConfigurationPanel.tsx
@@ -1,3 +1,4 @@
+import { Card } from '@/components/common/Card';
 import React, { useState } from 'react';
 import { BUILDINGS } from '@/config/buildings';
 import { BuildingSelector } from './BuildingSelector';
@@ -183,7 +184,7 @@ export const ExpectationsConfigurationPanel: React.FC<
         />
       </div>
 
-      <div className="bg-slate-50 rounded-xl border border-slate-200 p-4">
+      <Card rounded="xl" className="bg-slate-50">
         {renderOptionEditor(
           'Volume Options',
           VOLUME_OPTIONS as OptionBase[],
@@ -213,7 +214,7 @@ export const ExpectationsConfigurationPanel: React.FC<
           currentBuildingConfig.showInteraction ?? true,
           (enabled) => handleUpdateBuilding({ showInteraction: enabled })
         )}
-      </div>
+      </Card>
     </div>
   );
 };

--- a/components/admin/HotspotImageConfigurationPanel.tsx
+++ b/components/admin/HotspotImageConfigurationPanel.tsx
@@ -1,3 +1,4 @@
+import { Card } from '@/components/common/Card';
 import React, { useState } from 'react';
 import { BUILDINGS } from '@/config/buildings';
 import { BuildingSelector } from './BuildingSelector';
@@ -62,7 +63,7 @@ export const HotspotImageConfigurationPanel: React.FC<
         />
       </div>
 
-      <div className="bg-slate-50 rounded-xl border border-slate-200 p-4 space-y-4">
+      <Card rounded="xl" className="bg-slate-50 space-y-4">
         <p className="text-xxs text-slate-500 leading-tight">
           These defaults will pre-populate the Hotspot Image widget when a
           teacher in{' '}
@@ -96,7 +97,7 @@ export const HotspotImageConfigurationPanel: React.FC<
             ))}
           </div>
         </div>
-      </div>
+      </Card>
     </div>
   );
 };

--- a/components/admin/HotspotImageConfigurationPanel.tsx
+++ b/components/admin/HotspotImageConfigurationPanel.tsx
@@ -63,7 +63,7 @@ export const HotspotImageConfigurationPanel: React.FC<
         />
       </div>
 
-      <Card rounded="xl" className="bg-slate-50 space-y-4">
+      <Card rounded="xl" shadow="none" className="bg-slate-50 space-y-4">
         <p className="text-xxs text-slate-500 leading-tight">
           These defaults will pre-populate the Hotspot Image widget when a
           teacher in{' '}

--- a/components/admin/MaterialsConfigurationPanel.tsx
+++ b/components/admin/MaterialsConfigurationPanel.tsx
@@ -16,6 +16,7 @@ import {
 import { IconPicker } from '@/components/widgets/InstructionalRoutines/IconPicker';
 import { Button } from '@/components/common/Button';
 import { Plus, Trash2, Search } from 'lucide-react';
+import { Card } from '@/components/common/Card';
 
 interface MaterialsConfigurationPanelProps {
   config: MaterialsGlobalConfig;
@@ -446,7 +447,7 @@ export const MaterialsConfigurationPanel: React.FC<
         />
       </div>
 
-      <div className="bg-slate-50 rounded-xl border border-slate-200 p-4 space-y-4">
+      <Card rounded="xl" className="bg-slate-50 space-y-4">
         <p className="text-xxs text-slate-500 leading-tight">
           These materials will be available to teachers in{' '}
           <b>{BUILDINGS.find((b) => b.id === selectedBuildingId)?.name}</b> when
@@ -516,7 +517,7 @@ export const MaterialsConfigurationPanel: React.FC<
             this building is configured.
           </p>
         )}
-      </div>
+      </Card>
     </div>
   );
 };

--- a/components/admin/MaterialsConfigurationPanel.tsx
+++ b/components/admin/MaterialsConfigurationPanel.tsx
@@ -447,7 +447,7 @@ export const MaterialsConfigurationPanel: React.FC<
         />
       </div>
 
-      <Card rounded="xl" className="bg-slate-50 space-y-4">
+      <Card rounded="xl" shadow="none" className="bg-slate-50 space-y-4">
         <p className="text-xxs text-slate-500 leading-tight">
           These materials will be available to teachers in{' '}
           <b>{BUILDINGS.find((b) => b.id === selectedBuildingId)?.name}</b> when

--- a/components/admin/NoteConfigurationPanel.tsx
+++ b/components/admin/NoteConfigurationPanel.tsx
@@ -3,6 +3,7 @@ import { BUILDINGS } from '@/config/buildings';
 import { BuildingSelector } from './BuildingSelector';
 import { NoteGlobalConfig, BuildingNoteDefaults } from '@/types';
 import { STICKY_NOTE_COLORS } from '@/config/colors';
+import { Card } from '@/components/common/Card';
 
 interface NoteConfigurationPanelProps {
   config: NoteGlobalConfig;
@@ -65,7 +66,7 @@ export const NoteConfigurationPanel: React.FC<NoteConfigurationPanelProps> = ({
         />
       </div>
 
-      <div className="bg-slate-50 rounded-xl border border-slate-200 p-4 space-y-4">
+      <Card rounded="xl" className="bg-slate-50 space-y-4">
         <p className="text-xxs text-slate-500 leading-tight">
           These defaults will pre-configure the Note widget when a teacher in{' '}
           <b>{BUILDINGS.find((b) => b.id === selectedBuildingId)?.name}</b> adds
@@ -119,7 +120,7 @@ export const NoteConfigurationPanel: React.FC<NoteConfigurationPanelProps> = ({
             ))}
           </div>
         </div>
-      </div>
+      </Card>
     </div>
   );
 };

--- a/components/admin/NoteConfigurationPanel.tsx
+++ b/components/admin/NoteConfigurationPanel.tsx
@@ -66,7 +66,7 @@ export const NoteConfigurationPanel: React.FC<NoteConfigurationPanelProps> = ({
         />
       </div>
 
-      <Card rounded="xl" className="bg-slate-50 space-y-4">
+      <Card rounded="xl" shadow="none" className="bg-slate-50 space-y-4">
         <p className="text-xxs text-slate-500 leading-tight">
           These defaults will pre-configure the Note widget when a teacher in{' '}
           <b>{BUILDINGS.find((b) => b.id === selectedBuildingId)?.name}</b> adds

--- a/components/admin/PollConfigurationPanel.tsx
+++ b/components/admin/PollConfigurationPanel.tsx
@@ -9,6 +9,7 @@ import {
 } from '@/types';
 import { Plus, Trash2, GripVertical, Type } from 'lucide-react';
 import { WIDGET_DEFAULTS } from '@/config/widgetDefaults';
+import { Card } from '@/components/common/Card';
 
 interface PollConfigurationPanelProps {
   config: PollGlobalConfig;
@@ -104,7 +105,7 @@ export const PollConfigurationPanel: React.FC<PollConfigurationPanelProps> = ({
         />
       </div>
 
-      <div className="bg-slate-50 rounded-xl border border-slate-200 p-4 space-y-4">
+      <Card rounded="xl" className="bg-slate-50 space-y-4">
         <p className="text-xxs text-slate-500 leading-tight">
           These defaults will pre-populate the Poll widget when a teacher in{' '}
           <b>{BUILDINGS.find((b) => b.id === selectedBuildingId)?.name}</b> adds
@@ -184,7 +185,7 @@ export const PollConfigurationPanel: React.FC<PollConfigurationPanelProps> = ({
             <Plus className="w-3 h-3" /> Add Option
           </button>
         </div>
-      </div>
+      </Card>
     </div>
   );
 };

--- a/components/admin/PollConfigurationPanel.tsx
+++ b/components/admin/PollConfigurationPanel.tsx
@@ -105,7 +105,7 @@ export const PollConfigurationPanel: React.FC<PollConfigurationPanelProps> = ({
         />
       </div>
 
-      <Card rounded="xl" className="bg-slate-50 space-y-4">
+      <Card rounded="xl" shadow="none" className="bg-slate-50 space-y-4">
         <p className="text-xxs text-slate-500 leading-tight">
           These defaults will pre-populate the Poll widget when a teacher in{' '}
           <b>{BUILDINGS.find((b) => b.id === selectedBuildingId)?.name}</b> adds

--- a/components/admin/QRConfigurationPanel.tsx
+++ b/components/admin/QRConfigurationPanel.tsx
@@ -3,6 +3,7 @@ import { BUILDINGS } from '@/config/buildings';
 import { BuildingSelector } from './BuildingSelector';
 import { QRGlobalConfig, BuildingQRDefaults } from '@/types';
 import { QrCode, Link, Palette } from 'lucide-react';
+import { Card } from '@/components/common/Card';
 
 interface QRConfigurationPanelProps {
   config: QRGlobalConfig;
@@ -50,7 +51,7 @@ export const QRConfigurationPanel: React.FC<QRConfigurationPanelProps> = ({
         />
       </div>
 
-      <div className="bg-slate-50 rounded-xl border border-slate-200 p-4 space-y-5">
+      <Card rounded="xl" className="bg-slate-50 space-y-5">
         <p className="text-xxs text-slate-500 leading-tight">
           These defaults will pre-configure the QR widget when a teacher in{' '}
           <b>{BUILDINGS.find((b) => b.id === selectedBuildingId)?.name}</b> adds
@@ -189,7 +190,7 @@ export const QRConfigurationPanel: React.FC<QRConfigurationPanelProps> = ({
             </div>
           </div>
         </div>
-      </div>
+      </Card>
     </div>
   );
 };

--- a/components/admin/QRConfigurationPanel.tsx
+++ b/components/admin/QRConfigurationPanel.tsx
@@ -51,7 +51,7 @@ export const QRConfigurationPanel: React.FC<QRConfigurationPanelProps> = ({
         />
       </div>
 
-      <Card rounded="xl" className="bg-slate-50 space-y-5">
+      <Card rounded="xl" shadow="none" className="bg-slate-50 space-y-5">
         <p className="text-xxs text-slate-500 leading-tight">
           These defaults will pre-configure the QR widget when a teacher in{' '}
           <b>{BUILDINGS.find((b) => b.id === selectedBuildingId)?.name}</b> adds

--- a/components/admin/RandomConfigurationPanel.tsx
+++ b/components/admin/RandomConfigurationPanel.tsx
@@ -60,7 +60,7 @@ export const RandomConfigurationPanel: React.FC<
         />
       </div>
 
-      <div className="bg-slate-50 rounded-xl border border-slate-200 p-4 space-y-4">
+      <Card rounded="xl" className="bg-slate-50 space-y-4">
         <p className="text-xxs text-slate-500 leading-tight">
           These defaults will pre-configure the Random Picker widget when a
           teacher in{' '}
@@ -124,7 +124,7 @@ export const RandomConfigurationPanel: React.FC<
             showLabels={false}
           />
         </Card>
-      </div>
+      </Card>
     </div>
   );
 };

--- a/components/admin/RandomConfigurationPanel.tsx
+++ b/components/admin/RandomConfigurationPanel.tsx
@@ -60,7 +60,7 @@ export const RandomConfigurationPanel: React.FC<
         />
       </div>
 
-      <Card rounded="xl" className="bg-slate-50 space-y-4">
+      <Card rounded="xl" shadow="none" className="bg-slate-50 space-y-4">
         <p className="text-xxs text-slate-500 leading-tight">
           These defaults will pre-configure the Random Picker widget when a
           teacher in{' '}

--- a/components/admin/ScheduleConfigurationPanel.tsx
+++ b/components/admin/ScheduleConfigurationPanel.tsx
@@ -361,7 +361,7 @@ export const ScheduleConfigurationPanel: React.FC<
         />
       </div>
 
-      <Card rounded="xl" className="bg-slate-50">
+      <Card rounded="xl" shadow="none" className="bg-slate-50">
         {!activeScheduleId ? (
           <div>
             <div className="flex items-center justify-between mb-3">

--- a/components/admin/ScheduleConfigurationPanel.tsx
+++ b/components/admin/ScheduleConfigurationPanel.tsx
@@ -37,6 +37,7 @@ import {
   useSortable,
 } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
+import { Card } from '@/components/common/Card';
 
 interface ScheduleConfigurationPanelProps {
   config: ScheduleGlobalConfig;
@@ -360,7 +361,7 @@ export const ScheduleConfigurationPanel: React.FC<
         />
       </div>
 
-      <div className="bg-slate-50 rounded-xl border border-slate-200 p-4">
+      <Card rounded="xl" className="bg-slate-50">
         {!activeScheduleId ? (
           <div>
             <div className="flex items-center justify-between mb-3">
@@ -531,7 +532,7 @@ export const ScheduleConfigurationPanel: React.FC<
             </div>
           </div>
         )}
-      </div>
+      </Card>
     </div>
   );
 };

--- a/components/admin/ScoreboardConfigurationPanel.tsx
+++ b/components/admin/ScoreboardConfigurationPanel.tsx
@@ -99,7 +99,7 @@ export const ScoreboardConfigurationPanel: React.FC<
         />
       </div>
 
-      <Card rounded="xl" className="bg-slate-50 space-y-4">
+      <Card rounded="xl" shadow="none" className="bg-slate-50 space-y-4">
         <p className="text-xxs text-slate-500 leading-tight">
           These defaults will pre-populate the Scoreboard widget when a teacher
           in <b>{BUILDINGS.find((b) => b.id === selectedBuildingId)?.name}</b>{' '}

--- a/components/admin/ScoreboardConfigurationPanel.tsx
+++ b/components/admin/ScoreboardConfigurationPanel.tsx
@@ -16,6 +16,7 @@ interface ScoreboardConfigurationPanelProps {
 // Must match TEAM_COLORS in ScoreboardItem.tsx — these are the only valid
 // color classes the scoreboard widget knows how to render.
 import { SCOREBOARD_COLORS as AVAILABLE_COLORS } from '@/config/scoreboard';
+import { Card } from '@/components/common/Card';
 
 const DEFAULT_TEAMS: ScoreboardDefaultTeam[] = [
   { id: crypto.randomUUID(), name: 'Team A', color: 'bg-blue-500' },
@@ -98,7 +99,7 @@ export const ScoreboardConfigurationPanel: React.FC<
         />
       </div>
 
-      <div className="bg-slate-50 rounded-xl border border-slate-200 p-4 space-y-4">
+      <Card rounded="xl" className="bg-slate-50 space-y-4">
         <p className="text-xxs text-slate-500 leading-tight">
           These defaults will pre-populate the Scoreboard widget when a teacher
           in <b>{BUILDINGS.find((b) => b.id === selectedBuildingId)?.name}</b>{' '}
@@ -195,7 +196,7 @@ export const ScoreboardConfigurationPanel: React.FC<
             </p>
           )}
         </div>
-      </div>
+      </Card>
     </div>
   );
 };

--- a/components/admin/SoundConfigurationPanel.tsx
+++ b/components/admin/SoundConfigurationPanel.tsx
@@ -66,7 +66,7 @@ export const SoundConfigurationPanel: React.FC<
         />
       </div>
 
-      <Card rounded="xl" className="bg-slate-50 space-y-4">
+      <Card rounded="xl" shadow="none" className="bg-slate-50 space-y-4">
         <p className="text-xxs text-slate-500 leading-tight">
           These defaults will pre-configure the Sound Meter widget when a
           teacher in{' '}

--- a/components/admin/SoundConfigurationPanel.tsx
+++ b/components/admin/SoundConfigurationPanel.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { BUILDINGS } from '@/config/buildings';
 import { BuildingSelector } from './BuildingSelector';
 import { SoundGlobalConfig, BuildingSoundDefaults } from '@/types';
+import { Card } from '@/components/common/Card';
 
 interface SoundConfigurationPanelProps {
   config: SoundGlobalConfig;
@@ -65,7 +66,7 @@ export const SoundConfigurationPanel: React.FC<
         />
       </div>
 
-      <div className="bg-slate-50 rounded-xl border border-slate-200 p-4 space-y-4">
+      <Card rounded="xl" className="bg-slate-50 space-y-4">
         <p className="text-xxs text-slate-500 leading-tight">
           These defaults will pre-configure the Sound Meter widget when a
           teacher in{' '}
@@ -133,7 +134,7 @@ export const SoundConfigurationPanel: React.FC<
             <span>3.0x (High)</span>
           </div>
         </div>
-      </div>
+      </Card>
     </div>
   );
 };

--- a/components/admin/SoundboardConfigurationPanel.tsx
+++ b/components/admin/SoundboardConfigurationPanel.tsx
@@ -1,3 +1,4 @@
+import { Card } from '@/components/common/Card';
 import React, { useEffect, useRef, useState } from 'react';
 import { BUILDINGS } from '@/config/buildings';
 import {
@@ -420,7 +421,7 @@ export const SoundboardConfigurationPanel: React.FC<
       </div>
 
       {/* Custom Sounds Section */}
-      <div className="bg-slate-50 rounded-xl border border-slate-200 p-4 space-y-4">
+      <Card rounded="xl" className="bg-slate-50 space-y-4">
         <div className="flex justify-between items-center mb-4">
           <div className="flex items-center gap-2">
             <Plus size={16} className="text-brand-blue-primary" />
@@ -586,7 +587,7 @@ export const SoundboardConfigurationPanel: React.FC<
             })}
           </div>
         )}
-      </div>
+      </Card>
     </div>
   );
 };

--- a/components/admin/SoundboardConfigurationPanel.tsx
+++ b/components/admin/SoundboardConfigurationPanel.tsx
@@ -421,7 +421,7 @@ export const SoundboardConfigurationPanel: React.FC<
       </div>
 
       {/* Custom Sounds Section */}
-      <Card rounded="xl" className="bg-slate-50 space-y-4">
+      <Card rounded="xl" shadow="none" className="bg-slate-50 space-y-4">
         <div className="flex justify-between items-center mb-4">
           <div className="flex items-center gap-2">
             <Plus size={16} className="text-brand-blue-primary" />

--- a/components/admin/TimeToolConfigurationPanel.tsx
+++ b/components/admin/TimeToolConfigurationPanel.tsx
@@ -3,6 +3,7 @@ import { BUILDINGS } from '@/config/buildings';
 import { BuildingSelector } from './BuildingSelector';
 import { TimeToolGlobalConfig, BuildingTimeToolDefaults } from '@/types';
 import { SettingsLabel } from '@/components/common/SettingsLabel';
+import { Card } from '@/components/common/Card';
 
 interface TimeToolConfigurationPanelProps {
   config: TimeToolGlobalConfig;
@@ -69,7 +70,7 @@ export const TimeToolConfigurationPanel: React.FC<
         />
       </div>
 
-      <div className="bg-slate-50 rounded-xl border border-slate-200 p-4 space-y-4">
+      <Card rounded="xl" className="bg-slate-50 space-y-4">
         <p className="text-xxs text-slate-500 leading-tight">
           These defaults will pre-configure the Timer widget when a teacher in{' '}
           <b>{BUILDINGS.find((b) => b.id === selectedBuildingId)?.name}</b> adds
@@ -150,7 +151,7 @@ export const TimeToolConfigurationPanel: React.FC<
             ))}
           </div>
         </div>
-      </div>
+      </Card>
 
       <div className="flex items-center justify-between border-b pb-4">
         <div>

--- a/components/admin/TimeToolConfigurationPanel.tsx
+++ b/components/admin/TimeToolConfigurationPanel.tsx
@@ -70,7 +70,7 @@ export const TimeToolConfigurationPanel: React.FC<
         />
       </div>
 
-      <Card rounded="xl" className="bg-slate-50 space-y-4">
+      <Card rounded="xl" shadow="none" className="bg-slate-50 space-y-4">
         <p className="text-xxs text-slate-500 leading-tight">
           These defaults will pre-configure the Timer widget when a teacher in{' '}
           <b>{BUILDINGS.find((b) => b.id === selectedBuildingId)?.name}</b> adds

--- a/components/admin/TrafficLightConfigurationPanel.tsx
+++ b/components/admin/TrafficLightConfigurationPanel.tsx
@@ -1,3 +1,4 @@
+import { Card } from '@/components/common/Card';
 import React, { useState } from 'react';
 import { BUILDINGS } from '@/config/buildings';
 import { BuildingSelector } from './BuildingSelector';
@@ -96,7 +97,7 @@ export const TrafficLightConfigurationPanel: React.FC<
         />
       </div>
 
-      <div className="bg-slate-50 rounded-xl border border-slate-200 p-4 space-y-4">
+      <Card rounded="xl" className="bg-slate-50 space-y-4">
         <p className="text-xxs text-slate-500 leading-tight">
           Sets the default active light state when a teacher in{' '}
           <b>{BUILDINGS.find((b) => b.id === selectedBuildingId)?.name}</b> adds
@@ -138,7 +139,7 @@ export const TrafficLightConfigurationPanel: React.FC<
             })}
           </div>
         </div>
-      </div>
+      </Card>
     </div>
   );
 };

--- a/components/admin/TrafficLightConfigurationPanel.tsx
+++ b/components/admin/TrafficLightConfigurationPanel.tsx
@@ -97,7 +97,7 @@ export const TrafficLightConfigurationPanel: React.FC<
         />
       </div>
 
-      <Card rounded="xl" className="bg-slate-50 space-y-4">
+      <Card rounded="xl" shadow="none" className="bg-slate-50 space-y-4">
         <p className="text-xxs text-slate-500 leading-tight">
           Sets the default active light state when a teacher in{' '}
           <b>{BUILDINGS.find((b) => b.id === selectedBuildingId)?.name}</b> adds

--- a/components/common/Card.tsx
+++ b/components/common/Card.tsx
@@ -5,6 +5,7 @@ interface CardProps extends HTMLAttributes<HTMLDivElement> {
   padding?: 'none' | 'sm' | 'md' | 'lg';
   rounded?: 'md' | 'lg' | 'xl' | '2xl' | '3xl' | 'none';
   hoverable?: boolean;
+  shadow?: 'none' | 'sm' | 'md' | 'lg' | 'xl' | '2xl';
 }
 
 export const Card: React.FC<CardProps> = ({
@@ -13,9 +14,19 @@ export const Card: React.FC<CardProps> = ({
   padding = 'md',
   rounded = '2xl',
   hoverable = false,
+  shadow = 'sm',
   ...props
 }) => {
-  const baseStyles = 'bg-white border border-slate-200 shadow-sm';
+  const baseStyles = 'bg-white border border-slate-200';
+
+  const shadowStyles = {
+    none: 'shadow-none',
+    sm: 'shadow-sm',
+    md: 'shadow-md',
+    lg: 'shadow-lg',
+    xl: 'shadow-xl',
+    '2xl': 'shadow-2xl',
+  };
 
   const paddingStyles = {
     none: 'p-0',
@@ -36,6 +47,7 @@ export const Card: React.FC<CardProps> = ({
   const computedClass = [
     baseStyles,
     paddingStyles[padding],
+    shadowStyles[shadow],
     roundedStyles[rounded],
     hoverable && 'hover:shadow-md transition-all',
     className,


### PR DESCRIPTION
📉 Debt Removed: Replaced 19 instances of hardcoded generic container divs
🧱 Component Used: Implemented shared `<Card />` component from `@/components/common/Card`
📸 Before/After: Visual presentation identical, but enforces centralized design system shadow, border, and padding logic.

---
*PR created automatically by Jules for task [4250407057096060826](https://jules.google.com/task/4250407057096060826) started by @OPS-PIvers*