### PR TITLE
fix(library): break infinite-render loop in useSortableReorder (Wave 2 hotfix)

### DIFF
--- a/components/common/library/useSortableReorder.ts
+++ b/components/common/library/useSortableReorder.ts
@@ -87,13 +87,17 @@ export function useSortableReorder<TItem>(
       // Id set changed upstream — drop optimistic ordering and re-seed.
       setOrderedItems(items);
     } else if (!sameIdList(currentOrderedIds, currentIds)) {
-      // Same ids, but item bodies may have been updated by the consumer.
+      // Same ids, but the upstream order differs from our optimistic view.
       // Preserve our optimistic order while absorbing the fresh objects.
       setOrderedItems(reorderByIds(items, getId, currentOrderedIds));
-    } else {
-      // Ids and order both match — just pick up the new item references.
-      setOrderedItems(items);
     }
+    // Else: ids and order both match — orderedItems is already correct.
+    // We intentionally do NOT re-seed with the new array reference here;
+    // doing so would trigger an infinite render loop whenever the caller
+    // passes an unstable array reference (e.g. a freshly-computed useMemo
+    // whose deps include an inline function). Item bodies are rarely
+    // mutated without an id change in this codebase, so dropping the
+    // "absorb fresh object refs" case is a safe tradeoff.
   }
 
   const handleReorder = useCallback(

--- a/components/widgets/GuidedLearning/components/GuidedLearningManager.tsx
+++ b/components/widgets/GuidedLearning/components/GuidedLearningManager.tsx
@@ -18,7 +18,7 @@
  * Reference: components/widgets/QuizWidget/components/QuizManager.tsx.
  */
 
-import React, { useMemo } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import {
   Plus,
   Play,
@@ -153,6 +153,48 @@ const MODE_LABELS: Record<GuidedLearningSet['mode'], string> = {
   explore: 'Explore',
 };
 
+/* ─── Library hook option constants (module-level for referential stability) ─
+
+ * Inline literals passed to `useLibraryView`'s options would re-derive
+ * `visibleItems` on every render, which in turn triggers a re-render loop
+ * through `useSortableReorder`. Keeping them at module scope keeps references
+ * stable across renders. */
+
+const LIBRARY_SEARCH_FIELDS = (e: LibraryEntry): string[] => [
+  e.title,
+  e.description ?? '',
+];
+
+const LIBRARY_INITIAL_SORT = { key: 'manual', dir: 'asc' as const };
+
+const LIBRARY_SORT_COMPARATORS = {
+  manual: (a: LibraryEntry, b: LibraryEntry, dir: 'asc' | 'desc') => {
+    const av = a.order ?? Number.POSITIVE_INFINITY;
+    const bv = b.order ?? Number.POSITIVE_INFINITY;
+    const diff = av - bv;
+    return dir === 'asc' ? diff : -diff;
+  },
+  title: (a: LibraryEntry, b: LibraryEntry, dir: 'asc' | 'desc') => {
+    const diff = a.title.localeCompare(b.title);
+    return dir === 'asc' ? diff : -diff;
+  },
+  updatedAt: (a: LibraryEntry, b: LibraryEntry, dir: 'asc' | 'desc') => {
+    const diff = a.updatedAt - b.updatedAt;
+    return dir === 'asc' ? diff : -diff;
+  },
+  createdAt: (a: LibraryEntry, b: LibraryEntry, dir: 'asc' | 'desc') => {
+    const diff = a.createdAt - b.createdAt;
+    return dir === 'asc' ? diff : -diff;
+  },
+};
+
+const LIBRARY_FILTER_PREDICATES = {
+  source: (item: LibraryEntry, value: string): boolean =>
+    value === '' ? true : item.source === value,
+};
+
+const LIBRARY_GET_ID = (e: LibraryEntry): string => e.id;
+
 /* ─── Helpers ─────────────────────────────────────────────────────────────── */
 
 // Non-admins still see building sets (they're shared with the whole
@@ -248,31 +290,10 @@ export const GuidedLearningManager: React.FC<GuidedLearningManagerProps> = ({
 
   const view = useLibraryView<LibraryEntry>({
     items: allEntries,
-    initialSort: { key: 'manual', dir: 'asc' },
-    searchFields: (e) => [e.title, e.description ?? ''],
-    sortComparators: {
-      manual: (a, b, dir) => {
-        const av = a.order ?? Number.POSITIVE_INFINITY;
-        const bv = b.order ?? Number.POSITIVE_INFINITY;
-        const diff = av - bv;
-        return dir === 'asc' ? diff : -diff;
-      },
-      title: (a, b, dir) => {
-        const diff = a.title.localeCompare(b.title);
-        return dir === 'asc' ? diff : -diff;
-      },
-      updatedAt: (a, b, dir) => {
-        const diff = a.updatedAt - b.updatedAt;
-        return dir === 'asc' ? diff : -diff;
-      },
-      createdAt: (a, b, dir) => {
-        const diff = a.createdAt - b.createdAt;
-        return dir === 'asc' ? diff : -diff;
-      },
-    },
-    filterPredicates: {
-      source: (item, value) => (value === '' ? true : item.source === value),
-    },
+    initialSort: LIBRARY_INITIAL_SORT,
+    searchFields: LIBRARY_SEARCH_FIELDS,
+    sortComparators: LIBRARY_SORT_COMPARATORS,
+    filterPredicates: LIBRARY_FILTER_PREDICATES,
   });
 
   const activeSourceFilter = view.state.filterValues.source ?? '';
@@ -285,10 +306,8 @@ export const GuidedLearningManager: React.FC<GuidedLearningManagerProps> = ({
     [view.visibleItems]
   );
 
-  const reorder = useSortableReorder<LibraryEntry>({
-    items: view.visibleItems,
-    getId: (e) => e.id,
-    onCommit: async (orderedIds) => {
+  const onReorderCommit = useCallback(
+    async (orderedIds: string[]) => {
       // Strip the `personal:` prefix and ignore building entries — the Widget
       // only accepts personal set ids.
       const personalIds = orderedIds
@@ -296,6 +315,13 @@ export const GuidedLearningManager: React.FC<GuidedLearningManagerProps> = ({
         .map((id) => id.slice('personal:'.length));
       await onReorderPersonal(personalIds);
     },
+    [onReorderPersonal]
+  );
+
+  const reorder = useSortableReorder<LibraryEntry>({
+    items: view.visibleItems,
+    getId: LIBRARY_GET_ID,
+    onCommit: onReorderCommit,
   });
 
   const dragDisabled =

--- a/components/widgets/MiniApp/components/MiniAppManager.tsx
+++ b/components/widgets/MiniApp/components/MiniAppManager.tsx
@@ -26,7 +26,7 @@
  * session lifecycle lives in the parent Widget.tsx.
  */
 
-import React, { useMemo } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import {
   Plus,
   FileUp,
@@ -159,6 +159,35 @@ function compareNumbers(a: number, b: number, dir: LibrarySortDir): number {
   return dir === 'asc' ? a - b : b - a;
 }
 
+/* ─── Library hook option constants (module-level for referential stability) ─
+
+ * Inline literals passed to `useLibraryView` would re-derive `visibleItems` on
+ * every render, which in turn triggers a re-render loop through
+ * `useSortableReorder`. Module-scoped constants keep the references stable. */
+
+const LIBRARY_SEARCH_FIELDS = (row: UnifiedRow): string => row.item.title;
+
+const LIBRARY_INITIAL_SORT = { key: 'manual', dir: 'asc' as const };
+
+const LIBRARY_INITIAL_FILTER_VALUES = { source: 'personal' };
+
+const LIBRARY_SORT_COMPARATORS = {
+  // Manual = keep input order (personal first in its stored order, then
+  // global). useLibraryView preserves the input order when the comparator
+  // returns 0.
+  manual: () => 0,
+  title: (a: UnifiedRow, b: UnifiedRow, dir: LibrarySortDir) =>
+    compareStrings(getRowTitle(a), getRowTitle(b), dir),
+  createdAt: (a: UnifiedRow, b: UnifiedRow, dir: LibrarySortDir) =>
+    compareNumbers(getRowCreatedAt(a), getRowCreatedAt(b), dir),
+  size: (a: UnifiedRow, b: UnifiedRow, dir: LibrarySortDir) =>
+    compareNumbers(getRowSize(a), getRowSize(b), dir),
+};
+
+const LIBRARY_FILTER_PREDICATES = {
+  source: (row: UnifiedRow, value: string): boolean => row.kind === value,
+};
+
 /* ─── Component ───────────────────────────────────────────────────────────── */
 
 export const MiniAppManager: React.FC<MiniAppManagerProps> = ({
@@ -205,16 +234,21 @@ export const MiniAppManager: React.FC<MiniAppManagerProps> = ({
   );
 
   /* ── Reorder is only meaningful for personal rows ───────────────────── */
-  const reorderHook = useSortableReorder<UnifiedRow>({
-    items: personalRows,
-    getId: getRowId,
-    onCommit: async (nextOrderedIds) => {
+  const onReorderCommit = useCallback(
+    async (nextOrderedIds: string[]) => {
       // Strip the "personal:" prefix before handing to the parent.
       const ids = nextOrderedIds
         .filter((id) => id.startsWith('personal:'))
         .map((id) => id.slice('personal:'.length));
       await onReorder(ids);
     },
+    [onReorder]
+  );
+
+  const reorderHook = useSortableReorder<UnifiedRow>({
+    items: personalRows,
+    getId: getRowId,
+    onCommit: onReorderCommit,
   });
 
   /* ── useLibraryView manages toolbar state + filtered list ────────────── */
@@ -225,22 +259,11 @@ export const MiniAppManager: React.FC<MiniAppManagerProps> = ({
 
   const view = useLibraryView<UnifiedRow>({
     items: allRows,
-    initialSort: { key: 'manual', dir: 'asc' },
-    initialFilterValues: { source: 'personal' },
-    searchFields: (row) => row.item.title,
-    sortComparators: {
-      // Manual = keep input order (personal first in its stored order, then
-      // global). useLibraryView preserves the input order when the comparator
-      // returns 0.
-      manual: () => 0,
-      title: (a, b, dir) => compareStrings(getRowTitle(a), getRowTitle(b), dir),
-      createdAt: (a, b, dir) =>
-        compareNumbers(getRowCreatedAt(a), getRowCreatedAt(b), dir),
-      size: (a, b, dir) => compareNumbers(getRowSize(a), getRowSize(b), dir),
-    },
-    filterPredicates: {
-      source: (row, value) => row.kind === value,
-    },
+    initialSort: LIBRARY_INITIAL_SORT,
+    initialFilterValues: LIBRARY_INITIAL_FILTER_VALUES,
+    searchFields: LIBRARY_SEARCH_FIELDS,
+    sortComparators: LIBRARY_SORT_COMPARATORS,
+    filterPredicates: LIBRARY_FILTER_PREDICATES,
   });
 
   const source: MiniAppSource =

--- a/components/widgets/QuizWidget/components/QuizManager.tsx
+++ b/components/widgets/QuizWidget/components/QuizManager.tsx
@@ -193,6 +193,21 @@ const SORT_OPTIONS: LibrarySortOption[] = [
   { key: 'questions', label: 'Question count', defaultDir: 'desc' },
 ];
 
+/* Module-level constants passed to useLibraryView / useSortableReorder —
+ * keeping these stable across renders prevents `visibleItems` from being
+ * re-derived every render (which would drive `useSortableReorder` into a
+ * setState-during-render loop). */
+
+const LIBRARY_SEARCH_FIELDS = (q: QuizMetadata): string => q.title;
+
+const LIBRARY_INITIAL_SORT = { key: 'updated', dir: 'desc' as const };
+
+const QUIZ_GET_ID = (q: QuizMetadata): string => q.id;
+
+const REORDER_NOOP = (): void => {
+  /* reorder persistence not implemented for Quiz */
+};
+
 const SORT_COMPARATORS: Record<
   string,
   (a: QuizMetadata, b: QuizMetadata, dir: 'asc' | 'desc') => number
@@ -276,8 +291,8 @@ export const QuizManager: React.FC<QuizManagerProps> = ({
   // ─── Library tab toolbar state ────────────────────────────────────────────
   const libraryView = useLibraryView<QuizMetadata>({
     items: quizzes,
-    initialSort: { key: 'updated', dir: 'desc' },
-    searchFields: (q) => q.title,
+    initialSort: LIBRARY_INITIAL_SORT,
+    searchFields: LIBRARY_SEARCH_FIELDS,
     sortComparators: SORT_COMPARATORS,
   });
 
@@ -286,10 +301,8 @@ export const QuizManager: React.FC<QuizManagerProps> = ({
   // mirrors items + commits nothing, preserving the primitive API.
   const reorder = useSortableReorder<QuizMetadata>({
     items: libraryView.visibleItems,
-    getId: (q) => q.id,
-    onCommit: () => {
-      /* reorder persistence not implemented for Quiz */
-    },
+    getId: QUIZ_GET_ID,
+    onCommit: REORDER_NOOP,
   });
 
   // ─── Derived counts for tab badges ────────────────────────────────────────

--- a/components/widgets/VideoActivityWidget/components/VideoActivityManager.tsx
+++ b/components/widgets/VideoActivityWidget/components/VideoActivityManager.tsx
@@ -17,7 +17,7 @@
  *     specific toggles flow through that slot, not by forking the primitive.
  */
 
-import React, { useMemo, useState } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import {
   Activity,
   AlertCircle,
@@ -102,6 +102,57 @@ export interface VideoActivityManagerProps {
   onSessionResults?: (session: VideoActivitySession) => void;
 }
 
+/* ─── Library hook option constants (module-level for referential stability) ─
+
+ * Passing these as inline literals inside the component causes `useLibraryView`
+ * to re-derive `visibleItems` on every render, which in turn triggers a
+ * re-render loop through `useSortableReorder`. Keeping them at module scope
+ * makes the references stable. */
+
+const LIBRARY_SEARCH_FIELDS = (a: VideoActivityMetadata): string[] => [
+  a.title,
+  a.youtubeUrl,
+];
+
+const LIBRARY_SORT_COMPARATORS = {
+  manual: (a: VideoActivityMetadata, b: VideoActivityMetadata) =>
+    (a.order ?? 0) - (b.order ?? 0),
+  updated: (
+    a: VideoActivityMetadata,
+    b: VideoActivityMetadata,
+    dir: 'asc' | 'desc'
+  ) => {
+    const av = a.updatedAt || a.createdAt;
+    const bv = b.updatedAt || b.createdAt;
+    return dir === 'asc' ? av - bv : bv - av;
+  },
+  created: (
+    a: VideoActivityMetadata,
+    b: VideoActivityMetadata,
+    dir: 'asc' | 'desc'
+  ) => (dir === 'asc' ? a.createdAt - b.createdAt : b.createdAt - a.createdAt),
+  title: (
+    a: VideoActivityMetadata,
+    b: VideoActivityMetadata,
+    dir: 'asc' | 'desc'
+  ) => {
+    const cmp = a.title.localeCompare(b.title);
+    return dir === 'asc' ? cmp : -cmp;
+  },
+  questionCount: (
+    a: VideoActivityMetadata,
+    b: VideoActivityMetadata,
+    dir: 'asc' | 'desc'
+  ) => {
+    const cmp = a.questionCount - b.questionCount;
+    return dir === 'asc' ? cmp : -cmp;
+  },
+};
+
+const LIBRARY_INITIAL_SORT = { key: 'updated', dir: 'desc' as LibrarySortDir };
+
+const ACTIVITY_GET_ID = (a: VideoActivityMetadata): string => a.id;
+
 /* ─── Assignment status → badge mapping ───────────────────────────────────── */
 
 function statusToBadge(
@@ -176,39 +227,24 @@ export const VideoActivityManager: React.FC<VideoActivityManagerProps> = ({
 
   const libraryView = useLibraryView<VideoActivityMetadata>({
     items: activities,
-    initialSort: { key: 'updated', dir: 'desc' },
-    searchFields: (a) => [a.title, a.youtubeUrl],
-    sortComparators: {
-      manual: (a, b) => (a.order ?? 0) - (b.order ?? 0),
-      updated: (a, b, dir) => {
-        const av = a.updatedAt || a.createdAt;
-        const bv = b.updatedAt || b.createdAt;
-        return dir === 'asc' ? av - bv : bv - av;
-      },
-      created: (a, b, dir) => {
-        return dir === 'asc'
-          ? a.createdAt - b.createdAt
-          : b.createdAt - a.createdAt;
-      },
-      title: (a, b, dir) => {
-        const cmp = a.title.localeCompare(b.title);
-        return dir === 'asc' ? cmp : -cmp;
-      },
-      questionCount: (a, b, dir) => {
-        const cmp = a.questionCount - b.questionCount;
-        return dir === 'asc' ? cmp : -cmp;
-      },
-    },
+    initialSort: LIBRARY_INITIAL_SORT,
+    searchFields: LIBRARY_SEARCH_FIELDS,
+    sortComparators: LIBRARY_SORT_COMPARATORS,
   });
 
-  const reorder = useSortableReorder<VideoActivityMetadata>({
-    items: libraryView.visibleItems,
-    getId: (a) => a.id,
-    onCommit: async (orderedIds) => {
+  const onReorderCommit = useCallback(
+    async (orderedIds: string[]) => {
       if (onReorderActivities) {
         await Promise.resolve(onReorderActivities(orderedIds));
       }
     },
+    [onReorderActivities]
+  );
+
+  const reorder = useSortableReorder<VideoActivityMetadata>({
+    items: libraryView.visibleItems,
+    getId: ACTIVITY_GET_ID,
+    onCommit: onReorderCommit,
   });
 
   /* ─── Assignment splits ───────────────────────────────────────────────── */

--- a/tests/hooks/useSortableReorder.test.ts
+++ b/tests/hooks/useSortableReorder.test.ts
@@ -153,4 +153,26 @@ describe('useSortableReorder', () => {
       'AAA'
     );
   });
+
+  it('does not loop when the caller passes a fresh array reference on every render', () => {
+    // Regression: when a caller's parent re-renders and computes items via
+    // useMemo with an unstable dep (e.g. an inline searchFields callback),
+    // `items` arrives as a new array reference each render with identical
+    // ids and order. A previous implementation re-seeded state in that case,
+    // causing an infinite render loop (React error #301).
+    const onCommit = vi.fn();
+
+    const { rerender, result } = renderHook(
+      ({ items }) => useSortableReorder({ items, getId, onCommit }),
+      { initialProps: { items: makeItems(['a', 'b', 'c']) } }
+    );
+
+    // Simulate many parent renders, each passing a fresh array wrapper with
+    // the same logical contents. If this loops, renderHook throws.
+    for (let i = 0; i < 5; i++) {
+      rerender({ items: makeItems(['a', 'b', 'c']) });
+    }
+
+    expect(result.current.orderedItems.map(getId)).toEqual(['a', 'b', 'c']);
+  });
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,7 +8,12 @@ export default mergeConfig(
       globals: true,
       environment: 'jsdom',
       setupFiles: './tests/setup.ts',
-      exclude: [...configDefaults.exclude, 'tests/e2e/**', 'functions/**'],
+      exclude: [
+        ...configDefaults.exclude,
+        'tests/e2e/**',
+        'functions/**',
+        '.claude/worktrees/**',
+      ],
       coverage: { exclude: ['locales/**'] },
     },
   })


### PR DESCRIPTION
## Summary

Opening a board that contains the Quiz widget was crashing the page with **React error #301** (too many re-renders). The same root cause silently rendered the Guided Learning library invisible, and was latent in the Video Activity and MiniApp libraries as well.

## Root cause

In [useSortableReorder.ts](components/common/library/useSortableReorder.ts) the render-time \"adjust state while rendering\" block re-seeded \`orderedItems\` with the incoming \`items\` array whenever its reference changed — even when the id set and order were unchanged. When a caller passed an unstable array reference on every render (e.g. \`useLibraryView\`'s \`useMemo\` recomputed \`visibleItems\` because \`searchFields\` was an inline function literal), \`setState\` fired on every render, which re-rendered with a new items ref, which set state again → infinite loop.

The four Wave-2 Managers all passed inline \`searchFields\` / \`sortComparators\` / \`onCommit\` to \`useLibraryView\` and \`useSortableReorder\`, making the latent bug fire on every Quiz widget mount and render-cycle the GL library invisible.

## Fix (two parts)

**1. \`useSortableReorder\` (defense-in-depth):** drop the \"absorb fresh object refs when ids + order match\" branch. When both match, \`orderedItems\` is already correct — don't re-seed. Added a regression test that rerenders with fresh array wrappers 5× and asserts no crash.

**2. Library managers:** hoist \`searchFields\`, \`sortComparators\`, \`filterPredicates\`, \`getId\`, and reorder-noop to module-level constants; wrap stateful \`onCommit\` callbacks in \`useCallback\`. \`useLibraryView\`'s \`useMemo\` now only recomputes \`visibleItems\` when search/sort/filter actually change, so \`useSortableReorder\` receives a stable \`items\` reference across renders.

## Bonus cleanup

- **vitest config**: excluded \`.claude/worktrees/**\` so stale agent worktrees (each with their own \`node_modules\`) don't cause duplicate-React \"Invalid hook call\" failures during local test runs.

## Verification

- \`pnpm run type-check\` — clean
- \`pnpm exec eslint\` on all 6 changed source files + vitest.config — clean
- \`pnpm exec prettier --check\` on changed files — clean
- \`pnpm exec vitest run tests/hooks/useSortableReorder.test.ts tests/hooks/useLibraryView.test.ts tests/components/common/LibraryGrid.test.tsx\` — 21/21 passing, including the new regression test

## Test plan

- [ ] Load a dashboard containing a Quiz widget — no crash, Library tab renders
- [ ] Guided Learning widget is visible with content (not invisible)
- [ ] Video Activity and MiniApp libraries still render correctly and drag-reorder still works on personal sets
- [ ] Search / sort / filter controls still narrow the list as expected
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)