### PR TITLE
Make Gemini model selection configurable via admin panel

### DIFF
--- a/components/admin/GlobalPermissionsManager.tsx
+++ b/components/admin/GlobalPermissionsManager.tsx
@@ -1,5 +1,12 @@
 import React, { useState, useEffect, useCallback, useMemo } from 'react';
-import { collection, doc, setDoc, getDocs } from 'firebase/firestore';
+import {
+  collection,
+  doc,
+  setDoc,
+  getDocs,
+  addDoc,
+  serverTimestamp,
+} from 'firebase/firestore';
 import { db } from '@/config/firebase';
 import { AccessLevel, GlobalFeature, GlobalFeaturePermission } from '@/types';
 import {
@@ -106,6 +113,221 @@ const GEMINI_FEATURES: GlobalFeature[] = [
   'video-activity-audio-transcription',
 ];
 
+const KNOWN_GEMINI_MODELS = [
+  {
+    value: 'gemini-3-flash-preview',
+    label: 'Gemini 3 Flash (Preview)',
+    tier: 'advanced',
+  },
+  {
+    value: 'gemini-3.1-flash-lite-preview',
+    label: 'Gemini 3.1 Flash Lite (Preview)',
+    tier: 'standard',
+  },
+  {
+    value: 'gemini-2.5-flash',
+    label: 'Gemini 2.5 Flash',
+    tier: 'advanced',
+  },
+  {
+    value: 'gemini-2.5-flash-lite',
+    label: 'Gemini 2.5 Flash Lite',
+    tier: 'standard',
+  },
+  {
+    value: 'gemini-2.0-flash',
+    label: 'Gemini 2.0 Flash',
+    tier: 'advanced',
+  },
+  {
+    value: 'gemini-2.0-flash-lite',
+    label: 'Gemini 2.0 Flash Lite',
+    tier: 'standard',
+  },
+] as const;
+
+const GEMINI_MODEL_REGEX = /^gemini-[\w.-]+$/;
+
+const DEFAULT_ADVANCED_MODEL = 'gemini-3-flash-preview';
+const DEFAULT_STANDARD_MODEL = 'gemini-3.1-flash-lite-preview';
+
+/**
+ * Shared UI for configuring Gemini model overrides on the `gemini-functions`
+ * permission. Renders in two visual variants: `inline` for list view and
+ * `expanded` for grid view.
+ */
+const GeminiModelConfigSection: React.FC<{
+  variant: 'inline' | 'expanded';
+  permission: GlobalFeaturePermission;
+  onUpdate: (updates: Partial<GlobalFeaturePermission>) => void;
+}> = ({ variant, permission, onUpdate }) => {
+  const advancedModel = (permission.config?.advancedModel as string) ?? '';
+  const standardModel = (permission.config?.standardModel as string) ?? '';
+
+  const isCustomAdvanced =
+    advancedModel !== '' &&
+    !KNOWN_GEMINI_MODELS.some((m) => m.value === advancedModel);
+  const isCustomStandard =
+    standardModel !== '' &&
+    !KNOWN_GEMINI_MODELS.some((m) => m.value === standardModel);
+
+  const [showCustomAdvanced, setShowCustomAdvanced] =
+    React.useState(isCustomAdvanced);
+  const [showCustomStandard, setShowCustomStandard] =
+    React.useState(isCustomStandard);
+
+  const advancedError =
+    showCustomAdvanced &&
+    advancedModel !== '' &&
+    !GEMINI_MODEL_REGEX.test(advancedModel);
+  const standardError =
+    showCustomStandard &&
+    standardModel !== '' &&
+    !GEMINI_MODEL_REGEX.test(standardModel);
+
+  const handleSelectChange = (
+    field: 'advancedModel' | 'standardModel',
+    value: string,
+    setShowCustom: (v: boolean) => void
+  ) => {
+    if (value === '__custom__') {
+      setShowCustom(true);
+      onUpdate({
+        config: { ...permission.config, [field]: '' },
+      });
+    } else {
+      setShowCustom(false);
+      onUpdate({
+        config: { ...permission.config, [field]: value },
+      });
+    }
+  };
+
+  const handleCustomInput = (
+    field: 'advancedModel' | 'standardModel',
+    value: string
+  ) => {
+    onUpdate({
+      config: { ...permission.config, [field]: value },
+    });
+  };
+
+  const getSelectValue = (
+    currentValue: string,
+    showCustom: boolean
+  ): string => {
+    if (showCustom) return '__custom__';
+    if (currentValue === '') return '';
+    const known = KNOWN_GEMINI_MODELS.find((m) => m.value === currentValue);
+    return known ? currentValue : '__custom__';
+  };
+
+  const isInline = variant === 'inline';
+
+  const containerClass = isInline
+    ? 'border-t border-slate-100 bg-purple-50 p-4'
+    : 'mb-6 p-4 bg-purple-50 rounded-xl border border-purple-100';
+
+  const layoutClass = isInline
+    ? 'grid grid-cols-1 sm:grid-cols-2 gap-3'
+    : 'space-y-3';
+
+  const inputClass = isInline
+    ? 'w-full px-3 py-1.5 border rounded text-xs font-mono focus:outline-none focus:ring-1 focus:ring-purple-500'
+    : 'w-full px-3 py-2 border rounded-lg text-sm font-mono focus:outline-none focus:ring-2 focus:ring-purple-500';
+
+  const selectClass = isInline
+    ? 'w-full px-3 py-1.5 border border-purple-200 rounded text-xs focus:outline-none focus:ring-1 focus:ring-purple-500 bg-white'
+    : 'w-full px-3 py-2 border border-purple-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-purple-500 bg-white';
+
+  const renderModelField = (
+    label: string,
+    field: 'advancedModel' | 'standardModel',
+    currentValue: string,
+    defaultModel: string,
+    tier: string,
+    showCustom: boolean,
+    setShowCustom: (v: boolean) => void,
+    hasError: boolean
+  ) => (
+    <div>
+      <label className="text-xxs font-bold text-purple-700 uppercase tracking-widest mb-1 block">
+        {label}
+      </label>
+      <select
+        value={getSelectValue(currentValue, showCustom)}
+        onChange={(e) =>
+          handleSelectChange(field, e.target.value, setShowCustom)
+        }
+        className={selectClass}
+      >
+        <option value="">Default ({defaultModel})</option>
+        {KNOWN_GEMINI_MODELS.filter((m) => m.tier === tier).map((m) => (
+          <option key={m.value} value={m.value}>
+            {m.label}
+          </option>
+        ))}
+        <option value="__custom__">Custom...</option>
+      </select>
+      {showCustom && (
+        <div className="mt-1.5">
+          <input
+            type="text"
+            placeholder="e.g. gemini-2.5-flash"
+            value={currentValue}
+            onChange={(e) => handleCustomInput(field, e.target.value)}
+            className={`${inputClass} ${
+              hasError
+                ? 'border-red-400 focus:ring-red-400'
+                : 'border-purple-200'
+            }`}
+          />
+          {hasError && (
+            <p className="text-xxs text-red-600 mt-0.5">
+              Must match pattern: gemini-[name] (letters, digits, dots, hyphens,
+              underscores)
+            </p>
+          )}
+        </div>
+      )}
+    </div>
+  );
+
+  return (
+    <div className={containerClass}>
+      <label className="text-xs font-bold text-purple-700 uppercase tracking-widest mb-2 block">
+        Gemini Model Overrides
+      </label>
+      <div className={layoutClass}>
+        {renderModelField(
+          'Advanced Model (mini-apps, guided learning)',
+          'advancedModel',
+          advancedModel,
+          DEFAULT_ADVANCED_MODEL,
+          'advanced',
+          showCustomAdvanced,
+          setShowCustomAdvanced,
+          advancedError
+        )}
+        {renderModelField(
+          'Standard Model (OCR, polls, quizzes)',
+          'standardModel',
+          standardModel,
+          DEFAULT_STANDARD_MODEL,
+          'standard',
+          showCustomStandard,
+          setShowCustomStandard,
+          standardError
+        )}
+      </div>
+      <p className="text-xxs text-purple-500 mt-2 leading-tight">
+        Override the AI models used by Cloud Functions. Leave as
+        &quot;Default&quot; to use the built-in model for each tier.
+      </p>
+    </div>
+  );
+};
+
 export const GlobalPermissionsManager: React.FC = () => {
   const isMobile = useIsMobile();
   const [viewMode, setViewMode] = useState<'grid' | 'list'>('list');
@@ -122,7 +344,7 @@ export const GlobalPermissionsManager: React.FC = () => {
   } | null>(null);
   const [unsavedChanges, setUnsavedChanges] = useState<Set<string>>(new Set());
 
-  const { appSettings, updateAppSettings } = useAuth();
+  const { user, appSettings, updateAppSettings } = useAuth();
   const { uploadAdminLogo, deleteAdminLogo, uploading } = useStorage();
   const fileInputRef = React.useRef<HTMLInputElement>(null);
 
@@ -247,6 +469,27 @@ export const GlobalPermissionsManager: React.FC = () => {
       const permission = getPermission(featureId);
 
       await setDoc(doc(db, 'global_permissions', featureId), permission);
+
+      // Audit log for model config changes
+      if (
+        featureId === 'gemini-functions' &&
+        (permission.config?.advancedModel || permission.config?.standardModel)
+      ) {
+        try {
+          await addDoc(collection(db, 'admin_audit_log'), {
+            action: 'model_config_change',
+            email: user?.email ?? '(unknown)',
+            timestamp: serverTimestamp(),
+            advancedModel:
+              (permission.config?.advancedModel as string) || '(default)',
+            standardModel:
+              (permission.config?.standardModel as string) || '(default)',
+          });
+        } catch (auditErr) {
+          // Non-blocking — don't fail the save if audit logging fails
+          console.error('Failed to write audit log:', auditErr);
+        }
+      }
 
       setUnsavedChanges((prev) => {
         const next = new Set(prev);
@@ -753,85 +996,15 @@ export const GlobalPermissionsManager: React.FC = () => {
                     </div>
                   )}
 
-                  {/* Gemini Model Configuration (gemini-functions only) */}
+                  {/* Gemini Model Config (gemini-functions only) */}
                   {feature.id === 'gemini-functions' && (
-                    <div className="border-t border-slate-100 bg-purple-50 p-4 text-left">
-                      <label className="text-xs font-bold text-purple-700 uppercase tracking-widest mb-3 block">
-                        AI Model Configuration
-                      </label>
-                      <p className="text-xxs text-purple-500 mb-3 leading-tight">
-                        Override the default Gemini models. Leave blank to use
-                        defaults.
-                      </p>
-                      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-                        <div>
-                          <label className="text-xxs font-bold text-purple-600 mb-1 block">
-                            Advanced Model
-                          </label>
-                          <input
-                            type="text"
-                            placeholder="gemini-3-flash-preview"
-                            value={
-                              (permission.config?.advancedModel as string) ?? ''
-                            }
-                            onChange={(e) =>
-                              updatePermission(feature.id, {
-                                config: {
-                                  ...permission.config,
-                                  advancedModel: e.target.value,
-                                },
-                              })
-                            }
-                            onBlur={(e) => {
-                              const trimmed = e.target.value.trim();
-                              updatePermission(feature.id, {
-                                config: {
-                                  ...permission.config,
-                                  advancedModel: trimmed || undefined,
-                                },
-                              });
-                            }}
-                            className="w-full px-3 py-1.5 border border-purple-200 rounded-lg text-xs font-mono focus:outline-none focus:ring-1 focus:ring-purple-500 bg-white"
-                          />
-                          <span className="text-xxs text-purple-400 mt-0.5 block">
-                            Mini-apps, widget builder, guided learning
-                          </span>
-                        </div>
-                        <div>
-                          <label className="text-xxs font-bold text-purple-600 mb-1 block">
-                            Standard Model
-                          </label>
-                          <input
-                            type="text"
-                            placeholder="gemini-3.1-flash-lite-preview"
-                            value={
-                              (permission.config?.standardModel as string) ?? ''
-                            }
-                            onChange={(e) =>
-                              updatePermission(feature.id, {
-                                config: {
-                                  ...permission.config,
-                                  standardModel: e.target.value,
-                                },
-                              })
-                            }
-                            onBlur={(e) => {
-                              const trimmed = e.target.value.trim();
-                              updatePermission(feature.id, {
-                                config: {
-                                  ...permission.config,
-                                  standardModel: trimmed || undefined,
-                                },
-                              });
-                            }}
-                            className="w-full px-3 py-1.5 border border-purple-200 rounded-lg text-xs font-mono focus:outline-none focus:ring-1 focus:ring-purple-500 bg-white"
-                          />
-                          <span className="text-xxs text-purple-400 mt-0.5 block">
-                            OCR, quizzes, polls, layouts, video activities
-                          </span>
-                        </div>
-                      </div>
-                    </div>
+                    <GeminiModelConfigSection
+                      variant="inline"
+                      permission={permission}
+                      onUpdate={(updates) =>
+                        updatePermission(feature.id, updates)
+                      }
+                    />
                   )}
                 </div>
               );
@@ -1028,86 +1201,15 @@ export const GlobalPermissionsManager: React.FC = () => {
                   </div>
                 )}
 
-                {/* Gemini Model Configuration (gemini-functions only) */}
+                {/* Gemini Model Config (gemini-functions only) */}
                 {feature.id === 'gemini-functions' && (
-                  <div className="mb-6 p-4 bg-purple-50 rounded-xl border border-purple-100">
-                    <label className="text-xs font-bold text-purple-700 uppercase tracking-widest mb-2 block">
-                      AI Model Configuration
-                    </label>
-                    <p className="text-xxs text-purple-500 mb-4 leading-tight">
-                      Override the default Gemini models used by AI features.
-                      Leave blank to use defaults.
-                    </p>
-                    <div className="space-y-3">
-                      <div>
-                        <label className="text-xxs font-bold text-purple-600 mb-1 block">
-                          Advanced Model
-                        </label>
-                        <input
-                          type="text"
-                          placeholder="gemini-3-flash-preview"
-                          value={
-                            (permission.config?.advancedModel as string) ?? ''
-                          }
-                          onChange={(e) =>
-                            updatePermission(feature.id, {
-                              config: {
-                                ...permission.config,
-                                advancedModel: e.target.value,
-                              },
-                            })
-                          }
-                          onBlur={(e) => {
-                            const trimmed = e.target.value.trim();
-                            updatePermission(feature.id, {
-                              config: {
-                                ...permission.config,
-                                advancedModel: trimmed || undefined,
-                              },
-                            });
-                          }}
-                          className="w-full px-3 py-2 border border-purple-200 rounded-lg text-sm font-mono focus:outline-none focus:ring-2 focus:ring-purple-500 bg-white"
-                        />
-                        <span className="text-xxs text-purple-400 mt-1 block">
-                          Used for mini-apps, widget builder, guided learning
-                        </span>
-                      </div>
-                      <div>
-                        <label className="text-xxs font-bold text-purple-600 mb-1 block">
-                          Standard Model
-                        </label>
-                        <input
-                          type="text"
-                          placeholder="gemini-3.1-flash-lite-preview"
-                          value={
-                            (permission.config?.standardModel as string) ?? ''
-                          }
-                          onChange={(e) =>
-                            updatePermission(feature.id, {
-                              config: {
-                                ...permission.config,
-                                standardModel: e.target.value,
-                              },
-                            })
-                          }
-                          onBlur={(e) => {
-                            const trimmed = e.target.value.trim();
-                            updatePermission(feature.id, {
-                              config: {
-                                ...permission.config,
-                                standardModel: trimmed || undefined,
-                              },
-                            });
-                          }}
-                          className="w-full px-3 py-2 border border-purple-200 rounded-lg text-sm font-mono focus:outline-none focus:ring-2 focus:ring-purple-500 bg-white"
-                        />
-                        <span className="text-xxs text-purple-400 mt-1 block">
-                          Used for OCR, quizzes, polls, layouts, video
-                          activities
-                        </span>
-                      </div>
-                    </div>
-                  </div>
+                  <GeminiModelConfigSection
+                    variant="expanded"
+                    permission={permission}
+                    onUpdate={(updates) =>
+                      updatePermission(feature.id, updates)
+                    }
+                  />
                 )}
 
                 {/* Save Button */}

--- a/components/admin/GlobalPermissionsManager.tsx
+++ b/components/admin/GlobalPermissionsManager.tsx
@@ -752,6 +752,69 @@ export const GlobalPermissionsManager: React.FC = () => {
                       </div>
                     </div>
                   )}
+
+                  {/* Gemini Model Configuration (gemini-functions only) */}
+                  {feature.id === 'gemini-functions' && (
+                    <div className="border-t border-slate-100 bg-purple-50 p-4 text-left">
+                      <label className="text-xs font-bold text-purple-700 uppercase tracking-widest mb-3 block">
+                        AI Model Configuration
+                      </label>
+                      <p className="text-xxs text-purple-500 mb-3 leading-tight">
+                        Override the default Gemini models. Leave blank to use
+                        defaults.
+                      </p>
+                      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                        <div>
+                          <label className="text-xxs font-bold text-purple-600 mb-1 block">
+                            Advanced Model
+                          </label>
+                          <input
+                            type="text"
+                            placeholder="gemini-3-flash-preview"
+                            value={
+                              (permission.config?.advancedModel as string) ?? ''
+                            }
+                            onChange={(e) =>
+                              updatePermission(feature.id, {
+                                config: {
+                                  ...permission.config,
+                                  advancedModel: e.target.value,
+                                },
+                              })
+                            }
+                            className="w-full px-3 py-1.5 border border-purple-200 rounded-lg text-xs font-mono focus:outline-none focus:ring-1 focus:ring-purple-500 bg-white"
+                          />
+                          <span className="text-xxs text-purple-400 mt-0.5 block">
+                            Mini-apps, widget builder, guided learning
+                          </span>
+                        </div>
+                        <div>
+                          <label className="text-xxs font-bold text-purple-600 mb-1 block">
+                            Standard Model
+                          </label>
+                          <input
+                            type="text"
+                            placeholder="gemini-3.1-flash-lite-preview"
+                            value={
+                              (permission.config?.standardModel as string) ?? ''
+                            }
+                            onChange={(e) =>
+                              updatePermission(feature.id, {
+                                config: {
+                                  ...permission.config,
+                                  standardModel: e.target.value,
+                                },
+                              })
+                            }
+                            className="w-full px-3 py-1.5 border border-purple-200 rounded-lg text-xs font-mono focus:outline-none focus:ring-1 focus:ring-purple-500 bg-white"
+                          />
+                          <span className="text-xxs text-purple-400 mt-0.5 block">
+                            OCR, quizzes, polls, layouts, video activities
+                          </span>
+                        </div>
+                      </div>
+                    </div>
+                  )}
                 </div>
               );
             }
