### PR TITLE
fix(admin): scope analytics to org + sync buildings counter

### DIFF
--- a/components/admin/Analytics/AnalyticsManager.tsx
+++ b/components/admin/Analytics/AnalyticsManager.tsx
@@ -1375,6 +1375,11 @@ export const AnalyticsManager: React.FC = () => {
     if (!orgId) {
       // Org membership hasn't resolved yet; skip the request rather than
       // firing one that the backend would reject for missing org scope.
+      // Clear the initial loading flag so the UI shows an empty state instead
+      // of a permanent spinner for users who don't have an active org.
+      if (isMountedRef.current) {
+        setLoading(false);
+      }
       return;
     }
     const requestId = requestSequenceRef.current + 1;

--- a/components/admin/Analytics/AnalyticsManager.tsx
+++ b/components/admin/Analytics/AnalyticsManager.tsx
@@ -1377,6 +1377,11 @@ export const AnalyticsManager: React.FC = () => {
       // explicit message rather than a permanent spinner or a blank page. This
       // also handles the case where `orgId` flips back to null after a prior
       // successful load (e.g., the user is removed from the org).
+      //
+      // Bump the request sequence before clearing state so any in-flight
+      // response from a prior org fails its `requestId === requestSequenceRef`
+      // guard and cannot overwrite the cleared state with stale analytics.
+      requestSequenceRef.current += 1;
       if (isMountedRef.current) {
         setLoading(false);
         setData(null);

--- a/components/admin/Analytics/AnalyticsManager.tsx
+++ b/components/admin/Analytics/AnalyticsManager.tsx
@@ -35,6 +35,7 @@ import {
 } from 'lucide-react';
 import { Modal } from '@/components/common/Modal';
 import { useAdminBuildings } from '@/hooks/useAdminBuildings';
+import { useAuth } from '@/context/useAuth';
 import type { Building } from '@/config/buildings';
 import { TOOLS } from '@/config/tools';
 
@@ -1350,6 +1351,7 @@ const DataTable: React.FC<{
 
 export const AnalyticsManager: React.FC = () => {
   const KNOWN_BUILDINGS = useKnownBuildings();
+  const { orgId } = useAuth();
   const [loading, setLoading] = useState(true);
   const [data, setData] = useState<AnalyticsData | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -1370,6 +1372,11 @@ export const AnalyticsManager: React.FC = () => {
   }, []);
 
   const fetchAnalytics = useCallback(async () => {
+    if (!orgId) {
+      // Org membership hasn't resolved yet; skip the request rather than
+      // firing one that the backend would reject for missing org scope.
+      return;
+    }
     const requestId = requestSequenceRef.current + 1;
     requestSequenceRef.current = requestId;
 
@@ -1387,7 +1394,7 @@ export const AnalyticsManager: React.FC = () => {
           'Content-Type': 'application/json',
           Authorization: `Bearer ${token}`,
         },
-        body: JSON.stringify({}),
+        body: JSON.stringify({ orgId }),
       });
 
       if (!response.ok) {
@@ -1450,7 +1457,7 @@ export const AnalyticsManager: React.FC = () => {
         setLoading(false);
       }
     }
-  }, []);
+  }, [orgId]);
 
   useEffect(() => {
     void fetchAnalytics();

--- a/components/admin/Analytics/AnalyticsManager.tsx
+++ b/components/admin/Analytics/AnalyticsManager.tsx
@@ -1373,12 +1373,16 @@ export const AnalyticsManager: React.FC = () => {
 
   const fetchAnalytics = useCallback(async () => {
     if (!orgId) {
-      // Org membership hasn't resolved yet; skip the request rather than
-      // firing one that the backend would reject for missing org scope.
-      // Clear the initial loading flag so the UI shows an empty state instead
-      // of a permanent spinner for users who don't have an active org.
+      // No active org: clear any stale data from a previous org and surface an
+      // explicit message rather than a permanent spinner or a blank page. This
+      // also handles the case where `orgId` flips back to null after a prior
+      // successful load (e.g., the user is removed from the org).
       if (isMountedRef.current) {
         setLoading(false);
+        setData(null);
+        setError(
+          'No organization selected. Analytics require an active organization.'
+        );
       }
       return;
     }

--- a/functions/src/index.test.ts
+++ b/functions/src/index.test.ts
@@ -878,4 +878,63 @@ describe('adminAnalytics', () => {
     expect(capturedData.api.totalCalls).toBe(5);
     /* eslint-enable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-call */
   });
+
+  it('returns 400 when orgId is missing from the request body', async () => {
+    /* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-call */
+    const statusSpy = vi.fn().mockReturnThis();
+    const jsonSpy = vi.fn().mockReturnThis();
+    const mockRes = {
+      status: statusSpy,
+      json: jsonSpy,
+      setHeader: vi.fn().mockReturnThis(),
+      getHeader: vi.fn().mockReturnValue(''),
+    };
+
+    const mockReq = {
+      headers: {
+        origin: 'http://localhost',
+        authorization: 'Bearer mock-token',
+      },
+      body: {},
+    };
+
+    await (adminAnalytics as any)(mockReq, mockRes);
+
+    expect(statusSpy).toHaveBeenCalledWith(400);
+    expect(jsonSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ error: 'invalid-argument' })
+    );
+    /* eslint-enable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-call */
+  });
+
+  it('returns 403 when caller is neither super admin nor an org admin', async () => {
+    // No /admins entry and no member doc for this caller → denied.
+    mockFirestoreState.admins = new Set<string>();
+
+    /* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-call */
+    const statusSpy = vi.fn().mockReturnThis();
+    const jsonSpy = vi.fn().mockReturnThis();
+    const mockRes = {
+      status: statusSpy,
+      json: jsonSpy,
+      setHeader: vi.fn().mockReturnThis(),
+      getHeader: vi.fn().mockReturnValue(''),
+    };
+
+    const mockReq = {
+      headers: {
+        origin: 'http://localhost',
+        authorization: 'Bearer mock-token',
+      },
+      body: { orgId: 'orono' },
+    };
+
+    await (adminAnalytics as any)(mockReq, mockRes);
+
+    expect(statusSpy).toHaveBeenCalledWith(403);
+    expect(jsonSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ error: 'permission-denied' })
+    );
+    /* eslint-enable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-call */
+  });
 });

--- a/functions/src/index.test.ts
+++ b/functions/src/index.test.ts
@@ -49,26 +49,7 @@ const mockFirestore = {
   })),
   getAll: vi.fn((...refs: MockDocRef[]) => {
     return Promise.resolve(
-      refs.map((ref) => {
-        // Expected path: users/{uid}/userProfile/profile
-        const parts = ref.path.split('/');
-        const uid = parts[1];
-        const user = mockFirestoreState.users.find((u) => u.id === uid);
-        if (user) {
-          return {
-            exists: true,
-            data: () => ({
-              selectedBuildings: user.data.buildings,
-            }),
-            ref: {
-              parent: {
-                parent: { id: uid },
-              },
-            },
-          };
-        }
-        return { exists: false, data: () => ({}) };
-      })
+      refs.map(() => ({ exists: false, data: () => ({}) }))
     );
   }),
   collection: vi.fn((name: string) => {
@@ -79,6 +60,28 @@ const mockFirestore = {
             Promise.resolve({ exists: mockFirestoreState.admins.has(id) })
           ),
         })),
