### PR TITLE
feat(auth): ClassLink-via-Google student SSO, PII-free

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -11,6 +11,10 @@ import { UpdateNotification } from './components/layout/UpdateNotification';
 import { DriveDisconnectBanner } from './components/common/DriveDisconnectBanner';
 import { isConfigured, isAuthBypass } from './config/firebase';
 import { StudentProvider } from './components/student/StudentContexts';
+import {
+  StudentAuthProvider,
+  RequireStudentAuth,
+} from './context/StudentAuthContext';
 
 // Lazy load heavy components for code splitting
 // Using named export pattern: import(...).then(module => ({ default: module.ExportName }))
@@ -58,6 +62,16 @@ const GuidedLearningStudentApp = lazy(() =>
   import('./components/guidedLearning/GuidedLearningStudentApp').then(
     (module) => ({ default: module.GuidedLearningStudentApp })
   )
+);
+const StudentLoginPage = lazy(() =>
+  import('./components/student/StudentLoginPage').then((module) => ({
+    default: module.StudentLoginPage,
+  }))
+);
+const MyAssignmentsPage = lazy(() =>
+  import('./components/student/MyAssignmentsPage').then((module) => ({
+    default: module.MyAssignmentsPage,
+  }))
 );
 const LoginScreen = lazy(() =>
   import('./components/auth/LoginScreen').then((module) => ({
@@ -177,6 +191,10 @@ const App: React.FC = () => {
   const isActivityWallRoute =
     pathname === '/activity-wall' || pathname.startsWith('/activity-wall/');
   const isInviteRoute = pathname.startsWith('/invite/');
+  const isStudentLoginRoute =
+    pathname === '/student/login' || pathname.startsWith('/student/login/');
+  const isMyAssignmentsRoute =
+    pathname === '/my-assignments' || pathname.startsWith('/my-assignments/');
 
   // MiniApp student route — anonymous entry, no teacher auth needed
   if (isMiniAppRoute) {
@@ -222,6 +240,39 @@ const App: React.FC = () => {
         <Suspense fallback={<FullPageLoader />}>
           <GuidedLearningStudentApp />
         </Suspense>
+        <DialogContainer />
+      </DialogProvider>
+    );
+  }
+
+  // Student login route — PII-free GIS sign-in, NOT behind AuthProvider.
+  // The page is itself the auth gate; it signs the student in with a custom
+  // token once the Cloud Function verifies the Google id_token.
+  if (isStudentLoginRoute) {
+    return (
+      <DialogProvider>
+        <Suspense fallback={<FullPageLoader />}>
+          <StudentLoginPage />
+        </Suspense>
+        <DialogContainer />
+      </DialogProvider>
+    );
+  }
+
+  // My Assignments route — landing page for GIS-authenticated students.
+  // StudentAuthProvider owns the auth lifecycle (idle timeout, custom claims).
+  // RequireStudentAuth gates rendering on a valid student token and redirects
+  // to /student/login when missing.
+  if (isMyAssignmentsRoute) {
+    return (
+      <DialogProvider>
+        <StudentAuthProvider>
+          <RequireStudentAuth>
+            <Suspense fallback={<FullPageLoader />}>
+              <MyAssignmentsPage />
+            </Suspense>
+          </RequireStudentAuth>
+        </StudentAuthProvider>
         <DialogContainer />
       </DialogProvider>
     );

--- a/App.tsx
+++ b/App.tsx
@@ -15,6 +15,7 @@ import {
   StudentAuthProvider,
   RequireStudentAuth,
 } from './context/StudentAuthContext';
+import { StudentIdleTimeoutGuard } from './components/student/StudentIdleTimeoutGuard';
 
 // Lazy load heavy components for code splitting
 // Using named export pattern: import(...).then(module => ({ default: module.ExportName }))
@@ -196,10 +197,14 @@ const App: React.FC = () => {
   const isMyAssignmentsRoute =
     pathname === '/my-assignments' || pathname.startsWith('/my-assignments/');
 
-  // MiniApp student route — anonymous entry, no teacher auth needed
+  // MiniApp student route — anonymous entry, no teacher auth needed.
+  // StudentIdleTimeoutGuard is a no-op unless a studentRole (ClassLink-via-
+  // Google) session is active; anonymous code+PIN launches and teacher
+  // previews pass through untouched.
   if (isMiniAppRoute) {
     return (
       <DialogProvider>
+        <StudentIdleTimeoutGuard />
         <Suspense fallback={<FullPageLoader />}>
           <MiniAppStudentApp />
         </Suspense>
@@ -212,6 +217,7 @@ const App: React.FC = () => {
   if (isVideoActivityRoute) {
     return (
       <DialogProvider>
+        <StudentIdleTimeoutGuard />
         <Suspense fallback={<FullPageLoader />}>
           <VideoActivityStudentApp />
         </Suspense>
@@ -223,6 +229,7 @@ const App: React.FC = () => {
   if (isActivityWallRoute) {
     return (
       <DialogProvider>
+        <StudentIdleTimeoutGuard />
         <Suspense fallback={<FullPageLoader />}>
           <ActivityWallStudentApp />
         </Suspense>
@@ -237,6 +244,7 @@ const App: React.FC = () => {
   if (isGuidedLearningRoute) {
     return (
       <DialogProvider>
+        <StudentIdleTimeoutGuard />
         <Suspense fallback={<FullPageLoader />}>
           <GuidedLearningStudentApp />
         </Suspense>

--- a/components/activityWall/ActivityWallStudentApp.tsx
+++ b/components/activityWall/ActivityWallStudentApp.tsx
@@ -1,9 +1,9 @@
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { Camera, ImagePlus, Loader2, Send, X } from 'lucide-react';
 import { ActivityWallIdentificationMode, ActivityWallMode } from '@/types';
 import { db, auth, storage } from '@/config/firebase';
 import { signInAnonymously } from 'firebase/auth';
-import { doc, collection, setDoc } from 'firebase/firestore';
+import { doc, collection, getDoc, setDoc } from 'firebase/firestore';
 import { ref, uploadBytes } from 'firebase/storage';
 
 type ActivityPayload = {
@@ -15,6 +15,25 @@ type ActivityPayload = {
   identificationMode: ActivityWallIdentificationMode;
   teacherUid: string;
 };
+
+/**
+ * The `/activity-wall/:pathId` app supports two launch styles:
+ *
+ *   - **Legacy `?data=<base64>` payload** (teacher's code/PIN flow). The
+ *     path segment is the `activityId` and the payload JSON carries the
+ *     full activity config.
+ *   - **Class-targeted link** from `/my-assignments` (Phase 3D). No
+ *     `?data=` param; the path segment is the session doc id
+ *     (`${teacherUid}_${activityId}`) and we read the activity config
+ *     directly from `activity_wall_sessions/{sessionId}` via a one-shot
+ *     `getDoc`. We deliberately do NOT use `onSnapshot` here — session
+ *     config is write-once and re-rendering on every teacher tweak
+ *     would multiply per-student Firestore reads across a class of 30.
+ */
+type PayloadState =
+  | { kind: 'loading' }
+  | { kind: 'ready'; payload: ActivityPayload }
+  | { kind: 'error' };
 
 const isActivityPayload = (value: unknown): value is ActivityPayload => {
   if (typeof value !== 'object' || value === null) {
@@ -61,7 +80,7 @@ const decodeBase64Utf8 = (value: string): string | null => {
   }
 };
 
-const parsePayload = (): ActivityPayload | null => {
+const parsePayloadFromUrl = (): ActivityPayload | null => {
   const params = new URLSearchParams(window.location.search);
   const encoded = params.get('data');
   if (!encoded) return null;
@@ -76,6 +95,65 @@ const parsePayload = (): ActivityPayload | null => {
   } catch {
     return null;
   }
+};
+
+/**
+ * Normalise a raw Firestore `activity_wall_sessions/{sessionId}` doc
+ * into the same `ActivityPayload` shape the base64 URL carries. Returns
+ * null when required fields are missing or malformed — the student app
+ * treats that as an error state (no deep-link resolution possible).
+ *
+ * Session docs written before Phase 3D may be missing `moderationEnabled`
+ * and `identificationMode` (those fields were added alongside this
+ * fallback). We default `moderationEnabled` to false and
+ * `identificationMode` to 'anonymous' so legacy sessions still render —
+ * both are the safest possible defaults (no submissions auto-hidden,
+ * no PII collected).
+ */
+const normaliseSessionDoc = (
+  sessionId: string,
+  raw: Record<string, unknown>
+): ActivityPayload | null => {
+  const {
+    activityId,
+    teacherUid,
+    title,
+    prompt,
+    mode,
+    moderationEnabled,
+    identificationMode,
+  } = raw;
+
+  if (typeof activityId !== 'string' || activityId.length === 0) return null;
+  if (typeof teacherUid !== 'string' || teacherUid.length === 0) return null;
+  if (typeof title !== 'string') return null;
+  if (typeof prompt !== 'string') return null;
+  if (mode !== 'text' && mode !== 'photo') return null;
+
+  // The submit handler expects a specific sessionId: `${teacherUid}_${id}`.
+  // Refuse to proceed if the doc id doesn't match that convention, so
+  // submission paths never write to an unexpected collection.
+  if (sessionId !== `${teacherUid}_${activityId}`) return null;
+
+  const resolvedModeration =
+    typeof moderationEnabled === 'boolean' ? moderationEnabled : false;
+  const resolvedIdentification: ActivityWallIdentificationMode =
+    identificationMode === 'name' ||
+    identificationMode === 'pin' ||
+    identificationMode === 'name-pin' ||
+    identificationMode === 'anonymous'
+      ? identificationMode
+      : 'anonymous';
+
+  return {
+    id: activityId,
+    teacherUid,
+    title,
+    prompt,
+    mode,
+    moderationEnabled: resolvedModeration,
+    identificationMode: resolvedIdentification,
+  };
 };
 
 const getSafePreviewUrl = (value: string | null): string | null => {
@@ -95,10 +173,32 @@ const buildParticipantLabel = (
 };
 
 export const ActivityWallStudentApp: React.FC = () => {
-  const payload = useMemo(() => parsePayload(), []);
-  const activityIdFromPath = window.location.pathname
-    .replace(/^\/activity-wall\/?/, '')
-    .split('/')[0];
+  // The URL payload — when present — is authoritative. We parse it
+  // synchronously in the same render as mount so URL-based launches
+  // render immediately without a loading flash.
+  const urlPayload = useMemo(() => parsePayloadFromUrl(), []);
+  const pathSegment = useMemo(
+    () =>
+      window.location.pathname.replace(/^\/activity-wall\/?/, '').split('/')[0],
+    []
+  );
+
+  const [payloadState, setPayloadState] = useState<PayloadState>(() => {
+    if (urlPayload && pathSegment && urlPayload.id === pathSegment) {
+      return { kind: 'ready', payload: urlPayload };
+    }
+    // No usable URL payload (either missing or mismatched against the
+    // path) — fall back to a Firestore read, but only when we have a
+    // non-empty path segment we can use as a sessionId.
+    if (!pathSegment) return { kind: 'error' };
+    if (urlPayload) {
+      // Param was present but mismatched — that's a genuinely bad link,
+      // not a class-targeted deep-link. Surface the error immediately
+      // rather than wasting a Firestore read.
+      return { kind: 'error' };
+    }
+    return { kind: 'loading' };
+  });
   const [name, setName] = useState('');
   const [pin, setPin] = useState('');
   const [response, setResponse] = useState('');
@@ -107,6 +207,58 @@ export const ActivityWallStudentApp: React.FC = () => {
   const [submitted, setSubmitted] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
+
+  // Firestore session-config fallback (Phase 3D). Runs only when the URL
+  // didn't carry a `?data=` payload — i.e. a class-targeted launch from
+  // `/my-assignments`. Uses a one-shot `getDoc` rather than `onSnapshot`:
+  // session config is write-once (teachers don't mutate title/prompt
+  // mid-activity) and subscribing would multiply per-student reads for
+  // zero benefit. Firestore rules (`passesStudentClassGate`) enforce
+  // that ClassLink-authenticated students can only read the doc when
+  // their `classIds` claim contains the session's `classId`.
+  //
+  // Syncs with the Firestore external system, which is exactly what
+  // `useEffect` is for.
+  useEffect(() => {
+    if (payloadState.kind !== 'loading') return;
+    if (!pathSegment) return;
+    let cancelled = false;
+    void (async () => {
+      try {
+        const snap = await getDoc(
+          doc(db, 'activity_wall_sessions', pathSegment)
+        );
+        if (cancelled) return;
+        if (!snap.exists()) {
+          setPayloadState({ kind: 'error' });
+          return;
+        }
+        const normalised = normaliseSessionDoc(
+          pathSegment,
+          snap.data() as Record<string, unknown>
+        );
+        if (!normalised) {
+          setPayloadState({ kind: 'error' });
+          return;
+        }
+        setPayloadState({ kind: 'ready', payload: normalised });
+      } catch (error) {
+        // Firestore permission-denied and network failures both land
+        // here. We don't expose the specific reason to the student —
+        // just show the same clean "not available" state so the UI
+        // never leaks access-control hints.
+        console.error(
+          '[ActivityWallStudentApp] Session-config fallback failed:',
+          error
+        );
+        if (cancelled) return;
+        setPayloadState({ kind: 'error' });
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [payloadState.kind, pathSegment]);
 
   // Keep previewUrl in sync with selectedFile and revoke the blob URL on cleanup
   // to avoid leaking browser memory (synchronization with an external resource).
@@ -123,13 +275,25 @@ export const ActivityWallStudentApp: React.FC = () => {
 
   const safePreviewUrl = getSafePreviewUrl(previewUrl);
 
-  if (!payload || !activityIdFromPath || payload.id !== activityIdFromPath) {
+  if (payloadState.kind === 'loading') {
     return (
-      <div className="min-h-screen bg-slate-900 text-white flex items-center justify-center p-4 text-center">
-        Invalid activity link. Ask your teacher for a new link.
+      <div className="min-h-screen bg-slate-100 flex items-center justify-center p-4 text-center text-slate-600">
+        <Loader2 className="w-5 h-5 animate-spin mr-2" />
+        Loading activity…
       </div>
     );
   }
+
+  if (payloadState.kind === 'error') {
+    return (
+      <div className="min-h-screen bg-slate-900 text-white flex items-center justify-center p-4 text-center">
+        This activity isn&apos;t available right now. Ask your teacher for a new
+        link.
+      </div>
+    );
+  }
+
+  const payload = payloadState.payload;
 
   const requiresName =
     payload.identificationMode === 'name' ||

--- a/components/miniApp/MiniAppStudentApp.tsx
+++ b/components/miniApp/MiniAppStudentApp.tsx
@@ -1,21 +1,28 @@
 /**
  * MiniAppStudentApp — student-facing MiniApp experience.
- * Accessible at /miniapp/:sessionId (no Google auth required).
+ * Accessible at /miniapp/:sessionId.
  *
  * Flow:
- *  1. Anonymous Firebase auth (satisfies Firestore security rules)
+ *  1. If no Firebase Auth user (legacy shared-link launch), sign in anonymously.
+ *     Students launched via /my-assignments arrive already authenticated with
+ *     a studentRole custom-token user — we keep that auth and do not re-sign.
  *  2. Load session from Firestore by sessionId
  *  3. If active: render the app HTML in a sandboxed iframe immediately
  *  4. If ended: show "session ended" screen
- *  5. If collectResults configured: forward SPART_MINIAPP_RESULT postMessages to Apps Script
+ *  5. When the iframe posts SPART_MINIAPP_RESULT, write a submission doc under
+ *     `mini_app_sessions/{sessionId}/submissions/{docId}`. For studentRole
+ *     users the docId is an opaque per-assignment pseudonym (via
+ *     getAssignmentPseudonymV1) so grading can match-back without persisting
+ *     PII; for anonymous users the docId is the anon Firebase Auth UID.
  */
 
 import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { signInAnonymously } from 'firebase/auth';
-import { doc, onSnapshot } from 'firebase/firestore';
+import { doc, onSnapshot, setDoc } from 'firebase/firestore';
+import { httpsCallable } from 'firebase/functions';
 import { Loader2, AlertCircle, CheckCircle2, Box } from 'lucide-react';
-import { auth, db } from '@/config/firebase';
-import { MiniAppSession } from '@/types';
+import { auth, db, functions } from '@/config/firebase';
+import { MiniAppSession, MiniAppSubmission } from '@/types';
 
 const SESSIONS_COLLECTION = 'mini_app_sessions';
 
@@ -111,6 +118,50 @@ const SessionLoader: React.FC = () => {
   return <AppViewer session={session} />;
 };
 
+// ─── Submission doc-ID resolution ──────────────────────────────────────────────
+//
+// Pseudonym cache: sessionId -> pseudonym (Promise-valued so concurrent
+// submissions within the same session de-dupe the callable round trip).
+// Rebuild whenever the authenticated uid changes (tracked by
+// `pseudonymCacheOwnerUid`). Mirrors the pattern in MyAssignmentsPage.
+
+let pseudonymCacheOwnerUid: string | null = null;
+let pseudonymCache: Map<string, Promise<string>> = new Map();
+
+function getCachedPseudonym(
+  sessionId: string,
+  pseudonymUid: string
+): Promise<string> {
+  if (pseudonymCacheOwnerUid !== pseudonymUid) {
+    pseudonymCache = new Map();
+    pseudonymCacheOwnerUid = pseudonymUid;
+  }
+  const cached = pseudonymCache.get(sessionId);
+  if (cached) return cached;
+
+  const callable = httpsCallable<
+    { assignmentId: string },
+    { pseudonym?: string }
+  >(functions, 'getAssignmentPseudonymV1');
+
+  const promise = callable({ assignmentId: sessionId }).then((res) => {
+    const p = res.data?.pseudonym;
+    if (typeof p !== 'string' || p.length === 0) {
+      throw new Error('Pseudonym missing from callable response.');
+    }
+    return p;
+  });
+
+  pseudonymCache.set(sessionId, promise);
+  promise.catch(() => {
+    if (pseudonymCache.get(sessionId) === promise) {
+      pseudonymCache.delete(sessionId);
+    }
+  });
+
+  return promise;
+}
+
 // ─── App Viewer ────────────────────────────────────────────────────────────────
 
 const AppViewer: React.FC<{ session: MiniAppSession }> = ({ session }) => {
@@ -121,30 +172,46 @@ const AppViewer: React.FC<{ session: MiniAppSession }> = ({ session }) => {
       if (event.source !== iframeRef.current?.contentWindow) return;
 
       const data = event.data as { type?: string; payload?: unknown } | null;
-      if (data?.type === 'SPART_MINIAPP_RESULT' && session.submissionUrl) {
-        try {
-          await fetch(session.submissionUrl, {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({
-              sheetId: session.googleSheetId ?? '',
-              studentPin: 'Student',
-              data: data.payload,
-            }),
-          });
-        } catch (err) {
-          console.error('[MiniAppStudentApp] Result submission failed:', err);
-        }
+      if (data?.type !== 'SPART_MINIAPP_RESULT') return;
+
+      const currentUser = auth.currentUser;
+      if (!currentUser) {
+        console.warn('[MiniAppStudentApp] No auth user; skipping submission.');
+        return;
+      }
+
+      try {
+        // studentRole users (ClassLink-launched) submit under an opaque
+        // per-assignment pseudonym so the teacher can match-back without
+        // persisting PII. Anonymous shared-link users submit under their
+        // anon Firebase Auth UID.
+        const tokenResult = await currentUser.getIdTokenResult();
+        const isStudentRole = tokenResult.claims?.studentRole === true;
+
+        const docId = isStudentRole
+          ? await getCachedPseudonym(session.id, currentUser.uid)
+          : currentUser.uid;
+
+        const submission: MiniAppSubmission = {
+          submittedAt: Date.now(),
+          payload: data.payload,
+        };
+
+        await setDoc(
+          doc(db, SESSIONS_COLLECTION, session.id, 'submissions', docId),
+          submission
+        );
+      } catch (err) {
+        console.error('[MiniAppStudentApp] Submission write failed:', err);
       }
     },
-    [session.submissionUrl, session.googleSheetId]
+    [session.id]
   );
 
   useEffect(() => {
-    if (!session.submissionUrl) return;
     window.addEventListener('message', handleMessage);
     return () => window.removeEventListener('message', handleMessage);
-  }, [session.submissionUrl, handleMessage]);
+  }, [handleMessage]);
 
   return (
     <div className="h-screen w-screen overflow-hidden bg-slate-900 flex flex-col">

--- a/components/miniApp/MiniAppStudentApp.tsx
+++ b/components/miniApp/MiniAppStudentApp.tsx
@@ -20,9 +20,21 @@ import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { signInAnonymously } from 'firebase/auth';
 import { doc, onSnapshot, setDoc } from 'firebase/firestore';
 import { httpsCallable } from 'firebase/functions';
-import { Loader2, AlertCircle, CheckCircle2, Box } from 'lucide-react';
+import {
+  Loader2,
+  AlertCircle,
+  CheckCircle2,
+  Box,
+  RefreshCw,
+} from 'lucide-react';
 import { auth, db, functions } from '@/config/firebase';
 import { MiniAppSession, MiniAppSubmission } from '@/types';
+
+type SubmissionStatus =
+  | { kind: 'idle' }
+  | { kind: 'submitting' }
+  | { kind: 'saved'; at: number }
+  | { kind: 'error'; payload: unknown };
 
 const SESSIONS_COLLECTION = 'mini_app_sessions';
 
@@ -166,20 +178,18 @@ function getCachedPseudonym(
 
 const AppViewer: React.FC<{ session: MiniAppSession }> = ({ session }) => {
   const iframeRef = useRef<HTMLIFrameElement>(null);
+  const [status, setStatus] = useState<SubmissionStatus>({ kind: 'idle' });
 
-  const handleMessage = useCallback(
-    async (event: MessageEvent) => {
-      if (event.source !== iframeRef.current?.contentWindow) return;
-
-      const data = event.data as { type?: string; payload?: unknown } | null;
-      if (data?.type !== 'SPART_MINIAPP_RESULT') return;
-
+  const submit = useCallback(
+    async (payload: unknown) => {
       const currentUser = auth.currentUser;
       if (!currentUser) {
         console.warn('[MiniAppStudentApp] No auth user; skipping submission.');
+        setStatus({ kind: 'error', payload });
         return;
       }
 
+      setStatus({ kind: 'submitting' });
       try {
         // studentRole users (ClassLink-launched) submit under an opaque
         // per-assignment pseudonym so the teacher can match-back without
@@ -192,26 +202,56 @@ const AppViewer: React.FC<{ session: MiniAppSession }> = ({ session }) => {
           ? await getCachedPseudonym(session.id, currentUser.uid)
           : currentUser.uid;
 
+        // Rules require `payload is map`; coerce non-object payloads into a
+        // `{ value }` wrapper so mini-apps that post scalars or arrays still
+        // persist instead of silently failing the write.
+        const normalisedPayload =
+          payload !== null &&
+          typeof payload === 'object' &&
+          !Array.isArray(payload)
+            ? (payload as Record<string, unknown>)
+            : { value: payload };
+
         const submission: MiniAppSubmission = {
           submittedAt: Date.now(),
-          payload: data.payload,
+          payload: normalisedPayload,
         };
 
         await setDoc(
           doc(db, SESSIONS_COLLECTION, session.id, 'submissions', docId),
           submission
         );
+        setStatus({ kind: 'saved', at: Date.now() });
       } catch (err) {
         console.error('[MiniAppStudentApp] Submission write failed:', err);
+        setStatus({ kind: 'error', payload });
       }
     },
     [session.id]
+  );
+
+  const handleMessage = useCallback(
+    (event: MessageEvent) => {
+      if (event.source !== iframeRef.current?.contentWindow) return;
+      const data = event.data as { type?: string; payload?: unknown } | null;
+      if (data?.type !== 'SPART_MINIAPP_RESULT') return;
+      void submit(data.payload);
+    },
+    [submit]
   );
 
   useEffect(() => {
     window.addEventListener('message', handleMessage);
     return () => window.removeEventListener('message', handleMessage);
   }, [handleMessage]);
+
+  // Auto-clear the transient "Saved" confirmation after 2.5s so it doesn't
+  // linger over the activity.
+  useEffect(() => {
+    if (status.kind !== 'saved') return;
+    const timeout = window.setTimeout(() => setStatus({ kind: 'idle' }), 2500);
+    return () => window.clearTimeout(timeout);
+  }, [status]);
 
   return (
     <div className="h-screen w-screen overflow-hidden bg-slate-900 flex flex-col">
@@ -224,6 +264,59 @@ const AppViewer: React.FC<{ session: MiniAppSession }> = ({ session }) => {
         className="flex-1 w-full border-0"
         allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope"
       />
+      <SubmissionStatusOverlay status={status} onRetry={submit} />
+    </div>
+  );
+};
+
+// ─── Submission status overlay ─────────────────────────────────────────────────
+
+const SubmissionStatusOverlay: React.FC<{
+  status: SubmissionStatus;
+  onRetry: (payload: unknown) => void;
+}> = ({ status, onRetry }) => {
+  if (status.kind === 'idle') return null;
+
+  const base =
+    'fixed bottom-4 left-1/2 -translate-x-1/2 z-20 rounded-xl px-4 py-3 shadow-lg flex items-center gap-2 text-sm font-medium';
+
+  if (status.kind === 'submitting') {
+    return (
+      <div className={`${base} bg-slate-800 text-white`} role="status">
+        <Loader2 className="w-4 h-4 animate-spin" />
+        Saving your answer…
+      </div>
+    );
+  }
+
+  if (status.kind === 'saved') {
+    return (
+      <div
+        className={`${base} bg-emerald-600 text-white`}
+        role="status"
+        aria-live="polite"
+      >
+        <CheckCircle2 className="w-4 h-4" />
+        Saved
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className={`${base} bg-red-600 text-white`}
+      role="alert"
+      aria-live="assertive"
+    >
+      <AlertCircle className="w-4 h-4" />
+      <span>Couldn&apos;t save your answer.</span>
+      <button
+        onClick={() => onRetry(status.payload)}
+        className="inline-flex items-center gap-1 rounded-lg bg-white/20 hover:bg-white/30 px-2 py-1 text-xs font-bold"
+      >
+        <RefreshCw className="w-3 h-3" />
+        Retry
+      </button>
     </div>
   );
 };

--- a/components/student/MyAssignmentsPage.tsx
+++ b/components/student/MyAssignmentsPage.tsx
@@ -1,0 +1,696 @@
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import {
+  collection,
+  doc,
+  getDoc,
+  onSnapshot,
+  query,
+  where,
+  type QuerySnapshot,
+  type DocumentData,
+} from 'firebase/firestore';
+import { httpsCallable } from 'firebase/functions';
+import {
+  AlertCircle,
+  CheckCircle2,
+  ClipboardList,
+  GraduationCap,
+  Image as ImageIcon,
+  Inbox,
+  Loader2,
+  LogOut,
+  PlayCircle,
+  Puzzle,
+  Sparkles,
+} from 'lucide-react';
+import { db, functions } from '@/config/firebase';
+import { APP_NAME } from '@/config/constants';
+import { useStudentAuth } from '@/context/useStudentAuth';
+
+/**
+ * MyAssignmentsPage — Phase 2C of the ClassLink-via-Google auth flow.
+ *
+ * Landing page for a signed-in student. Subscribes to the five session
+ * collections (`quiz_sessions`, `video_activity_sessions`,
+ * `guided_learning_sessions`, `mini_app_sessions`, `activity_wall_sessions`),
+ * filtered by `classId in classIds`, and renders the union as a single list.
+ *
+ * PII-free: reads only session-level fields (title, status, code, classId).
+ * Never reads, logs, or persists email / displayName / sub. The only
+ * identifier we touch is the custom-token pseudonym UID from
+ * `useStudentAuth`.
+ *
+ * Completion check strategy: LAZY per-row. Each `AssignmentCard` kicks off
+ * a single `getAssignmentPseudonymV1` callable (results cached across the
+ * page lifetime via a shared `Map` ref) and then a single `getDoc`
+ * existence check against the correct response subcollection. This lets
+ * React render the list immediately and fill in completion badges as they
+ * resolve, rather than blocking on a large Promise.all.
+ *
+ * Firestore `in` cap: `classIds` is capped at 20 by `studentLoginV1`.
+ * Firestore's `where('x', 'in', arr)` supports up to 30 values. Do NOT
+ * raise the `studentLoginV1` cap past 30 without splitting this query
+ * into chunks.
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+type SessionKind =
+  | 'quiz'
+  | 'video-activity'
+  | 'guided-learning'
+  | 'mini-app'
+  | 'activity-wall';
+
+interface AssignmentSummary {
+  /** `${kind}:${sessionId}` — stable React key across collections. */
+  compositeId: string;
+  kind: SessionKind;
+  sessionId: string;
+  title: string;
+  /** Fully-qualified path the student can click to open the session. */
+  openHref: string;
+  /** When the session was created (for sorting). May be undefined for ad-hoc docs. */
+  createdAt?: number;
+}
+
+type LoadState = 'loading' | 'ready';
+
+interface KindConfig {
+  collectionName: string;
+  /** Firestore status filter, or `null` when the collection has no status field. */
+  statusFilter: { field: 'status'; value: 'active' } | null;
+  /** Subcollection where per-student response/submission docs live; null when absent. */
+  responseSubcollection: string | null;
+  label: string;
+  icon: React.ComponentType<{ className?: string; strokeWidth?: number }>;
+  /** Tailwind gradient for the card accent badge. */
+  accent: string;
+  /** Given a raw session document, build the display title. */
+  titleFrom: (data: DocumentData) => string;
+  /** Given a session id and the raw session doc, build the /open URL. */
+  hrefFrom: (sessionId: string, data: DocumentData) => string;
+}
+
+// ---------------------------------------------------------------------------
+// Per-kind configuration
+// ---------------------------------------------------------------------------
+//
+// Fields verified against:
+//   - `types.ts` (QuizSession, VideoActivitySession, MiniAppSession,
+//     GuidedLearningSession)
+//   - `firestore.rules` — each collection's `passesStudentClassGate` read rule
+//   - `components/widgets/ActivityWall/Widget.tsx` (session doc is created
+//     ad-hoc without a TS interface — fields confirmed from the setDoc call)
+//
+// Notes:
+//   - guided_learning_sessions and activity_wall_sessions have NO status
+//     field on the session document. The GL assignment wrapper lives in
+//     /users/{teacherUid}/guided_learning_assignments and ActivityWall uses
+//     the session's existence as liveness. We intentionally do not filter
+//     those by status.
+//   - mini_app_sessions submissions live under the `submissions` subcollection
+//     (doc ID = per-assignment pseudonym for studentRole launches, auth uid
+//     for anonymous launches). See MiniAppStudentApp.tsx for the write path
+//     and firestore.rules for the matching read/create rules.
+
+const KIND_CONFIG: Record<SessionKind, KindConfig> = {
+  quiz: {
+    collectionName: 'quiz_sessions',
+    statusFilter: { field: 'status', value: 'active' },
+    responseSubcollection: 'responses',
+    label: 'Quiz',
+    icon: ClipboardList,
+    accent: 'from-blue-500 to-indigo-600',
+    titleFrom: (data) =>
+      typeof data.quizTitle === 'string' && data.quizTitle.length > 0
+        ? data.quizTitle
+        : 'Untitled quiz',
+    hrefFrom: (sessionId, data) => {
+      // Quiz student app joins via ?code=<code> (the 6-char join code) rather
+      // than sessionId. Fall back to sessionId if code isn't present on the
+      // doc (shouldn't happen in practice, but keeps the link functional).
+      const code =
+        typeof data.code === 'string' && data.code.length > 0
+          ? data.code
+          : sessionId;
+      return `/quiz?code=${encodeURIComponent(code)}`;
+    },
+  },
+  'video-activity': {
+    collectionName: 'video_activity_sessions',
+    statusFilter: { field: 'status', value: 'active' },
+    responseSubcollection: 'responses',
+    label: 'Video Activity',
+    icon: PlayCircle,
+    accent: 'from-rose-500 to-red-600',
+    titleFrom: (data) => {
+      if (
+        typeof data.activityTitle === 'string' &&
+        data.activityTitle.length > 0
+      )
+        return data.activityTitle;
+      if (
+        typeof data.assignmentName === 'string' &&
+        data.assignmentName.length > 0
+      )
+        return data.assignmentName;
+      return 'Video activity';
+    },
+    hrefFrom: (sessionId) => `/activity/${encodeURIComponent(sessionId)}`,
+  },
+  'guided-learning': {
+    collectionName: 'guided_learning_sessions',
+    statusFilter: null, // No status field; session presence = live.
+    responseSubcollection: 'responses',
+    label: 'Guided Learning',
+    icon: Sparkles,
+    accent: 'from-emerald-500 to-teal-600',
+    titleFrom: (data) =>
+      typeof data.title === 'string' && data.title.length > 0
+        ? data.title
+        : 'Guided learning',
+    hrefFrom: (sessionId) =>
+      `/guided-learning/${encodeURIComponent(sessionId)}`,
+  },
+  'mini-app': {
+    collectionName: 'mini_app_sessions',
+    statusFilter: { field: 'status', value: 'active' },
+    responseSubcollection: 'submissions',
+    label: 'Mini App',
+    icon: Puzzle,
+    accent: 'from-violet-500 to-purple-600',
+    titleFrom: (data) => {
+      if (typeof data.appTitle === 'string' && data.appTitle.length > 0)
+        return data.appTitle;
+      if (
+        typeof data.assignmentName === 'string' &&
+        data.assignmentName.length > 0
+      )
+        return data.assignmentName;
+      return 'Mini app';
+    },
+    hrefFrom: (sessionId) => `/miniapp/${encodeURIComponent(sessionId)}`,
+  },
+  'activity-wall': {
+    collectionName: 'activity_wall_sessions',
+    statusFilter: null, // No status field on the session doc.
+    // ActivityWall submissions are a LIST per student (students can post
+    // multiple). We still use existence as a "has the student participated
+    // yet?" signal — but the doc id is the pseudonym, so this is a
+    // best-effort hint, not a true completion.
+    responseSubcollection: 'submissions',
+    label: 'Activity Wall',
+    icon: ImageIcon,
+    accent: 'from-amber-500 to-orange-600',
+    titleFrom: (data) =>
+      typeof data.title === 'string' && data.title.length > 0
+        ? data.title
+        : 'Activity wall',
+    hrefFrom: (sessionId) =>
+      // ActivityWall student app normally expects a `?data=<base64>` payload
+      // that the teacher builds. A class-targeted launch doesn't carry that
+      // payload yet (Phase 3E will wire it). For now we link to the session
+      // route — the student app may show an error until Phase 3E lands.
+      `/activity-wall/${encodeURIComponent(sessionId)}`,
+  },
+};
+
+const SESSION_KINDS: readonly SessionKind[] = [
+  'quiz',
+  'video-activity',
+  'guided-learning',
+  'mini-app',
+  'activity-wall',
+];
+
+// ---------------------------------------------------------------------------
+// Page component
+// ---------------------------------------------------------------------------
+
+interface AssignmentsByKind {
+  [kind: string]: AssignmentSummary[];
+}
+
+const MyAssignmentsPage: React.FC = () => {
+  const { classIds, pseudonymUid, signOut } = useStudentAuth();
+  const [byKind, setByKind] = useState<AssignmentsByKind>(() =>
+    Object.fromEntries(SESSION_KINDS.map((k) => [k, []]))
+  );
+  const [loadState, setLoadState] = useState<LoadState>('loading');
+
+  // Track which kinds have delivered their first snapshot so we can flip
+  // from `loading` -> `ready` only once every subscription has settled.
+  const settledKindsRef = useRef<Set<SessionKind>>(new Set());
+
+  // Stable subscription identity: we only re-subscribe when classIds actually
+  // changes, not on every render.
+  const classIdsKey = useMemo(
+    () => classIds.slice().sort().join('|'),
+    [classIds]
+  );
+
+  useEffect(() => {
+    // No classes → no queries (Firestore rejects `in` with []).
+    if (classIds.length === 0) {
+      setByKind(Object.fromEntries(SESSION_KINDS.map((k) => [k, []])));
+      setLoadState('ready');
+      return;
+    }
+
+    setLoadState('loading');
+    settledKindsRef.current = new Set();
+
+    const unsubs: Array<() => void> = [];
+
+    const handleSnapshot = (
+      kind: SessionKind,
+      snap: QuerySnapshot<DocumentData>
+    ) => {
+      const config = KIND_CONFIG[kind];
+      const items: AssignmentSummary[] = snap.docs.map((d) => {
+        const data = d.data();
+        const createdAtRaw: unknown = (data as Record<string, unknown>)
+          .createdAt;
+        return {
+          compositeId: `${kind}:${d.id}`,
+          kind,
+          sessionId: d.id,
+          title: config.titleFrom(data),
+          openHref: config.hrefFrom(d.id, data),
+          createdAt:
+            typeof createdAtRaw === 'number' ? createdAtRaw : undefined,
+        };
+      });
+
+      setByKind((prev) => ({ ...prev, [kind]: items }));
+      settledKindsRef.current.add(kind);
+      if (settledKindsRef.current.size === SESSION_KINDS.length) {
+        setLoadState('ready');
+      }
+    };
+
+    const handleError = (kind: SessionKind, err: unknown) => {
+      // PII safety: never log the error message or data — it may contain
+      // diagnostic data derived from the query. Log only the collection
+      // name and Firestore error code.
+      const code =
+        err && typeof err === 'object' && 'code' in err
+          ? String((err as { code?: unknown }).code)
+          : 'unknown';
+      console.warn(
+        `[MyAssignments] snapshot failed for ${KIND_CONFIG[kind].collectionName}:`,
+        code
+      );
+      // Mark as settled with an empty list so loading state can progress.
+      setByKind((prev) => ({ ...prev, [kind]: [] }));
+      settledKindsRef.current.add(kind);
+      if (settledKindsRef.current.size === SESSION_KINDS.length) {
+        setLoadState('ready');
+      }
+    };
+
+    for (const kind of SESSION_KINDS) {
+      const config = KIND_CONFIG[kind];
+      const col = collection(db, config.collectionName);
+      const constraints = [where('classId', 'in', classIds)];
+      if (config.statusFilter) {
+        constraints.push(
+          where(config.statusFilter.field, '==', config.statusFilter.value)
+        );
+      }
+      const q = query(col, ...constraints);
+      const unsub = onSnapshot(
+        q,
+        (snap) => handleSnapshot(kind, snap),
+        (err) => handleError(kind, err)
+      );
+      unsubs.push(unsub);
+    }
+
+    return () => {
+      for (const u of unsubs) u();
+    };
+    // `classIds` drives the `in` filter; re-subscribe only when the key
+    // changes. `classIdsKey` is derived from `classIds` and gives us a
+    // value-based comparison instead of reference identity.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [classIdsKey]);
+
+  // Flatten + sort: newest first, grouped visually by kind order inside a
+  // single list. Sort is stable on `createdAt` (desc), then by title to
+  // keep ordering deterministic when createdAt is missing.
+  const assignments: AssignmentSummary[] = useMemo(() => {
+    const merged: AssignmentSummary[] = [];
+    for (const kind of SESSION_KINDS) {
+      const list = byKind[kind] ?? [];
+      merged.push(...list);
+    }
+    merged.sort((a, b) => {
+      const ac = a.createdAt ?? 0;
+      const bc = b.createdAt ?? 0;
+      if (ac !== bc) return bc - ac;
+      return a.title.localeCompare(b.title);
+    });
+    return merged;
+  }, [byKind]);
+
+  const handleDone = useCallback(() => {
+    void signOut();
+  }, [signOut]);
+
+  return (
+    <div className="relative min-h-screen w-screen bg-slate-50 overflow-x-hidden font-sans">
+      {/* Ambient background, matches StudentLoginPage */}
+      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(#e5e7eb_1px,transparent_1px)] [background-size:16px_16px] opacity-50" />
+      <div className="pointer-events-none absolute top-[-10%] left-[-15%] w-[500px] h-[500px] rounded-full blur-[120px] bg-brand-blue-primary/15" />
+      <div className="pointer-events-none absolute bottom-[-15%] right-[-10%] w-[500px] h-[500px] bg-brand-red-primary/10 rounded-full blur-[120px]" />
+
+      <div className="relative z-10 flex flex-col min-h-screen">
+        <Header onDone={handleDone} />
+
+        <main className="flex-1 w-full max-w-3xl mx-auto px-4 sm:px-6 py-8 sm:py-12">
+          <div className="mb-8">
+            <h2 className="text-2xl sm:text-3xl font-black text-slate-800 tracking-tight">
+              My Assignments
+            </h2>
+            <p className="text-slate-500 text-sm sm:text-base mt-1.5 font-medium">
+              Everything your teachers have active for your classes right now.
+            </p>
+          </div>
+
+          <AssignmentsBody
+            loadState={loadState}
+            classIds={classIds}
+            assignments={assignments}
+            pseudonymUid={pseudonymUid}
+          />
+        </main>
+
+        <footer className="w-full max-w-3xl mx-auto px-4 sm:px-6 py-6 text-center text-xs text-slate-400 font-medium">
+          {APP_NAME}
+        </footer>
+      </div>
+    </div>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// Header — brand + "Done" sign-out
+// ---------------------------------------------------------------------------
+
+const Header: React.FC<{ onDone: () => void }> = ({ onDone }) => (
+  <header className="w-full max-w-3xl mx-auto px-4 sm:px-6 pt-6 sm:pt-8 flex items-center justify-between gap-4">
+    <div className="flex items-center gap-3 min-w-0">
+      <div className="w-10 h-10 bg-gradient-to-br from-brand-blue-primary to-brand-blue-dark rounded-xl flex items-center justify-center shadow-md shadow-brand-blue-primary/20 shrink-0">
+        <GraduationCap className="w-5 h-5 text-white" strokeWidth={2.5} />
+      </div>
+      <span className="text-lg sm:text-xl font-black text-slate-800 tracking-tight truncate">
+        {APP_NAME}
+      </span>
+    </div>
+
+    <button
+      type="button"
+      onClick={onDone}
+      aria-label="Done — sign out"
+      className="inline-flex items-center gap-2 px-4 py-2 rounded-xl bg-white/70 backdrop-blur-sm border border-slate-200 text-slate-700 hover:bg-white hover:border-slate-300 text-sm font-semibold shadow-sm transition focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue-primary focus-visible:ring-offset-2 focus-visible:ring-offset-slate-50"
+    >
+      <LogOut className="w-4 h-4" strokeWidth={2.25} />
+      <span>Done</span>
+    </button>
+  </header>
+);
+
+// ---------------------------------------------------------------------------
+// Body — loading / empty / list
+// ---------------------------------------------------------------------------
+
+interface AssignmentsBodyProps {
+  loadState: LoadState;
+  classIds: string[];
+  assignments: AssignmentSummary[];
+  pseudonymUid: string | null;
+}
+
+const AssignmentsBody: React.FC<AssignmentsBodyProps> = ({
+  loadState,
+  classIds,
+  assignments,
+  pseudonymUid,
+}) => {
+  if (loadState === 'loading') {
+    return (
+      <div className="min-h-[200px] flex flex-col items-center justify-center gap-3 text-slate-500">
+        <Loader2 className="w-8 h-8 animate-spin text-brand-blue-primary" />
+        <p className="text-sm font-medium">Loading your assignments…</p>
+      </div>
+    );
+  }
+
+  if (classIds.length === 0) {
+    return (
+      <EmptyState
+        icon={AlertCircle}
+        title="You're not on a roster yet"
+        body="You're not on any class rosters yet. If you just started at your school, ask a teacher to sync their roster."
+        tone="soft"
+      />
+    );
+  }
+
+  if (assignments.length === 0) {
+    return (
+      <EmptyState
+        icon={Inbox}
+        title="All caught up"
+        body="You're all caught up — no active assignments right now."
+        tone="soft"
+      />
+    );
+  }
+
+  return (
+    <ul className="space-y-3">
+      {assignments.map((a) => (
+        <li key={a.compositeId}>
+          <AssignmentCard assignment={a} pseudonymUid={pseudonymUid} />
+        </li>
+      ))}
+    </ul>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// Empty state
+// ---------------------------------------------------------------------------
+
+interface EmptyStateProps {
+  icon: React.ComponentType<{ className?: string; strokeWidth?: number }>;
+  title: string;
+  body: string;
+  tone: 'soft' | 'error';
+}
+
+const EmptyState: React.FC<EmptyStateProps> = ({
+  icon: Icon,
+  title,
+  body,
+  tone,
+}) => {
+  const isSoft = tone === 'soft';
+  return (
+    <div className="min-h-[240px] flex flex-col items-center justify-center gap-4 text-center px-6 py-12">
+      <div
+        className={`w-14 h-14 rounded-2xl flex items-center justify-center ${
+          isSoft ? 'bg-slate-100' : 'bg-brand-red-primary/10'
+        }`}
+      >
+        <Icon
+          className={`w-7 h-7 ${
+            isSoft ? 'text-slate-400' : 'text-brand-red-primary'
+          }`}
+          strokeWidth={2}
+        />
+      </div>
+      <div className="max-w-sm space-y-1.5">
+        <h3 className="text-base font-bold text-slate-800">{title}</h3>
+        <p className="text-sm text-slate-500 leading-relaxed">{body}</p>
+      </div>
+    </div>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// Assignment card — lazy completion check
+// ---------------------------------------------------------------------------
+//
+// Pseudonym cache: sessionId -> pseudonym (Promise-valued so concurrent
+// readers de-dupe the callable). This is module-local, so it survives
+// card remounts within a single page lifetime without re-fetching.
+// Pseudonyms are stable for a given (uid, assignmentId) within a session;
+// we rebuild the cache whenever the authenticated uid changes (tracked
+// via `pseudonymCacheOwnerUid`).
+
+let pseudonymCacheOwnerUid: string | null = null;
+let pseudonymCache: Map<string, Promise<string>> = new Map();
+
+function getCachedPseudonym(
+  sessionId: string,
+  pseudonymUid: string
+): Promise<string> {
+  if (pseudonymCacheOwnerUid !== pseudonymUid) {
+    pseudonymCache = new Map();
+    pseudonymCacheOwnerUid = pseudonymUid;
+  }
+  const cached = pseudonymCache.get(sessionId);
+  if (cached) return cached;
+
+  const callable = httpsCallable<
+    { assignmentId: string },
+    { pseudonym?: string }
+  >(functions, 'getAssignmentPseudonymV1');
+
+  const promise = callable({ assignmentId: sessionId }).then((res) => {
+    const p = res.data?.pseudonym;
+    if (typeof p !== 'string' || p.length === 0) {
+      throw new Error('Pseudonym missing from callable response.');
+    }
+    return p;
+  });
+
+  pseudonymCache.set(sessionId, promise);
+
+  // Evict on failure so a retry on a later card re-attempts the fetch.
+  promise.catch(() => {
+    if (pseudonymCache.get(sessionId) === promise) {
+      pseudonymCache.delete(sessionId);
+    }
+  });
+
+  return promise;
+}
+
+type CompletionState = 'unknown' | 'completed' | 'not-completed';
+
+const AssignmentCard: React.FC<{
+  assignment: AssignmentSummary;
+  pseudonymUid: string | null;
+}> = ({ assignment, pseudonymUid }) => {
+  const config = KIND_CONFIG[assignment.kind];
+  const [completion, setCompletion] = useState<CompletionState>('unknown');
+
+  // Lazy completion: fire one callable + one getDoc per card on mount.
+  // Pseudonym results are cached via `getCachedPseudonym`, so 30
+  // assignments from the same student = 30 callables (unavoidable —
+  // one per sessionId) and 30 doc reads. Same-kind retries reuse cached
+  // pseudonyms on remount.
+  useEffect(() => {
+    if (!pseudonymUid) return;
+    if (!config.responseSubcollection) {
+      // Collection has no per-student response docs — skip the badge.
+      return;
+    }
+
+    let cancelled = false;
+
+    const run = async () => {
+      try {
+        const pseudonym = await getCachedPseudonym(
+          assignment.sessionId,
+          pseudonymUid
+        );
+        if (cancelled) return;
+
+        const responseSub = config.responseSubcollection;
+        if (!responseSub) return;
+        const snap = await getDoc(
+          doc(
+            db,
+            config.collectionName,
+            assignment.sessionId,
+            responseSub,
+            pseudonym
+          )
+        );
+        if (cancelled) return;
+        setCompletion(snap.exists() ? 'completed' : 'not-completed');
+      } catch {
+        // Silent: a failed completion check shouldn't block the student
+        // from opening the assignment. Leave completion as 'unknown'.
+        if (cancelled) return;
+        setCompletion('unknown');
+      }
+    };
+
+    void run();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    assignment.sessionId,
+    pseudonymUid,
+    config.responseSubcollection,
+    config.collectionName,
+  ]);
+
+  const Icon = config.icon;
+  const isCompleted = completion === 'completed';
+
+  return (
+    <a
+      href={assignment.openHref}
+      className={`group block rounded-2xl border border-slate-200 bg-white/80 backdrop-blur-sm shadow-sm hover:shadow-md hover:border-slate-300 transition focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue-primary focus-visible:ring-offset-2 focus-visible:ring-offset-slate-50 ${
+        isCompleted ? 'opacity-75' : ''
+      }`}
+    >
+      <div className="flex items-center gap-4 p-4 sm:p-5">
+        <div
+          className={`w-11 h-11 sm:w-12 sm:h-12 rounded-xl bg-gradient-to-br ${config.accent} flex items-center justify-center shadow-sm shrink-0`}
+          aria-hidden="true"
+        >
+          <Icon
+            className="w-5 h-5 sm:w-6 sm:h-6 text-white"
+            strokeWidth={2.25}
+          />
+        </div>
+
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 flex-wrap">
+            <span className="text-[11px] sm:text-xs uppercase font-bold tracking-wider text-slate-400">
+              {config.label}
+            </span>
+            {isCompleted && (
+              <span className="inline-flex items-center gap-1 text-[11px] sm:text-xs font-semibold text-emerald-600 bg-emerald-50 px-2 py-0.5 rounded-full">
+                <CheckCircle2 className="w-3 h-3" strokeWidth={2.5} />
+                Completed
+              </span>
+            )}
+          </div>
+          <p className="mt-0.5 text-sm sm:text-base font-bold text-slate-800 truncate">
+            {assignment.title}
+          </p>
+        </div>
+
+        <span
+          className="hidden sm:inline-flex items-center px-3 py-1.5 rounded-lg bg-brand-blue-primary text-white text-xs font-semibold shadow-sm shadow-brand-blue-primary/20 group-hover:bg-brand-blue-dark transition shrink-0"
+          aria-hidden="true"
+        >
+          Open
+        </span>
+      </div>
+    </a>
+  );
+};
+
+export default MyAssignmentsPage;
+export { MyAssignmentsPage };

--- a/components/student/StudentIdleTimeoutGuard.tsx
+++ b/components/student/StudentIdleTimeoutGuard.tsx
@@ -1,0 +1,43 @@
+/**
+ * StudentIdleTimeoutGuard — arms the 15-minute idle-timeout sign-out for
+ * studentRole (ClassLink-via-Google) sessions on the lightweight student
+ * assignment routes that DON'T sit behind `StudentAuthProvider`
+ * (Mini-app, Video Activity, Activity Wall, Guided Learning).
+ *
+ * No-op for:
+ *   - Anonymous code+PIN student launches (no `studentRole` claim).
+ *   - Teachers previewing a student route (no `studentRole` claim).
+ *   - Auth-bypass testing mode.
+ *
+ * Subscribes to `onIdTokenChanged` so claim updates from a mid-session token
+ * refresh (student switches classes, admin revokes role, etc.) propagate
+ * immediately — no page reload required.
+ */
+
+import React, { useEffect, useState } from 'react';
+import { onIdTokenChanged } from 'firebase/auth';
+import { auth, isAuthBypass } from '@/config/firebase';
+import { useStudentIdleTimeout } from '@/hooks/useStudentIdleTimeout';
+
+export const StudentIdleTimeoutGuard: React.FC = () => {
+  const [isStudentRole, setIsStudentRole] = useState(false);
+
+  useEffect(() => {
+    if (isAuthBypass) return;
+    return onIdTokenChanged(auth, (user) => {
+      if (!user) {
+        setIsStudentRole(false);
+        return;
+      }
+      void user
+        .getIdTokenResult()
+        .then((result) => {
+          setIsStudentRole(result.claims.studentRole === true);
+        })
+        .catch(() => setIsStudentRole(false));
+    });
+  }, []);
+
+  useStudentIdleTimeout(isStudentRole);
+  return null;
+};

--- a/components/student/StudentIdleTimeoutGuard.tsx
+++ b/components/student/StudentIdleTimeoutGuard.tsx
@@ -24,18 +24,30 @@ export const StudentIdleTimeoutGuard: React.FC = () => {
 
   useEffect(() => {
     if (isAuthBypass) return;
-    return onIdTokenChanged(auth, (user) => {
+    let cancelled = false;
+    const unsubscribe = onIdTokenChanged(auth, (user) => {
       if (!user) {
-        setIsStudentRole(false);
+        if (!cancelled) setIsStudentRole(false);
         return;
       }
       void user
         .getIdTokenResult()
         .then((result) => {
+          if (cancelled) return;
+          // Drop stale resolutions: if the current user changed between
+          // callback fire and promise resolve, a newer callback will set
+          // the correct value.
+          if (auth.currentUser?.uid !== user.uid) return;
           setIsStudentRole(result.claims.studentRole === true);
         })
-        .catch(() => setIsStudentRole(false));
+        .catch(() => {
+          if (!cancelled) setIsStudentRole(false);
+        });
     });
+    return () => {
+      cancelled = true;
+      unsubscribe();
+    };
   }, []);
 
   useStudentIdleTimeout(isStudentRole);

--- a/components/student/StudentLoginPage.tsx
+++ b/components/student/StudentLoginPage.tsx
@@ -1,0 +1,431 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { signInWithCustomToken } from 'firebase/auth';
+import { httpsCallable, FunctionsError } from 'firebase/functions';
+import { Loader2, GraduationCap, AlertCircle, Inbox } from 'lucide-react';
+import { auth, functions } from '@/config/firebase';
+import { APP_NAME } from '@/config/constants';
+
+/**
+ * Student login page (Phase 2A of the ClassLink-via-Google auth flow).
+ *
+ * This page is intentionally PII-free on the client:
+ *   - We never render, log, or persist the student's email, name, or `sub`.
+ *   - The Google ID token is passed directly to `studentLoginV1` and discarded.
+ *   - Firebase Auth only ever sees the minted custom token, which contains an
+ *     opaque pseudonym UID.
+ *
+ * We use Google Identity Services (GIS) directly — NOT
+ * `signInWithPopup(googleProvider)` — because the built-in provider writes
+ * email / displayName / photoURL onto the Firebase Auth user record, which
+ * defeats the entire PII constraint.
+ */
+
+// ---------------------------------------------------------------------------
+// Minimal type declarations for Google Identity Services (no official types
+// exist for the `id` namespace). The project already pulls in
+// `@types/google.accounts` which covers `oauth2` but NOT `id`.
+// ---------------------------------------------------------------------------
+
+interface GsiCredentialResponse {
+  credential?: string;
+  select_by?: string;
+  clientId?: string;
+}
+
+interface GsiButtonConfig {
+  type?: 'standard' | 'icon';
+  theme?: 'outline' | 'filled_blue' | 'filled_black';
+  size?: 'small' | 'medium' | 'large';
+  text?: 'signin_with' | 'signup_with' | 'continue_with' | 'signin';
+  shape?: 'rectangular' | 'pill' | 'circle' | 'square';
+  logo_alignment?: 'left' | 'center';
+  width?: number | string;
+  locale?: string;
+}
+
+interface GsiInitializeOptions {
+  client_id: string;
+  callback: (response: GsiCredentialResponse) => void;
+  auto_select?: boolean;
+  cancel_on_tap_outside?: boolean;
+  use_fedcm_for_prompt?: boolean;
+  itp_support?: boolean;
+  ux_mode?: 'popup' | 'redirect';
+  context?: 'signin' | 'signup' | 'use';
+}
+
+interface GsiIdApi {
+  initialize(options: GsiInitializeOptions): void;
+  prompt(listener?: (notification: unknown) => void): void;
+  renderButton(parent: HTMLElement, config: GsiButtonConfig): void;
+  cancel(): void;
+  disableAutoSelect(): void;
+}
+
+declare global {
+  interface Window {
+    google?: {
+      accounts?: {
+        id?: GsiIdApi;
+      };
+    };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Response + error-code shapes for the studentLoginV1 callable.
+// Kept narrow on purpose — any claim about the student is server-side only.
+// ---------------------------------------------------------------------------
+
+interface StudentLoginV1Response {
+  customToken: string;
+  /** Organization id the student was matched to (non-PII, shared across students). */
+  orgId?: string;
+  /** Count of ClassLink classes the student is enrolled in. */
+  classCount?: number;
+  /** Optional future extension; if the function ever returns it, we forward a hint to /my-assignments. */
+  hasAssignments?: boolean;
+  /** Reserved for future shape evolution. */
+  classIds?: string[];
+}
+
+type ErrorKind =
+  | 'config-missing'
+  | 'domain-not-registered'
+  | 'not-in-roster'
+  | 'service-unavailable'
+  | 'generic';
+
+const ERROR_COPY: Record<ErrorKind, { title: string; body: string }> = {
+  'config-missing': {
+    title: 'Sign-in is not configured',
+    body: 'Ask your teacher to let their admin know SpartBoard is missing a Google client ID.',
+  },
+  'domain-not-registered': {
+    title: "We don't recognize your school",
+    body: 'This SpartBoard is only available to schools that have signed up. Ask your teacher to reach out to their admin if you think this is wrong.',
+  },
+  'not-in-roster': {
+    title: "You're not on a roster yet",
+    body: "You're not on any class rosters yet. If you just started at your school, ask a teacher to sync their roster.",
+  },
+  'service-unavailable': {
+    title: 'Roster service is unreachable',
+    body: "We can't reach the roster service right now. Try again in a few minutes.",
+  },
+  generic: {
+    title: 'Something went wrong',
+    body: 'Something went wrong. Please try again.',
+  },
+};
+
+/** Map a FunctionsError code to our four user-facing error buckets. */
+function classifyError(err: unknown): ErrorKind {
+  if (err && typeof err === 'object' && 'code' in err) {
+    const code = (err as { code?: unknown }).code;
+    if (typeof code === 'string') {
+      // Firebase callable errors use the form "functions/<grpc-code>".
+      const normalized = code.startsWith('functions/')
+        ? code.slice('functions/'.length)
+        : code;
+      switch (normalized) {
+        case 'permission-denied':
+          return 'domain-not-registered';
+        case 'not-found':
+          return 'not-in-roster';
+        case 'unavailable':
+        case 'internal':
+        case 'deadline-exceeded':
+          return 'service-unavailable';
+        default:
+          return 'generic';
+      }
+    }
+  }
+  return 'generic';
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+type Status =
+  | { kind: 'loading-sdk' }
+  | { kind: 'ready' }
+  | { kind: 'verifying' }
+  | { kind: 'success' }
+  | { kind: 'error'; error: ErrorKind };
+
+const StudentLoginPage: React.FC = () => {
+  const clientId = import.meta.env.VITE_GOOGLE_CLIENT_ID as string | undefined;
+
+  const [status, setStatus] = useState<Status>(() =>
+    !clientId
+      ? { kind: 'error', error: 'config-missing' }
+      : { kind: 'loading-sdk' }
+  );
+  const buttonContainerRef = useRef<HTMLDivElement | null>(null);
+
+  // The callable handle is stable across retries — create once.
+  const studentLoginRef = useRef(
+    httpsCallable<{ idToken: string }, StudentLoginV1Response>(
+      functions,
+      'studentLoginV1'
+    )
+  );
+
+  const handleCredential = useCallback(
+    async (response: GsiCredentialResponse) => {
+      if (!response.credential) {
+        setStatus({ kind: 'error', error: 'generic' });
+        return;
+      }
+
+      setStatus({ kind: 'verifying' });
+      try {
+        const result = await studentLoginRef.current({
+          idToken: response.credential,
+        });
+        const { customToken, hasAssignments } = result.data;
+        if (!customToken) {
+          setStatus({ kind: 'error', error: 'generic' });
+          return;
+        }
+
+        await signInWithCustomToken(auth, customToken);
+        setStatus({ kind: 'success' });
+
+        // Forward a hint about emptiness if the function told us — the
+        // assignments page will render its own empty state either way.
+        const target =
+          hasAssignments === false
+            ? '/my-assignments?empty=1'
+            : '/my-assignments';
+        window.location.assign(target);
+      } catch (err) {
+        // IMPORTANT: never log the id_token or the raw error object — either
+        // could carry PII. We only pull out `code` via classifyError.
+        const kind = classifyError(err);
+        if (err instanceof FunctionsError) {
+          // Log only the error code for debugging. Never log `err.message` or
+          // `err.details` — the server may include email-derived diagnostics.
+          console.warn('[studentLogin] callable failed:', err.code);
+        } else {
+          console.warn(
+            '[studentLogin] callable failed with non-callable error'
+          );
+        }
+        setStatus({ kind: 'error', error: kind });
+      }
+    },
+    []
+  );
+
+  // Poll briefly for the GIS SDK (the script tag is `async`), then init
+  // once it's available. This is an "external system" sync, hence useEffect.
+  useEffect(() => {
+    if (!clientId) return;
+    if (status.kind === 'error' && status.error !== 'config-missing') return;
+
+    let cancelled = false;
+    let attempts = 0;
+    const maxAttempts = 50; // ~5s at 100ms intervals
+
+    const init = () => {
+      const idApi = window.google?.accounts?.id;
+      if (!idApi) return false;
+
+      idApi.initialize({
+        client_id: clientId,
+        callback: handleCredential,
+        auto_select: true,
+        cancel_on_tap_outside: false,
+        itp_support: true,
+        context: 'signin',
+        ux_mode: 'popup',
+      });
+
+      if (buttonContainerRef.current) {
+        idApi.renderButton(buttonContainerRef.current, {
+          type: 'standard',
+          theme: 'outline',
+          size: 'large',
+          text: 'signin_with',
+          shape: 'pill',
+          logo_alignment: 'left',
+        });
+      }
+
+      // Try One-Tap. If it's suppressed the fallback button remains available.
+      idApi.prompt();
+
+      if (!cancelled) setStatus({ kind: 'ready' });
+      return true;
+    };
+
+    if (init()) return;
+
+    const interval = window.setInterval(() => {
+      attempts += 1;
+      if (init() || attempts >= maxAttempts) {
+        window.clearInterval(interval);
+        if (attempts >= maxAttempts && !cancelled) {
+          setStatus({ kind: 'error', error: 'service-unavailable' });
+        }
+      }
+    }, 100);
+
+    return () => {
+      cancelled = true;
+      window.clearInterval(interval);
+      // Best-effort: cancel any outstanding One-Tap prompt on unmount.
+      try {
+        window.google?.accounts?.id?.cancel();
+      } catch {
+        // Non-fatal — SDK may not be loaded.
+      }
+    };
+    // `handleCredential` is stable via useCallback; intentionally not reinit-ing
+    // GIS on status changes.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [clientId, handleCredential]);
+
+  const handleRetry = useCallback(() => {
+    setStatus(
+      !clientId
+        ? { kind: 'error', error: 'config-missing' }
+        : { kind: 'loading-sdk' }
+    );
+  }, [clientId]);
+
+  return (
+    <div className="relative min-h-screen w-screen flex items-center justify-center bg-slate-50 overflow-hidden font-sans px-4 py-8">
+      {/* Subtle radial dotted background, matching the teacher login tone. */}
+      <div className="absolute inset-0 bg-[radial-gradient(#e5e7eb_1px,transparent_1px)] [background-size:16px_16px] opacity-50" />
+      <div className="absolute top-1/4 -left-1/4 w-[500px] h-[500px] rounded-full blur-[100px] bg-brand-blue-primary/20 animate-pulse" />
+      <div className="absolute -bottom-1/4 -right-1/4 w-[500px] h-[500px] bg-brand-red-primary/10 rounded-full blur-[100px] animate-pulse delay-1000" />
+
+      <div className="relative z-10 bg-white/80 backdrop-blur-xl p-10 sm:p-12 rounded-3xl shadow-[0_8px_30px_rgb(0,0,0,0.04)] border border-slate-100/60 ring-1 ring-slate-900/5 max-w-md w-full text-center">
+        {/* Brand mark */}
+        <div className="mx-auto w-16 h-16 bg-gradient-to-br from-brand-blue-primary to-brand-blue-dark rounded-2xl flex items-center justify-center shadow-lg shadow-brand-blue-primary/20 mb-8 transform -rotate-3 hover:rotate-0 transition-transform duration-300">
+          <GraduationCap className="w-8 h-8 text-white" strokeWidth={2.5} />
+        </div>
+
+        <h1 className="text-3xl sm:text-4xl font-black text-slate-800 tracking-tight mb-3">
+          {APP_NAME}
+        </h1>
+        <p className="text-slate-500 mb-8 font-medium text-sm sm:text-base">
+          Sign in with your school Google account to see your assignments.
+        </p>
+
+        <StatusContent
+          status={status}
+          buttonContainerRef={buttonContainerRef}
+          onRetry={handleRetry}
+        />
+      </div>
+    </div>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// Status sub-view — split out to keep the top-level component readable.
+// ---------------------------------------------------------------------------
+
+interface StatusContentProps {
+  status: Status;
+  buttonContainerRef: React.RefObject<HTMLDivElement | null>;
+  onRetry: () => void;
+}
+
+const StatusContent: React.FC<StatusContentProps> = ({
+  status,
+  buttonContainerRef,
+  onRetry,
+}) => {
+  // The GIS button must stay mounted whenever we're in the `ready` (or
+  // early `loading-sdk`) states so that `renderButton` has a target. We
+  // toggle visibility with `hidden` rather than unmounting.
+  const showButton = status.kind === 'ready' || status.kind === 'loading-sdk';
+
+  return (
+    <div className="min-h-[140px] flex flex-col items-center justify-center gap-4">
+      {status.kind === 'loading-sdk' && (
+        <div className="flex flex-col items-center gap-3 text-slate-500">
+          <Loader2 className="w-6 h-6 animate-spin text-brand-blue-primary" />
+          <p className="text-sm font-medium">Loading sign-in…</p>
+        </div>
+      )}
+
+      {status.kind === 'verifying' && (
+        <div className="flex flex-col items-center gap-3 text-slate-500">
+          <Loader2 className="w-6 h-6 animate-spin text-brand-blue-primary" />
+          <p className="text-sm font-medium">Checking your classes…</p>
+        </div>
+      )}
+
+      {status.kind === 'success' && (
+        <div className="flex flex-col items-center gap-3 text-slate-500">
+          <Loader2 className="w-6 h-6 animate-spin text-brand-blue-primary" />
+          <p className="text-sm font-medium">Signing you in…</p>
+        </div>
+      )}
+
+      {status.kind === 'error' && (
+        <ErrorView error={status.error} onRetry={onRetry} />
+      )}
+
+      <div
+        ref={buttonContainerRef}
+        className="flex justify-center w-full"
+        aria-hidden={!showButton}
+        hidden={!showButton}
+      />
+    </div>
+  );
+};
+
+// ---------------------------------------------------------------------------
+
+interface ErrorViewProps {
+  error: ErrorKind;
+  onRetry: () => void;
+}
+
+const ErrorView: React.FC<ErrorViewProps> = ({ error, onRetry }) => {
+  const copy = ERROR_COPY[error];
+  // "Not in roster" is an empty-state, not a hard error — softer tone.
+  const isSoft = error === 'not-in-roster';
+  const Icon = isSoft ? Inbox : AlertCircle;
+  const iconColor = isSoft ? 'text-slate-400' : 'text-brand-red-primary';
+  const canRetry =
+    error !== 'domain-not-registered' && error !== 'config-missing';
+
+  return (
+    <div className="flex flex-col items-center gap-4 w-full">
+      <div
+        className={`w-12 h-12 rounded-2xl flex items-center justify-center ${
+          isSoft ? 'bg-slate-100' : 'bg-brand-red-primary/10'
+        }`}
+      >
+        <Icon className={`w-6 h-6 ${iconColor}`} strokeWidth={2} />
+      </div>
+      <div className="space-y-1.5">
+        <h2 className="text-base font-bold text-slate-800">{copy.title}</h2>
+        <p className="text-sm text-slate-500 leading-relaxed">{copy.body}</p>
+      </div>
+      {canRetry && (
+        <button
+          type="button"
+          onClick={onRetry}
+          className="mt-2 px-5 py-2.5 bg-brand-blue-primary text-white rounded-xl font-semibold text-sm hover:bg-brand-blue-dark transition-colors shadow-md shadow-brand-blue-primary/20"
+        >
+          Try again
+        </button>
+      )}
+    </div>
+  );
+};
+
+export default StudentLoginPage;
+export { StudentLoginPage };

--- a/components/widgets/ActivityWall/Widget.test.tsx
+++ b/components/widgets/ActivityWall/Widget.test.tsx
@@ -104,6 +104,16 @@ vi.mock('firebase/firestore', () => ({
   deleteField: vi.fn(() => '__delete__'),
 }));
 
+// Phase 3D: the widget fetches ClassLink classes on mount to decide
+// whether to show the target-class selector. Tests don't exercise
+// ClassLink, so stub the service to a no-op that returns an empty
+// classes list.
+vi.mock('@/utils/classlinkService', () => ({
+  classLinkService: {
+    getRosters: vi.fn().mockResolvedValue({ classes: [], studentsByClass: {} }),
+  },
+}));
+
 describe('ActivityWallWidget', () => {
   const baseWidget: WidgetData = {
     id: 'widget-1',

--- a/components/widgets/ActivityWall/Widget.tsx
+++ b/components/widgets/ActivityWall/Widget.tsx
@@ -14,6 +14,7 @@ import {
   Plus,
   QrCode,
   Trash2,
+  Users,
 } from 'lucide-react';
 import {
   WidgetData,
@@ -21,9 +22,11 @@ import {
   ActivityWallConfig,
   ActivityWallActivity,
   ActivityWallSubmission,
+  ClassLinkClass,
 } from '@/types';
 import { useDashboard } from '@/context/useDashboard';
 import { useAuth } from '@/context/useAuth';
+import { classLinkService } from '@/utils/classlinkService';
 import { WidgetLayout } from '@/components/widgets/WidgetLayout';
 import { db, functions, storage } from '@/config/firebase';
 import {
@@ -251,6 +254,17 @@ const buildBlankActivity = (): ActivityWallActivity => ({
   startedAt: null,
 });
 
+/**
+ * Human-readable label for a ClassLink class. Mirrors the format used by
+ * `ClassLinkImportDialog` and `QuizManager` so teachers see the same
+ * class names across every assignment-targeting flow.
+ */
+const formatClassLinkClassLabel = (cls: ClassLinkClass): string => {
+  const subjectPrefix = cls.subject ? `${cls.subject} - ` : '';
+  const codeSuffix = cls.classCode ? ` (${cls.classCode})` : '';
+  return `${subjectPrefix}${cls.title}${codeSuffix}`;
+};
+
 export const ActivityWallWidget: React.FC<{ widget: WidgetData }> = ({
   widget,
 }) => {
@@ -270,6 +284,35 @@ export const ActivityWallWidget: React.FC<{ widget: WidgetData }> = ({
     null
   );
   const [showLiveView, setShowLiveView] = useState(false);
+
+  // ─── ClassLink target-class fetch (Phase 3D) ────────────────────────────
+  // Teacher's ClassLink classes (if provisioned). Fetched once per widget
+  // mount via the existing `classLinkService` (5-min cache — cheap). If the
+  // teacher isn't on a ClassLink-provisioned org, the list stays empty and
+  // the target-class selector is hidden entirely. Errors are swallowed:
+  // ClassLink being unreachable must not block `?data=`-based launches.
+  const [classLinkClasses, setClassLinkClasses] = useState<ClassLinkClass[]>(
+    []
+  );
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const data = await classLinkService.getRosters();
+        if (cancelled) return;
+        setClassLinkClasses(data.classes);
+      } catch (err) {
+        // Silent: no-ClassLink orgs and transient failures both fall back
+        // to `?data=`-only launches, so the selector stays hidden.
+        if (import.meta.env.DEV) {
+          console.warn('[ActivityWall] ClassLink fetch failed:', err);
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
   const [selectedSubmissionId, setSelectedSubmissionId] = useState<
     string | null
   >(null);
@@ -342,6 +385,13 @@ export const ActivityWallWidget: React.FC<{ widget: WidgetData }> = ({
   useEffect(() => {
     if (!activeActivity || !user || !activeSessionId) return;
 
+    // Phase 3D: Mirror the full activity config onto the session doc so
+    // students who land via `/my-assignments` (no `?data=` payload) can
+    // hydrate the same UX as the base64-URL path — including moderation
+    // and participant-identification behavior. `classId`, when present,
+    // additionally gates ClassLink-authenticated student reads via
+    // Firestore rules (`passesStudentClassGate`); omitting it preserves
+    // the classic code/PIN-only flow.
     void setDoc(
       doc(db, 'activity_wall_sessions', activeSessionId),
       {
@@ -351,7 +401,10 @@ export const ActivityWallWidget: React.FC<{ widget: WidgetData }> = ({
         title: activeActivity.title,
         prompt: activeActivity.prompt,
         mode: activeActivity.mode,
+        moderationEnabled: activeActivity.moderationEnabled,
+        identificationMode: activeActivity.identificationMode,
         updatedAt: Date.now(),
+        ...(activeActivity.classId ? { classId: activeActivity.classId } : {}),
       },
       { merge: true }
     );
@@ -488,17 +541,45 @@ export const ActivityWallWidget: React.FC<{ widget: WidgetData }> = ({
     [updateWidget, widget.config, widget.id]
   );
 
+  // Open the editor seeded with the teacher's last-used classId for this
+  // activity (Phase 3D). Keeps the same UX as QuizManager where re-assigning
+  // the same item pre-fills the previous target class without surprising
+  // the teacher on a fresh "New" activity.
+  const openEditor = (activity: ActivityWallActivity) => {
+    const lastUsed = config.lastClassIdByActivityId?.[activity.id];
+    if (!activity.classId && lastUsed) {
+      setEditorDraft({ ...activity, classId: lastUsed });
+    } else {
+      setEditorDraft(activity);
+    }
+  };
+
   const saveEditorDraft = () => {
     if (!editorDraft) return;
     const title = editorDraft.title.trim();
     const prompt = editorDraft.prompt.trim();
     if (!title || !prompt) return;
 
+    // Phase 3D guard: if the teacher somehow held onto a classId that is
+    // no longer in the fetched ClassLink list (e.g. rosters changed
+    // between editor open and save), fall through to no-class rather
+    // than writing a stale id onto the activity or session doc.
+    const draftClassId = editorDraft.classId ?? '';
+    const selectedClassId =
+      draftClassId && classLinkClasses.some((c) => c.sourcedId === draftClassId)
+        ? draftClassId
+        : '';
+
     const nextActivity: ActivityWallActivity = {
       ...editorDraft,
       title,
       prompt,
       startedAt: editorDraft.startedAt ?? Date.now(),
+      // Only write `classId` onto the activity when non-empty so the
+      // Firestore session doc — and match-back rules — don't see a
+      // stale id. `undefined` serializes cleanly and keeps the doc
+      // shape aligned with the classic code/PIN flow.
+      classId: selectedClassId || undefined,
     };
 
     const exists = activities.some((a) => a.id === nextActivity.id);
@@ -506,9 +587,22 @@ export const ActivityWallWidget: React.FC<{ widget: WidgetData }> = ({
       ? activities.map((a) => (a.id === nextActivity.id ? nextActivity : a))
       : [...activities, nextActivity];
 
+    // Persist the teacher's last-used classId per activity so re-opening
+    // the same activity's editor pre-selects the same class. Clearing
+    // (picking "No class") removes the entry rather than writing an
+    // empty string to keep the config map small.
+    const prevMap = config.lastClassIdByActivityId ?? {};
+    const nextMap: Record<string, string> = { ...prevMap };
+    if (selectedClassId) {
+      nextMap[nextActivity.id] = selectedClassId;
+    } else {
+      delete nextMap[nextActivity.id];
+    }
+
     updateConfig({
       activities: nextActivities,
       activeActivityId: nextActivity.id,
+      lastClassIdByActivityId: nextMap,
     });
     setEditorDraft(null);
     setShowLiveView(true);
@@ -1082,6 +1176,49 @@ export const ActivityWallWidget: React.FC<{ widget: WidgetData }> = ({
                     <option value="name-pin">Name &amp; PIN</option>
                   </select>
                 </label>
+
+                {classLinkClasses.length > 0 && (
+                  <label className="block">
+                    <span
+                      className="flex items-center gap-1.5 font-black uppercase tracking-wider text-slate-600 mb-1"
+                      style={{ fontSize: 'min(10px, 3.2cqmin)' }}
+                    >
+                      <Users
+                        className="text-brand-blue-primary"
+                        style={{
+                          width: 'min(12px, 3.4cqmin)',
+                          height: 'min(12px, 3.4cqmin)',
+                        }}
+                      />
+                      Target class (optional)
+                    </span>
+                    <select
+                      value={editorDraft.classId ?? ''}
+                      onChange={(event) =>
+                        setEditorDraft({
+                          ...editorDraft,
+                          classId: event.target.value || undefined,
+                        })
+                      }
+                      className="w-full px-3 py-2 border border-slate-200 rounded-xl focus:ring-2 focus:ring-brand-blue-primary focus:outline-none"
+                      style={{ fontSize: 'min(12px, 3.8cqmin)' }}
+                    >
+                      <option value="">No class (use link only)</option>
+                      {classLinkClasses.map((cls) => (
+                        <option key={cls.sourcedId} value={cls.sourcedId}>
+                          {formatClassLinkClassLabel(cls)}
+                        </option>
+                      ))}
+                    </select>
+                    <p
+                      className="text-slate-500 mt-1"
+                      style={{ fontSize: 'min(9px, 2.9cqmin)' }}
+                    >
+                      Students in this class will see this activity in their
+                      assignments list. Leave blank to use a shareable link.
+                    </p>
+                  </label>
+                )}
               </div>
             </div>
 
@@ -1135,7 +1272,7 @@ export const ActivityWallWidget: React.FC<{ widget: WidgetData }> = ({
               <button
                 type="button"
                 onClick={() => {
-                  setEditorDraft(buildBlankActivity());
+                  openEditor(buildBlankActivity());
                   setShowLiveView(false);
                 }}
                 className="rounded-xl bg-brand-blue-primary text-white font-black uppercase flex items-center"
@@ -1216,7 +1353,7 @@ export const ActivityWallWidget: React.FC<{ widget: WidgetData }> = ({
                         </button>
                         <button
                           type="button"
-                          onClick={() => setEditorDraft(activity)}
+                          onClick={() => openEditor(activity)}
                           className="rounded-lg bg-amber-500 text-white font-bold flex items-center justify-center"
                           style={{ gap: 'min(4px, 1.1cqmin)' }}
                         >

--- a/components/widgets/GuidedLearning/Widget.tsx
+++ b/components/widgets/GuidedLearning/Widget.tsx
@@ -1,7 +1,8 @@
-import React, { useState, useCallback, useMemo } from 'react';
+import React, { useState, useCallback, useEffect, useMemo } from 'react';
 import { doc, writeBatch } from 'firebase/firestore';
 import {
   WidgetData,
+  ClassLinkClass,
   GuidedLearningConfig,
   GuidedLearningSet,
   GuidedLearningSetMetadata,
@@ -14,18 +15,32 @@ import { useGuidedLearning } from '@/hooks/useGuidedLearning';
 import { useGuidedLearningSessionTeacher } from '@/hooks/useGuidedLearningSession';
 import { useGuidedLearningAssignments } from '@/hooks/useGuidedLearningAssignments';
 import { useFolders } from '@/hooks/useFolders';
+import { classLinkService } from '@/utils/classlinkService';
 import { WidgetLayout } from '@/components/widgets/WidgetLayout';
+import { AssignModal } from '@/components/common/library';
 import { GuidedLearningManager } from './components/GuidedLearningManager';
 import { GuidedLearningEditorModal } from './components/GuidedLearningEditorModal';
 import { GuidedLearningPlayer } from './components/GuidedLearningPlayer';
 import { GuidedLearningResults } from './components/GuidedLearningResults';
-import { Loader2 } from 'lucide-react';
+import { Loader2, Users } from 'lucide-react';
 
 // ─── AI generation modal (admin only) ────────────────────────────────────────
 import { GuidedLearningAIGenerator } from './components/GuidedLearningAIGenerator';
 import { normalizeGuidedLearningSet } from './utils/setMigration';
 
 const GL_PERSONAL_COLLECTION = 'guided_learning';
+
+/**
+ * Pending Assign-dialog target (Phase 3C). Holds the already-loaded set
+ * and its source hint so the confirm step can create the matching
+ * assignment doc once the teacher picks (or skips) a ClassLink target
+ * class.
+ */
+interface AssignDialogTarget {
+  set: GuidedLearningSet;
+  source: 'personal' | 'building';
+  originSetId: string;
+}
 
 export const GuidedLearningWidget: React.FC<{ widget: WidgetData }> = ({
   widget,
@@ -81,6 +96,61 @@ export const GuidedLearningWidget: React.FC<{ widget: WidgetData }> = ({
   const [recentSessionIds, setRecentSessionIds] = useState<
     Record<string, string>
   >({});
+
+  // ─── ClassLink target-class fetch (Phase 3C) ────────────────────────────────
+  // Teacher's ClassLink classes (if provisioned). Fetched once per Widget
+  // mount via the shared `classLinkService` (5-min cache). If the teacher
+  // isn't on a ClassLink-provisioned org, the list stays empty and the
+  // Assign dialog is skipped entirely. Errors are swallowed: ClassLink
+  // being unreachable must not block classic join-link launches.
+  const [classLinkClasses, setClassLinkClasses] = useState<ClassLinkClass[]>(
+    []
+  );
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const data = await classLinkService.getRosters();
+        if (cancelled) return;
+        setClassLinkClasses(data.classes);
+      } catch (err) {
+        // Silent: no-ClassLink orgs and transient failures both fall back
+        // to classic join-link-only launches, so the selector stays hidden.
+        if (import.meta.env.DEV) {
+          console.warn('[GuidedLearning] ClassLink fetch failed:', err);
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // ─── Assign dialog state (Phase 3C) ─────────────────────────────────────────
+  // When a teacher clicks "Assign" and a ClassLink-provisioned org is in
+  // play, we pause to let them optionally pick a target class before
+  // actually creating the session. `assignTarget` holds the already-loaded
+  // set along with the source hint so we can create the assignment doc
+  // after confirmation.
+  const [assignTarget, setAssignTarget] = useState<AssignDialogTarget | null>(
+    null
+  );
+  const [assignOptions, setAssignOptions] = useState<{ classId: string }>({
+    classId: '',
+  });
+
+  // Reset the pending classId when the dialog re-opens for a different set
+  // (adjust-state-while-rendering pattern — no effect needed).
+  const [prevAssignTarget, setPrevAssignTarget] =
+    useState<AssignDialogTarget | null>(null);
+  if (assignTarget !== prevAssignTarget) {
+    setPrevAssignTarget(assignTarget);
+    if (assignTarget) {
+      setAssignOptions({
+        classId: config.lastClassIdBySetId?.[assignTarget.originSetId] ?? '',
+      });
+    }
+  }
 
   const setView = useCallback(
     (view: GuidedLearningConfig['view']) => {
@@ -176,6 +246,64 @@ export const GuidedLearningWidget: React.FC<{ widget: WidgetData }> = ({
     }
   };
 
+  // Actually create the session + matching assignment doc. Shared between
+  // the classic direct-assign path (no ClassLink org) and the target-class
+  // dialog confirm path. `classId` is the ClassLink class sourcedId, or
+  // `null` for "No class".
+  const performAssign = useCallback(
+    async (
+      data: GuidedLearningSet,
+      source: 'personal' | 'building',
+      originSetId: string,
+      classId: string | null
+    ) => {
+      try {
+        const url = await createSession(data, classId ?? undefined);
+        const sessionId = url.split('/').pop() ?? '';
+        setRecentSessionIds((prev) => ({
+          ...prev,
+          [originSetId]: sessionId,
+        }));
+        if (sessionId) {
+          try {
+            await createAssignment({
+              sessionId,
+              setId: data.id,
+              setTitle: data.title,
+              source,
+            });
+          } catch (err) {
+            console.warn('[GuidedLearning] Failed to record assignment:', err);
+          }
+        }
+        // Persist the teacher's last-used classId per set so re-launching
+        // the same set pre-selects the same class. Clearing (picking "No
+        // class") removes the entry rather than writing an empty string to
+        // keep the config map small.
+        const prevMap = config.lastClassIdBySetId ?? {};
+        const nextMap: Record<string, string> = { ...prevMap };
+        if (classId) {
+          nextMap[originSetId] = classId;
+        } else {
+          delete nextMap[originSetId];
+        }
+        updateWidget(widget.id, {
+          config: {
+            ...config,
+            lastClassIdBySetId: nextMap,
+          } as GuidedLearningConfig,
+        });
+        await navigator.clipboard.writeText(url);
+        addToast('Assignment link copied to clipboard!', 'success');
+      } catch (err) {
+        const msg =
+          err instanceof Error ? err.message : 'Failed to create session';
+        addToast(msg, 'error');
+      }
+    },
+    [createSession, createAssignment, addToast, config, updateWidget, widget.id]
+  );
+
   const handleAssign = async (
     setId: string,
     driveFileId?: string,
@@ -183,32 +311,33 @@ export const GuidedLearningWidget: React.FC<{ widget: WidgetData }> = ({
   ) => {
     const data = await loadSet(setId, driveFileId, buildingSet);
     if (!data) return;
-    try {
-      const url = await createSession(data);
-      const sessionId = url.split('/').pop() ?? '';
-      setRecentSessionIds((prev) => ({
-        ...prev,
-        [setId]: sessionId,
-      }));
-      if (sessionId) {
-        try {
-          await createAssignment({
-            sessionId,
-            setId: data.id,
-            setTitle: data.title,
-            source: buildingSet ? 'building' : 'personal',
-          });
-        } catch (err) {
-          console.warn('[GuidedLearning] Failed to record assignment:', err);
-        }
-      }
-      await navigator.clipboard.writeText(url);
-      addToast('Assignment link copied to clipboard!', 'success');
-    } catch (err) {
-      const msg =
-        err instanceof Error ? err.message : 'Failed to create session';
-      addToast(msg, 'error');
+    const source: 'personal' | 'building' = buildingSet
+      ? 'building'
+      : 'personal';
+    // If the teacher isn't on a ClassLink-provisioned org (or the fetch
+    // failed), skip the dialog entirely and preserve the classic
+    // join-link flow.
+    if (classLinkClasses.length === 0) {
+      await performAssign(data, source, setId, null);
+      return;
     }
+    // Otherwise open the dialog so they can optionally pick a target class.
+    setAssignTarget({ set: data, source, originSetId: setId });
+  };
+
+  const handleAssignConfirm = async (): Promise<void> => {
+    if (!assignTarget) return;
+    // Guard: if the teacher somehow picked a classId that's no longer in the
+    // fetched ClassLink list (e.g. rosters changed between fetch and confirm),
+    // fall through to no-class rather than writing a stale id.
+    const selectedClassId =
+      assignOptions.classId &&
+      classLinkClasses.some((c) => c.sourcedId === assignOptions.classId)
+        ? assignOptions.classId
+        : null;
+    const { set, source, originSetId } = assignTarget;
+    setAssignTarget(null);
+    await performAssign(set, source, originSetId, selectedClassId);
   };
 
   const handleViewResultsForRecent = async (sessionId: string) => {
@@ -497,6 +626,79 @@ export const GuidedLearningWidget: React.FC<{ widget: WidgetData }> = ({
           setEditingMeta(null);
         }}
       />
+
+      {assignTarget && (
+        <AssignModal<{ classId: string }>
+          isOpen={!!assignTarget}
+          onClose={() => setAssignTarget(null)}
+          itemTitle={assignTarget.set.title || 'Untitled set'}
+          options={assignOptions}
+          onOptionsChange={setAssignOptions}
+          extraSlot={
+            <GuidedLearningAssignTargetClassRow
+              classes={classLinkClasses}
+              value={assignOptions.classId}
+              onChange={(v) => setAssignOptions({ classId: v })}
+            />
+          }
+          onAssign={() => handleAssignConfirm()}
+          confirmLabel="Assign"
+        />
+      )}
     </>
+  );
+};
+
+/**
+ * Build a human-readable label for a ClassLink class. Mirrors the format
+ * used by `ClassLinkImportDialog` and `QuizManager` so teachers see the
+ * same class names across flows.
+ */
+function formatClassLinkClassLabel(cls: ClassLinkClass): string {
+  const subjectPrefix = cls.subject ? `${cls.subject} - ` : '';
+  const codeSuffix = cls.classCode ? ` (${cls.classCode})` : '';
+  return `${subjectPrefix}${cls.title}${codeSuffix}`;
+}
+
+/**
+ * Target-class selector rendered inside the Guided Learning Assign modal's
+ * `extraSlot`. Lets the teacher pick an optional ClassLink class to target
+ * this set at so that students who signed in via ClassLink see it on their
+ * `/my-assignments` page. Phase 3C — fan-out of the Quiz pilot.
+ */
+const GuidedLearningAssignTargetClassRow: React.FC<{
+  classes: ClassLinkClass[];
+  value: string;
+  onChange: (next: string) => void;
+}> = ({ classes, value, onChange }) => {
+  return (
+    <div>
+      <div className="flex items-center gap-2 mb-1">
+        <Users className="w-4 h-4 text-brand-blue-primary" />
+        <label
+          htmlFor="gl-assign-target-class"
+          className="text-sm font-bold text-brand-blue-dark"
+        >
+          Target class (optional)
+        </label>
+      </div>
+      <select
+        id="gl-assign-target-class"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        className="w-full px-3 py-2 bg-white border border-slate-200 rounded-lg text-slate-800 text-sm focus:outline-none focus:ring-2 focus:ring-brand-blue-primary"
+      >
+        <option value="">No class (use join code)</option>
+        {classes.map((cls) => (
+          <option key={cls.sourcedId} value={cls.sourcedId}>
+            {formatClassLinkClassLabel(cls)}
+          </option>
+        ))}
+      </select>
+      <p className="text-xxs text-slate-500 mt-1">
+        Students in this class will see this activity in their assignments list.
+        Leave blank to use a join code.
+      </p>
+    </div>
   );
 };

--- a/components/widgets/GuidedLearning/components/GuidedLearningResults.tsx
+++ b/components/widgets/GuidedLearning/components/GuidedLearningResults.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import {
   BarChart2,
   Download,
@@ -7,11 +7,17 @@ import {
   CheckCircle2,
   Loader2,
 } from 'lucide-react';
+import { doc, getDoc } from 'firebase/firestore';
+import { db } from '@/config/firebase';
 import { GuidedLearningSet } from '@/types';
 import {
   useGuidedLearningSessionTeacher,
   isAnswerCorrect,
 } from '@/hooks/useGuidedLearningSession';
+import {
+  useAssignmentPseudonyms,
+  formatStudentName,
+} from '@/hooks/useAssignmentPseudonyms';
 
 interface Props {
   set: GuidedLearningSet;
@@ -35,6 +41,30 @@ export const GuidedLearningResults: React.FC<Props> = ({
     const unsub = subscribeToResponses(sessionId);
     return unsub;
   }, [sessionId, subscribeToResponses]);
+
+  // Fetch the session doc once to learn the optional classId. When set
+  // (ClassLink-assigned), we resolve pseudonyms to real student names.
+  const [classId, setClassId] = useState<string | null>(null);
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const snap = await getDoc(
+          doc(db, 'guided_learning_sessions', sessionId)
+        );
+        if (cancelled) return;
+        const data = snap.data() as { classId?: string } | undefined;
+        setClassId(data?.classId ?? null);
+      } catch {
+        if (!cancelled) setClassId(null);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [sessionId]);
+
+  const { byStudentUid } = useAssignmentPseudonyms(sessionId, classId);
 
   const {
     questionSteps,
@@ -235,26 +265,33 @@ export const GuidedLearningResults: React.FC<Props> = ({
                 Responses
               </h3>
               <div className="space-y-1.5">
-                {responseStats.map(({ response: r, qCorrect, qAnswered }) => (
-                  <div
-                    key={r.studentAnonymousId}
-                    className="flex items-center justify-between bg-white/5 rounded-lg px-3 py-2"
-                  >
-                    <div>
-                      <span className="text-white text-xs font-medium">
-                        {r.pin ? `PIN: ${r.pin}` : 'Anonymous'}
-                      </span>
-                      <span className="text-slate-500 text-xs ml-2">
-                        {r.completedAt ? 'Completed' : 'In progress'}
-                      </span>
+                {responseStats.map(({ response: r, qCorrect, qAnswered }) => {
+                  const classLinkName = formatStudentName(
+                    byStudentUid.get(r.studentAnonymousId)
+                  );
+                  const label =
+                    classLinkName || (r.pin ? `PIN: ${r.pin}` : 'Anonymous');
+                  return (
+                    <div
+                      key={r.studentAnonymousId}
+                      className="flex items-center justify-between bg-white/5 rounded-lg px-3 py-2"
+                    >
+                      <div>
+                        <span className="text-white text-xs font-medium">
+                          {label}
+                        </span>
+                        <span className="text-slate-500 text-xs ml-2">
+                          {r.completedAt ? 'Completed' : 'In progress'}
+                        </span>
+                      </div>
+                      {questionSteps.length > 0 && (
+                        <span className="text-slate-300 text-xs">
+                          {qCorrect}/{qAnswered} correct
+                        </span>
+                      )}
                     </div>
-                    {questionSteps.length > 0 && (
-                      <span className="text-slate-300 text-xs">
-                        {qCorrect}/{qAnswered} correct
-                      </span>
-                    )}
-                  </div>
-                ))}
+                  );
+                })}
               </div>
             </div>
           )}

--- a/components/widgets/MiniApp/Widget.tsx
+++ b/components/widgets/MiniApp/Widget.tsx
@@ -6,6 +6,7 @@ import {
   GlobalMiniAppItem,
   MiniAppAssignment,
   WidgetComponentProps,
+  ClassLinkClass,
 } from '@/types';
 import {
   LayoutGrid,
@@ -18,7 +19,9 @@ import {
   Loader2,
   CheckCircle2,
   ExternalLink,
+  Users,
 } from 'lucide-react';
+import { classLinkService } from '@/utils/classlinkService';
 import { WidgetLayout } from '../WidgetLayout';
 import { useAuth } from '@/context/useAuth';
 import { useMiniAppSessionTeacher } from '@/hooks/useMiniAppSession';
@@ -55,7 +58,23 @@ interface MiniAppAssignModalProps {
   error: string | null;
   onConfirm: () => void;
   onClose: () => void;
+  /** ClassLink classes for the target-class picker. Hidden when empty. */
+  classLinkClasses: ClassLinkClass[];
+  /** Currently-selected classId, or '' for no class. */
+  selectedClassId: string;
+  onClassIdChange: (next: string) => void;
 }
+
+/**
+ * Human-readable label for a ClassLink class. Mirrors the format used by
+ * `QuizManager` / `ActivityWallWidget` / etc. so teachers see the same class
+ * names across every assignment-targeting flow.
+ */
+const formatClassLinkClassLabel = (cls: ClassLinkClass): string => {
+  const subjectPrefix = cls.subject ? `${cls.subject} - ` : '';
+  const codeSuffix = cls.classCode ? ` (${cls.classCode})` : '';
+  return `${subjectPrefix}${cls.title}${codeSuffix}`;
+};
 
 const MiniAppAssignModal: React.FC<MiniAppAssignModalProps> = ({
   appTitle,
@@ -66,6 +85,9 @@ const MiniAppAssignModal: React.FC<MiniAppAssignModalProps> = ({
   error,
   onConfirm,
   onClose,
+  classLinkClasses,
+  selectedClassId,
+  onClassIdChange,
 }) => {
   const link = createdSessionId
     ? `${window.location.origin}/miniapp/${createdSessionId}`
@@ -182,6 +204,36 @@ const MiniAppAssignModal: React.FC<MiniAppAssignModalProps> = ({
                   className="w-full rounded-xl border border-slate-200 px-3 py-2 text-sm font-medium text-slate-700 outline-none focus:border-brand-blue-primary"
                 />
               </div>
+              {classLinkClasses.length > 0 && (
+                <div className="bg-slate-50 border border-slate-200 rounded-xl p-3">
+                  <div className="flex items-center gap-2 mb-1.5">
+                    <Users className="w-4 h-4 text-brand-blue-primary" />
+                    <label
+                      htmlFor="miniapp-assign-target-class"
+                      className="text-sm font-bold text-slate-700"
+                    >
+                      Target class (optional)
+                    </label>
+                  </div>
+                  <select
+                    id="miniapp-assign-target-class"
+                    value={selectedClassId}
+                    onChange={(e) => onClassIdChange(e.target.value)}
+                    className="w-full px-3 py-2 bg-white border border-slate-200 rounded-lg text-slate-800 text-sm focus:outline-none focus:ring-2 focus:ring-brand-blue-primary"
+                  >
+                    <option value="">No class (shareable link only)</option>
+                    {classLinkClasses.map((cls) => (
+                      <option key={cls.sourcedId} value={cls.sourcedId}>
+                        {formatClassLinkClassLabel(cls)}
+                      </option>
+                    ))}
+                  </select>
+                  <p className="text-[11px] text-slate-500 mt-1">
+                    Students in this class will see this in their assignments
+                    list. Leave blank to share a link directly.
+                  </p>
+                </div>
+              )}
               {error && (
                 <p className="text-sm text-brand-red-primary text-center font-medium">
                   {error}
@@ -305,8 +357,35 @@ export const MiniAppWidget: React.FC<WidgetComponentProps> = ({
   const [isCreatingSession, setIsCreatingSession] = useState(false);
   const [createdSessionId, setCreatedSessionId] = useState<string | null>(null);
   const [assignError, setAssignError] = useState<string | null>(null);
+  const [assignTargetClassId, setAssignTargetClassId] = useState('');
   const [assignmentsForApp, setAssignmentsForApp] =
     useState<MiniAppItem | null>(null);
+
+  // ─── ClassLink target-class fetch (Phase 3E) ────────────────────────────────
+  // Fetched once per widget mount via the shared classLinkService (5-min
+  // cache). Hidden entirely when the teacher isn't on a ClassLink-provisioned
+  // org. Errors are swallowed: ClassLink being unreachable must not block
+  // shareable-link launches.
+  const [classLinkClasses, setClassLinkClasses] = useState<ClassLinkClass[]>(
+    []
+  );
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const data = await classLinkService.getRosters();
+        if (cancelled) return;
+        setClassLinkClasses(data.classes);
+      } catch (err) {
+        if (import.meta.env.DEV) {
+          console.warn('[MiniAppWidget] ClassLink fetch failed:', err);
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   const buildDefaultAssignmentName = (appTitle: string) => {
     const formatted = new Date().toLocaleString([], {
@@ -323,6 +402,9 @@ export const MiniAppWidget: React.FC<WidgetComponentProps> = ({
     setAssignmentName(buildDefaultAssignmentName(app.title));
     setCreatedSessionId(null);
     setAssignError(null);
+    // Pre-populate the class picker with whatever the teacher picked last
+    // time for this app, so repeated assignments don't require re-picking.
+    setAssignTargetClassId(config.lastClassIdByAppId?.[app.id] ?? '');
   };
 
   const handleOpenAssignments = (app: MiniAppItem) => {
@@ -354,15 +436,23 @@ export const MiniAppWidget: React.FC<WidgetComponentProps> = ({
     setIsCreatingSession(true);
     setAssignError(null);
     try {
-      const googleSheetIdForSession = config.collectResults
-        ? (config.googleSheetId ?? undefined)
-        : undefined;
+      // Guard against a stale-selection state: the class list refreshes on
+      // mount, and a teacher could have picked a class that's since been
+      // removed from the roster. Only forward a classId we can still see.
+      const resolvedClassId =
+        assignTargetClassId &&
+        classLinkClasses.some((c) => c.sourcedId === assignTargetClassId)
+          ? assignTargetClassId
+          : undefined;
       const sessionId = await createSession(
         assigningApp,
         user.uid,
         assignmentName,
-        globalConfig?.submissionUrl,
-        googleSheetIdForSession
+        // Legacy submissionUrl/googleSheetId — no longer threaded. Phase 3E
+        // migrates submissions to the Firestore `submissions/` subcollection.
+        undefined,
+        undefined,
+        resolvedClassId
       );
       // Mirror the new session into the per-teacher archive so it shows up
       // in the In Progress / Archive tabs. Failures here are non-fatal —
@@ -372,13 +462,31 @@ export const MiniAppWidget: React.FC<WidgetComponentProps> = ({
           sessionId,
           app: { id: assigningApp.id, title: assigningApp.title },
           assignmentName,
-          submissionUrl: globalConfig?.submissionUrl,
-          googleSheetId: googleSheetIdForSession,
+          ...(resolvedClassId ? { classId: resolvedClassId } : {}),
         });
       } catch (archiveErr) {
         console.warn(
           '[MiniAppWidget] Failed to archive assignment',
           archiveErr
+        );
+      }
+      // Remember this choice for next time (or clear it if the teacher
+      // deliberately picked "No class").
+      try {
+        const prevMap = config.lastClassIdByAppId ?? {};
+        const nextMap: Record<string, string> = { ...prevMap };
+        if (resolvedClassId) {
+          nextMap[assigningApp.id] = resolvedClassId;
+        } else {
+          delete nextMap[assigningApp.id];
+        }
+        updateWidget(widget.id, {
+          config: { ...config, lastClassIdByAppId: nextMap } as MiniAppConfig,
+        });
+      } catch (cfgErr) {
+        console.warn(
+          '[MiniAppWidget] Failed to persist lastClassIdByAppId',
+          cfgErr
         );
       }
       setCreatedSessionId(sessionId);
@@ -804,11 +912,15 @@ export const MiniAppWidget: React.FC<WidgetComponentProps> = ({
                 isCreating={isCreatingSession}
                 createdSessionId={createdSessionId}
                 error={assignError}
+                classLinkClasses={classLinkClasses}
+                selectedClassId={assignTargetClassId}
+                onClassIdChange={setAssignTargetClassId}
                 onConfirm={() => void handleConfirmAssign()}
                 onClose={() => {
                   setAssigningApp(null);
                   setCreatedSessionId(null);
                   setAssignError(null);
+                  setAssignTargetClassId('');
                 }}
               />
             )}
@@ -909,11 +1021,15 @@ export const MiniAppWidget: React.FC<WidgetComponentProps> = ({
                 isCreating={isCreatingSession}
                 createdSessionId={createdSessionId}
                 error={assignError}
+                classLinkClasses={classLinkClasses}
+                selectedClassId={assignTargetClassId}
+                onClassIdChange={setAssignTargetClassId}
                 onConfirm={() => void handleConfirmAssign()}
                 onClose={() => {
                   setAssigningApp(null);
                   setCreatedSessionId(null);
                   setAssignError(null);
+                  setAssignTargetClassId('');
                 }}
               />
             )}

--- a/components/widgets/MiniApp/components/AssignmentsModal.tsx
+++ b/components/widgets/MiniApp/components/AssignmentsModal.tsx
@@ -15,8 +15,10 @@ import {
   Ban,
   Check,
   Copy,
+  Inbox,
 } from 'lucide-react';
 import { MiniAppSession } from '@/types';
+import { SubmissionsModal } from './SubmissionsModal';
 
 interface AssignmentsModalProps {
   appTitle: string;
@@ -41,6 +43,8 @@ export const AssignmentsModal: React.FC<AssignmentsModalProps> = ({
   const [confirmEndId, setConfirmEndId] = useState<string | null>(null);
   const [actionError, setActionError] = useState<string | null>(null);
   const [copiedId, setCopiedId] = useState<string | null>(null);
+  const [viewingSubmissionsFor, setViewingSubmissionsFor] =
+    useState<MiniAppSession | null>(null);
 
   const getLink = (sessionId: string) =>
     `${window.location.origin}/miniapp/${sessionId}`;
@@ -231,6 +235,14 @@ export const AssignmentsModal: React.FC<AssignmentsModalProps> = ({
                         <Link2 className="w-3 h-3" />
                         Open
                       </a>
+                      <button
+                        onClick={() => setViewingSubmissionsFor(session)}
+                        className="rounded-xl bg-white px-3 py-2 text-xs font-bold text-slate-700 border border-slate-200 hover:bg-slate-100 inline-flex items-center gap-1"
+                        title="View student submissions"
+                      >
+                        <Inbox className="w-3 h-3" />
+                        Submissions
+                      </button>
                       {session.status === 'active' ? (
                         confirmEndId === session.id ? (
                           <>
@@ -272,6 +284,14 @@ export const AssignmentsModal: React.FC<AssignmentsModalProps> = ({
           )}
         </div>
       </div>
+
+      {viewingSubmissionsFor && (
+        <SubmissionsModal
+          sessionId={viewingSubmissionsFor.id}
+          assignmentName={viewingSubmissionsFor.assignmentName}
+          onClose={() => setViewingSubmissionsFor(null)}
+        />
+      )}
     </div>
   );
 };

--- a/components/widgets/MiniApp/components/AssignmentsModal.tsx
+++ b/components/widgets/MiniApp/components/AssignmentsModal.tsx
@@ -289,6 +289,7 @@ export const AssignmentsModal: React.FC<AssignmentsModalProps> = ({
         <SubmissionsModal
           sessionId={viewingSubmissionsFor.id}
           assignmentName={viewingSubmissionsFor.assignmentName}
+          classId={viewingSubmissionsFor.classId}
           onClose={() => setViewingSubmissionsFor(null)}
         />
       )}

--- a/components/widgets/MiniApp/components/SubmissionsModal.tsx
+++ b/components/widgets/MiniApp/components/SubmissionsModal.tsx
@@ -9,7 +9,7 @@
  * sandboxed mini-app iframe's postMessage.
  */
 
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { collection, onSnapshot, orderBy, query } from 'firebase/firestore';
 import { X, Loader2, Inbox, ChevronDown, ChevronRight } from 'lucide-react';
 import { db } from '@/config/firebase';
@@ -135,14 +135,6 @@ const SubmissionRowView: React.FC<{
   expanded: boolean;
   onToggle: () => void;
 }> = ({ submission, expanded, onToggle }) => {
-  const prettyPayload = useMemo(() => {
-    try {
-      return JSON.stringify(submission.payload, null, 2);
-    } catch {
-      return String(submission.payload);
-    }
-  }, [submission.payload]);
-
   const Chevron = expanded ? ChevronDown : ChevronRight;
 
   return (
@@ -165,9 +157,17 @@ const SubmissionRowView: React.FC<{
       </button>
       {expanded && (
         <pre className="mt-2 rounded-xl bg-slate-900 text-slate-100 text-xs p-3 overflow-x-auto whitespace-pre-wrap break-all">
-          {prettyPayload}
+          {formatPayload(submission.payload)}
         </pre>
       )}
     </div>
   );
 };
+
+function formatPayload(payload: unknown): string {
+  try {
+    return JSON.stringify(payload, null, 2);
+  } catch {
+    return String(payload);
+  }
+}

--- a/components/widgets/MiniApp/components/SubmissionsModal.tsx
+++ b/components/widgets/MiniApp/components/SubmissionsModal.tsx
@@ -73,10 +73,17 @@ export const SubmissionsModal: React.FC<SubmissionsModalProps> = ({
         setLoading(false);
       },
       (err) => {
-        console.error(
-          '[SubmissionsModal] Failed to load submissions:',
-          err instanceof Error ? err.message : 'unknown'
-        );
+        // FirestoreError carries a structured `code` (permission-denied,
+        // unavailable, etc.) — more diagnostic than .message under minified
+        // builds, and does not leak PII.
+        const code =
+          err &&
+          typeof err === 'object' &&
+          'code' in err &&
+          typeof (err as { code?: unknown }).code === 'string'
+            ? (err as { code: string }).code
+            : 'unknown';
+        console.error('[SubmissionsModal] Failed to load submissions:', code);
         setError('Could not load submissions.');
         setLoading(false);
       }

--- a/components/widgets/MiniApp/components/SubmissionsModal.tsx
+++ b/components/widgets/MiniApp/components/SubmissionsModal.tsx
@@ -7,12 +7,21 @@
  * launches) or an anonymous Firebase Auth UID (legacy shared-link launches).
  * No PII is persisted; the payload is arbitrary JSON forwarded from the
  * sandboxed mini-app iframe's postMessage.
+ *
+ * When the session was class-targeted (`classId` present), we call
+ * `getPseudonymsForAssignmentV1` to build a pseudonym -> name reverse map
+ * in teacher-browser memory so grading shows real names. Unmatched doc IDs
+ * (legacy shared-link launches) fall back to the opaque id.
  */
 
 import React, { useEffect, useState } from 'react';
 import { collection, onSnapshot, orderBy, query } from 'firebase/firestore';
 import { X, Loader2, Inbox, ChevronDown, ChevronRight } from 'lucide-react';
 import { db } from '@/config/firebase';
+import {
+  useAssignmentPseudonyms,
+  formatStudentName,
+} from '@/hooks/useAssignmentPseudonyms';
 
 interface SubmissionRow {
   id: string;
@@ -23,14 +32,20 @@ interface SubmissionRow {
 interface SubmissionsModalProps {
   sessionId: string;
   assignmentName: string;
+  classId?: string;
   onClose: () => void;
 }
 
 export const SubmissionsModal: React.FC<SubmissionsModalProps> = ({
   sessionId,
   assignmentName,
+  classId,
   onClose,
 }) => {
+  const { byAssignmentPseudonym } = useAssignmentPseudonyms(
+    sessionId,
+    classId ?? null
+  );
   const [submissions, setSubmissions] = useState<SubmissionRow[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -116,6 +131,9 @@ export const SubmissionsModal: React.FC<SubmissionsModalProps> = ({
                 <SubmissionRowView
                   key={s.id}
                   submission={s}
+                  studentName={formatStudentName(
+                    byAssignmentPseudonym.get(s.id)
+                  )}
                   expanded={expandedId === s.id}
                   onToggle={() =>
                     setExpandedId((prev) => (prev === s.id ? null : s.id))
@@ -132,9 +150,10 @@ export const SubmissionsModal: React.FC<SubmissionsModalProps> = ({
 
 const SubmissionRowView: React.FC<{
   submission: SubmissionRow;
+  studentName: string;
   expanded: boolean;
   onToggle: () => void;
-}> = ({ submission, expanded, onToggle }) => {
+}> = ({ submission, studentName, expanded, onToggle }) => {
   const Chevron = expanded ? ChevronDown : ChevronRight;
 
   return (
@@ -145,9 +164,20 @@ const SubmissionRowView: React.FC<{
       >
         <Chevron className="w-4 h-4 text-slate-500 shrink-0" />
         <div className="min-w-0 flex-1">
-          <p className="font-mono text-xs text-slate-600 truncate">
-            {submission.id}
-          </p>
+          {studentName ? (
+            <>
+              <p className="text-sm font-bold text-slate-800 truncate">
+                {studentName}
+              </p>
+              <p className="font-mono text-[10px] text-slate-400 truncate">
+                {submission.id}
+              </p>
+            </>
+          ) : (
+            <p className="font-mono text-xs text-slate-600 truncate">
+              {submission.id}
+            </p>
+          )}
           <p className="text-xs text-slate-400">
             {submission.submittedAt > 0
               ? new Date(submission.submittedAt).toLocaleString()

--- a/components/widgets/MiniApp/components/SubmissionsModal.tsx
+++ b/components/widgets/MiniApp/components/SubmissionsModal.tsx
@@ -1,0 +1,173 @@
+/**
+ * SubmissionsModal — teacher's view of student submissions for a single
+ * MiniApp assignment session.
+ *
+ * Reads `mini_app_sessions/{sessionId}/submissions/*` in real time. Submission
+ * doc IDs are opaque — either an opaque per-assignment pseudonym (studentRole
+ * launches) or an anonymous Firebase Auth UID (legacy shared-link launches).
+ * No PII is persisted; the payload is arbitrary JSON forwarded from the
+ * sandboxed mini-app iframe's postMessage.
+ */
+
+import React, { useEffect, useMemo, useState } from 'react';
+import { collection, onSnapshot, orderBy, query } from 'firebase/firestore';
+import { X, Loader2, Inbox, ChevronDown, ChevronRight } from 'lucide-react';
+import { db } from '@/config/firebase';
+
+interface SubmissionRow {
+  id: string;
+  submittedAt: number;
+  payload: unknown;
+}
+
+interface SubmissionsModalProps {
+  sessionId: string;
+  assignmentName: string;
+  onClose: () => void;
+}
+
+export const SubmissionsModal: React.FC<SubmissionsModalProps> = ({
+  sessionId,
+  assignmentName,
+  onClose,
+}) => {
+  const [submissions, setSubmissions] = useState<SubmissionRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+
+  useEffect(() => {
+    const q = query(
+      collection(db, 'mini_app_sessions', sessionId, 'submissions'),
+      orderBy('submittedAt', 'desc')
+    );
+    const unsub = onSnapshot(
+      q,
+      (snap) => {
+        setSubmissions(
+          snap.docs.map((d) => {
+            const data = d.data() as Partial<SubmissionRow>;
+            return {
+              id: d.id,
+              submittedAt:
+                typeof data.submittedAt === 'number' ? data.submittedAt : 0,
+              payload: data.payload,
+            };
+          })
+        );
+        setLoading(false);
+      },
+      (err) => {
+        console.error('[SubmissionsModal] Failed to load submissions:', err);
+        setError('Could not load submissions.');
+        setLoading(false);
+      }
+    );
+    return unsub;
+  }, [sessionId]);
+
+  return (
+    <div className="absolute inset-0 z-overlay bg-brand-blue-dark/70 backdrop-blur-sm flex items-center justify-center p-4">
+      <div className="bg-white rounded-3xl w-full max-w-2xl shadow-2xl overflow-hidden animate-in zoom-in-95 duration-200 max-h-[90vh] flex flex-col">
+        {/* Header */}
+        <div className="bg-indigo-600 p-4 flex items-center justify-between">
+          <div className="flex items-center gap-2 text-white min-w-0">
+            <Inbox className="w-5 h-5 shrink-0" />
+            <div className="min-w-0">
+              <p className="font-black uppercase tracking-tight">Submissions</p>
+              <p className="text-white/80 text-xs truncate">{assignmentName}</p>
+            </div>
+          </div>
+          <button
+            onClick={onClose}
+            className="text-white/60 hover:text-white transition-colors"
+            aria-label="Close submissions"
+          >
+            <X className="w-5 h-5" />
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className="p-5 overflow-y-auto space-y-3">
+          {error && (
+            <p className="text-sm text-brand-red-primary font-medium">
+              {error}
+            </p>
+          )}
+
+          {loading ? (
+            <div className="py-10 flex items-center justify-center text-brand-blue-primary">
+              <Loader2 className="w-5 h-5 animate-spin" />
+            </div>
+          ) : submissions.length === 0 ? (
+            <div className="rounded-2xl border border-dashed border-slate-200 bg-slate-50 p-8 text-center">
+              <p className="font-bold text-slate-700">No submissions yet</p>
+              <p className="text-sm text-slate-500 mt-1">
+                Submissions appear here as students finish the activity.
+              </p>
+            </div>
+          ) : (
+            <div className="space-y-2">
+              <p className="text-xs text-slate-500">
+                {submissions.length}{' '}
+                {submissions.length === 1 ? 'submission' : 'submissions'}
+              </p>
+              {submissions.map((s) => (
+                <SubmissionRowView
+                  key={s.id}
+                  submission={s}
+                  expanded={expandedId === s.id}
+                  onToggle={() =>
+                    setExpandedId((prev) => (prev === s.id ? null : s.id))
+                  }
+                />
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+const SubmissionRowView: React.FC<{
+  submission: SubmissionRow;
+  expanded: boolean;
+  onToggle: () => void;
+}> = ({ submission, expanded, onToggle }) => {
+  const prettyPayload = useMemo(() => {
+    try {
+      return JSON.stringify(submission.payload, null, 2);
+    } catch {
+      return String(submission.payload);
+    }
+  }, [submission.payload]);
+
+  const Chevron = expanded ? ChevronDown : ChevronRight;
+
+  return (
+    <div className="rounded-2xl border border-slate-200 bg-slate-50/80 p-3">
+      <button
+        onClick={onToggle}
+        className="w-full flex items-center gap-2 text-left"
+      >
+        <Chevron className="w-4 h-4 text-slate-500 shrink-0" />
+        <div className="min-w-0 flex-1">
+          <p className="font-mono text-xs text-slate-600 truncate">
+            {submission.id}
+          </p>
+          <p className="text-xs text-slate-400">
+            {submission.submittedAt > 0
+              ? new Date(submission.submittedAt).toLocaleString()
+              : 'Unknown time'}
+          </p>
+        </div>
+      </button>
+      {expanded && (
+        <pre className="mt-2 rounded-xl bg-slate-900 text-slate-100 text-xs p-3 overflow-x-auto whitespace-pre-wrap break-all">
+          {prettyPayload}
+        </pre>
+      )}
+    </div>
+  );
+};

--- a/components/widgets/MiniApp/components/SubmissionsModal.tsx
+++ b/components/widgets/MiniApp/components/SubmissionsModal.tsx
@@ -73,7 +73,10 @@ export const SubmissionsModal: React.FC<SubmissionsModalProps> = ({
         setLoading(false);
       },
       (err) => {
-        console.error('[SubmissionsModal] Failed to load submissions:', err);
+        console.error(
+          '[SubmissionsModal] Failed to load submissions:',
+          err instanceof Error ? err.message : 'unknown'
+        );
         setError('Could not load submissions.');
         setLoading(false);
       }

--- a/components/widgets/QuizWidget/Widget.tsx
+++ b/components/widgets/QuizWidget/Widget.tsx
@@ -667,7 +667,8 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
           meta,
           mode,
           plcOptions: PlcOptions,
-          sessionOptions: QuizSessionOptions
+          sessionOptions: QuizSessionOptions,
+          classId: string | null
         ) => {
           const data = await loadQuiz(meta);
           if (!data) return;
@@ -689,8 +690,20 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
                 periodNames: plcOptions.periodNames,
                 plcSheetUrl: plcOptions.plcSheetUrl,
               },
-              'paused'
+              'paused',
+              classId ?? undefined
             );
+            // Persist the teacher's last-used classId per quiz so re-launching
+            // the same quiz pre-selects the same class. Clearing (picking "No
+            // class") removes the entry rather than writing an empty string
+            // to keep the config map small.
+            const prevMap = config.lastClassIdByQuizId ?? {};
+            const nextMap: Record<string, string> = { ...prevMap };
+            if (classId) {
+              nextMap[meta.id] = classId;
+            } else {
+              delete nextMap[meta.id];
+            }
             updateWidget(widget.id, {
               config: {
                 ...config,
@@ -706,6 +719,7 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
                   plcOptions.periodNames?.[0] ?? plcOptions.periodName ?? '',
                 periodNames: plcOptions.periodNames ?? [],
                 plcSheetUrl: plcOptions.plcSheetUrl ?? '',
+                lastClassIdByQuizId: nextMap,
               } as QuizConfig,
             });
             const url = `${window.location.origin}/quiz?code=${code}`;

--- a/components/widgets/QuizWidget/components/QuizManager.tsx
+++ b/components/widgets/QuizWidget/components/QuizManager.tsx
@@ -16,7 +16,7 @@
  * only, not functionality.
  */
 
-import React, { useCallback, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   Plus,
   FileUp,
@@ -42,14 +42,17 @@ import {
   Loader2,
   AlertCircle,
   CheckSquare,
+  Users,
 } from 'lucide-react';
 import {
+  ClassLinkClass,
   QuizMetadata,
   QuizSessionMode,
   QuizConfig,
   ClassRoster,
   QuizAssignment,
 } from '@/types';
+import { classLinkService } from '@/utils/classlinkService';
 import { type QuizSessionOptions } from '@/hooks/useQuizSession';
 import { Toggle } from '@/components/common/Toggle';
 import {
@@ -104,9 +107,19 @@ interface QuizAssignOptions {
   teacherName: string;
   selectedPeriodNames: string[];
   plcSheetUrl: string;
+  /**
+   * ClassLink class `sourcedId` this quiz is targeted at, or `''` for the
+   * "No class" option (classic code/PIN-only flow). Written onto the
+   * `quiz_sessions/{sessionId}` document when non-empty so students who
+   * signed in via ClassLink see the session on their /my-assignments page.
+   */
+  classId: string;
 }
 
-function buildDefaultAssignOptions(config: QuizConfig): QuizAssignOptions {
+function buildDefaultAssignOptions(
+  config: QuizConfig,
+  quizId?: string
+): QuizAssignOptions {
   return {
     tabWarningsEnabled: true,
     showResultToStudent: false,
@@ -121,6 +134,7 @@ function buildDefaultAssignOptions(config: QuizConfig): QuizAssignOptions {
     selectedPeriodNames:
       config.periodNames ?? (config.periodName ? [config.periodName] : []),
     plcSheetUrl: config.plcSheetUrl ?? '',
+    classId: (quizId && config.lastClassIdByQuizId?.[quizId]) ?? '',
   };
 }
 
@@ -161,7 +175,12 @@ interface QuizManagerProps {
     quiz: QuizMetadata,
     mode: QuizSessionMode,
     plcOptions: PlcOptions,
-    sessionOptions: QuizSessionOptions
+    sessionOptions: QuizSessionOptions,
+    /**
+     * ClassLink target class `sourcedId`, or `null` when the teacher chose
+     * "No class" (classic code/PIN-only flow). Phase 3A.
+     */
+    classId: string | null
   ) => void;
   onResults: (quiz: QuizMetadata) => void;
   onDelete: (quiz: QuizMetadata) => void | Promise<void>;
@@ -314,9 +333,38 @@ export const QuizManager: React.FC<QuizManagerProps> = ({
     setPrevAssignTarget(assignTarget);
     if (assignTarget) {
       setSelectedMode(null);
-      setAssignOptions(buildDefaultAssignOptions(config));
+      setAssignOptions(buildDefaultAssignOptions(config, assignTarget.id));
     }
   }
+
+  // ─── ClassLink target-class fetch (Phase 3A) ──────────────────────────────
+  // Teacher's ClassLink classes (if provisioned). Fetched once per QuizManager
+  // mount via the existing `classLinkService` (5-min cache — cheap). If the
+  // teacher isn't on a ClassLink-provisioned org, the list stays empty and
+  // the selector is hidden entirely. Errors are swallowed: ClassLink being
+  // unreachable must not block code+PIN launches.
+  const [classLinkClasses, setClassLinkClasses] = useState<ClassLinkClass[]>(
+    []
+  );
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const data = await classLinkService.getRosters();
+        if (cancelled) return;
+        setClassLinkClasses(data.classes);
+      } catch (err) {
+        // Silent: no-ClassLink orgs and transient failures both fall back
+        // to code+PIN-only launches, so the selector stays hidden.
+        if (import.meta.env.DEV) {
+          console.warn('[QuizManager] ClassLink fetch failed:', err);
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   // ─── Folder navigation (Wave 3-B-3) ───────────────────────────────────────
   const folderState = useFolders(userId, 'quiz');
@@ -620,7 +668,21 @@ export const QuizManager: React.FC<QuizManagerProps> = ({
       showPodiumBetweenQuestions: assignOptions.showPodiumBetweenQuestions,
       soundEffectsEnabled: assignOptions.soundEffectsEnabled,
     };
-    onAssign(assignTarget, selectedMode, plcOptions, sessionOptions);
+    // Guard: if the teacher somehow picked a classId that's no longer in the
+    // fetched ClassLink list (e.g. rosters changed between fetch and confirm),
+    // fall through to no-class rather than writing a stale id.
+    const selectedClassId =
+      assignOptions.classId &&
+      classLinkClasses.some((c) => c.sourcedId === assignOptions.classId)
+        ? assignOptions.classId
+        : null;
+    onAssign(
+      assignTarget,
+      selectedMode,
+      plcOptions,
+      sessionOptions,
+      selectedClassId
+    );
     setAssignTarget(null);
     setSelectedMode(null);
   };
@@ -941,6 +1003,7 @@ export const QuizManager: React.FC<QuizManagerProps> = ({
             <AssignExtraSlot
               options={assignOptions}
               onChange={setAssignOptions}
+              classLinkClasses={classLinkClasses}
             />
           }
           plcSlot={
@@ -1216,7 +1279,8 @@ const AssignmentsList: React.FC<{
 const AssignExtraSlot: React.FC<{
   options: QuizAssignOptions;
   onChange: (next: QuizAssignOptions) => void;
-}> = ({ options, onChange }) => {
+  classLinkClasses: ClassLinkClass[];
+}> = ({ options, onChange, classLinkClasses }) => {
   const update = <K extends keyof QuizAssignOptions>(
     key: K,
     value: QuizAssignOptions[K]
@@ -1224,6 +1288,14 @@ const AssignExtraSlot: React.FC<{
 
   return (
     <>
+      {classLinkClasses.length > 0 && (
+        <AssignTargetClassRow
+          classes={classLinkClasses}
+          value={options.classId}
+          onChange={(v) => update('classId', v)}
+        />
+      )}
+
       <SectionHeader label="Quiz Integrity" />
       <ToggleRow
         label="Tab Switch Detection"
@@ -1279,6 +1351,62 @@ const AssignExtraSlot: React.FC<{
         hint="Chimes, ticks, and fanfares during the quiz"
       />
     </>
+  );
+};
+
+/**
+ * Build a human-readable label for a ClassLink class. Mirrors the format
+ * used by `ClassLinkImportDialog` so teachers see the same class names in
+ * both flows.
+ */
+function formatClassLinkClassLabel(cls: ClassLinkClass): string {
+  const subjectPrefix = cls.subject ? `${cls.subject} - ` : '';
+  const codeSuffix = cls.classCode ? ` (${cls.classCode})` : '';
+  return `${subjectPrefix}${cls.title}${codeSuffix}`;
+}
+
+/**
+ * Target-class selector rendered inside the Assign modal's `extraSlot`.
+ * Lets the teacher pick an optional ClassLink class to target this quiz at
+ * so that students who signed in via ClassLink see it on their
+ * `/my-assignments` page. Phase 3A — pilot for class-targeted session
+ * launches. Hidden entirely when the teacher isn't on a ClassLink org
+ * (empty classes list).
+ */
+const AssignTargetClassRow: React.FC<{
+  classes: ClassLinkClass[];
+  value: string;
+  onChange: (next: string) => void;
+}> = ({ classes, value, onChange }) => {
+  return (
+    <div>
+      <div className="flex items-center gap-2 mb-1">
+        <Users className="w-4 h-4 text-brand-blue-primary" />
+        <label
+          htmlFor="quiz-assign-target-class"
+          className="text-sm font-bold text-brand-blue-dark"
+        >
+          Target class (optional)
+        </label>
+      </div>
+      <select
+        id="quiz-assign-target-class"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        className="w-full px-3 py-2 bg-white border border-slate-200 rounded-lg text-slate-800 text-sm focus:outline-none focus:ring-2 focus:ring-brand-blue-primary"
+      >
+        <option value="">No class (use code/PIN only)</option>
+        {classes.map((cls) => (
+          <option key={cls.sourcedId} value={cls.sourcedId}>
+            {formatClassLinkClassLabel(cls)}
+          </option>
+        ))}
+      </select>
+      <p className="text-xxs text-slate-500 mt-1">
+        Students in this class will see this quiz in their assignments list.
+        Leave blank to use a join code.
+      </p>
+    </div>
   );
 };
 

--- a/components/widgets/QuizWidget/components/QuizResults.tsx
+++ b/components/widgets/QuizWidget/components/QuizResults.tsx
@@ -44,6 +44,10 @@ import {
   isGamificationActive,
 } from '../utils/quizScoreboard';
 import { useClickOutside } from '@/hooks/useClickOutside';
+import {
+  useAssignmentPseudonyms,
+  formatStudentName,
+} from '@/hooks/useAssignmentPseudonyms';
 
 interface QuizResultsProps {
   quiz: QuizData;
@@ -97,6 +101,14 @@ export const QuizResults: React.FC<QuizResultsProps> = ({
   const pinToName = useMemo(
     () => buildPinToNameMap(rosters, resolvedPeriods),
     [rosters, resolvedPeriods]
+  );
+
+  // ClassLink name resolution — only populated when session.classId is set
+  // (i.e. assigned to a ClassLink class). For legacy code+PIN sessions both
+  // maps are empty and pinToName handles display.
+  const { byStudentUid } = useAssignmentPseudonyms(
+    session?.id ?? null,
+    session?.classId ?? null
   );
   const exportPinToName = useMemo(
     () => buildPinToExportNameMap(rosters, resolvedPeriods),
@@ -510,6 +522,7 @@ export const QuizResults: React.FC<QuizResultsProps> = ({
                 responses={filteredResponses}
                 questions={quiz.questions}
                 pinToName={pinToName}
+                byStudentUid={byStudentUid}
                 tabWarningsEnabled={tabWarningsEnabled ?? true}
                 session={session}
               />
@@ -777,9 +790,20 @@ const StudentsTab: React.FC<{
   responses: QuizResponse[];
   questions: QuizQuestion[];
   pinToName: Record<string, string>;
+  byStudentUid: Map<
+    string,
+    import('@/hooks/useAssignmentPseudonyms').StudentName
+  >;
   tabWarningsEnabled: boolean;
   session?: import('@/types').QuizSession | null;
-}> = ({ responses, questions, pinToName, tabWarningsEnabled, session }) => {
+}> = ({
+  responses,
+  questions,
+  pinToName,
+  byStudentUid,
+  tabWarningsEnabled,
+  session,
+}) => {
   const [showResults, setShowResults] = useState(false);
   const maxPoints = questions.reduce((sum, q) => sum + (q.points ?? 1), 0);
   const gamified = isGamificationActive(session);
@@ -844,6 +868,13 @@ const StudentsTab: React.FC<{
             const earned = getEarnedPoints(r, questions, session);
             const warnings = r.tabSwitchWarnings ?? 0;
 
+            const classLinkName = formatStudentName(
+              byStudentUid.get(r.studentUid)
+            );
+            const rosterName = pinToName[r.pin];
+            const displayName = classLinkName || rosterName || `PIN ${r.pin}`;
+            const isResolved = Boolean(classLinkName || rosterName);
+
             return (
               <div
                 key={r.studentUid}
@@ -852,10 +883,10 @@ const StudentsTab: React.FC<{
                 <div className="flex-1 min-w-0">
                   <div className="flex items-center gap-2">
                     <p
-                      className={`font-bold text-brand-blue-dark truncate ${pinToName[r.pin] ? '' : 'font-mono'}`}
+                      className={`font-bold text-brand-blue-dark truncate ${isResolved ? '' : 'font-mono'}`}
                       style={{ fontSize: 'min(13px, 4.5cqmin)' }}
                     >
-                      {pinToName[r.pin] ?? `PIN ${r.pin}`}
+                      {displayName}
                     </p>
                     {tabWarningsEnabled && warnings > 0 && (
                       <span

--- a/components/widgets/VideoActivityWidget/Widget.tsx
+++ b/components/widgets/VideoActivityWidget/Widget.tsx
@@ -310,7 +310,7 @@ export const VideoActivityWidget: React.FC<{ widget: WidgetData }> = ({
           }
         }}
         defaultSessionSettings={defaultSessionSettings}
-        onAssign={async (meta, sessionSettings, assignmentName) => {
+        onAssign={async (meta, sessionSettings, assignmentName, classId) => {
           // Use loadActivityData directly to avoid setting loadingActivity
           // which would cause the Manager component to unmount and destroy the modal
           const data = await loadActivityData(meta.driveFileId);
@@ -320,12 +320,27 @@ export const VideoActivityWidget: React.FC<{ widget: WidgetData }> = ({
             user.uid,
             [],
             sessionSettings,
-            assignmentName
+            assignmentName,
+            classId ?? undefined
           );
+
+          // Phase 3B: persist per-activity memory of the last ClassLink target
+          // so the next launch of the same activity pre-selects the class the
+          // teacher used last time. Clearing the selection ("No class") also
+          // clears the remembered id so we don't stick on stale values.
+          const prevMap = config.lastClassIdByActivityId ?? {};
+          const nextMap: Record<string, string> = { ...prevMap };
+          if (classId) {
+            nextMap[meta.id] = classId;
+          } else {
+            delete nextMap[meta.id];
+          }
+
           updateWidget(widget.id, {
             config: {
               ...config,
               resultsSessionId: sessionId,
+              lastClassIdByActivityId: nextMap,
             } as VideoActivityConfig,
           });
 
@@ -336,6 +351,7 @@ export const VideoActivityWidget: React.FC<{ widget: WidgetData }> = ({
           });
           return sessionId;
         }}
+        lastClassIdByActivityId={config.lastClassIdByActivityId}
         onDelete={async (meta) => {
           try {
             await deleteActivity(meta.id, meta.driveFileId);

--- a/components/widgets/VideoActivityWidget/components/Results.tsx
+++ b/components/widgets/VideoActivityWidget/components/Results.tsx
@@ -19,6 +19,10 @@ import {
 import { VideoActivityResponse, VideoActivitySession } from '@/types';
 import { useAuth } from '@/context/useAuth';
 import { QuizDriveService } from '@/utils/quizDriveService';
+import {
+  useAssignmentPseudonyms,
+  formatStudentName,
+} from '@/hooks/useAssignmentPseudonyms';
 
 interface ResultsProps {
   session: VideoActivitySession;
@@ -32,6 +36,10 @@ export const Results: React.FC<ResultsProps> = ({
   onBack,
 }) => {
   const { googleAccessToken } = useAuth();
+  const { byStudentUid } = useAssignmentPseudonyms(
+    session.id,
+    session.classId ?? null
+  );
   const [exporting, setExporting] = useState(false);
   const [exportUrl, setExportUrl] = useState<string | null>(null);
   const [exportError, setExportError] = useState<string | null>(null);
@@ -497,7 +505,9 @@ export const Results: React.FC<ResultsProps> = ({
                           className="font-bold text-slate-800 truncate"
                           style={{ fontSize: 'min(13px, 4cqmin)' }}
                         >
-                          {r.name || r.pin}
+                          {formatStudentName(byStudentUid.get(r.studentUid)) ||
+                            r.name ||
+                            r.pin}
                         </p>
                         <p
                           className="text-slate-400"

--- a/components/widgets/VideoActivityWidget/components/VideoActivityManager.tsx
+++ b/components/widgets/VideoActivityWidget/components/VideoActivityManager.tsx
@@ -17,7 +17,7 @@
  *     specific toggles flow through that slot, not by forking the primitive.
  */
 
-import React, { useCallback, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   Activity,
   AlertCircle,
@@ -32,6 +32,7 @@ import {
   PlayCircle,
   Plus,
   Trash2,
+  Users,
 } from 'lucide-react';
 import { LibraryShell } from '@/components/common/library/LibraryShell';
 import { LibraryToolbar } from '@/components/common/library/LibraryToolbar';
@@ -62,12 +63,14 @@ import type {
   LibraryTab,
 } from '@/components/common/library/types';
 import type {
+  ClassLinkClass,
   VideoActivityAssignment,
   VideoActivityAssignmentStatus,
   VideoActivityMetadata,
   VideoActivitySession,
   VideoActivitySessionSettings,
 } from '@/types';
+import { classLinkService } from '@/utils/classlinkService';
 
 /* ─── Props ───────────────────────────────────────────────────────────────── */
 
@@ -91,8 +94,20 @@ export interface VideoActivityManagerProps {
   onAssign: (
     activity: VideoActivityMetadata,
     settings: VideoActivitySessionSettings,
-    assignmentName: string
+    assignmentName: string,
+    /**
+     * ClassLink target class `sourcedId`, or `null` when the teacher chose
+     * "No class" (classic join-URL-only flow). Phase 3B.
+     */
+    classId: string | null
   ) => Promise<string>;
+  /**
+   * Per-activity memory of the last ClassLink class the teacher targeted.
+   * Used to pre-select the target-class selector on re-launch of the same
+   * activity. Passed through from widget config; missing keys fall through
+   * to "No class". Phase 3B.
+   */
+  lastClassIdByActivityId?: Record<string, string>;
   /**
    * Optional persistence hook for manual drag-reorder of the library. Drag
    * reordering is only enabled when this callback is provided; otherwise the
@@ -212,6 +227,7 @@ export const VideoActivityManager: React.FC<VideoActivityManagerProps> = ({
   onArchiveResults,
   initialLibraryViewMode,
   onLibraryViewModeChange,
+  lastClassIdByActivityId,
 }) => {
   const [tab, setTab] = useState<LibraryTab>('library');
 
@@ -222,6 +238,9 @@ export const VideoActivityManager: React.FC<VideoActivityManagerProps> = ({
     useState<VideoActivitySessionSettings>(defaultSessionSettings);
   const [assignmentName, setAssignmentName] = useState<string>('');
   const [assignError, setAssignError] = useState<string | null>(null);
+  // Phase 3B: selected ClassLink target class `sourcedId`, or `''` for
+  // "No class" (classic join-URL-only flow).
+  const [assignClassId, setAssignClassId] = useState<string>('');
 
   // Adjust state during render when the assign target changes — avoids the
   // set-state-in-effect anti-pattern while keeping form fields reset per open.
@@ -233,9 +252,39 @@ export const VideoActivityManager: React.FC<VideoActivityManagerProps> = ({
     setAssignOptions(defaultSessionSettings);
     setAssignmentName(buildDefaultAssignmentName(assignTarget.title));
     setAssignError(null);
+    setAssignClassId(lastClassIdByActivityId?.[assignTarget.id] ?? '');
   } else if (!assignTarget && prevAssignTargetId !== null) {
     setPrevAssignTargetId(null);
   }
+
+  // ─── ClassLink target-class fetch (Phase 3B) ──────────────────────────────
+  // Teacher's ClassLink classes (if provisioned). Fetched once per manager
+  // mount via the existing `classLinkService` (5-min cache — cheap). If the
+  // teacher isn't on a ClassLink-provisioned org, the list stays empty and
+  // the selector is hidden entirely. Errors are swallowed: ClassLink being
+  // unreachable must not block classic join-URL launches.
+  const [classLinkClasses, setClassLinkClasses] = useState<ClassLinkClass[]>(
+    []
+  );
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const data = await classLinkService.getRosters();
+        if (cancelled) return;
+        setClassLinkClasses(data.classes);
+      } catch (err) {
+        // Silent: no-ClassLink orgs and transient failures both fall back
+        // to join-URL-only launches, so the selector stays hidden.
+        if (import.meta.env.DEV) {
+          console.warn('[VideoActivityManager] ClassLink fetch failed:', err);
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   // Delete confirmation state
   const [confirmDeleteActivityId, setConfirmDeleteActivityId] = useState<
@@ -423,8 +472,21 @@ export const VideoActivityManager: React.FC<VideoActivityManagerProps> = ({
       return;
     }
     setAssignError(null);
+    // Guard: if the teacher somehow picked a classId that's no longer in the
+    // fetched ClassLink list (e.g. rosters changed between fetch and confirm),
+    // fall through to no-class rather than writing a stale id.
+    const selectedClassId =
+      assignClassId &&
+      classLinkClasses.some((c) => c.sourcedId === assignClassId)
+        ? assignClassId
+        : null;
     try {
-      await onAssign(assignTarget, assignOptions, assignmentName.trim());
+      await onAssign(
+        assignTarget,
+        assignOptions,
+        assignmentName.trim(),
+        selectedClassId
+      );
       setAssignTarget(null);
     } catch (err) {
       setAssignError(
@@ -909,6 +971,14 @@ export const VideoActivityManager: React.FC<VideoActivityManagerProps> = ({
           onAssign={handleAssignConfirm}
           extraSlot={
             <div className="space-y-3">
+              {classLinkClasses.length > 0 && (
+                <AssignTargetClassRow
+                  classes={classLinkClasses}
+                  value={assignClassId}
+                  onChange={setAssignClassId}
+                />
+              )}
+
               {assignError && (
                 <div className="flex items-start gap-2 rounded-xl border border-brand-red-primary/30 bg-brand-red-lighter/40 px-3 py-2 text-sm font-medium text-brand-red-dark">
                   <AlertCircle className="h-4 w-4 shrink-0 mt-0.5" />
@@ -996,3 +1066,61 @@ const ToggleRow: React.FC<ToggleRowProps> = ({
     />
   </div>
 );
+
+/* ─── AssignTargetClassRow — ClassLink target-class selector (Phase 3B) ──── */
+
+/**
+ * Build a human-readable label for a ClassLink class. Mirrors the format
+ * used by `ClassLinkImportDialog` and `QuizManager` so teachers see the same
+ * class names across all assign flows.
+ */
+function formatClassLinkClassLabel(cls: ClassLinkClass): string {
+  const subjectPrefix = cls.subject ? `${cls.subject} - ` : '';
+  const codeSuffix = cls.classCode ? ` (${cls.classCode})` : '';
+  return `${subjectPrefix}${cls.title}${codeSuffix}`;
+}
+
+/**
+ * Target-class selector rendered inside the Assign modal's `extraSlot`.
+ * Lets the teacher pick an optional ClassLink class to target this activity
+ * at so that students who signed in via ClassLink see it on their
+ * `/my-assignments` page. Phase 3B — fan-out of the Phase 3A quiz pilot.
+ * Hidden entirely when the teacher isn't on a ClassLink org (empty classes
+ * list).
+ */
+const AssignTargetClassRow: React.FC<{
+  classes: ClassLinkClass[];
+  value: string;
+  onChange: (next: string) => void;
+}> = ({ classes, value, onChange }) => {
+  return (
+    <div>
+      <div className="flex items-center gap-2 mb-1">
+        <Users className="w-4 h-4 text-brand-blue-primary" />
+        <label
+          htmlFor="video-activity-assign-target-class"
+          className="text-sm font-bold text-brand-blue-dark"
+        >
+          Target class (optional)
+        </label>
+      </div>
+      <select
+        id="video-activity-assign-target-class"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        className="w-full px-3 py-2 bg-white border border-slate-200 rounded-lg text-slate-800 text-sm focus:outline-none focus:ring-2 focus:ring-brand-blue-primary"
+      >
+        <option value="">No class (use code/PIN only)</option>
+        {classes.map((cls) => (
+          <option key={cls.sourcedId} value={cls.sourcedId}>
+            {formatClassLinkClassLabel(cls)}
+          </option>
+        ))}
+      </select>
+      <p className="text-xxs text-slate-500 mt-1">
+        Students in this class will see this activity in their assignments list.
+        Leave blank to use a join code.
+      </p>
+    </div>
+  );
+};

--- a/context/StudentAuthContext.tsx
+++ b/context/StudentAuthContext.tsx
@@ -12,7 +12,10 @@ import {
 } from 'firebase/auth';
 import { Loader2 } from 'lucide-react';
 import { auth, isAuthBypass } from '@/config/firebase';
-import { useStudentIdleTimeout } from '@/hooks/useStudentIdleTimeout';
+import {
+  useStudentIdleTimeout,
+  STUDENT_LOGIN_PATH,
+} from '@/hooks/useStudentIdleTimeout';
 import {
   StudentAuthContext,
   type StudentAuthStatus,
@@ -54,8 +57,6 @@ const PROTECTED_STUDENT_PATH_PREFIXES: readonly string[] = [
 
 const isProtectedStudentRoute = (pathname: string): boolean =>
   PROTECTED_STUDENT_PATH_PREFIXES.some((prefix) => pathname.startsWith(prefix));
-
-const STUDENT_LOGIN_PATH = '/student/login';
 
 // ---------------------------------------------------------------------------
 // Claim validation

--- a/context/StudentAuthContext.tsx
+++ b/context/StudentAuthContext.tsx
@@ -12,6 +12,7 @@ import {
 } from 'firebase/auth';
 import { Loader2 } from 'lucide-react';
 import { auth, isAuthBypass } from '@/config/firebase';
+import { useStudentIdleTimeout } from '@/hooks/useStudentIdleTimeout';
 import {
   StudentAuthContext,
   type StudentAuthStatus,
@@ -44,9 +45,6 @@ import {
 // ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
-
-const IDLE_TIMEOUT_MS = 15 * 60 * 1000; // 15 minutes, per plan
-const INTERACTION_THROTTLE_MS = 5 * 1000; // Throttle interaction updates
 
 /** Protected student-facing routes. `/student/login` is NOT protected. */
 const PROTECTED_STUDENT_PATH_PREFIXES: readonly string[] = [
@@ -223,57 +221,10 @@ export const StudentAuthProvider: React.FC<{ children: React.ReactNode }> = ({
     return unsubscribe;
   }, []);
 
-  // --- Idle timeout (15 minutes) --------------------------------------------
-  //
-  // A single setTimeout that's reset on interaction. We intentionally do NOT
-  // poll — 60fps mousemove would reset the timeout thousands of times per
-  // minute, which is wasteful even if functionally correct.
-  useEffect(() => {
-    if (isAuthBypass) return;
-    if (state.status !== 'authenticated') return;
-
-    let timeoutId: number | undefined;
-    let lastInteractionAt = Date.now();
-
-    const triggerIdleSignOut = () => {
-      void firebaseSignOut(auth).catch(() => {
-        // Swallow — onIdTokenChanged will pick up the sign-out and redirect.
-      });
-      if (typeof window !== 'undefined') {
-        window.location.assign(STUDENT_LOGIN_PATH);
-      }
-    };
-
-    const scheduleTimeout = () => {
-      if (typeof window === 'undefined') return;
-      if (timeoutId !== undefined) window.clearTimeout(timeoutId);
-      timeoutId = window.setTimeout(triggerIdleSignOut, IDLE_TIMEOUT_MS);
-    };
-
-    const handleInteraction = () => {
-      const now = Date.now();
-      // Throttle: don't reset the timeout more than once per 5s.
-      if (now - lastInteractionAt < INTERACTION_THROTTLE_MS) return;
-      lastInteractionAt = now;
-      scheduleTimeout();
-    };
-
-    scheduleTimeout();
-
-    const events = ['mousemove', 'keydown', 'touchstart', 'click'] as const;
-    const options: AddEventListenerOptions = { passive: true, capture: true };
-    events.forEach((event) => {
-      window.addEventListener(event, handleInteraction, options);
-    });
-
-    return () => {
-      if (typeof window === 'undefined') return;
-      if (timeoutId !== undefined) window.clearTimeout(timeoutId);
-      events.forEach((event) => {
-        window.removeEventListener(event, handleInteraction, options);
-      });
-    };
-  }, [state.status]);
+  // Idle timeout (15 minutes). `useStudentIdleTimeout` owns the listeners,
+  // throttle, timer, and sign-out+redirect. Armed only for authenticated
+  // student sessions; bypass mode and teacher previews never arm it.
+  useStudentIdleTimeout(!isAuthBypass && state.status === 'authenticated');
 
   // --- Imperative sign-out (exposed on context) -----------------------------
   const signOut = useCallback(async () => {

--- a/context/StudentAuthContext.tsx
+++ b/context/StudentAuthContext.tsx
@@ -1,0 +1,344 @@
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import {
+  onIdTokenChanged,
+  signOut as firebaseSignOut,
+  type User,
+} from 'firebase/auth';
+import { Loader2 } from 'lucide-react';
+import { auth, isAuthBypass } from '@/config/firebase';
+import {
+  StudentAuthContext,
+  type StudentAuthStatus,
+  type StudentAuthValue,
+} from './StudentAuthContextValue';
+
+/**
+ * StudentAuthContext — Phase 2B of the ClassLink-via-Google auth flow.
+ *
+ * This provider is SEPARATE from the teacher `AuthContext`. A route uses one
+ * or the other, never both. The student context exposes only what a student
+ * page needs to render assignments: the opaque pseudonym UID, the org id, and
+ * the list of ClassLink class sourcedIds — all sourced from custom claims on
+ * the custom token minted by `studentLoginV1`.
+ *
+ * Hard PII rules (enforced here):
+ *   - Never read `user.email`, `user.displayName`, or `user.providerData`.
+ *   - Never log or persist the raw ID token, `sub`, email, or name.
+ *   - The only identifier we touch is `user.uid` (the pseudonym) plus the
+ *     three custom claims we mint ourselves: `studentRole`, `orgId`,
+ *     `classIds`.
+ *
+ * Shared-device hygiene:
+ *   - 15-minute idle timeout on activity listeners → auto sign-out + redirect.
+ *   - `signOut()` exposed for an explicit "Done" button on student pages.
+ *   - `<RequireStudentAuth>` wrapper renders nothing while redirecting, so
+ *     stale content never flashes between pages.
+ */
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const IDLE_TIMEOUT_MS = 15 * 60 * 1000; // 15 minutes, per plan
+const INTERACTION_THROTTLE_MS = 5 * 1000; // Throttle interaction updates
+
+/** Protected student-facing routes. `/student/login` is NOT protected. */
+const PROTECTED_STUDENT_PATH_PREFIXES: readonly string[] = [
+  '/my-assignments',
+  '/student/assignments', // Reserved for future use.
+];
+
+const isProtectedStudentRoute = (pathname: string): boolean =>
+  PROTECTED_STUDENT_PATH_PREFIXES.some((prefix) => pathname.startsWith(prefix));
+
+const STUDENT_LOGIN_PATH = '/student/login';
+
+// ---------------------------------------------------------------------------
+// Claim validation
+// ---------------------------------------------------------------------------
+
+interface ValidatedStudentClaims {
+  orgId: string;
+  classIds: string[];
+}
+
+/**
+ * Validate that the signed-in user carries the custom claims we mint in
+ * `studentLoginV1`. Returns `null` if any claim is missing / wrong shape —
+ * callers should treat `null` as "not a student" and sign out.
+ */
+async function extractStudentClaims(
+  user: User
+): Promise<ValidatedStudentClaims | null> {
+  // Force a refresh on the first call per mount so a stale cached token
+  // from a previous student's session can't leak into this one. Firebase
+  // transparently uses the refresh token; no network round-trip when the
+  // local token is still fresh.
+  const result = await user.getIdTokenResult();
+  const claims = result.claims;
+
+  if (claims.studentRole !== true) return null;
+  if (typeof claims.orgId !== 'string' || claims.orgId.length === 0) {
+    return null;
+  }
+  const rawClassIds: unknown = claims.classIds;
+  if (!Array.isArray(rawClassIds)) return null;
+  if (!rawClassIds.every((c): c is string => typeof c === 'string')) {
+    return null;
+  }
+
+  return { orgId: claims.orgId, classIds: rawClassIds };
+}
+
+// ---------------------------------------------------------------------------
+// Auth-bypass mock (dev/testing only; mirrors the teacher bypass pattern).
+// ---------------------------------------------------------------------------
+
+const MOCK_STUDENT: Omit<StudentAuthValue, 'signOut'> & {
+  status: 'authenticated';
+} = {
+  status: 'authenticated',
+  pseudonymUid: 'mock-student',
+  orgId: 'mock-org',
+  classIds: ['mock-class-1'],
+};
+
+// ---------------------------------------------------------------------------
+// Provider
+// ---------------------------------------------------------------------------
+
+interface ProviderState {
+  status: StudentAuthStatus;
+  pseudonymUid: string | null;
+  orgId: string | null;
+  classIds: string[];
+}
+
+const INITIAL_STATE: ProviderState = {
+  status: 'loading',
+  pseudonymUid: null,
+  orgId: null,
+  classIds: [],
+};
+
+const UNAUTH_STATE: ProviderState = {
+  status: 'unauthenticated',
+  pseudonymUid: null,
+  orgId: null,
+  classIds: [],
+};
+
+/**
+ * Redirect to `/student/login` iff we're currently on a protected route.
+ * Never yanks a user away from the login page itself (which would cause an
+ * infinite reload loop) or from unrelated app surfaces.
+ */
+function redirectToLoginIfProtected(): void {
+  if (typeof window === 'undefined') return;
+  if (isProtectedStudentRoute(window.location.pathname)) {
+    window.location.assign(STUDENT_LOGIN_PATH);
+  }
+}
+
+export const StudentAuthProvider: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => {
+  const [state, setState] = useState<ProviderState>(() =>
+    isAuthBypass
+      ? {
+          status: MOCK_STUDENT.status,
+          pseudonymUid: MOCK_STUDENT.pseudonymUid,
+          orgId: MOCK_STUDENT.orgId,
+          classIds: MOCK_STUDENT.classIds,
+        }
+      : INITIAL_STATE
+  );
+
+  // Track whether the provider is still mounted so async claim resolution
+  // doesn't set state on an unmounted component.
+  const mountedRef = useRef(true);
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  // Subscribe to onIdTokenChanged (NOT onAuthStateChanged) so claim updates
+  // from a token refresh (e.g. when a student joins a new class mid-session)
+  // propagate without requiring a full sign-out/sign-in cycle.
+  useEffect(() => {
+    if (isAuthBypass) return;
+
+    const unsubscribe = onIdTokenChanged(auth, (user) => {
+      if (!user) {
+        if (!mountedRef.current) return;
+        setState(UNAUTH_STATE);
+        redirectToLoginIfProtected();
+        return;
+      }
+
+      // Resolve claims asynchronously; guard against races by capturing the
+      // user reference we started with.
+      void extractStudentClaims(user).then(
+        (claims) => {
+          if (!mountedRef.current) return;
+          // If the user changed between resolution starting and finishing,
+          // a newer callback will reset state — bail to avoid clobbering.
+          if (auth.currentUser?.uid !== user.uid) return;
+
+          if (!claims) {
+            // Signed in, but not a student (e.g. teacher account) OR claims
+            // are malformed. Force a sign-out so the stale session can't
+            // linger on a shared device, then redirect if appropriate.
+            void firebaseSignOut(auth).catch(() => {
+              // Swallow — the redirect below is the actual remediation.
+            });
+            setState(UNAUTH_STATE);
+            redirectToLoginIfProtected();
+            return;
+          }
+
+          setState({
+            status: 'authenticated',
+            pseudonymUid: user.uid,
+            orgId: claims.orgId,
+            classIds: claims.classIds,
+          });
+        },
+        () => {
+          if (!mountedRef.current) return;
+          setState(UNAUTH_STATE);
+          redirectToLoginIfProtected();
+        }
+      );
+    });
+
+    return unsubscribe;
+  }, []);
+
+  // --- Idle timeout (15 minutes) --------------------------------------------
+  //
+  // A single setTimeout that's reset on interaction. We intentionally do NOT
+  // poll — 60fps mousemove would reset the timeout thousands of times per
+  // minute, which is wasteful even if functionally correct.
+  useEffect(() => {
+    if (isAuthBypass) return;
+    if (state.status !== 'authenticated') return;
+
+    let timeoutId: number | undefined;
+    let lastInteractionAt = Date.now();
+
+    const triggerIdleSignOut = () => {
+      void firebaseSignOut(auth).catch(() => {
+        // Swallow — onIdTokenChanged will pick up the sign-out and redirect.
+      });
+      if (typeof window !== 'undefined') {
+        window.location.assign(STUDENT_LOGIN_PATH);
+      }
+    };
+
+    const scheduleTimeout = () => {
+      if (typeof window === 'undefined') return;
+      if (timeoutId !== undefined) window.clearTimeout(timeoutId);
+      timeoutId = window.setTimeout(triggerIdleSignOut, IDLE_TIMEOUT_MS);
+    };
+
+    const handleInteraction = () => {
+      const now = Date.now();
+      // Throttle: don't reset the timeout more than once per 5s.
+      if (now - lastInteractionAt < INTERACTION_THROTTLE_MS) return;
+      lastInteractionAt = now;
+      scheduleTimeout();
+    };
+
+    scheduleTimeout();
+
+    const events = ['mousemove', 'keydown', 'touchstart', 'click'] as const;
+    const options: AddEventListenerOptions = { passive: true, capture: true };
+    events.forEach((event) => {
+      window.addEventListener(event, handleInteraction, options);
+    });
+
+    return () => {
+      if (typeof window === 'undefined') return;
+      if (timeoutId !== undefined) window.clearTimeout(timeoutId);
+      events.forEach((event) => {
+        window.removeEventListener(event, handleInteraction, options);
+      });
+    };
+  }, [state.status]);
+
+  // --- Imperative sign-out (exposed on context) -----------------------------
+  const signOut = useCallback(async () => {
+    if (isAuthBypass) {
+      // Bypass mode: simulate a sign-out by flipping to unauthenticated and
+      // redirecting. Real Firebase Auth isn't involved.
+      setState(UNAUTH_STATE);
+      if (typeof window !== 'undefined') {
+        window.location.assign(STUDENT_LOGIN_PATH);
+      }
+      return;
+    }
+    try {
+      await firebaseSignOut(auth);
+    } finally {
+      // Always redirect — even if sign-out threw, the user should be booted
+      // off a protected page on a shared device.
+      if (typeof window !== 'undefined') {
+        window.location.assign(STUDENT_LOGIN_PATH);
+      }
+    }
+  }, []);
+
+  const value = useMemo<StudentAuthValue>(
+    () => ({
+      status: state.status,
+      pseudonymUid: state.pseudonymUid,
+      orgId: state.orgId,
+      classIds: state.classIds,
+      signOut,
+    }),
+    [state.status, state.pseudonymUid, state.orgId, state.classIds, signOut]
+  );
+
+  return (
+    <StudentAuthContext.Provider value={value}>
+      {children}
+    </StudentAuthContext.Provider>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// RequireStudentAuth — gate component for protected student pages
+// ---------------------------------------------------------------------------
+
+const StudentAuthLoader: React.FC = () => (
+  <div className="h-screen w-screen flex items-center justify-center bg-slate-50">
+    <Loader2 className="w-12 h-12 text-brand-blue-primary animate-spin" />
+  </div>
+);
+
+/**
+ * Gate a protected student route. While loading, renders a full-page
+ * spinner. While unauthenticated, renders nothing — the provider has
+ * already kicked a redirect to `/student/login`. Only renders `children`
+ * once the custom claims are fully validated.
+ */
+export const RequireStudentAuth: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => {
+  const { status } = React.useContext(StudentAuthContext) ?? {
+    status: 'loading' as StudentAuthStatus,
+  };
+
+  if (status === 'loading') return <StudentAuthLoader />;
+  if (status === 'unauthenticated') return null;
+  return <>{children}</>;
+};

--- a/context/StudentAuthContextValue.ts
+++ b/context/StudentAuthContextValue.ts
@@ -1,0 +1,44 @@
+import { createContext } from 'react';
+
+/**
+ * Authentication status for a protected student page.
+ *
+ * - `'loading'`: initial ID-token check is in flight. Callers should render
+ *   a spinner and NOT redirect.
+ * - `'authenticated'`: the Firebase user has a valid custom token with
+ *   `studentRole === true` and the expected pseudonym claims.
+ * - `'unauthenticated'`: either no Firebase user, or the signed-in user is
+ *   not a student (e.g. a teacher who landed on a student page). The
+ *   provider has already kicked a redirect to `/student/login`.
+ */
+export type StudentAuthStatus = 'loading' | 'authenticated' | 'unauthenticated';
+
+/**
+ * Minimal auth surface for student-facing protected routes.
+ *
+ * This context is intentionally PII-free:
+ *   - `pseudonymUid` is the opaque pseudonym minted by `studentLoginV1`.
+ *   - `orgId` / `classIds` come from the custom claims on that custom token.
+ *   - No email, name, photo, or `sub` is ever read, rendered, or persisted.
+ */
+export interface StudentAuthValue {
+  /** Auth lifecycle status. */
+  status: StudentAuthStatus;
+  /** Opaque pseudonym UID (Firebase `user.uid`). `null` when not authenticated. */
+  pseudonymUid: string | null;
+  /** Org id from custom claims. `null` when not authenticated. */
+  orgId: string | null;
+  /** ClassLink class sourcedIds the student is enrolled in. Empty when not authenticated. */
+  classIds: string[];
+  /**
+   * Sign out of Firebase and redirect to `/student/login`.
+   *
+   * Exposed so that UI (e.g. a "Done" button on `/my-assignments`) can end
+   * a session on shared-device carts without depending on the idle timeout.
+   */
+  signOut: () => Promise<void>;
+}
+
+export const StudentAuthContext = createContext<StudentAuthValue | undefined>(
+  undefined
+);

--- a/context/useStudentAuth.ts
+++ b/context/useStudentAuth.ts
@@ -1,0 +1,18 @@
+import { useContext } from 'react';
+import { StudentAuthContext } from './StudentAuthContextValue';
+
+/**
+ * Access the active student auth state from inside a `<StudentAuthProvider>`.
+ *
+ * Throws if called outside a provider — this is intentional. Student pages
+ * must mount the provider (typically via `<RequireStudentAuth>`) before
+ * calling this hook. Silent fallbacks would mask routing mistakes that
+ * leak protected UI to unauthenticated users.
+ */
+export const useStudentAuth = () => {
+  const context = useContext(StudentAuthContext);
+  if (!context) {
+    throw new Error('useStudentAuth must be used within a StudentAuthProvider');
+  }
+  return context;
+};

--- a/docs/ADMIN_SETUP.md
+++ b/docs/ADMIN_SETUP.md
@@ -112,6 +112,87 @@ function MyComponent() {
 
   Then re-run the setup script.
 
+## ClassLink-via-Google Student Auth
+
+Students launch SpartBoard from ClassLink → Google ID token from GIS → Cloud
+Function `studentLoginV1` mints a Firebase custom token with an HMAC pseudonym
+UID and a `classIds` claim. No student PII is persisted in Firebase.
+
+### HMAC pseudonym secret
+
+**Secret:** `STUDENT_PSEUDONYM_HMAC_SECRET` (32+ random bytes).
+
+This secret is the keystone of the grading match-back system. Every response
+doc, submission doc, and pseudonym UID is derived from it.
+
+**Set on first deploy:**
+
+```bash
+firebase functions:secrets:set STUDENT_PSEUDONYM_HMAC_SECRET
+```
+
+**Rotation rules — read before touching:**
+
+- **NEVER rotate during a semester.** Rotation invalidates every pseudonym in
+  every in-flight assignment. Teacher grading breaks silently (pseudonyms in
+  Firestore no longer match those the function computes for the roster) and
+  students' prior submissions become unrecoverable.
+- Rotate only between semesters, with all assignments closed and rosters
+  archived.
+- If rotation is ever required mid-year (suspected leak), **do not** just
+  rotate. Implement dual-key verification first: `getPseudonymsForAssignmentV1`
+  tries the new key, falls back to the old key for 30 days, then the old key
+  is retired. Budget 1–2 days of dev time.
+
+### Per-organization domain configuration
+
+Each Organization document in Firestore carries a `domains: string[]` field.
+`studentLoginV1` looks up the organization by matching the student's Google
+`hd` claim (and email suffix) against any organization's domains list; no
+match = rejected login.
+
+- Manage via Admin Settings → Organizations in the app UI.
+- Seed Orono with `['orono.k12.mn.us']`.
+- Onboarding a new school is a pure admin-UI action, no code deploy.
+
+### Cloud Monitoring alerts
+
+Ship before rollout, not after. A class of 30 students logging in
+simultaneously is the default scenario — silent failures become classroom
+emergencies. Configure the following alert policies in Google Cloud
+Monitoring (Console → Monitoring → Alerting):
+
+1. **`studentLoginV1` error rate** — alert if >5% errors over any 5-minute
+   window. Metric: `cloudfunctions.googleapis.com/function/execution_count`
+   filtered to `function_name = "studentLoginV1"` and
+   `status != "ok"`; threshold = 5% of total executions.
+
+2. **`studentLoginV1` p95 latency** — alert if p95 > 2s sustained for 10
+   minutes. Metric: `cloudfunctions.googleapis.com/function/execution_times`
+   filtered to `function_name = "studentLoginV1"`; threshold = 2000ms.
+   Sustained latency usually indicates a cold-start or OneRoster slowness.
+
+3. **`students_rejected_domain` counter** — custom log-based counter. A
+   sudden spike means a domain-list misconfiguration (an organization's
+   domains changed, or a school's DNS/Workspace changed their `hd` claim).
+   Create a log-based metric from entries matching
+   `resource.type="cloud_function" function_name="studentLoginV1" textPayload=~"rejected_domain"`.
+
+4. **`students_not_in_roster` counter** — custom log-based counter. Low
+   baseline expected; spikes during roster rollover mean ClassLink sync is
+   behind. Create a log-based metric matching
+   `textPayload=~"not_in_roster"`.
+
+Route alert notifications to the admin ops channel. Confirm the channel at
+rollout — do not assume.
+
+### Cold-start mitigation
+
+`studentLoginV1` and `getPseudonymsForAssignmentV1` are configured with
+`minInstances: 1` to avoid cold-start penalties during simultaneous class
+logins. If cost becomes an issue, the two functions can share a warm
+instance by co-locating them.
+
 ## Troubleshooting
 
 **Script fails with "service-account-key.json not found":**

--- a/firestore.rules
+++ b/firestore.rules
@@ -10,6 +10,38 @@ service cloud.firestore {
              exists(/databases/$(database)/documents/admins/$(request.auth.token.email.lower()));
     }
 
+    // ---- Student (GIS/ClassLink) auth helpers ----
+    //
+    // GIS-authenticated students are signed in via custom tokens minted by
+    // studentLoginV1. The custom claims carry `studentRole: true` plus a
+    // `classIds` list of ClassLink class sourcedIds the student is enrolled
+    // in. These helpers let session rules restrict student-role access to
+    // their own classes without affecting any other auth path (teachers,
+    // admins, or anonymous PIN students).
+
+    function isStudentRoleUser() {
+      return request.auth != null && request.auth.token.studentRole == true;
+    }
+
+    // True iff the caller is a studentRole user AND the given classId is in
+    // their classIds custom claim. False if the claim is missing or the
+    // classId is empty/unknown.
+    function studentRoleCanAccessClass(classId) {
+      return isStudentRoleUser() &&
+             request.auth.token.classIds is list &&
+             classId is string &&
+             classId.size() > 0 &&
+             classId in request.auth.token.classIds;
+    }
+
+    // Gate helper used inside session rules: "either this caller is NOT a
+    // studentRole user, OR the session's classId is in their classIds claim".
+    // Used on both reads (resource.data) and writes (parent get()).
+    function passesStudentClassGate(sessionClassId) {
+      return !isStudentRoleUser() ||
+             studentRoleCanAccessClass(sessionClassId);
+    }
+
     // ---- Organization helpers (see docs/organization_wiring_implementation.md) ----
 
     // Super admins are listed on the legacy admin_settings/user_roles doc.
@@ -514,8 +546,14 @@ service cloud.firestore {
       // we accept that authenticated users can list session documents.
       // `get` allows reading a single known document (students listening for
       // question index updates after joining).
-      allow get: if request.auth != null;
-      allow list: if request.auth != null;
+      //
+      // studentRole (GIS-authenticated) users must additionally have the
+      // session's classId in their classIds custom claim. Non-student callers
+      // (teachers, admins, anonymous PIN students) are unaffected.
+      allow get: if request.auth != null &&
+        passesStudentClassGate(resource.data.get('classId', ''));
+      allow list: if request.auth != null &&
+        passesStudentClassGate(resource.data.get('classId', ''));
       // Only the teacher (session owner) can create/update/delete the session document.
       // Ownership is carried on the `teacherUid` field (no longer the doc id).
       allow create: if request.auth != null &&
@@ -534,16 +572,21 @@ service cloud.firestore {
         function sessionTeacherUid() {
           return get(/databases/$(database)/documents/quiz_sessions/$(sessionId)).data.teacherUid;
         }
+        function sessionClassId() {
+          return get(/databases/$(database)/documents/quiz_sessions/$(sessionId)).data.get('classId', '');
+        }
 
         allow read: if request.auth != null &&
           (request.auth.uid == sessionTeacherUid() ||
-           request.auth.uid == studentUid ||
+           (request.auth.uid == studentUid && passesStudentClassGate(sessionClassId())) ||
            isAdmin());
         allow create: if request.auth != null &&
           request.auth.uid == studentUid &&
           request.resource.data.studentUid == studentUid &&
           // Students cannot forge a score on creation
-          request.resource.data.score == null;
+          request.resource.data.score == null &&
+          // studentRole users must be enrolled in the session's class
+          passesStudentClassGate(sessionClassId());
         allow update: if request.auth != null && (
           // Teacher and admins can update any field
           request.auth.uid == sessionTeacherUid() || isAdmin() ||
@@ -553,6 +596,7 @@ service cloud.firestore {
           // score is never written by students.
           // tabSwitchWarnings may only increase (monotonic) to prevent tampering.
           (request.auth.uid == studentUid &&
+           passesStudentClassGate(sessionClassId()) &&
            request.resource.data.studentUid == resource.data.studentUid &&
            request.resource.data.pin == resource.data.pin &&
            request.resource.data.joinedAt == resource.data.joinedAt &&
@@ -641,8 +685,11 @@ service cloud.firestore {
 
     // Video Activity Sessions — Teacher creates, anonymous students can read and submit responses
     match /video_activity_sessions/{sessionId} {
-      // Any authenticated user (including anonymous) can read session documents
-      allow read: if request.auth != null;
+      // Any authenticated user (including anonymous) can read session documents.
+      // studentRole (GIS) users additionally must have the session's classId
+      // in their classIds claim.
+      allow read: if request.auth != null &&
+        passesStudentClassGate(resource.data.get('classId', ''));
       // Only authenticated (non-anonymous) users can create sessions (teachers)
       allow create: if request.auth != null && request.auth.token.firebase.sign_in_provider != 'anonymous';
       // Teacher owners may rename or end sessions, but not mutate session content.
@@ -671,22 +718,29 @@ service cloud.firestore {
         (resource.data.teacherUid == request.auth.uid || isAdmin());
 
       match /responses/{studentUid} {
+        function vaSessionClassId() {
+          return get(/databases/$(database)/documents/video_activity_sessions/$(sessionId)).data.get('classId', '');
+        }
+
         // Teacher can read all responses; students can only read their own (doc ID == auth UID)
         allow read: if request.auth != null && (
           isAdmin() ||
           get(/databases/$(database)/documents/video_activity_sessions/$(sessionId)).data.teacherUid == request.auth.uid ||
-          studentUid == request.auth.uid
+          (studentUid == request.auth.uid && passesStudentClassGate(vaSessionClassId()))
         );
-        // Students create their own response; document ID and studentUid field must match their auth UID
+        // Students create their own response; document ID and studentUid field must match their auth UID.
+        // studentRole users must also be enrolled in the session's class.
         allow create: if request.auth != null &&
           studentUid == request.auth.uid &&
           request.resource.data.studentUid == request.auth.uid &&
           request.resource.data.score == null &&
-          request.resource.data.completedAt == null;
+          request.resource.data.completedAt == null &&
+          passesStudentClassGate(vaSessionClassId());
         // Students can update only their own response to add answers or set completedAt;
         // identity fields and score are immutable from the client; answers array may only grow
         allow update: if request.auth != null &&
           studentUid == request.auth.uid &&
+          passesStudentClassGate(vaSessionClassId()) &&
           request.resource.data.studentUid == resource.data.studentUid &&
           request.resource.data.pin == resource.data.pin &&
           request.resource.data.name == resource.data.name &&
@@ -711,8 +765,11 @@ service cloud.firestore {
 
     // MiniApp Assignment Sessions — Teacher creates, anonymous students can read
     match /mini_app_sessions/{sessionId} {
-      // Any authenticated user (including anonymous) can read session documents
-      allow read: if request.auth != null;
+      // Any authenticated user (including anonymous) can read session documents.
+      // studentRole (GIS) users additionally must have the session's classId
+      // in their classIds claim.
+      allow read: if request.auth != null &&
+        passesStudentClassGate(resource.data.get('classId', ''));
       // Only authenticated (non-anonymous) teachers can create sessions they own
       allow create: if request.auth != null &&
         request.auth.token.firebase.sign_in_provider != 'anonymous' &&
@@ -725,6 +782,56 @@ service cloud.firestore {
           .hasOnly(['assignmentName', 'status', 'endedAt']) &&
         request.resource.data.status in ['active', 'ended'];
       allow delete: if false;
+
+      // MiniApp student submissions. Replaces the legacy Apps Script →
+      // Google Sheets pipeline. Doc ID is either an opaque per-assignment
+      // pseudonym (studentRole launches) or the anonymous Firebase Auth UID
+      // (legacy shared-link launches). Payload is deliberately opaque —
+      // no PII is persisted.
+      match /submissions/{submissionId} {
+        function maSessionData() {
+          return get(/databases/$(database)/documents/mini_app_sessions/$(sessionId)).data;
+        }
+        function maSessionClassId() {
+          return maSessionData().get('classId', '');
+        }
+
+        // Session owner (teacher) and admins can read all submissions.
+        // A student may read their own submission doc (used for the
+        // completion-badge check in /my-assignments). Anonymous students'
+        // doc ID is their auth uid; studentRole students know only their
+        // own pseudonym, so the same `submissionId == request.auth.uid`
+        // check naturally applies to anonymous-launch completion checks,
+        // while studentRole users read via the getDoc path they already
+        // obtained the pseudonym for.
+        allow read: if request.auth != null && (
+          isAdmin() ||
+          maSessionData().teacherUid == request.auth.uid ||
+          submissionId == request.auth.uid
+        );
+
+        // Any authenticated user (anonymous or studentRole) may create or
+        // update their own submission while the session is active.
+        // - Anonymous launches must use their auth uid as the doc ID.
+        // - studentRole launches use an opaque per-assignment pseudonym;
+        //   the class gate blocks cross-class writes and the HMAC secret
+        //   server-side prevents forging another student's pseudonym.
+        // Payload shape is validated to prevent junk writes bloating the
+        // subcollection.
+        allow create, update: if request.auth != null &&
+          maSessionData().status == 'active' &&
+          passesStudentClassGate(maSessionClassId()) &&
+          (isStudentRoleUser() || submissionId == request.auth.uid) &&
+          request.resource.data.keys().hasOnly(['submittedAt', 'payload']) &&
+          request.resource.data.submittedAt is int;
+
+        // Only the owning teacher or an admin may delete submissions —
+        // used when a teacher wipes an assignment.
+        allow delete: if request.auth != null && (
+          isAdmin() ||
+          maSessionData().teacherUid == request.auth.uid
+        );
+      }
     }
 
     // AI Usage Tracking — read-only for users; all writes go through Cloud Functions (Admin SDK)
@@ -743,8 +850,11 @@ service cloud.firestore {
 
     // Guided Learning Sessions — Teacher creates, authenticated (incl. anonymous) students read and submit
     match /guided_learning_sessions/{sessionId} {
-      // Any authenticated user (including anonymous) can read session documents
-      allow read: if request.auth != null;
+      // Any authenticated user (including anonymous) can read session documents.
+      // studentRole (GIS) users additionally must have the session's classId
+      // in their classIds claim.
+      allow read: if request.auth != null &&
+        passesStudentClassGate(resource.data.get('classId', ''));
       // Only authenticated (non-anonymous) teachers can create sessions; they must own it
       allow create: if request.auth != null &&
         request.auth.token.firebase.sign_in_provider != 'anonymous' &&
@@ -758,22 +868,29 @@ service cloud.firestore {
         (resource.data.teacherUid == request.auth.uid || isAdmin());
 
       match /responses/{studentUid} {
+        function glSessionClassId() {
+          return get(/databases/$(database)/documents/guided_learning_sessions/$(sessionId)).data.get('classId', '');
+        }
+
         // Teacher can read all responses; students can only read their own
         allow read: if request.auth != null && (
           isAdmin() ||
           get(/databases/$(database)/documents/guided_learning_sessions/$(sessionId)).data.teacherUid == request.auth.uid ||
-          studentUid == request.auth.uid
+          (studentUid == request.auth.uid && passesStudentClassGate(glSessionClassId()))
         );
-        // Students create their own response; doc ID, studentAnonymousId, and sessionId must match
+        // Students create their own response; doc ID, studentAnonymousId, and sessionId must match.
+        // studentRole users must also be enrolled in the session's class.
         allow create: if request.auth != null &&
           studentUid == request.auth.uid &&
           request.resource.data.studentAnonymousId == request.auth.uid &&
           request.resource.data.sessionId == sessionId &&
-          request.resource.data.score == null;
+          request.resource.data.score == null &&
+          passesStudentClassGate(glSessionClassId());
         // Students can update only their own response to add answers or set completedAt;
         // identity fields and score are immutable from the client
         allow update: if request.auth != null &&
           studentUid == request.auth.uid &&
+          passesStudentClassGate(glSessionClassId()) &&
           request.resource.data.studentAnonymousId == resource.data.studentAnonymousId &&
           request.resource.data.sessionId == resource.data.sessionId &&
           request.resource.data.startedAt == resource.data.startedAt &&
@@ -793,7 +910,10 @@ service cloud.firestore {
     // sessionId is formatted as {teacherUid}_{activityId}
     match /activity_wall_sessions/{sessionId} {
       // Any authenticated user can read the session metadata from a valid share link.
-      allow read: if request.auth != null;
+      // studentRole (GIS) users additionally must have the session's classId
+      // in their classIds claim.
+      allow read: if request.auth != null &&
+        passesStudentClassGate(resource.data.get('classId', ''));
       // Only authenticated non-anonymous teachers/admins can create or update the session document itself.
       allow create, update: if request.auth != null &&
                             request.auth.token.firebase.sign_in_provider != 'anonymous' &&
@@ -801,10 +921,16 @@ service cloud.firestore {
       allow delete: if false;
 
       match /submissions/{submissionId} {
+        function awSessionClassId() {
+          return get(/databases/$(database)/documents/activity_wall_sessions/$(sessionId)).data.get('classId', '');
+        }
+
         // Any authenticated user (including anonymous) can create a submission.
         // Photo submissions may include Firebase storage metadata for later Drive archiving.
+        // studentRole (GIS) users must be enrolled in the session's class.
         allow create: if request.auth != null &&
           exists(/databases/$(database)/documents/activity_wall_sessions/$(sessionId)) &&
+          passesStudentClassGate(awSessionClassId()) &&
           request.resource.data.id is string &&
           request.resource.data.content is string &&
           request.resource.data.content.size() > 0 &&

--- a/firestore.rules
+++ b/firestore.rules
@@ -823,7 +823,9 @@ service cloud.firestore {
           passesStudentClassGate(maSessionClassId()) &&
           (isStudentRoleUser() || submissionId == request.auth.uid) &&
           request.resource.data.keys().hasOnly(['submittedAt', 'payload']) &&
-          request.resource.data.submittedAt is int;
+          request.resource.data.submittedAt is int &&
+          request.resource.data.payload is map &&
+          request.resource.data.payload.size() <= 50;
 
         // Only the owning teacher or an admin may delete submissions —
         // used when a teacher wipes an assignment.

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -6,6 +6,7 @@ import axios, { AxiosError } from 'axios';
 import OAuth from 'oauth-1.0a';
 import * as CryptoJS from 'crypto-js';
 import { GoogleGenAI, Content } from '@google/genai';
+import { OAuth2Client } from 'google-auth-library';
 import { sanitizePrompt } from './sanitize';
 import { parseGeminiJson } from './parseGeminiJson';
 
@@ -27,6 +28,10 @@ const GEMINI_API_KEY = defineSecret('GEMINI_API_KEY');
 const CLASSLINK_CLIENT_ID = defineSecret('CLASSLINK_CLIENT_ID');
 const CLASSLINK_CLIENT_SECRET = defineSecret('CLASSLINK_CLIENT_SECRET');
 const CLASSLINK_TENANT_URL = defineSecret('CLASSLINK_TENANT_URL');
+const STUDENT_PSEUDONYM_HMAC_SECRET = defineSecret(
+  'STUDENT_PSEUDONYM_HMAC_SECRET'
+);
+const GOOGLE_OAUTH_CLIENT_ID = defineSecret('GOOGLE_OAUTH_CLIENT_ID');
 
 const ALLOWED_ORIGINS: (string | RegExp)[] = [
   'https://spartboard.web.app',
@@ -2481,6 +2486,467 @@ export const adminAnalytics = onRequest(
           ? err.message
           : 'An internal error occurred fetching analytics.';
       res.status(500).json({ error: 'internal', message: errorMessage });
+    }
+  }
+);
+
+// ---------------------------------------------------------------------------
+// Student identity (ClassLink-via-Google) — PII-free auth flow
+// ---------------------------------------------------------------------------
+//
+// Students launch SpartBoard from their ClassLink LaunchPad tile. Because
+// ClassLink is the district IdP and pushes identity into Google Workspace,
+// the student is already signed in with Google on the Chromebook. We use
+// Google Identity Services (GIS) client-side to obtain an ID token, verify
+// it server-side, then look up the student in ClassLink OneRoster and mint
+// a Firebase custom token whose UID is an HMAC pseudonym of the OneRoster
+// sourcedId. Email / name / sub / sourcedId are never persisted.
+//
+// Intentional design choices:
+//   - GIS + custom token (NOT signInWithPopup + GoogleAuthProvider) so that
+//     the Firebase Auth user record never receives email/displayName/photoURL.
+//   - Per-organization domain gating via existing
+//     /organizations/{orgId}/domains subcollection; a login with a domain
+//     not present (and verified) in any organization is rejected.
+//   - Per-assignment pseudonym = HMAC(SECRET, uid + assignmentId) so the
+//     server never needs the sourcedId after login. Teacher match-back
+//     recomputes it from the OneRoster roster at grading time.
+//   - NO PII logging. All catch blocks log class-of-failure only.
+
+interface OneRosterUserWithRole extends ClassLinkUser {
+  role?: string;
+  roles?: Array<{ role?: string; roleType?: string }>;
+}
+
+const STUDENT_LOGIN_CLASS_IDS_MAX = 20;
+
+function hmacSha256Hex(secret: string, message: string): string {
+  return CryptoJS.HmacSHA256(message, secret).toString(CryptoJS.enc.Hex);
+}
+
+function computeStudentUid(sourcedId: string, hmacSecret: string): string {
+  return hmacSha256Hex(hmacSecret, `sid:${sourcedId}`);
+}
+
+function computeAssignmentPseudonym(
+  uid: string,
+  assignmentId: string,
+  hmacSecret: string
+): string {
+  return hmacSha256Hex(hmacSecret, `asn:${uid}:${assignmentId}`);
+}
+
+function normalizeEmailDomain(email: string): string | null {
+  const at = email.lastIndexOf('@');
+  if (at < 0 || at === email.length - 1) return null;
+  return '@' + email.slice(at + 1).toLowerCase();
+}
+
+/**
+ * Looks up the organization that owns the given email domain. Matches against
+ * the existing /organizations/{orgId}/domains/{doc} subcollection, requiring
+ * `status === 'verified'`. Domain values in that collection are stored with a
+ * leading '@' (e.g. '@orono.k12.mn.us'). Returns null if no match.
+ */
+async function resolveOrgIdForDomain(
+  db: admin.firestore.Firestore,
+  domainWithAt: string
+): Promise<string | null> {
+  const snap = await db
+    .collectionGroup('domains')
+    .where('domain', '==', domainWithAt)
+    .where('status', '==', 'verified')
+    .limit(1)
+    .get();
+  if (snap.empty) return null;
+  const orgRef = snap.docs[0].ref.parent.parent;
+  return orgRef ? orgRef.id : null;
+}
+
+function isOneRosterStudent(user: OneRosterUserWithRole): boolean {
+  if (user.role && user.role.toLowerCase() === 'student') return true;
+  if (Array.isArray(user.roles)) {
+    return user.roles.some((r) => {
+      const v = (r.role ?? r.roleType ?? '').toLowerCase();
+      return v === 'student' || v === 'primary';
+    });
+  }
+  return false;
+}
+
+/**
+ * studentLoginV1
+ *
+ * Input:  { idToken: string }  — Google ID token from GIS on the client.
+ * Output: { customToken, orgId, classCount } — client then calls
+ *         signInWithCustomToken(customToken).
+ *
+ * Failure codes:
+ *   - unauthenticated / invalid-argument: ID token missing or invalid.
+ *   - permission-denied: email domain not registered with any organization.
+ *   - not-found: student email not present in ClassLink OneRoster, or no
+ *                classes enrolled, or account role is not 'student'.
+ *   - internal: ClassLink API unreachable or server misconfigured.
+ */
+export const studentLoginV1 = onCall(
+  {
+    memory: '256MiB',
+    minInstances: 1,
+    secrets: [
+      CLASSLINK_CLIENT_ID,
+      CLASSLINK_CLIENT_SECRET,
+      CLASSLINK_TENANT_URL,
+      STUDENT_PSEUDONYM_HMAC_SECRET,
+      GOOGLE_OAUTH_CLIENT_ID,
+    ],
+    invoker: 'public',
+  },
+  async (request) => {
+    const rawIdToken = (request.data as { idToken?: unknown })?.idToken;
+    const idToken = typeof rawIdToken === 'string' ? rawIdToken : '';
+    if (!idToken) {
+      throw new HttpsError('invalid-argument', 'Missing idToken.');
+    }
+
+    const googleClientId = GOOGLE_OAUTH_CLIENT_ID.value();
+    const hmacSecret = STUDENT_PSEUDONYM_HMAC_SECRET.value();
+    const classlinkClientId = CLASSLINK_CLIENT_ID.value();
+    const classlinkClientSecret = CLASSLINK_CLIENT_SECRET.value();
+    const tenantUrl = CLASSLINK_TENANT_URL.value();
+    if (
+      !googleClientId ||
+      !hmacSecret ||
+      !classlinkClientId ||
+      !classlinkClientSecret ||
+      !tenantUrl
+    ) {
+      console.error(
+        '[studentLoginV1] Missing required server configuration (secrets).'
+      );
+      throw new HttpsError('internal', 'Server configuration missing.');
+    }
+
+    // 1. Verify the Google ID token signature and audience. The library also
+    //    validates `iss`, `exp`, and our expected `aud` in one call.
+    const oauthClient = new OAuth2Client();
+    let email: string;
+    let hd: string | undefined;
+    let emailVerified: boolean;
+    try {
+      const ticket = await oauthClient.verifyIdToken({
+        idToken,
+        audience: googleClientId,
+      });
+      const payload = ticket.getPayload();
+      if (!payload) {
+        throw new Error('no-payload');
+      }
+      email = typeof payload.email === 'string' ? payload.email : '';
+      hd = typeof payload.hd === 'string' ? payload.hd : undefined;
+      emailVerified = payload.email_verified === true;
+    } catch {
+      // Do not log token contents.
+      console.warn('[studentLoginV1] ID token verification failed.');
+      throw new HttpsError('unauthenticated', 'Invalid identity token.');
+    }
+    if (!email || !emailVerified) {
+      throw new HttpsError('unauthenticated', 'Email not verified by Google.');
+    }
+
+    // 2. Organization / domain gate. Prefer the `hd` claim (Workspace-issued),
+    //    but fall back to the email suffix since `hd` is not guaranteed on
+    //    every Workspace configuration.
+    const emailDomain = normalizeEmailDomain(email);
+    if (!emailDomain) {
+      throw new HttpsError('unauthenticated', 'Malformed email.');
+    }
+    const hdDomain = hd ? '@' + hd.toLowerCase() : null;
+
+    const db = admin.firestore();
+    let orgId = hdDomain ? await resolveOrgIdForDomain(db, hdDomain) : null;
+    if (!orgId) {
+      orgId = await resolveOrgIdForDomain(db, emailDomain);
+    }
+    if (!orgId) {
+      // Counter for monitoring alert on misconfiguration / unregistered schools.
+      console.warn('[studentLoginV1] students_rejected_domain');
+      throw new HttpsError(
+        'permission-denied',
+        'This SpartBoard is only available to schools that have signed up.'
+      );
+    }
+
+    // 3. ClassLink OneRoster lookup — fetch the student's sourcedId and
+    //    classes. Held in memory only, never written to Firestore.
+    const cleanTenantUrl = tenantUrl.replace(/\/$/, '');
+    let sourcedId: string;
+    let classIds: string[];
+    try {
+      const usersBaseUrl = `${cleanTenantUrl}/ims/oneroster/v1p1/users`;
+      const userParams = { filter: `email='${email}'` };
+      const userHeaders = getOAuthHeaders(
+        usersBaseUrl,
+        userParams,
+        'GET',
+        classlinkClientId,
+        classlinkClientSecret
+      );
+      const userResp = await axios.get<{ users: OneRosterUserWithRole[] }>(
+        usersBaseUrl,
+        { params: userParams, headers: { ...userHeaders } }
+      );
+      const users = userResp.data.users ?? [];
+      const studentUser = users.find(isOneRosterStudent);
+      if (!studentUser) {
+        console.warn('[studentLoginV1] students_not_in_roster');
+        throw new HttpsError(
+          'not-found',
+          'No student record found in ClassLink roster.'
+        );
+      }
+      sourcedId = studentUser.sourcedId;
+
+      const classesUrl = `${cleanTenantUrl}/ims/oneroster/v1p1/users/${sourcedId}/classes`;
+      const classesHeaders = getOAuthHeaders(
+        classesUrl,
+        {},
+        'GET',
+        classlinkClientId,
+        classlinkClientSecret
+      );
+      const classesResp = await axios.get<{ classes: ClassLinkClass[] }>(
+        classesUrl,
+        { headers: { ...classesHeaders } }
+      );
+      classIds = (classesResp.data.classes ?? [])
+        .map((c) => c.sourcedId)
+        .filter((id): id is string => typeof id === 'string' && id.length > 0)
+        .slice(0, STUDENT_LOGIN_CLASS_IDS_MAX);
+    } catch (err) {
+      if (err instanceof HttpsError) throw err;
+      if (axios.isAxiosError(err)) {
+        console.error(
+          '[studentLoginV1] ClassLink request failed:',
+          err.response?.status
+        );
+      } else {
+        console.error('[studentLoginV1] ClassLink request failed.');
+      }
+      throw new HttpsError('internal', 'Roster service unavailable.');
+    }
+
+    // 4. Compute the stable opaque UID and mint the custom token with
+    //    the classIds claim that gates Firestore reads.
+    const uid = computeStudentUid(sourcedId, hmacSecret);
+
+    let customToken: string;
+    try {
+      customToken = await admin.auth().createCustomToken(uid, {
+        studentRole: true,
+        orgId,
+        classIds,
+      });
+    } catch (err) {
+      console.error('[studentLoginV1] createCustomToken failed:', err);
+      throw new HttpsError('internal', 'Failed to mint auth token.');
+    }
+
+    return { customToken, orgId, classCount: classIds.length };
+  }
+);
+
+/**
+ * getAssignmentPseudonymV1
+ *
+ * Called by the authenticated student client when opening a specific
+ * assignment. Returns the opaque pseudonym to write into the response doc:
+ *
+ *   pseudonym = HMAC_SHA256(HMAC_SECRET, "asn:" + uid + ":" + assignmentId)
+ *
+ * Stable within (uid, assignmentId), unlinkable across assignments, and
+ * unlinkable to a student without both the HMAC secret AND the OneRoster
+ * roster.
+ */
+export const getAssignmentPseudonymV1 = onCall(
+  {
+    memory: '128MiB',
+    secrets: [STUDENT_PSEUDONYM_HMAC_SECRET],
+    invoker: 'public',
+  },
+  (request) => {
+    if (!request.auth) {
+      throw new HttpsError('unauthenticated', 'Sign in required.');
+    }
+    if (request.auth.token.studentRole !== true) {
+      throw new HttpsError('permission-denied', 'Student role required.');
+    }
+    const rawAssignmentId = (request.data as { assignmentId?: unknown })
+      ?.assignmentId;
+    const assignmentId =
+      typeof rawAssignmentId === 'string' ? rawAssignmentId : '';
+    if (!assignmentId || assignmentId.length > 200) {
+      throw new HttpsError('invalid-argument', 'Invalid assignmentId.');
+    }
+
+    const hmacSecret = STUDENT_PSEUDONYM_HMAC_SECRET.value();
+    if (!hmacSecret) {
+      throw new HttpsError('internal', 'Server configuration missing.');
+    }
+
+    const pseudonym = computeAssignmentPseudonym(
+      request.auth.uid,
+      assignmentId,
+      hmacSecret
+    );
+    return { pseudonym };
+  }
+);
+
+/**
+ * getPseudonymsForAssignmentV1
+ *
+ * Called by a teacher's client when rendering the grading view for an
+ * assignment. Returns `{ sourcedId -> pseudonym }` for every student in the
+ * targeted ClassLink class so the teacher's client can join Firestore
+ * responses (keyed by pseudonym) back to roster identity (keyed by
+ * sourcedId). The HMAC secret never leaves the server.
+ */
+export const getPseudonymsForAssignmentV1 = onCall(
+  {
+    memory: '256MiB',
+    minInstances: 1,
+    secrets: [
+      CLASSLINK_CLIENT_ID,
+      CLASSLINK_CLIENT_SECRET,
+      CLASSLINK_TENANT_URL,
+      STUDENT_PSEUDONYM_HMAC_SECRET,
+    ],
+    invoker: 'public',
+  },
+  async (request) => {
+    if (!request.auth) {
+      throw new HttpsError('unauthenticated', 'Sign in required.');
+    }
+    // Teachers authenticate with standard Firebase Auth (email present on
+    // token). Students never have email on their token, so this also keeps
+    // students out of the teacher-only endpoint.
+    const teacherEmail = request.auth.token.email;
+    if (!teacherEmail || request.auth.token.studentRole === true) {
+      throw new HttpsError('permission-denied', 'Teacher account required.');
+    }
+
+    const data = request.data as {
+      assignmentId?: unknown;
+      classId?: unknown;
+    };
+    const assignmentId =
+      typeof data?.assignmentId === 'string' ? data.assignmentId : '';
+    const classId = typeof data?.classId === 'string' ? data.classId : '';
+    if (!assignmentId || !classId) {
+      throw new HttpsError(
+        'invalid-argument',
+        'assignmentId and classId are required.'
+      );
+    }
+
+    const hmacSecret = STUDENT_PSEUDONYM_HMAC_SECRET.value();
+    const classlinkClientId = CLASSLINK_CLIENT_ID.value();
+    const classlinkClientSecret = CLASSLINK_CLIENT_SECRET.value();
+    const tenantUrl = CLASSLINK_TENANT_URL.value();
+    if (
+      !hmacSecret ||
+      !classlinkClientId ||
+      !classlinkClientSecret ||
+      !tenantUrl
+    ) {
+      throw new HttpsError('internal', 'Server configuration missing.');
+    }
+
+    const cleanTenantUrl = tenantUrl.replace(/\/$/, '');
+
+    // Verify the teacher actually teaches this class before disclosing the
+    // roster pseudonyms. A teacher can only retrieve pseudonyms for their
+    // own classes.
+    try {
+      const teacherUrl = `${cleanTenantUrl}/ims/oneroster/v1p1/users`;
+      const teacherParams = { filter: `email='${teacherEmail}'` };
+      const teacherHeaders = getOAuthHeaders(
+        teacherUrl,
+        teacherParams,
+        'GET',
+        classlinkClientId,
+        classlinkClientSecret
+      );
+      const teacherResp = await axios.get<{ users: OneRosterUserWithRole[] }>(
+        teacherUrl,
+        { params: teacherParams, headers: { ...teacherHeaders } }
+      );
+      const teacherUser = (teacherResp.data.users ?? [])[0];
+      if (!teacherUser) {
+        throw new HttpsError(
+          'not-found',
+          'Teacher not found in ClassLink roster.'
+        );
+      }
+      const classesUrl = `${cleanTenantUrl}/ims/oneroster/v1p1/users/${teacherUser.sourcedId}/classes`;
+      const classesHeaders = getOAuthHeaders(
+        classesUrl,
+        {},
+        'GET',
+        classlinkClientId,
+        classlinkClientSecret
+      );
+      const classesResp = await axios.get<{ classes: ClassLinkClass[] }>(
+        classesUrl,
+        { headers: { ...classesHeaders } }
+      );
+      const teaches = (classesResp.data.classes ?? []).some(
+        (c) => c.sourcedId === classId
+      );
+      if (!teaches) {
+        throw new HttpsError(
+          'permission-denied',
+          'Not a teacher of this class.'
+        );
+      }
+
+      // Now fetch the class's students and compute the pseudonym map.
+      const studentsUrl = `${cleanTenantUrl}/ims/oneroster/v1p1/classes/${classId}/students`;
+      const studentsHeaders = getOAuthHeaders(
+        studentsUrl,
+        {},
+        'GET',
+        classlinkClientId,
+        classlinkClientSecret
+      );
+      const studentsResp = await axios.get<{ users: ClassLinkStudent[] }>(
+        studentsUrl,
+        { headers: { ...studentsHeaders } }
+      );
+      const students = studentsResp.data.users ?? [];
+
+      const pseudonyms: Record<string, string> = {};
+      for (const s of students) {
+        if (!s.sourcedId) continue;
+        const uid = computeStudentUid(s.sourcedId, hmacSecret);
+        pseudonyms[s.sourcedId] = computeAssignmentPseudonym(
+          uid,
+          assignmentId,
+          hmacSecret
+        );
+      }
+      return { pseudonyms };
+    } catch (err) {
+      if (err instanceof HttpsError) throw err;
+      if (axios.isAxiosError(err)) {
+        console.error(
+          '[getPseudonymsForAssignmentV1] ClassLink request failed:',
+          err.response?.status
+        );
+      } else {
+        console.error('[getPseudonymsForAssignmentV1] Unexpected failure.');
+      }
+      throw new HttpsError('internal', 'Roster service unavailable.');
     }
   }
 );

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -356,6 +356,9 @@ export const getClassLinkRosterV1 = onCall(
     const cleanTenantUrl = tenantUrl.replace(/\/$/, '');
 
     try {
+      if (!isSafeEmailForOneRosterFilter(userEmail)) {
+        return { classes: [], studentsByClass: {} };
+      }
       const usersBaseUrl = `${cleanTenantUrl}/ims/oneroster/v1p1/users`;
       const userParams = { filter: `email='${userEmail}'` };
 

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -2543,6 +2543,16 @@ function normalizeEmailDomain(email: string): string | null {
 }
 
 /**
+ * Rejects emails that would break (or be injected into) an unquoted
+ * OneRoster `filter=email='...'` string. Real Google-verified school emails
+ * never contain `'` or `\`, so callers short-circuit to the standard
+ * "not in roster" path rather than disclosing the guard's existence.
+ */
+function isSafeEmailForOneRosterFilter(email: string): boolean {
+  return !/['\\]/.test(email);
+}
+
+/**
  * Looks up the organization that owns the given email domain. Matches against
  * the existing /organizations/{orgId}/domains/{doc} subcollection, requiring
  * `status === 'verified'`. Domain values in that collection are stored with a
@@ -2682,6 +2692,13 @@ export const studentLoginV1 = onCall(
     let sourcedId: string;
     let classIds: string[];
     try {
+      if (!isSafeEmailForOneRosterFilter(email)) {
+        console.warn('[studentLoginV1] students_not_in_roster');
+        throw new HttpsError(
+          'not-found',
+          'No student record found in ClassLink roster.'
+        );
+      }
       const usersBaseUrl = `${cleanTenantUrl}/ims/oneroster/v1p1/users`;
       const userParams = { filter: `email='${email}'` };
       const userHeaders = getOAuthHeaders(
@@ -2876,6 +2893,12 @@ export const getPseudonymsForAssignmentV1 = onCall(
     // roster pseudonyms. A teacher can only retrieve pseudonyms for their
     // own classes.
     try {
+      if (!isSafeEmailForOneRosterFilter(teacherEmail)) {
+        throw new HttpsError(
+          'not-found',
+          'Teacher not found in ClassLink roster.'
+        );
+      }
       const teacherUrl = `${cleanTenantUrl}/ims/oneroster/v1p1/users`;
       const teacherParams = { filter: `email='${teacherEmail}'` };
       const teacherHeaders = getOAuthHeaders(

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -2806,10 +2806,18 @@ export const getAssignmentPseudonymV1 = onCall(
  * getPseudonymsForAssignmentV1
  *
  * Called by a teacher's client when rendering the grading view for an
- * assignment. Returns `{ sourcedId -> pseudonym }` for every student in the
- * targeted ClassLink class so the teacher's client can join Firestore
- * responses (keyed by pseudonym) back to roster identity (keyed by
- * sourcedId). The HMAC secret never leaves the server.
+ * assignment. Returns both pseudonyms plus names for every student in the
+ * targeted ClassLink class:
+ *   { sourcedId -> { studentUid, assignmentPseudonym, givenName, familyName } }
+ * so the teacher's client can join Firestore responses (keyed by either the
+ * session-scoped studentUid for quiz/video/guided-learning or the
+ * assignment-scoped pseudonym for mini-app submissions) back to roster
+ * identity and display names. Names never touch Firestore — they stay in
+ * teacher-browser memory for the session. The HMAC secret never leaves the
+ * server.
+ *
+ * Only callable by a teacher who actually teaches the requested class
+ * (ClassLink membership is re-verified on every call).
  */
 export const getPseudonymsForAssignmentV1 = onCall(
   {
@@ -2925,15 +2933,37 @@ export const getPseudonymsForAssignmentV1 = onCall(
       );
       const students = studentsResp.data.users ?? [];
 
-      const pseudonyms: Record<string, string> = {};
+      // Return both pseudonyms so teacher viewers can match whichever one
+      // the response doc is keyed by:
+      //  - studentUid            — HMAC(sourcedId, secret); equals the
+      //                            ClassLink student's Firebase Auth UID.
+      //                            Used by quiz/video-activity/guided-learning
+      //                            response docs that key on auth.currentUser.uid.
+      //  - assignmentPseudonym   — HMAC(studentUid + assignmentId, secret).
+      //                            Used by mini-app submission docs that key
+      //                            on a per-assignment opaque id.
+      const pseudonyms: Record<
+        string,
+        {
+          studentUid: string;
+          assignmentPseudonym: string;
+          givenName: string;
+          familyName: string;
+        }
+      > = {};
       for (const s of students) {
         if (!s.sourcedId) continue;
-        const uid = computeStudentUid(s.sourcedId, hmacSecret);
-        pseudonyms[s.sourcedId] = computeAssignmentPseudonym(
-          uid,
-          assignmentId,
-          hmacSecret
-        );
+        const studentUid = computeStudentUid(s.sourcedId, hmacSecret);
+        pseudonyms[s.sourcedId] = {
+          studentUid,
+          assignmentPseudonym: computeAssignmentPseudonym(
+            studentUid,
+            assignmentId,
+            hmacSecret
+          ),
+          givenName: s.givenName ?? '',
+          familyName: s.familyName ?? '',
+        };
       }
       return { pseudonyms };
     } catch (err) {

--- a/hooks/useAssignmentPseudonyms.ts
+++ b/hooks/useAssignmentPseudonyms.ts
@@ -1,0 +1,157 @@
+/**
+ * useAssignmentPseudonyms — teacher-side name resolution for ClassLink
+ * students.
+ *
+ * Calls `getPseudonymsForAssignmentV1` once per (assignmentId, classId) pair
+ * and returns two reverse maps so grading viewers can render student names
+ * regardless of which pseudonym their response docs are keyed by:
+ *
+ *   - `byStudentUid`           — keyed by HMAC(sourcedId). Matches Firestore
+ *                                docs that use `auth.currentUser.uid` as the
+ *                                doc ID (quiz, video-activity, guided-
+ *                                learning responses).
+ *   - `byAssignmentPseudonym`  — keyed by HMAC(studentUid + assignmentId).
+ *                                Matches Firestore docs that use a per-
+ *                                assignment opaque id as the doc ID (mini-
+ *                                app submissions).
+ *
+ * The callable is only invoked when `classId` is non-empty (i.e. the
+ * assignment was targeted to a ClassLink class). Unmatched ids in the
+ * reverse maps mean the submitting student arrived via the legacy code+PIN
+ * flow — callers should fall back to their existing PIN / anonymous label.
+ *
+ * Module-level Promise-valued cache so sibling viewers (e.g. AssignmentsModal
+ * opening a row-level modal) de-dupe the round trip. Cache is invalidated
+ * when the authenticated teacher uid changes.
+ */
+
+import { useEffect, useState } from 'react';
+import { httpsCallable } from 'firebase/functions';
+import { auth, functions } from '@/config/firebase';
+
+export interface StudentName {
+  givenName: string;
+  familyName: string;
+}
+
+export interface AssignmentPseudonymMaps {
+  byStudentUid: Map<string, StudentName>;
+  byAssignmentPseudonym: Map<string, StudentName>;
+}
+
+interface CallableResponse {
+  pseudonyms?: Record<
+    string,
+    {
+      studentUid?: string;
+      assignmentPseudonym?: string;
+      givenName?: string;
+      familyName?: string;
+    }
+  >;
+}
+
+const EMPTY_MAPS: AssignmentPseudonymMaps = {
+  byStudentUid: new Map(),
+  byAssignmentPseudonym: new Map(),
+};
+
+let cacheOwnerUid: string | null = null;
+let cache: Map<string, Promise<AssignmentPseudonymMaps>> = new Map();
+
+function cacheKey(assignmentId: string, classId: string): string {
+  return `${assignmentId}::${classId}`;
+}
+
+function fetchPseudonymMaps(
+  assignmentId: string,
+  classId: string,
+  teacherUid: string
+): Promise<AssignmentPseudonymMaps> {
+  if (cacheOwnerUid !== teacherUid) {
+    cache = new Map();
+    cacheOwnerUid = teacherUid;
+  }
+  const key = cacheKey(assignmentId, classId);
+  const cached = cache.get(key);
+  if (cached) return cached;
+
+  const callable = httpsCallable<
+    { assignmentId: string; classId: string },
+    CallableResponse
+  >(functions, 'getPseudonymsForAssignmentV1');
+
+  const promise = callable({ assignmentId, classId }).then((res) => {
+    const entries = res.data?.pseudonyms ?? {};
+    const byStudentUid = new Map<string, StudentName>();
+    const byAssignmentPseudonym = new Map<string, StudentName>();
+    for (const v of Object.values(entries)) {
+      const name: StudentName = {
+        givenName: v.givenName ?? '',
+        familyName: v.familyName ?? '',
+      };
+      if (v.studentUid) byStudentUid.set(v.studentUid, name);
+      if (v.assignmentPseudonym)
+        byAssignmentPseudonym.set(v.assignmentPseudonym, name);
+    }
+    return { byStudentUid, byAssignmentPseudonym };
+  });
+
+  cache.set(key, promise);
+  promise.catch(() => {
+    if (cache.get(key) === promise) cache.delete(key);
+  });
+
+  return promise;
+}
+
+interface ResolvedMaps {
+  key: string;
+  maps: AssignmentPseudonymMaps;
+}
+
+function pairKey(
+  assignmentId: string | null | undefined,
+  classId: string | null | undefined
+): string {
+  return assignmentId && classId ? `${assignmentId}::${classId}` : '';
+}
+
+export function useAssignmentPseudonyms(
+  assignmentId: string | null | undefined,
+  classId: string | null | undefined
+): AssignmentPseudonymMaps {
+  const [resolved, setResolved] = useState<ResolvedMaps>({
+    key: '',
+    maps: EMPTY_MAPS,
+  });
+
+  useEffect(() => {
+    const key = pairKey(assignmentId, classId);
+    if (!key || !assignmentId || !classId) return;
+    const teacherUid = auth.currentUser?.uid ?? '';
+    if (!teacherUid) return;
+    let cancelled = false;
+    fetchPseudonymMaps(assignmentId, classId, teacherUid)
+      .then((maps) => {
+        if (!cancelled) setResolved({ key, maps });
+      })
+      .catch((err) => {
+        console.warn('[useAssignmentPseudonyms] Name resolution failed:', err);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [assignmentId, classId]);
+
+  const currentKey = pairKey(assignmentId, classId);
+  return resolved.key === currentKey && currentKey !== ''
+    ? resolved.maps
+    : EMPTY_MAPS;
+}
+
+export function formatStudentName(name: StudentName | undefined): string {
+  if (!name) return '';
+  const full = `${name.givenName} ${name.familyName}`.trim();
+  return full;
+}

--- a/hooks/useGuidedLearningSession.ts
+++ b/hooks/useGuidedLearningSession.ts
@@ -134,8 +134,16 @@ export function toPublicStep(
 export interface UseGuidedLearningSessionTeacherResult {
   responses: GuidedLearningResponse[];
   responsesLoading: boolean;
-  /** Create a new session and return its URL */
-  createSession: (set: GuidedLearningSet) => Promise<string>;
+  /**
+   * Create a new session and return its URL.
+   *
+   * `classId` is an optional ClassLink class `sourcedId`. When provided, it's
+   * written onto the session doc so that ClassLink-authenticated students
+   * see this session on their `/my-assignments` page, and Firestore rules
+   * (`passesStudentClassGate`) enforce class-based access. Omitting it
+   * preserves the classic join-link flow.
+   */
+  createSession: (set: GuidedLearningSet, classId?: string) => Promise<string>;
   /** Load responses for a given session ID */
   subscribeToResponses: (sessionId: string) => () => void;
   /** Export responses as a CSV blob string */
@@ -152,7 +160,7 @@ export const useGuidedLearningSessionTeacher = (
   const [responsesLoading, setResponsesLoading] = useState(false);
 
   const createSession = useCallback(
-    async (set: GuidedLearningSet): Promise<string> => {
+    async (set: GuidedLearningSet, classId?: string): Promise<string> => {
       if (!teacherUid) throw new Error('Not authenticated');
 
       const sessionId = crypto.randomUUID();
@@ -166,6 +174,11 @@ export const useGuidedLearningSessionTeacher = (
         publicSteps,
         teacherUid,
         createdAt: Date.now(),
+        // Phase 3C: optional ClassLink target class. Only write when a
+        // non-empty sourcedId was supplied so sessions created without a
+        // target keep a clean doc shape (and the rules no-op branch kicks in
+        // via `resource.data.get('classId', '')`).
+        ...(classId ? { classId } : {}),
       };
 
       await setDoc(doc(db, GL_SESSIONS_COLLECTION, sessionId), session);

--- a/hooks/useMiniAppAssignments.ts
+++ b/hooks/useMiniAppAssignments.ts
@@ -36,6 +36,8 @@ export interface CreateMiniAppAssignmentInput {
   sessionId: string;
   app: Pick<MiniAppItem, 'id' | 'title'>;
   assignmentName: string;
+  /** Optional ClassLink classId the teacher targeted. */
+  classId?: string;
   submissionUrl?: string;
   googleSheetId?: string;
 }
@@ -123,6 +125,7 @@ export const useMiniAppAssignments = (
         status: 'active',
         createdAt: now,
         updatedAt: now,
+        ...(input.classId ? { classId: input.classId } : {}),
         ...(input.submissionUrl ? { submissionUrl: input.submissionUrl } : {}),
         ...(input.googleSheetId ? { googleSheetId: input.googleSheetId } : {}),
       };

--- a/hooks/useMiniAppSession.ts
+++ b/hooks/useMiniAppSession.ts
@@ -45,6 +45,7 @@ const normalizeSession = (
     status: data.status === 'ended' ? 'ended' : 'active',
     createdAt,
     ...(typeof data.endedAt === 'number' ? { endedAt: data.endedAt } : {}),
+    ...(data.classId ? { classId: data.classId } : {}),
     ...(data.submissionUrl ? { submissionUrl: data.submissionUrl } : {}),
     ...(data.googleSheetId ? { googleSheetId: data.googleSheetId } : {}),
   };
@@ -57,7 +58,9 @@ export interface UseMiniAppSessionTeacherResult {
     teacherUid: string,
     assignmentName: string,
     submissionUrl?: string,
-    googleSheetId?: string
+    googleSheetId?: string,
+    /** Optional ClassLink classId the teacher targeted. */
+    classId?: string
   ) => Promise<string>;
   /** Sessions created by this teacher for the currently subscribed app. */
   sessions: MiniAppSession[];
@@ -83,7 +86,8 @@ export const useMiniAppSessionTeacher = (): UseMiniAppSessionTeacherResult => {
       teacherUid: string,
       assignmentName: string,
       submissionUrl?: string,
-      googleSheetId?: string
+      googleSheetId?: string,
+      classId?: string
     ): Promise<string> => {
       const sessionId = crypto.randomUUID();
       const trimmedName = assignmentName.trim();
@@ -100,6 +104,7 @@ export const useMiniAppSessionTeacher = (): UseMiniAppSessionTeacherResult => {
             : `${app.title} — ${new Date().toLocaleString()}`,
         status: 'active',
         createdAt: Date.now(),
+        ...(classId ? { classId } : {}),
         ...(submissionUrl ? { submissionUrl } : {}),
         ...(googleSheetId ? { googleSheetId } : {}),
       };

--- a/hooks/useQuizAssignments.ts
+++ b/hooks/useQuizAssignments.ts
@@ -61,11 +61,18 @@ export interface UseQuizAssignmentsResult {
   /**
    * Create a new assignment + its matching session doc in one batch.
    * Returns the new assignment's id (== sessionId) and the allocated join code.
+   *
+   * `classId` is an optional ClassLink class `sourcedId`. When provided, it's
+   * written onto the session doc so that ClassLink-authenticated students
+   * see this session on their `/my-assignments` page, and Firestore rules
+   * (`passesStudentClassGate`) enforce class-based access. Omitting it
+   * preserves the classic code/PIN-only flow.
    */
   createAssignment: (
     quiz: AssignmentQuizRef,
     settings: QuizAssignmentSettings,
-    initialStatus?: QuizAssignmentStatus
+    initialStatus?: QuizAssignmentStatus,
+    classId?: string
   ) => Promise<{ id: string; code: string }>;
   /** Set both assignment.status and session.status to 'paused'. */
   pauseAssignment: (assignmentId: string) => Promise<void>;
@@ -174,7 +181,7 @@ export const useQuizAssignments = (
   const createAssignment = useCallback<
     UseQuizAssignmentsResult['createAssignment']
   >(
-    async (quiz, settings, initialStatus = 'active') => {
+    async (quiz, settings, initialStatus = 'active', classId) => {
       if (!userId) throw new Error('Not authenticated');
 
       const assignmentId = crypto.randomUUID();
@@ -240,6 +247,11 @@ export const useQuizAssignments = (
         soundEffectsEnabled: opts.soundEffectsEnabled ?? false,
         questionPhase: 'answering',
         periodNames: settings.periodNames,
+        // Phase 3A: optional ClassLink target class. Only write when a
+        // non-empty sourcedId was supplied so sessions created without a
+        // target keep a clean doc shape (and the rules no-op branch kicks in
+        // via `resource.data.get('classId', '')`).
+        ...(classId ? { classId } : {}),
       };
 
       const batch = writeBatch(db);

--- a/hooks/useStudentIdleTimeout.ts
+++ b/hooks/useStudentIdleTimeout.ts
@@ -1,0 +1,70 @@
+/**
+ * useStudentIdleTimeout — 15-minute idle auto-sign-out for student sessions
+ * on shared Chromebook carts.
+ *
+ * A single setTimeout, reset on interaction (throttled to once per 5s). On
+ * expiry, calls `firebaseSignOut` and redirects to `/student/login`. The
+ * 15-min window is meaningfully shorter than the ~1h custom-token TTL so
+ * the worst-case exposure window on a walk-away is 15 min, not 60.
+ *
+ * `enabled=false` fully tears down listeners and timers so teachers
+ * previewing student routes are never timed out.
+ */
+
+import { useEffect } from 'react';
+import { signOut as firebaseSignOut } from 'firebase/auth';
+import { auth } from '@/config/firebase';
+
+export const STUDENT_IDLE_TIMEOUT_MS = 15 * 60 * 1000;
+const INTERACTION_THROTTLE_MS = 5 * 1000;
+export const STUDENT_LOGIN_PATH = '/student/login';
+
+export function useStudentIdleTimeout(
+  enabled: boolean,
+  redirectPath: string = STUDENT_LOGIN_PATH
+): void {
+  useEffect(() => {
+    if (!enabled) return;
+    if (typeof window === 'undefined') return;
+
+    let timeoutId: number | undefined;
+    let lastInteractionAt = Date.now();
+
+    const triggerIdleSignOut = () => {
+      void firebaseSignOut(auth).catch(() => {
+        // Swallow — redirect below is the actual remediation.
+      });
+      window.location.assign(redirectPath);
+    };
+
+    const scheduleTimeout = () => {
+      if (timeoutId !== undefined) window.clearTimeout(timeoutId);
+      timeoutId = window.setTimeout(
+        triggerIdleSignOut,
+        STUDENT_IDLE_TIMEOUT_MS
+      );
+    };
+
+    const handleInteraction = () => {
+      const now = Date.now();
+      if (now - lastInteractionAt < INTERACTION_THROTTLE_MS) return;
+      lastInteractionAt = now;
+      scheduleTimeout();
+    };
+
+    scheduleTimeout();
+
+    const events = ['mousemove', 'keydown', 'touchstart', 'click'] as const;
+    const options: AddEventListenerOptions = { passive: true, capture: true };
+    events.forEach((event) => {
+      window.addEventListener(event, handleInteraction, options);
+    });
+
+    return () => {
+      if (timeoutId !== undefined) window.clearTimeout(timeoutId);
+      events.forEach((event) => {
+        window.removeEventListener(event, handleInteraction, options);
+      });
+    };
+  }, [enabled, redirectPath]);
+}

--- a/hooks/useVideoActivityAssignments.ts
+++ b/hooks/useVideoActivityAssignments.ts
@@ -56,11 +56,18 @@ export interface UseVideoActivityAssignmentsResult {
   /**
    * Create a new assignment + its matching session doc in one batch.
    * Returns the new assignment's id (== sessionId).
+   *
+   * `classId` is an optional ClassLink class `sourcedId`. When provided, it's
+   * written onto the session doc so that ClassLink-authenticated students
+   * see this session on their `/my-assignments` page, and Firestore rules
+   * (`passesStudentClassGate(vaSessionClassId())`) enforce class-based
+   * access. Omitting it preserves the classic join-URL-only flow.
    */
   createAssignment: (
     activity: AssignmentActivityRef,
     settings: VideoActivityAssignmentSettings,
-    initialStatus?: VideoActivityAssignmentStatus
+    initialStatus?: VideoActivityAssignmentStatus,
+    classId?: string
   ) => Promise<{ id: string }>;
   /** Set both assignment.status and session.status to 'paused' (assignment) / 'ended' (session). */
   pauseAssignment: (assignmentId: string) => Promise<void>;
@@ -128,7 +135,7 @@ export const useVideoActivityAssignments = (
   const createAssignment = useCallback<
     UseVideoActivityAssignmentsResult['createAssignment']
   >(
-    async (activity, settings, initialStatus = 'active') => {
+    async (activity, settings, initialStatus = 'active', classId) => {
       if (!userId) throw new Error('Not authenticated');
 
       const assignmentId = crypto.randomUUID();
@@ -166,6 +173,11 @@ export const useVideoActivityAssignments = (
         allowedPins: [],
         createdAt: now,
         ...(sessionStatus === 'ended' ? { endedAt: now } : {}),
+        // Phase 3B: optional ClassLink target class. Only write when a
+        // non-empty sourcedId was supplied so sessions created without a
+        // target keep a clean doc shape (and the rules no-op branch kicks in
+        // via `resource.data.get('classId', '')`).
+        ...(classId ? { classId } : {}),
       };
 
       const batch = writeBatch(db);

--- a/hooks/useVideoActivitySession.ts
+++ b/hooks/useVideoActivitySession.ts
@@ -74,13 +74,22 @@ const normalizeSession = (
 // ---------------------------------------------------------------------------
 
 export interface UseVideoActivitySessionTeacherResult {
-  /** Create a session for a class and return the sessionId (used as the share link). */
+  /**
+   * Create a session for a class and return the sessionId (used as the share link).
+   *
+   * `classId` is an optional ClassLink class `sourcedId`. When provided, it's
+   * written onto the session doc so that ClassLink-authenticated students
+   * see this session on their `/my-assignments` page, and Firestore rules
+   * (`passesStudentClassGate(vaSessionClassId())`) enforce class-based
+   * access. Omitting it preserves the classic code/PIN-only flow.
+   */
   createSession: (
     activity: VideoActivityData,
     teacherUid: string,
     allowedPins?: string[],
     settings?: Partial<VideoActivitySessionSettings>,
-    assignmentName?: string
+    assignmentName?: string,
+    classId?: string
   ) => Promise<string>;
   /** Sessions created by the current teacher for the selected activity. */
   sessions: VideoActivitySession[];
@@ -117,7 +126,8 @@ export const useVideoActivitySessionTeacher =
         teacherUid: string,
         allowedPins: string[] = [],
         settings?: Partial<VideoActivitySessionSettings>,
-        assignmentName?: string
+        assignmentName?: string,
+        classId?: string
       ): Promise<string> => {
         const sessionId = crypto.randomUUID();
         const trimmedAssignmentName = assignmentName?.trim();
@@ -142,6 +152,11 @@ export const useVideoActivitySessionTeacher =
           status: 'active',
           allowedPins,
           createdAt: Date.now(),
+          // Phase 3B: optional ClassLink target class. Only write when a
+          // non-empty sourcedId was supplied so sessions created without a
+          // target keep a clean doc shape (and the rules no-op branch kicks in
+          // via `resource.data.get('classId', '')`).
+          ...(classId ? { classId } : {}),
         };
 
         await setDoc(doc(db, SESSIONS_COLLECTION, sessionId), session);

--- a/tests/rules/studentRoleClassGate.test.ts
+++ b/tests/rules/studentRoleClassGate.test.ts
@@ -1,0 +1,568 @@
+// Firestore security-rules tests for the GIS student-role class gate.
+//
+// Requires a running Firestore emulator. Invoke via:
+//   pnpm run test:rules
+// which wraps the suite in `firebase emulators:exec --only firestore`.
+//
+// Covers the five session collections where passesStudentClassGate() is applied:
+//   quiz_sessions, video_activity_sessions, guided_learning_sessions,
+//   mini_app_sessions, activity_wall_sessions
+
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { afterAll, beforeAll, beforeEach, describe, it } from 'vitest';
+import {
+  initializeTestEnvironment,
+  assertSucceeds,
+  assertFails,
+  type RulesTestEnvironment,
+} from '@firebase/rules-unit-testing';
+import { setDoc, getDoc, addDoc, collection, doc } from 'firebase/firestore';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const PROJECT_ID = 'spartboard-student-gate-test';
+const SESSION_A = 'session-class-a';
+const SESSION_B = 'session-class-b';
+const CLASS_A = 'class-A';
+const CLASS_B = 'class-B';
+const TEACHER_UID = 'teacher-uid-1';
+const STUDENT_A_UID = 'student-a-uid';
+const STUDENT_EMPTY_UID = 'student-empty-uid';
+const ADMIN_EMAIL = 'admin@example.com';
+const ANON_UID = 'anon-pin-uid';
+
+const RULES_PATH = fileURLToPath(
+  new URL('../../firestore.rules', import.meta.url)
+);
+
+// ---------------------------------------------------------------------------
+// Environment + auth contexts
+// ---------------------------------------------------------------------------
+
+let testEnv: RulesTestEnvironment;
+
+const asStudentA = () =>
+  testEnv
+    .authenticatedContext(STUDENT_A_UID, {
+      studentRole: true,
+      classIds: [CLASS_A],
+    })
+    .firestore();
+
+const asStudentEmpty = () =>
+  testEnv
+    .authenticatedContext(STUDENT_EMPTY_UID, {
+      studentRole: true,
+      classIds: [],
+    })
+    .firestore();
+
+const asTeacher = () =>
+  testEnv
+    .authenticatedContext(TEACHER_UID, {
+      email: 'teacher@school.edu',
+      firebase: { sign_in_provider: 'google.com' },
+    })
+    .firestore();
+
+const asAnonStudent = () =>
+  testEnv
+    .authenticatedContext(ANON_UID, {
+      firebase: { sign_in_provider: 'anonymous' },
+    })
+    .firestore();
+
+const asUnauth = () => testEnv.unauthenticatedContext().firestore();
+
+// ---------------------------------------------------------------------------
+// Lifecycle
+// ---------------------------------------------------------------------------
+
+beforeAll(async () => {
+  testEnv = await initializeTestEnvironment({
+    projectId: PROJECT_ID,
+    firestore: {
+      rules: readFileSync(RULES_PATH, 'utf8'),
+      host: process.env.FIRESTORE_EMULATOR_HOST?.split(':')[0] ?? '127.0.0.1',
+      port: Number(
+        process.env.FIRESTORE_EMULATOR_HOST?.split(':')[1] ?? '8080'
+      ),
+    },
+  });
+});
+
+afterAll(async () => {
+  await testEnv?.cleanup();
+});
+
+// ---------------------------------------------------------------------------
+// Seeding helpers
+// ---------------------------------------------------------------------------
+
+function sessionDoc(classId: string) {
+  return { teacherUid: TEACHER_UID, classId, status: 'active' };
+}
+
+function vaFields(sessionId: string, classId: string) {
+  return {
+    id: sessionId,
+    activityId: 'act-1',
+    activityTitle: 'Test',
+    youtubeUrl: 'https://youtu.be/x',
+    questions: [],
+    settings: {},
+    allowedPins: [],
+    createdAt: 1000,
+    assignmentName: 'Assignment',
+    classId,
+    teacherUid: TEACHER_UID,
+    status: 'active',
+  };
+}
+
+type SeedOptions = { withResponses?: boolean };
+
+async function seedSessions(cols: string[], opts: SeedOptions = {}) {
+  await testEnv.withSecurityRulesDisabled(async (ctx) => {
+    const db = ctx.firestore();
+    await setDoc(doc(db, `admins/${ADMIN_EMAIL}`), { email: ADMIN_EMAIL });
+
+    for (const col of cols) {
+      const isVa = col === 'video_activity_sessions';
+      await setDoc(
+        doc(db, `${col}/${SESSION_A}`),
+        isVa ? vaFields(SESSION_A, CLASS_A) : sessionDoc(CLASS_A)
+      );
+      await setDoc(
+        doc(db, `${col}/${SESSION_B}`),
+        isVa ? vaFields(SESSION_B, CLASS_B) : sessionDoc(CLASS_B)
+      );
+
+      if (opts.withResponses) {
+        if (col === 'quiz_sessions') {
+          await setDoc(
+            doc(db, `${col}/${SESSION_A}/responses/${STUDENT_A_UID}`),
+            {
+              studentUid: STUDENT_A_UID,
+              pin: '9999',
+              joinedAt: 1000,
+              score: null,
+              answers: [],
+              status: 'active',
+              tabSwitchWarnings: 0,
+            }
+          );
+        } else if (col === 'video_activity_sessions') {
+          await setDoc(
+            doc(db, `${col}/${SESSION_A}/responses/${STUDENT_A_UID}`),
+            {
+              studentUid: STUDENT_A_UID,
+              pin: '9999',
+              name: 'Student A',
+              joinedAt: 1000,
+              score: null,
+              completedAt: null,
+              answers: [],
+            }
+          );
+        } else if (col === 'guided_learning_sessions') {
+          await setDoc(
+            doc(db, `${col}/${SESSION_A}/responses/${STUDENT_A_UID}`),
+            {
+              studentAnonymousId: STUDENT_A_UID,
+              sessionId: SESSION_A,
+              score: null,
+              answers: [],
+            }
+          );
+        }
+      }
+    }
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Session-level read gate — all five collections
+// ---------------------------------------------------------------------------
+
+const ALL_SESSION_COLS = [
+  'quiz_sessions',
+  'video_activity_sessions',
+  'guided_learning_sessions',
+  'mini_app_sessions',
+  'activity_wall_sessions',
+];
+
+describe('student-role class gate — session reads', () => {
+  beforeEach(async () => {
+    await testEnv.clearFirestore();
+    await seedSessions(ALL_SESSION_COLS);
+  });
+
+  for (const col of ALL_SESSION_COLS) {
+    describe(col, () => {
+      it('student with matching classId can read session-A', async () => {
+        await assertSucceeds(getDoc(doc(asStudentA(), `${col}/${SESSION_A}`)));
+      });
+
+      it('student with matching classId cannot read session-B (wrong class)', async () => {
+        await assertFails(getDoc(doc(asStudentA(), `${col}/${SESSION_B}`)));
+      });
+
+      it('student with empty classIds cannot read any session', async () => {
+        await assertFails(getDoc(doc(asStudentEmpty(), `${col}/${SESSION_A}`)));
+        await assertFails(getDoc(doc(asStudentEmpty(), `${col}/${SESSION_B}`)));
+      });
+
+      it('teacher (no studentRole claim) can read any session', async () => {
+        await assertSucceeds(getDoc(doc(asTeacher(), `${col}/${SESSION_A}`)));
+        await assertSucceeds(getDoc(doc(asTeacher(), `${col}/${SESSION_B}`)));
+      });
+
+      it('anonymous PIN student can read any session', async () => {
+        await assertSucceeds(
+          getDoc(doc(asAnonStudent(), `${col}/${SESSION_A}`))
+        );
+        await assertSucceeds(
+          getDoc(doc(asAnonStudent(), `${col}/${SESSION_B}`))
+        );
+      });
+
+      it('unauthenticated caller cannot read', async () => {
+        await assertFails(getDoc(doc(asUnauth(), `${col}/${SESSION_A}`)));
+      });
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// quiz_sessions/responses — create, read, update (immutability)
+// ---------------------------------------------------------------------------
+
+describe('quiz_sessions/responses — student-role gate', () => {
+  const respPath = (session: string) =>
+    `quiz_sessions/${session}/responses/${STUDENT_A_UID}`;
+  const baseResp = (pin = '1234', score: null | number = null) => ({
+    studentUid: STUDENT_A_UID,
+    pin,
+    joinedAt: 1000,
+    score,
+    answers: [],
+    status: 'active',
+    tabSwitchWarnings: 0,
+  });
+
+  beforeEach(async () => {
+    await testEnv.clearFirestore();
+    await seedSessions(['quiz_sessions'], { withResponses: true });
+  });
+
+  it('student in class-A can create response on session-A', async () => {
+    await assertSucceeds(
+      setDoc(doc(asStudentA(), respPath(SESSION_A)), {
+        ...baseResp(),
+        joinedAt: 2000,
+      })
+    );
+  });
+
+  it('student in class-A cannot create response on session-B', async () => {
+    await assertFails(
+      setDoc(doc(asStudentA(), respPath(SESSION_B)), {
+        ...baseResp(),
+        joinedAt: 2000,
+      })
+    );
+  });
+
+  it('student in class-A can read own response on session-A', async () => {
+    await assertSucceeds(getDoc(doc(asStudentA(), respPath(SESSION_A))));
+  });
+
+  it('student in class-A cannot read response on session-B', async () => {
+    await assertFails(getDoc(doc(asStudentA(), respPath(SESSION_B))));
+  });
+
+  it('teacher can read any response', async () => {
+    await assertSucceeds(getDoc(doc(asTeacher(), respPath(SESSION_A))));
+  });
+
+  it('student can update allowed fields on session-A response', async () => {
+    await assertSucceeds(
+      setDoc(doc(asStudentA(), respPath(SESSION_A)), {
+        ...baseResp('9999'),
+        answers: [{ q: 0, a: 'B' }],
+        status: 'submitted',
+        submittedAt: 3000,
+      })
+    );
+  });
+
+  it('student cannot mutate immutable pin field', async () => {
+    await assertFails(
+      setDoc(doc(asStudentA(), respPath(SESSION_A)), baseResp('CHANGED'))
+    );
+  });
+
+  it('student cannot set score field', async () => {
+    await assertFails(
+      setDoc(doc(asStudentA(), respPath(SESSION_A)), baseResp('9999', 100))
+    );
+  });
+
+  it('student in class-A cannot update response on session-B', async () => {
+    await assertFails(
+      setDoc(doc(asStudentA(), respPath(SESSION_B)), baseResp('9999'))
+    );
+  });
+
+  it('anonymous PIN student can create response without studentRole restriction', async () => {
+    await assertSucceeds(
+      setDoc(
+        doc(
+          asAnonStudent(),
+          `quiz_sessions/${SESSION_A}/responses/${ANON_UID}`
+        ),
+        {
+          studentUid: ANON_UID,
+          pin: '5678',
+          joinedAt: 2000,
+          score: null,
+          answers: [],
+          status: 'active',
+          tabSwitchWarnings: 0,
+        }
+      )
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// video_activity_sessions/responses — create, read, update
+// ---------------------------------------------------------------------------
+
+describe('video_activity_sessions/responses — student-role gate', () => {
+  const col = 'video_activity_sessions';
+  const respPath = (session: string) =>
+    `${col}/${session}/responses/${STUDENT_A_UID}`;
+  const baseResp = (pin = '1234') => ({
+    studentUid: STUDENT_A_UID,
+    pin,
+    name: 'Student A',
+    joinedAt: 1000,
+    score: null,
+    completedAt: null,
+    answers: [],
+  });
+
+  beforeEach(async () => {
+    await testEnv.clearFirestore();
+    await seedSessions([col], { withResponses: true });
+  });
+
+  it('student in class-A can create response on session-A', async () => {
+    await assertSucceeds(
+      setDoc(doc(asStudentA(), respPath(SESSION_A)), {
+        ...baseResp(),
+        joinedAt: 2000,
+      })
+    );
+  });
+
+  it('student in class-A cannot create response on session-B', async () => {
+    await assertFails(
+      setDoc(doc(asStudentA(), respPath(SESSION_B)), {
+        ...baseResp(),
+        joinedAt: 2000,
+      })
+    );
+  });
+
+  it('student in class-A can read own response on session-A', async () => {
+    await assertSucceeds(getDoc(doc(asStudentA(), respPath(SESSION_A))));
+  });
+
+  it('student in class-A cannot read response on session-B', async () => {
+    await assertFails(getDoc(doc(asStudentA(), respPath(SESSION_B))));
+  });
+
+  it('teacher can read responses on any session', async () => {
+    await assertSucceeds(getDoc(doc(asTeacher(), respPath(SESSION_A))));
+  });
+
+  it('student can update allowed fields on session-A response', async () => {
+    await assertSucceeds(
+      setDoc(doc(asStudentA(), respPath(SESSION_A)), {
+        ...baseResp('9999'),
+        completedAt: 3000,
+        answers: [{ q: 0, a: 'A' }],
+      })
+    );
+  });
+
+  it('student in class-A cannot update response on session-B', async () => {
+    await assertFails(
+      setDoc(doc(asStudentA(), respPath(SESSION_B)), baseResp('9999'))
+    );
+  });
+
+  it('anonymous PIN student can create response without studentRole restriction', async () => {
+    await assertSucceeds(
+      setDoc(
+        doc(asAnonStudent(), `${col}/${SESSION_A}/responses/${ANON_UID}`),
+        {
+          studentUid: ANON_UID,
+          pin: '5678',
+          name: 'Anon',
+          joinedAt: 2000,
+          score: null,
+          completedAt: null,
+          answers: [],
+        }
+      )
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// guided_learning_sessions/responses — create, read, update
+// ---------------------------------------------------------------------------
+
+describe('guided_learning_sessions/responses — student-role gate', () => {
+  const col = 'guided_learning_sessions';
+  const respPath = (session: string) =>
+    `${col}/${session}/responses/${STUDENT_A_UID}`;
+  const baseResp = (session = SESSION_A) => ({
+    studentAnonymousId: STUDENT_A_UID,
+    sessionId: session,
+    score: null,
+    answers: [],
+  });
+
+  beforeEach(async () => {
+    await testEnv.clearFirestore();
+    await seedSessions([col], { withResponses: true });
+  });
+
+  it('student in class-A can create response on session-A', async () => {
+    await assertSucceeds(
+      setDoc(doc(asStudentA(), respPath(SESSION_A)), baseResp())
+    );
+  });
+
+  it('student in class-A cannot create response on session-B', async () => {
+    await assertFails(
+      setDoc(doc(asStudentA(), respPath(SESSION_B)), baseResp(SESSION_B))
+    );
+  });
+
+  it('student in class-A can read own response on session-A', async () => {
+    await assertSucceeds(getDoc(doc(asStudentA(), respPath(SESSION_A))));
+  });
+
+  it('student in class-A cannot read response on session-B', async () => {
+    await assertFails(getDoc(doc(asStudentA(), respPath(SESSION_B))));
+  });
+
+  it('teacher can read responses on any session', async () => {
+    await assertSucceeds(getDoc(doc(asTeacher(), respPath(SESSION_A))));
+  });
+
+  it('student can update allowed fields on session-A response', async () => {
+    await assertSucceeds(
+      setDoc(doc(asStudentA(), respPath(SESSION_A)), {
+        ...baseResp(),
+        answers: [{ q: 0, a: 'B' }],
+        completedAt: 3000,
+      })
+    );
+  });
+
+  it('student in class-A cannot update response on session-B', async () => {
+    await assertFails(
+      setDoc(doc(asStudentA(), respPath(SESSION_B)), baseResp(SESSION_B))
+    );
+  });
+
+  it('anonymous PIN student can create response without studentRole restriction', async () => {
+    await assertSucceeds(
+      setDoc(
+        doc(asAnonStudent(), `${col}/${SESSION_A}/responses/${ANON_UID}`),
+        {
+          studentAnonymousId: ANON_UID,
+          sessionId: SESSION_A,
+          score: null,
+          answers: [],
+        }
+      )
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// activity_wall_sessions/submissions — create
+// ---------------------------------------------------------------------------
+
+describe('activity_wall_sessions/submissions — student-role gate', () => {
+  const col = 'activity_wall_sessions';
+  const subCol = (session: string) =>
+    collection(asStudentA(), `${col}/${session}/submissions`);
+  const validSub = () => ({
+    id: 'sub-1',
+    content: 'Hello world',
+    submittedAt: 1000,
+    status: 'pending' as const,
+  });
+
+  beforeEach(async () => {
+    await testEnv.clearFirestore();
+    await seedSessions([col]);
+  });
+
+  it('student in class-A can submit to session-A', async () => {
+    await assertSucceeds(addDoc(subCol(SESSION_A), validSub()));
+  });
+
+  it('student in class-A cannot submit to session-B (wrong class)', async () => {
+    await assertFails(addDoc(subCol(SESSION_B), validSub()));
+  });
+
+  it('student with empty classIds cannot submit to any session', async () => {
+    await assertFails(
+      addDoc(
+        collection(asStudentEmpty(), `${col}/${SESSION_A}/submissions`),
+        validSub()
+      )
+    );
+  });
+
+  it('anonymous PIN student can submit without studentRole restriction', async () => {
+    await assertSucceeds(
+      addDoc(
+        collection(asAnonStudent(), `${col}/${SESSION_A}/submissions`),
+        validSub()
+      )
+    );
+  });
+
+  it('teacher (non-anonymous) can submit (no studentRole block)', async () => {
+    await assertSucceeds(
+      addDoc(
+        collection(asTeacher(), `${col}/${SESSION_A}/submissions`),
+        validSub()
+      )
+    );
+  });
+
+  it('unauthenticated caller cannot submit', async () => {
+    await assertFails(
+      addDoc(
+        collection(asUnauth(), `${col}/${SESSION_A}/submissions`),
+        validSub()
+      )
+    );
+  });
+});

--- a/tests/rules/studentRoleClassGate.test.ts
+++ b/tests/rules/studentRoleClassGate.test.ts
@@ -566,3 +566,135 @@ describe('activity_wall_sessions/submissions — student-role gate', () => {
     );
   });
 });
+
+// ---------------------------------------------------------------------------
+// mini_app_sessions/submissions — create/update gate + payload validation
+// ---------------------------------------------------------------------------
+
+describe('mini_app_sessions/submissions — student-role gate', () => {
+  const col = 'mini_app_sessions';
+  const subPath = (session: string, uid: string) =>
+    `${col}/${session}/submissions/${uid}`;
+  const validSub = () => ({
+    submittedAt: 1000,
+    payload: { score: 42, answers: [1, 2, 3] } as Record<string, unknown>,
+  });
+
+  beforeEach(async () => {
+    await testEnv.clearFirestore();
+    await seedSessions([col]);
+  });
+
+  it('student in class-A can submit to session-A under their own pseudonym', async () => {
+    await assertSucceeds(
+      setDoc(doc(asStudentA(), subPath(SESSION_A, STUDENT_A_UID)), validSub())
+    );
+  });
+
+  it('student in class-A cannot submit to session-B (wrong class)', async () => {
+    await assertFails(
+      setDoc(doc(asStudentA(), subPath(SESSION_B, STUDENT_A_UID)), validSub())
+    );
+  });
+
+  it('student with empty classIds cannot submit to any session', async () => {
+    await assertFails(
+      setDoc(
+        doc(asStudentEmpty(), subPath(SESSION_A, STUDENT_EMPTY_UID)),
+        validSub()
+      )
+    );
+  });
+
+  it('anonymous PIN student can submit under their own auth uid', async () => {
+    await assertSucceeds(
+      setDoc(doc(asAnonStudent(), subPath(SESSION_A, ANON_UID)), validSub())
+    );
+  });
+
+  it('anonymous PIN student cannot submit under a different uid', async () => {
+    await assertFails(
+      setDoc(
+        doc(asAnonStudent(), subPath(SESSION_A, 'some-other-uid')),
+        validSub()
+      )
+    );
+  });
+
+  it('unauthenticated caller cannot submit', async () => {
+    await assertFails(
+      setDoc(doc(asUnauth(), subPath(SESSION_A, 'x')), validSub())
+    );
+  });
+
+  it('submission with extra keys is rejected', async () => {
+    await assertFails(
+      setDoc(doc(asStudentA(), subPath(SESSION_A, STUDENT_A_UID)), {
+        ...validSub(),
+        sneaky: 'extra-field',
+      })
+    );
+  });
+
+  it('submission with non-map payload is rejected', async () => {
+    await assertFails(
+      setDoc(doc(asStudentA(), subPath(SESSION_A, STUDENT_A_UID)), {
+        submittedAt: 1000,
+        payload: 'just-a-string',
+      })
+    );
+  });
+
+  it('submission with non-int submittedAt is rejected', async () => {
+    await assertFails(
+      setDoc(doc(asStudentA(), subPath(SESSION_A, STUDENT_A_UID)), {
+        submittedAt: 'not-a-number',
+        payload: { score: 1 },
+      })
+    );
+  });
+
+  it('submission to ended session is rejected', async () => {
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      await setDoc(doc(ctx.firestore(), `${col}/${SESSION_A}`), {
+        teacherUid: TEACHER_UID,
+        classId: CLASS_A,
+        status: 'ended',
+      });
+    });
+    await assertFails(
+      setDoc(doc(asStudentA(), subPath(SESSION_A, STUDENT_A_UID)), validSub())
+    );
+  });
+
+  it('student can read own submission; cannot read another student uid', async () => {
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      await setDoc(
+        doc(ctx.firestore(), subPath(SESSION_A, STUDENT_A_UID)),
+        validSub()
+      );
+      await setDoc(
+        doc(ctx.firestore(), subPath(SESSION_A, 'other-uid')),
+        validSub()
+      );
+    });
+    await assertSucceeds(
+      getDoc(doc(asStudentA(), subPath(SESSION_A, STUDENT_A_UID)))
+    );
+    await assertFails(
+      getDoc(doc(asStudentA(), subPath(SESSION_A, 'other-uid')))
+    );
+  });
+
+  it('teacher can read any submission on their session', async () => {
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      await setDoc(
+        doc(ctx.firestore(), subPath(SESSION_A, 'anyone')),
+        validSub()
+      );
+    });
+    await assertSucceeds(
+      getDoc(doc(asTeacher(), subPath(SESSION_A, 'anyone')))
+    );
+  });
+});

--- a/types.ts
+++ b/types.ts
@@ -570,6 +570,16 @@ export interface ActivityWallActivity {
   identificationMode: ActivityWallIdentificationMode;
   submissions: ActivityWallSubmission[];
   startedAt: number | null;
+  /**
+   * Optional ClassLink class `sourcedId` this activity is targeted at
+   * (Phase 3D). When present, the value is mirrored onto the
+   * `activity_wall_sessions/{sessionId}` document so that students who
+   * signed in via ClassLink see the activity on their `/my-assignments`
+   * page, and Firestore rules (`passesStudentClassGate`) enforce that
+   * only students enrolled in this class can read the session doc.
+   * Empty/undefined preserves the classic code/PIN-style (`?data=`) flow.
+   */
+  classId?: string;
 }
 
 export interface ActivityWallBuildingConfig {
@@ -591,6 +601,37 @@ export interface ActivityWallConfig {
   cardOpacity?: number;
   fontFamily?: GlobalFontFamily;
   fontColor?: string;
+  /**
+   * Per-activity memory of the teacher's last-selected ClassLink target
+   * class (Phase 3D). Keyed by `ActivityWallActivity.id`. Used to
+   * pre-populate the target-class selector when the teacher re-opens the
+   * editor for an existing activity. Entries are cleared when the teacher
+   * picks "No class" so the map stays small.
+   */
+  lastClassIdByActivityId?: Record<string, string>;
+}
+
+/**
+ * Firestore document shape for `activity_wall_sessions/{sessionId}`.
+ *
+ * The teacher's Activity Wall widget writes this doc when an activity
+ * becomes active so the student app (and the `/my-assignments` listing)
+ * can discover the session's configuration without relying on a
+ * base64-encoded URL payload. `classId`, when present, gates
+ * ClassLink-authenticated student access via Firestore rules.
+ */
+export interface ActivityWallSession {
+  id: string;
+  activityId: string;
+  teacherUid: string;
+  title: string;
+  prompt: string;
+  mode: ActivityWallMode;
+  moderationEnabled: boolean;
+  identificationMode: ActivityWallIdentificationMode;
+  updatedAt: number;
+  /** See `ActivityWallActivity.classId` — omitted for code/PIN-only launches. */
+  classId?: string;
 }
 
 export interface WebcamConfig {
@@ -1189,6 +1230,12 @@ export interface MiniAppConfig {
   googleSheetUrl?: string; // Original pasted URL for UI
   /** Persisted library grid/list toggle. */
   libraryViewMode?: 'grid' | 'list';
+  /**
+   * Remembers the last ClassLink classId the teacher selected per app, keyed
+   * by appId. Used to pre-populate the target-class picker on subsequent
+   * assigns so teachers don't have to re-pick the same class each time.
+   */
+  lastClassIdByAppId?: Record<string, string>;
 }
 
 // Add new Global Config type
@@ -1212,9 +1259,37 @@ export interface MiniAppSession {
   status: 'active' | 'ended';
   createdAt: number;
   endedAt?: number;
-  // Optional result collection via Apps Script
+  /**
+   * Optional ClassLink class sourcedId this session is targeted to. Present
+   * when the teacher launched the assignment from the class-targeted
+   * selector; absent for legacy shared-link launches. Used by the student
+   * `/my-assignments` feed to filter assignments by class.
+   */
+  classId?: string;
+  // Legacy result-collection fields — kept for rollback insurance, no longer
+  // written by current teacher flow. Submissions now land in the
+  // `submissions/` subcollection. See `MiniAppSubmission` below.
   submissionUrl?: string;
   googleSheetId?: string;
+}
+
+/**
+ * A single student submission inside `/mini_app_sessions/{sessionId}/submissions/{submissionId}`.
+ *
+ * `submissionId` is:
+ *   - The per-assignment HMAC pseudonym for ClassLink-authenticated students
+ *     (returned from the `getAssignmentPseudonymV1` Cloud Function). Stable
+ *     within the assignment so a student cannot double-submit but unlinkable
+ *     across assignments without the server HMAC secret.
+ *   - The anonymous Firebase Auth UID for legacy shared-link launches. Also
+ *     stable per-device per-session.
+ *
+ * No PII is ever persisted — the submission shape is deliberately opaque.
+ */
+export interface MiniAppSubmission {
+  submittedAt: number;
+  /** Arbitrary payload forwarded from the sandboxed iframe's postMessage. */
+  payload: unknown;
 }
 
 export interface PdfItem {
@@ -1633,6 +1708,18 @@ export interface QuizSession {
   // ─── Multi-class period support ─────────────────────────────────────────────
   /** Selected class period roster names available for students to join. */
   periodNames?: string[];
+
+  // ─── ClassLink target class (Phase 3A) ─────────────────────────────────────
+  /**
+   * Optional ClassLink class `sourcedId` this session is targeted at. When
+   * present, students who signed in via the ClassLink / Google flow will see
+   * this session on their `/my-assignments` page, and Firestore rules
+   * enforce (via `passesStudentClassGate`) that only students enrolled in
+   * this class can read the session doc. Omit (or leave as an empty string)
+   * to preserve the classic code/PIN-only flow — the gate is a no-op for
+   * non-studentRole users.
+   */
+  classId?: string;
 }
 
 export interface QuizResponseAnswer {
@@ -1725,6 +1812,14 @@ export interface QuizConfig {
   liveScoreboardScoring?: 'completion' | 'per-question';
   /** Persisted library grid/list toggle. */
   libraryViewMode?: 'grid' | 'list';
+  /**
+   * Per-quiz memory of the last ClassLink target class (`sourcedId`) the
+   * teacher picked in the Assign modal. Key is quizId, value is the
+   * ClassLink class sourcedId. Used to pre-select the selector on re-launch
+   * of the same quiz so teachers don't have to re-pick every time.
+   * Undefined means "use the default (No class)".
+   */
+  lastClassIdByQuizId?: Record<string, string>;
 }
 
 // --- QUIZ ASSIGNMENT TYPES ---
@@ -1853,6 +1948,14 @@ export interface VideoActivityConfig {
   allowSkipping?: boolean;
   /** Persisted library grid/list toggle. */
   libraryViewMode?: 'grid' | 'list';
+  /**
+   * Per-activity memory of the last ClassLink target class (`sourcedId`) the
+   * teacher picked in the Assign modal. Key is activityId, value is the
+   * ClassLink class sourcedId. Used to pre-select the selector on re-launch
+   * of the same activity so teachers don't have to re-pick every time.
+   * Undefined means "use the default (No class)".
+   */
+  lastClassIdByActivityId?: Record<string, string>;
 }
 
 export interface VideoActivitySessionSettings {
@@ -1896,6 +1999,14 @@ export interface VideoActivitySession {
   endedAt?: number;
   /** Optional Unix timestamp when the session link expires. */
   expiresAt?: number;
+  /**
+   * Optional ClassLink class `sourcedId` this session is targeted at. When
+   * set, ClassLink-authenticated students whose token includes this classId
+   * see the session on their `/my-assignments` page, and Firestore rules
+   * (`passesStudentClassGate(vaSessionClassId())`) enforce class-based
+   * access. Undefined preserves the classic code/PIN-only flow.
+   */
+  classId?: string;
 }
 
 /** A single answer submitted by a student for a video activity question. */
@@ -2499,6 +2610,17 @@ export interface GuidedLearningSession {
   teacherUid: string;
   createdAt: number;
   expiresAt?: number;
+  // ─── ClassLink target class (Phase 3C) ─────────────────────────────────────
+  /**
+   * Optional ClassLink class `sourcedId` this session is targeted at. When
+   * present, students who signed in via the ClassLink / Google flow will see
+   * this session on their `/my-assignments` page, and Firestore rules
+   * enforce (via `passesStudentClassGate`) that only students enrolled in
+   * this class can read the session doc. Omit (or leave as an empty string)
+   * to preserve the classic join-link flow — the gate is a no-op for
+   * non-studentRole users.
+   */
+  classId?: string;
 }
 
 /** Per-student response in /guided_learning_sessions/{id}/responses/{studentUid} */
@@ -2529,6 +2651,14 @@ export interface GuidedLearningConfig {
   resultsSessionId?: string | null;
   /** Persisted library grid/list toggle. */
   libraryViewMode?: 'grid' | 'list';
+  /**
+   * Per-set memory of the last ClassLink target class (`sourcedId`) the
+   * teacher picked in the Assign dialog. Key is the Guided Learning set id,
+   * value is the ClassLink class sourcedId. Used to pre-select the selector
+   * on re-launch of the same set so teachers don't have to re-pick every
+   * time. Undefined means "use the default (No class)".
+   */
+  lastClassIdBySetId?: Record<string, string>;
 }
 
 // Union of all widget configs
@@ -3573,7 +3703,10 @@ export interface MiniAppAssignment {
   status: 'active' | 'inactive';
   createdAt: number;
   updatedAt: number;
-  /** Optional mirrored fields so the archive list can show result-collection intent at a glance. */
+  /** Mirrors `MiniAppSession.classId`. Present when assigned via the
+   * class-targeted picker; absent for legacy shared-link launches. */
+  classId?: string;
+  /** Legacy fields kept for rollback insurance — no longer written. */
   submissionUrl?: string;
   googleSheetId?: string;
 }

--- a/types.ts
+++ b/types.ts
@@ -1288,8 +1288,13 @@ export interface MiniAppSession {
  */
 export interface MiniAppSubmission {
   submittedAt: number;
-  /** Arbitrary payload forwarded from the sandboxed iframe's postMessage. */
-  payload: unknown;
+  /**
+   * Payload forwarded from the sandboxed iframe's postMessage. Always a
+   * top-level object because Firestore rules enforce `payload is map`;
+   * scalar/array payloads from the iframe are wrapped in `{ value }` by
+   * the submission handler before persisting.
+   */
+  payload: Record<string, unknown>;
 }
 
 export interface PdfItem {


### PR DESCRIPTION
## Summary

PII-free student SSO: ClassLink-authenticated students launch SpartBoard → land on `/my-assignments` → enter assignments without PIN entry or period selection. No student PII (email, name, sub) ever persists in Firebase — only an opaque HMAC pseudonym UID plus a `classIds` claim.

- **Cloud Functions** — `studentLoginV1` (GIS id_token → custom token), `getAssignmentPseudonymV1` (per-assignment pseudonym), `getPseudonymsForAssignmentV1` (teacher reverse map)
- **Student UI** — `/student/login` (GIS One-Tap, 4 error states), `/my-assignments` (real-time onSnapshot across all 5 session types, lazy completion badges, 15-min idle timeout), `StudentAuthContext`
- **Teacher UI** — target-class selector in Quiz, Video Activity, Guided Learning, Activity Wall, and Mini-app assign dialogs
- **Mini-app pipeline migration** — replace broken Apps Script → Google Sheets with Firestore `submissions/` subcollection + teacher-side `SubmissionsModal`
- **Activity Wall class-targeted launches** — Firestore `getDoc` fallback when the legacy `?data=` URL param is absent
- **Security** — `passesStudentClassGate()` helper across all session collection rules; new submissions subcollection rules; HMAC secret stays server-side
- **Docs** — HMAC rotation rules, per-organization domain config, Cloud Monitoring alerts

Backwards compatible: code+PIN flow is untouched; assignments without `classId` continue to work as today.

## Test plan

- [ ] Deploy Cloud Functions with `STUDENT_PSEUDONYM_HMAC_SECRET` set and `minInstances: 1` config
- [ ] Deploy `firestore.rules`
- [ ] Seed Orono organization doc with `domains: ['orono.k12.mn.us']`
- [ ] Sign in at `/student/login` with an `@orono.k12.mn.us` Google account → verify `/my-assignments` loads, Firebase Auth record has only opaque UID (no email/displayName/photoURL)
- [ ] Sign in with a personal Gmail → verify domain-reject error, no Firebase Auth user created
- [ ] Teacher creates a class-targeted Quiz → student sees it on `/my-assignments` in real time
- [ ] Student completes the quiz → completion badge renders on `/my-assignments`
- [ ] Verify class-membership enforcement: attempt to read another class's assignment doc via student's token → rejected by rules
- [ ] Mini-app submission flow: student launches class-targeted mini-app → completes activity → Firestore `mini_app_sessions/{sessionId}/submissions/{pseudonym}` doc exists → teacher's new "Submissions" button shows the opaque doc ID + timestamp + JSON payload
- [ ] Activity Wall class-targeted launch: student opens via `/my-assignments` (no `?data=` param) → session config loads from Firestore
- [ ] Legacy code+PIN join still works for non-class-targeted assignments
- [ ] Cold-start: hit `studentLoginV1` after 10 min idle with `minInstances: 1` → sub-500ms
- [ ] Cloud Monitoring alert policies configured per `docs/ADMIN_SETUP.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)