### PR TITLE
Add StudentLeaderboard component and live leaderboard functionality

### DIFF
--- a/components/quiz/StudentLeaderboard.tsx
+++ b/components/quiz/StudentLeaderboard.tsx
@@ -1,0 +1,128 @@
+/**
+ * StudentLeaderboard — reusable top-N-plus-self leaderboard view used on
+ * student-facing quiz screens (review phase, submitted wait screen,
+ * results screen). Reads from session.liveLeaderboard which the teacher
+ * broadcasts from QuizLiveMonitor.
+ *
+ * Highlights the current student's row. When the student is outside the top
+ * `topN`, renders top (topN - 1) + a divider + the student's own entry.
+ */
+
+import React from 'react';
+import { Medal } from 'lucide-react';
+import { QuizLeaderboardEntry } from '@/types';
+
+interface StudentLeaderboardProps {
+  entries: QuizLeaderboardEntry[];
+  myPin: string;
+  scoreSuffix: string;
+  topN?: number;
+}
+
+const RANK_COLORS = [
+  'text-amber-400', // 1st - gold
+  'text-slate-300', // 2nd - silver
+  'text-orange-400', // 3rd - bronze
+];
+
+export const StudentLeaderboard: React.FC<StudentLeaderboardProps> = ({
+  entries,
+  myPin,
+  scoreSuffix,
+  topN = 5,
+}) => {
+  if (!entries || entries.length === 0) {
+    return (
+      <div className="w-full max-w-sm p-4 bg-slate-800/60 border border-slate-700 rounded-2xl text-center">
+        <p className="text-slate-400 text-xs">
+          Answer a question to appear on the leaderboard.
+        </p>
+      </div>
+    );
+  }
+
+  const myEntry = entries.find((e) => e.pin === myPin);
+  const topEntries = entries.slice(0, topN);
+  const isMyInTop = myEntry ? topEntries.some((e) => e.pin === myPin) : false;
+
+  // When the student is outside the top N, reserve the last slot for their row.
+  const displayEntries = isMyInTop
+    ? topEntries
+    : entries.slice(0, Math.max(0, topN - 1));
+  const showSelfBelow = !isMyInTop && myEntry;
+
+  return (
+    <div className="w-full max-w-sm p-4 bg-slate-800/60 border border-slate-700 rounded-2xl">
+      <p className="text-slate-400 text-xs uppercase tracking-widest font-semibold mb-3 text-center">
+        Leaderboard
+      </p>
+
+      <div className="flex flex-col gap-2">
+        {displayEntries.map((entry) => (
+          <LeaderboardRow
+            key={`top-${entry.pin}`}
+            entry={entry}
+            scoreSuffix={scoreSuffix}
+            isMe={entry.pin === myPin}
+          />
+        ))}
+
+        {showSelfBelow && myEntry && (
+          <>
+            <div className="flex items-center justify-center py-1 text-slate-600 text-xs tracking-widest">
+              • • •
+            </div>
+            <LeaderboardRow entry={myEntry} scoreSuffix={scoreSuffix} isMe />
+          </>
+        )}
+      </div>
+    </div>
+  );
+};
+
+const LeaderboardRow: React.FC<{
+  entry: QuizLeaderboardEntry;
+  scoreSuffix: string;
+  isMe: boolean;
+}> = ({ entry, scoreSuffix, isMe }) => {
+  const medalColor = RANK_COLORS[entry.rank - 1];
+  const showMedal = entry.rank <= 3;
+
+  return (
+    <div
+      className={`flex items-center gap-3 px-3 py-2 rounded-xl border transition ${
+        isMe
+          ? 'bg-violet-500/20 border-violet-500/50'
+          : 'bg-slate-900/40 border-slate-700/50'
+      }`}
+    >
+      <div className="w-6 flex items-center justify-center">
+        {showMedal ? (
+          <Medal className={`w-5 h-5 ${medalColor}`} />
+        ) : (
+          <span className="text-slate-500 text-xs font-bold">{entry.rank}</span>
+        )}
+      </div>
+      <span
+        className={`flex-1 text-sm font-semibold truncate ${
+          isMe ? 'text-white' : 'text-slate-200'
+        }`}
+      >
+        {entry.name ?? `PIN ${entry.pin}`}
+        {isMe && (
+          <span className="ml-2 text-xs text-violet-300 font-normal">
+            (you)
+          </span>
+        )}
+      </span>
+      <span
+        className={`font-mono font-bold text-sm ${
+          isMe ? 'text-violet-200' : 'text-slate-300'
+        }`}
+      >
+        {entry.score}
+        <span className="text-xs ml-0.5">{scoreSuffix.trim()}</span>
+      </span>
+    </div>
+  );
+};