@@ -944,6 +1007,70 @@ export const GlobalPermissionsManager: React.FC = () => {
                       see a &quot;limit reached&quot; message after this many
                       generations.
                     </p>
+                  </div>
+                )}
+
+                {/* Gemini Model Configuration (gemini-functions only) */}
+                {feature.id === 'gemini-functions' && (
+                  <div className="mb-6 p-4 bg-purple-50 rounded-xl border border-purple-100">
+                    <label className="text-xs font-bold text-purple-700 uppercase tracking-widest mb-2 block">
+                      AI Model Configuration
+                    </label>
+                    <p className="text-xxs text-purple-500 mb-4 leading-tight">
+                      Override the default Gemini models used by AI features.
+                      Leave blank to use defaults.
+                    </p>
+                    <div className="space-y-3">
+                      <div>
+                        <label className="text-xxs font-bold text-purple-600 mb-1 block">
+                          Advanced Model
+                        </label>
+                        <input
+                          type="text"
+                          placeholder="gemini-3-flash-preview"
+                          value={
+                            (permission.config?.advancedModel as string) ?? ''
+                          }
+                          onChange={(e) =>
+                            updatePermission(feature.id, {
+                              config: {
+                                ...permission.config,
+                                advancedModel: e.target.value,
+                              },
+                            })
+                          }
+                          className="w-full px-3 py-2 border border-purple-200 rounded-lg text-sm font-mono focus:outline-none focus:ring-2 focus:ring-purple-500 bg-white"
+                        />
+                        <span className="text-xxs text-purple-400 mt-1 block">
+                          Used for mini-apps, widget builder, guided learning
+                        </span>
+                      </div>
+                      <div>
+                        <label className="text-xxs font-bold text-purple-600 mb-1 block">
+                          Standard Model
+                        </label>
+                        <input
+                          type="text"
+                          placeholder="gemini-3.1-flash-lite-preview"
+                          value={
+                            (permission.config?.standardModel as string) ?? ''
+                          }
+                          onChange={(e) =>
+                            updatePermission(feature.id, {
+                              config: {
+                                ...permission.config,
+                                standardModel: e.target.value,
+                              },
+                            })
+                          }
+                          className="w-full px-3 py-2 border border-purple-200 rounded-lg text-sm font-mono focus:outline-none focus:ring-2 focus:ring-purple-500 bg-white"
+                        />
+                        <span className="text-xxs text-purple-400 mt-1 block">
+                          Used for OCR, quizzes, polls, layouts, video
+                          activities
+                        </span>
+                      </div>
+                    </div>
                   </div>
                 )}
 

