### PR TITLE
fix(admin): wire 6 widget building defaults into getAdminBuildingConfig

### DIFF
--- a/context/DashboardContext.tsx
+++ b/context/DashboardContext.tsx
@@ -2327,6 +2327,103 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
             out.classLinkEnabled = raw.classLinkEnabled;
           }
           break;
+        case 'url':
+          if (Array.isArray(raw.urls) && raw.urls.length > 0) {
+            out.urls = (
+              raw.urls as Array<{
+                url: string;
+                title?: string;
+                color?: string;
+              }>
+            ).map((item) => ({
+              id: crypto.randomUUID(),
+              url: typeof item.url === 'string' ? item.url : '',
+              ...(typeof item.title === 'string' ? { title: item.title } : {}),
+              ...(typeof item.color === 'string' ? { color: item.color } : {}),
+            }));
+          }
+          break;
+        case 'soundboard': {
+          const soundIds: string[] = [];
+          if (Array.isArray(raw.availableSounds)) {
+            for (const s of raw.availableSounds as Array<{ id?: string }>) {
+              if (typeof s.id === 'string') soundIds.push(s.id);
+            }
+          }
+          if (Array.isArray(raw.enabledLibrarySoundIds)) {
+            for (const id of raw.enabledLibrarySoundIds as string[]) {
+              if (typeof id === 'string') soundIds.push(id);
+            }
+          }
+          if (Array.isArray(raw.enabledCustomSoundIds)) {
+            for (const id of raw.enabledCustomSoundIds as string[]) {
+              if (typeof id === 'string') soundIds.push(id);
+            }
+          }
+          if (soundIds.length > 0) out.selectedSoundIds = soundIds;
+          break;
+        }
+        case 'schedule': {
+          if (Array.isArray(raw.schedules) && raw.schedules.length > 0) {
+            out.schedules = (
+              raw.schedules as Array<{
+                name?: string;
+                items?: Array<Record<string, unknown>>;
+                days?: number[];
+              }>
+            ).map((sched) => ({
+              ...sched,
+              id: crypto.randomUUID(),
+              items: Array.isArray(sched.items)
+                ? sched.items.map((item) => ({
+                    ...item,
+                    id: crypto.randomUUID(),
+                  }))
+                : [],
+            }));
+          }
+          if (Array.isArray(raw.items) && raw.items.length > 0) {
+            out.items = (raw.items as Array<Record<string, unknown>>).map(
+              (item) => ({
+                ...item,
+                id: crypto.randomUUID(),
+              })
+            );
+          }
+          break;
+        }
+        case 'embed':
+          // Building embed defaults (hideUrlField, whitelistUrls) are
+          // admin-level constraints consumed by the EmbedWidget via direct
+          // permission config lookup, not widget config fields.
+          break;
+        case 'qr':
+          if (
+            typeof raw.defaultUrl === 'string' &&
+            raw.defaultUrl.trim() !== ''
+          )
+            out.url = raw.defaultUrl;
+          if (typeof raw.qrColor === 'string' && raw.qrColor.trim() !== '')
+            out.qrColor = raw.qrColor;
+          if (typeof raw.qrBgColor === 'string' && raw.qrBgColor.trim() !== '')
+            out.qrBgColor = raw.qrBgColor;
+          break;
+        case 'countdown': {
+          const validViewModes = ['number', 'grid'] as const;
+          if (typeof raw.title === 'string') out.title = raw.title;
+          if (typeof raw.startDate === 'string') out.startDate = raw.startDate;
+          if (typeof raw.eventDate === 'string') out.eventDate = raw.eventDate;
+          if (typeof raw.includeWeekends === 'boolean')
+            out.includeWeekends = raw.includeWeekends;
+          if (typeof raw.countToday === 'boolean')
+            out.countToday = raw.countToday;
+          if (
+            typeof raw.viewMode === 'string' &&
+            (validViewModes as readonly string[]).includes(raw.viewMode)
+          )
+            out.viewMode = raw.viewMode;
+          break;
+        }
         default:
           break;
       }

