### PR TITLE
feat(org): super admin click-to-cycle editing for system role perms

### DIFF
--- a/components/admin/Organization/OrganizationPanel.tsx
+++ b/components/admin/Organization/OrganizationPanel.tsx
@@ -339,7 +339,11 @@ export const OrganizationPanel: React.FC = () => {
   };
   const handleSaveRoles = (working: RoleRecord[]) => {
     if (!writesEnabled) return comingSoon('Save roles');
-    run('Save roles', () => saveRoles(working), 'Roles saved');
+    run(
+      'Save roles',
+      () => saveRoles(working, { canEditSystemRoles: isSuperAdmin }),
+      'Roles saved'
+    );
   };
   const handleResetRoles = () => {
     if (!writesEnabled) return comingSoon('Reset roles');
@@ -692,6 +696,7 @@ export const OrganizationPanel: React.FC = () => {
                   roles={roles}
                   onSave={handleSaveRoles}
                   onReset={handleResetRoles}
+                  isSuperAdmin={isSuperAdmin}
                 />
               )}
               {effectiveSection === 'users' && (

--- a/components/admin/Organization/views/RolesView.tsx
+++ b/components/admin/Organization/views/RolesView.tsx
@@ -18,8 +18,6 @@ import { CAPABILITY_GROUPS } from '@/config/organizationCapabilities';
 import {
   Badge,
   Btn,
-  CellPopover,
-  PopoverOption,
   ViewHeader,
   Field,
   Input,
@@ -32,7 +30,21 @@ interface Props {
   roles: RoleRecord[];
   onSave: (roles: RoleRecord[]) => void;
   onReset: () => void;
+  /**
+   * Super admins can edit system role perms in place (rules allow perms-only
+   * updates on `system:true` docs). Non-super-admins still have to clone.
+   */
+  isSuperAdmin?: boolean;
 }
+
+// Click-to-cycle order used by every MatrixCell. Starting from an empty cell
+// the first click grants full access, the second scopes to building, and the
+// third clears it. Keeps the keyboard/mouse interaction identical.
+const CYCLE_NEXT: Record<CapabilityAccess, CapabilityAccess> = {
+  none: 'full',
+  full: 'building',
+  building: 'none',
+};
 
 const ACCESS_META: Record<
   CapabilityAccess,
@@ -55,7 +67,12 @@ const ACCESS_META: Record<
   },
 };
 
-export const RolesView: React.FC<Props> = ({ roles, onSave, onReset }) => {
+export const RolesView: React.FC<Props> = ({
+  roles,
+  onSave,
+  onReset,
+  isSuperAdmin = false,
+}) => {
   const [working, setWorking] = useState<RoleRecord[]>(roles);
   const [lastSyncedRoles, setLastSyncedRoles] = useState(roles);
   const [activeRoleId, setActiveRoleId] = useState<RoleId>(
@@ -110,7 +127,7 @@ export const RolesView: React.FC<Props> = ({ roles, onSave, onReset }) => {
     <div>
       <ViewHeader
         title="Roles & permissions"
-        blurb="Define what each role can do. Click any cell to pick Full, Own-building, or No access."
+        blurb="Define what each role can do. Click any cell to cycle through Full, Own-building, and No access."
         actions={
           <>
             <Btn
@@ -220,7 +237,7 @@ export const RolesView: React.FC<Props> = ({ roles, onSave, onReset }) => {
                             onChange={(v) =>
                               setCellValue(activeRole.id, cap.id, v)
                             }
-                            readOnly={activeRole.system}
+                            readOnly={activeRole.system && !isSuperAdmin}
                           />
                         </td>
                       </tr>
@@ -347,9 +364,6 @@ const MatrixCell: React.FC<{
   onChange: (v: CapabilityAccess) => void;
   readOnly?: boolean;
 }> = ({ value, onChange, readOnly }) => {
-  const [open, setOpen] = useState(false);
-  const triggerRef = useRef<HTMLButtonElement>(null);
-
   const content = (() => {
     if (value === 'full')
       return (
@@ -379,57 +393,17 @@ const MatrixCell: React.FC<{
     );
   }
 
+  const next = CYCLE_NEXT[value];
   return (
-    <div className="relative inline-block">
-      <button
-        ref={triggerRef}
-        type="button"
-        aria-haspopup="listbox"
-        aria-expanded={open}
-        aria-label={`Access: ${ACCESS_META[value].label}`}
-        onClick={() => setOpen((o) => !o)}
-        className="p-1 rounded-md hover:bg-slate-100 focus:outline-none focus-visible:ring-[3px] focus-visible:ring-brand-blue-primary/30"
-      >
-        {content}
-      </button>
-      <CellPopover
-        open={open}
-        onClose={() => setOpen(false)}
-        anchorRef={triggerRef}
-      >
-        {(['full', 'building', 'none'] as CapabilityAccess[]).map((v) => (
-          <PopoverOption
-            key={v}
-            onClick={() => {
-              onChange(v);
-              setOpen(false);
-            }}
-            selected={value === v}
-            label={ACCESS_META[v].label}
-            description={ACCESS_META[v].description}
-            icon={<AccessIcon value={v} />}
-          />
-        ))}
-      </CellPopover>
-    </div>
-  );
-};
-
-const AccessIcon: React.FC<{ value: CapabilityAccess }> = ({ value }) => {
-  if (value === 'full')
-    return (
-      <div className="h-5 w-5 rounded bg-emerald-500 text-white flex items-center justify-center">
-        <Check size={12} />
-      </div>
-    );
-  if (value === 'building')
-    return (
-      <div className="h-5 w-5 rounded bg-amber-400 text-white flex items-center justify-center">
-        <HomeIcon size={12} />
-      </div>
-    );
-  return (
-    <div className="h-5 w-5 rounded border-2 border-dashed border-slate-300" />
+    <button
+      type="button"
+      aria-label={`Access: ${ACCESS_META[value].label}. Click to set ${ACCESS_META[next].label}.`}
+      title={`${ACCESS_META[value].label} — click to set ${ACCESS_META[next].label}`}
+      onClick={() => onChange(next)}
+      className="p-1 rounded-md hover:bg-slate-100 focus:outline-none focus-visible:ring-[3px] focus-visible:ring-brand-blue-primary/30"
+    >
+      {content}
+    </button>
   );
 };
 

--- a/components/admin/Organization/views/RolesView.tsx
+++ b/components/admin/Organization/views/RolesView.tsx
@@ -127,7 +127,7 @@ export const RolesView: React.FC<Props> = ({
     <div>
       <ViewHeader
         title="Roles & permissions"
-        blurb="Define what each role can do. Click any cell to cycle through Full, Own-building, and No access."
+        blurb="Define what each role can do. Click editable cells to cycle through Full, Own-building, and No access."
         actions={
           <>
             <Btn
@@ -386,6 +386,8 @@ const MatrixCell: React.FC<{
     return (
       <div
         className="relative inline-block"
+        role="img"
+        aria-label={`${ACCESS_META[value].label} — locked (system role; clone to customize).`}
         title="System role — clone to customize."
       >
         {content}

--- a/firestore.rules
+++ b/firestore.rules
@@ -174,14 +174,27 @@ service cloud.firestore {
             'id', 'name', 'blurb', 'color', 'system', 'perms'
           ]);
         // Update whitelist keeps identity (id) and seed flag (system) pinned
-        // and blocks extensions beyond the known fields.
-        allow update: if (isSuperAdmin() || isDomainAdmin(orgId)) &&
-          resource.data.system != true &&
-          request.resource.data.system == resource.data.system &&
-          request.resource.data.id == resource.data.id &&
-          request.resource.data.diff(resource.data).affectedKeys().hasOnly([
-            'name', 'blurb', 'color', 'perms'
-          ]);
+        // and blocks extensions beyond the known fields. Super admins may
+        // additionally edit `perms` on system roles (still identity-pinned and
+        // `system:true` preserved) so they can tune capability defaults from
+        // the admin console; domain admins remain locked out of system docs.
+        allow update: if
+          (isSuperAdmin() &&
+           request.resource.data.system == resource.data.system &&
+           request.resource.data.id == resource.data.id &&
+           ((resource.data.system == true &&
+             request.resource.data.diff(resource.data).affectedKeys().hasOnly(['perms'])) ||
+            (resource.data.system != true &&
+             request.resource.data.diff(resource.data).affectedKeys().hasOnly([
+               'name', 'blurb', 'color', 'perms'
+             ])))) ||
+          (isDomainAdmin(orgId) &&
+           resource.data.system != true &&
+           request.resource.data.system == resource.data.system &&
+           request.resource.data.id == resource.data.id &&
+           request.resource.data.diff(resource.data).affectedKeys().hasOnly([
+             'name', 'blurb', 'color', 'perms'
+           ]));
         allow delete: if (isSuperAdmin() || isDomainAdmin(orgId)) &&
           resource.data.system != true;
       }

--- a/firestore.rules
+++ b/firestore.rules
@@ -160,9 +160,11 @@ service cloud.firestore {
 
       match /roles/{roleId} {
         allow read: if isOrgMember(orgId) || isSuperAdmin();
-        // System roles are immutable from clients — the migration script
-        // seeds them with `{ merge: true }` so the first write happens server
-        // side; every client mutation is refused if `system == true`.
+        // System roles are seeded by the migration script with `{ merge: true }`
+        // and are otherwise immutable from clients — every client mutation is
+        // refused if `system == true`, with one narrow exception: super admins
+        // may patch `perms` on system roles so they can tune capability
+        // defaults from the admin console (see the `update` branch below).
         // Client-created roles must carry canonical path identity, be
         // explicitly non-system, and stay within the supported schema so
         // clients can't attach unexpected fields.

--- a/hooks/useOrgRoles.test.ts
+++ b/hooks/useOrgRoles.test.ts
@@ -229,9 +229,10 @@ describe('useOrgRoles', () => {
 
   it('saveRoles skips system role update when perms are unchanged (even with canEditSystemRoles)', async () => {
     mockUseAuth.mockReturnValue({ user: { uid: 'u' } });
+    // Seed with two keys in a known insertion order.
     const seeded = {
       ...systemRole,
-      perms: { viewBoards: 'full' },
+      perms: { viewBoards: 'full', editBoards: 'building' },
     } as unknown as RoleRecord;
     seedRoles([seeded]);
 
@@ -240,11 +241,12 @@ describe('useOrgRoles', () => {
       expect(result.current.roles).toHaveLength(1);
     });
 
-    // Same perms, different key order — permsEqual should treat these as equal
-    // and skip the write.
+    // Same content, opposite insertion order — permsEqual must treat these as
+    // equal so we don't issue a no-op Firestore write just because the keys
+    // came back in a different order from the snapshot.
     const sameContent = {
       ...systemRole,
-      perms: { viewBoards: 'full' },
+      perms: { editBoards: 'building', viewBoards: 'full' },
     } as unknown as RoleRecord;
 
     await act(async () => {

--- a/hooks/useOrgRoles.test.ts
+++ b/hooks/useOrgRoles.test.ts
@@ -8,6 +8,7 @@ import {
   doc,
   onSnapshot,
   setDoc,
+  updateDoc,
 } from 'firebase/firestore';
 import type { RoleRecord } from '@/types/organization';
 
@@ -17,6 +18,7 @@ vi.mock('firebase/firestore', () => ({
   doc: vi.fn(),
   onSnapshot: vi.fn(),
   setDoc: vi.fn(),
+  updateDoc: vi.fn(),
 }));
 
 vi.mock('@/config/firebase', () => ({
@@ -53,6 +55,7 @@ describe('useOrgRoles', () => {
   const mockDoc = doc as Mock;
   const mockSetDoc = setDoc as Mock;
   const mockDeleteDoc = deleteDoc as Mock;
+  const mockUpdateDoc = updateDoc as Mock;
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -62,6 +65,7 @@ describe('useOrgRoles', () => {
     );
     mockSetDoc.mockResolvedValue(undefined);
     mockDeleteDoc.mockResolvedValue(undefined);
+    mockUpdateDoc.mockResolvedValue(undefined);
   });
 
   // Helper: seed the hook with a given roles snapshot and return the result
@@ -171,5 +175,84 @@ describe('useOrgRoles', () => {
     await expect(result.current.resetRoles()).rejects.toThrow(
       /No organization/
     );
+  });
+
+  it('saveRoles patches system role perms via updateDoc when canEditSystemRoles is true', async () => {
+    mockUseAuth.mockReturnValue({ user: { uid: 'u' } });
+    seedRoles([systemRole]);
+
+    const { result } = renderHook(() => useOrgRoles('orono'));
+    await waitFor(() => {
+      expect(result.current.roles).toHaveLength(1);
+    });
+
+    const edited = {
+      ...systemRole,
+      perms: { viewBoards: 'full' },
+    } as unknown as RoleRecord;
+
+    await act(async () => {
+      await result.current.saveRoles([edited], { canEditSystemRoles: true });
+    });
+
+    expect(mockUpdateDoc).toHaveBeenCalledTimes(1);
+    expect(mockUpdateDoc).toHaveBeenCalledWith(
+      'organizations/orono/roles/teacher',
+      { perms: { viewBoards: 'full' } }
+    );
+    // System roles must never go through setDoc (identity/seed fields would
+    // round-trip and the rules reject that).
+    expect(mockSetDoc).not.toHaveBeenCalled();
+  });
+
+  it('saveRoles does not touch system roles when canEditSystemRoles is false', async () => {
+    mockUseAuth.mockReturnValue({ user: { uid: 'u' } });
+    seedRoles([systemRole]);
+
+    const { result } = renderHook(() => useOrgRoles('orono'));
+    await waitFor(() => {
+      expect(result.current.roles).toHaveLength(1);
+    });
+
+    const edited = {
+      ...systemRole,
+      perms: { viewBoards: 'full' },
+    } as unknown as RoleRecord;
+
+    // Default options (no canEditSystemRoles) — domain admins hit this path.
+    await act(async () => {
+      await result.current.saveRoles([edited]);
+    });
+
+    expect(mockUpdateDoc).not.toHaveBeenCalled();
+  });
+
+  it('saveRoles skips system role update when perms are unchanged (even with canEditSystemRoles)', async () => {
+    mockUseAuth.mockReturnValue({ user: { uid: 'u' } });
+    const seeded = {
+      ...systemRole,
+      perms: { viewBoards: 'full' },
+    } as unknown as RoleRecord;
+    seedRoles([seeded]);
+
+    const { result } = renderHook(() => useOrgRoles('orono'));
+    await waitFor(() => {
+      expect(result.current.roles).toHaveLength(1);
+    });
+
+    // Same perms, different key order — permsEqual should treat these as equal
+    // and skip the write.
+    const sameContent = {
+      ...systemRole,
+      perms: { viewBoards: 'full' },
+    } as unknown as RoleRecord;
+
+    await act(async () => {
+      await result.current.saveRoles([sameContent], {
+        canEditSystemRoles: true,
+      });
+    });
+
+    expect(mockUpdateDoc).not.toHaveBeenCalled();
   });
 });

--- a/hooks/useOrgRoles.ts
+++ b/hooks/useOrgRoles.ts
@@ -9,18 +9,18 @@ import {
 } from 'firebase/firestore';
 import { db, isAuthBypass } from '@/config/firebase';
 import { useAuth } from '@/context/useAuth';
-import type { CapabilityAccess, RoleRecord } from '@/types/organization';
+import type { CapabilityId, RoleRecord } from '@/types/organization';
 
 // Key-by-key compare so we can't be tripped up by key-ordering differences
 // between a Firestore snapshot and the working state. Both sides are flat
-// string→enum maps.
+// CapabilityId→enum maps.
 const permsEqual = (
-  a: Record<string, CapabilityAccess> | undefined,
-  b: Record<string, CapabilityAccess> | undefined
+  a: RoleRecord['perms'] | undefined,
+  b: RoleRecord['perms'] | undefined
 ): boolean => {
-  const left = a ?? {};
-  const right = b ?? {};
-  const leftKeys = Object.keys(left);
+  const left = (a ?? {}) as RoleRecord['perms'];
+  const right = (b ?? {}) as RoleRecord['perms'];
+  const leftKeys = Object.keys(left) as CapabilityId[];
   if (leftKeys.length !== Object.keys(right).length) return false;
   for (const key of leftKeys) {
     if (left[key] !== right[key]) return false;

--- a/hooks/useOrgRoles.ts
+++ b/hooks/useOrgRoles.ts
@@ -5,6 +5,7 @@ import {
   doc,
   onSnapshot,
   setDoc,
+  updateDoc,
 } from 'firebase/firestore';
 import { db, isAuthBypass } from '@/config/firebase';
 import { useAuth } from '@/context/useAuth';
@@ -14,10 +15,12 @@ import type { RoleRecord } from '@/types/organization';
  * Subscribes to `/organizations/{orgId}/roles`. Reads allowed for org members
  * + super admins via Firestore rules.
  *
- * Writes: `saveRoles(working)` diffs the working set against live state and
- * upserts / deletes custom roles (system roles are never touched — the rules
- * block updates on `system:true`). `resetRoles()` deletes every custom role
- * (system roles remain as seeded by the migration script).
+ * Writes: `saveRoles(working, { canEditSystemRoles })` diffs the working set
+ * against live state, upserts / deletes custom roles, and — when the caller
+ * is a super admin — patches `perms` on system roles as well. Domain admins
+ * can't touch system roles; the rules still reject those writes.
+ * `resetRoles()` deletes every custom role (system roles remain as seeded by
+ * the migration script).
  */
 export const useOrgRoles = (orgId: string | null) => {
   const { user } = useAuth();
@@ -60,16 +63,18 @@ export const useOrgRoles = (orgId: string | null) => {
     return unsub;
   }, [shouldSubscribe, orgId]);
 
-  const saveRoles = async (workingRoles: RoleRecord[]): Promise<void> => {
+  const saveRoles = async (
+    workingRoles: RoleRecord[],
+    options: { canEditSystemRoles?: boolean } = {}
+  ): Promise<void> => {
     if (!orgId) {
       throw new Error('No organization selected.');
     }
 
     const workingIds = new Set(workingRoles.map((r) => r.id));
-    // Upsert every non-system role from the working set. System roles are
-    // intentionally skipped: rules reject `system:true` updates from clients,
-    // and the UI never mutates them (clone-to-customize creates a new role).
-    const upserts = workingRoles
+    // Custom roles: full setDoc upsert. The seed flag is always false because
+    // the rules reject any client write that tries to flip `system:true`.
+    const customUpserts = workingRoles
       .filter((r) => !r.system)
       .map((r) =>
         setDoc(doc(db, 'organizations', orgId, 'roles', r.id), {
@@ -82,12 +87,33 @@ export const useOrgRoles = (orgId: string | null) => {
         })
       );
 
+    // System roles: only super admins may edit them, and only `perms` is
+    // writable (rules enforce this). Diff against the live snapshot so we
+    // skip no-op writes and avoid touching identity fields.
+    const liveById = new Map(roles.map((r) => [r.id, r]));
+    const systemPatches = options.canEditSystemRoles
+      ? workingRoles
+          .filter((r) => r.system)
+          .filter((r) => {
+            const live = liveById.get(r.id);
+            if (!live) return false;
+            return (
+              JSON.stringify(live.perms ?? {}) !== JSON.stringify(r.perms ?? {})
+            );
+          })
+          .map((r) =>
+            updateDoc(doc(db, 'organizations', orgId, 'roles', r.id), {
+              perms: r.perms ?? {},
+            })
+          )
+      : [];
+
     // Delete custom roles that disappeared from the working set.
     const deletions = roles
       .filter((r) => !r.system && !workingIds.has(r.id))
       .map((r) => deleteDoc(doc(db, 'organizations', orgId, 'roles', r.id)));
 
-    await Promise.all([...upserts, ...deletions]);
+    await Promise.all([...customUpserts, ...systemPatches, ...deletions]);
   };
 
   const resetRoles = async (): Promise<void> => {

--- a/hooks/useOrgRoles.ts
+++ b/hooks/useOrgRoles.ts
@@ -9,7 +9,24 @@ import {
 } from 'firebase/firestore';
 import { db, isAuthBypass } from '@/config/firebase';
 import { useAuth } from '@/context/useAuth';
-import type { RoleRecord } from '@/types/organization';
+import type { CapabilityAccess, RoleRecord } from '@/types/organization';
+
+// Key-by-key compare so we can't be tripped up by key-ordering differences
+// between a Firestore snapshot and the working state. Both sides are flat
+// string→enum maps.
+const permsEqual = (
+  a: Record<string, CapabilityAccess> | undefined,
+  b: Record<string, CapabilityAccess> | undefined
+): boolean => {
+  const left = a ?? {};
+  const right = b ?? {};
+  const leftKeys = Object.keys(left);
+  if (leftKeys.length !== Object.keys(right).length) return false;
+  for (const key of leftKeys) {
+    if (left[key] !== right[key]) return false;
+  }
+  return true;
+};
 
 /**
  * Subscribes to `/organizations/{orgId}/roles`. Reads allowed for org members
@@ -97,9 +114,7 @@ export const useOrgRoles = (orgId: string | null) => {
           .filter((r) => {
             const live = liveById.get(r.id);
             if (!live) return false;
-            return (
-              JSON.stringify(live.perms ?? {}) !== JSON.stringify(r.perms ?? {})
-            );
+            return !permsEqual(live.perms, r.perms);
           })
           .map((r) =>
             updateDoc(doc(db, 'organizations', orgId, 'roles', r.id), {

--- a/tests/rules/firestore-rules-organizations.test.ts
+++ b/tests/rules/firestore-rules-organizations.test.ts
@@ -825,6 +825,39 @@ describe('organizations/roles — writes (system role protection)', () => {
       )
     );
   });
+
+  it('super admin can update perms on a system role', async () => {
+    await assertSucceeds(
+      updateDoc(doc(asSuper(), `organizations/${ORG_ID}/roles/domain_admin`), {
+        perms: { viewBoards: 'full' },
+      })
+    );
+  });
+
+  it('super admin cannot change non-perms fields on a system role', async () => {
+    await assertFails(
+      updateDoc(doc(asSuper(), `organizations/${ORG_ID}/roles/teacher`), {
+        name: 'Renamed system role',
+      })
+    );
+  });
+
+  it('super admin cannot flip system:true to false', async () => {
+    await assertFails(
+      updateDoc(doc(asSuper(), `organizations/${ORG_ID}/roles/teacher`), {
+        system: false,
+      })
+    );
+  });
+
+  it('super admin can still update name/perms on a custom role', async () => {
+    await assertSucceeds(
+      updateDoc(doc(asSuper(), `organizations/${ORG_ID}/roles/custom-coach`), {
+        name: 'Coach (super renamed)',
+        perms: { viewBoards: 'building' },
+      })
+    );
+  });
 });
 
 describe('organizations/members — writes', () => {


### PR DESCRIPTION
## Summary
- Super admins can now edit system role permissions directly from the Roles & permissions matrix. Previously those cells were hard-coded read-only and the only path to change defaults was cloning.
- Replaces the popover picker with a single click-to-cycle interaction: `none → full → building → none`. One click on an empty cell grants full access, again scopes it to the user's building, again clears it.
- Firestore rules now allow super-admin `perms`-only updates on `system:true` role docs. Identity (`id`) and the seed flag (`system`) stay pinned, and domain admins remain locked out of system roles.
- `useOrgRoles.saveRoles` takes a `{ canEditSystemRoles }` option and patches system role `perms` via `updateDoc` so writes stay within the rule whitelist; custom-role upserts/deletes are unchanged.
- Adds four Firestore rules tests covering the new super-admin behavior (perms allowed, non-perms fields rejected, system flag flip rejected, custom-role writes still succeed).

## Test plan
- [x] `pnpm run type-check`
- [x] `pnpm run lint`
- [x] `pnpm run format:check`
- [x] `pnpm run test` (1358 pass)
- [x] `pnpm run test:rules` (91 pass — includes 4 new super-admin role tests)
- [ ] Smoke test in preview: as a super admin, open Admin Settings → Organization → Roles & perms, click a Building-admin cell, confirm it cycles through green → yellow → empty and saves.
- [ ] Verify a domain admin still sees system role cells as read-only (clone-to-customize path).

https://claude.ai/code/session_01JF2UhGLzeXsQjivX8HBjBg