### PR TITLE
fix(library): transparency, scaling, modal z-index, inline actions, HTML import

### DIFF
--- a/components/common/DraggableWindow.test.tsx
+++ b/components/common/DraggableWindow.test.tsx
@@ -24,6 +24,11 @@ import {
   DashboardContext,
   DashboardContextValue,
 } from '@/context/DashboardContextValue';
+import {
+  incrementOpenModalCount,
+  decrementOpenModalCount,
+  getOpenModalCount,
+} from './modalStore';
 
 // Mock dependencies
 const { mockTakeScreenshot } = vi.hoisted(() => ({
@@ -509,6 +514,43 @@ describe('DraggableWindow', () => {
         screen.queryByDisplayValue('New Saved Title')
       ).not.toBeInTheDocument();
     });
+  });
+
+  it('suppresses the floating toolbar while any Modal is open and restores it on close', async () => {
+    // Sanity check: the global modal counter starts at 0 across tests.
+    expect(getOpenModalCount()).toBe(0);
+
+    renderComponent({}, <div>Content</div>, <div>Settings</div>, 'test-widget');
+
+    // With the widget selected and no modal open, the toolbar should render
+    // its action buttons (Settings / Minimize live only inside the toolbar).
+    expect(screen.getByTitle('Settings (Alt+S)')).toBeInTheDocument();
+    expect(screen.getByTitle('Minimize (Esc)')).toBeInTheDocument();
+
+    // Simulate a portalled <Modal> mount by incrementing the shared counter.
+    // DraggableWindow subscribes via useHasOpenModal / useSyncExternalStore
+    // and should re-render with the toolbar hidden.
+    act(() => {
+      incrementOpenModalCount();
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByTitle('Settings (Alt+S)')).not.toBeInTheDocument();
+      expect(screen.queryByTitle('Minimize (Esc)')).not.toBeInTheDocument();
+    });
+
+    // Simulate modal unmount — toolbar should come back.
+    act(() => {
+      decrementOpenModalCount();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTitle('Settings (Alt+S)')).toBeInTheDocument();
+      expect(screen.getByTitle('Minimize (Esc)')).toBeInTheDocument();
+    });
+
+    // Leave the counter the way we found it.
+    expect(getOpenModalCount()).toBe(0);
   });
 
   it('renders restore FAB when maximized and handles click', () => {

--- a/components/common/DraggableWindow.tsx
+++ b/components/common/DraggableWindow.tsx
@@ -45,6 +45,7 @@ import { useDashboard } from '@/context/useDashboard';
 import { GlassCard } from './GlassCard';
 import { SettingsPanel } from './SettingsPanel';
 import { useClickOutside } from '@/hooks/useClickOutside';
+import { useHasOpenModal } from './modalStore';
 import { AnnotationCanvas } from './AnnotationCanvas';
 import { IconButton } from '@/components/common/IconButton';
 import { STANDARD_COLORS, WIDGET_PALETTE } from '@/config/colors';
@@ -170,7 +171,13 @@ export const DraggableWindow: React.FC<DraggableWindowProps> = ({
   const [isDragging, setIsDragging] = useState(false);
   const [isResizing, setIsResizing] = useState(false);
   const [showConfirm, setShowConfirm] = useState(false);
-  const showTools = selectedWidgetId === widget.id;
+  // Suppress the floating toolbar while any portalled Modal is open. The
+  // toolbar normally sits at Z_INDEX.toolMenu (above modals) so it remains
+  // reachable during regular use, but when the user has opened an editor,
+  // import, or assignment modal from within the widget, the toolbar floating
+  // on top of that modal is disorienting and blocks clicks.
+  const hasOpenModal = useHasOpenModal();
+  const showTools = selectedWidgetId === widget.id && !hasOpenModal;
 
   // Group visual state
   const isInGroup = !!widget.groupId;

--- a/components/common/Modal.tsx
+++ b/components/common/Modal.tsx
@@ -1,6 +1,11 @@
 import React, { useEffect } from 'react';
 import { createPortal } from 'react-dom';
 import { X } from 'lucide-react';
+import {
+  decrementOpenModalCount,
+  getOpenModalCount,
+  incrementOpenModalCount,
+} from './modalStore';
 
 interface ModalProps {
   variant?: 'default' | 'bare';
@@ -19,9 +24,6 @@ interface ModalProps {
   ariaLabel?: string;
   ariaLabelledby?: string;
 }
-
-// Track number of open modals to handle nested locking correctly
-let openModalCount = 0;
 
 export const Modal: React.FC<ModalProps> = ({
   isOpen,
@@ -50,10 +52,10 @@ export const Modal: React.FC<ModalProps> = ({
       }
     };
 
-    if (openModalCount === 0) {
+    if (getOpenModalCount() === 0) {
       document.body.style.overflow = 'hidden';
     }
-    openModalCount++;
+    incrementOpenModalCount();
     window.addEventListener(
       'keydown',
       handleEscape,
@@ -61,8 +63,8 @@ export const Modal: React.FC<ModalProps> = ({
     );
 
     return () => {
-      openModalCount--;
-      if (openModalCount === 0) {
+      const remaining = decrementOpenModalCount();
+      if (remaining === 0) {
         document.body.style.overflow = 'unset';
       }
       window.removeEventListener(

--- a/components/common/library/LibraryItemCard.tsx
+++ b/components/common/library/LibraryItemCard.tsx
@@ -231,11 +231,17 @@ function CardBody<TMeta>(props: CardBodyProps<TMeta>) {
   const PrimaryIcon = primaryAction.icon;
   const isList = viewMode === 'list';
 
-  // Track card width so we can inline secondary actions when there's room and
-  // collapse to a 3-dot overflow menu only when the card is narrow.
+  // Inline-vs-overflow layout only applies to list-view cards with secondary
+  // actions. Grid-view cards always use the overflow menu, so we skip the
+  // ResizeObserver entirely there (avoids per-card observer overhead in large
+  // libraries).
+  const secondaryCount = secondaryActions?.length ?? 0;
+  const shouldMeasureSecondaryActions = isList && secondaryCount > 0;
+
   const cardRef = useRef<HTMLDivElement>(null);
   const [cardWidth, setCardWidth] = useState<number | null>(null);
   useEffect(() => {
+    if (!shouldMeasureSecondaryActions) return undefined;
     const el = cardRef.current;
     if (!el || typeof ResizeObserver === 'undefined') return undefined;
     const observer = new ResizeObserver((entries) => {
@@ -244,17 +250,22 @@ function CardBody<TMeta>(props: CardBodyProps<TMeta>) {
     });
     observer.observe(el);
     return () => observer.disconnect();
-  }, []);
+  }, [shouldMeasureSecondaryActions]);
+
+  // When we've flipped out of the measuring mode (e.g. view mode changed from
+  // list to grid, or secondary actions got removed), ignore the stale
+  // measurement so grid cards reliably fall back to the overflow menu.
+  const effectiveCardWidth = shouldMeasureSecondaryActions ? cardWidth : null;
 
   // Rough space budget per inline secondary: ~92px with label, ~40px icon-only.
   // Primary (ASSIGN) plus padding eats ~140px. Inline labels when we have
   // headroom; otherwise try icon-only; otherwise fall back to overflow menu.
-  const secondaryCount = secondaryActions?.length ?? 0;
   const widthForLabels = 160 + secondaryCount * 96;
   const widthForIconOnly = 160 + secondaryCount * 44;
   const canShowInlineLabels =
-    cardWidth != null && cardWidth >= widthForLabels && isList;
-  const canShowInlineIcons = cardWidth != null && cardWidth >= widthForIconOnly;
+    effectiveCardWidth != null && effectiveCardWidth >= widthForLabels;
+  const canShowInlineIcons =
+    effectiveCardWidth != null && effectiveCardWidth >= widthForIconOnly;
   const useOverflowMenu = !canShowInlineLabels && !canShowInlineIcons;
 
   const handleBodyClick = (e: React.MouseEvent<HTMLDivElement>) => {

--- a/components/common/library/LibraryItemCard.tsx
+++ b/components/common/library/LibraryItemCard.tsx
@@ -16,7 +16,7 @@
  * hint as the drag-handle tooltip at reduced opacity.
  */
 
-import React, { useContext, useRef, useState } from 'react';
+import React, { useContext, useEffect, useRef, useState } from 'react';
 import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 import { GripVertical, MoreHorizontal } from 'lucide-react';
@@ -55,6 +55,57 @@ const BADGE_TONE_STYLES: Record<
   },
 };
 
+/* ─── Inline action buttons ──────────────────────────────────────────────── */
+
+interface InlineActionButtonProps {
+  action: LibraryMenuAction;
+  compact?: boolean;
+}
+
+const InlineActionButton: React.FC<InlineActionButtonProps> = ({
+  action,
+  compact = false,
+}) => {
+  const Icon = action.icon;
+  const destructive = action.destructive;
+  const base =
+    'inline-flex shrink-0 items-center justify-center gap-1.5 rounded-xl border font-bold uppercase tracking-wider transition-all active:scale-95 disabled:cursor-not-allowed disabled:opacity-50';
+  const tone = destructive
+    ? 'border-brand-red-primary/20 bg-white/80 text-brand-red-dark hover:bg-brand-red-lighter/30 hover:border-brand-red-primary/40'
+    : 'border-slate-200 bg-white/80 text-slate-700 hover:bg-white hover:border-slate-300';
+  return (
+    <button
+      type="button"
+      onClick={(e) => {
+        e.stopPropagation();
+        if (!action.disabled) action.onClick();
+      }}
+      disabled={action.disabled}
+      title={action.disabled ? action.disabledReason : action.label}
+      aria-label={action.label}
+      className={`${base} ${tone}`}
+      style={{
+        paddingInline: compact ? '0' : 'min(12px, 2.8cqmin)',
+        paddingBlock: 'min(6px, 1.6cqmin)',
+        fontSize: 'min(11px, 3.6cqmin)',
+        minWidth: compact ? 'min(32px, 9cqmin)' : undefined,
+        height: compact ? 'min(32px, 9cqmin)' : undefined,
+      }}
+    >
+      {Icon && (
+        <Icon
+          style={{
+            width: 'min(14px, 4cqmin)',
+            height: 'min(14px, 4cqmin)',
+          }}
+          className="shrink-0"
+        />
+      )}
+      {!compact && <span className="truncate">{action.label}</span>}
+    </button>
+  );
+};
+
 /* ─── Overflow menu (click-outside aware) ─────────────────────────────────── */
 
 interface OverflowMenuProps {
@@ -83,13 +134,22 @@ const OverflowMenu: React.FC<OverflowMenuProps> = ({ actions }) => {
           e.stopPropagation();
           setOpen((v) => !v);
         }}
-        className="flex h-8 w-8 items-center justify-center rounded-lg text-slate-500 transition-colors hover:bg-slate-100 hover:text-slate-700"
+        className="inline-flex shrink-0 items-center justify-center rounded-lg text-slate-500 transition-colors hover:bg-slate-100 hover:text-slate-700"
+        style={{
+          width: 'min(32px, 9cqmin)',
+          height: 'min(32px, 9cqmin)',
+        }}
         title="More actions"
         aria-label="More actions"
         aria-haspopup="menu"
         aria-expanded={open}
       >
-        <MoreHorizontal className="h-4 w-4" />
+        <MoreHorizontal
+          style={{
+            width: 'min(16px, 4.5cqmin)',
+            height: 'min(16px, 4.5cqmin)',
+          }}
+        />
       </button>
       {open && (
         <div
@@ -171,6 +231,32 @@ function CardBody<TMeta>(props: CardBodyProps<TMeta>) {
   const PrimaryIcon = primaryAction.icon;
   const isList = viewMode === 'list';
 
+  // Track card width so we can inline secondary actions when there's room and
+  // collapse to a 3-dot overflow menu only when the card is narrow.
+  const cardRef = useRef<HTMLDivElement>(null);
+  const [cardWidth, setCardWidth] = useState<number | null>(null);
+  useEffect(() => {
+    const el = cardRef.current;
+    if (!el || typeof ResizeObserver === 'undefined') return undefined;
+    const observer = new ResizeObserver((entries) => {
+      const entry = entries[0];
+      if (entry) setCardWidth(entry.contentRect.width);
+    });
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, []);
+
+  // Rough space budget per inline secondary: ~92px with label, ~40px icon-only.
+  // Primary (ASSIGN) plus padding eats ~140px. Inline labels when we have
+  // headroom; otherwise try icon-only; otherwise fall back to overflow menu.
+  const secondaryCount = secondaryActions?.length ?? 0;
+  const widthForLabels = 160 + secondaryCount * 96;
+  const widthForIconOnly = 160 + secondaryCount * 44;
+  const canShowInlineLabels =
+    cardWidth != null && cardWidth >= widthForLabels && isList;
+  const canShowInlineIcons = cardWidth != null && cardWidth >= widthForIconOnly;
+  const useOverflowMenu = !canShowInlineLabels && !canShowInlineIcons;
+
   const handleBodyClick = (e: React.MouseEvent<HTMLDivElement>) => {
     // Ignore bubbled events from buttons / links / menus inside the card.
     if ((e.target as HTMLElement).closest('button, a, [role="menu"]')) return;
@@ -179,10 +265,11 @@ function CardBody<TMeta>(props: CardBodyProps<TMeta>) {
 
   return (
     <div
+      ref={cardRef}
       onClick={onClick ? handleBodyClick : undefined}
       className={[
-        'group relative flex rounded-2xl border border-slate-200 bg-white text-slate-700 shadow-sm transition-shadow hover:shadow-md',
-        isList ? 'flex-row items-center gap-3 p-3' : 'flex-col gap-3 p-4',
+        'group relative flex rounded-2xl border border-slate-200/80 bg-white/70 backdrop-blur-sm text-slate-700 shadow-sm transition-shadow hover:shadow-md hover:bg-white/85',
+        isList ? 'flex-row items-center' : 'flex-col',
         onClick && 'cursor-pointer',
         isDragging && 'opacity-50',
         isDragOverlay &&
@@ -190,6 +277,10 @@ function CardBody<TMeta>(props: CardBodyProps<TMeta>) {
       ]
         .filter(Boolean)
         .join(' ')}
+      style={{
+        gap: isList ? 'min(12px, 3cqmin)' : 'min(12px, 3cqmin)',
+        padding: isList ? 'min(12px, 2.8cqmin)' : 'min(16px, 3.5cqmin)',
+      }}
       aria-hidden={isDragOverlay}
     >
       {/* Drag handle (left edge) */}
@@ -198,30 +289,49 @@ function CardBody<TMeta>(props: CardBodyProps<TMeta>) {
       {/* Thumbnail */}
       {thumbnail && (
         <div
-          className={`flex shrink-0 items-center justify-center overflow-hidden rounded-xl bg-slate-50 ${
-            isList ? 'h-12 w-12' : 'h-24 w-full'
-          }`}
+          className="flex shrink-0 items-center justify-center overflow-hidden rounded-xl bg-slate-50/60"
+          style={
+            isList
+              ? {
+                  width: 'min(48px, 13cqmin)',
+                  height: 'min(48px, 13cqmin)',
+                }
+              : {
+                  width: '100%',
+                  height: 'min(96px, 26cqmin)',
+                }
+          }
         >
           {thumbnail}
         </div>
       )}
 
       {/* Main body */}
-      <div className="flex min-w-0 flex-1 flex-col gap-1">
+      <div
+        className="flex min-w-0 flex-1 flex-col"
+        style={{ gap: 'min(4px, 1cqmin)' }}
+      >
         <h3
-          className={`truncate font-black text-slate-800 ${
-            isList ? 'text-sm' : 'text-[15px]'
-          }`}
+          className="truncate font-black text-slate-800"
+          style={{
+            fontSize: isList ? 'min(14px, 4.5cqmin)' : 'min(15px, 4.8cqmin)',
+          }}
         >
           {title}
         </h3>
         {subtitle && (
-          <div className="truncate text-xs font-medium text-slate-500">
+          <div
+            className="truncate font-medium text-slate-500"
+            style={{ fontSize: 'min(12px, 3.8cqmin)' }}
+          >
             {subtitle}
           </div>
         )}
         {badges && badges.length > 0 && (
-          <div className="mt-1 flex flex-wrap items-center gap-1.5">
+          <div
+            className="mt-1 flex flex-wrap items-center"
+            style={{ gap: 'min(6px, 1.5cqmin)' }}
+          >
             {badges.map((b, i) => (
               <BadgeChip key={`${b.label}-${i}`} badge={b} />
             ))}
@@ -231,9 +341,8 @@ function CardBody<TMeta>(props: CardBodyProps<TMeta>) {
 
       {/* Actions (right side) */}
       <div
-        className={`flex shrink-0 items-center gap-1 ${
-          isList ? '' : 'self-end'
-        }`}
+        className={`flex shrink-0 items-center ${isList ? '' : 'self-end'}`}
+        style={{ gap: 'min(6px, 1.5cqmin)' }}
       >
         <button
           type="button"
@@ -247,13 +356,37 @@ function CardBody<TMeta>(props: CardBodyProps<TMeta>) {
               ? primaryAction.disabledReason
               : primaryAction.label
           }
-          className="inline-flex items-center gap-1.5 rounded-xl bg-brand-blue-primary px-3 py-1.5 text-xs font-bold uppercase tracking-widest text-white shadow-sm transition-all hover:bg-brand-blue-dark active:scale-95 disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:bg-brand-blue-primary"
+          className="inline-flex shrink-0 items-center gap-1.5 rounded-xl bg-brand-blue-primary font-bold uppercase tracking-widest text-white shadow-sm transition-all hover:bg-brand-blue-dark active:scale-95 disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:bg-brand-blue-primary"
+          style={{
+            paddingInline: 'min(14px, 3.2cqmin)',
+            paddingBlock: 'min(6px, 1.6cqmin)',
+            fontSize: 'min(12px, 3.8cqmin)',
+          }}
         >
-          {PrimaryIcon && <PrimaryIcon size={14} />}
+          {PrimaryIcon && (
+            <PrimaryIcon
+              style={{
+                width: 'min(14px, 4cqmin)',
+                height: 'min(14px, 4cqmin)',
+              }}
+            />
+          )}
           {primaryAction.label}
         </button>
         {secondaryActions && secondaryActions.length > 0 && (
-          <OverflowMenu actions={secondaryActions} />
+          <>
+            {useOverflowMenu ? (
+              <OverflowMenu actions={secondaryActions} />
+            ) : (
+              secondaryActions.map((action) => (
+                <InlineActionButton
+                  key={action.id}
+                  action={action}
+                  compact={!canShowInlineLabels}
+                />
+              ))
+            )}
+          </>
         )}
       </div>
     </div>

--- a/components/common/library/LibraryShell.tsx
+++ b/components/common/library/LibraryShell.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { BookOpen, Activity, Archive as ArchiveIcon } from 'lucide-react';
 import type {
   LibraryShellProps,
@@ -9,33 +9,60 @@ import type {
 interface TabDef {
   key: LibraryTab;
   label: string;
-  icon: React.ComponentType<{ size?: number; className?: string }>;
+  icon: React.ComponentType<{
+    size?: number;
+    className?: string;
+    style?: React.CSSProperties;
+  }>;
   count: number | undefined;
 }
 
 const renderActionButton = (
   action: LibraryPrimaryAction,
   variant: 'primary' | 'secondary',
+  labelsHidden: boolean,
   key?: string
 ): React.ReactElement => {
   const Icon = action.icon;
   const base =
-    'inline-flex items-center gap-1.5 px-3.5 py-2 rounded-xl text-sm font-bold transition-all shadow-sm active:scale-95 disabled:opacity-50 disabled:cursor-not-allowed';
+    'inline-flex shrink-0 items-center justify-center gap-1.5 rounded-xl font-bold transition-all shadow-sm active:scale-95 disabled:opacity-50 disabled:cursor-not-allowed';
   const variantClass =
     variant === 'primary'
       ? 'bg-brand-blue-primary hover:bg-brand-blue-dark text-white'
-      : 'bg-white hover:bg-brand-blue-lighter/40 text-brand-blue-primary border border-brand-blue-primary/20';
+      : 'bg-white/70 backdrop-blur-sm hover:bg-brand-blue-lighter/40 text-brand-blue-primary border border-brand-blue-primary/20';
   return (
     <button
       key={key}
       type="button"
       onClick={action.onClick}
       disabled={action.disabled}
-      title={action.disabled ? action.disabledReason : undefined}
+      title={
+        action.disabled
+          ? action.disabledReason
+          : labelsHidden
+            ? action.label
+            : undefined
+      }
+      aria-label={action.label}
       className={`${base} ${variantClass}`}
+      style={{
+        paddingInline: labelsHidden ? '0' : 'min(14px, 3cqmin)',
+        paddingBlock: 'min(8px, 1.8cqmin)',
+        fontSize: 'min(14px, 4cqmin)',
+        minWidth: labelsHidden ? 'min(36px, 10cqmin)' : undefined,
+        height: labelsHidden ? 'min(36px, 10cqmin)' : undefined,
+      }}
     >
-      {Icon && <Icon size={16} className="shrink-0" />}
-      <span className="truncate">{action.label}</span>
+      {Icon && (
+        <Icon
+          style={{
+            width: 'min(16px, 4.5cqmin)',
+            height: 'min(16px, 4.5cqmin)',
+          }}
+          className="shrink-0"
+        />
+      )}
+      {!labelsHidden && <span className="truncate">{action.label}</span>}
     </button>
   );
 };
@@ -72,24 +99,61 @@ export const LibraryShell: React.FC<LibraryShellProps> = ({
     },
   ];
 
+  // Collapse header action labels to icon-only when the widget is narrow so
+  // buttons never push off-screen. A crude width threshold based on the number
+  // of buttons keeps parity with the inline/overflow logic on library cards.
+  const rootRef = useRef<HTMLElement>(null);
+  const [rootWidth, setRootWidth] = useState<number | null>(null);
+  useEffect(() => {
+    const el = rootRef.current;
+    if (!el || typeof ResizeObserver === 'undefined') return undefined;
+    const observer = new ResizeObserver((entries) => {
+      const entry = entries[0];
+      if (entry) setRootWidth(entry.contentRect.width);
+    });
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, []);
+  const buttonCount = (primaryAction ? 1 : 0) + (secondaryActions?.length ?? 0);
+  const labelsHidden = rootWidth != null && rootWidth < 260 + buttonCount * 110;
+
   return (
     <section
-      className="flex flex-col h-full min-h-0 bg-slate-50 text-slate-800 rounded-2xl overflow-hidden"
+      ref={rootRef}
+      className="flex flex-col h-full min-h-0 text-slate-800 rounded-2xl overflow-hidden"
       aria-label={`${widgetLabel} library`}
     >
-      <header className="flex items-center justify-between gap-4 px-6 py-4 bg-white border-b border-slate-200 shrink-0">
+      <header
+        className="flex items-center justify-between gap-3 bg-white/60 backdrop-blur-sm border-b border-slate-200/70 shrink-0"
+        style={{
+          paddingInline: 'min(24px, 5cqmin)',
+          paddingBlock: 'min(16px, 3.5cqmin)',
+        }}
+      >
         <div className="min-w-0">
-          <h2 className="font-black text-lg text-slate-800 truncate">
+          <h2
+            className="font-black text-slate-800 truncate"
+            style={{ fontSize: 'min(18px, 5.5cqmin)' }}
+          >
             {widgetLabel} Library
           </h2>
         </div>
         {(primaryAction != null ||
           (secondaryActions != null && secondaryActions.length > 0)) && (
-          <div className="flex items-center gap-2 shrink-0">
+          <div
+            className="flex items-center shrink-0"
+            style={{ gap: 'min(8px, 2cqmin)' }}
+          >
             {secondaryActions?.map((action, i) =>
-              renderActionButton(action, 'secondary', `secondary-${i}`)
+              renderActionButton(
+                action,
+                'secondary',
+                labelsHidden,
+                `secondary-${i}`
+              )
             )}
-            {primaryAction && renderActionButton(primaryAction, 'primary')}
+            {primaryAction &&
+              renderActionButton(primaryAction, 'primary', labelsHidden)}
           </div>
         )}
       </header>
@@ -97,7 +161,12 @@ export const LibraryShell: React.FC<LibraryShellProps> = ({
       <nav
         role="tablist"
         aria-label={`${widgetLabel} library tabs`}
-        className="flex items-end gap-1 px-6 pt-3 bg-white border-b border-slate-200 shrink-0"
+        className="flex items-end bg-white/60 backdrop-blur-sm border-b border-slate-200/70 shrink-0"
+        style={{
+          gap: 'min(4px, 1cqmin)',
+          paddingInline: 'min(24px, 5cqmin)',
+          paddingTop: 'min(12px, 2.5cqmin)',
+        }}
       >
         {tabs.map(({ key, label, icon: Icon, count }) => {
           const selected = tab === key;
@@ -108,21 +177,38 @@ export const LibraryShell: React.FC<LibraryShellProps> = ({
               role="tab"
               aria-selected={selected}
               onClick={() => onTabChange(key)}
-              className={`inline-flex items-center gap-2 rounded-t-xl px-4 py-2.5 text-sm font-black uppercase tracking-widest transition-colors ${
+              className={`inline-flex items-center rounded-t-xl font-black uppercase tracking-widest transition-colors ${
                 selected
-                  ? 'bg-slate-50 text-brand-blue-primary border-x border-t border-slate-200'
-                  : 'text-slate-400 hover:text-brand-blue-primary hover:bg-slate-100/60'
+                  ? 'bg-white/40 text-brand-blue-primary border-x border-t border-slate-200/70'
+                  : 'text-slate-500 hover:text-brand-blue-primary hover:bg-white/30'
               }`}
+              style={{
+                gap: 'min(8px, 2cqmin)',
+                paddingInline: 'min(16px, 3.5cqmin)',
+                paddingBlock: 'min(10px, 2.2cqmin)',
+                fontSize: 'min(13px, 3.8cqmin)',
+              }}
             >
-              <Icon size={14} className="shrink-0" />
+              <Icon
+                style={{
+                  width: 'min(14px, 4cqmin)',
+                  height: 'min(14px, 4cqmin)',
+                }}
+                className="shrink-0"
+              />
               <span>{label}</span>
               {count != null && count > 0 && (
                 <span
-                  className={`inline-flex items-center justify-center rounded-full px-2 py-0.5 text-[10px] font-bold leading-none ${
+                  className={`inline-flex items-center justify-center rounded-full font-bold leading-none ${
                     selected
                       ? 'bg-brand-blue-primary text-white'
-                      : 'bg-slate-200 text-slate-600'
+                      : 'bg-slate-200/70 text-slate-600'
                   }`}
+                  style={{
+                    paddingInline: 'min(8px, 2cqmin)',
+                    paddingBlock: 'min(2px, 0.5cqmin)',
+                    fontSize: 'min(10px, 3cqmin)',
+                  }}
                 >
                   {count}
                 </span>
@@ -133,21 +219,31 @@ export const LibraryShell: React.FC<LibraryShellProps> = ({
       </nav>
 
       {toolbarSlot && (
-        <div className="px-6 py-3 bg-white border-b border-slate-200 shrink-0">
+        <div
+          className="bg-white/40 backdrop-blur-sm border-b border-slate-200/70 shrink-0"
+          style={{
+            paddingInline: 'min(24px, 5cqmin)',
+            paddingBlock: 'min(12px, 2.5cqmin)',
+          }}
+        >
           {toolbarSlot}
         </div>
       )}
 
       <div className="flex flex-1 min-h-0">
         {filterSidebarSlot && (
-          <aside className="w-60 shrink-0 bg-white border-r border-slate-200 overflow-y-auto">
+          <aside className="w-60 shrink-0 bg-white/40 backdrop-blur-sm border-r border-slate-200/70 overflow-y-auto">
             {filterSidebarSlot}
           </aside>
         )}
         <div
           role="tabpanel"
           aria-label={`${widgetLabel} ${tab} tab content`}
-          className="flex-1 min-w-0 overflow-y-auto px-6 py-5"
+          className="flex-1 min-w-0 overflow-y-auto"
+          style={{
+            paddingInline: 'min(24px, 5cqmin)',
+            paddingBlock: 'min(20px, 4.5cqmin)',
+          }}
         >
           {children}
         </div>

--- a/components/common/library/importer/ImportWizard.tsx
+++ b/components/common/library/importer/ImportWizard.tsx
@@ -49,6 +49,10 @@ function acceptExtensionsForSources(sources: ImportSourceKind[]): string {
   const exts = new Set<string>();
   if (sources.includes('csv')) exts.add('.csv');
   if (sources.includes('json')) exts.add('.json');
+  if (sources.includes('html')) {
+    exts.add('.html');
+    exts.add('.htm');
+  }
   if (sources.includes('file')) {
     exts.add('.csv');
     exts.add('.json');
@@ -62,9 +66,15 @@ function inferKindFromFileName(
   supported: ImportSourceKind[]
 ): Exclude<ImportSourceKind, 'sheet'> {
   const lower = fileName.toLowerCase();
+  if (
+    (lower.endsWith('.html') || lower.endsWith('.htm')) &&
+    supported.includes('html')
+  )
+    return 'html';
   if (lower.endsWith('.json') && supported.includes('json')) return 'json';
   if (lower.endsWith('.csv') && supported.includes('csv')) return 'csv';
   if (supported.includes('file')) return 'file';
+  if (supported.includes('html')) return 'html';
   if (supported.includes('csv')) return 'csv';
   if (supported.includes('json')) return 'json';
   return 'file';
@@ -126,8 +136,10 @@ export function ImportWizard<TData>({
   const supportsSheet = adapter.supportedSources.includes('sheet');
   const supportsCsv = adapter.supportedSources.includes('csv');
   const supportsJson = adapter.supportedSources.includes('json');
+  const supportsHtml = adapter.supportedSources.includes('html');
   const supportsFile = adapter.supportedSources.includes('file');
-  const supportsAnyUpload = supportsCsv || supportsJson || supportsFile;
+  const supportsAnyUpload =
+    supportsCsv || supportsJson || supportsHtml || supportsFile;
 
   const runParse = async (payload: ImportSourcePayload): Promise<void> => {
     setLoading(true);
@@ -441,16 +453,20 @@ export function ImportWizard<TData>({
           >
             <FileUp className="w-6 h-6 text-brand-blue-primary group-hover:scale-110 transition-transform" />
             <span className="font-bold text-brand-blue-primary text-sm">
-              Upload file
+              {supportsHtml && !supportsCsv && !supportsJson && !supportsFile
+                ? 'Upload HTML file'
+                : 'Upload file'}
             </span>
             <p className="text-[11px] text-brand-blue-primary/60 font-bold">
-              {supportsCsv && supportsJson
-                ? 'CSV or JSON'
-                : supportsCsv
-                  ? 'CSV'
-                  : supportsJson
-                    ? 'JSON'
-                    : 'File'}
+              {supportsHtml && !supportsCsv && !supportsJson && !supportsFile
+                ? '.html or .htm'
+                : supportsCsv && supportsJson
+                  ? 'CSV or JSON'
+                  : supportsCsv
+                    ? 'CSV'
+                    : supportsJson
+                      ? 'JSON'
+                      : 'File'}
             </p>
           </button>
           <input

--- a/components/common/library/importer/ImportWizard.tsx
+++ b/components/common/library/importer/ImportWizard.tsx
@@ -148,6 +148,16 @@ export function ImportWizard<TData>({
       const result = await adapter.parse(payload);
       setParsed(result.data);
       setWarnings(result.warnings);
+      // If the adapter can extract a title from the parsed data (e.g. an
+      // HTML `<title>` tag) and the user hasn't typed one, prefill it so
+      // the derived title isn't wasted. We only overwrite empty input —
+      // any title the user has already supplied wins.
+      if (adapter.suggestTitle && !title.trim()) {
+        const suggestion = adapter.suggestTitle(result.data);
+        if (suggestion && suggestion.trim()) {
+          setTitle(suggestion.trim());
+        }
+      }
       setStep('preview');
     } catch (err) {
       setParseError(

--- a/components/common/library/types.ts
+++ b/components/common/library/types.ts
@@ -47,7 +47,7 @@ export type LibraryBadgeTone =
 export type LibraryAssignmentStatus = 'active' | 'paused' | 'inactive';
 
 /** Import source kinds. Adapters declare which they support. */
-export type ImportSourceKind = 'sheet' | 'csv' | 'json' | 'file';
+export type ImportSourceKind = 'sheet' | 'csv' | 'json' | 'html' | 'file';
 
 /* ─── Generic value objects ───────────────────────────────────────────────── */
 
@@ -55,7 +55,11 @@ export type ImportSourceKind = 'sheet' | 'csv' | 'json' | 'file';
 export interface LibraryMenuAction {
   id: string;
   label: string;
-  icon?: React.ComponentType<{ size?: number; className?: string }>;
+  icon?: React.ComponentType<{
+    size?: number;
+    className?: string;
+    style?: React.CSSProperties;
+  }>;
   onClick: () => void;
   /** Renders with danger styling and (optionally) moves to the bottom. */
   destructive?: boolean;
@@ -67,7 +71,11 @@ export interface LibraryMenuAction {
 /** Primary action on a card — always visible, never nested under overflow. */
 export interface LibraryPrimaryAction {
   label: string;
-  icon?: React.ComponentType<{ size?: number; className?: string }>;
+  icon?: React.ComponentType<{
+    size?: number;
+    className?: string;
+    style?: React.CSSProperties;
+  }>;
   onClick: () => void;
   disabled?: boolean;
   disabledReason?: string;
@@ -305,7 +313,11 @@ export interface AssignModeOption {
   id: string;
   label: string;
   description: string;
-  icon?: React.ComponentType<{ size?: number; className?: string }>;
+  icon?: React.ComponentType<{
+    size?: number;
+    className?: string;
+    style?: React.CSSProperties;
+  }>;
   /** Lock the mode selector (e.g. assignment is already live). */
   disabled?: boolean;
 }
@@ -363,6 +375,7 @@ export type ImportSourcePayload =
   | { kind: 'sheet'; url: string }
   | { kind: 'csv'; text: string; fileName?: string }
   | { kind: 'json'; text: string; fileName?: string }
+  | { kind: 'html'; text: string; fileName?: string }
   | { kind: 'file'; file: File };
 
 /** Parser result — `warnings` surface non-fatal issues in the preview. */

--- a/components/common/library/types.ts
+++ b/components/common/library/types.ts
@@ -406,6 +406,13 @@ export interface ImportAdapter<TData> {
   parse: (source: ImportSourcePayload) => Promise<ImportParseResult<TData>>;
   validate: (data: TData) => ImportValidationResult;
   renderPreview: (data: TData) => React.ReactNode;
+  /**
+   * Optional — given the parsed data, return a suggested title. The wizard
+   * auto-populates its title input with this value when the input is empty,
+   * so callers shouldn't have to retype an already-extracted title (e.g. a
+   * `<title>` tag from an uploaded HTML file).
+   */
+  suggestTitle?: (data: TData) => string | undefined;
   /** Persist to the widget's library. Consumer owns Firestore/Drive writes. */
   save: (data: TData, title: string) => Promise<void>;
   /** Optional AI-assist path (e.g. Quiz's Gemini generator). */

--- a/components/common/modalStore.ts
+++ b/components/common/modalStore.ts
@@ -23,8 +23,19 @@ export const incrementOpenModalCount = (): number => {
   return openModalCount;
 };
 
-/** Modal calls this on unmount. */
+/**
+ * Modal calls this on unmount. Clamps at 0 so a stray extra call can't drive
+ * the counter negative and leave `document.body.style.overflow` locked.
+ */
 export const decrementOpenModalCount = (): number => {
+  if (openModalCount === 0) {
+    if (import.meta.env.DEV) {
+      console.warn(
+        '[modalStore] decrementOpenModalCount called while count is 0'
+      );
+    }
+    return 0;
+  }
   openModalCount -= 1;
   notify();
   return openModalCount;

--- a/components/common/modalStore.ts
+++ b/components/common/modalStore.ts
@@ -1,0 +1,48 @@
+/**
+ * Shared state for portalled `Modal` instances.
+ *
+ * Counts how many modals are currently mounted and exposes a `useHasOpenModal`
+ * hook so other UI (DraggableWindow's floating toolbar, popovers that would
+ * render above the modal surface, etc.) can suppress itself while any modal
+ * is on screen.
+ */
+
+import { useSyncExternalStore } from 'react';
+
+let openModalCount = 0;
+const listeners = new Set<() => void>();
+
+const notify = (): void => {
+  for (const listener of listeners) listener();
+};
+
+/** Modal calls this on mount. */
+export const incrementOpenModalCount = (): number => {
+  openModalCount += 1;
+  notify();
+  return openModalCount;
+};
+
+/** Modal calls this on unmount. */
+export const decrementOpenModalCount = (): number => {
+  openModalCount -= 1;
+  notify();
+  return openModalCount;
+};
+
+/** Current count, synchronous. */
+export const getOpenModalCount = (): number => openModalCount;
+
+const subscribeToOpenModalCount = (listener: () => void): (() => void) => {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+};
+
+/**
+ * Returns true whenever at least one portalled `Modal` is mounted.
+ */
+export const useHasOpenModal = (): boolean =>
+  useSyncExternalStore(subscribeToOpenModalCount, getOpenModalCount, () => 0) >
+  0;

--- a/components/widgets/MiniApp/adapters/miniAppImportAdapter.test.ts
+++ b/components/widgets/MiniApp/adapters/miniAppImportAdapter.test.ts
@@ -1,0 +1,243 @@
+/**
+ * Tests for miniAppImportAdapter — covers the purely-functional surfaces
+ * (title derivation, parse warnings, validation, suggested title, import
+ * ordering) so HTML file imports stay stable as the wizard evolves.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { MiniAppItem } from '@/types';
+import {
+  createMiniAppImportAdapter,
+  parseMiniAppImport,
+  titleFromFileName,
+  titleFromHtml,
+  validateMiniAppImport,
+  type MiniAppImportData,
+} from './miniAppImportAdapter';
+
+const batchSet = vi.fn<(docRef: unknown, data: MiniAppItem) => void>();
+const batchCommit = vi.fn<() => Promise<void>>(() => Promise.resolve());
+
+vi.mock('firebase/firestore', () => ({
+  collection: vi.fn(() => ({ __type: 'collection' })),
+  doc: vi.fn((_ref: unknown, id: string) => ({ __type: 'doc', id })),
+  writeBatch: vi.fn(() => ({
+    set: batchSet,
+    commit: batchCommit,
+  })),
+}));
+
+vi.mock('@/config/firebase', () => ({
+  db: { __type: 'mock-db' },
+}));
+
+describe('miniAppImportAdapter', () => {
+  describe('titleFromFileName', () => {
+    it('strips the extension and returns the stem', () => {
+      expect(titleFromFileName('my-app.html')).toBe('my-app');
+      expect(titleFromFileName('Some Game.htm')).toBe('Some Game');
+    });
+
+    it('falls back to "Untitled App" for empty / undefined input', () => {
+      expect(titleFromFileName(undefined)).toBe('Untitled App');
+      expect(titleFromFileName('')).toBe('Untitled App');
+      expect(titleFromFileName('.html')).toBe('Untitled App');
+    });
+
+    it('truncates very long filenames', () => {
+      const long = 'a'.repeat(200) + '.html';
+      expect(titleFromFileName(long).length).toBe(100);
+    });
+  });
+
+  describe('titleFromHtml', () => {
+    it('prefers the <title> tag', () => {
+      expect(
+        titleFromHtml('<html><head><title>Hello</title></head></html>')
+      ).toBe('Hello');
+    });
+
+    it('falls back to the first <h1> when <title> is missing', () => {
+      expect(titleFromHtml('<html><body><h1>Hi there</h1></body></html>')).toBe(
+        'Hi there'
+      );
+    });
+
+    it('normalizes whitespace in titles', () => {
+      expect(titleFromHtml('<title>  Multi\n  Line\t Title  </title>')).toBe(
+        'Multi Line Title'
+      );
+    });
+
+    it('extracts text safely from nested / malformed tags via DOMParser', () => {
+      // Regex-based tag stripping would be bypassable here; DOMParser is not.
+      const html = '<h1>Safe <scr<b>ipt>Title</h1>';
+      expect(titleFromHtml(html)).not.toContain('<script');
+      expect(titleFromHtml(html).length).toBeGreaterThan(0);
+    });
+
+    it('truncates to 100 characters', () => {
+      const long = '<title>' + 'x'.repeat(150) + '</title>';
+      expect(titleFromHtml(long).length).toBe(100);
+    });
+
+    it('returns "" when neither <title> nor <h1> is present', () => {
+      expect(titleFromHtml('<div>no headings here</div>')).toBe('');
+    });
+  });
+
+  describe('parseMiniAppImport', () => {
+    it('reads html source and derives the title from <title>', async () => {
+      const result = await parseMiniAppImport({
+        kind: 'html',
+        text: '<title>Flash Cards</title><body>Hi</body>',
+        fileName: 'fallback.html',
+      });
+      expect(result.data.rows).toHaveLength(1);
+      expect(result.data.rows[0].title).toBe('Flash Cards');
+      expect(result.data.rows[0].html).toContain('<body>');
+      expect(result.warnings).toEqual([]);
+    });
+
+    it('falls back to filename when the HTML has no title or h1', async () => {
+      const result = await parseMiniAppImport({
+        kind: 'html',
+        text: '<div>no headings</div>',
+        fileName: 'my-game.html',
+      });
+      expect(result.data.rows[0].title).toBe('my-game');
+    });
+
+    it('reads file sources and uses the file name for title fallback', async () => {
+      // jsdom's File polyfill doesn't implement `.text()`, so hand-roll a
+      // compatible object that satisfies the subset the adapter uses.
+      const file = {
+        name: 'FromFile.htm',
+        text: () => Promise.resolve('<div>hi</div>'),
+      } as unknown as File;
+      const result = await parseMiniAppImport({ kind: 'file', file });
+      expect(result.data.rows[0].title).toBe('FromFile');
+    });
+
+    it('rejects empty files', async () => {
+      await expect(
+        parseMiniAppImport({ kind: 'html', text: '   ' })
+      ).rejects.toThrow(/empty/i);
+    });
+
+    it('warns (but does not reject) when the content does not look like HTML', async () => {
+      const result = await parseMiniAppImport({
+        kind: 'html',
+        text: 'Just some text, no tags.',
+        fileName: 'Plain.html',
+      });
+      expect(result.warnings.length).toBe(1);
+      expect(result.warnings[0]).toMatch(/doesn't look like HTML/i);
+      expect(result.data.rows).toHaveLength(1);
+    });
+
+    it('rejects unsupported source kinds', async () => {
+      await expect(
+        parseMiniAppImport({ kind: 'json', text: '{}' })
+      ).rejects.toThrow(/only accepts HTML/i);
+    });
+  });
+
+  describe('validateMiniAppImport', () => {
+    it('passes when at least one row is present', () => {
+      const result = validateMiniAppImport({
+        rows: [{ title: 'A', html: '<div/>' }],
+      });
+      expect(result.ok).toBe(true);
+      expect(result.errors).toEqual([]);
+    });
+
+    it('fails when there are no rows', () => {
+      const result = validateMiniAppImport({ rows: [] });
+      expect(result.ok).toBe(false);
+      expect(result.errors.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('createMiniAppImportAdapter', () => {
+    beforeEach(() => {
+      batchSet.mockClear();
+      batchCommit.mockClear();
+    });
+
+    it('suggests the derived title for single-row imports', () => {
+      const adapter = createMiniAppImportAdapter('user-1');
+      const data: MiniAppImportData = {
+        rows: [{ title: 'Derived', html: '<div/>' }],
+      };
+      expect(adapter.suggestTitle?.(data)).toBe('Derived');
+    });
+
+    it('does not suggest a title for multi-row imports', () => {
+      const adapter = createMiniAppImportAdapter('user-1');
+      const data: MiniAppImportData = {
+        rows: [
+          { title: 'A', html: '<div/>' },
+          { title: 'B', html: '<div/>' },
+        ],
+      };
+      expect(adapter.suggestTitle?.(data)).toBeUndefined();
+    });
+
+    it('rejects save when not authenticated', async () => {
+      const adapter = createMiniAppImportAdapter('');
+      await expect(
+        adapter.save({ rows: [{ title: 'x', html: '<div/>' }] }, 'T')
+      ).rejects.toThrow(/not authenticated/i);
+    });
+
+    it('assigns strongly-negative orders so imports land above existing items', async () => {
+      const adapter = createMiniAppImportAdapter('user-1');
+      const before = Date.now();
+      await adapter.save(
+        { rows: [{ title: 'Derived', html: '<div/>' }] },
+        'User Title'
+      );
+      const after = Date.now();
+
+      expect(batchSet).toHaveBeenCalledTimes(1);
+      const saved: MiniAppItem = batchSet.mock.calls[0][1];
+      // Single row → order is exactly -baseTime.
+      expect(saved.order ?? 0).toBeLessThanOrEqual(-before);
+      expect(saved.order ?? 0).toBeGreaterThanOrEqual(-after);
+      // Much smaller than MiniAppWidget's -1, -2, ... ordering.
+      expect(saved.order ?? 0).toBeLessThan(-1_000_000);
+      // Title the user typed wins over the derived one.
+      expect(saved.title).toBe('User Title');
+      expect(batchCommit).toHaveBeenCalledOnce();
+    });
+
+    it('preserves relative order for multi-row batches', async () => {
+      const adapter = createMiniAppImportAdapter('user-1');
+      await adapter.save(
+        {
+          rows: [
+            { title: 'First', html: '<div/>' },
+            { title: 'Second', html: '<div/>' },
+            { title: 'Third', html: '<div/>' },
+          ],
+        },
+        '' // No user title — per-row titles should be kept.
+      );
+      const saved: MiniAppItem[] = batchSet.mock.calls.map((c) => c[1]);
+      const orders = saved.map((s) => s.order ?? 0);
+      const titles = saved.map((s) => s.title);
+      // Strictly ascending: index 0 (top) has smallest order.
+      expect(orders[0]).toBeLessThan(orders[1]);
+      expect(orders[1]).toBeLessThan(orders[2]);
+      // All strongly negative.
+      orders.forEach((o) => expect(o).toBeLessThan(-1_000_000));
+      // Per-row titles kept in a multi-row import.
+      expect(titles).toEqual(['First', 'Second', 'Third']);
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+});

--- a/components/widgets/MiniApp/adapters/miniAppImportAdapter.ts
+++ b/components/widgets/MiniApp/adapters/miniAppImportAdapter.ts
@@ -6,8 +6,9 @@
  * mini-app row. The title is derived from the file's `<title>` tag (falling
  * back to the first `<h1>`, then to the filename stem).
  *
- * Writes to `/users/{uid}/miniapps/` with `order: -1` so the import lands at
- * the top of the library (matches the pre-migration ordering behavior).
+ * Writes to `/users/{uid}/miniapps/` with negative `order` values
+ * (`index - total`) so imports land at the top of the library while
+ * preserving their relative order (matches the pre-migration behavior).
  *
  * Magic Generator (Gemini) deliberately stays inside the editor body; it is
  * NOT surfaced here as `aiAssist`, per the original MiniApp brief.

--- a/components/widgets/MiniApp/adapters/miniAppImportAdapter.ts
+++ b/components/widgets/MiniApp/adapters/miniAppImportAdapter.ts
@@ -47,18 +47,22 @@ function titleFromFileName(name: string | undefined): string {
 /**
  * Extract a human-readable title from an HTML document. Tries `<title>`, then
  * the first `<h1>`. Returns an empty string if neither is present.
+ *
+ * Uses `DOMParser` so nested/malformed tags in an `<h1>` are handled by the
+ * browser's HTML parser (safer than regex-based tag stripping, which can be
+ * bypassed by patterns like `<scr<b>ipt>`).
  */
 function titleFromHtml(html: string): string {
-  const titleMatch = html.match(/<title[^>]*>([\s\S]*?)<\/title>/i);
-  const titleText = titleMatch?.[1]?.replace(/\s+/g, ' ').trim();
-  if (titleText) return titleText.slice(0, MAX_TITLE_LENGTH);
+  if (typeof DOMParser === 'undefined') return '';
+  const doc = new DOMParser().parseFromString(html, 'text/html');
 
-  const h1Match = html.match(/<h1[^>]*>([\s\S]*?)<\/h1>/i);
-  const h1Text = h1Match?.[1]
-    ?.replace(/<[^>]+>/g, '')
-    .replace(/\s+/g, ' ')
-    .trim();
-  if (h1Text) return h1Text.slice(0, MAX_TITLE_LENGTH);
+  const titleText = doc.querySelector('title')?.textContent;
+  const normalizedTitle = titleText?.replace(/\s+/g, ' ').trim();
+  if (normalizedTitle) return normalizedTitle.slice(0, MAX_TITLE_LENGTH);
+
+  const h1Text = doc.querySelector('h1')?.textContent;
+  const normalizedH1 = h1Text?.replace(/\s+/g, ' ').trim();
+  if (normalizedH1) return normalizedH1.slice(0, MAX_TITLE_LENGTH);
 
   return '';
 }

--- a/components/widgets/MiniApp/adapters/miniAppImportAdapter.ts
+++ b/components/widgets/MiniApp/adapters/miniAppImportAdapter.ts
@@ -6,9 +6,11 @@
  * mini-app row. The title is derived from the file's `<title>` tag (falling
  * back to the first `<h1>`, then to the filename stem).
  *
- * Writes to `/users/{uid}/miniapps/` with negative `order` values
- * (`index - total`) so imports land at the top of the library while
- * preserving their relative order (matches the pre-migration behavior).
+ * Writes to `/users/{uid}/miniapps/` with strongly-negative `order` values
+ * derived from `-Date.now()` so imports always land above the existing top
+ * item (which MiniAppWidget creates at `minOrder - 1`, typically small
+ * negative integers). For multi-row imports the row index offsets the
+ * timestamp so relative order within the batch is preserved.
  *
  * Magic Generator (Gemini) deliberately stays inside the editor body; it is
  * NOT surfaced here as `aiAssist`, per the original MiniApp brief.
@@ -39,7 +41,7 @@ export interface MiniAppImportData {
 const MAX_TITLE_LENGTH = 100;
 
 /** Strip a filename down to a reasonable fallback title. */
-function titleFromFileName(name: string | undefined): string {
+export function titleFromFileName(name: string | undefined): string {
   if (!name) return 'Untitled App';
   const stem = name.replace(/\.[^.]+$/, '').trim();
   return stem ? stem.slice(0, MAX_TITLE_LENGTH) : 'Untitled App';
@@ -53,7 +55,7 @@ function titleFromFileName(name: string | undefined): string {
  * browser's HTML parser (safer than regex-based tag stripping, which can be
  * bypassed by patterns like `<scr<b>ipt>`).
  */
-function titleFromHtml(html: string): string {
+export function titleFromHtml(html: string): string {
   if (typeof DOMParser === 'undefined') return '';
   const doc = new DOMParser().parseFromString(html, 'text/html');
 
@@ -83,7 +85,7 @@ async function readSourceAsHtml(
   );
 }
 
-async function parseMiniAppImport(
+export async function parseMiniAppImport(
   source: ImportSourcePayload
 ): Promise<ImportParseResult<MiniAppImportData>> {
   const { text, fileName } = await readSourceAsHtml(source);
@@ -109,7 +111,7 @@ async function parseMiniAppImport(
   return { data: { rows: [row] }, warnings };
 }
 
-function validateMiniAppImport(
+export function validateMiniAppImport(
   data: MiniAppImportData
 ): ImportValidationResult {
   if (data.rows.length === 0) {
@@ -178,6 +180,13 @@ export function createMiniAppImportAdapter(
     parse: parseMiniAppImport,
     validate: validateMiniAppImport,
     renderPreview: renderMiniAppPreview,
+    suggestTitle(data) {
+      // The wizard prefills its title input from this value when empty.
+      // Only meaningful for single-row imports — per-row titles stand on
+      // their own in a batch.
+      if (data.rows.length !== 1) return undefined;
+      return data.rows[0]?.title;
+    },
     async save(data, title) {
       if (!userId) throw new Error('Not authenticated');
       if (data.rows.length === 0) return;
@@ -185,6 +194,12 @@ export function createMiniAppImportAdapter(
       const appsRef = collection(db, 'users', userId, 'miniapps');
       const batch = writeBatch(db);
       const total = data.rows.length;
+      // Anchor the batch to a single moment so all rows share a baseline and
+      // relative order within the batch is preserved. Using `-Date.now()`
+      // makes these orders strictly smaller than anything MiniAppWidget
+      // creates through its `minOrder - 1` scheme, so imports reliably land
+      // at the very top of the list.
+      const baseOrder = -Date.now();
 
       data.rows.forEach((row, index) => {
         const id = crypto.randomUUID();
@@ -199,9 +214,9 @@ export function createMiniAppImportAdapter(
           title: resolvedTitle,
           html: row.html,
           createdAt: Date.now(),
-          // New imports land at the top by taking strictly smaller `order`
-          // values than anything existing (matches pre-migration behavior).
-          order: index - total,
+          // First row (index 0) gets the smallest order so it sits at the
+          // top; subsequent rows follow with strictly larger orders.
+          order: baseOrder - (total - 1 - index),
         };
         batch.set(doc(appsRef, id), appData);
       });

--- a/components/widgets/MiniApp/adapters/miniAppImportAdapter.ts
+++ b/components/widgets/MiniApp/adapters/miniAppImportAdapter.ts
@@ -1,20 +1,16 @@
 /**
- * MiniApp Import Adapter (Wave 2-MA).
+ * MiniApp Import Adapter.
  *
  * Implements `ImportAdapter<MiniAppImportData>` for the shared `ImportWizard`.
- * Preserves the exact JSON-file import format that existed on
- * `MiniAppWidget` before migration (see Widget.tsx pre-migration, handleImport):
+ * Teachers upload a single `.html` / `.htm` file; that file becomes one
+ * mini-app row. The title is derived from the file's `<title>` tag (falling
+ * back to the first `<h1>`, then to the filename stem).
  *
- *   - Top level must be a JSON array of objects.
- *   - Each object must have a string `html` field; non-strings are skipped.
- *   - `title` is optional; falsy or non-string titles default to "Untitled App".
- *   - Titles are truncated to 100 characters.
- *   - Items are written in batch to `/users/{uid}/miniapps/` with a freshly
- *     generated id per row and `order: index - total` so the import lands at
- *     the top of the library.
+ * Writes to `/users/{uid}/miniapps/` with `order: -1` so the import lands at
+ * the top of the library (matches the pre-migration ordering behavior).
  *
  * Magic Generator (Gemini) deliberately stays inside the editor body; it is
- * NOT surfaced here as `aiAssist`, per the Wave 2-MA brief.
+ * NOT surfaced here as `aiAssist`, per the original MiniApp brief.
  */
 
 import React from 'react';
@@ -37,69 +33,75 @@ export interface MiniAppImportRow {
 /** What the adapter hands the wizard across parse → validate → save. */
 export interface MiniAppImportData {
   rows: MiniAppImportRow[];
-  /** Rows that were skipped during parse (no string `html`). */
-  skipped: number;
 }
 
 const MAX_TITLE_LENGTH = 100;
 
-function normalizeRow(raw: unknown): MiniAppImportRow | null {
-  if (typeof raw !== 'object' || raw === null) return null;
-  const record = raw as Record<string, unknown>;
-  if (typeof record.html !== 'string') return null;
-  const rawTitle =
-    typeof record.title === 'string' && record.title ? record.title : '';
-  const title = rawTitle ? rawTitle.slice(0, MAX_TITLE_LENGTH) : 'Untitled App';
-  return { title, html: record.html };
+/** Strip a filename down to a reasonable fallback title. */
+function titleFromFileName(name: string | undefined): string {
+  if (!name) return 'Untitled App';
+  const stem = name.replace(/\.[^.]+$/, '').trim();
+  return stem ? stem.slice(0, MAX_TITLE_LENGTH) : 'Untitled App';
 }
 
-async function readPayloadText(source: ImportSourcePayload): Promise<string> {
-  if (source.kind === 'json') return source.text;
-  if (source.kind === 'csv') return source.text;
+/**
+ * Extract a human-readable title from an HTML document. Tries `<title>`, then
+ * the first `<h1>`. Returns an empty string if neither is present.
+ */
+function titleFromHtml(html: string): string {
+  const titleMatch = html.match(/<title[^>]*>([\s\S]*?)<\/title>/i);
+  const titleText = titleMatch?.[1]?.replace(/\s+/g, ' ').trim();
+  if (titleText) return titleText.slice(0, MAX_TITLE_LENGTH);
+
+  const h1Match = html.match(/<h1[^>]*>([\s\S]*?)<\/h1>/i);
+  const h1Text = h1Match?.[1]
+    ?.replace(/<[^>]+>/g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+  if (h1Text) return h1Text.slice(0, MAX_TITLE_LENGTH);
+
+  return '';
+}
+
+async function readSourceAsHtml(
+  source: ImportSourcePayload
+): Promise<{ text: string; fileName?: string }> {
+  if (source.kind === 'html') {
+    return { text: source.text, fileName: source.fileName };
+  }
   if (source.kind === 'file') {
-    return await source.file.text();
+    const text = await source.file.text();
+    return { text, fileName: source.file.name };
   }
   throw new Error(
-    `MiniApp import does not support source kind: ${source.kind}`
+    `MiniApp import only accepts HTML files. Got source kind: ${source.kind}.`
   );
 }
 
 async function parseMiniAppImport(
   source: ImportSourcePayload
 ): Promise<ImportParseResult<MiniAppImportData>> {
-  const text = await readPayloadText(source);
+  const { text, fileName } = await readSourceAsHtml(source);
 
-  let parsedJson: unknown;
-  try {
-    parsedJson = JSON.parse(text);
-  } catch {
-    throw new Error(
-      'The selected file is not valid JSON. Export from SpartBoard to get a compatible file.'
-    );
+  const trimmed = text.trim();
+  if (trimmed.length === 0) {
+    throw new Error('The selected file is empty.');
   }
 
-  if (!Array.isArray(parsedJson)) {
-    throw new Error(
-      'Expected a JSON array of mini-app objects. Export from SpartBoard to get a compatible file.'
-    );
-  }
-
-  let skipped = 0;
-  const rows: MiniAppImportRow[] = [];
-  for (const raw of parsedJson) {
-    const row = normalizeRow(raw);
-    if (row) rows.push(row);
-    else skipped++;
-  }
-
+  // Light sanity check — warn (not block) if it doesn't look like HTML. An
+  // iframe srcdoc can still render a bare fragment, so we don't reject.
+  const looksLikeHtml = /<\/?[a-z][\s\S]*>/i.test(trimmed);
   const warnings: string[] = [];
-  if (skipped > 0) {
+  if (!looksLikeHtml) {
     warnings.push(
-      `Skipped ${skipped} ${skipped === 1 ? 'entry' : 'entries'} with missing or invalid HTML.`
+      "That file doesn't look like HTML, but we'll try to run it anyway."
     );
   }
 
-  return { data: { rows, skipped }, warnings };
+  const derivedTitle = titleFromHtml(trimmed) || titleFromFileName(fileName);
+
+  const row: MiniAppImportRow = { title: derivedTitle, html: text };
+  return { data: { rows: [row] }, warnings };
 }
 
 function validateMiniAppImport(
@@ -108,17 +110,13 @@ function validateMiniAppImport(
   if (data.rows.length === 0) {
     return {
       ok: false,
-      errors: [
-        'No importable apps were found. Each entry needs an `html` string.',
-      ],
+      errors: ['No importable app was found in the selected file.'],
     };
   }
   return { ok: true, errors: [] };
 }
 
 function renderMiniAppPreview(data: MiniAppImportData): React.ReactElement {
-  const preview = data.rows.slice(0, 8);
-  const remaining = data.rows.length - preview.length;
   return React.createElement(
     'div',
     { className: 'flex flex-col gap-2' },
@@ -130,7 +128,7 @@ function renderMiniAppPreview(data: MiniAppImportData): React.ReactElement {
     React.createElement(
       'ul',
       { className: 'flex flex-col gap-1.5' },
-      ...preview.map((row, idx) =>
+      ...data.rows.map((row, idx) =>
         React.createElement(
           'li',
           {
@@ -158,14 +156,7 @@ function renderMiniAppPreview(data: MiniAppImportData): React.ReactElement {
           )
         )
       )
-    ),
-    remaining > 0
-      ? React.createElement(
-          'p',
-          { className: 'text-xs text-slate-500' },
-          `…and ${remaining} more.`
-        )
-      : null
+    )
   );
 }
 
@@ -178,11 +169,11 @@ export function createMiniAppImportAdapter(
 ): ImportAdapter<MiniAppImportData> {
   return {
     widgetLabel: 'Mini App',
-    supportedSources: ['json', 'file'],
+    supportedSources: ['html'],
     parse: parseMiniAppImport,
     validate: validateMiniAppImport,
     renderPreview: renderMiniAppPreview,
-    async save(data) {
+    async save(data, title) {
       if (!userId) throw new Error('Not authenticated');
       if (data.rows.length === 0) return;
 
@@ -192,13 +183,19 @@ export function createMiniAppImportAdapter(
 
       data.rows.forEach((row, index) => {
         const id = crypto.randomUUID();
+        // When the user typed a title in the confirm step, apply it to the
+        // single-row import. For multi-row (future) we leave per-row titles.
+        const resolvedTitle =
+          total === 1 && title && title.trim()
+            ? title.trim().slice(0, MAX_TITLE_LENGTH)
+            : row.title;
         const appData: MiniAppItem = {
           id,
-          title: row.title,
+          title: resolvedTitle,
           html: row.html,
           createdAt: Date.now(),
-          // Matches the pre-migration behavior: new imports land at the top
-          // by taking strictly smaller `order` values than anything existing.
+          // New imports land at the top by taking strictly smaller `order`
+          // values than anything existing (matches pre-migration behavior).
           order: index - total,
         };
         batch.set(doc(appsRef, id), appData);

--- a/components/widgets/MiniApp/components/MiniAppManager.tsx
+++ b/components/widgets/MiniApp/components/MiniAppManager.tsx
@@ -415,7 +415,7 @@ export const MiniAppManager: React.FC<MiniAppManagerProps> = ({
 
   const personalEmpty = (
     <div className="flex flex-col items-center justify-center gap-3 text-center py-10 text-slate-400">
-      <div className="rounded-2xl border border-dashed border-slate-300 bg-white p-5">
+      <div className="rounded-2xl border border-dashed border-slate-300/70 bg-white/60 backdrop-blur-sm p-5">
         <Box className="h-8 w-8 stroke-slate-300" />
       </div>
       <div>
@@ -431,7 +431,7 @@ export const MiniAppManager: React.FC<MiniAppManagerProps> = ({
 
   const globalEmpty = (
     <div className="flex flex-col items-center justify-center gap-3 text-center py-10 text-slate-400">
-      <div className="rounded-2xl border border-dashed border-slate-300 bg-white p-5">
+      <div className="rounded-2xl border border-dashed border-slate-300/70 bg-white/60 backdrop-blur-sm p-5">
         <Globe className="h-8 w-8 stroke-slate-300" />
       </div>
       <div>

--- a/tests/components/ImportWizard.test.tsx
+++ b/tests/components/ImportWizard.test.tsx
@@ -25,6 +25,7 @@ interface MakeAdapterOptions {
   aiAssist?: ImportAdapter<FakeData>['aiAssist'];
   templateHelper?: ImportAdapter<FakeData>['templateHelper'];
   supportedSources?: ImportAdapter<FakeData>['supportedSources'];
+  suggestTitle?: (data: FakeData) => string | undefined;
 }
 
 function makeAdapter(opts: MakeAdapterOptions = {}): {
@@ -69,6 +70,7 @@ function makeAdapter(opts: MakeAdapterOptions = {}): {
     ),
     save: saveSpy as unknown as ImportAdapter<FakeData>['save'],
     aiAssist,
+    suggestTitle: opts.suggestTitle,
   };
   return { adapter, parseSpy, validateSpy, saveSpy, aiGenerateSpy };
 }
@@ -425,6 +427,61 @@ describe('ImportWizard', () => {
     expect(
       screen.getByText('Ambiguous timestamp on row 5')
     ).toBeInTheDocument();
+  });
+
+  it('prefills the title from adapter.suggestTitle after a successful parse when the input is empty', async () => {
+    const { adapter } = makeAdapter({
+      suggestTitle: (data) => `Derived ${data.rows.length}`,
+    });
+    renderWizard(adapter);
+
+    // Parse a sheet URL — suggestTitle should fire because title state is empty.
+    const urlField = screen.getByLabelText('Google Sheet URL');
+    fireEvent.change(urlField, {
+      target: { value: 'https://docs.google.com/spreadsheets/d/abc' },
+    });
+    fireEvent.click(
+      urlField.parentElement?.querySelector('button') as HTMLButtonElement
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('preview')).toBeInTheDocument();
+    });
+
+    // Advance to the Confirm step where the Title input lives.
+    fireEvent.click(screen.getByRole('button', { name: /continue/i }));
+
+    const titleInput = await screen.findByLabelText('Title');
+    expect((titleInput as HTMLInputElement).value).toBe('Derived 2');
+  });
+
+  it('does not overwrite an already-typed title on subsequent parses', async () => {
+    const suggestTitleSpy = vi.fn(
+      (data: FakeData) => `Derived ${data.rows[0]}`
+    );
+    const { adapter } = makeAdapter({
+      suggestTitle: suggestTitleSpy,
+    });
+    // defaultTitle simulates a title the user (or caller) has already supplied.
+    renderWizard(adapter, { defaultTitle: 'User Typed Title' });
+
+    // First parse — adapter has a suggestion, but the input is non-empty, so
+    // the user-provided title must stand.
+    const urlField = screen.getByLabelText('Google Sheet URL');
+    fireEvent.change(urlField, {
+      target: { value: 'https://docs.google.com/spreadsheets/d/abc' },
+    });
+    fireEvent.click(
+      urlField.parentElement?.querySelector('button') as HTMLButtonElement
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId('preview')).toBeInTheDocument();
+    });
+
+    // Advance to Confirm and verify the user's title is still there.
+    fireEvent.click(screen.getByRole('button', { name: /continue/i }));
+    const titleInput = await screen.findByLabelText('Title');
+    expect((titleInput as HTMLInputElement).value).toBe('User Typed Title');
   });
 
   it('shows the template helper when adapter exposes templateHelper', () => {


### PR DESCRIPTION
## Summary

Five UX fixes for the unified library shell used by Quiz, Video Activity, Guided Learning, and MiniApp widgets.

- **Issue 1 — Transparency:** Removed hardcoded `bg-white` / `bg-slate-50` on the shell header/tabs/toolbar/sidebar and cards. Replaced with translucent `bg-white/60..80 backdrop-blur-sm` surfaces so widget opacity and the glassmorphism design system actually take effect.
- **Issue 2 — Dynamic scaling:** Added container-query (`cqmin`) sizing throughout `LibraryShell` and `LibraryItemCard` — header title, tabs, action buttons, card titles, subtitles, icons, padding, and gap. Buttons no longer push off-screen at small widget widths. Header action labels collapse to icon-only below a width threshold.
- **Issue 3 — Floating toolbar over modals:** `DraggableWindow`'s tool menu used to render at `Z_INDEX.toolMenu` (12000) above modals (10000). Extracted the modal-open count into a small `modalStore` with a `useHasOpenModal` hook, and `DraggableWindow` now hides `showTools` whenever any portalled `Modal` is mounted. The editor, import wizard, and assignment modals are no longer obscured.
- **Issue 4 — Hidden secondary actions:** Library cards now render Edit / Delete (and other `secondaryActions`) as inline icon+label buttons by default. A `ResizeObserver` on each card measures width and collapses to the 3-dot `OverflowMenu` only when the card is too narrow. Destructive buttons keep the brand-red tone.
- **Issue 5 — MiniApp JSON import:** Teachers don't know what JSON is. Replaced with single-file HTML upload. The new adapter derives a title from `<title>` → first `<h1>` → filename stem, and saves to `/users/{uid}/miniapps/` with `order` that keeps new imports at the top. Added `'html'` to `ImportSourceKind` and threaded `.html` / `.htm` through `ImportWizard`.

## Test plan

- [ ] Resize Quiz / VideoActivity / GuidedLearning / MiniApp widgets from ~300×240 up to ~900×700 — verify header buttons, tabs, and cards scale smoothly and no control wraps off-screen.
- [ ] Open the editor / import / assignment modals from each widget while the widget is selected — the widget's floating toolbar should disappear while the modal is open and re-appear on close.
- [ ] Verify Edit / Delete / Copy Link etc. appear inline on list-view cards and collapse into the 3-dot menu only when the card gets narrow.
- [ ] Lower widget opacity / change global transparency — confirm the library surface visibly honors it (glass look instead of solid white).
- [ ] Import a `.html` file into the MiniApp library; verify the title is auto-detected from the HTML `<title>`, that it saves, and lands at the top of the library.
- [ ] `pnpm run validate` — type-check, lint, format-check, and all 1,248 unit tests pass.

https://claude.ai/code/session_01TgwcpJC8N2mH8XqYak28ps