### PR TITLE
refactor(classes): split widget into selector + "My Classes" sidebar page

### DIFF
--- a/components/classes/ClassLinkImportDialog.tsx
+++ b/components/classes/ClassLinkImportDialog.tsx
@@ -58,7 +58,11 @@ export const ClassLinkImportDialog: React.FC<ClassLinkImportDialogProps> = ({
       } catch (err) {
         if (cancelled) return;
         console.error('Failed to fetch from ClassLink', err);
-        setError('Failed to fetch from ClassLink. Check console.');
+        setError(
+          t('toasts.classLink.fetchFailed', {
+            defaultValue: 'Failed to fetch from ClassLink. Check console.',
+          })
+        );
       } finally {
         if (!cancelled) setLoading(false);
       }
@@ -66,7 +70,7 @@ export const ClassLinkImportDialog: React.FC<ClassLinkImportDialogProps> = ({
     return () => {
       cancelled = true;
     };
-  }, [isOpen]);
+  }, [isOpen, t]);
 
   const handleImportNew = async (cls: ClassLinkClass) => {
     setPendingId(cls.sourcedId);
@@ -84,11 +88,23 @@ export const ClassLinkImportDialog: React.FC<ClassLinkImportDialogProps> = ({
       const codeSuffix = cls.classCode ? ` (${cls.classCode})` : '';
       const displayName = `${subjectPrefix}${cls.title}${codeSuffix}`;
       await addRoster(displayName, students);
-      addToast(`Imported ${cls.title}`, 'success');
+      addToast(
+        t('toasts.classLink.imported', {
+          defaultValue: 'Imported {{name}}',
+          name: cls.title,
+        }),
+        'success'
+      );
       onClose();
     } catch (err) {
       console.error(err);
-      addToast(`Failed to import ${cls.title}`, 'error');
+      addToast(
+        t('toasts.classLink.importFailed', {
+          defaultValue: 'Failed to import {{name}}',
+          name: cls.title,
+        }),
+        'error'
+      );
     } finally {
       setPendingId(null);
     }
@@ -102,7 +118,12 @@ export const ClassLinkImportDialog: React.FC<ClassLinkImportDialogProps> = ({
         (r) => r.id === mode.rosterId
       );
       if (!target) {
-        addToast('Target class no longer exists', 'error');
+        addToast(
+          t('toasts.classLink.targetMissing', {
+            defaultValue: 'Target class no longer exists',
+          }),
+          'error'
+        );
         onClose();
         return;
       }
@@ -112,22 +133,43 @@ export const ClassLinkImportDialog: React.FC<ClassLinkImportDialogProps> = ({
       );
       await updateRoster(mode.rosterId, { students: result.students });
       if (result.addedCount === 0 && result.matchedCount === 0) {
-        addToast(`No students found in ${cls.title}`, 'info');
+        addToast(
+          t('toasts.classLink.noStudents', {
+            defaultValue: 'No students found in {{name}}',
+            name: cls.title,
+          }),
+          'info'
+        );
       } else if (result.addedCount === 0) {
         addToast(
-          `All ${result.matchedCount} students already in ${target.name}`,
+          t('toasts.classLink.allAlreadyPresent', {
+            count: result.matchedCount,
+            defaultValue: 'All {{count}} students already in {{name}}',
+            name: target.name,
+          }),
           'info'
         );
       } else {
         addToast(
-          `Added ${result.addedCount} student${result.addedCount === 1 ? '' : 's'} to ${target.name}`,
+          t('toasts.classLink.addedStudents', {
+            count: result.addedCount,
+            defaultValue: 'Added {{count}} student to {{name}}',
+            defaultValue_other: 'Added {{count}} students to {{name}}',
+            name: target.name,
+          }),
           'success'
         );
       }
       onClose();
     } catch (err) {
       console.error(err);
-      addToast(`Failed to sync ${cls.title}`, 'error');
+      addToast(
+        t('toasts.classLink.syncFailed', {
+          defaultValue: 'Failed to sync {{name}}',
+          name: cls.title,
+        }),
+        'error'
+      );
     } finally {
       setPendingId(null);
     }

--- a/components/classes/ClassLinkImportDialog.tsx
+++ b/components/classes/ClassLinkImportDialog.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
-import { Loader2, RefreshCw, AlertCircle } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { Download, Loader2, RefreshCw, AlertCircle } from 'lucide-react';
 import { ClassLinkClass, ClassRoster, Student } from '@/types';
 import { Modal } from '@/components/common/Modal';
 import { classLinkService } from '@/utils/classlinkService';
@@ -30,6 +31,7 @@ export const ClassLinkImportDialog: React.FC<ClassLinkImportDialogProps> = ({
   mode,
   onClose,
 }) => {
+  const { t } = useTranslation();
   const { rosters, addRoster, updateRoster, addToast } = useDashboard();
 
   const [loading, setLoading] = useState(false);
@@ -133,12 +135,22 @@ export const ClassLinkImportDialog: React.FC<ClassLinkImportDialogProps> = ({
 
   const title =
     mode.kind === 'new'
-      ? 'Import from ClassLink'
-      : `Sync "${mode.rosterName}" with ClassLink`;
+      ? t('sidebar.classes.classLinkImportTitle', {
+          defaultValue: 'Import from ClassLink',
+        })
+      : t('sidebar.classes.classLinkMergeTitle', {
+          defaultValue: 'Sync "{{name}}" with ClassLink',
+          name: mode.rosterName,
+        });
   const subtitle =
     mode.kind === 'new'
-      ? 'Pick a class to import as a new roster.'
-      : 'Pick the ClassLink class whose students should be pulled in. Existing students are preserved.';
+      ? t('sidebar.classes.classLinkImportSubtitle', {
+          defaultValue: 'Pick a class to import as a new roster.',
+        })
+      : t('sidebar.classes.classLinkMergeSubtitle', {
+          defaultValue:
+            'Pick the ClassLink class whose students should be pulled in. Existing students are preserved.',
+        });
 
   return (
     <Modal
@@ -154,7 +166,9 @@ export const ClassLinkImportDialog: React.FC<ClassLinkImportDialogProps> = ({
         <div className="flex flex-col items-center justify-center gap-3 py-10 text-slate-400">
           <Loader2 className="w-8 h-8 animate-spin text-brand-blue-primary" />
           <p className="text-xxs font-bold uppercase tracking-widest">
-            Connecting to ClassLink…
+            {t('sidebar.classes.classLinkConnecting', {
+              defaultValue: 'Connecting to ClassLink…',
+            })}
           </p>
         </div>
       )}
@@ -168,7 +182,9 @@ export const ClassLinkImportDialog: React.FC<ClassLinkImportDialogProps> = ({
 
       {!loading && !error && classes.length === 0 && (
         <div className="py-10 text-center text-slate-400 text-sm italic">
-          No classes found in ClassLink.
+          {t('sidebar.classes.classLinkNoClasses', {
+            defaultValue: 'No classes found in ClassLink.',
+          })}
         </div>
       )}
 
@@ -187,7 +203,11 @@ export const ClassLinkImportDialog: React.FC<ClassLinkImportDialogProps> = ({
                     {cls.title}
                   </div>
                   <div className="text-xxs font-semibold text-slate-400 uppercase tracking-widest">
-                    {count} Students
+                    {t('sidebar.classes.studentCount', {
+                      count,
+                      defaultValue: '{{count}} Student',
+                      defaultValue_other: '{{count}} Students',
+                    })}
                     {cls.classCode ? ` · ${cls.classCode}` : ''}
                   </div>
                 </div>
@@ -202,10 +222,18 @@ export const ClassLinkImportDialog: React.FC<ClassLinkImportDialogProps> = ({
                 >
                   {isPending ? (
                     <Loader2 className="w-3 h-3 animate-spin" />
+                  ) : mode.kind === 'new' ? (
+                    <Download className="w-3 h-3" />
                   ) : (
                     <RefreshCw className="w-3 h-3" />
                   )}
-                  {mode.kind === 'new' ? 'Import' : 'Merge'}
+                  {mode.kind === 'new'
+                    ? t('sidebar.classes.classLinkImport', {
+                        defaultValue: 'Import',
+                      })
+                    : t('sidebar.classes.classLinkMerge', {
+                        defaultValue: 'Merge',
+                      })}
                 </button>
               </div>
             );

--- a/components/classes/ClassLinkImportDialog.tsx
+++ b/components/classes/ClassLinkImportDialog.tsx
@@ -1,0 +1,217 @@
+import React, { useEffect, useState } from 'react';
+import { Loader2, RefreshCw, AlertCircle } from 'lucide-react';
+import { ClassLinkClass, ClassRoster, Student } from '@/types';
+import { Modal } from '@/components/common/Modal';
+import { classLinkService } from '@/utils/classlinkService';
+import { useDashboard } from '@/context/useDashboard';
+import { mergeClassLinkStudents } from './mergeClassLinkStudents';
+
+export type ClassLinkDialogMode =
+  | { kind: 'new' }
+  | { kind: 'merge'; rosterId: string; rosterName: string };
+
+interface ClassLinkImportDialogProps {
+  isOpen: boolean;
+  mode: ClassLinkDialogMode;
+  onClose: () => void;
+}
+
+/**
+ * Unified ClassLink dialog.
+ *
+ * - `new` mode: lists all ClassLink classes with an "Import" action that
+ *   creates a fresh local roster (name derived from subject/title/classCode).
+ * - `merge` mode: lists all ClassLink classes with a "Merge" action that
+ *   pulls missing students into the existing local roster (dedup by
+ *   `classLinkSourcedId` → normalized name → append).
+ */
+export const ClassLinkImportDialog: React.FC<ClassLinkImportDialogProps> = ({
+  isOpen,
+  mode,
+  onClose,
+}) => {
+  const { rosters, addRoster, updateRoster, addToast } = useDashboard();
+
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [classes, setClasses] = useState<ClassLinkClass[]>([]);
+  const [studentsByClass, setStudentsByClass] = useState<
+    Record<string, import('@/types').ClassLinkStudent[]>
+  >({});
+  const [pendingId, setPendingId] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    setClasses([]);
+    setStudentsByClass({});
+    void (async () => {
+      try {
+        const data = await classLinkService.getRosters(true);
+        if (cancelled) return;
+        setClasses(data.classes);
+        setStudentsByClass(data.studentsByClass);
+      } catch (err) {
+        if (cancelled) return;
+        console.error('Failed to fetch from ClassLink', err);
+        setError('Failed to fetch from ClassLink. Check console.');
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [isOpen]);
+
+  const handleImportNew = async (cls: ClassLinkClass) => {
+    setPendingId(cls.sourcedId);
+    try {
+      const students: Student[] = (studentsByClass[cls.sourcedId] ?? []).map(
+        (s) => ({
+          id: crypto.randomUUID(),
+          firstName: s.givenName,
+          lastName: s.familyName,
+          pin: '',
+          classLinkSourcedId: s.sourcedId,
+        })
+      );
+      const subjectPrefix = cls.subject ? `${cls.subject} - ` : '';
+      const codeSuffix = cls.classCode ? ` (${cls.classCode})` : '';
+      const displayName = `${subjectPrefix}${cls.title}${codeSuffix}`;
+      await addRoster(displayName, students);
+      addToast(`Imported ${cls.title}`, 'success');
+      onClose();
+    } catch (err) {
+      console.error(err);
+      addToast(`Failed to import ${cls.title}`, 'error');
+    } finally {
+      setPendingId(null);
+    }
+  };
+
+  const handleMergeInto = async (cls: ClassLinkClass) => {
+    if (mode.kind !== 'merge') return;
+    setPendingId(cls.sourcedId);
+    try {
+      const target: ClassRoster | undefined = rosters.find(
+        (r) => r.id === mode.rosterId
+      );
+      if (!target) {
+        addToast('Target class no longer exists', 'error');
+        onClose();
+        return;
+      }
+      const result = mergeClassLinkStudents(
+        target.students,
+        studentsByClass[cls.sourcedId] ?? []
+      );
+      await updateRoster(mode.rosterId, { students: result.students });
+      if (result.addedCount === 0 && result.matchedCount === 0) {
+        addToast(`No students found in ${cls.title}`, 'info');
+      } else if (result.addedCount === 0) {
+        addToast(
+          `All ${result.matchedCount} students already in ${target.name}`,
+          'info'
+        );
+      } else {
+        addToast(
+          `Added ${result.addedCount} student${result.addedCount === 1 ? '' : 's'} to ${target.name}`,
+          'success'
+        );
+      }
+      onClose();
+    } catch (err) {
+      console.error(err);
+      addToast(`Failed to sync ${cls.title}`, 'error');
+    } finally {
+      setPendingId(null);
+    }
+  };
+
+  const title =
+    mode.kind === 'new'
+      ? 'Import from ClassLink'
+      : `Sync "${mode.rosterName}" with ClassLink`;
+  const subtitle =
+    mode.kind === 'new'
+      ? 'Pick a class to import as a new roster.'
+      : 'Pick the ClassLink class whose students should be pulled in. Existing students are preserved.';
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      maxWidth="max-w-lg"
+      title={title}
+      contentClassName="px-6 pb-6"
+    >
+      <p className="text-xs text-slate-500 mb-4">{subtitle}</p>
+
+      {loading && (
+        <div className="flex flex-col items-center justify-center gap-3 py-10 text-slate-400">
+          <Loader2 className="w-8 h-8 animate-spin text-brand-blue-primary" />
+          <p className="text-xxs font-bold uppercase tracking-widest">
+            Connecting to ClassLink…
+          </p>
+        </div>
+      )}
+
+      {error && !loading && (
+        <div className="flex items-start gap-2 p-3 bg-red-50 border border-red-200 rounded-xl text-red-700 text-xs">
+          <AlertCircle className="w-4 h-4 shrink-0 mt-0.5" />
+          <span>{error}</span>
+        </div>
+      )}
+
+      {!loading && !error && classes.length === 0 && (
+        <div className="py-10 text-center text-slate-400 text-sm italic">
+          No classes found in ClassLink.
+        </div>
+      )}
+
+      {!loading && !error && classes.length > 0 && (
+        <div className="flex flex-col gap-2 max-h-[60vh] overflow-y-auto custom-scrollbar pr-1">
+          {classes.map((cls) => {
+            const count = studentsByClass[cls.sourcedId]?.length ?? 0;
+            const isPending = pendingId === cls.sourcedId;
+            return (
+              <div
+                key={cls.sourcedId}
+                className="flex items-center justify-between gap-3 p-3 border border-slate-200 rounded-xl bg-white hover:border-brand-blue-primary hover:shadow-sm transition-all"
+              >
+                <div className="min-w-0 flex-1">
+                  <div className="text-sm font-bold text-slate-800 truncate">
+                    {cls.title}
+                  </div>
+                  <div className="text-xxs font-semibold text-slate-400 uppercase tracking-widest">
+                    {count} Students
+                    {cls.classCode ? ` · ${cls.classCode}` : ''}
+                  </div>
+                </div>
+                <button
+                  onClick={() =>
+                    mode.kind === 'new'
+                      ? void handleImportNew(cls)
+                      : void handleMergeInto(cls)
+                  }
+                  disabled={isPending}
+                  className="shrink-0 bg-brand-blue-primary text-white px-3 py-2 rounded-xl text-xxs font-bold uppercase tracking-wider hover:bg-brand-blue-dark transition-colors disabled:opacity-50 flex items-center gap-1.5"
+                >
+                  {isPending ? (
+                    <Loader2 className="w-3 h-3 animate-spin" />
+                  ) : (
+                    <RefreshCw className="w-3 h-3" />
+                  )}
+                  {mode.kind === 'new' ? 'Import' : 'Merge'}
+                </button>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </Modal>
+  );
+};

--- a/components/classes/RosterEditorModal.test.tsx
+++ b/components/classes/RosterEditorModal.test.tsx
@@ -1,0 +1,262 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi } from 'vitest';
+import { RosterEditorModal } from './RosterEditorModal';
+import { ClassRoster } from '@/types';
+
+describe('RosterEditorModal', () => {
+  it('renders single name field by default for a new roster', () => {
+    render(
+      <RosterEditorModal
+        isOpen={true}
+        roster={null}
+        onClose={vi.fn()}
+        onSave={vi.fn()}
+      />
+    );
+
+    expect(screen.getByPlaceholderText(/class name/i)).toBeInTheDocument();
+    expect(
+      screen.getByPlaceholderText(/paste full names or group names here/i)
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByPlaceholderText(/paste first names/i)
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /\+ last name/i })
+    ).toBeInTheDocument();
+  });
+
+  it('toggles to dual name fields', async () => {
+    const user = userEvent.setup();
+    render(
+      <RosterEditorModal
+        isOpen={true}
+        roster={null}
+        onClose={vi.fn()}
+        onSave={vi.fn()}
+      />
+    );
+
+    await user.click(screen.getByRole('button', { name: /\+ last name/i }));
+
+    expect(
+      screen.getByPlaceholderText(/paste first names/i)
+    ).toBeInTheDocument();
+    expect(
+      screen.getByPlaceholderText(/paste last names/i)
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /remove/i })).toBeInTheDocument();
+  });
+
+  it('calls onSave with single-field full names and closes', async () => {
+    const user = userEvent.setup();
+    const onSave = vi.fn().mockResolvedValue(undefined);
+    const onClose = vi.fn();
+
+    render(
+      <RosterEditorModal
+        isOpen={true}
+        roster={null}
+        onClose={onClose}
+        onSave={onSave}
+      />
+    );
+
+    await user.type(screen.getByPlaceholderText(/class name/i), 'New Class');
+    await user.type(
+      screen.getByPlaceholderText(/paste full names or group names here/i),
+      'Alice Smith\nBob Jones'
+    );
+    await user.click(screen.getByRole('button', { name: /save/i }));
+
+    await waitFor(() => {
+      expect(onSave).toHaveBeenCalledWith('New Class', [
+        expect.objectContaining({ firstName: 'Alice Smith', lastName: '' }),
+        expect.objectContaining({ firstName: 'Bob Jones', lastName: '' }),
+      ]);
+    });
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('calls onSave with split first/last names when in dual mode', async () => {
+    const user = userEvent.setup();
+    const onSave = vi.fn().mockResolvedValue(undefined);
+    const existing: ClassRoster = {
+      id: 'r1',
+      name: 'Existing Class',
+      students: [],
+      driveFileId: null,
+      studentCount: 0,
+      createdAt: Date.now(),
+    };
+
+    render(
+      <RosterEditorModal
+        isOpen={true}
+        roster={existing}
+        onClose={vi.fn()}
+        onSave={onSave}
+      />
+    );
+
+    await user.click(screen.getByRole('button', { name: /\+ last name/i }));
+    const firsts = screen.getByPlaceholderText(/paste first names/i);
+    await user.clear(firsts);
+    await user.type(firsts, 'Alice\nBob');
+    await user.type(
+      screen.getByPlaceholderText(/paste last names/i),
+      'Smith\nJones'
+    );
+    await user.click(screen.getByRole('button', { name: /save/i }));
+
+    await waitFor(() => {
+      expect(onSave).toHaveBeenCalledWith(
+        'Existing Class',
+        expect.arrayContaining([
+          expect.objectContaining({ firstName: 'Alice', lastName: 'Smith' }),
+          expect.objectContaining({ firstName: 'Bob', lastName: 'Jones' }),
+        ])
+      );
+    });
+  });
+
+  it('splits full names when toggling single → dual', async () => {
+    const user = userEvent.setup();
+    render(
+      <RosterEditorModal
+        isOpen={true}
+        roster={null}
+        onClose={vi.fn()}
+        onSave={vi.fn()}
+      />
+    );
+
+    await user.type(
+      screen.getByPlaceholderText(/paste full names or group names here/i),
+      'Alice Smith\nBob Jones\nCharlie'
+    );
+    await user.click(screen.getByRole('button', { name: /\+ last name/i }));
+
+    expect(screen.getByPlaceholderText(/paste first names/i)).toHaveValue(
+      'Alice\nBob\nCharlie'
+    );
+    expect(screen.getByPlaceholderText(/paste last names/i)).toHaveValue(
+      'Smith\nJones\n'
+    );
+  });
+
+  it('merges names when toggling dual → single', async () => {
+    const user = userEvent.setup();
+    render(
+      <RosterEditorModal
+        isOpen={true}
+        roster={null}
+        onClose={vi.fn()}
+        onSave={vi.fn()}
+      />
+    );
+
+    await user.click(screen.getByRole('button', { name: /\+ last name/i }));
+    await user.type(
+      screen.getByPlaceholderText(/paste first names/i),
+      'Alice\nBob'
+    );
+    await user.type(
+      screen.getByPlaceholderText(/paste last names/i),
+      'Smith\nJones'
+    );
+    await user.click(screen.getByRole('button', { name: /remove/i }));
+
+    expect(
+      screen.getByPlaceholderText(/paste full names or group names here/i)
+    ).toHaveValue('Alice Smith\nBob Jones');
+  });
+
+  it('shows "+ Quiz PIN" button and toggles PIN column', async () => {
+    const user = userEvent.setup();
+    render(
+      <RosterEditorModal
+        isOpen={true}
+        roster={null}
+        onClose={vi.fn()}
+        onSave={vi.fn()}
+      />
+    );
+
+    expect(screen.queryByPlaceholderText(/^01/)).not.toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: /\+ quiz pin/i }));
+    expect(screen.getByPlaceholderText(/^01/)).toBeInTheDocument();
+  });
+
+  it('persists PINs through save', async () => {
+    const user = userEvent.setup();
+    const onSave = vi.fn().mockResolvedValue(undefined);
+
+    render(
+      <RosterEditorModal
+        isOpen={true}
+        roster={null}
+        onClose={vi.fn()}
+        onSave={onSave}
+      />
+    );
+
+    await user.type(screen.getByPlaceholderText(/class name/i), 'PIN Class');
+    await user.type(
+      screen.getByPlaceholderText(/paste full names or group names here/i),
+      'Alice\nBob'
+    );
+    await user.click(screen.getByRole('button', { name: /\+ quiz pin/i }));
+    await user.type(screen.getByPlaceholderText(/^01/), 'dragon\n42');
+    await user.click(screen.getByRole('button', { name: /save/i }));
+
+    await waitFor(() => {
+      expect(onSave).toHaveBeenCalledWith('PIN Class', [
+        expect.objectContaining({ firstName: 'Alice', pin: 'dragon' }),
+        expect.objectContaining({ firstName: 'Bob', pin: '42' }),
+      ]);
+    });
+  });
+
+  it('shows duplicate PIN warning', async () => {
+    const user = userEvent.setup();
+    render(
+      <RosterEditorModal
+        isOpen={true}
+        roster={null}
+        onClose={vi.fn()}
+        onSave={vi.fn()}
+      />
+    );
+
+    await user.type(
+      screen.getByPlaceholderText(/paste full names or group names here/i),
+      'Alice\nBob'
+    );
+    await user.click(screen.getByRole('button', { name: /\+ quiz pin/i }));
+    await user.type(screen.getByPlaceholderText(/^01/), 'same\nsame');
+
+    await waitFor(() => {
+      expect(screen.getByText(/duplicate pins/i)).toBeInTheDocument();
+    });
+  });
+
+  it('does not call onSave when name is empty', async () => {
+    const user = userEvent.setup();
+    const onSave = vi.fn();
+    render(
+      <RosterEditorModal
+        isOpen={true}
+        roster={null}
+        onClose={vi.fn()}
+        onSave={onSave}
+      />
+    );
+
+    const saveBtn = screen.getByRole('button', { name: /save/i });
+    expect(saveBtn).toBeDisabled();
+    await user.click(saveBtn);
+    expect(onSave).not.toHaveBeenCalled();
+  });
+});

--- a/components/classes/RosterEditorModal.tsx
+++ b/components/classes/RosterEditorModal.tsx
@@ -86,7 +86,10 @@ export const RosterEditorModal: React.FC<RosterEditorModalProps> = ({
         {duplicatePins.size > 0 && (
           <div className="flex items-center gap-1.5 px-3 py-1.5 bg-yellow-50 border border-yellow-300 rounded-lg text-yellow-800 text-xxs font-semibold shrink-0">
             <AlertTriangle size={12} className="text-yellow-600 shrink-0" />
-            Duplicate PINs: {[...duplicatePins].join(', ')}
+            {t('sidebar.classes.duplicatePins', {
+              defaultValue: 'Duplicate PINs: {{pins}}',
+              pins: [...duplicatePins].join(', '),
+            })}
           </div>
         )}
 
@@ -104,7 +107,13 @@ export const RosterEditorModal: React.FC<RosterEditorModalProps> = ({
           <div className="flex flex-col h-full min-h-0">
             <div className="flex justify-between items-end mb-1">
               <label className="text-xxs font-bold text-slate-500 uppercase tracking-widest">
-                {showLastNames ? 'First Names' : 'Names (One per line)'}
+                {showLastNames
+                  ? t('sidebar.classes.firstNames', {
+                      defaultValue: 'First Names',
+                    })
+                  : t('sidebar.classes.namesOnePerLine', {
+                      defaultValue: 'Names (One per line)',
+                    })}
               </label>
               <div className="flex gap-2">
                 {!showLastNames && (
@@ -112,7 +121,9 @@ export const RosterEditorModal: React.FC<RosterEditorModalProps> = ({
                     onClick={handleToggleToLastNames}
                     className="text-xxs text-blue-600 hover:text-blue-700 font-black uppercase tracking-wider"
                   >
-                    + Last Name
+                    {t('sidebar.classes.addLastName', {
+                      defaultValue: '+ Last Name',
+                    })}
                   </button>
                 )}
                 {!showPins && (
@@ -120,7 +131,9 @@ export const RosterEditorModal: React.FC<RosterEditorModalProps> = ({
                     onClick={() => setShowPins(true)}
                     className="text-xxs text-violet-600 hover:text-violet-700 font-black uppercase tracking-wider"
                   >
-                    + Quiz PIN
+                    {t('sidebar.classes.addQuizPin', {
+                      defaultValue: '+ Quiz PIN',
+                    })}
                   </button>
                 )}
               </div>
@@ -131,8 +144,12 @@ export const RosterEditorModal: React.FC<RosterEditorModalProps> = ({
               onChange={(e) => setFirsts(e.target.value)}
               placeholder={
                 showLastNames
-                  ? 'Paste first names...'
-                  : 'Paste full names or group names here...'
+                  ? t('sidebar.classes.pasteFirstNames', {
+                      defaultValue: 'Paste first names...',
+                    })
+                  : t('sidebar.classes.pasteFullNames', {
+                      defaultValue: 'Paste full names or group names here...',
+                    })
               }
             />
           </div>
@@ -140,20 +157,24 @@ export const RosterEditorModal: React.FC<RosterEditorModalProps> = ({
             <div className="flex flex-col h-full min-h-0">
               <div className="flex justify-between items-end mb-1">
                 <label className="text-xxs font-bold text-slate-500 uppercase tracking-widest">
-                  Last Names
+                  {t('sidebar.classes.lastNames', {
+                    defaultValue: 'Last Names',
+                  })}
                 </label>
                 <button
                   onClick={handleToggleToSingleField}
                   className="text-xxs text-slate-400 hover:text-red-500 font-black uppercase tracking-wider transition-colors"
                 >
-                  Remove
+                  {t('sidebar.classes.remove', { defaultValue: 'Remove' })}
                 </button>
               </div>
               <textarea
                 className="flex-1 border border-slate-200 focus:border-blue-400 p-3 rounded-xl resize-none text-xs font-mono focus:ring-2 focus:ring-blue-100 outline-none transition-all custom-scrollbar bg-slate-50/30 min-h-0"
                 value={lasts}
                 onChange={(e) => setLasts(e.target.value)}
-                placeholder="Paste last names..."
+                placeholder={t('sidebar.classes.pasteLastNames', {
+                  defaultValue: 'Paste last names...',
+                })}
               />
             </div>
           )}
@@ -161,13 +182,13 @@ export const RosterEditorModal: React.FC<RosterEditorModalProps> = ({
             <div className="flex flex-col h-full min-h-0 w-24">
               <div className="flex justify-between items-end mb-1">
                 <label className="text-xxs font-bold text-slate-500 uppercase tracking-widest">
-                  Quiz PIN
+                  {t('sidebar.classes.quizPin', { defaultValue: 'Quiz PIN' })}
                 </label>
                 <button
                   onClick={() => setShowPins(false)}
                   className="text-xxs text-slate-400 hover:text-red-500 font-black uppercase tracking-wider transition-colors"
                 >
-                  Hide
+                  {t('sidebar.classes.hide', { defaultValue: 'Hide' })}
                 </button>
               </div>
               <textarea
@@ -181,8 +202,11 @@ export const RosterEditorModal: React.FC<RosterEditorModalProps> = ({
         </div>
 
         <div className="text-xxs text-slate-400 font-medium shrink-0">
-          {previewStudents.length}{' '}
-          {previewStudents.length === 1 ? 'student' : 'students'}
+          {t('sidebar.classes.studentCount', {
+            count: previewStudents.length,
+            defaultValue: '{{count}} Student',
+            defaultValue_other: '{{count}} Students',
+          })}
         </div>
       </div>
     </Modal>

--- a/components/classes/RosterEditorModal.tsx
+++ b/components/classes/RosterEditorModal.tsx
@@ -53,7 +53,7 @@ export const RosterEditorModal: React.FC<RosterEditorModalProps> = ({
       isOpen={isOpen}
       onClose={onClose}
       maxWidth="max-w-2xl"
-      className="h-[85vh]"
+      className="max-h-[85vh]"
       contentClassName="px-6 pb-6 flex flex-col"
       title={roster ? 'Edit Class' : 'New Class'}
     >

--- a/components/classes/RosterEditorModal.tsx
+++ b/components/classes/RosterEditorModal.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 import { Save, AlertTriangle } from 'lucide-react';
 import { Student, ClassRoster } from '@/types';
 import { Modal } from '@/components/common/Modal';
@@ -24,6 +25,7 @@ export const RosterEditorModal: React.FC<RosterEditorModalProps> = ({
   onClose,
   onSave,
 }) => {
+  const { t } = useTranslation();
   const {
     name,
     setName,
@@ -55,13 +57,19 @@ export const RosterEditorModal: React.FC<RosterEditorModalProps> = ({
       maxWidth="max-w-2xl"
       className="max-h-[85vh]"
       contentClassName="px-6 pb-6 flex flex-col"
-      title={roster ? 'Edit Class' : 'New Class'}
+      title={
+        roster
+          ? t('sidebar.classes.editClassTitle', { defaultValue: 'Edit Class' })
+          : t('sidebar.classes.newClassTitle', { defaultValue: 'New Class' })
+      }
     >
       <div className="flex flex-col h-full gap-3 min-h-0">
         <div className="flex items-center gap-3 shrink-0">
           <input
             className="flex-1 min-w-0 px-3 py-2 text-sm border border-slate-200 rounded-xl focus:outline-none focus:ring-2 focus:ring-brand-blue-primary focus:border-brand-blue-primary font-bold"
-            placeholder="Class Name"
+            placeholder={t('sidebar.classes.classNamePlaceholder', {
+              defaultValue: 'Class Name',
+            })}
             value={name}
             onChange={(e) => setName(e.target.value)}
             autoFocus
@@ -71,7 +79,7 @@ export const RosterEditorModal: React.FC<RosterEditorModalProps> = ({
             disabled={!name.trim()}
             className="bg-brand-blue-primary text-white px-4 py-2 rounded-xl flex gap-1.5 items-center text-xs font-bold uppercase tracking-wider hover:bg-brand-blue-dark shadow-sm transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
           >
-            <Save size={14} /> Save
+            <Save size={14} /> {t('common.save', { defaultValue: 'Save' })}
           </button>
         </div>
 

--- a/components/classes/RosterEditorModal.tsx
+++ b/components/classes/RosterEditorModal.tsx
@@ -1,0 +1,182 @@
+import React from 'react';
+import { Save, AlertTriangle } from 'lucide-react';
+import { Student, ClassRoster } from '@/types';
+import { Modal } from '@/components/common/Modal';
+import { useRosterEditorState } from './useRosterEditorState';
+
+interface RosterEditorModalProps {
+  isOpen: boolean;
+  /** Pass `null` to create a new roster. */
+  roster: ClassRoster | null;
+  onClose: () => void;
+  onSave: (name: string, students: Student[]) => Promise<void> | void;
+}
+
+/**
+ * Account-level roster editor. Used by the "My Classes" sidebar page.
+ *
+ * Wraps the shared `useRosterEditorState` hook in a portal Modal — no
+ * widget chrome.
+ */
+export const RosterEditorModal: React.FC<RosterEditorModalProps> = ({
+  isOpen,
+  roster,
+  onClose,
+  onSave,
+}) => {
+  const {
+    name,
+    setName,
+    firsts,
+    setFirsts,
+    lasts,
+    setLasts,
+    pins,
+    setPins,
+    showPins,
+    setShowPins,
+    showLastNames,
+    handleToggleToLastNames,
+    handleToggleToSingleField,
+    previewStudents,
+    duplicatePins,
+  } = useRosterEditorState(roster);
+
+  const handleSave = async () => {
+    if (!name.trim()) return;
+    await onSave(name.trim(), previewStudents);
+    onClose();
+  };
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      maxWidth="max-w-2xl"
+      className="h-[85vh]"
+      contentClassName="px-6 pb-6 flex flex-col"
+      title={roster ? 'Edit Class' : 'New Class'}
+    >
+      <div className="flex flex-col h-full gap-3 min-h-0">
+        <div className="flex items-center gap-3 shrink-0">
+          <input
+            className="flex-1 min-w-0 px-3 py-2 text-sm border border-slate-200 rounded-xl focus:outline-none focus:ring-2 focus:ring-brand-blue-primary focus:border-brand-blue-primary font-bold"
+            placeholder="Class Name"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            autoFocus
+          />
+          <button
+            onClick={handleSave}
+            disabled={!name.trim()}
+            className="bg-brand-blue-primary text-white px-4 py-2 rounded-xl flex gap-1.5 items-center text-xs font-bold uppercase tracking-wider hover:bg-brand-blue-dark shadow-sm transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            <Save size={14} /> Save
+          </button>
+        </div>
+
+        {duplicatePins.size > 0 && (
+          <div className="flex items-center gap-1.5 px-3 py-1.5 bg-yellow-50 border border-yellow-300 rounded-lg text-yellow-800 text-xxs font-semibold shrink-0">
+            <AlertTriangle size={12} className="text-yellow-600 shrink-0" />
+            Duplicate PINs: {[...duplicatePins].join(', ')}
+          </div>
+        )}
+
+        <div
+          className={`grid ${
+            showLastNames && showPins
+              ? 'grid-cols-[1fr_1fr_auto]'
+              : showLastNames
+                ? 'grid-cols-2'
+                : showPins
+                  ? 'grid-cols-[1fr_auto]'
+                  : 'grid-cols-1'
+          } gap-3 flex-1 min-h-0`}
+        >
+          <div className="flex flex-col h-full min-h-0">
+            <div className="flex justify-between items-end mb-1">
+              <label className="text-xxs font-bold text-slate-500 uppercase tracking-widest">
+                {showLastNames ? 'First Names' : 'Names (One per line)'}
+              </label>
+              <div className="flex gap-2">
+                {!showLastNames && (
+                  <button
+                    onClick={handleToggleToLastNames}
+                    className="text-xxs text-blue-600 hover:text-blue-700 font-black uppercase tracking-wider"
+                  >
+                    + Last Name
+                  </button>
+                )}
+                {!showPins && (
+                  <button
+                    onClick={() => setShowPins(true)}
+                    className="text-xxs text-violet-600 hover:text-violet-700 font-black uppercase tracking-wider"
+                  >
+                    + Quiz PIN
+                  </button>
+                )}
+              </div>
+            </div>
+            <textarea
+              className="flex-1 border border-slate-200 focus:border-blue-400 p-3 rounded-xl resize-none text-xs font-mono focus:ring-2 focus:ring-blue-100 outline-none transition-all custom-scrollbar bg-slate-50/30 min-h-0"
+              value={firsts}
+              onChange={(e) => setFirsts(e.target.value)}
+              placeholder={
+                showLastNames
+                  ? 'Paste first names...'
+                  : 'Paste full names or group names here...'
+              }
+            />
+          </div>
+          {showLastNames && (
+            <div className="flex flex-col h-full min-h-0">
+              <div className="flex justify-between items-end mb-1">
+                <label className="text-xxs font-bold text-slate-500 uppercase tracking-widest">
+                  Last Names
+                </label>
+                <button
+                  onClick={handleToggleToSingleField}
+                  className="text-xxs text-slate-400 hover:text-red-500 font-black uppercase tracking-wider transition-colors"
+                >
+                  Remove
+                </button>
+              </div>
+              <textarea
+                className="flex-1 border border-slate-200 focus:border-blue-400 p-3 rounded-xl resize-none text-xs font-mono focus:ring-2 focus:ring-blue-100 outline-none transition-all custom-scrollbar bg-slate-50/30 min-h-0"
+                value={lasts}
+                onChange={(e) => setLasts(e.target.value)}
+                placeholder="Paste last names..."
+              />
+            </div>
+          )}
+          {showPins && (
+            <div className="flex flex-col h-full min-h-0 w-24">
+              <div className="flex justify-between items-end mb-1">
+                <label className="text-xxs font-bold text-slate-500 uppercase tracking-widest">
+                  Quiz PIN
+                </label>
+                <button
+                  onClick={() => setShowPins(false)}
+                  className="text-xxs text-slate-400 hover:text-red-500 font-black uppercase tracking-wider transition-colors"
+                >
+                  Hide
+                </button>
+              </div>
+              <textarea
+                className="flex-1 border border-slate-200 focus:border-violet-400 p-3 rounded-xl resize-none text-xs font-mono focus:ring-2 focus:ring-violet-100 outline-none transition-all custom-scrollbar bg-slate-50/30 min-h-0"
+                value={pins}
+                onChange={(e) => setPins(e.target.value)}
+                placeholder={'01\n02\n03\n...'}
+              />
+            </div>
+          )}
+        </div>
+
+        <div className="text-xxs text-slate-400 font-medium shrink-0">
+          {previewStudents.length}{' '}
+          {previewStudents.length === 1 ? 'student' : 'students'}
+        </div>
+      </div>
+    </Modal>
+  );
+};

--- a/components/classes/RosterEditorModal.tsx
+++ b/components/classes/RosterEditorModal.tsx
@@ -195,7 +195,9 @@ export const RosterEditorModal: React.FC<RosterEditorModalProps> = ({
                 className="flex-1 border border-slate-200 focus:border-violet-400 p-3 rounded-xl resize-none text-xs font-mono focus:ring-2 focus:ring-violet-100 outline-none transition-all custom-scrollbar bg-slate-50/30 min-h-0"
                 value={pins}
                 onChange={(e) => setPins(e.target.value)}
-                placeholder={'01\n02\n03\n...'}
+                placeholder={t('sidebar.classes.quizPinPlaceholder', {
+                  defaultValue: '01\n02\n03\n...',
+                })}
               />
             </div>
           )}

--- a/components/classes/mergeClassLinkStudents.test.ts
+++ b/components/classes/mergeClassLinkStudents.test.ts
@@ -136,6 +136,20 @@ describe('mergeClassLinkStudents', () => {
     expect(result.students[1].pin).toBe('');
   });
 
+  it('matches across trailing/leading whitespace in either name component', () => {
+    const existing = [
+      makeLocal({ firstName: 'Ada ', lastName: ' Lovelace', pin: '01' }),
+    ];
+    const cl = [
+      makeCL({ sourcedId: 'cl-ada', givenName: 'Ada', familyName: 'Lovelace' }),
+    ];
+    const result = mergeClassLinkStudents(existing, cl);
+    expect(result.matchedCount).toBe(1);
+    expect(result.addedCount).toBe(0);
+    expect(result.students[0].classLinkSourcedId).toBe('cl-ada');
+    expect(result.students[0].pin).toBe('01');
+  });
+
   it('sourcedId match wins even if a different local row has matching name', () => {
     const existing = [
       makeLocal({

--- a/components/classes/mergeClassLinkStudents.test.ts
+++ b/components/classes/mergeClassLinkStudents.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect } from 'vitest';
+import { Student, ClassLinkStudent } from '@/types';
+import { mergeClassLinkStudents } from './mergeClassLinkStudents';
+
+const makeLocal = (overrides: Partial<Student> = {}): Student => ({
+  id: crypto.randomUUID(),
+  firstName: 'Local',
+  lastName: 'Student',
+  pin: '01',
+  ...overrides,
+});
+
+const makeCL = (
+  overrides: Partial<ClassLinkStudent> = {}
+): ClassLinkStudent => ({
+  sourcedId: 'cl-' + crypto.randomUUID(),
+  givenName: 'CL',
+  familyName: 'Student',
+  email: 'x@x.com',
+  ...overrides,
+});
+
+describe('mergeClassLinkStudents', () => {
+  it('appends new students when no existing roster', () => {
+    const cl = [makeCL({ givenName: 'Ada', familyName: 'Lovelace' })];
+    const result = mergeClassLinkStudents([], cl);
+    expect(result.addedCount).toBe(1);
+    expect(result.matchedCount).toBe(0);
+    expect(result.students).toHaveLength(1);
+    expect(result.students[0].firstName).toBe('Ada');
+    expect(result.students[0].classLinkSourcedId).toBe(cl[0].sourcedId);
+    expect(result.students[0].pin).toBe(''); // caller assigns
+  });
+
+  it('matches by classLinkSourcedId and preserves id + pin (handles upstream rename)', () => {
+    const existing = makeLocal({
+      firstName: 'Old',
+      lastName: 'Name',
+      pin: '42',
+      classLinkSourcedId: 'stable-1',
+    });
+    const cl = [
+      makeCL({
+        sourcedId: 'stable-1',
+        givenName: 'Renamed',
+        familyName: 'Upstream',
+      }),
+    ];
+    const result = mergeClassLinkStudents([existing], cl);
+    expect(result.matchedCount).toBe(1);
+    expect(result.alreadySourcedCount).toBe(1);
+    expect(result.addedCount).toBe(0);
+    // Existing row untouched (we deliberately do NOT overwrite local name)
+    expect(result.students[0].firstName).toBe('Old');
+    expect(result.students[0].lastName).toBe('Name');
+    expect(result.students[0].pin).toBe('42');
+    expect(result.students[0].id).toBe(existing.id);
+  });
+
+  it('matches by normalized name and stamps classLinkSourcedId', () => {
+    const existing = makeLocal({
+      firstName: 'Ada',
+      lastName: 'Lovelace',
+      pin: '01',
+    });
+    const cl = [
+      makeCL({
+        sourcedId: 'cl-ada',
+        givenName: 'ada',
+        familyName: 'LOVELACE',
+      }),
+    ];
+    const result = mergeClassLinkStudents([existing], cl);
+    expect(result.matchedCount).toBe(1);
+    expect(result.alreadySourcedCount).toBe(0);
+    expect(result.addedCount).toBe(0);
+    expect(result.students[0].id).toBe(existing.id);
+    expect(result.students[0].pin).toBe('01');
+    expect(result.students[0].classLinkSourcedId).toBe('cl-ada');
+  });
+
+  it('preserves local-only students (aides, kids not in SIS) — additive only', () => {
+    const existing = [
+      makeLocal({ firstName: 'Ada', lastName: 'Lovelace', pin: '01' }),
+      makeLocal({ firstName: 'Local', lastName: 'Aide', pin: '99' }),
+    ];
+    const cl = [
+      makeCL({ sourcedId: 'cl-ada', givenName: 'Ada', familyName: 'Lovelace' }),
+      makeCL({ sourcedId: 'cl-new', givenName: 'New', familyName: 'Kid' }),
+    ];
+    const result = mergeClassLinkStudents(existing, cl);
+    expect(result.addedCount).toBe(1);
+    expect(result.matchedCount).toBe(1);
+    // Local aide remains in result with their pin
+    const aide = result.students.find((s) => s.lastName === 'Aide');
+    expect(aide).toBeDefined();
+    expect(aide?.pin).toBe('99');
+  });
+
+  it('running merge twice is a no-op (sourcedIds already stamped)', () => {
+    const existing = [makeLocal({ firstName: 'Ada', lastName: 'Lovelace' })];
+    const cl = [
+      makeCL({ sourcedId: 'cl-ada', givenName: 'Ada', familyName: 'Lovelace' }),
+    ];
+    const first = mergeClassLinkStudents(existing, cl);
+    const second = mergeClassLinkStudents(first.students, cl);
+    expect(second.addedCount).toBe(0);
+    expect(second.alreadySourcedCount).toBe(1);
+    expect(second.students).toHaveLength(1);
+  });
+
+  it('handles name collision: two ClassLink students with same name', () => {
+    const existing = [
+      makeLocal({ firstName: 'Alex', lastName: 'Smith', pin: '01' }),
+    ];
+    const cl = [
+      makeCL({
+        sourcedId: 'cl-alex-1',
+        givenName: 'Alex',
+        familyName: 'Smith',
+      }),
+      makeCL({
+        sourcedId: 'cl-alex-2',
+        givenName: 'Alex',
+        familyName: 'Smith',
+      }),
+    ];
+    const result = mergeClassLinkStudents(existing, cl);
+    // First matches the local row; second is appended as a new student
+    expect(result.addedCount).toBe(1);
+    expect(result.matchedCount).toBe(1);
+    expect(result.students).toHaveLength(2);
+    expect(result.students[0].classLinkSourcedId).toBe('cl-alex-1');
+    expect(result.students[0].pin).toBe('01');
+    expect(result.students[1].classLinkSourcedId).toBe('cl-alex-2');
+    expect(result.students[1].pin).toBe('');
+  });
+
+  it('sourcedId match wins even if a different local row has matching name', () => {
+    const existing = [
+      makeLocal({
+        firstName: 'Ada',
+        lastName: 'Lovelace',
+        pin: '01',
+        classLinkSourcedId: 'cl-ada',
+      }),
+      // This row has the same name but no sourcedId
+      makeLocal({ firstName: 'Ada', lastName: 'Lovelace', pin: '77' }),
+    ];
+    const cl = [
+      makeCL({ sourcedId: 'cl-ada', givenName: 'Ada', familyName: 'Lovelace' }),
+    ];
+    const result = mergeClassLinkStudents(existing, cl);
+    expect(result.matchedCount).toBe(1);
+    expect(result.alreadySourcedCount).toBe(1);
+    expect(result.addedCount).toBe(0);
+    // Second "Ada Lovelace" row is untouched (no sourcedId stamped)
+    expect(result.students[1].classLinkSourcedId).toBeUndefined();
+    expect(result.students[1].pin).toBe('77');
+  });
+});

--- a/components/classes/mergeClassLinkStudents.ts
+++ b/components/classes/mergeClassLinkStudents.ts
@@ -12,7 +12,7 @@ export interface MergeClassLinkResult {
 }
 
 const normalizeNameKey = (first: string, last: string): string =>
-  `${first}|${last}`.toLowerCase().trim();
+  `${first.trim()}|${last.trim()}`.toLowerCase();
 
 /**
  * Additive-only merge of ClassLink students into an existing local roster.

--- a/components/classes/mergeClassLinkStudents.ts
+++ b/components/classes/mergeClassLinkStudents.ts
@@ -1,0 +1,112 @@
+import { Student, ClassLinkStudent } from '@/types';
+
+export interface MergeClassLinkResult {
+  /** Merged roster students (pass directly to updateRoster). */
+  students: Student[];
+  /** Students newly appended from ClassLink. */
+  addedCount: number;
+  /** Students matched to an existing local entry (by sourcedId OR name). */
+  matchedCount: number;
+  /** Subset of matchedCount matched via stable classLinkSourcedId. */
+  alreadySourcedCount: number;
+}
+
+const normalizeNameKey = (first: string, last: string): string =>
+  `${first}|${last}`.toLowerCase().trim();
+
+/**
+ * Additive-only merge of ClassLink students into an existing local roster.
+ *
+ * Dedup algorithm (two-tier, stable):
+ *   1. Primary — match by `classLinkSourcedId`. Handles upstream renames.
+ *   2. Secondary — match by normalized first+last name. On match, stamp the
+ *      existing student with `classLinkSourcedId` (upgrade to stable link).
+ *      Each existing student can only be consumed once per merge run, which
+ *      avoids collisions when two ClassLink students share a name.
+ *   3. Else — append a new student with empty pin (useRosters auto-assigns).
+ *
+ * Preserves local `id` and `pin` for all matched students. Never removes
+ * local-only students (teacher aides / kids not in SIS stay untouched).
+ */
+export function mergeClassLinkStudents(
+  existing: Student[],
+  classLinkStudents: ClassLinkStudent[]
+): MergeClassLinkResult {
+  const result: Student[] = existing.map((s) => ({ ...s }));
+
+  // Index existing students for fast lookup.
+  const bySourcedId = new Map<string, number>();
+  result.forEach((s, i) => {
+    if (s.classLinkSourcedId) bySourcedId.set(s.classLinkSourcedId, i);
+  });
+
+  // Name index — each key maps to a queue of indices so we can "consume" one
+  // per merge call (prevents two incoming students with identical names from
+  // both matching the same local row).
+  const byName = new Map<string, number[]>();
+  result.forEach((s, i) => {
+    const key = normalizeNameKey(s.firstName, s.lastName);
+    const queue = byName.get(key);
+    if (queue) queue.push(i);
+    else byName.set(key, [i]);
+  });
+
+  // Track consumed indices so name-lookup never returns an already-matched row.
+  const consumed = new Set<number>();
+
+  let addedCount = 0;
+  let matchedCount = 0;
+  let alreadySourcedCount = 0;
+
+  for (const cls of classLinkStudents) {
+    // 1. Match by sourcedId
+    const sourcedIndex = bySourcedId.get(cls.sourcedId);
+    if (sourcedIndex !== undefined && !consumed.has(sourcedIndex)) {
+      consumed.add(sourcedIndex);
+      matchedCount += 1;
+      alreadySourcedCount += 1;
+      continue;
+    }
+
+    // 2. Match by normalized name
+    const key = normalizeNameKey(cls.givenName, cls.familyName);
+    const queue = byName.get(key);
+    let nameMatchIndex: number | undefined;
+    if (queue) {
+      while (queue.length > 0) {
+        const candidate = queue.shift();
+        if (candidate !== undefined && !consumed.has(candidate)) {
+          nameMatchIndex = candidate;
+          break;
+        }
+      }
+    }
+    if (nameMatchIndex !== undefined) {
+      consumed.add(nameMatchIndex);
+      matchedCount += 1;
+      // Stamp the sourcedId onto the existing row (preserve id + pin)
+      result[nameMatchIndex] = {
+        ...result[nameMatchIndex],
+        classLinkSourcedId: cls.sourcedId,
+      };
+      continue;
+    }
+
+    // 3. Append
+    result.push({
+      id: crypto.randomUUID(),
+      firstName: cls.givenName,
+      lastName: cls.familyName,
+      pin: '',
+      classLinkSourcedId: cls.sourcedId,
+    });
+    addedCount += 1;
+  }
+
+  return {
+    students: result,
+    addedCount,
+    matchedCount,
+    alreadySourcedCount,
+  };
+}

--- a/components/classes/useRosterEditorState.ts
+++ b/components/classes/useRosterEditorState.ts
@@ -1,0 +1,86 @@
+import { useState, useMemo } from 'react';
+import { Student, ClassRoster } from '@/types';
+import {
+  splitNames,
+  mergeNames,
+  generateStudentsList,
+  findDuplicatePins,
+} from '@/components/widgets/Classes/rosterUtils';
+
+/**
+ * Shared state hook for the roster editor UI.
+ *
+ * Consumed by both the in-widget RosterEditor (legacy) and the sidebar
+ * RosterEditorModal (new). Keeps all state + compute in one place so the
+ * two surfaces can't drift apart.
+ */
+export function useRosterEditorState(roster: ClassRoster | null) {
+  const [name, setName] = useState(roster?.name ?? '');
+  const [firsts, setFirsts] = useState(
+    roster?.students.map((s) => s.firstName).join('\n') ?? ''
+  );
+  const [lasts, setLasts] = useState(
+    roster?.students.map((s) => s.lastName).join('\n') ?? ''
+  );
+  const [pins, setPins] = useState(
+    roster?.students.map((s) => s.pin).join('\n') ?? ''
+  );
+  const [showPins, setShowPins] = useState(
+    roster?.students.some((s) => s.pin.trim() !== '') ?? false
+  );
+  const [showLastNames, setShowLastNames] = useState(
+    roster?.students.some((s) => s.lastName.trim() !== '') ?? false
+  );
+
+  const handleToggleToLastNames = () => {
+    if (!showLastNames) {
+      const { firsts: newFirsts, lasts: newLasts } = splitNames(firsts);
+      setFirsts(newFirsts.join('\n'));
+      setLasts(newLasts.join('\n'));
+      setShowLastNames(true);
+    }
+  };
+
+  const handleToggleToSingleField = () => {
+    if (showLastNames) {
+      const merged = mergeNames(firsts, lasts);
+      setFirsts(merged.join('\n'));
+      setLasts('');
+      setShowLastNames(false);
+    }
+  };
+
+  const previewStudents: Student[] = useMemo(
+    () =>
+      generateStudentsList(
+        firsts,
+        lasts,
+        roster?.students,
+        showPins ? pins : undefined
+      ),
+    [firsts, lasts, pins, showPins, roster?.students]
+  );
+
+  const duplicatePins = useMemo(
+    () => findDuplicatePins(previewStudents),
+    [previewStudents]
+  );
+
+  return {
+    name,
+    setName,
+    firsts,
+    setFirsts,
+    lasts,
+    setLasts,
+    pins,
+    setPins,
+    showPins,
+    setShowPins,
+    showLastNames,
+    handleToggleToLastNames,
+    handleToggleToSingleField,
+    previewStudents,
+    duplicatePins,
+  };
+}

--- a/components/layout/Dock.tsx
+++ b/components/layout/Dock.tsx
@@ -430,7 +430,11 @@ export const Dock: React.FC = () => {
   }, [libraryRef]);
 
   const openClassEditor = () => {
-    addWidget('classes');
+    // Roster management lives in the "My Classes" sidebar page now; dispatch
+    // the existing open-sidebar CustomEvent with a section hint.
+    window.dispatchEvent(
+      new CustomEvent('open-sidebar', { detail: { section: 'classes' } })
+    );
     setShowRosterMenu(false);
   };
 

--- a/components/layout/sidebar/Sidebar.tsx
+++ b/components/layout/sidebar/Sidebar.tsx
@@ -23,6 +23,7 @@ import {
   Globe,
   Building2,
   SlidersHorizontal,
+  Users,
 } from 'lucide-react';
 import { GoogleDriveIcon } from '@/components/common/GoogleDriveIcon';
 import { useGoogleDrive } from '@/hooks/useGoogleDrive';
@@ -39,11 +40,13 @@ import { SidebarGoogleDrive } from './SidebarGoogleDrive';
 import { SidebarLanguageRegion } from './SidebarLanguageRegion';
 import { SidebarBuildings } from './SidebarBuildings';
 import { SidebarPreferences } from './SidebarPreferences';
+import { SidebarClasses } from './SidebarClasses';
 
 type MenuSection =
   | 'main'
   | 'boards'
   | 'backgrounds'
+  | 'classes'
   | 'style'
   | 'quick-access'
   | 'google-drive'
@@ -67,6 +70,7 @@ export const Sidebar: React.FC = () => {
     clearAllWidgets,
     setGlobalStyle,
     addToast,
+    rosters,
   } = useDashboard();
 
   const { isConnected: isDriveConnected } = useGoogleDrive();
@@ -99,7 +103,11 @@ export const Sidebar: React.FC = () => {
   }, []);
 
   useEffect(() => {
-    const handleOpenSidebar = () => setIsOpen(true);
+    const handleOpenSidebar = (e: Event) => {
+      setIsOpen(true);
+      const detail = (e as CustomEvent<{ section?: MenuSection }>).detail;
+      if (detail?.section) setActiveSection(detail.section);
+    };
     window.addEventListener('open-sidebar', handleOpenSidebar);
 
     return () => {
@@ -394,6 +402,23 @@ export const Sidebar: React.FC = () => {
                     </span>
                     <ChevronRight className="w-4 h-4 text-slate-300 group-hover:text-brand-blue-primary transition-colors" />
                   </button>
+                  <button
+                    onClick={() => setActiveSection('classes')}
+                    className="group flex items-center gap-3 px-3 py-2.5 rounded-xl text-sm font-medium text-slate-700 hover:bg-brand-blue-lighter/40 transition-colors text-left"
+                  >
+                    <div className="w-8 h-8 rounded-lg bg-brand-blue-lighter group-hover:bg-brand-blue-lighter flex items-center justify-center transition-colors flex-shrink-0">
+                      <Users className="w-4 h-4 text-brand-blue-light group-hover:text-brand-blue-primary transition-colors" />
+                    </div>
+                    <span className="flex-grow text-[13px]">
+                      {t('sidebar.nav.classes', {
+                        defaultValue: 'My Classes',
+                      })}
+                    </span>
+                    <span className="text-xxs bg-brand-blue-lighter text-brand-blue-primary px-2 py-0.5 rounded-full font-bold">
+                      {rosters.length}
+                    </span>
+                    <ChevronRight className="w-4 h-4 text-slate-300 group-hover:text-brand-blue-primary transition-colors" />
+                  </button>
                 </div>
 
                 <div className="mx-5 my-2.5 border-t border-slate-100" />
@@ -516,6 +541,9 @@ export const Sidebar: React.FC = () => {
 
               {/* BACKGROUNDS SECTION */}
               <SidebarBackgrounds isVisible={activeSection === 'backgrounds'} />
+
+              {/* CLASSES SECTION */}
+              <SidebarClasses isVisible={activeSection === 'classes'} />
 
               {/* STYLE SECTION */}
               <StylePanel

--- a/components/layout/sidebar/SidebarClasses.tsx
+++ b/components/layout/sidebar/SidebarClasses.tsx
@@ -230,8 +230,11 @@ export const SidebarClasses: React.FC<SidebarClassesProps> = ({
                             {r.name}
                           </div>
                           <div className="text-xxs font-semibold text-slate-400 uppercase tracking-widest">
-                            {r.students.length}{' '}
-                            {r.students.length === 1 ? 'Student' : 'Students'}
+                            {t('sidebar.classes.studentCount', {
+                              count: r.students.length,
+                              defaultValue: '{{count}} Student',
+                              defaultValue_other: '{{count}} Students',
+                            })}
                           </div>
                         </div>
                         <div className="flex items-center gap-0.5 shrink-0">

--- a/components/layout/sidebar/SidebarClasses.tsx
+++ b/components/layout/sidebar/SidebarClasses.tsx
@@ -290,12 +290,15 @@ export const SidebarClasses: React.FC<SidebarClassesProps> = ({
         </div>
       </div>
 
-      <RosterEditorModal
-        isOpen={editingRosterId !== null}
-        roster={editingRoster}
-        onClose={() => setEditingRosterId(null)}
-        onSave={handleSaveRoster}
-      />
+      {editingRosterId !== null && (
+        <RosterEditorModal
+          key={editingRosterId}
+          isOpen
+          roster={editingRoster}
+          onClose={() => setEditingRosterId(null)}
+          onSave={handleSaveRoster}
+        />
+      )}
 
       {classLinkMode && (
         <ClassLinkImportDialog

--- a/components/layout/sidebar/SidebarClasses.tsx
+++ b/components/layout/sidebar/SidebarClasses.tsx
@@ -1,0 +1,309 @@
+import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import {
+  Users,
+  Plus,
+  Star,
+  Pencil,
+  Trash2,
+  RefreshCw,
+  Download,
+} from 'lucide-react';
+
+import { useDashboard } from '@/context/useDashboard';
+import { useAuth } from '@/context/useAuth';
+import { useDialog } from '@/context/useDialog';
+import { useClassLinkEnabled } from '@/hooks/useClassLinkEnabled';
+import { ClassRoster, Student } from '@/types';
+import { RosterEditorModal } from '@/components/classes/RosterEditorModal';
+import {
+  ClassLinkImportDialog,
+  ClassLinkDialogMode,
+} from '@/components/classes/ClassLinkImportDialog';
+
+interface SidebarClassesProps {
+  isVisible: boolean;
+}
+
+/**
+ * "My Classes" sidebar page.
+ *
+ * Replaces the in-widget roster editor and ClassLink import that used to live
+ * inside the Classes dashboard widget. Roster management is account-level, not
+ * dashboard-level, so it belongs here in the app shell.
+ */
+export const SidebarClasses: React.FC<SidebarClassesProps> = ({
+  isVisible,
+}) => {
+  const { t } = useTranslation();
+  const { showConfirm } = useDialog();
+  const {
+    rosters,
+    activeRosterId,
+    addRoster,
+    updateRoster,
+    deleteRoster,
+    setActiveRoster,
+  } = useDashboard();
+  const { selectedBuildings } = useAuth();
+  const classLinkEnabled = useClassLinkEnabled(selectedBuildings[0]);
+
+  const [editingRosterId, setEditingRosterId] = useState<string | null>(null);
+  const [classLinkMode, setClassLinkMode] =
+    useState<ClassLinkDialogMode | null>(null);
+
+  const editingRoster: ClassRoster | null =
+    editingRosterId && editingRosterId !== 'new'
+      ? (rosters.find((r) => r.id === editingRosterId) ?? null)
+      : null;
+
+  const handleSaveRoster = async (name: string, students: Student[]) => {
+    if (editingRosterId === 'new') {
+      await addRoster(name, students);
+    } else if (editingRosterId) {
+      await updateRoster(editingRosterId, { name, students });
+    }
+  };
+
+  const handleDelete = async (roster: ClassRoster) => {
+    const confirmed = await showConfirm(
+      t('sidebar.classes.confirmDelete', {
+        defaultValue: `Delete "${roster.name}"? This cannot be undone.`,
+        name: roster.name,
+      }),
+      {
+        title: t('sidebar.classes.confirmDeleteTitle', {
+          defaultValue: 'Delete Class',
+        }),
+        variant: 'danger',
+        confirmLabel: t('common.delete', { defaultValue: 'Delete' }),
+      }
+    );
+    if (confirmed) {
+      await deleteRoster(roster.id);
+    }
+  };
+
+  return (
+    <>
+      <div
+        className={`absolute inset-0 flex flex-col transition-all duration-300 ease-in-out ${
+          isVisible
+            ? 'translate-x-0 opacity-100 visible'
+            : 'translate-x-full opacity-0 invisible'
+        }`}
+      >
+        <div className="flex-1 overflow-y-auto custom-scrollbar">
+          <div className="p-5 space-y-5">
+            {/* Page Header */}
+            <div>
+              <div className="flex items-center gap-2.5 mb-1.5">
+                <div className="w-8 h-8 rounded-lg bg-brand-blue-lighter flex items-center justify-center">
+                  <Users className="w-4 h-4 text-brand-blue-primary" />
+                </div>
+                <h2 className="text-sm font-bold text-slate-800">
+                  {t('sidebar.classes.title', { defaultValue: 'My Classes' })}
+                </h2>
+              </div>
+              <p className="text-xs text-slate-500 mt-2 leading-relaxed">
+                {t('sidebar.classes.description', {
+                  defaultValue:
+                    'Manage your class rosters here. The active class is used by seating charts, random picker, polls, and more.',
+                })}
+              </p>
+            </div>
+
+            {/* Top CTAs */}
+            <div
+              className={`grid gap-2 ${
+                classLinkEnabled ? 'grid-cols-2' : 'grid-cols-1'
+              }`}
+            >
+              <button
+                onClick={() => setEditingRosterId('new')}
+                className="flex flex-col items-center justify-center gap-1.5 p-3 bg-brand-blue-primary text-white rounded-xl shadow-sm hover:bg-brand-blue-dark transition-all"
+              >
+                <Plus className="w-4 h-4" />
+                <span className="text-xxs font-bold uppercase tracking-wider">
+                  {t('sidebar.classes.newClass', {
+                    defaultValue: 'New Class',
+                  })}
+                </span>
+              </button>
+              {classLinkEnabled && (
+                <button
+                  onClick={() => setClassLinkMode({ kind: 'new' })}
+                  className="flex flex-col items-center justify-center gap-1.5 p-3 bg-white border border-slate-200 text-slate-600 rounded-xl hover:border-brand-blue-primary hover:text-brand-blue-primary transition-all"
+                >
+                  <Download className="w-4 h-4" />
+                  <span className="text-xxs font-bold uppercase tracking-wider">
+                    {t('sidebar.classes.importClassLink', {
+                      defaultValue: 'ClassLink',
+                    })}
+                  </span>
+                </button>
+              )}
+            </div>
+
+            {/* Roster list */}
+            {rosters.length === 0 ? (
+              <div className="flex flex-col items-center justify-center gap-3 py-12 text-slate-400">
+                <div className="w-14 h-14 rounded-full bg-slate-100 flex items-center justify-center">
+                  <Users className="w-6 h-6 text-slate-300" />
+                </div>
+                <div className="text-center">
+                  <p className="text-sm font-bold text-slate-600">
+                    {t('sidebar.classes.emptyTitle', {
+                      defaultValue: 'No classes yet',
+                    })}
+                  </p>
+                  <p className="text-xs text-slate-400 mt-0.5">
+                    {t('sidebar.classes.emptySubtitle', {
+                      defaultValue:
+                        'Create a class or import from ClassLink to get started.',
+                    })}
+                  </p>
+                </div>
+                <button
+                  onClick={() => setEditingRosterId('new')}
+                  className="mt-2 px-4 py-2 bg-brand-blue-primary text-white rounded-xl text-xxs font-bold uppercase tracking-wider hover:bg-brand-blue-dark shadow-sm transition-colors"
+                >
+                  {t('sidebar.classes.createNewClass', {
+                    defaultValue: 'Create New Class',
+                  })}
+                </button>
+              </div>
+            ) : (
+              <div className="space-y-3">
+                <h3 className="text-xxs font-bold text-slate-400 uppercase tracking-widest px-1">
+                  {t('sidebar.classes.myClasses', {
+                    defaultValue: 'Your Classes',
+                  })}
+                </h3>
+                <div className="flex flex-col gap-2">
+                  {rosters.map((r) => {
+                    const isActive = activeRosterId === r.id;
+                    return (
+                      <div
+                        key={r.id}
+                        className={`flex items-center gap-2 p-2.5 bg-white border rounded-xl transition-all ${
+                          isActive
+                            ? 'border-brand-blue-primary shadow-sm ring-1 ring-brand-blue-primary/20'
+                            : 'border-slate-200 hover:border-slate-300'
+                        }`}
+                      >
+                        <button
+                          onClick={() =>
+                            setActiveRoster(isActive ? null : r.id)
+                          }
+                          className={`shrink-0 p-1.5 rounded-lg transition-colors ${
+                            isActive
+                              ? 'text-amber-500 hover:bg-amber-50'
+                              : 'text-slate-300 hover:text-amber-400 hover:bg-amber-50'
+                          }`}
+                          title={
+                            isActive
+                              ? t('sidebar.classes.activeClass', {
+                                  defaultValue: 'Active Class',
+                                })
+                              : t('sidebar.classes.setActive', {
+                                  defaultValue: 'Set as Active',
+                                })
+                          }
+                          aria-label={
+                            isActive
+                              ? t('sidebar.classes.activeClass', {
+                                  defaultValue: 'Active Class',
+                                })
+                              : t('sidebar.classes.setActive', {
+                                  defaultValue: 'Set as Active',
+                                })
+                          }
+                        >
+                          <Star
+                            className="w-4 h-4"
+                            fill={isActive ? 'currentColor' : 'none'}
+                          />
+                        </button>
+                        <div className="flex-1 min-w-0">
+                          <div className="text-sm font-bold text-slate-800 truncate">
+                            {r.name}
+                          </div>
+                          <div className="text-xxs font-semibold text-slate-400 uppercase tracking-widest">
+                            {r.students.length}{' '}
+                            {r.students.length === 1 ? 'Student' : 'Students'}
+                          </div>
+                        </div>
+                        <div className="flex items-center gap-0.5 shrink-0">
+                          <button
+                            onClick={() => setEditingRosterId(r.id)}
+                            className="p-1.5 text-slate-400 hover:text-brand-blue-primary hover:bg-brand-blue-lighter rounded-lg transition-colors"
+                            title={t('sidebar.classes.edit', {
+                              defaultValue: 'Edit Class',
+                            })}
+                            aria-label={t('sidebar.classes.edit', {
+                              defaultValue: 'Edit Class',
+                            })}
+                          >
+                            <Pencil className="w-3.5 h-3.5" />
+                          </button>
+                          {classLinkEnabled && (
+                            <button
+                              onClick={() =>
+                                setClassLinkMode({
+                                  kind: 'merge',
+                                  rosterId: r.id,
+                                  rosterName: r.name,
+                                })
+                              }
+                              className="p-1.5 text-slate-400 hover:text-brand-blue-primary hover:bg-brand-blue-lighter rounded-lg transition-colors"
+                              title={t('sidebar.classes.syncClassLink', {
+                                defaultValue: 'Sync with ClassLink',
+                              })}
+                              aria-label={t('sidebar.classes.syncClassLink', {
+                                defaultValue: 'Sync with ClassLink',
+                              })}
+                            >
+                              <RefreshCw className="w-3.5 h-3.5" />
+                            </button>
+                          )}
+                          <button
+                            onClick={() => void handleDelete(r)}
+                            className="p-1.5 text-slate-400 hover:text-red-500 hover:bg-red-50 rounded-lg transition-colors"
+                            title={t('sidebar.classes.delete', {
+                              defaultValue: 'Delete Class',
+                            })}
+                            aria-label={t('sidebar.classes.delete', {
+                              defaultValue: 'Delete Class',
+                            })}
+                          >
+                            <Trash2 className="w-3.5 h-3.5" />
+                          </button>
+                        </div>
+                      </div>
+                    );
+                  })}
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+
+      <RosterEditorModal
+        isOpen={editingRosterId !== null}
+        roster={editingRoster}
+        onClose={() => setEditingRosterId(null)}
+        onSave={handleSaveRoster}
+      />
+
+      {classLinkMode && (
+        <ClassLinkImportDialog
+          isOpen={classLinkMode !== null}
+          mode={classLinkMode}
+          onClose={() => setClassLinkMode(null)}
+        />
+      )}
+    </>
+  );
+};

--- a/components/widgets/Classes/ClassesWidget.test.tsx
+++ b/components/widgets/Classes/ClassesWidget.test.tsx
@@ -1,28 +1,15 @@
-import { render, screen, waitFor, within } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, it, expect, vi, beforeEach, Mock } from 'vitest';
 import ClassesWidget from './ClassesWidget';
 import { useDashboard } from '@/context/useDashboard';
-import { useAuth } from '@/context/useAuth';
-import { classLinkService } from '@/utils/classlinkService';
 
 vi.mock('@/context/useDashboard');
-vi.mock('@/context/useAuth');
-vi.mock('@/utils/classlinkService');
 
-describe('ClassesWidget RosterEditor', () => {
-  const defaultAuthMock = {
-    featurePermissions: [],
-    selectedBuildings: [],
-  };
-
+describe('ClassesWidget (slim active-class selector)', () => {
   const defaultDashboardMock = {
     rosters: [] as Record<string, unknown>[],
-    addRoster: vi.fn() as Mock,
-    updateRoster: vi.fn() as Mock,
-    deleteRoster: vi.fn() as Mock,
     setActiveRoster: vi.fn() as Mock,
-    addToast: vi.fn() as Mock,
     activeRosterId: null as string | null,
   };
 
@@ -35,637 +22,111 @@ describe('ClassesWidget RosterEditor', () => {
     h: 4,
     z: 1,
     flipped: false,
-    config: { classLinkEnabled: true },
+    config: {},
   };
 
   beforeEach(() => {
     vi.clearAllMocks();
     (useDashboard as Mock).mockReturnValue(defaultDashboardMock);
-    (useAuth as Mock).mockReturnValue(defaultAuthMock);
   });
 
-  it('renders single name field by default', async () => {
-    const user = userEvent.setup();
+  it('renders empty state with CTA when no rosters exist', () => {
     render(<ClassesWidget widget={mockWidget} />);
-
-    // Open add modal
-    await user.click(screen.getByRole('button', { name: /create new class/i }));
-
-    expect(screen.getByPlaceholderText(/class name/i)).toBeInTheDocument();
+    expect(screen.getByText(/no classes/i)).toBeInTheDocument();
     expect(
-      screen.getByPlaceholderText(/paste full names or group names here/i)
-    ).toBeInTheDocument();
-    expect(
-      screen.queryByPlaceholderText(/first names/i)
-    ).not.toBeInTheDocument();
-    expect(
-      screen.queryByPlaceholderText(/last names/i)
-    ).not.toBeInTheDocument();
-    expect(
-      screen.getByRole('button', { name: /\+ last name/i })
+      screen.getByRole('button', { name: /manage classes/i })
     ).toBeInTheDocument();
   });
 
-  it('toggles to dual name fields', async () => {
+  it('empty-state CTA dispatches open-sidebar with section: classes', async () => {
     const user = userEvent.setup();
+    const dispatchSpy = vi.spyOn(window, 'dispatchEvent');
+
     render(<ClassesWidget widget={mockWidget} />);
+    await user.click(screen.getByRole('button', { name: /manage classes/i }));
 
-    await user.click(screen.getByRole('button', { name: /create new class/i }));
-
-    await user.click(screen.getByRole('button', { name: /\+ last name/i }));
-
-    expect(
-      screen.getByPlaceholderText(/paste first names/i)
-    ).toBeInTheDocument();
-    expect(
-      screen.getByPlaceholderText(/paste last names/i)
-    ).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /remove/i })).toBeInTheDocument();
-  });
-
-  it('saves correctly in single field mode with full names', async () => {
-    const user = userEvent.setup();
-    render(<ClassesWidget widget={mockWidget} />);
-
-    await user.click(screen.getByRole('button', { name: /create new class/i }));
-
-    const nameInput = screen.getByPlaceholderText(/class name/i);
-    await user.type(nameInput, 'New Class');
-
-    const namesTextarea = screen.getByPlaceholderText(
-      /paste full names or group names here/i
+    const event = dispatchSpy.mock.calls
+      .map(([e]) => e)
+      .find((e) => e.type === 'open-sidebar');
+    expect(event).toBeDefined();
+    expect((event as CustomEvent<{ section?: string }>).detail?.section).toBe(
+      'classes'
     );
-    await user.type(namesTextarea, 'Alice Smith\nBob Jones');
 
-    const saveButton = screen.getByRole('button', { name: /save/i });
-    await user.click(saveButton);
-
-    await waitFor(() => {
-      expect(defaultDashboardMock.addRoster).toHaveBeenCalled();
-    });
-
-    // In single-field mode, full names go into firstName, lastName is empty
-    expect(defaultDashboardMock.addRoster).toHaveBeenCalledWith('New Class', [
-      expect.objectContaining({ firstName: 'Alice Smith', lastName: '' }),
-      expect.objectContaining({ firstName: 'Bob Jones', lastName: '' }),
-    ]);
+    dispatchSpy.mockRestore();
   });
 
-  it('saves correctly in dual field mode', async () => {
-    const user = userEvent.setup();
-    const existingRoster = {
-      id: 'roster-1',
-      name: 'Existing Class',
-      students: [],
-    };
-    (useDashboard as Mock).mockReturnValue({
-      ...defaultDashboardMock,
-      rosters: [existingRoster],
-    });
-
-    render(<ClassesWidget widget={mockWidget} />);
-
-    // Open edit modal
-    await user.click(screen.getByRole('button', { name: /edit class/i }));
-
-    // Toggle to last names
-    await user.click(screen.getByRole('button', { name: /\+ last name/i }));
-
-    const firstsTextarea = screen.getByPlaceholderText(/paste first names/i);
-    await user.clear(firstsTextarea);
-    await user.type(firstsTextarea, 'Alice\nBob');
-
-    const lastsTextarea = screen.getByPlaceholderText(/paste last names/i);
-    await user.type(lastsTextarea, 'Smith\nJones');
-
-    const saveButton = screen.getByRole('button', { name: /save/i });
-    await user.click(saveButton);
-
-    await waitFor(() => {
-      expect(defaultDashboardMock.updateRoster).toHaveBeenCalled();
-    });
-
-    expect(defaultDashboardMock.updateRoster).toHaveBeenCalledWith(
-      'roster-1',
-      expect.objectContaining({
-        name: 'Existing Class',
-        students: [
-          expect.objectContaining({ firstName: 'Alice', lastName: 'Smith' }),
-          expect.objectContaining({ firstName: 'Bob', lastName: 'Jones' }),
-        ],
-      })
-    );
-  });
-
-  it('auto-splits names when toggling from single to dual-field mode', async () => {
-    const user = userEvent.setup();
-    render(<ClassesWidget widget={mockWidget} />);
-
-    await user.click(screen.getByRole('button', { name: /create new class/i }));
-
-    // Enter full names in single field
-    const namesTextarea = screen.getByPlaceholderText(
-      /paste full names or group names here/i
-    );
-    await user.type(namesTextarea, 'Alice Smith\nBob Jones\nCharlie');
-
-    // Toggle to dual-field mode
-    await user.click(screen.getByRole('button', { name: /\+ last name/i }));
-
-    // Verify names are split
-    const firstsTextarea = screen.getByPlaceholderText(/paste first names/i);
-    const lastsTextarea = screen.getByPlaceholderText(/paste last names/i);
-
-    expect(firstsTextarea).toHaveValue('Alice\nBob\nCharlie');
-    expect(lastsTextarea).toHaveValue('Smith\nJones\n');
-  });
-
-  it('merges names when toggling from dual to single-field mode', async () => {
-    const user = userEvent.setup();
-    render(<ClassesWidget widget={mockWidget} />);
-
-    await user.click(screen.getByRole('button', { name: /create new class/i }));
-
-    // Toggle to dual-field mode
-    await user.click(screen.getByRole('button', { name: /\+ last name/i }));
-
-    // Enter separate first and last names
-    const firstsTextarea = screen.getByPlaceholderText(/paste first names/i);
-    const lastsTextarea = screen.getByPlaceholderText(/paste last names/i);
-
-    await user.type(firstsTextarea, 'Alice\nBob');
-    await user.type(lastsTextarea, 'Smith\nJones');
-
-    // Toggle back to single-field mode
-    await user.click(screen.getByRole('button', { name: /remove/i }));
-
-    // Verify names are merged
-    const namesTextarea = screen.getByPlaceholderText(
-      /paste full names or group names here/i
-    );
-    expect(namesTextarea).toHaveValue('Alice Smith\nBob Jones');
-  });
-
-  it('preserves data correctly when toggling modes and then saving', async () => {
-    const user = userEvent.setup();
-    render(<ClassesWidget widget={mockWidget} />);
-
-    await user.click(screen.getByRole('button', { name: /create new class/i }));
-
-    const nameInput = screen.getByPlaceholderText(/class name/i);
-    await user.type(nameInput, 'Test Class');
-
-    // Start with full names
-    const namesTextarea = screen.getByPlaceholderText(
-      /paste full names or group names here/i
-    );
-    await user.type(namesTextarea, 'Alice Smith\nBob Jones');
-
-    // Toggle to dual mode (should split)
-    await user.click(screen.getByRole('button', { name: /\+ last name/i }));
-
-    // Toggle back to single mode (should merge)
-    await user.click(screen.getByRole('button', { name: /remove/i }));
-
-    // Save in single mode
-    const saveButton = screen.getByRole('button', { name: /save/i });
-    await user.click(saveButton);
-
-    await waitFor(() => {
-      expect(defaultDashboardMock.addRoster).toHaveBeenCalled();
-    });
-
-    // Data should be preserved as full names
-    expect(defaultDashboardMock.addRoster).toHaveBeenCalledWith('Test Class', [
-      expect.objectContaining({ firstName: 'Alice Smith', lastName: '' }),
-      expect.objectContaining({ firstName: 'Bob Jones', lastName: '' }),
-    ]);
-  });
-
-  it('handles names without spaces when toggling to dual mode', async () => {
-    const user = userEvent.setup();
-    render(<ClassesWidget widget={mockWidget} />);
-
-    await user.click(screen.getByRole('button', { name: /create new class/i }));
-
-    // Enter names without spaces
-    const namesTextarea = screen.getByPlaceholderText(
-      /paste full names or group names here/i
-    );
-    await user.type(namesTextarea, 'Alice\nBob\nCharlie');
-
-    // Toggle to dual-field mode
-    await user.click(screen.getByRole('button', { name: /\+ last name/i }));
-
-    // Names without spaces should stay in first name field
-    const firstsTextarea = screen.getByPlaceholderText(/paste first names/i);
-    const lastsTextarea = screen.getByPlaceholderText(/paste last names/i);
-
-    expect(firstsTextarea).toHaveValue('Alice\nBob\nCharlie');
-    expect(lastsTextarea).toHaveValue('\n\n');
-  });
-
-  it('handles mixed names (some with spaces, some without) when toggling', async () => {
-    const user = userEvent.setup();
-    render(<ClassesWidget widget={mockWidget} />);
-
-    await user.click(screen.getByRole('button', { name: /create new class/i }));
-
-    // Mix of full names and single names
-    const namesTextarea = screen.getByPlaceholderText(
-      /paste full names or group names here/i
-    );
-    await user.type(namesTextarea, 'Alice Smith\nBob\nCharlie Brown');
-
-    // Toggle to dual-field mode
-    await user.click(screen.getByRole('button', { name: /\+ last name/i }));
-
-    const firstsTextarea = screen.getByPlaceholderText(/paste first names/i);
-    const lastsTextarea = screen.getByPlaceholderText(/paste last names/i);
-
-    expect(firstsTextarea).toHaveValue('Alice\nBob\nCharlie');
-    expect(lastsTextarea).toHaveValue('Smith\n\nBrown');
-  });
-
-  it('renders "No classes yet" when there are no rosters', () => {
-    render(<ClassesWidget widget={mockWidget} />);
-    expect(screen.getByText(/no classes yet/i)).toBeInTheDocument();
-    expect(screen.getByText(/create one to get started/i)).toBeInTheDocument();
-  });
-
-  it('allows setting active roster', async () => {
-    const user = userEvent.setup();
+  it('renders active class hero and "Switch To" list for other rosters', () => {
     (useDashboard as Mock).mockReturnValue({
       ...defaultDashboardMock,
       rosters: [
-        { id: 'r1', name: 'Class 1', students: [] },
-        { id: 'r2', name: 'Class 2', students: [] },
+        { id: 'r1', name: 'Period 3 Biology', students: new Array(24) },
+        { id: 'r2', name: 'Period 5 Chemistry', students: new Array(19) },
       ],
       activeRosterId: 'r1',
     });
 
     render(<ClassesWidget widget={mockWidget} />);
 
-    // Class 1 is active, clicking it again should toggle it off
-    const class1Text = screen.getByText('Class 1');
-    const class1Container = class1Text.closest('div.border.rounded-2xl');
-    const class1Button = within(class1Container as HTMLElement).getByRole(
-      'button',
-      { name: /active class/i }
-    );
-    expect(class1Button).toHaveAttribute('title', 'Active Class');
-    await user.click(class1Button);
-    expect(defaultDashboardMock.setActiveRoster).toHaveBeenCalledWith(null);
+    expect(screen.getByText(/active class/i)).toBeInTheDocument();
+    expect(screen.getByText('Period 3 Biology')).toBeInTheDocument();
+    expect(screen.getByText('24 Students')).toBeInTheDocument();
 
-    // Class 2 is not active, clicking it should toggle it on
-    const class2Text = screen.getByText('Class 2');
-    const class2Container = class2Text.closest('div.border.rounded-2xl');
-    const class2Button = within(class2Container as HTMLElement).getByRole(
-      'button',
-      { name: /set as active/i }
-    );
-    expect(class2Button).toHaveAttribute('title', 'Set as Active');
-    await user.click(class2Button);
-    expect(defaultDashboardMock.setActiveRoster).toHaveBeenCalledWith('r2');
+    // Other roster appears in the switch list
+    expect(screen.getByText(/switch to/i)).toBeInTheDocument();
+    expect(screen.getByText('Period 5 Chemistry')).toBeInTheDocument();
   });
 
-  it('handles roster deletion process', async () => {
-    const user = userEvent.setup();
+  it('shows "No Class Selected" hero when activeRosterId is null', () => {
     (useDashboard as Mock).mockReturnValue({
       ...defaultDashboardMock,
-      rosters: [{ id: 'roster-1', name: 'Existing Class', students: [] }],
+      rosters: [{ id: 'r1', name: 'Homeroom', students: [] }],
+      activeRosterId: null,
     });
 
     render(<ClassesWidget widget={mockWidget} />);
-
-    // Click delete button on roster item
-    await user.click(screen.getByRole('button', { name: /delete class/i }));
-
-    // Confirmation dialog should appear
-    expect(
-      screen.getByText(/delete roster "existing class"\?/i)
-    ).toBeInTheDocument();
-
-    // Cancel deletion
-    await user.click(screen.getByRole('button', { name: /^cancel$/i }));
-    expect(
-      screen.queryByText(/delete roster "existing class"\?/i)
-    ).not.toBeInTheDocument();
-
-    // Trigger delete again and confirm
-    await user.click(screen.getByRole('button', { name: /delete class/i }));
-    await user.click(screen.getByRole('button', { name: /^delete$/i }));
-
-    expect(defaultDashboardMock.deleteRoster).toHaveBeenCalledWith('roster-1');
+    expect(screen.getByText(/no class selected/i)).toBeInTheDocument();
+    expect(screen.getByText(/pick a class below/i)).toBeInTheDocument();
   });
 
-  it('fetches classlink rosters, displays empty state if none', async () => {
+  it('clicking a row in "Switch To" sets that roster active', async () => {
     const user = userEvent.setup();
-    (classLinkService.getRosters as Mock).mockResolvedValue({
-      classes: [],
-      studentsByClass: {},
-    });
-
-    render(<ClassesWidget widget={mockWidget} />);
-
-    await user.click(screen.getByRole('button', { name: /classlink/i }));
-
-    // Wait for the classlink view to load
-    await waitFor(() => {
-      expect(
-        screen.getByText(/no classes found in classlink/i)
-      ).toBeInTheDocument();
-    });
-  });
-
-  it('fetches classlink rosters and allows importing', async () => {
-    const user = userEvent.setup();
-    (classLinkService.getRosters as Mock).mockResolvedValue({
-      classes: [
-        {
-          sourcedId: 'c1',
-          title: 'Math 101',
-          subject: 'Math',
-          classCode: 'M101',
-        },
-        { sourcedId: 'c2', title: 'No Students Class' }, // Test fallback logic
+    const setActive = vi.fn();
+    (useDashboard as Mock).mockReturnValue({
+      ...defaultDashboardMock,
+      rosters: [
+        { id: 'r1', name: 'Class A', students: [] },
+        { id: 'r2', name: 'Class B', students: [] },
       ],
-      studentsByClass: {
-        c1: [
-          {
-            sourcedId: 's1',
-            givenName: 'John',
-            familyName: 'Doe',
-            role: 'student',
-          },
-        ],
-        // c2 is intentionally missing from studentsByClass to test the fallback `|| []`
-      },
+      activeRosterId: 'r1',
+      setActiveRoster: setActive,
     });
 
     render(<ClassesWidget widget={mockWidget} />);
-
-    await user.click(screen.getByRole('button', { name: /classlink/i }));
-
-    // Wait for classes to load
-    await waitFor(() => {
-      expect(screen.getByText(/Math 101/i)).toBeInTheDocument();
-      expect(screen.getByText(/1 Students/i)).toBeInTheDocument();
-      expect(screen.getByText(/No Students Class/i)).toBeInTheDocument();
-    });
-
-    // Import the first class
-    const mathText = screen.getByText('Math 101');
-    const class1Container = mathText.closest('div.border.rounded-2xl');
-    const class1ImportBtn = within(class1Container as HTMLElement).getByRole(
-      'button',
-      {
-        name: /import/i,
-      }
-    );
-    await user.click(class1ImportBtn);
-
-    await waitFor(() => {
-      expect(defaultDashboardMock.addRoster).toHaveBeenCalledWith(
-        'Math - Math 101 (M101)',
-        [expect.objectContaining({ firstName: 'John', lastName: 'Doe' })]
-      );
-      expect(defaultDashboardMock.addToast).toHaveBeenCalledWith(
-        'Imported Math 101',
-        'success'
-      );
-    });
-
-    // Open classlink again to import the second class
-    await user.click(screen.getByRole('button', { name: /classlink/i }));
-    await waitFor(() => {
-      expect(screen.getByText(/No Students Class/i)).toBeInTheDocument();
-    });
-
-    const noStudentsText = screen.getByText('No Students Class');
-    const class2Container = noStudentsText.closest('div.border.rounded-2xl');
-    const class2ImportBtn = within(class2Container as HTMLElement).getByRole(
-      'button',
-      {
-        name: /import/i,
-      }
-    );
-    await user.click(class2ImportBtn);
-
-    await waitFor(() => {
-      expect(defaultDashboardMock.addRoster).toHaveBeenCalledWith(
-        'No Students Class', // No subject or classCode
-        [] // empty students array
-      );
-    });
+    await user.click(screen.getByRole('button', { name: /class b/i }));
+    expect(setActive).toHaveBeenCalledWith('r2');
   });
 
-  it('can back out of roster editing', async () => {
+  it('footer "Manage Classes" dispatches open-sidebar', async () => {
     const user = userEvent.setup();
+    const dispatchSpy = vi.spyOn(window, 'dispatchEvent');
+    (useDashboard as Mock).mockReturnValue({
+      ...defaultDashboardMock,
+      rosters: [{ id: 'r1', name: 'Class A', students: [] }],
+      activeRosterId: 'r1',
+    });
+
     render(<ClassesWidget widget={mockWidget} />);
+    await user.click(screen.getByRole('button', { name: /manage classes/i }));
 
-    // Open add modal
-    await user.click(screen.getByRole('button', { name: /create new class/i }));
-
-    expect(screen.getByPlaceholderText(/class name/i)).toBeInTheDocument();
-
-    // Click back/cancel in the editor
-    await user.click(screen.getByRole('button', { name: /back/i }));
-
-    // Should return to list view
-    expect(
-      screen.queryByPlaceholderText(/class name/i)
-    ).not.toBeInTheDocument();
-  });
-
-  it('handles classlink fetch failure', async () => {
-    const user = userEvent.setup();
-    (classLinkService.getRosters as Mock).mockRejectedValue(
-      new Error('Network error')
+    const event = dispatchSpy.mock.calls
+      .map(([e]) => e)
+      .find((e) => e.type === 'open-sidebar');
+    expect(event).toBeDefined();
+    expect((event as CustomEvent<{ section?: string }>).detail?.section).toBe(
+      'classes'
     );
 
-    render(<ClassesWidget widget={mockWidget} />);
-
-    await user.click(screen.getByRole('button', { name: /classlink/i }));
-
-    await waitFor(() => {
-      expect(defaultDashboardMock.addToast).toHaveBeenCalledWith(
-        'Failed to fetch from ClassLink. Check console.',
-        'error'
-      );
-      // Should revert to list view
-      expect(screen.queryByText(/ClassLink Rosters/i)).not.toBeInTheDocument();
-    });
-  });
-
-  it('handles classlink import failure', async () => {
-    const user = userEvent.setup();
-    (classLinkService.getRosters as Mock).mockResolvedValue({
-      classes: [{ sourcedId: 'c1', title: 'Math 101' }],
-      studentsByClass: { c1: [] },
-    });
-    // Make addRoster throw to simulate failure
-    defaultDashboardMock.addRoster.mockRejectedValueOnce(
-      new Error('Import failed')
-    );
-
-    render(<ClassesWidget widget={mockWidget} />);
-
-    await user.click(screen.getByRole('button', { name: /classlink/i }));
-
-    await waitFor(() => {
-      expect(screen.getByText(/Math 101/i)).toBeInTheDocument();
-    });
-
-    await user.click(screen.getByRole('button', { name: /import/i }));
-
-    await waitFor(() => {
-      expect(defaultDashboardMock.addToast).toHaveBeenCalledWith(
-        'Failed to import Math 101',
-        'error'
-      );
-    });
-  });
-
-  it('can cancel out of classlink view', async () => {
-    const user = userEvent.setup();
-    (classLinkService.getRosters as Mock).mockResolvedValue({
-      classes: [],
-      studentsByClass: {},
-    });
-
-    render(<ClassesWidget widget={mockWidget} />);
-
-    await user.click(screen.getByRole('button', { name: /classlink/i }));
-
-    await waitFor(() => {
-      expect(screen.getByText(/ClassLink Rosters/i)).toBeInTheDocument();
-    });
-
-    await user.click(screen.getByRole('button', { name: /cancel/i }));
-
-    expect(screen.queryByText(/ClassLink Rosters/i)).not.toBeInTheDocument();
-  });
-
-  it('hides ClassLink button when classLinkEnabled is false in widget config', () => {
-    const disabledWidget = {
-      ...mockWidget,
-      config: { classLinkEnabled: false },
-    };
-    render(<ClassesWidget widget={disabledWidget} />);
-
-    expect(
-      screen.queryByRole('button', { name: /classlink/i })
-    ).not.toBeInTheDocument();
-  });
-
-  it('hides ClassLink button when classLinkEnabled is false in global auth featurePermissions', () => {
-    (useAuth as Mock).mockReturnValue({
-      ...defaultAuthMock,
-      selectedBuildings: ['building-1'],
-      featurePermissions: [
-        {
-          widgetType: 'classes',
-          config: {
-            buildingDefaults: {
-              'building-1': { classLinkEnabled: false },
-            },
-          },
-        },
-      ],
-    });
-
-    render(<ClassesWidget widget={mockWidget} />); // widget config implies true
-
-    expect(
-      screen.queryByRole('button', { name: /classlink/i })
-    ).not.toBeInTheDocument();
-  });
-
-  // ─── PIN UI Tests ──────────────────────────────────────────────────────────
-
-  it('shows "+ Quiz PIN" button and toggles PIN column', async () => {
-    const user = userEvent.setup();
-    render(<ClassesWidget widget={mockWidget} />);
-
-    await user.click(screen.getByRole('button', { name: /create new class/i }));
-
-    // PIN column not shown by default
-    expect(
-      screen.queryByPlaceholderText(/01\n02\n03/i)
-    ).not.toBeInTheDocument();
-
-    // Toggle PIN column on
-    await user.click(screen.getByRole('button', { name: /\+ quiz pin/i }));
-
-    // PIN textarea is now visible
-    expect(screen.getByPlaceholderText(/^01/)).toBeInTheDocument();
-  });
-
-  it('saves PINs from the PIN column', async () => {
-    const user = userEvent.setup();
-    render(<ClassesWidget widget={mockWidget} />);
-
-    await user.click(screen.getByRole('button', { name: /create new class/i }));
-
-    const nameInput = screen.getByPlaceholderText(/class name/i);
-    await user.type(nameInput, 'PIN Class');
-
-    const namesTextarea = screen.getByPlaceholderText(
-      /paste full names or group names here/i
-    );
-    await user.type(namesTextarea, 'Alice\nBob');
-
-    // Toggle PIN column and enter PINs
-    await user.click(screen.getByRole('button', { name: /\+ quiz pin/i }));
-    const pinTextarea = screen.getByPlaceholderText(/^01/);
-    await user.type(pinTextarea, 'dragon\n42');
-
-    await user.click(screen.getByRole('button', { name: /save/i }));
-
-    await waitFor(() => {
-      expect(defaultDashboardMock.addRoster).toHaveBeenCalled();
-    });
-
-    expect(defaultDashboardMock.addRoster).toHaveBeenCalledWith('PIN Class', [
-      expect.objectContaining({ firstName: 'Alice', pin: 'dragon' }),
-      expect.objectContaining({ firstName: 'Bob', pin: '42' }),
-    ]);
-  });
-
-  it('shows duplicate PIN warning', async () => {
-    const user = userEvent.setup();
-    render(<ClassesWidget widget={mockWidget} />);
-
-    await user.click(screen.getByRole('button', { name: /create new class/i }));
-
-    const namesTextarea = screen.getByPlaceholderText(
-      /paste full names or group names here/i
-    );
-    await user.type(namesTextarea, 'Alice\nBob');
-
-    // Toggle PIN column and enter duplicate PINs
-    await user.click(screen.getByRole('button', { name: /\+ quiz pin/i }));
-    const pinTextarea = screen.getByPlaceholderText(/^01/);
-    await user.type(pinTextarea, 'same\nsame');
-
-    await waitFor(() => {
-      expect(screen.getByText(/duplicate pins/i)).toBeInTheDocument();
-    });
-  });
-
-  it('hides PIN column when Hide button is clicked', async () => {
-    const user = userEvent.setup();
-    render(<ClassesWidget widget={mockWidget} />);
-
-    await user.click(screen.getByRole('button', { name: /create new class/i }));
-
-    // Toggle PIN column on
-    await user.click(screen.getByRole('button', { name: /\+ quiz pin/i }));
-    expect(screen.getByPlaceholderText(/^01/)).toBeInTheDocument();
-
-    // Toggle it off via "Hide" button
-    await user.click(screen.getByRole('button', { name: /hide/i }));
-    expect(screen.queryByPlaceholderText(/^01/)).not.toBeInTheDocument();
+    dispatchSpy.mockRestore();
   });
 });

--- a/components/widgets/Classes/ClassesWidget.tsx
+++ b/components/widgets/Classes/ClassesWidget.tsx
@@ -21,7 +21,7 @@ interface Props {
  * `open-sidebar` CustomEvent with `detail.section: 'classes'`, which the
  * Sidebar listens for.
  */
-const ClassesWidget: React.FC<Props> = () => {
+const ClassesWidget: React.FC<Props> = ({ widget: _widget }) => {
   const { rosters, activeRosterId, setActiveRoster } = useDashboard();
 
   const activeRoster = rosters.find((r) => r.id === activeRosterId) ?? null;

--- a/components/widgets/Classes/ClassesWidget.tsx
+++ b/components/widgets/Classes/ClassesWidget.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 import { Star, Users, ChevronRight, Settings } from 'lucide-react';
 import { WidgetData } from '@/types';
 import { useDashboard } from '@/context/useDashboard';
@@ -22,6 +23,7 @@ interface Props {
  * Sidebar listens for.
  */
 const ClassesWidget: React.FC<Props> = ({ widget: _widget }) => {
+  const { t } = useTranslation();
   const { rosters, activeRosterId, setActiveRoster } = useDashboard();
 
   const activeRoster = rosters.find((r) => r.id === activeRosterId) ?? null;
@@ -37,8 +39,13 @@ const ClassesWidget: React.FC<Props> = ({ widget: _widget }) => {
     return (
       <ScaledEmptyState
         icon={Users}
-        title="No Classes"
-        subtitle="Create or import a class to get started."
+        title={t('sidebar.classes.emptyTitle', {
+          defaultValue: 'No classes yet',
+        })}
+        subtitle={t('sidebar.classes.emptySubtitle', {
+          defaultValue:
+            'Create a class or import from ClassLink to get started.',
+        })}
         action={
           <button
             onClick={openManageSidebar}
@@ -49,7 +56,9 @@ const ClassesWidget: React.FC<Props> = ({ widget: _widget }) => {
               marginTop: 'min(8px, 2cqmin)',
             }}
           >
-            Manage Classes
+            {t('sidebar.classes.manageClasses', {
+              defaultValue: 'Manage Classes',
+            })}
           </button>
         }
       />
@@ -70,7 +79,9 @@ const ClassesWidget: React.FC<Props> = ({ widget: _widget }) => {
               className="font-black text-slate-400 uppercase tracking-widest"
               style={{ fontSize: 'min(11px, 3cqmin)' }}
             >
-              Active Class
+              {t('sidebar.classes.activeClass', {
+                defaultValue: 'Active Class',
+              })}
             </span>
             <div
               className="bg-white border-2 border-brand-blue-primary rounded-2xl flex items-center shadow-sm"
@@ -81,10 +92,25 @@ const ClassesWidget: React.FC<Props> = ({ widget: _widget }) => {
             >
               <button
                 onClick={() => setActiveRoster(null)}
-                className="shrink-0 text-amber-500 hover:text-amber-600 transition-colors"
-                title={activeRoster ? 'Clear active class' : 'No active class'}
+                disabled={!activeRoster}
+                className="shrink-0 text-amber-500 hover:text-amber-600 transition-colors disabled:text-slate-300 disabled:hover:text-slate-300 disabled:cursor-default"
+                title={
+                  activeRoster
+                    ? t('sidebar.classes.clearActive', {
+                        defaultValue: 'Clear active class',
+                      })
+                    : t('sidebar.classes.noActive', {
+                        defaultValue: 'No active class',
+                      })
+                }
                 aria-label={
-                  activeRoster ? 'Clear active class' : 'No active class'
+                  activeRoster
+                    ? t('sidebar.classes.clearActive', {
+                        defaultValue: 'Clear active class',
+                      })
+                    : t('sidebar.classes.noActive', {
+                        defaultValue: 'No active class',
+                      })
                 }
               >
                 <Star
@@ -101,19 +127,25 @@ const ClassesWidget: React.FC<Props> = ({ widget: _widget }) => {
                   className="text-slate-800 font-black truncate"
                   style={{ fontSize: 'min(22px, 7cqmin)' }}
                 >
-                  {activeRoster ? activeRoster.name : 'No Class Selected'}
+                  {activeRoster
+                    ? activeRoster.name
+                    : t('sidebar.classes.noClassSelected', {
+                        defaultValue: 'No Class Selected',
+                      })}
                 </div>
                 <div
                   className="text-slate-400 font-bold uppercase tracking-widest"
                   style={{ fontSize: 'min(12px, 3cqmin)' }}
                 >
                   {activeRoster
-                    ? `${activeRoster.students.length} ${
-                        activeRoster.students.length === 1
-                          ? 'Student'
-                          : 'Students'
-                      }`
-                    : 'Pick a class below'}
+                    ? t('sidebar.classes.studentCount', {
+                        count: activeRoster.students.length,
+                        defaultValue: '{{count}} Student',
+                        defaultValue_other: '{{count}} Students',
+                      })
+                    : t('sidebar.classes.pickClass', {
+                        defaultValue: 'Pick a class below',
+                      })}
                 </div>
               </div>
             </div>
@@ -129,7 +161,7 @@ const ClassesWidget: React.FC<Props> = ({ widget: _widget }) => {
                 className="font-black text-slate-400 uppercase tracking-widest shrink-0"
                 style={{ fontSize: 'min(11px, 3cqmin)' }}
               >
-                Switch To
+                {t('sidebar.classes.switchTo', { defaultValue: 'Switch To' })}
               </span>
               <div
                 className="flex-1 min-h-0 overflow-y-auto custom-scrollbar flex flex-col"
@@ -186,7 +218,9 @@ const ClassesWidget: React.FC<Props> = ({ widget: _widget }) => {
                 height: 'min(14px, 3.5cqmin)',
               }}
             />
-            Manage Classes
+            {t('sidebar.classes.manageClasses', {
+              defaultValue: 'Manage Classes',
+            })}
           </button>
         </div>
       }

--- a/components/widgets/Classes/ClassesWidget.tsx
+++ b/components/widgets/Classes/ClassesWidget.tsx
@@ -1,465 +1,197 @@
-import React, { useState } from 'react';
-import {
-  WidgetData,
-  Student,
-  ClassLinkClass,
-  ClassLinkStudent,
-  ClassesConfig,
-} from '@/types';
+import React from 'react';
+import { Star, Users, ChevronRight, Settings } from 'lucide-react';
+import { WidgetData } from '@/types';
 import { useDashboard } from '@/context/useDashboard';
-import { useAuth } from '@/context/useAuth';
-import { useWidgetBuildingId } from '@/hooks/useWidgetBuildingId';
-import { Plus, Trash2, Star, Edit2, RefreshCw } from 'lucide-react';
-import { classLinkService } from '@/utils/classlinkService';
 import { WidgetLayout } from '@/components/widgets/WidgetLayout';
-import { RosterEditor } from './RosterEditor';
+import { ScaledEmptyState } from '@/components/common/ScaledEmptyState';
 
 interface Props {
   widget: WidgetData;
 }
 
-const ClassesWidget: React.FC<Props> = ({ widget }) => {
-  const { featurePermissions } = useAuth();
-  const buildingId = useWidgetBuildingId(widget);
-  const {
-    rosters,
-    addRoster,
-    updateRoster,
-    deleteRoster,
-    activeRosterId,
-    setActiveRoster,
-    addToast,
-  } = useDashboard();
+/**
+ * Classes widget — the active-class selector.
+ *
+ * This widget is intentionally compact. Roster CRUD, ClassLink import, and
+ * per-class sync all live in the "My Classes" sidebar page
+ * (`components/layout/sidebar/SidebarClasses.tsx`). The widget's only job
+ * is to show the active class and let the teacher switch.
+ *
+ * "Manage Classes →" and the empty-state CTA both dispatch the
+ * `open-sidebar` CustomEvent with `detail.section: 'classes'`, which the
+ * Sidebar listens for.
+ */
+const ClassesWidget: React.FC<Props> = () => {
+  const { rosters, activeRosterId, setActiveRoster } = useDashboard();
 
-  const [view, setView] = useState<'list' | 'edit' | 'classlink'>('list');
-  const [editingId, setEditingId] = useState<string | null>(null);
-  const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
+  const activeRoster = rosters.find((r) => r.id === activeRosterId) ?? null;
+  const otherRosters = rosters.filter((r) => r.id !== activeRosterId);
 
-  // ClassLink state
-  const [classLinkLoading, setClassLinkLoading] = useState(false);
-  const [classLinkClasses, setClassLinkClasses] = useState<ClassLinkClass[]>(
-    []
-  );
-  const [classLinkStudents, setClassLinkStudents] = useState<
-    Record<string, ClassLinkStudent[]>
-  >({});
-
-  const onSave = async (name: string, students: Student[]) => {
-    if (!editingId) {
-      await addRoster(name, students);
-    } else {
-      await updateRoster(editingId, { name, students });
-    }
-    setView('list');
-    setEditingId(null);
+  const openManageSidebar = () => {
+    window.dispatchEvent(
+      new CustomEvent('open-sidebar', { detail: { section: 'classes' } })
+    );
   };
 
-  const handleFetchClassLink = async () => {
-    setClassLinkLoading(true);
-    setView('classlink');
-    try {
-      const data = await classLinkService.getRosters(true);
-      setClassLinkClasses(data.classes);
-      setClassLinkStudents(data.studentsByClass);
-    } catch (err) {
-      console.error(err);
-      addToast('Failed to fetch from ClassLink. Check console.', 'error');
-      setView('list');
-    } finally {
-      setClassLinkLoading(false);
-    }
-  };
-
-  const importClassLinkClass = async (cls: ClassLinkClass) => {
-    try {
-      const students: Student[] = (classLinkStudents[cls.sourcedId] || []).map(
-        (s) => ({
-          id: crypto.randomUUID(),
-          firstName: s.givenName,
-          lastName: s.familyName,
-          pin: '',
-        })
-      );
-
-      // Add a nice Subject / Class Code prefix if available
-      const subjectPrefix = cls.subject ? `${cls.subject} - ` : '';
-      const codeSuffix = cls.classCode ? ` (${cls.classCode})` : '';
-      const displayName = `${subjectPrefix}${cls.title}${codeSuffix}`;
-
-      await addRoster(displayName, students);
-      addToast(`Imported ${cls.title}`, 'success');
-      setView('list');
-    } catch (err) {
-      console.error(err);
-      addToast(`Failed to import ${cls.title}`, 'error');
-    }
-  };
-
-  const editingRoster = rosters.find((r) => r.id === editingId) ?? null;
-  const config = widget.config as ClassesConfig;
-
-  // Calculate effective classLinkEnabled flag
-  const effectiveClassLinkEnabled = (() => {
-    // 1. Check building-specific admin defaults first
-    if (buildingId) {
-      const classesPerm = featurePermissions.find(
-        (p) => p.widgetType === 'classes'
-      );
-      const buildingDefaults = (
-        classesPerm?.config as {
-          buildingDefaults?: Record<string, { classLinkEnabled?: boolean }>;
+  if (rosters.length === 0) {
+    return (
+      <ScaledEmptyState
+        icon={Users}
+        title="No Classes"
+        subtitle="Create or import a class to get started."
+        action={
+          <button
+            onClick={openManageSidebar}
+            className="bg-brand-blue-primary text-white font-black uppercase tracking-widest rounded-xl hover:bg-brand-blue-dark shadow-sm transition-colors"
+            style={{
+              padding: 'min(10px, 2.5cqmin) min(16px, 4cqmin)',
+              fontSize: 'min(12px, 3.5cqmin)',
+              marginTop: 'min(8px, 2cqmin)',
+            }}
+          >
+            Manage Classes
+          </button>
         }
-      )?.buildingDefaults?.[buildingId];
-      if (buildingDefaults?.classLinkEnabled !== undefined) {
-        return buildingDefaults.classLinkEnabled;
-      }
-    }
-    // 2. Fall back to widget config if no building default is found
-    return config.classLinkEnabled !== false;
-  })();
+      />
+    );
+  }
 
   return (
-    <div className="flex flex-col h-full overflow-hidden">
-      {view === 'list' && (
-        <WidgetLayout
-          padding="p-0"
-          header={
-            <div style={{ padding: 'min(12px, 2.5cqmin)' }}>
-              <div className="flex" style={{ gap: 'min(8px, 2cqmin)' }}>
-                <button
-                  onClick={() => {
-                    setEditingId(null);
-                    setView('edit');
-                  }}
-                  className="flex-1 bg-blue-600 text-white rounded-xl font-black flex items-center justify-center hover:bg-blue-700 shadow-md shadow-blue-500/20 transition-all"
+    <WidgetLayout
+      padding="p-0"
+      content={
+        <div
+          className="w-full h-full flex flex-col"
+          style={{ padding: 'min(14px, 3.5cqmin)', gap: 'min(12px, 3cqmin)' }}
+        >
+          {/* Active class hero */}
+          <div style={{ gap: 'min(4px, 1cqmin)' }} className="flex flex-col">
+            <span
+              className="font-black text-slate-400 uppercase tracking-widest"
+              style={{ fontSize: 'min(11px, 3cqmin)' }}
+            >
+              Active Class
+            </span>
+            <div
+              className="bg-white border-2 border-brand-blue-primary rounded-2xl flex items-center shadow-sm"
+              style={{
+                padding: 'min(14px, 3.5cqmin)',
+                gap: 'min(12px, 3cqmin)',
+              }}
+            >
+              <button
+                onClick={() => setActiveRoster(null)}
+                className="shrink-0 text-amber-500 hover:text-amber-600 transition-colors"
+                title={activeRoster ? 'Clear active class' : 'No active class'}
+                aria-label={
+                  activeRoster ? 'Clear active class' : 'No active class'
+                }
+              >
+                <Star
+                  fill={activeRoster ? 'currentColor' : 'none'}
                   style={{
-                    padding: 'min(10px, 2cqmin)',
-                    gap: 'min(8px, 2cqmin)',
-                    fontSize: 'min(12px, 3cqmin)',
+                    width: 'min(28px, 7cqmin)',
+                    height: 'min(28px, 7cqmin)',
                   }}
+                  strokeWidth={2.5}
+                />
+              </button>
+              <div className="flex-1 min-w-0">
+                <div
+                  className="text-slate-800 font-black truncate"
+                  style={{ fontSize: 'min(22px, 7cqmin)' }}
                 >
-                  <Plus
-                    style={{
-                      width: 'min(16px, 4cqmin)',
-                      height: 'min(16px, 4cqmin)',
-                    }}
-                  />{' '}
-                  Create New Class
-                </button>
-                {effectiveClassLinkEnabled && (
+                  {activeRoster ? activeRoster.name : 'No Class Selected'}
+                </div>
+                <div
+                  className="text-slate-400 font-bold uppercase tracking-widest"
+                  style={{ fontSize: 'min(12px, 3cqmin)' }}
+                >
+                  {activeRoster
+                    ? `${activeRoster.students.length} ${
+                        activeRoster.students.length === 1
+                          ? 'Student'
+                          : 'Students'
+                      }`
+                    : 'Pick a class below'}
+                </div>
+              </div>
+            </div>
+          </div>
+
+          {/* Switch to list */}
+          {otherRosters.length > 0 && (
+            <div
+              className="flex-1 min-h-0 flex flex-col"
+              style={{ gap: 'min(6px, 1.5cqmin)' }}
+            >
+              <span
+                className="font-black text-slate-400 uppercase tracking-widest shrink-0"
+                style={{ fontSize: 'min(11px, 3cqmin)' }}
+              >
+                Switch To
+              </span>
+              <div
+                className="flex-1 min-h-0 overflow-y-auto custom-scrollbar flex flex-col"
+                style={{ gap: 'min(4px, 1cqmin)' }}
+              >
+                {otherRosters.map((r) => (
                   <button
-                    onClick={handleFetchClassLink}
-                    className="bg-white text-slate-700 border border-slate-200 rounded-xl font-black flex items-center justify-center hover:bg-slate-50 shadow-sm transition-all"
+                    key={r.id}
+                    onClick={() => setActiveRoster(r.id)}
+                    className="flex items-center bg-white border border-slate-200 rounded-xl hover:border-brand-blue-primary hover:shadow-sm transition-all text-left group"
                     style={{
-                      padding: 'min(10px, 2cqmin)',
-                      gap: 'min(8px, 2cqmin)',
-                      fontSize: 'min(12px, 3cqmin)',
+                      padding: 'min(10px, 2.5cqmin)',
+                      gap: 'min(10px, 2.5cqmin)',
                     }}
-                    title="Sync from ClassLink"
                   >
-                    <RefreshCw
-                      className={classLinkLoading ? 'animate-spin' : ''}
+                    <ChevronRight
+                      className="text-slate-300 group-hover:text-brand-blue-primary transition-colors shrink-0"
                       style={{
                         width: 'min(16px, 4cqmin)',
                         height: 'min(16px, 4cqmin)',
                       }}
                     />
-                    ClassLink
-                  </button>
-                )}
-              </div>
-            </div>
-          }
-          content={
-            <div className="w-full h-full flex flex-col relative overflow-hidden">
-              {confirmDeleteId && (
-                <div
-                  className="absolute inset-0 z-widget-internal-overlay bg-slate-900/90 flex flex-col items-center justify-center text-center animate-in fade-in duration-200 backdrop-blur-sm"
-                  style={{ padding: 'min(16px, 3.5cqmin)' }}
-                >
-                  <p
-                    className="text-white font-bold uppercase tracking-tight"
-                    style={{
-                      fontSize: 'min(14px, 3.5cqmin)',
-                      marginBottom: 'min(16px, 3.5cqmin)',
-                    }}
-                  >
-                    Delete roster &quot;
-                    {rosters.find((r) => r.id === confirmDeleteId)?.name}&quot;?
-                    <br />
                     <span
-                      className="text-red-400 font-black tracking-widest"
-                      style={{ fontSize: 'min(10px, 2.5cqmin)' }}
+                      className="flex-1 min-w-0 text-slate-700 font-bold truncate"
+                      style={{ fontSize: 'min(14px, 3.5cqmin)' }}
                     >
-                      This cannot be undone.
+                      {r.name}
                     </span>
-                  </p>
-                  <div className="flex" style={{ gap: 'min(12px, 3cqmin)' }}>
-                    <button
-                      onClick={() => setConfirmDeleteId(null)}
-                      className="rounded-xl bg-slate-700 text-white font-black hover:bg-slate-600 transition-colors uppercase tracking-widest"
-                      style={{
-                        padding: 'min(8px, 2cqmin) min(24px, 5cqmin)',
-                        fontSize: 'min(12px, 3cqmin)',
-                      }}
+                    <span
+                      className="shrink-0 text-slate-400 font-bold uppercase tracking-widest"
+                      style={{ fontSize: 'min(11px, 2.75cqmin)' }}
                     >
-                      Cancel
-                    </button>
-                    <button
-                      onClick={async () => {
-                        if (confirmDeleteId) {
-                          await deleteRoster(confirmDeleteId);
-                          setConfirmDeleteId(null);
-                        }
-                      }}
-                      className="rounded-xl bg-red-600 text-white font-black hover:bg-red-700 transition-colors shadow-lg shadow-red-500/20 uppercase tracking-widest"
-                      style={{
-                        padding: 'min(8px, 2cqmin) min(24px, 5cqmin)',
-                        fontSize: 'min(12px, 3cqmin)',
-                      }}
-                      title="Confirm deletion"
-                    >
-                      Delete
-                    </button>
-                  </div>
-                </div>
-              )}
-              <div
-                className="flex-1 overflow-y-auto custom-scrollbar flex flex-col"
-                style={{
-                  gap: 'min(8px, 2cqmin)',
-                  padding: 'min(12px, 2.5cqmin)',
-                }}
-              >
-                {rosters.length === 0 && (
-                  <div
-                    className="h-full flex flex-col items-center justify-center text-slate-400 opacity-40"
-                    style={{ gap: 'min(12px, 3cqmin)' }}
-                  >
-                    <Star
-                      className="stroke-slate-300"
-                      style={{
-                        width: 'min(40px, 10cqmin)',
-                        height: 'min(40px, 10cqmin)',
-                      }}
-                    />
-                    <div className="text-center">
-                      <p
-                        className="font-black uppercase tracking-widest"
-                        style={{ fontSize: 'min(14px, 3.5cqmin)' }}
-                      >
-                        No classes yet.
-                      </p>
-                      <p
-                        className="font-bold"
-                        style={{ fontSize: 'min(12px, 3cqmin)' }}
-                      >
-                        Create one to get started!
-                      </p>
-                    </div>
-                  </div>
-                )}
-                {rosters.map((r) => (
-                  <div
-                    key={r.id}
-                    className={`border rounded-2xl bg-white flex justify-between items-center transition-all hover:shadow-md ${activeRosterId === r.id ? 'ring-2 ring-blue-400 border-blue-400 shadow-lg shadow-blue-500/5' : 'border-slate-200'}`}
-                    style={{ padding: 'min(14px, 3cqmin)' }}
-                  >
-                    <div
-                      className="flex items-center flex-1 min-w-0"
-                      style={{ gap: 'min(12px, 3cqmin)' }}
-                    >
-                      <button
-                        onClick={() =>
-                          setActiveRoster(activeRosterId === r.id ? null : r.id)
-                        }
-                        className={`transition-colors ${activeRosterId === r.id ? 'text-yellow-500 hover:text-yellow-600' : 'text-slate-200 hover:text-yellow-400'}`}
-                        title={
-                          activeRosterId === r.id
-                            ? 'Active Class'
-                            : 'Set as Active'
-                        }
-                      >
-                        <Star
-                          fill={
-                            activeRosterId === r.id ? 'currentColor' : 'none'
-                          }
-                          style={{
-                            width: 'min(24px, 5cqmin)',
-                            height: 'min(24px, 5cqmin)',
-                          }}
-                          strokeWidth={2.5}
-                        />
-                      </button>
-                      <div className="min-w-0 flex-1">
-                        <div
-                          className="text-slate-800 font-black truncate uppercase tracking-tight"
-                          style={{ fontSize: 'min(24px, 8cqmin)' }}
-                        >
-                          {r.name}
-                        </div>
-                        <div
-                          className="text-slate-400 font-bold uppercase tracking-widest"
-                          style={{ fontSize: 'min(14px, 5cqmin)' }}
-                        >
-                          {r.students.length} Students
-                        </div>
-                      </div>
-                    </div>
-                    <div className="flex" style={{ gap: 'min(4px, 1cqmin)' }}>
-                      <button
-                        onClick={() => {
-                          setEditingId(r.id);
-                          setView('edit');
-                        }}
-                        className="hover:bg-blue-50 text-slate-400 hover:text-blue-600 rounded-xl transition-colors"
-                        style={{ padding: 'min(8px, 2cqmin)' }}
-                        title="Edit Class"
-                      >
-                        <Edit2
-                          style={{
-                            width: 'min(18px, 4cqmin)',
-                            height: 'min(18px, 4cqmin)',
-                          }}
-                        />
-                      </button>
-                      <button
-                        onClick={() => setConfirmDeleteId(r.id)}
-                        className="hover:bg-red-50 text-slate-400 hover:text-red-500 rounded-xl transition-colors"
-                        style={{ padding: 'min(8px, 2cqmin)' }}
-                        title="Delete Class"
-                      >
-                        <Trash2
-                          style={{
-                            width: 'min(18px, 4cqmin)',
-                            height: 'min(18px, 4cqmin)',
-                          }}
-                        />
-                      </button>
-                    </div>
-                  </div>
+                      {r.students.length}
+                    </span>
+                  </button>
                 ))}
               </div>
             </div>
-          }
-        />
-      )}
+          )}
 
-      {view === 'edit' && (
-        <RosterEditor
-          key={editingId ?? 'new'}
-          roster={editingRoster}
-          onSave={onSave}
-          onBack={() => setView('list')}
-        />
-      )}
-
-      {view === 'classlink' && (
-        <WidgetLayout
-          padding="p-0"
-          header={
-            <div
-              className="flex justify-between items-center"
-              style={{ padding: 'min(12px, 2.5cqmin)' }}
-            >
-              <button
-                onClick={() => setView('list')}
-                className="text-slate-500 hover:text-blue-600 uppercase tracking-wider font-bold"
-                style={{ fontSize: 'min(12px, 3cqmin)' }}
-              >
-                &larr; Cancel
-              </button>
-              <h3
-                className="text-slate-800 font-black uppercase tracking-widest"
-                style={{ fontSize: 'min(12px, 3cqmin)' }}
-              >
-                ClassLink Rosters
-              </h3>
-              <div style={{ width: 'min(40px, 10cqmin)' }}></div>
-            </div>
-          }
-          content={
-            <div
-              className="w-full h-full flex flex-col overflow-hidden"
-              style={{ padding: 'min(12px, 2.5cqmin)' }}
-            >
-              {classLinkLoading ? (
-                <div
-                  className="flex-1 flex flex-col items-center justify-center text-slate-400"
-                  style={{ gap: 'min(16px, 3.5cqmin)' }}
-                >
-                  <RefreshCw
-                    className="animate-spin text-blue-500"
-                    style={{
-                      width: 'min(40px, 10cqmin)',
-                      height: 'min(40px, 10cqmin)',
-                    }}
-                  />
-                  <p
-                    className="font-black uppercase tracking-widest opacity-60"
-                    style={{ fontSize: 'min(14px, 3.5cqmin)' }}
-                  >
-                    Connecting to ClassLink...
-                  </p>
-                </div>
-              ) : (
-                <div
-                  className="flex-1 overflow-y-auto pr-1 custom-scrollbar flex flex-col"
-                  style={{ gap: 'min(8px, 2cqmin)' }}
-                >
-                  {classLinkClasses.length === 0 ? (
-                    <div
-                      className="text-center text-slate-400 italic font-bold opacity-40"
-                      style={{
-                        paddingTop: 'min(48px, 10cqmin)',
-                        paddingBottom: 'min(48px, 10cqmin)',
-                        fontSize: 'min(14px, 3.5cqmin)',
-                      }}
-                    >
-                      No classes found in ClassLink.
-                    </div>
-                  ) : (
-                    classLinkClasses.map((cls) => (
-                      <div
-                        key={cls.sourcedId}
-                        className="border border-slate-200 rounded-2xl bg-white flex justify-between items-center hover:shadow-md transition-all hover:border-blue-200 group"
-                        style={{ padding: 'min(16px, 3.5cqmin)' }}
-                      >
-                        <div className="min-w-0 flex-1">
-                          <div
-                            className="text-slate-800 font-black uppercase tracking-tight truncate"
-                            style={{ fontSize: 'min(14px, 3.5cqmin)' }}
-                          >
-                            {cls.title}
-                          </div>
-                          <div
-                            className="text-slate-400 font-bold uppercase tracking-widest"
-                            style={{ fontSize: 'min(10px, 2.5cqmin)' }}
-                          >
-                            {classLinkStudents[cls.sourcedId]?.length || 0}{' '}
-                            Students
-                          </div>
-                        </div>
-                        <button
-                          onClick={() => importClassLinkClass(cls)}
-                          className="bg-blue-50 text-blue-600 rounded-xl font-black uppercase tracking-widest hover:bg-blue-600 hover:text-white transition-all shadow-sm group-hover:shadow-md"
-                          style={{
-                            padding: 'min(8px, 2cqmin) min(16px, 3.5cqmin)',
-                            fontSize: 'min(12px, 3cqmin)',
-                          }}
-                        >
-                          Import
-                        </button>
-                      </div>
-                    ))
-                  )}
-                </div>
-              )}
-            </div>
-          }
-        />
-      )}
-    </div>
+          {/* Manage footer CTA */}
+          <button
+            onClick={openManageSidebar}
+            className="shrink-0 flex items-center justify-center bg-brand-blue-lighter/50 text-brand-blue-primary font-black uppercase tracking-widest rounded-xl hover:bg-brand-blue-lighter transition-colors"
+            style={{
+              padding: 'min(10px, 2.5cqmin)',
+              gap: 'min(6px, 1.5cqmin)',
+              fontSize: 'min(12px, 3cqmin)',
+            }}
+          >
+            <Settings
+              style={{
+                width: 'min(14px, 3.5cqmin)',
+                height: 'min(14px, 3.5cqmin)',
+              }}
+            />
+            Manage Classes
+          </button>
+        </div>
+      }
+    />
   );
 };
+
 export default ClassesWidget;

--- a/components/widgets/Classes/RosterEditor.tsx
+++ b/components/widgets/Classes/RosterEditor.tsx
@@ -1,14 +1,9 @@
-import React, { useState, useMemo } from 'react';
+import React from 'react';
 import { Student, ClassRoster } from '@/types';
 import { Save, AlertTriangle } from 'lucide-react';
 import { SettingsLabel } from '@/components/common/SettingsLabel';
 import { WidgetLayout } from '@/components/widgets/WidgetLayout';
-import {
-  splitNames,
-  mergeNames,
-  generateStudentsList,
-  findDuplicatePins,
-} from './rosterUtils';
+import { useRosterEditorState } from '@/components/classes/useRosterEditorState';
 
 interface EditorProps {
   roster: ClassRoster | null;
@@ -16,60 +11,34 @@ interface EditorProps {
   onBack: () => void;
 }
 
+/**
+ * Widget-chromed roster editor. Used inside the Classes widget.
+ *
+ * The account-level version lives at `components/classes/RosterEditorModal.tsx`.
+ * Both consume `useRosterEditorState` so their behavior can't drift.
+ */
 export const RosterEditor: React.FC<EditorProps> = ({
   roster,
   onSave,
   onBack,
 }) => {
-  const [name, setName] = useState(roster?.name ?? '');
-  const [firsts, setFirsts] = useState(
-    roster?.students.map((s) => s.firstName).join('\n') ?? ''
-  );
-  const [lasts, setLasts] = useState(
-    roster?.students.map((s) => s.lastName).join('\n') ?? ''
-  );
-  const [pins, setPins] = useState(
-    roster?.students.map((s) => s.pin).join('\n') ?? ''
-  );
-  const [showPins, setShowPins] = useState(
-    roster?.students.some((s) => s.pin.trim() !== '') ?? false
-  );
-  const [showLastNames, setShowLastNames] = useState(
-    roster?.students.some((s) => s.lastName.trim() !== '') ?? false
-  );
-
-  const handleToggleToLastNames = () => {
-    if (!showLastNames) {
-      const { firsts: newFirsts, lasts: newLasts } = splitNames(firsts);
-      setFirsts(newFirsts.join('\n'));
-      setLasts(newLasts.join('\n'));
-      setShowLastNames(true);
-    }
-  };
-
-  const handleToggleToSingleField = () => {
-    if (showLastNames) {
-      const merged = mergeNames(firsts, lasts);
-      setFirsts(merged.join('\n'));
-      setLasts('');
-      setShowLastNames(false);
-    }
-  };
-
-  const previewStudents = useMemo(
-    () =>
-      generateStudentsList(
-        firsts,
-        lasts,
-        roster?.students,
-        showPins ? pins : undefined
-      ),
-    [firsts, lasts, pins, showPins, roster?.students]
-  );
-  const duplicatePins = useMemo(
-    () => findDuplicatePins(previewStudents),
-    [previewStudents]
-  );
+  const {
+    name,
+    setName,
+    firsts,
+    setFirsts,
+    lasts,
+    setLasts,
+    pins,
+    setPins,
+    showPins,
+    setShowPins,
+    showLastNames,
+    handleToggleToLastNames,
+    handleToggleToSingleField,
+    previewStudents,
+    duplicatePins,
+  } = useRosterEditorState(roster);
 
   const handleSave = () => {
     if (!name.trim()) return;

--- a/components/widgets/Classes/rosterUtils.test.ts
+++ b/components/widgets/Classes/rosterUtils.test.ts
@@ -152,6 +152,27 @@ describe('rosterUtils', () => {
       const result = generateStudentsList('Alice', 'A', existing);
       expect(result[0].pin).toBe('05');
     });
+
+    it('preserves classLinkSourcedId on existing rows so re-sync stays stable', () => {
+      const existing = [
+        {
+          id: '1',
+          firstName: 'Ada',
+          lastName: 'Lovelace',
+          pin: '01',
+          classLinkSourcedId: 'cl-ada',
+        },
+        { id: '2', firstName: 'Manual', lastName: 'Kid', pin: '02' },
+      ];
+      // Simulates saving the editor after a manual rename (no pin changes).
+      const result = generateStudentsList(
+        'Ada Renamed\nManual',
+        'Lovelace\nKid',
+        existing
+      );
+      expect(result[0].classLinkSourcedId).toBe('cl-ada');
+      expect(result[1].classLinkSourcedId).toBeUndefined();
+    });
   });
 
   describe('findDuplicatePins', () => {

--- a/components/widgets/Classes/rosterUtils.ts
+++ b/components/widgets/Classes/rosterUtils.ts
@@ -56,7 +56,7 @@ export const mergeNames = (firsts: string, lasts: string): string[] => {
 
 /**
  * Generates a list of Student objects from first and last names,
- * preserving IDs from an existing list if possible.
+ * preserving IDs (and `classLinkSourcedId`) from an existing list if possible.
  */
 export const generateStudentsList = (
   firsts: string,
@@ -74,14 +74,19 @@ export const generateStudentsList = (
       const last = lList[i] ? lList[i].trim() : '';
       if (!first && !last) return null;
 
-      // Try to find an existing student at this position to preserve ID
+      // Try to find an existing student at this position to preserve ID,
+      // pin, and ClassLink link (keeps re-sync stable after manual edits).
       const existing = existingStudents[i];
       const id = existing ? existing.id : crypto.randomUUID();
       const pin = pList
         ? (pList[i]?.trim() ?? existing?.pin ?? '')
         : (existing?.pin ?? '');
 
-      return { id, firstName: first, lastName: last, pin };
+      const student: Student = { id, firstName: first, lastName: last, pin };
+      if (existing?.classLinkSourcedId !== undefined) {
+        student.classLinkSourcedId = existing.classLinkSourcedId;
+      }
+      return student;
     })
     .filter((s): s is Student => s !== null);
 };

--- a/components/widgets/WidgetRegistry.ts
+++ b/components/widgets/WidgetRegistry.ts
@@ -623,8 +623,8 @@ export const WIDGET_SCALING_CONFIG: Record<WidgetType, ScalingConfig> = {
     skipScaling: true,
   },
   classes: {
-    baseWidth: 600,
-    baseHeight: 500,
+    baseWidth: 280,
+    baseHeight: 360,
     canSpread: true,
     skipScaling: true,
   },

--- a/config/widgetDefaults.ts
+++ b/config/widgetDefaults.ts
@@ -163,8 +163,8 @@ export const WIDGET_DEFAULTS: Record<WidgetType, Partial<WidgetData>> = {
     },
   },
   classes: {
-    w: 600,
-    h: 500,
+    w: 280,
+    h: 360,
     config: {},
   },
   instructionalRoutines: {

--- a/hooks/useClassLinkEnabled.ts
+++ b/hooks/useClassLinkEnabled.ts
@@ -1,5 +1,6 @@
 import { useMemo } from 'react';
 import { useAuth } from '@/context/useAuth';
+import { ClassesGlobalConfig } from '@/types';
 
 /**
  * Resolves whether ClassLink sync should be visible for a given building.
@@ -13,13 +14,7 @@ export function useClassLinkEnabled(buildingId?: string): boolean {
   return useMemo(() => {
     if (!buildingId) return true;
     const perm = featurePermissions.find((p) => p.widgetType === 'classes');
-    const defaults = (
-      perm?.config as
-        | {
-            buildingDefaults?: Record<string, { classLinkEnabled?: boolean }>;
-          }
-        | undefined
-    )?.buildingDefaults?.[buildingId];
-    return defaults?.classLinkEnabled ?? true;
+    const config = perm?.config as Partial<ClassesGlobalConfig> | undefined;
+    return config?.buildingDefaults?.[buildingId]?.classLinkEnabled ?? true;
   }, [featurePermissions, buildingId]);
 }

--- a/hooks/useClassLinkEnabled.ts
+++ b/hooks/useClassLinkEnabled.ts
@@ -1,0 +1,25 @@
+import { useMemo } from 'react';
+import { useAuth } from '@/context/useAuth';
+
+/**
+ * Resolves whether ClassLink sync should be visible for a given building.
+ *
+ * Looks up the `classes` feature permission's `buildingDefaults[buildingId]`
+ * setting, which is managed by the admin `ClassesConfigurationPanel`. Defaults
+ * to enabled when no building is selected or no override is configured.
+ */
+export function useClassLinkEnabled(buildingId?: string): boolean {
+  const { featurePermissions } = useAuth();
+  return useMemo(() => {
+    if (!buildingId) return true;
+    const perm = featurePermissions.find((p) => p.widgetType === 'classes');
+    const defaults = (
+      perm?.config as
+        | {
+            buildingDefaults?: Record<string, { classLinkEnabled?: boolean }>;
+          }
+        | undefined
+    )?.buildingDefaults?.[buildingId];
+    return defaults?.classLinkEnabled ?? true;
+  }, [featurePermissions, buildingId]);
+}

--- a/hooks/useRosters.ts
+++ b/hooks/useRosters.ts
@@ -27,6 +27,33 @@ function assignPins(students: Student[]): Student[] {
 }
 
 /**
+ * Parse a raw record (from Drive JSON or Firestore doc) into a Student.
+ * Returns null if required fields are missing or malformed. Centralized here so
+ * all load paths pick up new optional fields (e.g., classLinkSourcedId) at once.
+ */
+function parseRawStudent(raw: unknown): Student | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const s = raw as Record<string, unknown>;
+  if (
+    typeof s.id !== 'string' ||
+    typeof s.firstName !== 'string' ||
+    typeof s.lastName !== 'string'
+  ) {
+    return null;
+  }
+  const base: Student = {
+    id: s.id,
+    firstName: s.firstName,
+    lastName: s.lastName,
+    pin: typeof s.pin === 'string' ? s.pin : '',
+  };
+  if (typeof s.classLinkSourcedId === 'string') {
+    base.classLinkSourcedId = s.classLinkSourcedId;
+  }
+  return base;
+}
+
+/**
  * Drive folder path for per-roster student files.
  * Structure: SpartBoard/Data/Rosters/{rosterId}.json → Student[]
  */
@@ -200,27 +227,7 @@ export const useRosters = (user: User | null) => {
         const parsed = JSON.parse(text) as unknown;
         if (!Array.isArray(parsed)) return [];
         const students = (parsed as unknown[])
-          .map((s) => {
-            if (!s || typeof s !== 'object') return null;
-            const student = s as Record<string, unknown>;
-            if (
-              typeof student.id === 'string' &&
-              typeof student.firstName === 'string' &&
-              typeof student.lastName === 'string'
-            ) {
-              const base: Student = {
-                id: student.id,
-                firstName: student.firstName,
-                lastName: student.lastName,
-                pin: typeof student.pin === 'string' ? student.pin : '',
-              };
-              if (typeof student.classLinkSourcedId === 'string') {
-                base.classLinkSourcedId = student.classLinkSourcedId;
-              }
-              return base;
-            }
-            return null;
-          })
+          .map(parseRawStudent)
           .filter((s): s is Student => s !== null);
         return assignPins(students);
       } catch (err) {
@@ -274,27 +281,9 @@ export const useRosters = (user: User | null) => {
         // Only migrate docs that still have a students[] array in Firestore
         if (!Array.isArray(raw.students) || raw.students.length === 0) continue;
 
-        const rawStudents = raw.students as Record<string, unknown>[];
+        const rawStudents = raw.students as unknown[];
         const students: Student[] = rawStudents
-          .map((s) => {
-            if (
-              typeof s.id === 'string' &&
-              typeof s.firstName === 'string' &&
-              typeof s.lastName === 'string'
-            ) {
-              const base: Student = {
-                id: s.id,
-                firstName: s.firstName,
-                lastName: s.lastName,
-                pin: typeof s.pin === 'string' ? s.pin : '',
-              };
-              if (typeof s.classLinkSourcedId === 'string') {
-                base.classLinkSourcedId = s.classLinkSourcedId;
-              }
-              return base;
-            }
-            return null;
-          })
+          .map(parseRawStudent)
           .filter((s): s is Student => s !== null);
 
         const withPins = assignPins(students);

--- a/hooks/useRosters.ts
+++ b/hooks/useRosters.ts
@@ -208,12 +208,16 @@ export const useRosters = (user: User | null) => {
               typeof student.firstName === 'string' &&
               typeof student.lastName === 'string'
             ) {
-              return {
+              const base: Student = {
                 id: student.id,
                 firstName: student.firstName,
                 lastName: student.lastName,
                 pin: typeof student.pin === 'string' ? student.pin : '',
               };
+              if (typeof student.classLinkSourcedId === 'string') {
+                base.classLinkSourcedId = student.classLinkSourcedId;
+              }
+              return base;
             }
             return null;
           })
@@ -278,12 +282,16 @@ export const useRosters = (user: User | null) => {
               typeof s.firstName === 'string' &&
               typeof s.lastName === 'string'
             ) {
-              return {
+              const base: Student = {
                 id: s.id,
                 firstName: s.firstName,
                 lastName: s.lastName,
                 pin: typeof s.pin === 'string' ? s.pin : '',
               };
+              if (typeof s.classLinkSourcedId === 'string') {
+                base.classLinkSourcedId = s.classLinkSourcedId;
+              }
+              return base;
             }
             return null;
           })

--- a/locales/de.json
+++ b/locales/de.json
@@ -77,7 +77,20 @@
       "syncClassLink": "Mit ClassLink synchronisieren",
       "delete": "Klasse löschen",
       "confirmDelete": "„{{name}}“ löschen? Dies kann nicht rückgängig gemacht werden.",
-      "confirmDeleteTitle": "Klasse löschen"
+      "confirmDeleteTitle": "Klasse löschen",
+      "editClassTitle": "Klasse bearbeiten",
+      "newClassTitle": "Neue Klasse",
+      "classNamePlaceholder": "Klassenname",
+      "studentCount_one": "{{count}} Schüler/in",
+      "studentCount_other": "{{count}} Schüler/innen",
+      "classLinkImportTitle": "Aus ClassLink importieren",
+      "classLinkMergeTitle": "„{{name}}“ mit ClassLink synchronisieren",
+      "classLinkImportSubtitle": "Wähle eine Klasse, die als neue Klassenliste importiert wird.",
+      "classLinkMergeSubtitle": "Wähle die ClassLink-Klasse, deren Schüler/innen übernommen werden sollen. Bestehende Einträge bleiben erhalten.",
+      "classLinkConnecting": "Verbinde mit ClassLink…",
+      "classLinkNoClasses": "Keine Klassen in ClassLink gefunden.",
+      "classLinkImport": "Importieren",
+      "classLinkMerge": "Zusammenführen"
     },
     "widgets": {
       "gradeFilter": "Klassenstufen-Filter",

--- a/locales/de.json
+++ b/locales/de.json
@@ -76,7 +76,7 @@
       "edit": "Klasse bearbeiten",
       "syncClassLink": "Mit ClassLink synchronisieren",
       "delete": "Klasse löschen",
-      "confirmDelete": "„{{name}}\" löschen? Dies kann nicht rückgängig gemacht werden.",
+      "confirmDelete": "„{{name}}“ löschen? Dies kann nicht rückgängig gemacht werden.",
       "confirmDeleteTitle": "Klasse löschen"
     },
     "widgets": {

--- a/locales/de.json
+++ b/locales/de.json
@@ -90,7 +90,19 @@
       "classLinkConnecting": "Verbinde mit ClassLink…",
       "classLinkNoClasses": "Keine Klassen in ClassLink gefunden.",
       "classLinkImport": "Importieren",
-      "classLinkMerge": "Zusammenführen"
+      "classLinkMerge": "Zusammenführen",
+      "duplicatePins": "Doppelte PINs: {{pins}}",
+      "namesOnePerLine": "Namen (eine pro Zeile)",
+      "firstNames": "Vornamen",
+      "lastNames": "Nachnamen",
+      "quizPin": "Quiz-PIN",
+      "addLastName": "+ Nachname",
+      "addQuizPin": "+ Quiz-PIN",
+      "remove": "Entfernen",
+      "hide": "Ausblenden",
+      "pasteFullNames": "Vollständige oder Gruppennamen hier einfügen...",
+      "pasteFirstNames": "Vornamen einfügen...",
+      "pasteLastNames": "Nachnamen einfügen..."
     },
     "widgets": {
       "gradeFilter": "Klassenstufen-Filter",
@@ -176,7 +188,18 @@
     "invalidBoardData": "Ungültige Tafeldaten",
     "imageTooLarge": "Bild zu groß (max. 5 MB)",
     "backgroundUploaded": "Benutzerdefinierter Hintergrund in die Cloud hochgeladen",
-    "settingsSaved": "Einstellungen erfolgreich gespeichert"
+    "settingsSaved": "Einstellungen erfolgreich gespeichert",
+    "classLink": {
+      "fetchFailed": "Abruf von ClassLink fehlgeschlagen. Prüfe die Konsole.",
+      "imported": "{{name}} importiert",
+      "importFailed": "Fehler beim Importieren von {{name}}",
+      "targetMissing": "Zielklasse existiert nicht mehr",
+      "noStudents": "Keine Schüler/innen in {{name}} gefunden",
+      "allAlreadyPresent": "Alle {{count}} Schüler/innen sind bereits in {{name}}",
+      "addedStudents_one": "{{count}} Schüler/in zu {{name}} hinzugefügt",
+      "addedStudents_other": "{{count}} Schüler/innen zu {{name}} hinzugefügt",
+      "syncFailed": "Synchronisieren von {{name}} fehlgeschlagen"
+    }
   },
   "dock": {
     "uploadingToDrive": "Aufnahme wird auf Google Drive hochgeladen...",

--- a/locales/de.json
+++ b/locales/de.json
@@ -42,6 +42,7 @@
       "configuration": "Konfiguration",
       "boards": "Tafeln",
       "backgrounds": "Hintergründe",
+      "classes": "Meine Klassen",
       "widgets": "Widgets",
       "globalStyle": "Globaler Stil",
       "generalSettings": "Allgemeine Einstellungen"
@@ -60,6 +61,23 @@
       "presets": "Voreinstellungen",
       "colors": "Farben",
       "gradients": "Verläufe"
+    },
+    "classes": {
+      "title": "Meine Klassen",
+      "description": "Verwalte hier deine Klassenlisten. Die aktive Klasse wird für Sitzpläne, Zufallsauswahl, Umfragen und mehr verwendet.",
+      "newClass": "Neue Klasse",
+      "importClassLink": "ClassLink",
+      "myClasses": "Deine Klassen",
+      "emptyTitle": "Noch keine Klassen",
+      "emptySubtitle": "Erstelle eine Klasse oder importiere aus ClassLink, um loszulegen.",
+      "createNewClass": "Neue Klasse erstellen",
+      "activeClass": "Aktive Klasse",
+      "setActive": "Als aktiv setzen",
+      "edit": "Klasse bearbeiten",
+      "syncClassLink": "Mit ClassLink synchronisieren",
+      "delete": "Klasse löschen",
+      "confirmDelete": "„{{name}}\" löschen? Dies kann nicht rückgängig gemacht werden.",
+      "confirmDeleteTitle": "Klasse löschen"
     },
     "widgets": {
       "gradeFilter": "Klassenstufen-Filter",

--- a/locales/de.json
+++ b/locales/de.json
@@ -102,7 +102,14 @@
       "hide": "Ausblenden",
       "pasteFullNames": "Vollständige oder Gruppennamen hier einfügen...",
       "pasteFirstNames": "Vornamen einfügen...",
-      "pasteLastNames": "Nachnamen einfügen..."
+      "pasteLastNames": "Nachnamen einfügen...",
+      "quizPinPlaceholder": "01\n02\n03\n...",
+      "manageClasses": "Klassen verwalten",
+      "switchTo": "Wechseln zu",
+      "noClassSelected": "Keine Klasse ausgewählt",
+      "pickClass": "Wählen Sie unten eine Klasse",
+      "clearActive": "Aktive Klasse entfernen",
+      "noActive": "Keine aktive Klasse"
     },
     "widgets": {
       "gradeFilter": "Klassenstufen-Filter",

--- a/locales/en.json
+++ b/locales/en.json
@@ -88,7 +88,20 @@
       "syncClassLink": "Sync with ClassLink",
       "delete": "Delete Class",
       "confirmDelete": "Delete \"{{name}}\"? This cannot be undone.",
-      "confirmDeleteTitle": "Delete Class"
+      "confirmDeleteTitle": "Delete Class",
+      "editClassTitle": "Edit Class",
+      "newClassTitle": "New Class",
+      "classNamePlaceholder": "Class Name",
+      "studentCount_one": "{{count}} Student",
+      "studentCount_other": "{{count}} Students",
+      "classLinkImportTitle": "Import from ClassLink",
+      "classLinkMergeTitle": "Sync \"{{name}}\" with ClassLink",
+      "classLinkImportSubtitle": "Pick a class to import as a new roster.",
+      "classLinkMergeSubtitle": "Pick the ClassLink class whose students should be pulled in. Existing students are preserved.",
+      "classLinkConnecting": "Connecting to ClassLink…",
+      "classLinkNoClasses": "No classes found in ClassLink.",
+      "classLinkImport": "Import",
+      "classLinkMerge": "Merge"
     },
     "widgets": {
       "gradeFilter": "Grade Filter",

--- a/locales/en.json
+++ b/locales/en.json
@@ -101,7 +101,19 @@
       "classLinkConnecting": "Connecting to ClassLink…",
       "classLinkNoClasses": "No classes found in ClassLink.",
       "classLinkImport": "Import",
-      "classLinkMerge": "Merge"
+      "classLinkMerge": "Merge",
+      "duplicatePins": "Duplicate PINs: {{pins}}",
+      "namesOnePerLine": "Names (One per line)",
+      "firstNames": "First Names",
+      "lastNames": "Last Names",
+      "quizPin": "Quiz PIN",
+      "addLastName": "+ Last Name",
+      "addQuizPin": "+ Quiz PIN",
+      "remove": "Remove",
+      "hide": "Hide",
+      "pasteFullNames": "Paste full names or group names here...",
+      "pasteFirstNames": "Paste first names...",
+      "pasteLastNames": "Paste last names..."
     },
     "widgets": {
       "gradeFilter": "Grade Filter",
@@ -194,7 +206,18 @@
     "invalidBoardData": "Invalid board data",
     "imageTooLarge": "Image too large (Max 5MB)",
     "backgroundUploaded": "Custom background uploaded to cloud",
-    "settingsSaved": "Settings saved successfully"
+    "settingsSaved": "Settings saved successfully",
+    "classLink": {
+      "fetchFailed": "Failed to fetch from ClassLink. Check console.",
+      "imported": "Imported {{name}}",
+      "importFailed": "Failed to import {{name}}",
+      "targetMissing": "Target class no longer exists",
+      "noStudents": "No students found in {{name}}",
+      "allAlreadyPresent": "All {{count}} students already in {{name}}",
+      "addedStudents_one": "Added {{count}} student to {{name}}",
+      "addedStudents_other": "Added {{count}} students to {{name}}",
+      "syncFailed": "Failed to sync {{name}}"
+    }
   },
   "dock": {
     "uploadingToDrive": "Uploading recording to Google Drive...",

--- a/locales/en.json
+++ b/locales/en.json
@@ -113,7 +113,14 @@
       "hide": "Hide",
       "pasteFullNames": "Paste full names or group names here...",
       "pasteFirstNames": "Paste first names...",
-      "pasteLastNames": "Paste last names..."
+      "pasteLastNames": "Paste last names...",
+      "quizPinPlaceholder": "01\n02\n03\n...",
+      "manageClasses": "Manage Classes",
+      "switchTo": "Switch To",
+      "noClassSelected": "No Class Selected",
+      "pickClass": "Pick a class below",
+      "clearActive": "Clear active class",
+      "noActive": "No active class"
     },
     "widgets": {
       "gradeFilter": "Grade Filter",

--- a/locales/en.json
+++ b/locales/en.json
@@ -50,6 +50,7 @@
       "configuration": "Configuration",
       "boards": "Boards",
       "backgrounds": "Backgrounds",
+      "classes": "My Classes",
       "widgets": "Widgets",
       "globalStyle": "Global Style",
       "generalSettings": "General Settings"
@@ -71,6 +72,23 @@
       "presets": "Presets",
       "colors": "Colors",
       "gradients": "Gradients"
+    },
+    "classes": {
+      "title": "My Classes",
+      "description": "Manage your class rosters here. The active class is used by seating charts, random picker, polls, and more.",
+      "newClass": "New Class",
+      "importClassLink": "ClassLink",
+      "myClasses": "Your Classes",
+      "emptyTitle": "No classes yet",
+      "emptySubtitle": "Create a class or import from ClassLink to get started.",
+      "createNewClass": "Create New Class",
+      "activeClass": "Active Class",
+      "setActive": "Set as Active",
+      "edit": "Edit Class",
+      "syncClassLink": "Sync with ClassLink",
+      "delete": "Delete Class",
+      "confirmDelete": "Delete \"{{name}}\"? This cannot be undone.",
+      "confirmDeleteTitle": "Delete Class"
     },
     "widgets": {
       "gradeFilter": "Grade Filter",

--- a/locales/es.json
+++ b/locales/es.json
@@ -80,7 +80,20 @@
       "syncClassLink": "Sincronizar con ClassLink",
       "delete": "Eliminar Clase",
       "confirmDelete": "¿Eliminar \"{{name}}\"? Esta acción no se puede deshacer.",
-      "confirmDeleteTitle": "Eliminar Clase"
+      "confirmDeleteTitle": "Eliminar Clase",
+      "editClassTitle": "Editar Clase",
+      "newClassTitle": "Nueva Clase",
+      "classNamePlaceholder": "Nombre de la Clase",
+      "studentCount_one": "{{count}} Estudiante",
+      "studentCount_other": "{{count}} Estudiantes",
+      "classLinkImportTitle": "Importar desde ClassLink",
+      "classLinkMergeTitle": "Sincronizar \"{{name}}\" con ClassLink",
+      "classLinkImportSubtitle": "Elige una clase para importar como nueva lista.",
+      "classLinkMergeSubtitle": "Elige la clase de ClassLink cuyos estudiantes quieres incorporar. Los estudiantes existentes se conservan.",
+      "classLinkConnecting": "Conectando con ClassLink…",
+      "classLinkNoClasses": "No se encontraron clases en ClassLink.",
+      "classLinkImport": "Importar",
+      "classLinkMerge": "Fusionar"
     },
     "widgets": {
       "gradeFilter": "Filtro por Grado",

--- a/locales/es.json
+++ b/locales/es.json
@@ -93,7 +93,19 @@
       "classLinkConnecting": "Conectando con ClassLink…",
       "classLinkNoClasses": "No se encontraron clases en ClassLink.",
       "classLinkImport": "Importar",
-      "classLinkMerge": "Fusionar"
+      "classLinkMerge": "Fusionar",
+      "duplicatePins": "PIN duplicados: {{pins}}",
+      "namesOnePerLine": "Nombres (uno por línea)",
+      "firstNames": "Nombres",
+      "lastNames": "Apellidos",
+      "quizPin": "PIN de Quiz",
+      "addLastName": "+ Apellido",
+      "addQuizPin": "+ PIN de Quiz",
+      "remove": "Quitar",
+      "hide": "Ocultar",
+      "pasteFullNames": "Pega nombres completos o nombres de grupo aquí...",
+      "pasteFirstNames": "Pega los nombres...",
+      "pasteLastNames": "Pega los apellidos..."
     },
     "widgets": {
       "gradeFilter": "Filtro por Grado",
@@ -185,7 +197,18 @@
     "invalidBoardData": "Datos del tablero no válidos",
     "imageTooLarge": "Imagen demasiado grande (máx. 5 MB)",
     "backgroundUploaded": "Fondo personalizado subido a la nube",
-    "settingsSaved": "Configuración guardada con éxito"
+    "settingsSaved": "Configuración guardada con éxito",
+    "classLink": {
+      "fetchFailed": "Error al obtener datos de ClassLink. Revisa la consola.",
+      "imported": "{{name}} importada",
+      "importFailed": "Error al importar {{name}}",
+      "targetMissing": "La clase de destino ya no existe",
+      "noStudents": "No se encontraron estudiantes en {{name}}",
+      "allAlreadyPresent": "Los {{count}} estudiantes ya están en {{name}}",
+      "addedStudents_one": "Se añadió {{count}} estudiante a {{name}}",
+      "addedStudents_other": "Se añadieron {{count}} estudiantes a {{name}}",
+      "syncFailed": "Error al sincronizar {{name}}"
+    }
   },
   "dock": {
     "uploadingToDrive": "Subiendo grabación a Google Drive...",

--- a/locales/es.json
+++ b/locales/es.json
@@ -42,6 +42,7 @@
       "configuration": "Configuración",
       "boards": "Tableros",
       "backgrounds": "Fondos",
+      "classes": "Mis Clases",
       "widgets": "Widgets",
       "globalStyle": "Estilo Global",
       "generalSettings": "Ajustes Generales"
@@ -63,6 +64,23 @@
       "presets": "Presets",
       "colors": "Colores",
       "gradients": "Degradados"
+    },
+    "classes": {
+      "title": "Mis Clases",
+      "description": "Administra tus listas de clase aquí. La clase activa se usa en los planos de asientos, selección aleatoria, encuestas y más.",
+      "newClass": "Nueva Clase",
+      "importClassLink": "ClassLink",
+      "myClasses": "Tus Clases",
+      "emptyTitle": "Aún no hay clases",
+      "emptySubtitle": "Crea una clase o impórtala desde ClassLink para comenzar.",
+      "createNewClass": "Crear Nueva Clase",
+      "activeClass": "Clase Activa",
+      "setActive": "Marcar como Activa",
+      "edit": "Editar Clase",
+      "syncClassLink": "Sincronizar con ClassLink",
+      "delete": "Eliminar Clase",
+      "confirmDelete": "¿Eliminar \"{{name}}\"? Esta acción no se puede deshacer.",
+      "confirmDeleteTitle": "Eliminar Clase"
     },
     "widgets": {
       "gradeFilter": "Filtro por Grado",

--- a/locales/es.json
+++ b/locales/es.json
@@ -105,7 +105,14 @@
       "hide": "Ocultar",
       "pasteFullNames": "Pega nombres completos o nombres de grupo aquí...",
       "pasteFirstNames": "Pega los nombres...",
-      "pasteLastNames": "Pega los apellidos..."
+      "pasteLastNames": "Pega los apellidos...",
+      "quizPinPlaceholder": "01\n02\n03\n...",
+      "manageClasses": "Gestionar clases",
+      "switchTo": "Cambiar a",
+      "noClassSelected": "Sin clase seleccionada",
+      "pickClass": "Elige una clase abajo",
+      "clearActive": "Quitar clase activa",
+      "noActive": "Sin clase activa"
     },
     "widgets": {
       "gradeFilter": "Filtro por Grado",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -90,7 +90,19 @@
       "classLinkConnecting": "Connexion à ClassLink…",
       "classLinkNoClasses": "Aucune classe trouvée dans ClassLink.",
       "classLinkImport": "Importer",
-      "classLinkMerge": "Fusionner"
+      "classLinkMerge": "Fusionner",
+      "duplicatePins": "PIN en double : {{pins}}",
+      "namesOnePerLine": "Noms (un par ligne)",
+      "firstNames": "Prénoms",
+      "lastNames": "Noms",
+      "quizPin": "PIN du quiz",
+      "addLastName": "+ Nom",
+      "addQuizPin": "+ PIN du quiz",
+      "remove": "Retirer",
+      "hide": "Masquer",
+      "pasteFullNames": "Collez les noms complets ou les noms de groupe ici...",
+      "pasteFirstNames": "Collez les prénoms...",
+      "pasteLastNames": "Collez les noms..."
     },
     "widgets": {
       "gradeFilter": "Filtre par niveau",
@@ -176,7 +188,18 @@
     "invalidBoardData": "Données du tableau invalides",
     "imageTooLarge": "Image trop grande (max. 5 Mo)",
     "backgroundUploaded": "Arrière-plan personnalisé téléchargé dans le cloud",
-    "settingsSaved": "Paramètres enregistrés avec succès"
+    "settingsSaved": "Paramètres enregistrés avec succès",
+    "classLink": {
+      "fetchFailed": "Échec de la récupération depuis ClassLink. Consultez la console.",
+      "imported": "{{name}} importée",
+      "importFailed": "Échec de l'import de {{name}}",
+      "targetMissing": "La classe cible n'existe plus",
+      "noStudents": "Aucun élève trouvé dans {{name}}",
+      "allAlreadyPresent": "Les {{count}} élèves sont déjà dans {{name}}",
+      "addedStudents_one": "{{count}} élève ajouté à {{name}}",
+      "addedStudents_other": "{{count}} élèves ajoutés à {{name}}",
+      "syncFailed": "Échec de la synchronisation de {{name}}"
+    }
   },
   "dock": {
     "uploadingToDrive": "Téléchargement de l'enregistrement sur Google Drive...",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -77,7 +77,20 @@
       "syncClassLink": "Synchroniser avec ClassLink",
       "delete": "Supprimer la classe",
       "confirmDelete": "Supprimer « {{name}} » ? Cette action est irréversible.",
-      "confirmDeleteTitle": "Supprimer la classe"
+      "confirmDeleteTitle": "Supprimer la classe",
+      "editClassTitle": "Modifier la classe",
+      "newClassTitle": "Nouvelle classe",
+      "classNamePlaceholder": "Nom de la classe",
+      "studentCount_one": "{{count}} élève",
+      "studentCount_other": "{{count}} élèves",
+      "classLinkImportTitle": "Importer depuis ClassLink",
+      "classLinkMergeTitle": "Synchroniser « {{name}} » avec ClassLink",
+      "classLinkImportSubtitle": "Choisis une classe à importer comme nouvelle liste.",
+      "classLinkMergeSubtitle": "Choisis la classe ClassLink dont les élèves doivent être ajoutés. Les élèves existants sont conservés.",
+      "classLinkConnecting": "Connexion à ClassLink…",
+      "classLinkNoClasses": "Aucune classe trouvée dans ClassLink.",
+      "classLinkImport": "Importer",
+      "classLinkMerge": "Fusionner"
     },
     "widgets": {
       "gradeFilter": "Filtre par niveau",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -102,7 +102,14 @@
       "hide": "Masquer",
       "pasteFullNames": "Collez les noms complets ou les noms de groupe ici...",
       "pasteFirstNames": "Collez les prénoms...",
-      "pasteLastNames": "Collez les noms..."
+      "pasteLastNames": "Collez les noms...",
+      "quizPinPlaceholder": "01\n02\n03\n...",
+      "manageClasses": "Gérer les classes",
+      "switchTo": "Passer à",
+      "noClassSelected": "Aucune classe sélectionnée",
+      "pickClass": "Choisissez une classe ci-dessous",
+      "clearActive": "Effacer la classe active",
+      "noActive": "Aucune classe active"
     },
     "widgets": {
       "gradeFilter": "Filtre par niveau",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -42,6 +42,7 @@
       "configuration": "Configuration",
       "boards": "Tableaux",
       "backgrounds": "Arrière-plans",
+      "classes": "Mes Classes",
       "widgets": "Widgets",
       "globalStyle": "Style global",
       "generalSettings": "Paramètres généraux"
@@ -60,6 +61,23 @@
       "presets": "Préréglages",
       "colors": "Couleurs",
       "gradients": "Dégradés"
+    },
+    "classes": {
+      "title": "Mes Classes",
+      "description": "Gérez vos listes de classe ici. La classe active est utilisée pour les plans de classe, le sélecteur aléatoire, les sondages, etc.",
+      "newClass": "Nouvelle classe",
+      "importClassLink": "ClassLink",
+      "myClasses": "Vos classes",
+      "emptyTitle": "Aucune classe pour l'instant",
+      "emptySubtitle": "Créez une classe ou importez depuis ClassLink pour commencer.",
+      "createNewClass": "Créer une nouvelle classe",
+      "activeClass": "Classe active",
+      "setActive": "Définir comme active",
+      "edit": "Modifier la classe",
+      "syncClassLink": "Synchroniser avec ClassLink",
+      "delete": "Supprimer la classe",
+      "confirmDelete": "Supprimer « {{name}} » ? Cette action est irréversible.",
+      "confirmDeleteTitle": "Supprimer la classe"
     },
     "widgets": {
       "gradeFilter": "Filtre par niveau",

--- a/types.ts
+++ b/types.ts
@@ -87,6 +87,12 @@ export interface Student {
   lastName: string;
   /** Teacher-distributed join code used for live sessions and quizzes (zero-padded, e.g. "01") */
   pin: string;
+  /**
+   * Stable ClassLink link, stamped when the student is imported or merged from
+   * ClassLink. Enables re-sync without duplicating rows even if the student's
+   * name changes upstream. Undefined for manually created students.
+   */
+  classLinkSourcedId?: string;
 }
 
 /**


### PR DESCRIPTION
The Classes widget previously did three unrelated jobs: list all rosters,
provide a full roster editor, and import from ClassLink. Roster management
is an account-level concern, not a dashboard-level one, so it belongs in
the app shell.

Widget → slim active-class selector:
- Compact hero for the active class + "Switch To" list of other rosters
- Footer "Manage Classes" button and empty-state CTA dispatch
  open-sidebar with detail.section: 'classes'
- Default size shrunk from 600x500 to 280x360 (widgetDefaults +
  WidgetRegistry base dims)

Sidebar → new "My Classes" page (SidebarClasses.tsx):
- Top CTAs: "New Class" (opens RosterEditorModal) and "Import from
  ClassLink" (opens ClassLinkImportDialog in `new` mode)
- Roster list with per-row actions: star toggles active; pencil opens
  modal editor; RefreshCw opens ClassLinkImportDialog in `merge` mode;
  trash opens showConfirm then deleteRoster
- ClassLink UI gated by useClassLinkEnabled(selectedBuildings[0]) —
  extracted from the inline resolver at the old widget

Sidebar wiring:
- Added 'classes' to MenuSection, WORKSPACE menu button with Users icon
  and roster count badge, and extended open-sidebar listener to honor
  detail.section (backwards compatible with swipe dispatcher)

ClassLink-safe re-sync (new capability):
- Added optional Student.classLinkSourcedId for stable cross-sync linking
- useRosters loadStudentsFromDrive + migration pass the field through
- mergeClassLinkStudents.ts: pure, additive-only merge with two-tier
  dedup (primary: sourcedId; secondary: normalized name with stamping),
  consumed-index tracking prevents collisions across same-named
  ClassLink students; local-only students (aides) stay; local PINs/IDs
  preserved

Editor reuse:
- Extracted useRosterEditorState.ts; widget-chromed RosterEditor and new
  RosterEditorModal both consume it so behavior can't drift

Dock:
- openClassEditor (ClassRosterMenu "Open Full Editor" + "+" row) now
  dispatches open-sidebar instead of spawning a duplicate widget

Tests:
- Migrated editor-flow tests to RosterEditorModal.test.tsx (10 cases)
- Rewrote ClassesWidget.test.tsx around the slim selector (6 cases)
- mergeClassLinkStudents.test.ts covers all four branches + collisions
  (7 cases)
- Full validate green: 126 files / 1117 tests, zero lint/type/format
  issues

i18n:
- sidebar.nav.classes + sidebar.classes.* added to en/es/de/fr

https://claude.ai/code/session_01RRatYSuPt2XQK1bqNzEu7a