### PR TITLE
fix(random): default to Auto roster and prevent blank-screen on mode switch

### DIFF
--- a/components/widgets/random/RandomWidget.tsx
+++ b/components/widgets/random/RandomWidget.tsx
@@ -79,6 +79,26 @@ export const RandomWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
   });
   const [rotation, setRotation] = useState(0);
 
+  // Reset displayResult synchronously on mode change so the wrong-shape value
+  // (e.g. RandomGroup[] from groups mode) is never passed to a single/shuffle
+  // renderer — which would crash with "Objects are not valid as a React child".
+  const [prevMode, setPrevMode] = useState(mode);
+  if (mode !== prevMode) {
+    setPrevMode(mode);
+    const raw = config.lastResult;
+    if (
+      Array.isArray(raw) &&
+      raw.length > 0 &&
+      typeof raw[0] === 'object' &&
+      raw[0] !== null &&
+      'names' in raw[0]
+    ) {
+      setDisplayResult(raw as RandomGroup[]);
+    } else {
+      setDisplayResult((raw as string | string[] | string[][]) ?? '');
+    }
+  }
+
   // Track active roster to only clear when it actually changes
   const lastRosterRef = useRef<{ id: string | null; mode: string }>({
     id: activeRosterId,

--- a/utils/widgetConfigPersistence.ts
+++ b/utils/widgetConfigPersistence.ts
@@ -67,6 +67,10 @@ const TRANSIENT_CONFIG_KEYS = new Set<string>([
   // User-typed instance content: styling should carry over to new widgets,
   // but the text/notes themselves belong to a single instance only.
   'content',
+
+  // Roster selection is a per-instance choice (Auto vs Custom), not a global
+  // styling preference — new widgets should always default to the Auto roster.
+  'rosterMode',
 ]);
 
 /** Strips transient/runtime keys from a config object before persisting. */


### PR DESCRIPTION
## Summary

Fixes two issues in the Randomizer widget:

- **Default roster mode**: New Randomizer widgets were inheriting `rosterMode: 'custom'` from the user's `savedWidgetConfigs` (a per-instance choice that was leaking into the global default). `rosterMode` is now treated as a transient key — new widgets reliably get `'class'` (Auto) from `widgetDefaults.ts` while per-instance changes still work.
- **Blank-screen crash on mode change**: Switching from `mode: 'groups'` to `'single'` (Pick One) or `'shuffle'` crashed the widget to blank. The `useEffect` syncing `displayResult` from `config.lastResult` only fired *after* the first render, so stale `RandomGroup[]` objects were passed to `RandomFlash`/`RandomSlots`/`RandomWheel`, which cast `displayResult as string` and rendered it directly — triggering React's "Objects are not valid as a React child" error. Fixed by resetting `displayResult` synchronously on mode change via the "adjusting state while rendering" pattern.

Scope note: adding `rosterMode` to `TRANSIENT_CONFIG_KEYS` also applies to SeatingChart, Checklist, and LunchCount widgets — all will consistently default to the Auto roster for new instances.

## Test plan

- [ ] Open a Randomizer widget and confirm Roster Selection defaults to **Auto**.
- [ ] Delete the Randomizer, add a fresh one — confirm **Auto** on first render.
- [ ] In Groups mode, generate groups, then switch to **Pick One** — widget shows "Ready?" (no blank screen). Switch back to **Groups**, then to **Shuffle** — appropriate empty state renders.
- [ ] Repeat mode-switch cycle with each Pick One animation style (Standard, Wheel, Slots).
- [ ] Spot-check SeatingChart / Checklist / LunchCount roster defaults (new instances should default to Auto).
- [x] `pnpm run type-check` passes
- [x] `pnpm run lint` passes (0 warnings)
- [x] `pnpm run format:check` passes
- [x] `pnpm run test` — 1183 tests pass

https://claude.ai/code/session_01TJZDQD9SypMBbhYdbVpKA6