+      };
+    }
+
+    // Members collection for org-scoped analytics. Each `mockFirestoreState.users`
+    // entry represents a member of the org with `id` as their uid, `email` as
+    // their member email, and `buildings` as their admin-assigned buildingIds.
+    if (name.startsWith('organizations/') && name.endsWith('/members')) {
+      return {
+        get: vi.fn(() =>
+          Promise.resolve({
+            docs: mockFirestoreState.users
+              .filter((u) => !u.anonymous)
+              .map((u) => ({
+                id: (u.data.email as string | undefined) ?? u.id,
+                data: () => ({
+                  email: u.data.email,
+                  uid: u.id,
+                  buildingIds: u.data.buildings ?? [],
+                }),
+              })),
+          })
+        ),
       };
     }
 
@@ -177,6 +180,11 @@ vi.mock('firebase-admin', () => {
           .map((u) => ({
             uid: u.id,
             email: u.anonymous ? undefined : (u.data.email as string),
+            metadata: {
+              lastSignInTime: u.data.lastLogin
+                ? new Date(u.data.lastLogin as number).toISOString()
+                : undefined,
+            },
           }));
         return Promise.resolve({ users });
       }),
@@ -537,6 +545,7 @@ describe('adminAnalytics', () => {
           origin: 'http://localhost',
           authorization: 'Bearer mock-token',
         },
+        body: { orgId: 'orono' },
       };
 
       (handler as any)(mockReq, mockRes);
@@ -614,6 +623,7 @@ describe('adminAnalytics', () => {
           origin: 'http://localhost',
           authorization: 'Bearer mock-token',
         },
+        body: { orgId: 'orono' },
       };
 
       (handler as any)(mockReq, mockRes);
@@ -698,6 +708,7 @@ describe('adminAnalytics', () => {
           origin: 'http://localhost',
           authorization: 'Bearer mock-token',
         },
+        body: { orgId: 'orono' },
       };
       (adminAnalytics as any)(mockReq, mockRes);
     });
@@ -755,6 +766,7 @@ describe('adminAnalytics', () => {
           origin: 'http://localhost',
           authorization: 'Bearer mock-token',
         },
+        body: { orgId: 'orono' },
       };
       (adminAnalytics as any)(mockReq, mockRes);
     });
@@ -837,6 +849,7 @@ describe('adminAnalytics', () => {
           origin: 'http://localhost',
           authorization: 'Bearer mock-token',
         },
+        body: { orgId: 'orono' },
       };
       (adminAnalytics as any)(mockReq, mockRes);
     });

