### PR TITLE
feat(library): folders, grid, bulk select, collapsible sidebar

### DIFF
--- a/components/common/library/BulkActionBar.tsx
+++ b/components/common/library/BulkActionBar.tsx
@@ -1,0 +1,102 @@
+/**
+ * BulkActionBar — floating contextual bar shown above the grid when one or
+ * more library items are selected. Surfaces count + Move-to-folder + Delete
+ * + Clear. Rendered by each manager above its LibraryGrid so the shell
+ * stays agnostic of selection state.
+ */
+
+import React, { useState } from 'react';
+import { FolderInput, Trash2, X } from 'lucide-react';
+import type { LibraryFolder } from '@/types';
+import { FolderPickerPopover } from './FolderPickerPopover';
+
+export interface BulkActionBarProps {
+  count: number;
+  onClear: () => void;
+  /** Folder picker data. When omitted, the "Move" button is hidden. */
+  folders?: LibraryFolder[];
+  onMove?: (folderId: string | null) => void | Promise<void>;
+  /** Delete handler. When omitted, the "Delete" button is hidden. */
+  onDelete?: () => void | Promise<void>;
+  /** Optional busy flag that disables actions while a batch is in-flight. */
+  busy?: boolean;
+}
+
+export const BulkActionBar: React.FC<BulkActionBarProps> = ({
+  count,
+  onClear,
+  folders,
+  onMove,
+  onDelete,
+  busy,
+}) => {
+  const [showFolderPicker, setShowFolderPicker] = useState(false);
+
+  if (count === 0) return null;
+
+  return (
+    <div
+      role="region"
+      aria-label="Bulk actions"
+      className="flex flex-wrap items-center gap-2 rounded-2xl border border-brand-blue-primary/30 bg-brand-blue-lighter/30 px-3 py-2 shadow-sm backdrop-blur-sm"
+    >
+      <span className="font-bold text-sm text-brand-blue-dark">
+        {count} selected
+      </span>
+
+      <div className="ml-auto flex items-center gap-2">
+        {folders && onMove && (
+          <div className="relative">
+            <button
+              type="button"
+              onClick={() => setShowFolderPicker((v) => !v)}
+              disabled={busy}
+              className="inline-flex items-center gap-1.5 rounded-lg bg-white px-3 py-1.5 text-xs font-bold uppercase tracking-wider text-brand-blue-dark shadow-sm transition-colors hover:bg-brand-blue-lighter/40 disabled:cursor-not-allowed disabled:opacity-50"
+              aria-haspopup="menu"
+              aria-expanded={showFolderPicker}
+            >
+              <FolderInput className="h-3.5 w-3.5" />
+              Move
+            </button>
+            {showFolderPicker && (
+              <FolderPickerPopover
+                folders={folders}
+                selectedFolderId={null}
+                onSelect={async (folderId) => {
+                  setShowFolderPicker(false);
+                  await onMove(folderId);
+                }}
+                onClose={() => setShowFolderPicker(false)}
+              />
+            )}
+          </div>
+        )}
+
+        {onDelete && (
+          <button
+            type="button"
+            onClick={() => {
+              if (!busy) void onDelete();
+            }}
+            disabled={busy}
+            className="inline-flex items-center gap-1.5 rounded-lg bg-white px-3 py-1.5 text-xs font-bold uppercase tracking-wider text-brand-red-dark shadow-sm transition-colors hover:bg-brand-red-lighter/30 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            <Trash2 className="h-3.5 w-3.5" />
+            Delete
+          </button>
+        )}
+
+        <button
+          type="button"
+          onClick={onClear}
+          disabled={busy}
+          className="inline-flex items-center gap-1.5 rounded-lg px-2 py-1.5 text-xs font-semibold text-slate-600 hover:bg-white/60 disabled:cursor-not-allowed disabled:opacity-50"
+          aria-label="Clear selection"
+        >
+          <X className="h-3.5 w-3.5" />
+          Clear
+        </button>
+      </div>
+    </div>
+  );
+};

