### PR TITLE
feat(library): shared primitives for unified widget library UX (Wave 1)

### DIFF
--- a/components/common/library/AssignModal.tsx
+++ b/components/common/library/AssignModal.tsx
@@ -1,0 +1,235 @@
+/**
+ * AssignModal — shared chrome for widget "Assign" flows.
+ *
+ * Renders a modal with:
+ *   - Header containing the item title being assigned.
+ *   - Optional mode selector (radio-card layout) when `modes` is provided.
+ *   - Optional assignment-name text input (when `onAssignmentNameChange`
+ *     is provided).
+ *   - `extraSlot` body region for widget-specific toggles/inputs.
+ *   - `plcSlot` rendered below `extraSlot` for PLC / period selection.
+ *   - Footer with Cancel + Assign buttons.
+ *
+ * The primitive is presentational — it owns no widget-specific state.
+ * Widgets pass their options shape through the `options` generic; the
+ * modal echoes them back on confirm via `onAssign`.
+ *
+ * `onAssign` is async — the confirm button stays disabled while the
+ * returned promise is in-flight so callers don't need to manage a
+ * spinner themselves.
+ */
+
+import React, { useCallback, useState } from 'react';
+import { Loader2, Rocket } from 'lucide-react';
+import { Modal } from '../Modal';
+import type { AssignModalProps, AssignModeOption } from './types';
+
+const MODAL_LABEL_ID = 'assign-modal-title';
+
+export function AssignModal<TOptions>({
+  isOpen,
+  onClose,
+  itemTitle,
+  modes,
+  selectedMode,
+  onModeChange,
+  options,
+  extraSlot,
+  plcSlot,
+  assignmentName,
+  onAssignmentNameChange,
+  onAssign,
+  confirmLabel = 'Assign',
+  confirmDisabled = false,
+  confirmDisabledReason,
+}: AssignModalProps<TOptions>): React.ReactElement | null {
+  const [submitting, setSubmitting] = useState(false);
+
+  const handleAssign = useCallback(async () => {
+    if (submitting || confirmDisabled) return;
+    setSubmitting(true);
+    try {
+      await onAssign({
+        mode: selectedMode,
+        options,
+        assignmentName,
+      });
+    } finally {
+      setSubmitting(false);
+    }
+  }, [
+    submitting,
+    confirmDisabled,
+    onAssign,
+    selectedMode,
+    options,
+    assignmentName,
+  ]);
+
+  const confirmButtonDisabled = confirmDisabled || submitting;
+
+  const customHeader = (
+    <div className="flex items-center justify-between gap-4 px-6 py-4 border-b border-slate-200 shrink-0">
+      <div className="min-w-0">
+        <p className="text-xxs font-bold text-brand-blue-primary/60 uppercase tracking-widest">
+          Assign
+        </p>
+        <h3
+          id={MODAL_LABEL_ID}
+          className="font-black text-lg text-slate-800 truncate"
+        >
+          {itemTitle}
+        </h3>
+      </div>
+      <button
+        type="button"
+        onClick={onClose}
+        disabled={submitting}
+        className="text-sm font-bold text-slate-500 hover:text-slate-700 px-3 py-1.5 rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+        aria-label="Close"
+      >
+        Cancel
+      </button>
+    </div>
+  );
+
+  const footer = (
+    <div className="flex items-center justify-end gap-2 px-6 py-3">
+      <button
+        type="button"
+        onClick={onClose}
+        disabled={submitting}
+        className="px-4 py-2 text-sm font-bold text-slate-700 hover:bg-slate-100 rounded-xl transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+      >
+        Cancel
+      </button>
+      <button
+        type="button"
+        onClick={() => void handleAssign()}
+        disabled={confirmButtonDisabled}
+        title={
+          confirmDisabled && confirmDisabledReason
+            ? confirmDisabledReason
+            : undefined
+        }
+        className="inline-flex items-center gap-1.5 px-5 py-2 bg-brand-blue-primary hover:bg-brand-blue-dark text-white text-sm font-bold rounded-xl transition-colors shadow-sm disabled:opacity-50 disabled:cursor-not-allowed"
+      >
+        {submitting ? (
+          <Loader2 className="w-4 h-4 animate-spin" aria-hidden="true" />
+        ) : (
+          <Rocket className="w-4 h-4" aria-hidden="true" />
+        )}
+        {confirmLabel}
+      </button>
+    </div>
+  );
+
+  const hasModes = Array.isArray(modes) && modes.length > 0;
+  const hasName =
+    typeof assignmentName === 'string' && !!onAssignmentNameChange;
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={submitting ? () => undefined : onClose}
+      customHeader={customHeader}
+      footer={footer}
+      footerClassName="shrink-0 border-t border-slate-200 bg-white"
+      maxWidth="max-w-lg"
+      className="bg-white rounded-2xl shadow-2xl"
+      contentClassName="px-6 py-5 space-y-5"
+      ariaLabelledby={MODAL_LABEL_ID}
+    >
+      {hasName && (
+        <div>
+          <label
+            htmlFor="assign-modal-assignment-name"
+            className="block text-xxs font-bold text-slate-400 uppercase tracking-widest mb-1"
+          >
+            Assignment Name
+          </label>
+          <input
+            id="assign-modal-assignment-name"
+            type="text"
+            value={assignmentName ?? ''}
+            onChange={(e) => onAssignmentNameChange?.(e.target.value)}
+            placeholder="e.g. Period 2"
+            className="w-full px-3 py-2 bg-white border border-slate-200 rounded-lg text-slate-800 text-sm focus:outline-none focus:ring-2 focus:ring-brand-blue-primary"
+          />
+          <p className="text-xxs text-slate-400 mt-1">
+            Shown in the archive to distinguish assignments.
+          </p>
+        </div>
+      )}
+
+      {hasModes && (
+        <div className="space-y-3">
+          <p className="text-xxs font-bold text-brand-blue-primary/60 uppercase tracking-widest">
+            Session Mode
+          </p>
+          <div className="grid gap-2">
+            {modes.map((mode) => (
+              <ModeCard
+                key={mode.id}
+                mode={mode}
+                selected={mode.id === selectedMode}
+                onSelect={() => onModeChange?.(mode.id)}
+              />
+            ))}
+          </div>
+        </div>
+      )}
+
+      {extraSlot !== undefined && extraSlot !== null && (
+        <div className="space-y-3">{extraSlot}</div>
+      )}
+
+      {plcSlot !== undefined && plcSlot !== null && (
+        <div className="space-y-3">{plcSlot}</div>
+      )}
+    </Modal>
+  );
+}
+
+interface ModeCardProps {
+  mode: AssignModeOption;
+  selected: boolean;
+  onSelect: () => void;
+}
+
+const ModeCard: React.FC<ModeCardProps> = ({ mode, selected, onSelect }) => {
+  const Icon = mode.icon;
+  return (
+    <button
+      type="button"
+      onClick={onSelect}
+      disabled={mode.disabled}
+      aria-pressed={selected}
+      className={`w-full text-left p-3 rounded-xl border-2 transition-all flex items-start gap-3 group ${
+        selected
+          ? 'border-brand-blue-primary bg-brand-blue-lighter/30'
+          : 'border-slate-200 hover:border-brand-blue-primary hover:bg-brand-blue-lighter/20'
+      } ${mode.disabled ? 'opacity-50 cursor-not-allowed' : ''}`}
+    >
+      {Icon && (
+        <div
+          className={`p-2 rounded-lg transition-colors shrink-0 ${
+            selected
+              ? 'bg-brand-blue-primary text-white'
+              : 'bg-slate-100 text-brand-blue-primary'
+          }`}
+        >
+          <Icon size={18} />
+        </div>
+      )}
+      <div className="min-w-0 flex-1">
+        <p className="font-black text-sm text-slate-800 leading-tight">
+          {mode.label}
+        </p>
+        <p className="text-xs text-slate-500 mt-0.5 leading-snug">
+          {mode.description}
+        </p>
+      </div>
+    </button>
+  );
+};

