### PR TITLE
audit+action(scheduled-tasks): Wednesday 2026-04-22 — useQuizSession tests

### DIFF
--- a/docs/scheduled-tasks/code-structure.md
+++ b/docs/scheduled-tasks/code-structure.md
@@ -3,7 +3,7 @@
 _Audit model: claude-sonnet-4-6_
 _Action model: claude-opus-4-6_
 _Audit cadence: weekly — Wednesday_
-_Last audited: 2026-04-15_
+_Last audited: 2026-04-22_
 _Last action: never_
 
 ---
@@ -16,25 +16,20 @@ _Nothing currently in progress._
 
 ## Open
 
-### MEDIUM `DashboardContext.tsx` is 3165 lines with at least three extractable responsibilities
+### MEDIUM `DashboardContext.tsx` is 3394 lines and growing — at least three extractable responsibilities
 
 - **Detected:** 2026-04-15
+- **Updated:** 2026-04-22 — file grew from 3165 to 3394 lines (+229) in 7 days. Issue is actively worsening.
 - **File:** context/DashboardContext.tsx
-- **Detail:** The context file is the largest non-test source file at 3165 lines. It owns: (1) Firestore CRUD + real-time sync, (2) Google Drive backup/restore orchestration, (3) widget CRUD actions (add/update/delete/reorder), (4) `getAdminBuildingConfig` — a 300-line switch covering 20+ widget types that maps per-building admin overrides onto widget defaults, (5) `applyDashboardTemplate` and `loadStarterPack`, (6) migration and legacy handling. The `getAdminBuildingConfig` switch alone is long enough to be its own module.
-- **Fix:** Extract `getAdminBuildingConfig` into `utils/adminBuildingConfig.ts` (pure function: `(type, featurePermissions, selectedBuildings) => Record<string, unknown>`). This removes ~300 lines from the context without touching its public API and makes the validation logic independently testable.
+- **Detail:** The context file is the largest non-test source file at 3394 lines (was 3165 on 2026-04-15). It owns: (1) Firestore CRUD + real-time sync, (2) Google Drive backup/restore orchestration, (3) widget CRUD actions (add/update/delete/reorder), (4) `getAdminBuildingConfig` — a 400-line switch covering 30+ widget types that maps per-building admin overrides onto widget defaults, (5) `applyDashboardTemplate` and `loadStarterPack`, (6) migration and legacy handling. The `getAdminBuildingConfig` switch spans lines 2053–2450 (~397 lines) and is long enough to be its own module. At the current growth rate (+229 lines/week), the file will exceed 4500 lines within 5 weeks.
+- **Fix:** Extract `getAdminBuildingConfig` into `utils/adminBuildingConfig.ts` (pure function: `(type, featurePermissions, selectedBuildings) => Record<string, unknown>`). This removes ~400 lines from the context without touching its public API and makes the validation logic independently testable. Also consider extracting migration logic to `utils/dashboardMigration.ts` (~150 lines).
 
-### MEDIUM All 9 Cloud Functions use Firebase Functions v1 (`functionsV1`) — migration to v2 warranted for high-memory functions
-
-- **Detected:** 2026-04-15
-- **File:** functions/src/index.ts (lines 294, 421, 909, 949, 1086, 1214, 1453, 1737, 1913)
-- **Detail:** Every exported Cloud Function (`getClassLinkRosterV1`, `generateWithAI`, `fetchWeatherProxy`, `archiveActivityWallPhoto`, `checkUrlCompatibility`, `generateVideoActivity`, `transcribeVideoWithGemini`, `generateGuidedLearning`, `adminAnalytics`) uses `firebase-functions/v1`. The v1 API is in maintenance mode; v2 offers concurrency, per-request billing, better cold-start, and `onCall` v2 resolves CORS automatically without manual `corsHandler`. Three functions have heavy resource requirements: `generateVideoActivity` (1 GB / 300 s), `transcribeVideoWithGemini` (1 GB / 300 s), and `adminAnalytics` (4 GB / 540 s) — these benefit most from v2's concurrency model which avoids spinning up separate instances per simultaneous request. Comments in the file note that `generateWithAI` intentionally stays on v1 for URL format compatibility and `getClassLinkRosterV1` was kept on v1 while working, but neither block applies to the media-generation or analytics functions.
-- **Fix:** Migrate `generateVideoActivity`, `transcribeVideoWithGemini`, `adminAnalytics`, `archiveActivityWallPhoto`, and `generateGuidedLearning` to `firebase-functions/v2`. Update imports from `firebase-functions/v1` to `firebase-functions/v2/https` (`onCall`, `onRequest`). Replace `.runWith({memory, timeoutSeconds})` with the v2 option object syntax. Keep `generateWithAI` and `getClassLinkRosterV1` on v1 per existing comments. Migrate `fetchWeatherProxy` and `checkUrlCompatibility` as lower priority.
-
-### MEDIUM `functions/src/index.ts` is 2445 lines — single file for all Cloud Functions
+### MEDIUM `functions/src/index.ts` is 2488 lines — single file for all Cloud Functions
 
 - **Detected:** 2026-04-15
+- **Updated:** 2026-04-22 — file grew from 2445 to 2488 lines (+43).
 - **File:** functions/src/index.ts
