### PR TITLE
feat(schedule): timer-mode events with duration input and chained countdowns

### DIFF
--- a/components/widgets/Schedule/ScheduleWidget.tsx
+++ b/components/widgets/Schedule/ScheduleWidget.tsx
@@ -25,6 +25,8 @@ import {
   resolveActiveSchedule,
   getActiveScheduleId,
   parseScheduleTime,
+  computeEffectiveTimes,
+  getItemDurationSeconds,
 } from '@/components/widgets/Schedule/utils';
 import { ScheduleRow } from '@/components/widgets/Schedule/components/ScheduleRow';
 import { resolveTextPresetMultiplier } from '@/config/widgetAppearance';
@@ -145,58 +147,50 @@ export const ScheduleWidget: React.FC<{ widget: WidgetData }> = ({
   // Scroll container ref used for programmatic auto-scroll.
   const scrollContainerRef = useRef<HTMLDivElement>(null);
 
+  // Compute each item's effective start/end seconds once per displayItems
+  // change. Clock-mode items anchor to their explicit times; timer-mode items
+  // chain off the previous item's effective end. This is the single source of
+  // truth for "when does this event run?" and is reused by the row renderer,
+  // activeIndex, auto-progress, and auto-launch.
+  const effectiveTimes = useMemo(
+    () => computeEffectiveTimes(displayItems),
+    [displayItems]
+  );
+
   /**
    * Derive the index of the currently active schedule item.
    *
-   * An item is "active" when: startTime <= now < endTime.
-   * If an explicit `endTime` is not set, we infer it as the nearest start time
-   * (by clock time) among all other items that begins after this one.
-   * This search is performed over the whole items array so the result is correct
-   * regardless of whether items happen to be stored in chronological array order
-   * (e.g. the user may have used the manual up/down move buttons in Settings).
+   * An item is "active" when: effectiveStartSec <= now < effectiveEndSec.
+   * Clock-mode items use their explicit times; timer-mode items use the
+   * chained effective window. Idle items (timer-mode with no anchor) are
+   * never considered active.
    *
    * Returns -1 when no item is active (e.g. before the first item starts).
    */
   const activeIndex = useMemo(() => {
     if (displayItems.length === 0) return -1;
-    const nowMinutes = Math.floor(nowSeconds / 60);
-
-    // Precompute start minutes once to avoid repeated string parsing.
-    const startMinutes = displayItems.map((item) =>
-      parseScheduleTime(item.startTime ?? item.time)
-    );
 
     let bestIndex = -1;
+    let bestStart = -1;
 
     for (let i = 0; i < displayItems.length; i++) {
-      const startMin = startMinutes[i];
-      if (startMin === -1 || nowMinutes < startMin) continue;
+      const eff = effectiveTimes[i];
+      if (!eff || eff.isIdle) continue;
+      if (eff.startSec === -1 || nowSeconds < eff.startSec) continue;
 
-      // Resolve end boundary: explicit endTime → nearest later start → no bound.
-      let endMin = parseScheduleTime(displayItems[i].endTime ?? '');
-      if (endMin === -1) {
-        let nearestLater = -1;
-        for (let j = 0; j < displayItems.length; j++) {
-          const s = startMinutes[j];
-          if (s > startMin && (nearestLater === -1 || s < nearestLater)) {
-            nearestLater = s;
-          }
-        }
-        endMin = nearestLater;
-      }
-
-      const isActive = endMin === -1 ? true : nowMinutes < endMin;
+      const isActive = eff.endSec === -1 ? true : nowSeconds < eff.endSec;
       if (isActive) {
         // When items overlap, prefer the one with the latest start time
         // (the most recently started event is the most specific match).
-        if (bestIndex === -1 || startMin > startMinutes[bestIndex]) {
+        if (bestIndex === -1 || eff.startSec > bestStart) {
           bestIndex = i;
+          bestStart = eff.startSec;
         }
       }
     }
 
     return bestIndex;
-  }, [displayItems, nowSeconds]);
+  }, [displayItems, effectiveTimes, nowSeconds]);
 
   /**
    * Scroll the list so that the previously-completed item is at the top,
@@ -298,15 +292,22 @@ export const ScheduleWidget: React.FC<{ widget: WidgetData }> = ({
 
   const handleStartTimer = useCallback(
     (item: ScheduleItem) => {
-      if (!item.endTime) return;
-      const endMinutes = parseScheduleTime(item.endTime);
-      if (endMinutes < 0) return;
-
-      const now = new Date();
-      const nowSeconds =
-        now.getHours() * 3600 + now.getMinutes() * 60 + now.getSeconds();
-      const endSeconds = endMinutes * 60;
-      const remainingSeconds = Math.max(0, endSeconds - nowSeconds);
+      // For timer-mode items, launch a standalone countdown using the item's
+      // configured duration (not wall-clock endTime). This lets a teacher
+      // start the first idle timer manually even with no clock anchor.
+      let remainingSeconds = 0;
+      if (item.mode === 'timer') {
+        remainingSeconds = getItemDurationSeconds(item);
+      } else {
+        if (!item.endTime) return;
+        const endMinutes = parseScheduleTime(item.endTime);
+        if (endMinutes < 0) return;
+        const now = new Date();
+        const nowSec =
+          now.getHours() * 3600 + now.getMinutes() * 60 + now.getSeconds();
+        remainingSeconds = Math.max(0, endMinutes * 60 - nowSec);
+      }
+      if (remainingSeconds <= 0) return;
       const spawnNow = Date.now();
 
       addWidget('time-tool', {
@@ -317,8 +318,8 @@ export const ScheduleWidget: React.FC<{ widget: WidgetData }> = ({
           visualType: 'digital',
           duration: remainingSeconds,
           elapsedTime: remainingSeconds,
-          isRunning: remainingSeconds > 0,
-          startTime: remainingSeconds > 0 ? spawnNow : null,
+          isRunning: true,
+          startTime: spawnNow,
           selectedSound: 'Gong',
         },
       });
@@ -331,12 +332,21 @@ export const ScheduleWidget: React.FC<{ widget: WidgetData }> = ({
   // re-launch on every interval tick.
   const launchedItemsRef = useRef<Set<string>>(new Set());
 
+  // Keep the latest effective times accessible to the auto-launch interval
+  // (which runs on a 10s tick but wants the current chain).
+  const effectiveTimesRef = useRef(effectiveTimes);
+  useEffect(() => {
+    effectiveTimesRef.current = effectiveTimes;
+  }, [effectiveTimes]);
+
   useEffect(() => {
     const checkAutoLaunch = () => {
       const now = new Date();
-      const nowMinutes = now.getHours() * 60 + now.getMinutes();
+      const nowSec =
+        now.getHours() * 3600 + now.getMinutes() * 60 + now.getSeconds();
       const today = now.toISOString().slice(0, 10);
       const currentItems = itemsRef.current;
+      const currentEffective = effectiveTimesRef.current;
       const w = widgetRef.current;
 
       // Prune keys from previous days so the Set doesn't grow across long sessions.
@@ -353,21 +363,12 @@ export const ScheduleWidget: React.FC<{ widget: WidgetData }> = ({
         const itemKey = `${baseKey}-${today}`;
         if (launchedItemsRef.current.has(itemKey)) return;
 
-        const startMin = parseScheduleTime(item.startTime ?? item.time);
-        if (startMin === -1 || nowMinutes < startMin) return;
-
-        // Check the event is still within its active time window.
-        const endMin = parseScheduleTime(item.endTime);
-        if (endMin !== -1 && nowMinutes >= endMin) return; // past this event
-
-        // If no endTime, use the next item's start as the upper bound.
-        if (endMin === -1 && index < currentItems.length - 1) {
-          const nextItem = currentItems[index + 1];
-          const nextMin = parseScheduleTime(
-            nextItem.startTime ?? nextItem.time
-          );
-          if (nextMin !== -1 && nowMinutes >= nextMin) return;
-        }
+        // Use effective start/end from the chain so timer-mode events fire
+        // when the chain reaches them (not at a non-existent wall-clock time).
+        const eff = currentEffective[index];
+        if (!eff || eff.isIdle) return;
+        if (eff.startSec === -1 || nowSec < eff.startSec) return;
+        if (eff.endSec !== -1 && nowSec >= eff.endSec) return;
 
         // Mark as launched and spawn each linked widget.
         launchedItemsRef.current.add(itemKey);
@@ -391,37 +392,40 @@ export const ScheduleWidget: React.FC<{ widget: WidgetData }> = ({
 
     const checkTime = () => {
       const now = new Date();
-      const nowMinutes = now.getHours() * 60 + now.getMinutes();
+      const nowSec =
+        now.getHours() * 3600 + now.getMinutes() * 60 + now.getSeconds();
+      const nowMinutes = Math.floor(nowSec / 60);
       // Use displayItems for completion logic so ordering/inference is correct.
       const currentDisplayItems = itemsRef.current;
       // Use scheduleItems for the write-back so hidden one-off items are preserved.
       const currentScheduleItems = scheduleItemsRef.current;
       const currentConfig = configRef.current;
+      const currentEffective = effectiveTimesRef.current;
 
       // Compute updated done-states for visible items using display ordering.
       let changed = false;
       const newDisplayItems = currentDisplayItems.map((item, index) => {
         let isDone = false;
-        let completionTime = -1;
 
-        const itemEndTime = parseScheduleTime(item.endTime);
-        if (itemEndTime !== -1) {
-          // Prioritize the item's own end time when available.
-          completionTime = itemEndTime;
+        // Prefer chain-computed effective end. This handles timer-mode items
+        // naturally (end = previous end + duration) and matches the countdown
+        // the user sees on the widget face.
+        const eff = currentEffective[index];
+        if (eff && !eff.isIdle && eff.endSec !== -1) {
+          if (nowSec >= eff.endSec) isDone = true;
         } else if (index < currentDisplayItems.length - 1) {
-          // Fall back to the next item's start time.
+          // No usable chain entry and not the last item: fall back to the
+          // next item's start time (legacy behavior).
           const nextItem = currentDisplayItems[index + 1];
-          completionTime = parseScheduleTime(
+          const nextMin = parseScheduleTime(
             nextItem.startTime ?? nextItem.time
           );
+          if (nextMin !== -1 && nowMinutes >= nextMin) isDone = true;
         } else {
           // Last item with no end time: assume a 60-minute duration.
           const myTime = parseScheduleTime(item.startTime ?? item.time);
-          if (myTime !== -1) completionTime = myTime + 60;
+          if (myTime !== -1 && nowMinutes >= myTime + 60) isDone = true;
         }
-
-        if (completionTime !== -1 && nowMinutes >= completionTime)
-          isDone = true;
 
         if (item.done !== isDone) {
           changed = true;
@@ -497,22 +501,33 @@ export const ScheduleWidget: React.FC<{ widget: WidgetData }> = ({
               msOverflowStyle: 'none',
             }}
           >
-            {displayItems.map((item: ScheduleItem, i: number) => (
-              <ScheduleRow
-                key={item.id ?? `${item.task}-${item.startTime ?? item.time}`}
-                index={i}
-                item={item}
-                onToggle={toggle}
-                onStartTimer={handleStartTimer}
-                cardOpacity={cardOpacity}
-                cardColor={cardColor}
-                format24={format24}
-                nowSeconds={nowSeconds}
-                isActive={i === activeIndex}
-                textScale={textScale}
-                fontColor={fontColor}
-              />
-            ))}
+            {displayItems.map((item: ScheduleItem, i: number) => {
+              const eff = effectiveTimes[i] ?? {
+                startSec: -1,
+                endSec: -1,
+                isIdle: true,
+              };
+              return (
+                <ScheduleRow
+                  key={item.id ?? `${item.task}-${item.startTime ?? item.time}`}
+                  index={i}
+                  item={item}
+                  onToggle={toggle}
+                  onStartTimer={handleStartTimer}
+                  cardOpacity={cardOpacity}
+                  cardColor={cardColor}
+                  format24={format24}
+                  nowSeconds={nowSeconds}
+                  isActive={i === activeIndex}
+                  effectiveStartSec={eff.startSec}
+                  effectiveEndSec={eff.endSec}
+                  isIdle={eff.isIdle}
+                  durationSeconds={getItemDurationSeconds(item)}
+                  textScale={textScale}
+                  fontColor={fontColor}
+                />
+              );
+            })}
             {displayItems.length === 0 && (
               <ScaledEmptyState
                 icon={Clock}

--- a/components/widgets/Schedule/components/ScheduleRow.tsx
+++ b/components/widgets/Schedule/components/ScheduleRow.tsx
@@ -214,16 +214,22 @@ export const ScheduleRow = React.memo<ScheduleRowProps>(function ScheduleRow({
     backgroundColor: bgColor,
   };
 
-  // Timer-start icon: preserve existing behavior. For timer-mode items we
-  // require a positive duration (not an endTime) before offering the launch
-  // button.
+  // Timer-start icon: strictly mode-aware so the button only appears when
+  // handleStartTimer can actually launch something. Clock-mode needs a valid
+  // endTime (remaining = endTime - now). Timer-mode needs a positive
+  // duration. Without this check a stale `durationSeconds` left on a
+  // clock-mode item would render a clickable button that does nothing.
   const canLaunchStandaloneTimer =
-    !!onStartTimer && (!!item.endTime || durationSeconds > 0);
-  const timerLaunchLabel = item.endTime
-    ? t('widgets.schedule.startTimerUntil', { time: item.endTime })
-    : t('widgets.schedule.startTimerUntil', {
-        time: formatCountdown(durationSeconds),
-      });
+    !!onStartTimer &&
+    (item.mode === 'timer' ? durationSeconds > 0 : !!item.endTime);
+  const timerLaunchLabel =
+    item.mode === 'timer'
+      ? t('widgets.schedule.startTimerUntil', {
+          time: formatCountdown(durationSeconds),
+        })
+      : t('widgets.schedule.startTimerUntil', {
+          time: item.endTime ?? '',
+        });
 
   return (
     <div

--- a/components/widgets/Schedule/components/ScheduleRow.tsx
+++ b/components/widgets/Schedule/components/ScheduleRow.tsx
@@ -5,42 +5,35 @@ import { Circle, CheckCircle2, Timer } from 'lucide-react';
 import {
   formatCountdown,
   formatScheduleTime,
-  parseScheduleTimeSeconds,
 } from '@/components/widgets/Schedule/utils';
 import { hexToRgba } from '@/utils/styles';
 
 interface CountdownDisplayProps {
-  startTime?: string;
-  endTime: string;
-  /** Seconds since midnight, driven by the parent's single shared interval. */
-  nowSeconds: number;
+  /** Seconds remaining to display. Pass the full duration to render a frozen "waiting" state. */
+  remainingSeconds: number;
+  /** Full duration of the countdown in seconds (used for the progress bar). */
+  totalSeconds: number;
+  /** When true, the progress bar is shown at 100% and marked idle (no live tick). */
+  isIdle?: boolean;
 }
 
 /**
- * Pure countdown display – no internal timer, driven by parent's nowSeconds.
+ * Pure countdown display – no internal timer, driven by parent-computed
+ * `remainingSeconds`. When the parent passes the full duration (e.g. because
+ * the event hasn't become active yet), the display stays frozen.
  *
  * NOTE: Cross-midnight events (e.g. startTime "23:00" → endTime "01:00") are
  * not supported. The Schedule widget is designed for same-day classroom
  * schedules where all times fall within a single calendar day.
  */
 export const CountdownDisplay: React.FC<CountdownDisplayProps> = ({
-  startTime,
-  endTime,
-  nowSeconds,
+  remainingSeconds,
+  totalSeconds,
+  isIdle = false,
 }) => {
-  const endSec = parseScheduleTimeSeconds(endTime);
-  if (endSec === -1) return null;
-
-  const rem = Math.max(0, endSec - nowSeconds);
-
-  const startSec = parseScheduleTimeSeconds(startTime);
-  let progress: number;
-  if (startSec !== -1 && endSec > startSec) {
-    const total = endSec - startSec;
-    progress = total > 0 ? rem / total : 0;
-  } else {
-    progress = rem > 0 ? 1 : 0;
-  }
+  const rem = Math.max(0, remainingSeconds);
+  const total = Math.max(0, totalSeconds);
+  const progress = total > 0 ? rem / total : 0;
 
   return (
     <div className="flex flex-col w-full" style={{ gap: 'min(4px, 0.8cqmin)' }}>
@@ -49,6 +42,7 @@ export const CountdownDisplay: React.FC<CountdownDisplayProps> = ({
         style={{
           fontSize: 'min(24px, 6cqmin)',
           fontVariantNumeric: 'tabular-nums',
+          opacity: isIdle ? 0.6 : 1,
         }}
       >
         {formatCountdown(rem)}
@@ -62,6 +56,7 @@ export const CountdownDisplay: React.FC<CountdownDisplayProps> = ({
           style={{
             width: `${Math.max(0, Math.min(100, progress * 100))}%`,
             transition: 'width 1s linear',
+            opacity: isIdle ? 0.5 : 1,
           }}
         />
       </div>
@@ -82,6 +77,14 @@ export interface ScheduleRowProps {
   nowSeconds: number;
   /** Whether this is the currently active schedule item. */
   isActive: boolean;
+  /** Computed effective start time (seconds since midnight); -1 if idle. */
+  effectiveStartSec: number;
+  /** Computed effective end time (seconds since midnight); -1 if idle. */
+  effectiveEndSec: number;
+  /** True when a timer-mode item has no anchor to chain from. */
+  isIdle: boolean;
+  /** Duration in seconds for timer-mode items (ignored for clock-mode items). */
+  durationSeconds: number;
   textScale?: number;
   fontColor?: string;
 }
@@ -100,6 +103,10 @@ const areScheduleRowPropsEqual = (
   if (prev.format24 !== next.format24) return false;
   if (prev.textScale !== next.textScale) return false;
   if (prev.fontColor !== next.fontColor) return false;
+  if (prev.effectiveStartSec !== next.effectiveStartSec) return false;
+  if (prev.effectiveEndSec !== next.effectiveEndSec) return false;
+  if (prev.isIdle !== next.isIdle) return false;
+  if (prev.durationSeconds !== next.durationSeconds) return false;
 
   // Optimized manual comparison for `item` object (ScheduleItem) instead of JSON.stringify
   // to avoid serialization overhead on every tick.
@@ -113,6 +120,7 @@ const areScheduleRowPropsEqual = (
   if (prevItem.mode !== nextItem.mode) return false;
   if (prevItem.startTime !== nextItem.startTime) return false;
   if (prevItem.endTime !== nextItem.endTime) return false;
+  if (prevItem.durationSeconds !== nextItem.durationSeconds) return false;
 
   // Compare linkedWidgets array shallowly
   if (prevItem.linkedWidgets !== nextItem.linkedWidgets) {
@@ -125,12 +133,19 @@ const areScheduleRowPropsEqual = (
   }
 
   // Optimized check for `nowSeconds`:
-  // Only re-render if the item is in active timer mode.
-  // If not in timer mode, `nowSeconds` changes should be ignored.
-  const isTimerActive =
-    next.item.mode === 'timer' && !!next.item.endTime && !next.item.done;
+  // Only re-render if the item is actively ticking (timer mode, within its
+  // chained window, not idle, not done). Otherwise `nowSeconds` changes
+  // have no visual effect and can be safely ignored.
+  const isActivelyTicking =
+    next.item.mode === 'timer' &&
+    !next.item.done &&
+    !next.isIdle &&
+    next.effectiveStartSec !== -1 &&
+    next.effectiveEndSec !== -1 &&
+    next.nowSeconds >= next.effectiveStartSec &&
+    next.nowSeconds <= next.effectiveEndSec;
 
-  if (isTimerActive) {
+  if (isActivelyTicking) {
     return prev.nowSeconds === next.nowSeconds;
   }
 
@@ -147,6 +162,10 @@ export const ScheduleRow = React.memo<ScheduleRowProps>(function ScheduleRow({
   format24,
   nowSeconds,
   isActive,
+  effectiveStartSec,
+  effectiveEndSec,
+  isIdle,
+  durationSeconds,
   textScale = 1,
   fontColor = '#334155',
 }) {
@@ -157,8 +176,35 @@ export const ScheduleRow = React.memo<ScheduleRowProps>(function ScheduleRow({
     ? hexToRgba('#cbd5e1', cardOpacity) // slate-300
     : hexToRgba(cardColor, cardOpacity);
 
-  // Show live countdown only when mode is 'timer', endTime is set, and item isn't done.
-  const showCountdown = item.mode === 'timer' && !!item.endTime && !item.done;
+  // Timer-mode: show a countdown-style display whenever the item is a timer
+  // and not yet marked done. We display the duration frozen until the chain
+  // reaches this item, then tick live until the chain moves past it.
+  const isTimerMode = item.mode === 'timer' && !item.done;
+  const hasAnchor =
+    !isIdle && effectiveStartSec !== -1 && effectiveEndSec !== -1;
+  const isBeforeActive = hasAnchor && nowSeconds < effectiveStartSec;
+  const isAfterEnd = hasAnchor && nowSeconds >= effectiveEndSec;
+
+  let countdownRemaining = durationSeconds;
+  let countdownIsIdle = true;
+  if (isTimerMode && hasAnchor) {
+    if (isBeforeActive) {
+      countdownRemaining = durationSeconds;
+      countdownIsIdle = true;
+    } else if (isAfterEnd) {
+      countdownRemaining = 0;
+      countdownIsIdle = false;
+    } else {
+      countdownRemaining = Math.max(0, effectiveEndSec - nowSeconds);
+      countdownIsIdle = false;
+    }
+  } else if (isTimerMode && !hasAnchor) {
+    // Idle timer-mode (no anchor): show full duration frozen.
+    countdownRemaining = durationSeconds;
+    countdownIsIdle = true;
+  }
+
+  const showCountdown = isTimerMode && durationSeconds > 0;
 
   // Rows size to their content so all events are visible when the widget is
   // tall enough. Auto-scroll keeps the active item in view.
@@ -167,6 +213,17 @@ export const ScheduleRow = React.memo<ScheduleRowProps>(function ScheduleRow({
     minHeight: 'min(72px, 18cqmin)',
     backgroundColor: bgColor,
   };
+
+  // Timer-start icon: preserve existing behavior. For timer-mode items we
+  // require a positive duration (not an endTime) before offering the launch
+  // button.
+  const canLaunchStandaloneTimer =
+    !!onStartTimer && (!!item.endTime || durationSeconds > 0);
+  const timerLaunchLabel = item.endTime
+    ? t('widgets.schedule.startTimerUntil', { time: item.endTime })
+    : t('widgets.schedule.startTimerUntil', {
+        time: formatCountdown(durationSeconds),
+      });
 
   return (
     <div
@@ -214,9 +271,9 @@ export const ScheduleRow = React.memo<ScheduleRowProps>(function ScheduleRow({
         <div className="flex flex-col items-start justify-center min-w-0 flex-1 min-h-0">
           {showCountdown ? (
             <CountdownDisplay
-              startTime={item.startTime}
-              endTime={item.endTime ?? ''}
-              nowSeconds={nowSeconds}
+              remainingSeconds={countdownRemaining}
+              totalSeconds={durationSeconds}
+              isIdle={countdownIsIdle}
             />
           ) : (
             <span
@@ -240,20 +297,16 @@ export const ScheduleRow = React.memo<ScheduleRowProps>(function ScheduleRow({
           </span>
         </div>
       </button>
-      {item.endTime && onStartTimer && (
+      {canLaunchStandaloneTimer && (
         <button
-          onClick={() => onStartTimer(item)}
+          onClick={() => onStartTimer?.(item)}
           className="shrink-0 text-indigo-300 hover:text-indigo-500 hover:bg-indigo-50 rounded-lg transition-colors"
           style={{
             padding: 'min(4px, 1cqmin)',
             marginRight: 'min(12px, 2.5cqmin)',
           }}
-          title={t('widgets.schedule.startTimerUntil', {
-            time: item.endTime,
-          })}
-          aria-label={t('widgets.schedule.startTimerUntil', {
-            time: item.endTime,
-          })}
+          title={timerLaunchLabel}
+          aria-label={timerLaunchLabel}
         >
           <Timer
             className="shrink-0"

--- a/components/widgets/Schedule/components/SortableScheduleItem.tsx
+++ b/components/widgets/Schedule/components/SortableScheduleItem.tsx
@@ -10,6 +10,11 @@ import {
 } from '@/components/widgets/Schedule/utils';
 import { Z_INDEX } from '@/config/zIndex';
 
+/** Upper bound for the minutes field on a timer-mode duration input. */
+const MAX_TIMER_MINUTES = 180;
+/** Upper bound for the seconds field on a timer-mode duration input. */
+const MAX_TIMER_SECONDS = 59;
+
 const AVAILABLE_WIDGETS: { type: WidgetType; label: string }[] = [
   { type: 'time-tool', label: 'Timer' },
   { type: 'clock', label: 'Clock' },
@@ -131,11 +136,11 @@ export const SortableScheduleItem: React.FC<SortableScheduleItemProps> =
               const writeDuration = (mins: number, secs: number) => {
                 const safeMins = Math.max(
                   0,
-                  Math.min(180, Math.floor(mins) || 0)
+                  Math.min(MAX_TIMER_MINUTES, Math.floor(mins) || 0)
                 );
                 const safeSecs = Math.max(
                   0,
-                  Math.min(59, Math.floor(secs) || 0)
+                  Math.min(MAX_TIMER_SECONDS, Math.floor(secs) || 0)
                 );
                 onUpdate(item.id, {
                   durationSeconds: safeMins * 60 + safeSecs,
@@ -150,7 +155,7 @@ export const SortableScheduleItem: React.FC<SortableScheduleItemProps> =
                     type="number"
                     inputMode="numeric"
                     min={0}
-                    max={180}
+                    max={MAX_TIMER_MINUTES}
                     value={minutes}
                     onChange={(e) =>
                       writeDuration(Number(e.target.value), seconds)
@@ -165,7 +170,7 @@ export const SortableScheduleItem: React.FC<SortableScheduleItemProps> =
                     type="number"
                     inputMode="numeric"
                     min={0}
-                    max={59}
+                    max={MAX_TIMER_SECONDS}
                     value={seconds.toString().padStart(2, '0')}
                     onChange={(e) =>
                       writeDuration(minutes, Number(e.target.value))

--- a/components/widgets/Schedule/components/SortableScheduleItem.tsx
+++ b/components/widgets/Schedule/components/SortableScheduleItem.tsx
@@ -3,7 +3,11 @@ import { ScheduleItem, WidgetType } from '@/types';
 import { GripVertical, Trash2, Timer, Link, CheckCircle2 } from 'lucide-react';
 import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
-import { getTodayStr } from '@/components/widgets/Schedule/utils';
+import {
+  getTodayStr,
+  getItemDurationSeconds,
+  parseScheduleTimeSeconds,
+} from '@/components/widgets/Schedule/utils';
 import { Z_INDEX } from '@/config/zIndex';
 
 const AVAILABLE_WIDGETS: { type: WidgetType; label: string }[] = [
@@ -117,32 +121,112 @@ export const SortableScheduleItem: React.FC<SortableScheduleItemProps> =
             <Trash2 className="w-3.5 h-3.5" />
           </button>
         </div>
-        {/* Row 2: times + toggles (indented to align with task input) */}
+        {/* Row 2: times (clock) OR duration (timer) + toggles */}
         <div className="flex items-center gap-1.5 px-2 pb-2 pl-9">
-          <input
-            type="time"
-            value={item.startTime ?? item.time ?? ''}
-            onChange={(e) =>
-              onUpdate(item.id, {
-                startTime: e.target.value,
-                time: e.target.value,
-              })
-            }
-            className="flex-1 min-w-0 px-1.5 py-1 text-xs border border-slate-200 rounded outline-none"
-          />
-          <input
-            type="time"
-            value={item.endTime ?? ''}
-            onChange={(e) => onUpdate(item.id, { endTime: e.target.value })}
-            className="flex-1 min-w-0 px-1.5 py-1 text-xs border border-slate-200 rounded outline-none"
-          />
+          {item.mode === 'timer' ? (
+            (() => {
+              const total = getItemDurationSeconds(item);
+              const minutes = Math.floor(total / 60);
+              const seconds = total % 60;
+              const writeDuration = (mins: number, secs: number) => {
+                const safeMins = Math.max(
+                  0,
+                  Math.min(180, Math.floor(mins) || 0)
+                );
+                const safeSecs = Math.max(
+                  0,
+                  Math.min(59, Math.floor(secs) || 0)
+                );
+                onUpdate(item.id, {
+                  durationSeconds: safeMins * 60 + safeSecs,
+                });
+              };
+              return (
+                <div
+                  className="flex-1 min-w-0 flex items-center gap-1"
+                  title="Timer duration (minutes : seconds)"
+                >
+                  <input
+                    type="number"
+                    inputMode="numeric"
+                    min={0}
+                    max={180}
+                    value={minutes}
+                    onChange={(e) =>
+                      writeDuration(Number(e.target.value), seconds)
+                    }
+                    aria-label="Timer minutes"
+                    className="w-14 min-w-0 px-1.5 py-1 text-xs text-center border border-slate-200 rounded outline-none tabular-nums"
+                  />
+                  <span className="text-xs text-slate-400 font-semibold select-none">
+                    :
+                  </span>
+                  <input
+                    type="number"
+                    inputMode="numeric"
+                    min={0}
+                    max={59}
+                    value={seconds.toString().padStart(2, '0')}
+                    onChange={(e) =>
+                      writeDuration(minutes, Number(e.target.value))
+                    }
+                    aria-label="Timer seconds"
+                    className="w-14 min-w-0 px-1.5 py-1 text-xs text-center border border-slate-200 rounded outline-none tabular-nums"
+                  />
+                  <span className="text-xxs text-slate-400 uppercase tracking-wide ml-1">
+                    min:sec
+                  </span>
+                </div>
+              );
+            })()
+          ) : (
+            <>
+              <input
+                type="time"
+                value={item.startTime ?? item.time ?? ''}
+                onChange={(e) =>
+                  onUpdate(item.id, {
+                    startTime: e.target.value,
+                    time: e.target.value,
+                  })
+                }
+                className="flex-1 min-w-0 px-1.5 py-1 text-xs border border-slate-200 rounded outline-none"
+              />
+              <input
+                type="time"
+                value={item.endTime ?? ''}
+                onChange={(e) => onUpdate(item.id, { endTime: e.target.value })}
+                className="flex-1 min-w-0 px-1.5 py-1 text-xs border border-slate-200 rounded outline-none"
+              />
+            </>
+          )}
           <button
             type="button"
-            onClick={() =>
-              onUpdate(item.id, {
-                mode: item.mode === 'timer' ? 'clock' : 'timer',
-              })
-            }
+            onClick={() => {
+              if (item.mode === 'timer') {
+                // Timer → Clock: preserve existing startTime/endTime if present.
+                onUpdate(item.id, { mode: 'clock' });
+              } else {
+                // Clock → Timer: seed durationSeconds from endTime-startTime if
+                // unset so switching doesn't lose the user's prior window.
+                const updates: Partial<ScheduleItem> = { mode: 'timer' };
+                if (
+                  typeof item.durationSeconds !== 'number' ||
+                  item.durationSeconds <= 0
+                ) {
+                  const startSec = parseScheduleTimeSeconds(
+                    item.startTime ?? item.time
+                  );
+                  const endSec = parseScheduleTimeSeconds(item.endTime);
+                  if (startSec !== -1 && endSec !== -1 && endSec > startSec) {
+                    updates.durationSeconds = endSec - startSec;
+                  } else {
+                    updates.durationSeconds = 0;
+                  }
+                }
+                onUpdate(item.id, updates);
+              }
+            }}
             className={`p-1.5 rounded transition-colors shrink-0 ${
               item.mode === 'timer'
                 ? 'text-indigo-500 bg-indigo-50'

--- a/components/widgets/Schedule/utils.ts
+++ b/components/widgets/Schedule/utils.ts
@@ -24,6 +24,123 @@ export const parseScheduleTimeSeconds = (t: string | undefined): number => {
   return h * 3600 + m * 60;
 };
 
+/**
+ * Returns the duration (in seconds) for a schedule item.
+ *
+ * - For timer-mode items: prefers the explicit `durationSeconds` field when set.
+ * - Legacy / fallback: infers duration from `endTime - startTime` when both are
+ *   valid HH:MM strings. This lets older timer-mode items (that used the old
+ *   start/end model) keep rendering a sensible countdown without a data
+ *   migration.
+ *
+ * Returns 0 when no duration can be determined.
+ */
+export const getItemDurationSeconds = (item: ScheduleItem): number => {
+  if (
+    typeof item.durationSeconds === 'number' &&
+    isFinite(item.durationSeconds) &&
+    item.durationSeconds > 0
+  ) {
+    return item.durationSeconds;
+  }
+  const startSec = parseScheduleTimeSeconds(item.startTime ?? item.time);
+  const endSec = parseScheduleTimeSeconds(item.endTime);
+  if (startSec !== -1 && endSec !== -1 && endSec > startSec) {
+    return endSec - startSec;
+  }
+  return 0;
+};
+
+/**
+ * An item's computed position in the schedule's time chain.
+ *
+ * Clock-mode items anchor to their explicit startTime/endTime. Timer-mode
+ * items chain off the previous item's `endSec` and add their own duration.
+ * If a timer-mode item has no valid predecessor to anchor to (e.g. it is the
+ * first item), it is marked `isIdle` — the widget face shows its duration
+ * frozen and the countdown does not run.
+ */
+export interface EffectiveTime {
+  /** Seconds since midnight when this item effectively begins. -1 if idle. */
+  startSec: number;
+  /** Seconds since midnight when this item effectively ends. -1 if idle. */
+  endSec: number;
+  /** True when the item has no anchor (timer-mode with no preceding event). */
+  isIdle: boolean;
+}
+
+/**
+ * Computes effective start/end seconds for each item in `items`, in order.
+ *
+ * - Clock-mode items use their explicit `startTime` (and `endTime`, falling
+ *   back to the next clock-mode item's start — matching the existing
+ *   activeIndex inference logic).
+ * - Timer-mode items chain off the previous item's `endSec`. They add
+ *   `getItemDurationSeconds(item)` to produce their `endSec`.
+ * - Items without a computable anchor are `isIdle: true`.
+ *
+ * Returns an array parallel to `items`.
+ */
+export const computeEffectiveTimes = (
+  items: ScheduleItem[]
+): EffectiveTime[] => {
+  const result: EffectiveTime[] = [];
+
+  // Precompute clock-mode starts so we can infer endSec for clock items
+  // that lack an explicit endTime (by looking at the next clock-mode start).
+  const clockStartSecByIndex: number[] = items.map((item) => {
+    if (item.mode === 'timer') return -1;
+    return parseScheduleTimeSeconds(item.startTime ?? item.time);
+  });
+
+  for (let i = 0; i < items.length; i++) {
+    const item = items[i];
+    const prev: EffectiveTime | undefined = i > 0 ? result[i - 1] : undefined;
+
+    if (item.mode === 'timer') {
+      const duration = getItemDurationSeconds(item);
+      if (!prev || prev.isIdle || prev.endSec === -1 || duration <= 0) {
+        result[i] = { startSec: -1, endSec: -1, isIdle: true };
+      } else {
+        const startSec = prev.endSec;
+        result[i] = {
+          startSec,
+          endSec: startSec + duration,
+          isIdle: false,
+        };
+      }
+      continue;
+    }
+
+    // Clock mode (default).
+    const startSec = clockStartSecByIndex[i];
+    if (startSec === -1) {
+      result[i] = { startSec: -1, endSec: -1, isIdle: true };
+      continue;
+    }
+    let endSec = parseScheduleTimeSeconds(item.endTime);
+    if (endSec === -1) {
+      // Infer from the nearest later clock-mode start (matches the existing
+      // inference in ScheduleWidget.activeIndex so behavior stays consistent).
+      let nearest = -1;
+      for (let j = 0; j < items.length; j++) {
+        const s = clockStartSecByIndex[j];
+        if (s > startSec && (nearest === -1 || s < nearest)) {
+          nearest = s;
+        }
+      }
+      endSec = nearest;
+    }
+    result[i] = {
+      startSec,
+      endSec,
+      isIdle: false,
+    };
+  }
+
+  return result;
+};
+
 /** Formats a total-seconds value into M:SS or H:MM:SS. */
 export const formatCountdown = (totalSeconds: number): string => {
   const s = Math.max(0, Math.round(totalSeconds));

--- a/components/widgets/ScheduleWidget.test.tsx
+++ b/components/widgets/ScheduleWidget.test.tsx
@@ -141,8 +141,45 @@ describe('ScheduleWidget', () => {
     expect(screen.getByText('08:00')).toBeInTheDocument();
   });
 
-  it('shows countdown instead of clock time for a timer-mode item', () => {
-    // 08:30 — 30 minutes remain until endTime 09:00 → displays "30:00"
+  it('shows countdown for a timer-mode item chained after a preceding clock-mode item', () => {
+    // Timer-mode items chain off the previous item's effective end. The first
+    // item here is a clock-mode event that ended at 08:00; the timer item
+    // (60-minute duration) therefore runs 08:00–09:00, and at 08:30 has 30:00
+    // remaining.
+    const date = new Date();
+    date.setHours(8, 30, 0, 0);
+    vi.setSystemTime(date);
+
+    const widget = createWidget({
+      items: [
+        {
+          id: 'item-0',
+          time: '07:00',
+          task: 'Warmup',
+          done: true,
+          mode: 'clock' as const,
+          startTime: '07:00',
+          endTime: '08:00',
+        },
+        {
+          id: 'item-1',
+          task: 'Math',
+          done: false,
+          mode: 'timer' as const,
+          durationSeconds: 3600,
+        },
+      ],
+    });
+    render(<ScheduleWidget widget={widget} />);
+
+    // Chained countdown: effective end = 09:00, now = 8:30 → rem 30:00
+    expect(screen.getByText('30:00')).toBeInTheDocument();
+  });
+
+  it('shows a first-item timer-mode event as idle (frozen full duration)', () => {
+    // First-item timer has no predecessor to chain from → stays idle and
+    // displays the full duration. Teacher can launch it manually via the
+    // timer-start icon (covered elsewhere).
     const date = new Date();
     date.setHours(8, 30, 0, 0);
     vi.setSystemTime(date);
@@ -151,20 +188,18 @@ describe('ScheduleWidget', () => {
       items: [
         {
           id: 'item-1',
-          time: '08:00',
           task: 'Math',
           done: false,
-          mode: 'timer',
-          startTime: '08:00',
-          endTime: '09:00',
+          mode: 'timer' as const,
+          durationSeconds: 1800, // 30 minutes
         },
       ],
     });
     render(<ScheduleWidget widget={widget} />);
 
-    // Countdown: endTime 09:00 = 32400s, now = 8:30:00 = 30600s, rem = 1800s = 30:00
+    // Duration (not live countdown) is shown; idle display is frozen at full.
     expect(screen.getByText('30:00')).toBeInTheDocument();
-    // Clock-format time should NOT appear
+    // Clock-format time should NOT appear (it's a timer item).
     expect(screen.queryByText('8:00 AM')).not.toBeInTheDocument();
   });
 

--- a/types.ts
+++ b/types.ts
@@ -288,6 +288,12 @@ export interface ScheduleItem {
   done?: boolean;
   startTime?: string;
   endTime?: string;
+  /**
+   * Duration in seconds for timer-mode items. When set (and mode === 'timer'),
+   * the item chains off the previous item's effective end time rather than
+   * running off a fixed wall-clock window.
+   */
+  durationSeconds?: number;
   mode?: 'clock' | 'timer';
   linkedWidgets?: WidgetType[];
   spawnedWidgetIds?: string[];


### PR DESCRIPTION
## Summary

Makes the Schedule widget's per-event "timer mode" toggle do what it implies. Previously, switching an event to timer mode just swapped the clock label for a countdown — it still required a fixed start/end time and ran off wall-clock time. Now:

- **Timer-mode events have a single duration field** (minutes + seconds) in settings instead of the two start/end time inputs.
- **Timer-mode events chain**: they don't begin counting down until the previous event completes (its clock endTime is reached, OR the previous timer's countdown finishes).
- **First-item timer events stay idle** (frozen full duration) when there's no preceding event to anchor off — teacher can launch manually via the existing timer-start icon.

## How it works

- `types.ts` — adds `ScheduleItem.durationSeconds` (timer-mode items).
- `Schedule/utils.ts` — adds `getItemDurationSeconds()` (with legacy `endTime - startTime` fallback so old timer items keep working with no migration) and `computeEffectiveTimes()`, a pure helper that walks items in order and produces each item's effective start/end seconds: clock-mode items anchor to their explicit times; timer-mode items chain off `prev.endSec + duration`. Idle when no predecessor.
- `components/SortableScheduleItem.tsx` — conditionally renders a minutes/seconds duration input pair when `item.mode === 'timer'`. Clock→Timer toggle seeds `durationSeconds` from the existing window so no values are lost.
- `components/ScheduleRow.tsx` — `CountdownDisplay` now takes `remainingSeconds` / `totalSeconds` directly. Idle/waiting state renders the full duration frozen with a dimmed progress bar; active state ticks live.
- `ScheduleWidget.tsx` — threads `effectiveTimes` into `activeIndex`, auto-progress, and auto-launch so timer-mode items complete when the chain says they end, not when a non-existent wall-clock endTime arrives. `handleStartTimer` uses `durationSeconds` for timer items when spawning a standalone time-tool widget.

## Test plan

- [x] `pnpm run type-check` — passes
- [x] `pnpm run lint` — passes (0 errors, 0 warnings)
- [x] `pnpm run format:check` — passes
- [x] `pnpm run test` — 1132/1132 pass (existing timer-countdown test updated to exercise chain semantics; added a first-item idle test)
- [ ] Manual: add a schedule widget; add (a) clock-mode 8:00–8:05, (b) timer-mode 2:00, (c) timer-mode 3:00. Confirm flip panel shows duration inputs for (b)/(c) and time inputs for (a); confirm widget face shows (b) and (c) frozen at their durations until 8:05, then (b) ticks down live, and (c) begins ticking only when (b) hits 0:00.
- [ ] Manual: switch the first item to timer mode; confirm it stays idle (frozen full duration) and can be launched manually via the timer-start icon.
- [ ] Manual: back-compat — legacy timer item with `endTime` but no `durationSeconds` still renders a sensible countdown via the `endTime - startTime` fallback.

https://claude.ai/code/session_01RXRysMq2PbmvAoq3wEAvJc