### PR TITLE
feat(library): folder schema + stubs (Wave 3-A)

### DIFF
--- a/components/common/library/FolderSidebar.tsx
+++ b/components/common/library/FolderSidebar.tsx
@@ -1,0 +1,55 @@
+/**
+ * FolderSidebar — left-rail folder navigation for library-style widgets.
+ *
+ * **STUB ONLY (Wave 3-A).** This component accepts the final prop shape
+ * but renders nothing. Wave 3-B ships the real tree + selection UI on
+ * top of this contract. The prop surface is defined here so Wave 3-A's
+ * type shape + PR review can lock the API before UI work lands.
+ *
+ * Intended slot: `LibraryShellProps.filterSidebarSlot` (already reserved
+ * by the Wave 1 primitives for exactly this use case).
+ */
+
+import React from 'react';
+import type { LibraryFolder, LibraryFolderWidget } from '@/types';
+
+export interface FolderSidebarProps {
+  /** Which widget's folder tree to render. */
+  widget: LibraryFolderWidget;
+  /** Flat list of folders — the component builds the tree client-side. */
+  folders: LibraryFolder[];
+  /**
+   * Currently-selected folder id. `null` = root ("All items"). Used by
+   * the library view to filter items by `folderId`.
+   */
+  selectedFolderId: string | null;
+  onSelectFolder: (folderId: string | null) => void;
+
+  /** Count of items at each folder id (for "(N)" badges). Null key = root. */
+  itemCounts?: Record<string, number>;
+
+  /** Create/Rename/Move/Delete handlers — delegated to `useFolders`. */
+  onCreateFolder?: (name: string, parentId: string | null) => Promise<string>;
+  onRenameFolder?: (folderId: string, nextName: string) => Promise<void>;
+  onDeleteFolder?: (folderId: string) => Promise<void>;
+  onMoveFolder?: (
+    folderId: string,
+    nextParentId: string | null
+  ) => Promise<void>;
+
+  /** Optional initial loading state (e.g. while the snapshot is in-flight). */
+  loading?: boolean;
+  /** Optional error string to surface inline. */
+  error?: string | null;
+}
+
+/**
+ * Placeholder render. Intentionally returns null so the sidebar slot
+ * collapses to zero width before Wave 3-B fills it in.
+ */
+export const FolderSidebar: React.FC<FolderSidebarProps> = () => {
+  /* TODO: Wave 3-B — render folder tree, selection, and CRUD affordances. */
+  return null;
+};
+
+export default FolderSidebar;

--- a/components/common/library/FolderTree.tsx
+++ b/components/common/library/FolderTree.tsx
@@ -1,0 +1,52 @@
+/**
+ * FolderTree — recursive folder tree renderer used inside `FolderSidebar`.
+ *
+ * **STUB ONLY (Wave 3-A).** This component defines the tree-level props
+ * that the Wave 3-B implementation will consume. It renders nothing for
+ * now so the module can be imported without visual side effects.
+ *
+ * Kept separate from `FolderSidebar` so Wave 3-B can unit-test the
+ * recursive rendering + expand/collapse behavior in isolation.
+ */
+
+import React from 'react';
+import type { LibraryFolder } from '@/types';
+
+export interface FolderTreeProps {
+  /** Flat folder list — the tree shape is derived from `parentId`. */
+  folders: LibraryFolder[];
+  /** Which subtree to render. `null` = start from root-level folders. */
+  parentId?: string | null;
+  /** Current depth — used for indentation. Defaults to 0 at the root. */
+  depth?: number;
+
+  /** Currently-selected folder id (`null` = root). */
+  selectedFolderId: string | null;
+  onSelectFolder: (folderId: string | null) => void;
+
+  /** Expand/collapse state, keyed by folder id. */
+  expanded?: Record<string, boolean>;
+  onToggleExpanded?: (folderId: string) => void;
+
+  /** Optional item count per folder id, rendered as a trailing badge. */
+  itemCounts?: Record<string, number>;
+
+  /** Rename + delete handlers — omit to render a read-only tree. */
+  onRenameFolder?: (folderId: string, nextName: string) => Promise<void>;
+  onDeleteFolder?: (folderId: string) => Promise<void>;
+  onMoveFolder?: (
+    folderId: string,
+    nextParentId: string | null
+  ) => Promise<void>;
+}
+
+/**
+ * Placeholder render. Wave 3-B will build the recursive tree + drag
+ * handles here.
+ */
+export const FolderTree: React.FC<FolderTreeProps> = () => {
+  /* TODO: Wave 3-B — render recursive folder rows with expand/collapse. */
+  return null;
+};
+
+export default FolderTree;