--- a/components/common/library/BulkActionBar.tsx
+++ b/components/common/library/BulkActionBar.tsx
@@ -52,7 +52,7 @@ export const BulkActionBar: React.FC<BulkActionBarProps> = ({
               onClick={() => setShowFolderPicker((v) => !v)}
               disabled={busy}
               className="inline-flex items-center gap-1.5 rounded-lg bg-white px-3 py-1.5 text-xs font-bold uppercase tracking-wider text-brand-blue-dark shadow-sm transition-colors hover:bg-brand-blue-lighter/40 disabled:cursor-not-allowed disabled:opacity-50"
-              aria-haspopup="menu"
+              aria-haspopup="dialog"
               aria-expanded={showFolderPicker}
             >
               <FolderInput className="h-3.5 w-3.5" />
@@ -75,8 +75,8 @@ export const BulkActionBar: React.FC<BulkActionBarProps> = ({
         {onDelete && (
           <button
             type="button"
-            onClick={() => {
-              if (!busy) void onDelete();
+            onClick={async () => {
+              if (!busy) await onDelete();
             }}
             disabled={busy}
             className="inline-flex items-center gap-1.5 rounded-lg bg-white px-3 py-1.5 text-xs font-bold uppercase tracking-wider text-brand-red-dark shadow-sm transition-colors hover:bg-brand-red-lighter/30 disabled:cursor-not-allowed disabled:opacity-50"

--- a/components/common/library/FolderPickerPopover.tsx
+++ b/components/common/library/FolderPickerPopover.tsx
@@ -12,7 +12,7 @@
  * folders from `useFolders()` and handle the move/commit themselves.
  */
 
-import React, { useEffect, useMemo, useRef } from 'react';
+import React, { useEffect, useId, useMemo, useRef } from 'react';
 import { Folder as FolderIcon, Check, Inbox } from 'lucide-react';
 import type { LibraryFolder } from '@/types';
 
@@ -92,6 +92,7 @@ export const FolderPickerPopover: React.FC<FolderPickerPopoverProps> = ({
   variant = 'popover',
 }) => {
   const containerRef = useRef<HTMLDivElement>(null);
+  const headerId = useId();
 
   useEffect(() => {
     const handlePointer = (event: MouseEvent): void => {
@@ -151,7 +152,8 @@ export const FolderPickerPopover: React.FC<FolderPickerPopoverProps> = ({
     <div
       ref={containerRef}
       role="dialog"
-      aria-label={title}
+      aria-labelledby={headerId}
+      aria-modal={variant === 'dialog' ? true : undefined}
       className={
         variant === 'dialog'
           ? 'relative z-10 flex max-h-[80vh] w-80 flex-col rounded-xl border border-slate-200 bg-white/95 shadow-2xl backdrop-blur-md'
@@ -159,6 +161,7 @@ export const FolderPickerPopover: React.FC<FolderPickerPopoverProps> = ({
       }
     >
       <header
+        id={headerId}
         className="border-b border-slate-200 font-semibold text-slate-500"
         style={{
           paddingInline: 'min(12px, 3cqmin)',
@@ -212,7 +215,6 @@ export const FolderPickerPopover: React.FC<FolderPickerPopoverProps> = ({
     return (
       <div
         className="fixed inset-0 z-[100] flex items-center justify-center bg-slate-900/40 backdrop-blur-sm"
-        aria-modal="true"
         role="presentation"
       >
         {card}

--- a/components/common/library/FolderPickerPopover.tsx
+++ b/components/common/library/FolderPickerPopover.tsx
@@ -1,0 +1,224 @@
+/**
+ * FolderPickerPopover — lightweight single-select folder picker.
+ *
+ * Used by:
+ *   1. Row "Move to folder…" kebab action (see `folderMenuAction.ts`)
+ *   2. `FolderSelectField` in editor modals
+ *   3. Bulk-action bar's "Move to folder" button
+ *
+ * Renders a flat list of all folders (indented by depth to convey hierarchy)
+ * plus a top "All items" entry that maps to `folderId = null` (root). Keeps
+ * it dumb: fully controlled, no Firestore access. Callers pass the current
+ * folders from `useFolders()` and handle the move/commit themselves.
+ */
+
+import React, { useEffect, useMemo, useRef } from 'react';
+import { Folder as FolderIcon, Check, Inbox } from 'lucide-react';
+import type { LibraryFolder } from '@/types';
+
+export interface FolderPickerPopoverProps {
+  folders: LibraryFolder[];
+  /** Currently-selected folder id (`null` = root / "All items"). */
+  selectedFolderId: string | null;
+  onSelect: (folderId: string | null) => void;
+  /** Called when the user dismisses the popover (click outside, Esc). */
+  onClose: () => void;
+  /** Header copy, e.g. "Move quiz to…". */
+  title?: string;
+  /**
+   * Layout mode:
+   *   - `'popover'` (default): absolutely-positioned card — caller owns the
+   *     relative anchor (usually the kebab-menu row).
+   *   - `'dialog'`: fixed-position centered modal with a backdrop, suitable
+   *     for use from a row action without a stable anchor.
+   */
+  variant?: 'popover' | 'dialog';
+}
+
+interface FlatNode {
+  id: string;
+  name: string;
+  depth: number;
+}
+
+/**
+ * Flatten the folder tree into a depth-ordered list so we can render a
+ * single scrollable column with indentation. Orphans (parent not in set)
+ * are treated as root-level so they remain reachable.
+ */
+const flattenFolders = (folders: LibraryFolder[]): FlatNode[] => {
+  const byParent = new Map<string | null, LibraryFolder[]>();
+  for (const f of folders) {
+    const bucket = byParent.get(f.parentId) ?? [];
+    bucket.push(f);
+    byParent.set(f.parentId, bucket);
+  }
+  // Stable order — already ordered by `order` from Firestore.
+  for (const [key, bucket] of byParent) {
+    bucket.sort((a, b) => a.order - b.order);
+    byParent.set(key, bucket);
+  }
+
+  const knownIds = new Set(folders.map((f) => f.id));
+  const out: FlatNode[] = [];
+  const walk = (parentId: string | null, depth: number): void => {
+    const children = byParent.get(parentId) ?? [];
+    for (const child of children) {
+      out.push({ id: child.id, name: child.name, depth });
+      walk(child.id, depth + 1);
+    }
+  };
+  walk(null, 0);
+
+  // Surface any orphan folders (parent id is not in our set) at the root
+  // so they're still pickable instead of silently hidden.
+  for (const f of folders) {
+    if (f.parentId != null && !knownIds.has(f.parentId)) {
+      if (!out.some((n) => n.id === f.id)) {
+        out.push({ id: f.id, name: f.name, depth: 0 });
+      }
+    }
+  }
+
+  return out;
+};
+
+export const FolderPickerPopover: React.FC<FolderPickerPopoverProps> = ({
+  folders,
+  selectedFolderId,
+  onSelect,
+  onClose,
+  title = 'Move to folder',
+  variant = 'popover',
+}) => {
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handlePointer = (event: MouseEvent): void => {
+      if (!containerRef.current) return;
+      if (!containerRef.current.contains(event.target as Node)) {
+        onClose();
+      }
+    };
+    const handleKey = (event: KeyboardEvent): void => {
+      if (event.key === 'Escape') onClose();
+    };
+    document.addEventListener('mousedown', handlePointer);
+    document.addEventListener('keydown', handleKey);
+    return () => {
+      document.removeEventListener('mousedown', handlePointer);
+      document.removeEventListener('keydown', handleKey);
+    };
+  }, [onClose]);
+
+  const flat = useMemo(() => flattenFolders(folders), [folders]);
+
+  const renderRow = (
+    id: string | null,
+    name: string,
+    depth: number,
+    icon: React.ReactNode
+  ): React.ReactElement => {
+    const selected = selectedFolderId === id;
+    return (
+      <button
+        key={id ?? 'root'}
+        type="button"
+        onClick={() => {
+          onSelect(id);
+          onClose();
+        }}
+        className={`flex w-full items-center gap-2 rounded-md text-left transition-colors ${
+          selected
+            ? 'bg-brand-blue-primary/10 text-brand-blue-primary'
+            : 'text-slate-700 hover:bg-slate-100'
+        }`}
+        style={{
+          paddingInline: 'min(10px, 2.5cqmin)',
+          paddingBlock: 'min(6px, 1.5cqmin)',
+          paddingLeft: `calc(min(10px, 2.5cqmin) + ${depth * 14}px)`,
+          fontSize: 'min(13px, 4cqmin)',
+        }}
+      >
+        <span className="shrink-0 text-slate-400">{icon}</span>
+        <span className="flex-1 truncate">{name}</span>
+        {selected && <Check className="h-4 w-4 shrink-0" aria-hidden="true" />}
+      </button>
+    );
+  };
+
+  const card = (
+    <div
+      ref={containerRef}
+      role="dialog"
+      aria-label={title}
+      className={
+        variant === 'dialog'
+          ? 'relative z-10 flex max-h-[80vh] w-80 flex-col rounded-xl border border-slate-200 bg-white/95 shadow-2xl backdrop-blur-md'
+          : 'absolute z-50 mt-1 flex max-h-72 w-64 flex-col rounded-xl border border-slate-200 bg-white/95 shadow-xl backdrop-blur-md'
+      }
+    >
+      <header
+        className="border-b border-slate-200 font-semibold text-slate-500"
+        style={{
+          paddingInline: 'min(12px, 3cqmin)',
+          paddingBlock: 'min(8px, 2cqmin)',
+          fontSize: 'min(11px, 3.5cqmin)',
+          letterSpacing: '0.06em',
+          textTransform: 'uppercase',
+        }}
+      >
+        {title}
+      </header>
+      <div
+        className="flex-1 overflow-y-auto"
+        style={{
+          paddingInline: 'min(6px, 1.5cqmin)',
+          paddingBlock: 'min(6px, 1.5cqmin)',
+        }}
+      >
+        {renderRow(
+          null,
+          'All items (no folder)',
+          0,
+          <Inbox className="h-4 w-4" aria-hidden="true" />
+        )}
+        {flat.length === 0 ? (
+          <p
+            className="text-slate-400"
+            style={{
+              paddingInline: 'min(10px, 2.5cqmin)',
+              paddingBlock: 'min(8px, 2cqmin)',
+              fontSize: 'min(12px, 3.5cqmin)',
+            }}
+          >
+            No folders yet. Create one from the sidebar.
+          </p>
+        ) : (
+          flat.map((node) =>
+            renderRow(
+              node.id,
+              node.name,
+              node.depth,
+              <FolderIcon className="h-4 w-4" aria-hidden="true" />
+            )
+          )
+        )}
+      </div>
+    </div>
+  );
+
+  if (variant === 'dialog') {
+    return (
+      <div
+        className="fixed inset-0 z-[100] flex items-center justify-center bg-slate-900/40 backdrop-blur-sm"
+        aria-modal="true"
+        role="presentation"
+      >
+        {card}
+      </div>
+    );
+  }
+
+  return card;
+};

--- a/components/common/library/FolderSelectField.tsx
+++ b/components/common/library/FolderSelectField.tsx
@@ -1,0 +1,86 @@
+/**
+ * FolderSelectField — labeled folder chooser for editor modals.
+ *
+ * Presents the current folder as an inline button. Clicking opens a
+ * `FolderPickerPopover` (dialog variant) so the teacher can reassign the
+ * item while editing — no need to save, close, open the kebab, and move.
+ *
+ * Controlled: caller owns the `value` and handles `onChange`. Pairs with
+ * `useFolders()` on the manager side to persist.
+ */
+
+import React, { useMemo, useState } from 'react';
+import { Folder as FolderIcon, Inbox, ChevronDown } from 'lucide-react';
+import type { LibraryFolder } from '@/types';
+import { FolderPickerPopover } from './FolderPickerPopover';
+
+export interface FolderSelectFieldProps {
+  /** All folders for this (user, widget) pair. */
+  folders: LibraryFolder[];
+  /** Currently-selected folder id (`null` = root / unfoldered). */
+  value: string | null;
+  onChange: (folderId: string | null) => void;
+  /** Field label, e.g. "Folder". Defaults to "Folder". */
+  label?: string;
+  /** Disables the field and tooltips with `disabledReason`. */
+  disabled?: boolean;
+  disabledReason?: string;
+}
+
+export const FolderSelectField: React.FC<FolderSelectFieldProps> = ({
+  folders,
+  value,
+  onChange,
+  label = 'Folder',
+  disabled = false,
+  disabledReason,
+}) => {
+  const [pickerOpen, setPickerOpen] = useState(false);
+
+  const currentFolder = useMemo(
+    () =>
+      value == null ? null : (folders.find((f) => f.id === value) ?? null),
+    [folders, value]
+  );
+
+  const displayName =
+    value == null
+      ? 'No folder'
+      : currentFolder
+        ? currentFolder.name
+        : 'Folder not found';
+
+  return (
+    <div className="flex flex-col gap-1.5">
+      <label className="text-xs font-bold uppercase tracking-widest text-slate-500">
+        {label}
+      </label>
+      <button
+        type="button"
+        disabled={disabled}
+        onClick={() => setPickerOpen(true)}
+        title={disabled ? disabledReason : undefined}
+        className="inline-flex items-center gap-2 rounded-xl border border-slate-300 bg-white px-3 py-2 text-left text-sm font-medium text-slate-700 transition-colors hover:border-brand-blue-primary/40 hover:bg-brand-blue-lighter/10 disabled:cursor-not-allowed disabled:opacity-60"
+      >
+        {value == null ? (
+          <Inbox className="h-4 w-4 shrink-0 text-slate-400" />
+        ) : (
+          <FolderIcon className="h-4 w-4 shrink-0 text-slate-400" />
+        )}
+        <span className="flex-1 truncate">{displayName}</span>
+        <ChevronDown className="h-4 w-4 shrink-0 text-slate-400" />
+      </button>
+
+      {pickerOpen && (
+        <FolderPickerPopover
+          variant="dialog"
+          folders={folders}
+          selectedFolderId={value}
+          onSelect={onChange}
+          onClose={() => setPickerOpen(false)}
+          title={`Select ${label.toLowerCase()}`}
+        />
+      )}
+    </div>
+  );
+};

--- a/components/common/library/FolderSidebar.tsx
+++ b/components/common/library/FolderSidebar.tsx
@@ -16,6 +16,7 @@ import { useDroppable } from '@dnd-kit/core';
 import type { LibraryFolder, LibraryFolderWidget } from '@/types';
 import { FolderTree } from './FolderTree';
 import { folderDroppableId, type FolderDropData } from './folderDropTargets';
+import { useFolderPanelMode } from './LibraryFolderPanelContext';
 
 export type FolderDeleteMode = 'move-to-parent' | 'delete-all';
 
@@ -168,37 +169,61 @@ export const FolderSidebar: React.FC<FolderSidebarProps> = ({
     setConfirmDelete(target);
   };
 
+  const panelMode = useFolderPanelMode();
+  const isRail = panelMode === 'rail';
+
   return (
-    <aside
-      className="flex flex-col gap-1 w-56 shrink-0 border-r border-slate-200 bg-slate-50/60 p-2 overflow-y-auto"
-      aria-label="Folders"
+    <div
+      className="flex flex-col gap-1 w-full"
+      style={{ padding: isRail ? 'min(4px, 1cqmin)' : 'min(8px, 2cqmin)' }}
     >
-      <header className="flex items-center justify-between px-2 pt-1 pb-2">
-        <span className="text-xs font-bold text-brand-blue-dark uppercase tracking-widest">
-          Folders
-        </span>
-        {onCreateFolder && (
-          <button
-            type="button"
-            onClick={() => {
-              setCreatingUnder(null);
-              setNewName('');
-            }}
-            className="p-1 rounded-lg hover:bg-white text-brand-blue-primary transition-colors"
-            title="New folder"
-            aria-label="New folder"
+      {!isRail && (
+        <header
+          className="flex items-center justify-between"
+          style={{
+            paddingInline: 'min(8px, 2cqmin)',
+            paddingTop: 'min(4px, 1cqmin)',
+            paddingBottom: 'min(8px, 2cqmin)',
+          }}
+        >
+          <span
+            className="font-bold text-brand-blue-dark uppercase tracking-widest"
+            style={{ fontSize: 'min(11px, 3.5cqmin)' }}
           >
-            <FolderPlus className="w-4 h-4" />
-          </button>
-        )}
-      </header>
+            Folders
+          </span>
+          {onCreateFolder && (
+            <button
+              type="button"
+              onClick={() => {
+                setCreatingUnder(null);
+                setNewName('');
+              }}
+              className="p-1 rounded-lg hover:bg-white text-brand-blue-primary transition-colors"
+              title="New folder"
+              aria-label="New folder"
+            >
+              <FolderPlus
+                style={{
+                  width: 'min(16px, 4.5cqmin)',
+                  height: 'min(16px, 4.5cqmin)',
+                }}
+              />
+            </button>
+          )}
+        </header>
+      )}
 
       {/* Root / "All items" entry */}
       <button
         ref={enableDrop ? rootDroppable.setNodeRef : undefined}
         type="button"
         onClick={() => onSelectFolder(null)}
-        className={`flex items-center gap-2 px-2 py-1.5 rounded-lg text-sm font-semibold text-left transition-colors ${
+        title={isRail ? 'All items' : undefined}
+        aria-label={isRail ? 'All items' : undefined}
+        className={`flex items-center rounded-lg font-semibold text-left transition-colors ${
+          isRail ? 'justify-center' : ''
+        } ${
           selectedFolderId === null
             ? 'bg-brand-blue-primary text-white'
             : 'text-brand-blue-dark hover:bg-white'
@@ -207,16 +232,29 @@ export const FolderSidebar: React.FC<FolderSidebarProps> = ({
             ? 'ring-2 ring-brand-blue-primary/60 bg-brand-blue-lighter/40'
             : ''
         }`}
+        style={{
+          gap: isRail ? '0' : 'min(8px, 2cqmin)',
+          paddingInline: isRail ? '0' : 'min(8px, 2cqmin)',
+          paddingBlock: 'min(6px, 1.5cqmin)',
+          fontSize: 'min(13px, 4cqmin)',
+        }}
       >
-        <Inbox className="w-4 h-4" />
-        <span className="flex-1">All items</span>
-        {rootCount > 0 && (
+        <Inbox
+          style={{
+            width: 'min(16px, 4.5cqmin)',
+            height: 'min(16px, 4.5cqmin)',
+            flexShrink: 0,
+          }}
+        />
+        {!isRail && <span className="flex-1 truncate">All items</span>}
+        {!isRail && rootCount > 0 && (
           <span
-            className={`text-xxs font-bold ${
+            className={`font-bold ${
               selectedFolderId === null
                 ? 'text-white/80'
                 : 'text-brand-blue-primary/60'
             }`}
+            style={{ fontSize: 'min(10px, 3cqmin)' }}
           >
             {rootCount}
           </span>
@@ -224,7 +262,7 @@ export const FolderSidebar: React.FC<FolderSidebarProps> = ({
       </button>
 
       {/* Inline new-folder at root */}
-      {creatingUnder === null && (
+      {!isRail && creatingUnder === null && (
         <NewFolderInput
           value={newName}
           onChange={setNewName}
@@ -236,15 +274,15 @@ export const FolderSidebar: React.FC<FolderSidebarProps> = ({
         />
       )}
 
-      {loading && (
+      {!isRail && loading && (
         <p className="text-xxs text-slate-400 italic px-2 py-1">
           Loading folders…
         </p>
       )}
-      {error && (
+      {!isRail && error && (
         <p className="text-xxs text-brand-red-primary px-2 py-1">{error}</p>
       )}
-      {commitError && (
+      {!isRail && commitError && (
         <p className="text-xxs text-brand-red-primary px-2 py-1">
           {commitError}
         </p>
@@ -287,7 +325,7 @@ export const FolderSidebar: React.FC<FolderSidebarProps> = ({
       />
 
       {/* Inline new-folder rendered below the subtree it targets */}
-      {creatingUnder && creatingUnder !== null && (
+      {!isRail && creatingUnder && creatingUnder !== null && (
         <div className="ml-6">
           <NewFolderInput
             value={newName}
@@ -310,7 +348,7 @@ export const FolderSidebar: React.FC<FolderSidebarProps> = ({
           onConfirm={handleConfirmDelete}
         />
       )}
-    </aside>
+    </div>
   );
 };
 

--- a/components/common/library/FolderTree.tsx
+++ b/components/common/library/FolderTree.tsx
@@ -23,6 +23,7 @@ import {
 import { useDroppable } from '@dnd-kit/core';
 import type { LibraryFolder } from '@/types';
 import { folderDroppableId, type FolderDropData } from './folderDropTargets';
+import { useFolderPanelMode } from './LibraryFolderPanelContext';
 
 export interface FolderTreeProps {
   /** Flat folder list — the tree shape is derived from `parentId`. */
@@ -158,6 +159,8 @@ const FolderRow: React.FC<FolderRowProps> = ({
   onCreateChild,
   onMoveToRoot,
 }) => {
+  const panelMode = useFolderPanelMode();
+  const isRail = panelMode === 'rail';
   const dropData = useMemo<FolderDropData>(
     () => ({ type: 'folder', folderId: folder.id }),
     [folder.id]
@@ -169,10 +172,50 @@ const FolderRow: React.FC<FolderRowProps> = ({
   });
   const isOver = enableDrop && droppable.isOver;
 
+  // Rail mode: render a single icon button per folder so the tiny rail is
+  // still navigable. Nesting/rename/menu affordances are suppressed; the
+  // user can expand the panel to access them.
+  if (isRail) {
+    return (
+      <div
+        ref={enableDrop ? droppable.setNodeRef : undefined}
+        className={`flex items-center justify-center rounded-lg transition-colors ${
+          isSelected
+            ? 'bg-brand-blue-primary/15 text-brand-blue-dark'
+            : 'text-slate-500 hover:bg-slate-100'
+        } ${
+          isOver
+            ? 'ring-2 ring-brand-blue-primary/60 bg-brand-blue-lighter/40'
+            : ''
+        }`}
+        style={{ paddingBlock: 'min(6px, 1.5cqmin)' }}
+      >
+        <button
+          type="button"
+          onClick={() => onSelectFolder(folder.id)}
+          title={`${folder.name}${count > 0 ? ` (${count})` : ''}`}
+          aria-label={`${folder.name}, ${count} items`}
+          className="flex items-center justify-center"
+          style={{
+            width: 'min(32px, 9cqmin)',
+            height: 'min(32px, 9cqmin)',
+          }}
+        >
+          <Folder
+            style={{
+              width: 'min(16px, 4.5cqmin)',
+              height: 'min(16px, 4.5cqmin)',
+            }}
+          />
+        </button>
+      </div>
+    );
+  }
+
   return (
     <div
       ref={enableDrop ? droppable.setNodeRef : undefined}
-      className={`group relative flex items-center gap-1 rounded-lg text-sm font-medium select-none transition-colors ${
+      className={`group relative flex items-center font-medium select-none rounded-lg transition-colors ${
         isSelected
           ? 'bg-brand-blue-primary/10 text-brand-blue-dark'
           : 'text-slate-700 hover:bg-slate-100'
@@ -181,7 +224,11 @@ const FolderRow: React.FC<FolderRowProps> = ({
           ? 'ring-2 ring-brand-blue-primary/60 bg-brand-blue-lighter/40'
           : ''
       }`}
-      style={{ paddingLeft: depth * INDENT_PX + 4 }}
+      style={{
+        paddingLeft: depth * INDENT_PX + 4,
+        gap: 'min(4px, 1cqmin)',
+        fontSize: 'min(13px, 4cqmin)',
+      }}
     >
       {/* Expand/collapse chevron. */}
       <button
@@ -258,11 +305,15 @@ const FolderRow: React.FC<FolderRowProps> = ({
       {/* Item count badge. */}
       {!isRenaming && count > 0 && (
         <span
-          className={`shrink-0 inline-flex items-center justify-center rounded-full px-1.5 text-[10px] font-bold leading-none ${
+          className={`shrink-0 inline-flex items-center justify-center rounded-full font-bold leading-none ${
             isSelected
               ? 'bg-brand-blue-primary/20 text-brand-blue-dark'
               : 'bg-slate-200 text-slate-600'
           }`}
+          style={{
+            paddingInline: 'min(6px, 1.5cqmin)',
+            fontSize: 'min(10px, 3cqmin)',
+          }}
         >
           {count}
         </span>

--- a/components/common/library/LibraryDndContext.tsx
+++ b/components/common/library/LibraryDndContext.tsx
@@ -26,7 +26,6 @@ import {
   DragOverlay,
   KeyboardSensor,
   PointerSensor,
-  closestCenter,
   useSensor,
   useSensors,
   type DragEndEvent,
@@ -34,7 +33,10 @@ import {
 } from '@dnd-kit/core';
 import { sortableKeyboardCoordinates } from '@dnd-kit/sortable';
 import { LibraryGridLockContext } from './LibraryGridLockContext';
-import type { FolderDropData } from './folderDropTargets';
+import {
+  folderAwareCollisionDetection,
+  type FolderDropData,
+} from './folderDropTargets';
 
 export interface LibraryDndContextProps {
   /** Ordered list of draggable item ids in the grid. */
@@ -117,7 +119,7 @@ export const LibraryDndContext: React.FC<LibraryDndContextProps> = ({
   return (
     <DndContext
       sensors={sensors}
-      collisionDetection={closestCenter}
+      collisionDetection={folderAwareCollisionDetection}
       onDragStart={handleDragStart}
       onDragEnd={handleDragEnd}
       onDragCancel={handleDragCancel}

--- a/components/common/library/LibraryFolderPanelContext.ts
+++ b/components/common/library/LibraryFolderPanelContext.ts
@@ -1,0 +1,24 @@
+/**
+ * LibraryFolderPanelContext — read-only handle for the folder-panel's effective
+ * display mode, resolved by `LibraryShell` from widget width + user override.
+ *
+ * 'full' → labels + counts + new-folder button
+ * 'rail' → icons only with tooltips
+ * 'hidden' → panel is not rendered (caller surfaces a picker elsewhere)
+ *
+ * Consumers (e.g. `FolderSidebar`) subscribe to pick rail vs full rendering.
+ */
+
+import { createContext, useContext } from 'react';
+
+export type FolderPanelMode = 'full' | 'rail' | 'hidden';
+
+export interface LibraryFolderPanelContextValue {
+  mode: FolderPanelMode;
+}
+
+export const LibraryFolderPanelContext =
+  createContext<LibraryFolderPanelContextValue>({ mode: 'full' });
+
+export const useFolderPanelMode = (): FolderPanelMode =>
+  useContext(LibraryFolderPanelContext).mode;

--- a/components/common/library/LibraryGrid.tsx
+++ b/components/common/library/LibraryGrid.tsx
@@ -135,15 +135,24 @@ export function LibraryGrid<TItem>(
     ? verticalListSortingStrategy
     : rectSortingStrategy;
 
-  const containerClass = isListLayout
-    ? 'flex flex-col gap-3'
-    : 'grid gap-3 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3';
+  const containerClass = isListLayout ? 'flex flex-col gap-3' : 'gap-3';
+  const containerStyle: React.CSSProperties | undefined = isListLayout
+    ? undefined
+    : {
+        display: 'grid',
+        gridTemplateColumns:
+          'repeat(auto-fill, minmax(min(240px, 80cqmin), 1fr))',
+      };
 
   if (useExternalDndContext) {
     return (
       <LibraryGridLockContext.Provider value={lockState}>
         <SortableContext items={ids} strategy={strategy}>
-          <div className={containerClass} data-testid="library-grid">
+          <div
+            className={containerClass}
+            style={containerStyle}
+            data-testid="library-grid"
+          >
             {items.map((item, index) => renderCard(item, index))}
           </div>
         </SortableContext>
@@ -161,7 +170,11 @@ export function LibraryGrid<TItem>(
         onDragCancel={handleDragCancel}
       >
         <SortableContext items={ids} strategy={strategy}>
-          <div className={containerClass} data-testid="library-grid">
+          <div
+            className={containerClass}
+            style={containerStyle}
+            data-testid="library-grid"
+          >
             {items.map((item, index) => renderCard(item, index))}
           </div>
         </SortableContext>

--- a/components/common/library/LibraryItemCard.tsx
+++ b/components/common/library/LibraryItemCard.tsx
@@ -3,9 +3,10 @@
  *
  * Implements `LibraryItemCardProps<TMeta>` from ./types. Wraps dnd-kit's
  * `useSortable` when `sortable !== false && !isDragOverlay`, otherwise renders
- * a static card (used for the floating `DragOverlay`). Card body click routes
- * to `onClick`; drag starts from a dedicated grip handle so body clicks are
- * unambiguous.
+ * a static card (used for the floating `DragOverlay`). The whole card is the
+ * drag activator so the `DragOverlay` clone tracks the cursor naturally;
+ * `PointerSensor`'s 5px activation distance keeps body clicks unambiguous.
+ * The left-edge grip is a visual affordance only.
  *
  * Visual style matches the QuizManager light interior — white surface with
  * slate border, rounded-2xl, brand-blue accents on primary action, and a
@@ -16,10 +17,10 @@
  * hint as the drag-handle tooltip at reduced opacity.
  */
 
-import React, { useContext, useEffect, useRef, useState } from 'react';
+import React, { useContext, useRef, useState } from 'react';
 import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
-import { GripVertical, MoreHorizontal } from 'lucide-react';
+import { Check, GripVertical, MoreHorizontal } from 'lucide-react';
 import { useClickOutside } from '@/hooks/useClickOutside';
 import { Z_INDEX } from '@/config/zIndex';
 import { LibraryGridLockContext } from './LibraryGridLockContext';
@@ -53,57 +54,6 @@ const BADGE_TONE_STYLES: Record<
     fg: 'text-brand-red-dark',
     dot: 'bg-brand-red-primary',
   },
-};
-
-/* ─── Inline action buttons ──────────────────────────────────────────────── */
-
-interface InlineActionButtonProps {
-  action: LibraryMenuAction;
-  compact?: boolean;
-}
-
-const InlineActionButton: React.FC<InlineActionButtonProps> = ({
-  action,
-  compact = false,
-}) => {
-  const Icon = action.icon;
-  const destructive = action.destructive;
-  const base =
-    'inline-flex shrink-0 items-center justify-center gap-1.5 rounded-xl border font-bold uppercase tracking-wider transition-all active:scale-95 disabled:cursor-not-allowed disabled:opacity-50';
-  const tone = destructive
-    ? 'border-brand-red-primary/20 bg-white/80 text-brand-red-dark hover:bg-brand-red-lighter/30 hover:border-brand-red-primary/40'
-    : 'border-slate-200 bg-white/80 text-slate-700 hover:bg-white hover:border-slate-300';
-  return (
-    <button
-      type="button"
-      onClick={(e) => {
-        e.stopPropagation();
-        if (!action.disabled) action.onClick();
-      }}
-      disabled={action.disabled}
-      title={action.disabled ? action.disabledReason : action.label}
-      aria-label={action.label}
-      className={`${base} ${tone}`}
-      style={{
-        paddingInline: compact ? '0' : 'min(12px, 2.8cqmin)',
-        paddingBlock: 'min(6px, 1.6cqmin)',
-        fontSize: 'min(11px, 3.6cqmin)',
-        minWidth: compact ? 'min(32px, 9cqmin)' : undefined,
-        height: compact ? 'min(32px, 9cqmin)' : undefined,
-      }}
-    >
-      {Icon && (
-        <Icon
-          style={{
-            width: 'min(14px, 4cqmin)',
-            height: 'min(14px, 4cqmin)',
-          }}
-          className="shrink-0"
-        />
-      )}
-      {!compact && <span className="truncate">{action.label}</span>}
-    </button>
-  );
 };
 
 /* ─── Overflow menu (click-outside aware) ─────────────────────────────────── */
@@ -226,62 +176,34 @@ function CardBody<TMeta>(props: CardBodyProps<TMeta>) {
     dragHandle,
     isDragOverlay,
     isDragging,
+    selectionMode,
+    selected,
+    onSelectionToggle,
   } = props;
 
   const PrimaryIcon = primaryAction.icon;
   const isList = viewMode === 'list';
 
-  // Inline-vs-overflow layout only applies to list-view cards with secondary
-  // actions. Grid-view cards always use the overflow menu, so we skip the
-  // ResizeObserver entirely there (avoids per-card observer overhead in large
-  // libraries).
-  const secondaryCount = secondaryActions?.length ?? 0;
-  const shouldMeasureSecondaryActions = isList && secondaryCount > 0;
-
-  const cardRef = useRef<HTMLDivElement>(null);
-  const [cardWidth, setCardWidth] = useState<number | null>(null);
-  useEffect(() => {
-    if (!shouldMeasureSecondaryActions) return undefined;
-    const el = cardRef.current;
-    if (!el || typeof ResizeObserver === 'undefined') return undefined;
-    const observer = new ResizeObserver((entries) => {
-      const entry = entries[0];
-      if (entry) setCardWidth(entry.contentRect.width);
-    });
-    observer.observe(el);
-    return () => observer.disconnect();
-  }, [shouldMeasureSecondaryActions]);
-
-  // When we've flipped out of the measuring mode (e.g. view mode changed from
-  // list to grid, or secondary actions got removed), ignore the stale
-  // measurement so grid cards reliably fall back to the overflow menu.
-  const effectiveCardWidth = shouldMeasureSecondaryActions ? cardWidth : null;
-
-  // Rough space budget per inline secondary: ~92px with label, ~40px icon-only.
-  // Primary (ASSIGN) plus padding eats ~140px. Inline labels when we have
-  // headroom; otherwise try icon-only; otherwise fall back to overflow menu.
-  const widthForLabels = 160 + secondaryCount * 96;
-  const widthForIconOnly = 160 + secondaryCount * 44;
-  const canShowInlineLabels =
-    effectiveCardWidth != null && effectiveCardWidth >= widthForLabels;
-  const canShowInlineIcons =
-    effectiveCardWidth != null && effectiveCardWidth >= widthForIconOnly;
-  const useOverflowMenu = !canShowInlineLabels && !canShowInlineIcons;
-
   const handleBodyClick = (e: React.MouseEvent<HTMLDivElement>) => {
     // Ignore bubbled events from buttons / links / menus inside the card.
     if ((e.target as HTMLElement).closest('button, a, [role="menu"]')) return;
+    if (selectionMode) {
+      onSelectionToggle?.();
+      return;
+    }
     onClick?.();
   };
 
   return (
     <div
-      ref={cardRef}
-      onClick={onClick ? handleBodyClick : undefined}
+      onClick={(onClick ?? selectionMode) ? handleBodyClick : undefined}
       className={[
-        'group relative flex rounded-2xl border border-slate-200/80 bg-white/70 backdrop-blur-sm text-slate-700 shadow-sm transition-shadow hover:shadow-md hover:bg-white/85',
+        'group relative flex rounded-2xl border backdrop-blur-sm text-slate-700 shadow-sm transition-shadow hover:shadow-md',
+        selectionMode && selected
+          ? 'border-brand-blue-primary/60 bg-brand-blue-lighter/30 hover:bg-brand-blue-lighter/40 ring-2 ring-brand-blue-primary/30'
+          : 'border-slate-200/80 bg-white/70 hover:bg-white/85',
         isList ? 'flex-row items-center' : 'flex-col',
-        onClick && 'cursor-pointer',
+        (onClick ?? selectionMode) && 'cursor-pointer',
         isDragging && 'opacity-50',
         isDragOverlay &&
           'pointer-events-none ring-2 ring-brand-blue-primary/30',
@@ -294,8 +216,41 @@ function CardBody<TMeta>(props: CardBodyProps<TMeta>) {
       }}
       aria-hidden={isDragOverlay}
     >
-      {/* Drag handle (left edge) */}
-      {dragHandle}
+      {/* Selection checkbox (left edge, rendered before drag handle) */}
+      {selectionMode && (
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation();
+            onSelectionToggle?.();
+          }}
+          role="checkbox"
+          aria-checked={!!selected}
+          aria-label={selected ? `Deselect ${title}` : `Select ${title}`}
+          className={`flex shrink-0 items-center justify-center rounded-md border-2 transition-colors ${
+            selected
+              ? 'border-brand-blue-primary bg-brand-blue-primary text-white'
+              : 'border-slate-300 bg-white hover:border-brand-blue-primary/70'
+          }`}
+          style={{
+            width: 'min(20px, 5.5cqmin)',
+            height: 'min(20px, 5.5cqmin)',
+          }}
+        >
+          {selected && (
+            <Check
+              style={{
+                width: 'min(14px, 4cqmin)',
+                height: 'min(14px, 4cqmin)',
+              }}
+              strokeWidth={3}
+            />
+          )}
+        </button>
+      )}
+
+      {/* Drag handle (left edge) — hidden in selection mode */}
+      {!selectionMode && dragHandle}
 
       {/* Thumbnail */}
       {thumbnail && (
@@ -385,19 +340,7 @@ function CardBody<TMeta>(props: CardBodyProps<TMeta>) {
           {primaryAction.label}
         </button>
         {secondaryActions && secondaryActions.length > 0 && (
-          <>
-            {useOverflowMenu ? (
-              <OverflowMenu actions={secondaryActions} />
-            ) : (
-              secondaryActions.map((action) => (
-                <InlineActionButton
-                  key={action.id}
-                  action={action}
-                  compact={!canShowInlineLabels}
-                />
-              ))
-            )}
-          </>
+          <OverflowMenu actions={secondaryActions} />
         )}
       </div>
     </div>
@@ -409,12 +352,14 @@ function CardBody<TMeta>(props: CardBodyProps<TMeta>) {
 export function LibraryItemCard<TMeta = unknown>(
   props: LibraryItemCardProps<TMeta>
 ) {
-  const { sortable = true, isDragOverlay = false } = props;
+  const { sortable = true, isDragOverlay = false, selectionMode } = props;
   const lockState = useContext(LibraryGridLockContext);
 
   // When used inside the floating DragOverlay, or when sorting is disabled
-  // at either card or grid level, render a static card without useSortable.
-  const canSort = sortable && !isDragOverlay && !lockState.dragDisabled;
+  // at either card or grid level (or the user is in selection mode), render
+  // a static card without useSortable.
+  const canSort =
+    sortable && !isDragOverlay && !lockState.dragDisabled && !selectionMode;
 
   if (!canSort) {
     return <CardBody {...props} />;
@@ -444,26 +389,36 @@ function SortableCard<TMeta>(props: SortableCardProps<TMeta>) {
     transform: CSS.Transform.toString(transform),
     transition,
     zIndex: isDragging ? Z_INDEX.itemDragging : undefined,
+    touchAction: 'none',
   };
 
+  // Visual affordance only — drag listeners live on the outer sortable node
+  // so the grab point aligns with wherever the user presses on the card.
+  // The PointerSensor's 5px activation distance keeps body clicks from
+  // accidentally starting a drag.
   const dragHandle = (
-    <button
-      type="button"
-      {...attributes}
-      {...listeners}
-      disabled={Boolean(lockedReason)}
+    <div
+      aria-hidden="true"
       title={lockedReason ?? 'Drag to reorder'}
-      aria-label={lockedReason ?? 'Drag to reorder'}
-      className={`flex h-8 w-6 shrink-0 cursor-grab items-center justify-center rounded-lg text-slate-300 transition-colors hover:bg-slate-100 hover:text-slate-500 active:cursor-grabbing touch-none disabled:cursor-not-allowed ${
+      className={`pointer-events-none flex h-8 w-6 shrink-0 items-center justify-center rounded-lg text-slate-300 ${
         lockedReason ? 'opacity-40' : ''
       }`}
     >
       <GripVertical className="h-4 w-4" />
-    </button>
+    </div>
   );
 
+  const accessibleName = lockedReason ?? 'Drag to reorder';
   return (
-    <div ref={setNodeRef} style={style}>
+    <div
+      ref={setNodeRef}
+      style={style}
+      {...attributes}
+      {...listeners}
+      aria-label={accessibleName}
+      aria-disabled={Boolean(lockedReason) || undefined}
+      className={lockedReason ? '' : 'cursor-grab active:cursor-grabbing'}
+    >
       <CardBody {...props} dragHandle={dragHandle} isDragging={isDragging} />
     </div>
   );

--- a/components/common/library/LibraryShell.tsx
+++ b/components/common/library/LibraryShell.tsx
@@ -1,10 +1,52 @@
-import React, { useEffect, useRef, useState } from 'react';
-import { BookOpen, Activity, Archive as ArchiveIcon } from 'lucide-react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import {
+  BookOpen,
+  Activity,
+  Archive as ArchiveIcon,
+  ChevronsLeft,
+  ChevronsRight,
+} from 'lucide-react';
 import type {
   LibraryShellProps,
   LibraryTab,
   LibraryPrimaryAction,
+  LibraryFolderPanelSetting,
 } from './types';
+import {
+  LibraryFolderPanelContext,
+  type FolderPanelMode,
+} from './LibraryFolderPanelContext';
+
+/**
+ * Widget-width breakpoints (px) for auto-collapsing the folder panel. Below
+ * `HIDE_BELOW_PX` the panel is not rendered (caller surfaces a picker
+ * elsewhere); below `RAIL_BELOW_PX` the panel shrinks to an icon rail.
+ */
+const HIDE_BELOW_PX = 360;
+const RAIL_BELOW_PX = 560;
+
+const resolveFolderPanelMode = (
+  setting: LibraryFolderPanelSetting,
+  widthPx: number | null
+): FolderPanelMode => {
+  if (setting === 'full' || setting === 'rail' || setting === 'hidden') {
+    return setting;
+  }
+  if (widthPx == null) return 'full';
+  if (widthPx < HIDE_BELOW_PX) return 'hidden';
+  if (widthPx < RAIL_BELOW_PX) return 'rail';
+  return 'full';
+};
+
+const cycleFolderPanelSetting = (
+  current: FolderPanelMode
+): LibraryFolderPanelSetting => {
+  // Toggle progression: full ↔ rail ↔ hidden. Always lands on an explicit
+  // setting so the user's choice sticks (instead of reverting to 'auto').
+  if (current === 'full') return 'rail';
+  if (current === 'rail') return 'hidden';
+  return 'full';
+};
 
 interface TabDef {
   key: LibraryTab;
@@ -76,8 +118,19 @@ export const LibraryShell: React.FC<LibraryShellProps> = ({
   secondaryActions,
   toolbarSlot,
   filterSidebarSlot,
+  folderPanelMode: folderPanelModeProp,
+  onFolderPanelModeChange,
   children,
 }) => {
+  // When the caller doesn't wire a controlled setting, fall back to internal
+  // state so the chevron toggle still works (just won't persist across mounts).
+  const [uncontrolledMode, setUncontrolledMode] =
+    useState<LibraryFolderPanelSetting>('auto');
+  const folderPanelSetting = folderPanelModeProp ?? uncontrolledMode;
+  const setFolderPanelSetting = (next: LibraryFolderPanelSetting): void => {
+    if (onFolderPanelModeChange) onFolderPanelModeChange(next);
+    else setUncontrolledMode(next);
+  };
   const tabs: TabDef[] = [
     {
       key: 'library',
@@ -116,6 +169,17 @@ export const LibraryShell: React.FC<LibraryShellProps> = ({
   }, []);
   const buttonCount = (primaryAction ? 1 : 0) + (secondaryActions?.length ?? 0);
   const labelsHidden = rootWidth != null && rootWidth < 260 + buttonCount * 110;
+
+  const effectiveFolderPanelMode: FolderPanelMode = useMemo(
+    () => resolveFolderPanelMode(folderPanelSetting, rootWidth),
+    [folderPanelSetting, rootWidth]
+  );
+  const folderPanelContextValue = useMemo(
+    () => ({ mode: effectiveFolderPanelMode }),
+    [effectiveFolderPanelMode]
+  );
+  const shouldRenderFolderPanel =
+    filterSidebarSlot != null && effectiveFolderPanelMode !== 'hidden';
 
   return (
     <section
@@ -231,10 +295,99 @@ export const LibraryShell: React.FC<LibraryShellProps> = ({
       )}
 
       <div className="flex flex-1 min-h-0">
-        {filterSidebarSlot && (
-          <aside className="w-60 shrink-0 bg-white/40 backdrop-blur-sm border-r border-slate-200/70 overflow-y-auto">
-            {filterSidebarSlot}
-          </aside>
+        {shouldRenderFolderPanel && (
+          <LibraryFolderPanelContext.Provider value={folderPanelContextValue}>
+            <aside
+              className="shrink-0 bg-white/40 backdrop-blur-sm border-r border-slate-200/70 overflow-y-auto flex flex-col"
+              style={{
+                width:
+                  effectiveFolderPanelMode === 'rail'
+                    ? 'min(56px, 14cqmin)'
+                    : 'min(240px, 30cqmin)',
+              }}
+              aria-label="Folders"
+            >
+              <div
+                className="flex items-center justify-end shrink-0"
+                style={{
+                  paddingInline:
+                    effectiveFolderPanelMode === 'rail'
+                      ? 'min(4px, 1cqmin)'
+                      : 'min(8px, 2cqmin)',
+                  paddingBlock: 'min(6px, 1.5cqmin)',
+                }}
+              >
+                <button
+                  type="button"
+                  onClick={() =>
+                    setFolderPanelSetting(
+                      cycleFolderPanelSetting(effectiveFolderPanelMode)
+                    )
+                  }
+                  className="inline-flex items-center justify-center rounded-lg text-slate-500 transition-colors hover:bg-white/70 hover:text-brand-blue-primary"
+                  style={{
+                    width: 'min(28px, 7cqmin)',
+                    height: 'min(28px, 7cqmin)',
+                  }}
+                  title={
+                    effectiveFolderPanelMode === 'full'
+                      ? 'Collapse folders'
+                      : effectiveFolderPanelMode === 'rail'
+                        ? 'Hide folders'
+                        : 'Show folders'
+                  }
+                  aria-label="Toggle folder panel"
+                >
+                  {effectiveFolderPanelMode === 'full' ? (
+                    <ChevronsLeft
+                      style={{
+                        width: 'min(16px, 4.5cqmin)',
+                        height: 'min(16px, 4.5cqmin)',
+                      }}
+                    />
+                  ) : (
+                    <ChevronsRight
+                      style={{
+                        width: 'min(16px, 4.5cqmin)',
+                        height: 'min(16px, 4.5cqmin)',
+                      }}
+                    />
+                  )}
+                </button>
+              </div>
+              <div className="flex-1 min-h-0 overflow-y-auto">
+                {filterSidebarSlot}
+              </div>
+            </aside>
+          </LibraryFolderPanelContext.Provider>
+        )}
+        {!shouldRenderFolderPanel && filterSidebarSlot != null && (
+          <div
+            className="shrink-0 border-r border-slate-200/70 bg-white/40 backdrop-blur-sm flex items-start justify-center"
+            style={{
+              paddingInline: 'min(6px, 1.5cqmin)',
+              paddingBlock: 'min(8px, 2cqmin)',
+            }}
+          >
+            <button
+              type="button"
+              onClick={() => setFolderPanelSetting('rail')}
+              className="inline-flex items-center justify-center rounded-lg text-slate-500 transition-colors hover:bg-white/70 hover:text-brand-blue-primary"
+              style={{
+                width: 'min(28px, 7cqmin)',
+                height: 'min(28px, 7cqmin)',
+              }}
+              title="Show folders"
+              aria-label="Show folders"
+            >
+              <ChevronsRight
+                style={{
+                  width: 'min(16px, 4.5cqmin)',
+                  height: 'min(16px, 4.5cqmin)',
+                }}
+              />
+            </button>
+          </div>
         )}
         <div
           role="tabpanel"

--- a/components/common/library/folderDropTargets.ts
+++ b/components/common/library/folderDropTargets.ts
@@ -6,6 +6,13 @@
  * lint rule to keep Fast Refresh happy in dev).
  */
 
+import {
+  closestCenter,
+  pointerWithin,
+  rectIntersection,
+  type CollisionDetection,
+} from '@dnd-kit/core';
+
 /** Data attached to folder droppables via `useDroppable({ data: {...} })`. */
 export interface FolderDropData {
   type: 'folder';
@@ -22,3 +29,49 @@ export const FOLDER_DROPPABLE_PREFIX = 'folder:';
 /** Build the droppable id for a given folder (null = root). */
 export const folderDroppableId = (folderId: string | null): string =>
   `${FOLDER_DROPPABLE_PREFIX}${folderId ?? 'root'}`;
+
+/**
+ * Collision detection that prioritizes folder droppables over card droppables.
+ *
+ * When the user drags a card over the FolderSidebar, dnd-kit's default
+ * `closestCenter` picks whichever drop target has the closest centroid — and
+ * the next card in the grid is almost always closer than a sidebar folder row.
+ * This means drops land back on the grid (as reorder) instead of on the folder
+ * (as a move). That's the bug behind "drag-to-folder doesn't work".
+ *
+ * Strategy:
+ *   1. First try `pointerWithin` against folder droppables only — if the
+ *      pointer is directly over a folder row, commit to that folder.
+ *   2. If the pointer isn't over any folder but the drag *rect* intersects
+ *      one, fall back to `rectIntersection` against folders — covers drags
+ *      where the ghost card overlaps the sidebar while the pointer is still
+ *      on the grid side of the edge.
+ *   3. Otherwise, run `closestCenter` against the card droppables for normal
+ *      reorder behavior.
+ */
+export const folderAwareCollisionDetection: CollisionDetection = (args) => {
+  const folderContainers = args.droppableContainers.filter((c) => {
+    const data = c.data.current as FolderDropData | undefined;
+    return data?.type === 'folder';
+  });
+  const cardContainers = args.droppableContainers.filter((c) => {
+    const data = c.data.current as FolderDropData | undefined;
+    return data?.type !== 'folder';
+  });
+
+  if (folderContainers.length > 0) {
+    const pointerHits = pointerWithin({
+      ...args,
+      droppableContainers: folderContainers,
+    });
+    if (pointerHits.length > 0) return pointerHits;
+
+    const rectHits = rectIntersection({
+      ...args,
+      droppableContainers: folderContainers,
+    });
+    if (rectHits.length > 0) return rectHits;
+  }
+
+  return closestCenter({ ...args, droppableContainers: cardContainers });
+};

--- a/components/common/library/folderMenuAction.ts
+++ b/components/common/library/folderMenuAction.ts
@@ -1,0 +1,38 @@
+/**
+ * folderMenuAction — builds a "Move to folder…" kebab-menu entry.
+ *
+ * Keeps the action definition reusable across all four library managers
+ * (Quiz, Video Activity, Guided Learning, MiniApp). The caller owns the
+ * popover/dialog state — this helper only produces a `LibraryMenuAction`
+ * whose `onClick` invokes the opener callback with the item id. The
+ * manager is expected to render a `FolderPickerPopover` (or any chooser
+ * UI) and call `useFolders().moveItem(id, folderId)` on commit.
+ */
+
+import { FolderInput } from 'lucide-react';
+import type { LibraryMenuAction } from './types';
+
+export interface MoveToFolderActionOptions {
+  /** Invoked with the item id when the user picks "Move to folder…". */
+  onOpenPicker: () => void;
+  /**
+   * When true, the action is disabled and tooltips with `disabledReason`.
+   * Use this if the caller hasn't loaded folders yet or the user isn't
+   * signed in.
+   */
+  disabled?: boolean;
+  disabledReason?: string;
+  /** Override the label (default: "Move to folder…"). */
+  label?: string;
+}
+
+export const buildMoveToFolderAction = (
+  options: MoveToFolderActionOptions
+): LibraryMenuAction => ({
+  id: 'move-to-folder',
+  label: options.label ?? 'Move to folder…',
+  icon: FolderInput,
+  onClick: options.onOpenPicker,
+  disabled: options.disabled,
+  disabledReason: options.disabledReason,
+});

--- a/components/common/library/index.ts
+++ b/components/common/library/index.ts
@@ -27,6 +27,24 @@ export { FolderSidebar } from './FolderSidebar';
 export type { FolderSidebarProps, FolderDeleteMode } from './FolderSidebar';
 export { FolderTree } from './FolderTree';
 export {
+  LibraryFolderPanelContext,
+  useFolderPanelMode,
+} from './LibraryFolderPanelContext';
+export { FolderPickerPopover } from './FolderPickerPopover';
+export type { FolderPickerPopoverProps } from './FolderPickerPopover';
+export { buildMoveToFolderAction } from './folderMenuAction';
+export type { MoveToFolderActionOptions } from './folderMenuAction';
+export { FolderSelectField } from './FolderSelectField';
+export type { FolderSelectFieldProps } from './FolderSelectField';
+export { useLibrarySelection } from './useLibrarySelection';
+export type { LibrarySelectionApi } from './useLibrarySelection';
+export { BulkActionBar } from './BulkActionBar';
+export type { BulkActionBarProps } from './BulkActionBar';
+export type {
+  FolderPanelMode,
+  LibraryFolderPanelContextValue,
+} from './LibraryFolderPanelContext';
+export {
   ROOT_FOLDER_COUNT_KEY,
   filterByFolder,
   countItemsByFolder,
@@ -47,6 +65,7 @@ export type {
   LibrarySortOption,
   LibraryFilter,
   LibraryShellTabCounts,
+  LibraryFolderPanelSetting,
   LibraryShellProps,
   LibraryToolbarProps,
   LibraryItemCardProps,

--- a/components/common/library/types.ts
+++ b/components/common/library/types.ts
@@ -114,6 +114,12 @@ export interface LibraryShellTabCounts {
   archive?: number;
 }
 
+/**
+ * Folder-panel display mode. `'auto'` resolves to full/rail/hidden based on
+ * the widget's container width; the other values pin the panel to that mode.
+ */
+export type LibraryFolderPanelSetting = 'auto' | 'full' | 'rail' | 'hidden';
+
 export interface LibraryShellProps {
   /** e.g. "Quiz", "Video Activity" — drives empty-state copy, aria labels. */
   widgetLabel: string;
@@ -129,6 +135,13 @@ export interface LibraryShellProps {
   toolbarSlot?: React.ReactNode;
   /** Rendered as a left sidebar — used by Phase 4 folders. */
   filterSidebarSlot?: React.ReactNode;
+  /**
+   * Controls the folder-panel state machine. Defaults to `'auto'` (derived
+   * from widget width). Passing an explicit value pins the panel open/closed.
+   */
+  folderPanelMode?: LibraryFolderPanelSetting;
+  /** Called when the user toggles panel mode via the chevron. */
+  onFolderPanelModeChange?: (mode: LibraryFolderPanelSetting) => void;
   /** Tab-specific content. Consumer decides what to render per tab. */
   children: React.ReactNode;
 }
@@ -181,6 +194,15 @@ export interface LibraryItemCardProps<TMeta = unknown> {
   viewMode?: LibraryViewMode;
   /** Hidden from screen readers when this card is the drag overlay. */
   isDragOverlay?: boolean;
+  /**
+   * When true, renders a left-edge checkbox and suppresses the default card
+   * click → the row toggles selection instead of opening the editor.
+   */
+  selectionMode?: boolean;
+  /** Current selection state — only meaningful when `selectionMode` is true. */
+  selected?: boolean;
+  /** Fired when the user toggles the card's checkbox (or clicks the row in selection mode). */
+  onSelectionToggle?: () => void;
 }
 
 /* ─── LibraryGrid (dnd-kit SortableContext wrapper) ───────────────────────── */
@@ -240,6 +262,11 @@ export interface UseLibraryViewOptions<TItem> {
    * item. Missing filter id = no-op (all pass).
    */
   filterPredicates?: Record<string, (item: TItem, value: string) => boolean>;
+  /**
+   * Optional side-effect fired when the teacher toggles grid/list. Lets the
+   * consumer persist the choice (e.g. to widget config).
+   */
+  onViewModeChange?: (viewMode: LibraryViewMode) => void;
 }
 
 export interface UseLibraryViewResult<TItem> {

--- a/components/common/library/useLibrarySelection.ts
+++ b/components/common/library/useLibrarySelection.ts
@@ -1,0 +1,51 @@
+import { useCallback, useMemo, useState } from 'react';
+
+export interface LibrarySelectionApi {
+  selectedIds: Set<string>;
+  isSelected: (id: string) => boolean;
+  toggle: (id: string) => void;
+  clear: () => void;
+  selectAll: (ids: string[]) => void;
+  count: number;
+}
+
+export function useLibrarySelection(): LibrarySelectionApi {
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(() => new Set());
+
+  const isSelected = useCallback(
+    (id: string) => selectedIds.has(id),
+    [selectedIds]
+  );
+
+  const toggle = useCallback((id: string) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  }, []);
+
+  const clear = useCallback(() => {
+    setSelectedIds((prev) => (prev.size === 0 ? prev : new Set()));
+  }, []);
+
+  const selectAll = useCallback((ids: string[]) => {
+    setSelectedIds(new Set(ids));
+  }, []);
+
+  return useMemo(
+    () => ({
+      selectedIds,
+      isSelected,
+      toggle,
+      clear,
+      selectAll,
+      count: selectedIds.size,
+    }),
+    [selectedIds, isSelected, toggle, clear, selectAll]
+  );
+}

--- a/components/common/library/useLibraryView.ts
+++ b/components/common/library/useLibraryView.ts
@@ -20,13 +20,22 @@ export function useLibraryView<TItem>(
     searchFields,
     sortComparators,
     filterPredicates,
+    onViewModeChange,
   } = options;
 
   const [search, setSearch] = useState<string>(initialSearch);
   const [sort, setSort] = useState<{ key: string; dir: LibrarySortDir }>(
     initialSort
   );
-  const [viewMode, setViewMode] = useState<LibraryViewMode>(initialViewMode);
+  const [viewMode, setViewModeState] =
+    useState<LibraryViewMode>(initialViewMode);
+  const handleViewModeChange = useCallback(
+    (next: LibraryViewMode) => {
+      setViewModeState(next);
+      onViewModeChange?.(next);
+    },
+    [onViewModeChange]
+  );
   const [filterValues, setFilterValues] =
     useState<Record<string, string>>(initialFilterValues);
 
@@ -89,9 +98,16 @@ export function useLibraryView<TItem>(
       filterValues,
       onFilterChange: handleFilterChange,
       viewMode,
-      onViewModeChange: setViewMode,
+      onViewModeChange: handleViewModeChange,
     }),
-    [search, sort, filterValues, handleFilterChange, viewMode]
+    [
+      search,
+      sort,
+      filterValues,
+      handleFilterChange,
+      viewMode,
+      handleViewModeChange,
+    ]
   );
 
   const state = useMemo(

--- a/components/widgets/GuidedLearning/Widget.tsx
+++ b/components/widgets/GuidedLearning/Widget.tsx
@@ -13,6 +13,7 @@ import { useAuth } from '@/context/useAuth';
 import { useGuidedLearning } from '@/hooks/useGuidedLearning';
 import { useGuidedLearningSessionTeacher } from '@/hooks/useGuidedLearningSession';
 import { useGuidedLearningAssignments } from '@/hooks/useGuidedLearningAssignments';
+import { useFolders } from '@/hooks/useFolders';
 import { WidgetLayout } from '@/components/widgets/WidgetLayout';
 import { GuidedLearningManager } from './components/GuidedLearningManager';
 import { GuidedLearningEditorModal } from './components/GuidedLearningEditorModal';
@@ -71,6 +72,11 @@ export const GuidedLearningWidget: React.FC<{ widget: WidgetData }> = ({
   const [editingSet, setEditingSet] = useState<GuidedLearningSet | null>(null);
   const [editingMeta, setEditingMeta] =
     useState<GuidedLearningSetMetadata | null>(null);
+
+  const { folders: glFolders, moveItem: moveGlItem } = useFolders(
+    user?.uid,
+    'guided_learning'
+  );
   const [showAIGen, setShowAIGen] = useState(false);
   const [recentSessionIds, setRecentSessionIds] = useState<
     Record<string, string>
@@ -407,6 +413,15 @@ export const GuidedLearningWidget: React.FC<{ widget: WidgetData }> = ({
                 onAssignmentDelete={(a) => {
                   void handleAssignmentDelete(a);
                 }}
+                initialLibraryViewMode={config.libraryViewMode}
+                onLibraryViewModeChange={(mode) => {
+                  updateWidget(widget.id, {
+                    config: {
+                      ...config,
+                      libraryViewMode: mode,
+                    } as GuidedLearningConfig,
+                  });
+                }}
               />
             )}
 
@@ -453,6 +468,25 @@ export const GuidedLearningWidget: React.FC<{ widget: WidgetData }> = ({
         isOpen={!!editingSet}
         set={editingSet}
         meta={editingMeta}
+        folders={editingMeta ? glFolders : undefined}
+        folderId={editingMeta?.folderId ?? null}
+        onFolderChange={
+          editingMeta
+            ? async (folderId) => {
+                try {
+                  await moveGlItem(editingMeta.id, folderId);
+                  addToast('Folder updated.', 'success');
+                } catch (err) {
+                  addToast(
+                    err instanceof Error
+                      ? err.message
+                      : 'Failed to update folder',
+                    'error'
+                  );
+                }
+              }
+            : undefined
+        }
         onClose={() => {
           setEditingSet(null);
           setEditingMeta(null);

--- a/components/widgets/GuidedLearning/components/GuidedLearningEditor.tsx
+++ b/components/widgets/GuidedLearning/components/GuidedLearningEditor.tsx
@@ -22,9 +22,11 @@ import {
   GuidedLearningMode,
   GuidedLearningStep,
   GuidedLearningSetMetadata,
+  LibraryFolder,
 } from '@/types';
 import { useAuth } from '@/context/useAuth';
 import { useStorage } from '@/hooks/useStorage';
+import { FolderSelectField } from '@/components/common/library/FolderSelectField';
 import { GuidedLearningStepEditor } from './GuidedLearningStepEditor';
 import { calculateImageFootprint } from '../utils/imageUtils';
 
@@ -49,6 +51,10 @@ interface Props {
   headless?: boolean;
   /** Fires whenever editable fields change so a parent modal can compute isDirty. */
   onStateChange?: (state: GuidedLearningEditorState) => void;
+  /** Optional folder picker. When `folders` and `onFolderChange` are both provided, a folder-select field is shown. */
+  folders?: LibraryFolder[];
+  folderId?: string | null;
+  onFolderChange?: (folderId: string | null) => void;
 }
 
 const MODE_OPTIONS: {
@@ -73,6 +79,9 @@ export const GuidedLearningEditor: React.FC<Props> = ({
   saving,
   headless,
   onStateChange,
+  folders,
+  folderId,
+  onFolderChange,
 }) => {
   const { user } = useAuth();
   const { uploading, uploadHotspotImage } = useStorage();
@@ -408,6 +417,14 @@ export const GuidedLearningEditor: React.FC<Props> = ({
               }}
             />
           </div>
+
+          {folders && onFolderChange && (
+            <FolderSelectField
+              folders={folders}
+              value={folderId ?? null}
+              onChange={onFolderChange}
+            />
+          )}
 
           <div>
             <label

--- a/components/widgets/GuidedLearning/components/GuidedLearningEditorModal.tsx
+++ b/components/widgets/GuidedLearning/components/GuidedLearningEditorModal.tsx
@@ -14,6 +14,7 @@ import {
   GuidedLearningSet,
   GuidedLearningSetMetadata,
   GuidedLearningStep,
+  LibraryFolder,
 } from '@/types';
 import { EditorModalShell } from '@/components/common/EditorModalShell';
 import { useAuth } from '@/context/useAuth';
@@ -36,6 +37,10 @@ interface GuidedLearningEditorModalProps {
    * identity changes).
    */
   onAiGenerated?: (set: GuidedLearningSet) => void;
+  /** Optional folder picker. When `folders` and `onFolderChange` are both provided, a folder-select field is shown. */
+  folders?: LibraryFolder[];
+  folderId?: string | null;
+  onFolderChange?: (folderId: string | null) => void;
 }
 
 // ─── Deep equality helpers ──────────────────────────────────────────────────
@@ -109,7 +114,17 @@ function stepsEqual(a: GuidedLearningStep[], b: GuidedLearningStep[]): boolean {
 
 export const GuidedLearningEditorModal: React.FC<
   GuidedLearningEditorModalProps
-> = ({ isOpen, set, meta, onClose, onSave, onAiGenerated }) => {
+> = ({
+  isOpen,
+  set,
+  meta,
+  onClose,
+  onSave,
+  onAiGenerated,
+  folders,
+  folderId,
+  onFolderChange,
+}) => {
   const { isAdmin, canAccessFeature } = useAuth();
   // Track live state from the headless editor via onStateChange callback
   const [liveState, setLiveState] = useState<GuidedLearningEditorState | null>(
@@ -247,6 +262,9 @@ export const GuidedLearningEditorModal: React.FC<
           saving={saving}
           headless
           onStateChange={handleStateChange}
+          folders={folders}
+          folderId={folderId}
+          onFolderChange={onFolderChange}
         />
       )}
       {showAiGen && canUseAi && (

--- a/components/widgets/GuidedLearning/components/GuidedLearningManager.tsx
+++ b/components/widgets/GuidedLearning/components/GuidedLearningManager.tsx
@@ -34,6 +34,7 @@ import {
   RotateCcw,
   Copy,
   ExternalLink,
+  CheckSquare,
 } from 'lucide-react';
 import type {
   GuidedLearningAssignment,
@@ -45,9 +46,13 @@ import { LibraryToolbar } from '@/components/common/library/LibraryToolbar';
 import { LibraryGrid } from '@/components/common/library/LibraryGrid';
 import { LibraryItemCard } from '@/components/common/library/LibraryItemCard';
 import { FolderSidebar } from '@/components/common/library/FolderSidebar';
+import { FolderPickerPopover } from '@/components/common/library/FolderPickerPopover';
+import { buildMoveToFolderAction } from '@/components/common/library/folderMenuAction';
 import { LibraryDndContext } from '@/components/common/library/LibraryDndContext';
 import { useLibraryView } from '@/components/common/library/useLibraryView';
+import { useLibrarySelection } from '@/components/common/library/useLibrarySelection';
 import { useSortableReorder } from '@/components/common/library/useSortableReorder';
+import { BulkActionBar } from '@/components/common/library/BulkActionBar';
 import {
   countItemsByFolder,
   filterSourcedEntriesByFolder,
@@ -147,6 +152,11 @@ export interface GuidedLearningManagerProps {
   onAssignmentArchive: (assignment: GuidedLearningAssignment) => void;
   onAssignmentUnarchive: (assignment: GuidedLearningAssignment) => void;
   onAssignmentDelete: (assignment: GuidedLearningAssignment) => void;
+
+  /** Persisted library grid/list toggle (from widget config). */
+  initialLibraryViewMode?: 'grid' | 'list';
+  /** Persist the library grid/list toggle into widget config. */
+  onLibraryViewModeChange?: (mode: 'grid' | 'list') => void;
 }
 
 /* ─── Sort / filter config ────────────────────────────────────────────────── */
@@ -281,14 +291,38 @@ export const GuidedLearningManager: React.FC<GuidedLearningManagerProps> = ({
   onAssignmentArchive,
   onAssignmentUnarchive,
   onAssignmentDelete,
+  initialLibraryViewMode,
+  onLibraryViewModeChange,
 }) => {
   const [tab, setTab] = React.useState<LibraryTab>('library');
+
+  // ─── Bulk selection (Step 8) ────────────────────────────────────────────
+  const selection = useLibrarySelection();
+  const [selectionMode, setSelectionMode] = React.useState(false);
+  const [bulkBusy, setBulkBusy] = React.useState(false);
+  const [prevTab, setPrevTab] = React.useState(tab);
+  if (prevTab !== tab) {
+    setPrevTab(tab);
+    if (tab !== 'library' && selectionMode) {
+      setSelectionMode(false);
+      selection.clear();
+    }
+  }
 
   // ─── Folder navigation (Wave 3-B-3) ─────────────────────────────────────
   const folderState = useFolders(userId, 'guided_learning');
   const [selectedFolderId, setSelectedFolderId] = React.useState<string | null>(
     null
   );
+  // When set, a `FolderPickerPopover` dialog is shown for this personal entry.
+  // Only 'personal' sets participate in folders (building sets have no
+  // folderId). Carry the rawId + display title so the dialog can label itself
+  // without another lookup.
+  const [folderPickerTarget, setFolderPickerTarget] = React.useState<{
+    rawId: string;
+    title: string;
+    folderId: string | null;
+  } | null>(null);
 
   // Reset folder selection when the signed-in user changes or the selected
   // folder no longer exists (adjust-state-during-render pattern).
@@ -333,9 +367,11 @@ export const GuidedLearningManager: React.FC<GuidedLearningManagerProps> = ({
   const view = useLibraryView<LibraryEntry>({
     items: allEntries,
     initialSort: LIBRARY_INITIAL_SORT,
+    initialViewMode: initialLibraryViewMode ?? 'grid',
     searchFields: LIBRARY_SEARCH_FIELDS,
     sortComparators: LIBRARY_SORT_COMPARATORS,
     filterPredicates: LIBRARY_FILTER_PREDICATES,
+    onViewModeChange: onLibraryViewModeChange,
   });
 
   const activeSourceFilter = view.state.filterValues.source ?? '';
@@ -385,6 +421,60 @@ export const GuidedLearningManager: React.FC<GuidedLearningManagerProps> = ({
     [userId, moveItem]
   );
 
+  // ─── Bulk handlers (Step 8) ─────────────────────────────────────────────
+  const handleBulkDelete = useCallback((): void => {
+    if (selection.count === 0) return;
+    const personalIds = Array.from(selection.selectedIds).filter((id) =>
+      id.startsWith('personal:')
+    );
+    if (personalIds.length === 0) return;
+    const ok = window.confirm(
+      `Delete ${personalIds.length} set${personalIds.length === 1 ? '' : 's'}? This cannot be undone.`
+    );
+    if (!ok) return;
+    setBulkBusy(true);
+    try {
+      for (const id of personalIds) {
+        const rawId = id.slice('personal:'.length);
+        const entry = allEntries.find((e) => e.id === id);
+        if (entry?.driveFileId) {
+          onDeletePersonal(rawId, entry.driveFileId);
+        }
+      }
+      selection.clear();
+      setSelectionMode(false);
+    } finally {
+      setBulkBusy(false);
+    }
+  }, [selection, allEntries, onDeletePersonal]);
+
+  const handleBulkMove = useCallback(
+    async (folderId: string | null): Promise<void> => {
+      if (!userId || selection.count === 0) return;
+      setBulkBusy(true);
+      try {
+        for (const id of Array.from(selection.selectedIds)) {
+          if (!id.startsWith('personal:')) continue;
+          const rawId = id.slice('personal:'.length);
+          try {
+            await moveItem(rawId, folderId);
+          } catch (err) {
+            console.error(
+              '[GuidedLearningManager] bulk move failed for',
+              id,
+              err
+            );
+          }
+        }
+        selection.clear();
+        setSelectionMode(false);
+      } finally {
+        setBulkBusy(false);
+      }
+    },
+    [userId, selection, moveItem]
+  );
+
   const reorderDragActive =
     !view.reorderLocked &&
     activeSourceFilter === 'personal' &&
@@ -393,7 +483,8 @@ export const GuidedLearningManager: React.FC<GuidedLearningManagerProps> = ({
   // would be blocked (e.g. sort !== 'manual'). Drops on a folder tile move the
   // item; drops on another card reorder (only honored when manual reorder is
   // active — see `handleReorderDrop` below).
-  const enableCardDrag = Boolean(userId) || reorderDragActive;
+  const enableCardDrag =
+    (Boolean(userId) || reorderDragActive) && !selectionMode;
 
   const handleReorderDrop = useCallback(
     (orderedIds: string[]) => {
@@ -502,6 +593,20 @@ export const GuidedLearningManager: React.FC<GuidedLearningManagerProps> = ({
       });
     }
 
+    if (entry.source === 'personal') {
+      secondary.push(
+        buildMoveToFolderAction({
+          onOpenPicker: () =>
+            setFolderPickerTarget({
+              rawId,
+              title: entry.title,
+              folderId: entry.folderId ?? null,
+            }),
+          disabled: !userId,
+        })
+      );
+    }
+
     if (canDelete) {
       secondary.push({
         id: 'delete',
@@ -537,6 +642,8 @@ export const GuidedLearningManager: React.FC<GuidedLearningManagerProps> = ({
       <BookOpen className="h-5 w-5 text-slate-400" aria-hidden="true" />
     );
 
+    const isPersonal = entry.source === 'personal';
+    const selectable = isPersonal && selectionMode;
     return (
       <LibraryItemCard<LibraryEntry>
         key={entry.id}
@@ -556,9 +663,14 @@ export const GuidedLearningManager: React.FC<GuidedLearningManagerProps> = ({
             ? () => onEdit(rawId, entry.driveFileId, entry.buildingSet)
             : undefined
         }
-        sortable={entry.source === 'personal' && enableCardDrag}
+        sortable={isPersonal && enableCardDrag && !selectionMode}
         viewMode={view.state.viewMode}
         meta={entry}
+        selectionMode={selectable}
+        selected={selectable && selection.isSelected(entry.id)}
+        onSelectionToggle={
+          selectable ? () => selection.toggle(entry.id) : undefined
+        }
       />
     );
   };
@@ -667,6 +779,22 @@ export const GuidedLearningManager: React.FC<GuidedLearningManagerProps> = ({
           <div className="mb-3 rounded-xl border border-amber-200 bg-amber-50 px-3 py-2 text-xs font-medium text-amber-800">
             Your personal sets are saved to Google Drive. Sign out and sign back
             in to grant Drive access. Building sets are still available below.
+          </div>
+        )}
+
+        {selectionMode && selection.count > 0 && (
+          <div className="mb-3">
+            <BulkActionBar
+              count={selection.count}
+              onClear={() => {
+                selection.clear();
+                setSelectionMode(false);
+              }}
+              folders={folderState.folders}
+              onMove={handleBulkMove}
+              onDelete={handleBulkDelete}
+              busy={bulkBusy}
+            />
           </div>
         )}
 
@@ -818,12 +946,41 @@ export const GuidedLearningManager: React.FC<GuidedLearningManagerProps> = ({
             filters={[sourceFilter]}
             searchPlaceholder="Search sets…"
             rightSlot={
-              isBuildingFiltered ? (
-                <span className="inline-flex items-center gap-1 text-[11px] font-bold uppercase tracking-widest text-slate-500">
-                  <Building2 size={12} />
-                  Building library
-                </span>
-              ) : null
+              <span className="flex items-center gap-2">
+                {isBuildingFiltered && (
+                  <span className="inline-flex items-center gap-1 text-[11px] font-bold uppercase tracking-widest text-slate-500">
+                    <Building2 size={12} />
+                    Building library
+                  </span>
+                )}
+                {userId && (
+                  <button
+                    type="button"
+                    onClick={() => {
+                      if (selectionMode) {
+                        selection.clear();
+                        setSelectionMode(false);
+                      } else {
+                        setSelectionMode(true);
+                      }
+                    }}
+                    className={`inline-flex items-center gap-1.5 rounded-lg px-2.5 py-1.5 text-xs font-bold uppercase tracking-wider transition-colors ${
+                      selectionMode
+                        ? 'bg-brand-blue-primary text-white hover:bg-brand-blue-dark'
+                        : 'bg-white/70 text-slate-600 hover:bg-white hover:text-slate-800'
+                    }`}
+                    aria-pressed={selectionMode}
+                    title={
+                      selectionMode
+                        ? 'Exit selection mode'
+                        : 'Enter selection mode'
+                    }
+                  >
+                    <CheckSquare className="h-3.5 w-3.5" />
+                    {selectionMode ? 'Cancel' : 'Select'}
+                  </button>
+                )}
+              </span>
             }
           />
         ) : undefined
@@ -835,16 +992,35 @@ export const GuidedLearningManager: React.FC<GuidedLearningManagerProps> = ({
     </LibraryShell>
   );
 
+  const folderPickerDialog = folderPickerTarget ? (
+    <FolderPickerPopover
+      variant="dialog"
+      folders={folderState.folders}
+      selectedFolderId={folderPickerTarget.folderId}
+      onSelect={(folderId) => {
+        void handleDropOnFolder(folderPickerTarget.rawId, folderId);
+      }}
+      onClose={() => setFolderPickerTarget(null)}
+      title={`Move "${folderPickerTarget.title}" to…`}
+    />
+  ) : null;
+
   return userId && tab === 'library' ? (
-    <LibraryDndContext
-      itemIds={orderedIds}
-      onDropOnFolder={handleDropOnFolder}
-      onReorder={handleReorderDrop}
-      renderOverlay={renderDragOverlay}
-    >
-      {shell}
-    </LibraryDndContext>
+    <>
+      <LibraryDndContext
+        itemIds={orderedIds}
+        onDropOnFolder={handleDropOnFolder}
+        onReorder={handleReorderDrop}
+        renderOverlay={renderDragOverlay}
+      >
+        {shell}
+      </LibraryDndContext>
+      {folderPickerDialog}
+    </>
   ) : (
-    shell
+    <>
+      {shell}
+      {folderPickerDialog}
+    </>
   );
 };

--- a/components/widgets/GuidedLearning/components/GuidedLearningManager.tsx
+++ b/components/widgets/GuidedLearning/components/GuidedLearningManager.tsx
@@ -127,8 +127,11 @@ export interface GuidedLearningManagerProps {
     driveFileId?: string,
     buildingSet?: GuidedLearningSet
   ) => void;
-  onDeletePersonal: (setId: string, driveFileId: string) => void;
-  onDeleteBuilding: (setId: string) => void;
+  onDeletePersonal: (
+    setId: string,
+    driveFileId: string
+  ) => void | Promise<void>;
+  onDeleteBuilding: (setId: string) => void | Promise<void>;
   onCreateNewPersonal: () => void;
   onCreateNewBuilding: () => void;
   /** Admin-only — opens the standalone AI authoring dialog for building sets. */
@@ -422,7 +425,7 @@ export const GuidedLearningManager: React.FC<GuidedLearningManagerProps> = ({
   );
 
   // ─── Bulk handlers (Step 8) ─────────────────────────────────────────────
-  const handleBulkDelete = useCallback((): void => {
+  const handleBulkDelete = useCallback(async (): Promise<void> => {
     if (selection.count === 0) return;
     const personalIds = Array.from(selection.selectedIds).filter((id) =>
       id.startsWith('personal:')
@@ -434,13 +437,24 @@ export const GuidedLearningManager: React.FC<GuidedLearningManagerProps> = ({
     if (!ok) return;
     setBulkBusy(true);
     try {
-      for (const id of personalIds) {
-        const rawId = id.slice('personal:'.length);
-        const entry = allEntries.find((e) => e.id === id);
-        if (entry?.driveFileId) {
-          onDeletePersonal(rawId, entry.driveFileId);
+      const results = await Promise.allSettled(
+        personalIds.map(async (id) => {
+          const rawId = id.slice('personal:'.length);
+          const entry = allEntries.find((e) => e.id === id);
+          if (entry?.driveFileId) {
+            await onDeletePersonal(rawId, entry.driveFileId);
+          }
+        })
+      );
+      results.forEach((result, idx) => {
+        if (result.status === 'rejected') {
+          console.error(
+            '[GuidedLearningManager] bulk delete failed for',
+            personalIds[idx],
+            result.reason
+          );
         }
-      }
+      });
       selection.clear();
       setSelectionMode(false);
     } finally {
@@ -451,21 +465,23 @@ export const GuidedLearningManager: React.FC<GuidedLearningManagerProps> = ({
   const handleBulkMove = useCallback(
     async (folderId: string | null): Promise<void> => {
       if (!userId || selection.count === 0) return;
+      const ids = Array.from(selection.selectedIds).filter((id) =>
+        id.startsWith('personal:')
+      );
       setBulkBusy(true);
       try {
-        for (const id of Array.from(selection.selectedIds)) {
-          if (!id.startsWith('personal:')) continue;
-          const rawId = id.slice('personal:'.length);
-          try {
-            await moveItem(rawId, folderId);
-          } catch (err) {
+        const results = await Promise.allSettled(
+          ids.map((id) => moveItem(id.slice('personal:'.length), folderId))
+        );
+        results.forEach((result, idx) => {
+          if (result.status === 'rejected') {
             console.error(
               '[GuidedLearningManager] bulk move failed for',
-              id,
-              err
+              ids[idx],
+              result.reason
             );
           }
-        }
+        });
         selection.clear();
         setSelectionMode(false);
       } finally {
@@ -615,9 +631,9 @@ export const GuidedLearningManager: React.FC<GuidedLearningManagerProps> = ({
         destructive: true,
         onClick: () => {
           if (entry.source === 'personal' && entry.driveFileId) {
-            onDeletePersonal(rawId, entry.driveFileId);
+            void onDeletePersonal(rawId, entry.driveFileId);
           } else if (entry.source === 'building') {
-            onDeleteBuilding(rawId);
+            void onDeleteBuilding(rawId);
           }
         },
       });

--- a/components/widgets/MiniApp/Widget.tsx
+++ b/components/widgets/MiniApp/Widget.tsx
@@ -23,6 +23,7 @@ import { WidgetLayout } from '../WidgetLayout';
 import { useAuth } from '@/context/useAuth';
 import { useMiniAppSessionTeacher } from '@/hooks/useMiniAppSession';
 import { useMiniAppAssignments } from '@/hooks/useMiniAppAssignments';
+import { useFolders } from '@/hooks/useFolders';
 import {
   collection,
   doc,
@@ -397,6 +398,11 @@ export const MiniAppWidget: React.FC<WidgetComponentProps> = ({
     }
   };
   const [editingApp, setEditingApp] = useState<MiniAppItem | null>(null);
+
+  const { folders: miniAppFolders, moveItem: moveMiniAppItem } = useFolders(
+    user?.uid,
+    'miniapp'
+  );
 
   // Unsaved paste state: shown as an overlay when activeAppUnsaved is true
   const [showSaveForm, setShowSaveForm] = useState(false);
@@ -830,6 +836,25 @@ export const MiniAppWidget: React.FC<WidgetComponentProps> = ({
         isOpen={!!editingApp}
         app={editingApp}
         widget={widget}
+        folders={editingApp ? miniAppFolders : undefined}
+        folderId={editingApp?.folderId ?? null}
+        onFolderChange={
+          editingApp
+            ? async (folderId) => {
+                try {
+                  await moveMiniAppItem(editingApp.id, folderId);
+                  addToast('Folder updated.', 'success');
+                } catch (err) {
+                  addToast(
+                    err instanceof Error
+                      ? err.message
+                      : 'Failed to update folder',
+                    'error'
+                  );
+                }
+              }
+            : undefined
+        }
         onClose={() => setEditingApp(null)}
         onSave={saveMiniApp}
       />
@@ -868,6 +893,12 @@ export const MiniAppWidget: React.FC<WidgetComponentProps> = ({
               onArchiveCopyUrl={(a) => void handleArchiveCopyUrl(a)}
               onArchiveEnd={(a) => void handleArchiveEnd(a)}
               onArchiveDelete={(a) => void handleArchiveDelete(a)}
+              initialLibraryViewMode={config.libraryViewMode}
+              onLibraryViewModeChange={(mode) =>
+                updateWidget(widget.id, {
+                  config: { ...config, libraryViewMode: mode } as MiniAppConfig,
+                })
+              }
             />
             {/* Assign modal */}
             {!isStudentView && assigningApp && (

--- a/components/widgets/MiniApp/components/MiniAppEditorModal.tsx
+++ b/components/widgets/MiniApp/components/MiniAppEditorModal.tsx
@@ -20,8 +20,15 @@ import {
   Sparkles,
   X,
 } from 'lucide-react';
-import { MiniAppConfig, MiniAppItem, TextConfig, WidgetData } from '@/types';
+import {
+  LibraryFolder,
+  MiniAppConfig,
+  MiniAppItem,
+  TextConfig,
+  WidgetData,
+} from '@/types';
 import { EditorModalShell } from '@/components/common/EditorModalShell';
+import { FolderSelectField } from '@/components/common/library/FolderSelectField';
 import { useAuth } from '@/context/useAuth';
 import { useDashboard } from '@/context/useDashboard';
 import { useGoogleDrive } from '@/hooks/useGoogleDrive';
@@ -36,6 +43,10 @@ interface MiniAppEditorModalProps {
   widget: WidgetData;
   onClose: () => void;
   onSave: (updated: MiniAppItem) => Promise<void>;
+  /** Optional folder picker. When `folders` and `onFolderChange` are both provided, a folder-select field is shown. */
+  folders?: LibraryFolder[];
+  folderId?: string | null;
+  onFolderChange?: (folderId: string | null) => void;
 }
 
 export const MiniAppEditorModal: React.FC<MiniAppEditorModalProps> = ({
@@ -44,6 +55,9 @@ export const MiniAppEditorModal: React.FC<MiniAppEditorModalProps> = ({
   widget,
   onClose,
   onSave,
+  folders,
+  folderId,
+  onFolderChange,
 }) => {
   const { canAccessFeature } = useAuth();
   const { updateWidget, addToast, activeDashboard } = useDashboard();
@@ -398,6 +412,14 @@ export const MiniAppEditorModal: React.FC<MiniAppEditorModalProps> = ({
             </div>
           )}
         </div>
+
+        {folders && onFolderChange && (
+          <FolderSelectField
+            folders={folders}
+            value={folderId ?? null}
+            onChange={onFolderChange}
+          />
+        )}
 
         {/* HTML Code textarea */}
         <div className="flex-1 flex flex-col min-h-[250px]">

--- a/components/widgets/MiniApp/components/MiniAppManager.tsx
+++ b/components/widgets/MiniApp/components/MiniAppManager.tsx
@@ -42,6 +42,7 @@ import {
   Loader2,
   ExternalLink,
   Copy,
+  CheckSquare,
 } from 'lucide-react';
 import type {
   MiniAppItem,
@@ -54,9 +55,13 @@ import { LibraryGrid } from '@/components/common/library/LibraryGrid';
 import { LibraryItemCard } from '@/components/common/library/LibraryItemCard';
 import { AssignmentArchiveCard } from '@/components/common/library/AssignmentArchiveCard';
 import { FolderSidebar } from '@/components/common/library/FolderSidebar';
+import { FolderPickerPopover } from '@/components/common/library/FolderPickerPopover';
+import { buildMoveToFolderAction } from '@/components/common/library/folderMenuAction';
 import { LibraryDndContext } from '@/components/common/library/LibraryDndContext';
 import { useLibraryView } from '@/components/common/library/useLibraryView';
+import { useLibrarySelection } from '@/components/common/library/useLibrarySelection';
 import { useSortableReorder } from '@/components/common/library/useSortableReorder';
+import { BulkActionBar } from '@/components/common/library/BulkActionBar';
 import {
   countItemsByFolder,
   filterByFolder,
@@ -115,6 +120,11 @@ export interface MiniAppManagerProps {
   onArchiveDelete: (assignment: MiniAppAssignment) => void;
   /** Optional — open the underlying app in the widget. */
   onArchiveOpenApp?: (assignment: MiniAppAssignment) => void;
+
+  /** Persisted library grid/list toggle (from widget config). */
+  initialLibraryViewMode?: 'grid' | 'list';
+  /** Persist the library grid/list toggle into widget config. */
+  onLibraryViewModeChange?: (mode: 'grid' | 'list') => void;
 }
 
 /* ─── Constants ───────────────────────────────────────────────────────────── */
@@ -222,6 +232,8 @@ export const MiniAppManager: React.FC<MiniAppManagerProps> = ({
   onArchiveEnd,
   onArchiveDelete,
   onArchiveOpenApp,
+  initialLibraryViewMode,
+  onLibraryViewModeChange,
 }) => {
   /* ── Assignment buckets ─────────────────────────────────────────────── */
   const activeAssignments = useMemo(
@@ -233,9 +245,27 @@ export const MiniAppManager: React.FC<MiniAppManagerProps> = ({
     [assignments]
   );
 
+  /* ── Bulk selection (Step 8) ───────────────────────────────────────── */
+  const selection = useLibrarySelection();
+  const [selectionMode, setSelectionMode] = useState(false);
+  const [bulkBusy, setBulkBusy] = useState(false);
+  const [prevTab, setPrevTab] = useState(tab);
+  if (prevTab !== tab) {
+    setPrevTab(tab);
+    if (tab !== 'library' && selectionMode) {
+      setSelectionMode(false);
+      selection.clear();
+    }
+  }
+
   /* ── Folder navigation (Wave 3-B-3) ────────────────────────────────── */
   const folderState = useFolders(userId, 'miniapp');
   const [selectedFolderId, setSelectedFolderId] = useState<string | null>(null);
+  const [folderPickerTarget, setFolderPickerTarget] = useState<{
+    id: string;
+    title: string;
+    folderId: string | null;
+  } | null>(null);
 
   // Reset folder selection when the signed-in user changes or the selected
   // folder no longer exists (adjust-state-during-render pattern). We clear the
@@ -308,6 +338,8 @@ export const MiniAppManager: React.FC<MiniAppManagerProps> = ({
     searchFields: LIBRARY_SEARCH_FIELDS,
     sortComparators: LIBRARY_SORT_COMPARATORS,
     filterPredicates: LIBRARY_FILTER_PREDICATES,
+    initialViewMode: initialLibraryViewMode ?? 'grid',
+    onViewModeChange: onLibraryViewModeChange,
   });
 
   const source: MiniAppSource =
@@ -362,6 +394,54 @@ export const MiniAppManager: React.FC<MiniAppManagerProps> = ({
     [userId, moveItem]
   );
 
+  /* ── Bulk handlers (Step 8) ──────────────────────────────────────────── */
+  const handleBulkDelete = useCallback((): void => {
+    if (selection.count === 0) return;
+    const personalIds = Array.from(selection.selectedIds).filter((id) =>
+      id.startsWith('personal:')
+    );
+    if (personalIds.length === 0) return;
+    const ok = window.confirm(
+      `Delete ${personalIds.length} app${personalIds.length === 1 ? '' : 's'}? This cannot be undone.`
+    );
+    if (!ok) return;
+    setBulkBusy(true);
+    try {
+      for (const id of personalIds) {
+        const rawId = id.slice('personal:'.length);
+        const app = personalLibrary.find((a) => a.id === rawId);
+        if (app) onDelete(app);
+      }
+      selection.clear();
+      setSelectionMode(false);
+    } finally {
+      setBulkBusy(false);
+    }
+  }, [selection, personalLibrary, onDelete]);
+
+  const handleBulkMove = useCallback(
+    async (folderId: string | null): Promise<void> => {
+      if (!userId || selection.count === 0) return;
+      setBulkBusy(true);
+      try {
+        for (const id of Array.from(selection.selectedIds)) {
+          if (!id.startsWith('personal:')) continue;
+          const rawId = id.slice('personal:'.length);
+          try {
+            await moveItem(rawId, folderId);
+          } catch (err) {
+            console.error('[MiniAppManager] bulk move failed for', id, err);
+          }
+        }
+        selection.clear();
+        setSelectionMode(false);
+      } finally {
+        setBulkBusy(false);
+      }
+    },
+    [userId, selection, moveItem]
+  );
+
   /* ── Folder sidebar (Library tab + personal source only) ─────────────── */
   const folderSidebarSlot =
     tab === 'library' && userId && !isGlobalView ? (
@@ -404,6 +484,15 @@ export const MiniAppManager: React.FC<MiniAppManagerProps> = ({
         icon: Pencil,
         onClick: () => onEdit(app),
       },
+      buildMoveToFolderAction({
+        onOpenPicker: () =>
+          setFolderPickerTarget({
+            id: app.id,
+            title: app.title,
+            folderId: app.folderId ?? null,
+          }),
+        disabled: !userId,
+      }),
       {
         id: 'delete',
         label: 'Delete',
@@ -435,8 +524,11 @@ export const MiniAppManager: React.FC<MiniAppManagerProps> = ({
         }}
         secondaryActions={secondary}
         onClick={() => onEdit(app)}
-        sortable
+        sortable={!selectionMode}
         viewMode={view.state.viewMode}
+        selectionMode={selectionMode}
+        selected={selection.isSelected(getRowId(row))}
+        onSelectionToggle={() => selection.toggle(getRowId(row))}
       />
     );
   }
@@ -676,38 +768,55 @@ export const MiniAppManager: React.FC<MiniAppManagerProps> = ({
     // Enable card drag when a teacher is signed in so drag-to-folder works.
     // In the Global view we keep drag disabled — global items are read-only
     // and never move between folders.
-    const enableCardDrag = Boolean(userId) && !isGlobalView;
+    const enableCardDrag = Boolean(userId) && !isGlobalView && !selectionMode;
     // When folder drag is enabled we keep the drag handle active so cards can
     // be dropped on folder tiles — even in filtered/sorted views. The card-to-
     // card reorder commit is gated separately (see the onReorder wiring on
     // the shared `LibraryDndContext` below), so a non-manual sort won't persist
     // a new order.
     tabContent = (
-      <LibraryGrid<UnifiedRow>
-        items={view.visibleItems}
-        getId={getRowId}
-        renderCard={renderCard}
-        onReorder={
-          isGlobalView ? undefined : (ids) => reorderHook.handleReorder(ids)
-        }
-        dragDisabled={isGlobalView}
-        reorderLocked={
-          enableCardDrag ? false : !isGlobalView && view.reorderLocked
-        }
-        reorderLockedReason={
-          enableCardDrag ? undefined : view.reorderLockedReason
-        }
-        layout={view.state.viewMode}
-        useExternalDndContext={enableCardDrag}
-        emptyState={empty}
-      />
+      <>
+        {selectionMode && selection.count > 0 && (
+          <div className="mb-3">
+            <BulkActionBar
+              count={selection.count}
+              onClear={() => {
+                selection.clear();
+                setSelectionMode(false);
+              }}
+              folders={folderState.folders}
+              onMove={handleBulkMove}
+              onDelete={handleBulkDelete}
+              busy={bulkBusy}
+            />
+          </div>
+        )}
+        <LibraryGrid<UnifiedRow>
+          items={view.visibleItems}
+          getId={getRowId}
+          renderCard={renderCard}
+          onReorder={
+            isGlobalView ? undefined : (ids) => reorderHook.handleReorder(ids)
+          }
+          dragDisabled={isGlobalView || selectionMode}
+          reorderLocked={
+            enableCardDrag ? false : !isGlobalView && view.reorderLocked
+          }
+          reorderLockedReason={
+            enableCardDrag ? undefined : view.reorderLockedReason
+          }
+          layout={view.state.viewMode}
+          useExternalDndContext={enableCardDrag}
+          emptyState={empty}
+        />
+      </>
     );
   }
 
   /* ── Shared DndContext wiring (must wrap full shell so FolderSidebar
    *    droppables live in the same context as sortable cards) ───────────── */
   const libraryDndEnabled =
-    tab === 'library' && Boolean(userId) && !isGlobalView;
+    tab === 'library' && Boolean(userId) && !isGlobalView && !selectionMode;
   const orderedRowIds = libraryDndEnabled
     ? view.visibleItems.map(getRowId)
     : [];
@@ -756,6 +865,33 @@ export const MiniAppManager: React.FC<MiniAppManagerProps> = ({
         onFilterChange={view.toolbarProps.onFilterChange}
         viewMode={view.toolbarProps.viewMode}
         onViewModeChange={view.toolbarProps.onViewModeChange}
+        rightSlot={
+          userId && !isGlobalView ? (
+            <button
+              type="button"
+              onClick={() => {
+                if (selectionMode) {
+                  selection.clear();
+                  setSelectionMode(false);
+                } else {
+                  setSelectionMode(true);
+                }
+              }}
+              className={`inline-flex items-center gap-1.5 rounded-lg px-2.5 py-1.5 text-xs font-bold uppercase tracking-wider transition-colors ${
+                selectionMode
+                  ? 'bg-brand-blue-primary text-white hover:bg-brand-blue-dark'
+                  : 'bg-white/70 text-slate-600 hover:bg-white hover:text-slate-800'
+              }`}
+              aria-pressed={selectionMode}
+              title={
+                selectionMode ? 'Exit selection mode' : 'Enter selection mode'
+              }
+            >
+              <CheckSquare className="h-3.5 w-3.5" />
+              {selectionMode ? 'Cancel' : 'Select'}
+            </button>
+          ) : undefined
+        }
       />
     ) : null;
 
@@ -786,16 +922,35 @@ export const MiniAppManager: React.FC<MiniAppManagerProps> = ({
     void reorderHook.handleReorder(ids);
   };
 
+  const folderPickerDialog = folderPickerTarget ? (
+    <FolderPickerPopover
+      variant="dialog"
+      folders={folderState.folders}
+      selectedFolderId={folderPickerTarget.folderId}
+      onSelect={(folderId) => {
+        void handleDropOnFolder(folderPickerTarget.id, folderId);
+      }}
+      onClose={() => setFolderPickerTarget(null)}
+      title={`Move "${folderPickerTarget.title}" to…`}
+    />
+  ) : null;
+
   return libraryDndEnabled ? (
-    <LibraryDndContext
-      itemIds={orderedRowIds}
-      onDropOnFolder={handleDropOnFolder}
-      onReorder={handleLibraryReorderDrop}
-      renderOverlay={renderLibraryDragOverlay}
-    >
-      {shell}
-    </LibraryDndContext>
+    <>
+      <LibraryDndContext
+        itemIds={orderedRowIds}
+        onDropOnFolder={handleDropOnFolder}
+        onReorder={handleLibraryReorderDrop}
+        renderOverlay={renderLibraryDragOverlay}
+      >
+        {shell}
+      </LibraryDndContext>
+      {folderPickerDialog}
+    </>
   ) : (
-    shell
+    <>
+      {shell}
+      {folderPickerDialog}
+    </>
   );
 };

--- a/components/widgets/MiniApp/components/MiniAppManager.tsx
+++ b/components/widgets/MiniApp/components/MiniAppManager.tsx
@@ -99,7 +99,7 @@ export interface MiniAppManagerProps {
   /* ── Library-tab callbacks (personal) ─────────────────────────────────── */
   onCreate: () => void;
   onEdit: (app: MiniAppItem) => void;
-  onDelete: (app: MiniAppItem) => void;
+  onDelete: (app: MiniAppItem) => void | Promise<void>;
   onRun: (app: MiniAppItem) => void;
   onAssign: (app: MiniAppItem) => void;
   onShowAssignments: (app: MiniAppItem) => void;
@@ -395,7 +395,7 @@ export const MiniAppManager: React.FC<MiniAppManagerProps> = ({
   );
 
   /* ── Bulk handlers (Step 8) ──────────────────────────────────────────── */
-  const handleBulkDelete = useCallback((): void => {
+  const handleBulkDelete = useCallback(async (): Promise<void> => {
     if (selection.count === 0) return;
     const personalIds = Array.from(selection.selectedIds).filter((id) =>
       id.startsWith('personal:')
@@ -407,11 +407,22 @@ export const MiniAppManager: React.FC<MiniAppManagerProps> = ({
     if (!ok) return;
     setBulkBusy(true);
     try {
-      for (const id of personalIds) {
-        const rawId = id.slice('personal:'.length);
-        const app = personalLibrary.find((a) => a.id === rawId);
-        if (app) onDelete(app);
-      }
+      const results = await Promise.allSettled(
+        personalIds.map(async (id) => {
+          const rawId = id.slice('personal:'.length);
+          const app = personalLibrary.find((a) => a.id === rawId);
+          if (app) await onDelete(app);
+        })
+      );
+      results.forEach((result, idx) => {
+        if (result.status === 'rejected') {
+          console.error(
+            '[MiniAppManager] bulk delete failed for',
+            personalIds[idx],
+            result.reason
+          );
+        }
+      });
       selection.clear();
       setSelectionMode(false);
     } finally {
@@ -422,17 +433,23 @@ export const MiniAppManager: React.FC<MiniAppManagerProps> = ({
   const handleBulkMove = useCallback(
     async (folderId: string | null): Promise<void> => {
       if (!userId || selection.count === 0) return;
+      const ids = Array.from(selection.selectedIds).filter((id) =>
+        id.startsWith('personal:')
+      );
       setBulkBusy(true);
       try {
-        for (const id of Array.from(selection.selectedIds)) {
-          if (!id.startsWith('personal:')) continue;
-          const rawId = id.slice('personal:'.length);
-          try {
-            await moveItem(rawId, folderId);
-          } catch (err) {
-            console.error('[MiniAppManager] bulk move failed for', id, err);
+        const results = await Promise.allSettled(
+          ids.map((id) => moveItem(id.slice('personal:'.length), folderId))
+        );
+        results.forEach((result, idx) => {
+          if (result.status === 'rejected') {
+            console.error(
+              '[MiniAppManager] bulk move failed for',
+              ids[idx],
+              result.reason
+            );
           }
-        }
+        });
         selection.clear();
         setSelectionMode(false);
       } finally {
@@ -497,7 +514,7 @@ export const MiniAppManager: React.FC<MiniAppManagerProps> = ({
         id: 'delete',
         label: 'Delete',
         icon: Trash2,
-        onClick: () => onDelete(app),
+        onClick: () => void onDelete(app),
         destructive: true,
       },
     ];

--- a/components/widgets/QuizWidget/Widget.tsx
+++ b/components/widgets/QuizWidget/Widget.tsx
@@ -14,6 +14,7 @@ import {
   type QuizSessionOptions,
 } from '@/hooks/useQuizSession';
 import { useQuizAssignments } from '@/hooks/useQuizAssignments';
+import { useFolders } from '@/hooks/useFolders';
 import { QuizManager, PlcOptions } from './components/QuizManager';
 import { ImportWizard } from '@/components/common/library/importer';
 import { createQuizImportAdapter } from './adapters/quizImportAdapter';
@@ -74,6 +75,14 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
     updateAssignmentSettings,
     shareAssignment,
   } = useQuizAssignments(user?.uid);
+
+  // Folders are managed by QuizManager separately; this duplicate binding is
+  // used only so the editor modal can surface a folder picker and commit
+  // moves via `moveItem` without leaving the modal.
+  const { folders: quizFolders, moveItem: moveQuizItem } = useFolders(
+    user?.uid,
+    'quiz'
+  );
 
   // Ephemeral modal state for per-assignment settings editing.
   const [editingAssignment, setEditingAssignment] =
@@ -965,10 +974,34 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
             );
           }
         }}
+        onLibraryViewModeChange={(mode) => {
+          updateWidget(widget.id, {
+            config: { ...config, libraryViewMode: mode } as QuizConfig,
+          });
+        }}
       />
       <QuizEditorModal
         isOpen={!!editingQuiz}
         quiz={editingQuiz}
+        folders={editingMeta ? quizFolders : undefined}
+        folderId={editingMeta?.folderId ?? null}
+        onFolderChange={
+          editingMeta
+            ? async (folderId) => {
+                try {
+                  await moveQuizItem(editingMeta.id, folderId);
+                  addToast('Folder updated.', 'success');
+                } catch (err) {
+                  addToast(
+                    err instanceof Error
+                      ? err.message
+                      : 'Failed to update folder',
+                    'error'
+                  );
+                }
+              }
+            : undefined
+        }
         onClose={() => {
           setEditingQuiz(null);
           setEditingMeta(null);

--- a/components/widgets/QuizWidget/components/QuizEditorModal.tsx
+++ b/components/widgets/QuizWidget/components/QuizEditorModal.tsx
@@ -17,8 +17,14 @@ import {
   Trash2,
   X,
 } from 'lucide-react';
-import { QuizData, QuizQuestion, QuizQuestionType } from '@/types';
+import {
+  LibraryFolder,
+  QuizData,
+  QuizQuestion,
+  QuizQuestionType,
+} from '@/types';
 import { EditorModalShell } from '@/components/common/EditorModalShell';
+import { FolderSelectField } from '@/components/common/library/FolderSelectField';
 import { useAuth } from '@/context/useAuth';
 import {
   GeneratedQuestion,
@@ -32,6 +38,16 @@ interface QuizEditorModalProps {
   quiz: QuizData | null;
   onClose: () => void;
   onSave: (updatedQuiz: QuizData) => Promise<void>;
+  /** Folders for the FolderSelectField. Omit to hide the field. */
+  folders?: LibraryFolder[];
+  /** Current folder id for this quiz (null = root). */
+  folderId?: string | null;
+  /**
+   * Called when the user picks a different folder in the modal. Expected to
+   * call `useFolders().moveItem(...)` — metadata-only, separate from onSave
+   * since QuizData is stored in Drive (folderId lives in Firestore metadata).
+   */
+  onFolderChange?: (folderId: string | null) => void;
 }
 
 const QUESTION_TYPES: {
@@ -98,6 +114,9 @@ export const QuizEditorModal: React.FC<QuizEditorModalProps> = ({
   quiz,
   onClose,
   onSave,
+  folders,
+  folderId,
+  onFolderChange,
 }) => {
   const { canAccessFeature } = useAuth();
   // Snapshot the quiz when the modal opens so `isDirty` compares against the
@@ -355,6 +374,14 @@ export const QuizEditorModal: React.FC<QuizEditorModalProps> = ({
             </button>
           )}
         </div>
+
+        {folders && onFolderChange && (
+          <FolderSelectField
+            folders={folders}
+            value={folderId ?? null}
+            onChange={onFolderChange}
+          />
+        )}
 
         {error && (
           <div className="p-3 bg-brand-red-lighter/40 border border-brand-red-primary/20 rounded-xl flex items-center gap-2 text-sm text-brand-red-dark font-bold">

--- a/components/widgets/QuizWidget/components/QuizManager.tsx
+++ b/components/widgets/QuizWidget/components/QuizManager.tsx
@@ -164,7 +164,7 @@ interface QuizManagerProps {
     sessionOptions: QuizSessionOptions
   ) => void;
   onResults: (quiz: QuizMetadata) => void;
-  onDelete: (quiz: QuizMetadata) => void;
+  onDelete: (quiz: QuizMetadata) => void | Promise<void>;
   onShare: (quiz: QuizMetadata) => void;
   rosters: ClassRoster[];
   config: QuizConfig;
@@ -429,7 +429,7 @@ export const QuizManager: React.FC<QuizManagerProps> = ({
         const ok = window.confirm(
           `Delete "${quiz.title}"? This cannot be undone.`
         );
-        if (ok) onDelete(quiz);
+        if (ok) void onDelete(quiz);
       },
     },
   ];
@@ -632,15 +632,21 @@ export const QuizManager: React.FC<QuizManagerProps> = ({
   const handleBulkMove = useCallback(
     async (folderId: string | null): Promise<void> => {
       if (!userId || selection.count === 0) return;
+      const ids = Array.from(selection.selectedIds);
       setBulkBusy(true);
       try {
-        for (const id of Array.from(selection.selectedIds)) {
-          try {
-            await moveItem(id, folderId);
-          } catch (err) {
-            console.error('[QuizManager] bulk move failed for', id, err);
+        const results = await Promise.allSettled(
+          ids.map((id) => moveItem(id, folderId))
+        );
+        results.forEach((result, idx) => {
+          if (result.status === 'rejected') {
+            console.error(
+              '[QuizManager] bulk move failed for',
+              ids[idx],
+              result.reason
+            );
           }
-        }
+        });
         selection.clear();
         setSelectionMode(false);
       } finally {
@@ -650,7 +656,7 @@ export const QuizManager: React.FC<QuizManagerProps> = ({
     [userId, selection, moveItem]
   );
 
-  const handleBulkDelete = useCallback((): void => {
+  const handleBulkDelete = useCallback(async (): Promise<void> => {
     if (selection.count === 0) return;
     const ok = window.confirm(
       `Delete ${selection.count} quiz${selection.count === 1 ? '' : 'zes'}? This cannot be undone.`
@@ -660,9 +666,18 @@ export const QuizManager: React.FC<QuizManagerProps> = ({
     const targets = quizzes.filter((q) => ids.includes(q.id));
     setBulkBusy(true);
     try {
-      for (const quiz of targets) {
-        onDelete(quiz);
-      }
+      const results = await Promise.allSettled(
+        targets.map(async (quiz) => onDelete(quiz))
+      );
+      results.forEach((result, idx) => {
+        if (result.status === 'rejected') {
+          console.error(
+            '[QuizManager] bulk delete failed for',
+            targets[idx]?.id,
+            result.reason
+          );
+        }
+      });
       selection.clear();
       setSelectionMode(false);
     } finally {
@@ -945,7 +960,7 @@ const LibraryTabContent: React.FC<{
   bulkBusy: boolean;
   folders: import('@/types').LibraryFolder[];
   onBulkMove: (folderId: string | null) => Promise<void>;
-  onBulkDelete: () => void;
+  onBulkDelete: () => void | Promise<void>;
 }> = ({
   error,
   orderedItems,

--- a/components/widgets/QuizWidget/components/QuizManager.tsx
+++ b/components/widgets/QuizWidget/components/QuizManager.tsx
@@ -41,6 +41,7 @@ import {
   Inbox,
   Loader2,
   AlertCircle,
+  CheckSquare,
 } from 'lucide-react';
 import {
   QuizMetadata,
@@ -59,14 +60,19 @@ import {
   AssignModal,
   AssignmentArchiveCard,
   FolderSidebar,
+  FolderPickerPopover,
   LibraryDndContext,
+  buildMoveToFolderAction,
   useLibraryView,
+  useLibrarySelection,
   useSortableReorder,
+  BulkActionBar,
   type LibraryMenuAction,
   type LibrarySortOption,
   type AssignModeOption,
   type AssignmentStatusBadge,
   type LibraryBadgeTone,
+  type LibrarySelectionApi,
 } from '@/components/common/library';
 import {
   countItemsByFolder,
@@ -177,6 +183,8 @@ interface QuizManagerProps {
   onArchivePauseResume?: (assignment: QuizAssignment) => void;
   onArchiveDeactivate?: (assignment: QuizAssignment) => void;
   onArchiveDelete?: (assignment: QuizAssignment) => void;
+  /** Persist the library grid/list toggle into widget config. */
+  onLibraryViewModeChange?: (mode: 'grid' | 'list') => void;
 }
 
 /* ─── Status resolver for archive cards ───────────────────────────────────── */
@@ -272,6 +280,7 @@ export const QuizManager: React.FC<QuizManagerProps> = ({
   onArchivePauseResume,
   onArchiveDeactivate,
   onArchiveDelete,
+  onLibraryViewModeChange,
 }) => {
   const noop = () => {
     /* action not wired */
@@ -301,6 +310,23 @@ export const QuizManager: React.FC<QuizManagerProps> = ({
   // ─── Folder navigation (Wave 3-B-3) ───────────────────────────────────────
   const folderState = useFolders(userId, 'quiz');
   const [selectedFolderId, setSelectedFolderId] = useState<string | null>(null);
+  // Quiz whose "Move to folder…" picker is open (null = picker closed).
+  const [folderPickerTarget, setFolderPickerTarget] =
+    useState<QuizMetadata | null>(null);
+
+  // ─── Bulk selection (Step 8) ──────────────────────────────────────────────
+  const selection = useLibrarySelection();
+  const [selectionMode, setSelectionMode] = useState(false);
+  const [bulkBusy, setBulkBusy] = useState(false);
+  // Exit selection mode if the user leaves the library tab
+  const [prevManagerTab, setPrevManagerTab] = useState(managerTab);
+  if (prevManagerTab !== managerTab) {
+    setPrevManagerTab(managerTab);
+    if (managerTab !== 'library' && selectionMode) {
+      setSelectionMode(false);
+      selection.clear();
+    }
+  }
 
   // Reset folder selection when the signed-in user changes or the selected
   // folder no longer exists (e.g. after delete, sign-out, or account switch).
@@ -337,8 +363,10 @@ export const QuizManager: React.FC<QuizManagerProps> = ({
   const libraryView = useLibraryView<QuizMetadata>({
     items: folderFilteredQuizzes,
     initialSort: LIBRARY_INITIAL_SORT,
+    initialViewMode: config.libraryViewMode ?? 'grid',
     searchFields: LIBRARY_SEARCH_FIELDS,
     sortComparators: SORT_COMPARATORS,
+    onViewModeChange: onLibraryViewModeChange,
   });
 
   // useSortableReorder is used in no-op mode: Quiz metadata has no persisted
@@ -388,6 +416,10 @@ export const QuizManager: React.FC<QuizManagerProps> = ({
       icon: Link2,
       onClick: () => onShare(quiz),
     },
+    buildMoveToFolderAction({
+      onOpenPicker: () => setFolderPickerTarget(quiz),
+      disabled: !userId,
+    }),
     {
       id: 'delete',
       label: 'Delete',
@@ -596,6 +628,48 @@ export const QuizManager: React.FC<QuizManagerProps> = ({
     [userId, moveItem]
   );
 
+  // ─── Bulk handlers (Step 8) ───────────────────────────────────────────────
+  const handleBulkMove = useCallback(
+    async (folderId: string | null): Promise<void> => {
+      if (!userId || selection.count === 0) return;
+      setBulkBusy(true);
+      try {
+        for (const id of Array.from(selection.selectedIds)) {
+          try {
+            await moveItem(id, folderId);
+          } catch (err) {
+            console.error('[QuizManager] bulk move failed for', id, err);
+          }
+        }
+        selection.clear();
+        setSelectionMode(false);
+      } finally {
+        setBulkBusy(false);
+      }
+    },
+    [userId, selection, moveItem]
+  );
+
+  const handleBulkDelete = useCallback((): void => {
+    if (selection.count === 0) return;
+    const ok = window.confirm(
+      `Delete ${selection.count} quiz${selection.count === 1 ? '' : 'zes'}? This cannot be undone.`
+    );
+    if (!ok) return;
+    const ids = Array.from(selection.selectedIds);
+    const targets = quizzes.filter((q) => ids.includes(q.id));
+    setBulkBusy(true);
+    try {
+      for (const quiz of targets) {
+        onDelete(quiz);
+      }
+      selection.clear();
+      setSelectionMode(false);
+    } finally {
+      setBulkBusy(false);
+    }
+  }, [selection, quizzes, onDelete]);
+
   // ─── Folder sidebar (Library tab only) ────────────────────────────────────
   const folderSidebarSlot =
     managerTab === 'library' && userId ? (
@@ -632,6 +706,33 @@ export const QuizManager: React.FC<QuizManagerProps> = ({
         {...libraryView.toolbarProps}
         searchPlaceholder="Search quizzes…"
         sortOptions={SORT_OPTIONS}
+        rightSlot={
+          userId ? (
+            <button
+              type="button"
+              onClick={() => {
+                if (selectionMode) {
+                  selection.clear();
+                  setSelectionMode(false);
+                } else {
+                  setSelectionMode(true);
+                }
+              }}
+              className={`inline-flex items-center gap-1.5 rounded-lg px-2.5 py-1.5 text-xs font-bold uppercase tracking-wider transition-colors ${
+                selectionMode
+                  ? 'bg-brand-blue-primary text-white hover:bg-brand-blue-dark'
+                  : 'bg-white/70 text-slate-600 hover:bg-white hover:text-slate-800'
+              }`}
+              aria-pressed={selectionMode}
+              title={
+                selectionMode ? 'Exit selection mode' : 'Enter selection mode'
+              }
+            >
+              <CheckSquare className="h-3.5 w-3.5" />
+              {selectionMode ? 'Cancel' : 'Select'}
+            </button>
+          ) : undefined
+        }
       />
     ) : undefined;
 
@@ -721,7 +822,14 @@ export const QuizManager: React.FC<QuizManagerProps> = ({
           totalCount={quizzes.length}
           reorderLocked={libraryView.reorderLocked}
           reorderLockedReason={libraryView.reorderLockedReason}
-          enableCardDrag={Boolean(userId)}
+          enableCardDrag={Boolean(userId) && !selectionMode}
+          viewMode={libraryView.state.viewMode}
+          selection={selection}
+          selectionMode={selectionMode}
+          bulkBusy={bulkBusy}
+          folders={folderState.folders}
+          onBulkMove={handleBulkMove}
+          onBulkDelete={handleBulkDelete}
         />
       )}
 
@@ -761,6 +869,19 @@ export const QuizManager: React.FC<QuizManagerProps> = ({
         </LibraryDndContext>
       ) : (
         shell
+      )}
+
+      {folderPickerTarget && (
+        <FolderPickerPopover
+          variant="dialog"
+          folders={folderState.folders}
+          selectedFolderId={folderPickerTarget.folderId ?? null}
+          onSelect={(folderId) => {
+            void handleDropOnFolder(folderPickerTarget.id, folderId);
+          }}
+          onClose={() => setFolderPickerTarget(null)}
+          title={`Move "${folderPickerTarget.title}" to…`}
+        />
       )}
 
       {assignTarget && (
@@ -818,6 +939,13 @@ const LibraryTabContent: React.FC<{
    * enable drag when a teacher is signed in so drag-to-folder works.
    */
   enableCardDrag: boolean;
+  viewMode: 'grid' | 'list';
+  selection: LibrarySelectionApi;
+  selectionMode: boolean;
+  bulkBusy: boolean;
+  folders: import('@/types').LibraryFolder[];
+  onBulkMove: (folderId: string | null) => Promise<void>;
+  onBulkDelete: () => void;
 }> = ({
   error,
   orderedItems,
@@ -829,6 +957,13 @@ const LibraryTabContent: React.FC<{
   reorderLocked,
   reorderLockedReason,
   enableCardDrag,
+  viewMode,
+  selection,
+  selectionMode,
+  bulkBusy,
+  folders,
+  onBulkMove,
+  onBulkDelete,
 }) => {
   const emptyState =
     totalCount === 0 ? (
@@ -868,6 +1003,19 @@ const LibraryTabContent: React.FC<{
         </div>
       )}
 
+      {selectionMode && selection.count > 0 && (
+        <div className="mb-3">
+          <BulkActionBar
+            count={selection.count}
+            onClear={() => selection.clear()}
+            folders={folders}
+            onMove={onBulkMove}
+            onDelete={onBulkDelete}
+            busy={bulkBusy}
+          />
+        </div>
+      )}
+
       <LibraryGrid<QuizMetadata>
         items={orderedItems}
         getId={(q) => q.id}
@@ -877,7 +1025,7 @@ const LibraryTabContent: React.FC<{
         // works on grids without folder drag.
         reorderLocked={enableCardDrag ? false : reorderLocked}
         reorderLockedReason={enableCardDrag ? undefined : reorderLockedReason}
-        layout="list"
+        layout={viewMode}
         emptyState={emptyState}
         useExternalDndContext={enableCardDrag}
         renderCard={(quiz) => (
@@ -905,9 +1053,12 @@ const LibraryTabContent: React.FC<{
             }}
             secondaryActions={buildSecondaryActions(quiz)}
             onClick={() => onEdit(quiz)}
-            viewMode="list"
+            viewMode={viewMode}
             sortable={enableCardDrag}
             meta={quiz}
+            selectionMode={selectionMode}
+            selected={selection.isSelected(quiz.id)}
+            onSelectionToggle={() => selection.toggle(quiz.id)}
           />
         )}
       />

--- a/components/widgets/VideoActivityWidget/Widget.tsx
+++ b/components/widgets/VideoActivityWidget/Widget.tsx
@@ -23,6 +23,7 @@ import { useAuth } from '@/context/useAuth';
 import { useVideoActivity } from '@/hooks/useVideoActivity';
 import { useVideoActivitySessionTeacher } from '@/hooks/useVideoActivitySession';
 import { useVideoActivityAssignments } from '@/hooks/useVideoActivityAssignments';
+import { useFolders } from '@/hooks/useFolders';
 import { VideoActivityManager } from './components/VideoActivityManager';
 import { Creator } from './components/Creator';
 import { Results } from './components/Results';
@@ -108,6 +109,9 @@ export const VideoActivityWidget: React.FC<{ widget: WidgetData }> = ({
   const [editingMeta, setEditingMeta] = useState<VideoActivityMetadata | null>(
     null
   );
+
+  const { folders: videoActivityFolders, moveItem: moveVideoActivityItem } =
+    useFolders(user?.uid, 'video_activity');
 
   // Get global AI generation permission from feature permissions
   const videoActivityPerm = featurePermissions.find(
@@ -447,12 +451,37 @@ export const VideoActivityWidget: React.FC<{ widget: WidgetData }> = ({
             } as VideoActivityConfig,
           });
         }}
+        initialLibraryViewMode={config.libraryViewMode}
+        onLibraryViewModeChange={(mode) => {
+          updateWidget(widget.id, {
+            config: { ...config, libraryViewMode: mode } as VideoActivityConfig,
+          });
+        }}
       />
       <VideoActivityEditorModal
         isOpen={!!editingActivity}
         activity={editingActivity}
         aiEnabled={aiEnabled}
         isAdmin={isAdmin === true}
+        folders={editingMeta ? videoActivityFolders : undefined}
+        folderId={editingMeta?.folderId ?? null}
+        onFolderChange={
+          editingMeta
+            ? async (folderId) => {
+                try {
+                  await moveVideoActivityItem(editingMeta.id, folderId);
+                  addToast('Folder updated.', 'success');
+                } catch (err) {
+                  addToast(
+                    err instanceof Error
+                      ? err.message
+                      : 'Failed to update folder',
+                    'error'
+                  );
+                }
+              }
+            : undefined
+        }
         onClose={() => {
           setEditingActivity(null);
           setEditingMeta(null);

--- a/components/widgets/VideoActivityWidget/components/VideoActivityEditorModal.tsx
+++ b/components/widgets/VideoActivityWidget/components/VideoActivityEditorModal.tsx
@@ -23,8 +23,13 @@ import {
   X,
   Youtube,
 } from 'lucide-react';
-import { VideoActivityData, VideoActivityQuestion } from '@/types';
+import {
+  LibraryFolder,
+  VideoActivityData,
+  VideoActivityQuestion,
+} from '@/types';
 import { EditorModalShell } from '@/components/common/EditorModalShell';
+import { FolderSelectField } from '@/components/common/library/FolderSelectField';
 import { useAuth } from '@/context/useAuth';
 import { generateVideoActivity } from '@/utils/ai';
 
@@ -37,6 +42,10 @@ interface VideoActivityEditorModalProps {
   aiEnabled?: boolean;
   /** Admin override — admins can use AI even when the widget-level toggle is off. */
   isAdmin?: boolean;
+  /** Optional folder picker. When `folders` and `onFolderChange` are both provided, a folder-select field is shown. */
+  folders?: LibraryFolder[];
+  folderId?: string | null;
+  onFolderChange?: (folderId: string | null) => void;
 }
 
 /** Convert total seconds to MM:SS string. */
@@ -100,6 +109,9 @@ export const VideoActivityEditorModal: React.FC<
   onSave,
   aiEnabled = true,
   isAdmin = false,
+  folders,
+  folderId,
+  onFolderChange,
 }) => {
   const { canAccessFeature } = useAuth();
   // Snapshot the activity when the modal opens so `isDirty` compares against
@@ -410,6 +422,14 @@ export const VideoActivityEditorModal: React.FC<
             />
           </div>
         </div>
+
+        {folders && onFolderChange && (
+          <FolderSelectField
+            folders={folders}
+            value={folderId ?? null}
+            onChange={onFolderChange}
+          />
+        )}
 
         {error && (
           <div className="p-3 bg-brand-red-lighter/40 border border-brand-red-primary/20 rounded-xl flex items-center gap-2 text-sm text-brand-red-dark font-bold">

--- a/components/widgets/VideoActivityWidget/components/VideoActivityManager.tsx
+++ b/components/widgets/VideoActivityWidget/components/VideoActivityManager.tsx
@@ -23,6 +23,7 @@ import {
   AlertCircle,
   BarChart3,
   Ban,
+  CheckSquare,
   Copy,
   Edit2,
   FileUp,
@@ -39,9 +40,13 @@ import { LibraryItemCard } from '@/components/common/library/LibraryItemCard';
 import { AssignModal } from '@/components/common/library/AssignModal';
 import { AssignmentArchiveCard } from '@/components/common/library/AssignmentArchiveCard';
 import { FolderSidebar } from '@/components/common/library/FolderSidebar';
+import { FolderPickerPopover } from '@/components/common/library/FolderPickerPopover';
+import { buildMoveToFolderAction } from '@/components/common/library/folderMenuAction';
 import { LibraryDndContext } from '@/components/common/library/LibraryDndContext';
 import { useLibraryView } from '@/components/common/library/useLibraryView';
+import { useLibrarySelection } from '@/components/common/library/useLibrarySelection';
 import { useSortableReorder } from '@/components/common/library/useSortableReorder';
+import { BulkActionBar } from '@/components/common/library/BulkActionBar';
 import {
   countItemsByFolder,
   filterByFolder,
@@ -104,6 +109,11 @@ export interface VideoActivityManagerProps {
   onArchiveDeactivate?: (assignment: VideoActivityAssignment) => Promise<void>;
   onArchiveDelete?: (assignment: VideoActivityAssignment) => Promise<void>;
   onArchiveResults?: (assignment: VideoActivityAssignment) => void;
+
+  /** Persisted library grid/list toggle (from widget config). */
+  initialLibraryViewMode?: 'grid' | 'list';
+  /** Persist the library grid/list toggle into widget config. */
+  onLibraryViewModeChange?: (mode: 'grid' | 'list') => void;
 
   // Legacy per-activity session view (one-off session history). Kept for
   // backwards compatibility with existing Widget.tsx wiring; new work should
@@ -200,6 +210,8 @@ export const VideoActivityManager: React.FC<VideoActivityManagerProps> = ({
   onArchiveDeactivate,
   onArchiveDelete,
   onArchiveResults,
+  initialLibraryViewMode,
+  onLibraryViewModeChange,
 }) => {
   const [tab, setTab] = useState<LibraryTab>('library');
 
@@ -236,6 +248,21 @@ export const VideoActivityManager: React.FC<VideoActivityManagerProps> = ({
   /* ─── Folder navigation (Wave 3-B-3) ──────────────────────────────────── */
   const folderState = useFolders(userId, 'video_activity');
   const [selectedFolderId, setSelectedFolderId] = useState<string | null>(null);
+  const [folderPickerTarget, setFolderPickerTarget] =
+    useState<VideoActivityMetadata | null>(null);
+
+  /* ─── Bulk selection (Step 8) ─────────────────────────────────────────── */
+  const selection = useLibrarySelection();
+  const [selectionMode, setSelectionMode] = useState(false);
+  const [bulkBusy, setBulkBusy] = useState(false);
+  const [prevManagerTab, setPrevManagerTab] = useState(tab);
+  if (prevManagerTab !== tab) {
+    setPrevManagerTab(tab);
+    if (tab !== 'library' && selectionMode) {
+      setSelectionMode(false);
+      selection.clear();
+    }
+  }
 
   // Reset folder selection when the signed-in user changes or the selected
   // folder no longer exists (adjust-state-during-render pattern).
@@ -267,8 +294,10 @@ export const VideoActivityManager: React.FC<VideoActivityManagerProps> = ({
   const libraryView = useLibraryView<VideoActivityMetadata>({
     items: folderFilteredActivities,
     initialSort: LIBRARY_INITIAL_SORT,
+    initialViewMode: initialLibraryViewMode ?? 'grid',
     searchFields: LIBRARY_SEARCH_FIELDS,
     sortComparators: LIBRARY_SORT_COMPARATORS,
+    onViewModeChange: onLibraryViewModeChange,
   });
 
   const onReorderCommit = useCallback(
@@ -299,6 +328,52 @@ export const VideoActivityManager: React.FC<VideoActivityManagerProps> = ({
     },
     [userId, moveItem]
   );
+
+  /* ─── Bulk handlers (Step 8) ──────────────────────────────────────────── */
+  const handleBulkMove = useCallback(
+    async (folderId: string | null): Promise<void> => {
+      if (!userId || selection.count === 0) return;
+      setBulkBusy(true);
+      try {
+        for (const id of Array.from(selection.selectedIds)) {
+          try {
+            await moveItem(id, folderId);
+          } catch (err) {
+            console.error(
+              '[VideoActivityManager] bulk move failed for',
+              id,
+              err
+            );
+          }
+        }
+        selection.clear();
+        setSelectionMode(false);
+      } finally {
+        setBulkBusy(false);
+      }
+    },
+    [userId, selection, moveItem]
+  );
+
+  const handleBulkDelete = useCallback((): void => {
+    if (selection.count === 0) return;
+    const ok = window.confirm(
+      `Delete ${selection.count} activit${selection.count === 1 ? 'y' : 'ies'}? This cannot be undone.`
+    );
+    if (!ok) return;
+    const ids = Array.from(selection.selectedIds);
+    const targets = activities.filter((a) => ids.includes(a.id));
+    setBulkBusy(true);
+    try {
+      for (const activity of targets) {
+        onDelete(activity);
+      }
+      selection.clear();
+      setSelectionMode(false);
+    } finally {
+      setBulkBusy(false);
+    }
+  }, [selection, activities, onDelete]);
 
   const handleReorderDrop = useCallback(
     async (nextOrderedIds: string[]): Promise<void> => {
@@ -382,8 +457,9 @@ export const VideoActivityManager: React.FC<VideoActivityManagerProps> = ({
     />
   );
 
-  const useExternalDnd = Boolean(userId);
-  const cardDragEnabled = useExternalDnd || Boolean(onReorderActivities);
+  const useExternalDnd = Boolean(userId) && !selectionMode;
+  const cardDragEnabled =
+    (useExternalDnd || Boolean(onReorderActivities)) && !selectionMode;
 
   const renderLibraryTab = (): React.ReactElement => (
     <>
@@ -391,6 +467,19 @@ export const VideoActivityManager: React.FC<VideoActivityManagerProps> = ({
         <div className="mb-3 flex items-center gap-2 rounded-xl border border-brand-red-primary/30 bg-brand-red-lighter/40 px-3 py-2 text-sm font-medium text-brand-red-dark">
           <AlertCircle className="h-4 w-4 shrink-0" />
           {error}
+        </div>
+      )}
+
+      {selectionMode && selection.count > 0 && (
+        <div className="mb-3">
+          <BulkActionBar
+            count={selection.count}
+            onClear={() => selection.clear()}
+            folders={folderState.folders}
+            onMove={handleBulkMove}
+            onDelete={handleBulkDelete}
+            busy={bulkBusy}
+          />
         </div>
       )}
 
@@ -424,6 +513,10 @@ export const VideoActivityManager: React.FC<VideoActivityManagerProps> = ({
                   } satisfies LibraryMenuAction,
                 ]
               : []),
+            buildMoveToFolderAction({
+              onOpenPicker: () => setFolderPickerTarget(activity),
+              disabled: !userId,
+            }),
             {
               id: 'delete',
               label:
@@ -465,6 +558,9 @@ export const VideoActivityManager: React.FC<VideoActivityManagerProps> = ({
               onClick={() => onEdit(activity)}
               viewMode={libraryView.state.viewMode}
               meta={activity}
+              selectionMode={selectionMode}
+              selected={selection.isSelected(activity.id)}
+              onSelectionToggle={() => selection.toggle(activity.id)}
             />
           );
         }}
@@ -650,6 +746,33 @@ export const VideoActivityManager: React.FC<VideoActivityManagerProps> = ({
           { key: 'title', label: 'Title', defaultDir: 'asc' },
           { key: 'questionCount', label: 'Question count', defaultDir: 'desc' },
         ]}
+        rightSlot={
+          userId ? (
+            <button
+              type="button"
+              onClick={() => {
+                if (selectionMode) {
+                  selection.clear();
+                  setSelectionMode(false);
+                } else {
+                  setSelectionMode(true);
+                }
+              }}
+              className={`inline-flex items-center gap-1.5 rounded-lg px-2.5 py-1.5 text-xs font-bold uppercase tracking-wider transition-colors ${
+                selectionMode
+                  ? 'bg-brand-blue-primary text-white hover:bg-brand-blue-dark'
+                  : 'bg-white/70 text-slate-600 hover:bg-white hover:text-slate-800'
+              }`}
+              aria-pressed={selectionMode}
+              title={
+                selectionMode ? 'Exit selection mode' : 'Enter selection mode'
+              }
+            >
+              <CheckSquare className="h-3.5 w-3.5" />
+              {selectionMode ? 'Cancel' : 'Select'}
+            </button>
+          ) : undefined
+        }
       />
     ) : null;
 
@@ -745,6 +868,19 @@ export const VideoActivityManager: React.FC<VideoActivityManagerProps> = ({
         </LibraryDndContext>
       ) : (
         shell
+      )}
+
+      {folderPickerTarget && (
+        <FolderPickerPopover
+          variant="dialog"
+          folders={folderState.folders}
+          selectedFolderId={folderPickerTarget.folderId ?? null}
+          onSelect={(folderId) => {
+            void handleDropOnFolder(folderPickerTarget.id, folderId);
+          }}
+          onClose={() => setFolderPickerTarget(null)}
+          title={`Move "${folderPickerTarget.title}" to…`}
+        />
       )}
 
       {assignTarget && (

--- a/components/widgets/VideoActivityWidget/components/VideoActivityManager.tsx
+++ b/components/widgets/VideoActivityWidget/components/VideoActivityManager.tsx
@@ -81,7 +81,7 @@ export interface VideoActivityManagerProps {
   onNew: () => void;
   onImport: () => void;
   onEdit: (activity: VideoActivityMetadata) => void;
-  onDelete: (activity: VideoActivityMetadata) => void;
+  onDelete: (activity: VideoActivityMetadata) => void | Promise<void>;
   /**
    * Optional per-activity results view. New work prefers the assignment-
    * archive tab; kept for backwards-compatibility while the legacy Widget
@@ -333,19 +333,21 @@ export const VideoActivityManager: React.FC<VideoActivityManagerProps> = ({
   const handleBulkMove = useCallback(
     async (folderId: string | null): Promise<void> => {
       if (!userId || selection.count === 0) return;
+      const ids = Array.from(selection.selectedIds);
       setBulkBusy(true);
       try {
-        for (const id of Array.from(selection.selectedIds)) {
-          try {
-            await moveItem(id, folderId);
-          } catch (err) {
+        const results = await Promise.allSettled(
+          ids.map((id) => moveItem(id, folderId))
+        );
+        results.forEach((result, idx) => {
+          if (result.status === 'rejected') {
             console.error(
               '[VideoActivityManager] bulk move failed for',
-              id,
-              err
+              ids[idx],
+              result.reason
             );
           }
-        }
+        });
         selection.clear();
         setSelectionMode(false);
       } finally {
@@ -355,7 +357,7 @@ export const VideoActivityManager: React.FC<VideoActivityManagerProps> = ({
     [userId, selection, moveItem]
   );
 
-  const handleBulkDelete = useCallback((): void => {
+  const handleBulkDelete = useCallback(async (): Promise<void> => {
     if (selection.count === 0) return;
     const ok = window.confirm(
       `Delete ${selection.count} activit${selection.count === 1 ? 'y' : 'ies'}? This cannot be undone.`
@@ -365,9 +367,18 @@ export const VideoActivityManager: React.FC<VideoActivityManagerProps> = ({
     const targets = activities.filter((a) => ids.includes(a.id));
     setBulkBusy(true);
     try {
-      for (const activity of targets) {
-        onDelete(activity);
-      }
+      const results = await Promise.allSettled(
+        targets.map(async (activity) => onDelete(activity))
+      );
+      results.forEach((result, idx) => {
+        if (result.status === 'rejected') {
+          console.error(
+            '[VideoActivityManager] bulk delete failed for',
+            targets[idx]?.id,
+            result.reason
+          );
+        }
+      });
       selection.clear();
       setSelectionMode(false);
     } finally {
@@ -528,7 +539,7 @@ export const VideoActivityManager: React.FC<VideoActivityManagerProps> = ({
               onClick: () => {
                 if (confirmDeleteActivityId === activity.id) {
                   setConfirmDeleteActivityId(null);
-                  onDelete(activity);
+                  void onDelete(activity);
                 } else {
                   setConfirmDeleteActivityId(activity.id);
                 }

--- a/tests/components/common/LibraryGrid.test.tsx
+++ b/tests/components/common/LibraryGrid.test.tsx
@@ -83,8 +83,10 @@ describe('LibraryGrid', () => {
       name: /clear search to reorder/i,
     });
     expect(handles.length).toBeGreaterThan(0);
-    // Handles should be disabled while locked.
-    expect(handles[0]).toBeDisabled();
+    // The sortable wrapper reflects the lock via aria-disabled. The whole card
+    // is the drag activator (not a native <button>), so we assert the aria
+    // contract rather than the form-control disabled attribute.
+    expect(handles[0]).toHaveAttribute('aria-disabled', 'true');
   });
 
   it('keyboard accessibility smoke test: drag handle is focusable and responds to Space', () => {
@@ -119,9 +121,10 @@ describe('LibraryGrid', () => {
 
     // We assert the integration path plumbed through — the exact dnd-kit
     // keyboard coordination is exercised in dnd-kit's own test suite; for
-    // us it's enough to verify the handle is a real focusable button
-    // participating in the DndContext. (Some jsdom environments don't
-    // fully simulate the keyboard sensor's internal layout math.)
-    expect(handles[0]).toHaveAttribute('type', 'button');
+    // us it's enough to verify the handle is a focusable element with the
+    // button role participating in the DndContext. (Some jsdom environments
+    // don't fully simulate the keyboard sensor's internal layout math.)
+    expect(handles[0]).toHaveAttribute('role', 'button');
+    expect(handles[0]).toHaveAttribute('tabindex', '0');
   });
 });

--- a/types.ts
+++ b/types.ts
@@ -1187,6 +1187,8 @@ export interface MiniAppConfig {
   collectResults?: boolean; // Toggle switch state
   googleSheetId?: string; // Extracted Sheet ID
   googleSheetUrl?: string; // Original pasted URL for UI
+  /** Persisted library grid/list toggle. */
+  libraryViewMode?: 'grid' | 'list';
 }
 
 // Add new Global Config type
@@ -1721,6 +1723,8 @@ export interface QuizConfig {
   liveScoreboardMode?: 'pin' | 'name';
   /** When to update scores: on quiz completion or after each question */
   liveScoreboardScoring?: 'completion' | 'per-question';
+  /** Persisted library grid/list toggle. */
+  libraryViewMode?: 'grid' | 'list';
 }
 
 // --- QUIZ ASSIGNMENT TYPES ---
@@ -1847,6 +1851,8 @@ export interface VideoActivityConfig {
   autoPlay?: boolean;
   requireCorrectAnswer?: boolean;
   allowSkipping?: boolean;
+  /** Persisted library grid/list toggle. */
+  libraryViewMode?: 'grid' | 'list';
 }
 
 export interface VideoActivitySessionSettings {
@@ -2521,6 +2527,8 @@ export interface GuidedLearningConfig {
   playerSetId?: string | null;
   /** Session ID when viewing results */
   resultsSessionId?: string | null;
+  /** Persisted library grid/list toggle. */
+  libraryViewMode?: 'grid' | 'list';
 }
 
 // Union of all widget configs


### PR DESCRIPTION
## Summary

8-step overhaul of the shared library primitives consumed by Quiz, Video Activity, Guided Learning, and Mini-App widgets. All visual/UX work lives in `components/common/library/`; managers change only to wire viewMode, selection, and the editor folder field.

- **Folders actually usable** — drag-to-folder (folder-aware collision detection + full-row drop targets), "Move to folder…" row action, `FolderSelectField` in every editor modal, bulk move via the new `BulkActionBar`.
- **Collapsible folder sidebar** — full / rail / hidden state machine driven by container width + a persisted user override, with cqmin-scaled text.
- **Grid view wired** — managers were hard-coding `list`; now respects `viewMode` and uses container-query columns. Preference persists per widget instance.
- **Row density** — kebab-only secondary actions (dropped the inline-icon path that truncated titles at mid widths).
- **Bulk select** — floating `BulkActionBar` with count + Move + Delete + Clear. GL/MiniApp restrict selection to personal entries (building/global stay read-only).

## Test plan

- [x] `pnpm run type-check` — clean
- [x] `pnpm run test` — 1382/1382 passing
- [x] `pnpm exec prettier --check` + `eslint --max-warnings 0` on all touched files — clean
- [ ] Manual preview: drag-to-folder, row-menu move, editor-modal folder picker, bulk move, sidebar state cycling (hidden → rail → full), grid view at varying widths
- [ ] Parity check across Quiz, Video Activity, Guided Learning, Mini-App

🤖 Generated with [Claude Code](https://claude.com/claude-code)