### PR TITLE
fix(admin): improve mobile UI for Organization tab lists and headers

### DIFF
--- a/components/admin/Organization/components/primitives.tsx
+++ b/components/admin/Organization/components/primitives.tsx
@@ -106,7 +106,7 @@ export const ViewHeader: React.FC<{
   blurb?: string;
   actions?: React.ReactNode;
 }> = ({ title, blurb, actions }) => (
-  <div className="flex items-start justify-between gap-4 mb-6">
+  <div className="flex flex-col gap-3 mb-6 sm:flex-row sm:items-start sm:justify-between sm:gap-4">
     <div className="min-w-0">
       <h2 className="text-xl font-bold text-slate-900 leading-tight">
         {title}
@@ -116,7 +116,9 @@ export const ViewHeader: React.FC<{
       )}
     </div>
     {actions && (
-      <div className="shrink-0 flex items-center gap-2">{actions}</div>
+      <div className="flex flex-wrap items-center gap-2 sm:shrink-0">
+        {actions}
+      </div>
     )}
   </div>
 );
@@ -405,14 +407,37 @@ export const RowMenu: React.FC<{ items: MenuItem[]; label?: string }> = ({
   label = 'Row actions',
 }) => {
   const [open, setOpen] = useState(false);
-  const ref = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
+  const [pos, setPos] = useState<{ top: number; right: number } | null>(null);
+
+  useLayoutEffect(() => {
+    if (!open) return undefined;
+    const measure = () => {
+      const el = triggerRef.current;
+      if (!el) return;
+      const r = el.getBoundingClientRect();
+      setPos({ top: r.bottom + 4, right: window.innerWidth - r.right });
+    };
+    measure();
+    const raf = requestAnimationFrame(measure);
+    window.addEventListener('resize', measure);
+    // Capture scroll from any ancestor (tables, modals, etc.)
+    window.addEventListener('scroll', measure, true);
+    return () => {
+      cancelAnimationFrame(raf);
+      window.removeEventListener('resize', measure);
+      window.removeEventListener('scroll', measure, true);
+    };
+  }, [open]);
 
   useEffect(() => {
     if (!open) return undefined;
     const onDocClick = (e: MouseEvent) => {
-      if (ref.current && !ref.current.contains(e.target as Node)) {
-        setOpen(false);
-      }
+      const target = e.target as Node;
+      if (menuRef.current?.contains(target)) return;
+      if (triggerRef.current?.contains(target)) return;
+      setOpen(false);
     };
     const onEsc = (e: KeyboardEvent) => {
       if (e.key === 'Escape') setOpen(false);
@@ -426,8 +451,9 @@ export const RowMenu: React.FC<{ items: MenuItem[]; label?: string }> = ({
   }, [open]);
 
   return (
-    <div className="relative" ref={ref}>
+    <div>
       <button
+        ref={triggerRef}
         type="button"
         aria-label={label}
         aria-haspopup="menu"
@@ -447,32 +473,39 @@ export const RowMenu: React.FC<{ items: MenuItem[]; label?: string }> = ({
           <circle cx="8" cy="13" r="1.5" />
         </svg>
       </button>
-      {open && (
-        <div
-          role="menu"
-          className="absolute right-0 top-full mt-1 z-dropdown min-w-[200px] bg-white rounded-xl shadow-[0_10px_15px_-3px_rgba(29,42,93,.12),0_4px_6px_-4px_rgba(29,42,93,.08)] border border-slate-200 py-1"
-        >
-          {items.map((item, i) => (
-            <button
-              key={i}
-              role="menuitem"
-              disabled={item.disabled}
-              onClick={() => {
-                setOpen(false);
-                item.onClick();
-              }}
-              className={`w-full text-left px-3 py-2 text-sm flex items-center gap-2 disabled:opacity-40 disabled:cursor-not-allowed ${
-                item.danger
-                  ? 'text-brand-red hover:bg-rose-50'
-                  : 'text-slate-700 hover:bg-slate-50'
-              }`}
-            >
-              {item.icon}
-              {item.label}
-            </button>
-          ))}
-        </div>
-      )}
+      {open &&
+        pos &&
+        typeof document !== 'undefined' &&
+        createPortal(
+          <div
+            ref={menuRef}
+            role="menu"
+            style={{ position: 'fixed', top: pos.top, right: pos.right }}
+            className="z-dropdown min-w-[200px] bg-white rounded-xl shadow-[0_10px_15px_-3px_rgba(29,42,93,.12),0_4px_6px_-4px_rgba(29,42,93,.08)] border border-slate-200 py-1"
+            onClick={(e) => e.stopPropagation()}
+          >
+            {items.map((item, i) => (
+              <button
+                key={i}
+                role="menuitem"
+                disabled={item.disabled}
+                onClick={() => {
+                  setOpen(false);
+                  item.onClick();
+                }}
+                className={`w-full text-left px-3 py-2 text-sm flex items-center gap-2 disabled:opacity-40 disabled:cursor-not-allowed ${
+                  item.danger
+                    ? 'text-brand-red hover:bg-rose-50'
+                    : 'text-slate-700 hover:bg-slate-50'
+                }`}
+              >
+                {item.icon}
+                {item.label}
+              </button>
+            ))}
+          </div>,
+          document.body
+        )}
     </div>
   );
 };

--- a/components/admin/Organization/components/primitives.tsx
+++ b/components/admin/Organization/components/primitives.tsx
@@ -417,7 +417,35 @@ export const RowMenu: React.FC<{ items: MenuItem[]; label?: string }> = ({
       const el = triggerRef.current;
       if (!el) return;
       const r = el.getBoundingClientRect();
-      setPos({ top: r.bottom + 4, right: window.innerWidth - r.right });
+      const menuRect = menuRef.current?.getBoundingClientRect();
+      const viewportMargin = 8;
+      const gap = 4;
+      const menuWidth = Math.max(menuRect?.width ?? 0, 200);
+      const menuHeight = menuRect?.height ?? 0;
+
+      const preferredTop = r.bottom + gap;
+      const flippedTop = r.top - menuHeight - gap;
+      const maxTop = Math.max(
+        viewportMargin,
+        window.innerHeight - menuHeight - viewportMargin
+      );
+      const top =
+        menuHeight > 0 &&
+        preferredTop + menuHeight > window.innerHeight - viewportMargin
+          ? Math.max(viewportMargin, flippedTop)
+          : Math.min(preferredTop, maxTop);
+
+      const preferredRight = window.innerWidth - r.right;
+      const maxRight = Math.max(
+        viewportMargin,
+        window.innerWidth - menuWidth - viewportMargin
+      );
+      const right = Math.min(
+        Math.max(preferredRight, viewportMargin),
+        maxRight
+      );
+
+      setPos({ top, right });
     };
     measure();
     const raf = requestAnimationFrame(measure);

--- a/components/admin/Organization/views/AllOrganizationsView.tsx
+++ b/components/admin/Organization/views/AllOrganizationsView.tsx
@@ -101,114 +101,118 @@ export const AllOrganizationsView: React.FC<Props> = ({
       </div>
 
       <div className="bg-white rounded-xl border border-slate-200 shadow-[0_1px_2px_rgba(29,42,93,.06),0_1px_3px_rgba(29,42,93,.08)] overflow-hidden">
-        <div className="grid grid-cols-[2fr_1fr_0.75fr_0.75fr_0.75fr_1.5fr_0.9fr_auto] items-center gap-4 px-5 py-3 border-b border-slate-200 text-[11px] font-semibold uppercase tracking-wide text-slate-500">
-          <div>Organization</div>
-          <div>Plan</div>
-          <div>AI</div>
-          <div className="text-right">Users</div>
-          <div className="text-right">Buildings</div>
-          <div>Primary admin</div>
-          <div>Status</div>
-          <div />
-        </div>
-        {filtered.map((org) => (
-          <div
-            key={org.id}
-            role="button"
-            tabIndex={0}
-            onClick={() => onOpen(org.id)}
-            onKeyDown={(e) => {
-              if (e.key === 'Enter' || e.key === ' ') {
-                e.preventDefault();
-                onOpen(org.id);
-              }
-            }}
-            className="w-full grid grid-cols-[2fr_1fr_0.75fr_0.75fr_0.75fr_1.5fr_0.9fr_auto] items-center gap-4 px-5 py-3 border-b border-slate-100 last:border-b-0 text-left hover:bg-slate-50 focus:bg-slate-50 focus:outline-none transition-colors cursor-pointer"
-          >
-            <div className="flex items-center gap-3 min-w-0">
-              <OrgLogoTile
-                shortCode={org.shortCode}
-                seedColor={org.seedColor}
-              />
-              <div className="min-w-0">
-                <div className="text-sm font-semibold text-slate-900 truncate">
-                  {org.name}
+        <div className="overflow-x-auto">
+          <div className="min-w-[780px]">
+            <div className="grid grid-cols-[2fr_1fr_0.75fr_0.75fr_0.75fr_1.5fr_0.9fr_auto] items-center gap-4 px-5 py-3 border-b border-slate-200 text-[11px] font-semibold uppercase tracking-wide text-slate-500">
+              <div>Organization</div>
+              <div>Plan</div>
+              <div>AI</div>
+              <div className="text-right">Users</div>
+              <div className="text-right">Buildings</div>
+              <div>Primary admin</div>
+              <div>Status</div>
+              <div />
+            </div>
+            {filtered.map((org) => (
+              <div
+                key={org.id}
+                role="button"
+                tabIndex={0}
+                onClick={() => onOpen(org.id)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    onOpen(org.id);
+                  }
+                }}
+                className="w-full grid grid-cols-[2fr_1fr_0.75fr_0.75fr_0.75fr_1.5fr_0.9fr_auto] items-center gap-4 px-5 py-3 border-b border-slate-100 last:border-b-0 text-left hover:bg-slate-50 focus:bg-slate-50 focus:outline-none transition-colors cursor-pointer"
+              >
+                <div className="flex items-center gap-3 min-w-0">
+                  <OrgLogoTile
+                    shortCode={org.shortCode}
+                    seedColor={org.seedColor}
+                  />
+                  <div className="min-w-0">
+                    <div className="text-sm font-semibold text-slate-900 truncate">
+                      {org.name}
+                    </div>
+                    <div className="text-xs text-slate-500 font-mono">
+                      {org.state} · created {org.createdAt}
+                    </div>
+                  </div>
                 </div>
-                <div className="text-xs text-slate-500 font-mono">
-                  {org.state} · created {org.createdAt}
+                <div>
+                  <Badge
+                    color={
+                      org.plan === 'full'
+                        ? 'indigo'
+                        : org.plan === 'expanded'
+                          ? 'cyan'
+                          : 'slate'
+                    }
+                  >
+                    {PLAN_LABEL[org.plan]}
+                  </Badge>
+                </div>
+                <div>
+                  <span
+                    className={`inline-flex items-center gap-1.5 text-xs font-semibold ${
+                      org.aiEnabled ? 'text-emerald-700' : 'text-slate-500'
+                    }`}
+                  >
+                    <span
+                      className={`h-1.5 w-1.5 rounded-full ${
+                        org.aiEnabled ? 'bg-emerald-500' : 'bg-slate-400'
+                      }`}
+                      aria-hidden
+                    />
+                    {org.aiEnabled ? 'On' : 'Off'}
+                  </span>
+                </div>
+                <div className="text-right text-sm font-mono text-slate-700">
+                  {org.users}
+                </div>
+                <div className="text-right text-sm font-mono text-slate-700">
+                  {org.buildings}
+                </div>
+                <div className="text-sm text-slate-700 font-mono truncate">
+                  {org.primaryAdminEmail}
+                </div>
+                <div>
+                  <StatusPill
+                    status={org.status === 'archived' ? 'inactive' : org.status}
+                  />
+                </div>
+                <div
+                  onClick={(e) => e.stopPropagation()}
+                  onKeyDown={(e) => e.stopPropagation()}
+                  role="none"
+                >
+                  <RowMenu
+                    items={[
+                      { label: 'Open', onClick: () => onOpen(org.id) },
+                      {
+                        label: 'Edit details',
+                        onClick: () => onOpen(org.id),
+                      },
+                      {
+                        label: 'Archive',
+                        onClick: () =>
+                          console.warn('[AllOrganizations] archive', org.id),
+                        danger: true,
+                      },
+                    ]}
+                  />
                 </div>
               </div>
-            </div>
-            <div>
-              <Badge
-                color={
-                  org.plan === 'full'
-                    ? 'indigo'
-                    : org.plan === 'expanded'
-                      ? 'cyan'
-                      : 'slate'
-                }
-              >
-                {PLAN_LABEL[org.plan]}
-              </Badge>
-            </div>
-            <div>
-              <span
-                className={`inline-flex items-center gap-1.5 text-xs font-semibold ${
-                  org.aiEnabled ? 'text-emerald-700' : 'text-slate-500'
-                }`}
-              >
-                <span
-                  className={`h-1.5 w-1.5 rounded-full ${
-                    org.aiEnabled ? 'bg-emerald-500' : 'bg-slate-400'
-                  }`}
-                  aria-hidden
-                />
-                {org.aiEnabled ? 'On' : 'Off'}
-              </span>
-            </div>
-            <div className="text-right text-sm font-mono text-slate-700">
-              {org.users}
-            </div>
-            <div className="text-right text-sm font-mono text-slate-700">
-              {org.buildings}
-            </div>
-            <div className="text-sm text-slate-700 font-mono truncate">
-              {org.primaryAdminEmail}
-            </div>
-            <div>
-              <StatusPill
-                status={org.status === 'archived' ? 'inactive' : org.status}
-              />
-            </div>
-            <div
-              onClick={(e) => e.stopPropagation()}
-              onKeyDown={(e) => e.stopPropagation()}
-              role="none"
-            >
-              <RowMenu
-                items={[
-                  { label: 'Open', onClick: () => onOpen(org.id) },
-                  {
-                    label: 'Edit details',
-                    onClick: () => onOpen(org.id),
-                  },
-                  {
-                    label: 'Archive',
-                    onClick: () =>
-                      console.warn('[AllOrganizations] archive', org.id),
-                    danger: true,
-                  },
-                ]}
-              />
-            </div>
+            ))}
+            {filtered.length === 0 && (
+              <div className="px-5 py-10 text-center text-sm text-slate-500">
+                No organizations match your filters.
+              </div>
+            )}
           </div>
-        ))}
-        {filtered.length === 0 && (
-          <div className="px-5 py-10 text-center text-sm text-slate-500">
-            No organizations match your filters.
-          </div>
-        )}
+        </div>
       </div>
 
       <CreateOrgModal
@@ -282,7 +286,7 @@ const CreateOrgModal: React.FC<{
             autoFocus
           />
         </Field>
-        <div className="grid grid-cols-2 gap-4">
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
           <Field label="Short code" hint="2-4 letters, used in avatars">
             <Input
               value={shortCode}

--- a/components/admin/Organization/views/BuildingsView.tsx
+++ b/components/admin/Organization/views/BuildingsView.tsx
@@ -104,72 +104,78 @@ export const BuildingsView: React.FC<Props> = ({
         />
       ) : view === 'list' ? (
         <div className="bg-white rounded-xl border border-slate-200 shadow-[0_1px_2px_rgba(29,42,93,.06),0_1px_3px_rgba(29,42,93,.08)] overflow-hidden">
-          <div className="grid grid-cols-[2fr_1fr_2fr_0.8fr_0.8fr_auto] gap-4 px-5 py-3 border-b border-slate-200 text-[11px] font-semibold uppercase tracking-wide text-slate-500">
-            <div>Building</div>
-            <div>Type</div>
-            <div>Address</div>
-            <div>Grades</div>
-            <div className="text-right">Users</div>
-            <div />
-          </div>
-          {visibleBuildings.map((b) => (
-            <div
-              key={b.id}
-              className="grid grid-cols-[2fr_1fr_2fr_0.8fr_0.8fr_auto] items-center gap-4 px-5 py-3 border-b border-slate-100 last:border-b-0 hover:bg-slate-50 transition-colors"
-            >
-              <div className="flex items-center gap-3 min-w-0">
-                <div className="h-9 w-9 rounded-lg bg-brand-blue-lighter text-brand-blue-dark flex items-center justify-center shrink-0">
-                  <School size={16} />
-                </div>
-                <div className="min-w-0">
-                  <div className="text-sm font-semibold text-slate-900 truncate">
-                    {b.name}
-                  </div>
-                  {b.adminEmails.length > 0 && (
-                    <div className="flex items-center gap-1 mt-0.5">
-                      <div className="flex -space-x-1">
-                        {b.adminEmails.slice(0, 3).map((e) => (
-                          <Avatar key={e} name={e} size="sm" />
-                        ))}
+          <div className="overflow-x-auto">
+            <div className="min-w-[660px]">
+              <div className="grid grid-cols-[2fr_1fr_2fr_0.8fr_0.8fr_auto] gap-4 px-5 py-3 border-b border-slate-200 text-[11px] font-semibold uppercase tracking-wide text-slate-500">
+                <div>Building</div>
+                <div>Type</div>
+                <div>Address</div>
+                <div>Grades</div>
+                <div className="text-right">Users</div>
+                <div />
+              </div>
+              {visibleBuildings.map((b) => (
+                <div
+                  key={b.id}
+                  className="grid grid-cols-[2fr_1fr_2fr_0.8fr_0.8fr_auto] items-center gap-4 px-5 py-3 border-b border-slate-100 last:border-b-0 hover:bg-slate-50 transition-colors"
+                >
+                  <div className="flex items-center gap-3 min-w-0">
+                    <div className="h-9 w-9 rounded-lg bg-brand-blue-lighter text-brand-blue-dark flex items-center justify-center shrink-0">
+                      <School size={16} />
+                    </div>
+                    <div className="min-w-0">
+                      <div className="text-sm font-semibold text-slate-900 truncate">
+                        {b.name}
                       </div>
-                      {b.adminEmails.length > 3 && (
-                        <span className="text-xs text-slate-500 ml-1">
-                          +{b.adminEmails.length - 3}
-                        </span>
+                      {b.adminEmails.length > 0 && (
+                        <div className="flex items-center gap-1 mt-0.5">
+                          <div className="flex -space-x-1">
+                            {b.adminEmails.slice(0, 3).map((e) => (
+                              <Avatar key={e} name={e} size="sm" />
+                            ))}
+                          </div>
+                          {b.adminEmails.length > 3 && (
+                            <span className="text-xs text-slate-500 ml-1">
+                              +{b.adminEmails.length - 3}
+                            </span>
+                          )}
+                        </div>
                       )}
                     </div>
-                  )}
+                  </div>
+                  <div>
+                    <Badge color={TYPE_META[b.type].color}>
+                      {TYPE_META[b.type].label}
+                    </Badge>
+                  </div>
+                  <div className="text-sm text-slate-600 truncate">
+                    {b.address}
+                  </div>
+                  <div>
+                    <Badge color="slate">{b.grades}</Badge>
+                  </div>
+                  <div className="text-right text-sm font-mono text-slate-700">
+                    {b.users}
+                  </div>
+                  <RowMenu
+                    items={[
+                      {
+                        label: 'Edit',
+                        onClick: () => setEditingId(b.id),
+                        disabled: !canEdit(b.id),
+                      },
+                      {
+                        label: 'Archive',
+                        onClick: () => onRemove(b.id),
+                        danger: true,
+                        disabled: !canRemove(b.id),
+                      },
+                    ]}
+                  />
                 </div>
-              </div>
-              <div>
-                <Badge color={TYPE_META[b.type].color}>
-                  {TYPE_META[b.type].label}
-                </Badge>
-              </div>
-              <div className="text-sm text-slate-600 truncate">{b.address}</div>
-              <div>
-                <Badge color="slate">{b.grades}</Badge>
-              </div>
-              <div className="text-right text-sm font-mono text-slate-700">
-                {b.users}
-              </div>
-              <RowMenu
-                items={[
-                  {
-                    label: 'Edit',
-                    onClick: () => setEditingId(b.id),
-                    disabled: !canEdit(b.id),
-                  },
-                  {
-                    label: 'Archive',
-                    onClick: () => onRemove(b.id),
-                    danger: true,
-                    disabled: !canRemove(b.id),
-                  },
-                ]}
-              />
+              ))}
             </div>
-          ))}
+          </div>
         </div>
       ) : (
         <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">
@@ -305,7 +311,7 @@ const BuildingModalInner: React.FC<BuildingModalProps> = ({
             autoFocus
           />
         </Field>
-        <div className="grid grid-cols-2 gap-4">
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
           <Field label="Type">
             <Select
               value={type}

--- a/components/admin/Organization/views/DomainsView.tsx
+++ b/components/admin/Organization/views/DomainsView.tsx
@@ -126,84 +126,91 @@ export const DomainsView: React.FC<Props> = ({ domains, onAdd, onRemove }) => {
           </div>
 
           <div className="bg-white rounded-xl border border-slate-200 shadow-[0_1px_2px_rgba(29,42,93,.06),0_1px_3px_rgba(29,42,93,.08)] overflow-hidden">
-            <div className="grid grid-cols-[2fr_1.2fr_0.9fr_0.6fr_0.9fr_auto] gap-4 px-5 py-3 border-b border-slate-200 text-[11px] font-semibold uppercase tracking-wide text-slate-500">
-              <div>Domain</div>
-              <div>Auth method</div>
-              <div>Status</div>
-              <div className="text-right">Users</div>
-              <div>Added</div>
-              <div />
-            </div>
-            {domains.map((d) => {
-              const roleMeta = DOMAIN_ROLE_META[d.role];
-              return (
-                <div
-                  key={d.id}
-                  className="grid grid-cols-[2fr_1.2fr_0.9fr_0.6fr_0.9fr_auto] items-center gap-4 px-5 py-3 border-b border-slate-100 last:border-b-0 hover:bg-slate-50 transition-colors"
-                >
-                  <div className="flex items-center gap-3 min-w-0">
-                    <div
-                      className={`h-8 w-8 rounded-lg flex items-center justify-center shrink-0 ${
-                        d.role === 'student'
-                          ? 'bg-sky-50 text-sky-600'
-                          : 'bg-slate-100 text-slate-500'
-                      }`}
-                    >
-                      {d.role === 'student' ? (
-                        <GraduationCap size={16} />
-                      ) : (
-                        <Globe size={16} />
-                      )}
-                    </div>
-                    <div className="min-w-0">
-                      <div className="text-sm font-mono text-slate-800 truncate">
-                        {d.domain}
-                      </div>
-                      <div className="mt-0.5">
-                        <Badge color={roleMeta.color}>{roleMeta.label}</Badge>
-                      </div>
-                    </div>
-                  </div>
-                  <div className="flex items-center gap-2 text-sm text-slate-700">
-                    {AUTH_ICON[d.authMethod]}
-                    {AUTH_LABEL[d.authMethod]}
-                  </div>
-                  <div>
-                    <StatusPill status={d.status} />
-                  </div>
-                  <div className="text-right text-sm font-mono text-slate-700">
-                    {d.users.toLocaleString()}
-                  </div>
-                  <div className="text-sm font-mono text-slate-500">
-                    {d.addedAt}
-                  </div>
-                  <RowMenu
-                    items={[
-                      {
-                        label: 'Edit',
-                        onClick: () => console.warn('[Domains] edit', d.id),
-                      },
-                      {
-                        label: 'Set as primary',
-                        onClick: () =>
-                          console.warn('[Domains] set primary', d.id),
-                        disabled: d.role === 'primary',
-                      },
-                      {
-                        label: 'Resend verification',
-                        onClick: () => console.warn('[Domains] resend', d.id),
-                        disabled: d.status !== 'pending',
-                      },
-                      {
-                        label: 'Remove',
-                        onClick: () => onRemove(d.id),
-                        danger: true,
-                      },
-                    ]}
-                  />
+            <div className="overflow-x-auto">
+              <div className="min-w-[640px]">
+                <div className="grid grid-cols-[2fr_1.2fr_0.9fr_0.6fr_0.9fr_auto] gap-4 px-5 py-3 border-b border-slate-200 text-[11px] font-semibold uppercase tracking-wide text-slate-500">
+                  <div>Domain</div>
+                  <div>Auth method</div>
+                  <div>Status</div>
+                  <div className="text-right">Users</div>
+                  <div>Added</div>
+                  <div />
                 </div>
-              );
-            })}
+                {domains.map((d) => {
+                  const roleMeta = DOMAIN_ROLE_META[d.role];
+                  return (
+                    <div
+                      key={d.id}
+                      className="grid grid-cols-[2fr_1.2fr_0.9fr_0.6fr_0.9fr_auto] items-center gap-4 px-5 py-3 border-b border-slate-100 last:border-b-0 hover:bg-slate-50 transition-colors min-w-0"
+                    >
+                      <div className="flex items-center gap-3 min-w-0">
+                        <div
+                          className={`h-8 w-8 rounded-lg flex items-center justify-center shrink-0 ${
+                            d.role === 'student'
+                              ? 'bg-sky-50 text-sky-600'
+                              : 'bg-slate-100 text-slate-500'
+                          }`}
+                        >
+                          {d.role === 'student' ? (
+                            <GraduationCap size={16} />
+                          ) : (
+                            <Globe size={16} />
+                          )}
+                        </div>
+                        <div className="min-w-0">
+                          <div className="text-sm font-mono text-slate-800 truncate">
+                            {d.domain}
+                          </div>
+                          <div className="mt-0.5">
+                            <Badge color={roleMeta.color}>
+                              {roleMeta.label}
+                            </Badge>
+                          </div>
+                        </div>
+                      </div>
+                      <div className="flex items-center gap-2 text-sm text-slate-700">
+                        {AUTH_ICON[d.authMethod]}
+                        {AUTH_LABEL[d.authMethod]}
+                      </div>
+                      <div>
+                        <StatusPill status={d.status} />
+                      </div>
+                      <div className="text-right text-sm font-mono text-slate-700">
+                        {d.users.toLocaleString()}
+                      </div>
+                      <div className="text-sm font-mono text-slate-500">
+                        {d.addedAt}
+                      </div>
+                      <RowMenu
+                        items={[
+                          {
+                            label: 'Edit',
+                            onClick: () => console.warn('[Domains] edit', d.id),
+                          },
+                          {
+                            label: 'Set as primary',
+                            onClick: () =>
+                              console.warn('[Domains] set primary', d.id),
+                            disabled: d.role === 'primary',
+                          },
+                          {
+                            label: 'Resend verification',
+                            onClick: () =>
+                              console.warn('[Domains] resend', d.id),
+                            disabled: d.status !== 'pending',
+                          },
+                          {
+                            label: 'Remove',
+                            onClick: () => onRemove(d.id),
+                            danger: true,
+                          },
+                        ]}
+                      />
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
           </div>
 
           <div className="mt-4 p-4 rounded-xl bg-brand-blue-lighter/50 border border-brand-blue-lighter text-sm text-slate-700 flex items-start gap-3">

--- a/components/admin/Organization/views/UsersView.tsx
+++ b/components/admin/Organization/views/UsersView.tsx
@@ -247,7 +247,7 @@ export const UsersView: React.FC<Props> = ({
       />
 
       <div className="flex flex-wrap items-center gap-3 mb-4">
-        <div className="relative w-80">
+        <div className="relative w-full sm:w-80">
           <Search
             size={16}
             className="absolute left-3 top-1/2 -translate-y-1/2 text-slate-400"
@@ -259,32 +259,34 @@ export const UsersView: React.FC<Props> = ({
             className="pl-9"
           />
         </div>
-        <Select
-          value={roleFilter}
-          onChange={(e) => changeRoleFilter(e.target.value)}
-          className="w-40"
-          aria-label="Filter by role"
-        >
-          <option value="">All roles</option>
-          {roles.map((r) => (
-            <option key={r.id} value={r.id}>
-              {r.name}
-            </option>
-          ))}
-        </Select>
-        <Select
-          value={buildingFilter}
-          onChange={(e) => changeBuildingFilter(e.target.value)}
-          className="w-48"
-          aria-label="Filter by building"
-        >
-          <option value="">All buildings</option>
-          {visibleBuildings.map((b) => (
-            <option key={b.id} value={b.id}>
-              {b.name}
-            </option>
-          ))}
-        </Select>
+        <div className="flex items-center gap-3 w-full sm:w-auto">
+          <Select
+            value={roleFilter}
+            onChange={(e) => changeRoleFilter(e.target.value)}
+            className="flex-1 sm:w-40"
+            aria-label="Filter by role"
+          >
+            <option value="">All roles</option>
+            {roles.map((r) => (
+              <option key={r.id} value={r.id}>
+                {r.name}
+              </option>
+            ))}
+          </Select>
+          <Select
+            value={buildingFilter}
+            onChange={(e) => changeBuildingFilter(e.target.value)}
+            className="flex-1 sm:w-48"
+            aria-label="Filter by building"
+          >
+            <option value="">All buildings</option>
+            {visibleBuildings.map((b) => (
+              <option key={b.id} value={b.id}>
+                {b.name}
+              </option>
+            ))}
+          </Select>
+        </div>
         <Segmented
           value={statusFilter}
           onChange={changeStatusFilter}
@@ -296,11 +298,11 @@ export const UsersView: React.FC<Props> = ({
           ]}
           ariaLabel="Status filter"
         />
-        <div className="ml-auto">
+        <div className="sm:ml-auto">
           <Select
             value={sort}
             onChange={(e) => setSort(e.target.value as SortKey)}
-            className="w-48"
+            className="w-full sm:w-48"
             aria-label="Sort"
           >
             <option value="name_asc">Name A-Z</option>
@@ -312,7 +314,7 @@ export const UsersView: React.FC<Props> = ({
       </div>
 
       {selected.size > 0 && (
-        <div className="sticky top-0 z-dropdown mb-3 bg-slate-900 text-white rounded-xl px-4 py-2.5 flex items-center gap-3 shadow-[0_10px_15px_-3px_rgba(29,42,93,.25)]">
+        <div className="sticky top-0 z-dropdown mb-3 bg-slate-900 text-white rounded-xl px-4 py-2.5 flex flex-wrap items-center gap-x-3 gap-y-1.5 shadow-[0_10px_15px_-3px_rgba(29,42,93,.25)]">
           <span className="text-sm font-semibold">
             {selected.size} selected
           </span>
@@ -375,46 +377,50 @@ export const UsersView: React.FC<Props> = ({
         </div>
       )}
 
-      <div className="bg-white rounded-xl border border-slate-200 shadow-[0_1px_2px_rgba(29,42,93,.06)] overflow-visible">
-        <div className="grid grid-cols-[32px_2.2fr_1.3fr_1.5fr_1fr_1fr_auto] items-center gap-4 px-5 py-3 border-b border-slate-200 text-[11px] font-semibold uppercase tracking-wide text-slate-500">
-          <div>
-            <Checkbox
-              aria-label="Select all"
-              checked={allChecked}
-              onChange={() => {
-                if (allChecked) setSelected(new Set());
-                else setSelected(new Set(filtered.map((u) => u.id)));
-              }}
-            />
+      <div className="bg-white rounded-xl border border-slate-200 shadow-[0_1px_2px_rgba(29,42,93,.06)] overflow-hidden">
+        <div className="overflow-x-auto">
+          <div className="min-w-[740px]">
+            <div className="grid grid-cols-[32px_2.2fr_1.3fr_1.5fr_1fr_1fr_auto] items-center gap-4 px-5 py-3 border-b border-slate-200 text-[11px] font-semibold uppercase tracking-wide text-slate-500">
+              <div>
+                <Checkbox
+                  aria-label="Select all"
+                  checked={allChecked}
+                  onChange={() => {
+                    if (allChecked) setSelected(new Set());
+                    else setSelected(new Set(filtered.map((u) => u.id)));
+                  }}
+                />
+              </div>
+              <div>Name</div>
+              <div>Role</div>
+              <div>Buildings</div>
+              <div>Status</div>
+              <div>Last active</div>
+              <div />
+            </div>
+            {filtered.map((u) => {
+              const editable = canEditUser(u);
+              return (
+                <UserRow
+                  key={u.id}
+                  user={u}
+                  roles={roles}
+                  buildings={visibleBuildings}
+                  selected={selected.has(u.id)}
+                  onToggle={() => toggleRow(u.id)}
+                  editable={editable}
+                  onUpdate={(patch) => onUpdate(u.id, patch)}
+                  onDelete={() => (editable ? onRemove([u.id]) : undefined)}
+                />
+              );
+            })}
+            {filtered.length === 0 && (
+              <div className="px-5 py-10 text-center text-sm text-slate-500">
+                No users match your filters.
+              </div>
+            )}
           </div>
-          <div>Name</div>
-          <div>Role</div>
-          <div>Buildings</div>
-          <div>Status</div>
-          <div>Last active</div>
-          <div />
         </div>
-        {filtered.map((u) => {
-          const editable = canEditUser(u);
-          return (
-            <UserRow
-              key={u.id}
-              user={u}
-              roles={roles}
-              buildings={visibleBuildings}
-              selected={selected.has(u.id)}
-              onToggle={() => toggleRow(u.id)}
-              editable={editable}
-              onUpdate={(patch) => onUpdate(u.id, patch)}
-              onDelete={() => (editable ? onRemove([u.id]) : undefined)}
-            />
-          );
-        })}
-        {filtered.length === 0 && (
-          <div className="px-5 py-10 text-center text-sm text-slate-500">
-            No users match your filters.
-          </div>
-        )}
       </div>
 
       <InviteModal
@@ -814,7 +820,7 @@ const InviteModal: React.FC<{
             ))}
           </div>
         )}
-        <div className="grid grid-cols-2 gap-4">
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
           <Field label="Role">
             <Select value={role} onChange={(e) => setRole(e.target.value)}>
               {roles.map((r) => (


### PR DESCRIPTION
## Summary

- **RowMenu → portal rendering**: Dropdown now renders via `createPortal` at a `fixed` position (same pattern as `CellPopover`), so it's never clipped by `overflow-x-auto` scroll containers or `overflow-hidden` card wrappers. Works correctly on both mobile and desktop.
- **ViewHeader → responsive wrap**: On mobile the action buttons stack below the title (`flex-col`); on `sm:` and up the existing side-by-side layout is restored.
- **Table lists → horizontal scroll**: All four multi-column grid tables (All Organizations, Domains, Buildings list, Users) are wrapped in `overflow-x-auto` + a `min-width` inner container. Headers, badges, chips, and row-action menus stay properly positioned on narrow screens. The desktop grid layout is untouched.
- **Users filter bar**: Search field is full-width on mobile; Role + Building selects share a row; Sort loses the hard `ml-auto` at mobile width.
- **Users selection bar**: `flex-wrap` added so bulk-action buttons wrap to a second line instead of overflowing off-screen.
- **Modal grids**: `grid-cols-2` → `grid-cols-1 sm:grid-cols-2` in the Create Org, Add Building, and Invite Users modals so form fields stack on phones.

## Files changed

- `components/admin/Organization/components/primitives.tsx`
- `components/admin/Organization/views/AllOrganizationsView.tsx`
- `components/admin/Organization/views/DomainsView.tsx`
- `components/admin/Organization/views/BuildingsView.tsx`
- `components/admin/Organization/views/UsersView.tsx`

## Test plan

- [ ] At 375px viewport, each Organization sub-page (All Orgs, Domains, Buildings, Users) scrolls horizontally through its table — no content cut off, all columns reachable
- [ ] RowMenu (3-dot) dropdowns open correctly in each table on both mobile and desktop
- [ ] ViewHeader action buttons wrap below the title on mobile; remain inline on desktop (≥640px)
- [ ] Users filter bar: search is full-width on mobile, role+building share a row, all controls are usable
- [ ] Users bulk-selection bar wraps gracefully when multiple actions are shown on mobile
- [ ] Modal forms (Create Org, Add Building, Invite Users) stack fields on mobile and show side-by-side on ≥640px
- [ ] Desktop layout (≥768px) is visually unchanged across all pages
- [ ] `pnpm run validate` passes clean

https://claude.ai/code/session_01AdidvMkgMs8prEQrb4rA2b