### PR TITLE
feat: expose AI generation inside unified editor modals

### DIFF
--- a/components/common/DriveFileAttachment.tsx
+++ b/components/common/DriveFileAttachment.tsx
@@ -10,6 +10,8 @@ interface DriveFileAttachmentProps {
   onFileContent: (content: string | null, fileName: string | null) => void;
   /** Disable the attachment button (e.g. while generating). */
   disabled?: boolean;
+  /** Notified when extraction starts/stops so callers can gate Generate. */
+  onExtractingChange?: (extracting: boolean) => void;
   className?: string;
 }
 
@@ -23,6 +25,7 @@ interface DriveFileAttachmentProps {
 export const DriveFileAttachment: React.FC<DriveFileAttachmentProps> = ({
   onFileContent,
   disabled = false,
+  onExtractingChange,
   className = '',
 }) => {
   const { openPicker, isConnected } = useGooglePicker();
@@ -46,6 +49,10 @@ export const DriveFileAttachment: React.FC<DriveFileAttachmentProps> = ({
   useEffect(() => {
     onFileContentRef.current = onFileContent;
   }, [onFileContent]);
+
+  useEffect(() => {
+    onExtractingChange?.(isExtracting);
+  }, [isExtracting, onExtractingChange]);
 
   useEffect(() => {
     return () => {

--- a/components/widgets/GuidedLearning/Widget.tsx
+++ b/components/widgets/GuidedLearning/Widget.tsx
@@ -304,6 +304,10 @@ export const GuidedLearningWidget: React.FC<{ widget: WidgetData }> = ({
           setEditingMeta(null);
         }}
         onSave={handleSave}
+        onAiGenerated={(generated) => {
+          setEditingSet({ ...generated, isBuilding: true });
+          setEditingMeta(null);
+        }}
       />
     </>
   );

--- a/components/widgets/GuidedLearning/components/GuidedLearningAIGenerator.tsx
+++ b/components/widgets/GuidedLearning/components/GuidedLearningAIGenerator.tsx
@@ -43,13 +43,22 @@ export const GuidedLearningAIGenerator: React.FC<Props> = ({
       try {
         const url = await uploadHotspotImage(user.uid, file);
         setImageUrl(url);
-      } catch {
-        setError(
-          'Image upload failed. Please check your connection and try again.'
-        );
+      } catch (err) {
+        const msg =
+          err instanceof Error
+            ? err.message
+            : 'Image upload failed. Please check your connection and try again.';
+        setError(msg);
         setImageBase64('');
         setImageMimeType('');
       }
+    };
+    reader.onerror = () => {
+      setError(
+        'Could not read the selected file. Try a different image (JPEG or PNG).'
+      );
+      setImageBase64('');
+      setImageMimeType('');
     };
     reader.readAsDataURL(file);
   };

--- a/components/widgets/GuidedLearning/components/GuidedLearningEditorModal.tsx
+++ b/components/widgets/GuidedLearning/components/GuidedLearningEditorModal.tsx
@@ -7,6 +7,7 @@
  */
 
 import React, { useCallback, useMemo, useState } from 'react';
+import { Wand2 } from 'lucide-react';
 import {
   GuidedLearningMode,
   GuidedLearningQuestion,
@@ -15,10 +16,12 @@ import {
   GuidedLearningStep,
 } from '@/types';
 import { EditorModalShell } from '@/components/common/EditorModalShell';
+import { useAuth } from '@/context/useAuth';
 import {
   GuidedLearningEditor,
   GuidedLearningEditorState,
 } from './GuidedLearningEditor';
+import { GuidedLearningAIGenerator } from './GuidedLearningAIGenerator';
 
 interface GuidedLearningEditorModalProps {
   isOpen: boolean;
@@ -26,6 +29,13 @@ interface GuidedLearningEditorModalProps {
   meta: GuidedLearningSetMetadata | null;
   onClose: () => void;
   onSave: (set: GuidedLearningSet, driveFileId?: string) => Promise<void>;
+  /**
+   * When provided, shows a "Generate with AI" button inside the modal (admin +
+   * `gemini-functions` gated). Invoked with the generated set so the parent
+   * can replace the in-flight draft (the editor resets when its `set` prop
+   * identity changes).
+   */
+  onAiGenerated?: (set: GuidedLearningSet) => void;
 }
 
 // ─── Deep equality helpers ──────────────────────────────────────────────────
@@ -99,12 +109,17 @@ function stepsEqual(a: GuidedLearningStep[], b: GuidedLearningStep[]): boolean {
 
 export const GuidedLearningEditorModal: React.FC<
   GuidedLearningEditorModalProps
-> = ({ isOpen, set, meta, onClose, onSave }) => {
+> = ({ isOpen, set, meta, onClose, onSave, onAiGenerated }) => {
+  const { isAdmin, canAccessFeature } = useAuth();
   // Track live state from the headless editor via onStateChange callback
   const [liveState, setLiveState] = useState<GuidedLearningEditorState | null>(
     null
   );
   const [saving, setSaving] = useState(false);
+  const [showAiGen, setShowAiGen] = useState(false);
+
+  const canUseAi =
+    !!onAiGenerated && isAdmin === true && canAccessFeature('gemini-functions');
 
   // Snapshot originals when `set` identity changes
   const originalTitle = set?.title ?? '';
@@ -125,6 +140,7 @@ export const GuidedLearningEditorModal: React.FC<
     setPrevSet(set);
     setLiveState(null);
     setSaving(false);
+    setShowAiGen(false);
   }
 
   // Stable callback for the editor
@@ -205,9 +221,21 @@ export const GuidedLearningEditorModal: React.FC<
         liveState.imageUrls.length === 0 ||
         liveState.uploading
       }
+      footerExtras={
+        canUseAi ? (
+          <button
+            onClick={() => setShowAiGen(true)}
+            className="h-[36px] px-3 bg-gradient-to-br from-indigo-500 to-purple-600 hover:from-indigo-600 hover:to-purple-700 text-white rounded-xl font-black text-xs uppercase tracking-widest shadow-md shadow-indigo-200 transition-all flex items-center gap-2 active:scale-95"
+            title="Generate with AI (Admin)"
+          >
+            <Wand2 className="w-4 h-4" />
+            Magic
+          </button>
+        ) : null
+      }
       maxWidth="max-w-6xl"
       className="h-[90vh]"
-      bodyClassName="p-0"
+      bodyClassName="p-0 relative"
     >
       {set && (
         <GuidedLearningEditor
@@ -218,6 +246,15 @@ export const GuidedLearningEditorModal: React.FC<
           saving={saving}
           headless
           onStateChange={handleStateChange}
+        />
+      )}
+      {showAiGen && canUseAi && (
+        <GuidedLearningAIGenerator
+          onClose={() => setShowAiGen(false)}
+          onGenerated={(generated) => {
+            setShowAiGen(false);
+            onAiGenerated?.(generated);
+          }}
         />
       )}
     </EditorModalShell>

--- a/components/widgets/GuidedLearning/components/GuidedLearningEditorModal.tsx
+++ b/components/widgets/GuidedLearning/components/GuidedLearningEditorModal.tsx
@@ -239,6 +239,7 @@ export const GuidedLearningEditorModal: React.FC<
     >
       {set && (
         <GuidedLearningEditor
+          key={set.id}
           existingSet={set}
           existingMeta={meta}
           onSave={onSave}

--- a/components/widgets/QuizWidget/components/QuizEditorModal.tsx
+++ b/components/widgets/QuizWidget/components/QuizEditorModal.tsx
@@ -5,17 +5,27 @@
  * editors (Video Activity, Guided Learning, MiniApp).
  */
 
-import React, { useMemo, useState } from 'react';
+import React, { useMemo, useRef, useState } from 'react';
 import {
   AlertCircle,
   ChevronDown,
   ChevronUp,
   GripVertical,
+  Loader2,
   Plus,
+  Sparkles,
   Trash2,
+  X,
 } from 'lucide-react';
 import { QuizData, QuizQuestion, QuizQuestionType } from '@/types';
 import { EditorModalShell } from '@/components/common/EditorModalShell';
+import { useAuth } from '@/context/useAuth';
+import {
+  GeneratedQuestion,
+  buildPromptWithFileContext,
+  generateQuiz,
+} from '@/utils/ai';
+import { DriveFileAttachment } from '@/components/common/DriveFileAttachment';
 
 interface QuizEditorModalProps {
   isOpen: boolean;
@@ -89,6 +99,7 @@ export const QuizEditorModal: React.FC<QuizEditorModalProps> = ({
   onClose,
   onSave,
 }) => {
+  const { canAccessFeature } = useAuth();
   // Snapshot the quiz when the modal opens so `isDirty` compares against the
   // original. When the `quiz` prop identity changes, local state is reset via
   // the "adjusting state while rendering" block below — no `key` prop needed.
@@ -105,6 +116,14 @@ export const QuizEditorModal: React.FC<QuizEditorModalProps> = ({
     originalQuestions[0]?.id ?? null
   );
 
+  const [showAiPrompt, setShowAiPrompt] = useState(false);
+  const [aiPrompt, setAiPrompt] = useState('');
+  const [aiGenerating, setAiGenerating] = useState(false);
+  const [aiError, setAiError] = useState<string | null>(null);
+  const [aiFileContext, setAiFileContext] = useState<string | null>(null);
+  const [aiFileName, setAiFileName] = useState<string | null>(null);
+  const aiOverlayRef = useRef<HTMLDivElement>(null);
+
   // Reset local state when the `quiz` prop identity changes (new quiz loaded).
   const [prevQuiz, setPrevQuiz] = useState<QuizData | null>(quiz);
   if (quiz !== prevQuiz) {
@@ -114,7 +133,65 @@ export const QuizEditorModal: React.FC<QuizEditorModalProps> = ({
     setError(null);
     setSaving(false);
     setExpandedId(originalQuestions[0]?.id ?? null);
+    setShowAiPrompt(false);
+    setAiPrompt('');
+    setAiGenerating(false);
+    setAiError(null);
+    setAiFileContext(null);
+    setAiFileName(null);
   }
+
+  const aiEnabled = canAccessFeature('gemini-functions');
+
+  const handleAiGenerate = async () => {
+    if (!aiPrompt.trim()) return;
+    setAiGenerating(true);
+    setAiError(null);
+    try {
+      const fullPrompt = buildPromptWithFileContext(
+        aiPrompt,
+        aiFileContext,
+        aiFileName
+      );
+      const result = await generateQuiz(fullPrompt);
+      const validTypes: QuizQuestionType[] = [
+        'MC',
+        'FIB',
+        'Matching',
+        'Ordering',
+      ];
+      const generated: QuizQuestion[] = result.questions.map(
+        (q: GeneratedQuestion) => {
+          const type = validTypes.includes((q.type ?? 'MC') as QuizQuestionType)
+            ? ((q.type as QuizQuestionType) ?? 'MC')
+            : 'MC';
+          return {
+            id: crypto.randomUUID(),
+            text: q.text,
+            timeLimit: q.timeLimit ?? 30,
+            type,
+            correctAnswer: q.correctAnswer ?? '',
+            incorrectAnswers: q.incorrectAnswers ?? [],
+          };
+        }
+      );
+      if (!title.trim() && result.title) setTitle(result.title);
+      setQuestions((prev) => [...prev, ...generated]);
+      if (generated[0]) setExpandedId(generated[0].id);
+      setShowAiPrompt(false);
+      setAiPrompt('');
+      setAiFileContext(null);
+      setAiFileName(null);
+    } catch (err) {
+      setAiError(
+        err instanceof Error
+          ? err.message
+          : 'Failed to generate quiz. Please try again.'
+      );
+    } finally {
+      setAiGenerating(false);
+    }
+  };
 
   const isDirty = useMemo(
     () =>
@@ -225,20 +302,32 @@ export const QuizEditorModal: React.FC<QuizEditorModalProps> = ({
       onSave={handleSave}
       onClose={onClose}
       saveLabel="Save Quiz"
-      bodyClassName="px-6 py-5 bg-slate-50/50"
+      bodyClassName="px-6 py-5 bg-slate-50/50 relative"
     >
       <div className="flex flex-col gap-3">
-        <div>
-          <label className="block font-bold text-brand-blue-dark mb-1 text-xs">
-            Quiz Title
-          </label>
-          <input
-            type="text"
-            value={title}
-            onChange={(e) => setTitle(e.target.value)}
-            placeholder="e.g. Science Unit 4 Review"
-            className="w-full px-3 py-2 bg-white border border-brand-blue-primary/20 rounded-xl text-brand-blue-dark font-bold focus:outline-none focus:border-brand-blue-primary shadow-sm text-sm"
-          />
+        <div className="flex gap-2 items-end">
+          <div className="flex-1">
+            <label className="block font-bold text-brand-blue-dark mb-1 text-xs">
+              Quiz Title
+            </label>
+            <input
+              type="text"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              placeholder="e.g. Science Unit 4 Review"
+              className="w-full px-3 py-2 bg-white border border-brand-blue-primary/20 rounded-xl text-brand-blue-dark font-bold focus:outline-none focus:border-brand-blue-primary shadow-sm text-sm"
+            />
+          </div>
+          {aiEnabled && (
+            <button
+              onClick={() => setShowAiPrompt(true)}
+              className="h-[38px] px-4 bg-gradient-to-br from-indigo-500 to-purple-600 hover:from-indigo-600 hover:to-purple-700 text-white rounded-xl font-black text-xs uppercase tracking-widest shadow-lg shadow-indigo-200 transition-all flex items-center gap-2 active:scale-95"
+              title="Generate with AI"
+            >
+              <Sparkles className="w-4 h-4" />
+              Magic
+            </button>
+          )}
         </div>
 
         {error && (
@@ -495,6 +584,74 @@ export const QuizEditorModal: React.FC<QuizEditorModalProps> = ({
           <span className="text-sm">ADD NEW QUESTION</span>
         </button>
       </div>
+
+      {showAiPrompt && aiEnabled && (
+        <div
+          ref={aiOverlayRef}
+          tabIndex={-1}
+          className="absolute inset-0 z-20 bg-white/95 backdrop-blur-sm flex items-center justify-center p-6 animate-in fade-in duration-200 outline-none"
+          onKeyDown={(e) => {
+            if (e.code === 'Escape') setShowAiPrompt(false);
+          }}
+        >
+          <div className="w-full max-w-sm space-y-4">
+            <div className="flex items-center justify-between">
+              <h4 className="font-black text-indigo-600 flex items-center gap-2 uppercase tracking-tight">
+                <Sparkles className="w-5 h-5" /> Magic Quiz Generator
+              </h4>
+              <button
+                onClick={() => setShowAiPrompt(false)}
+                className="p-1 hover:bg-slate-100 rounded-lg text-slate-400 hover:text-slate-600"
+                aria-label="Close Magic Generator"
+              >
+                <X className="w-5 h-5" />
+              </button>
+            </div>
+            <p className="text-xs text-slate-500 font-bold uppercase tracking-widest opacity-60">
+              Describe the quiz you want to create. Generated questions will be
+              appended to the current list.
+            </p>
+            <textarea
+              value={aiPrompt}
+              onChange={(e) => setAiPrompt(e.target.value)}
+              placeholder="e.g. A 5-question quiz about the solar system for 3rd graders."
+              className="w-full h-32 p-4 bg-white border-2 border-indigo-100 rounded-2xl text-sm text-indigo-900 placeholder-indigo-300 focus:outline-none focus:border-indigo-500 resize-none shadow-inner"
+              autoFocus
+              aria-label="Describe your quiz"
+            />
+            {canAccessFeature('ai-file-context') && (
+              <DriveFileAttachment
+                onFileContent={(content, name) => {
+                  setAiFileContext(content);
+                  setAiFileName(name);
+                }}
+                disabled={aiGenerating}
+              />
+            )}
+            {aiError && (
+              <div className="p-3 bg-brand-red-lighter/40 border border-brand-red-primary/20 rounded-xl flex items-center gap-2 text-sm text-brand-red-dark font-bold">
+                <AlertCircle className="w-4 h-4 shrink-0" />
+                {aiError}
+              </div>
+            )}
+            <button
+              onClick={() => void handleAiGenerate()}
+              disabled={aiGenerating || !aiPrompt.trim()}
+              className="w-full py-3 bg-indigo-600 hover:bg-indigo-700 disabled:opacity-50 disabled:cursor-not-allowed text-white rounded-xl font-black text-xs uppercase tracking-widest shadow-lg shadow-indigo-200 transition-all flex items-center justify-center gap-2"
+            >
+              {aiGenerating ? (
+                <>
+                  <Loader2 className="w-4 h-4 animate-spin" /> Generating...
+                </>
+              ) : (
+                <>
+                  <Sparkles className="w-4 h-4" /> Generate Quiz
+                </>
+              )}
+            </button>
+          </div>
+        </div>
+      )}
     </EditorModalShell>
   );
 };

--- a/components/widgets/QuizWidget/components/QuizEditorModal.tsx
+++ b/components/widgets/QuizWidget/components/QuizEditorModal.tsx
@@ -5,7 +5,7 @@
  * editors (Video Activity, Guided Learning, MiniApp).
  */
 
-import React, { useMemo, useRef, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import {
   AlertCircle,
   ChevronDown,
@@ -122,7 +122,7 @@ export const QuizEditorModal: React.FC<QuizEditorModalProps> = ({
   const [aiError, setAiError] = useState<string | null>(null);
   const [aiFileContext, setAiFileContext] = useState<string | null>(null);
   const [aiFileName, setAiFileName] = useState<string | null>(null);
-  const aiOverlayRef = useRef<HTMLDivElement>(null);
+  const [aiFileExtracting, setAiFileExtracting] = useState(false);
 
   // Reset local state when the `quiz` prop identity changes (new quiz loaded).
   const [prevQuiz, setPrevQuiz] = useState<QuizData | null>(quiz);
@@ -139,6 +139,7 @@ export const QuizEditorModal: React.FC<QuizEditorModalProps> = ({
     setAiError(null);
     setAiFileContext(null);
     setAiFileName(null);
+    setAiFileExtracting(false);
   }
 
   const aiEnabled = canAccessFeature('gemini-functions');
@@ -147,13 +148,27 @@ export const QuizEditorModal: React.FC<QuizEditorModalProps> = ({
     if (!aiPrompt.trim()) return;
     setAiGenerating(true);
     setAiError(null);
+    const fullPrompt = buildPromptWithFileContext(
+      aiPrompt,
+      aiFileContext,
+      aiFileName
+    );
+    let result: Awaited<ReturnType<typeof generateQuiz>>;
     try {
-      const fullPrompt = buildPromptWithFileContext(
-        aiPrompt,
-        aiFileContext,
-        aiFileName
+      result = await generateQuiz(fullPrompt);
+    } catch (err) {
+      setAiError(
+        err instanceof Error
+          ? err.message
+          : 'Failed to generate quiz. Please try again.'
       );
-      const result = await generateQuiz(fullPrompt);
+      setAiGenerating(false);
+      return;
+    }
+    try {
+      if (!result || !Array.isArray(result.questions)) {
+        throw new Error('AI returned an unexpected response shape.');
+      }
       const validTypes: QuizQuestionType[] = [
         'MC',
         'FIB',
@@ -185,13 +200,24 @@ export const QuizEditorModal: React.FC<QuizEditorModalProps> = ({
     } catch (err) {
       setAiError(
         err instanceof Error
-          ? err.message
-          : 'Failed to generate quiz. Please try again.'
+          ? `Could not parse AI response: ${err.message}`
+          : 'Could not parse AI response.'
       );
     } finally {
       setAiGenerating(false);
     }
   };
+
+  // Global Escape listener so the overlay dismisses even when focus is
+  // outside its children (e.g., user clicked the backdrop).
+  useEffect(() => {
+    if (!showAiPrompt) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.code === 'Escape') setShowAiPrompt(false);
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [showAiPrompt]);
 
   const isDirty = useMemo(
     () =>
@@ -587,12 +613,10 @@ export const QuizEditorModal: React.FC<QuizEditorModalProps> = ({
 
       {showAiPrompt && aiEnabled && (
         <div
-          ref={aiOverlayRef}
-          tabIndex={-1}
-          className="absolute inset-0 z-20 bg-white/95 backdrop-blur-sm flex items-center justify-center p-6 animate-in fade-in duration-200 outline-none"
-          onKeyDown={(e) => {
-            if (e.code === 'Escape') setShowAiPrompt(false);
-          }}
+          role="dialog"
+          aria-modal="true"
+          aria-label="Magic Quiz Generator"
+          className="absolute inset-0 z-20 bg-white/95 backdrop-blur-sm flex items-center justify-center p-6 animate-in fade-in duration-200"
         >
           <div className="w-full max-w-sm space-y-4">
             <div className="flex items-center justify-between">
@@ -625,6 +649,7 @@ export const QuizEditorModal: React.FC<QuizEditorModalProps> = ({
                   setAiFileContext(content);
                   setAiFileName(name);
                 }}
+                onExtractingChange={setAiFileExtracting}
                 disabled={aiGenerating}
               />
             )}
@@ -636,7 +661,7 @@ export const QuizEditorModal: React.FC<QuizEditorModalProps> = ({
             )}
             <button
               onClick={() => void handleAiGenerate()}
-              disabled={aiGenerating || !aiPrompt.trim()}
+              disabled={aiGenerating || aiFileExtracting || !aiPrompt.trim()}
               className="w-full py-3 bg-indigo-600 hover:bg-indigo-700 disabled:opacity-50 disabled:cursor-not-allowed text-white rounded-xl font-black text-xs uppercase tracking-widest shadow-lg shadow-indigo-200 transition-all flex items-center justify-center gap-2"
             >
               {aiGenerating ? (

--- a/components/widgets/VideoActivityWidget/Widget.tsx
+++ b/components/widgets/VideoActivityWidget/Widget.tsx
@@ -355,6 +355,8 @@ export const VideoActivityWidget: React.FC<{ widget: WidgetData }> = ({
       <VideoActivityEditorModal
         isOpen={!!editingActivity}
         activity={editingActivity}
+        aiEnabled={aiEnabled}
+        isAdmin={isAdmin === true}
         onClose={() => {
           setEditingActivity(null);
           setEditingMeta(null);

--- a/components/widgets/VideoActivityWidget/components/VideoActivityEditorModal.tsx
+++ b/components/widgets/VideoActivityWidget/components/VideoActivityEditorModal.tsx
@@ -15,18 +15,28 @@ import {
   ChevronUp,
   Clock,
   GripVertical,
+  Loader2,
   Plus,
+  Sparkles,
   Trash2,
+  Wand2,
+  X,
   Youtube,
 } from 'lucide-react';
 import { VideoActivityData, VideoActivityQuestion } from '@/types';
 import { EditorModalShell } from '@/components/common/EditorModalShell';
+import { useAuth } from '@/context/useAuth';
+import { generateVideoActivity } from '@/utils/ai';
 
 interface VideoActivityEditorModalProps {
   isOpen: boolean;
   activity: VideoActivityData | null;
   onClose: () => void;
   onSave: (updated: VideoActivityData) => Promise<void>;
+  /** Video Activity widget-level AI toggle (from VideoActivityGlobalConfig.aiEnabled). */
+  aiEnabled?: boolean;
+  /** Admin override — admins can use AI even when the widget-level toggle is off. */
+  isAdmin?: boolean;
 }
 
 /** Convert total seconds to MM:SS string. */
@@ -83,7 +93,15 @@ const questionsEqual = (
 
 export const VideoActivityEditorModal: React.FC<
   VideoActivityEditorModalProps
-> = ({ isOpen, activity, onClose, onSave }) => {
+> = ({
+  isOpen,
+  activity,
+  onClose,
+  onSave,
+  aiEnabled = true,
+  isAdmin = false,
+}) => {
+  const { canAccessFeature } = useAuth();
   // Snapshot the activity when the modal opens so `isDirty` compares against
   // the original. When the `activity` prop identity changes, local state is
   // reset via the "adjusting state while rendering" block below.
@@ -116,6 +134,15 @@ export const VideoActivityEditorModal: React.FC<
     return init;
   });
 
+  // AI generation state.
+  const [showAiPrompt, setShowAiPrompt] = useState(false);
+  const [aiQuestionCount, setAiQuestionCount] = useState(5);
+  const [aiGenerating, setAiGenerating] = useState(false);
+  const [aiError, setAiError] = useState<string | null>(null);
+
+  const canUseAi =
+    canAccessFeature('gemini-functions') && (aiEnabled || isAdmin);
+
   // Reset local state when the `activity` prop identity changes.
   const [prevActivity, setPrevActivity] = useState<VideoActivityData | null>(
     activity
@@ -133,6 +160,10 @@ export const VideoActivityEditorModal: React.FC<
       init[q.id] = secondsToMmSs(q.timestamp);
     });
     setTimestampInputs(init);
+    setShowAiPrompt(false);
+    setAiQuestionCount(5);
+    setAiGenerating(false);
+    setAiError(null);
   }
 
   const isDirty = useMemo(
@@ -193,6 +224,50 @@ export const VideoActivityEditorModal: React.FC<
     setQuestions((prev) => [...prev, q]);
     setTimestampInputs((prev) => ({ ...prev, [q.id]: secondsToMmSs(0) }));
     setExpandedId(q.id);
+  };
+
+  const handleAiGenerate = async () => {
+    if (!youtubeUrl.trim()) {
+      setAiError('A YouTube URL is required to generate questions.');
+      return;
+    }
+    setAiGenerating(true);
+    setAiError(null);
+    try {
+      const result = await generateVideoActivity(
+        youtubeUrl.trim(),
+        aiQuestionCount
+      );
+      if (!title.trim() && result.title) setTitle(result.title);
+      const generated: VideoActivityQuestion[] = result.questions.map((q) => ({
+        id: crypto.randomUUID(),
+        timestamp: q.timestamp,
+        text: q.text,
+        type: 'MC',
+        correctAnswer: q.correctAnswer ?? '',
+        incorrectAnswers: q.incorrectAnswers ?? [],
+        timeLimit: q.timeLimit ?? 30,
+      }));
+      // Merge with existing, then sort by timestamp so strictly-increasing
+      // validation passes in handleSave.
+      const merged = [...questions, ...generated].sort(
+        (a, b) => a.timestamp - b.timestamp
+      );
+      setQuestions(merged);
+      setTimestampInputs((prev) => {
+        const next = { ...prev };
+        generated.forEach((q) => {
+          next[q.id] = secondsToMmSs(q.timestamp);
+        });
+        return next;
+      });
+      if (generated[0]) setExpandedId(generated[0].id);
+      setShowAiPrompt(false);
+    } catch (err) {
+      setAiError(err instanceof Error ? err.message : 'Generation failed');
+    } finally {
+      setAiGenerating(false);
+    }
   };
 
   const handleSave = async () => {
@@ -257,20 +332,37 @@ export const VideoActivityEditorModal: React.FC<
       onSave={handleSave}
       onClose={onClose}
       saveLabel="Save Activity"
-      bodyClassName="px-6 py-5 bg-slate-50/50"
+      bodyClassName="px-6 py-5 bg-slate-50/50 relative"
     >
       <div className="flex flex-col gap-3">
-        <div>
-          <label className="block font-bold text-brand-blue-dark mb-1 text-xs">
-            Activity Title
-          </label>
-          <input
-            type="text"
-            value={title}
-            onChange={(e) => setTitle(e.target.value)}
-            placeholder="e.g. Introduction to Photosynthesis"
-            className="w-full px-3 py-2 bg-white border border-brand-blue-primary/20 rounded-xl text-brand-blue-dark font-bold focus:outline-none focus:border-brand-blue-primary shadow-sm text-sm"
-          />
+        <div className="flex gap-2 items-end">
+          <div className="flex-1">
+            <label className="block font-bold text-brand-blue-dark mb-1 text-xs">
+              Activity Title
+            </label>
+            <input
+              type="text"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              placeholder="e.g. Introduction to Photosynthesis"
+              className="w-full px-3 py-2 bg-white border border-brand-blue-primary/20 rounded-xl text-brand-blue-dark font-bold focus:outline-none focus:border-brand-blue-primary shadow-sm text-sm"
+            />
+          </div>
+          {canUseAi && (
+            <button
+              onClick={() => setShowAiPrompt(true)}
+              disabled={!youtubeUrl.trim()}
+              className="h-[38px] px-4 bg-gradient-to-br from-indigo-500 to-purple-600 hover:from-indigo-600 hover:to-purple-700 disabled:opacity-50 disabled:cursor-not-allowed text-white rounded-xl font-black text-xs uppercase tracking-widest shadow-lg shadow-indigo-200 transition-all flex items-center gap-2 active:scale-95"
+              title={
+                youtubeUrl.trim()
+                  ? 'Generate questions with AI'
+                  : 'Enter a YouTube URL to enable AI generation'
+              }
+            >
+              <Wand2 className="w-4 h-4" />
+              Magic
+            </button>
+          )}
         </div>
 
         <div>
@@ -478,6 +570,71 @@ export const VideoActivityEditorModal: React.FC<
           <span className="text-sm">ADD NEW QUESTION</span>
         </button>
       </div>
+
+      {showAiPrompt && canUseAi && (
+        <div
+          className="absolute inset-0 z-20 bg-white/95 backdrop-blur-sm flex items-center justify-center p-6 animate-in fade-in duration-200 outline-none"
+          onKeyDown={(e) => {
+            if (e.code === 'Escape') setShowAiPrompt(false);
+          }}
+          tabIndex={-1}
+        >
+          <div className="w-full max-w-sm space-y-4">
+            <div className="flex items-center justify-between">
+              <h4 className="font-black text-indigo-600 flex items-center gap-2 uppercase tracking-tight">
+                <Sparkles className="w-5 h-5" /> Magic Question Generator
+              </h4>
+              <button
+                onClick={() => setShowAiPrompt(false)}
+                className="p-1 hover:bg-slate-100 rounded-lg text-slate-400 hover:text-slate-600"
+                aria-label="Close Magic Generator"
+              >
+                <X className="w-5 h-5" />
+              </button>
+            </div>
+            <p className="text-xs text-slate-500 font-bold uppercase tracking-widest opacity-60">
+              Gemini will watch the video and generate questions. They will be
+              appended to the current list.
+            </p>
+            <div className="bg-indigo-50 border border-indigo-100 rounded-2xl p-4 space-y-2">
+              <div className="flex justify-between items-center text-xs font-bold text-indigo-700/70 uppercase">
+                <span>Question Count</span>
+                <span>{aiQuestionCount}</span>
+              </div>
+              <input
+                type="range"
+                min={3}
+                max={15}
+                value={aiQuestionCount}
+                onChange={(e) => setAiQuestionCount(parseInt(e.target.value))}
+                className="w-full accent-indigo-600"
+                aria-label="Target question count"
+              />
+            </div>
+            {aiError && (
+              <div className="p-3 bg-brand-red-lighter/40 border border-brand-red-primary/20 rounded-xl flex items-center gap-2 text-sm text-brand-red-dark font-bold">
+                <AlertCircle className="w-4 h-4 shrink-0" />
+                {aiError}
+              </div>
+            )}
+            <button
+              onClick={() => void handleAiGenerate()}
+              disabled={aiGenerating || !youtubeUrl.trim()}
+              className="w-full py-3 bg-indigo-600 hover:bg-indigo-700 disabled:opacity-50 disabled:cursor-not-allowed text-white rounded-xl font-black text-xs uppercase tracking-widest shadow-lg shadow-indigo-200 transition-all flex items-center justify-center gap-2"
+            >
+              {aiGenerating ? (
+                <>
+                  <Loader2 className="w-4 h-4 animate-spin" /> Generating...
+                </>
+              ) : (
+                <>
+                  <Wand2 className="w-4 h-4" /> Generate Questions
+                </>
+              )}
+            </button>
+          </div>
+        </div>
+      )}
     </EditorModalShell>
   );
 };

--- a/components/widgets/VideoActivityWidget/components/VideoActivityEditorModal.tsx
+++ b/components/widgets/VideoActivityWidget/components/VideoActivityEditorModal.tsx
@@ -233,11 +233,18 @@ export const VideoActivityEditorModal: React.FC<
     }
     setAiGenerating(true);
     setAiError(null);
+    let result: Awaited<ReturnType<typeof generateVideoActivity>>;
     try {
-      const result = await generateVideoActivity(
-        youtubeUrl.trim(),
-        aiQuestionCount
-      );
+      result = await generateVideoActivity(youtubeUrl.trim(), aiQuestionCount);
+    } catch (err) {
+      setAiError(err instanceof Error ? err.message : 'Generation failed');
+      setAiGenerating(false);
+      return;
+    }
+    try {
+      if (!result || !Array.isArray(result.questions)) {
+        throw new Error('AI returned an unexpected response shape.');
+      }
       if (!title.trim() && result.title) setTitle(result.title);
       const generated: VideoActivityQuestion[] = result.questions.map((q) => ({
         id: crypto.randomUUID(),
@@ -264,7 +271,11 @@ export const VideoActivityEditorModal: React.FC<
       if (generated[0]) setExpandedId(generated[0].id);
       setShowAiPrompt(false);
     } catch (err) {
-      setAiError(err instanceof Error ? err.message : 'Generation failed');
+      setAiError(
+        err instanceof Error
+          ? `Could not parse AI response: ${err.message}`
+          : 'Could not parse AI response.'
+      );
     } finally {
       setAiGenerating(false);
     }
@@ -349,19 +360,27 @@ export const VideoActivityEditorModal: React.FC<
             />
           </div>
           {canUseAi && (
-            <button
-              onClick={() => setShowAiPrompt(true)}
-              disabled={!youtubeUrl.trim()}
-              className="h-[38px] px-4 bg-gradient-to-br from-indigo-500 to-purple-600 hover:from-indigo-600 hover:to-purple-700 disabled:opacity-50 disabled:cursor-not-allowed text-white rounded-xl font-black text-xs uppercase tracking-widest shadow-lg shadow-indigo-200 transition-all flex items-center gap-2 active:scale-95"
-              title={
-                youtubeUrl.trim()
+            <>
+              <button
+                onClick={() => setShowAiPrompt(true)}
+                disabled={!youtubeUrl.trim()}
+                className="h-[38px] px-4 bg-gradient-to-br from-indigo-500 to-purple-600 hover:from-indigo-600 hover:to-purple-700 disabled:opacity-50 disabled:cursor-not-allowed text-white rounded-xl font-black text-xs uppercase tracking-widest shadow-lg shadow-indigo-200 transition-all flex items-center gap-2 active:scale-95"
+                title={
+                  youtubeUrl.trim()
+                    ? 'Generate questions with AI'
+                    : 'Enter a YouTube URL to enable AI generation'
+                }
+                aria-describedby="va-ai-button-hint"
+              >
+                <Wand2 className="w-4 h-4" />
+                Magic
+              </button>
+              <span id="va-ai-button-hint" className="sr-only">
+                {youtubeUrl.trim()
                   ? 'Generate questions with AI'
-                  : 'Enter a YouTube URL to enable AI generation'
-              }
-            >
-              <Wand2 className="w-4 h-4" />
-              Magic
-            </button>
+                  : 'Enter a YouTube URL to enable AI generation'}
+              </span>
+            </>
           )}
         </div>
 


### PR DESCRIPTION
## Summary

Adds a "Magic" (Generate with AI) button inside the unified editor modals for **Quiz**, **Video Activity**, and **Guided Learning** so teachers can generate content with AI without leaving the editor. MiniApp already had this button; the three other editors only exposed AI generation from *outside* the modal (Creator step, QuizImporter, library), so the unified editor experience wasn't actually unified.

Visibility respects existing admin gates — no new permission surfaces are introduced:

| Widget | Gate |
| --- | --- |
| Quiz | `canAccessFeature('gemini-functions')` |
| Video Activity | `canAccessFeature('gemini-functions')` **AND** (`VideoActivityGlobalConfig.aiEnabled` **OR** `isAdmin`) |
| Guided Learning | admin **AND** `canAccessFeature('gemini-functions')` (matches the library-level button gate) |
| MiniApp | unchanged |

Generated questions/steps are merged into the editor's draft state, so the existing dirty-guard and save flow in `EditorModalShell` handle review and persistence unchanged.

## Files changed

- `components/widgets/QuizWidget/components/QuizEditorModal.tsx` — "Magic" button + prompt overlay, reuses `generateQuiz` and `DriveFileAttachment`.
- `components/widgets/VideoActivityWidget/components/VideoActivityEditorModal.tsx` — "Magic" button + prompt overlay with question-count slider, reuses `generateVideoActivity`. New `aiEnabled` / `isAdmin` props.
- `components/widgets/VideoActivityWidget/Widget.tsx` — pass `aiEnabled` / `isAdmin` into the modal (both already computed in the widget).
- `components/widgets/GuidedLearning/components/GuidedLearningEditorModal.tsx` — "Magic" button in `footerExtras`, embeds the existing `GuidedLearningAIGenerator` overlay. New optional `onAiGenerated` callback.
- `components/widgets/GuidedLearning/Widget.tsx` — wire `onAiGenerated` to replace the in-flight draft set.

## Test plan

- [ ] As admin with `gemini-functions` enabled, open each editor (Quiz, Video Activity, Guided Learning, Mini App) for both new and existing items. Confirm the AI button is visible in all four.
- [ ] Trigger AI generation in each; confirm content populates the draft, dirty-guard activates, Save persists, and Cancel offers discard.
- [ ] In Admin Settings → Global Permissions, disable `gemini-functions`. As a non-admin, confirm the AI button disappears in all four editors.
- [ ] In the Video Activity admin config modal, disable "Enable AI Mode". Confirm non-admins no longer see the button in the Video Activity editor, but admins still do.
- [ ] In Guided Learning, confirm non-admins never see the button even when `gemini-functions` is enabled.
- [ ] `pnpm run type-check`, `pnpm run lint`, `pnpm run format:check`, `pnpm run test` all green. ✅

https://claude.ai/code/session_01KeRvUzyVVc9ai5u7cQESRf