### PR TITLE
🔒 Restrict public read access to admin assets in Firebase Storage

### DIFF
--- a/storage.rules
+++ b/storage.rules
@@ -62,37 +62,37 @@ service firebase.storage {
     }
 
     match /admin_weather/{rangeId}/{fileName} {
-      allow read: if true; // Weather images are public
+      allow read: if request.auth != null; // Weather images require authentication
       allow write: if isAdmin();
     }
 
     match /admin_stickers/{fileName} {
-      allow read: if true;
+      allow read: if request.auth != null;
       allow write: if isAdmin();
     }
 
     match /admin_work_symbols/{fileName} {
-      allow read: if true;
+      allow read: if request.auth != null;
       allow write: if isAdmin();
     }
 
     match /admin_catalyst_icons/{allPaths=**} {
-      allow read: if true;
+      allow read: if request.auth != null;
       allow write: if isAdmin();
     }
 
     match /catalyst/images/{routineId}/{fileName} {
-      allow read: if true;
+      allow read: if request.auth != null;
       allow write: if isAdmin();
     }
 
     match /admin_music_thumbnails/{allPaths=**} {
-      allow read: if true;
+      allow read: if request.auth != null;
       allow write: if isAdmin();
     }
 
     match /admin_logos/{fileName} {
-      allow read: if true; // Logo should be public for all users
+      allow read: if request.auth != null; // Logo should be visible to all authenticated users
       allow write: if isAdmin();
     }
 


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed was overly permissive read access to Firebase Storage admin assets.
⚠️ **Risk:** Publicly accessible assets could lead to unauthorized scraping or exposure of internal platform content and branding.
🛡️ **Solution:** Updated `storage.rules` to replace `allow read: if true;` with `allow read: if request.auth != null;` for all affected admin paths. All legitimate users (teachers and students) are authenticated in this application, so functionality remains preserved while security is significantly improved.

---
*PR created automatically by Jules for task [10122760798061331598](https://jules.google.com/task/10122760798061331598) started by @OPS-PIvers*