-- **Detail:** All 9 Cloud Functions live in one file. Logical groupings exist: ClassLink roster integration (getClassLinkRosterV1), AI generation (generateWithAI, generateVideoActivity, transcribeVideoWithGemini, generateGuidedLearning), utility (fetchWeatherProxy, archiveActivityWallPhoto, checkUrlCompatibility), admin (adminAnalytics). The file is difficult to navigate and review as a unit.
+- **Detail:** All 9 Cloud Functions live in one file. Logical groupings exist: ClassLink roster integration (getClassLinkRosterV1), AI generation (generateWithAI, generateVideoActivity, transcribeVideoWithGemini, generateGuidedLearning), utility (fetchExternalProxy, archiveActivityWallPhoto, checkUrlCompatibility), admin (adminAnalytics). The file is difficult to navigate and review as a unit.
 - **Fix:** Split into domain files: `functions/src/classlink.ts`, `functions/src/ai.ts`, `functions/src/utils.ts`, `functions/src/admin.ts`. Re-export all functions from `functions/src/index.ts` to preserve deployed names. This is a refactor with no behavior change but significantly improves reviewability.
 
 ### LOW `getAdminBuildingConfig` has 10+ near-identical single-field switch cases
@@ -77,4 +72,9 @@ _Nothing currently in progress._
 
 ## Completed
 
-_No completed items yet._
+### MEDIUM All 9 Cloud Functions use Firebase Functions v1 — migration to v2 warranted
+
+- **Detected:** 2026-04-15
+- **Completed:** 2026-04-22
+- **File:** functions/src/index.ts
+- **Resolution:** Resolved outside journal workflow. 2026-04-22 audit confirmed all functions already import from `firebase-functions/v2/https` (onCall, onRequest) and `firebase-functions/v2` (setGlobalOptions). The 2026-04-15 journal entry was incorrect — the migration was already complete at time of first detection or completed shortly after. Verified: `generateVideoActivity` (1 GiB / 300s), `transcribeVideoWithGemini` (1 GiB / 300s), `adminAnalytics` (4 GiB / 540s), and all others use v2 syntax.

--- a/docs/scheduled-tasks/css-scaling.md
+++ b/docs/scheduled-tasks/css-scaling.md
@@ -3,7 +3,7 @@
 _Audit model: claude-sonnet-4-6_
 _Action model: claude-opus-4-6_
 _Audit cadence: daily_
-_Last audited: 2026-04-21_
+_Last audited: 2026-04-22_
 _Last action: 2026-04-19_
 
 ---

--- a/docs/scheduled-tasks/firestore-rules.md
+++ b/docs/scheduled-tasks/firestore-rules.md
@@ -3,7 +3,7 @@
 _Audit model: claude-sonnet-4-6_
 _Action model: claude-opus-4-6_
 _Audit cadence: weekly — Monday_
-_Last audited: 2026-04-20_
+_Last audited: 2026-04-22_
 _Last action: never_
 
 ---

--- a/docs/scheduled-tasks/pr-review-log.md
+++ b/docs/scheduled-tasks/pr-review-log.md
@@ -116,3 +116,33 @@ _Automated nightly review by claude-opus-4-6_
   - PR #1354 head SHA `d8cf3e3d` — two `useEffect`s converted in `SidebarBackgrounds.tsx`; `useEffect` still used for Google Drive fetch elsewhere in the file
   - PR #1353 head SHA `7a043e4a` — draft, no CI triggered; diff covers MathTools/Widget.tsx + 4 journal files + new `tests/hooks/useLiveSession.test.ts` (201 lines, 9 tests covering `joinSession` validation)
   - PR #1335 head SHA `5a78487e` — largest PR in the review cycle; rollback risk is very high if a regression ships