--- a/components/admin/GlobalPermissionsManager.tsx
+++ b/components/admin/GlobalPermissionsManager.tsx
@@ -782,6 +782,15 @@ export const GlobalPermissionsManager: React.FC = () => {
                                 },
                               })
                             }
+                            onBlur={(e) => {
+                              const trimmed = e.target.value.trim();
+                              updatePermission(feature.id, {
+                                config: {
+                                  ...permission.config,
+                                  advancedModel: trimmed || undefined,
+                                },
+                              });
+                            }}
                             className="w-full px-3 py-1.5 border border-purple-200 rounded-lg text-xs font-mono focus:outline-none focus:ring-1 focus:ring-purple-500 bg-white"
                           />
                           <span className="text-xxs text-purple-400 mt-0.5 block">
@@ -806,6 +815,15 @@ export const GlobalPermissionsManager: React.FC = () => {
                                 },
                               })
                             }
+                            onBlur={(e) => {
+                              const trimmed = e.target.value.trim();
+                              updatePermission(feature.id, {
+                                config: {
+                                  ...permission.config,
+                                  standardModel: trimmed || undefined,
+                                },
+                              });
+                            }}
                             className="w-full px-3 py-1.5 border border-purple-200 rounded-lg text-xs font-mono focus:outline-none focus:ring-1 focus:ring-purple-500 bg-white"
                           />
                           <span className="text-xxs text-purple-400 mt-0.5 block">
