### PR TITLE
Add per-widget building selection for multi-building users

### DIFF
--- a/components/common/WidgetBuildingSelector.test.tsx
+++ b/components/common/WidgetBuildingSelector.test.tsx
@@ -5,8 +5,8 @@ import { useAuth } from '@/context/useAuth';
 import { useDashboard } from '@/context/useDashboard';
 import { WidgetData } from '@/types';
 
-vi.mock('../../context/useAuth');
-vi.mock('../../context/useDashboard');
+vi.mock('@/context/useAuth');
+vi.mock('@/context/useDashboard');
 
 vi.mock('lucide-react', () => ({
   Building2: () => <span data-testid="building-icon" />,

--- a/components/common/WidgetBuildingSelector.test.tsx
+++ b/components/common/WidgetBuildingSelector.test.tsx
@@ -1,0 +1,133 @@
+import { describe, it, expect, vi, beforeEach, Mock } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { WidgetBuildingSelector } from './WidgetBuildingSelector';
+import { useAuth } from '@/context/useAuth';
+import { useDashboard } from '@/context/useDashboard';
+import { WidgetData } from '@/types';
+
+vi.mock('../../context/useAuth');
+vi.mock('../../context/useDashboard');
+
+vi.mock('lucide-react', () => ({
+  Building2: () => <span data-testid="building-icon" />,
+}));
+
+const makeWidget = (overrides: Partial<WidgetData> = {}): WidgetData =>
+  ({
+    id: 'w1',
+    type: 'schedule',
+    x: 0,
+    y: 0,
+    w: 300,
+    h: 200,
+    z: 1,
+    flipped: false,
+    config: {},
+    ...overrides,
+  }) as WidgetData;
+
+const mockUpdateWidget = vi.fn();
+
+describe('WidgetBuildingSelector', () => {
+  beforeEach(() => {
+    mockUpdateWidget.mockClear();
+    (useDashboard as unknown as Mock).mockReturnValue({
+      updateWidget: mockUpdateWidget,
+    });
+  });
+
+  it('returns null when user has fewer than 2 buildings', () => {
+    (useAuth as unknown as Mock).mockReturnValue({
+      selectedBuildings: ['schumann-elementary'],
+    });
+
+    const { container } = render(
+      <WidgetBuildingSelector widget={makeWidget()} />
+    );
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('returns null when selectedBuildings is empty', () => {
+    (useAuth as unknown as Mock).mockReturnValue({
+      selectedBuildings: [],
+    });
+
+    const { container } = render(
+      <WidgetBuildingSelector widget={makeWidget()} />
+    );
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('renders building options when user has 2+ buildings', () => {
+    (useAuth as unknown as Mock).mockReturnValue({
+      selectedBuildings: ['schumann-elementary', 'orono-intermediate-school'],
+    });
+
+    render(<WidgetBuildingSelector widget={makeWidget()} />);
+
+    expect(screen.getByText('Schumann Elementary')).toBeTruthy();
+    expect(screen.getByText('Orono Intermediate')).toBeTruthy();
+    expect(screen.getByRole('radiogroup')).toBeTruthy();
+    expect(screen.getAllByRole('radio')).toHaveLength(2);
+  });
+
+  it('marks the effective building as checked', () => {
+    (useAuth as unknown as Mock).mockReturnValue({
+      selectedBuildings: ['schumann-elementary', 'orono-intermediate-school'],
+    });
+
+    render(
+      <WidgetBuildingSelector
+        widget={makeWidget({ buildingId: 'orono-intermediate-school' })}
+      />
+    );
+
+    const radios = screen.getAllByRole('radio');
+    const schumann = radios.find((r) =>
+      r.textContent?.includes('Schumann Elementary')
+    );
+    const orono = radios.find((r) =>
+      r.textContent?.includes('Orono Intermediate')
+    );
+
+    expect(schumann?.getAttribute('aria-checked')).toBe('false');
+    expect(orono?.getAttribute('aria-checked')).toBe('true');
+  });
+
+  it('calls updateWidget with the selected buildingId on click', () => {
+    (useAuth as unknown as Mock).mockReturnValue({
+      selectedBuildings: ['schumann-elementary', 'orono-intermediate-school'],
+    });
+
+    render(<WidgetBuildingSelector widget={makeWidget()} />);
+
+    const oronoText = screen.getByText('Orono Intermediate');
+    const oronoButton = oronoText.closest('button');
+    expect(oronoButton).toBeTruthy();
+    fireEvent.click(oronoButton as HTMLElement);
+
+    expect(mockUpdateWidget).toHaveBeenCalledWith('w1', {
+      buildingId: 'orono-intermediate-school',
+    });
+  });
+
+  it('falls back to selectedBuildings[0] when widget.buildingId is no longer valid', () => {
+    (useAuth as unknown as Mock).mockReturnValue({
+      selectedBuildings: ['schumann-elementary', 'orono-intermediate-school'],
+    });
+
+    // Widget has a buildingId that's not in the user's selection
+    render(
+      <WidgetBuildingSelector
+        widget={makeWidget({ buildingId: 'orono-high-school' })}
+      />
+    );
+
+    const radios = screen.getAllByRole('radio');
+    const schumann = radios.find((r) =>
+      r.textContent?.includes('Schumann Elementary')
+    );
+    // Falls back to first selected building
+    expect(schumann?.getAttribute('aria-checked')).toBe('true');
+  });
+});

--- a/components/common/WidgetBuildingSelector.tsx
+++ b/components/common/WidgetBuildingSelector.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Building2 } from 'lucide-react';
 import { useAuth } from '@/context/useAuth';
 import { useDashboard } from '@/context/useDashboard';
+import { useWidgetBuildingId } from '@/hooks/useWidgetBuildingId';
 import { BUILDINGS } from '@/config/buildings';
 import { WidgetData } from '@/types';
 
@@ -19,6 +20,7 @@ export const WidgetBuildingSelector: React.FC<WidgetBuildingSelectorProps> = ({
 }) => {
   const { selectedBuildings = [] } = useAuth();
   const { updateWidget } = useDashboard();
+  const effectiveBuildingId = useWidgetBuildingId(widget);
 
   // Only show when user works across multiple buildings
   if (selectedBuildings.length < 2) return null;
@@ -27,13 +29,6 @@ export const WidgetBuildingSelector: React.FC<WidgetBuildingSelectorProps> = ({
   const userBuildings = BUILDINGS.filter((b) =>
     selectedBuildings.includes(b.id)
   );
-
-  // Constrain to the user's current selection — if the widget's saved
-  // buildingId is no longer among their selected buildings, fall back.
-  const effectiveBuildingId =
-    widget.buildingId && selectedBuildings.includes(widget.buildingId)
-      ? widget.buildingId
-      : selectedBuildings[0];
 
   return (
     <div className="mb-3">

--- a/components/common/WidgetBuildingSelector.tsx
+++ b/components/common/WidgetBuildingSelector.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { Building2 } from 'lucide-react';
+import { useAuth } from '@/context/useAuth';
+import { useDashboard } from '@/context/useDashboard';
+import { BUILDINGS } from '@/config/buildings';
+import { WidgetData } from '@/types';
+
+interface WidgetBuildingSelectorProps {
+  widget: WidgetData;
+}
+
+/**
+ * Compact building selector for widget settings panels.
+ * Only renders when the user has 2+ buildings selected.
+ * Persists the choice to `widget.buildingId` via updateWidget.
+ */
+export const WidgetBuildingSelector: React.FC<WidgetBuildingSelectorProps> = ({
+  widget,
+}) => {
+  const { selectedBuildings } = useAuth();
+  const { updateWidget } = useDashboard();
+
+  // Only show when user works across multiple buildings
+  if (selectedBuildings.length < 2) return null;
+
+  // Resolve the buildings the user has selected
+  const userBuildings = BUILDINGS.filter((b) =>
+    selectedBuildings.includes(b.id)
+  );
+
+  const effectiveBuildingId = widget.buildingId ?? selectedBuildings[0];
+
+  return (
+    <div className="mb-3">
+      <label className="flex items-center gap-1.5 text-xs font-semibold text-slate-400 mb-1.5">
+        <Building2 className="w-3.5 h-3.5" />
+        Building
+      </label>
+      <div className="flex gap-1.5 flex-wrap">
+        {userBuildings.map((building) => {
+          const isActive = building.id === effectiveBuildingId;
+          return (
+            <button
+              key={building.id}
+              type="button"
+              onClick={() =>
+                updateWidget(widget.id, { buildingId: building.id })
+              }
+              className={`px-2.5 py-1 text-xs font-bold rounded-lg border transition-colors ${
+                isActive
+                  ? 'bg-brand-blue-primary text-white border-brand-blue-primary shadow-sm'
+                  : 'bg-slate-800 text-slate-400 border-slate-600 hover:border-slate-500 hover:text-slate-300'
+              }`}
+            >
+              {building.name}
+              <span
+                className={`ml-1.5 text-xxs font-black uppercase tracking-wider ${
+                  isActive ? 'text-white/60' : 'text-slate-500'
+                }`}
+              >
+                {building.gradeLabel}
+              </span>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+};

--- a/components/common/WidgetBuildingSelector.tsx
+++ b/components/common/WidgetBuildingSelector.tsx
@@ -17,7 +17,7 @@ interface WidgetBuildingSelectorProps {
 export const WidgetBuildingSelector: React.FC<WidgetBuildingSelectorProps> = ({
   widget,
 }) => {
-  const { selectedBuildings } = useAuth();
+  const { selectedBuildings = [] } = useAuth();
   const { updateWidget } = useDashboard();
 
   // Only show when user works across multiple buildings
@@ -28,21 +28,35 @@ export const WidgetBuildingSelector: React.FC<WidgetBuildingSelectorProps> = ({
     selectedBuildings.includes(b.id)
   );
 
-  const effectiveBuildingId = widget.buildingId ?? selectedBuildings[0];
+  // Constrain to the user's current selection — if the widget's saved
+  // buildingId is no longer among their selected buildings, fall back.
+  const effectiveBuildingId =
+    widget.buildingId && selectedBuildings.includes(widget.buildingId)
+      ? widget.buildingId
+      : selectedBuildings[0];
 
   return (
     <div className="mb-3">
-      <label className="flex items-center gap-1.5 text-xs font-semibold text-slate-400 mb-1.5">
-        <Building2 className="w-3.5 h-3.5" />
+      <div
+        className="flex items-center gap-1.5 text-xs font-semibold text-slate-400 mb-1.5"
+        id={`building-label-${widget.id}`}
+      >
+        <Building2 className="w-3.5 h-3.5" aria-hidden="true" />
         Building
-      </label>
-      <div className="flex gap-1.5 flex-wrap">
+      </div>
+      <div
+        className="flex gap-1.5 flex-wrap"
+        role="radiogroup"
+        aria-labelledby={`building-label-${widget.id}`}
+      >
         {userBuildings.map((building) => {
           const isActive = building.id === effectiveBuildingId;
           return (
             <button
               key={building.id}
               type="button"
+              role="radio"
+              aria-checked={isActive}
               onClick={() =>
                 updateWidget(widget.id, { buildingId: building.id })
               }

--- a/components/widgets/Calendar/Settings.tsx
+++ b/components/widgets/Calendar/Settings.tsx
@@ -13,6 +13,7 @@ import {
 import { useFeaturePermissions } from '@/hooks/useFeaturePermissions';
 import { useAuth } from '@/context/useAuth';
 import { useGoogleCalendar } from '@/hooks/useGoogleCalendar';
+import { WidgetBuildingSelector } from '@/components/common/WidgetBuildingSelector';
 import { Toggle } from '@/components/common/Toggle';
 import { extractCalendarId } from './constants';
 import { TypographySettings } from '@/components/common/TypographySettings';
@@ -51,7 +52,7 @@ export const CalendarSettings: React.FC<{ widget: WidgetData }> = ({
     });
   }, [subscribeToPermission]);
 
-  const buildingId = selectedBuildings?.[0];
+  const buildingId = widget.buildingId ?? selectedBuildings?.[0];
   const lastSyncAt = buildingId
     ? globalConfig?.buildingDefaults?.[buildingId]?.lastProxySync
     : null;
@@ -98,6 +99,7 @@ export const CalendarSettings: React.FC<{ widget: WidgetData }> = ({
 
   return (
     <div className="space-y-6">
+      <WidgetBuildingSelector widget={widget} />
       {/* 1. Display Options */}
       <section>
         <label className="text-xxs text-slate-400 uppercase tracking-widest mb-3 block flex items-center gap-2">

--- a/components/widgets/Calendar/Settings.tsx
+++ b/components/widgets/Calendar/Settings.tsx
@@ -12,6 +12,7 @@ import {
 } from 'lucide-react';
 import { useFeaturePermissions } from '@/hooks/useFeaturePermissions';
 import { useAuth } from '@/context/useAuth';
+import { useWidgetBuildingId } from '@/hooks/useWidgetBuildingId';
 import { useGoogleCalendar } from '@/hooks/useGoogleCalendar';
 import { WidgetBuildingSelector } from '@/components/common/WidgetBuildingSelector';
 import { Toggle } from '@/components/common/Toggle';
@@ -24,7 +25,8 @@ export const CalendarSettings: React.FC<{ widget: WidgetData }> = ({
   widget,
 }) => {
   const { updateWidget } = useDashboard();
-  const { signInWithGoogle, selectedBuildings } = useAuth();
+  const { signInWithGoogle } = useAuth();
+  const buildingId = useWidgetBuildingId(widget);
   const { isConnected } = useGoogleCalendar();
   const { subscribeToPermission } = useFeaturePermissions();
   const config = widget.config as CalendarConfig;
@@ -52,7 +54,6 @@ export const CalendarSettings: React.FC<{ widget: WidgetData }> = ({
     });
   }, [subscribeToPermission]);
 
-  const buildingId = widget.buildingId ?? selectedBuildings?.[0];
   const lastSyncAt = buildingId
     ? globalConfig?.buildingDefaults?.[buildingId]?.lastProxySync
     : null;

--- a/components/widgets/Calendar/Widget.tsx
+++ b/components/widgets/Calendar/Widget.tsx
@@ -109,7 +109,7 @@ export const CalendarWidget: React.FC<{ widget: WidgetData }> = ({
 
   // Combined events for display (Local + Building Synced + Personal)
   const displayEvents = useMemo(() => {
-    const buildingId = selectedBuildings?.[0];
+    const buildingId = widget.buildingId ?? selectedBuildings?.[0];
     const buildingDefaults = buildingId
       ? globalConfig?.buildingDefaults?.[buildingId]
       : null;
@@ -166,6 +166,7 @@ export const CalendarWidget: React.FC<{ widget: WidgetData }> = ({
     localEvents,
     globalConfig,
     isBuildingSyncEnabled,
+    widget.buildingId,
     selectedBuildings,
     config.daysVisible,
     personalEvents,

--- a/components/widgets/Calendar/Widget.tsx
+++ b/components/widgets/Calendar/Widget.tsx
@@ -11,7 +11,7 @@ import { Calendar as CalendarIcon, Ban, Timer } from 'lucide-react';
 import { ScaledEmptyState } from '@/components/common/ScaledEmptyState';
 import { WidgetLayout } from '../WidgetLayout';
 import { useFeaturePermissions } from '@/hooks/useFeaturePermissions';
-import { useAuth } from '@/context/useAuth';
+import { useWidgetBuildingId } from '@/hooks/useWidgetBuildingId';
 import { useGoogleCalendar } from '@/hooks/useGoogleCalendar';
 import { GAP_STYLE } from './constants';
 import { hexToRgba } from '@/utils/styles';
@@ -39,7 +39,7 @@ export const CalendarWidget: React.FC<{ widget: WidgetData }> = ({
   widget,
 }) => {
   const { activeDashboard, addWidget } = useDashboard();
-  const { selectedBuildings } = useAuth();
+  const buildingId = useWidgetBuildingId(widget);
   const { subscribeToPermission } = useFeaturePermissions();
   const { calendarService, isConnected } = useGoogleCalendar();
   const globalStyle = activeDashboard?.globalStyle ?? DEFAULT_GLOBAL_STYLE;
@@ -109,7 +109,6 @@ export const CalendarWidget: React.FC<{ widget: WidgetData }> = ({
 
   // Combined events for display (Local + Building Synced + Personal)
   const displayEvents = useMemo(() => {
-    const buildingId = widget.buildingId ?? selectedBuildings?.[0];
     const buildingDefaults = buildingId
       ? globalConfig?.buildingDefaults?.[buildingId]
       : null;
@@ -166,8 +165,7 @@ export const CalendarWidget: React.FC<{ widget: WidgetData }> = ({
     localEvents,
     globalConfig,
     isBuildingSyncEnabled,
-    widget.buildingId,
-    selectedBuildings,
+    buildingId,
     config.daysVisible,
     personalEvents,
     isConnected,

--- a/components/widgets/Classes/ClassesWidget.tsx
+++ b/components/widgets/Classes/ClassesWidget.tsx
@@ -18,9 +18,9 @@ interface Props {
   widget: WidgetData;
 }
 
-const ClassesWidget: React.FC<Props> = ({ widget: _widget }) => {
+const ClassesWidget: React.FC<Props> = ({ widget }) => {
   const { featurePermissions } = useAuth();
-  const buildingId = useWidgetBuildingId(_widget);
+  const buildingId = useWidgetBuildingId(widget);
   const {
     rosters,
     addRoster,
@@ -96,7 +96,7 @@ const ClassesWidget: React.FC<Props> = ({ widget: _widget }) => {
   };
 
   const editingRoster = rosters.find((r) => r.id === editingId) ?? null;
-  const config = _widget.config as ClassesConfig;
+  const config = widget.config as ClassesConfig;
 
   // Calculate effective classLinkEnabled flag
   const effectiveClassLinkEnabled = (() => {

--- a/components/widgets/Classes/ClassesWidget.tsx
+++ b/components/widgets/Classes/ClassesWidget.tsx
@@ -8,6 +8,7 @@ import {
 } from '@/types';
 import { useDashboard } from '@/context/useDashboard';
 import { useAuth } from '@/context/useAuth';
+import { useWidgetBuildingId } from '@/hooks/useWidgetBuildingId';
 import { Plus, Trash2, Star, Edit2, RefreshCw } from 'lucide-react';
 import { classLinkService } from '@/utils/classlinkService';
 import { WidgetLayout } from '@/components/widgets/WidgetLayout';
@@ -18,7 +19,8 @@ interface Props {
 }
 
 const ClassesWidget: React.FC<Props> = ({ widget: _widget }) => {
-  const { featurePermissions, selectedBuildings } = useAuth();
+  const { featurePermissions } = useAuth();
+  const buildingId = useWidgetBuildingId(_widget);
   const {
     rosters,
     addRoster,
@@ -99,8 +101,7 @@ const ClassesWidget: React.FC<Props> = ({ widget: _widget }) => {
   // Calculate effective classLinkEnabled flag
   const effectiveClassLinkEnabled = (() => {
     // 1. Check building-specific admin defaults first
-    if (_widget.buildingId || selectedBuildings.length > 0) {
-      const buildingId = _widget.buildingId ?? selectedBuildings[0];
+    if (buildingId) {
       const classesPerm = featurePermissions.find(
         (p) => p.widgetType === 'classes'
       );

--- a/components/widgets/Classes/ClassesWidget.tsx
+++ b/components/widgets/Classes/ClassesWidget.tsx
@@ -99,8 +99,8 @@ const ClassesWidget: React.FC<Props> = ({ widget: _widget }) => {
   // Calculate effective classLinkEnabled flag
   const effectiveClassLinkEnabled = (() => {
     // 1. Check building-specific admin defaults first
-    if (selectedBuildings.length > 0) {
-      const buildingId = selectedBuildings[0];
+    if (_widget.buildingId || selectedBuildings.length > 0) {
+      const buildingId = _widget.buildingId ?? selectedBuildings[0];
       const classesPerm = featurePermissions.find(
         (p) => p.widgetType === 'classes'
       );

--- a/components/widgets/Embed/Settings.tsx
+++ b/components/widgets/Embed/Settings.tsx
@@ -16,6 +16,7 @@ import { httpsCallable } from 'firebase/functions';
 import { functions } from '@/config/firebase';
 import { ensureProtocol } from '@/utils/urlHelpers';
 import { useEmbedConfig } from './hooks/useEmbedConfig';
+import { useWidgetBuildingId } from '@/hooks/useWidgetBuildingId';
 import { WidgetBuildingSelector } from '@/components/common/WidgetBuildingSelector';
 
 interface CompatibilityResult {
@@ -27,6 +28,7 @@ interface CompatibilityResult {
 
 export const EmbedSettings: React.FC<{ widget: WidgetData }> = ({ widget }) => {
   const { updateWidget } = useDashboard();
+  const buildingId = useWidgetBuildingId(widget);
   const config = widget.config as EmbedConfig;
   const {
     mode = 'url',
@@ -41,7 +43,7 @@ export const EmbedSettings: React.FC<{ widget: WidgetData }> = ({ widget }) => {
     'idle' | 'success' | 'blocked' | 'error'
   >('idle');
   const [errorMsg, setErrorMsg] = useState('');
-  const { config: globalConfig, isLoading } = useEmbedConfig(widget.buildingId);
+  const { config: globalConfig, isLoading } = useEmbedConfig(buildingId);
 
   const isActuallyEmbeddable = React.useMemo(() => {
     if (isEmbeddable) return true;

--- a/components/widgets/Embed/Settings.tsx
+++ b/components/widgets/Embed/Settings.tsx
@@ -16,6 +16,7 @@ import { httpsCallable } from 'firebase/functions';
 import { functions } from '@/config/firebase';
 import { ensureProtocol } from '@/utils/urlHelpers';
 import { useEmbedConfig } from './hooks/useEmbedConfig';
+import { WidgetBuildingSelector } from '@/components/common/WidgetBuildingSelector';
 
 interface CompatibilityResult {
   isEmbeddable: boolean;
@@ -40,7 +41,7 @@ export const EmbedSettings: React.FC<{ widget: WidgetData }> = ({ widget }) => {
     'idle' | 'success' | 'blocked' | 'error'
   >('idle');
   const [errorMsg, setErrorMsg] = useState('');
-  const { config: globalConfig, isLoading } = useEmbedConfig();
+  const { config: globalConfig, isLoading } = useEmbedConfig(widget.buildingId);
 
   const isActuallyEmbeddable = React.useMemo(() => {
     if (isEmbeddable) return true;
@@ -141,6 +142,7 @@ export const EmbedSettings: React.FC<{ widget: WidgetData }> = ({ widget }) => {
 
   return (
     <div className="space-y-4">
+      <WidgetBuildingSelector widget={widget} />
       {/* Mode Toggle */}
       {!hideUrlField && (
         <div className="flex bg-slate-100 p-1 rounded-xl">

--- a/components/widgets/Embed/Widget.tsx
+++ b/components/widgets/Embed/Widget.tsx
@@ -23,6 +23,7 @@ import { generateMiniAppCode } from '@/utils/ai';
 import { useEmbedConfig } from './hooks/useEmbedConfig';
 import { useGoogleDrive } from '@/hooks/useGoogleDrive';
 import { useAuth } from '@/context/useAuth';
+import { useWidgetBuildingId } from '@/hooks/useWidgetBuildingId';
 
 import { applyAutoplay } from './applyAutoplay';
 
@@ -31,7 +32,8 @@ const NEW_WIDGET_SPACING = 20;
 export const EmbedWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
   const { addWidget, addToast, updateWidget } = useDashboard();
   const { canAccessFeature } = useAuth();
-  const { config: globalConfig } = useEmbedConfig(widget.buildingId);
+  const buildingId = useWidgetBuildingId(widget);
+  const { config: globalConfig } = useEmbedConfig(buildingId);
   const { getDriveFileTextContent } = useGoogleDrive();
   const [isGeneratingApp, setIsGeneratingApp] = useState(false);
   const config = widget.config as EmbedConfig;

--- a/components/widgets/Embed/Widget.tsx
+++ b/components/widgets/Embed/Widget.tsx
@@ -31,7 +31,7 @@ const NEW_WIDGET_SPACING = 20;
 export const EmbedWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
   const { addWidget, addToast, updateWidget } = useDashboard();
   const { canAccessFeature } = useAuth();
-  const { config: globalConfig } = useEmbedConfig();
+  const { config: globalConfig } = useEmbedConfig(widget.buildingId);
   const { getDriveFileTextContent } = useGoogleDrive();
   const [isGeneratingApp, setIsGeneratingApp] = useState(false);
   const config = widget.config as EmbedConfig;

--- a/components/widgets/Embed/hooks/useEmbedConfig.ts
+++ b/components/widgets/Embed/hooks/useEmbedConfig.ts
@@ -10,7 +10,11 @@ export const useEmbedConfig = (widgetBuildingId?: string) => {
   const [config, setConfig] = useState<BuildingEmbedDefaults | null>(null);
 
   useEffect(() => {
-    const buildingId = widgetBuildingId ?? selectedBuildings?.[0];
+    const validatedBuildingId =
+      widgetBuildingId && selectedBuildings?.includes(widgetBuildingId)
+        ? widgetBuildingId
+        : undefined;
+    const buildingId = validatedBuildingId ?? selectedBuildings?.[0];
 
     const unsubscribe = subscribeToPermission('embed', (perm) => {
       // When no building is selected, use neutral defaults (no restrictions)

--- a/components/widgets/Embed/hooks/useEmbedConfig.ts
+++ b/components/widgets/Embed/hooks/useEmbedConfig.ts
@@ -3,14 +3,14 @@ import { useAuth } from '@/context/useAuth';
 import { useFeaturePermissions } from '@/hooks/useFeaturePermissions';
 import { EmbedGlobalConfig, BuildingEmbedDefaults } from '@/types';
 
-export const useEmbedConfig = () => {
+export const useEmbedConfig = (widgetBuildingId?: string) => {
   const { selectedBuildings } = useAuth();
   const { subscribeToPermission, loading: permsLoading } =
     useFeaturePermissions();
   const [config, setConfig] = useState<BuildingEmbedDefaults | null>(null);
 
   useEffect(() => {
-    const buildingId = selectedBuildings?.[0];
+    const buildingId = widgetBuildingId ?? selectedBuildings?.[0];
 
     const unsubscribe = subscribeToPermission('embed', (perm) => {
       // When no building is selected, use neutral defaults (no restrictions)
@@ -43,7 +43,7 @@ export const useEmbedConfig = () => {
     });
 
     return () => unsubscribe();
-  }, [selectedBuildings, subscribeToPermission]);
+  }, [widgetBuildingId, selectedBuildings, subscribeToPermission]);
 
   return { config, isLoading: permsLoading || !config };
 };

--- a/components/widgets/ExpectationsWidget/Settings.tsx
+++ b/components/widgets/ExpectationsWidget/Settings.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { useDashboard } from '@/context/useDashboard';
 import { WidgetData, ExpectationsConfig } from '@/types';
+import { WidgetBuildingSelector } from '@/components/common/WidgetBuildingSelector';
 
 export const ExpectationsSettings: React.FC<{ widget: WidgetData }> = ({
   widget,
@@ -10,6 +11,7 @@ export const ExpectationsSettings: React.FC<{ widget: WidgetData }> = ({
 
   return (
     <div className="space-y-6">
+      <WidgetBuildingSelector widget={widget} />
       <div>
         <label className="text-xxs text-slate-400 uppercase tracking-widest mb-3 block flex items-center gap-2">
           Nexus Connections

--- a/components/widgets/ExpectationsWidget/Widget.tsx
+++ b/components/widgets/ExpectationsWidget/Widget.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { useDashboard } from '@/context/useDashboard';
 import { useAuth } from '@/context/useAuth';
+import { useWidgetBuildingId } from '@/hooks/useWidgetBuildingId';
 import {
   WidgetData,
   ExpectationsConfig,
@@ -28,7 +29,8 @@ export const ExpectationsWidget: React.FC<{ widget: WidgetData }> = ({
   widget,
 }) => {
   const { updateWidget, addWidget } = useDashboard();
-  const { featurePermissions, selectedBuildings } = useAuth();
+  const { featurePermissions } = useAuth();
+  const buildingId = useWidgetBuildingId(widget);
   const config = widget.config as ExpectationsConfig;
   const { voiceLevel = null, workMode = null, interactionMode = null } = config;
 
@@ -41,9 +43,8 @@ export const ExpectationsWidget: React.FC<{ widget: WidgetData }> = ({
     | undefined;
 
   // Get current building's config
-  const primaryBuildingId = widget.buildingId ?? selectedBuildings?.[0];
-  const buildingConfig = primaryBuildingId
-    ? globalConfig?.buildings?.[primaryBuildingId]
+  const buildingConfig = buildingId
+    ? globalConfig?.buildings?.[buildingId]
     : undefined;
 
   // Compute active options based on overrides and category toggles

--- a/components/widgets/ExpectationsWidget/Widget.tsx
+++ b/components/widgets/ExpectationsWidget/Widget.tsx
@@ -41,7 +41,7 @@ export const ExpectationsWidget: React.FC<{ widget: WidgetData }> = ({
     | undefined;
 
   // Get current building's config
-  const primaryBuildingId = selectedBuildings?.[0];
+  const primaryBuildingId = widget.buildingId ?? selectedBuildings?.[0];
   const buildingConfig = primaryBuildingId
     ? globalConfig?.buildings?.[primaryBuildingId]
     : undefined;

--- a/components/widgets/GraphicOrganizer/Settings.tsx
+++ b/components/widgets/GraphicOrganizer/Settings.tsx
@@ -6,6 +6,7 @@ import {
 } from '@/types';
 import { useDashboard } from '@/context/useDashboard';
 import { useAuth } from '@/context/useAuth';
+import { useWidgetBuildingId } from '@/hooks/useWidgetBuildingId';
 import { SurfaceColorSettings } from '@/components/common/SurfaceColorSettings';
 import { TypographySettings } from '@/components/common/TypographySettings';
 import { WidgetBuildingSelector } from '@/components/common/WidgetBuildingSelector';
@@ -14,10 +15,9 @@ export const GraphicOrganizerSettings: React.FC<{ widget: WidgetData }> = ({
   widget,
 }) => {
   const { updateWidget } = useDashboard();
-  const { selectedBuildings, featurePermissions } = useAuth();
+  const { featurePermissions } = useAuth();
+  const buildingId = useWidgetBuildingId(widget) ?? 'global';
   const config = widget.config as GraphicOrganizerConfig;
-
-  const buildingId = widget.buildingId ?? selectedBuildings[0] ?? 'global';
   const featureObj = featurePermissions?.find(
     (p) => p.widgetType === 'graphic-organizer'
   );

--- a/components/widgets/GraphicOrganizer/Settings.tsx
+++ b/components/widgets/GraphicOrganizer/Settings.tsx
@@ -8,6 +8,7 @@ import { useDashboard } from '@/context/useDashboard';
 import { useAuth } from '@/context/useAuth';
 import { SurfaceColorSettings } from '@/components/common/SurfaceColorSettings';
 import { TypographySettings } from '@/components/common/TypographySettings';
+import { WidgetBuildingSelector } from '@/components/common/WidgetBuildingSelector';
 
 export const GraphicOrganizerSettings: React.FC<{ widget: WidgetData }> = ({
   widget,
@@ -16,7 +17,7 @@ export const GraphicOrganizerSettings: React.FC<{ widget: WidgetData }> = ({
   const { selectedBuildings, featurePermissions } = useAuth();
   const config = widget.config as GraphicOrganizerConfig;
 
-  const buildingId = selectedBuildings[0] ?? 'global';
+  const buildingId = widget.buildingId ?? selectedBuildings[0] ?? 'global';
   const featureObj = featurePermissions?.find(
     (p) => p.widgetType === 'graphic-organizer'
   );
@@ -41,6 +42,7 @@ export const GraphicOrganizerSettings: React.FC<{ widget: WidgetData }> = ({
 
   return (
     <div className="p-4 space-y-4 text-slate-800">
+      <WidgetBuildingSelector widget={widget} />
       <div className="space-y-2">
         <label className="block text-sm font-medium">Template Type</label>
         <select

--- a/components/widgets/GraphicOrganizer/Widget.tsx
+++ b/components/widgets/GraphicOrganizer/Widget.tsx
@@ -84,7 +84,7 @@ export const GraphicOrganizerWidget: React.FC<{ widget: WidgetData }> = ({
   const { selectedBuildings, featurePermissions } = useAuth();
   const config = widget.config as GraphicOrganizerConfig;
 
-  const buildingId = selectedBuildings[0] ?? 'global';
+  const buildingId = widget.buildingId ?? selectedBuildings[0] ?? 'global';
   const featureObj = featurePermissions?.find(
     (p) => p.widgetType === 'graphic-organizer'
   );

--- a/components/widgets/GraphicOrganizer/Widget.tsx
+++ b/components/widgets/GraphicOrganizer/Widget.tsx
@@ -7,6 +7,7 @@ import {
 import { WidgetLayout } from '@/components/widgets/WidgetLayout';
 import { useDashboard } from '@/context/useDashboard';
 import { useAuth } from '@/context/useAuth';
+import { useWidgetBuildingId } from '@/hooks/useWidgetBuildingId';
 import { getFontClass, hexToRgba } from '@/utils/styles';
 
 const EditableNode: React.FC<{
@@ -81,10 +82,9 @@ export const GraphicOrganizerWidget: React.FC<{ widget: WidgetData }> = ({
   widget,
 }) => {
   const { updateWidget, activeDashboard } = useDashboard();
-  const { selectedBuildings, featurePermissions } = useAuth();
+  const { featurePermissions } = useAuth();
+  const buildingId = useWidgetBuildingId(widget) ?? 'global';
   const config = widget.config as GraphicOrganizerConfig;
-
-  const buildingId = widget.buildingId ?? selectedBuildings[0] ?? 'global';
   const featureObj = featurePermissions?.find(
     (p) => p.widgetType === 'graphic-organizer'
   );

--- a/components/widgets/MaterialsWidget/Settings.tsx
+++ b/components/widgets/MaterialsWidget/Settings.tsx
@@ -6,13 +6,15 @@ import { SettingsLabel } from '@/components/common/SettingsLabel';
 import { Type, Palette, Edit3 } from 'lucide-react';
 import { WIDGET_PALETTE } from '@/config/colors';
 import { useAuth } from '@/context/useAuth';
+import { useWidgetBuildingId } from '@/hooks/useWidgetBuildingId';
 import { WidgetBuildingSelector } from '@/components/common/WidgetBuildingSelector';
 
 export const MaterialsSettings: React.FC<{ widget: WidgetData }> = ({
   widget,
 }) => {
   const { updateWidget } = useDashboard();
-  const { featurePermissions, selectedBuildings } = useAuth();
+  const { featurePermissions } = useAuth();
+  const buildingId = useWidgetBuildingId(widget);
   const config = widget.config as MaterialsConfig;
   const {
     selectedItems = [],
@@ -25,9 +27,8 @@ export const MaterialsSettings: React.FC<{ widget: WidgetData }> = ({
     (item) => item.widgetType === 'materials'
   );
   const materialsConfig = permission?.config as Partial<MaterialsGlobalConfig>;
-  const effectiveBuildingId = widget.buildingId ?? selectedBuildings[0];
-  const buildingAssignedIds = effectiveBuildingId
-    ? materialsConfig.buildingDefaults?.[effectiveBuildingId]?.selectedItems
+  const buildingAssignedIds = buildingId
+    ? materialsConfig.buildingDefaults?.[buildingId]?.selectedItems
     : undefined;
   const materialsCatalog = React.useMemo(() => {
     const fullCatalog = getMaterialsCatalog(materialsConfig);

--- a/components/widgets/MaterialsWidget/Settings.tsx
+++ b/components/widgets/MaterialsWidget/Settings.tsx
@@ -6,6 +6,7 @@ import { SettingsLabel } from '@/components/common/SettingsLabel';
 import { Type, Palette, Edit3 } from 'lucide-react';
 import { WIDGET_PALETTE } from '@/config/colors';
 import { useAuth } from '@/context/useAuth';
+import { WidgetBuildingSelector } from '@/components/common/WidgetBuildingSelector';
 
 export const MaterialsSettings: React.FC<{ widget: WidgetData }> = ({
   widget,
@@ -24,10 +25,10 @@ export const MaterialsSettings: React.FC<{ widget: WidgetData }> = ({
     (item) => item.widgetType === 'materials'
   );
   const materialsConfig = permission?.config as Partial<MaterialsGlobalConfig>;
-  const buildingAssignedIds =
-    selectedBuildings.length > 0
-      ? materialsConfig.buildingDefaults?.[selectedBuildings[0]]?.selectedItems
-      : undefined;
+  const effectiveBuildingId = widget.buildingId ?? selectedBuildings[0];
+  const buildingAssignedIds = effectiveBuildingId
+    ? materialsConfig.buildingDefaults?.[effectiveBuildingId]?.selectedItems
+    : undefined;
   const materialsCatalog = React.useMemo(() => {
     const fullCatalog = getMaterialsCatalog(materialsConfig);
     if (!buildingAssignedIds || buildingAssignedIds.length === 0) {
@@ -91,6 +92,7 @@ export const MaterialsSettings: React.FC<{ widget: WidgetData }> = ({
 
   return (
     <div className="flex flex-col gap-6 p-1">
+      <WidgetBuildingSelector widget={widget} />
       {/* Title Settings */}
       <div className="space-y-4">
         <div>

--- a/components/widgets/QRWidget/Settings.tsx
+++ b/components/widgets/QRWidget/Settings.tsx
@@ -3,6 +3,7 @@ import { useDashboard } from '@/context/useDashboard';
 import { WidgetData, QRConfig } from '@/types';
 import { Link, AlertCircle } from 'lucide-react';
 import { Toggle } from '@/components/common/Toggle';
+import { WidgetBuildingSelector } from '@/components/common/WidgetBuildingSelector';
 
 export const QRSettings: React.FC<{ widget: WidgetData }> = ({ widget }) => {
   const { updateWidget, activeDashboard } = useDashboard();
@@ -12,6 +13,7 @@ export const QRSettings: React.FC<{ widget: WidgetData }> = ({ widget }) => {
 
   return (
     <div className="space-y-6">
+      <WidgetBuildingSelector widget={widget} />
       <div className="space-y-2">
         <label className="text-xs text-slate-500 uppercase font-bold tracking-wider">
           Destination URL

--- a/components/widgets/QRWidget/Widget.tsx
+++ b/components/widgets/QRWidget/Widget.tsx
@@ -42,7 +42,7 @@ export const QRWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
   const globalConfig = permission?.config as unknown as
     | QRGlobalConfig
     | undefined;
-  const buildingId = selectedBuildings?.[0];
+  const buildingId = widget.buildingId ?? selectedBuildings?.[0];
   const defaults =
     globalConfig && buildingId
       ? globalConfig.buildingDefaults?.[buildingId]

--- a/components/widgets/QRWidget/Widget.tsx
+++ b/components/widgets/QRWidget/Widget.tsx
@@ -10,7 +10,7 @@ import {
 import { Link } from 'lucide-react';
 import { WidgetLayout } from '../WidgetLayout';
 import { useFeaturePermissions } from '@/hooks/useFeaturePermissions';
-import { useAuth } from '@/context/useAuth';
+import { useWidgetBuildingId } from '@/hooks/useWidgetBuildingId';
 
 const stripHtml = (html: string) => {
   if (typeof DOMParser === 'undefined') {
@@ -31,7 +31,7 @@ const stripHtml = (html: string) => {
 export const QRWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
   const { activeDashboard, updateWidget } = useDashboard();
   const { subscribeToPermission } = useFeaturePermissions();
-  const { selectedBuildings } = useAuth();
+  const buildingId = useWidgetBuildingId(widget);
   const config = widget.config as QRConfig;
   const [permission, setPermission] = useState<FeaturePermission | null>(null);
 
@@ -42,7 +42,6 @@ export const QRWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
   const globalConfig = permission?.config as unknown as
     | QRGlobalConfig
     | undefined;
-  const buildingId = widget.buildingId ?? selectedBuildings?.[0];
   const defaults =
     globalConfig && buildingId
       ? globalConfig.buildingDefaults?.[buildingId]

--- a/components/widgets/Schedule/ScheduleWidget.tsx
+++ b/components/widgets/Schedule/ScheduleWidget.tsx
@@ -19,7 +19,7 @@ import { Clock } from 'lucide-react';
 import { ScaledEmptyState } from '@/components/common/ScaledEmptyState';
 import { WidgetLayout } from '@/components/widgets/WidgetLayout';
 import { useFeaturePermissions } from '@/hooks/useFeaturePermissions';
-import { useAuth } from '@/context/useAuth';
+import { useWidgetBuildingId } from '@/hooks/useWidgetBuildingId';
 import {
   getTodayStr,
   resolveActiveSchedule,
@@ -35,7 +35,7 @@ export const ScheduleWidget: React.FC<{ widget: WidgetData }> = ({
   widget,
 }) => {
   const { updateWidget, activeDashboard, addWidget } = useDashboard();
-  const { selectedBuildings } = useAuth();
+  const buildingId = useWidgetBuildingId(widget);
   const { subscribeToPermission } = useFeaturePermissions();
   const globalStyle = activeDashboard?.globalStyle ?? DEFAULT_GLOBAL_STYLE;
   const config = widget.config as ScheduleConfig;
@@ -115,11 +115,9 @@ export const ScheduleWidget: React.FC<{ widget: WidgetData }> = ({
           isBuildingSyncEnabled &&
           schedules.length === 0 &&
           legacyItems.length === 0 &&
-          (widget.buildingId ?? selectedBuildings?.[0]) &&
-          config.lastSyncedBuildingId !==
-            (widget.buildingId ?? selectedBuildings[0])
+          buildingId &&
+          config.lastSyncedBuildingId !== buildingId
         ) {
-          const buildingId = widget.buildingId ?? selectedBuildings[0];
           const defaults = gConfig.buildingDefaults?.[buildingId];
           if (defaults && defaults.items?.length > 0) {
             updateWidget(widget.id, {
@@ -138,8 +136,7 @@ export const ScheduleWidget: React.FC<{ widget: WidgetData }> = ({
     isBuildingSyncEnabled,
     schedules.length,
     legacyItems.length,
-    widget.buildingId,
-    selectedBuildings,
+    buildingId,
     config,
     widget.id,
     updateWidget,

--- a/components/widgets/Schedule/ScheduleWidget.tsx
+++ b/components/widgets/Schedule/ScheduleWidget.tsx
@@ -115,10 +115,11 @@ export const ScheduleWidget: React.FC<{ widget: WidgetData }> = ({
           isBuildingSyncEnabled &&
           schedules.length === 0 &&
           legacyItems.length === 0 &&
-          selectedBuildings?.[0] &&
-          config.lastSyncedBuildingId !== selectedBuildings[0]
+          (widget.buildingId ?? selectedBuildings?.[0]) &&
+          config.lastSyncedBuildingId !==
+            (widget.buildingId ?? selectedBuildings[0])
         ) {
-          const buildingId = selectedBuildings[0];
+          const buildingId = widget.buildingId ?? selectedBuildings[0];
           const defaults = gConfig.buildingDefaults?.[buildingId];
           if (defaults && defaults.items?.length > 0) {
             updateWidget(widget.id, {
@@ -137,6 +138,7 @@ export const ScheduleWidget: React.FC<{ widget: WidgetData }> = ({
     isBuildingSyncEnabled,
     schedules.length,
     legacyItems.length,
+    widget.buildingId,
     selectedBuildings,
     config,
     widget.id,

--- a/components/widgets/Schedule/Settings.tsx
+++ b/components/widgets/Schedule/Settings.tsx
@@ -1,8 +1,8 @@
 import React, { useState, useMemo, useEffect, useCallback } from 'react';
 import { useDashboard } from '@/context/useDashboard';
-import { useAuth } from '@/context/useAuth';
 import { useDialog } from '@/context/useDialog';
 import { useFeaturePermissions } from '@/hooks/useFeaturePermissions';
+import { useWidgetBuildingId } from '@/hooks/useWidgetBuildingId';
 import {
   WidgetData,
   ScheduleConfig,
@@ -79,9 +79,9 @@ export const ScheduleSettings: React.FC<{ widget: WidgetData }> = ({
   widget,
 }) => {
   const { updateWidget, addToast, activeDashboard } = useDashboard();
-  const { selectedBuildings } = useAuth();
   const { showConfirm } = useDialog();
   const { subscribeToPermission } = useFeaturePermissions();
+  const buildingId = useWidgetBuildingId(widget);
   const config = widget.config as ScheduleConfig;
 
   const [adminPermission, setAdminPermission] =
@@ -91,16 +91,14 @@ export const ScheduleSettings: React.FC<{ widget: WidgetData }> = ({
     return subscribeToPermission('schedule', setAdminPermission);
   }, [subscribeToPermission]);
 
-  const effectiveBuildingId = widget.buildingId ?? selectedBuildings?.[0];
-
   const buildingSchedules = useMemo((): DailySchedule[] => {
-    if (!effectiveBuildingId) return [];
+    if (!buildingId) return [];
     const adminConfig = adminPermission?.config as
       | ScheduleGlobalConfig
       | undefined;
-    const raw = adminConfig?.buildingDefaults?.[effectiveBuildingId];
+    const raw = adminConfig?.buildingDefaults?.[buildingId];
     return raw?.schedules ?? [];
-  }, [effectiveBuildingId, adminPermission]);
+  }, [buildingId, adminPermission]);
 
   const schedules = useMemo(() => {
     const list = [...(config.schedules ?? [])];

--- a/components/widgets/Schedule/Settings.tsx
+++ b/components/widgets/Schedule/Settings.tsx
@@ -43,6 +43,7 @@ import { Toggle } from '@/components/common/Toggle';
 import { TypographySettings } from '@/components/common/TypographySettings';
 import { SurfaceColorSettings } from '@/components/common/SurfaceColorSettings';
 import { TextSizePresetSettings } from '@/components/common/TextSizePresetSettings';
+import { WidgetBuildingSelector } from '@/components/common/WidgetBuildingSelector';
 import { getTodayStr } from './utils';
 import { SortableScheduleItem } from './components/SortableScheduleItem';
 
@@ -90,15 +91,16 @@ export const ScheduleSettings: React.FC<{ widget: WidgetData }> = ({
     return subscribeToPermission('schedule', setAdminPermission);
   }, [subscribeToPermission]);
 
+  const effectiveBuildingId = widget.buildingId ?? selectedBuildings?.[0];
+
   const buildingSchedules = useMemo((): DailySchedule[] => {
-    if (!selectedBuildings?.length) return [];
-    const buildingId = selectedBuildings[0];
+    if (!effectiveBuildingId) return [];
     const adminConfig = adminPermission?.config as
       | ScheduleGlobalConfig
       | undefined;
-    const raw = adminConfig?.buildingDefaults?.[buildingId];
+    const raw = adminConfig?.buildingDefaults?.[effectiveBuildingId];
     return raw?.schedules ?? [];
-  }, [selectedBuildings, adminPermission]);
+  }, [effectiveBuildingId, adminPermission]);
 
   const schedules = useMemo(() => {
     const list = [...(config.schedules ?? [])];
@@ -395,6 +397,7 @@ export const ScheduleSettings: React.FC<{ widget: WidgetData }> = ({
 
   return (
     <div className="space-y-4">
+      <WidgetBuildingSelector widget={widget} />
       {/* ── Schedule picker ─────────────────────────────────────── */}
       {schedules.length === 0 ? (
         <div className="text-center py-8 border-2 border-dashed border-slate-200 rounded-xl text-slate-400 text-xs">

--- a/components/widgets/SoundboardWidget/Settings.tsx
+++ b/components/widgets/SoundboardWidget/Settings.tsx
@@ -2,6 +2,7 @@ import React, { useMemo } from 'react';
 import { WidgetData, SoundboardConfig, SoundboardGlobalConfig } from '@/types';
 import { useAuth } from '@/context/useAuth';
 import { useDashboard } from '@/context/useDashboard';
+import { useWidgetBuildingId } from '@/hooks/useWidgetBuildingId';
 import { Toggle } from '@/components/common/Toggle';
 import { getAvailableSoundboardSounds } from '@/utils/soundboardConfig';
 import { WidgetBuildingSelector } from '@/components/common/WidgetBuildingSelector';
@@ -13,10 +14,8 @@ export const SoundboardSettings: React.FC<{ widget: WidgetData }> = ({
   const config = widget.config as SoundboardConfig;
   const { selectedSoundIds = [] } = config;
 
-  const { featurePermissions, selectedBuildings } = useAuth();
-  const buildingId =
-    widget.buildingId ??
-    (selectedBuildings.length > 0 ? selectedBuildings[0] : null);
+  const { featurePermissions } = useAuth();
+  const buildingId = useWidgetBuildingId(widget) ?? null;
 
   const globalConfig = useMemo(() => {
     const perm = featurePermissions.find((p) => p.widgetType === 'soundboard');

--- a/components/widgets/SoundboardWidget/Settings.tsx
+++ b/components/widgets/SoundboardWidget/Settings.tsx
@@ -4,6 +4,7 @@ import { useAuth } from '@/context/useAuth';
 import { useDashboard } from '@/context/useDashboard';
 import { Toggle } from '@/components/common/Toggle';
 import { getAvailableSoundboardSounds } from '@/utils/soundboardConfig';
+import { WidgetBuildingSelector } from '@/components/common/WidgetBuildingSelector';
 
 export const SoundboardSettings: React.FC<{ widget: WidgetData }> = ({
   widget,
@@ -13,7 +14,9 @@ export const SoundboardSettings: React.FC<{ widget: WidgetData }> = ({
   const { selectedSoundIds = [] } = config;
 
   const { featurePermissions, selectedBuildings } = useAuth();
-  const buildingId = selectedBuildings.length > 0 ? selectedBuildings[0] : null;
+  const buildingId =
+    widget.buildingId ??
+    (selectedBuildings.length > 0 ? selectedBuildings[0] : null);
 
   const globalConfig = useMemo(() => {
     const perm = featurePermissions.find((p) => p.widgetType === 'soundboard');
@@ -39,6 +42,7 @@ export const SoundboardSettings: React.FC<{ widget: WidgetData }> = ({
 
   return (
     <div className="p-4 space-y-6">
+      <WidgetBuildingSelector widget={widget} />
       <div>
         <label className="block text-xs font-bold text-slate-600 mb-4 uppercase tracking-wider">
           Available Sounds

--- a/components/widgets/SoundboardWidget/Widget.tsx
+++ b/components/widgets/SoundboardWidget/Widget.tsx
@@ -212,7 +212,9 @@ export const SoundboardWidget: React.FC<{ widget: WidgetData }> = ({
     useAuth();
   const { updateWidget, selectedWidgetId } = useDashboard();
   const isFocused = selectedWidgetId === widget.id;
-  const buildingId = selectedBuildings.length > 0 ? selectedBuildings[0] : null;
+  const buildingId =
+    widget.buildingId ??
+    (selectedBuildings.length > 0 ? selectedBuildings[0] : null);
 
   const globalConfig = useMemo(() => {
     const perm = featurePermissions.find((p) => p.widgetType === 'soundboard');

--- a/components/widgets/SoundboardWidget/Widget.tsx
+++ b/components/widgets/SoundboardWidget/Widget.tsx
@@ -7,6 +7,7 @@ import {
 } from '@/types';
 import { useAuth } from '@/context/useAuth';
 import { useDashboard } from '@/context/useDashboard';
+import { useWidgetBuildingId } from '@/hooks/useWidgetBuildingId';
 import { WidgetLayout } from '@/components/widgets/WidgetLayout';
 import { ScaledEmptyState } from '@/components/common/ScaledEmptyState';
 import { Volume2, Music } from 'lucide-react';
@@ -208,13 +209,10 @@ export const SoundboardWidget: React.FC<{ widget: WidgetData }> = ({
   const config = widget.config as SoundboardConfig;
   const { selectedSoundIds = [], activeSoundIds } = config;
 
-  const { featurePermissions, selectedBuildings, googleAccessToken } =
-    useAuth();
+  const { featurePermissions, googleAccessToken } = useAuth();
   const { updateWidget, selectedWidgetId } = useDashboard();
   const isFocused = selectedWidgetId === widget.id;
-  const buildingId =
-    widget.buildingId ??
-    (selectedBuildings.length > 0 ? selectedBuildings[0] : null);
+  const buildingId = useWidgetBuildingId(widget) ?? null;
 
   const globalConfig = useMemo(() => {
     const perm = featurePermissions.find((p) => p.widgetType === 'soundboard');

--- a/components/widgets/SpecialistSchedule/Settings.tsx
+++ b/components/widgets/SpecialistSchedule/Settings.tsx
@@ -22,6 +22,7 @@ import { Button } from '@/components/common/Button';
 import { TypographySettings } from '@/components/common/TypographySettings';
 import { SurfaceColorSettings } from '@/components/common/SurfaceColorSettings';
 import { TextSizePresetSettings } from '@/components/common/TextSizePresetSettings';
+import { WidgetBuildingSelector } from '@/components/common/WidgetBuildingSelector';
 
 const RECURRING_DEFAULTS = [
   { task: '🍴 Lunch', startTime: '11:00', endTime: '11:30' },
@@ -54,7 +55,8 @@ export const SpecialistScheduleSettings: React.FC<{ widget: WidgetData }> = ({
     return perm?.config as SpecialistScheduleGlobalConfig | undefined;
   }, [featurePermissions]);
 
-  const buildingId = selectedBuildings[0] ?? 'schumann-elementary';
+  const buildingId =
+    widget.buildingId ?? selectedBuildings[0] ?? 'schumann-elementary';
   const buildingConfig = globalConfig?.buildingDefaults?.[buildingId] ?? {
     cycleLength: 6,
     dayLabel: 'Day',
@@ -216,6 +218,7 @@ export const SpecialistScheduleSettings: React.FC<{ widget: WidgetData }> = ({
 
   return (
     <div className="space-y-4">
+      <WidgetBuildingSelector widget={widget} />
       {/* Tabs */}
       <div className="flex border-b border-slate-200">
         <button

--- a/components/widgets/SpecialistSchedule/Settings.tsx
+++ b/components/widgets/SpecialistSchedule/Settings.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useMemo } from 'react';
 import { useDashboard } from '@/context/useDashboard';
 import { useAuth } from '@/context/useAuth';
+import { useWidgetBuildingId } from '@/hooks/useWidgetBuildingId';
 import {
   WidgetData,
   SpecialistScheduleConfig,
@@ -44,7 +45,8 @@ export const SpecialistScheduleSettings: React.FC<{ widget: WidgetData }> = ({
   widget,
 }) => {
   const { updateWidget } = useDashboard();
-  const { featurePermissions, selectedBuildings } = useAuth();
+  const { featurePermissions } = useAuth();
+  const buildingId = useWidgetBuildingId(widget) ?? 'schumann-elementary';
   const config = widget.config as SpecialistScheduleConfig;
 
   // Fetch Global Configuration to know current cycleLength and dayLabel
@@ -54,9 +56,6 @@ export const SpecialistScheduleSettings: React.FC<{ widget: WidgetData }> = ({
     );
     return perm?.config as SpecialistScheduleGlobalConfig | undefined;
   }, [featurePermissions]);
-
-  const buildingId =
-    widget.buildingId ?? selectedBuildings[0] ?? 'schumann-elementary';
   const buildingConfig = globalConfig?.buildingDefaults?.[buildingId] ?? {
     cycleLength: 6,
     dayLabel: 'Day',

--- a/components/widgets/SpecialistSchedule/SpecialistScheduleWidget.tsx
+++ b/components/widgets/SpecialistSchedule/SpecialistScheduleWidget.tsx
@@ -1,6 +1,7 @@
 import React, { useMemo, useState, useEffect } from 'react';
 import { useDashboard } from '@/context/useDashboard';
 import { useAuth } from '@/context/useAuth';
+import { useWidgetBuildingId } from '@/hooks/useWidgetBuildingId';
 import {
   WidgetData,
   SpecialistScheduleConfig,
@@ -46,7 +47,8 @@ export const SpecialistScheduleWidget: React.FC<{ widget: WidgetData }> = ({
   widget,
 }) => {
   const { activeDashboard } = useDashboard();
-  const { featurePermissions, selectedBuildings } = useAuth();
+  const { featurePermissions } = useAuth();
+  const buildingId = useWidgetBuildingId(widget) ?? 'schumann-elementary';
   const config = widget.config as SpecialistScheduleConfig;
 
   // Fetch Global Configuration
@@ -56,9 +58,6 @@ export const SpecialistScheduleWidget: React.FC<{ widget: WidgetData }> = ({
     );
     return perm?.config as SpecialistScheduleGlobalConfig | undefined;
   }, [featurePermissions]);
-
-  const buildingId =
-    widget.buildingId ?? selectedBuildings[0] ?? 'schumann-elementary';
   const buildingConfig = globalConfig?.buildingDefaults?.[buildingId] ?? {
     cycleLength: 6,
     startDate: toDateStr(new Date()),

--- a/components/widgets/SpecialistSchedule/SpecialistScheduleWidget.tsx
+++ b/components/widgets/SpecialistSchedule/SpecialistScheduleWidget.tsx
@@ -57,7 +57,8 @@ export const SpecialistScheduleWidget: React.FC<{ widget: WidgetData }> = ({
     return perm?.config as SpecialistScheduleGlobalConfig | undefined;
   }, [featurePermissions]);
 
-  const buildingId = selectedBuildings[0] ?? 'schumann-elementary';
+  const buildingId =
+    widget.buildingId ?? selectedBuildings[0] ?? 'schumann-elementary';
   const buildingConfig = globalConfig?.buildingDefaults?.[buildingId] ?? {
     cycleLength: 6,
     startDate: toDateStr(new Date()),

--- a/context/DashboardContext.tsx
+++ b/context/DashboardContext.tsx
@@ -746,6 +746,7 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
                 'fontFamily',
                 'baseTextSize',
                 'transparency',
+                'buildingId',
               ] as const;
 
               const remoteControlEnabled =

--- a/hooks/useWidgetBuildingId.ts
+++ b/hooks/useWidgetBuildingId.ts
@@ -1,0 +1,15 @@
+import { useAuth } from '@/context/useAuth';
+import { WidgetData } from '@/types';
+
+/**
+ * Returns the effective building ID for a widget.
+ * Prefers `widget.buildingId` if it's still in the user's selected buildings,
+ * otherwise falls back to the user's primary building.
+ */
+export function useWidgetBuildingId(widget: WidgetData): string | undefined {
+  const { selectedBuildings = [] } = useAuth();
+  if (widget.buildingId && selectedBuildings.includes(widget.buildingId)) {
+    return widget.buildingId;
+  }
+  return selectedBuildings[0];
+}

--- a/types.ts
+++ b/types.ts
@@ -2353,6 +2353,8 @@ export interface WidgetData {
   isLocked?: boolean; // When true: widget cannot be moved, resized, or deleted by end-users
   transparency?: number;
   annotation?: DrawingConfig;
+  /** Override which building's admin defaults this widget uses (falls back to user's primary building) */
+  buildingId?: string;
   config: WidgetConfig;
 
   // Universal style properties


### PR DESCRIPTION
## Summary
This PR enables users who manage multiple buildings to select which building's admin defaults each widget should use, rather than always defaulting to their primary building. A new `WidgetBuildingSelector` component provides a compact UI for this selection in widget settings panels.

## Key Changes

- **New Component**: `WidgetBuildingSelector` - A reusable building selector that appears in widget settings when users have 2+ buildings selected. Only renders for multi-building users to keep the UI clean.

- **Type Update**: Added `buildingId?: string` field to `WidgetData` interface to persist the per-widget building selection.

- **Consistent Building Resolution**: Updated all widget implementations to use the pattern `widget.buildingId ?? selectedBuildings[0]` to respect the widget-specific building choice while falling back to the user's primary building.

- **Affected Widgets**: Integrated the building selector into settings panels for:
  - Schedule
  - Materials
  - Soundboard
  - Specialist Schedule
  - Calendar
  - Embed
  - Graphic Organizer
  - Expectations
  - QR

- **Hook Updates**: Modified `useEmbedConfig` to accept an optional `widgetBuildingId` parameter for building-specific configuration loading.

## Implementation Details

- The selector only renders when `selectedBuildings.length >= 2`, keeping the UI uncluttered for single-building users
- Building selection is persisted via `updateWidget()` to the widget's `buildingId` property
- All widget logic (both Settings and Widget components) now respects the widget-specific building ID with proper fallback behavior
- The implementation maintains backward compatibility—widgets without an explicit `buildingId` continue to use the user's primary building

https://claude.ai/code/session_01PgdDvigAbj1WVsJ7zBtjdF