+
+## 2026-04-22
+
+- PRs reviewed:
+  - #1377 — audit+action(scheduled-tasks): Wednesday 2026-04-22 — useQuizSession tests (head `scheduled-tasks`, base `dev-paul`, DRAFT)
+  - #1376 — feat(auth): ClassLink-via-Google student SSO, PII-free (head `claude/distracted-fermi-040d18`, base `dev-paul`)
+  - #1375 — fix(admin): scope analytics to org + sync buildings counter (head `claude/fix-admin-settings-alignment-uVLDu`, base `dev-paul`, DRAFT)
+  - #1371 — Refactor adminAnalytics and enhance organization member management (head `dev-paul`, base `main`) — read-only for pushes per branch-safety
+  - #1366 — docs: plan for repo-wide line-ending normalization (head `docs/line-endings-normalization-plan`, base `main`)
+- Comments processed: 31 total — 0 new fixes, 31 already addressed by prior author responses
+  - PR #1377: 0 inline threads; 1 bot review comment (gemini) with no findings
+  - PR #1376: 3 inline threads, all already replied to by OPS-PIvers (1 declined pseudonym→name follow-up w/ reason, 1 confirmed fixed in `be6fc29`, 1 declined `cqmin` change w/ correct reasoning per CLAUDE.md)
+  - PR #1375: 10 inline threads, all already addressed — 4 fixed in `060f206`, 3 fixed in `97c14c1`, 3 outdated — auth scoping, engagement bucket iteration, dead `buildingsMap`, chunk-failure isolation, test coverage, and UI loading state all resolved
+  - PR #1371: 6 inline threads, all already replied to by OPS-PIvers (5 fixed in `15cfb65`, 1 documentation-scope deferral); branch is `dev-paul` so no pushes attempted regardless
+  - PR #1366: 6 inline threads, all already replied to by OPS-PIvers (all reflected in the final plan doc — 3-PR structure, subject-based hash lookup, working-tree refresh warnings)
+- Fixes pushed: none
+  - No unaddressed comments remained requiring a code fix on any PR
+- Reviews posted: 5
+  - PR #1377: Ready — scheduled audit + 432-line `useQuizSession.test.ts`; flagged `DashboardContext.tsx` growth rate (projection >4500 lines in 5 weeks) as priority for extraction
+  - PR #1376: Ready with minor notes — large SSO PR with sound security model; flagged deploy prerequisites (`STUDENT_PSEUDONYM_HMAC_SECRET`, `minInstances: 1`), legacy PIN-flow regression test, mini-app Apps Script → Firestore cutover, and Activity Wall fallback ordering
+  - PR #1375: Ready — three well-targeted fixes (trigger-based building counter, orgId gating, admin-assigned `buildingIds` for labels); suggested correlation-id follow-up + dedicated test for never-signed-in member engagement contract
+  - PR #1371: Ready with minor notes — 160+ file cumulative `dev-paul → main` merge; flagged initial-hydration empty `orgBuildings` window, `test:all` workflow change, absent tests for `DriveImagePicker` race path + new library primitives, and 944-line `QuizLiveMonitor` as follow-up extraction candidate
+  - PR #1366: Ready — doc-only runbook, no runtime effect; suggested linking from `docs/DEV_WORKFLOW.md`
+- Notes:
+  - PR #1377 head SHA `0977c1c8` — adds `useQuizSession.test.ts` (24 tests) covering pure helpers + student-side join; teacher-side flows still untested
+  - PR #1376 head SHA `e2253f58` — 35 files touched; `firestore.rules` +162 lines, `functions/src/index.ts` +522 lines, 568-line rules-test file for student-role class gate
+  - PR #1375 head SHA `97c14c15` — 6 files; new `organizationBuildingCounters` trigger + test (5 cases); `functions/src/index.ts` +147/-88
+  - PR #1371 head SHA `15cfb658` — cumulative merge, 160+ files; organization management (new Cloud Functions for reset-password/counters/activity), library folder subsystem, `DriveImagePicker`, migration of every admin panel from static `BUILDINGS` to dynamic `useAdminBuildings`
+  - PR #1366 head SHA `7ffde284` — single doc (194 lines); no code impact; execution gated on "all open PRs merged" precondition
+  - Branch-safety: PR #1371 is on `dev-paul` (matches `dev-*`) — pushes prohibited by policy; comment-only scope observed

--- a/docs/scheduled-tasks/test-coverage.md
+++ b/docs/scheduled-tasks/test-coverage.md
@@ -4,7 +4,7 @@ _Audit model: claude-sonnet-4-6_
 _Action model: claude-opus-4-6_
 _Audit cadence: weekly — Monday_
 _Last audited: 2026-04-22_
-_Last action: 2026-04-20_
+_Last action: 2026-04-22_
 
 ---
 
@@ -19,8 +19,9 @@ _Nothing currently in progress._
 ### HIGH hooks/ coverage — session hooks still missing tests (partial progress)
 
 - **Detected:** 2026-04-13
+- **Progress (2026-04-22):** Added test coverage for `useQuizSession.ts` (24 tests). Covers pure helpers (`normalizeAnswer`, `gradeAnswer` across MC/FIB/Matching/Ordering, `toPublicQuestion` including `correctAnswer` strip-off for each question type) and `useQuizSessionStudent` student-join logic (`lookupSession` empty/no-match/all-ended/joinable-picker paths; `joinQuizSession` invalid-code/empty-PIN/no-session/all-ended throws, most-recent-joinable selection, PIN truncation to 10 chars, code normalization, and `classPeriod` backfill on existing responses).
 - **Progress (2026-04-20):** Added initial test coverage for `useLiveSession.ts` (9 tests covering `joinSession` input validation and sanitization — code normalization, PIN truncation, duplicate-PIN rejection, self-rejoin allowance, and all error paths). Also confirmed pre-existing coverage for `useGuidedLearningSession.ts` (pure-helper test) and `useGoogleDrive.ts` / `useStorage.ts` (full test files in `tests/hooks/`). Remaining critical hooks with zero coverage:
-  - `useQuizSession.ts` — quiz session state for both teacher and student flows
+  - `useQuizSession.ts` — teacher-side flows (`useQuizSessionTeacher`: `advanceQuestion`, `endQuizSession`, `removeStudent`, `revealAnswer`/`hideAnswer`, auto-progress effect) still untested
   - `useVideoActivity.ts` / `useVideoActivitySession.ts` — video activity session management
   - `useMiniAppSession.ts` — mini-app assignment session lifecycle
   - `useRosters.ts` — roster CRUD, student list management
@@ -30,7 +31,7 @@ _Nothing currently in progress._
   - `useScreenRecord.ts` — screen recording lifecycle
   - `useLiveSession.ts` — needs deeper coverage (teacher actions: `startSession`, `updateSessionConfig`, `endSession`, `toggleFreezeStudent`, `toggleGlobalFreeze`)
 - **File:** hooks/ directory
