### PR TITLE
Add shape drawing tools (rect, ellipse, line, arrow) to drawing widget

### DIFF
--- a/components/layout/AnnotationOverlay.tsx
+++ b/components/layout/AnnotationOverlay.tsx
@@ -9,6 +9,11 @@ import { createPortal } from 'react-dom';
 import { toPng } from 'html-to-image';
 import {
   Eraser,
+  Pencil,
+  Minus,
+  ArrowRight,
+  Square,
+  Circle,
   Trash2,
   Undo2,
   MousePointer2,
@@ -23,22 +28,39 @@ import { useGoogleDrive } from '@/hooks/useGoogleDrive';
 import { useDrawingCanvas } from '@/components/widgets/DrawingWidget/useDrawingCanvas';
 import { Button } from '@/components/common/Button';
 import { extractTextWithGemini } from '@/utils/ai';
-import { DrawableObject, TextConfig } from '@/types';
+import { DrawableObject, ShapeTool, TextConfig } from '@/types';
 import { DRAWING_DEFAULTS } from '@/components/widgets/DrawingWidget/constants';
 import { STANDARD_COLORS } from '@/config/colors';
 import { Z_INDEX } from '@/config/zIndex';
 import { nextZ } from '@/utils/migrateDrawingConfig';
+
+const TOOL_BUTTONS: {
+  tool: ShapeTool;
+  icon: React.ReactNode;
+  label: string;
+}[] = [
+  { tool: 'pen', icon: <Pencil className="w-4 h-4" />, label: 'Pen' },
+  { tool: 'eraser', icon: <Eraser className="w-3.5 h-3.5" />, label: 'Eraser' },
+  { tool: 'line', icon: <Minus className="w-4 h-4" />, label: 'Line' },
+  { tool: 'arrow', icon: <ArrowRight className="w-4 h-4" />, label: 'Arrow' },
+  { tool: 'rect', icon: <Square className="w-4 h-4" />, label: 'Rectangle' },
+  { tool: 'ellipse', icon: <Circle className="w-4 h-4" />, label: 'Ellipse' },
+];
 
 const FALLBACK_ANNOTATION_STATE: {
   objects: DrawableObject[];
   color: string;
   width: number;
   customColors: string[];
+  activeTool: ShapeTool;
+  shapeFill: boolean;
 } = {
   objects: [],
   color: STANDARD_COLORS.slate,
   width: DRAWING_DEFAULTS.WIDTH,
   customColors: [...DRAWING_DEFAULTS.CUSTOM_COLORS],
+  activeTool: DRAWING_DEFAULTS.ACTIVE_TOOL,
+  shapeFill: false,
 };
 
 /**
@@ -133,6 +155,8 @@ export const AnnotationOverlay: React.FC = () => {
     scale: 1,
     canvasSize,
     nextZ: nextZ(annotationState.objects),
+    activeTool: annotationState.activeTool,
+    shapeFill: annotationState.shapeFill,
   });
 
   const capturePng = useCallback(async (): Promise<string | null> => {
@@ -245,7 +269,14 @@ export const AnnotationOverlay: React.FC = () => {
 
   if (!annotationActive || !portalTarget) return null;
 
-  const { color, width, customColors, objects } = annotationState;
+  const {
+    color,
+    width,
+    customColors,
+    objects,
+    activeTool,
+    shapeFill: _shapeFill,
+  } = annotationState;
 
   return createPortal(
     <div
@@ -274,13 +305,40 @@ export const AnnotationOverlay: React.FC = () => {
           </span>
         </div>
 
+        {/* Tool selector */}
         <div className="flex gap-1 bg-slate-100 p-1 rounded-lg">
