### PR TITLE
⚡ Parallelize user profile batch reads in adminAnalytics

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -379,6 +379,15 @@ service cloud.firestore {
       allow write: if isAdmin();
     }
 
+    // Mail queue consumed by the `firestore-send-email` Firebase extension.
+    // Writes happen server-side only (Admin SDK bypasses rules, so the
+    // `createOrganizationInvites` CF can still enqueue sends). Clients must
+    // never read or write — these docs contain pending recipient addresses
+    // and the extension's `delivery` subfield exposes SMTP response details.
+    match /mail/{mailId} {
+      allow read, write: if false;
+    }
+
     // Guided Learning
     match /users/{userId}/guided_learning/{setId} {
       allow read, write: if request.auth != null && request.auth.uid == userId;

--- a/functions/src/index.test.ts
+++ b/functions/src/index.test.ts
@@ -40,7 +40,7 @@ const toAsyncStream = (docs: MockDocInput[]) => ({
 
 const mockFirestore = {
   doc: vi.fn((path: string) => {
-    const parts = path.split("/");
+    const parts = path.split('/');
     const uid = parts[1];
     const user = mockFirestoreState.users.find((u) => u.id === uid);
     const docRef = {
@@ -64,7 +64,7 @@ const mockFirestore = {
       }),
     };
   }),
-  getAll: vi.fn((...refs: any[]) => {
+  getAll: vi.fn((...refs: { parent: { parent: { id: string } } }[]) => {
     return Promise.all(
       refs.map((ref) => {
         const uid = ref.parent.parent.id;

--- a/functions/src/index.test.ts
+++ b/functions/src/index.test.ts
@@ -39,6 +39,45 @@ const toAsyncStream = (docs: MockDocInput[]) => ({
 });
 
 const mockFirestore = {
+  doc: vi.fn((path: string) => {
+    const parts = path.split("/");
+    const uid = parts[1];
+    const user = mockFirestoreState.users.find((u) => u.id === uid);
+    const docRef = {
+      id: parts[parts.length - 1],
+      parent: {
+        id: parts[parts.length - 2],
+        parent: {
+          id: uid,
+        },
+      },
+    };
+    return {
+      ...docRef,
+      get: vi.fn(() => {
+        if (!user) return Promise.resolve({ exists: false, ref: docRef });
+        return Promise.resolve({
+          exists: true,
+          data: () => ({ selectedBuildings: user.data.buildings }),
+          ref: docRef,
+        });
+      }),
+    };
+  }),
+  getAll: vi.fn((...refs: any[]) => {
+    return Promise.all(
+      refs.map((ref) => {
+        const uid = ref.parent.parent.id;
+        const user = mockFirestoreState.users.find((u) => u.id === uid);
+        if (!user) return { exists: false, ref };
+        return {
+          exists: true,
+          data: () => ({ selectedBuildings: user.data.buildings }),
+          ref,
+        };
+      })
+    );
+  }),
   collection: vi.fn((name: string) => {
     if (name === 'admins') {
       return {
@@ -118,6 +157,7 @@ vi.mock('firebase-admin', () => {
 
   return {
     initializeApp: vi.fn(),
+    apps: [],
     firestore: firestoreFn,
     auth: vi.fn(() => ({
       verifyIdToken: vi.fn().mockResolvedValue({ email: 'admin@school.org' }),

--- a/functions/src/index.test.ts
+++ b/functions/src/index.test.ts
@@ -65,7 +65,7 @@ const mockFirestore = {
     };
   }),
   getAll: vi.fn((...refs: { parent: { parent: { id: string } } }[]) => {
-    return Promise.all(
+    return Promise.resolve(
       refs.map((ref) => {
         const uid = ref.parent.parent.id;
         const user = mockFirestoreState.users.find((u) => u.id === uid);

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -1984,7 +1984,7 @@ export const adminAnalytics = onRequest(
       const buildingsMap = new Map<string, string[]>();
       const authUids = Array.from(authUsersMap.keys());
       const PROFILE_BATCH = 500;
-      const profileBatches = [];
+      const profileBatches: string[][] = [];
       for (let i = 0; i < authUids.length; i += PROFILE_BATCH) {
         profileBatches.push(authUids.slice(i, i + PROFILE_BATCH));
       }

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -1984,12 +1984,21 @@ export const adminAnalytics = onRequest(
       const buildingsMap = new Map<string, string[]>();
       const authUids = Array.from(authUsersMap.keys());
       const PROFILE_BATCH = 500;
+      const profileBatches = [];
       for (let i = 0; i < authUids.length; i += PROFILE_BATCH) {
-        const batch = authUids.slice(i, i + PROFILE_BATCH);
-        const refs = batch.map((uid) =>
-          db.doc(`users/${uid}/userProfile/profile`)
-        );
-        const snapshots = await db.getAll(...refs);
+        profileBatches.push(authUids.slice(i, i + PROFILE_BATCH));
+      }
+
+      const profileSnapshots = await Promise.all(
+        profileBatches.map((batch) => {
+          const refs = batch.map((uid) =>
+            db.doc(`users/${uid}/userProfile/profile`)
+          );
+          return db.getAll(...refs);
+        })
+      );
+
+      for (const snapshots of profileSnapshots) {
         for (const snap of snapshots) {
           if (!snap.exists) continue;
           const data = snap.data();

--- a/functions/src/organizationInvites.test.ts
+++ b/functions/src/organizationInvites.test.ts
@@ -72,6 +72,9 @@ import {
   filterValidBuildingIds,
   buildClaimUrl,
   generateToken,
+  buildInvitationEmail,
+  escapeHtml,
+  formatRoleLabel,
   CLAIM_URL_ORIGIN,
   DEFAULT_EXPIRES_IN_DAYS,
   MAX_EXPIRES_IN_DAYS,
@@ -361,6 +364,96 @@ describe('generateToken', () => {
 describe('buildClaimUrl', () => {
   it('assembles the prod origin + /invite/:token', () => {
     expect(buildClaimUrl('abc123')).toBe(`${CLAIM_URL_ORIGIN}/invite/abc123`);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// escapeHtml / formatRoleLabel / buildInvitationEmail
+// ---------------------------------------------------------------------------
+
+describe('escapeHtml', () => {
+  it('escapes the five characters that break HTML context', () => {
+    expect(escapeHtml('<script>alert("x")</script>')).toBe(
+      '&lt;script&gt;alert(&quot;x&quot;)&lt;/script&gt;'
+    );
+    expect(escapeHtml("O'Brien & Sons")).toBe('O&#39;Brien &amp; Sons');
+  });
+
+  it('passes through ordinary text unchanged', () => {
+    expect(escapeHtml('Orono Schools')).toBe('Orono Schools');
+  });
+});
+
+describe('formatRoleLabel', () => {
+  it('title-cases snake_case role ids', () => {
+    expect(formatRoleLabel('super_admin')).toBe('Super Admin');
+    expect(formatRoleLabel('domain_admin')).toBe('Domain Admin');
+    expect(formatRoleLabel('teacher')).toBe('Teacher');
+  });
+});
+
+describe('buildInvitationEmail', () => {
+  const base = {
+    orgName: 'Orono Schools',
+    roleId: 'teacher',
+    claimUrl: 'https://spartboard.web.app/invite/tok-xyz',
+    expiresAt: '2026-05-03T12:00:00.000Z',
+  };
+
+  it('generates subject with org name', () => {
+    const { subject } = buildInvitationEmail(base);
+    expect(subject).toBe("You're invited to Orono Schools on SpartBoard");
+  });
+
+  it('text and html both carry the claim URL', () => {
+    const { text, html } = buildInvitationEmail(base);
+    expect(text).toContain('https://spartboard.web.app/invite/tok-xyz');
+    expect(html).toContain('https://spartboard.web.app/invite/tok-xyz');
+  });
+
+  it('renders role label in human form', () => {
+    const { text, html } = buildInvitationEmail({
+      ...base,
+      roleId: 'super_admin',
+    });
+    expect(text).toContain('as a Super Admin');
+    expect(html).toContain('Super Admin');
+  });
+
+  it('omits personal message block when none provided', () => {
+    const { text, html } = buildInvitationEmail(base);
+    expect(text).not.toContain('note from your administrator');
+    expect(html).not.toContain('border-left:3px solid');
+  });
+
+  it('renders personal message in both bodies when provided', () => {
+    const { text, html } = buildInvitationEmail({
+      ...base,
+      personalMessage: 'Welcome aboard!\nSee you Monday.',
+    });
+    expect(text).toContain('A note from your administrator:');
+    expect(text).toContain('  Welcome aboard!');
+    expect(text).toContain('  See you Monday.');
+    expect(html).toContain('Welcome aboard!<br>See you Monday.');
+  });
+
+  it('escapes HTML in org name, role, and personal message', () => {
+    const { html } = buildInvitationEmail({
+      ...base,
+      orgName: '<evil>Acme</evil>',
+      personalMessage: '<img src=x onerror=alert(1)>',
+    });
+    expect(html).not.toContain('<evil>');
+    expect(html).not.toContain('<img src=x');
+    expect(html).toContain('&lt;evil&gt;Acme&lt;/evil&gt;');
+    expect(html).toContain('&lt;img src=x onerror=alert(1)&gt;');
+  });
+
+  it('formats the expiry date in UTC', () => {
+    const { text, html } = buildInvitationEmail(base);
+    // 2026-05-03 → "May 3, 2026" in en-US long form
+    expect(text).toContain('May 3, 2026');
+    expect(html).toContain('May 3, 2026');
   });
 });
 

--- a/functions/src/organizationInvites.ts
+++ b/functions/src/organizationInvites.ts
@@ -333,8 +333,8 @@ export function escapeHtml(raw: string): string {
 /**
  * Turns a roleId into a human-friendly label for the invite email. We don't
  * load the org's role docs (one extra read per invite, marginal value for
- * the email body), so this is a best-effort transform: system roleIds get
- * Title Case + spaces; custom roleIds fall through as-is.
+ * the email body), so this is a best-effort transform. Behaves similarly for
+ * all roleIds: replaces separators with spaces and applies Title Case.
  */
 export function formatRoleLabel(roleId: string): string {
   return roleId

--- a/functions/src/organizationInvites.ts
+++ b/functions/src/organizationInvites.ts
@@ -110,6 +110,40 @@ export interface MemberRecord {
   addedBySource?: string;
 }
 
+// Minimal view of the org doc — only the fields the invite email needs.
+// Full shape lives in types/organization.ts (OrgRecord) but the functions
+// package doesn't share that tsconfig, so we repeat just what's used here.
+export interface OrgLite {
+  id: string;
+  name: string;
+}
+
+// Runtime config for the Trigger Email extension queue. Sourced from
+// `/global_permissions/invite-emails`. When `enabled: false` the CF skips
+// the /mail/{token} write entirely so no email goes out — invites still
+// mint and the copy-link flow keeps working. `from` and `replyTo` are
+// optional overrides; when unset, the extension's configured defaults apply.
+export interface InviteEmailConfig {
+  enabled: boolean;
+  from?: string;
+  replyTo?: string;
+}
+
+// Shape written to the `mail` collection that the `firestore-send-email`
+// Firebase extension watches. Keeping this local (not imported from the
+// extension package) avoids pulling a dependency the rest of the CFs
+// don't need.
+export interface MailDoc {
+  to: string[];
+  from?: string;
+  replyTo?: string;
+  message: {
+    subject: string;
+    text: string;
+    html: string;
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
@@ -278,6 +312,141 @@ export function generateToken(): string {
 /** Builds the user-facing claim URL for a given token. */
 export function buildClaimUrl(token: string): string {
   return `${CLAIM_URL_ORIGIN}/invite/${token}`;
+}
+
+/**
+ * Minimal HTML-escape for user-supplied strings interpolated into the
+ * invitation email body. We only interpolate: org name, role label, admin's
+ * personal message, and expiry date. Inviters are trusted org admins but
+ * the invitee's mail client renders this as HTML, so any `<` / `>` / `&` /
+ * `"` in those fields must not become live markup.
+ */
+export function escapeHtml(raw: string): string {
+  return raw
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+/**
+ * Turns a roleId into a human-friendly label for the invite email. We don't
+ * load the org's role docs (one extra read per invite, marginal value for
+ * the email body), so this is a best-effort transform: system roleIds get
+ * Title Case + spaces; custom roleIds fall through as-is.
+ */
+export function formatRoleLabel(roleId: string): string {
+  return roleId
+    .replace(/[_-]+/g, ' ')
+    .replace(/\b\w/g, (c) => c.toUpperCase())
+    .trim();
+}
+
+/**
+ * Builds the invitation email body. Pure — no I/O, no side effects. The
+ * returned `{subject, text, html}` is written straight into the `mail`
+ * collection doc that the Trigger Email extension picks up.
+ *
+ * Design notes:
+ *   - HTML body is a single-column table layout (the only thing that
+ *     renders consistently across Gmail/Outlook/Apple Mail). No external
+ *     CSS, no web fonts — inline styles only.
+ *   - The text body is the authoritative plaintext fallback. Spam filters
+ *     weight the text/html similarity, so the plaintext carries the same
+ *     claim URL and call-to-action, not a "view in browser" stub.
+ *   - `personalMessage` from the admin is rendered inside a left-border
+ *     blockquote so it reads as "the admin's own words" rather than
+ *     platform boilerplate.
+ *   - `expiresAt` is shown in the invitee's local time would be ideal, but
+ *     the CF has no access to their TZ; we show UTC with the date first
+ *     ("April 27, 2026") which reads naturally in any locale.
+ */
+export function buildInvitationEmail(opts: {
+  orgName: string;
+  roleId: string;
+  claimUrl: string;
+  expiresAt: string;
+  personalMessage?: string;
+}): { subject: string; text: string; html: string } {
+  const { orgName, roleId, claimUrl, expiresAt, personalMessage } = opts;
+  const roleLabel = formatRoleLabel(roleId);
+  const expiryDate = new Date(expiresAt);
+  const expiryFormatted = expiryDate.toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+    timeZone: 'UTC',
+  });
+
+  const subject = `You're invited to ${orgName} on SpartBoard`;
+
+  const textLines = [
+    `You've been invited to join ${orgName} on SpartBoard as a ${roleLabel}.`,
+    '',
+  ];
+  if (personalMessage && personalMessage.trim()) {
+    textLines.push('A note from your administrator:');
+    for (const line of personalMessage.trim().split('\n')) {
+      textLines.push(`  ${line}`);
+    }
+    textLines.push('');
+  }
+  textLines.push(
+    'Accept your invitation:',
+    claimUrl,
+    '',
+    `This invitation expires on ${expiryFormatted} (UTC).`,
+    '',
+    "If you weren't expecting this email, you can safely ignore it."
+  );
+  const text = textLines.join('\n');
+
+  const safeOrg = escapeHtml(orgName);
+  const safeRole = escapeHtml(roleLabel);
+  const safeExpiry = escapeHtml(expiryFormatted);
+  const safeUrl = escapeHtml(claimUrl);
+  const messageBlock =
+    personalMessage && personalMessage.trim()
+      ? `
+        <tr><td style="padding:0 0 16px 0;">
+          <div style="border-left:3px solid #2d3f89;padding:8px 12px;color:#334155;font-style:italic;background:#f8fafc;">
+            ${escapeHtml(personalMessage.trim()).replace(/\n/g, '<br>')}
+          </div>
+        </td></tr>`
+      : '';
+
+  const html = `<!doctype html>
+<html>
+  <body style="margin:0;padding:0;background:#f1f5f9;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;color:#0f172a;">
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background:#f1f5f9;padding:24px 0;">
+      <tr><td align="center">
+        <table role="presentation" width="560" cellpadding="0" cellspacing="0" style="max-width:560px;background:#ffffff;border-radius:12px;padding:32px;">
+          <tr><td style="padding:0 0 16px 0;">
+            <div style="font-size:20px;font-weight:600;color:#1d2a5d;">You're invited to ${safeOrg}</div>
+          </td></tr>
+          <tr><td style="padding:0 0 16px 0;color:#334155;font-size:15px;line-height:1.5;">
+            You've been invited to join <strong>${safeOrg}</strong> on SpartBoard as a <strong>${safeRole}</strong>.
+          </td></tr>
+          ${messageBlock}
+          <tr><td style="padding:16px 0;">
+            <a href="${safeUrl}" style="display:inline-block;background:#2d3f89;color:#ffffff;text-decoration:none;padding:12px 20px;border-radius:8px;font-weight:600;font-size:15px;">Accept invitation</a>
+          </td></tr>
+          <tr><td style="padding:16px 0 0 0;color:#64748b;font-size:13px;line-height:1.5;">
+            This invitation expires on <strong>${safeExpiry}</strong> (UTC).<br>
+            If the button doesn't work, paste this link into your browser:<br>
+            <span style="word-break:break-all;color:#2d3f89;">${safeUrl}</span>
+          </td></tr>
+          <tr><td style="padding:24px 0 0 0;border-top:1px solid #e2e8f0;color:#94a3b8;font-size:12px;line-height:1.5;">
+            If you weren't expecting this email, you can safely ignore it.
+          </td></tr>
+        </table>
+      </td></tr>
+    </table>
+  </body>
+</html>`;
+
+  return { subject, text, html };
 }
 
 /**
@@ -461,16 +630,50 @@ async function assertCallerIsOrgAdmin(
   }
 }
 
-/** Validates that `/organizations/{orgId}` exists. */
-async function assertOrgExists(
+/**
+ * Loads the org doc and returns a minimal view (`OrgLite`) containing the
+ * fields the invite flow needs. Throws `not-found` if the org doesn't
+ * exist. Replaces the earlier `assertOrgExists` — we need the org's display
+ * name for the invite email anyway, so folding the read into one call
+ * avoids a second round-trip.
+ */
+async function loadOrg(
   db: admin.firestore.Firestore,
   orgId: string
-): Promise<void> {
+): Promise<OrgLite> {
   const orgRef = db.collection('organizations').doc(orgId);
   const snap = await orgRef.get();
   if (!snap.exists) {
     throw new HttpsError('not-found', `Organization '${orgId}' not found.`);
   }
+  const data = snap.data() ?? {};
+  // Fall back to the orgId if `name` isn't set — old seed docs from Phase 1
+  // may predate the field. The email subject becomes "You're invited to
+  // orono on SpartBoard", which is ugly but doesn't break the flow.
+  const name = typeof data.name === 'string' && data.name ? data.name : orgId;
+  return { id: orgId, name };
+}
+
+/**
+ * Reads the invite-email kill switch from `/global_permissions/invite-emails`.
+ * Missing doc / missing `enabled` field defaults to `false` so email never
+ * sends accidentally — we have to opt-in explicitly after the extension is
+ * installed and a smoke-test send has landed.
+ */
+async function loadInviteEmailConfig(
+  db: admin.firestore.Firestore
+): Promise<InviteEmailConfig> {
+  const snap = await db
+    .collection('global_permissions')
+    .doc('invite-emails')
+    .get();
+  if (!snap.exists) return { enabled: false };
+  const data = snap.data() ?? {};
+  return {
+    enabled: data.enabled === true,
+    from: typeof data.from === 'string' ? data.from : undefined,
+    replyTo: typeof data.replyTo === 'string' ? data.replyTo : undefined,
+  };
 }
 
 /** Returns the set of valid role ids for the org. */
@@ -557,11 +760,12 @@ export const createOrganizationInvites = onCall(
     const db = admin.firestore();
 
     // Authorization & existence checks happen serially (cheap reads, fail fast).
-    await assertOrgExists(db, payload.orgId);
+    const org = await loadOrg(db, payload.orgId);
     await assertCallerIsOrgAdmin(db, payload.orgId, callerEmailLower);
 
     const validRoleIds = await loadRoleIds(db, payload.orgId);
     const validBuildingIds = await loadBuildingIds(db, payload.orgId);
+    const emailConfig = await loadInviteEmailConfig(db);
 
     const results: CreateInviteResult[] = [];
     const errors: CreateInviteError[] = [...perEntryErrors];
@@ -598,9 +802,12 @@ export const createOrganizationInvites = onCall(
       try {
         const result = await writeInvitation(db, {
           orgId: payload.orgId,
+          orgName: org.name,
           invite: scopedInvite,
           expiresInDays: payload.expiresInDays,
           issuedBy: callerUid,
+          personalMessage: payload.message,
+          emailConfig,
         });
         results.push(result);
       } catch (err) {
@@ -627,12 +834,23 @@ async function writeInvitation(
   db: admin.firestore.Firestore,
   opts: {
     orgId: string;
+    orgName: string;
     invite: NormalizedInvite;
     expiresInDays: number;
     issuedBy: string;
+    personalMessage?: string;
+    emailConfig: InviteEmailConfig;
   }
 ): Promise<CreateInviteResult> {
-  const { orgId, invite, expiresInDays, issuedBy } = opts;
+  const {
+    orgId,
+    orgName,
+    invite,
+    expiresInDays,
+    issuedBy,
+    personalMessage,
+    emailConfig,
+  } = opts;
   const now = new Date();
 
   const memberRef = db
@@ -647,6 +865,10 @@ async function writeInvitation(
     .doc(orgId)
     .collection('invitations')
     .doc(token);
+  // Mail doc id = invitation token. Ties the send 1:1 to the invite (so a
+  // re-send for the same token would be idempotent) and makes the extension
+  // output easy to trace back to its source invite.
+  const mailRef = db.collection('mail').doc(token);
 
   const status = await db.runTransaction(
     async (tx): Promise<'created' | 'already_active'> => {
@@ -662,13 +884,14 @@ async function writeInvitation(
       });
 
       if (plan.action === 'already_active') {
-        // Don't mint an invitation or touch the member doc — the user is
-        // already active and the UI should reflect "already_active".
+        // Don't mint an invitation or queue mail — the user is already
+        // active and the UI should reflect "already_active".
         return 'already_active';
       }
 
       tx.set(memberRef, plan.patch, { merge: true });
 
+      const expiresAt = computeExpiresAt(now, expiresInDays);
       const invitation: InvitationRecord = {
         token,
         orgId,
@@ -676,10 +899,32 @@ async function writeInvitation(
         roleId: invite.roleId,
         buildingIds: invite.buildingIds,
         createdAt: now.toISOString(),
-        expiresAt: computeExpiresAt(now, expiresInDays),
+        expiresAt,
         issuedBy,
       };
       tx.set(invitationRef, invitation);
+
+      // Email queue: only touched when the flag is enabled. Writing here
+      // (inside the same tx) means "invite minted AND email queued" is
+      // atomic — if the tx aborts, neither lands. The extension picks up
+      // /mail/{token} async and appends its own `delivery` subfield for
+      // observability.
+      if (emailConfig.enabled) {
+        const body = buildInvitationEmail({
+          orgName,
+          roleId: invite.roleId,
+          claimUrl: buildClaimUrl(token),
+          expiresAt,
+          personalMessage,
+        });
+        const mailDoc: MailDoc = {
+          to: [invite.email],
+          message: body,
+        };
+        if (emailConfig.from) mailDoc.from = emailConfig.from;
+        if (emailConfig.replyTo) mailDoc.replyTo = emailConfig.replyTo;
+        tx.set(mailRef, mailDoc);
+      }
       return 'created';
     }
   );

--- a/scripts/configure-invite-emails-flag.js
+++ b/scripts/configure-invite-emails-flag.js
@@ -79,10 +79,20 @@ function parseArgs(argv) {
     else if (a === '--enable') args.enable = true;
     else if (a === '--disable') args.enable = false;
     else if (a === '--from') {
-      args.from = argv[i + 1];
+      const val = argv[i + 1];
+      if (!val || val.startsWith('--')) {
+        console.error('Error: --from requires an email address');
+        process.exit(1);
+      }
+      args.from = val;
       i += 1;
     } else if (a === '--reply-to') {
-      args.replyTo = argv[i + 1];
+      const val = argv[i + 1];
+      if (!val || val.startsWith('--')) {
+        console.error('Error: --reply-to requires an email address');
+        process.exit(1);
+      }
+      args.replyTo = val;
       i += 1;
     }
   }
@@ -200,6 +210,10 @@ async function run() {
     if (args.enable !== null) patch.enabled = args.enable;
     if (args.from !== null) patch.from = args.from;
     if (args.replyTo !== null) patch.replyTo = args.replyTo;
+
+    // Guard against any remaining undefineds from previous logic
+    if (patch.from === undefined) delete patch.from;
+    if (patch.replyTo === undefined) delete patch.replyTo;
   }
 
   if (Object.keys(patch).length === 0) {

--- a/scripts/configure-invite-emails-flag.js
+++ b/scripts/configure-invite-emails-flag.js
@@ -60,8 +60,8 @@ const FLAG_ID = 'invite-emails';
 
 // Default sender for the initial Option A smoke-test path. Resend's
 // onboarding@resend.dev sender works without domain verification but can
-// only deliver to the Resend account's own verified email address
-// (paul.ivers@orono.k12.mn.us). Swap via --from once a real domain is live.
+// only deliver to the Resend account's own verified recipient. See
+// internal email setup docs and swap via --from once a real domain is live.
 const DEFAULT_FROM = 'onboarding@resend.dev';
 
 function parseArgs(argv) {

--- a/scripts/configure-invite-emails-flag.js
+++ b/scripts/configure-invite-emails-flag.js
@@ -1,0 +1,242 @@
+/**
+ * Seed / adjust `/global_permissions/invite-emails` — the kill switch that
+ * gates whether `createOrganizationInvites` queues a `/mail/{token}` write
+ * for the Trigger Email extension.
+ *
+ * WHY THIS EXISTS
+ *   Phase 4.1 (invite email wiring). The CF defaults to OFF when the doc
+ *   is missing, so we have to opt-in explicitly after the extension is
+ *   installed + configured with valid SMTP creds. This script creates the
+ *   doc for the first time (defaults: disabled, Resend test sender) and
+ *   can later flip `enabled` or update `from` / `replyTo` when we migrate
+ *   off the test sender.
+ *
+ *   Similar pattern to scripts/graduate-org-admin-writes-flag.js, but this
+ *   one is upsert + multi-field, so it stays useful across multiple runs:
+ *     - First run (no doc):     creates the doc with defaults + any flags
+ *     - Subsequent runs:        merges only the fields you explicitly pass
+ *     - No flags, doc exists:   prints state and exits (no-op)
+ *
+ *   Schema at `/global_permissions/invite-emails`:
+ *     enabled: boolean
+ *     from?: string     // default sender; the extension also has a default
+ *     replyTo?: string  // default reply-to
+ *
+ * Usage:
+ *   # First-time seed (disabled, Resend test sender — Option A path)
+ *   node scripts/configure-invite-emails-flag.js
+ *
+ *   # Enable sends
+ *   node scripts/configure-invite-emails-flag.js --enable
+ *
+ *   # Swap to a verified domain after DNS is live
+ *   node scripts/configure-invite-emails-flag.js \
+ *     --from invites@spartboard.orono.k12.mn.us \
+ *     --reply-to support@orono.k12.mn.us
+ *
+ *   # Kill switch
+ *   node scripts/configure-invite-emails-flag.js --disable
+ *
+ *   # Inspect current state
+ *   node scripts/configure-invite-emails-flag.js --dry-run
+ *
+ * Credentials resolution (same chain as sibling scripts):
+ *   1. FIREBASE_SERVICE_ACCOUNT env var (JSON)
+ *   2. scripts/service-account-key.json
+ *   3. applicationDefault() via GOOGLE_APPLICATION_CREDENTIALS or gcloud ADC
+ */
+
+import { initializeApp, applicationDefault, cert } from 'firebase-admin/app';
+import { getFirestore } from 'firebase-admin/firestore';
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const PROJECT_ID = 'spartboard';
+const FLAG_ID = 'invite-emails';
+
+// Default sender for the initial Option A smoke-test path. Resend's
+// onboarding@resend.dev sender works without domain verification but can
+// only deliver to the Resend account's own verified email address
+// (paul.ivers@orono.k12.mn.us). Swap via --from once a real domain is live.
+const DEFAULT_FROM = 'onboarding@resend.dev';
+
+function parseArgs(argv) {
+  const args = {
+    dryRun: false,
+    help: false,
+    enable: null, // null = don't touch; true/false = set explicitly
+    from: null,
+    replyTo: null,
+  };
+  for (let i = 0; i < argv.length; i += 1) {
+    const a = argv[i];
+    if (a === '--dry-run' || a === '-n') args.dryRun = true;
+    else if (a === '--help' || a === '-h') args.help = true;
+    else if (a === '--enable') args.enable = true;
+    else if (a === '--disable') args.enable = false;
+    else if (a === '--from') {
+      args.from = argv[i + 1];
+      i += 1;
+    } else if (a === '--reply-to') {
+      args.replyTo = argv[i + 1];
+      i += 1;
+    }
+  }
+  return args;
+}
+
+function printHelp() {
+  console.log(
+    `Usage: node scripts/configure-invite-emails-flag.js [options]
+
+Options:
+  --enable            Set enabled: true
+  --disable           Set enabled: false
+  --from <addr>       Set default sender
+  --reply-to <addr>   Set default reply-to
+  --dry-run, -n       Show planned write without committing
+  --help, -h          Show this help
+
+First run with no flags seeds the doc with defaults (enabled: false,
+from: ${DEFAULT_FROM}). Subsequent runs only touch fields you pass
+explicitly — unspecified fields are left alone.`
+  );
+}
+
+function loadCredentials() {
+  const envJson = process.env.FIREBASE_SERVICE_ACCOUNT;
+  if (envJson) {
+    return {
+      source: 'FIREBASE_SERVICE_ACCOUNT env',
+      creds: JSON.parse(envJson),
+      useApplicationDefault: false,
+    };
+  }
+  const keyPath = join(__dirname, 'service-account-key.json');
+  try {
+    const raw = readFileSync(keyPath, 'utf8');
+    return {
+      source: 'scripts/service-account-key.json',
+      creds: JSON.parse(raw),
+      useApplicationDefault: false,
+    };
+  } catch {
+    // Fall through to ADC.
+  }
+  if (process.env.GOOGLE_APPLICATION_CREDENTIALS) {
+    return {
+      source:
+        'GOOGLE_APPLICATION_CREDENTIALS=' +
+        process.env.GOOGLE_APPLICATION_CREDENTIALS,
+      creds: null,
+      useApplicationDefault: true,
+    };
+  }
+  return {
+    source: 'applicationDefault()',
+    creds: null,
+    useApplicationDefault: true,
+  };
+}
+
+function printState(label, data) {
+  console.log('');
+  console.log(label);
+  console.log('  enabled:  ' + JSON.stringify(data?.enabled ?? null));
+  console.log('  from:     ' + JSON.stringify(data?.from ?? null));
+  console.log('  replyTo:  ' + JSON.stringify(data?.replyTo ?? null));
+}
+
+async function run() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    printHelp();
+    process.exit(0);
+  }
+
+  const { source, creds, useApplicationDefault } = loadCredentials();
+  console.log('Using credentials from ' + source);
+
+  const initOpts = {
+    projectId: (creds && creds.project_id) || PROJECT_ID,
+  };
+  if (useApplicationDefault) {
+    initOpts.credential = applicationDefault();
+  } else {
+    initOpts.credential = cert(creds);
+  }
+  initializeApp(initOpts);
+
+  const db = getFirestore();
+  const ref = db.doc('global_permissions/' + FLAG_ID);
+
+  const before = await ref.get();
+  const beforeData = before.exists ? (before.data() ?? {}) : null;
+
+  if (before.exists) {
+    printState(
+      'Current state of /global_permissions/' + FLAG_ID + ':',
+      beforeData
+    );
+  } else {
+    console.log('');
+    console.log(
+      '/global_permissions/' + FLAG_ID + ' does not exist — will be created.'
+    );
+  }
+
+  // Build the merge patch from flags. First run (no doc) always gets the
+  // default `from`; subsequent runs only touch fields the caller passed.
+  const patch = {};
+  if (!before.exists) {
+    patch.enabled = args.enable === true; // defaults to false on first seed
+    patch.from = args.from ?? DEFAULT_FROM;
+    if (args.replyTo !== null) patch.replyTo = args.replyTo;
+  } else {
+    if (args.enable !== null) patch.enabled = args.enable;
+    if (args.from !== null) patch.from = args.from;
+    if (args.replyTo !== null) patch.replyTo = args.replyTo;
+  }
+
+  if (Object.keys(patch).length === 0) {
+    console.log('');
+    console.log(
+      'No flags provided — nothing to change. Pass --help to see options.'
+    );
+    process.exit(0);
+  }
+
+  console.log('');
+  console.log('Planned patch (merge=true): ' + JSON.stringify(patch));
+
+  if (args.dryRun) {
+    console.log('');
+    console.log('Dry run only -- no writes were committed.');
+    process.exit(0);
+  }
+
+  await ref.set(patch, { merge: true });
+
+  const after = await ref.get();
+  printState(
+    'Post-write state of /global_permissions/' + FLAG_ID + ':',
+    after.data() ?? {}
+  );
+
+  console.log('');
+  console.log('✅ Invite-email config updated.');
+  process.exit(0);
+}
+
+run().catch((err) => {
+  console.error(
+    '\nconfigure-invite-emails-flag failed: ' +
+      (err && err.message ? err.message : err)
+  );
+  if (err && err.stack) console.error(err.stack);
+  process.exit(1);
+});


### PR DESCRIPTION
💡 **What:** Parallelized the fetching of user profile batches using `Promise.all` and `db.getAll` in the `adminAnalytics` function.

🎯 **Why:** The previous implementation awaited each batch sequentially in a loop, leading to $O(N \cdot L)$ latency. Parallelization reduces this to approximately $O(L)$, making the function significantly faster as the number of users grows.

📊 **Measured Improvement:** While actual I/O latency could not be measured in the mock test environment, the architectural improvement from sequential to concurrent processing is a standard optimization that yields measurable benefits in production environments.

Also fixed the unit test environment which was previously broken due to missing mocks for `admin.apps` and Firestore `doc`/`getAll` methods.

---
*PR created automatically by Jules for task [6701482378594574203](https://jules.google.com/task/6701482378594574203) started by @OPS-PIvers*