### PR TITLE
fix(ai): rebuild Guided Learning AI generator with multi-image support

### DIFF
--- a/components/admin/WidgetBuilder/GeminiPanel.tsx
+++ b/components/admin/WidgetBuilder/GeminiPanel.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useCallback } from 'react';
 import { httpsCallable } from 'firebase/functions';
 import { functions } from '@/config/firebase';
-import { Wand2, Wrench, Plus, HelpCircle, Loader2 } from 'lucide-react';
+import { Sparkles, Wrench, Plus, HelpCircle, Loader2 } from 'lucide-react';
 
 interface GeminiPanelProps {
   onGenerate: (code: string) => void;
@@ -110,7 +110,7 @@ export const GeminiPanel: React.FC<GeminiPanelProps> = ({
   return (
     <div className="flex flex-col h-full bg-slate-800 rounded-lg border border-slate-700 overflow-hidden">
       <div className="px-3 py-2 bg-slate-700 border-b border-slate-600 flex items-center gap-2">
-        <Wand2 size={14} className="text-purple-400" />
+        <Sparkles size={14} className="text-brand-blue-light" />
         <span className="text-xs font-semibold text-slate-200">
           AI Assistant
         </span>
@@ -121,7 +121,7 @@ export const GeminiPanel: React.FC<GeminiPanelProps> = ({
           value={description}
           onChange={(e) => setDescription(e.target.value)}
           placeholder="Describe what you want this widget to do..."
-          className="w-full bg-slate-900 border border-slate-600 rounded px-3 py-2 text-sm text-slate-200 placeholder-slate-500 resize-none focus:outline-none focus:border-purple-500 transition-colors"
+          className="w-full bg-slate-900 border border-slate-600 rounded px-3 py-2 text-sm text-slate-200 placeholder-slate-500 resize-none focus:outline-none focus:border-brand-blue-light transition-colors"
           rows={3}
         />
 
@@ -129,9 +129,9 @@ export const GeminiPanel: React.FC<GeminiPanelProps> = ({
           <button
             onClick={() => handleAction('generate')}
             disabled={loading}
-            className="flex items-center justify-center gap-1.5 px-3 py-2 bg-purple-600 hover:bg-purple-700 disabled:opacity-50 disabled:cursor-not-allowed text-white text-xs font-medium rounded transition-colors"
+            className="flex items-center justify-center gap-1.5 px-3 py-2 bg-brand-blue-primary hover:bg-brand-blue-dark disabled:opacity-50 disabled:cursor-not-allowed text-white text-xs font-medium rounded transition-colors"
           >
-            <Wand2 size={12} />
+            <Sparkles size={12} />
             Generate
           </button>
           <button

--- a/components/common/DriveFileAttachment.tsx
+++ b/components/common/DriveFileAttachment.tsx
@@ -13,6 +13,13 @@ interface DriveFileAttachmentProps {
   /** Notified when extraction starts/stops so callers can gate Generate. */
   onExtractingChange?: (extracting: boolean) => void;
   className?: string;
+  /** Button label. Defaults to "Attach file from Drive". */
+  label?: string;
+  /**
+   * Color palette. `'light'` (default) is indigo-on-white for light
+   * containers; `'dark'` is slate-on-transparent for dark overlays.
+   */
+  variant?: 'light' | 'dark';
 }
 
 /**
@@ -27,6 +34,8 @@ export const DriveFileAttachment: React.FC<DriveFileAttachmentProps> = ({
   disabled = false,
   onExtractingChange,
   className = '',
+  label = 'Attach file from Drive',
+  variant = 'light',
 }) => {
   const { openPicker, isConnected } = useGooglePicker();
   const { getDriveFileTextContent } = useGoogleDrive();
@@ -62,45 +71,43 @@ export const DriveFileAttachment: React.FC<DriveFileAttachmentProps> = ({
     };
   }, []);
 
-  const handlePick = useCallback(async () => {
-    if (disabled || isExtracting) return;
-    setError(null);
+  const handlePick = useCallback(
+    async (e?: React.MouseEvent) => {
+      if (e) e.stopPropagation();
+      if (disabled || isExtracting) return;
+      setError(null);
 
-    try {
-      const file = await openPicker();
-      if (!file) return; // User cancelled
+      try {
+        const file = await openPicker({ mode: 'docs' });
+        if (!file) return; // User cancelled
 
-      setSelectedFile(file);
-      setIsExtracting(true);
+        setSelectedFile(file);
+        setIsExtracting(true);
 
-      const text = await getDriveFileTextContent(file.id);
-      if (!text) {
-        setError(
-          'Could not extract text from this file. Try a Google Doc, Sheet, Slides, or text file.'
-        );
+        const text = await getDriveFileTextContent(file.id);
+        if (!text) {
+          setError(
+            'Could not extract text from this file. Try a Google Doc, Sheet, Slides, or text file.'
+          );
+          setSelectedFile(null);
+          onFileContent(null, null);
+          return;
+        }
+
+        const trimmed = text.substring(0, FILE_TEXT_LIMIT);
+        onFileContent(trimmed, file.name);
+      } catch (err) {
+        const message =
+          err instanceof Error ? err.message : 'Failed to read file';
+        setError(message);
         setSelectedFile(null);
         onFileContent(null, null);
-        return;
+      } finally {
+        setIsExtracting(false);
       }
-
-      const trimmed = text.substring(0, FILE_TEXT_LIMIT);
-      onFileContent(trimmed, file.name);
-    } catch (err) {
-      const message =
-        err instanceof Error ? err.message : 'Failed to read file';
-      setError(message);
-      setSelectedFile(null);
-      onFileContent(null, null);
-    } finally {
-      setIsExtracting(false);
-    }
-  }, [
-    disabled,
-    isExtracting,
-    openPicker,
-    getDriveFileTextContent,
-    onFileContent,
-  ]);
+    },
+    [disabled, isExtracting, openPicker, getDriveFileTextContent, onFileContent]
+  );
 
   const handleRemove = useCallback(() => {
     setSelectedFile(null);
@@ -112,26 +119,50 @@ export const DriveFileAttachment: React.FC<DriveFileAttachmentProps> = ({
     return null; // Don't show anything if Drive is not connected
   }
 
+  const isDark = variant === 'dark';
+
+  const pillClasses = isDark
+    ? 'flex items-center gap-2 px-3 py-2 bg-white/5 border border-white/10 rounded-xl text-xs'
+    : 'flex items-center gap-2 px-3 py-2 bg-indigo-50 border border-indigo-200 rounded-xl text-xs';
+
+  const iconClasses = isDark
+    ? 'w-3.5 h-3.5 text-slate-300 shrink-0'
+    : 'w-3.5 h-3.5 text-indigo-500 shrink-0';
+
+  const fileNameClasses = isDark
+    ? 'text-slate-200 font-medium truncate flex-1'
+    : 'text-indigo-700 font-medium truncate flex-1';
+
+  const removeButtonClasses = isDark
+    ? 'p-0.5 hover:bg-white/10 rounded text-slate-400 hover:text-slate-200 transition-colors'
+    : 'p-0.5 hover:bg-indigo-200 rounded text-indigo-400 hover:text-indigo-600 transition-colors';
+
+  const extractingPillClasses = isDark
+    ? 'flex items-center gap-2 px-3 py-2 bg-white/5 border border-white/10 rounded-xl text-xs text-slate-300'
+    : 'flex items-center gap-2 px-3 py-2 bg-indigo-50 border border-indigo-200 rounded-xl text-xs text-indigo-500';
+
+  const pickButtonClasses = isDark
+    ? 'flex items-center gap-1.5 px-3 py-2 text-xs font-bold text-slate-200 hover:text-white bg-white/5 hover:bg-white/10 border border-dashed border-white/10 hover:border-white/20 rounded-xl transition-colors disabled:opacity-50 disabled:cursor-not-allowed'
+    : 'flex items-center gap-1.5 px-3 py-2 text-xs font-bold text-indigo-500 hover:text-indigo-700 bg-indigo-50/50 hover:bg-indigo-50 border border-dashed border-indigo-200 hover:border-indigo-300 rounded-xl transition-colors disabled:opacity-50 disabled:cursor-not-allowed';
+
   return (
     <div className={`flex flex-col gap-1.5 ${className}`}>
       {selectedFile && !isExtracting ? (
-        <div className="flex items-center gap-2 px-3 py-2 bg-indigo-50 border border-indigo-200 rounded-xl text-xs">
-          <FileText className="w-3.5 h-3.5 text-indigo-500 shrink-0" />
-          <span className="text-indigo-700 font-medium truncate flex-1">
-            {selectedFile.name}
-          </span>
+        <div className={pillClasses}>
+          <FileText className={iconClasses} />
+          <span className={fileNameClasses}>{selectedFile.name}</span>
           <button
             type="button"
             onClick={handleRemove}
             disabled={disabled}
-            className="p-0.5 hover:bg-indigo-200 rounded text-indigo-400 hover:text-indigo-600 transition-colors"
+            className={removeButtonClasses}
             aria-label="Remove attached file"
           >
             <X className="w-3.5 h-3.5" />
           </button>
         </div>
       ) : isExtracting ? (
-        <div className="flex items-center gap-2 px-3 py-2 bg-indigo-50 border border-indigo-200 rounded-xl text-xs text-indigo-500">
+        <div className={extractingPillClasses}>
           <Loader2 className="w-3.5 h-3.5 animate-spin shrink-0" />
           <span className="font-medium truncate">
             Reading {selectedFile?.name}...
@@ -142,14 +173,14 @@ export const DriveFileAttachment: React.FC<DriveFileAttachmentProps> = ({
           type="button"
           onClick={handlePick}
           disabled={disabled}
-          className="flex items-center gap-1.5 px-3 py-2 text-xs font-bold text-indigo-500 hover:text-indigo-700 bg-indigo-50/50 hover:bg-indigo-50 border border-dashed border-indigo-200 hover:border-indigo-300 rounded-xl transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          className={pickButtonClasses}
         >
           <HardDrive className="w-3.5 h-3.5" />
-          Attach file from Drive
+          {label}
         </button>
       )}
       {error && (
-        <div className="flex items-center gap-1.5 text-xs text-red-500 animate-in slide-in-from-top-1">
+        <div className="flex items-center gap-1.5 text-xs text-red-400 animate-in slide-in-from-top-1">
           <AlertCircle className="w-3 h-3 shrink-0" />
           <span>{error}</span>
         </div>

--- a/components/common/DriveImagePicker.tsx
+++ b/components/common/DriveImagePicker.tsx
@@ -1,0 +1,140 @@
+import React, { useCallback, useState } from 'react';
+import { Loader2, ImageIcon, AlertCircle } from 'lucide-react';
+import { useGooglePicker } from '@/hooks/useGooglePicker';
+import { useGoogleDrive } from '@/hooks/useGoogleDrive';
+import { useStorage } from '@/hooks/useStorage';
+import { useAuth } from '@/context/useAuth';
+
+export interface PickedDriveImage {
+  url: string;
+  base64: string;
+  mimeType: string;
+  fileName: string;
+}
+
+interface DriveImagePickerProps {
+  onImageAdded: (image: PickedDriveImage) => void;
+  disabled?: boolean;
+  className?: string;
+  label?: string;
+  variant?: 'light' | 'dark';
+  maxItems?: number;
+}
+
+const blobToBase64 = (blob: Blob): Promise<string> =>
+  new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      const dataUrl = reader.result as string;
+      const commaIndex = dataUrl.indexOf(',');
+      resolve(commaIndex >= 0 ? dataUrl.slice(commaIndex + 1) : dataUrl);
+    };
+    reader.onerror = () => reject(reader.error ?? new Error('Read failed'));
+    reader.readAsDataURL(blob);
+  });
+
+/**
+ * Lets users pick one or more images from Google Drive. Each pick is
+ * uploaded to Firebase Storage (via `uploadHotspotImage`) and converted to
+ * base64 in parallel so the consumer can both render it and send the bytes
+ * to Gemini.
+ */
+export const DriveImagePicker: React.FC<DriveImagePickerProps> = ({
+  onImageAdded,
+  disabled = false,
+  className = '',
+  label = 'Add image from Drive',
+  variant = 'light',
+  maxItems = 5,
+}) => {
+  const { user } = useAuth();
+  const { openPicker, isConnected } = useGooglePicker();
+  const { getDriveFileAsBlob } = useGoogleDrive();
+  const { uploadHotspotImage } = useStorage();
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handlePick = useCallback(
+    async (e?: React.MouseEvent) => {
+      if (e) e.stopPropagation();
+      if (disabled || loading || !user) return;
+      setError(null);
+
+      try {
+        const picked = await openPicker({ mode: 'images', maxItems });
+        if (!picked) return;
+
+        setLoading(true);
+        const downloaded = await getDriveFileAsBlob(picked.id);
+        if (!downloaded) {
+          setError('Could not download the selected image from Drive.');
+          return;
+        }
+
+        const file = new File([downloaded.blob], downloaded.name, {
+          type: downloaded.mimeType,
+        });
+
+        const [url, base64] = await Promise.all([
+          uploadHotspotImage(user.uid, file),
+          blobToBase64(downloaded.blob),
+        ]);
+
+        onImageAdded({
+          url,
+          base64,
+          mimeType: downloaded.mimeType,
+          fileName: downloaded.name,
+        });
+      } catch (err) {
+        const message =
+          err instanceof Error ? err.message : 'Failed to add Drive image';
+        setError(message);
+      } finally {
+        setLoading(false);
+      }
+    },
+    [
+      disabled,
+      loading,
+      user,
+      openPicker,
+      getDriveFileAsBlob,
+      uploadHotspotImage,
+      onImageAdded,
+      maxItems,
+    ]
+  );
+
+  if (!isConnected) return null;
+
+  const isDark = variant === 'dark';
+
+  const buttonClasses = isDark
+    ? 'flex items-center gap-1.5 px-3 py-2 text-xs font-bold text-slate-200 hover:text-white bg-white/5 hover:bg-white/10 border border-dashed border-white/10 hover:border-white/20 rounded-xl transition-colors disabled:opacity-50 disabled:cursor-not-allowed'
+    : 'flex items-center gap-1.5 px-3 py-2 text-xs font-bold text-indigo-500 hover:text-indigo-700 bg-indigo-50/50 hover:bg-indigo-50 border border-dashed border-indigo-200 hover:border-indigo-300 rounded-xl transition-colors disabled:opacity-50 disabled:cursor-not-allowed';
+
+  return (
+    <div className={`flex flex-col gap-1.5 ${className}`}>
+      <button
+        type="button"
+        onClick={handlePick}
+        disabled={disabled || loading}
+        className={buttonClasses}
+      >
+        {loading ? (
+          <Loader2 className="w-3.5 h-3.5 animate-spin" />
+        ) : (
+          <ImageIcon className="w-3.5 h-3.5" />
+        )}
+        {loading ? 'Adding image…' : label}
+      </button>
+      {error && (
+        <div className="flex items-center gap-1.5 text-xs text-red-400 animate-in slide-in-from-top-1">
+          <AlertCircle className="w-3 h-3 shrink-0" />
+          <span>{error}</span>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/components/common/DriveImagePicker.tsx
+++ b/components/common/DriveImagePicker.tsx
@@ -19,14 +19,14 @@ interface DriveImagePickerProps {
   className?: string;
   label?: string;
   variant?: 'light' | 'dark';
-  maxItems?: number;
 }
 
 /**
- * Lets users pick one or more images from Google Drive. Each pick is
+ * Lets users pick a single image from Google Drive. The picked file is
  * uploaded to Firebase Storage (via `uploadHotspotImage`) and converted to
  * base64 in parallel so the consumer can both render it and send the bytes
- * to Gemini.
+ * to Gemini. Callers that need multiple images should invoke this once per
+ * image.
  */
 export const DriveImagePicker: React.FC<DriveImagePickerProps> = ({
   onImageAdded,
@@ -34,7 +34,6 @@ export const DriveImagePicker: React.FC<DriveImagePickerProps> = ({
   className = '',
   label = 'Add image from Drive',
   variant = 'light',
-  maxItems = 5,
 }) => {
   const { user } = useAuth();
   const { openPicker, isConnected } = useGooglePicker();
@@ -50,7 +49,7 @@ export const DriveImagePicker: React.FC<DriveImagePickerProps> = ({
       setError(null);
 
       try {
-        const picked = await openPicker({ mode: 'images', maxItems });
+        const picked = await openPicker({ mode: 'images' });
         if (!picked) return;
 
         setLoading(true);
@@ -91,7 +90,6 @@ export const DriveImagePicker: React.FC<DriveImagePickerProps> = ({
       getDriveFileAsBlob,
       uploadHotspotImage,
       onImageAdded,
-      maxItems,
     ]
   );
 

--- a/components/common/DriveImagePicker.tsx
+++ b/components/common/DriveImagePicker.tsx
@@ -4,6 +4,7 @@ import { useGooglePicker } from '@/hooks/useGooglePicker';
 import { useGoogleDrive } from '@/hooks/useGoogleDrive';
 import { useStorage } from '@/hooks/useStorage';
 import { useAuth } from '@/context/useAuth';
+import { blobToBase64 } from '@/utils/fileEncoding';
 
 export interface PickedDriveImage {
   url: string;
@@ -20,18 +21,6 @@ interface DriveImagePickerProps {
   variant?: 'light' | 'dark';
   maxItems?: number;
 }
-
-const blobToBase64 = (blob: Blob): Promise<string> =>
-  new Promise((resolve, reject) => {
-    const reader = new FileReader();
-    reader.onload = () => {
-      const dataUrl = reader.result as string;
-      const commaIndex = dataUrl.indexOf(',');
-      resolve(commaIndex >= 0 ? dataUrl.slice(commaIndex + 1) : dataUrl);
-    };
-    reader.onerror = () => reject(reader.error ?? new Error('Read failed'));
-    reader.readAsDataURL(blob);
-  });
 
 /**
  * Lets users pick one or more images from Google Drive. Each pick is

--- a/components/common/library/importer/ImportWizard.tsx
+++ b/components/common/library/importer/ImportWizard.tsx
@@ -400,14 +400,14 @@ export function ImportWizard<TData>({
         <button
           type="button"
           onClick={() => setAiOpen(true)}
-          className="w-full py-4 bg-gradient-to-br from-indigo-500/10 to-purple-500/10 hover:from-indigo-500/20 hover:to-purple-500/20 border-2 border-dashed border-indigo-500/30 rounded-2xl flex flex-col items-center justify-center gap-1 transition-all group active:scale-95"
+          className="w-full py-4 bg-slate-50 hover:bg-slate-100 border-2 border-dashed border-slate-300 hover:border-brand-blue-primary/40 rounded-2xl flex flex-col items-center justify-center gap-1 transition-colors group active:scale-95"
           aria-label={`AI-assist import for ${adapter.widgetLabel}`}
         >
-          <Sparkles className="w-6 h-6 text-indigo-500 group-hover:scale-110 transition-transform" />
-          <span className="font-black text-indigo-600 text-xs uppercase tracking-widest">
-            AI-assist
+          <Sparkles className="w-6 h-6 text-brand-blue-primary group-hover:scale-110 transition-transform" />
+          <span className="font-black text-brand-blue-dark text-xs uppercase tracking-widest">
+            Draft with AI
           </span>
-          <p className="text-[11px] text-indigo-400 font-bold">
+          <p className="text-[11px] text-slate-500 font-bold">
             Describe it and we&apos;ll draft it.
           </p>
         </button>

--- a/components/layout/dock/ImagePastePickerModal.tsx
+++ b/components/layout/dock/ImagePastePickerModal.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ImageIcon, Wand2, X } from 'lucide-react';
+import { ImageIcon, Sparkles, X } from 'lucide-react';
 import { GlassCard } from '@/components/common/GlassCard';
 import { Modal } from '@/components/common/Modal';
 import { GlobalStyle } from '@/types';
@@ -47,7 +47,7 @@ export const ImagePastePickerModal: React.FC<ImagePastePickerModalProps> = ({
             className="group flex flex-col items-center gap-3 p-5 bg-amber-50 hover:bg-amber-100 border-2 border-amber-200 hover:border-amber-400 rounded-2xl transition-all active:scale-95 text-left"
           >
             <div className="w-11 h-11 rounded-xl bg-amber-400 flex items-center justify-center shadow-md shadow-amber-300/40 group-hover:scale-110 transition-transform">
-              <Wand2 className="w-5 h-5 text-white" />
+              <Sparkles className="w-5 h-5 text-white" />
             </div>
             <div>
               <p className="text-xs font-black uppercase tracking-widest text-amber-800">

--- a/components/layout/dock/MagicLayoutModal.tsx
+++ b/components/layout/dock/MagicLayoutModal.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Wand2, Loader2 } from 'lucide-react';
+import { Sparkles, Loader2 } from 'lucide-react';
 import { GlassCard } from '@/components/common/GlassCard';
 import { Modal } from '@/components/common/Modal';
 import {
@@ -40,7 +40,7 @@ export const MagicLayoutModal: React.FC<MagicLayoutModalProps> = ({
       );
       const widgets = await generateDashboardLayout(fullDescription);
       addWidgets(widgets);
-      addToast('Magic layout generated!', 'success');
+      addToast('Layout generated!', 'success');
       onClose();
     } catch (error) {
       console.error(error);
@@ -62,12 +62,12 @@ export const MagicLayoutModal: React.FC<MagicLayoutModalProps> = ({
     >
       <GlassCard className="w-full max-w-lg p-6 shadow-2xl animate-in zoom-in-95 duration-200">
         <div className="flex items-center gap-3 mb-4">
-          <div className="p-2 bg-gradient-to-br from-indigo-500 to-purple-600 rounded-xl shadow-lg text-white">
-            <Wand2 className="w-5 h-5" />
+          <div className="p-2 bg-brand-blue-primary rounded-xl shadow-sm text-white">
+            <Sparkles className="w-5 h-5" />
           </div>
           <div>
             <h3 className="text-sm font-black uppercase tracking-widest text-slate-800">
-              Magic Layout
+              Layout Generator
             </h3>
             <p className="text-xs text-slate-500">
               Describe your lesson, and AI will set it up.
@@ -132,7 +132,7 @@ export const MagicLayoutModal: React.FC<MagicLayoutModalProps> = ({
           <button
             onClick={handleGenerate}
             disabled={isGenerating || !description.trim()}
-            className="flex-[2] py-3 text-xs font-black uppercase tracking-widest text-white bg-gradient-to-r from-indigo-600 to-purple-600 rounded-xl hover:from-indigo-700 hover:to-purple-700 shadow-lg shadow-purple-500/25 transition-all flex items-center justify-center gap-2 disabled:opacity-50 disabled:cursor-not-allowed"
+            className="flex-[2] py-3 text-xs font-black uppercase tracking-widest text-white bg-brand-blue-primary hover:bg-brand-blue-dark rounded-xl shadow-sm transition-colors flex items-center justify-center gap-2 disabled:opacity-50 disabled:cursor-not-allowed"
           >
             {isGenerating ? (
               <>
@@ -141,8 +141,8 @@ export const MagicLayoutModal: React.FC<MagicLayoutModalProps> = ({
               </>
             ) : (
               <>
-                <Wand2 className="w-4 h-4" />
-                <span>Cast Spell</span>
+                <Sparkles className="w-4 h-4" />
+                <span>Draft with AI</span>
               </>
             )}
           </button>

--- a/components/widgets/Embed/Widget.tsx
+++ b/components/widgets/Embed/Widget.tsx
@@ -6,7 +6,7 @@ import {
   ExternalLink,
   Code,
   XCircle,
-  Wand2,
+  Sparkles,
   Loader2,
   ZoomIn,
   ZoomOut,
@@ -513,7 +513,7 @@ export const EmbedWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
                     {isGeneratingApp ? (
                       <Loader2 className="w-4 h-4 animate-spin" />
                     ) : (
-                      <Wand2 className="w-4 h-4" />
+                      <Sparkles className="w-4 h-4" />
                     )}
                   </button>
                 )}

--- a/components/widgets/GuidedLearning/components/GuidedLearningAIGenerator.tsx
+++ b/components/widgets/GuidedLearning/components/GuidedLearningAIGenerator.tsx
@@ -37,6 +37,7 @@ import {
   DriveImagePicker,
   PickedDriveImage,
 } from '@/components/common/DriveImagePicker';
+import { blobToBase64 } from '@/utils/fileEncoding';
 import { Z_INDEX } from '@/config/zIndex';
 
 interface Props {
@@ -52,18 +53,6 @@ interface GeneratorImage {
   fileName: string;
   caption: string;
 }
-
-const fileToBase64 = (file: Blob): Promise<string> =>
-  new Promise((resolve, reject) => {
-    const reader = new FileReader();
-    reader.onload = () => {
-      const dataUrl = reader.result as string;
-      const commaIndex = dataUrl.indexOf(',');
-      resolve(commaIndex >= 0 ? dataUrl.slice(commaIndex + 1) : dataUrl);
-    };
-    reader.onerror = () => reject(reader.error ?? new Error('Read failed'));
-    reader.readAsDataURL(file);
-  });
 
 interface SortableImageRowProps {
   image: GeneratorImage;
@@ -189,7 +178,7 @@ export const GuidedLearningAIGenerator: React.FC<Props> = ({
           files.map(async (file) => {
             const [url, base64] = await Promise.all([
               uploadHotspotImage(user.uid, file),
-              fileToBase64(file),
+              blobToBase64(file),
             ]);
             return {
               id: crypto.randomUUID(),

--- a/components/widgets/GuidedLearning/components/GuidedLearningAIGenerator.tsx
+++ b/components/widgets/GuidedLearning/components/GuidedLearningAIGenerator.tsx
@@ -76,7 +76,7 @@ const SortableImageRow: React.FC<SortableImageRowProps> = ({
     transform,
     transition,
     isDragging,
-  } = useSortable({ id: image.id });
+  } = useSortable({ id: image.id, disabled });
 
   const style = {
     transform: CSS.Transform.toString(transform),
@@ -97,9 +97,10 @@ const SortableImageRow: React.FC<SortableImageRowProps> = ({
       <div className="flex items-center gap-2">
         <button
           type="button"
-          {...attributes}
-          {...listeners}
-          className="cursor-grab active:cursor-grabbing p-1 text-slate-400 hover:text-slate-200 transition-colors"
+          {...(disabled ? {} : attributes)}
+          {...(disabled ? {} : listeners)}
+          disabled={disabled}
+          className="cursor-grab active:cursor-grabbing p-1 text-slate-400 hover:text-slate-200 transition-colors disabled:cursor-not-allowed disabled:opacity-50"
           aria-label="Drag to reorder"
         >
           <GripVertical className="w-4 h-4" />
@@ -277,12 +278,15 @@ export const GuidedLearningAIGenerator: React.FC<Props> = ({
 
   const handleGenerate = async () => {
     if (images.length === 0) return;
+    // Snapshot the image order at kickoff so a late reorder or remove can't
+    // desync the `imageIndex` values Gemini sees from the final `imageUrls`.
+    const snapshot = images;
     setGenerating(true);
     setError('');
     try {
       const fullPrompt =
         buildPromptWithFileContext(prompt, fileContext, fileName) || undefined;
-      const aiImages: GuidedLearningImageInput[] = images.map((img) => ({
+      const aiImages: GuidedLearningImageInput[] = snapshot.map((img) => ({
         base64: img.base64,
         mimeType: img.mimeType,
         caption: img.caption.trim() || undefined,
@@ -291,7 +295,7 @@ export const GuidedLearningAIGenerator: React.FC<Props> = ({
       const set: GuidedLearningSet = {
         id: crypto.randomUUID(),
         title: result.suggestedTitle,
-        imageUrls: images.map((img) => img.url),
+        imageUrls: snapshot.map((img) => img.url),
         steps: result.steps,
         mode: result.suggestedMode,
         createdAt: Date.now(),

--- a/components/widgets/GuidedLearning/components/GuidedLearningAIGenerator.tsx
+++ b/components/widgets/GuidedLearning/components/GuidedLearningAIGenerator.tsx
@@ -1,15 +1,161 @@
-import React, { useState, useRef } from 'react';
-import { Wand2, Upload, Loader2, X } from 'lucide-react';
+import React, { useCallback, useRef, useState } from 'react';
+import {
+  Sparkles,
+  Upload,
+  Loader2,
+  X,
+  GripVertical,
+  Trash2,
+} from 'lucide-react';
+import {
+  DndContext,
+  closestCenter,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  DragEndEvent,
+} from '@dnd-kit/core';
+import {
+  arrayMove,
+  SortableContext,
+  sortableKeyboardCoordinates,
+  verticalListSortingStrategy,
+  useSortable,
+} from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
 import { GuidedLearningSet } from '@/types';
-import { generateGuidedLearning, buildPromptWithFileContext } from '@/utils/ai';
+import {
+  generateGuidedLearning,
+  buildPromptWithFileContext,
+  GuidedLearningImageInput,
+} from '@/utils/ai';
 import { useStorage } from '@/hooks/useStorage';
 import { useAuth } from '@/context/useAuth';
 import { DriveFileAttachment } from '@/components/common/DriveFileAttachment';
+import {
+  DriveImagePicker,
+  PickedDriveImage,
+} from '@/components/common/DriveImagePicker';
+import { Z_INDEX } from '@/config/zIndex';
 
 interface Props {
   onClose: () => void;
   onGenerated: (set: GuidedLearningSet) => void;
 }
+
+interface GeneratorImage {
+  id: string;
+  url: string;
+  base64: string;
+  mimeType: string;
+  fileName: string;
+  caption: string;
+}
+
+const fileToBase64 = (file: Blob): Promise<string> =>
+  new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      const dataUrl = reader.result as string;
+      const commaIndex = dataUrl.indexOf(',');
+      resolve(commaIndex >= 0 ? dataUrl.slice(commaIndex + 1) : dataUrl);
+    };
+    reader.onerror = () => reject(reader.error ?? new Error('Read failed'));
+    reader.readAsDataURL(file);
+  });
+
+interface SortableImageRowProps {
+  image: GeneratorImage;
+  index: number;
+  onCaptionChange: (id: string, caption: string) => void;
+  onRemove: (id: string) => void;
+  disabled: boolean;
+}
+
+const SortableImageRow: React.FC<SortableImageRowProps> = ({
+  image,
+  index,
+  onCaptionChange,
+  onRemove,
+  disabled,
+}) => {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id: image.id });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    zIndex: isDragging ? Z_INDEX.itemDragging : undefined,
+  };
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      className={`grid grid-cols-[auto_1fr] gap-3 p-2.5 bg-white/5 border rounded-xl ${
+        isDragging
+          ? 'border-brand-blue-light/60 shadow-lg opacity-80'
+          : 'border-white/10'
+      }`}
+    >
+      <div className="flex items-center gap-2">
+        <button
+          type="button"
+          {...attributes}
+          {...listeners}
+          className="cursor-grab active:cursor-grabbing p-1 text-slate-400 hover:text-slate-200 transition-colors"
+          aria-label="Drag to reorder"
+        >
+          <GripVertical className="w-4 h-4" />
+        </button>
+        <div className="relative w-16 h-16 rounded-lg overflow-hidden bg-slate-800 shrink-0">
+          <img
+            src={image.url}
+            alt={image.fileName}
+            className="w-full h-full object-cover"
+          />
+          <span className="absolute top-1 left-1 px-1.5 py-0.5 text-[10px] font-bold bg-black/60 text-white rounded">
+            {index + 1}
+          </span>
+        </div>
+      </div>
+      <div className="flex flex-col gap-1 min-w-0">
+        <div className="flex items-start gap-2">
+          <span
+            className="text-xs text-slate-300 font-medium truncate flex-1"
+            title={image.fileName}
+          >
+            {image.fileName}
+          </span>
+          <button
+            type="button"
+            onClick={() => onRemove(image.id)}
+            disabled={disabled}
+            className="p-1 text-slate-400 hover:text-red-400 transition-colors disabled:opacity-50"
+            aria-label="Remove image"
+          >
+            <Trash2 className="w-3.5 h-3.5" />
+          </button>
+        </div>
+        <textarea
+          value={image.caption}
+          onChange={(e) => onCaptionChange(image.id, e.target.value)}
+          placeholder="Optional notes for this image…"
+          rows={2}
+          disabled={disabled}
+          className="w-full bg-slate-900/60 border border-white/10 rounded-md px-2 py-1.5 text-xs text-slate-200 placeholder:text-slate-500 focus:border-brand-blue-light focus:outline-none resize-none disabled:opacity-50"
+        />
+      </div>
+    </div>
+  );
+};
 
 export const GuidedLearningAIGenerator: React.FC<Props> = ({
   onClose,
@@ -17,68 +163,146 @@ export const GuidedLearningAIGenerator: React.FC<Props> = ({
 }) => {
   const { user, canAccessFeature } = useAuth();
   const { uploading, uploadHotspotImage } = useStorage();
-  const [imageUrl, setImageUrl] = useState('');
-  const [imageBase64, setImageBase64] = useState('');
-  const [imageMimeType, setImageMimeType] = useState('');
+  const [images, setImages] = useState<GeneratorImage[]>([]);
   const [prompt, setPrompt] = useState('');
   const [generating, setGenerating] = useState(false);
+  const [uploadingImages, setUploadingImages] = useState(false);
   const [error, setError] = useState('');
   const [fileContext, setFileContext] = useState<string | null>(null);
   const [fileName, setFileName] = useState<string | null>(null);
   const fileRef = useRef<HTMLInputElement>(null);
 
-  const handleFile = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0];
-    if (!file || !user) return;
-    setError('');
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 4 } }),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    })
+  );
 
-    // Convert to base64 for Gemini
-    const reader = new FileReader();
-    reader.onload = async () => {
-      const dataUrl = reader.result as string;
-      const base64 = dataUrl.split(',')[1];
-      setImageBase64(base64);
-      setImageMimeType(file.type);
-      // Upload to Storage; if it fails, reject rather than persisting a large data URI
+  const addFiles = useCallback(
+    async (files: File[]) => {
+      if (files.length === 0 || !user) return;
+      setError('');
+      setUploadingImages(true);
       try {
-        const url = await uploadHotspotImage(user.uid, file);
-        setImageUrl(url);
+        const uploads = await Promise.all(
+          files.map(async (file) => {
+            const [url, base64] = await Promise.all([
+              uploadHotspotImage(user.uid, file),
+              fileToBase64(file),
+            ]);
+            return {
+              id: crypto.randomUUID(),
+              url,
+              base64,
+              mimeType: file.type || 'image/png',
+              fileName: file.name || 'pasted-image',
+              caption: '',
+            };
+          })
+        );
+        setImages((prev) => [...prev, ...uploads]);
       } catch (err) {
         const msg =
           err instanceof Error
             ? err.message
             : 'Image upload failed. Please check your connection and try again.';
         setError(msg);
-        setImageBase64('');
-        setImageMimeType('');
+      } finally {
+        setUploadingImages(false);
       }
-    };
-    reader.onerror = () => {
-      setError(
-        'Could not read the selected file. Try a different image (JPEG or PNG).'
-      );
-      setImageBase64('');
-      setImageMimeType('');
-    };
-    reader.readAsDataURL(file);
+    },
+    [user, uploadHotspotImage]
+  );
+
+  const handleFileInput = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const files = Array.from(e.target.files ?? []);
+    e.target.value = '';
+    if (files.length > 0) void addFiles(files);
   };
 
+  const handlePaste = useCallback(
+    (e: React.ClipboardEvent<HTMLDivElement>) => {
+      const items = e.clipboardData?.items;
+      if (!items) return;
+      const imageFiles: File[] = [];
+      for (const item of items) {
+        if (item.type.startsWith('image/')) {
+          const file = item.getAsFile();
+          if (file) imageFiles.push(file);
+        }
+      }
+      if (imageFiles.length > 0) {
+        e.preventDefault();
+        void addFiles(imageFiles);
+      }
+    },
+    [addFiles]
+  );
+
+  const handleDrop = useCallback(
+    (e: React.DragEvent<HTMLDivElement>) => {
+      e.preventDefault();
+      const files = Array.from(e.dataTransfer.files).filter((f) =>
+        f.type.startsWith('image/')
+      );
+      if (files.length > 0) void addFiles(files);
+    },
+    [addFiles]
+  );
+
+  const handleDriveImageAdded = useCallback((picked: PickedDriveImage) => {
+    setImages((prev) => [
+      ...prev,
+      {
+        id: crypto.randomUUID(),
+        url: picked.url,
+        base64: picked.base64,
+        mimeType: picked.mimeType,
+        fileName: picked.fileName,
+        caption: '',
+      },
+    ]);
+  }, []);
+
+  const handleCaptionChange = useCallback((id: string, caption: string) => {
+    setImages((prev) =>
+      prev.map((img) => (img.id === id ? { ...img, caption } : img))
+    );
+  }, []);
+
+  const handleRemove = useCallback((id: string) => {
+    setImages((prev) => prev.filter((img) => img.id !== id));
+  }, []);
+
+  const handleDragEnd = useCallback((event: DragEndEvent) => {
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+    setImages((prev) => {
+      const oldIndex = prev.findIndex((img) => img.id === active.id);
+      const newIndex = prev.findIndex((img) => img.id === over.id);
+      if (oldIndex === -1 || newIndex === -1) return prev;
+      return arrayMove(prev, oldIndex, newIndex);
+    });
+  }, []);
+
   const handleGenerate = async () => {
-    if (!imageBase64 || !imageUrl) return;
+    if (images.length === 0) return;
     setGenerating(true);
     setError('');
     try {
       const fullPrompt =
         buildPromptWithFileContext(prompt, fileContext, fileName) || undefined;
-      const result = await generateGuidedLearning(
-        imageBase64,
-        imageMimeType,
-        fullPrompt
-      );
+      const aiImages: GuidedLearningImageInput[] = images.map((img) => ({
+        base64: img.base64,
+        mimeType: img.mimeType,
+        caption: img.caption.trim() || undefined,
+      }));
+      const result = await generateGuidedLearning(aiImages, fullPrompt);
       const set: GuidedLearningSet = {
         id: crypto.randomUUID(),
         title: result.suggestedTitle,
-        imageUrls: [imageUrl],
+        imageUrls: images.map((img) => img.url),
         steps: result.steps,
         mode: result.suggestedMode,
         createdAt: Date.now(),
@@ -95,13 +319,20 @@ export const GuidedLearningAIGenerator: React.FC<Props> = ({
     }
   };
 
+  const busy = generating || uploading || uploadingImages;
+
   return (
-    <div className="absolute inset-0 z-widget-internal-overlay bg-slate-900/95 backdrop-blur-sm flex flex-col p-4">
+    <div
+      className="absolute inset-0 z-widget-internal-overlay bg-slate-900/95 backdrop-blur-sm flex flex-col p-4"
+      onPaste={handlePaste}
+      onDragOver={(e) => e.preventDefault()}
+      onDrop={handleDrop}
+    >
       <div className="flex items-center gap-2 mb-4">
         <button onClick={onClose} className="text-slate-400 hover:text-white">
           <X className="w-4 h-4" />
         </button>
-        <Wand2 className="w-4 h-4 text-violet-400" />
+        <Sparkles className="w-4 h-4 text-brand-blue-light" />
         <span className="text-white font-semibold text-sm">
           Generate with AI
         </span>
@@ -109,52 +340,97 @@ export const GuidedLearningAIGenerator: React.FC<Props> = ({
 
       <div className="space-y-3 flex-1 overflow-y-auto">
         <p className="text-slate-400 text-xs">
-          Upload an image and Gemini will analyze it to automatically create a
-          guided learning experience with hotspot steps.
+          Add one or more images — upload, paste, or pull from Drive. Gemini
+          will analyze them together and draft a guided learning experience with
+          hotspots spanning the images you provide.
         </p>
 
-        {/* Image upload */}
-        <div>
-          <label className="block text-xs text-slate-400 mb-1">Image *</label>
-          {imageUrl ? (
-            <div className="relative rounded-lg overflow-hidden">
-              <img
-                src={imageUrl}
-                alt="Selected"
-                className="w-full max-h-40 object-contain bg-slate-800"
-              />
-              <button
-                onClick={() => {
-                  setImageUrl('');
-                  setImageBase64('');
-                }}
-                className="absolute top-2 right-2 bg-black/60 text-white rounded-full p-1 hover:bg-black/80"
-                aria-label="Remove image"
-              >
-                <X className="w-3 h-3" />
-              </button>
-            </div>
-          ) : (
-            <button
-              onClick={() => fileRef.current?.click()}
-              className="w-full border-2 border-dashed border-white/20 rounded-xl py-6 text-center hover:border-white/30 transition-colors"
-            >
-              <Upload className="w-6 h-6 text-slate-500 mx-auto mb-1" />
-              <span className="text-slate-400 text-xs">
-                Click to upload image
-              </span>
-            </button>
-          )}
+        <div className="flex flex-col gap-2">
+          <button
+            type="button"
+            onClick={() => fileRef.current?.click()}
+            disabled={busy}
+            className="w-full border-2 border-dashed border-white/20 rounded-xl py-5 text-center hover:border-white/30 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            <Upload className="w-6 h-6 text-slate-400 mx-auto mb-1" />
+            <span className="text-slate-300 text-xs block">
+              Click to upload, drop here, or paste (Ctrl+V)
+            </span>
+            <span className="text-slate-500 text-[11px] mt-0.5 block">
+              PNG, JPG, WebP — multi-select supported
+            </span>
+          </button>
           <input
             ref={fileRef}
             type="file"
             accept="image/*"
+            multiple
             className="hidden"
-            onChange={handleFile}
+            onChange={handleFileInput}
           />
+
+          <div className="flex flex-wrap gap-2">
+            <DriveImagePicker
+              onImageAdded={handleDriveImageAdded}
+              disabled={busy}
+              variant="dark"
+              label="Add image from Drive"
+            />
+            {canAccessFeature('ai-file-context') && (
+              <DriveFileAttachment
+                onFileContent={(content, name) => {
+                  setFileContext(content);
+                  setFileName(name);
+                }}
+                disabled={busy}
+                variant="dark"
+                label="Attach context doc"
+              />
+            )}
+          </div>
         </div>
 
-        {/* Optional prompt */}
+        {uploadingImages && (
+          <div className="flex items-center gap-2 text-xs text-slate-400">
+            <Loader2 className="w-3.5 h-3.5 animate-spin" />
+            Uploading images…
+          </div>
+        )}
+
+        {images.length > 0 && (
+          <div className="flex flex-col gap-2">
+            <div className="flex items-center justify-between">
+              <label className="text-xs text-slate-400">
+                {images.length} image{images.length === 1 ? '' : 's'} — drag to
+                reorder
+              </label>
+            </div>
+            <DndContext
+              sensors={sensors}
+              collisionDetection={closestCenter}
+              onDragEnd={handleDragEnd}
+            >
+              <SortableContext
+                items={images.map((img) => img.id)}
+                strategy={verticalListSortingStrategy}
+              >
+                <div className="flex flex-col gap-2">
+                  {images.map((image, index) => (
+                    <SortableImageRow
+                      key={image.id}
+                      image={image}
+                      index={index}
+                      onCaptionChange={handleCaptionChange}
+                      onRemove={handleRemove}
+                      disabled={busy}
+                    />
+                  ))}
+                </div>
+              </SortableContext>
+            </DndContext>
+          </div>
+        )}
+
         <div>
           <label className="block text-xs text-slate-400 mb-1">
             Additional instructions (optional)
@@ -168,19 +444,8 @@ export const GuidedLearningAIGenerator: React.FC<Props> = ({
           />
         </div>
 
-        {/* Drive file attachment */}
-        {canAccessFeature('ai-file-context') && (
-          <DriveFileAttachment
-            onFileContent={(content, name) => {
-              setFileContext(content);
-              setFileName(name);
-            }}
-            disabled={generating}
-          />
-        )}
-
         {error && (
-          <p className="text-red-400 text-xs bg-red-900/20 px-3 py-2 rounded-lg">
+          <p className="text-red-400 text-xs bg-red-900/20 px-3 py-2 rounded-lg whitespace-pre-wrap">
             {error}
           </p>
         )}
@@ -188,8 +453,8 @@ export const GuidedLearningAIGenerator: React.FC<Props> = ({
 
       <button
         onClick={handleGenerate}
-        disabled={!imageBase64 || !imageUrl || generating || uploading}
-        className="mt-4 w-full flex items-center justify-center gap-2 py-2.5 bg-violet-600 hover:bg-violet-500 disabled:bg-slate-700 disabled:text-slate-500 text-white rounded-xl transition-colors font-medium text-sm"
+        disabled={images.length === 0 || busy}
+        className="mt-4 w-full flex items-center justify-center gap-2 py-2.5 bg-brand-blue-primary hover:bg-brand-blue-dark disabled:bg-slate-700 disabled:text-slate-500 text-white rounded-xl transition-colors font-medium text-sm"
       >
         {generating ? (
           <>
@@ -198,8 +463,8 @@ export const GuidedLearningAIGenerator: React.FC<Props> = ({
           </>
         ) : (
           <>
-            <Wand2 className="w-4 h-4" />
-            Generate Experience
+            <Sparkles className="w-4 h-4" />
+            Draft with AI
           </>
         )}
       </button>

--- a/components/widgets/GuidedLearning/components/GuidedLearningAIGenerator.tsx
+++ b/components/widgets/GuidedLearning/components/GuidedLearningAIGenerator.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import {
   Sparkles,
   Upload,
@@ -53,6 +53,9 @@ interface GeneratorImage {
   fileName: string;
   caption: string;
 }
+
+const MAX_IMAGES = 10;
+const MAX_FILE_BYTES = 10 * 1024 * 1024; // 10 MB (matches HotspotImageSettings)
 
 interface SortableImageRowProps {
   image: GeneratorImage;
@@ -172,11 +175,36 @@ export const GuidedLearningAIGenerator: React.FC<Props> = ({
   const addFiles = useCallback(
     async (files: File[]) => {
       if (files.length === 0 || !user) return;
-      setError('');
+
+      const oversized = files.find((f) => f.size > MAX_FILE_BYTES);
+      if (oversized) {
+        setError(
+          `"${oversized.name}" is larger than 10 MB. Please choose a smaller image.`
+        );
+        return;
+      }
+
+      const remaining = MAX_IMAGES - images.length;
+      if (remaining <= 0) {
+        setError(
+          `You can attach at most ${MAX_IMAGES} images. Remove one before adding more.`
+        );
+        return;
+      }
+
+      const accepted = files.slice(0, remaining);
+      if (files.length > remaining) {
+        setError(
+          `Only the first ${remaining} of ${files.length} images were added (max ${MAX_IMAGES} per request).`
+        );
+      } else {
+        setError('');
+      }
+
       setUploadingImages(true);
       try {
         const uploads = await Promise.all(
-          files.map(async (file) => {
+          accepted.map(async (file) => {
             const [url, base64] = await Promise.all([
               uploadHotspotImage(user.uid, file),
               blobToBase64(file),
@@ -202,7 +230,7 @@ export const GuidedLearningAIGenerator: React.FC<Props> = ({
         setUploadingImages(false);
       }
     },
-    [user, uploadHotspotImage]
+    [user, uploadHotspotImage, images.length]
   );
 
   const handleFileInput = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -211,8 +239,10 @@ export const GuidedLearningAIGenerator: React.FC<Props> = ({
     if (files.length > 0) void addFiles(files);
   };
 
-  const handlePaste = useCallback(
-    (e: React.ClipboardEvent<HTMLDivElement>) => {
+  // Window-level paste listener — an onPaste on the overlay <div> only fires
+  // when focus happens to be inside a child input, so it made Ctrl+V unreliable.
+  useEffect(() => {
+    const onPaste = (e: ClipboardEvent) => {
       const items = e.clipboardData?.items;
       if (!items) return;
       const imageFiles: File[] = [];
@@ -226,9 +256,10 @@ export const GuidedLearningAIGenerator: React.FC<Props> = ({
         e.preventDefault();
         void addFiles(imageFiles);
       }
-    },
-    [addFiles]
-  );
+    };
+    window.addEventListener('paste', onPaste);
+    return () => window.removeEventListener('paste', onPaste);
+  }, [addFiles]);
 
   const handleDrop = useCallback(
     (e: React.DragEvent<HTMLDivElement>) => {
@@ -317,7 +348,6 @@ export const GuidedLearningAIGenerator: React.FC<Props> = ({
   return (
     <div
       className="absolute inset-0 z-widget-internal-overlay bg-slate-900/95 backdrop-blur-sm flex flex-col p-4"
-      onPaste={handlePaste}
       onDragOver={(e) => e.preventDefault()}
       onDrop={handleDrop}
     >

--- a/components/widgets/GuidedLearning/components/GuidedLearningEditorModal.tsx
+++ b/components/widgets/GuidedLearning/components/GuidedLearningEditorModal.tsx
@@ -7,7 +7,7 @@
  */
 
 import React, { useCallback, useMemo, useState } from 'react';
-import { Wand2 } from 'lucide-react';
+import { Sparkles } from 'lucide-react';
 import {
   GuidedLearningMode,
   GuidedLearningQuestion,
@@ -225,11 +225,11 @@ export const GuidedLearningEditorModal: React.FC<
         canUseAi ? (
           <button
             onClick={() => setShowAiGen(true)}
-            className="h-[36px] px-3 bg-gradient-to-br from-indigo-500 to-purple-600 hover:from-indigo-600 hover:to-purple-700 text-white rounded-xl font-black text-xs uppercase tracking-widest shadow-md shadow-indigo-200 transition-all flex items-center gap-2 active:scale-95"
+            className="h-[36px] px-3 bg-brand-blue-primary hover:bg-brand-blue-dark text-white rounded-xl font-bold text-xs uppercase tracking-wider shadow-sm transition-colors flex items-center gap-2 active:scale-95"
             title="Generate with AI (Admin)"
           >
-            <Wand2 className="w-4 h-4" />
-            Magic
+            <Sparkles className="w-4 h-4" />
+            Draft with AI
           </button>
         ) : null
       }

--- a/components/widgets/GuidedLearning/components/GuidedLearningManager.tsx
+++ b/components/widgets/GuidedLearning/components/GuidedLearningManager.tsx
@@ -26,7 +26,7 @@ import {
   Trash2,
   Link2,
   BarChart2,
-  Wand2,
+  Sparkles,
   Building2,
   BookOpen,
   Loader2,
@@ -431,7 +431,7 @@ export const GuidedLearningManager: React.FC<GuidedLearningManagerProps> = ({
       ? [
           {
             label: 'AI',
-            icon: Wand2,
+            icon: Sparkles,
             onClick: onOpenAIAuthoring,
           },
         ]

--- a/components/widgets/InstructionalRoutines/LibraryManager.tsx
+++ b/components/widgets/InstructionalRoutines/LibraryManager.tsx
@@ -195,14 +195,14 @@ export const LibraryManager: React.FC<LibraryManagerProps> = ({
         <button
           onClick={() => setShowPromptDialog(true)}
           disabled={isGenerating}
-          className="flex items-center gap-1.5 px-3 py-1.5 bg-gradient-to-r from-purple-500 to-pink-500 text-white rounded-lg text-xxs font-black uppercase tracking-wider hover:from-purple-600 hover:to-pink-600 disabled:opacity-50 transition-all shadow-sm"
+          className="flex items-center gap-1.5 px-3 py-1.5 bg-brand-blue-primary hover:bg-brand-blue-dark text-white rounded-lg text-xxs font-black uppercase tracking-wider disabled:opacity-50 transition-colors shadow-sm"
         >
           {isGenerating ? (
             <Loader2 size={14} className="animate-spin" />
           ) : (
             <Sparkles size={14} />
           )}
-          Magic Design
+          Draft with AI
         </button>
         <button
           onClick={onSave}

--- a/components/widgets/MiniApp/components/MiniAppEditorModal.tsx
+++ b/components/widgets/MiniApp/components/MiniAppEditorModal.tsx
@@ -389,11 +389,11 @@ export const MiniAppEditorModal: React.FC<MiniAppEditorModalProps> = ({
             <div className="pt-5">
               <button
                 onClick={() => setShowPromptInput(true)}
-                className="h-[46px] px-4 bg-gradient-to-br from-indigo-500 to-purple-600 hover:from-indigo-600 hover:to-purple-700 text-white rounded-xl font-black text-xs uppercase tracking-widest shadow-lg shadow-indigo-200 transition-all flex items-center gap-2 active:scale-95"
+                className="h-[46px] px-4 bg-brand-blue-primary hover:bg-brand-blue-dark text-white rounded-xl font-bold text-xs uppercase tracking-wider shadow-sm transition-colors flex items-center gap-2 active:scale-95"
                 title="Generate with AI"
               >
                 <Sparkles className="w-4 h-4" />
-                Magic
+                Draft with AI
               </button>
             </div>
           )}

--- a/components/widgets/Onboarding/components/Header.tsx
+++ b/components/widgets/Onboarding/components/Header.tsx
@@ -11,7 +11,7 @@ export const Header: React.FC<HeaderProps> = ({ allDone }) => {
 
   return (
     <div
-      className="flex items-center gap-2 bg-gradient-to-r from-indigo-600 to-purple-600 shrink-0"
+      className="flex items-center gap-2 bg-brand-blue-primary shrink-0"
       style={{ padding: 'min(10px, 2.5cqmin) min(14px, 3cqmin)' }}
     >
       <Rocket

--- a/components/widgets/QuizWidget/components/QuizEditorModal.tsx
+++ b/components/widgets/QuizWidget/components/QuizEditorModal.tsx
@@ -347,11 +347,11 @@ export const QuizEditorModal: React.FC<QuizEditorModalProps> = ({
           {aiEnabled && (
             <button
               onClick={() => setShowAiPrompt(true)}
-              className="h-[38px] px-4 bg-gradient-to-br from-indigo-500 to-purple-600 hover:from-indigo-600 hover:to-purple-700 text-white rounded-xl font-black text-xs uppercase tracking-widest shadow-lg shadow-indigo-200 transition-all flex items-center gap-2 active:scale-95"
+              className="h-[38px] px-4 bg-brand-blue-primary hover:bg-brand-blue-dark text-white rounded-xl font-bold text-xs uppercase tracking-wider shadow-sm transition-colors flex items-center gap-2 active:scale-95"
               title="Generate with AI"
             >
               <Sparkles className="w-4 h-4" />
-              Magic
+              Draft with AI
             </button>
           )}
         </div>

--- a/components/widgets/VideoActivityWidget/components/Creator.tsx
+++ b/components/widgets/VideoActivityWidget/components/Creator.tsx
@@ -7,7 +7,6 @@ import React, { useState } from 'react';
 import {
   ArrowLeft,
   Youtube,
-  Wand2,
   FileSpreadsheet,
   PlusCircle,
   Sparkles,
@@ -214,11 +213,11 @@ export const Creator: React.FC<CreatorProps> = ({
                   </div>
                   <div className="flex items-center gap-4">
                     <div className="p-3 bg-indigo-50 rounded-xl group-hover:bg-indigo-100 transition-colors">
-                      <Wand2 className="w-6 h-6 text-indigo-600" />
+                      <Sparkles className="w-6 h-6 text-indigo-600" />
                     </div>
                     <div>
                       <h4 className="font-bold text-slate-800">
-                        Magic Creator
+                        Draft with AI
                       </h4>
                       <p className="text-xs text-slate-500 leading-relaxed">
                         Generate questions automatically using Gemini&apos;s
@@ -279,7 +278,7 @@ export const Creator: React.FC<CreatorProps> = ({
             <div className="space-y-6 animate-in fade-in slide-in-from-right-4 duration-300">
               <div className="bg-indigo-50 border border-indigo-100 rounded-2xl p-5 space-y-4">
                 <div className="flex items-center gap-3">
-                  <Wand2 className="w-5 h-5 text-indigo-600" />
+                  <Sparkles className="w-5 h-5 text-indigo-600" />
                   <span className="font-bold text-indigo-900 text-sm">
                     AI Configuration
                   </span>

--- a/components/widgets/VideoActivityWidget/components/VideoActivityEditorModal.tsx
+++ b/components/widgets/VideoActivityWidget/components/VideoActivityEditorModal.tsx
@@ -19,7 +19,6 @@ import {
   Plus,
   Sparkles,
   Trash2,
-  Wand2,
   X,
   Youtube,
 } from 'lucide-react';
@@ -375,7 +374,7 @@ export const VideoActivityEditorModal: React.FC<
               <button
                 onClick={() => setShowAiPrompt(true)}
                 disabled={!youtubeUrl.trim()}
-                className="h-[38px] px-4 bg-gradient-to-br from-indigo-500 to-purple-600 hover:from-indigo-600 hover:to-purple-700 disabled:opacity-50 disabled:cursor-not-allowed text-white rounded-xl font-black text-xs uppercase tracking-widest shadow-lg shadow-indigo-200 transition-all flex items-center gap-2 active:scale-95"
+                className="h-[38px] px-4 bg-brand-blue-primary hover:bg-brand-blue-dark disabled:opacity-50 disabled:cursor-not-allowed text-white rounded-xl font-bold text-xs uppercase tracking-wider shadow-sm transition-colors flex items-center gap-2 active:scale-95"
                 title={
                   youtubeUrl.trim()
                     ? 'Generate questions with AI'
@@ -383,8 +382,8 @@ export const VideoActivityEditorModal: React.FC<
                 }
                 aria-describedby="va-ai-button-hint"
               >
-                <Wand2 className="w-4 h-4" />
-                Magic
+                <Sparkles className="w-4 h-4" />
+                Draft with AI
               </button>
               <span id="va-ai-button-hint" className="sr-only">
                 {youtubeUrl.trim()
@@ -649,7 +648,7 @@ export const VideoActivityEditorModal: React.FC<
             <button
               onClick={() => void handleAiGenerate()}
               disabled={aiGenerating || !youtubeUrl.trim()}
-              className="w-full py-3 bg-indigo-600 hover:bg-indigo-700 disabled:opacity-50 disabled:cursor-not-allowed text-white rounded-xl font-black text-xs uppercase tracking-widest shadow-lg shadow-indigo-200 transition-all flex items-center justify-center gap-2"
+              className="w-full py-3 bg-brand-blue-primary hover:bg-brand-blue-dark disabled:opacity-50 disabled:cursor-not-allowed text-white rounded-xl font-bold text-xs uppercase tracking-wider shadow-sm transition-colors flex items-center justify-center gap-2"
             >
               {aiGenerating ? (
                 <>
@@ -657,7 +656,7 @@ export const VideoActivityEditorModal: React.FC<
                 </>
               ) : (
                 <>
-                  <Wand2 className="w-4 h-4" /> Generate Questions
+                  <Sparkles className="w-4 h-4" /> Generate Questions
                 </>
               )}
             </button>

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -7,6 +7,7 @@ import OAuth from 'oauth-1.0a';
 import * as CryptoJS from 'crypto-js';
 import { GoogleGenAI, Content } from '@google/genai';
 import { sanitizePrompt } from './sanitize';
+import { parseGeminiJson } from './parseGeminiJson';
 
 // Phase 4 — organization invitations + membership write-through.
 // These modules initialize their own `admin.initializeApp()` guarded by
@@ -899,7 +900,7 @@ export const generateWithAI = onCall(
         return { result: text };
       }
 
-      return JSON.parse(text) as Record<string, unknown>;
+      return parseGeminiJson<Record<string, unknown>>(text);
     } catch (error: unknown) {
       console.error('AI Generation Error Details:', error);
 
@@ -1394,7 +1395,7 @@ Return JSON in this exact format:
       const text = result.text;
       if (!text) throw new Error('Empty response from AI');
 
-      const parsed = JSON.parse(text) as GeneratedVideoActivity;
+      const parsed = parseGeminiJson<GeneratedVideoActivity>(text);
 
       if (
         !parsed.title ||
@@ -1677,7 +1678,7 @@ Return JSON:
       const text = result.text;
       if (!text) throw new Error('Empty response from AI');
 
-      const parsed = JSON.parse(text) as GeneratedVideoActivity;
+      const parsed = parseGeminiJson<GeneratedVideoActivity>(text);
 
       if (
         !parsed.title ||
@@ -1728,6 +1729,12 @@ interface GeneratedGuidedLearning {
   steps: GuidedLearningStep[];
 }
 
+interface GuidedLearningImageInput {
+  base64: string;
+  mimeType: string;
+  caption?: string;
+}
+
 export const generateGuidedLearning = onCall(
   {
     memory: '512MiB',
@@ -1736,9 +1743,11 @@ export const generateGuidedLearning = onCall(
   },
   async (request) => {
     const data = request.data as {
-      imageBase64: string;
-      mimeType: string;
+      images?: GuidedLearningImageInput[];
       prompt?: string;
+      // Legacy single-image shape — accepted for backward compatibility.
+      imageBase64?: string;
+      mimeType?: string;
     };
     // Admin only
     const uid = request.auth?.uid;
@@ -1768,12 +1777,27 @@ export const generateGuidedLearning = onCall(
       );
     }
 
-    const { imageBase64, mimeType, prompt } = data;
-    if (!imageBase64 || !mimeType) {
+    const { prompt } = data;
+    const images: GuidedLearningImageInput[] =
+      Array.isArray(data.images) && data.images.length > 0
+        ? data.images
+        : data.imageBase64 && data.mimeType
+          ? [{ base64: data.imageBase64, mimeType: data.mimeType }]
+          : [];
+
+    if (images.length === 0) {
       throw new HttpsError(
         'invalid-argument',
-        'imageBase64 and mimeType are required.'
+        'At least one image is required.'
       );
+    }
+    for (const img of images) {
+      if (!img.base64 || !img.mimeType) {
+        throw new HttpsError(
+          'invalid-argument',
+          'Every image must include base64 data and mimeType.'
+        );
+      }
     }
 
     const apiKey = GEMINI_API_KEY.value();
@@ -1788,8 +1812,10 @@ export const generateGuidedLearning = onCall(
     try {
       const ai = new GoogleGenAI({ apiKey });
 
+      const imageCount = images.length;
+      const maxIndex = imageCount - 1;
       const systemInstruction = `You are an educational content creator helping teachers build interactive guided learning experiences.
-Analyze the provided image and generate a guided learning experience as a JSON object.
+Analyze the provided image(s) and generate a guided learning experience as a JSON object.
 
 Return ONLY valid JSON with this exact structure:
 {
@@ -1802,7 +1828,7 @@ Return ONLY valid JSON with this exact structure:
       "yPct": number (0-100),
       "label": "string",
       "interactionType": "text-popover" | "tooltip" | "pan-zoom" | "spotlight" | "pan-zoom-spotlight" | "question",
-      "imageIndex": number (always 0 for now),
+      "imageIndex": number (0-based index into the provided images, 0..${maxIndex}),
       "hideStepNumber": boolean (optional),
       "showOverlay": "none" | "popover" | "tooltip" | "banner" (for pan-zoom, spotlight, pan-zoom-spotlight),
       "text": "string (for text-popover/tooltip)",
@@ -1822,32 +1848,46 @@ Return ONLY valid JSON with this exact structure:
 }
 
 Guidelines:
-- Create 4-8 meaningful steps that guide learners through the content
-- Use text-popover for key concepts, spotlight to highlight areas, pan-zoom to zoom in on details, pan-zoom-spotlight when both are useful, questions to check understanding
-- This phase supports single-image AI generation only, so set imageIndex to 0 for every step
-- Place hotspots at meaningful locations on the image (xPct/yPct as percentages 0-100)
-- Include at least 1 question step for comprehension checking
-- Make content educational and age-appropriate
-- Set autoAdvanceDuration to 5-15 seconds for non-question steps in guided mode`;
+- You have been given ${imageCount} image${imageCount === 1 ? '' : 's'} (imageIndex ${imageCount === 1 ? '0' : `0..${maxIndex}`}).
+- Each step's imageIndex MUST be the 0-based position of the image it refers to.
+- Distribute steps across the images in a pedagogically meaningful order; do not cluster everything on image 0 unless only one image was provided.
+- Respect any per-image notes the teacher provided (sent as text before each image).
+- Create 4-8 meaningful steps per image that guide learners through the content (scale total step count with image count, cap at ~${Math.min(24, imageCount * 6)}).
+- Use text-popover for key concepts, spotlight to highlight areas, pan-zoom to zoom in on details, pan-zoom-spotlight when both are useful, questions to check understanding.
+- Place hotspots at meaningful locations on the image (xPct/yPct as percentages 0-100, relative to the image they reference).
+- Include at least 1 question step for comprehension checking.
+- Make content educational and age-appropriate.
+- Set autoAdvanceDuration to 5-15 seconds for non-question steps in guided mode.`;
 
-      const userPrompt = prompt
+      const userPromptHeader = prompt
         ? `Additional instructions: ${sanitizePrompt(prompt)}`
-        : 'Analyze this educational image and create an engaging guided learning experience.';
+        : 'Analyze the image(s) below and create an engaging guided learning experience.';
+
+      const parts: {
+        text?: string;
+        inlineData?: { mimeType: string; data: string };
+      }[] = [{ text: userPromptHeader }];
+
+      images.forEach((img, index) => {
+        const caption = img.caption ? sanitizePrompt(img.caption) : '';
+        const header = caption
+          ? `Image ${index} notes: ${caption}`
+          : `Image ${index}:`;
+        parts.push({ text: header });
+        parts.push({
+          inlineData: {
+            mimeType: img.mimeType,
+            data: img.base64,
+          },
+        });
+      });
 
       const response = await ai.models.generateContent({
         model: guidedLearningModel,
         contents: [
           {
             role: 'user',
-            parts: [
-              { text: userPrompt },
-              {
-                inlineData: {
-                  mimeType,
-                  data: imageBase64,
-                },
-              },
-            ],
+            parts,
           },
         ],
         config: {
@@ -1857,7 +1897,7 @@ Guidelines:
       });
 
       const rawText = response.text ?? '';
-      const parsed = JSON.parse(rawText) as GeneratedGuidedLearning;
+      const parsed = parseGeminiJson<GeneratedGuidedLearning>(rawText);
 
       if (
         !parsed.suggestedTitle ||
@@ -1867,10 +1907,16 @@ Guidelines:
         throw new Error('Invalid response structure from AI');
       }
 
-      // Ensure all steps have IDs
+      // Ensure all steps have IDs and imageIndex values fall within range.
       parsed.steps = parsed.steps.map((step, i) => ({
         ...step,
         id: step.id || `step-${i + 1}-${Date.now()}`,
+        imageIndex:
+          typeof step.imageIndex === 'number' &&
+          step.imageIndex >= 0 &&
+          step.imageIndex <= maxIndex
+            ? step.imageIndex
+            : 0,
       }));
 
       return parsed;

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -1791,6 +1791,17 @@ export const generateGuidedLearning = onCall(
         'At least one image is required.'
       );
     }
+
+    const MAX_IMAGES = 10;
+    const MAX_TOTAL_RAW_BYTES = 20 * 1024 * 1024; // 20 MB raw (~27 MB base64)
+    if (images.length > MAX_IMAGES) {
+      throw new HttpsError(
+        'invalid-argument',
+        `Too many images — please limit to ${MAX_IMAGES} per request.`
+      );
+    }
+
+    let totalRawBytes = 0;
     for (const img of images) {
       if (!img.base64 || !img.mimeType) {
         throw new HttpsError(
@@ -1798,6 +1809,14 @@ export const generateGuidedLearning = onCall(
           'Every image must include base64 data and mimeType.'
         );
       }
+      // Base64 decodes to ~0.75 bytes per char (minus padding).
+      totalRawBytes += Math.ceil((img.base64.length * 3) / 4);
+    }
+    if (totalRawBytes > MAX_TOTAL_RAW_BYTES) {
+      throw new HttpsError(
+        'invalid-argument',
+        'Image payload is too large. Please use fewer or smaller images (under 20 MB total).'
+      );
     }
 
     const apiKey = GEMINI_API_KEY.value();

--- a/functions/src/parseGeminiJson.test.ts
+++ b/functions/src/parseGeminiJson.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import { parseGeminiJson } from './parseGeminiJson';
+
+interface Sample {
+  foo: string;
+  items: number[];
+}
+
+describe('parseGeminiJson', () => {
+  it('parses plain JSON', () => {
+    const raw = '{"foo":"bar","items":[1,2,3]}';
+    expect(parseGeminiJson<Sample>(raw)).toEqual({
+      foo: 'bar',
+      items: [1, 2, 3],
+    });
+  });
+
+  it('strips ```json fenced blocks', () => {
+    const raw = '```json\n{"foo":"bar","items":[1]}\n```';
+    expect(parseGeminiJson<Sample>(raw)).toEqual({ foo: 'bar', items: [1] });
+  });
+
+  it('strips bare ``` fences', () => {
+    const raw = '```\n{"foo":"bar","items":[]}\n```';
+    expect(parseGeminiJson<Sample>(raw)).toEqual({ foo: 'bar', items: [] });
+  });
+
+  it('trims trailing markdown/explanation after the JSON object', () => {
+    const raw =
+      '{"foo":"bar","items":[1,2]}\n\nHere is an explanation of my choices…';
+    expect(parseGeminiJson<Sample>(raw)).toEqual({ foo: 'bar', items: [1, 2] });
+  });
+
+  it('handles leading prose before the JSON object', () => {
+    const raw =
+      'Sure! Here is the JSON you requested:\n{"foo":"x","items":[9]}';
+    expect(parseGeminiJson<Sample>(raw)).toEqual({ foo: 'x', items: [9] });
+  });
+
+  it('throws on empty input', () => {
+    expect(() => parseGeminiJson('')).toThrow(/empty/i);
+    expect(() => parseGeminiJson('   \n  ')).toThrow(/empty/i);
+  });
+
+  it('throws on genuinely malformed JSON', () => {
+    expect(() => parseGeminiJson('{not json at all}')).toThrow();
+  });
+});

--- a/functions/src/parseGeminiJson.ts
+++ b/functions/src/parseGeminiJson.ts
@@ -1,0 +1,29 @@
+/**
+ * Robust JSON extraction for Gemini responses. Gemini occasionally returns
+ * the requested JSON object followed by a trailing explanation, markdown
+ * code fences, or a stray newline. `JSON.parse` on that raw text throws
+ * "Unexpected non-whitespace character after JSON …".
+ *
+ * This helper strips fences and trims to the outermost `{ … }` slice before
+ * parsing. Callers still get a thrown error on genuinely malformed JSON.
+ */
+export const parseGeminiJson = <T>(raw: string): T => {
+  const trimmed = (raw ?? '').trim();
+  if (trimmed.length === 0) {
+    throw new Error('Empty response from AI');
+  }
+
+  const fenced = trimmed
+    .replace(/^```(?:json)?\s*/i, '')
+    .replace(/```\s*$/i, '')
+    .trim();
+
+  const firstBrace = fenced.indexOf('{');
+  const lastBrace = fenced.lastIndexOf('}');
+  const slice =
+    firstBrace !== -1 && lastBrace > firstBrace
+      ? fenced.slice(firstBrace, lastBrace + 1)
+      : fenced;
+
+  return JSON.parse(slice) as T;
+};

--- a/hooks/useGoogleDrive.ts
+++ b/hooks/useGoogleDrive.ts
@@ -156,6 +156,26 @@ export const useGoogleDrive = () => {
     [driveService]
   );
 
+  /**
+   * Download a binary file (e.g. a JPEG/PNG image) from Drive as a Blob.
+   * Used by image-picker flows that want to push the raw bytes to Firebase
+   * Storage + forward a base64 copy to Gemini.
+   */
+  const getDriveFileAsBlob = useCallback(
+    async (
+      fileId: string
+    ): Promise<{ blob: Blob; mimeType: string; name: string } | null> => {
+      if (!driveService) return null;
+      try {
+        return await driveService.downloadFileAsBlob(fileId);
+      } catch (error) {
+        console.error('Failed to download Drive file:', error);
+        return null;
+      }
+    },
+    [driveService]
+  );
+
   return {
     driveService,
     isConnected,
@@ -165,6 +185,7 @@ export const useGoogleDrive = () => {
     uploadBackgroundToDrive,
     getUserBackgroundsFromDrive,
     getDriveFileTextContent,
+    getDriveFileAsBlob,
     saveDrawingToDrive,
   };
 };

--- a/hooks/useGooglePicker.ts
+++ b/hooks/useGooglePicker.ts
@@ -25,7 +25,6 @@ const IMAGE_MIME_TYPES = ['image/jpeg', 'image/png', 'image/webp'].join(',');
 /** Options for `openPicker`. Default mode is `'docs'`. */
 export interface OpenPickerOptions {
   mode?: 'docs' | 'images';
-  maxItems?: number;
 }
 
 /** Max time (ms) to wait for the gapi script to become available. */
@@ -126,7 +125,6 @@ export const useGooglePicker = () => {
       }
 
       const mode = options?.mode ?? 'docs';
-      const maxItems = Math.max(1, options?.maxItems ?? 1);
 
       // Set synchronously before async work to prevent race conditions
       pickerActiveRef.current = true;
@@ -158,7 +156,7 @@ export const useGooglePicker = () => {
             const builder = new google.picker.PickerBuilder()
               .addView(docsView)
               .setOAuthToken(googleAccessToken)
-              .setMaxItems(maxItems)
+              .setMaxItems(1)
               .setTitle(title)
               .setCallback((response: google.picker.ResponseObject) => {
                 const action = response[

--- a/hooks/useGooglePicker.ts
+++ b/hooks/useGooglePicker.ts
@@ -19,6 +19,15 @@ const SUPPORTED_MIME_TYPES = [
   'text/markdown',
 ].join(',');
 
+/** Image MIME types offered in the image-picker mode. */
+const IMAGE_MIME_TYPES = ['image/jpeg', 'image/png', 'image/webp'].join(',');
+
+/** Options for `openPicker`. Default mode is `'docs'`. */
+export interface OpenPickerOptions {
+  mode?: 'docs' | 'images';
+  maxItems?: number;
+}
+
 /** Max time (ms) to wait for the gapi script to become available. */
 const GAPI_LOAD_TIMEOUT_MS = 15_000;
 
@@ -104,81 +113,100 @@ export const useGooglePicker = () => {
   const { googleAccessToken } = useAuth();
   const pickerActiveRef = useRef(false);
 
-  const openPicker = useCallback((): Promise<PickedFile | null> => {
-    if (!googleAccessToken) {
-      return Promise.reject(
-        new Error('Google Drive is not connected. Please sign in again.')
-      );
-    }
+  const openPicker = useCallback(
+    (options?: OpenPickerOptions): Promise<PickedFile | null> => {
+      if (!googleAccessToken) {
+        return Promise.reject(
+          new Error('Google Drive is not connected. Please sign in again.')
+        );
+      }
 
-    if (pickerActiveRef.current) {
-      return Promise.resolve(null);
-    }
+      if (pickerActiveRef.current) {
+        return Promise.resolve(null);
+      }
 
-    // Set synchronously before async work to prevent race conditions
-    pickerActiveRef.current = true;
+      const mode = options?.mode ?? 'docs';
+      const maxItems = Math.max(1, options?.maxItems ?? 1);
 
-    return ensurePickerApi()
-      .then(() => {
-        return new Promise<PickedFile | null>((resolve) => {
-          const docsView = new google.picker.DocsView(google.picker.ViewId.DOCS)
-            .setIncludeFolders(true)
-            .setMimeTypes(SUPPORTED_MIME_TYPES)
-            .setMode(google.picker.DocsViewMode.LIST);
+      // Set synchronously before async work to prevent race conditions
+      pickerActiveRef.current = true;
 
-          const apiKey = (import.meta.env.VITE_GOOGLE_API_KEY ??
-            import.meta.env.VITE_FIREBASE_API_KEY) as string | undefined;
+      return ensurePickerApi()
+        .then(() => {
+          return new Promise<PickedFile | null>((resolve) => {
+            const viewId =
+              mode === 'images'
+                ? google.picker.ViewId.DOCS_IMAGES
+                : google.picker.ViewId.DOCS;
 
-          const builder = new google.picker.PickerBuilder()
-            .addView(docsView)
-            .setOAuthToken(googleAccessToken)
-            .setMaxItems(1)
-            .setTitle('Select a file for AI context')
-            .setCallback((response: google.picker.ResponseObject) => {
-              const action = response[
-                google.picker.Response.ACTION
-              ] as google.picker.Action;
+            const mimeTypes =
+              mode === 'images' ? IMAGE_MIME_TYPES : SUPPORTED_MIME_TYPES;
 
-              if (action === google.picker.Action.PICKED) {
-                const docs = response[google.picker.Response.DOCUMENTS];
-                if (docs && docs.length > 0) {
-                  const doc = docs[0];
-                  resolve({
-                    id: doc[google.picker.Document.ID],
-                    name: doc[google.picker.Document.NAME] ?? 'Untitled',
-                    mimeType: doc[google.picker.Document.MIME_TYPE] ?? '',
-                  });
+            const docsView = new google.picker.DocsView(viewId)
+              .setIncludeFolders(mode === 'docs')
+              .setMimeTypes(mimeTypes)
+              .setMode(google.picker.DocsViewMode.LIST);
+
+            const apiKey = (import.meta.env.VITE_GOOGLE_API_KEY ??
+              import.meta.env.VITE_FIREBASE_API_KEY) as string | undefined;
+
+            const title =
+              mode === 'images'
+                ? 'Select an image from Drive'
+                : 'Select a file for AI context';
+
+            const builder = new google.picker.PickerBuilder()
+              .addView(docsView)
+              .setOAuthToken(googleAccessToken)
+              .setMaxItems(maxItems)
+              .setTitle(title)
+              .setCallback((response: google.picker.ResponseObject) => {
+                const action = response[
+                  google.picker.Response.ACTION
+                ] as google.picker.Action;
+
+                if (action === google.picker.Action.PICKED) {
+                  const docs = response[google.picker.Response.DOCUMENTS];
+                  if (docs && docs.length > 0) {
+                    const doc = docs[0];
+                    resolve({
+                      id: doc[google.picker.Document.ID],
+                      name: doc[google.picker.Document.NAME] ?? 'Untitled',
+                      mimeType: doc[google.picker.Document.MIME_TYPE] ?? '',
+                    });
+                  } else {
+                    resolve(null);
+                  }
+                  pickerActiveRef.current = false;
                 } else {
+                  // CANCEL, ERROR, or any unexpected action — always clean up
                   resolve(null);
+                  pickerActiveRef.current = false;
                 }
-                pickerActiveRef.current = false;
-              } else {
-                // CANCEL, ERROR, or any unexpected action — always clean up
-                resolve(null);
-                pickerActiveRef.current = false;
-              }
-            });
+              });
 
-          if (apiKey) {
-            builder.setDeveloperKey(apiKey);
-          }
+            if (apiKey) {
+              builder.setDeveloperKey(apiKey);
+            }
 
-          const appId = (import.meta.env.VITE_GOOGLE_APP_ID ??
-            import.meta.env.VITE_FIREBASE_MESSAGING_SENDER_ID) as
-            | string
-            | undefined;
-          if (appId) {
-            builder.setAppId(appId);
-          }
+            const appId = (import.meta.env.VITE_GOOGLE_APP_ID ??
+              import.meta.env.VITE_FIREBASE_MESSAGING_SENDER_ID) as
+              | string
+              | undefined;
+            if (appId) {
+              builder.setAppId(appId);
+            }
 
-          builder.build().setVisible(true);
+            builder.build().setVisible(true);
+          });
+        })
+        .catch((err) => {
+          pickerActiveRef.current = false;
+          throw err;
         });
-      })
-      .catch((err) => {
-        pickerActiveRef.current = false;
-        throw err;
-      });
-  }, [googleAccessToken]);
+    },
+    [googleAccessToken]
+  );
 
   return { openPicker, isConnected: !!googleAccessToken };
 };

--- a/tests/hooks/useGooglePicker.test.ts
+++ b/tests/hooks/useGooglePicker.test.ts
@@ -24,6 +24,14 @@ function setupGapiMock() {
  * DocsView and PickerBuilder are used with `new` in the hook, so they must
  * be real constructor functions (not arrow-function vi.fn mocks).
  */
+/**
+ * Captured references to the most recent picker mock — tests can read
+ * these after calling `openPicker` to assert on how the builder was
+ * configured (view id, mime types, include-folders, etc.).
+ */
+let lastDocsViewArg: string | undefined;
+let lastDocsViewInstance: Record<string, Mock> | undefined;
+
 function setupPickerMock(
   action: 'picked' | 'cancel',
   fileData?: { id: string; name: string; mimeType: string }
@@ -50,6 +58,8 @@ function setupPickerMock(
 
   const docsViewInstance = chainable();
   const builderInstance = chainable();
+  lastDocsViewInstance = docsViewInstance;
+  lastDocsViewArg = undefined;
 
   // setCallback captures the picker response callback, build().setVisible() invokes it
   builderInstance.setCallback = vi.fn().mockImplementation(function (
@@ -77,10 +87,11 @@ function setupPickerMock(
       Action: { PICKED: 'picked', CANCEL: 'cancel' },
       Response: { ACTION: 'action', DOCUMENTS: 'docs' },
       Document: { ID: 'id', NAME: 'name', MIME_TYPE: 'mimeType' },
-      ViewId: { DOCS: 'docs' },
+      ViewId: { DOCS: 'docs', DOCS_IMAGES: 'docs-images' },
       DocsViewMode: { LIST: 'list' },
       // Must use function() — not arrow — so `new` works
-      DocsView: function DocsView() {
+      DocsView: function DocsView(viewId: string) {
+        lastDocsViewArg = viewId;
         return docsViewInstance;
       },
       PickerBuilder: function PickerBuilder() {
@@ -183,6 +194,35 @@ describe('useGooglePicker', () => {
       name: 'My Document',
       mimeType: 'application/vnd.google-apps.document',
     });
+  });
+
+  it('configures the picker for images mode with image MIME types', async () => {
+    setupGapiMock();
+    setupPickerMock('cancel');
+    const { useGooglePicker } = await import('@/hooks/useGooglePicker');
+    const { result } = renderHook(() => useGooglePicker());
+
+    await vi.advanceTimersByTimeAsync(300);
+    await result.current.openPicker({ mode: 'images' });
+
+    expect(lastDocsViewArg).toBe('docs-images');
+    expect(lastDocsViewInstance?.setMimeTypes).toHaveBeenCalledWith(
+      'image/jpeg,image/png,image/webp'
+    );
+    expect(lastDocsViewInstance?.setIncludeFolders).toHaveBeenCalledWith(false);
+  });
+
+  it('defaults to docs mode with document MIME types', async () => {
+    setupGapiMock();
+    setupPickerMock('cancel');
+    const { useGooglePicker } = await import('@/hooks/useGooglePicker');
+    const { result } = renderHook(() => useGooglePicker());
+
+    await vi.advanceTimersByTimeAsync(300);
+    await result.current.openPicker();
+
+    expect(lastDocsViewArg).toBe('docs');
+    expect(lastDocsViewInstance?.setIncludeFolders).toHaveBeenCalledWith(true);
   });
 
   it('dynamically injects gapi script tag when picker is opened', async () => {

--- a/tests/utils/ai.test.ts
+++ b/tests/utils/ai.test.ts
@@ -307,42 +307,46 @@ describe('extractTextWithGemini', () => {
 });
 
 describe('generateGuidedLearning', () => {
+  const img = (caption?: string) => [
+    { base64: 'base64', mimeType: 'image/jpeg', caption },
+  ];
+
   it('generates guided learning successfully', async () => {
-    const result = await generateGuidedLearning(
-      'base64',
-      'image/jpeg',
-      'prompt'
-    );
+    const result = await generateGuidedLearning(img(), 'prompt');
     expect(result.suggestedTitle).toBe('Learning Module');
     expect(result.suggestedMode).toBe('guided');
     expect(result.steps).toHaveLength(1);
     expect(result.steps[0].interactionType).toBe('tooltip');
   });
 
-  it('throws formatted error on failure', async () => {
-    await expect(
-      generateGuidedLearning('base64', 'image/jpeg', 'FAIL')
-    ).rejects.toThrow(
-      'Failed to generate guided learning experience. Please try again.'
+  it('surfaces the real server error on failure', async () => {
+    await expect(generateGuidedLearning(img(), 'FAIL')).rejects.toThrow(
+      'Simulated API Failure'
     );
   });
 
   it('throws error on invalid response format', async () => {
     await expect(
-      generateGuidedLearning('base64', 'image/jpeg', 'invalid-response')
+      generateGuidedLearning(img(), 'invalid-response')
     ).rejects.toThrow('Invalid response format from AI');
   });
 
   it('throws error when no valid steps are returned', async () => {
-    await expect(
-      generateGuidedLearning('base64', 'image/jpeg', 'no-steps')
-    ).rejects.toThrow('Invalid response format from AI');
+    await expect(generateGuidedLearning(img(), 'no-steps')).rejects.toThrow(
+      'Invalid response format from AI'
+    );
   });
 
   it('throws error when AI returns no valid guided learning steps', async () => {
     await expect(
-      generateGuidedLearning('base64', 'image/jpeg', 'invalid-steps')
+      generateGuidedLearning(img(), 'invalid-steps')
     ).rejects.toThrow('AI returned no valid guided learning steps');
+  });
+
+  it('rejects when no images are provided', async () => {
+    await expect(generateGuidedLearning([], 'prompt')).rejects.toThrow(
+      'At least one image is required.'
+    );
   });
 });
 

--- a/utils/ai.ts
+++ b/utils/ai.ts
@@ -356,26 +356,38 @@ interface AIGuidedLearningResponse {
   steps?: unknown[];
 }
 
+/** One image to send to Gemini for guided-learning generation. */
+export interface GuidedLearningImageInput {
+  /** Base64-encoded image data (no `data:` URI prefix). */
+  base64: string;
+  /** MIME type, e.g. 'image/jpeg'. */
+  mimeType: string;
+  /** Optional per-image instructions the teacher wrote. */
+  caption?: string;
+}
+
 /**
- * Generates a complete guided learning experience from an image using Gemini.
- * Admin-only. Sends the image inline to the Cloud Function which calls Gemini.
+ * Generates a complete guided learning experience from one or more images.
+ * Admin-only. Sends the images inline to the Cloud Function which calls Gemini.
  *
- * @param imageBase64 - Base64-encoded image data (no data URI prefix).
- * @param mimeType - MIME type of the image (e.g. 'image/jpeg').
- * @param prompt - Optional additional instructions for Gemini.
+ * Returned steps reference images by `imageIndex` (0-based). Indices outside
+ * the `images.length` range are clamped to 0 rather than dropping the step.
  */
 export async function generateGuidedLearning(
-  imageBase64: string,
-  mimeType: string,
+  images: GuidedLearningImageInput[],
   prompt?: string
 ): Promise<GeneratedGuidedLearning> {
+  if (!Array.isArray(images) || images.length === 0) {
+    throw new Error('At least one image is required.');
+  }
+
   try {
     const fn = httpsCallable<
-      { imageBase64: string; mimeType: string; prompt?: string },
+      { images: GuidedLearningImageInput[]; prompt?: string },
       AIGuidedLearningResponse
     >(functions, 'generateGuidedLearning');
 
-    const result = await fn({ imageBase64, mimeType, prompt });
+    const result = await fn({ images, prompt });
     const data = result.data;
 
     if (
@@ -408,6 +420,7 @@ export async function generateGuidedLearning(
       'question',
     ];
 
+    const maxImageIndex = images.length - 1;
     const validatedSteps = data.steps
       .map((step, index) => {
         if (typeof step !== 'object' || step === null) return null;
@@ -433,14 +446,16 @@ export async function generateGuidedLearning(
             : null;
         if (xPct === null || yPct === null || interactionType === null)
           return null;
+        const rawIndex = typeof s.imageIndex === 'number' ? s.imageIndex : 0;
+        const imageIndex =
+          rawIndex >= 0 && rawIndex <= maxImageIndex ? rawIndex : 0;
         return {
           ...s,
           id,
           xPct,
           yPct,
           interactionType,
-          imageIndex:
-            typeof s.imageIndex === 'number' ? Math.max(0, s.imageIndex) : 0,
+          imageIndex,
           showOverlay:
             s.showOverlay === 'popover' ||
             s.showOverlay === 'tooltip' ||
@@ -463,16 +478,11 @@ export async function generateGuidedLearning(
   } catch (error) {
     console.error('Guided Learning Generation Error:', error);
     if (error instanceof Error) {
-      if (
-        error.message.includes('Invalid response format from AI') ||
-        error.message.includes('AI returned no valid guided learning steps')
-      ) {
-        throw error;
-      }
+      // Re-throw with the real message so the UI surfaces quota / parse /
+      // network errors rather than a generic "try again" string.
+      throw error;
     }
-    throw new Error(
-      'Failed to generate guided learning experience. Please try again.'
-    );
+    throw new Error('Failed to generate guided learning experience.');
   }
 }
 

--- a/utils/fileEncoding.ts
+++ b/utils/fileEncoding.ts
@@ -1,0 +1,16 @@
+/**
+ * Reads a Blob or File as base64, stripping the `data:*;base64,` prefix so
+ * the raw bytes can be sent to APIs that expect a bare base64 string
+ * (e.g. Gemini's `inlineData.data` field).
+ */
+export const blobToBase64 = (blob: Blob): Promise<string> =>
+  new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      const dataUrl = reader.result as string;
+      const commaIndex = dataUrl.indexOf(',');
+      resolve(commaIndex >= 0 ? dataUrl.slice(commaIndex + 1) : dataUrl);
+    };
+    reader.onerror = () => reject(reader.error ?? new Error('Read failed'));
+    reader.readAsDataURL(blob);
+  });

--- a/utils/googleDriveService.ts
+++ b/utils/googleDriveService.ts
@@ -712,4 +712,27 @@ export class GoogleDriveService {
 
     return response.text();
   }
+
+  /**
+   * Download a binary file from Drive (e.g. a JPEG/PNG image) as a Blob.
+   * Uses `alt=media` so the raw bytes come back, not metadata.
+   */
+  async downloadFileAsBlob(
+    fileId: string
+  ): Promise<{ blob: Blob; mimeType: string; name: string }> {
+    const metadata = await this.getFileMetadata(fileId);
+    const response = await this.fetchWithRetry(
+      `${DRIVE_API_URL}/files/${fileId}?alt=media`,
+      { headers: this.headers }
+    );
+    if (!response.ok) {
+      throw new Error(`Failed to download file: ${response.statusText}`);
+    }
+    const blob = await response.blob();
+    return {
+      blob,
+      mimeType: metadata.mimeType || blob.type || 'application/octet-stream',
+      name: metadata.name || 'drive-file',
+    };
+  }
 }

--- a/utils/googleDriveService.ts
+++ b/utils/googleDriveService.ts
@@ -726,7 +726,15 @@ export class GoogleDriveService {
       { headers: this.headers }
     );
     if (!response.ok) {
-      throw new Error(`Failed to download file: ${response.statusText}`);
+      const bodyExcerpt = await response
+        .text()
+        .then((t) => t.slice(0, 200))
+        .catch(() => '');
+      const statusText = response.statusText || 'Unknown error';
+      const suffix = bodyExcerpt ? ` — ${bodyExcerpt}` : '';
+      throw new Error(
+        `Failed to download file (${response.status} ${statusText})${suffix}`
+      );
     }
     const blob = await response.blob();
     return {


### PR DESCRIPTION
## Summary

- **Fix Cloud Function 500** — Gemini's JSON + trailing markdown was breaking `JSON.parse` at position 2648. Added shared `parseGeminiJson` helper (fence stripping + outermost-brace slice); applied to `generateGuidedLearning`, `generateVideoActivity`, and `generateWithAI`.
- **Rebuild Guided Learning AI overlay** — paste support, multi-upload, drag-to-reorder (`@dnd-kit`), per-image caption textareas in a two-column layout.
- **Split Drive integration** — new `DriveImagePicker` (for image attachments) alongside `DriveFileAttachment` (context docs). Dark variant added so buttons are legible on the slate-900 overlay; `e.stopPropagation()` prevents click-through.
- **Surface real errors** — client wrapper in `utils/ai.ts` now bubbles up the server's actual error instead of masking every failure as a generic string.
- **Brand purge** — removed all indigo→purple gradients and "Magic"/`Wand2` vocabulary from AI generation surfaces (Guided Learning, Quiz, Video Activity, MiniApp, Magic Layout, Import Wizard, Onboarding, Instructional Routines, Embed, Image Paste Picker, Widget Builder Gemini Panel). Replaced with `bg-brand-blue-primary` + `Sparkles` + "Draft with AI".

## Test plan

- [x] `pnpm run type-check` (root + functions) — green
- [x] `pnpm run test` — 1383/1383 root, 125/125 functions
- [x] `parseGeminiJson` unit tests cover plain JSON, fenced JSON, JSON with trailing markdown, invalid JSON
- [x] `generateGuidedLearning` tests updated to new `(images[], prompt)` signature
- [ ] **Manual verification in preview deploy:**
  - [ ] Paste an image into the overlay (Ctrl+V from Snipping Tool + browser tab)
  - [ ] Select multiple images via file input
  - [ ] Drag a row from position 3 to position 1, generate, confirm `imageIndex` values reflect reordered positions
  - [ ] "Add image from Drive" → pick a PNG, row appears with thumbnail
  - [ ] "Attach context doc" renders legibly on dark overlay, no click-through
  - [ ] Force a parse failure, confirm real server message shows (not the old generic string)
  - [ ] Walk through all purged files — confirm zero indigo→purple gradients remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)