### PR TITLE
fix(auth): force re-login after 7 days of inactivity

### DIFF
--- a/context/AuthContext.tsx
+++ b/context/AuthContext.tsx
@@ -897,7 +897,12 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
         // of stale tokens silently failing to load rosters and Drive data.
         const lastActivity = localStorage.getItem(LAST_ACTIVITY_KEY);
         if (lastActivity) {
-          const elapsed = Date.now() - parseInt(lastActivity, 10);
+          const lastActivityTime = parseInt(lastActivity, 10);
+          // Treat corrupted/unparseable values as stale — safer to force
+          // re-login than to silently skip the inactivity check.
+          const elapsed = Number.isFinite(lastActivityTime)
+            ? Date.now() - lastActivityTime
+            : INACTIVITY_TIMEOUT_MS + 1;
           if (elapsed > INACTIVITY_TIMEOUT_MS) {
             localStorage.removeItem(LAST_ACTIVITY_KEY);
             localStorage.removeItem(GOOGLE_ACCESS_TOKEN_KEY);

--- a/context/AuthContext.tsx
+++ b/context/AuthContext.tsx
@@ -902,17 +902,19 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
             localStorage.removeItem(LAST_ACTIVITY_KEY);
             localStorage.removeItem(GOOGLE_ACCESS_TOKEN_KEY);
             localStorage.removeItem(GOOGLE_TOKEN_EXPIRY_KEY);
+            // Transition UI to signed-out immediately so the login screen
+            // shows without waiting for the async firebaseSignOut round-trip.
+            setUser(null);
+            setGoogleAccessToken(null);
+            rootDocSyncedRef.current = false;
+            setLoading(false);
             void firebaseSignOut(auth).catch((err: unknown) => {
               console.error(
                 '[AuthContext] Error signing out stale session:',
                 err
               );
-              // Force local state to signed-out even if Firebase sign-out fails
-              setUser(null);
-              setGoogleAccessToken(null);
-              setLoading(false);
             });
-            return; // onAuthStateChanged will fire again with user = null
+            return;
           }
         }
         // Session is fresh (or first visit) — record activity
