### PR TITLE
Polish Guided Learning overlays: tooltip anchors, banner tones, spotlight alignment, and edge navigation

### DIFF
--- a/components/widgets/GuidedLearning/components/GuidedLearningPlayer.tsx
+++ b/components/widgets/GuidedLearning/components/GuidedLearningPlayer.tsx
@@ -210,6 +210,46 @@ export const GuidedLearningPlayer: React.FC<Props> = ({
     };
   }, [mode, playing, currentIdx, startTimer]);
 
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      const target = event.target as HTMLElement | null;
+      if (
+        target &&
+        (target.tagName === 'INPUT' ||
+          target.tagName === 'TEXTAREA' ||
+          target.isContentEditable)
+      ) {
+        return;
+      }
+
+      if (event.key === 'Escape') {
+        setActiveStepId(null);
+        return;
+      }
+
+      if (mode === 'structured') {
+        if (event.key === 'ArrowLeft') {
+          event.preventDefault();
+          goPrev();
+          return;
+        }
+        if (event.key === 'ArrowRight') {
+          event.preventDefault();
+          goNext();
+          return;
+        }
+      }
+
+      if (mode === 'guided' && event.code === 'Space') {
+        event.preventDefault();
+        setPlaying((prev) => !prev);
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [goNext, goPrev, mode]);
+
   const handlePinClick = (step: GuidedLearningPublicStep) => {
     if (mode === 'explore') {
       setExploreImageIndex(step.imageIndex ?? 0);
@@ -239,9 +279,14 @@ export const GuidedLearningPlayer: React.FC<Props> = ({
       containerSize.w / 2 - (step.xPct / 100) * containerSize.w * scale;
     const ty =
       containerSize.h / 2 - (step.yPct / 100) * containerSize.h * scale;
+    const reduceMotion =
+      typeof window !== 'undefined' &&
+      typeof window.matchMedia === 'function' &&
+      window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
     return {
       transform: `scale(${scale}) translate(${tx / scale}px, ${ty / scale}px)`,
-      transition: 'transform 0.6s ease-in-out',
+      transition: reduceMotion ? 'none' : 'transform 0.6s ease-in-out',
       transformOrigin: '0 0',
     };
   };
@@ -318,6 +363,16 @@ export const GuidedLearningPlayer: React.FC<Props> = ({
       );
     }
 
+    if (type === 'tooltip') {
+      return activeStepInContainer ? (
+        <TooltipInteraction
+          step={activeStepInContainer}
+          containerWidth={containerSize.w}
+          containerHeight={containerSize.h}
+        />
+      ) : null;
+    }
+
     if (
       type === 'pan-zoom' ||
       type === 'spotlight' ||
@@ -340,7 +395,10 @@ export const GuidedLearningPlayer: React.FC<Props> = ({
             </div>
           </div>
         ) : activeStep.showOverlay === 'banner' ? (
-          <BannerInteraction step={activeStep} />
+          <BannerInteraction
+            step={activeStep}
+            onClose={() => setActiveStepId(null)}
+          />
         ) : null;
 
       if (
@@ -353,6 +411,7 @@ export const GuidedLearningPlayer: React.FC<Props> = ({
               step={activeStepInContainer}
               containerWidth={containerSize.w}
               containerHeight={containerSize.h}
+              panZoomActive={Boolean(panZoomActive)}
             />
             {overlay}
           </>
@@ -364,25 +423,6 @@ export const GuidedLearningPlayer: React.FC<Props> = ({
 
     return null;
   };
-
-  // Tooltip — rendered separately (not in overlay, directly on canvas)
-  const renderTooltip = () => {
-    if (
-      !activeStepInContainer ||
-      activeStepInContainer.interactionType !== 'tooltip'
-    ) {
-      return null;
-    }
-
-    return (
-      <TooltipInteraction
-        step={activeStepInContainer}
-        containerWidth={containerSize.w}
-        containerHeight={containerSize.h}
-      />
-    );
-  };
-
   return (
     <div className="h-full flex flex-col bg-slate-900">
       {/* Controls bar */}
@@ -419,38 +459,12 @@ export const GuidedLearningPlayer: React.FC<Props> = ({
             className="flex items-center"
             style={{ gap: 'min(8px, 2cqmin)' }}
           >
-            <button
-              onClick={goPrev}
-              disabled={currentIdx === 0}
-              className="text-slate-400 hover:text-white disabled:opacity-30 transition-colors"
-              aria-label="Previous"
-            >
-              <ChevronLeft
-                style={{
-                  width: 'min(20px, 5cqmin)',
-                  height: 'min(20px, 5cqmin)',
-                }}
-              />
-            </button>
             <span
               className="text-slate-300 font-bold"
               style={{ fontSize: 'min(11px, 3cqmin)' }}
             >
               {currentIdx + 1} / {steps.length}
             </span>
-            <button
-              onClick={goNext}
-              disabled={currentIdx === steps.length - 1}
-              className="text-slate-400 hover:text-white disabled:opacity-30 transition-colors"
-              aria-label="Next"
-            >
-              <ChevronRight
-                style={{
-                  width: 'min(20px, 5cqmin)',
-                  height: 'min(20px, 5cqmin)',
-                }}
-              />
-            </button>
           </div>
         )}
 
@@ -552,7 +566,10 @@ export const GuidedLearningPlayer: React.FC<Props> = ({
           className="w-full h-full relative flex items-center justify-center"
         >
           {/* Image with optional pan-zoom transform */}
-          <div className="w-full h-full relative" style={getPanZoomStyle()}>
+          <div
+            className="w-full h-full relative motion-reduce:transition-none"
+            style={getPanZoomStyle()}
+          >
             {currentImageUrl && (
               <img
                 ref={imgRef}
@@ -570,7 +587,13 @@ export const GuidedLearningPlayer: React.FC<Props> = ({
               const isActive = activeStepId === step.id;
               const isCurrentStructured =
                 mode !== 'explore' && step.id === currentStep?.id;
-              const showPin = mode === 'explore' || isCurrentStructured;
+              const hidePinInStructured =
+                mode !== 'explore' &&
+                isCurrentStructured &&
+                Boolean(step.hideStepNumber);
+              const showPin =
+                (mode === 'explore' || isCurrentStructured) &&
+                !hidePinInStructured;
 
               if (!showPin) return null;
 
@@ -592,10 +615,10 @@ export const GuidedLearningPlayer: React.FC<Props> = ({
                 >
                   <button
                     onClick={() => handlePinClick(step)}
-                    className={`relative flex items-center justify-center rounded-full border-2 border-white transition-all shadow-lg focus:outline-none ${
+                    className={`group relative flex items-center justify-center rounded-full border-2 border-white transition-all shadow-lg focus:outline-none focus-visible:ring-2 focus-visible:ring-white/90 ${
                       isActive
                         ? 'bg-indigo-600 scale-125 shadow-indigo-500/60'
-                        : 'bg-white/20 hover:bg-white/30 animate-pulse'
+                        : 'bg-white/25 hover:bg-white/35'
                     }`}
                     style={{
                       width: 'min(32px, 8cqmin)',
@@ -603,20 +626,62 @@ export const GuidedLearningPlayer: React.FC<Props> = ({
                     }}
                     aria-label={step.label ?? `Step ${idx + 1}`}
                   >
+                    {!isActive && (
+                      <span className="pointer-events-none absolute inset-0 rounded-full border border-white/70 animate-ping opacity-70 motion-reduce:hidden [animation-duration:2s]" />
+                    )}
                     <span
-                      className="text-white font-bold select-none"
+                      className="pointer-events-none absolute rounded-full bg-white/95"
+                      style={{
+                        width: 'min(7px, 1.8cqmin)',
+                        height: 'min(7px, 1.8cqmin)',
+                      }}
+                    />
+                    <span
+                      className="relative text-white font-bold select-none"
                       style={{ fontSize: 'min(12px, 3cqmin)' }}
                     >
-                      {step.hideStepNumber ? '' : idx + 1}
+                      {mode === 'explore' && step.hideStepNumber ? '' : idx + 1}
                     </span>
                   </button>
                 </div>
               );
             })}
-
-            {/* Tooltip (rendered inline with image) */}
-            {renderTooltip()}
           </div>
+
+          {mode === 'structured' && steps.length > 0 && (
+            <>
+              <button
+                onClick={goPrev}
+                disabled={currentIdx === 0}
+                aria-label="Previous step"
+                className="absolute top-1/2 left-3 -translate-y-1/2 z-30 rounded-full bg-white/10 backdrop-blur-md border border-white/20 hover:bg-white/20 disabled:opacity-40 transition-all duration-200 active:scale-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/90"
+                style={{
+                  width: 'clamp(40px, 8cqmin, 72px)',
+                  height: 'clamp(40px, 8cqmin, 72px)',
+                }}
+              >
+                <ChevronLeft
+                  className="mx-auto text-white"
+                  style={{ width: '60%', height: '60%' }}
+                />
+              </button>
+              <button
+                onClick={goNext}
+                disabled={currentIdx === steps.length - 1}
+                aria-label="Next step"
+                className="absolute top-1/2 right-3 -translate-y-1/2 z-30 rounded-full bg-white/10 backdrop-blur-md border border-white/20 hover:bg-white/20 disabled:opacity-40 transition-all duration-200 active:scale-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/90"
+                style={{
+                  width: 'clamp(40px, 8cqmin, 72px)',
+                  height: 'clamp(40px, 8cqmin, 72px)',
+                }}
+              >
+                <ChevronRight
+                  className="mx-auto text-white"
+                  style={{ width: '60%', height: '60%' }}
+                />
+              </button>
+            </>
+          )}
 
           {/* Interaction overlays */}
           {renderInteraction()}
@@ -643,8 +708,10 @@ export const GuidedLearningPlayer: React.FC<Props> = ({
               }`}
               style={{
                 width:
-                  i === currentIdx ? 'min(16px, 4cqmin)' : 'min(8px, 2cqmin)',
-                height: 'min(8px, 2cqmin)',
+                  i === currentIdx
+                    ? 'clamp(20px, 5cqmin, 36px)'
+                    : 'clamp(8px, 2cqmin, 14px)',
+                height: 'clamp(8px, 2cqmin, 14px)',
               }}
               aria-label={`Go to step ${i + 1}`}
             />

--- a/components/widgets/GuidedLearning/components/GuidedLearningPlayer.tsx
+++ b/components/widgets/GuidedLearning/components/GuidedLearningPlayer.tsx
@@ -53,6 +53,14 @@ export const GuidedLearningPlayer: React.FC<Props> = ({
   const [progress, setProgress] = useState(0); // 0-1 for guided auto-advance
   const [containerSize, setContainerSize] = useState({ w: 0, h: 0 });
   const [answeredSteps, setAnsweredSteps] = useState<Set<string>>(new Set());
+  const [prefersReducedMotion, setPrefersReducedMotion] = useState(() => {
+    if (
+      typeof window === 'undefined' ||
+      typeof window.matchMedia !== 'function'
+    )
+      return false;
+    return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  });
 
   // Track previous mode to reset step index when mode changes (adjusting state while rendering)
   const [prevMode, setPrevMode] = useState(mode);
@@ -211,7 +219,29 @@ export const GuidedLearningPlayer: React.FC<Props> = ({
   }, [mode, playing, currentIdx, startTimer]);
 
   useEffect(() => {
+    if (
+      typeof window === 'undefined' ||
+      typeof window.matchMedia !== 'function'
+    )
+      return;
+    const mediaQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
+    const onChange = (event: MediaQueryListEvent) => {
+      setPrefersReducedMotion(event.matches);
+    };
+    mediaQuery.addEventListener('change', onChange);
+    return () => mediaQuery.removeEventListener('change', onChange);
+  }, []);
+
+  useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
+      const container = containerRef.current;
+      const activeElement = document.activeElement;
+      const hasKeyboardFocus = Boolean(
+        container && activeElement && container.contains(activeElement)
+      );
+      const isHovered = Boolean(container?.matches(':hover'));
+      if (!hasKeyboardFocus && !isHovered) return;
+
       const target = event.target as HTMLElement | null;
       if (
         target &&
@@ -279,14 +309,10 @@ export const GuidedLearningPlayer: React.FC<Props> = ({
       containerSize.w / 2 - (step.xPct / 100) * containerSize.w * scale;
     const ty =
       containerSize.h / 2 - (step.yPct / 100) * containerSize.h * scale;
-    const reduceMotion =
-      typeof window !== 'undefined' &&
-      typeof window.matchMedia === 'function' &&
-      window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 
     return {
       transform: `scale(${scale}) translate(${tx / scale}px, ${ty / scale}px)`,
-      transition: reduceMotion ? 'none' : 'transform 0.6s ease-in-out',
+      transition: prefersReducedMotion ? 'none' : 'transform 0.6s ease-in-out',
       transformOrigin: '0 0',
     };
   };
@@ -564,6 +590,7 @@ export const GuidedLearningPlayer: React.FC<Props> = ({
         <div
           ref={containerRef}
           className="w-full h-full relative flex items-center justify-center"
+          tabIndex={0}
         >
           {/* Image with optional pan-zoom transform */}
           <div
@@ -655,10 +682,7 @@ export const GuidedLearningPlayer: React.FC<Props> = ({
                 disabled={currentIdx === 0}
                 aria-label="Previous step"
                 className="absolute top-1/2 left-3 -translate-y-1/2 z-30 rounded-full bg-white/10 backdrop-blur-md border border-white/20 hover:bg-white/20 disabled:opacity-40 transition-all duration-200 active:scale-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/90"
-                style={{
-                  width: 'clamp(40px, 8cqmin, 72px)',
-                  height: 'clamp(40px, 8cqmin, 72px)',
-                }}
+                style={{ width: '56px', height: '56px' }}
               >
                 <ChevronLeft
                   className="mx-auto text-white"
@@ -670,10 +694,7 @@ export const GuidedLearningPlayer: React.FC<Props> = ({
                 disabled={currentIdx === steps.length - 1}
                 aria-label="Next step"
                 className="absolute top-1/2 right-3 -translate-y-1/2 z-30 rounded-full bg-white/10 backdrop-blur-md border border-white/20 hover:bg-white/20 disabled:opacity-40 transition-all duration-200 active:scale-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/90"
-                style={{
-                  width: 'clamp(40px, 8cqmin, 72px)',
-                  height: 'clamp(40px, 8cqmin, 72px)',
-                }}
+                style={{ width: '56px', height: '56px' }}
               >
                 <ChevronRight
                   className="mx-auto text-white"

--- a/components/widgets/GuidedLearning/components/GuidedLearningPlayer.tsx
+++ b/components/widgets/GuidedLearning/components/GuidedLearningPlayer.tsx
@@ -234,6 +234,7 @@ export const GuidedLearningPlayer: React.FC<Props> = ({
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.defaultPrevented) return;
       const container = containerRef.current;
       const activeElement = document.activeElement;
       const hasKeyboardFocus = Boolean(
@@ -247,6 +248,9 @@ export const GuidedLearningPlayer: React.FC<Props> = ({
         target &&
         (target.tagName === 'INPUT' ||
           target.tagName === 'TEXTAREA' ||
+          target.tagName === 'BUTTON' ||
+          target.tagName === 'SELECT' ||
+          target.tagName === 'A' ||
           target.isContentEditable)
       ) {
         return;
@@ -270,7 +274,11 @@ export const GuidedLearningPlayer: React.FC<Props> = ({
         }
       }
 
-      if (mode === 'guided' && event.code === 'Space') {
+      if (
+        mode === 'guided' &&
+        event.code === 'Space' &&
+        target === containerRef.current
+      ) {
         event.preventDefault();
         setPlaying((prev) => !prev);
       }
@@ -681,24 +689,38 @@ export const GuidedLearningPlayer: React.FC<Props> = ({
                 onClick={goPrev}
                 disabled={currentIdx === 0}
                 aria-label="Previous step"
-                className="absolute top-1/2 left-3 -translate-y-1/2 z-30 rounded-full bg-white/10 backdrop-blur-md border border-white/20 hover:bg-white/20 disabled:opacity-40 transition-all duration-200 active:scale-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/90"
-                style={{ width: '56px', height: '56px' }}
+                className="absolute top-1/2 -translate-y-1/2 z-30 rounded-full bg-white/10 backdrop-blur-md border border-white/20 hover:bg-white/20 disabled:opacity-40 transition-all duration-200 active:scale-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/90"
+                style={{
+                  left: 'clamp(8px, 2cqmin, 12px)',
+                  width: 'clamp(36px, 7cqmin, 56px)',
+                  height: 'clamp(36px, 7cqmin, 56px)',
+                }}
               >
                 <ChevronLeft
                   className="mx-auto text-white"
-                  style={{ width: '60%', height: '60%' }}
+                  style={{
+                    width: 'clamp(18px, 4cqmin, 32px)',
+                    height: 'clamp(18px, 4cqmin, 32px)',
+                  }}
                 />
               </button>
               <button
                 onClick={goNext}
                 disabled={currentIdx === steps.length - 1}
                 aria-label="Next step"
-                className="absolute top-1/2 right-3 -translate-y-1/2 z-30 rounded-full bg-white/10 backdrop-blur-md border border-white/20 hover:bg-white/20 disabled:opacity-40 transition-all duration-200 active:scale-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/90"
-                style={{ width: '56px', height: '56px' }}
+                className="absolute top-1/2 -translate-y-1/2 z-30 rounded-full bg-white/10 backdrop-blur-md border border-white/20 hover:bg-white/20 disabled:opacity-40 transition-all duration-200 active:scale-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/90"
+                style={{
+                  right: 'clamp(8px, 2cqmin, 12px)',
+                  width: 'clamp(36px, 7cqmin, 56px)',
+                  height: 'clamp(36px, 7cqmin, 56px)',
+                }}
               >
                 <ChevronRight
                   className="mx-auto text-white"
-                  style={{ width: '60%', height: '60%' }}
+                  style={{
+                    width: 'clamp(18px, 4cqmin, 32px)',
+                    height: 'clamp(18px, 4cqmin, 32px)',
+                  }}
                 />
               </button>
             </>

--- a/components/widgets/GuidedLearning/components/GuidedLearningStepEditor.tsx
+++ b/components/widgets/GuidedLearning/components/GuidedLearningStepEditor.tsx
@@ -228,10 +228,7 @@ export const GuidedLearningStepEditor: React.FC<Props> = ({
           )}
 
           {step.interactionType === 'tooltip' && (
-            <div
-              className="grid grid-cols-2"
-              style={{ gap: 'min(8px, 2cqmin)' }}
-            >
+            <div className="grid grid-cols-2 gap-2">
               <div>
                 <label
                   className="block text-slate-400 font-bold uppercase tracking-wider mb-1"
@@ -440,10 +437,7 @@ export const GuidedLearningStepEditor: React.FC<Props> = ({
               )}
 
               {step.showOverlay === 'tooltip' && (
-                <div
-                  className="grid grid-cols-2"
-                  style={{ gap: 'min(8px, 2cqmin)' }}
-                >
+                <div className="grid grid-cols-2 gap-2">
                   <div>
                     <label
                       className="block text-slate-400 font-bold uppercase tracking-wider mb-1"

--- a/components/widgets/GuidedLearning/components/GuidedLearningStepEditor.tsx
+++ b/components/widgets/GuidedLearning/components/GuidedLearningStepEditor.tsx
@@ -35,6 +35,15 @@ const QUESTION_TYPES: { value: GuidedLearningQuestionType; label: string }[] = [
   { value: 'sorting', label: 'Sorting' },
 ];
 
+const TOOLTIP_POSITIONS: NonNullable<GuidedLearningStep['tooltipPosition']>[] =
+  ['auto', 'above', 'below', 'left', 'right'];
+
+const BANNER_TONES: NonNullable<GuidedLearningStep['bannerTone']>[] = [
+  'blue',
+  'red',
+  'neutral',
+];
+
 export const GuidedLearningStepEditor: React.FC<Props> = ({
   step,
   imageCount,
@@ -191,7 +200,7 @@ export const GuidedLearningStepEditor: React.FC<Props> = ({
               onChange={(e) => update({ hideStepNumber: e.target.checked })}
               className="accent-indigo-500"
             />
-            Hide step number on hotspot
+            Hide hotspot pin
           </label>
 
           {/* Text content */}
@@ -215,6 +224,61 @@ export const GuidedLearningStepEditor: React.FC<Props> = ({
                   fontSize: 'clamp(12px, 3.2cqmin, 16px)',
                 }}
               />
+            </div>
+          )}
+
+          {step.interactionType === 'tooltip' && (
+            <div
+              className="grid grid-cols-2"
+              style={{ gap: 'min(8px, 2cqmin)' }}
+            >
+              <div>
+                <label
+                  className="block text-slate-400 font-bold uppercase tracking-wider mb-1"
+                  style={{ fontSize: 'clamp(10px, 2.5cqmin, 14px)' }}
+                >
+                  Tooltip Position
+                </label>
+                <select
+                  value={step.tooltipPosition ?? 'auto'}
+                  onChange={(e) =>
+                    update({
+                      tooltipPosition: e.target
+                        .value as GuidedLearningStep['tooltipPosition'],
+                    })
+                  }
+                  className="w-full bg-slate-800 border border-slate-600 rounded-lg text-white focus:outline-none focus:ring-2 focus:ring-indigo-500/40 appearance-none"
+                  style={{
+                    padding: 'min(6px, 1.5cqmin) min(12px, 3cqmin)',
+                    fontSize: 'clamp(12px, 3.2cqmin, 16px)',
+                  }}
+                >
+                  {TOOLTIP_POSITIONS.map((position) => (
+                    <option key={position} value={position}>
+                      {position[0].toUpperCase() + position.slice(1)}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div>
+                <label
+                  className="block text-slate-400 font-bold uppercase tracking-wider mb-1"
+                  style={{ fontSize: 'clamp(10px, 2.5cqmin, 14px)' }}
+                >
+                  Tooltip Offset ({step.tooltipOffset ?? 12}px)
+                </label>
+                <input
+                  type="range"
+                  min={0}
+                  max={48}
+                  step={2}
+                  value={step.tooltipOffset ?? 12}
+                  onChange={(e) =>
+                    update({ tooltipOffset: parseInt(e.target.value, 10) })
+                  }
+                  className="w-full accent-indigo-500"
+                />
+              </div>
             </div>
           )}
 
@@ -372,6 +436,92 @@ export const GuidedLearningStepEditor: React.FC<Props> = ({
                       fontSize: 'clamp(12px, 3.2cqmin, 16px)',
                     }}
                   />
+                </div>
+              )}
+
+              {step.showOverlay === 'tooltip' && (
+                <div
+                  className="grid grid-cols-2"
+                  style={{ gap: 'min(8px, 2cqmin)' }}
+                >
+                  <div>
+                    <label
+                      className="block text-slate-400 font-bold uppercase tracking-wider mb-1"
+                      style={{ fontSize: 'clamp(10px, 2.5cqmin, 14px)' }}
+                    >
+                      Tooltip Position
+                    </label>
+                    <select
+                      value={step.tooltipPosition ?? 'auto'}
+                      onChange={(e) =>
+                        update({
+                          tooltipPosition: e.target
+                            .value as GuidedLearningStep['tooltipPosition'],
+                        })
+                      }
+                      className="w-full bg-slate-800 border border-slate-600 rounded-lg text-white focus:outline-none focus:ring-2 focus:ring-indigo-500/40 appearance-none"
+                      style={{
+                        padding: 'min(6px, 1.5cqmin) min(12px, 3cqmin)',
+                        fontSize: 'clamp(12px, 3.2cqmin, 16px)',
+                      }}
+                    >
+                      {TOOLTIP_POSITIONS.map((position) => (
+                        <option key={position} value={position}>
+                          {position[0].toUpperCase() + position.slice(1)}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+                  <div>
+                    <label
+                      className="block text-slate-400 font-bold uppercase tracking-wider mb-1"
+                      style={{ fontSize: 'clamp(10px, 2.5cqmin, 14px)' }}
+                    >
+                      Tooltip Offset ({step.tooltipOffset ?? 12}px)
+                    </label>
+                    <input
+                      type="range"
+                      min={0}
+                      max={48}
+                      step={2}
+                      value={step.tooltipOffset ?? 12}
+                      onChange={(e) =>
+                        update({ tooltipOffset: parseInt(e.target.value, 10) })
+                      }
+                      className="w-full accent-indigo-500"
+                    />
+                  </div>
+                </div>
+              )}
+
+              {step.showOverlay === 'banner' && (
+                <div>
+                  <label
+                    className="block text-slate-400 font-bold uppercase tracking-wider mb-1"
+                    style={{ fontSize: 'clamp(10px, 2.5cqmin, 14px)' }}
+                  >
+                    Banner Tone
+                  </label>
+                  <select
+                    value={step.bannerTone ?? 'blue'}
+                    onChange={(e) =>
+                      update({
+                        bannerTone: e.target
+                          .value as GuidedLearningStep['bannerTone'],
+                      })
+                    }
+                    className="w-full bg-slate-800 border border-slate-600 rounded-lg text-white focus:outline-none focus:ring-2 focus:ring-indigo-500/40 appearance-none"
+                    style={{
+                      padding: 'min(6px, 1.5cqmin) min(12px, 3cqmin)',
+                      fontSize: 'clamp(12px, 3.2cqmin, 16px)',
+                    }}
+                  >
+                    {BANNER_TONES.map((tone) => (
+                      <option key={tone} value={tone}>
+                        {tone[0].toUpperCase() + tone.slice(1)}
+                      </option>
+                    ))}
+                  </select>
                 </div>
               )}
             </>

--- a/components/widgets/GuidedLearning/components/interactions/BannerInteraction.tsx
+++ b/components/widgets/GuidedLearning/components/interactions/BannerInteraction.tsx
@@ -1,28 +1,54 @@
 import React from 'react';
+import { X } from 'lucide-react';
 import { GuidedLearningPublicStep } from '@/types';
 
 export const BannerInteraction: React.FC<{
   step: GuidedLearningPublicStep;
-}> = ({ step }) => {
+  onClose?: () => void;
+}> = ({ step, onClose }) => {
   if (!step.text) return null;
+  const tone = step.bannerTone ?? 'blue';
+  const toneStyles: Record<typeof tone, string> = {
+    blue: 'linear-gradient(135deg, #1d2a5d 0%, #2d3f89 50%, #4356a0 100%)',
+    red: 'linear-gradient(135deg, #7a1718 0%, #ad2122 50%, #c13435 100%)',
+    neutral:
+      'linear-gradient(135deg, rgba(15, 23, 42, 0.9) 0%, rgba(30, 41, 59, 0.85) 100%)',
+  };
+
   return (
     <div
-      className="absolute top-0 left-0 right-0 z-30 pointer-events-none"
-      style={{ padding: 'min(12px, 3cqmin)' }}
+      className="absolute top-0 left-0 right-0 z-30 pointer-events-none animate-in slide-in-from-top-4 duration-500 motion-reduce:animate-none"
+      style={{ padding: 'min(8px, 2.2cqmin)' }}
     >
       <div
-        className="mx-auto bg-slate-900/85 border border-white/20 text-white rounded-xl shadow-xl"
+        className="relative w-full text-white rounded-xl shadow-2xl border border-white/15"
         style={{
-          maxWidth: 'min(48rem, 90cqmin)',
-          paddingInline: 'min(16px, 4cqmin)',
-          paddingBlock: 'min(12px, 3cqmin)',
+          background: toneStyles[tone],
+          boxShadow: '0 10px 25px rgba(2, 6, 23, 0.45)',
+          paddingInline: 'clamp(14px, 3.8cqmin, 40px)',
+          paddingBlock: 'clamp(12px, 3cqmin, 24px)',
         }}
       >
+        {onClose && (
+          <button
+            onClick={onClose}
+            className="pointer-events-auto absolute text-white/80 hover:text-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/80 rounded"
+            style={{ top: 'min(8px, 2cqmin)', right: 'min(8px, 2cqmin)' }}
+            aria-label="Close overlay"
+          >
+            <X
+              style={{
+                width: 'min(18px, 4.5cqmin)',
+                height: 'min(18px, 4.5cqmin)',
+              }}
+            />
+          </button>
+        )}
         {step.label && (
           <div
-            className="font-bold"
+            className="font-black uppercase tracking-tight pr-8"
             style={{
-              fontSize: 'min(14px, 5.5cqmin)',
+              fontSize: 'clamp(20px, 6cqmin, 40px)',
               marginBottom: 'min(4px, 1cqmin)',
             }}
           >
@@ -30,8 +56,8 @@ export const BannerInteraction: React.FC<{
           </div>
         )}
         <div
-          className="whitespace-pre-wrap"
-          style={{ fontSize: 'min(14px, 5.5cqmin)' }}
+          className="whitespace-pre-wrap font-medium leading-snug"
+          style={{ fontSize: 'clamp(16px, 5cqmin, 32px)' }}
         >
           {step.text}
         </div>

--- a/components/widgets/GuidedLearning/components/interactions/BannerInteraction.tsx
+++ b/components/widgets/GuidedLearning/components/interactions/BannerInteraction.tsx
@@ -33,13 +33,13 @@ export const BannerInteraction: React.FC<{
           <button
             onClick={onClose}
             className="pointer-events-auto absolute text-white/80 hover:text-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/80 rounded"
-            style={{ top: 'min(8px, 2cqmin)', right: 'min(8px, 2cqmin)' }}
+            style={{ top: '8px', right: '8px' }}
             aria-label="Close overlay"
           >
             <X
               style={{
-                width: 'min(18px, 4.5cqmin)',
-                height: 'min(18px, 4.5cqmin)',
+                width: '20px',
+                height: '20px',
               }}
             />
           </button>

--- a/components/widgets/GuidedLearning/components/interactions/BannerInteraction.tsx
+++ b/components/widgets/GuidedLearning/components/interactions/BannerInteraction.tsx
@@ -33,13 +33,16 @@ export const BannerInteraction: React.FC<{
           <button
             onClick={onClose}
             className="pointer-events-auto absolute text-white/80 hover:text-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/80 rounded"
-            style={{ top: '8px', right: '8px' }}
+            style={{
+              top: 'clamp(6px, 1.8cqmin, 12px)',
+              right: 'clamp(6px, 1.8cqmin, 12px)',
+            }}
             aria-label="Close overlay"
           >
             <X
               style={{
-                width: '20px',
-                height: '20px',
+                width: 'clamp(16px, 4.5cqmin, 24px)',
+                height: 'clamp(16px, 4.5cqmin, 24px)',
               }}
             />
           </button>

--- a/components/widgets/GuidedLearning/components/interactions/SpotlightInteraction.tsx
+++ b/components/widgets/GuidedLearning/components/interactions/SpotlightInteraction.tsx
@@ -5,6 +5,7 @@ interface Props {
   step: GuidedLearningPublicStep;
   containerWidth: number;
   containerHeight: number;
+  panZoomActive?: boolean;
 }
 
 /**
@@ -16,9 +17,14 @@ export const SpotlightInteraction: React.FC<Props> = ({
   step,
   containerWidth,
   containerHeight,
+  panZoomActive = false,
 }) => {
-  const cx = (step.xPct / 100) * containerWidth;
-  const cy = (step.yPct / 100) * containerHeight;
+  const cx = panZoomActive
+    ? containerWidth / 2
+    : (step.xPct / 100) * containerWidth;
+  const cy = panZoomActive
+    ? containerHeight / 2
+    : (step.yPct / 100) * containerHeight;
   // Radius as % of the smaller container dimension
   const radiusPct = step.spotlightRadius ?? 25;
   const radius = (Math.min(containerWidth, containerHeight) * radiusPct) / 100;

--- a/components/widgets/GuidedLearning/components/interactions/TooltipInteraction.tsx
+++ b/components/widgets/GuidedLearning/components/interactions/TooltipInteraction.tsx
@@ -15,32 +15,96 @@ export const TooltipInteraction: React.FC<Props> = ({
 }) => {
   const x = (step.xPct / 100) * containerWidth;
   const y = (step.yPct / 100) * containerHeight;
+  const tooltipWidth = Math.min(280, containerWidth * 0.42);
+  const tooltipHeight = Math.max(68, containerHeight * 0.15);
+  const viewportPadding = 16;
+  const offset = Math.max(0, step.tooltipOffset ?? 12);
+  const desiredPosition = step.tooltipPosition ?? 'auto';
 
-  // Determine tooltip offset direction so it stays inside the container
-  const offsetX = step.xPct > 60 ? -8 : 12;
-  const offsetY = step.yPct > 70 ? -40 : 8;
-  const alignRight = step.xPct > 60;
+  let position = desiredPosition;
+  if (desiredPosition === 'auto') {
+    const roomBelow = containerHeight - y;
+    const roomAbove = y;
+    const roomRight = containerWidth - x;
+    if (roomBelow >= tooltipHeight + offset + viewportPadding) {
+      position = 'below';
+    } else if (roomAbove >= tooltipHeight + offset + viewportPadding) {
+      position = 'above';
+    } else if (roomRight >= tooltipWidth + offset + viewportPadding) {
+      position = 'right';
+    } else {
+      position = 'left';
+    }
+  }
+
+  const anchorStyles: Record<
+    NonNullable<GuidedLearningPublicStep['tooltipPosition']>,
+    React.CSSProperties
+  > = {
+    above: {
+      left: x,
+      top: y - offset,
+      transform: 'translate(-50%, -100%)',
+      transformOrigin: '50% 100%',
+    },
+    below: {
+      left: x,
+      top: y + offset,
+      transform: 'translate(-50%, 0)',
+      transformOrigin: '50% 0%',
+    },
+    left: {
+      left: x - offset,
+      top: y,
+      transform: 'translate(-100%, -50%)',
+      transformOrigin: '100% 50%',
+    },
+    right: {
+      left: x + offset,
+      top: y,
+      transform: 'translate(0, -50%)',
+      transformOrigin: '0% 50%',
+    },
+    auto: {},
+  };
+
+  type ResolvedTooltipPosition = 'above' | 'below' | 'left' | 'right';
+  const resolvedPosition: ResolvedTooltipPosition =
+    position === 'auto' ? 'below' : position;
+  const bubbleAlignment =
+    resolvedPosition === 'left'
+      ? 'items-end text-right'
+      : 'items-start text-left';
+  const arrowClassByPosition = {
+    above:
+      'absolute left-1/2 -bottom-[5px] -translate-x-1/2 border-l-[6px] border-r-[6px] border-t-[6px] border-l-transparent border-r-transparent border-t-black/80',
+    below:
+      'absolute left-1/2 -top-[5px] -translate-x-1/2 border-l-[6px] border-r-[6px] border-b-[6px] border-l-transparent border-r-transparent border-b-black/80',
+    left: 'absolute top-1/2 -right-[5px] -translate-y-1/2 border-y-[6px] border-l-[6px] border-y-transparent border-l-black/80',
+    right:
+      'absolute top-1/2 -left-[5px] -translate-y-1/2 border-y-[6px] border-r-[6px] border-y-transparent border-r-black/80',
+  } as const;
 
   return (
     <div
       className="absolute pointer-events-none z-20"
       style={{
-        left: x + offsetX,
-        top: y + offsetY,
-        maxWidth: 'min(200px, 40cqw)',
+        ...anchorStyles[resolvedPosition],
+        maxWidth: 'min(280px, 42cqw)',
       }}
     >
       <div
-        className={`bg-black/70 backdrop-blur-sm text-white rounded-lg leading-relaxed shadow-lg border border-white/10 ${alignRight ? 'text-right' : 'text-left'}`}
+        className={`relative flex flex-col ${bubbleAlignment} bg-black/80 backdrop-blur-md text-white rounded-xl leading-relaxed shadow-xl border border-white/15`}
         style={{
-          padding: 'min(8px, 2cqmin) min(12px, 3cqmin)',
-          fontSize: 'min(12px, 3cqmin)',
+          padding: 'min(10px, 2.3cqmin) min(12px, 3cqmin)',
+          fontSize: 'min(13px, 3.1cqmin)',
         }}
       >
+        <span className={arrowClassByPosition[resolvedPosition]} />
         {step.label && (
           <div
             className="font-bold mb-0.5"
-            style={{ fontSize: 'min(12px, 3.2cqmin)' }}
+            style={{ fontSize: 'min(12px, 3.3cqmin)' }}
           >
             {step.label}
           </div>

--- a/components/widgets/GuidedLearning/components/interactions/TooltipInteraction.tsx
+++ b/components/widgets/GuidedLearning/components/interactions/TooltipInteraction.tsx
@@ -26,14 +26,28 @@ export const TooltipInteraction: React.FC<Props> = ({
     const roomBelow = containerHeight - y;
     const roomAbove = y;
     const roomRight = containerWidth - x;
-    if (roomBelow >= tooltipHeight + offset + viewportPadding) {
+    const roomLeft = x;
+    const requiredVerticalSpace = tooltipHeight + offset + viewportPadding;
+    const requiredHorizontalSpace = tooltipWidth + offset + viewportPadding;
+
+    if (roomBelow >= requiredVerticalSpace) {
       position = 'below';
-    } else if (roomAbove >= tooltipHeight + offset + viewportPadding) {
+    } else if (roomAbove >= requiredVerticalSpace) {
       position = 'above';
-    } else if (roomRight >= tooltipWidth + offset + viewportPadding) {
+    } else if (roomRight >= requiredHorizontalSpace) {
       position = 'right';
-    } else {
+    } else if (roomLeft >= requiredHorizontalSpace) {
       position = 'left';
+    } else {
+      const availableSpaceByPosition = [
+        { position: 'below' as const, space: roomBelow },
+        { position: 'above' as const, space: roomAbove },
+        { position: 'right' as const, space: roomRight },
+        { position: 'left' as const, space: roomLeft },
+      ];
+      position = availableSpaceByPosition.reduce((best, current) =>
+        current.space > best.space ? current : best
+      ).position;
     }
   }
 

--- a/hooks/useGuidedLearningSession.ts
+++ b/hooks/useGuidedLearningSession.ts
@@ -75,7 +75,9 @@ function shuffleArray<T>(arr: T[]): T[] {
 }
 
 /** Convert a full step to a student-safe public step (strips answer keys, shuffles choices) */
-function toPublicStep(step: GuidedLearningStep): GuidedLearningPublicStep {
+export function toPublicStep(
+  step: GuidedLearningStep
+): GuidedLearningPublicStep {
   const base: GuidedLearningPublicStep = {
     id: step.id,
     xPct: step.xPct,
@@ -85,11 +87,14 @@ function toPublicStep(step: GuidedLearningStep): GuidedLearningPublicStep {
     interactionType: step.interactionType,
     hideStepNumber: step.hideStepNumber,
     showOverlay: step.showOverlay,
+    tooltipPosition: step.tooltipPosition,
+    tooltipOffset: step.tooltipOffset,
     text: step.text,
     audioUrl: step.audioUrl,
     videoUrl: step.videoUrl,
     panZoomScale: step.panZoomScale,
     spotlightRadius: step.spotlightRadius,
+    bannerTone: step.bannerTone,
     autoAdvanceDuration: step.autoAdvanceDuration,
   };
 

--- a/tests/hooks/useGuidedLearningSession.test.ts
+++ b/tests/hooks/useGuidedLearningSession.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { toPublicStep } from '@/hooks/useGuidedLearningSession';
+import { GuidedLearningStep } from '@/types';
+
+describe('toPublicStep', () => {
+  it('forwards public-safe visual configuration fields', () => {
+    const step: GuidedLearningStep = {
+      id: 'step-1',
+      xPct: 42,
+      yPct: 64,
+      imageIndex: 0,
+      label: 'Focus area',
+      interactionType: 'tooltip',
+      hideStepNumber: true,
+      showOverlay: 'tooltip',
+      tooltipPosition: 'below',
+      tooltipOffset: 24,
+      text: 'Read this section carefully.',
+      panZoomScale: 3,
+      spotlightRadius: 30,
+      bannerTone: 'red',
+      autoAdvanceDuration: 7,
+      question: {
+        type: 'multiple-choice',
+        text: 'What is 2 + 2?',
+        choices: ['4', '5', '6'],
+        correctAnswer: '4',
+      },
+    };
+
+    const publicStep = toPublicStep(step);
+
+    expect(publicStep.tooltipPosition).toBe('below');
+    expect(publicStep.tooltipOffset).toBe(24);
+    expect(publicStep.bannerTone).toBe('red');
+    expect(publicStep.question?.text).toBe('What is 2 + 2?');
+    expect(publicStep.question).not.toHaveProperty('correctAnswer');
+  });
+});

--- a/types.ts
+++ b/types.ts
@@ -2227,6 +2227,10 @@ export interface GuidedLearningStep {
   hideStepNumber?: boolean;
   /** Overlay style for pan-zoom/spotlight interactions */
   showOverlay?: GuidedLearningOverlayType;
+  /** Tooltip anchor relative to hotspot (default 'auto') */
+  tooltipPosition?: 'above' | 'below' | 'left' | 'right' | 'auto';
+  /** Distance in px from hotspot to tooltip edge (default 12) */
+  tooltipOffset?: number;
   /** Content for text-popover and tooltip */
   text?: string;
   /** Firebase Storage URL for audio */
@@ -2239,6 +2243,8 @@ export interface GuidedLearningStep {
   panZoomScale?: number;
   /** Spotlight radius as % of container cqmin (default 25) */
   spotlightRadius?: number;
+  /** Banner color tone for banner overlay (default 'blue') */
+  bannerTone?: 'blue' | 'red' | 'neutral';
   question?: GuidedLearningQuestion;
   /** Seconds before auto-advance in guided mode */
   autoAdvanceDuration?: number;
@@ -2288,11 +2294,14 @@ export interface GuidedLearningPublicStep {
   interactionType: GuidedLearningInteractionType;
   hideStepNumber?: boolean;
   showOverlay?: GuidedLearningOverlayType;
+  tooltipPosition?: 'above' | 'below' | 'left' | 'right' | 'auto';
+  tooltipOffset?: number;
   text?: string;
   audioUrl?: string;
   videoUrl?: string;
   panZoomScale?: number;
   spotlightRadius?: number;
+  bannerTone?: 'blue' | 'red' | 'neutral';
   question?: {
     type: GuidedLearningQuestionType;
     text: string;


### PR DESCRIPTION
### Motivation
- Fix five UX defects in Guided Learning (spotlight misalignment under pan/zoom, hidden hotspot semantics, brittle tooltip placement, weak banner styling, and inconspicuous Prev/Next nav) and raise overall interaction fidelity for teacher and student experiences. 
- Give authors lightweight, safe visual controls (tooltip anchor/offset, banner tone) while preserving student-safe data boundaries (no answer-key leakage).

### Description
- Spotlight: make the SVG spotlight center on the container when pan-zoom is active by passing `panZoomActive` into `SpotlightInteraction` and using container center coords while keeping the dim layer full-bleed (components/widgets/GuidedLearning/components/interactions/SpotlightInteraction.tsx and GuidedLearningPlayer.tsx). 
- Hide-hotspot semantics: change editor label to "Hide hotspot pin" and hide the entire pin in structured/guided mode when `hideStepNumber` is set, while keeping explore-mode behavior consistent (GuidedLearningStepEditor.tsx, GuidedLearningPlayer.tsx). 
- Tooltip: add `tooltipPosition` and `tooltipOffset` to `GuidedLearningStep` and `GuidedLearningPublicStep`, implement robust auto-placement + explicit anchor resolution, a directional caret, and refined styling (components/widgets/GuidedLearning/components/interactions/TooltipInteraction.tsx). 
- Banner: replace boxed card with a full-width brand gradient banner, larger typography, slide-in animation, selectable `bannerTone` (blue/red/neutral), and an optional close button (BannerInteraction.tsx, StepEditor wiring). 
- Navigation & hotspots polish: remove small top-bar chevrons and add large edge-anchored chevron buttons with keyboard support (`ArrowLeft`/`ArrowRight`, `Space`, `Escape`), improved focus rings and reduced-motion respect, stronger hotspot ping/inner dot, and larger step indicator dots (GuidedLearningPlayer.tsx). 
- Data model and mapping: extend `types.ts` (add `tooltipPosition`, `tooltipOffset`, `bannerTone`) and update `toPublicStep()` in `hooks/useGuidedLearningSession.ts` to forward only the new public-safe visual fields. 
- Editor UX: expose `tooltipPosition` / `tooltipOffset` and `bannerTone` in `GuidedLearningStepEditor.tsx` in both direct tooltip mode and overlay-style sections, and rename the checkbox label to "Hide hotspot pin". 
- Tests: add a unit test `tests/hooks/useGuidedLearningSession.test.ts` validating `toPublicStep()` forwards the new visual fields while stripping answer keys.

### Testing
- Ran type-check: `pnpm run type-check` — success (no type errors).
- Ran lint: `pnpm run lint` — success (no lint errors reported after auto-fix/formatting).
- Ran unit tests: `pnpm run test -- tests/hooks/useGuidedLearningSession.test.ts` — the added test passed and the repository test run in this environment completed with the test suite passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de22a622748320ab8169a2c5d54d23)