### PR TITLE
fix(deps): patch vite arbitrary file read + rollup path traversal CVEs

### DIFF
--- a/components/widgets/MathTools/Widget.tsx
+++ b/components/widgets/MathTools/Widget.tsx
@@ -204,10 +204,11 @@ export const MathToolsWidget: React.FC<{ widget: WidgetData }> = ({
           style={{ padding: 'min(12px, 2.5cqmin)' }}
         >
           <div
-            className="flex items-center gap-2 text-slate-400 font-medium shrink-0"
+            className="flex items-center text-slate-400 font-medium shrink-0"
             style={{
               fontSize: 'min(9px, 3.2cqmin)',
               marginBottom: 'min(12px, 2.5cqmin)',
+              gap: 'min(8px, 1.8cqmin)',
             }}
           >
             <span>{activeSection.subtitle}</span>

--- a/components/widgets/MathTools/Widget.tsx
+++ b/components/widgets/MathTools/Widget.tsx
@@ -115,8 +115,11 @@ export const MathToolsWidget: React.FC<{ widget: WidgetData }> = ({
   const header = (
     <div className="flex flex-col shrink-0 border-b border-slate-200">
       <div
-        className="flex items-center gap-2"
-        style={{ padding: 'min(8px, 1.5cqmin) min(12px, 2.5cqmin)' }}
+        className="flex items-center"
+        style={{
+          padding: 'min(8px, 1.5cqmin) min(12px, 2.5cqmin)',
+          gap: 'min(8px, 2cqmin)',
+        }}
       >
         <span style={{ fontSize: 'min(18px, 6cqmin)' }}>🧮</span>
         <span
@@ -125,7 +128,13 @@ export const MathToolsWidget: React.FC<{ widget: WidgetData }> = ({
         >
           Math Tools
         </span>
-        <div className="ml-auto flex items-center gap-1.5 bg-white/60 px-1.5 py-0.5 rounded-md border border-brand-blue-lighter/50 shadow-sm">
+        <div
+          className="ml-auto flex items-center bg-white/60 rounded-md border border-brand-blue-lighter/50 shadow-sm"
+          style={{
+            gap: 'min(6px, 1.2cqmin)',
+            padding: 'min(2px, 0.5cqmin) min(6px, 1.2cqmin)',
+          }}
+        >
           <span
             className="text-brand-blue-primary font-bold uppercase tracking-wider"
             style={{ fontSize: 'min(8px, 3cqmin)' }}
@@ -164,12 +173,13 @@ export const MathToolsWidget: React.FC<{ widget: WidgetData }> = ({
           <button
             key={s.id}
             onClick={() => setActiveTab(s.id)}
-            className={`px-3 py-1.5 rounded-t-xl font-black transition-colors border-t border-x ${
+            className={`rounded-t-xl font-black transition-colors border-t border-x ${
               activeTab === s.id
                 ? 'bg-white text-brand-blue-dark border-slate-200'
                 : 'bg-transparent text-brand-blue-light border-transparent hover:text-brand-blue-primary hover:bg-white/40'
             }`}
             style={{
+              padding: 'min(6px, 1.2cqmin) min(12px, 2.5cqmin)',
               fontSize: 'min(10px, 3.8cqmin)',
               marginBottom: '-1px', // Cover bottom border
               boxShadow:
@@ -190,11 +200,11 @@ export const MathToolsWidget: React.FC<{ widget: WidgetData }> = ({
       contentClassName="flex-1 min-h-0 flex flex-col"
       content={
         <div
-          className="flex-1 overflow-y-auto custom-scrollbar"
+          className="flex-1 min-h-0 overflow-y-auto custom-scrollbar flex flex-col"
           style={{ padding: 'min(12px, 2.5cqmin)' }}
         >
           <div
-            className="flex items-center gap-2 text-slate-400 font-medium"
+            className="flex items-center gap-2 text-slate-400 font-medium shrink-0"
             style={{
               fontSize: 'min(9px, 3.2cqmin)',
               marginBottom: 'min(12px, 2.5cqmin)',
@@ -209,7 +219,7 @@ export const MathToolsWidget: React.FC<{ widget: WidgetData }> = ({
 
           {visibleTools.length === 0 && (
             <div
-              className="flex flex-col items-center justify-center text-slate-400 h-32"
+              className="flex flex-col items-center justify-center text-slate-400 flex-1 min-h-0"
               style={{ gap: 'min(8px, 1.5cqmin)' }}
             >
               <span style={{ fontSize: 'min(32px, 10cqmin)', opacity: 0.5 }}>

--- a/docs/scheduled-tasks/css-scaling.md
+++ b/docs/scheduled-tasks/css-scaling.md
@@ -3,7 +3,7 @@
 _Audit model: claude-sonnet-4-6_
 _Action model: claude-opus-4-6_
 _Audit cadence: daily_
-_Last audited: 2026-04-19_
+_Last audited: 2026-04-20_
 _Last action: 2026-04-19_
 
 ---

--- a/docs/scheduled-tasks/css-scaling.md
+++ b/docs/scheduled-tasks/css-scaling.md
@@ -3,7 +3,7 @@
 _Audit model: claude-sonnet-4-6_
 _Action model: claude-opus-4-6_
 _Audit cadence: daily_
-_Last audited: 2026-04-18_
+_Last audited: 2026-04-19_
 _Last action: 2026-04-17_
 
 ---

--- a/docs/scheduled-tasks/css-scaling.md
+++ b/docs/scheduled-tasks/css-scaling.md
@@ -4,7 +4,7 @@ _Audit model: claude-sonnet-4-6_
 _Action model: claude-opus-4-6_
 _Audit cadence: daily_
 _Last audited: 2026-04-19_
-_Last action: 2026-04-17_
+_Last action: 2026-04-19_
 
 ---
 
@@ -21,13 +21,6 @@ _Nothing currently in progress._
 ---
 
 ## Open
-
-### MEDIUM MathToolsWidget uses `h-32` to cap an empty-state content container
-
-- **Detected:** 2026-04-14
-- **File:** components/widgets/MathTools/Widget.tsx:213
-- **Detail:** The empty-state container for the math tool list uses `h-32` — a fixed 128 px height cap. Widget has `skipScaling: true`. When the widget is large this truncates the container, wasting space. Also has hardcoded `gap-2`, `gap-1.5`, `px-3 py-1.5` on the tab bar and controls.
-- **Fix:** Replace `h-32` with `min-h-0 flex-1` so the empty-state fills available space. Convert tab-bar spacing (`px-3 py-1.5`, `gap-2`, `gap-1.5`) to `cqmin` inline styles.
 
 ### MEDIUM GraphicOrganizerWidget has hardcoded padding throughout node layouts (post-text-fix)
 
@@ -58,7 +51,6 @@ _Nothing currently in progress._
   - `CatalystWidget/Widget.tsx:88` — `mr-2` on back button
   - `DiceWidget/Widget.tsx:109, :113-116` — `px-3 pb-3` footer, `py-4 px-6 gap-3` Roll Dice button
   - `GuidedLearning/Widget.tsx:231` — `w-8 h-8` on Loader2 loading icon
-  - `MathTools/Widget.tsx:118, :128, :167-168` — `gap-2`, `gap-1.5`, `px-3 py-1.5` tab buttons
   - `NextUp/Widget.tsx:295, :331, :344, :346, :360, :409, :425, :430` — `p-6`, `gap-2`, `p-1`, `px-3 py-1`, `mb-2 px-1`, `space-y-2`, `py-8`
   - `random/RandomWidget.tsx:711, :750, :752` — `px-2 pb-2` footer, `h-12` Randomize button, `w-4 h-4` RefreshCw icon
   - `SoundWidget/Widget.tsx:182, :210, :212` — `p-2` content wrapper, `pb-3` footer, `px-6 py-2` level label
@@ -71,6 +63,14 @@ _Nothing currently in progress._
 ---
 
 ## Completed
+
+### MEDIUM MathToolsWidget uses `h-32` to cap an empty-state content container
+
+- **Detected:** 2026-04-14
+- **Completed:** 2026-04-19
+- **File:** components/widgets/MathTools/Widget.tsx
+- **Detail:** The empty-state container for the math tool list used `h-32` — a fixed 128 px height cap. Widget has `skipScaling: true`. When the widget grew large, this truncated the empty state and wasted space. The tab bar and grade-selector pill also had hardcoded `gap-2`, `gap-1.5`, `px-3 py-1.5`, `px-1.5 py-0.5` Tailwind spacing.
+- **Resolution:** Made the scrollable content wrapper a flex column (`flex-1 min-h-0 overflow-y-auto custom-scrollbar flex flex-col`) and replaced `h-32` on the empty-state container with `flex-1 min-h-0` so it now fills the available content area. Marked the subtitle row `shrink-0` so it does not collapse. Converted the header row's `gap-2` to inline `gap: 'min(8px, 2cqmin)'`. Converted the grade-selector pill's `gap-1.5 px-1.5 py-0.5` to inline `gap: 'min(6px, 1.2cqmin)'` and `padding: 'min(2px, 0.5cqmin) min(6px, 1.2cqmin)'`. Converted each tab button's `px-3 py-1.5` to inline `padding: 'min(6px, 1.2cqmin) min(12px, 2.5cqmin)'`. Also covers the corresponding MathTools entries from the LOW group "Multiple widgets with hardcoded gap/padding" item, which were removed. `pnpm type-check`, `pnpm lint --max-warnings 0`, and prettier check on the changed file all clean.
 
 ### MEDIUM ExpectationsWidget uses `text-xs` on the empty-state content area
 

--- a/docs/scheduled-tasks/css-scaling.md
+++ b/docs/scheduled-tasks/css-scaling.md
@@ -3,7 +3,7 @@
 _Audit model: claude-sonnet-4-6_
 _Action model: claude-opus-4-6_
 _Audit cadence: daily_
-_Last audited: 2026-04-20_
+_Last audited: 2026-04-21_
 _Last action: 2026-04-19_
 
 ---

--- a/docs/scheduled-tasks/dependency-audit.md
+++ b/docs/scheduled-tasks/dependency-audit.md
@@ -4,7 +4,7 @@ _Audit model: claude-sonnet-4-6_
 _Action model: claude-opus-4-6_
 _Audit cadence: weekly — Tuesday_
 _Last audited: 2026-04-21_
-_Last action: 2026-04-14_
+_Last action: 2026-04-21_
 
 ---
 
@@ -15,13 +15,6 @@ _Nothing currently in progress._
 ---
 
 ## Open
-
-### HIGH `vite` dev server has HIGH arbitrary file read vulnerability
-
-- **Detected:** 2026-04-14
-- **File:** package.json (`"vite": "^6.4.1"` locked at 6.4.1)
-- **Detail:** HIGH vulnerability in the Vite dev server allows arbitrary file reads via path traversal in certain server configurations. While this only affects the dev server (not production builds), it affects the development environment and CI preview builds.
-- **Fix:** `pnpm up vite@latest` within the ^6.x range, or upgrade to vite 7+ if a patched version is available. Also check rollup (locked at 4.55.1) — HIGH path traversal in rollup >=4.0.0 <4.59.0, fix: rollup@>=4.59.0. Running `pnpm up vite` should pull in the updated rollup as a transitive dep.
 
 ### HIGH `hono` has authorization bypass, arbitrary file access, and HTML injection vulnerabilities
 
@@ -108,6 +101,14 @@ _Nothing currently in progress._
 ---
 
 ## Completed
+
+### HIGH `vite` dev server has HIGH arbitrary file read vulnerability
+
+- **Detected:** 2026-04-14
+- **Completed:** 2026-04-21
+- **File:** package.json
+- **Detail:** HIGH vulnerability in the Vite dev server allows arbitrary file reads via path traversal. Rollup (transitive dep of Vite) also had a HIGH path traversal issue in versions <4.59.0.
+- **Resolution:** Ran `pnpm up vite` which upgraded `vite` from 6.4.1 → 6.4.2 (semver-compatible within ^6.x range). `pnpm up vite` did not pull in a newer rollup on its own, so added `"rollup": "^4.59.0"` to the existing `pnpm.overrides` block in `package.json`. After reinstall, rollup resolved to 4.60.2. Verified both advisories cleared in `pnpm audit`. `pnpm type-check`, `pnpm -C functions type-check`, `pnpm lint --max-warnings 0`, `pnpm format:check`, `pnpm build` (23.5s, successful), and `pnpm test` (all 1367 unit tests pass across 150 files) all clean.
 
 ### HIGH `axios` direct dependency has CRITICAL CVEs — upgrade to >=1.15.0
 

--- a/docs/scheduled-tasks/dependency-audit.md
+++ b/docs/scheduled-tasks/dependency-audit.md
@@ -3,7 +3,7 @@
 _Audit model: claude-sonnet-4-6_
 _Action model: claude-opus-4-6_
 _Audit cadence: weekly — Tuesday_
-_Last audited: 2026-04-14_
+_Last audited: 2026-04-21_
 _Last action: 2026-04-14_
 
 ---
@@ -23,15 +23,17 @@ _Nothing currently in progress._
 - **Detail:** HIGH vulnerability in the Vite dev server allows arbitrary file reads via path traversal in certain server configurations. While this only affects the dev server (not production builds), it affects the development environment and CI preview builds.
 - **Fix:** `pnpm up vite@latest` within the ^6.x range, or upgrade to vite 7+ if a patched version is available. Also check rollup (locked at 4.55.1) — HIGH path traversal in rollup >=4.0.0 <4.59.0, fix: rollup@>=4.59.0. Running `pnpm up vite` should pull in the updated rollup as a transitive dep.
 
-### HIGH `hono` has authorization bypass and arbitrary file access vulnerabilities
+### HIGH `hono` has authorization bypass, arbitrary file access, and HTML injection vulnerabilities
 
 - **Detected:** 2026-04-14
+- **Updated:** 2026-04-21
 - **File:** package.json (`"hono": "^4.11.4"`), locked at 4.11.x
-- **Detail:** Two HIGH CVEs:
+- **Detail:** Three CVEs — two HIGH, one MODERATE:
   - `@hono/node-server` has authorization bypass for certain request patterns.
   - Hono vulnerable to arbitrary file access via path traversal in static file serving.
-    Current locked version 4.11.x is affected; latest is 4.12.12 which patches both.
-- **Fix:** `pnpm up hono@^4.12.12` — semver-compatible within the ^4 range. Review any static file serving configuration in hono routes after upgrade.
+  - GHSA-458j-xx4x-4375 (moderate): Hono improperly handles JSX attribute names, allowing HTML injection in `hono/jsx` SSR — patched in >=4.12.14.
+    Current locked version 4.11.x is affected by all three; latest is 4.12.14 which patches all.
+- **Fix:** `pnpm up hono@^4.12.14` — semver-compatible within the ^4 range. Target 4.12.14 specifically (not just 4.12.12) to resolve the HTML injection moderate CVE as well. Review any static file serving configuration in hono routes after upgrade.
 
 ### MEDIUM `firebase-tools` brings in multiple vulnerable transitive deps
 
@@ -77,18 +79,26 @@ _Nothing currently in progress._
 - **Detail:** HIGH — lodash >=4.0.0 <=4.17.23 vulnerable to code injection via `_.template`. This comes via `firebase-functions-test > lodash`. Only in test infrastructure, not production runtime.
 - **Fix:** Update `firebase-functions-test` from 3.4.1 to latest — check if newer version depends on a patched lodash. This is a test-only devDependency.
 
+### MEDIUM `dompurify` has ADD_TAGS bypass via short-circuit evaluation
+
+- **Detected:** 2026-04-21
+- **File:** package.json (transitive via `@monaco-editor/react > monaco-editor > dompurify`)
+- **Detail:** GHSA-39q2-94rc-95cp (moderate): DOMPurify's `ADD_TAGS` function bypasses `FORBID_TAGS` due to short-circuit evaluation in versions <=3.3.3. Patched in >=3.4.0. This affects the Monaco editor used in the widget builder. Not directly exploitable by end users unless they can craft input that passes through the Monaco editor's sanitization path, but it is a sanitization bypass.
+- **Fix:** This is a transitive dep two levels deep (`@monaco-editor/react > monaco-editor > dompurify`). Updating `@monaco-editor/react` to latest may pull in a fixed `monaco-editor` that pins `dompurify >= 3.4.0`. Check: `pnpm why dompurify` to trace the resolution and `pnpm up @monaco-editor/react@latest` if a patched version is available.
+
 ### LOW Major version updates available — require planned migration
 
 - **Detected:** 2026-04-14
+- **Updated:** 2026-04-21
 - **File:** package.json
 - **Detail:** Several packages have major version releases available that require migration planning (breaking changes):
-  - `tailwindcss`: 3.4.19 → **4.2.2** (major — config format changed completely)
-  - `vite`: 6.4.1 → **8.0.8** (2 majors ahead, but focus on patching within v6 first)
-  - `eslint`: 9.39.2 → **10.2.0** (major — verify flat config compatibility)
+  - `tailwindcss`: 3.4.19 → **4.2.3** (major — config format changed completely)
+  - `vite`: 6.4.1 → **8.0.9** (2 majors ahead, but focus on patching within v6 first)
+  - `eslint`: 9.39.2 → **10.2.1** (major — verify flat config compatibility)
   - `@eslint/js`: 9.39.2 → **10.0.1** (paired with eslint)
-  - `typescript`: 5.9.3 → **6.0.2** (major — strict mode changes)
-  - `i18next`: 25.8.13 → **26.0.4** (major — API changes)
-  - `react-i18next`: 16.5.4 → **17.0.2** (paired with i18next)
+  - `typescript`: 5.9.3 → **6.0.3** (major — strict mode changes)
+  - `i18next`: 25.8.13 → **26.0.6** (major — API changes)
+  - `react-i18next`: 16.5.4 → **17.0.4** (paired with i18next)
   - `lucide-react`: 0.563.0 → **1.8.0** (first stable major — icon API changes possible)
   - `@vitejs/plugin-react`: 5.1.2 → **6.0.1** (major)
   - `jsdom` (test): 27.4.0 → **29.0.2** (2 majors)

--- a/docs/scheduled-tasks/firestore-rules.md
+++ b/docs/scheduled-tasks/firestore-rules.md
@@ -3,7 +3,7 @@
 _Audit model: claude-sonnet-4-6_
 _Action model: claude-opus-4-6_
 _Audit cadence: weekly — Monday_
-_Last audited: 2026-04-13_
+_Last audited: 2026-04-20_
 _Last action: never_
 
 ---

--- a/docs/scheduled-tasks/pr-review-log.md
+++ b/docs/scheduled-tasks/pr-review-log.md
@@ -91,3 +91,28 @@ _Automated nightly review by claude-opus-4-6_
   - PR #1329 head SHA `3a52afaf` — small, low-risk docs-only change
   - PR #1328 head SHA `386fdc87` — DRAFT status; 3-file diff cleanly scoped to SeatingChart empty states
   - PR #1326 head SHA `c6498487` — large feature bundle (22 files, +1401/-268); RandomWidget refactor is +343/-217 and warrants a human eye at 30+ student rosters
+
+## 2026-04-20
+
+- PRs reviewed:
+  - #1355 — 🧹 remove leftover console.log in adminAnalytics (head `code-health-remove-logs-admin-analytics-16413078109270849377`, base `dev-paul`)
+  - #1354 — Refactor `useEffect` prop synchronization in `SidebarBackgrounds` (head `refactor-use-effect-prop-sync-2711741412273027246`, base `dev-paul`)
+  - #1353 — fix(math-tools): scale empty-state and tab-bar spacing with cqmin (head `scheduled-tasks`, base `dev-paul`, DRAFT)
+  - #1335 — Randomizer scaling/a11y, absent tracking, dock positioning, editor AI overlays (head `dev-paul`, base `main`) — read-only for pushes per branch-safety
+- Comments processed: 15 total — 0 new fixes, 15 already addressed by prior runs
+  - PR #1355: 0 review threads; 2 bot summary comments (gemini + copilot) with no actionable feedback
+  - PR #1354: 0 review threads; 1 bot summary comment with no actionable feedback
+  - PR #1353: 4 inline threads (1 outdated) — all already replied to by OPS-PIvers explaining non-actionability (3 reference files not in this PR's diff — `AbsentStudentsModal`, `useRosters`, `DraggableWindow` — fixed on `dev-paul`)
+  - PR #1335: 11 inline threads — all already replied to by OPS-PIvers (9 fixed in `49ab44f7`/earlier commits, 2 declined with rationale for intentional `cqw`/`cqh` mix and PR-description update)
+- Fixes pushed: none
+  - No unaddressed comments remained requiring a code fix on any PR
+- Reviews posted: 4
+  - PR #1355: Ready — zero-risk single-file hygiene cleanup; all 13 CI checks green
+  - PR #1354: Ready — correct implementation of CLAUDE.md's "adjusting state while rendering" pattern; behavior preserved; all 6 CI checks green
+  - PR #1353: Ready with minor notes — MathTools scaling fix follows `cqmin` guidance; draft PR also bundles `tests/hooks/useLiveSession.test.ts` (not mentioned in PR body); recommend description update before marking ready
+  - PR #1335: Needs changes (non-code) — 130+ file PR whose title/description cover only ~20% of the actual scope; bundles organization hierarchy (Organizations/Buildings/Domains/Roles/Users/StudentPage/Invites), full Library shell, and Manager/Importer refactor of four widgets (Quiz/MiniApp/VideoActivity/GuidedLearning) alongside the advertised Randomizer/dock/editor polish. Recommended splitting or rewriting the description. All 13 CI checks green. Flagged: `quizImportAdapter.ts` missing test coverage (sibling adapters have tests); `firestore.rules` +314 lines needs human verification; sibling changes to `AuthContext`/`AuthContextValue` may affect `getAdminBuildingConfig` permission-filtering path
+- Notes:
+  - PR #1355 head SHA `02822790` — 10 log lines + 1 unused counter removed from `functions/src/index.ts`
+  - PR #1354 head SHA `d8cf3e3d` — two `useEffect`s converted in `SidebarBackgrounds.tsx`; `useEffect` still used for Google Drive fetch elsewhere in the file
+  - PR #1353 head SHA `7a043e4a` — draft, no CI triggered; diff covers MathTools/Widget.tsx + 4 journal files + new `tests/hooks/useLiveSession.test.ts` (201 lines, 9 tests covering `joinSession` validation)
+  - PR #1335 head SHA `5a78487e` — largest PR in the review cycle; rollback risk is very high if a regression ships

--- a/docs/scheduled-tasks/skill-freshness.md
+++ b/docs/scheduled-tasks/skill-freshness.md
@@ -3,7 +3,7 @@
 _Audit model: claude-sonnet-4-6_
 _Action model: claude-opus-4-6_
 _Audit cadence: weekly — Tuesday_
-_Last audited: 2026-04-14_
+_Last audited: 2026-04-21_
 _Last action: never_
 
 ---

--- a/docs/scheduled-tasks/test-coverage.md
+++ b/docs/scheduled-tasks/test-coverage.md
@@ -3,7 +3,7 @@
 _Audit model: claude-sonnet-4-6_
 _Action model: claude-opus-4-6_
 _Audit cadence: weekly — Monday_
-_Last audited: 2026-04-13_
+_Last audited: 2026-04-20_
 _Last action: never_
 
 ---

--- a/docs/scheduled-tasks/test-coverage.md
+++ b/docs/scheduled-tasks/test-coverage.md
@@ -4,7 +4,7 @@ _Audit model: claude-sonnet-4-6_
 _Action model: claude-opus-4-6_
 _Audit cadence: weekly — Monday_
 _Last audited: 2026-04-20_
-_Last action: never_
+_Last action: 2026-04-20_
 
 ---
 
@@ -16,24 +16,21 @@ _Nothing currently in progress._
 
 ## Open
 
-### HIGH hooks/ coverage — 27 of 33 hooks have no dedicated tests
+### HIGH hooks/ coverage — session hooks still missing tests (partial progress)
 
 - **Detected:** 2026-04-13
-- **File:** hooks/ directory
-- **Detail:** Only 6 hook files have matching test files in tests/hooks/. The following critical hooks have zero test coverage:
-  - `useLiveSession.ts` — manages live classroom sessions, teacher/student role switching, PIN validation
+- **Progress (2026-04-20):** Added initial test coverage for `useLiveSession.ts` (9 tests covering `joinSession` input validation and sanitization — code normalization, PIN truncation, duplicate-PIN rejection, self-rejoin allowance, and all error paths). Also confirmed pre-existing coverage for `useGuidedLearningSession.ts` (pure-helper test) and `useGoogleDrive.ts` / `useStorage.ts` (full test files in `tests/hooks/`). Remaining critical hooks with zero coverage:
   - `useQuizSession.ts` — quiz session state for both teacher and student flows
-  - `useGuidedLearningSession.ts` — guided learning session orchestration
   - `useVideoActivity.ts` / `useVideoActivitySession.ts` — video activity session management
   - `useMiniAppSession.ts` — mini-app assignment session lifecycle
   - `useRosters.ts` — roster CRUD, student list management
-  - `useGoogleDrive.ts` — Google Drive dashboard sync (has a test file but missing coverage for core sync flows)
   - `useImageUpload.ts` — image upload handling with Firebase Storage
   - `useFirestore.ts` — core Firestore CRUD for dashboards
   - `useStarterPacks.ts` — starter pack template management
   - `useScreenRecord.ts` — screen recording lifecycle
-  - `useMusicStations.ts` — music station state (has partial tests)
-- **Fix:** Prioritize test coverage for session hooks (useLiveSession, useQuizSession, useGuidedLearningSession) as these are the most complex stateful hooks. Use Vitest with mock Firebase adapters. See existing tests in tests/hooks/useMusicStations.test.ts as a reference pattern.
+  - `useLiveSession.ts` — needs deeper coverage (teacher actions: `startSession`, `updateSessionConfig`, `endSession`, `toggleFreezeStudent`, `toggleGlobalFreeze`)
+- **File:** hooks/ directory
+- **Fix:** Next priority: add `useQuizSession.ts` coverage, then expand `useLiveSession` to cover teacher-mode actions. Use Vitest with mock Firebase adapters. See `tests/hooks/useLiveSession.test.ts` and `tests/hooks/useMusicStations.test.ts` as reference patterns.
 
 ### MEDIUM utils/ coverage — 31 of 41 utility files have no tests
 

--- a/docs/scheduled-tasks/typescript-eslint.md
+++ b/docs/scheduled-tasks/typescript-eslint.md
@@ -3,7 +3,7 @@
 _Audit model: claude-sonnet-4-6_
 _Action model: claude-opus-4-6_
 _Audit cadence: daily_
-_Last audited: 2026-04-19_
+_Last audited: 2026-04-20_
 _Last action: never_
 
 ---
@@ -16,7 +16,7 @@ _Nothing currently in progress._
 
 ## Open
 
-_No open items. Both `pnpm type-check` and `pnpm lint` pass cleanly as of 2026-04-19. TypeScript: 0 errors. ESLint: 0 errors, 0 warnings (`--max-warnings 0`)._
+_No open items. Both `pnpm type-check` and `pnpm lint` pass cleanly as of 2026-04-20. TypeScript: 0 errors. ESLint: 0 errors, 0 warnings (`--max-warnings 0`)._
 
 ---
 

--- a/docs/scheduled-tasks/typescript-eslint.md
+++ b/docs/scheduled-tasks/typescript-eslint.md
@@ -3,7 +3,7 @@
 _Audit model: claude-sonnet-4-6_
 _Action model: claude-opus-4-6_
 _Audit cadence: daily_
-_Last audited: 2026-04-18_
+_Last audited: 2026-04-19_
 _Last action: never_
 
 ---
@@ -16,7 +16,7 @@ _Nothing currently in progress._
 
 ## Open
 
-_No open items. Both `pnpm type-check` and `pnpm lint` pass cleanly as of 2026-04-18. TypeScript: 0 errors. ESLint: 0 errors, 0 warnings (`--max-warnings 0`)._
+_No open items. Both `pnpm type-check` and `pnpm lint` pass cleanly as of 2026-04-19. TypeScript: 0 errors. ESLint: 0 errors, 0 warnings (`--max-warnings 0`)._
 
 ---
 

--- a/docs/scheduled-tasks/typescript-eslint.md
+++ b/docs/scheduled-tasks/typescript-eslint.md
@@ -3,7 +3,7 @@
 _Audit model: claude-sonnet-4-6_
 _Action model: claude-opus-4-6_
 _Audit cadence: daily_
-_Last audited: 2026-04-20_
+_Last audited: 2026-04-21_
 _Last action: never_
 
 ---
@@ -16,7 +16,7 @@ _Nothing currently in progress._
 
 ## Open
 
-_No open items. Both `pnpm type-check` and `pnpm lint` pass cleanly as of 2026-04-20. TypeScript: 0 errors. ESLint: 0 errors, 0 warnings (`--max-warnings 0`)._
+_No open items. Both `pnpm type-check` and `pnpm lint` pass cleanly as of 2026-04-21. TypeScript: 0 errors. ESLint: 0 errors, 0 warnings (`--max-warnings 0`)._
 
 ---
 

--- a/docs/scheduled-tasks/widget-registry.md
+++ b/docs/scheduled-tasks/widget-registry.md
@@ -3,7 +3,7 @@
 _Audit model: claude-sonnet-4-6_
 _Action model: claude-opus-4-6_
 _Audit cadence: daily_
-_Last audited: 2026-04-18_
+_Last audited: 2026-04-19_
 _Last action: never_
 
 ---

--- a/docs/scheduled-tasks/widget-registry.md
+++ b/docs/scheduled-tasks/widget-registry.md
@@ -3,7 +3,7 @@
 _Audit model: claude-sonnet-4-6_
 _Action model: claude-opus-4-6_
 _Audit cadence: daily_
-_Last audited: 2026-04-19_
+_Last audited: 2026-04-20_
 _Last action: never_
 
 ---

--- a/docs/scheduled-tasks/widget-registry.md
+++ b/docs/scheduled-tasks/widget-registry.md
@@ -3,7 +3,7 @@
 _Audit model: claude-sonnet-4-6_
 _Action model: claude-opus-4-6_
 _Audit cadence: daily_
-_Last audited: 2026-04-20_
+_Last audited: 2026-04-21_
 _Last action: never_
 
 ---

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
       "hono": "^4.11.4",
       "diff": "^8.0.3",
       "tar": "^7.5.4",
-      "lodash": "^4.17.23"
+      "lodash": "^4.17.23",
+      "rollup": "^4.59.0"
     }
   },
   "dependencies": {
@@ -109,7 +110,7 @@
     "tailwindcss": "^3.4.19",
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.54.0",
-    "vite": "^6.4.1",
+    "vite": "^6.4.2",
     "vitest": "^4.0.18"
   },
   "lint-staged": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,6 +9,7 @@ overrides:
   diff: ^8.0.3
   tar: ^7.5.4
   lodash: ^4.17.23
+  rollup: ^4.59.0
 
 importers:
 
@@ -134,7 +135,7 @@ importers:
         version: 8.54.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)
       '@vitejs/plugin-react':
         specifier: ^5.1.2
-        version: 5.1.2(vite@6.4.1(@types/node@24.12.2)(jiti@1.21.7)(yaml@2.8.2))
+        version: 5.1.2(vite@6.4.2(@types/node@24.12.2)(jiti@1.21.7)(yaml@2.8.2))
       '@vitest/coverage-v8':
         specifier: ^4.0.18
         version: 4.0.18(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.12.2)(jiti@1.21.7)(jsdom@27.4.0)(yaml@2.8.2))
@@ -217,8 +218,8 @@ importers:
         specifier: ^8.54.0
         version: 8.54.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)
       vite:
-        specifier: ^6.4.1
-        version: 6.4.1(@types/node@24.12.2)(jiti@1.21.7)(yaml@2.8.2)
+        specifier: ^6.4.2
+        version: 6.4.2(@types/node@24.12.2)(jiti@1.21.7)(yaml@2.8.2)
       vitest:
         specifier: ^4.0.18
         version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.12.2)(jiti@1.21.7)(jsdom@27.4.0)(yaml@2.8.2)
@@ -545,11 +546,11 @@ packages:
   '@electric-sql/pglite@0.3.15':
     resolution: {integrity: sha512-Cj++n1Mekf9ETfdc16TlDi+cDDQF0W7EcbyRHYOAeZdsAe8M/FJg18itDTSwyHfar2WIezawM9o0EKaRGVKygQ==}
 
-  '@emnapi/core@1.9.2':
-    resolution: {integrity: sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==}
+  '@emnapi/core@1.10.0':
+    resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
 
-  '@emnapi/runtime@1.9.2':
-    resolution: {integrity: sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==}
+  '@emnapi/runtime@1.10.0':
+    resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
 
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
@@ -1480,141 +1481,141 @@ packages:
   '@rolldown/pluginutils@1.0.0-beta.53':
     resolution: {integrity: sha512-vENRlFU4YbrwVqNDZ7fLvy+JR1CRkyr01jhSiDpE1u6py3OMzQfztQU2jxykW3ALNxO4kSlqIDeYyD0Y9RcQeQ==}
 
-  '@rollup/rollup-android-arm-eabi@4.55.1':
-    resolution: {integrity: sha512-9R0DM/ykwfGIlNu6+2U09ga0WXeZ9MRC2Ter8jnz8415VbuIykVuc6bhdrbORFZANDmTDvq26mJrEVTl8TdnDg==}
+  '@rollup/rollup-android-arm-eabi@4.60.2':
+    resolution: {integrity: sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==}
     cpu: [arm]
     os: [android]
 
-  '@rollup/rollup-android-arm64@4.55.1':
-    resolution: {integrity: sha512-eFZCb1YUqhTysgW3sj/55du5cG57S7UTNtdMjCW7LwVcj3dTTcowCsC8p7uBdzKsZYa8J7IDE8lhMI+HX1vQvg==}
+  '@rollup/rollup-android-arm64@4.60.2':
+    resolution: {integrity: sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==}
     cpu: [arm64]
     os: [android]
 
-  '@rollup/rollup-darwin-arm64@4.55.1':
-    resolution: {integrity: sha512-p3grE2PHcQm2e8PSGZdzIhCKbMCw/xi9XvMPErPhwO17vxtvCN5FEA2mSLgmKlCjHGMQTP6phuQTYWUnKewwGg==}
+  '@rollup/rollup-darwin-arm64@4.60.2':
+    resolution: {integrity: sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==}
     cpu: [arm64]
     os: [darwin]
 
-  '@rollup/rollup-darwin-x64@4.55.1':
-    resolution: {integrity: sha512-rDUjG25C9qoTm+e02Esi+aqTKSBYwVTaoS1wxcN47/Luqef57Vgp96xNANwt5npq9GDxsH7kXxNkJVEsWEOEaQ==}
+  '@rollup/rollup-darwin-x64@4.60.2':
+    resolution: {integrity: sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==}
     cpu: [x64]
     os: [darwin]
 
-  '@rollup/rollup-freebsd-arm64@4.55.1':
-    resolution: {integrity: sha512-+JiU7Jbp5cdxekIgdte0jfcu5oqw4GCKr6i3PJTlXTCU5H5Fvtkpbs4XJHRmWNXF+hKmn4v7ogI5OQPaupJgOg==}
+  '@rollup/rollup-freebsd-arm64@4.60.2':
+    resolution: {integrity: sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==}
     cpu: [arm64]
     os: [freebsd]
 
-  '@rollup/rollup-freebsd-x64@4.55.1':
-    resolution: {integrity: sha512-V5xC1tOVWtLLmr3YUk2f6EJK4qksksOYiz/TCsFHu/R+woubcLWdC9nZQmwjOAbmExBIVKsm1/wKmEy4z4u4Bw==}
+  '@rollup/rollup-freebsd-x64@4.60.2':
+    resolution: {integrity: sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==}
     cpu: [x64]
     os: [freebsd]
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.55.1':
-    resolution: {integrity: sha512-Rn3n+FUk2J5VWx+ywrG/HGPTD9jXNbicRtTM11e/uorplArnXZYsVifnPPqNNP5BsO3roI4n8332ukpY/zN7rQ==}
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.2':
+    resolution: {integrity: sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==}
     cpu: [arm]
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-arm-musleabihf@4.55.1':
-    resolution: {integrity: sha512-grPNWydeKtc1aEdrJDWk4opD7nFtQbMmV7769hiAaYyUKCT1faPRm2av8CX1YJsZ4TLAZcg9gTR1KvEzoLjXkg==}
+  '@rollup/rollup-linux-arm-musleabihf@4.60.2':
+    resolution: {integrity: sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==}
     cpu: [arm]
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-linux-arm64-gnu@4.55.1':
-    resolution: {integrity: sha512-a59mwd1k6x8tXKcUxSyISiquLwB5pX+fJW9TkWU46lCqD/GRDe9uDN31jrMmVP3feI3mhAdvcCClhV8V5MhJFQ==}
+  '@rollup/rollup-linux-arm64-gnu@4.60.2':
+    resolution: {integrity: sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-arm64-musl@4.55.1':
-    resolution: {integrity: sha512-puS1MEgWX5GsHSoiAsF0TYrpomdvkaXm0CofIMG5uVkP6IBV+ZO9xhC5YEN49nsgYo1DuuMquF9+7EDBVYu4uA==}
+  '@rollup/rollup-linux-arm64-musl@4.60.2':
+    resolution: {integrity: sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-linux-loong64-gnu@4.55.1':
-    resolution: {integrity: sha512-r3Wv40in+lTsULSb6nnoudVbARdOwb2u5fpeoOAZjFLznp6tDU8kd+GTHmJoqZ9lt6/Sys33KdIHUaQihFcu7g==}
+  '@rollup/rollup-linux-loong64-gnu@4.60.2':
+    resolution: {integrity: sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==}
     cpu: [loong64]
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-loong64-musl@4.55.1':
-    resolution: {integrity: sha512-MR8c0+UxAlB22Fq4R+aQSPBayvYa3+9DrwG/i1TKQXFYEaoW3B5b/rkSRIypcZDdWjWnpcvxbNaAJDcSbJU3Lw==}
+  '@rollup/rollup-linux-loong64-musl@4.60.2':
+    resolution: {integrity: sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==}
     cpu: [loong64]
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-linux-ppc64-gnu@4.55.1':
-    resolution: {integrity: sha512-3KhoECe1BRlSYpMTeVrD4sh2Pw2xgt4jzNSZIIPLFEsnQn9gAnZagW9+VqDqAHgm1Xc77LzJOo2LdigS5qZ+gw==}
+  '@rollup/rollup-linux-ppc64-gnu@4.60.2':
+    resolution: {integrity: sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-ppc64-musl@4.55.1':
-    resolution: {integrity: sha512-ziR1OuZx0vdYZZ30vueNZTg73alF59DicYrPViG0NEgDVN8/Jl87zkAPu4u6VjZST2llgEUjaiNl9JM6HH1Vdw==}
+  '@rollup/rollup-linux-ppc64-musl@4.60.2':
+    resolution: {integrity: sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==}
     cpu: [ppc64]
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-linux-riscv64-gnu@4.55.1':
-    resolution: {integrity: sha512-uW0Y12ih2XJRERZ4jAfKamTyIHVMPQnTZcQjme2HMVDAHY4amf5u414OqNYC+x+LzRdRcnIG1YodLrrtA8xsxw==}
+  '@rollup/rollup-linux-riscv64-gnu@4.60.2':
+    resolution: {integrity: sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==}
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-riscv64-musl@4.55.1':
-    resolution: {integrity: sha512-u9yZ0jUkOED1BFrqu3BwMQoixvGHGZ+JhJNkNKY/hyoEgOwlqKb62qu+7UjbPSHYjiVy8kKJHvXKv5coH4wDeg==}
+  '@rollup/rollup-linux-riscv64-musl@4.60.2':
+    resolution: {integrity: sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==}
     cpu: [riscv64]
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-linux-s390x-gnu@4.55.1':
-    resolution: {integrity: sha512-/0PenBCmqM4ZUd0190j7J0UsQ/1nsi735iPRakO8iPciE7BQ495Y6msPzaOmvx0/pn+eJVVlZrNrSh4WSYLxNg==}
+  '@rollup/rollup-linux-s390x-gnu@4.60.2':
+    resolution: {integrity: sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-x64-gnu@4.55.1':
-    resolution: {integrity: sha512-a8G4wiQxQG2BAvo+gU6XrReRRqj+pLS2NGXKm8io19goR+K8lw269eTrPkSdDTALwMmJp4th2Uh0D8J9bEV1vg==}
+  '@rollup/rollup-linux-x64-gnu@4.60.2':
+    resolution: {integrity: sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-x64-musl@4.55.1':
-    resolution: {integrity: sha512-bD+zjpFrMpP/hqkfEcnjXWHMw5BIghGisOKPj+2NaNDuVT+8Ds4mPf3XcPHuat1tz89WRL+1wbcxKY3WSbiT7w==}
+  '@rollup/rollup-linux-x64-musl@4.60.2':
+    resolution: {integrity: sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-openbsd-x64@4.55.1':
-    resolution: {integrity: sha512-eLXw0dOiqE4QmvikfQ6yjgkg/xDM+MdU9YJuP4ySTibXU0oAvnEWXt7UDJmD4UkYialMfOGFPJnIHSe/kdzPxg==}
+  '@rollup/rollup-openbsd-x64@4.60.2':
+    resolution: {integrity: sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==}
     cpu: [x64]
     os: [openbsd]
 
-  '@rollup/rollup-openharmony-arm64@4.55.1':
-    resolution: {integrity: sha512-xzm44KgEP11te3S2HCSyYf5zIzWmx3n8HDCc7EE59+lTcswEWNpvMLfd9uJvVX8LCg9QWG67Xt75AuHn4vgsXw==}
+  '@rollup/rollup-openharmony-arm64@4.60.2':
+    resolution: {integrity: sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==}
     cpu: [arm64]
     os: [openharmony]
 
-  '@rollup/rollup-win32-arm64-msvc@4.55.1':
-    resolution: {integrity: sha512-yR6Bl3tMC/gBok5cz/Qi0xYnVbIxGx5Fcf/ca0eB6/6JwOY+SRUcJfI0OpeTpPls7f194as62thCt/2BjxYN8g==}
+  '@rollup/rollup-win32-arm64-msvc@4.60.2':
+    resolution: {integrity: sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==}
     cpu: [arm64]
     os: [win32]
 
-  '@rollup/rollup-win32-ia32-msvc@4.55.1':
-    resolution: {integrity: sha512-3fZBidchE0eY0oFZBnekYCfg+5wAB0mbpCBuofh5mZuzIU/4jIVkbESmd2dOsFNS78b53CYv3OAtwqkZZmU5nA==}
+  '@rollup/rollup-win32-ia32-msvc@4.60.2':
+    resolution: {integrity: sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==}
     cpu: [ia32]
     os: [win32]
 
-  '@rollup/rollup-win32-x64-gnu@4.55.1':
-    resolution: {integrity: sha512-xGGY5pXj69IxKb4yv/POoocPy/qmEGhimy/FoTpTSVju3FYXUQQMFCaZZXJVidsmGxRioZAwpThl/4zX41gRKg==}
+  '@rollup/rollup-win32-x64-gnu@4.60.2':
+    resolution: {integrity: sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==}
     cpu: [x64]
     os: [win32]
 
-  '@rollup/rollup-win32-x64-msvc@4.55.1':
-    resolution: {integrity: sha512-SPEpaL6DX4rmcXtnhdrQYgzQ5W2uW3SCJch88lB2zImhJRhIIK44fkUrgIV/Q8yUNfw5oyZ5vkeQsZLhCb06lw==}
+  '@rollup/rollup-win32-x64-msvc@4.60.2':
+    resolution: {integrity: sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==}
     cpu: [x64]
     os: [win32]
 
@@ -5136,6 +5137,10 @@ packages:
     resolution: {integrity: sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==}
     engines: {node: '>=12.0.0'}
 
+  protobufjs@7.5.5:
+    resolution: {integrity: sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==}
+    engines: {node: '>=12.0.0'}
+
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
@@ -5376,8 +5381,8 @@ packages:
     resolution: {integrity: sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==}
     hasBin: true
 
-  rollup@4.55.1:
-    resolution: {integrity: sha512-wDv/Ht1BNHB4upNbK74s9usvl7hObDnvVzknxqY/E/O3X6rW1U1rV1aENEfJ54eFZDTNo7zv1f5N4edCluH7+A==}
+  rollup@4.60.2:
+    resolution: {integrity: sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
@@ -6019,8 +6024,8 @@ packages:
   victory-vendor@37.3.6:
     resolution: {integrity: sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==}
 
-  vite@6.4.1:
-    resolution: {integrity: sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==}
+  vite@6.4.2:
+    resolution: {integrity: sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
     peerDependencies:
@@ -6695,13 +6700,13 @@ snapshots:
 
   '@electric-sql/pglite@0.3.15': {}
 
-  '@emnapi/core@1.9.2':
+  '@emnapi/core@1.10.0':
     dependencies:
       '@emnapi/wasi-threads': 1.2.1
       tslib: 2.8.1
     optional: true
 
-  '@emnapi/runtime@1.9.2':
+  '@emnapi/runtime@1.10.0':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -7711,8 +7716,8 @@ snapshots:
 
   '@napi-rs/wasm-runtime@0.2.12':
     dependencies:
-      '@emnapi/core': 1.9.2
-      '@emnapi/runtime': 1.9.2
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
       '@tybys/wasm-util': 0.10.1
     optional: true
 
@@ -7817,79 +7822,79 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.0-beta.53': {}
 
-  '@rollup/rollup-android-arm-eabi@4.55.1':
+  '@rollup/rollup-android-arm-eabi@4.60.2':
     optional: true
 
-  '@rollup/rollup-android-arm64@4.55.1':
+  '@rollup/rollup-android-arm64@4.60.2':
     optional: true
 
-  '@rollup/rollup-darwin-arm64@4.55.1':
+  '@rollup/rollup-darwin-arm64@4.60.2':
     optional: true
 
-  '@rollup/rollup-darwin-x64@4.55.1':
+  '@rollup/rollup-darwin-x64@4.60.2':
     optional: true
 
-  '@rollup/rollup-freebsd-arm64@4.55.1':
+  '@rollup/rollup-freebsd-arm64@4.60.2':
     optional: true
 
-  '@rollup/rollup-freebsd-x64@4.55.1':
+  '@rollup/rollup-freebsd-x64@4.60.2':
     optional: true
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.55.1':
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.2':
     optional: true
 
-  '@rollup/rollup-linux-arm-musleabihf@4.55.1':
+  '@rollup/rollup-linux-arm-musleabihf@4.60.2':
     optional: true
 
-  '@rollup/rollup-linux-arm64-gnu@4.55.1':
+  '@rollup/rollup-linux-arm64-gnu@4.60.2':
     optional: true
 
-  '@rollup/rollup-linux-arm64-musl@4.55.1':
+  '@rollup/rollup-linux-arm64-musl@4.60.2':
     optional: true
 
-  '@rollup/rollup-linux-loong64-gnu@4.55.1':
+  '@rollup/rollup-linux-loong64-gnu@4.60.2':
     optional: true
 
-  '@rollup/rollup-linux-loong64-musl@4.55.1':
+  '@rollup/rollup-linux-loong64-musl@4.60.2':
     optional: true
 
-  '@rollup/rollup-linux-ppc64-gnu@4.55.1':
+  '@rollup/rollup-linux-ppc64-gnu@4.60.2':
     optional: true
 
-  '@rollup/rollup-linux-ppc64-musl@4.55.1':
+  '@rollup/rollup-linux-ppc64-musl@4.60.2':
     optional: true
 
-  '@rollup/rollup-linux-riscv64-gnu@4.55.1':
+  '@rollup/rollup-linux-riscv64-gnu@4.60.2':
     optional: true
 
-  '@rollup/rollup-linux-riscv64-musl@4.55.1':
+  '@rollup/rollup-linux-riscv64-musl@4.60.2':
     optional: true
 
-  '@rollup/rollup-linux-s390x-gnu@4.55.1':
+  '@rollup/rollup-linux-s390x-gnu@4.60.2':
     optional: true
 
-  '@rollup/rollup-linux-x64-gnu@4.55.1':
+  '@rollup/rollup-linux-x64-gnu@4.60.2':
     optional: true
 
-  '@rollup/rollup-linux-x64-musl@4.55.1':
+  '@rollup/rollup-linux-x64-musl@4.60.2':
     optional: true
 
-  '@rollup/rollup-openbsd-x64@4.55.1':
+  '@rollup/rollup-openbsd-x64@4.60.2':
     optional: true
 
-  '@rollup/rollup-openharmony-arm64@4.55.1':
+  '@rollup/rollup-openharmony-arm64@4.60.2':
     optional: true
 
-  '@rollup/rollup-win32-arm64-msvc@4.55.1':
+  '@rollup/rollup-win32-arm64-msvc@4.60.2':
     optional: true
 
-  '@rollup/rollup-win32-ia32-msvc@4.55.1':
+  '@rollup/rollup-win32-ia32-msvc@4.60.2':
     optional: true
 
-  '@rollup/rollup-win32-x64-gnu@4.55.1':
+  '@rollup/rollup-win32-x64-gnu@4.60.2':
     optional: true
 
-  '@rollup/rollup-win32-x64-msvc@4.55.1':
+  '@rollup/rollup-win32-x64-msvc@4.60.2':
     optional: true
 
   '@sinclair/typebox@0.34.49': {}
@@ -8314,7 +8319,7 @@ snapshots:
       '@use-gesture/core': 10.3.1
       react: 19.2.4
 
-  '@vitejs/plugin-react@5.1.2(vite@6.4.1(@types/node@24.12.2)(jiti@1.21.7)(yaml@2.8.2))':
+  '@vitejs/plugin-react@5.1.2(vite@6.4.2(@types/node@24.12.2)(jiti@1.21.7)(yaml@2.8.2))':
     dependencies:
       '@babel/core': 7.28.6
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.28.6)
@@ -8322,7 +8327,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.53
       '@types/babel__core': 7.20.5
       react-refresh: 0.18.0
-      vite: 6.4.1(@types/node@24.12.2)(jiti@1.21.7)(yaml@2.8.2)
+      vite: 6.4.2(@types/node@24.12.2)(jiti@1.21.7)(yaml@2.8.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -8349,13 +8354,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.0.3
 
-  '@vitest/mocker@4.0.18(vite@6.4.1(@types/node@24.12.2)(jiti@1.21.7)(yaml@2.8.2))':
+  '@vitest/mocker@4.0.18(vite@6.4.2(@types/node@24.12.2)(jiti@1.21.7)(yaml@2.8.2))':
     dependencies:
       '@vitest/spy': 4.0.18
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 6.4.1(@types/node@24.12.2)(jiti@1.21.7)(yaml@2.8.2)
+      vite: 6.4.2(@types/node@24.12.2)(jiti@1.21.7)(yaml@2.8.2)
 
   '@vitest/pretty-format@4.0.18':
     dependencies:
@@ -11724,7 +11729,7 @@ snapshots:
       long: 5.3.2
       onnxruntime-common: 1.21.0
       platform: 1.3.6
-      protobufjs: 7.5.4
+      protobufjs: 7.5.5
 
   open@6.4.0:
     dependencies:
@@ -12059,6 +12064,21 @@ snapshots:
       '@types/node': 24.12.2
       long: 5.3.2
 
+  protobufjs@7.5.5:
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/base64': 1.1.2
+      '@protobufjs/codegen': 2.0.4
+      '@protobufjs/eventemitter': 1.1.0
+      '@protobufjs/fetch': 1.1.0
+      '@protobufjs/float': 1.0.2
+      '@protobufjs/inquire': 1.1.0
+      '@protobufjs/path': 1.1.2
+      '@protobufjs/pool': 1.1.0
+      '@protobufjs/utf8': 1.1.0
+      '@types/node': 24.12.2
+      long: 5.3.2
+
   proxy-addr@2.0.7:
     dependencies:
       forwarded: 0.2.0
@@ -12334,35 +12354,35 @@ snapshots:
     dependencies:
       glob: 10.5.0
 
-  rollup@4.55.1:
+  rollup@4.60.2:
     dependencies:
       '@types/estree': 1.0.8
     optionalDependencies:
-      '@rollup/rollup-android-arm-eabi': 4.55.1
-      '@rollup/rollup-android-arm64': 4.55.1
-      '@rollup/rollup-darwin-arm64': 4.55.1
-      '@rollup/rollup-darwin-x64': 4.55.1
-      '@rollup/rollup-freebsd-arm64': 4.55.1
-      '@rollup/rollup-freebsd-x64': 4.55.1
-      '@rollup/rollup-linux-arm-gnueabihf': 4.55.1
-      '@rollup/rollup-linux-arm-musleabihf': 4.55.1
-      '@rollup/rollup-linux-arm64-gnu': 4.55.1
-      '@rollup/rollup-linux-arm64-musl': 4.55.1
-      '@rollup/rollup-linux-loong64-gnu': 4.55.1
-      '@rollup/rollup-linux-loong64-musl': 4.55.1
-      '@rollup/rollup-linux-ppc64-gnu': 4.55.1
-      '@rollup/rollup-linux-ppc64-musl': 4.55.1
-      '@rollup/rollup-linux-riscv64-gnu': 4.55.1
-      '@rollup/rollup-linux-riscv64-musl': 4.55.1
-      '@rollup/rollup-linux-s390x-gnu': 4.55.1
-      '@rollup/rollup-linux-x64-gnu': 4.55.1
-      '@rollup/rollup-linux-x64-musl': 4.55.1
-      '@rollup/rollup-openbsd-x64': 4.55.1
-      '@rollup/rollup-openharmony-arm64': 4.55.1
-      '@rollup/rollup-win32-arm64-msvc': 4.55.1
-      '@rollup/rollup-win32-ia32-msvc': 4.55.1
-      '@rollup/rollup-win32-x64-gnu': 4.55.1
-      '@rollup/rollup-win32-x64-msvc': 4.55.1
+      '@rollup/rollup-android-arm-eabi': 4.60.2
+      '@rollup/rollup-android-arm64': 4.60.2
+      '@rollup/rollup-darwin-arm64': 4.60.2
+      '@rollup/rollup-darwin-x64': 4.60.2
+      '@rollup/rollup-freebsd-arm64': 4.60.2
+      '@rollup/rollup-freebsd-x64': 4.60.2
+      '@rollup/rollup-linux-arm-gnueabihf': 4.60.2
+      '@rollup/rollup-linux-arm-musleabihf': 4.60.2
+      '@rollup/rollup-linux-arm64-gnu': 4.60.2
+      '@rollup/rollup-linux-arm64-musl': 4.60.2
+      '@rollup/rollup-linux-loong64-gnu': 4.60.2
+      '@rollup/rollup-linux-loong64-musl': 4.60.2
+      '@rollup/rollup-linux-ppc64-gnu': 4.60.2
+      '@rollup/rollup-linux-ppc64-musl': 4.60.2
+      '@rollup/rollup-linux-riscv64-gnu': 4.60.2
+      '@rollup/rollup-linux-riscv64-musl': 4.60.2
+      '@rollup/rollup-linux-s390x-gnu': 4.60.2
+      '@rollup/rollup-linux-x64-gnu': 4.60.2
+      '@rollup/rollup-linux-x64-musl': 4.60.2
+      '@rollup/rollup-openbsd-x64': 4.60.2
+      '@rollup/rollup-openharmony-arm64': 4.60.2
+      '@rollup/rollup-win32-arm64-msvc': 4.60.2
+      '@rollup/rollup-win32-ia32-msvc': 4.60.2
+      '@rollup/rollup-win32-x64-gnu': 4.60.2
+      '@rollup/rollup-win32-x64-msvc': 4.60.2
       fsevents: 2.3.3
 
   router@2.2.0:
@@ -13203,13 +13223,13 @@ snapshots:
       d3-time: 3.1.0
       d3-timer: 3.0.1
 
-  vite@6.4.1(@types/node@24.12.2)(jiti@1.21.7)(yaml@2.8.2):
+  vite@6.4.2(@types/node@24.12.2)(jiti@1.21.7)(yaml@2.8.2):
     dependencies:
       esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
       postcss: 8.5.6
-      rollup: 4.55.1
+      rollup: 4.60.2
       tinyglobby: 0.2.15
     optionalDependencies:
       '@types/node': 24.12.2
@@ -13220,7 +13240,7 @@ snapshots:
   vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.12.2)(jiti@1.21.7)(jsdom@27.4.0)(yaml@2.8.2):
     dependencies:
       '@vitest/expect': 4.0.18
-      '@vitest/mocker': 4.0.18(vite@6.4.1(@types/node@24.12.2)(jiti@1.21.7)(yaml@2.8.2))
+      '@vitest/mocker': 4.0.18(vite@6.4.2(@types/node@24.12.2)(jiti@1.21.7)(yaml@2.8.2))
       '@vitest/pretty-format': 4.0.18
       '@vitest/runner': 4.0.18
       '@vitest/snapshot': 4.0.18
@@ -13237,7 +13257,7 @@ snapshots:
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vite: 6.4.1(@types/node@24.12.2)(jiti@1.21.7)(yaml@2.8.2)
+      vite: 6.4.2(@types/node@24.12.2)(jiti@1.21.7)(yaml@2.8.2)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.0

--- a/tests/hooks/useLiveSession.test.ts
+++ b/tests/hooks/useLiveSession.test.ts
@@ -1,0 +1,201 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+import * as firestore from 'firebase/firestore';
+import { useLiveSession } from '@/hooks/useLiveSession';
+import { auth } from '@/config/firebase';
+
+vi.mock('firebase/firestore');
+
+describe('useLiveSession — joinSession input validation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (auth as unknown as { currentUser: { uid: string } | null }).currentUser = {
+      uid: 'student-uid-1',
+    };
+
+    // onSnapshot is invoked on mount for the session subscription.
+    // Return a no-op unsubscribe and do not fire a snapshot so state stays pristine.
+    (
+      firestore.onSnapshot as unknown as ReturnType<typeof vi.fn>
+    ).mockImplementation(() => vi.fn());
+
+    (firestore.doc as unknown as ReturnType<typeof vi.fn>).mockReturnValue({});
+    (
+      firestore.collection as unknown as ReturnType<typeof vi.fn>
+    ).mockReturnValue({});
+    (firestore.query as unknown as ReturnType<typeof vi.fn>).mockReturnValue(
+      {}
+    );
+    (firestore.where as unknown as ReturnType<typeof vi.fn>).mockReturnValue(
+      {}
+    );
+  });
+
+  it('throws "Invalid code format" when the code is empty or whitespace', async () => {
+    const { result } = renderHook(() =>
+      useLiveSession(undefined, 'student', 'ABC123')
+    );
+    await expect(result.current.joinSession('1234', '   ')).rejects.toThrow(
+      'Invalid code format'
+    );
+  });
+
+  it('throws "Invalid code format" when the code contains only special characters', async () => {
+    const { result } = renderHook(() =>
+      useLiveSession(undefined, 'student', 'ABC123')
+    );
+    await expect(result.current.joinSession('1234', '!!!---')).rejects.toThrow(
+      'Invalid code format'
+    );
+  });
+
+  it('throws "Session not found" when the query returns no matching session', async () => {
+    (
+      firestore.getDocs as unknown as ReturnType<typeof vi.fn>
+    ).mockResolvedValueOnce({ empty: true, docs: [] });
+
+    const { result } = renderHook(() =>
+      useLiveSession(undefined, 'student', 'ABC123')
+    );
+    await expect(result.current.joinSession('1234', 'ABC123')).rejects.toThrow(
+      'Session not found'
+    );
+  });
+
+  it('throws "PIN is required" when the PIN is empty after trimming', async () => {
+    (
+      firestore.getDocs as unknown as ReturnType<typeof vi.fn>
+    ).mockResolvedValueOnce({
+      empty: false,
+      docs: [{ id: 'teacher-uid-1' }],
+    });
+
+    const { result } = renderHook(() =>
+      useLiveSession(undefined, 'student', 'ABC123')
+    );
+    await expect(result.current.joinSession('   ', 'ABC123')).rejects.toThrow(
+      'PIN is required'
+    );
+  });
+
+  it('throws when no authenticated user is available', async () => {
+    (auth as unknown as { currentUser: null }).currentUser = null;
+
+    (
+      firestore.getDocs as unknown as ReturnType<typeof vi.fn>
+    ).mockResolvedValueOnce({
+      empty: false,
+      docs: [{ id: 'teacher-uid-1' }],
+    });
+
+    const { result } = renderHook(() =>
+      useLiveSession(undefined, 'student', 'ABC123')
+    );
+    await expect(result.current.joinSession('1234', 'ABC123')).rejects.toThrow(
+      'Not authenticated'
+    );
+  });
+
+  it('rejects a duplicate PIN already held by a different student', async () => {
+    // First getDocs: session lookup
+    // Second getDocs: existing students list with duplicate PIN
+    (firestore.getDocs as unknown as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce({
+        empty: false,
+        docs: [{ id: 'teacher-uid-1' }],
+      })
+      .mockResolvedValueOnce({
+        docs: [
+          {
+            id: 'other-student-uid',
+            data: () => ({ pin: '1234' }),
+          },
+        ],
+      });
+
+    const { result } = renderHook(() =>
+      useLiveSession(undefined, 'student', 'ABC123')
+    );
+    await expect(result.current.joinSession('1234', 'ABC123')).rejects.toThrow(
+      /PIN "1234" is already in use/
+    );
+  });
+
+  it('allows the same user to rejoin with their own previously-used PIN', async () => {
+    (firestore.getDocs as unknown as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce({
+        empty: false,
+        docs: [{ id: 'teacher-uid-1' }],
+      })
+      .mockResolvedValueOnce({
+        docs: [
+          {
+            id: 'student-uid-1', // same uid as auth.currentUser
+            data: () => ({ pin: '1234' }),
+          },
+        ],
+      });
+    (
+      firestore.setDoc as unknown as ReturnType<typeof vi.fn>
+    ).mockResolvedValueOnce(undefined);
+
+    const { result } = renderHook(() =>
+      useLiveSession(undefined, 'student', 'ABC123')
+    );
+    let teacherId = '';
+    await act(async () => {
+      teacherId = await result.current.joinSession('1234', 'ABC123');
+    });
+    expect(teacherId).toBe('teacher-uid-1');
+  });
+
+  it('normalizes the code to uppercase and strips non-alphanumeric characters before querying', async () => {
+    (firestore.getDocs as unknown as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce({
+        empty: false,
+        docs: [{ id: 'teacher-uid-1' }],
+      })
+      .mockResolvedValueOnce({ docs: [] });
+    (
+      firestore.setDoc as unknown as ReturnType<typeof vi.fn>
+    ).mockResolvedValueOnce(undefined);
+
+    const { result } = renderHook(() =>
+      useLiveSession(undefined, 'student', 'abc-123')
+    );
+    await act(async () => {
+      await result.current.joinSession('5678', '  abc-123!!  ');
+    });
+
+    const whereCalls = (firestore.where as unknown as ReturnType<typeof vi.fn>)
+      .mock.calls;
+    const codeEqualsCall = whereCalls.find(
+      (args) => args[0] === 'code' && args[1] === '=='
+    );
+    expect(codeEqualsCall).toBeDefined();
+    expect(codeEqualsCall?.[2]).toBe('ABC123');
+  });
+
+  it('truncates a PIN longer than MAX_PIN_LENGTH (10) before writing', async () => {
+    (firestore.getDocs as unknown as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce({
+        empty: false,
+        docs: [{ id: 'teacher-uid-1' }],
+      })
+      .mockResolvedValueOnce({ docs: [] });
+    const setDocMock = firestore.setDoc as unknown as ReturnType<typeof vi.fn>;
+    setDocMock.mockResolvedValueOnce(undefined);
+
+    const { result } = renderHook(() =>
+      useLiveSession(undefined, 'student', 'ABC123')
+    );
+    await act(async () => {
+      await result.current.joinSession('123456789012345', 'ABC123');
+    });
+
+    expect(setDocMock).toHaveBeenCalledTimes(1);
+    const writtenStudent = setDocMock.mock.calls[0][1] as { pin: string };
+    expect(writtenStudent.pin).toBe('1234567890');
+    expect(writtenStudent.pin.length).toBe(10);
+  });
+});


### PR DESCRIPTION
## Summary

Resolves the HIGH-severity `vite` dev server arbitrary file read vulnerability (and the related rollup path traversal CVE) tracked as the top open item in `docs/scheduled-tasks/dependency-audit.md`.

- Upgraded `vite` 6.4.1 → 6.4.2 via `pnpm up vite` (stays within the existing `^6.x` semver range — no breaking-change migration).
- Added `"rollup": "^4.59.0"` to the existing `pnpm.overrides` block. `pnpm up vite` did not pull in a newer rollup on its own, so an explicit override was needed to pick up the path-traversal patch. Rollup now resolves to 4.60.2.
- Verified both advisories are cleared: `pnpm audit` no longer reports entries for `vite` or `rollup`.
- Marked the item **Completed** in `docs/scheduled-tasks/dependency-audit.md` and bumped `_Last action:_` to 2026-04-21.

## Test plan

- [x] `pnpm type-check` — clean
- [x] `pnpm -C functions type-check` — clean
- [x] `pnpm lint --max-warnings 0` — 0 errors, 0 warnings
- [x] `pnpm format:check` — all files formatted
- [x] `pnpm build` — production build succeeds (23.5s)
- [x] `pnpm test` — all 1367 unit tests pass across 150 test files
- [x] `pnpm audit` — confirmed vite and rollup advisories cleared

https://claude.ai/code/session_016YTrc7dKzCsajzix9wQi2q