--- a/firestore.rules
+++ b/firestore.rules
@@ -580,6 +580,25 @@ service cloud.firestore {
       allow read, write: if request.auth != null && request.auth.uid == userId;
     }
 
+    // === Library folders (Wave 3) ===
+    // Per-teacher folder tree for each library-style widget (Quiz, Video
+    // Activity, Guided Learning, MiniApp). Folders never cross widgets —
+    // each widget has its own collection. Owner-only read/write, matching
+    // the *_assignments pattern above. Wave 3-A ships the rules + schema;
+    // Wave 3-B wires the UI.
+    match /users/{userId}/quiz_folders/{folderId} {
+      allow read, write: if request.auth != null && request.auth.uid == userId;
+    }
+    match /users/{userId}/video_activity_folders/{folderId} {
+      allow read, write: if request.auth != null && request.auth.uid == userId;
+    }
+    match /users/{userId}/guided_learning_folders/{folderId} {
+      allow read, write: if request.auth != null && request.auth.uid == userId;
+    }
+    match /users/{userId}/miniapp_folders/{folderId} {
+      allow read, write: if request.auth != null && request.auth.uid == userId;
+    }
+
     // Default deny all other collections
     match /{document=**} {
       allow read, write: if false;

--- a/hooks/useFolders.ts
+++ b/hooks/useFolders.ts
@@ -1,0 +1,130 @@
+/**
+ * useFolders — library folder management (Wave 3).
+ *
+ * **SHELL ONLY.** This file defines the hook signature and return-type
+ * contract that Wave 3-B will implement. All operations are currently
+ * no-ops so the module can compile and type-check across the codebase
+ * without shipping any behavior change. The real implementation
+ * (Firestore CRUD, real-time listener, optimistic tree state) lands in
+ * Wave 3-B on top of this shape.
+ *
+ * Schema recap (see `types.ts` "Library folders (Wave 3)" section):
+ *   /users/{userId}/{widget}_folders/{folderId}
+ *     => { id, name, parentId: string | null, order: number,
+ *          createdAt: number, updatedAt?: number }
+ *
+ * One folders collection per widget — folders never cross widgets. The
+ * `widget` argument selects which collection this hook binds to, and is
+ * mapped to the collection name via `folderCollectionName()` below.
+ */
+
+import { useMemo } from 'react';
+import type { LibraryFolder, LibraryFolderWidget } from '@/types';
+
+/**
+ * Map a `LibraryFolderWidget` to its Firestore subcollection name.
+ * Exported so Wave 3-B's internal writes + any admin tooling use a
+ * single source of truth.
+ */
+export const folderCollectionName = (widget: LibraryFolderWidget): string => {
+  switch (widget) {
+    case 'quiz':
+      return 'quiz_folders';
+    case 'video_activity':
+      return 'video_activity_folders';
+    case 'guided_learning':
+      return 'guided_learning_folders';
+    case 'miniapp':
+      return 'miniapp_folders';
+  }
+};
+
+export interface UseFoldersResult {
+  /** All folders for this (user, widget) pair. Empty while the shell is in place. */
+  folders: LibraryFolder[];
+  /** True while the initial Firestore snapshot is loading. */
+  loading: boolean;
+  /** Most recent error from a read/write, or null. */
+  error: string | null;
+  /**
+   * Create a new folder under `parentId` (null = root). Returns the
+   * folder id on success. Wave 3-B wires this to Firestore; the shell
+   * throws so callers don't silently think a write succeeded.
+   */
+  createFolder: (name: string, parentId: string | null) => Promise<string>;
+  /** Rename a folder by id. */
+  renameFolder: (folderId: string, nextName: string) => Promise<void>;
+  /**
+   * Move a folder to a new parent. Passing `null` moves it to the root.
+   * Implementations should guard against creating cycles (moving a
+   * folder into its own descendant).
+   */
+  moveFolder: (folderId: string, nextParentId: string | null) => Promise<void>;
+  /**
+   * Delete a folder by id. The exact policy for children / items inside
+   * the folder is a Wave 3-B decision (likely: reparent children to the
+   * deleted folder's parent, and null out items' `folderId`).
+   */
+  deleteFolder: (folderId: string) => Promise<void>;
+  /**
+   * Reorder sibling folders under the same parent. Pass the full
+   * ordered list of ids as they should appear after the move.
+   */
+  reorderSiblings: (
+    parentId: string | null,
+    orderedIds: string[]
+  ) => Promise<void>;
+}
+
+/**
+ * Shell implementation. Returns the full `UseFoldersResult` shape with
+ * empty state and rejecting write operations. Wave 3-B replaces the body.
+ */
+export const useFolders = (
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  userId: string | undefined,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  widget: LibraryFolderWidget
+): UseFoldersResult => {
+  // The returned object is memoized so consumers' `useEffect` dependencies
+  // on it (if any) don't thrash. Wave 3-B will replace this with a real
+  // listener-backed state machine.
+  return useMemo<UseFoldersResult>(
+    () => ({
+      folders: [],
+      loading: false,
+      error: null,
+      createFolder: () =>
+        Promise.reject(
+          new Error(
+            'useFolders.createFolder: not implemented (Wave 3-A shell). Lands in Wave 3-B.'
+          )
+        ),
+      renameFolder: () =>
+        Promise.reject(
+          new Error(
+            'useFolders.renameFolder: not implemented (Wave 3-A shell). Lands in Wave 3-B.'
+          )
+        ),
+      moveFolder: () =>
+        Promise.reject(
+          new Error(
+            'useFolders.moveFolder: not implemented (Wave 3-A shell). Lands in Wave 3-B.'
+          )
+        ),
+      deleteFolder: () =>
+        Promise.reject(
+          new Error(
+            'useFolders.deleteFolder: not implemented (Wave 3-A shell). Lands in Wave 3-B.'
+          )
+        ),
+      reorderSiblings: () =>
+        Promise.reject(
+          new Error(
+            'useFolders.reorderSiblings: not implemented (Wave 3-A shell). Lands in Wave 3-B.'
+          )
+        ),
+    }),
+    []
+  );
+};

--- a/tests/hooks/useFolders.test.ts
+++ b/tests/hooks/useFolders.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Shape test for the Wave 3-A `useFolders` shell.
+ *
+ * Wave 3-A ships the hook as a no-op shell with the full return-type
+ * contract Wave 3-B will implement. These tests pin the public shape so
+ * that later commits can't silently drop a field or change a signature
+ * without the tests catching it.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useFolders, folderCollectionName } from '../../hooks/useFolders';
+import type { LibraryFolderWidget } from '../../types';
+
+describe('useFolders (Wave 3-A shell)', () => {
+  const widgets: LibraryFolderWidget[] = [
+    'quiz',
+    'video_activity',
+    'guided_learning',
+    'miniapp',
+  ];
+
+  it.each(widgets)('returns the expected empty shape for %s', (widget) => {
+    const { result } = renderHook(() => useFolders('user-1', widget));
+
+    expect(result.current.folders).toEqual([]);
+    expect(result.current.loading).toBe(false);
+    expect(result.current.error).toBeNull();
+
+    expect(typeof result.current.createFolder).toBe('function');
+    expect(typeof result.current.renameFolder).toBe('function');
+    expect(typeof result.current.moveFolder).toBe('function');
+    expect(typeof result.current.deleteFolder).toBe('function');
+    expect(typeof result.current.reorderSiblings).toBe('function');
+  });
+
+  it('returns the same shape when userId is undefined', () => {
+    const { result } = renderHook(() => useFolders(undefined, 'quiz'));
+
+    expect(result.current.folders).toEqual([]);
+    expect(result.current.loading).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('write operations reject until Wave 3-B implements them', async () => {
+    const { result } = renderHook(() => useFolders('user-1', 'quiz'));
+
+    await expect(result.current.createFolder('New', null)).rejects.toThrow(
+      /Wave 3-B/
+    );
+    await expect(result.current.renameFolder('f1', 'X')).rejects.toThrow(
+      /Wave 3-B/
+    );
+    await expect(result.current.moveFolder('f1', null)).rejects.toThrow(
+      /Wave 3-B/
+    );
+    await expect(result.current.deleteFolder('f1')).rejects.toThrow(/Wave 3-B/);
+    await expect(result.current.reorderSiblings(null, [])).rejects.toThrow(
+      /Wave 3-B/
+    );
+  });
+});
+
+describe('folderCollectionName', () => {
+  it('maps each widget to its Firestore collection name', () => {
+    expect(folderCollectionName('quiz')).toBe('quiz_folders');
+    expect(folderCollectionName('video_activity')).toBe(
+      'video_activity_folders'
+    );
+    expect(folderCollectionName('guided_learning')).toBe(
+      'guided_learning_folders'
+    );
+    expect(folderCollectionName('miniapp')).toBe('miniapp_folders');
+  });
+});

--- a/types.ts
+++ b/types.ts
@@ -1160,6 +1160,11 @@ export interface MiniAppItem {
   html: string;
   createdAt: number;
   order?: number;
+  /**
+   * Optional folder assignment (Wave 3). `null` or missing = root.
+   * Refers to a folder id in `/users/{userId}/miniapp_folders/{folderId}`.
+   */
+  folderId?: string | null;
 }
 
 /**
@@ -1518,6 +1523,11 @@ export interface QuizMetadata {
   questionCount: number;
   createdAt: number;
   updatedAt: number;
+  /**
+   * Optional folder assignment (Wave 3). `null` or missing = root.
+   * Refers to a folder id in `/users/{userId}/quiz_folders/{folderId}`.
+   */
+  folderId?: string | null;
 }
 
 export type QuizSessionStatus = 'waiting' | 'active' | 'paused' | 'ended';
@@ -1817,6 +1827,11 @@ export interface VideoActivityMetadata {
   updatedAt: number;
   /** Optional manual ordering index for drag-reorder in the Library view. */
   order?: number;
+  /**
+   * Optional folder assignment (Wave 3). `null` or missing = root.
+   * Refers to a folder id in `/users/{userId}/video_activity_folders/{folderId}`.
+   */
+  folderId?: string | null;
 }
 
 export type VideoActivityView = 'manager' | 'create' | 'results';
@@ -2424,6 +2439,11 @@ export interface GuidedLearningSetMetadata {
    * flow. Omitted for sets that have never been manually reordered.
    */
   order?: number;
+  /**
+   * Optional folder assignment (Wave 3). `null` or missing = root.
+   * Refers to a folder id in `/users/{userId}/guided_learning_folders/{folderId}`.
+   */
+  folderId?: string | null;
 }
 
 /**
@@ -3580,4 +3600,59 @@ export interface GuidedLearningAssignment {
   archivedAt?: number | null;
   /** Optional origin set: 'personal' (Drive) or 'building' (Firestore). */
   source?: 'personal' | 'building';
+}
+
+// === Library folders (Wave 3) ===
+//
+// Folder organization for the four library-style widgets (Quiz, Video
+// Activity, Guided Learning, MiniApp). Each widget has its OWN folders
+// collection — folders are never shared across widgets.
+//
+// Storage shape: a flat per-widget collection at
+//   /users/{userId}/{widget}_folders/{folderId}
+// where `{widget}` is one of `quiz`, `video_activity`, `guided_learning`,
+// `miniapp`. Nested folders are modeled via `parentId` (string id of
+// the parent, or `null` for root) rather than nested subcollection paths.
+//
+// Why flat-collection-with-`parentId` instead of nested paths:
+//   - Firestore cannot query across subcollection segments. A flat
+//     collection lets us list all folders for a widget in one snapshot
+//     and build the tree client-side, and lets us reorder / move between
+//     folders with a single-field update.
+//   - Library items (quizzes, activities, sets, miniapps) stay in their
+//     existing metadata collections; each item gains an optional
+//     `folderId` pointer. `null` / missing means root.
+//
+// Implementation lands in Wave 3-B. This schema PR only introduces the
+// types, the Firestore security rules, and empty stubs for the consumer
+// hook + UI components.
+
+/** Which library the folders belong to. Folders never cross widgets. */
+export type LibraryFolderWidget =
+  | 'quiz'
+  | 'video_activity'
+  | 'guided_learning'
+  | 'miniapp';
+
+/**
+ * A folder record stored at
+ * `/users/{userId}/{widget}_folders/{folderId}`.
+ *
+ * Siblings within a given `parentId` are ordered by the `order` field
+ * (ascending); ties break by `createdAt`. `parentId: null` = root-level
+ * folder. Folder-name uniqueness is NOT enforced by the schema — the UI
+ * layer may append " (2)" on collision, but two sibling folders are
+ * allowed to share a name if the user really wants that.
+ */
+export interface LibraryFolder {
+  id: string;
+  name: string;
+  /** Parent folder id, or `null` for root-level folders. */
+  parentId: string | null;
+  /** Sort order among siblings (ascending). */
+  order: number;
+  /** Epoch ms at create. */
+  createdAt: number;
+  /** Epoch ms at last rename / move / reorder. Optional on legacy records. */
+  updatedAt?: number;
 }