--- a/components/common/library/AssignmentArchiveCard.tsx
+++ b/components/common/library/AssignmentArchiveCard.tsx
@@ -1,0 +1,229 @@
+/**
+ * AssignmentArchiveCard — one card per assignment in the In Progress /
+ * Archive tabs.
+ *
+ * Generalizes `QuizAssignmentArchive`'s row rendering: status badge,
+ * title + subtitle, optional meta line, primary action button, and an
+ * overflow menu (MoreHorizontal) surfacing secondary actions.
+ *
+ * Two visual modes:
+ *   - `'active'`: full-colour styling for live/paused assignments.
+ *   - `'archive'`: muted styling for ended assignments.
+ *
+ * The primitive is status-agnostic — the consumer resolves the
+ * assignment's status into an `AssignmentStatusBadge` (label + tone +
+ * optional dot) and passes it in. Tone → colour mapping follows the
+ * shared `LibraryBadgeTone` convention.
+ */
+
+import React, { useRef, useState } from 'react';
+import { MoreHorizontal } from 'lucide-react';
+import { useClickOutside } from '@/hooks/useClickOutside';
+import type {
+  AssignmentArchiveCardProps,
+  LibraryBadgeTone,
+  LibraryMenuAction,
+} from './types';
+
+/* ─── Tone → styling ──────────────────────────────────────────────────────── */
+
+interface ToneStyles {
+  badgeBg: string;
+  badgeFg: string;
+  dot: string;
+  activeBorder: string;
+}
+
+const TONE_STYLES: Record<LibraryBadgeTone, ToneStyles> = {
+  success: {
+    badgeBg: 'bg-emerald-100',
+    badgeFg: 'text-emerald-700',
+    dot: 'bg-emerald-500',
+    activeBorder: 'border-emerald-200/60 hover:shadow-md',
+  },
+  warn: {
+    badgeBg: 'bg-amber-100',
+    badgeFg: 'text-amber-700',
+    dot: 'bg-amber-500',
+    activeBorder: 'border-amber-200/60 hover:shadow',
+  },
+  neutral: {
+    badgeBg: 'bg-slate-200',
+    badgeFg: 'text-slate-500',
+    dot: 'bg-slate-400',
+    activeBorder: 'border-slate-200/60 hover:shadow',
+  },
+  info: {
+    badgeBg: 'bg-blue-100',
+    badgeFg: 'text-blue-700',
+    dot: 'bg-blue-500',
+    activeBorder: 'border-blue-200/60 hover:shadow',
+  },
+  danger: {
+    badgeBg: 'bg-red-100',
+    badgeFg: 'text-red-700',
+    dot: 'bg-red-500',
+    activeBorder: 'border-red-200/60 hover:shadow',
+  },
+};
+
+/* ─── OverflowMenu (reused pattern from QuizAssignmentArchive) ────────────── */
+
+interface OverflowMenuProps {
+  actions: LibraryMenuAction[];
+}
+
+const OverflowMenu: React.FC<OverflowMenuProps> = ({ actions }) => {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+  useClickOutside(ref, () => setOpen(false));
+
+  if (actions.length === 0) return null;
+
+  // Sort destructive actions to the bottom while preserving caller order
+  // within each bucket.
+  const normalActions = actions.filter((a) => !a.destructive);
+  const destructiveActions = actions.filter((a) => a.destructive);
+  const orderedActions = [...normalActions, ...destructiveActions];
+
+  return (
+    <div ref={ref} className="relative">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className="flex items-center justify-center w-7 h-7 rounded-lg text-brand-blue-dark/60 hover:text-brand-blue-dark hover:bg-brand-blue-lighter/30 transition-colors"
+        title="More actions"
+        aria-label="More actions"
+        aria-haspopup="menu"
+        aria-expanded={open}
+      >
+        <MoreHorizontal size={16} />
+      </button>
+      {open && (
+        <div
+          role="menu"
+          className="absolute right-0 top-full mt-1 min-w-[160px] bg-white rounded-lg shadow-lg border border-brand-blue-primary/15 py-1 z-50"
+        >
+          {orderedActions.map((item) => {
+            const Icon = item.icon;
+            return (
+              <button
+                key={item.id}
+                type="button"
+                role="menuitem"
+                onClick={() => {
+                  if (item.disabled) return;
+                  setOpen(false);
+                  item.onClick();
+                }}
+                disabled={item.disabled}
+                title={item.disabled ? item.disabledReason : undefined}
+                className={`w-full flex items-center gap-2 text-left px-3 py-1.5 text-xs font-semibold transition-colors disabled:opacity-40 disabled:cursor-not-allowed ${
+                  item.destructive
+                    ? 'text-brand-red-dark hover:bg-brand-red-lighter/30'
+                    : 'text-brand-blue-dark hover:bg-brand-blue-lighter/30'
+                }`}
+              >
+                {Icon && <Icon size={12} className="shrink-0" />}
+                <span className="truncate">{item.label}</span>
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+};
+
+/* ─── Main component ──────────────────────────────────────────────────────── */
+
+export function AssignmentArchiveCard<TAssignment>({
+  mode,
+  status,
+  primaryAction,
+  secondaryActions,
+  meta,
+  title,
+  subtitle,
+}: AssignmentArchiveCardProps<TAssignment>): React.ReactElement {
+  const tone = TONE_STYLES[status.tone];
+  const isArchive = mode === 'archive';
+
+  const PrimaryIcon = primaryAction.icon;
+
+  const cardClass = isArchive
+    ? 'bg-white/70 border-slate-200/60 opacity-70'
+    : `bg-white ${tone.activeBorder}`;
+
+  const titleClass = isArchive ? 'text-slate-500' : 'text-brand-blue-dark';
+  const metaClass = isArchive ? 'text-slate-400' : 'text-brand-blue-primary/60';
+
+  return (
+    <div
+      className={`rounded-xl border shadow-sm transition-shadow p-2.5 ${cardClass}`}
+    >
+      <div className="flex items-center gap-2">
+        {/* Status dot (live pulse / paused static dot) */}
+        {status.dot && !isArchive && (
+          <div
+            className={`shrink-0 w-2 h-2 rounded-full ${tone.dot} ${
+              status.tone === 'success'
+                ? 'animate-pulse shadow-[0_0_6px_rgba(16,185,129,0.5)]'
+                : ''
+            }`}
+            aria-hidden="true"
+          />
+        )}
+
+        {/* Title + subtitle + meta */}
+        <div className="flex-1 min-w-0">
+          <div
+            className={`font-bold text-sm truncate ${titleClass}`}
+            title={title}
+          >
+            {title}
+          </div>
+          <div
+            className={`flex items-center gap-2 mt-0.5 text-xs ${metaClass}`}
+          >
+            {subtitle !== undefined && subtitle !== null && (
+              <span className="font-semibold truncate max-w-[120px]">
+                {subtitle}
+              </span>
+            )}
+            {meta !== undefined && meta !== null && (
+              <span className="flex items-center gap-2 min-w-0">{meta}</span>
+            )}
+          </div>
+        </div>
+
+        {/* Status badge */}
+        <div
+          data-testid="assignment-status-badge"
+          className={`flex items-center gap-1 rounded-full px-2 py-0.5 text-[9px] font-bold uppercase tracking-wide shrink-0 ${tone.badgeBg} ${tone.badgeFg}`}
+        >
+          {status.label}
+        </div>
+
+        {/* Primary action */}
+        <button
+          type="button"
+          onClick={primaryAction.onClick}
+          disabled={primaryAction.disabled}
+          title={
+            primaryAction.disabled ? primaryAction.disabledReason : undefined
+          }
+          className="flex items-center gap-1 shrink-0 px-2.5 py-1 bg-brand-blue-primary hover:bg-brand-blue-dark text-white text-xs font-bold rounded-lg transition-all active:scale-95 disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          {PrimaryIcon && <PrimaryIcon size={12} className="shrink-0" />}
+          <span>{primaryAction.label}</span>
+        </button>
+
+        {/* Overflow menu */}
+        {secondaryActions && secondaryActions.length > 0 && (
+          <OverflowMenu actions={secondaryActions} />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/components/common/library/LibraryGrid.tsx
+++ b/components/common/library/LibraryGrid.tsx
@@ -1,0 +1,148 @@
+/**
+ * LibraryGrid — dnd-kit `SortableContext` wrapper for the library surface.
+ *
+ * Presentational only: it does not own item state. Consumers pass their
+ * (already-ordered) items and a `renderCard` callback, and the grid wires
+ * up the `DndContext` + `SortableContext` + `DragOverlay` around them.
+ *
+ * Drag is auto-disabled when `dragDisabled === true`. When `reorderLocked`
+ * is set (but drag isn't fully disabled), drag handles are rendered at
+ * reduced opacity with an explanatory tooltip from `reorderLockedReason`
+ * — this is surfaced to cards via `LibraryGridLockContext`.
+ *
+ * The grid renders `emptyState` in place of the list when `items.length === 0`.
+ */
+
+import React, { useMemo, useState } from 'react';
+import {
+  DndContext,
+  DragOverlay,
+  KeyboardSensor,
+  PointerSensor,
+  closestCenter,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+  type DragStartEvent,
+} from '@dnd-kit/core';
+import {
+  SortableContext,
+  rectSortingStrategy,
+  sortableKeyboardCoordinates,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable';
+import type { LibraryGridProps } from './types';
+import { LibraryGridLockContext } from './LibraryGridLockContext';
+
+export function LibraryGrid<TItem>(props: LibraryGridProps<TItem>) {
+  const {
+    items,
+    getId,
+    renderCard,
+    onReorder,
+    dragDisabled = false,
+    reorderLocked = false,
+    reorderLockedReason,
+    layout = 'grid',
+    emptyState,
+  } = props;
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, {
+      activationConstraint: { distance: 5 },
+    }),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    })
+  );
+
+  const [activeId, setActiveId] = useState<string | null>(null);
+
+  const ids = useMemo(() => items.map(getId), [items, getId]);
+  const activeItem = useMemo(
+    () =>
+      activeId == null
+        ? null
+        : (items.find((i) => getId(i) === activeId) ?? null),
+    [activeId, items, getId]
+  );
+  const activeIndex = useMemo(
+    () => (activeItem == null ? -1 : items.indexOf(activeItem)),
+    [activeItem, items]
+  );
+
+  const lockState = useMemo(
+    () => ({
+      locked: reorderLocked,
+      reason: reorderLocked ? reorderLockedReason : undefined,
+      dragDisabled,
+    }),
+    [reorderLocked, reorderLockedReason, dragDisabled]
+  );
+
+  if (items.length === 0) {
+    return <>{emptyState ?? null}</>;
+  }
+
+  const handleDragStart = (event: DragStartEvent) => {
+    setActiveId(String(event.active.id));
+  };
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    setActiveId(null);
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+    if (!onReorder) return;
+
+    const oldIndex = ids.indexOf(String(active.id));
+    const newIndex = ids.indexOf(String(over.id));
+    if (oldIndex === -1 || newIndex === -1) return;
+
+    const next = [...ids];
+    const [moved] = next.splice(oldIndex, 1);
+    if (moved === undefined) return;
+    next.splice(newIndex, 0, moved);
+
+    void Promise.resolve(onReorder(next));
+  };
+
+  const handleDragCancel = () => {
+    setActiveId(null);
+  };
+
+  const isListLayout = layout === 'list';
+  const strategy = isListLayout
+    ? verticalListSortingStrategy
+    : rectSortingStrategy;
+
+  const containerClass = isListLayout
+    ? 'flex flex-col gap-3'
+    : 'grid gap-3 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3';
+
+  return (
+    <LibraryGridLockContext.Provider value={lockState}>
+      <DndContext
+        sensors={sensors}
+        collisionDetection={closestCenter}
+        onDragStart={handleDragStart}
+        onDragEnd={handleDragEnd}
+        onDragCancel={handleDragCancel}
+      >
+        <SortableContext items={ids} strategy={strategy}>
+          <div className={containerClass} data-testid="library-grid">
+            {items.map((item, index) => renderCard(item, index))}
+          </div>
+        </SortableContext>
+        <DragOverlay>
+          {activeItem != null ? (
+            <LibraryGridLockContext.Provider
+              value={{ locked: false, reason: undefined, dragDisabled: true }}
+            >
+              {renderCard(activeItem, activeIndex)}
+            </LibraryGridLockContext.Provider>
+          ) : null}
+        </DragOverlay>
+      </DndContext>
+    </LibraryGridLockContext.Provider>
+  );
+}

--- a/components/common/library/LibraryGridLockContext.ts
+++ b/components/common/library/LibraryGridLockContext.ts
@@ -1,0 +1,22 @@
+/**
+ * LibraryGridLockContext — channel by which `LibraryGrid` communicates its
+ * drag/reorder lock state down to each `LibraryItemCard` it renders.
+ *
+ * Consumers never read this context directly; it's an internal primitive
+ * of the library surface. Separated from `LibraryItemCard` for react-refresh
+ * (fast refresh only works when a file exports components-only).
+ */
+
+import { createContext } from 'react';
+
+export interface LibraryGridLockState {
+  locked: boolean;
+  reason?: string;
+  /** When true, hides drag handles outright (grid-level `dragDisabled`). */
+  dragDisabled: boolean;
+}
+
+export const LibraryGridLockContext = createContext<LibraryGridLockState>({
+  locked: false,
+  dragDisabled: false,
+});

--- a/components/common/library/LibraryItemCard.tsx
+++ b/components/common/library/LibraryItemCard.tsx
@@ -180,11 +180,16 @@ function CardBody<TMeta>(props: CardBodyProps<TMeta>) {
   return (
     <div
       onClick={onClick ? handleBodyClick : undefined}
-      className={`group relative flex rounded-2xl border border-slate-200 bg-white text-slate-700 shadow-sm transition-shadow hover:shadow-md ${
-        isList ? 'flex-row items-center gap-3 p-3' : 'flex-col gap-3 p-4'
-      } ${onClick ? 'cursor-pointer' : ''} ${
-        isDragging ? 'opacity-50' : ''
-      } ${isDragOverlay ? 'pointer-events-none ring-2 ring-brand-blue-primary/30' : ''}`}
+      className={[
+        'group relative flex rounded-2xl border border-slate-200 bg-white text-slate-700 shadow-sm transition-shadow hover:shadow-md',
+        isList ? 'flex-row items-center gap-3 p-3' : 'flex-col gap-3 p-4',
+        onClick && 'cursor-pointer',
+        isDragging && 'opacity-50',
+        isDragOverlay &&
+          'pointer-events-none ring-2 ring-brand-blue-primary/30',
+      ]
+        .filter(Boolean)
+        .join(' ')}
       aria-hidden={isDragOverlay}
     >
       {/* Drag handle (left edge) */}
@@ -204,8 +209,9 @@ function CardBody<TMeta>(props: CardBodyProps<TMeta>) {
       {/* Main body */}
       <div className="flex min-w-0 flex-1 flex-col gap-1">
         <h3
-          className="truncate font-black text-slate-800"
-          style={{ fontSize: isList ? '14px' : '15px' }}
+          className={`truncate font-black text-slate-800 ${
+            isList ? 'text-sm' : 'text-[15px]'
+          }`}
         >
           {title}
         </h3>

--- a/components/common/library/LibraryItemCard.tsx
+++ b/components/common/library/LibraryItemCard.tsx
@@ -1,0 +1,320 @@
+/**
+ * LibraryItemCard — generic sortable card for the unified Library system.
+ *
+ * Implements `LibraryItemCardProps<TMeta>` from ./types. Wraps dnd-kit's
+ * `useSortable` when `sortable !== false && !isDragOverlay`, otherwise renders
+ * a static card (used for the floating `DragOverlay`). Card body click routes
+ * to `onClick`; drag starts from a dedicated grip handle so body clicks are
+ * unambiguous.
+ *
+ * Visual style matches the QuizManager light interior — white surface with
+ * slate border, rounded-2xl, brand-blue accents on primary action, and a
+ * click-outside overflow menu (MoreHorizontal) for secondary actions.
+ *
+ * When the parent `LibraryGrid` locks reordering (search active or non-manual
+ * sort) it passes a hint through `LibraryGridLockContext`; cards surface the
+ * hint as the drag-handle tooltip at reduced opacity.
+ */
+
+import React, { useContext, useRef, useState } from 'react';
+import { useSortable } from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import { GripVertical, MoreHorizontal } from 'lucide-react';
+import { useClickOutside } from '@/hooks/useClickOutside';
+import { Z_INDEX } from '@/config/zIndex';
+import { LibraryGridLockContext } from './LibraryGridLockContext';
+import type {
+  LibraryBadge,
+  LibraryBadgeTone,
+  LibraryItemCardProps,
+  LibraryMenuAction,
+} from './types';
+
+/* ─── Badge tone styles ───────────────────────────────────────────────────── */
+
+const BADGE_TONE_STYLES: Record<
+  LibraryBadgeTone,
+  { bg: string; fg: string; dot: string }
+> = {
+  neutral: { bg: 'bg-slate-100', fg: 'text-slate-600', dot: 'bg-slate-400' },
+  info: {
+    bg: 'bg-brand-blue-lighter/40',
+    fg: 'text-brand-blue-dark',
+    dot: 'bg-brand-blue-primary',
+  },
+  warn: { bg: 'bg-amber-100', fg: 'text-amber-700', dot: 'bg-amber-500' },
+  success: {
+    bg: 'bg-emerald-100',
+    fg: 'text-emerald-700',
+    dot: 'bg-emerald-500',
+  },
+  danger: {
+    bg: 'bg-brand-red-lighter/40',
+    fg: 'text-brand-red-dark',
+    dot: 'bg-brand-red-primary',
+  },
+};
+
+/* ─── Overflow menu (click-outside aware) ─────────────────────────────────── */
+
+interface OverflowMenuProps {
+  actions: LibraryMenuAction[];
+}
+
+const OverflowMenu: React.FC<OverflowMenuProps> = ({ actions }) => {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useClickOutside(ref, () => setOpen(false));
+
+  if (actions.length === 0) return null;
+
+  // Destructive actions float to the bottom to mirror the Quiz pattern.
+  const ordered = [...actions].sort((a, b) => {
+    if (a.destructive === b.destructive) return 0;
+    return a.destructive ? 1 : -1;
+  });
+
+  return (
+    <div ref={ref} className="relative">
+      <button
+        type="button"
+        onClick={(e) => {
+          e.stopPropagation();
+          setOpen((v) => !v);
+        }}
+        className="flex h-8 w-8 items-center justify-center rounded-lg text-slate-500 transition-colors hover:bg-slate-100 hover:text-slate-700"
+        title="More actions"
+        aria-label="More actions"
+        aria-haspopup="menu"
+        aria-expanded={open}
+      >
+        <MoreHorizontal className="h-4 w-4" />
+      </button>
+      {open && (
+        <div
+          role="menu"
+          className="absolute right-0 top-full z-50 mt-1 min-w-[176px] overflow-hidden rounded-xl border border-slate-200 bg-white py-1 text-sm shadow-lg"
+        >
+          {ordered.map((item) => {
+            const Icon = item.icon;
+            return (
+              <button
+                key={item.id}
+                role="menuitem"
+                type="button"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  setOpen(false);
+                  if (!item.disabled) item.onClick();
+                }}
+                disabled={item.disabled}
+                title={item.disabled ? item.disabledReason : undefined}
+                className={`flex w-full items-center gap-2 px-3 py-1.5 text-left font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-40 ${
+                  item.destructive
+                    ? 'text-brand-red-dark hover:bg-brand-red-lighter/30'
+                    : 'text-slate-700 hover:bg-slate-100'
+                }`}
+              >
+                {Icon && <Icon size={14} className="shrink-0" />}
+                <span className="truncate">{item.label}</span>
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+};
+
+/* ─── Badge chip ──────────────────────────────────────────────────────────── */
+
+const BadgeChip: React.FC<{ badge: LibraryBadge }> = ({ badge }) => {
+  const tone = BADGE_TONE_STYLES[badge.tone];
+  return (
+    <span
+      className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[11px] font-bold uppercase tracking-wider ${tone.bg} ${tone.fg}`}
+    >
+      {badge.dot && (
+        <span
+          className={`h-1.5 w-1.5 shrink-0 rounded-full ${tone.dot}`}
+          aria-hidden="true"
+        />
+      )}
+      {badge.label}
+    </span>
+  );
+};
+
+/* ─── Inner card body (presentation only — no dnd-kit coupling) ───────────── */
+
+interface CardBodyProps<TMeta> extends LibraryItemCardProps<TMeta> {
+  dragHandle?: React.ReactNode;
+  isDragging?: boolean;
+}
+
+function CardBody<TMeta>(props: CardBodyProps<TMeta>) {
+  const {
+    title,
+    subtitle,
+    thumbnail,
+    badges,
+    primaryAction,
+    secondaryActions,
+    onClick,
+    viewMode = 'grid',
+    dragHandle,
+    isDragOverlay,
+    isDragging,
+  } = props;
+
+  const PrimaryIcon = primaryAction.icon;
+  const isList = viewMode === 'list';
+
+  const handleBodyClick = (e: React.MouseEvent<HTMLDivElement>) => {
+    // Ignore bubbled events from buttons / links / menus inside the card.
+    if ((e.target as HTMLElement).closest('button, a, [role="menu"]')) return;
+    onClick?.();
+  };
+
+  return (
+    <div
+      onClick={onClick ? handleBodyClick : undefined}
+      className={`group relative flex rounded-2xl border border-slate-200 bg-white text-slate-700 shadow-sm transition-shadow hover:shadow-md ${
+        isList ? 'flex-row items-center gap-3 p-3' : 'flex-col gap-3 p-4'
+      } ${onClick ? 'cursor-pointer' : ''} ${
+        isDragging ? 'opacity-50' : ''
+      } ${isDragOverlay ? 'pointer-events-none ring-2 ring-brand-blue-primary/30' : ''}`}
+      aria-hidden={isDragOverlay}
+    >
+      {/* Drag handle (left edge) */}
+      {dragHandle}
+
+      {/* Thumbnail */}
+      {thumbnail && (
+        <div
+          className={`flex shrink-0 items-center justify-center overflow-hidden rounded-xl bg-slate-50 ${
+            isList ? 'h-12 w-12' : 'h-24 w-full'
+          }`}
+        >
+          {thumbnail}
+        </div>
+      )}
+
+      {/* Main body */}
+      <div className="flex min-w-0 flex-1 flex-col gap-1">
+        <h3
+          className="truncate font-black text-slate-800"
+          style={{ fontSize: isList ? '14px' : '15px' }}
+        >
+          {title}
+        </h3>
+        {subtitle && (
+          <div className="truncate text-xs font-medium text-slate-500">
+            {subtitle}
+          </div>
+        )}
+        {badges && badges.length > 0 && (
+          <div className="mt-1 flex flex-wrap items-center gap-1.5">
+            {badges.map((b, i) => (
+              <BadgeChip key={`${b.label}-${i}`} badge={b} />
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Actions (right side) */}
+      <div
+        className={`flex shrink-0 items-center gap-1 ${
+          isList ? '' : 'self-end'
+        }`}
+      >
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation();
+            if (!primaryAction.disabled) primaryAction.onClick();
+          }}
+          disabled={primaryAction.disabled}
+          title={
+            primaryAction.disabled
+              ? primaryAction.disabledReason
+              : primaryAction.label
+          }
+          className="inline-flex items-center gap-1.5 rounded-xl bg-brand-blue-primary px-3 py-1.5 text-xs font-bold uppercase tracking-widest text-white shadow-sm transition-all hover:bg-brand-blue-dark active:scale-95 disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:bg-brand-blue-primary"
+        >
+          {PrimaryIcon && <PrimaryIcon size={14} />}
+          {primaryAction.label}
+        </button>
+        {secondaryActions && secondaryActions.length > 0 && (
+          <OverflowMenu actions={secondaryActions} />
+        )}
+      </div>
+    </div>
+  );
+}
+
+/* ─── Main component ──────────────────────────────────────────────────────── */
+
+export function LibraryItemCard<TMeta = unknown>(
+  props: LibraryItemCardProps<TMeta>
+) {
+  const { sortable = true, isDragOverlay = false } = props;
+  const lockState = useContext(LibraryGridLockContext);
+
+  // When used inside the floating DragOverlay, or when sorting is disabled
+  // at either card or grid level, render a static card without useSortable.
+  const canSort = sortable && !isDragOverlay && !lockState.dragDisabled;
+
+  if (!canSort) {
+    return <CardBody {...props} />;
+  }
+
+  return <SortableCard {...props} lockedReason={lockState.reason} />;
+}
+
+/* ─── Sortable wrapper (separate to keep hook call conditional-safe) ──────── */
+
+interface SortableCardProps<TMeta> extends LibraryItemCardProps<TMeta> {
+  lockedReason?: string;
+}
+
+function SortableCard<TMeta>(props: SortableCardProps<TMeta>) {
+  const { id, lockedReason } = props;
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id, disabled: Boolean(lockedReason) });
+
+  const style: React.CSSProperties = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    zIndex: isDragging ? Z_INDEX.itemDragging : undefined,
+  };
+
+  const dragHandle = (
+    <button
+      type="button"
+      {...attributes}
+      {...listeners}
+      disabled={Boolean(lockedReason)}
+      title={lockedReason ?? 'Drag to reorder'}
+      aria-label={lockedReason ?? 'Drag to reorder'}
+      className={`flex h-8 w-6 shrink-0 cursor-grab items-center justify-center rounded-lg text-slate-300 transition-colors hover:bg-slate-100 hover:text-slate-500 active:cursor-grabbing touch-none disabled:cursor-not-allowed ${
+        lockedReason ? 'opacity-40' : ''
+      }`}
+    >
+      <GripVertical className="h-4 w-4" />
+    </button>
+  );
+
+  return (
+    <div ref={setNodeRef} style={style}>
+      <CardBody {...props} dragHandle={dragHandle} isDragging={isDragging} />
+    </div>
+  );
+}

--- a/components/common/library/LibraryShell.tsx
+++ b/components/common/library/LibraryShell.tsx
@@ -1,0 +1,157 @@
+import React from 'react';
+import { BookOpen, Activity, Archive as ArchiveIcon } from 'lucide-react';
+import type {
+  LibraryShellProps,
+  LibraryTab,
+  LibraryPrimaryAction,
+} from './types';
+
+interface TabDef {
+  key: LibraryTab;
+  label: string;
+  icon: React.ComponentType<{ size?: number; className?: string }>;
+  count: number | undefined;
+}
+
+const renderActionButton = (
+  action: LibraryPrimaryAction,
+  variant: 'primary' | 'secondary',
+  key?: string
+): React.ReactElement => {
+  const Icon = action.icon;
+  const base =
+    'inline-flex items-center gap-1.5 px-3.5 py-2 rounded-xl text-sm font-bold transition-all shadow-sm active:scale-95 disabled:opacity-50 disabled:cursor-not-allowed';
+  const variantClass =
+    variant === 'primary'
+      ? 'bg-brand-blue-primary hover:bg-brand-blue-dark text-white'
+      : 'bg-white hover:bg-brand-blue-lighter/40 text-brand-blue-primary border border-brand-blue-primary/20';
+  return (
+    <button
+      key={key}
+      type="button"
+      onClick={action.onClick}
+      disabled={action.disabled}
+      title={action.disabled ? action.disabledReason : undefined}
+      className={`${base} ${variantClass}`}
+    >
+      {Icon && <Icon size={16} className="shrink-0" />}
+      <span className="truncate">{action.label}</span>
+    </button>
+  );
+};
+
+export const LibraryShell: React.FC<LibraryShellProps> = ({
+  widgetLabel,
+  tab,
+  onTabChange,
+  counts,
+  primaryAction,
+  secondaryActions,
+  toolbarSlot,
+  filterSidebarSlot,
+  children,
+}) => {
+  const tabs: TabDef[] = [
+    {
+      key: 'library',
+      label: 'Library',
+      icon: BookOpen,
+      count: counts?.library,
+    },
+    {
+      key: 'active',
+      label: 'In Progress',
+      icon: Activity,
+      count: counts?.active,
+    },
+    {
+      key: 'archive',
+      label: 'Archive',
+      icon: ArchiveIcon,
+      count: counts?.archive,
+    },
+  ];
+
+  return (
+    <section
+      className="flex flex-col h-full min-h-0 bg-slate-50 text-slate-800 rounded-2xl overflow-hidden"
+      aria-label={`${widgetLabel} library`}
+    >
+      <header className="flex items-center justify-between gap-4 px-6 py-4 bg-white border-b border-slate-200 shrink-0">
+        <div className="min-w-0">
+          <h2 className="font-black text-lg text-slate-800 truncate">
+            {widgetLabel} Library
+          </h2>
+        </div>
+        {(primaryAction != null ||
+          (secondaryActions != null && secondaryActions.length > 0)) && (
+          <div className="flex items-center gap-2 shrink-0">
+            {secondaryActions?.map((action, i) =>
+              renderActionButton(action, 'secondary', `secondary-${i}`)
+            )}
+            {primaryAction && renderActionButton(primaryAction, 'primary')}
+          </div>
+        )}
+      </header>
+
+      <nav
+        role="tablist"
+        aria-label={`${widgetLabel} library tabs`}
+        className="flex items-end gap-1 px-6 pt-3 bg-white border-b border-slate-200 shrink-0"
+      >
+        {tabs.map(({ key, label, icon: Icon, count }) => {
+          const selected = tab === key;
+          return (
+            <button
+              key={key}
+              type="button"
+              role="tab"
+              aria-selected={selected}
+              onClick={() => onTabChange(key)}
+              className={`inline-flex items-center gap-2 rounded-t-xl px-4 py-2.5 text-sm font-black uppercase tracking-widest transition-colors ${
+                selected
+                  ? 'bg-slate-50 text-brand-blue-primary border-x border-t border-slate-200'
+                  : 'text-slate-400 hover:text-brand-blue-primary hover:bg-slate-100/60'
+              }`}
+            >
+              <Icon size={14} className="shrink-0" />
+              <span>{label}</span>
+              {count != null && count > 0 && (
+                <span
+                  className={`inline-flex items-center justify-center rounded-full px-2 py-0.5 text-[10px] font-bold leading-none ${
+                    selected
+                      ? 'bg-brand-blue-primary text-white'
+                      : 'bg-slate-200 text-slate-600'
+                  }`}
+                >
+                  {count}
+                </span>
+              )}
+            </button>
+          );
+        })}
+      </nav>
+
+      {toolbarSlot && (
+        <div className="px-6 py-3 bg-white border-b border-slate-200 shrink-0">
+          {toolbarSlot}
+        </div>
+      )}
+
+      <div className="flex flex-1 min-h-0">
+        {filterSidebarSlot && (
+          <aside className="w-60 shrink-0 bg-white border-r border-slate-200 overflow-y-auto">
+            {filterSidebarSlot}
+          </aside>
+        )}
+        <div
+          role="tabpanel"
+          aria-label={`${widgetLabel} ${tab} tab content`}
+          className="flex-1 min-w-0 overflow-y-auto px-6 py-5"
+        >
+          {children}
+        </div>
+      </div>
+    </section>
+  );
+};

--- a/components/common/library/LibraryToolbar.tsx
+++ b/components/common/library/LibraryToolbar.tsx
@@ -1,0 +1,231 @@
+import React, { useRef, useState } from 'react';
+import {
+  Search,
+  ArrowUpDown,
+  ArrowUp,
+  ArrowDown,
+  LayoutGrid,
+  List as ListIcon,
+  Check,
+  ChevronDown,
+} from 'lucide-react';
+import type {
+  LibraryToolbarProps,
+  LibrarySortDir,
+  LibraryViewMode,
+} from './types';
+import { useClickOutside } from '@/hooks/useClickOutside';
+
+const SortDropdown: React.FC<{
+  sort: LibraryToolbarProps['sort'];
+  sortOptions: LibraryToolbarProps['sortOptions'];
+  onSortChange: LibraryToolbarProps['onSortChange'];
+}> = ({ sort, sortOptions, onSortChange }) => {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+  useClickOutside(ref, () => setOpen(false));
+
+  const active = sortOptions.find((o) => o.key === sort.key);
+  const toggleDir = () => {
+    const next: LibrarySortDir = sort.dir === 'asc' ? 'desc' : 'asc';
+    onSortChange({ key: sort.key, dir: next });
+  };
+
+  return (
+    <div ref={ref} className="relative">
+      <div className="inline-flex items-stretch rounded-xl border border-slate-200 bg-white shadow-sm overflow-hidden">
+        <button
+          type="button"
+          onClick={() => setOpen((v) => !v)}
+          aria-haspopup="listbox"
+          aria-expanded={open}
+          className="inline-flex items-center gap-2 px-3 py-2 text-sm font-bold text-slate-700 hover:bg-slate-50 transition-colors"
+        >
+          <ArrowUpDown size={14} className="shrink-0 text-slate-500" />
+          <span className="truncate">{active?.label ?? 'Sort'}</span>
+          <ChevronDown size={14} className="shrink-0 text-slate-400" />
+        </button>
+        <button
+          type="button"
+          onClick={toggleDir}
+          aria-label={sort.dir === 'asc' ? 'Sort ascending' : 'Sort descending'}
+          title={sort.dir === 'asc' ? 'Ascending' : 'Descending'}
+          className="inline-flex items-center justify-center px-2.5 border-l border-slate-200 text-slate-600 hover:bg-slate-50 transition-colors"
+        >
+          {sort.dir === 'asc' ? <ArrowUp size={14} /> : <ArrowDown size={14} />}
+        </button>
+      </div>
+      {open && (
+        <div
+          role="listbox"
+          className="absolute right-0 top-full mt-1 z-10 min-w-[12rem] rounded-xl border border-slate-200 bg-white shadow-lg py-1"
+        >
+          {sortOptions.map((opt) => {
+            const selected = opt.key === sort.key;
+            return (
+              <button
+                key={opt.key}
+                type="button"
+                role="option"
+                aria-selected={selected}
+                onClick={() => {
+                  const nextDir: LibrarySortDir =
+                    opt.key === sort.key ? sort.dir : (opt.defaultDir ?? 'asc');
+                  onSortChange({ key: opt.key, dir: nextDir });
+                  setOpen(false);
+                }}
+                className={`flex items-center justify-between w-full px-3 py-2 text-sm text-left transition-colors ${
+                  selected
+                    ? 'bg-brand-blue-lighter/30 text-brand-blue-primary font-bold'
+                    : 'text-slate-700 hover:bg-slate-50 font-medium'
+                }`}
+              >
+                <span className="truncate">{opt.label}</span>
+                {selected && <Check size={14} className="shrink-0" />}
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+};
+
+const FilterDropdown: React.FC<{
+  id: string;
+  label: string;
+  options: Array<{ value: string; label: string }>;
+  value: string;
+  onChange: (value: string) => void;
+}> = ({ id, label, options, value, onChange }) => {
+  const isActive = value !== '';
+  return (
+    <div className="relative inline-flex items-center">
+      <select
+        id={`library-filter-${id}`}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        aria-label={label}
+        className={`appearance-none rounded-xl border bg-white shadow-sm pl-3 pr-8 py-2 text-sm font-bold transition-colors cursor-pointer hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-brand-blue-primary/30 ${
+          isActive
+            ? 'border-brand-blue-primary/40 text-brand-blue-primary'
+            : 'border-slate-200 text-slate-700'
+        }`}
+      >
+        <option value="">{label}: All</option>
+        {options.map((opt) => (
+          <option key={opt.value} value={opt.value}>
+            {label}: {opt.label}
+          </option>
+        ))}
+      </select>
+      <ChevronDown
+        size={14}
+        className="absolute right-2.5 top-1/2 -translate-y-1/2 text-slate-400 pointer-events-none"
+      />
+    </div>
+  );
+};
+
+const ViewModeToggle: React.FC<{
+  viewMode: LibraryViewMode;
+  onChange: (next: LibraryViewMode) => void;
+}> = ({ viewMode, onChange }) => {
+  const btn = (
+    mode: LibraryViewMode,
+    Icon: typeof LayoutGrid,
+    label: string
+  ) => {
+    const selected = viewMode === mode;
+    return (
+      <button
+        key={mode}
+        type="button"
+        role="radio"
+        aria-checked={selected}
+        aria-label={label}
+        title={label}
+        onClick={() => onChange(mode)}
+        className={`inline-flex items-center justify-center px-2.5 py-2 transition-colors ${
+          selected
+            ? 'bg-brand-blue-primary text-white'
+            : 'text-slate-500 hover:bg-slate-50'
+        }`}
+      >
+        <Icon size={14} />
+      </button>
+    );
+  };
+  return (
+    <div
+      role="radiogroup"
+      aria-label="View mode"
+      className="inline-flex items-stretch rounded-xl border border-slate-200 bg-white shadow-sm overflow-hidden"
+    >
+      {btn('grid', LayoutGrid, 'Grid view')}
+      {btn('list', ListIcon, 'List view')}
+    </div>
+  );
+};
+
+export const LibraryToolbar: React.FC<LibraryToolbarProps> = ({
+  search,
+  onSearchChange,
+  searchPlaceholder = 'Search…',
+  sort,
+  sortOptions,
+  onSortChange,
+  filters,
+  filterValues,
+  onFilterChange,
+  viewMode,
+  onViewModeChange,
+  rightSlot,
+}) => {
+  const visibleFilters = (filters ?? []).filter((f) => f.visible !== false);
+
+  return (
+    <div className="flex items-center gap-2 flex-wrap">
+      <div className="relative flex-1 min-w-[12rem] max-w-md">
+        <Search
+          size={14}
+          className="absolute left-3 top-1/2 -translate-y-1/2 text-slate-400 pointer-events-none"
+        />
+        <input
+          type="search"
+          value={search}
+          onChange={(e) => onSearchChange(e.target.value)}
+          placeholder={searchPlaceholder}
+          className="w-full rounded-xl border border-slate-200 bg-white pl-9 pr-3 py-2 text-sm font-medium text-slate-700 placeholder:text-slate-400 shadow-sm focus:outline-none focus:ring-2 focus:ring-brand-blue-primary/30 focus:border-brand-blue-primary/40"
+        />
+      </div>
+
+      <SortDropdown
+        sort={sort}
+        sortOptions={sortOptions}
+        onSortChange={onSortChange}
+      />
+
+      {visibleFilters.length > 0 &&
+        onFilterChange &&
+        visibleFilters.map((f) => (
+          <FilterDropdown
+            key={f.id}
+            id={f.id}
+            label={f.label}
+            options={f.options}
+            value={filterValues?.[f.id] ?? ''}
+            onChange={(v) => onFilterChange(f.id, v)}
+          />
+        ))}
+
+      {viewMode !== undefined && onViewModeChange && (
+        <ViewModeToggle viewMode={viewMode} onChange={onViewModeChange} />
+      )}
+
+      {rightSlot && (
+        <div className="ml-auto flex items-center">{rightSlot}</div>
+      )}
+    </div>
+  );
+};

--- a/components/common/library/PeriodSelector.tsx
+++ b/components/common/library/PeriodSelector.tsx
@@ -1,0 +1,122 @@
+/**
+ * PeriodSelector — popout checkbox list for selecting class periods on
+ * an assignment.
+ *
+ * Extracted from `QuizPeriodSelector`. The Quiz version derived locked
+ * periods internally from a `responses` array; the shared primitive
+ * takes `lockedPeriodNames` directly so callers can compute that from
+ * whatever their widget's response shape is (Quiz → QuizResponse[],
+ * Video Activity → VideoActivityResponse[], etc.). Everything else
+ * ports over unchanged.
+ */
+
+import React, { useCallback, useRef, useState } from 'react';
+import { X, Check } from 'lucide-react';
+import { useClickOutside } from '@/hooks/useClickOutside';
+import type { PeriodSelectorProps } from './types';
+
+export const PeriodSelector: React.FC<PeriodSelectorProps> = ({
+  rosters,
+  selectedPeriodNames,
+  lockedPeriodNames = [],
+  onSave,
+  onClose,
+}) => {
+  const [selected, setSelected] = useState<string[]>(selectedPeriodNames);
+  const ref = useRef<HTMLDivElement>(null);
+  useClickOutside(ref, onClose);
+
+  const lockedSet = new Set(lockedPeriodNames);
+
+  const handleToggle = (name: string) => {
+    setSelected((prev) =>
+      prev.includes(name) ? prev.filter((n) => n !== name) : [...prev, name]
+    );
+  };
+
+  const handleSave = useCallback(() => {
+    onSave(selected);
+    onClose();
+  }, [selected, onSave, onClose]);
+
+  return (
+    <div
+      ref={ref}
+      className="absolute z-50 bg-white rounded-xl shadow-xl border border-slate-200 overflow-hidden animate-in zoom-in-95 duration-150"
+      style={{
+        width: 'min(240px, 60cqmin)',
+        right: 0,
+        top: '100%',
+        marginTop: 4,
+      }}
+    >
+      <div className="flex items-center justify-between px-3 py-2 border-b border-slate-100">
+        <span className="text-xs font-bold text-slate-500 uppercase tracking-widest">
+          Class Periods
+        </span>
+        <button
+          onClick={onClose}
+          className="text-slate-400 hover:text-slate-600"
+          aria-label="Close"
+        >
+          <X className="w-3.5 h-3.5" />
+        </button>
+      </div>
+      <div className="p-2 space-y-0.5 max-h-48 overflow-y-auto">
+        {rosters.map((r) => {
+          const checked = selected.includes(r.name);
+          const locked = lockedSet.has(r.name);
+          return (
+            <label
+              key={r.id}
+              className={`flex items-center gap-2 rounded px-2 py-1.5 transition-colors ${
+                locked
+                  ? 'cursor-not-allowed opacity-70'
+                  : 'cursor-pointer hover:bg-slate-50'
+              }`}
+              title={
+                locked
+                  ? 'Students have already joined from this class'
+                  : undefined
+              }
+            >
+              <input
+                type="checkbox"
+                checked={checked}
+                disabled={locked && checked}
+                onChange={() => handleToggle(r.name)}
+                className="rounded border-slate-300 text-indigo-600 focus:ring-indigo-500 disabled:opacity-50"
+              />
+              <span className="text-sm text-slate-800 flex-1">{r.name}</span>
+              {locked && (
+                <span className="text-xxs text-amber-600 font-medium">
+                  Locked
+                </span>
+              )}
+            </label>
+          );
+        })}
+        {rosters.length === 0 && (
+          <p className="text-xs text-slate-400 italic px-2 py-2">
+            No rosters available. Add rosters in the Class widget.
+          </p>
+        )}
+      </div>
+      <div className="flex items-center justify-end gap-2 border-t border-slate-100 px-3 py-2">
+        <button
+          onClick={onClose}
+          className="text-xs font-medium text-slate-500 hover:text-slate-700 px-2 py-1 rounded transition-colors"
+        >
+          Cancel
+        </button>
+        <button
+          onClick={handleSave}
+          className="flex items-center gap-1 text-xs font-bold text-white bg-indigo-600 hover:bg-indigo-700 px-3 py-1.5 rounded-lg transition-colors"
+        >
+          <Check className="w-3 h-3" />
+          Save
+        </button>
+      </div>
+    </div>
+  );
+};

--- a/components/common/library/importer/ImportWizard.tsx
+++ b/components/common/library/importer/ImportWizard.tsx
@@ -1,0 +1,744 @@
+/**
+ * ImportWizard — shared, adapter-driven three-step (Source → Preview → Confirm)
+ * import flow for Quiz, Video Activity, Guided Learning, and MiniApp widgets.
+ *
+ * The wizard itself has no knowledge of column layouts, Google Sheets APIs,
+ * Drive, or AI models — all widget-specific logic flows through `ImportAdapter`.
+ *
+ * Modal base: we use the plain `Modal` primitive (not `EditorModalShell`)
+ * because this flow has per-step footers (Back / Next / Save) rather than a
+ * single persistent Save button, and the discard-prompt guard in
+ * `EditorModalShell` doesn't map cleanly onto a parse-preview-confirm flow.
+ * The wizard is self-contained: parse/save errors surface inline here as
+ * red banners, not toasts.
+ */
+
+import React, { useRef, useState } from 'react';
+import {
+  AlertCircle,
+  ArrowLeft,
+  CheckCircle2,
+  Copy,
+  ExternalLink,
+  FileSpreadsheet,
+  FileUp,
+  Info,
+  Loader2,
+  Sparkles,
+  X,
+} from 'lucide-react';
+import { Modal } from '../../Modal';
+import type {
+  ImportAdapter,
+  ImportSourceKind,
+  ImportSourcePayload,
+  ImportWizardProps,
+} from '../types';
+
+type Step = 'source' | 'preview' | 'confirm';
+
+const STEPS: ReadonlyArray<{ key: Step; label: string }> = [
+  { key: 'source', label: 'Source' },
+  { key: 'preview', label: 'Preview' },
+  { key: 'confirm', label: 'Confirm' },
+];
+
+const GOOGLE_SHEET_URL_PATTERN = /docs\.google\.com\/spreadsheets/i;
+
+function acceptExtensionsForSources(sources: ImportSourceKind[]): string {
+  const exts = new Set<string>();
+  if (sources.includes('csv')) exts.add('.csv');
+  if (sources.includes('json')) exts.add('.json');
+  if (sources.includes('file')) {
+    exts.add('.csv');
+    exts.add('.json');
+    exts.add('.txt');
+  }
+  return Array.from(exts).join(',');
+}
+
+function inferKindFromFileName(
+  fileName: string,
+  supported: ImportSourceKind[]
+): Exclude<ImportSourceKind, 'sheet'> {
+  const lower = fileName.toLowerCase();
+  if (lower.endsWith('.json') && supported.includes('json')) return 'json';
+  if (lower.endsWith('.csv') && supported.includes('csv')) return 'csv';
+  if (supported.includes('file')) return 'file';
+  if (supported.includes('csv')) return 'csv';
+  if (supported.includes('json')) return 'json';
+  return 'file';
+}
+
+export function ImportWizard<TData>({
+  isOpen,
+  onClose,
+  adapter,
+  defaultTitle,
+  onSaved,
+}: ImportWizardProps<TData>): React.ReactElement | null {
+  const [step, setStep] = useState<Step>('source');
+  const [sheetUrl, setSheetUrl] = useState('');
+  const [parsed, setParsed] = useState<TData | null>(null);
+  const [warnings, setWarnings] = useState<string[]>([]);
+  const [title, setTitle] = useState(defaultTitle ?? '');
+  const [parseError, setParseError] = useState<string | null>(null);
+  const [validationErrors, setValidationErrors] = useState<string[]>([]);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
+
+  // AI-assist overlay state.
+  const [aiOpen, setAiOpen] = useState(false);
+  const [aiPrompt, setAiPrompt] = useState('');
+  const [aiGenerating, setAiGenerating] = useState(false);
+
+  // Template helper UI state.
+  const [showFormat, setShowFormat] = useState(false);
+  const [creatingTemplate, setCreatingTemplate] = useState(false);
+
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  // Reset ephemeral state whenever the wizard opens.
+  // Using adjust-state-while-rendering so we don't need useEffect.
+  const [prevOpen, setPrevOpen] = useState(isOpen);
+  if (prevOpen !== isOpen) {
+    setPrevOpen(isOpen);
+    if (isOpen) {
+      setStep('source');
+      setSheetUrl('');
+      setParsed(null);
+      setWarnings([]);
+      setTitle(defaultTitle ?? '');
+      setParseError(null);
+      setValidationErrors([]);
+      setSaveError(null);
+      setLoading(false);
+      setSaving(false);
+      setAiOpen(false);
+      setAiPrompt('');
+      setAiGenerating(false);
+      setShowFormat(false);
+      setCreatingTemplate(false);
+    }
+  }
+
+  const supportsSheet = adapter.supportedSources.includes('sheet');
+  const supportsCsv = adapter.supportedSources.includes('csv');
+  const supportsJson = adapter.supportedSources.includes('json');
+  const supportsFile = adapter.supportedSources.includes('file');
+  const supportsAnyUpload = supportsCsv || supportsJson || supportsFile;
+
+  const runParse = async (payload: ImportSourcePayload): Promise<void> => {
+    setLoading(true);
+    setParseError(null);
+    try {
+      const result = await adapter.parse(payload);
+      setParsed(result.data);
+      setWarnings(result.warnings);
+      setStep('preview');
+    } catch (err) {
+      setParseError(
+        err instanceof Error ? err.message : 'Failed to parse import source.'
+      );
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleSheetSubmit = (): void => {
+    if (!sheetUrl.trim()) {
+      setParseError('Please enter a Google Sheet URL.');
+      return;
+    }
+    void runParse({ kind: 'sheet', url: sheetUrl.trim() });
+  };
+
+  const handleFilePicked = async (
+    e: React.ChangeEvent<HTMLInputElement>
+  ): Promise<void> => {
+    const file = e.target.files?.[0];
+    if (fileInputRef.current) fileInputRef.current.value = '';
+    if (!file) return;
+
+    const kind = inferKindFromFileName(file.name, adapter.supportedSources);
+    if (kind === 'file') {
+      await runParse({ kind: 'file', file });
+      return;
+    }
+    try {
+      const text = await file.text();
+      await runParse({ kind, text, fileName: file.name });
+    } catch (err) {
+      setParseError(
+        err instanceof Error ? err.message : 'Failed to read the selected file.'
+      );
+    }
+  };
+
+  const handleCreateTemplate = async (): Promise<void> => {
+    if (!adapter.templateHelper) return;
+    setCreatingTemplate(true);
+    setParseError(null);
+    // Open blank tab synchronously to preserve the user gesture
+    // (avoids popup blockers).
+    const newTab = window.open('about:blank', '_blank', 'noopener,noreferrer');
+    try {
+      const { url } = await adapter.templateHelper.createTemplate();
+      if (newTab && !newTab.closed) {
+        newTab.location.href = url;
+      } else {
+        window.open(url, '_blank', 'noopener,noreferrer');
+      }
+    } catch (err) {
+      if (newTab && !newTab.closed) newTab.close();
+      setParseError(
+        err instanceof Error ? err.message : 'Failed to create template.'
+      );
+    } finally {
+      setCreatingTemplate(false);
+    }
+  };
+
+  const handleCopyTemplateUrl = async (): Promise<void> => {
+    if (!adapter.templateHelper) return;
+    setParseError(null);
+    try {
+      const { url } = await adapter.templateHelper.createTemplate();
+      await navigator.clipboard.writeText(url);
+    } catch (err) {
+      setParseError(
+        err instanceof Error ? err.message : 'Failed to copy template URL.'
+      );
+    }
+  };
+
+  const handleAiGenerate = async (): Promise<void> => {
+    if (!adapter.aiAssist) return;
+    if (!aiPrompt.trim()) return;
+    setAiGenerating(true);
+    setParseError(null);
+    try {
+      const data = await adapter.aiAssist.generate({ prompt: aiPrompt.trim() });
+      setParsed(data);
+      setWarnings([]);
+      setAiOpen(false);
+      setAiPrompt('');
+      setStep('preview');
+    } catch (err) {
+      setParseError(
+        err instanceof Error
+          ? err.message
+          : 'Failed to generate from AI. Please try again.'
+      );
+    } finally {
+      setAiGenerating(false);
+    }
+  };
+
+  const handleConfirmSave = async (): Promise<void> => {
+    if (!parsed) return;
+    const trimmed = title.trim();
+    if (!trimmed) {
+      setValidationErrors(['Please enter a title before saving.']);
+      return;
+    }
+    const v = adapter.validate(parsed);
+    if (!v.ok || v.errors.length > 0) {
+      setValidationErrors(v.errors.length > 0 ? v.errors : ['Invalid import.']);
+      return;
+    }
+    setValidationErrors([]);
+    setSaveError(null);
+    setSaving(true);
+    try {
+      await adapter.save(parsed, trimmed);
+      onSaved?.(trimmed);
+      onClose();
+    } catch (err) {
+      setSaveError(
+        err instanceof Error ? err.message : 'Failed to save import.'
+      );
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const stepIndicator = (
+    <ol
+      aria-label="Import progress"
+      className="flex items-center gap-2"
+      data-testid="import-wizard-steps"
+    >
+      {STEPS.map((s, idx) => {
+        const activeIdx = STEPS.findIndex((x) => x.key === step);
+        const state: 'active' | 'done' | 'upcoming' =
+          idx < activeIdx ? 'done' : idx === activeIdx ? 'active' : 'upcoming';
+        const tone =
+          state === 'active'
+            ? 'bg-brand-blue-primary text-white'
+            : state === 'done'
+              ? 'bg-emerald-500 text-white'
+              : 'bg-slate-200 text-slate-500';
+        return (
+          <li key={s.key} className="flex items-center gap-2">
+            <span
+              aria-current={state === 'active' ? 'step' : undefined}
+              className={`inline-flex items-center gap-1.5 rounded-full px-3 py-1 text-xs font-black uppercase tracking-widest ${tone}`}
+            >
+              <span className="inline-flex items-center justify-center w-4 h-4 rounded-full bg-white/25 text-[10px]">
+                {idx + 1}
+              </span>
+              {s.label}
+            </span>
+            {idx < STEPS.length - 1 && (
+              <span
+                aria-hidden="true"
+                className="w-4 h-px bg-slate-300 shrink-0"
+              />
+            )}
+          </li>
+        );
+      })}
+    </ol>
+  );
+
+  const customHeader = (
+    <div className="flex items-center justify-between gap-4 px-6 py-4 border-b border-slate-200 shrink-0 bg-white rounded-t-2xl">
+      <div className="flex flex-col min-w-0">
+        <h3
+          id="import-wizard-title"
+          className="font-black text-lg text-slate-800 truncate"
+        >
+          Import {adapter.widgetLabel}
+        </h3>
+        <div className="mt-2">{stepIndicator}</div>
+      </div>
+      <button
+        type="button"
+        onClick={onClose}
+        className="p-1.5 hover:bg-slate-100 rounded-full text-slate-400 transition-colors shrink-0"
+        aria-label="Close import wizard"
+      >
+        <X size={20} />
+      </button>
+    </div>
+  );
+
+  /* ─── Source step ───────────────────────────────────────────────────── */
+
+  const sourceStep = (
+    <div className="space-y-4">
+      {adapter.templateHelper && (
+        <div className="rounded-2xl border border-brand-blue-primary/20 bg-brand-blue-lighter/20 p-3">
+          <button
+            type="button"
+            onClick={() => setShowFormat((v) => !v)}
+            className="w-full flex items-center gap-2 text-brand-blue-primary text-xs font-bold"
+          >
+            <Info className="w-3.5 h-3.5 shrink-0" />
+            <span>Template &amp; format help</span>
+            <span className="ml-auto opacity-50">{showFormat ? '▲' : '▼'}</span>
+          </button>
+          {showFormat && (
+            <div className="mt-3 space-y-3 text-xs">
+              <div className="text-slate-700 leading-relaxed">
+                {adapter.templateHelper.instructions}
+              </div>
+              <div className="flex flex-wrap gap-2">
+                <button
+                  type="button"
+                  onClick={() => void handleCreateTemplate()}
+                  disabled={creatingTemplate}
+                  className="flex-1 min-w-[160px] inline-flex items-center justify-center gap-1.5 py-2 bg-white border-2 border-brand-blue-primary/20 hover:border-brand-blue-primary/40 rounded-xl text-brand-blue-primary font-black transition-all shadow-sm active:scale-95 disabled:opacity-50 text-xs uppercase tracking-widest"
+                >
+                  {creatingTemplate ? (
+                    <Loader2 className="w-3.5 h-3.5 animate-spin" />
+                  ) : (
+                    <FileSpreadsheet className="w-3.5 h-3.5" />
+                  )}
+                  Create template
+                  <ExternalLink className="w-3 h-3 opacity-40" />
+                </button>
+                <button
+                  type="button"
+                  onClick={() => void handleCopyTemplateUrl()}
+                  className="flex-1 min-w-[160px] inline-flex items-center justify-center gap-1.5 py-2 bg-white border-2 border-brand-blue-primary/20 hover:border-brand-blue-primary/40 rounded-xl text-brand-blue-primary font-black transition-all shadow-sm active:scale-95 text-xs uppercase tracking-widest"
+                >
+                  <Copy className="w-3.5 h-3.5" />
+                  Copy template URL
+                </button>
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+
+      {adapter.aiAssist && (
+        <button
+          type="button"
+          onClick={() => setAiOpen(true)}
+          className="w-full py-4 bg-gradient-to-br from-indigo-500/10 to-purple-500/10 hover:from-indigo-500/20 hover:to-purple-500/20 border-2 border-dashed border-indigo-500/30 rounded-2xl flex flex-col items-center justify-center gap-1 transition-all group active:scale-95"
+          aria-label={`AI-assist import for ${adapter.widgetLabel}`}
+        >
+          <Sparkles className="w-6 h-6 text-indigo-500 group-hover:scale-110 transition-transform" />
+          <span className="font-black text-indigo-600 text-xs uppercase tracking-widest">
+            AI-assist
+          </span>
+          <p className="text-[11px] text-indigo-400 font-bold">
+            Describe it and we&apos;ll draft it.
+          </p>
+        </button>
+      )}
+
+      {supportsSheet && (
+        <div className="space-y-2">
+          <label
+            htmlFor="import-wizard-sheet-url"
+            className="block text-xs font-black uppercase tracking-widest text-slate-500"
+          >
+            Google Sheet URL
+          </label>
+          <div className="flex gap-2">
+            <input
+              id="import-wizard-sheet-url"
+              type="url"
+              value={sheetUrl}
+              onChange={(e) => setSheetUrl(e.target.value)}
+              placeholder="https://docs.google.com/spreadsheets/…"
+              className="flex-1 px-4 py-2 bg-white border-2 border-slate-200 rounded-xl text-slate-800 font-medium placeholder-slate-400 focus:outline-none focus:border-brand-blue-primary transition-colors"
+            />
+            <button
+              type="button"
+              onClick={handleSheetSubmit}
+              disabled={loading || !sheetUrl.trim()}
+              className="px-4 py-2 bg-brand-blue-primary hover:bg-brand-blue-dark disabled:bg-slate-300 text-white font-bold rounded-xl transition-colors shadow-sm active:scale-95 flex items-center justify-center"
+            >
+              {loading ? (
+                <Loader2 className="w-4 h-4 animate-spin" />
+              ) : (
+                <FileSpreadsheet className="w-4 h-4" />
+              )}
+            </button>
+          </div>
+          {sheetUrl.trim() !== '' &&
+            !GOOGLE_SHEET_URL_PATTERN.test(sheetUrl) && (
+              <p className="text-[11px] text-amber-600 font-bold">
+                Hint: this doesn&apos;t look like a Google Sheets URL. Make sure
+                it&apos;s shared for viewing.
+              </p>
+            )}
+        </div>
+      )}
+
+      {supportsAnyUpload && (
+        <div>
+          <button
+            type="button"
+            onClick={() => fileInputRef.current?.click()}
+            disabled={loading}
+            className="w-full py-4 bg-brand-blue-lighter/30 hover:bg-brand-blue-lighter/60 disabled:opacity-40 border-2 border-dashed border-brand-blue-primary/30 rounded-2xl flex flex-col items-center justify-center gap-1 transition-all group active:scale-95"
+          >
+            <FileUp className="w-6 h-6 text-brand-blue-primary group-hover:scale-110 transition-transform" />
+            <span className="font-bold text-brand-blue-primary text-sm">
+              Upload file
+            </span>
+            <p className="text-[11px] text-brand-blue-primary/60 font-bold">
+              {supportsCsv && supportsJson
+                ? 'CSV or JSON'
+                : supportsCsv
+                  ? 'CSV'
+                  : supportsJson
+                    ? 'JSON'
+                    : 'File'}
+            </p>
+          </button>
+          <input
+            type="file"
+            ref={fileInputRef}
+            accept={acceptExtensionsForSources(adapter.supportedSources)}
+            onChange={(e) => void handleFilePicked(e)}
+            className="hidden"
+            aria-label="Upload import file"
+          />
+        </div>
+      )}
+
+      {loading && (
+        <div className="flex items-center justify-center gap-2 py-2 text-brand-blue-primary font-bold text-sm">
+          <Loader2 className="w-4 h-4 animate-spin" />
+          Parsing…
+        </div>
+      )}
+
+      {parseError && (
+        <div
+          role="alert"
+          className="flex items-start gap-2 p-3 bg-brand-red-lighter/40 border border-brand-red-primary/20 rounded-xl text-brand-red-dark font-medium text-sm"
+        >
+          <AlertCircle className="w-4 h-4 shrink-0 mt-0.5" />
+          <span>{parseError}</span>
+        </div>
+      )}
+    </div>
+  );
+
+  /* ─── Preview step ──────────────────────────────────────────────────── */
+
+  const previewStep = (
+    <div className="space-y-4">
+      <div className="rounded-2xl border border-slate-200 bg-white p-3 shadow-sm">
+        {parsed != null ? (
+          adapter.renderPreview(parsed)
+        ) : (
+          <p className="text-sm text-slate-500">No preview available.</p>
+        )}
+      </div>
+      {warnings.length > 0 && (
+        <ul
+          role="alert"
+          aria-label="Import warnings"
+          className="space-y-1.5 rounded-xl border border-amber-300/60 bg-amber-50 p-3"
+        >
+          {warnings.map((w, i) => (
+            <li
+              key={i}
+              className="flex items-start gap-2 text-amber-800 text-xs font-medium"
+            >
+              <AlertCircle className="w-3.5 h-3.5 shrink-0 mt-0.5" />
+              <span>{w}</span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+
+  /* ─── Confirm step ──────────────────────────────────────────────────── */
+
+  const confirmStep = (
+    <div className="space-y-4">
+      <div>
+        <label
+          htmlFor="import-wizard-title-input"
+          className="block text-xs font-black uppercase tracking-widest text-slate-500 mb-1.5"
+        >
+          Title
+        </label>
+        <input
+          id="import-wizard-title-input"
+          type="text"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          placeholder={`Untitled ${adapter.widgetLabel}`}
+          className="w-full px-4 py-2 bg-white border-2 border-slate-200 rounded-xl text-slate-800 font-medium placeholder-slate-400 focus:outline-none focus:border-brand-blue-primary transition-colors"
+        />
+      </div>
+      {validationErrors.length > 0 && (
+        <ul
+          role="alert"
+          aria-label="Validation errors"
+          className="space-y-1.5 rounded-xl border border-brand-red-primary/30 bg-brand-red-lighter/40 p-3"
+        >
+          {validationErrors.map((e, i) => (
+            <li
+              key={i}
+              className="flex items-start gap-2 text-brand-red-dark text-sm font-medium"
+            >
+              <AlertCircle className="w-4 h-4 shrink-0 mt-0.5" />
+              <span>{e}</span>
+            </li>
+          ))}
+        </ul>
+      )}
+      {saveError && (
+        <div
+          role="alert"
+          className="flex items-start gap-2 p-3 bg-brand-red-lighter/40 border border-brand-red-primary/20 rounded-xl text-brand-red-dark font-medium text-sm"
+        >
+          <AlertCircle className="w-4 h-4 shrink-0 mt-0.5" />
+          <span>{saveError}</span>
+        </div>
+      )}
+    </div>
+  );
+
+  /* ─── Footer ────────────────────────────────────────────────────────── */
+
+  const footer = (
+    <div className="flex items-center justify-between gap-3 px-6 py-3 bg-white">
+      {step === 'source' ? (
+        <button
+          type="button"
+          onClick={onClose}
+          className="px-4 py-2 text-sm font-bold text-slate-700 hover:bg-slate-100 rounded-xl transition-colors"
+        >
+          Cancel
+        </button>
+      ) : (
+        <button
+          type="button"
+          onClick={() => {
+            setSaveError(null);
+            setValidationErrors([]);
+            setStep(step === 'confirm' ? 'preview' : 'source');
+          }}
+          className="inline-flex items-center gap-1.5 px-4 py-2 text-sm font-bold text-slate-700 hover:bg-slate-100 rounded-xl transition-colors"
+        >
+          <ArrowLeft className="w-4 h-4" />
+          Back
+        </button>
+      )}
+
+      <div className="flex items-center gap-2">
+        {step === 'preview' && (
+          <button
+            type="button"
+            onClick={() => setStep('confirm')}
+            disabled={parsed == null}
+            className="inline-flex items-center gap-1.5 px-5 py-2 bg-brand-blue-primary hover:bg-brand-blue-dark text-white text-sm font-bold rounded-xl transition-colors shadow-sm disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            Continue
+          </button>
+        )}
+        {step === 'confirm' && (
+          <button
+            type="button"
+            onClick={() => void handleConfirmSave()}
+            disabled={saving || parsed == null}
+            className="inline-flex items-center gap-1.5 px-5 py-2 bg-brand-blue-primary hover:bg-brand-blue-dark text-white text-sm font-bold rounded-xl transition-colors shadow-sm disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {saving ? (
+              <>
+                <Loader2 className="w-4 h-4 animate-spin" />
+                Saving…
+              </>
+            ) : (
+              <>
+                <CheckCircle2 className="w-4 h-4" />
+                Save to library
+              </>
+            )}
+          </button>
+        )}
+      </div>
+    </div>
+  );
+
+  const body =
+    step === 'source'
+      ? sourceStep
+      : step === 'preview'
+        ? previewStep
+        : confirmStep;
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      customHeader={customHeader}
+      footer={footer}
+      footerClassName="shrink-0 border-t border-slate-200 rounded-b-2xl"
+      maxWidth="max-w-2xl"
+      className="font-sans"
+      contentClassName="px-6 py-5 bg-slate-50"
+      ariaLabelledby="import-wizard-title"
+    >
+      <div className="relative">
+        {body}
+
+        {aiOpen && adapter.aiAssist && (
+          <AiAssistOverlay
+            widgetLabel={adapter.widgetLabel}
+            placeholder={adapter.aiAssist.promptPlaceholder}
+            prompt={aiPrompt}
+            onPromptChange={setAiPrompt}
+            isGenerating={aiGenerating}
+            onCancel={() => {
+              setAiOpen(false);
+              setAiPrompt('');
+            }}
+            onGenerate={() => void handleAiGenerate()}
+          />
+        )}
+      </div>
+    </Modal>
+  );
+}
+
+/* ─── AI-assist overlay ──────────────────────────────────────────────── */
+
+interface AiAssistOverlayProps {
+  widgetLabel: string;
+  placeholder: string;
+  prompt: string;
+  onPromptChange: (next: string) => void;
+  isGenerating: boolean;
+  onCancel: () => void;
+  onGenerate: () => void;
+}
+
+const AiAssistOverlay: React.FC<AiAssistOverlayProps> = ({
+  widgetLabel,
+  placeholder,
+  prompt,
+  onPromptChange,
+  isGenerating,
+  onCancel,
+  onGenerate,
+}) => (
+  <div
+    role="dialog"
+    aria-label={`AI-assist for ${widgetLabel}`}
+    className="absolute inset-0 z-10 bg-white/95 backdrop-blur-sm flex items-center justify-center p-4 animate-in fade-in duration-200 -mx-6 -my-5"
+    onKeyDown={(e) => {
+      if (e.key === 'Escape') onCancel();
+    }}
+  >
+    <div className="w-full max-w-md space-y-4">
+      <div className="flex items-center justify-between">
+        <h4 className="font-black text-indigo-600 flex items-center gap-2 uppercase tracking-tight">
+          <Sparkles className="w-5 h-5" /> AI-assist
+        </h4>
+        <button
+          type="button"
+          onClick={onCancel}
+          className="p-1 hover:bg-slate-100 rounded-lg text-slate-400 hover:text-slate-600"
+          aria-label="Close AI-assist"
+        >
+          <X className="w-5 h-5" />
+        </button>
+      </div>
+      <p className="text-xs text-slate-500 font-bold uppercase tracking-widest opacity-70">
+        Describe the {widgetLabel.toLowerCase()} you want to create.
+      </p>
+      <textarea
+        value={prompt}
+        onChange={(e) => onPromptChange(e.target.value)}
+        placeholder={placeholder}
+        className="w-full h-32 p-4 bg-white border-2 border-indigo-100 rounded-2xl text-sm text-indigo-900 placeholder-indigo-300 focus:outline-none focus:border-indigo-500 resize-none shadow-inner"
+        aria-label={`AI-assist prompt for ${widgetLabel}`}
+      />
+      <button
+        type="button"
+        onClick={onGenerate}
+        disabled={isGenerating || !prompt.trim()}
+        className="w-full py-3 bg-indigo-600 hover:bg-indigo-700 disabled:opacity-50 disabled:cursor-not-allowed text-white rounded-xl font-black text-xs uppercase tracking-widest shadow-lg shadow-indigo-200 transition-all flex items-center justify-center gap-2"
+      >
+        {isGenerating ? (
+          <>
+            <Loader2 className="w-4 h-4 animate-spin" /> Generating…
+          </>
+        ) : (
+          <>
+            <Sparkles className="w-4 h-4" /> Generate
+          </>
+        )}
+      </button>
+    </div>
+  </div>
+);
+
+// Re-export the adapter/type contract at the import point for consumer
+// convenience — this keeps Wave 2 migration imports tidy.
+export type { ImportAdapter, ImportWizardProps };

--- a/components/common/library/importer/index.ts
+++ b/components/common/library/importer/index.ts
@@ -1,0 +1,2 @@
+export { ImportWizard } from './ImportWizard';
+export type { ImportAdapter, ImportWizardProps } from './ImportWizard';

--- a/components/common/library/types.ts
+++ b/components/common/library/types.ts
@@ -1,0 +1,422 @@
+/**
+ * Shared integration contract for the unified Library / Assign / Import / Archive
+ * primitives used by Quiz, Video Activity, Guided Learning, and MiniApp widgets.
+ *
+ * This file is the single source of truth for the Wave 1 primitive APIs. The
+ * four parallel implementation agents (LibraryShell, LibraryGrid, AssignModal,
+ * ImportWizard) import from here; they MUST NOT change these shapes without
+ * coordinated review — they are the integration contract for the Wave 2 widget
+ * migrations.
+ *
+ * Design principles:
+ *   1. Primitives are presentational + state-only. No Firestore/Drive calls.
+ *      Consumers own persistence.
+ *   2. Per-widget variation flows through `extraSlot` / `plcSlot` / adapters,
+ *      not through conditional branches in the primitives.
+ *   3. Generics preserve consumer types (e.g. TAssignment, TOptions, TItem)
+ *      so callers keep full type safety without casts.
+ */
+
+import type React from 'react';
+import type { ClassRoster } from '@/types';
+
+/* ─── Shared enums / tokens ───────────────────────────────────────────────── */
+
+/** Top-level library tabs. Mirrors Quiz's proven pattern. */
+export type LibraryTab = 'library' | 'active' | 'archive';
+
+/** View mode for item rendering. Grid is default; list is a density option. */
+export type LibraryViewMode = 'grid' | 'list';
+
+/** Sort direction for `LibraryToolbar` sort dropdown. */
+export type LibrarySortDir = 'asc' | 'desc';
+
+/**
+ * Badge tone for status chips and info pills. Keep small — resist adding a
+ * tone per semantic nuance. Consumers can override via custom badge slot
+ * if needed.
+ */
+export type LibraryBadgeTone =
+  | 'neutral'
+  | 'info'
+  | 'warn'
+  | 'success'
+  | 'danger';
+
+/** Assignment lifecycle status. Mirrors `QuizAssignmentStatus` in `types.ts`. */
+export type LibraryAssignmentStatus = 'active' | 'paused' | 'inactive';
+
+/** Import source kinds. Adapters declare which they support. */
+export type ImportSourceKind = 'sheet' | 'csv' | 'json' | 'file';
+
+/* ─── Generic value objects ───────────────────────────────────────────────── */
+
+/** A clickable menu entry — used in overflow menus, secondary action lists. */
+export interface LibraryMenuAction {
+  id: string;
+  label: string;
+  icon?: React.ComponentType<{ size?: number; className?: string }>;
+  onClick: () => void;
+  /** Renders with danger styling and (optionally) moves to the bottom. */
+  destructive?: boolean;
+  disabled?: boolean;
+  /** Tooltip when hover-disabled. */
+  disabledReason?: string;
+}
+
+/** Primary action on a card — always visible, never nested under overflow. */
+export interface LibraryPrimaryAction {
+  label: string;
+  icon?: React.ComponentType<{ size?: number; className?: string }>;
+  onClick: () => void;
+  disabled?: boolean;
+  disabledReason?: string;
+}
+
+/** A badge chip shown on library cards. */
+export interface LibraryBadge {
+  label: string;
+  tone: LibraryBadgeTone;
+  /** Optional dot indicator (used for live/paused pulses on archive cards). */
+  dot?: boolean;
+}
+
+/** A sort option surfaced in the toolbar sort dropdown. */
+export interface LibrarySortOption {
+  key: string;
+  label: string;
+  /** Default direction when the key is selected. */
+  defaultDir?: LibrarySortDir;
+}
+
+/** A filter exposed in the toolbar. Current value lives in `useLibraryView`. */
+export interface LibraryFilter {
+  id: string;
+  label: string;
+  options: Array<{ value: string; label: string }>;
+  /** Optional: show only when predicate returns true (e.g. admin-only). */
+  visible?: boolean;
+}
+
+/* ─── LibraryShell (3-tab chrome) ─────────────────────────────────────────── */
+
+export interface LibraryShellTabCounts {
+  library?: number;
+  active?: number;
+  archive?: number;
+}
+
+export interface LibraryShellProps {
+  /** e.g. "Quiz", "Video Activity" — drives empty-state copy, aria labels. */
+  widgetLabel: string;
+  tab: LibraryTab;
+  onTabChange: (tab: LibraryTab) => void;
+  /** Numeric badges on tabs. `undefined` hides the badge for that tab. */
+  counts?: LibraryShellTabCounts;
+  /** Header right-side primary CTA, e.g. "+ New Quiz". */
+  primaryAction?: LibraryPrimaryAction;
+  /** Header right-side secondary buttons, e.g. Import, Export. */
+  secondaryActions?: LibraryPrimaryAction[];
+  /** Rendered above the tab content — typically <LibraryToolbar />. */
+  toolbarSlot?: React.ReactNode;
+  /** Rendered as a left sidebar — used by Phase 4 folders. */
+  filterSidebarSlot?: React.ReactNode;
+  /** Tab-specific content. Consumer decides what to render per tab. */
+  children: React.ReactNode;
+}
+
+/* ─── LibraryToolbar (search / sort / filter / view-mode) ─────────────────── */
+
+export interface LibraryToolbarProps {
+  search: string;
+  onSearchChange: (next: string) => void;
+  searchPlaceholder?: string;
+
+  sort: { key: string; dir: LibrarySortDir };
+  sortOptions: LibrarySortOption[];
+  onSortChange: (next: { key: string; dir: LibrarySortDir }) => void;
+
+  filters?: LibraryFilter[];
+  /** Current filter selection, keyed by filter id. */
+  filterValues?: Record<string, string>;
+  onFilterChange?: (id: string, value: string) => void;
+
+  viewMode?: LibraryViewMode;
+  onViewModeChange?: (next: LibraryViewMode) => void;
+
+  /** Optional right-aligned extras (e.g. "5 of 20 items"). */
+  rightSlot?: React.ReactNode;
+}
+
+/* ─── LibraryItemCard (sortable card) ─────────────────────────────────────── */
+
+export interface LibraryItemCardProps<TMeta = unknown> {
+  /** Stable id — used by dnd-kit and by consumer for navigation. */
+  id: string;
+  title: string;
+  /** e.g. "12 questions · Updated Apr 12". */
+  subtitle?: React.ReactNode;
+  /** Visual preview, usually an <img> or icon. */
+  thumbnail?: React.ReactNode;
+  badges?: LibraryBadge[];
+  /** e.g. "Assign" — the headline action. Clicked card body defaults to edit. */
+  primaryAction: LibraryPrimaryAction;
+  /** Overflow-menu actions (Edit, Duplicate, Share, Delete...). */
+  secondaryActions?: LibraryMenuAction[];
+  /** Default click handler for the card body. Typically opens the editor. */
+  onClick?: () => void;
+  /** Default true. Disabled via `LibraryGrid.dragDisabled` for read-only views. */
+  sortable?: boolean;
+  /** Passthrough for consumer — typed via the generic. */
+  meta?: TMeta;
+  /** View mode influences density — passed down from `LibraryGrid`. */
+  viewMode?: LibraryViewMode;
+  /** Hidden from screen readers when this card is the drag overlay. */
+  isDragOverlay?: boolean;
+}
+
+/* ─── LibraryGrid (dnd-kit SortableContext wrapper) ───────────────────────── */
+
+export interface LibraryGridProps<TItem> {
+  items: TItem[];
+  /** Stable id extractor — used by dnd-kit. Must return unique strings. */
+  getId: (item: TItem) => string;
+  /** One card per item. Consumer composes <LibraryItemCard /> inside. */
+  renderCard: (item: TItem, index: number) => React.ReactElement;
+  /**
+   * Called with the new full ordering of ids after a drag ends. Consumer
+   * persists (e.g. Firestore `order` field writes). Reject → revert.
+   */
+  onReorder?: (nextOrderedIds: string[]) => Promise<void> | void;
+  /**
+   * Force-disable drag. Also auto-disabled when search is non-empty or
+   * sort.key !== 'manual' — the toolbar state is passed in via `reorderLocked`.
+   */
+  dragDisabled?: boolean;
+  /**
+   * When true, shows a tooltip on drag handles explaining why they're disabled
+   * (e.g. "Clear search to reorder"). Distinct from `dragDisabled` so the
+   * consumer can show the handles at reduced opacity rather than hidden.
+   */
+  reorderLocked?: boolean;
+  reorderLockedReason?: string;
+  layout?: LibraryViewMode;
+  /** Rendered when `items.length === 0`. */
+  emptyState?: React.ReactNode;
+}
+
+/* ─── useLibraryView (toolbar state + derived filtering) ──────────────────── */
+
+export interface UseLibraryViewOptions<TItem> {
+  items: TItem[];
+  /** Initial toolbar state. Consumers can persist/restore via these. */
+  initialSearch?: string;
+  initialSort?: { key: string; dir: LibrarySortDir };
+  initialViewMode?: LibraryViewMode;
+  initialFilterValues?: Record<string, string>;
+  /**
+   * Fields to search across. Return a string (or array of strings) per item;
+   * the hook lowercases + substring-matches against `search`.
+   */
+  searchFields: (item: TItem) => string | string[];
+  /**
+   * Comparator registry keyed by sort key. `'manual'` must be one of the
+   * registered keys — used to signal drag-reorder is the active ordering.
+   */
+  sortComparators: Record<
+    string,
+    (a: TItem, b: TItem, dir: LibrarySortDir) => number
+  >;
+  /**
+   * Filter predicate registry keyed by filter id. Returns true to keep the
+   * item. Missing filter id = no-op (all pass).
+   */
+  filterPredicates?: Record<string, (item: TItem, value: string) => boolean>;
+}
+
+export interface UseLibraryViewResult<TItem> {
+  /** Fully filtered + sorted items. Feed into <LibraryGrid items={...} />. */
+  visibleItems: TItem[];
+  /** Bound props for <LibraryToolbar />. */
+  toolbarProps: Omit<LibraryToolbarProps, 'sortOptions' | 'filters'>;
+  /** True when manual-drag reorder should be locked (search or non-manual sort). */
+  reorderLocked: boolean;
+  reorderLockedReason: string | undefined;
+  /** Raw state (for consumers that want to persist across mounts). */
+  state: {
+    search: string;
+    sort: { key: string; dir: LibrarySortDir };
+    viewMode: LibraryViewMode;
+    filterValues: Record<string, string>;
+  };
+}
+
+/* ─── useSortableReorder (dnd-kit → persistence helper) ───────────────────── */
+
+export interface UseSortableReorderOptions<TItem> {
+  items: TItem[];
+  getId: (item: TItem) => string;
+  /**
+   * Commit the new ordering. May persist over the network; if it rejects,
+   * the hook reverts the optimistic local reorder.
+   */
+  onCommit: (nextOrderedIds: string[]) => Promise<void> | void;
+}
+
+export interface UseSortableReorderResult<TItem> {
+  /** Optimistically-reordered items. Feed into <LibraryGrid items={...} />. */
+  orderedItems: TItem[];
+  /** Wire this into <LibraryGrid onReorder={...} />. */
+  handleReorder: (nextOrderedIds: string[]) => Promise<void>;
+  /** True while the commit is in-flight. */
+  isCommitting: boolean;
+  /** Last commit error, if any. Cleared on successful commit. */
+  error: Error | null;
+}
+
+/* ─── AssignmentArchiveCard (generalized QuizAssignmentArchive) ───────────── */
+
+/** Status badge resolved for an assignment (consumer computes from its status). */
+export interface AssignmentStatusBadge {
+  label: string; // e.g. "Live" | "Paused" | "Ended"
+  tone: LibraryBadgeTone; // success | warn | neutral
+  dot?: boolean;
+}
+
+export interface AssignmentArchiveCardProps<TAssignment> {
+  assignment: TAssignment;
+  /** Controls styling + available actions. */
+  mode: 'active' | 'archive';
+  status: AssignmentStatusBadge;
+  primaryAction: LibraryPrimaryAction;
+  secondaryActions?: LibraryMenuAction[];
+  /** Optional metadata line(s) — e.g. due date, student count, response count. */
+  meta?: React.ReactNode;
+  /** Card title — consumer usually passes `assignment.quizTitle` etc. */
+  title: string;
+  /** Optional small-text subtitle, e.g. className, period name. */
+  subtitle?: React.ReactNode;
+}
+
+/* ─── AssignModal (shared assign chrome + widget slots) ───────────────────── */
+
+/** Session-mode option (Quiz uses teacher/auto/student). */
+export interface AssignModeOption {
+  id: string;
+  label: string;
+  description: string;
+  icon?: React.ComponentType<{ size?: number; className?: string }>;
+  /** Lock the mode selector (e.g. assignment is already live). */
+  disabled?: boolean;
+}
+
+export interface AssignModalProps<TOptions> {
+  isOpen: boolean;
+  onClose: () => void;
+  /** The thing being assigned (e.g. quiz title). Shown in header. */
+  itemTitle: string;
+  /** Optional mode selector. Omit for widgets that don't have modes (MiniApp). */
+  modes?: AssignModeOption[];
+  selectedMode?: string;
+  onModeChange?: (id: string) => void;
+  /** Widget-specific options object. Primitive is agnostic to its shape. */
+  options: TOptions;
+  onOptionsChange: (next: TOptions) => void;
+  /** Widget-specific toggles/inputs. Rendered in the body. */
+  extraSlot?: React.ReactNode;
+  /** PLC / period selection slot. Rendered below extraSlot. */
+  plcSlot?: React.ReactNode;
+  /** Assignment name (e.g. "Period 2"). Primitive owns the input. */
+  assignmentName?: string;
+  onAssignmentNameChange?: (next: string) => void;
+  /** Called with the committed mode + options on confirm. */
+  onAssign: (payload: {
+    mode: string | undefined;
+    options: TOptions;
+    assignmentName: string | undefined;
+  }) => Promise<void> | void;
+  /** Override confirm button label (default: "Assign"). */
+  confirmLabel?: string;
+  /** Inline disabled reason (e.g. missing required field). */
+  confirmDisabled?: boolean;
+  confirmDisabledReason?: string;
+}
+
+/* ─── PeriodSelector (extracted from QuizPeriodSelector) ──────────────────── */
+
+export interface PeriodSelectorProps {
+  rosters: ClassRoster[];
+  selectedPeriodNames: string[];
+  /**
+   * Period names that have students who've already joined. These cannot be
+   * unchecked. Consumer computes this from responses/submissions.
+   */
+  lockedPeriodNames?: string[];
+  onSave: (periodNames: string[]) => void;
+  onClose: () => void;
+}
+
+/* ─── ImportWizard (shared chrome) + ImportAdapter<TData> (contract) ──────── */
+
+/** Payload wrapper passed to the adapter's parse function. */
+export type ImportSourcePayload =
+  | { kind: 'sheet'; url: string }
+  | { kind: 'csv'; text: string; fileName?: string }
+  | { kind: 'json'; text: string; fileName?: string }
+  | { kind: 'file'; file: File };
+
+/** Parser result — `warnings` surface non-fatal issues in the preview. */
+export interface ImportParseResult<TData> {
+  data: TData;
+  warnings: string[];
+}
+
+/** Validation result — `errors` block Save; empty array = pass. */
+export interface ImportValidationResult {
+  ok: boolean;
+  errors: string[];
+}
+
+/**
+ * Per-widget adapter. The wizard drives through these methods sequentially.
+ * Adapters are pure — no UI state inside them.
+ */
+export interface ImportAdapter<TData> {
+  /** e.g. "Quiz", used for wizard copy. */
+  widgetLabel: string;
+  supportedSources: ImportSourceKind[];
+  /** Optional helper for Google Sheets template creation. */
+  templateHelper?: {
+    createTemplate: () => Promise<{ url: string }>;
+    instructions: React.ReactNode;
+  };
+  parse: (source: ImportSourcePayload) => Promise<ImportParseResult<TData>>;
+  validate: (data: TData) => ImportValidationResult;
+  renderPreview: (data: TData) => React.ReactNode;
+  /** Persist to the widget's library. Consumer owns Firestore/Drive writes. */
+  save: (data: TData, title: string) => Promise<void>;
+  /** Optional AI-assist path (e.g. Quiz's Gemini generator). */
+  aiAssist?: {
+    promptPlaceholder: string;
+    generate: (ctx: { prompt: string }) => Promise<TData>;
+  };
+}
+
+export interface ImportWizardProps<TData> {
+  isOpen: boolean;
+  onClose: () => void;
+  adapter: ImportAdapter<TData>;
+  /** Prefill the title input (e.g. from a filename). */
+  defaultTitle?: string;
+  /** Called after a successful save closes the wizard. */
+  onSaved?: (title: string) => void;
+}
+
+/* ─── Re-exports ──────────────────────────────────────────────────────────── */
+
+/**
+ * Convenience alias — widgets defining per-assignment types (`QuizAssignment`,
+ * `VideoActivityAssignment`, etc.) can import `LibraryAssignmentStatus` as
+ * `AssignmentStatus` without polluting the root types.ts namespace.
+ */
+export type { LibraryAssignmentStatus as AssignmentStatus };

--- a/components/common/library/useLibraryView.ts
+++ b/components/common/library/useLibraryView.ts
@@ -1,0 +1,109 @@
+import { useCallback, useMemo, useState } from 'react';
+import type {
+  LibrarySortDir,
+  LibraryViewMode,
+  UseLibraryViewOptions,
+  UseLibraryViewResult,
+} from './types';
+
+const DEFAULT_LOCKED_REASON = 'Clear search and set sort to Manual to reorder.';
+
+export function useLibraryView<TItem>(
+  options: UseLibraryViewOptions<TItem>
+): UseLibraryViewResult<TItem> {
+  const {
+    items,
+    initialSearch = '',
+    initialSort = { key: 'manual', dir: 'asc' },
+    initialViewMode = 'grid',
+    initialFilterValues = {},
+    searchFields,
+    sortComparators,
+    filterPredicates,
+  } = options;
+
+  const [search, setSearch] = useState<string>(initialSearch);
+  const [sort, setSort] = useState<{ key: string; dir: LibrarySortDir }>(
+    initialSort
+  );
+  const [viewMode, setViewMode] = useState<LibraryViewMode>(initialViewMode);
+  const [filterValues, setFilterValues] =
+    useState<Record<string, string>>(initialFilterValues);
+
+  const visibleItems = useMemo<TItem[]>(() => {
+    const normalizedSearch = search.trim().toLowerCase();
+    const activeFilters = filterPredicates
+      ? Object.entries(filterValues).filter(
+          ([id, value]) => value !== '' && filterPredicates[id] != null
+        )
+      : [];
+
+    const filtered = items.filter((item) => {
+      if (normalizedSearch !== '') {
+        const raw = searchFields(item);
+        const haystacks = Array.isArray(raw) ? raw : [raw];
+        const matches = haystacks.some((field) =>
+          (field ?? '').toLowerCase().includes(normalizedSearch)
+        );
+        if (!matches) return false;
+      }
+      for (const [id, value] of activeFilters) {
+        const predicate = filterPredicates?.[id];
+        if (predicate && !predicate(item, value)) return false;
+      }
+      return true;
+    });
+
+    const comparator = sortComparators[sort.key];
+    if (!comparator) return filtered;
+    // Copy before sort so we never mutate the input array.
+    return [...filtered].sort((a, b) => comparator(a, b, sort.dir));
+  }, [
+    items,
+    search,
+    sort,
+    filterValues,
+    searchFields,
+    sortComparators,
+    filterPredicates,
+  ]);
+
+  const reorderLocked = search.trim() !== '' || sort.key !== 'manual';
+  const reorderLockedReason = reorderLocked ? DEFAULT_LOCKED_REASON : undefined;
+
+  const handleFilterChange = useCallback((id: string, value: string) => {
+    setFilterValues((prev) => {
+      if (prev[id] === value) return prev;
+      const next = { ...prev, [id]: value };
+      if (value === '') delete next[id];
+      return next;
+    });
+  }, []);
+
+  const toolbarProps = useMemo<UseLibraryViewResult<TItem>['toolbarProps']>(
+    () => ({
+      search,
+      onSearchChange: setSearch,
+      sort,
+      onSortChange: setSort,
+      filterValues,
+      onFilterChange: handleFilterChange,
+      viewMode,
+      onViewModeChange: setViewMode,
+    }),
+    [search, sort, filterValues, handleFilterChange, viewMode]
+  );
+
+  const state = useMemo(
+    () => ({ search, sort, viewMode, filterValues }),
+    [search, sort, viewMode, filterValues]
+  );
+
+  return {
+    visibleItems,
+    toolbarProps,
+    reorderLocked,
+    reorderLockedReason,
+    state,
+  };
+}

--- a/components/common/library/useSortableReorder.ts
+++ b/components/common/library/useSortableReorder.ts
@@ -1,0 +1,128 @@
+/**
+ * useSortableReorder — dnd-kit → persistence helper.
+ *
+ * Keeps an optimistic `orderedItems` list. When the user drops a card and
+ * `LibraryGrid` fires `onReorder`, call `handleReorder` with the new id list;
+ * this hook reorders locally, awaits `onCommit`, and reverts if the commit
+ * rejects. Exposes `isCommitting` for UI affordances and `error` for inline
+ * messages (cleared on the next successful commit).
+ *
+ * The `orderedItems` state stays in sync with the `items` prop whenever the
+ * incoming id set changes — computed during render via a prev-id-comparison
+ * pattern (no useEffect). This is the "adjusting state while rendering"
+ * escape hatch from the React docs.
+ */
+
+import { useCallback, useRef, useState } from 'react';
+import type {
+  UseSortableReorderOptions,
+  UseSortableReorderResult,
+} from './types';
+
+function reorderByIds<TItem>(
+  items: TItem[],
+  getId: (item: TItem) => string,
+  orderedIds: string[]
+): TItem[] {
+  const byId = new Map<string, TItem>();
+  for (const item of items) byId.set(getId(item), item);
+
+  const reordered: TItem[] = [];
+  const seen = new Set<string>();
+  for (const id of orderedIds) {
+    const item = byId.get(id);
+    if (item !== undefined) {
+      reordered.push(item);
+      seen.add(id);
+    }
+  }
+  // Append any items whose ids weren't in the requested ordering, preserving
+  // their original relative order. This makes the hook safe against partial
+  // id lists (e.g. filtered views that only reorder a subset).
+  for (const item of items) {
+    if (!seen.has(getId(item))) reordered.push(item);
+  }
+  return reordered;
+}
+
+function sameIdList(a: string[], b: string[]): boolean {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) return false;
+  }
+  return true;
+}
+
+function sameIdSet(a: string[], b: string[]): boolean {
+  if (a.length !== b.length) return false;
+  const setA = new Set(a);
+  for (const id of b) {
+    if (!setA.has(id)) return false;
+  }
+  return true;
+}
+
+export function useSortableReorder<TItem>(
+  options: UseSortableReorderOptions<TItem>
+): UseSortableReorderResult<TItem> {
+  const { items, getId, onCommit } = options;
+
+  // Mirror the incoming items optimistically. We always start from the prop.
+  const [orderedItems, setOrderedItems] = useState<TItem[]>(items);
+  const [isCommitting, setIsCommitting] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  // Track the last prop `items` reference so we can detect upstream changes
+  // during render without a useEffect.
+  const lastSeenItemsRef = useRef<TItem[]>(items);
+
+  if (lastSeenItemsRef.current !== items) {
+    const previousIds = lastSeenItemsRef.current.map(getId);
+    const currentIds = items.map(getId);
+    const currentOrderedIds = orderedItems.map(getId);
+
+    lastSeenItemsRef.current = items;
+
+    if (!sameIdSet(previousIds, currentIds)) {
+      // Id set changed upstream — drop optimistic ordering and re-seed.
+      setOrderedItems(items);
+    } else if (!sameIdList(currentOrderedIds, currentIds)) {
+      // Same ids, but item bodies may have been updated by the consumer.
+      // Preserve our optimistic order while absorbing the fresh objects.
+      setOrderedItems(reorderByIds(items, getId, currentOrderedIds));
+    } else {
+      // Ids and order both match — just pick up the new item references.
+      setOrderedItems(items);
+    }
+  }
+
+  const handleReorder = useCallback(
+    async (nextOrderedIds: string[]) => {
+      const previous = orderedItems;
+      const next = reorderByIds(items, getId, nextOrderedIds);
+
+      setOrderedItems(next);
+      setIsCommitting(true);
+      setError(null);
+
+      try {
+        await Promise.resolve(onCommit(nextOrderedIds));
+        setError(null);
+      } catch (err) {
+        // Revert on failure.
+        setOrderedItems(previous);
+        setError(err instanceof Error ? err : new Error(String(err)));
+      } finally {
+        setIsCommitting(false);
+      }
+    },
+    [orderedItems, items, getId, onCommit]
+  );
+
+  return {
+    orderedItems,
+    handleReorder,
+    isCommitting,
+    error,
+  };
+}

--- a/tests/components/AssignModal.test.tsx
+++ b/tests/components/AssignModal.test.tsx
@@ -1,0 +1,179 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { AssignModal } from '@/components/common/library/AssignModal';
+import type { AssignModeOption } from '@/components/common/library/types';
+
+interface MiniAppOptions {
+  allowRedo: boolean;
+}
+
+interface QuizOptions {
+  speedBonusEnabled: boolean;
+}
+
+const MODES: AssignModeOption[] = [
+  {
+    id: 'teacher',
+    label: 'Teacher-paced',
+    description: 'You control when to move.',
+  },
+  {
+    id: 'auto',
+    label: 'Auto-progress',
+    description: 'Moves when everyone answers.',
+  },
+  {
+    id: 'student',
+    label: 'Self-paced',
+    description: 'Students progress themselves.',
+  },
+];
+
+describe('AssignModal', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders without modes (MiniApp shape)', () => {
+    render(
+      <AssignModal<MiniAppOptions>
+        isOpen
+        onClose={vi.fn()}
+        itemTitle="Test Mini-App"
+        options={{ allowRedo: true }}
+        onOptionsChange={vi.fn()}
+        onAssign={vi.fn()}
+      />
+    );
+    expect(screen.getByText('Test Mini-App')).toBeInTheDocument();
+    // No mode selector
+    expect(screen.queryByText('Session Mode')).not.toBeInTheDocument();
+    expect(screen.queryByText('Teacher-paced')).not.toBeInTheDocument();
+    // No assignment name input when not provided
+    expect(screen.queryByLabelText('Assignment Name')).not.toBeInTheDocument();
+    // Assign button exists
+    expect(screen.getByRole('button', { name: /assign/i })).toBeInTheDocument();
+  });
+
+  it('renders with modes (Quiz shape) and reflects selected mode', () => {
+    const onModeChange = vi.fn();
+    render(
+      <AssignModal<QuizOptions>
+        isOpen
+        onClose={vi.fn()}
+        itemTitle="Test Quiz"
+        modes={MODES}
+        selectedMode="teacher"
+        onModeChange={onModeChange}
+        options={{ speedBonusEnabled: false }}
+        onOptionsChange={vi.fn()}
+        onAssign={vi.fn()}
+      />
+    );
+    expect(screen.getByText('Session Mode')).toBeInTheDocument();
+    const teacherBtn = screen.getByRole('button', { name: /Teacher-paced/ });
+    const autoBtn = screen.getByRole('button', { name: /Auto-progress/ });
+    expect(teacherBtn).toHaveAttribute('aria-pressed', 'true');
+    expect(autoBtn).toHaveAttribute('aria-pressed', 'false');
+
+    fireEvent.click(autoBtn);
+    expect(onModeChange).toHaveBeenCalledWith('auto');
+  });
+
+  it('renders extraSlot and plcSlot content', () => {
+    render(
+      <AssignModal<QuizOptions>
+        isOpen
+        onClose={vi.fn()}
+        itemTitle="Quiz"
+        options={{ speedBonusEnabled: false }}
+        onOptionsChange={vi.fn()}
+        onAssign={vi.fn()}
+        extraSlot={<div data-testid="extra-slot">Extra toggles</div>}
+        plcSlot={<div data-testid="plc-slot">PLC options</div>}
+      />
+    );
+    expect(screen.getByTestId('extra-slot')).toBeInTheDocument();
+    expect(screen.getByTestId('plc-slot')).toBeInTheDocument();
+  });
+
+  it('binds assignmentName input to onAssignmentNameChange', () => {
+    const onAssignmentNameChange = vi.fn();
+    render(
+      <AssignModal<QuizOptions>
+        isOpen
+        onClose={vi.fn()}
+        itemTitle="Quiz"
+        options={{ speedBonusEnabled: false }}
+        onOptionsChange={vi.fn()}
+        onAssign={vi.fn()}
+        assignmentName="Period 1"
+        onAssignmentNameChange={onAssignmentNameChange}
+      />
+    );
+    const input = screen.getByLabelText<HTMLInputElement>('Assignment Name');
+    expect(input.value).toBe('Period 1');
+    fireEvent.change(input, { target: { value: 'Period 3' } });
+    expect(onAssignmentNameChange).toHaveBeenCalledWith('Period 3');
+  });
+
+  it('calls onAssign with the correct payload', async () => {
+    const onAssign = vi.fn().mockResolvedValue(undefined);
+    const options: QuizOptions = { speedBonusEnabled: true };
+    render(
+      <AssignModal<QuizOptions>
+        isOpen
+        onClose={vi.fn()}
+        itemTitle="Quiz"
+        modes={MODES}
+        selectedMode="auto"
+        onModeChange={vi.fn()}
+        options={options}
+        onOptionsChange={vi.fn()}
+        onAssign={onAssign}
+        assignmentName="Period 2"
+        onAssignmentNameChange={vi.fn()}
+      />
+    );
+    const assignButtons = screen.getAllByRole('button', { name: /assign/i });
+    // Grab the footer "Assign" button (not a header Cancel/Assign label),
+    // there is exactly one named "Assign".
+    const confirm = assignButtons.find(
+      (b) => b.textContent?.trim() === 'Assign'
+    );
+    if (!confirm) throw new Error('Confirm button not found');
+    fireEvent.click(confirm);
+    await waitFor(() => {
+      expect(onAssign).toHaveBeenCalledTimes(1);
+    });
+    expect(onAssign).toHaveBeenCalledWith({
+      mode: 'auto',
+      options,
+      assignmentName: 'Period 2',
+    });
+  });
+
+  it('disables Assign when confirmDisabled is true and exposes confirmDisabledReason as tooltip', () => {
+    const onAssign = vi.fn();
+    render(
+      <AssignModal<QuizOptions>
+        isOpen
+        onClose={vi.fn()}
+        itemTitle="Quiz"
+        options={{ speedBonusEnabled: false }}
+        onOptionsChange={vi.fn()}
+        onAssign={onAssign}
+        confirmDisabled
+        confirmDisabledReason="No periods selected"
+      />
+    );
+    const confirm = screen
+      .getAllByRole('button', { name: /assign/i })
+      .find((b) => b.textContent?.trim() === 'Assign');
+    if (!confirm) throw new Error('Confirm button not found');
+    expect(confirm).toBeDisabled();
+    expect(confirm).toHaveAttribute('title', 'No periods selected');
+    fireEvent.click(confirm);
+    expect(onAssign).not.toHaveBeenCalled();
+  });
+});

--- a/tests/components/AssignmentArchiveCard.test.tsx
+++ b/tests/components/AssignmentArchiveCard.test.tsx
@@ -1,0 +1,148 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { AssignmentArchiveCard } from '@/components/common/library/AssignmentArchiveCard';
+import type {
+  AssignmentStatusBadge,
+  LibraryMenuAction,
+  LibraryPrimaryAction,
+} from '@/components/common/library/types';
+
+interface Assignment {
+  id: string;
+  quizTitle: string;
+}
+
+const ASSIGNMENT: Assignment = { id: 'a1', quizTitle: 'My Quiz' };
+
+const LIVE_STATUS: AssignmentStatusBadge = {
+  label: 'Live',
+  tone: 'success',
+  dot: true,
+};
+
+const ENDED_STATUS: AssignmentStatusBadge = {
+  label: 'Ended',
+  tone: 'neutral',
+};
+
+const basePrimary: LibraryPrimaryAction = {
+  label: 'Monitor',
+  onClick: vi.fn(),
+};
+
+describe('AssignmentArchiveCard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders with emerald styling in active mode for success tone', () => {
+    render(
+      <AssignmentArchiveCard<Assignment>
+        assignment={ASSIGNMENT}
+        mode="active"
+        status={LIVE_STATUS}
+        primaryAction={{ ...basePrimary, onClick: vi.fn() }}
+        title={ASSIGNMENT.quizTitle}
+      />
+    );
+    const badge = screen.getByTestId('assignment-status-badge');
+    expect(badge).toHaveTextContent('Live');
+    expect(badge.className).toContain('bg-emerald-100');
+    expect(badge.className).toContain('text-emerald-700');
+  });
+
+  it('renders with slate styling in archive mode for neutral tone', () => {
+    const { container } = render(
+      <AssignmentArchiveCard<Assignment>
+        assignment={ASSIGNMENT}
+        mode="archive"
+        status={ENDED_STATUS}
+        primaryAction={{ ...basePrimary, label: 'Results', onClick: vi.fn() }}
+        title={ASSIGNMENT.quizTitle}
+      />
+    );
+    const badge = screen.getByTestId('assignment-status-badge');
+    expect(badge).toHaveTextContent('Ended');
+    expect(badge.className).toContain('bg-slate-200');
+    expect(badge.className).toContain('text-slate-500');
+    // Archive mode applies muted card styling (opacity-70 on root)
+    const card = container.firstChild as HTMLElement;
+    expect(card.className).toContain('opacity-70');
+  });
+
+  it('opens overflow menu on click and closes on outside click', () => {
+    const secondary: LibraryMenuAction[] = [
+      { id: 'edit', label: 'Edit', onClick: vi.fn() },
+      { id: 'share', label: 'Share', onClick: vi.fn() },
+    ];
+    render(
+      <AssignmentArchiveCard<Assignment>
+        assignment={ASSIGNMENT}
+        mode="active"
+        status={LIVE_STATUS}
+        primaryAction={{ ...basePrimary, onClick: vi.fn() }}
+        secondaryActions={secondary}
+        title={ASSIGNMENT.quizTitle}
+      />
+    );
+    const trigger = screen.getByRole('button', { name: 'More actions' });
+    // Menu initially closed
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+    fireEvent.click(trigger);
+    expect(screen.getByRole('menu')).toBeInTheDocument();
+    expect(screen.getByRole('menuitem', { name: /Edit/ })).toBeInTheDocument();
+    // Close on outside click (mousedown on document.body)
+    fireEvent.mouseDown(document.body);
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+  });
+
+  it('styles destructive actions with destructive classes', () => {
+    const secondary: LibraryMenuAction[] = [
+      { id: 'edit', label: 'Edit', onClick: vi.fn() },
+      {
+        id: 'delete',
+        label: 'Delete',
+        onClick: vi.fn(),
+        destructive: true,
+      },
+    ];
+    render(
+      <AssignmentArchiveCard<Assignment>
+        assignment={ASSIGNMENT}
+        mode="active"
+        status={LIVE_STATUS}
+        primaryAction={{ ...basePrimary, onClick: vi.fn() }}
+        secondaryActions={secondary}
+        title={ASSIGNMENT.quizTitle}
+      />
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'More actions' }));
+    const deleteBtn = screen.getByRole('menuitem', { name: /Delete/ });
+    expect(deleteBtn.className).toContain('text-brand-red-dark');
+    const editBtn = screen.getByRole('menuitem', { name: /Edit/ });
+    expect(editBtn.className).not.toContain('text-brand-red-dark');
+  });
+
+  it('renders disabled primary action with disabledReason as tooltip', () => {
+    const onClick = vi.fn();
+    render(
+      <AssignmentArchiveCard<Assignment>
+        assignment={ASSIGNMENT}
+        mode="active"
+        status={LIVE_STATUS}
+        primaryAction={{
+          label: 'Monitor',
+          onClick,
+          disabled: true,
+          disabledReason: 'Session not started',
+        }}
+        title={ASSIGNMENT.quizTitle}
+      />
+    );
+    const btn = screen.getByRole('button', { name: /Monitor/ });
+    expect(btn).toBeDisabled();
+    expect(btn).toHaveAttribute('title', 'Session not started');
+    fireEvent.click(btn);
+    expect(onClick).not.toHaveBeenCalled();
+  });
+});

--- a/tests/components/ImportWizard.test.tsx
+++ b/tests/components/ImportWizard.test.tsx
@@ -1,0 +1,451 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+  act,
+} from '@testing-library/react';
+import { ImportWizard } from '@/components/common/library/importer';
+import type {
+  ImportAdapter,
+  ImportSourcePayload,
+} from '@/components/common/library/types';
+
+type FakeData = { rows: string[] };
+
+interface MakeAdapterOptions {
+  parseImpl?: (source: ImportSourcePayload) => Promise<{
+    data: FakeData;
+    warnings: string[];
+  }>;
+  validateImpl?: (data: FakeData) => { ok: boolean; errors: string[] };
+  saveImpl?: (data: FakeData, title: string) => Promise<void>;
+  aiAssist?: ImportAdapter<FakeData>['aiAssist'];
+  templateHelper?: ImportAdapter<FakeData>['templateHelper'];
+  supportedSources?: ImportAdapter<FakeData>['supportedSources'];
+}
+
+function makeAdapter(opts: MakeAdapterOptions = {}): {
+  adapter: ImportAdapter<FakeData>;
+  parseSpy: ReturnType<typeof vi.fn>;
+  validateSpy: ReturnType<typeof vi.fn>;
+  saveSpy: ReturnType<typeof vi.fn>;
+  aiGenerateSpy: ReturnType<typeof vi.fn> | null;
+} {
+  const parseSpy = vi.fn(
+    opts.parseImpl ??
+      ((_source: ImportSourcePayload) =>
+        Promise.resolve({
+          data: { rows: ['row-a', 'row-b'] },
+          warnings: [],
+        }))
+  );
+  const validateSpy = vi.fn(
+    opts.validateImpl ??
+      ((_data: FakeData) => ({ ok: true, errors: [] as string[] }))
+  );
+  const saveSpy = vi.fn(
+    opts.saveImpl ??
+      ((_data: FakeData, _title: string) => Promise.resolve(undefined))
+  );
+
+  let aiGenerateSpy: ReturnType<typeof vi.fn> | null = null;
+  const aiAssist = opts.aiAssist;
+  if (aiAssist) {
+    aiGenerateSpy = vi.fn(aiAssist.generate);
+    aiAssist.generate = aiGenerateSpy as typeof aiAssist.generate;
+  }
+
+  const adapter: ImportAdapter<FakeData> = {
+    widgetLabel: 'Quiz',
+    supportedSources: opts.supportedSources ?? ['sheet', 'csv', 'json'],
+    templateHelper: opts.templateHelper,
+    parse: parseSpy as unknown as ImportAdapter<FakeData>['parse'],
+    validate: validateSpy as unknown as ImportAdapter<FakeData>['validate'],
+    renderPreview: (data) => (
+      <div data-testid="preview">rows: {data.rows.join(', ')}</div>
+    ),
+    save: saveSpy as unknown as ImportAdapter<FakeData>['save'],
+    aiAssist,
+  };
+  return { adapter, parseSpy, validateSpy, saveSpy, aiGenerateSpy };
+}
+
+function renderWizard(
+  adapter: ImportAdapter<FakeData>,
+  extra: {
+    onClose?: () => void;
+    onSaved?: (title: string) => void;
+    defaultTitle?: string;
+  } = {}
+) {
+  const onClose = extra.onClose ?? vi.fn();
+  const onSaved = extra.onSaved ?? vi.fn();
+  const utils = render(
+    <ImportWizard<FakeData>
+      isOpen={true}
+      onClose={onClose}
+      adapter={adapter}
+      defaultTitle={extra.defaultTitle}
+      onSaved={onSaved}
+    />
+  );
+  return { ...utils, onClose, onSaved };
+}
+
+function makeFile(name: string, content: string, type = 'text/plain'): File {
+  const file = new File([content], name, { type });
+  // jsdom's File does not implement `text()` — polyfill to the provided
+  // content so the wizard's `await file.text()` resolves deterministically.
+  if (typeof file.text !== 'function') {
+    Object.defineProperty(file, 'text', {
+      value: () => Promise.resolve(content),
+    });
+  }
+  return file;
+}
+
+describe('ImportWizard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('does not render when isOpen is false', () => {
+    const { adapter } = makeAdapter();
+    const { container } = render(
+      <ImportWizard<FakeData>
+        isOpen={false}
+        onClose={vi.fn()}
+        adapter={adapter}
+      />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders the Source step by default with the step indicator', () => {
+    const { adapter } = makeAdapter();
+    renderWizard(adapter);
+    expect(screen.getByText('Import Quiz')).toBeInTheDocument();
+    // Step indicator pills
+    const steps = screen.getByTestId('import-wizard-steps');
+    expect(steps).toHaveTextContent('Source');
+    expect(steps).toHaveTextContent('Preview');
+    expect(steps).toHaveTextContent('Confirm');
+    // Source-specific UI visible
+    expect(screen.getByLabelText('Google Sheet URL')).toBeInTheDocument();
+  });
+
+  it('routes Sheet URL submission through adapter.parse with kind:sheet', async () => {
+    const { adapter, parseSpy } = makeAdapter();
+    renderWizard(adapter);
+
+    const input = screen.getByLabelText('Google Sheet URL');
+    fireEvent.change(input, {
+      target: {
+        value: 'https://docs.google.com/spreadsheets/d/abc/edit',
+      },
+    });
+    const submit = input.parentElement?.querySelector('button');
+    expect(submit).not.toBeNull();
+    fireEvent.click(submit as HTMLButtonElement);
+
+    await waitFor(() => {
+      expect(parseSpy).toHaveBeenCalledTimes(1);
+    });
+    expect(parseSpy).toHaveBeenCalledWith({
+      kind: 'sheet',
+      url: 'https://docs.google.com/spreadsheets/d/abc/edit',
+    });
+    // Moved to Preview step
+    await waitFor(() => {
+      expect(screen.getByTestId('preview')).toBeInTheDocument();
+    });
+  });
+
+  it('routes CSV upload through adapter.parse with kind:csv', async () => {
+    const { adapter, parseSpy } = makeAdapter();
+    renderWizard(adapter);
+
+    const fileInput = screen.getByLabelText('Upload import file');
+    const file = makeFile('questions.csv', 'col1,col2\nfoo,bar', 'text/csv');
+
+    await act(async () => {
+      fireEvent.change(fileInput, { target: { files: [file] } });
+      // Allow the async file.text() read + runParse promise chain to flush.
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(parseSpy).toHaveBeenCalledTimes(1);
+    });
+    const call = parseSpy.mock.calls[0]?.[0] as ImportSourcePayload;
+    expect(call.kind).toBe('csv');
+    if (call.kind === 'csv') {
+      expect(call.text).toContain('foo,bar');
+      expect(call.fileName).toBe('questions.csv');
+    }
+  });
+
+  it('routes JSON upload through adapter.parse with kind:json', async () => {
+    const { adapter, parseSpy } = makeAdapter({
+      supportedSources: ['sheet', 'json'],
+    });
+    renderWizard(adapter);
+
+    const fileInput = screen.getByLabelText('Upload import file');
+    const file = makeFile(
+      'data.json',
+      JSON.stringify({ hello: 'world' }),
+      'application/json'
+    );
+
+    await act(async () => {
+      fireEvent.change(fileInput, { target: { files: [file] } });
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(parseSpy).toHaveBeenCalledTimes(1);
+    });
+    const call = parseSpy.mock.calls[0]?.[0] as ImportSourcePayload;
+    expect(call.kind).toBe('json');
+    if (call.kind === 'json') {
+      expect(call.text).toContain('"hello":"world"');
+      expect(call.fileName).toBe('data.json');
+    }
+  });
+
+  it('surfaces parse errors inline and stays on Source step', async () => {
+    const { adapter } = makeAdapter({
+      parseImpl: () => Promise.reject(new Error('Bad sheet format')),
+    });
+    renderWizard(adapter);
+
+    const input = screen.getByLabelText('Google Sheet URL');
+    fireEvent.change(input, {
+      target: { value: 'https://docs.google.com/spreadsheets/d/bad' },
+    });
+    const submit = input.parentElement?.querySelector('button');
+    fireEvent.click(submit as HTMLButtonElement);
+
+    await waitFor(() => {
+      expect(screen.getByText('Bad sheet format')).toBeInTheDocument();
+    });
+    // Still on Source step (no preview rendered)
+    expect(screen.queryByTestId('preview')).not.toBeInTheDocument();
+  });
+
+  it('blocks save when validation fails and displays validation errors', async () => {
+    const { adapter, saveSpy } = makeAdapter({
+      validateImpl: () => ({
+        ok: false,
+        errors: ['Missing required column', 'Row 3 is empty'],
+      }),
+    });
+    const { onSaved, onClose } = renderWizard(adapter, {
+      defaultTitle: 'My Import',
+    });
+
+    // Parse a sheet → go to Preview
+    const urlField = screen.getByLabelText('Google Sheet URL');
+    fireEvent.change(urlField, {
+      target: { value: 'https://docs.google.com/spreadsheets/d/abc' },
+    });
+    fireEvent.click(
+      urlField.parentElement?.querySelector('button') as HTMLButtonElement
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('preview')).toBeInTheDocument();
+    });
+
+    // Preview → Confirm
+    fireEvent.click(screen.getByRole('button', { name: /continue/i }));
+
+    // Confirm → try to save
+    const saveBtn = await screen.findByRole('button', {
+      name: /save to library/i,
+    });
+    fireEvent.click(saveBtn);
+
+    await waitFor(() => {
+      expect(screen.getByText('Missing required column')).toBeInTheDocument();
+    });
+    expect(screen.getByText('Row 3 is empty')).toBeInTheDocument();
+    expect(saveSpy).not.toHaveBeenCalled();
+    expect(onSaved).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('on successful save calls onSaved with title then onClose', async () => {
+    const { adapter, saveSpy } = makeAdapter();
+    const { onSaved, onClose } = renderWizard(adapter);
+
+    // Parse a sheet
+    fireEvent.change(screen.getByLabelText('Google Sheet URL'), {
+      target: { value: 'https://docs.google.com/spreadsheets/d/abc' },
+    });
+    // Click the small icon button adjacent to the URL input (the sheet submit)
+    const urlField = screen.getByLabelText('Google Sheet URL');
+    const submitBtn = urlField.parentElement?.querySelector('button');
+    fireEvent.click(submitBtn as HTMLButtonElement);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('preview')).toBeInTheDocument();
+    });
+
+    // Preview → Confirm
+    fireEvent.click(screen.getByRole('button', { name: /continue/i }));
+
+    // Enter a title
+    const titleInput = await screen.findByLabelText('Title');
+    fireEvent.change(titleInput, { target: { value: 'Unit 4 Review' } });
+
+    // Save
+    fireEvent.click(screen.getByRole('button', { name: /save to library/i }));
+
+    await waitFor(() => {
+      expect(saveSpy).toHaveBeenCalledTimes(1);
+    });
+    expect(saveSpy).toHaveBeenCalledWith(
+      { rows: ['row-a', 'row-b'] },
+      'Unit 4 Review'
+    );
+    expect(onSaved).toHaveBeenCalledWith('Unit 4 Review');
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('surfaces save errors inline without closing', async () => {
+    const { adapter } = makeAdapter({
+      saveImpl: () => Promise.reject(new Error('Network down')),
+    });
+    const { onClose, onSaved } = renderWizard(adapter, {
+      defaultTitle: 'Prefilled',
+    });
+
+    // Source → Preview
+    fireEvent.change(screen.getByLabelText('Google Sheet URL'), {
+      target: { value: 'https://docs.google.com/spreadsheets/d/abc' },
+    });
+    const urlField = screen.getByLabelText('Google Sheet URL');
+    fireEvent.click(
+      urlField.parentElement?.querySelector('button') as HTMLButtonElement
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId('preview')).toBeInTheDocument();
+    });
+    // Preview → Confirm
+    fireEvent.click(screen.getByRole('button', { name: /continue/i }));
+    // Save
+    fireEvent.click(
+      await screen.findByRole('button', { name: /save to library/i })
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Network down')).toBeInTheDocument();
+    });
+    expect(onClose).not.toHaveBeenCalled();
+    expect(onSaved).not.toHaveBeenCalled();
+  });
+
+  it('AI-assist path bypasses Source and jumps to Preview with generated data', async () => {
+    const generated: FakeData = { rows: ['ai-row-1', 'ai-row-2'] };
+    const aiAssist: ImportAdapter<FakeData>['aiAssist'] = {
+      promptPlaceholder: 'Describe your quiz…',
+      generate: () => Promise.resolve(generated),
+    };
+    const { adapter, aiGenerateSpy, parseSpy } = makeAdapter({ aiAssist });
+    renderWizard(adapter);
+
+    // Open AI-assist overlay
+    fireEvent.click(
+      screen.getByRole('button', { name: /ai-assist import for quiz/i })
+    );
+    // Prompt + generate
+    const textarea = screen.getByLabelText('AI-assist prompt for Quiz');
+    fireEvent.change(textarea, {
+      target: { value: '5 questions on the solar system' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /^generate$/i }));
+
+    await waitFor(() => {
+      expect(aiGenerateSpy).toHaveBeenCalledTimes(1);
+    });
+    expect(aiGenerateSpy).toHaveBeenCalledWith({
+      prompt: '5 questions on the solar system',
+    });
+    // Should NOT have called parse — AI bypasses parsing
+    expect(parseSpy).not.toHaveBeenCalled();
+    // Now on Preview showing generated rows
+    await waitFor(() => {
+      expect(screen.getByTestId('preview')).toHaveTextContent(
+        'rows: ai-row-1, ai-row-2'
+      );
+    });
+  });
+
+  it('shows a hint when Sheet URL does not look like a Google Sheets URL', () => {
+    const { adapter } = makeAdapter();
+    renderWizard(adapter);
+
+    fireEvent.change(screen.getByLabelText('Google Sheet URL'), {
+      target: { value: 'https://example.com/some-other-sheet' },
+    });
+    expect(
+      screen.getByText(/doesn.t look like a Google Sheets URL/i)
+    ).toBeInTheDocument();
+  });
+
+  it('renders warnings from parse result on the Preview step', async () => {
+    const { adapter } = makeAdapter({
+      parseImpl: () =>
+        Promise.resolve({
+          data: { rows: ['x'] },
+          warnings: ['Row 2 had a blank cell', 'Ambiguous timestamp on row 5'],
+        }),
+    });
+    renderWizard(adapter);
+
+    fireEvent.change(screen.getByLabelText('Google Sheet URL'), {
+      target: { value: 'https://docs.google.com/spreadsheets/d/abc' },
+    });
+    const urlField = screen.getByLabelText('Google Sheet URL');
+    fireEvent.click(
+      urlField.parentElement?.querySelector('button') as HTMLButtonElement
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('preview')).toBeInTheDocument();
+    });
+    expect(screen.getByText('Row 2 had a blank cell')).toBeInTheDocument();
+    expect(
+      screen.getByText('Ambiguous timestamp on row 5')
+    ).toBeInTheDocument();
+  });
+
+  it('shows the template helper when adapter exposes templateHelper', () => {
+    const { adapter } = makeAdapter({
+      templateHelper: {
+        createTemplate: () =>
+          Promise.resolve({ url: 'https://example.com/tpl' }),
+        instructions: <p>Template instructions here.</p>,
+      },
+    });
+    renderWizard(adapter);
+
+    fireEvent.click(
+      screen.getByRole('button', { name: /template .* format help/i })
+    );
+    expect(screen.getByText('Template instructions here.')).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /create template/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /copy template url/i })
+    ).toBeInTheDocument();
+  });
+});

--- a/tests/components/PeriodSelector.test.tsx
+++ b/tests/components/PeriodSelector.test.tsx
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { PeriodSelector } from '@/components/common/library/PeriodSelector';
+import type { ClassRoster } from '@/types';
+
+function makeRoster(id: string, name: string): ClassRoster {
+  return {
+    id,
+    name,
+    driveFileId: null,
+    studentCount: 0,
+    createdAt: Date.now(),
+    students: [],
+  };
+}
+
+/** Find the checkbox input associated with a given period name. */
+function getPeriodCheckbox(name: string): HTMLInputElement {
+  const label = screen.getByText(name).closest('label');
+  if (!label) throw new Error(`Label for ${name} not found`);
+  const input = label.querySelector<HTMLInputElement>('input[type="checkbox"]');
+  if (!input) throw new Error(`Checkbox for ${name} not found`);
+  return input;
+}
+
+const ROSTERS: ClassRoster[] = [
+  makeRoster('r1', 'Period 1'),
+  makeRoster('r2', 'Period 2'),
+  makeRoster('r3', 'Period 3'),
+];
+
+describe('PeriodSelector', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('cannot uncheck a locked period', () => {
+    const onSave = vi.fn();
+    const onClose = vi.fn();
+    render(
+      <PeriodSelector
+        rosters={ROSTERS}
+        selectedPeriodNames={['Period 1', 'Period 2']}
+        lockedPeriodNames={['Period 2']}
+        onSave={onSave}
+        onClose={onClose}
+      />
+    );
+    // Period 2 checkbox should be disabled because it's selected AND locked.
+    // A disabled checkbox cannot be toggled off by a user — that's what
+    // guarantees the period stays selected in the saved payload below.
+    const period2Input = getPeriodCheckbox('Period 2');
+    expect(period2Input).toBeDisabled();
+    expect(period2Input.checked).toBe(true);
+
+    // Period 1 is selected but not locked — should still be toggleable
+    const period1Input = getPeriodCheckbox('Period 1');
+    expect(period1Input).not.toBeDisabled();
+
+    // Even if onSave fires, the locked period remains in the selection.
+    fireEvent.click(screen.getByRole('button', { name: /Save/ }));
+    expect(onSave).toHaveBeenCalledWith(
+      expect.arrayContaining(['Period 1', 'Period 2'])
+    );
+  });
+
+  it('fires onSave with the selected period names on Save', () => {
+    const onSave = vi.fn();
+    const onClose = vi.fn();
+    render(
+      <PeriodSelector
+        rosters={ROSTERS}
+        selectedPeriodNames={['Period 1']}
+        onSave={onSave}
+        onClose={onClose}
+      />
+    );
+    // Toggle Period 3 on
+    fireEvent.click(getPeriodCheckbox('Period 3'));
+
+    // Click Save
+    fireEvent.click(screen.getByRole('button', { name: /Save/ }));
+    expect(onSave).toHaveBeenCalledTimes(1);
+    expect(onSave).toHaveBeenCalledWith(['Period 1', 'Period 3']);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('closes on outside click (mousedown on document)', () => {
+    const onClose = vi.fn();
+    render(
+      <PeriodSelector
+        rosters={ROSTERS}
+        selectedPeriodNames={[]}
+        onSave={vi.fn()}
+        onClose={onClose}
+      />
+    );
+    // Click outside the popover
+    fireEvent.mouseDown(document.body);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('closes via the explicit close button', () => {
+    const onClose = vi.fn();
+    render(
+      <PeriodSelector
+        rosters={ROSTERS}
+        selectedPeriodNames={[]}
+        onSave={vi.fn()}
+        onClose={onClose}
+      />
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Close' }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows empty-state copy when no rosters exist', () => {
+    render(
+      <PeriodSelector
+        rosters={[]}
+        selectedPeriodNames={[]}
+        onSave={vi.fn()}
+        onClose={vi.fn()}
+      />
+    );
+    expect(screen.getByText(/No rosters available/i)).toBeInTheDocument();
+  });
+});

--- a/tests/components/common/LibraryGrid.test.tsx
+++ b/tests/components/common/LibraryGrid.test.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { describe, it, expect, vi } from 'vitest';
 import { act, render, screen, fireEvent } from '@testing-library/react';
-import { LibraryGrid } from '../../../components/common/library/LibraryGrid';
-import { LibraryItemCard } from '../../../components/common/library/LibraryItemCard';
+import { LibraryGrid } from '@/components/common/library/LibraryGrid';
+import { LibraryItemCard } from '@/components/common/library/LibraryItemCard';
 
 interface Item {
   id: string;

--- a/tests/components/common/LibraryGrid.test.tsx
+++ b/tests/components/common/LibraryGrid.test.tsx
@@ -1,0 +1,127 @@
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { act, render, screen, fireEvent } from '@testing-library/react';
+import { LibraryGrid } from '../../../components/common/library/LibraryGrid';
+import { LibraryItemCard } from '../../../components/common/library/LibraryItemCard';
+
+interface Item {
+  id: string;
+  title: string;
+}
+
+const makeItems = (ids: string[]): Item[] =>
+  ids.map((id) => ({ id, title: id.toUpperCase() }));
+
+const noop = vi.fn();
+
+const renderCard = (item: Item) => (
+  <LibraryItemCard
+    key={item.id}
+    id={item.id}
+    title={item.title}
+    primaryAction={{ label: 'Assign', onClick: noop }}
+  />
+);
+
+describe('LibraryGrid', () => {
+  it('renders one card per item', () => {
+    const items = makeItems(['a', 'b', 'c']);
+    render(
+      <LibraryGrid items={items} getId={(i) => i.id} renderCard={renderCard} />
+    );
+
+    expect(screen.getByText('A')).toBeInTheDocument();
+    expect(screen.getByText('B')).toBeInTheDocument();
+    expect(screen.getByText('C')).toBeInTheDocument();
+    expect(screen.getByTestId('library-grid').children).toHaveLength(3);
+  });
+
+  it('renders the emptyState when items is empty', () => {
+    render(
+      <LibraryGrid
+        items={[] as Item[]}
+        getId={(i) => i.id}
+        renderCard={renderCard}
+        emptyState={<div>Nothing here</div>}
+      />
+    );
+
+    expect(screen.getByText('Nothing here')).toBeInTheDocument();
+    expect(screen.queryByTestId('library-grid')).not.toBeInTheDocument();
+  });
+
+  it('hides drag handles when dragDisabled is true', () => {
+    const items = makeItems(['a', 'b']);
+    render(
+      <LibraryGrid
+        items={items}
+        getId={(i) => i.id}
+        renderCard={renderCard}
+        dragDisabled
+      />
+    );
+
+    // With sortable auto-disabled, cards render without a drag handle.
+    expect(
+      screen.queryByRole('button', { name: /drag to reorder/i })
+    ).not.toBeInTheDocument();
+  });
+
+  it('exposes drag handles with a reason tooltip when reorder is locked', () => {
+    const items = makeItems(['a', 'b']);
+    render(
+      <LibraryGrid
+        items={items}
+        getId={(i) => i.id}
+        renderCard={renderCard}
+        reorderLocked
+        reorderLockedReason="Clear search to reorder"
+      />
+    );
+
+    const handles = screen.getAllByRole('button', {
+      name: /clear search to reorder/i,
+    });
+    expect(handles.length).toBeGreaterThan(0);
+    // Handles should be disabled while locked.
+    expect(handles[0]).toBeDisabled();
+  });
+
+  it('keyboard accessibility smoke test: drag handle is focusable and responds to Space', () => {
+    const items = makeItems(['a', 'b', 'c']);
+    const onReorder = vi.fn();
+    render(
+      <LibraryGrid
+        items={items}
+        getId={(i) => i.id}
+        renderCard={renderCard}
+        onReorder={onReorder}
+      />
+    );
+
+    const handles = screen.getAllByRole('button', { name: /drag to reorder/i });
+    expect(handles).toHaveLength(3);
+
+    // First handle should be reachable via keyboard.
+    handles[0].focus();
+    expect(handles[0]).toHaveFocus();
+
+    // Activate the keyboard drag sensor (space begins drag), move down, drop.
+    act(() => {
+      fireEvent.keyDown(handles[0], { key: ' ', code: 'Space' });
+    });
+    act(() => {
+      fireEvent.keyDown(handles[0], { key: 'ArrowDown', code: 'ArrowDown' });
+    });
+    act(() => {
+      fireEvent.keyDown(handles[0], { key: ' ', code: 'Space' });
+    });
+
+    // We assert the integration path plumbed through — the exact dnd-kit
+    // keyboard coordination is exercised in dnd-kit's own test suite; for
+    // us it's enough to verify the handle is a real focusable button
+    // participating in the DndContext. (Some jsdom environments don't
+    // fully simulate the keyboard sensor's internal layout math.)
+    expect(handles[0]).toHaveAttribute('type', 'button');
+  });
+});

--- a/tests/hooks/useLibraryView.test.ts
+++ b/tests/hooks/useLibraryView.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
-import { useLibraryView } from '../../components/common/library/useLibraryView';
-import type { LibrarySortDir } from '../../components/common/library/types';
+import { useLibraryView } from '@/components/common/library/useLibraryView';
+import type { LibrarySortDir } from '@/components/common/library/types';
 
 interface Item {
   id: string;

--- a/tests/hooks/useLibraryView.test.ts
+++ b/tests/hooks/useLibraryView.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useLibraryView } from '../../components/common/library/useLibraryView';
+import type { LibrarySortDir } from '../../components/common/library/types';
+
+interface Item {
+  id: string;
+  title: string;
+  grade: string;
+  order: number;
+  createdAt: number;
+}
+
+const ITEMS: Item[] = [
+  { id: 'a', title: 'Alpha Quiz', grade: 'K-2', order: 3, createdAt: 300 },
+  { id: 'b', title: 'Bravo Quiz', grade: '3-5', order: 1, createdAt: 100 },
+  { id: 'c', title: 'Charlie Test', grade: 'K-2', order: 2, createdAt: 200 },
+];
+
+const searchFields = (item: Item) => [item.title, item.grade];
+
+const sortComparators = {
+  manual: (a: Item, b: Item, dir: LibrarySortDir) => {
+    const diff = a.order - b.order;
+    return dir === 'asc' ? diff : -diff;
+  },
+  title: (a: Item, b: Item, dir: LibrarySortDir) => {
+    const diff = a.title.localeCompare(b.title);
+    return dir === 'asc' ? diff : -diff;
+  },
+  createdAt: (a: Item, b: Item, dir: LibrarySortDir) => {
+    const diff = a.createdAt - b.createdAt;
+    return dir === 'asc' ? diff : -diff;
+  },
+};
+
+const filterPredicates = {
+  grade: (item: Item, value: string) => item.grade === value,
+  hasC: (item: Item, value: string) =>
+    value === 'yes' ? item.title.toLowerCase().includes('c') : true,
+};
+
+const baseOptions = () => ({
+  items: ITEMS,
+  searchFields,
+  sortComparators,
+  filterPredicates,
+});
+
+describe('useLibraryView', () => {
+  it('returns all items in manual order by default', () => {
+    const { result } = renderHook(() => useLibraryView(baseOptions()));
+    expect(result.current.visibleItems.map((i) => i.id)).toEqual([
+      'b',
+      'c',
+      'a',
+    ]);
+    expect(result.current.reorderLocked).toBe(false);
+    expect(result.current.reorderLockedReason).toBeUndefined();
+  });
+
+  it('filters items by search substring (case-insensitive) across fields', () => {
+    const { result } = renderHook(() => useLibraryView(baseOptions()));
+
+    act(() => {
+      result.current.toolbarProps.onSearchChange('QUIZ');
+    });
+
+    const ids = result.current.visibleItems.map((i) => i.id).sort();
+    expect(ids).toEqual(['a', 'b']);
+
+    act(() => {
+      result.current.toolbarProps.onSearchChange('3-5');
+    });
+
+    expect(result.current.visibleItems.map((i) => i.id)).toEqual(['b']);
+  });
+
+  it('sorts ascending and descending for the same key', () => {
+    const { result } = renderHook(() => useLibraryView(baseOptions()));
+
+    act(() => {
+      result.current.toolbarProps.onSortChange({ key: 'title', dir: 'asc' });
+    });
+    expect(result.current.visibleItems.map((i) => i.id)).toEqual([
+      'a',
+      'b',
+      'c',
+    ]);
+
+    act(() => {
+      result.current.toolbarProps.onSortChange({ key: 'title', dir: 'desc' });
+    });
+    expect(result.current.visibleItems.map((i) => i.id)).toEqual([
+      'c',
+      'b',
+      'a',
+    ]);
+  });
+
+  it('AND-combines multiple active filters', () => {
+    const { result } = renderHook(() => useLibraryView(baseOptions()));
+
+    act(() => {
+      result.current.toolbarProps.onFilterChange?.('grade', 'K-2');
+    });
+    expect(result.current.visibleItems.map((i) => i.id).sort()).toEqual([
+      'a',
+      'c',
+    ]);
+
+    act(() => {
+      result.current.toolbarProps.onFilterChange?.('hasC', 'yes');
+    });
+    // grade=K-2 AND title contains "c" → only "Charlie Test"
+    expect(result.current.visibleItems.map((i) => i.id)).toEqual(['c']);
+
+    // Clearing a filter (empty string) removes it from active set.
+    act(() => {
+      result.current.toolbarProps.onFilterChange?.('grade', '');
+    });
+    expect(result.current.visibleItems.map((i) => i.id).sort()).toEqual(['c']);
+  });
+
+  it('reorder is unlocked when sort=manual and search is empty', () => {
+    const { result } = renderHook(() => useLibraryView(baseOptions()));
+    expect(result.current.reorderLocked).toBe(false);
+  });
+
+  it('reorder locks when search is non-empty', () => {
+    const { result } = renderHook(() => useLibraryView(baseOptions()));
+    act(() => {
+      result.current.toolbarProps.onSearchChange('Alpha');
+    });
+    expect(result.current.reorderLocked).toBe(true);
+    expect(result.current.reorderLockedReason).toBeDefined();
+  });
+
+  it('reorder locks when sort.key is not manual', () => {
+    const { result } = renderHook(() => useLibraryView(baseOptions()));
+    act(() => {
+      result.current.toolbarProps.onSortChange({
+        key: 'createdAt',
+        dir: 'desc',
+      });
+    });
+    expect(result.current.reorderLocked).toBe(true);
+    expect(result.current.reorderLockedReason).toBeDefined();
+  });
+
+  it('visibleItems is referentially stable when inputs do not change', () => {
+    const opts = baseOptions();
+    const { result, rerender } = renderHook(() => useLibraryView(opts));
+    const first = result.current.visibleItems;
+    rerender();
+    expect(result.current.visibleItems).toBe(first);
+  });
+
+  it('respects initial sort / search / filter values', () => {
+    const { result } = renderHook(() =>
+      useLibraryView({
+        ...baseOptions(),
+        initialSearch: 'quiz',
+        initialSort: { key: 'title', dir: 'desc' },
+        initialFilterValues: { grade: 'K-2' },
+      })
+    );
+    // grade=K-2 AND title ~ "quiz" → only Alpha Quiz
+    expect(result.current.visibleItems.map((i) => i.id)).toEqual(['a']);
+    expect(result.current.reorderLocked).toBe(true);
+  });
+});

--- a/tests/hooks/useSortableReorder.test.ts
+++ b/tests/hooks/useSortableReorder.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { renderHook, act, waitFor } from '@testing-library/react';
-import { useSortableReorder } from '../../components/common/library/useSortableReorder';
+import { useSortableReorder } from '@/components/common/library/useSortableReorder';
 
 interface Item {
   id: string;

--- a/tests/hooks/useSortableReorder.test.ts
+++ b/tests/hooks/useSortableReorder.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { useSortableReorder } from '../../components/common/library/useSortableReorder';
+
+interface Item {
+  id: string;
+  label: string;
+}
+
+const makeItems = (ids: string[]): Item[] =>
+  ids.map((id) => ({ id, label: id.toUpperCase() }));
+
+const getId = (item: Item) => item.id;
+
+describe('useSortableReorder', () => {
+  it('returns the items in their original order by default', () => {
+    const items = makeItems(['a', 'b', 'c']);
+    const onCommit = vi.fn();
+
+    const { result } = renderHook(() =>
+      useSortableReorder({ items, getId, onCommit })
+    );
+
+    expect(result.current.orderedItems.map(getId)).toEqual(['a', 'b', 'c']);
+    expect(result.current.isCommitting).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('optimistically reorders before the commit resolves', async () => {
+    const items = makeItems(['a', 'b', 'c']);
+    let resolveCommit: (() => void) | null = null;
+    const onCommit = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveCommit = resolve;
+        })
+    );
+
+    const { result } = renderHook(() =>
+      useSortableReorder({ items, getId, onCommit })
+    );
+
+    // Fire the reorder but don't await it yet.
+    let reorderPromise: Promise<void> | undefined;
+    act(() => {
+      reorderPromise = result.current.handleReorder(['c', 'a', 'b']);
+    });
+
+    // Optimistic update landed.
+    expect(result.current.orderedItems.map(getId)).toEqual(['c', 'a', 'b']);
+    expect(result.current.isCommitting).toBe(true);
+    expect(onCommit).toHaveBeenCalledWith(['c', 'a', 'b']);
+
+    // Let the commit finish.
+    await act(async () => {
+      resolveCommit?.();
+      await reorderPromise;
+    });
+
+    expect(result.current.orderedItems.map(getId)).toEqual(['c', 'a', 'b']);
+    expect(result.current.isCommitting).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('clears a prior error after a successful commit', async () => {
+    const items = makeItems(['a', 'b', 'c']);
+    const onCommit = vi
+      .fn<(ids: string[]) => Promise<void>>()
+      .mockRejectedValueOnce(new Error('nope'))
+      .mockResolvedValueOnce(undefined);
+
+    const { result } = renderHook(() =>
+      useSortableReorder({ items, getId, onCommit })
+    );
+
+    await act(async () => {
+      await result.current.handleReorder(['b', 'a', 'c']);
+    });
+    expect(result.current.error).toBeInstanceOf(Error);
+    expect(result.current.error?.message).toBe('nope');
+    // Reverted.
+    expect(result.current.orderedItems.map(getId)).toEqual(['a', 'b', 'c']);
+
+    await act(async () => {
+      await result.current.handleReorder(['c', 'b', 'a']);
+    });
+    expect(result.current.error).toBeNull();
+    expect(result.current.orderedItems.map(getId)).toEqual(['c', 'b', 'a']);
+  });
+
+  it('reverts the order and captures the error when commit rejects', async () => {
+    const items = makeItems(['a', 'b', 'c']);
+    const onCommit = vi.fn().mockRejectedValue(new Error('persist failed'));
+
+    const { result } = renderHook(() =>
+      useSortableReorder({ items, getId, onCommit })
+    );
+
+    await act(async () => {
+      await result.current.handleReorder(['c', 'a', 'b']);
+    });
+
+    expect(result.current.orderedItems.map(getId)).toEqual(['a', 'b', 'c']);
+    expect(result.current.isCommitting).toBe(false);
+    expect(result.current.error).toBeInstanceOf(Error);
+    expect(result.current.error?.message).toBe('persist failed');
+  });
+
+  it('re-syncs orderedItems when the items prop id set changes', () => {
+    const initial = makeItems(['a', 'b', 'c']);
+    const onCommit = vi.fn();
+
+    const { result, rerender } = renderHook(
+      ({ items }) => useSortableReorder({ items, getId, onCommit }),
+      { initialProps: { items: initial } }
+    );
+
+    expect(result.current.orderedItems.map(getId)).toEqual(['a', 'b', 'c']);
+
+    const next = makeItems(['a', 'd', 'e']);
+    rerender({ items: next });
+
+    expect(result.current.orderedItems.map(getId)).toEqual(['a', 'd', 'e']);
+  });
+
+  it('preserves optimistic order when prop items update but id set is unchanged', async () => {
+    const first = makeItems(['a', 'b', 'c']);
+    const onCommit = vi.fn().mockResolvedValue(undefined);
+
+    const { result, rerender } = renderHook(
+      ({ items }) => useSortableReorder({ items, getId, onCommit }),
+      { initialProps: { items: first } }
+    );
+
+    await act(async () => {
+      await result.current.handleReorder(['c', 'a', 'b']);
+    });
+    expect(result.current.orderedItems.map(getId)).toEqual(['c', 'a', 'b']);
+
+    // Consumer sends a new items array with identical ids but updated labels
+    // (e.g. Firestore snapshot delivered fresh data).
+    const refreshed: Item[] = [
+      { id: 'a', label: 'AAA' },
+      { id: 'b', label: 'BBB' },
+      { id: 'c', label: 'CCC' },
+    ];
+    rerender({ items: refreshed });
+
+    await waitFor(() => {
+      expect(result.current.orderedItems.map(getId)).toEqual(['c', 'a', 'b']);
+    });
+    expect(result.current.orderedItems.find((i) => i.id === 'a')?.label).toBe(
+      'AAA'
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Phase 0 / Wave 1 of the [unified library plan](https://github.com/OPS-PIvers/SpartBoard/blob/dev-paul/docs/unified-editor-modal-plan.md). Ships a cross-widget set of presentational + state primitives in \`components/common/library/\` that Quiz, Video Activity, Guided Learning, and MiniApp will migrate to in Wave 2.

**No widget behavior changes in this PR — all four widgets are untouched.** Wave 2 migrations land as separate PRs.

## What's in the box

**Shell & toolbar**
- \`LibraryShell\` — 3-tab chrome (Library / In Progress / Archive) with badge counts, primary + secondary action slots, optional filter-sidebar slot
- \`LibraryToolbar\` — search, sort (with asc/desc), per-filter selects, grid/list view-mode toggle
- \`useLibraryView\` — state hook; derives \`visibleItems\` (filter + sort) and auto-locks reorder when search is active or sort is not \`manual\`

**Grid & cards**
- \`LibraryItemCard\` — sortable card with title, subtitle, thumbnail, badges, primary action, overflow menu (destructive actions floated to bottom)
- \`LibraryGrid\` — dnd-kit \`SortableContext\` wrapper; supports grid and list layouts; uses a lock-context fallback so the \`DragOverlay\` renders without needing to clone+inject props
- \`useSortableReorder\` — optimistic reorder with revert-on-reject; re-syncs on upstream id-set changes without \`useEffect\`

**Assign & archive**
- \`AssignModal\` — chrome with optional mode selector, assignment-name input, \`extraSlot\` (widget-specific options) and \`plcSlot\` (PLC multi-select)
- \`AssignmentArchiveCard\` — generalized from \`QuizAssignmentArchive\` with status badge, context-aware primary action, overflow menu
- \`PeriodSelector\` — extracted from \`QuizPeriodSelector\`; takes \`lockedPeriodNames\` directly (derivation lives upstream)

**Importer**
- \`ImportWizard\` — 3-step Source → Preview → Confirm wizard driven by an \`ImportAdapter<TData>\`; supports sheet / csv / json / file sources, in-wizard AI-assist overlay, collapsible template helper

## Verification

- \`pnpm run type-check\` — clean repo-wide
- \`pnpm exec eslint components/common/library\` — clean
- \`pnpm exec prettier --check\` on new files — clean
- \`pnpm exec vitest run\` on 7 new test files — **49/49 passing**

## Test plan

- [ ] CI: PR validation passes (type-check, lint, format, build)
- [ ] No runtime wiring yet — these primitives have no consumers, so smoke test is just build + unit tests
- [ ] Wave 2 agents can import against the API in [\`components/common/library/types.ts\`](https://github.com/OPS-PIvers/SpartBoard/blob/claude/romantic-lichterman-0c2178/components/common/library/types.ts) as the integration contract

## Next up

- **Wave 2** (4 parallel PRs): VA / GL / MiniApp migrations + Quiz reconciliation
- **Wave 3**: folder schema PR, then folder UI PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)