### PR TITLE
feat(library): wire folders into widget libraries (Wave 3-B-3)

### DIFF
--- a/components/common/library/FolderSidebar.tsx
+++ b/components/common/library/FolderSidebar.tsx
@@ -12,8 +12,10 @@
 
 import React, { useMemo, useState } from 'react';
 import { FolderPlus, Inbox, X, AlertTriangle } from 'lucide-react';
+import { useDroppable } from '@dnd-kit/core';
 import type { LibraryFolder, LibraryFolderWidget } from '@/types';
 import { FolderTree } from './FolderTree';
+import { folderDroppableId, type FolderDropData } from './folderDropTargets';
 
 export type FolderDeleteMode = 'move-to-parent' | 'delete-all';
 
@@ -39,6 +41,13 @@ export interface FolderSidebarProps {
 
   loading?: boolean;
   error?: string | null;
+
+  /**
+   * When true, folder rows (and the "All items" root) become drop targets via
+   * `useDroppable`. Must be rendered inside a `LibraryDndContext`. The parent
+   * context is responsible for routing drops to `useFolders.moveItem(...)`.
+   */
+  enableDrop?: boolean;
 }
 
 export const FolderSidebar: React.FC<FolderSidebarProps> = ({
@@ -52,7 +61,18 @@ export const FolderSidebar: React.FC<FolderSidebarProps> = ({
   onDeleteFolder,
   loading = false,
   error = null,
+  enableDrop = false,
 }) => {
+  const rootDropData = useMemo<FolderDropData>(
+    () => ({ type: 'folder', folderId: null }),
+    []
+  );
+  const rootDroppable = useDroppable({
+    id: folderDroppableId(null),
+    data: rootDropData,
+    disabled: !enableDrop,
+  });
+  const isRootOver = enableDrop && rootDroppable.isOver;
   const [expanded, setExpanded] = useState<Record<string, boolean>>({});
   const [openMenuId, setOpenMenuId] = useState<string | null>(null);
   const [renamingId, setRenamingId] = useState<string | null>(null);
@@ -175,12 +195,17 @@ export const FolderSidebar: React.FC<FolderSidebarProps> = ({
 
       {/* Root / "All items" entry */}
       <button
+        ref={enableDrop ? rootDroppable.setNodeRef : undefined}
         type="button"
         onClick={() => onSelectFolder(null)}
         className={`flex items-center gap-2 px-2 py-1.5 rounded-lg text-sm font-semibold text-left transition-colors ${
           selectedFolderId === null
             ? 'bg-brand-blue-primary text-white'
             : 'text-brand-blue-dark hover:bg-white'
+        } ${
+          isRootOver
+            ? 'ring-2 ring-brand-blue-primary/60 bg-brand-blue-lighter/40'
+            : ''
         }`}
       >
         <Inbox className="w-4 h-4" />
@@ -229,6 +254,7 @@ export const FolderSidebar: React.FC<FolderSidebarProps> = ({
         folders={folders}
         parentId={null}
         depth={0}
+        enableDrop={enableDrop}
         selectedFolderId={selectedFolderId}
         onSelectFolder={onSelectFolder}
         expanded={expanded}

--- a/components/common/library/FolderTree.tsx
+++ b/components/common/library/FolderTree.tsx
@@ -172,7 +172,7 @@ const FolderRow: React.FC<FolderRowProps> = ({
   return (
     <div
       ref={enableDrop ? droppable.setNodeRef : undefined}
-      className={`group relative flex items-center gap-1 rounded-lg text-sm font-medium cursor-pointer select-none transition-colors ${
+      className={`group relative flex items-center gap-1 rounded-lg text-sm font-medium select-none transition-colors ${
         isSelected
           ? 'bg-brand-blue-primary/10 text-brand-blue-dark'
           : 'text-slate-700 hover:bg-slate-100'
@@ -182,25 +182,6 @@ const FolderRow: React.FC<FolderRowProps> = ({
           : ''
       }`}
       style={{ paddingLeft: depth * INDENT_PX + 4 }}
-      onClick={() => onSelectFolder(folder.id)}
-      onKeyDown={(e) => {
-        if (e.key === 'Enter' || e.key === ' ') {
-          e.preventDefault();
-          onSelectFolder(folder.id);
-        } else if (e.key === 'ArrowRight' && hasChildren && !isExpanded) {
-          e.preventDefault();
-          onToggleExpanded(folder.id);
-        } else if (e.key === 'ArrowLeft' && hasChildren && isExpanded) {
-          e.preventDefault();
-          onToggleExpanded(folder.id);
-        } else if (e.key === 'F2') {
-          e.preventDefault();
-          onStartRename(folder.id);
-        }
-      }}
-      tabIndex={0}
-      role="button"
-      aria-label={`${folder.name}, ${count} items`}
     >
       {/* Expand/collapse chevron. */}
       <button
@@ -222,24 +203,56 @@ const FolderRow: React.FC<FolderRowProps> = ({
         ) : null}
       </button>
 
-      {/* Folder icon. */}
-      <span className="shrink-0 text-brand-blue-primary/80">
-        {isExpanded && hasChildren ? (
-          <FolderOpen size={14} />
-        ) : (
-          <Folder size={14} />
-        )}
-      </span>
-
-      {/* Folder name (or inline rename input). */}
+      {/* Primary select action — a real <button> wrapping the folder icon +
+          name. Kept distinct from the outer container so the chevron and
+          overflow menu buttons aren't nested inside another interactive
+          element (HTML spec + screen-reader clarity). During inline rename
+          we render the input in its place to avoid nesting an <input> inside
+          a <button>, which is invalid HTML. */}
       {isRenaming ? (
-        <RenameInput
-          initial={folder.name}
-          onCommit={(next) => onCommitRename(folder.id, next)}
-          onCancel={onCancelRename}
-        />
+        <span className="flex-1 min-w-0 flex items-center gap-1 py-1">
+          <span className="shrink-0 text-brand-blue-primary/80">
+            {isExpanded && hasChildren ? (
+              <FolderOpen size={14} />
+            ) : (
+              <Folder size={14} />
+            )}
+          </span>
+          <RenameInput
+            initial={folder.name}
+            onCommit={(next) => onCommitRename(folder.id, next)}
+            onCancel={onCancelRename}
+          />
+        </span>
       ) : (
-        <span className="flex-1 min-w-0 truncate py-1">{folder.name}</span>
+        <button
+          type="button"
+          onClick={() => onSelectFolder(folder.id)}
+          onKeyDown={(e) => {
+            if (e.key === 'ArrowRight' && hasChildren && !isExpanded) {
+              e.preventDefault();
+              onToggleExpanded(folder.id);
+            } else if (e.key === 'ArrowLeft' && hasChildren && isExpanded) {
+              e.preventDefault();
+              onToggleExpanded(folder.id);
+            } else if (e.key === 'F2') {
+              e.preventDefault();
+              onStartRename(folder.id);
+            }
+          }}
+          className="flex-1 min-w-0 flex items-center gap-1 py-1 text-left cursor-pointer"
+          aria-label={`${folder.name}, ${count} items`}
+          aria-pressed={isSelected}
+        >
+          <span className="shrink-0 text-brand-blue-primary/80">
+            {isExpanded && hasChildren ? (
+              <FolderOpen size={14} />
+            ) : (
+              <Folder size={14} />
+            )}
+          </span>
+          <span className="flex-1 min-w-0 truncate">{folder.name}</span>
+        </button>
       )}
 
       {/* Item count badge. */}

--- a/components/common/library/FolderTree.tsx
+++ b/components/common/library/FolderTree.tsx
@@ -20,7 +20,9 @@ import {
   ChevronDown,
   MoreHorizontal,
 } from 'lucide-react';
+import { useDroppable } from '@dnd-kit/core';
 import type { LibraryFolder } from '@/types';
+import { folderDroppableId, type FolderDropData } from './folderDropTargets';
 
 export interface FolderTreeProps {
   /** Flat folder list — the tree shape is derived from `parentId`. */
@@ -57,6 +59,13 @@ export interface FolderTreeProps {
   onCreateChild: (parentId: string) => void;
   /** Move a folder up to the root (null parent). */
   onMoveToRoot: (folderId: string) => void;
+
+  /**
+   * When true, each folder row becomes a `useDroppable` target. Must be
+   * rendered inside a `DndContext` (see `LibraryDndContext`). Drops fire via
+   * the parent context's `onDropOnFolder` callback, not through this prop.
+   */
+  enableDrop?: boolean;
 }
 
 const INDENT_PX = 14;
@@ -104,6 +113,229 @@ const RenameInput: React.FC<{
   );
 };
 
+interface FolderRowProps {
+  folder: LibraryFolder;
+  depth: number;
+  hasChildren: boolean;
+  isExpanded: boolean;
+  isSelected: boolean;
+  isMenuOpen: boolean;
+  isRenaming: boolean;
+  count: number;
+  enableDrop: boolean;
+  onSelectFolder: (folderId: string | null) => void;
+  onToggleExpanded: (folderId: string) => void;
+  onOpenMenu: (folderId: string | null) => void;
+  onStartRename: (folderId: string) => void;
+  onCommitRename: (folderId: string, nextName: string) => void;
+  onCancelRename: () => void;
+  onRequestDelete: (folder: LibraryFolder) => void;
+  onCreateChild: (parentId: string) => void;
+  onMoveToRoot: (folderId: string) => void;
+}
+
+/**
+ * Single folder row. Extracted into a component so we can call the
+ * `useDroppable` hook per-row without violating the Rules of Hooks.
+ */
+const FolderRow: React.FC<FolderRowProps> = ({
+  folder,
+  depth,
+  hasChildren,
+  isExpanded,
+  isSelected,
+  isMenuOpen,
+  isRenaming,
+  count,
+  enableDrop,
+  onSelectFolder,
+  onToggleExpanded,
+  onOpenMenu,
+  onStartRename,
+  onCommitRename,
+  onCancelRename,
+  onRequestDelete,
+  onCreateChild,
+  onMoveToRoot,
+}) => {
+  const dropData = useMemo<FolderDropData>(
+    () => ({ type: 'folder', folderId: folder.id }),
+    [folder.id]
+  );
+  const droppable = useDroppable({
+    id: folderDroppableId(folder.id),
+    data: dropData,
+    disabled: !enableDrop,
+  });
+  const isOver = enableDrop && droppable.isOver;
+
+  return (
+    <div
+      ref={enableDrop ? droppable.setNodeRef : undefined}
+      className={`group relative flex items-center gap-1 rounded-lg text-sm font-medium cursor-pointer select-none transition-colors ${
+        isSelected
+          ? 'bg-brand-blue-primary/10 text-brand-blue-dark'
+          : 'text-slate-700 hover:bg-slate-100'
+      } ${
+        isOver
+          ? 'ring-2 ring-brand-blue-primary/60 bg-brand-blue-lighter/40'
+          : ''
+      }`}
+      style={{ paddingLeft: depth * INDENT_PX + 4 }}
+      onClick={() => onSelectFolder(folder.id)}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          onSelectFolder(folder.id);
+        } else if (e.key === 'ArrowRight' && hasChildren && !isExpanded) {
+          e.preventDefault();
+          onToggleExpanded(folder.id);
+        } else if (e.key === 'ArrowLeft' && hasChildren && isExpanded) {
+          e.preventDefault();
+          onToggleExpanded(folder.id);
+        } else if (e.key === 'F2') {
+          e.preventDefault();
+          onStartRename(folder.id);
+        }
+      }}
+      tabIndex={0}
+      role="button"
+      aria-label={`${folder.name}, ${count} items`}
+    >
+      {/* Expand/collapse chevron. */}
+      <button
+        type="button"
+        onClick={(e) => {
+          e.stopPropagation();
+          if (hasChildren) onToggleExpanded(folder.id);
+        }}
+        className="shrink-0 w-4 h-5 flex items-center justify-center text-slate-400"
+        aria-label={isExpanded ? 'Collapse' : 'Expand'}
+        tabIndex={-1}
+      >
+        {hasChildren ? (
+          isExpanded ? (
+            <ChevronDown size={12} />
+          ) : (
+            <ChevronRight size={12} />
+          )
+        ) : null}
+      </button>
+
+      {/* Folder icon. */}
+      <span className="shrink-0 text-brand-blue-primary/80">
+        {isExpanded && hasChildren ? (
+          <FolderOpen size={14} />
+        ) : (
+          <Folder size={14} />
+        )}
+      </span>
+
+      {/* Folder name (or inline rename input). */}
+      {isRenaming ? (
+        <RenameInput
+          initial={folder.name}
+          onCommit={(next) => onCommitRename(folder.id, next)}
+          onCancel={onCancelRename}
+        />
+      ) : (
+        <span className="flex-1 min-w-0 truncate py-1">{folder.name}</span>
+      )}
+
+      {/* Item count badge. */}
+      {!isRenaming && count > 0 && (
+        <span
+          className={`shrink-0 inline-flex items-center justify-center rounded-full px-1.5 text-[10px] font-bold leading-none ${
+            isSelected
+              ? 'bg-brand-blue-primary/20 text-brand-blue-dark'
+              : 'bg-slate-200 text-slate-600'
+          }`}
+        >
+          {count}
+        </span>
+      )}
+
+      {/* Overflow menu trigger. */}
+      {!isRenaming && (
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation();
+            onOpenMenu(isMenuOpen ? null : folder.id);
+          }}
+          aria-label={`Actions for ${folder.name}`}
+          aria-haspopup="menu"
+          aria-expanded={isMenuOpen}
+          className={`shrink-0 p-1 rounded-md text-slate-400 hover:text-brand-blue-dark hover:bg-white/60 ${
+            isMenuOpen
+              ? 'opacity-100'
+              : 'opacity-0 group-hover:opacity-100 group-focus-within:opacity-100'
+          }`}
+          tabIndex={-1}
+        >
+          <MoreHorizontal size={14} />
+        </button>
+      )}
+
+      {/* Overflow menu popover. */}
+      {isMenuOpen && (
+        <div
+          role="menu"
+          onClick={(e) => e.stopPropagation()}
+          className="absolute right-1 top-full mt-1 z-20 min-w-[160px] rounded-xl bg-white shadow-xl border border-slate-200 p-1 text-sm"
+        >
+          <button
+            type="button"
+            role="menuitem"
+            className="w-full text-left px-2.5 py-1.5 rounded-md hover:bg-slate-100 text-slate-700"
+            onClick={() => {
+              onOpenMenu(null);
+              onStartRename(folder.id);
+            }}
+          >
+            Rename
+          </button>
+          <button
+            type="button"
+            role="menuitem"
+            className="w-full text-left px-2.5 py-1.5 rounded-md hover:bg-slate-100 text-slate-700"
+            onClick={() => {
+              onOpenMenu(null);
+              onCreateChild(folder.id);
+            }}
+          >
+            New subfolder
+          </button>
+          {folder.parentId != null && (
+            <button
+              type="button"
+              role="menuitem"
+              className="w-full text-left px-2.5 py-1.5 rounded-md hover:bg-slate-100 text-slate-700"
+              onClick={() => {
+                onOpenMenu(null);
+                onMoveToRoot(folder.id);
+              }}
+            >
+              Move to root
+            </button>
+          )}
+          <button
+            type="button"
+            role="menuitem"
+            className="w-full text-left px-2.5 py-1.5 rounded-md hover:bg-brand-red-lighter/40 text-brand-red-dark"
+            onClick={() => {
+              onOpenMenu(null);
+              onRequestDelete(folder);
+            }}
+          >
+            Delete
+          </button>
+        </div>
+      )}
+    </div>
+  );
+};
+
 export const FolderTree: React.FC<FolderTreeProps> = ({
   folders,
   parentId = null,
@@ -122,6 +354,7 @@ export const FolderTree: React.FC<FolderTreeProps> = ({
   onRequestDelete,
   onCreateChild,
   onMoveToRoot,
+  enableDrop = false,
 }) => {
   // Group children by parentId once per render. Sorted input is expected
   // (the hook orders by `order` asc); still, sort defensively.
@@ -147,171 +380,26 @@ export const FolderTree: React.FC<FolderTreeProps> = ({
 
         return (
           <li key={folder.id} role="treeitem" aria-expanded={isExpanded}>
-            <div
-              className={`group relative flex items-center gap-1 rounded-lg text-sm font-medium cursor-pointer select-none transition-colors ${
-                isSelected
-                  ? 'bg-brand-blue-primary/10 text-brand-blue-dark'
-                  : 'text-slate-700 hover:bg-slate-100'
-              }`}
-              style={{ paddingLeft: depth * INDENT_PX + 4 }}
-              onClick={() => onSelectFolder(folder.id)}
-              onKeyDown={(e) => {
-                if (e.key === 'Enter' || e.key === ' ') {
-                  e.preventDefault();
-                  onSelectFolder(folder.id);
-                } else if (
-                  e.key === 'ArrowRight' &&
-                  hasChildren &&
-                  !isExpanded
-                ) {
-                  e.preventDefault();
-                  onToggleExpanded(folder.id);
-                } else if (e.key === 'ArrowLeft' && hasChildren && isExpanded) {
-                  e.preventDefault();
-                  onToggleExpanded(folder.id);
-                } else if (e.key === 'F2') {
-                  e.preventDefault();
-                  onStartRename(folder.id);
-                }
-              }}
-              tabIndex={0}
-              role="button"
-              aria-label={`${folder.name}, ${count} items`}
-            >
-              {/* Expand/collapse chevron (placeholder width when no children keeps alignment). */}
-              <button
-                type="button"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  if (hasChildren) onToggleExpanded(folder.id);
-                }}
-                className="shrink-0 w-4 h-5 flex items-center justify-center text-slate-400"
-                aria-label={isExpanded ? 'Collapse' : 'Expand'}
-                tabIndex={-1}
-              >
-                {hasChildren ? (
-                  isExpanded ? (
-                    <ChevronDown size={12} />
-                  ) : (
-                    <ChevronRight size={12} />
-                  )
-                ) : null}
-              </button>
-
-              {/* Folder icon. */}
-              <span className="shrink-0 text-brand-blue-primary/80">
-                {isExpanded && hasChildren ? (
-                  <FolderOpen size={14} />
-                ) : (
-                  <Folder size={14} />
-                )}
-              </span>
-
-              {/* Folder name (or inline rename input). */}
-              {isRenaming ? (
-                <RenameInput
-                  initial={folder.name}
-                  onCommit={(next) => onCommitRename(folder.id, next)}
-                  onCancel={onCancelRename}
-                />
-              ) : (
-                <span className="flex-1 min-w-0 truncate py-1">
-                  {folder.name}
-                </span>
-              )}
-
-              {/* Item count badge. */}
-              {!isRenaming && count > 0 && (
-                <span
-                  className={`shrink-0 inline-flex items-center justify-center rounded-full px-1.5 text-[10px] font-bold leading-none ${
-                    isSelected
-                      ? 'bg-brand-blue-primary/20 text-brand-blue-dark'
-                      : 'bg-slate-200 text-slate-600'
-                  }`}
-                >
-                  {count}
-                </span>
-              )}
-
-              {/* Overflow menu trigger. */}
-              {!isRenaming && (
-                <button
-                  type="button"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    onOpenMenu(isMenuOpen ? null : folder.id);
-                  }}
-                  aria-label={`Actions for ${folder.name}`}
-                  aria-haspopup="menu"
-                  aria-expanded={isMenuOpen}
-                  className={`shrink-0 p-1 rounded-md text-slate-400 hover:text-brand-blue-dark hover:bg-white/60 ${
-                    isMenuOpen
-                      ? 'opacity-100'
-                      : 'opacity-0 group-hover:opacity-100 group-focus-within:opacity-100'
-                  }`}
-                  tabIndex={-1}
-                >
-                  <MoreHorizontal size={14} />
-                </button>
-              )}
-
-              {/* Overflow menu popover. */}
-              {isMenuOpen && (
-                <div
-                  role="menu"
-                  onClick={(e) => e.stopPropagation()}
-                  className="absolute right-1 top-full mt-1 z-20 min-w-[160px] rounded-xl bg-white shadow-xl border border-slate-200 p-1 text-sm"
-                >
-                  <button
-                    type="button"
-                    role="menuitem"
-                    className="w-full text-left px-2.5 py-1.5 rounded-md hover:bg-slate-100 text-slate-700"
-                    onClick={() => {
-                      onOpenMenu(null);
-                      onStartRename(folder.id);
-                    }}
-                  >
-                    Rename
-                  </button>
-                  <button
-                    type="button"
-                    role="menuitem"
-                    className="w-full text-left px-2.5 py-1.5 rounded-md hover:bg-slate-100 text-slate-700"
-                    onClick={() => {
-                      onOpenMenu(null);
-                      onCreateChild(folder.id);
-                    }}
-                  >
-                    New subfolder
-                  </button>
-                  {folder.parentId != null && (
-                    <button
-                      type="button"
-                      role="menuitem"
-                      className="w-full text-left px-2.5 py-1.5 rounded-md hover:bg-slate-100 text-slate-700"
-                      onClick={() => {
-                        onOpenMenu(null);
-                        onMoveToRoot(folder.id);
-                      }}
-                    >
-                      Move to root
-                    </button>
-                  )}
-                  <button
-                    type="button"
-                    role="menuitem"
-                    className="w-full text-left px-2.5 py-1.5 rounded-md hover:bg-brand-red-lighter/40 text-brand-red-dark"
-                    onClick={() => {
-                      onOpenMenu(null);
-                      onRequestDelete(folder);
-                    }}
-                  >
-                    Delete
-                  </button>
-                </div>
-              )}
-            </div>
-
+            <FolderRow
+              folder={folder}
+              depth={depth}
+              hasChildren={hasChildren}
+              isExpanded={isExpanded}
+              isSelected={isSelected}
+              isMenuOpen={isMenuOpen}
+              isRenaming={isRenaming}
+              count={count}
+              enableDrop={enableDrop}
+              onSelectFolder={onSelectFolder}
+              onToggleExpanded={onToggleExpanded}
+              onOpenMenu={onOpenMenu}
+              onStartRename={onStartRename}
+              onCommitRename={onCommitRename}
+              onCancelRename={onCancelRename}
+              onRequestDelete={onRequestDelete}
+              onCreateChild={onCreateChild}
+              onMoveToRoot={onMoveToRoot}
+            />
             {/* Recurse into children when expanded. */}
             {isExpanded && hasChildren && (
               <FolderTree
@@ -332,6 +420,7 @@ export const FolderTree: React.FC<FolderTreeProps> = ({
                 onRequestDelete={onRequestDelete}
                 onCreateChild={onCreateChild}
                 onMoveToRoot={onMoveToRoot}
+                enableDrop={enableDrop}
               />
             )}
           </li>

--- a/components/common/library/LibraryDndContext.tsx
+++ b/components/common/library/LibraryDndContext.tsx
@@ -1,0 +1,136 @@
+/**
+ * LibraryDndContext — shared `DndContext` scope for folder-aware libraries.
+ *
+ * Wave 3-B-3: sharing a single `DndContext` between the grid (sortable cards)
+ * and the `FolderSidebar` (droppable folder nodes) is how we implement
+ * drag-to-folder. `dnd-kit` does not bubble drop events between nested
+ * `DndContext`s, so the grid must opt out of creating its own context
+ * (`LibraryGrid.useExternalDndContext={true}`) and let this wrapper own both
+ * sortable and droppable interactions.
+ *
+ * The wrapper is presentation-only — it takes the ordered list of sortable
+ * item ids (so reorder drops can compute the new ordering) plus two
+ * callbacks:
+ *   - `onReorder`       fires when a card is dropped on another card.
+ *   - `onDropOnFolder`  fires when a card is dropped on a folder node.
+ *
+ * Consumers supply `renderOverlay(activeId)` so the `DragOverlay` renders the
+ * same card shape as in the grid. The overlay is wrapped in
+ * `LibraryGridLockContext.Provider` so overlay cards render unlocked, matching
+ * the internal-DndContext behavior of `LibraryGrid`.
+ */
+
+import React, { useMemo, useState } from 'react';
+import {
+  DndContext,
+  DragOverlay,
+  KeyboardSensor,
+  PointerSensor,
+  closestCenter,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+  type DragStartEvent,
+} from '@dnd-kit/core';
+import { sortableKeyboardCoordinates } from '@dnd-kit/sortable';
+import { LibraryGridLockContext } from './LibraryGridLockContext';
+import type { FolderDropData } from './folderDropTargets';
+
+export interface LibraryDndContextProps {
+  /** Ordered list of draggable item ids in the grid. */
+  itemIds: string[];
+  /** Fires when a card is dropped on another card; receives the new order. */
+  onReorder?: (nextOrderedIds: string[]) => Promise<void> | void;
+  /** Fires when a card is dropped on a folder drop target. */
+  onDropOnFolder?: (
+    itemId: string,
+    folderId: string | null
+  ) => Promise<void> | void;
+  /**
+   * Render the dragged card inside `DragOverlay`. Return `null` if the active
+   * id is not a sortable card (e.g. future sidebar-to-sidebar drags).
+   */
+  renderOverlay?: (activeId: string) => React.ReactNode;
+  children: React.ReactNode;
+}
+
+export const LibraryDndContext: React.FC<LibraryDndContextProps> = ({
+  itemIds,
+  onReorder,
+  onDropOnFolder,
+  renderOverlay,
+  children,
+}) => {
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    })
+  );
+
+  const [activeId, setActiveId] = useState<string | null>(null);
+
+  const handleDragStart = (event: DragStartEvent): void => {
+    setActiveId(String(event.active.id));
+  };
+
+  const handleDragEnd = (event: DragEndEvent): void => {
+    setActiveId(null);
+    const { active, over } = event;
+    if (!over) return;
+
+    const overData = over.data.current as FolderDropData | undefined;
+    if (overData && overData.type === 'folder') {
+      if (onDropOnFolder) {
+        void Promise.resolve(
+          onDropOnFolder(String(active.id), overData.folderId)
+        );
+      }
+      return;
+    }
+
+    if (active.id === over.id) return;
+    if (!onReorder) return;
+
+    const oldIndex = itemIds.indexOf(String(active.id));
+    const newIndex = itemIds.indexOf(String(over.id));
+    if (oldIndex === -1 || newIndex === -1) return;
+
+    const next = [...itemIds];
+    const [moved] = next.splice(oldIndex, 1);
+    if (moved === undefined) return;
+    next.splice(newIndex, 0, moved);
+
+    void Promise.resolve(onReorder(next));
+  };
+
+  const handleDragCancel = (): void => {
+    setActiveId(null);
+  };
+
+  const overlayLockState = useMemo(
+    () => ({ locked: false, reason: undefined, dragDisabled: true }),
+    []
+  );
+
+  return (
+    <DndContext
+      sensors={sensors}
+      collisionDetection={closestCenter}
+      onDragStart={handleDragStart}
+      onDragEnd={handleDragEnd}
+      onDragCancel={handleDragCancel}
+    >
+      {children}
+      <DragOverlay>
+        {activeId != null && renderOverlay ? (
+          <LibraryGridLockContext.Provider value={overlayLockState}>
+            {renderOverlay(activeId)}
+          </LibraryGridLockContext.Provider>
+        ) : null}
+      </DragOverlay>
+    </DndContext>
+  );
+};
+
+export default LibraryDndContext;

--- a/components/common/library/LibraryDndContext.tsx
+++ b/components/common/library/LibraryDndContext.tsx
@@ -20,7 +20,7 @@
  * the internal-DndContext behavior of `LibraryGrid`.
  */
 
-import React, { useMemo, useState } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import {
   DndContext,
   DragOverlay,
@@ -70,43 +70,44 @@ export const LibraryDndContext: React.FC<LibraryDndContextProps> = ({
 
   const [activeId, setActiveId] = useState<string | null>(null);
 
-  const handleDragStart = (event: DragStartEvent): void => {
+  const handleDragStart = useCallback((event: DragStartEvent): void => {
     setActiveId(String(event.active.id));
-  };
+  }, []);
 
-  const handleDragEnd = (event: DragEndEvent): void => {
-    setActiveId(null);
-    const { active, over } = event;
-    if (!over) return;
+  const handleDragEnd = useCallback(
+    (event: DragEndEvent): void => {
+      setActiveId(null);
+      const { active, over } = event;
+      if (!over) return;
 
-    const overData = over.data.current as FolderDropData | undefined;
-    if (overData && overData.type === 'folder') {
-      if (onDropOnFolder) {
-        void Promise.resolve(
-          onDropOnFolder(String(active.id), overData.folderId)
-        );
+      const overData = over.data.current as FolderDropData | undefined;
+      if (overData && overData.type === 'folder') {
+        if (onDropOnFolder) {
+          void onDropOnFolder(String(active.id), overData.folderId);
+        }
+        return;
       }
-      return;
-    }
 
-    if (active.id === over.id) return;
-    if (!onReorder) return;
+      if (active.id === over.id) return;
+      if (!onReorder) return;
 
-    const oldIndex = itemIds.indexOf(String(active.id));
-    const newIndex = itemIds.indexOf(String(over.id));
-    if (oldIndex === -1 || newIndex === -1) return;
+      const oldIndex = itemIds.indexOf(String(active.id));
+      const newIndex = itemIds.indexOf(String(over.id));
+      if (oldIndex === -1 || newIndex === -1) return;
 
-    const next = [...itemIds];
-    const [moved] = next.splice(oldIndex, 1);
-    if (moved === undefined) return;
-    next.splice(newIndex, 0, moved);
+      const next = [...itemIds];
+      const [moved] = next.splice(oldIndex, 1);
+      if (moved === undefined) return;
+      next.splice(newIndex, 0, moved);
 
-    void Promise.resolve(onReorder(next));
-  };
+      void onReorder(next);
+    },
+    [itemIds, onDropOnFolder, onReorder]
+  );
 
-  const handleDragCancel = (): void => {
+  const handleDragCancel = useCallback((): void => {
     setActiveId(null);
-  };
+  }, []);
 
   const overlayLockState = useMemo(
     () => ({ locked: false, reason: undefined, dragDisabled: true }),

--- a/components/common/library/LibraryGrid.tsx
+++ b/components/common/library/LibraryGrid.tsx
@@ -11,6 +11,12 @@
  * — this is surfaced to cards via `LibraryGridLockContext`.
  *
  * The grid renders `emptyState` in place of the list when `items.length === 0`.
+ *
+ * Wave 3-B-3 adds an opt-in `useExternalDndContext` mode. When true, the grid
+ * renders only the `SortableContext` and defers `DndContext` + `DragOverlay`
+ * ownership to the parent (typically `LibraryDndContext`). This is what the
+ * folder-drag-drop flow uses to share a single DndContext across both the
+ * grid and the `FolderSidebar` so that cards can be dropped on folders.
  */
 
 import React, { useMemo, useState } from 'react';
@@ -34,7 +40,18 @@ import {
 import type { LibraryGridProps } from './types';
 import { LibraryGridLockContext } from './LibraryGridLockContext';
 
-export function LibraryGrid<TItem>(props: LibraryGridProps<TItem>) {
+interface LibraryGridExtraProps {
+  /**
+   * When true, the grid skips creating its own `DndContext` + `DragOverlay`
+   * and relies on a parent `DndContext` (e.g. `LibraryDndContext`). In this
+   * mode `onReorder` is ignored — the parent owns drag-end routing.
+   */
+  useExternalDndContext?: boolean;
+}
+
+export function LibraryGrid<TItem>(
+  props: LibraryGridProps<TItem> & LibraryGridExtraProps
+) {
   const {
     items,
     getId,
@@ -45,6 +62,7 @@ export function LibraryGrid<TItem>(props: LibraryGridProps<TItem>) {
     reorderLockedReason,
     layout = 'grid',
     emptyState,
+    useExternalDndContext = false,
   } = props;
 
   const sensors = useSensors(
@@ -118,6 +136,18 @@ export function LibraryGrid<TItem>(props: LibraryGridProps<TItem>) {
   const containerClass = isListLayout
     ? 'flex flex-col gap-3'
     : 'grid gap-3 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3';
+
+  if (useExternalDndContext) {
+    return (
+      <LibraryGridLockContext.Provider value={lockState}>
+        <SortableContext items={ids} strategy={strategy}>
+          <div className={containerClass} data-testid="library-grid">
+            {items.map((item, index) => renderCard(item, index))}
+          </div>
+        </SortableContext>
+      </LibraryGridLockContext.Provider>
+    );
+  }
 
   return (
     <LibraryGridLockContext.Provider value={lockState}>

--- a/components/common/library/folderDropTargets.ts
+++ b/components/common/library/folderDropTargets.ts
@@ -1,0 +1,24 @@
+/**
+ * folderDropTargets — shared helpers + types for folder drag/drop wiring.
+ *
+ * Extracted out of `LibraryDndContext.tsx` so the context file exports only a
+ * React component (required by the `react-refresh/only-export-components`
+ * lint rule to keep Fast Refresh happy in dev).
+ */
+
+/** Data attached to folder droppables via `useDroppable({ data: {...} })`. */
+export interface FolderDropData {
+  type: 'folder';
+  /** `null` means the "All items" root drop zone. */
+  folderId: string | null;
+}
+
+/**
+ * Droppable id prefix for folder drop targets. Prefixing keeps folder ids
+ * from ever colliding with sortable card ids in the same DndContext.
+ */
+export const FOLDER_DROPPABLE_PREFIX = 'folder:';
+
+/** Build the droppable id for a given folder (null = root). */
+export const folderDroppableId = (folderId: string | null): string =>
+  `${FOLDER_DROPPABLE_PREFIX}${folderId ?? 'root'}`;

--- a/components/common/library/folderFilters.ts
+++ b/components/common/library/folderFilters.ts
@@ -1,0 +1,72 @@
+/**
+ * Pure helpers for the per-widget folder navigation introduced in Wave 3-B-3.
+ *
+ * The four widget Managers (Quiz, VideoActivity, GuidedLearning, MiniApp) all
+ * filter their library items by a selected folder and bucket counts for the
+ * sidebar badges the same way. Keeping the logic here makes it trivial to test
+ * and guarantees the four call sites stay in sync.
+ *
+ * Conventions:
+ *   - `folderId: null | undefined` means the item is at the personal root.
+ *   - `selectedFolderId === null` means "no folder selected" (show everything
+ *     the caller passed in).
+ *   - The count bucket for root items is keyed under `ROOT_FOLDER_COUNT_KEY`.
+ */
+
+export const ROOT_FOLDER_COUNT_KEY = 'root';
+
+/** Minimum shape required for folder-based filtering / counting. */
+export interface HasFolderId {
+  folderId?: string | null;
+}
+
+/** Minimum shape for GuidedLearning-style entries that mix sources. */
+export interface HasFolderIdAndSource extends HasFolderId {
+  source: 'personal' | 'building';
+}
+
+/**
+ * Returns only the items whose `folderId` matches `selectedFolderId`. When
+ * `selectedFolderId` is `null` the caller hasn't picked a folder, so the full
+ * input list is returned unchanged.
+ */
+export function filterByFolder<T extends HasFolderId>(
+  items: T[],
+  selectedFolderId: string | null
+): T[] {
+  if (selectedFolderId === null) return items;
+  return items.filter((item) => (item.folderId ?? null) === selectedFolderId);
+}
+
+/**
+ * Buckets `items` by `folderId`, using `ROOT_FOLDER_COUNT_KEY` for items
+ * without one. The returned shape matches what `FolderSidebar` expects for its
+ * badge counts.
+ */
+export function countItemsByFolder<T extends HasFolderId>(
+  items: T[]
+): Record<string, number> {
+  const counts: Record<string, number> = {};
+  for (const item of items) {
+    const key = item.folderId ?? ROOT_FOLDER_COUNT_KEY;
+    counts[key] = (counts[key] ?? 0) + 1;
+  }
+  return counts;
+}
+
+/**
+ * GuidedLearning-style filter: folder selection only narrows the personal
+ * subset. Building entries are always retained so the toolbar's Source filter
+ * can still show a non-empty list when the teacher switches to "Building".
+ */
+export function filterSourcedEntriesByFolder<T extends HasFolderIdAndSource>(
+  entries: T[],
+  selectedFolderId: string | null
+): T[] {
+  if (selectedFolderId === null) return entries;
+  return entries.filter(
+    (e) =>
+      e.source === 'building' ||
+      (e.source === 'personal' && (e.folderId ?? null) === selectedFolderId)
+  );
+}

--- a/components/common/library/index.ts
+++ b/components/common/library/index.ts
@@ -26,6 +26,13 @@ export type { FolderDropData } from './folderDropTargets';
 export { FolderSidebar } from './FolderSidebar';
 export type { FolderSidebarProps, FolderDeleteMode } from './FolderSidebar';
 export { FolderTree } from './FolderTree';
+export {
+  ROOT_FOLDER_COUNT_KEY,
+  filterByFolder,
+  countItemsByFolder,
+  filterSourcedEntriesByFolder,
+} from './folderFilters';
+export type { HasFolderId, HasFolderIdAndSource } from './folderFilters';
 
 export type {
   LibraryTab,

--- a/components/common/library/index.ts
+++ b/components/common/library/index.ts
@@ -17,6 +17,15 @@ export { useSortableReorder } from './useSortableReorder';
 export { AssignModal } from './AssignModal';
 export { AssignmentArchiveCard } from './AssignmentArchiveCard';
 export { PeriodSelector } from './PeriodSelector';
+export { LibraryDndContext } from './LibraryDndContext';
+export {
+  folderDroppableId,
+  FOLDER_DROPPABLE_PREFIX,
+} from './folderDropTargets';
+export type { FolderDropData } from './folderDropTargets';
+export { FolderSidebar } from './FolderSidebar';
+export type { FolderSidebarProps, FolderDeleteMode } from './FolderSidebar';
+export { FolderTree } from './FolderTree';
 
 export type {
   LibraryTab,

--- a/components/widgets/GuidedLearning/Widget.tsx
+++ b/components/widgets/GuidedLearning/Widget.tsx
@@ -360,6 +360,7 @@ export const GuidedLearningWidget: React.FC<{ widget: WidgetData }> = ({
           <div className="h-full w-full">
             {config.view === 'library' && (
               <GuidedLearningManager
+                userId={user?.uid}
                 sets={sets}
                 buildingSets={buildingSets}
                 assignments={assignments}

--- a/components/widgets/GuidedLearning/components/GuidedLearningManager.tsx
+++ b/components/widgets/GuidedLearning/components/GuidedLearningManager.tsx
@@ -44,8 +44,11 @@ import { LibraryShell } from '@/components/common/library/LibraryShell';
 import { LibraryToolbar } from '@/components/common/library/LibraryToolbar';
 import { LibraryGrid } from '@/components/common/library/LibraryGrid';
 import { LibraryItemCard } from '@/components/common/library/LibraryItemCard';
+import { FolderSidebar } from '@/components/common/library/FolderSidebar';
+import { LibraryDndContext } from '@/components/common/library/LibraryDndContext';
 import { useLibraryView } from '@/components/common/library/useLibraryView';
 import { useSortableReorder } from '@/components/common/library/useSortableReorder';
+import { useFolders } from '@/hooks/useFolders';
 import { ScaledEmptyState } from '@/components/common/ScaledEmptyState';
 import type {
   LibraryBadge,
@@ -77,11 +80,15 @@ interface LibraryEntry {
   driveFileId?: string;
   /** Building-only: the hydrated building set so callers can pass it through. */
   buildingSet?: GuidedLearningSet;
+  /** Personal-only: current folder assignment (`null` = root). */
+  folderId?: string | null;
 }
 
 /* ─── Props ───────────────────────────────────────────────────────────────── */
 
 export interface GuidedLearningManagerProps {
+  /** Teacher's Firebase UID — scopes the folders subcollection. */
+  userId?: string;
   /** Personal set metadata (Drive-backed). */
   sets: GuidedLearningSetMetadata[];
   /** Admin-authored building sets (Firestore-backed). */
@@ -216,6 +223,7 @@ const buildLibraryEntries = (
     createdAt: meta.createdAt,
     order: meta.order,
     driveFileId: meta.driveFileId,
+    folderId: meta.folderId ?? null,
   }));
 
   const building: LibraryEntry[] = buildingSets.map((set) => ({
@@ -244,6 +252,7 @@ const formatDate = (ms: number): string =>
 /* ─── Component ───────────────────────────────────────────────────────────── */
 
 export const GuidedLearningManager: React.FC<GuidedLearningManagerProps> = ({
+  userId,
   sets,
   buildingSets,
   assignments,
@@ -271,10 +280,33 @@ export const GuidedLearningManager: React.FC<GuidedLearningManagerProps> = ({
 }) => {
   const [tab, setTab] = React.useState<LibraryTab>('library');
 
-  const allEntries = useMemo(
-    () => buildLibraryEntries(sets, buildingSets),
-    [sets, buildingSets]
+  // ─── Folder navigation (Wave 3-B-3) ─────────────────────────────────────
+  const folderState = useFolders(userId, 'guided_learning');
+  const [selectedFolderId, setSelectedFolderId] = React.useState<string | null>(
+    null
   );
+
+  const folderItemCounts = useMemo(() => {
+    const counts: Record<string, number> = {};
+    // Only personal sets participate in folders. Building sets are always at
+    // root (they're shared at the building level and have no folderId field).
+    for (const meta of sets) {
+      const key = meta.folderId ?? 'root';
+      counts[key] = (counts[key] ?? 0) + 1;
+    }
+    return counts;
+  }, [sets]);
+
+  const allEntries = useMemo(() => {
+    const entries = buildLibraryEntries(sets, buildingSets);
+    if (selectedFolderId === null) return entries;
+    // When a folder is selected, hide building entries (they can't live in a
+    // teacher's personal folder) and show only the matching personal entries.
+    return entries.filter(
+      (e) =>
+        e.source === 'personal' && (e.folderId ?? null) === selectedFolderId
+    );
+  }, [sets, buildingSets, selectedFolderId]);
 
   // ─── Toolbar state (search/sort/filter) via useLibraryView ────────────────
   const sourceFilter: LibraryFilter = {
@@ -324,10 +356,42 @@ export const GuidedLearningManager: React.FC<GuidedLearningManagerProps> = ({
     onCommit: onReorderCommit,
   });
 
-  const dragDisabled =
-    view.reorderLocked ||
-    activeSourceFilter !== 'personal' ||
-    personalEntries.length < 2;
+  // ─── Drop-to-folder handler ───────────────────────────────────────────────
+  const { moveItem } = folderState;
+  const handleDropOnFolder = useCallback(
+    async (itemId: string, folderId: string | null): Promise<void> => {
+      if (!userId) return;
+      // GL entry ids are prefixed "personal:" or "building:". Only personal
+      // entries participate in folders; building cards are `sortable={false}`
+      // so drops from them shouldn't fire, but we guard defensively.
+      if (!itemId.startsWith('personal:')) return;
+      const rawId = itemId.slice('personal:'.length);
+      try {
+        await moveItem(rawId, folderId);
+      } catch (err) {
+        console.error('[GuidedLearningManager] moveItem failed:', err);
+      }
+    },
+    [userId, moveItem]
+  );
+
+  const reorderDragActive =
+    !view.reorderLocked &&
+    activeSourceFilter === 'personal' &&
+    personalEntries.length >= 2;
+  // When folder drag is available we enable card drag even if manual reorder
+  // would be blocked (e.g. sort !== 'manual'). Drops on a folder tile move the
+  // item; drops on another card reorder (only honored when manual reorder is
+  // active — see `handleReorderDrop` below).
+  const enableCardDrag = Boolean(userId) || reorderDragActive;
+
+  const handleReorderDrop = useCallback(
+    (orderedIds: string[]) => {
+      if (!reorderDragActive) return;
+      void reorder.handleReorder(orderedIds);
+    },
+    [reorder, reorderDragActive]
+  );
 
   // ─── Counts for tabs ──────────────────────────────────────────────────────
   const activeAssignments = useMemo(
@@ -482,7 +546,7 @@ export const GuidedLearningManager: React.FC<GuidedLearningManagerProps> = ({
             ? () => onEdit(rawId, entry.driveFileId, entry.buildingSet)
             : undefined
         }
-        sortable={entry.source === 'personal'}
+        sortable={entry.source === 'personal' && enableCardDrag}
         viewMode={view.state.viewMode}
         meta={entry}
       />
@@ -600,11 +664,14 @@ export const GuidedLearningManager: React.FC<GuidedLearningManagerProps> = ({
           items={reorder.orderedItems}
           getId={(e) => e.id}
           renderCard={renderLibraryCard}
-          onReorder={reorder.handleReorder}
-          dragDisabled={dragDisabled}
-          reorderLocked={view.reorderLocked}
-          reorderLockedReason={view.reorderLockedReason}
+          onReorder={handleReorderDrop}
+          dragDisabled={!enableCardDrag}
+          reorderLocked={reorderDragActive ? view.reorderLocked : false}
+          reorderLockedReason={
+            reorderDragActive ? view.reorderLockedReason : undefined
+          }
           layout={view.state.viewMode}
+          useExternalDndContext={Boolean(userId)}
           emptyState={
             <ScaledEmptyState
               icon={BookOpen}
@@ -656,7 +723,85 @@ export const GuidedLearningManager: React.FC<GuidedLearningManagerProps> = ({
     );
   };
 
+  /* ─── Folder sidebar + DnD overlay ─────────────────────────────────────── */
+
+  const folderSidebarSlot =
+    tab === 'library' && userId ? (
+      <FolderSidebar
+        widget="guided_learning"
+        folders={folderState.folders}
+        loading={folderState.loading}
+        error={folderState.error}
+        selectedFolderId={selectedFolderId}
+        onSelectFolder={setSelectedFolderId}
+        itemCounts={folderItemCounts}
+        onCreateFolder={folderState.createFolder}
+        onRenameFolder={folderState.renameFolder}
+        onMoveFolder={folderState.moveFolder}
+        onDeleteFolder={folderState.deleteFolder}
+        enableDrop
+      />
+    ) : undefined;
+
+  const orderedIds = reorder.orderedItems.map((e) => e.id);
+
+  const renderDragOverlay = (activeId: string): React.ReactNode => {
+    const entry = reorder.orderedItems.find((e) => e.id === activeId);
+    if (!entry) return null;
+    const thumbnail = entry.imageUrl ? (
+      <img
+        src={entry.imageUrl}
+        alt=""
+        aria-hidden="true"
+        className="h-full w-full object-cover"
+      />
+    ) : (
+      <BookOpen className="h-5 w-5 text-slate-400" aria-hidden="true" />
+    );
+    const subtitle = (
+      <span>
+        {entry.stepCount} step{entry.stepCount === 1 ? '' : 's'}
+        {' · Updated '}
+        {formatDate(entry.updatedAt)}
+      </span>
+    );
+    return (
+      <LibraryItemCard<LibraryEntry>
+        id={entry.id}
+        title={entry.title}
+        subtitle={subtitle}
+        thumbnail={thumbnail}
+        badges={[{ label: MODE_LABELS[entry.mode], tone: 'info' }]}
+        primaryAction={{
+          label: 'Assign',
+          icon: Link2,
+          onClick: () => undefined,
+        }}
+        viewMode={view.state.viewMode}
+        sortable={false}
+        isDragOverlay
+        meta={entry}
+      />
+    );
+  };
+
   /* ─── Render ─────────────────────────────────────────────────────────────── */
+
+  const libraryBody =
+    tab === 'library' ? (
+      userId ? (
+        <LibraryDndContext
+          itemIds={orderedIds}
+          onDropOnFolder={handleDropOnFolder}
+          onReorder={handleReorderDrop}
+          renderOverlay={renderDragOverlay}
+        >
+          {renderLibraryTab()}
+        </LibraryDndContext>
+      ) : (
+        renderLibraryTab()
+      )
+    ) : null;
 
   return (
     <LibraryShell
@@ -670,6 +815,7 @@ export const GuidedLearningManager: React.FC<GuidedLearningManagerProps> = ({
       }}
       primaryAction={tab === 'library' ? primaryAction : undefined}
       secondaryActions={tab === 'library' ? secondaryActions : undefined}
+      filterSidebarSlot={folderSidebarSlot}
       toolbarSlot={
         tab === 'library' ? (
           <LibraryToolbar
@@ -689,7 +835,7 @@ export const GuidedLearningManager: React.FC<GuidedLearningManagerProps> = ({
         ) : undefined
       }
     >
-      {tab === 'library' && renderLibraryTab()}
+      {tab === 'library' && libraryBody}
       {tab === 'active' && renderAssignmentTab('active')}
       {tab === 'archive' && renderAssignmentTab('archive')}
     </LibraryShell>

--- a/components/widgets/GuidedLearning/components/GuidedLearningManager.tsx
+++ b/components/widgets/GuidedLearning/components/GuidedLearningManager.tsx
@@ -48,6 +48,10 @@ import { FolderSidebar } from '@/components/common/library/FolderSidebar';
 import { LibraryDndContext } from '@/components/common/library/LibraryDndContext';
 import { useLibraryView } from '@/components/common/library/useLibraryView';
 import { useSortableReorder } from '@/components/common/library/useSortableReorder';
+import {
+  countItemsByFolder,
+  filterSourcedEntriesByFolder,
+} from '@/components/common/library/folderFilters';
 import { useFolders } from '@/hooks/useFolders';
 import { ScaledEmptyState } from '@/components/common/ScaledEmptyState';
 import type {
@@ -301,29 +305,18 @@ export const GuidedLearningManager: React.FC<GuidedLearningManagerProps> = ({
     setSelectedFolderId(null);
   }
 
-  const folderItemCounts = useMemo(() => {
-    const counts: Record<string, number> = {};
-    // Only personal sets participate in folders. Building sets are always at
-    // root (they're shared at the building level and have no folderId field).
-    for (const meta of sets) {
-      const key = meta.folderId ?? 'root';
-      counts[key] = (counts[key] ?? 0) + 1;
-    }
-    return counts;
-  }, [sets]);
+  // Only personal sets participate in folders. Building sets are always at
+  // root (they're shared at the building level and have no folderId field).
+  const folderItemCounts = useMemo(() => countItemsByFolder(sets), [sets]);
 
-  const allEntries = useMemo(() => {
-    const entries = buildLibraryEntries(sets, buildingSets);
-    if (selectedFolderId === null) return entries;
-    // Folder selection only applies to personal sets. Keep building entries in
-    // the unified list so the toolbar Source filter can still switch to
-    // "Building" without producing a misleading empty state.
-    return entries.filter(
-      (e) =>
-        e.source === 'building' ||
-        (e.source === 'personal' && (e.folderId ?? null) === selectedFolderId)
-    );
-  }, [sets, buildingSets, selectedFolderId]);
+  const allEntries = useMemo(
+    () =>
+      filterSourcedEntriesByFolder(
+        buildLibraryEntries(sets, buildingSets),
+        selectedFolderId
+      ),
+    [sets, buildingSets, selectedFolderId]
+  );
 
   // ─── Toolbar state (search/sort/filter) via useLibraryView ────────────────
   const sourceFilter: LibraryFilter = {

--- a/components/widgets/GuidedLearning/components/GuidedLearningManager.tsx
+++ b/components/widgets/GuidedLearning/components/GuidedLearningManager.tsx
@@ -787,23 +787,7 @@ export const GuidedLearningManager: React.FC<GuidedLearningManagerProps> = ({
 
   /* ─── Render ─────────────────────────────────────────────────────────────── */
 
-  const libraryBody =
-    tab === 'library' ? (
-      userId ? (
-        <LibraryDndContext
-          itemIds={orderedIds}
-          onDropOnFolder={handleDropOnFolder}
-          onReorder={handleReorderDrop}
-          renderOverlay={renderDragOverlay}
-        >
-          {renderLibraryTab()}
-        </LibraryDndContext>
-      ) : (
-        renderLibraryTab()
-      )
-    ) : null;
-
-  return (
+  const shell = (
     <LibraryShell
       widgetLabel="Guided Learning"
       tab={tab}
@@ -835,9 +819,22 @@ export const GuidedLearningManager: React.FC<GuidedLearningManagerProps> = ({
         ) : undefined
       }
     >
-      {tab === 'library' && libraryBody}
+      {tab === 'library' && renderLibraryTab()}
       {tab === 'active' && renderAssignmentTab('active')}
       {tab === 'archive' && renderAssignmentTab('archive')}
     </LibraryShell>
+  );
+
+  return userId && tab === 'library' ? (
+    <LibraryDndContext
+      itemIds={orderedIds}
+      onDropOnFolder={handleDropOnFolder}
+      onReorder={handleReorderDrop}
+      renderOverlay={renderDragOverlay}
+    >
+      {shell}
+    </LibraryDndContext>
+  ) : (
+    shell
   );
 };

--- a/components/widgets/GuidedLearning/components/GuidedLearningManager.tsx
+++ b/components/widgets/GuidedLearning/components/GuidedLearningManager.tsx
@@ -286,6 +286,21 @@ export const GuidedLearningManager: React.FC<GuidedLearningManagerProps> = ({
     null
   );
 
+  // Reset folder selection when the signed-in user changes or the selected
+  // folder no longer exists (adjust-state-during-render pattern).
+  const [prevFolderUserId, setPrevFolderUserId] = React.useState(userId);
+  if (prevFolderUserId !== userId) {
+    setPrevFolderUserId(userId);
+    setSelectedFolderId(null);
+  }
+  if (
+    !folderState.loading &&
+    selectedFolderId !== null &&
+    !folderState.folders.some((f) => f.id === selectedFolderId)
+  ) {
+    setSelectedFolderId(null);
+  }
+
   const folderItemCounts = useMemo(() => {
     const counts: Record<string, number> = {};
     // Only personal sets participate in folders. Building sets are always at
@@ -300,11 +315,13 @@ export const GuidedLearningManager: React.FC<GuidedLearningManagerProps> = ({
   const allEntries = useMemo(() => {
     const entries = buildLibraryEntries(sets, buildingSets);
     if (selectedFolderId === null) return entries;
-    // When a folder is selected, hide building entries (they can't live in a
-    // teacher's personal folder) and show only the matching personal entries.
+    // Folder selection only applies to personal sets. Keep building entries in
+    // the unified list so the toolbar Source filter can still switch to
+    // "Building" without producing a misleading empty state.
     return entries.filter(
       (e) =>
-        e.source === 'personal' && (e.folderId ?? null) === selectedFolderId
+        e.source === 'building' ||
+        (e.source === 'personal' && (e.folderId ?? null) === selectedFolderId)
     );
   }, [sets, buildingSets, selectedFolderId]);
 

--- a/components/widgets/MiniApp/Widget.tsx
+++ b/components/widgets/MiniApp/Widget.tsx
@@ -847,6 +847,7 @@ export const MiniAppWidget: React.FC<WidgetComponentProps> = ({
         content={
           <div className="relative flex flex-col w-full h-full min-h-0">
             <MiniAppManager
+              userId={user?.uid}
               tab={managerTab}
               onTabChange={setManagerTab}
               personalLibrary={library}

--- a/components/widgets/MiniApp/components/MiniAppManager.tsx
+++ b/components/widgets/MiniApp/components/MiniAppManager.tsx
@@ -656,7 +656,7 @@ export const MiniAppManager: React.FC<MiniAppManagerProps> = ({
     // In the Global view we keep drag disabled — global items are read-only
     // and never move between folders.
     const enableCardDrag = Boolean(userId) && !isGlobalView;
-    const gridEl = (
+    tabContent = (
       <LibraryGrid<UnifiedRow>
         items={view.visibleItems}
         getId={getRowId}
@@ -672,52 +672,44 @@ export const MiniAppManager: React.FC<MiniAppManagerProps> = ({
         emptyState={empty}
       />
     );
-
-    if (enableCardDrag) {
-      const orderedIds = view.visibleItems.map(getRowId);
-      const renderDragOverlay = (activeId: string): React.ReactNode => {
-        const row = view.visibleItems.find((r) => getRowId(r) === activeId);
-        if (!row || row.kind !== 'personal') return null;
-        const app = row.item;
-        return (
-          <LibraryItemCard<MiniAppItem>
-            id={getRowId(row)}
-            title={app.title}
-            subtitle={
-              <span className="font-mono">
-                {(app.html.length / 1024).toFixed(1)} KB
-              </span>
-            }
-            thumbnail={
-              <div className="flex h-full w-full items-center justify-center bg-indigo-50 text-[10px] font-black uppercase tracking-widest text-indigo-600">
-                HTML
-              </div>
-            }
-            primaryAction={{
-              label: 'Assign',
-              icon: Link2,
-              onClick: () => undefined,
-            }}
-            viewMode={view.state.viewMode}
-            sortable={false}
-            isDragOverlay
-          />
-        );
-      };
-      tabContent = (
-        <LibraryDndContext
-          itemIds={orderedIds}
-          onDropOnFolder={handleDropOnFolder}
-          onReorder={(ids) => reorderHook.handleReorder(ids)}
-          renderOverlay={renderDragOverlay}
-        >
-          {gridEl}
-        </LibraryDndContext>
-      );
-    } else {
-      tabContent = gridEl;
-    }
   }
+
+  /* ── Shared DndContext wiring (must wrap full shell so FolderSidebar
+   *    droppables live in the same context as sortable cards) ───────────── */
+  const libraryDndEnabled =
+    tab === 'library' && Boolean(userId) && !isGlobalView;
+  const orderedRowIds = libraryDndEnabled
+    ? view.visibleItems.map(getRowId)
+    : [];
+  const renderLibraryDragOverlay = (activeId: string): React.ReactNode => {
+    const row = view.visibleItems.find((r) => getRowId(r) === activeId);
+    if (!row || row.kind !== 'personal') return null;
+    const app = row.item;
+    return (
+      <LibraryItemCard<MiniAppItem>
+        id={getRowId(row)}
+        title={app.title}
+        subtitle={
+          <span className="font-mono">
+            {(app.html.length / 1024).toFixed(1)} KB
+          </span>
+        }
+        thumbnail={
+          <div className="flex h-full w-full items-center justify-center bg-indigo-50 text-[10px] font-black uppercase tracking-widest text-indigo-600">
+            HTML
+          </div>
+        }
+        primaryAction={{
+          label: 'Assign',
+          icon: Link2,
+          onClick: () => undefined,
+        }}
+        viewMode={view.state.viewMode}
+        sortable={false}
+        isDragOverlay
+      />
+    );
+  };
 
   /* ── Toolbar is only meaningful on the Library tab ────────────────────── */
   const toolbarSlot =
@@ -737,7 +729,7 @@ export const MiniAppManager: React.FC<MiniAppManagerProps> = ({
       />
     ) : null;
 
-  return (
+  const shell = (
     <LibraryShell
       widgetLabel="Mini App"
       tab={tab}
@@ -754,5 +746,18 @@ export const MiniAppManager: React.FC<MiniAppManagerProps> = ({
     >
       {tabContent}
     </LibraryShell>
+  );
+
+  return libraryDndEnabled ? (
+    <LibraryDndContext
+      itemIds={orderedRowIds}
+      onDropOnFolder={handleDropOnFolder}
+      onReorder={(ids) => reorderHook.handleReorder(ids)}
+      renderOverlay={renderLibraryDragOverlay}
+    >
+      {shell}
+    </LibraryDndContext>
+  ) : (
+    shell
   );
 };

--- a/components/widgets/MiniApp/components/MiniAppManager.tsx
+++ b/components/widgets/MiniApp/components/MiniAppManager.tsx
@@ -656,6 +656,11 @@ export const MiniAppManager: React.FC<MiniAppManagerProps> = ({
     // In the Global view we keep drag disabled — global items are read-only
     // and never move between folders.
     const enableCardDrag = Boolean(userId) && !isGlobalView;
+    // When folder drag is enabled we keep the drag handle active so cards can
+    // be dropped on folder tiles — even in filtered/sorted views. The card-to-
+    // card reorder commit is gated separately (see the onReorder wiring on
+    // the shared `LibraryDndContext` below), so a non-manual sort won't persist
+    // a new order.
     tabContent = (
       <LibraryGrid<UnifiedRow>
         items={view.visibleItems}
@@ -665,8 +670,12 @@ export const MiniAppManager: React.FC<MiniAppManagerProps> = ({
           isGlobalView ? undefined : (ids) => reorderHook.handleReorder(ids)
         }
         dragDisabled={isGlobalView}
-        reorderLocked={!isGlobalView && view.reorderLocked}
-        reorderLockedReason={view.reorderLockedReason}
+        reorderLocked={
+          enableCardDrag ? false : !isGlobalView && view.reorderLocked
+        }
+        reorderLockedReason={
+          enableCardDrag ? undefined : view.reorderLockedReason
+        }
         layout={view.state.viewMode}
         useExternalDndContext={enableCardDrag}
         emptyState={empty}
@@ -748,11 +757,19 @@ export const MiniAppManager: React.FC<MiniAppManagerProps> = ({
     </LibraryShell>
   );
 
+  // Card-to-card drops are only meaningful when the view is in manual reorder
+  // mode (empty search, sort === 'manual'). Gate the reorder commit so a drop
+  // in a filtered/sorted view is a no-op, while folder drops remain live.
+  const handleLibraryReorderDrop = (ids: string[]): void => {
+    if (view.reorderLocked) return;
+    void reorderHook.handleReorder(ids);
+  };
+
   return libraryDndEnabled ? (
     <LibraryDndContext
       itemIds={orderedRowIds}
       onDropOnFolder={handleDropOnFolder}
-      onReorder={(ids) => reorderHook.handleReorder(ids)}
+      onReorder={handleLibraryReorderDrop}
       renderOverlay={renderLibraryDragOverlay}
     >
       {shell}

--- a/components/widgets/MiniApp/components/MiniAppManager.tsx
+++ b/components/widgets/MiniApp/components/MiniAppManager.tsx
@@ -26,7 +26,7 @@
  * session lifecycle lives in the parent Widget.tsx.
  */
 
-import React, { useCallback, useMemo } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import {
   Plus,
   FileUp,
@@ -53,8 +53,11 @@ import { LibraryToolbar } from '@/components/common/library/LibraryToolbar';
 import { LibraryGrid } from '@/components/common/library/LibraryGrid';
 import { LibraryItemCard } from '@/components/common/library/LibraryItemCard';
 import { AssignmentArchiveCard } from '@/components/common/library/AssignmentArchiveCard';
+import { FolderSidebar } from '@/components/common/library/FolderSidebar';
+import { LibraryDndContext } from '@/components/common/library/LibraryDndContext';
 import { useLibraryView } from '@/components/common/library/useLibraryView';
 import { useSortableReorder } from '@/components/common/library/useSortableReorder';
+import { useFolders } from '@/hooks/useFolders';
 import type {
   LibraryTab,
   LibrarySortDir,
@@ -69,6 +72,8 @@ import type {
 export type MiniAppSource = 'personal' | 'global';
 
 export interface MiniAppManagerProps {
+  /** Teacher's Firebase UID — scopes the folders subcollection. */
+  userId?: string;
   /** Which tab is active. Parent owns this so it can persist across flips. */
   tab: LibraryTab;
   onTabChange: (tab: LibraryTab) => void;
@@ -191,6 +196,7 @@ const LIBRARY_FILTER_PREDICATES = {
 /* ─── Component ───────────────────────────────────────────────────────────── */
 
 export const MiniAppManager: React.FC<MiniAppManagerProps> = ({
+  userId,
   tab,
   onTabChange,
   personalLibrary,
@@ -223,10 +229,34 @@ export const MiniAppManager: React.FC<MiniAppManagerProps> = ({
     [assignments]
   );
 
+  /* ── Folder navigation (Wave 3-B-3) ────────────────────────────────── */
+  const folderState = useFolders(userId, 'miniapp');
+  const [selectedFolderId, setSelectedFolderId] = useState<string | null>(null);
+
+  // Count personal apps per folder id (+ `root` for unfoldered items) for the
+  // sidebar badges. Global apps never live in a teacher's folder.
+  const folderItemCounts = useMemo(() => {
+    const counts: Record<string, number> = {};
+    for (const item of personalLibrary) {
+      const key = item.folderId ?? 'root';
+      counts[key] = (counts[key] ?? 0) + 1;
+    }
+    return counts;
+  }, [personalLibrary]);
+
+  // Filter BEFORE building rows so search/sort only operate on the currently
+  // selected folder's apps.
+  const folderFilteredPersonal = useMemo(() => {
+    if (selectedFolderId === null) return personalLibrary;
+    return personalLibrary.filter(
+      (item) => (item.folderId ?? null) === selectedFolderId
+    );
+  }, [personalLibrary, selectedFolderId]);
+
   /* ── Unified rows (sorted by source + ordering) ─────────────────────── */
   const personalRows = useMemo<UnifiedRow[]>(
-    () => personalLibrary.map((item) => ({ kind: 'personal', item })),
-    [personalLibrary]
+    () => folderFilteredPersonal.map((item) => ({ kind: 'personal', item })),
+    [folderFilteredPersonal]
   );
   const globalRows = useMemo<UnifiedRow[]>(
     () => globalLibrary.map((item) => ({ kind: 'global', item })),
@@ -291,6 +321,44 @@ export const MiniAppManager: React.FC<MiniAppManagerProps> = ({
       disabledReason: 'Your library is empty.',
     },
   ];
+
+  /* ── Drop-to-folder handler (Wave 3-B-3) ─────────────────────────────── */
+  const { moveItem } = folderState;
+  const handleDropOnFolder = useCallback(
+    async (itemId: string, folderId: string | null): Promise<void> => {
+      if (!userId) return;
+      // Row ids are prefixed `personal:` or `global:`. Only personal rows
+      // participate in folders; global cards are `sortable={false}` so drops
+      // from them shouldn't fire, but guard defensively.
+      if (!itemId.startsWith('personal:')) return;
+      const rawId = itemId.slice('personal:'.length);
+      try {
+        await moveItem(rawId, folderId);
+      } catch (err) {
+        console.error('[MiniAppManager] moveItem failed:', err);
+      }
+    },
+    [userId, moveItem]
+  );
+
+  /* ── Folder sidebar (Library tab only) ───────────────────────────────── */
+  const folderSidebarSlot =
+    tab === 'library' && userId ? (
+      <FolderSidebar
+        widget="miniapp"
+        folders={folderState.folders}
+        loading={folderState.loading}
+        error={folderState.error}
+        selectedFolderId={selectedFolderId}
+        onSelectFolder={setSelectedFolderId}
+        itemCounts={folderItemCounts}
+        onCreateFolder={folderState.createFolder}
+        onRenameFolder={folderState.renameFolder}
+        onMoveFolder={folderState.moveFolder}
+        onDeleteFolder={folderState.deleteFolder}
+        enableDrop
+      />
+    ) : undefined;
 
   /* ── Card builders ────────────────────────────────────────────────────── */
 
@@ -584,7 +652,11 @@ export const MiniAppManager: React.FC<MiniAppManagerProps> = ({
   } else {
     /* Library tab */
     const empty = isGlobalView ? globalEmpty : personalEmpty;
-    tabContent = (
+    // Enable card drag when a teacher is signed in so drag-to-folder works.
+    // In the Global view we keep drag disabled — global items are read-only
+    // and never move between folders.
+    const enableCardDrag = Boolean(userId) && !isGlobalView;
+    const gridEl = (
       <LibraryGrid<UnifiedRow>
         items={view.visibleItems}
         getId={getRowId}
@@ -596,9 +668,55 @@ export const MiniAppManager: React.FC<MiniAppManagerProps> = ({
         reorderLocked={!isGlobalView && view.reorderLocked}
         reorderLockedReason={view.reorderLockedReason}
         layout={view.state.viewMode}
+        useExternalDndContext={enableCardDrag}
         emptyState={empty}
       />
     );
+
+    if (enableCardDrag) {
+      const orderedIds = view.visibleItems.map(getRowId);
+      const renderDragOverlay = (activeId: string): React.ReactNode => {
+        const row = view.visibleItems.find((r) => getRowId(r) === activeId);
+        if (!row || row.kind !== 'personal') return null;
+        const app = row.item;
+        return (
+          <LibraryItemCard<MiniAppItem>
+            id={getRowId(row)}
+            title={app.title}
+            subtitle={
+              <span className="font-mono">
+                {(app.html.length / 1024).toFixed(1)} KB
+              </span>
+            }
+            thumbnail={
+              <div className="flex h-full w-full items-center justify-center bg-indigo-50 text-[10px] font-black uppercase tracking-widest text-indigo-600">
+                HTML
+              </div>
+            }
+            primaryAction={{
+              label: 'Assign',
+              icon: Link2,
+              onClick: () => undefined,
+            }}
+            viewMode={view.state.viewMode}
+            sortable={false}
+            isDragOverlay
+          />
+        );
+      };
+      tabContent = (
+        <LibraryDndContext
+          itemIds={orderedIds}
+          onDropOnFolder={handleDropOnFolder}
+          onReorder={(ids) => reorderHook.handleReorder(ids)}
+          renderOverlay={renderDragOverlay}
+        >
+          {gridEl}
+        </LibraryDndContext>
+      );
+    } else {
+      tabContent = gridEl;
+    }
   }
 
   /* ── Toolbar is only meaningful on the Library tab ────────────────────── */
@@ -631,6 +749,7 @@ export const MiniAppManager: React.FC<MiniAppManagerProps> = ({
       }}
       primaryAction={primaryAction}
       secondaryActions={secondaryActions}
+      filterSidebarSlot={folderSidebarSlot}
       toolbarSlot={toolbarSlot}
     >
       {tabContent}

--- a/components/widgets/MiniApp/components/MiniAppManager.tsx
+++ b/components/widgets/MiniApp/components/MiniAppManager.tsx
@@ -57,6 +57,10 @@ import { FolderSidebar } from '@/components/common/library/FolderSidebar';
 import { LibraryDndContext } from '@/components/common/library/LibraryDndContext';
 import { useLibraryView } from '@/components/common/library/useLibraryView';
 import { useSortableReorder } from '@/components/common/library/useSortableReorder';
+import {
+  countItemsByFolder,
+  filterByFolder,
+} from '@/components/common/library/folderFilters';
 import { useFolders } from '@/hooks/useFolders';
 import type {
   LibraryTab,
@@ -251,23 +255,17 @@ export const MiniAppManager: React.FC<MiniAppManagerProps> = ({
 
   // Count personal apps per folder id (+ `root` for unfoldered items) for the
   // sidebar badges. Global apps never live in a teacher's folder.
-  const folderItemCounts = useMemo(() => {
-    const counts: Record<string, number> = {};
-    for (const item of personalLibrary) {
-      const key = item.folderId ?? 'root';
-      counts[key] = (counts[key] ?? 0) + 1;
-    }
-    return counts;
-  }, [personalLibrary]);
+  const folderItemCounts = useMemo(
+    () => countItemsByFolder(personalLibrary),
+    [personalLibrary]
+  );
 
   // Filter BEFORE building rows so search/sort only operate on the currently
   // selected folder's apps.
-  const folderFilteredPersonal = useMemo(() => {
-    if (selectedFolderId === null) return personalLibrary;
-    return personalLibrary.filter(
-      (item) => (item.folderId ?? null) === selectedFolderId
-    );
-  }, [personalLibrary, selectedFolderId]);
+  const folderFilteredPersonal = useMemo(
+    () => filterByFolder(personalLibrary, selectedFolderId),
+    [personalLibrary, selectedFolderId]
+  );
 
   /* ── Unified rows (sorted by source + ordering) ─────────────────────── */
   const personalRows = useMemo<UnifiedRow[]>(

--- a/components/widgets/MiniApp/components/MiniAppManager.tsx
+++ b/components/widgets/MiniApp/components/MiniAppManager.tsx
@@ -233,6 +233,22 @@ export const MiniAppManager: React.FC<MiniAppManagerProps> = ({
   const folderState = useFolders(userId, 'miniapp');
   const [selectedFolderId, setSelectedFolderId] = useState<string | null>(null);
 
+  // Reset folder selection when the signed-in user changes or the selected
+  // folder no longer exists (adjust-state-during-render pattern). We clear the
+  // selection on switch-to-global-view below, after `isGlobalView` is derived.
+  const [prevFolderUserId, setPrevFolderUserId] = useState(userId);
+  if (prevFolderUserId !== userId) {
+    setPrevFolderUserId(userId);
+    setSelectedFolderId(null);
+  }
+  if (
+    !folderState.loading &&
+    selectedFolderId !== null &&
+    !folderState.folders.some((f) => f.id === selectedFolderId)
+  ) {
+    setSelectedFolderId(null);
+  }
+
   // Count personal apps per folder id (+ `root` for unfoldered items) for the
   // sidebar badges. Global apps never live in a teacher's folder.
   const folderItemCounts = useMemo(() => {
@@ -300,6 +316,13 @@ export const MiniAppManager: React.FC<MiniAppManagerProps> = ({
     (view.state.filterValues.source as MiniAppSource | undefined) ?? 'personal';
   const isGlobalView = source === 'global';
 
+  // Folder navigation is personal-only; switching to the global source clears
+  // any stale personal-folder selection so the library isn't hidden behind a
+  // filter that no longer applies.
+  if (isGlobalView && selectedFolderId !== null) {
+    setSelectedFolderId(null);
+  }
+
   /* ── Shell actions ────────────────────────────────────────────────────── */
   const primaryAction = {
     label: 'New App',
@@ -341,9 +364,9 @@ export const MiniAppManager: React.FC<MiniAppManagerProps> = ({
     [userId, moveItem]
   );
 
-  /* ── Folder sidebar (Library tab only) ───────────────────────────────── */
+  /* ── Folder sidebar (Library tab + personal source only) ─────────────── */
   const folderSidebarSlot =
-    tab === 'library' && userId ? (
+    tab === 'library' && userId && !isGlobalView ? (
       <FolderSidebar
         widget="miniapp"
         folders={folderState.folders}

--- a/components/widgets/QuizWidget/Widget.tsx
+++ b/components/widgets/QuizWidget/Widget.tsx
@@ -624,6 +624,7 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
   return (
     <>
       <QuizManager
+        userId={user?.uid}
         quizzes={quizzes}
         loading={quizzesLoading}
         error={quizzesError ?? dataError}

--- a/components/widgets/QuizWidget/components/QuizManager.tsx
+++ b/components/widgets/QuizWidget/components/QuizManager.tsx
@@ -678,79 +678,73 @@ export const QuizManager: React.FC<QuizManagerProps> = ({
   };
 
   // ─── Render ───────────────────────────────────────────────────────────────
+  const shell = (
+    <LibraryShell
+      widgetLabel="Quiz"
+      tab={managerTab}
+      onTabChange={(t) => onTabChange?.(t)}
+      counts={{
+        library: quizzes.length,
+        active: activeAssignments.length,
+        archive: inactiveAssignments.length,
+      }}
+      primaryAction={primaryAction}
+      secondaryActions={secondaryActions}
+      toolbarSlot={toolbar}
+      filterSidebarSlot={folderSidebarSlot}
+    >
+      {managerTab === 'library' && (
+        <LibraryTabContent
+          error={error}
+          orderedItems={reorder.orderedItems}
+          onAssignClick={(q) => setAssignTarget(q)}
+          buildSecondaryActions={buildQuizSecondaryActions}
+          onEdit={onEdit}
+          onImport={onImport}
+          totalCount={quizzes.length}
+          reorderLocked={libraryView.reorderLocked}
+          reorderLockedReason={libraryView.reorderLockedReason}
+          enableCardDrag={Boolean(userId)}
+        />
+      )}
+
+      {managerTab === 'active' && (
+        <AssignmentsList
+          assignments={activeAssignments}
+          loading={assignmentsLoading}
+          mode="active"
+          buildActions={buildArchiveActions}
+          emptyTitle="No quizzes in progress"
+          emptySub="Assign a quiz from the Library tab to get started. Active and paused assignments appear here."
+        />
+      )}
+
+      {managerTab === 'archive' && (
+        <AssignmentsList
+          assignments={inactiveAssignments}
+          loading={assignmentsLoading}
+          mode="archive"
+          buildActions={buildArchiveActions}
+          emptyTitle="No archived assignments"
+          emptySub="Ended assignments are moved here so you can review results and share them."
+        />
+      )}
+    </LibraryShell>
+  );
+
   return (
     <>
-      <LibraryShell
-        widgetLabel="Quiz"
-        tab={managerTab}
-        onTabChange={(t) => onTabChange?.(t)}
-        counts={{
-          library: quizzes.length,
-          active: activeAssignments.length,
-          archive: inactiveAssignments.length,
-        }}
-        primaryAction={primaryAction}
-        secondaryActions={secondaryActions}
-        toolbarSlot={toolbar}
-        filterSidebarSlot={folderSidebarSlot}
-      >
-        {managerTab === 'library' &&
-          (userId ? (
-            <LibraryDndContext
-              itemIds={orderedIds}
-              onDropOnFolder={handleDropOnFolder}
-              renderOverlay={renderDragOverlay}
-            >
-              <LibraryTabContent
-                error={error}
-                orderedItems={reorder.orderedItems}
-                onAssignClick={(q) => setAssignTarget(q)}
-                buildSecondaryActions={buildQuizSecondaryActions}
-                onEdit={onEdit}
-                onImport={onImport}
-                totalCount={quizzes.length}
-                reorderLocked={libraryView.reorderLocked}
-                reorderLockedReason={libraryView.reorderLockedReason}
-                enableCardDrag
-              />
-            </LibraryDndContext>
-          ) : (
-            <LibraryTabContent
-              error={error}
-              orderedItems={reorder.orderedItems}
-              onAssignClick={(q) => setAssignTarget(q)}
-              buildSecondaryActions={buildQuizSecondaryActions}
-              onEdit={onEdit}
-              onImport={onImport}
-              totalCount={quizzes.length}
-              reorderLocked={libraryView.reorderLocked}
-              reorderLockedReason={libraryView.reorderLockedReason}
-              enableCardDrag={false}
-            />
-          ))}
-
-        {managerTab === 'active' && (
-          <AssignmentsList
-            assignments={activeAssignments}
-            loading={assignmentsLoading}
-            mode="active"
-            buildActions={buildArchiveActions}
-            emptyTitle="No quizzes in progress"
-            emptySub="Assign a quiz from the Library tab to get started. Active and paused assignments appear here."
-          />
-        )}
-
-        {managerTab === 'archive' && (
-          <AssignmentsList
-            assignments={inactiveAssignments}
-            loading={assignmentsLoading}
-            mode="archive"
-            buildActions={buildArchiveActions}
-            emptyTitle="No archived assignments"
-            emptySub="Ended assignments are moved here so you can review results and share them."
-          />
-        )}
-      </LibraryShell>
+      {userId && managerTab === 'library' ? (
+        <LibraryDndContext
+          itemIds={orderedIds}
+          onDropOnFolder={handleDropOnFolder}
+          renderOverlay={renderDragOverlay}
+        >
+          {shell}
+        </LibraryDndContext>
+      ) : (
+        shell
+      )}
 
       {assignTarget && (
         <AssignModal<QuizAssignOptions>

--- a/components/widgets/QuizWidget/components/QuizManager.tsx
+++ b/components/widgets/QuizWidget/components/QuizManager.tsx
@@ -16,7 +16,7 @@
  * only, not functionality.
  */
 
-import React, { useMemo, useState } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import {
   Plus,
   FileUp,
@@ -58,6 +58,8 @@ import {
   LibraryItemCard,
   AssignModal,
   AssignmentArchiveCard,
+  FolderSidebar,
+  LibraryDndContext,
   useLibraryView,
   useSortableReorder,
   type LibraryMenuAction,
@@ -66,6 +68,7 @@ import {
   type AssignmentStatusBadge,
   type LibraryBadgeTone,
 } from '@/components/common/library';
+import { useFolders } from '@/hooks/useFolders';
 
 export interface PlcOptions {
   plcMode: boolean;
@@ -135,6 +138,8 @@ const ASSIGN_MODES: AssignModeOption[] = [
 /* ─── Props ───────────────────────────────────────────────────────────────── */
 
 interface QuizManagerProps {
+  /** Teacher's Firebase UID — used to scope the folders subcollection. */
+  userId?: string;
   quizzes: QuizMetadata[];
   loading: boolean;
   error: string | null;
@@ -236,6 +241,7 @@ const SORT_COMPARATORS: Record<
 /* ─── Main component ──────────────────────────────────────────────────────── */
 
 export const QuizManager: React.FC<QuizManagerProps> = ({
+  userId,
   quizzes,
   loading,
   error,
@@ -288,9 +294,31 @@ export const QuizManager: React.FC<QuizManagerProps> = ({
     }
   }
 
+  // ─── Folder navigation (Wave 3-B-3) ───────────────────────────────────────
+  const folderState = useFolders(userId, 'quiz');
+  const [selectedFolderId, setSelectedFolderId] = useState<string | null>(null);
+
+  // Count quizzes per folder id (+ `root` for unfoldered items) for sidebar
+  // badges.
+  const folderItemCounts = useMemo(() => {
+    const counts: Record<string, number> = {};
+    for (const q of quizzes) {
+      const key = q.folderId ?? 'root';
+      counts[key] = (counts[key] ?? 0) + 1;
+    }
+    return counts;
+  }, [quizzes]);
+
+  // Filter BEFORE useLibraryView so search/sort only operate on the
+  // currently-selected folder's quizzes.
+  const folderFilteredQuizzes = useMemo(() => {
+    if (selectedFolderId === null) return quizzes;
+    return quizzes.filter((q) => (q.folderId ?? null) === selectedFolderId);
+  }, [quizzes, selectedFolderId]);
+
   // ─── Library tab toolbar state ────────────────────────────────────────────
   const libraryView = useLibraryView<QuizMetadata>({
-    items: quizzes,
+    items: folderFilteredQuizzes,
     initialSort: LIBRARY_INITIAL_SORT,
     searchFields: LIBRARY_SEARCH_FIELDS,
     sortComparators: SORT_COMPARATORS,
@@ -537,6 +565,39 @@ export const QuizManager: React.FC<QuizManagerProps> = ({
     setSelectedMode(null);
   };
 
+  // ─── Drop-to-folder handler ───────────────────────────────────────────────
+  const { moveItem } = folderState;
+  const handleDropOnFolder = useCallback(
+    async (itemId: string, folderId: string | null): Promise<void> => {
+      if (!userId) return;
+      try {
+        await moveItem(itemId, folderId);
+      } catch (err) {
+        console.error('[QuizManager] moveItem failed:', err);
+      }
+    },
+    [userId, moveItem]
+  );
+
+  // ─── Folder sidebar (Library tab only) ────────────────────────────────────
+  const folderSidebarSlot =
+    managerTab === 'library' && userId ? (
+      <FolderSidebar
+        widget="quiz"
+        folders={folderState.folders}
+        loading={folderState.loading}
+        error={folderState.error}
+        selectedFolderId={selectedFolderId}
+        onSelectFolder={setSelectedFolderId}
+        itemCounts={folderItemCounts}
+        onCreateFolder={folderState.createFolder}
+        onRenameFolder={folderState.renameFolder}
+        onMoveFolder={folderState.moveFolder}
+        onDeleteFolder={folderState.deleteFolder}
+        enableDrop
+      />
+    ) : undefined;
+
   // ─── Shell header actions ─────────────────────────────────────────────────
   const primaryAction =
     managerTab === 'library'
@@ -572,6 +633,7 @@ export const QuizManager: React.FC<QuizManagerProps> = ({
         primaryAction={primaryAction}
         secondaryActions={secondaryActions}
         toolbarSlot={toolbar}
+        filterSidebarSlot={folderSidebarSlot}
       >
         <div className="flex flex-col items-center justify-center h-full text-brand-blue-primary gap-3 py-10">
           <Loader2 className="w-8 h-8 animate-spin" />
@@ -580,6 +642,40 @@ export const QuizManager: React.FC<QuizManagerProps> = ({
       </LibraryShell>
     );
   }
+
+  // ─── Ordered ids for LibraryDndContext (for overlay + reorder routing) ───
+  const orderedIds = reorder.orderedItems.map(QUIZ_GET_ID);
+  const renderDragOverlay = (activeId: string): React.ReactNode => {
+    const quiz = reorder.orderedItems.find((q) => q.id === activeId);
+    if (!quiz) return null;
+    return (
+      <LibraryItemCard<QuizMetadata>
+        id={quiz.id}
+        title={quiz.title}
+        subtitle={
+          <span className="flex items-center gap-2">
+            <span className="bg-brand-blue-lighter text-brand-blue-primary font-bold rounded px-1.5 text-[10px] uppercase">
+              {quiz.questionCount} Qs
+            </span>
+            <span>
+              Updated{' '}
+              {new Date(quiz.updatedAt || quiz.createdAt).toLocaleDateString()}
+            </span>
+          </span>
+        }
+        primaryAction={{
+          label: 'Assign',
+          icon: Play,
+          onClick: () => setAssignTarget(quiz),
+        }}
+        secondaryActions={buildQuizSecondaryActions(quiz)}
+        viewMode="list"
+        sortable={false}
+        isDragOverlay
+        meta={quiz}
+      />
+    );
+  };
 
   // ─── Render ───────────────────────────────────────────────────────────────
   return (
@@ -596,20 +692,42 @@ export const QuizManager: React.FC<QuizManagerProps> = ({
         primaryAction={primaryAction}
         secondaryActions={secondaryActions}
         toolbarSlot={toolbar}
+        filterSidebarSlot={folderSidebarSlot}
       >
-        {managerTab === 'library' && (
-          <LibraryTabContent
-            error={error}
-            orderedItems={reorder.orderedItems}
-            onAssignClick={(q) => setAssignTarget(q)}
-            buildSecondaryActions={buildQuizSecondaryActions}
-            onEdit={onEdit}
-            onImport={onImport}
-            totalCount={quizzes.length}
-            reorderLocked={libraryView.reorderLocked}
-            reorderLockedReason={libraryView.reorderLockedReason}
-          />
-        )}
+        {managerTab === 'library' &&
+          (userId ? (
+            <LibraryDndContext
+              itemIds={orderedIds}
+              onDropOnFolder={handleDropOnFolder}
+              renderOverlay={renderDragOverlay}
+            >
+              <LibraryTabContent
+                error={error}
+                orderedItems={reorder.orderedItems}
+                onAssignClick={(q) => setAssignTarget(q)}
+                buildSecondaryActions={buildQuizSecondaryActions}
+                onEdit={onEdit}
+                onImport={onImport}
+                totalCount={quizzes.length}
+                reorderLocked={libraryView.reorderLocked}
+                reorderLockedReason={libraryView.reorderLockedReason}
+                enableCardDrag
+              />
+            </LibraryDndContext>
+          ) : (
+            <LibraryTabContent
+              error={error}
+              orderedItems={reorder.orderedItems}
+              onAssignClick={(q) => setAssignTarget(q)}
+              buildSecondaryActions={buildQuizSecondaryActions}
+              onEdit={onEdit}
+              onImport={onImport}
+              totalCount={quizzes.length}
+              reorderLocked={libraryView.reorderLocked}
+              reorderLockedReason={libraryView.reorderLockedReason}
+              enableCardDrag={false}
+            />
+          ))}
 
         {managerTab === 'active' && (
           <AssignmentsList
@@ -683,6 +801,12 @@ const LibraryTabContent: React.FC<{
   totalCount: number;
   reorderLocked: boolean;
   reorderLockedReason: string | undefined;
+  /**
+   * When true, cards are draggable (to folders) via the external
+   * `LibraryDndContext`. Quiz has no card-to-card reorder, but we still
+   * enable drag when a teacher is signed in so drag-to-folder works.
+   */
+  enableCardDrag: boolean;
 }> = ({
   error,
   orderedItems,
@@ -693,6 +817,7 @@ const LibraryTabContent: React.FC<{
   totalCount,
   reorderLocked,
   reorderLockedReason,
+  enableCardDrag,
 }) => {
   const emptyState =
     totalCount === 0 ? (
@@ -735,11 +860,15 @@ const LibraryTabContent: React.FC<{
       <LibraryGrid<QuizMetadata>
         items={orderedItems}
         getId={(q) => q.id}
-        dragDisabled
-        reorderLocked={reorderLocked}
-        reorderLockedReason={reorderLockedReason}
+        dragDisabled={!enableCardDrag}
+        // Quiz has no manual reorder, so reorderLocked is noise; only surface
+        // it when drag is fully disabled so the existing lock tooltip still
+        // works on grids without folder drag.
+        reorderLocked={enableCardDrag ? false : reorderLocked}
+        reorderLockedReason={enableCardDrag ? undefined : reorderLockedReason}
         layout="list"
         emptyState={emptyState}
+        useExternalDndContext={enableCardDrag}
         renderCard={(quiz) => (
           <LibraryItemCard<QuizMetadata>
             key={quiz.id}
@@ -766,7 +895,7 @@ const LibraryTabContent: React.FC<{
             secondaryActions={buildSecondaryActions(quiz)}
             onClick={() => onEdit(quiz)}
             viewMode="list"
-            sortable={false}
+            sortable={enableCardDrag}
             meta={quiz}
           />
         )}

--- a/components/widgets/QuizWidget/components/QuizManager.tsx
+++ b/components/widgets/QuizWidget/components/QuizManager.tsx
@@ -68,6 +68,10 @@ import {
   type AssignmentStatusBadge,
   type LibraryBadgeTone,
 } from '@/components/common/library';
+import {
+  countItemsByFolder,
+  filterByFolder,
+} from '@/components/common/library/folderFilters';
 import { useFolders } from '@/hooks/useFolders';
 
 export interface PlcOptions {
@@ -317,21 +321,17 @@ export const QuizManager: React.FC<QuizManagerProps> = ({
 
   // Count quizzes per folder id (+ `root` for unfoldered items) for sidebar
   // badges.
-  const folderItemCounts = useMemo(() => {
-    const counts: Record<string, number> = {};
-    for (const q of quizzes) {
-      const key = q.folderId ?? 'root';
-      counts[key] = (counts[key] ?? 0) + 1;
-    }
-    return counts;
-  }, [quizzes]);
+  const folderItemCounts = useMemo(
+    () => countItemsByFolder(quizzes),
+    [quizzes]
+  );
 
   // Filter BEFORE useLibraryView so search/sort only operate on the
   // currently-selected folder's quizzes.
-  const folderFilteredQuizzes = useMemo(() => {
-    if (selectedFolderId === null) return quizzes;
-    return quizzes.filter((q) => (q.folderId ?? null) === selectedFolderId);
-  }, [quizzes, selectedFolderId]);
+  const folderFilteredQuizzes = useMemo(
+    () => filterByFolder(quizzes, selectedFolderId),
+    [quizzes, selectedFolderId]
+  );
 
   // ─── Library tab toolbar state ────────────────────────────────────────────
   const libraryView = useLibraryView<QuizMetadata>({

--- a/components/widgets/QuizWidget/components/QuizManager.tsx
+++ b/components/widgets/QuizWidget/components/QuizManager.tsx
@@ -298,6 +298,23 @@ export const QuizManager: React.FC<QuizManagerProps> = ({
   const folderState = useFolders(userId, 'quiz');
   const [selectedFolderId, setSelectedFolderId] = useState<string | null>(null);
 
+  // Reset folder selection when the signed-in user changes or the selected
+  // folder no longer exists (e.g. after delete, sign-out, or account switch).
+  // Done in render via React's "adjust state during render" pattern so the
+  // stale selection never participates in filtering.
+  const [prevFolderUserId, setPrevFolderUserId] = useState(userId);
+  if (prevFolderUserId !== userId) {
+    setPrevFolderUserId(userId);
+    setSelectedFolderId(null);
+  }
+  if (
+    !folderState.loading &&
+    selectedFolderId !== null &&
+    !folderState.folders.some((f) => f.id === selectedFolderId)
+  ) {
+    setSelectedFolderId(null);
+  }
+
   // Count quizzes per folder id (+ `root` for unfoldered items) for sidebar
   // badges.
   const folderItemCounts = useMemo(() => {

--- a/components/widgets/VideoActivityWidget/Widget.tsx
+++ b/components/widgets/VideoActivityWidget/Widget.tsx
@@ -281,6 +281,7 @@ export const VideoActivityWidget: React.FC<{ widget: WidgetData }> = ({
   return (
     <>
       <VideoActivityManager
+        userId={user?.uid}
         activities={activities}
         loading={loading}
         error={error}

--- a/components/widgets/VideoActivityWidget/components/VideoActivityManager.tsx
+++ b/components/widgets/VideoActivityWidget/components/VideoActivityManager.tsx
@@ -287,11 +287,11 @@ export const VideoActivityManager: React.FC<VideoActivityManagerProps> = ({
 
   const handleReorderDrop = useCallback(
     async (nextOrderedIds: string[]): Promise<void> => {
-      if (onReorderActivities) {
-        await Promise.resolve(onReorderActivities(nextOrderedIds));
-      }
+      if (!onReorderActivities) return;
+      if (libraryView.reorderLocked) return;
+      await Promise.resolve(onReorderActivities(nextOrderedIds));
     },
-    [onReorderActivities]
+    [libraryView.reorderLocked, onReorderActivities]
   );
 
   /* ─── Assignment splits ───────────────────────────────────────────────── */
@@ -384,8 +384,10 @@ export const VideoActivityManager: React.FC<VideoActivityManagerProps> = ({
         getId={(a) => a.id}
         onReorder={reorder.handleReorder}
         dragDisabled={!cardDragEnabled}
-        reorderLocked={libraryView.reorderLocked}
-        reorderLockedReason={libraryView.reorderLockedReason}
+        reorderLocked={useExternalDnd ? false : libraryView.reorderLocked}
+        reorderLockedReason={
+          useExternalDnd ? undefined : libraryView.reorderLockedReason
+        }
         layout={libraryView.state.viewMode}
         emptyState={libraryEmptyState}
         useExternalDndContext={useExternalDnd}

--- a/components/widgets/VideoActivityWidget/components/VideoActivityManager.tsx
+++ b/components/widgets/VideoActivityWidget/components/VideoActivityManager.tsx
@@ -42,6 +42,10 @@ import { FolderSidebar } from '@/components/common/library/FolderSidebar';
 import { LibraryDndContext } from '@/components/common/library/LibraryDndContext';
 import { useLibraryView } from '@/components/common/library/useLibraryView';
 import { useSortableReorder } from '@/components/common/library/useSortableReorder';
+import {
+  countItemsByFolder,
+  filterByFolder,
+} from '@/components/common/library/folderFilters';
 import { useFolders } from '@/hooks/useFolders';
 import { ScaledEmptyState } from '@/components/common/ScaledEmptyState';
 import { Toggle } from '@/components/common/Toggle';
@@ -248,19 +252,15 @@ export const VideoActivityManager: React.FC<VideoActivityManagerProps> = ({
     setSelectedFolderId(null);
   }
 
-  const folderItemCounts = useMemo(() => {
-    const counts: Record<string, number> = {};
-    for (const a of activities) {
-      const key = a.folderId ?? 'root';
-      counts[key] = (counts[key] ?? 0) + 1;
-    }
-    return counts;
-  }, [activities]);
+  const folderItemCounts = useMemo(
+    () => countItemsByFolder(activities),
+    [activities]
+  );
 
-  const folderFilteredActivities = useMemo(() => {
-    if (selectedFolderId === null) return activities;
-    return activities.filter((a) => (a.folderId ?? null) === selectedFolderId);
-  }, [activities, selectedFolderId]);
+  const folderFilteredActivities = useMemo(
+    () => filterByFolder(activities, selectedFolderId),
+    [activities, selectedFolderId]
+  );
 
   /* ─── Library (activities) view state ─────────────────────────────────── */
 

--- a/components/widgets/VideoActivityWidget/components/VideoActivityManager.tsx
+++ b/components/widgets/VideoActivityWidget/components/VideoActivityManager.tsx
@@ -38,8 +38,11 @@ import { LibraryGrid } from '@/components/common/library/LibraryGrid';
 import { LibraryItemCard } from '@/components/common/library/LibraryItemCard';
 import { AssignModal } from '@/components/common/library/AssignModal';
 import { AssignmentArchiveCard } from '@/components/common/library/AssignmentArchiveCard';
+import { FolderSidebar } from '@/components/common/library/FolderSidebar';
+import { LibraryDndContext } from '@/components/common/library/LibraryDndContext';
 import { useLibraryView } from '@/components/common/library/useLibraryView';
 import { useSortableReorder } from '@/components/common/library/useSortableReorder';
+import { useFolders } from '@/hooks/useFolders';
 import { ScaledEmptyState } from '@/components/common/ScaledEmptyState';
 import { Toggle } from '@/components/common/Toggle';
 import type {
@@ -60,6 +63,8 @@ import type {
 /* ─── Props ───────────────────────────────────────────────────────────────── */
 
 export interface VideoActivityManagerProps {
+  /** Teacher's Firebase UID — scopes the folders subcollection. */
+  userId?: string;
   // Library (activity templates)
   activities: VideoActivityMetadata[];
   loading: boolean;
@@ -172,6 +177,7 @@ function statusToBadge(
 /* ─── Main component ──────────────────────────────────────────────────────── */
 
 export const VideoActivityManager: React.FC<VideoActivityManagerProps> = ({
+  userId,
   activities,
   loading,
   error,
@@ -223,10 +229,28 @@ export const VideoActivityManager: React.FC<VideoActivityManagerProps> = ({
     string | null
   >(null);
 
+  /* ─── Folder navigation (Wave 3-B-3) ──────────────────────────────────── */
+  const folderState = useFolders(userId, 'video_activity');
+  const [selectedFolderId, setSelectedFolderId] = useState<string | null>(null);
+
+  const folderItemCounts = useMemo(() => {
+    const counts: Record<string, number> = {};
+    for (const a of activities) {
+      const key = a.folderId ?? 'root';
+      counts[key] = (counts[key] ?? 0) + 1;
+    }
+    return counts;
+  }, [activities]);
+
+  const folderFilteredActivities = useMemo(() => {
+    if (selectedFolderId === null) return activities;
+    return activities.filter((a) => (a.folderId ?? null) === selectedFolderId);
+  }, [activities, selectedFolderId]);
+
   /* ─── Library (activities) view state ─────────────────────────────────── */
 
   const libraryView = useLibraryView<VideoActivityMetadata>({
-    items: activities,
+    items: folderFilteredActivities,
     initialSort: LIBRARY_INITIAL_SORT,
     searchFields: LIBRARY_SEARCH_FIELDS,
     sortComparators: LIBRARY_SORT_COMPARATORS,
@@ -246,6 +270,29 @@ export const VideoActivityManager: React.FC<VideoActivityManagerProps> = ({
     getId: ACTIVITY_GET_ID,
     onCommit: onReorderCommit,
   });
+
+  /* ─── Drop-to-folder handler ──────────────────────────────────────────── */
+  const { moveItem } = folderState;
+  const handleDropOnFolder = useCallback(
+    async (itemId: string, folderId: string | null): Promise<void> => {
+      if (!userId) return;
+      try {
+        await moveItem(itemId, folderId);
+      } catch (err) {
+        console.error('[VideoActivityManager] moveItem failed:', err);
+      }
+    },
+    [userId, moveItem]
+  );
+
+  const handleReorderDrop = useCallback(
+    async (nextOrderedIds: string[]): Promise<void> => {
+      if (onReorderActivities) {
+        await Promise.resolve(onReorderActivities(nextOrderedIds));
+      }
+    },
+    [onReorderActivities]
+  );
 
   /* ─── Assignment splits ───────────────────────────────────────────────── */
 
@@ -320,6 +367,9 @@ export const VideoActivityManager: React.FC<VideoActivityManagerProps> = ({
     />
   );
 
+  const useExternalDnd = Boolean(userId);
+  const cardDragEnabled = useExternalDnd || Boolean(onReorderActivities);
+
   const renderLibraryTab = (): React.ReactElement => (
     <>
       {error && (
@@ -333,11 +383,12 @@ export const VideoActivityManager: React.FC<VideoActivityManagerProps> = ({
         items={reorder.orderedItems}
         getId={(a) => a.id}
         onReorder={reorder.handleReorder}
-        dragDisabled={!onReorderActivities}
+        dragDisabled={!cardDragEnabled}
         reorderLocked={libraryView.reorderLocked}
         reorderLockedReason={libraryView.reorderLockedReason}
         layout={libraryView.state.viewMode}
         emptyState={libraryEmptyState}
+        useExternalDndContext={useExternalDnd}
         renderCard={(activity) => {
           const secondaryActions: LibraryMenuAction[] = [
             {
@@ -587,6 +638,68 @@ export const VideoActivityManager: React.FC<VideoActivityManagerProps> = ({
 
   /* ─── Render ──────────────────────────────────────────────────────────── */
 
+  const folderSidebarSlot =
+    tab === 'library' && userId ? (
+      <FolderSidebar
+        widget="video_activity"
+        folders={folderState.folders}
+        loading={folderState.loading}
+        error={folderState.error}
+        selectedFolderId={selectedFolderId}
+        onSelectFolder={setSelectedFolderId}
+        itemCounts={folderItemCounts}
+        onCreateFolder={folderState.createFolder}
+        onRenameFolder={folderState.renameFolder}
+        onMoveFolder={folderState.moveFolder}
+        onDeleteFolder={folderState.deleteFolder}
+        enableDrop
+      />
+    ) : undefined;
+
+  const orderedIds = reorder.orderedItems.map(ACTIVITY_GET_ID);
+
+  const renderDragOverlay = (activeId: string): React.ReactNode => {
+    const activity = reorder.orderedItems.find((a) => a.id === activeId);
+    if (!activity) return null;
+    return (
+      <LibraryItemCard<VideoActivityMetadata>
+        id={activity.id}
+        title={activity.title}
+        subtitle={
+          <span className="truncate">
+            Updated{' '}
+            {new Date(
+              activity.updatedAt || activity.createdAt
+            ).toLocaleDateString()}
+          </span>
+        }
+        badges={activityBadges(activity)}
+        primaryAction={{
+          label: 'Assign',
+          icon: Link2,
+          onClick: () => setAssignTarget(activity),
+        }}
+        viewMode={libraryView.state.viewMode}
+        sortable={false}
+        isDragOverlay
+        meta={activity}
+      />
+    );
+  };
+
+  const libraryTabContent = useExternalDnd ? (
+    <LibraryDndContext
+      itemIds={orderedIds}
+      onReorder={handleReorderDrop}
+      onDropOnFolder={handleDropOnFolder}
+      renderOverlay={renderDragOverlay}
+    >
+      {renderLibraryTab()}
+    </LibraryDndContext>
+  ) : (
+    renderLibraryTab()
+  );
+
   return (
     <>
       <LibraryShell
@@ -607,8 +720,9 @@ export const VideoActivityManager: React.FC<VideoActivityManagerProps> = ({
           },
         ]}
         toolbarSlot={toolbar}
+        filterSidebarSlot={folderSidebarSlot}
       >
-        {tab === 'library' && renderLibraryTab()}
+        {tab === 'library' && libraryTabContent}
         {tab === 'active' && renderAssignmentList(activeAssignments, 'active')}
         {tab === 'archive' &&
           renderAssignmentList(inactiveAssignments, 'archive')}

--- a/components/widgets/VideoActivityWidget/components/VideoActivityManager.tsx
+++ b/components/widgets/VideoActivityWidget/components/VideoActivityManager.tsx
@@ -687,46 +687,48 @@ export const VideoActivityManager: React.FC<VideoActivityManagerProps> = ({
     );
   };
 
-  const libraryTabContent = useExternalDnd ? (
-    <LibraryDndContext
-      itemIds={orderedIds}
-      onReorder={handleReorderDrop}
-      onDropOnFolder={handleDropOnFolder}
-      renderOverlay={renderDragOverlay}
+  const shell = (
+    <LibraryShell
+      widgetLabel="Video Activity"
+      tab={tab}
+      onTabChange={setTab}
+      counts={tabCounts}
+      primaryAction={{
+        label: 'New',
+        icon: Plus,
+        onClick: onNew,
+      }}
+      secondaryActions={[
+        {
+          label: 'Import',
+          icon: FileUp,
+          onClick: onImport,
+        },
+      ]}
+      toolbarSlot={toolbar}
+      filterSidebarSlot={folderSidebarSlot}
     >
-      {renderLibraryTab()}
-    </LibraryDndContext>
-  ) : (
-    renderLibraryTab()
+      {tab === 'library' && renderLibraryTab()}
+      {tab === 'active' && renderAssignmentList(activeAssignments, 'active')}
+      {tab === 'archive' &&
+        renderAssignmentList(inactiveAssignments, 'archive')}
+    </LibraryShell>
   );
 
   return (
     <>
-      <LibraryShell
-        widgetLabel="Video Activity"
-        tab={tab}
-        onTabChange={setTab}
-        counts={tabCounts}
-        primaryAction={{
-          label: 'New',
-          icon: Plus,
-          onClick: onNew,
-        }}
-        secondaryActions={[
-          {
-            label: 'Import',
-            icon: FileUp,
-            onClick: onImport,
-          },
-        ]}
-        toolbarSlot={toolbar}
-        filterSidebarSlot={folderSidebarSlot}
-      >
-        {tab === 'library' && libraryTabContent}
-        {tab === 'active' && renderAssignmentList(activeAssignments, 'active')}
-        {tab === 'archive' &&
-          renderAssignmentList(inactiveAssignments, 'archive')}
-      </LibraryShell>
+      {useExternalDnd && tab === 'library' ? (
+        <LibraryDndContext
+          itemIds={orderedIds}
+          onReorder={handleReorderDrop}
+          onDropOnFolder={handleDropOnFolder}
+          renderOverlay={renderDragOverlay}
+        >
+          {shell}
+        </LibraryDndContext>
+      ) : (
+        shell
+      )}
 
       {assignTarget && (
         <AssignModal<VideoActivitySessionSettings>

--- a/components/widgets/VideoActivityWidget/components/VideoActivityManager.tsx
+++ b/components/widgets/VideoActivityWidget/components/VideoActivityManager.tsx
@@ -233,6 +233,21 @@ export const VideoActivityManager: React.FC<VideoActivityManagerProps> = ({
   const folderState = useFolders(userId, 'video_activity');
   const [selectedFolderId, setSelectedFolderId] = useState<string | null>(null);
 
+  // Reset folder selection when the signed-in user changes or the selected
+  // folder no longer exists (adjust-state-during-render pattern).
+  const [prevFolderUserId, setPrevFolderUserId] = useState(userId);
+  if (prevFolderUserId !== userId) {
+    setPrevFolderUserId(userId);
+    setSelectedFolderId(null);
+  }
+  if (
+    !folderState.loading &&
+    selectedFolderId !== null &&
+    !folderState.folders.some((f) => f.id === selectedFolderId)
+  ) {
+    setSelectedFolderId(null);
+  }
+
   const folderItemCounts = useMemo(() => {
     const counts: Record<string, number> = {};
     for (const a of activities) {

--- a/tests/utils/folderFilters.test.ts
+++ b/tests/utils/folderFilters.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from 'vitest';
+import {
+  ROOT_FOLDER_COUNT_KEY,
+  filterByFolder,
+  countItemsByFolder,
+  filterSourcedEntriesByFolder,
+} from '@/components/common/library/folderFilters';
+
+interface FolderedItem {
+  id: string;
+  folderId?: string | null;
+}
+
+interface SourcedEntry {
+  id: string;
+  source: 'personal' | 'building';
+  folderId?: string | null;
+}
+
+describe('filterByFolder', () => {
+  const items: FolderedItem[] = [
+    { id: 'a', folderId: 'f1' },
+    { id: 'b', folderId: 'f2' },
+    { id: 'c' },
+    { id: 'd', folderId: null },
+    { id: 'e', folderId: 'f1' },
+  ];
+
+  it('returns the input unchanged when no folder is selected', () => {
+    const result = filterByFolder(items, null);
+    expect(result).toBe(items);
+  });
+
+  it('returns only items whose folderId matches the selection', () => {
+    const result = filterByFolder(items, 'f1').map((i) => i.id);
+    expect(result).toEqual(['a', 'e']);
+  });
+
+  it('treats missing and null folderId identically (root bucket)', () => {
+    // Selecting a folder excludes both `undefined` and `null` items.
+    expect(filterByFolder(items, 'f1').some((i) => i.folderId == null)).toBe(
+      false
+    );
+  });
+
+  it('returns an empty array when no items match the selected folder', () => {
+    expect(filterByFolder(items, 'does-not-exist')).toEqual([]);
+  });
+});
+
+describe('countItemsByFolder', () => {
+  it('buckets items by folderId and uses the root key for unfoldered items', () => {
+    const items: FolderedItem[] = [
+      { id: 'a', folderId: 'f1' },
+      { id: 'b', folderId: 'f1' },
+      { id: 'c', folderId: 'f2' },
+      { id: 'd' },
+      { id: 'e', folderId: null },
+    ];
+    expect(countItemsByFolder(items)).toEqual({
+      f1: 2,
+      f2: 1,
+      [ROOT_FOLDER_COUNT_KEY]: 2,
+    });
+  });
+
+  it('returns an empty object for an empty input', () => {
+    expect(countItemsByFolder([])).toEqual({});
+  });
+
+  it('only creates keys for folders that contain items', () => {
+    const items: FolderedItem[] = [{ id: 'a', folderId: 'only-one' }];
+    const counts = countItemsByFolder(items);
+    expect(Object.keys(counts)).toEqual(['only-one']);
+  });
+});
+
+describe('filterSourcedEntriesByFolder', () => {
+  const entries: SourcedEntry[] = [
+    { id: 'p1', source: 'personal', folderId: 'f1' },
+    { id: 'p2', source: 'personal', folderId: 'f2' },
+    { id: 'p3', source: 'personal' },
+    { id: 'b1', source: 'building' },
+    { id: 'b2', source: 'building', folderId: null },
+  ];
+
+  it('returns the input unchanged when no folder is selected', () => {
+    expect(filterSourcedEntriesByFolder(entries, null)).toBe(entries);
+  });
+
+  it('keeps every building entry regardless of folder selection', () => {
+    // Regression: folder filtering previously hid building entries and caused
+    // the toolbar Source=Building filter to show an empty library.
+    const result = filterSourcedEntriesByFolder(entries, 'f1').map((e) => e.id);
+    expect(result).toEqual(['p1', 'b1', 'b2']);
+  });
+
+  it('narrows only the personal subset to the selected folder', () => {
+    const result = filterSourcedEntriesByFolder(entries, 'f2').map((e) => e.id);
+    expect(result).toEqual(['p2', 'b1', 'b2']);
+  });
+
+  it('drops personal entries whose folder does not match, but keeps building', () => {
+    const result = filterSourcedEntriesByFolder(entries, 'unknown-folder');
+    expect(result.every((e) => e.source === 'building')).toBe(true);
+    expect(result.map((e) => e.id)).toEqual(['b1', 'b2']);
+  });
+});


### PR DESCRIPTION
## Summary

Wires per-widget folder navigation into all four library widgets
(Quiz, VideoActivity, GuidedLearning, MiniApp) so teachers can
organize their personal library items into folders and drag cards
between folders. Builds on Wave 3-B-1 (`useFolders`) and Wave 3-B-2
(`FolderSidebar` chrome).

## Per-Manager wiring

Each of the four Managers now:

- Calls `useFolders(userId, <widget>)` to get folders + CRUD + `moveItem`.
- Tracks `selectedFolderId` state.
- Computes memoized `itemCounts` keyed by `folderId ?? 'root'` for sidebar badges.
- Filters its personal item list by the selected folder **before** passing into `useLibraryView`, so search/sort only run on the current folder.
- Renders `<FolderSidebar widget="…" enableDrop …/>` into `LibraryShell.filterSidebarSlot`, gated on `tab === 'library' && userId`.
- Forwards `userId` from the Widget via `useAuth().user?.uid`.

Non-personal cards (GL "building" entries, MiniApp "global" entries)
keep `sortable={false}`, so they can't be dragged into a teacher's
personal folder.

## Drag-to-folder approach + rationale

Introduced a shared `LibraryDndContext` that owns a single `DndContext`
spanning both the grid and the folder sidebar. Rationale: `dnd-kit`
does not bubble drop events between nested `DndContext`s, so the grid
must opt out of creating its own via
`LibraryGrid.useExternalDndContext={true}` and let the shared wrapper
own both sortable and droppable interactions.

- Folder drop targets (`FolderTree` rows + the "All items" root button) register via `useDroppable` using a namespaced id (`folder:<id>`) and a typed `FolderDropData` payload. This keeps `closestCenter` collision detection unambiguous between card-to-card (reorder) and card-to-folder (move) drops.
- `LibraryDndContext` routes: drops on a folder call `onDropOnFolder` → `useFolders.moveItem(itemId, folderId)`; drops on another card call `onReorder` → `useSortableReorder.handleReorder(nextIds)`. Reorder is only honored when manual sort is actually active; otherwise the drop is a no-op.
- Folder drop constants (`FOLDER_DROPPABLE_PREFIX`, `folderDroppableId`, `FolderDropData`) live in a new `folderDropTargets.ts` so `LibraryDndContext.tsx` can export only its component — satisfies `react-refresh/only-export-components`.
- `renderOverlay(activeId)` lets each Manager render the correct `LibraryItemCard` shape inside `DragOverlay`. Overlay cards render unlocked (via `LibraryGridLockContext`) so they look right even when the grid reports a lock.

## Verification

- `pnpm run type-check` — clean
- `pnpm exec eslint <changed files> --max-warnings 0` — clean
- `pnpm exec prettier --check <changed files>` — clean
- `pnpm exec vitest run` — 139 test files, 1247 tests passing

## Smoke test

Functional smoke test (teacher flow: open widget → toggle sidebar →
create folder → drag card into folder → nest folder → delete folder
with "move to parent" strategy) has not been executed in this
environment yet. Flagging as a todo on the PR before un-drafting.

## Follow-ups

- Small unit test pinning the "filter items by folder before
  `useLibraryView`" contract for each Manager.
- Live browser smoke test (above).

https://claude.ai/code/session_01Hc44ESzwRmBSSK1RmAZsVJ