### PR TITLE
🧪 Add tests for normalizeGuidedLearningSet

### DIFF
--- a/components/widgets/GuidedLearning/utils/setMigration.test.ts
+++ b/components/widgets/GuidedLearning/utils/setMigration.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from 'vitest';
+import { GuidedLearningSet } from '@/types';
+import { normalizeGuidedLearningSet } from './setMigration';
+
+interface LegacyGuidedLearningSet extends GuidedLearningSet {
+  imageUrl?: string;
+  imagePath?: string;
+}
+
+describe('normalizeGuidedLearningSet', () => {
+  const baseSet: GuidedLearningSet = {
+    id: 'test-set',
+    title: 'Test Set',
+    imageUrls: ['url1'],
+    imagePaths: ['path1'],
+    steps: [
+      {
+        id: 'step1',
+        xPct: 50,
+        yPct: 50,
+        imageIndex: 0,
+        interactionType: 'text-popover',
+        showOverlay: 'popover',
+      },
+    ],
+    mode: 'guided',
+    createdAt: 123456,
+    updatedAt: 123456,
+  };
+
+  it('identity: returns same values if already normalized', () => {
+    const result = normalizeGuidedLearningSet(baseSet);
+    expect(result).toEqual(baseSet);
+  });
+
+  it('migration: migrates legacy imageUrl to imageUrls array', () => {
+    const legacySet: LegacyGuidedLearningSet = {
+      ...baseSet,
+      imageUrls: [],
+      imageUrl: 'legacy-url',
+    };
+
+    const result = normalizeGuidedLearningSet(legacySet);
+    expect(result.imageUrls).toEqual(['legacy-url']);
+  });
+
+  it('migration: migrates legacy imagePath to imagePaths array', () => {
+    const legacySet: LegacyGuidedLearningSet = {
+      ...baseSet,
+      imagePaths: [],
+      imagePath: 'legacy-path',
+    };
+
+    const result = normalizeGuidedLearningSet(legacySet);
+    expect(result.imagePaths).toEqual(['legacy-path']);
+  });
+
+  it('step normalization: clamps imageIndex within bounds', () => {
+    const setWithBadIndices: GuidedLearningSet = {
+      ...baseSet,
+      imageUrls: ['url1', 'url2'], // last index is 1
+      steps: [
+        {
+          ...baseSet.steps[0],
+          id: 'too-low',
+          imageIndex: -1,
+        },
+        {
+          ...baseSet.steps[0],
+          id: 'too-high',
+          imageIndex: 5,
+        },
+      ],
+    };
+
+    const result = normalizeGuidedLearningSet(setWithBadIndices);
+    expect(result.steps[0].imageIndex).toBe(0);
+    expect(result.steps[1].imageIndex).toBe(1);
+  });
+
+  it('step normalization: defaults imageIndex to 0 if imageUrls is empty', () => {
+    const setWithNoImages: GuidedLearningSet = {
+      ...baseSet,
+      imageUrls: [],
+      steps: [
+        {
+          ...baseSet.steps[0],
+          imageIndex: 5,
+        },
+      ],
+    };
+
+    const result = normalizeGuidedLearningSet(setWithNoImages);
+    expect(result.steps[0].imageIndex).toBe(0);
+  });
+
+  it('step normalization: defaults showOverlay to "none"', () => {
+    // To test missing showOverlay, we need to cast or use a partial that we then cast to GuidedLearningSet
+    // Since GuidedLearningStep requires showOverlay normally (based on my read of types.ts),
+    // we use Omit to simulate it being missing from a legacy source.
+    const setWithMissingOverlay = {
+      ...baseSet,
+      steps: [
+        {
+          id: 'step1',
+          xPct: 10,
+          yPct: 10,
+          imageIndex: 0,
+          interactionType: 'text-popover',
+        },
+      ],
+    } as unknown as GuidedLearningSet;
+
+    const result = normalizeGuidedLearningSet(setWithMissingOverlay);
+    expect(result.steps[0].showOverlay).toBe('none');
+  });
+
+  it('handles missing steps by defaulting to empty array', () => {
+    const setWithoutSteps = {
+      ...baseSet,
+      steps: undefined,
+    } as unknown as GuidedLearningSet;
+
+    const result = normalizeGuidedLearningSet(setWithoutSteps);
+    expect(result.steps).toEqual([]);
+  });
+});