--- a/docs/scheduled-tasks/admin-settings-alignment.md
+++ b/docs/scheduled-tasks/admin-settings-alignment.md
@@ -3,7 +3,7 @@
 _Audit model: claude-sonnet-4-6_
 _Action model: claude-opus-4-6_
 _Audit cadence: weekly — Thursday_
-_Last audited: never_
+_Last audited: 2026-04-16_
 _Last action: never_
 
 ---
@@ -16,7 +16,55 @@ _Nothing currently in progress._
 
 ## Open
 
-_No open items. Awaiting first audit run._
+### HIGH 6 widgets have Building\*Defaults + ConfigurationPanel but no getAdminBuildingConfig handler
+
+- **Detected:** 2026-04-16
+- **File:** context/DashboardContext.tsx (getAdminBuildingConfig, lines 2035–2340), components/admin/FeatureConfigurationPanel.tsx
+- **Detail:** The following 6 widgets have all three required pieces — a `Building*Defaults` interface in `types.ts`, a `buildingDefaults` field on their config interface, and a `*ConfigurationPanel.tsx` registered in `BUILDING_CONFIG_PANELS` — but have **no `case` in `getAdminBuildingConfig()`**. This means admins can set building-level defaults through the UI, the data is persisted to Firestore, but the defaults are **never applied** when a teacher adds one of these widgets. The admin config is effectively dead UI.
+  - `url` — `BuildingUrlDefaults` in types.ts; `UrlConfigurationPanel` registered; no `case 'url'`
+  - `soundboard` — `SoundboardBuildingConfig` in types.ts; `SoundboardConfigurationPanel` registered; no `case 'soundboard'`
+  - `schedule` — `BuildingScheduleDefaults` in types.ts; `ScheduleConfigurationPanel` registered; no `case 'schedule'`
+  - `embed` — `BuildingEmbedDefaults` in types.ts; `EmbedConfigurationPanel` registered; no `case 'embed'`
+  - `qr` — `BuildingQRDefaults` in types.ts; `QRConfigurationPanel` registered; no `case 'qr'`
+  - `countdown` — `BuildingCountdownDefaults` in types.ts; `CountdownConfigurationPanel` registered; no `case 'countdown'`
+- **Fix:** For each widget, add a `case '<type>': { ... }` block in `getAdminBuildingConfig()` (context/DashboardContext.tsx ~line 2330) that reads from `adminBuildingConfig.widgetDefaults['<type>']` and spreads the appropriate `Building*Defaults` fields into the returned config object. Follow the pattern of existing cases like `case 'clock'` (line ~2153) or `case 'time-tool'` (line ~2175).
+
+### MEDIUM 5 widgets have ConfigurationPanels but no Building\*Defaults type infrastructure
+
+- **Detected:** 2026-04-16
+- **File:** types.ts, context/DashboardContext.tsx, components/admin/FeatureConfigurationPanel.tsx
+- **Detail:** The following 5 widgets have `*ConfigurationPanel.tsx` components registered in `BUILDING_CONFIG_PANELS` but have NO `Building*Defaults` interface in `types.ts` and NO `buildingDefaults` field on their config interface. The panels collect admin input with no defined schema, no Firestore storage key, and no application logic.
+  - `mathTools` — `MathToolsConfigurationPanel` registered
+  - `recessGear` — `RecessGearConfigurationPanel` registered
+  - `magic` — `MagicConfigurationPanel` registered
+  - `record` — `RecordConfigurationPanel` registered
+  - `remote` — `RemoteConfigurationPanel` registered
+- **Fix:** For each widget, decide: (a) if building-level defaults are genuinely needed, add a `Building*Defaults` interface to types.ts, add a `buildingDefaults` field to the widget's config interface, and add a case in `getAdminBuildingConfig()`; or (b) if admin settings aren't needed, remove the panel from `BUILDING_CONFIG_PANELS` in `FeatureConfigurationPanel.tsx` to avoid confusing admins with non-functional UI.
+
+### MEDIUM Appearance settings (cardColor, cardOpacity, fontFamily, fontColor) exposed in user Settings.tsx but absent from admin building config
+
+- **Detected:** 2026-04-16
+- **File:** types.ts, context/DashboardContext.tsx (getAdminBuildingConfig)
+- **Detail:** Multiple widgets expose appearance controls in their user-facing Settings.tsx (via `SurfaceColorSettings` and `TypographySettings`) and have the corresponding fields in their `types.ts` config interface, but these fields are not handled in `getAdminBuildingConfig()` and are not controllable from any admin ConfigurationPanel. Admins cannot set per-building appearance defaults for these widgets. Affected widgets:
+  - `smartNotebook` — `cardColor`, `cardOpacity`, `fontFamily`, `fontColor` fields in `SmartNotebookConfig`; `getAdminBuildingConfig` handles only `storageLimitMb`
+  - `concept-web` — `cardColor`, `cardOpacity`, `fontColor` fields in `ConceptWebConfig`; `getAdminBuildingConfig` handles only `defaultNodeWidth`, `defaultNodeHeight`, `fontFamily`
+  - `numberLine` — `cardColor`, `cardOpacity`, `fontFamily`, `fontColor` fields in `NumberLineConfig`; `getAdminBuildingConfig` handles only axis parameters
+  - `checklist` — `cardColor`, `cardOpacity`, `fontFamily`, `fontColor` fields in `ChecklistConfig`; `getAdminBuildingConfig` handles only `items`, `scaleMultiplier`
+- **Fix:** For each widget, either (a) add the appearance fields to the widget's `Building*Defaults` interface in `types.ts` and add them to the `getAdminBuildingConfig()` case, plus expose them in the `*ConfigurationPanel.tsx`; or (b) add a note in the config interface comment that appearance fields are intentionally user-only and not admin-configurable per building.
+
+### MEDIUM Clock: `clockStyle` and `glow` configurable by user but not included in admin building defaults
+
+- **Detected:** 2026-04-16
+- **File:** types.ts (ClockConfig / BuildingClockDefaults), context/DashboardContext.tsx (~line 2153), components/admin/ClockConfigurationPanel.tsx
+- **Detail:** `ClockConfig` in types.ts has `clockStyle` and `glow` fields. The user-facing `ClockSettings.tsx` exposes both fields. However, `BuildingClockDefaults` does not include `clockStyle` or `glow`, and `getAdminBuildingConfig` case `'clock'` only applies `format24`, `fontFamily`, and `themeColor`. Admins cannot pre-set clock appearance style or glow effect per building.
+- **Fix:** Add `clockStyle` and `glow` to `BuildingClockDefaults` interface in types.ts. Add them to the `case 'clock'` handler in `getAdminBuildingConfig()`. Expose controls for both in `ClockConfigurationPanel.tsx`.
+
+### LOW Checklist: `rosterMode` user-configurable but not in admin building config
+
+- **Detected:** 2026-04-16
+- **File:** types.ts (ChecklistConfig / BuildingChecklistDefaults), context/DashboardContext.tsx (~line 2183)
+- **Detail:** `ChecklistConfig` has a `rosterMode` field that controls whether the checklist uses a manually-entered list or a synced class roster. Users can toggle this in Settings.tsx. `BuildingChecklistDefaults` does not include `rosterMode`, so admins cannot set a default roster mode per building.
+- **Fix:** Add `rosterMode` to `BuildingChecklistDefaults` in types.ts. Add it to the `case 'checklist'` handler in `getAdminBuildingConfig()`. Expose a toggle in `ChecklistConfigurationPanel.tsx`.
 
 ---
 

