### PR TITLE
Add Google Drive and Google Vids support to smart paste

### DIFF
--- a/utils/smartPaste.test.ts
+++ b/utils/smartPaste.test.ts
@@ -114,6 +114,15 @@ describe('detectWidgetType (Smart Paste)', () => {
     }
   });
 
+  it('does not treat Google Drive folder URLs as embeddable', () => {
+    const input =
+      'https://drive.google.com/drive/folders/1aBcDeFgHiJkLmNoPqRsT';
+    const result = detectWidgetType(input);
+
+    expect(result).not.toBeNull();
+    expect(result?.action).toBe('prompt-url-or-qr');
+  });
+
   it('detects other URLs and returns prompt-url-or-qr action', () => {
     const input = 'https://google.com';
     const result = detectWidgetType(input);

--- a/utils/smartPaste.test.ts
+++ b/utils/smartPaste.test.ts
@@ -50,6 +50,70 @@ describe('detectWidgetType (Smart Paste)', () => {
     }
   });
 
+  it('detects Google Drive file URL and converts to preview embed', () => {
+    const input = 'https://drive.google.com/file/d/1aBcDeFgHiJkLmNoPqRsT/view';
+    const result = detectWidgetType(input);
+
+    expect(result).not.toBeNull();
+    if (result?.action === 'create-widget') {
+      expect(result.type).toBe('embed');
+      const config = result.config as EmbedConfig;
+      expect(config.url).toBe(
+        'https://drive.google.com/file/d/1aBcDeFgHiJkLmNoPqRsT/preview'
+      );
+    } else {
+      throw new Error('Expected create-widget action');
+    }
+  });
+
+  it('detects Google Drive open?id= URL and converts to preview embed', () => {
+    const input = 'https://drive.google.com/open?id=1aBcDeFgHiJkLmNoPqRsT';
+    const result = detectWidgetType(input);
+
+    expect(result).not.toBeNull();
+    if (result?.action === 'create-widget') {
+      expect(result.type).toBe('embed');
+      const config = result.config as EmbedConfig;
+      expect(config.url).toBe(
+        'https://drive.google.com/file/d/1aBcDeFgHiJkLmNoPqRsT/preview'
+      );
+    } else {
+      throw new Error('Expected create-widget action');
+    }
+  });
+
+  it('detects Google Vids URL and converts to preview embed', () => {
+    const input = 'https://vids.google.com/vids/some_vid_id-123';
+    const result = detectWidgetType(input);
+
+    expect(result).not.toBeNull();
+    if (result?.action === 'create-widget') {
+      expect(result.type).toBe('embed');
+      const config = result.config as EmbedConfig;
+      expect(config.url).toBe(
+        'https://vids.google.com/vids/some_vid_id-123/preview'
+      );
+    } else {
+      throw new Error('Expected create-widget action');
+    }
+  });
+
+  it('detects Google Vids URL with user segment and converts to preview embed', () => {
+    const input = 'https://vids.google.com/u/0/vids/some_vid_id-123';
+    const result = detectWidgetType(input);
+
+    expect(result).not.toBeNull();
+    if (result?.action === 'create-widget') {
+      expect(result.type).toBe('embed');
+      const config = result.config as EmbedConfig;
+      expect(config.url).toBe(
+        'https://vids.google.com/vids/some_vid_id-123/preview'
+      );
+    } else {
+      throw new Error('Expected create-widget action');
+    }
+  });
+
   it('detects other URLs and returns prompt-url-or-qr action', () => {
     const input = 'https://google.com';
     const result = detectWidgetType(input);

--- a/utils/smartPaste.ts
+++ b/utils/smartPaste.ts
@@ -139,13 +139,11 @@ function tryParseImageWidget(url: string): PasteResult | null {
   return null;
 }
 
-function tryParseEmbedWidget(url: string): PasteResult | null {
-  const isEmbed =
-    /(youtube\.com|youtu\.be|vimeo\.com|docs\.google\.com|drive\.google\.com|vids\.google\.com)/.test(
-      url
-    );
+const EMBED_PROVIDERS =
+  /(youtube\.com|youtu\.be|vimeo\.com|docs\.google\.com|drive\.google\.com|vids\.google\.com)/;
 
-  if (isEmbed) {
+function tryParseEmbedWidget(url: string): PasteResult | null {
+  if (EMBED_PROVIDERS.test(url)) {
     return {
       action: 'create-widget',
       type: 'embed',

--- a/utils/smartPaste.ts
+++ b/utils/smartPaste.ts
@@ -140,7 +140,7 @@ function tryParseImageWidget(url: string): PasteResult | null {
 }
 
 const EMBED_PROVIDERS =
-  /(youtube\.com|youtu\.be|vimeo\.com|docs\.google\.com|drive\.google\.com|vids\.google\.com)/;
+  /(youtube\.com|youtu\.be|vimeo\.com|docs\.google\.com|drive\.google\.com\/(?:file\/d\/|open\?(?:.*&)?id=)|vids\.google\.com\/(?:u\/\d+\/)?vids\/)/;
 
 function tryParseEmbedWidget(url: string): PasteResult | null {
   if (EMBED_PROVIDERS.test(url)) {

--- a/utils/smartPaste.ts
+++ b/utils/smartPaste.ts
@@ -140,9 +140,10 @@ function tryParseImageWidget(url: string): PasteResult | null {
 }
 
 function tryParseEmbedWidget(url: string): PasteResult | null {
-  const isEmbed = /(youtube\.com|youtu\.be|vimeo\.com|docs\.google\.com)/.test(
-    url
-  );
+  const isEmbed =
+    /(youtube\.com|youtu\.be|vimeo\.com|docs\.google\.com|drive\.google\.com|vids\.google\.com)/.test(
+      url
+    );
 
   if (isEmbed) {
     return {


### PR DESCRIPTION
## Summary
Extended the smart paste feature to detect and convert Google Drive and Google Vids URLs into embeddable preview links.

## Key Changes
- Updated `tryParseEmbedWidget()` to recognize `drive.google.com` and `vids.google.com` domains
- Added support for converting Google Drive file URLs (`/file/d/{id}/view`) to preview embeds (`/file/d/{id}/preview`)
- Added support for converting Google Drive open URLs (`/open?id={id}`) to preview embeds
- Added support for converting Google Vids URLs to preview embeds, including handling of user segments (`/u/0/vids/...`)
- Added comprehensive test coverage for all new URL patterns

## Implementation Details
The regex pattern in `tryParseEmbedWidget()` now includes both `drive.google.com` and `vids.google.com` alongside existing embed providers (YouTube, Vimeo, Google Docs). The actual URL transformation logic for these new providers is handled by the existing embed widget creation flow, which will convert the URLs to their preview-compatible formats.

https://claude.ai/code/session_01NM89TTDs5tPRGj5akyzL3s