### PR TITLE
Dev paul

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -8,5 +8,18 @@
     "skill-creator@claude-plugins-official": true,
     "chrome-devtools-mcp@claude-plugins-official": true,
     "code-simplifier@claude-plugins-official": true
+  },
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/scripts/setup.sh"
+          }
+        ]
+      }
+    ]
   }
 }

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -6,11 +6,11 @@ echo "🚀 Starting SPART Board Environment Setup..."
 # 1. Setup PNPM for the project
 echo "📦 Enabling corepack and pnpm..."
 corepack enable
-corepack prepare pnpm@latest --activate
+corepack prepare pnpm@10.30.2 --activate
 
 # 2. Install Project Dependencies
 echo "📥 Installing project dependencies..."
-pnpm install
+pnpm run install:all
 
 # 3. Install Playwright Browsers
 echo "🎭 Installing Playwright browsers..."

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ pnpm-debug.log*
 lerna-debug.log*
 
 node_modules
+.pnpm-store
 dist
 dist-ssr
 *.local

--- a/components/admin/DrawingConfigurationPanel.test.tsx
+++ b/components/admin/DrawingConfigurationPanel.test.tsx
@@ -16,7 +16,6 @@ describe('DrawingConfigurationPanel', () => {
     buildingDefaults: {
       b1: {
         buildingId: 'b1',
-        mode: 'window',
         width: 5,
         customColors: ['#FF0000', '#00FF00', '#0000FF', '#FFFF00', '#FF00FF'],
       },
@@ -43,24 +42,14 @@ describe('DrawingConfigurationPanel', () => {
     // Check initial values
     const widthInput = screen.getByRole('slider');
     expect(widthInput).toHaveValue('5');
-
-    const windowModeButton = screen.getByText('Window').closest('button');
-    expect(windowModeButton).toBeInTheDocument();
   });
 
-  it('updates mode when clicked', () => {
+  it('does not render mode toggle (mode is now picked at click-time)', () => {
     render(
       <DrawingConfigurationPanel config={mockConfig} onChange={mockOnChange} />
     );
-
-    const overlayButton = screen
-      .getByText('Overlay (Annotate)')
-      .closest('button');
-    if (overlayButton) fireEvent.click(overlayButton);
-
-    expect(mockOnChange).toHaveBeenCalled();
-    const lastCall = mockOnChange.mock.calls[0][0] as DrawingGlobalConfig;
-    expect(lastCall.buildingDefaults['b1']?.mode).toBe('overlay');
+    expect(screen.queryByText('Overlay (Annotate)')).toBeNull();
+    expect(screen.queryByText('Default Mode')).toBeNull();
   });
 
   it('updates width when changed', () => {

--- a/components/admin/DrawingConfigurationPanel.tsx
+++ b/components/admin/DrawingConfigurationPanel.tsx
@@ -3,7 +3,7 @@ import { BUILDINGS } from '@/config/buildings';
 import { BuildingSelector } from './BuildingSelector';
 import { DrawingGlobalConfig, BuildingDrawingDefaults } from '@/types';
 import { WIDGET_PALETTE } from '@/config/colors';
-import { Maximize, Minimize, Pencil, Palette } from 'lucide-react';
+import { Pencil, Palette } from 'lucide-react';
 import { Card } from '@/components/common/Card';
 
 interface DrawingConfigurationPanelProps {
@@ -40,7 +40,6 @@ export const DrawingConfigurationPanel: React.FC<
 
   const NUM_COLOR_PRESETS = 5;
 
-  const activeMode = currentBuildingConfig.mode ?? 'window';
   const activeWidth = currentBuildingConfig.width ?? 4;
 
   // Normalize palette to exactly 5 colors
@@ -80,35 +79,6 @@ export const DrawingConfigurationPanel: React.FC<
           <b>{BUILDINGS.find((b) => b.id === selectedBuildingId)?.name}</b> adds
           it to their dashboard.
         </p>
-
-        {/* Default Mode */}
-        <div>
-          <label className="text-xxs font-bold text-slate-500 uppercase mb-2 block flex items-center gap-1.5">
-            <Maximize className="w-3 h-3" /> Default Mode
-          </label>
-          <div className="flex bg-white rounded-lg border border-slate-200 p-1">
-            <button
-              onClick={() => handleUpdateBuilding({ mode: 'window' })}
-              className={`flex-1 py-1.5 text-xxs font-bold rounded transition-colors flex items-center justify-center gap-1.5 ${
-                activeMode === 'window'
-                  ? 'bg-brand-blue-primary text-white shadow-sm'
-                  : 'text-slate-500 hover:bg-slate-50'
-              }`}
-            >
-              <Minimize className="w-3 h-3" /> Window
-            </button>
-            <button
-              onClick={() => handleUpdateBuilding({ mode: 'overlay' })}
-              className={`flex-1 py-1.5 text-xxs font-bold rounded transition-colors flex items-center justify-center gap-1.5 ${
-                activeMode === 'overlay'
-                  ? 'bg-brand-blue-primary text-white shadow-sm'
-                  : 'text-slate-500 hover:bg-slate-50'
-              }`}
-            >
-              <Maximize className="w-3 h-3" /> Overlay (Annotate)
-            </button>
-          </div>
-        </div>
 
         {/* Default Brush Thickness */}
         <div>

--- a/components/common/DraggableWindow.tsx
+++ b/components/common/DraggableWindow.tsx
@@ -40,6 +40,7 @@ import {
 import { SNAP_LAYOUTS, SnapZone } from '@/config/snapLayouts';
 import { calculateSnapBounds, SNAP_LAYOUT_CONSTANTS } from '@/utils/layoutMath';
 import { useScreenshot } from '@/hooks/useScreenshot';
+import { useWindowSize } from '@/hooks/useWindowSize';
 import { useDashboard } from '@/context/useDashboard';
 import { GlassCard } from './GlassCard';
 import { SettingsPanel } from './SettingsPanel';
@@ -60,8 +61,8 @@ const COLOR_HEX_TO_NAME: Record<string, string> = Object.fromEntries(
 );
 
 // Custom size picker grid dimensions
-const GRID_COLS = 8;
-const GRID_ROWS = 6;
+const GRID_COLS = 10;
+const GRID_ROWS = 10;
 
 // Widgets that require real-time position updates for inter-widget functionality
 const POSITION_AWARE_WIDGETS: WidgetType[] = [
@@ -187,6 +188,7 @@ export const DraggableWindow: React.FC<DraggableWindowProps> = ({
   );
 
   const [showSnapMenu, setShowSnapMenu] = useState(false);
+  const windowSize = useWindowSize(showSnapMenu);
   const [snapPreviewZone, setSnapPreviewZone] = useState<
     SnapZone | 'maximize' | 'minimize' | null
   >(null);
@@ -200,6 +202,46 @@ export const DraggableWindow: React.FC<DraggableWindowProps> = ({
   }>({ start: null, end: null, selecting: false });
   const customGridRef = useRef(customGrid);
   customGridRef.current = customGrid;
+  const occupiedCells = useMemo(() => {
+    const set = new Set<string>();
+    if (!showSnapMenu || !activeDashboard) return set;
+
+    const { PADDING } = SNAP_LAYOUT_CONSTANTS;
+    const safeWidth = Math.max(1, windowSize.width - PADDING * 2);
+    const safeHeight = Math.max(1, windowSize.height - PADDING * 2);
+
+    for (const w of activeDashboard.widgets) {
+      if (w.id === widget.id) continue; // ignore self
+      if (w.minimized || w.maximized) continue; // not visible on canvas
+
+      const nx = (w.x - PADDING) / safeWidth;
+      const ny = (w.y - PADDING) / safeHeight;
+      const nr = (w.x + w.w - PADDING) / safeWidth;
+      const nb = (w.y + w.h - PADDING) / safeHeight;
+
+      const c0 = Math.max(
+        0,
+        Math.min(GRID_COLS - 1, Math.floor(nx * GRID_COLS))
+      );
+      const r0 = Math.max(
+        0,
+        Math.min(GRID_ROWS - 1, Math.floor(ny * GRID_ROWS))
+      );
+      const c1 = Math.max(
+        0,
+        Math.min(GRID_COLS - 1, Math.ceil(nr * GRID_COLS) - 1)
+      );
+      const r1 = Math.max(
+        0,
+        Math.min(GRID_ROWS - 1, Math.ceil(nb * GRID_ROWS) - 1)
+      );
+
+      for (let r = r0; r <= r1; r++) {
+        for (let c = c0; c <= c1; c++) set.add(`${c},${r}`);
+      }
+    }
+    return set;
+  }, [showSnapMenu, activeDashboard, widget.id, windowSize]);
 
   // Pre-cached zones for edge detection optimization
   const splitLayout = useMemo(
@@ -2243,11 +2285,24 @@ export const DraggableWindow: React.FC<DraggableWindowProps> = ({
                                     customGrid.start.row,
                                     customGrid.end.row
                                   );
+                              const isOccupied = occupiedCells.has(
+                                `${col},${row}`
+                              );
+                              const cellClassName = selected
+                                ? 'bg-brand-blue-light'
+                                : isOccupied
+                                  ? 'bg-brand-blue-primary'
+                                  : 'bg-slate-300';
                               return (
                                 <div
                                   key={i}
-                                  className={`rounded-[2px] transition-colors ${selected ? 'bg-brand-blue-light' : 'bg-slate-300'}`}
+                                  className={`rounded-[2px] transition-colors ${cellClassName}`}
                                   style={{ height: '14px' }}
+                                  aria-label={
+                                    isOccupied
+                                      ? 'Cell occupied by another widget'
+                                      : undefined
+                                  }
                                 />
                               );
                             }

--- a/components/common/DraggableWindow.tsx
+++ b/components/common/DraggableWindow.tsx
@@ -1107,8 +1107,15 @@ export const DraggableWindow: React.FC<DraggableWindowProps> = ({
 
   // Widget-local floating toolbar reservation (e.g. TextWidget's rich-text
   // toolbar). When set, this tool menu flips to the opposite side of the
-  // widget so the two toolbars don't overlap.
-  const toolbarReservationRef = useRef<'above' | 'below' | null>(null);
+  // widget so the two toolbars don't overlap. The reserved footprint
+  // (height + gap) is subtracted from that side's available space, and — if
+  // this tool menu is forced onto the same side — it is offset past that
+  // footprint so the two stack instead of overlapping.
+  const toolbarReservationRef = useRef<{
+    side: 'above' | 'below';
+    height: number;
+    gap: number;
+  } | null>(null);
 
   useLayoutEffect(() => {
     if (showTools && windowRef.current) {
@@ -1141,29 +1148,36 @@ export const DraggableWindow: React.FC<DraggableWindowProps> = ({
         // Vertical: prefer above; flip below only when space above is tight AND
         // there is room below. If neither side fits, pick whichever has more space
         // and clamp to keep the toolbar on-screen.
-        const spaceAbove = effectiveTop;
-        const spaceBelow = window.innerHeight - effectiveBottom;
         // If the widget has reserved a side for its own floating toolbar
         // (e.g. TextWidget's formatting toolbar), prefer the opposite side
-        // so the two don't overlap. Fall back to the reserved side if the
-        // opposite is too tight; if neither fits, pick whichever has more
-        // room. With no reservation, prefer above and flip below only when
-        // above is tight and below has more room.
+        // so the two don't overlap. The reserved footprint is subtracted from
+        // that side's available space, and — if this tool menu is forced onto
+        // the same side — it is offset past that footprint so the two stack.
         const reservation = toolbarReservationRef.current;
+        const reservedAbove =
+          reservation?.side === 'above'
+            ? reservation.height + reservation.gap
+            : 0;
+        const reservedBelow =
+          reservation?.side === 'below'
+            ? reservation.height + reservation.gap
+            : 0;
+        const spaceAbove = effectiveTop - reservedAbove;
+        const spaceBelow = window.innerHeight - effectiveBottom - reservedBelow;
         const needed = menuHeight + MARGIN;
         const fitsAbove = spaceAbove >= needed;
         const fitsBelow = spaceBelow >= needed;
         let showBelow: boolean;
-        if (reservation === 'above') {
+        if (reservation?.side === 'above') {
           showBelow = fitsBelow || (!fitsAbove && spaceBelow >= spaceAbove);
-        } else if (reservation === 'below') {
+        } else if (reservation?.side === 'below') {
           showBelow = !fitsAbove && (fitsBelow || spaceBelow >= spaceAbove);
         } else {
           showBelow = !fitsAbove && spaceBelow >= spaceAbove;
         }
         const rawTopPos = showBelow
-          ? effectiveBottom + MARGIN
-          : effectiveTop - menuHeight - MARGIN;
+          ? effectiveBottom + reservedBelow + MARGIN
+          : effectiveTop - reservedAbove - menuHeight - MARGIN;
         const clampedTop = Math.max(
           MARGIN,
           Math.min(rawTopPos, window.innerHeight - menuHeight - MARGIN)
@@ -1300,11 +1314,29 @@ export const DraggableWindow: React.FC<DraggableWindowProps> = ({
         e as CustomEvent<{
           widgetId: string;
           side: 'above' | 'below' | null;
+          height?: number;
+          gap?: number;
         }>
       ).detail;
       if (!detail || detail.widgetId !== widgetId) return;
-      if (toolbarReservationRef.current === detail.side) return;
-      toolbarReservationRef.current = detail.side;
+      const next =
+        detail.side === null
+          ? null
+          : {
+              side: detail.side,
+              height: detail.height ?? 0,
+              gap: detail.gap ?? 0,
+            };
+      const current = toolbarReservationRef.current;
+      const unchanged =
+        (current === null && next === null) ||
+        (current !== null &&
+          next !== null &&
+          current.side === next.side &&
+          current.height === next.height &&
+          current.gap === next.gap);
+      if (unchanged) return;
+      toolbarReservationRef.current = next;
       updatePositionRef.current?.();
     };
     window.addEventListener('widget-toolbar-reservation', handleReservation);

--- a/components/layout/AnnotationOverlay.tsx
+++ b/components/layout/AnnotationOverlay.tsx
@@ -23,13 +23,19 @@ import { useGoogleDrive } from '@/hooks/useGoogleDrive';
 import { useDrawingCanvas } from '@/components/widgets/DrawingWidget/useDrawingCanvas';
 import { Button } from '@/components/common/Button';
 import { extractTextWithGemini } from '@/utils/ai';
-import { TextConfig } from '@/types';
+import { DrawableObject, TextConfig } from '@/types';
 import { DRAWING_DEFAULTS } from '@/components/widgets/DrawingWidget/constants';
 import { STANDARD_COLORS } from '@/config/colors';
 import { Z_INDEX } from '@/config/zIndex';
+import { nextZ } from '@/utils/migrateDrawingConfig';
 
-const FALLBACK_ANNOTATION_STATE = {
-  paths: [],
+const FALLBACK_ANNOTATION_STATE: {
+  objects: DrawableObject[];
+  color: string;
+  width: number;
+  customColors: string[];
+} = {
+  objects: [],
   color: STANDARD_COLORS.slate,
   width: DRAWING_DEFAULTS.WIDTH,
   customColors: [...DRAWING_DEFAULTS.CUSTOM_COLORS],
@@ -49,7 +55,7 @@ export const AnnotationOverlay: React.FC = () => {
     annotationActive,
     closeAnnotation,
     updateAnnotationState,
-    addAnnotationPath,
+    addAnnotationObject,
     undoAnnotation,
     clearAnnotation,
     activeDashboard,
@@ -122,10 +128,11 @@ export const AnnotationOverlay: React.FC = () => {
     canvasRef,
     color: annotationState.color,
     width: annotationState.width,
-    paths: annotationState.paths,
-    onPathComplete: addAnnotationPath,
+    objects: annotationState.objects,
+    onObjectComplete: addAnnotationObject,
     scale: 1,
     canvasSize,
+    nextZ: nextZ(annotationState.objects),
   });
 
   const capturePng = useCallback(async (): Promise<string | null> => {
@@ -238,7 +245,7 @@ export const AnnotationOverlay: React.FC = () => {
 
   if (!annotationActive || !portalTarget) return null;
 
-  const { color, width, customColors, paths } = annotationState;
+  const { color, width, customColors, objects } = annotationState;
 
   return createPortal(
     <div
@@ -318,7 +325,7 @@ export const AnnotationOverlay: React.FC = () => {
           title="Undo"
           variant="ghost"
           size="icon"
-          disabled={paths.length === 0}
+          disabled={objects.length === 0}
           icon={<Undo2 className="w-4 h-4" />}
         />
         <Button
@@ -326,7 +333,7 @@ export const AnnotationOverlay: React.FC = () => {
           title="Clear all"
           variant="ghost-danger"
           size="icon"
-          disabled={paths.length === 0}
+          disabled={objects.length === 0}
           icon={<Trash2 className="w-4 h-4" />}
         />
 

--- a/components/layout/AnnotationOverlay.tsx
+++ b/components/layout/AnnotationOverlay.tsx
@@ -26,6 +26,7 @@ import { extractTextWithGemini } from '@/utils/ai';
 import { TextConfig } from '@/types';
 import { DRAWING_DEFAULTS } from '@/components/widgets/DrawingWidget/constants';
 import { STANDARD_COLORS } from '@/config/colors';
+import { Z_INDEX } from '@/config/zIndex';
 
 const FALLBACK_ANNOTATION_STATE = {
   paths: [],
@@ -242,7 +243,7 @@ export const AnnotationOverlay: React.FC = () => {
   return createPortal(
     <div
       className="fixed inset-0 pointer-events-none overflow-hidden"
-      style={{ zIndex: 9910 }}
+      style={{ zIndex: Z_INDEX.overlay }}
     >
       <canvas
         ref={canvasRef}

--- a/components/layout/AnnotationOverlay.tsx
+++ b/components/layout/AnnotationOverlay.tsx
@@ -1,0 +1,388 @@
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import { createPortal } from 'react-dom';
+import { toPng } from 'html-to-image';
+import {
+  Eraser,
+  Trash2,
+  Undo2,
+  MousePointer2,
+  X,
+  Camera,
+  HardDriveUpload,
+  Type,
+} from 'lucide-react';
+import { useDashboard } from '@/context/useDashboard';
+import { useAuth } from '@/context/useAuth';
+import { useGoogleDrive } from '@/hooks/useGoogleDrive';
+import { useDrawingCanvas } from '@/components/widgets/DrawingWidget/useDrawingCanvas';
+import { Button } from '@/components/common/Button';
+import { extractTextWithGemini } from '@/utils/ai';
+import { TextConfig } from '@/types';
+import { DRAWING_DEFAULTS } from '@/components/widgets/DrawingWidget/constants';
+import { STANDARD_COLORS } from '@/config/colors';
+
+const FALLBACK_ANNOTATION_STATE = {
+  paths: [],
+  color: STANDARD_COLORS.slate,
+  width: DRAWING_DEFAULTS.WIDTH,
+  customColors: [...DRAWING_DEFAULTS.CUSTOM_COLORS],
+};
+
+/**
+ * Full-screen annotation overlay — ephemeral, NOT a widget.
+ *
+ * Renders into `#dashboard-root` above all widgets. No dimming layer: the
+ * dashboard stays visually identical, the user just gains the ability to
+ * draw over everything. The floating toolbar sits at the bottom, where the
+ * Dock normally lives (the Dock hides itself while annotation is active).
+ */
+export const AnnotationOverlay: React.FC = () => {
+  const dashboard = useDashboard();
+  const {
+    annotationActive,
+    closeAnnotation,
+    updateAnnotationState,
+    addAnnotationPath,
+    undoAnnotation,
+    clearAnnotation,
+    activeDashboard,
+    addToast,
+    updateWidget,
+    addWidget,
+  } = dashboard;
+  // Defensive fallback — older mock contexts (e.g. in unit tests) may omit
+  // annotationState; provide sensible defaults so this component never throws.
+  const annotationState =
+    dashboard.annotationState ?? FALLBACK_ANNOTATION_STATE;
+  const { canAccessFeature } = useAuth();
+  const { saveDrawingToDrive, isConnected: isDriveConnected } =
+    useGoogleDrive();
+
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const [portalTarget, setPortalTarget] = useState<HTMLElement | null>(null);
+  const [viewport, setViewport] = useState(() => ({
+    width: typeof window !== 'undefined' ? window.innerWidth : 1280,
+    height: typeof window !== 'undefined' ? window.innerHeight : 720,
+  }));
+  const [isBusy, setIsBusy] = useState<null | 'download' | 'drive' | 'ocr'>(
+    null
+  );
+
+  // Locate the dashboard root portal target (waits for mount if needed)
+  useEffect(() => {
+    if (!annotationActive) return;
+    const findTarget = () => {
+      const target = document.getElementById('dashboard-root');
+      if (target) {
+        setPortalTarget(target);
+        return true;
+      }
+      return false;
+    };
+    if (findTarget()) return undefined;
+    const observer = new MutationObserver(() => {
+      if (findTarget()) observer.disconnect();
+    });
+    observer.observe(document.body, { childList: true, subtree: true });
+    return () => observer.disconnect();
+  }, [annotationActive]);
+
+  // Track viewport size for canvas resolution
+  useEffect(() => {
+    if (!annotationActive) return undefined;
+    const handleResize = () =>
+      setViewport({ width: window.innerWidth, height: window.innerHeight });
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, [annotationActive]);
+
+  // Escape key exits annotation
+  useEffect(() => {
+    if (!annotationActive) return undefined;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') closeAnnotation();
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [annotationActive, closeAnnotation]);
+
+  const canvasSize = useMemo(
+    () => ({ width: viewport.width, height: viewport.height }),
+    [viewport.width, viewport.height]
+  );
+
+  const { handleStart, handleMove, handleEnd } = useDrawingCanvas({
+    canvasRef,
+    color: annotationState.color,
+    width: annotationState.width,
+    paths: annotationState.paths,
+    onPathComplete: addAnnotationPath,
+    scale: 1,
+    canvasSize,
+  });
+
+  const capturePng = useCallback(async (): Promise<string | null> => {
+    const root = document.getElementById('dashboard-root');
+    if (!root) return null;
+    const dataUrl = await toPng(root, {
+      cacheBust: true,
+      pixelRatio: 2,
+      filter: (node: Element) => {
+        if (!(node instanceof HTMLElement)) return true;
+        return node.dataset.screenshot !== 'exclude';
+      },
+    });
+    return dataUrl;
+  }, []);
+
+  const handleDownload = useCallback(async () => {
+    setIsBusy('download');
+    try {
+      const dataUrl = await capturePng();
+      if (!dataUrl) return;
+      const link = document.createElement('a');
+      link.download = `Annotation-${new Date().toISOString().split('T')[0]}.png`;
+      link.href = dataUrl;
+      link.click();
+      addToast('Annotation downloaded!', 'success');
+    } catch (e) {
+      console.error('Annotation download failed:', e);
+      addToast('Failed to download annotation.', 'error');
+    } finally {
+      setIsBusy(null);
+    }
+  }, [capturePng, addToast]);
+
+  const handleSaveToDrive = useCallback(async () => {
+    if (!isDriveConnected) {
+      addToast(
+        'Google Drive is not connected. Sign in to Drive first.',
+        'error'
+      );
+      return;
+    }
+    setIsBusy('drive');
+    try {
+      const dataUrl = await capturePng();
+      if (!dataUrl) return;
+      const blob = await (await fetch(dataUrl)).blob();
+      const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+      const name = `Annotation-${timestamp}.png`;
+      await saveDrawingToDrive(blob, name);
+      addToast('Annotation saved to Google Drive!', 'success');
+    } catch (e) {
+      console.error('Drive save failed:', e);
+      addToast('Failed to save to Google Drive.', 'error');
+    } finally {
+      setIsBusy(null);
+    }
+  }, [isDriveConnected, capturePng, saveDrawingToDrive, addToast]);
+
+  const handleExtractText = useCallback(async () => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    setIsBusy('ocr');
+    try {
+      addToast('Scanning handwriting...', 'info');
+      const dataUrl = canvas.toDataURL('image/png');
+      const extractedText = await extractTextWithGemini(dataUrl);
+      if (!extractedText || !extractedText.trim()) {
+        addToast('No text could be extracted.', 'info');
+        return;
+      }
+      const safeText = extractedText
+        .trim()
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#039;')
+        .replace(/\n/g, '<br/>');
+
+      const existingTextWidget = activeDashboard?.widgets.find(
+        (w) => w.type === 'text'
+      );
+      if (existingTextWidget) {
+        const currentConfig = existingTextWidget.config as TextConfig;
+        const newContent = currentConfig.content
+          ? `${currentConfig.content}<br><br>${safeText}`
+          : safeText;
+        updateWidget(existingTextWidget.id, {
+          config: { ...currentConfig, content: newContent },
+        });
+        addToast('Appended text to notes!', 'success');
+      } else {
+        addWidget('text', {
+          x: 80,
+          y: 80,
+          w: 400,
+          h: 300,
+          config: { content: safeText } as TextConfig,
+        });
+        addToast('Created new note with text!', 'success');
+      }
+    } catch (e) {
+      console.error('OCR failed:', e);
+      addToast('Failed to extract text.', 'error');
+    } finally {
+      setIsBusy(null);
+    }
+  }, [activeDashboard, addToast, addWidget, updateWidget]);
+
+  if (!annotationActive || !portalTarget) return null;
+
+  const { color, width, customColors, paths } = annotationState;
+
+  return createPortal(
+    <div
+      className="fixed inset-0 pointer-events-none overflow-hidden"
+      style={{ zIndex: 9910 }}
+    >
+      <canvas
+        ref={canvasRef}
+        onPointerDown={handleStart}
+        onPointerMove={handleMove}
+        onPointerUp={handleEnd}
+        onPointerLeave={handleEnd}
+        className="absolute inset-0 pointer-events-auto cursor-crosshair"
+        style={{ touchAction: 'none' }}
+      />
+
+      {/* Floating toolbar — sits where the Dock normally lives */}
+      <div
+        data-screenshot="exclude"
+        className="absolute bottom-6 left-1/2 -translate-x-1/2 pointer-events-auto bg-white/80 backdrop-blur-xl rounded-2xl shadow-2xl border border-white/40 p-2 flex items-center gap-2 animate-in slide-in-from-bottom duration-300"
+      >
+        <div className="px-2 flex items-center gap-2 border-r border-slate-200 mr-1">
+          <MousePointer2 className="w-4 h-4 text-indigo-600 animate-pulse" />
+          <span className="text-xxs font-black uppercase tracking-widest text-slate-700">
+            Annotating
+          </span>
+        </div>
+
+        <div className="flex gap-1 bg-slate-100 p-1 rounded-lg">
+          {customColors.map((c) => (
+            <button
+              key={c}
+              onClick={() => updateAnnotationState({ color: c })}
+              className={`w-7 h-7 rounded-md transition-all ${
+                color === c
+                  ? 'scale-110 shadow-sm ring-2 ring-indigo-500'
+                  : 'hover:scale-105'
+              }`}
+              style={{ backgroundColor: c }}
+              aria-label={`Color ${c}`}
+            />
+          ))}
+          <button
+            onClick={() => updateAnnotationState({ color: 'eraser' })}
+            className={`w-7 h-7 rounded-md bg-white border border-slate-200 flex items-center justify-center transition-all ${
+              color === 'eraser' ? 'ring-2 ring-indigo-500' : ''
+            }`}
+            aria-label="Eraser"
+          >
+            <Eraser className="w-3.5 h-3.5 text-slate-500" />
+          </button>
+        </div>
+
+        {/* Width slider */}
+        <div className="flex items-center gap-2 px-2">
+          <input
+            type="range"
+            min={1}
+            max={20}
+            step={1}
+            value={width}
+            onChange={(e) =>
+              updateAnnotationState({ width: parseInt(e.target.value, 10) })
+            }
+            className="w-20 accent-indigo-600"
+            aria-label="Brush thickness"
+          />
+          <span className="w-7 text-center font-mono text-xs text-slate-600">
+            {width}px
+          </span>
+        </div>
+
+        <div className="h-6 w-px bg-slate-200 mx-1" />
+
+        <Button
+          onClick={undoAnnotation}
+          title="Undo"
+          variant="ghost"
+          size="icon"
+          disabled={paths.length === 0}
+          icon={<Undo2 className="w-4 h-4" />}
+        />
+        <Button
+          onClick={clearAnnotation}
+          title="Clear all"
+          variant="ghost-danger"
+          size="icon"
+          disabled={paths.length === 0}
+          icon={<Trash2 className="w-4 h-4" />}
+        />
+
+        <div className="h-6 w-px bg-slate-200 mx-1" />
+
+        <Button
+          onClick={() => void handleDownload()}
+          disabled={isBusy !== null}
+          variant="ghost"
+          size="icon"
+          title="Download PNG"
+          icon={<Camera className="w-4 h-4" />}
+        />
+        <Button
+          onClick={() => void handleSaveToDrive()}
+          disabled={isBusy !== null}
+          variant="ghost"
+          size="icon"
+          title="Save to Google Drive"
+          icon={
+            isBusy === 'drive' ? (
+              <div className="w-4 h-4 border-2 border-slate-400 border-t-transparent rounded-full animate-spin" />
+            ) : (
+              <HardDriveUpload className="w-4 h-4" />
+            )
+          }
+        />
+        {canAccessFeature('gemini-functions') && (
+          <Button
+            onClick={() => void handleExtractText()}
+            disabled={isBusy !== null}
+            variant="ghost"
+            size="icon"
+            title="Extract text (AI)"
+            icon={
+              isBusy === 'ocr' ? (
+                <div className="w-4 h-4 border-2 border-slate-400 border-t-transparent rounded-full animate-spin" />
+              ) : (
+                <Type className="w-4 h-4" />
+              )
+            }
+          />
+        )}
+
+        <div className="h-6 w-px bg-slate-200 mx-1" />
+
+        <Button
+          onClick={closeAnnotation}
+          variant="secondary"
+          size="sm"
+          title="Exit annotation (Esc)"
+          icon={<X className="w-3.5 h-3.5" />}
+        >
+          Exit
+        </Button>
+      </div>
+    </div>,
+    portalTarget
+  );
+};

--- a/components/layout/DashboardView.tsx
+++ b/components/layout/DashboardView.tsx
@@ -15,6 +15,7 @@ import { useQuiz } from '@/hooks/useQuiz';
 import { useStorage, MAX_PDF_SIZE_BYTES } from '@/hooks/useStorage';
 import { Sidebar } from './sidebar/Sidebar';
 import { Dock } from './Dock';
+import { AnnotationOverlay } from './AnnotationOverlay';
 import { WidgetRenderer } from '@/components/widgets/WidgetRenderer';
 import { GroupBoundingBox } from '@/components/common/GroupBoundingBox';
 import { AnnouncementOverlay } from '@/components/announcements/AnnouncementOverlay';
@@ -150,6 +151,7 @@ export const DashboardView: React.FC = () => {
     selectedWidgetIds,
     setSelectedWidgetIds,
     selectedWidgetId,
+    annotationActive,
   } = useDashboard();
 
   const { importSharedQuiz } = useQuiz(user?.uid);
@@ -1272,7 +1274,8 @@ export const DashboardView: React.FC = () => {
 
       {/* FIXED UI: Outside the zoom container */}
       <Sidebar />
-      <Dock />
+      {!annotationActive && <Dock />}
+      <AnnotationOverlay />
       <ToastContainer />
       <AnnouncementOverlay />
       <BoardZoomControl />

--- a/components/layout/Dock.tsx
+++ b/components/layout/Dock.tsx
@@ -76,6 +76,7 @@ import { QuickAccessButton } from './dock/QuickAccessButton';
 import { useScreenRecord } from '@/hooks/useScreenRecord';
 import { useGoogleDrive } from '@/hooks/useGoogleDrive';
 import { useCatalystSets } from '@/hooks/useCatalystSets';
+import { beginWidgetDrag, endWidgetDrag } from '@/utils/widgetDragFlag';
 
 export const Dock: React.FC = () => {
   const { t } = useTranslation();
@@ -494,7 +495,13 @@ export const Dock: React.FC = () => {
   );
 
   const handleDragStart = useCallback((event: DragStartEvent) => {
+    beginWidgetDrag();
     setActiveItemId(event.active.id as string);
+  }, []);
+
+  const handleDragCancel = useCallback(() => {
+    endWidgetDrag();
+    setActiveItemId(null);
   }, []);
 
   /**
@@ -530,6 +537,7 @@ export const Dock: React.FC = () => {
 
   const handleDragEnd = useCallback(
     (event: DragEndEvent) => {
+      endWidgetDrag();
       const { active, over } = event;
       setActiveItemId(null);
 
@@ -901,6 +909,7 @@ export const Dock: React.FC = () => {
                   collisionDetection={customCollisionDetection}
                   onDragStart={handleDragStart}
                   onDragEnd={handleDragEnd}
+                  onDragCancel={handleDragCancel}
                 >
                   <SortableContext
                     items={dockItems.map((item) =>

--- a/components/layout/Dock.tsx
+++ b/components/layout/Dock.tsx
@@ -7,7 +7,15 @@ import React, {
 } from 'react';
 import { createPortal } from 'react-dom';
 import { useTranslation } from 'react-i18next';
-import { LayoutGrid, Puzzle, Users, Cast, Square } from 'lucide-react';
+import {
+  LayoutGrid,
+  Puzzle,
+  Users,
+  Cast,
+  Square,
+  Pencil,
+  Maximize,
+} from 'lucide-react';
 import {
   DndContext,
   closestCenter,
@@ -90,6 +98,9 @@ export const Dock: React.FC = () => {
     moveItemOutOfFolder,
     reorderFolderItems,
     addToast,
+    annotationActive,
+    openAnnotation,
+    closeAnnotation,
   } = useDashboard();
   const {
     canAccessWidget,
@@ -373,6 +384,12 @@ export const Dock: React.FC = () => {
   const classesButtonRef = useRef<HTMLButtonElement>(null);
   const remoteButtonRef = useRef<HTMLButtonElement>(null);
   const catalystButtonRef = useRef<HTMLButtonElement>(null);
+  const drawingButtonRef = useRef<HTMLButtonElement>(null);
+  const drawingPopoverRef = useRef<HTMLDivElement>(null);
+  const [showDrawingMenu, setShowDrawingMenu] = useState(false);
+  const [drawingAnchorRect, setDrawingAnchorRect] = useState<DOMRect | null>(
+    null
+  );
   const [showCatalystPicker, setShowCatalystPicker] = useState(false);
   const [catalystAnchorRect, setCatalystAnchorRect] = useState<DOMRect | null>(
     null
@@ -436,6 +453,30 @@ export const Dock: React.FC = () => {
     }
     setShowCatalystPicker((prev) => !prev);
   }, [showCatalystPicker]);
+
+  /**
+   * Draw tool click:
+   *  - If an annotation is already active, clicking Draw is a shortcut to
+   *    close it (toggle-off) without showing the picker.
+   *  - Otherwise, show a small popover so the teacher can explicitly choose
+   *    between full-screen annotation and a windowed whiteboard widget.
+   */
+  const handleToggleDrawingMenu = useCallback(() => {
+    if (annotationActive) {
+      closeAnnotation();
+      setShowDrawingMenu(false);
+      return;
+    }
+    if (!showDrawingMenu && drawingButtonRef.current) {
+      setDrawingAnchorRect(drawingButtonRef.current.getBoundingClientRect());
+    }
+    setShowDrawingMenu((prev) => !prev);
+  }, [annotationActive, closeAnnotation, showDrawingMenu]);
+
+  // Close drawing popover when clicking outside
+  useClickOutside(drawingPopoverRef, () => {
+    if (showDrawingMenu) setShowDrawingMenu(false);
+  }, [drawingButtonRef]);
 
   const handleLongPress = useCallback(() => {
     setIsEditMode(true);
@@ -624,6 +665,70 @@ export const Dock: React.FC = () => {
           onClose={() => setShowCatalystPicker(false)}
         />
       )}
+
+      {showDrawingMenu &&
+        drawingAnchorRect &&
+        createPortal(
+          <GlassCard
+            globalStyle={globalStyle}
+            ref={drawingPopoverRef}
+            style={{
+              position: 'fixed',
+              left: drawingAnchorRect.left + drawingAnchorRect.width / 2,
+              bottom: window.innerHeight - drawingAnchorRect.top + 10,
+              transform: 'translateX(-50%)',
+              zIndex: Z_INDEX.popover,
+            }}
+            className="w-64 overflow-hidden animate-in slide-in-from-bottom-2 duration-200"
+          >
+            <div className="bg-white/50 px-3 py-2 border-b border-white/30">
+              <span className="text-xxs font-black uppercase text-slate-600 tracking-wider">
+                Draw mode
+              </span>
+            </div>
+            <div className="p-2 space-y-1">
+              <button
+                onClick={() => {
+                  setShowDrawingMenu(false);
+                  openAnnotation();
+                }}
+                className="w-full flex items-start gap-3 p-2.5 hover:bg-white/60 rounded-lg transition-colors text-left"
+              >
+                <div className="shrink-0 w-9 h-9 rounded-lg bg-brand-blue-primary/10 text-brand-blue-primary flex items-center justify-center">
+                  <Maximize className="w-5 h-5" />
+                </div>
+                <div className="min-w-0">
+                  <div className="text-sm font-bold text-slate-800">
+                    Annotate screen
+                  </div>
+                  <div className="text-xxs text-slate-500 leading-tight">
+                    Draw over everything. Ephemeral — closes cleanly.
+                  </div>
+                </div>
+              </button>
+              <button
+                onClick={() => {
+                  setShowDrawingMenu(false);
+                  addWidget('drawing');
+                }}
+                className="w-full flex items-start gap-3 p-2.5 hover:bg-white/60 rounded-lg transition-colors text-left"
+              >
+                <div className="shrink-0 w-9 h-9 rounded-lg bg-cyan-500/10 text-cyan-600 flex items-center justify-center">
+                  <Pencil className="w-5 h-5" />
+                </div>
+                <div className="min-w-0">
+                  <div className="text-sm font-bold text-slate-800">
+                    Open whiteboard
+                  </div>
+                  <div className="text-xxs text-slate-500 leading-tight">
+                    Add a windowed whiteboard widget to your board.
+                  </div>
+                </div>
+              </button>
+            </div>
+          </GlassCard>,
+          document.body
+        )}
 
       {imagePastePending !== null && (
         <ImagePastePickerModal
@@ -938,6 +1043,41 @@ export const Dock: React.FC = () => {
                                   : undefined
                               }
                               buttonRef={catalystButtonRef}
+                            />
+                          );
+                        }
+
+                        // Handle "drawing" with a mode-picker popover
+                        // (Annotate screen vs Open whiteboard)
+                        if (item.toolType === 'drawing') {
+                          const minimizedDrawing =
+                            minimizedWidgetsByType['drawing'] ?? [];
+                          return (
+                            <ToolDockItem
+                              key={tool.type}
+                              tool={tool}
+                              minimizedWidgets={minimizedDrawing}
+                              onAdd={handleToggleDrawingMenu}
+                              onRestore={(id) =>
+                                updateWidget(id, { minimized: false })
+                              }
+                              onDelete={(id) => removeWidget(id)}
+                              onDeleteAll={() =>
+                                removeWidgets(minimizedDrawing.map((w) => w.id))
+                              }
+                              onRemoveFromDock={() =>
+                                toggleToolVisibility(tool.type)
+                              }
+                              isEditMode={isEditMode}
+                              onLongPress={handleLongPress}
+                              globalStyle={globalStyle}
+                              customLabel={getToolLabel(tool.type)}
+                              onClickOverride={
+                                minimizedDrawing.length === 0
+                                  ? handleToggleDrawingMenu
+                                  : undefined
+                              }
+                              buttonRef={drawingButtonRef}
                             />
                           );
                         }

--- a/components/layout/dock/FolderItem.tsx
+++ b/components/layout/dock/FolderItem.tsx
@@ -31,6 +31,7 @@ import {
   WidgetData,
   InternalToolType,
 } from '@/types';
+import { beginWidgetDrag, endWidgetDrag } from '@/utils/widgetDragFlag';
 
 interface FolderItemProps {
   folder: DockFolder;
@@ -96,6 +97,7 @@ export const FolderItem = React.memo(
 
     const handleDragEnd = useCallback(
       (event: DragEndEvent) => {
+        endWidgetDrag();
         const { active, over } = event;
         if (active.id !== over?.id) {
           const oldIndex = folder.items.indexOf(
@@ -149,7 +151,9 @@ export const FolderItem = React.memo(
               <DndContext
                 sensors={sensors}
                 collisionDetection={closestCenter}
+                onDragStart={beginWidgetDrag}
                 onDragEnd={handleDragEnd}
+                onDragCancel={endWidgetDrag}
               >
                 <SortableContext
                   items={folder.items}

--- a/components/layout/dock/WidgetLibrary.tsx
+++ b/components/layout/dock/WidgetLibrary.tsx
@@ -33,6 +33,7 @@ import { WidgetType, GlobalStyle, InternalToolType } from '@/types';
 import { useClickOutside } from '@/hooks/useClickOutside';
 import { useDialog } from '@/context/useDialog';
 import { useDashboard } from '@/context/useDashboard';
+import { beginWidgetDrag, endWidgetDrag } from '@/utils/widgetDragFlag';
 
 // O(1) Lookup Map for TOOLS optimization.
 // Extracted outside the component to prevent recreating the map on every mount.
@@ -196,6 +197,7 @@ export const WidgetLibrary = forwardRef<HTMLDivElement, WidgetLibraryProps>(
 
     const handleDragEnd = useCallback(
       (event: DragEndEvent) => {
+        endWidgetDrag();
         const { active, over } = event;
         if (over && active.id !== over.id) {
           const oldIndex = effectiveOrder.indexOf(
@@ -314,7 +316,9 @@ export const WidgetLibrary = forwardRef<HTMLDivElement, WidgetLibraryProps>(
               <DndContext
                 sensors={sensors}
                 collisionDetection={closestCenter}
+                onDragStart={beginWidgetDrag}
                 onDragEnd={handleDragEnd}
+                onDragCancel={endWidgetDrag}
               >
                 <SortableContext
                   items={availableTools.map((t) => t.type)}

--- a/components/layout/sidebar/SidebarBoards.tsx
+++ b/components/layout/sidebar/SidebarBoards.tsx
@@ -26,6 +26,7 @@ import { SortableDashboardItem } from './SortableDashboardItem';
 import { useDialog } from '@/context/useDialog';
 import { SaveAsTemplateModal } from '@/components/admin/SaveAsTemplateModal';
 import { db as firestoreDb, isAuthBypass } from '@/config/firebase';
+import { beginWidgetDrag, endWidgetDrag } from '@/utils/widgetDragFlag';
 
 const TEMPLATES_COLLECTION = 'dashboard_templates';
 
@@ -122,6 +123,7 @@ export const SidebarBoards: React.FC<SidebarBoardsProps> = ({ isVisible }) => {
 
   const handleDragEnd = useCallback(
     (event: DragEndEvent) => {
+      endWidgetDrag();
       const { active, over } = event;
 
       if (over && active.id !== over.id) {
@@ -271,7 +273,9 @@ export const SidebarBoards: React.FC<SidebarBoardsProps> = ({ isVisible }) => {
             <DndContext
               sensors={sensors}
               collisionDetection={closestCenter}
+              onDragStart={beginWidgetDrag}
               onDragEnd={handleDragEnd}
+              onDragCancel={endWidgetDrag}
             >
               <SortableContext
                 items={dashboards.map((d) => d.id)}

--- a/components/student/StudentContexts.tsx
+++ b/components/student/StudentContexts.tsx
@@ -269,7 +269,7 @@ const mockDashboard: DashboardContextValue = {
   // Annotation (app-level overlay) — not applicable in student view
   annotationActive: false,
   annotationState: {
-    paths: [],
+    objects: [],
     color: '#000000',
     width: 4,
     customColors: ['#000000', '#ffffff', '#ff0000', '#00ff00', '#0000ff'],
@@ -283,7 +283,7 @@ const mockDashboard: DashboardContextValue = {
   updateAnnotationState: () => {
     // No-op
   },
-  addAnnotationPath: () => {
+  addAnnotationObject: () => {
     // No-op
   },
   undoAnnotation: () => {

--- a/components/student/StudentContexts.tsx
+++ b/components/student/StudentContexts.tsx
@@ -266,6 +266,32 @@ const mockDashboard: DashboardContextValue = {
   setActiveRoster: () => {
     // No-op
   },
+  // Annotation (app-level overlay) — not applicable in student view
+  annotationActive: false,
+  annotationState: {
+    paths: [],
+    color: '#000000',
+    width: 4,
+    customColors: ['#000000', '#ffffff', '#ff0000', '#00ff00', '#0000ff'],
+  },
+  openAnnotation: () => {
+    // No-op
+  },
+  closeAnnotation: () => {
+    // No-op
+  },
+  updateAnnotationState: () => {
+    // No-op
+  },
+  addAnnotationPath: () => {
+    // No-op
+  },
+  undoAnnotation: () => {
+    // No-op
+  },
+  clearAnnotation: () => {
+    // No-op
+  },
 };
 
 export const StudentProvider: React.FC<StudentProviderProps> = ({

--- a/components/widgets/DrawingWidget/Settings.tsx
+++ b/components/widgets/DrawingWidget/Settings.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useDashboard } from '@/context/useDashboard';
 import { WidgetData, DrawingConfig } from '@/types';
-import { Pencil, Palette, Minimize, Maximize } from 'lucide-react';
+import { Pencil, Palette } from 'lucide-react';
 import { SettingsLabel } from '@/components/common/SettingsLabel';
 import { DRAWING_DEFAULTS } from './constants';
 
@@ -73,29 +73,11 @@ export const DrawingSettings: React.FC<{ widget: WidgetData }> = ({
       </div>
 
       <div className="p-4 bg-indigo-50 rounded-2xl border border-indigo-100">
-        <h4 className="text-xxs  text-indigo-700 uppercase mb-2">
-          Modes Guide
-        </h4>
-        <div className="space-y-3">
-          <div className="flex gap-3">
-            <div className="w-5 h-5 bg-white rounded-md flex items-center justify-center shadow-sm shrink-0">
-              <Minimize className="w-3 h-3 text-indigo-600" />
-            </div>
-            <p className="text-xxs text-indigo-600 ">
-              <b>Window:</b> Standard canvas inside the widget box. Best for
-              quick sketches and notes.
-            </p>
-          </div>
-          <div className="flex gap-3">
-            <div className="w-5 h-5 bg-indigo-600 rounded-md flex items-center justify-center shadow-sm shrink-0">
-              <Maximize className="w-3 h-3 text-white" />
-            </div>
-            <p className="text-xxs text-indigo-600 ">
-              <b>Overlay:</b> Hides the window and moves the toolbar to the top
-              of your screen. Perfect for drawing over other content!
-            </p>
-          </div>
-        </div>
+        <p className="text-xxs text-indigo-600 leading-relaxed">
+          <b>Tip:</b> To annotate over your whole dashboard, click the Draw icon
+          in the Dock and choose <b>Annotate screen</b>. The whiteboard widget
+          here is best for persistent sketches and notes.
+        </p>
       </div>
     </div>
   );

--- a/components/widgets/DrawingWidget/Widget.test.tsx
+++ b/components/widgets/DrawingWidget/Widget.test.tsx
@@ -94,7 +94,7 @@ describe('DrawingWidget', () => {
     config: {
       color: '#000000',
       width: 4,
-      paths: [],
+      objects: [],
       customColors: ['#000000', '#ffffff', '#ff0000', '#00ff00', '#0000ff'],
     } as DrawingConfig,
   };
@@ -118,13 +118,16 @@ describe('DrawingWidget', () => {
     expect(container.textContent).not.toMatch(/ANNOTATE|EXIT/);
   });
 
-  it('draws existing paths on mount', () => {
-    const widgetWithPaths: WidgetData = {
+  it('draws existing path objects on mount', () => {
+    const widgetWithObjects: WidgetData = {
       ...widget,
       config: {
         ...widget.config,
-        paths: [
+        objects: [
           {
+            id: 'obj-1',
+            kind: 'path',
+            z: 0,
             color: '#ff0000',
             width: 5,
             points: [
@@ -135,9 +138,34 @@ describe('DrawingWidget', () => {
         ],
       } as DrawingConfig,
     };
-    render(<DrawingWidget widget={widgetWithPaths} />);
+    render(<DrawingWidget widget={widgetWithObjects} />);
     expect(mockContext.moveTo).toHaveBeenCalledWith(10, 10);
     expect(mockContext.lineTo).toHaveBeenCalledWith(20, 20);
+    expect(mockContext.stroke).toHaveBeenCalled();
+  });
+
+  it('migrates legacy paths[] config forward and renders strokes', () => {
+    const legacyWidget: WidgetData = {
+      ...widget,
+      config: {
+        ...widget.config,
+        // Legacy shape — objects omitted, paths present. The widget's
+        // defensive migration should wrap these as PathObjects at render.
+        paths: [
+          {
+            color: '#0000ff',
+            width: 3,
+            points: [
+              { x: 5, y: 5 },
+              { x: 15, y: 15 },
+            ],
+          },
+        ],
+      } as unknown as DrawingConfig,
+    };
+    render(<DrawingWidget widget={legacyWidget} />);
+    expect(mockContext.moveTo).toHaveBeenCalledWith(5, 5);
+    expect(mockContext.lineTo).toHaveBeenCalledWith(15, 15);
     expect(mockContext.stroke).toHaveBeenCalled();
   });
 
@@ -174,15 +202,21 @@ describe('DrawingWidget', () => {
       new PointerEvent('pointerup', { bubbles: true, cancelable: true })
     );
 
-    // Should update widget with new path
+    // Should update widget with new object
     expect(mockUpdateWidget).toHaveBeenCalled();
     const args = mockUpdateWidget.mock.calls[0];
     expect(args[0]).toBe(widget.id);
     const newConfig = (args[1] as Partial<WidgetData>).config as DrawingConfig;
-    expect(newConfig.paths).toHaveLength(1);
-    expect(newConfig.paths[0].points).toEqual([
-      { x: 10, y: 10 },
-      { x: 20, y: 20 },
-    ]);
+    const objects = newConfig.objects ?? [];
+    expect(objects).toHaveLength(1);
+    const created = objects[0];
+    expect(created.kind).toBe('path');
+    expect(typeof created.id).toBe('string');
+    if (created.kind === 'path') {
+      expect(created.points).toEqual([
+        { x: 10, y: 10 },
+        { x: 20, y: 20 },
+      ]);
+    }
   });
 });

--- a/components/widgets/DrawingWidget/Widget.test.tsx
+++ b/components/widgets/DrawingWidget/Widget.test.tsx
@@ -4,8 +4,6 @@ import { DrawingWidget } from './Widget';
 import { WidgetData, DrawingConfig } from '@/types';
 import { useDashboard } from '@/context/useDashboard';
 import { useAuth } from '@/context/useAuth';
-import { useLiveSession } from '@/hooks/useLiveSession';
-import { useScreenshot } from '@/hooks/useScreenshot';
 
 // Mock hooks
 vi.mock('../../../context/useDashboard', () => ({
@@ -13,12 +11,6 @@ vi.mock('../../../context/useDashboard', () => ({
 }));
 vi.mock('../../../context/useAuth', () => ({
   useAuth: vi.fn(),
-}));
-vi.mock('../../../hooks/useLiveSession', () => ({
-  useLiveSession: vi.fn(),
-}));
-vi.mock('../../../hooks/useScreenshot', () => ({
-  useScreenshot: vi.fn(),
 }));
 
 interface MockContext {
@@ -43,20 +35,13 @@ describe('DrawingWidget', () => {
     mockUpdateWidget = vi.fn();
     (useDashboard as Mock).mockReturnValue({
       updateWidget: mockUpdateWidget,
-      activeDashboard: { background: 'bg-slate-900' },
+      activeDashboard: { background: 'bg-slate-900', widgets: [] },
+      addToast: vi.fn(),
+      addWidget: vi.fn(),
     });
     (useAuth as Mock).mockReturnValue({
       user: { uid: 'user1' },
       canAccessFeature: vi.fn(() => true),
-    });
-    (useLiveSession as Mock).mockReturnValue({
-      session: null,
-      startSession: vi.fn(),
-      endSession: vi.fn(),
-    });
-    (useScreenshot as Mock).mockReturnValue({
-      takeScreenshot: vi.fn(),
-      isCapturing: false,
     });
 
     // Mock Canvas
@@ -107,17 +92,30 @@ describe('DrawingWidget', () => {
     z: 1,
     flipped: false,
     config: {
-      mode: 'window',
       color: '#000000',
       width: 4,
       paths: [],
       customColors: ['#000000', '#ffffff', '#ff0000', '#00ff00', '#0000ff'],
-    },
+    } as DrawingConfig,
   };
 
   it('renders without crashing', () => {
     render(<DrawingWidget widget={widget} />);
     expect(mockContext.clearRect).toHaveBeenCalled();
+  });
+
+  it('no longer renders the Assign (Cast) or Save-to-Cloud buttons', () => {
+    const { container } = render(<DrawingWidget widget={widget} />);
+    // Previously the overlay-mode toolbar included buttons titled "Assign..."
+    // and "Save to Cloud". Those were removed in the annotation overhaul.
+    expect(container.querySelector('[title*="Assign"]')).toBeNull();
+    expect(container.querySelector('[title*="Save to Cloud"]')).toBeNull();
+  });
+
+  it('no longer renders the ANNOTATE / EXIT mode toggle', () => {
+    const { container } = render(<DrawingWidget widget={widget} />);
+    // Mode toggle moved to dock-level popover
+    expect(container.textContent).not.toMatch(/ANNOTATE|EXIT/);
   });
 
   it('draws existing paths on mount', () => {

--- a/components/widgets/DrawingWidget/Widget.tsx
+++ b/components/widgets/DrawingWidget/Widget.tsx
@@ -47,7 +47,7 @@ export const DrawingWidget: React.FC<{
     });
   };
 
-  const { handleStart, handleMove, handleEnd } = useDrawingCanvas({
+  const { handleStart, handleMove, handleEnd, isDrawing } = useDrawingCanvas({
     canvasRef,
     color,
     width,
@@ -215,7 +215,7 @@ export const DrawingWidget: React.FC<{
           className="absolute inset-0"
           style={{ touchAction: 'none' }}
         />
-        {paths.length === 0 && (
+        {paths.length === 0 && !isDrawing && (
           <div className="absolute inset-0 flex items-center justify-center pointer-events-none text-slate-400">
             <Pencil className="w-8 h-8 opacity-20" />
           </div>

--- a/components/widgets/DrawingWidget/Widget.tsx
+++ b/components/widgets/DrawingWidget/Widget.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo, useRef, useState } from 'react';
 import { useDashboard } from '@/context/useDashboard';
-import { WidgetData, DrawingConfig, Path, TextConfig } from '@/types';
+import { WidgetData, DrawableObject, DrawingConfig, TextConfig } from '@/types';
 import { Pencil, Eraser, Trash2, Undo2, Type } from 'lucide-react';
 import { extractTextWithGemini } from '@/utils/ai';
 import { useAuth } from '@/context/useAuth';
@@ -8,6 +8,7 @@ import { Button } from '@/components/common/Button';
 import { STANDARD_COLORS } from '@/config/colors';
 import { DRAWING_DEFAULTS } from './constants';
 import { useDrawingCanvas } from './useDrawingCanvas';
+import { migrateDrawingConfig, nextZ } from '@/utils/migrateDrawingConfig';
 
 export const DrawingWidget: React.FC<{
   widget: WidgetData;
@@ -17,11 +18,17 @@ export const DrawingWidget: React.FC<{
   const { updateWidget, activeDashboard, addToast, addWidget } = useDashboard();
   const { canAccessFeature } = useAuth();
 
-  const config = widget.config as DrawingConfig;
+  // Defensive migration — the canonical migration happens during dashboard
+  // hydration, but widgets constructed in tests or edge cases may still
+  // carry the legacy `paths[]` shape.
+  const config = useMemo(
+    () => migrateDrawingConfig(widget.config as DrawingConfig),
+    [widget.config]
+  );
   const {
     color = STANDARD_COLORS.slate,
     width = DRAWING_DEFAULTS.WIDTH,
-    paths = [],
+    objects,
     customColors = DRAWING_DEFAULTS.CUSTOM_COLORS,
   } = config;
 
@@ -38,11 +45,11 @@ export const DrawingWidget: React.FC<{
     return { width: widget.w, height: Math.max(widget.h - 40, 0) };
   }, [isStudentView, widget.w, widget.h]);
 
-  const appendPath = (path: Path) => {
+  const appendObject = (obj: DrawableObject) => {
     updateWidget(widget.id, {
       config: {
         ...config,
-        paths: [...paths, path],
+        objects: [...objects, obj],
       } as DrawingConfig,
     });
   };
@@ -51,22 +58,23 @@ export const DrawingWidget: React.FC<{
     canvasRef,
     color,
     width,
-    paths,
-    onPathComplete: appendPath,
+    objects,
+    onObjectComplete: appendObject,
     scale,
     disabled: isStudentView,
     canvasSize,
+    nextZ: nextZ(objects),
   });
 
   const clear = () => {
     updateWidget(widget.id, {
-      config: { ...config, paths: [] } as DrawingConfig,
+      config: { ...config, objects: [] } as DrawingConfig,
     });
   };
 
   const undo = () => {
     updateWidget(widget.id, {
-      config: { ...config, paths: paths.slice(0, -1) } as DrawingConfig,
+      config: { ...config, objects: objects.slice(0, -1) } as DrawingConfig,
     });
   };
 
@@ -215,7 +223,7 @@ export const DrawingWidget: React.FC<{
           className="absolute inset-0"
           style={{ touchAction: 'none' }}
         />
-        {paths.length === 0 && !isDrawing && (
+        {objects.length === 0 && !isDrawing && (
           <div className="absolute inset-0 flex items-center justify-center pointer-events-none text-slate-400">
             <Pencil className="w-8 h-8 opacity-20" />
           </div>

--- a/components/widgets/DrawingWidget/Widget.tsx
+++ b/components/widgets/DrawingWidget/Widget.tsx
@@ -1,27 +1,13 @@
-import React, { useState, useRef, useEffect, useCallback } from 'react';
-import { createPortal } from 'react-dom';
+import React, { useMemo, useRef, useState } from 'react';
 import { useDashboard } from '@/context/useDashboard';
-import { WidgetData, DrawingConfig, Point, Path, TextConfig } from '@/types';
-import {
-  Pencil,
-  Eraser,
-  Trash2,
-  Maximize,
-  Undo2,
-  MousePointer2,
-  Minimize2,
-  Camera,
-  Cast,
-  CloudUpload,
-  Type,
-} from 'lucide-react';
-import { useScreenshot } from '@/hooks/useScreenshot';
+import { WidgetData, DrawingConfig, Path, TextConfig } from '@/types';
+import { Pencil, Eraser, Trash2, Undo2, Type } from 'lucide-react';
 import { extractTextWithGemini } from '@/utils/ai';
 import { useAuth } from '@/context/useAuth';
-import { useLiveSession } from '@/hooks/useLiveSession';
 import { Button } from '@/components/common/Button';
 import { STANDARD_COLORS } from '@/config/colors';
 import { DRAWING_DEFAULTS } from './constants';
+import { useDrawingCanvas } from './useDrawingCanvas';
 
 export const DrawingWidget: React.FC<{
   widget: WidgetData;
@@ -29,50 +15,10 @@ export const DrawingWidget: React.FC<{
   scale?: number;
 }> = ({ widget, isStudentView = false, scale = 1 }) => {
   const { updateWidget, activeDashboard, addToast, addWidget } = useDashboard();
-  const { user, canAccessFeature } = useAuth();
-  const { session, startSession, endSession } = useLiveSession(
-    user?.uid,
-    'teacher'
-  );
-
-  const isLive = session?.isActive && session?.activeWidgetId === widget.id;
-
-  const handleToggleLive = async () => {
-    try {
-      if (isLive) {
-        await endSession();
-      } else {
-        const newSession = await startSession(
-          widget.id,
-          widget.type,
-          widget.config,
-          activeDashboard?.background
-        );
-        const url = `${window.location.origin}/join?code=${newSession.code}`;
-        if (typeof navigator !== 'undefined' && navigator.clipboard) {
-          void navigator.clipboard
-            .writeText(url)
-            .then(() =>
-              addToast('Assignment link copied to clipboard!', 'success')
-            )
-            .catch(() =>
-              addToast(
-                'Assignment created, but link could not be copied.',
-                'info'
-              )
-            );
-        } else {
-          addToast('Assignment created, but link could not be copied.', 'info');
-        }
-      }
-    } catch (error) {
-      console.error('Failed to toggle live session:', error);
-    }
-  };
+  const { canAccessFeature } = useAuth();
 
   const config = widget.config as DrawingConfig;
   const {
-    mode = DRAWING_DEFAULTS.MODE,
     color = STANDARD_COLORS.slate,
     width = DRAWING_DEFAULTS.WIDTH,
     paths = [],
@@ -80,202 +26,47 @@ export const DrawingWidget: React.FC<{
   } = config;
 
   const canvasRef = useRef<HTMLCanvasElement>(null);
-  const [isDrawing, setIsDrawing] = useState(false);
   const [isExtracting, setIsExtracting] = useState(false);
-  const currentPathRef = useRef<Point[]>([]);
-  const [portalTarget, setPortalTarget] = useState<HTMLElement | null>(null);
 
-  useEffect(() => {
-    // Try to find the target immediately, but also use a MutationObserver or a small delay
-    // if it's not found, to handle cases where DashboardView hasn't mounted yet.
-    const findTarget = () => {
-      const target = document.getElementById('dashboard-root');
-      if (target) {
-        setPortalTarget(target);
-        return true;
-      }
-      return false;
-    };
-
-    if (!findTarget()) {
-      const observer = new MutationObserver(() => {
-        if (findTarget()) observer.disconnect();
-      });
-      observer.observe(document.body, { childList: true, subtree: true });
-      return () => observer.disconnect();
+  // Canvas internal resolution follows the widget (minus header) in window mode,
+  // or the parent container in student view.
+  const canvasSize = useMemo(() => {
+    if (isStudentView) {
+      // Student view sizes canvas to its container; fall back to widget dims.
+      return { width: widget.w, height: widget.h };
     }
-    return undefined;
-  }, []);
+    return { width: widget.w, height: Math.max(widget.h - 40, 0) };
+  }, [isStudentView, widget.w, widget.h]);
 
-  const { takeScreenshot, isCapturing } = useScreenshot(
-    portalTarget,
-    `Classroom-Annotation-${new Date().toISOString().split('T')[0]}`,
-    {
-      onSuccess: (url) => {
-        if (url) {
-          addToast('Drawing saved to cloud!', 'success');
-        }
-      },
-    }
-  );
-
-  const setContextStyles = useCallback(
-    (ctx: CanvasRenderingContext2D) => {
-      ctx.lineCap = 'round';
-      ctx.lineJoin = 'round';
-      if (color === 'eraser') {
-        ctx.globalCompositeOperation = 'destination-out';
-        ctx.strokeStyle = 'rgba(0,0,0,1)';
-      } else {
-        ctx.globalCompositeOperation = 'source-over';
-        ctx.strokeStyle = color;
-      }
-      ctx.lineWidth = width;
-    },
-    [color, width]
-  );
-
-  // Draw paths on the canvas whenever they change
-  const draw = useCallback(
-    (ctx: CanvasRenderingContext2D, allPaths: Path[], current: Point[]) => {
-      ctx.clearRect(0, 0, ctx.canvas.width, ctx.canvas.height);
-
-      const renderPath = (p: Path) => {
-        if (p.points.length < 2) return;
-        ctx.beginPath();
-        ctx.lineCap = 'round';
-        ctx.lineJoin = 'round';
-
-        if (p.color === 'eraser') {
-          ctx.globalCompositeOperation = 'destination-out';
-          ctx.strokeStyle = 'rgba(0,0,0,1)';
-        } else {
-          ctx.globalCompositeOperation = 'source-over';
-          ctx.strokeStyle = p.color;
-        }
-
-        ctx.lineWidth = p.width;
-        ctx.moveTo(p.points[0].x, p.points[0].y);
-        for (let i = 1; i < p.points.length; i++) {
-          ctx.lineTo(p.points[i].x, p.points[i].y);
-        }
-        ctx.stroke();
-        ctx.globalCompositeOperation = 'source-over';
-      };
-
-      allPaths.forEach(renderPath);
-      if (current.length > 1) {
-        renderPath({ points: current, color, width });
-      }
-    },
-    [color, width]
-  );
-
-  useEffect(() => {
-    const canvas = canvasRef.current;
-    if (!canvas) return;
-    const ctx = canvas.getContext('2d');
-    if (!ctx) return;
-
-    // Set internal resolution
-    if (mode === 'window') {
-      if (isStudentView) {
-        // Fill the student container
-        const container = canvas.parentElement;
-        canvas.width = container?.clientWidth ?? 800;
-        canvas.height = container?.clientHeight ?? 600;
-      } else {
-        canvas.width = widget.w;
-        canvas.height = widget.h - 40; // Subtract header
-      }
-    } else {
-      canvas.width = window.innerWidth;
-      canvas.height = window.innerHeight;
-    }
-
-    draw(ctx, paths, currentPathRef.current);
-  }, [paths, mode, widget.w, widget.h, draw, isStudentView]);
-
-  const handleStart = (e: React.PointerEvent) => {
-    if (isStudentView) return;
-    setIsDrawing(true);
-    const pos = getPos(e);
-    currentPathRef.current = [pos];
-
-    // Start imperative drawing
-    const ctx = canvasRef.current?.getContext('2d');
-    if (ctx) {
-      setContextStyles(ctx);
-      ctx.beginPath();
-      ctx.moveTo(pos.x, pos.y);
-    }
-  };
-
-  const handleMove = (e: React.PointerEvent) => {
-    if (isStudentView || !isDrawing) return;
-    const pos = getPos(e);
-    currentPathRef.current.push(pos);
-
-    // Imperatively draw the new segment
-    const ctx = canvasRef.current?.getContext('2d');
-    if (ctx && currentPathRef.current.length > 1) {
-      // Ensure styles are set (in case they were lost or reset)
-      setContextStyles(ctx);
-
-      const prev = currentPathRef.current[currentPathRef.current.length - 2];
-      ctx.beginPath();
-      ctx.moveTo(prev.x, prev.y);
-      ctx.lineTo(pos.x, pos.y);
-      ctx.stroke();
-    }
-  };
-
-  const handleEnd = () => {
-    if (!isDrawing) return;
-    setIsDrawing(false);
-    if (currentPathRef.current.length > 1) {
-      const newPath: Path = { points: currentPathRef.current, color, width };
-      updateWidget(widget.id, {
-        config: {
-          ...config,
-          paths: [...paths, newPath],
-        } as DrawingConfig,
-      });
-    }
-    currentPathRef.current = [];
-  };
-
-  const getPos = (e: React.PointerEvent): Point => {
-    const canvas = canvasRef.current;
-    if (!canvas) {
-      return { x: 0, y: 0 };
-    }
-    const rect = canvas.getBoundingClientRect();
-    // When in window mode, we must account for the CSS transform scale applied by the parent ScalableWidget
-    // In overlay mode, the canvas is portalled to the root and is not scaled.
-    const effectiveScale = mode === 'overlay' ? 1 : scale;
-
-    return {
-      x: (e.clientX - rect.left) / effectiveScale,
-      y: (e.clientY - rect.top) / effectiveScale,
-    };
-  };
-
-  const clear = () => {
+  const appendPath = (path: Path) => {
     updateWidget(widget.id, {
       config: {
         ...config,
-        paths: [],
+        paths: [...paths, path],
       } as DrawingConfig,
+    });
+  };
+
+  const { handleStart, handleMove, handleEnd } = useDrawingCanvas({
+    canvasRef,
+    color,
+    width,
+    paths,
+    onPathComplete: appendPath,
+    scale,
+    disabled: isStudentView,
+    canvasSize,
+  });
+
+  const clear = () => {
+    updateWidget(widget.id, {
+      config: { ...config, paths: [] } as DrawingConfig,
     });
   };
 
   const undo = () => {
     updateWidget(widget.id, {
-      config: {
-        ...config,
-        paths: paths.slice(0, -1),
-      } as DrawingConfig,
+      config: { ...config, paths: paths.slice(0, -1) } as DrawingConfig,
     });
   };
 
@@ -348,26 +139,22 @@ export const DrawingWidget: React.FC<{
             key={c}
             onClick={() =>
               updateWidget(widget.id, {
-                config: {
-                  ...config,
-                  color: c,
-                } as DrawingConfig,
+                config: { ...config, color: c } as DrawingConfig,
               })
             }
             className={`w-6 h-6 rounded-md transition-all ${color === c ? 'scale-110 shadow-sm ring-2 ring-indigo-500' : 'hover:scale-105'}`}
             style={{ backgroundColor: c }}
+            aria-label={`Color ${c}`}
           />
         ))}
         <button
           onClick={() =>
             updateWidget(widget.id, {
-              config: {
-                ...config,
-                color: 'eraser',
-              } as DrawingConfig,
+              config: { ...config, color: 'eraser' } as DrawingConfig,
             })
           }
           className={`w-6 h-6 rounded-md bg-white border border-slate-200 flex items-center justify-center transition-all ${color === 'eraser' ? 'ring-2 ring-indigo-500' : ''}`}
+          aria-label="Eraser"
         >
           <Eraser className="w-3 h-3 text-slate-400" />
         </button>
@@ -390,132 +177,27 @@ export const DrawingWidget: React.FC<{
         icon={<Trash2 className="w-4 h-4" />}
       />
 
-      <div className="h-6 w-px bg-slate-200 mx-1" />
-
-      {mode === 'overlay' && (
+      {canAccessFeature('gemini-functions') && (
         <>
-          <Button
-            onClick={() => void handleToggleLive()}
-            variant={isLive ? 'danger' : 'ghost'}
-            size="icon"
-            className={isLive ? 'animate-pulse' : ''}
-            title={isLive ? 'End Assignment' : 'Assign (copy student link)'}
-            icon={<Cast className="w-4 h-4" />}
-          />
-          <Button
-            onClick={() => void takeScreenshot()}
-            disabled={isCapturing}
-            variant="ghost"
-            size="icon"
-            title="Capture Full Screen"
-            icon={<Camera className="w-4 h-4" />}
-          />
-          <Button
-            onClick={() => void takeScreenshot({ upload: true })}
-            disabled={isCapturing}
-            variant="ghost"
-            size="icon"
-            title="Save to Cloud"
-            icon={<CloudUpload className="w-4 h-4" />}
-          />
-          {canAccessFeature('gemini-functions') && (
-            <Button
-              onClick={() => void handleSendToText()}
-              disabled={isCapturing || isExtracting}
-              variant="ghost"
-              size="icon"
-              title="Extract Text (AI)"
-              icon={
-                isExtracting ? (
-                  <div className="w-4 h-4 border-2 border-slate-400 border-t-transparent rounded-full animate-spin" />
-                ) : (
-                  <Type className="w-4 h-4" />
-                )
-              }
-            />
-          )}
           <div className="h-6 w-px bg-slate-200 mx-1" />
+          <Button
+            onClick={() => void handleSendToText()}
+            disabled={isExtracting}
+            variant="ghost"
+            size="icon"
+            title="Extract Text (AI)"
+            icon={
+              isExtracting ? (
+                <div className="w-4 h-4 border-2 border-slate-400 border-t-transparent rounded-full animate-spin" />
+              ) : (
+                <Type className="w-4 h-4" />
+              )
+            }
+          />
         </>
       )}
-
-      <Button
-        onClick={() =>
-          updateWidget(widget.id, {
-            config: {
-              ...config,
-              mode: mode === 'window' ? 'overlay' : 'window',
-            } as DrawingConfig,
-          })
-        }
-        variant={mode === 'overlay' ? 'primary' : 'secondary'}
-        size="sm"
-        className={mode === 'overlay' ? 'shadow-lg' : ''}
-        icon={
-          mode === 'overlay' ? (
-            <Minimize2 className="w-3 h-3" />
-          ) : (
-            <Maximize className="w-3 h-3" />
-          )
-        }
-      >
-        {mode === 'overlay' ? (
-          <span>EXIT</span>
-        ) : (
-          widget.w > 250 && <span>ANNOTATE</span>
-        )}
-      </Button>
     </div>
   );
-
-  if (mode === 'overlay') {
-    // Show loading state while waiting for portal target
-    if (!portalTarget) {
-      return (
-        <div className="h-full flex items-center justify-center bg-slate-50">
-          <div className="text-center space-y-2">
-            <div className="w-8 h-8 border-4 border-indigo-600 border-t-transparent rounded-full animate-spin mx-auto" />
-            <p className="text-xs text-slate-500 ">Preparing overlay mode...</p>
-          </div>
-        </div>
-      );
-    }
-
-    return (
-      <>
-        {createPortal(
-          <div className="fixed inset-0 z-overlay pointer-events-none overflow-hidden">
-            {/* Darken background slightly to indicate annotation mode */}
-            <div className="absolute inset-0 bg-slate-900/10 pointer-events-none" />
-            <canvas
-              ref={canvasRef}
-              onPointerDown={handleStart}
-              onPointerMove={handleMove}
-              onPointerUp={handleEnd}
-              onPointerLeave={handleEnd}
-              className="absolute inset-0 pointer-events-auto cursor-crosshair"
-              style={{ touchAction: 'none' }}
-            />
-            {/* Floating Toolbar at the Top */}
-            {!isStudentView && (
-              <div
-                data-screenshot="exclude"
-                className="absolute top-6 left-1/2 -translate-x-1/2 pointer-events-auto bg-white/60 backdrop-blur-xl rounded-2xl shadow-2xl border border-white/40 p-1 flex items-center gap-1 animate-in slide-in-from-top duration-300"
-              >
-                <div className="px-3 flex items-center gap-2 border-r border-white/30 mr-1">
-                  <MousePointer2 className="w-4 h-4 text-indigo-600 animate-pulse" />
-                  <span className="text-xxs  font-black uppercase tracking-widest text-slate-700">
-                    Annotating
-                  </span>
-                </div>
-                {PaletteUI}
-              </div>
-            )}
-          </div>,
-          portalTarget
-        )}
-      </>
-    );
-  }
 
   return (
     <div className="h-full flex flex-col overflow-hidden">
@@ -533,7 +215,7 @@ export const DrawingWidget: React.FC<{
           className="absolute inset-0"
           style={{ touchAction: 'none' }}
         />
-        {paths.length === 0 && !isDrawing && (
+        {paths.length === 0 && (
           <div className="absolute inset-0 flex items-center justify-center pointer-events-none text-slate-400">
             <Pencil className="w-8 h-8 opacity-20" />
           </div>

--- a/components/widgets/DrawingWidget/constants.ts
+++ b/components/widgets/DrawingWidget/constants.ts
@@ -3,5 +3,4 @@ import { WIDGET_PALETTE } from '@/config/colors';
 export const DRAWING_DEFAULTS = {
   WIDTH: 4,
   CUSTOM_COLORS: WIDGET_PALETTE.slice(0, 5),
-  MODE: 'window' as const,
 };

--- a/components/widgets/DrawingWidget/useDrawingCanvas.test.ts
+++ b/components/widgets/DrawingWidget/useDrawingCanvas.test.ts
@@ -1,0 +1,333 @@
+import { describe, it, expect, vi, beforeEach, afterEach, Mock } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import React from 'react';
+import { useDrawingCanvas } from './useDrawingCanvas';
+import type { DrawableObject, PathObject } from '@/types';
+
+interface MockCtx {
+  clearRect: Mock;
+  beginPath: Mock;
+  moveTo: Mock;
+  lineTo: Mock;
+  stroke: Mock;
+  canvas: { width: number; height: number };
+  lineCap: string;
+  lineJoin: string;
+  globalCompositeOperation: string;
+  strokeStyle: string;
+  lineWidth: number;
+}
+
+const makeMockCtx = (): MockCtx => ({
+  clearRect: vi.fn(),
+  beginPath: vi.fn(),
+  moveTo: vi.fn(),
+  lineTo: vi.fn(),
+  stroke: vi.fn(),
+  canvas: { width: 800, height: 600 },
+  lineCap: 'round',
+  lineJoin: 'round',
+  globalCompositeOperation: 'source-over',
+  strokeStyle: '#000000',
+  lineWidth: 1,
+});
+
+const makeCanvas = (): HTMLCanvasElement => {
+  const canvas = document.createElement('canvas');
+  canvas.width = 800;
+  canvas.height = 600;
+  return canvas;
+};
+
+const pathObj = (overrides: Partial<PathObject> = {}): PathObject => ({
+  id: 'obj-1',
+  kind: 'path',
+  z: 0,
+  points: [
+    { x: 0, y: 0 },
+    { x: 10, y: 10 },
+  ],
+  color: '#f00',
+  width: 4,
+  ...overrides,
+});
+
+describe('useDrawingCanvas', () => {
+  let mockCtx: MockCtx;
+
+  beforeEach(() => {
+    mockCtx = makeMockCtx();
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue(
+      mockCtx as unknown as CanvasRenderingContext2D
+    );
+    vi.spyOn(
+      HTMLCanvasElement.prototype,
+      'getBoundingClientRect'
+    ).mockReturnValue({
+      left: 0,
+      top: 0,
+      width: 800,
+      height: 600,
+      right: 800,
+      bottom: 600,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+    } as DOMRect);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renders existing path objects on mount', () => {
+    const canvas = makeCanvas();
+    const canvasRef = { current: canvas };
+    const objects: DrawableObject[] = [
+      pathObj({
+        points: [
+          { x: 3, y: 3 },
+          { x: 7, y: 7 },
+        ],
+      }),
+    ];
+
+    renderHook(() =>
+      useDrawingCanvas({
+        canvasRef,
+        color: '#000',
+        width: 4,
+        objects,
+        onObjectComplete: vi.fn(),
+        canvasSize: { width: 800, height: 600 },
+        nextZ: 1,
+      })
+    );
+
+    expect(mockCtx.clearRect).toHaveBeenCalled();
+    expect(mockCtx.moveTo).toHaveBeenCalledWith(3, 3);
+    expect(mockCtx.lineTo).toHaveBeenCalledWith(7, 7);
+    expect(mockCtx.stroke).toHaveBeenCalled();
+  });
+
+  it('ignores empty path objects (fewer than 2 points)', () => {
+    const canvas = makeCanvas();
+    const canvasRef = { current: canvas };
+    const objects: DrawableObject[] = [pathObj({ points: [{ x: 0, y: 0 }] })];
+
+    renderHook(() =>
+      useDrawingCanvas({
+        canvasRef,
+        color: '#000',
+        width: 4,
+        objects,
+        onObjectComplete: vi.fn(),
+        canvasSize: { width: 800, height: 600 },
+        nextZ: 1,
+      })
+    );
+
+    // Clear + set up draw, but never strokes a degenerate path
+    expect(mockCtx.stroke).not.toHaveBeenCalled();
+  });
+
+  it('renders in z-order (low z first so higher z overlays)', () => {
+    const canvas = makeCanvas();
+    const canvasRef = { current: canvas };
+    const objects: DrawableObject[] = [
+      pathObj({
+        id: 'b',
+        z: 5,
+        points: [
+          { x: 100, y: 100 },
+          { x: 200, y: 200 },
+        ],
+      }),
+      pathObj({
+        id: 'a',
+        z: 1,
+        points: [
+          { x: 1, y: 1 },
+          { x: 2, y: 2 },
+        ],
+      }),
+    ];
+
+    renderHook(() =>
+      useDrawingCanvas({
+        canvasRef,
+        color: '#000',
+        width: 4,
+        objects,
+        onObjectComplete: vi.fn(),
+        canvasSize: { width: 800, height: 600 },
+        nextZ: 6,
+      })
+    );
+
+    const moveCalls = mockCtx.moveTo.mock.calls;
+    // First moveTo should be the low-z object (z:1 at 1,1), then the high-z one
+    expect(moveCalls[0]).toEqual([1, 1]);
+    expect(moveCalls[1]).toEqual([100, 100]);
+  });
+
+  it('uses destination-out composite op for eraser paths', () => {
+    const canvas = makeCanvas();
+    const canvasRef = { current: canvas };
+    const objects: DrawableObject[] = [
+      pathObj({
+        color: 'eraser',
+        points: [
+          { x: 0, y: 0 },
+          { x: 5, y: 5 },
+        ],
+      }),
+    ];
+
+    renderHook(() =>
+      useDrawingCanvas({
+        canvasRef,
+        color: '#000',
+        width: 4,
+        objects,
+        onObjectComplete: vi.fn(),
+        canvasSize: { width: 800, height: 600 },
+        nextZ: 1,
+      })
+    );
+
+    // After the path renders, the final composite op is reset to source-over;
+    // we verify via strokeStyle which reflects the eraser branch.
+    expect(mockCtx.stroke).toHaveBeenCalled();
+    expect(mockCtx.globalCompositeOperation).toBe('source-over');
+  });
+
+  it('on pointerup emits a new PathObject with kind=path, supplied id, and nextZ', () => {
+    const canvas = makeCanvas();
+    const canvasRef = { current: canvas };
+    const onObjectComplete = vi.fn();
+    const generateId = vi.fn(() => 'deterministic-id');
+
+    const { result } = renderHook(() =>
+      useDrawingCanvas({
+        canvasRef,
+        color: '#123',
+        width: 7,
+        objects: [],
+        onObjectComplete,
+        canvasSize: { width: 800, height: 600 },
+        generateId,
+        nextZ: 42,
+      })
+    );
+
+    const mkEvent = (clientX: number, clientY: number) =>
+      ({
+        clientX,
+        clientY,
+        pointerId: 1,
+      }) as unknown as React.PointerEvent;
+
+    act(() => result.current.handleStart(mkEvent(2, 3)));
+    act(() => result.current.handleMove(mkEvent(5, 6)));
+    act(() => result.current.handleEnd());
+
+    expect(onObjectComplete).toHaveBeenCalledTimes(1);
+    const emitted = onObjectComplete.mock.calls[0][0] as PathObject;
+    expect(emitted).toMatchObject({
+      id: 'deterministic-id',
+      kind: 'path',
+      z: 42,
+      color: '#123',
+      width: 7,
+    });
+    expect(emitted.points).toEqual([
+      { x: 2, y: 3 },
+      { x: 5, y: 6 },
+    ]);
+  });
+
+  it('does not emit a path when pointer barely moves (<2 points)', () => {
+    const canvas = makeCanvas();
+    const canvasRef = { current: canvas };
+    const onObjectComplete = vi.fn();
+
+    const { result } = renderHook(() =>
+      useDrawingCanvas({
+        canvasRef,
+        color: '#000',
+        width: 4,
+        objects: [],
+        onObjectComplete,
+        canvasSize: { width: 800, height: 600 },
+        nextZ: 0,
+      })
+    );
+
+    const mkEvent = (x: number, y: number) =>
+      ({ clientX: x, clientY: y }) as unknown as React.PointerEvent;
+    act(() => result.current.handleStart(mkEvent(1, 1)));
+    act(() => result.current.handleEnd());
+
+    expect(onObjectComplete).not.toHaveBeenCalled();
+  });
+
+  it('is a no-op when disabled (student view)', () => {
+    const canvas = makeCanvas();
+    const canvasRef = { current: canvas };
+    const onObjectComplete = vi.fn();
+
+    const { result } = renderHook(() =>
+      useDrawingCanvas({
+        canvasRef,
+        color: '#000',
+        width: 4,
+        objects: [],
+        onObjectComplete,
+        disabled: true,
+        canvasSize: { width: 800, height: 600 },
+        nextZ: 0,
+      })
+    );
+
+    const mkEvent = (x: number, y: number) =>
+      ({ clientX: x, clientY: y }) as unknown as React.PointerEvent;
+    act(() => result.current.handleStart(mkEvent(0, 0)));
+    act(() => result.current.handleMove(mkEvent(10, 10)));
+    act(() => result.current.handleEnd());
+
+    expect(onObjectComplete).not.toHaveBeenCalled();
+    expect(result.current.isDrawing).toBe(false);
+  });
+
+  it('divides pointer coordinates by the supplied scale factor', () => {
+    const canvas = makeCanvas();
+    const canvasRef = { current: canvas };
+    const onObjectComplete = vi.fn();
+
+    const { result } = renderHook(() =>
+      useDrawingCanvas({
+        canvasRef,
+        color: '#000',
+        width: 4,
+        objects: [],
+        onObjectComplete,
+        scale: 2, // half the on-screen coords
+        canvasSize: { width: 800, height: 600 },
+        nextZ: 0,
+      })
+    );
+
+    const mkEvent = (x: number, y: number) =>
+      ({ clientX: x, clientY: y }) as unknown as React.PointerEvent;
+    act(() => result.current.handleStart(mkEvent(100, 200)));
+    act(() => result.current.handleMove(mkEvent(300, 400)));
+    act(() => result.current.handleEnd());
+
+    const emitted = onObjectComplete.mock.calls[0][0] as PathObject;
+    expect(emitted.points).toEqual([
+      { x: 50, y: 100 },
+      { x: 150, y: 200 },
+    ]);
+  });
+});

--- a/components/widgets/DrawingWidget/useDrawingCanvas.ts
+++ b/components/widgets/DrawingWidget/useDrawingCanvas.ts
@@ -1,12 +1,12 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { Point, Path } from '@/types';
+import { DrawableObject, PathObject, Point } from '@/types';
 
 interface UseDrawingCanvasOptions {
   canvasRef: React.RefObject<HTMLCanvasElement | null>;
   color: string;
   width: number;
-  paths: Path[];
-  onPathComplete: (path: Path) => void;
+  objects: DrawableObject[];
+  onObjectComplete: (obj: DrawableObject) => void;
   /** CSS transform scale applied to the canvas by a parent ScalableWidget.
    *  Pass `1` for full-viewport overlays where no parent scaling applies. */
   scale?: number;
@@ -14,6 +14,12 @@ interface UseDrawingCanvasOptions {
   disabled?: boolean;
   /** Internal canvas resolution. Re-applies on change. */
   canvasSize: { width: number; height: number };
+  /** Generate an id for a newly-completed path object. Injected so tests can
+   *  produce deterministic output without mocking crypto. */
+  generateId?: () => string;
+  /** Next z-index to assign to the completed path object. Owned by caller so
+   *  this hook stays stateless w.r.t. object history. */
+  nextZ: number;
 }
 
 interface UseDrawingCanvasResult {
@@ -25,18 +31,21 @@ interface UseDrawingCanvasResult {
 
 /**
  * Shared canvas-drawing logic for the DrawingWidget and the AnnotationOverlay.
- * Handles stroke rendering, pointer handling, and history-on-path-complete.
- * The caller owns the paths state and history semantics.
+ * Renders a polymorphic list of DrawableObjects and captures freehand strokes
+ * as new PathObjects (Phase 2a: path-only rendering; shape/text/image kinds
+ * are recognized by the dispatcher but render nothing until their PRs land).
  */
 export const useDrawingCanvas = ({
   canvasRef,
   color,
   width,
-  paths,
-  onPathComplete,
+  objects,
+  onObjectComplete,
   scale = 1,
   disabled = false,
   canvasSize,
+  generateId = () => crypto.randomUUID(),
+  nextZ,
 }: UseDrawingCanvasOptions): UseDrawingCanvasResult => {
   const [isDrawing, setIsDrawing] = useState(false);
   const currentPathRef = useRef<Point[]>([]);
@@ -58,41 +67,26 @@ export const useDrawingCanvas = ({
   );
 
   const draw = useCallback(
-    (ctx: CanvasRenderingContext2D, allPaths: Path[], current: Point[]) => {
+    (
+      ctx: CanvasRenderingContext2D,
+      allObjects: DrawableObject[],
+      current: Point[]
+    ) => {
       ctx.clearRect(0, 0, ctx.canvas.width, ctx.canvas.height);
 
-      const renderPath = (p: Path) => {
-        if (p.points.length < 2) return;
-        ctx.beginPath();
-        ctx.lineCap = 'round';
-        ctx.lineJoin = 'round';
+      // Render in z-order so later PRs (shapes, images, text) can layer cleanly
+      // without needing to touch this call site.
+      const sorted = [...allObjects].sort((a, b) => a.z - b.z);
+      sorted.forEach((obj) => renderObject(ctx, obj));
 
-        if (p.color === 'eraser') {
-          ctx.globalCompositeOperation = 'destination-out';
-          ctx.strokeStyle = 'rgba(0,0,0,1)';
-        } else {
-          ctx.globalCompositeOperation = 'source-over';
-          ctx.strokeStyle = p.color;
-        }
-
-        ctx.lineWidth = p.width;
-        ctx.moveTo(p.points[0].x, p.points[0].y);
-        for (let i = 1; i < p.points.length; i++) {
-          ctx.lineTo(p.points[i].x, p.points[i].y);
-        }
-        ctx.stroke();
-        ctx.globalCompositeOperation = 'source-over';
-      };
-
-      allPaths.forEach(renderPath);
       if (current.length > 1) {
-        renderPath({ points: current, color, width });
+        renderPathPoints(ctx, current, color, width);
       }
     },
     [color, width]
   );
 
-  // Apply canvas resolution + redraw on size or paths change
+  // Apply canvas resolution + redraw on size / object-list change
   useEffect(() => {
     const canvas = canvasRef.current;
     if (!canvas) return;
@@ -102,8 +96,8 @@ export const useDrawingCanvas = ({
     if (canvas.width !== canvasSize.width) canvas.width = canvasSize.width;
     if (canvas.height !== canvasSize.height) canvas.height = canvasSize.height;
 
-    draw(ctx, paths, currentPathRef.current);
-  }, [canvasRef, canvasSize.width, canvasSize.height, paths, draw]);
+    draw(ctx, objects, currentPathRef.current);
+  }, [canvasRef, canvasSize.width, canvasSize.height, objects, draw]);
 
   const getPos = useCallback(
     (e: React.PointerEvent): Point => {
@@ -158,14 +152,66 @@ export const useDrawingCanvas = ({
     if (!isDrawing) return;
     setIsDrawing(false);
     if (currentPathRef.current.length > 1) {
-      onPathComplete({
+      const completed: PathObject = {
+        id: generateId(),
+        kind: 'path',
+        z: nextZ,
         points: currentPathRef.current,
         color,
         width,
-      });
+      };
+      onObjectComplete(completed);
     }
     currentPathRef.current = [];
-  }, [isDrawing, onPathComplete, color, width]);
+  }, [isDrawing, onObjectComplete, color, width, generateId, nextZ]);
 
   return { handleStart, handleMove, handleEnd, isDrawing };
+};
+
+// --- Object dispatcher ---
+// Phase 2a only renders `path` objects. Later PRs fill in the remaining
+// `kind` branches (rect, ellipse, line, arrow, text, image).
+
+const renderObject = (
+  ctx: CanvasRenderingContext2D,
+  obj: DrawableObject
+): void => {
+  switch (obj.kind) {
+    case 'path':
+      renderPathPoints(ctx, obj.points, obj.color, obj.width);
+      return;
+    case 'rect':
+    case 'ellipse':
+    case 'line':
+    case 'arrow':
+    case 'text':
+    case 'image':
+      return;
+  }
+};
+
+const renderPathPoints = (
+  ctx: CanvasRenderingContext2D,
+  points: Point[],
+  color: string,
+  width: number
+): void => {
+  if (points.length < 2) return;
+  ctx.beginPath();
+  ctx.lineCap = 'round';
+  ctx.lineJoin = 'round';
+  if (color === 'eraser') {
+    ctx.globalCompositeOperation = 'destination-out';
+    ctx.strokeStyle = 'rgba(0,0,0,1)';
+  } else {
+    ctx.globalCompositeOperation = 'source-over';
+    ctx.strokeStyle = color;
+  }
+  ctx.lineWidth = width;
+  ctx.moveTo(points[0].x, points[0].y);
+  for (let i = 1; i < points.length; i++) {
+    ctx.lineTo(points[i].x, points[i].y);
+  }
+  ctx.stroke();
+  ctx.globalCompositeOperation = 'source-over';
 };

--- a/components/widgets/DrawingWidget/useDrawingCanvas.ts
+++ b/components/widgets/DrawingWidget/useDrawingCanvas.ts
@@ -1,0 +1,171 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { Point, Path } from '@/types';
+
+interface UseDrawingCanvasOptions {
+  canvasRef: React.RefObject<HTMLCanvasElement | null>;
+  color: string;
+  width: number;
+  paths: Path[];
+  onPathComplete: (path: Path) => void;
+  /** CSS transform scale applied to the canvas by a parent ScalableWidget.
+   *  Pass `1` for full-viewport overlays where no parent scaling applies. */
+  scale?: number;
+  /** If true, pointer events are ignored (e.g. student read-only view). */
+  disabled?: boolean;
+  /** Internal canvas resolution. Re-applies on change. */
+  canvasSize: { width: number; height: number };
+}
+
+interface UseDrawingCanvasResult {
+  handleStart: (e: React.PointerEvent) => void;
+  handleMove: (e: React.PointerEvent) => void;
+  handleEnd: () => void;
+  isDrawing: boolean;
+}
+
+/**
+ * Shared canvas-drawing logic for the DrawingWidget and the AnnotationOverlay.
+ * Handles stroke rendering, pointer handling, and history-on-path-complete.
+ * The caller owns the paths state and history semantics.
+ */
+export const useDrawingCanvas = ({
+  canvasRef,
+  color,
+  width,
+  paths,
+  onPathComplete,
+  scale = 1,
+  disabled = false,
+  canvasSize,
+}: UseDrawingCanvasOptions): UseDrawingCanvasResult => {
+  const [isDrawing, setIsDrawing] = useState(false);
+  const currentPathRef = useRef<Point[]>([]);
+
+  const setContextStyles = useCallback(
+    (ctx: CanvasRenderingContext2D) => {
+      ctx.lineCap = 'round';
+      ctx.lineJoin = 'round';
+      if (color === 'eraser') {
+        ctx.globalCompositeOperation = 'destination-out';
+        ctx.strokeStyle = 'rgba(0,0,0,1)';
+      } else {
+        ctx.globalCompositeOperation = 'source-over';
+        ctx.strokeStyle = color;
+      }
+      ctx.lineWidth = width;
+    },
+    [color, width]
+  );
+
+  const draw = useCallback(
+    (ctx: CanvasRenderingContext2D, allPaths: Path[], current: Point[]) => {
+      ctx.clearRect(0, 0, ctx.canvas.width, ctx.canvas.height);
+
+      const renderPath = (p: Path) => {
+        if (p.points.length < 2) return;
+        ctx.beginPath();
+        ctx.lineCap = 'round';
+        ctx.lineJoin = 'round';
+
+        if (p.color === 'eraser') {
+          ctx.globalCompositeOperation = 'destination-out';
+          ctx.strokeStyle = 'rgba(0,0,0,1)';
+        } else {
+          ctx.globalCompositeOperation = 'source-over';
+          ctx.strokeStyle = p.color;
+        }
+
+        ctx.lineWidth = p.width;
+        ctx.moveTo(p.points[0].x, p.points[0].y);
+        for (let i = 1; i < p.points.length; i++) {
+          ctx.lineTo(p.points[i].x, p.points[i].y);
+        }
+        ctx.stroke();
+        ctx.globalCompositeOperation = 'source-over';
+      };
+
+      allPaths.forEach(renderPath);
+      if (current.length > 1) {
+        renderPath({ points: current, color, width });
+      }
+    },
+    [color, width]
+  );
+
+  // Apply canvas resolution + redraw on size or paths change
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+
+    if (canvas.width !== canvasSize.width) canvas.width = canvasSize.width;
+    if (canvas.height !== canvasSize.height) canvas.height = canvasSize.height;
+
+    draw(ctx, paths, currentPathRef.current);
+  }, [canvasRef, canvasSize.width, canvasSize.height, paths, draw]);
+
+  const getPos = useCallback(
+    (e: React.PointerEvent): Point => {
+      const canvas = canvasRef.current;
+      if (!canvas) return { x: 0, y: 0 };
+      const rect = canvas.getBoundingClientRect();
+      return {
+        x: (e.clientX - rect.left) / scale,
+        y: (e.clientY - rect.top) / scale,
+      };
+    },
+    [canvasRef, scale]
+  );
+
+  const handleStart = useCallback(
+    (e: React.PointerEvent) => {
+      if (disabled) return;
+      setIsDrawing(true);
+      const pos = getPos(e);
+      currentPathRef.current = [pos];
+
+      const ctx = canvasRef.current?.getContext('2d');
+      if (ctx) {
+        setContextStyles(ctx);
+        ctx.beginPath();
+        ctx.moveTo(pos.x, pos.y);
+      }
+    },
+    [disabled, getPos, canvasRef, setContextStyles]
+  );
+
+  const handleMove = useCallback(
+    (e: React.PointerEvent) => {
+      if (disabled || !isDrawing) return;
+      const pos = getPos(e);
+      currentPathRef.current.push(pos);
+
+      const ctx = canvasRef.current?.getContext('2d');
+      if (ctx && currentPathRef.current.length > 1) {
+        setContextStyles(ctx);
+        const prev = currentPathRef.current[currentPathRef.current.length - 2];
+        ctx.beginPath();
+        ctx.moveTo(prev.x, prev.y);
+        ctx.lineTo(pos.x, pos.y);
+        ctx.stroke();
+      }
+    },
+    [disabled, isDrawing, getPos, canvasRef, setContextStyles]
+  );
+
+  const handleEnd = useCallback(() => {
+    if (!isDrawing) return;
+    setIsDrawing(false);
+    if (currentPathRef.current.length > 1) {
+      onPathComplete({
+        points: currentPathRef.current,
+        color,
+        width,
+      });
+    }
+    currentPathRef.current = [];
+  }, [isDrawing, onPathComplete, color, width]);
+
+  return { handleStart, handleMove, handleEnd, isDrawing };
+};

--- a/components/widgets/LunchCount/Widget.tsx
+++ b/components/widgets/LunchCount/Widget.tsx
@@ -27,6 +27,7 @@ import { SubmitReportModal } from './SubmitReportModal';
 import { useNutrislice } from './useNutrislice';
 import { DraggableStudent } from './components/DraggableStudent';
 import { DroppableZone } from './components/DroppableZone';
+import { beginWidgetDrag, endWidgetDrag } from '@/utils/widgetDragFlag';
 
 import { WidgetLayout } from '../WidgetLayout';
 import { hexToRgba } from '@/utils/styles';
@@ -224,11 +225,13 @@ export const LunchCountWidget: React.FC<{ widget: WidgetData }> = ({
   );
 
   const handleDragStart = useCallback((event: DragStartEvent) => {
+    beginWidgetDrag();
     setActiveId(event.active.id as string);
   }, []);
 
   const handleDragEnd = useCallback(
     (event: DragEndEvent) => {
+      endWidgetDrag();
       const { active, over } = event;
       setActiveId(null);
 
@@ -243,6 +246,11 @@ export const LunchCountWidget: React.FC<{ widget: WidgetData }> = ({
     },
     [assignments, updateAssignment]
   );
+
+  const handleDragCancel = useCallback(() => {
+    endWidgetDrag();
+    setActiveId(null);
+  }, []);
 
   const handleSubmitReport = async (notes: string, extraPizza?: number) => {
     const { submissionUrl, schumannSheetId, intermediateSheetId } =
@@ -446,6 +454,7 @@ export const LunchCountWidget: React.FC<{ widget: WidgetData }> = ({
       collisionDetection={pointerWithin}
       onDragStart={handleDragStart}
       onDragEnd={handleDragEnd}
+      onDragCancel={handleDragCancel}
     >
       <WidgetLayout
         padding="p-0"

--- a/components/widgets/MiniApp/Widget.tsx
+++ b/components/widgets/MiniApp/Widget.tsx
@@ -57,6 +57,7 @@ import { AssignmentsModal } from './components/AssignmentsModal';
 import { useMiniAppSync } from './hooks/useMiniAppSync';
 import { useMiniAppGlobalConfig } from './hooks/useMiniAppGlobalConfig';
 import { useDialog } from '@/context/useDialog';
+import { beginWidgetDrag, endWidgetDrag } from '@/utils/widgetDragFlag';
 
 // --- ASSIGN MODAL ---
 interface MiniAppAssignModalProps {
@@ -554,6 +555,7 @@ export const MiniAppWidget: React.FC<WidgetComponentProps> = ({
 
   const handleDragEnd = useCallback(
     async (event: DragEndEvent) => {
+      endWidgetDrag();
       const { active, over } = event;
       if (!user || !over || active.id === over.id) return;
 
@@ -1085,7 +1087,9 @@ export const MiniAppWidget: React.FC<WidgetComponentProps> = ({
                   <DndContext
                     sensors={sensors}
                     collisionDetection={closestCenter}
+                    onDragStart={beginWidgetDrag}
                     onDragEnd={handleDragEnd}
+                    onDragCancel={endWidgetDrag}
                   >
                     <SortableContext
                       items={library.map((item) => item.id)}

--- a/components/widgets/PdfWidget/PdfWidget.tsx
+++ b/components/widgets/PdfWidget/PdfWidget.tsx
@@ -33,6 +33,7 @@ import { WidgetLayout } from '@/components/widgets/WidgetLayout';
 import { ScaledEmptyState } from '@/components/common/ScaledEmptyState';
 import { SortableRow } from './components/SortableRow';
 import { useDialog } from '@/context/useDialog';
+import { beginWidgetDrag, endWidgetDrag } from '@/utils/widgetDragFlag';
 
 export const PdfWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
   const { updateWidget, addToast } = useDashboard();
@@ -154,6 +155,7 @@ export const PdfWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
 
   const handleDragEnd = useCallback(
     async (event: DragEndEvent) => {
+      endWidgetDrag();
       const { active, over } = event;
       if (!user || !over || active.id === over.id) return;
 
@@ -320,7 +322,9 @@ export const PdfWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
             <DndContext
               sensors={sensors}
               collisionDetection={closestCenter}
+              onDragStart={beginWidgetDrag}
               onDragEnd={handleDragEnd}
+              onDragCancel={endWidgetDrag}
             >
               <SortableContext
                 items={library.map((p) => p.id)}

--- a/components/widgets/Schedule/Settings.tsx
+++ b/components/widgets/Schedule/Settings.tsx
@@ -45,6 +45,7 @@ import { SurfaceColorSettings } from '@/components/common/SurfaceColorSettings';
 import { TextSizePresetSettings } from '@/components/common/TextSizePresetSettings';
 import { getTodayStr } from './utils';
 import { SortableScheduleItem } from './components/SortableScheduleItem';
+import { beginWidgetDrag, endWidgetDrag } from '@/utils/widgetDragFlag';
 
 const DAYS = [
   { id: 0, label: 'Su', fullName: 'Sunday' },
@@ -358,6 +359,7 @@ export const ScheduleSettings: React.FC<{ widget: WidgetData }> = ({
 
   const handleDragEnd = useCallback(
     (scheduleId: string, event: DragEndEvent) => {
+      endWidgetDrag();
       const { active, over } = event;
       if (!over || active.id === over.id) return;
       const items = getScheduleItems(scheduleId);
@@ -564,7 +566,9 @@ export const ScheduleSettings: React.FC<{ widget: WidgetData }> = ({
                 <DndContext
                   sensors={sensors}
                   collisionDetection={closestCenter}
+                  onDragStart={beginWidgetDrag}
                   onDragEnd={(e) => handleDragEnd(selectedSchedule.id, e)}
+                  onDragCancel={endWidgetDrag}
                 >
                   <SortableContext
                     items={validItems.map((i) => i.id)}

--- a/components/widgets/SyntaxFramer/Widget.tsx
+++ b/components/widgets/SyntaxFramer/Widget.tsx
@@ -18,6 +18,7 @@ import {
 } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 import { useDashboard } from '@/context/useDashboard';
+import { beginWidgetDrag, endWidgetDrag } from '@/utils/widgetDragFlag';
 import { Z_INDEX } from '@/config/zIndex';
 import { WidgetLayout } from '@/components/widgets/WidgetLayout';
 import { ScaledEmptyState } from '@/components/common/ScaledEmptyState';
@@ -159,6 +160,7 @@ export const SyntaxFramerWidget: React.FC<WidgetComponentProps> = ({
 
   const handleDragEnd = useCallback(
     (event: DragEndEvent) => {
+      endWidgetDrag();
       const { active, over } = event;
 
       if (over && active.id !== over.id) {
@@ -226,7 +228,9 @@ export const SyntaxFramerWidget: React.FC<WidgetComponentProps> = ({
           <DndContext
             sensors={sensors}
             collisionDetection={closestCenter}
+            onDragStart={beginWidgetDrag}
             onDragEnd={handleDragEnd}
+            onDragCancel={endWidgetDrag}
           >
             <SortableContext
               items={tokens.map((t) => t.id)}

--- a/components/widgets/TextWidget/FormattingToolbar.test.tsx
+++ b/components/widgets/TextWidget/FormattingToolbar.test.tsx
@@ -101,13 +101,96 @@ describe('FormattingToolbar', () => {
     );
   });
 
-  it('increments font size via stepper button', () => {
-    render(<FormattingToolbar {...defaultProps} />);
+  it('wraps selection in <span style="font-size:Xpx"> when + is clicked', () => {
+    const editor = document.createElement('div');
+    const text = document.createTextNode('hello');
+    editor.appendChild(text);
+    document.body.appendChild(editor);
+
+    const editorRef = {
+      current: editor,
+    } as React.RefObject<HTMLDivElement>;
+
+    const initialRange = document.createRange();
+    initialRange.selectNodeContents(text);
+
+    let currentRange: Range = initialRange;
+    const mockSelection = {
+      get anchorNode() {
+        return currentRange.startContainer;
+      },
+      get rangeCount() {
+        return 1;
+      },
+      getRangeAt: () => currentRange,
+      removeAllRanges: vi.fn(),
+      addRange: vi.fn((r: Range) => {
+        currentRange = r;
+      }),
+    } as unknown as Selection;
+    vi.spyOn(window, 'getSelection').mockReturnValue(mockSelection);
+
+    render(<FormattingToolbar {...defaultProps} editorRef={editorRef} />);
+
+    fireEvent.click(screen.getByTitle('Increase font size'));
+
+    const span = editor.querySelector<HTMLElement>('span[style*="font-size"]');
+    expect(span).not.toBeNull();
+    expect(span?.style.fontSize).toBe('19px');
+    expect(span?.textContent).toBe('hello');
+    expect(mockOnContentChange).toHaveBeenCalled();
+
+    document.body.removeChild(editor);
+    vi.restoreAllMocks();
+  });
+
+  it('increments by +1px per click, not to xx-large', () => {
+    const editor = document.createElement('div');
+    const text = document.createTextNode('hello');
+    editor.appendChild(text);
+    document.body.appendChild(editor);
+
+    const editorRef = {
+      current: editor,
+    } as React.RefObject<HTMLDivElement>;
+
+    const initialRange = document.createRange();
+    initialRange.selectNodeContents(text);
+
+    let currentRange: Range = initialRange;
+    const mockSelection = {
+      get anchorNode() {
+        return currentRange.startContainer;
+      },
+      get rangeCount() {
+        return 1;
+      },
+      getRangeAt: () => currentRange,
+      removeAllRanges: vi.fn(),
+      addRange: vi.fn((r: Range) => {
+        currentRange = r;
+      }),
+    } as unknown as Selection;
+    vi.spyOn(window, 'getSelection').mockReturnValue(mockSelection);
+
+    render(<FormattingToolbar {...defaultProps} editorRef={editorRef} />);
+
     const increaseButton = screen.getByTitle('Increase font size');
     fireEvent.click(increaseButton);
+    fireEvent.click(increaseButton);
+    fireEvent.click(increaseButton);
 
-    // The marker-replacement technique calls fontSize with '7' as a marker
-    expect(execCommandMock).toHaveBeenCalledWith('fontSize', false, '7');
+    const spans = editor.querySelectorAll<HTMLElement>(
+      'span[style*="font-size"]'
+    );
+    expect(spans.length).toBeGreaterThan(0);
+    const innermost = spans[spans.length - 1];
+    expect(innermost.style.fontSize).toBe('21px');
+    expect(innermost.textContent).toBe('hello');
+    expect(editor.innerHTML).not.toContain('xx-large');
+
+    document.body.removeChild(editor);
+    vi.restoreAllMocks();
   });
 
   it('calls showPrompt when link button is clicked', async () => {

--- a/components/widgets/TextWidget/FormattingToolbar.tsx
+++ b/components/widgets/TextWidget/FormattingToolbar.tsx
@@ -277,57 +277,49 @@ export const FormattingToolbar: React.FC<FormattingToolbarProps> = ({
     [restoreSelection, editorRef]
   );
 
-  /** Apply an arbitrary pixel font size using the marker-replacement technique.
-   *  Suppresses the parent's handleInput during the multi-step DOM mutation
-   *  (execCommand creates <font size="7"> markers, then we replace them with
-   *  <span style="font-size:…">), and explicitly saves content afterward. */
+  /** Apply an arbitrary pixel font size to the current selection by wrapping it
+   *  in <span style="font-size:Xpx">. Uses Range.extractContents/insertNode to
+   *  handle selections that cross inline-element boundaries. Suppresses the
+   *  parent's handleInput during the mutation, then explicitly persists. */
   const applyFontSize = useCallback(
     (size: number) => {
       const clamped = Math.max(8, Math.min(96, Math.round(size)));
       setCurrentFontSize(clamped);
       setFontSizeInput(String(clamped));
 
-      // Capture the selection scope before execCommand mutates the DOM
-      const sel = window.getSelection();
-      const range =
-        sel && sel.rangeCount > 0 ? sel.getRangeAt(0).cloneRange() : null;
-      const ancestor = range?.commonAncestorContainer ?? null;
-      const scopeEl =
-        ancestor?.nodeType === Node.ELEMENT_NODE
-          ? ancestor
-          : (ancestor?.parentElement ?? null);
-
-      // Suppress handleInput while we mutate the DOM in two steps
-      suppressInputRef.current = true;
+      const editor = editorRef.current;
+      if (!editor) return;
 
       restoreSelection();
-      document.execCommand('styleWithCSS', false, 'true');
-      document.execCommand('fontSize', false, '7');
 
-      // Replace <font size="7"> markers scoped to the selection area
-      const editor = editorRef.current;
-      if (editor) {
-        const searchRoot: Element =
-          scopeEl instanceof Element && editor.contains(scopeEl)
-            ? scopeEl
-            : editor;
-        const fontElements =
-          searchRoot.querySelectorAll<HTMLElement>('font[size="7"]');
-        fontElements.forEach((el) => {
-          const span = document.createElement('span');
-          span.style.fontSize = `${clamped}px`;
-          while (el.firstChild) {
-            span.appendChild(el.firstChild);
-          }
-          el.replaceWith(span);
-        });
+      const sel = window.getSelection();
+      if (!sel || sel.rangeCount === 0) return;
+      const range = sel.getRangeAt(0);
+
+      // Act only on ranges inside this editor, and only for non-collapsed
+      // selections (cursor-only is a no-op — better than the xx-large lock).
+      if (!editor.contains(range.commonAncestorContainer) || range.collapsed) {
+        editor.focus();
+        return;
       }
 
-      // Re-enable input handling and persist the final DOM state
+      suppressInputRef.current = true;
+
+      const span = document.createElement('span');
+      span.style.fontSize = `${clamped}px`;
+      span.appendChild(range.extractContents());
+      range.insertNode(span);
+
+      // Re-select the wrapped span so repeated +/- clicks keep targeting it.
+      const newRange = document.createRange();
+      newRange.selectNodeContents(span);
+      sel.removeAllRanges();
+      sel.addRange(newRange);
+      savedRangeRef.current = newRange.cloneRange();
+
       suppressInputRef.current = false;
       onContentChange();
-
-      editor?.focus();
+      editor.focus();
     },
     [editorRef, restoreSelection, suppressInputRef, onContentChange]
   );

--- a/components/widgets/TextWidget/Widget.tsx
+++ b/components/widgets/TextWidget/Widget.tsx
@@ -49,6 +49,7 @@ export const TextWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
 
   const editorRef = useRef<HTMLDivElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
+  const toolbarPortalRef = useRef<HTMLDivElement>(null);
   const isEditingRef = useRef(false);
   const lastExternalContent = useRef(content);
   const didInit = useRef(false);
@@ -78,6 +79,7 @@ export const TextWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
     let prevWidth = NaN;
     let prevHeight = NaN;
     let prevSide: 'above' | 'below' | null = null;
+    let prevToolbarH = NaN;
     const tick = () => {
       const rect = containerRef.current?.getBoundingClientRect();
       if (rect) {
@@ -99,11 +101,18 @@ export const TextWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
         }
         const side: 'above' | 'below' =
           top > TOOLBAR_FLIP_THRESHOLD ? 'above' : 'below';
-        if (side !== prevSide) {
+        const toolbarH = toolbarPortalRef.current?.offsetHeight ?? 0;
+        if (side !== prevSide || toolbarH !== prevToolbarH) {
           prevSide = side;
+          prevToolbarH = toolbarH;
           window.dispatchEvent(
             new CustomEvent('widget-toolbar-reservation', {
-              detail: { widgetId, side },
+              detail: {
+                widgetId,
+                side,
+                height: toolbarH,
+                gap: TOOLBAR_GAP,
+              },
             })
           );
         }
@@ -229,6 +238,7 @@ export const TextWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
             toolbarPos &&
             createPortal(
               <div
+                ref={toolbarPortalRef}
                 data-click-outside-ignore="true"
                 style={{
                   position: 'fixed',

--- a/components/widgets/WidgetRenderer.tsx
+++ b/components/widgets/WidgetRenderer.tsx
@@ -2,7 +2,6 @@ import React, { memo, Suspense, useMemo, useCallback } from 'react';
 import { Z_INDEX } from '@/config/zIndex';
 import {
   WidgetData,
-  DrawingConfig,
   WidgetConfig,
   LiveStudent,
   LiveSession,
@@ -185,26 +184,21 @@ const WidgetRendererComponent: React.FC<WidgetRendererProps> = ({
     return null;
   };
 
-  const isDrawingOverlay =
-    widget.type === 'drawing' &&
-    (widget.config as DrawingConfig).mode === 'overlay';
   // When spotlighted we switch to position:fixed so the element escapes all
   // parent stacking contexts (will-change:transform / container-type:size on
   // DraggableWindow both create stacking contexts that would otherwise trap
   // the widget below the backdrop overlay). position:fixed is relative to the
   // viewport, and the dashboard is always full-screen, so widget.x / widget.y
   // map 1:1 to viewport coordinates — the widget stays visually in place.
-  const customStyle: React.CSSProperties = isDrawingOverlay
-    ? { display: 'none' }
-    : isSpotlighted
-      ? {
-          position: 'fixed',
-          zIndex: Z_INDEX.backdrop + 1,
-          outline: '3px solid #facc15', // yellow-400 ring
-          outlineOffset: '2px',
-          boxShadow: '0 0 32px 8px rgba(250,204,21,0.25)',
-        }
-      : {};
+  const customStyle: React.CSSProperties = isSpotlighted
+    ? {
+        position: 'fixed',
+        zIndex: Z_INDEX.backdrop + 1,
+        outline: '3px solid #facc15', // yellow-400 ring
+        outlineOffset: '2px',
+        boxShadow: '0 0 32px 8px rgba(250,204,21,0.25)',
+      }
+    : {};
 
   const scaling = WIDGET_SCALING_CONFIG[widget.type];
   const effectiveWidth = widget.maximized ? windowSize.width : widget.w;

--- a/components/widgets/stickers/StickerBookWidget.tsx
+++ b/components/widgets/stickers/StickerBookWidget.tsx
@@ -29,6 +29,7 @@ import { WidgetData, StickerBookConfig, StickerGlobalConfig } from '@/types';
 import { useDashboard } from '@/context/useDashboard';
 import { useAuth } from '@/context/useAuth';
 import { useImageUpload } from '@/hooks/useImageUpload';
+import { beginWidgetDrag, endWidgetDrag } from '@/utils/widgetDragFlag';
 
 const DEFAULT_STICKERS = [
   // Star
@@ -406,6 +407,7 @@ export const StickerBookWidget: React.FC<{ widget: WidgetData }> = ({
 
   const handleDragEnd = useCallback(
     (event: DragEndEvent) => {
+      endWidgetDrag();
       const { active, over } = event;
 
       if (active.id !== over?.id && over) {
@@ -638,7 +640,9 @@ export const StickerBookWidget: React.FC<{ widget: WidgetData }> = ({
           <DndContext
             sensors={sensors}
             collisionDetection={closestCenter}
+            onDragStart={beginWidgetDrag}
             onDragEnd={handleDragEnd}
+            onDragCancel={endWidgetDrag}
           >
             <div className="mb-8">
               <SortableContext

--- a/config/widgetDefaults.ts
+++ b/config/widgetDefaults.ts
@@ -78,7 +78,7 @@ export const WIDGET_DEFAULTS: Record<WidgetType, Partial<WidgetData>> = {
     h: 300,
     config: { sensitivity: 1, visual: 'thermometer' },
   },
-  drawing: { w: 400, h: 350, config: { mode: 'window', paths: [] } },
+  drawing: { w: 400, h: 350, config: { paths: [] } },
   qr: { w: 200, h: 250, config: { showUrl: false } satisfies QRConfig },
   embed: { w: 480, h: 350, config: { url: '' } },
   poll: {

--- a/context/DashboardContext.tsx
+++ b/context/DashboardContext.tsx
@@ -22,7 +22,7 @@ import {
   GridPosition,
   FeaturePermission,
   MaterialsGlobalConfig,
-  Path,
+  DrawableObject,
 } from '../types';
 import { useAuth } from './useAuth';
 import { stripTransientKeys } from '../utils/widgetConfigPersistence';
@@ -157,7 +157,7 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
   const [annotationActive, setAnnotationActive] = useState(false);
   const [annotationState, setAnnotationState] = useState<AnnotationState>(
     () => ({
-      paths: [],
+      objects: [],
       color: STANDARD_COLORS.slate,
       width: DRAWING_DEFAULTS.WIDTH,
       customColors: [...DRAWING_DEFAULTS.CUSTOM_COLORS],
@@ -170,7 +170,7 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
     setZoom(1);
     // Auto-close annotation when switching dashboards — annotations are board-local
     setAnnotationActive(false);
-    setAnnotationState((prev) => ({ ...prev, paths: [] }));
+    setAnnotationState((prev) => ({ ...prev, objects: [] }));
   }, []);
 
   const [isDockInitialized, setIsDockInitialized] = useState<boolean>(() => {
@@ -820,7 +820,8 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
                   if (la === sa) return false;
                   if (!la || !sa) return true;
                   if (la.mode !== sa.mode) return true;
-                  if (la.paths.length !== sa.paths.length) return true;
+                  if ((la.paths?.length ?? 0) !== (sa.paths?.length ?? 0))
+                    return true;
                   return JSON.stringify(la) !== JSON.stringify(sa);
                 })();
 
@@ -3028,7 +3029,7 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
       customColors?: string[];
     };
     setAnnotationState((prev) => ({
-      paths: [],
+      objects: [],
       color: prev.color,
       width: adminConfig.width ?? DRAWING_DEFAULTS.WIDTH,
       customColors: adminConfig.customColors ?? [
@@ -3040,7 +3041,7 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
 
   const closeAnnotation = useCallback(() => {
     setAnnotationActive(false);
-    setAnnotationState((prev) => ({ ...prev, paths: [] }));
+    setAnnotationState((prev) => ({ ...prev, objects: [] }));
   }, []);
 
   const updateAnnotationState = useCallback(
@@ -3050,16 +3051,22 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
     []
   );
 
-  const addAnnotationPath = useCallback((path: Path) => {
-    setAnnotationState((prev) => ({ ...prev, paths: [...prev.paths, path] }));
+  const addAnnotationObject = useCallback((obj: DrawableObject) => {
+    setAnnotationState((prev) => ({
+      ...prev,
+      objects: [...prev.objects, obj],
+    }));
   }, []);
 
   const undoAnnotation = useCallback(() => {
-    setAnnotationState((prev) => ({ ...prev, paths: prev.paths.slice(0, -1) }));
+    setAnnotationState((prev) => ({
+      ...prev,
+      objects: prev.objects.slice(0, -1),
+    }));
   }, []);
 
   const clearAnnotation = useCallback(() => {
-    setAnnotationState((prev) => ({ ...prev, paths: [] }));
+    setAnnotationState((prev) => ({ ...prev, objects: [] }));
   }, []);
 
   const contextValue = useMemo(
@@ -3144,7 +3151,7 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
       openAnnotation,
       closeAnnotation,
       updateAnnotationState,
-      addAnnotationPath,
+      addAnnotationObject,
       undoAnnotation,
       clearAnnotation,
     }),
@@ -3229,7 +3236,7 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
       openAnnotation,
       closeAnnotation,
       updateAnnotationState,
-      addAnnotationPath,
+      addAnnotationObject,
       undoAnnotation,
       clearAnnotation,
     ]

--- a/context/DashboardContext.tsx
+++ b/context/DashboardContext.tsx
@@ -3020,15 +3020,16 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
 
   // --- Annotation actions ---
   const openAnnotation = useCallback(() => {
-    // Seed from admin building defaults for width + color palette
+    // Seed from admin building defaults for width + color palette.
+    // `color` is not configurable at the admin level — keep the user's
+    // previously-chosen color across sessions.
     const adminConfig = getAdminBuildingConfig('drawing') as {
       width?: number;
-      color?: string;
       customColors?: string[];
     };
     setAnnotationState((prev) => ({
       paths: [],
-      color: adminConfig.color ?? prev.color,
+      color: prev.color,
       width: adminConfig.width ?? DRAWING_DEFAULTS.WIDTH,
       customColors: adminConfig.customColors ?? [
         ...DRAWING_DEFAULTS.CUSTOM_COLORS,

--- a/context/DashboardContext.tsx
+++ b/context/DashboardContext.tsx
@@ -22,6 +22,7 @@ import {
   GridPosition,
   FeaturePermission,
   MaterialsGlobalConfig,
+  Path,
 } from '../types';
 import { useAuth } from './useAuth';
 import { stripTransientKeys } from '../utils/widgetConfigPersistence';
@@ -43,6 +44,9 @@ import { useGoogleDrive } from '../hooks/useGoogleDrive';
 import { DashboardContext } from './DashboardContextValue';
 import { validateGridConfig, sanitizeAIConfig } from '../utils/ai_security';
 import { getMaterialsCatalog } from '../components/widgets/MaterialsWidget/constants';
+import { AnnotationState } from './DashboardContextValue';
+import { DRAWING_DEFAULTS } from '../components/widgets/DrawingWidget/constants';
+import { STANDARD_COLORS } from '../config/colors';
 
 // Helper to migrate legacy visibleTools to dockItems
 const migrateToDockItems = (
@@ -149,10 +153,24 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
   const [toasts, setToasts] = useState<Toast[]>([]);
   const [zoom, setZoom] = useState<number>(1);
 
+  // --- Annotation (ephemeral full-screen draw-over overlay; NOT a widget) ---
+  const [annotationActive, setAnnotationActive] = useState(false);
+  const [annotationState, setAnnotationState] = useState<AnnotationState>(
+    () => ({
+      paths: [],
+      color: STANDARD_COLORS.slate,
+      width: DRAWING_DEFAULTS.WIDTH,
+      customColors: [...DRAWING_DEFAULTS.CUSTOM_COLORS],
+    })
+  );
+
   // Helper to centralize active dashboard switching and its side-effects (like zoom reset)
   const updateActiveId = useCallback((id: string | null) => {
     setActiveId(id);
     setZoom(1);
+    // Auto-close annotation when switching dashboards — annotations are board-local
+    setAnnotationActive(false);
+    setAnnotationState((prev) => ({ ...prev, paths: [] }));
   }, []);
 
   const [isDockInitialized, setIsDockInitialized] = useState<boolean>(() => {
@@ -2194,9 +2212,9 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
           if (typeof raw.count === 'number') out.count = raw.count;
           break;
         case 'drawing':
-          if (raw.mode === 'window' || raw.mode === 'overlay') {
-            out.mode = raw.mode;
-          }
+          // Note: `mode` is no longer configurable per-building — annotation
+          // vs windowed whiteboard is now an explicit runtime choice via the
+          // Dock popover. Only width/colors remain as building defaults.
           if (typeof raw.width === 'number') {
             const roundedWidth = Math.round(raw.width);
             if (roundedWidth >= 1 && roundedWidth <= 20) {
@@ -3000,6 +3018,49 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
     );
   }, []);
 
+  // --- Annotation actions ---
+  const openAnnotation = useCallback(() => {
+    // Seed from admin building defaults for width + color palette
+    const adminConfig = getAdminBuildingConfig('drawing') as {
+      width?: number;
+      color?: string;
+      customColors?: string[];
+    };
+    setAnnotationState((prev) => ({
+      paths: [],
+      color: adminConfig.color ?? prev.color,
+      width: adminConfig.width ?? DRAWING_DEFAULTS.WIDTH,
+      customColors: adminConfig.customColors ?? [
+        ...DRAWING_DEFAULTS.CUSTOM_COLORS,
+      ],
+    }));
+    setAnnotationActive(true);
+  }, [getAdminBuildingConfig]);
+
+  const closeAnnotation = useCallback(() => {
+    setAnnotationActive(false);
+    setAnnotationState((prev) => ({ ...prev, paths: [] }));
+  }, []);
+
+  const updateAnnotationState = useCallback(
+    (updates: Partial<AnnotationState>) => {
+      setAnnotationState((prev) => ({ ...prev, ...updates }));
+    },
+    []
+  );
+
+  const addAnnotationPath = useCallback((path: Path) => {
+    setAnnotationState((prev) => ({ ...prev, paths: [...prev.paths, path] }));
+  }, []);
+
+  const undoAnnotation = useCallback(() => {
+    setAnnotationState((prev) => ({ ...prev, paths: prev.paths.slice(0, -1) }));
+  }, []);
+
+  const clearAnnotation = useCallback(() => {
+    setAnnotationState((prev) => ({ ...prev, paths: [] }));
+  }, []);
+
   const contextValue = useMemo(
     () => ({
       dashboards,
@@ -3077,6 +3138,14 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
       clearPendingQuizShare,
       zoom,
       setZoom,
+      annotationActive,
+      annotationState,
+      openAnnotation,
+      closeAnnotation,
+      updateAnnotationState,
+      addAnnotationPath,
+      undoAnnotation,
+      clearAnnotation,
     }),
     [
       dashboards,
@@ -3154,6 +3223,14 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
       clearPendingQuizShare,
       zoom,
       setZoom,
+      annotationActive,
+      annotationState,
+      openAnnotation,
+      closeAnnotation,
+      updateAnnotationState,
+      addAnnotationPath,
+      undoAnnotation,
+      clearAnnotation,
     ]
   );
 

--- a/context/DashboardContextValue.ts
+++ b/context/DashboardContextValue.ts
@@ -13,11 +13,11 @@ import {
   Student,
   AddWidgetOverrides,
   GridPosition,
-  Path,
+  DrawableObject,
 } from '../types';
 
 export interface AnnotationState {
-  paths: Path[];
+  objects: DrawableObject[];
   color: string;
   width: number;
   customColors: string[];
@@ -81,7 +81,7 @@ export interface DashboardContextValue {
   openAnnotation: () => void;
   closeAnnotation: () => void;
   updateAnnotationState: (updates: Partial<AnnotationState>) => void;
-  addAnnotationPath: (path: Path) => void;
+  addAnnotationObject: (obj: DrawableObject) => void;
   undoAnnotation: () => void;
   clearAnnotation: () => void;
 

--- a/context/DashboardContextValue.ts
+++ b/context/DashboardContextValue.ts
@@ -13,7 +13,15 @@ import {
   Student,
   AddWidgetOverrides,
   GridPosition,
+  Path,
 } from '../types';
+
+export interface AnnotationState {
+  paths: Path[];
+  color: string;
+  width: number;
+  customColors: string[];
+}
 
 export interface DashboardContextValue {
   dashboards: Dashboard[];
@@ -66,6 +74,16 @@ export interface DashboardContextValue {
   libraryOrder: (WidgetType | InternalToolType)[];
   updateDashboardSettings: (settings: Partial<Dashboard['settings']>) => void;
   updateDashboard: (updates: Partial<Dashboard>) => void;
+
+  // Annotation (ephemeral full-screen draw-over overlay; NOT a widget)
+  annotationActive: boolean;
+  annotationState: AnnotationState;
+  openAnnotation: () => void;
+  closeAnnotation: () => void;
+  updateAnnotationState: (updates: Partial<AnnotationState>) => void;
+  addAnnotationPath: (path: Path) => void;
+  undoAnnotation: () => void;
+  clearAnnotation: () => void;
 
   // Zoom system
   zoom: number;

--- a/docs/drawing-widget-phase-2.md
+++ b/docs/drawing-widget-phase-2.md
@@ -1,0 +1,243 @@
+# Phase 2 Drawing Widget — Remaining Roadmap & PR 2.1b Deep Dive
+
+## Context
+
+Phase 2a (polymorphic `DrawableObject[]` migration) shipped as [PR #1289](https://github.com/OPS-PIvers/SpartBoard/pull/1289), commit `7e34a64d`. The widget now stores a union-typed object list but only renders `kind: 'path'` — every other kind (`rect`, `ellipse`, `line`, `arrow`, `text`, `image`) is declared in [types.ts:163-263](types.ts#L163-L263) with a stubbed `case` branch in [useDrawingCanvas.ts:179-190](components/widgets/DrawingWidget/useDrawingCanvas.ts#L179-L190).
+
+The Phase 2 endpoint is a classroom whiteboard comparable to SMART Notebook: shapes, text, images, selection/transform, multi-page, undo/redo, export, and perf work. The master roadmap lives in [witty-fluttering-frost.md](/home/node/.claude/plans/witty-fluttering-frost.md). **User confirmed: keep the documented order, deep-dive only the next PR (2.1b).** Later PRs get sketch-level notes here and will be fully designed when each branch opens.
+
+---
+
+## Remaining Phase 2 PRs (roadmap snapshot)
+
+| PR       | Title                                             | Status                   |
+| -------- | ------------------------------------------------- | ------------------------ |
+| 2.1a     | Object-model migration                            | ✅ Merged                |
+| **2.1b** | **Shape primitives + tool palette**               | **Next — planned below** |
+| 2.1c     | Selection + transform (move/resize/rotate/delete) | Sketch                   |
+| 2.1d     | Text objects                                      | Sketch                   |
+| 2.2      | Image insertion                                   | Sketch                   |
+| 2.3      | Multi-page canvases                               | Sketch                   |
+| 2.4      | Undo/redo command stack                           | Sketch                   |
+| 2.5      | Export + background templates                     | Sketch                   |
+| 2.6      | Firestore subcollection + incremental render      | Sketch                   |
+
+---
+
+## PR 2.1b — Shape Primitives + Tool Palette (deep dive)
+
+### Goal
+
+Teachers can draw rectangles, ellipses, straight lines, and arrows with the same pen-and-eraser ergonomics as today. No selection/resize yet (that's 2.1c); shapes are created once and then immutable until undo/clear. Zero regressions for freehand pen or eraser.
+
+### Key design decisions
+
+1. **Explicit `activeTool` replaces the `color === 'eraser'` overload.**
+   Today [Widget.tsx:161](components/widgets/DrawingWidget/Widget.tsx#L161) stuffs the string `'eraser'` into `config.color` to toggle erase mode. With six tools the overload stops scaling. Add an `activeTool` field to `DrawingConfig`; let `color` hold only real color strings. Migration: legacy `color === 'eraser'` → `{ activeTool: 'eraser', color: <default pen color> }`.
+
+2. **Tool state persists in `config`.** Matches existing behavior for `color`/`width` (already persisted). A teacher who left the rectangle tool selected yesterday finds it selected today. No extra Firestore write cost over today's per-click color writes.
+
+3. **Shape drawing uses the same pointer-down/move/up flow as pen.** Start captures origin; move updates a live preview; up emits one `DrawableObject`. Reuses `getPos()`, `scale`, `disabled`, `nextZ` plumbing. No new state machines.
+
+4. **Live preview renders on top of committed objects.** Mirrors today's `currentPathRef` + re-render pattern ([useDrawingCanvas.ts:82-84](components/widgets/DrawingWidget/useDrawingCanvas.ts#L82-L84)). During drag, the in-progress shape is passed to `draw()` as an extra ephemeral object alongside the real list.
+
+5. **Fill is stroke-only by default.** `RectObject.fill` / `EllipseObject.fill` stay `undefined`. A fill toggle (solid in current color) lives in [Settings.tsx](components/widgets/DrawingWidget/Settings.tsx) so the front-face toolbar stays compact.
+
+6. **Arrows are a styled line.** `ArrowObject` renders as the line plus a triangular head at `(x2,y2)`. Head size scales with `strokeWidth` (`headLen = max(12, strokeWidth * 3)`). No configurable head style in 2.1b — keep it simple.
+
+7. **AnnotationOverlay gets the same palette.** The overlay shares `useDrawingCanvas`, so renderer changes come for free; we just also need to expose the tool buttons in the overlay's toolbar so mid-lecture teachers can draw arrows/rects too. Keep the two toolbars visually consistent.
+
+### Data model changes
+
+**`types.ts`** — add `ShapeTool` and extend `DrawingConfig`:
+
+```ts
+export type ShapeTool =
+  | 'pen'
+  | 'eraser'
+  | 'rect'
+  | 'ellipse'
+  | 'line'
+  | 'arrow';
+
+export interface DrawingConfig {
+  /** @deprecated — kept only to read legacy saved widgets. */
+  paths?: Path[];
+  /** @deprecated — pre-Phase-1 mode toggle. */
+  mode?: 'window' | 'overlay';
+
+  objects: DrawableObject[];
+  color?: string; // always a real color; 'eraser' no longer valid
+  width?: number;
+  customColors?: string[];
+  activeTool?: ShapeTool; // default 'pen'
+  shapeFill?: boolean; // default false; toggles fill-with-current-color for rect/ellipse
+}
+```
+
+No changes to the seven `DrawableObject` variants — they already carry everything shapes need.
+
+### Migration update
+
+Extend [utils/migrateDrawingConfig.ts](utils/migrateDrawingConfig.ts) so the single forward migration also:
+
+- If legacy `color === 'eraser'`: set `activeTool = 'eraser'`, clear `color` (fall back to palette default at render time).
+- If `activeTool` is missing or invalid: default to `'pen'`.
+- If `shapeFill` is missing: default to `false`.
+
+Pure-function addition; extend the existing test file `tests/utils/migrateDrawingConfig.test.ts` with 3 new cases (legacy eraser → activeTool eraser; missing activeTool → pen; invalid activeTool string → pen).
+
+### Hook changes — `useDrawingCanvas.ts`
+
+Option signature gains:
+
+```ts
+interface UseDrawingCanvasOptions {
+  // ...existing fields...
+  activeTool: ShapeTool; // was implicit via `color === 'eraser'`
+  shapeFill?: boolean; // for rect/ellipse only
+}
+```
+
+Internals:
+
+- Replace `currentPathRef: Point[]` with a discriminated in-progress ref:
+  ```ts
+  type InProgress =
+    | { kind: 'path'; points: Point[] }
+    | {
+        kind: 'rect' | 'ellipse';
+        x0: number;
+        y0: number;
+        x1: number;
+        y1: number;
+      }
+    | {
+        kind: 'line' | 'arrow';
+        x1: number;
+        y1: number;
+        x2: number;
+        y2: number;
+      };
+  const inProgressRef = useRef<InProgress | null>(null);
+  ```
+- `handleStart` branches on `activeTool`: pen/eraser initializes `{ kind: 'path', points: [pos] }`; shape tools record start point (`x0,y0 = x1,y1 = pos`).
+- `handleMove` updates the last point (pen) or the end point (shapes). Triggers a redraw with the preview object passed into `draw()`.
+- `handleEnd` materializes the in-progress into a `DrawableObject`:
+  - `path` → `PathObject` (unchanged logic; uses `color`/`width`, honors eraser mode).
+  - `rect`/`ellipse` → normalize `x0,y0,x1,y1` to `{x, y, w, h}` with `w,h >= 0`; apply `stroke: color`, `strokeWidth: width`, `fill: shapeFill ? color : undefined`.
+  - `line`/`arrow` → `{ x1, y1, x2, y2, stroke: color, strokeWidth: width }`.
+  - Degenerate shapes (zero width AND zero height, or same start/end point) are dropped — mirrors today's "paths of length < 2 are dropped" ([useDrawingCanvas.ts:154](components/widgets/DrawingWidget/useDrawingCanvas.ts#L154)).
+- Eraser path keeps today's `destination-out` composite. Shape tools do NOT offer an eraser variant (matches teacher expectations; keeps the matrix small).
+
+Renderer dispatcher — fill in the four stubbed branches at [useDrawingCanvas.ts:183-189](components/widgets/DrawingWidget/useDrawingCanvas.ts#L183-L189):
+
+```ts
+case 'rect':
+  return renderRect(ctx, obj);
+case 'ellipse':
+  return renderEllipse(ctx, obj);
+case 'line':
+  return renderLine(ctx, obj);
+case 'arrow':
+  return renderArrow(ctx, obj);
+// 'text' / 'image' stay no-op — land in 2.1d / 2.2
+```
+
+Each new renderer is ~10 lines of Canvas 2D: `ctx.strokeRect`, `ctx.ellipse`, `ctx.moveTo/lineTo`, plus an arrow head via two extra `lineTo` calls and `ctx.fill()`. Save/restore the context around each so `globalCompositeOperation`, `strokeStyle`, `lineWidth`, and `fillStyle` don't leak between objects.
+
+### UI — `DrawingWidget/Widget.tsx` toolbar
+
+Reshape `PaletteUI` into three compact clusters, each separated by the existing `h-6 w-px bg-slate-200` divider:
+
+1. **Tools** (radio-style, one active) — Pen, Eraser, Line, Arrow, Rect, Ellipse. Six `<Button variant="ghost" size="icon">`, icons from lucide-react: `Pencil`, `Eraser`, `Slash` (or `Minus`), `ArrowRight`, `Square`, `Circle`. Active tool gets `ring-2 ring-indigo-500`.
+2. **Color swatches** — unchanged, but eraser swatch removed (eraser is now in Tools cluster). Disabled visually when `activeTool === 'eraser'`.
+3. **Actions** — Undo, Clear All, AI-extract (unchanged).
+
+Tool click handler sets `config.activeTool`; color click handler only sets `config.color`. Don't auto-flip activeTool back to pen after a color click — teachers picking shape color then drawing a shape is the natural flow.
+
+Stroke width (the `width` slider) applies to every tool. Keep its current home in [Settings.tsx:~55](components/widgets/DrawingWidget/Settings.tsx) — no need to promote to the front toolbar in 2.1b. Add a `shapeFill` toggle to Settings below the width slider.
+
+### Files modified
+
+| File                                                                                                         | Change                                                                                                                                                             |
+| ------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| [types.ts](types.ts)                                                                                         | Add `ShapeTool` type; extend `DrawingConfig` with `activeTool`, `shapeFill`.                                                                                       |
+| [utils/migrateDrawingConfig.ts](utils/migrateDrawingConfig.ts)                                               | Migrate legacy `color === 'eraser'` → `activeTool: 'eraser'`; default `activeTool: 'pen'`, `shapeFill: false`.                                                     |
+| [components/widgets/DrawingWidget/useDrawingCanvas.ts](components/widgets/DrawingWidget/useDrawingCanvas.ts) | `activeTool` in options; discriminated `inProgressRef`; shape `handleStart/Move/End`; fill in rect/ellipse/line/arrow renderers; preview-object param to `draw()`. |
+| [components/widgets/DrawingWidget/Widget.tsx](components/widgets/DrawingWidget/Widget.tsx)                   | Tool cluster in `PaletteUI`; decouple color from tool; pass `activeTool` + `shapeFill` to hook.                                                                    |
+| [components/widgets/DrawingWidget/Settings.tsx](components/widgets/DrawingWidget/Settings.tsx)               | Add `shapeFill` toggle.                                                                                                                                            |
+| [components/widgets/DrawingWidget/constants.ts](components/widgets/DrawingWidget/constants.ts)               | Add `DRAWING_DEFAULTS.ACTIVE_TOOL = 'pen'`.                                                                                                                        |
+| [components/layout/AnnotationOverlay.tsx](components/layout/AnnotationOverlay.tsx)                           | Mirror the tool cluster so shapes work during full-screen annotation.                                                                                              |
+
+### Reused utilities (don't rebuild)
+
+- `crypto.randomUUID()` + `nextZ()` from [utils/migrateDrawingConfig.ts](utils/migrateDrawingConfig.ts) — same as paths.
+- `Button` primitive at [components/common/Button.tsx](components/common/Button.tsx) — existing `variant="ghost"` + `size="icon"` matches current toolbar.
+- `STANDARD_COLORS` from [config/colors.ts](config/colors.ts) — shape stroke color comes from the same palette as pen color; no new palette logic.
+- `DrawableObject` + all seven variant interfaces — already defined in [types.ts:163-263](types.ts#L163-L263).
+
+### Verification
+
+1. **Unit tests** — extend [useDrawingCanvas.test.ts](components/widgets/DrawingWidget/useDrawingCanvas.test.ts) with:
+   - Rect drag: pointer-down-right-up emits one `RectObject` with correctly normalized `{x, y, w, h}` (including drag-up-left, producing non-negative `w`/`h`).
+   - Ellipse drag: same normalization; `kind: 'ellipse'`.
+   - Line drag: emits `LineObject` with `{x1, y1, x2, y2}` matching start/end.
+   - Arrow drag: same but `kind: 'arrow'`.
+   - Degenerate shape (start === end) does not append to objects.
+   - Shape drawn while `shapeFill: true` produces `fill === color`; while false, `fill === undefined`.
+   - Tool switch during drag is ignored (activeTool captured at `handleStart`).
+2. **Migration tests** — extend [migrateDrawingConfig.test.ts](tests/utils/migrateDrawingConfig.test.ts) with the 3 cases listed in the Migration section.
+3. **Widget tests** — extend [Widget.test.tsx](components/widgets/DrawingWidget/Widget.test.tsx) with a tool-switch round trip (click rect button → `config.activeTool === 'rect'` persisted).
+4. **Validation gate**: `pnpm run validate` green. Target: 1120+ tests passing (Phase 2a landed at 1117).
+5. **Manual smoke test** — `pnpm run dev`:
+   - Draw each shape in sequence; verify stroke renders at correct position and width.
+   - Drag a rect up-left from bottom-right; confirm it appears correctly (normalized).
+   - Toggle `shapeFill` in settings; verify new rects/ellipses fill with the current color.
+   - Load a pre-Phase-2a dashboard with legacy `color: 'eraser'`; confirm it hydrates into `activeTool: 'eraser'` and the eraser button is selected.
+   - Open annotation overlay; draw an arrow over a slide; verify it renders and persists until cleared.
+   - Refresh the page; verify shapes persist and the previously selected tool is still active.
+6. **Firestore shape check** — open a dev-project widget document: `config.activeTool` is present; `config.color` is a hex string (never `"eraser"`); `config.objects` contains `RectObject`/`EllipseObject`/`LineObject`/`ArrowObject` entries with the expected fields.
+
+### Non-goals for 2.1b (stay disciplined)
+
+- Selecting, moving, resizing, rotating, or deleting individual shapes (that's 2.1c).
+- Multi-select / marquee selection (2.1c).
+- Per-shape stroke width / color editing after creation (2.1c).
+- Snap-to-grid or alignment guides (possible 2.5 stretch; out of scope here).
+- Keyboard shortcuts for tool switching (fits naturally after 2.4's command stack).
+
+---
+
+## Later PRs — sketch only (design when each branch opens)
+
+**2.1c — Selection + transform.** New `selection` transient state in Widget (not persisted). Hit-test on pointer-down when `activeTool === 'select'`: bounding-box test for shapes/text/image, stroke-proximity test for paths/lines. Render 8 drag handles around selected object's bbox for resize; a rotation handle above. `Backspace`/`Delete` key removes. Group-select (marquee) likely out of scope for first cut.
+
+**2.1d — Text objects.** New `text` tool places an empty `TextObject` on click and focuses a contenteditable overlay positioned over the canvas. Reuse [TypographySettings.tsx](components/common/TypographySettings.tsx) for font family/color editing (already shared across widgets). Persisted `content` is sanitized via [utils/security.ts](utils/security.ts) on save.
+
+**2.2 — Image insertion.** Reuse [hooks/useImageUpload.ts](hooks/useImageUpload.ts) and `useStorage.uploadDisplayImage`. Entry points: paste (clipboard), drag-and-drop onto the canvas, or an image button in the toolbar. Upload returns `src` + `assetId` for the `ImageObject`.
+
+**2.3 — Multi-page canvases.** Mirror SmartNotebook's page-array pattern ([components/widgets/SmartNotebook/Widget.tsx:33-87](components/widgets/SmartNotebook/Widget.tsx#L33-L87)). `DrawingConfig.objects` becomes `DrawingConfig.pages: DrawableObject[][]` plus `currentPage: number`. Migration wraps existing `objects` into `pages: [objects]`. Page stepper + thumbnail strip in the toolbar.
+
+**2.4 — Undo/redo command stack.** Replace the single-level `objects.slice(0, -1)` undo with a `Command[]` stack. Commands are `AddObject | RemoveObject | UpdateObject | ReorderObject`. In-memory only (not persisted); cleared on reload. `Ctrl/Cmd+Z` / `Ctrl/Cmd+Shift+Z` bindings. Coexists with selection-era mutations from 2.1c (each transform pushes one `UpdateObject` command).
+
+**2.5 — Export + background templates.** PNG export via `canvas.toDataURL('image/png')` (already used in OCR flow at [Widget.tsx:88](components/widgets/DrawingWidget/Widget.tsx#L88)). PDF via a `jspdf`-style lib if not already in repo; otherwise print-dialog fallback. Background templates: `DrawingConfig.background: 'blank' | 'grid' | 'lines' | 'dots'` rendered as a CSS background layer below the canvas (no object churn).
+
+**2.6 — Firestore subcollection + incremental render.** Move `objects` off the dashboard doc into `/users/{uid}/dashboards/{id}/drawings/{widgetId}/objects/{objectId}`. Use `onSnapshot` with `includeMetadataChanges`. Incremental render: when one object changes, redraw only that object's bbox region instead of `clearRect`-ing the whole canvas. Target: 500+ objects without lag.
+
+---
+
+## Critical files (for any Phase 2 work)
+
+- [types.ts:163-263](types.ts#L163-L263) — `DrawableObject` union and variants. Already complete for every PR below.
+- [components/widgets/DrawingWidget/useDrawingCanvas.ts](components/widgets/DrawingWidget/useDrawingCanvas.ts) — the shared rendering + pointer pipeline. Each PR extends this hook.
+- [components/widgets/DrawingWidget/Widget.tsx](components/widgets/DrawingWidget/Widget.tsx) — toolbar + widget wiring. Main UI surface for each PR.
+- [components/layout/AnnotationOverlay.tsx](components/layout/AnnotationOverlay.tsx) — parallel consumer of `useDrawingCanvas`; must stay in lockstep.
+- [utils/migrateDrawingConfig.ts](utils/migrateDrawingConfig.ts) — central migration point. Each schema change adds a lazy forward-migration rule here.
+- [context/DashboardContext.tsx](context/DashboardContext.tsx) — annotation state + hydration; touches whenever `DrawingConfig` grows new fields.
+
+---
+
+## Success definition for Phase 2
+
+Phase 2 is done when a teacher can open a DrawingWidget and do every core whiteboard action without leaving the tool: draw strokes and shapes, add and edit text, paste images, move/resize/delete anything they placed, undo/redo freely, flip between multiple pages, export the result, and have it all stay responsive at classroom-scale object counts. Each PR above ticks one of those boxes; 2.1b ticks "draw shapes."

--- a/hooks/useGoogleDrive.ts
+++ b/hooks/useGoogleDrive.ts
@@ -99,8 +99,15 @@ export const useGoogleDrive = () => {
 
   /**
    * Upload a drawing/annotation PNG to the user's Drive "Drawings" folder and
-   * return a shareable Drive URL. Uses the same public-sharing pattern as
-   * background uploads so the link works across contexts.
+   * return a shareable Drive viewer URL.
+   *
+   * NOTE: Returns a `drive.google.com/file/d/.../view` URL — intended for
+   * teachers clicking through to open the saved annotation in Drive's
+   * native viewer. This is **different** from `uploadBackgroundToDrive`,
+   * which returns a `lh3.googleusercontent.com/d/...` URL so the image can
+   * be rendered via CSS `background-image` (requires CORS-friendly headers).
+   * Annotations are teacher-facing artifacts, not embedded images, so the
+   * viewer URL is the appropriate return value.
    */
   const saveDrawingToDrive = useCallback(
     async (blob: Blob, fileName: string): Promise<string> => {

--- a/hooks/useGoogleDrive.ts
+++ b/hooks/useGoogleDrive.ts
@@ -101,6 +101,13 @@ export const useGoogleDrive = () => {
    * Upload a drawing/annotation PNG to the user's Drive "Drawings" folder and
    * return a shareable Drive viewer URL.
    *
+   * Sharing: when the user is on a Google Workspace domain, the file is
+   * shared with that domain (so only colleagues at the same school can open
+   * it). Consumer accounts (gmail.com etc.) fall back to "anyone with the
+   * link" automatically — `makePublic` handles the consumer-domain case.
+   * Annotations can contain classroom info, so domain-restricted sharing
+   * is the safer default when available.
+   *
    * NOTE: Returns a `drive.google.com/file/d/.../view` URL — intended for
    * teachers clicking through to open the saved annotation in Drive's
    * native viewer. This is **different** from `uploadBackgroundToDrive`,
@@ -121,11 +128,11 @@ export const useGoogleDrive = () => {
         DRAWINGS_FOLDER
       );
 
-      await driveService.makePublic(driveFile.id, undefined);
+      await driveService.makePublic(driveFile.id, userDomain);
 
       return `https://drive.google.com/file/d/${driveFile.id}/view`;
     },
-    [driveService]
+    [driveService, userDomain]
   );
 
   /**

--- a/hooks/useGoogleDrive.ts
+++ b/hooks/useGoogleDrive.ts
@@ -4,6 +4,7 @@ import { GoogleDriveService } from '../utils/googleDriveService';
 import { APP_NAME } from '../config/constants';
 
 const BACKGROUNDS_FOLDER = 'Backgrounds';
+const DRAWINGS_FOLDER = 'Drawings';
 const LEGACY_FOLDER_NAME = 'SPART Board';
 const MIGRATION_COMPLETED_FLAG = 'true';
 const migrationKey = (uid: string) => `spart_drive_folder_migrated_v2_${uid}`;
@@ -97,6 +98,30 @@ export const useGoogleDrive = () => {
   }, [driveService]);
 
   /**
+   * Upload a drawing/annotation PNG to the user's Drive "Drawings" folder and
+   * return a shareable Drive URL. Uses the same public-sharing pattern as
+   * background uploads so the link works across contexts.
+   */
+  const saveDrawingToDrive = useCallback(
+    async (blob: Blob, fileName: string): Promise<string> => {
+      if (!driveService) {
+        throw new Error('Google Drive is not connected. Please sign in again.');
+      }
+
+      const driveFile = await driveService.uploadFile(
+        blob,
+        fileName,
+        DRAWINGS_FOLDER
+      );
+
+      await driveService.makePublic(driveFile.id, undefined);
+
+      return `https://drive.google.com/file/d/${driveFile.id}/view`;
+    },
+    [driveService]
+  );
+
+  /**
    * Attempts to extract text content from a Google Drive file if it is a supported type (Docs, Slides, Sheets, Text).
    */
   const getDriveFileTextContent = useCallback(
@@ -126,5 +151,6 @@ export const useGoogleDrive = () => {
     uploadBackgroundToDrive,
     getUserBackgroundsFromDrive,
     getDriveFileTextContent,
+    saveDrawingToDrive,
   };
 };

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e
+
+echo "Setting up environment..."
+
+corepack enable
+corepack prepare pnpm@10.30.2 --activate
+
+pnpm run install:all
+
+echo "Setup complete."

--- a/tests/utils/migrateDrawingConfig.test.ts
+++ b/tests/utils/migrateDrawingConfig.test.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect } from 'vitest';
+import {
+  emptyDrawingConfig,
+  migrateDrawingConfig,
+  nextZ,
+} from '@/utils/migrateDrawingConfig';
+import type {
+  DrawableObject,
+  DrawingConfig,
+  Path,
+  PathObject,
+  RectObject,
+} from '@/types';
+
+const legacyPath = (overrides: Partial<Path> = {}): Path => ({
+  points: [
+    { x: 0, y: 0 },
+    { x: 10, y: 10 },
+  ],
+  color: '#123456',
+  width: 4,
+  ...overrides,
+});
+
+const pathObject = (overrides: Partial<PathObject> = {}): PathObject => ({
+  id: 'obj-1',
+  kind: 'path',
+  z: 0,
+  points: [{ x: 0, y: 0 }],
+  color: '#000',
+  width: 2,
+  ...overrides,
+});
+
+describe('migrateDrawingConfig', () => {
+  it('returns an empty config when input is null or undefined', () => {
+    expect(migrateDrawingConfig(null)).toEqual({ objects: [] });
+    expect(migrateDrawingConfig(undefined)).toEqual({ objects: [] });
+  });
+
+  it('passes through an already-migrated config unchanged', () => {
+    const existing: DrawableObject[] = [
+      pathObject(),
+      pathObject({ id: 'obj-2', z: 1 }),
+    ];
+    const input: DrawingConfig = {
+      objects: existing,
+      color: '#ff0000',
+      width: 6,
+      customColors: ['#111', '#222'],
+    };
+    const out = migrateDrawingConfig(input);
+    expect(out.objects).toBe(existing);
+    expect(out.color).toBe('#ff0000');
+    expect(out.width).toBe(6);
+    expect(out.customColors).toEqual(['#111', '#222']);
+  });
+
+  it('strips deprecated `paths` and `mode` even from migrated configs', () => {
+    const input = {
+      objects: [pathObject()],
+      paths: [legacyPath()],
+      mode: 'overlay' as const,
+    };
+    const out = migrateDrawingConfig(input as DrawingConfig);
+    expect(out).not.toHaveProperty('paths');
+    expect(out).not.toHaveProperty('mode');
+    expect(out.objects).toHaveLength(1);
+  });
+
+  it('wraps legacy paths as PathObjects with fresh UUIDs and sequential z', () => {
+    const input: DrawingConfig = {
+      objects: [] as DrawableObject[],
+      // Intentionally set objects undefined via cast — simulating a legacy
+      // document that only has `paths`.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any;
+    delete (input as unknown as { objects?: unknown }).objects;
+    (input as unknown as { paths: Path[] }).paths = [
+      legacyPath({ color: '#aaa' }),
+      legacyPath({ color: '#bbb' }),
+      legacyPath({ color: '#ccc' }),
+    ];
+
+    const out = migrateDrawingConfig(input);
+    expect(out.objects).toHaveLength(3);
+    out.objects.forEach((o, i) => {
+      expect(o.kind).toBe('path');
+      expect(o.z).toBe(i);
+      expect(typeof o.id).toBe('string');
+      expect(o.id).not.toHaveLength(0);
+    });
+    const colors = out.objects.map((o) => (o as PathObject).color);
+    expect(colors).toEqual(['#aaa', '#bbb', '#ccc']);
+  });
+
+  it('assigns distinct UUIDs to each migrated path', () => {
+    const input = {
+      paths: [legacyPath(), legacyPath(), legacyPath()],
+    } as unknown as DrawingConfig;
+    const out = migrateDrawingConfig(input);
+    const ids = out.objects.map((o) => o.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('drops malformed legacy paths rather than throwing', () => {
+    const input = {
+      paths: [
+        legacyPath(),
+        { points: [], color: '#000', width: 2 }, // empty points
+        { points: [{ x: 0, y: 0 }], color: '#000' }, // missing width
+        { color: '#000', width: 2 }, // missing points
+        null,
+        undefined,
+        'not a path',
+      ],
+    } as unknown as DrawingConfig;
+    const out = migrateDrawingConfig(input);
+    expect(out.objects).toHaveLength(1);
+  });
+
+  it('returns an empty objects array when neither paths nor objects exist', () => {
+    const input = { color: '#000' } as unknown as DrawingConfig;
+    const out = migrateDrawingConfig(input);
+    expect(out.objects).toEqual([]);
+    expect(out.color).toBe('#000');
+  });
+
+  it('is idempotent — migrating twice equals migrating once', () => {
+    const input = {
+      paths: [legacyPath(), legacyPath()],
+      color: '#f0f',
+      width: 3,
+    } as unknown as DrawingConfig;
+    const once = migrateDrawingConfig(input);
+    const twice = migrateDrawingConfig(once);
+    expect(twice.objects).toEqual(once.objects);
+    expect(twice.color).toBe(once.color);
+    expect(twice.width).toBe(once.width);
+  });
+});
+
+describe('nextZ', () => {
+  it('returns 0 for an empty list', () => {
+    expect(nextZ([])).toBe(0);
+  });
+
+  it('returns max(z) + 1', () => {
+    const objects: DrawableObject[] = [
+      pathObject({ z: 0 }),
+      pathObject({ id: '2', z: 5 }),
+      pathObject({ id: '3', z: 3 }),
+    ];
+    expect(nextZ(objects)).toBe(6);
+  });
+
+  it('handles non-path objects', () => {
+    const rect: RectObject = {
+      id: 'r',
+      kind: 'rect',
+      z: 10,
+      x: 0,
+      y: 0,
+      w: 100,
+      h: 100,
+      stroke: '#000',
+      strokeWidth: 2,
+    };
+    expect(nextZ([rect])).toBe(11);
+  });
+});
+
+describe('emptyDrawingConfig', () => {
+  it('returns a fresh empty config each call', () => {
+    const a = emptyDrawingConfig();
+    const b = emptyDrawingConfig();
+    expect(a).toEqual({ objects: [] });
+    expect(a).not.toBe(b);
+  });
+});

--- a/types.ts
+++ b/types.ts
@@ -160,6 +160,108 @@ export interface Path {
   width: number;
 }
 
+// --- Whiteboard object model (Phase 2a) ---
+// DrawableObject is a polymorphic union that replaces the pen-only `Path[]`
+// model used in Phase 1. All objects share an id + z + optional rotation;
+// each kind adds its own geometry/style fields. Rendering dispatches on
+// `kind` (see components/widgets/DrawingWidget/useDrawingCanvas.ts).
+
+export type DrawableObjectKind =
+  | 'path'
+  | 'rect'
+  | 'ellipse'
+  | 'line'
+  | 'arrow'
+  | 'text'
+  | 'image';
+
+export interface BaseDrawableObject {
+  id: string;
+  kind: DrawableObjectKind;
+  z: number;
+  rotation?: number;
+}
+
+export interface PathObject extends BaseDrawableObject {
+  kind: 'path';
+  points: Point[];
+  color: string;
+  width: number;
+}
+
+export interface RectObject extends BaseDrawableObject {
+  kind: 'rect';
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+  stroke: string;
+  strokeWidth: number;
+  fill?: string;
+}
+
+export interface EllipseObject extends BaseDrawableObject {
+  kind: 'ellipse';
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+  stroke: string;
+  strokeWidth: number;
+  fill?: string;
+}
+
+export interface LineObject extends BaseDrawableObject {
+  kind: 'line';
+  x1: number;
+  y1: number;
+  x2: number;
+  y2: number;
+  stroke: string;
+  strokeWidth: number;
+}
+
+export interface ArrowObject extends BaseDrawableObject {
+  kind: 'arrow';
+  x1: number;
+  y1: number;
+  x2: number;
+  y2: number;
+  stroke: string;
+  strokeWidth: number;
+}
+
+export interface TextObject extends BaseDrawableObject {
+  kind: 'text';
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+  content: string;
+  fontFamily: string;
+  fontSize: number;
+  color: string;
+}
+
+export interface ImageObject extends BaseDrawableObject {
+  kind: 'image';
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+  src: string;
+  assetId?: string;
+}
+
+export type DrawableObject =
+  | PathObject
+  | RectObject
+  | EllipseObject
+  | LineObject
+  | ArrowObject
+  | TextObject
+  | ImageObject;
+
 export interface ChecklistItem {
   id: string;
   text: string;
@@ -348,7 +450,18 @@ export interface DrawingConfig {
    * for backward compatibility.
    */
   mode?: 'window' | 'overlay';
-  paths: Path[];
+  /**
+   * Legacy pen-only stroke list. Still used by the per-widget annotation
+   * feature on DraggableWindow (`widget.annotation.paths`). The DrawingWidget
+   * migrates this to `objects[]` on read via `migrateDrawingConfig`.
+   */
+  paths?: Path[];
+  /**
+   * Canonical whiteboard content for the DrawingWidget: a polymorphic list
+   * of drawable objects. Optional so the per-widget annotation feature can
+   * continue storing only `paths`.
+   */
+  objects?: DrawableObject[];
   color?: string;
   width?: number;
   customColors?: string[];

--- a/types.ts
+++ b/types.ts
@@ -342,7 +342,12 @@ export interface SoundConfig {
 }
 
 export interface DrawingConfig {
-  mode: 'window' | 'overlay';
+  /**
+   * @deprecated Annotation mode is now an app-level overlay (not a widget).
+   * Legacy widgets may have this set; it is otherwise unused and kept only
+   * for backward compatibility.
+   */
+  mode?: 'window' | 'overlay';
   paths: Path[];
   color?: string;
   width?: number;
@@ -824,7 +829,6 @@ export interface ScoreboardGlobalConfig {
 // --- Drawing Global Config ---
 export interface BuildingDrawingDefaults {
   buildingId: string;
-  mode?: 'window' | 'overlay';
   width?: number;
   customColors?: string[];
 }

--- a/utils/migrateDrawingConfig.ts
+++ b/utils/migrateDrawingConfig.ts
@@ -1,0 +1,96 @@
+import { DrawableObject, DrawingConfig, Path, PathObject } from '../types';
+
+/** DrawingConfig with `objects` guaranteed non-optional. Post-migration shape. */
+export type MigratedDrawingConfig = DrawingConfig & {
+  objects: DrawableObject[];
+};
+
+/**
+ * Forward-migrate a DrawingConfig to the Phase-2 object-model shape.
+ *
+ * Legacy (Phase 1) shape: `{ paths: Path[]; mode?; color?; width?; customColors? }`.
+ * Canonical (Phase 2a) shape: `{ objects: DrawableObject[]; ... }`.
+ *
+ * Behavior:
+ * - If `objects[]` is non-empty, it's the source of truth — we keep it and
+ *   drop any lingering legacy `paths`/`mode`.
+ * - If `objects` is missing or empty AND `paths` has content, each legacy
+ *   Path is wrapped as a `PathObject` with a fresh UUID and sequential z.
+ *   Preferring `paths` in this edge case prevents data loss when a widget is
+ *   halfway through migration (shouldn't happen in production, but defensive
+ *   behavior is cheap).
+ * - If neither has content, `objects` becomes `[]`.
+ * - Malformed `paths` entries (missing points array, empty points, etc.) are
+ *   dropped rather than crashing the widget.
+ *
+ * This function is pure and idempotent — calling it on an already-migrated
+ * config returns an equivalent config.
+ */
+export const migrateDrawingConfig = (
+  raw: DrawingConfig | undefined | null
+): MigratedDrawingConfig => {
+  if (!raw || typeof raw !== 'object') {
+    return { objects: [] };
+  }
+
+  const { paths, mode: _mode, ...rest } = raw;
+
+  if (Array.isArray(raw.objects) && raw.objects.length > 0) {
+    // Already migrated with content — strip legacy fields and return.
+    return { ...rest, objects: raw.objects };
+  }
+
+  const migratedFromPaths: PathObject[] = Array.isArray(paths)
+    ? paths.reduce<PathObject[]>((acc, p, idx) => {
+        if (!isValidLegacyPath(p)) return acc;
+        acc.push({
+          id: crypto.randomUUID(),
+          kind: 'path',
+          z: idx,
+          points: p.points,
+          color: p.color,
+          width: p.width,
+        });
+        return acc;
+      }, [])
+    : [];
+
+  if (migratedFromPaths.length > 0) {
+    return { ...rest, objects: migratedFromPaths };
+  }
+
+  // Nothing to migrate — preserve existing `objects` (even if empty) so that
+  // intentional resets like `clear()` round-trip correctly.
+  return { ...rest, objects: Array.isArray(raw.objects) ? raw.objects : [] };
+};
+
+const isValidLegacyPath = (p: unknown): p is Path => {
+  if (!p || typeof p !== 'object') return false;
+  const candidate = p as Partial<Path>;
+  return (
+    Array.isArray(candidate.points) &&
+    candidate.points.length > 0 &&
+    typeof candidate.color === 'string' &&
+    typeof candidate.width === 'number'
+  );
+};
+
+/**
+ * Convenience: the "empty" drawing config used for new widgets.
+ */
+export const emptyDrawingConfig = (): MigratedDrawingConfig => ({
+  objects: [],
+});
+
+/**
+ * Return the next z-index to use when appending a new object. Matches the
+ * "last-drawn-on-top" rule: max(z) + 1, or 0 for an empty list.
+ */
+export const nextZ = (objects: readonly DrawableObject[]): number => {
+  if (objects.length === 0) return 0;
+  let max = objects[0].z;
+  for (let i = 1; i < objects.length; i++) {
+    if (objects[i].z > max) max = objects[i].z;
+  }
+  return max + 1;
+};

--- a/utils/migration.ts
+++ b/utils/migration.ts
@@ -1,5 +1,6 @@
 import {
   Dashboard,
+  DrawingConfig,
   WidgetData,
   TimeToolConfig,
   TextConfig,
@@ -8,6 +9,7 @@ import {
 } from '../types';
 import { sanitizeHtml } from './security';
 import { WIDGET_DEFAULTS } from '@/config/widgetDefaults';
+import { migrateDrawingConfig } from './migrateDrawingConfig';
 
 // Minimum dimension threshold: widgets smaller than this were likely
 // created with a bug where pixel dimensions were recorded as single digits
@@ -93,6 +95,21 @@ export const migrateWidget = (widget: WidgetData): WidgetData => {
       ...w,
       type: 'expectations',
     };
+  }
+
+  // Phase 2a: migrate legacy drawing configs (paths[]) forward to the
+  // polymorphic objects[] model. The widget also does this defensively, but
+  // hydrating into the canonical shape avoids spurious Firestore re-writes.
+  if (type === 'drawing') {
+    const raw = w.config as DrawingConfig;
+    const migrated = migrateDrawingConfig(raw);
+    // Only replace the config object when a meaningful change occurred to
+    // keep React reference equality stable for already-migrated widgets.
+    const hadLegacyPaths = Array.isArray(raw?.paths);
+    const hadLegacyMode = typeof raw?.mode === 'string';
+    if (hadLegacyPaths || hadLegacyMode || !Array.isArray(raw?.objects)) {
+      return { ...w, config: migrated };
+    }
   }
 
   // Ensure poll options have stable IDs (legacy data may lack them)

--- a/utils/widgetDragFlag.ts
+++ b/utils/widgetDragFlag.ts
@@ -1,0 +1,7 @@
+export function beginWidgetDrag(): void {
+  document.body.classList.add('is-dragging-widget');
+}
+
+export function endWidgetDrag(): void {
+  document.body.classList.remove('is-dragging-widget');
+}


### PR DESCRIPTION
This pull request introduces several significant improvements to the annotation and drawing experience in the dashboard, focusing on a new full-screen annotation overlay, UI simplification, and enhancements to the custom snap grid. The most notable change is the addition of the `AnnotationOverlay` component, which allows users to annotate directly over the dashboard with advanced features like downloading, Google Drive export, and AI-powered text extraction. Other changes include removing the drawing "mode" toggle from configuration, updating tests accordingly, and improving the snap grid UI to visually indicate occupied cells.

**Annotation overlay and dashboard integration:**
- Added a new `AnnotationOverlay` component that provides a full-screen, ephemeral annotation layer above all widgets. This overlay includes a floating toolbar for brush selection, erasing, undo/clear, download, Google Drive export, and AI text extraction. The overlay is rendered above all other UI elements and disables the Dock while active. [[1]](diffhunk://#diff-5d4029a0ba353f2df6825e1a1fc70129c29e379ed1ef4152a456e7bf7cafbd8cR1-R396) [[2]](diffhunk://#diff-bac38d8c60b33e9863b78ac27c76a3cb2a289b283841d80ab7752cf5dad2d21bR18) [[3]](diffhunk://#diff-bac38d8c60b33e9863b78ac27c76a3cb2a289b283841d80ab7752cf5dad2d21bR154) [[4]](diffhunk://#diff-bac38d8c60b33e9863b78ac27c76a3cb2a289b283841d80ab7752cf5dad2d21bL1275-R1278)

**Drawing configuration simplification:**
- Removed the "mode" (window/overlay) toggle from the `DrawingConfigurationPanel` UI and its related logic, as the annotation mode is now selected at click-time rather than via settings. Tests were updated to reflect this change. [[1]](diffhunk://#diff-652ecbc61b12aa6f5d61f7dadefaa9da36e3382b97219f2629a58586dfec9cdcL6-R6) [[2]](diffhunk://#diff-652ecbc61b12aa6f5d61f7dadefaa9da36e3382b97219f2629a58586dfec9cdcL43) [[3]](diffhunk://#diff-652ecbc61b12aa6f5d61f7dadefaa9da36e3382b97219f2629a58586dfec9cdcL84-L112) [[4]](diffhunk://#diff-283fd80d696a2283ebfb0447e41dfeafa5feb8e30fa7b10b60f806c9c569b7bbL19) [[5]](diffhunk://#diff-283fd80d696a2283ebfb0447e41dfeafa5feb8e30fa7b10b60f806c9c569b7bbL46-R52)

**Custom snap grid enhancements:**
- Increased the snap grid size in `DraggableWindow` from 8x6 to 10x10 for finer control, and added logic to visually indicate grid cells that are already occupied by other widgets, preventing overlap during resizing or repositioning. [[1]](diffhunk://#diff-0d33fd1f9e084a22794f65c762da0467ecb5d266454fa1359d74a6156b9c03dcL63-R65) [[2]](diffhunk://#diff-0d33fd1f9e084a22794f65c762da0467ecb5d266454fa1359d74a6156b9c03dcR191) [[3]](diffhunk://#diff-0d33fd1f9e084a22794f65c762da0467ecb5d266454fa1359d74a6156b9c03dcR205-R244) [[4]](diffhunk://#diff-0d33fd1f9e084a22794f65c762da0467ecb5d266454fa1359d74a6156b9c03dcR2288-R2305)