### PR TITLE
fix(text-widget): stop spellCheck toggle from collapsing drag-selection

### DIFF
--- a/components/widgets/TextWidget/Widget.tsx
+++ b/components/widgets/TextWidget/Widget.tsx
@@ -318,7 +318,7 @@ export const TextWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
                   data-placeholder={PLACEHOLDER_TEXT}
                   contentEditable
                   suppressContentEditableWarning
-                  spellCheck={isSelected}
+                  spellCheck={true}
                   onFocus={handleFocus}
                   onBlur={handleBlur}
                   onInput={handleInput}


### PR DESCRIPTION
## Summary

- Fixes multi-paragraph drag-highlight in the Text widget. Previously, dragging the cursor across new lines collapsed the selection to only the final paragraph — the reported bug.
- Root cause: `spellCheck={isSelected}` flipped `false → true` on the first focus. Chromium rebuilds internal text-node state when the `spellCheck` attribute changes on an actively-focused contentEditable, which collapses any in-progress selection to the current anchor.
- Fix: render `spellCheck={true}` as a stable value so the attribute never changes during an active focus/drag. Single-line change in `components/widgets/TextWidget/Widget.tsx:321`.
- Prior fixes from `ecf9c12` (skip focus-stealing on contentEditable, `select-text` override) remain in place and are still required.

The only UX trade-off is that spellcheck squiggles now appear whenever the widget contains text, not just when it's selected — consistent with how spellcheck works in Slack, Notion, Google Docs, etc.

## Test plan

- [ ] `pnpm run dev` and open a dashboard with a Text widget
- [ ] Type three paragraphs separated by Enter
- [ ] Click another widget to deselect the Text widget
- [ ] Click inside paragraph 1 and drag the cursor down to paragraph 3 — selection should span all three paragraphs continuously (previously: only paragraph 3 was highlighted)
- [ ] Repeat starting the drag on an already-selected Text widget
- [ ] Apply bullet list, font color, and font size to the multi-paragraph selection via the floating toolbar — each command applies to the full range
- [ ] Ctrl+A, shift-click, double/triple-click still work
- [ ] `pnpm run validate` passes (type-check + lint + format + tests)

https://claude.ai/code/session_013CAAMJ5LkWbTxMXKnw3oxP