--- a/docs/scheduled-tasks/admin-settings-alignment.md
+++ b/docs/scheduled-tasks/admin-settings-alignment.md
@@ -4,7 +4,7 @@ _Audit model: claude-sonnet-4-6_
 _Action model: claude-opus-4-6_
 _Audit cadence: weekly — Thursday_
 _Last audited: 2026-04-16_
-_Last action: never_
+_Last action: 2026-04-16_
 
 ---
 
@@ -15,19 +15,6 @@ _Nothing currently in progress._
 ---
 
 ## Open
-
-### HIGH 6 widgets have Building\*Defaults + ConfigurationPanel but no getAdminBuildingConfig handler
-
-- **Detected:** 2026-04-16
-- **File:** context/DashboardContext.tsx (getAdminBuildingConfig, lines 2035–2340), components/admin/FeatureConfigurationPanel.tsx
-- **Detail:** The following 6 widgets have all three required pieces — a `Building*Defaults` interface in `types.ts`, a `buildingDefaults` field on their config interface, and a `*ConfigurationPanel.tsx` registered in `BUILDING_CONFIG_PANELS` — but have **no `case` in `getAdminBuildingConfig()`**. This means admins can set building-level defaults through the UI, the data is persisted to Firestore, but the defaults are **never applied** when a teacher adds one of these widgets. The admin config is effectively dead UI.
-  - `url` — `BuildingUrlDefaults` in types.ts; `UrlConfigurationPanel` registered; no `case 'url'`
-  - `soundboard` — `SoundboardBuildingConfig` in types.ts; `SoundboardConfigurationPanel` registered; no `case 'soundboard'`
-  - `schedule` — `BuildingScheduleDefaults` in types.ts; `ScheduleConfigurationPanel` registered; no `case 'schedule'`
-  - `embed` — `BuildingEmbedDefaults` in types.ts; `EmbedConfigurationPanel` registered; no `case 'embed'`
-  - `qr` — `BuildingQRDefaults` in types.ts; `QRConfigurationPanel` registered; no `case 'qr'`
-  - `countdown` — `BuildingCountdownDefaults` in types.ts; `CountdownConfigurationPanel` registered; no `case 'countdown'`
-- **Fix:** For each widget, add a `case '<type>': { ... }` block in `getAdminBuildingConfig()` (context/DashboardContext.tsx ~line 2330) that reads from `adminBuildingConfig.widgetDefaults['<type>']` and spreads the appropriate `Building*Defaults` fields into the returned config object. Follow the pattern of existing cases like `case 'clock'` (line ~2153) or `case 'time-tool'` (line ~2175).
 
 ### MEDIUM 5 widgets have ConfigurationPanels but no Building\*Defaults type infrastructure
 
