### PR TITLE
feat(quiz): full-screen editor modal (Phase 1 of unified editor plan)

### DIFF
--- a/components/common/EditorModalShell.tsx
+++ b/components/common/EditorModalShell.tsx
@@ -1,0 +1,143 @@
+import React, { useCallback } from 'react';
+import { Loader2, X } from 'lucide-react';
+import { Modal } from './Modal';
+import { useDialog } from '@/context/useDialog';
+
+interface EditorModalShellProps {
+  isOpen: boolean;
+  title: string;
+  subtitle?: React.ReactNode;
+  isDirty: boolean;
+  isSaving?: boolean;
+  saveLabel?: string;
+  saveDisabled?: boolean;
+  footerExtras?: React.ReactNode;
+  onSave: () => void | Promise<void>;
+  onClose: () => void;
+  confirmDiscardMessage?: string;
+  confirmDiscardTitle?: string;
+  maxWidth?: string;
+  className?: string;
+  bodyClassName?: string;
+  children: React.ReactNode;
+}
+
+/**
+ * Shared shell for full-screen editor modals (Quiz, Video Activity,
+ * Guided Learning, MiniApp, etc.).
+ *
+ * Provides consistent chrome: sticky header with title + close, scrollable
+ * body, sticky footer with Cancel + Save, and a dirty-state guard that
+ * prompts before discarding unsaved changes.
+ *
+ * Parent owns draft state and `isDirty` computation; the shell just handles
+ * presentation, the close-confirm flow, and the saving spinner.
+ */
+export const EditorModalShell: React.FC<EditorModalShellProps> = ({
+  isOpen,
+  title,
+  subtitle,
+  isDirty,
+  isSaving = false,
+  saveLabel = 'Save',
+  saveDisabled = false,
+  footerExtras,
+  onSave,
+  onClose,
+  confirmDiscardMessage = 'You have unsaved changes. Discard them?',
+  confirmDiscardTitle = 'Discard changes?',
+  maxWidth = 'max-w-5xl',
+  className = 'h-[85vh]',
+  bodyClassName = 'px-6 py-5',
+  children,
+}) => {
+  const { showConfirm } = useDialog();
+
+  const requestClose = useCallback(async () => {
+    if (isSaving) return;
+    if (!isDirty) {
+      onClose();
+      return;
+    }
+    const ok = await showConfirm(confirmDiscardMessage, {
+      title: confirmDiscardTitle,
+      variant: 'warning',
+      confirmLabel: 'Discard',
+      cancelLabel: 'Keep editing',
+    });
+    if (ok) onClose();
+  }, [
+    isDirty,
+    isSaving,
+    onClose,
+    showConfirm,
+    confirmDiscardMessage,
+    confirmDiscardTitle,
+  ]);
+
+  const handleSave = useCallback(async () => {
+    if (saveDisabled || isSaving) return;
+    await onSave();
+  }, [saveDisabled, isSaving, onSave]);
+
+  const customHeader = (
+    <div className="flex items-center justify-between gap-4 px-6 py-4 border-b border-slate-200 shrink-0">
+      <div className="flex flex-col min-w-0">
+        <h3
+          id="editor-modal-shell-title"
+          className="font-black text-lg text-slate-800 truncate"
+        >
+          {title}
+        </h3>
+        {subtitle !== undefined && subtitle !== null && (
+          <div className="text-xs text-slate-500 mt-0.5">{subtitle}</div>
+        )}
+      </div>
+      <button
+        onClick={() => void requestClose()}
+        className="p-1.5 hover:bg-slate-100 rounded-full text-slate-400 transition-colors shrink-0"
+        aria-label="Close"
+      >
+        <X size={20} />
+      </button>
+    </div>
+  );
+
+  const footer = (
+    <div className="flex items-center justify-between gap-3 px-6 py-3 bg-white">
+      <div className="flex items-center gap-2">{footerExtras}</div>
+      <div className="flex items-center gap-2">
+        <button
+          onClick={() => void requestClose()}
+          className="px-4 py-2 text-sm font-bold text-slate-700 hover:bg-slate-100 rounded-xl transition-colors"
+        >
+          Cancel
+        </button>
+        <button
+          onClick={() => void handleSave()}
+          disabled={saveDisabled || isSaving}
+          className="flex items-center gap-1.5 px-5 py-2 bg-brand-blue-primary hover:bg-brand-blue-dark text-white text-sm font-bold rounded-xl transition-colors shadow-sm disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          {isSaving && <Loader2 className="w-4 h-4 animate-spin" />}
+          {saveLabel}
+        </button>
+      </div>
+    </div>
+  );
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={() => void requestClose()}
+      customHeader={customHeader}
+      footer={footer}
+      footerClassName="shrink-0 border-t border-slate-200"
+      maxWidth={maxWidth}
+      className={className}
+      contentClassName={bodyClassName}
+      ariaLabelledby="editor-modal-shell-title"
+    >
+      {children}
+    </Modal>
+  );
+};

--- a/components/widgets/QuizWidget/Widget.tsx
+++ b/components/widgets/QuizWidget/Widget.tsx
@@ -15,7 +15,7 @@ import {
 } from '@/hooks/useQuizSession';
 import { QuizManager, PlcOptions } from './components/QuizManager';
 import { QuizImporter } from './components/QuizImporter';
