### PR TITLE
fix(embed): float zoom toolbar below widget, outside its frame

### DIFF
--- a/components/widgets/Embed/Widget.test.tsx
+++ b/components/widgets/Embed/Widget.test.tsx
@@ -125,6 +125,22 @@ vi.mock('@/utils/ai', () => ({
   generateMiniAppCode: vi.fn(),
 }));
 
+// The toolbar (zoom + mini-app + open-in-new-tab) now renders via createPortal,
+// anchored to the nearest `[data-widget-id]` ancestor. Production provides this
+// via DraggableWindow; tests must provide it explicitly. The toolbar only
+// becomes interactive while the widget is hovered, so we fire a pointerEnter
+// on the wrapper so the portaled buttons are clickable in tests.
+const renderEmbedWidget = (widget: WidgetData) => {
+  const utils = render(
+    <div data-testid={`widget-wrapper-${widget.id}`} data-widget-id={widget.id}>
+      <EmbedWidget widget={widget} />
+    </div>
+  );
+  const wrapper = utils.getByTestId(`widget-wrapper-${widget.id}`);
+  fireEvent.pointerEnter(wrapper);
+  return utils;
+};
+
 describe('EmbedWidget', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -266,7 +282,7 @@ describe('EmbedWidget', () => {
     };
 
     it('renders the generate mini app button', () => {
-      render(<EmbedWidget widget={validWidget} />);
+      renderEmbedWidget(validWidget);
       const btn = screen.getByRole('button', {
         name: /generate interactive mini app/i,
       });
@@ -283,7 +299,7 @@ describe('EmbedWidget', () => {
       };
       vi.mocked(aiModule.generateMiniAppCode).mockResolvedValueOnce(mockResult);
 
-      render(<EmbedWidget widget={validWidget} />);
+      renderEmbedWidget(validWidget);
       const btn = screen.getByRole('button', {
         name: /generate interactive mini app/i,
       });
@@ -332,7 +348,7 @@ describe('EmbedWidget', () => {
         new Error('AI failed')
       );
 
-      render(<EmbedWidget widget={validWidget} />);
+      renderEmbedWidget(validWidget);
       const btn = screen.getByRole('button', {
         name: /generate interactive mini app/i,
       });

--- a/components/widgets/Embed/Widget.tsx
+++ b/components/widgets/Embed/Widget.tsx
@@ -1,4 +1,5 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef, useCallback } from 'react';
+import { createPortal } from 'react-dom';
 import { WidgetData, EmbedConfig, MiniAppConfig } from '@/types';
 import {
   Globe,
@@ -24,10 +25,13 @@ import { useEmbedConfig } from './hooks/useEmbedConfig';
 import { useGoogleDrive } from '@/hooks/useGoogleDrive';
 import { useAuth } from '@/context/useAuth';
 import { useWidgetBuildingId } from '@/hooks/useWidgetBuildingId';
+import { Z_INDEX } from '@/config/zIndex';
 
 import { applyAutoplay } from './applyAutoplay';
 
 const NEW_WIDGET_SPACING = 20;
+const TOOLBAR_GAP = 6;
+const ESTIMATED_TOOLBAR_HEIGHT = 44;
 
 export const EmbedWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
   const { addWidget, addToast, updateWidget } = useDashboard();
@@ -81,6 +85,91 @@ export const EmbedWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
     e.stopPropagation();
     updateWidget(widget.id, { config: { ...config, zoom: 1.0 } });
   };
+
+  // Track the outer widget element so we can anchor the floating toolbar
+  // just outside the widget's frame (bottom-left). The toolbar lives in a
+  // portal under <body> so it never overlaps full-bleed iframe content
+  // (Google Docs tabs, YouTube chrome, etc.).
+  const contentRef = useRef<HTMLDivElement | null>(null);
+  const [widgetEl, setWidgetEl] = useState<HTMLElement | null>(null);
+  const [rect, setRect] = useState<DOMRect | null>(null);
+  const [isHot, setIsHot] = useState(false);
+  const [focusCount, setFocusCount] = useState(0);
+  // Delayed-hide timer so the pointer can cross the small gap between the
+  // widget and the portaled toolbar without the toolbar flickering off.
+  const hideTimerRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    const el =
+      contentRef.current?.closest<HTMLElement>(
+        `[data-widget-id="${widget.id}"]`
+      ) ?? null;
+    setWidgetEl(el);
+    if (el) setRect(el.getBoundingClientRect());
+  }, [widget.id]);
+
+  const updateRect = useCallback(() => {
+    if (!widgetEl) return;
+    setRect(widgetEl.getBoundingClientRect());
+  }, [widgetEl]);
+
+  useEffect(() => {
+    if (!widgetEl) return;
+    updateRect();
+
+    const resizeObserver = new ResizeObserver(() => updateRect());
+    resizeObserver.observe(widgetEl);
+
+    const mutationObserver = new MutationObserver(() => updateRect());
+    mutationObserver.observe(widgetEl, {
+      attributes: true,
+      attributeFilter: ['style'],
+    });
+
+    const onScrollOrResize = () => updateRect();
+    window.addEventListener('scroll', onScrollOrResize, true);
+    window.addEventListener('resize', onScrollOrResize);
+
+    return () => {
+      resizeObserver.disconnect();
+      mutationObserver.disconnect();
+      window.removeEventListener('scroll', onScrollOrResize, true);
+      window.removeEventListener('resize', onScrollOrResize);
+    };
+  }, [widgetEl, updateRect]);
+
+  const cancelPendingHide = useCallback(() => {
+    if (hideTimerRef.current != null) {
+      window.clearTimeout(hideTimerRef.current);
+      hideTimerRef.current = null;
+    }
+  }, []);
+
+  const showToolbar = useCallback(() => {
+    cancelPendingHide();
+    setIsHot(true);
+  }, [cancelPendingHide]);
+
+  const scheduleHide = useCallback(() => {
+    cancelPendingHide();
+    hideTimerRef.current = window.setTimeout(() => {
+      hideTimerRef.current = null;
+      setIsHot(false);
+    }, 150);
+  }, [cancelPendingHide]);
+
+  useEffect(() => () => cancelPendingHide(), [cancelPendingHide]);
+
+  useEffect(() => {
+    if (!widgetEl) return;
+    widgetEl.addEventListener('pointerenter', showToolbar);
+    widgetEl.addEventListener('pointerleave', scheduleHide);
+    return () => {
+      widgetEl.removeEventListener('pointerenter', showToolbar);
+      widgetEl.removeEventListener('pointerleave', scheduleHide);
+    };
+  }, [widgetEl, showToolbar, scheduleHide]);
+
   const sanitizedUrl = ensureProtocol(url);
   const embedUrl = convertToEmbedUrl(sanitizedUrl);
 
@@ -244,120 +333,121 @@ export const EmbedWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
     );
   }
 
+  const hasContent =
+    (displayMode === 'url' && url.trim().length > 0) ||
+    (displayMode === 'code' && html.trim().length > 0);
+  const toolbarVisible = !widget.minimized && (isHot || focusCount > 0);
+  const flipAbove =
+    rect != null &&
+    rect.bottom + ESTIMATED_TOOLBAR_HEIGHT + TOOLBAR_GAP > window.innerHeight;
+
   return (
     <WidgetLayout
       padding="p-0"
       content={
-        <div className="w-full h-full bg-transparent flex flex-col overflow-hidden relative group/embed-content">
-          {((displayMode === 'url' && url.trim()) ||
-            (displayMode === 'code' && html.trim())) && (
-            <div className="absolute top-2 left-2 z-10 flex items-center gap-1 opacity-0 group-hover/embed-content:opacity-100 focus-within:opacity-100 transition-opacity">
-              <div className="flex items-center bg-white/80 backdrop-blur-sm shadow-sm border border-slate-200/50 rounded-lg overflow-hidden">
-                <button
-                  onClick={handleZoomOut}
-                  disabled={!canZoomOut}
-                  className="text-slate-500 hover:text-blue-500 hover:bg-slate-50 transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
-                  style={{ padding: 'min(8px, 2cqmin)' }}
-                  title="Zoom out"
-                >
-                  <ZoomOut
-                    style={{
-                      width: 'clamp(14px, 4cqmin, 18px)',
-                      height: 'clamp(14px, 4cqmin, 18px)',
-                    }}
-                  />
-                </button>
-                <span title={isDefaultZoom ? 'Current zoom' : undefined}>
+        <div
+          ref={contentRef}
+          className="w-full h-full bg-transparent flex flex-col overflow-hidden relative"
+        >
+          {hasContent &&
+            rect &&
+            typeof document !== 'undefined' &&
+            createPortal(
+              <div
+                data-settings-exclude
+                onPointerDown={(e) => e.stopPropagation()}
+                onClick={(e) => e.stopPropagation()}
+                onPointerEnter={showToolbar}
+                onPointerLeave={scheduleHide}
+                onFocus={() => {
+                  cancelPendingHide();
+                  setFocusCount((c) => c + 1);
+                }}
+                onBlur={() => setFocusCount((c) => (c > 0 ? c - 1 : 0))}
+                style={{
+                  position: 'fixed',
+                  left: rect.left,
+                  top: flipAbove
+                    ? rect.top - TOOLBAR_GAP
+                    : rect.bottom + TOOLBAR_GAP,
+                  transform: flipAbove ? 'translateY(-100%)' : undefined,
+                  zIndex: Z_INDEX.popover,
+                  opacity: toolbarVisible ? 1 : 0,
+                  pointerEvents: toolbarVisible ? 'auto' : 'none',
+                  transition: 'opacity 150ms ease',
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 4,
+                }}
+              >
+                <div className="flex items-center bg-white/80 backdrop-blur-sm shadow-sm border border-slate-200/50 rounded-lg overflow-hidden">
                   <button
-                    onClick={handleZoomReset}
-                    disabled={isDefaultZoom}
-                    className="text-slate-600 font-mono font-bold select-none hover:text-blue-500 hover:bg-slate-50 transition-colors disabled:cursor-default disabled:hover:text-slate-600 disabled:hover:bg-transparent"
-                    style={{
-                      fontSize: 'clamp(10px, 3cqmin, 13px)',
-                      minWidth: '3em',
-                      padding: '0 min(4px, 1cqmin)',
-                    }}
-                    title={isDefaultZoom ? undefined : 'Reset to 100%'}
+                    onClick={handleZoomOut}
+                    disabled={!canZoomOut}
+                    className="p-2 text-slate-500 hover:text-blue-500 hover:bg-slate-50 transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
+                    title="Zoom out"
                   >
-                    {Math.round(effectiveZoom * 100)}%
+                    <ZoomOut className="w-4 h-4" />
                   </button>
-                </span>
-                <button
-                  onClick={handleZoomIn}
-                  disabled={!canZoomIn}
-                  className="text-slate-500 hover:text-blue-500 hover:bg-slate-50 transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
-                  style={{ padding: 'min(8px, 2cqmin)' }}
-                  title="Zoom in"
-                >
-                  <ZoomIn
-                    style={{
-                      width: 'clamp(14px, 4cqmin, 18px)',
-                      height: 'clamp(14px, 4cqmin, 18px)',
-                    }}
-                  />
-                </button>
-                {!isDefaultZoom && (
+                  <span title={isDefaultZoom ? 'Current zoom' : undefined}>
+                    <button
+                      onClick={handleZoomReset}
+                      disabled={isDefaultZoom}
+                      className="px-1 text-xs font-mono font-bold text-slate-600 select-none hover:text-blue-500 hover:bg-slate-50 transition-colors disabled:cursor-default disabled:hover:text-slate-600 disabled:hover:bg-transparent"
+                      style={{ minWidth: '3em' }}
+                      title={isDefaultZoom ? undefined : 'Reset to 100%'}
+                    >
+                      {Math.round(effectiveZoom * 100)}%
+                    </button>
+                  </span>
                   <button
-                    onClick={handleZoomReset}
-                    className="text-slate-400 hover:text-orange-500 hover:bg-orange-50 transition-colors border-l border-slate-200/50"
-                    style={{ padding: 'min(8px, 2cqmin)' }}
-                    title="Reset zoom to 100%"
+                    onClick={handleZoomIn}
+                    disabled={!canZoomIn}
+                    className="p-2 text-slate-500 hover:text-blue-500 hover:bg-slate-50 transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
+                    title="Zoom in"
                   >
-                    <RotateCcw
-                      style={{
-                        width: 'clamp(12px, 3.5cqmin, 15px)',
-                        height: 'clamp(12px, 3.5cqmin, 15px)',
-                      }}
-                    />
+                    <ZoomIn className="w-4 h-4" />
+                  </button>
+                  {!isDefaultZoom && (
+                    <button
+                      onClick={handleZoomReset}
+                      className="p-2 text-slate-400 hover:text-orange-500 hover:bg-orange-50 transition-colors border-l border-slate-200/50"
+                      title="Reset zoom to 100%"
+                    >
+                      <RotateCcw className="w-3.5 h-3.5" />
+                    </button>
+                  )}
+                </div>
+                {canAccessFeature('embed-mini-app') && (
+                  <button
+                    onClick={handleGenerateMiniApp}
+                    disabled={isGeneratingApp}
+                    className="p-2 bg-white/80 backdrop-blur-sm hover:bg-indigo-50 text-indigo-500 shadow-sm border border-indigo-200/50 rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center"
+                    title="Generate Interactive Mini App"
+                    aria-label="Generate Interactive Mini App"
+                  >
+                    {isGeneratingApp ? (
+                      <Loader2 className="w-4 h-4 animate-spin" />
+                    ) : (
+                      <Wand2 className="w-4 h-4" />
+                    )}
                   </button>
                 )}
-              </div>
-              {canAccessFeature('embed-mini-app') && (
-                <button
-                  onClick={handleGenerateMiniApp}
-                  disabled={isGeneratingApp}
-                  className="bg-white/80 backdrop-blur-sm hover:bg-indigo-50 text-indigo-500 shadow-sm border border-indigo-200/50 rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center"
-                  style={{ padding: 'min(8px, 2cqmin)' }}
-                  title="Generate Interactive Mini App"
-                  aria-label="Generate Interactive Mini App"
-                >
-                  {isGeneratingApp ? (
-                    <Loader2
-                      className="animate-spin"
-                      style={{
-                        width: 'clamp(14px, 4cqmin, 18px)',
-                        height: 'clamp(14px, 4cqmin, 18px)',
-                      }}
-                    />
-                  ) : (
-                    <Wand2
-                      style={{
-                        width: 'clamp(14px, 4cqmin, 18px)',
-                        height: 'clamp(14px, 4cqmin, 18px)',
-                      }}
-                    />
-                  )}
-                </button>
-              )}
-              {displayMode === 'url' && sanitizedUrl && (
-                <a
-                  href={sanitizedUrl}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="bg-white/80 backdrop-blur-sm hover:bg-white text-slate-500 hover:text-blue-500 shadow-sm border border-slate-200/50 rounded-lg p-2 transition-colors flex items-center justify-center"
-                  title="Open in new tab"
-                  onClick={(e) => e.stopPropagation()}
-                >
-                  <ExternalLink
-                    style={{
-                      width: 'clamp(14px, 4cqmin, 18px)',
-                      height: 'clamp(14px, 4cqmin, 18px)',
-                    }}
-                  />
-                </a>
-              )}
-            </div>
-          )}
+                {displayMode === 'url' && sanitizedUrl && (
+                  <a
+                    href={sanitizedUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="p-2 bg-white/80 backdrop-blur-sm hover:bg-white text-slate-500 hover:text-blue-500 shadow-sm border border-slate-200/50 rounded-lg transition-colors flex items-center justify-center"
+                    title="Open in new tab"
+                    onClick={(e) => e.stopPropagation()}
+                  >
+                    <ExternalLink className="w-4 h-4" />
+                  </a>
+                )}
+              </div>,
+              document.body
+            )}
           {displayMode === 'url' && isActuallyEmbeddable === false ? (
             <div className="flex-1 flex flex-col items-center justify-center p-[6cqmin] text-center bg-slate-50">
               <div

--- a/components/widgets/Embed/Widget.tsx
+++ b/components/widgets/Embed/Widget.tsx
@@ -170,6 +170,15 @@ export const EmbedWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
     };
   }, [widgetEl, showToolbar, scheduleHide]);
 
+  // Reset hover/focus state whenever the widget minimizes or restores so the
+  // toolbar doesn't pop back up after restore just because isHot was left
+  // true from a pre-minimize hover.
+  useEffect(() => {
+    cancelPendingHide();
+    setIsHot(false);
+    setFocusCount(0);
+  }, [widget.minimized, cancelPendingHide]);
+
   const sanitizedUrl = ensureProtocol(url);
   const embedUrl = convertToEmbedUrl(sanitizedUrl);
 
@@ -359,11 +368,19 @@ export const EmbedWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
                 onClick={(e) => e.stopPropagation()}
                 onPointerEnter={showToolbar}
                 onPointerLeave={scheduleHide}
-                onFocus={() => {
+                onFocusCapture={() => {
                   cancelPendingHide();
-                  setFocusCount((c) => c + 1);
+                  setFocusCount(1);
                 }}
-                onBlur={() => setFocusCount((c) => (c > 0 ? c - 1 : 0))}
+                onBlurCapture={(e) => {
+                  const nextFocused = e.relatedTarget;
+                  if (
+                    !(nextFocused instanceof Node) ||
+                    !e.currentTarget.contains(nextFocused)
+                  ) {
+                    setFocusCount(0);
+                  }
+                }}
                 style={{
                   position: 'fixed',
                   left: rect.left,
@@ -386,6 +403,7 @@ export const EmbedWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
                     disabled={!canZoomOut}
                     className="p-2 text-slate-500 hover:text-blue-500 hover:bg-slate-50 transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
                     title="Zoom out"
+                    aria-label="Zoom out"
                   >
                     <ZoomOut className="w-4 h-4" />
                   </button>
@@ -405,6 +423,7 @@ export const EmbedWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
                     disabled={!canZoomIn}
                     className="p-2 text-slate-500 hover:text-blue-500 hover:bg-slate-50 transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
                     title="Zoom in"
+                    aria-label="Zoom in"
                   >
                     <ZoomIn className="w-4 h-4" />
                   </button>
@@ -413,6 +432,7 @@ export const EmbedWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
                       onClick={handleZoomReset}
                       className="p-2 text-slate-400 hover:text-orange-500 hover:bg-orange-50 transition-colors border-l border-slate-200/50"
                       title="Reset zoom to 100%"
+                      aria-label="Reset zoom to 100%"
                     >
                       <RotateCcw className="w-3.5 h-3.5" />
                     </button>
@@ -440,6 +460,7 @@ export const EmbedWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
                     rel="noopener noreferrer"
                     className="p-2 bg-white/80 backdrop-blur-sm hover:bg-white text-slate-500 hover:text-blue-500 shadow-sm border border-slate-200/50 rounded-lg transition-colors flex items-center justify-center"
                     title="Open in new tab"
+                    aria-label="Open in new tab"
                     onClick={(e) => e.stopPropagation()}
                   >
                     <ExternalLink className="w-4 h-4" />


### PR DESCRIPTION
## Summary

- The Embed widget's zoom + mini-app + open-in-new-tab toolbar sat in the top-left of the widget content, overlapping Google Docs' "All tabs" selector and the top chrome of most full-bleed iframes.
- Moved the toolbar to the **bottom-left** and rendered it via `createPortal` to `document.body` so it lives fully **outside** the widget frame — no more overlap with any embedded content.
- Pinned to the widget via a `ResizeObserver` + `MutationObserver` on the nearest `[data-widget-id]` ancestor so it tracks the widget through drag and resize. Flips above the widget when the widget is near the bottom of the viewport.
- Shows on hover (with a short delayed hide so the cursor can bridge the widget→toolbar gap) and while any toolbar button is focused.

## Test plan

- [ ] Add an Embed widget with a Google Doc URL → toolbar appears below the widget on hover, Google Docs' "All tabs" selector is fully clickable.
- [ ] Drag the widget around → toolbar follows the widget's bottom-left corner.
- [ ] Resize the widget → toolbar stays anchored.
- [ ] Move widget near the bottom of the viewport → toolbar flips above.
- [ ] Minimize the widget → toolbar disappears.
- [ ] Maximize the widget → toolbar still reachable.
- [ ] Tab into the zoom controls with the keyboard → toolbar stays visible while focused.
- [ ] Embed a YouTube URL → YouTube's top-left logo is no longer obscured.
- [ ] `pnpm run validate` passes locally.

https://claude.ai/code/session_01JoM1Lg3adE3qoofNk7os6p