### PR TITLE
🔒 Hardened Storage security with get/list separation (v3)

### DIFF
--- a/storage.rules
+++ b/storage.rules
@@ -61,7 +61,7 @@ service firebase.storage {
       allow write: if isAdmin();
     }
 
-    match /admin_weather/{rangeId}/{fileName} {
+    match /admin_weather/{allPaths=**} {
       allow get: if request.auth != null; // Authenticated users can fetch images
       allow list: if isAdmin();           // Only admins can enumerate all images
       allow write: if isAdmin();
@@ -85,7 +85,7 @@ service firebase.storage {
       allow write: if isAdmin();
     }
 
-    match /catalyst/images/{routineId}/{fileName} {
+    match /catalyst/images/{allPaths=**} {
       allow get: if request.auth != null;
       allow list: if isAdmin();
       allow write: if isAdmin();

--- a/storage.rules
+++ b/storage.rules
@@ -62,37 +62,44 @@ service firebase.storage {
     }
 
     match /admin_weather/{rangeId}/{fileName} {
-      allow read: if true; // Weather images are public
+      allow get: if request.auth != null; // Authenticated users can fetch images
+      allow list: if isAdmin();           // Only admins can enumerate all images
       allow write: if isAdmin();
     }
 
     match /admin_stickers/{fileName} {
-      allow read: if true;
+      allow get: if request.auth != null;
+      allow list: if isAdmin();
       allow write: if isAdmin();
     }
 
     match /admin_work_symbols/{fileName} {
-      allow read: if true;
+      allow get: if request.auth != null;
+      allow list: if isAdmin();
       allow write: if isAdmin();
     }
 
     match /admin_catalyst_icons/{allPaths=**} {
-      allow read: if true;
+      allow get: if request.auth != null;
+      allow list: if isAdmin();
       allow write: if isAdmin();
     }
 
     match /catalyst/images/{routineId}/{fileName} {
-      allow read: if true;
+      allow get: if request.auth != null;
+      allow list: if isAdmin();
       allow write: if isAdmin();
     }
 
     match /admin_music_thumbnails/{allPaths=**} {
-      allow read: if true;
+      allow get: if request.auth != null;
+      allow list: if isAdmin();
       allow write: if isAdmin();
     }
 
     match /admin_logos/{fileName} {
-      allow read: if true; // Logo should be public for all users
+      allow get: if true;        // Logo remains public for fetching (e.g. login screen)
+      allow list: if isAdmin();   // Only admins can enumerate the logos directory
       allow write: if isAdmin();
     }
 


### PR DESCRIPTION
🎯 **What:** Hardened Firebase Storage security by splitting 'read' into 'get' and 'list'.
⚠️ **Risk:** Enumeration of administrative assets by authenticated users.
🛡️ **Solution:**
- Replaced `allow read` with `allow get: if request.auth != null;` for most admin paths.
- Added `allow list: if isAdmin();` to restrict directory enumeration to administrators.
- Maintained public `get` for `admin_logos` while securing its `list` permission.
This follows the principle of least privilege and prevents authenticated users from scraping the entire asset library.

---
*PR created automatically by Jules for task [10122760798061331598](https://jules.google.com/task/10122760798061331598) started by @OPS-PIvers*