-- **Fix:** Next priority: add `useQuizSession.ts` coverage, then expand `useLiveSession` to cover teacher-mode actions. Use Vitest with mock Firebase adapters. See `tests/hooks/useLiveSession.test.ts` and `tests/hooks/useMusicStations.test.ts` as reference patterns.
+- **Fix:** Next priority: expand `useQuizSession.ts` to cover `useQuizSessionTeacher` (advance/end/reveal/remove-student), then expand `useLiveSession` to cover teacher-mode actions. Use Vitest with mock Firebase adapters. See `tests/hooks/useLiveSession.test.ts` and `tests/hooks/useQuizSession.test.ts` as reference patterns.
 
 ### MEDIUM utils/ coverage — 28 of 41 utility files have no tests
 

--- a/docs/scheduled-tasks/test-coverage.md
+++ b/docs/scheduled-tasks/test-coverage.md
@@ -3,7 +3,7 @@
 _Audit model: claude-sonnet-4-6_
 _Action model: claude-opus-4-6_
 _Audit cadence: weekly — Monday_
-_Last audited: 2026-04-20_
+_Last audited: 2026-04-22_
 _Last action: 2026-04-20_
 
 ---
@@ -32,13 +32,10 @@ _Nothing currently in progress._
 - **File:** hooks/ directory
 - **Fix:** Next priority: add `useQuizSession.ts` coverage, then expand `useLiveSession` to cover teacher-mode actions. Use Vitest with mock Firebase adapters. See `tests/hooks/useLiveSession.test.ts` and `tests/hooks/useMusicStations.test.ts` as reference patterns.
 
-### MEDIUM utils/ coverage — 31 of 41 utility files have no tests
+### MEDIUM utils/ coverage — 28 of 41 utility files have no tests
 
 - **Detected:** 2026-04-13
-- **File:** utils/ directory
-- **Detail:** Only 10 of 41 util files have test coverage. High-priority untested utilities:
-  - `ai.ts` — core AI generation interface, calls Cloud Functions for quiz/poll/mini-app/dashboard generation
-  - `ai_security.ts` — AI prompt sanitization and security utilities
+- **Progress (2026-04-22):** Count improved from 31 untested (2026-04-20) to 28. Since last audit, `ai.ts`, `ai_security.ts`, and `classlinkService.ts` gained test files. Currently 13 utils are tested. Still untested high-priority utilities:
   - `googleDriveService.ts` — Google Drive dashboard sync service
   - `googleCalendarService.ts` — Google Calendar API integration
   - `guidedLearningDriveService.ts` — guided learning material sync from Drive
@@ -46,16 +43,21 @@ _Nothing currently in progress._
   - `pexelsService.ts` — Pexels stock image API integration
   - `quizAudio.ts` — quiz audio generation utilities
   - `quizDriveService.ts` — quiz import/export via Google Drive
-  - `randomHelpers.ts` — random selection, shuffling utilities
   - `soundboardConfig.ts` — sound configuration parser
-  - `widgetConfigPersistence.ts` — widget state persistence logic
-- **Fix:** Start with pure utility functions (randomHelpers, soundboardConfig, widgetConfigPersistence) as they have no external dependencies. Then add tests for service wrappers (googleDriveService, pexelsService) using vi.mock() for fetch/API calls.
+  - `security.ts` — XSS prevention and input sanitization (pure, no deps, high value)
+  - `slug.ts` — URL slug generation (pure, easy to test)
+  - `backgrounds.ts` — background format detection and CSS generation (pure)
+  - `urlHelpers.ts` — URL parsing and manipulation (pure)
+  - `widgetHelpers.ts` — widget layout and config default helpers (pure)
+- **File:** utils/ directory
+- **Fix:** Start with pure utilities with no external dependencies (security.ts, slug.ts, backgrounds.ts, urlHelpers.ts, widgetHelpers.ts) — all are testable without mocking. Then add service wrappers (googleDriveService, pexelsService) using vi.mock() for fetch/API calls.
 
-### LOW widget test coverage — most of 57 widgets have no component tests
+### LOW widget test coverage — most of 58 widgets have no component tests
 
 - **Detected:** 2026-04-13
+- **Progress (2026-04-22):** Confirmed 7 test files exist (up from 6 last audit). Total widget count is now 58 (blooms-detail added). ~51 widgets remain untested.
 - **File:** components/widgets/ directory
-- **Detail:** Only 6 test files exist in tests/components/widgets/. The vast majority of widget components (50+) have no automated tests. This means regressions in widget rendering, config persistence, and settings panels go undetected.
+- **Detail:** Only 7 test files exist for widget components. The vast majority (51+) have no automated tests. This means regressions in widget rendering, config persistence, and settings panels go undetected.
 - **Fix:** Focus first on high-complexity widgets: PollWidget (live session sync), QuizWidget, RevealGridWidget, ChecklistWidget. Use React Testing Library with Vitest. Mock useDashboard() and useAuth() hooks.
 
 ---

--- a/docs/scheduled-tasks/typescript-eslint.md
+++ b/docs/scheduled-tasks/typescript-eslint.md
@@ -3,7 +3,7 @@
 _Audit model: claude-sonnet-4-6_
 _Action model: claude-opus-4-6_
 _Audit cadence: daily_
-_Last audited: 2026-04-21_
+_Last audited: 2026-04-22_
 _Last action: never_
 
 ---
@@ -16,7 +16,7 @@ _Nothing currently in progress._
 
 ## Open
 