--- a/functions/src/index.test.ts
+++ b/functions/src/index.test.ts
@@ -9,6 +9,22 @@ interface MockDocInput {
   ownerUid?: string;
   /** Optional: when true, simulates an anonymous auth user (no email, no providers) */
   anonymous?: boolean;
+  /**
+   * Optional: when true, the member doc exists (so the user counts toward
+   * totals/domain/building buckets) but carries no `uid` — mirrors a user
+   * who was invited but has never signed in. Engagement (monthly/daily,
+   * lastSignInMs, lastEditMs) is forced to zero for these members.
+   */
+  invited?: boolean;
+  /**
+   * Optional: when true, simulates a signed-in Firebase Auth user who is NOT
+   * a member of the requested org. Their auth account exists (so listUsers /
+   * getUsers still returns them) and their dashboards/AI usage still live
+   * under their uid, but the member doc at
+   * `/organizations/{orgId}/members/{email}` does NOT exist, so they must
+   * be excluded from every analytics metric.
+   */
+  nonMember?: boolean;
 }
 
 const mockFirestoreState = {
@@ -71,12 +87,15 @@ const mockFirestore = {
         get: vi.fn(() =>
           Promise.resolve({
             docs: mockFirestoreState.users
-              .filter((u) => !u.anonymous)
+              .filter((u) => !u.anonymous && !u.nonMember)
               .map((u) => ({
                 id: (u.data.email as string | undefined) ?? u.id,
                 data: () => ({
                   email: u.data.email,
-                  uid: u.id,
+                  // Invited-but-never-signed-in members have no uid on the
+                  // member doc. Production treats a non-string `uid` as null
+                  // and skips engagement for them.
+                  uid: u.invited ? null : u.id,
                   buildingIds: u.data.buildings ?? [],
                 }),
               })),
@@ -879,14 +898,248 @@ describe('adminAnalytics', () => {
     /* eslint-enable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-call */
   });
 
+  it('excludes signed-in auth users who are not members of the requested org', async () => {
+    // Tenant-isolation contract: membership is determined by the presence of
+    // a member doc at `/organizations/{orgId}/members/{email}`, NOT by the
+    // user's email domain or the existence of a Firebase Auth account. A
+    // signed-in user must not leak into analytics just because they:
+    //   (a) belong to a different org (foreign domain), OR
+    //   (b) share an approved domain with real members but were never invited
+    //       (e.g., signed in via Google SSO, got an auth account, created
+    //       some dashboards, but the admin never added them to the roster).
+    // Locks in the fix for the "foreign-domain users leaking into analytics"
+    // bug (PR #1375) and the related "approved-domain but not invited" case.
+    const now = Date.now();
+    mockFirestoreState.users = [
+      // Real org member.
+      {
+        id: 'uid_member',
+        data: {
+          email: 'member@school.org',
+          lastLogin: now - 2 * 60 * 60 * 1000,
+          buildings: ['north'],
+        },
+      },
+      // Case (a): signed-in auth user from a different org — real email,
+      // real uid, real dashboards, but no member doc for this org.
+      {
+        id: 'uid_foreign',
+        nonMember: true,
+        data: {
+          email: 'foreign@other-district.org',
+          lastLogin: now - 1 * 60 * 60 * 1000,
+          buildings: [],
+        },
+      },
+      // Case (b): signed-in auth user whose email domain MATCHES the real
+      // member's domain (e.g., an approved-domain user who SSO'd in but was
+      // never invited). Must still be excluded — domain match alone doesn't
+      // grant org membership.
+      {
+        id: 'uid_uninvited_same_domain',
+        nonMember: true,
+        data: {
+          email: 'uninvited@school.org',
+          lastLogin: now - 30 * 60 * 1000,
+          buildings: [],
+        },
+      },
+    ];
+
+    mockFirestoreState.dashboards = [
+      {
+        id: 'dash-member',
+        ownerUid: 'uid_member',
+        data: { updatedAt: now, widgets: [{ type: 'clock' }] },
+      },
+      {
+        id: 'dash-foreign',
+        ownerUid: 'uid_foreign',
+        data: {
+          updatedAt: now,
+          widgets: [{ type: 'clock' }, { type: 'timer' }],
+        },
+      },
+      {
+        id: 'dash-uninvited',
+        ownerUid: 'uid_uninvited_same_domain',
+        data: {
+          updatedAt: now,
+          widgets: [{ type: 'stopwatch' }],
+        },
+      },
+    ];
+
+    mockFirestoreState.aiUsage = [
+      { id: 'uid_member_2026-03-30', data: { count: 5 } },
+      { id: 'uid_foreign_2026-03-30', data: { count: 99 } },
+      { id: 'uid_uninvited_same_domain_2026-03-30', data: { count: 42 } },
+    ];
+
+    /* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-call */
+    const resPromise = new Promise<any>((resolve) => {
+      const mockRes = {
+        status: vi.fn().mockReturnThis(),
+        json: vi.fn().mockImplementation((data) => {
+          resolve(data);
+          return data;
+        }),
+        setHeader: vi.fn().mockReturnThis(),
+        getHeader: vi.fn().mockReturnValue(''),
+      };
+      const mockReq = {
+        headers: {
+          origin: 'http://localhost',
+          authorization: 'Bearer mock-token',
+        },
+        body: { orgId: 'orono' },
+      };
+      (adminAnalytics as any)(mockReq, mockRes);
+    });
+
+    const capturedData = await resPromise;
+
+    // Only the invited member counts toward totals.
+    expect(capturedData.users.total).toBe(1);
+
+    // Foreign domain must not surface.
+    expect(capturedData.users.domains['other-district.org']).toBeUndefined();
+
+    // Approved-but-uninvited user must not inflate the approved-domain
+    // bucket — the bucket total matches the member roster, not the auth
+    // population that happens to share a domain.
+    expect(capturedData.users.domains['school.org']).toEqual({
+      total: 1,
+      monthly: 1,
+      daily: 1,
+    });
+
+    // Non-member dashboards/AI usage must not leak into totals.
+    expect(capturedData.users.withDashboards).toBe(1);
+    expect(capturedData.dashboards.total).toBe(1);
+    expect(capturedData.api.totalCalls).toBe(5);
+
+    // Non-member widget types must not show up.
+    expect(capturedData.widgets.usersByType.timer).toBeUndefined();
+    expect(capturedData.widgets.usersByType.stopwatch).toBeUndefined();
+    expect(capturedData.widgets.usersByType.clock?.count).toBe(1);
+
+    // Neither non-member may appear in the per-user drilldown.
+    const foreignRow = capturedData.users.userList.find(
+      (u: { email: string }) => u.email === 'foreign@other-district.org'
+    );
+    expect(foreignRow).toBeUndefined();
+    const uninvitedRow = capturedData.users.userList.find(
+      (u: { email: string }) => u.email === 'uninvited@school.org'
+    );
+    expect(uninvitedRow).toBeUndefined();
+    /* eslint-enable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-call */
+  });
+
+  it('counts invited-but-never-signed-in members toward totals with zero engagement', async () => {
+    const now = Date.now();
+    mockFirestoreState.users = [
+      // Active signed-in member with a recent dashboard edit.
+      {
+        id: 'uid_active',
+        data: {
+          email: 'active@district.org',
+          lastLogin: now - 60 * 60 * 1000,
+          buildings: ['north'],
+        },
+      },
+      // Invited member: member doc exists but `uid` is null on the doc,
+      // so there is no Auth metadata to join and no dashboards can be
+      // attributed. Should still count toward total/domain/building.
+      {
+        id: 'uid_invited_unused',
+        data: {
+          email: 'invited@district.org',
+          buildings: ['north'],
+        },
+        invited: true,
+      },
+    ];
+    mockFirestoreState.dashboards = [
+      {
+        id: 'dash-active',
+        ownerUid: 'uid_active',
+        data: {
+          updatedAt: now - 60 * 60 * 1000,
+          widgets: [{ type: 'clock' }],
+        },
+      },
+    ];
+
+    /* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-call */
+    const resPromise = new Promise<any>((resolve) => {
+      const mockRes = {
+        status: vi.fn().mockReturnThis(),
+        json: vi.fn().mockImplementation((data) => {
+          resolve(data);
+          return data;
+        }),
+        setHeader: vi.fn().mockReturnThis(),
+        getHeader: vi.fn().mockReturnValue(''),
+      };
+      const mockReq = {
+        headers: {
+          origin: 'http://localhost',
+          authorization: 'Bearer mock-token',
+        },
+        body: { orgId: 'orono' },
+      };
+      (adminAnalytics as any)(mockReq, mockRes);
+    });
+
+    const capturedData = await resPromise;
+
+    // Totals include the invited member.
+    expect(capturedData.users.total).toBe(2);
+    // Only the active member has a recent edit.
+    expect(capturedData.users.monthly).toBe(1);
+    expect(capturedData.users.daily).toBe(1);
+
+    // Domain bucket: both members share the same domain.
+    expect(capturedData.users.domains['district.org']).toEqual({
+      total: 2,
+      monthly: 1,
+      daily: 1,
+    });
+
+    // Building bucket: both members are assigned to 'north'.
+    expect(capturedData.users.buildings.north).toEqual({
+      total: 2,
+      monthly: 1,
+      daily: 1,
+    });
+
+    // Per-user drilldown: the invited member is present with zero engagement.
+    const invitedRow = capturedData.users.userList.find(
+      (u: { email: string }) => u.email === 'invited@district.org'
+    );
+    expect(invitedRow).toBeDefined();
+    expect(invitedRow.lastSignInMs).toBe(0);
+    expect(invitedRow.lastEditMs).toBe(0);
+    expect(invitedRow.hasDashboard).toBe(false);
+    expect(invitedRow.isMonthlyActive).toBe(false);
+    expect(invitedRow.isDailyActive).toBe(false);
+
+    // Only the active member owns a dashboard.
+    expect(capturedData.users.withDashboards).toBe(1);
+    expect(capturedData.dashboards.total).toBe(1);
+    /* eslint-enable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-call */
+  });
+
   it('returns 400 when orgId is missing from the request body', async () => {
     /* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-call */
     const statusSpy = vi.fn().mockReturnThis();
     const jsonSpy = vi.fn().mockReturnThis();
+    const setHeaderSpy = vi.fn().mockReturnThis();
     const mockRes = {
       status: statusSpy,
       json: jsonSpy,
-      setHeader: vi.fn().mockReturnThis(),
+      setHeader: setHeaderSpy,
       getHeader: vi.fn().mockReturnValue(''),
     };
 
@@ -901,8 +1154,18 @@ describe('adminAnalytics', () => {
     await (adminAnalytics as any)(mockReq, mockRes);
 
     expect(statusSpy).toHaveBeenCalledWith(400);
-    expect(jsonSpy).toHaveBeenCalledWith(
-      expect.objectContaining({ error: 'invalid-argument' })
+    // The error body and X-Request-Id header must carry the same
+    // correlation id so Cloud Logging alerts can be pivoted back to the
+    // exact client-visible response.
+    const jsonCall = jsonSpy.mock.calls[0]?.[0] as
+      | { error?: string; requestId?: string }
+      | undefined;
+    expect(jsonCall?.error).toBe('invalid-argument');
+    expect(typeof jsonCall?.requestId).toBe('string');
+    expect(jsonCall?.requestId?.length ?? 0).toBeGreaterThan(0);
+    expect(setHeaderSpy).toHaveBeenCalledWith(
+      'X-Request-Id',
+      jsonCall?.requestId
     );
     /* eslint-enable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-call */
   });
@@ -914,10 +1177,11 @@ describe('adminAnalytics', () => {
     /* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-call */
     const statusSpy = vi.fn().mockReturnThis();
     const jsonSpy = vi.fn().mockReturnThis();
+    const setHeaderSpy = vi.fn().mockReturnThis();
     const mockRes = {
       status: statusSpy,
       json: jsonSpy,
-      setHeader: vi.fn().mockReturnThis(),
+      setHeader: setHeaderSpy,
       getHeader: vi.fn().mockReturnValue(''),
     };
 
@@ -932,8 +1196,15 @@ describe('adminAnalytics', () => {
     await (adminAnalytics as any)(mockReq, mockRes);
 
     expect(statusSpy).toHaveBeenCalledWith(403);
-    expect(jsonSpy).toHaveBeenCalledWith(
-      expect.objectContaining({ error: 'permission-denied' })
+    const jsonCall = jsonSpy.mock.calls[0]?.[0] as
+      | { error?: string; requestId?: string }
+      | undefined;
+    expect(jsonCall?.error).toBe('permission-denied');
+    expect(typeof jsonCall?.requestId).toBe('string');
+    expect(jsonCall?.requestId?.length ?? 0).toBeGreaterThan(0);
+    expect(setHeaderSpy).toHaveBeenCalledWith(
+      'X-Request-Id',
+      jsonCall?.requestId
     );
     /* eslint-enable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-call */
   });

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -2017,13 +2017,30 @@ export const adminAnalytics = onRequest(
 
     const db = admin.firestore();
 
-    // 2. Verify caller is an admin (super admin in /admins, or a member of
-    // the requested org — org-scoped admins should see their own analytics).
+    // 2. Verify caller is authorized for the requested org. Two paths:
+    //   - Super admin: exists in `/admins/{email}`. May view any org.
+    //   - Org admin: has a member doc at `/organizations/{orgId}/members/{email}`
+    //     whose `roleId` is in the admin-tier set. Mirrors the role gating in
+    //     `assertCallerIsOrgAdmin` (organizationInvites.ts) but also admits
+    //     building_admin, since reading analytics is a lesser privilege than
+    //     inviting members.
+    const ORG_ADMIN_ROLE_IDS = new Set([
+      'super_admin',
+      'domain_admin',
+      'building_admin',
+    ]);
     const [adminDoc, memberDoc] = await Promise.all([
       db.collection('admins').doc(email).get(),
       db.doc(`organizations/${orgId}/members/${email}`).get(),
     ]);
-    if (!adminDoc.exists && !memberDoc.exists) {
+    const memberData = memberDoc.exists
+      ? (memberDoc.data() as { roleId?: unknown })
+      : undefined;
+    const memberRoleId =
+      typeof memberData?.roleId === 'string' ? memberData.roleId.trim() : '';
+    const isSuperAdmin = adminDoc.exists;
+    const isOrgAdmin = memberDoc.exists && ORG_ADMIN_ROLE_IDS.has(memberRoleId);
+    if (!isSuperAdmin && !isOrgAdmin) {
       console.error(
         `[getAdminAnalytics] Unauthorized access: ${email} is not an admin of ${orgId}`
       );
@@ -2101,11 +2118,14 @@ export const adminAnalytics = onRequest(
         }
       }
 
-      // 3b. Build the buildings map from the member record (admin-assigned)
-      // rather than from each user's self-selected `selectedBuildings`
-      // profile field. The member record's `buildingIds` are the authoritative
-      // source and are guaranteed to match live building doc ids, so the
-      // client-side "Unknown (…)" fallbacks disappear.
+      // 3b. Build the buildings map (uid → buildingIds) from the member record
+      // (admin-assigned) rather than from each user's self-selected
+      // `selectedBuildings` profile field. The member record's `buildingIds`
+      // are the authoritative source and are guaranteed to match live building
+      // doc ids, so the client-side "Unknown (…)" fallbacks disappear. Only
+      // members with a resolved `uid` land in the map (widget drilldowns key
+      // off uid); totals/bucketing iterate `members` directly below so invited
+      // users without a uid still count.
       const buildingsMap = new Map<string, string[]>();
       for (const m of members) {
         if (!m.uid) continue;
@@ -2219,11 +2239,18 @@ export const adminAnalytics = onRequest(
         daily: 0,
       };
 
-      for (const [uid, { email: userEmail }] of authUsersMap) {
+      // Iterate the org member roster (not just the auth-resolved subset) so
+      // invited-but-never-signed-in members count toward totals/domain/building
+      // buckets with zero engagement, matching the "totals come from the
+      // member roster; engagement is joined from Auth when available" contract.
+      for (const member of members) {
+        const userEmail = member.email;
         const domain = userEmail.includes('@')
           ? userEmail.split('@')[1]
           : 'unknown';
-        const lastEditMs = lastEditByUser.get(uid) ?? 0;
+        const lastEditMs = member.uid
+          ? (lastEditByUser.get(member.uid) ?? 0)
+          : 0;
         const isMonthlyActive =
           lastEditMs > 0 && now - lastEditMs <= thirtyDaysMs;
         const isDailyActive = lastEditMs > 0 && now - lastEditMs <= oneDayMs;
@@ -2234,7 +2261,7 @@ export const adminAnalytics = onRequest(
 
         increment(usersByDomain, domain, isMonthlyActive, isDailyActive);
 
-        const buildings = buildingsMap.get(uid) ?? [];
+        const buildings = member.buildingIds;
         if (buildings.length === 0) {
           increment(usersByBuilding, 'none', isMonthlyActive, isDailyActive);
           if (!usersByDomainAndBuilding[domain]) {
@@ -2267,21 +2294,26 @@ export const adminAnalytics = onRequest(
         }
       }
 
-      // 4c. Build per-user detail list for KPI drilldowns
-      const userList = Array.from(authUsersMap.entries()).map(
-        ([uid, { email: userEmail, lastSignInMs }]) => {
-          const lastEditMs = lastEditByUser.get(uid) ?? 0;
-          return {
-            email: userEmail,
-            buildings: buildingsMap.get(uid) ?? [],
-            lastSignInMs,
-            lastEditMs,
-            hasDashboard: allDashboardOwnerUids.has(uid),
-            isMonthlyActive: lastEditMs > 0 && now - lastEditMs <= thirtyDaysMs,
-            isDailyActive: lastEditMs > 0 && now - lastEditMs <= oneDayMs,
-          };
-        }
-      );
+      // 4c. Build per-user detail list for KPI drilldowns. Same rule: iterate
+      // the member roster, join Auth metadata when a uid is present.
+      const userList = members.map((member) => {
+        const authInfo = member.uid ? authUsersMap.get(member.uid) : undefined;
+        const lastSignInMs = authInfo?.lastSignInMs ?? 0;
+        const lastEditMs = member.uid
+          ? (lastEditByUser.get(member.uid) ?? 0)
+          : 0;
+        return {
+          email: member.email,
+          buildings: member.buildingIds,
+          lastSignInMs,
+          lastEditMs,
+          hasDashboard: member.uid
+            ? allDashboardOwnerUids.has(member.uid)
+            : false,
+          isMonthlyActive: lastEditMs > 0 && now - lastEditMs <= thirtyDaysMs,
+          isDailyActive: lastEditMs > 0 && now - lastEditMs <= oneDayMs,
+        };
+      });
 
       // Auth data was already collected in step 3a – no separate scan needed
       const totalRegisteredUsers = authUsersMap.size;

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -6,6 +6,7 @@ import axios, { AxiosError } from 'axios';
 import OAuth from 'oauth-1.0a';
 import * as CryptoJS from 'crypto-js';
 import { GoogleGenAI, Content } from '@google/genai';
+import { randomUUID } from 'node:crypto';
 import { sanitizePrompt } from './sanitize';
 import { parseGeminiJson } from './parseGeminiJson';
 
@@ -1979,11 +1980,20 @@ export const adminAnalytics = onRequest(
     invoker: 'public',
   },
   async (req, res) => {
+    // Correlation id for log triage. Emitted on the response (body +
+    // X-Request-Id header) and threaded through every `[getAdminAnalytics]`
+    // log line so a Cloud Logging alert can be pivoted back to the exact
+    // client-visible response.
+    const requestId = randomUUID();
+    res.setHeader('X-Request-Id', requestId);
+
     // 1. Verify caller is authenticated via Bearer token
     const authHeader = req.headers.authorization;
     if (!authHeader?.startsWith('Bearer ')) {
-      console.error('[getAdminAnalytics] Unauthenticated access attempt');
-      res.status(401).json({ error: 'unauthenticated' });
+      console.error('[getAdminAnalytics] Unauthenticated access attempt', {
+        requestId,
+      });
+      res.status(401).json({ error: 'unauthenticated', requestId });
       return;
     }
 
@@ -1992,12 +2002,12 @@ export const adminAnalytics = onRequest(
       const idToken = authHeader.split('Bearer ')[1];
       const decodedToken = await admin.auth().verifyIdToken(idToken);
       if (!decodedToken.email) {
-        res.status(401).json({ error: 'unauthenticated' });
+        res.status(401).json({ error: 'unauthenticated', requestId });
         return;
       }
       email = decodedToken.email.toLowerCase();
     } catch {
-      res.status(401).json({ error: 'unauthenticated' });
+      res.status(401).json({ error: 'unauthenticated', requestId });
       return;
     }
 
@@ -2009,9 +2019,11 @@ export const adminAnalytics = onRequest(
     const orgId =
       rawBody && typeof rawBody.orgId === 'string' ? rawBody.orgId.trim() : '';
     if (!orgId) {
-      res
-        .status(400)
-        .json({ error: 'invalid-argument', message: 'orgId is required' });
+      res.status(400).json({
+        error: 'invalid-argument',
+        message: 'orgId is required',
+        requestId,
+      });
       return;
     }
 
@@ -2041,10 +2053,12 @@ export const adminAnalytics = onRequest(
     const isSuperAdmin = adminDoc.exists;
     const isOrgAdmin = memberDoc.exists && ORG_ADMIN_ROLE_IDS.has(memberRoleId);
     if (!isSuperAdmin && !isOrgAdmin) {
-      console.error(
-        `[getAdminAnalytics] Unauthorized access: ${email} is not an admin of ${orgId}`
-      );
-      res.status(403).json({ error: 'permission-denied' });
+      console.error('[getAdminAnalytics] Unauthorized access', {
+        requestId,
+        email,
+        orgId,
+      });
+      res.status(403).json({ error: 'permission-denied', requestId });
       return;
     }
 
@@ -2111,6 +2125,7 @@ export const adminAnalytics = onRequest(
           }
         } catch (err) {
           console.warn('[getAdminAnalytics] auth().getUsers() chunk failed', {
+            requestId,
             orgId,
             chunkSize: chunk.length,
             error: err instanceof Error ? err.message : String(err),
@@ -2345,6 +2360,7 @@ export const adminAnalytics = onRequest(
             console.warn(
               `[getAdminAnalytics] Failed to resolve user emails via auth fallback for ${warningContext}`,
               {
+                requestId,
                 chunkSize: chunk.length,
                 chunkStart: i,
                 totalIdentifiers: identifiers.length,
@@ -2536,12 +2552,18 @@ export const adminAnalytics = onRequest(
         },
       });
     } catch (err: unknown) {
-      console.error('[getAdminAnalytics] Error fetching analytics:', err);
+      console.error('[getAdminAnalytics] Error fetching analytics', {
+        requestId,
+        orgId,
+        error: err instanceof Error ? err.message : String(err),
+      });
       const errorMessage =
         err instanceof Error
           ? err.message
           : 'An internal error occurred fetching analytics.';
-      res.status(500).json({ error: 'internal', message: errorMessage });
+      res
+        .status(500)
+        .json({ error: 'internal', message: errorMessage, requestId });
     }
   }
 );

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -2118,20 +2118,14 @@ export const adminAnalytics = onRequest(
         }
       }
 
-      // 3b. Build the buildings map (uid → buildingIds) from the member record
-      // (admin-assigned) rather than from each user's self-selected
-      // `selectedBuildings` profile field. The member record's `buildingIds`
-      // are the authoritative source and are guaranteed to match live building
-      // doc ids, so the client-side "Unknown (…)" fallbacks disappear. Only
-      // members with a resolved `uid` land in the map (widget drilldowns key
-      // off uid); totals/bucketing iterate `members` directly below so invited
-      // users without a uid still count.
-      const buildingsMap = new Map<string, string[]>();
+      // 3b. Build a uid → member lookup so downstream dashboard/AI filters can
+      // scope to org members without being gated on a successful
+      // `auth().getUsers()` round-trip. `authUsersMap` is only used to join
+      // lastSignIn metadata; an auth lookup failure must not silently drop a
+      // real member's dashboards or AI usage from the totals.
+      const memberUids = new Set<string>();
       for (const m of members) {
-        if (!m.uid) continue;
-        if (m.buildingIds.length > 0) {
-          buildingsMap.set(m.uid, m.buildingIds);
-        }
+        if (m.uid) memberUids.add(m.uid);
       }
 
       // 3c. Time constants & helpers (engagement computed after dashboard
@@ -2182,8 +2176,10 @@ export const adminAnalytics = onRequest(
         // Extract owner UID from path: users/{uid}/dashboards/{dashId}
         const ownerUid: string | null = dashDoc.ref.parent.parent?.id ?? null;
 
-        // Skip dashboards owned by anonymous users (not in filtered auth map)
-        if (!ownerUid || !authUsersMap.has(ownerUid)) continue;
+        // Skip dashboards not owned by a member of this org. Use the member
+        // roster (not `authUsersMap`) so a transient `auth().getUsers()`
+        // failure doesn't silently drop real members' dashboards from totals.
+        if (!ownerUid || !memberUids.has(ownerUid)) continue;
 
         totalDashboards++;
         allDashboardOwnerUids.add(ownerUid);
@@ -2436,8 +2432,10 @@ export const adminAnalytics = onRequest(
 
         if (!uid || !datePart) continue;
 
-        // Skip AI usage from anonymous users (not in filtered auth map)
-        if (!authUsersMap.has(uid)) continue;
+        // Skip AI usage not attributed to a member of this org. Scope by the
+        // member roster rather than `authUsersMap` so auth lookup failures
+        // don't silently drop members' AI calls from the totals.
+        if (!memberUids.has(uid)) continue;
 
         const usageData = usageDoc.data();
         const count = typeof usageData.count === 'number' ? usageData.count : 0;

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -20,6 +20,7 @@ export {
 } from './organizationInvites';
 export { organizationMembersSync } from './organizationMembersSync';
 export { organizationMemberCounters } from './organizationMemberCounters';
+export { organizationBuildingCounters } from './organizationBuildingCounters';
 export { resetOrganizationUserPassword } from './organizationResetPassword';
 export { getOrgUserActivity } from './organizationUserActivity';
 
@@ -2000,13 +2001,31 @@ export const adminAnalytics = onRequest(
       return;
     }
 
+    // 1b. Require an orgId in the request body so analytics can be scoped to
+    // a single tenant. The previous behavior listed every Firebase Auth user
+    // globally, which leaked foreign-domain accounts into the calling admin's
+    // analytics view.
+    const rawBody = req.body as { orgId?: unknown } | undefined;
+    const orgId =
+      rawBody && typeof rawBody.orgId === 'string' ? rawBody.orgId.trim() : '';
+    if (!orgId) {
+      res
+        .status(400)
+        .json({ error: 'invalid-argument', message: 'orgId is required' });
+      return;
+    }
+
     const db = admin.firestore();
 
-    // 2. Verify caller is an admin
-    const adminDoc = await db.collection('admins').doc(email).get();
-    if (!adminDoc.exists) {
+    // 2. Verify caller is an admin (super admin in /admins, or a member of
+    // the requested org — org-scoped admins should see their own analytics).
+    const [adminDoc, memberDoc] = await Promise.all([
+      db.collection('admins').doc(email).get(),
+      db.doc(`organizations/${orgId}/members/${email}`).get(),
+    ]);
+    if (!adminDoc.exists && !memberDoc.exists) {
       console.error(
-        `[getAdminAnalytics] Unauthorized access: ${email} is not an admin`
+        `[getAdminAnalytics] Unauthorized access: ${email} is not an admin of ${orgId}`
       );
       res.status(403).json({ error: 'permission-denied' });
       return;
@@ -2014,74 +2033,84 @@ export const adminAnalytics = onRequest(
 
     try {
       const now = Date.now();
-      // 3a. Collect ALL user data from Firebase Auth (authoritative source
-      // for MAU/DAU). This replaces the previous Firestore-only approach
-      // which missed users without a /users/{uid} root doc.
+      // 3a. Load the org's members as the authoritative user roster. This
+      // replaces the previous global `listUsers()` scan, which pulled in every
+      // Firebase Auth account regardless of org and caused foreign-domain
+      // users to show up in a different org's analytics.
+      //
+      // For each member we need auth metadata (lastSignInTime) to compute
+      // engagement. Members without a `uid` (invited but never signed in)
+      // still count toward totals but have zero engagement.
+      interface MemberLite {
+        email: string;
+        uid: string | null;
+        buildingIds: string[];
+      }
+      const members: MemberLite[] = [];
+      const membersSnap = await db
+        .collection(`organizations/${orgId}/members`)
+        .get();
+      for (const doc of membersSnap.docs) {
+        const data = doc.data() as {
+          email?: unknown;
+          uid?: unknown;
+          buildingIds?: unknown;
+        };
+        const memberEmail =
+          typeof data.email === 'string' ? data.email.toLowerCase() : doc.id;
+        const uid = typeof data.uid === 'string' && data.uid ? data.uid : null;
+        const buildingIds = Array.isArray(data.buildingIds)
+          ? data.buildingIds.filter(
+              (id): id is string => typeof id === 'string' && id.length > 0
+            )
+          : [];
+        members.push({ email: memberEmail, uid, buildingIds });
+      }
+
+      // Resolve Firebase Auth metadata for members that have a linked uid.
+      // `getUsers()` tolerates up to 100 identifiers per call and silently
+      // drops uids that no longer exist in Auth, which is the right behavior
+      // for a member doc whose uid was revoked.
       const authUsersMap = new Map<
         string,
         { email: string; lastSignInMs: number }
       >();
-      let authPageToken: string | undefined;
-      do {
-        const listResult = await admin.auth().listUsers(1000, authPageToken);
-        for (const u of listResult.users) {
-          // Skip anonymous auth users (student accounts) — they have no
-          // linked providers and no email, and should not appear in analytics.
-          if (!u.email && u.providerData.length === 0) continue;
-
-          const lastSignIn = u.metadata.lastSignInTime
-            ? new Date(u.metadata.lastSignInTime).getTime()
-            : 0;
-          authUsersMap.set(u.uid, {
-            email: u.email ?? '',
-            lastSignInMs: lastSignIn,
+      const uidsToResolve = members
+        .map((m) => m.uid)
+        .filter((uid): uid is string => uid !== null);
+      for (let i = 0; i < uidsToResolve.length; i += 100) {
+        const chunk = uidsToResolve.slice(i, i + 100).map((uid) => ({ uid }));
+        if (chunk.length === 0) continue;
+        try {
+          const result = await admin.auth().getUsers(chunk);
+          for (const u of result.users) {
+            const lastSignIn = u.metadata.lastSignInTime
+              ? new Date(u.metadata.lastSignInTime).getTime()
+              : 0;
+            authUsersMap.set(u.uid, {
+              email: u.email ?? '',
+              lastSignInMs: lastSignIn,
+            });
+          }
+        } catch (err) {
+          console.warn('[getAdminAnalytics] auth().getUsers() chunk failed', {
+            orgId,
+            chunkSize: chunk.length,
+            error: err instanceof Error ? err.message : String(err),
           });
         }
-        authPageToken = listResult.pageToken;
-      } while (authPageToken);
+      }
 
-      // 3b. Batch-read /users/{uid}/userProfile/profile for building assignments
-      // The source of truth for buildings is the profile subcollection, not the
-      // root user doc (which is only populated on recent logins).
+      // 3b. Build the buildings map from the member record (admin-assigned)
+      // rather than from each user's self-selected `selectedBuildings`
+      // profile field. The member record's `buildingIds` are the authoritative
+      // source and are guaranteed to match live building doc ids, so the
+      // client-side "Unknown (…)" fallbacks disappear.
       const buildingsMap = new Map<string, string[]>();
-      const authUids = Array.from(authUsersMap.keys());
-      const PROFILE_BATCH = 500;
-      const CONCURRENCY_LIMIT = 10;
-
-      for (
-        let i = 0;
-        i < authUids.length;
-        i += PROFILE_BATCH * CONCURRENCY_LIMIT
-      ) {
-        const chunkUids = authUids.slice(
-          i,
-          i + PROFILE_BATCH * CONCURRENCY_LIMIT
-        );
-        const chunkPromises: Promise<admin.firestore.DocumentSnapshot[]>[] = [];
-
-        for (let j = 0; j < chunkUids.length; j += PROFILE_BATCH) {
-          const batch = chunkUids.slice(j, j + PROFILE_BATCH);
-          const refs = batch.map((uid) =>
-            db.doc(`users/${uid}/userProfile/profile`)
-          );
-          chunkPromises.push(db.getAll(...refs));
-        }
-
-        const chunkSnapshots = await Promise.all(chunkPromises);
-        for (const snapshots of chunkSnapshots) {
-          for (const snap of snapshots) {
-            if (!snap.exists) continue;
-            const data = snap.data();
-            if (
-              data &&
-              Array.isArray(data.selectedBuildings) &&
-              data.selectedBuildings.length > 0
-            ) {
-              const uid = snap.ref.parent.parent?.id;
-              if (!uid) continue;
-              buildingsMap.set(uid, data.selectedBuildings.map(String));
-            }
-          }
+      for (const m of members) {
+        if (!m.uid) continue;
+        if (m.buildingIds.length > 0) {
+          buildingsMap.set(m.uid, m.buildingIds);
         }
       }
 

--- a/functions/src/organizationBuildingCounters.test.ts
+++ b/functions/src/organizationBuildingCounters.test.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+type TriggerHandler = (event: unknown) => Promise<void>;
+
+// `vi.mock` is hoisted above all imports, so the factory cannot close over
+// module-scope variables. `vi.hoisted` gives us a shared holder that runs in
+// the same pre-import phase and is safe to reference from the mock factory.
+const triggerHolder = vi.hoisted(() => ({
+  handler: null as TriggerHandler | null,
+}));
+
+vi.mock('firebase-functions/v2/firestore', () => ({
+  onDocumentWritten: (_path: string, handler: TriggerHandler) => {
+    triggerHolder.handler = handler;
+    return handler;
+  },
+}));
+
+vi.mock('firebase-functions/logger', () => ({
+  warn: vi.fn(),
+  info: vi.fn(),
+  error: vi.fn(),
+}));
+
+// Shared test state for the firebase-admin mock, hoisted so the factory can
+// reference it. Each test seeds `buildingsByOrg` with the expected post-event
+// count; `shouldFailNext` forces a transient recount failure to exercise the
+// retry-on-error path.
+const mockState = vi.hoisted(() => ({
+  buildingsByOrg: new Map<string, number>(),
+  shouldFailNext: false,
+  updateSpy: vi.fn(() => Promise.resolve()),
+  countGetSpy: vi.fn(),
+  countSpy: vi.fn(),
+}));
+
+vi.mock('firebase-admin', () => {
+  const firestoreFn = vi.fn(() => ({
+    collection: vi.fn((path: string) => ({
+      count: () => {
+        mockState.countSpy(path);
+        return {
+          get: () => {
+            mockState.countGetSpy(path);
+            if (mockState.shouldFailNext) {
+              mockState.shouldFailNext = false;
+              return Promise.reject(new Error('firestore transient failure'));
+            }
+            // Expected path: organizations/{orgId}/buildings
+            const match = /^organizations\/([^/]+)\/buildings$/.exec(path);
+            const orgId = match?.[1] ?? '';
+            const count = mockState.buildingsByOrg.get(orgId) ?? 0;
+            return Promise.resolve({ data: () => ({ count }) });
+          },
+        };
+      },
+    })),
+    doc: vi.fn((path: string) => ({
+      update: (patch: Record<string, unknown>) => {
+        void mockState.updateSpy({ path, patch });
+        return Promise.resolve();
+      },
+    })),
+  }));
+
+  return {
+    apps: [{ name: '[DEFAULT]' }],
+    initializeApp: vi.fn(),
+    firestore: firestoreFn,
+  };
+});
+
+// Import after mocks so the module's onDocumentWritten call lands in our stub.
+import './organizationBuildingCounters';
+
+const makeEvent = (opts: {
+  orgId: string;
+  buildingId: string;
+  beforeExists: boolean;
+  afterExists: boolean;
+}) => ({
+  params: { orgId: opts.orgId, buildingId: opts.buildingId },
+  data: {
+    before: { exists: opts.beforeExists },
+    after: { exists: opts.afterExists },
+  },
+});
+
+const invoke = async (event: unknown): Promise<void> => {
+  if (!triggerHolder.handler) {
+    throw new Error('trigger handler not registered');
+  }
+  await triggerHolder.handler(event);
+};
+
+describe('organizationBuildingCounters trigger', () => {
+  beforeEach(() => {
+    mockState.updateSpy.mockClear();
+    mockState.countGetSpy.mockClear();
+    mockState.countSpy.mockClear();
+    mockState.buildingsByOrg.clear();
+    mockState.shouldFailNext = false;
+  });
+
+  it('on create, writes the recounted value to organizations/{orgId}.buildings', async () => {
+    mockState.buildingsByOrg.set('orono', 6);
+
+    await invoke(
+      makeEvent({
+        orgId: 'orono',
+        buildingId: 'orono-community-ed',
+        beforeExists: false,
+        afterExists: true,
+      })
+    );
+
+    expect(mockState.countSpy).toHaveBeenCalledWith(
+      'organizations/orono/buildings'
+    );
+    expect(mockState.updateSpy).toHaveBeenCalledTimes(1);
+    expect(mockState.updateSpy).toHaveBeenCalledWith({
+      path: 'organizations/orono',
+      patch: { buildings: 6 },
+    });
+  });
+
+  it('on delete, writes the decremented count', async () => {
+    mockState.buildingsByOrg.set('orono', 5);
+
+    await invoke(
+      makeEvent({
+        orgId: 'orono',
+        buildingId: 'orono-community-ed',
+        beforeExists: true,
+        afterExists: false,
+      })
+    );
+
+    expect(mockState.updateSpy).toHaveBeenCalledTimes(1);
+    expect(mockState.updateSpy).toHaveBeenCalledWith({
+      path: 'organizations/orono',
+      patch: { buildings: 5 },
+    });
+  });
+
+  it('on update-only events (both before and after exist), issues no write', async () => {
+    mockState.buildingsByOrg.set('orono', 6);
+
+    await invoke(
+      makeEvent({
+        orgId: 'orono',
+        buildingId: 'orono-high',
+        beforeExists: true,
+        afterExists: true,
+      })
+    );
+
+    expect(mockState.countSpy).not.toHaveBeenCalled();
+    expect(mockState.updateSpy).not.toHaveBeenCalled();
+  });
+
+  it('self-heals pre-existing drift: stored value is irrelevant, write uses live count', async () => {
+    // Even if the org doc already had `buildings: 99` (wrong), the trigger
+    // recounts the subcollection and overwrites with the live value.
+    mockState.buildingsByOrg.set('orono', 6);
+
+    await invoke(
+      makeEvent({
+        orgId: 'orono',
+        buildingId: 'orono-new',
+        beforeExists: false,
+        afterExists: true,
+      })
+    );
+
+    expect(mockState.updateSpy).toHaveBeenCalledWith({
+      path: 'organizations/orono',
+      patch: { buildings: 6 },
+    });
+  });
+
+  it('rethrows recount failures so Cloud Functions retries the invocation', async () => {
+    // Force the `.get()` to reject, simulating a transient Firestore failure.
+    mockState.shouldFailNext = true;
+    mockState.buildingsByOrg.set('orono', 1);
+
+    await expect(
+      invoke(
+        makeEvent({
+          orgId: 'orono',
+          buildingId: 'orono-new',
+          beforeExists: false,
+          afterExists: true,
+        })
+      )
+    ).rejects.toThrow();
+
+    expect(mockState.updateSpy).not.toHaveBeenCalled();
+  });
+});

--- a/functions/src/organizationBuildingCounters.test.ts
+++ b/functions/src/organizationBuildingCounters.test.ts
@@ -29,9 +29,10 @@ vi.mock('firebase-functions/logger', () => ({
 const mockState = vi.hoisted(() => ({
   buildingsByOrg: new Map<string, number>(),
   shouldFailNext: false,
-  updateSpy: vi.fn(() => Promise.resolve()),
-  countGetSpy: vi.fn(),
-  countSpy: vi.fn(),
+  updateSpy:
+    vi.fn<(call: { path: string; patch: Record<string, unknown> }) => void>(),
+  countGetSpy: vi.fn<(path: string) => void>(),
+  countSpy: vi.fn<(path: string) => void>(),
 }));
 
 vi.mock('firebase-admin', () => {

--- a/functions/src/organizationBuildingCounters.ts
+++ b/functions/src/organizationBuildingCounters.ts
@@ -59,6 +59,14 @@ export const organizationBuildingCounters = onDocumentWritten(
         buildingId,
         error: err instanceof Error ? err.message : String(err),
       });
+      // Rethrow so Cloud Functions retries the invocation. The counter is
+      // supposed to self-heal drift; swallowing transient errors would leave
+      // it stale until the next create/delete.
+      throw err instanceof Error
+        ? err
+        : new Error(
+            `organizationBuildingCounters: recount failed for org ${orgId}, building ${buildingId}: ${String(err)}`
+          );
     }
   }
 );

--- a/functions/src/organizationBuildingCounters.ts
+++ b/functions/src/organizationBuildingCounters.ts
@@ -1,0 +1,64 @@
+import { onDocumentWritten } from 'firebase-functions/v2/firestore';
+import * as logger from 'firebase-functions/logger';
+import * as admin from 'firebase-admin';
+
+if (!admin.apps.length) {
+  admin.initializeApp();
+}
+
+/**
+ * Firestore trigger that keeps the denormalized `buildings` count on
+ * `/organizations/{orgId}` in sync with the live
+ * `/organizations/{orgId}/buildings` subcollection.
+ *
+ * Firestore rules forbid clients (including domain admins) from writing the
+ * `buildings` counter on the org doc, so this trigger — running on the
+ * Admin SDK — is the only path that updates it.
+ *
+ * Uses a recount-on-every-write strategy (rather than `FieldValue.increment`)
+ * because the collection is tiny (≤ dozens of buildings per org) and recount
+ * self-heals any drift from at-least-once event delivery or pre-trigger state.
+ */
+export const organizationBuildingCounters = onDocumentWritten(
+  'organizations/{orgId}/buildings/{buildingId}',
+  async (event) => {
+    const { orgId, buildingId } = event.params;
+    const change = event.data;
+    if (!change) {
+      logger.warn('organizationBuildingCounters: received event without data', {
+        orgId,
+        buildingId,
+      });
+      return;
+    }
+
+    const created = !change.before.exists && change.after.exists;
+    const deleted = change.before.exists && !change.after.exists;
+    if (!created && !deleted) {
+      // Update-only events don't change the count; skip the recount write.
+      return;
+    }
+
+    const db = admin.firestore();
+    try {
+      const snap = await db
+        .collection(`organizations/${orgId}/buildings`)
+        .count()
+        .get();
+      const count = snap.data().count;
+      await db.doc(`organizations/${orgId}`).update({ buildings: count });
+      logger.info('organizationBuildingCounters: updated count', {
+        orgId,
+        buildingId,
+        count,
+        trigger: created ? 'create' : 'delete',
+      });
+    } catch (err) {
+      logger.error('organizationBuildingCounters: recount failed', {
+        orgId,
+        buildingId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+);

--- a/scripts/recount-org-members.js
+++ b/scripts/recount-org-members.js
@@ -1,8 +1,8 @@
 /**
- * One-shot recount of the denormalized `users` counters on
- *   /organizations/{orgId}
- *   /organizations/{orgId}/buildings/{buildingId}
- *   /organizations/{orgId}/domains/{domainId}
+ * One-shot recount of the denormalized counters on
+ *   /organizations/{orgId}                    (users + buildings)
+ *   /organizations/{orgId}/buildings/{buildingId}  (users)
+ *   /organizations/{orgId}/domains/{domainId}      (users)
  *
  * WHY THIS EXISTS
  *   These fields display in the Organization panel (All Organizations table,
@@ -210,6 +210,7 @@ async function run() {
   console.log('');
   console.log('Planned counters:');
   console.log('  org "' + orgId + '":              ' + orgTotal);
+  console.log('  org "' + orgId + '" buildings:    ' + buildingDocs.length);
   for (const b of buildingDocs) {
     console.log(
       '  building "' + b.id + '":        ' + (byBuilding.get(b.id) || 0)
@@ -256,7 +257,7 @@ async function run() {
   const batch = db.batch();
   batch.set(
     db.doc('organizations/' + orgId),
-    { users: orgTotal },
+    { users: orgTotal, buildings: buildingDocs.length },
     { merge: true }
   );
   for (const b of buildingDocs) {


### PR DESCRIPTION
## Summary

Fixes three misalignments between the Organization and Analytics pages of the Admin Settings console. All three stem from code paths that predate the multi-tenant `/organizations/{orgId}/…` data model.

### 1. Stale `buildings` counter on Organizations table
The denormalized `organizations/{orgId}.buildings` counter was seeded at `4` by `scripts/setup-organization.js` and never updated when buildings are added/removed via the Buildings tab.

- **New Cloud Function** `organizationBuildingCounters` (`functions/src/organizationBuildingCounters.ts`) — `onDocumentWritten` trigger on `/organizations/{orgId}/buildings/{buildingId}` that recounts the subcollection on every create/delete and writes the result to the org doc. Uses recount (not `increment`) so it self-heals existing drift from the seed value.
- Exported from `functions/src/index.ts`.
- `scripts/recount-org-members.js` extended to also set `buildings` as a one-shot reconcile.

Firestore rules already forbid client writes to the `buildings` field on the org doc, so the trigger (Admin SDK) is the only path that updates it.

### 2. Foreign-domain users showing up in Analytics
`adminAnalytics` was calling `admin.auth().listUsers()` globally with no org filter, so any user (e.g. `@ashwaubenonk12.org`) who had ever signed in was included.

- `adminAnalytics` now requires `orgId` in the request body (400 if missing).
- Caller must be a super admin **or** a member of the requested org (403 otherwise).
- Replaced the global `listUsers()` loop with a scan of `/organizations/{orgId}/members/`. Auth metadata resolved via `admin.auth().getUsers()` in chunks of 100 using each member's `uid`. Members without a `uid` (never signed in) are counted in `total` but report `monthly: 0, daily: 0`.
- Client (`AnalyticsManager.tsx`) now sends `orgId` from `useAuth()` in the request body and re-fetches when the active org changes.

### 3. "Unknown Building (…)" labels in Analytics
Analytics was bucketing by the user's self-selected `selectedBuildings` profile field instead of the admin-assigned `buildingIds` on the member record. When the two drifted, the building lookup in `useKnownBuildings()` failed.

- Backend now buckets by `member.buildingIds` — the authoritative admin-assigned list from Organization > Users. These IDs are guaranteed to match live building docs because they come from the same write path.

## Test plan
- [x] `pnpm run validate` passes locally (1393 frontend tests + 134 functions tests, lint clean, format clean, typecheck clean)
- [ ] In a dev build signed in as super admin for Orono: add/remove a building, confirm the Organizations table cell updates immediately
- [ ] Manually set `organizations/{orgId}.buildings` to a wrong value in Firestore console, add or remove a building, confirm the trigger writes the correct count
- [ ] Confirm `ashwaubenonk12.org` no longer appears in the Analytics domain filter or domains table for Orono
- [ ] Total user count in Analytics matches Organization > Users rows (minus members without `uid`)
- [ ] Call `adminAnalytics` with missing `orgId` → expect 400
- [ ] Call `adminAnalytics` with a non-member / non-admin token → expect 403
- [ ] Every non-"No Building Assigned" row in "Users by Building" shows a real building name

## Deploy notes
Cloud Function changes require `firebase deploy --only functions:adminAnalytics,functions:organizationBuildingCounters`. Front-end deploys via the normal dev/main pipeline.

## Out of scope (follow-up)
- Migrating existing `selectedBuildings` profile fields to match `buildingIds` (audit needed — `context/AuthContext.tsx`, `components/layout/sidebar/SidebarBuildings.tsx`)
- Super-admin "all orgs" aggregate analytics view

https://claude.ai/code/session_017o2qhrc64fbt6bdct7yRPa