### PR TITLE
chore: upgrade Firebase Functions runtime to Node 24

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -6,6 +6,7 @@
   "functions": {
     "source": "functions",
     "codebase": "default",
+    "runtime": "nodejs24",
     "ignore": [
       "node_modules",
       ".git",

--- a/functions/package.json
+++ b/functions/package.json
@@ -11,7 +11,7 @@
     "logs": "firebase functions:log"
   },
   "engines": {
-    "node": "20"
+    "node": "24"
   },
   "main": "lib/index.js",
   "dependencies": {


### PR DESCRIPTION
## Summary

- Bump `functions/package.json` engines.node from `"20"` → `"24"`
- Add `"runtime": "nodejs24"` to the `functions` block in `firebase.json`

## Why now

Per `firebase-tools@15.8.0/lib/deploy/functions/runtimes/supported/types.js`:

| Runtime | Status | Deprecation | Decommission |
|---|---|---|---|
| `nodejs20` (current) | GA | **2026-04-30 (17 days)** | 2026-10-30 |
| `nodejs22` | GA | 2027-04-30 | 2028-10-31 |
| `nodejs24` (this PR) | GA | 2028-04-30 | 2028-10-31 |

Node 20 Functions runtime deprecation is imminent. Jumping straight to Node 24 aligns the server runtime with the dev environment from the parent PR and maximizes time before the next forced upgrade.

## Depends on

This branch is stacked on `dev-paul`, which already contains the Node 24 dev environment upgrade (`engines.node >=24.0.0`, `.node-version`, Dockerfile, devcontainer, CI) and the GitHub Actions runtime bumps. Targeting `dev-paul` as the base so the PR diff is just the two Functions-specific files.

## Test plan

- [x] `pnpm -C functions run type-check` — passes
- [x] `pnpm -C functions run build` (tsc) — passes
- [x] Verified `nodejs24` is GA in `firebase-tools@15.8.0`
- [ ] CI passes on `dev-paul` with action bumps (in progress)
- [ ] Deploy to preview channel via `firebase-dev-deploy.yml` — this workflow runs `firebase deploy --only functions,firestore,storage` which will be the first real validation that the runtime is accepted by our Firebase project
- [ ] Verify a callable function cold-starts and returns successfully post-deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)