### PR TITLE
fix(drawing): align cursor with ink when widget is resized

### DIFF
--- a/components/layout/AnnotationOverlay.tsx
+++ b/components/layout/AnnotationOverlay.tsx
@@ -130,7 +130,6 @@ export const AnnotationOverlay: React.FC = () => {
     width: annotationState.width,
     objects: annotationState.objects,
     onObjectComplete: addAnnotationObject,
-    scale: 1,
     canvasSize,
     nextZ: nextZ(annotationState.objects),
   });

--- a/components/widgets/DrawingWidget/Widget.test.tsx
+++ b/components/widgets/DrawingWidget/Widget.test.tsx
@@ -62,16 +62,19 @@ describe('DrawingWidget', () => {
     vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue(
       mockContext as unknown as CanvasRenderingContext2D
     );
+    // The widget sets canvas internal resolution from canvasSize =
+    // { w: widget.w, h: widget.h - 40 } → 400x260 for the test widget below.
+    // Mock the rect to match so pointer coords translate 1:1 (no CSS scaling).
     vi.spyOn(
       HTMLCanvasElement.prototype,
       'getBoundingClientRect'
     ).mockReturnValue({
       left: 0,
       top: 0,
-      width: 800,
-      height: 600,
-      right: 800,
-      bottom: 600,
+      width: 400,
+      height: 260,
+      right: 400,
+      bottom: 260,
       x: 0,
       y: 0,
       toJSON: () => ({}),

--- a/components/widgets/DrawingWidget/Widget.tsx
+++ b/components/widgets/DrawingWidget/Widget.tsx
@@ -13,8 +13,7 @@ import { migrateDrawingConfig, nextZ } from '@/utils/migrateDrawingConfig';
 export const DrawingWidget: React.FC<{
   widget: WidgetData;
   isStudentView?: boolean;
-  scale?: number;
-}> = ({ widget, isStudentView = false, scale = 1 }) => {
+}> = ({ widget, isStudentView = false }) => {
   const { updateWidget, activeDashboard, addToast, addWidget } = useDashboard();
   const { canAccessFeature } = useAuth();
 
@@ -60,7 +59,6 @@ export const DrawingWidget: React.FC<{
     width,
     objects,
     onObjectComplete: appendObject,
-    scale,
     disabled: isStudentView,
     canvasSize,
     nextZ: nextZ(objects),

--- a/components/widgets/DrawingWidget/useDrawingCanvas.test.ts
+++ b/components/widgets/DrawingWidget/useDrawingCanvas.test.ts
@@ -300,7 +300,25 @@ describe('useDrawingCanvas', () => {
     expect(result.current.isDrawing).toBe(false);
   });
 
-  it('divides pointer coordinates by the supplied scale factor', () => {
+  it('scales pointer coordinates by the DOM-measured internal-to-CSS ratio', () => {
+    // Canvas internal resolution 800x600, but CSS-rendered at half size
+    // (e.g. via a parent `transform: scale(0.5)`). Pointer coords should be
+    // multiplied by canvas.width/rect.width = 2 to land in canvas space.
+    vi.spyOn(
+      HTMLCanvasElement.prototype,
+      'getBoundingClientRect'
+    ).mockReturnValue({
+      left: 0,
+      top: 0,
+      width: 400,
+      height: 300,
+      right: 400,
+      bottom: 300,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+    } as DOMRect);
+
     const canvas = makeCanvas();
     const canvasRef = { current: canvas };
     const onObjectComplete = vi.fn();
@@ -312,7 +330,38 @@ describe('useDrawingCanvas', () => {
         width: 4,
         objects: [],
         onObjectComplete,
-        scale: 2, // half the on-screen coords
+        canvasSize: { width: 800, height: 600 },
+        nextZ: 0,
+      })
+    );
+
+    const mkEvent = (x: number, y: number) =>
+      ({ clientX: x, clientY: y }) as unknown as React.PointerEvent;
+    act(() => result.current.handleStart(mkEvent(50, 100)));
+    act(() => result.current.handleMove(mkEvent(150, 200)));
+    act(() => result.current.handleEnd());
+
+    const emitted = onObjectComplete.mock.calls[0][0] as PathObject;
+    expect(emitted.points).toEqual([
+      { x: 100, y: 200 },
+      { x: 300, y: 400 },
+    ]);
+  });
+
+  it('uses a 1:1 ratio when canvas internal resolution matches CSS size', () => {
+    // Default mocked rect is 800x600, matching canvas.width/height — so
+    // pointer coords should pass through unchanged (minus rect offset).
+    const canvas = makeCanvas();
+    const canvasRef = { current: canvas };
+    const onObjectComplete = vi.fn();
+
+    const { result } = renderHook(() =>
+      useDrawingCanvas({
+        canvasRef,
+        color: '#000',
+        width: 4,
+        objects: [],
+        onObjectComplete,
         canvasSize: { width: 800, height: 600 },
         nextZ: 0,
       })
@@ -326,8 +375,8 @@ describe('useDrawingCanvas', () => {
 
     const emitted = onObjectComplete.mock.calls[0][0] as PathObject;
     expect(emitted.points).toEqual([
-      { x: 50, y: 100 },
-      { x: 150, y: 200 },
+      { x: 100, y: 200 },
+      { x: 300, y: 400 },
     ]);
   });
 });

--- a/components/widgets/DrawingWidget/useDrawingCanvas.ts
+++ b/components/widgets/DrawingWidget/useDrawingCanvas.ts
@@ -7,9 +7,6 @@ interface UseDrawingCanvasOptions {
   width: number;
   objects: DrawableObject[];
   onObjectComplete: (obj: DrawableObject) => void;
-  /** CSS transform scale applied to the canvas by a parent ScalableWidget.
-   *  Pass `1` for full-viewport overlays where no parent scaling applies. */
-  scale?: number;
   /** If true, pointer events are ignored (e.g. student read-only view). */
   disabled?: boolean;
   /** Internal canvas resolution. Re-applies on change. */
@@ -41,7 +38,6 @@ export const useDrawingCanvas = ({
   width,
   objects,
   onObjectComplete,
-  scale = 1,
   disabled = false,
   canvasSize,
   generateId = () => crypto.randomUUID(),
@@ -99,17 +95,24 @@ export const useDrawingCanvas = ({
     draw(ctx, objects, currentPathRef.current);
   }, [canvasRef, canvasSize.width, canvasSize.height, objects, draw]);
 
+  // Translate a pointer event's client coords into the canvas's internal
+  // resolution (which is also the coordinate space stored on PathObjects).
+  // Using the DOM-measured ratio of internal resolution to on-screen CSS size
+  // handles any parent CSS `transform: scale()` and any internal-vs-CSS size
+  // mismatch in a single step — matching the pattern used by SeatingChart.
   const getPos = useCallback(
     (e: React.PointerEvent): Point => {
       const canvas = canvasRef.current;
       if (!canvas) return { x: 0, y: 0 };
       const rect = canvas.getBoundingClientRect();
+      const scaleX = rect.width > 0 ? canvas.width / rect.width : 1;
+      const scaleY = rect.height > 0 ? canvas.height / rect.height : 1;
       return {
-        x: (e.clientX - rect.left) / scale,
-        y: (e.clientY - rect.top) / scale,
+        x: (e.clientX - rect.left) * scaleX,
+        y: (e.clientY - rect.top) * scaleY,
       };
     },
-    [canvasRef, scale]
+    [canvasRef]
   );
 
   const handleStart = useCallback(


### PR DESCRIPTION
## Summary

The drawing widget's cursor aligned with the ink at the default size (400×350) but drifted badly once the widget was resized — the ink lagged toward the upper-left as the widget grew.

### Root cause

`ScalableWidget` (used by `canSpread: true` widgets, including drawing) computes two scales:

- `baseScale` — can exceed `1` when the widget is larger than its base
- `renderScale = min(baseScale, 1)` — the CSS `transform: scale()` actually applied (capped at 1)

The `scale` prop passed to widget children is the uncapped `baseScale`, but the visual transform uses `renderScale`. `useDrawingCanvas.getPos()` divided pointer coords by `scale`, so when the widget was enlarged (`baseScale = 2`, CSS transform = 1) pointer coordinates collapsed to half their true position.

### Fix

Drop the `scale` prop dependency in `getPos()` and measure the scale directly from the DOM — `canvas.width / rect.width` — matching the pattern already used by `SeatingChart`. This handles any parent CSS scaling **and** any mismatch between canvas internal resolution and CSS size in one step.

### Changes

- `useDrawingCanvas` — `getPos()` uses DOM-measured scale; removes now-unused `scale` option
- `DrawingWidget` — drops the `scale` prop it no longer needs
- `AnnotationOverlay` — drops the `scale: 1` argument it was passing
- Tests updated: the old `useDrawingCanvas` test that codified the buggy "divide by scale" behavior is replaced with a DOM-measured scaling test; `Widget.test.tsx`'s mock rect is aligned with the canvas's internal resolution (the old mocks hid the bug).

## Test plan

- [x] `pnpm run type-check`
- [x] `pnpm run lint`
- [x] `pnpm run format:check`
- [x] `pnpm run test` (1132/1132 passing)
- [ ] Manual: add Drawing widget, resize larger and smaller than default, draw diagonal strokes in each corner → cursor stays under ink
- [ ] Manual: maximized drawing widget still tracks correctly
- [ ] Manual: annotation overlay (full-viewport draw) still works

https://claude.ai/code/session_01RxB6vjrSjftQANVeKCyTTW