@@ -70,4 +57,17 @@ _Nothing currently in progress._
 
 ## Completed
 
-_No completed items yet._
+### HIGH 6 widgets have Building\*Defaults + ConfigurationPanel but no getAdminBuildingConfig handler
+
+- **Detected:** 2026-04-16
+- **Completed:** 2026-04-16
+- **File:** context/DashboardContext.tsx (getAdminBuildingConfig)
+- **Detail:** url, soundboard, schedule, embed, qr, countdown had Building\*Defaults interfaces and registered ConfigurationPanels but no `case` in `getAdminBuildingConfig()`, making admin config dead UI.
+- **Resolution:** Added `case` blocks for all 6 widgets in `getAdminBuildingConfig()`:
+  - `url`: Copies `urls[]` array with fresh UUIDs to widget config
+  - `soundboard`: Combines `availableSounds[].id` + `enabledLibrarySoundIds` + `enabledCustomSoundIds` into `selectedSoundIds`
+  - `schedule`: Copies `items` and `schedules` arrays with fresh UUIDs for each schedule and item
+  - `embed`: No-op case with comment — building defaults (`hideUrlField`, `whitelistUrls`) are admin constraints consumed via permission config lookup, not widget config fields
+  - `qr`: Maps `defaultUrl` → `url`, copies `qrColor` and `qrBgColor`
+  - `countdown`: Copies `title`, `startDate`, `eventDate`, `includeWeekends`, `countToday`, `viewMode` (validated against 'number'|'grid')
+    All 1129 unit tests pass; `pnpm type-check`, `pnpm lint --max-warnings 0`, and prettier check all clean.

--- a/docs/scheduled-tasks/css-scaling.md
+++ b/docs/scheduled-tasks/css-scaling.md
@@ -3,7 +3,7 @@
 _Audit model: claude-sonnet-4-6_
 _Action model: claude-opus-4-6_
 _Audit cadence: daily_
-_Last audited: 2026-04-15_
+_Last audited: 2026-04-16_
 _Last action: 2026-04-15_
 
 ---

--- a/docs/scheduled-tasks/legacy-cleanup.md
+++ b/docs/scheduled-tasks/legacy-cleanup.md
@@ -3,7 +3,7 @@
 _Audit model: claude-sonnet-4-6_
 _Action model: claude-opus-4-6_
 _Audit cadence: weekly — Thursday_
