### PR TITLE
fix(quiz): improve shared assignment UX and navigation

### DIFF
--- a/components/layout/DashboardView.tsx
+++ b/components/layout/DashboardView.tsx
@@ -163,7 +163,7 @@ export const DashboardView: React.FC = () => {
   // Helper: open (or create) a Quiz widget and set its managerTab.
   // Used by pending-share effects to surface the imported content to the user.
   const openQuizWidgetToTab = React.useCallback(
-    (tab: 'library' | 'archive') => {
+    (tab: 'library' | 'active' | 'archive') => {
       const quizWidget = activeDashboard?.widgets.find(
         (w) => w.type === 'quiz'
       );
@@ -233,8 +233,11 @@ export const DashboardView: React.FC = () => {
       return { id: meta.id, driveFileId: meta.driveFileId };
     })
       .then(() => {
-        addToast('Shared assignment imported (paused).', 'success');
-        openQuizWidgetToTab('archive');
+        addToast(
+          'Shared assignment imported! Click Start to begin.',
+          'success'
+        );
+        openQuizWidgetToTab('active');
       })
       .catch((err: unknown) => {
         const msg =

--- a/components/widgets/QuizWidget/Widget.tsx
+++ b/components/widgets/QuizWidget/Widget.tsx
@@ -563,7 +563,13 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
           } else {
             await endQuizSession();
           }
-          setView('manager');
+          updateWidget(widget.id, {
+            config: {
+              ...config,
+              view: 'manager',
+              managerTab: 'archive',
+            } as QuizConfig,
+          });
         }}
         onPause={
           config.activeAssignmentId
@@ -591,6 +597,17 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
         onRemoveStudent={removeStudent}
         onRevealAnswer={revealAnswer}
         onHideAnswer={hideAnswer}
+        onBack={() => {
+          // Navigate back to the In Progress tab without ending the quiz.
+          // The assignment stays active/paused — students are unaffected.
+          updateWidget(widget.id, {
+            config: {
+              ...config,
+              view: 'manager',
+              managerTab: 'active',
+            } as QuizConfig,
+          });
+        }}
       />
     );
   }
@@ -657,6 +674,7 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
               config: {
                 ...config,
                 view: 'monitor',
+                managerTab: 'active',
                 selectedQuizId: meta.id,
                 selectedQuizTitle: meta.title,
                 activeAssignmentId: assignmentId,
@@ -777,6 +795,42 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
           }
           const data = await loadQuiz(meta);
           if (!data) return;
+          updateWidget(widget.id, {
+            config: {
+              ...config,
+              view: 'monitor',
+              selectedQuizId: a.quizId,
+              selectedQuizTitle: a.quizTitle,
+              activeAssignmentId: a.id,
+              activeLiveSessionCode: a.code,
+              periodName: a.periodName ?? '',
+              teacherName: a.teacherName ?? '',
+              plcMode: a.plcMode,
+              plcSheetUrl: a.plcSheetUrl ?? '',
+            } as QuizConfig,
+          });
+        }}
+        onArchiveStart={async (a) => {
+          // Resume the paused assignment, then open the monitor view.
+          const meta = quizzes.find((q) => q.id === a.quizId);
+          if (!meta) {
+            addToast(
+              'Quiz is no longer in your library — cannot start.',
+              'error'
+            );
+            return;
+          }
+          const data = await loadQuiz(meta);
+          if (!data) return;
+          try {
+            await resumeAssignment(a.id);
+          } catch (err) {
+            addToast(
+              err instanceof Error ? err.message : 'Failed to resume',
+              'error'
+            );
+            return;
+          }
           updateWidget(widget.id, {
             config: {
               ...config,

--- a/components/widgets/QuizWidget/components/QuizAssignmentArchive.tsx
+++ b/components/widgets/QuizWidget/components/QuizAssignmentArchive.tsx
@@ -120,6 +120,9 @@ const OverflowMenu: React.FC<OverflowMenuProps> = ({ items }) => {
           height: 'min(28px, 7cqmin)',
         }}
         title="More actions"
+        aria-label="More actions"
+        aria-haspopup="menu"
+        aria-expanded={open}
       >
         <MoreHorizontal
           style={{
@@ -356,9 +359,7 @@ export const QuizAssignmentArchive: React.FC<QuizAssignmentArchiveProps> = ({
           }
 
           // Remove the primary action from the overflow menu to avoid duplication
-          // For paused-active assignments, "Resume" is primary; for active "Monitor" is primary.
-          // We keep "Monitor" in overflow for active cards since primary IS monitor.
-          // Actually, let's just filter out exact duplicates by label:
+          // by filtering out any menu item whose label matches the primary action.
           const filteredMenu = menuItems.filter(
             (m) => m.label !== primaryLabel
           );

--- a/components/widgets/QuizWidget/components/QuizAssignmentArchive.tsx
+++ b/components/widgets/QuizWidget/components/QuizAssignmentArchive.tsx
@@ -1,19 +1,15 @@
 /**
- * QuizAssignmentArchive — teacher's list of past and current quiz assignments.
+ * QuizAssignmentArchive — displays assignment cards in two modes:
  *
- * Each row represents a single assignment (one instance of a quiz being
- * assigned out to students). Actions available per row:
- *   - Copy join URL (if active/paused)
- *   - Monitor (re-opens the live session)
- *   - Results (review responses)
- *   - Edit settings (class label, PLC, session toggles)
- *   - Share (publishes as /share/assignment/{id})
- *   - Pause / Resume toggle
- *   - Make Inactive (kills URL, preserves responses)
- *   - Delete (hard delete, removes responses)
+ * **"active" mode** (In Progress tab): Shows active/paused assignments with
+ * a context-aware primary action (Start / Resume / Monitor) and a compact
+ * overflow menu for secondary actions.
+ *
+ * **"archive" mode** (Archive tab): Shows inactive assignments with muted
+ * styling, primary action = Results, and a smaller overflow menu.
  */
 
-import React, { useState } from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 import {
   Link2,
   Monitor,
@@ -21,21 +17,29 @@ import {
   Settings,
   Share2,
   Pause,
-  Play,
   PowerOff,
   Trash2,
   Calendar,
   Loader2,
   AlertTriangle,
   Inbox,
+  MoreHorizontal,
+  Radio,
+  Rocket,
 } from 'lucide-react';
 import type { QuizAssignment } from '@/types';
+
+/* ─── Props ───────────────────────────────────────────────────────────────── */
 
 interface QuizAssignmentArchiveProps {
   assignments: QuizAssignment[];
   loading: boolean;
+  /** Controls card styling & which primary action to show. */
+  mode: 'active' | 'archive';
   onCopyUrl: (assignment: QuizAssignment) => void;
   onMonitor: (assignment: QuizAssignment) => void;
+  /** Navigate to monitor for a never-started assignment (acts as "Start"). */
+  onStart: (assignment: QuizAssignment) => void;
   onResults: (assignment: QuizAssignment) => void;
   onEditSettings: (assignment: QuizAssignment) => void;
   onShare: (assignment: QuizAssignment) => void;
@@ -44,12 +48,14 @@ interface QuizAssignmentArchiveProps {
   onDelete: (assignment: QuizAssignment) => void;
 }
 
+/* ─── Status styling ──────────────────────────────────────────────────────── */
+
 const STATUS_STYLES: Record<
   QuizAssignment['status'],
   { label: string; bg: string; fg: string; dot: string }
 > = {
   active: {
-    label: 'Active',
+    label: 'Live',
     bg: 'bg-emerald-100',
     fg: 'text-emerald-700',
     dot: 'bg-emerald-500',
@@ -61,9 +67,9 @@ const STATUS_STYLES: Record<
     dot: 'bg-amber-500',
   },
   inactive: {
-    label: 'Inactive',
+    label: 'Ended',
     bg: 'bg-slate-200',
-    fg: 'text-slate-600',
+    fg: 'text-slate-500',
     dot: 'bg-slate-400',
   },
 };
@@ -77,11 +83,96 @@ function formatDate(ts: number): string {
   });
 }
 
+/* ─── Overflow menu (click-outside aware) ─────────────────────────────────── */
+
+interface OverflowMenuProps {
+  items: {
+    label: string;
+    icon: React.ReactNode;
+    onClick: () => void;
+    danger?: boolean;
+    disabled?: boolean;
+  }[];
+}
+
+const OverflowMenu: React.FC<OverflowMenuProps> = ({ items }) => {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const handle = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handle);
+    return () => document.removeEventListener('mousedown', handle);
+  }, [open]);
+
+  return (
+    <div ref={ref} className="relative">
+      <button
+        onClick={() => setOpen((v) => !v)}
+        className="flex items-center justify-center rounded-lg text-brand-blue-dark/60 hover:text-brand-blue-dark hover:bg-brand-blue-lighter/30 transition-colors"
+        style={{
+          width: 'min(28px, 7cqmin)',
+          height: 'min(28px, 7cqmin)',
+        }}
+        title="More actions"
+      >
+        <MoreHorizontal
+          style={{
+            width: 'min(16px, 4cqmin)',
+            height: 'min(16px, 4cqmin)',
+          }}
+        />
+      </button>
+      {open && (
+        <div
+          className="absolute right-0 top-full mt-1 bg-white rounded-lg shadow-lg border border-brand-blue-primary/15 py-1 z-50"
+          style={{
+            minWidth: 'min(160px, 40cqmin)',
+            fontSize: 'min(11px, 3.25cqmin)',
+          }}
+        >
+          {items.map((item) => (
+            <button
+              key={item.label}
+              onClick={() => {
+                setOpen(false);
+                item.onClick();
+              }}
+              disabled={item.disabled}
+              className={`w-full flex items-center text-left font-semibold transition-colors disabled:opacity-40 disabled:cursor-not-allowed ${
+                item.danger
+                  ? 'text-brand-red-dark hover:bg-brand-red-lighter/30'
+                  : 'text-brand-blue-dark hover:bg-brand-blue-lighter/30'
+              }`}
+              style={{
+                gap: 'min(8px, 2cqmin)',
+                padding: 'min(6px, 1.5cqmin) min(12px, 3cqmin)',
+              }}
+            >
+              {item.icon}
+              {item.label}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+/* ─── Main component ──────────────────────────────────────────────────────── */
+
 export const QuizAssignmentArchive: React.FC<QuizAssignmentArchiveProps> = ({
   assignments,
   loading,
+  mode,
   onCopyUrl,
   onMonitor,
+  onStart,
   onResults,
   onEditSettings,
   onShare,
@@ -93,6 +184,8 @@ export const QuizAssignmentArchive: React.FC<QuizAssignmentArchiveProps> = ({
   const [confirmDeactivate, setConfirmDeactivate] = useState<string | null>(
     null
   );
+
+  const isActiveMode = mode === 'active';
 
   if (loading) {
     return (
@@ -125,22 +218,28 @@ export const QuizAssignmentArchive: React.FC<QuizAssignmentArchiveProps> = ({
           className="font-semibold text-brand-blue-dark"
           style={{ fontSize: 'min(14px, 4.5cqmin)' }}
         >
-          No assignments yet
+          {isActiveMode ? 'No quizzes in progress' : 'No archived assignments'}
         </p>
         <p style={{ fontSize: 'min(12px, 3.5cqmin)', maxWidth: 320 }}>
-          When you assign a quiz from the Library, it appears here so you can
-          monitor, review results, or pause/resume it later.
+          {isActiveMode
+            ? 'Assign a quiz from the Library tab to get started. Active and paused assignments appear here.'
+            : 'Ended assignments are moved here so you can review results and share them.'}
         </p>
       </div>
     );
   }
 
+  const iconSize = {
+    width: 'min(12px, 3cqmin)',
+    height: 'min(12px, 3cqmin)',
+  };
+
   return (
     <div
       className="flex-1 overflow-y-auto custom-scrollbar"
-      style={{ padding: 'min(16px, 4cqmin)' }}
+      style={{ padding: 'min(12px, 3cqmin)' }}
     >
-      <div className="flex flex-col" style={{ gap: 'min(10px, 2.5cqmin)' }}>
+      <div className="flex flex-col" style={{ gap: 'min(8px, 2cqmin)' }}>
         {assignments.map((a) => {
           const styles = STATUS_STYLES[a.status];
           const isActive = a.status === 'active';
@@ -150,64 +249,227 @@ export const QuizAssignmentArchive: React.FC<QuizAssignmentArchiveProps> = ({
           const isConfirmingDelete = confirmDelete === a.id;
           const isConfirmingDeactivate = confirmDeactivate === a.id;
 
+          // Determine primary action for the card
+          let primaryLabel: string;
+          let primaryIcon: React.ReactNode;
+          let primaryOnClick: () => void;
+          let primaryClass: string;
+
+          if (isActiveMode) {
+            if (isActive) {
+              primaryLabel = 'Monitor';
+              primaryIcon = <Monitor style={iconSize} />;
+              primaryOnClick = () => onMonitor(a);
+              primaryClass =
+                'bg-brand-blue-primary hover:bg-brand-blue-dark text-white';
+            } else {
+              // Paused — "Start" resumes the assignment and opens the monitor.
+              primaryLabel = 'Start';
+              primaryIcon = <Rocket style={iconSize} />;
+              primaryOnClick = () => onStart(a);
+              primaryClass = 'bg-emerald-600 hover:bg-emerald-700 text-white';
+            }
+          } else {
+            // Archive mode — primary is Results
+            primaryLabel = 'Results';
+            primaryIcon = <BarChart3 style={iconSize} />;
+            primaryOnClick = () => onResults(a);
+            primaryClass =
+              'bg-brand-blue-primary hover:bg-brand-blue-dark text-white';
+          }
+
+          // Build overflow menu items
+          const menuItems: OverflowMenuProps['items'] = [];
+
+          if (isActiveMode) {
+            // In Progress overflow: Copy URL, Results, Settings, Share, Pause (if active), Make Inactive, Delete
+            menuItems.push({
+              label: 'Copy URL',
+              icon: <Link2 style={iconSize} />,
+              onClick: () => onCopyUrl(a),
+              disabled: !urlLive,
+            });
+            if (isActive) {
+              menuItems.push({
+                label: 'Monitor',
+                icon: <Monitor style={iconSize} />,
+                onClick: () => onMonitor(a),
+              });
+            }
+            menuItems.push({
+              label: 'Results',
+              icon: <BarChart3 style={iconSize} />,
+              onClick: () => onResults(a),
+            });
+            menuItems.push({
+              label: 'Settings',
+              icon: <Settings style={iconSize} />,
+              onClick: () => onEditSettings(a),
+            });
+            menuItems.push({
+              label: 'Share',
+              icon: <Share2 style={iconSize} />,
+              onClick: () => onShare(a),
+            });
+            if (isActive) {
+              menuItems.push({
+                label: 'Pause',
+                icon: <Pause style={iconSize} />,
+                onClick: () => onPauseResume(a),
+              });
+            }
+            menuItems.push({
+              label: 'Make Inactive',
+              icon: <PowerOff style={iconSize} />,
+              onClick: () => setConfirmDeactivate(a.id),
+              danger: true,
+            });
+            menuItems.push({
+              label: 'Delete',
+              icon: <Trash2 style={iconSize} />,
+              onClick: () => setConfirmDelete(a.id),
+              danger: true,
+            });
+          } else {
+            // Archive overflow: Monitor (view-only), Settings, Share, Delete
+            menuItems.push({
+              label: 'Monitor',
+              icon: <Monitor style={iconSize} />,
+              onClick: () => onMonitor(a),
+            });
+            menuItems.push({
+              label: 'Settings',
+              icon: <Settings style={iconSize} />,
+              onClick: () => onEditSettings(a),
+            });
+            menuItems.push({
+              label: 'Share',
+              icon: <Share2 style={iconSize} />,
+              onClick: () => onShare(a),
+            });
+            menuItems.push({
+              label: 'Delete',
+              icon: <Trash2 style={iconSize} />,
+              onClick: () => setConfirmDelete(a.id),
+              danger: true,
+            });
+          }
+
+          // Remove the primary action from the overflow menu to avoid duplication
+          // For paused-active assignments, "Resume" is primary; for active "Monitor" is primary.
+          // We keep "Monitor" in overflow for active cards since primary IS monitor.
+          // Actually, let's just filter out exact duplicates by label:
+          const filteredMenu = menuItems.filter(
+            (m) => m.label !== primaryLabel
+          );
+
           return (
             <div
               key={a.id}
-              className="bg-white rounded-xl border border-brand-blue-primary/15 shadow-sm hover:shadow transition-shadow"
-              style={{ padding: 'min(12px, 3cqmin)' }}
+              className={`rounded-xl border shadow-sm transition-shadow ${
+                isInactive
+                  ? 'bg-white/70 border-slate-200/60 opacity-70'
+                  : isActive
+                    ? 'bg-white border-emerald-200/60 hover:shadow-md'
+                    : 'bg-white border-amber-200/60 hover:shadow'
+              }`}
+              style={{ padding: 'min(10px, 2.5cqmin)' }}
             >
-              {/* Row header: title + status pill */}
+              {/* Card header: title + metadata + status + actions */}
               <div
-                className="flex items-start justify-between"
+                className="flex items-center"
                 style={{ gap: 'min(8px, 2cqmin)' }}
               >
+                {/* Live pulse for active assignments */}
+                {isActive && (
+                  <div
+                    className="shrink-0 rounded-full bg-emerald-500 animate-pulse shadow-[0_0_6px_rgba(16,185,129,0.5)]"
+                    style={{
+                      width: 'min(8px, 2cqmin)',
+                      height: 'min(8px, 2cqmin)',
+                    }}
+                  />
+                )}
+                {isPaused && (
+                  <div
+                    className="shrink-0 rounded-full bg-amber-400"
+                    style={{
+                      width: 'min(8px, 2cqmin)',
+                      height: 'min(8px, 2cqmin)',
+                    }}
+                  />
+                )}
+
+                {/* Title + metadata */}
                 <div className="flex-1 min-w-0">
                   <div
-                    className="font-bold text-brand-blue-dark truncate"
-                    style={{ fontSize: 'min(14px, 4.5cqmin)' }}
+                    className={`font-bold truncate ${isInactive ? 'text-slate-500' : 'text-brand-blue-dark'}`}
+                    style={{ fontSize: 'min(13px, 4cqmin)' }}
                   >
                     {a.quizTitle}
                   </div>
                   <div
-                    className="flex items-center text-brand-blue-primary/70 mt-0.5"
+                    className={`flex items-center mt-0.5 ${isInactive ? 'text-slate-400' : 'text-brand-blue-primary/60'}`}
                     style={{
-                      gap: 'min(10px, 2.5cqmin)',
-                      fontSize: 'min(11px, 3.5cqmin)',
+                      gap: 'min(8px, 2cqmin)',
+                      fontSize: 'min(10px, 3cqmin)',
                     }}
                   >
                     {a.className && (
-                      <span className="font-semibold truncate">
+                      <span className="font-semibold truncate max-w-[80px]">
                         {a.className}
                       </span>
                     )}
-                    <span className="flex items-center gap-1">
+                    <span className="flex items-center gap-0.5">
                       <Calendar
                         style={{
-                          width: 'min(11px, 3cqmin)',
-                          height: 'min(11px, 3cqmin)',
+                          width: 'min(10px, 2.5cqmin)',
+                          height: 'min(10px, 2.5cqmin)',
                         }}
                       />
                       {formatDate(a.createdAt)}
                     </span>
-                    <span className="font-mono tracking-wider">{a.code}</span>
+                    {urlLive && (
+                      <span className="font-mono tracking-wider">{a.code}</span>
+                    )}
                   </div>
                 </div>
+
+                {/* Status pill */}
                 <div
-                  className={`flex items-center gap-1.5 rounded-full ${styles.bg} ${styles.fg} font-bold uppercase tracking-wide shrink-0`}
+                  className={`flex items-center gap-1 rounded-full ${styles.bg} ${styles.fg} font-bold uppercase tracking-wide shrink-0`}
                   style={{
-                    padding: 'min(3px, 0.75cqmin) min(10px, 2.5cqmin)',
-                    fontSize: 'min(10px, 2.75cqmin)',
+                    padding: 'min(2px, 0.5cqmin) min(8px, 2cqmin)',
+                    fontSize: 'min(9px, 2.5cqmin)',
                   }}
                 >
-                  <span
-                    className={`rounded-full ${styles.dot}`}
-                    style={{
-                      width: 'min(6px, 1.5cqmin)',
-                      height: 'min(6px, 1.5cqmin)',
-                    }}
-                  />
+                  {isActive && (
+                    <Radio
+                      style={{
+                        width: 'min(9px, 2.25cqmin)',
+                        height: 'min(9px, 2.25cqmin)',
+                      }}
+                    />
+                  )}
                   {styles.label}
                 </div>
+
+                {/* Primary action */}
+                <button
+                  onClick={primaryOnClick}
+                  className={`flex items-center shrink-0 font-bold rounded-lg transition-all active:scale-95 ${primaryClass}`}
+                  style={{
+                    gap: 'min(4px, 1cqmin)',
+                    padding: 'min(5px, 1.25cqmin) min(10px, 2.5cqmin)',
+                    fontSize: 'min(11px, 3.25cqmin)',
+                  }}
+                >
+                  {primaryIcon}
+                  {primaryLabel}
+                </button>
+
+                {/* Overflow menu */}
+                <OverflowMenu items={filteredMenu} />
               </div>
 
               {/* Inline delete confirmation */}
@@ -215,27 +477,30 @@ export const QuizAssignmentArchive: React.FC<QuizAssignmentArchiveProps> = ({
                 <div
                   className="mt-2 flex items-center justify-between bg-brand-red-lighter/40 border border-brand-red-primary/30 rounded-lg"
                   style={{
-                    padding: 'min(8px, 2cqmin) min(10px, 2.5cqmin)',
-                    gap: 'min(8px, 2cqmin)',
+                    padding: 'min(6px, 1.5cqmin) min(10px, 2.5cqmin)',
+                    gap: 'min(6px, 1.5cqmin)',
                   }}
                 >
                   <div
-                    className="flex items-center gap-2 text-brand-red-dark"
-                    style={{ fontSize: 'min(11px, 3.5cqmin)' }}
+                    className="flex items-center gap-1.5 text-brand-red-dark"
+                    style={{ fontSize: 'min(10px, 3cqmin)' }}
                   >
                     <AlertTriangle
                       style={{
-                        width: 'min(14px, 3.5cqmin)',
-                        height: 'min(14px, 3.5cqmin)',
+                        width: 'min(12px, 3cqmin)',
+                        height: 'min(12px, 3cqmin)',
                       }}
                     />
-                    Delete assignment and all student responses?
+                    Delete assignment and all responses?
                   </div>
                   <div className="flex gap-1.5">
                     <button
                       onClick={() => setConfirmDelete(null)}
-                      className="px-2 py-0.5 rounded bg-white text-brand-blue-dark font-semibold border border-brand-blue-primary/20"
-                      style={{ fontSize: 'min(11px, 3.5cqmin)' }}
+                      className="rounded bg-white text-brand-blue-dark font-semibold border border-brand-blue-primary/20"
+                      style={{
+                        padding: 'min(3px, 0.75cqmin) min(8px, 2cqmin)',
+                        fontSize: 'min(10px, 3cqmin)',
+                      }}
                     >
                       Cancel
                     </button>
@@ -244,8 +509,11 @@ export const QuizAssignmentArchive: React.FC<QuizAssignmentArchiveProps> = ({
                         setConfirmDelete(null);
                         onDelete(a);
                       }}
-                      className="px-2 py-0.5 rounded bg-brand-red-primary text-white font-bold"
-                      style={{ fontSize: 'min(11px, 3.5cqmin)' }}
+                      className="rounded bg-brand-red-primary text-white font-bold"
+                      style={{
+                        padding: 'min(3px, 0.75cqmin) min(8px, 2cqmin)',
+                        fontSize: 'min(10px, 3cqmin)',
+                      }}
                     >
                       Delete
                     </button>
@@ -258,18 +526,18 @@ export const QuizAssignmentArchive: React.FC<QuizAssignmentArchiveProps> = ({
                 <div
                   className="mt-2 flex items-center justify-between bg-amber-50 border border-amber-300 rounded-lg"
                   style={{
-                    padding: 'min(8px, 2cqmin) min(10px, 2.5cqmin)',
-                    gap: 'min(8px, 2cqmin)',
+                    padding: 'min(6px, 1.5cqmin) min(10px, 2.5cqmin)',
+                    gap: 'min(6px, 1.5cqmin)',
                   }}
                 >
                   <div
-                    className="flex items-center gap-2 text-amber-900"
-                    style={{ fontSize: 'min(11px, 3.5cqmin)' }}
+                    className="flex items-center gap-1.5 text-amber-900"
+                    style={{ fontSize: 'min(10px, 3cqmin)' }}
                   >
                     <AlertTriangle
                       style={{
-                        width: 'min(14px, 3.5cqmin)',
-                        height: 'min(14px, 3.5cqmin)',
+                        width: 'min(12px, 3cqmin)',
+                        height: 'min(12px, 3cqmin)',
                       }}
                     />
                     The join URL will stop working. Responses are preserved.
@@ -277,8 +545,11 @@ export const QuizAssignmentArchive: React.FC<QuizAssignmentArchiveProps> = ({
                   <div className="flex gap-1.5">
                     <button
                       onClick={() => setConfirmDeactivate(null)}
-                      className="px-2 py-0.5 rounded bg-white text-brand-blue-dark font-semibold border border-brand-blue-primary/20"
-                      style={{ fontSize: 'min(11px, 3.5cqmin)' }}
+                      className="rounded bg-white text-brand-blue-dark font-semibold border border-brand-blue-primary/20"
+                      style={{
+                        padding: 'min(3px, 0.75cqmin) min(8px, 2cqmin)',
+                        fontSize: 'min(10px, 3cqmin)',
+                      }}
                     >
                       Cancel
                     </button>
@@ -287,182 +558,17 @@ export const QuizAssignmentArchive: React.FC<QuizAssignmentArchiveProps> = ({
                         setConfirmDeactivate(null);
                         onDeactivate(a);
                       }}
-                      className="px-2 py-0.5 rounded bg-amber-600 text-white font-bold"
-                      style={{ fontSize: 'min(11px, 3.5cqmin)' }}
+                      className="rounded bg-amber-600 text-white font-bold"
+                      style={{
+                        padding: 'min(3px, 0.75cqmin) min(8px, 2cqmin)',
+                        fontSize: 'min(10px, 3cqmin)',
+                      }}
                     >
                       Make Inactive
                     </button>
                   </div>
                 </div>
               )}
-
-              {/* Action row */}
-              <div
-                className="flex flex-wrap items-center mt-2"
-                style={{ gap: 'min(6px, 1.5cqmin)' }}
-              >
-                <button
-                  onClick={() => onCopyUrl(a)}
-                  disabled={!urlLive}
-                  className="flex items-center gap-1 rounded-lg bg-brand-blue-primary text-white font-bold disabled:opacity-40 disabled:cursor-not-allowed hover:bg-brand-blue-dark transition-colors"
-                  style={{
-                    padding: 'min(5px, 1.25cqmin) min(10px, 2.5cqmin)',
-                    fontSize: 'min(11px, 3.25cqmin)',
-                  }}
-                  title={
-                    urlLive ? 'Copy student join URL' : 'Assignment is inactive'
-                  }
-                >
-                  <Link2
-                    style={{
-                      width: 'min(12px, 3cqmin)',
-                      height: 'min(12px, 3cqmin)',
-                    }}
-                  />
-                  Copy URL
-                </button>
-                <button
-                  onClick={() => onMonitor(a)}
-                  className="flex items-center gap-1 rounded-lg bg-white text-brand-blue-dark font-bold border border-brand-blue-primary/20 hover:bg-brand-blue-lighter/40 transition-colors"
-                  style={{
-                    padding: 'min(5px, 1.25cqmin) min(10px, 2.5cqmin)',
-                    fontSize: 'min(11px, 3.25cqmin)',
-                  }}
-                >
-                  <Monitor
-                    style={{
-                      width: 'min(12px, 3cqmin)',
-                      height: 'min(12px, 3cqmin)',
-                    }}
-                  />
-                  Monitor
-                </button>
-                <button
-                  onClick={() => onResults(a)}
-                  className="flex items-center gap-1 rounded-lg bg-white text-brand-blue-dark font-bold border border-brand-blue-primary/20 hover:bg-brand-blue-lighter/40 transition-colors"
-                  style={{
-                    padding: 'min(5px, 1.25cqmin) min(10px, 2.5cqmin)',
-                    fontSize: 'min(11px, 3.25cqmin)',
-                  }}
-                >
-                  <BarChart3
-                    style={{
-                      width: 'min(12px, 3cqmin)',
-                      height: 'min(12px, 3cqmin)',
-                    }}
-                  />
-                  Results
-                </button>
-                <button
-                  onClick={() => onEditSettings(a)}
-                  className="flex items-center gap-1 rounded-lg bg-white text-brand-blue-dark font-bold border border-brand-blue-primary/20 hover:bg-brand-blue-lighter/40 transition-colors"
-                  style={{
-                    padding: 'min(5px, 1.25cqmin) min(10px, 2.5cqmin)',
-                    fontSize: 'min(11px, 3.25cqmin)',
-                  }}
-                >
-                  <Settings
-                    style={{
-                      width: 'min(12px, 3cqmin)',
-                      height: 'min(12px, 3cqmin)',
-                    }}
-                  />
-                  Settings
-                </button>
-                <button
-                  onClick={() => onShare(a)}
-                  className="flex items-center gap-1 rounded-lg bg-white text-brand-blue-dark font-bold border border-brand-blue-primary/20 hover:bg-brand-blue-lighter/40 transition-colors"
-                  style={{
-                    padding: 'min(5px, 1.25cqmin) min(10px, 2.5cqmin)',
-                    fontSize: 'min(11px, 3.25cqmin)',
-                  }}
-                >
-                  <Share2
-                    style={{
-                      width: 'min(12px, 3cqmin)',
-                      height: 'min(12px, 3cqmin)',
-                    }}
-                  />
-                  Share
-                </button>
-
-                {/* Spacer pushes destructive actions to the right */}
-                <div className="flex-1" />
-
-                {urlLive && (
-                  <button
-                    onClick={() => onPauseResume(a)}
-                    className={`flex items-center gap-1 rounded-lg font-bold transition-colors ${
-                      isPaused
-                        ? 'bg-emerald-600 hover:bg-emerald-700 text-white'
-                        : 'bg-amber-500 hover:bg-amber-600 text-white'
-                    }`}
-                    style={{
-                      padding: 'min(5px, 1.25cqmin) min(10px, 2.5cqmin)',
-                      fontSize: 'min(11px, 3.25cqmin)',
-                    }}
-                  >
-                    {isPaused ? (
-                      <Play
-                        style={{
-                          width: 'min(12px, 3cqmin)',
-                          height: 'min(12px, 3cqmin)',
-                        }}
-                      />
-                    ) : (
-                      <Pause
-                        style={{
-                          width: 'min(12px, 3cqmin)',
-                          height: 'min(12px, 3cqmin)',
-                        }}
-                      />
-                    )}
-                    {isPaused ? 'Resume' : 'Pause'}
-                  </button>
-                )}
-
-                {urlLive && (
-                  <button
-                    onClick={() => setConfirmDeactivate(a.id)}
-                    className="flex items-center gap-1 rounded-lg bg-white text-amber-700 font-bold border border-amber-300 hover:bg-amber-50 transition-colors"
-                    style={{
-                      padding: 'min(5px, 1.25cqmin) min(10px, 2.5cqmin)',
-                      fontSize: 'min(11px, 3.25cqmin)',
-                    }}
-                    title="Kill the join URL. Responses are kept."
-                  >
-                    <PowerOff
-                      style={{
-                        width: 'min(12px, 3cqmin)',
-                        height: 'min(12px, 3cqmin)',
-                      }}
-                    />
-                    Make Inactive
-                  </button>
-                )}
-
-                <button
-                  onClick={() => setConfirmDelete(a.id)}
-                  className="flex items-center gap-1 rounded-lg text-brand-red-dark font-bold border border-brand-red-primary/30 hover:bg-brand-red-lighter/40 transition-colors"
-                  style={{
-                    padding: 'min(5px, 1.25cqmin) min(10px, 2.5cqmin)',
-                    fontSize: 'min(11px, 3.25cqmin)',
-                  }}
-                  title={
-                    isInactive
-                      ? 'Delete assignment and responses'
-                      : 'Delete assignment and all responses'
-                  }
-                >
-                  <Trash2
-                    style={{
-                      width: 'min(12px, 3cqmin)',
-                      height: 'min(12px, 3cqmin)',
-                    }}
-                  />
-                  Delete
-                </button>
-              </div>
             </div>
           );
         })}

--- a/components/widgets/QuizWidget/components/QuizLiveMonitor.tsx
+++ b/components/widgets/QuizWidget/components/QuizLiveMonitor.tsx
@@ -410,6 +410,7 @@ export const QuizLiveMonitor: React.FC<QuizLiveMonitorProps> = ({
                   height: 'min(28px, 7cqmin)',
                 }}
                 title="Back to assignments"
+                aria-label="Back to assignments"
               >
                 <ArrowLeft
                   style={{

--- a/components/widgets/QuizWidget/components/QuizLiveMonitor.tsx
+++ b/components/widgets/QuizWidget/components/QuizLiveMonitor.tsx
@@ -35,6 +35,7 @@ import {
   Medal,
   Pause,
   Play,
+  ArrowLeft,
 } from 'lucide-react';
 import { deleteField, doc, updateDoc } from 'firebase/firestore';
 import {
@@ -81,6 +82,8 @@ interface QuizLiveMonitorProps {
   onRemoveStudent?: (studentUid: string) => Promise<void>;
   onRevealAnswer?: (questionId: string, correctAnswer: string) => Promise<void>;
   onHideAnswer?: (questionId: string) => Promise<void>;
+  /** Navigate back to the manager view without ending the quiz. */
+  onBack?: () => void;
 }
 
 export const QuizLiveMonitor: React.FC<QuizLiveMonitorProps> = ({
@@ -97,6 +100,7 @@ export const QuizLiveMonitor: React.FC<QuizLiveMonitorProps> = ({
   onRemoveStudent,
   onRevealAnswer,
   onHideAnswer,
+  onBack,
 }) => {
   const pinToName = useMemo(
     () => buildPinToNameMap(rosters, config.periodName),
@@ -397,6 +401,24 @@ export const QuizLiveMonitor: React.FC<QuizLiveMonitorProps> = ({
             className="flex items-center"
             style={{ gap: 'min(8px, 2cqmin)' }}
           >
+            {onBack && (
+              <button
+                onClick={onBack}
+                className="flex items-center justify-center rounded-lg text-brand-blue-dark/70 hover:text-brand-blue-dark hover:bg-brand-blue-lighter/30 transition-colors"
+                style={{
+                  width: 'min(28px, 7cqmin)',
+                  height: 'min(28px, 7cqmin)',
+                }}
+                title="Back to assignments"
+              >
+                <ArrowLeft
+                  style={{
+                    width: 'min(16px, 4cqmin)',
+                    height: 'min(16px, 4cqmin)',
+                  }}
+                />
+              </button>
+            )}
             <div
               className="rounded-full bg-brand-red-primary animate-pulse shadow-[0_0_8px_rgba(173,33,34,0.5)]"
               style={{

--- a/components/widgets/QuizWidget/components/QuizManager.tsx
+++ b/components/widgets/QuizWidget/components/QuizManager.tsx
@@ -25,6 +25,7 @@ import {
   ChevronRight,
   Link2,
   Archive as ArchiveIcon,
+  Activity,
 } from 'lucide-react';
 import {
   QuizMetadata,
@@ -64,14 +65,16 @@ interface QuizManagerProps {
   rosters: ClassRoster[];
   config: QuizConfig;
 
-  // ─── Archive tab ───────────────────────────────────────────────────────────
+  // ─── Tabs ───────────────────────────────────────────────────────────────────
   /** Which manager tab is currently active. Defaults to `'library'`. */
-  managerTab?: 'library' | 'archive';
-  onTabChange?: (tab: 'library' | 'archive') => void;
+  managerTab?: 'library' | 'active' | 'archive';
+  onTabChange?: (tab: 'library' | 'active' | 'archive') => void;
   assignments?: QuizAssignment[];
   assignmentsLoading?: boolean;
   onArchiveCopyUrl?: (assignment: QuizAssignment) => void;
   onArchiveMonitor?: (assignment: QuizAssignment) => void;
+  /** Start a paused assignment: resume + navigate to monitor. */
+  onArchiveStart?: (assignment: QuizAssignment) => void;
   onArchiveResults?: (assignment: QuizAssignment) => void;
   onArchiveEditSettings?: (assignment: QuizAssignment) => void;
   onArchiveShare?: (assignment: QuizAssignment) => void;
@@ -100,6 +103,7 @@ export const QuizManager: React.FC<QuizManagerProps> = ({
   assignmentsLoading = false,
   onArchiveCopyUrl,
   onArchiveMonitor,
+  onArchiveStart,
   onArchiveResults,
   onArchiveEditSettings,
   onArchiveShare,
@@ -487,42 +491,65 @@ export const QuizManager: React.FC<QuizManagerProps> = ({
         style={{ padding: 'min(12px, 2.5cqmin) min(16px, 4cqmin)' }}
       >
         <div className="flex items-center" style={{ gap: 'min(8px, 2cqmin)' }}>
-          <div
-            className="bg-brand-blue-primary text-white flex items-center justify-center rounded-lg"
-            style={{ width: 'min(24px, 6cqmin)', height: 'min(24px, 6cqmin)' }}
-          >
-            {managerTab === 'archive' ? (
-              <ArchiveIcon
-                style={{
-                  width: 'min(14px, 3.5cqmin)',
-                  height: 'min(14px, 3.5cqmin)',
-                }}
-              />
-            ) : (
-              <BookOpen
-                style={{
-                  width: 'min(14px, 3.5cqmin)',
-                  height: 'min(14px, 3.5cqmin)',
-                }}
-              />
-            )}
-          </div>
-          <div className="flex flex-col">
-            <span
-              className="font-bold text-brand-blue-dark leading-none"
-              style={{ fontSize: 'min(14px, 4.5cqmin)' }}
-            >
-              {managerTab === 'archive' ? 'Assignment Archive' : 'Quiz Library'}
-            </span>
-            <span
-              className="text-brand-blue-primary/70 font-medium"
-              style={{ fontSize: 'min(11px, 3cqmin)' }}
-            >
-              {managerTab === 'archive'
-                ? `${assignments.length} ${assignments.length === 1 ? 'assignment' : 'assignments'}`
-                : `${quizzes.length} saved ${quizzes.length === 1 ? 'quiz' : 'quizzes'}`}
-            </span>
-          </div>
+          {(() => {
+            const activeAssignments = assignments.filter(
+              (a) => a.status !== 'inactive'
+            );
+            const inactiveAssignments = assignments.filter(
+              (a) => a.status === 'inactive'
+            );
+            const iconStyle = {
+              width: 'min(14px, 3.5cqmin)',
+              height: 'min(14px, 3.5cqmin)',
+            };
+            const headerIcon =
+              managerTab === 'archive' ? (
+                <ArchiveIcon style={iconStyle} />
+              ) : managerTab === 'active' ? (
+                <Activity style={iconStyle} />
+              ) : (
+                <BookOpen style={iconStyle} />
+              );
+            const headerTitle =
+              managerTab === 'archive'
+                ? 'Archive'
+                : managerTab === 'active'
+                  ? 'In Progress'
+                  : 'Quiz Library';
+            const headerSub =
+              managerTab === 'archive'
+                ? `${inactiveAssignments.length} ended`
+                : managerTab === 'active'
+                  ? `${activeAssignments.length} ${activeAssignments.length === 1 ? 'assignment' : 'assignments'}`
+                  : `${quizzes.length} saved ${quizzes.length === 1 ? 'quiz' : 'quizzes'}`;
+            return (
+              <>
+                <div
+                  className="bg-brand-blue-primary text-white flex items-center justify-center rounded-lg"
+                  style={{
+                    width: 'min(24px, 6cqmin)',
+                    height: 'min(24px, 6cqmin)',
+                  }}
+                >
+                  {headerIcon}
+                </div>
+                <div className="flex flex-col">
+                  <span
+                    className="font-bold text-brand-blue-dark leading-none"
+                    style={{ fontSize: 'min(14px, 4.5cqmin)' }}
+                  >
+                    {headerTitle}
+                  </span>
+                  <span
+                    className="text-brand-blue-primary/70 font-medium"
+                    style={{ fontSize: 'min(11px, 3cqmin)' }}
+                  >
+                    {headerSub}
+                  </span>
+                </div>
+              </>
+            );
+          })()}
         </div>
         {managerTab === 'library' && (
           <div
@@ -568,56 +595,125 @@ export const QuizManager: React.FC<QuizManagerProps> = ({
         )}
       </div>
 
-      {/* Tab switcher — Library / Archive */}
-      <div
-        className="flex border-b border-brand-blue-primary/10 bg-brand-blue-lighter/10"
-        style={{
-          padding: 'min(6px, 1.5cqmin) min(12px, 3cqmin) 0',
-          gap: 'min(4px, 1cqmin)',
-        }}
-      >
-        {(['library', 'archive'] as const).map((tab) => (
-          <button
-            key={tab}
-            onClick={() => onTabChange?.(tab)}
-            className={`font-black uppercase tracking-widest rounded-t-xl transition-all flex items-center ${
-              managerTab === tab
-                ? 'bg-white text-brand-blue-primary border-x border-t border-brand-blue-primary/10'
-                : 'text-brand-blue-primary/40 hover:text-brand-blue-primary hover:bg-brand-blue-lighter/30'
-            }`}
-            style={{
-              gap: 'min(6px, 1.5cqmin)',
-              padding: 'min(8px, 2cqmin) min(14px, 3.5cqmin)',
-              fontSize: 'min(10px, 3cqmin)',
-            }}
-          >
-            {tab === 'library' ? (
+      {/* Tab switcher — Library / In Progress / Archive */}
+      {(() => {
+        const activeCount = assignments.filter(
+          (a) => a.status !== 'inactive'
+        ).length;
+        const tabs: {
+          key: 'library' | 'active' | 'archive';
+          label: string;
+          icon: React.ReactNode;
+          badge?: number;
+        }[] = [
+          {
+            key: 'library',
+            label: 'Library',
+            icon: (
               <BookOpen
                 style={{
                   width: 'min(12px, 3cqmin)',
                   height: 'min(12px, 3cqmin)',
                 }}
               />
-            ) : (
+            ),
+          },
+          {
+            key: 'active',
+            label: 'In Progress',
+            icon: (
+              <Activity
+                style={{
+                  width: 'min(12px, 3cqmin)',
+                  height: 'min(12px, 3cqmin)',
+                }}
+              />
+            ),
+            badge: activeCount > 0 ? activeCount : undefined,
+          },
+          {
+            key: 'archive',
+            label: 'Archive',
+            icon: (
               <ArchiveIcon
                 style={{
                   width: 'min(12px, 3cqmin)',
                   height: 'min(12px, 3cqmin)',
                 }}
               />
-            )}
-            {tab}
-          </button>
-        ))}
-      </div>
+            ),
+          },
+        ];
 
-      {/* Archive tab content */}
-      {managerTab === 'archive' && (
+        return (
+          <div
+            className="flex border-b border-brand-blue-primary/10 bg-brand-blue-lighter/10"
+            style={{
+              padding: 'min(6px, 1.5cqmin) min(12px, 3cqmin) 0',
+              gap: 'min(2px, 0.5cqmin)',
+            }}
+          >
+            {tabs.map((tab) => (
+              <button
+                key={tab.key}
+                onClick={() => onTabChange?.(tab.key)}
+                className={`font-black uppercase tracking-widest rounded-t-xl transition-all flex items-center ${
+                  managerTab === tab.key
+                    ? 'bg-white text-brand-blue-primary border-x border-t border-brand-blue-primary/10'
+                    : 'text-brand-blue-primary/40 hover:text-brand-blue-primary hover:bg-brand-blue-lighter/30'
+                }`}
+                style={{
+                  gap: 'min(4px, 1cqmin)',
+                  padding: 'min(7px, 1.75cqmin) min(10px, 2.5cqmin)',
+                  fontSize: 'min(9px, 2.75cqmin)',
+                }}
+              >
+                {tab.icon}
+                {tab.label}
+                {tab.badge != null && (
+                  <span
+                    className="bg-emerald-500 text-white rounded-full font-bold leading-none"
+                    style={{
+                      padding: 'min(1px, 0.25cqmin) min(5px, 1.25cqmin)',
+                      fontSize: 'min(8px, 2.25cqmin)',
+                    }}
+                  >
+                    {tab.badge}
+                  </span>
+                )}
+              </button>
+            ))}
+          </div>
+        );
+      })()}
+
+      {/* In Progress tab content — active/paused assignments */}
+      {managerTab === 'active' && (
         <QuizAssignmentArchive
-          assignments={assignments}
+          assignments={assignments.filter((a) => a.status !== 'inactive')}
           loading={assignmentsLoading}
+          mode="active"
           onCopyUrl={onArchiveCopyUrl ?? noop}
           onMonitor={onArchiveMonitor ?? noop}
+          onStart={onArchiveStart ?? noop}
+          onResults={onArchiveResults ?? noop}
+          onEditSettings={onArchiveEditSettings ?? noop}
+          onShare={onArchiveShare ?? noop}
+          onPauseResume={onArchivePauseResume ?? noop}
+          onDeactivate={onArchiveDeactivate ?? noop}
+          onDelete={onArchiveDelete ?? noop}
+        />
+      )}
+
+      {/* Archive tab content — inactive assignments */}
+      {managerTab === 'archive' && (
+        <QuizAssignmentArchive
+          assignments={assignments.filter((a) => a.status === 'inactive')}
+          loading={assignmentsLoading}
+          mode="archive"
+          onCopyUrl={onArchiveCopyUrl ?? noop}
+          onMonitor={onArchiveMonitor ?? noop}
+          onStart={onArchiveStart ?? noop}
           onResults={onArchiveResults ?? noop}
           onEditSettings={onArchiveEditSettings ?? noop}
           onShare={onArchiveShare ?? noop}

--- a/types.ts
+++ b/types.ts
@@ -1662,8 +1662,8 @@ export interface QuizGlobalConfig {
 /** Widget configuration for the quiz widget (teacher side) */
 export interface QuizConfig {
   view: 'manager' | 'import' | 'editor' | 'preview' | 'results' | 'monitor';
-  /** Tab within the manager view (library of saved quizzes vs archive of past assignments). */
-  managerTab?: 'library' | 'archive';
+  /** Tab within the manager view: library of saved quizzes, in-progress assignments, or archived (inactive) assignments. */
+  managerTab?: 'library' | 'active' | 'archive';
   selectedQuizId: string | null;
   selectedQuizTitle: string | null;
   /** Assignment currently opened in monitor/results views. */


### PR DESCRIPTION
## Summary

- **3-tab layout**: Splits the old 2-tab manager into Library | In Progress | Archive — active/paused assignments live in "In Progress", inactive (ended) assignments in "Archive"
- **Back button in monitor**: Teachers can now return to the assignment list without ending the quiz — the assignment stays active and students are unaffected
- **Context-aware primary actions**: "Start" on paused assignments (resumes + opens monitor in one click), "Monitor" on active, "Results" on archived — no more confusing Resume → Monitor two-step
- **Overflow menu**: Secondary actions (Settings, Share, Copy URL, Make Inactive, Delete) collapsed into a `...` menu to reduce button clutter
- **Shared assignment imports**: Now land on the "In Progress" tab with a clear "Start" button instead of being buried in the archive

## Test plan

- [ ] Create a quiz and assign it — verify it opens monitor and "In Progress" tab has the assignment when you click back
- [ ] From monitor, click the back arrow — verify quiz stays active for students, card shows "Live" with pulsing indicator
- [ ] Share an assignment URL to another account — verify the import lands on "In Progress" tab with "Start" button
- [ ] Click "Start" on a paused imported assignment — verify it resumes and opens monitor in one click
- [ ] Click "End" in monitor — verify it navigates to the Archive tab with the ended assignment
- [ ] Verify overflow menu works: Settings, Share, Copy URL, Make Inactive, Delete all functional
- [ ] Verify inactive assignments in Archive tab appear muted/de-emphasized
- [ ] Check that the "In Progress" tab badge shows the correct count of active assignments

https://claude.ai/code/session_01BS8YtkL9FLH7RVCvcaZuCa