### PR TITLE
feat(quiz): assignment archive with pause/resume and PLC sharing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -322,6 +322,7 @@ The project uses `@/` as an alias for the **root directory** (not `src/`):
 /users/{userId}/notebooks/{notebookId}      # Notes
 /users/{userId}/pdfs/{pdfId}                # PDFs
 /users/{userId}/userProfile/{profileId}     # User profile / building selection
+/users/{userId}/quiz_assignments/{id}       # Teacher's quiz assignment archive
 
 # Admin collections (admin read/write, authenticated read)
 /admins/{email}                             # Admin users (existence = admin)
@@ -334,6 +335,7 @@ The project uses `@/` as an alias for the **root directory** (not `src/`):
 
 # Shared/global collections
 /shared_boards/{shareId}                    # Shared dashboards
+/shared_assignments/{shareId}               # Shared quiz assignments (PLC sharing)
 /global_weather/{document}                  # Cached weather data
 /global_music_stations/{document}           # Shared music stations
 /global_pdfs/{pdfId}                        # Shared PDF library
@@ -344,7 +346,7 @@ The project uses `@/` as an alias for the **root directory** (not `src/`):
 
 # Live session collections
 /sessions/{userId}/students/{studentId}     # Live session students
-/quiz_sessions/{teacherUid}/responses/...   # Quiz responses
+/quiz_sessions/{sessionId}/responses/...    # Quiz responses (one session doc per assignment)
 /video_activity_sessions/{sessionId}/...    # Video activity responses
 /guided_learning_sessions/{sessionId}/...   # GL session responses
 /mini_app_sessions/{sessionId}              # Mini-app assignment sessions