-_No open items. Both `pnpm type-check` and `pnpm lint` pass cleanly as of 2026-04-21. TypeScript: 0 errors. ESLint: 0 errors, 0 warnings (`--max-warnings 0`)._
+_No open items. Both `pnpm type-check` and `pnpm lint` pass cleanly as of 2026-04-22. TypeScript: 0 errors. ESLint: 0 errors, 0 warnings (`--max-warnings 0`). Test suite: 1393 tests across 151 files — all passing (up from 1094 tests noted 2026-04-15)._
 
 ---
 

--- a/docs/scheduled-tasks/ui-unification.md
+++ b/docs/scheduled-tasks/ui-unification.md
@@ -3,7 +3,7 @@
 _Audit model: claude-sonnet-4-6_
 _Action model: claude-opus-4-6_
 _Audit cadence: weekly — Wednesday_
-_Last audited: 2026-04-15_
+_Last audited: 2026-04-22_
 _Last action: never_
 
 ---

--- a/docs/scheduled-tasks/widget-registry.md
+++ b/docs/scheduled-tasks/widget-registry.md
@@ -3,7 +3,7 @@
 _Audit model: claude-sonnet-4-6_
 _Action model: claude-opus-4-6_
 _Audit cadence: daily_
-_Last audited: 2026-04-21_
+_Last audited: 2026-04-22_
 _Last action: never_
 
 ---