-import { QuizEditor } from './components/QuizEditor';
+import { QuizEditorModal } from './components/QuizEditorModal';
 import { QuizPreview } from './components/QuizPreview';
 import { QuizResults } from './components/QuizResults';
 import {
@@ -63,7 +63,10 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
   const [loadedQuizData, setLoadedQuizData] = useState<QuizData | null>(null);
   const [loadingQuizData, setLoadingQuizData] = useState(false);
   const [dataError, setDataError] = useState<string | null>(null);
-  const [selectedMeta, setSelectedMeta] = useState<QuizMetadata | null>(null);
+
+  // Editor modal state — ephemeral, not persisted to Firestore.
+  const [editingQuiz, setEditingQuiz] = useState<QuizData | null>(null);
+  const [editingMeta, setEditingMeta] = useState<QuizMetadata | null>(null);
 
   const setView = useCallback(
     (view: QuizConfig['view']) => {
@@ -79,7 +82,6 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
       try {
         const data = await loadQuizData(meta.driveFileId);
         setLoadedQuizData(data);
-        setSelectedMeta(meta);
         return data;
       } catch (err) {
         const msg = err instanceof Error ? err.message : 'Failed to load quiz';
@@ -472,24 +474,6 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
     );
   }
 
-  if (view === 'editor' && loadedQuizData) {
-    return (
-      <QuizEditor
-        quiz={loadedQuizData}
-        onBack={() => {
-          setLoadedQuizData(null);
-          setView('manager');
-        }}
-        onSave={async (updated) => {
-          await saveQuiz(updated, selectedMeta?.driveFileId);
-          setLoadedQuizData(updated);
-          addToast('Quiz updated!', 'success');
-          setView('manager');
-        }}
-      />
-    );
-  }
-
   if (view === 'preview' && loadedQuizData) {
     return (
       <QuizPreview
@@ -561,112 +545,141 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
     );
   }
 
-  // Default: manager view
+  // Default: manager view (with editor modal rendered as sibling)
   return (
-    <QuizManager
-      quizzes={quizzes}
-      loading={quizzesLoading}
-      error={quizzesError ?? dataError}
-      hasActiveSession={!!(liveSession && liveSession.status !== 'ended')}
-      activeQuizId={liveSession?.quizId ?? null}
-      onImport={() => setView('import')}
-      onResume={() => setView('monitor')}
-      onEndSession={async () => {
-        await endQuizSession();
-        addToast('Session ended.', 'success');
-      }}
-      onEdit={async (meta) => {
-        const data = await loadQuiz(meta);
-        if (data) setView('editor');
-      }}
-      onPreview={async (meta) => {
-        const data = await loadQuiz(meta);
-        if (data) setView('preview');
-      }}
-      rosters={rosters}
-      config={config}
-      onAssign={async (
-        meta,
-        mode,
-        plcOptions: PlcOptions,
-        sessionOptions: QuizSessionOptions
-      ) => {
-        const data = await loadQuiz(meta);
-        if (!data) return;
-        try {
-          const code = await startQuizSession(data, mode, sessionOptions);
-          updateWidget(widget.id, {
-            config: {
-              ...config,
-              view: 'monitor',
-              selectedQuizId: meta.id,
-              selectedQuizTitle: meta.title,
-              activeLiveSessionCode: code,
-              plcMode: plcOptions.plcMode,
-              teacherName: plcOptions.teacherName ?? '',
-              periodName: plcOptions.periodName ?? '',
-              plcSheetUrl: plcOptions.plcSheetUrl ?? '',
-            } as QuizConfig,
+    <>
+      <QuizManager
+        quizzes={quizzes}
+        loading={quizzesLoading}
+        error={quizzesError ?? dataError}
+        hasActiveSession={!!(liveSession && liveSession.status !== 'ended')}
+        activeQuizId={liveSession?.quizId ?? null}
+        onNew={() => {
+          const now = Date.now();
+          setEditingQuiz({
+            id: crypto.randomUUID(),
+            title: '',
+            questions: [],
+            createdAt: now,
+            updatedAt: now,
           });
-          const url = `${window.location.origin}/quiz?code=${code}`;
-          if (typeof navigator !== 'undefined' && navigator.clipboard) {
-            void navigator.clipboard
-              .writeText(url)
-              .then(() =>
-                addToast('Assignment link copied to clipboard!', 'success')
-              )
-              .catch(() =>
-                addToast(
-                  'Assignment created, but link could not be copied.',
-                  'info'
+          setEditingMeta(null);
+        }}
+        onImport={() => setView('import')}
+        onResume={() => setView('monitor')}
+        onEndSession={async () => {
+          await endQuizSession();
+          addToast('Session ended.', 'success');
+        }}
+        onEdit={async (meta) => {
+          const data = await loadQuiz(meta);
+          if (data) {
+            setEditingQuiz(data);
+            setEditingMeta(meta);
+          }
+        }}
+        onPreview={async (meta) => {
+          const data = await loadQuiz(meta);
+          if (data) setView('preview');
+        }}
+        rosters={rosters}
+        config={config}
+        onAssign={async (
+          meta,
+          mode,
+          plcOptions: PlcOptions,
+          sessionOptions: QuizSessionOptions
+        ) => {
+          const data = await loadQuiz(meta);
+          if (!data) return;
+          try {
+            const code = await startQuizSession(data, mode, sessionOptions);
+            updateWidget(widget.id, {
+              config: {
+                ...config,
+                view: 'monitor',
+                selectedQuizId: meta.id,
+                selectedQuizTitle: meta.title,
+                activeLiveSessionCode: code,
+                plcMode: plcOptions.plcMode,
+                teacherName: plcOptions.teacherName ?? '',
+                periodName: plcOptions.periodName ?? '',
+                plcSheetUrl: plcOptions.plcSheetUrl ?? '',
+              } as QuizConfig,
+            });
+            const url = `${window.location.origin}/quiz?code=${code}`;
+            if (typeof navigator !== 'undefined' && navigator.clipboard) {
+              void navigator.clipboard
+                .writeText(url)
+                .then(() =>
+                  addToast('Assignment link copied to clipboard!', 'success')
                 )
+                .catch(() =>
+                  addToast(
+                    'Assignment created, but link could not be copied.',
+                    'info'
+                  )
+                );
+            } else {
+              addToast(
+                'Assignment created, but link could not be copied.',
+                'info'
               );
-          } else {
+            }
+          } catch (err) {
             addToast(
-              'Assignment created, but link could not be copied.',
-              'info'
+              err instanceof Error ? err.message : 'Failed to start session',
+              'error'
             );
           }
-        } catch (err) {
-          addToast(
-            err instanceof Error ? err.message : 'Failed to start session',
-            'error'
-          );
-        }
-      }}
-      onResults={async (meta) => {
-        const data = await loadQuiz(meta);
-        if (data) setView('results');
-      }}
-      onDelete={async (meta) => {
-        try {
-          await deleteQuiz(meta.id, meta.driveFileId);
-          addToast('Quiz deleted.', 'success');
-        } catch (err) {
-          addToast(
-            err instanceof Error ? err.message : 'Delete failed',
-            'error'
-          );
-        }
-      }}
-      onShare={async (meta) => {
-        let url: string;
-        try {
-          url = await shareQuiz(meta);
-        } catch (err) {
-          addToast(
-            err instanceof Error ? err.message : 'Share failed',
-            'error'
-          );
-          return;
-        }
-        try {
-          await navigator.clipboard.writeText(url);
-          addToast('Share link copied to clipboard!', 'success');
-        } catch {
-          addToast(`Share link: ${url}`, 'info');
-        }
-      }}
-    />
+        }}
+        onResults={async (meta) => {
+          const data = await loadQuiz(meta);
+          if (data) setView('results');
+        }}
+        onDelete={async (meta) => {
+          try {
+            await deleteQuiz(meta.id, meta.driveFileId);
+            addToast('Quiz deleted.', 'success');
+          } catch (err) {
+            addToast(
+              err instanceof Error ? err.message : 'Delete failed',
+              'error'
+            );
+          }
+        }}
+        onShare={async (meta) => {
+          let url: string;
+          try {
+            url = await shareQuiz(meta);
+          } catch (err) {
+            addToast(
+              err instanceof Error ? err.message : 'Share failed',
+              'error'
+            );
+            return;
+          }
+          try {
+            await navigator.clipboard.writeText(url);
+            addToast('Share link copied to clipboard!', 'success');
+          } catch {
+            addToast(`Share link: ${url}`, 'info');
+          }
+        }}
+      />
+      <QuizEditorModal
+        isOpen={!!editingQuiz}
+        quiz={editingQuiz}
+        onClose={() => {
+          setEditingQuiz(null);
+          setEditingMeta(null);
+        }}
+        onSave={async (updated) => {
+          await saveQuiz(updated, editingMeta?.driveFileId);
+          setLoadedQuizData(updated);
+          addToast('Quiz updated!', 'success');
+        }}
+      />
+    </>
   );
 };

--- a/components/widgets/QuizWidget/Widget.tsx
+++ b/components/widgets/QuizWidget/Widget.tsx
@@ -675,9 +675,10 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
           setEditingMeta(null);
         }}
         onSave={async (updated) => {
+          const isNew = !editingMeta;
           await saveQuiz(updated, editingMeta?.driveFileId);
           setLoadedQuizData(updated);
-          addToast('Quiz updated!', 'success');
+          addToast(isNew ? 'Quiz created!' : 'Quiz saved!', 'success');
         }}
       />
     </>

--- a/components/widgets/QuizWidget/components/QuizEditorModal.tsx
+++ b/components/widgets/QuizWidget/components/QuizEditorModal.tsx
@@ -1,26 +1,26 @@
 /**
- * QuizEditor — inline editor for quiz questions.
- * Teachers can add, edit, reorder, and delete questions.
+ * QuizEditorModal — full-screen modal editor for quiz questions.
+ * Launched from the QuizManager library view. Wraps the shared
+ * EditorModalShell so it stays visually aligned with other content
+ * editors (Video Activity, Guided Learning, MiniApp).
  */
 
-import React, { useState, useEffect } from 'react';
+import React, { useMemo, useState } from 'react';
 import {
-  ArrowLeft,
+  AlertCircle,
+  ChevronDown,
+  ChevronUp,
+  GripVertical,
   Plus,
   Trash2,
-  ChevronUp,
-  ChevronDown,
-  Save,
-  Loader2,
-  AlertCircle,
-  GripVertical,
-  Edit,
 } from 'lucide-react';
 import { QuizData, QuizQuestion, QuizQuestionType } from '@/types';
+import { EditorModalShell } from '@/components/common/EditorModalShell';
 
-interface QuizEditorProps {
-  quiz: QuizData;
-  onBack: () => void;
+interface QuizEditorModalProps {
+  isOpen: boolean;
+  quiz: QuizData | null;
+  onClose: () => void;
   onSave: (updatedQuiz: QuizData) => Promise<void>;
 }
 
@@ -60,26 +60,66 @@ const blankQuestion = (): QuizQuestion => ({
   incorrectAnswers: ['', ''],
 });
 
-export const QuizEditor: React.FC<QuizEditorProps> = ({
+const questionsEqual = (a: QuizQuestion[], b: QuizQuestion[]): boolean => {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    const qa = a[i];
+    const qb = b[i];
+    if (
+      qa.id !== qb.id ||
+      qa.text !== qb.text ||
+      qa.type !== qb.type ||
+      qa.correctAnswer !== qb.correctAnswer ||
+      qa.timeLimit !== qb.timeLimit ||
+      (qa.points ?? 1) !== (qb.points ?? 1) ||
+      qa.incorrectAnswers.length !== qb.incorrectAnswers.length
+    ) {
+      return false;
+    }
+    for (let j = 0; j < qa.incorrectAnswers.length; j++) {
+      if (qa.incorrectAnswers[j] !== qb.incorrectAnswers[j]) return false;
+    }
+  }
+  return true;
+};
+
+export const QuizEditorModal: React.FC<QuizEditorModalProps> = ({
+  isOpen,
   quiz,
-  onBack,
+  onClose,
   onSave,
 }) => {
-  const [questions, setQuestions] = useState<QuizQuestion[]>(() =>
-    quiz.questions.map((q) => ({ ...q }))
+  // Snapshot the quiz when the modal opens so `isDirty` compares against the
+  // original. Reset via `key` prop on the parent when switching quizzes.
+  const originalQuestions = useMemo(
+    () => (quiz ? quiz.questions.map((q) => ({ ...q })) : []),
+    [quiz]
   );
+  const originalTitle = quiz?.title ?? '';
+  const [title, setTitle] = useState<string>(originalTitle);
+  const [questions, setQuestions] = useState<QuizQuestion[]>(originalQuestions);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [expandedId, setExpandedId] = useState<string | null>(
-    quiz.questions.length === 0 ? null : (quiz.questions[0]?.id ?? null)
+    originalQuestions[0]?.id ?? null
   );
 
-  // Auto-expand newly added questions
-  useEffect(() => {
-    if (questions.length > quiz.questions.length) {
-      setExpandedId(questions[questions.length - 1].id);
-    }
-  }, [questions, quiz.questions.length]);
+  // Reset local state when the `quiz` prop identity changes (new quiz loaded).
+  const [prevQuiz, setPrevQuiz] = useState<QuizData | null>(quiz);
+  if (quiz !== prevQuiz) {
+    setPrevQuiz(quiz);
+    setTitle(originalTitle);
+    setQuestions(originalQuestions);
+    setError(null);
+    setSaving(false);
+    setExpandedId(originalQuestions[0]?.id ?? null);
+  }
+
+  const isDirty = useMemo(
+    () =>
+      title !== originalTitle || !questionsEqual(questions, originalQuestions),
+    [title, originalTitle, questions, originalQuestions]
+  );
 
   const updateQuestion = (id: string, updates: Partial<QuizQuestion>) => {
     setQuestions((prev) =>
@@ -131,8 +171,17 @@ export const QuizEditor: React.FC<QuizEditorProps> = ({
     if (expandedId === id) setExpandedId(null);
   };
 
+  const addQuestion = () => {
+    const q = blankQuestion();
+    setQuestions((prev) => [...prev, q]);
+    setExpandedId(q.id);
+  };
+
   const handleSave = async () => {
+    if (!quiz) return;
     const errors: string[] = [];
+    if (!title.trim()) errors.push('Quiz title is required');
+    if (questions.length === 0) errors.push('Add at least one question');
     questions.forEach((q, i) => {
       if (!q.text.trim()) errors.push(`Question ${i + 1}: text is required`);
       if (!q.correctAnswer.trim())
@@ -145,7 +194,13 @@ export const QuizEditor: React.FC<QuizEditorProps> = ({
     setSaving(true);
     setError(null);
     try {
-      await onSave({ ...quiz, questions, updatedAt: Date.now() });
+      await onSave({
+        ...quiz,
+        title: title.trim(),
+        questions,
+        updatedAt: Date.now(),
+      });
+      onClose();
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Save failed');
     } finally {
@@ -153,95 +208,70 @@ export const QuizEditor: React.FC<QuizEditorProps> = ({
     }
   };
 
+  if (!quiz) return null;
+
   return (
-    <div className="flex flex-col h-full font-sans">
-      {/* Header */}
-      <div
-        className="flex items-center gap-3 border-b border-brand-blue-primary/10"
-        style={{ padding: 'min(12px, 2.5cqmin) min(16px, 4cqmin)' }}
-      >
-        <button
-          onClick={onBack}
-          className="p-1.5 hover:bg-brand-blue-primary/10 rounded-lg transition-colors text-brand-blue-primary"
-        >
-          <ArrowLeft className="w-4 h-4" />
-        </button>
-        <div className="flex-1 min-w-0">
-          <div className="flex items-center gap-2">
-            <Edit className="w-3.5 h-3.5 text-brand-blue-primary" />
-            <span
-              className="font-bold text-brand-blue-dark truncate"
-              style={{ fontSize: 'min(14px, 4.5cqmin)' }}
-            >
-              {quiz.title}
-            </span>
+    <EditorModalShell
+      isOpen={isOpen}
+      title={title.trim() || (originalTitle ? 'Edit Quiz' : 'New Quiz')}
+      subtitle={
+        <span>
+          {questions.length} {questions.length === 1 ? 'question' : 'questions'}
+        </span>
+      }
+      isDirty={isDirty}
+      isSaving={saving}
+      onSave={handleSave}
+      onClose={onClose}
+      saveLabel="Save Quiz"
+      bodyClassName="px-6 py-5 bg-slate-50/50"
+    >
+      <div className="flex flex-col gap-3">
+        <div>
+          <label className="block font-bold text-brand-blue-dark mb-1 text-xs">
+            Quiz Title
+          </label>
+          <input
+            type="text"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            placeholder="e.g. Science Unit 4 Review"
+            className="w-full px-3 py-2 bg-white border border-brand-blue-primary/20 rounded-xl text-brand-blue-dark font-bold focus:outline-none focus:border-brand-blue-primary shadow-sm text-sm"
+          />
+        </div>
+
+        {error && (
+          <div className="p-3 bg-brand-red-lighter/40 border border-brand-red-primary/20 rounded-xl flex items-center gap-2 text-sm text-brand-red-dark font-bold">
+            <AlertCircle className="w-4 h-4 shrink-0" />
+            {error}
           </div>
-          <p
-            className="text-brand-blue-primary/60 font-bold"
-            style={{ fontSize: 'min(11px, 3.5cqmin)' }}
-          >
-            {questions.length} Questions
-          </p>
-        </div>
-        <button
-          onClick={() => void handleSave()}
-          disabled={saving}
-          className="flex items-center bg-brand-blue-primary hover:bg-brand-blue-dark disabled:bg-brand-gray-lighter text-white font-black rounded-xl transition-all shadow-md active:scale-95"
-          style={{
-            gap: 'min(6px, 1.5cqmin)',
-            padding: 'min(8px, 2cqmin) min(14px, 3.5cqmin)',
-            fontSize: 'min(12px, 3.5cqmin)',
-          }}
-        >
-          {saving ? (
-            <Loader2 className="w-4 h-4 animate-spin" />
-          ) : (
-            <Save className="w-4 h-4" />
-          )}
-          SAVE
-        </button>
-      </div>
+        )}
 
-      {error && (
-        <div
-          className="mx-4 mt-3 p-3 bg-brand-red-lighter/40 border border-brand-red-primary/20 rounded-xl flex items-center gap-2 text-brand-red-dark font-bold"
-          style={{ fontSize: 'min(11px, 3.5cqmin)' }}
-        >
-          <AlertCircle className="w-4 h-4 shrink-0" />
-          {error}
-        </div>
-      )}
-
-      {/* Question list */}
-      <div className="flex-1 overflow-y-auto p-4 space-y-3 custom-scrollbar">
         {questions.map((q, i) => (
           <div
             key={q.id}
-            className={`bg-white border rounded-2xl overflow-hidden transition-all shadow-sm ${expandedId === q.id ? 'border-brand-blue-primary/30 ring-2 ring-brand-blue-primary/5 shadow-md' : 'border-brand-blue-primary/10 hover:border-brand-blue-primary/20'}`}
+            className={`bg-white border rounded-2xl overflow-hidden transition-all shadow-sm ${
+              expandedId === q.id
+                ? 'border-brand-blue-primary/30 ring-2 ring-brand-blue-primary/5 shadow-md'
+                : 'border-brand-blue-primary/10 hover:border-brand-blue-primary/20'
+            }`}
           >
-            {/* Question header (collapsed) */}
             <div
               className="flex items-center gap-2 px-3 py-2.5 cursor-pointer"
               onClick={() => setExpandedId(expandedId === q.id ? null : q.id)}
             >
               <GripVertical className="w-4 h-4 text-brand-blue-primary/20 shrink-0" />
-              <span
-                className="font-black text-brand-blue-primary/40 w-5 shrink-0"
-                style={{ fontSize: 'min(11px, 3.5cqmin)' }}
-              >
+              <span className="font-black text-brand-blue-primary/40 w-5 shrink-0 text-xs">
                 {i + 1}.
               </span>
-              <span
-                className="flex-1 font-bold text-brand-blue-dark truncate"
-                style={{ fontSize: 'min(13px, 4cqmin)' }}
-              >
+              <span className="flex-1 font-bold text-brand-blue-dark truncate text-sm">
                 {q.text || (
                   <span className="italic opacity-40">Untitled question</span>
                 )}
               </span>
 
               <span
-                className={`font-black rounded-md px-1.5 py-0.5 shrink-0 uppercase tracking-wider ${
+                className={`font-black rounded-md px-1.5 py-0.5 shrink-0 uppercase tracking-wider text-xxs ${
                   q.type === 'MC'
                     ? 'bg-blue-100 text-blue-700'
                     : q.type === 'FIB'
@@ -250,12 +280,10 @@ export const QuizEditor: React.FC<QuizEditorProps> = ({
                         ? 'bg-purple-100 text-purple-700'
                         : 'bg-teal-100 text-teal-700'
                 }`}
-                style={{ fontSize: 'min(9px, 2.5cqmin)' }}
               >
                 {q.type}
               </span>
 
-              {/* Action row buttons */}
               <div className="flex items-center gap-1 ml-1 border-l border-brand-blue-primary/5 pl-1">
                 <button
                   onClick={(e) => {
@@ -264,6 +292,7 @@ export const QuizEditor: React.FC<QuizEditorProps> = ({
                   }}
                   disabled={i === 0}
                   className="p-1 text-brand-blue-primary hover:bg-brand-blue-lighter rounded transition-colors disabled:opacity-20"
+                  aria-label="Move up"
                 >
                   <ChevronUp className="w-4 h-4" />
                 </button>
@@ -274,6 +303,7 @@ export const QuizEditor: React.FC<QuizEditorProps> = ({
                   }}
                   disabled={i === questions.length - 1}
                   className="p-1 text-brand-blue-primary hover:bg-brand-blue-lighter rounded transition-colors disabled:opacity-20"
+                  aria-label="Move down"
                 >
                   <ChevronDown className="w-4 h-4" />
                 </button>
@@ -283,22 +313,18 @@ export const QuizEditor: React.FC<QuizEditorProps> = ({
                     deleteQuestion(q.id);
                   }}
                   className="p-1 text-brand-red-primary hover:bg-brand-red-lighter rounded transition-colors"
+                  aria-label="Delete question"
                 >
                   <Trash2 className="w-4 h-4" />
                 </button>
               </div>
             </div>
 
-            {/* Expanded form */}
             {expandedId === q.id && (
               <div className="px-4 pb-4 space-y-4 border-t border-brand-blue-primary/5 pt-4 bg-brand-blue-lighter/10">
-                {/* Type + time limit + points */}
                 <div className="grid grid-cols-3 gap-3">
                   <div>
-                    <label
-                      className="block font-bold text-brand-blue-dark mb-1"
-                      style={{ fontSize: 'min(11px, 3.5cqmin)' }}
-                    >
+                    <label className="block font-bold text-brand-blue-dark mb-1 text-xs">
                       Question Type
                     </label>
                     <select
@@ -310,8 +336,7 @@ export const QuizEditor: React.FC<QuizEditorProps> = ({
                             e.target.value === 'MC' ? ['', ''] : [],
                         })
                       }
-                      className="w-full px-3 py-2 bg-white border border-brand-blue-primary/20 rounded-xl text-brand-blue-dark font-bold focus:outline-none focus:border-brand-blue-primary shadow-sm"
-                      style={{ fontSize: 'min(12px, 3.5cqmin)' }}
+                      className="w-full px-3 py-2 bg-white border border-brand-blue-primary/20 rounded-xl text-brand-blue-dark font-bold focus:outline-none focus:border-brand-blue-primary shadow-sm text-sm"
                     >
                       {QUESTION_TYPES.map((t) => (
                         <option key={t.value} value={t.value}>
@@ -321,10 +346,7 @@ export const QuizEditor: React.FC<QuizEditorProps> = ({
                     </select>
                   </div>
                   <div>
-                    <label
-                      className="block font-bold text-brand-blue-dark mb-1"
-                      style={{ fontSize: 'min(11px, 3.5cqmin)' }}
-                    >
+                    <label className="block font-bold text-brand-blue-dark mb-1 text-xs">
                       Time Limit (Seconds)
                     </label>
                     <div className="relative">
@@ -338,22 +360,15 @@ export const QuizEditor: React.FC<QuizEditorProps> = ({
                             timeLimit: parseInt(e.target.value, 10) || 0,
                           })
                         }
-                        className="w-full pl-3 pr-8 py-2 bg-white border border-brand-blue-primary/20 rounded-xl text-brand-blue-dark font-bold focus:outline-none focus:border-brand-blue-primary shadow-sm"
-                        style={{ fontSize: 'min(12px, 3.5cqmin)' }}
+                        className="w-full pl-3 pr-8 py-2 bg-white border border-brand-blue-primary/20 rounded-xl text-brand-blue-dark font-bold focus:outline-none focus:border-brand-blue-primary shadow-sm text-sm"
                       />
-                      <span
-                        className="absolute right-3 top-1/2 -translate-y-1/2 text-brand-gray-light font-bold"
-                        style={{ fontSize: 'min(10px, 3cqmin)' }}
-                      >
+                      <span className="absolute right-3 top-1/2 -translate-y-1/2 text-brand-gray-light font-bold text-xxs">
                         SEC
                       </span>
                     </div>
                   </div>
                   <div>
-                    <label
-                      className="block font-bold text-brand-blue-dark mb-1"
-                      style={{ fontSize: 'min(11px, 3.5cqmin)' }}
-                    >
+                    <label className="block font-bold text-brand-blue-dark mb-1 text-xs">
                       Points
                     </label>
                     <div className="relative">
@@ -370,38 +385,26 @@ export const QuizEditor: React.FC<QuizEditorProps> = ({
                             ),
                           })
                         }
-                        className="w-full pl-3 pr-8 py-2 bg-white border border-brand-blue-primary/20 rounded-xl text-brand-blue-dark font-bold focus:outline-none focus:border-brand-blue-primary shadow-sm"
-                        style={{ fontSize: 'min(12px, 3.5cqmin)' }}
+                        className="w-full pl-3 pr-8 py-2 bg-white border border-brand-blue-primary/20 rounded-xl text-brand-blue-dark font-bold focus:outline-none focus:border-brand-blue-primary shadow-sm text-sm"
                       />
-                      <span
-                        className="absolute right-3 top-1/2 -translate-y-1/2 text-brand-gray-light font-bold"
-                        style={{ fontSize: 'min(10px, 3cqmin)' }}
-                      >
+                      <span className="absolute right-3 top-1/2 -translate-y-1/2 text-brand-gray-light font-bold text-xxs">
                         PT
                       </span>
                     </div>
                   </div>
                 </div>
 
-                {/* Hint for special formats */}
                 {(q.type === 'Matching' || q.type === 'Ordering') && (
                   <div className="flex gap-2 p-2.5 bg-brand-blue-primary text-white rounded-xl shadow-sm">
                     <AlertCircle className="w-4 h-4 shrink-0" />
-                    <p
-                      className="font-medium"
-                      style={{ fontSize: 'min(11px, 3.5cqmin)' }}
-                    >
+                    <p className="font-medium text-xs">
                       {QUESTION_TYPES.find((t) => t.value === q.type)?.hint}
                     </p>
                   </div>
                 )}
 
-                {/* Question text */}
                 <div>
-                  <label
-                    className="block font-bold text-brand-blue-dark mb-1"
-                    style={{ fontSize: 'min(11px, 3.5cqmin)' }}
-                  >
+                  <label className="block font-bold text-brand-blue-dark mb-1 text-xs">
                     Question Prompt
                   </label>
                   <textarea
@@ -410,18 +413,13 @@ export const QuizEditor: React.FC<QuizEditorProps> = ({
                       updateQuestion(q.id, { text: e.target.value })
                     }
                     rows={2}
-                    className="w-full px-3 py-2 bg-white border border-brand-blue-primary/20 rounded-xl text-brand-blue-dark font-medium resize-none focus:outline-none focus:border-brand-blue-primary shadow-sm"
-                    style={{ fontSize: 'min(13px, 4cqmin)' }}
+                    className="w-full px-3 py-2 bg-white border border-brand-blue-primary/20 rounded-xl text-brand-blue-dark font-medium resize-none focus:outline-none focus:border-brand-blue-primary shadow-sm text-sm"
                     placeholder="e.g. What is the capital of France?"
                   />
                 </div>
 
-                {/* Correct answer */}
                 <div>
-                  <label
-                    className="block font-bold text-emerald-700 mb-1"
-                    style={{ fontSize: 'min(11px, 3.5cqmin)' }}
-                  >
+                  <label className="block font-bold text-emerald-700 mb-1 text-xs">
                     Correct Answer
                   </label>
                   <input
@@ -430,8 +428,7 @@ export const QuizEditor: React.FC<QuizEditorProps> = ({
                     onChange={(e) =>
                       updateQuestion(q.id, { correctAnswer: e.target.value })
                     }
-                    className="w-full px-3 py-2 bg-white border-2 border-emerald-500/20 rounded-xl text-emerald-800 font-bold focus:outline-none focus:border-emerald-500 shadow-sm"
-                    style={{ fontSize: 'min(13px, 4cqmin)' }}
+                    className="w-full px-3 py-2 bg-white border-2 border-emerald-500/20 rounded-xl text-emerald-800 font-bold focus:outline-none focus:border-emerald-500 shadow-sm text-sm"
                     placeholder={
                       q.type === 'Matching'
                         ? 'term1:def1|term2:def2'
@@ -442,13 +439,9 @@ export const QuizEditor: React.FC<QuizEditorProps> = ({
                   />
                 </div>
 
-                {/* Incorrect answers (MC only) */}
                 {q.type === 'MC' && (
                   <div className="space-y-2">
-                    <label
-                      className="block font-bold text-brand-red-primary mb-1"
-                      style={{ fontSize: 'min(11px, 3.5cqmin)' }}
-                    >
+                    <label className="block font-bold text-brand-red-primary mb-1 text-xs">
                       Distractors (Incorrect Options)
                     </label>
                     <div className="grid gap-2">
@@ -461,13 +454,13 @@ export const QuizEditor: React.FC<QuizEditorProps> = ({
                               updateIncorrect(q.id, idx, e.target.value)
                             }
                             placeholder={`Distractor ${idx + 1}`}
-                            className="flex-1 px-3 py-1.5 bg-white border border-brand-red-primary/10 rounded-xl text-brand-blue-dark font-medium focus:outline-none focus:border-brand-red-primary shadow-sm"
-                            style={{ fontSize: 'min(12px, 3.5cqmin)' }}
+                            className="flex-1 px-3 py-1.5 bg-white border border-brand-red-primary/10 rounded-xl text-brand-blue-dark font-medium focus:outline-none focus:border-brand-red-primary shadow-sm text-sm"
                           />
                           {q.incorrectAnswers.length > 1 && (
                             <button
                               onClick={() => removeIncorrect(q.id, idx)}
                               className="p-2 text-brand-red-primary hover:bg-brand-red-lighter rounded-xl transition-colors"
+                              aria-label={`Remove distractor ${idx + 1}`}
                             >
                               <Trash2 className="w-4 h-4" />
                             </button>
@@ -477,8 +470,7 @@ export const QuizEditor: React.FC<QuizEditorProps> = ({
                       {q.incorrectAnswers.length < 4 && (
                         <button
                           onClick={() => addIncorrect(q.id)}
-                          className="flex items-center justify-center gap-1.5 py-2 border-2 border-dashed border-brand-blue-primary/10 hover:border-brand-blue-primary/30 rounded-xl text-brand-blue-primary font-bold transition-all"
-                          style={{ fontSize: 'min(11px, 3.5cqmin)' }}
+                          className="flex items-center justify-center gap-1.5 py-2 border-2 border-dashed border-brand-blue-primary/10 hover:border-brand-blue-primary/30 rounded-xl text-brand-blue-primary font-bold transition-all text-xs"
                         >
                           <Plus className="w-3.5 h-3.5" />
                           Add Choice
@@ -492,19 +484,16 @@ export const QuizEditor: React.FC<QuizEditorProps> = ({
           </div>
         ))}
 
-        {/* Add question button */}
         <button
-          onClick={() => setQuestions((prev) => [...prev, blankQuestion()])}
+          onClick={addQuestion}
           className="w-full py-4 border-2 border-dashed border-brand-blue-primary/20 hover:border-brand-blue-primary/40 hover:bg-brand-blue-lighter/30 rounded-2xl text-brand-blue-primary font-black flex flex-col items-center justify-center gap-1 transition-all active:scale-95"
         >
           <div className="bg-brand-blue-primary text-white rounded-full p-1 shadow-sm">
             <Plus className="w-5 h-5" />
           </div>
-          <span style={{ fontSize: 'min(14px, 4.5cqmin)' }}>
-            ADD NEW QUESTION
-          </span>
+          <span className="text-sm">ADD NEW QUESTION</span>
         </button>
       </div>
-    </div>
+    </EditorModalShell>
   );
 };

--- a/components/widgets/QuizWidget/components/QuizEditorModal.tsx
+++ b/components/widgets/QuizWidget/components/QuizEditorModal.tsx
@@ -90,7 +90,8 @@ export const QuizEditorModal: React.FC<QuizEditorModalProps> = ({
   onSave,
 }) => {
   // Snapshot the quiz when the modal opens so `isDirty` compares against the
-  // original. Reset via `key` prop on the parent when switching quizzes.
+  // original. When the `quiz` prop identity changes, local state is reset via
+  // the "adjusting state while rendering" block below — no `key` prop needed.
   const originalQuestions = useMemo(
     () => (quiz ? quiz.questions.map((q) => ({ ...q })) : []),
     [quiz]

--- a/components/widgets/QuizWidget/components/QuizManager.tsx
+++ b/components/widgets/QuizWidget/components/QuizManager.tsx
@@ -45,6 +45,7 @@ interface QuizManagerProps {
   quizzes: QuizMetadata[];
   loading: boolean;
   error: string | null;
+  onNew: () => void;
   onImport: () => void;
   onEdit: (quiz: QuizMetadata) => void;
   onPreview: (quiz: QuizMetadata) => void;
@@ -69,6 +70,7 @@ export const QuizManager: React.FC<QuizManagerProps> = ({
   quizzes,
   loading,
   error,
+  onNew,
   onImport,
   onEdit,
   onPreview,
@@ -486,20 +488,46 @@ export const QuizManager: React.FC<QuizManagerProps> = ({
             </span>
           </div>
         </div>
-        <button
-          onClick={onImport}
-          className="flex items-center bg-brand-blue-primary hover:bg-brand-blue-dark text-white font-bold rounded-xl transition-all shadow-sm active:scale-95"
-          style={{
-            gap: 'min(6px, 1.5cqmin)',
-            padding: 'min(6px, 1.5cqmin) min(12px, 3cqmin)',
-            fontSize: 'min(12px, 3.5cqmin)',
-          }}
+        <div
+          className="flex items-center"
+          style={{ gap: 'min(6px, 1.5cqmin)' }}
         >
-          <Plus
-            style={{ width: 'min(14px, 4cqmin)', height: 'min(14px, 4cqmin)' }}
-          />
-          New Quiz
-        </button>
+          <button
+            onClick={onImport}
+            className="flex items-center bg-white hover:bg-brand-blue-lighter/40 text-brand-blue-primary font-bold rounded-xl transition-all shadow-sm active:scale-95 border border-brand-blue-primary/20"
+            style={{
+              gap: 'min(6px, 1.5cqmin)',
+              padding: 'min(6px, 1.5cqmin) min(12px, 3cqmin)',
+              fontSize: 'min(12px, 3.5cqmin)',
+            }}
+            title="Import from CSV or Google Sheet"
+          >
+            <FileUp
+              style={{
+                width: 'min(14px, 4cqmin)',
+                height: 'min(14px, 4cqmin)',
+              }}
+            />
+            Import
+          </button>
+          <button
+            onClick={onNew}
+            className="flex items-center bg-brand-blue-primary hover:bg-brand-blue-dark text-white font-bold rounded-xl transition-all shadow-sm active:scale-95"
+            style={{
+              gap: 'min(6px, 1.5cqmin)',
+              padding: 'min(6px, 1.5cqmin) min(12px, 3cqmin)',
+              fontSize: 'min(12px, 3.5cqmin)',
+            }}
+          >
+            <Plus
+              style={{
+                width: 'min(14px, 4cqmin)',
+                height: 'min(14px, 4cqmin)',
+              }}
+            />
+            New Quiz
+          </button>
+        </div>
       </div>
 
       {/* Active Session Banner */}

--- a/context/AuthContext.tsx
+++ b/context/AuthContext.tsx
@@ -8,6 +8,7 @@ import React, {
 import {
   User,
   signInWithPopup,
+  signInAnonymously,
   signOut as firebaseSignOut,
   onAuthStateChanged,
   GoogleAuthProvider,
@@ -141,12 +142,30 @@ const MOCK_USER = {
   toJSON: () => ({}),
 } as unknown as User;
 
+/**
+ * Wraps a real anonymous Firebase User so it presents mock email/displayName
+ * to the UI while preserving the real uid and auth methods. The real uid is
+ * critical: Firestore security rules enforce `request.auth.uid == userId`,
+ * so data paths like `/users/{uid}/...` must match the anonymous user's uid.
+ */
+const makeHybridBypassUser = (anonUser: User): User =>
+  new Proxy(anonUser, {
+    get(target, prop, receiver) {
+      if (prop === 'email') return MOCK_USER.email;
+      if (prop === 'displayName') return MOCK_USER.displayName;
+      const value: unknown = Reflect.get(target, prop, receiver);
+      return typeof value === 'function'
+        ? (value as (...args: unknown[]) => unknown).bind(target)
+        : value;
+    },
+  });
+
 export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
   children,
 }) => {
-  const [user, setUser] = useState<User | null>(
-    isAuthBypass ? MOCK_USER : null
-  );
+  // In bypass mode, start with no user until anonymous Firebase auth completes.
+  // This keeps `user.uid` consistent with `request.auth.uid` for Firestore rules.
+  const [user, setUser] = useState<User | null>(null);
   const [googleAccessToken, setGoogleAccessToken] = useState<string | null>(
     () => {
       if (isAuthBypass) return MOCK_ACCESS_TOKEN;
@@ -166,10 +185,9 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
       return token;
     }
   );
-  // Note: In bypass mode we initialize `loading` to false because the mock user
-  // and admin status are set synchronously above. This makes the auth state
-  // appear "ready" immediately for faster local development and testing.
-  const [loading, setLoading] = useState(!isAuthBypass);
+  // Even in bypass mode, start loading=true until anonymous Firebase auth
+  // resolves so `user.uid` is ready before any Firestore reads fire.
+  const [loading, setLoading] = useState(true);
   const [isAdmin, setIsAdmin] = useState<boolean | null>(
     isAuthBypass ? true : null
   ); // null = not yet checked
@@ -876,6 +894,33 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
     return unsubscribe;
   }, []);
 
+  // Bypass mode: sign in anonymously so `request.auth.uid` is a real Firebase
+  // uid that satisfies Firestore security rules. Wrap the resulting user in a
+  // proxy that still presents mock email/displayName for UI continuity.
+  useEffect(() => {
+    if (!isAuthBypass) return;
+    let cancelled = false;
+    void (async () => {
+      try {
+        const { user: anonUser } = await signInAnonymously(auth);
+        if (cancelled) return;
+        setUser(makeHybridBypassUser(anonUser));
+      } catch (err) {
+        console.error(
+          '[AuthContext] Anonymous sign-in failed in bypass mode. ' +
+            'Enable Anonymous provider in Firebase Console > Authentication.',
+          err
+        );
+        if (!cancelled) setUser(MOCK_USER);
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
   // Helper for checking if a user has beta access
   const isBetaUser = useCallback(
     (betaUsers: string[], email: string | null | undefined) => {
@@ -961,7 +1006,13 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
   const signInWithGoogle = async () => {
     if (isAuthBypass) {
       console.warn('Bypassing Google Sign In');
-      setUser(MOCK_USER);
+      try {
+        const { user: anonUser } = await signInAnonymously(auth);
+        setUser(makeHybridBypassUser(anonUser));
+      } catch (err) {
+        console.error('[AuthContext] Anonymous sign-in failed:', err);
+        setUser(MOCK_USER);
+      }
       setGoogleAccessToken(MOCK_ACCESS_TOKEN);
       localStorage.setItem(
         GOOGLE_TOKEN_EXPIRY_KEY,

--- a/context/AuthContext.tsx
+++ b/context/AuthContext.tsx
@@ -897,12 +897,17 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
   // Bypass mode: sign in anonymously so `request.auth.uid` is a real Firebase
   // uid that satisfies Firestore security rules. Wrap the resulting user in a
   // proxy that still presents mock email/displayName for UI continuity.
+  // Reuse an existing anonymous session if one is already active — avoids
+  // churning the anonymous uid on hot reloads and StrictMode double-mounts.
   useEffect(() => {
     if (!isAuthBypass) return;
     let cancelled = false;
     void (async () => {
       try {
-        const { user: anonUser } = await signInAnonymously(auth);
+        const existing = auth.currentUser;
+        const anonUser = existing?.isAnonymous
+          ? existing
+          : (await signInAnonymously(auth)).user;
         if (cancelled) return;
         setUser(makeHybridBypassUser(anonUser));
       } catch (err) {

--- a/docs/unified-editor-modal-plan.md
+++ b/docs/unified-editor-modal-plan.md
@@ -1,0 +1,205 @@
+# Unified Full-Screen Editor Modal — Implementation Plan
+
+Shared full-screen modal editor for library-style widgets (Quiz, Video Activity, MiniApp, Guided Learning). Replaces cramped in-widget back-face editors with a viewport-scale modal that mirrors the roster editor pattern established in commit `57fc7b13`.
+
+## Status
+
+- [x] **Phase 0** — Shared primitives (EditorModalShell, auth-bypass plumbing)
+- [x] **Phase 1** — Quiz
+- [ ] **Phase 2** — Video Activity
+- [ ] **Phase 3** — MiniApp
+- [ ] **Phase 4** — Guided Learning
+
+Each phase is independently shippable. Phase 1 is landed on `dev-paul`; the remaining phases follow the same playbook.
+
+---
+
+## Phase 0 — Shared Primitives (Complete)
+
+### `components/common/EditorModalShell.tsx`
+
+Wraps the base `components/common/Modal.tsx` with standardized editor chrome. All four per-widget modals should use it verbatim — do not fork.
+
+- Sizing: `max-w-5xl` (override via `maxWidth`), `h-[85vh]` (override via `className`).
+- Sticky header: title, optional subtitle, close (X) button.
+- Sticky footer: `Cancel` (always enabled) and `Save` (spinner when `isSaving`, disabled when `saveDisabled`). Optional `footerExtras` slot for per-editor actions (e.g., Delete).
+- Dirty-state guard: when `isDirty` is true, X / Cancel / Escape / backdrop-click all route through `DialogContext.showConfirm` with "Discard changes?" / "Keep editing" / "Discard".
+- Accessibility: focus trap, `aria-labelledby` on title, Escape handled at the shell level.
+
+Parent owns draft state and `isDirty` computation. The shell only handles presentation, close-confirm flow, and the save spinner.
+
+### Auth-bypass mode plumbing (`context/AuthContext.tsx`)
+
+When `VITE_AUTH_BYPASS=true`, the app now calls `signInAnonymously()` to get a real Firebase UID (so Firestore security rules like `request.auth.uid == userId` pass) and wraps the returned user in a `Proxy` that overrides `email` and `displayName` with the `MOCK_USER` values for UI display. This keeps the dev experience identical while letting Firestore writes actually work.
+
+### Mock Drive service pattern (`utils/mockQuizDriveService.ts`)
+
+Structural stand-in for `QuizDriveService` used in bypass mode (no Google access token means the real Drive service can't save/load). Stores the full blob in `localStorage` keyed by `mock_quiz_drive:{userId}:{fileId}`.
+
+- `localStorage` chosen over a Firestore-backed mock path so no dev-only Firestore rule has to be deployed to the shared production project (`spartboard`).
+- Swapped in via `useQuiz.getDriveService()` based on `isAuthBypass`.
+- The `QuizDriveLike` interface in the mock file is the structural contract — both real and mock services satisfy it.
+
+**Apply this pattern for VA / MiniApp / GL**: each widget stores authored content in Google Drive + metadata in Firestore. Create `mockVideoActivityDriveService.ts`, `mockMiniAppDriveService.ts`, etc., each with a `<Widget>DriveLike` interface and an `isAuthBypass` branch in their hook.
+
+---
+
+## Phase 1 — Quiz (Complete, landed on `dev-paul`)
+
+### Files changed
+
+**New**
+
+- `components/common/EditorModalShell.tsx`
+- `components/widgets/QuizWidget/components/QuizEditorModal.tsx`
+- `utils/mockQuizDriveService.ts`
+
+**Modified**
+
+- `components/widgets/QuizWidget/Widget.tsx` — removed back-face editor; added `editingQuiz` / `editingMeta` local state; `onNew` builds a blank `QuizData` draft; modal rendered as sibling to `QuizManager`.
+- `components/widgets/QuizWidget/components/QuizManager.tsx` — split `onNew` (primary "+ New Quiz" button) from `onImport` (secondary "Import" button) in the header; "Start Importing" empty-state CTA still routes to import.
+- `hooks/useQuiz.ts` — selects real vs mock drive service by `isAuthBypass`.
+- `context/AuthContext.tsx` — anonymous-auth plumbing described above.
+
+**Deleted**
+
+- `components/widgets/QuizWidget/components/QuizEditor.tsx`
+
+### Key UX decisions (locked — follow for VA/MiniApp/GL)
+
+1. **"New" opens the editor modal directly** with a blank draft — not the import wizard.
+2. **"Import" is a separate secondary button** in the library header (plus the empty-state CTA).
+3. **Title input is the first field** in the editor body. It is required on save and must be part of the `isDirty` computation.
+4. **Modal header title** reflects the live draft title as the user types; falls back to `New <Widget>` for blank drafts and `Edit <Widget>` for renaming-to-empty edge cases.
+5. **Save for new items**: parent calls `save<X>(draft, undefined)` — the existing drive service creates a new file. Do not add new-vs-edit branching.
+6. **Dirty-guard**: X / Escape / backdrop all route through the shell's confirm flow. Do not re-implement.
+7. **No back-face editor** for any of the four widgets. The back-face still exists for regular widget settings (visual/playback), just not content authoring.
+
+### Verified flows (manual preview under `VITE_AUTH_BYPASS=true`)
+
+- **Create**: `+ New Quiz` → blank modal with empty title + zero questions → fill title → `ADD NEW QUESTION` → fill text + correct answer → `Save Quiz` → modal closes, quiz appears in library.
+- **Edit**: `Edit` on row → modal pre-populated → change a field → `Save Quiz` → persisted.
+- **Dirty-guard**: change title or question field → Escape → "Discard changes?" dialog → `Keep editing` preserves state, `Discard` reverts.
+- **Import**: `Import` button still opens CSV/Sheet wizard; saved quiz appears in library.
+
+---
+
+## Phase 2 — Video Activity (Pending)
+
+Location: `components/widgets/VideoActivityWidget/`
+
+### Files to create
+
+- `components/widgets/VideoActivityWidget/components/VideoActivityEditorModal.tsx`
+- `utils/mockVideoActivityDriveService.ts` (only if VA stores blobs in Drive — verify by reading the existing VA drive service / hook)
+
+### Files to modify
+
+- `components/widgets/VideoActivityWidget/Widget.tsx` — remove back-face editor path; add `editingActivity` local state; render the modal as a sibling to the library component; `onNew` builds a blank `VideoActivityData` draft.
+- The VA library/manager component (find it — probably `Manager.tsx` or similar) — add `onNew` prop; split header into `Import` + `New` buttons same as Quiz.
+- `hooks/useVideoActivity.ts` (or wherever the VA hook lives) — add real/mock drive service selection by `isAuthBypass`.
+
+### Implementation notes
+
+1. Follow `QuizEditorModal.tsx` as the reference. VA questions have an extra `timestamp` field (the video time the question fires at) — add it as a field inside each question block; include it in the `questionsEqual` dirty-check.
+2. **Decision during implementation**: extract `components/common/QuestionEditor.tsx` shared between Quiz and VA if the duplication is clean. If the timestamp field makes the shared props shape awkward, defer the extraction and accept the duplication for now. Per the original plan, this is opportunistic — don't force it.
+3. Verify the 5 flows from the Phase 1 verification list.
+
+---
+
+## Phase 3 — MiniApp (Pending)
+
+Location: `components/widgets/MiniApp/`
+
+### Files to create
+
+- `components/widgets/MiniApp/components/MiniAppEditorModal.tsx`
+- `utils/mockMiniAppDriveService.ts` (only if MiniApp stores code/config blobs in Drive — verify)
+
+### Files to modify
+
+- `components/widgets/MiniApp/Widget.tsx` — same pattern as Quiz.
+- MiniApp library view component — split `Import` / `New` header buttons.
+- `components/widgets/MiniApp/components/MiniAppEditor.tsx` — body migrated into the new modal (or deleted if replaced entirely).
+
+### Implementation notes
+
+1. MiniApp editor body is code/config-centric — structurally unlike Quiz questions. Just wrap the existing body in `EditorModalShell`; don't try to reuse `QuestionEditor`.
+2. Dirty-check: a deep-equal (`JSON.stringify` compare or a small helper) on the draft vs original may be simpler than field-by-field given the config shape. The shell just needs a boolean.
+3. Verify the 5 flows.
+
+---
+
+## Phase 4 — Guided Learning (Pending, highest complexity)
+
+Location: `components/widgets/GuidedLearning/`
+
+### Files to create
+
+- `components/widgets/GuidedLearning/components/GuidedLearningEditorModal.tsx`
+- `utils/mockGuidedLearningDriveService.ts` (only if GL stores blobs in Drive — verify)
+
+### Files to modify
+
+- `components/widgets/GuidedLearning/Widget.tsx`
+- `GuidedLearningLibrary.tsx`
+- `GuidedLearningEditor.tsx` — body migrated into the modal.
+
+### Implementation notes
+
+1. GL has nested steps, nested questions, and image uploads. **Do not refactor the body** during this migration — move it into the modal as-is. Refactoring can happen later in its own PR.
+2. Dirty-check: write a structural compare for the steps array (recursive helper). Don't rely on deep-equal on image data URIs — compare by URL/key.
+3. Do this phase last so the shell is battle-tested by the simpler editors.
+4. Verify: step reordering, image upload, nested question types all work inside the modal. Plus the standard 5 flows.
+
+---
+
+## Verification checklist (per phase)
+
+Run locally under `pnpm run dev` (set `VITE_AUTH_BYPASS=true` in `.env.local` for speed).
+
+1. **Create**: Add widget to dashboard → click `+ New <X>` → modal opens at `max-w-5xl h-[85vh]` → fill a minimum valid item → `Save` → modal closes → item appears in library → widget plays it correctly.
+2. **Edit**: `Edit` on a library row → modal opens pre-populated → change field → `Save` → change persisted (refresh page, still there).
+3. **Dirty-guard**: Open editor → change a field → press Escape → confirm dialog → `Keep editing` preserves state with changes intact → `Discard` closes and reverts.
+4. **Close paths are uniform**: X button, Escape, and backdrop click all route through the same dirty-guard.
+5. **Validation + save errors**: block the network tab → `Save` → button returns to enabled, error shown inline, editor stays open.
+6. **Widget playback regression**: confirm the widget front-face (live session, playback, etc.) is unchanged.
+
+After all phases, cross-widget verification:
+
+- Visual consistency: stack screenshots — header, footer, spacing, button placement should be visually identical across all four editors.
+- `pnpm run validate` passes (type-check + lint + format-check + tests).
+- No back-face editor is reachable for the four in-scope widgets.
+- Hotspot Image, PDF, SmartNotebook behavior unchanged (regression).
+
+---
+
+## Out of scope (explicitly deferred)
+
+- **Hotspot Image editor** — different UX (visual canvas), warrants its own plan.
+- **Global "Content Library" surface** in the sidebar — considered and rejected.
+- **Autosave** — explicit Save + dirty-guard is the chosen model.
+- **Extracting primitives from Guided Learning or MiniApp** — defer until a clear reuse case appears.
+
+---
+
+## Known quirks / implementation gotchas
+
+1. **Auth-bypass mode uses a real anon Firebase UID** under the hood (`AuthContext`) so Firestore rules pass. A `Proxy` overrides `email` / `displayName` to `MOCK_USER` values for UI display. If you see "Missing or insufficient permissions" on a Firestore write in bypass mode, the likely cause is the target path not being covered by any `allow` rule — either add a real rule or (preferred) swap the storage for `localStorage` via the mock service pattern.
+
+2. **Why `localStorage` for mock drive blobs, not Firestore?** Avoids deploying dev-only Firestore rules to the shared production project (`spartboard`). Keyed per user (`{userId}:{fileId}`) to survive multi-user dev scenarios on the same browser.
+
+3. **Editor modal title field**: remember to include the title in `isDirty`. Quiz does `title !== originalTitle || !questionsEqual(...)`. Forgetting this means rename-only edits are silently discarded when the user hits Escape.
+
+4. **Save path for new vs existing**: the existing save functions (`saveQuiz`, etc.) take `(data, existingFileId?)`. Pass `undefined` for new; pass the meta's `driveFileId` for edits. Don't add new-vs-edit branching in the modal — it's already handled downstream.
+
+5. **Widget.tsx modal sibling rendering**: the modal is rendered as a sibling to the library component, not inside it. This keeps modal state in the widget's root and avoids prop-drilling through the library.
+
+---
+
+## References
+
+- Template: `components/classes/RosterEditorModal.tsx` (commit `57fc7b13`)
+- Base primitive: `components/common/Modal.tsx`
+- Confirm dialog: `context/DialogContext.tsx` (`showConfirm`)
+- Z-index: `config/zIndex.ts` (`modal: 10000`, `modalNested: 10100`)

--- a/hooks/useQuiz.ts
+++ b/hooks/useQuiz.ts
@@ -17,12 +17,16 @@ import {
   query,
   orderBy,
 } from 'firebase/firestore';
-import { db } from '../config/firebase';
+import { db, isAuthBypass } from '../config/firebase';
 import { useAuth } from '../context/useAuth';
 import { useGoogleDrive } from './useGoogleDrive';
 import { useQuizSessionTeacher } from './useQuizSession';
 import { QuizData, QuizMetadata } from '../types';
 import { QuizDriveService } from '../utils/quizDriveService';
+import {
+  MockQuizDriveService,
+  QuizDriveLike,
+} from '../utils/mockQuizDriveService';
 
 const QUIZZES_COLLECTION = 'quizzes';
 
@@ -95,14 +99,18 @@ export const useQuiz = (userId: string | undefined): UseQuizResult => {
     return unsub;
   }, [userId]);
 
-  const getDriveService = useCallback((): QuizDriveService => {
+  const getDriveService = useCallback((): QuizDriveLike => {
+    if (isAuthBypass) {
+      if (!userId) throw new Error('Not authenticated');
+      return new MockQuizDriveService(userId);
+    }
     if (!googleAccessToken) {
       throw new Error(
         'Not connected to Google Drive. Please sign in again to grant access.'
       );
     }
     return new QuizDriveService(googleAccessToken);
-  }, [googleAccessToken]);
+  }, [googleAccessToken, userId]);
 
   const saveQuiz = useCallback(
     async (
@@ -258,6 +266,6 @@ export const useQuiz = (userId: string | undefined): UseQuizResult => {
     createQuizTemplate,
     shareQuiz,
     importSharedQuiz,
-    isDriveConnected: isConnected,
+    isDriveConnected: isAuthBypass || isConnected,
   };
 };

--- a/utils/mockQuizDriveService.ts
+++ b/utils/mockQuizDriveService.ts
@@ -1,0 +1,71 @@
+/**
+ * Dev-only mock of QuizDriveService for auth-bypass mode.
+ *
+ * When VITE_AUTH_BYPASS=true there is no Google access token, so the real
+ * Drive service cannot save or load quizzes. This mock stores the full
+ * QuizData blob in localStorage keyed by synthetic file IDs. Metadata
+ * continues to live in Firestore under the normal quizzes path — only
+ * the blob half of the storage pair is replaced.
+ *
+ * localStorage was chosen over a Firestore-backed mock path so no dev-only
+ * rule has to be deployed to the shared production Firebase project.
+ *
+ * Only activated when isAuthBypass is true.
+ */
+import { QuizData, QuizQuestion } from '../types';
+
+const STORAGE_PREFIX = 'mock_quiz_drive';
+
+/** Structural surface of QuizDriveService consumed by useQuiz. */
+export interface QuizDriveLike {
+  saveQuiz(quiz: QuizData, existingFileId?: string): Promise<string>;
+  loadQuiz(fileId: string): Promise<QuizData>;
+  deleteQuizFile(fileId: string): Promise<void>;
+  importFromGoogleSheet(
+    sheetId: string,
+    sheetName?: string
+  ): Promise<QuizQuestion[]>;
+  createQuizTemplate(): Promise<string>;
+}
+
+export class MockQuizDriveService implements QuizDriveLike {
+  constructor(private userId: string) {}
+
+  private key(fileId: string): string {
+    return `${STORAGE_PREFIX}:${this.userId}:${fileId}`;
+  }
+
+  saveQuiz(quiz: QuizData, existingFileId?: string): Promise<string> {
+    const fileId = existingFileId ?? `mock-${crypto.randomUUID()}`;
+    localStorage.setItem(this.key(fileId), JSON.stringify(quiz));
+    return Promise.resolve(fileId);
+  }
+
+  loadQuiz(fileId: string): Promise<QuizData> {
+    const raw = localStorage.getItem(this.key(fileId));
+    if (!raw)
+      return Promise.reject(new Error('Quiz file not found in mock drive'));
+    return Promise.resolve(JSON.parse(raw) as QuizData);
+  }
+
+  deleteQuizFile(fileId: string): Promise<void> {
+    localStorage.removeItem(this.key(fileId));
+    return Promise.resolve();
+  }
+
+  importFromGoogleSheet(): Promise<QuizQuestion[]> {
+    return Promise.reject(
+      new Error(
+        'Google Sheet import is not available in auth-bypass mode. Use CSV import instead.'
+      )
+    );
+  }
+
+  createQuizTemplate(): Promise<string> {
+    return Promise.reject(
+      new Error(
+        'Template creation requires Google Drive. Not available in auth-bypass mode.'
+      )
+    );
+  }
+}


### PR DESCRIPTION
Replaces Quiz back-face editor with a viewport-scale modal using the shared EditorModalShell primitive. "New Quiz" opens the editor with a blank draft; "Import" remains as a secondary path. Editable title field included in dirty-check and validated on save.

Adds auth-bypass plumbing (anon Firebase sign-in with Proxy overrides) and a localStorage-backed MockQuizDriveService so dev flows work under VITE_AUTH_BYPASS=true without deploying dev-only Firestore rules.

Plan for Phases 2-4 (Video Activity, MiniApp, Guided Learning) at docs/unified-editor-modal-plan.md.