### PR TITLE
refactor(seating-chart): use ScaledEmptyState for empty states

### DIFF
--- a/components/widgets/SeatingChart/Widget.tsx
+++ b/components/widgets/SeatingChart/Widget.tsx
@@ -28,6 +28,7 @@ import {
 } from './constants';
 import { useDialog } from '@/context/useDialog';
 import { shuffleArray, getRandomInt } from '@/utils/randomHelpers';
+import { ScaledEmptyState } from '@/components/common/ScaledEmptyState';
 
 // Drag state tracks current positions for all items being dragged simultaneously
 type DragPositions = Map<string, { x: number; y: number }>;
@@ -956,28 +957,32 @@ export const SeatingChartWidget: React.FC<{ widget: WidgetData }> = ({
           })}
 
           {furniture.length === 0 && mode !== 'setup' && (
-            <div className="absolute inset-0 flex flex-col items-center justify-center text-slate-400 pointer-events-none">
-              <LayoutGrid className="w-12 h-12 opacity-20 mb-2" />
-              <p className="text-sm font-bold uppercase tracking-widest">
-                Empty Classroom
-              </p>
-              <p className="text-xs">
-                Switch to &quot;Setup&quot; to arrange furniture.
-              </p>
+            <div
+              data-testid="seating-chart-empty-assign"
+              className="absolute inset-0 pointer-events-none"
+            >
+              <ScaledEmptyState
+                icon={LayoutGrid}
+                title="Empty Classroom"
+                subtitle='Switch to "Setup" to arrange furniture.'
+              />
             </div>
           )}
 
           {furniture.length === 0 && mode === 'setup' && (
-            <div className="absolute inset-0 flex flex-col items-center justify-center text-slate-400 pointer-events-none">
-              <LayoutTemplate className="w-12 h-12 opacity-20 mb-2" />
-              <p className="text-sm font-bold uppercase tracking-widest">
-                No Furniture
-              </p>
-              <p className="text-xs">
-                {template === 'freeform'
-                  ? t('widgets.seatingChart.emptyStateFreeform')
-                  : t('widgets.seatingChart.emptyStateTemplate')}
-              </p>
+            <div
+              data-testid="seating-chart-empty-setup"
+              className="absolute inset-0 pointer-events-none"
+            >
+              <ScaledEmptyState
+                icon={LayoutTemplate}
+                title="No Furniture"
+                subtitle={
+                  template === 'freeform'
+                    ? t('widgets.seatingChart.emptyStateFreeform')
+                    : t('widgets.seatingChart.emptyStateTemplate')
+                }
+              />
             </div>
           )}
         </div>

--- a/components/widgets/SeatingChart/Widget.tsx
+++ b/components/widgets/SeatingChart/Widget.tsx
@@ -963,8 +963,8 @@ export const SeatingChartWidget: React.FC<{ widget: WidgetData }> = ({
             >
               <ScaledEmptyState
                 icon={LayoutGrid}
-                title="Empty Classroom"
-                subtitle='Switch to "Setup" to arrange furniture.'
+                title={t('widgets.seatingChart.emptyStateAssignTitle')}
+                subtitle={t('widgets.seatingChart.emptyStateAssignSubtitle')}
               />
             </div>
           )}
