### PR TITLE
feat(org): Phase 3 — Organization panel writes behind org-admin-writes flag

### DIFF
--- a/components/admin/Organization/OrganizationPanel.tsx
+++ b/components/admin/Organization/OrganizationPanel.tsx
@@ -293,7 +293,16 @@ export const OrganizationPanel: React.FC = () => {
   // archive the wrong org.
   const handleArchiveOrg = (targetOrgId: string) => {
     if (!writesEnabled) return comingSoon('Archive organization');
-    if (targetOrgId !== activeOrgId) return;
+    if (targetOrgId !== activeOrgId) {
+      // A mismatch means the view passed an org id that doesn't match the
+      // hook's subscription — almost always a wiring bug. Warn so we notice
+      // in dev rather than silently dropping the write.
+      console.warn(
+        '[OrganizationPanel] Archive skipped: targetOrgId mismatch',
+        { targetOrgId, activeOrgId }
+      );
+      return;
+    }
     run('Archive organization', archiveOrg, 'Organization archived');
   };
   const handleAddBuilding = (b: Partial<BuildingRecord>) => {

--- a/components/admin/Organization/OrganizationPanel.tsx
+++ b/components/admin/Organization/OrganizationPanel.tsx
@@ -225,7 +225,6 @@ export const OrganizationPanel: React.FC = () => {
     updateMember,
     bulkUpdateMembers,
     removeMembers,
-    inviteMembers,
   } = useOrgMembers(orgScopedOrgId);
   const {
     studentPage,
@@ -273,7 +272,7 @@ export const OrganizationPanel: React.FC = () => {
   ) => {
     task()
       .then(() => {
-        if (successMsg) showToast(successMsg, 'info');
+        if (successMsg) showToast(successMsg, 'success');
       })
       .catch((err: unknown) => {
         const msg = err instanceof Error ? err.message : String(err);
@@ -342,15 +341,16 @@ export const OrganizationPanel: React.FC = () => {
     );
   };
   const handleInvite = (
-    emails: string[],
-    role: string,
-    bids: string[],
-    msg?: string
+    _emails: string[],
+    _role: string,
+    _bids: string[],
+    _msg?: string
   ) => {
-    // Invitations require a Cloud Function (Phase 4); keep the dedicated
-    // message even when `org-admin-writes` is enabled so the UI is honest.
+    // Invitations require a Cloud Function (Phase 4); surface a dedicated
+    // info toast rather than forwarding to the rejection stub (which would
+    // render as a misleading error toast).
     if (!writesEnabled) return comingSoon('Invite users');
-    run('Invite users', () => inviteMembers(emails, role, bids, msg));
+    showToast('Invitations — coming in Phase 4', 'info');
   };
   const handleUpdateStudentPage = (patch: Partial<StudentPageConfig>) => {
     if (!writesEnabled) return comingSoon('Student page edits');

--- a/components/admin/Organization/OrganizationPanel.tsx
+++ b/components/admin/Organization/OrganizationPanel.tsx
@@ -288,8 +288,12 @@ export const OrganizationPanel: React.FC = () => {
     if (!writesEnabled) return comingSoon('Organization edits');
     run('Update organization', () => updateOrg(patch));
   };
-  const handleArchiveOrg = () => {
+  // `archiveOrg` is scoped to the hook's active orgId, so the caller's id
+  // should always match. Assert it so a stale row in the view can't silently
+  // archive the wrong org.
+  const handleArchiveOrg = (targetOrgId: string) => {
     if (!writesEnabled) return comingSoon('Archive organization');
+    if (targetOrgId !== activeOrgId) return;
     run('Archive organization', archiveOrg, 'Organization archived');
   };
   const handleAddBuilding = (b: Partial<BuildingRecord>) => {

--- a/components/admin/Organization/OrganizationPanel.tsx
+++ b/components/admin/Organization/OrganizationPanel.tsx
@@ -18,7 +18,15 @@ import { useOrgDomains } from '@/hooks/useOrgDomains';
 import { useOrgRoles } from '@/hooks/useOrgRoles';
 import { useOrgMembers } from '@/hooks/useOrgMembers';
 import { useOrgStudentPage } from '@/hooks/useOrgStudentPage';
-import type { ActorRole } from '@/types/organization';
+import type {
+  ActorRole,
+  BuildingRecord,
+  DomainRecord,
+  OrgRecord,
+  RoleRecord,
+  StudentPageConfig,
+  UserRecord,
+} from '@/types/organization';
 import { AllOrganizationsView } from './views/AllOrganizationsView';
 import { OverviewView } from './views/OverviewView';
 import { DomainsView } from './views/DomainsView';
@@ -120,6 +128,7 @@ export const OrganizationPanel: React.FC = () => {
     user,
     orgId: authOrgId,
     buildingIds: memberBuildingIds,
+    canAccessFeature,
   } = useAuth();
   const isSuperAdmin = Boolean(
     user?.email &&
@@ -184,16 +193,45 @@ export const OrganizationPanel: React.FC = () => {
   // "no data" empty state.
   const isMembershipHydrating =
     !isSuperAdmin && Boolean(user) && authOrgId === null;
-  const { organizations, loading: orgsLoading } = useOrganizations();
-  const { organization: activeOrg, loading: orgLoadingRaw } =
-    useOrganization(orgScopedOrgId);
-  const { buildings, loading: buildingsLoadingRaw } =
-    useOrgBuildings(orgScopedOrgId);
-  const { domains, loading: domainsLoadingRaw } = useOrgDomains(orgScopedOrgId);
-  const { roles, loading: rolesLoadingRaw } = useOrgRoles(orgScopedOrgId);
-  const { users, loading: usersLoadingRaw } = useOrgMembers(orgScopedOrgId);
-  const { studentPage, loading: studentPageLoadingRaw } =
-    useOrgStudentPage(orgScopedOrgId);
+  const { organizations, loading: orgsLoading, createOrg } = useOrganizations();
+  const {
+    organization: activeOrg,
+    loading: orgLoadingRaw,
+    updateOrg,
+    archiveOrg,
+  } = useOrganization(orgScopedOrgId);
+  const {
+    buildings,
+    loading: buildingsLoadingRaw,
+    addBuilding,
+    updateBuilding,
+    removeBuilding,
+  } = useOrgBuildings(orgScopedOrgId);
+  const {
+    domains,
+    loading: domainsLoadingRaw,
+    addDomain,
+    removeDomain,
+  } = useOrgDomains(orgScopedOrgId);
+  const {
+    roles,
+    loading: rolesLoadingRaw,
+    saveRoles,
+    resetRoles,
+  } = useOrgRoles(orgScopedOrgId);
+  const {
+    users,
+    loading: usersLoadingRaw,
+    updateMember,
+    bulkUpdateMembers,
+    removeMembers,
+    inviteMembers,
+  } = useOrgMembers(orgScopedOrgId);
+  const {
+    studentPage,
+    loading: studentPageLoadingRaw,
+    updateStudentPage,
+  } = useOrgStudentPage(orgScopedOrgId);
   const orgLoading = orgLoadingRaw || isMembershipHydrating;
   const buildingsLoading = buildingsLoadingRaw || isMembershipHydrating;
   const domainsLoading = domainsLoadingRaw || isMembershipHydrating;
@@ -218,13 +256,106 @@ export const OrganizationPanel: React.FC = () => {
     []
   );
 
-  // Phase 2 is read-only: every write handler surfaces a single "Coming soon"
-  // toast. Phase 3 replaces these with real mutations behind the
-  // `orgAdminWrites` feature flag.
+  // Phase 3: real writes are gated behind the `org-admin-writes` global
+  // feature flag. When the flag is off (or not yet enabled for this user) we
+  // fall back to the Phase 2 "coming soon" toast so the UI stays safe.
+  const writesEnabled = canAccessFeature('org-admin-writes');
   const comingSoon = (label: string) =>
-    showToast(`${label} — coming in Phase 3`, 'info');
-  const inviteComingSoon = () =>
-    showToast('Invitations — coming in Phase 4', 'info');
+    showToast(`${label} — coming soon`, 'info');
+
+  // Wrap a hook promise so it surfaces a success/error toast uniformly. The
+  // views call these fire-and-forget; Firestore writes are optimistic via
+  // `onSnapshot` so we don't need to block on resolution.
+  const run = (
+    label: string,
+    task: () => Promise<void>,
+    successMsg?: string
+  ) => {
+    task()
+      .then(() => {
+        if (successMsg) showToast(successMsg, 'info');
+      })
+      .catch((err: unknown) => {
+        const msg = err instanceof Error ? err.message : String(err);
+        showToast(`${label} failed: ${msg}`, 'error');
+      });
+  };
+
+  const handleCreateOrg = (o: Partial<OrgRecord>) => {
+    if (!writesEnabled) return comingSoon('Create organization');
+    run('Create organization', () => createOrg(o), `Created "${o.name ?? ''}"`);
+  };
+  const handleUpdateOrg = (patch: Partial<OrgRecord>) => {
+    if (!writesEnabled) return comingSoon('Organization edits');
+    run('Update organization', () => updateOrg(patch));
+  };
+  const handleArchiveOrg = () => {
+    if (!writesEnabled) return comingSoon('Archive organization');
+    run('Archive organization', archiveOrg, 'Organization archived');
+  };
+  const handleAddBuilding = (b: Partial<BuildingRecord>) => {
+    if (!writesEnabled) return comingSoon('Add building');
+    run('Add building', () => addBuilding(b), `Added "${b.name ?? ''}"`);
+  };
+  const handleUpdateBuilding = (id: string, patch: Partial<BuildingRecord>) => {
+    if (!writesEnabled) return comingSoon('Edit building');
+    run('Update building', () => updateBuilding(id, patch));
+  };
+  const handleRemoveBuilding = (id: string) => {
+    if (!writesEnabled) return comingSoon('Archive building');
+    run('Remove building', () => removeBuilding(id), 'Building removed');
+  };
+  const handleAddDomain = (d: Partial<DomainRecord>) => {
+    if (!writesEnabled) return comingSoon('Add domain');
+    run('Add domain', () => addDomain(d), `Added ${d.domain ?? 'domain'}`);
+  };
+  const handleRemoveDomain = (id: string) => {
+    if (!writesEnabled) return comingSoon('Remove domain');
+    run('Remove domain', () => removeDomain(id), 'Domain removed');
+  };
+  const handleSaveRoles = (working: RoleRecord[]) => {
+    if (!writesEnabled) return comingSoon('Save roles');
+    run('Save roles', () => saveRoles(working), 'Roles saved');
+  };
+  const handleResetRoles = () => {
+    if (!writesEnabled) return comingSoon('Reset roles');
+    run('Reset roles', resetRoles, 'Roles reset to defaults');
+  };
+  const handleUpdateUser = (id: string, patch: Partial<UserRecord>) => {
+    if (!writesEnabled) return comingSoon('Update user');
+    run('Update user', () => updateMember(id, patch));
+  };
+  const handleBulkUpdateUsers = (ids: string[], patch: Partial<UserRecord>) => {
+    if (!writesEnabled) return comingSoon('Bulk update users');
+    run(
+      'Bulk update users',
+      () => bulkUpdateMembers(ids, patch),
+      `Updated ${ids.length} users`
+    );
+  };
+  const handleRemoveUsers = (ids: string[]) => {
+    if (!writesEnabled) return comingSoon('Remove users');
+    run(
+      'Remove users',
+      () => removeMembers(ids),
+      `Removed ${ids.length} users`
+    );
+  };
+  const handleInvite = (
+    emails: string[],
+    role: string,
+    bids: string[],
+    msg?: string
+  ) => {
+    // Invitations require a Cloud Function (Phase 4); keep the dedicated
+    // message even when `org-admin-writes` is enabled so the UI is honest.
+    if (!writesEnabled) return comingSoon('Invite users');
+    run('Invite users', () => inviteMembers(emails, role, bids, msg));
+  };
+  const handleUpdateStudentPage = (patch: Partial<StudentPageConfig>) => {
+    if (!writesEnabled) return comingSoon('Student page edits');
+    run('Update student page', () => updateStudentPage(patch));
+  };
 
   // Building-admin scope: restrict strictly to the member doc's buildingIds.
   // A building admin with no assigned buildings sees an empty list — this
@@ -411,7 +542,7 @@ export const OrganizationPanel: React.FC = () => {
                     setSelectedOrgId(id);
                     setSection('overview');
                   }}
-                  onCreate={() => comingSoon('Create organization')}
+                  onCreate={handleCreateOrg}
                 />
               )}
               {effectiveSection === 'overview' &&
@@ -420,8 +551,8 @@ export const OrganizationPanel: React.FC = () => {
                     org={activeOrg}
                     isSuperAdmin={isSuperAdmin}
                     actorRole={actorRole}
-                    onUpdate={() => comingSoon('Organization edits')}
-                    onArchive={() => comingSoon('Archive organization')}
+                    onUpdate={handleUpdateOrg}
+                    onArchive={handleArchiveOrg}
                   />
                 ) : (
                   <PanelEmpty message="No organization found for this account." />
@@ -429,8 +560,8 @@ export const OrganizationPanel: React.FC = () => {
               {effectiveSection === 'domains' && (
                 <DomainsView
                   domains={domains}
-                  onAdd={() => comingSoon('Add domain')}
-                  onRemove={() => comingSoon('Remove domain')}
+                  onAdd={handleAddDomain}
+                  onRemove={handleRemoveDomain}
                 />
               )}
               {effectiveSection === 'buildings' && (
@@ -438,16 +569,16 @@ export const OrganizationPanel: React.FC = () => {
                   buildings={buildings}
                   actorRole={actorRole}
                   actorBuildingIds={actorBuildingIds}
-                  onAdd={() => comingSoon('Add building')}
-                  onUpdate={() => comingSoon('Edit building')}
-                  onRemove={() => comingSoon('Archive building')}
+                  onAdd={handleAddBuilding}
+                  onUpdate={handleUpdateBuilding}
+                  onRemove={handleRemoveBuilding}
                 />
               )}
               {effectiveSection === 'roles' && (
                 <RolesView
                   roles={roles}
-                  onSave={() => comingSoon('Save roles')}
-                  onReset={() => comingSoon('Reset roles')}
+                  onSave={handleSaveRoles}
+                  onReset={handleResetRoles}
                 />
               )}
               {effectiveSection === 'users' && (
@@ -457,10 +588,10 @@ export const OrganizationPanel: React.FC = () => {
                   buildings={buildings}
                   actorRole={actorRole}
                   actorBuildingIds={actorBuildingIds}
-                  onUpdate={() => comingSoon('Update user')}
-                  onBulkUpdate={() => comingSoon('Bulk update users')}
-                  onRemove={() => comingSoon('Remove users')}
-                  onInvite={inviteComingSoon}
+                  onUpdate={handleUpdateUser}
+                  onBulkUpdate={handleBulkUpdateUsers}
+                  onRemove={handleRemoveUsers}
+                  onInvite={handleInvite}
                 />
               )}
               {effectiveSection === 'student' &&
@@ -468,7 +599,7 @@ export const OrganizationPanel: React.FC = () => {
                   <StudentPageView
                     config={studentPage}
                     orgName={activeOrg.name}
-                    onUpdate={() => comingSoon('Student page edits')}
+                    onUpdate={handleUpdateStudentPage}
                   />
                 ) : (
                   <PanelEmpty message="Student page config has not been seeded yet." />

--- a/components/admin/Organization/components/primitives.tsx
+++ b/components/admin/Organization/components/primitives.tsx
@@ -1,6 +1,12 @@
 import React, { useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
-import { Check, AlertCircle, Info, AlertTriangle } from 'lucide-react';
+import {
+  Check,
+  CheckCircle2,
+  AlertCircle,
+  Info,
+  AlertTriangle,
+} from 'lucide-react';
 
 // Color palette for badges and role accents.
 export type AccentColor =
@@ -635,7 +641,7 @@ export const PopoverOption: React.FC<{
 
 // Inline toast shim (bottom-center) ----------------------------------
 
-export type OrgToastType = 'info' | 'warn' | 'error';
+export type OrgToastType = 'info' | 'success' | 'warn' | 'error';
 
 export const OrgToast: React.FC<{
   message: string;
@@ -643,6 +649,7 @@ export const OrgToast: React.FC<{
 }> = ({ message, type = 'info' }) => {
   const styles: Record<OrgToastType, { bg: string; Icon: typeof Info }> = {
     info: { bg: 'bg-brand-blue-dark', Icon: Info },
+    success: { bg: 'bg-emerald-600', Icon: CheckCircle2 },
     warn: { bg: 'bg-amber-600', Icon: AlertTriangle },
     error: { bg: 'bg-brand-red', Icon: AlertCircle },
   };

--- a/docs/organization_wiring_implementation.md
+++ b/docs/organization_wiring_implementation.md
@@ -246,15 +246,26 @@ Enable writes for each view, gated on a new `orgAdminWrites` entry in the existi
 
 ### Deploy order (important)
 
-Order matters for Phase 3 rollout. Do each step from a host with Firebase
-admin credentials, in this sequence:
+Order matters for Phase 3 rollout. The `global_permissions/org-admin-writes`
+doc was seeded on 2026-04-19 ahead of merge (see Decisions Log), so the
+rules can now deploy without opening the beta gate. If you ever re-seed
+from scratch, follow this order:
 
-1. **Seed the perm doc first** — `node scripts/init-global-perms.js`.
-   If rules deploy before the `global_permissions/org-admin-writes` doc
-   exists, `canAccessFeature('org-admin-writes')` falls back to the
-   default-allow path in `AuthContext` (no permission record ⇒ public), so
-   every domain admin would briefly get write UI without the beta gate.
-2. **Deploy the rules** — `firebase deploy --only firestore:rules --project spartboard`.
+1. **Seed the perm doc first.** Do NOT run `scripts/init-global-perms.js`
+   as-is — it uses unconditional `set()` (not merge) with stale config
+   values and would clobber live `gemini-functions`/`smart-poll`/
+   `live-session`/`embed-mini-app` entries. Either (a) run a targeted
+   one-off that only writes `global_permissions/org-admin-writes` with
+   `merge: true`, or (b) first align `init-global-perms.js` with prod and
+   switch it to `set(..., { merge: true })`. A follow-up task should fix
+   the script so it's safe to run again; until then treat it as unsafe.
+   If the doc is missing at deploy time, `canAccessFeature('org-admin-writes')`
+   falls back to the default-allow path in `AuthContext` (no permission
+   record ⇒ public), so every domain admin would briefly get write UI
+   without the beta gate.
+2. **Deploy the rules.** CI does this automatically on push to `dev-*` or
+   `main` (`firebase deploy --only functions,firestore,storage` in
+   `.github/workflows/firebase-dev-deploy.yml`). Manual: `firebase deploy --only firestore:rules --project spartboard` from a host with creds.
 3. **Smoke test as paul.ivers** (in `betaUsers`) — writes should persist.
 4. **Smoke test as a non-beta domain admin** — writes should still show the
    Phase-2 "coming soon" toast.
@@ -349,6 +360,8 @@ Record non-obvious choices so future sessions don't re-litigate them. Append; do
 - **2026-04-19** — Phase 4 link-uid write **must** happen through a Cloud Function, not the client. The member-update rule's whitelist at `firestore.rules` intentionally excludes `uid`. Admin SDK in a CF bypasses rules, so the trigger can safely link `uid` on first sign-in; a client-side link would let any domain admin reassign a member's uid and hijack the linked account. Documented in the rules file itself so future contributors don't quietly add `uid` to the whitelist.
 - **2026-04-19** — Phase 3 deploy order is perm-doc-first: `node scripts/init-global-perms.js` before `firebase deploy --only firestore:rules --project spartboard`. Deploying rules first opens the beta gate briefly for every domain admin because `canAccessFeature` defaults to `true` when no permission record exists. This order is enforced by the deploy-order section in this doc rather than tooling — the scripts are separately owned.
 - **2026-04-19** — Mobile layout bug in `OrganizationPanel.tsx` found during Phase 2 QA: the outer wrapper was `<div className="flex gap-6 h-full">` (flex-row) with no mobile stacking override. On mobile, the aside is `hidden md:flex` so it disappears, but the mobile section `<select>` wrapper is `md:hidden w-full` — with `w-full` it claimed 100% of the row's width, leaving 0px for `<main className="flex-1">`. Every tab appeared blank. Fix is a one-line addition of `flex-col md:flex-row` so mobile stacks vertically. Landed on `dev-paul` as `b593c9ca` (separate from the Phase 3 PR so Phase 2 shippability wasn't blocked).
+- **2026-04-19** — `global_permissions/org-admin-writes` seeded directly in prod Firestore ahead of the Phase 3 merge. Targeted `setDoc(..., { merge: true })` of the single doc (not via `init-global-perms.js` — see next entry). Before: doc did not exist → `canAccessFeature` would default-allow. After: `{ accessLevel: 'beta', enabled: true, betaUsers: ['paul.ivers@orono.k12.mn.us'], featureId: 'org-admin-writes', config: {} }`. This unblocks the automatic rules deploy CI runs on merge to `dev-paul`.
+- **2026-04-19** — `scripts/init-global-perms.js` has drifted from prod and is **unsafe to run as-is**. It uses unconditional `set()` (not merge) and carries stale config for `gemini-functions` (`dailyLimit: 20` vs. prod `3`), `smart-poll` (flips prod `admin`/`disabled` back to `public`/`enabled`), `live-session` (flips prod `admin`/`disabled` back to `public`/`enabled`), `embed-mini-app` (re-enables and raises daily cap), and `video-activity-audio-transcription` (`dailyLimit: 5` vs. prod `3`). Follow-up task (outside Phase 3 scope): rebuild the script from a current prod snapshot and switch it to `set(..., { merge: true })`. Until then, targeted one-off scripts are the safe path.
 
 ---
 

--- a/docs/organization_wiring_implementation.md
+++ b/docs/organization_wiring_implementation.md
@@ -4,7 +4,7 @@ Wire the newly-merged `components/admin/Organization/` scaffold (PR #1348) to re
 
 **Base branch:** `dev-paul`
 **Last updated:** 2026-04-19
-**Status:** Phase 3 implementation complete on `claude/implement-org-wiring-phase-3-qtCsb` — awaiting Paul's manual QA before Phase 4 kicks off.
+**Status:** Phase 3 review fixes landed on `claude/implement-org-wiring-phase-3-qtCsb` (commit `702e07f4`); rules-unit suite green locally (83/83), `pnpm run validate` green (1331 tests). Awaiting Paul's manual QA in preview before merging to `dev-paul` and kicking off Phase 4.
 
 ---
 
@@ -23,13 +23,13 @@ If implementation is interrupted, do this before writing any code:
 
 ## Current State
 
-| Field               | Value                                                                                                                                            |
-| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
-| Active phase        | Phase 3 implementation complete — awaiting Paul's manual QA (task R) before Phase 4                                                              |
-| Active branch       | `claude/implement-org-wiring-phase-3-qtCsb`                                                                                                      |
-| Last completed task | Phase 3 / Q — `OrganizationPanel` writes gated on `canAccessFeature('org-admin-writes')`; `init-global-perms.js` seeds the flag as beta-for-Paul |
-| Last updated (UTC)  | 2026-04-19                                                                                                                                       |
-| Next action         | Phase 3 / R (Paul manual QA in preview) → merge → kick off Phase 4 on `claude/org-wiring-p4-invites`                                             |
+| Field               | Value                                                                                                                                                                                                                                               |
+| ------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Active phase        | Phase 3 implementation complete + review fixes applied — awaiting Paul's manual QA (task R) before Phase 4                                                                                                                                          |
+| Active branch       | `claude/implement-org-wiring-phase-3-qtCsb` (PR #1352, currently draft, MERGEABLE)                                                                                                                                                                  |
+| Last completed task | Phase 3 / T — review-feedback fixes (`702e07f4`): domain `keys().hasOnly([...])`, uid-CF-only rules comment, empty-`buildingIds` rules comment, `handleArchiveOrg` dev warning, deploy-order doc, +1 rules test. Rules suite green locally (83/83). |
+| Last updated (UTC)  | 2026-04-19                                                                                                                                                                                                                                          |
+| Next action         | Phase 3 / R (Paul manual QA in preview) → flip PR out of draft → merge → kick off Phase 4 on `claude/org-wiring-p4-invites`                                                                                                                         |
 
 ---
 
@@ -172,12 +172,12 @@ View prop signatures were not changed — instead, the panel wires hook data in 
 **Serial:**
 
 - [x] **P — Remove `mockData.ts`.** Deleted. `CAPABILITY_GROUPS` was extracted to `config/organizationCapabilities.ts` first so it remained the source of truth for the Roles matrix + the migration script's `SYSTEM_ROLES.perms` block.
-- [ ] **Q — Manual QA in preview.** Sign in as paul.ivers@orono.k12.mn.us; verify every section loads real data. _(Pending — requires preview deploy from this branch; this is the only remaining blocker before the PR merges.)_
-- [x] **R — Update this doc.** Phase 2 task ledger closed (commits `180e370` → `27beb25` → `5fd0e6b`); Current State advanced to Phase 3 handoff.
+- [x] **Q — Manual QA in preview.** Signed in as paul.ivers@orono.k12.mn.us on 2026-04-19; every section loads real Firestore data. Mobile viewport required a follow-up fix (`b593c9ca`) — the panel's outer `flex gap-6` wrapper was a flex-row with no mobile override, so the `md:hidden w-full` section selector claimed 100% width and squeezed `<main>` (flex-1) to 0px, making every tab appear blank on mobile. Fix: added `flex-col md:flex-row` so the layout stacks vertically on mobile. Counters (`users` on org/buildings/domains) still render as 0; this is expected — they're denormalized fields whose maintenance ships as a Phase 4 Cloud Function.
+- [x] **R — Update this doc.** Phase 2 task ledger closed (commits `180e370` → `27beb25` → `5fd0e6b` → `b593c9ca`); Current State advanced to Phase 3 handoff.
 
 ### Acceptance checklist
 
-- [ ] Every view renders real Firestore data (verified in preview) _(pending preview QA — task Q)_
+- [x] Every view renders real Firestore data (verified in preview 2026-04-19)
 - [x] No `SEED_*` references remain in `components/admin/Organization/` (verified via `rg 'SEED_' components/admin/Organization` → no matches)
 - [x] Write buttons/menus show "Coming soon" toasts (not errors) — all handlers route through `OrganizationPanel`'s `showComingSoon()` helper
 - [x] `pnpm run validate` passes — green on `5fd0e6b` (type-check + lint + format-check + 1312 unit tests)
@@ -227,11 +227,19 @@ Enable writes for each view, gated on a new `orgAdminWrites` entry in the existi
 - [x] **Q — `canAccessFeature('org-admin-writes')` gate** in `OrganizationPanel.tsx`. When the flag is off (or the current user isn't in `betaUsers`), every `handleX` short-circuits to the Phase-2 "coming soon" toast. `'org-admin-writes'` added to the `GlobalFeature` union in `types.ts`; `scripts/init-global-perms.js` seeds the global-permissions doc as `accessLevel:'beta', betaUsers:['paul.ivers@orono.k12.mn.us']` so the default-allow behaviour of `canAccessFeature` doesn't accidentally open the gate for everyone.
 - [ ] **R — Paul manual QA in preview.** Walk every mutation path; confirm rules fail out-of-scope writes and that the flag genuinely gates on non-beta accounts.
 - [x] **S — Update this doc.** Phase 3 task ledger closed; Current State advanced to Phase 4 handoff (pending task R).
+- [x] **T — Review-feedback fixes (`702e07f4`)** from the merge-readiness review on PR #1352:
+  - `firestore.rules` — domain `create` gained `keys().hasOnly([...])` to match the shape enforcement on buildings/roles/members (clients can no longer stash arbitrary fields on a new domain doc).
+  - `firestore.rules` — member-update rule gained an explicit comment documenting that `uid` is intentionally excluded from the whitelist: Phase 4's first-sign-in link-uid write must go through a Cloud Function so no client actor can reassign a member's uid and hijack the linked account.
+  - `firestore.rules` — building-admin member-update branch gained a comment documenting the `hasAny([])` gotcha: a newly invited member with `buildingIds: []` is intentionally not editable by a building admin until a domain admin assigns a building first.
+  - `tests/rules/firestore-rules-organizations.test.ts` — new negative test for the domain `hasOnly` constraint (now 83 rules tests).
+  - `components/admin/Organization/OrganizationPanel.tsx` — `handleArchiveOrg` logs a `console.warn` on `targetOrgId !== activeOrgId` instead of silently dropping the write, so wiring bugs surface in dev.
+  - This doc — Phase 3 deploy-order section added (perm doc must be seeded before rules deploy, or the beta gate briefly opens for every domain admin).
+  - Rules-unit tests run locally against the Firestore emulator (Java 21 installed via `openjdk-21-jre-headless`): **83/83 pass**. `pnpm run validate` green (1331 unit tests).
 
 ### Acceptance checklist
 
-- [ ] `pnpm run validate` passes _(runs at commit time on this branch)_
-- [ ] All rules-unit tests pass _(still requires an emulator host — shape complete, first green run deferred)_
+- [x] `pnpm run validate` passes — green on `702e07f4` (type-check + lint + format-check + 1331 unit tests)
+- [x] All rules-unit tests pass — 83/83 green locally on 2026-04-19 against the Firestore emulator (Java 21 installed in the devcontainer; CI still runs them via `pnpm run test:rules` wrapping `firebase emulators:exec`)
 - [ ] With flag off, no writes happen (toasts only) _(verify in preview as part of task R)_
 - [ ] With flag on for paul.ivers, every mutation persists and re-renders via snapshot _(verify in preview as part of task R)_
 - [ ] Cross-org writes are rejected by rules (verified in preview console)
@@ -258,8 +266,16 @@ admin credentials, in this sequence:
 Activates the invitation flow, CSV bulk-import, and the Cloud Function that keeps `/admins/{email}` in sync with membership changes (so `isAdmin()` keeps working for any new domain admins added via the panel).
 
 **Branch:** `claude/org-wiring-p4-invites`
-**Depends on:** Phase 3
-**Status:** Not started
+**Depends on:** Phase 3 (merged to `dev-paul`)
+**Status:** Not started — ready to pick up once Phase 3 merges.
+
+### Pre-work already done (carry into Phase 4)
+
+- **Rules are Phase-4-compatible.** Invitations collection stays locked (`allow read, write: if false`) so CFs own it end-to-end. Member update rule intentionally excludes `uid` from the whitelist — link-uid writes MUST go through a CF (see Decisions Log 2026-04-19).
+- **User counters are Phase 4's responsibility.** `users` on org/building/domain docs currently reads 0 because only migrated admins have `members` docs. A Phase-4 CF (counter trigger on `members/{email}` writes) needs to maintain these. Treat this as deliverable alongside `organizationMembersSync`.
+- **Existing teachers need backfill.** The migration only upserted `/admins/*` + `superAdmins` into `members`. The ~90 active teachers at `/users/{uid}` have no member doc. Phase 4's acceptance-flow hook (step F) handles new invitees, but a one-shot backfill script is needed for existing teachers so they appear in the Users view with real counts. Recommend adding task A2 to the parallel batch below: `scripts/backfill-org-members.js` that iterates `/users/{uid}`, resolves each user's email + selectedBuildings, and upserts `/organizations/orono/members/{emailLower}` with `roleId: 'teacher'`. Idempotent via `{ merge: true }`.
+- **Rules-unit tests run locally.** Java 21 is installed in the devcontainer; `pnpm run test:rules` works without needing a separate host. Add Phase 4 cases (invitation claim, uid link via CF, counter triggers) to the existing `tests/rules/firestore-rules-organizations.test.ts` file.
+- **Feature flag graduation path.** `global_permissions/org-admin-writes` is currently `accessLevel: 'beta', betaUsers: ['paul.ivers@orono.k12.mn.us']`. Phase 4 step K graduates to `accessLevel: 'admin'`. That change is a single doc update via `scripts/init-global-perms.js` — rewrite the `betaUsers` entry and re-run.
 
 ### Deliverables
 
@@ -329,6 +345,10 @@ Record non-obvious choices so future sessions don't re-litigate them. Append; do
 - **2026-04-19** — System role immutability is enforced at the rules tier (`resource.data.system == true` blocks updates; `system: true` on create is rejected). `useOrgRoles.saveRoles` still filters system roles client-side so the UI never sends doomed writes — the rules check is defence-in-depth, not the primary UX path.
 - **2026-04-19** — View prop signatures were deliberately left untouched in Phase 3. The real mutation callbacks are wired inside `OrganizationPanel` via a `run()` helper that awaits the hook promise and surfaces a toast on both success and failure. Views remain pure presentation components; this keeps Phase 2's view layer diff-free.
 - **2026-04-19** — Slug-based id derivation (buildings, domains, orgs) generates URL-safe ids from user-provided names via `name.toLowerCase().replace(/[^a-z0-9]+/g, '-')`. If the resulting slug is empty it falls back to a `crypto.randomUUID()` prefix so document paths stay valid. Views never surface ids to end-users — they're opaque routing keys.
+- **2026-04-19** — Denormalized user counters (`users` on `/organizations/{orgId}`, `/buildings/{id}`, `/domains/{id}`) stay at 0 through Phase 3. Only the 6 migrated admins currently have `members` docs; the ~90 active teachers exist at `/users/{uid}` but haven't been backfilled into the org's member tree. Phase 4's Cloud Functions (`organizationMembersSync` + a counter-maintenance trigger) will keep these accurate. Teachers signing in before Phase 4 will NOT lose data: their `/users/{uid}/*` subtrees are untouched by the org layer, and `AuthContext`'s membership listener handles missing member docs gracefully (leaves `orgId`/`roleId`/`buildingIds` null/empty).
+- **2026-04-19** — Phase 4 link-uid write **must** happen through a Cloud Function, not the client. The member-update rule's whitelist at `firestore.rules` intentionally excludes `uid`. Admin SDK in a CF bypasses rules, so the trigger can safely link `uid` on first sign-in; a client-side link would let any domain admin reassign a member's uid and hijack the linked account. Documented in the rules file itself so future contributors don't quietly add `uid` to the whitelist.
+- **2026-04-19** — Phase 3 deploy order is perm-doc-first: `node scripts/init-global-perms.js` before `firebase deploy --only firestore:rules --project spartboard`. Deploying rules first opens the beta gate briefly for every domain admin because `canAccessFeature` defaults to `true` when no permission record exists. This order is enforced by the deploy-order section in this doc rather than tooling — the scripts are separately owned.
+- **2026-04-19** — Mobile layout bug in `OrganizationPanel.tsx` found during Phase 2 QA: the outer wrapper was `<div className="flex gap-6 h-full">` (flex-row) with no mobile stacking override. On mobile, the aside is `hidden md:flex` so it disappears, but the mobile section `<select>` wrapper is `md:hidden w-full` — with `w-full` it claimed 100% of the row's width, leaving 0px for `<main className="flex-1">`. Every tab appeared blank. Fix is a one-line addition of `flex-col md:flex-row` so mobile stacks vertically. Landed on `dev-paul` as `b593c9ca` (separate from the Phase 3 PR so Phase 2 shippability wasn't blocked).
 
 ---
 
@@ -347,3 +367,5 @@ Append one line per commit that advances this plan. Include short SHA + task let
 - 2026-04-18 — `5fd0e6b` — Phase 2 review-feedback round 2 (Gemini on PR #1351): (a) `OrganizationPanel` hook order reshuffled so `section`/`visibleSections`/`effectiveSection` are computed before hooks, letting `orgScopedOrgId = effectiveSection === 'orgs' ? null : activeOrgId` short-circuit org-scoped `onSnapshot` subscriptions when a super-admin is on the orgs list; (b) panel-level `isMembershipHydrating = !isSuperAdmin && Boolean(user) && authOrgId === null` now keeps every org-scoped section in loading state until the `useAuth` membership listener returns (prevents brief empty-state flashes); (c) removed unreachable `building_admin` fallback in `actorBuildingIds` (the branch was unreachable because `actorRole === 'building_admin'` already handled it). No behavioural regressions; all 1312 tests green.
 - 2026-04-18 — Phase 2 final-review subagent pass confirmed production-ready; Current State advanced to Phase 3 handoff; PR #1351 cleared for merge pending preview QA (task Q).
 - 2026-04-19 — Phase 3 A–S landed on `claude/implement-org-wiring-phase-3-qtCsb`: (A) `firestore.rules` replaced every `allow write: if false` stub with real scoping — super admin for `create`/`delete` + `aiEnabled`/`plan`; domain admin for identity fields via `affectedKeys().hasOnly([...])`; building admin restricted to member-`status`-only within `buildingIds`; system roles immutable; invitations still locked. (B) `tests/rules/firestore-rules-organizations.test.ts` expanded to cover every write path including negative cases. (C–I) All seven per-view hooks gained real writes replacing the Phase-2 stubs: `useOrganization` (updateOrg/archiveOrg), `useOrganizations` (createOrg w/ slug id, archiveOrg), `useOrgBuildings` (add/update/remove w/ slug id + defaults), `useOrgDomains` (add/remove w/ slug from `@domain.tld`), `useOrgRoles` (saveRoles upsert+delete, system-role-safe; resetRoles), `useOrgMembers` (updateMember translates `role`→`roleId`; bulk + remove fan out; invite still Phase-4 stub), `useOrgStudentPage` (setDoc merge). (J–P) `OrganizationPanel.tsx` replaced every `comingSoon()` handler with a `handleX()` wrapper routed through a shared `run()` helper that surfaces success/error toasts. (Q) `'org-admin-writes'` added to `GlobalFeature` union; `canAccessFeature('org-admin-writes')` gates every write handler; `scripts/init-global-perms.js` seeds the flag as `accessLevel:'beta'` with Paul as the sole beta user. (S) Doc updated; Current State advanced to Phase 3 QA handoff.
+- 2026-04-19 — `b593c9ca` — Phase 2 follow-up on `dev-paul`: mobile layout fix in `OrganizationPanel.tsx` (outer wrapper gains `flex-col md:flex-row` so `<main>` doesn't collapse to 0px beside the `w-full` mobile section selector). Found during preview QA (task Q); every tab appeared blank on mobile until fixed.
+- 2026-04-19 — `702e07f4` — Phase 3 review-feedback fixes landed on `claude/implement-org-wiring-phase-3-qtCsb`: (T1) domain `create` rule gained `keys().hasOnly([...])` to match other sub-collections' shape enforcement + new negative test in the rules suite. (T2) Member update rule gained a comment documenting that `uid` is intentionally excluded from the whitelist — Phase 4 link-uid writes must go through a Cloud Function. (T3) Building-admin member-update branch gained a comment documenting the `hasAny([])` empty-`buildingIds` gotcha. (T4) `OrganizationPanel.handleArchiveOrg` now logs a `console.warn` on target/active org-id mismatch instead of silently dropping the write. (T5) Phase 3 deploy-order note added to this doc (seed perm doc first). Rules-unit tests run locally against the emulator — **83/83 pass**; `pnpm run validate` green (1331 unit tests).

--- a/docs/organization_wiring_implementation.md
+++ b/docs/organization_wiring_implementation.md
@@ -236,6 +236,21 @@ Enable writes for each view, gated on a new `orgAdminWrites` entry in the existi
 - [ ] With flag on for paul.ivers, every mutation persists and re-renders via snapshot _(verify in preview as part of task R)_
 - [ ] Cross-org writes are rejected by rules (verified in preview console)
 
+### Deploy order (important)
+
+Order matters for Phase 3 rollout. Do each step from a host with Firebase
+admin credentials, in this sequence:
+
+1. **Seed the perm doc first** — `node scripts/init-global-perms.js`.
+   If rules deploy before the `global_permissions/org-admin-writes` doc
+   exists, `canAccessFeature('org-admin-writes')` falls back to the
+   default-allow path in `AuthContext` (no permission record ⇒ public), so
+   every domain admin would briefly get write UI without the beta gate.
+2. **Deploy the rules** — `firebase deploy --only firestore:rules --project spartboard`.
+3. **Smoke test as paul.ivers** (in `betaUsers`) — writes should persist.
+4. **Smoke test as a non-beta domain admin** — writes should still show the
+   Phase-2 "coming soon" toast.
+
 ---
 
 ## Phase 4 — Invitations, CSV import, write-through

--- a/docs/organization_wiring_implementation.md
+++ b/docs/organization_wiring_implementation.md
@@ -3,8 +3,8 @@
 Wire the newly-merged `components/admin/Organization/` scaffold (PR #1348) to real Firestore, replacing `mockData.ts`. The scaffold is UI-complete and landed on `dev-paul` as a non-functional preview; this plan delivers real persistence in four shippable phases.
 
 **Base branch:** `dev-paul`
-**Last updated:** 2026-04-18
-**Status:** Phase 2 complete — PR #1351 cleared for merge (pending preview QA); Phase 3 ready to start on `claude/org-wiring-p3-writes`
+**Last updated:** 2026-04-19
+**Status:** Phase 3 implementation complete on `claude/implement-org-wiring-phase-3-qtCsb` — awaiting Paul's manual QA before Phase 4 kicks off.
 
 ---
 
@@ -23,13 +23,13 @@ If implementation is interrupted, do this before writing any code:
 
 ## Current State
 
-| Field               | Value                                                                                                                                |
-| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
-| Active phase        | Phase 2 complete — ready for Phase 3                                                                                                 |
-| Active branch       | `claude/implement-org-wiring-phase-2-NRzzg` — PR #1351 (commits `180e370`, `27beb25`, `5fd0e6b`); merge pending manual QA in preview |
-| Last completed task | Phase 2 / R — review-feedback fixes applied (defensive `id` spread, super-admin listener gating, membership hydration loading, docs) |
-| Last updated (UTC)  | 2026-04-18                                                                                                                           |
-| Next action         | Phase 2 / Q (manual QA in preview) then kick off Phase 3 on `claude/org-wiring-p3-writes`                                            |
+| Field               | Value                                                                                                                                            |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Active phase        | Phase 3 implementation complete — awaiting Paul's manual QA (task R) before Phase 4                                                              |
+| Active branch       | `claude/implement-org-wiring-phase-3-qtCsb`                                                                                                      |
+| Last completed task | Phase 3 / Q — `OrganizationPanel` writes gated on `canAccessFeature('org-admin-writes')`; `init-global-perms.js` seeds the flag as beta-for-Paul |
+| Last updated (UTC)  | 2026-04-19                                                                                                                                       |
+| Next action         | Phase 3 / R (Paul manual QA in preview) → merge → kick off Phase 4 on `claude/org-wiring-p4-invites`                                             |
 
 ---
 
@@ -189,57 +189,51 @@ View prop signatures were not changed — instead, the panel wires hook data in 
 
 Enable writes for each view, gated on a new `orgAdminWrites` entry in the existing `feature_permissions` collection. Paul tests live first as the sole beta user; graduate to `admin` or `public` once verified.
 
-**Branch:** `claude/org-wiring-p3-writes`
+**Branch:** `claude/implement-org-wiring-phase-3-qtCsb`
 **Depends on:** Phase 2
-**Status:** Not started
+**Status:** Implementation complete; awaiting Paul's manual QA in preview (task R).
 
 ### Deliverables
 
-- [ ] `feature_permissions/orgAdminWrites` document exists with `accessLevel: 'beta'`, `betaUsers: ['paul.ivers@orono.k12.mn.us']`
-- [ ] Each hook's `add`/`update`/`remove` runs real Firestore writes when flag allows, else throws a gated error caught by view layer
-- [ ] `firestore.rules` enforces scoping: super-admin for org create/delete, domain-admin for org-wide fields, building-admin restricted to diff of `buildingIds` + `status` on members within their buildings
-- [ ] Rules-unit tests cover: domain-admin cannot edit another org; building-admin cannot change member `roleId`; building-admin can update member `status` only within their buildings
-- [ ] Debounced "saving…" indicator (reuse existing pattern from other admin views)
+- [x] `global_permissions/org-admin-writes` seeded via `scripts/init-global-perms.js` with `accessLevel: 'beta'`, `betaUsers: ['paul.ivers@orono.k12.mn.us']` (new `GlobalFeature` union member `'org-admin-writes'`)
+- [x] Each hook's `add`/`update`/`remove` runs real Firestore writes; panel throws `"No organization selected"` when `orgId` is null (view layer catches via the `run()` helper and surfaces an error toast)
+- [x] `firestore.rules` enforces scoping: super-admin for org `create`/`delete` + `aiEnabled`/`plan`; domain-admin for identity fields (via `affectedKeys().hasOnly([...])`); building-admin restricted to diffing member `status` within their `buildingIds`; system roles (`system:true`) immutable at the rules tier
+- [x] Rules-unit tests cover: domain-admin cannot touch `aiEnabled`/`plan`; building-admin cannot change member `roleId` or `buildingIds`; building-admin can update member `status` only within their buildings; system roles cannot be mutated or deleted; cross-org writes blocked; invitations fully locked
+- [x] Toasts surface success/error per mutation (reuses the Phase 2 `OrgToast` primitive; no debounced saving indicator needed because writes are optimistic via `onSnapshot`)
 
 ### Task ledger
 
 **Serial (rules must land before writes are attempted):**
 
-- [ ] **A — Rules update.** Replace `allow write: if false` stubs in `firestore.rules` with real scoping using helpers added in P1. Deploy to preview.
-- [ ] **B — Rules tests.** Expand `tests/e2e/firestore-rules-organizations.test.ts` to cover every write path. Must pass before any hook write lands.
+- [x] **A — Rules update.** Replaced `allow write: if false` stubs in `firestore.rules` with real scoping using helpers added in P1. `affectedKeys().hasOnly([...])` enforces field whitelists per actor role; system roles are blocked entirely. _Deploy is a user-owned step — `firebase deploy --only firestore:rules --project spartboard` from a host with credentials._
+- [x] **B — Rules tests.** Expanded `tests/rules/firestore-rules-organizations.test.ts` to cover every write path (super admin, domain admin, building admin; in-scope + out-of-scope member updates; system-role immutability; invitations still locked; legacy `/admins/*` still readable). First green run still requires a host with Java for the emulator.
 
 **Parallelizable — batch 1 (each hook gets a write path; no cross-file writes):**
 
-- [ ] **C — Writes in `useOrganization.ts`** (updateOrg, archiveOrg) + tests
-- [ ] **D — Writes in `useOrgBuildings.ts`** (add, update, remove) + tests
-- [ ] **E — Writes in `useOrgDomains.ts`** + tests
-- [ ] **F — Writes in `useOrgRoles.ts`** (create/clone/delete system-role-protected) + tests
-- [ ] **G — Writes in `useOrgMembers.ts`** (status, roleId, buildingIds, bulk update) + tests
-- [ ] **H — Writes in `useOrgStudentPage.ts`** + tests
-- [ ] **I — Writes in `useOrganizations.ts`** (create org, archive) + tests — super-admin only
+- [x] **C — Writes in `useOrganization.ts`** (`updateOrg` strips `id`; `archiveOrg` sets `status:'archived'`) + tests
+- [x] **D — Writes in `useOrgBuildings.ts`** (`addBuilding` derives slug id + defaults; `updateBuilding` strips `id`/`orgId`; `removeBuilding` deletes) + tests
+- [x] **E — Writes in `useOrgDomains.ts`** (`addDomain` derives a slug id from the domain string with dot→dash; `removeDomain` deletes) + tests
+- [x] **F — Writes in `useOrgRoles.ts`** (`saveRoles` upserts non-system roles + deletes custom roles dropped from the working set; system roles are filtered out client-side because the rules tier blocks writes to them; `resetRoles` deletes every custom role) + tests
+- [x] **G — Writes in `useOrgMembers.ts`** (`updateMember` translates UI `role` → `roleId` and strips identity fields; `bulkUpdateMembers` + `removeMembers` fan out via `Promise.all`; `inviteMembers` remains a Phase-4 stub that rejects) + tests
+- [x] **H — Writes in `useOrgStudentPage.ts`** (`updateStudentPage` uses `setDoc(..., { merge: true })` so the first write still works if the migration hasn't seeded the config; strips `orgId` from the patch and re-injects the canonical value) + tests
+- [x] **I — Writes in `useOrganizations.ts`** (`createOrg` derives an id via `slugFromName()` and seeds `{ createdAt: ISO, plan:'basic', status:'trial', users:0, buildings:0, seedColor }`; `archiveOrg(orgId)` sets `status:'archived'`) + tests — super-admin only
 
 **Parallelizable — batch 2 (each view swaps its no-op handlers for real writes):**
 
-- [ ] **J — AllOrganizationsView** mutations live
-- [ ] **K — OverviewView** mutations live
-- [ ] **L — BuildingsView** mutations live
-- [ ] **M — DomainsView** mutations live
-- [ ] **N — RolesView** mutations live
-- [ ] **O — UsersView** mutations live (bulk + inline)
-- [ ] **P — StudentPageView** mutations live
+- [x] **J–P — View wiring in `OrganizationPanel.tsx`.** Every `comingSoon()` handler replaced with a `handleX()` wrapper that routes through a shared `run(label, task, successMsg?)` helper. The helper awaits the hook promise, shows a success toast on resolve, and an error toast with the rejection message on reject. View prop signatures were unchanged — this keeps `views/*.tsx` diff-free for Phase 3 and preserves the Phase-2 read-only layout.
 
 **Serial:**
 
-- [ ] **Q — Add `useFeaturePermissions` gate** in `OrganizationPanel.tsx`. When flag is off, views remain read-only and "Coming soon" toasts persist.
-- [ ] **R — Paul manual QA in preview.** Walk every mutation path; confirm rules fail out-of-scope writes.
-- [ ] **S — Update this doc.** Mark Phase 3 complete; set Current State → Phase 4.
+- [x] **Q — `canAccessFeature('org-admin-writes')` gate** in `OrganizationPanel.tsx`. When the flag is off (or the current user isn't in `betaUsers`), every `handleX` short-circuits to the Phase-2 "coming soon" toast. `'org-admin-writes'` added to the `GlobalFeature` union in `types.ts`; `scripts/init-global-perms.js` seeds the global-permissions doc as `accessLevel:'beta', betaUsers:['paul.ivers@orono.k12.mn.us']` so the default-allow behaviour of `canAccessFeature` doesn't accidentally open the gate for everyone.
+- [ ] **R — Paul manual QA in preview.** Walk every mutation path; confirm rules fail out-of-scope writes and that the flag genuinely gates on non-beta accounts.
+- [x] **S — Update this doc.** Phase 3 task ledger closed; Current State advanced to Phase 4 handoff (pending task R).
 
 ### Acceptance checklist
 
-- [ ] `pnpm run validate` passes
-- [ ] All rules-unit tests pass
-- [ ] With flag off, no writes happen (toasts only)
-- [ ] With flag on for paul.ivers, every mutation persists and re-renders via snapshot
+- [ ] `pnpm run validate` passes _(runs at commit time on this branch)_
+- [ ] All rules-unit tests pass _(still requires an emulator host — shape complete, first green run deferred)_
+- [ ] With flag off, no writes happen (toasts only) _(verify in preview as part of task R)_
+- [ ] With flag on for paul.ivers, every mutation persists and re-renders via snapshot _(verify in preview as part of task R)_
 - [ ] Cross-org writes are rejected by rules (verified in preview console)
 
 ---
@@ -314,6 +308,12 @@ Record non-obvious choices so future sessions don't re-litigate them. Append; do
 - **2026-04-18** — Task E terminology clarified: `.firebaserc` has only one project (`spartboard`). Firebase preview channels only cover Hosting; Firestore rules + collections live on the single production database. "Deploy to preview" in the plan effectively means "deploy to prod Firestore." Phase 1 rules are additive (new read grants only, all writes denied) so blast radius is tiny.
 - **2026-04-18** — Added `applicationDefault()` fallback path to `scripts/setup-organization.js`. Original script only accepted `FIREBASE_SERVICE_ACCOUNT` env or `scripts/service-account-key.json`; ADC fallback lets the script run from any host that has `gcloud auth application-default login` or a `GOOGLE_APPLICATION_CREDENTIALS` file. Service-account path remains the primary pattern for CI.
 - **2026-04-18** — `/admins/*` contains 8 docs but only 6 unique emails after lowercase-dedup. Two admin docs are case-duplicates of other entries. The migration handles this correctly via `Set` on lowercased emails, but the duplicate admin docs are a data-quality item worth cleaning up in a follow-up (not a Phase-1 blocker).
+- **2026-04-19** — Phase 3 feature flag key is `'org-admin-writes'` (hyphenated to match the existing `GlobalFeature` union convention) rather than `orgAdminWrites`. Stored in the `global_permissions` collection because `canAccessFeature` reads from there; the per-widget `feature_permissions` path is typed against `WidgetType | InternalToolType` and doesn't accept string-keyed features.
+- **2026-04-19** — `canAccessFeature` defaults to `true` when no permission doc exists. For Phase 3's beta rollout we must seed the global-permissions doc (otherwise the gate opens for every user). `scripts/init-global-perms.js` now covers this; operators running a fresh environment still need to execute it.
+- **2026-04-19** — Org archive is a soft archive (`status:'archived'`) for both super and domain admins rather than a hard delete. Hard delete is available at the rules tier for super admins, but it orphans sub-collections (`buildings`, `domains`, `roles`, `members`, `studentPageConfig`). Soft archive keeps the data recoverable and lets us write a real deletion path later if the business actually needs it.
+- **2026-04-19** — System role immutability is enforced at the rules tier (`resource.data.system == true` blocks updates; `system: true` on create is rejected). `useOrgRoles.saveRoles` still filters system roles client-side so the UI never sends doomed writes — the rules check is defence-in-depth, not the primary UX path.
+- **2026-04-19** — View prop signatures were deliberately left untouched in Phase 3. The real mutation callbacks are wired inside `OrganizationPanel` via a `run()` helper that awaits the hook promise and surfaces a toast on both success and failure. Views remain pure presentation components; this keeps Phase 2's view layer diff-free.
+- **2026-04-19** — Slug-based id derivation (buildings, domains, orgs) generates URL-safe ids from user-provided names via `name.toLowerCase().replace(/[^a-z0-9]+/g, '-')`. If the resulting slug is empty it falls back to a `crypto.randomUUID()` prefix so document paths stay valid. Views never surface ids to end-users — they're opaque routing keys.
 
 ---
 
@@ -331,3 +331,4 @@ Append one line per commit that advances this plan. Include short SHA + task let
 - 2026-04-18 — `27beb25` — Phase 2 review-feedback round 1 (Copilot on PR #1351): (a) collection hooks now spread `{ id: d.id, ...d.data() }` so Firestore doc IDs survive the snapshot hydration (`useOrganizations`, `useOrgBuildings`, `useOrgDomains`, `useOrgRoles`; `useOrgMembers` uses `email: d.id` since the doc ID is `emailLower`); (b) hook tests updated to the `docs[]` mock shape; (c) `DEFAULT_ORG_ID` moved below imports in `AuthContext`; (d) `setOrgId(member.orgId ?? DEFAULT_ORG_ID)` uses the member-doc-derived org when available.
 - 2026-04-18 — `5fd0e6b` — Phase 2 review-feedback round 2 (Gemini on PR #1351): (a) `OrganizationPanel` hook order reshuffled so `section`/`visibleSections`/`effectiveSection` are computed before hooks, letting `orgScopedOrgId = effectiveSection === 'orgs' ? null : activeOrgId` short-circuit org-scoped `onSnapshot` subscriptions when a super-admin is on the orgs list; (b) panel-level `isMembershipHydrating = !isSuperAdmin && Boolean(user) && authOrgId === null` now keeps every org-scoped section in loading state until the `useAuth` membership listener returns (prevents brief empty-state flashes); (c) removed unreachable `building_admin` fallback in `actorBuildingIds` (the branch was unreachable because `actorRole === 'building_admin'` already handled it). No behavioural regressions; all 1312 tests green.
 - 2026-04-18 — Phase 2 final-review subagent pass confirmed production-ready; Current State advanced to Phase 3 handoff; PR #1351 cleared for merge pending preview QA (task Q).
+- 2026-04-19 — Phase 3 A–S landed on `claude/implement-org-wiring-phase-3-qtCsb`: (A) `firestore.rules` replaced every `allow write: if false` stub with real scoping — super admin for `create`/`delete` + `aiEnabled`/`plan`; domain admin for identity fields via `affectedKeys().hasOnly([...])`; building admin restricted to member-`status`-only within `buildingIds`; system roles immutable; invitations still locked. (B) `tests/rules/firestore-rules-organizations.test.ts` expanded to cover every write path including negative cases. (C–I) All seven per-view hooks gained real writes replacing the Phase-2 stubs: `useOrganization` (updateOrg/archiveOrg), `useOrganizations` (createOrg w/ slug id, archiveOrg), `useOrgBuildings` (add/update/remove w/ slug id + defaults), `useOrgDomains` (add/remove w/ slug from `@domain.tld`), `useOrgRoles` (saveRoles upsert+delete, system-role-safe; resetRoles), `useOrgMembers` (updateMember translates `role`→`roleId`; bulk + remove fan out; invite still Phase-4 stub), `useOrgStudentPage` (setDoc merge). (J–P) `OrganizationPanel.tsx` replaced every `comingSoon()` handler with a `handleX()` wrapper routed through a shared `run()` helper that surfaces success/error toasts. (Q) `'org-admin-writes'` added to `GlobalFeature` union; `canAccessFeature('org-admin-writes')` gates every write handler; `scripts/init-global-perms.js` seeds the flag as `accessLevel:'beta'` with Paul as the sole beta user. (S) Doc updated; Current State advanced to Phase 3 QA handoff.

--- a/firestore.rules
+++ b/firestore.rules
@@ -135,13 +135,19 @@ service cloud.firestore {
         // Domain admin or super admin only. Create must carry canonical
         // orgId + matching doc id, and clients cannot seed `status:'verified'`
         // or inflate `users` — verification is DNS-based server-side, and
-        // `users` is a derived count. Update is whitelisted to the fields
+        // `users` is a derived count. `keys().hasOnly([...])` mirrors the
+        // shape enforced on buildings/roles/members so clients can't stash
+        // arbitrary fields on create. Update is whitelisted to the fields
         // admins actually configure.
         allow create: if (isSuperAdmin() || isDomainAdmin(orgId)) &&
           request.resource.data.orgId == orgId &&
           request.resource.data.id == domainId &&
           request.resource.data.status == 'pending' &&
-          request.resource.data.users == 0;
+          request.resource.data.users == 0 &&
+          request.resource.data.keys().hasOnly([
+            'id', 'orgId', 'domain', 'authMethod', 'status', 'role',
+            'users', 'addedAt'
+          ]);
         allow delete: if isSuperAdmin() || isDomainAdmin(orgId);
         allow update: if isSuperAdmin() ||
           (isDomainAdmin(orgId) &&
@@ -192,8 +198,13 @@ service cloud.firestore {
                     isSuperAdmin();
         // Domain+ admins manage members with a field whitelist so identity
         // fields (email, orgId, uid, addedBy, addedBySource) stay pinned to
-        // what the invitation/sign-in flow set. Building admins can only
-        // update `status` on members whose buildingIds intersect their own.
+        // what the invitation/sign-in flow set. `uid` is intentionally not
+        // in the update whitelist: Phase 4's first-sign-in link-uid write
+        // must happen through a Cloud Function (Admin SDK bypasses these
+        // rules) so no client actor can reassign a member's uid and hijack
+        // the linked account. Building admins can only update `status` on
+        // members whose buildingIds intersect their own — see the update
+        // branch below for the `hasAny()` scoping note.
         // Create enforces shape: doc id == lowercased email (both the path
         // segment and payload field must be lowercase so isOrgMember() — which
         // always looks up `members/{token.email.lower()}` — can find the
@@ -217,6 +228,12 @@ service cloud.firestore {
            request.resource.data.diff(resource.data).affectedKeys().hasOnly([
              'roleId', 'buildingIds', 'status', 'name', 'invitedAt', 'lastActive'
            ])) ||
+          // Building admin can flip `status` on a member whose buildingIds
+          // overlap their own. `hasAny([])` returns false, so a newly
+          // invited member with `buildingIds: []` is *not* editable by a
+          // building admin — the domain admin must assign a building first.
+          // This is intentional: building admins shouldn't be able to act on
+          // members who haven't been scoped into their building yet.
           (isBuildingAdmin(orgId) &&
            resource.data.buildingIds.hasAny(orgMember(orgId).buildingIds) &&
            request.resource.data.diff(resource.data).affectedKeys().hasOnly(['status']));

--- a/firestore.rules
+++ b/firestore.rules
@@ -87,31 +87,59 @@ service cloud.firestore {
 
     match /organizations/{orgId} {
       allow read: if isOrgMember(orgId) || isSuperAdmin();
-      // Only super admins can create, archive (delete), or flip AI/plan.
-      // Domain admins can edit identity-ish fields for their own org.
+      // Only super admins can create, archive (delete), flip AI/plan, or
+      // change `status` (soft-archive). Domain admins can edit identity-ish
+      // fields for their own org. `users`/`buildings` are derived counts
+      // maintained server-side — never settable from the client at the
+      // domain-admin tier.
       allow create, delete: if isSuperAdmin();
       allow update: if isSuperAdmin() ||
         (isDomainAdmin(orgId) &&
          request.resource.data.diff(resource.data).affectedKeys().hasOnly([
            'name', 'shortName', 'shortCode', 'state', 'primaryAdminEmail',
-           'users', 'buildings', 'status', 'seedColor', 'supportUrl'
+           'seedColor', 'supportUrl'
          ]));
 
       match /buildings/{buildingId} {
         allow read: if isOrgMember(orgId) || isSuperAdmin();
-        // Only domain+ admins can create/delete buildings.
-        allow create, delete: if isSuperAdmin() || isDomainAdmin(orgId);
-        // Building admins can edit buildings they manage (name, address,
-        // grades, type, adminEmails). Domain+ admins edit any building.
-        allow update: if isSuperAdmin() || isDomainAdmin(orgId) ||
-          (isBuildingAdmin(orgId) &&
-           buildingId in orgMember(orgId).buildingIds);
+        // Only domain+ admins can create/delete buildings. Create must carry
+        // the canonical orgId and matching doc id so clients can't seed
+        // records that misrepresent their parent.
+        allow create: if (isSuperAdmin() || isDomainAdmin(orgId)) &&
+          request.resource.data.orgId == orgId &&
+          request.resource.data.id == buildingId;
+        allow delete: if isSuperAdmin() || isDomainAdmin(orgId);
+        // Building admins can edit the mutable fields of buildings they
+        // manage; domain+ admins edit any building. Identity fields
+        // (id, orgId) are immutable for all tiers below super admin.
+        allow update: if (isSuperAdmin() ||
+            (isDomainAdmin(orgId) &&
+             request.resource.data.id == resource.data.id &&
+             request.resource.data.orgId == resource.data.orgId) ||
+            (isBuildingAdmin(orgId) &&
+             buildingId in orgMember(orgId).buildingIds &&
+             request.resource.data.diff(resource.data).affectedKeys().hasOnly([
+               'name', 'address', 'grades', 'type', 'adminEmails'
+             ])));
       }
 
       match /domains/{domainId} {
         allow read: if isOrgMember(orgId) || isSuperAdmin();
-        // Domain admin or super admin only.
-        allow create, update, delete: if isSuperAdmin() || isDomainAdmin(orgId);
+        // Domain admin or super admin only. Create must carry canonical
+        // orgId + matching doc id. Update is whitelisted to the fields
+        // admins actually configure — `status` is DNS-verified server-side
+        // (never client-set) and `users`/`addedAt` are derived/stamped.
+        allow create: if (isSuperAdmin() || isDomainAdmin(orgId)) &&
+          request.resource.data.orgId == orgId &&
+          request.resource.data.id == domainId;
+        allow delete: if isSuperAdmin() || isDomainAdmin(orgId);
+        allow update: if isSuperAdmin() ||
+          (isDomainAdmin(orgId) &&
+           request.resource.data.id == resource.data.id &&
+           request.resource.data.orgId == resource.data.orgId &&
+           request.resource.data.diff(resource.data).affectedKeys().hasOnly([
+             'domain', 'authMethod', 'role'
+           ]));
       }
 
       match /roles/{roleId} {
@@ -138,11 +166,18 @@ service cloud.firestore {
                        request.auth.token.email.lower() == emailLower) ||
                     isOrgMember(orgId) ||
                     isSuperAdmin();
-        // Domain+ admins fully manage members. Building admins can only
+        // Domain+ admins manage members with a field whitelist so identity
+        // fields (email, orgId, uid, addedBy, addedBySource) stay pinned to
+        // what the invitation/sign-in flow set. Building admins can only
         // update `status` on members whose buildingIds intersect their own.
-        // roleId is never editable by building admins.
         allow create, delete: if isSuperAdmin() || isDomainAdmin(orgId);
-        allow update: if isSuperAdmin() || isDomainAdmin(orgId) ||
+        allow update: if isSuperAdmin() ||
+          (isDomainAdmin(orgId) &&
+           request.resource.data.email == resource.data.email &&
+           request.resource.data.orgId == resource.data.orgId &&
+           request.resource.data.diff(resource.data).affectedKeys().hasOnly([
+             'roleId', 'buildingIds', 'status', 'name', 'invitedAt', 'lastActive'
+           ])) ||
           (isBuildingAdmin(orgId) &&
            resource.data.buildingIds.hasAny(orgMember(orgId).buildingIds) &&
            request.resource.data.diff(resource.data).affectedKeys().hasOnly(['status']));

--- a/firestore.rules
+++ b/firestore.rules
@@ -126,12 +126,15 @@ service cloud.firestore {
       match /domains/{domainId} {
         allow read: if isOrgMember(orgId) || isSuperAdmin();
         // Domain admin or super admin only. Create must carry canonical
-        // orgId + matching doc id. Update is whitelisted to the fields
-        // admins actually configure — `status` is DNS-verified server-side
-        // (never client-set) and `users`/`addedAt` are derived/stamped.
+        // orgId + matching doc id, and clients cannot seed `status:'verified'`
+        // or inflate `users` — verification is DNS-based server-side, and
+        // `users` is a derived count. Update is whitelisted to the fields
+        // admins actually configure.
         allow create: if (isSuperAdmin() || isDomainAdmin(orgId)) &&
           request.resource.data.orgId == orgId &&
-          request.resource.data.id == domainId;
+          request.resource.data.id == domainId &&
+          request.resource.data.status == 'pending' &&
+          request.resource.data.users == 0;
         allow delete: if isSuperAdmin() || isDomainAdmin(orgId);
         allow update: if isSuperAdmin() ||
           (isDomainAdmin(orgId) &&
@@ -147,11 +150,15 @@ service cloud.firestore {
         // System roles are immutable from clients — the migration script
         // seeds them with `{ merge: true }` so the first write happens server
         // side; every client mutation is refused if `system == true`.
+        // Client-created roles must carry canonical path identity and be
+        // explicitly non-system.
         allow create: if (isSuperAdmin() || isDomainAdmin(orgId)) &&
-          request.resource.data.system != true;
+          request.resource.data.id == roleId &&
+          request.resource.data.system == false;
         allow update: if (isSuperAdmin() || isDomainAdmin(orgId)) &&
           resource.data.system != true &&
-          request.resource.data.system == resource.data.system;
+          request.resource.data.system == resource.data.system &&
+          request.resource.data.id == resource.data.id;
         allow delete: if (isSuperAdmin() || isDomainAdmin(orgId)) &&
           resource.data.system != true;
       }
@@ -170,7 +177,17 @@ service cloud.firestore {
         // fields (email, orgId, uid, addedBy, addedBySource) stay pinned to
         // what the invitation/sign-in flow set. Building admins can only
         // update `status` on members whose buildingIds intersect their own.
-        allow create, delete: if isSuperAdmin() || isDomainAdmin(orgId);
+        // Create enforces shape: doc id == lowercased email, required
+        // fields present, and only the invite-shape keys are allowed.
+        allow create: if (isSuperAdmin() || isDomainAdmin(orgId)) &&
+          request.resource.data.email == emailLower &&
+          request.resource.data.orgId == orgId &&
+          request.resource.data.keys().hasAll(['email', 'orgId', 'roleId', 'buildingIds', 'status']) &&
+          request.resource.data.keys().hasOnly([
+            'email', 'orgId', 'roleId', 'buildingIds', 'status',
+            'name', 'invitedAt', 'addedBy', 'addedBySource'
+          ]);
+        allow delete: if isSuperAdmin() || isDomainAdmin(orgId);
         allow update: if isSuperAdmin() ||
           (isDomainAdmin(orgId) &&
            request.resource.data.email == resource.data.email &&
@@ -185,7 +202,12 @@ service cloud.firestore {
 
       match /studentPageConfig/{configId} {
         allow read: if isOrgMember(orgId) || isSuperAdmin();
-        allow create, update, delete: if isSuperAdmin() || isDomainAdmin(orgId);
+        // Only the canonical `default` doc is writable; clients never need
+        // arbitrary config ids, and delete is refused so the org always has
+        // a config doc (rules tier narrows the attack surface).
+        allow create, update: if (isSuperAdmin() || isDomainAdmin(orgId)) &&
+          configId == 'default';
+        allow delete: if false;
       }
 
       match /invitations/{token} {

--- a/firestore.rules
+++ b/firestore.rules
@@ -194,10 +194,15 @@ service cloud.firestore {
         // fields (email, orgId, uid, addedBy, addedBySource) stay pinned to
         // what the invitation/sign-in flow set. Building admins can only
         // update `status` on members whose buildingIds intersect their own.
-        // Create enforces shape: doc id == lowercased email, required
-        // fields present, and only the invite-shape keys are allowed.
+        // Create enforces shape: doc id == lowercased email (both the path
+        // segment and payload field must be lowercase so isOrgMember() — which
+        // always looks up `members/{token.email.lower()}` — can find the
+        // record), required fields present, and only the invite-shape keys
+        // are allowed.
         allow create: if (isSuperAdmin() || isDomainAdmin(orgId)) &&
+          emailLower == emailLower.lower() &&
           request.resource.data.email == emailLower &&
+          request.resource.data.email == request.resource.data.email.lower() &&
           request.resource.data.orgId == orgId &&
           request.resource.data.keys().hasAll(['email', 'orgId', 'roleId', 'buildingIds', 'status']) &&
           request.resource.data.keys().hasOnly([

--- a/firestore.rules
+++ b/firestore.rules
@@ -103,24 +103,31 @@ service cloud.firestore {
       match /buildings/{buildingId} {
         allow read: if isOrgMember(orgId) || isSuperAdmin();
         // Only domain+ admins can create/delete buildings. Create must carry
-        // the canonical orgId and matching doc id so clients can't seed
-        // records that misrepresent their parent.
+        // the canonical orgId + matching doc id, pin `users == 0` (derived
+        // count, server-managed), and only include the known building fields
+        // so clients can't seed unexpected attributes.
         allow create: if (isSuperAdmin() || isDomainAdmin(orgId)) &&
           request.resource.data.orgId == orgId &&
-          request.resource.data.id == buildingId;
+          request.resource.data.id == buildingId &&
+          request.resource.data.users == 0 &&
+          request.resource.data.keys().hasOnly([
+            'id', 'orgId', 'name', 'address', 'grades', 'type',
+            'adminEmails', 'users'
+          ]);
         allow delete: if isSuperAdmin() || isDomainAdmin(orgId);
-        // Building admins can edit the mutable fields of buildings they
-        // manage; domain+ admins edit any building. Identity fields
-        // (id, orgId) are immutable for all tiers below super admin.
-        allow update: if (isSuperAdmin() ||
-            (isDomainAdmin(orgId) &&
+        // Domain+ admins edit any building in their org; building admins edit
+        // only buildings they manage. Both tiers share a field whitelist so
+        // neither can touch identity fields (id, orgId) or the server-managed
+        // `users` count. Super admins are unrestricted.
+        allow update: if isSuperAdmin() ||
+            ((isDomainAdmin(orgId) ||
+              (isBuildingAdmin(orgId) &&
+               buildingId in orgMember(orgId).buildingIds)) &&
              request.resource.data.id == resource.data.id &&
-             request.resource.data.orgId == resource.data.orgId) ||
-            (isBuildingAdmin(orgId) &&
-             buildingId in orgMember(orgId).buildingIds &&
+             request.resource.data.orgId == resource.data.orgId &&
              request.resource.data.diff(resource.data).affectedKeys().hasOnly([
                'name', 'address', 'grades', 'type', 'adminEmails'
-             ])));
+             ]));
       }
 
       match /domains/{domainId} {
@@ -204,9 +211,15 @@ service cloud.firestore {
         allow read: if isOrgMember(orgId) || isSuperAdmin();
         // Only the canonical `default` doc is writable; clients never need
         // arbitrary config ids, and delete is refused so the org always has
-        // a config doc (rules tier narrows the attack surface).
+        // a config doc. Payload must carry the canonical orgId and only the
+        // known config fields so clients can't seed unexpected attributes.
         allow create, update: if (isSuperAdmin() || isDomainAdmin(orgId)) &&
-          configId == 'default';
+          configId == 'default' &&
+          request.resource.data.orgId == orgId &&
+          request.resource.data.keys().hasOnly([
+            'orgId', 'showAnnouncements', 'showTeacherDirectory',
+            'showLunchMenu', 'accentColor', 'heroText'
+          ]);
         allow delete: if false;
       }
 

--- a/firestore.rules
+++ b/firestore.rules
@@ -65,7 +65,7 @@ service cloud.firestore {
 
     // ---- Organizations collection (Phase 3: scoped writes enabled) ----
     // Rules enforce role scoping; the client additionally gates UI via the
-    // `orgAdminWrites` feature flag so ramp-up stays controlled. Writes that
+    // `org-admin-writes` feature flag so ramp-up stays controlled. Writes that
     // bypass the client gate still land in these rules.
     //
     // Scoping summary:
@@ -157,15 +157,25 @@ service cloud.firestore {
         // System roles are immutable from clients — the migration script
         // seeds them with `{ merge: true }` so the first write happens server
         // side; every client mutation is refused if `system == true`.
-        // Client-created roles must carry canonical path identity and be
-        // explicitly non-system.
+        // Client-created roles must carry canonical path identity, be
+        // explicitly non-system, and stay within the supported schema so
+        // clients can't attach unexpected fields.
         allow create: if (isSuperAdmin() || isDomainAdmin(orgId)) &&
           request.resource.data.id == roleId &&
-          request.resource.data.system == false;
+          request.resource.data.system == false &&
+          request.resource.data.keys().hasAll(['id', 'name', 'system', 'perms']) &&
+          request.resource.data.keys().hasOnly([
+            'id', 'name', 'blurb', 'color', 'system', 'perms'
+          ]);
+        // Update whitelist keeps identity (id) and seed flag (system) pinned
+        // and blocks extensions beyond the known fields.
         allow update: if (isSuperAdmin() || isDomainAdmin(orgId)) &&
           resource.data.system != true &&
           request.resource.data.system == resource.data.system &&
-          request.resource.data.id == resource.data.id;
+          request.resource.data.id == resource.data.id &&
+          request.resource.data.diff(resource.data).affectedKeys().hasOnly([
+            'name', 'blurb', 'color', 'perms'
+          ]);
         allow delete: if (isSuperAdmin() || isDomainAdmin(orgId)) &&
           resource.data.system != true;
       }

--- a/firestore.rules
+++ b/firestore.rules
@@ -63,10 +63,21 @@ service cloud.firestore {
              exists(/databases/$(database)/documents/organizations/$(orgId)/members/$(request.auth.token.email.lower()));
     }
 
-    // ---- Organizations collection (Phase 1: read-only foundation) ----
-    // All writes are blocked until Phase 3 wires the scoping + feature flag.
-    // TODO(phase-3): replace `allow write: if false` with scoped rules using
-    // isSuperAdmin(), isDomainAdmin(orgId), isBuildingAdmin(orgId).
+    // ---- Organizations collection (Phase 3: scoped writes enabled) ----
+    // Rules enforce role scoping; the client additionally gates UI via the
+    // `orgAdminWrites` feature flag so ramp-up stays controlled. Writes that
+    // bypass the client gate still land in these rules.
+    //
+    // Scoping summary:
+    //   - Super admins: any field, any org.
+    //   - Domain admins: org-wide writes for their org (except AI/plan flags
+    //     reserved to super admins) — create/update/delete on buildings,
+    //     domains, roles (custom only), members, studentPageConfig.
+    //   - Building admins: read-only almost everywhere; on members, may
+    //     update `status` for a member whose existing buildingIds intersect
+    //     the actor's own buildingIds. Never roleId.
+    //   - System roles (`system: true`) are immutable from clients —
+    //     migration script seeds them once; clone-to-customize is the path.
 
     // Short-circuit ordering note: `isOrgMember()` performs a single targeted
     // `exists()` against the caller's member doc, while `isSuperAdmin()` runs
@@ -76,21 +87,45 @@ service cloud.firestore {
 
     match /organizations/{orgId} {
       allow read: if isOrgMember(orgId) || isSuperAdmin();
-      allow write: if false; // TODO(phase-3)
+      // Only super admins can create, archive (delete), or flip AI/plan.
+      // Domain admins can edit identity-ish fields for their own org.
+      allow create, delete: if isSuperAdmin();
+      allow update: if isSuperAdmin() ||
+        (isDomainAdmin(orgId) &&
+         request.resource.data.diff(resource.data).affectedKeys().hasOnly([
+           'name', 'shortName', 'shortCode', 'state', 'primaryAdminEmail',
+           'users', 'buildings', 'status', 'seedColor', 'supportUrl'
+         ]));
 
       match /buildings/{buildingId} {
         allow read: if isOrgMember(orgId) || isSuperAdmin();
-        allow write: if false; // TODO(phase-3)
+        // Only domain+ admins can create/delete buildings.
+        allow create, delete: if isSuperAdmin() || isDomainAdmin(orgId);
+        // Building admins can edit buildings they manage (name, address,
+        // grades, type, adminEmails). Domain+ admins edit any building.
+        allow update: if isSuperAdmin() || isDomainAdmin(orgId) ||
+          (isBuildingAdmin(orgId) &&
+           buildingId in orgMember(orgId).buildingIds);
       }
 
       match /domains/{domainId} {
         allow read: if isOrgMember(orgId) || isSuperAdmin();
-        allow write: if false; // TODO(phase-3)
+        // Domain admin or super admin only.
+        allow create, update, delete: if isSuperAdmin() || isDomainAdmin(orgId);
       }
 
       match /roles/{roleId} {
         allow read: if isOrgMember(orgId) || isSuperAdmin();
-        allow write: if false; // TODO(phase-3)
+        // System roles are immutable from clients — the migration script
+        // seeds them with `{ merge: true }` so the first write happens server
+        // side; every client mutation is refused if `system == true`.
+        allow create: if (isSuperAdmin() || isDomainAdmin(orgId)) &&
+          request.resource.data.system != true;
+        allow update: if (isSuperAdmin() || isDomainAdmin(orgId)) &&
+          resource.data.system != true &&
+          request.resource.data.system == resource.data.system;
+        allow delete: if (isSuperAdmin() || isDomainAdmin(orgId)) &&
+          resource.data.system != true;
       }
 
       match /members/{emailLower} {
@@ -103,12 +138,19 @@ service cloud.firestore {
                        request.auth.token.email.lower() == emailLower) ||
                     isOrgMember(orgId) ||
                     isSuperAdmin();
-        allow write: if false; // TODO(phase-3)
+        // Domain+ admins fully manage members. Building admins can only
+        // update `status` on members whose buildingIds intersect their own.
+        // roleId is never editable by building admins.
+        allow create, delete: if isSuperAdmin() || isDomainAdmin(orgId);
+        allow update: if isSuperAdmin() || isDomainAdmin(orgId) ||
+          (isBuildingAdmin(orgId) &&
+           resource.data.buildingIds.hasAny(orgMember(orgId).buildingIds) &&
+           request.resource.data.diff(resource.data).affectedKeys().hasOnly(['status']));
       }
 
       match /studentPageConfig/{configId} {
         allow read: if isOrgMember(orgId) || isSuperAdmin();
-        allow write: if false; // TODO(phase-3)
+        allow create, update, delete: if isSuperAdmin() || isDomainAdmin(orgId);
       }
 
       match /invitations/{token} {

--- a/hooks/useOrgBuildings.test.ts
+++ b/hooks/useOrgBuildings.test.ts
@@ -1,13 +1,24 @@
-import { renderHook, waitFor } from '@testing-library/react';
+import { act, renderHook, waitFor } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
 import { useOrgBuildings } from './useOrgBuildings';
 import { useAuth } from '@/context/useAuth';
-import { collection, onSnapshot } from 'firebase/firestore';
+import {
+  collection,
+  deleteDoc,
+  doc,
+  onSnapshot,
+  setDoc,
+  updateDoc,
+} from 'firebase/firestore';
 import type { BuildingRecord } from '@/types/organization';
 
 vi.mock('firebase/firestore', () => ({
   collection: vi.fn(),
+  deleteDoc: vi.fn(),
+  doc: vi.fn(),
   onSnapshot: vi.fn(),
+  setDoc: vi.fn(),
+  updateDoc: vi.fn(),
 }));
 
 vi.mock('@/config/firebase', () => ({
@@ -34,10 +45,20 @@ describe('useOrgBuildings', () => {
   const mockUseAuth = useAuth as Mock;
   const mockCollection = collection as Mock;
   const mockOnSnapshot = onSnapshot as Mock;
+  const mockDoc = doc as Mock;
+  const mockSetDoc = setDoc as Mock;
+  const mockUpdateDoc = updateDoc as Mock;
+  const mockDeleteDoc = deleteDoc as Mock;
 
   beforeEach(() => {
     vi.clearAllMocks();
     mockCollection.mockReturnValue('buildings-ref');
+    mockDoc.mockImplementation((_db: unknown, ...segs: string[]) =>
+      segs.join('/')
+    );
+    mockSetDoc.mockResolvedValue(undefined);
+    mockUpdateDoc.mockResolvedValue(undefined);
+    mockDeleteDoc.mockResolvedValue(undefined);
   });
 
   it('skips subscription when orgId is null', () => {
@@ -72,13 +93,80 @@ describe('useOrgBuildings', () => {
     });
   });
 
-  it('write stubs throw phase-3 errors', async () => {
-    mockUseAuth.mockReturnValue({ user: null });
+  it('addBuilding writes a new doc with a derived id', async () => {
+    mockUseAuth.mockReturnValue({ user: { uid: 'u' } });
+    mockOnSnapshot.mockReturnValue(() => undefined);
+
     const { result } = renderHook(() => useOrgBuildings('orono'));
-    await expect(result.current.addBuilding({})).rejects.toThrow(/Phase 3/);
-    await expect(result.current.updateBuilding('x', {})).rejects.toThrow(
-      /Phase 3/
+
+    await act(async () => {
+      await result.current.addBuilding({
+        name: 'New School',
+        type: 'middle',
+      });
+    });
+
+    expect(mockSetDoc).toHaveBeenCalledTimes(1);
+    const [ref, payload] = mockSetDoc.mock.calls[0] as [string, unknown];
+    expect(ref).toBe('organizations/orono/buildings/new-school');
+    expect(payload).toMatchObject({
+      id: 'new-school',
+      orgId: 'orono',
+      name: 'New School',
+      type: 'middle',
+      address: '',
+      grades: '',
+      users: 0,
+      adminEmails: [],
+    });
+  });
+
+  it('updateBuilding patches the doc (stripping id/orgId)', async () => {
+    mockUseAuth.mockReturnValue({ user: { uid: 'u' } });
+    mockOnSnapshot.mockReturnValue(() => undefined);
+
+    const { result } = renderHook(() => useOrgBuildings('orono'));
+
+    await act(async () => {
+      await result.current.updateBuilding('schumann', {
+        id: 'ignored',
+        orgId: 'ignored',
+        address: '456 Oak',
+      });
+    });
+
+    expect(mockUpdateDoc).toHaveBeenCalledWith(
+      'organizations/orono/buildings/schumann',
+      { address: '456 Oak' }
     );
-    await expect(result.current.removeBuilding('x')).rejects.toThrow(/Phase 3/);
+  });
+
+  it('removeBuilding deletes the doc', async () => {
+    mockUseAuth.mockReturnValue({ user: { uid: 'u' } });
+    mockOnSnapshot.mockReturnValue(() => undefined);
+
+    const { result } = renderHook(() => useOrgBuildings('orono'));
+
+    await act(async () => {
+      await result.current.removeBuilding('schumann');
+    });
+
+    expect(mockDeleteDoc).toHaveBeenCalledWith(
+      'organizations/orono/buildings/schumann'
+    );
+  });
+
+  it('writes reject when orgId is null', async () => {
+    mockUseAuth.mockReturnValue({ user: null });
+    const { result } = renderHook(() => useOrgBuildings(null));
+    await expect(result.current.addBuilding({ name: 'x' })).rejects.toThrow(
+      /No organization/
+    );
+    await expect(result.current.updateBuilding('x', {})).rejects.toThrow(
+      /No organization/
+    );
+    await expect(result.current.removeBuilding('x')).rejects.toThrow(
+      /No organization/
+    );
   });
 });

--- a/hooks/useOrgBuildings.ts
+++ b/hooks/useOrgBuildings.ts
@@ -10,22 +10,7 @@ import {
 import { db, isAuthBypass } from '@/config/firebase';
 import { useAuth } from '@/context/useAuth';
 import type { BuildingRecord, BuildingType } from '@/types/organization';
-
-const slug = (s: string): string =>
-  s
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-|-$/g, '')
-    .slice(0, 48);
-
-const defaultBuildingId = (b: Partial<BuildingRecord>): string => {
-  const base = slug(b.name ?? '');
-  if (base) return base;
-  return (globalThis.crypto?.randomUUID?.() ?? `building-${Date.now()}`).slice(
-    0,
-    24
-  );
-};
+import { slugOrFallback } from '@/utils/slug';
 
 /**
  * Subscribes to `/organizations/{orgId}/buildings`. Reads allowed for org
@@ -82,7 +67,7 @@ export const useOrgBuildings = (orgId: string | null) => {
     if (!orgId) {
       throw new Error('No organization selected.');
     }
-    const id = building.id ?? defaultBuildingId(building);
+    const id = building.id ?? slugOrFallback(building.name ?? '', 'building');
     const record: BuildingRecord = {
       id,
       orgId,
@@ -104,6 +89,7 @@ export const useOrgBuildings = (orgId: string | null) => {
       throw new Error('No organization selected.');
     }
     const { id: _omitId, orgId: _omitOrg, ...rest } = patch;
+    if (Object.keys(rest).length === 0) return;
     await updateDoc(doc(db, 'organizations', orgId, 'buildings', id), rest);
   };
 

--- a/hooks/useOrgBuildings.ts
+++ b/hooks/useOrgBuildings.ts
@@ -68,6 +68,9 @@ export const useOrgBuildings = (orgId: string | null) => {
       throw new Error('No organization selected.');
     }
     const id = building.id ?? slugOrFallback(building.name ?? '', 'building');
+    // `users` is a derived count maintained server-side; `id`/`orgId` are
+    // fixed by the path. Hard-code safe defaults so caller data can't
+    // spoof counts — the rules also pin `users == 0` on create.
     const record: BuildingRecord = {
       id,
       orgId,
@@ -75,7 +78,7 @@ export const useOrgBuildings = (orgId: string | null) => {
       type: (building.type as BuildingType) ?? 'other',
       address: building.address ?? '',
       grades: building.grades ?? '',
-      users: building.users ?? 0,
+      users: 0,
       adminEmails: building.adminEmails ?? [],
     };
     await setDoc(doc(db, 'organizations', orgId, 'buildings', id), record);
@@ -88,7 +91,9 @@ export const useOrgBuildings = (orgId: string | null) => {
     if (!orgId) {
       throw new Error('No organization selected.');
     }
-    const { id: _omitId, orgId: _omitOrg, ...rest } = patch;
+    // Strip identity + server-managed fields defensively — rules reject these
+    // via the field whitelist, but filtering client-side avoids the round-trip.
+    const { id: _omitId, orgId: _omitOrg, users: _omitUsers, ...rest } = patch;
     if (Object.keys(rest).length === 0) return;
     await updateDoc(doc(db, 'organizations', orgId, 'buildings', id), rest);
   };

--- a/hooks/useOrgBuildings.ts
+++ b/hooks/useOrgBuildings.ts
@@ -1,14 +1,39 @@
 import { useEffect, useState } from 'react';
-import { collection, onSnapshot } from 'firebase/firestore';
+import {
+  collection,
+  deleteDoc,
+  doc,
+  onSnapshot,
+  setDoc,
+  updateDoc,
+} from 'firebase/firestore';
 import { db, isAuthBypass } from '@/config/firebase';
 import { useAuth } from '@/context/useAuth';
-import type { BuildingRecord } from '@/types/organization';
+import type { BuildingRecord, BuildingType } from '@/types/organization';
+
+const slug = (s: string): string =>
+  s
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '')
+    .slice(0, 48);
+
+const defaultBuildingId = (b: Partial<BuildingRecord>): string => {
+  const base = slug(b.name ?? '');
+  if (base) return base;
+  return (globalThis.crypto?.randomUUID?.() ?? `building-${Date.now()}`).slice(
+    0,
+    24
+  );
+};
 
 /**
  * Subscribes to `/organizations/{orgId}/buildings`. Reads allowed for org
  * members + super admins via Firestore rules.
  *
- * Writes are stubbed — Phase 3 wires real mutations.
+ * Writes (add/update/remove) are scoped at the rules tier: domain+ admins
+ * can CRUD any building in their org; building admins can only update
+ * buildings listed in their own `buildingIds`.
  */
 export const useOrgBuildings = (orgId: string | null) => {
   const { user } = useAuth();
@@ -51,17 +76,43 @@ export const useOrgBuildings = (orgId: string | null) => {
     return unsub;
   }, [shouldSubscribe, orgId]);
 
-  const addBuilding = (_building: Partial<BuildingRecord>): Promise<void> =>
-    Promise.reject(new Error('Building creation will be enabled in Phase 3.'));
+  const addBuilding = async (
+    building: Partial<BuildingRecord>
+  ): Promise<void> => {
+    if (!orgId) {
+      throw new Error('No organization selected.');
+    }
+    const id = building.id ?? defaultBuildingId(building);
+    const record: BuildingRecord = {
+      id,
+      orgId,
+      name: building.name ?? '',
+      type: (building.type as BuildingType) ?? 'other',
+      address: building.address ?? '',
+      grades: building.grades ?? '',
+      users: building.users ?? 0,
+      adminEmails: building.adminEmails ?? [],
+    };
+    await setDoc(doc(db, 'organizations', orgId, 'buildings', id), record);
+  };
 
-  const updateBuilding = (
-    _id: string,
-    _patch: Partial<BuildingRecord>
-  ): Promise<void> =>
-    Promise.reject(new Error('Building edits will be enabled in Phase 3.'));
+  const updateBuilding = async (
+    id: string,
+    patch: Partial<BuildingRecord>
+  ): Promise<void> => {
+    if (!orgId) {
+      throw new Error('No organization selected.');
+    }
+    const { id: _omitId, orgId: _omitOrg, ...rest } = patch;
+    await updateDoc(doc(db, 'organizations', orgId, 'buildings', id), rest);
+  };
 
-  const removeBuilding = (_id: string): Promise<void> =>
-    Promise.reject(new Error('Building archival will be enabled in Phase 3.'));
+  const removeBuilding = async (id: string): Promise<void> => {
+    if (!orgId) {
+      throw new Error('No organization selected.');
+    }
+    await deleteDoc(doc(db, 'organizations', orgId, 'buildings', id));
+  };
 
   return {
     buildings,

--- a/hooks/useOrgDomains.test.ts
+++ b/hooks/useOrgDomains.test.ts
@@ -1,13 +1,22 @@
-import { renderHook, waitFor } from '@testing-library/react';
+import { act, renderHook, waitFor } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
 import { useOrgDomains } from './useOrgDomains';
 import { useAuth } from '@/context/useAuth';
-import { collection, onSnapshot } from 'firebase/firestore';
+import {
+  collection,
+  deleteDoc,
+  doc,
+  onSnapshot,
+  setDoc,
+} from 'firebase/firestore';
 import type { DomainRecord } from '@/types/organization';
 
 vi.mock('firebase/firestore', () => ({
   collection: vi.fn(),
+  deleteDoc: vi.fn(),
+  doc: vi.fn(),
   onSnapshot: vi.fn(),
+  setDoc: vi.fn(),
 }));
 
 vi.mock('@/config/firebase', () => ({
@@ -34,10 +43,18 @@ describe('useOrgDomains', () => {
   const mockUseAuth = useAuth as Mock;
   const mockCollection = collection as Mock;
   const mockOnSnapshot = onSnapshot as Mock;
+  const mockDoc = doc as Mock;
+  const mockSetDoc = setDoc as Mock;
+  const mockDeleteDoc = deleteDoc as Mock;
 
   beforeEach(() => {
     vi.clearAllMocks();
     mockCollection.mockReturnValue('domains-ref');
+    mockDoc.mockImplementation((_db: unknown, ...segs: string[]) =>
+      segs.join('/')
+    );
+    mockSetDoc.mockResolvedValue(undefined);
+    mockDeleteDoc.mockResolvedValue(undefined);
   });
 
   it('skips subscription when orgId is null', () => {
@@ -72,10 +89,67 @@ describe('useOrgDomains', () => {
     });
   });
 
-  it('write stubs throw phase-3 errors', async () => {
-    mockUseAuth.mockReturnValue({ user: null });
+  it('addDomain writes a new doc with a derived id', async () => {
+    mockUseAuth.mockReturnValue({ user: { uid: 'u' } });
+    mockOnSnapshot.mockReturnValue(() => undefined);
+
     const { result } = renderHook(() => useOrgDomains('orono'));
-    await expect(result.current.addDomain({})).rejects.toThrow(/Phase 3/);
-    await expect(result.current.removeDomain('x')).rejects.toThrow(/Phase 3/);
+
+    await act(async () => {
+      await result.current.addDomain({
+        domain: '@students.orono.k12.mn.us',
+        authMethod: 'google',
+        role: 'student',
+      });
+    });
+
+    expect(mockSetDoc).toHaveBeenCalledTimes(1);
+    const [ref, payload] = mockSetDoc.mock.calls[0] as [string, unknown];
+    expect(ref).toBe('organizations/orono/domains/students-orono-k12-mn-us');
+    expect(payload).toMatchObject({
+      orgId: 'orono',
+      domain: '@students.orono.k12.mn.us',
+      authMethod: 'google',
+      role: 'student',
+      status: 'pending',
+      users: 0,
+    });
+  });
+
+  it('addDomain rejects when domain is missing', async () => {
+    mockUseAuth.mockReturnValue({ user: { uid: 'u' } });
+    mockOnSnapshot.mockReturnValue(() => undefined);
+
+    const { result } = renderHook(() => useOrgDomains('orono'));
+
+    await expect(result.current.addDomain({})).rejects.toThrow(
+      /Domain is required/
+    );
+  });
+
+  it('removeDomain deletes the doc', async () => {
+    mockUseAuth.mockReturnValue({ user: { uid: 'u' } });
+    mockOnSnapshot.mockReturnValue(() => undefined);
+
+    const { result } = renderHook(() => useOrgDomains('orono'));
+
+    await act(async () => {
+      await result.current.removeDomain('orono.k12.mn.us');
+    });
+
+    expect(mockDeleteDoc).toHaveBeenCalledWith(
+      'organizations/orono/domains/orono.k12.mn.us'
+    );
+  });
+
+  it('writes reject when orgId is null', async () => {
+    mockUseAuth.mockReturnValue({ user: null });
+    const { result } = renderHook(() => useOrgDomains(null));
+    await expect(
+      result.current.addDomain({ domain: '@x.com' })
+    ).rejects.toThrow(/No organization/);
+    await expect(result.current.removeDomain('x')).rejects.toThrow(
+      /No organization/
+    );
   });
 });

--- a/hooks/useOrgDomains.ts
+++ b/hooks/useOrgDomains.ts
@@ -12,25 +12,8 @@ import type {
   AuthMethod,
   DomainRecord,
   DomainRole,
-  DomainStatus,
 } from '@/types/organization';
-
-const slug = (s: string): string =>
-  s
-    .toLowerCase()
-    .replace(/^@/, '')
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-|-$/g, '')
-    .slice(0, 48);
-
-const defaultDomainId = (d: Partial<DomainRecord>): string => {
-  const base = slug(d.domain ?? '');
-  if (base) return base;
-  return (globalThis.crypto?.randomUUID?.() ?? `domain-${Date.now()}`).slice(
-    0,
-    24
-  );
-};
+import { slugOrFallback } from '@/utils/slug';
 
 /**
  * Subscribes to `/organizations/{orgId}/domains`. Reads allowed for org
@@ -86,16 +69,21 @@ export const useOrgDomains = (orgId: string | null) => {
     if (!domain.domain) {
       throw new Error('Domain is required.');
     }
-    const id = domain.id ?? defaultDomainId(domain);
+    const id = domain.id ?? slugOrFallback(domain.domain, 'domain');
+    // `status`, `users`, and `addedAt` are server-managed (status is
+    // DNS-verified by a Cloud Function; users is a derived count; addedAt is
+    // the admin's create stamp). Hard-code safe defaults so caller data can
+    // never spoof the verification state — the rules also reject a
+    // client-supplied `status != 'pending'` on create.
     const record: DomainRecord = {
       id,
       orgId,
       domain: domain.domain,
       authMethod: (domain.authMethod as AuthMethod) ?? 'google',
-      status: (domain.status as DomainStatus) ?? 'pending',
+      status: 'pending',
       role: (domain.role as DomainRole) ?? 'staff',
-      users: domain.users ?? 0,
-      addedAt: domain.addedAt ?? new Date().toISOString(),
+      users: 0,
+      addedAt: new Date().toISOString(),
     };
     await setDoc(doc(db, 'organizations', orgId, 'domains', id), record);
   };

--- a/hooks/useOrgDomains.ts
+++ b/hooks/useOrgDomains.ts
@@ -1,14 +1,42 @@
 import { useEffect, useState } from 'react';
-import { collection, onSnapshot } from 'firebase/firestore';
+import {
+  collection,
+  deleteDoc,
+  doc,
+  onSnapshot,
+  setDoc,
+} from 'firebase/firestore';
 import { db, isAuthBypass } from '@/config/firebase';
 import { useAuth } from '@/context/useAuth';
-import type { DomainRecord } from '@/types/organization';
+import type {
+  AuthMethod,
+  DomainRecord,
+  DomainRole,
+  DomainStatus,
+} from '@/types/organization';
+
+const slug = (s: string): string =>
+  s
+    .toLowerCase()
+    .replace(/^@/, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '')
+    .slice(0, 48);
+
+const defaultDomainId = (d: Partial<DomainRecord>): string => {
+  const base = slug(d.domain ?? '');
+  if (base) return base;
+  return (globalThis.crypto?.randomUUID?.() ?? `domain-${Date.now()}`).slice(
+    0,
+    24
+  );
+};
 
 /**
  * Subscribes to `/organizations/{orgId}/domains`. Reads allowed for org
  * members + super admins via Firestore rules.
  *
- * Writes are stubbed — Phase 3 wires real mutations.
+ * Writes (add/remove) are scoped to domain+ admins at the rules tier.
  */
 export const useOrgDomains = (orgId: string | null) => {
   const { user } = useAuth();
@@ -51,11 +79,33 @@ export const useOrgDomains = (orgId: string | null) => {
     return unsub;
   }, [shouldSubscribe, orgId]);
 
-  const addDomain = (_domain: Partial<DomainRecord>): Promise<void> =>
-    Promise.reject(new Error('Domain creation will be enabled in Phase 3.'));
+  const addDomain = async (domain: Partial<DomainRecord>): Promise<void> => {
+    if (!orgId) {
+      throw new Error('No organization selected.');
+    }
+    if (!domain.domain) {
+      throw new Error('Domain is required.');
+    }
+    const id = domain.id ?? defaultDomainId(domain);
+    const record: DomainRecord = {
+      id,
+      orgId,
+      domain: domain.domain,
+      authMethod: (domain.authMethod as AuthMethod) ?? 'google',
+      status: (domain.status as DomainStatus) ?? 'pending',
+      role: (domain.role as DomainRole) ?? 'staff',
+      users: domain.users ?? 0,
+      addedAt: domain.addedAt ?? new Date().toISOString(),
+    };
+    await setDoc(doc(db, 'organizations', orgId, 'domains', id), record);
+  };
 
-  const removeDomain = (_id: string): Promise<void> =>
-    Promise.reject(new Error('Domain removal will be enabled in Phase 3.'));
+  const removeDomain = async (id: string): Promise<void> => {
+    if (!orgId) {
+      throw new Error('No organization selected.');
+    }
+    await deleteDoc(doc(db, 'organizations', orgId, 'domains', id));
+  };
 
   return {
     domains,

--- a/hooks/useOrgMembers.test.ts
+++ b/hooks/useOrgMembers.test.ts
@@ -1,13 +1,22 @@
-import { renderHook, waitFor } from '@testing-library/react';
+import { act, renderHook, waitFor } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
 import { useOrgMembers } from './useOrgMembers';
 import { useAuth } from '@/context/useAuth';
-import { collection, onSnapshot } from 'firebase/firestore';
+import {
+  collection,
+  deleteDoc,
+  doc,
+  onSnapshot,
+  updateDoc,
+} from 'firebase/firestore';
 import type { MemberRecord } from '@/types/organization';
 
 vi.mock('firebase/firestore', () => ({
   collection: vi.fn(),
+  deleteDoc: vi.fn(),
+  doc: vi.fn(),
   onSnapshot: vi.fn(),
+  updateDoc: vi.fn(),
 }));
 
 vi.mock('@/config/firebase', () => ({
@@ -33,10 +42,18 @@ describe('useOrgMembers', () => {
   const mockUseAuth = useAuth as Mock;
   const mockCollection = collection as Mock;
   const mockOnSnapshot = onSnapshot as Mock;
+  const mockDoc = doc as Mock;
+  const mockUpdateDoc = updateDoc as Mock;
+  const mockDeleteDoc = deleteDoc as Mock;
 
   beforeEach(() => {
     vi.clearAllMocks();
     mockCollection.mockReturnValue('members-ref');
+    mockDoc.mockImplementation((_db: unknown, ...segs: string[]) =>
+      segs.join('/')
+    );
+    mockUpdateDoc.mockResolvedValue(undefined);
+    mockDeleteDoc.mockResolvedValue(undefined);
   });
 
   it('skips subscription when orgId is null', () => {
@@ -76,18 +93,105 @@ describe('useOrgMembers', () => {
     });
   });
 
-  it('write stubs throw with correct phase labels', async () => {
-    mockUseAuth.mockReturnValue({ user: null });
+  it('updateMember translates role → roleId and strips identity fields', async () => {
+    mockUseAuth.mockReturnValue({ user: { uid: 'u' } });
+    mockOnSnapshot.mockReturnValue(() => undefined);
+
     const { result } = renderHook(() => useOrgMembers('orono'));
-    await expect(result.current.updateMember('id', {})).rejects.toThrow(
-      /Phase 3/
+
+    await act(async () => {
+      await result.current.updateMember('paul@x.com', {
+        id: 'ignored',
+        email: 'ignored',
+        orgId: 'ignored',
+        role: 'teacher',
+        status: 'inactive',
+      });
+    });
+
+    expect(mockUpdateDoc).toHaveBeenCalledWith(
+      'organizations/orono/members/paul@x.com',
+      { roleId: 'teacher', status: 'inactive' }
     );
-    await expect(result.current.bulkUpdateMembers([], {})).rejects.toThrow(
-      /Phase 3/
+  });
+
+  it('updateMember no-ops when patch is empty', async () => {
+    mockUseAuth.mockReturnValue({ user: { uid: 'u' } });
+    mockOnSnapshot.mockReturnValue(() => undefined);
+
+    const { result } = renderHook(() => useOrgMembers('orono'));
+
+    await act(async () => {
+      await result.current.updateMember('paul@x.com', {});
+    });
+
+    expect(mockUpdateDoc).not.toHaveBeenCalled();
+  });
+
+  it('bulkUpdateMembers fans out across ids', async () => {
+    mockUseAuth.mockReturnValue({ user: { uid: 'u' } });
+    mockOnSnapshot.mockReturnValue(() => undefined);
+
+    const { result } = renderHook(() => useOrgMembers('orono'));
+
+    await act(async () => {
+      await result.current.bulkUpdateMembers(['a@x.com', 'b@x.com'], {
+        status: 'inactive',
+      });
+    });
+
+    expect(mockUpdateDoc).toHaveBeenCalledTimes(2);
+    expect(mockUpdateDoc).toHaveBeenCalledWith(
+      'organizations/orono/members/a@x.com',
+      { status: 'inactive' }
     );
-    await expect(result.current.removeMembers([])).rejects.toThrow(/Phase 3/);
+    expect(mockUpdateDoc).toHaveBeenCalledWith(
+      'organizations/orono/members/b@x.com',
+      { status: 'inactive' }
+    );
+  });
+
+  it('removeMembers fans out deleteDoc calls', async () => {
+    mockUseAuth.mockReturnValue({ user: { uid: 'u' } });
+    mockOnSnapshot.mockReturnValue(() => undefined);
+
+    const { result } = renderHook(() => useOrgMembers('orono'));
+
+    await act(async () => {
+      await result.current.removeMembers(['a@x.com', 'b@x.com']);
+    });
+
+    expect(mockDeleteDoc).toHaveBeenCalledTimes(2);
+    expect(mockDeleteDoc).toHaveBeenCalledWith(
+      'organizations/orono/members/a@x.com'
+    );
+    expect(mockDeleteDoc).toHaveBeenCalledWith(
+      'organizations/orono/members/b@x.com'
+    );
+  });
+
+  it('inviteMembers is still a Phase 4 stub', async () => {
+    mockUseAuth.mockReturnValue({ user: { uid: 'u' } });
+    mockOnSnapshot.mockReturnValue(() => undefined);
+
+    const { result } = renderHook(() => useOrgMembers('orono'));
+
     await expect(
       result.current.inviteMembers([], 'teacher', [])
     ).rejects.toThrow(/Phase 4/);
+  });
+
+  it('writes reject when orgId is null', async () => {
+    mockUseAuth.mockReturnValue({ user: null });
+    const { result } = renderHook(() => useOrgMembers(null));
+    await expect(
+      result.current.updateMember('x', { status: 'active' })
+    ).rejects.toThrow(/No organization/);
+    await expect(
+      result.current.bulkUpdateMembers(['x'], { status: 'active' })
+    ).rejects.toThrow(/No organization/);
+    await expect(result.current.removeMembers(['x'])).rejects.toThrow(
+      /No organization/
+    );
   });
 });

--- a/hooks/useOrgMembers.test.ts
+++ b/hooks/useOrgMembers.test.ts
@@ -4,19 +4,19 @@ import { useOrgMembers } from './useOrgMembers';
 import { useAuth } from '@/context/useAuth';
 import {
   collection,
-  deleteDoc,
   doc,
   onSnapshot,
   updateDoc,
+  writeBatch,
 } from 'firebase/firestore';
 import type { MemberRecord } from '@/types/organization';
 
 vi.mock('firebase/firestore', () => ({
   collection: vi.fn(),
-  deleteDoc: vi.fn(),
   doc: vi.fn(),
   onSnapshot: vi.fn(),
   updateDoc: vi.fn(),
+  writeBatch: vi.fn(),
 }));
 
 vi.mock('@/config/firebase', () => ({
@@ -44,7 +44,10 @@ describe('useOrgMembers', () => {
   const mockOnSnapshot = onSnapshot as Mock;
   const mockDoc = doc as Mock;
   const mockUpdateDoc = updateDoc as Mock;
-  const mockDeleteDoc = deleteDoc as Mock;
+  const mockWriteBatch = writeBatch as Mock;
+  const batchUpdate = vi.fn();
+  const batchDelete = vi.fn();
+  const batchCommit = vi.fn();
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -53,7 +56,14 @@ describe('useOrgMembers', () => {
       segs.join('/')
     );
     mockUpdateDoc.mockResolvedValue(undefined);
-    mockDeleteDoc.mockResolvedValue(undefined);
+    batchUpdate.mockReset();
+    batchDelete.mockReset();
+    batchCommit.mockReset().mockResolvedValue(undefined);
+    mockWriteBatch.mockReturnValue({
+      update: batchUpdate,
+      delete: batchDelete,
+      commit: batchCommit,
+    });
   });
 
   it('skips subscription when orgId is null', () => {
@@ -128,7 +138,7 @@ describe('useOrgMembers', () => {
     expect(mockUpdateDoc).not.toHaveBeenCalled();
   });
 
-  it('bulkUpdateMembers fans out across ids', async () => {
+  it('bulkUpdateMembers batches writes via writeBatch', async () => {
     mockUseAuth.mockReturnValue({ user: { uid: 'u' } });
     mockOnSnapshot.mockReturnValue(() => undefined);
 
@@ -140,18 +150,38 @@ describe('useOrgMembers', () => {
       });
     });
 
-    expect(mockUpdateDoc).toHaveBeenCalledTimes(2);
-    expect(mockUpdateDoc).toHaveBeenCalledWith(
+    expect(mockWriteBatch).toHaveBeenCalledTimes(1);
+    expect(batchUpdate).toHaveBeenCalledTimes(2);
+    expect(batchUpdate).toHaveBeenCalledWith(
       'organizations/orono/members/a@x.com',
       { status: 'inactive' }
     );
-    expect(mockUpdateDoc).toHaveBeenCalledWith(
+    expect(batchUpdate).toHaveBeenCalledWith(
       'organizations/orono/members/b@x.com',
       { status: 'inactive' }
     );
+    expect(batchCommit).toHaveBeenCalledTimes(1);
+    expect(mockUpdateDoc).not.toHaveBeenCalled();
   });
 
-  it('removeMembers fans out deleteDoc calls', async () => {
+  it('bulkUpdateMembers chunks batches at the 400-op ceiling', async () => {
+    mockUseAuth.mockReturnValue({ user: { uid: 'u' } });
+    mockOnSnapshot.mockReturnValue(() => undefined);
+
+    const { result } = renderHook(() => useOrgMembers('orono'));
+
+    const ids = Array.from({ length: 450 }, (_, i) => `u${i}@x.com`);
+
+    await act(async () => {
+      await result.current.bulkUpdateMembers(ids, { status: 'inactive' });
+    });
+
+    expect(mockWriteBatch).toHaveBeenCalledTimes(2);
+    expect(batchUpdate).toHaveBeenCalledTimes(450);
+    expect(batchCommit).toHaveBeenCalledTimes(2);
+  });
+
+  it('removeMembers batches deletes via writeBatch', async () => {
     mockUseAuth.mockReturnValue({ user: { uid: 'u' } });
     mockOnSnapshot.mockReturnValue(() => undefined);
 
@@ -161,13 +191,15 @@ describe('useOrgMembers', () => {
       await result.current.removeMembers(['a@x.com', 'b@x.com']);
     });
 
-    expect(mockDeleteDoc).toHaveBeenCalledTimes(2);
-    expect(mockDeleteDoc).toHaveBeenCalledWith(
+    expect(mockWriteBatch).toHaveBeenCalledTimes(1);
+    expect(batchDelete).toHaveBeenCalledTimes(2);
+    expect(batchDelete).toHaveBeenCalledWith(
       'organizations/orono/members/a@x.com'
     );
-    expect(mockDeleteDoc).toHaveBeenCalledWith(
+    expect(batchDelete).toHaveBeenCalledWith(
       'organizations/orono/members/b@x.com'
     );
+    expect(batchCommit).toHaveBeenCalledTimes(1);
   });
 
   it('inviteMembers is still a Phase 4 stub', async () => {

--- a/hooks/useOrgMembers.ts
+++ b/hooks/useOrgMembers.ts
@@ -1,5 +1,11 @@
 import { useEffect, useMemo, useState } from 'react';
-import { collection, onSnapshot } from 'firebase/firestore';
+import {
+  collection,
+  deleteDoc,
+  doc,
+  onSnapshot,
+  updateDoc,
+} from 'firebase/firestore';
 import { db, isAuthBypass } from '@/config/firebase';
 import { useAuth } from '@/context/useAuth';
 import type { MemberRecord, UserRecord } from '@/types/organization';
@@ -26,13 +32,33 @@ const toUserRecord = (m: MemberRecord, orgId: string): UserRecord => ({
   invitedAt: m.invitedAt,
 });
 
+// Translate a `UserRecord` patch from the UI into the underlying
+// `MemberRecord` field names. `role` (UI) ↔ `roleId` (schema); identity
+// fields (id/email/orgId) are stripped because they're immutable.
+const userPatchToMemberPatch = (
+  patch: Partial<UserRecord>
+): Record<string, unknown> => {
+  const {
+    id: _omitId,
+    email: _omitEmail,
+    orgId: _omitOrg,
+    role,
+    ...rest
+  } = patch;
+  const memberPatch: Record<string, unknown> = { ...rest };
+  if (role !== undefined) memberPatch.roleId = role;
+  return memberPatch;
+};
+
 /**
  * Subscribes to `/organizations/{orgId}/members`. Returns both the raw member
  * records and a UI-friendly `UserRecord[]` projection.
  *
- * Writes (update / bulk / remove / invite) are stubbed — Phase 3 wires real
- * mutations behind the `orgAdminWrites` flag. Phase 4 wires invite emails +
- * the Cloud Function that syncs `members` → `/admins/{email}`.
+ * Writes: `updateMember` / `bulkUpdateMembers` patch member docs (rules scope
+ * the allowed fields per actor role). `removeMembers` deletes the docs —
+ * rules restrict this to domain+ admins. `inviteMembers` is a Phase 4 stub
+ * because the invite flow requires a Cloud Function to mint tokens and send
+ * email; it still throws here.
  */
 export const useOrgMembers = (orgId: string | null) => {
   const { user } = useAuth();
@@ -80,20 +106,46 @@ export const useOrgMembers = (orgId: string | null) => {
     [members, orgId]
   );
 
-  const updateMember = (
-    _id: string,
-    _patch: Partial<UserRecord>
-  ): Promise<void> =>
-    Promise.reject(new Error('User edits will be enabled in Phase 3.'));
+  const updateMember = async (
+    id: string,
+    patch: Partial<UserRecord>
+  ): Promise<void> => {
+    if (!orgId) {
+      throw new Error('No organization selected.');
+    }
+    const memberPatch = userPatchToMemberPatch(patch);
+    if (Object.keys(memberPatch).length === 0) return;
+    await updateDoc(
+      doc(db, 'organizations', orgId, 'members', id),
+      memberPatch
+    );
+  };
 
-  const bulkUpdateMembers = (
-    _ids: string[],
-    _patch: Partial<UserRecord>
-  ): Promise<void> =>
-    Promise.reject(new Error('Bulk user edits will be enabled in Phase 3.'));
+  const bulkUpdateMembers = async (
+    ids: string[],
+    patch: Partial<UserRecord>
+  ): Promise<void> => {
+    if (!orgId) {
+      throw new Error('No organization selected.');
+    }
+    const memberPatch = userPatchToMemberPatch(patch);
+    if (Object.keys(memberPatch).length === 0 || ids.length === 0) return;
+    await Promise.all(
+      ids.map((id) =>
+        updateDoc(doc(db, 'organizations', orgId, 'members', id), memberPatch)
+      )
+    );
+  };
 
-  const removeMembers = (_ids: string[]): Promise<void> =>
-    Promise.reject(new Error('User removal will be enabled in Phase 3.'));
+  const removeMembers = async (ids: string[]): Promise<void> => {
+    if (!orgId) {
+      throw new Error('No organization selected.');
+    }
+    if (ids.length === 0) return;
+    await Promise.all(
+      ids.map((id) => deleteDoc(doc(db, 'organizations', orgId, 'members', id)))
+    );
+  };
 
   const inviteMembers = (
     _emails: string[],

--- a/hooks/useOrgMembers.ts
+++ b/hooks/useOrgMembers.ts
@@ -1,14 +1,27 @@
 import { useEffect, useMemo, useState } from 'react';
 import {
   collection,
-  deleteDoc,
   doc,
   onSnapshot,
   updateDoc,
+  writeBatch,
 } from 'firebase/firestore';
 import { db, isAuthBypass } from '@/config/firebase';
 import { useAuth } from '@/context/useAuth';
 import type { MemberRecord, UserRecord } from '@/types/organization';
+
+// Firestore caps writeBatch at 500 operations; 400 leaves headroom for
+// incidental writes on the same path (e.g. migration scripts) without
+// hitting the limit. Matches the chunk size used by useFolders.
+const BATCH_CHUNK = 400;
+
+const chunk = <T>(items: T[], size: number): T[][] => {
+  const chunks: T[][] = [];
+  for (let i = 0; i < items.length; i += size) {
+    chunks.push(items.slice(i, i + size));
+  }
+  return chunks;
+};
 
 // Derive a display name from an email local-part when the member record
 // doesn't carry one. Matches the pattern used by the prototype invite flow.
@@ -131,9 +144,16 @@ export const useOrgMembers = (orgId: string | null) => {
     const memberPatch = userPatchToMemberPatch(patch);
     if (Object.keys(memberPatch).length === 0 || ids.length === 0) return;
     await Promise.all(
-      ids.map((id) =>
-        updateDoc(doc(db, 'organizations', orgId, 'members', id), memberPatch)
-      )
+      chunk(ids, BATCH_CHUNK).map((batchIds) => {
+        const batch = writeBatch(db);
+        for (const id of batchIds) {
+          batch.update(
+            doc(db, 'organizations', orgId, 'members', id),
+            memberPatch
+          );
+        }
+        return batch.commit();
+      })
     );
   };
 
@@ -143,7 +163,13 @@ export const useOrgMembers = (orgId: string | null) => {
     }
     if (ids.length === 0) return;
     await Promise.all(
-      ids.map((id) => deleteDoc(doc(db, 'organizations', orgId, 'members', id)))
+      chunk(ids, BATCH_CHUNK).map((batchIds) => {
+        const batch = writeBatch(db);
+        for (const id of batchIds) {
+          batch.delete(doc(db, 'organizations', orgId, 'members', id));
+        }
+        return batch.commit();
+      })
     );
   };
 

--- a/hooks/useOrgMembers.ts
+++ b/hooks/useOrgMembers.ts
@@ -10,9 +10,10 @@ import { db, isAuthBypass } from '@/config/firebase';
 import { useAuth } from '@/context/useAuth';
 import type { MemberRecord, UserRecord } from '@/types/organization';
 
-// Firestore caps writeBatch at 500 operations; 400 leaves headroom for
-// incidental writes on the same path (e.g. migration scripts) without
-// hitting the limit. Matches the chunk size used by useFolders.
+// Firestore caps each writeBatch commit at 500 operations; 400 keeps a
+// safety margin so future additions to the same batch (e.g. audit-log
+// writes) can be appended without risking the limit. Matches the chunk
+// size used by useFolders.
 const BATCH_CHUNK = 400;
 
 const chunk = <T>(items: T[], size: number): T[][] => {

--- a/hooks/useOrgRoles.test.ts
+++ b/hooks/useOrgRoles.test.ts
@@ -1,13 +1,22 @@
-import { renderHook, waitFor } from '@testing-library/react';
+import { act, renderHook, waitFor } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
 import { useOrgRoles } from './useOrgRoles';
 import { useAuth } from '@/context/useAuth';
-import { collection, onSnapshot } from 'firebase/firestore';
+import {
+  collection,
+  deleteDoc,
+  doc,
+  onSnapshot,
+  setDoc,
+} from 'firebase/firestore';
 import type { RoleRecord } from '@/types/organization';
 
 vi.mock('firebase/firestore', () => ({
   collection: vi.fn(),
+  deleteDoc: vi.fn(),
+  doc: vi.fn(),
   onSnapshot: vi.fn(),
+  setDoc: vi.fn(),
 }));
 
 vi.mock('@/config/firebase', () => ({
@@ -19,7 +28,7 @@ vi.mock('@/context/useAuth', () => ({
   useAuth: vi.fn(),
 }));
 
-const mockRole = {
+const systemRole = {
   id: 'teacher',
   name: 'Teacher',
   blurb: 'Default teacher role',
@@ -28,15 +37,52 @@ const mockRole = {
   perms: {},
 } as unknown as RoleRecord;
 
+const customRole = {
+  id: 'coach',
+  name: 'Instructional Coach',
+  blurb: 'Supports teachers',
+  color: 'teal',
+  system: false,
+  perms: {},
+} as unknown as RoleRecord;
+
 describe('useOrgRoles', () => {
   const mockUseAuth = useAuth as Mock;
   const mockCollection = collection as Mock;
   const mockOnSnapshot = onSnapshot as Mock;
+  const mockDoc = doc as Mock;
+  const mockSetDoc = setDoc as Mock;
+  const mockDeleteDoc = deleteDoc as Mock;
 
   beforeEach(() => {
     vi.clearAllMocks();
     mockCollection.mockReturnValue('roles-ref');
+    mockDoc.mockImplementation((_db: unknown, ...segs: string[]) =>
+      segs.join('/')
+    );
+    mockSetDoc.mockResolvedValue(undefined);
+    mockDeleteDoc.mockResolvedValue(undefined);
   });
+
+  // Helper: seed the hook with a given roles snapshot and return the result
+  // handle. Pattern lifted from the other org hooks.
+  const seedRoles = (rolesSeed: RoleRecord[]) => {
+    mockOnSnapshot.mockImplementation(
+      (
+        _ref: unknown,
+        onNext: (snap: {
+          docs: { id: string; data: () => RoleRecord }[];
+        }) => void
+      ) => {
+        queueMicrotask(() =>
+          onNext({
+            docs: rolesSeed.map((r) => ({ id: r.id, data: () => r })),
+          })
+        );
+        return () => undefined;
+      }
+    );
+  };
 
   it('skips subscription when orgId is null', () => {
     mockUseAuth.mockReturnValue({ user: { uid: 'u' } });
@@ -47,19 +93,7 @@ describe('useOrgRoles', () => {
 
   it('hydrates roles from snapshot', async () => {
     mockUseAuth.mockReturnValue({ user: { uid: 'u' } });
-    mockOnSnapshot.mockImplementation(
-      (
-        _ref: unknown,
-        onNext: (snap: {
-          docs: { id: string; data: () => RoleRecord }[];
-        }) => void
-      ) => {
-        queueMicrotask(() =>
-          onNext({ docs: [{ id: 'teacher', data: () => mockRole }] })
-        );
-        return () => undefined;
-      }
-    );
+    seedRoles([systemRole]);
 
     const { result } = renderHook(() => useOrgRoles('orono'));
     await waitFor(() => {
@@ -69,10 +103,73 @@ describe('useOrgRoles', () => {
     });
   });
 
-  it('write stubs throw phase-3 errors', async () => {
-    mockUseAuth.mockReturnValue({ user: null });
+  it('saveRoles upserts non-system roles and deletes removed custom roles', async () => {
+    mockUseAuth.mockReturnValue({ user: { uid: 'u' } });
+    seedRoles([systemRole, customRole]);
+
     const { result } = renderHook(() => useOrgRoles('orono'));
-    await expect(result.current.saveRoles([])).rejects.toThrow(/Phase 3/);
-    await expect(result.current.resetRoles()).rejects.toThrow(/Phase 3/);
+    await waitFor(() => {
+      expect(result.current.roles).toHaveLength(2);
+    });
+
+    // Working set: keep the system role, drop `coach`, add a new custom role.
+    const newCustom = {
+      id: 'specialist',
+      name: 'Specialist',
+      blurb: '',
+      color: 'emerald',
+      system: false,
+      perms: {},
+    } as unknown as RoleRecord;
+
+    await act(async () => {
+      await result.current.saveRoles([systemRole, newCustom]);
+    });
+
+    // Upsert only hits the custom role (system:true is skipped).
+    expect(mockSetDoc).toHaveBeenCalledTimes(1);
+    expect(mockSetDoc.mock.calls[0][0]).toBe(
+      'organizations/orono/roles/specialist'
+    );
+    expect(mockSetDoc.mock.calls[0][1]).toMatchObject({
+      id: 'specialist',
+      system: false,
+      color: 'emerald',
+    });
+
+    // Removed custom role is deleted.
+    expect(mockDeleteDoc).toHaveBeenCalledWith(
+      'organizations/orono/roles/coach'
+    );
+  });
+
+  it('resetRoles deletes every custom role but keeps system roles', async () => {
+    mockUseAuth.mockReturnValue({ user: { uid: 'u' } });
+    seedRoles([systemRole, customRole]);
+
+    const { result } = renderHook(() => useOrgRoles('orono'));
+    await waitFor(() => {
+      expect(result.current.roles).toHaveLength(2);
+    });
+
+    await act(async () => {
+      await result.current.resetRoles();
+    });
+
+    expect(mockDeleteDoc).toHaveBeenCalledTimes(1);
+    expect(mockDeleteDoc).toHaveBeenCalledWith(
+      'organizations/orono/roles/coach'
+    );
+  });
+
+  it('writes reject when orgId is null', async () => {
+    mockUseAuth.mockReturnValue({ user: null });
+    const { result } = renderHook(() => useOrgRoles(null));
+    await expect(result.current.saveRoles([])).rejects.toThrow(
+      /No organization/
+    );
+    await expect(result.current.resetRoles()).rejects.toThrow(
+      /No organization/
+    );
   });
 });

--- a/hooks/useOrgRoles.ts
+++ b/hooks/useOrgRoles.ts
@@ -1,5 +1,11 @@
 import { useEffect, useState } from 'react';
-import { collection, onSnapshot } from 'firebase/firestore';
+import {
+  collection,
+  deleteDoc,
+  doc,
+  onSnapshot,
+  setDoc,
+} from 'firebase/firestore';
 import { db, isAuthBypass } from '@/config/firebase';
 import { useAuth } from '@/context/useAuth';
 import type { RoleRecord } from '@/types/organization';
@@ -8,8 +14,10 @@ import type { RoleRecord } from '@/types/organization';
  * Subscribes to `/organizations/{orgId}/roles`. Reads allowed for org members
  * + super admins via Firestore rules.
  *
- * Writes are stubbed — Phase 3 wires real role save / reset behind the
- * `orgAdminWrites` feature flag, with system-role protection in the rules.
+ * Writes: `saveRoles(working)` diffs the working set against live state and
+ * upserts / deletes custom roles (system roles are never touched — the rules
+ * block updates on `system:true`). `resetRoles()` deletes every custom role
+ * (system roles remain as seeded by the migration script).
  */
 export const useOrgRoles = (orgId: string | null) => {
   const { user } = useAuth();
@@ -52,11 +60,49 @@ export const useOrgRoles = (orgId: string | null) => {
     return unsub;
   }, [shouldSubscribe, orgId]);
 
-  const saveRoles = (_roles: RoleRecord[]): Promise<void> =>
-    Promise.reject(new Error('Role edits will be enabled in Phase 3.'));
+  const saveRoles = async (workingRoles: RoleRecord[]): Promise<void> => {
+    if (!orgId) {
+      throw new Error('No organization selected.');
+    }
 
-  const resetRoles = (): Promise<void> =>
-    Promise.reject(new Error('Role reset will be enabled in Phase 3.'));
+    const workingIds = new Set(workingRoles.map((r) => r.id));
+    // Upsert every non-system role from the working set. System roles are
+    // intentionally skipped: rules reject `system:true` updates from clients,
+    // and the UI never mutates them (clone-to-customize creates a new role).
+    const upserts = workingRoles
+      .filter((r) => !r.system)
+      .map((r) =>
+        setDoc(doc(db, 'organizations', orgId, 'roles', r.id), {
+          id: r.id,
+          name: r.name,
+          blurb: r.blurb ?? '',
+          color: r.color,
+          system: false,
+          perms: r.perms ?? {},
+        })
+      );
+
+    // Delete custom roles that disappeared from the working set.
+    const deletions = roles
+      .filter((r) => !r.system && !workingIds.has(r.id))
+      .map((r) => deleteDoc(doc(db, 'organizations', orgId, 'roles', r.id)));
+
+    await Promise.all([...upserts, ...deletions]);
+  };
+
+  const resetRoles = async (): Promise<void> => {
+    if (!orgId) {
+      throw new Error('No organization selected.');
+    }
+    // Client-side reset is "drop all custom roles". System role perms live in
+    // the migration script and `config/organizationCapabilities.ts`; re-seeding
+    // those happens out-of-band (the rules block client writes to
+    // `system:true` docs).
+    const deletions = roles
+      .filter((r) => !r.system)
+      .map((r) => deleteDoc(doc(db, 'organizations', orgId, 'roles', r.id)));
+    await Promise.all(deletions);
+  };
 
   return {
     roles,

--- a/hooks/useOrgStudentPage.test.ts
+++ b/hooks/useOrgStudentPage.test.ts
@@ -1,13 +1,14 @@
-import { renderHook, waitFor } from '@testing-library/react';
+import { act, renderHook, waitFor } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
 import { useOrgStudentPage } from './useOrgStudentPage';
 import { useAuth } from '@/context/useAuth';
-import { doc, onSnapshot } from 'firebase/firestore';
+import { doc, onSnapshot, setDoc } from 'firebase/firestore';
 import type { StudentPageConfig } from '@/types/organization';
 
 vi.mock('firebase/firestore', () => ({
   doc: vi.fn(),
   onSnapshot: vi.fn(),
+  setDoc: vi.fn(),
 }));
 
 vi.mock('@/config/firebase', () => ({
@@ -32,10 +33,14 @@ describe('useOrgStudentPage', () => {
   const mockUseAuth = useAuth as Mock;
   const mockDoc = doc as Mock;
   const mockOnSnapshot = onSnapshot as Mock;
+  const mockSetDoc = setDoc as Mock;
 
   beforeEach(() => {
     vi.clearAllMocks();
-    mockDoc.mockReturnValue('student-page-doc');
+    mockDoc.mockImplementation((_db: unknown, ...segs: string[]) =>
+      segs.join('/')
+    );
+    mockSetDoc.mockResolvedValue(undefined);
   });
 
   it('skips subscription when orgId is null', () => {
@@ -69,11 +74,40 @@ describe('useOrgStudentPage', () => {
     });
   });
 
-  it('write stub throws phase-3 error', async () => {
-    mockUseAuth.mockReturnValue({ user: null });
+  it('updateStudentPage upserts the config doc with merge + canonical orgId', async () => {
+    mockUseAuth.mockReturnValue({ user: { uid: 'u' } });
+    mockOnSnapshot.mockReturnValue(() => undefined);
+
     const { result } = renderHook(() => useOrgStudentPage('orono'));
+
+    await act(async () => {
+      await result.current.updateStudentPage({
+        orgId: 'ignored',
+        heroText: 'Go Spartans!',
+        showLunchMenu: true,
+      });
+    });
+
+    expect(mockSetDoc).toHaveBeenCalledTimes(1);
+    const [ref, payload, options] = mockSetDoc.mock.calls[0] as [
+      string,
+      unknown,
+      unknown,
+    ];
+    expect(ref).toBe('organizations/orono/studentPageConfig/default');
+    expect(payload).toEqual({
+      orgId: 'orono',
+      heroText: 'Go Spartans!',
+      showLunchMenu: true,
+    });
+    expect(options).toEqual({ merge: true });
+  });
+
+  it('updateStudentPage rejects when orgId is null', async () => {
+    mockUseAuth.mockReturnValue({ user: null });
+    const { result } = renderHook(() => useOrgStudentPage(null));
     await expect(result.current.updateStudentPage({})).rejects.toThrow(
-      /Phase 3/
+      /No organization/
     );
   });
 });

--- a/hooks/useOrgStudentPage.ts
+++ b/hooks/useOrgStudentPage.ts
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { doc, onSnapshot } from 'firebase/firestore';
+import { doc, onSnapshot, setDoc } from 'firebase/firestore';
 import { db, isAuthBypass } from '@/config/firebase';
 import { useAuth } from '@/context/useAuth';
 import type { StudentPageConfig } from '@/types/organization';
@@ -8,8 +8,9 @@ import type { StudentPageConfig } from '@/types/organization';
  * Subscribes to `/organizations/{orgId}/studentPageConfig/default`. Reads
  * allowed for org members + super admins via Firestore rules.
  *
- * Writes are stubbed — Phase 3 wires real mutations behind the
- * `orgAdminWrites` feature flag.
+ * Writes: `updateStudentPage` upserts the config doc (setDoc with `merge:
+ * true`) so the first write still works even if the migration script hasn't
+ * seeded the config yet. Rules restrict writes to domain+ admins.
  */
 export const useOrgStudentPage = (orgId: string | null) => {
   const { user } = useAuth();
@@ -53,10 +54,19 @@ export const useOrgStudentPage = (orgId: string | null) => {
     return unsub;
   }, [shouldSubscribe, orgId]);
 
-  const updateStudentPage = (
-    _patch: Partial<StudentPageConfig>
-  ): Promise<void> =>
-    Promise.reject(new Error('Student page edits will be enabled in Phase 3.'));
+  const updateStudentPage = async (
+    patch: Partial<StudentPageConfig>
+  ): Promise<void> => {
+    if (!orgId) {
+      throw new Error('No organization selected.');
+    }
+    const { orgId: _omit, ...rest } = patch;
+    await setDoc(
+      doc(db, 'organizations', orgId, 'studentPageConfig', 'default'),
+      { orgId, ...rest },
+      { merge: true }
+    );
+  };
 
   return {
     studentPage,

--- a/hooks/useOrganization.test.ts
+++ b/hooks/useOrganization.test.ts
@@ -1,13 +1,14 @@
-import { renderHook, waitFor } from '@testing-library/react';
+import { act, renderHook, waitFor } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
 import { useOrganization } from './useOrganization';
 import { useAuth } from '@/context/useAuth';
-import { doc, onSnapshot } from 'firebase/firestore';
+import { doc, onSnapshot, updateDoc } from 'firebase/firestore';
 import type { OrgRecord } from '@/types/organization';
 
 vi.mock('firebase/firestore', () => ({
   doc: vi.fn(),
   onSnapshot: vi.fn(),
+  updateDoc: vi.fn(),
 }));
 
 vi.mock('@/config/firebase', () => ({
@@ -39,10 +40,14 @@ describe('useOrganization', () => {
   const mockUseAuth = useAuth as Mock;
   const mockDoc = doc as Mock;
   const mockOnSnapshot = onSnapshot as Mock;
+  const mockUpdateDoc = updateDoc as Mock;
 
   beforeEach(() => {
     vi.clearAllMocks();
-    mockDoc.mockReturnValue('org-doc-ref');
+    mockDoc.mockImplementation((_db: unknown, ...segs: string[]) =>
+      segs.join('/')
+    );
+    mockUpdateDoc.mockResolvedValue(undefined);
   });
 
   it('returns null org and clears loading when orgId is null', () => {
@@ -75,10 +80,47 @@ describe('useOrganization', () => {
     });
   });
 
-  it('write stubs throw phase-3 errors', async () => {
-    mockUseAuth.mockReturnValue({ user: null });
+  it('updateOrg patches the org doc (stripping id)', async () => {
+    mockUseAuth.mockReturnValue({ user: { uid: 'u' } });
+    mockOnSnapshot.mockReturnValue(() => undefined);
+
     const { result } = renderHook(() => useOrganization('orono'));
-    await expect(result.current.updateOrg({})).rejects.toThrow(/Phase 3/);
-    await expect(result.current.archiveOrg()).rejects.toThrow(/Phase 3/);
+
+    await act(async () => {
+      await result.current.updateOrg({
+        id: 'ignored',
+        name: 'Orono Public',
+      });
+    });
+
+    expect(mockUpdateDoc).toHaveBeenCalledWith('organizations/orono', {
+      name: 'Orono Public',
+    });
+  });
+
+  it('archiveOrg sets status to archived', async () => {
+    mockUseAuth.mockReturnValue({ user: { uid: 'u' } });
+    mockOnSnapshot.mockReturnValue(() => undefined);
+
+    const { result } = renderHook(() => useOrganization('orono'));
+
+    await act(async () => {
+      await result.current.archiveOrg();
+    });
+
+    expect(mockUpdateDoc).toHaveBeenCalledWith('organizations/orono', {
+      status: 'archived',
+    });
+  });
+
+  it('updateOrg rejects when orgId is null', async () => {
+    mockUseAuth.mockReturnValue({ user: null });
+    const { result } = renderHook(() => useOrganization(null));
+    await expect(result.current.updateOrg({ name: 'X' })).rejects.toThrow(
+      /No organization/
+    );
+    await expect(result.current.archiveOrg()).rejects.toThrow(
+      /No organization/
+    );
   });
 });

--- a/hooks/useOrganization.ts
+++ b/hooks/useOrganization.ts
@@ -60,6 +60,7 @@ export const useOrganization = (orgId: string | null) => {
     }
     // Never let a client clobber the doc id field.
     const { id: _omit, ...rest } = patch;
+    if (Object.keys(rest).length === 0) return;
     await updateDoc(doc(db, 'organizations', orgId), rest);
   };
 

--- a/hooks/useOrganization.ts
+++ b/hooks/useOrganization.ts
@@ -11,7 +11,7 @@ import type { OrgRecord } from '@/types/organization';
  * Writes: `updateOrg` patches the org doc; `archiveOrg` soft-archives by
  * setting `status: 'archived'` (the rules don't allow client delete at the
  * domain-admin tier, and hard-delete cascades across sub-collections). Both
- * mutations require the `orgAdminWrites` feature flag to be enabled in the
+ * mutations require the `org-admin-writes` feature flag to be enabled in the
  * client gate — the rules still enforce role scoping regardless.
  */
 export const useOrganization = (orgId: string | null) => {

--- a/hooks/useOrganization.ts
+++ b/hooks/useOrganization.ts
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { doc, onSnapshot } from 'firebase/firestore';
+import { doc, onSnapshot, updateDoc } from 'firebase/firestore';
 import { db, isAuthBypass } from '@/config/firebase';
 import { useAuth } from '@/context/useAuth';
 import type { OrgRecord } from '@/types/organization';
@@ -8,7 +8,11 @@ import type { OrgRecord } from '@/types/organization';
  * Subscribes to a single `/organizations/{orgId}` doc. Reads are gated at the
  * rules layer to org members + super admins; non-members will see an error.
  *
- * Writes (update / archive) are stubbed — Phase 3 wires real mutations.
+ * Writes: `updateOrg` patches the org doc; `archiveOrg` soft-archives by
+ * setting `status: 'archived'` (the rules don't allow client delete at the
+ * domain-admin tier, and hard-delete cascades across sub-collections). Both
+ * mutations require the `orgAdminWrites` feature flag to be enabled in the
+ * client gate — the rules still enforce role scoping regardless.
  */
 export const useOrganization = (orgId: string | null) => {
   const { user } = useAuth();
@@ -50,13 +54,21 @@ export const useOrganization = (orgId: string | null) => {
     return unsub;
   }, [shouldSubscribe, orgId]);
 
-  const updateOrg = (_patch: Partial<OrgRecord>): Promise<void> =>
-    Promise.reject(new Error('Organization edits will be enabled in Phase 3.'));
+  const updateOrg = async (patch: Partial<OrgRecord>): Promise<void> => {
+    if (!orgId) {
+      throw new Error('No organization selected.');
+    }
+    // Never let a client clobber the doc id field.
+    const { id: _omit, ...rest } = patch;
+    await updateDoc(doc(db, 'organizations', orgId), rest);
+  };
 
-  const archiveOrg = (): Promise<void> =>
-    Promise.reject(
-      new Error('Organization archival will be enabled in Phase 3.')
-    );
+  const archiveOrg = async (): Promise<void> => {
+    if (!orgId) {
+      throw new Error('No organization selected.');
+    }
+    await updateDoc(doc(db, 'organizations', orgId), { status: 'archived' });
+  };
 
   return {
     organization,

--- a/hooks/useOrganizations.test.ts
+++ b/hooks/useOrganizations.test.ts
@@ -1,13 +1,22 @@
-import { renderHook, waitFor } from '@testing-library/react';
+import { act, renderHook, waitFor } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
 import { useOrganizations } from './useOrganizations';
 import { useAuth } from '@/context/useAuth';
-import { collection, onSnapshot } from 'firebase/firestore';
+import {
+  collection,
+  doc,
+  onSnapshot,
+  setDoc,
+  updateDoc,
+} from 'firebase/firestore';
 import type { OrgRecord } from '@/types/organization';
 
 vi.mock('firebase/firestore', () => ({
   collection: vi.fn(),
+  doc: vi.fn(),
   onSnapshot: vi.fn(),
+  setDoc: vi.fn(),
+  updateDoc: vi.fn(),
 }));
 
 vi.mock('@/config/firebase', () => ({
@@ -39,10 +48,18 @@ describe('useOrganizations', () => {
   const mockUseAuth = useAuth as Mock;
   const mockCollection = collection as Mock;
   const mockOnSnapshot = onSnapshot as Mock;
+  const mockDoc = doc as Mock;
+  const mockSetDoc = setDoc as Mock;
+  const mockUpdateDoc = updateDoc as Mock;
 
   beforeEach(() => {
     vi.clearAllMocks();
     mockCollection.mockReturnValue('organizations-ref');
+    mockDoc.mockImplementation((_db: unknown, ...segs: string[]) =>
+      segs.join('/')
+    );
+    mockSetDoc.mockResolvedValue(undefined);
+    mockUpdateDoc.mockResolvedValue(undefined);
   });
 
   it('does not subscribe when user is not a super admin', () => {
@@ -89,15 +106,74 @@ describe('useOrganizations', () => {
     });
   });
 
-  it('write stubs throw phase-3 errors', async () => {
+  it('createOrg writes a new doc with a derived id + defaults', async () => {
     mockUseAuth.mockReturnValue({
-      user: null,
-      userRoles: { superAdmins: [] },
+      user: { email: 'super@spartboard.io' },
+      userRoles: { superAdmins: ['super@spartboard.io'] },
     });
+    mockOnSnapshot.mockReturnValue(() => undefined);
 
     const { result } = renderHook(() => useOrganizations());
 
-    await expect(result.current.createOrg({})).rejects.toThrow(/Phase 3/);
-    await expect(result.current.archiveOrg('orono')).rejects.toThrow(/Phase 3/);
+    await act(async () => {
+      await result.current.createOrg({
+        name: 'New District',
+        shortCode: 'ND',
+        plan: 'basic',
+        primaryAdminEmail: 'admin@nd.org',
+      });
+    });
+
+    expect(mockSetDoc).toHaveBeenCalledTimes(1);
+    const [ref, payload] = mockSetDoc.mock.calls[0] as [
+      string,
+      Record<string, unknown>,
+    ];
+    expect(ref).toBe('organizations/new-district');
+    expect(payload).toMatchObject({
+      id: 'new-district',
+      name: 'New District',
+      shortCode: 'ND',
+      plan: 'basic',
+      primaryAdminEmail: 'admin@nd.org',
+      status: 'trial',
+      aiEnabled: false,
+      users: 0,
+      buildings: 0,
+    });
+    expect(typeof payload.createdAt).toBe('string');
+  });
+
+  it('createOrg rejects when name is missing', async () => {
+    mockUseAuth.mockReturnValue({
+      user: { email: 'super@spartboard.io' },
+      userRoles: { superAdmins: ['super@spartboard.io'] },
+    });
+    mockOnSnapshot.mockReturnValue(() => undefined);
+
+    const { result } = renderHook(() => useOrganizations());
+
+    await expect(result.current.createOrg({})).rejects.toThrow(
+      /name is required/i
+    );
+    expect(mockSetDoc).not.toHaveBeenCalled();
+  });
+
+  it('archiveOrg sets status to archived', async () => {
+    mockUseAuth.mockReturnValue({
+      user: { email: 'super@spartboard.io' },
+      userRoles: { superAdmins: ['super@spartboard.io'] },
+    });
+    mockOnSnapshot.mockReturnValue(() => undefined);
+
+    const { result } = renderHook(() => useOrganizations());
+
+    await act(async () => {
+      await result.current.archiveOrg('orono');
+    });
+
+    expect(mockUpdateDoc).toHaveBeenCalledWith('organizations/orono', {
+      status: 'archived',
+    });
   });
 });

--- a/hooks/useOrganizations.ts
+++ b/hooks/useOrganizations.ts
@@ -9,23 +9,7 @@ import {
 import { db, isAuthBypass } from '@/config/firebase';
 import { useAuth } from '@/context/useAuth';
 import type { OrgRecord } from '@/types/organization';
-
-// Derive a URL-friendly id from an org name. Falls back to a UUID when the
-// name has no alphanumeric content (keeps document paths valid either way).
-const slugFromName = (name: string): string => {
-  const base = name
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-|-$/g, '')
-    .slice(0, 48);
-  if (base) return base;
-  // crypto.randomUUID is guaranteed on every runtime we support (modern
-  // browsers + Node 19+). Matches the id-gen pattern used by other hooks.
-  return (globalThis.crypto?.randomUUID?.() ?? `org-${Date.now()}`).slice(
-    0,
-    24
-  );
-};
+import { slugOrFallback } from '@/utils/slug';
 
 /**
  * Subscribes to the top-level `/organizations` collection.
@@ -96,7 +80,7 @@ export const useOrganizations = () => {
     if (!name) {
       throw new Error('Organization name is required.');
     }
-    const id = partial.id ?? slugFromName(name);
+    const id = partial.id ?? slugOrFallback(name, 'org');
     const record = {
       id,
       name,

--- a/hooks/useOrganizations.ts
+++ b/hooks/useOrganizations.ts
@@ -1,8 +1,31 @@
 import { useEffect, useState } from 'react';
-import { collection, onSnapshot } from 'firebase/firestore';
+import {
+  collection,
+  doc,
+  onSnapshot,
+  setDoc,
+  updateDoc,
+} from 'firebase/firestore';
 import { db, isAuthBypass } from '@/config/firebase';
 import { useAuth } from '@/context/useAuth';
 import type { OrgRecord } from '@/types/organization';
+
+// Derive a URL-friendly id from an org name. Falls back to a UUID when the
+// name has no alphanumeric content (keeps document paths valid either way).
+const slugFromName = (name: string): string => {
+  const base = name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '')
+    .slice(0, 48);
+  if (base) return base;
+  // crypto.randomUUID is guaranteed on every runtime we support (modern
+  // browsers + Node 19+). Matches the id-gen pattern used by other hooks.
+  return (globalThis.crypto?.randomUUID?.() ?? `org-${Date.now()}`).slice(
+    0,
+    24
+  );
+};
 
 /**
  * Subscribes to the top-level `/organizations` collection.
@@ -12,8 +35,10 @@ import type { OrgRecord } from '@/types/organization';
  * gates the subscription behind `isSuperAdmin` so the common teacher path
  * never triggers a failing listener.
  *
- * Writes (create / archive) are stubbed as no-ops that throw — Phase 3 wires
- * real mutations once the `orgAdminWrites` feature flag lands.
+ * Writes (create / archive) are super-admin-only at the rules tier. Archive
+ * is a soft-archive (sets `status: 'archived'`) rather than a hard delete so
+ * sub-collections aren't orphaned — the rules allow hard delete via
+ * super-admin, but we keep archive non-destructive by default.
  */
 export const useOrganizations = () => {
   const { user, userRoles } = useAuth();
@@ -66,15 +91,37 @@ export const useOrganizations = () => {
     return unsub;
   }, [shouldSubscribe]);
 
-  const createOrg = (_org: Partial<OrgRecord>): Promise<void> =>
-    Promise.reject(
-      new Error('Organization creation will be enabled in Phase 3.')
-    );
+  const createOrg = async (partial: Partial<OrgRecord>): Promise<void> => {
+    const name = partial.name?.trim();
+    if (!name) {
+      throw new Error('Organization name is required.');
+    }
+    const id = partial.id ?? slugFromName(name);
+    const record = {
+      id,
+      name,
+      shortName: partial.shortName ?? name,
+      shortCode: partial.shortCode ?? name.slice(0, 4).toUpperCase(),
+      state: partial.state ?? '',
+      plan: partial.plan ?? 'basic',
+      aiEnabled: partial.aiEnabled ?? false,
+      primaryAdminEmail: partial.primaryAdminEmail ?? '',
+      createdAt: new Date().toISOString(),
+      users: 0,
+      buildings: 0,
+      status: partial.status ?? 'trial',
+      seedColor: partial.seedColor ?? 'bg-indigo-600',
+      ...(partial.supportUrl ? { supportUrl: partial.supportUrl } : {}),
+    };
+    await setDoc(doc(db, 'organizations', id), record);
+  };
 
-  const archiveOrg = (_orgId: string): Promise<void> =>
-    Promise.reject(
-      new Error('Organization archival will be enabled in Phase 3.')
-    );
+  const archiveOrg = async (orgId: string): Promise<void> => {
+    if (!orgId) {
+      throw new Error('Organization id is required.');
+    }
+    await updateDoc(doc(db, 'organizations', orgId), { status: 'archived' });
+  };
 
   return {
     organizations,

--- a/scripts/init-global-perms.js
+++ b/scripts/init-global-perms.js
@@ -56,6 +56,15 @@ async function initGlobalPermissions() {
       enabled: true,
       betaUsers: [],
     },
+    {
+      // Phase 3: gates the Organization admin panel's write actions. Default
+      // to beta so a domain admin can't accidentally mutate org state until
+      // Paul's team has validated the flow end-to-end.
+      id: 'org-admin-writes',
+      accessLevel: 'beta',
+      enabled: true,
+      betaUsers: ['paul.ivers@orono.k12.mn.us'],
+    },
   ];
 
   console.log('🚀 Initializing global_permissions collection...');

--- a/tests/rules/firestore-rules-organizations.test.ts
+++ b/tests/rules/firestore-rules-organizations.test.ts
@@ -362,6 +362,27 @@ describe('organizations — domain admin writes on own org', () => {
     );
   });
 
+  it('cannot change status (archive is super-admin-only)', async () => {
+    await assertFails(
+      updateDoc(doc(asDomainAdmin(), `organizations/${ORG_ID}`), {
+        status: 'archived',
+      })
+    );
+  });
+
+  it('cannot overwrite derived counts (users, buildings)', async () => {
+    await assertFails(
+      updateDoc(doc(asDomainAdmin(), `organizations/${ORG_ID}`), {
+        users: 9999,
+      })
+    );
+    await assertFails(
+      updateDoc(doc(asDomainAdmin(), `organizations/${ORG_ID}`), {
+        buildings: 9999,
+      })
+    );
+  });
+
   it('cannot edit another org', async () => {
     await assertFails(
       updateDoc(doc(asDomainAdmin(), `organizations/${OTHER_ORG_ID}`), {
@@ -392,6 +413,7 @@ describe('organizations/buildings — writes', () => {
     await assertSucceeds(
       setDoc(doc(asDomainAdmin(), `organizations/${ORG_ID}/buildings/new`), {
         id: 'new',
+        orgId: ORG_ID,
         name: 'New School',
       })
     );
@@ -408,11 +430,55 @@ describe('organizations/buildings — writes', () => {
     );
   });
 
+  it('domain admin cannot create a building whose orgId != path orgId', async () => {
+    await assertFails(
+      setDoc(doc(asDomainAdmin(), `organizations/${ORG_ID}/buildings/sneaky`), {
+        id: 'sneaky',
+        orgId: OTHER_ORG_ID, // spoofed parent
+        name: 'Sneaky',
+      })
+    );
+  });
+
+  it('domain admin cannot create a building whose id != path buildingId', async () => {
+    await assertFails(
+      setDoc(doc(asDomainAdmin(), `organizations/${ORG_ID}/buildings/real`), {
+        id: 'fake',
+        orgId: ORG_ID,
+        name: 'Mismatch',
+      })
+    );
+  });
+
   it('building admin can update a building in their scope', async () => {
     await assertSucceeds(
       updateDoc(
         doc(asBuildingAdmin(), `organizations/${ORG_ID}/buildings/high`),
         { address: '123 Spartan Way' }
+      )
+    );
+  });
+
+  it('building admin cannot rewrite a building identity field', async () => {
+    await assertFails(
+      updateDoc(
+        doc(asBuildingAdmin(), `organizations/${ORG_ID}/buildings/high`),
+        { orgId: OTHER_ORG_ID }
+      )
+    );
+    await assertFails(
+      updateDoc(
+        doc(asBuildingAdmin(), `organizations/${ORG_ID}/buildings/high`),
+        { id: 'renamed' }
+      )
+    );
+  });
+
+  it('domain admin cannot rewrite a building identity field', async () => {
+    await assertFails(
+      updateDoc(
+        doc(asDomainAdmin(), `organizations/${ORG_ID}/buildings/high`),
+        { orgId: OTHER_ORG_ID }
       )
     );
   });
@@ -430,6 +496,7 @@ describe('organizations/buildings — writes', () => {
     await assertFails(
       setDoc(doc(asBuildingAdmin(), `organizations/${ORG_ID}/buildings/new`), {
         id: 'new',
+        orgId: ORG_ID,
         name: 'X',
       })
     );
@@ -454,6 +521,7 @@ describe('organizations/domains — writes', () => {
     await assertSucceeds(
       setDoc(doc(asDomainAdmin(), `organizations/${ORG_ID}/domains/students`), {
         id: 'students',
+        orgId: ORG_ID,
         domain: '@students.orono.k12.mn.us',
       })
     );
@@ -468,10 +536,64 @@ describe('organizations/domains — writes', () => {
     );
   });
 
+  it('domain admin cannot create a domain whose orgId != path orgId', async () => {
+    await assertFails(
+      setDoc(doc(asDomainAdmin(), `organizations/${ORG_ID}/domains/sneaky`), {
+        id: 'sneaky',
+        orgId: OTHER_ORG_ID,
+        domain: '@x.com',
+      })
+    );
+  });
+
+  it('domain admin cannot create a domain whose id != path domainId', async () => {
+    await assertFails(
+      setDoc(doc(asDomainAdmin(), `organizations/${ORG_ID}/domains/real`), {
+        id: 'fake',
+        orgId: ORG_ID,
+        domain: '@x.com',
+      })
+    );
+  });
+
+  it('domain admin cannot flip status (server-managed) via update', async () => {
+    await assertFails(
+      updateDoc(
+        doc(asDomainAdmin(), `organizations/${ORG_ID}/domains/primary`),
+        { status: 'verified' }
+      )
+    );
+  });
+
+  it('domain admin cannot overwrite derived users count or addedAt', async () => {
+    await assertFails(
+      updateDoc(
+        doc(asDomainAdmin(), `organizations/${ORG_ID}/domains/primary`),
+        { users: 9999 }
+      )
+    );
+    await assertFails(
+      updateDoc(
+        doc(asDomainAdmin(), `organizations/${ORG_ID}/domains/primary`),
+        { addedAt: '2020-01-01' }
+      )
+    );
+  });
+
+  it('domain admin cannot rewrite a domain identity field', async () => {
+    await assertFails(
+      updateDoc(
+        doc(asDomainAdmin(), `organizations/${ORG_ID}/domains/primary`),
+        { orgId: OTHER_ORG_ID }
+      )
+    );
+  });
+
   it('building admin cannot write domains', async () => {
     await assertFails(
       setDoc(doc(asBuildingAdmin(), `organizations/${ORG_ID}/domains/new`), {
         id: 'new',
+        orgId: ORG_ID,
         domain: '@x.com',
       })
     );
@@ -612,6 +734,48 @@ describe('organizations/members — writes', () => {
           `organizations/${ORG_ID}/members/${TEACHER_EMAIL}`
         ),
         { roleId: 'building_admin', buildingIds: ['high', 'middle'] }
+      )
+    );
+  });
+
+  it('domain admin cannot spoof member identity (email, orgId, uid)', async () => {
+    await assertFails(
+      updateDoc(
+        doc(
+          asDomainAdmin(),
+          `organizations/${ORG_ID}/members/${TEACHER_EMAIL}`
+        ),
+        { email: 'other@example.com' }
+      )
+    );
+    await assertFails(
+      updateDoc(
+        doc(
+          asDomainAdmin(),
+          `organizations/${ORG_ID}/members/${TEACHER_EMAIL}`
+        ),
+        { orgId: OTHER_ORG_ID }
+      )
+    );
+    await assertFails(
+      updateDoc(
+        doc(
+          asDomainAdmin(),
+          `organizations/${ORG_ID}/members/${TEACHER_EMAIL}`
+        ),
+        { uid: 'impostor-uid' }
+      )
+    );
+  });
+
+  it('domain admin cannot add arbitrary fields to a member doc', async () => {
+    await assertFails(
+      updateDoc(
+        doc(
+          asDomainAdmin(),
+          `organizations/${ORG_ID}/members/${TEACHER_EMAIL}`
+        ),
+        { isSuperAdmin: true }
       )
     );
   });

--- a/tests/rules/firestore-rules-organizations.test.ts
+++ b/tests/rules/firestore-rules-organizations.test.ts
@@ -891,6 +891,32 @@ describe('organizations/members — writes', () => {
     );
   });
 
+  it('domain admin cannot create a member with a mixed-case doc id', async () => {
+    // isOrgMember() always looks up members/{token.email.lower()}, so a
+    // mixed-case id would be orphaned and never found.
+    await assertFails(
+      setDoc(
+        doc(
+          asDomainAdmin(),
+          `organizations/${ORG_ID}/members/Mixed.Case@orono.k12.mn.us`
+        ),
+        validMember('mixed.case@orono.k12.mn.us')
+      )
+    );
+  });
+
+  it('domain admin cannot create a member with a mixed-case email field', async () => {
+    await assertFails(
+      setDoc(
+        doc(
+          asDomainAdmin(),
+          `organizations/${ORG_ID}/members/mixed.case@orono.k12.mn.us`
+        ),
+        validMember('Mixed.Case@orono.k12.mn.us')
+      )
+    );
+  });
+
   it('domain admin can update roleId and buildingIds', async () => {
     await assertSucceeds(
       updateDoc(

--- a/tests/rules/firestore-rules-organizations.test.ts
+++ b/tests/rules/firestore-rules-organizations.test.ts
@@ -517,13 +517,23 @@ describe('organizations/buildings — writes', () => {
 });
 
 describe('organizations/domains — writes', () => {
+  const pendingDomain = (id: string, domain: string) => ({
+    id,
+    orgId: ORG_ID,
+    domain,
+    authMethod: 'google',
+    status: 'pending',
+    role: 'staff',
+    users: 0,
+    addedAt: '2026-01-01',
+  });
+
   it('domain admin can create, update, delete domains', async () => {
     await assertSucceeds(
-      setDoc(doc(asDomainAdmin(), `organizations/${ORG_ID}/domains/students`), {
-        id: 'students',
-        orgId: ORG_ID,
-        domain: '@students.orono.k12.mn.us',
-      })
+      setDoc(
+        doc(asDomainAdmin(), `organizations/${ORG_ID}/domains/students`),
+        pendingDomain('students', '@students.orono.k12.mn.us')
+      )
     );
     await assertSucceeds(
       updateDoc(
@@ -539,9 +549,8 @@ describe('organizations/domains — writes', () => {
   it('domain admin cannot create a domain whose orgId != path orgId', async () => {
     await assertFails(
       setDoc(doc(asDomainAdmin(), `organizations/${ORG_ID}/domains/sneaky`), {
-        id: 'sneaky',
+        ...pendingDomain('sneaky', '@x.com'),
         orgId: OTHER_ORG_ID,
-        domain: '@x.com',
       })
     );
   });
@@ -549,9 +558,25 @@ describe('organizations/domains — writes', () => {
   it('domain admin cannot create a domain whose id != path domainId', async () => {
     await assertFails(
       setDoc(doc(asDomainAdmin(), `organizations/${ORG_ID}/domains/real`), {
-        id: 'fake',
-        orgId: ORG_ID,
-        domain: '@x.com',
+        ...pendingDomain('fake', '@x.com'),
+      })
+    );
+  });
+
+  it('domain admin cannot seed status:verified on create (server-managed)', async () => {
+    await assertFails(
+      setDoc(doc(asDomainAdmin(), `organizations/${ORG_ID}/domains/spoof`), {
+        ...pendingDomain('spoof', '@spoof.com'),
+        status: 'verified',
+      })
+    );
+  });
+
+  it('domain admin cannot seed a nonzero users count on create', async () => {
+    await assertFails(
+      setDoc(doc(asDomainAdmin(), `organizations/${ORG_ID}/domains/inflate`), {
+        ...pendingDomain('inflate', '@inflate.com'),
+        users: 9999,
       })
     );
   });
@@ -592,9 +617,7 @@ describe('organizations/domains — writes', () => {
   it('building admin cannot write domains', async () => {
     await assertFails(
       setDoc(doc(asBuildingAdmin(), `organizations/${ORG_ID}/domains/new`), {
-        id: 'new',
-        orgId: ORG_ID,
-        domain: '@x.com',
+        ...pendingDomain('new', '@x.com'),
       })
     );
     await assertFails(
@@ -632,6 +655,17 @@ describe('organizations/roles — writes (system role protection)', () => {
         id: 'hacked',
         name: 'Hacked',
         system: true,
+        perms: {},
+      })
+    );
+  });
+
+  it('domain admin cannot create a role whose id != path roleId', async () => {
+    await assertFails(
+      setDoc(doc(asDomainAdmin(), `organizations/${ORG_ID}/roles/real`), {
+        id: 'fake',
+        name: 'Mismatch',
+        system: false,
         perms: {},
       })
     );
@@ -708,6 +742,14 @@ describe('organizations/roles — writes (system role protection)', () => {
 });
 
 describe('organizations/members — writes', () => {
+  const validMember = (email: string) => ({
+    email,
+    orgId: ORG_ID,
+    roleId: 'teacher',
+    status: 'invited',
+    buildingIds: ['high'],
+  });
+
   it('domain admin can create a new member', async () => {
     await assertSucceeds(
       setDoc(
@@ -715,13 +757,59 @@ describe('organizations/members — writes', () => {
           asDomainAdmin(),
           `organizations/${ORG_ID}/members/new.teacher@orono.k12.mn.us`
         ),
+        validMember('new.teacher@orono.k12.mn.us')
+      )
+    );
+  });
+
+  it('domain admin cannot create a member whose email != doc id', async () => {
+    await assertFails(
+      setDoc(
+        doc(
+          asDomainAdmin(),
+          `organizations/${ORG_ID}/members/expected@orono.k12.mn.us`
+        ),
+        validMember('someoneelse@orono.k12.mn.us')
+      )
+    );
+  });
+
+  it('domain admin cannot create a member whose orgId != path orgId', async () => {
+    await assertFails(
+      setDoc(
+        doc(
+          asDomainAdmin(),
+          `organizations/${ORG_ID}/members/xorg@orono.k12.mn.us`
+        ),
+        { ...validMember('xorg@orono.k12.mn.us'), orgId: OTHER_ORG_ID }
+      )
+    );
+  });
+
+  it('domain admin cannot create a member missing required fields', async () => {
+    await assertFails(
+      setDoc(
+        doc(
+          asDomainAdmin(),
+          `organizations/${ORG_ID}/members/missing@orono.k12.mn.us`
+        ),
         {
-          email: 'new.teacher@orono.k12.mn.us',
+          email: 'missing@orono.k12.mn.us',
           orgId: ORG_ID,
-          roleId: 'teacher',
-          status: 'invited',
-          buildingIds: ['high'],
+          // roleId, status, buildingIds all missing
         }
+      )
+    );
+  });
+
+  it('domain admin cannot create a member with arbitrary extra fields', async () => {
+    await assertFails(
+      setDoc(
+        doc(
+          asDomainAdmin(),
+          `organizations/${ORG_ID}/members/extra@orono.k12.mn.us`
+        ),
+        { ...validMember('extra@orono.k12.mn.us'), isSuperAdmin: true }
       )
     );
   });
@@ -844,13 +932,7 @@ describe('organizations/members — writes', () => {
           asBuildingAdmin(),
           `organizations/${ORG_ID}/members/new@orono.k12.mn.us`
         ),
-        {
-          email: 'new@orono.k12.mn.us',
-          orgId: ORG_ID,
-          roleId: 'teacher',
-          status: 'invited',
-          buildingIds: ['high'],
-        }
+        validMember('new@orono.k12.mn.us')
       )
     );
     await assertFails(
@@ -912,6 +994,26 @@ describe('organizations/studentPageConfig — writes', () => {
       updateDoc(
         doc(asTeacher(), `organizations/${ORG_ID}/studentPageConfig/default`),
         { heroText: 'nope' }
+      )
+    );
+  });
+
+  it('domain admin cannot create a non-default student page config', async () => {
+    await assertFails(
+      setDoc(
+        doc(
+          asDomainAdmin(),
+          `organizations/${ORG_ID}/studentPageConfig/sneaky`
+        ),
+        { orgId: ORG_ID, heroText: 'sneaky' }
+      )
+    );
+  });
+
+  it('super admin cannot delete the student page config', async () => {
+    await assertFails(
+      deleteDoc(
+        doc(asSuper(), `organizations/${ORG_ID}/studentPageConfig/default`)
       )
     );
   });

--- a/tests/rules/firestore-rules-organizations.test.ts
+++ b/tests/rules/firestore-rules-organizations.test.ts
@@ -620,6 +620,15 @@ describe('organizations/domains — writes', () => {
     );
   });
 
+  it('domain admin cannot attach arbitrary fields on create (hasOnly)', async () => {
+    await assertFails(
+      setDoc(doc(asDomainAdmin(), `organizations/${ORG_ID}/domains/extra`), {
+        ...pendingDomain('extra', '@extra.com'),
+        secretNote: 'stash',
+      })
+    );
+  });
+
   it('domain admin cannot flip status (server-managed) via update', async () => {
     await assertFails(
       updateDoc(

--- a/tests/rules/firestore-rules-organizations.test.ts
+++ b/tests/rules/firestore-rules-organizations.test.ts
@@ -1,15 +1,23 @@
-// Firestore security-rules tests for the Organization hierarchy (Phase 1).
+// Firestore security-rules tests for the Organization hierarchy.
 //
 // Requires a running Firestore emulator. Invoke via:
 //   pnpm run test:rules
 // which wraps this file in `firebase emulators:exec --only firestore`.
 //
-// Covers Phase 1 acceptance checks:
-//   - Org members can read /organizations/{orgId} and sub-collections
-//   - Non-members are denied reads (including super-admin bypass via
-//     admin_settings/user_roles.superAdmins)
-//   - All writes to organization/** are denied (Phase 3 wires these)
-//   - Legacy /admins/{email} reads still work for the owning user (no regression)
+// Covers:
+//   Phase 1 reads — org members can read sub-collections; outsiders blocked
+//   (except own member-doc probe); legacy /admins/{email} still works.
+//   Phase 3 writes — scoped writes enabled per role:
+//     * super admin: org create/delete; any field on any org
+//     * domain admin: update identity fields on own org (NOT aiEnabled/plan);
+//       full CRUD on buildings/domains/roles (custom only)/members/
+//       studentPageConfig
+//     * building admin: read-only everywhere, with two exceptions —
+//       (a) update buildings they manage, and
+//       (b) update `status` (only) on members whose buildingIds intersect
+//           the actor's buildingIds
+//     * system roles (`system: true`) are immutable from clients
+//     * invitations collection stays fully locked (Phase 4 wires it).
 
 import { readFileSync } from 'fs';
 import { fileURLToPath } from 'url';
@@ -20,11 +28,16 @@ import {
   assertFails,
   RulesTestEnvironment,
 } from '@firebase/rules-unit-testing';
-import { setDoc, getDoc, doc } from 'firebase/firestore';
+import { setDoc, updateDoc, deleteDoc, getDoc, doc } from 'firebase/firestore';
 
 const PROJECT_ID = 'spartboard-rules-test';
 const ORG_ID = 'orono';
+const OTHER_ORG_ID = 'other-district';
 const MEMBER_EMAIL = 'paul.ivers@orono.k12.mn.us';
+const DOMAIN_ADMIN_EMAIL = MEMBER_EMAIL;
+const BUILDING_ADMIN_EMAIL = 'bldg.admin@orono.k12.mn.us';
+const TEACHER_EMAIL = 'teacher@orono.k12.mn.us';
+const OUT_OF_SCOPE_MEMBER_EMAIL = 'other.building@orono.k12.mn.us';
 const OUTSIDER_EMAIL = 'outsider@example.com';
 const SUPER_EMAIL = 'super@spartboard.io';
 
@@ -56,32 +69,117 @@ afterAll(async () => {
 beforeEach(async () => {
   await testEnv.clearFirestore();
 
-  // Seed org, member, role, building, domain, super-admin list using privileged context.
+  // Seed org, members, roles, buildings, domains, super-admin list using
+  // privileged context. Membership shape mirrors what the Phase 1 migration
+  // script writes: domain admin + building admin scoped to 'high', a teacher
+  // in 'middle', and an "out of scope" member in 'elementary'.
   await testEnv.withSecurityRulesDisabled(async (ctx) => {
     const db = ctx.firestore();
     await setDoc(doc(db, `organizations/${ORG_ID}`), {
       id: ORG_ID,
       name: 'Orono',
+      shortName: 'Orono',
+      shortCode: 'OPS',
+      state: 'MN',
       plan: 'full',
-    });
-    await setDoc(doc(db, `organizations/${ORG_ID}/members/${MEMBER_EMAIL}`), {
-      email: MEMBER_EMAIL,
-      orgId: ORG_ID,
-      roleId: 'domain_admin',
+      aiEnabled: true,
+      primaryAdminEmail: DOMAIN_ADMIN_EMAIL,
+      createdAt: '2026-01-01',
+      users: 4,
+      buildings: 1,
       status: 'active',
-      buildingIds: [],
+      seedColor: 'bg-indigo-600',
     });
+    await setDoc(doc(db, `organizations/${OTHER_ORG_ID}`), {
+      id: OTHER_ORG_ID,
+      name: 'Other',
+      plan: 'basic',
+      aiEnabled: false,
+    });
+
+    // Members
+    await setDoc(
+      doc(db, `organizations/${ORG_ID}/members/${DOMAIN_ADMIN_EMAIL}`),
+      {
+        email: DOMAIN_ADMIN_EMAIL,
+        orgId: ORG_ID,
+        roleId: 'domain_admin',
+        status: 'active',
+        buildingIds: ['high', 'middle'],
+      }
+    );
+    await setDoc(
+      doc(db, `organizations/${ORG_ID}/members/${BUILDING_ADMIN_EMAIL}`),
+      {
+        email: BUILDING_ADMIN_EMAIL,
+        orgId: ORG_ID,
+        roleId: 'building_admin',
+        status: 'active',
+        buildingIds: ['high'],
+      }
+    );
+    await setDoc(doc(db, `organizations/${ORG_ID}/members/${TEACHER_EMAIL}`), {
+      email: TEACHER_EMAIL,
+      orgId: ORG_ID,
+      roleId: 'teacher',
+      status: 'active',
+      buildingIds: ['high'], // in the building admin's scope
+    });
+    await setDoc(
+      doc(db, `organizations/${ORG_ID}/members/${OUT_OF_SCOPE_MEMBER_EMAIL}`),
+      {
+        email: OUT_OF_SCOPE_MEMBER_EMAIL,
+        orgId: ORG_ID,
+        roleId: 'teacher',
+        status: 'active',
+        buildingIds: ['elementary'], // NOT in building admin's scope
+      }
+    );
+
+    // Roles — system + a custom one used by Phase 3 update tests.
     await setDoc(doc(db, `organizations/${ORG_ID}/roles/domain_admin`), {
       id: 'domain_admin',
       name: 'Domain admin',
       system: true,
       perms: {},
     });
+    await setDoc(doc(db, `organizations/${ORG_ID}/roles/building_admin`), {
+      id: 'building_admin',
+      name: 'Building admin',
+      system: true,
+      perms: {},
+    });
+    await setDoc(doc(db, `organizations/${ORG_ID}/roles/teacher`), {
+      id: 'teacher',
+      name: 'Teacher',
+      system: true,
+      perms: {},
+    });
+    await setDoc(doc(db, `organizations/${ORG_ID}/roles/custom-coach`), {
+      id: 'custom-coach',
+      name: 'Instructional Coach',
+      system: false,
+      perms: {},
+    });
+
+    // Buildings
     await setDoc(doc(db, `organizations/${ORG_ID}/buildings/high`), {
       id: 'high',
       orgId: ORG_ID,
       name: 'Orono High',
     });
+    await setDoc(doc(db, `organizations/${ORG_ID}/buildings/middle`), {
+      id: 'middle',
+      orgId: ORG_ID,
+      name: 'Orono Middle',
+    });
+    await setDoc(doc(db, `organizations/${ORG_ID}/buildings/elementary`), {
+      id: 'elementary',
+      orgId: ORG_ID,
+      name: 'Orono Elementary',
+    });
+
+    // Domains + student page config
     await setDoc(doc(db, `organizations/${ORG_ID}/domains/primary`), {
       id: 'primary',
       orgId: ORG_ID,
@@ -91,19 +189,29 @@ beforeEach(async () => {
       orgId: ORG_ID,
       heroText: 'Hi',
     });
+
+    // Super admin list (legacy)
     await setDoc(doc(db, 'admin_settings/user_roles'), {
       superAdmins: [SUPER_EMAIL],
     });
     // Legacy admin record used by the unchanged isAdmin() rule.
-    await setDoc(doc(db, `admins/${MEMBER_EMAIL}`), {
-      email: MEMBER_EMAIL,
+    await setDoc(doc(db, `admins/${DOMAIN_ADMIN_EMAIL}`), {
+      email: DOMAIN_ADMIN_EMAIL,
     });
   });
 });
 
-const asMember = () =>
+const asDomainAdmin = () =>
   testEnv
-    .authenticatedContext('member-uid', { email: MEMBER_EMAIL })
+    .authenticatedContext('member-uid', { email: DOMAIN_ADMIN_EMAIL })
+    .firestore();
+const asBuildingAdmin = () =>
+  testEnv
+    .authenticatedContext('bldg-uid', { email: BUILDING_ADMIN_EMAIL })
+    .firestore();
+const asTeacher = () =>
+  testEnv
+    .authenticatedContext('teacher-uid', { email: TEACHER_EMAIL })
     .firestore();
 const asOutsider = () =>
   testEnv
@@ -113,27 +221,34 @@ const asSuper = () =>
   testEnv.authenticatedContext('super-uid', { email: SUPER_EMAIL }).firestore();
 const asAnon = () => testEnv.unauthenticatedContext().firestore();
 
-describe('organizations — reads', () => {
+describe('organizations — reads (Phase 1)', () => {
   it('member can read the org doc', async () => {
-    await assertSucceeds(getDoc(doc(asMember(), `organizations/${ORG_ID}`)));
+    await assertSucceeds(
+      getDoc(doc(asDomainAdmin(), `organizations/${ORG_ID}`))
+    );
   });
 
   it('member can read buildings, domains, roles, members, studentPageConfig', async () => {
     await assertSucceeds(
-      getDoc(doc(asMember(), `organizations/${ORG_ID}/buildings/high`))
+      getDoc(doc(asDomainAdmin(), `organizations/${ORG_ID}/buildings/high`))
     );
     await assertSucceeds(
-      getDoc(doc(asMember(), `organizations/${ORG_ID}/domains/primary`))
+      getDoc(doc(asDomainAdmin(), `organizations/${ORG_ID}/domains/primary`))
     );
     await assertSucceeds(
-      getDoc(doc(asMember(), `organizations/${ORG_ID}/roles/domain_admin`))
-    );
-    await assertSucceeds(
-      getDoc(doc(asMember(), `organizations/${ORG_ID}/members/${MEMBER_EMAIL}`))
+      getDoc(doc(asDomainAdmin(), `organizations/${ORG_ID}/roles/domain_admin`))
     );
     await assertSucceeds(
       getDoc(
-        doc(asMember(), `organizations/${ORG_ID}/studentPageConfig/default`)
+        doc(asDomainAdmin(), `organizations/${ORG_ID}/members/${MEMBER_EMAIL}`)
+      )
+    );
+    await assertSucceeds(
+      getDoc(
+        doc(
+          asDomainAdmin(),
+          `organizations/${ORG_ID}/studentPageConfig/default`
+        )
       )
     );
   });
@@ -141,7 +256,7 @@ describe('organizations — reads', () => {
   it('super admin (legacy user_roles) can read every org', async () => {
     await assertSucceeds(getDoc(doc(asSuper(), `organizations/${ORG_ID}`)));
     await assertSucceeds(
-      getDoc(doc(asSuper(), `organizations/${ORG_ID}/buildings/high`))
+      getDoc(doc(asSuper(), `organizations/${OTHER_ORG_ID}`))
     );
   });
 
@@ -156,9 +271,6 @@ describe('organizations — reads', () => {
   });
 
   it('non-member CAN read their own (absent) member doc to bootstrap useAuth', async () => {
-    // Reading /organizations/{orgId}/members/{myEmail} must succeed even if
-    // the doc does not exist — the auth layer uses this probe to decide
-    // whether the user has an org membership.
     await assertSucceeds(
       getDoc(
         doc(asOutsider(), `organizations/${ORG_ID}/members/${OUTSIDER_EMAIL}`)
@@ -166,10 +278,7 @@ describe('organizations — reads', () => {
     );
   });
 
-  it('non-member cannot read another user\u2019s member doc', async () => {
-    // Self-probe is the ONLY reason a non-member can read /members/*.
-    // Reading some other user's membership must fall through to the
-    // isOrgMember / isSuperAdmin clauses and be denied.
+  it("non-member cannot read another user's member doc", async () => {
     await assertFails(
       getDoc(
         doc(asOutsider(), `organizations/${ORG_ID}/members/${MEMBER_EMAIL}`)
@@ -185,67 +294,497 @@ describe('organizations — reads', () => {
   });
 });
 
-describe('organizations — writes (all blocked in Phase 1)', () => {
-  it('member cannot write the org doc', async () => {
-    await assertFails(
-      setDoc(doc(asMember(), `organizations/${ORG_ID}`), { name: 'Changed' })
+describe('organizations — super admin writes (Phase 3)', () => {
+  it('super admin can create an org', async () => {
+    await assertSucceeds(
+      setDoc(doc(asSuper(), 'organizations/new-org'), {
+        id: 'new-org',
+        name: 'New',
+        plan: 'basic',
+        aiEnabled: false,
+      })
     );
   });
 
-  it('member cannot write buildings, domains, roles, members, studentPageConfig', async () => {
+  it('super admin can delete an org', async () => {
+    await assertSucceeds(
+      deleteDoc(doc(asSuper(), `organizations/${OTHER_ORG_ID}`))
+    );
+  });
+
+  it('super admin can flip aiEnabled / plan', async () => {
+    await assertSucceeds(
+      updateDoc(doc(asSuper(), `organizations/${ORG_ID}`), {
+        aiEnabled: false,
+        plan: 'expanded',
+      })
+    );
+  });
+
+  it('domain admin cannot create an org', async () => {
     await assertFails(
-      setDoc(doc(asMember(), `organizations/${ORG_ID}/buildings/new`), {
+      setDoc(doc(asDomainAdmin(), 'organizations/nope'), { name: 'Nope' })
+    );
+  });
+
+  it('domain admin cannot delete their own org', async () => {
+    await assertFails(
+      deleteDoc(doc(asDomainAdmin(), `organizations/${ORG_ID}`))
+    );
+  });
+});
+
+describe('organizations — domain admin writes on own org', () => {
+  it('can update identity fields (name, shortName, seedColor, supportUrl)', async () => {
+    await assertSucceeds(
+      updateDoc(doc(asDomainAdmin(), `organizations/${ORG_ID}`), {
+        name: 'Orono Public Schools',
+        shortName: 'Orono',
+        seedColor: 'bg-emerald-600',
+        supportUrl: 'https://orono.k12.mn.us/support',
+      })
+    );
+  });
+
+  it('cannot flip aiEnabled', async () => {
+    await assertFails(
+      updateDoc(doc(asDomainAdmin(), `organizations/${ORG_ID}`), {
+        aiEnabled: false,
+      })
+    );
+  });
+
+  it('cannot change plan', async () => {
+    await assertFails(
+      updateDoc(doc(asDomainAdmin(), `organizations/${ORG_ID}`), {
+        plan: 'basic',
+      })
+    );
+  });
+
+  it('cannot edit another org', async () => {
+    await assertFails(
+      updateDoc(doc(asDomainAdmin(), `organizations/${OTHER_ORG_ID}`), {
+        name: 'Hijacked',
+      })
+    );
+  });
+});
+
+describe('organizations — building admin writes on org doc (denied)', () => {
+  it('building admin cannot update org identity fields', async () => {
+    await assertFails(
+      updateDoc(doc(asBuildingAdmin(), `organizations/${ORG_ID}`), {
+        name: 'Nope',
+      })
+    );
+  });
+
+  it('teacher cannot update org doc', async () => {
+    await assertFails(
+      updateDoc(doc(asTeacher(), `organizations/${ORG_ID}`), { name: 'Nope' })
+    );
+  });
+});
+
+describe('organizations/buildings — writes', () => {
+  it('domain admin can create, update, delete any building', async () => {
+    await assertSucceeds(
+      setDoc(doc(asDomainAdmin(), `organizations/${ORG_ID}/buildings/new`), {
+        id: 'new',
+        name: 'New School',
+      })
+    );
+    await assertSucceeds(
+      updateDoc(
+        doc(asDomainAdmin(), `organizations/${ORG_ID}/buildings/middle`),
+        { name: 'Orono Middle School' }
+      )
+    );
+    await assertSucceeds(
+      deleteDoc(
+        doc(asDomainAdmin(), `organizations/${ORG_ID}/buildings/elementary`)
+      )
+    );
+  });
+
+  it('building admin can update a building in their scope', async () => {
+    await assertSucceeds(
+      updateDoc(
+        doc(asBuildingAdmin(), `organizations/${ORG_ID}/buildings/high`),
+        { address: '123 Spartan Way' }
+      )
+    );
+  });
+
+  it('building admin cannot update a building outside their scope', async () => {
+    await assertFails(
+      updateDoc(
+        doc(asBuildingAdmin(), `organizations/${ORG_ID}/buildings/middle`),
+        { address: 'nope' }
+      )
+    );
+  });
+
+  it('building admin cannot create or delete buildings', async () => {
+    await assertFails(
+      setDoc(doc(asBuildingAdmin(), `organizations/${ORG_ID}/buildings/new`), {
+        id: 'new',
         name: 'X',
       })
     );
     await assertFails(
-      setDoc(doc(asMember(), `organizations/${ORG_ID}/domains/new`), {
+      deleteDoc(
+        doc(asBuildingAdmin(), `organizations/${ORG_ID}/buildings/high`)
+      )
+    );
+  });
+
+  it('teacher cannot update a building', async () => {
+    await assertFails(
+      updateDoc(doc(asTeacher(), `organizations/${ORG_ID}/buildings/high`), {
+        name: 'nope',
+      })
+    );
+  });
+});
+
+describe('organizations/domains — writes', () => {
+  it('domain admin can create, update, delete domains', async () => {
+    await assertSucceeds(
+      setDoc(doc(asDomainAdmin(), `organizations/${ORG_ID}/domains/students`), {
+        id: 'students',
+        domain: '@students.orono.k12.mn.us',
+      })
+    );
+    await assertSucceeds(
+      updateDoc(
+        doc(asDomainAdmin(), `organizations/${ORG_ID}/domains/primary`),
+        { authMethod: 'google' }
+      )
+    );
+    await assertSucceeds(
+      deleteDoc(doc(asDomainAdmin(), `organizations/${ORG_ID}/domains/primary`))
+    );
+  });
+
+  it('building admin cannot write domains', async () => {
+    await assertFails(
+      setDoc(doc(asBuildingAdmin(), `organizations/${ORG_ID}/domains/new`), {
+        id: 'new',
         domain: '@x.com',
       })
     );
     await assertFails(
-      setDoc(doc(asMember(), `organizations/${ORG_ID}/roles/custom`), {
-        name: 'Custom',
+      updateDoc(
+        doc(asBuildingAdmin(), `organizations/${ORG_ID}/domains/primary`),
+        { authMethod: 'saml' }
+      )
+    );
+    await assertFails(
+      deleteDoc(
+        doc(asBuildingAdmin(), `organizations/${ORG_ID}/domains/primary`)
+      )
+    );
+  });
+});
+
+describe('organizations/roles — writes (system role protection)', () => {
+  it('domain admin can create a custom role (system:false)', async () => {
+    await assertSucceeds(
+      setDoc(
+        doc(asDomainAdmin(), `organizations/${ORG_ID}/roles/custom-specialist`),
+        {
+          id: 'custom-specialist',
+          name: 'Specialist',
+          system: false,
+          perms: {},
+        }
+      )
+    );
+  });
+
+  it('domain admin cannot create a role with system:true', async () => {
+    await assertFails(
+      setDoc(doc(asDomainAdmin(), `organizations/${ORG_ID}/roles/hacked`), {
+        id: 'hacked',
+        name: 'Hacked',
+        system: true,
+        perms: {},
+      })
+    );
+  });
+
+  it('domain admin can update a custom role', async () => {
+    await assertSucceeds(
+      updateDoc(
+        doc(asDomainAdmin(), `organizations/${ORG_ID}/roles/custom-coach`),
+        { name: 'Instructional Coach (renamed)' }
+      )
+    );
+  });
+
+  it('domain admin cannot update a system role', async () => {
+    await assertFails(
+      updateDoc(
+        doc(asDomainAdmin(), `organizations/${ORG_ID}/roles/domain_admin`),
+        { name: 'Renamed' }
+      )
+    );
+  });
+
+  it('domain admin cannot flip system:true to false', async () => {
+    // Starting from system:true; request tries to change to false.
+    await assertFails(
+      updateDoc(doc(asDomainAdmin(), `organizations/${ORG_ID}/roles/teacher`), {
+        system: false,
+      })
+    );
+  });
+
+  it('domain admin cannot flip system:false to true on a custom role', async () => {
+    await assertFails(
+      updateDoc(
+        doc(asDomainAdmin(), `organizations/${ORG_ID}/roles/custom-coach`),
+        { system: true }
+      )
+    );
+  });
+
+  it('domain admin cannot delete a system role', async () => {
+    await assertFails(
+      deleteDoc(
+        doc(asDomainAdmin(), `organizations/${ORG_ID}/roles/domain_admin`)
+      )
+    );
+  });
+
+  it('domain admin can delete a custom role', async () => {
+    await assertSucceeds(
+      deleteDoc(
+        doc(asDomainAdmin(), `organizations/${ORG_ID}/roles/custom-coach`)
+      )
+    );
+  });
+
+  it('building admin cannot create or update roles', async () => {
+    await assertFails(
+      setDoc(doc(asBuildingAdmin(), `organizations/${ORG_ID}/roles/custom-x`), {
+        id: 'custom-x',
+        name: 'X',
+        system: false,
+        perms: {},
       })
     );
     await assertFails(
-      setDoc(
-        doc(asMember(), `organizations/${ORG_ID}/members/new@example.com`),
-        { roleId: 'teacher' }
+      updateDoc(
+        doc(asBuildingAdmin(), `organizations/${ORG_ID}/roles/custom-coach`),
+        { name: 'hack' }
       )
     );
-    await assertFails(
+  });
+});
+
+describe('organizations/members — writes', () => {
+  it('domain admin can create a new member', async () => {
+    await assertSucceeds(
       setDoc(
-        doc(asMember(), `organizations/${ORG_ID}/studentPageConfig/default`),
-        { heroText: 'Hacked' }
+        doc(
+          asDomainAdmin(),
+          `organizations/${ORG_ID}/members/new.teacher@orono.k12.mn.us`
+        ),
+        {
+          email: 'new.teacher@orono.k12.mn.us',
+          orgId: ORG_ID,
+          roleId: 'teacher',
+          status: 'invited',
+          buildingIds: ['high'],
+        }
       )
     );
   });
 
-  it('super admin cannot write either (Phase 3 will enable)', async () => {
-    await assertFails(
-      setDoc(doc(asSuper(), `organizations/${ORG_ID}`), { name: 'Changed' })
+  it('domain admin can update roleId and buildingIds', async () => {
+    await assertSucceeds(
+      updateDoc(
+        doc(
+          asDomainAdmin(),
+          `organizations/${ORG_ID}/members/${TEACHER_EMAIL}`
+        ),
+        { roleId: 'building_admin', buildingIds: ['high', 'middle'] }
+      )
     );
   });
 
+  it('domain admin can delete a member', async () => {
+    await assertSucceeds(
+      deleteDoc(
+        doc(asDomainAdmin(), `organizations/${ORG_ID}/members/${TEACHER_EMAIL}`)
+      )
+    );
+  });
+
+  it('building admin can update status for a member in their scope', async () => {
+    // TEACHER_EMAIL has buildingIds: ['high'] which intersects bldg admin's ['high'].
+    await assertSucceeds(
+      updateDoc(
+        doc(
+          asBuildingAdmin(),
+          `organizations/${ORG_ID}/members/${TEACHER_EMAIL}`
+        ),
+        { status: 'inactive' }
+      )
+    );
+  });
+
+  it('building admin cannot change roleId even within scope', async () => {
+    await assertFails(
+      updateDoc(
+        doc(
+          asBuildingAdmin(),
+          `organizations/${ORG_ID}/members/${TEACHER_EMAIL}`
+        ),
+        { roleId: 'domain_admin' }
+      )
+    );
+  });
+
+  it('building admin cannot change buildingIds even within scope', async () => {
+    await assertFails(
+      updateDoc(
+        doc(
+          asBuildingAdmin(),
+          `organizations/${ORG_ID}/members/${TEACHER_EMAIL}`
+        ),
+        { buildingIds: ['high', 'elementary'] }
+      )
+    );
+  });
+
+  it('building admin cannot update members outside their scope', async () => {
+    await assertFails(
+      updateDoc(
+        doc(
+          asBuildingAdmin(),
+          `organizations/${ORG_ID}/members/${OUT_OF_SCOPE_MEMBER_EMAIL}`
+        ),
+        { status: 'inactive' }
+      )
+    );
+  });
+
+  it('building admin cannot create or delete members', async () => {
+    await assertFails(
+      setDoc(
+        doc(
+          asBuildingAdmin(),
+          `organizations/${ORG_ID}/members/new@orono.k12.mn.us`
+        ),
+        {
+          email: 'new@orono.k12.mn.us',
+          orgId: ORG_ID,
+          roleId: 'teacher',
+          status: 'invited',
+          buildingIds: ['high'],
+        }
+      )
+    );
+    await assertFails(
+      deleteDoc(
+        doc(
+          asBuildingAdmin(),
+          `organizations/${ORG_ID}/members/${TEACHER_EMAIL}`
+        )
+      )
+    );
+  });
+
+  it('teacher cannot update any member', async () => {
+    await assertFails(
+      updateDoc(
+        doc(asTeacher(), `organizations/${ORG_ID}/members/${TEACHER_EMAIL}`),
+        { status: 'inactive' }
+      )
+    );
+  });
+});
+
+describe('organizations/studentPageConfig — writes', () => {
+  it('domain admin can update student page config', async () => {
+    await assertSucceeds(
+      updateDoc(
+        doc(
+          asDomainAdmin(),
+          `organizations/${ORG_ID}/studentPageConfig/default`
+        ),
+        { heroText: 'Welcome Spartans!', accentColor: '#ad2122' }
+      )
+    );
+  });
+
+  it('super admin can update student page config', async () => {
+    await assertSucceeds(
+      updateDoc(
+        doc(asSuper(), `organizations/${ORG_ID}/studentPageConfig/default`),
+        { heroText: 'From super' }
+      )
+    );
+  });
+
+  it('building admin cannot update student page config', async () => {
+    await assertFails(
+      updateDoc(
+        doc(
+          asBuildingAdmin(),
+          `organizations/${ORG_ID}/studentPageConfig/default`
+        ),
+        { heroText: 'nope' }
+      )
+    );
+  });
+
+  it('teacher cannot update student page config', async () => {
+    await assertFails(
+      updateDoc(
+        doc(asTeacher(), `organizations/${ORG_ID}/studentPageConfig/default`),
+        { heroText: 'nope' }
+      )
+    );
+  });
+});
+
+describe('organizations/invitations — fully locked (Phase 4)', () => {
   it('invitations collection is fully locked from clients', async () => {
     await assertFails(
-      getDoc(doc(asMember(), `organizations/${ORG_ID}/invitations/token-123`))
+      getDoc(
+        doc(asDomainAdmin(), `organizations/${ORG_ID}/invitations/token-123`)
+      )
     );
     await assertFails(
-      setDoc(doc(asMember(), `organizations/${ORG_ID}/invitations/token-123`), {
-        email: 'x@y.com',
-      })
+      setDoc(
+        doc(asDomainAdmin(), `organizations/${ORG_ID}/invitations/token-123`),
+        { email: 'x@y.com' }
+      )
+    );
+    await assertFails(
+      setDoc(
+        doc(asSuper(), `organizations/${ORG_ID}/invitations/token-super`),
+        { email: 'x@y.com' }
+      )
     );
   });
 });
 
 describe('no regression on legacy /admins/{email}', () => {
   it('owning user can still read their own admin doc', async () => {
-    await assertSucceeds(getDoc(doc(asMember(), `admins/${MEMBER_EMAIL}`)));
+    await assertSucceeds(
+      getDoc(doc(asDomainAdmin(), `admins/${DOMAIN_ADMIN_EMAIL}`))
+    );
   });
 
   it('other users still cannot read another admin doc', async () => {
-    await assertFails(getDoc(doc(asOutsider(), `admins/${MEMBER_EMAIL}`)));
+    await assertFails(
+      getDoc(doc(asOutsider(), `admins/${DOMAIN_ADMIN_EMAIL}`))
+    );
   });
 });

--- a/tests/rules/firestore-rules-organizations.test.ts
+++ b/tests/rules/firestore-rules-organizations.test.ts
@@ -415,6 +415,7 @@ describe('organizations/buildings — writes', () => {
         id: 'new',
         orgId: ORG_ID,
         name: 'New School',
+        users: 0,
       })
     );
     await assertSucceeds(
@@ -436,6 +437,7 @@ describe('organizations/buildings — writes', () => {
         id: 'sneaky',
         orgId: OTHER_ORG_ID, // spoofed parent
         name: 'Sneaky',
+        users: 0,
       })
     );
   });
@@ -446,7 +448,43 @@ describe('organizations/buildings — writes', () => {
         id: 'fake',
         orgId: ORG_ID,
         name: 'Mismatch',
+        users: 0,
       })
+    );
+  });
+
+  it('domain admin cannot create a building with users != 0', async () => {
+    await assertFails(
+      setDoc(
+        doc(asDomainAdmin(), `organizations/${ORG_ID}/buildings/inflate`),
+        {
+          id: 'inflate',
+          orgId: ORG_ID,
+          name: 'Inflated',
+          users: 9999, // derived count — server-managed
+        }
+      )
+    );
+  });
+
+  it('domain admin cannot create a building with unknown keys', async () => {
+    await assertFails(
+      setDoc(doc(asDomainAdmin(), `organizations/${ORG_ID}/buildings/extra`), {
+        id: 'extra',
+        orgId: ORG_ID,
+        name: 'Extra',
+        users: 0,
+        secretField: 'nope', // not in the whitelist
+      })
+    );
+  });
+
+  it('domain admin cannot mutate derived `users` on a building', async () => {
+    await assertFails(
+      updateDoc(
+        doc(asDomainAdmin(), `organizations/${ORG_ID}/buildings/high`),
+        { users: 9999 }
+      )
     );
   });
 
@@ -498,6 +536,7 @@ describe('organizations/buildings — writes', () => {
         id: 'new',
         orgId: ORG_ID,
         name: 'X',
+        users: 0,
       })
     );
     await assertFails(
@@ -1014,6 +1053,34 @@ describe('organizations/studentPageConfig — writes', () => {
     await assertFails(
       deleteDoc(
         doc(asSuper(), `organizations/${ORG_ID}/studentPageConfig/default`)
+      )
+    );
+  });
+
+  it('domain admin cannot create student page config with mismatched orgId', async () => {
+    await assertFails(
+      setDoc(
+        doc(
+          asDomainAdmin(),
+          `organizations/${ORG_ID}/studentPageConfig/default`
+        ),
+        { orgId: OTHER_ORG_ID, heroText: 'spoof' }
+      )
+    );
+  });
+
+  it('domain admin cannot create student page config with unknown keys', async () => {
+    await assertFails(
+      setDoc(
+        doc(
+          asDomainAdmin(),
+          `organizations/${ORG_ID}/studentPageConfig/default`
+        ),
+        {
+          orgId: ORG_ID,
+          heroText: 'Hi',
+          secretField: 'nope', // not in whitelist
+        }
       )
     );
   });

--- a/tests/rules/firestore-rules-organizations.test.ts
+++ b/tests/rules/firestore-rules-organizations.test.ts
@@ -762,6 +762,44 @@ describe('organizations/roles — writes (system role protection)', () => {
     );
   });
 
+  it('domain admin cannot create a role with unknown keys', async () => {
+    await assertFails(
+      setDoc(
+        doc(asDomainAdmin(), `organizations/${ORG_ID}/roles/custom-extra`),
+        {
+          id: 'custom-extra',
+          name: 'Extra',
+          system: false,
+          perms: {},
+          secretField: 'nope', // not in the whitelist
+        }
+      )
+    );
+  });
+
+  it('domain admin cannot create a role missing required fields', async () => {
+    await assertFails(
+      setDoc(
+        doc(asDomainAdmin(), `organizations/${ORG_ID}/roles/custom-thin`),
+        {
+          id: 'custom-thin',
+          name: 'Thin',
+          system: false,
+          // perms omitted — required by hasAll
+        }
+      )
+    );
+  });
+
+  it('domain admin cannot update a custom role with unknown keys', async () => {
+    await assertFails(
+      updateDoc(
+        doc(asDomainAdmin(), `organizations/${ORG_ID}/roles/custom-coach`),
+        { secretField: 'nope' }
+      )
+    );
+  });
+
   it('building admin cannot create or update roles', async () => {
     await assertFails(
       setDoc(doc(asBuildingAdmin(), `organizations/${ORG_ID}/roles/custom-x`), {

--- a/types.ts
+++ b/types.ts
@@ -2912,7 +2912,8 @@ export type GlobalFeature =
   | 'remote-control'
   | 'embed-mini-app'
   | 'video-activity-audio-transcription'
-  | 'ai-file-context';
+  | 'ai-file-context'
+  | 'org-admin-writes';
 
 export interface GlobalFeaturePermission {
   featureId: GlobalFeature;

--- a/utils/slug.ts
+++ b/utils/slug.ts
@@ -1,0 +1,39 @@
+// Shared slug / doc-id derivation used by the Organization admin hooks
+// (useOrganizations, useOrgBuildings, useOrgDomains). Centralizing the logic
+// keeps id-gen consistent across sibling collections so a single
+// `organizations/{orgId}/...` path never mixes differently-normalized ids.
+//
+// `slugify()` produces a URL-friendly, Firestore-safe id from free-form
+// input. `slugOrFallback()` wraps it with a UUID fallback for inputs that
+// contain no alphanumerics (e.g. "¿¿¿") so callers always get a valid id.
+
+const MAX_SLUG_LENGTH = 48;
+const UUID_FALLBACK_LENGTH = 24;
+
+/**
+ * Lowercases, strips a leading `@` (convenient for email-style domains),
+ * collapses non-alphanumerics into a single `-`, trims leading/trailing `-`,
+ * and caps the length. Returns `''` when the input normalizes to nothing.
+ */
+export const slugify = (input: string): string =>
+  input
+    .toLowerCase()
+    .replace(/^@/, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '')
+    .slice(0, MAX_SLUG_LENGTH);
+
+/**
+ * Like `slugify()`, but falls back to a UUID (or `${prefix}-${timestamp}` on
+ * runtimes without `crypto.randomUUID`) when the input has no usable
+ * alphanumeric content. Use this as the default id-generator for
+ * Organization sub-collections.
+ */
+export const slugOrFallback = (input: string, prefix: string): string => {
+  const base = slugify(input);
+  if (base) return base;
+  return (globalThis.crypto?.randomUUID?.() ?? `${prefix}-${Date.now()}`).slice(
+    0,
+    UUID_FALLBACK_LENGTH
+  );
+};

--- a/utils/slug.ts
+++ b/utils/slug.ts
@@ -20,7 +20,7 @@ export const slugify = (input: string): string =>
     .toLowerCase()
     .replace(/^@/, '')
     .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-|-$/g, '')
+    .replace(/^-+|-+$/g, '')
     .slice(0, MAX_SLUG_LENGTH);
 
 /**


### PR DESCRIPTION
## Summary

Phase 3 of the Organization admin panel Firestore wiring plan. Replaces the Phase 2 "coming soon" toasts with real Firestore writes, gated on a new `org-admin-writes` global feature flag seeded beta-for-Paul.

- **Rules (`firestore.rules`):** every `allow write: if false` stub under `/organizations/{orgId}` replaced with real scoping via `affectedKeys().hasOnly([...])`. Super admin for `create`/`delete` + `aiEnabled`/`plan`; domain admin for identity fields; building admin restricted to member `status` only within their `buildingIds`. System roles (`system:true`) immutable; invitations still locked.
- **Hooks (`hooks/useOrg*.ts`):** seven hooks swap reject-stubs for real `setDoc` / `updateDoc` / `deleteDoc`. Slug-derived ids for buildings/domains/orgs; `userPatchToMemberPatch` translates UI `role` → `roleId`; `saveRoles` upserts non-system + deletes dropped custom roles; `updateStudentPage` uses `setDoc({ merge: true })` for first-write safety. Invitations remain a Phase-4 stub.
- **Panel (`OrganizationPanel.tsx`):** every view callback routed through a shared `run()` helper that surfaces success/error toasts. `canAccessFeature('org-admin-writes')` gates every handler — when off, they short-circuit to the Phase-2 "coming soon" toast. `'org-admin-writes'` added to the `GlobalFeature` union; `scripts/init-global-perms.js` seeds the flag as `accessLevel:'beta'`, `betaUsers:['paul.ivers@orono.k12.mn.us']`.
- **Rules tests (`tests/rules/firestore-rules-organizations.test.ts`):** expanded to cover every write path — super + domain + building admin, in-scope + out-of-scope member updates, system-role immutability, cross-org denial.
- **Docs:** `docs/organization_wiring_implementation.md` Phase 3 ledger closed; Decisions Log + Changelog appended.

`pnpm run type-check`, `pnpm run lint`, `pnpm run format:check`, and `pnpm run test` all pass (1330 unit tests across 148 files).

## Test plan

- [ ] Deploy updated `firestore.rules` to `spartboard` (`firebase deploy --only firestore:rules --project spartboard`)
- [ ] Run `node scripts/init-global-perms.js` to seed the `org-admin-writes` global-permission doc
- [ ] Run the rules-unit suite against the emulator (`pnpm run test:rules`) on a host with Java
- [ ] Preview deploy from this branch
- [ ] Sign in as `paul.ivers@orono.k12.mn.us`; verify every mutation persists in the Overview, Buildings, Domains, Roles, Users, Student Page views
- [ ] Sign in as a non-beta domain admin; verify writes still show "coming soon" toasts (flag gate)
- [ ] Verify cross-org writes in the browser console fail with a Firestore permission error

https://claude.ai/code/session_01TdjkKT5J5E7ranfm9SSZGy