### PR TITLE
Refactor media sidebar to featured overview + detail panels

### DIFF
--- a/components/admin/BackgroundManager/GridPresetCard.tsx
+++ b/components/admin/BackgroundManager/GridPresetCard.tsx
@@ -48,6 +48,7 @@ export const GridPresetCard: React.FC<PresetCardProps> = ({
         )}
         <div className="absolute top-1.5 right-1.5 z-10 flex items-center gap-1">
           <button
+            type="button"
             onClick={() => void toggleFeatured(preset.id)}
             className={`p-1.5 rounded-lg shadow-md transition-all scale-90 hover:scale-100 ${
               preset.featured
@@ -55,6 +56,9 @@ export const GridPresetCard: React.FC<PresetCardProps> = ({
                 : 'bg-white/80 text-slate-400 hover:bg-amber-500 hover:text-white'
             }`}
             title={
+              preset.featured ? 'Remove from featured' : 'Mark as featured'
+            }
+            aria-label={
               preset.featured ? 'Remove from featured' : 'Mark as featured'
             }
           >

--- a/components/admin/BackgroundManager/GridPresetCard.tsx
+++ b/components/admin/BackgroundManager/GridPresetCard.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Video, Pencil, Check, X, Tag, Plus, Trash2 } from 'lucide-react';
+import { Video, Pencil, Check, X, Tag, Plus, Trash2, Star } from 'lucide-react';
 import { Toggle } from '@/components/common/Toggle';
 import { BUILDINGS } from '@/config/buildings';
 import { extractYouTubeId } from '@/utils/youtube';
