### PR TITLE
Preserve instance and annotation fields during widget merge

### DIFF
--- a/context/DashboardContext.tsx
+++ b/context/DashboardContext.tsx
@@ -765,6 +765,7 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
                     saved,
                     keepLocalConfig: false,
                     keepLocalLayout: false,
+                    keepLocalStyle: false,
                     keepLocalInstance: false,
                     keepLocalAnnotation: false,
                     isDeletedLocally,
@@ -785,9 +786,13 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
                 const instanceChangedLocally = INSTANCE_FIELDS.some(
                   (f) => lw[f] !== saved[f]
                 );
+                // Fast-path: skip expensive JSON.stringify when both are
+                // absent or the same reference. Only deep-compare when both
+                // are present and structurally different.
                 const annotationChangedLocally =
+                  lw.annotation !== saved.annotation &&
                   JSON.stringify(lw.annotation) !==
-                  JSON.stringify(saved.annotation);
+                    JSON.stringify(saved.annotation);
 
                 return {
                   sw,

--- a/context/DashboardContext.tsx
+++ b/context/DashboardContext.tsx
@@ -786,13 +786,19 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
                 const instanceChangedLocally = INSTANCE_FIELDS.some(
                   (f) => lw[f] !== saved[f]
                 );
-                // Fast-path: skip expensive JSON.stringify when both are
-                // absent or the same reference. Only deep-compare when both
-                // are present and structurally different.
-                const annotationChangedLocally =
-                  lw.annotation !== saved.annotation &&
-                  JSON.stringify(lw.annotation) !==
-                    JSON.stringify(saved.annotation);
+                // Fast-path: skip JSON.stringify when both values are the
+                // same reference (including both undefined). When references
+                // differ, short-circuit on paths array length before falling
+                // back to deep comparison to avoid serializing large paths.
+                const annotationChangedLocally = (() => {
+                  const la = lw.annotation;
+                  const sa = saved.annotation;
+                  if (la === sa) return false;
+                  if (!la || !sa) return true;
+                  if (la.mode !== sa.mode) return true;
+                  if (la.paths.length !== sa.paths.length) return true;
+                  return JSON.stringify(la) !== JSON.stringify(sa);
+                })();
 
                 return {
                   sw,

--- a/context/DashboardContext.tsx
+++ b/context/DashboardContext.tsx
@@ -743,6 +743,8 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
                 'buildingId',
               ] as const;
 
+              const INSTANCE_FIELDS = ['customTitle', 'isPinned'] as const;
+
               const remoteControlEnabled =
                 accountRemoteControlEnabledRef.current;
 
@@ -763,6 +765,8 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
                     saved,
                     keepLocalConfig: false,
                     keepLocalLayout: false,
+                    keepLocalInstance: false,
+                    keepLocalAnnotation: false,
                     isDeletedLocally,
                   };
                 }
@@ -778,6 +782,12 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
                 const styleChangedLocally = STYLE_FIELDS.some(
                   (f) => lw[f] !== saved[f]
                 );
+                const instanceChangedLocally = INSTANCE_FIELDS.some(
+                  (f) => lw[f] !== saved[f]
+                );
+                const annotationChangedLocally =
+                  JSON.stringify(lw.annotation) !==
+                  JSON.stringify(saved.annotation);
 
                 return {
                   sw,
@@ -790,6 +800,10 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
                   keepLocalLayout:
                     layoutChangedLocally || !remoteControlEnabled,
                   keepLocalStyle: styleChangedLocally || !remoteControlEnabled,
+                  keepLocalInstance:
+                    instanceChangedLocally || !remoteControlEnabled,
+                  keepLocalAnnotation:
+                    annotationChangedLocally || !remoteControlEnabled,
                 };
               });
 
@@ -802,6 +816,8 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
                     keepLocalConfig,
                     keepLocalLayout,
                     keepLocalStyle,
+                    keepLocalInstance,
+                    keepLocalAnnotation,
                   }) => {
                     if (!lw) return sw; // new widget from server -> accept
 
@@ -824,6 +840,17 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
                               acc[f] = lw[f as keyof WidgetData];
                             return acc as Partial<WidgetData>;
                           })()
+                        : {}),
+                      ...(keepLocalInstance
+                        ? (() => {
+                            const acc: Record<string, unknown> = {};
+                            for (const f of INSTANCE_FIELDS)
+                              acc[f] = lw[f as keyof WidgetData];
+                            return acc as Partial<WidgetData>;
+                          })()
+                        : {}),
+                      ...(keepLocalAnnotation
+                        ? { annotation: lw.annotation }
                         : {}),
                     };
                   }
@@ -868,6 +895,8 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
                   keepLocalConfig,
                   keepLocalLayout,
                   keepLocalStyle,
+                  keepLocalInstance,
+                  keepLocalAnnotation,
                 }) => {
                   if (!lw || !saved) return sw;
 
@@ -890,6 +919,17 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
                             acc[f] = saved[f as keyof WidgetData];
                           return acc as Partial<WidgetData>;
                         })()
+                      : {}),
+                    ...(keepLocalInstance
+                      ? (() => {
+                          const acc: Record<string, unknown> = {};
+                          for (const f of INSTANCE_FIELDS)
+                            acc[f] = saved[f as keyof WidgetData];
+                          return acc as Partial<WidgetData>;
+                        })()
+                      : {}),
+                    ...(keepLocalAnnotation
+                      ? { annotation: saved.annotation }
                       : {}),
                   };
                 }

--- a/tests/DashboardContext_merge.test.tsx
+++ b/tests/DashboardContext_merge.test.tsx
@@ -11,7 +11,7 @@
  *   1. Local config change on one widget + remote config change on another.
  *   2. Remote deletion of a previously-synced widget while local edits exist.
  *   3. Local changes to non-config, non-layout widget fields (customTitle,
- *      maximized, transparency).
+ *      isPinned, annotation, transparency).
  */
 
 import React, { useEffect } from 'react';
