### PR TITLE
fix(image): pasted images resize with the widget frame

### DIFF
--- a/components/layout/Dock.tsx
+++ b/components/layout/Dock.tsx
@@ -68,6 +68,10 @@ import { SmartPastePickerModal } from './dock/SmartPastePickerModal';
 import { UrlPickerModal } from './dock/UrlPickerModal';
 import { ImagePastePickerModal } from './dock/ImagePastePickerModal';
 import { useImageUpload } from '@/hooks/useImageUpload';
+import {
+  getImageDimensionsFromFile,
+  computeWidgetSizeForImage,
+} from '@/utils/imageProcessing';
 import { DockIcon } from './dock/DockIcon';
 import { DockLabel } from './dock/DockLabel';
 import { ToolDockItem } from './dock/ToolDockItem';
@@ -753,9 +757,26 @@ export const Dock: React.FC = () => {
 
             addToast('Processing image...', 'info');
             const skipProcessing = type === 'full-image';
-            const url = await processAndUploadImage(file, { skipProcessing });
+
+            // For full images, also measure the source's natural dimensions
+            // so the widget frame starts at the image's aspect ratio. This
+            // prevents the resize handles from moving an invisible boundary
+            // around a smaller, aspect-mismatched image.
+            const [url, sourceDims] = await Promise.all([
+              processAndUploadImage(file, { skipProcessing }),
+              skipProcessing
+                ? getImageDimensionsFromFile(file).catch(() => null)
+                : Promise.resolve(null),
+            ]);
+
             if (url) {
-              addWidget('sticker', { config: { url, rotation: 0 } });
+              const sizeOverrides = sourceDims
+                ? computeWidgetSizeForImage(sourceDims)
+                : {};
+              addWidget('sticker', {
+                ...sizeOverrides,
+                config: { url, rotation: 0 },
+              });
               addToast('Image added!', 'success');
             } else {
               addToast('Failed to process image', 'error');

--- a/components/widgets/stickers/StickerItemWidget.tsx
+++ b/components/widgets/stickers/StickerItemWidget.tsx
@@ -178,7 +178,7 @@ export const StickerItemWidget: React.FC<StickerItemWidgetProps> = ({
           <img
             src={config.url}
             alt="Sticker"
-            className="max-w-full max-h-full object-contain pointer-events-none drop-shadow-lg transition-transform group-hover/img:scale-105"
+            className="w-full h-full object-contain pointer-events-none drop-shadow-lg transition-transform group-hover/img:scale-105"
           />
         ) : (
           <div className="w-full h-full flex items-center justify-center bg-pink-100/50 rounded-lg border-2 border-dashed border-pink-300">

--- a/utils/imageProcessing.ts
+++ b/utils/imageProcessing.ts
@@ -178,3 +178,67 @@ export const removeBackgroundFloodFill = (
     img.src = dataUrl;
   });
 };
+
+/**
+ * Reads the natural width/height of an image file without uploading it.
+ * Uses an object URL so the browser only decodes the bitmap locally.
+ */
+export const getImageDimensionsFromFile = (
+  file: File
+): Promise<{ width: number; height: number }> => {
+  return new Promise((resolve, reject) => {
+    const url = URL.createObjectURL(file);
+    const img = new Image();
+    img.onload = () => {
+      URL.revokeObjectURL(url);
+      resolve({ width: img.naturalWidth, height: img.naturalHeight });
+    };
+    img.onerror = () => {
+      URL.revokeObjectURL(url);
+      reject(new Error('Image failed to load'));
+    };
+    img.src = url;
+  });
+};
+
+/**
+ * Given an image's natural dimensions, returns sensible widget w/h that
+ * preserves the image's aspect ratio and fits within [minDim, maxDim].
+ * Used when placing an image on the board so the initial widget frame
+ * matches the image's natural aspect ratio (and resize feels natural).
+ */
+export const computeWidgetSizeForImage = (
+  dimensions: { width: number; height: number },
+  options: { maxDim?: number; minDim?: number } = {}
+): { w: number; h: number } => {
+  const maxDim = options.maxDim ?? 500;
+  const minDim = options.minDim ?? 100;
+
+  const { width, height } = dimensions;
+  if (!width || !height) return { w: maxDim, h: maxDim };
+
+  const aspectRatio = width / height;
+
+  // Fit the larger dimension to maxDim.
+  let w: number;
+  let h: number;
+  if (aspectRatio >= 1) {
+    w = Math.min(maxDim, width);
+    h = w / aspectRatio;
+  } else {
+    h = Math.min(maxDim, height);
+    w = h * aspectRatio;
+  }
+
+  // Guard the smaller dimension against falling below minDim.
+  if (w < minDim) {
+    w = minDim;
+    h = w / aspectRatio;
+  }
+  if (h < minDim) {
+    h = minDim;
+    w = h * aspectRatio;
+  }
+
+  return { w: Math.round(w), h: Math.round(h) };
+};


### PR DESCRIPTION
## Summary

- "Full Image" pastes now actually resize when you drag the handle — the sticker `<img>` used `max-w-full max-h-full`, which only *caps* the image at the widget bounds and never grows it, so smaller pasted images sat at their natural size inside a 200x200 widget while the resize handle just moved an invisible boundary around them.
- Switched the sticker image to `w-full h-full object-contain` so it fills the widget frame while preserving aspect ratio.
- When pasting a full image, we now read its natural dimensions (via a local object URL — no extra network fetch) and seed the widget `w/h` from that aspect ratio, capped to a sensible max. The widget lands matching the image's shape instead of a mismatched 200x200 square.

## Test plan

- [ ] Paste a small portrait screenshot → choose **Full Image** → widget lands at the image's aspect ratio, image fills it, and dragging the resize handle grows/shrinks the image.
- [ ] Paste a wide landscape image → same: widget matches shape, resize handle grows the image.
- [ ] Paste a huge image (e.g. 3000×2000) → widget caps at ~500px in its larger dimension, still resizes naturally.
- [ ] Paste an image → choose **Sticker** → existing bg-removed/trimmed behavior still works (image visible, resize still works, no regression from the CSS change).
- [ ] `pnpm run type-check`, `pnpm run lint`, `pnpm run format:check`, `pnpm vitest run` — all green locally (1131 tests passing).

https://claude.ai/code/session_01GBD49wJTTUga3vP6GLj2oP