@@ -1039,6 +1057,15 @@ export const GlobalPermissionsManager: React.FC = () => {
                               },
                             })
                           }
+                          onBlur={(e) => {
+                            const trimmed = e.target.value.trim();
+                            updatePermission(feature.id, {
+                              config: {
+                                ...permission.config,
+                                advancedModel: trimmed || undefined,
+                              },
+                            });
+                          }}
                           className="w-full px-3 py-2 border border-purple-200 rounded-lg text-sm font-mono focus:outline-none focus:ring-2 focus:ring-purple-500 bg-white"
                         />
                         <span className="text-xxs text-purple-400 mt-1 block">
@@ -1063,6 +1090,15 @@ export const GlobalPermissionsManager: React.FC = () => {
                               },
                             })
                           }
+                          onBlur={(e) => {
+                            const trimmed = e.target.value.trim();
+                            updatePermission(feature.id, {
+                              config: {
+                                ...permission.config,
+                                standardModel: trimmed || undefined,
+                              },
+                            });
+                          }}
                           className="w-full px-3 py-2 border border-purple-200 rounded-lg text-sm font-mono focus:outline-none focus:ring-2 focus:ring-purple-500 bg-white"
                         />
                         <span className="text-xxs text-purple-400 mt-1 block">

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -53,6 +53,8 @@ interface AIData {
 interface GlobalPermConfig {
   dailyLimit?: number;
   dailyLimitEnabled?: boolean;
+  advancedModel?: string;
+  standardModel?: string;
 }
 
 interface GlobalPermission {
@@ -537,6 +539,15 @@ export const generateWithAI = functionsV1
       }
     }
 