@@ -270,7 +270,7 @@ describe('DashboardContext per-widget merge', () => {
     });
   });
 
-  it('preserves local changes to style fields but drops un-tracked fields like customTitle', async () => {
+  it('preserves local changes to style and instance fields including customTitle', async () => {
     const stateRef = setup();
 
     const widgetA = makeWidget('wA', 'original-A');
@@ -306,17 +306,15 @@ describe('DashboardContext per-widget merge', () => {
     ]);
     await pushSnapshot([{ ...serverDashboard, updatedAt: 2000 }]);
 
-    // Known behaviour: non-config, non-layout fields (customTitle,
-    // maximized) are NOT covered by the per-field merge logic.  The merge uses
-    // `...sw` (the server widget) as the base, so server values overwrite any
-    // locally-changed fields outside of `config`, `STYLE_FIELDS` and `LAYOUT_FIELDS`.
-    // This test documents that limitation as a regression baseline.
+    // customTitle is now preserved during merge via INSTANCE_FIELDS,
+    // alongside transparency (STYLE_FIELDS). Server config changes
+    // on other widgets are still accepted.
     await waitFor(() => {
       const wA = stateRef.current?.activeDashboard?.widgets.find(
         (w) => w.id === 'wA'
       );
-      // customTitle reverts to the server's (undefined) value
-      expect(wA?.customTitle).toBeUndefined();
+      // customTitle is preserved since it is in INSTANCE_FIELDS
+      expect(wA?.customTitle).toBe('My Custom Title');
       // transparency is preserved since it is in STYLE_FIELDS
       expect(wA?.transparency).toBe(0.5);
       // But widget B's server config is still accepted

--- a/tests/DashboardContext_merge.test.tsx
+++ b/tests/DashboardContext_merge.test.tsx
@@ -283,10 +283,16 @@ describe('DashboardContext per-widget merge', () => {
     );
     await pushSnapshot([initialDashboard]);
 
-    // Local changes to non-config, non-layout fields on widget A
+    // Local changes to instance, style, and annotation fields on widget A
+    const testAnnotation = {
+      mode: 'window' as const,
+      paths: [{ points: [{ x: 0, y: 0 }], color: '#000', width: 2 }],
+    };
     await act(async () => {
       stateRef.current?.updateWidget('wA', {
         customTitle: 'My Custom Title',
+        isPinned: true,
+        annotation: testAnnotation,
         transparency: 0.5,
       });
       await Promise.resolve();
@@ -297,24 +303,30 @@ describe('DashboardContext per-widget merge', () => {
         (w) => w.id === 'wA'
       );
       expect(wA?.customTitle).toBe('My Custom Title');
+      expect(wA?.isPinned).toBe(true);
     });
 
     // Server snapshot: widget B config changed; widget A unchanged on server
     const serverDashboard = makeDashboard([
-      makeWidget('wA', 'original-A'), // server unaware of local customTitle / transparency
+      makeWidget('wA', 'original-A'), // server unaware of local instance / style changes
       makeWidget('wB', 'server-B'),
     ]);
     await pushSnapshot([{ ...serverDashboard, updatedAt: 2000 }]);
 
-    // customTitle is now preserved during merge via INSTANCE_FIELDS,
-    // alongside transparency (STYLE_FIELDS). Server config changes
-    // on other widgets are still accepted.
+    // All locally-changed fields are preserved during merge:
+    // customTitle and isPinned via INSTANCE_FIELDS, annotation via
+    // dedicated annotation tracking, transparency via STYLE_FIELDS.
+    // Server config changes on other widgets are still accepted.
     await waitFor(() => {
       const wA = stateRef.current?.activeDashboard?.widgets.find(
         (w) => w.id === 'wA'
       );
       // customTitle is preserved since it is in INSTANCE_FIELDS
       expect(wA?.customTitle).toBe('My Custom Title');
+      // isPinned is preserved since it is in INSTANCE_FIELDS
+      expect(wA?.isPinned).toBe(true);
+      // annotation is preserved via dedicated annotation tracking
+      expect(wA?.annotation).toEqual(testAnnotation);
       // transparency is preserved since it is in STYLE_FIELDS
       expect(wA?.transparency).toBe(0.5);
       // But widget B's server config is still accepted


### PR DESCRIPTION
## Summary
Extended the per-widget merge logic in DashboardContext to preserve local changes to instance fields (`customTitle`, `isPinned`) and annotation data during sync operations, similar to how style and layout fields are already preserved.

## Key Changes
- Added `INSTANCE_FIELDS` constant defining fields that should be preserved locally: `customTitle` and `isPinned`
- Added detection logic for local changes to instance and annotation fields (`instanceChangedLocally`, `annotationChangedLocally`)
- Added `keepLocalInstance` and `keepLocalAnnotation` flags to the merge state, respecting the remote control enabled setting
- Updated both merge strategies (when local widget exists and when comparing against saved state) to preserve instance and annotation fields when their local versions have changed
- Updated test expectations to reflect that `customTitle` is now properly preserved during merge operations instead of being overwritten by server values

## Implementation Details
- Instance field changes are detected by comparing individual fields in `INSTANCE_FIELDS` between local and saved versions
- Annotation changes are detected via JSON stringification comparison (since annotation is a complex object)
- Both preservation behaviors respect the `remoteControlEnabled` flag, allowing remote control to override local changes when enabled
- The merge logic follows the existing pattern used for style and layout fields, maintaining consistency across the codebase

https://claude.ai/code/session_01NCahKyg355PaE9PbvCuJk9