### PR TITLE
Refactor drawing to separate annotation overlay from widget

### DIFF
--- a/components/admin/DrawingConfigurationPanel.test.tsx
+++ b/components/admin/DrawingConfigurationPanel.test.tsx
@@ -16,7 +16,6 @@ describe('DrawingConfigurationPanel', () => {
     buildingDefaults: {
       b1: {
         buildingId: 'b1',
-        mode: 'window',
         width: 5,
         customColors: ['#FF0000', '#00FF00', '#0000FF', '#FFFF00', '#FF00FF'],
       },
@@ -43,24 +42,14 @@ describe('DrawingConfigurationPanel', () => {
     // Check initial values
     const widthInput = screen.getByRole('slider');
     expect(widthInput).toHaveValue('5');
-
-    const windowModeButton = screen.getByText('Window').closest('button');
-    expect(windowModeButton).toBeInTheDocument();
   });
 
-  it('updates mode when clicked', () => {
+  it('does not render mode toggle (mode is now picked at click-time)', () => {
     render(
       <DrawingConfigurationPanel config={mockConfig} onChange={mockOnChange} />
     );
-
-    const overlayButton = screen
-      .getByText('Overlay (Annotate)')
-      .closest('button');
-    if (overlayButton) fireEvent.click(overlayButton);
-
-    expect(mockOnChange).toHaveBeenCalled();
-    const lastCall = mockOnChange.mock.calls[0][0] as DrawingGlobalConfig;
-    expect(lastCall.buildingDefaults['b1']?.mode).toBe('overlay');
+    expect(screen.queryByText('Overlay (Annotate)')).toBeNull();
+    expect(screen.queryByText('Default Mode')).toBeNull();
   });
 
   it('updates width when changed', () => {

--- a/components/admin/DrawingConfigurationPanel.tsx
+++ b/components/admin/DrawingConfigurationPanel.tsx
@@ -3,7 +3,7 @@ import { BUILDINGS } from '@/config/buildings';
 import { BuildingSelector } from './BuildingSelector';
 import { DrawingGlobalConfig, BuildingDrawingDefaults } from '@/types';
 import { WIDGET_PALETTE } from '@/config/colors';
-import { Maximize, Minimize, Pencil, Palette } from 'lucide-react';
+import { Pencil, Palette } from 'lucide-react';
 import { Card } from '@/components/common/Card';
 
 interface DrawingConfigurationPanelProps {
@@ -40,7 +40,6 @@ export const DrawingConfigurationPanel: React.FC<
 
   const NUM_COLOR_PRESETS = 5;
 
-  const activeMode = currentBuildingConfig.mode ?? 'window';
   const activeWidth = currentBuildingConfig.width ?? 4;
 
   // Normalize palette to exactly 5 colors
@@ -80,35 +79,6 @@ export const DrawingConfigurationPanel: React.FC<
           <b>{BUILDINGS.find((b) => b.id === selectedBuildingId)?.name}</b> adds
           it to their dashboard.
         </p>
-
-        {/* Default Mode */}
-        <div>
-          <label className="text-xxs font-bold text-slate-500 uppercase mb-2 block flex items-center gap-1.5">
-            <Maximize className="w-3 h-3" /> Default Mode
-          </label>
-          <div className="flex bg-white rounded-lg border border-slate-200 p-1">
-            <button
-              onClick={() => handleUpdateBuilding({ mode: 'window' })}
-              className={`flex-1 py-1.5 text-xxs font-bold rounded transition-colors flex items-center justify-center gap-1.5 ${
-                activeMode === 'window'
-                  ? 'bg-brand-blue-primary text-white shadow-sm'
-                  : 'text-slate-500 hover:bg-slate-50'
-              }`}
-            >
-              <Minimize className="w-3 h-3" /> Window
-            </button>
-            <button
-              onClick={() => handleUpdateBuilding({ mode: 'overlay' })}
-              className={`flex-1 py-1.5 text-xxs font-bold rounded transition-colors flex items-center justify-center gap-1.5 ${
-                activeMode === 'overlay'
-                  ? 'bg-brand-blue-primary text-white shadow-sm'
-                  : 'text-slate-500 hover:bg-slate-50'
-              }`}
-            >
-              <Maximize className="w-3 h-3" /> Overlay (Annotate)
-            </button>
-          </div>
-        </div>
 
         {/* Default Brush Thickness */}
         <div>

--- a/components/layout/AnnotationOverlay.tsx
+++ b/components/layout/AnnotationOverlay.tsx
@@ -26,6 +26,7 @@ import { extractTextWithGemini } from '@/utils/ai';
 import { TextConfig } from '@/types';
 import { DRAWING_DEFAULTS } from '@/components/widgets/DrawingWidget/constants';
 import { STANDARD_COLORS } from '@/config/colors';
+import { Z_INDEX } from '@/config/zIndex';
 
 const FALLBACK_ANNOTATION_STATE = {
   paths: [],
@@ -242,7 +243,7 @@ export const AnnotationOverlay: React.FC = () => {
   return createPortal(
     <div
       className="fixed inset-0 pointer-events-none overflow-hidden"
-      style={{ zIndex: 9910 }}
+      style={{ zIndex: Z_INDEX.overlay }}
     >
       <canvas
         ref={canvasRef}

--- a/components/layout/AnnotationOverlay.tsx
+++ b/components/layout/AnnotationOverlay.tsx
@@ -1,0 +1,388 @@
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import { createPortal } from 'react-dom';
+import { toPng } from 'html-to-image';
+import {
+  Eraser,
+  Trash2,
+  Undo2,
+  MousePointer2,
+  X,
+  Camera,
+  HardDriveUpload,
+  Type,
+} from 'lucide-react';
+import { useDashboard } from '@/context/useDashboard';
+import { useAuth } from '@/context/useAuth';
+import { useGoogleDrive } from '@/hooks/useGoogleDrive';
+import { useDrawingCanvas } from '@/components/widgets/DrawingWidget/useDrawingCanvas';
+import { Button } from '@/components/common/Button';
+import { extractTextWithGemini } from '@/utils/ai';
+import { TextConfig } from '@/types';
+import { DRAWING_DEFAULTS } from '@/components/widgets/DrawingWidget/constants';
+import { STANDARD_COLORS } from '@/config/colors';
+
+const FALLBACK_ANNOTATION_STATE = {
+  paths: [],
+  color: STANDARD_COLORS.slate,
+  width: DRAWING_DEFAULTS.WIDTH,
+  customColors: [...DRAWING_DEFAULTS.CUSTOM_COLORS],
+};
+
+/**
+ * Full-screen annotation overlay — ephemeral, NOT a widget.
+ *
+ * Renders into `#dashboard-root` above all widgets. No dimming layer: the
+ * dashboard stays visually identical, the user just gains the ability to
+ * draw over everything. The floating toolbar sits at the bottom, where the
+ * Dock normally lives (the Dock hides itself while annotation is active).
+ */
+export const AnnotationOverlay: React.FC = () => {
+  const dashboard = useDashboard();
+  const {
+    annotationActive,
+    closeAnnotation,
+    updateAnnotationState,
+    addAnnotationPath,
+    undoAnnotation,
+    clearAnnotation,
+    activeDashboard,
+    addToast,
+    updateWidget,
+    addWidget,
+  } = dashboard;
+  // Defensive fallback — older mock contexts (e.g. in unit tests) may omit
+  // annotationState; provide sensible defaults so this component never throws.
+  const annotationState =
+    dashboard.annotationState ?? FALLBACK_ANNOTATION_STATE;
+  const { canAccessFeature } = useAuth();
+  const { saveDrawingToDrive, isConnected: isDriveConnected } =
+    useGoogleDrive();
+
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const [portalTarget, setPortalTarget] = useState<HTMLElement | null>(null);
+  const [viewport, setViewport] = useState(() => ({
+    width: typeof window !== 'undefined' ? window.innerWidth : 1280,
+    height: typeof window !== 'undefined' ? window.innerHeight : 720,
+  }));
+  const [isBusy, setIsBusy] = useState<null | 'download' | 'drive' | 'ocr'>(
+    null
+  );
+
+  // Locate the dashboard root portal target (waits for mount if needed)
+  useEffect(() => {
+    if (!annotationActive) return;
+    const findTarget = () => {
+      const target = document.getElementById('dashboard-root');
+      if (target) {
+        setPortalTarget(target);
+        return true;
+      }
+      return false;
+    };
+    if (findTarget()) return undefined;
+    const observer = new MutationObserver(() => {
+      if (findTarget()) observer.disconnect();
+    });
+    observer.observe(document.body, { childList: true, subtree: true });
+    return () => observer.disconnect();
+  }, [annotationActive]);
+
+  // Track viewport size for canvas resolution
+  useEffect(() => {
+    if (!annotationActive) return undefined;
+    const handleResize = () =>
+      setViewport({ width: window.innerWidth, height: window.innerHeight });
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, [annotationActive]);
+
+  // Escape key exits annotation
+  useEffect(() => {
+    if (!annotationActive) return undefined;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') closeAnnotation();
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [annotationActive, closeAnnotation]);
+
+  const canvasSize = useMemo(
+    () => ({ width: viewport.width, height: viewport.height }),
+    [viewport.width, viewport.height]
+  );
+
+  const { handleStart, handleMove, handleEnd } = useDrawingCanvas({
+    canvasRef,
+    color: annotationState.color,
+    width: annotationState.width,
+    paths: annotationState.paths,
+    onPathComplete: addAnnotationPath,
+    scale: 1,
+    canvasSize,
+  });
+
+  const capturePng = useCallback(async (): Promise<string | null> => {
+    const root = document.getElementById('dashboard-root');
+    if (!root) return null;
+    const dataUrl = await toPng(root, {
+      cacheBust: true,
+      pixelRatio: 2,
+      filter: (node: Element) => {
+        if (!(node instanceof HTMLElement)) return true;
+        return node.dataset.screenshot !== 'exclude';
+      },
+    });
+    return dataUrl;
+  }, []);
+
+  const handleDownload = useCallback(async () => {
+    setIsBusy('download');
+    try {
+      const dataUrl = await capturePng();
+      if (!dataUrl) return;
+      const link = document.createElement('a');
+      link.download = `Annotation-${new Date().toISOString().split('T')[0]}.png`;
+      link.href = dataUrl;
+      link.click();
+      addToast('Annotation downloaded!', 'success');
+    } catch (e) {
+      console.error('Annotation download failed:', e);
+      addToast('Failed to download annotation.', 'error');
+    } finally {
+      setIsBusy(null);
+    }
+  }, [capturePng, addToast]);
+
+  const handleSaveToDrive = useCallback(async () => {
+    if (!isDriveConnected) {
+      addToast(
+        'Google Drive is not connected. Sign in to Drive first.',
+        'error'
+      );
+      return;
+    }
+    setIsBusy('drive');
+    try {
+      const dataUrl = await capturePng();
+      if (!dataUrl) return;
+      const blob = await (await fetch(dataUrl)).blob();
+      const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+      const name = `Annotation-${timestamp}.png`;
+      await saveDrawingToDrive(blob, name);
+      addToast('Annotation saved to Google Drive!', 'success');
+    } catch (e) {
+      console.error('Drive save failed:', e);
+      addToast('Failed to save to Google Drive.', 'error');
+    } finally {
+      setIsBusy(null);
+    }
+  }, [isDriveConnected, capturePng, saveDrawingToDrive, addToast]);
+
+  const handleExtractText = useCallback(async () => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    setIsBusy('ocr');
+    try {
+      addToast('Scanning handwriting...', 'info');
+      const dataUrl = canvas.toDataURL('image/png');
+      const extractedText = await extractTextWithGemini(dataUrl);
+      if (!extractedText || !extractedText.trim()) {
+        addToast('No text could be extracted.', 'info');
+        return;
+      }
+      const safeText = extractedText
+        .trim()
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#039;')
+        .replace(/\n/g, '<br/>');
+
+      const existingTextWidget = activeDashboard?.widgets.find(
+        (w) => w.type === 'text'
+      );
+      if (existingTextWidget) {
+        const currentConfig = existingTextWidget.config as TextConfig;
+        const newContent = currentConfig.content
+          ? `${currentConfig.content}<br><br>${safeText}`
+          : safeText;
+        updateWidget(existingTextWidget.id, {
+          config: { ...currentConfig, content: newContent },
+        });
+        addToast('Appended text to notes!', 'success');
+      } else {
+        addWidget('text', {
+          x: 80,
+          y: 80,
+          w: 400,
+          h: 300,
+          config: { content: safeText } as TextConfig,
+        });
+        addToast('Created new note with text!', 'success');
+      }
+    } catch (e) {
+      console.error('OCR failed:', e);
+      addToast('Failed to extract text.', 'error');
+    } finally {
+      setIsBusy(null);
+    }
+  }, [activeDashboard, addToast, addWidget, updateWidget]);
+
+  if (!annotationActive || !portalTarget) return null;
+
+  const { color, width, customColors, paths } = annotationState;
+
+  return createPortal(
+    <div
+      className="fixed inset-0 pointer-events-none overflow-hidden"
+      style={{ zIndex: 9910 }}
+    >
+      <canvas
+        ref={canvasRef}
+        onPointerDown={handleStart}
+        onPointerMove={handleMove}
+        onPointerUp={handleEnd}
+        onPointerLeave={handleEnd}
+        className="absolute inset-0 pointer-events-auto cursor-crosshair"
+        style={{ touchAction: 'none' }}
+      />
+
+      {/* Floating toolbar — sits where the Dock normally lives */}
+      <div
+        data-screenshot="exclude"
+        className="absolute bottom-6 left-1/2 -translate-x-1/2 pointer-events-auto bg-white/80 backdrop-blur-xl rounded-2xl shadow-2xl border border-white/40 p-2 flex items-center gap-2 animate-in slide-in-from-bottom duration-300"
+      >
+        <div className="px-2 flex items-center gap-2 border-r border-slate-200 mr-1">
+          <MousePointer2 className="w-4 h-4 text-indigo-600 animate-pulse" />
+          <span className="text-xxs font-black uppercase tracking-widest text-slate-700">
+            Annotating
+          </span>
+        </div>
+
+        <div className="flex gap-1 bg-slate-100 p-1 rounded-lg">
+          {customColors.map((c) => (
+            <button
+              key={c}
+              onClick={() => updateAnnotationState({ color: c })}
+              className={`w-7 h-7 rounded-md transition-all ${
+                color === c
+                  ? 'scale-110 shadow-sm ring-2 ring-indigo-500'
+                  : 'hover:scale-105'
+              }`}
+              style={{ backgroundColor: c }}
+              aria-label={`Color ${c}`}
+            />
+          ))}
+          <button
+            onClick={() => updateAnnotationState({ color: 'eraser' })}
+            className={`w-7 h-7 rounded-md bg-white border border-slate-200 flex items-center justify-center transition-all ${
+              color === 'eraser' ? 'ring-2 ring-indigo-500' : ''
+            }`}
+            aria-label="Eraser"
+          >
+            <Eraser className="w-3.5 h-3.5 text-slate-500" />
+          </button>
+        </div>
+
+        {/* Width slider */}
+        <div className="flex items-center gap-2 px-2">
+          <input
+            type="range"
+            min={1}
+            max={20}
+            step={1}
+            value={width}
+            onChange={(e) =>
+              updateAnnotationState({ width: parseInt(e.target.value, 10) })
+            }
+            className="w-20 accent-indigo-600"
+            aria-label="Brush thickness"
+          />
+          <span className="w-7 text-center font-mono text-xs text-slate-600">
+            {width}px
+          </span>
+        </div>
+
+        <div className="h-6 w-px bg-slate-200 mx-1" />
+
+        <Button
+          onClick={undoAnnotation}
+          title="Undo"
+          variant="ghost"
+          size="icon"
+          disabled={paths.length === 0}
+          icon={<Undo2 className="w-4 h-4" />}
+        />
+        <Button
+          onClick={clearAnnotation}
+          title="Clear all"
+          variant="ghost-danger"
+          size="icon"
+          disabled={paths.length === 0}
+          icon={<Trash2 className="w-4 h-4" />}
+        />
+
+        <div className="h-6 w-px bg-slate-200 mx-1" />
+
+        <Button
+          onClick={() => void handleDownload()}
+          disabled={isBusy !== null}
+          variant="ghost"
+          size="icon"
+          title="Download PNG"
+          icon={<Camera className="w-4 h-4" />}
+        />
+        <Button
+          onClick={() => void handleSaveToDrive()}
+          disabled={isBusy !== null}
+          variant="ghost"
+          size="icon"
+          title="Save to Google Drive"
+          icon={
+            isBusy === 'drive' ? (
+              <div className="w-4 h-4 border-2 border-slate-400 border-t-transparent rounded-full animate-spin" />
+            ) : (
+              <HardDriveUpload className="w-4 h-4" />
+            )
+          }
+        />
+        {canAccessFeature('gemini-functions') && (
+          <Button
+            onClick={() => void handleExtractText()}
+            disabled={isBusy !== null}
+            variant="ghost"
+            size="icon"
+            title="Extract text (AI)"
+            icon={
+              isBusy === 'ocr' ? (
+                <div className="w-4 h-4 border-2 border-slate-400 border-t-transparent rounded-full animate-spin" />
+              ) : (
+                <Type className="w-4 h-4" />
+              )
+            }
+          />
+        )}
+
+        <div className="h-6 w-px bg-slate-200 mx-1" />
+
+        <Button
+          onClick={closeAnnotation}
+          variant="secondary"
+          size="sm"
+          title="Exit annotation (Esc)"
+          icon={<X className="w-3.5 h-3.5" />}
+        >
+          Exit
+        </Button>
+      </div>
+    </div>,
+    portalTarget
+  );
+};

--- a/components/layout/DashboardView.tsx
+++ b/components/layout/DashboardView.tsx
@@ -15,6 +15,7 @@ import { useQuiz } from '@/hooks/useQuiz';
 import { useStorage, MAX_PDF_SIZE_BYTES } from '@/hooks/useStorage';
 import { Sidebar } from './sidebar/Sidebar';
 import { Dock } from './Dock';
+import { AnnotationOverlay } from './AnnotationOverlay';
 import { WidgetRenderer } from '@/components/widgets/WidgetRenderer';
 import { GroupBoundingBox } from '@/components/common/GroupBoundingBox';
 import { AnnouncementOverlay } from '@/components/announcements/AnnouncementOverlay';
@@ -150,6 +151,7 @@ export const DashboardView: React.FC = () => {
     selectedWidgetIds,
     setSelectedWidgetIds,
     selectedWidgetId,
+    annotationActive,
   } = useDashboard();
 
   const { importSharedQuiz } = useQuiz(user?.uid);
@@ -1272,7 +1274,8 @@ export const DashboardView: React.FC = () => {
 
       {/* FIXED UI: Outside the zoom container */}
       <Sidebar />
-      <Dock />
+      {!annotationActive && <Dock />}
+      <AnnotationOverlay />
       <ToastContainer />
       <AnnouncementOverlay />
       <BoardZoomControl />

--- a/components/layout/Dock.tsx
+++ b/components/layout/Dock.tsx
@@ -7,7 +7,15 @@ import React, {
 } from 'react';
 import { createPortal } from 'react-dom';
 import { useTranslation } from 'react-i18next';
-import { LayoutGrid, Puzzle, Users, Cast, Square } from 'lucide-react';
+import {
+  LayoutGrid,
+  Puzzle,
+  Users,
+  Cast,
+  Square,
+  Pencil,
+  Maximize,
+} from 'lucide-react';
 import {
   DndContext,
   closestCenter,
@@ -90,6 +98,9 @@ export const Dock: React.FC = () => {
     moveItemOutOfFolder,
     reorderFolderItems,
     addToast,
+    annotationActive,
+    openAnnotation,
+    closeAnnotation,
   } = useDashboard();
   const {
     canAccessWidget,
@@ -373,6 +384,12 @@ export const Dock: React.FC = () => {
   const classesButtonRef = useRef<HTMLButtonElement>(null);
   const remoteButtonRef = useRef<HTMLButtonElement>(null);
   const catalystButtonRef = useRef<HTMLButtonElement>(null);
+  const drawingButtonRef = useRef<HTMLButtonElement>(null);
+  const drawingPopoverRef = useRef<HTMLDivElement>(null);
+  const [showDrawingMenu, setShowDrawingMenu] = useState(false);
+  const [drawingAnchorRect, setDrawingAnchorRect] = useState<DOMRect | null>(
+    null
+  );
   const [showCatalystPicker, setShowCatalystPicker] = useState(false);
   const [catalystAnchorRect, setCatalystAnchorRect] = useState<DOMRect | null>(
     null
@@ -436,6 +453,30 @@ export const Dock: React.FC = () => {
     }
     setShowCatalystPicker((prev) => !prev);
   }, [showCatalystPicker]);
+
+  /**
+   * Draw tool click:
+   *  - If an annotation is already active, clicking Draw is a shortcut to
+   *    close it (toggle-off) without showing the picker.
+   *  - Otherwise, show a small popover so the teacher can explicitly choose
+   *    between full-screen annotation and a windowed whiteboard widget.
+   */
+  const handleToggleDrawingMenu = useCallback(() => {
+    if (annotationActive) {
+      closeAnnotation();
+      setShowDrawingMenu(false);
+      return;
+    }
+    if (!showDrawingMenu && drawingButtonRef.current) {
+      setDrawingAnchorRect(drawingButtonRef.current.getBoundingClientRect());
+    }
+    setShowDrawingMenu((prev) => !prev);
+  }, [annotationActive, closeAnnotation, showDrawingMenu]);
+
+  // Close drawing popover when clicking outside
+  useClickOutside(drawingPopoverRef, () => {
+    if (showDrawingMenu) setShowDrawingMenu(false);
+  }, [drawingButtonRef]);
 
   const handleLongPress = useCallback(() => {
     setIsEditMode(true);
@@ -624,6 +665,70 @@ export const Dock: React.FC = () => {
           onClose={() => setShowCatalystPicker(false)}
         />
       )}
+
+      {showDrawingMenu &&
+        drawingAnchorRect &&
+        createPortal(
+          <GlassCard
+            globalStyle={globalStyle}
+            ref={drawingPopoverRef}
+            style={{
+              position: 'fixed',
+              left: drawingAnchorRect.left + drawingAnchorRect.width / 2,
+              bottom: window.innerHeight - drawingAnchorRect.top + 10,
+              transform: 'translateX(-50%)',
+              zIndex: Z_INDEX.popover,
+            }}
+            className="w-64 overflow-hidden animate-in slide-in-from-bottom-2 duration-200"
+          >
+            <div className="bg-white/50 px-3 py-2 border-b border-white/30">
+              <span className="text-xxs font-black uppercase text-slate-600 tracking-wider">
+                Draw mode
+              </span>
+            </div>
+            <div className="p-2 space-y-1">
+              <button
+                onClick={() => {
+                  setShowDrawingMenu(false);
+                  openAnnotation();
+                }}
+                className="w-full flex items-start gap-3 p-2.5 hover:bg-white/60 rounded-lg transition-colors text-left"
+              >
+                <div className="shrink-0 w-9 h-9 rounded-lg bg-brand-blue-primary/10 text-brand-blue-primary flex items-center justify-center">
+                  <Maximize className="w-5 h-5" />
+                </div>
+                <div className="min-w-0">
+                  <div className="text-sm font-bold text-slate-800">
+                    Annotate screen
+                  </div>
+                  <div className="text-xxs text-slate-500 leading-tight">
+                    Draw over everything. Ephemeral — closes cleanly.
+                  </div>
+                </div>
+              </button>
+              <button
+                onClick={() => {
+                  setShowDrawingMenu(false);
+                  addWidget('drawing');
+                }}
+                className="w-full flex items-start gap-3 p-2.5 hover:bg-white/60 rounded-lg transition-colors text-left"
+              >
+                <div className="shrink-0 w-9 h-9 rounded-lg bg-cyan-500/10 text-cyan-600 flex items-center justify-center">
+                  <Pencil className="w-5 h-5" />
+                </div>
+                <div className="min-w-0">
+                  <div className="text-sm font-bold text-slate-800">
+                    Open whiteboard
+                  </div>
+                  <div className="text-xxs text-slate-500 leading-tight">
+                    Add a windowed whiteboard widget to your board.
+                  </div>
+                </div>
+              </button>
+            </div>
+          </GlassCard>,
+          document.body
+        )}
 
       {imagePastePending !== null && (
         <ImagePastePickerModal
@@ -938,6 +1043,41 @@ export const Dock: React.FC = () => {
                                   : undefined
                               }
                               buttonRef={catalystButtonRef}
+                            />
+                          );
+                        }
+
+                        // Handle "drawing" with a mode-picker popover
+                        // (Annotate screen vs Open whiteboard)
+                        if (item.toolType === 'drawing') {
+                          const minimizedDrawing =
+                            minimizedWidgetsByType['drawing'] ?? [];
+                          return (
+                            <ToolDockItem
+                              key={tool.type}
+                              tool={tool}
+                              minimizedWidgets={minimizedDrawing}
+                              onAdd={handleToggleDrawingMenu}
+                              onRestore={(id) =>
+                                updateWidget(id, { minimized: false })
+                              }
+                              onDelete={(id) => removeWidget(id)}
+                              onDeleteAll={() =>
+                                removeWidgets(minimizedDrawing.map((w) => w.id))
+                              }
+                              onRemoveFromDock={() =>
+                                toggleToolVisibility(tool.type)
+                              }
+                              isEditMode={isEditMode}
+                              onLongPress={handleLongPress}
+                              globalStyle={globalStyle}
+                              customLabel={getToolLabel(tool.type)}
+                              onClickOverride={
+                                minimizedDrawing.length === 0
+                                  ? handleToggleDrawingMenu
+                                  : undefined
+                              }
+                              buttonRef={drawingButtonRef}
                             />
                           );
                         }

--- a/components/student/StudentContexts.tsx
+++ b/components/student/StudentContexts.tsx
@@ -266,6 +266,32 @@ const mockDashboard: DashboardContextValue = {
   setActiveRoster: () => {
     // No-op
   },
+  // Annotation (app-level overlay) — not applicable in student view
+  annotationActive: false,
+  annotationState: {
+    paths: [],
+    color: '#000000',
+    width: 4,
+    customColors: ['#000000', '#ffffff', '#ff0000', '#00ff00', '#0000ff'],
+  },
+  openAnnotation: () => {
+    // No-op
+  },
+  closeAnnotation: () => {
+    // No-op
+  },
+  updateAnnotationState: () => {
+    // No-op
+  },
+  addAnnotationPath: () => {
+    // No-op
+  },
+  undoAnnotation: () => {
+    // No-op
+  },
+  clearAnnotation: () => {
+    // No-op
+  },
 };
 
 export const StudentProvider: React.FC<StudentProviderProps> = ({

--- a/components/widgets/DrawingWidget/Settings.tsx
+++ b/components/widgets/DrawingWidget/Settings.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useDashboard } from '@/context/useDashboard';
 import { WidgetData, DrawingConfig } from '@/types';
-import { Pencil, Palette, Minimize, Maximize } from 'lucide-react';
+import { Pencil, Palette } from 'lucide-react';
 import { SettingsLabel } from '@/components/common/SettingsLabel';
 import { DRAWING_DEFAULTS } from './constants';
 
@@ -73,29 +73,11 @@ export const DrawingSettings: React.FC<{ widget: WidgetData }> = ({
       </div>
 
       <div className="p-4 bg-indigo-50 rounded-2xl border border-indigo-100">
-        <h4 className="text-xxs  text-indigo-700 uppercase mb-2">
-          Modes Guide
-        </h4>
-        <div className="space-y-3">
-          <div className="flex gap-3">
-            <div className="w-5 h-5 bg-white rounded-md flex items-center justify-center shadow-sm shrink-0">
-              <Minimize className="w-3 h-3 text-indigo-600" />
-            </div>
-            <p className="text-xxs text-indigo-600 ">
-              <b>Window:</b> Standard canvas inside the widget box. Best for
-              quick sketches and notes.
-            </p>
-          </div>
-          <div className="flex gap-3">
-            <div className="w-5 h-5 bg-indigo-600 rounded-md flex items-center justify-center shadow-sm shrink-0">
-              <Maximize className="w-3 h-3 text-white" />
-            </div>
-            <p className="text-xxs text-indigo-600 ">
-              <b>Overlay:</b> Hides the window and moves the toolbar to the top
-              of your screen. Perfect for drawing over other content!
-            </p>
-          </div>
-        </div>
+        <p className="text-xxs text-indigo-600 leading-relaxed">
+          <b>Tip:</b> To annotate over your whole dashboard, click the Draw icon
+          in the Dock and choose <b>Annotate screen</b>. The whiteboard widget
+          here is best for persistent sketches and notes.
+        </p>
       </div>
     </div>
   );

--- a/components/widgets/DrawingWidget/Widget.test.tsx
+++ b/components/widgets/DrawingWidget/Widget.test.tsx
@@ -4,8 +4,6 @@ import { DrawingWidget } from './Widget';
 import { WidgetData, DrawingConfig } from '@/types';
 import { useDashboard } from '@/context/useDashboard';
 import { useAuth } from '@/context/useAuth';
-import { useLiveSession } from '@/hooks/useLiveSession';
-import { useScreenshot } from '@/hooks/useScreenshot';
 
 // Mock hooks
 vi.mock('../../../context/useDashboard', () => ({
@@ -13,12 +11,6 @@ vi.mock('../../../context/useDashboard', () => ({
 }));
 vi.mock('../../../context/useAuth', () => ({
   useAuth: vi.fn(),
-}));
-vi.mock('../../../hooks/useLiveSession', () => ({
-  useLiveSession: vi.fn(),
-}));
-vi.mock('../../../hooks/useScreenshot', () => ({
-  useScreenshot: vi.fn(),
 }));
 
 interface MockContext {
@@ -43,20 +35,13 @@ describe('DrawingWidget', () => {
     mockUpdateWidget = vi.fn();
     (useDashboard as Mock).mockReturnValue({
       updateWidget: mockUpdateWidget,
-      activeDashboard: { background: 'bg-slate-900' },
+      activeDashboard: { background: 'bg-slate-900', widgets: [] },
+      addToast: vi.fn(),
+      addWidget: vi.fn(),
     });
     (useAuth as Mock).mockReturnValue({
       user: { uid: 'user1' },
       canAccessFeature: vi.fn(() => true),
-    });
-    (useLiveSession as Mock).mockReturnValue({
-      session: null,
-      startSession: vi.fn(),
-      endSession: vi.fn(),
-    });
-    (useScreenshot as Mock).mockReturnValue({
-      takeScreenshot: vi.fn(),
-      isCapturing: false,
     });
 
     // Mock Canvas
@@ -107,17 +92,30 @@ describe('DrawingWidget', () => {
     z: 1,
     flipped: false,
     config: {
-      mode: 'window',
       color: '#000000',
       width: 4,
       paths: [],
       customColors: ['#000000', '#ffffff', '#ff0000', '#00ff00', '#0000ff'],
-    },
+    } as DrawingConfig,
   };
 
   it('renders without crashing', () => {
     render(<DrawingWidget widget={widget} />);
     expect(mockContext.clearRect).toHaveBeenCalled();
+  });
+
+  it('no longer renders the Assign (Cast) or Save-to-Cloud buttons', () => {
+    const { container } = render(<DrawingWidget widget={widget} />);
+    // Previously the overlay-mode toolbar included buttons titled "Assign..."
+    // and "Save to Cloud". Those were removed in the annotation overhaul.
+    expect(container.querySelector('[title*="Assign"]')).toBeNull();
+    expect(container.querySelector('[title*="Save to Cloud"]')).toBeNull();
+  });
+
+  it('no longer renders the ANNOTATE / EXIT mode toggle', () => {
+    const { container } = render(<DrawingWidget widget={widget} />);
+    // Mode toggle moved to dock-level popover
+    expect(container.textContent).not.toMatch(/ANNOTATE|EXIT/);
   });
 
   it('draws existing paths on mount', () => {

--- a/components/widgets/DrawingWidget/Widget.tsx
+++ b/components/widgets/DrawingWidget/Widget.tsx
@@ -47,7 +47,7 @@ export const DrawingWidget: React.FC<{
     });
   };
 
-  const { handleStart, handleMove, handleEnd } = useDrawingCanvas({
+  const { handleStart, handleMove, handleEnd, isDrawing } = useDrawingCanvas({
     canvasRef,
     color,
     width,
@@ -215,7 +215,7 @@ export const DrawingWidget: React.FC<{
           className="absolute inset-0"
           style={{ touchAction: 'none' }}
         />
-        {paths.length === 0 && (
+        {paths.length === 0 && !isDrawing && (
           <div className="absolute inset-0 flex items-center justify-center pointer-events-none text-slate-400">
             <Pencil className="w-8 h-8 opacity-20" />
           </div>

--- a/components/widgets/DrawingWidget/Widget.tsx
+++ b/components/widgets/DrawingWidget/Widget.tsx
@@ -1,27 +1,13 @@
-import React, { useState, useRef, useEffect, useCallback } from 'react';
-import { createPortal } from 'react-dom';
+import React, { useMemo, useRef, useState } from 'react';
 import { useDashboard } from '@/context/useDashboard';
-import { WidgetData, DrawingConfig, Point, Path, TextConfig } from '@/types';
-import {
-  Pencil,
-  Eraser,
-  Trash2,
-  Maximize,
-  Undo2,
-  MousePointer2,
-  Minimize2,
-  Camera,
-  Cast,
-  CloudUpload,
-  Type,
-} from 'lucide-react';
-import { useScreenshot } from '@/hooks/useScreenshot';
+import { WidgetData, DrawingConfig, Path, TextConfig } from '@/types';
+import { Pencil, Eraser, Trash2, Undo2, Type } from 'lucide-react';
 import { extractTextWithGemini } from '@/utils/ai';
 import { useAuth } from '@/context/useAuth';
-import { useLiveSession } from '@/hooks/useLiveSession';
 import { Button } from '@/components/common/Button';
 import { STANDARD_COLORS } from '@/config/colors';
 import { DRAWING_DEFAULTS } from './constants';
+import { useDrawingCanvas } from './useDrawingCanvas';
 
 export const DrawingWidget: React.FC<{
   widget: WidgetData;
@@ -29,50 +15,10 @@ export const DrawingWidget: React.FC<{
   scale?: number;
 }> = ({ widget, isStudentView = false, scale = 1 }) => {
   const { updateWidget, activeDashboard, addToast, addWidget } = useDashboard();
-  const { user, canAccessFeature } = useAuth();
-  const { session, startSession, endSession } = useLiveSession(
-    user?.uid,
-    'teacher'
-  );
-
-  const isLive = session?.isActive && session?.activeWidgetId === widget.id;
-
-  const handleToggleLive = async () => {
-    try {
-      if (isLive) {
-        await endSession();
-      } else {
-        const newSession = await startSession(
-          widget.id,
-          widget.type,
-          widget.config,
-          activeDashboard?.background
-        );
-        const url = `${window.location.origin}/join?code=${newSession.code}`;
-        if (typeof navigator !== 'undefined' && navigator.clipboard) {
-          void navigator.clipboard
-            .writeText(url)
-            .then(() =>
-              addToast('Assignment link copied to clipboard!', 'success')
-            )
-            .catch(() =>
-              addToast(
-                'Assignment created, but link could not be copied.',
-                'info'
-              )
-            );
-        } else {
-          addToast('Assignment created, but link could not be copied.', 'info');
-        }
-      }
-    } catch (error) {
-      console.error('Failed to toggle live session:', error);
-    }
-  };
+  const { canAccessFeature } = useAuth();
 
   const config = widget.config as DrawingConfig;
   const {
-    mode = DRAWING_DEFAULTS.MODE,
     color = STANDARD_COLORS.slate,
     width = DRAWING_DEFAULTS.WIDTH,
     paths = [],
@@ -80,202 +26,47 @@ export const DrawingWidget: React.FC<{
   } = config;
 
   const canvasRef = useRef<HTMLCanvasElement>(null);
-  const [isDrawing, setIsDrawing] = useState(false);
   const [isExtracting, setIsExtracting] = useState(false);
-  const currentPathRef = useRef<Point[]>([]);
-  const [portalTarget, setPortalTarget] = useState<HTMLElement | null>(null);
 
-  useEffect(() => {
-    // Try to find the target immediately, but also use a MutationObserver or a small delay
-    // if it's not found, to handle cases where DashboardView hasn't mounted yet.
-    const findTarget = () => {
-      const target = document.getElementById('dashboard-root');
-      if (target) {
-        setPortalTarget(target);
-        return true;
-      }
-      return false;
-    };
-
-    if (!findTarget()) {
-      const observer = new MutationObserver(() => {
-        if (findTarget()) observer.disconnect();
-      });
-      observer.observe(document.body, { childList: true, subtree: true });
-      return () => observer.disconnect();
+  // Canvas internal resolution follows the widget (minus header) in window mode,
+  // or the parent container in student view.
+  const canvasSize = useMemo(() => {
+    if (isStudentView) {
+      // Student view sizes canvas to its container; fall back to widget dims.
+      return { width: widget.w, height: widget.h };
     }
-    return undefined;
-  }, []);
+    return { width: widget.w, height: Math.max(widget.h - 40, 0) };
+  }, [isStudentView, widget.w, widget.h]);
 
-  const { takeScreenshot, isCapturing } = useScreenshot(
-    portalTarget,
-    `Classroom-Annotation-${new Date().toISOString().split('T')[0]}`,
-    {
-      onSuccess: (url) => {
-        if (url) {
-          addToast('Drawing saved to cloud!', 'success');
-        }
-      },
-    }
-  );
-
-  const setContextStyles = useCallback(
-    (ctx: CanvasRenderingContext2D) => {
-      ctx.lineCap = 'round';
-      ctx.lineJoin = 'round';
-      if (color === 'eraser') {
-        ctx.globalCompositeOperation = 'destination-out';
-        ctx.strokeStyle = 'rgba(0,0,0,1)';
-      } else {
-        ctx.globalCompositeOperation = 'source-over';
-        ctx.strokeStyle = color;
-      }
-      ctx.lineWidth = width;
-    },
-    [color, width]
-  );
-
-  // Draw paths on the canvas whenever they change
-  const draw = useCallback(
-    (ctx: CanvasRenderingContext2D, allPaths: Path[], current: Point[]) => {
-      ctx.clearRect(0, 0, ctx.canvas.width, ctx.canvas.height);
-
-      const renderPath = (p: Path) => {
-        if (p.points.length < 2) return;
-        ctx.beginPath();
-        ctx.lineCap = 'round';
-        ctx.lineJoin = 'round';
-
-        if (p.color === 'eraser') {
-          ctx.globalCompositeOperation = 'destination-out';
-          ctx.strokeStyle = 'rgba(0,0,0,1)';
-        } else {
-          ctx.globalCompositeOperation = 'source-over';
-          ctx.strokeStyle = p.color;
-        }
-
-        ctx.lineWidth = p.width;
-        ctx.moveTo(p.points[0].x, p.points[0].y);
-        for (let i = 1; i < p.points.length; i++) {
-          ctx.lineTo(p.points[i].x, p.points[i].y);
-        }
-        ctx.stroke();
-        ctx.globalCompositeOperation = 'source-over';
-      };
-
-      allPaths.forEach(renderPath);
-      if (current.length > 1) {
-        renderPath({ points: current, color, width });
-      }
-    },
-    [color, width]
-  );
-
-  useEffect(() => {
-    const canvas = canvasRef.current;
-    if (!canvas) return;
-    const ctx = canvas.getContext('2d');
-    if (!ctx) return;
-
-    // Set internal resolution
-    if (mode === 'window') {
-      if (isStudentView) {
-        // Fill the student container
-        const container = canvas.parentElement;
-        canvas.width = container?.clientWidth ?? 800;
-        canvas.height = container?.clientHeight ?? 600;
-      } else {
-        canvas.width = widget.w;
-        canvas.height = widget.h - 40; // Subtract header
-      }
-    } else {
-      canvas.width = window.innerWidth;
-      canvas.height = window.innerHeight;
-    }
-
-    draw(ctx, paths, currentPathRef.current);
-  }, [paths, mode, widget.w, widget.h, draw, isStudentView]);
-
-  const handleStart = (e: React.PointerEvent) => {
-    if (isStudentView) return;
-    setIsDrawing(true);
-    const pos = getPos(e);
-    currentPathRef.current = [pos];
-
-    // Start imperative drawing
-    const ctx = canvasRef.current?.getContext('2d');
-    if (ctx) {
-      setContextStyles(ctx);
-      ctx.beginPath();
-      ctx.moveTo(pos.x, pos.y);
-    }
-  };
-
-  const handleMove = (e: React.PointerEvent) => {
-    if (isStudentView || !isDrawing) return;
-    const pos = getPos(e);
-    currentPathRef.current.push(pos);
-
-    // Imperatively draw the new segment
-    const ctx = canvasRef.current?.getContext('2d');
-    if (ctx && currentPathRef.current.length > 1) {
-      // Ensure styles are set (in case they were lost or reset)
-      setContextStyles(ctx);
-
-      const prev = currentPathRef.current[currentPathRef.current.length - 2];
-      ctx.beginPath();
-      ctx.moveTo(prev.x, prev.y);
-      ctx.lineTo(pos.x, pos.y);
-      ctx.stroke();
-    }
-  };
-
-  const handleEnd = () => {
-    if (!isDrawing) return;
-    setIsDrawing(false);
-    if (currentPathRef.current.length > 1) {
-      const newPath: Path = { points: currentPathRef.current, color, width };
-      updateWidget(widget.id, {
-        config: {
-          ...config,
-          paths: [...paths, newPath],
-        } as DrawingConfig,
-      });
-    }
-    currentPathRef.current = [];
-  };
-
-  const getPos = (e: React.PointerEvent): Point => {
-    const canvas = canvasRef.current;
-    if (!canvas) {
-      return { x: 0, y: 0 };
-    }
-    const rect = canvas.getBoundingClientRect();
-    // When in window mode, we must account for the CSS transform scale applied by the parent ScalableWidget
-    // In overlay mode, the canvas is portalled to the root and is not scaled.
-    const effectiveScale = mode === 'overlay' ? 1 : scale;
-
-    return {
-      x: (e.clientX - rect.left) / effectiveScale,
-      y: (e.clientY - rect.top) / effectiveScale,
-    };
-  };
-
-  const clear = () => {
+  const appendPath = (path: Path) => {
     updateWidget(widget.id, {
       config: {
         ...config,
-        paths: [],
+        paths: [...paths, path],
       } as DrawingConfig,
+    });
+  };
+
+  const { handleStart, handleMove, handleEnd } = useDrawingCanvas({
+    canvasRef,
+    color,
+    width,
+    paths,
+    onPathComplete: appendPath,
+    scale,
+    disabled: isStudentView,
+    canvasSize,
+  });
+
+  const clear = () => {
+    updateWidget(widget.id, {
+      config: { ...config, paths: [] } as DrawingConfig,
     });
   };
 
   const undo = () => {
     updateWidget(widget.id, {
-      config: {
-        ...config,
-        paths: paths.slice(0, -1),
-      } as DrawingConfig,
+      config: { ...config, paths: paths.slice(0, -1) } as DrawingConfig,
     });
   };
 
@@ -348,26 +139,22 @@ export const DrawingWidget: React.FC<{
             key={c}
             onClick={() =>
               updateWidget(widget.id, {
-                config: {
-                  ...config,
-                  color: c,
-                } as DrawingConfig,
+                config: { ...config, color: c } as DrawingConfig,
               })
             }
             className={`w-6 h-6 rounded-md transition-all ${color === c ? 'scale-110 shadow-sm ring-2 ring-indigo-500' : 'hover:scale-105'}`}
             style={{ backgroundColor: c }}
+            aria-label={`Color ${c}`}
           />
         ))}
         <button
           onClick={() =>
             updateWidget(widget.id, {
-              config: {
-                ...config,
-                color: 'eraser',
-              } as DrawingConfig,
+              config: { ...config, color: 'eraser' } as DrawingConfig,
             })
           }
           className={`w-6 h-6 rounded-md bg-white border border-slate-200 flex items-center justify-center transition-all ${color === 'eraser' ? 'ring-2 ring-indigo-500' : ''}`}
+          aria-label="Eraser"
         >
           <Eraser className="w-3 h-3 text-slate-400" />
         </button>
@@ -390,132 +177,27 @@ export const DrawingWidget: React.FC<{
         icon={<Trash2 className="w-4 h-4" />}
       />
 
-      <div className="h-6 w-px bg-slate-200 mx-1" />
-
-      {mode === 'overlay' && (
+      {canAccessFeature('gemini-functions') && (
         <>
-          <Button
-            onClick={() => void handleToggleLive()}
-            variant={isLive ? 'danger' : 'ghost'}
-            size="icon"
-            className={isLive ? 'animate-pulse' : ''}
-            title={isLive ? 'End Assignment' : 'Assign (copy student link)'}
-            icon={<Cast className="w-4 h-4" />}
-          />
-          <Button
-            onClick={() => void takeScreenshot()}
-            disabled={isCapturing}
-            variant="ghost"
-            size="icon"
-            title="Capture Full Screen"
-            icon={<Camera className="w-4 h-4" />}
-          />
-          <Button
-            onClick={() => void takeScreenshot({ upload: true })}
-            disabled={isCapturing}
-            variant="ghost"
-            size="icon"
-            title="Save to Cloud"
-            icon={<CloudUpload className="w-4 h-4" />}
-          />
-          {canAccessFeature('gemini-functions') && (
-            <Button
-              onClick={() => void handleSendToText()}
-              disabled={isCapturing || isExtracting}
-              variant="ghost"
-              size="icon"
-              title="Extract Text (AI)"
-              icon={
-                isExtracting ? (
-                  <div className="w-4 h-4 border-2 border-slate-400 border-t-transparent rounded-full animate-spin" />
-                ) : (
-                  <Type className="w-4 h-4" />
-                )
-              }
-            />
-          )}
           <div className="h-6 w-px bg-slate-200 mx-1" />
+          <Button
+            onClick={() => void handleSendToText()}
+            disabled={isExtracting}
+            variant="ghost"
+            size="icon"
+            title="Extract Text (AI)"
+            icon={
+              isExtracting ? (
+                <div className="w-4 h-4 border-2 border-slate-400 border-t-transparent rounded-full animate-spin" />
+              ) : (
+                <Type className="w-4 h-4" />
+              )
+            }
+          />
         </>
       )}
-
-      <Button
-        onClick={() =>
-          updateWidget(widget.id, {
-            config: {
-              ...config,
-              mode: mode === 'window' ? 'overlay' : 'window',
-            } as DrawingConfig,
-          })
-        }
-        variant={mode === 'overlay' ? 'primary' : 'secondary'}
-        size="sm"
-        className={mode === 'overlay' ? 'shadow-lg' : ''}
-        icon={
-          mode === 'overlay' ? (
-            <Minimize2 className="w-3 h-3" />
-          ) : (
-            <Maximize className="w-3 h-3" />
-          )
-        }
-      >
-        {mode === 'overlay' ? (
-          <span>EXIT</span>
-        ) : (
-          widget.w > 250 && <span>ANNOTATE</span>
-        )}
-      </Button>
     </div>
   );
-
-  if (mode === 'overlay') {
-    // Show loading state while waiting for portal target
-    if (!portalTarget) {
-      return (
-        <div className="h-full flex items-center justify-center bg-slate-50">
-          <div className="text-center space-y-2">
-            <div className="w-8 h-8 border-4 border-indigo-600 border-t-transparent rounded-full animate-spin mx-auto" />
-            <p className="text-xs text-slate-500 ">Preparing overlay mode...</p>
-          </div>
-        </div>
-      );
-    }
-
-    return (
-      <>
-        {createPortal(
-          <div className="fixed inset-0 z-overlay pointer-events-none overflow-hidden">
-            {/* Darken background slightly to indicate annotation mode */}
-            <div className="absolute inset-0 bg-slate-900/10 pointer-events-none" />
-            <canvas
-              ref={canvasRef}
-              onPointerDown={handleStart}
-              onPointerMove={handleMove}
-              onPointerUp={handleEnd}
-              onPointerLeave={handleEnd}
-              className="absolute inset-0 pointer-events-auto cursor-crosshair"
-              style={{ touchAction: 'none' }}
-            />
-            {/* Floating Toolbar at the Top */}
-            {!isStudentView && (
-              <div
-                data-screenshot="exclude"
-                className="absolute top-6 left-1/2 -translate-x-1/2 pointer-events-auto bg-white/60 backdrop-blur-xl rounded-2xl shadow-2xl border border-white/40 p-1 flex items-center gap-1 animate-in slide-in-from-top duration-300"
-              >
-                <div className="px-3 flex items-center gap-2 border-r border-white/30 mr-1">
-                  <MousePointer2 className="w-4 h-4 text-indigo-600 animate-pulse" />
-                  <span className="text-xxs  font-black uppercase tracking-widest text-slate-700">
-                    Annotating
-                  </span>
-                </div>
-                {PaletteUI}
-              </div>
-            )}
-          </div>,
-          portalTarget
-        )}
-      </>
-    );
-  }
 
   return (
     <div className="h-full flex flex-col overflow-hidden">
@@ -533,7 +215,7 @@ export const DrawingWidget: React.FC<{
           className="absolute inset-0"
           style={{ touchAction: 'none' }}
         />
-        {paths.length === 0 && !isDrawing && (
+        {paths.length === 0 && (
           <div className="absolute inset-0 flex items-center justify-center pointer-events-none text-slate-400">
             <Pencil className="w-8 h-8 opacity-20" />
           </div>

--- a/components/widgets/DrawingWidget/constants.ts
+++ b/components/widgets/DrawingWidget/constants.ts
@@ -3,5 +3,4 @@ import { WIDGET_PALETTE } from '@/config/colors';
 export const DRAWING_DEFAULTS = {
   WIDTH: 4,
   CUSTOM_COLORS: WIDGET_PALETTE.slice(0, 5),
-  MODE: 'window' as const,
 };

--- a/components/widgets/DrawingWidget/useDrawingCanvas.ts
+++ b/components/widgets/DrawingWidget/useDrawingCanvas.ts
@@ -1,0 +1,171 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { Point, Path } from '@/types';
+
+interface UseDrawingCanvasOptions {
+  canvasRef: React.RefObject<HTMLCanvasElement | null>;
+  color: string;
+  width: number;
+  paths: Path[];
+  onPathComplete: (path: Path) => void;
+  /** CSS transform scale applied to the canvas by a parent ScalableWidget.
+   *  Pass `1` for full-viewport overlays where no parent scaling applies. */
+  scale?: number;
+  /** If true, pointer events are ignored (e.g. student read-only view). */
+  disabled?: boolean;
+  /** Internal canvas resolution. Re-applies on change. */
+  canvasSize: { width: number; height: number };
+}
+
+interface UseDrawingCanvasResult {
+  handleStart: (e: React.PointerEvent) => void;
+  handleMove: (e: React.PointerEvent) => void;
+  handleEnd: () => void;
+  isDrawing: boolean;
+}
+
+/**
+ * Shared canvas-drawing logic for the DrawingWidget and the AnnotationOverlay.
+ * Handles stroke rendering, pointer handling, and history-on-path-complete.
+ * The caller owns the paths state and history semantics.
+ */
+export const useDrawingCanvas = ({
+  canvasRef,
+  color,
+  width,
+  paths,
+  onPathComplete,
+  scale = 1,
+  disabled = false,
+  canvasSize,
+}: UseDrawingCanvasOptions): UseDrawingCanvasResult => {
+  const [isDrawing, setIsDrawing] = useState(false);
+  const currentPathRef = useRef<Point[]>([]);
+
+  const setContextStyles = useCallback(
+    (ctx: CanvasRenderingContext2D) => {
+      ctx.lineCap = 'round';
+      ctx.lineJoin = 'round';
+      if (color === 'eraser') {
+        ctx.globalCompositeOperation = 'destination-out';
+        ctx.strokeStyle = 'rgba(0,0,0,1)';
+      } else {
+        ctx.globalCompositeOperation = 'source-over';
+        ctx.strokeStyle = color;
+      }
+      ctx.lineWidth = width;
+    },
+    [color, width]
+  );
+
+  const draw = useCallback(
+    (ctx: CanvasRenderingContext2D, allPaths: Path[], current: Point[]) => {
+      ctx.clearRect(0, 0, ctx.canvas.width, ctx.canvas.height);
+
+      const renderPath = (p: Path) => {
+        if (p.points.length < 2) return;
+        ctx.beginPath();
+        ctx.lineCap = 'round';
+        ctx.lineJoin = 'round';
+
+        if (p.color === 'eraser') {
+          ctx.globalCompositeOperation = 'destination-out';
+          ctx.strokeStyle = 'rgba(0,0,0,1)';
+        } else {
+          ctx.globalCompositeOperation = 'source-over';
+          ctx.strokeStyle = p.color;
+        }
+
+        ctx.lineWidth = p.width;
+        ctx.moveTo(p.points[0].x, p.points[0].y);
+        for (let i = 1; i < p.points.length; i++) {
+          ctx.lineTo(p.points[i].x, p.points[i].y);
+        }
+        ctx.stroke();
+        ctx.globalCompositeOperation = 'source-over';
+      };
+
+      allPaths.forEach(renderPath);
+      if (current.length > 1) {
+        renderPath({ points: current, color, width });
+      }
+    },
+    [color, width]
+  );
+
+  // Apply canvas resolution + redraw on size or paths change
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+
+    if (canvas.width !== canvasSize.width) canvas.width = canvasSize.width;
+    if (canvas.height !== canvasSize.height) canvas.height = canvasSize.height;
+
+    draw(ctx, paths, currentPathRef.current);
+  }, [canvasRef, canvasSize.width, canvasSize.height, paths, draw]);
+
+  const getPos = useCallback(
+    (e: React.PointerEvent): Point => {
+      const canvas = canvasRef.current;
+      if (!canvas) return { x: 0, y: 0 };
+      const rect = canvas.getBoundingClientRect();
+      return {
+        x: (e.clientX - rect.left) / scale,
+        y: (e.clientY - rect.top) / scale,
+      };
+    },
+    [canvasRef, scale]
+  );
+
+  const handleStart = useCallback(
+    (e: React.PointerEvent) => {
+      if (disabled) return;
+      setIsDrawing(true);
+      const pos = getPos(e);
+      currentPathRef.current = [pos];
+
+      const ctx = canvasRef.current?.getContext('2d');
+      if (ctx) {
+        setContextStyles(ctx);
+        ctx.beginPath();
+        ctx.moveTo(pos.x, pos.y);
+      }
+    },
+    [disabled, getPos, canvasRef, setContextStyles]
+  );
+
+  const handleMove = useCallback(
+    (e: React.PointerEvent) => {
+      if (disabled || !isDrawing) return;
+      const pos = getPos(e);
+      currentPathRef.current.push(pos);
+
+      const ctx = canvasRef.current?.getContext('2d');
+      if (ctx && currentPathRef.current.length > 1) {
+        setContextStyles(ctx);
+        const prev = currentPathRef.current[currentPathRef.current.length - 2];
+        ctx.beginPath();
+        ctx.moveTo(prev.x, prev.y);
+        ctx.lineTo(pos.x, pos.y);
+        ctx.stroke();
+      }
+    },
+    [disabled, isDrawing, getPos, canvasRef, setContextStyles]
+  );
+
+  const handleEnd = useCallback(() => {
+    if (!isDrawing) return;
+    setIsDrawing(false);
+    if (currentPathRef.current.length > 1) {
+      onPathComplete({
+        points: currentPathRef.current,
+        color,
+        width,
+      });
+    }
+    currentPathRef.current = [];
+  }, [isDrawing, onPathComplete, color, width]);
+
+  return { handleStart, handleMove, handleEnd, isDrawing };
+};

--- a/components/widgets/WidgetRenderer.tsx
+++ b/components/widgets/WidgetRenderer.tsx
@@ -2,7 +2,6 @@ import React, { memo, Suspense, useMemo, useCallback } from 'react';
 import { Z_INDEX } from '@/config/zIndex';
 import {
   WidgetData,
-  DrawingConfig,
   WidgetConfig,
   LiveStudent,
   LiveSession,
@@ -185,26 +184,21 @@ const WidgetRendererComponent: React.FC<WidgetRendererProps> = ({
     return null;
   };
 
-  const isDrawingOverlay =
-    widget.type === 'drawing' &&
-    (widget.config as DrawingConfig).mode === 'overlay';
   // When spotlighted we switch to position:fixed so the element escapes all
   // parent stacking contexts (will-change:transform / container-type:size on
   // DraggableWindow both create stacking contexts that would otherwise trap
   // the widget below the backdrop overlay). position:fixed is relative to the
   // viewport, and the dashboard is always full-screen, so widget.x / widget.y
   // map 1:1 to viewport coordinates — the widget stays visually in place.
-  const customStyle: React.CSSProperties = isDrawingOverlay
-    ? { display: 'none' }
-    : isSpotlighted
-      ? {
-          position: 'fixed',
-          zIndex: Z_INDEX.backdrop + 1,
-          outline: '3px solid #facc15', // yellow-400 ring
-          outlineOffset: '2px',
-          boxShadow: '0 0 32px 8px rgba(250,204,21,0.25)',
-        }
-      : {};
+  const customStyle: React.CSSProperties = isSpotlighted
+    ? {
+        position: 'fixed',
+        zIndex: Z_INDEX.backdrop + 1,
+        outline: '3px solid #facc15', // yellow-400 ring
+        outlineOffset: '2px',
+        boxShadow: '0 0 32px 8px rgba(250,204,21,0.25)',
+      }
+    : {};
 
   const scaling = WIDGET_SCALING_CONFIG[widget.type];
   const effectiveWidth = widget.maximized ? windowSize.width : widget.w;

--- a/config/widgetDefaults.ts
+++ b/config/widgetDefaults.ts
@@ -78,7 +78,7 @@ export const WIDGET_DEFAULTS: Record<WidgetType, Partial<WidgetData>> = {
     h: 300,
     config: { sensitivity: 1, visual: 'thermometer' },
   },
-  drawing: { w: 400, h: 350, config: { mode: 'window', paths: [] } },
+  drawing: { w: 400, h: 350, config: { paths: [] } },
   qr: { w: 200, h: 250, config: { showUrl: false } satisfies QRConfig },
   embed: { w: 480, h: 350, config: { url: '' } },
   poll: {

--- a/context/DashboardContext.tsx
+++ b/context/DashboardContext.tsx
@@ -3020,15 +3020,16 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
 
   // --- Annotation actions ---
   const openAnnotation = useCallback(() => {
-    // Seed from admin building defaults for width + color palette
+    // Seed from admin building defaults for width + color palette.
+    // `color` is not configurable at the admin level — keep the user's
+    // previously-chosen color across sessions.
     const adminConfig = getAdminBuildingConfig('drawing') as {
       width?: number;
-      color?: string;
       customColors?: string[];
     };
     setAnnotationState((prev) => ({
       paths: [],
-      color: adminConfig.color ?? prev.color,
+      color: prev.color,
       width: adminConfig.width ?? DRAWING_DEFAULTS.WIDTH,
       customColors: adminConfig.customColors ?? [
         ...DRAWING_DEFAULTS.CUSTOM_COLORS,

--- a/context/DashboardContext.tsx
+++ b/context/DashboardContext.tsx
@@ -22,6 +22,7 @@ import {
   GridPosition,
   FeaturePermission,
   MaterialsGlobalConfig,
+  Path,
 } from '../types';
 import { useAuth } from './useAuth';
 import { stripTransientKeys } from '../utils/widgetConfigPersistence';
@@ -43,6 +44,9 @@ import { useGoogleDrive } from '../hooks/useGoogleDrive';
 import { DashboardContext } from './DashboardContextValue';
 import { validateGridConfig, sanitizeAIConfig } from '../utils/ai_security';
 import { getMaterialsCatalog } from '../components/widgets/MaterialsWidget/constants';
+import { AnnotationState } from './DashboardContextValue';
+import { DRAWING_DEFAULTS } from '../components/widgets/DrawingWidget/constants';
+import { STANDARD_COLORS } from '../config/colors';
 
 // Helper to migrate legacy visibleTools to dockItems
 const migrateToDockItems = (
@@ -149,10 +153,24 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
   const [toasts, setToasts] = useState<Toast[]>([]);
   const [zoom, setZoom] = useState<number>(1);
 
+  // --- Annotation (ephemeral full-screen draw-over overlay; NOT a widget) ---
+  const [annotationActive, setAnnotationActive] = useState(false);
+  const [annotationState, setAnnotationState] = useState<AnnotationState>(
+    () => ({
+      paths: [],
+      color: STANDARD_COLORS.slate,
+      width: DRAWING_DEFAULTS.WIDTH,
+      customColors: [...DRAWING_DEFAULTS.CUSTOM_COLORS],
+    })
+  );
+
   // Helper to centralize active dashboard switching and its side-effects (like zoom reset)
   const updateActiveId = useCallback((id: string | null) => {
     setActiveId(id);
     setZoom(1);
+    // Auto-close annotation when switching dashboards — annotations are board-local
+    setAnnotationActive(false);
+    setAnnotationState((prev) => ({ ...prev, paths: [] }));
   }, []);
 
   const [isDockInitialized, setIsDockInitialized] = useState<boolean>(() => {
@@ -2194,9 +2212,9 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
           if (typeof raw.count === 'number') out.count = raw.count;
           break;
         case 'drawing':
-          if (raw.mode === 'window' || raw.mode === 'overlay') {
-            out.mode = raw.mode;
-          }
+          // Note: `mode` is no longer configurable per-building — annotation
+          // vs windowed whiteboard is now an explicit runtime choice via the
+          // Dock popover. Only width/colors remain as building defaults.
           if (typeof raw.width === 'number') {
             const roundedWidth = Math.round(raw.width);
             if (roundedWidth >= 1 && roundedWidth <= 20) {
@@ -3000,6 +3018,49 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
     );
   }, []);
 
+  // --- Annotation actions ---
+  const openAnnotation = useCallback(() => {
+    // Seed from admin building defaults for width + color palette
+    const adminConfig = getAdminBuildingConfig('drawing') as {
+      width?: number;
+      color?: string;
+      customColors?: string[];
+    };
+    setAnnotationState((prev) => ({
+      paths: [],
+      color: adminConfig.color ?? prev.color,
+      width: adminConfig.width ?? DRAWING_DEFAULTS.WIDTH,
+      customColors: adminConfig.customColors ?? [
+        ...DRAWING_DEFAULTS.CUSTOM_COLORS,
+      ],
+    }));
+    setAnnotationActive(true);
+  }, [getAdminBuildingConfig]);
+
+  const closeAnnotation = useCallback(() => {
+    setAnnotationActive(false);
+    setAnnotationState((prev) => ({ ...prev, paths: [] }));
+  }, []);
+
+  const updateAnnotationState = useCallback(
+    (updates: Partial<AnnotationState>) => {
+      setAnnotationState((prev) => ({ ...prev, ...updates }));
+    },
+    []
+  );
+
+  const addAnnotationPath = useCallback((path: Path) => {
+    setAnnotationState((prev) => ({ ...prev, paths: [...prev.paths, path] }));
+  }, []);
+
+  const undoAnnotation = useCallback(() => {
+    setAnnotationState((prev) => ({ ...prev, paths: prev.paths.slice(0, -1) }));
+  }, []);
+
+  const clearAnnotation = useCallback(() => {
+    setAnnotationState((prev) => ({ ...prev, paths: [] }));
+  }, []);
+
   const contextValue = useMemo(
     () => ({
       dashboards,
@@ -3077,6 +3138,14 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
       clearPendingQuizShare,
       zoom,
       setZoom,
+      annotationActive,
+      annotationState,
+      openAnnotation,
+      closeAnnotation,
+      updateAnnotationState,
+      addAnnotationPath,
+      undoAnnotation,
+      clearAnnotation,
     }),
     [
       dashboards,
@@ -3154,6 +3223,14 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
       clearPendingQuizShare,
       zoom,
       setZoom,
+      annotationActive,
+      annotationState,
+      openAnnotation,
+      closeAnnotation,
+      updateAnnotationState,
+      addAnnotationPath,
+      undoAnnotation,
+      clearAnnotation,
     ]
   );
 

--- a/context/DashboardContextValue.ts
+++ b/context/DashboardContextValue.ts
@@ -13,7 +13,15 @@ import {
   Student,
   AddWidgetOverrides,
   GridPosition,
+  Path,
 } from '../types';
+
+export interface AnnotationState {
+  paths: Path[];
+  color: string;
+  width: number;
+  customColors: string[];
+}
 
 export interface DashboardContextValue {
   dashboards: Dashboard[];
@@ -66,6 +74,16 @@ export interface DashboardContextValue {
   libraryOrder: (WidgetType | InternalToolType)[];
   updateDashboardSettings: (settings: Partial<Dashboard['settings']>) => void;
   updateDashboard: (updates: Partial<Dashboard>) => void;
+
+  // Annotation (ephemeral full-screen draw-over overlay; NOT a widget)
+  annotationActive: boolean;
+  annotationState: AnnotationState;
+  openAnnotation: () => void;
+  closeAnnotation: () => void;
+  updateAnnotationState: (updates: Partial<AnnotationState>) => void;
+  addAnnotationPath: (path: Path) => void;
+  undoAnnotation: () => void;
+  clearAnnotation: () => void;
 
   // Zoom system
   zoom: number;

--- a/hooks/useGoogleDrive.ts
+++ b/hooks/useGoogleDrive.ts
@@ -99,8 +99,15 @@ export const useGoogleDrive = () => {
 
   /**
    * Upload a drawing/annotation PNG to the user's Drive "Drawings" folder and
-   * return a shareable Drive URL. Uses the same public-sharing pattern as
-   * background uploads so the link works across contexts.
+   * return a shareable Drive viewer URL.
+   *
+   * NOTE: Returns a `drive.google.com/file/d/.../view` URL — intended for
+   * teachers clicking through to open the saved annotation in Drive's
+   * native viewer. This is **different** from `uploadBackgroundToDrive`,
+   * which returns a `lh3.googleusercontent.com/d/...` URL so the image can
+   * be rendered via CSS `background-image` (requires CORS-friendly headers).
+   * Annotations are teacher-facing artifacts, not embedded images, so the
+   * viewer URL is the appropriate return value.
    */
   const saveDrawingToDrive = useCallback(
     async (blob: Blob, fileName: string): Promise<string> => {

--- a/hooks/useGoogleDrive.ts
+++ b/hooks/useGoogleDrive.ts
@@ -101,6 +101,13 @@ export const useGoogleDrive = () => {
    * Upload a drawing/annotation PNG to the user's Drive "Drawings" folder and
    * return a shareable Drive viewer URL.
    *
+   * Sharing: when the user is on a Google Workspace domain, the file is
+   * shared with that domain (so only colleagues at the same school can open
+   * it). Consumer accounts (gmail.com etc.) fall back to "anyone with the
+   * link" automatically — `makePublic` handles the consumer-domain case.
+   * Annotations can contain classroom info, so domain-restricted sharing
+   * is the safer default when available.
+   *
    * NOTE: Returns a `drive.google.com/file/d/.../view` URL — intended for
    * teachers clicking through to open the saved annotation in Drive's
    * native viewer. This is **different** from `uploadBackgroundToDrive`,
@@ -121,11 +128,11 @@ export const useGoogleDrive = () => {
         DRAWINGS_FOLDER
       );
 
-      await driveService.makePublic(driveFile.id, undefined);
+      await driveService.makePublic(driveFile.id, userDomain);
 
       return `https://drive.google.com/file/d/${driveFile.id}/view`;
     },
-    [driveService]
+    [driveService, userDomain]
   );
 
   /**

--- a/hooks/useGoogleDrive.ts
+++ b/hooks/useGoogleDrive.ts
@@ -4,6 +4,7 @@ import { GoogleDriveService } from '../utils/googleDriveService';
 import { APP_NAME } from '../config/constants';
 
 const BACKGROUNDS_FOLDER = 'Backgrounds';
+const DRAWINGS_FOLDER = 'Drawings';
 const LEGACY_FOLDER_NAME = 'SPART Board';
 const MIGRATION_COMPLETED_FLAG = 'true';
 const migrationKey = (uid: string) => `spart_drive_folder_migrated_v2_${uid}`;
@@ -97,6 +98,30 @@ export const useGoogleDrive = () => {
   }, [driveService]);
 
   /**
+   * Upload a drawing/annotation PNG to the user's Drive "Drawings" folder and
+   * return a shareable Drive URL. Uses the same public-sharing pattern as
+   * background uploads so the link works across contexts.
+   */
+  const saveDrawingToDrive = useCallback(
+    async (blob: Blob, fileName: string): Promise<string> => {
+      if (!driveService) {
+        throw new Error('Google Drive is not connected. Please sign in again.');
+      }
+
+      const driveFile = await driveService.uploadFile(
+        blob,
+        fileName,
+        DRAWINGS_FOLDER
+      );
+
+      await driveService.makePublic(driveFile.id, undefined);
+
+      return `https://drive.google.com/file/d/${driveFile.id}/view`;
+    },
+    [driveService]
+  );
+
+  /**
    * Attempts to extract text content from a Google Drive file if it is a supported type (Docs, Slides, Sheets, Text).
    */
   const getDriveFileTextContent = useCallback(
@@ -126,5 +151,6 @@ export const useGoogleDrive = () => {
     uploadBackgroundToDrive,
     getUserBackgroundsFromDrive,
     getDriveFileTextContent,
+    saveDrawingToDrive,
   };
 };

--- a/types.ts
+++ b/types.ts
@@ -342,7 +342,12 @@ export interface SoundConfig {
 }
 
 export interface DrawingConfig {
-  mode: 'window' | 'overlay';
+  /**
+   * @deprecated Annotation mode is now an app-level overlay (not a widget).
+   * Legacy widgets may have this set; it is otherwise unused and kept only
+   * for backward compatibility.
+   */
+  mode?: 'window' | 'overlay';
   paths: Path[];
   color?: string;
   width?: number;
@@ -824,7 +829,6 @@ export interface ScoreboardGlobalConfig {
 // --- Drawing Global Config ---
 export interface BuildingDrawingDefaults {
   buildingId: string;
-  mode?: 'window' | 'overlay';
   width?: number;
   customColors?: string[];
 }


### PR DESCRIPTION
## Summary
This PR decouples the full-screen annotation feature from the DrawingWidget by introducing a dedicated `AnnotationOverlay` component and extracting shared canvas logic into a reusable hook. Annotation is now an ephemeral app-level overlay (not a persisted widget), while the DrawingWidget remains a standard windowed whiteboard. The Dock now provides an explicit menu to choose between these two modes.

## Key Changes

- **New `AnnotationOverlay` component** (`components/layout/AnnotationOverlay.tsx`): A full-screen, non-dimming overlay that renders into the dashboard root. Provides floating toolbar with drawing tools, screenshot/Drive upload, and AI text extraction. Automatically hides the Dock while active and closes on Escape.

- **Extracted `useDrawingCanvas` hook** (`components/widgets/DrawingWidget/useDrawingCanvas.ts`): Shared canvas drawing logic (stroke rendering, pointer handling, path completion) used by both DrawingWidget and AnnotationOverlay. Accepts canvas size, color, width, and a callback for path completion.

- **Simplified DrawingWidget** (`components/widgets/DrawingWidget/Widget.tsx`): Removed overlay mode, live session, and screenshot logic. Now only handles windowed whiteboard. Delegates canvas drawing to `useDrawingCanvas` hook. Removed ~200 lines of code.

- **Updated Dock** (`components/layout/Dock.tsx`): Added Draw button with popover menu offering two explicit choices:
  - "Annotate screen" → opens ephemeral AnnotationOverlay
  - "Add whiteboard" → creates a new DrawingWidget
  - Clicking Draw while annotation is active closes it (toggle-off).

- **Context updates** (`context/DashboardContext.tsx`, `context/DashboardContextValue.ts`): Added annotation state management (paths, color, width, customColors) and actions (openAnnotation, closeAnnotation, updateAnnotationState, addAnnotationPath, undoAnnotation, clearAnnotation). Annotation state auto-clears when switching dashboards.

- **Google Drive integration** (`hooks/useGoogleDrive.ts`): Added `saveDrawingToDrive()` method to upload annotation PNGs to a "Drawings" folder with public sharing.

- **Removed mode configuration**: Deleted `mode` field from DrawingConfig and admin/widget settings panels. Mode is now a runtime choice via the Dock, not a building default.

- **Updated tests and mocks**: Removed mocks for `useLiveSession` and `useScreenshot`. Updated DrawingWidget tests and student context mocks to reflect new annotation API.

## Implementation Details

- **Annotation state is ephemeral**: Stored in DashboardContext but not persisted to Firestore. Clears when switching dashboards or closing the overlay.
- **No dimming layer**: The overlay canvas sits above widgets with `pointer-events-auto` on the canvas and `pointer-events-none` on the container, so the dashboard remains visually unchanged.
- **Toolbar positioning**: Floats at the bottom center (where the Dock normally sits), with `data-screenshot="exclude"` to hide itself from captures.
- **Shared canvas logic**: `useDrawingCanvas` handles all pointer events, stroke rendering, and path completion. Both DrawingWidget and AnnotationOverlay use identical drawing mechanics.
- **Defensive fallback**: AnnotationOverlay provides sensible defaults if the context omits annotationState (e.g., in older test mocks).

https://claude.ai/code/session_01C9q8CRXAK9RbMQhSiwW944