--- a/components/widgets/QuizWidget/Widget.tsx
+++ b/components/widgets/QuizWidget/Widget.tsx
@@ -57,6 +57,7 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
     removeStudent,
     revealAnswer,
     hideAnswer,
+    broadcastLiveLeaderboard,
   } = useQuizSessionTeacher(user?.uid);
 
   // Local state for views that need loaded data
@@ -557,6 +558,7 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
         onRemoveStudent={removeStudent}
         onRevealAnswer={revealAnswer}
         onHideAnswer={hideAnswer}
+        onBroadcastLiveLeaderboard={broadcastLiveLeaderboard}
       />
     );
   }

--- a/components/widgets/QuizWidget/utils/quizScoreboard.ts
+++ b/components/widgets/QuizWidget/utils/quizScoreboard.ts
@@ -9,6 +9,7 @@ import {
   ClassRoster,
   ScoreboardTeam,
   QuizSession,
+  QuizLeaderboardEntry,
 } from '@/types';
 import { gradeAnswer } from '@/hooks/useQuizSession';
 import { SCOREBOARD_COLORS } from '@/config/scoreboard';
@@ -150,6 +151,39 @@ export function buildPinToNameMap(
     }
   }
   return map;
+}
+
+/**
+ * Build a student-facing live leaderboard snapshot from the teacher's view of
+ * responses. Called from QuizLiveMonitor and written to
+ * session.liveLeaderboard so students can read it (they can't read other
+ * students' response docs directly).
+ *
+ * Skips students still in 'joined' status (haven't answered anything yet).
+ * Returns entries sorted by score descending, limited to `limit` (default 10).
+ */
+export function buildLiveLeaderboard(
+  responses: QuizResponse[],
+  questions: QuizQuestion[],
+  session: QuizSession | null | undefined,
+  pinToName: Record<string, string>,
+  limit = 10
+): QuizLeaderboardEntry[] {
+  return responses
+    .filter((r) => r.status !== 'joined')
+    .map((r) => ({
+      pin: r.pin,
+      name: pinToName[r.pin],
+      score: getDisplayScore(r, questions, session),
+    }))
+    .sort((a, b) => b.score - a.score)
+    .slice(0, limit)
+    .map((entry, i) => ({
+      pin: entry.pin,
+      ...(entry.name ? { name: entry.name } : {}),
+      score: entry.score,
+      rank: i + 1,
+    }));
 }
 
 /**


### PR DESCRIPTION
This pull request introduces a reusable `StudentLeaderboard` component for student-facing quiz screens and adds supporting logic to generate and broadcast a live leaderboard to students. The main changes are the creation of the leaderboard UI component, the addition of a function to build the leaderboard data, and the integration of leaderboard broadcasting in the teacher's quiz session logic.

**Student leaderboard UI:**
- Added a new `StudentLeaderboard` component in `StudentLeaderboard.tsx` that displays the top N students plus the current student (if not in the top N), highlights the current student, and handles empty states.

**Leaderboard data generation:**
- Implemented `buildLiveLeaderboard` in `quizScoreboard.ts` to generate a sorted, student-facing leaderboard snapshot from quiz responses, skipping students who haven't answered yet and assigning ranks.
- Updated imports in `quizScoreboard.ts` to include the new `QuizLeaderboardEntry` type.

**Integration with quiz session logic:**
- Added `broadcastLiveLeaderboard` to the teacher's quiz session hook and passed it to the quiz widget for use in broadcasting leaderboard updates. [[1]](diffhunk://#diff-048aa6c14a798f8886ece64742b2a60f8239f92c1b1b71231e928468bea17b81R60) [[2]](diffhunk://#diff-048aa6c14a798f8886ece64742b2a60f8239f92c1b1b71231e928468bea17b81R561)