@@ -1140,6 +1142,8 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
     }
     try {
       localStorage.removeItem(LAST_ACTIVITY_KEY);
+      localStorage.removeItem(GOOGLE_ACCESS_TOKEN_KEY);
+      localStorage.removeItem(GOOGLE_TOKEN_EXPIRY_KEY);
       await firebaseSignOut(auth);
       setGoogleAccessToken(null);
     } catch (error) {

--- a/context/AuthContext.tsx
+++ b/context/AuthContext.tsx
@@ -94,6 +94,12 @@ const GOOGLE_TOKEN_CHECK_INTERVAL_MS = 60 * 1000; // How often to poll for expir
 const GOOGLE_TOKEN_REFRESH_THRESHOLD_MS = 10 * 60 * 1000; // Refresh this far before expiry
 const GOOGLE_TOKEN_EXPIRY_BUFFER_MS = 5 * 60 * 1000; // Don't use tokens within 5 min of expiry
 
+// Inactivity-based session timeout: force re-login after 7 days of no app usage
+// so stale Google OAuth tokens (Drive, Calendar, Sheets) get fully refreshed.
+const LAST_ACTIVITY_KEY = 'spart_last_activity';
+const INACTIVITY_TIMEOUT_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
+const ACTIVITY_UPDATE_INTERVAL_MS = 5 * 60 * 1000; // Update activity timestamp every 5 minutes
+
 /**
  * Mock user object for bypass mode.
  * Defined at module level to ensure referential equality.
@@ -883,9 +889,38 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
   useEffect(() => {
     if (isAuthBypass) return;
 
-    const unsubscribe = onAuthStateChanged(auth, (user) => {
-      setUser(user);
-      if (!user) {
+    const unsubscribe = onAuthStateChanged(auth, (firebaseUser) => {
+      if (firebaseUser) {
+        // Check for inactivity timeout — if the user hasn't used the app in
+        // over 7 days, force a full re-login so Google OAuth tokens (Drive,
+        // Calendar, Sheets) are freshly issued. This prevents the common issue
+        // of stale tokens silently failing to load rosters and Drive data.
+        const lastActivity = localStorage.getItem(LAST_ACTIVITY_KEY);
+        if (lastActivity) {
+          const elapsed = Date.now() - parseInt(lastActivity, 10);
+          if (elapsed > INACTIVITY_TIMEOUT_MS) {
+            localStorage.removeItem(LAST_ACTIVITY_KEY);
+            localStorage.removeItem(GOOGLE_ACCESS_TOKEN_KEY);
+            localStorage.removeItem(GOOGLE_TOKEN_EXPIRY_KEY);
+            void firebaseSignOut(auth).catch((err: unknown) => {
+              console.error(
+                '[AuthContext] Error signing out stale session:',
+                err
+              );
+              // Force local state to signed-out even if Firebase sign-out fails
+              setUser(null);
+              setGoogleAccessToken(null);
+              setLoading(false);
+            });
+            return; // onAuthStateChanged will fire again with user = null
+          }
+        }
+        // Session is fresh (or first visit) — record activity
+        localStorage.setItem(LAST_ACTIVITY_KEY, Date.now().toString());
+      }
+
+      setUser(firebaseUser);
+      if (!firebaseUser) {
         setGoogleAccessToken(null);
         rootDocSyncedRef.current = false;
       }
@@ -893,6 +928,40 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
     });
     return unsubscribe;
   }, []);
+
+  // Track user activity so we can detect stale sessions on next load.
+  // Updates a localStorage timestamp every 5 minutes while the app is in use,
+  // and whenever the tab regains visibility.
+  useEffect(() => {
+    if (isAuthBypass || !user) return;
+
+    const updateActivity = () => {
+      localStorage.setItem(LAST_ACTIVITY_KEY, Date.now().toString());
+    };
+
+    // User is active right now
+    updateActivity();
+
+    // Update periodically while the tab is visible
+    const interval = setInterval(() => {
+      if (!document.hidden) {
+        updateActivity();
+      }
+    }, ACTIVITY_UPDATE_INTERVAL_MS);
+
+    // Also update when the tab regains focus
+    const handleVisibilityChange = () => {
+      if (!document.hidden) {
+        updateActivity();
+      }
+    };
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+
+    return () => {
+      clearInterval(interval);
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+    };
+  }, [user]);
 
   // Bypass mode: sign in anonymously so `request.auth.uid` is a real Firebase
   // uid that satisfies Firestore security rules. Wrap the resulting user in a
@@ -1070,6 +1139,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
       return;
     }
     try {
+      localStorage.removeItem(LAST_ACTIVITY_KEY);
       await firebaseSignOut(auth);
       setGoogleAccessToken(null);
     } catch (error) {


### PR DESCRIPTION
## Summary

- Adds inactivity-based session timeout that forces a full re-login after 7 days of no app usage
- Tracks last activity timestamp in localStorage (updated every 5 minutes while app is in use, and on tab visibility changes)
- On app load, checks the timestamp — if >7 days stale, signs the user out of Firebase so they go through the full Google OAuth flow again
- Clears the activity timestamp on explicit sign-out

**Problem:** When users return to SpartBoard after extended absence, Firebase Auth sessions persist indefinitely but Google OAuth tokens (Drive, Calendar, Sheets) are silently stale. The silent GIS refresh can fail if the user's Google session has also expired, resulting in empty rosters, missing Drive data, and other integrations failing with no visible error.

**Solution:** By forcing a re-login after 7 days of inactivity, users get fresh Google OAuth tokens with all scopes, eliminating the stale token problem entirely.

## Test plan

- [ ] Verify normal login/logout flow still works (no regression)
- [ ] Verify `spart_last_activity` is written to localStorage after login
- [ ] Verify the timestamp updates periodically while the app is open
- [ ] Simulate stale session: manually set `spart_last_activity` in localStorage to 8+ days ago, then reload — should be signed out
- [ ] Verify auth bypass mode is unaffected (no inactivity checks)
- [ ] Verify Drive connection works after fresh login

https://claude.ai/code/session_014PQHJfuTxG5CN79cKaUDtc