--- a/components/widgets/GuidedLearning/utils/setMigration.test.ts
+++ b/components/widgets/GuidedLearning/utils/setMigration.test.ts
@@ -95,10 +95,8 @@ describe('normalizeGuidedLearningSet', () => {
   });
 
   it('step normalization: defaults showOverlay to "none"', () => {
-    // To test missing showOverlay, we need to cast or use a partial that we then cast to GuidedLearningSet
-    // Since GuidedLearningStep requires showOverlay normally (based on my read of types.ts),
-    // we use Omit to simulate it being missing from a legacy source.
-    const setWithMissingOverlay = {
+    // Test missing showOverlay; it is optional in GuidedLearningStep but we ensure a default is applied.
+    const setWithMissingOverlay: GuidedLearningSet = {
       ...baseSet,
       steps: [
         {
@@ -109,7 +107,7 @@ describe('normalizeGuidedLearningSet', () => {
           interactionType: 'text-popover',
         },
       ],
-    } as unknown as GuidedLearningSet;
+    };
 
     const result = normalizeGuidedLearningSet(setWithMissingOverlay);
     expect(result.steps[0].showOverlay).toBe('none');
@@ -123,5 +121,15 @@ describe('normalizeGuidedLearningSet', () => {
 
     const result = normalizeGuidedLearningSet(setWithoutSteps);
     expect(result.steps).toEqual([]);
+  });
+
+  it('handles missing imageUrls by defaulting to empty array', () => {
+    const setWithoutImageUrls = {
+      ...baseSet,
+      imageUrls: undefined,
+    } as unknown as GuidedLearningSet;
+
+    const result = normalizeGuidedLearningSet(setWithoutImageUrls);
+    expect(result.imageUrls).toEqual([]);
   });
 });

--- a/components/widgets/GuidedLearning/utils/setMigration.test.ts
+++ b/components/widgets/GuidedLearning/utils/setMigration.test.ts
@@ -1,11 +1,20 @@
 import { describe, expect, it } from 'vitest';
-import { GuidedLearningSet } from '@/types';
+import { GuidedLearningSet, GuidedLearningStep } from '@/types';
 import { normalizeGuidedLearningSet } from './setMigration';
 
-interface LegacyGuidedLearningSet extends GuidedLearningSet {
+/**
+ * Helper type to simulate legacy/malformed data from Firestore/Drive.
+ * Marks typically required fields as optional to test robust normalization.
+ */
+type LegacyGuidedLearningSetInput = Omit<
+  GuidedLearningSet,
+  'steps' | 'imageUrls'
+> & {
+  steps?: GuidedLearningStep[];
+  imageUrls?: string[];
   imageUrl?: string;
   imagePath?: string;
-}
+};
 
 describe('normalizeGuidedLearningSet', () => {
   const baseSet: GuidedLearningSet = {
@@ -34,24 +43,24 @@ describe('normalizeGuidedLearningSet', () => {
   });
 
   it('migration: migrates legacy imageUrl to imageUrls array', () => {
-    const legacySet: LegacyGuidedLearningSet = {
+    const legacySet: LegacyGuidedLearningSetInput = {
       ...baseSet,
       imageUrls: [],
       imageUrl: 'legacy-url',
     };
 
-    const result = normalizeGuidedLearningSet(legacySet);
+    const result = normalizeGuidedLearningSet(legacySet as GuidedLearningSet);
     expect(result.imageUrls).toEqual(['legacy-url']);
   });
 
   it('migration: migrates legacy imagePath to imagePaths array', () => {
-    const legacySet: LegacyGuidedLearningSet = {
+    const legacySet: LegacyGuidedLearningSetInput = {
       ...baseSet,
       imagePaths: [],
       imagePath: 'legacy-path',
     };
 
-    const result = normalizeGuidedLearningSet(legacySet);
+    const result = normalizeGuidedLearningSet(legacySet as GuidedLearningSet);
     expect(result.imagePaths).toEqual(['legacy-path']);
   });
 
@@ -105,7 +114,7 @@ describe('normalizeGuidedLearningSet', () => {
           yPct: 10,
           imageIndex: 0,
           interactionType: 'text-popover',
-        },
+        } as GuidedLearningStep,
       ],
     };
 
@@ -114,22 +123,26 @@ describe('normalizeGuidedLearningSet', () => {
   });
 
   it('handles missing steps by defaulting to empty array', () => {
-    const setWithoutSteps = {
+    const setWithoutSteps: LegacyGuidedLearningSetInput = {
       ...baseSet,
       steps: undefined,
-    } as unknown as GuidedLearningSet;
+    };
 
-    const result = normalizeGuidedLearningSet(setWithoutSteps);
+    const result = normalizeGuidedLearningSet(
+      setWithoutSteps as GuidedLearningSet
+    );
     expect(result.steps).toEqual([]);
   });
 
   it('handles missing imageUrls by defaulting to empty array', () => {
-    const setWithoutImageUrls = {
+    const setWithoutImageUrls: LegacyGuidedLearningSetInput = {
       ...baseSet,
       imageUrls: undefined,
-    } as unknown as GuidedLearningSet;
+    };
 
-    const result = normalizeGuidedLearningSet(setWithoutImageUrls);
+    const result = normalizeGuidedLearningSet(
+      setWithoutImageUrls as GuidedLearningSet
+    );
     expect(result.imageUrls).toEqual([]);
   });
 });


### PR DESCRIPTION
This PR adds unit tests for the `normalizeGuidedLearningSet` function in `components/widgets/GuidedLearning/utils/setMigration.ts`.

🎯 **What:** The testing gap addressed. `normalizeGuidedLearningSet` is a critical data migration function that lacked test coverage.
📊 **Coverage:** The following scenarios are now tested:
- **Identity:** Returns the same object if already normalized.
- **Migration:** Correctly migrates legacy `imageUrl` and `imagePath` strings to their respective array fields.
- **Step Normalization:** Clamps `imageIndex` within the valid bounds of the `imageUrls` array.
- **Defaults:** Ensures `showOverlay` defaults to `'none'` and `steps` defaults to an empty array if missing.
✨ **Result:** Increased reliability of the GuidedLearning data migration logic and improved overall test coverage.

---
*PR created automatically by Jules for task [17926892247881033086](https://jules.google.com/task/17926892247881033086) started by @OPS-PIvers*