@@ -976,7 +976,7 @@ export const SeatingChartWidget: React.FC<{ widget: WidgetData }> = ({
             >
               <ScaledEmptyState
                 icon={LayoutTemplate}
-                title="No Furniture"
+                title={t('widgets.seatingChart.emptyStateSetupTitle')}
                 subtitle={
                   template === 'freeform'
                     ? t('widgets.seatingChart.emptyStateFreeform')

--- a/locales/en.json
+++ b/locales/en.json
@@ -282,6 +282,9 @@
       }
     },
     "seatingChart": {
+      "emptyStateAssignTitle": "Empty Classroom",
+      "emptyStateAssignSubtitle": "Switch to \"Setup\" to arrange furniture.",
+      "emptyStateSetupTitle": "No Furniture",
       "emptyStateFreeform": "Add furniture from the sidebar.",
       "emptyStateTemplate": "Pick a template and click Apply Layout."
     },

--- a/tests/components/widgets/SeatingChart.test.tsx
+++ b/tests/components/widgets/SeatingChart.test.tsx
@@ -1,0 +1,164 @@
+import React from 'react';
+import { render, screen, fireEvent, within } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { WidgetData, SeatingChartConfig } from '@/types';
+
+const mockUpdateWidget = vi.fn();
+
+vi.mock('@/context/useDashboard', () => ({
+  useDashboard: () => ({
+    updateWidget: mockUpdateWidget,
+    rosters: [],
+    activeRosterId: null,
+    addToast: vi.fn(),
+    activeDashboard: { widgets: [] },
+  }),
+}));
+
+// Mock heavy sub-components so the test is hermetic and fast. The toolbar mock
+// exposes the `setMode` callback via buttons so tests can toggle the widget
+// between assign/setup modes and verify the correct empty state renders.
+vi.mock('@/components/widgets/SeatingChart/SeatingChartToolbar', () => ({
+  SeatingChartToolbar: ({
+    setMode,
+  }: {
+    setMode: (mode: 'setup' | 'assign' | 'interact') => void;
+  }) => (
+    <div data-testid="toolbar-mock">
+      <button onClick={() => setMode('setup')}>set-setup</button>
+      <button onClick={() => setMode('assign')}>set-assign</button>
+      <button onClick={() => setMode('interact')}>set-interact</button>
+    </div>
+  ),
+}));
+
+vi.mock('@/components/widgets/SeatingChart/SeatingChartSidebar', () => ({
+  SeatingChartSidebar: () => <div data-testid="sidebar-mock" />,
+}));
+
+vi.mock('@/components/widgets/SeatingChart/FurnitureItemRenderer', () => ({
+  FurnitureItemRenderer: ({ item }: { item: { id: string } }) => (
+    <div data-testid={`furniture-${item.id}`} />
+  ),
+}));
+
+import { SeatingChartWidget } from '@/components/widgets/SeatingChart/Widget';
+
+const makeWidget = (
+  overrides: Partial<SeatingChartConfig> = {}
+): WidgetData => ({
+  id: 'seating-1',
+  type: 'seating-chart',
+  x: 0,
+  y: 0,
+  w: 600,
+  h: 500,
+  z: 1,
+  flipped: false,
+  config: {
+    furniture: [],
+    assignments: {},
+    gridSize: 20,
+    template: 'freeform',
+    ...overrides,
+  } as SeatingChartConfig,
+});
+
+describe('SeatingChartWidget empty states', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders the "Empty Classroom" empty state in non-setup mode (default: interact)', () => {
+    render(<SeatingChartWidget widget={makeWidget()} />);
+    const emptyState = screen.getByTestId('seating-chart-empty-assign');
+    expect(within(emptyState).getByText('Empty Classroom')).toBeInTheDocument();
+    expect(
+      within(emptyState).getByText('Switch to "Setup" to arrange furniture.')
+    ).toBeInTheDocument();
+    // The setup empty state must NOT be present in non-setup mode.
+    expect(
+      screen.queryByTestId('seating-chart-empty-setup')
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders the freeform "No Furniture" empty state in setup mode when template is freeform', () => {
+    render(
+      <SeatingChartWidget widget={makeWidget({ template: 'freeform' })} />
+    );
+    fireEvent.click(screen.getByText('set-setup'));
+
+    const emptyState = screen.getByTestId('seating-chart-empty-setup');
+    expect(within(emptyState).getByText('No Furniture')).toBeInTheDocument();
+    // i18n subtitle for freeform template comes from
+    // widgets.seatingChart.emptyStateFreeform.
+    expect(
+      within(emptyState).getByText('Add furniture from the sidebar.')
+    ).toBeInTheDocument();
+    // The non-setup empty state must NOT render at the same time.
+    expect(
+      screen.queryByTestId('seating-chart-empty-assign')
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders the templated "No Furniture" subtitle when template is not freeform', () => {
+    render(<SeatingChartWidget widget={makeWidget({ template: 'rows' })} />);
+    fireEvent.click(screen.getByText('set-setup'));
+
+    const emptyState = screen.getByTestId('seating-chart-empty-setup');
+    expect(within(emptyState).getByText('No Furniture')).toBeInTheDocument();
+    // Template-flavored subtitle from widgets.seatingChart.emptyStateTemplate.
+    expect(
+      within(emptyState).getByText('Pick a template and click Apply Layout.')
+    ).toBeInTheDocument();
+  });
+
+  it('does NOT render either empty state when furniture exists', () => {
+    const widgetWithFurniture = makeWidget({
+      furniture: [
+        {
+          id: 'desk-1',
+          type: 'desk' as const,
+          x: 10,
+          y: 10,
+          width: 60,
+          height: 40,
+          rotation: 0,
+        },
+      ],
+    });
+    render(<SeatingChartWidget widget={widgetWithFurniture} />);
+
+    expect(
+      screen.queryByTestId('seating-chart-empty-assign')
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId('seating-chart-empty-setup')
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText('Empty Classroom')).not.toBeInTheDocument();
+    expect(screen.queryByText('No Furniture')).not.toBeInTheDocument();
+  });
+
+  it('empty-state wrapper is pointer-events-none so it does not block canvas interaction', () => {
+    render(<SeatingChartWidget widget={makeWidget()} />);
+    const emptyState = screen.getByTestId('seating-chart-empty-assign');
+    expect(emptyState).toHaveClass('pointer-events-none');
+  });
+
+  it('uses the ScaledEmptyState primitive (no legacy hardcoded size classes on the text nodes)', () => {
+    render(<SeatingChartWidget widget={makeWidget()} />);
+    const title = screen.getByText('Empty Classroom');
+    const subtitle = screen.getByText(
+      'Switch to "Setup" to arrange furniture.'
+    );
+
+    // Guard against the hand-rolled pattern sneaking back in. The old empty
+    // state put `text-sm` on the title and `text-xs` on the subtitle; the
+    // ScaledEmptyState primitive uses inline cqmin font sizing instead.
+    expect(title).not.toHaveClass('text-sm');
+    expect(subtitle).not.toHaveClass('text-xs');
+
+    // ScaledEmptyState emits uppercase/tracked title styling.
+    expect(title).toHaveClass('uppercase', 'tracking-widest');
+  });
+});