+    // Read model config from Firestore (for both admins and non-admins)
+    const geminiPermDoc = await db
+      .collection('global_permissions')
+      .doc('gemini-functions')
+      .get();
+    const geminiConfig = geminiPermDoc.exists
+      ? (geminiPermDoc.data()?.config as GlobalPermConfig | undefined)
+      : undefined;
+
     const apiKey = process.env.GEMINI_API_KEY;
     if (!apiKey) {
       console.error('CRITICAL: GEMINI_API_KEY is missing');
@@ -770,10 +781,15 @@ export const generateWithAI = functionsV1
       }
 
       // Use higher complexity model for code generation, and lite for OCR and simple JSON tasks
+      // Model names are admin-configurable via global_permissions/gemini-functions
+      const advancedModel =
+        geminiConfig?.advancedModel || 'gemini-3-flash-preview';
+      const standardModel =
+        geminiConfig?.standardModel || 'gemini-3.1-flash-lite-preview';
       const model =
         genType === 'mini-app' || genType === 'widget-builder'
-          ? 'gemini-3-flash-preview'
-          : 'gemini-3.1-flash-lite-preview';
+          ? advancedModel
+          : standardModel;
 
       const result = await ai.models.generateContent({
         model,
@@ -1213,6 +1229,17 @@ export const generateVideoActivity = functionsV1
         );
       }
 