@@ -23,6 +23,7 @@ export const GridPresetCard: React.FC<PresetCardProps> = ({
   addBetaUser,
   removeBetaUser,
   toggleBuildingId,
+  toggleFeatured,
   getAccessLevelIcon,
   getAccessLevelColor,
 }) => {
@@ -45,7 +46,23 @@ export const GridPresetCard: React.FC<PresetCardProps> = ({
             </span>
           </div>
         )}
-        <div className="absolute top-1.5 right-1.5 z-10">
+        <div className="absolute top-1.5 right-1.5 z-10 flex items-center gap-1">
+          <button
+            onClick={() => void toggleFeatured(preset.id)}
+            className={`p-1.5 rounded-lg shadow-md transition-all scale-90 hover:scale-100 ${
+              preset.featured
+                ? 'bg-amber-500 text-white hover:bg-amber-600'
+                : 'bg-white/80 text-slate-400 hover:bg-amber-500 hover:text-white'
+            }`}
+            title={
+              preset.featured ? 'Remove from featured' : 'Mark as featured'
+            }
+          >
+            <Star
+              className="w-3.5 h-3.5"
+              fill={preset.featured ? 'currentColor' : 'none'}
+            />
+          </button>
           <button
             onClick={() => void deletePreset(preset)}
             className="p-1.5 bg-red-600 text-white rounded-lg hover:bg-red-700 shadow-md transition-all scale-90 hover:scale-100"

--- a/components/admin/BackgroundManager/ListPresetRow.tsx
+++ b/components/admin/BackgroundManager/ListPresetRow.tsx
@@ -8,6 +8,7 @@ import {
   Plus,
   Trash2,
   Building2,
+  Star,
 } from 'lucide-react';
 import { Toggle } from '@/components/common/Toggle';
 import { BUILDINGS } from '@/config/buildings';
@@ -32,6 +33,7 @@ export const ListPresetRow: React.FC<PresetCardProps> = ({
   addBetaUser,
   removeBetaUser,
   toggleBuildingId,
+  toggleFeatured,
   getAccessLevelIcon,
   getAccessLevelColor,
 }) => {
@@ -231,6 +233,22 @@ export const ListPresetRow: React.FC<PresetCardProps> = ({
             <span className="text-xxs text-slate-400 italic">All</span>
           )}
         </div>
+
+        {/* Featured */}
+        <button
+          onClick={() => void toggleFeatured(preset.id)}
+          className={`p-1.5 rounded-lg transition-colors shrink-0 ${
+            preset.featured
+              ? 'text-amber-500 hover:bg-amber-50'
+              : 'text-slate-300 hover:text-amber-500 hover:bg-amber-50'
+          }`}
+          title={preset.featured ? 'Remove from featured' : 'Mark as featured'}
+        >
+          <Star
+            className="w-4 h-4"
+            fill={preset.featured ? 'currentColor' : 'none'}
+          />
+        </button>
 
         {/* Delete */}
         <button

--- a/components/admin/BackgroundManager/ListPresetRow.tsx
+++ b/components/admin/BackgroundManager/ListPresetRow.tsx
@@ -236,6 +236,7 @@ export const ListPresetRow: React.FC<PresetCardProps> = ({
 
         {/* Featured */}
         <button
+          type="button"
           onClick={() => void toggleFeatured(preset.id)}
           className={`p-1.5 rounded-lg transition-colors shrink-0 ${
             preset.featured
@@ -243,6 +244,9 @@ export const ListPresetRow: React.FC<PresetCardProps> = ({
               : 'text-slate-300 hover:text-amber-500 hover:bg-amber-50'
           }`}
           title={preset.featured ? 'Remove from featured' : 'Mark as featured'}
+          aria-label={
+            preset.featured ? 'Remove from featured' : 'Mark as featured'
+          }
         >
           <Star
             className="w-4 h-4"

--- a/components/admin/BackgroundManager/index.tsx
+++ b/components/admin/BackgroundManager/index.tsx
@@ -533,6 +533,12 @@ export const BackgroundManager: React.FC = () => {
     await updatePreset(presetId, { buildingIds: updated });
   };
 
+  const toggleFeatured = async (presetId: string) => {
+    const preset = presets.find((p) => p.id === presetId);
+    if (!preset) return;
+    await updatePreset(presetId, { featured: !preset.featured });
+  };
+
   const getAccessLevelIcon = (level: AccessLevel) => {
     switch (level) {
       case 'admin':
@@ -568,6 +574,16 @@ export const BackgroundManager: React.FC = () => {
     const counts = new Map<string, number>();
     presets.forEach((p) => {
       if (p.category) {
+        counts.set(p.category, (counts.get(p.category) ?? 0) + 1);
+      }
+    });
+    return counts;
+  }, [presets]);
+
+  const categoryFeaturedCounts = useMemo(() => {
+    const counts = new Map<string, number>();
+    presets.forEach((p) => {
+      if (p.category && p.featured) {
         counts.set(p.category, (counts.get(p.category) ?? 0) + 1);
       }
     });
@@ -804,18 +820,26 @@ export const BackgroundManager: React.FC = () => {
                   No categories yet. Add one below.
                 </p>
               )}
-              {allCategories.map((cat) => (
-                <div
-                  key={cat}
-                  className="flex items-center gap-1.5 px-3 py-1 bg-white border border-slate-200 rounded-full text-xs font-medium text-slate-700 shadow-sm"
-                >
-                  <Tag className="w-3 h-3 text-brand-blue-primary" />
-                  {cat}
-                  <span className="text-slate-400 ml-1">
-                    ({categoryCounts.get(cat) ?? 0})
-                  </span>
-                </div>
-              ))}
+              {allCategories.map((cat) => {
+                const featuredCount = categoryFeaturedCounts.get(cat) ?? 0;
+                return (
+                  <div
+                    key={cat}
+                    className="flex items-center gap-1.5 px-3 py-1 bg-white border border-slate-200 rounded-full text-xs font-medium text-slate-700 shadow-sm"
+                  >
+                    <Tag className="w-3 h-3 text-brand-blue-primary" />
+                    {cat}
+                    <span className="text-slate-400 ml-1">
+                      ({categoryCounts.get(cat) ?? 0})
+                    </span>
+                    {featuredCount > 0 && (
+                      <span className="text-amber-500 ml-0.5">
+                        {featuredCount} featured
+                      </span>
+                    )}
+                  </div>
+                );
+              })}
             </div>
             <div className="flex gap-2 max-w-xs">
               <input
@@ -1141,6 +1165,7 @@ export const BackgroundManager: React.FC = () => {
                 addBetaUser={addBetaUser}
                 removeBetaUser={removeBetaUser}
                 toggleBuildingId={toggleBuildingId}
+                toggleFeatured={toggleFeatured}
                 getAccessLevelIcon={getAccessLevelIcon}
                 getAccessLevelColor={getAccessLevelColor}
               />
@@ -1168,6 +1193,7 @@ export const BackgroundManager: React.FC = () => {
                 addBetaUser={addBetaUser}
                 removeBetaUser={removeBetaUser}
                 toggleBuildingId={toggleBuildingId}
+                toggleFeatured={toggleFeatured}
                 getAccessLevelIcon={getAccessLevelIcon}
                 getAccessLevelColor={getAccessLevelColor}
               />

--- a/components/admin/BackgroundManager/types.ts
+++ b/components/admin/BackgroundManager/types.ts
@@ -21,6 +21,7 @@ export interface PresetCardProps {
   addBetaUser: (presetId: string, email: string) => Promise<void>;
   removeBetaUser: (presetId: string, email: string) => Promise<void>;
   toggleBuildingId: (presetId: string, buildingId: string) => Promise<void>;
+  toggleFeatured: (presetId: string) => Promise<void>;
   getAccessLevelIcon: (level: AccessLevel) => React.ReactNode;
   getAccessLevelColor: (level: AccessLevel) => string;
 }

--- a/components/layout/sidebar/SidebarBackgrounds.tsx
+++ b/components/layout/sidebar/SidebarBackgrounds.tsx
@@ -177,13 +177,12 @@ export const SidebarBackgrounds: React.FC<SidebarBackgroundsProps> = ({
     );
   }, [activeCategory, groupedImagePresets]);
 
-  // Reset detail panel when switching away from media tab
+  // Reset search when switching away from media tab.
+  // activeCategory is intentionally preserved across tab switches so users
+  // don't lose their place when briefly switching to Colors or My Uploads.
   const handleTabChange = (tab: typeof designTab) => {
     setDesignTab(tab);
-    if (tab !== 'media') {
-      setSearchQuery('');
-      setActiveCategory(null);
-    }
+    if (tab !== 'media') setSearchQuery('');
   };
 
   // Reset detail panel when sidebar is hidden

--- a/components/layout/sidebar/SidebarBackgrounds.tsx
+++ b/components/layout/sidebar/SidebarBackgrounds.tsx
@@ -5,12 +5,13 @@ import {
   Video,
   Search,
   X,
-  ChevronDown,
   Check,
   ArrowRight,
   ArrowDownRight,
   ArrowDown,
   ArrowDownLeft,
+  ArrowLeft,
+  ChevronRight,
 } from 'lucide-react';
 import { useBackgrounds } from '@/hooks/useBackgrounds';
 import { useGoogleDrive } from '@/hooks/useGoogleDrive';
@@ -65,22 +66,12 @@ const GRADIENT_DIRECTIONS = [
   { angle: '225deg', label: 'Down-Left', icon: ArrowDownLeft },
 ] as const;
 
+/** Max featured backgrounds shown per category in the overview */
+const FEATURED_LIMIT = 6;
+
 interface SidebarBackgroundsProps {
   isVisible: boolean;
 }
-
-// Namespaced keys for the openCategories Set to prevent collision between
-// image category names and the special ambient-videos section.
-const imgKey = (category: string) => `img:${category}`;
-const VIDEOS_KEY = 'vid';
-
-// Produce a DOM-safe id from an arbitrary category string (which may contain
-// spaces or special chars from Firestore admin input).
-const toPanelId = (category: string) =>
-  `bg-panel-${category
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '')}`;
 
 export const SidebarBackgrounds: React.FC<SidebarBackgroundsProps> = ({
   isVisible,
@@ -97,8 +88,9 @@ export const SidebarBackgrounds: React.FC<SidebarBackgroundsProps> = ({
     'media'
   );
   const [searchQuery, setSearchQuery] = useState('');
-  // Stores namespaced keys (imgKey(category) or VIDEOS_KEY) for open sections
-  const [openCategories, setOpenCategories] = useState<Set<string>>(new Set());
+
+  // Category detail panel — null = overview, string = detail view for that category
+  const [activeCategory, setActiveCategory] = useState<string | null>(null);
 
   // Custom color picker state
   const [customColor, setCustomColor] = useState('#3b82f6');
@@ -150,6 +142,21 @@ export const SidebarBackgrounds: React.FC<SidebarBackgroundsProps> = ({
       .map((c) => ({ category: c, items: groups.get(c) ?? [] }));
   }, [imagePresets]);
 
+  // For each category, pick the featured items (or fallback to first N)
+  const categoryFeaturedItems = useMemo(() => {
+    const result = new Map<string, typeof imagePresets>();
+    for (const { category, items } of groupedImagePresets) {
+      const featured = items.filter((bg) => bg.featured);
+      result.set(
+        category,
+        featured.length > 0
+          ? featured.slice(0, FEATURED_LIMIT)
+          : items.slice(0, FEATURED_LIMIT)
+      );
+    }
+    return result;
+  }, [groupedImagePresets]);
+
   // Search results across all presets (images + videos); null = no active search
   const searchResults = useMemo(() => {
     if (!searchQuery.trim()) return null;
@@ -161,22 +168,28 @@ export const SidebarBackgrounds: React.FC<SidebarBackgroundsProps> = ({
     );
   }, [presets, searchQuery]);
 
-  const toggleCategory = (key: string) => {
-    setOpenCategories((prev) => {
-      const next = new Set(prev);
-      if (next.has(key)) next.delete(key);
-      else next.add(key);
-      return next;
-    });
-  };
+  // Items for the active category detail panel
+  const activeCategoryItems = useMemo(() => {
+    if (!activeCategory) return [];
+    return (
+      groupedImagePresets.find((g) => g.category === activeCategory)?.items ??
+      []
+    );
+  }, [activeCategory, groupedImagePresets]);
 
-  // Reset search when switching away from media tab.
-  // openCategories is intentionally preserved across tab switches so expanded
-  // sections remain open when the user returns to the Media tab.
+  // Reset detail panel when switching away from media tab
   const handleTabChange = (tab: typeof designTab) => {
     setDesignTab(tab);
-    if (tab !== 'media') setSearchQuery('');
+    if (tab !== 'media') {
+      setSearchQuery('');
+      setActiveCategory(null);
+    }
   };
+
+  // Reset detail panel when sidebar is hidden
+  useEffect(() => {
+    if (!isVisible) setActiveCategory(null);
+  }, [isVisible]);
 
   // Fetch past uploads from Google Drive when the "My Uploads" tab is opened
   useEffect(() => {
@@ -268,167 +281,92 @@ export const SidebarBackgrounds: React.FC<SidebarBackgroundsProps> = ({
 
   return (
     <div
-      className={`absolute inset-0 p-4 flex flex-col gap-4 overflow-y-auto custom-scrollbar transition-all duration-300 ease-in-out ${
+      className={`absolute inset-0 flex flex-col transition-all duration-300 ease-in-out ${
         isVisible
           ? 'translate-x-0 opacity-100 visible'
           : 'translate-x-full opacity-0 invisible'
       }`}
     >
       {/* Tab bar */}
-      <div className="flex bg-slate-100 p-0.5 rounded-lg text-xxs font-bold uppercase tracking-widest shrink-0">
-        <button
-          type="button"
-          onClick={() => handleTabChange('media')}
-          className={`flex-1 py-1.5 rounded-md transition-all ${
-            designTab === 'media'
-              ? 'bg-white shadow-sm text-brand-blue-primary'
-              : 'text-slate-500'
-          }`}
-        >
-          Media
-        </button>
-        <button
-          type="button"
-          onClick={() => handleTabChange('colors')}
-          className={`flex-1 py-1.5 rounded-md transition-all ${
-            designTab === 'colors'
-              ? 'bg-white shadow-sm text-brand-blue-primary'
-              : 'text-slate-500'
-          }`}
-        >
-          Colors
-        </button>
-        <button
-          type="button"
-          onClick={() => handleTabChange('my-uploads')}
-          className={`flex-1 py-1.5 rounded-md transition-all ${
-            designTab === 'my-uploads'
-              ? 'bg-white shadow-sm text-brand-blue-primary'
-              : 'text-slate-500'
-          }`}
-        >
-          My Uploads
-        </button>
+      <div className="px-4 pt-4 shrink-0">
+        <div className="flex bg-slate-100 p-0.5 rounded-lg text-xxs font-bold uppercase tracking-widest">
+          <button
+            type="button"
+            onClick={() => handleTabChange('media')}
+            className={`flex-1 py-1.5 rounded-md transition-all ${
+              designTab === 'media'
+                ? 'bg-white shadow-sm text-brand-blue-primary'
+                : 'text-slate-500'
+            }`}
+          >
+            Media
+          </button>
+          <button
+            type="button"
+            onClick={() => handleTabChange('colors')}
+            className={`flex-1 py-1.5 rounded-md transition-all ${
+              designTab === 'colors'
+                ? 'bg-white shadow-sm text-brand-blue-primary'
+                : 'text-slate-500'
+            }`}
+          >
+            Colors
+          </button>
+          <button
+            type="button"
+            onClick={() => handleTabChange('my-uploads')}
+            className={`flex-1 py-1.5 rounded-md transition-all ${
+              designTab === 'my-uploads'
+                ? 'bg-white shadow-sm text-brand-blue-primary'
+                : 'text-slate-500'
+            }`}
+          >
+            My Uploads
+          </button>
+        </div>
       </div>
 
       {/* ── Media tab ── */}
       {designTab === 'media' && (
-        <div className="flex flex-col gap-3 pb-4">
-          {/* Search input */}
-          <div className="relative flex items-center shrink-0">
-            <Search className="absolute left-2.5 w-3.5 h-3.5 text-slate-400 pointer-events-none" />
-            <input
-              type="text"
-              value={searchQuery}
-              onChange={(e) => setSearchQuery(e.target.value)}
-              placeholder="Search backgrounds…"
-              aria-label="Search backgrounds"
-              className="w-full pl-8 pr-8 py-1.5 text-xs bg-white border border-slate-200 rounded-lg text-slate-700 placeholder-slate-400 focus:outline-none focus:border-brand-blue-primary transition-colors"
-            />
-            {searchQuery.trim() && (
-              <button
-                type="button"
-                onClick={() => setSearchQuery('')}
-                className="absolute right-2.5 text-slate-400 hover:text-slate-600 transition-colors"
-                aria-label="Clear search"
-              >
-                <X className="w-3.5 h-3.5" />
-              </button>
-            )}
-          </div>
-
-          {/* Search results */}
-          {searchResults !== null ? (
-            <div className="flex flex-col gap-2">
-              {searchResults.length > 0 ? (
-                <div className="grid grid-cols-2 gap-2">
-                  {searchResults.map((bg) => (
-                    <ThumbnailButton
-                      key={bg.id}
-                      {...bg}
-                      isActive={activeDashboard?.background === bg.id}
-                      onSelect={setBackground}
-                    />
-                  ))}
-                </div>
-              ) : (
-                <p className="text-center text-xs text-slate-400 py-8">
-                  No backgrounds match &ldquo;{searchQuery}&rdquo;.
-                </p>
-              )}
-            </div>
-          ) : (
-            /* Accordion view — no active search */
-            <div className="flex flex-col gap-2">
-              {groupedImagePresets.map(({ category, items }) => {
-                const key = imgKey(category);
-                const isOpen = openCategories.has(key);
-                const panelId = toPanelId(category);
-                return (
-                  <div
-                    key={category}
-                    className="border border-slate-200 rounded-lg overflow-hidden"
-                  >
-                    <button
-                      type="button"
-                      onClick={() => toggleCategory(key)}
-                      aria-expanded={isOpen}
-                      aria-controls={panelId}
-                      className="w-full flex items-center justify-between px-3 py-2 bg-slate-50 hover:bg-slate-100 transition-colors"
-                    >
-                      <span className="text-xs font-bold text-slate-600 uppercase tracking-wide">
-                        {category}
-                        <span className="ml-1.5 text-slate-400 font-normal normal-case tracking-normal">
-                          ({items.length})
-                        </span>
-                      </span>
-                      <ChevronDown
-                        className={`w-4 h-4 text-slate-400 transition-transform ${isOpen ? 'rotate-180' : ''}`}
-                      />
-                    </button>
-                    {isOpen && (
-                      <div id={panelId} className="p-2 grid grid-cols-2 gap-2">
-                        {items.map((bg) => (
-                          <ThumbnailButton
-                            key={bg.id}
-                            {...bg}
-                            isActive={activeDashboard?.background === bg.id}
-                            onSelect={setBackground}
-                          />
-                        ))}
-                      </div>
-                    )}
-                  </div>
-                );
-              })}
-
-              {/* Ambient Videos accordion section */}
-              {videoPresets.length > 0 && (
-                <div className="border border-slate-200 rounded-lg overflow-hidden">
+        <div className="flex-1 relative overflow-hidden">
+          {/* Overview panel */}
+          <div
+            className={`absolute inset-0 flex flex-col overflow-y-auto custom-scrollbar transition-[transform,opacity] duration-300 ease-in-out ${
+              activeCategory === null
+                ? 'translate-x-0 opacity-100 visible'
+                : '-translate-x-full opacity-0 invisible'
+            }`}
+          >
+            <div className="flex flex-col gap-3 p-4 pb-4">
+              {/* Search input */}
+              <div className="relative flex items-center shrink-0">
+                <Search className="absolute left-2.5 w-3.5 h-3.5 text-slate-400 pointer-events-none" />
+                <input
+                  type="text"
+                  value={searchQuery}
+                  onChange={(e) => setSearchQuery(e.target.value)}
+                  placeholder="Search backgrounds…"
+                  aria-label="Search backgrounds"
+                  className="w-full pl-8 pr-8 py-1.5 text-xs bg-white border border-slate-200 rounded-lg text-slate-700 placeholder-slate-400 focus:outline-none focus:border-brand-blue-primary transition-colors"
+                />
+                {searchQuery.trim() && (
                   <button
                     type="button"
-                    onClick={() => toggleCategory(VIDEOS_KEY)}
-                    aria-expanded={openCategories.has(VIDEOS_KEY)}
-                    aria-controls="bg-panel-vid"
-                    className="w-full flex items-center justify-between px-3 py-2 bg-slate-50 hover:bg-slate-100 transition-colors"
+                    onClick={() => setSearchQuery('')}
+                    className="absolute right-2.5 text-slate-400 hover:text-slate-600 transition-colors"
+                    aria-label="Clear search"
                   >
-                    <span className="text-xs font-bold text-slate-600 uppercase tracking-wide flex items-center gap-1.5">
-                      <Video className="w-3.5 h-3.5" />
-                      Ambient Videos
-                      <span className="text-slate-400 font-normal normal-case tracking-normal">
-                        ({videoPresets.length})
-                      </span>
-                    </span>
-                    <ChevronDown
-                      className={`w-4 h-4 text-slate-400 transition-transform ${openCategories.has(VIDEOS_KEY) ? 'rotate-180' : ''}`}
-                    />
+                    <X className="w-3.5 h-3.5" />
                   </button>
-                  {openCategories.has(VIDEOS_KEY) && (
-                    <div
-                      id="bg-panel-vid"
-                      className="p-2 grid grid-cols-2 gap-2"
-                    >
-                      {videoPresets.map((bg) => (
+                )}
+              </div>
+
+              {/* Search results */}
+              {searchResults !== null ? (
+                <div className="flex flex-col gap-2">
+                  {searchResults.length > 0 ? (
+                    <div className="grid grid-cols-2 gap-2">
+                      {searchResults.map((bg) => (
                         <ThumbnailButton
                           key={bg.id}
                           {...bg}
@@ -437,205 +375,315 @@ export const SidebarBackgrounds: React.FC<SidebarBackgroundsProps> = ({
                         />
                       ))}
                     </div>
+                  ) : (
+                    <p className="text-center text-xs text-slate-400 py-8">
+                      No backgrounds match &ldquo;{searchQuery}&rdquo;.
+                    </p>
                   )}
                 </div>
-              )}
+              ) : (
+                /* Category overview — featured items only */
+                <div className="flex flex-col gap-4">
+                  {groupedImagePresets.map(({ category, items }) => {
+                    const featured = categoryFeaturedItems.get(category) ?? [];
+                    const hasMore = items.length > featured.length;
+                    return (
+                      <div key={category} className="flex flex-col gap-1.5">
+                        <div className="flex items-center justify-between">
+                          <span className="text-xs font-bold text-slate-600 uppercase tracking-wide">
+                            {category}
+                            <span className="ml-1.5 text-slate-400 font-normal normal-case tracking-normal">
+                              ({items.length})
+                            </span>
+                          </span>
+                          {hasMore && (
+                            <button
+                              type="button"
+                              onClick={() => setActiveCategory(category)}
+                              className="flex items-center gap-0.5 text-xxs font-semibold text-brand-blue-primary hover:text-brand-blue-dark transition-colors"
+                            >
+                              See More
+                              <ChevronRight className="w-3.5 h-3.5" />
+                            </button>
+                          )}
+                        </div>
+                        <div className="grid grid-cols-2 gap-2">
+                          {featured.map((bg) => (
+                            <ThumbnailButton
+                              key={bg.id}
+                              {...bg}
+                              isActive={activeDashboard?.background === bg.id}
+                              onSelect={setBackground}
+                            />
+                          ))}
+                        </div>
+                      </div>
+                    );
+                  })}
 
-              {groupedImagePresets.length === 0 &&
-                videoPresets.length === 0 && (
-                  <p className="text-center text-xs text-slate-400 py-8">
-                    No media backgrounds available yet.
-                  </p>
-                )}
+                  {/* Ambient Videos section */}
+                  {videoPresets.length > 0 && (
+                    <div className="flex flex-col gap-1.5">
+                      <span className="text-xs font-bold text-slate-600 uppercase tracking-wide flex items-center gap-1.5">
+                        <Video className="w-3.5 h-3.5" />
+                        Ambient Videos
+                        <span className="text-slate-400 font-normal normal-case tracking-normal">
+                          ({videoPresets.length})
+                        </span>
+                      </span>
+                      <div className="grid grid-cols-2 gap-2">
+                        {videoPresets.map((bg) => (
+                          <ThumbnailButton
+                            key={bg.id}
+                            {...bg}
+                            isActive={activeDashboard?.background === bg.id}
+                            onSelect={setBackground}
+                          />
+                        ))}
+                      </div>
+                    </div>
+                  )}
+
+                  {groupedImagePresets.length === 0 &&
+                    videoPresets.length === 0 && (
+                      <p className="text-center text-xs text-slate-400 py-8">
+                        No media backgrounds available yet.
+                      </p>
+                    )}
+                </div>
+              )}
             </div>
-          )}
+          </div>
+
+          {/* Category detail panel */}
+          <div
+            className={`absolute inset-0 flex flex-col overflow-y-auto custom-scrollbar transition-[transform,opacity] duration-300 ease-in-out ${
+              activeCategory !== null
+                ? 'translate-x-0 opacity-100 visible'
+                : 'translate-x-full opacity-0 invisible'
+            }`}
+          >
+            {/* Detail header */}
+            <div className="flex items-center gap-2 px-4 py-3 border-b border-slate-200 shrink-0 bg-white">
+              <button
+                type="button"
+                onClick={() => setActiveCategory(null)}
+                className="p-1 -ml-1 rounded-md text-slate-400 hover:text-slate-600 hover:bg-slate-100 transition-colors"
+                aria-label="Back to overview"
+              >
+                <ArrowLeft className="w-4 h-4" />
+              </button>
+              <span className="text-xs font-bold text-slate-600 uppercase tracking-wide">
+                {activeCategory}
+                <span className="ml-1.5 text-slate-400 font-normal normal-case tracking-normal">
+                  ({activeCategoryItems.length})
+                </span>
+              </span>
+            </div>
+
+            {/* Detail grid */}
+            <div className="p-4 grid grid-cols-2 gap-2">
+              {activeCategoryItems.map((bg) => (
+                <ThumbnailButton
+                  key={bg.id}
+                  {...bg}
+                  isActive={activeDashboard?.background === bg.id}
+                  onSelect={setBackground}
+                />
+              ))}
+            </div>
+          </div>
         </div>
       )}
 
       {/* ── Colors tab ── */}
       {designTab === 'colors' && (
-        <div className="flex flex-col gap-6 pb-4">
-          {/* ── Solid Colors ── */}
-          <div className="space-y-2">
-            <h3 className="text-xs font-bold text-slate-500 uppercase">
-              Solid Colors
-            </h3>
-            <div className="grid grid-cols-3 gap-2">
-              {colors.map((bg) => (
-                <button
-                  type="button"
-                  key={bg.id}
-                  onClick={() => setBackground(bg.id)}
-                  className={`aspect-square rounded-lg border transition-all ${bg.id} ${
-                    activeDashboard?.background === bg.id
-                      ? 'border-brand-blue-primary ring-2 ring-brand-blue-lighter'
-                      : 'border-slate-200'
-                  }`}
-                />
-              ))}
-            </div>
-
-            {/* Custom color picker */}
-            <div className="flex items-center gap-2 pt-1">
-              <div className="relative">
-                <input
-                  type="color"
-                  value={customColor}
-                  onChange={(e) => setCustomColor(e.target.value)}
-                  className="w-8 h-8 rounded-lg border border-slate-200 cursor-pointer p-0.5"
-                  title="Pick a custom color"
-                />
+        <div className="flex-1 overflow-y-auto custom-scrollbar">
+          <div className="flex flex-col gap-6 p-4 pb-4">
+            {/* ── Solid Colors ── */}
+            <div className="space-y-2">
+              <h3 className="text-xs font-bold text-slate-500 uppercase">
+                Solid Colors
+              </h3>
+              <div className="grid grid-cols-3 gap-2">
+                {colors.map((bg) => (
+                  <button
+                    type="button"
+                    key={bg.id}
+                    onClick={() => setBackground(bg.id)}
+                    className={`aspect-square rounded-lg border transition-all ${bg.id} ${
+                      activeDashboard?.background === bg.id
+                        ? 'border-brand-blue-primary ring-2 ring-brand-blue-lighter'
+                        : 'border-slate-200'
+                    }`}
+                  />
+                ))}
               </div>
-              <input
-                type="text"
-                value={customColor}
-                onChange={(e) => {
-                  const v = e.target.value;
-                  if (/^#[0-9a-fA-F]{0,6}$/.test(v)) setCustomColor(v);
-                }}
-                className="flex-1 px-2 py-1.5 text-xs bg-white border border-slate-200 rounded-lg text-slate-700 font-mono uppercase focus:outline-none focus:border-brand-blue-primary transition-colors"
-                maxLength={7}
-                placeholder="#000000"
-              />
-              <button
-                type="button"
-                onClick={() => setBackground(`custom:${customColor}`)}
-                disabled={!/^#([0-9a-fA-F]{3}){1,2}$/.test(customColor)}
-                className={`px-3 py-1.5 text-xxs font-bold uppercase rounded-lg transition-all ${
-                  isCustomColorActive
-                    ? 'bg-brand-blue-primary text-white'
-                    : 'bg-slate-100 text-slate-600 hover:bg-brand-blue-primary hover:text-white disabled:opacity-50 disabled:hover:bg-slate-100 disabled:hover:text-slate-600'
-                }`}
-              >
-                {isCustomColorActive ? (
-                  <Check className="w-3.5 h-3.5" />
-                ) : (
-                  'Apply'
-                )}
-              </button>
-            </div>
-          </div>
 
-          {/* ── Patterns ── */}
-          <div className="space-y-2">
-            <h3 className="text-xs font-bold text-slate-500 uppercase">
-              Patterns
-            </h3>
-            <div className="grid grid-cols-3 gap-2">
-              {patterns.map((bg) => (
-                <button
-                  type="button"
-                  key={bg.id}
-                  onClick={() => setBackground(bg.id)}
-                  className={`aspect-square rounded-lg border transition-all relative overflow-hidden ${
-                    activeDashboard?.background === bg.id
-                      ? 'border-brand-blue-primary ring-2 ring-brand-blue-lighter'
-                      : 'border-slate-200'
-                  }`}
-                >
-                  <div className={`w-full h-full rounded-md ${bg.id}`} />
-                  <div className="absolute bottom-0 inset-x-0 bg-black/40 py-0.5">
-                    <span className="text-white text-xxxs font-bold uppercase block text-center">
-                      {bg.label}
-                    </span>
-                  </div>
-                </button>
-              ))}
-            </div>
-          </div>
-
-          {/* ── Gradients ── */}
-          <div className="space-y-2">
-            <h3 className="text-xs font-bold text-slate-500 uppercase">
-              Gradients
-            </h3>
-            <div className="grid grid-cols-2 gap-2">
-              {gradients.map((bg) => (
-                <button
-                  type="button"
-                  key={bg.id}
-                  onClick={() => setBackground(bg.id)}
-                  className={`aspect-video rounded-lg border transition-all relative ${
-                    activeDashboard?.background === bg.id
-                      ? 'border-brand-blue-primary ring-2 ring-brand-blue-lighter'
-                      : 'border-slate-200'
-                  }`}
-                >
-                  <div className={`w-full h-full rounded-md ${bg.id}`} />
-                  <div className="absolute bottom-1.5 left-1.5 text-xxxs font-bold uppercase text-white drop-shadow-md">
-                    {bg.label}
-                  </div>
-                </button>
-              ))}
-            </div>
-
-            {/* Custom gradient creator */}
-            <div className="space-y-2 pt-1">
-              {/* Live preview */}
-              <div
-                className={`w-full h-10 rounded-lg border transition-all ${
-                  isCustomGradientActive
-                    ? 'border-brand-blue-primary ring-2 ring-brand-blue-lighter'
-                    : 'border-slate-200'
-                }`}
-                style={{
-                  background: `linear-gradient(${gradientAngle}, ${gradientColor1}, ${gradientColor2})`,
-                }}
-              />
-
-              {/* Color pickers + direction */}
-              <div className="flex items-center gap-2">
-                <input
-                  type="color"
-                  value={gradientColor1}
-                  onChange={(e) => setGradientColor1(e.target.value)}
-                  className="w-8 h-8 rounded-lg border border-slate-200 cursor-pointer p-0.5"
-                  title="Start color"
-                />
-                <div className="flex-1 flex items-center justify-center gap-1 bg-slate-100 rounded-lg p-0.5">
-                  {GRADIENT_DIRECTIONS.map(({ angle, label, icon: Icon }) => (
-                    <button
-                      type="button"
-                      key={angle}
-                      onClick={() => setGradientAngle(angle)}
-                      title={label}
-                      className={`p-1.5 rounded-md transition-all ${
-                        gradientAngle === angle
-                          ? 'bg-white shadow-sm text-brand-blue-primary'
-                          : 'text-slate-400 hover:text-slate-600'
-                      }`}
-                    >
-                      <Icon className="w-3.5 h-3.5" />
-                    </button>
-                  ))}
+              {/* Custom color picker */}
+              <div className="flex items-center gap-2 pt-1">
+                <div className="relative">
+                  <input
+                    type="color"
+                    value={customColor}
+                    onChange={(e) => setCustomColor(e.target.value)}
+                    className="w-8 h-8 rounded-lg border border-slate-200 cursor-pointer p-0.5"
+                    title="Pick a custom color"
+                  />
                 </div>
                 <input
-                  type="color"
-                  value={gradientColor2}
-                  onChange={(e) => setGradientColor2(e.target.value)}
-                  className="w-8 h-8 rounded-lg border border-slate-200 cursor-pointer p-0.5"
-                  title="End color"
+                  type="text"
+                  value={customColor}
+                  onChange={(e) => {
+                    const v = e.target.value;
+                    if (/^#[0-9a-fA-F]{0,6}$/.test(v)) setCustomColor(v);
+                  }}
+                  className="flex-1 px-2 py-1.5 text-xs bg-white border border-slate-200 rounded-lg text-slate-700 font-mono uppercase focus:outline-none focus:border-brand-blue-primary transition-colors"
+                  maxLength={7}
+                  placeholder="#000000"
                 />
+                <button
+                  type="button"
+                  onClick={() => setBackground(`custom:${customColor}`)}
+                  disabled={!/^#([0-9a-fA-F]{3}){1,2}$/.test(customColor)}
+                  className={`px-3 py-1.5 text-xxs font-bold uppercase rounded-lg transition-all ${
+                    isCustomColorActive
+                      ? 'bg-brand-blue-primary text-white'
+                      : 'bg-slate-100 text-slate-600 hover:bg-brand-blue-primary hover:text-white disabled:opacity-50 disabled:hover:bg-slate-100 disabled:hover:text-slate-600'
+                  }`}
+                >
+                  {isCustomColorActive ? (
+                    <Check className="w-3.5 h-3.5" />
+                  ) : (
+                    'Apply'
+                  )}
+                </button>
+              </div>
+            </div>
+
+            {/* ── Patterns ── */}
+            <div className="space-y-2">
+              <h3 className="text-xs font-bold text-slate-500 uppercase">
+                Patterns
+              </h3>
+              <div className="grid grid-cols-3 gap-2">
+                {patterns.map((bg) => (
+                  <button
+                    type="button"
+                    key={bg.id}
+                    onClick={() => setBackground(bg.id)}
+                    className={`aspect-square rounded-lg border transition-all relative overflow-hidden ${
+                      activeDashboard?.background === bg.id
+                        ? 'border-brand-blue-primary ring-2 ring-brand-blue-lighter'
+                        : 'border-slate-200'
+                    }`}
+                  >
+                    <div className={`w-full h-full rounded-md ${bg.id}`} />
+                    <div className="absolute bottom-0 inset-x-0 bg-black/40 py-0.5">
+                      <span className="text-white text-xxxs font-bold uppercase block text-center">
+                        {bg.label}
+                      </span>
+                    </div>
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            {/* ── Gradients ── */}
+            <div className="space-y-2">
+              <h3 className="text-xs font-bold text-slate-500 uppercase">
+                Gradients
+              </h3>
+              <div className="grid grid-cols-2 gap-2">
+                {gradients.map((bg) => (
+                  <button
+                    type="button"
+                    key={bg.id}
+                    onClick={() => setBackground(bg.id)}
+                    className={`aspect-video rounded-lg border transition-all relative ${
+                      activeDashboard?.background === bg.id
+                        ? 'border-brand-blue-primary ring-2 ring-brand-blue-lighter'
+                        : 'border-slate-200'
+                    }`}
+                  >
+                    <div className={`w-full h-full rounded-md ${bg.id}`} />
+                    <div className="absolute bottom-1.5 left-1.5 text-xxxs font-bold uppercase text-white drop-shadow-md">
+                      {bg.label}
+                    </div>
+                  </button>
+                ))}
               </div>
 
-              {/* Apply button */}
-              <button
-                type="button"
-                onClick={() => setBackground(`custom:${currentGradientValue}`)}
-                className={`w-full py-1.5 text-xxs font-bold uppercase rounded-lg transition-all ${
-                  isCustomGradientActive
-                    ? 'bg-brand-blue-primary text-white'
-                    : 'bg-slate-100 text-slate-600 hover:bg-brand-blue-primary hover:text-white'
-                }`}
-              >
-                {isCustomGradientActive ? (
-                  <span className="flex items-center justify-center gap-1">
-                    <Check className="w-3.5 h-3.5" /> Applied
-                  </span>
-                ) : (
-                  'Apply Gradient'
-                )}
-              </button>
+              {/* Custom gradient creator */}
+              <div className="space-y-2 pt-1">
+                {/* Live preview */}
+                <div
+                  className={`w-full h-10 rounded-lg border transition-all ${
+                    isCustomGradientActive
+                      ? 'border-brand-blue-primary ring-2 ring-brand-blue-lighter'
+                      : 'border-slate-200'
+                  }`}
+                  style={{
+                    background: `linear-gradient(${gradientAngle}, ${gradientColor1}, ${gradientColor2})`,
+                  }}
+                />
+
+                {/* Color pickers + direction */}
+                <div className="flex items-center gap-2">
+                  <input
+                    type="color"
+                    value={gradientColor1}
+                    onChange={(e) => setGradientColor1(e.target.value)}
+                    className="w-8 h-8 rounded-lg border border-slate-200 cursor-pointer p-0.5"
+                    title="Start color"
+                  />
+                  <div className="flex-1 flex items-center justify-center gap-1 bg-slate-100 rounded-lg p-0.5">
+                    {GRADIENT_DIRECTIONS.map(({ angle, label, icon: Icon }) => (
+                      <button
+                        type="button"
+                        key={angle}
+                        onClick={() => setGradientAngle(angle)}
+                        title={label}
+                        className={`p-1.5 rounded-md transition-all ${
+                          gradientAngle === angle
+                            ? 'bg-white shadow-sm text-brand-blue-primary'
+                            : 'text-slate-400 hover:text-slate-600'
+                        }`}
+                      >
+                        <Icon className="w-3.5 h-3.5" />
+                      </button>
+                    ))}
+                  </div>
+                  <input
+                    type="color"
+                    value={gradientColor2}
+                    onChange={(e) => setGradientColor2(e.target.value)}
+                    className="w-8 h-8 rounded-lg border border-slate-200 cursor-pointer p-0.5"
+                    title="End color"
+                  />
+                </div>
+
+                {/* Apply button */}
+                <button
+                  type="button"
+                  onClick={() =>
+                    setBackground(`custom:${currentGradientValue}`)
+                  }
+                  className={`w-full py-1.5 text-xxs font-bold uppercase rounded-lg transition-all ${
+                    isCustomGradientActive
+                      ? 'bg-brand-blue-primary text-white'
+                      : 'bg-slate-100 text-slate-600 hover:bg-brand-blue-primary hover:text-white'
+                  }`}
+                >
+                  {isCustomGradientActive ? (
+                    <span className="flex items-center justify-center gap-1">
+                      <Check className="w-3.5 h-3.5" /> Applied
+                    </span>
+                  ) : (
+                    'Apply Gradient'
+                  )}
+                </button>
+              </div>
             </div>
           </div>
         </div>
@@ -643,63 +691,65 @@ export const SidebarBackgrounds: React.FC<SidebarBackgroundsProps> = ({
 
       {/* ── My Uploads tab ── */}
       {designTab === 'my-uploads' && (
-        <div className="flex flex-col gap-4 pb-4">
-          <button
-            type="button"
-            onClick={() => fileInputRef.current?.click()}
-            disabled={uploading || !isInitialized}
-            className="w-full py-8 rounded-lg border-2 border-dashed border-slate-300 flex flex-col items-center justify-center text-slate-400 hover:border-brand-blue-primary hover:text-brand-blue-primary hover:bg-slate-50 transition-all disabled:opacity-50"
-          >
-            {uploading ? (
-              <Loader2 className="w-6 h-6 animate-spin" />
-            ) : (
-              <>
-                <Upload className="w-6 h-6 mb-2" />
-                <span className="text-xs font-bold uppercase tracking-wide">
-                  Upload Image
-                </span>
-                {!isInitialized && (
-                  <span className="text-xxs mt-1 text-slate-400">
-                    Sign in with Google to enable
+        <div className="flex-1 overflow-y-auto custom-scrollbar">
+          <div className="flex flex-col gap-4 p-4 pb-4">
+            <button
+              type="button"
+              onClick={() => fileInputRef.current?.click()}
+              disabled={uploading || !isInitialized}
+              className="w-full py-8 rounded-lg border-2 border-dashed border-slate-300 flex flex-col items-center justify-center text-slate-400 hover:border-brand-blue-primary hover:text-brand-blue-primary hover:bg-slate-50 transition-all disabled:opacity-50"
+            >
+              {uploading ? (
+                <Loader2 className="w-6 h-6 animate-spin" />
+              ) : (
+                <>
+                  <Upload className="w-6 h-6 mb-2" />
+                  <span className="text-xs font-bold uppercase tracking-wide">
+                    Upload Image
                   </span>
-                )}
-              </>
-            )}
-          </button>
+                  {!isInitialized && (
+                    <span className="text-xxs mt-1 text-slate-400">
+                      Sign in with Google to enable
+                    </span>
+                  )}
+                </>
+              )}
+            </button>
 
-          {loadingUploads ? (
-            <div className="flex justify-center p-4">
-              <Loader2 className="w-5 h-5 text-slate-400 animate-spin" />
-            </div>
-          ) : userUploads.length > 0 ? (
-            <div className="grid grid-cols-2 gap-2">
-              {userUploads.map((url) => (
-                <button
-                  type="button"
-                  key={url}
-                  onClick={() => setBackground(url)}
-                  className={`aspect-video rounded-lg overflow-hidden border transition-all ${
-                    activeDashboard?.background === url
-                      ? 'border-brand-blue-primary ring-2 ring-brand-blue-lighter'
-                      : 'border-slate-200'
-                  }`}
-                >
-                  <img
-                    src={url}
-                    alt="Custom background"
-                    loading="lazy"
-                    decoding="async"
-                    className="w-full h-full object-cover"
-                  />
-                </button>
-              ))}
-            </div>
-          ) : (
-            <p className="text-center text-xs text-slate-400 mt-2">
-              Custom images you upload will be stored in your Google Drive and
-              shared via link so they can be used as backgrounds.
-            </p>
-          )}
+            {loadingUploads ? (
+              <div className="flex justify-center p-4">
+                <Loader2 className="w-5 h-5 text-slate-400 animate-spin" />
+              </div>
+            ) : userUploads.length > 0 ? (
+              <div className="grid grid-cols-2 gap-2">
+                {userUploads.map((url) => (
+                  <button
+                    type="button"
+                    key={url}
+                    onClick={() => setBackground(url)}
+                    className={`aspect-video rounded-lg overflow-hidden border transition-all ${
+                      activeDashboard?.background === url
+                        ? 'border-brand-blue-primary ring-2 ring-brand-blue-lighter'
+                        : 'border-slate-200'
+                    }`}
+                  >
+                    <img
+                      src={url}
+                      alt="Custom background"
+                      loading="lazy"
+                      decoding="async"
+                      className="w-full h-full object-cover"
+                    />
+                  </button>
+                ))}
+              </div>
+            ) : (
+              <p className="text-center text-xs text-slate-400 mt-2">
+                Custom images you upload will be stored in your Google Drive and
+                shared via link so they can be used as backgrounds.
+              </p>
+            )}
+          </div>
         </div>
       )}
 

--- a/hooks/useBackgrounds.ts
+++ b/hooks/useBackgrounds.ts
@@ -15,6 +15,7 @@ export interface BackgroundPresetItem {
   label: string;
   thumbnailUrl?: string;
   category: string;
+  featured: boolean;
 }
 
 export const useBackgrounds = () => {
@@ -121,11 +122,15 @@ export const useBackgrounds = () => {
     return () => unsubscribes.forEach((unsub) => unsub());
   }, [user, isAdmin]);
 
-  // Preload the first 20 thumbnails into the browser cache so the sidebar
-  // feels instant when opened. This is a legitimate external side-effect
-  // (warming the HTTP cache) rather than derived state.
+  // Preload featured thumbnails first, then fill up to 20 with non-featured.
+  // This ensures the sidebar overview (which only shows featured) feels instant.
   useEffect(() => {
-    const toPreload = managedBackgrounds.slice(0, 20);
+    const featured = managedBackgrounds.filter((bg) => bg.featured);
+    const nonFeatured = managedBackgrounds.filter((bg) => !bg.featured);
+    const toPreload = [
+      ...featured,
+      ...nonFeatured.slice(0, Math.max(0, 20 - featured.length)),
+    ];
     toPreload.forEach((bg) => {
       const src = bg.thumbnailUrl ?? bg.url;
       if (src?.startsWith('http')) {
@@ -141,6 +146,7 @@ export const useBackgrounds = () => {
       label: bg.label,
       thumbnailUrl: bg.thumbnailUrl,
       category: resolveCategory(bg.label, bg.category),
+      featured: bg.featured ?? false,
     }));
   }, [managedBackgrounds]);
 

--- a/hooks/useBackgrounds.ts
+++ b/hooks/useBackgrounds.ts
@@ -125,12 +125,14 @@ export const useBackgrounds = () => {
   // Preload featured thumbnails first, then fill up to 20 with non-featured.
   // This ensures the sidebar overview (which only shows featured) feels instant.
   useEffect(() => {
-    const featured = managedBackgrounds.filter((bg) => bg.featured);
+    const featured = managedBackgrounds
+      .filter((bg) => bg.featured)
+      .slice(0, 20);
     const nonFeatured = managedBackgrounds.filter((bg) => !bg.featured);
     const toPreload = [
       ...featured,
       ...nonFeatured.slice(0, Math.max(0, 20 - featured.length)),
-    ];
+    ].slice(0, 20);
     toPreload.forEach((bg) => {
       const src = bg.thumbnailUrl ?? bg.url;
       if (src?.startsWith('http')) {

--- a/types.ts
+++ b/types.ts
@@ -2667,6 +2667,8 @@ export interface BackgroundPreset {
   category?: string;
   /** Building IDs this background is assigned to; empty/undefined = all buildings */
   buildingIds?: string[];
+  /** Whether this background is featured in the sidebar overview (max ~6 per category) */
+  featured?: boolean;
 }
 
 // --- GLOBAL STYLING TYPES ---


### PR DESCRIPTION
## Summary
Redesigned the media tab in the sidebar backgrounds component to use a two-panel navigation system: an overview showing featured items per category, and detail panels for browsing all items in a category. Added a "featured" flag to backgrounds so admins can curate which items appear in the overview.

## Key Changes

**Sidebar Navigation & UX:**
- Replaced accordion-style category expansion with a featured overview + detail panel system
- Overview shows up to 6 featured items per category with a "See More" button to drill into full category
- Detail panel displays all items in a category with a back button to return to overview
- Active category state persists across tab switches but resets when sidebar is hidden
- Improved layout with proper scrolling: tab bar fixed at top, content area scrollable

**Featured Items System:**
- Added `featured` boolean field to `BackgroundPreset` type
- Implemented `toggleFeatured()` function in BackgroundManager to mark/unmark presets
- Added featured count badges in category pills showing how many items are featured
- Thumbnail preloading prioritizes featured items first, then fills up to 20 with non-featured

**Admin UI Updates:**
- Added star icon button in both grid and list preset cards to toggle featured status
- Visual feedback: amber/gold color for featured items, gray for non-featured
- Category summary now displays featured count alongside total count

**Code Cleanup:**
- Removed `openCategories` Set and related accordion logic (`toggleCategory`, `imgKey`, `VIDEOS_KEY`, `toPanelId`)
- Replaced with simpler `activeCategory` state (null = overview, string = detail view)
- Removed unused `ChevronDown` import, added `ArrowLeft` and `ChevronRight` icons
- Consolidated padding/scrolling: moved `p-4` and `overflow-y-auto` to content containers instead of root

## Implementation Details
- Featured limit set to 6 items per category via `FEATURED_LIMIT` constant
- Category featured items computed via `categoryFeaturedItems` memoized map
- Detail panel items computed via `activeCategoryItems` memoized selector
- Smooth transitions between panels using `translate-x` and opacity animations
- Tab change handler resets both search query and active category to prevent stale state

https://claude.ai/code/session_01UVCXw3ZH85zr81farPmiiM