### PR TITLE
Improve pointer event handling and drag performance with RAF batching

### DIFF
--- a/components/layout/dock/FolderItem.tsx
+++ b/components/layout/dock/FolderItem.tsx
@@ -77,6 +77,7 @@ export const FolderItem = React.memo(
     const buttonRef = useRef<HTMLButtonElement>(null);
     const popoverRef = useRef<HTMLDivElement>(null);
     const longPressTimer = useRef<NodeJS.Timeout | null>(null);
+    const longPressStartPos = useRef<{ x: number; y: number } | null>(null);
 
     // DND Sensors for internal folder sorting
     const sensors = useSensors(
@@ -92,6 +93,7 @@ export const FolderItem = React.memo(
     const handlePointerDown = (e: React.PointerEvent) => {
       listeners?.onPointerDown?.(e);
       if (isEditMode) return;
+      longPressStartPos.current = { x: e.clientX, y: e.clientY };
       longPressTimer.current = setTimeout(() => {
         onLongPress();
       }, 600);
@@ -101,6 +103,19 @@ export const FolderItem = React.memo(
       if (longPressTimer.current) {
         clearTimeout(longPressTimer.current);
         longPressTimer.current = null;
+      }
+      longPressStartPos.current = null;
+    };
+
+    const handlePointerMove = (e: React.PointerEvent) => {
+      if (longPressTimer.current && longPressStartPos.current) {
+        const dx = e.clientX - longPressStartPos.current.x;
+        const dy = e.clientY - longPressStartPos.current.y;
+        if (Math.sqrt(dx * dx + dy * dy) > 15) {
+          clearTimeout(longPressTimer.current);
+          longPressTimer.current = null;
+          longPressStartPos.current = null;
+        }
       }
     };
 
@@ -228,6 +243,7 @@ export const FolderItem = React.memo(
             onPointerDown={handlePointerDown}
             onPointerUp={handlePointerUp}
             onPointerLeave={handlePointerUp}
+            onPointerMove={handlePointerMove}
             onClick={() => setShowPopover(true)}
             className={`group flex flex-col items-center gap-1 min-w-[50px] transition-transform active:scale-90 relative ${
               isEditMode

--- a/components/layout/dock/FolderItem.tsx
+++ b/components/layout/dock/FolderItem.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useRef, useCallback } from 'react';
 import { createPortal } from 'react-dom';
 import { FolderPlus, X } from 'lucide-react';
+import { useLongPress } from '@/hooks/useLongPress';
 import {
   useSortable,
   SortableContext,
@@ -76,8 +77,6 @@ export const FolderItem = React.memo(
     const [showPopover, setShowPopover] = useState(false);
     const buttonRef = useRef<HTMLButtonElement>(null);
     const popoverRef = useRef<HTMLDivElement>(null);
-    const longPressTimer = useRef<NodeJS.Timeout | null>(null);
-    const longPressStartPos = useRef<{ x: number; y: number } | null>(null);
 
     // DND Sensors for internal folder sorting
     const sensors = useSensors(
@@ -88,36 +87,12 @@ export const FolderItem = React.memo(
       })
     );
 
+    const longPress = useLongPress(onLongPress, {
+      disabled: isEditMode,
+      onPointerDown: listeners?.onPointerDown,
+    });
+
     useClickOutside(popoverRef, () => setShowPopover(false), [buttonRef]);
-
-    const handlePointerDown = (e: React.PointerEvent) => {
-      listeners?.onPointerDown?.(e);
-      if (isEditMode) return;
-      longPressStartPos.current = { x: e.clientX, y: e.clientY };
-      longPressTimer.current = setTimeout(() => {
-        onLongPress();
-      }, 600);
-    };
-
-    const handlePointerUp = () => {
-      if (longPressTimer.current) {
-        clearTimeout(longPressTimer.current);
-        longPressTimer.current = null;
-      }
-      longPressStartPos.current = null;
-    };
-
-    const handlePointerMove = (e: React.PointerEvent) => {
-      if (longPressTimer.current && longPressStartPos.current) {
-        const dx = e.clientX - longPressStartPos.current.x;
-        const dy = e.clientY - longPressStartPos.current.y;
-        if (Math.sqrt(dx * dx + dy * dy) > 15) {
-          clearTimeout(longPressTimer.current);
-          longPressTimer.current = null;
-          longPressStartPos.current = null;
-        }
-      }
-    };
 
     const handleDragEnd = useCallback(
       (event: DragEndEvent) => {
@@ -240,10 +215,10 @@ export const FolderItem = React.memo(
             ref={buttonRef}
             {...attributes}
             {...listeners}
-            onPointerDown={handlePointerDown}
-            onPointerUp={handlePointerUp}
-            onPointerLeave={handlePointerUp}
-            onPointerMove={handlePointerMove}
+            onPointerDown={longPress.onPointerDown}
+            onPointerUp={longPress.onPointerUp}
+            onPointerLeave={longPress.onPointerUp}
+            onPointerMove={longPress.onPointerMove}
             onClick={() => setShowPopover(true)}
             className={`group flex flex-col items-center gap-1 min-w-[50px] transition-transform active:scale-90 relative ${
               isEditMode

--- a/components/layout/dock/SortableFolderWidget.tsx
+++ b/components/layout/dock/SortableFolderWidget.tsx
@@ -40,10 +40,12 @@ export const SortableFolderWidget = React.memo(
     });
 
     const longPressTimer = useRef<NodeJS.Timeout | null>(null);
+    const longPressStartPos = useRef<{ x: number; y: number } | null>(null);
 
     const handlePointerDown = (e: React.PointerEvent) => {
       listeners?.onPointerDown?.(e);
       if (isEditMode) return;
+      longPressStartPos.current = { x: e.clientX, y: e.clientY };
       longPressTimer.current = setTimeout(() => {
         onLongPress();
       }, 600);
@@ -53,6 +55,19 @@ export const SortableFolderWidget = React.memo(
       if (longPressTimer.current) {
         clearTimeout(longPressTimer.current);
         longPressTimer.current = null;
+      }
+      longPressStartPos.current = null;
+    };
+
+    const handlePointerMove = (e: React.PointerEvent) => {
+      if (longPressTimer.current && longPressStartPos.current) {
+        const dx = e.clientX - longPressStartPos.current.x;
+        const dy = e.clientY - longPressStartPos.current.y;
+        if (Math.sqrt(dx * dx + dy * dy) > 15) {
+          clearTimeout(longPressTimer.current);
+          longPressTimer.current = null;
+          longPressStartPos.current = null;
+        }
       }
     };
 
@@ -81,6 +96,7 @@ export const SortableFolderWidget = React.memo(
             onPointerDown={handlePointerDown}
             onPointerUp={handlePointerUp}
             onPointerLeave={handlePointerUp}
+            onPointerMove={handlePointerMove}
             className={`relative ${
               isEditMode
                 ? 'cursor-grab active:cursor-grabbing'

--- a/components/layout/dock/SortableFolderWidget.tsx
+++ b/components/layout/dock/SortableFolderWidget.tsx
@@ -1,7 +1,8 @@
-import React, { useRef } from 'react';
+import React from 'react';
 import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 import { X } from 'lucide-react';
+import { useLongPress } from '@/hooks/useLongPress';
 import { DockIcon } from './DockIcon';
 import { Z_INDEX } from '@/config/zIndex';
 import { WidgetType, ToolMetadata, InternalToolType } from '@/types';
@@ -39,37 +40,10 @@ export const SortableFolderWidget = React.memo(
       disabled: !isEditMode,
     });
 
-    const longPressTimer = useRef<NodeJS.Timeout | null>(null);
-    const longPressStartPos = useRef<{ x: number; y: number } | null>(null);
-
-    const handlePointerDown = (e: React.PointerEvent) => {
-      listeners?.onPointerDown?.(e);
-      if (isEditMode) return;
-      longPressStartPos.current = { x: e.clientX, y: e.clientY };
-      longPressTimer.current = setTimeout(() => {
-        onLongPress();
-      }, 600);
-    };
-
-    const handlePointerUp = () => {
-      if (longPressTimer.current) {
-        clearTimeout(longPressTimer.current);
-        longPressTimer.current = null;
-      }
-      longPressStartPos.current = null;
-    };
-
-    const handlePointerMove = (e: React.PointerEvent) => {
-      if (longPressTimer.current && longPressStartPos.current) {
-        const dx = e.clientX - longPressStartPos.current.x;
-        const dy = e.clientY - longPressStartPos.current.y;
-        if (Math.sqrt(dx * dx + dy * dy) > 15) {
-          clearTimeout(longPressTimer.current);
-          longPressTimer.current = null;
-          longPressStartPos.current = null;
-        }
-      }
-    };
+    const longPress = useLongPress(onLongPress, {
+      disabled: isEditMode,
+      onPointerDown: listeners?.onPointerDown,
+    });
 
     const style = {
       transform: CSS.Translate.toString(transform),
@@ -93,10 +67,10 @@ export const SortableFolderWidget = React.memo(
               if (isEditMode) return;
               onAdd();
             }}
-            onPointerDown={handlePointerDown}
-            onPointerUp={handlePointerUp}
-            onPointerLeave={handlePointerUp}
-            onPointerMove={handlePointerMove}
+            onPointerDown={longPress.onPointerDown}
+            onPointerUp={longPress.onPointerUp}
+            onPointerLeave={longPress.onPointerUp}
+            onPointerMove={longPress.onPointerMove}
             className={`relative ${
               isEditMode
                 ? 'cursor-grab active:cursor-grabbing'

--- a/components/layout/dock/ToolDockItem.tsx
+++ b/components/layout/dock/ToolDockItem.tsx
@@ -66,6 +66,7 @@ export const ToolDockItem = React.memo(
 
     const [showPopover, setShowPopover] = useState(false);
     const longPressTimer = useRef<NodeJS.Timeout | null>(null);
+    const longPressStartPos = useRef<{ x: number; y: number } | null>(null);
     const popoverRef = useRef<HTMLDivElement>(null);
     const internalButtonRef = useRef<HTMLButtonElement>(null);
     const buttonRef = externalButtonRef ?? internalButtonRef;
@@ -80,6 +81,7 @@ export const ToolDockItem = React.memo(
     const handlePointerDown = (e: React.PointerEvent) => {
       listeners?.onPointerDown?.(e);
       if (isEditMode) return;
+      longPressStartPos.current = { x: e.clientX, y: e.clientY };
       longPressTimer.current = setTimeout(() => {
         onLongPress();
       }, 600); // 600ms long press threshold
@@ -89,6 +91,19 @@ export const ToolDockItem = React.memo(
       if (longPressTimer.current) {
         clearTimeout(longPressTimer.current);
         longPressTimer.current = null;
+      }
+      longPressStartPos.current = null;
+    };
+
+    const handlePointerMove = (e: React.PointerEvent) => {
+      if (longPressTimer.current && longPressStartPos.current) {
+        const dx = e.clientX - longPressStartPos.current.x;
+        const dy = e.clientY - longPressStartPos.current.y;
+        if (Math.sqrt(dx * dx + dy * dy) > 15) {
+          clearTimeout(longPressTimer.current);
+          longPressTimer.current = null;
+          longPressStartPos.current = null;
+        }
       }
     };
 
@@ -244,6 +259,7 @@ export const ToolDockItem = React.memo(
             onPointerDown={handlePointerDown}
             onPointerUp={handlePointerUp}
             onPointerLeave={handlePointerUp}
+            onPointerMove={handlePointerMove}
             onClick={handleClick}
             data-tool-id={tool.type}
             className={`group flex flex-col items-center gap-1 min-w-[50px] transition-transform active:scale-90 relative ${

--- a/components/layout/dock/ToolDockItem.tsx
+++ b/components/layout/dock/ToolDockItem.tsx
@@ -4,6 +4,7 @@ import { RefreshCcw, Trash2, Plus, X } from 'lucide-react';
 import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 import { useClickOutside } from '@/hooks/useClickOutside';
+import { useLongPress } from '@/hooks/useLongPress';
 import { GlassCard } from '@/components/common/GlassCard';
 import { DockIcon } from './DockIcon';
 import { DockLabel } from './DockLabel';
@@ -65,8 +66,6 @@ export const ToolDockItem = React.memo(
     });
 
     const [showPopover, setShowPopover] = useState(false);
-    const longPressTimer = useRef<NodeJS.Timeout | null>(null);
-    const longPressStartPos = useRef<{ x: number; y: number } | null>(null);
     const popoverRef = useRef<HTMLDivElement>(null);
     const internalButtonRef = useRef<HTMLButtonElement>(null);
     const buttonRef = externalButtonRef ?? internalButtonRef;
@@ -75,37 +74,13 @@ export const ToolDockItem = React.memo(
       bottom: number;
     } | null>(null);
 
+    const longPress = useLongPress(onLongPress, {
+      disabled: isEditMode,
+      onPointerDown: listeners?.onPointerDown,
+    });
+
     // Close popover when clicking outside
     useClickOutside(popoverRef, () => setShowPopover(false), [buttonRef]);
-
-    const handlePointerDown = (e: React.PointerEvent) => {
-      listeners?.onPointerDown?.(e);
-      if (isEditMode) return;
-      longPressStartPos.current = { x: e.clientX, y: e.clientY };
-      longPressTimer.current = setTimeout(() => {
-        onLongPress();
-      }, 600); // 600ms long press threshold
-    };
-
-    const handlePointerUp = () => {
-      if (longPressTimer.current) {
-        clearTimeout(longPressTimer.current);
-        longPressTimer.current = null;
-      }
-      longPressStartPos.current = null;
-    };
-
-    const handlePointerMove = (e: React.PointerEvent) => {
-      if (longPressTimer.current && longPressStartPos.current) {
-        const dx = e.clientX - longPressStartPos.current.x;
-        const dy = e.clientY - longPressStartPos.current.y;
-        if (Math.sqrt(dx * dx + dy * dy) > 15) {
-          clearTimeout(longPressTimer.current);
-          longPressTimer.current = null;
-          longPressStartPos.current = null;
-        }
-      }
-    };
 
     const handleClick = (e: React.MouseEvent) => {
       if (isEditMode) {
@@ -256,10 +231,10 @@ export const ToolDockItem = React.memo(
             ref={buttonRef}
             {...attributes}
             {...listeners}
-            onPointerDown={handlePointerDown}
-            onPointerUp={handlePointerUp}
-            onPointerLeave={handlePointerUp}
-            onPointerMove={handlePointerMove}
+            onPointerDown={longPress.onPointerDown}
+            onPointerUp={longPress.onPointerUp}
+            onPointerLeave={longPress.onPointerUp}
+            onPointerMove={longPress.onPointerMove}
             onClick={handleClick}
             data-tool-id={tool.type}
             className={`group flex flex-col items-center gap-1 min-w-[50px] transition-transform active:scale-90 relative ${

--- a/components/widgets/ConceptWeb/Widget.tsx
+++ b/components/widgets/ConceptWeb/Widget.tsx
@@ -44,8 +44,10 @@ export const ConceptWebWidget: React.FC<WidgetComponentProps> = ({
   // rAF batching refs for drag and resize performance
   const dragRafRef = useRef<number | null>(null);
   const dragPosRef = useRef<{ x: number; y: number } | null>(null);
+  const dragPointerIdRef = useRef<number | null>(null);
   const resizeRafRef = useRef<number | null>(null);
   const resizeDimRef = useRef<{ w: number; h: number } | null>(null);
+  const resizePointerIdRef = useRef<number | null>(null);
 
   // Default dimensions
   const DEFAULT_WIDTH = config.defaultNodeWidth ?? 15;
@@ -123,6 +125,7 @@ export const ConceptWebWidget: React.FC<WidgetComponentProps> = ({
     e.stopPropagation();
     e.currentTarget.setPointerCapture(e.pointerId);
     dragPosRef.current = { x: node.x, y: node.y };
+    dragPointerIdRef.current = e.pointerId;
     setActiveNodeId(node.id);
     setActiveNodePos({ x: node.x, y: node.y });
   };
@@ -132,17 +135,19 @@ export const ConceptWebWidget: React.FC<WidgetComponentProps> = ({
       !activeNodeId ||
       isStudentView ||
       !dragPosRef.current ||
-      !containerRef.current
+      !containerRef.current ||
+      e.pointerId !== dragPointerIdRef.current
     )
       return;
     e.stopPropagation();
 
+    const pos = dragPosRef.current;
     const rect = containerRef.current.getBoundingClientRect();
     const movementXPct = (e.movementX / rect.width) * 100;
     const movementYPct = (e.movementY / rect.height) * 100;
 
-    dragPosRef.current.x += movementXPct;
-    dragPosRef.current.y += movementYPct;
+    pos.x += movementXPct;
+    pos.y += movementYPct;
 
     if (dragRafRef.current !== null) return;
     dragRafRef.current = requestAnimationFrame(() => {
@@ -154,7 +159,13 @@ export const ConceptWebWidget: React.FC<WidgetComponentProps> = ({
   };
 
   const handleNodePointerUp = (e: React.PointerEvent<HTMLDivElement>) => {
-    if (!activeNodeId || isStudentView || !dragPosRef.current) return;
+    if (
+      !activeNodeId ||
+      isStudentView ||
+      !dragPosRef.current ||
+      e.pointerId !== dragPointerIdRef.current
+    )
+      return;
     e.stopPropagation();
     e.currentTarget.releasePointerCapture(e.pointerId);
 
@@ -163,8 +174,9 @@ export const ConceptWebWidget: React.FC<WidgetComponentProps> = ({
       dragRafRef.current = null;
     }
 
-    const finalPos = dragPosRef.current;
+    const finalPos = { ...dragPosRef.current };
     dragPosRef.current = null;
+    dragPointerIdRef.current = null;
 
     const updated = nodes.map((n) =>
       n.id === activeNodeId ? { ...n, x: finalPos.x, y: finalPos.y } : n
@@ -187,6 +199,7 @@ export const ConceptWebWidget: React.FC<WidgetComponentProps> = ({
       w: node.width ?? DEFAULT_WIDTH,
       h: node.height ?? DEFAULT_HEIGHT,
     };
+    resizePointerIdRef.current = e.pointerId;
     setResizingNodeId(node.id);
     setResizingNodeDim({
       w: node.width ?? DEFAULT_WIDTH,
@@ -199,17 +212,19 @@ export const ConceptWebWidget: React.FC<WidgetComponentProps> = ({
       !resizingNodeId ||
       isStudentView ||
       !resizeDimRef.current ||
-      !containerRef.current
+      !containerRef.current ||
+      e.pointerId !== resizePointerIdRef.current
     )
       return;
     e.stopPropagation();
 
+    const dim = resizeDimRef.current;
     const rect = containerRef.current.getBoundingClientRect();
     const movementXPct = (e.movementX / rect.width) * 100;
     const movementYPct = (e.movementY / rect.height) * 100;
 
-    resizeDimRef.current.w = Math.max(5, resizeDimRef.current.w + movementXPct);
-    resizeDimRef.current.h = Math.max(5, resizeDimRef.current.h + movementYPct);
+    dim.w = Math.max(5, dim.w + movementXPct);
+    dim.h = Math.max(5, dim.h + movementYPct);
 
     if (resizeRafRef.current !== null) return;
     resizeRafRef.current = requestAnimationFrame(() => {
@@ -221,7 +236,13 @@ export const ConceptWebWidget: React.FC<WidgetComponentProps> = ({
   };
 
   const handleResizePointerUp = (e: React.PointerEvent<HTMLElement>) => {
-    if (!resizingNodeId || isStudentView || !resizeDimRef.current) return;
+    if (
+      !resizingNodeId ||
+      isStudentView ||
+      !resizeDimRef.current ||
+      e.pointerId !== resizePointerIdRef.current
+    )
+      return;
     e.stopPropagation();
     e.currentTarget.releasePointerCapture(e.pointerId);
 
@@ -230,8 +251,9 @@ export const ConceptWebWidget: React.FC<WidgetComponentProps> = ({
       resizeRafRef.current = null;
     }
 
-    const finalDim = resizeDimRef.current;
+    const finalDim = { ...resizeDimRef.current };
     resizeDimRef.current = null;
+    resizePointerIdRef.current = null;
 
     const updated = nodes.map((n) =>
       n.id === resizingNodeId

--- a/components/widgets/ConceptWeb/Widget.tsx
+++ b/components/widgets/ConceptWeb/Widget.tsx
@@ -41,6 +41,12 @@ export const ConceptWebWidget: React.FC<WidgetComponentProps> = ({
     y: number;
   } | null>(null);
 
+  // rAF batching refs for drag and resize performance
+  const dragRafRef = useRef<number | null>(null);
+  const dragPosRef = useRef<{ x: number; y: number } | null>(null);
+  const resizeRafRef = useRef<number | null>(null);
+  const resizeDimRef = useRef<{ w: number; h: number } | null>(null);
+
   // Default dimensions
   const DEFAULT_WIDTH = config.defaultNodeWidth ?? 15;
   const DEFAULT_HEIGHT = config.defaultNodeHeight ?? 15;
@@ -116,6 +122,7 @@ export const ConceptWebWidget: React.FC<WidgetComponentProps> = ({
     bringToFront(widget.id);
     e.stopPropagation();
     e.currentTarget.setPointerCapture(e.pointerId);
+    dragPosRef.current = { x: node.x, y: node.y };
     setActiveNodeId(node.id);
     setActiveNodePos({ x: node.x, y: node.y });
   };
@@ -124,7 +131,7 @@ export const ConceptWebWidget: React.FC<WidgetComponentProps> = ({
     if (
       !activeNodeId ||
       isStudentView ||
-      !activeNodePos ||
+      !dragPosRef.current ||
       !containerRef.current
     )
       return;
@@ -134,20 +141,33 @@ export const ConceptWebWidget: React.FC<WidgetComponentProps> = ({
     const movementXPct = (e.movementX / rect.width) * 100;
     const movementYPct = (e.movementY / rect.height) * 100;
 
-    setActiveNodePos((prev) =>
-      prev ? { x: prev.x + movementXPct, y: prev.y + movementYPct } : null
-    );
+    dragPosRef.current.x += movementXPct;
+    dragPosRef.current.y += movementYPct;
+
+    if (dragRafRef.current !== null) return;
+    dragRafRef.current = requestAnimationFrame(() => {
+      dragRafRef.current = null;
+      if (dragPosRef.current) {
+        setActiveNodePos({ ...dragPosRef.current });
+      }
+    });
   };
 
   const handleNodePointerUp = (e: React.PointerEvent<HTMLDivElement>) => {
-    if (!activeNodeId || isStudentView || !activeNodePos) return;
+    if (!activeNodeId || isStudentView || !dragPosRef.current) return;
     e.stopPropagation();
     e.currentTarget.releasePointerCapture(e.pointerId);
 
+    if (dragRafRef.current !== null) {
+      cancelAnimationFrame(dragRafRef.current);
+      dragRafRef.current = null;
+    }
+
+    const finalPos = dragPosRef.current;
+    dragPosRef.current = null;
+
     const updated = nodes.map((n) =>
-      n.id === activeNodeId
-        ? { ...n, x: activeNodePos.x, y: activeNodePos.y }
-        : n
+      n.id === activeNodeId ? { ...n, x: finalPos.x, y: finalPos.y } : n
     );
     updateWidget(widget.id, { config: { ...config, nodes: updated } });
 
@@ -163,6 +183,10 @@ export const ConceptWebWidget: React.FC<WidgetComponentProps> = ({
     if (isStudentView) return;
     e.stopPropagation();
     e.currentTarget.setPointerCapture(e.pointerId);
+    resizeDimRef.current = {
+      w: node.width ?? DEFAULT_WIDTH,
+      h: node.height ?? DEFAULT_HEIGHT,
+    };
     setResizingNodeId(node.id);
     setResizingNodeDim({
       w: node.width ?? DEFAULT_WIDTH,
@@ -171,31 +195,47 @@ export const ConceptWebWidget: React.FC<WidgetComponentProps> = ({
   };
 
   const handleResizePointerMove = (e: React.PointerEvent<HTMLElement>) => {
-    if (!resizingNodeId || isStudentView || !containerRef.current) return;
+    if (
+      !resizingNodeId ||
+      isStudentView ||
+      !resizeDimRef.current ||
+      !containerRef.current
+    )
+      return;
     e.stopPropagation();
 
     const rect = containerRef.current.getBoundingClientRect();
     const movementXPct = (e.movementX / rect.width) * 100;
     const movementYPct = (e.movementY / rect.height) * 100;
 
-    setResizingNodeDim((prev) =>
-      prev
-        ? {
-            w: Math.max(5, prev.w + movementXPct),
-            h: Math.max(5, prev.h + movementYPct),
-          }
-        : null
-    );
+    resizeDimRef.current.w = Math.max(5, resizeDimRef.current.w + movementXPct);
+    resizeDimRef.current.h = Math.max(5, resizeDimRef.current.h + movementYPct);
+
+    if (resizeRafRef.current !== null) return;
+    resizeRafRef.current = requestAnimationFrame(() => {
+      resizeRafRef.current = null;
+      if (resizeDimRef.current) {
+        setResizingNodeDim({ ...resizeDimRef.current });
+      }
+    });
   };
 
   const handleResizePointerUp = (e: React.PointerEvent<HTMLElement>) => {
-    if (!resizingNodeId || isStudentView || !resizingNodeDim) return;
+    if (!resizingNodeId || isStudentView || !resizeDimRef.current) return;
     e.stopPropagation();
     e.currentTarget.releasePointerCapture(e.pointerId);
 
+    if (resizeRafRef.current !== null) {
+      cancelAnimationFrame(resizeRafRef.current);
+      resizeRafRef.current = null;
+    }
+
+    const finalDim = resizeDimRef.current;
+    resizeDimRef.current = null;
+
     const updated = nodes.map((n) =>
       n.id === resizingNodeId
-        ? { ...n, width: resizingNodeDim.w, height: resizingNodeDim.h }
+        ? { ...n, width: finalDim.w, height: finalDim.h }
         : n
     );
     updateWidget(widget.id, { config: { ...config, nodes: updated } });
@@ -414,6 +454,7 @@ export const ConceptWebWidget: React.FC<WidgetComponentProps> = ({
               backgroundColor: node.bgColor,
               fontFamily: 'inherit',
               containerType: 'size',
+              touchAction: 'none',
             }}
           >
             <textarea
@@ -464,6 +505,7 @@ export const ConceptWebWidget: React.FC<WidgetComponentProps> = ({
                     transform: 'translateX(-50%)',
                     padding: 'min(4px, 1cqmin)',
                     borderRadius: '9999px',
+                    touchAction: 'none',
                   }}
                   onPointerDown={(e) => handleHandlePointerDown(e, node.id)}
                   onPointerMove={handleHandlePointerMove}
@@ -485,6 +527,7 @@ export const ConceptWebWidget: React.FC<WidgetComponentProps> = ({
                   className="resize-handle absolute bottom-0 right-0 cursor-nwse-resize text-slate-300 hover:text-indigo-500 transition-colors"
                   style={{
                     padding: 'min(4px, 1cqmin)',
+                    touchAction: 'none',
                   }}
                   onPointerDown={(e) => handleResizePointerDown(e, node)}
                   onPointerMove={handleResizePointerMove}

--- a/components/widgets/SeatingChart/FurnitureItemRenderer.tsx
+++ b/components/widgets/SeatingChart/FurnitureItemRenderer.tsx
@@ -111,6 +111,7 @@ export const FurnitureItemRenderer = memo(
           width: displayW,
           height: displayH,
           transform: `rotate(${item.rotation}deg)`,
+          touchAction: 'none',
         }}
         className={`${furnitureClassName} ${
           mode === 'setup' ? 'cursor-move' : ''

--- a/components/widgets/stickers/DraggableSticker.tsx
+++ b/components/widgets/stickers/DraggableSticker.tsx
@@ -36,6 +36,14 @@ export const DraggableSticker: React.FC<DraggableStickerProps> = ({
   const [showMenu, setShowMenu] = useState(false);
 
   const nodeRef = useRef<HTMLDivElement>(null);
+  const cleanupRef = useRef<(() => void) | null>(null);
+
+  // Clean up any active window listeners on unmount
+  useEffect(() => {
+    return () => {
+      cleanupRef.current?.();
+    };
+  }, []);
 
   useClickOutside(nodeRef, () => {
     if (!isDragging) {
@@ -105,17 +113,19 @@ export const DraggableSticker: React.FC<DraggableStickerProps> = ({
     let hasMoved = false;
     const startPointerId = e.pointerId;
     let rafId: number | null = null;
+    let latestX = origX;
+    let latestY = origY;
 
     const onPointerMove = (ev: PointerEvent) => {
       if (ev.pointerId !== startPointerId) return;
       hasMoved = true;
       setIsDragging(true);
-      const dx = ev.clientX - startX;
-      const dy = ev.clientY - startY;
-      if (rafId !== null) cancelAnimationFrame(rafId);
+      latestX = origX + (ev.clientX - startX);
+      latestY = origY + (ev.clientY - startY);
+      if (rafId !== null) return;
       rafId = requestAnimationFrame(() => {
         rafId = null;
-        updateWidget(widget.id, { x: origX + dx, y: origY + dy });
+        updateWidget(widget.id, { x: latestX, y: latestY });
       });
     };
 
@@ -125,23 +135,30 @@ export const DraggableSticker: React.FC<DraggableStickerProps> = ({
         cancelAnimationFrame(rafId);
         rafId = null;
       }
+      // Flush final position so the last frame is never dropped
+      if (hasMoved) {
+        updateWidget(widget.id, { x: latestX, y: latestY });
+      }
       setIsDragging(false);
       try {
         captureTarget.releasePointerCapture(startPointerId);
       } catch {
         /* already released */
       }
+      cleanup();
+    };
+
+    const cleanup = () => {
       window.removeEventListener('pointermove', onPointerMove);
       window.removeEventListener('pointerup', onPointerUp);
       window.removeEventListener('pointercancel', onPointerUp);
-      if (!hasMoved) {
-        // Just a click
-      }
+      cleanupRef.current = null;
     };
 
     window.addEventListener('pointermove', onPointerMove);
     window.addEventListener('pointerup', onPointerUp);
     window.addEventListener('pointercancel', onPointerUp);
+    cleanupRef.current = cleanup;
   };
 
   const handleKeyDown = async (e: React.KeyboardEvent) => {
@@ -191,16 +208,17 @@ export const DraggableSticker: React.FC<DraggableStickerProps> = ({
     const captureTarget = e.currentTarget as HTMLElement;
     captureTarget.setPointerCapture(e.pointerId);
     let rafId: number | null = null;
+    let latestDeg = rotation;
 
     const onPointerMove = (ev: PointerEvent) => {
       if (ev.pointerId !== startPointerId) return;
       const angle = Math.atan2(ev.clientY - centerY, ev.clientX - centerX);
-      const deg = angle * (180 / Math.PI) + 90;
-      if (rafId !== null) cancelAnimationFrame(rafId);
+      latestDeg = angle * (180 / Math.PI) + 90;
+      if (rafId !== null) return;
       rafId = requestAnimationFrame(() => {
         rafId = null;
         updateWidget(widget.id, {
-          config: { ...config, rotation: deg },
+          config: { ...config, rotation: latestDeg },
         });
       });
     };
@@ -211,6 +229,10 @@ export const DraggableSticker: React.FC<DraggableStickerProps> = ({
         cancelAnimationFrame(rafId);
         rafId = null;
       }
+      // Flush final rotation
+      updateWidget(widget.id, {
+        config: { ...config, rotation: latestDeg },
+      });
       try {
         captureTarget.releasePointerCapture(startPointerId);
       } catch {
@@ -238,6 +260,8 @@ export const DraggableSticker: React.FC<DraggableStickerProps> = ({
     const captureTarget = e.currentTarget as HTMLElement;
     captureTarget.setPointerCapture(e.pointerId);
     let rafId: number | null = null;
+    let latestW = startW;
+    let latestH = startH;
 
     // Rotation in radians
     const rad = (rotation * Math.PI) / 180;
@@ -250,19 +274,15 @@ export const DraggableSticker: React.FC<DraggableStickerProps> = ({
       const dy = ev.clientY - startY;
 
       // Project screen delta onto local axes
-      // For 0 deg (cos=1, sin=0): localDx = dx, localDy = dy.
-      // For 90 deg (cos=0, sin=1): localDx = dy, localDy = -dx.
-
       const localDx = dx * cos + dy * sin;
       const localDy = -dx * sin + dy * cos;
 
-      if (rafId !== null) cancelAnimationFrame(rafId);
+      latestW = Math.max(50, startW + localDx);
+      latestH = Math.max(50, startH + localDy);
+      if (rafId !== null) return;
       rafId = requestAnimationFrame(() => {
         rafId = null;
-        updateWidget(widget.id, {
-          w: Math.max(50, startW + localDx),
-          h: Math.max(50, startH + localDy),
-        });
+        updateWidget(widget.id, { w: latestW, h: latestH });
       });
     };
 
@@ -272,6 +292,8 @@ export const DraggableSticker: React.FC<DraggableStickerProps> = ({
         cancelAnimationFrame(rafId);
         rafId = null;
       }
+      // Flush final dimensions
+      updateWidget(widget.id, { w: latestW, h: latestH });
       try {
         captureTarget.releasePointerCapture(startPointerId);
       } catch {

--- a/components/widgets/stickers/DraggableSticker.tsx
+++ b/components/widgets/stickers/DraggableSticker.tsx
@@ -90,7 +90,9 @@ export const DraggableSticker: React.FC<DraggableStickerProps> = ({
     e.stopPropagation();
 
     // Explicitly focus the sticker so it can receive keyboard events
-    (e.currentTarget as HTMLElement).focus();
+    const captureTarget = e.currentTarget as HTMLElement;
+    captureTarget.focus();
+    captureTarget.setPointerCapture(e.pointerId);
 
     setIsSelected(true);
     // Select and bring this sticker to the front on click or drag start.
@@ -101,19 +103,37 @@ export const DraggableSticker: React.FC<DraggableStickerProps> = ({
     const origX = widget.x;
     const origY = widget.y;
     let hasMoved = false;
+    const startPointerId = e.pointerId;
+    let rafId: number | null = null;
 
     const onPointerMove = (ev: PointerEvent) => {
+      if (ev.pointerId !== startPointerId) return;
       hasMoved = true;
       setIsDragging(true);
       const dx = ev.clientX - startX;
       const dy = ev.clientY - startY;
-      updateWidget(widget.id, { x: origX + dx, y: origY + dy });
+      if (rafId !== null) cancelAnimationFrame(rafId);
+      rafId = requestAnimationFrame(() => {
+        rafId = null;
+        updateWidget(widget.id, { x: origX + dx, y: origY + dy });
+      });
     };
 
-    const onPointerUp = () => {
+    const onPointerUp = (upEvent: PointerEvent) => {
+      if (upEvent.pointerId !== startPointerId) return;
+      if (rafId !== null) {
+        cancelAnimationFrame(rafId);
+        rafId = null;
+      }
       setIsDragging(false);
+      try {
+        captureTarget.releasePointerCapture(startPointerId);
+      } catch {
+        /* already released */
+      }
       window.removeEventListener('pointermove', onPointerMove);
       window.removeEventListener('pointerup', onPointerUp);
+      window.removeEventListener('pointercancel', onPointerUp);
       if (!hasMoved) {
         // Just a click
       }
@@ -121,6 +141,7 @@ export const DraggableSticker: React.FC<DraggableStickerProps> = ({
 
     window.addEventListener('pointermove', onPointerMove);
     window.addEventListener('pointerup', onPointerUp);
+    window.addEventListener('pointercancel', onPointerUp);
   };
 
   const handleKeyDown = async (e: React.KeyboardEvent) => {
@@ -166,22 +187,43 @@ export const DraggableSticker: React.FC<DraggableStickerProps> = ({
 
     const centerX = rect.left + rect.width / 2;
     const centerY = rect.top + rect.height / 2;
+    const startPointerId = e.pointerId;
+    const captureTarget = e.currentTarget as HTMLElement;
+    captureTarget.setPointerCapture(e.pointerId);
+    let rafId: number | null = null;
 
     const onPointerMove = (ev: PointerEvent) => {
+      if (ev.pointerId !== startPointerId) return;
       const angle = Math.atan2(ev.clientY - centerY, ev.clientX - centerX);
       const deg = angle * (180 / Math.PI) + 90;
-      updateWidget(widget.id, {
-        config: { ...config, rotation: deg },
+      if (rafId !== null) cancelAnimationFrame(rafId);
+      rafId = requestAnimationFrame(() => {
+        rafId = null;
+        updateWidget(widget.id, {
+          config: { ...config, rotation: deg },
+        });
       });
     };
 
-    const onPointerUp = () => {
+    const onPointerUp = (upEvent: PointerEvent) => {
+      if (upEvent.pointerId !== startPointerId) return;
+      if (rafId !== null) {
+        cancelAnimationFrame(rafId);
+        rafId = null;
+      }
+      try {
+        captureTarget.releasePointerCapture(startPointerId);
+      } catch {
+        /* already released */
+      }
       window.removeEventListener('pointermove', onPointerMove);
       window.removeEventListener('pointerup', onPointerUp);
+      window.removeEventListener('pointercancel', onPointerUp);
     };
 
     window.addEventListener('pointermove', onPointerMove);
     window.addEventListener('pointerup', onPointerUp);
+    window.addEventListener('pointercancel', onPointerUp);
   };
 
   const handleResizeStart = (e: React.PointerEvent) => {
@@ -192,6 +234,10 @@ export const DraggableSticker: React.FC<DraggableStickerProps> = ({
     const startH = widget.h;
     const startX = e.clientX;
     const startY = e.clientY;
+    const startPointerId = e.pointerId;
+    const captureTarget = e.currentTarget as HTMLElement;
+    captureTarget.setPointerCapture(e.pointerId);
+    let rafId: number | null = null;
 
     // Rotation in radians
     const rad = (rotation * Math.PI) / 180;
@@ -199,6 +245,7 @@ export const DraggableSticker: React.FC<DraggableStickerProps> = ({
     const sin = Math.sin(rad);
 
     const onPointerMove = (ev: PointerEvent) => {
+      if (ev.pointerId !== startPointerId) return;
       const dx = ev.clientX - startX;
       const dy = ev.clientY - startY;
 
@@ -209,19 +256,35 @@ export const DraggableSticker: React.FC<DraggableStickerProps> = ({
       const localDx = dx * cos + dy * sin;
       const localDy = -dx * sin + dy * cos;
 
-      updateWidget(widget.id, {
-        w: Math.max(50, startW + localDx),
-        h: Math.max(50, startH + localDy),
+      if (rafId !== null) cancelAnimationFrame(rafId);
+      rafId = requestAnimationFrame(() => {
+        rafId = null;
+        updateWidget(widget.id, {
+          w: Math.max(50, startW + localDx),
+          h: Math.max(50, startH + localDy),
+        });
       });
     };
 
-    const onPointerUp = () => {
+    const onPointerUp = (upEvent: PointerEvent) => {
+      if (upEvent.pointerId !== startPointerId) return;
+      if (rafId !== null) {
+        cancelAnimationFrame(rafId);
+        rafId = null;
+      }
+      try {
+        captureTarget.releasePointerCapture(startPointerId);
+      } catch {
+        /* already released */
+      }
       window.removeEventListener('pointermove', onPointerMove);
       window.removeEventListener('pointerup', onPointerUp);
+      window.removeEventListener('pointercancel', onPointerUp);
     };
 
     window.addEventListener('pointermove', onPointerMove);
     window.addEventListener('pointerup', onPointerUp);
+    window.addEventListener('pointercancel', onPointerUp);
   };
 
   return (

--- a/hooks/useLongPress.ts
+++ b/hooks/useLongPress.ts
@@ -1,0 +1,67 @@
+import React, { useRef, useCallback } from 'react';
+
+/** Distance in px the pointer can move before cancelling the long press. */
+const MOVE_THRESHOLD = 15;
+/** How long the pointer must be held before firing. */
+const HOLD_DELAY_MS = 600;
+
+interface UseLongPressOptions {
+  /** Skip long-press detection entirely (e.g. during edit/drag mode). */
+  disabled?: boolean;
+  /**
+   * Extra handler to invoke at the start of the press (e.g. dnd-kit listener passthrough).
+   * Accepts a generic Function to match dnd-kit's SyntheticListenerMap type.
+   */
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
+  onPointerDown?: ((e: React.PointerEvent) => void) | Function;
+}
+
+/**
+ * Returns pointer-event handlers that detect a long press while cancelling
+ * if the pointer moves beyond a threshold.  Attach `onPointerUp` to both
+ * `onPointerUp` and `onPointerLeave` on the target element.
+ */
+export function useLongPress(
+  onLongPress: () => void,
+  options?: UseLongPressOptions
+) {
+  const timerRef = useRef<NodeJS.Timeout | null>(null);
+  const startPosRef = useRef<{ x: number; y: number } | null>(null);
+
+  const clear = useCallback(() => {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+    startPosRef.current = null;
+  }, []);
+
+  const handlePointerDown = useCallback(
+    (e: React.PointerEvent) => {
+      options?.onPointerDown?.(e);
+      if (options?.disabled) return;
+      startPosRef.current = { x: e.clientX, y: e.clientY };
+      timerRef.current = setTimeout(onLongPress, HOLD_DELAY_MS);
+    },
+    [onLongPress, options]
+  );
+
+  const handlePointerMove = useCallback(
+    (e: React.PointerEvent) => {
+      const start = startPosRef.current;
+      if (!timerRef.current || !start) return;
+      const dx = e.clientX - start.x;
+      const dy = e.clientY - start.y;
+      if (dx * dx + dy * dy > MOVE_THRESHOLD * MOVE_THRESHOLD) {
+        clear();
+      }
+    },
+    [clear]
+  );
+
+  return {
+    onPointerDown: handlePointerDown,
+    onPointerUp: clear,
+    onPointerMove: handlePointerMove,
+  } as const;
+}


### PR DESCRIPTION
## Summary
- **DraggableSticker**: Added pointer capture, RAF-batched drag/rotate/resize with 'return if pending' pattern, pointerId validation, final-frame flushing on pointerUp, and unmount cleanup
- **ConceptWeb**: Introduced RAF batching with refs for node drag/resize, pointer capture, pointerId tracking for multi-touch safety, type-safe ref mutations, and `touchAction: 'none'`
- **Dock components**: Extracted duplicated long-press detection into a shared `useLongPress` hook with movement threshold cancellation
- **FurnitureItemRenderer**: Added `touchAction: 'none'` to prevent browser default touch handling

## Implementation details
- RAF batching uses the 'return if pending' pattern (latest values stored in closure variables, RAF callback reads them) for better efficiency than cancel-and-reschedule
- All pointerUp handlers flush final position/rotation/dimensions directly before cleanup, ensuring the last frame is never dropped
- `useLongPress` hook encapsulates timer management, 15px movement threshold, and dnd-kit listener passthrough
- ConceptWeb clones ref snapshots (`{ ...ref.current }`) before nullifying to prevent mutation-after-clear

## Test plan
- [ ] Drag stickers on touch and mouse — verify smooth movement, final position accuracy
- [ ] Rotate and resize stickers — verify no dropped final frame
- [ ] Long-press dock items — verify fires after hold, cancels on drag
- [ ] ConceptWeb: drag nodes, resize nodes — verify RAF-batched smoothness
- [ ] Multi-touch: start drag with one finger, touch with another — second pointer should be ignored
- [ ] Unmount during drag (e.g. switch dashboard) — verify no console errors from orphaned listeners

🤖 Generated with [Claude Code](https://claude.com/claude-code)