### PR TITLE
fix(quiz): post-assign redirect + library UX polish

### DIFF
--- a/components/common/EditorModalShell.tsx
+++ b/components/common/EditorModalShell.tsx
@@ -159,7 +159,9 @@ export const EditorModalShell: React.FC<EditorModalShellProps> = ({
       contentClassName={bodyClassName}
       ariaLabelledby="editor-modal-shell-title"
     >
-      {children}
+      <div style={{ colorScheme: 'light' }} className="contents">
+        {children}
+      </div>
     </Modal>
   );
 };

--- a/components/common/library/FolderPickerPopover.tsx
+++ b/components/common/library/FolderPickerPopover.tsx
@@ -12,8 +12,18 @@
  * folders from `useFolders()` and handle the move/commit themselves.
  */
 
-import React, { useEffect, useId, useMemo, useRef } from 'react';
+import React, {
+  useEffect,
+  useId,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  type RefObject,
+} from 'react';
+import { createPortal } from 'react-dom';
 import { Folder as FolderIcon, Check, Inbox } from 'lucide-react';
+import { Z_INDEX } from '@/config/zIndex';
 import type { LibraryFolder } from '@/types';
 
 export interface FolderPickerPopoverProps {
@@ -27,12 +37,19 @@ export interface FolderPickerPopoverProps {
   title?: string;
   /**
    * Layout mode:
-   *   - `'popover'` (default): absolutely-positioned card — caller owns the
-   *     relative anchor (usually the kebab-menu row).
+   *   - `'popover'` (default): portal-rendered card anchored via `anchorRef`
+   *     to escape clipping ancestors (`overflow: hidden`, `will-change:
+   *     transform`, etc.) inside widgets and modals.
    *   - `'dialog'`: fixed-position centered modal with a backdrop, suitable
    *     for use from a row action without a stable anchor.
    */
   variant?: 'popover' | 'dialog';
+  /**
+   * Anchor element for the `'popover'` variant. The popover is positioned
+   * with `position: fixed` relative to this element's bounding rect.
+   * Required for `'popover'`, ignored for `'dialog'`.
+   */
+  anchorRef?: RefObject<HTMLElement | null>;
 }
 
 interface FlatNode {
@@ -83,6 +100,9 @@ const flattenFolders = (folders: LibraryFolder[]): FlatNode[] => {
   return out;
 };
 
+const POPOVER_WIDTH = 256;
+const POPOVER_GAP = 4;
+
 export const FolderPickerPopover: React.FC<FolderPickerPopoverProps> = ({
   folders,
   selectedFolderId,
@@ -90,16 +110,41 @@ export const FolderPickerPopover: React.FC<FolderPickerPopoverProps> = ({
   onClose,
   title = 'Move to folder',
   variant = 'popover',
+  anchorRef,
 }) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const headerId = useId();
+  const isPortaledPopover = variant === 'popover' && !!anchorRef;
+  const [anchorPos, setAnchorPos] = useState<{
+    top: number;
+    left: number;
+  } | null>(null);
+
+  useLayoutEffect(() => {
+    if (!isPortaledPopover || !anchorRef?.current) return;
+    const rect = anchorRef.current.getBoundingClientRect();
+    const viewportW =
+      typeof window !== 'undefined' ? window.innerWidth : rect.right;
+    const left = Math.max(
+      8,
+      Math.min(rect.left, viewportW - POPOVER_WIDTH - 8)
+    );
+    setAnchorPos({ top: rect.bottom + POPOVER_GAP, left });
+  }, [isPortaledPopover, anchorRef]);
 
   useEffect(() => {
     const handlePointer = (event: MouseEvent): void => {
-      if (!containerRef.current) return;
-      if (!containerRef.current.contains(event.target as Node)) {
-        onClose();
+      const target = event.target as Node | null;
+      if (!target) return;
+      if (containerRef.current && containerRef.current.contains(target)) return;
+      if (
+        isPortaledPopover &&
+        anchorRef?.current &&
+        anchorRef.current.contains(target)
+      ) {
+        return;
       }
+      onClose();
     };
     const handleKey = (event: KeyboardEvent): void => {
       if (event.key === 'Escape') onClose();
@@ -110,7 +155,18 @@ export const FolderPickerPopover: React.FC<FolderPickerPopoverProps> = ({
       document.removeEventListener('mousedown', handlePointer);
       document.removeEventListener('keydown', handleKey);
     };
-  }, [onClose]);
+  }, [onClose, isPortaledPopover, anchorRef]);
+
+  useLayoutEffect(() => {
+    if (!isPortaledPopover) return;
+    const close = () => onClose();
+    window.addEventListener('resize', close);
+    window.addEventListener('scroll', close, true);
+    return () => {
+      window.removeEventListener('resize', close);
+      window.removeEventListener('scroll', close, true);
+    };
+  }, [isPortaledPopover, onClose]);
 
   const flat = useMemo(() => flattenFolders(folders), [folders]);
 
@@ -148,17 +204,33 @@ export const FolderPickerPopover: React.FC<FolderPickerPopoverProps> = ({
     );
   };
 
+  const cardClass =
+    variant === 'dialog'
+      ? 'relative z-10 flex max-h-[80vh] w-80 flex-col rounded-xl border border-slate-200 bg-white/95 shadow-2xl backdrop-blur-md'
+      : isPortaledPopover
+        ? 'flex max-h-72 flex-col rounded-xl border border-slate-200 bg-white/95 shadow-xl backdrop-blur-md'
+        : 'absolute z-50 mt-1 flex max-h-72 w-64 flex-col rounded-xl border border-slate-200 bg-white/95 shadow-xl backdrop-blur-md';
+
+  const cardStyle: React.CSSProperties | undefined =
+    isPortaledPopover && anchorPos
+      ? {
+          position: 'fixed',
+          top: anchorPos.top,
+          left: anchorPos.left,
+          width: POPOVER_WIDTH,
+          zIndex: Z_INDEX.modalNestedContent,
+        }
+      : undefined;
+
   const card = (
     <div
       ref={containerRef}
       role="dialog"
       aria-labelledby={headerId}
       aria-modal={variant === 'dialog' ? true : undefined}
-      className={
-        variant === 'dialog'
-          ? 'relative z-10 flex max-h-[80vh] w-80 flex-col rounded-xl border border-slate-200 bg-white/95 shadow-2xl backdrop-blur-md'
-          : 'absolute z-50 mt-1 flex max-h-72 w-64 flex-col rounded-xl border border-slate-200 bg-white/95 shadow-xl backdrop-blur-md'
-      }
+      data-click-outside-ignore={isPortaledPopover ? 'true' : undefined}
+      className={cardClass}
+      style={cardStyle}
     >
       <header
         id={headerId}
@@ -220,6 +292,11 @@ export const FolderPickerPopover: React.FC<FolderPickerPopoverProps> = ({
         {card}
       </div>
     );
+  }
+
+  if (isPortaledPopover) {
+    if (!anchorPos || typeof document === 'undefined') return null;
+    return createPortal(card, document.body);
   }
 
   return card;

--- a/components/common/library/FolderPickerPopover.tsx
+++ b/components/common/library/FolderPickerPopover.tsx
@@ -133,7 +133,7 @@ export const FolderPickerPopover: React.FC<FolderPickerPopoverProps> = ({
   }, [isPortaledPopover, anchorRef]);
 
   useEffect(() => {
-    const handlePointer = (event: MouseEvent): void => {
+    const handlePointer = (event: MouseEvent | TouchEvent): void => {
       const target = event.target as Node | null;
       if (!target) return;
       if (containerRef.current && containerRef.current.contains(target)) return;
@@ -150,9 +150,11 @@ export const FolderPickerPopover: React.FC<FolderPickerPopoverProps> = ({
       if (event.key === 'Escape') onClose();
     };
     document.addEventListener('mousedown', handlePointer);
+    document.addEventListener('touchstart', handlePointer);
     document.addEventListener('keydown', handleKey);
     return () => {
       document.removeEventListener('mousedown', handlePointer);
+      document.removeEventListener('touchstart', handlePointer);
       document.removeEventListener('keydown', handleKey);
     };
   }, [onClose, isPortaledPopover, anchorRef]);

--- a/components/common/library/FolderSelectField.tsx
+++ b/components/common/library/FolderSelectField.tsx
@@ -9,7 +9,7 @@
  * `useFolders()` on the manager side to persist.
  */
 
-import React, { useMemo, useState } from 'react';
+import React, { useMemo, useRef, useState } from 'react';
 import { Folder as FolderIcon, Inbox, ChevronDown } from 'lucide-react';
 import type { LibraryFolder } from '@/types';
 import { FolderPickerPopover } from './FolderPickerPopover';
@@ -36,6 +36,7 @@ export const FolderSelectField: React.FC<FolderSelectFieldProps> = ({
   disabledReason,
 }) => {
   const [pickerOpen, setPickerOpen] = useState(false);
+  const buttonRef = useRef<HTMLButtonElement>(null);
 
   const currentFolder = useMemo(
     () =>
@@ -56,6 +57,7 @@ export const FolderSelectField: React.FC<FolderSelectFieldProps> = ({
         {label}
       </label>
       <button
+        ref={buttonRef}
         type="button"
         disabled={disabled}
         onClick={() => setPickerOpen(true)}
@@ -73,7 +75,8 @@ export const FolderSelectField: React.FC<FolderSelectFieldProps> = ({
 
       {pickerOpen && (
         <FolderPickerPopover
-          variant="dialog"
+          variant="popover"
+          anchorRef={buttonRef}
           folders={folders}
           selectedFolderId={value}
           onSelect={onChange}

--- a/components/common/library/LibraryDndContext.tsx
+++ b/components/common/library/LibraryDndContext.tsx
@@ -32,6 +32,7 @@ import {
   type DragStartEvent,
 } from '@dnd-kit/core';
 import { sortableKeyboardCoordinates } from '@dnd-kit/sortable';
+import { snapCenterToCursor } from '@dnd-kit/modifiers';
 import { LibraryGridLockContext } from './LibraryGridLockContext';
 import {
   folderAwareCollisionDetection,
@@ -125,7 +126,7 @@ export const LibraryDndContext: React.FC<LibraryDndContextProps> = ({
       onDragCancel={handleDragCancel}
     >
       {children}
-      <DragOverlay>
+      <DragOverlay modifiers={[snapCenterToCursor]}>
         {activeId != null && renderOverlay ? (
           <LibraryGridLockContext.Provider value={overlayLockState}>
             {renderOverlay(activeId)}

--- a/components/common/library/LibraryGrid.tsx
+++ b/components/common/library/LibraryGrid.tsx
@@ -37,6 +37,7 @@ import {
   sortableKeyboardCoordinates,
   verticalListSortingStrategy,
 } from '@dnd-kit/sortable';
+import { snapCenterToCursor } from '@dnd-kit/modifiers';
 import type { LibraryGridProps } from './types';
 import { LibraryGridLockContext } from './LibraryGridLockContext';
 
@@ -178,7 +179,7 @@ export function LibraryGrid<TItem>(
             {items.map((item, index) => renderCard(item, index))}
           </div>
         </SortableContext>
-        <DragOverlay>
+        <DragOverlay modifiers={[snapCenterToCursor]}>
           {activeItem != null ? (
             <LibraryGridLockContext.Provider
               value={{ locked: false, reason: undefined, dragDisabled: true }}

--- a/components/common/library/LibraryItemCard.tsx
+++ b/components/common/library/LibraryItemCard.tsx
@@ -17,7 +17,8 @@
  * hint as the drag-handle tooltip at reduced opacity.
  */
 
-import React, { useContext, useRef, useState } from 'react';
+import React, { useContext, useLayoutEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 import { Check, GripVertical, MoreHorizontal } from 'lucide-react';
@@ -62,11 +63,43 @@ interface OverflowMenuProps {
   actions: LibraryMenuAction[];
 }
 
+const MENU_WIDTH = 176;
+const MENU_GAP = 4;
+
 const OverflowMenu: React.FC<OverflowMenuProps> = ({ actions }) => {
   const [open, setOpen] = useState(false);
+  const [menuPos, setMenuPos] = useState<{ top: number; left: number } | null>(
+    null
+  );
   const ref = useRef<HTMLDivElement>(null);
+  const buttonRef = useRef<HTMLButtonElement>(null);
 
   useClickOutside(ref, () => setOpen(false));
+
+  useLayoutEffect(() => {
+    if (!open || !buttonRef.current) return;
+    const rect = buttonRef.current.getBoundingClientRect();
+    const viewportW =
+      typeof window !== 'undefined' ? window.innerWidth : rect.right;
+    // Right-align menu to the trigger, clamped to viewport.
+    const left = Math.max(
+      8,
+      Math.min(rect.right - MENU_WIDTH, viewportW - MENU_WIDTH - 8)
+    );
+    setMenuPos({ top: rect.bottom + MENU_GAP, left });
+  }, [open]);
+
+  useLayoutEffect(() => {
+    if (!open) return;
+    const close = () => setOpen(false);
+    window.addEventListener('resize', close);
+    // Capture phase catches scrolls on any ancestor scroll container.
+    window.addEventListener('scroll', close, true);
+    return () => {
+      window.removeEventListener('resize', close);
+      window.removeEventListener('scroll', close, true);
+    };
+  }, [open]);
 
   if (actions.length === 0) return null;
 
@@ -76,9 +109,55 @@ const OverflowMenu: React.FC<OverflowMenuProps> = ({ actions }) => {
     return a.destructive ? 1 : -1;
   });
 
+  const menu =
+    open && menuPos
+      ? createPortal(
+          <div
+            role="menu"
+            data-click-outside-ignore="true"
+            className="min-w-[176px] overflow-hidden rounded-xl border border-slate-200 bg-white py-1 text-sm shadow-lg"
+            style={{
+              position: 'fixed',
+              top: menuPos.top,
+              left: menuPos.left,
+              width: MENU_WIDTH,
+              zIndex: Z_INDEX.popover,
+            }}
+          >
+            {ordered.map((item) => {
+              const Icon = item.icon;
+              return (
+                <button
+                  key={item.id}
+                  role="menuitem"
+                  type="button"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    setOpen(false);
+                    if (!item.disabled) item.onClick();
+                  }}
+                  disabled={item.disabled}
+                  title={item.disabled ? item.disabledReason : undefined}
+                  className={`flex w-full items-center gap-2 px-3 py-1.5 text-left font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-40 ${
+                    item.destructive
+                      ? 'text-brand-red-dark hover:bg-brand-red-lighter/30'
+                      : 'text-slate-700 hover:bg-slate-100'
+                  }`}
+                >
+                  {Icon && <Icon size={14} className="shrink-0" />}
+                  <span className="truncate">{item.label}</span>
+                </button>
+              );
+            })}
+          </div>,
+          document.body
+        )
+      : null;
+
   return (
     <div ref={ref} className="relative">
       <button
+        ref={buttonRef}
         type="button"
         onClick={(e) => {
           e.stopPropagation();
@@ -101,38 +180,7 @@ const OverflowMenu: React.FC<OverflowMenuProps> = ({ actions }) => {
           }}
         />
       </button>
-      {open && (
-        <div
-          role="menu"
-          className="absolute right-0 top-full z-50 mt-1 min-w-[176px] overflow-hidden rounded-xl border border-slate-200 bg-white py-1 text-sm shadow-lg"
-        >
-          {ordered.map((item) => {
-            const Icon = item.icon;
-            return (
-              <button
-                key={item.id}
-                role="menuitem"
-                type="button"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  setOpen(false);
-                  if (!item.disabled) item.onClick();
-                }}
-                disabled={item.disabled}
-                title={item.disabled ? item.disabledReason : undefined}
-                className={`flex w-full items-center gap-2 px-3 py-1.5 text-left font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-40 ${
-                  item.destructive
-                    ? 'text-brand-red-dark hover:bg-brand-red-lighter/30'
-                    : 'text-slate-700 hover:bg-slate-100'
-                }`}
-              >
-                {Icon && <Icon size={14} className="shrink-0" />}
-                <span className="truncate">{item.label}</span>
-              </button>
-            );
-          })}
-        </div>
-      )}
+      {menu}
     </div>
   );
 };

--- a/components/common/library/LibraryShell.tsx
+++ b/components/common/library/LibraryShell.tsx
@@ -371,7 +371,7 @@ export const LibraryShell: React.FC<LibraryShellProps> = ({
           >
             <button
               type="button"
-              onClick={() => setFolderPanelSetting('rail')}
+              onClick={() => setFolderPanelSetting('full')}
               className="inline-flex items-center justify-center rounded-lg text-slate-500 transition-colors hover:bg-white/70 hover:text-brand-blue-primary"
               style={{
                 width: 'min(28px, 7cqmin)',

--- a/components/common/library/LibraryShell.tsx
+++ b/components/common/library/LibraryShell.tsx
@@ -338,21 +338,12 @@ export const LibraryShell: React.FC<LibraryShellProps> = ({
                   }
                   aria-label="Toggle folder panel"
                 >
-                  {effectiveFolderPanelMode === 'full' ? (
-                    <ChevronsLeft
-                      style={{
-                        width: 'min(16px, 4.5cqmin)',
-                        height: 'min(16px, 4.5cqmin)',
-                      }}
-                    />
-                  ) : (
-                    <ChevronsRight
-                      style={{
-                        width: 'min(16px, 4.5cqmin)',
-                        height: 'min(16px, 4.5cqmin)',
-                      }}
-                    />
-                  )}
+                  <ChevronsLeft
+                    style={{
+                      width: 'min(16px, 4.5cqmin)',
+                      height: 'min(16px, 4.5cqmin)',
+                    }}
+                  />
                 </button>
               </div>
               <div className="flex-1 min-h-0 overflow-y-auto">

--- a/components/widgets/QuizWidget/Widget.tsx
+++ b/components/widgets/QuizWidget/Widget.tsx
@@ -694,12 +694,11 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
             updateWidget(widget.id, {
               config: {
                 ...config,
-                view: 'monitor',
+                view: 'manager',
                 managerTab: 'active',
                 selectedQuizId: meta.id,
                 selectedQuizTitle: meta.title,
                 activeAssignmentId: assignmentId,
-                activeLiveSessionCode: code,
                 plcMode: plcOptions.plcMode,
                 teacherName: plcOptions.teacherName ?? '',
                 periodName:
@@ -1090,7 +1089,11 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
         isOpen={!!editingQuiz}
         quiz={editingQuiz}
         folders={editingMeta ? quizFolders : undefined}
-        folderId={editingMeta?.folderId ?? null}
+        folderId={
+          editingMeta
+            ? (quizzes.find((q) => q.id === editingMeta.id)?.folderId ?? null)
+            : null
+        }
         onFolderChange={
           editingMeta
             ? async (folderId) => {


### PR DESCRIPTION
## Summary

Addresses seven papercuts reported after PR #1369 (folder/grid/bulk-select) on the Quiz widget library:

1. **Post-assign redirect** — Assigning a quiz lands on the IN PROGRESS tab (paused session with Start button) instead of jumping to the monitor view.
2. **Drag preview offset** — `DragOverlay` now snaps to the cursor via `snapCenterToCursor`, bypassing `DraggableWindow`'s `will-change:transform` containing-block trap. Precedent: `LunchCount/Widget.tsx`.
3. **Kebab popout clipped** — The card overflow menu is portaled to `document.body` at `Z_INDEX.popover`, with window scroll/resize closing it. No longer clipped by `DraggableWindow`'s `overflow:hidden`, and layers above neighboring cards.
4. **Kebab click-away** — Fixed as a side-effect of #3; the portaled menu honors `data-click-outside-ignore` so `useClickOutside` keeps working.
5. **Folder selector as modal** — `FolderPickerPopover` gained a portaled popover mode (fixed-position, anchored to trigger ref, `Z_INDEX.modalNestedContent`) so the field inside the editor opens as a dropdown, not a centered dialog. Plus a stale-display fix: `folderId` is now derived from the live `quizzes` list each render so the field updates immediately after `moveQuizItem`.
6. **Native select dark flash** — `EditorModalShell` forces `colorScheme: 'light'` so `<select>` dropdowns stop flashing dark in OS dark mode. One line, covers every descendant form control.
7. **Sidebar collapse chevron UX** —
   - Clicking the collapsed `>>` button now expands directly to **full** mode (was going to rail, which looked nearly identical to hidden, so users reported the sidebar "didn't pop back open").
   - Rail mode's chevron now points `<<` (collapse direction) instead of `>>` (which falsely implied expansion but actually cycled to hidden).

## Test plan

- [ ] Assign a new quiz → lands on IN PROGRESS tab with Start button, not monitor view
- [ ] Drag a card in list & grid views → drag preview centered on cursor; dropping on folder works
- [ ] Click ⋯ on a card near the widget edge → menu fully visible, not clipped
- [ ] Open kebab menu → click dashboard/other widget → menu closes
- [ ] Edit a quiz → click Folder field → dropdown anchored below button (not centered modal); picking a folder updates the field immediately
- [ ] OS dark mode + edit quiz → open Question Type select → options render light, no black flash
- [ ] Collapse sidebar to hidden → click `>>` → expands straight to full with folder labels
- [ ] Full sidebar → click `<<` → rail; click `<<` again → hidden; click `>>` → full

🤖 Generated with [Claude Code](https://claude.com/claude-code)