### PR TITLE
feat(org): Phase 1 — schema, rules, migration (read-only foundation)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ package-lock.json
 .firebase
 firebase-debug.log
 service-account-key.json
+scripts/org-seed.json
 
 # Backups
 *.backup

--- a/components/admin/Organization/mockData.ts
+++ b/components/admin/Organization/mockData.ts
@@ -1,6 +1,8 @@
 import type {
   BuildingRecord,
+  CapabilityAccess,
   CapabilityGroup,
+  CapabilityId,
   DomainRecord,
   OrgRecord,
   RoleRecord,
@@ -200,12 +202,17 @@ export const SEED_DOMAINS: DomainRecord[] = [
   },
 ];
 
-const full = (caps: string[]): Record<string, 'full'> =>
-  Object.fromEntries(caps.map((c) => [c, 'full'])) as Record<string, 'full'>;
-
-const allCaps: string[] = CAPABILITY_GROUPS.flatMap((g) =>
+const ALL_CAP_IDS: CapabilityId[] = CAPABILITY_GROUPS.flatMap((g) =>
   g.capabilities.map((c) => c.id)
 );
+
+const allWith = (
+  value: CapabilityAccess
+): Record<CapabilityId, CapabilityAccess> =>
+  Object.fromEntries(ALL_CAP_IDS.map((c) => [c, value])) as Record<
+    CapabilityId,
+    CapabilityAccess
+  >;
 
 export const SEED_ROLES: RoleRecord[] = [
   {
@@ -214,7 +221,7 @@ export const SEED_ROLES: RoleRecord[] = [
     blurb: 'SpartBoard staff. Full access across every organization.',
     color: 'rose',
     system: true,
-    perms: full(allCaps),
+    perms: allWith('full'),
   },
   {
     id: 'domain_admin',
@@ -223,11 +230,7 @@ export const SEED_ROLES: RoleRecord[] = [
     color: 'indigo',
     system: true,
     perms: {
-      ...full(
-        allCaps.filter(
-          (c) => !['manageOrgs', 'toggleAI', 'viewPlatform'].includes(c)
-        )
-      ),
+      ...allWith('full'),
       manageOrgs: 'none',
       toggleAI: 'none',
       viewPlatform: 'none',

--- a/components/admin/Organization/types.ts
+++ b/components/admin/Organization/types.ts
@@ -1,92 +1,25 @@
-export type ActorRole = 'super_admin' | 'domain_admin' | 'building_admin';
-
-export type RoleId = string;
-
-export type Plan = 'basic' | 'expanded' | 'full';
-
-export type CapabilityAccess = 'full' | 'building' | 'none';
-
-export type BuildingType = 'elementary' | 'middle' | 'high' | 'other';
-
-export type AuthMethod = 'google' | 'microsoft' | 'saml' | 'password' | 'email';
-
-export type DomainStatus = 'verified' | 'pending';
-
-export type DomainRole = 'primary' | 'student' | 'staff';
-
-export type UserStatus = 'active' | 'invited' | 'inactive';
-
-export interface OrgRecord {
-  id: string;
-  name: string;
-  shortName: string;
-  shortCode: string; // 2-4 letters, used in avatars
-  state: string;
-  plan: Plan;
-  aiEnabled: boolean;
-  primaryAdminEmail: string;
-  createdAt: string; // ISO date
-  users: number;
-  buildings: number;
-  status: 'active' | 'trial' | 'archived';
-  seedColor: string; // tailwind bg class e.g. 'bg-indigo-600'
-  supportUrl?: string;
-}
-
-export interface BuildingRecord {
-  id: string;
-  orgId: string;
-  name: string;
-  type: BuildingType;
-  address: string;
-  grades: string; // e.g. 'K-2', '3-5'
-  users: number;
-  adminEmails: string[];
-}
-
-export interface DomainRecord {
-  id: string;
-  orgId: string;
-  domain: string; // e.g. '@orono.k12.mn.us'
-  authMethod: AuthMethod;
-  status: DomainStatus;
-  role: DomainRole;
-  users: number;
-  addedAt: string; // ISO date
-}
-
-export interface RoleRecord {
-  id: RoleId;
-  name: string;
-  blurb: string;
-  color: string; // tailwind accent name: 'rose'|'indigo'|'violet'|'emerald'|'sky'
-  system: boolean;
-  perms: Record<string, CapabilityAccess>;
-}
-
-export interface UserRecord {
-  id: string;
-  orgId: string;
-  name: string;
-  email: string;
-  role: RoleId;
-  buildingIds: string[];
-  status: UserStatus;
-  lastActive: string | null; // ISO date or null
-  invitedAt?: string;
-}
-
-export interface CapabilityGroup {
-  id: string;
-  label: string;
-  capabilities: { id: string; label: string }[];
-}
-
-export interface StudentPageConfig {
-  orgId: string;
-  showAnnouncements: boolean;
-  showTeacherDirectory: boolean;
-  showLunchMenu: boolean;
-  accentColor: string; // hex
-  heroText: string;
-}
+// Organization types moved to @/types/organization so they can be shared
+// between UI components and the Firestore-backed hooks. This file re-exports
+// the shared module for backward compatibility; import from
+// '@/types/organization' in new code.
+export type {
+  ActorRole,
+  AuthMethod,
+  BuildingRecord,
+  BuildingType,
+  CapabilityAccess,
+  CapabilityGroup,
+  CapabilityId,
+  DomainRecord,
+  DomainRole,
+  DomainStatus,
+  InvitationRecord,
+  MemberRecord,
+  OrgRecord,
+  Plan,
+  RoleId,
+  RoleRecord,
+  StudentPageConfig,
+  UserRecord,
+  UserStatus,
+} from '@/types/organization';

--- a/components/admin/Organization/views/RolesView.tsx
+++ b/components/admin/Organization/views/RolesView.tsx
@@ -8,7 +8,12 @@ import {
   Copy,
   Home as HomeIcon,
 } from 'lucide-react';
-import type { CapabilityAccess, RoleId, RoleRecord } from '../types';
+import type {
+  CapabilityAccess,
+  CapabilityId,
+  RoleId,
+  RoleRecord,
+} from '../types';
 import { CAPABILITY_GROUPS } from '../mockData';
 import {
   Badge,
@@ -73,7 +78,11 @@ export const RolesView: React.FC<Props> = ({ roles, onSave, onReset }) => {
 
   const activeRole = working.find((r) => r.id === activeRoleId) ?? working[0];
 
-  const setCellValue = (roleId: RoleId, capId: string, v: CapabilityAccess) => {
+  const setCellValue = (
+    roleId: RoleId,
+    capId: CapabilityId,
+    v: CapabilityAccess
+  ) => {
     setWorking((prev) =>
       prev.map((r) =>
         r.id === roleId ? { ...r, perms: { ...r.perms, [capId]: v } } : r
@@ -268,7 +277,7 @@ export const RolesView: React.FC<Props> = ({ roles, onSave, onReset }) => {
                   c.id,
                   'none' as CapabilityAccess,
                 ])
-              ),
+              ) as Record<CapabilityId, CapabilityAccess>,
             },
           ]);
           setActiveRoleId(id);

--- a/docs/organization_wiring_implementation.md
+++ b/docs/organization_wiring_implementation.md
@@ -88,7 +88,7 @@ Lays the data model, gets rules in place for read-only access, and migrates exis
 ### Deliverables
 
 - [ ] `/organizations/orono` doc created in Firestore with seeded defaults _(deferred to task G)_
-- [ ] System roles (`super_admin`, `domain_admin`, `building_admin`, `teacher`) seeded into `/organizations/orono/roles/*` _(deferred to task G)_
+- [ ] System roles (`super_admin`, `domain_admin`, `building_admin`, `teacher`, `student`) seeded into `/organizations/orono/roles/*` _(deferred to task G)_
 - [ ] Buildings seeded from input CSV into `/organizations/orono/buildings/*` _(deferred to task G)_
 - [ ] Every current `/admins/*` email upserted into `/organizations/orono/members/{emailLower}` with correct roleId _(deferred to task G)_
 - [ ] Every `admin_settings/user_roles.superAdmins` email upserted as `super_admin` role _(deferred to task G)_

--- a/docs/organization_wiring_implementation.md
+++ b/docs/organization_wiring_implementation.md
@@ -23,13 +23,13 @@ If implementation is interrupted, do this before writing any code:
 
 ## Current State
 
-| Field               | Value                                |
-| ------------------- | ------------------------------------ |
-| Active phase        | _(none — not started)_               |
-| Active branch       | _(none)_                             |
-| Last completed task | _(none)_                             |
-| Last updated (UTC)  | 2026-04-18                           |
-| Next action         | Start Phase 1 — Schema and migration |
+| Field               | Value                                                                   |
+| ------------------- | ----------------------------------------------------------------------- |
+| Active phase        | Phase 1 — Schema, rules, migration                                      |
+| Active branch       | `claude/implement-phase-1-AB4DD` (local; opened against `dev-paul`)     |
+| Last completed task | Phase 1 / D — Rules unit tests                                          |
+| Last updated (UTC)  | 2026-04-18                                                              |
+| Next action         | Phase 1 / E–G (firebase deploy + migration run, needs live preview env) |
 
 ---
 
@@ -82,43 +82,43 @@ Each phase below calls out **which task groups can run in parallel** under sub-a
 
 Lays the data model, gets rules in place for read-only access, and migrates existing admins into the new `members` collection. No UI changes yet; `mockData.ts` continues to back every view.
 
-**Branch:** `claude/org-wiring-p1-schema`
-**Status:** Not started
+**Branch:** `claude/implement-phase-1-AB4DD` (tasks A–D landed here; opens against `dev-paul`)
+**Status:** Code tasks (A–D) complete; live-env tasks (E–G) deferred until a Firebase preview is available.
 
 ### Deliverables
 
-- [ ] `/organizations/orono` doc created in Firestore with seeded defaults
-- [ ] System roles (`super_admin`, `domain_admin`, `building_admin`, `teacher`) seeded into `/organizations/orono/roles/*`
-- [ ] Buildings seeded from input CSV into `/organizations/orono/buildings/*`
-- [ ] Every current `/admins/*` email upserted into `/organizations/orono/members/{emailLower}` with correct roleId
-- [ ] Every `admin_settings/user_roles.superAdmins` email upserted as `super_admin` role
-- [ ] `firestore.rules` extended with new helpers (`isSuperAdmin()`, `orgMember()`, `memberRole()`, `roleHasCap()`, `isDomainAdmin()`, `isBuildingAdmin()`)
-- [ ] Rules allow authed org members to `read` org/buildings/domains/roles/members; all writes still denied
-- [ ] Rules-unit tests green via `@firebase/rules-unit-testing`
-- [ ] `scripts/setup-organization.js` idempotent via `set(…, { merge: true })`, with `--dry-run` flag
+- [ ] `/organizations/orono` doc created in Firestore with seeded defaults _(deferred to task G)_
+- [ ] System roles (`super_admin`, `domain_admin`, `building_admin`, `teacher`) seeded into `/organizations/orono/roles/*` _(deferred to task G)_
+- [ ] Buildings seeded from input CSV into `/organizations/orono/buildings/*` _(deferred to task G)_
+- [ ] Every current `/admins/*` email upserted into `/organizations/orono/members/{emailLower}` with correct roleId _(deferred to task G)_
+- [ ] Every `admin_settings/user_roles.superAdmins` email upserted as `super_admin` role _(deferred to task G)_
+- [x] `firestore.rules` extended with new helpers (`isSuperAdmin()`, `orgMember()`, `memberRole()`, `roleHasCap()`, `isDomainAdmin()`, `isBuildingAdmin()`, plus `isOrgMember()`)
+- [x] Rules allow authed org members to `read` org/buildings/domains/roles/members; all writes still denied (Phase 3 TODO comments in place)
+- [x] Rules-unit tests written for `@firebase/rules-unit-testing` — green run requires the Firestore emulator (`pnpm run test:rules`)
+- [x] `scripts/setup-organization.js` idempotent via `set(…, { merge: true })`, with `--dry-run` flag
 
 ### Task ledger
 
 **Parallelizable (kick off together):**
 
-- [ ] **A — Type definitions.** Move `components/admin/Organization/types.ts` → `types/organization.ts` (shared between UI and hooks). Add `MemberRecord`, `InvitationRecord`, tighten `RoleRecord.perms` to `Record<CapabilityId, 'full' | 'building' | 'none'>`.
-- [ ] **B — Security rules.** Write new helpers in `firestore.rules`. Read-only for now; all `allow write` stubs return `false` with a TODO comment linking P3.
-- [ ] **C — Migration script.** `scripts/setup-organization.js` based on `scripts/setup-admins.js`. Reads org config from `scripts/org-seed.json` (gitignored — use `scripts/org-seed.example.json` as template). Supports `--dry-run`.
+- [x] **A — Type definitions.** Moved `components/admin/Organization/types.ts` → `types/organization.ts` (the old path re-exports for back-compat). Added `MemberRecord`, `InvitationRecord`, `CapabilityId` union, and tightened `RoleRecord.perms` to `Record<CapabilityId, CapabilityAccess>`. Updated `mockData.ts` + `RolesView.tsx` to satisfy the tighter type.
+- [x] **B — Security rules.** Added `isSuperAdmin()`, `orgMember()`, `memberRole()`, `roleHasCap()`, `isDomainAdmin()`, `isBuildingAdmin()`, and `isOrgMember()` helpers in `firestore.rules`. `/organizations/{orgId}` + sub-collections (`buildings`, `domains`, `roles`, `members`, `studentPageConfig`, `invitations`) are read-only for org members; `invitations` is fully locked. All write stubs are `if false` with `TODO(phase-3)` / `TODO(phase-4)` comments.
+- [x] **C — Migration script.** `scripts/setup-organization.js` mirrors `scripts/setup-admins.js`. Reads config from `scripts/org-seed.json` (gitignored — copy `scripts/org-seed.example.json`). Supports `--dry-run` and `--seed <path>`; batches writes in chunks of 400 with `{ merge: true }`.
 
 **Serial (after parallel block completes):**
 
-- [ ] **D — Rules tests.** `tests/e2e/firestore-rules-organizations.test.ts` covering: member can read, non-member cannot read, all writes denied. Run via `firebase emulators:exec`.
-- [ ] **E — Deploy rules to preview.** `firebase deploy --only firestore:rules --project <preview>`. Verify existing `isAdmin()` rules still pass by hitting a known admin-gated collection.
+- [x] **D — Rules tests.** `tests/rules/firestore-rules-organizations.test.ts` (not `tests/e2e/` — that dir is owned by Playwright; `tests/rules` is excluded from default vitest and invoked via `firebase emulators:exec` through `pnpm run test:rules`, using a dedicated `vitest.rules.config.ts`). Covers: member reads, outsider-reads-blocked (except own member-doc probe), super-admin bypass via legacy `admin_settings/user_roles.superAdmins`, all writes denied, invitations fully locked, and no regression on `/admins/{email}`.
+- [ ] **E — Deploy rules to preview.** `firebase deploy --only firestore:rules --project <preview>`. Verify existing `isAdmin()` rules still pass by hitting a known admin-gated collection. _(Requires preview-project access — not runnable in this session.)_
 - [ ] **F — Run migration dry-run.** `node scripts/setup-organization.js --dry-run` against preview; review planned writes.
 - [ ] **G — Run migration for real.** `node scripts/setup-organization.js`. Verify in Firebase console that `/organizations/orono/members` contains all expected emails.
-- [ ] **H — Update this doc.** Mark Phase 1 complete; set Current State → Phase 2.
+- [ ] **H — Update this doc.** Mark Phase 1 complete; set Current State → Phase 2. _(Blocked on E–G.)_
 
 ### Acceptance checklist
 
-- [ ] `pnpm run validate` passes
-- [ ] Firestore emulator rules tests pass
-- [ ] Migration script is idempotent (running twice produces no diff)
-- [ ] Existing admin users can still sign in and open Admin Settings (legacy `isAdmin()` still reads `/admins/*`)
+- [x] `pnpm run validate` passes (type-check, lint, format-check, unit tests)
+- [ ] Firestore emulator rules tests pass _(pending first emulator run — see task D)_
+- [ ] Migration script is idempotent (running twice produces no diff) _(verify during task G)_
+- [ ] Existing admin users can still sign in and open Admin Settings (legacy `isAdmin()` still reads `/admins/*`) _(verify during task E)_
 
 ---
 
@@ -305,6 +305,8 @@ Record non-obvious choices so future sessions don't re-litigate them. Append; do
 - **2026-04-18** — Per-view hooks, not one `useOrganization` mega-hook. Matches existing `useFeaturePermissions` convention; enables granular `onSnapshot` subscriptions + parallel agent implementation.
 - **2026-04-18** — Writes gate through existing `feature_permissions` collection (new `orgAdminWrites` key), not a new flag system. Reuses real-time sync infrastructure.
 - **2026-04-18** — Migration script is idempotent via `merge: true`, with `--dry-run` flag. Pattern: `scripts/setup-admins.js`.
+- **2026-04-18** — Rules tests live in `tests/rules/` (not `tests/e2e/`) because `tests/e2e/` is the Playwright test root; keeping emulator-dependent vitest tests in a separate directory lets the default `pnpm test` stay emulator-free while `pnpm run test:rules` wraps them in `firebase emulators:exec`.
+- **2026-04-18** — `isSuperAdmin()` in `firestore.rules` reads from the legacy `admin_settings/user_roles.superAdmins` list (not from an org-scoped `members` roleId). The check is called without an `orgId` context, so it has to use a global source; the migration also upserts supers into Orono's members for Phase 2 UI parity.
 
 ---
 
@@ -312,4 +314,4 @@ Record non-obvious choices so future sessions don't re-litigate them. Append; do
 
 Append one line per commit that advances this plan. Include short SHA + task letter.
 
-_(Empty — no work landed yet.)_
+- 2026-04-18 — Phase 1 A–D landed on `claude/implement-phase-1-AB4DD` (types, rules, migration script, rules-unit-testing suite).

--- a/firestore.rules
+++ b/firestore.rules
@@ -10,6 +10,104 @@ service cloud.firestore {
              exists(/databases/$(database)/documents/admins/$(request.auth.token.email.lower()));
     }
 
+    // ---- Organization helpers (see docs/organization_wiring_implementation.md) ----
+
+    // Super admins are listed on the legacy admin_settings/user_roles doc.
+    // Phase 1 also upserts them as /organizations/{orgId}/members with roleId
+    // 'super_admin', but because super-admin checks run globally (not scoped
+    // to a single org) the rules keep reading the legacy list here.
+    function isSuperAdmin() {
+      return request.auth != null &&
+             request.auth.token.email != null &&
+             exists(/databases/$(database)/documents/admin_settings/user_roles) &&
+             request.auth.token.email.lower() in
+               get(/databases/$(database)/documents/admin_settings/user_roles).data.get('superAdmins', []);
+    }
+
+    // Returns the caller's /organizations/{orgId}/members/{email} doc data.
+    // Callers must guard with isOrgMember(orgId) first; otherwise get() fails.
+    function orgMember(orgId) {
+      return get(/databases/$(database)/documents/organizations/$(orgId)/members/$(request.auth.token.email.lower())).data;
+    }
+
+    // The caller's roleId within an org, or empty string when not a member.
+    function memberRole(orgId, emailLower) {
+      return exists(/databases/$(database)/documents/organizations/$(orgId)/members/$(emailLower))
+             ? get(/databases/$(database)/documents/organizations/$(orgId)/members/$(emailLower)).data.get('roleId', '')
+             : '';
+    }
+
+    // Check whether a role has a given capability at the given access level.
+    // access: 'full' | 'building' | 'none'. A missing perm defaults to 'none'.
+    function roleHasCap(orgId, roleId, capId, access) {
+      return exists(/databases/$(database)/documents/organizations/$(orgId)/roles/$(roleId)) &&
+             get(/databases/$(database)/documents/organizations/$(orgId)/roles/$(roleId)).data
+               .get('perms', {}).get(capId, 'none') == access;
+    }
+
+    function isDomainAdmin(orgId) {
+      return request.auth != null && request.auth.token.email != null &&
+             memberRole(orgId, request.auth.token.email.lower()) == 'domain_admin';
+    }
+
+    function isBuildingAdmin(orgId) {
+      return request.auth != null && request.auth.token.email != null &&
+             memberRole(orgId, request.auth.token.email.lower()) == 'building_admin';
+    }
+
+    // True when the caller is an active member of the org (any role).
+    function isOrgMember(orgId) {
+      return request.auth != null && request.auth.token.email != null &&
+             exists(/databases/$(database)/documents/organizations/$(orgId)/members/$(request.auth.token.email.lower()));
+    }
+
+    // ---- Organizations collection (Phase 1: read-only foundation) ----
+    // All writes are blocked until Phase 3 wires the scoping + feature flag.
+    // TODO(phase-3): replace `allow write: if false` with scoped rules using
+    // isSuperAdmin(), isDomainAdmin(orgId), isBuildingAdmin(orgId).
+
+    match /organizations/{orgId} {
+      allow read: if isSuperAdmin() || isOrgMember(orgId);
+      allow write: if false; // TODO(phase-3)
+
+      match /buildings/{buildingId} {
+        allow read: if isSuperAdmin() || isOrgMember(orgId);
+        allow write: if false; // TODO(phase-3)
+      }
+
+      match /domains/{domainId} {
+        allow read: if isSuperAdmin() || isOrgMember(orgId);
+        allow write: if false; // TODO(phase-3)
+      }
+
+      match /roles/{roleId} {
+        allow read: if isSuperAdmin() || isOrgMember(orgId);
+        allow write: if false; // TODO(phase-3)
+      }
+
+      match /members/{emailLower} {
+        // Members can always see their own membership (to bootstrap useAuth);
+        // other org members can see the member directory.
+        allow read: if isSuperAdmin() ||
+                    isOrgMember(orgId) ||
+                    (request.auth != null &&
+                     request.auth.token.email != null &&
+                     request.auth.token.email.lower() == emailLower);
+        allow write: if false; // TODO(phase-3)
+      }
+
+      match /studentPageConfig/{configId} {
+        allow read: if isSuperAdmin() || isOrgMember(orgId);
+        allow write: if false; // TODO(phase-3)
+      }
+
+      match /invitations/{token} {
+        // Phase 4 wires invite acceptance; until then nothing reads or writes
+        // from the client — Cloud Functions own this collection.
+        allow read, write: if false; // TODO(phase-4)
+      }
+    }
+
     // Admins collection
     match /admins/{email} {
       // Users can read their own admin record to check status

--- a/firestore.rules
+++ b/firestore.rules
@@ -68,38 +68,46 @@ service cloud.firestore {
     // TODO(phase-3): replace `allow write: if false` with scoped rules using
     // isSuperAdmin(), isDomainAdmin(orgId), isBuildingAdmin(orgId).
 
+    // Short-circuit ordering note: `isOrgMember()` performs a single targeted
+    // `exists()` against the caller's member doc, while `isSuperAdmin()` runs
+    // `exists()` + `get()` on `admin_settings/user_roles`. Checking membership
+    // first keeps the common teacher path cheap and falls back to the super-
+    // admin lookup only for non-members.
+
     match /organizations/{orgId} {
-      allow read: if isSuperAdmin() || isOrgMember(orgId);
+      allow read: if isOrgMember(orgId) || isSuperAdmin();
       allow write: if false; // TODO(phase-3)
 
       match /buildings/{buildingId} {
-        allow read: if isSuperAdmin() || isOrgMember(orgId);
+        allow read: if isOrgMember(orgId) || isSuperAdmin();
         allow write: if false; // TODO(phase-3)
       }
 
       match /domains/{domainId} {
-        allow read: if isSuperAdmin() || isOrgMember(orgId);
+        allow read: if isOrgMember(orgId) || isSuperAdmin();
         allow write: if false; // TODO(phase-3)
       }
 
       match /roles/{roleId} {
-        allow read: if isSuperAdmin() || isOrgMember(orgId);
+        allow read: if isOrgMember(orgId) || isSuperAdmin();
         allow write: if false; // TODO(phase-3)
       }
 
       match /members/{emailLower} {
         // Members can always see their own membership (to bootstrap useAuth);
-        // other org members can see the member directory.
-        allow read: if isSuperAdmin() ||
+        // other org members can see the member directory. Self-probe comes
+        // first so a non-member checking their own (absent) doc never triggers
+        // the super-admin lookup.
+        allow read: if (request.auth != null &&
+                       request.auth.token.email != null &&
+                       request.auth.token.email.lower() == emailLower) ||
                     isOrgMember(orgId) ||
-                    (request.auth != null &&
-                     request.auth.token.email != null &&
-                     request.auth.token.email.lower() == emailLower);
+                    isSuperAdmin();
         allow write: if false; // TODO(phase-3)
       }
 
       match /studentPageConfig/{configId} {
-        allow read: if isSuperAdmin() || isOrgMember(orgId);
+        allow read: if isOrgMember(orgId) || isSuperAdmin();
         allow write: if false; // TODO(phase-3)
       }
 

--- a/firestore.rules
+++ b/firestore.rules
@@ -55,7 +55,9 @@ service cloud.firestore {
              memberRole(orgId, request.auth.token.email.lower()) == 'building_admin';
     }
 
-    // True when the caller is an active member of the org (any role).
+    // True when the caller has a member doc under the given org (any role,
+    // any status). Phase 1 intentionally does not filter on status:'active';
+    // Phase 3 will add a status check once invited/inactive states are wired.
     function isOrgMember(orgId) {
       return request.auth != null && request.auth.token.email != null &&
              exists(/databases/$(database)/documents/organizations/$(orgId)/members/$(request.auth.token.email.lower()));

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "validate": "pnpm run type-check:all && pnpm lint && pnpm format:check && pnpm test",
     "test": "vitest run",
     "test:e2e": "playwright test",
+    "test:rules": "firebase emulators:exec --only firestore \"vitest run --config vitest.rules.config.ts\"",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
     "prepare": "husky"
@@ -61,6 +62,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.39.2",
+    "@firebase/rules-unit-testing": "^5.0.0",
     "@google/genai": "^1.39.0",
     "@playwright/test": "^1.58.0",
     "@testing-library/dom": "^10.4.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,6 +75,9 @@ importers:
       '@eslint/js':
         specifier: ^9.39.2
         version: 9.39.2
+      '@firebase/rules-unit-testing':
+        specifier: ^5.0.0
+        version: 5.0.0(firebase@12.8.0)
       '@google/genai':
         specifier: ^1.39.0
         version: 1.39.0(@modelcontextprotocol/sdk@1.25.2(hono@4.11.4)(zod@3.25.76))
@@ -944,6 +947,12 @@ packages:
     resolution: {integrity: sha512-sJz7C2VACeE257Z/3kY9Ap2WXbFsgsDLfaGfZmmToKAK39ipXxFan+vzB9CSbF6mP7bzjyzEnqPcMXhAnYE6fQ==}
     peerDependencies:
       '@firebase/app': 0.x
+
+  '@firebase/rules-unit-testing@5.0.0':
+    resolution: {integrity: sha512-C6+d3Msgjnqay2ml663ChvKYoD8VsQ+TIa0e+fGq0LFC0CKSPlacT1EVGL/ryo6Rc+wFs7Fpqz3fRlYdUEa2bA==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      firebase: ^12.0.0
 
   '@firebase/storage-compat@0.4.0':
     resolution: {integrity: sha512-vDzhgGczr1OfcOy285YAPur5pWDEvD67w4thyeCUh6Ys0izN9fNYtA1MJERmNBfqjqu0lg0FM5GLbw0Il21M+g==}
@@ -7119,6 +7128,10 @@ snapshots:
       '@firebase/logger': 0.5.0
       '@firebase/util': 1.13.0
       tslib: 2.8.1
+
+  '@firebase/rules-unit-testing@5.0.0(firebase@12.8.0)':
+    dependencies:
+      firebase: 12.8.0
 
   '@firebase/storage-compat@0.4.0(@firebase/app-compat@0.5.7)(@firebase/app-types@0.9.3)(@firebase/app@0.14.7)':
     dependencies:

--- a/scripts/org-seed.example.json
+++ b/scripts/org-seed.example.json
@@ -1,0 +1,65 @@
+{
+  "orgId": "orono",
+  "org": {
+    "name": "Orono Public Schools",
+    "shortName": "Orono",
+    "shortCode": "OPS",
+    "state": "MN",
+    "plan": "full",
+    "aiEnabled": true,
+    "primaryAdminEmail": "paul.ivers@orono.k12.mn.us",
+    "status": "active",
+    "seedColor": "bg-indigo-600",
+    "supportUrl": "https://orono.k12.mn.us/support"
+  },
+  "buildings": [
+    {
+      "id": "schumann",
+      "name": "Schumann Elementary",
+      "type": "elementary",
+      "address": "5455 Old Crystal Bay Rd N",
+      "grades": "K-2",
+      "adminEmails": []
+    },
+    {
+      "id": "intermediate",
+      "name": "Orono Intermediate",
+      "type": "elementary",
+      "address": "685 Old Crystal Bay Rd N",
+      "grades": "3-5",
+      "adminEmails": []
+    },
+    {
+      "id": "middle",
+      "name": "Orono Middle School",
+      "type": "middle",
+      "address": "685 Old Crystal Bay Rd N",
+      "grades": "6-8",
+      "adminEmails": []
+    },
+    {
+      "id": "high",
+      "name": "Orono High School",
+      "type": "high",
+      "address": "795 Old Crystal Bay Rd N",
+      "grades": "9-12",
+      "adminEmails": []
+    }
+  ],
+  "domains": [
+    {
+      "id": "primary",
+      "domain": "@orono.k12.mn.us",
+      "authMethod": "google",
+      "status": "verified",
+      "role": "primary"
+    }
+  ],
+  "studentPage": {
+    "showAnnouncements": true,
+    "showTeacherDirectory": true,
+    "showLunchMenu": false,
+    "accentColor": "#2d3f89",
+    "heroText": "Welcome, Orono students!"
+  }
+}

--- a/scripts/setup-organization.js
+++ b/scripts/setup-organization.js
@@ -225,6 +225,7 @@ async function run() {
 
   // 1. Org doc
   const nowIso = new Date().toISOString();
+  const buildings = seed.buildings ?? [];
   writer.set(`organizations/${orgId}`, {
     id: orgId,
     name: seed.org.name,
@@ -238,10 +239,13 @@ async function run() {
     seedColor: seed.org.seedColor ?? 'bg-indigo-600',
     supportUrl: seed.org.supportUrl ?? null,
     createdAt: nowIso,
+    // Counters required by OrgRecord. A Phase-4 Cloud Function will keep
+    // `users` in sync; seed `buildings` from the migration input.
+    users: 0,
+    buildings: buildings.length,
   });
 
   // 2. Buildings
-  const buildings = seed.buildings ?? [];
   for (const b of buildings) {
     if (!b.id) throw new Error('Every building must have an "id".');
     writer.set(`organizations/${orgId}/buildings/${b.id}`, {
@@ -252,6 +256,7 @@ async function run() {
       address: b.address ?? '',
       grades: b.grades ?? '',
       adminEmails: (b.adminEmails ?? []).map((e) => e.toLowerCase()),
+      users: 0,
     });
   }
 
@@ -267,6 +272,7 @@ async function run() {
       status: d.status ?? 'pending',
       role: d.role ?? 'staff',
       addedAt: nowIso,
+      users: 0,
     });
   }
 
@@ -284,7 +290,7 @@ async function run() {
     accentColor: seed.studentPage?.accentColor ?? '#2d3f89',
     heroText:
       seed.studentPage?.heroText ??
-      `Welcome, ${seed.org.shortName ?? ''}!`.trim(),
+      `Welcome, ${seed.org.shortName ?? seed.org.name ?? ''}!`.trim(),
   });
 
   // 6. Members from legacy /admins/*
@@ -318,7 +324,7 @@ async function run() {
       buildingIds: [],
       status: 'active',
       addedBy: 'migration:setup-organization',
-      migratedAt: nowIso,
+      invitedAt: nowIso,
     });
   }
 

--- a/scripts/setup-organization.js
+++ b/scripts/setup-organization.js
@@ -331,13 +331,16 @@ async function run() {
   const allMemberEmails = new Set([...adminEmails, ...superAdmins]);
   for (const email of allMemberEmails) {
     const roleId = superSet.has(email) ? 'super_admin' : 'domain_admin';
+    // `addedBy` is reserved for real Firebase Auth uids (per MemberRecord
+    // in types/organization.ts). Migration-created members omit it and
+    // record provenance in `addedBySource` instead.
     writer.set(`organizations/${orgId}/members/${email}`, {
       email,
       orgId,
       roleId,
       buildingIds: [],
       status: 'active',
-      addedBy: 'migration:setup-organization',
+      addedBySource: 'migration:setup-organization',
       invitedAt: nowIso,
     });
   }

--- a/scripts/setup-organization.js
+++ b/scripts/setup-organization.js
@@ -1,0 +1,345 @@
+/**
+ * Organization migration script (Phase 1 of the Organization wiring plan).
+ *
+ * Creates the /organizations/{orgId} hierarchy and seeds it with:
+ *   - the org doc (name, shortCode, plan, aiEnabled, …)
+ *   - buildings, domains, system roles, studentPageConfig/default
+ *   - members for every current /admins/* email (roleId: domain_admin)
+ *   - members for every admin_settings/user_roles.superAdmins email
+ *     (roleId: super_admin)
+ *
+ * All writes use `{ merge: true }` so the script is idempotent — running it
+ * twice produces no diff.
+ *
+ * Usage:
+ *   node scripts/setup-organization.js [--dry-run] [--seed <path>]
+ *
+ * Seed config is loaded from scripts/org-seed.json by default (gitignored).
+ * Copy scripts/org-seed.example.json → scripts/org-seed.json and edit before
+ * running for real.
+ *
+ * Credentials resolution mirrors scripts/setup-admins.js:
+ *   1. FIREBASE_SERVICE_ACCOUNT env var (JSON)
+ *   2. scripts/service-account-key.json
+ */
+
+import { initializeApp, cert } from 'firebase-admin/app';
+import { getFirestore } from 'firebase-admin/firestore';
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+// Mirror of types/organization.ts CapabilityId + the system role templates.
+// Kept in JS so the script has no runtime dependency on TS — if a capability
+// is added there, add it here too and the migration will seed the new cap.
+const ALL_CAPS = [
+  'viewBoards',
+  'editBoards',
+  'shareBoards',
+  'saveTemplate',
+  'accessAdmin',
+  'manageUsers',
+  'manageRoles',
+  'manageBuildings',
+  'configureWidgets',
+  'manageBackgrounds',
+  'postAnnouncements',
+  'editOrg',
+  'manageDomains',
+  'editStudentPage',
+  'manageOrgs',
+  'toggleAI',
+  'viewPlatform',
+  'joinSession',
+  'viewAssignments',
+];
+
+const allWith = (value) => Object.fromEntries(ALL_CAPS.map((c) => [c, value]));
+
+const SYSTEM_ROLES = [
+  {
+    id: 'super_admin',
+    name: 'Super admin',
+    blurb: 'SpartBoard staff. Full access across every organization.',
+    color: 'rose',
+    system: true,
+    perms: allWith('full'),
+  },
+  {
+    id: 'domain_admin',
+    name: 'Domain admin',
+    blurb: 'District IT. Full access within this organization.',
+    color: 'indigo',
+    system: true,
+    perms: {
+      ...allWith('full'),
+      manageOrgs: 'none',
+      toggleAI: 'none',
+      viewPlatform: 'none',
+    },
+  },
+  {
+    id: 'building_admin',
+    name: 'Building admin',
+    blurb: 'Principals and site leads. Scoped to their building(s).',
+    color: 'violet',
+    system: true,
+    perms: {
+      ...allWith('none'),
+      viewBoards: 'full',
+      editBoards: 'full',
+      shareBoards: 'full',
+      saveTemplate: 'full',
+      accessAdmin: 'full',
+      manageUsers: 'building',
+      configureWidgets: 'building',
+      manageBackgrounds: 'building',
+      postAnnouncements: 'building',
+    },
+  },
+  {
+    id: 'teacher',
+    name: 'Teacher',
+    blurb: 'Classroom teachers. Can build and share boards.',
+    color: 'emerald',
+    system: true,
+    perms: {
+      ...allWith('none'),
+      viewBoards: 'full',
+      editBoards: 'full',
+      shareBoards: 'full',
+      saveTemplate: 'full',
+    },
+  },
+];
+
+function parseArgs(argv) {
+  const args = { dryRun: false, seedPath: null };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--dry-run' || a === '-n') args.dryRun = true;
+    else if (a === '--seed') args.seedPath = argv[++i];
+    else if (a === '--help' || a === '-h') args.help = true;
+  }
+  return args;
+}
+
+function loadCredentials() {
+  const envJson = process.env.FIREBASE_SERVICE_ACCOUNT;
+  if (envJson) {
+    try {
+      return {
+        source: 'FIREBASE_SERVICE_ACCOUNT env',
+        creds: JSON.parse(envJson),
+      };
+    } catch (e) {
+      throw new Error(
+        `Failed to parse FIREBASE_SERVICE_ACCOUNT env var as JSON: ${e.message}`
+      );
+    }
+  }
+  const path = join(__dirname, 'service-account-key.json');
+  try {
+    return {
+      source: 'scripts/service-account-key.json',
+      creds: JSON.parse(readFileSync(path, 'utf8')),
+    };
+  } catch {
+    throw new Error(
+      'Firebase Admin credentials not found. Either set FIREBASE_SERVICE_ACCOUNT (JSON) ' +
+        'or save the service account key at scripts/service-account-key.json.'
+    );
+  }
+}
+
+function loadSeed(customPath) {
+  const path = customPath ? customPath : join(__dirname, 'org-seed.json');
+  try {
+    return JSON.parse(readFileSync(path, 'utf8'));
+  } catch {
+    throw new Error(
+      `Org seed config not found at ${path}. Copy scripts/org-seed.example.json ` +
+        'to scripts/org-seed.json (or pass --seed <path>) and edit before running.'
+    );
+  }
+}
+
+// Collects writes so --dry-run can print them without committing.
+class Writer {
+  constructor(db, { dryRun }) {
+    this.db = db;
+    this.dryRun = dryRun;
+    this.queued = [];
+  }
+
+  set(refPath, data) {
+    this.queued.push({ path: refPath, data });
+  }
+
+  async flush() {
+    if (this.dryRun) {
+      console.log(`\n[dry-run] Would write ${this.queued.length} documents:`);
+      for (const q of this.queued) {
+        console.log(`  - ${q.path}`);
+      }
+      return;
+    }
+    console.log(`\n✏️  Writing ${this.queued.length} documents…`);
+    // Batch in chunks of 400 to stay under the 500-op batch limit.
+    for (let i = 0; i < this.queued.length; i += 400) {
+      const batch = this.db.batch();
+      for (const { path, data } of this.queued.slice(i, i + 400)) {
+        batch.set(this.db.doc(path), data, { merge: true });
+      }
+      await batch.commit();
+    }
+    console.log(`✅ Wrote ${this.queued.length} documents.`);
+  }
+}
+
+async function run() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    console.log(
+      'Usage: node scripts/setup-organization.js [--dry-run] [--seed <path>]'
+    );
+    process.exit(0);
+  }
+
+  const { source, creds } = loadCredentials();
+  console.log(`✅ Using credentials from ${source}`);
+
+  const seed = loadSeed(args.seedPath);
+  if (!seed.orgId || !seed.org) {
+    throw new Error('Seed config must include "orgId" and "org" fields.');
+  }
+  const orgId = seed.orgId;
+  console.log(`🏢 Migrating organization: ${orgId}`);
+
+  initializeApp({ credential: cert(creds) });
+  const db = getFirestore();
+  const writer = new Writer(db, { dryRun: args.dryRun });
+
+  // 1. Org doc
+  const nowIso = new Date().toISOString();
+  writer.set(`organizations/${orgId}`, {
+    id: orgId,
+    name: seed.org.name,
+    shortName: seed.org.shortName ?? seed.org.name,
+    shortCode: seed.org.shortCode,
+    state: seed.org.state ?? '',
+    plan: seed.org.plan ?? 'basic',
+    aiEnabled: Boolean(seed.org.aiEnabled),
+    primaryAdminEmail: seed.org.primaryAdminEmail?.toLowerCase() ?? '',
+    status: seed.org.status ?? 'active',
+    seedColor: seed.org.seedColor ?? 'bg-indigo-600',
+    supportUrl: seed.org.supportUrl ?? null,
+    createdAt: nowIso,
+  });
+
+  // 2. Buildings
+  const buildings = seed.buildings ?? [];
+  for (const b of buildings) {
+    if (!b.id) throw new Error('Every building must have an "id".');
+    writer.set(`organizations/${orgId}/buildings/${b.id}`, {
+      id: b.id,
+      orgId,
+      name: b.name,
+      type: b.type ?? 'other',
+      address: b.address ?? '',
+      grades: b.grades ?? '',
+      adminEmails: (b.adminEmails ?? []).map((e) => e.toLowerCase()),
+    });
+  }
+
+  // 3. Domains
+  const domains = seed.domains ?? [];
+  for (const d of domains) {
+    if (!d.id) throw new Error('Every domain must have an "id".');
+    writer.set(`organizations/${orgId}/domains/${d.id}`, {
+      id: d.id,
+      orgId,
+      domain: d.domain,
+      authMethod: d.authMethod ?? 'google',
+      status: d.status ?? 'pending',
+      role: d.role ?? 'staff',
+      addedAt: nowIso,
+    });
+  }
+
+  // 4. System roles
+  for (const role of SYSTEM_ROLES) {
+    writer.set(`organizations/${orgId}/roles/${role.id}`, role);
+  }
+
+  // 5. Student page config
+  writer.set(`organizations/${orgId}/studentPageConfig/default`, {
+    orgId,
+    showAnnouncements: seed.studentPage?.showAnnouncements ?? true,
+    showTeacherDirectory: seed.studentPage?.showTeacherDirectory ?? true,
+    showLunchMenu: seed.studentPage?.showLunchMenu ?? false,
+    accentColor: seed.studentPage?.accentColor ?? '#2d3f89',
+    heroText:
+      seed.studentPage?.heroText ??
+      `Welcome, ${seed.org.shortName ?? ''}!`.trim(),
+  });
+
+  // 6. Members from legacy /admins/*
+  console.log('👥 Scanning /admins/* for domain admins…');
+  const adminsSnap = await db.collection('admins').get();
+  const adminEmails = adminsSnap.docs.map((d) => d.id.toLowerCase());
+  console.log(`   Found ${adminEmails.length} admin email(s).`);
+
+  // 7. Super admins from admin_settings/user_roles
+  let superAdmins = [];
+  const userRolesDoc = await db.doc('admin_settings/user_roles').get();
+  if (userRolesDoc.exists) {
+    const data = userRolesDoc.data() ?? {};
+    superAdmins = Array.isArray(data.superAdmins)
+      ? data.superAdmins.map((e) => String(e).toLowerCase())
+      : [];
+    console.log(`   Found ${superAdmins.length} super admin email(s).`);
+  } else {
+    console.log('   admin_settings/user_roles does not exist — skipping.');
+  }
+
+  const superSet = new Set(superAdmins);
+
+  const allMemberEmails = new Set([...adminEmails, ...superAdmins]);
+  for (const email of allMemberEmails) {
+    const roleId = superSet.has(email) ? 'super_admin' : 'domain_admin';
+    writer.set(`organizations/${orgId}/members/${email}`, {
+      email,
+      orgId,
+      roleId,
+      buildingIds: [],
+      status: 'active',
+      addedBy: 'migration:setup-organization',
+      migratedAt: nowIso,
+    });
+  }
+
+  await writer.flush();
+
+  if (args.dryRun) {
+    console.log('\nℹ️  Dry run only — no writes were committed.');
+  } else {
+    console.log('\n✨ Organization setup complete!');
+    console.log(`   Org: /organizations/${orgId}`);
+    console.log(`   Buildings: ${buildings.length}`);
+    console.log(`   Domains: ${domains.length}`);
+    console.log(`   System roles: ${SYSTEM_ROLES.length}`);
+    console.log(`   Members: ${allMemberEmails.size}`);
+  }
+
+  process.exit(0);
+}
+
+run().catch((err) => {
+  console.error('\n❌ setup-organization failed:', err.message ?? err);
+  if (err.stack) console.error(err.stack);
+  process.exit(1);
+});

--- a/scripts/setup-organization.js
+++ b/scripts/setup-organization.js
@@ -114,6 +114,18 @@ const SYSTEM_ROLES = [
       saveTemplate: 'full',
     },
   },
+  {
+    id: 'student',
+    name: 'Student',
+    blurb: 'Students. Can join sessions and view assignments.',
+    color: 'sky',
+    system: true,
+    perms: {
+      ...allWith('none'),
+      joinSession: 'full',
+      viewAssignments: 'full',
+    },
+  },
 ];
 
 function parseArgs(argv) {

--- a/scripts/setup-organization.js
+++ b/scripts/setup-organization.js
@@ -237,7 +237,9 @@ async function run() {
     primaryAdminEmail: seed.org.primaryAdminEmail?.toLowerCase() ?? '',
     status: seed.org.status ?? 'active',
     seedColor: seed.org.seedColor ?? 'bg-indigo-600',
-    supportUrl: seed.org.supportUrl ?? null,
+    // Only include supportUrl when provided — OrgRecord types it as optional
+    // string (not string|null) and Firestore omits undefined fields.
+    ...(seed.org.supportUrl ? { supportUrl: seed.org.supportUrl } : {}),
     createdAt: nowIso,
     // Counters required by OrgRecord. A Phase-4 Cloud Function will keep
     // `users` in sync; seed `buildings` from the migration input.

--- a/tests/rules/firestore-rules-organizations.test.ts
+++ b/tests/rules/firestore-rules-organizations.test.ts
@@ -166,6 +166,17 @@ describe('organizations — reads', () => {
     );
   });
 
+  it('non-member cannot read another user\u2019s member doc', async () => {
+    // Self-probe is the ONLY reason a non-member can read /members/*.
+    // Reading some other user's membership must fall through to the
+    // isOrgMember / isSuperAdmin clauses and be denied.
+    await assertFails(
+      getDoc(
+        doc(asOutsider(), `organizations/${ORG_ID}/members/${MEMBER_EMAIL}`)
+      )
+    );
+  });
+
   it('unauthenticated users cannot read org data', async () => {
     await assertFails(getDoc(doc(asAnon(), `organizations/${ORG_ID}`)));
     await assertFails(

--- a/tests/rules/firestore-rules-organizations.test.ts
+++ b/tests/rules/firestore-rules-organizations.test.ts
@@ -12,7 +12,7 @@
 //   - Legacy /admins/{email} reads still work for the owning user (no regression)
 
 import { readFileSync } from 'fs';
-import { resolve } from 'path';
+import { fileURLToPath } from 'url';
 import { afterAll, beforeAll, beforeEach, describe, it } from 'vitest';
 import {
   initializeTestEnvironment,
@@ -28,13 +28,19 @@ const MEMBER_EMAIL = 'paul.ivers@orono.k12.mn.us';
 const OUTSIDER_EMAIL = 'outsider@example.com';
 const SUPER_EMAIL = 'super@spartboard.io';
 
+// ESM-safe path resolution — the repo is `"type": "module"`, so __dirname is
+// not defined and we locate firestore.rules via import.meta.url instead.
+const RULES_PATH = fileURLToPath(
+  new URL('../../firestore.rules', import.meta.url)
+);
+
 let testEnv: RulesTestEnvironment;
 
 beforeAll(async () => {
   testEnv = await initializeTestEnvironment({
     projectId: PROJECT_ID,
     firestore: {
-      rules: readFileSync(resolve(__dirname, '../../firestore.rules'), 'utf8'),
+      rules: readFileSync(RULES_PATH, 'utf8'),
       host: process.env.FIRESTORE_EMULATOR_HOST?.split(':')[0] ?? '127.0.0.1',
       port: Number(
         process.env.FIRESTORE_EMULATOR_HOST?.split(':')[1] ?? '8080'

--- a/tests/rules/firestore-rules-organizations.test.ts
+++ b/tests/rules/firestore-rules-organizations.test.ts
@@ -1,0 +1,234 @@
+// Firestore security-rules tests for the Organization hierarchy (Phase 1).
+//
+// Requires a running Firestore emulator. Invoke via:
+//   pnpm run test:rules
+// which wraps this file in `firebase emulators:exec --only firestore`.
+//
+// Covers Phase 1 acceptance checks:
+//   - Org members can read /organizations/{orgId} and sub-collections
+//   - Non-members are denied reads (including super-admin bypass via
+//     admin_settings/user_roles.superAdmins)
+//   - All writes to organization/** are denied (Phase 3 wires these)
+//   - Legacy /admins/{email} reads still work for the owning user (no regression)
+
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+import { afterAll, beforeAll, beforeEach, describe, it } from 'vitest';
+import {
+  initializeTestEnvironment,
+  assertSucceeds,
+  assertFails,
+  RulesTestEnvironment,
+} from '@firebase/rules-unit-testing';
+import { setDoc, getDoc, doc } from 'firebase/firestore';
+
+const PROJECT_ID = 'spartboard-rules-test';
+const ORG_ID = 'orono';
+const MEMBER_EMAIL = 'paul.ivers@orono.k12.mn.us';
+const OUTSIDER_EMAIL = 'outsider@example.com';
+const SUPER_EMAIL = 'super@spartboard.io';
+
+let testEnv: RulesTestEnvironment;
+
+beforeAll(async () => {
+  testEnv = await initializeTestEnvironment({
+    projectId: PROJECT_ID,
+    firestore: {
+      rules: readFileSync(resolve(__dirname, '../../firestore.rules'), 'utf8'),
+      host: process.env.FIRESTORE_EMULATOR_HOST?.split(':')[0] ?? '127.0.0.1',
+      port: Number(
+        process.env.FIRESTORE_EMULATOR_HOST?.split(':')[1] ?? '8080'
+      ),
+    },
+  });
+});
+
+afterAll(async () => {
+  await testEnv?.cleanup();
+});
+
+beforeEach(async () => {
+  await testEnv.clearFirestore();
+
+  // Seed org, member, role, building, domain, super-admin list using privileged context.
+  await testEnv.withSecurityRulesDisabled(async (ctx) => {
+    const db = ctx.firestore();
+    await setDoc(doc(db, `organizations/${ORG_ID}`), {
+      id: ORG_ID,
+      name: 'Orono',
+      plan: 'full',
+    });
+    await setDoc(doc(db, `organizations/${ORG_ID}/members/${MEMBER_EMAIL}`), {
+      email: MEMBER_EMAIL,
+      orgId: ORG_ID,
+      roleId: 'domain_admin',
+      status: 'active',
+      buildingIds: [],
+    });
+    await setDoc(doc(db, `organizations/${ORG_ID}/roles/domain_admin`), {
+      id: 'domain_admin',
+      name: 'Domain admin',
+      system: true,
+      perms: {},
+    });
+    await setDoc(doc(db, `organizations/${ORG_ID}/buildings/high`), {
+      id: 'high',
+      orgId: ORG_ID,
+      name: 'Orono High',
+    });
+    await setDoc(doc(db, `organizations/${ORG_ID}/domains/primary`), {
+      id: 'primary',
+      orgId: ORG_ID,
+      domain: '@orono.k12.mn.us',
+    });
+    await setDoc(doc(db, `organizations/${ORG_ID}/studentPageConfig/default`), {
+      orgId: ORG_ID,
+      heroText: 'Hi',
+    });
+    await setDoc(doc(db, 'admin_settings/user_roles'), {
+      superAdmins: [SUPER_EMAIL],
+    });
+    // Legacy admin record used by the unchanged isAdmin() rule.
+    await setDoc(doc(db, `admins/${MEMBER_EMAIL}`), {
+      email: MEMBER_EMAIL,
+    });
+  });
+});
+
+const asMember = () =>
+  testEnv
+    .authenticatedContext('member-uid', { email: MEMBER_EMAIL })
+    .firestore();
+const asOutsider = () =>
+  testEnv
+    .authenticatedContext('outsider-uid', { email: OUTSIDER_EMAIL })
+    .firestore();
+const asSuper = () =>
+  testEnv.authenticatedContext('super-uid', { email: SUPER_EMAIL }).firestore();
+const asAnon = () => testEnv.unauthenticatedContext().firestore();
+
+describe('organizations — reads', () => {
+  it('member can read the org doc', async () => {
+    await assertSucceeds(getDoc(doc(asMember(), `organizations/${ORG_ID}`)));
+  });
+
+  it('member can read buildings, domains, roles, members, studentPageConfig', async () => {
+    await assertSucceeds(
+      getDoc(doc(asMember(), `organizations/${ORG_ID}/buildings/high`))
+    );
+    await assertSucceeds(
+      getDoc(doc(asMember(), `organizations/${ORG_ID}/domains/primary`))
+    );
+    await assertSucceeds(
+      getDoc(doc(asMember(), `organizations/${ORG_ID}/roles/domain_admin`))
+    );
+    await assertSucceeds(
+      getDoc(doc(asMember(), `organizations/${ORG_ID}/members/${MEMBER_EMAIL}`))
+    );
+    await assertSucceeds(
+      getDoc(
+        doc(asMember(), `organizations/${ORG_ID}/studentPageConfig/default`)
+      )
+    );
+  });
+
+  it('super admin (legacy user_roles) can read every org', async () => {
+    await assertSucceeds(getDoc(doc(asSuper(), `organizations/${ORG_ID}`)));
+    await assertSucceeds(
+      getDoc(doc(asSuper(), `organizations/${ORG_ID}/buildings/high`))
+    );
+  });
+
+  it('non-member cannot read the org doc or sub-collections', async () => {
+    await assertFails(getDoc(doc(asOutsider(), `organizations/${ORG_ID}`)));
+    await assertFails(
+      getDoc(doc(asOutsider(), `organizations/${ORG_ID}/buildings/high`))
+    );
+    await assertFails(
+      getDoc(doc(asOutsider(), `organizations/${ORG_ID}/roles/domain_admin`))
+    );
+  });
+
+  it('non-member CAN read their own (absent) member doc to bootstrap useAuth', async () => {
+    // Reading /organizations/{orgId}/members/{myEmail} must succeed even if
+    // the doc does not exist — the auth layer uses this probe to decide
+    // whether the user has an org membership.
+    await assertSucceeds(
+      getDoc(
+        doc(asOutsider(), `organizations/${ORG_ID}/members/${OUTSIDER_EMAIL}`)
+      )
+    );
+  });
+
+  it('unauthenticated users cannot read org data', async () => {
+    await assertFails(getDoc(doc(asAnon(), `organizations/${ORG_ID}`)));
+    await assertFails(
+      getDoc(doc(asAnon(), `organizations/${ORG_ID}/buildings/high`))
+    );
+  });
+});
+
+describe('organizations — writes (all blocked in Phase 1)', () => {
+  it('member cannot write the org doc', async () => {
+    await assertFails(
+      setDoc(doc(asMember(), `organizations/${ORG_ID}`), { name: 'Changed' })
+    );
+  });
+
+  it('member cannot write buildings, domains, roles, members, studentPageConfig', async () => {
+    await assertFails(
+      setDoc(doc(asMember(), `organizations/${ORG_ID}/buildings/new`), {
+        name: 'X',
+      })
+    );
+    await assertFails(
+      setDoc(doc(asMember(), `organizations/${ORG_ID}/domains/new`), {
+        domain: '@x.com',
+      })
+    );
+    await assertFails(
+      setDoc(doc(asMember(), `organizations/${ORG_ID}/roles/custom`), {
+        name: 'Custom',
+      })
+    );
+    await assertFails(
+      setDoc(
+        doc(asMember(), `organizations/${ORG_ID}/members/new@example.com`),
+        { roleId: 'teacher' }
+      )
+    );
+    await assertFails(
+      setDoc(
+        doc(asMember(), `organizations/${ORG_ID}/studentPageConfig/default`),
+        { heroText: 'Hacked' }
+      )
+    );
+  });
+
+  it('super admin cannot write either (Phase 3 will enable)', async () => {
+    await assertFails(
+      setDoc(doc(asSuper(), `organizations/${ORG_ID}`), { name: 'Changed' })
+    );
+  });
+
+  it('invitations collection is fully locked from clients', async () => {
+    await assertFails(
+      getDoc(doc(asMember(), `organizations/${ORG_ID}/invitations/token-123`))
+    );
+    await assertFails(
+      setDoc(doc(asMember(), `organizations/${ORG_ID}/invitations/token-123`), {
+        email: 'x@y.com',
+      })
+    );
+  });
+});
+
+describe('no regression on legacy /admins/{email}', () => {
+  it('owning user can still read their own admin doc', async () => {
+    await assertSucceeds(getDoc(doc(asMember(), `admins/${MEMBER_EMAIL}`)));
+  });
+
+  it('other users still cannot read another admin doc', async () => {
+    await assertFails(getDoc(doc(asOutsider(), `admins/${MEMBER_EMAIL}`)));
+  });
+});

--- a/types/organization.ts
+++ b/types/organization.ts
@@ -111,6 +111,9 @@ export interface MemberRecord {
   invitedAt?: string;
   lastActive?: string | null;
   addedBy?: string; // uid of admin who created this membership
+  // Provenance for non-uid creation paths (migration scripts, Cloud Functions).
+  // Set when `addedBy` can't be a real uid — e.g. 'migration:setup-organization'.
+  addedBySource?: string;
 }
 
 // Short-lived invitation stored at /organizations/{orgId}/invitations/{token}.

--- a/types/organization.ts
+++ b/types/organization.ts
@@ -1,0 +1,159 @@
+// Shared Organization types (Firestore schema + UI view models).
+// Used by both the Organization admin panel and the hooks that back it.
+// See docs/organization_wiring_implementation.md for the wiring plan.
+
+export type ActorRole = 'super_admin' | 'domain_admin' | 'building_admin';
+
+export type RoleId = string;
+
+export type Plan = 'basic' | 'expanded' | 'full';
+
+export type CapabilityAccess = 'full' | 'building' | 'none';
+
+export type BuildingType = 'elementary' | 'middle' | 'high' | 'other';
+
+export type AuthMethod = 'google' | 'microsoft' | 'saml' | 'password' | 'email';
+
+export type DomainStatus = 'verified' | 'pending';
+
+export type DomainRole = 'primary' | 'student' | 'staff';
+
+export type UserStatus = 'active' | 'invited' | 'inactive';
+
+// Canonical list of capabilities. Mirrors the UI definitions in
+// components/admin/Organization/mockData.ts (CAPABILITY_GROUPS). When adding
+// a capability, update both this union and the UI list.
+export type CapabilityId =
+  // Boards
+  | 'viewBoards'
+  | 'editBoards'
+  | 'shareBoards'
+  | 'saveTemplate'
+  // Admin
+  | 'accessAdmin'
+  | 'manageUsers'
+  | 'manageRoles'
+  | 'manageBuildings'
+  | 'configureWidgets'
+  | 'manageBackgrounds'
+  | 'postAnnouncements'
+  // Organization
+  | 'editOrg'
+  | 'manageDomains'
+  | 'editStudentPage'
+  // Super admin
+  | 'manageOrgs'
+  | 'toggleAI'
+  | 'viewPlatform'
+  // Student tools
+  | 'joinSession'
+  | 'viewAssignments';
+
+export interface OrgRecord {
+  id: string;
+  name: string;
+  shortName: string;
+  shortCode: string; // 2-4 letters, used in avatars
+  state: string;
+  plan: Plan;
+  aiEnabled: boolean;
+  primaryAdminEmail: string;
+  createdAt: string; // ISO date
+  users: number;
+  buildings: number;
+  status: 'active' | 'trial' | 'archived';
+  seedColor: string; // tailwind bg class e.g. 'bg-indigo-600'
+  supportUrl?: string;
+}
+
+export interface BuildingRecord {
+  id: string;
+  orgId: string;
+  name: string;
+  type: BuildingType;
+  address: string;
+  grades: string; // e.g. 'K-2', '3-5'
+  users: number;
+  adminEmails: string[];
+}
+
+export interface DomainRecord {
+  id: string;
+  orgId: string;
+  domain: string; // e.g. '@orono.k12.mn.us'
+  authMethod: AuthMethod;
+  status: DomainStatus;
+  role: DomainRole;
+  users: number;
+  addedAt: string; // ISO date
+}
+
+export interface RoleRecord {
+  id: RoleId;
+  name: string;
+  blurb: string;
+  color: string; // tailwind accent name: 'rose'|'indigo'|'violet'|'emerald'|'sky'
+  system: boolean;
+  perms: Record<CapabilityId, CapabilityAccess>;
+}
+
+// Canonical membership record stored at
+// /organizations/{orgId}/members/{emailLower}. `uid` is populated the first
+// time the invited user signs in; absent until then.
+export interface MemberRecord {
+  email: string; // lowercase; matches doc id
+  orgId: string;
+  roleId: RoleId;
+  buildingIds: string[];
+  status: UserStatus;
+  uid?: string; // linked on first sign-in
+  name?: string;
+  invitedAt?: string;
+  lastActive?: string | null;
+  addedBy?: string; // uid of admin who created this membership
+}
+
+// Short-lived invitation stored at /organizations/{orgId}/invitations/{token}.
+// Created by the CSV import flow and consumed on first sign-in.
+export interface InvitationRecord {
+  token: string; // matches doc id
+  orgId: string;
+  email: string; // lowercase
+  roleId: RoleId;
+  buildingIds: string[];
+  createdAt: string; // ISO date
+  expiresAt: string; // ISO date
+  issuedBy: string; // uid of admin who issued the invite
+  claimedAt?: string; // ISO date; present once accepted
+  claimedByUid?: string;
+}
+
+// UI view model. Hydrated from MemberRecord + display fields derived from
+// email when a name isn't available. Kept separate from MemberRecord so the
+// persistence schema can evolve without touching UI components.
+export interface UserRecord {
+  id: string;
+  orgId: string;
+  name: string;
+  email: string;
+  role: RoleId;
+  buildingIds: string[];
+  status: UserStatus;
+  lastActive: string | null; // ISO date or null
+  invitedAt?: string;
+}
+
+export interface CapabilityGroup {
+  id: string;
+  label: string;
+  capabilities: { id: CapabilityId; label: string }[];
+}
+
+export interface StudentPageConfig {
+  orgId: string;
+  showAnnouncements: boolean;
+  showTeacherDirectory: boolean;
+  showLunchMenu: boolean;
+  accentColor: string; // hex
+  heroText: string;
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -11,6 +11,11 @@ export default mergeConfig(
       exclude: [
         ...configDefaults.exclude,
         'tests/e2e/**',
+        // Firestore rules tests need the Firestore emulator; they run via
+        // the `test:rules` script under `firebase emulators:exec`. Excluded
+        // from the default vitest run so `pnpm test` / CI stays green
+        // without an emulator.
+        'tests/rules/**',
         'functions/**',
         '.claude/worktrees/**',
       ],

--- a/vitest.rules.config.ts
+++ b/vitest.rules.config.ts
@@ -1,0 +1,16 @@
+// Firestore rules test config — runs only the tests/rules/** suite against a
+// running Firestore emulator. Invoked by `pnpm run test:rules` which wraps
+// this in `firebase emulators:exec --only firestore`.
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['tests/rules/**/*.test.ts'],
+    environment: 'node',
+    globals: true,
+    testTimeout: 30000,
+    hookTimeout: 30000,
+    // No jsdom / React setup — these tests talk directly to the Firestore
+    // emulator using @firebase/rules-unit-testing.
+  },
+});


### PR DESCRIPTION
## Summary

Lands Phase 1 tasks **A–D** from `docs/organization_wiring_implementation.md`: the read-only foundation for the Organization admin panel. No existing runtime behavior changes — all new Firestore paths are write-denied until Phase 3.

- **A — Shared types**: Extracted Organization types to `types/organization.ts`. Tightened `RoleRecord.perms` to `Record<CapabilityId, CapabilityAccess>`. `components/admin/Organization/types.ts` is now a re-export shim.
- **B — Firestore rules**: Added `isSuperAdmin`, `isOrgMember`, `memberRole`, `roleHasCap` helpers. Read rules for `/organizations/{orgId}` + `buildings`, `domains`, `roles`, `members`, `studentPageConfig`. Writes stay `if false` with `TODO(phase-3)` / `TODO(phase-4)` markers. Invitations fully locked from clients. Members can self-probe their own (possibly absent) member doc so `useAuth` can bootstrap.
- **C — Migration**: `scripts/setup-organization.js` (idempotent, `--dry-run`, `--seed <path>`) mirrors `setup-admins.js`. Seeds org doc, buildings, domains, 4 system roles, `studentPageConfig/default`, and migrates `/admins/*` → `domain_admin` members and `admin_settings/user_roles.superAdmins` → `super_admin` members. Example seed at `scripts/org-seed.example.json`; real `scripts/org-seed.json` is gitignored.
- **D — Rules tests**: `tests/rules/firestore-rules-organizations.test.ts` via `@firebase/rules-unit-testing`. New `pnpm test:rules` script wraps `vitest --config vitest.rules.config.ts` inside `firebase emulators:exec --only firestore`. Default `pnpm test` excludes the rules suite (no emulator available in CI unit run).

## Deferred (require live Firebase preview access)

- **E** — Deploy rules to preview via `firebase deploy --only firestore:rules`
- **F** — `node scripts/setup-organization.js --dry-run` against preview
- **G** — Real migration run against preview + spot-check writes in Firebase Console
- **H** — Final plan-doc flip marking Phase 1 complete / Current State → Phase 2

These need credentials and a live project this environment does not have; they are explicitly marked deferred in the plan doc.

## Test plan

- [x] `pnpm run type-check` — clean
- [x] `pnpm run lint` — clean
- [x] `pnpm run format:check` — clean
- [x] `pnpm test` — 1291 tests pass (rules suite excluded, as designed)
- [ ] `pnpm run test:rules` in an environment with the Firebase CLI + emulator installed
- [ ] `firebase deploy --only firestore:rules` against preview and verify with Firestore console
- [ ] `node scripts/setup-organization.js --dry-run --seed scripts/org-seed.json` against preview
- [ ] Real migration run; spot-check `/organizations/orono/**` in Firestore console

https://claude.ai/code/session_01KSKgCnXfzsTTpYAXBhkSvx