### PR TITLE
fix(quiz): aggregate bulk-delete prompts into one confirm + summary toast

### DIFF
--- a/components/widgets/QuizWidget/Widget.tsx
+++ b/components/widgets/QuizWidget/Widget.tsx
@@ -790,7 +790,7 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
             );
           }
         }}
-        onBulkDelete={async (metas) => {
+        onBulkDelete={async (metas): Promise<boolean> => {
           // Aggregated variant of the single-quiz onDelete handler above.
           // Partitions targets into:
           //   - blocked: has live/paused assignments → cannot delete
@@ -800,6 +800,11 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
           // confirm for the archived-assignment warning, regardless of how
           // many quizzes are selected — replaces the old per-item dialogs
           // that would fire up to N times when bulk-deleting N quizzes.
+          //
+          // Returns `true` when a delete was attempted (caller clears
+          // selection) and `false` when the handler aborted or the user
+          // cancelled (caller preserves selection so the teacher can retry
+          // without re-selecting everything).
 
           // Guard against stale/empty assignments: the live-assignment check
           // is load-bearing for student safety. Abort if the listener hasn't
@@ -809,7 +814,7 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
               'Still loading assignment data — try bulk delete again in a moment.',
               'info'
             );
-            return;
+            return false;
           }
 
           // Pre-index assignments by quizId so partitioning stays O(N+M)
@@ -844,7 +849,7 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
           }
 
           const deletable = [...clean, ...withArchived];
-          if (deletable.length === 0) return;
+          if (deletable.length === 0) return false;
 
           const confirmMsg =
             withArchived.length > 0
@@ -853,7 +858,7 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
                 `deleting will prevent viewing their monitor and results. This cannot be undone.`
               : `Delete ${deletable.length} quiz${deletable.length === 1 ? '' : 'zes'}? This cannot be undone.`;
           const ok = window.confirm(confirmMsg);
-          if (!ok) return;
+          if (!ok) return false;
 
           const results = await Promise.allSettled(
             deletable.map((meta) => deleteQuiz(meta.id, meta.driveFileId))
@@ -884,6 +889,7 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
               'error'
             );
           }
+          return true;
         }}
         // ─── Archive tab ─────────────────────────────────────────────────────
         managerTab={config.managerTab ?? 'library'}

--- a/components/widgets/QuizWidget/Widget.tsx
+++ b/components/widgets/QuizWidget/Widget.tsx
@@ -790,6 +790,80 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
             );
           }
         }}
+        onBulkDelete={async (metas) => {
+          // Aggregated variant of the single-quiz onDelete handler above.
+          // Partitions targets into:
+          //   - blocked: has live/paused assignments → cannot delete
+          //   - withArchived: has only archived assignments → needs warning
+          //   - clean: no assignments → delete silently
+          // Shows ONE summary toast for blocked items and ONE aggregated
+          // confirm for the archived-assignment warning, regardless of how
+          // many quizzes are selected — replaces the old per-item dialogs
+          // that would fire up to N times when bulk-deleting N quizzes.
+          const blocked: QuizMetadata[] = [];
+          const withArchived: QuizMetadata[] = [];
+          const clean: QuizMetadata[] = [];
+          for (const meta of metas) {
+            const related = assignments.filter((a) => a.quizId === meta.id);
+            const live = related.filter((a) => a.status !== 'inactive');
+            if (live.length > 0) {
+              blocked.push(meta);
+            } else if (related.length > 0) {
+              withArchived.push(meta);
+            } else {
+              clean.push(meta);
+            }
+          }
+
+          if (blocked.length > 0) {
+            addToast(
+              `Skipped ${blocked.length} quiz${blocked.length === 1 ? '' : 'zes'} with active or paused assignments. Deactivate them first.`,
+              'error'
+            );
+          }
+
+          const deletable = [...clean, ...withArchived];
+          if (deletable.length === 0) return;
+
+          const confirmMsg =
+            withArchived.length > 0
+              ? `Delete ${deletable.length} quiz${deletable.length === 1 ? '' : 'zes'}? ` +
+                `${withArchived.length} ${withArchived.length === 1 ? 'has' : 'have'} archived assignments — ` +
+                `deleting will prevent viewing their monitor and results. This cannot be undone.`
+              : `Delete ${deletable.length} quiz${deletable.length === 1 ? '' : 'zes'}? This cannot be undone.`;
+          const ok = window.confirm(confirmMsg);
+          if (!ok) return;
+
+          const results = await Promise.allSettled(
+            deletable.map((meta) => deleteQuiz(meta.id, meta.driveFileId))
+          );
+          const failed: string[] = [];
+          results.forEach((result, idx) => {
+            if (result.status === 'rejected') {
+              const id = deletable[idx]?.id ?? '?';
+              failed.push(id);
+              console.error(
+                '[QuizWidget] bulk delete failed for',
+                id,
+                result.reason
+              );
+            }
+          });
+
+          const succeeded = deletable.length - failed.length;
+          if (succeeded > 0) {
+            addToast(
+              `Deleted ${succeeded} quiz${succeeded === 1 ? '' : 'zes'}.`,
+              'success'
+            );
+          }
+          if (failed.length > 0) {
+            addToast(
+              `${failed.length} quiz${failed.length === 1 ? '' : 'zes'} failed to delete.`,
+              'error'
+            );
+          }
+        }}
         // ─── Archive tab ─────────────────────────────────────────────────────
         managerTab={config.managerTab ?? 'library'}
         onTabChange={(tab) => handleUpdateQuizConfig({ managerTab: tab })}

