### PR TITLE
Conduct daily audits with no new issues found

### DIFF
--- a/docs/scheduled-tasks/css-scaling.md
+++ b/docs/scheduled-tasks/css-scaling.md
@@ -3,7 +3,7 @@
 _Audit model: claude-sonnet-4-6_
 _Action model: claude-opus-4-6_
 _Audit cadence: daily_
-_Last audited: 2026-04-17_
+_Last audited: 2026-04-18_
 _Last action: 2026-04-17_
 
 ---

--- a/docs/scheduled-tasks/typescript-eslint.md
+++ b/docs/scheduled-tasks/typescript-eslint.md
@@ -3,7 +3,7 @@
 _Audit model: claude-sonnet-4-6_
 _Action model: claude-opus-4-6_
 _Audit cadence: daily_
-_Last audited: 2026-04-17_
+_Last audited: 2026-04-18_
 _Last action: never_
 
 ---
@@ -16,7 +16,7 @@ _Nothing currently in progress._
 
 ## Open
 
-_No open items. Both `pnpm type-check` and `pnpm lint` pass cleanly as of 2026-04-17. TypeScript: 0 errors. ESLint: 0 errors, 0 warnings (`--max-warnings 0`)._
+_No open items. Both `pnpm type-check` and `pnpm lint` pass cleanly as of 2026-04-18. TypeScript: 0 errors. ESLint: 0 errors, 0 warnings (`--max-warnings 0`)._
 
 ---
 

--- a/docs/scheduled-tasks/widget-registry.md
+++ b/docs/scheduled-tasks/widget-registry.md
@@ -3,7 +3,7 @@
 _Audit model: claude-sonnet-4-6_
 _Action model: claude-opus-4-6_
 _Audit cadence: daily_
-_Last audited: 2026-04-17_
+_Last audited: 2026-04-18_
 _Last action: never_
 
 ---


### PR DESCRIPTION
This pull request updates the audit dates in several scheduled task documentation files to reflect the most recent audit. There are no functional or code changes.

- Documentation updates:
  * Updated the `_Last audited_` date to `2026-04-18` in `css-scaling.md`, `typescript-eslint.md`, and `widget-registry.md` to indicate the latest audit. [[1]](diffhunk://#diff-72998ebae4abf848d127e7b902c4c872201f1e4687f8a30a947f35f44d94ec9fL6-R6) [[2]](diffhunk://#diff-b14054f30aec4a319e0cd4c8abbc3a20d29555be4a6f8c2b8e052473434795ceL6-R6) [[3]](diffhunk://#diff-9fe9da5a76be6febd2939678c859474727eaf93f4656d0ae8fa5270c1d5b4d06L6-R6)
  * Updated the status note in `typescript-eslint.md` to confirm both `pnpm type-check` and `pnpm lint` pass cleanly as of `2026-04-18`.