### PR DESCRIPTION
## Summary

- Replace the two hand-rolled empty states in the SeatingChart widget (`components/widgets/SeatingChart/Widget.tsx`) with the shared `ScaledEmptyState` primitive.
- The previous empty states used hardcoded Tailwind size classes (`w-12 h-12`, `text-sm`, `text-xs`) that violate the container-query scaling standard documented in `CLAUDE.md` and produced inconsistent styling vs. the other 15+ widgets already using `ScaledEmptyState`.
- Existing i18n keys (`widgets.seatingChart.emptyStateFreeform` / `emptyStateTemplate`), icons (`LayoutGrid`, `LayoutTemplate`), and the `pointer-events-none` overlay behavior are preserved exactly.
- Add a focused test suite for the SeatingChart empty states (6 cases).

## Why

Low-burden, high-reward polish. SeatingChart is one of the most visible widgets (default 600×500) and the fix is a pure find-and-replace onto an already-tested primitive — no new component design, no API surface changes, no data-flow changes.

## Test plan

- [x] `pnpm run type-check` — clean
- [x] `pnpm run lint` — zero errors, zero warnings
- [x] `pnpm run format:check` — clean
- [x] `pnpm run test tests/components/widgets/SeatingChart.test.tsx` — 6/6 pass
- [x] `pnpm run test` — full unit suite green (1183/1183 across 132 files)
- [ ] Manual smoke: add SeatingChart widget, toggle between Assign / Setup modes, resize small, confirm empty states scale and canvas still receives clicks (empty-state overlay is `pointer-events-none`)

### New test coverage (tests/components/widgets/SeatingChart.test.tsx)

1. Renders the `"Empty Classroom"` empty state in the default (non-setup) mode.
2. Renders the `"No Furniture"` + freeform subtitle in setup mode with `template: 'freeform'`.
3. Renders the `"No Furniture"` + template subtitle in setup mode with `template: 'rows'`.
4. Renders neither empty state when the `furniture` array is non-empty.
5. Empty-state overlay has `pointer-events-none` so it never blocks canvas interactions.
6. Guard test: title/subtitle nodes are NOT decorated with the legacy `text-sm`/`text-xs` classes, and the `ScaledEmptyState` shape (`uppercase tracking-widest` title) is present. Prevents the hand-rolled pattern from re-entering the file.

https://claude.ai/code/session_01Q8p3Cz7Jgbnpw1HgBu1atx