--- a/components/widgets/QuizWidget/Widget.tsx
+++ b/components/widgets/QuizWidget/Widget.tsx
@@ -67,6 +67,7 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
   const {
     assignments,
     loading: assignmentsLoading,
+    error: assignmentsError,
     createAssignment,
     pauseAssignment,
     resumeAssignment,
@@ -808,10 +809,14 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
 
           // Guard against stale/empty assignments: the live-assignment check
           // is load-bearing for student safety. Abort if the listener hasn't
-          // populated yet so we don't misclassify a live quiz as deletable.
-          if (assignmentsLoading) {
+          // populated yet — or if it errored (hook flips loading→false and
+          // leaves `assignments=[]` on error, which would otherwise let a
+          // live quiz get misclassified as deletable).
+          if (assignmentsLoading || assignmentsError) {
             addToast(
-              'Still loading assignment data — try bulk delete again in a moment.',
+              assignmentsError
+                ? "Couldn't verify assignment status — try bulk delete again in a moment."
+                : 'Still loading assignment data — try bulk delete again in a moment.',
               'info'
             );
             return false;

--- a/components/widgets/QuizWidget/Widget.tsx
+++ b/components/widgets/QuizWidget/Widget.tsx
@@ -800,13 +800,34 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
           // confirm for the archived-assignment warning, regardless of how
           // many quizzes are selected — replaces the old per-item dialogs
           // that would fire up to N times when bulk-deleting N quizzes.
+
+          // Guard against stale/empty assignments: the live-assignment check
+          // is load-bearing for student safety. Abort if the listener hasn't
+          // populated yet so we don't misclassify a live quiz as deletable.
+          if (assignmentsLoading) {
+            addToast(
+              'Still loading assignment data — try bulk delete again in a moment.',
+              'info'
+            );
+            return;
+          }
+
+          // Pre-index assignments by quizId so partitioning stays O(N+M)
+          // rather than O(N*M) for large teacher archives.
+          const byQuizId = new Map<string, QuizAssignment[]>();
+          for (const a of assignments) {
+            const list = byQuizId.get(a.quizId);
+            if (list) list.push(a);
+            else byQuizId.set(a.quizId, [a]);
+          }
+
           const blocked: QuizMetadata[] = [];
           const withArchived: QuizMetadata[] = [];
           const clean: QuizMetadata[] = [];
           for (const meta of metas) {
-            const related = assignments.filter((a) => a.quizId === meta.id);
-            const live = related.filter((a) => a.status !== 'inactive');
-            if (live.length > 0) {
+            const related = byQuizId.get(meta.id) ?? [];
+            const hasLive = related.some((a) => a.status !== 'inactive');
+            if (hasLive) {
               blocked.push(meta);
             } else if (related.length > 0) {
               withArchived.push(meta);

--- a/components/widgets/QuizWidget/components/QuizManager.tsx
+++ b/components/widgets/QuizWidget/components/QuizManager.tsx
@@ -170,9 +170,11 @@ interface QuizManagerProps {
    * fired by `onDelete` (see QuizWidget's `onDelete` wiring, which prompts
    * per-quiz when archived assignments exist). Receives every selected
    * quiz — implementers are responsible for their own aggregated confirms
-   * and summary toasts.
+   * and summary toasts. Resolve to `true` when a delete was attempted
+   * (selection will be cleared) or `false` when the handler aborted or
+   * the user cancelled (selection will be preserved so they can retry).
    */
-  onBulkDelete?: (quizzes: QuizMetadata[]) => Promise<void>;
+  onBulkDelete?: (quizzes: QuizMetadata[]) => Promise<boolean>;
   onShare: (quiz: QuizMetadata) => void;
   rosters: ClassRoster[];
   config: QuizConfig;
@@ -671,29 +673,38 @@ export const QuizManager: React.FC<QuizManagerProps> = ({
     if (targets.length === 0) return;
     setBulkBusy(true);
     try {
+      // `didAttempt` gates the selection clear: if the user cancelled a
+      // confirm or the widget-level handler aborted (e.g. assignments
+      // still loading), keep the selection so they can retry without
+      // re-selecting everything.
+      let didAttempt = false;
       if (onBulkDelete) {
         // Widget-level handler owns confirmation + summary toasts.
-        await onBulkDelete(targets);
+        didAttempt = await onBulkDelete(targets);
       } else {
         const ok = window.confirm(
           `Delete ${targets.length} quiz${targets.length === 1 ? '' : 'zes'}? This cannot be undone.`
         );
-        if (!ok) return;
-        const results = await Promise.allSettled(
-          targets.map(async (quiz) => onDelete(quiz))
-        );
-        results.forEach((result, idx) => {
-          if (result.status === 'rejected') {
-            console.error(
-              '[QuizManager] bulk delete failed for',
-              targets[idx]?.id,
-              result.reason
-            );
-          }
-        });
+        if (ok) {
+          const results = await Promise.allSettled(
+            targets.map(async (quiz) => onDelete(quiz))
+          );
+          results.forEach((result, idx) => {
+            if (result.status === 'rejected') {
+              console.error(
+                '[QuizManager] bulk delete failed for',
+                targets[idx]?.id,
+                result.reason
+              );
+            }
+          });
+          didAttempt = true;
+        }
       }
-      selection.clear();
-      setSelectionMode(false);
+      if (didAttempt) {
+        selection.clear();
+        setSelectionMode(false);
+      }
     } finally {
       setBulkBusy(false);
     }

--- a/components/widgets/QuizWidget/components/QuizManager.tsx
+++ b/components/widgets/QuizWidget/components/QuizManager.tsx
@@ -165,6 +165,14 @@ interface QuizManagerProps {
   ) => void;
   onResults: (quiz: QuizMetadata) => void;
   onDelete: (quiz: QuizMetadata) => void | Promise<void>;
+  /**
+   * Optional batch delete that bypasses the per-quiz confirmation/toasts
+   * fired by `onDelete` (see QuizWidget's `onDelete` wiring, which prompts
+   * per-quiz when archived assignments exist). Receives every selected
+   * quiz — implementers are responsible for their own aggregated confirms
+   * and summary toasts.
+   */
+  onBulkDelete?: (quizzes: QuizMetadata[]) => Promise<void>;
   onShare: (quiz: QuizMetadata) => void;
   rosters: ClassRoster[];
   config: QuizConfig;
@@ -264,6 +272,7 @@ export const QuizManager: React.FC<QuizManagerProps> = ({
   onAssign,
   onResults,
   onDelete,
+  onBulkDelete,
   onShare,
   rosters,
   config,
@@ -658,32 +667,38 @@ export const QuizManager: React.FC<QuizManagerProps> = ({
 
   const handleBulkDelete = useCallback(async (): Promise<void> => {
     if (selection.count === 0) return;
-    const ok = window.confirm(
-      `Delete ${selection.count} quiz${selection.count === 1 ? '' : 'zes'}? This cannot be undone.`
-    );
-    if (!ok) return;
     const ids = Array.from(selection.selectedIds);
     const targets = quizzes.filter((q) => ids.includes(q.id));
+    if (targets.length === 0) return;
     setBulkBusy(true);
     try {
-      const results = await Promise.allSettled(
-        targets.map(async (quiz) => onDelete(quiz))
-      );
-      results.forEach((result, idx) => {
-        if (result.status === 'rejected') {
-          console.error(
-            '[QuizManager] bulk delete failed for',
-            targets[idx]?.id,
-            result.reason
-          );
-        }
-      });
+      if (onBulkDelete) {
+        // Widget-level handler owns confirmation + summary toasts.
+        await onBulkDelete(targets);
+      } else {
+        const ok = window.confirm(
+          `Delete ${targets.length} quiz${targets.length === 1 ? '' : 'zes'}? This cannot be undone.`
+        );
+        if (!ok) return;
+        const results = await Promise.allSettled(
+          targets.map(async (quiz) => onDelete(quiz))
+        );
+        results.forEach((result, idx) => {
+          if (result.status === 'rejected') {
+            console.error(
+              '[QuizManager] bulk delete failed for',
+              targets[idx]?.id,
+              result.reason
+            );
+          }
+        });
+      }
       selection.clear();
       setSelectionMode(false);
     } finally {
       setBulkBusy(false);
     }
-  }, [selection, quizzes, onDelete]);
+  }, [selection, quizzes, onDelete, onBulkDelete]);
 
   // ─── Folder sidebar (Library tab only) ────────────────────────────────────
   const folderSidebarSlot =

--- a/components/widgets/QuizWidget/components/QuizManager.tsx
+++ b/components/widgets/QuizWidget/components/QuizManager.tsx
@@ -667,8 +667,7 @@ export const QuizManager: React.FC<QuizManagerProps> = ({
 
   const handleBulkDelete = useCallback(async (): Promise<void> => {
     if (selection.count === 0) return;
-    const ids = Array.from(selection.selectedIds);
-    const targets = quizzes.filter((q) => ids.includes(q.id));
+    const targets = quizzes.filter((q) => selection.selectedIds.has(q.id));
     if (targets.length === 0) return;
     setBulkBusy(true);
     try {


### PR DESCRIPTION
## Summary

Follow-up to #1369. Copilot flagged that `QuizManager.handleBulkDelete` calls `onDelete(quiz)` in a loop, and Widget.tsx's `onDelete` wiring fires a `window.confirm(...)` per archived-assignment quiz plus one success toast per successful delete. Bulk-deleting 10 quizzes with archived assignments could produce up to 11 confirm dialogs and 10 success toasts — rough UX.

- **QuizManager**: new optional `onBulkDelete` prop. When provided, `handleBulkDelete` delegates to it (the widget owns the confirm and summary toasts) and skips the generic "Delete N quizzes?" dialog. When omitted, falls back to the existing per-item loop so non-Quiz callers keep working.
- **QuizWidget**: implements `onBulkDelete`. Partitions the selection into:
  - **blocked** (has active/paused assignments) → one error toast listing the skipped count
  - **with-archived** (has only archived assignments) → folded into the one aggregated confirm, which mentions the archived-assignment impact
  - **clean** (no assignments) → silent delete
  
  The result: at most ONE confirm dialog, ONE aggregated error toast if any items are blocked, and ONE success/failure summary toast.

The single-item `onDelete` path (used by the row kebab menu) is unchanged — that flow still shows the per-quiz confirm and per-quiz toast.

## Test plan

- [x] `pnpm run type-check` — clean
- [x] `pnpm exec prettier --check` + `eslint --max-warnings 0` on touched files — clean
- [x] `pnpm run test` — 1385/1385 passing
- [ ] **Manual preview** (requires seeded Firestore data — not exercised here):
  - [ ] Bulk-select 2 clean quizzes + 1 with an archived assignment → one confirm that mentions "1 has archived assignments", one success toast
  - [ ] Bulk-select quizzes with live assignments → one error toast, no delete happens
  - [ ] Single-quiz delete via row menu → still shows the per-quiz confirm + per-quiz toast

🤖 Generated with [Claude Code](https://claude.com/claude-code)