+      // Read model config from Firestore
+      const geminiPermDoc = await db
+        .collection('global_permissions')
+        .doc('gemini-functions')
+        .get();
+      const geminiConfig = geminiPermDoc.exists
+        ? (geminiPermDoc.data()?.config as GlobalPermConfig | undefined)
+        : undefined;
+      const videoModel =
+        geminiConfig?.standardModel || 'gemini-3.1-flash-lite-preview';
+
       const ai = new GoogleGenAI({ apiKey });
 
       const systemPrompt = `You are an expert teacher creating a video comprehension activity.
@@ -1243,7 +1270,7 @@ Return JSON in this exact format:
 
       try {
         const result = await ai.models.generateContent({
-          model: 'gemini-3.1-flash-lite-preview',
+          model: videoModel,
           contents: [
             {
               role: 'user',
@@ -1657,6 +1684,18 @@ export const generateGuidedLearning = functionsV1
         );
       }
 
+      // Read model config from Firestore
+      const db = admin.firestore();
+      const geminiPermDoc = await db
+        .collection('global_permissions')
+        .doc('gemini-functions')
+        .get();
+      const geminiConfig = geminiPermDoc.exists
+        ? (geminiPermDoc.data()?.config as GlobalPermConfig | undefined)
+        : undefined;
+      const guidedLearningModel =
+        geminiConfig?.advancedModel || 'gemini-3-flash-preview';
+
       try {
         const ai = new GoogleGenAI({ apiKey });
 
@@ -1707,7 +1746,7 @@ Guidelines:
           : 'Analyze this educational image and create an engaging guided learning experience.';
 
         const response = await ai.models.generateContent({
-          model: 'gemini-3-flash-preview',
+          model: guidedLearningModel,
           contents: [
             {
               role: 'user',

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -53,8 +53,6 @@ interface AIData {
 interface GlobalPermConfig {
   dailyLimit?: number;
   dailyLimitEnabled?: boolean;
-  advancedModel?: string;
-  standardModel?: string;
 }
 
 interface GlobalPermission {
@@ -64,30 +62,55 @@ interface GlobalPermission {
   config?: GlobalPermConfig;
 }
 
-/** Trim and treat empty-after-trim as undefined so fallback defaults apply. */
-function normalizeModelName(name?: string): string | undefined {
-  const trimmed = name?.trim();
-  return trimmed || undefined;
+const DEFAULT_ADVANCED_MODEL = 'gemini-3-flash-preview';
+const DEFAULT_STANDARD_MODEL = 'gemini-3.1-flash-lite-preview';
+
+/**
+ * Validates and normalises a Gemini model name.
+ * Returns `undefined` when the supplied value is falsy or fails the pattern
+ * check, so callers can fall back to a default.
+ */
+function normalizeModelName(raw: unknown): string | undefined {
+  if (!raw || typeof raw !== 'string') return undefined;
+  const trimmed = raw.trim();
+  if (!trimmed) return undefined;
+  if (!/^gemini-[\w.-]+$/.test(trimmed)) return undefined;
+  return trimmed;
 }
 
-/** Read Gemini model config from Firestore with graceful fallback to defaults. */
+interface GeminiModelConfig {
+  advancedModel?: string;
+  standardModel?: string;
+}
+
+/**
+ * Reads the admin-configured model overrides from the `gemini-functions`
+ * global permissions document. Returns validated model names (or defaults).
+ */
 async function getGeminiModelConfig(
   db: admin.firestore.Firestore
-): Promise<GlobalPermConfig | undefined> {
+): Promise<{ advancedModel: string; standardModel: string }> {
   try {
     const doc = await db
       .collection('global_permissions')
       .doc('gemini-functions')
       .get();
-    return doc.exists
-      ? (doc.data()?.config as GlobalPermConfig | undefined)
-      : undefined;
+    const cfg = doc.data()?.config as GeminiModelConfig | undefined;
+    return {
+      advancedModel:
+        normalizeModelName(cfg?.advancedModel) ?? DEFAULT_ADVANCED_MODEL,
+      standardModel:
+        normalizeModelName(cfg?.standardModel) ?? DEFAULT_STANDARD_MODEL,
+    };
   } catch (error) {
     console.warn(
       'Failed to read Gemini model config from Firestore; using defaults.',
       error
     );
-    return undefined;
+    return {
+      advancedModel: DEFAULT_ADVANCED_MODEL,
+      standardModel: DEFAULT_STANDARD_MODEL,
+    };
   }
 }
 
@@ -801,16 +824,10 @@ export const generateWithAI = functionsV1
 
       // Use higher complexity model for code generation, and lite for OCR and simple JSON tasks
       // Model names are admin-configurable via global_permissions/gemini-functions
-      const advancedModel =
-        normalizeModelName(geminiConfig?.advancedModel) ??
-        'gemini-3-flash-preview';
-      const standardModel =
-        normalizeModelName(geminiConfig?.standardModel) ??
-        'gemini-3.1-flash-lite-preview';
       const model =
         genType === 'mini-app' || genType === 'widget-builder'
-          ? advancedModel
-          : standardModel;
+          ? geminiConfig.advancedModel
+          : geminiConfig.standardModel;
 
       const result = await ai.models.generateContent({
         model,
@@ -849,9 +866,11 @@ export const generateWithAI = functionsV1
         throw error;
       }
 
-      const msg =
-        error instanceof Error ? error.message : 'AI Generation failed';
-      throw new functionsV1.https.HttpsError('internal', msg);
+      const detail = error instanceof Error ? error.message : 'unknown error';
+      throw new functionsV1.https.HttpsError(
+        'internal',
+        `AI generation failed (model: ${model}): ${detail}`
+      );
     }
   });
 
@@ -1252,9 +1271,7 @@ export const generateVideoActivity = functionsV1
 
       // Read model config from Firestore
       const geminiConfig = await getGeminiModelConfig(db);
-      const videoModel =
-        normalizeModelName(geminiConfig?.standardModel) ??
-        'gemini-3.1-flash-lite-preview';
+      const videoModel = geminiConfig.standardModel;
 
       const ai = new GoogleGenAI({ apiKey });
 
@@ -1320,9 +1337,11 @@ Return JSON in this exact format:
         return parsed;
       } catch (error: unknown) {
         console.error('[generateVideoActivity] Gemini error:', error);
-        const msg =
-          error instanceof Error ? error.message : 'AI generation failed';
-        throw new functionsV1.https.HttpsError('internal', msg);
+        const detail = error instanceof Error ? error.message : 'unknown error';
+        throw new functionsV1.https.HttpsError(
+          'internal',
+          `AI generation failed (model: ${videoModel}): ${detail}`
+        );
       }
     }
   );
@@ -1607,8 +1626,8 @@ Return JSON:
         return parsed;
       } catch (error: unknown) {
         console.error('[transcribeVideoWithGemini] Gemini error:', error);
-        const msg =
-          error instanceof Error ? error.message : 'AI generation failed';
+        const detail = error instanceof Error ? error.message : 'unknown error';
+        const msg = `AI generation failed (model: ${model}): ${detail}`;
         throw new functionsV1.https.HttpsError('internal', msg);
       }
     }
@@ -1672,8 +1691,8 @@ export const generateGuidedLearning = functionsV1
           'Authenticated user must have an email address.'
         );
       }
-      const adminDoc = await admin
-        .firestore()
+      const db = admin.firestore();
+      const adminDoc = await db
         .collection('admins')
         .doc(userEmail.toLowerCase())
         .get();
@@ -1701,11 +1720,8 @@ export const generateGuidedLearning = functionsV1
       }
 
       // Read model config from Firestore
-      const db = admin.firestore();
       const geminiConfig = await getGeminiModelConfig(db);
-      const guidedLearningModel =
-        normalizeModelName(geminiConfig?.advancedModel) ??
-        'gemini-3-flash-preview';
+      const guidedLearningModel = geminiConfig.advancedModel;
 
       try {
         const ai = new GoogleGenAI({ apiKey });
@@ -1798,8 +1814,8 @@ Guidelines:
         return parsed;
       } catch (error: unknown) {
         console.error('[generateGuidedLearning] Gemini error:', error);
-        const msg =
-          error instanceof Error ? error.message : 'AI generation failed';
+        const detail = error instanceof Error ? error.message : 'unknown error';
+        const msg = `AI generation failed (model: ${guidedLearningModel}): ${detail}`;
         throw new functionsV1.https.HttpsError('internal', msg);
       }
     }

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -64,6 +64,33 @@ interface GlobalPermission {
   config?: GlobalPermConfig;
 }
 
+/** Trim and treat empty-after-trim as undefined so fallback defaults apply. */
+function normalizeModelName(name?: string): string | undefined {
+  const trimmed = name?.trim();
+  return trimmed || undefined;
+}
+
+/** Read Gemini model config from Firestore with graceful fallback to defaults. */
+async function getGeminiModelConfig(
+  db: admin.firestore.Firestore
+): Promise<GlobalPermConfig | undefined> {
+  try {
+    const doc = await db
+      .collection('global_permissions')
+      .doc('gemini-functions')
+      .get();
+    return doc.exists
+      ? (doc.data()?.config as GlobalPermConfig | undefined)
+      : undefined;
+  } catch (error) {
+    console.warn(
+      'Failed to read Gemini model config from Firestore; using defaults.',
+      error
+    );
+    return undefined;
+  }
+}
+
 interface ArchiveActivityWallPhotoData {
   accessToken?: string;
   sessionId?: string;
@@ -540,13 +567,7 @@ export const generateWithAI = functionsV1
     }
 
     // Read model config from Firestore (for both admins and non-admins)
-    const geminiPermDoc = await db
-      .collection('global_permissions')
-      .doc('gemini-functions')
-      .get();
-    const geminiConfig = geminiPermDoc.exists
-      ? (geminiPermDoc.data()?.config as GlobalPermConfig | undefined)
-      : undefined;
+    const geminiConfig = await getGeminiModelConfig(db);
 
     const apiKey = process.env.GEMINI_API_KEY;
     if (!apiKey) {
@@ -783,9 +804,11 @@ export const generateWithAI = functionsV1
       // Use higher complexity model for code generation, and lite for OCR and simple JSON tasks
       // Model names are admin-configurable via global_permissions/gemini-functions
       const advancedModel =
-        geminiConfig?.advancedModel || 'gemini-3-flash-preview';
+        normalizeModelName(geminiConfig?.advancedModel) ??
+        'gemini-3-flash-preview';
       const standardModel =
-        geminiConfig?.standardModel || 'gemini-3.1-flash-lite-preview';
+        normalizeModelName(geminiConfig?.standardModel) ??
+        'gemini-3.1-flash-lite-preview';
       const model =
         genType === 'mini-app' || genType === 'widget-builder'
           ? advancedModel
@@ -1230,15 +1253,10 @@ export const generateVideoActivity = functionsV1
       }
 
       // Read model config from Firestore
-      const geminiPermDoc = await db
-        .collection('global_permissions')
-        .doc('gemini-functions')
-        .get();
-      const geminiConfig = geminiPermDoc.exists
-        ? (geminiPermDoc.data()?.config as GlobalPermConfig | undefined)
-        : undefined;
+      const geminiConfig = await getGeminiModelConfig(db);
       const videoModel =
-        geminiConfig?.standardModel || 'gemini-3.1-flash-lite-preview';
+        normalizeModelName(geminiConfig?.standardModel) ??
+        'gemini-3.1-flash-lite-preview';
 
       const ai = new GoogleGenAI({ apiKey });
 
@@ -1686,15 +1704,10 @@ export const generateGuidedLearning = functionsV1
 
       // Read model config from Firestore
       const db = admin.firestore();
-      const geminiPermDoc = await db
-        .collection('global_permissions')
-        .doc('gemini-functions')
-        .get();
-      const geminiConfig = geminiPermDoc.exists
-        ? (geminiPermDoc.data()?.config as GlobalPermConfig | undefined)
-        : undefined;
+      const geminiConfig = await getGeminiModelConfig(db);
       const guidedLearningModel =
-        geminiConfig?.advancedModel || 'gemini-3-flash-preview';
+        normalizeModelName(geminiConfig?.advancedModel) ??
+        'gemini-3-flash-preview';
 
       try {
         const ai = new GoogleGenAI({ apiKey });


### PR DESCRIPTION
## Summary
This PR adds admin-configurable Gemini model selection to the Global Permissions Manager, allowing administrators to override default AI models used across various features without code changes.

## Key Changes

- **Admin UI Configuration**: Added a new "AI Model Configuration" section in the Global Permissions Manager for the `gemini-functions` feature, allowing admins to specify:
  - Advanced Model (used for mini-apps, widget builder, guided learning)
  - Standard Model (used for OCR, quizzes, polls, layouts, video activities)
  - Implemented in both the inline and expanded permission views with consistent styling

- **Backend Model Resolution**: Updated three AI generation functions to read model configuration from Firestore:
  - `generateWithAI`: Reads config and uses `advancedModel` for code generation tasks and `standardModel` for OCR/JSON tasks
  - `generateVideoActivity`: Uses `standardModel` for video comprehension activities
  - `generateGuidedLearning`: Uses `advancedModel` for guided learning experiences

- **Data Model**: Extended `GlobalPermConfig` interface to include `advancedModel` and `standardModel` optional string fields

- **Fallback Defaults**: All functions maintain backward compatibility with hardcoded defaults when no admin configuration is present:
  - Advanced: `gemini-3-flash-preview`
  - Standard: `gemini-3.1-flash-lite-preview`

## Implementation Details

- Configuration is stored in `global_permissions/gemini-functions` document under the `config` field
- Model selection is read at runtime from Firestore, enabling dynamic updates without redeployment
- UI provides helpful descriptions of which features use each model tier
- Both admin and non-admin users benefit from the configured models

https://claude.ai/code/session_01VtWS3KaQyo8rSMap1u63mV