### PR TITLE
feat(dock): add left/right dock position preference

### DIFF
--- a/components/layout/BoardZoomControl.tsx
+++ b/components/layout/BoardZoomControl.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { RotateCcw, ZoomIn, ZoomOut, Search } from 'lucide-react';
 import { useDashboard } from '@/context/useDashboard';
+import { useAuth } from '@/context/useAuth';
 import { IconButton } from '@/components/common/IconButton';
 
 // First zoom level applied when the collapsed FAB is clicked — small enough
@@ -11,6 +12,9 @@ const INITIAL_ZOOM = 1.2;
 export const BoardZoomControl: React.FC = () => {
   const { t } = useTranslation();
   const { zoom, setZoom } = useDashboard();
+  const { dockPosition } = useAuth();
+  // Avoid colliding with a right-anchored dock.
+  const horizontalAnchor = dockPosition === 'right' ? 'left-14' : 'right-4';
 
   const percentage = Math.round(zoom * 100);
 
@@ -20,7 +24,7 @@ export const BoardZoomControl: React.FC = () => {
       <button
         onClick={() => setZoom(INITIAL_ZOOM)}
         title={t('common.zoom') ?? 'Zoom (Ctrl + scroll)'}
-        className="fixed bottom-16 right-4 z-critical w-8 h-8 rounded-full bg-white/10 hover:bg-white/20 border border-white/20 text-white/60 hover:text-white/90 flex items-center justify-center transition-colors backdrop-blur-sm"
+        className={`fixed bottom-16 ${horizontalAnchor} z-critical w-8 h-8 rounded-full bg-white/10 hover:bg-white/20 border border-white/20 text-white/60 hover:text-white/90 flex items-center justify-center transition-colors backdrop-blur-sm`}
         aria-label={t('common.zoom') ?? 'Zoom'}
       >
         <Search className="w-4 h-4" />
@@ -30,7 +34,13 @@ export const BoardZoomControl: React.FC = () => {
 
   // Expanded panel when zoomed
   return (
-    <div className="fixed bottom-16 right-4 z-critical flex flex-col items-center gap-2 animate-in slide-in-from-right-4 fade-in duration-300">
+    <div
+      className={`fixed bottom-16 ${horizontalAnchor} z-critical flex flex-col items-center gap-2 animate-in ${
+        dockPosition === 'right'
+          ? 'slide-in-from-left-4'
+          : 'slide-in-from-right-4'
+      } fade-in duration-300`}
+    >
       <div className="bg-white/80 backdrop-blur-md border border-white/40 shadow-xl rounded-2xl p-1.5 flex flex-col gap-1 items-center">
         <span className="text-xxs font-black text-slate-500 uppercase tracking-tighter px-2 pt-1">
           {t('common.zoom') ?? 'Zoom'}

--- a/components/layout/DashboardView.tsx
+++ b/components/layout/DashboardView.tsx
@@ -432,7 +432,7 @@ export const DashboardView: React.FC = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps -- intentionally only on id change
   }, [activeDashboard?.id]);
 
-  const { canAccessFeature } = useAuth();
+  const { canAccessFeature, dockPosition } = useAuth();
 
   const {
     session,
@@ -1383,7 +1383,9 @@ export const DashboardView: React.FC = () => {
               ? 'Enable background video sound'
               : 'Mute background video'
           }
-          className="fixed bottom-6 left-4 z-dock w-8 h-8 rounded-full bg-white/10 hover:bg-white/20 border border-white/20 text-white/60 hover:text-white/90 flex items-center justify-center transition-colors backdrop-blur-sm"
+          className={`fixed bottom-6 z-dock w-8 h-8 rounded-full bg-white/10 hover:bg-white/20 border border-white/20 text-white/60 hover:text-white/90 flex items-center justify-center transition-colors backdrop-blur-sm ${
+            dockPosition === 'left' ? 'right-14' : 'left-4'
+          }`}
           aria-label="Toggle background video sound"
         >
           <div className="relative flex items-center justify-center w-full h-full">
@@ -1412,7 +1414,9 @@ export const DashboardView: React.FC = () => {
       <button
         onClick={() => setIsCheatSheetOpen(true)}
         title={`${t('widgets.cheatSheet.title')} (Ctrl+/)`}
-        className="fixed bottom-6 right-4 z-dock w-8 h-8 rounded-full bg-white/10 hover:bg-white/20 border border-white/20 text-white/60 hover:text-white/90 flex items-center justify-center transition-colors backdrop-blur-sm"
+        className={`fixed bottom-6 z-dock w-8 h-8 rounded-full bg-white/10 hover:bg-white/20 border border-white/20 text-white/60 hover:text-white/90 flex items-center justify-center transition-colors backdrop-blur-sm ${
+          dockPosition === 'right' ? 'left-14' : 'right-4'
+        }`}
         aria-label={t('widgets.cheatSheet.title')}
       >
         <HelpCircle className="w-4 h-4" />

--- a/components/layout/Dock.tsx
+++ b/components/layout/Dock.tsx
@@ -32,6 +32,7 @@ import {
   arrayMove,
   SortableContext,
   horizontalListSortingStrategy,
+  verticalListSortingStrategy,
 } from '@dnd-kit/sortable';
 import { useDashboard } from '@/context/useDashboard';
 import { useAuth } from '@/context/useAuth';
@@ -116,7 +117,9 @@ export const Dock: React.FC = () => {
     userGradeLevels,
     selectedBuildings,
     featurePermissions,
+    dockPosition,
   } = useAuth();
+  const isVerticalDock = dockPosition === 'left' || dockPosition === 'right';
   const { driveService } = useGoogleDrive();
   const { sets: catalystSets, executeRoutine } = useCatalystSets();
   const { customWidgets } = useCustomWidgets();
@@ -236,47 +239,60 @@ export const Dock: React.FC = () => {
   );
   const [imagePastePending, setImagePastePending] = useState<File | null>(null);
 
-  // Drag-to-collapse state
-  const [dragY, setDragY] = useState(0);
-  const [isDraggingDown, setIsDraggingDown] = useState(false);
+  // Drag-to-collapse state — `dragOffset` is the magnitude moved along the
+  // collapse axis (down for bottom dock, left/right for side docks).
+  const [dragOffset, setDragOffset] = useState(0);
+  const [isDragCollapsing, setIsDragCollapsing] = useState(false);
   const startY = useRef(0);
   const startX = useRef(0);
   const hasCaptured = useRef(false);
   const threshold = 80; // Distance to trigger collapse
 
+  // Sign of the collapse direction along the primary axis.
+  // bottom: +Y moves dock off-screen; left: -X; right: +X.
+  const collapseSign =
+    dockPosition === 'left' ? -1 : dockPosition === 'right' ? 1 : 1;
+
   const handleDockPointerDown = (e: React.PointerEvent) => {
     if (!isExpanded || isEditMode) return;
 
-    setIsDraggingDown(true);
+    setIsDragCollapsing(true);
     startY.current = e.clientY;
     startX.current = e.clientX;
     hasCaptured.current = false;
   };
 
   const handleDockPointerMove = (e: React.PointerEvent) => {
-    if (!isDraggingDown) return;
-    const deltaY = e.clientY - startY.current;
-    const deltaX = Math.abs(e.clientX - startX.current);
+    if (!isDragCollapsing) return;
+    const rawDeltaX = e.clientX - startX.current;
+    const rawDeltaY = e.clientY - startY.current;
+
+    // Primary = movement along collapse axis (signed toward "off-screen").
+    // Secondary = orthogonal movement (cancels the gesture if it dominates).
+    const primaryDelta = isVerticalDock ? rawDeltaX * collapseSign : rawDeltaY; // bottom dock collapses on positive Y
+    const secondaryDelta = isVerticalDock
+      ? Math.abs(rawDeltaY)
+      : Math.abs(rawDeltaX);
 
     if (!hasCaptured.current) {
-      if (deltaX > 10 && deltaX > deltaY) {
-        setIsDraggingDown(false);
+      if (secondaryDelta > 10 && secondaryDelta > primaryDelta) {
+        setIsDragCollapsing(false);
         return;
       }
-      if (deltaY > 10) {
+      if (primaryDelta > 10) {
         (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
         hasCaptured.current = true;
       }
     }
 
-    if (deltaY > 0) {
-      setDragY(deltaY);
+    if (primaryDelta > 0) {
+      setDragOffset(primaryDelta);
     }
   };
 
   const handleDockPointerUp = (e: React.PointerEvent) => {
-    if (!isDraggingDown) return;
-    setIsDraggingDown(false);
+    if (!isDragCollapsing) return;
+    setIsDragCollapsing(false);
 
     if (hasCaptured.current) {
       try {
@@ -287,10 +303,10 @@ export const Dock: React.FC = () => {
       hasCaptured.current = false;
     }
 
-    if (dragY > threshold) {
+    if (dragOffset > threshold) {
       setIsExpanded(false);
     }
-    setDragY(0);
+    setDragOffset(0);
   };
 
   const globalStyle = activeDashboard?.globalStyle ?? DEFAULT_GLOBAL_STYLE;
@@ -639,6 +655,26 @@ export const Dock: React.FC = () => {
     [canAccessFeature, canAccessWidget]
   );
 
+  // Position-aware anchoring: bottom-center (default), left-center, right-center.
+  const containerPositionClasses =
+    dockPosition === 'left'
+      ? 'left-6 top-1/2 flex-row'
+      : dockPosition === 'right'
+        ? 'right-6 top-1/2 flex-row'
+        : 'bottom-6 left-1/2 flex-col';
+
+  // Base centering transform (before drag offset is applied).
+  const baseTransform = isVerticalDock
+    ? 'translateY(-50%)'
+    : 'translateX(-50%)';
+
+  // Drag offset translates along the collapse axis.
+  const dragTransform = isVerticalDock
+    ? `translateX(${dragOffset * collapseSign}px)`
+    : `translateY(${dragOffset}px)`;
+
+  const scaleFactor = 1 - Math.min(dragOffset / 500, 0.15);
+
   return (
     <div
       ref={dockContainerRef}
@@ -650,13 +686,13 @@ export const Dock: React.FC = () => {
       data-role="dock"
       data-testid="dock"
       data-screenshot="exclude"
-      className={`fixed bottom-6 left-1/2 -translate-x-1/2 z-dock flex flex-col items-center gap-4 transition-all duration-300 select-none ${
-        isDraggingDown ? 'transition-none' : 'ease-out'
+      className={`fixed ${containerPositionClasses} z-dock flex items-center gap-4 transition-all duration-300 select-none ${
+        isDragCollapsing ? 'transition-none' : 'ease-out'
       }`}
       style={{
-        transform: `translateX(-50%) translateY(${dragY}px) scale(${1 - Math.min(dragY / 500, 0.15)})`,
-        opacity: 1 - Math.min(dragY / 400, 0.4),
-        touchAction: 'pan-x',
+        transform: `${baseTransform} ${dragTransform} scale(${scaleFactor})`,
+        opacity: 1 - Math.min(dragOffset / 400, 0.4),
+        touchAction: isVerticalDock ? 'pan-y' : 'pan-x',
       }}
     >
       {showRosterMenu && (
@@ -701,12 +737,33 @@ export const Dock: React.FC = () => {
             ref={drawingPopoverRef}
             style={{
               position: 'fixed',
-              left: drawingAnchorRect.left + drawingAnchorRect.width / 2,
-              bottom: window.innerHeight - drawingAnchorRect.top + 10,
-              transform: 'translateX(-50%)',
               zIndex: Z_INDEX.popover,
+              ...(dockPosition === 'left'
+                ? {
+                    left: drawingAnchorRect.right + 10,
+                    top: drawingAnchorRect.top + drawingAnchorRect.height / 2,
+                    transform: 'translateY(-50%)',
+                  }
+                : dockPosition === 'right'
+                  ? {
+                      right: window.innerWidth - drawingAnchorRect.left + 10,
+                      top: drawingAnchorRect.top + drawingAnchorRect.height / 2,
+                      transform: 'translateY(-50%)',
+                    }
+                  : {
+                      left:
+                        drawingAnchorRect.left + drawingAnchorRect.width / 2,
+                      bottom: window.innerHeight - drawingAnchorRect.top + 10,
+                      transform: 'translateX(-50%)',
+                    }),
             }}
-            className="w-64 overflow-hidden animate-in slide-in-from-bottom-2 duration-200"
+            className={`w-64 overflow-hidden animate-in duration-200 ${
+              dockPosition === 'left'
+                ? 'slide-in-from-left-2'
+                : dockPosition === 'right'
+                  ? 'slide-in-from-right-2'
+                  : 'slide-in-from-bottom-2'
+            }`}
           >
             <div className="bg-white/50 px-3 py-2 border-b border-white/30">
               <span className="text-xxs font-black uppercase text-slate-600 tracking-wider">
@@ -893,7 +950,13 @@ export const Dock: React.FC = () => {
           className={`transition-all duration-500 ease-[cubic-bezier(0.34,1.56,0.64,1)] ${
             isExpanded
               ? 'scale-100 opacity-100'
-              : 'scale-50 opacity-0 pointer-events-none absolute translate-y-12'
+              : `scale-50 opacity-0 pointer-events-none absolute ${
+                  dockPosition === 'left'
+                    ? '-translate-x-12'
+                    : dockPosition === 'right'
+                      ? 'translate-x-12'
+                      : 'translate-y-12'
+                }`
           }`}
         >
           {/* Widget Library Modal (Triggered by button) */}
@@ -942,7 +1005,11 @@ export const Dock: React.FC = () => {
                   ? 'none'
                   : globalStyle.dockBorderRadius
             }
-            className="relative z-10 px-4 py-3 flex items-center gap-1.5 md:gap-3 max-w-[95vw] overflow-x-auto no-scrollbar flex-nowrap"
+            className={`relative z-10 px-4 py-3 flex items-center gap-1.5 md:gap-3 no-scrollbar flex-nowrap ${
+              isVerticalDock
+                ? 'flex-col max-h-[85vh] overflow-y-auto'
+                : 'max-w-[95vw] overflow-x-auto'
+            }`}
           >
             {dockItems.length > 0 ? (
               <>
@@ -957,7 +1024,11 @@ export const Dock: React.FC = () => {
                     items={dockItems.map((item) =>
                       item.type === 'tool' ? item.toolType : item.folder.id
                     )}
-                    strategy={horizontalListSortingStrategy}
+                    strategy={
+                      isVerticalDock
+                        ? verticalListSortingStrategy
+                        : horizontalListSortingStrategy
+                    }
                   >
                     {dockItems.map((item) => {
                       if (item.type === 'tool') {
@@ -1221,6 +1292,7 @@ export const Dock: React.FC = () => {
                             }
                             onReorder={reorderFolderItems}
                             globalStyle={globalStyle}
+                            dockPosition={dockPosition}
                           />
                         );
                       }
@@ -1369,7 +1441,13 @@ export const Dock: React.FC = () => {
                 )}
 
                 {/* Separator and More Button */}
-                <div className="w-px h-8 bg-slate-200 mx-1 md:mx-2 flex-shrink-0" />
+                <div
+                  className={`bg-slate-200 flex-shrink-0 ${
+                    isVerticalDock
+                      ? 'h-px w-8 my-1 md:my-2'
+                      : 'w-px h-8 mx-1 md:mx-2'
+                  }`}
+                />
 
                 <button
                   ref={moreButtonRef}
@@ -1409,7 +1487,11 @@ export const Dock: React.FC = () => {
           }`}
         >
           {/* Compressed down to a single icon (plus quick access) */}
-          <div className="flex items-center gap-4">
+          <div
+            className={`flex items-center gap-4 ${
+              isVerticalDock ? 'flex-col' : ''
+            }`}
+          >
             {activeDashboard?.settings?.quickAccessWidgets?.[0] && (
               <QuickAccessButton
                 type={activeDashboard.settings.quickAccessWidgets[0]}

--- a/components/layout/Dock.tsx
+++ b/components/layout/Dock.tsx
@@ -1094,6 +1094,7 @@ export const Dock: React.FC = () => {
                                       .padStart(2, '0')}`
                                   : getToolLabel(item.toolType)
                               }
+                              dockPosition={dockPosition}
                             />
                           );
                         }
@@ -1129,6 +1130,7 @@ export const Dock: React.FC = () => {
                                   : undefined
                               }
                               buttonRef={classesButtonRef}
+                              dockPosition={dockPosition}
                             />
                           );
                         }
@@ -1165,6 +1167,7 @@ export const Dock: React.FC = () => {
                                   : undefined
                               }
                               buttonRef={catalystButtonRef}
+                              dockPosition={dockPosition}
                             />
                           );
                         }
@@ -1200,6 +1203,7 @@ export const Dock: React.FC = () => {
                                   : undefined
                               }
                               buttonRef={drawingButtonRef}
+                              dockPosition={dockPosition}
                             />
                           );
                         }
@@ -1225,6 +1229,7 @@ export const Dock: React.FC = () => {
                               customLabel={getToolLabel(tool.type)}
                               onClickOverride={handleToggleRemoteMenu}
                               buttonRef={remoteButtonRef}
+                              dockPosition={dockPosition}
                             />
                           );
                         }
@@ -1258,6 +1263,7 @@ export const Dock: React.FC = () => {
                             onLongPress={handleLongPress}
                             globalStyle={globalStyle}
                             customLabel={getToolLabel(tool.type)}
+                            dockPosition={dockPosition}
                           />
                         );
                       } else {

--- a/components/layout/dock/FolderItem.tsx
+++ b/components/layout/dock/FolderItem.tsx
@@ -284,7 +284,9 @@ export const FolderItem = React.memo(
             className={`group flex flex-col items-center gap-1 min-w-[50px] transition-transform active:scale-90 relative ${
               isEditMode
                 ? 'cursor-grab active:cursor-grabbing touch-none'
-                : 'touch-pan-x'
+                : dockPosition === 'left' || dockPosition === 'right'
+                  ? 'touch-pan-y'
+                  : 'touch-pan-x'
             }`}
           >
             <DockIcon

--- a/components/layout/dock/FolderItem.tsx
+++ b/components/layout/dock/FolderItem.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useCallback } from 'react';
+import React, { useState, useRef, useCallback, useLayoutEffect } from 'react';
 import { createPortal } from 'react-dom';
 import { FolderPlus, X } from 'lucide-react';
 import { useLongPress } from '@/hooks/useLongPress';
@@ -30,6 +30,7 @@ import {
   GlobalStyle,
   WidgetData,
   InternalToolType,
+  DockPosition,
 } from '@/types';
 import { beginWidgetDrag, endWidgetDrag } from '@/utils/widgetDragFlag';
 
@@ -47,6 +48,7 @@ interface FolderItemProps {
     newItems: (WidgetType | InternalToolType)[]
   ) => void;
   globalStyle: GlobalStyle;
+  dockPosition?: DockPosition;
 }
 
 // Folder Item Component
@@ -62,6 +64,7 @@ export const FolderItem = React.memo(
     onRemoveItem,
     onReorder,
     globalStyle,
+    dockPosition = 'bottom',
   }: FolderItemProps) => {
     const {
       attributes,
@@ -76,8 +79,17 @@ export const FolderItem = React.memo(
     });
 
     const [showPopover, setShowPopover] = useState(false);
+    const [anchorRect, setAnchorRect] = useState<DOMRect | null>(null);
     const buttonRef = useRef<HTMLButtonElement>(null);
     const popoverRef = useRef<HTMLDivElement>(null);
+
+    useLayoutEffect(() => {
+      if (showPopover && buttonRef.current) {
+        setAnchorRect(buttonRef.current.getBoundingClientRect());
+      } else {
+        setAnchorRect(null);
+      }
+    }, [showPopover]);
 
     // DND Sensors for internal folder sorting
     const sensors = useSensors(
@@ -128,11 +140,55 @@ export const FolderItem = React.memo(
         className="relative flex flex-col items-center"
       >
         {showPopover &&
+          anchorRect &&
           createPortal(
             <GlassCard
               globalStyle={globalStyle}
               ref={popoverRef}
-              className="fixed bottom-32 left-1/2 -translate-x-1/2 w-64 p-4 animate-in slide-in-from-bottom-2 duration-200 z-popover"
+              style={
+                dockPosition === 'left'
+                  ? {
+                      position: 'fixed',
+                      left: anchorRect.right + 12,
+                      top: Math.max(
+                        12,
+                        Math.min(
+                          anchorRect.top + anchorRect.height / 2,
+                          window.innerHeight - 12
+                        )
+                      ),
+                      transform: 'translateY(-50%)',
+                      zIndex: Z_INDEX.popover,
+                    }
+                  : dockPosition === 'right'
+                    ? {
+                        position: 'fixed',
+                        right: window.innerWidth - anchorRect.left + 12,
+                        top: Math.max(
+                          12,
+                          Math.min(
+                            anchorRect.top + anchorRect.height / 2,
+                            window.innerHeight - 12
+                          )
+                        ),
+                        transform: 'translateY(-50%)',
+                        zIndex: Z_INDEX.popover,
+                      }
+                    : {
+                        position: 'fixed',
+                        left: anchorRect.left + anchorRect.width / 2,
+                        bottom: window.innerHeight - anchorRect.top + 12,
+                        transform: 'translateX(-50%)',
+                        zIndex: Z_INDEX.popover,
+                      }
+              }
+              className={`w-64 p-4 animate-in duration-200 ${
+                dockPosition === 'left'
+                  ? 'slide-in-from-left-2'
+                  : dockPosition === 'right'
+                    ? 'slide-in-from-right-2'
+                    : 'slide-in-from-bottom-2'
+              }`}
             >
               <div className="flex justify-between items-center mb-3">
                 <h4 className="text-xxs font-black uppercase text-slate-500 tracking-widest">

--- a/components/layout/dock/ToolDockItem.tsx
+++ b/components/layout/dock/ToolDockItem.tsx
@@ -10,7 +10,7 @@ import { DockIcon } from './DockIcon';
 import { DockLabel } from './DockLabel';
 import { getTitle } from '@/utils/widgetHelpers';
 import { Z_INDEX } from '@/config/zIndex';
-import { ToolMetadata, WidgetData, GlobalStyle } from '@/types';
+import { ToolMetadata, WidgetData, GlobalStyle, DockPosition } from '@/types';
 
 interface ToolDockItemProps {
   tool: ToolMetadata;
@@ -28,6 +28,7 @@ interface ToolDockItemProps {
   customColor?: string;
   onClickOverride?: (e: React.MouseEvent) => void;
   buttonRef?: React.RefObject<HTMLButtonElement | null>;
+  dockPosition?: DockPosition;
 }
 
 // Tool Item with Popover Logic
@@ -48,6 +49,7 @@ export const ToolDockItem = React.memo(
     customColor,
     onClickOverride,
     buttonRef: externalButtonRef,
+    dockPosition = 'bottom',
   }: ToolDockItemProps) => {
     const Icon = customIcon ?? tool.icon;
     const label = customLabel ?? tool.label;
@@ -241,7 +243,9 @@ export const ToolDockItem = React.memo(
             className={`group flex flex-col items-center gap-1 min-w-[50px] transition-transform active:scale-90 relative ${
               isEditMode
                 ? 'cursor-grab active:cursor-grabbing touch-none'
-                : 'touch-pan-x'
+                : dockPosition === 'left' || dockPosition === 'right'
+                  ? 'touch-pan-y'
+                  : 'touch-pan-x'
             }`}
           >
             <DockIcon

--- a/components/layout/sidebar/SidebarPreferences.tsx
+++ b/components/layout/sidebar/SidebarPreferences.tsx
@@ -1,9 +1,15 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { SlidersHorizontal, ShieldX, MousePointerClick } from 'lucide-react';
+import {
+  SlidersHorizontal,
+  ShieldX,
+  MousePointerClick,
+  LayoutPanelLeft,
+} from 'lucide-react';
 import { Toggle } from '@/components/common/Toggle';
 import { Card } from '@/components/common/Card';
 import { useAuth } from '@/context/useAuth';
+import { DockPosition } from '@/types';
 
 interface SidebarPreferencesProps {
   isVisible: boolean;
@@ -16,8 +22,31 @@ export const SidebarPreferences: React.FC<SidebarPreferencesProps> = ({
   const {
     disableCloseConfirmation,
     remoteControlEnabled,
+    dockPosition,
     updateAccountPreferences,
   } = useAuth();
+
+  const dockOptions: {
+    value: DockPosition;
+    labelKey: string;
+    fallback: string;
+  }[] = [
+    {
+      value: 'bottom',
+      labelKey: 'sidebar.settings.dockBottom',
+      fallback: 'Bottom',
+    },
+    {
+      value: 'left',
+      labelKey: 'sidebar.settings.dockLeft',
+      fallback: 'Left',
+    },
+    {
+      value: 'right',
+      labelKey: 'sidebar.settings.dockRight',
+      fallback: 'Right',
+    },
+  ];
 
   return (
     <div
@@ -110,6 +139,59 @@ export const SidebarPreferences: React.FC<SidebarPreferencesProps> = ({
                       'Allow controlling your boards remotely from another device.',
                   })}
                 </p>
+              </div>
+            </Card>
+
+            {/* Dock Position Selector */}
+            <Card className="flex items-start gap-4" hoverable>
+              <div className="w-9 h-9 rounded-xl bg-emerald-50 flex items-center justify-center flex-shrink-0 mt-0.5">
+                <LayoutPanelLeft className="w-[18px] h-[18px] text-emerald-400" />
+              </div>
+              <div className="flex-1 min-w-0">
+                <div className="flex items-center justify-between gap-3">
+                  <span className="text-xs font-bold text-slate-700">
+                    {t('sidebar.settings.dockPosition', {
+                      defaultValue: 'Dock Position',
+                    })}
+                  </span>
+                </div>
+                <p className="text-xxs text-slate-500 mt-1 leading-relaxed pr-2">
+                  {t('sidebar.settings.dockPositionDescription', {
+                    defaultValue:
+                      'Choose where the dock appears on your screen.',
+                  })}
+                </p>
+                <div
+                  role="radiogroup"
+                  aria-label={t('sidebar.settings.dockPosition', {
+                    defaultValue: 'Dock Position',
+                  })}
+                  className="mt-2 inline-flex rounded-lg border border-slate-200 bg-slate-50 p-0.5"
+                >
+                  {dockOptions.map((option) => {
+                    const active = dockPosition === option.value;
+                    return (
+                      <button
+                        key={option.value}
+                        type="button"
+                        role="radio"
+                        aria-checked={active}
+                        onClick={() =>
+                          void updateAccountPreferences({
+                            dockPosition: option.value,
+                          })
+                        }
+                        className={`px-2.5 py-1 text-xxs font-bold rounded-md transition-colors ${
+                          active
+                            ? 'bg-white text-slate-800 shadow-sm'
+                            : 'text-slate-500 hover:text-slate-700'
+                        }`}
+                      >
+                        {t(option.labelKey, { defaultValue: option.fallback })}
+                      </button>
+                    );
+                  })}
+                </div>
               </div>
             </Card>
           </div>

--- a/components/student/StudentContexts.tsx
+++ b/components/student/StudentContexts.tsx
@@ -57,6 +57,7 @@ const mockAuth: AuthContextType = {
   },
   disableCloseConfirmation: false,
   remoteControlEnabled: true,
+  dockPosition: 'bottom',
   updateAccountPreferences: async () => {
     // No-op in student view
   },

--- a/components/widgets/Embed/Widget.test.tsx
+++ b/components/widgets/Embed/Widget.test.tsx
@@ -64,6 +64,7 @@ vi.mock('@/context/useAuth', () => ({
     completeSetup: vi.fn(),
     disableCloseConfirmation: false,
     remoteControlEnabled: true,
+    dockPosition: 'bottom',
     updateAccountPreferences: vi.fn(),
   })),
 }));
@@ -410,6 +411,7 @@ describe('EmbedWidget', () => {
         completeSetup: vi.fn(),
         disableCloseConfirmation: false,
         remoteControlEnabled: true,
+        dockPosition: 'bottom',
         updateAccountPreferences: vi.fn(),
       });
 

--- a/components/widgets/TalkingTool/Widget.test.tsx
+++ b/components/widgets/TalkingTool/Widget.test.tsx
@@ -67,6 +67,7 @@ const mockAuthContext = (
   },
   disableCloseConfirmation: false,
   remoteControlEnabled: true,
+  dockPosition: 'bottom',
   updateAccountPreferences: async () => {
     /* mock */
   },

--- a/context/AuthContext.tsx
+++ b/context/AuthContext.tsx
@@ -600,6 +600,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
       setSavedWidgetConfigs({});
       setDisableCloseConfirmationState(false);
       setRemoteControlEnabledState(true);
+      setDockPositionState('bottom');
 
       if (!user) {
         setSelectedBuildingsState([]);

--- a/context/AuthContext.tsx
+++ b/context/AuthContext.tsx
@@ -36,6 +36,7 @@ import {
   WidgetConfig,
   UserRolesConfig,
   AppSettings,
+  DockPosition,
 } from '../types';
 import { AuthContext } from './AuthContextValue';
 import { getBuildingGradeLevels } from '../config/buildings';
@@ -219,6 +220,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
   const [disableCloseConfirmation, setDisableCloseConfirmationState] =
     useState(false);
   const [remoteControlEnabled, setRemoteControlEnabledState] = useState(true);
+  const [dockPosition, setDockPositionState] = useState<DockPosition>('bottom');
   // Tracks the latest setSelectedBuildings / setLanguage call to detect and suppress stale writes
   const writeTokenRef = useRef(0);
   const widgetConfigTimeoutRef = useRef<NodeJS.Timeout | null>(null);
@@ -686,6 +688,16 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
             // Default to true if not explicitly set
             setRemoteControlEnabledState(true);
           }
+          if (
+            'dockPosition' in data &&
+            (data.dockPosition === 'bottom' ||
+              data.dockPosition === 'left' ||
+              data.dockPosition === 'right')
+          ) {
+            setDockPositionState(data.dockPosition);
+          } else {
+            setDockPositionState('bottom');
+          }
 
           setProfileLoaded(true);
           return;
@@ -801,6 +813,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
     async (updates: {
       disableCloseConfirmation?: boolean;
       remoteControlEnabled?: boolean;
+      dockPosition?: DockPosition;
     }) => {
       if (updates.disableCloseConfirmation !== undefined) {
         setDisableCloseConfirmationState(updates.disableCloseConfirmation);
@@ -808,11 +821,15 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
       if (updates.remoteControlEnabled !== undefined) {
         setRemoteControlEnabledState(updates.remoteControlEnabled);
       }
+      if (updates.dockPosition !== undefined) {
+        setDockPositionState(updates.dockPosition);
+      }
 
       // Build a sanitized payload — Firestore rejects `undefined` field values
       const sanitizedUpdates: {
         disableCloseConfirmation?: boolean;
         remoteControlEnabled?: boolean;
+        dockPosition?: DockPosition;
       } = {};
       if (typeof updates.disableCloseConfirmation === 'boolean') {
         sanitizedUpdates.disableCloseConfirmation =
@@ -820,6 +837,13 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
       }
       if (typeof updates.remoteControlEnabled === 'boolean') {
         sanitizedUpdates.remoteControlEnabled = updates.remoteControlEnabled;
+      }
+      if (
+        updates.dockPosition === 'bottom' ||
+        updates.dockPosition === 'left' ||
+        updates.dockPosition === 'right'
+      ) {
+        sanitizedUpdates.dockPosition = updates.dockPosition;
       }
 
       if (!user || isAuthBypass || Object.keys(sanitizedUpdates).length === 0) {
@@ -1188,6 +1212,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
         completeSetup,
         disableCloseConfirmation,
         remoteControlEnabled,
+        dockPosition,
         updateAccountPreferences,
       }}
     >

--- a/context/AuthContextValue.ts
+++ b/context/AuthContextValue.ts
@@ -9,6 +9,7 @@ import {
   WidgetConfig,
   UserRolesConfig,
   AppSettings,
+  DockPosition,
 } from '../types';
 
 export interface AuthContextType {
@@ -66,10 +67,13 @@ export interface AuthContextType {
   disableCloseConfirmation: boolean;
   /** Whether remote control is enabled (account-level preference) */
   remoteControlEnabled: boolean;
-  /** Update account-level preferences (disableCloseConfirmation, remoteControlEnabled) */
+  /** Where the dock is anchored on screen (account-level preference) */
+  dockPosition: DockPosition;
+  /** Update account-level preferences */
   updateAccountPreferences: (updates: {
     disableCloseConfirmation?: boolean;
     remoteControlEnabled?: boolean;
+    dockPosition?: DockPosition;
   }) => Promise<void>;
 }
 

--- a/locales/de.json
+++ b/locales/de.json
@@ -146,6 +146,11 @@
       "skipConfirmation": "Bestätigungsdialog beim Schließen von Widgets überspringen.",
       "quickAccessWidgets": "Schnellzugriff-Widgets",
       "quickAccessDescription": "Wähle bis zu 2 Widgets aus, die erscheinen, wenn das Dock minimiert ist.",
+      "dockPosition": "Dock-Position",
+      "dockPositionDescription": "Wähle, wo das Dock auf deinem Bildschirm erscheint.",
+      "dockBottom": "Unten",
+      "dockLeft": "Links",
+      "dockRight": "Rechts",
       "language": "Oberflächensprache",
       "languageDescription": "Wähle deine bevorzugte Anzeigesprache für die gesamte Tafel.",
       "saveAllChanges": "Alle Änderungen speichern"

--- a/locales/en.json
+++ b/locales/en.json
@@ -169,6 +169,11 @@
       "skipConfirmation": "Skip the confirmation prompt when closing widgets.",
       "quickAccessWidgets": "Quick Access Widgets",
       "quickAccessDescription": "Select up to 2 widgets to appear when the dock is minimized.",
+      "dockPosition": "Dock Position",
+      "dockPositionDescription": "Choose where the dock appears on your screen.",
+      "dockBottom": "Bottom",
+      "dockLeft": "Left",
+      "dockRight": "Right",
       "language": "Interface Language",
       "languageDescription": "Choose your preferred display language for the entire board.",
       "saveAllChanges": "Save all changes"

--- a/locales/es.json
+++ b/locales/es.json
@@ -149,6 +149,11 @@
       "skipConfirmation": "Omitir la confirmación al cerrar widgets.",
       "quickAccessWidgets": "Widgets de Acceso Rápido",
       "quickAccessDescription": "Selecciona hasta 2 widgets para que aparezcan cuando el dock esté minimizado.",
+      "dockPosition": "Posición del Dock",
+      "dockPositionDescription": "Elige dónde aparece el dock en tu pantalla.",
+      "dockBottom": "Abajo",
+      "dockLeft": "Izquierda",
+      "dockRight": "Derecha",
       "language": "Idioma de la Interfaz",
       "languageDescription": "Elige el idioma de visualización preferido para todo el tablero.",
       "saveAllChanges": "Guardar todos los cambios"

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -146,6 +146,11 @@
       "skipConfirmation": "Ignorer la confirmation lors de la fermeture des widgets.",
       "quickAccessWidgets": "Widgets d'accès rapide",
       "quickAccessDescription": "Sélectionnez jusqu'à 2 widgets à afficher lorsque le dock est réduit.",
+      "dockPosition": "Position du dock",
+      "dockPositionDescription": "Choisissez où le dock apparaît à l'écran.",
+      "dockBottom": "Bas",
+      "dockLeft": "Gauche",
+      "dockRight": "Droite",
       "language": "Langue de l'interface",
       "languageDescription": "Choisissez votre langue d'affichage préférée pour l'ensemble du tableau.",
       "saveAllChanges": "Enregistrer toutes les modifications"

--- a/types.ts
+++ b/types.ts
@@ -2808,6 +2808,8 @@ export interface UserProfile {
   disableCloseConfirmation?: boolean;
   /** Whether remote control is enabled for all boards (account-level) */
   remoteControlEnabled?: boolean;
+  /** Where the dock is anchored on screen (account-level) */
+  dockPosition?: DockPosition;
 }
 
 export interface SharedGroup {

--- a/types.ts
+++ b/types.ts
@@ -2915,6 +2915,12 @@ export interface AppSettings {
 export type GradeLevel = 'k-2' | '3-5' | '6-8' | '9-12';
 
 /**
+ * Where the widget dock renders on screen. Persisted per-user in the
+ * `userProfile/profile` Firestore document and surfaced via `useAuth()`.
+ */
+export type DockPosition = 'bottom' | 'left' | 'right';
+
+/**
  * Grade filter values including the 'all' ("All") option used in the UI.
  * Combined with {@link GradeLevel}, this yields: "K-2, 3-5, 6-8, 9-12, All".
  * Used for filtering widgets in the sidebar.


### PR DESCRIPTION
## Summary

Adds a new account-level preference that lets teachers anchor the dock to the **bottom** (default), **left**, or **right** edge of the screen. The setting lives in Sidebar → Preferences, is saved to `users/{uid}/userProfile/profile` in Firestore, and follows the account across devices.

- **New preference**: `dockPosition: 'bottom' | 'left' | 'right'` wired through `AuthContext` / `updateAccountPreferences`, matching the existing pattern used for `disableCloseConfirmation` and `remoteControlEnabled`.
- **Preferences UI**: new segmented `bottom / left / right` radio in `SidebarPreferences.tsx` with i18n strings for en / es / de / fr.
- **Dock layout**: `components/layout/Dock.tsx` now picks a vertical (`flex-col`) toolbar with `verticalListSortingStrategy` when the dock is on a side, and swaps drag-to-collapse to be axis-aware (collapse left on the left dock, right on the right dock, down on the bottom dock). Touch-action, collapsed-state offsets, and the inner separator also follow the orientation.
- **Popovers**: the drawing-mode popover and folder popover (`components/layout/dock/FolderItem.tsx`) now anchor off their trigger's bounding rect and flip to open beside the icon on side docks.
- **Collision avoidance**: `BoardZoomControl.tsx` and the two bottom-corner helper buttons in `DashboardView.tsx` (background-mute + cheat-sheet) shift to the opposite edge when the dock takes their default corner.

## Test plan

- [ ] `pnpm run validate` (type-check + lint + format:check + unit tests) passes locally — done; all 1,183 unit tests green.
- [ ] Sign in, open Sidebar → Preferences, confirm the new "Dock Position" card is present with three options (Bottom / Left / Right).
- [ ] Switch to **Left**: dock moves to left edge, icons are stacked vertically, drag-to-collapse works by dragging left, folder popover opens to the right of its folder icon, drawing popover opens to the right of the pencil icon.
- [ ] Switch to **Right**: mirror of the above, and confirm `BoardZoomControl` + cheat-sheet button move to the left so they don't overlap the dock.
- [ ] Switch back to **Bottom**: default behavior is unchanged (centered at bottom, drag-down-to-collapse, popovers open upward).
- [ ] Refresh the page: the preference persists (verify `users/{uid}/userProfile/profile.dockPosition` in Firestore).
- [ ] Switch UI language to es / de / fr and confirm the new labels are translated.

https://claude.ai/code/session_016aNq7XtCfDx4GgeUAMUPA1