### PR TITLE
test: Add test coverage for useIsMobile hook

### DIFF
--- a/tests/hooks/useIsMobile.test.ts
+++ b/tests/hooks/useIsMobile.test.ts
@@ -1,9 +1,9 @@
 import { renderHook } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { useIsMobile } from '../../hooks/useIsMobile';
-import * as useWindowSizeModule from '../../hooks/useWindowSize';
+import { useIsMobile } from '@/hooks/useIsMobile';
+import * as useWindowSizeModule from '@/hooks/useWindowSize';
 
-vi.mock('../../hooks/useWindowSize', () => ({
+vi.mock('@/hooks/useWindowSize', () => ({
   useWindowSize: vi.fn(),
 }));
 

--- a/tests/hooks/useIsMobile.test.ts
+++ b/tests/hooks/useIsMobile.test.ts
@@ -1,0 +1,50 @@
+import { renderHook } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { useIsMobile } from '../../hooks/useIsMobile';
+import * as useWindowSizeModule from '../../hooks/useWindowSize';
+
+vi.mock('../../hooks/useWindowSize', () => ({
+  useWindowSize: vi.fn(),
+}));
+
+describe('useIsMobile', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns false initially if width is 0', () => {
+    vi.mocked(useWindowSizeModule.useWindowSize).mockReturnValue({
+      width: 0,
+      height: 0,
+    });
+    const { result } = renderHook(() => useIsMobile());
+    expect(result.current).toBe(false);
+  });
+
+  it('returns true if width is greater than 0 and less than 768', () => {
+    vi.mocked(useWindowSizeModule.useWindowSize).mockReturnValue({
+      width: 767,
+      height: 1000,
+    });
+    const { result } = renderHook(() => useIsMobile());
+    expect(result.current).toBe(true);
+  });
+
+  it('returns false if width is exactly 768', () => {
+    vi.mocked(useWindowSizeModule.useWindowSize).mockReturnValue({
+      width: 768,
+      height: 1000,
+    });
+    const { result } = renderHook(() => useIsMobile());
+    expect(result.current).toBe(false);
+  });
+
+  it('returns false if width is greater than 768', () => {
+    vi.mocked(useWindowSizeModule.useWindowSize).mockReturnValue({
+      width: 1024,
+      height: 1000,
+    });
+    const { result } = renderHook(() => useIsMobile());
+    expect(result.current).toBe(false);
+  });
+});


### PR DESCRIPTION
**Analysis:**
I ran `vitest run --coverage` and identified that the test coverage for `hooks/useIsMobile.ts` was 0%. This hook is responsible for determining if the viewport is narrower than the Tailwind `md` breakpoint (768px), which is crucial for responsive layout rendering.

**Work Completed:**
- Created a new test file `tests/hooks/useIsMobile.test.ts`.
- Mocks `useWindowSize` to simulate different window sizes safely.
- Added comprehensive unit tests:
  - Verifies that it returns `false` initially if width is `0`.
  - Verifies that it returns `true` if width is greater than `0` and less than `768`.
  - Verifies that it returns `false` if width is exactly `768`.
  - Verifies that it returns `false` if width is greater than `768`.
- Ran `pnpm run lint --fix` and `pnpm run validate` to ensure zero type/lint warnings or errors.
- Verified test coverage is now 100% for `useIsMobile`.

**How it Resolves the Issue:**
This PR closes the verifiable gap in test coverage for `useIsMobile.ts`, increasing the reliability of mobile breakpoint detection logic and fulfilling the project requirements for rigorous test coverage.

---
*PR created automatically by Jules for task [9673350723980504660](https://jules.google.com/task/9673350723980504660) started by @OPS-PIvers*