-_Last audited: never_
+_Last audited: 2026-04-16_
 _Last action: never_
 
 ---
@@ -16,7 +16,28 @@ _Nothing currently in progress._
 
 ## Open
 
-_No open items. Awaiting first audit run._
+### LOW scripts/tools/\*.py — 8 deprecated manual-testing scripts with no automated role
+
+- **Detected:** 2026-04-16
+- **File:** scripts/tools/ (verify_routines_manager.py, verify_dock_icons.py, verify_routines.py, verify_lunch_count.py, refactor_manager.py, fix_buttons.py, inspect_buttons.py, debug_admin_settings.py, debug_landing.py)
+- **Detail:** The `scripts/tools/` directory contains 9 Python/Playwright scripts. All are either one-off refactoring tasks that have already been executed (refactor*manager.py, fix_buttons.py) or manual test/debug inspection scripts (verify*_.py, inspect\__.py, debug\_\*.py). None are wired into any CI pipeline, build step, or npm script. They provide no automated value and their presence in the repository creates confusion about what testing tools are canonical.
+- **Fix:** Delete `scripts/tools/` directory entirely. Ongoing E2E testing is handled by `tests/e2e/` via Playwright and pnpm test:e2e.
+
+---
+
+## Clean (no issues found)
+
+Migration code audit (2026-04-16):
+
+- Old type strings 'timer', 'stopwatch': Only referenced in `utils/migration.ts` migrateWidget() handler — correct.
+- Old type string 'workSymbols': Zero usage outside `utils/migration.ts` — data fully migrated.
+- `migrateLocalStorageToFirestore()`: Actively called in `context/DashboardContext.tsx` lines 1065–1089 with proper guard (`!migrated`). Still needed.
+
+Commented-out code (2026-04-16): No blocks of 10+ consecutive commented lines found in components/, context/, hooks/, or utils/.
+
+Dead exports (2026-04-16): All sampled utils/ exports are actively used. No abandoned exports found.
+
+console.log() calls (2026-04-16): Zero `console.log()` calls in components/, context/, hooks/, utils/. Only `console.error()` and `console.warn()` calls exist (by design).
 
 ---
 

--- a/docs/scheduled-tasks/legacy-cleanup.md
+++ b/docs/scheduled-tasks/legacy-cleanup.md
@@ -20,7 +20,7 @@ _Nothing currently in progress._
 
 - **Detected:** 2026-04-16
 - **File:** scripts/tools/ (verify_routines_manager.py, verify_dock_icons.py, verify_routines.py, verify_lunch_count.py, refactor_manager.py, fix_buttons.py, inspect_buttons.py, debug_admin_settings.py, debug_landing.py)
-- **Detail:** The `scripts/tools/` directory contains 9 Python/Playwright scripts. All are either one-off refactoring tasks that have already been executed (refactor*manager.py, fix_buttons.py) or manual test/debug inspection scripts (verify*_.py, inspect\__.py, debug\_\*.py). None are wired into any CI pipeline, build step, or npm script. They provide no automated value and their presence in the repository creates confusion about what testing tools are canonical.
+- **Detail:** The `scripts/tools/` directory contains 9 Python/Playwright scripts. All are either one-off refactoring tasks that have already been executed (refactor*manager.py, fix_buttons.py) or manual test/debug inspection scripts (verify*\_.py, inspect\_\_.py, debug\_\*.py). None are wired into any CI pipeline, build step, or npm script. They provide no automated value and their presence in the repository creates confusion about what testing tools are canonical.
 - **Fix:** Delete `scripts/tools/` directory entirely. Ongoing E2E testing is handled by `tests/e2e/` via Playwright and pnpm test:e2e.
 
 ---

--- a/docs/scheduled-tasks/pr-review-log.md
+++ b/docs/scheduled-tasks/pr-review-log.md
@@ -49,3 +49,22 @@ _Automated nightly review by claude-opus-4-6_
   - PR #1305 head SHA `d38c2270` — CI green across type-check, lint, unit tests, E2E, build, CodeQL, Docker build
   - PR #1285 head SHA `986f7dc6` — unchanged since last review; duplicate review was minimized to a brief refresher to avoid noise
   - No new PRs opened since last run
