### PR TITLE
fix(org): kebab popover z-index + real last-active from Auth metadata

### DIFF
--- a/components/admin/Organization/components/primitives.tsx
+++ b/components/admin/Organization/components/primitives.tsx
@@ -509,7 +509,7 @@ export const RowMenu: React.FC<{ items: MenuItem[]; label?: string }> = ({
             ref={menuRef}
             role="menu"
             style={{ position: 'fixed', top: pos.top, right: pos.right }}
-            className="z-dropdown min-w-[200px] bg-white rounded-xl shadow-[0_10px_15px_-3px_rgba(29,42,93,.12),0_4px_6px_-4px_rgba(29,42,93,.08)] border border-slate-200 py-1"
+            className="z-popover min-w-[200px] bg-white rounded-xl shadow-[0_10px_15px_-3px_rgba(29,42,93,.12),0_4px_6px_-4px_rgba(29,42,93,.08)] border border-slate-200 py-1"
             onClick={(e) => e.stopPropagation()}
           >
             {items.map((item, i) => (

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -21,6 +21,7 @@ export {
 export { organizationMembersSync } from './organizationMembersSync';
 export { organizationMemberCounters } from './organizationMemberCounters';
 export { resetOrganizationUserPassword } from './organizationResetPassword';
+export { getOrgUserActivity } from './organizationUserActivity';
 
 setGlobalOptions({ region: 'us-central1' });
 

--- a/functions/src/organizationUserActivity.test.ts
+++ b/functions/src/organizationUserActivity.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('firebase-admin', () => {
+  return {
+    apps: [{ name: '[DEFAULT]' }],
+    initializeApp: vi.fn(),
+    firestore: vi.fn(() => ({})),
+    auth: vi.fn(() => ({
+      getUsers: vi.fn(),
+    })),
+  };
+});
+
+vi.mock('firebase-functions/v2/https', () => {
+  class HttpsError extends Error {
+    code: string;
+    constructor(code: string, message: string) {
+      super(message);
+      this.code = code;
+      this.name = 'HttpsError';
+    }
+  }
+  return {
+    onCall: (_options: unknown, handler: unknown) => handler,
+    HttpsError,
+  };
+});
+
+import { getOrgUserActivity } from './organizationUserActivity';
+
+type CallableHandler = (request: {
+  auth?: { uid: string; token: { email?: string } };
+  data: unknown;
+}) => Promise<unknown>;
+
+const handler = getOrgUserActivity as unknown as CallableHandler;
+
+describe('getOrgUserActivity — input validation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('rejects unauthenticated callers', async () => {
+    await expect(handler({ data: { orgId: 'orono' } })).rejects.toMatchObject({
+      code: 'unauthenticated',
+    });
+  });
+
+  it('rejects callers without an email claim', async () => {
+    await expect(
+      handler({
+        auth: { uid: 'uid1', token: {} },
+        data: { orgId: 'orono' },
+      })
+    ).rejects.toMatchObject({ code: 'invalid-argument' });
+  });
+
+  it('rejects payloads missing orgId', async () => {
+    await expect(
+      handler({
+        auth: { uid: 'uid1', token: { email: 'admin@orono.k12.mn.us' } },
+        data: {},
+      })
+    ).rejects.toMatchObject({ code: 'invalid-argument' });
+  });
+
+  it('rejects non-object payloads', async () => {
+    await expect(
+      handler({
+        auth: { uid: 'uid1', token: { email: 'admin@orono.k12.mn.us' } },
+        data: 'not-an-object',
+      })
+    ).rejects.toMatchObject({ code: 'invalid-argument' });
+  });
+});

--- a/functions/src/organizationUserActivity.ts
+++ b/functions/src/organizationUserActivity.ts
@@ -1,0 +1,179 @@
+/**
+ * Org-scoped "Last active" lookup.
+ *
+ * Returns `{ email → lastSignInMs | null }` for every member of an organization
+ * by batch-reading `admin.auth().getUsers()` metadata. This is the same signal
+ * the Analytics page uses (Firebase Auth `lastSignInTime`), projected through
+ * the org's member list so the Users tab can render an accurate "Last active"
+ * column for every row — not just the currently signed-in user.
+ *
+ * Why a callable instead of a client read: Firebase Auth metadata is only
+ * reachable via the Admin SDK, so we need the function tier. The callable is
+ * scoped to a single orgId and gated on the caller being an admin-tier member
+ * of that org.
+ */
+import { onCall, HttpsError } from 'firebase-functions/v2/https';
+import * as admin from 'firebase-admin';
+import { type MemberRecord } from './organizationInvites';
+
+if (!admin.apps.length) {
+  admin.initializeApp();
+}
+
+export interface OrgUserActivityPayload {
+  orgId: string;
+}
+
+export interface OrgUserActivityEntry {
+  email: string;
+  lastActiveMs: number | null;
+}
+
+export interface OrgUserActivityResponse {
+  activity: OrgUserActivityEntry[];
+}
+
+// Admin-tier roles that can view the org's member activity. Broader than the
+// invite/reset-password admin set (super + domain only) because building admins
+// can already read the members list today — exposing `lastActive` to them is
+// not a new information leak, it's just filling in the column.
+const ACTIVITY_ROLE_IDS: readonly string[] = [
+  'super_admin',
+  'domain_admin',
+  'building_admin',
+];
+
+// `admin.auth().getUsers()` caps each call at 100 identifiers.
+const AUTH_LOOKUP_BATCH = 100;
+
+function parsePayload(data: unknown): OrgUserActivityPayload {
+  if (!data || typeof data !== 'object') {
+    throw new HttpsError('invalid-argument', 'Payload must be an object.');
+  }
+  const raw = data as Record<string, unknown>;
+  const orgId = typeof raw.orgId === 'string' ? raw.orgId.trim() : '';
+  if (!orgId) throw new HttpsError('invalid-argument', 'orgId is required.');
+  return { orgId };
+}
+
+async function assertCallerIsAdminMember(
+  db: admin.firestore.Firestore,
+  orgId: string,
+  callerEmailLower: string
+): Promise<void> {
+  const snap = await db
+    .collection('organizations')
+    .doc(orgId)
+    .collection('members')
+    .doc(callerEmailLower)
+    .get();
+  if (!snap.exists) {
+    throw new HttpsError(
+      'permission-denied',
+      'Caller is not a member of this organization.'
+    );
+  }
+  const data = snap.data() as MemberRecord;
+  if (!ACTIVITY_ROLE_IDS.includes(data.roleId)) {
+    throw new HttpsError(
+      'permission-denied',
+      'Caller does not have permission to view member activity.'
+    );
+  }
+}
+
+async function listMemberEmails(
+  db: admin.firestore.Firestore,
+  orgId: string
+): Promise<string[]> {
+  const snap = await db
+    .collection('organizations')
+    .doc(orgId)
+    .collection('members')
+    .select() // doc ids only — we don't need the member body here
+    .get();
+  return snap.docs.map((d) => d.id);
+}
+
+function chunk<T>(items: T[], size: number): T[][] {
+  const out: T[][] = [];
+  for (let i = 0; i < items.length; i += size) {
+    out.push(items.slice(i, i + size));
+  }
+  return out;
+}
+
+function parseLastSignIn(metadata: admin.auth.UserMetadata): number | null {
+  const raw = metadata.lastSignInTime;
+  if (!raw) return null;
+  const ms = Date.parse(raw);
+  return Number.isFinite(ms) ? ms : null;
+}
+
+export const getOrgUserActivity = onCall<OrgUserActivityPayload>(
+  { region: 'us-central1' },
+  async (request): Promise<OrgUserActivityResponse> => {
+    if (!request.auth) {
+      throw new HttpsError(
+        'unauthenticated',
+        'Sign in to view member activity.'
+      );
+    }
+    const callerEmail = request.auth.token.email;
+    if (typeof callerEmail !== 'string' || callerEmail.length === 0) {
+      throw new HttpsError(
+        'invalid-argument',
+        'Caller must have a verified email.'
+      );
+    }
+    const callerEmailLower = callerEmail.toLowerCase();
+
+    const { orgId } = parsePayload(request.data);
+    const db = admin.firestore();
+
+    await assertCallerIsAdminMember(db, orgId, callerEmailLower);
+
+    const emails = await listMemberEmails(db, orgId);
+    if (emails.length === 0) {
+      return { activity: [] };
+    }
+
+    // Populate from Auth in parallel batches. Each getUsers call returns only
+    // users that exist — invited-but-never-signed-in members simply don't
+    // appear, so we initialize the map with null and overwrite as results land.
+    const lastActive = new Map<string, number | null>();
+    for (const email of emails) lastActive.set(email, null);
+
+    const batches = chunk(emails, AUTH_LOOKUP_BATCH);
+    const results = await Promise.all(
+      batches.map((batch) =>
+        admin
+          .auth()
+          .getUsers(batch.map((email) => ({ email })))
+          .catch((err) => {
+            console.error('[getOrgUserActivity] getUsers batch failed:', err);
+            const empty: admin.auth.GetUsersResult = {
+              users: [],
+              notFound: [],
+            };
+            return empty;
+          })
+      )
+    );
+
+    for (const result of results) {
+      for (const user of result.users) {
+        const email = user.email?.toLowerCase();
+        if (!email) continue;
+        if (!lastActive.has(email)) continue;
+        lastActive.set(email, parseLastSignIn(user.metadata));
+      }
+    }
+
+    const activity: OrgUserActivityEntry[] = emails.map((email) => ({
+      email,
+      lastActiveMs: lastActive.get(email) ?? null,
+    }));
+    return { activity };
+  }
+);

--- a/hooks/useOrgMembers.test.ts
+++ b/hooks/useOrgMembers.test.ts
@@ -54,6 +54,7 @@ describe('useOrgMembers', () => {
   const batchUpdate = vi.fn();
   const batchDelete = vi.fn();
   const batchCommit = vi.fn();
+  const mockHttpsCallable = httpsCallable as Mock;
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -70,6 +71,11 @@ describe('useOrgMembers', () => {
       delete: batchDelete,
       commit: batchCommit,
     });
+    // Default: any callable resolves with an empty activity payload. Tests that
+    // exercise a specific callable (e.g. bulkInviteMembers) override this.
+    mockHttpsCallable.mockReturnValue(
+      vi.fn().mockResolvedValue({ data: { activity: [] } })
+    );
   });
 
   it('skips subscription when orgId is null', () => {
@@ -285,12 +291,16 @@ describe('useOrgMembers', () => {
   it('bulkInviteMembers short-circuits on empty intent list without calling the CF', async () => {
     mockUseAuth.mockReturnValue({ user: { uid: 'u' } });
     mockOnSnapshot.mockReturnValue(() => undefined);
-    const mockCallable = vi.fn();
-    (httpsCallable as Mock).mockReturnValue(mockCallable);
+    const inviteCallable = vi.fn();
+    mockHttpsCallable.mockImplementation((_fns: unknown, name: string) =>
+      name === 'createOrganizationInvites'
+        ? inviteCallable
+        : vi.fn().mockResolvedValue({ data: { activity: [] } })
+    );
 
     const { result } = renderHook(() => useOrgMembers('orono'));
     const response = await result.current.bulkInviteMembers([]);
-    expect(mockCallable).not.toHaveBeenCalled();
+    expect(inviteCallable).not.toHaveBeenCalled();
     expect(response).toEqual({ invitations: [], errors: [] });
   });
 

--- a/hooks/useOrgMembers.ts
+++ b/hooks/useOrgMembers.ts
@@ -85,17 +85,31 @@ const nameFromEmail = (email: string): string => {
     .trim();
 };
 
-const toUserRecord = (m: MemberRecord, orgId: string): UserRecord => ({
-  id: m.email,
-  orgId,
-  name: m.name ?? nameFromEmail(m.email),
-  email: m.email,
-  role: m.roleId,
-  buildingIds: m.buildingIds ?? [],
-  status: m.status,
-  lastActive: m.lastActive ?? null,
-  invitedAt: m.invitedAt,
-});
+const toUserRecord = (
+  m: MemberRecord,
+  orgId: string,
+  activityMs: number | null | undefined
+): UserRecord => {
+  // Prefer the Firebase Auth metadata signal (fetched via getOrgUserActivity)
+  // over the denormalized member.lastActive — the Auth metadata is populated
+  // on every sign-in for every user, while the member doc is only stamped for
+  // the currently signed-in user via AuthContext.
+  const lastActive =
+    activityMs != null
+      ? new Date(activityMs).toISOString()
+      : (m.lastActive ?? null);
+  return {
+    id: m.email,
+    orgId,
+    name: m.name ?? nameFromEmail(m.email),
+    email: m.email,
+    role: m.roleId,
+    buildingIds: m.buildingIds ?? [],
+    status: m.status,
+    lastActive,
+    invitedAt: m.invitedAt,
+  };
+};
 
 // Translate a `UserRecord` patch from the UI into the underlying
 // `MemberRecord` field names. `role` (UI) ↔ `roleId` (schema); identity
@@ -129,6 +143,12 @@ export const useOrgMembers = (orgId: string | null) => {
   const { user } = useAuth();
   const [members, setMembers] = useState<MemberRecord[]>([]);
   const [error, setError] = useState<Error | null>(null);
+  // Map of emailLower → Auth metadata lastSignInMs (null for invited-never-
+  // signed-in members). Fetched once per org via `getOrgUserActivity` since
+  // Firebase Auth metadata isn't reachable from the client without Admin SDK.
+  const [activityMs, setActivityMs] = useState<Map<string, number | null>>(
+    () => new Map()
+  );
 
   const shouldSubscribe = !isAuthBypass && Boolean(user) && Boolean(orgId);
   const [loading, setLoading] = useState<boolean>(shouldSubscribe);
@@ -138,6 +158,7 @@ export const useOrgMembers = (orgId: string | null) => {
   if (prevKey !== nextKey) {
     setPrevKey(nextKey);
     setLoading(shouldSubscribe);
+    setActivityMs(new Map());
     if (!shouldSubscribe) {
       setMembers([]);
       setError(null);
@@ -166,9 +187,40 @@ export const useOrgMembers = (orgId: string | null) => {
     return unsub;
   }, [shouldSubscribe, orgId]);
 
+  // Fetch Auth-metadata-backed activity once per org. Failures fall back to
+  // the denormalized member.lastActive field (only populated for the current
+  // user today), so a denied or erroring callable still renders "—" for
+  // everyone else rather than blocking the Users tab.
+  useEffect(() => {
+    if (!shouldSubscribe || !orgId) return;
+    let cancelled = false;
+    const callable = httpsCallable<
+      { orgId: string },
+      { activity: { email: string; lastActiveMs: number | null }[] }
+    >(functions, 'getOrgUserActivity');
+    callable({ orgId })
+      .then((result) => {
+        if (cancelled) return;
+        const next = new Map<string, number | null>();
+        for (const entry of result.data.activity) {
+          next.set(entry.email.toLowerCase(), entry.lastActiveMs);
+        }
+        setActivityMs(next);
+      })
+      .catch((err) => {
+        console.error(`[useOrgMembers:${orgId}] getOrgUserActivity:`, err);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [shouldSubscribe, orgId]);
+
   const users = useMemo<UserRecord[]>(
-    () => (orgId ? members.map((m) => toUserRecord(m, orgId)) : []),
-    [members, orgId]
+    () =>
+      orgId
+        ? members.map((m) => toUserRecord(m, orgId, activityMs.get(m.email)))
+        : [],
+    [members, orgId, activityMs]
   );
 
   const updateMember = async (


### PR DESCRIPTION
## Summary

Follow-ups to [#1373](https://github.com/OPS-PIvers/SpartBoard/pull/1373) addressing two bugs the user reported after deploy:

- **Kebab popover didn't open.** `RowMenu`'s portaled popover was rendering at `z-dropdown` (110), but `AdminSettings` sits at `z-modal` (10000), so the menu opened *behind* the modal. Bumped to `z-popover` (11000) to match `CellPopover` in the same file.
- **"Last active" only showed for the signed-in user.** The previous client-side stamp can only write the caller's own member doc (per firestore.rules), so every other row stayed blank. Added a new `getOrgUserActivity` callable that reads `lastSignInTime` from Firebase Auth via the Admin SDK — the same source Analytics uses — and projects it across the org's members. Wired into `useOrgMembers` so `UserRecord.lastActive` prefers Auth metadata when available.

## Test plan

- [ ] Sign in as a domain admin → open Admin Settings → Organization → Users tab
- [ ] Click the kebab on any row → menu now appears above the modal
- [ ] "Last active" column shows real timestamps for users with recent sign-ins, not just the current user
- [ ] Values match what Analytics reports for the same users
- [ ] `pnpm run type-check` clean (root + functions)
- [ ] `pnpm run lint` clean
- [ ] Function unit tests pass (9/9 in functions, including 4 new input-validation tests for `getOrgUserActivity`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)