--- a/tests/hooks/useQuizSession.test.ts
+++ b/tests/hooks/useQuizSession.test.ts
@@ -1,0 +1,432 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+import * as firestore from 'firebase/firestore';
+import {
+  normalizeAnswer,
+  gradeAnswer,
+  toPublicQuestion,
+  useQuizSessionStudent,
+} from '@/hooks/useQuizSession';
+import { auth } from '@/config/firebase';
+import type { QuizQuestion, QuizSession } from '@/types';
+
+vi.mock('firebase/firestore');
+vi.mock('firebase/auth', () => ({
+  signInAnonymously: vi.fn().mockResolvedValue({ user: { uid: 'anon-uid' } }),
+}));
+
+// ─── Pure helpers ─────────────────────────────────────────────────────────────
+
+describe('normalizeAnswer', () => {
+  it('lowercases, trims, and collapses internal whitespace', () => {
+    expect(normalizeAnswer('  Hello   World  ')).toBe('hello world');
+  });
+
+  it('treats tabs and newlines as whitespace', () => {
+    expect(normalizeAnswer('a\tb\nc')).toBe('a b c');
+  });
+
+  it('returns empty string for all-whitespace input', () => {
+    expect(normalizeAnswer('   \t\n ')).toBe('');
+  });
+});
+
+describe('gradeAnswer', () => {
+  const mcQuestion: QuizQuestion = {
+    id: 'q1',
+    timeLimit: 30,
+    text: 'Capital of France?',
+    type: 'MC',
+    correctAnswer: 'Paris',
+    incorrectAnswers: ['London', 'Berlin', 'Madrid'],
+  };
+
+  it('grades MC case-insensitively and ignores surrounding whitespace', () => {
+    expect(gradeAnswer(mcQuestion, 'paris')).toBe(true);
+    expect(gradeAnswer(mcQuestion, '  PARIS  ')).toBe(true);
+    expect(gradeAnswer(mcQuestion, 'London')).toBe(false);
+  });
+
+  it('grades FIB with whitespace normalization', () => {
+    const fib: QuizQuestion = {
+      id: 'q2',
+      timeLimit: 0,
+      text: 'Two plus two equals',
+      type: 'FIB',
+      correctAnswer: 'four',
+      incorrectAnswers: [],
+    };
+    expect(gradeAnswer(fib, '  Four  ')).toBe(true);
+    expect(gradeAnswer(fib, 'five')).toBe(false);
+  });
+
+  it('grades Matching regardless of pair order', () => {
+    const matching: QuizQuestion = {
+      id: 'q3',
+      timeLimit: 0,
+      text: 'Match each',
+      type: 'Matching',
+      correctAnswer: 'dog:bark|cat:meow|cow:moo',
+      incorrectAnswers: [],
+    };
+    expect(gradeAnswer(matching, 'cat:meow|dog:bark|cow:moo')).toBe(true);
+    expect(gradeAnswer(matching, 'dog:bark|cat:meow|cow:moo')).toBe(true);
+  });
+
+  it('rejects Matching when a pair is wrong or missing', () => {
+    const matching: QuizQuestion = {
+      id: 'q3',
+      timeLimit: 0,
+      text: 'Match each',
+      type: 'Matching',
+      correctAnswer: 'dog:bark|cat:meow',
+      incorrectAnswers: [],
+    };
+    expect(gradeAnswer(matching, 'dog:meow|cat:bark')).toBe(false);
+    expect(gradeAnswer(matching, 'dog:bark')).toBe(false);
+  });
+
+  it('grades Ordering strictly by sequence', () => {
+    const ordering: QuizQuestion = {
+      id: 'q4',
+      timeLimit: 0,
+      text: 'Order these',
+      type: 'Ordering',
+      correctAnswer: 'first|second|third',
+      incorrectAnswers: [],
+    };
+    expect(gradeAnswer(ordering, 'first|second|third')).toBe(true);
+    expect(gradeAnswer(ordering, 'FIRST|Second|THIRD')).toBe(true);
+    expect(gradeAnswer(ordering, 'first|third|second')).toBe(false);
+  });
+});
+
+describe('toPublicQuestion', () => {
+  it('strips correctAnswer and includes MC choices combining correct + filtered incorrect', () => {
+    const q: QuizQuestion = {
+      id: 'q1',
+      timeLimit: 20,
+      text: 'Pick one',
+      type: 'MC',
+      correctAnswer: 'alpha',
+      incorrectAnswers: ['beta', '', 'gamma'], // empty string should be filtered
+    };
+    const pub = toPublicQuestion(q);
+    expect(pub).not.toHaveProperty('correctAnswer');
+    expect(pub).not.toHaveProperty('incorrectAnswers');
+    expect(pub.id).toBe('q1');
+    expect(pub.type).toBe('MC');
+    expect(pub.text).toBe('Pick one');
+    expect(pub.timeLimit).toBe(20);
+    expect(pub.choices).toHaveLength(3);
+    expect(pub.choices).toEqual(
+      expect.arrayContaining(['alpha', 'beta', 'gamma'])
+    );
+  });
+
+  it('splits Matching into left prompts and shuffled right values without leaking pairs', () => {
+    const q: QuizQuestion = {
+      id: 'q2',
+      timeLimit: 0,
+      text: 'Match',
+      type: 'Matching',
+      correctAnswer: 'dog:bark|cat:meow|cow:moo',
+      incorrectAnswers: [],
+    };
+    const pub = toPublicQuestion(q);
+    expect(pub.matchingLeft).toEqual(['dog', 'cat', 'cow']);
+    expect(pub.matchingRight).toHaveLength(3);
+    expect(pub.matchingRight).toEqual(
+      expect.arrayContaining(['bark', 'meow', 'moo'])
+    );
+    expect(pub).not.toHaveProperty('correctAnswer');
+  });
+
+  it('splits Ordering into items without preserving order or correctAnswer', () => {
+    const q: QuizQuestion = {
+      id: 'q3',
+      timeLimit: 0,
+      text: 'Order',
+      type: 'Ordering',
+      correctAnswer: 'one|two|three|four',
+      incorrectAnswers: [],
+    };
+    const pub = toPublicQuestion(q);
+    expect(pub.orderingItems).toHaveLength(4);
+    expect(pub.orderingItems).toEqual(
+      expect.arrayContaining(['one', 'two', 'three', 'four'])
+    );
+    expect(pub).not.toHaveProperty('correctAnswer');
+  });
+
+  it('returns only base fields for FIB questions', () => {
+    const q: QuizQuestion = {
+      id: 'q4',
+      timeLimit: 0,
+      text: 'Fill in',
+      type: 'FIB',
+      correctAnswer: 'secret',
+      incorrectAnswers: [],
+    };
+    const pub = toPublicQuestion(q);
+    expect(pub.choices).toBeUndefined();
+    expect(pub.matchingLeft).toBeUndefined();
+    expect(pub.orderingItems).toBeUndefined();
+    expect(pub).not.toHaveProperty('correctAnswer');
+    expect(pub.id).toBe('q4');
+    expect(pub.type).toBe('FIB');
+  });
+});
+
+// ─── Student hook ─────────────────────────────────────────────────────────────
+
+function buildSessionDoc(
+  id: string,
+  data: Partial<QuizSession> & { status: QuizSession['status'] }
+) {
+  return {
+    id,
+    data: () => data as QuizSession,
+  };
+}
+
+describe('useQuizSessionStudent — lookupSession', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (firestore.doc as unknown as ReturnType<typeof vi.fn>).mockReturnValue({});
+    (
+      firestore.collection as unknown as ReturnType<typeof vi.fn>
+    ).mockReturnValue({});
+    (firestore.query as unknown as ReturnType<typeof vi.fn>).mockReturnValue(
+      {}
+    );
+    (firestore.where as unknown as ReturnType<typeof vi.fn>).mockReturnValue(
+      {}
+    );
+    (
+      firestore.onSnapshot as unknown as ReturnType<typeof vi.fn>
+    ).mockImplementation(() => vi.fn());
+  });
+
+  it('returns null when the code is empty after normalization', async () => {
+    const { result } = renderHook(() => useQuizSessionStudent());
+    await expect(result.current.lookupSession('  !!!  ')).resolves.toBeNull();
+  });
+
+  it('returns null when no matching session is found', async () => {
+    (
+      firestore.getDocs as unknown as ReturnType<typeof vi.fn>
+    ).mockResolvedValueOnce({ empty: true, docs: [] });
+
+    const { result } = renderHook(() => useQuizSessionStudent());
+    await expect(result.current.lookupSession('ABC123')).resolves.toBeNull();
+  });
+
+  it('returns null when every matching session has already ended', async () => {
+    (
+      firestore.getDocs as unknown as ReturnType<typeof vi.fn>
+    ).mockResolvedValueOnce({
+      empty: false,
+      docs: [buildSessionDoc('old-1', { status: 'ended' })],
+    });
+
+    const { result } = renderHook(() => useQuizSessionStudent());
+    await expect(result.current.lookupSession('ABC123')).resolves.toBeNull();
+  });
+
+  it('returns resolved periodNames for the most recently started joinable session', async () => {
+    (
+      firestore.getDocs as unknown as ReturnType<typeof vi.fn>
+    ).mockResolvedValueOnce({
+      empty: false,
+      docs: [
+        buildSessionDoc('older', {
+          status: 'active',
+          startedAt: 100,
+          periodNames: ['Stale Period'],
+        }),
+        buildSessionDoc('newer', {
+          status: 'waiting',
+          startedAt: 999,
+          periodNames: ['Period 1', 'Period 2'],
+        }),
+      ],
+    });
+
+    const { result } = renderHook(() => useQuizSessionStudent());
+    const out = await result.current.lookupSession('abc-123');
+    expect(out).toEqual({ periodNames: ['Period 1', 'Period 2'] });
+  });
+});
+
+describe('useQuizSessionStudent — joinQuizSession', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (auth as unknown as { currentUser: { uid: string } | null }).currentUser = {
+      uid: 'student-uid-1',
+    };
+    (
+      firestore.onSnapshot as unknown as ReturnType<typeof vi.fn>
+    ).mockImplementation(() => vi.fn());
+    (firestore.doc as unknown as ReturnType<typeof vi.fn>).mockReturnValue({});
+    (
+      firestore.collection as unknown as ReturnType<typeof vi.fn>
+    ).mockReturnValue({});
+    (firestore.query as unknown as ReturnType<typeof vi.fn>).mockReturnValue(
+      {}
+    );
+    (firestore.where as unknown as ReturnType<typeof vi.fn>).mockReturnValue(
+      {}
+    );
+  });
+
+  it('throws "Invalid code" when the code normalizes to empty', async () => {
+    const { result } = renderHook(() => useQuizSessionStudent());
+    await expect(
+      result.current.joinQuizSession('  !!  ', '1234')
+    ).rejects.toThrow('Invalid code');
+  });
+
+  it('throws "PIN is required" when the PIN is only whitespace', async () => {
+    const { result } = renderHook(() => useQuizSessionStudent());
+    await expect(
+      result.current.joinQuizSession('ABC123', '   ')
+    ).rejects.toThrow('PIN is required');
+  });
+
+  it('throws a not-found error when no session matches the code', async () => {
+    (
+      firestore.getDocs as unknown as ReturnType<typeof vi.fn>
+    ).mockResolvedValueOnce({ empty: true, docs: [] });
+
+    const { result } = renderHook(() => useQuizSessionStudent());
+    await expect(
+      result.current.joinQuizSession('ABC123', '1234')
+    ).rejects.toThrow('No active quiz found with that code.');
+  });
+
+  it('throws when every matching session is ended', async () => {
+    (
+      firestore.getDocs as unknown as ReturnType<typeof vi.fn>
+    ).mockResolvedValueOnce({
+      empty: false,
+      docs: [buildSessionDoc('ended-1', { status: 'ended' })],
+    });
+
+    const { result } = renderHook(() => useQuizSessionStudent());
+    await expect(
+      result.current.joinQuizSession('ABC123', '1234')
+    ).rejects.toThrow('This quiz session has already ended.');
+  });
+
+  it('prefers the most recently started joinable session and creates a response doc', async () => {
+    (
+      firestore.getDocs as unknown as ReturnType<typeof vi.fn>
+    ).mockResolvedValueOnce({
+      empty: false,
+      docs: [
+        buildSessionDoc('old', { status: 'active', startedAt: 100 }),
+        buildSessionDoc('new', { status: 'waiting', startedAt: 999 }),
+      ],
+    });
+    (
+      firestore.getDoc as unknown as ReturnType<typeof vi.fn>
+    ).mockResolvedValueOnce({ exists: () => false });
+    const setDocMock = firestore.setDoc as unknown as ReturnType<typeof vi.fn>;
+    setDocMock.mockResolvedValueOnce(undefined);
+
+    const { result } = renderHook(() => useQuizSessionStudent());
+    let sessionId = '';
+    await act(async () => {
+      sessionId = await result.current.joinQuizSession('abc-123', '1234');
+    });
+    expect(sessionId).toBe('new');
+    expect(setDocMock).toHaveBeenCalledTimes(1);
+    const writtenResponse = setDocMock.mock.calls[0][1] as {
+      pin: string;
+      studentUid: string;
+      status: string;
+    };
+    expect(writtenResponse.pin).toBe('1234');
+    expect(writtenResponse.studentUid).toBe('student-uid-1');
+    expect(writtenResponse.status).toBe('joined');
+  });
+
+  it('truncates an over-long PIN to 10 characters before writing', async () => {
+    (
+      firestore.getDocs as unknown as ReturnType<typeof vi.fn>
+    ).mockResolvedValueOnce({
+      empty: false,
+      docs: [buildSessionDoc('s1', { status: 'waiting' })],
+    });
+    (
+      firestore.getDoc as unknown as ReturnType<typeof vi.fn>
+    ).mockResolvedValueOnce({ exists: () => false });
+    const setDocMock = firestore.setDoc as unknown as ReturnType<typeof vi.fn>;
+    setDocMock.mockResolvedValueOnce(undefined);
+
+    const { result } = renderHook(() => useQuizSessionStudent());
+    await act(async () => {
+      await result.current.joinQuizSession('ABC123', '123456789012345');
+    });
+    const writtenResponse = setDocMock.mock.calls[0][1] as { pin: string };
+    expect(writtenResponse.pin).toBe('1234567890');
+    expect(writtenResponse.pin.length).toBe(10);
+  });
+
+  it('normalizes the code by stripping non-alphanumerics and uppercasing before querying', async () => {
+    (
+      firestore.getDocs as unknown as ReturnType<typeof vi.fn>
+    ).mockResolvedValueOnce({
+      empty: false,
+      docs: [buildSessionDoc('s1', { status: 'waiting' })],
+    });
+    (
+      firestore.getDoc as unknown as ReturnType<typeof vi.fn>
+    ).mockResolvedValueOnce({ exists: () => false });
+    (
+      firestore.setDoc as unknown as ReturnType<typeof vi.fn>
+    ).mockResolvedValueOnce(undefined);
+
+    const { result } = renderHook(() => useQuizSessionStudent());
+    await act(async () => {
+      await result.current.joinQuizSession('  abc-123!!  ', '1234');
+    });
+
+    const whereCalls = (firestore.where as unknown as ReturnType<typeof vi.fn>)
+      .mock.calls;
+    const codeEqualsCall = whereCalls.find(
+      (args) => args[0] === 'code' && args[1] === '=='
+    );
+    expect(codeEqualsCall).toBeDefined();
+    expect(codeEqualsCall?.[2]).toBe('ABC123');
+  });
+
+  it('backfills classPeriod on an existing response when it changed', async () => {
+    (
+      firestore.getDocs as unknown as ReturnType<typeof vi.fn>
+    ).mockResolvedValueOnce({
+      empty: false,
+      docs: [buildSessionDoc('s1', { status: 'active' })],
+    });
+    (
+      firestore.getDoc as unknown as ReturnType<typeof vi.fn>
+    ).mockResolvedValueOnce({
+      exists: () => true,
+      data: () => ({ classPeriod: 'Period 1' }),
+    });
+    const updateDocMock = firestore.updateDoc as unknown as ReturnType<
+      typeof vi.fn
+    >;
+    updateDocMock.mockResolvedValueOnce(undefined);
+    const setDocMock = firestore.setDoc as unknown as ReturnType<typeof vi.fn>;
+
+    const { result } = renderHook(() => useQuizSessionStudent());
+    await act(async () => {
+      await result.current.joinQuizSession('ABC123', '1234', 'Period 2');
+    });
+    expect(setDocMock).not.toHaveBeenCalled();
+    expect(updateDocMock).toHaveBeenCalledTimes(1);
+    expect(updateDocMock.mock.calls[0][1]).toEqual({ classPeriod: 'Period 2' });
+  });
+});