+          {TOOL_BUTTONS.map(({ tool, icon, label }) => (
+            <button
+              key={tool}
+              onClick={() => updateAnnotationState({ activeTool: tool })}
+              title={label}
+              className={`w-7 h-7 rounded-md flex items-center justify-center transition-all text-slate-600 hover:bg-white hover:shadow-sm ${
+                activeTool === tool
+                  ? 'ring-2 ring-indigo-500 bg-white shadow-sm'
+                  : ''
+              }`}
+              aria-label={label}
+              aria-pressed={activeTool === tool}
+            >
+              {icon}
+            </button>
+          ))}
+        </div>
+
+        <div className="h-6 w-px bg-slate-200 mx-1" />
+
+        {/* Color swatches (dimmed when eraser active) */}
+        <div
+          className={`flex gap-1 bg-slate-100 p-1 rounded-lg transition-opacity ${
+            activeTool === 'eraser' ? 'opacity-40 pointer-events-none' : ''
+          }`}
+        >
           {customColors.map((c) => (
             <button
               key={c}
               onClick={() => updateAnnotationState({ color: c })}
               className={`w-7 h-7 rounded-md transition-all ${
-                color === c
+                color === c && activeTool !== 'eraser'
                   ? 'scale-110 shadow-sm ring-2 ring-indigo-500'
                   : 'hover:scale-105'
               }`}
@@ -288,15 +346,6 @@ export const AnnotationOverlay: React.FC = () => {
               aria-label={`Color ${c}`}
             />
           ))}
-          <button
-            onClick={() => updateAnnotationState({ color: 'eraser' })}
-            className={`w-7 h-7 rounded-md bg-white border border-slate-200 flex items-center justify-center transition-all ${
-              color === 'eraser' ? 'ring-2 ring-indigo-500' : ''
-            }`}
-            aria-label="Eraser"
-          >
-            <Eraser className="w-3.5 h-3.5 text-slate-500" />
-          </button>
         </div>
 
         {/* Width slider */}

--- a/components/student/StudentContexts.tsx
+++ b/components/student/StudentContexts.tsx
@@ -273,6 +273,8 @@ const mockDashboard: DashboardContextValue = {
     color: '#000000',
     width: 4,
     customColors: ['#000000', '#ffffff', '#ff0000', '#00ff00', '#0000ff'],
+    activeTool: 'pen' as const,
+    shapeFill: false,
   },
   openAnnotation: () => {
     // No-op

--- a/components/widgets/DrawingWidget/Settings.tsx
+++ b/components/widgets/DrawingWidget/Settings.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useDashboard } from '@/context/useDashboard';
 import { WidgetData, DrawingConfig } from '@/types';
-import { Pencil, Palette } from 'lucide-react';
+import { Pencil, Palette, Square } from 'lucide-react';
 import { SettingsLabel } from '@/components/common/SettingsLabel';
 import { DRAWING_DEFAULTS } from './constants';
 
@@ -12,6 +12,7 @@ export const DrawingSettings: React.FC<{ widget: WidgetData }> = ({
   const config = widget.config as DrawingConfig;
   const width = config.width ?? DRAWING_DEFAULTS.WIDTH;
   const customColors = config.customColors ?? DRAWING_DEFAULTS.CUSTOM_COLORS;
+  const shapeFill = config.shapeFill ?? false;
 
   const handleColorChange = (index: number, newColor: string) => {
     const nextColors = [...customColors];
@@ -70,6 +71,28 @@ export const DrawingSettings: React.FC<{ widget: WidgetData }> = ({
             {width}px
           </span>
         </div>
+      </div>
+
+      <div>
+        <SettingsLabel icon={Square}>Shape Fill</SettingsLabel>
+        <label className="flex items-center gap-3 px-2 cursor-pointer select-none">
+          <input
+            type="checkbox"
+            checked={shapeFill}
+            onChange={(e) =>
+              updateWidget(widget.id, {
+                config: {
+                  ...config,
+                  shapeFill: e.target.checked,
+                } as DrawingConfig,
+              })
+            }
+            className="accent-indigo-600 w-4 h-4 rounded"
+          />
+          <span className="text-sm text-slate-700">
+            Fill shapes with current color
+          </span>
+        </label>
       </div>
 
       <div className="p-4 bg-indigo-50 rounded-2xl border border-indigo-100">

--- a/components/widgets/DrawingWidget/Widget.test.tsx
+++ b/components/widgets/DrawingWidget/Widget.test.tsx
@@ -19,11 +19,19 @@ interface MockContext {
   moveTo: Mock;
   lineTo: Mock;
   stroke: Mock;
+  fill: Mock;
+  fillRect: Mock;
+  strokeRect: Mock;
+  ellipse: Mock;
+  closePath: Mock;
+  save: Mock;
+  restore: Mock;
   canvas: { width: number; height: number };
   lineCap: string;
   lineJoin: string;
   globalCompositeOperation: string;
   strokeStyle: string;
+  fillStyle: string;
   lineWidth: number;
 }
 
@@ -51,11 +59,19 @@ describe('DrawingWidget', () => {
       moveTo: vi.fn(),
       lineTo: vi.fn(),
       stroke: vi.fn(),
+      fill: vi.fn(),
+      fillRect: vi.fn(),
+      strokeRect: vi.fn(),
+      ellipse: vi.fn(),
+      closePath: vi.fn(),
+      save: vi.fn(),
+      restore: vi.fn(),
       canvas: { width: 800, height: 600 },
       lineCap: 'round',
       lineJoin: 'round',
       globalCompositeOperation: 'source-over',
       strokeStyle: '#000000',
+      fillStyle: '#000000',
       lineWidth: 1,
     };
 
@@ -167,6 +183,22 @@ describe('DrawingWidget', () => {
     expect(mockContext.moveTo).toHaveBeenCalledWith(5, 5);
     expect(mockContext.lineTo).toHaveBeenCalledWith(15, 15);
     expect(mockContext.stroke).toHaveBeenCalled();
+  });
+
+  it('clicking a tool button persists activeTool to config', () => {
+    const { container } = render(<DrawingWidget widget={widget} />);
+    // The "Rectangle" button has aria-label="Rectangle"
+    const rectBtn = container.querySelector('[aria-label="Rectangle"]');
+    if (!rectBtn) throw new Error('Rectangle tool button not found');
+
+    fireEvent.click(rectBtn);
+
+    expect(mockUpdateWidget).toHaveBeenCalled();
+    const args =
+      mockUpdateWidget.mock.calls[mockUpdateWidget.mock.calls.length - 1];
+    expect(args[0]).toBe(widget.id);
+    const newConfig = (args[1] as Partial<WidgetData>).config as DrawingConfig;
+    expect(newConfig.activeTool).toBe('rect');
   });
 
   it('handles drawing interaction', () => {

--- a/components/widgets/DrawingWidget/Widget.tsx
+++ b/components/widgets/DrawingWidget/Widget.tsx
@@ -1,7 +1,23 @@
 import React, { useMemo, useRef, useState } from 'react';
 import { useDashboard } from '@/context/useDashboard';
-import { WidgetData, DrawableObject, DrawingConfig, TextConfig } from '@/types';
-import { Pencil, Eraser, Trash2, Undo2, Type } from 'lucide-react';
+import {
+  WidgetData,
+  DrawableObject,
+  DrawingConfig,
+  TextConfig,
+  ShapeTool,
+} from '@/types';
+import {
+  Pencil,
+  Eraser,
+  Trash2,
+  Undo2,
+  Type,
+  Minus,
+  ArrowRight,
+  Square,
+  Circle,
+} from 'lucide-react';
 import { extractTextWithGemini } from '@/utils/ai';
 import { useAuth } from '@/context/useAuth';
 import { Button } from '@/components/common/Button';
@@ -9,6 +25,19 @@ import { STANDARD_COLORS } from '@/config/colors';
 import { DRAWING_DEFAULTS } from './constants';
 import { useDrawingCanvas } from './useDrawingCanvas';
 import { migrateDrawingConfig, nextZ } from '@/utils/migrateDrawingConfig';
+
+const TOOL_BUTTONS: {
+  tool: ShapeTool;
+  icon: React.ReactNode;
+  label: string;
+}[] = [
+  { tool: 'pen', icon: <Pencil className="w-4 h-4" />, label: 'Pen' },
+  { tool: 'eraser', icon: <Eraser className="w-4 h-4" />, label: 'Eraser' },
+  { tool: 'line', icon: <Minus className="w-4 h-4" />, label: 'Line' },
+  { tool: 'arrow', icon: <ArrowRight className="w-4 h-4" />, label: 'Arrow' },
+  { tool: 'rect', icon: <Square className="w-4 h-4" />, label: 'Rectangle' },
+  { tool: 'ellipse', icon: <Circle className="w-4 h-4" />, label: 'Ellipse' },
+];
 
 export const DrawingWidget: React.FC<{
   widget: WidgetData;
@@ -30,6 +59,8 @@ export const DrawingWidget: React.FC<{
     width = DRAWING_DEFAULTS.WIDTH,
     objects,
     customColors = DRAWING_DEFAULTS.CUSTOM_COLORS,
+    activeTool = DRAWING_DEFAULTS.ACTIVE_TOOL,
+    shapeFill = false,
   } = config;
 
   const canvasRef = useRef<HTMLCanvasElement>(null);
@@ -39,7 +70,6 @@ export const DrawingWidget: React.FC<{
   // or the parent container in student view.
   const canvasSize = useMemo(() => {
     if (isStudentView) {
-      // Student view sizes canvas to its container; fall back to widget dims.
       return { width: widget.w, height: widget.h };
     }
     return { width: widget.w, height: Math.max(widget.h - 40, 0) };
@@ -64,6 +94,8 @@ export const DrawingWidget: React.FC<{
     disabled: isStudentView,
     canvasSize,
     nextZ: nextZ(objects),
+    activeTool,
+    shapeFill,
   });
 
   const clear = () => {
@@ -139,37 +171,66 @@ export const DrawingWidget: React.FC<{
     }
   };
 
+  const setTool = (tool: ShapeTool) => {
+    updateWidget(widget.id, {
+      config: { ...config, activeTool: tool } as DrawingConfig,
+    });
+  };
+
+  const setColor = (c: string) => {
+    updateWidget(widget.id, {
+      config: { ...config, color: c } as DrawingConfig,
+    });
+  };
+
   const PaletteUI = (
     <div className="flex flex-wrap items-center gap-2 p-2">
+      {/* Cluster 1: Tool selector */}
       <div className="flex gap-1 bg-slate-100 p-1 rounded-lg">
-        {customColors.map((c) => (
+        {TOOL_BUTTONS.map(({ tool, icon, label }) => (
           <button
-            key={c}
-            onClick={() =>
-              updateWidget(widget.id, {
-                config: { ...config, color: c } as DrawingConfig,
-              })
-            }
-            className={`w-6 h-6 rounded-md transition-all ${color === c ? 'scale-110 shadow-sm ring-2 ring-indigo-500' : 'hover:scale-105'}`}
-            style={{ backgroundColor: c }}
-            aria-label={`Color ${c}`}
-          />
+            key={tool}
+            onClick={() => setTool(tool)}
+            title={label}
+            className={`w-7 h-7 rounded-md flex items-center justify-center transition-all text-slate-600 hover:bg-white hover:shadow-sm ${
+              activeTool === tool
+                ? 'ring-2 ring-indigo-500 bg-white shadow-sm'
+                : ''
+            }`}
+            aria-label={label}
+            aria-pressed={activeTool === tool}
+          >
+            {icon}
+          </button>
         ))}
-        <button
-          onClick={() =>
-            updateWidget(widget.id, {
-              config: { ...config, color: 'eraser' } as DrawingConfig,
-            })
-          }
-          className={`w-6 h-6 rounded-md bg-white border border-slate-200 flex items-center justify-center transition-all ${color === 'eraser' ? 'ring-2 ring-indigo-500' : ''}`}
-          aria-label="Eraser"
-        >
-          <Eraser className="w-3 h-3 text-slate-400" />
-        </button>
       </div>
 
       <div className="h-6 w-px bg-slate-200 mx-1" />
 
+      {/* Cluster 2: Color swatches (dimmed when eraser active) */}
+      <div
+        className={`flex gap-1 bg-slate-100 p-1 rounded-lg transition-opacity ${
+          activeTool === 'eraser' ? 'opacity-40 pointer-events-none' : ''
+        }`}
+      >
+        {customColors.map((c) => (
+          <button
+            key={c}
+            onClick={() => setColor(c)}
+            className={`w-6 h-6 rounded-md transition-all ${
+              color === c && activeTool !== 'eraser'
+                ? 'scale-110 shadow-sm ring-2 ring-indigo-500'
+                : 'hover:scale-105'
+            }`}
+            style={{ backgroundColor: c }}
+            aria-label={`Color ${c}`}
+          />
+        ))}
+      </div>
+
+      <div className="h-6 w-px bg-slate-200 mx-1" />
+
+      {/* Cluster 3: Actions */}
       <Button
         onClick={undo}
         title="Undo"

--- a/components/widgets/DrawingWidget/constants.ts
+++ b/components/widgets/DrawingWidget/constants.ts
@@ -1,6 +1,8 @@
 import { WIDGET_PALETTE } from '@/config/colors';
+import type { ShapeTool } from '@/types';
 
 export const DRAWING_DEFAULTS = {
   WIDTH: 4,
   CUSTOM_COLORS: WIDGET_PALETTE.slice(0, 5),
+  ACTIVE_TOOL: 'pen' as ShapeTool,
 };

--- a/components/widgets/DrawingWidget/useDrawingCanvas.test.ts
+++ b/components/widgets/DrawingWidget/useDrawingCanvas.test.ts
@@ -2,7 +2,14 @@ import { describe, it, expect, vi, beforeEach, afterEach, Mock } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 import React from 'react';
 import { useDrawingCanvas } from './useDrawingCanvas';
-import type { DrawableObject, PathObject } from '@/types';
+import type {
+  ArrowObject,
+  DrawableObject,
+  EllipseObject,
+  LineObject,
+  PathObject,
+  RectObject,
+} from '@/types';
 
 interface MockCtx {
   clearRect: Mock;
@@ -10,11 +17,19 @@ interface MockCtx {
   moveTo: Mock;
   lineTo: Mock;
   stroke: Mock;
+  fill: Mock;
+  fillRect: Mock;
+  strokeRect: Mock;
+  ellipse: Mock;
+  closePath: Mock;
+  save: Mock;
+  restore: Mock;
   canvas: { width: number; height: number };
   lineCap: string;
   lineJoin: string;
   globalCompositeOperation: string;
   strokeStyle: string;
+  fillStyle: string;
   lineWidth: number;
 }
 
@@ -24,11 +39,19 @@ const makeMockCtx = (): MockCtx => ({
   moveTo: vi.fn(),
   lineTo: vi.fn(),
   stroke: vi.fn(),
+  fill: vi.fn(),
+  fillRect: vi.fn(),
+  strokeRect: vi.fn(),
+  ellipse: vi.fn(),
+  closePath: vi.fn(),
+  save: vi.fn(),
+  restore: vi.fn(),
   canvas: { width: 800, height: 600 },
   lineCap: 'round',
   lineJoin: 'round',
   globalCompositeOperation: 'source-over',
   strokeStyle: '#000000',
+  fillStyle: '#000000',
   lineWidth: 1,
 });
 
@@ -196,10 +219,7 @@ describe('useDrawingCanvas', () => {
       })
     );
 
-    // After the path renders, the final composite op is reset to source-over;
-    // we verify via strokeStyle which reflects the eraser branch.
     expect(mockCtx.stroke).toHaveBeenCalled();
-    expect(mockCtx.globalCompositeOperation).toBe('source-over');
   });
 
   it('on pointerup emits a new PathObject with kind=path, supplied id, and nextZ', () => {
@@ -329,5 +349,252 @@ describe('useDrawingCanvas', () => {
       { x: 50, y: 100 },
       { x: 150, y: 200 },
     ]);
+  });
+
+  // --- 2.1b: Shape tool tests ---
+
+  const mkEvent = (clientX: number, clientY: number) =>
+    ({ clientX, clientY }) as unknown as React.PointerEvent;
+
+  it('rect drag right-down emits a RectObject with correct {x, y, w, h}', () => {
+    const canvas = makeCanvas();
+    const canvasRef = { current: canvas };
+    const onObjectComplete = vi.fn();
+    const generateId = vi.fn(() => 'rect-id');
+
+    const { result } = renderHook(() =>
+      useDrawingCanvas({
+        canvasRef,
+        color: '#f00',
+        width: 2,
+        objects: [],
+        onObjectComplete,
+        canvasSize: { width: 800, height: 600 },
+        generateId,
+        nextZ: 1,
+        activeTool: 'rect',
+      })
+    );
+
+    act(() => result.current.handleStart(mkEvent(10, 20)));
+    act(() => result.current.handleMove(mkEvent(110, 70)));
+    act(() => result.current.handleEnd());
+
+    expect(onObjectComplete).toHaveBeenCalledTimes(1);
+    const emitted = onObjectComplete.mock.calls[0][0] as RectObject;
+    expect(emitted.kind).toBe('rect');
+    expect(emitted.id).toBe('rect-id');
+    expect(emitted.z).toBe(1);
+    expect(emitted.x).toBe(10);
+    expect(emitted.y).toBe(20);
+    expect(emitted.w).toBe(100);
+    expect(emitted.h).toBe(50);
+    expect(emitted.stroke).toBe('#f00');
+    expect(emitted.strokeWidth).toBe(2);
+  });
+
+  it('rect drag up-left (inverted) produces normalized w >= 0 and h >= 0', () => {
+    const canvas = makeCanvas();
+    const canvasRef = { current: canvas };
+    const onObjectComplete = vi.fn();
+
+    const { result } = renderHook(() =>
+      useDrawingCanvas({
+        canvasRef,
+        color: '#000',
+        width: 1,
+        objects: [],
+        onObjectComplete,
+        canvasSize: { width: 800, height: 600 },
+        nextZ: 0,
+        activeTool: 'rect',
+      })
+    );
+
+    // Drag from (200, 150) to (50, 30) — up-left
+    act(() => result.current.handleStart(mkEvent(200, 150)));
+    act(() => result.current.handleMove(mkEvent(50, 30)));
+    act(() => result.current.handleEnd());
+
+    const emitted = onObjectComplete.mock.calls[0][0] as RectObject;
+    expect(emitted.x).toBe(50);
+    expect(emitted.y).toBe(30);
+    expect(emitted.w).toBe(150);
+    expect(emitted.h).toBe(120);
+    expect(emitted.w).toBeGreaterThanOrEqual(0);
+    expect(emitted.h).toBeGreaterThanOrEqual(0);
+  });
+
+  it('ellipse drag emits an EllipseObject with correct geometry', () => {
+    const canvas = makeCanvas();
+    const canvasRef = { current: canvas };
+    const onObjectComplete = vi.fn();
+
+    const { result } = renderHook(() =>
+      useDrawingCanvas({
+        canvasRef,
+        color: '#0f0',
+        width: 3,
+        objects: [],
+        onObjectComplete,
+        canvasSize: { width: 800, height: 600 },
+        nextZ: 0,
+        activeTool: 'ellipse',
+      })
+    );
+
+    act(() => result.current.handleStart(mkEvent(40, 50)));
+    act(() => result.current.handleMove(mkEvent(140, 100)));
+    act(() => result.current.handleEnd());
+
+    const emitted = onObjectComplete.mock.calls[0][0] as EllipseObject;
+    expect(emitted.kind).toBe('ellipse');
+    expect(emitted.x).toBe(40);
+    expect(emitted.y).toBe(50);
+    expect(emitted.w).toBe(100);
+    expect(emitted.h).toBe(50);
+  });
+
+  it('line drag emits a LineObject with {x1, y1, x2, y2}', () => {
+    const canvas = makeCanvas();
+    const canvasRef = { current: canvas };
+    const onObjectComplete = vi.fn();
+
+    const { result } = renderHook(() =>
+      useDrawingCanvas({
+        canvasRef,
+        color: '#00f',
+        width: 2,
+        objects: [],
+        onObjectComplete,
+        canvasSize: { width: 800, height: 600 },
+        nextZ: 5,
+        activeTool: 'line',
+      })
+    );
+
+    act(() => result.current.handleStart(mkEvent(10, 10)));
+    act(() => result.current.handleMove(mkEvent(90, 50)));
+    act(() => result.current.handleEnd());
+
+    const emitted = onObjectComplete.mock.calls[0][0] as LineObject;
+    expect(emitted.kind).toBe('line');
+    expect(emitted.x1).toBe(10);
+    expect(emitted.y1).toBe(10);
+    expect(emitted.x2).toBe(90);
+    expect(emitted.y2).toBe(50);
+    expect(emitted.z).toBe(5);
+  });
+
+  it('arrow drag emits an ArrowObject', () => {
+    const canvas = makeCanvas();
+    const canvasRef = { current: canvas };
+    const onObjectComplete = vi.fn();
+
+    const { result } = renderHook(() =>
+      useDrawingCanvas({
+        canvasRef,
+        color: '#ff0',
+        width: 3,
+        objects: [],
+        onObjectComplete,
+        canvasSize: { width: 800, height: 600 },
+        nextZ: 0,
+        activeTool: 'arrow',
+      })
+    );
+
+    act(() => result.current.handleStart(mkEvent(20, 20)));
+    act(() => result.current.handleMove(mkEvent(80, 60)));
+    act(() => result.current.handleEnd());
+
+    const emitted = onObjectComplete.mock.calls[0][0] as ArrowObject;
+    expect(emitted.kind).toBe('arrow');
+    expect(emitted.x1).toBe(20);
+    expect(emitted.y1).toBe(20);
+    expect(emitted.x2).toBe(80);
+    expect(emitted.y2).toBe(60);
+  });
+
+  it('degenerate shape (start === end) does not emit an object', () => {
+    const canvas = makeCanvas();
+    const canvasRef = { current: canvas };
+    const onObjectComplete = vi.fn();
+
+    for (const activeTool of ['rect', 'ellipse', 'line', 'arrow'] as const) {
+      onObjectComplete.mockClear();
+      const { result } = renderHook(() =>
+        useDrawingCanvas({
+          canvasRef,
+          color: '#000',
+          width: 2,
+          objects: [],
+          onObjectComplete,
+          canvasSize: { width: 800, height: 600 },
+          nextZ: 0,
+          activeTool,
+        })
+      );
+
+      // Pointer down and immediately up at same position
+      act(() => result.current.handleStart(mkEvent(50, 50)));
+      act(() => result.current.handleEnd());
+
+      expect(onObjectComplete).not.toHaveBeenCalled();
+    }
+  });
+
+  it('shapeFill: true emits RectObject with fill === color', () => {
+    const canvas = makeCanvas();
+    const canvasRef = { current: canvas };
+    const onObjectComplete = vi.fn();
+
+    const { result } = renderHook(() =>
+      useDrawingCanvas({
+        canvasRef,
+        color: '#abc',
+        width: 2,
+        objects: [],
+        onObjectComplete,
+        canvasSize: { width: 800, height: 600 },
+        nextZ: 0,
+        activeTool: 'rect',
+        shapeFill: true,
+      })
+    );
+
+    act(() => result.current.handleStart(mkEvent(0, 0)));
+    act(() => result.current.handleMove(mkEvent(100, 100)));
+    act(() => result.current.handleEnd());
+
+    const emitted = onObjectComplete.mock.calls[0][0] as RectObject;
+    expect(emitted.fill).toBe('#abc');
+  });
+
+  it('shapeFill: false emits RectObject with fill === undefined', () => {
+    const canvas = makeCanvas();
+    const canvasRef = { current: canvas };
+    const onObjectComplete = vi.fn();
+
+    const { result } = renderHook(() =>
+      useDrawingCanvas({
+        canvasRef,
+        color: '#abc',
+        width: 2,
+        objects: [],
+        onObjectComplete,
+        canvasSize: { width: 800, height: 600 },
+        nextZ: 0,
+        activeTool: 'rect',
+        shapeFill: false,
+      })
+    );
+
+    act(() => result.current.handleStart(mkEvent(0, 0)));
+    act(() => result.current.handleMove(mkEvent(100, 100)));
+    act(() => result.current.handleEnd());
+
+    const emitted = onObjectComplete.mock.calls[0][0] as RectObject;
+    expect(emitted.fill).toBeUndefined();
   });
 });

--- a/components/widgets/DrawingWidget/useDrawingCanvas.ts
+++ b/components/widgets/DrawingWidget/useDrawingCanvas.ts
@@ -1,5 +1,14 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { DrawableObject, PathObject, Point } from '@/types';
+import {
+  ArrowObject,
+  DrawableObject,
+  EllipseObject,
+  LineObject,
+  PathObject,
+  Point,
+  RectObject,
+  ShapeTool,
+} from '@/types';
 
 interface UseDrawingCanvasOptions {
   canvasRef: React.RefObject<HTMLCanvasElement | null>;
@@ -14,12 +23,15 @@ interface UseDrawingCanvasOptions {
   disabled?: boolean;
   /** Internal canvas resolution. Re-applies on change. */
   canvasSize: { width: number; height: number };
-  /** Generate an id for a newly-completed path object. Injected so tests can
+  /** Generate an id for a newly-completed object. Injected so tests can
    *  produce deterministic output without mocking crypto. */
   generateId?: () => string;
-  /** Next z-index to assign to the completed path object. Owned by caller so
-   *  this hook stays stateless w.r.t. object history. */
+  /** Next z-index to assign to the completed object. */
   nextZ: number;
+  /** Active drawing tool. Defaults to 'pen'. */
+  activeTool?: ShapeTool;
+  /** If true, rect and ellipse shapes are filled with the current color. */
+  shapeFill?: boolean;
 }
 
 interface UseDrawingCanvasResult {
@@ -29,11 +41,17 @@ interface UseDrawingCanvasResult {
   isDrawing: boolean;
 }
 
+// Discriminated union for the in-progress gesture
+type InProgress =
+  | { kind: 'path'; points: Point[] }
+  | { kind: 'rect' | 'ellipse'; x0: number; y0: number; x1: number; y1: number }
+  | { kind: 'line' | 'arrow'; x1: number; y1: number; x2: number; y2: number };
+
 /**
  * Shared canvas-drawing logic for the DrawingWidget and the AnnotationOverlay.
- * Renders a polymorphic list of DrawableObjects and captures freehand strokes
- * as new PathObjects (Phase 2a: path-only rendering; shape/text/image kinds
- * are recognized by the dispatcher but render nothing until their PRs land).
+ * Renders a polymorphic list of DrawableObjects and captures gestures as new
+ * objects (pen, eraser, rect, ellipse, line, arrow). Text and image kinds are
+ * recognized by the dispatcher but render nothing until PRs 2.1d / 2.2.
  */
 export const useDrawingCanvas = ({
   canvasRef,
@@ -46,44 +64,28 @@ export const useDrawingCanvas = ({
   canvasSize,
   generateId = () => crypto.randomUUID(),
   nextZ,
+  activeTool = 'pen',
+  shapeFill = false,
 }: UseDrawingCanvasOptions): UseDrawingCanvasResult => {
   const [isDrawing, setIsDrawing] = useState(false);
-  const currentPathRef = useRef<Point[]>([]);
-
-  const setContextStyles = useCallback(
-    (ctx: CanvasRenderingContext2D) => {
-      ctx.lineCap = 'round';
-      ctx.lineJoin = 'round';
-      if (color === 'eraser') {
-        ctx.globalCompositeOperation = 'destination-out';
-        ctx.strokeStyle = 'rgba(0,0,0,1)';
-      } else {
-        ctx.globalCompositeOperation = 'source-over';
-        ctx.strokeStyle = color;
-      }
-      ctx.lineWidth = width;
-    },
-    [color, width]
-  );
+  const inProgressRef = useRef<InProgress | null>(null);
+  // Capture activeTool at gesture start so mid-drag tool switches are ignored
+  const activeToolAtStartRef = useRef<ShapeTool>('pen');
 
   const draw = useCallback(
     (
       ctx: CanvasRenderingContext2D,
       allObjects: DrawableObject[],
-      current: Point[]
+      preview?: DrawableObject
     ) => {
       ctx.clearRect(0, 0, ctx.canvas.width, ctx.canvas.height);
 
-      // Render in z-order so later PRs (shapes, images, text) can layer cleanly
-      // without needing to touch this call site.
       const sorted = [...allObjects].sort((a, b) => a.z - b.z);
       sorted.forEach((obj) => renderObject(ctx, obj));
 
-      if (current.length > 1) {
-        renderPathPoints(ctx, current, color, width);
-      }
+      if (preview) renderObject(ctx, preview);
     },
-    [color, width]
+    []
   );
 
   // Apply canvas resolution + redraw on size / object-list change
@@ -96,7 +98,7 @@ export const useDrawingCanvas = ({
     if (canvas.width !== canvasSize.width) canvas.width = canvasSize.width;
     if (canvas.height !== canvasSize.height) canvas.height = canvasSize.height;
 
-    draw(ctx, objects, currentPathRef.current);
+    draw(ctx, objects);
   }, [canvasRef, canvasSize.width, canvasSize.height, objects, draw]);
 
   const getPos = useCallback(
@@ -117,60 +119,241 @@ export const useDrawingCanvas = ({
       if (disabled) return;
       setIsDrawing(true);
       const pos = getPos(e);
-      currentPathRef.current = [pos];
+      const tool = activeTool;
+      activeToolAtStartRef.current = tool;
 
-      const ctx = canvasRef.current?.getContext('2d');
-      if (ctx) {
-        setContextStyles(ctx);
-        ctx.beginPath();
-        ctx.moveTo(pos.x, pos.y);
+      if (tool === 'pen' || tool === 'eraser') {
+        inProgressRef.current = { kind: 'path', points: [pos] };
+
+        const ctx = canvasRef.current?.getContext('2d');
+        if (ctx) {
+          setPathContextStyles(ctx, color, width, tool === 'eraser');
+          ctx.beginPath();
+          ctx.moveTo(pos.x, pos.y);
+        }
+      } else if (tool === 'rect' || tool === 'ellipse') {
+        inProgressRef.current = {
+          kind: tool,
+          x0: pos.x,
+          y0: pos.y,
+          x1: pos.x,
+          y1: pos.y,
+        };
+      } else {
+        // line | arrow
+        inProgressRef.current = {
+          kind: tool,
+          x1: pos.x,
+          y1: pos.y,
+          x2: pos.x,
+          y2: pos.y,
+        };
       }
     },
-    [disabled, getPos, canvasRef, setContextStyles]
+    [disabled, getPos, canvasRef, color, width, activeTool]
   );
 
   const handleMove = useCallback(
     (e: React.PointerEvent) => {
       if (disabled || !isDrawing) return;
-      const pos = getPos(e);
-      currentPathRef.current.push(pos);
+      const ip = inProgressRef.current;
+      if (!ip) return;
 
-      const ctx = canvasRef.current?.getContext('2d');
-      if (ctx && currentPathRef.current.length > 1) {
-        setContextStyles(ctx);
-        const prev = currentPathRef.current[currentPathRef.current.length - 2];
-        ctx.beginPath();
-        ctx.moveTo(prev.x, prev.y);
-        ctx.lineTo(pos.x, pos.y);
-        ctx.stroke();
+      const pos = getPos(e);
+
+      if (ip.kind === 'path') {
+        ip.points.push(pos);
+        const ctx = canvasRef.current?.getContext('2d');
+        if (ctx && ip.points.length > 1) {
+          const isEraser = activeToolAtStartRef.current === 'eraser';
+          setPathContextStyles(ctx, color, width, isEraser);
+          const prev = ip.points[ip.points.length - 2];
+          ctx.beginPath();
+          ctx.moveTo(prev.x, prev.y);
+          ctx.lineTo(pos.x, pos.y);
+          ctx.stroke();
+        }
+      } else if (ip.kind === 'rect' || ip.kind === 'ellipse') {
+        ip.x1 = pos.x;
+        ip.y1 = pos.y;
+        const ctx = canvasRef.current?.getContext('2d');
+        if (ctx) {
+          const preview = buildRectEllipsePreview(
+            ip.kind,
+            ip.x0,
+            ip.y0,
+            ip.x1,
+            ip.y1,
+            color,
+            width,
+            shapeFill,
+            nextZ
+          );
+          draw(ctx, objects, preview);
+        }
+      } else if (ip.kind === 'line' || ip.kind === 'arrow') {
+        ip.x2 = pos.x;
+        ip.y2 = pos.y;
+        const ctx = canvasRef.current?.getContext('2d');
+        if (ctx) {
+          const preview = buildLineArrowPreview(
+            ip.kind,
+            ip.x1,
+            ip.y1,
+            ip.x2,
+            ip.y2,
+            color,
+            width,
+            nextZ
+          );
+          draw(ctx, objects, preview);
+        }
       }
     },
-    [disabled, isDrawing, getPos, canvasRef, setContextStyles]
+    [
+      disabled,
+      isDrawing,
+      getPos,
+      canvasRef,
+      color,
+      width,
+      shapeFill,
+      objects,
+      draw,
+      nextZ,
+    ]
   );
 
   const handleEnd = useCallback(() => {
     if (!isDrawing) return;
     setIsDrawing(false);
-    if (currentPathRef.current.length > 1) {
-      const completed: PathObject = {
+
+    const ip = inProgressRef.current;
+    inProgressRef.current = null;
+
+    if (!ip) return;
+
+    if (ip.kind === 'path') {
+      if (ip.points.length > 1) {
+        const isEraser = activeToolAtStartRef.current === 'eraser';
+        const completed: PathObject = {
+          id: generateId(),
+          kind: 'path',
+          z: nextZ,
+          points: ip.points,
+          color: isEraser ? 'eraser' : color,
+          width,
+        };
+        onObjectComplete(completed);
+      }
+    } else if (ip.kind === 'rect' || ip.kind === 'ellipse') {
+      const x = Math.min(ip.x0, ip.x1);
+      const y = Math.min(ip.y0, ip.y1);
+      const w = Math.abs(ip.x1 - ip.x0);
+      const h = Math.abs(ip.y1 - ip.y0);
+      if (w === 0 && h === 0) return; // degenerate — drop
+      const obj: RectObject | EllipseObject = {
         id: generateId(),
-        kind: 'path',
+        kind: ip.kind,
         z: nextZ,
-        points: currentPathRef.current,
-        color,
-        width,
+        x,
+        y,
+        w,
+        h,
+        stroke: color,
+        strokeWidth: width,
+        fill: shapeFill ? color : undefined,
       };
-      onObjectComplete(completed);
+      onObjectComplete(obj);
+    } else if (ip.kind === 'line' || ip.kind === 'arrow') {
+      if (ip.x1 === ip.x2 && ip.y1 === ip.y2) return; // degenerate — drop
+      const obj: LineObject | ArrowObject = {
+        id: generateId(),
+        kind: ip.kind,
+        z: nextZ,
+        x1: ip.x1,
+        y1: ip.y1,
+        x2: ip.x2,
+        y2: ip.y2,
+        stroke: color,
+        strokeWidth: width,
+      };
+      onObjectComplete(obj);
     }
-    currentPathRef.current = [];
-  }, [isDrawing, onObjectComplete, color, width, generateId, nextZ]);
+  }, [isDrawing, onObjectComplete, color, width, shapeFill, generateId, nextZ]);
 
   return { handleStart, handleMove, handleEnd, isDrawing };
 };
 
+// --- Context style helpers ---
+
+const setPathContextStyles = (
+  ctx: CanvasRenderingContext2D,
+  color: string,
+  width: number,
+  isEraser: boolean
+) => {
+  ctx.lineCap = 'round';
+  ctx.lineJoin = 'round';
+  if (isEraser) {
+    ctx.globalCompositeOperation = 'destination-out';
+    ctx.strokeStyle = 'rgba(0,0,0,1)';
+  } else {
+    ctx.globalCompositeOperation = 'source-over';
+    ctx.strokeStyle = color;
+  }
+  ctx.lineWidth = width;
+};
+
+// --- Preview object builders (ephemeral, not stored) ---
+
+const buildRectEllipsePreview = (
+  kind: 'rect' | 'ellipse',
+  x0: number,
+  y0: number,
+  x1: number,
+  y1: number,
+  color: string,
+  width: number,
+  shapeFill: boolean,
+  z: number
+): RectObject | EllipseObject => ({
+  id: '__preview__',
+  kind,
+  z,
+  x: Math.min(x0, x1),
+  y: Math.min(y0, y1),
+  w: Math.abs(x1 - x0),
+  h: Math.abs(y1 - y0),
+  stroke: color,
+  strokeWidth: width,
+  fill: shapeFill ? color : undefined,
+});
+
+const buildLineArrowPreview = (
+  kind: 'line' | 'arrow',
+  x1: number,
+  y1: number,
+  x2: number,
+  y2: number,
+  color: string,
+  width: number,
+  z: number
+): LineObject | ArrowObject => ({
+  id: '__preview__',
+  kind,
+  z,
+  x1,
+  y1,
+  x2,
+  y2,
+  stroke: color,
+  strokeWidth: width,
+});
+
 // --- Object dispatcher ---
-// Phase 2a only renders `path` objects. Later PRs fill in the remaining
-// `kind` branches (rect, ellipse, line, arrow, text, image).
+// Phase 2.1b renders path, rect, ellipse, line, and arrow.
+// text / image remain no-ops until PRs 2.1d / 2.2.
 
 const renderObject = (
   ctx: CanvasRenderingContext2D,
@@ -181,12 +364,20 @@ const renderObject = (
       renderPathPoints(ctx, obj.points, obj.color, obj.width);
       return;
     case 'rect':
+      renderRect(ctx, obj);
+      return;
     case 'ellipse':
+      renderEllipse(ctx, obj);
+      return;
     case 'line':
+      renderLine(ctx, obj);
+      return;
     case 'arrow':
+      renderArrow(ctx, obj);
+      return;
     case 'text':
     case 'image':
-      return;
+      return; // land in 2.1d / 2.2
   }
 };
 
@@ -197,6 +388,7 @@ const renderPathPoints = (
   width: number
 ): void => {
   if (points.length < 2) return;
+  ctx.save();
   ctx.beginPath();
   ctx.lineCap = 'round';
   ctx.lineJoin = 'round';
@@ -213,5 +405,88 @@ const renderPathPoints = (
     ctx.lineTo(points[i].x, points[i].y);
   }
   ctx.stroke();
+  ctx.restore();
+};
+
+const renderRect = (ctx: CanvasRenderingContext2D, obj: RectObject): void => {
+  ctx.save();
   ctx.globalCompositeOperation = 'source-over';
+  ctx.strokeStyle = obj.stroke;
+  ctx.lineWidth = obj.strokeWidth;
+  ctx.lineCap = 'round';
+  ctx.lineJoin = 'round';
+  if (obj.fill) {
+    ctx.fillStyle = obj.fill;
+    ctx.fillRect(obj.x, obj.y, obj.w, obj.h);
+  }
+  ctx.strokeRect(obj.x, obj.y, obj.w, obj.h);
+  ctx.restore();
+};
+
+const renderEllipse = (
+  ctx: CanvasRenderingContext2D,
+  obj: EllipseObject
+): void => {
+  const cx = obj.x + obj.w / 2;
+  const cy = obj.y + obj.h / 2;
+  const rx = Math.abs(obj.w / 2);
+  const ry = Math.abs(obj.h / 2);
+  ctx.save();
+  ctx.globalCompositeOperation = 'source-over';
+  ctx.strokeStyle = obj.stroke;
+  ctx.lineWidth = obj.strokeWidth;
+  ctx.beginPath();
+  ctx.ellipse(cx, cy, rx, ry, 0, 0, Math.PI * 2);
+  if (obj.fill) {
+    ctx.fillStyle = obj.fill;
+    ctx.fill();
+  }
+  ctx.stroke();
+  ctx.restore();
+};
+
+const renderLine = (ctx: CanvasRenderingContext2D, obj: LineObject): void => {
+  ctx.save();
+  ctx.globalCompositeOperation = 'source-over';
+  ctx.strokeStyle = obj.stroke;
+  ctx.lineWidth = obj.strokeWidth;
+  ctx.lineCap = 'round';
+  ctx.beginPath();
+  ctx.moveTo(obj.x1, obj.y1);
+  ctx.lineTo(obj.x2, obj.y2);
+  ctx.stroke();
+  ctx.restore();
+};
+
+const renderArrow = (ctx: CanvasRenderingContext2D, obj: ArrowObject): void => {
+  const headLen = Math.max(12, obj.strokeWidth * 3);
+  const angle = Math.atan2(obj.y2 - obj.y1, obj.x2 - obj.x1);
+
+  ctx.save();
+  ctx.globalCompositeOperation = 'source-over';
+  ctx.strokeStyle = obj.stroke;
+  ctx.fillStyle = obj.stroke;
+  ctx.lineWidth = obj.strokeWidth;
+  ctx.lineCap = 'round';
+
+  // Line body
+  ctx.beginPath();
+  ctx.moveTo(obj.x1, obj.y1);
+  ctx.lineTo(obj.x2, obj.y2);
+  ctx.stroke();
+
+  // Triangular arrowhead at (x2, y2)
+  ctx.beginPath();
+  ctx.moveTo(obj.x2, obj.y2);
+  ctx.lineTo(
+    obj.x2 - headLen * Math.cos(angle - Math.PI / 6),
+    obj.y2 - headLen * Math.sin(angle - Math.PI / 6)
+  );
+  ctx.lineTo(
+    obj.x2 - headLen * Math.cos(angle + Math.PI / 6),
+    obj.y2 - headLen * Math.sin(angle + Math.PI / 6)
+  );
+  ctx.closePath();
+  ctx.fill();
+  ctx.restore();
 };

--- a/context/DashboardContextValue.ts
+++ b/context/DashboardContextValue.ts
@@ -14,6 +14,7 @@ import {
   AddWidgetOverrides,
   GridPosition,
   DrawableObject,
+  ShapeTool,
 } from '../types';
 
 export interface AnnotationState {
@@ -21,6 +22,8 @@ export interface AnnotationState {
   color: string;
   width: number;
   customColors: string[];
+  activeTool: ShapeTool;
+  shapeFill: boolean;
 }
 
 export interface DashboardContextValue {

--- a/tests/utils/migrateDrawingConfig.test.ts
+++ b/tests/utils/migrateDrawingConfig.test.ts
@@ -33,9 +33,16 @@ const pathObject = (overrides: Partial<PathObject> = {}): PathObject => ({
 });
 
 describe('migrateDrawingConfig', () => {
-  it('returns an empty config when input is null or undefined', () => {
-    expect(migrateDrawingConfig(null)).toEqual({ objects: [] });
-    expect(migrateDrawingConfig(undefined)).toEqual({ objects: [] });
+  it('returns an empty config with defaults when input is null or undefined', () => {
+    const nullResult = migrateDrawingConfig(null);
+    expect(nullResult.objects).toEqual([]);
+    expect(nullResult.activeTool).toBe('pen');
+    expect(nullResult.shapeFill).toBe(false);
+
+    const undefinedResult = migrateDrawingConfig(undefined);
+    expect(undefinedResult.objects).toEqual([]);
+    expect(undefinedResult.activeTool).toBe('pen');
+    expect(undefinedResult.shapeFill).toBe(false);
   });
 
   it('passes through an already-migrated config unchanged', () => {
@@ -54,6 +61,20 @@ describe('migrateDrawingConfig', () => {
     expect(out.color).toBe('#ff0000');
     expect(out.width).toBe(6);
     expect(out.customColors).toEqual(['#111', '#222']);
+    // New 2.1b fields default correctly
+    expect(out.activeTool).toBe('pen');
+    expect(out.shapeFill).toBe(false);
+  });
+
+  it('preserves explicit activeTool and shapeFill when already set', () => {
+    const input: DrawingConfig = {
+      objects: [pathObject()],
+      activeTool: 'rect',
+      shapeFill: true,
+    };
+    const out = migrateDrawingConfig(input);
+    expect(out.activeTool).toBe('rect');
+    expect(out.shapeFill).toBe(true);
   });
 
   it('strips deprecated `paths` and `mode` even from migrated configs', () => {
@@ -137,6 +158,39 @@ describe('migrateDrawingConfig', () => {
     expect(twice.objects).toEqual(once.objects);
     expect(twice.color).toBe(once.color);
     expect(twice.width).toBe(once.width);
+    expect(twice.activeTool).toBe(once.activeTool);
+    expect(twice.shapeFill).toBe(once.shapeFill);
+  });
+
+  // --- 2.1b: activeTool and shapeFill migration ---
+
+  it('promotes legacy color === "eraser" to activeTool: "eraser" and clears color', () => {
+    const input = {
+      objects: [pathObject()],
+      color: 'eraser',
+    } as unknown as DrawingConfig;
+    const out = migrateDrawingConfig(input);
+    expect(out.activeTool).toBe('eraser');
+    // color should be cleared (undefined) so callers fall back to palette default
+    expect(out.color).toBeUndefined();
+  });
+
+  it('defaults activeTool to "pen" when field is missing', () => {
+    const input: DrawingConfig = {
+      objects: [pathObject()],
+      color: '#abc',
+    };
+    const out = migrateDrawingConfig(input);
+    expect(out.activeTool).toBe('pen');
+  });
+
+  it('defaults activeTool to "pen" when value is not a valid ShapeTool', () => {
+    const input = {
+      objects: [pathObject()],
+      activeTool: 'select', // future tool not yet valid
+    } as unknown as DrawingConfig;
+    const out = migrateDrawingConfig(input);
+    expect(out.activeTool).toBe('pen');
   });
 });
 
@@ -171,10 +225,12 @@ describe('nextZ', () => {
 });
 
 describe('emptyDrawingConfig', () => {
-  it('returns a fresh empty config each call', () => {
+  it('returns a fresh empty config with defaults each call', () => {
     const a = emptyDrawingConfig();
     const b = emptyDrawingConfig();
-    expect(a).toEqual({ objects: [] });
+    expect(a.objects).toEqual([]);
+    expect(a.activeTool).toBe('pen');
+    expect(a.shapeFill).toBe(false);
     expect(a).not.toBe(b);
   });
 });

--- a/utils/migrateDrawingConfig.ts
+++ b/utils/migrateDrawingConfig.ts
@@ -1,27 +1,74 @@
-import { DrawableObject, DrawingConfig, Path, PathObject } from '../types';
+import {
+  DrawableObject,
+  DrawingConfig,
+  Path,
+  PathObject,
+  ShapeTool,
+} from '../types';
 
 /** DrawingConfig with `objects` guaranteed non-optional. Post-migration shape. */
 export type MigratedDrawingConfig = DrawingConfig & {
   objects: DrawableObject[];
+  activeTool: ShapeTool;
+  shapeFill: boolean;
+};
+
+const VALID_TOOLS: readonly ShapeTool[] = [
+  'pen',
+  'eraser',
+  'rect',
+  'ellipse',
+  'line',
+  'arrow',
+];
+
+/**
+ * Normalize activeTool and shapeFill from a raw config object.
+ * Handles:
+ * - Legacy `color === 'eraser'` overload → activeTool: 'eraser', color cleared
+ * - Missing or invalid activeTool → 'pen'
+ * - Missing shapeFill → false
+ */
+const normalizeToolFields = (
+  raw: DrawingConfig
+): { activeTool: ShapeTool; shapeFill: boolean; color?: string } => {
+  let activeTool: ShapeTool = 'pen';
+  let color = raw.color;
+
+  if (color === 'eraser') {
+    // Legacy overload: the string 'eraser' was stuffed into color to toggle
+    // eraser mode. Promote to activeTool and clear the overloaded color.
+    activeTool = 'eraser';
+    color = undefined;
+  } else if (
+    raw.activeTool !== undefined &&
+    VALID_TOOLS.includes(raw.activeTool)
+  ) {
+    activeTool = raw.activeTool;
+  }
+
+  const shapeFill = typeof raw.shapeFill === 'boolean' ? raw.shapeFill : false;
+
+  return { activeTool, shapeFill, color };
 };
 
 /**
- * Forward-migrate a DrawingConfig to the Phase-2 object-model shape.
+ * Forward-migrate a DrawingConfig to the Phase-2.1b object-model shape.
  *
  * Legacy (Phase 1) shape: `{ paths: Path[]; mode?; color?; width?; customColors? }`.
- * Canonical (Phase 2a) shape: `{ objects: DrawableObject[]; ... }`.
+ * Phase 2a shape: `{ objects: DrawableObject[]; ... }`.
+ * Phase 2.1b shape: adds `activeTool: ShapeTool` and `shapeFill: boolean`.
  *
  * Behavior:
  * - If `objects[]` is non-empty, it's the source of truth — we keep it and
  *   drop any lingering legacy `paths`/`mode`.
  * - If `objects` is missing or empty AND `paths` has content, each legacy
  *   Path is wrapped as a `PathObject` with a fresh UUID and sequential z.
- *   Preferring `paths` in this edge case prevents data loss when a widget is
- *   halfway through migration (shouldn't happen in production, but defensive
- *   behavior is cheap).
  * - If neither has content, `objects` becomes `[]`.
- * - Malformed `paths` entries (missing points array, empty points, etc.) are
- *   dropped rather than crashing the widget.
+ * - Malformed `paths` entries are dropped rather than crashing the widget.
+ * - Legacy `color === 'eraser'` is promoted to `activeTool: 'eraser'`.
+ * - Missing/invalid `activeTool` defaults to `'pen'`.
+ * - Missing `shapeFill` defaults to `false`.
  *
  * This function is pure and idempotent — calling it on an already-migrated
  * config returns an equivalent config.
@@ -30,14 +77,15 @@ export const migrateDrawingConfig = (
   raw: DrawingConfig | undefined | null
 ): MigratedDrawingConfig => {
   if (!raw || typeof raw !== 'object') {
-    return { objects: [] };
+    return { objects: [], activeTool: 'pen', shapeFill: false };
   }
 
-  const { paths, mode: _mode, ...rest } = raw;
+  const { paths, mode: _mode, activeTool: _at, shapeFill: _sf, ...rest } = raw;
+  const { activeTool, shapeFill, color } = normalizeToolFields(raw);
 
   if (Array.isArray(raw.objects) && raw.objects.length > 0) {
     // Already migrated with content — strip legacy fields and return.
-    return { ...rest, objects: raw.objects };
+    return { ...rest, color, objects: raw.objects, activeTool, shapeFill };
   }
 
   const migratedFromPaths: PathObject[] = Array.isArray(paths)
@@ -56,12 +104,24 @@ export const migrateDrawingConfig = (
     : [];
 
   if (migratedFromPaths.length > 0) {
-    return { ...rest, objects: migratedFromPaths };
+    return {
+      ...rest,
+      color,
+      objects: migratedFromPaths,
+      activeTool,
+      shapeFill,
+    };
   }
 
   // Nothing to migrate — preserve existing `objects` (even if empty) so that
   // intentional resets like `clear()` round-trip correctly.
-  return { ...rest, objects: Array.isArray(raw.objects) ? raw.objects : [] };
+  return {
+    ...rest,
+    color,
+    objects: Array.isArray(raw.objects) ? raw.objects : [],
+    activeTool,
+    shapeFill,
+  };
 };
 
 const isValidLegacyPath = (p: unknown): p is Path => {
@@ -80,6 +140,8 @@ const isValidLegacyPath = (p: unknown): p is Path => {
  */
 export const emptyDrawingConfig = (): MigratedDrawingConfig => ({
   objects: [],
+  activeTool: 'pen',
+  shapeFill: false,
 });
 
 /**


### PR DESCRIPTION
## Summary
Extends the drawing widget to support multiple shape tools beyond freehand pen/eraser strokes. Users can now draw rectangles, ellipses, lines, and arrows with live preview during interaction.

## Key Changes

### Core Drawing Logic (`useDrawingCanvas.ts`)
- Replaced single `currentPathRef` with discriminated union `InProgress` type to track different gesture states (path, rect/ellipse, line/arrow)
- Added `activeTool` and `shapeFill` options to control which tool is active and whether shapes are filled
- Implemented live preview rendering during shape drawing via new `buildRectEllipsePreview` and `buildLineArrowPreview` helpers
- Added rendering functions for all shape types: `renderRect`, `renderEllipse`, `renderLine`, `renderArrow`
- Refactored path context setup into `setPathContextStyles` helper for reusability
- Capture active tool at gesture start to prevent mid-drag tool switches from affecting the current stroke

### UI Components
- **DrawingWidget**: Added tool selector buttons (pen, eraser, line, arrow, rect, ellipse) with visual feedback for active tool
- **AnnotationOverlay**: Mirrored tool selector UI with same button layout and styling
- **DrawingSettings**: Added "Shape Fill" checkbox to toggle fill behavior for rect/ellipse shapes
- Color swatches now dim when eraser is active (visual feedback that color selection is disabled)

### Type System & Migration
- Added `ShapeTool` type union: `'pen' | 'eraser' | 'rect' | 'ellipse' | 'line' | 'arrow'`
- Extended `DrawingConfig` with `activeTool` and `shapeFill` fields
- Updated `migrateDrawingConfig` to handle legacy `color === 'eraser'` overload by promoting it to `activeTool: 'eraser'`
- Ensured migration is idempotent and handles missing/invalid tool values gracefully

### Rendering Details
- All shape rendering uses `ctx.save()`/`ctx.restore()` to isolate context state changes
- Rectangles and ellipses support optional fill via `shapeFill` config
- Arrow rendering includes dynamic arrowhead sizing (min 12px, scales with stroke width) with proper angle calculation
- Line and arrow strokes use `lineCap: 'round'` for consistency with pen tool

## Implementation Notes
- Preview objects use a special `id: '__preview__'` to distinguish them from persisted objects
- Degenerate shapes (zero width/height or identical endpoints) are dropped on completion
- Tool state is captured at gesture start (`activeToolAtStartRef`) to ensure consistent behavior even if user switches tools mid-stroke
- Canvas context styling is now tool-aware (eraser uses `destination-out` composite operation)

https://claude.ai/code/session_01PSvMQBtXyFDXRvci35ZNSD