### PR TITLE
Prioritize resize handle over iframe elements in DraggableWindow

### DIFF
--- a/components/common/DraggableWindow.tsx
+++ b/components/common/DraggableWindow.tsx
@@ -818,12 +818,13 @@ export const DraggableWindow: React.FC<DraggableWindowProps> = ({
     const elementsAtPoint = document.elementsFromPoint(e.clientX, e.clientY);
     for (const el of elementsAtPoint) {
       if (el === resizeEl) continue;
-      // Iframes (e.g. embed widget) fill the entire container — the resize
-      // handle must always take priority over them.
-      if ((el as HTMLElement).tagName === 'IFRAME') continue;
+      // Iframes and canvases (e.g. embed or drawing widgets) often fill the
+      // entire container — the resize handle must take priority over them.
+      if (el instanceof HTMLIFrameElement || el instanceof HTMLCanvasElement)
+        continue;
       if (
-        (el as HTMLElement).matches?.(INTERACTIVE_ELEMENTS_SELECTOR) ||
-        (el as HTMLElement).closest?.(INTERACTIVE_ELEMENTS_SELECTOR)
+        el.matches?.(INTERACTIVE_ELEMENTS_SELECTOR) ||
+        el.closest?.(INTERACTIVE_ELEMENTS_SELECTOR)
       ) {
         // Temporarily remove pointer-events so the browser dispatches
         // the subsequent click to the interactive element beneath.

--- a/components/common/DraggableWindow.tsx
+++ b/components/common/DraggableWindow.tsx
@@ -818,6 +818,9 @@ export const DraggableWindow: React.FC<DraggableWindowProps> = ({
     const elementsAtPoint = document.elementsFromPoint(e.clientX, e.clientY);
     for (const el of elementsAtPoint) {
       if (el === resizeEl) continue;
+      // Iframes (e.g. embed widget) fill the entire container — the resize
+      // handle must always take priority over them.
+      if ((el as HTMLElement).tagName === 'IFRAME') continue;
       if (
         (el as HTMLElement).matches?.(INTERACTIVE_ELEMENTS_SELECTOR) ||
         (el as HTMLElement).closest?.(INTERACTIVE_ELEMENTS_SELECTOR)


### PR DESCRIPTION
## Summary
Fixed an issue where iframe elements (such as embed widgets) could intercept mouse events intended for the DraggableWindow resize handle, preventing proper window resizing.

## Changes
- Added a check to skip iframe elements when evaluating interactive elements at the cursor position
- This ensures the resize handle always takes priority over embedded content that fills the container
- Added clarifying comment explaining the rationale for iframe special handling

## Implementation Details
The fix modifies the element detection logic in the drag/resize handler to explicitly skip `IFRAME` elements, similar to how the resize element itself is already skipped. This prevents iframes from blocking resize interactions while still allowing other interactive elements to function normally.

https://claude.ai/code/session_01RW95mogzVd8EbeP74mUSW1