### PR DESCRIPTION
## Summary

Automated audit + action run — Wednesday 2026-04-22.

### Action — useQuizSession test coverage (test-coverage HIGH)

Selected the highest-priority Open item: **HIGH `hooks/` coverage — session hooks still missing tests** from `docs/scheduled-tasks/test-coverage.md`. The fix guidance explicitly named `useQuizSession.ts` as the next priority after `useLiveSession.ts`.

Added `tests/hooks/useQuizSession.test.ts` — 24 new tests:

- **Pure helpers** (no mocks): `normalizeAnswer`; `gradeAnswer` for MC / FIB / Matching / Ordering; `toPublicQuestion` verifies `correctAnswer` is stripped for each question type and that empty MC distractors are filtered.
- **`useQuizSessionStudent.lookupSession`**: empty-normalized-code, no-match, all-ended, and most-recent-joinable-session picker.
- **`useQuizSessionStudent.joinQuizSession`**: invalid code, empty PIN, no session, all-ended, most-recent joinable selection, PIN truncation to 10 chars, code normalization (uppercase + alphanumerics only), and `classPeriod` backfill on an existing response doc.

Journal updated to record the 2026-04-22 progress and note that teacher-side flows (`useQuizSessionTeacher`: advance / end / reveal / remove-student / auto-progress) remain open.