+
+## 2026-04-16
+
+- PRs reviewed:
+  - #1318 — fix(admin): wire 6 widget building defaults into getAdminBuildingConfig (head `scheduled-tasks`, base `main`)
+  - #1311 — Implement full-screen editor modal and address review feedback (head `dev-paul`, base `main`) — read-only for pushes per branch-safety
+- Comments processed: 4 total — 0 fixed, 4 explained
+  - PR #1318: 1 inline thread (gemini-code-assist style suggestion re: functional array methods) — replied explaining no fix needed (style preference, not correctness issue)
+  - PR #1311: 3 inline threads, all already replied to by OPS-PIvers in prior conversation — no action needed
+- Fixes pushed: none
+  - PR #1318: the one comment was a style preference, not a bug or lint issue
+  - PR #1311: on `dev-paul` (dev-\* branch) — pushes prohibited by branch-safety policy; all comments already addressed by author
+- Reviews posted: 2
+  - PR #1318: Ready with minor notes — clean code following existing patterns, fills genuine gap (dead admin UI for 6 widgets). One open style comment is non-blocking.
+  - PR #1311: Needs changes — large PR (51 files, +4766/-1588) with 3 items to address before merge: (1) verify QuizSession.id semantics change doesn't break consumers, (2) fix DiceWidget Roll button scaling regression, (3) confirm composite Firestore index for allocateJoinCode. Also noted ~1,500 lines of new Quiz Assignment code with no test coverage.
+- Notes:
+  - PR #1318 head SHA `53d22f4c` — mergeable state clean
+  - PR #1311 head SHA `8ead5797` — mergeable state clean; Firestore rules changes are well-secured with proper auth checks and ownership enforcement
+  - PR #1311 has HIGH regression risk around QuizSession.id changing from teacher UID to session UUID

--- a/docs/scheduled-tasks/typescript-eslint.md
+++ b/docs/scheduled-tasks/typescript-eslint.md
@@ -3,7 +3,7 @@
 _Audit model: claude-sonnet-4-6_
 _Action model: claude-opus-4-6_
 _Audit cadence: daily_
-_Last audited: 2026-04-15_
+_Last audited: 2026-04-16_
 _Last action: never_
 
 ---
@@ -16,7 +16,7 @@ _Nothing currently in progress._
 
 ## Open
 
-_No open items. Both `pnpm type-check` and `pnpm lint` pass cleanly as of 2026-04-15. TypeScript: 0 errors. ESLint: 0 errors, 0 warnings (`--max-warnings 0`)._
+_No open items. Both `pnpm type-check` and `pnpm lint` pass cleanly as of 2026-04-16. TypeScript: 0 errors. ESLint: 0 errors, 0 warnings (`--max-warnings 0`)._
 
 ---
 

--- a/docs/scheduled-tasks/widget-registry.md
+++ b/docs/scheduled-tasks/widget-registry.md
@@ -3,7 +3,7 @@
 _Audit model: claude-sonnet-4-6_
 _Action model: claude-opus-4-6_
 _Audit cadence: daily_
-_Last audited: 2026-04-15_
+_Last audited: 2026-04-16_
 _Last action: never_
 
 ---


### PR DESCRIPTION
## Summary

- Adds missing `case` blocks in `getAdminBuildingConfig()` for 6 widgets (`url`, `soundboard`, `schedule`, `embed`, `qr`, `countdown`) that had Building*Defaults interfaces and registered ConfigurationPanels but were never wired into the config application logic
- Admin-configured building defaults for these widgets were being persisted to Firestore but silently ignored when teachers added new widget instances — effectively dead UI

## Test plan

- [ ] Verify `pnpm run validate` passes (type-check, lint, format, tests)
- [ ] As admin, configure building defaults for url, soundboard, schedule, qr, and countdown widgets
- [ ] As teacher in that building, add each widget and confirm admin defaults are applied
- [ ] Verify existing widget types (clock, checklist, drawing, etc.) still apply building defaults correctly

https://claude.ai/code/session_01SnHBGVWoSvrd9LTe1LwmXk