### PR TITLE
Add pin position feature to prevent widget movement and resizing

### DIFF
--- a/components/common/DraggableWindow.tsx
+++ b/components/common/DraggableWindow.tsx
@@ -323,8 +323,9 @@ export const DraggableWindow: React.FC<DraggableWindowProps> = ({
   };
 
   const handleMaximizeToggle = useCallback(() => {
-    if (isLocked || isPinned) return;
+    if (isLocked) return;
     const newMaximized = !isMaximized;
+    if (isPinned && newMaximized) return;
     updateWidget(widget.id, { maximized: newMaximized, flipped: false });
     if (newMaximized) {
       bringToFront(widget.id);
@@ -475,10 +476,12 @@ export const DraggableWindow: React.FC<DraggableWindowProps> = ({
           handleMaximizeToggle();
           break;
         case 'r': // Reset size
+          if (isLocked || isPinned) break;
           e.preventDefault();
           resetWidgetSize(widget.id);
           break;
         case 'p': // Pin/Unpin position
+          if (isLocked) break;
           e.preventDefault();
           updateWidget(widget.id, { isPinned: !isPinned });
           break;
@@ -1609,9 +1612,11 @@ export const DraggableWindow: React.FC<DraggableWindowProps> = ({
               <div className="flex items-center gap-1">
                 {!isLocked && (
                   <IconButton
-                    onClick={() =>
-                      updateWidget(widget.id, { isPinned: !isPinned })
-                    }
+                    onClick={() => {
+                      const nextPinned = !isPinned;
+                      if (nextPinned) setShowSnapMenu(false);
+                      updateWidget(widget.id, { isPinned: nextPinned });
+                    }}
                     icon={<Pin className="w-3.5 h-3.5" />}
                     label={
                       isPinned
@@ -1706,9 +1711,8 @@ export const DraggableWindow: React.FC<DraggableWindowProps> = ({
                     size="sm"
                     variant="glass"
                     active={showSnapMenu}
-                    disabled={isPinned}
+                    disabled={isPinned || isLocked}
                   />
-
                   {showSnapMenu &&
                     typeof document !== 'undefined' &&
                     createPortal(
@@ -1873,7 +1877,7 @@ export const DraggableWindow: React.FC<DraggableWindowProps> = ({
                   }
                   size="sm"
                   variant="glass"
-                  disabled={isPinned}
+                  disabled={isLocked || (isPinned && !isMaximized)}
                 />
                 <IconButton
                   onClick={() =>

--- a/components/common/DraggableWindow.tsx
+++ b/components/common/DraggableWindow.tsx
@@ -24,6 +24,7 @@ import {
   LayoutTemplate,
   LayoutGrid,
   Lock,
+  Pin,
 } from 'lucide-react';
 import {
   WidgetData,
@@ -311,6 +312,7 @@ export const DraggableWindow: React.FC<DraggableWindowProps> = ({
 
   const isMaximized = widget.maximized ?? false;
   const isLocked = widget.isLocked ?? false;
+  const isPinned = widget.isPinned ?? false;
   const canScreenshot = !SCREENSHOT_BLACKLIST.includes(widget.type);
 
   const handlePointerDown = (e: React.PointerEvent) => {
@@ -321,17 +323,17 @@ export const DraggableWindow: React.FC<DraggableWindowProps> = ({
   };
 
   const handleMaximizeToggle = useCallback(() => {
-    if (isLocked) return;
+    if (isLocked || isPinned) return;
     const newMaximized = !isMaximized;
     updateWidget(widget.id, { maximized: newMaximized, flipped: false });
     if (newMaximized) {
       bringToFront(widget.id);
     }
-  }, [isLocked, isMaximized, widget.id, updateWidget, bringToFront]);
+  }, [isLocked, isPinned, isMaximized, widget.id, updateWidget, bringToFront]);
 
   const handleSnapToZone = useCallback(
     (zone: SnapZone) => {
-      if (isLocked) return;
+      if (isLocked || isPinned) return;
       const { x, y, w, h } = calculateSnapBounds(zone);
 
       updateWidget(widget.id, {
@@ -346,7 +348,7 @@ export const DraggableWindow: React.FC<DraggableWindowProps> = ({
       setShowSnapMenu(false);
       handleCloseTools();
     },
-    [isLocked, widget.id, updateWidget, handleCloseTools]
+    [isLocked, isPinned, widget.id, updateWidget, handleCloseTools]
   );
 
   const getCellFromPointer = (
@@ -476,6 +478,10 @@ export const DraggableWindow: React.FC<DraggableWindowProps> = ({
           e.preventDefault();
           resetWidgetSize(widget.id);
           break;
+        case 'p': // Pin/Unpin position
+          e.preventDefault();
+          updateWidget(widget.id, { isPinned: !isPinned });
+          break;
       }
     }
   };
@@ -489,7 +495,7 @@ export const DraggableWindow: React.FC<DraggableWindowProps> = ({
 
   const handleDragStart = (e: React.PointerEvent) => {
     if (isMaximized) return;
-    if (isLocked) return;
+    if (isLocked || isPinned) return;
 
     // Don't drag if clicking interactive elements or resize handle
     const target = e.target as HTMLElement;
@@ -677,7 +683,7 @@ export const DraggableWindow: React.FC<DraggableWindowProps> = ({
 
   const handleResizeStart = (e: React.PointerEvent, direction: string) => {
     if (isMaximized) return;
-    if (isLocked) return;
+    if (isLocked || isPinned) return;
     e.stopPropagation();
     e.preventDefault();
 
@@ -1378,7 +1384,7 @@ export const DraggableWindow: React.FC<DraggableWindowProps> = ({
         </div>
 
         {/* Resize Handles (Corners Only) */}
-        {!isLocked && (
+        {!isLocked && !isPinned && (
           <>
             <div
               onPointerDown={(e) => handleResizeStart(e, 'nw')}
@@ -1408,7 +1414,7 @@ export const DraggableWindow: React.FC<DraggableWindowProps> = ({
       {/* Invisible edge grab zones — extend INVISIBLE_EDGE_PAD px outside the widget's visual
           bounds so users can reliably grab and drag widgets whose content fills edge-to-edge.
           No visual appearance; only the pointer hit area is expanded. */}
-      {!isMaximized && !isAnnotating && (
+      {!isMaximized && !isAnnotating && !isPinned && !isLocked && (
         <>
           {/* Top */}
           <div
@@ -1601,6 +1607,25 @@ export const DraggableWindow: React.FC<DraggableWindowProps> = ({
               <div className="h-4 w-px bg-slate-300/50 mx-1" />
 
               <div className="flex items-center gap-1">
+                {!isLocked && (
+                  <IconButton
+                    onClick={() =>
+                      updateWidget(widget.id, { isPinned: !isPinned })
+                    }
+                    icon={<Pin className="w-3.5 h-3.5" />}
+                    label={
+                      isPinned
+                        ? `${t('widgetWindow.unpin')} (Alt+P)`
+                        : `${t('widgetWindow.pin')} (Alt+P)`
+                    }
+                    size="sm"
+                    variant="glass"
+                    active={isPinned}
+                    className={
+                      isPinned ? '!bg-amber-500/20 !text-amber-600' : ''
+                    }
+                  />
+                )}
                 {headerActions && (
                   <div className="flex items-center text-slate-700">
                     {headerActions}
@@ -1681,6 +1706,7 @@ export const DraggableWindow: React.FC<DraggableWindowProps> = ({
                     size="sm"
                     variant="glass"
                     active={showSnapMenu}
+                    disabled={isPinned}
                   />
 
                   {showSnapMenu &&
@@ -1847,6 +1873,7 @@ export const DraggableWindow: React.FC<DraggableWindowProps> = ({
                   }
                   size="sm"
                   variant="glass"
+                  disabled={isPinned}
                 />
                 <IconButton
                   onClick={() =>

--- a/components/common/DraggableWindow.tsx
+++ b/components/common/DraggableWindow.tsx
@@ -483,7 +483,9 @@ export const DraggableWindow: React.FC<DraggableWindowProps> = ({
         case 'p': // Pin/Unpin position
           if (isLocked) break;
           e.preventDefault();
+          if (!isPinned) setShowSnapMenu(false);
           updateWidget(widget.id, { isPinned: !isPinned });
+          handleCloseTools();
           break;
       }
     }

--- a/locales/de.json
+++ b/locales/de.json
@@ -103,6 +103,8 @@
     "undo": "Rückgängig",
     "clearAll": "Alles löschen",
     "done": "Fertig",
+    "pin": "Position fixieren",
+    "unpin": "Position lösen",
     "snapLayout": "Layout anpassen",
     "chooseLayout": "Layout wählen",
     "snapTo": "Anpassen an",

--- a/locales/en.json
+++ b/locales/en.json
@@ -121,6 +121,8 @@
     "undo": "Undo",
     "clearAll": "Clear All",
     "done": "Done",
+    "pin": "Pin Position",
+    "unpin": "Unpin Position",
     "snapLayout": "Snap Layout",
     "chooseLayout": "Choose Layout",
     "snapTo": "Snap to",

--- a/locales/es.json
+++ b/locales/es.json
@@ -112,6 +112,8 @@
     "undo": "Deshacer",
     "clearAll": "Borrar Todo",
     "done": "Listo",
+    "pin": "Fijar posición",
+    "unpin": "Soltar posición",
     "snapLayout": "Ajustar Diseño",
     "chooseLayout": "Elegir Diseño",
     "snapTo": "Ajustar a",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -103,6 +103,8 @@
     "undo": "Annuler",
     "clearAll": "Tout effacer",
     "done": "Terminé",
+    "pin": "Épingler la position",
+    "unpin": "Désépingler la position",
     "snapLayout": "Ajuster la mise en page",
     "chooseLayout": "Choisir la mise en page",
     "snapTo": "Ajuster à",

--- a/tests/components/common/DraggableWindow.test.tsx
+++ b/tests/components/common/DraggableWindow.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { DraggableWindow } from '@/components/common/DraggableWindow';
 import { WidgetData, GlobalStyle } from '@/types';
 import {
@@ -203,5 +203,113 @@ describe('DraggableWindow (Tests folder)', () => {
     // The GlassCard root container should have the background class
     const widgetCard = content.closest('.widget') as HTMLElement;
     expect(widgetCard.className).toContain('bg-emerald-50');
+  });
+
+  describe('Pin feature', () => {
+    const renderWithToolbar = (
+      widgetOverrides: Partial<WidgetData> = {},
+      contextOverrides: Partial<typeof mockContext> = {}
+    ) => {
+      const widget = { ...mockWidget, ...widgetOverrides };
+      return render(
+        <DashboardContext.Provider
+          value={
+            {
+              ...mockContext,
+              selectedWidgetId: widget.id,
+              ...contextOverrides,
+            } as unknown as DashboardContextValue
+          }
+        >
+          <DraggableWindow
+            widget={widget}
+            settings={<div>Settings</div>}
+            title="Test Widget"
+            globalStyle={mockGlobalStyle}
+          >
+            <div data-testid="widget-content">Content</div>
+          </DraggableWindow>
+        </DashboardContext.Provider>
+      );
+    };
+
+    it('renders pin button in toolbar when widget is selected', () => {
+      renderWithToolbar();
+
+      const pinButton = screen.getByLabelText(/pin position/i);
+      expect(pinButton).toBeInTheDocument();
+    });
+
+    it('shows unpin label when widget is pinned', () => {
+      renderWithToolbar({ isPinned: true });
+
+      const unpinButton = screen.getByLabelText(/unpin position/i);
+      expect(unpinButton).toBeInTheDocument();
+    });
+
+    it('calls updateWidget with isPinned toggle when pin button is clicked', () => {
+      renderWithToolbar();
+
+      const pinButton = screen.getByLabelText(/pin position/i);
+      fireEvent.click(pinButton);
+
+      expect(mockContext.updateWidget).toHaveBeenCalledWith('test-widget', {
+        isPinned: true,
+      });
+    });
+
+    it('calls updateWidget to unpin when pinned widget pin button is clicked', () => {
+      renderWithToolbar({ isPinned: true });
+
+      const unpinButton = screen.getByLabelText(/unpin position/i);
+      fireEvent.click(unpinButton);
+
+      expect(mockContext.updateWidget).toHaveBeenCalledWith('test-widget', {
+        isPinned: false,
+      });
+    });
+
+    it('applies active styling when pinned', () => {
+      renderWithToolbar({ isPinned: true });
+
+      const unpinButton = screen.getByLabelText(/unpin position/i);
+      expect(unpinButton.className).toContain('bg-amber-500/20');
+      expect(unpinButton.className).toContain('text-amber-600');
+    });
+
+    it('hides pin button when widget is admin-locked', () => {
+      renderWithToolbar({ isLocked: true });
+
+      const pinButton = screen.queryByLabelText(/pin position/i);
+      expect(pinButton).not.toBeInTheDocument();
+    });
+
+    it('hides resize handles when pinned', () => {
+      renderWithToolbar({ isPinned: true });
+
+      const resizeHandles = document.querySelectorAll('.resize-handle');
+      expect(resizeHandles).toHaveLength(0);
+    });
+
+    it('shows resize handles when not pinned', () => {
+      renderWithToolbar();
+
+      const resizeHandles = document.querySelectorAll('.resize-handle');
+      expect(resizeHandles.length).toBeGreaterThan(0);
+    });
+
+    it('disables snap layout button when pinned', () => {
+      renderWithToolbar({ isPinned: true });
+
+      const snapButton = screen.getByLabelText(/snap layout/i);
+      expect(snapButton).toBeDisabled();
+    });
+
+    it('does not disable close button when pinned', () => {
+      renderWithToolbar({ isPinned: true });
+
+      const closeButton = screen.getByLabelText(/close/i);
+      expect(closeButton).not.toBeDisabled();
+    });
   });
 });

--- a/types.ts
+++ b/types.ts
@@ -2351,6 +2351,7 @@ export interface WidgetData {
   customTitle?: string | null;
   isLive?: boolean;
   isLocked?: boolean; // When true: widget cannot be moved, resized, or deleted by end-users
+  isPinned?: boolean; // User-pinned: drag, resize, maximize, snap disabled
   transparency?: number;
   annotation?: DrawingConfig;
   config: WidgetConfig;


### PR DESCRIPTION
## Summary
This PR introduces a new "pin position" feature that allows users to lock a widget's position, size, and state while still allowing interaction with its content. This complements the existing "lock" feature by providing a user-controlled way to prevent accidental modifications to widget layout.

## Key Changes
- **New `isPinned` property**: Added to `WidgetData` interface to track pinned state per widget
- **Pin/Unpin button**: Added to widget header toolbar with visual indicator (amber highlight when active)
- **Keyboard shortcut**: Implemented Alt+P to toggle pin state
- **Restricted operations when pinned**: Disabled dragging, resizing, maximizing, and snap-to-zone functionality
- **UI updates**: 
  - Resize handles hidden when pinned
  - Edge grab zones disabled when pinned
  - Snap menu and maximize buttons disabled when pinned
  - Pin button only visible when widget is not locked
- **Internationalization**: Added translations for "pin" and "unpin" labels in English, German, Spanish, and French

## Implementation Details
- The pin state is checked alongside the existing lock state in all movement/resize handlers
- Pinned widgets can still be interacted with (clicked, scrolled, etc.) but cannot be repositioned or resized
- The feature integrates seamlessly with existing widget state management via `updateWidget`
- Visual feedback is provided through button styling and disabled states on related controls

https://claude.ai/code/session_01ToBSkEqkLVBcTSnkTe9cw2