--- a/components/layout/DashboardView.tsx
+++ b/components/layout/DashboardView.tsx
@@ -12,6 +12,7 @@ import {
 import { useAuth } from '@/context/useAuth';
 import { useLiveSession } from '@/hooks/useLiveSession';
 import { useQuiz } from '@/hooks/useQuiz';
+import { useQuizAssignments } from '@/hooks/useQuizAssignments';
 import { useStorage, MAX_PDF_SIZE_BYTES } from '@/hooks/useStorage';
 import { Sidebar } from './sidebar/Sidebar';
 import { Dock } from './Dock';
@@ -144,6 +145,8 @@ export const DashboardView: React.FC = () => {
     setZoom,
     pendingQuizShareId,
     clearPendingQuizShare,
+    pendingAssignmentShareId,
+    clearPendingAssignmentShare,
     // Widget grouping
     groupWidgets,
     groupBuildMode,
@@ -154,13 +157,48 @@ export const DashboardView: React.FC = () => {
     annotationActive,
   } = useDashboard();
 
-  const { importSharedQuiz } = useQuiz(user?.uid);
+  const { importSharedQuiz, saveQuiz } = useQuiz(user?.uid);
+  const { importSharedAssignment } = useQuizAssignments(user?.uid);
 
-  // Handle pending quiz share import from URL
+  // Helper: open (or create) a Quiz widget and set its managerTab.
+  // Used by pending-share effects to surface the imported content to the user.
+  const openQuizWidgetToTab = React.useCallback(
+    (tab: 'library' | 'archive') => {
+      const quizWidget = activeDashboard?.widgets.find(
+        (w) => w.type === 'quiz'
+      );
+      if (quizWidget) {
+        if (quizWidget.minimized) {
+          updateWidget(quizWidget.id, { minimized: false });
+        }
+        updateWidget(quizWidget.id, {
+          config: {
+            ...quizWidget.config,
+            view: 'manager',
+            managerTab: tab,
+          },
+        });
+        bringToFront(quizWidget.id);
+      } else {
+        addWidget('quiz', {
+          config: { view: 'manager', managerTab: tab },
+        });
+      }
+    },
+    [activeDashboard, updateWidget, addWidget, bringToFront]
+  );
+
+  // Handle pending quiz share import from URL/paste.
+  // After a successful import, surface the Quiz widget to the Library tab so
+  // the user actually sees where the new quiz landed (fixes the "nothing
+  // happened" paste UX).
   useEffect(() => {
     if (!pendingQuizShareId || !user) return;
     void importSharedQuiz(pendingQuizShareId)
-      .then(() => addToast('Shared quiz imported to your library!', 'success'))
+      .then(() => {
+        addToast('Shared quiz imported to your library!', 'success');
+        openQuizWidgetToTab('library');
+      })
       .catch((err: unknown) => {
         const msg =
           err instanceof Error
@@ -182,6 +220,45 @@ export const DashboardView: React.FC = () => {
     importSharedQuiz,
     addToast,
     clearPendingQuizShare,
+    openQuizWidgetToTab,
+  ]);
+
+  // Handle pending shared assignment import from URL/paste.
+  // Imports copy the quiz into the user's library and create a paused
+  // assignment, then surface the Quiz widget to the Archive tab.
+  useEffect(() => {
+    if (!pendingAssignmentShareId || !user) return;
+    void importSharedAssignment(pendingAssignmentShareId, async (quiz) => {
+      const meta = await saveQuiz(quiz);
+      return { id: meta.id, driveFileId: meta.driveFileId };
+    })
+      .then(() => {
+        addToast('Shared assignment imported (paused).', 'success');
+        openQuizWidgetToTab('archive');
+      })
+      .catch((err: unknown) => {
+        const msg =
+          err instanceof Error
+            ? err.message
+            : typeof err === 'string'
+              ? err
+              : '';
+        addToast(
+          msg
+            ? `Failed to import shared assignment: ${msg}`
+            : 'Failed to import shared assignment.',
+          'error'
+        );
+      })
+      .finally(() => clearPendingAssignmentShare());
+  }, [
+    pendingAssignmentShareId,
+    user,
+    importSharedAssignment,
+    saveQuiz,
+    addToast,
+    clearPendingAssignmentShare,
+    openQuizWidgetToTab,
   ]);
 
   const [panOffset, setPanOffset] = React.useState({ x: 0, y: 0 });

--- a/components/layout/Dock.tsx
+++ b/components/layout/Dock.tsx
@@ -106,6 +106,8 @@ export const Dock: React.FC = () => {
     annotationActive,
     openAnnotation,
     closeAnnotation,
+    setPendingQuizShareId,
+    setPendingAssignmentShareId,
   } = useDashboard();
   const {
     canAccessWidget,
@@ -361,8 +363,15 @@ export const Dock: React.FC = () => {
             });
             addToast('HTML opened — click the save icon to keep it!', 'info');
           } else if (result.action === 'import-quiz') {
-            // Navigate to the share/quiz URL to trigger import
-            window.location.href = `${window.location.origin}/share/quiz/${result.shareId}`;
+            // Soft import — set pending state; DashboardView will import the
+            // quiz and open the Quiz widget to the Library tab. No reload.
+            setPendingQuizShareId(result.shareId);
+            addToast('Importing shared quiz…', 'info');
+          } else if (result.action === 'import-assignment') {
+            // Soft import — set pending state; DashboardView will import the
+            // assignment (paused) and open the Quiz widget to the Archive tab.
+            setPendingAssignmentShareId(result.shareId);
+            addToast('Importing shared assignment…', 'info');
           } else if (result.action === 'prompt-text-or-checklist') {
             // Ambiguous: show a picker modal for the user to decide
             setSmartPastePending(result.text);
@@ -384,6 +393,8 @@ export const Dock: React.FC = () => {
     imagePastePending,
     smartPastePending,
     urlPastePending,
+    setPendingQuizShareId,
+    setPendingAssignmentShareId,
   ]);
 
   const classesButtonRef = useRef<HTMLButtonElement>(null);

--- a/components/quiz/QuizPausedPlaceholder.tsx
+++ b/components/quiz/QuizPausedPlaceholder.tsx
@@ -1,0 +1,39 @@
+/**
+ * Full-screen placeholder shown to students when their quiz assignment is
+ * currently paused. The join URL is still live, but submissions are blocked
+ * until the teacher resumes the session.
+ */
+
+import React from 'react';
+import { PauseCircle } from 'lucide-react';
+import { QuizSession } from '@/types';
+
+interface QuizPausedPlaceholderProps {
+  session: QuizSession;
+  pin: string;
+}
+
+export const QuizPausedPlaceholder: React.FC<QuizPausedPlaceholderProps> = ({
+  session,
+  pin,
+}) => (
+  <div className="min-h-screen bg-slate-900 flex flex-col items-center justify-center p-6 text-center">
+    <div className="w-20 h-20 bg-amber-500/20 border border-amber-500/30 rounded-2xl flex items-center justify-center mb-6">
+      <PauseCircle className="w-10 h-10 text-amber-400" />
+    </div>
+    <h1 className="text-2xl font-black text-white mb-2">{session.quizTitle}</h1>
+    <p className="text-slate-300 text-base font-semibold mb-2">
+      This quiz is paused.
+    </p>
+    <p className="text-slate-400 text-sm mb-8 max-w-sm">
+      Your teacher will resume the session shortly. Keep this tab open — your
+      place is saved.
+    </p>
+    <div className="p-4 bg-slate-800 rounded-xl">
+      <p className="text-slate-300 text-sm">
+        Joined as PIN{' '}
+        <span className="font-semibold text-white font-mono">{pin}</span>
+      </p>
+    </div>
+  </div>
+);

--- a/components/quiz/QuizStudentApp.tsx
+++ b/components/quiz/QuizStudentApp.tsx
@@ -30,6 +30,7 @@ import { useQuizSessionStudent, normalizeAnswer } from '@/hooks/useQuizSession';
 import { QuizSession, QuizPublicQuestion } from '@/types';
 import { useDialog } from '@/context/useDialog';
 import { StudentLeaderboard } from './StudentLeaderboard';
+import { QuizPausedPlaceholder } from './QuizPausedPlaceholder';
 import {
   getScoreSuffix,
   isGamificationActive,
@@ -198,6 +199,12 @@ const QuizJoinFlow: React.FC = () => {
         </div>
       </div>
     );
+  }
+
+  // Paused — teacher has temporarily paused the session. URL is still live,
+  // submissions are blocked until the session is resumed.
+  if (session.status === 'paused') {
+    return <QuizPausedPlaceholder session={session} pin={pin} />;
   }
 
   // Waiting room

--- a/components/student/StudentContexts.tsx
+++ b/components/student/StudentContexts.tsx
@@ -249,6 +249,16 @@ const mockDashboard: DashboardContextValue = {
   clearPendingQuizShare: () => {
     // No-op
   },
+  setPendingQuizShareId: () => {
+    // No-op
+  },
+  pendingAssignmentShareId: null,
+  setPendingAssignmentShareId: () => {
+    // No-op
+  },
+  clearPendingAssignmentShare: () => {
+    // No-op
+  },
   // Roster mocks
   rosters: [],
   activeRosterId: null,

--- a/components/widgets/QuizWidget/Settings.tsx
+++ b/components/widgets/QuizWidget/Settings.tsx
@@ -1,20 +1,15 @@
 import React from 'react';
 import { WidgetData, QuizConfig } from '@/types';
 import { useDashboard } from '@/context/useDashboard';
-import { useAuth } from '@/context/useAuth';
-import { useQuizSessionTeacher } from '@/hooks/useQuizSession';
 import { SettingsLabel } from '@/components/common/SettingsLabel';
-import { Info } from 'lucide-react';
+import { Info, Archive } from 'lucide-react';
 
 // Settings panel (back of the widget) — minimal since all management is front-facing
 export const QuizWidgetSettings: React.FC<{ widget: WidgetData }> = ({
   widget,
 }) => {
-  const { updateWidget, addToast } = useDashboard();
-  const { user } = useAuth();
-  const { session, endQuizSession } = useQuizSessionTeacher(user?.uid);
+  const { updateWidget } = useDashboard();
   const config = widget.config as QuizConfig;
-  const hasActiveSession = !!(session && session.status !== 'ended');
 
   return (
     <div className="space-y-5">
@@ -39,17 +34,21 @@ export const QuizWidgetSettings: React.FC<{ widget: WidgetData }> = ({
         />
       </div>
 
-      {hasActiveSession && (
-        <button
-          onClick={async () => {
-            await endQuizSession();
-            addToast('Active session ended.', 'success');
-          }}
-          className="w-full py-2 bg-brand-red-primary hover:bg-brand-red-dark text-white text-sm rounded-lg transition-colors font-bold"
-        >
-          Force End Active Session
-        </button>
-      )}
+      <button
+        onClick={() =>
+          updateWidget(widget.id, {
+            config: {
+              ...config,
+              view: 'manager',
+              managerTab: 'archive',
+            } as QuizConfig,
+          })
+        }
+        className="w-full py-2 bg-slate-100 hover:bg-slate-200 text-slate-700 text-sm rounded-lg transition-colors border border-slate-200 flex items-center justify-center gap-2"
+      >
+        <Archive className="w-4 h-4" />
+        View Assignment Archive
+      </button>
 
       <button
         onClick={() =>
@@ -57,8 +56,10 @@ export const QuizWidgetSettings: React.FC<{ widget: WidgetData }> = ({
             config: {
               ...config,
               view: 'manager',
+              managerTab: 'library',
               selectedQuizId: null,
               selectedQuizTitle: null,
+              activeAssignmentId: null,
               activeLiveSessionCode: null,
               resultsSessionId: null,
             } as QuizConfig,

--- a/components/widgets/QuizWidget/Widget.tsx
+++ b/components/widgets/QuizWidget/Widget.tsx
@@ -697,17 +697,6 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
           const data = await loadQuiz(meta);
           if (data) setView('results');
         }}
-        onDelete={async (meta) => {
-          try {
-            await deleteQuiz(meta.id, meta.driveFileId);
-            addToast('Quiz deleted.', 'success');
-          } catch (err) {
-            addToast(
-              err instanceof Error ? err.message : 'Delete failed',
-              'error'
-            );
-          }
-        }}
         onShare={async (meta) => {
           let url: string;
           try {
@@ -724,6 +713,38 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
             addToast('Share link copied to clipboard!', 'success');
           } catch {
             addToast(`Share link: ${url}`, 'info');
+          }
+        }}
+        onDelete={async (meta) => {
+          // Block deletion when active/paused assignments reference the quiz,
+          // since the monitor + results views need the answer key from the
+          // library record. Archived (inactive) assignments trigger only a
+          // warning — the teacher has already chosen to end those sessions.
+          const related = assignments.filter((a) => a.quizId === meta.id);
+          const live = related.filter((a) => a.status !== 'inactive');
+          if (live.length > 0) {
+            addToast(
+              `Cannot delete: ${live.length} active or paused assignment(s) still reference this quiz. Deactivate them first.`,
+              'error'
+            );
+            return;
+          }
+          if (related.length > 0) {
+            const ok = window.confirm(
+              `This quiz has ${related.length} archived assignment(s). ` +
+                `Deleting the quiz will prevent viewing their monitor and results. ` +
+                `Continue anyway?`
+            );
+            if (!ok) return;
+          }
+          try {
+            await deleteQuiz(meta.id, meta.driveFileId);
+            addToast('Quiz deleted.', 'success');
+          } catch (err) {
+            addToast(
+              err instanceof Error ? err.message : 'Delete failed',
+              'error'
+            );
           }
         }}
         // ─── Archive tab ─────────────────────────────────────────────────────
@@ -807,7 +828,8 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
             return;
           }
           try {
-            const data = await loadQuizData(meta.driveFileId);
+            const data = await loadQuiz(meta);
+            if (!data) return;
             const url = await shareAssignment(a.id, data);
             try {
               await navigator.clipboard.writeText(url);

--- a/components/widgets/QuizWidget/Widget.tsx
+++ b/components/widgets/QuizWidget/Widget.tsx
@@ -13,11 +13,14 @@ import {
   useQuizSessionTeacher,
   type QuizSessionOptions,
 } from '@/hooks/useQuizSession';
+import { useQuizAssignments } from '@/hooks/useQuizAssignments';
 import { QuizManager, PlcOptions } from './components/QuizManager';
 import { QuizImporter } from './components/QuizImporter';
 import { QuizEditorModal } from './components/QuizEditorModal';
 import { QuizPreview } from './components/QuizPreview';
 import { QuizResults } from './components/QuizResults';
+import { QuizAssignmentSettingsModal } from './components/QuizAssignmentSettingsModal';
+import type { QuizAssignment } from '@/types';
 import {
   buildPinToNameMap,
   buildScoreboardTeams,
@@ -51,13 +54,29 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
   const {
     session: liveSession,
     responses,
-    startQuizSession,
     advanceQuestion,
     endQuizSession,
     removeStudent,
     revealAnswer,
     hideAnswer,
-  } = useQuizSessionTeacher(user?.uid);
+  } = useQuizSessionTeacher(config.activeAssignmentId);
+
+  // Assignment archive — per-teacher list of past/current assignments.
+  const {
+    assignments,
+    loading: assignmentsLoading,
+    createAssignment,
+    pauseAssignment,
+    resumeAssignment,
+    deactivateAssignment,
+    deleteAssignment,
+    updateAssignmentSettings,
+    shareAssignment,
+  } = useQuizAssignments(user?.uid);
+
+  // Ephemeral modal state for per-assignment settings editing.
+  const [editingAssignment, setEditingAssignment] =
+    useState<QuizAssignment | null>(null);
 
   // Local state for views that need loaded data
   const [loadedQuizData, setLoadedQuizData] = useState<QuizData | null>(null);
@@ -309,24 +328,27 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
     widget.id,
   ]);
 
-  // Auto-disable live scoreboard when session ends
+  // Auto-disable live scoreboard when session ends, and clear the LIVE badge
+  // when paused. A paused session can be resumed, so we keep the teacher's
+  // liveScoreboardEnabled preference — we just drop the "LIVE" badge on the
+  // scoreboard widget while the quiz isn't accepting answers.
   useEffect(() => {
-    if (
-      config.liveScoreboardEnabled &&
-      liveSession &&
-      liveSession.status === 'ended'
-    ) {
-      // Clear the liveQuizWidgetId on the scoreboard to remove the LIVE badge
-      const scoreboardId = configRef.current.liveScoreboardWidgetId;
-      if (scoreboardId) {
-        const widgets = widgetsRef.current;
-        const scoreboard = widgets?.find((w) => w.id === scoreboardId);
-        if (scoreboard) {
-          updateWidget(scoreboardId, {
-            config: { ...scoreboard.config, liveQuizWidgetId: undefined },
-          });
-        }
+    if (!config.liveScoreboardEnabled || !liveSession) return;
+    const isEnded = liveSession.status === 'ended';
+    const isPaused = liveSession.status === 'paused';
+    if (!isEnded && !isPaused) return;
+
+    const scoreboardId = configRef.current.liveScoreboardWidgetId;
+    if (scoreboardId) {
+      const widgets = widgetsRef.current;
+      const scoreboard = widgets?.find((w) => w.id === scoreboardId);
+      if (scoreboard) {
+        updateWidget(scoreboardId, {
+          config: { ...scoreboard.config, liveQuizWidgetId: undefined },
+        });
       }
+    }
+    if (isEnded) {
       handleUpdateQuizConfig({ liveScoreboardEnabled: false });
     }
   }, [
@@ -532,9 +554,37 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
           await advanceQuestion();
         }}
         onEnd={async () => {
-          await endQuizSession();
+          // "End" now means Make Inactive at the assignment level so the URL
+          // dies but responses are preserved. Confirmation happens inside
+          // QuizLiveMonitor.
+          const assignmentId = config.activeAssignmentId;
+          if (assignmentId) {
+            await deactivateAssignment(assignmentId);
+          } else {
+            await endQuizSession();
+          }
           setView('manager');
         }}
+        onPause={
+          config.activeAssignmentId
+            ? async () => {
+                const id = config.activeAssignmentId;
+                if (!id) return;
+                await pauseAssignment(id);
+                addToast('Assignment paused.', 'success');
+              }
+            : undefined
+        }
+        onResume={
+          config.activeAssignmentId
+            ? async () => {
+                const id = config.activeAssignmentId;
+                if (!id) return;
+                await resumeAssignment(id);
+                addToast('Assignment resumed.', 'success');
+              }
+            : undefined
+        }
         config={config}
         rosters={rosters}
         onUpdateConfig={handleUpdateQuizConfig}
@@ -552,8 +602,6 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
         quizzes={quizzes}
         loading={quizzesLoading}
         error={quizzesError ?? dataError}
-        hasActiveSession={!!(liveSession && liveSession.status !== 'ended')}
-        activeQuizId={liveSession?.quizId ?? null}
         onNew={() => {
           const now = Date.now();
           setEditingQuiz({
@@ -566,11 +614,6 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
           setEditingMeta(null);
         }}
         onImport={() => setView('import')}
-        onResume={() => setView('monitor')}
-        onEndSession={async () => {
-          await endQuizSession();
-          addToast('Session ended.', 'success');
-        }}
         onEdit={async (meta) => {
           const data = await loadQuiz(meta);
           if (data) {
@@ -593,13 +636,30 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
           const data = await loadQuiz(meta);
           if (!data) return;
           try {
-            const code = await startQuizSession(data, mode, sessionOptions);
+            const { id: assignmentId, code } = await createAssignment(
+              {
+                id: meta.id,
+                title: meta.title,
+                driveFileId: meta.driveFileId,
+                questions: data.questions,
+              },
+              {
+                sessionMode: mode,
+                sessionOptions,
+                plcMode: plcOptions.plcMode,
+                teacherName: plcOptions.teacherName,
+                periodName: plcOptions.periodName,
+                plcSheetUrl: plcOptions.plcSheetUrl,
+              },
+              'active'
+            );
             updateWidget(widget.id, {
               config: {
                 ...config,
                 view: 'monitor',
                 selectedQuizId: meta.id,
                 selectedQuizTitle: meta.title,
+                activeAssignmentId: assignmentId,
                 activeLiveSessionCode: code,
                 plcMode: plcOptions.plcMode,
                 teacherName: plcOptions.teacherName ?? '',
@@ -666,6 +726,140 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
             addToast(`Share link: ${url}`, 'info');
           }
         }}
+        // ─── Archive tab ─────────────────────────────────────────────────────
+        managerTab={config.managerTab ?? 'library'}
+        onTabChange={(tab) => handleUpdateQuizConfig({ managerTab: tab })}
+        assignments={assignments}
+        assignmentsLoading={assignmentsLoading}
+        onArchiveCopyUrl={(a) => {
+          const url = `${window.location.origin}/quiz?code=${a.code}`;
+          if (typeof navigator !== 'undefined' && navigator.clipboard) {
+            void navigator.clipboard
+              .writeText(url)
+              .then(() => addToast('Join link copied!', 'success'))
+              .catch(() => addToast(`Join link: ${url}`, 'info'));
+          } else {
+            addToast(`Join link: ${url}`, 'info');
+          }
+        }}
+        onArchiveMonitor={async (a) => {
+          // Look up the library quiz metadata so the monitor can load the full
+          // answer key from Drive. If the quiz was deleted from the library,
+          // we still have the session doc but no way to show the answer key.
+          const meta = quizzes.find((q) => q.id === a.quizId);
+          if (!meta) {
+            addToast(
+              'Quiz is no longer in your library — cannot open monitor.',
+              'error'
+            );
+            return;
+          }
+          const data = await loadQuiz(meta);
+          if (!data) return;
+          updateWidget(widget.id, {
+            config: {
+              ...config,
+              view: 'monitor',
+              selectedQuizId: a.quizId,
+              selectedQuizTitle: a.quizTitle,
+              activeAssignmentId: a.id,
+              activeLiveSessionCode: a.code,
+              periodName: a.periodName ?? '',
+              teacherName: a.teacherName ?? '',
+              plcMode: a.plcMode,
+              plcSheetUrl: a.plcSheetUrl ?? '',
+            } as QuizConfig,
+          });
+        }}
+        onArchiveResults={async (a) => {
+          const meta = quizzes.find((q) => q.id === a.quizId);
+          if (!meta) {
+            addToast(
+              'Quiz is no longer in your library — cannot open results.',
+              'error'
+            );
+            return;
+          }
+          const data = await loadQuiz(meta);
+          if (!data) return;
+          updateWidget(widget.id, {
+            config: {
+              ...config,
+              view: 'results',
+              selectedQuizId: a.quizId,
+              selectedQuizTitle: a.quizTitle,
+              activeAssignmentId: a.id,
+              periodName: a.periodName ?? '',
+              teacherName: a.teacherName ?? '',
+            } as QuizConfig,
+          });
+        }}
+        onArchiveEditSettings={(a) => {
+          setEditingAssignment(a);
+        }}
+        onArchiveShare={async (a) => {
+          const meta = quizzes.find((q) => q.id === a.quizId);
+          if (!meta) {
+            addToast(
+              'Quiz no longer in library — cannot share assignment.',
+              'error'
+            );
+            return;
+          }
+          try {
+            const data = await loadQuizData(meta.driveFileId);
+            const url = await shareAssignment(a.id, data);
+            try {
+              await navigator.clipboard.writeText(url);
+              addToast('Assignment share link copied!', 'success');
+            } catch {
+              addToast(`Assignment share link: ${url}`, 'info');
+            }
+          } catch (err) {
+            addToast(
+              err instanceof Error ? err.message : 'Share failed',
+              'error'
+            );
+          }
+        }}
+        onArchivePauseResume={async (a) => {
+          try {
+            if (a.status === 'paused') {
+              await resumeAssignment(a.id);
+              addToast('Assignment resumed.', 'success');
+            } else if (a.status === 'active') {
+              await pauseAssignment(a.id);
+              addToast('Assignment paused.', 'success');
+            }
+          } catch (err) {
+            addToast(
+              err instanceof Error ? err.message : 'Failed to update status',
+              'error'
+            );
+          }
+        }}
+        onArchiveDeactivate={async (a) => {
+          try {
+            await deactivateAssignment(a.id);
+            addToast('Assignment deactivated. Responses preserved.', 'success');
+          } catch (err) {
+            addToast(
+              err instanceof Error ? err.message : 'Failed to deactivate',
+              'error'
+            );
+          }
+        }}
+        onArchiveDelete={async (a) => {
+          try {
+            await deleteAssignment(a.id);
+            addToast('Assignment deleted.', 'success');
+          } catch (err) {
+            addToast(
+              err instanceof Error ? err.message : 'Failed to delete',
+              'error'
+            );
+          }
+        }}
       />
       <QuizEditorModal
         isOpen={!!editingQuiz}
@@ -681,6 +875,25 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
           addToast(isNew ? 'Quiz created!' : 'Quiz saved!', 'success');
         }}
       />
+      {editingAssignment && (
+        <QuizAssignmentSettingsModal
+          assignment={editingAssignment}
+          rosters={rosters}
+          onClose={() => setEditingAssignment(null)}
+          onSave={async (patch) => {
+            try {
+              await updateAssignmentSettings(editingAssignment.id, patch);
+              addToast('Assignment settings saved.', 'success');
+              setEditingAssignment(null);
+            } catch (err) {
+              addToast(
+                err instanceof Error ? err.message : 'Failed to save settings',
+                'error'
+              );
+            }
+          }}
+        />
+      )}
     </>
   );
 };

--- a/components/widgets/QuizWidget/components/QuizAssignmentArchive.tsx
+++ b/components/widgets/QuizWidget/components/QuizAssignmentArchive.tsx
@@ -1,0 +1,468 @@
+/**
+ * QuizAssignmentArchive — teacher's list of past and current quiz assignments.
+ *
+ * Each row represents a single assignment (one instance of a quiz being
+ * assigned out to students). Actions available per row:
+ *   - Copy join URL (if active/paused)
+ *   - Monitor (re-opens the live session)
+ *   - Results (review responses)
+ *   - Edit settings (class label, PLC, session toggles)
+ *   - Share (publishes as /share/assignment/{id})
+ *   - Pause / Resume toggle
+ *   - Make Inactive (kills URL, preserves responses)
+ *   - Delete (hard delete, removes responses)
+ */
+
+import React, { useState } from 'react';
+import {
+  Link2,
+  Monitor,
+  BarChart3,
+  Settings,
+  Share2,
+  Pause,
+  Play,
+  PowerOff,
+  Trash2,
+  Calendar,
+  Loader2,
+  AlertTriangle,
+  Inbox,
+} from 'lucide-react';
+import type { QuizAssignment } from '@/types';
+
+interface QuizAssignmentArchiveProps {
+  assignments: QuizAssignment[];
+  loading: boolean;
+  onCopyUrl: (assignment: QuizAssignment) => void;
+  onMonitor: (assignment: QuizAssignment) => void;
+  onResults: (assignment: QuizAssignment) => void;
+  onEditSettings: (assignment: QuizAssignment) => void;
+  onShare: (assignment: QuizAssignment) => void;
+  onPauseResume: (assignment: QuizAssignment) => void;
+  onDeactivate: (assignment: QuizAssignment) => void;
+  onDelete: (assignment: QuizAssignment) => void;
+}
+
+const STATUS_STYLES: Record<
+  QuizAssignment['status'],
+  { label: string; bg: string; fg: string; dot: string }
+> = {
+  active: {
+    label: 'Active',
+    bg: 'bg-emerald-100',
+    fg: 'text-emerald-700',
+    dot: 'bg-emerald-500',
+  },
+  paused: {
+    label: 'Paused',
+    bg: 'bg-amber-100',
+    fg: 'text-amber-700',
+    dot: 'bg-amber-500',
+  },
+  inactive: {
+    label: 'Inactive',
+    bg: 'bg-slate-200',
+    fg: 'text-slate-600',
+    dot: 'bg-slate-400',
+  },
+};
+
+function formatDate(ts: number): string {
+  const d = new Date(ts);
+  return d.toLocaleDateString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  });
+}
+
+export const QuizAssignmentArchive: React.FC<QuizAssignmentArchiveProps> = ({
+  assignments,
+  loading,
+  onCopyUrl,
+  onMonitor,
+  onResults,
+  onEditSettings,
+  onShare,
+  onPauseResume,
+  onDeactivate,
+  onDelete,
+}) => {
+  const [confirmDelete, setConfirmDelete] = useState<string | null>(null);
+  const [confirmDeactivate, setConfirmDeactivate] = useState<string | null>(
+    null
+  );
+
+  if (loading) {
+    return (
+      <div
+        className="flex flex-col items-center justify-center flex-1 text-brand-blue-primary/60"
+        style={{ gap: 'min(12px, 3cqmin)' }}
+      >
+        <Loader2
+          className="animate-spin"
+          style={{ width: 'min(28px, 7cqmin)', height: 'min(28px, 7cqmin)' }}
+        />
+        <span style={{ fontSize: 'min(12px, 3.5cqmin)' }}>
+          Loading assignments…
+        </span>
+      </div>
+    );
+  }
+
+  if (assignments.length === 0) {
+    return (
+      <div
+        className="flex flex-col items-center justify-center flex-1 text-center text-brand-blue-primary/60"
+        style={{ padding: 'min(24px, 6cqmin)', gap: 'min(10px, 2.5cqmin)' }}
+      >
+        <Inbox
+          className="opacity-40"
+          style={{ width: 'min(40px, 10cqmin)', height: 'min(40px, 10cqmin)' }}
+        />
+        <p
+          className="font-semibold text-brand-blue-dark"
+          style={{ fontSize: 'min(14px, 4.5cqmin)' }}
+        >
+          No assignments yet
+        </p>
+        <p style={{ fontSize: 'min(12px, 3.5cqmin)', maxWidth: 320 }}>
+          When you assign a quiz from the Library, it appears here so you can
+          monitor, review results, or pause/resume it later.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className="flex-1 overflow-y-auto custom-scrollbar"
+      style={{ padding: 'min(16px, 4cqmin)' }}
+    >
+      <div className="flex flex-col" style={{ gap: 'min(10px, 2.5cqmin)' }}>
+        {assignments.map((a) => {
+          const styles = STATUS_STYLES[a.status];
+          const isActive = a.status === 'active';
+          const isPaused = a.status === 'paused';
+          const isInactive = a.status === 'inactive';
+          const urlLive = isActive || isPaused;
+          const isConfirmingDelete = confirmDelete === a.id;
+          const isConfirmingDeactivate = confirmDeactivate === a.id;
+
+          return (
+            <div
+              key={a.id}
+              className="bg-white rounded-xl border border-brand-blue-primary/15 shadow-sm hover:shadow transition-shadow"
+              style={{ padding: 'min(12px, 3cqmin)' }}
+            >
+              {/* Row header: title + status pill */}
+              <div
+                className="flex items-start justify-between"
+                style={{ gap: 'min(8px, 2cqmin)' }}
+              >
+                <div className="flex-1 min-w-0">
+                  <div
+                    className="font-bold text-brand-blue-dark truncate"
+                    style={{ fontSize: 'min(14px, 4.5cqmin)' }}
+                  >
+                    {a.quizTitle}
+                  </div>
+                  <div
+                    className="flex items-center text-brand-blue-primary/70 mt-0.5"
+                    style={{
+                      gap: 'min(10px, 2.5cqmin)',
+                      fontSize: 'min(11px, 3.5cqmin)',
+                    }}
+                  >
+                    {a.className && (
+                      <span className="font-semibold truncate">
+                        {a.className}
+                      </span>
+                    )}
+                    <span className="flex items-center gap-1">
+                      <Calendar
+                        style={{
+                          width: 'min(11px, 3cqmin)',
+                          height: 'min(11px, 3cqmin)',
+                        }}
+                      />
+                      {formatDate(a.createdAt)}
+                    </span>
+                    <span className="font-mono tracking-wider">{a.code}</span>
+                  </div>
+                </div>
+                <div
+                  className={`flex items-center gap-1.5 rounded-full ${styles.bg} ${styles.fg} font-bold uppercase tracking-wide shrink-0`}
+                  style={{
+                    padding: 'min(3px, 0.75cqmin) min(10px, 2.5cqmin)',
+                    fontSize: 'min(10px, 2.75cqmin)',
+                  }}
+                >
+                  <span
+                    className={`rounded-full ${styles.dot}`}
+                    style={{
+                      width: 'min(6px, 1.5cqmin)',
+                      height: 'min(6px, 1.5cqmin)',
+                    }}
+                  />
+                  {styles.label}
+                </div>
+              </div>
+
+              {/* Inline delete confirmation */}
+              {isConfirmingDelete && (
+                <div
+                  className="mt-2 flex items-center justify-between bg-brand-red-lighter/40 border border-brand-red-primary/30 rounded-lg"
+                  style={{
+                    padding: 'min(8px, 2cqmin) min(10px, 2.5cqmin)',
+                    gap: 'min(8px, 2cqmin)',
+                  }}
+                >
+                  <div
+                    className="flex items-center gap-2 text-brand-red-dark"
+                    style={{ fontSize: 'min(11px, 3.5cqmin)' }}
+                  >
+                    <AlertTriangle
+                      style={{
+                        width: 'min(14px, 3.5cqmin)',
+                        height: 'min(14px, 3.5cqmin)',
+                      }}
+                    />
+                    Delete assignment and all student responses?
+                  </div>
+                  <div className="flex gap-1.5">
+                    <button
+                      onClick={() => setConfirmDelete(null)}
+                      className="px-2 py-0.5 rounded bg-white text-brand-blue-dark font-semibold text-[11px] border border-brand-blue-primary/20"
+                    >
+                      Cancel
+                    </button>
+                    <button
+                      onClick={() => {
+                        setConfirmDelete(null);
+                        onDelete(a);
+                      }}
+                      className="px-2 py-0.5 rounded bg-brand-red-primary text-white font-bold text-[11px]"
+                    >
+                      Delete
+                    </button>
+                  </div>
+                </div>
+              )}
+
+              {/* Inline deactivate confirmation */}
+              {isConfirmingDeactivate && (
+                <div
+                  className="mt-2 flex items-center justify-between bg-amber-50 border border-amber-300 rounded-lg"
+                  style={{
+                    padding: 'min(8px, 2cqmin) min(10px, 2.5cqmin)',
+                    gap: 'min(8px, 2cqmin)',
+                  }}
+                >
+                  <div
+                    className="flex items-center gap-2 text-amber-900"
+                    style={{ fontSize: 'min(11px, 3.5cqmin)' }}
+                  >
+                    <AlertTriangle
+                      style={{
+                        width: 'min(14px, 3.5cqmin)',
+                        height: 'min(14px, 3.5cqmin)',
+                      }}
+                    />
+                    The join URL will stop working. Responses are preserved.
+                  </div>
+                  <div className="flex gap-1.5">
+                    <button
+                      onClick={() => setConfirmDeactivate(null)}
+                      className="px-2 py-0.5 rounded bg-white text-brand-blue-dark font-semibold text-[11px] border border-brand-blue-primary/20"
+                    >
+                      Cancel
+                    </button>
+                    <button
+                      onClick={() => {
+                        setConfirmDeactivate(null);
+                        onDeactivate(a);
+                      }}
+                      className="px-2 py-0.5 rounded bg-amber-600 text-white font-bold text-[11px]"
+                    >
+                      Make Inactive
+                    </button>
+                  </div>
+                </div>
+              )}
+
+              {/* Action row */}
+              <div
+                className="flex flex-wrap items-center mt-2"
+                style={{ gap: 'min(6px, 1.5cqmin)' }}
+              >
+                <button
+                  onClick={() => onCopyUrl(a)}
+                  disabled={!urlLive}
+                  className="flex items-center gap-1 rounded-lg bg-brand-blue-primary text-white font-bold disabled:opacity-40 disabled:cursor-not-allowed hover:bg-brand-blue-dark transition-colors"
+                  style={{
+                    padding: 'min(5px, 1.25cqmin) min(10px, 2.5cqmin)',
+                    fontSize: 'min(11px, 3.25cqmin)',
+                  }}
+                  title={
+                    urlLive ? 'Copy student join URL' : 'Assignment is inactive'
+                  }
+                >
+                  <Link2
+                    style={{
+                      width: 'min(12px, 3cqmin)',
+                      height: 'min(12px, 3cqmin)',
+                    }}
+                  />
+                  Copy URL
+                </button>
+                <button
+                  onClick={() => onMonitor(a)}
+                  className="flex items-center gap-1 rounded-lg bg-white text-brand-blue-dark font-bold border border-brand-blue-primary/20 hover:bg-brand-blue-lighter/40 transition-colors"
+                  style={{
+                    padding: 'min(5px, 1.25cqmin) min(10px, 2.5cqmin)',
+                    fontSize: 'min(11px, 3.25cqmin)',
+                  }}
+                >
+                  <Monitor
+                    style={{
+                      width: 'min(12px, 3cqmin)',
+                      height: 'min(12px, 3cqmin)',
+                    }}
+                  />
+                  Monitor
+                </button>
+                <button
+                  onClick={() => onResults(a)}
+                  className="flex items-center gap-1 rounded-lg bg-white text-brand-blue-dark font-bold border border-brand-blue-primary/20 hover:bg-brand-blue-lighter/40 transition-colors"
+                  style={{
+                    padding: 'min(5px, 1.25cqmin) min(10px, 2.5cqmin)',
+                    fontSize: 'min(11px, 3.25cqmin)',
+                  }}
+                >
+                  <BarChart3
+                    style={{
+                      width: 'min(12px, 3cqmin)',
+                      height: 'min(12px, 3cqmin)',
+                    }}
+                  />
+                  Results
+                </button>
+                <button
+                  onClick={() => onEditSettings(a)}
+                  className="flex items-center gap-1 rounded-lg bg-white text-brand-blue-dark font-bold border border-brand-blue-primary/20 hover:bg-brand-blue-lighter/40 transition-colors"
+                  style={{
+                    padding: 'min(5px, 1.25cqmin) min(10px, 2.5cqmin)',
+                    fontSize: 'min(11px, 3.25cqmin)',
+                  }}
+                >
+                  <Settings
+                    style={{
+                      width: 'min(12px, 3cqmin)',
+                      height: 'min(12px, 3cqmin)',
+                    }}
+                  />
+                  Settings
+                </button>
+                <button
+                  onClick={() => onShare(a)}
+                  className="flex items-center gap-1 rounded-lg bg-white text-brand-blue-dark font-bold border border-brand-blue-primary/20 hover:bg-brand-blue-lighter/40 transition-colors"
+                  style={{
+                    padding: 'min(5px, 1.25cqmin) min(10px, 2.5cqmin)',
+                    fontSize: 'min(11px, 3.25cqmin)',
+                  }}
+                >
+                  <Share2
+                    style={{
+                      width: 'min(12px, 3cqmin)',
+                      height: 'min(12px, 3cqmin)',
+                    }}
+                  />
+                  Share
+                </button>
+
+                {/* Spacer pushes destructive actions to the right */}
+                <div className="flex-1" />
+
+                {urlLive && (
+                  <button
+                    onClick={() => onPauseResume(a)}
+                    className={`flex items-center gap-1 rounded-lg font-bold transition-colors ${
+                      isPaused
+                        ? 'bg-emerald-600 hover:bg-emerald-700 text-white'
+                        : 'bg-amber-500 hover:bg-amber-600 text-white'
+                    }`}
+                    style={{
+                      padding: 'min(5px, 1.25cqmin) min(10px, 2.5cqmin)',
+                      fontSize: 'min(11px, 3.25cqmin)',
+                    }}
+                  >
+                    {isPaused ? (
+                      <Play
+                        style={{
+                          width: 'min(12px, 3cqmin)',
+                          height: 'min(12px, 3cqmin)',
+                        }}
+                      />
+                    ) : (
+                      <Pause
+                        style={{
+                          width: 'min(12px, 3cqmin)',
+                          height: 'min(12px, 3cqmin)',
+                        }}
+                      />
+                    )}
+                    {isPaused ? 'Resume' : 'Pause'}
+                  </button>
+                )}
+
+                {urlLive && (
+                  <button
+                    onClick={() => setConfirmDeactivate(a.id)}
+                    className="flex items-center gap-1 rounded-lg bg-white text-amber-700 font-bold border border-amber-300 hover:bg-amber-50 transition-colors"
+                    style={{
+                      padding: 'min(5px, 1.25cqmin) min(10px, 2.5cqmin)',
+                      fontSize: 'min(11px, 3.25cqmin)',
+                    }}
+                    title="Kill the join URL. Responses are kept."
+                  >
+                    <PowerOff
+                      style={{
+                        width: 'min(12px, 3cqmin)',
+                        height: 'min(12px, 3cqmin)',
+                      }}
+                    />
+                    Make Inactive
+                  </button>
+                )}
+
+                <button
+                  onClick={() => setConfirmDelete(a.id)}
+                  className="flex items-center gap-1 rounded-lg text-brand-red-dark font-bold border border-brand-red-primary/30 hover:bg-brand-red-lighter/40 transition-colors"
+                  style={{
+                    padding: 'min(5px, 1.25cqmin) min(10px, 2.5cqmin)',
+                    fontSize: 'min(11px, 3.25cqmin)',
+                  }}
+                  title={
+                    isInactive
+                      ? 'Delete assignment and responses'
+                      : 'Delete assignment and all responses'
+                  }
+                >
+                  <Trash2
+                    style={{
+                      width: 'min(12px, 3cqmin)',
+                      height: 'min(12px, 3cqmin)',
+                    }}
+                  />
+                  Delete
+                </button>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+};

--- a/components/widgets/QuizWidget/components/QuizAssignmentArchive.tsx
+++ b/components/widgets/QuizWidget/components/QuizAssignmentArchive.tsx
@@ -234,7 +234,8 @@ export const QuizAssignmentArchive: React.FC<QuizAssignmentArchiveProps> = ({
                   <div className="flex gap-1.5">
                     <button
                       onClick={() => setConfirmDelete(null)}
-                      className="px-2 py-0.5 rounded bg-white text-brand-blue-dark font-semibold text-[11px] border border-brand-blue-primary/20"
+                      className="px-2 py-0.5 rounded bg-white text-brand-blue-dark font-semibold border border-brand-blue-primary/20"
+                      style={{ fontSize: 'min(11px, 3.5cqmin)' }}
                     >
                       Cancel
                     </button>
@@ -243,7 +244,8 @@ export const QuizAssignmentArchive: React.FC<QuizAssignmentArchiveProps> = ({
                         setConfirmDelete(null);
                         onDelete(a);
                       }}
-                      className="px-2 py-0.5 rounded bg-brand-red-primary text-white font-bold text-[11px]"
+                      className="px-2 py-0.5 rounded bg-brand-red-primary text-white font-bold"
+                      style={{ fontSize: 'min(11px, 3.5cqmin)' }}
                     >
                       Delete
                     </button>
@@ -275,7 +277,8 @@ export const QuizAssignmentArchive: React.FC<QuizAssignmentArchiveProps> = ({
                   <div className="flex gap-1.5">
                     <button
                       onClick={() => setConfirmDeactivate(null)}
-                      className="px-2 py-0.5 rounded bg-white text-brand-blue-dark font-semibold text-[11px] border border-brand-blue-primary/20"
+                      className="px-2 py-0.5 rounded bg-white text-brand-blue-dark font-semibold border border-brand-blue-primary/20"
+                      style={{ fontSize: 'min(11px, 3.5cqmin)' }}
                     >
                       Cancel
                     </button>
@@ -284,7 +287,8 @@ export const QuizAssignmentArchive: React.FC<QuizAssignmentArchiveProps> = ({
                         setConfirmDeactivate(null);
                         onDeactivate(a);
                       }}
-                      className="px-2 py-0.5 rounded bg-amber-600 text-white font-bold text-[11px]"
+                      className="px-2 py-0.5 rounded bg-amber-600 text-white font-bold"
+                      style={{ fontSize: 'min(11px, 3.5cqmin)' }}
                     >
                       Make Inactive
                     </button>

--- a/components/widgets/QuizWidget/components/QuizAssignmentSettingsModal.tsx
+++ b/components/widgets/QuizWidget/components/QuizAssignmentSettingsModal.tsx
@@ -103,14 +103,18 @@ export const QuizAssignmentSettingsModal: React.FC<
         showPodiumBetweenQuestions,
         soundEffectsEnabled,
       };
+      // Intentionally pass empty strings (not undefined) so that clearing a
+      // field actually writes '' to Firestore. Using `|| undefined` would
+      // cause updateDoc to skip the field and leave the previous value in
+      // place, making these settings unclearable after they've been set.
       const patch: Partial<QuizAssignmentSettings> = {
-        className: className || undefined,
+        className: className.trim(),
         sessionMode: modeLocked ? assignment.sessionMode : sessionMode,
         sessionOptions,
         plcMode,
-        teacherName: teacherName || undefined,
-        periodName: periodName || undefined,
-        plcSheetUrl: plcSheetUrl || undefined,
+        teacherName: teacherName.trim(),
+        periodName: periodName.trim(),
+        plcSheetUrl: plcSheetUrl.trim(),
       };
       await onSave(patch);
       onClose();

--- a/components/widgets/QuizWidget/components/QuizAssignmentSettingsModal.tsx
+++ b/components/widgets/QuizWidget/components/QuizAssignmentSettingsModal.tsx
@@ -1,0 +1,493 @@
+/**
+ * QuizAssignmentSettingsModal — edit the settings for a single assignment.
+ *
+ * Edits apply only to the assignment record (className, PLC fields, session
+ * toggles). The quiz content is sourced from the teacher's library and cannot
+ * be modified here. `sessionMode` is locked while the assignment is still
+ * active or paused (mid-session mode changes are incoherent); it becomes
+ * editable once the assignment is `inactive`.
+ */
+
+import React, { useState } from 'react';
+import {
+  X,
+  ArrowLeft,
+  User,
+  Zap,
+  Clock,
+  Share2,
+  AlertTriangle,
+  Lock,
+  Save,
+  Settings as SettingsIcon,
+} from 'lucide-react';
+import type {
+  QuizAssignment,
+  QuizAssignmentSettings,
+  QuizSessionMode,
+  QuizSessionOptions,
+  ClassRoster,
+} from '@/types';
+import { Toggle } from '@/components/common/Toggle';
+
+interface QuizAssignmentSettingsModalProps {
+  assignment: QuizAssignment;
+  rosters: ClassRoster[];
+  onClose: () => void;
+  onSave: (patch: Partial<QuizAssignmentSettings>) => Promise<void> | void;
+}
+
+export const QuizAssignmentSettingsModal: React.FC<
+  QuizAssignmentSettingsModalProps
+> = ({ assignment, rosters, onClose, onSave }) => {
+  // Mode is only editable when the assignment is inactive — changing it
+  // mid-session would leave the live session in an incoherent state.
+  const modeLocked = assignment.status !== 'inactive';
+
+  const opts = assignment.sessionOptions ?? {};
+
+  const [className, setClassName] = useState(assignment.className ?? '');
+  const [sessionMode, setSessionMode] = useState<QuizSessionMode>(
+    assignment.sessionMode
+  );
+
+  // Session toggles
+  const [tabWarningsEnabled, setTabWarningsEnabled] = useState(
+    opts.tabWarningsEnabled ?? true
+  );
+  const [showResultToStudent, setShowResultToStudent] = useState(
+    opts.showResultToStudent ?? false
+  );
+  const [showCorrectAnswerToStudent, setShowCorrectAnswerToStudent] = useState(
+    opts.showCorrectAnswerToStudent ?? false
+  );
+  const [showCorrectOnBoard, setShowCorrectOnBoard] = useState(
+    opts.showCorrectOnBoard ?? false
+  );
+  const [speedBonusEnabled, setSpeedBonusEnabled] = useState(
+    opts.speedBonusEnabled ?? false
+  );
+  const [streakBonusEnabled, setStreakBonusEnabled] = useState(
+    opts.streakBonusEnabled ?? false
+  );
+  const [showPodiumBetweenQuestions, setShowPodiumBetweenQuestions] = useState(
+    opts.showPodiumBetweenQuestions ?? true
+  );
+  const [soundEffectsEnabled, setSoundEffectsEnabled] = useState(
+    opts.soundEffectsEnabled ?? false
+  );
+
+  // PLC
+  const [plcMode, setPlcMode] = useState(assignment.plcMode ?? false);
+  const [teacherName, setTeacherName] = useState(assignment.teacherName ?? '');
+  const [periodName, setPeriodName] = useState(assignment.periodName ?? '');
+  const [plcSheetUrl, setPlcSheetUrl] = useState(assignment.plcSheetUrl ?? '');
+
+  const [saving, setSaving] = useState(false);
+
+  const plcSheetUrlInvalid =
+    !!plcSheetUrl &&
+    !plcSheetUrl.startsWith('https://docs.google.com/spreadsheets/');
+
+  const handleSave = async () => {
+    if (saving) return;
+    setSaving(true);
+    try {
+      const sessionOptions: QuizSessionOptions = {
+        tabWarningsEnabled,
+        showResultToStudent,
+        showCorrectAnswerToStudent,
+        showCorrectOnBoard,
+        speedBonusEnabled,
+        streakBonusEnabled,
+        showPodiumBetweenQuestions,
+        soundEffectsEnabled,
+      };
+      const patch: Partial<QuizAssignmentSettings> = {
+        className: className || undefined,
+        sessionMode: modeLocked ? assignment.sessionMode : sessionMode,
+        sessionOptions,
+        plcMode,
+        teacherName: teacherName || undefined,
+        periodName: periodName || undefined,
+        plcSheetUrl: plcSheetUrl || undefined,
+      };
+      await onSave(patch);
+      onClose();
+    } catch (err) {
+      console.error('[QuizAssignmentSettingsModal] save failed:', err);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="absolute inset-0 z-overlay bg-brand-blue-dark/60 backdrop-blur-sm flex items-center justify-center p-4">
+      <div className="bg-white rounded-3xl w-full max-w-sm shadow-2xl overflow-hidden animate-in zoom-in-95 duration-200 flex flex-col max-h-full">
+        {/* Header */}
+        <div className="bg-brand-blue-primary p-4 flex items-center justify-between shrink-0">
+          <div className="flex items-center gap-2 text-white">
+            <SettingsIcon className="w-5 h-5" />
+            <span className="font-black uppercase tracking-tight">
+              Assignment Settings
+            </span>
+          </div>
+          <button
+            onClick={onClose}
+            className="text-white/60 hover:text-white transition-colors"
+            aria-label="Close"
+          >
+            <X className="w-5 h-5" />
+          </button>
+        </div>
+
+        <div className="flex-1 overflow-y-auto p-5 space-y-4">
+          {/* Quiz title (read-only) */}
+          <div className="text-center">
+            <p className="font-bold text-brand-blue-dark text-base truncate px-2">
+              {assignment.quizTitle}
+            </p>
+            <p
+              className="text-brand-blue-primary/60 font-black uppercase tracking-widest mt-1"
+              style={{ fontSize: 'min(10px, 3cqmin)' }}
+            >
+              Edit assignment settings
+            </p>
+          </div>
+
+          {/* Class label */}
+          <div>
+            <label className="block text-xxs font-bold text-slate-400 uppercase tracking-widest mb-1">
+              Class Label
+            </label>
+            <input
+              type="text"
+              value={className}
+              onChange={(e) => setClassName(e.target.value)}
+              placeholder="e.g. Period 2"
+              className="w-full px-3 py-2 bg-white border border-slate-200 rounded-lg text-slate-800 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+            />
+            <p className="text-xxs text-slate-400 mt-0.5">
+              Shown in the archive to distinguish assignments.
+            </p>
+          </div>
+
+          {/* Session mode */}
+          <div className="border-t border-slate-100 pt-4 space-y-3">
+            <div className="flex items-center justify-between">
+              <p
+                className="text-brand-blue-primary/60 font-black uppercase tracking-widest"
+                style={{ fontSize: 'min(10px, 3cqmin)' }}
+              >
+                Session Mode
+              </p>
+              {modeLocked && (
+                <span className="flex items-center gap-1 text-xxs font-bold text-slate-400 uppercase tracking-widest">
+                  <Lock className="w-3 h-3" />
+                  Locked
+                </span>
+              )}
+            </div>
+            {modeLocked && (
+              <p className="text-xxs text-slate-500 -mt-1">
+                Make this assignment inactive to change its session mode.
+              </p>
+            )}
+            <div className="grid gap-3">
+              <ModeButton
+                icon={<User className="w-5 h-5" />}
+                title="Teacher-paced"
+                desc="You control when to move to the next question."
+                selected={sessionMode === 'teacher'}
+                disabled={modeLocked}
+                onClick={() => setSessionMode('teacher')}
+              />
+              <ModeButton
+                icon={<Zap className="w-5 h-5" />}
+                title="Auto-progress"
+                desc="Moves automatically once everyone has answered."
+                selected={sessionMode === 'auto'}
+                disabled={modeLocked}
+                onClick={() => setSessionMode('auto')}
+              />
+              <ModeButton
+                icon={<Clock className="w-5 h-5" />}
+                title="Self-paced"
+                desc="Students move through questions at their own speed."
+                selected={sessionMode === 'student'}
+                disabled={modeLocked}
+                onClick={() => setSessionMode('student')}
+              />
+            </div>
+          </div>
+
+          {/* Quiz Integrity */}
+          <div className="border-t border-slate-100 pt-4 space-y-3">
+            <p
+              className="text-brand-blue-primary/60 font-black uppercase tracking-widest"
+              style={{ fontSize: 'min(10px, 3cqmin)' }}
+            >
+              Quiz Integrity
+            </p>
+            <ToggleRow
+              label="Tab Switch Detection"
+              checked={tabWarningsEnabled}
+              onChange={setTabWarningsEnabled}
+              hint="Warn students who leave the quiz tab"
+            />
+          </div>
+
+          {/* Answer Feedback */}
+          <div className="border-t border-slate-100 pt-4 space-y-3">
+            <p
+              className="text-brand-blue-primary/60 font-black uppercase tracking-widest"
+              style={{ fontSize: 'min(10px, 3cqmin)' }}
+            >
+              Answer Feedback
+            </p>
+            <ToggleRow
+              label="Show right/wrong to students"
+              checked={showResultToStudent}
+              onChange={setShowResultToStudent}
+              hint="Students see ✓ or ✗ after submitting"
+            />
+            <ToggleRow
+              label="Reveal correct answer to students"
+              checked={showCorrectAnswerToStudent}
+              onChange={setShowCorrectAnswerToStudent}
+              disabled={!showResultToStudent}
+              hint="Also show what the correct answer was"
+            />
+            <ToggleRow
+              label="Show correct answer on board"
+              checked={showCorrectOnBoard}
+              onChange={setShowCorrectOnBoard}
+              hint="Display correct answer on the projected screen"
+            />
+          </div>
+
+          {/* Gamification */}
+          <div className="border-t border-slate-100 pt-4 space-y-3">
+            <p
+              className="text-brand-blue-primary/60 font-black uppercase tracking-widest"
+              style={{ fontSize: 'min(10px, 3cqmin)' }}
+            >
+              Gamification
+            </p>
+            <ToggleRow
+              label="Speed Bonus Points"
+              checked={speedBonusEnabled}
+              onChange={setSpeedBonusEnabled}
+              hint="Up to 50% bonus for fast answers"
+            />
+            <ToggleRow
+              label="Streak Bonuses"
+              checked={streakBonusEnabled}
+              onChange={setStreakBonusEnabled}
+              hint="Multiplier for consecutive correct answers"
+            />
+            <ToggleRow
+              label="Podium Between Questions"
+              checked={showPodiumBetweenQuestions}
+              onChange={setShowPodiumBetweenQuestions}
+              hint="Show top 3 leaderboard after each question"
+            />
+            <ToggleRow
+              label="Sound Effects"
+              checked={soundEffectsEnabled}
+              onChange={setSoundEffectsEnabled}
+              hint="Chimes, ticks, and fanfares during the quiz"
+            />
+          </div>
+
+          {/* PLC / Share with PLC */}
+          <div className="border-t border-slate-100 pt-4">
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-2">
+                <Share2 className="w-4 h-4 text-brand-blue-primary" />
+                <span className="text-sm font-bold text-brand-blue-dark">
+                  Share with PLC
+                </span>
+              </div>
+              <Toggle
+                checked={plcMode}
+                onChange={setPlcMode}
+                size="sm"
+                showLabels={true}
+              />
+            </div>
+            <p className="text-xxs text-slate-500 mt-1">
+              Export results to a shared Google Sheet for your PLC team.
+            </p>
+
+            {plcMode && (
+              <div className="mt-3 space-y-3 bg-slate-50 rounded-xl p-3 border border-slate-100">
+                <div>
+                  <label className="block text-xxs font-bold text-slate-400 uppercase tracking-widest mb-1">
+                    Your Name
+                  </label>
+                  <input
+                    type="text"
+                    value={teacherName}
+                    onChange={(e) => setTeacherName(e.target.value)}
+                    placeholder="e.g. Ms. Smith"
+                    className="w-full px-3 py-2 bg-white border border-slate-200 rounded-lg text-slate-800 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                  />
+                  <p className="text-xxs text-slate-400 mt-0.5">
+                    Appears in the &quot;Teacher&quot; column of the shared
+                    sheet
+                  </p>
+                </div>
+
+                <div>
+                  <label className="block text-xxs font-bold text-slate-400 uppercase tracking-widest mb-1">
+                    Class Period
+                  </label>
+                  {rosters.length > 0 ? (
+                    <select
+                      value={periodName}
+                      onChange={(e) => setPeriodName(e.target.value)}
+                      className="w-full px-3 py-2 bg-white border border-slate-200 rounded-lg text-slate-800 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                    >
+                      <option value="">Select a class...</option>
+                      {rosters.map((r) => (
+                        <option key={r.id} value={r.name}>
+                          {r.name}
+                        </option>
+                      ))}
+                    </select>
+                  ) : (
+                    <input
+                      type="text"
+                      value={periodName}
+                      onChange={(e) => setPeriodName(e.target.value)}
+                      placeholder="e.g. Period 3"
+                      className="w-full px-3 py-2 bg-white border border-slate-200 rounded-lg text-slate-800 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                    />
+                  )}
+                  <p className="text-xxs text-slate-400 mt-0.5">
+                    Must match your Class widget roster name for student name
+                    lookup
+                  </p>
+                </div>
+
+                <div>
+                  <label className="block text-xxs font-bold text-slate-400 uppercase tracking-widest mb-1">
+                    Shared Google Sheet URL
+                  </label>
+                  <input
+                    type="text"
+                    value={plcSheetUrl}
+                    onChange={(e) => setPlcSheetUrl(e.target.value)}
+                    placeholder="https://docs.google.com/spreadsheets/d/..."
+                    className="w-full px-3 py-2 bg-white border border-slate-200 rounded-lg text-slate-800 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                  />
+                  {plcSheetUrlInvalid && (
+                    <div className="flex items-center gap-1 mt-1 text-amber-600">
+                      <AlertTriangle className="w-3 h-3" />
+                      <span className="text-xxs">
+                        This doesn&apos;t look like a Google Sheets URL
+                      </span>
+                    </div>
+                  )}
+                  <p className="text-xxs text-slate-400 mt-0.5">
+                    Paste the URL of the Google Sheet shared by your PLC lead
+                  </p>
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+
+        {/* Footer */}
+        <div className="flex items-center justify-between border-t border-slate-200 p-4 shrink-0">
+          <button
+            onClick={onClose}
+            className="flex items-center gap-1.5 px-4 py-2 text-brand-blue-primary hover:bg-brand-blue-lighter/40 font-bold rounded-xl transition-colors text-sm"
+          >
+            <ArrowLeft className="w-4 h-4" />
+            Cancel
+          </button>
+          <button
+            disabled={saving}
+            onClick={() => {
+              void handleSave();
+            }}
+            className="flex items-center gap-1.5 px-5 py-2 bg-emerald-600 hover:bg-emerald-700 disabled:bg-brand-gray-lighter disabled:cursor-not-allowed text-white font-black rounded-xl transition-all shadow-md active:scale-95 text-sm"
+          >
+            <Save className="w-4 h-4" />
+            {saving ? 'Saving…' : 'Save'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+const ModeButton: React.FC<{
+  icon: React.ReactNode;
+  title: string;
+  desc: string;
+  selected?: boolean;
+  disabled?: boolean;
+  onClick: () => void;
+}> = ({ icon, title, desc, selected, disabled, onClick }) => (
+  <button
+    onClick={onClick}
+    disabled={disabled}
+    className={`w-full text-left p-3 rounded-2xl border-2 transition-all flex items-start gap-3 group ${
+      selected
+        ? 'border-brand-blue-primary bg-brand-blue-lighter/30'
+        : 'border-brand-blue-primary/10 hover:border-brand-blue-primary hover:bg-brand-blue-lighter/30'
+    } ${disabled ? 'opacity-50 cursor-not-allowed hover:border-brand-blue-primary/10 hover:bg-transparent' : ''}`}
+  >
+    <div
+      className={`p-2 rounded-xl transition-colors ${
+        selected
+          ? 'bg-brand-blue-primary text-white'
+          : 'bg-brand-blue-lighter text-brand-blue-primary group-hover:bg-brand-blue-primary group-hover:text-white'
+      }`}
+    >
+      {icon}
+    </div>
+    <div>
+      <p className="font-black text-brand-blue-dark text-sm leading-tight">
+        {title}
+      </p>
+      <p
+        className="text-brand-gray-primary font-medium leading-tight mt-0.5"
+        style={{ fontSize: 'min(11px, 3.25cqmin)' }}
+      >
+        {desc}
+      </p>
+    </div>
+  </button>
+);
+
+const ToggleRow: React.FC<{
+  label: string;
+  checked: boolean;
+  onChange: (v: boolean) => void;
+  hint?: string;
+  disabled?: boolean;
+}> = ({ label, checked, onChange, hint, disabled }) => (
+  <div className={disabled ? 'opacity-40 pointer-events-none' : ''}>
+    <div className="flex items-center justify-between">
+      <span
+        className="font-bold text-brand-blue-dark"
+        style={{ fontSize: 'min(14px, 4cqmin)' }}
+      >
+        {label}
+      </span>
+      <Toggle checked={checked} onChange={onChange} size="sm" showLabels />
+    </div>
+    {hint && (
+      <p
+        className="text-slate-500 mt-0.5"
+        style={{ fontSize: 'min(10px, 3cqmin)' }}
+      >
+        {hint}
+      </p>
+    )}
+  </div>
+);

--- a/components/widgets/QuizWidget/components/QuizLiveMonitor.tsx
+++ b/components/widgets/QuizWidget/components/QuizLiveMonitor.tsx
@@ -33,6 +33,8 @@ import {
   VolumeX,
   Palette,
   Medal,
+  Pause,
+  Play,
 } from 'lucide-react';
 import { deleteField, doc, updateDoc } from 'firebase/firestore';
 import {
@@ -63,7 +65,16 @@ interface QuizLiveMonitorProps {
   responses: QuizResponse[];
   quizData: QuizData;
   onAdvance: () => Promise<void>;
+  /**
+   * "Make Inactive" for this assignment — kills the student URL but preserves
+   * all responses. Replaces the old "End" action which only touched the
+   * session doc.
+   */
   onEnd: () => Promise<void>;
+  /** Pause this assignment — URL stays live, students see a paused placeholder. */
+  onPause?: () => Promise<void>;
+  /** Resume a paused assignment. */
+  onResume?: () => Promise<void>;
   config: QuizConfig;
   rosters: ClassRoster[];
   onUpdateConfig: (updates: Partial<QuizConfig>) => void;
@@ -78,6 +89,8 @@ export const QuizLiveMonitor: React.FC<QuizLiveMonitorProps> = ({
   quizData,
   onAdvance,
   onEnd,
+  onPause,
+  onResume,
   config,
   rosters,
   onUpdateConfig,
@@ -284,11 +297,30 @@ export const QuizLiveMonitor: React.FC<QuizLiveMonitorProps> = ({
   };
 
   const handleEnd = async () => {
+    const ok = window.confirm(
+      'Make this assignment inactive?\n\nThe student URL will stop working. Responses are preserved and will still be viewable from the Archive.'
+    );
+    if (!ok) return;
     setEnding(true);
     try {
       await onEnd();
     } finally {
       setEnding(false);
+    }
+  };
+
+  const [toggling, setToggling] = useState(false);
+  const handleTogglePause = async () => {
+    if (toggling) return;
+    setToggling(true);
+    try {
+      if (session.status === 'paused') {
+        if (onResume) await onResume();
+      } else if (onPause) {
+        await onPause();
+      }
+    } finally {
+      setToggling(false);
     }
   };
 
@@ -388,34 +420,82 @@ export const QuizLiveMonitor: React.FC<QuizLiveMonitorProps> = ({
               </span>
             </div>
           </div>
-          <button
-            onClick={() => void handleEnd()}
-            disabled={ending}
-            className="flex items-center bg-brand-red-primary hover:bg-brand-red-dark disabled:opacity-50 text-white font-black rounded-xl transition-all shadow-md active:scale-95"
-            style={{
-              gap: 'min(6px, 1.5cqmin)',
-              padding: 'min(6px, 1.5cqmin) min(12px, 3cqmin)',
-              fontSize: 'min(11px, 3.5cqmin)',
-            }}
+          <div
+            className="flex items-center"
+            style={{ gap: 'min(6px, 1.5cqmin)' }}
           >
-            {ending ? (
-              <Loader2
-                className="animate-spin"
+            {(onPause ?? onResume) && session.status !== 'ended' && (
+              <button
+                onClick={() => void handleTogglePause()}
+                disabled={toggling}
+                className="flex items-center bg-amber-500 hover:bg-amber-600 disabled:opacity-50 text-white font-black rounded-xl transition-all shadow-md active:scale-95"
                 style={{
-                  width: 'min(14px, 3.5cqmin)',
-                  height: 'min(14px, 3.5cqmin)',
+                  gap: 'min(6px, 1.5cqmin)',
+                  padding: 'min(6px, 1.5cqmin) min(12px, 3cqmin)',
+                  fontSize: 'min(11px, 3.5cqmin)',
                 }}
-              />
-            ) : (
-              <Square
-                style={{
-                  width: 'min(14px, 3.5cqmin)',
-                  height: 'min(14px, 3.5cqmin)',
-                }}
-              />
+                title={
+                  session.status === 'paused'
+                    ? 'Resume — students can answer again'
+                    : 'Pause — students see a paused screen'
+                }
+              >
+                {toggling ? (
+                  <Loader2
+                    className="animate-spin"
+                    style={{
+                      width: 'min(14px, 3.5cqmin)',
+                      height: 'min(14px, 3.5cqmin)',
+                    }}
+                  />
+                ) : session.status === 'paused' ? (
+                  <Play
+                    style={{
+                      width: 'min(14px, 3.5cqmin)',
+                      height: 'min(14px, 3.5cqmin)',
+                    }}
+                  />
+                ) : (
+                  <Pause
+                    style={{
+                      width: 'min(14px, 3.5cqmin)',
+                      height: 'min(14px, 3.5cqmin)',
+                    }}
+                  />
+                )}
+                {session.status === 'paused' ? 'RESUME' : 'PAUSE'}
+              </button>
             )}
-            END
-          </button>
+            <button
+              onClick={() => void handleEnd()}
+              disabled={ending}
+              className="flex items-center bg-brand-red-primary hover:bg-brand-red-dark disabled:opacity-50 text-white font-black rounded-xl transition-all shadow-md active:scale-95"
+              style={{
+                gap: 'min(6px, 1.5cqmin)',
+                padding: 'min(6px, 1.5cqmin) min(12px, 3cqmin)',
+                fontSize: 'min(11px, 3.5cqmin)',
+              }}
+              title="Make this assignment inactive. Responses are preserved."
+            >
+              {ending ? (
+                <Loader2
+                  className="animate-spin"
+                  style={{
+                    width: 'min(14px, 3.5cqmin)',
+                    height: 'min(14px, 3.5cqmin)',
+                  }}
+                />
+              ) : (
+                <Square
+                  style={{
+                    width: 'min(14px, 3.5cqmin)',
+                    height: 'min(14px, 3.5cqmin)',
+                  }}
+                />
+              )}
+              END
+            </button>
+          </div>
         </div>
       </div>
 

--- a/components/widgets/QuizWidget/components/QuizManager.tsx
+++ b/components/widgets/QuizWidget/components/QuizManager.tsx
@@ -24,15 +24,18 @@ import {
   ArrowLeft,
   ChevronRight,
   Link2,
+  Archive as ArchiveIcon,
 } from 'lucide-react';
 import {
   QuizMetadata,
   QuizSessionMode,
   QuizConfig,
   ClassRoster,
+  QuizAssignment,
 } from '@/types';
 import { type QuizSessionOptions } from '@/hooks/useQuizSession';
 import { Toggle } from '@/components/common/Toggle';
+import { QuizAssignmentArchive } from './QuizAssignmentArchive';
 
 export interface PlcOptions {
   plcMode: boolean;
@@ -55,15 +58,26 @@ interface QuizManagerProps {
     plcOptions: PlcOptions,
     sessionOptions: QuizSessionOptions
   ) => void;
-  onResume: () => void;
-  onEndSession: () => Promise<void>;
   onResults: (quiz: QuizMetadata) => void;
   onDelete: (quiz: QuizMetadata) => void;
   onShare: (quiz: QuizMetadata) => void;
-  hasActiveSession: boolean;
-  activeQuizId: string | null;
   rosters: ClassRoster[];
   config: QuizConfig;
+
+  // ─── Archive tab ───────────────────────────────────────────────────────────
+  /** Which manager tab is currently active. Defaults to `'library'`. */
+  managerTab?: 'library' | 'archive';
+  onTabChange?: (tab: 'library' | 'archive') => void;
+  assignments?: QuizAssignment[];
+  assignmentsLoading?: boolean;
+  onArchiveCopyUrl?: (assignment: QuizAssignment) => void;
+  onArchiveMonitor?: (assignment: QuizAssignment) => void;
+  onArchiveResults?: (assignment: QuizAssignment) => void;
+  onArchiveEditSettings?: (assignment: QuizAssignment) => void;
+  onArchiveShare?: (assignment: QuizAssignment) => void;
+  onArchivePauseResume?: (assignment: QuizAssignment) => void;
+  onArchiveDeactivate?: (assignment: QuizAssignment) => void;
+  onArchiveDelete?: (assignment: QuizAssignment) => void;
 }
 
 export const QuizManager: React.FC<QuizManagerProps> = ({
@@ -75,16 +89,27 @@ export const QuizManager: React.FC<QuizManagerProps> = ({
   onEdit,
   onPreview,
   onAssign,
-  onResume,
-  onEndSession,
   onResults,
   onDelete,
   onShare,
-  hasActiveSession,
-  activeQuizId,
   rosters,
   config,
+  managerTab = 'library',
+  onTabChange,
+  assignments = [],
+  assignmentsLoading = false,
+  onArchiveCopyUrl,
+  onArchiveMonitor,
+  onArchiveResults,
+  onArchiveEditSettings,
+  onArchiveShare,
+  onArchivePauseResume,
+  onArchiveDeactivate,
+  onArchiveDelete,
 }) => {
+  const noop = () => {
+    /* archive action not yet wired */
+  };
   const [confirmDelete, setConfirmDelete] = useState<string | null>(null);
   const [selectedForLive, setSelectedForLive] = useState<QuizMetadata | null>(
     null
@@ -466,100 +491,144 @@ export const QuizManager: React.FC<QuizManagerProps> = ({
             className="bg-brand-blue-primary text-white flex items-center justify-center rounded-lg"
             style={{ width: 'min(24px, 6cqmin)', height: 'min(24px, 6cqmin)' }}
           >
-            <BookOpen
-              style={{
-                width: 'min(14px, 3.5cqmin)',
-                height: 'min(14px, 3.5cqmin)',
-              }}
-            />
+            {managerTab === 'archive' ? (
+              <ArchiveIcon
+                style={{
+                  width: 'min(14px, 3.5cqmin)',
+                  height: 'min(14px, 3.5cqmin)',
+                }}
+              />
+            ) : (
+              <BookOpen
+                style={{
+                  width: 'min(14px, 3.5cqmin)',
+                  height: 'min(14px, 3.5cqmin)',
+                }}
+              />
+            )}
           </div>
           <div className="flex flex-col">
             <span
               className="font-bold text-brand-blue-dark leading-none"
               style={{ fontSize: 'min(14px, 4.5cqmin)' }}
             >
-              Quiz Library
+              {managerTab === 'archive' ? 'Assignment Archive' : 'Quiz Library'}
             </span>
             <span
               className="text-brand-blue-primary/70 font-medium"
               style={{ fontSize: 'min(11px, 3cqmin)' }}
             >
-              {quizzes.length} saved {quizzes.length === 1 ? 'quiz' : 'quizzes'}
+              {managerTab === 'archive'
+                ? `${assignments.length} ${assignments.length === 1 ? 'assignment' : 'assignments'}`
+                : `${quizzes.length} saved ${quizzes.length === 1 ? 'quiz' : 'quizzes'}`}
             </span>
           </div>
         </div>
-        <div
-          className="flex items-center"
-          style={{ gap: 'min(6px, 1.5cqmin)' }}
-        >
-          <button
-            onClick={onImport}
-            className="flex items-center bg-white hover:bg-brand-blue-lighter/40 text-brand-blue-primary font-bold rounded-xl transition-all shadow-sm active:scale-95 border border-brand-blue-primary/20"
-            style={{
-              gap: 'min(6px, 1.5cqmin)',
-              padding: 'min(6px, 1.5cqmin) min(12px, 3cqmin)',
-              fontSize: 'min(12px, 3.5cqmin)',
-            }}
-            title="Import from CSV or Google Sheet"
+        {managerTab === 'library' && (
+          <div
+            className="flex items-center"
+            style={{ gap: 'min(6px, 1.5cqmin)' }}
           >
-            <FileUp
+            <button
+              onClick={onImport}
+              className="flex items-center bg-white hover:bg-brand-blue-lighter/40 text-brand-blue-primary font-bold rounded-xl transition-all shadow-sm active:scale-95 border border-brand-blue-primary/20"
               style={{
-                width: 'min(14px, 4cqmin)',
-                height: 'min(14px, 4cqmin)',
+                gap: 'min(6px, 1.5cqmin)',
+                padding: 'min(6px, 1.5cqmin) min(12px, 3cqmin)',
+                fontSize: 'min(12px, 3.5cqmin)',
               }}
-            />
-            Import
-          </button>
-          <button
-            onClick={onNew}
-            className="flex items-center bg-brand-blue-primary hover:bg-brand-blue-dark text-white font-bold rounded-xl transition-all shadow-sm active:scale-95"
-            style={{
-              gap: 'min(6px, 1.5cqmin)',
-              padding: 'min(6px, 1.5cqmin) min(12px, 3cqmin)',
-              fontSize: 'min(12px, 3.5cqmin)',
-            }}
-          >
-            <Plus
+              title="Import from CSV or Google Sheet"
+            >
+              <FileUp
+                style={{
+                  width: 'min(14px, 4cqmin)',
+                  height: 'min(14px, 4cqmin)',
+                }}
+              />
+              Import
+            </button>
+            <button
+              onClick={onNew}
+              className="flex items-center bg-brand-blue-primary hover:bg-brand-blue-dark text-white font-bold rounded-xl transition-all shadow-sm active:scale-95"
               style={{
-                width: 'min(14px, 4cqmin)',
-                height: 'min(14px, 4cqmin)',
+                gap: 'min(6px, 1.5cqmin)',
+                padding: 'min(6px, 1.5cqmin) min(12px, 3cqmin)',
+                fontSize: 'min(12px, 3.5cqmin)',
               }}
-            />
-            New Quiz
-          </button>
-        </div>
+            >
+              <Plus
+                style={{
+                  width: 'min(14px, 4cqmin)',
+                  height: 'min(14px, 4cqmin)',
+                }}
+              />
+              New Quiz
+            </button>
+          </div>
+        )}
       </div>
 
-      {/* Active Session Banner */}
-      {hasActiveSession && (
-        <div
-          className="bg-emerald-50 border-y border-emerald-200 flex items-center justify-between"
-          style={{
-            padding: 'min(8px, 2cqmin) min(16px, 4cqmin)',
-            gap: 'min(12px, 3cqmin)',
-          }}
-        >
-          <div className="flex items-center gap-2">
-            <Zap className="text-emerald-600 w-4 h-4 animate-pulse" />
-            <span className="text-emerald-800 font-bold text-xs uppercase tracking-tight">
-              Session in Progress
-            </span>
-          </div>
+      {/* Tab switcher — Library / Archive */}
+      <div
+        className="flex border-b border-brand-blue-primary/10 bg-brand-blue-lighter/10"
+        style={{
+          padding: 'min(6px, 1.5cqmin) min(12px, 3cqmin) 0',
+          gap: 'min(4px, 1cqmin)',
+        }}
+      >
+        {(['library', 'archive'] as const).map((tab) => (
           <button
-            onClick={onResume}
-            className="bg-emerald-600 hover:bg-emerald-700 text-white font-black rounded-lg transition-all active:scale-95 shadow-sm"
+            key={tab}
+            onClick={() => onTabChange?.(tab)}
+            className={`font-black uppercase tracking-widest rounded-t-xl transition-all flex items-center ${
+              managerTab === tab
+                ? 'bg-white text-brand-blue-primary border-x border-t border-brand-blue-primary/10'
+                : 'text-brand-blue-primary/40 hover:text-brand-blue-primary hover:bg-brand-blue-lighter/30'
+            }`}
             style={{
-              padding: 'min(4px, 1cqmin) min(12px, 3cqmin)',
-              fontSize: 'min(11px, 3cqmin)',
+              gap: 'min(6px, 1.5cqmin)',
+              padding: 'min(8px, 2cqmin) min(14px, 3.5cqmin)',
+              fontSize: 'min(10px, 3cqmin)',
             }}
           >
-            RESUME MONITOR
+            {tab === 'library' ? (
+              <BookOpen
+                style={{
+                  width: 'min(12px, 3cqmin)',
+                  height: 'min(12px, 3cqmin)',
+                }}
+              />
+            ) : (
+              <ArchiveIcon
+                style={{
+                  width: 'min(12px, 3cqmin)',
+                  height: 'min(12px, 3cqmin)',
+                }}
+              />
+            )}
+            {tab}
           </button>
-        </div>
+        ))}
+      </div>
+
+      {/* Archive tab content */}
+      {managerTab === 'archive' && (
+        <QuizAssignmentArchive
+          assignments={assignments}
+          loading={assignmentsLoading}
+          onCopyUrl={onArchiveCopyUrl ?? noop}
+          onMonitor={onArchiveMonitor ?? noop}
+          onResults={onArchiveResults ?? noop}
+          onEditSettings={onArchiveEditSettings ?? noop}
+          onShare={onArchiveShare ?? noop}
+          onPauseResume={onArchivePauseResume ?? noop}
+          onDeactivate={onArchiveDeactivate ?? noop}
+          onDelete={onArchiveDelete ?? noop}
+        />
       )}
 
-      {/* Error */}
-      {error && (
+      {/* Error (library tab only) */}
+      {managerTab === 'library' && error && (
         <div
           className="flex items-center bg-brand-red-lighter/40 border border-brand-red-primary/30 rounded-xl text-brand-red-dark"
           style={{
@@ -581,263 +650,224 @@ export const QuizManager: React.FC<QuizManagerProps> = ({
         </div>
       )}
 
-      {/* Quiz list */}
-      <div
-        className="flex-1 overflow-y-auto custom-scrollbar"
-        style={{ padding: 'min(16px, 4cqmin)' }}
-      >
-        {quizzes.length === 0 ? (
-          <div
-            className="flex flex-col items-center justify-center h-full text-brand-blue-primary/40 py-12"
-            style={{ gap: 'min(16px, 4cqmin)' }}
-          >
+      {/* Quiz list (library tab only) */}
+      {managerTab === 'library' && (
+        <div
+          className="flex-1 overflow-y-auto custom-scrollbar"
+          style={{ padding: 'min(16px, 4cqmin)' }}
+        >
+          {quizzes.length === 0 ? (
             <div
-              className="bg-brand-blue-lighter/50 p-6 rounded-full border-2 border-dashed border-brand-blue-primary/20"
-              style={{ padding: 'min(24px, 6cqmin)' }}
+              className="flex flex-col items-center justify-center h-full text-brand-blue-primary/40 py-12"
+              style={{ gap: 'min(16px, 4cqmin)' }}
             >
-              <FileUp
-                style={{
-                  width: 'min(48px, 12cqmin)',
-                  height: 'min(48px, 12cqmin)',
-                }}
-              />
-            </div>
-            <div className="text-center">
-              <p
-                className="font-bold text-brand-blue-primary"
-                style={{ fontSize: 'min(15px, 5cqmin)' }}
-              >
-                No quizzes yet
-              </p>
-              <p
-                className="text-brand-blue-primary/60 font-medium"
-                style={{
-                  fontSize: 'min(12px, 3.5cqmin)',
-                  marginTop: 'min(4px, 1cqmin)',
-                  maxWidth: '180px',
-                }}
-              >
-                Import a CSV or Google Sheet to build your library
-              </p>
-            </div>
-            <button
-              onClick={onImport}
-              className="flex items-center bg-brand-blue-primary hover:bg-brand-blue-dark text-white font-bold rounded-2xl transition-all shadow-md active:scale-95"
-              style={{
-                gap: 'min(8px, 2cqmin)',
-                padding: 'min(10px, 2.5cqmin) min(20px, 5cqmin)',
-                fontSize: 'min(14px, 4.5cqmin)',
-              }}
-            >
-              <Plus
-                style={{
-                  width: 'min(18px, 4.5cqmin)',
-                  height: 'min(18px, 4.5cqmin)',
-                }}
-              />
-              Start Importing
-            </button>
-          </div>
-        ) : (
-          <div className="space-y-3">
-            {quizzes.map((quiz) => (
               <div
-                key={quiz.id}
-                className="bg-white border border-brand-blue-primary/10 rounded-2xl shadow-sm hover:shadow-md hover:border-brand-blue-primary/20 transition-all group overflow-hidden"
-                style={{ padding: 'min(12px, 3cqmin)' }}
+                className="bg-brand-blue-lighter/50 p-6 rounded-full border-2 border-dashed border-brand-blue-primary/20"
+                style={{ padding: 'min(24px, 6cqmin)' }}
               >
-                {/* Quiz info */}
-                <div
-                  className="flex items-start justify-between"
+                <FileUp
                   style={{
-                    gap: 'min(12px, 3cqmin)',
-                    marginBottom: 'min(12px, 3cqmin)',
+                    width: 'min(48px, 12cqmin)',
+                    height: 'min(48px, 12cqmin)',
+                  }}
+                />
+              </div>
+              <div className="text-center">
+                <p
+                  className="font-bold text-brand-blue-primary"
+                  style={{ fontSize: 'min(15px, 5cqmin)' }}
+                >
+                  No quizzes yet
+                </p>
+                <p
+                  className="text-brand-blue-primary/60 font-medium"
+                  style={{
+                    fontSize: 'min(12px, 3.5cqmin)',
+                    marginTop: 'min(4px, 1cqmin)',
+                    maxWidth: '180px',
                   }}
                 >
-                  <div className="min-w-0">
-                    <h3
-                      className="font-bold text-brand-blue-dark truncate"
-                      style={{ fontSize: 'min(15px, 5cqmin)' }}
-                    >
-                      {quiz.title}
-                    </h3>
-                    <div className="flex items-center gap-2 mt-0.5">
-                      <span
-                        className="bg-brand-blue-lighter text-brand-blue-primary font-bold rounded-md"
-                        style={{
-                          fontSize: 'min(10px, 3cqmin)',
-                          padding: 'min(1px, 0.2cqmin) min(6px, 1.5cqmin)',
-                          textTransform: 'uppercase',
-                        }}
-                      >
-                        {quiz.questionCount} Qs
-                      </span>
-                      <span
-                        className="text-brand-gray-primary font-medium"
-                        style={{ fontSize: 'min(11px, 3.5cqmin)' }}
-                      >
-                        Updated{' '}
-                        {new Date(
-                          quiz.updatedAt || quiz.createdAt
-                        ).toLocaleDateString()}
-                      </span>
-                    </div>
-                  </div>
-                </div>
-
-                {/* Action buttons */}
-                {confirmDelete === quiz.id ? (
+                  Import a CSV or Google Sheet to build your library
+                </p>
+              </div>
+              <button
+                onClick={onImport}
+                className="flex items-center bg-brand-blue-primary hover:bg-brand-blue-dark text-white font-bold rounded-2xl transition-all shadow-md active:scale-95"
+                style={{
+                  gap: 'min(8px, 2cqmin)',
+                  padding: 'min(10px, 2.5cqmin) min(20px, 5cqmin)',
+                  fontSize: 'min(14px, 4.5cqmin)',
+                }}
+              >
+                <Plus
+                  style={{
+                    width: 'min(18px, 4.5cqmin)',
+                    height: 'min(18px, 4.5cqmin)',
+                  }}
+                />
+                Start Importing
+              </button>
+            </div>
+          ) : (
+            <div className="space-y-3">
+              {quizzes.map((quiz) => (
+                <div
+                  key={quiz.id}
+                  className="bg-white border border-brand-blue-primary/10 rounded-2xl shadow-sm hover:shadow-md hover:border-brand-blue-primary/20 transition-all group overflow-hidden"
+                  style={{ padding: 'min(12px, 3cqmin)' }}
+                >
+                  {/* Quiz info */}
                   <div
-                    className="flex items-center justify-end bg-brand-red-lighter/30 rounded-xl"
+                    className="flex items-start justify-between"
                     style={{
-                      gap: 'min(8px, 2cqmin)',
-                      padding: 'min(8px, 2cqmin)',
+                      gap: 'min(12px, 3cqmin)',
+                      marginBottom: 'min(12px, 3cqmin)',
                     }}
                   >
-                    <span
-                      className="text-brand-red-dark font-bold"
-                      style={{ fontSize: 'min(12px, 3.5cqmin)' }}
-                    >
-                      Delete?
-                    </span>
-                    <button
-                      onClick={() => {
-                        setConfirmDelete(null);
-                        onDelete(quiz);
-                      }}
-                      className="bg-brand-red-primary hover:bg-brand-red-dark text-white font-bold rounded-lg transition-colors shadow-sm"
-                      style={{
-                        padding: 'min(6px, 1.5cqmin) min(12px, 3cqmin)',
-                        fontSize: 'min(12px, 3.5cqmin)',
-                      }}
-                    >
-                      Confirm
-                    </button>
-                    <button
-                      onClick={() => setConfirmDelete(null)}
-                      className="bg-brand-gray-light hover:bg-brand-gray-primary text-white font-bold rounded-lg transition-colors"
-                      style={{
-                        padding: 'min(6px, 1.5cqmin) min(12px, 3cqmin)',
-                        fontSize: 'min(12px, 3.5cqmin)',
-                      }}
-                    >
-                      Back
-                    </button>
+                    <div className="min-w-0">
+                      <h3
+                        className="font-bold text-brand-blue-dark truncate"
+                        style={{ fontSize: 'min(15px, 5cqmin)' }}
+                      >
+                        {quiz.title}
+                      </h3>
+                      <div className="flex items-center gap-2 mt-0.5">
+                        <span
+                          className="bg-brand-blue-lighter text-brand-blue-primary font-bold rounded-md"
+                          style={{
+                            fontSize: 'min(10px, 3cqmin)',
+                            padding: 'min(1px, 0.2cqmin) min(6px, 1.5cqmin)',
+                            textTransform: 'uppercase',
+                          }}
+                        >
+                          {quiz.questionCount} Qs
+                        </span>
+                        <span
+                          className="text-brand-gray-primary font-medium"
+                          style={{ fontSize: 'min(11px, 3.5cqmin)' }}
+                        >
+                          Updated{' '}
+                          {new Date(
+                            quiz.updatedAt || quiz.createdAt
+                          ).toLocaleDateString()}
+                        </span>
+                      </div>
+                    </div>
                   </div>
-                ) : (
-                  <div
-                    className="flex items-center flex-wrap"
-                    style={{ gap: 'min(8px, 2cqmin)' }}
-                  >
-                    <ActionButton
-                      icon={
-                        <Eye
-                          style={{
-                            width: 'min(14px, 4cqmin)',
-                            height: 'min(14px, 4cqmin)',
-                          }}
-                        />
-                      }
-                      label="Preview"
-                      onClick={() => onPreview(quiz)}
-                      variant="ghost"
-                    />
-                    <ActionButton
-                      icon={
-                        <Edit2
-                          style={{
-                            width: 'min(14px, 4cqmin)',
-                            height: 'min(14px, 4cqmin)',
-                          }}
-                        />
-                      }
-                      label="Edit"
-                      onClick={() => onEdit(quiz)}
-                      variant="ghost"
-                    />
-                    <ActionButton
-                      icon={
-                        <BarChart3
-                          style={{
-                            width: 'min(14px, 4cqmin)',
-                            height: 'min(14px, 4cqmin)',
-                          }}
-                        />
-                      }
-                      label="Stats"
-                      onClick={() => onResults(quiz)}
-                      variant="ghost"
-                    />
-                    <ActionButton
-                      icon={
-                        <Link2
-                          style={{
-                            width: 'min(14px, 4cqmin)',
-                            height: 'min(14px, 4cqmin)',
-                          }}
-                        />
-                      }
-                      label="Share"
-                      onClick={() => void onShare(quiz)}
-                      variant="ghost"
-                    />
-                    <ActionButton
-                      icon={
-                        <Trash2
-                          style={{
-                            width: 'min(14px, 4cqmin)',
-                            height: 'min(14px, 4cqmin)',
-                          }}
-                        />
-                      }
-                      label=""
-                      onClick={() => setConfirmDelete(quiz.id)}
-                      variant="danger"
-                    />
-                    <div className="ml-auto flex items-center gap-2">
-                      {hasActiveSession && quiz.id === activeQuizId ? (
-                        <>
-                          <button
-                            onClick={onEndSession}
-                            className="flex items-center bg-brand-red-primary hover:bg-brand-red-dark text-white font-black rounded-xl shadow-md transition-all active:scale-95 group/btn"
+
+                  {/* Action buttons */}
+                  {confirmDelete === quiz.id ? (
+                    <div
+                      className="flex items-center justify-end bg-brand-red-lighter/30 rounded-xl"
+                      style={{
+                        gap: 'min(8px, 2cqmin)',
+                        padding: 'min(8px, 2cqmin)',
+                      }}
+                    >
+                      <span
+                        className="text-brand-red-dark font-bold"
+                        style={{ fontSize: 'min(12px, 3.5cqmin)' }}
+                      >
+                        Delete?
+                      </span>
+                      <button
+                        onClick={() => {
+                          setConfirmDelete(null);
+                          onDelete(quiz);
+                        }}
+                        className="bg-brand-red-primary hover:bg-brand-red-dark text-white font-bold rounded-lg transition-colors shadow-sm"
+                        style={{
+                          padding: 'min(6px, 1.5cqmin) min(12px, 3cqmin)',
+                          fontSize: 'min(12px, 3.5cqmin)',
+                        }}
+                      >
+                        Confirm
+                      </button>
+                      <button
+                        onClick={() => setConfirmDelete(null)}
+                        className="bg-brand-gray-light hover:bg-brand-gray-primary text-white font-bold rounded-lg transition-colors"
+                        style={{
+                          padding: 'min(6px, 1.5cqmin) min(12px, 3cqmin)',
+                          fontSize: 'min(12px, 3.5cqmin)',
+                        }}
+                      >
+                        Back
+                      </button>
+                    </div>
+                  ) : (
+                    <div
+                      className="flex items-center flex-wrap"
+                      style={{ gap: 'min(8px, 2cqmin)' }}
+                    >
+                      <ActionButton
+                        icon={
+                          <Eye
                             style={{
-                              gap: 'min(6px, 1.5cqmin)',
-                              padding: 'min(8px, 2cqmin) min(14px, 3.5cqmin)',
-                              fontSize: 'min(11px, 3.5cqmin)',
+                              width: 'min(14px, 4cqmin)',
+                              height: 'min(14px, 4cqmin)',
                             }}
-                          >
-                            <X
-                              style={{
-                                width: 'min(14px, 4cqmin)',
-                                height: 'min(14px, 4cqmin)',
-                              }}
-                            />
-                            END
-                          </button>
-                          <button
-                            onClick={onResume}
-                            className="flex items-center bg-emerald-600 hover:bg-emerald-700 text-white font-black rounded-xl shadow-md transition-all active:scale-95 group/btn"
+                          />
+                        }
+                        label="Preview"
+                        onClick={() => onPreview(quiz)}
+                        variant="ghost"
+                      />
+                      <ActionButton
+                        icon={
+                          <Edit2
                             style={{
-                              gap: 'min(6px, 1.5cqmin)',
-                              padding: 'min(8px, 2cqmin) min(14px, 3.5cqmin)',
-                              fontSize: 'min(11px, 3.5cqmin)',
+                              width: 'min(14px, 4cqmin)',
+                              height: 'min(14px, 4cqmin)',
                             }}
-                          >
-                            <Zap
-                              className="animate-pulse"
-                              style={{
-                                width: 'min(14px, 4cqmin)',
-                                height: 'min(14px, 4cqmin)',
-                              }}
-                            />
-                            RESUME
-                          </button>
-                        </>
-                      ) : (
+                          />
+                        }
+                        label="Edit"
+                        onClick={() => onEdit(quiz)}
+                        variant="ghost"
+                      />
+                      <ActionButton
+                        icon={
+                          <BarChart3
+                            style={{
+                              width: 'min(14px, 4cqmin)',
+                              height: 'min(14px, 4cqmin)',
+                            }}
+                          />
+                        }
+                        label="Stats"
+                        onClick={() => onResults(quiz)}
+                        variant="ghost"
+                      />
+                      <ActionButton
+                        icon={
+                          <Link2
+                            style={{
+                              width: 'min(14px, 4cqmin)',
+                              height: 'min(14px, 4cqmin)',
+                            }}
+                          />
+                        }
+                        label="Share"
+                        onClick={() => void onShare(quiz)}
+                        variant="ghost"
+                      />
+                      <ActionButton
+                        icon={
+                          <Trash2
+                            style={{
+                              width: 'min(14px, 4cqmin)',
+                              height: 'min(14px, 4cqmin)',
+                            }}
+                          />
+                        }
+                        label=""
+                        onClick={() => setConfirmDelete(quiz.id)}
+                        variant="danger"
+                      />
+                      <div className="ml-auto flex items-center gap-2">
                         <button
                           onClick={() => setSelectedForLive(quiz)}
-                          disabled={hasActiveSession}
-                          className="flex items-center bg-emerald-600 hover:bg-emerald-700 disabled:bg-brand-gray-lighter disabled:text-brand-gray-primary text-white font-black rounded-xl shadow-md transition-all active:scale-95 group/btn"
+                          className="flex items-center bg-emerald-600 hover:bg-emerald-700 text-white font-black rounded-xl shadow-md transition-all active:scale-95 group/btn"
                           style={{
                             gap: 'min(6px, 1.5cqmin)',
                             padding: 'min(8px, 2cqmin) min(14px, 3.5cqmin)',
@@ -853,15 +883,15 @@ export const QuizManager: React.FC<QuizManagerProps> = ({
                           />
                           ASSIGN
                         </button>
-                      )}
+                      </div>
                     </div>
-                  </div>
-                )}
-              </div>
-            ))}
-          </div>
-        )}
-      </div>
+                  )}
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
     </div>
   );
 };

--- a/config/widgetDefaults.ts
+++ b/config/widgetDefaults.ts
@@ -249,8 +249,10 @@ export const WIDGET_DEFAULTS: Record<WidgetType, Partial<WidgetData>> = {
     h: 560,
     config: {
       view: 'manager',
+      managerTab: 'library',
       selectedQuizId: null,
       selectedQuizTitle: null,
+      activeAssignmentId: null,
       activeLiveSessionCode: null,
       resultsSessionId: null,
       plcMode: false,

--- a/context/DashboardContext.tsx
+++ b/context/DashboardContext.tsx
@@ -111,8 +111,9 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
   const [pendingShareId, setPendingShareId] = useState<string | null>(() => {
     if (typeof window === 'undefined') return null;
     const path = window.location.pathname;
-    // Skip quiz share URLs — those are handled separately
+    // Skip quiz and assignment share URLs — those are handled separately
     if (path.startsWith('/share/quiz/')) return null;
+    if (path.startsWith('/share/assignment/')) return null;
     if (path.startsWith('/share/')) {
       return path.split('/share/')[1] || null;
     }
@@ -130,6 +131,17 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
     }
   );
 
+  const [pendingAssignmentShareId, setPendingAssignmentShareId] = useState<
+    string | null
+  >(() => {
+    if (typeof window === 'undefined') return null;
+    const path = window.location.pathname;
+    if (path.startsWith('/share/assignment/')) {
+      return path.split('/share/assignment/')[1] || null;
+    }
+    return null;
+  });
+
   const clearPendingShare = useCallback(() => {
     setPendingShareId(null);
     window.history.replaceState(null, '', '/');
@@ -137,6 +149,11 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
 
   const clearPendingQuizShare = useCallback(() => {
     setPendingQuizShareId(null);
+    window.history.replaceState(null, '', '/');
+  }, []);
+
+  const clearPendingAssignmentShare = useCallback(() => {
+    setPendingAssignmentShareId(null);
     window.history.replaceState(null, '', '/');
   }, []);
 
@@ -3163,6 +3180,10 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
       clearPendingShare,
       pendingQuizShareId,
       clearPendingQuizShare,
+      setPendingQuizShareId,
+      pendingAssignmentShareId,
+      setPendingAssignmentShareId,
+      clearPendingAssignmentShare,
       zoom,
       setZoom,
       annotationActive,
@@ -3248,6 +3269,10 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
       clearPendingShare,
       pendingQuizShareId,
       clearPendingQuizShare,
+      setPendingQuizShareId,
+      pendingAssignmentShareId,
+      setPendingAssignmentShareId,
+      clearPendingAssignmentShare,
       zoom,
       setZoom,
       annotationActive,

--- a/context/DashboardContextValue.ts
+++ b/context/DashboardContextValue.ts
@@ -116,6 +116,10 @@ export interface DashboardContextValue {
   clearPendingShare: () => void;
   pendingQuizShareId: string | null;
   clearPendingQuizShare: () => void;
+  pendingAssignmentShareId: string | null;
+  setPendingAssignmentShareId: (shareId: string | null) => void;
+  clearPendingAssignmentShare: () => void;
+  setPendingQuizShareId: (shareId: string | null) => void;
 
   // Roster system
   rosters: ClassRoster[];

--- a/firestore.rules
+++ b/firestore.rules
@@ -51,8 +51,19 @@ service cloud.firestore {
     }
 
     // Quiz assignments - archive of past/current assignments of a quiz. Per-user.
+    // Harden writes so the user can't spoof the embedded teacherUid / id fields —
+    // those are relied on by ownership checks elsewhere (session rules, shared
+    // assignment author checks). Keep teacherUid and id immutable after create.
     match /users/{userId}/quiz_assignments/{assignmentId} {
-      allow read, write: if request.auth != null && request.auth.uid == userId;
+      allow read, delete: if request.auth != null && request.auth.uid == userId;
+      allow create: if request.auth != null
+                    && request.auth.uid == userId
+                    && request.resource.data.teacherUid == userId
+                    && request.resource.data.id == assignmentId;
+      allow update: if request.auth != null
+                    && request.auth.uid == userId
+                    && request.resource.data.teacherUid == resource.data.teacherUid
+                    && request.resource.data.id == resource.data.id;
     }
 
     // User data collection

--- a/firestore.rules
+++ b/firestore.rules
@@ -50,6 +50,11 @@ service cloud.firestore {
       allow read, write: if request.auth != null && request.auth.uid == userId;
     }
 
+    // Quiz assignments - archive of past/current assignments of a quiz. Per-user.
+    match /users/{userId}/quiz_assignments/{assignmentId} {
+      allow read, write: if request.auth != null && request.auth.uid == userId;
+    }
+
     // User data collection
     match /users/{userId} {
       allow read, write: if request.auth != null && request.auth.uid == userId;
@@ -174,6 +179,17 @@ service cloud.firestore {
         (resource.data.get('originalAuthor', null) == request.auth.uid || isAdmin());
     }
 
+    // Shared quiz assignments - like shared_quizzes but also carries assignment
+    // settings (class label, PLC sheet URL, session toggles) so a receiving
+    // teacher can get a pre-configured, paused assignment when they paste the link.
+    match /shared_assignments/{shareId} {
+      allow get: if request.auth != null;
+      allow create: if request.auth != null &&
+        request.resource.data.originalAuthor == request.auth.uid;
+      allow update, delete: if request.auth != null &&
+        (resource.data.get('originalAuthor', null) == request.auth.uid || isAdmin());
+    }
+
     // Sessions - Teacher owns it, Students can join
     match /sessions/{userId} {
       // Only authenticated users (including anonymous) can read sessions
@@ -201,8 +217,10 @@ service cloud.firestore {
       }
     }
 
-    // Quiz Sessions — Teacher owns it, authenticated students submit responses
-    match /quiz_sessions/{teacherUid} {
+    // Quiz Sessions — keyed by session UUID (was teacherUid). The teacher
+    // owns the document and stores their uid on the `teacherUid` field.
+    // Multiple concurrent sessions per teacher are allowed.
+    match /quiz_sessions/{sessionId} {
       // Students need `list` access to find sessions by join code via a
       // collection-group query (getDocs + where('code', '==',...)).
       // Restricting enumeration fully requires a Cloud Function proxy; for now
@@ -211,19 +229,27 @@ service cloud.firestore {
       // question index updates after joining).
       allow get: if request.auth != null;
       allow list: if request.auth != null;
-      // Only the teacher (session owner) can create/update/delete the session document
-      allow write: if request.auth != null && request.auth.uid == teacherUid;
+      // Only the teacher (session owner) can create/update/delete the session document.
+      // Ownership is carried on the `teacherUid` field (no longer the doc id).
+      allow create: if request.auth != null &&
+        request.resource.data.teacherUid == request.auth.uid;
+      allow update, delete: if request.auth != null &&
+        resource.data.teacherUid == request.auth.uid;
 
       match /responses/{studentUid} {
         // Quiz response records store only a PIN — no student name or email.
         // Students join using anonymous Firebase Auth; their anonymous UID is
         // the document key. This satisfies request.auth != null without PII.
         //
-        // - Teacher can read/write all responses (for monitoring)
-        // - Students (anonymous or signed-in) can read/write their own response
-        // - Admins have full access
+        // Teacher ownership is looked up from the parent session doc because
+        // the sessionId is no longer the teacher's uid. This adds one get()
+        // per response write (~50ms, $0 at class scale).
+        function sessionTeacherUid() {
+          return get(/databases/$(database)/documents/quiz_sessions/$(sessionId)).data.teacherUid;
+        }
+
         allow read: if request.auth != null &&
-          (request.auth.uid == teacherUid ||
+          (request.auth.uid == sessionTeacherUid() ||
            request.auth.uid == studentUid ||
            isAdmin());
         allow create: if request.auth != null &&
@@ -233,7 +259,7 @@ service cloud.firestore {
           request.resource.data.score == null;
         allow update: if request.auth != null && (
           // Teacher and admins can update any field
-          request.auth.uid == teacherUid || isAdmin() ||
+          request.auth.uid == sessionTeacherUid() || isAdmin() ||
           // Students may only update their own response to submit answers.
           // pin and join metadata are immutable; only answers, status,
           // submittedAt, and tabSwitchWarnings may change.
@@ -250,7 +276,7 @@ service cloud.firestore {
             request.resource.data.tabSwitchWarnings >= resource.data.get('tabSwitchWarnings', 0)))
         );
         allow delete: if request.auth != null &&
-          (request.auth.uid == teacherUid || isAdmin());
+          (request.auth.uid == sessionTeacherUid() || isAdmin());
       }
     }
 

--- a/hooks/useQuiz.ts
+++ b/hooks/useQuiz.ts
@@ -20,7 +20,6 @@ import {
 import { db, isAuthBypass } from '../config/firebase';
 import { useAuth } from '../context/useAuth';
 import { useGoogleDrive } from './useGoogleDrive';
-import { useQuizSessionTeacher } from './useQuizSession';
 import { QuizData, QuizMetadata } from '../types';
 import { QuizDriveService } from '../utils/quizDriveService';
 import {
@@ -60,7 +59,6 @@ export interface UseQuizResult {
 export const useQuiz = (userId: string | undefined): UseQuizResult => {
   const { googleAccessToken } = useAuth();
   const { isConnected } = useGoogleDrive();
-  const { session, endQuizSession } = useQuizSessionTeacher(userId);
   const [quizzes, setQuizzes] = useState<QuizMetadata[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -158,10 +156,10 @@ export const useQuiz = (userId: string | undefined): UseQuizResult => {
       if (!userId) throw new Error('Not authenticated');
       const drive = getDriveService();
 
-      // If this quiz is currently active, end the session first
-      if (session && session.quizId === quizId) {
-        await endQuizSession();
-      }
+      // Note: the old session-cascade lived here. With multi-assignment support,
+      // ending a session is no longer tied to deleting a quiz from the library —
+      // the caller (Widget.tsx) is responsible for warning the teacher if any
+      // active assignments reference this quiz.
 
       // Delete from Drive (ignore 404 — file may already be gone)
       await drive.deleteQuizFile(driveFileId).catch((err: unknown) => {
@@ -172,7 +170,7 @@ export const useQuiz = (userId: string | undefined): UseQuizResult => {
       // Delete metadata from Firestore
       await deleteDoc(doc(db, 'users', userId, QUIZZES_COLLECTION, quizId));
     },
-    [userId, getDriveService, session, endQuizSession]
+    [userId, getDriveService]
   );
 
   const importFromSheet = useCallback(

--- a/hooks/useQuizAssignments.ts
+++ b/hooks/useQuizAssignments.ts
@@ -260,11 +260,17 @@ export const useQuizAssignments = (
         doc(db, 'users', userId, QUIZ_ASSIGNMENTS_COLLECTION, assignmentId),
         { status: assignmentStatus, updatedAt: now }
       );
-      const sessionPatch: Partial<QuizSession> = { status: sessionStatus };
+      // When pausing or ending, null out autoProgressAt so any in-flight
+      // auto-advance timer (from useQuizSession) no longer fires and the
+      // session can't silently advance past the intended stopping point.
+      const sessionPatch: Record<string, unknown> = { status: sessionStatus };
+      if (sessionStatus === 'paused' || sessionStatus === 'ended') {
+        sessionPatch.autoProgressAt = null;
+      }
       if (sessionStatus === 'ended') sessionPatch.endedAt = now;
       batch.update(
         doc(db, QUIZ_SESSIONS_COLLECTION, assignmentId),
-        sessionPatch as Record<string, unknown>
+        sessionPatch
       );
       await batch.commit();
     },
@@ -284,11 +290,26 @@ export const useQuizAssignments = (
     UseQuizAssignmentsResult['resumeAssignment']
   >(
     async (assignmentId) => {
-      // Resume into 'active'; teacher-mode sessions that were never started
-      // still function because students look up by code, not by status.
-      await setStatus(assignmentId, 'active', 'active');
+      if (!userId) throw new Error('Not authenticated');
+      // Resume to the correct session status depending on whether gameplay
+      // has begun. For teacher-mode sessions that were imported as paused
+      // (or paused before the teacher advanced to question 1), startedAt is
+      // still null and currentQuestionIndex is -1 — in that case the
+      // students should see the waiting room again, not the active-quiz UI
+      // with no question loaded.
+      const sessionRef = doc(db, QUIZ_SESSIONS_COLLECTION, assignmentId);
+      const snap = await getDoc(sessionRef);
+      const session = snap.data() as QuizSession | undefined;
+      const neverStarted =
+        !!session &&
+        (session.startedAt == null || session.currentQuestionIndex < 0);
+      await setStatus(
+        assignmentId,
+        'active',
+        neverStarted ? 'waiting' : 'active'
+      );
     },
-    [setStatus]
+    [userId, setStatus]
   );
 
   const deactivateAssignment = useCallback<

--- a/hooks/useQuizAssignments.ts
+++ b/hooks/useQuizAssignments.ts
@@ -1,0 +1,441 @@
+/**
+ * useQuizAssignments hook
+ *
+ * Manages the per-teacher archive of quiz assignments. An "assignment" is a
+ * single instance of a quiz being assigned out to students — it pairs a
+ * QuizAssignment document (under /users/{teacherUid}/quiz_assignments/) with
+ * a QuizSession document (under /quiz_sessions/{sessionId}) 1:1.
+ *
+ * Multiple concurrent assignments per teacher are supported. The assignment
+ * can be Active (URL live, accepting submissions), Paused (URL live, no
+ * submissions) or Inactive (URL dead, responses preserved).
+ */
+
+import { useState, useEffect, useCallback } from 'react';
+import {
+  collection,
+  doc,
+  onSnapshot,
+  getDoc,
+  getDocs,
+  updateDoc,
+  addDoc,
+  query,
+  where,
+  orderBy,
+  writeBatch,
+} from 'firebase/firestore';
+import { db } from '../config/firebase';
+import type {
+  QuizAssignment,
+  QuizAssignmentSettings,
+  QuizAssignmentStatus,
+  QuizData,
+  QuizQuestion,
+  QuizSession,
+  SharedQuizAssignment,
+} from '../types';
+import {
+  QUIZ_SESSIONS_COLLECTION,
+  RESPONSES_COLLECTION,
+  toPublicQuestion,
+} from './useQuizSession';
+
+const QUIZ_ASSIGNMENTS_COLLECTION = 'quiz_assignments';
+const SHARED_ASSIGNMENTS_COLLECTION = 'shared_assignments';
+
+/**
+ * Minimal quiz data needed to stand up an assignment. The driveFileId lets the
+ * monitor/results views hydrate the full answer key later.
+ */
+export interface AssignmentQuizRef {
+  id: string;
+  title: string;
+  driveFileId: string;
+  questions: QuizQuestion[];
+}
+
+export interface UseQuizAssignmentsResult {
+  assignments: QuizAssignment[];
+  loading: boolean;
+  error: string | null;
+  /**
+   * Create a new assignment + its matching session doc in one batch.
+   * Returns the new assignment's id (== sessionId) and the allocated join code.
+   */
+  createAssignment: (
+    quiz: AssignmentQuizRef,
+    settings: QuizAssignmentSettings,
+    initialStatus?: QuizAssignmentStatus
+  ) => Promise<{ id: string; code: string }>;
+  /** Set both assignment.status and session.status to 'paused'. */
+  pauseAssignment: (assignmentId: string) => Promise<void>;
+  /** Set both assignment.status and session.status back to 'active'. */
+  resumeAssignment: (assignmentId: string) => Promise<void>;
+  /** Kills the student URL; preserves responses. assignment='inactive', session='ended'. */
+  deactivateAssignment: (assignmentId: string) => Promise<void>;
+  /** Permanently delete assignment + session + all responses. */
+  deleteAssignment: (assignmentId: string) => Promise<void>;
+  /** Update editable settings (className, PLC fields, session toggles). */
+  updateAssignmentSettings: (
+    assignmentId: string,
+    patch: Partial<QuizAssignmentSettings>
+  ) => Promise<void>;
+  /** Publish this assignment as a shareable link. Returns the /share/assignment/{id} URL. */
+  shareAssignment: (
+    assignmentId: string,
+    quizData: QuizData
+  ) => Promise<string>;
+  /**
+   * Import a shared assignment. Delegates quiz copy to the injected saveQuiz
+   * (from useQuiz.ts) and creates a new paused assignment under the importer's
+   * collection. Returns the new assignmentId.
+   */
+  importSharedAssignment: (
+    shareId: string,
+    saveQuiz: (quiz: QuizData) => Promise<{ id: string; driveFileId: string }>
+  ) => Promise<string>;
+}
+
+/** Unique 6-char join code generator with collision check against live sessions. */
+async function allocateJoinCode(): Promise<string> {
+  for (let attempt = 0; attempt < 5; attempt++) {
+    const candidate = Math.random()
+      .toString(36)
+      .substring(2, 8)
+      .toUpperCase()
+      .padEnd(6, '0');
+    const collision = await getDocs(
+      query(
+        collection(db, QUIZ_SESSIONS_COLLECTION),
+        where('code', '==', candidate),
+        where('status', '!=', 'ended')
+      )
+    );
+    if (collision.empty) return candidate;
+  }
+  // Last-resort fallback: we accept a theoretical collision rather than
+  // blocking the teacher from starting a quiz.
+  return Math.random()
+    .toString(36)
+    .substring(2, 8)
+    .toUpperCase()
+    .padEnd(6, '0');
+}
+
+export const useQuizAssignments = (
+  userId: string | undefined
+): UseQuizAssignmentsResult => {
+  const [assignments, setAssignments] = useState<QuizAssignment[]>([]);
+  const [loading, setLoading] = useState<boolean>(!!userId);
+  const [error, setError] = useState<string | null>(null);
+
+  // Adjust state during render when userId transitions away — avoids the
+  // "set-state-in-effect" anti-pattern while still clearing stale data when
+  // the user signs out.
+  const [prevUserId, setPrevUserId] = useState(userId);
+  if (userId !== prevUserId) {
+    setPrevUserId(userId);
+    if (!userId) {
+      setAssignments([]);
+      setLoading(false);
+      setError(null);
+    } else {
+      setLoading(true);
+    }
+  }
+
+  useEffect(() => {
+    if (!userId) return;
+
+    const q = query(
+      collection(db, 'users', userId, QUIZ_ASSIGNMENTS_COLLECTION),
+      orderBy('createdAt', 'desc')
+    );
+    const unsub = onSnapshot(
+      q,
+      (snap) => {
+        setAssignments(snap.docs.map((d) => d.data() as QuizAssignment));
+        setLoading(false);
+      },
+      (err) => {
+        console.error('[useQuizAssignments] Firestore error:', err);
+        setError('Failed to load assignments');
+        setLoading(false);
+      }
+    );
+    return unsub;
+  }, [userId]);
+
+  const createAssignment = useCallback<
+    UseQuizAssignmentsResult['createAssignment']
+  >(
+    async (quiz, settings, initialStatus = 'active') => {
+      if (!userId) throw new Error('Not authenticated');
+
+      const assignmentId = crypto.randomUUID();
+      const code = await allocateJoinCode();
+      const now = Date.now();
+
+      const assignment: QuizAssignment = {
+        id: assignmentId,
+        quizId: quiz.id,
+        quizTitle: quiz.title,
+        quizDriveFileId: quiz.driveFileId,
+        teacherUid: userId,
+        code,
+        status: initialStatus,
+        createdAt: now,
+        updatedAt: now,
+        className: settings.className,
+        sessionMode: settings.sessionMode,
+        sessionOptions: settings.sessionOptions,
+        plcMode: settings.plcMode,
+        plcSheetUrl: settings.plcSheetUrl,
+        teacherName: settings.teacherName,
+        periodName: settings.periodName,
+        plcMemberEmails: settings.plcMemberEmails,
+      };
+
+      const mode = settings.sessionMode;
+      const opts = settings.sessionOptions;
+      const sessionStatus: QuizSession['status'] =
+        initialStatus === 'paused'
+          ? 'paused'
+          : initialStatus === 'inactive'
+            ? 'ended'
+            : 'waiting';
+
+      const session: QuizSession = {
+        id: assignmentId,
+        assignmentId,
+        quizId: quiz.id,
+        quizTitle: quiz.title,
+        teacherUid: userId,
+        status: sessionStatus,
+        sessionMode: mode,
+        currentQuestionIndex: mode === 'student' ? 0 : -1,
+        startedAt: mode === 'student' ? now : null,
+        endedAt: null,
+        code,
+        totalQuestions: quiz.questions.length,
+        publicQuestions: quiz.questions.map(toPublicQuestion),
+        // Phase 1 toggles
+        tabWarningsEnabled: opts.tabWarningsEnabled ?? true,
+        showResultToStudent: opts.showResultToStudent ?? false,
+        showCorrectAnswerToStudent: opts.showCorrectAnswerToStudent ?? false,
+        showCorrectOnBoard: opts.showCorrectOnBoard ?? false,
+        revealedAnswers: {},
+        // Phase 2 gamification
+        speedBonusEnabled: opts.speedBonusEnabled ?? false,
+        streakBonusEnabled: opts.streakBonusEnabled ?? false,
+        showPodiumBetweenQuestions: opts.showPodiumBetweenQuestions ?? true,
+        soundEffectsEnabled: opts.soundEffectsEnabled ?? false,
+        questionPhase: 'answering',
+      };
+
+      const batch = writeBatch(db);
+      batch.set(
+        doc(db, 'users', userId, QUIZ_ASSIGNMENTS_COLLECTION, assignmentId),
+        assignment
+      );
+      batch.set(doc(db, QUIZ_SESSIONS_COLLECTION, assignmentId), session);
+      await batch.commit();
+
+      return { id: assignmentId, code };
+    },
+    [userId]
+  );
+
+  const setStatus = useCallback(
+    async (
+      assignmentId: string,
+      assignmentStatus: QuizAssignmentStatus,
+      sessionStatus: QuizSession['status']
+    ): Promise<void> => {
+      if (!userId) throw new Error('Not authenticated');
+      const now = Date.now();
+      const batch = writeBatch(db);
+      batch.update(
+        doc(db, 'users', userId, QUIZ_ASSIGNMENTS_COLLECTION, assignmentId),
+        { status: assignmentStatus, updatedAt: now }
+      );
+      const sessionPatch: Partial<QuizSession> = { status: sessionStatus };
+      if (sessionStatus === 'ended') sessionPatch.endedAt = now;
+      batch.update(
+        doc(db, QUIZ_SESSIONS_COLLECTION, assignmentId),
+        sessionPatch as Record<string, unknown>
+      );
+      await batch.commit();
+    },
+    [userId]
+  );
+
+  const pauseAssignment = useCallback<
+    UseQuizAssignmentsResult['pauseAssignment']
+  >(
+    async (assignmentId) => {
+      await setStatus(assignmentId, 'paused', 'paused');
+    },
+    [setStatus]
+  );
+
+  const resumeAssignment = useCallback<
+    UseQuizAssignmentsResult['resumeAssignment']
+  >(
+    async (assignmentId) => {
+      // Resume into 'active'; teacher-mode sessions that were never started
+      // still function because students look up by code, not by status.
+      await setStatus(assignmentId, 'active', 'active');
+    },
+    [setStatus]
+  );
+
+  const deactivateAssignment = useCallback<
+    UseQuizAssignmentsResult['deactivateAssignment']
+  >(
+    async (assignmentId) => {
+      await setStatus(assignmentId, 'inactive', 'ended');
+    },
+    [setStatus]
+  );
+
+  const deleteAssignment = useCallback<
+    UseQuizAssignmentsResult['deleteAssignment']
+  >(
+    async (assignmentId) => {
+      if (!userId) throw new Error('Not authenticated');
+
+      // Delete all response documents first (batched)
+      const responsesSnap = await getDocs(
+        collection(
+          db,
+          QUIZ_SESSIONS_COLLECTION,
+          assignmentId,
+          RESPONSES_COLLECTION
+        )
+      );
+      const BATCH_LIMIT = 500;
+      for (let i = 0; i < responsesSnap.docs.length; i += BATCH_LIMIT) {
+        const batch = writeBatch(db);
+        responsesSnap.docs
+          .slice(i, i + BATCH_LIMIT)
+          .forEach((d) => batch.delete(d.ref));
+        await batch.commit();
+      }
+
+      // Delete the session doc and the assignment doc in one batch
+      const batch = writeBatch(db);
+      batch.delete(doc(db, QUIZ_SESSIONS_COLLECTION, assignmentId));
+      batch.delete(
+        doc(db, 'users', userId, QUIZ_ASSIGNMENTS_COLLECTION, assignmentId)
+      );
+      await batch.commit();
+    },
+    [userId]
+  );
+
+  const updateAssignmentSettings = useCallback<
+    UseQuizAssignmentsResult['updateAssignmentSettings']
+  >(
+    async (assignmentId, patch) => {
+      if (!userId) throw new Error('Not authenticated');
+      await updateDoc(
+        doc(db, 'users', userId, QUIZ_ASSIGNMENTS_COLLECTION, assignmentId),
+        { ...patch, updatedAt: Date.now() } as Record<string, unknown>
+      );
+    },
+    [userId]
+  );
+
+  const shareAssignment = useCallback<
+    UseQuizAssignmentsResult['shareAssignment']
+  >(
+    async (assignmentId, quizData) => {
+      if (!userId) throw new Error('Not authenticated');
+      const snap = await getDoc(
+        doc(db, 'users', userId, QUIZ_ASSIGNMENTS_COLLECTION, assignmentId)
+      );
+      if (!snap.exists()) throw new Error('Assignment not found');
+      const assignment = snap.data() as QuizAssignment;
+
+      const payload: Omit<SharedQuizAssignment, 'id'> = {
+        title: quizData.title,
+        questions: quizData.questions,
+        createdAt: quizData.createdAt,
+        updatedAt: quizData.updatedAt,
+        assignmentSettings: {
+          className: assignment.className,
+          sessionMode: assignment.sessionMode,
+          sessionOptions: assignment.sessionOptions,
+          plcMode: assignment.plcMode,
+          plcSheetUrl: assignment.plcSheetUrl,
+          teacherName: assignment.teacherName,
+          periodName: assignment.periodName,
+          plcMemberEmails: assignment.plcMemberEmails,
+        },
+        originalAuthor: userId,
+        sharedAt: Date.now(),
+      };
+      const ref = await addDoc(
+        collection(db, SHARED_ASSIGNMENTS_COLLECTION),
+        payload
+      );
+      return `${window.location.origin}/share/assignment/${ref.id}`;
+    },
+    [userId]
+  );
+
+  const importSharedAssignment = useCallback<
+    UseQuizAssignmentsResult['importSharedAssignment']
+  >(
+    async (shareId, saveQuiz) => {
+      if (!userId) throw new Error('Not authenticated');
+
+      const snap = await getDoc(
+        doc(db, SHARED_ASSIGNMENTS_COLLECTION, shareId)
+      );
+      if (!snap.exists()) throw new Error('Shared assignment not found');
+      const shared = snap.data() as SharedQuizAssignment;
+
+      // 1. Copy the quiz into the importer's library.
+      const now = Date.now();
+      const newQuiz: QuizData = {
+        id: crypto.randomUUID(),
+        title: shared.title,
+        questions: shared.questions,
+        createdAt: now,
+        updatedAt: now,
+      };
+      const savedMeta = await saveQuiz(newQuiz);
+
+      // 2. Create a Paused assignment with the shared settings.
+      const created = await createAssignment(
+        {
+          id: savedMeta.id,
+          title: newQuiz.title,
+          driveFileId: savedMeta.driveFileId,
+          questions: newQuiz.questions,
+        },
+        shared.assignmentSettings,
+        'paused'
+      );
+      return created.id;
+    },
+    [userId, createAssignment]
+  );
+
+  return {
+    assignments,
+    loading,
+    error,
+    createAssignment,
+    pauseAssignment,
+    resumeAssignment,
+    deactivateAssignment,
+    deleteAssignment,
+    updateAssignmentSettings,
+    shareAssignment,
+    importSharedAssignment,
+  };
+};

--- a/hooks/useQuizSession.ts
+++ b/hooks/useQuizSession.ts
@@ -34,15 +34,18 @@ import { signInAnonymously } from 'firebase/auth';
 import {
   QuizSession,
   QuizSessionStatus,
-  QuizSessionMode,
   QuizResponse,
   QuizResponseAnswer,
   QuizQuestion,
   QuizPublicQuestion,
 } from '../types';
 
-const QUIZ_SESSIONS_COLLECTION = 'quiz_sessions';
-const RESPONSES_COLLECTION = 'responses';
+// Re-export for backward compatibility with callers that imported
+// QuizSessionOptions from this module before it was moved into types.ts.
+export type { QuizSessionOptions } from '../types';
+
+export const QUIZ_SESSIONS_COLLECTION = 'quiz_sessions';
+export const RESPONSES_COLLECTION = 'responses';
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -61,7 +64,7 @@ function fisherYatesShuffle<T>(arr: T[]): T[] {
  * QuizPublicQuestion (without correctAnswer). Answer choices are pre-shuffled
  * so students can render the UI without ever seeing the answer key.
  */
-function toPublicQuestion(q: QuizQuestion): QuizPublicQuestion {
+export function toPublicQuestion(q: QuizQuestion): QuizPublicQuestion {
   const base: QuizPublicQuestion = {
     id: q.id,
     type: q.type,
@@ -118,32 +121,17 @@ export function gradeAnswer(
 
 // ─── Teacher hook ─────────────────────────────────────────────────────────────
 
-/** Options passed from the assignment modal to configure session toggles. */
-export interface QuizSessionOptions {
-  tabWarningsEnabled?: boolean;
-  showResultToStudent?: boolean;
-  showCorrectAnswerToStudent?: boolean;
-  showCorrectOnBoard?: boolean;
-  speedBonusEnabled?: boolean;
-  streakBonusEnabled?: boolean;
-  showPodiumBetweenQuestions?: boolean;
-  soundEffectsEnabled?: boolean;
-}
-
 export interface UseQuizSessionTeacherResult {
   session: QuizSession | null;
   responses: QuizResponse[];
   loading: boolean;
-  startQuizSession: (
-    quiz: {
-      id: string;
-      title: string;
-      questions: QuizQuestion[];
-    },
-    mode?: QuizSessionMode,
-    options?: QuizSessionOptions
-  ) => Promise<string>;
   advanceQuestion: () => Promise<void>;
+  /**
+   * Transitions the session to `ended` state and finalizes any in-flight
+   * student responses. The underlying assignment document is NOT touched — use
+   * `useQuizAssignments.deactivateAssignment(sessionId)` if you also want the
+   * assignment's lifecycle state flipped to `inactive`.
+   */
   endQuizSession: () => Promise<void>;
   /** Remove a student from the live session roster */
   removeStudent: (studentUid: string) => Promise<void>;
@@ -153,20 +141,32 @@ export interface UseQuizSessionTeacherResult {
   hideAnswer: (questionId: string) => Promise<void>;
 }
 
+/**
+ * Subscribe to a specific quiz session document (keyed by assignment UUID).
+ * Pass `undefined` or `null` when no assignment is currently selected — the
+ * hook will return an empty state until a session id is supplied.
+ */
 export const useQuizSessionTeacher = (
-  teacherUid: string | undefined
+  sessionId: string | undefined | null
 ): UseQuizSessionTeacherResult => {
   const [session, setSession] = useState<QuizSession | null>(null);
   const [responses, setResponses] = useState<QuizResponse[]>([]);
-  const [loading, setLoading] = useState(true);
+  const [loading, setLoading] = useState<boolean>(!!sessionId);
   const advancingRef = useRef(false);
 
+  // Adjust state during render when sessionId changes — avoids state-in-effect
+  // anti-pattern while still clearing stale data when the selection changes.
+  const [prevSessionId, setPrevSessionId] = useState(sessionId);
+  if (sessionId !== prevSessionId) {
+    setPrevSessionId(sessionId);
+    setSession(null);
+    setResponses([]);
+    setLoading(!!sessionId);
+  }
+
   useEffect(() => {
-    if (!teacherUid) {
-      setTimeout(() => setLoading(false), 0);
-      return;
-    }
-    const sessionRef = doc(db, QUIZ_SESSIONS_COLLECTION, teacherUid);
+    if (!sessionId) return;
+    const sessionRef = doc(db, QUIZ_SESSIONS_COLLECTION, sessionId);
     return onSnapshot(
       sessionRef,
       (snap) => {
@@ -178,17 +178,17 @@ export const useQuizSessionTeacher = (
         setLoading(false);
       }
     );
-  }, [teacherUid]);
+  }, [sessionId]);
 
   const hasSession = !!session;
   useEffect(() => {
     // Keep the listener active even after the session ends so that any
     // late student submissions still appear in the live monitor / results.
-    if (!teacherUid || !hasSession) return;
+    if (!sessionId || !hasSession) return;
     const responsesRef = collection(
       db,
       QUIZ_SESSIONS_COLLECTION,
-      teacherUid,
+      sessionId,
       RESPONSES_COLLECTION
     );
     return onSnapshot(
@@ -199,14 +199,14 @@ export const useQuizSessionTeacher = (
       },
       (err) => console.error('[useQuizSessionTeacher] responses:', err)
     );
-  }, [teacherUid, hasSession]);
+  }, [sessionId, hasSession]);
 
   const finalizeAllResponses = useCallback(async () => {
-    if (!teacherUid) return;
+    if (!sessionId) return;
     const responsesRef = collection(
       db,
       QUIZ_SESSIONS_COLLECTION,
-      teacherUid,
+      sessionId,
       RESPONSES_COLLECTION
     );
     const snap = await getDocs(responsesRef);
@@ -225,48 +225,48 @@ export const useQuizSessionTeacher = (
     if (count > 0) {
       await batch.commit();
     }
-  }, [teacherUid]);
+  }, [sessionId]);
 
   const removeStudent = useCallback(
     async (studentUid: string) => {
-      if (!teacherUid) return;
+      if (!sessionId) return;
       const responseRef = doc(
         db,
         QUIZ_SESSIONS_COLLECTION,
-        teacherUid,
+        sessionId,
         RESPONSES_COLLECTION,
         studentUid
       );
       await deleteDoc(responseRef);
     },
-    [teacherUid]
+    [sessionId]
   );
 
   const revealAnswer = useCallback(
     async (questionId: string, correctAnswer: string) => {
-      if (!teacherUid) return;
-      const sessionRef = doc(db, QUIZ_SESSIONS_COLLECTION, teacherUid);
+      if (!sessionId) return;
+      const sessionRef = doc(db, QUIZ_SESSIONS_COLLECTION, sessionId);
       await updateDoc(sessionRef, {
         [`revealedAnswers.${questionId}`]: correctAnswer,
       });
     },
-    [teacherUid]
+    [sessionId]
   );
 
   const hideAnswer = useCallback(
     async (questionId: string) => {
-      if (!teacherUid) return;
-      const sessionRef = doc(db, QUIZ_SESSIONS_COLLECTION, teacherUid);
+      if (!sessionId) return;
+      const sessionRef = doc(db, QUIZ_SESSIONS_COLLECTION, sessionId);
       await updateDoc(sessionRef, {
         [`revealedAnswers.${questionId}`]: deleteField(),
       });
     },
-    [teacherUid]
+    [sessionId]
   );
 
   const advanceQuestion = useCallback(async () => {
-    if (!teacherUid || !session) return;
-    const sessionRef = doc(db, QUIZ_SESSIONS_COLLECTION, teacherUid);
+    if (!sessionId || !session) return;
+    const sessionRef = doc(db, QUIZ_SESSIONS_COLLECTION, sessionId);
 
     const isReviewing = session.questionPhase === 'reviewing';
 
@@ -306,13 +306,13 @@ export const useQuizSessionTeacher = (
       questionPhase: 'answering',
       ...(session.startedAt === null ? { startedAt: Date.now() } : {}),
     });
-  }, [teacherUid, session, finalizeAllResponses]);
+  }, [sessionId, session, finalizeAllResponses]);
 
   const endQuizSession = useCallback(async () => {
-    if (!teacherUid) return;
+    if (!sessionId) return;
 
     // 1. End the session
-    await updateDoc(doc(db, QUIZ_SESSIONS_COLLECTION, teacherUid), {
+    await updateDoc(doc(db, QUIZ_SESSIONS_COLLECTION, sessionId), {
       status: 'ended' as QuizSessionStatus,
       endedAt: Date.now(),
       autoProgressAt: null,
@@ -320,11 +320,11 @@ export const useQuizSessionTeacher = (
 
     // 2. Mark all active students as completed so their data is preserved in results
     await finalizeAllResponses();
-  }, [teacherUid, finalizeAllResponses]);
+  }, [sessionId, finalizeAllResponses]);
 
   // ─── Auto-progress logic ────────────────────────────────────────────────────
   useEffect(() => {
-    if (!teacherUid || !session || session.sessionMode !== 'auto') return;
+    if (!sessionId || !session || session.sessionMode !== 'auto') return;
     if (session.status !== 'active') return;
 
     const currentQId =
@@ -353,15 +353,15 @@ export const useQuizSessionTeacher = (
       if (shouldReview) {
         updates.questionPhase = 'reviewing';
       }
-      updateDoc(doc(db, QUIZ_SESSIONS_COLLECTION, teacherUid), updates).catch(
+      updateDoc(doc(db, QUIZ_SESSIONS_COLLECTION, sessionId), updates).catch(
         (err) => console.error('[AutoProgress] update failed:', err)
       );
     }
-  }, [responses, session, teacherUid]);
+  }, [responses, session, sessionId]);
 
   // Handle the actual auto-advance when the timestamp is reached
   useEffect(() => {
-    if (!teacherUid || !session?.autoProgressAt) return;
+    if (!sessionId || !session?.autoProgressAt) return;
 
     const timer = setInterval(() => {
       if (Date.now() >= (session.autoProgressAt ?? 0)) {
@@ -377,104 +377,12 @@ export const useQuizSessionTeacher = (
     }, 1000);
 
     return () => clearInterval(timer);
-  }, [session?.autoProgressAt, teacherUid, advanceQuestion]);
-
-  const startQuizSession = useCallback(
-    async (
-      quiz: {
-        id: string;
-        title: string;
-        questions: QuizQuestion[];
-      },
-      mode: QuizSessionMode = 'teacher',
-      options?: QuizSessionOptions
-    ): Promise<string> => {
-      if (!teacherUid) throw new Error('Not authenticated');
-
-      // Delete any existing response documents from a previous session
-      const oldResponses = await getDocs(
-        collection(
-          db,
-          QUIZ_SESSIONS_COLLECTION,
-          teacherUid,
-          RESPONSES_COLLECTION
-        )
-      );
-      const BATCH_LIMIT = 500;
-      for (let i = 0; i < oldResponses.docs.length; i += BATCH_LIMIT) {
-        const batch = writeBatch(db);
-        oldResponses.docs.slice(i, i + BATCH_LIMIT).forEach((d) => {
-          batch.delete(d.ref);
-        });
-        await batch.commit();
-      }
-
-      // Generate a unique 6-character join code
-      let code = '';
-      for (let attempt = 0; attempt < 5; attempt++) {
-        const candidate = Math.random()
-          .toString(36)
-          .substring(2, 8)
-          .toUpperCase()
-          .padEnd(6, '0');
-        const collision = await getDocs(
-          query(
-            collection(db, QUIZ_SESSIONS_COLLECTION),
-            where('code', '==', candidate),
-            where('status', '!=', 'ended')
-          )
-        );
-        if (collision.empty) {
-          code = candidate;
-          break;
-        }
-      }
-      if (!code) {
-        code = Math.random()
-          .toString(36)
-          .substring(2, 8)
-          .toUpperCase()
-          .padEnd(6, '0');
-      }
-
-      const newSession: QuizSession = {
-        id: teacherUid,
-        quizId: quiz.id,
-        quizTitle: quiz.title,
-        teacherUid,
-        status: 'waiting' as QuizSessionStatus,
-        sessionMode: mode,
-        currentQuestionIndex: mode === 'student' ? 0 : -1,
-        startedAt: mode === 'student' ? Date.now() : null,
-        endedAt: null,
-        code,
-        totalQuestions: quiz.questions.length,
-        publicQuestions: quiz.questions.map(toPublicQuestion),
-        // Phase 1 toggles
-        tabWarningsEnabled: options?.tabWarningsEnabled ?? true,
-        showResultToStudent: options?.showResultToStudent ?? false,
-        showCorrectAnswerToStudent:
-          options?.showCorrectAnswerToStudent ?? false,
-        showCorrectOnBoard: options?.showCorrectOnBoard ?? false,
-        revealedAnswers: {},
-        // Phase 2 gamification
-        speedBonusEnabled: options?.speedBonusEnabled ?? false,
-        streakBonusEnabled: options?.streakBonusEnabled ?? false,
-        showPodiumBetweenQuestions: options?.showPodiumBetweenQuestions ?? true,
-        soundEffectsEnabled: options?.soundEffectsEnabled ?? false,
-        questionPhase: 'answering',
-      };
-      await setDoc(doc(db, QUIZ_SESSIONS_COLLECTION, teacherUid), newSession);
-      return code;
-    },
-    [teacherUid]
-  );
+  }, [session?.autoProgressAt, sessionId, advanceQuestion]);
 
   return {
     session,
     responses,
     loading,
-    startQuizSession,
     advanceQuestion,
     endQuizSession,
     removeStudent,
@@ -490,7 +398,12 @@ export interface UseQuizSessionStudentResult {
   myResponse: QuizResponse | null;
   loading: boolean;
   error: string | null;
-  teacherUidRef: MutableRefObject<string | null>;
+  /**
+   * Ref holding the active session id (the Firestore doc ID under
+   * `/quiz_sessions/{sessionId}`). Historically named `teacherUidRef` back
+   * when sessions were keyed by the teacher's uid.
+   */
+  sessionIdRef: MutableRefObject<string | null>;
   joinQuizSession: (code: string, pin: string) => Promise<string>;
   submitAnswer: (
     questionId: string,
@@ -511,7 +424,7 @@ export const useQuizSessionStudent = (): UseQuizSessionStudentResult => {
   const [myResponse, setMyResponse] = useState<QuizResponse | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const teacherUidRef = useRef<string | null>(null);
+  const sessionIdRef = useRef<string | null>(null);
   const studentUidRef = useRef<string | null>(null);
   // Keep a ref to current answers to avoid stale closure issues
   const myResponseRef = useRef<QuizResponse | null>(null);
@@ -534,34 +447,34 @@ export const useQuizSessionStudent = (): UseQuizSessionStudentResult => {
     }
   }, [myResponse?.tabSwitchWarnings]);
 
-  // Session listener — only subscribes once teacherUid is known
-  const [teacherUidState, setTeacherUidState] = useState<string | null>(null);
+  // Session listener — only subscribes once sessionId is known
+  const [sessionIdState, setSessionIdState] = useState<string | null>(null);
 
   useEffect(() => {
-    if (!teacherUidState) return;
+    if (!sessionIdState) return;
     return onSnapshot(
-      doc(db, QUIZ_SESSIONS_COLLECTION, teacherUidState),
+      doc(db, QUIZ_SESSIONS_COLLECTION, sessionIdState),
       (snap) => setSession(snap.exists() ? (snap.data() as QuizSession) : null)
     );
-  }, [teacherUidState]);
+  }, [sessionIdState]);
 
   // My response listener
   const [studentUidState, setStudentUidState] = useState<string | null>(null);
 
   useEffect(() => {
-    if (!teacherUidState || !studentUidState) return;
+    if (!sessionIdState || !studentUidState) return;
     return onSnapshot(
       doc(
         db,
         QUIZ_SESSIONS_COLLECTION,
-        teacherUidState,
+        sessionIdState,
         RESPONSES_COLLECTION,
         studentUidState
       ),
       (snap) =>
         setMyResponse(snap.exists() ? (snap.data() as QuizResponse) : null)
     );
-  }, [teacherUidState, studentUidState]);
+  }, [sessionIdState, studentUidState]);
 
   const joinQuizSession = useCallback(
     async (code: string, pin: string): Promise<string> => {
@@ -598,18 +511,22 @@ export const useQuizSessionStudent = (): UseQuizSessionStudentResult => {
 
         const sessionDoc = snap.docs[0];
         const sessionData = sessionDoc.data() as QuizSession;
+        // Reject joins on sessions that are no longer accepting new students.
+        // An assignment that has been deactivated ends its session ('ended').
+        // Paused sessions keep the URL live — students see a paused placeholder
+        // rather than being rejected — so they are NOT rejected here.
         if (sessionData.status === 'ended') {
           throw new Error('This quiz session has already ended.');
         }
 
-        teacherUidRef.current = sessionDoc.id;
+        sessionIdRef.current = sessionDoc.id;
         studentUidRef.current = studentUid;
         // Reset warning count before activating snapshot listeners so a
         // late-arriving snapshot from a previous session can't race with
         // the finally-block reset and leave the counter stuck at 0.
         warningCountRef.current = 0;
         setWarningCount(0);
-        setTeacherUidState(sessionDoc.id);
+        setSessionIdState(sessionDoc.id);
         setStudentUidState(studentUid);
 
         const responseRef = doc(
@@ -653,9 +570,9 @@ export const useQuizSessionStudent = (): UseQuizSessionStudentResult => {
 
   const submitAnswer = useCallback(
     async (questionId: string, answer: string, speedBonus?: number) => {
-      const teacherUid = teacherUidRef.current;
+      const sessionId = sessionIdRef.current;
       const studentUid = studentUidRef.current;
-      if (!teacherUid || !studentUid) return;
+      if (!sessionId || !studentUid) return;
 
       // isCorrect is intentionally not written by the student to prevent
       // client-side forgery. It is computed by the teacher's results view
@@ -679,7 +596,7 @@ export const useQuizSessionStudent = (): UseQuizSessionStudentResult => {
         doc(
           db,
           QUIZ_SESSIONS_COLLECTION,
-          teacherUid,
+          sessionId,
           RESPONSES_COLLECTION,
           studentUid
         ),
@@ -690,9 +607,9 @@ export const useQuizSessionStudent = (): UseQuizSessionStudentResult => {
   );
 
   const completeQuiz = useCallback(async () => {
-    const teacherUid = teacherUidRef.current;
+    const sessionId = sessionIdRef.current;
     const studentUid = studentUidRef.current;
-    if (!teacherUid || !studentUid) return;
+    if (!sessionId || !studentUid) return;
 
     // Score is computed from gradeAnswer() by the teacher/results view,
     // not written by the student, to prevent client-side forgery of the score field.
@@ -700,7 +617,7 @@ export const useQuizSessionStudent = (): UseQuizSessionStudentResult => {
       doc(
         db,
         QUIZ_SESSIONS_COLLECTION,
-        teacherUid,
+        sessionId,
         RESPONSES_COLLECTION,
         studentUid
       ),
@@ -709,14 +626,14 @@ export const useQuizSessionStudent = (): UseQuizSessionStudentResult => {
   }, []);
 
   const reportTabSwitch = useCallback(async (): Promise<number> => {
-    const teacherUid = teacherUidRef.current;
+    const sessionId = sessionIdRef.current;
     const studentUid = studentUidRef.current;
-    if (!teacherUid || !studentUid) return 0;
+    if (!sessionId || !studentUid) return 0;
 
     const responseRef = doc(
       db,
       QUIZ_SESSIONS_COLLECTION,
-      teacherUid,
+      sessionId,
       RESPONSES_COLLECTION,
       studentUid
     );
@@ -745,7 +662,7 @@ export const useQuizSessionStudent = (): UseQuizSessionStudentResult => {
     myResponse,
     loading,
     error,
-    teacherUidRef,
+    sessionIdRef,
     joinQuizSession,
     submitAnswer,
     completeQuiz,

--- a/hooks/useQuizSession.ts
+++ b/hooks/useQuizSession.ts
@@ -509,15 +509,27 @@ export const useQuizSessionStudent = (): UseQuizSessionStudentResult => {
         );
         if (snap.empty) throw new Error('No active quiz found with that code.');
 
-        const sessionDoc = snap.docs[0];
-        const sessionData = sessionDoc.data() as QuizSession;
-        // Reject joins on sessions that are no longer accepting new students.
-        // An assignment that has been deactivated ends its session ('ended').
-        // Paused sessions keep the URL live — students see a paused placeholder
-        // rather than being rejected — so they are NOT rejected here.
-        if (sessionData.status === 'ended') {
+        // A code can transiently appear on more than one doc — e.g. an old
+        // ended session plus a new live one with a recycled code. Filter
+        // client-side to the docs that are still accepting joins (waiting /
+        // active / paused) before picking one, otherwise docs[0] may be the
+        // stale ended session and students get rejected despite a live
+        // session existing.
+        const joinable = snap.docs.filter((d) => {
+          const s = (d.data() as QuizSession).status;
+          return s === 'waiting' || s === 'active' || s === 'paused';
+        });
+        if (joinable.length === 0) {
           throw new Error('This quiz session has already ended.');
         }
+        // Prefer the most recently created joinable doc.
+        joinable.sort((a, b) => {
+          const at = (a.data() as QuizSession).startedAt ?? 0;
+          const bt = (b.data() as QuizSession).startedAt ?? 0;
+          return bt - at;
+        });
+        const sessionDoc = joinable[0];
+        const sessionData = sessionDoc.data() as QuizSession;
 
         sessionIdRef.current = sessionDoc.id;
         studentUidRef.current = studentUid;

--- a/tests/components/layout/DashboardView.test.tsx
+++ b/tests/components/layout/DashboardView.test.tsx
@@ -43,6 +43,16 @@ vi.mock('@/hooks/useQuiz', () => ({
     importSharedQuiz: vi.fn().mockResolvedValue(undefined),
     shareQuiz: vi.fn().mockResolvedValue(''),
     createQuizTemplate: vi.fn().mockResolvedValue(''),
+    saveQuiz: vi.fn().mockResolvedValue({ id: 'q1', driveFileId: 'drive-1' }),
+  }),
+}));
+
+vi.mock('@/hooks/useQuizAssignments', () => ({
+  useQuizAssignments: vi.fn().mockReturnValue({
+    assignments: [],
+    loading: false,
+    error: null,
+    importSharedAssignment: vi.fn().mockResolvedValue('a1'),
   }),
 }));
 

--- a/tests/escapeInteraction.test.tsx
+++ b/tests/escapeInteraction.test.tsx
@@ -74,6 +74,15 @@ vi.mock('../hooks/useQuiz', () => ({
     importSharedQuiz: vi.fn().mockResolvedValue(undefined),
     shareQuiz: vi.fn().mockResolvedValue(''),
     createQuizTemplate: vi.fn().mockResolvedValue(''),
+    saveQuiz: vi.fn().mockResolvedValue({ id: 'q1', driveFileId: 'drive-1' }),
+  }),
+}));
+vi.mock('../hooks/useQuizAssignments', () => ({
+  useQuizAssignments: () => ({
+    assignments: [],
+    loading: false,
+    error: null,
+    importSharedAssignment: vi.fn().mockResolvedValue('a1'),
   }),
 }));
 

--- a/types.ts
+++ b/types.ts
@@ -1505,8 +1505,20 @@ export interface QuizMetadata {
   updatedAt: number;
 }
 
-export type QuizSessionStatus = 'waiting' | 'active' | 'ended';
+export type QuizSessionStatus = 'waiting' | 'active' | 'paused' | 'ended';
 export type QuizSessionMode = 'teacher' | 'auto' | 'student';
+
+/** Options passed from the assignment modal to configure session toggles. */
+export interface QuizSessionOptions {
+  tabWarningsEnabled?: boolean;
+  showResultToStudent?: boolean;
+  showCorrectAnswerToStudent?: boolean;
+  showCorrectOnBoard?: boolean;
+  speedBonusEnabled?: boolean;
+  streakBonusEnabled?: boolean;
+  showPodiumBetweenQuestions?: boolean;
+  soundEffectsEnabled?: boolean;
+}
 
 /**
  * Student-safe question stored in the session document.
@@ -1535,9 +1547,11 @@ export interface QuizLeaderboardEntry {
   rank: number;
 }
 
-/** Live quiz session document in Firestore (/quiz_sessions/{teacherUid}) */
+/** Live quiz session document in Firestore (/quiz_sessions/{sessionId}) */
 export interface QuizSession {
-  id: string; // teacher's UID
+  id: string; // session UUID (same as QuizAssignment.id)
+  /** FK back to /users/{teacherUid}/quiz_assignments/{assignmentId}. 1:1 with session. */
+  assignmentId: string;
   quizId: string;
   quizTitle: string;
   teacherUid: string;
@@ -1646,9 +1660,13 @@ export interface QuizGlobalConfig {
 /** Widget configuration for the quiz widget (teacher side) */
 export interface QuizConfig {
   view: 'manager' | 'import' | 'editor' | 'preview' | 'results' | 'monitor';
+  /** Tab within the manager view (library of saved quizzes vs archive of past assignments). */
+  managerTab?: 'library' | 'archive';
   selectedQuizId: string | null;
   selectedQuizTitle: string | null;
-  /** Session code when a live quiz is running */
+  /** Assignment currently opened in monitor/results views. */
+  activeAssignmentId: string | null;
+  /** Session code when a live quiz is running (denormalized from the active assignment for display). */
   activeLiveSessionCode: string | null;
   /** Quiz session ID for viewing historical results */
   resultsSessionId: string | null;
@@ -1670,6 +1688,73 @@ export interface QuizConfig {
   liveScoreboardMode?: 'pin' | 'name';
   /** When to update scores: on quiz completion or after each question */
   liveScoreboardScoring?: 'completion' | 'per-question';
+}
+
+// --- QUIZ ASSIGNMENT TYPES ---
+
+/**
+ * Lifecycle state of a quiz assignment.
+ * - `active`: the student URL is live and accepting submissions.
+ * - `paused`: the student URL is live but submissions are blocked; students see a paused placeholder.
+ * - `inactive`: the student URL is dead; existing responses are preserved for review.
+ */
+export type QuizAssignmentStatus = 'active' | 'paused' | 'inactive';
+
+/**
+ * Settings that can be carried between assignments and are shareable in PLCs.
+ * These do NOT include the quiz content itself — content is always sourced from the library.
+ */
+export interface QuizAssignmentSettings {
+  /** Free-text label shown in the archive (e.g. "Period 2"). */
+  className?: string;
+  sessionMode: QuizSessionMode;
+  sessionOptions: QuizSessionOptions;
+  /** PLC mode: export results to a shared Google Sheet */
+  plcMode?: boolean;
+  plcSheetUrl?: string;
+  teacherName?: string;
+  periodName?: string;
+  plcMemberEmails?: string[];
+}
+
+/**
+ * A single instance of a quiz being assigned out. Stored per-teacher at
+ * `/users/{teacherUid}/quiz_assignments/{assignmentId}`. The assignment id is
+ * also the id of the matching `/quiz_sessions/{sessionId}` document (1:1).
+ */
+export interface QuizAssignment extends QuizAssignmentSettings {
+  /** Assignment UUID — also the sessionId. */
+  id: string;
+  quizId: string;
+  quizTitle: string;
+  /** Drive file id of the source quiz so the monitor can hydrate after reload. */
+  quizDriveFileId: string;
+  teacherUid: string;
+  /** Join code for the student URL. Denormalized from the session doc for archive display. */
+  code: string;
+  status: QuizAssignmentStatus;
+  createdAt: number;
+  updatedAt: number;
+}
+
+/**
+ * Shared-assignment document stored at `/shared_assignments/{shareId}`.
+ * Unlike a shared quiz, this carries assignment settings (including the PLC
+ * sheet URL) so another teacher can paste the link and get both the library
+ * quiz and a preconfigured, paused assignment in one step.
+ */
+export interface SharedQuizAssignment {
+  /** Shared-doc id (Firestore auto-id). */
+  id: string;
+  /** Inlined quiz data so the importer can copy it into their own library. */
+  title: string;
+  questions: QuizQuestion[];
+  createdAt: number;
+  updatedAt: number;
+  assignmentSettings: QuizAssignmentSettings;
+  /** Original author's UID. */
+  originalAuthor: string;
+  sharedAt: number;
 }
 
 // --- VIDEO ACTIVITY TYPES ---

--- a/utils/smartPaste.ts
+++ b/utils/smartPaste.ts
@@ -12,7 +12,8 @@ export type PasteResult =
   | { action: 'create-mini-app'; html: string; title?: string }
   | { action: 'prompt-text-or-checklist'; text: string }
   | { action: 'prompt-url-or-qr'; url: string }
-  | { action: 'import-quiz'; shareId: string };
+  | { action: 'import-quiz'; shareId: string }
+  | { action: 'import-assignment'; shareId: string };
 
 /**
  * Detects the most appropriate paste action based on the provided text.
@@ -27,6 +28,7 @@ export function detectWidgetType(text: string): PasteResult | null {
   if (!trimmed) return null;
 
   return (
+    tryParseAssignmentImport(trimmed) ??
     tryParseQuizImport(trimmed) ??
     tryParseBoardImport(trimmed) ??
     tryParseMiniApp(trimmed) ??
@@ -34,6 +36,27 @@ export function detectWidgetType(text: string): PasteResult | null {
     tryParseChecklist(trimmed) ??
     createDefaultTextWidget(trimmed)
   );
+}
+
+function tryParseAssignmentImport(text: string): PasteResult | null {
+  let candidate = text;
+  if (!/^(http|https):\/\//i.test(candidate)) {
+    const domainPattern = /^(?:[a-zA-Z0-9-]+\.)+[a-zA-Z]{2,}(?:[/:?].*)?$/;
+    if (domainPattern.test(candidate)) {
+      candidate = `https://${candidate}`;
+    }
+  }
+
+  try {
+    const url = new URL(candidate, window.location.origin);
+    const match = url.pathname.match(/^\/share\/assignment\/([a-zA-Z0-9_-]+)$/);
+    if (match) {
+      return { action: 'import-assignment', shareId: match[1] };
+    }
+  } catch {
+    // Fall through
+  }
+  return null;
 }
 
 function tryParseQuizImport(text: string): PasteResult | null {

--- a/utils/widgetConfigPersistence.ts
+++ b/utils/widgetConfigPersistence.ts
@@ -17,6 +17,7 @@ const TRANSIENT_CONFIG_KEYS = new Set<string>([
 
   // Live session identifiers (ephemeral, would reference dead sessions)
   'activeLiveSessionCode',
+  'activeAssignmentId',
   'resultsSessionId',
   'liveScoreboardWidgetId',
   'liveScoreboardEnabled',
@@ -25,6 +26,7 @@ const TRANSIENT_CONFIG_KEYS = new Set<string>([
 
   // Navigation view state (should reset to landing page)
   'view',
+  'managerTab',
   'selectedQuizId',
   'selectedQuizTitle',
   'selectedActivityId',


### PR DESCRIPTION
## Summary

Replaces the single-session-per-teacher quiz model with a per-assignment archive. Multiple classes can be active concurrently, each with its own join code, and responses are preserved until the teacher explicitly deletes an assignment. Adds PLC sharing of full assignments (settings + sheet URL) and fixes the paste flow so `/share/quiz` and `/share/assignment` links open the Quiz widget without a page reload.

### Data model

- `QuizAssignment` is a new record under `/users/{uid}/quiz_assignments/{id}` that owns session settings (className, PLC fields, session toggles) and a back-reference to the quiz in the Library.
- `QuizSession` docs at `/quiz_sessions/{sessionId}` are now keyed by the assignment's UUID (1:1) rather than teacher UID. `teacherUid` moved to a field; student join-by-code is unaffected.
- New `/shared_assignments/{shareId}` collection mirrors `/shared_quizzes/*` for PLC imports.
- Assignment status: `active | paused | inactive`. Paused keeps the session alive but halts the timer and shows a full-screen placeholder in the student app. Inactive ends it while preserving responses.

### UI

- Quiz Manager gains a **Library / Archive** tab switcher. Per-quiz END/RESUME controls on library rows are gone; assignment lifecycle lives entirely in the Archive.
- `QuizAssignmentArchive` lists rows with color-coded status pill and per-row actions: Copy URL, Monitor, Results, Edit Settings, Share, Pause/Resume, Deactivate, Delete.
- `QuizAssignmentSettingsModal` edits settings only (quiz content stays tied to the Library). `sessionMode` is locked while active/paused.
- `QuizLiveMonitor` adds Pause/Resume; End is now "Make Inactive" with a confirm dialog explaining preservation.
- Student app renders `QuizPausedPlaceholder` on paused sessions and rejects joins on ended/inactive.
- Quiz Settings' "Force End Active Session" button is replaced with a "View Assignment Archive" link.

### Paste flow fix

- `Dock.tsx` no longer does `window.location.href` on share-link paste; it sets `pendingQuizShareId` / `pendingAssignmentShareId` in `DashboardContext`.
- `DashboardView.tsx` imports the shared quiz or assignment, then opens (or focuses) a Quiz widget and switches it to the matching tab. External `/share/*` URLs still work via the mount-time URL parser.
- `smartPaste.ts` gains `tryParseAssignmentImport`.

### Firestore rules

- `/quiz_sessions/{sessionId}` rules moved to sessionId keying; ownership checks use `resource.data.teacherUid`. Response writes add one `get()` lookup — ~50ms per answer submission, fine at class scale.
- New owner-only rules for `/users/{uid}/quiz_assignments/*` and author-create rules for `/shared_assignments/*`.

### Migration

No script. Live sessions are ephemeral; orphan `/quiz_sessions/{teacherUid}` docs are left in place but become unreachable. Release note should warn teachers to re-assign anything mid-session.

## Test plan

- [ ] Teacher A creates Quiz X, clicks Assign with className "Period 1" → Archive shows one Active row with a code.
- [ ] Teacher A clicks Assign again with "Period 2" → Archive shows two Active rows with different codes; students can join either.
- [ ] Teacher A pauses Period 1 → student on Period 1 sees paused placeholder; resume brings them back.
- [ ] Teacher A makes Period 1 inactive → student sees session-ended; Results from Archive still load.
- [ ] Teacher A deletes Period 1 → Archive row gone, responses purged.
- [ ] Teacher A shares Quiz X; Teacher B pastes link → Quiz widget opens to Library tab with Quiz X present. No reload.
- [ ] Teacher A shares Period 2 assignment (with PLC sheet URL); Teacher B pastes link → Quiz widget opens to Archive tab, row is Paused, settings show preserved sheet URL. Resume → copy code → student joins.
- [ ] Rules: student responses accepted on active/paused, rejected on inactive; teacher can only access their own assignments.
- [ ] `pnpm run validate` green; 1156 tests pass.

https://claude.ai/code/session_01YWopTYRKmMGRWHUdkT8GfU