### PR DESCRIPTION
## Summary

**Schema-only PR** — no UI behavior yet. Wave 3-B builds the folder UI on top of these types and stubs.

This is the gated Phase-4 schema-review PR from the unified library plan. Reviewing the shape of the data model + Firestore rules in isolation (before any UI work) lets us catch schema issues cheaply.

## Design rationale

- **One folders collection per widget**: \`/users/{userId}/{widget}_folders/{folderId}\` with \`{ id, name, parentId, order, createdAt, updatedAt? }\`
- **Flat-collection-with-\`parentId\`** — not nested paths. Nested paths break Firestore queries and ordering; flat-collection supports efficient sibling listing and single-field drag-between-folders.
- **Four disjoint folder collections** (quiz / video_activity / guided_learning / miniapp) — no cross-widget folders. Heterogeneous item types make rendering/sorting messy for minimal teacher-value gain.
- **Item-side pointer**: each library-item metadata type gains an optional \`folderId?: string | null\`. \`null\` / missing means root. All existing consumers unaffected because it's optional.

## Files

**Modified:**
- [types.ts](types.ts) — appended \`LibraryFolderWidget\` + \`LibraryFolder\` types in a clearly-delimited \`=== Library folders (Wave 3) ===\` section; added \`folderId?: string | null\` to \`QuizMetadata\`, \`VideoActivityMetadata\`, \`GuidedLearningSetMetadata\`, \`MiniAppItem\`.
- [firestore.rules](firestore.rules) — four new \`match /users/{userId}/{widget}_folders/{folderId}\` blocks with \`allow read, write: if request.auth.uid == userId;\` (matches existing \`*_assignments\` rule pattern).

**Created:**
- [hooks/useFolders.ts](hooks/useFolders.ts) — hook shell. The full \`UseFoldersResult\` interface is exported so Wave 3-B can drop in the real implementation without changing the contract. Currently returns empty arrays + no-op functions.
- [components/common/library/FolderSidebar.tsx](components/common/library/FolderSidebar.tsx) — props contract stub.
- [components/common/library/FolderTree.tsx](components/common/library/FolderTree.tsx) — props contract stub.
- [tests/hooks/useFolders.test.ts](tests/hooks/useFolders.test.ts) — 7 shape tests confirming the hook returns expected defaults and every function is callable.

## Verification

- \`pnpm run type-check\` — clean
- \`pnpm exec eslint\` — clean on all changed files at \`--max-warnings 0\`
- \`pnpm exec prettier --check\` — clean
- \`pnpm exec vitest run tests/hooks/useFolders.test.ts\` — 7/7 passing

## Test plan for reviewers

- [ ] Schema shape matches expectations (LibraryFolder fields, widget enum)
- [ ] Firestore rules are owner-scoped and mirror the \`*_assignments\` pattern
- [ ] \`folderId\` on item metadata types is optional (non-breaking)
- [ ] \`UseFoldersResult\` interface is a reasonable API surface for Wave 3-B to implement against

🤖 Generated with [Claude Code](https://claude.com/claude-code)