### Audits (docs only)

**Daily audits (all 3 — no new issues):**
- Widget Registry: no new gaps; 5 existing LOW issues remain open
- CSS Scaling: no new violations; 4 existing MEDIUM/LOW issues remain open
- TypeScript & ESLint: clean (0 errors, 0 warnings); test suite grew to 1,393 tests across 151 files

**Weekly AUDIT A — Test Coverage + Firestore Rules:**
- Test coverage: utils gap improved 31→28 untested (`ai.ts`, `ai_security.ts`, `classlinkService.ts` gained tests); widget count updated to 58; hooks gaps unchanged (this PR now adds `useQuizSession`)
- Firestore rules: `admin_audit_log` HIGH severity gap persists; no new gaps found

**Weekly AUDIT C — Code Structure + UI Unification:**
- Code structure: `DashboardContext.tsx` grew 229 lines to 3,394 in 7 days (severity upgraded); `functions/src/index.ts` at 2,488 lines; Cloud Functions v1→v2 issue **closed** (already using v2)
- UI Unification: no new issues; 5 existing open items confirmed

## Test plan

- [x] `pnpm vitest run tests/hooks/useQuizSession.test.ts` — 24 passed
- [x] `pnpm type-check` — clean
- [x] `pnpm lint --max-warnings 0` — clean
- [x] `pnpm prettier --check tests/hooks/useQuizSession.test.ts` — clean
- [ ] Verify CI runs the full suite (previously 1,393 tests; now 1,417 with the 24 new tests)

https://claude.ai/code/session_01C6mi6khtn3cpENsRKKuM4A