### PR TITLE
feat(student-sso): admin-managed mock classes for PII-free testing

### DIFF
--- a/components/widgets/MiniApp/Widget.tsx
+++ b/components/widgets/MiniApp/Widget.tsx
@@ -30,6 +30,7 @@ import { useFolders } from '@/hooks/useFolders';
 import {
   collection,
   doc,
+  getDocs,
   setDoc,
   deleteDoc,
   writeBatch,
@@ -266,7 +267,7 @@ export const MiniAppWidget: React.FC<WidgetComponentProps> = ({
   studentPin,
 }) => {
   const { updateWidget, addToast } = useDashboard();
-  const { user } = useAuth();
+  const { user, isAdmin, orgId } = useAuth();
   const { showConfirm } = useDialog();
   const config = (widget.config ?? {}) as MiniAppConfig;
   const activeApp = config.activeApp ?? null;
@@ -372,20 +373,41 @@ export const MiniAppWidget: React.FC<WidgetComponentProps> = ({
   useEffect(() => {
     let cancelled = false;
     void (async () => {
-      try {
-        const data = await classLinkService.getRosters();
-        if (cancelled) return;
-        setClassLinkClasses(data.classes);
-      } catch (err) {
-        if (import.meta.env.DEV) {
-          console.warn('[MiniAppWidget] ClassLink fetch failed:', err);
-        }
+      const [rosterResult, testClassesResult] = await Promise.allSettled([
+        classLinkService.getRosters(),
+        isAdmin && orgId
+          ? getDocs(collection(db, `organizations/${orgId}/testClasses`))
+          : Promise.resolve(null),
+      ]);
+      if (cancelled) return;
+
+      const classLinkList: ClassLinkClass[] =
+        rosterResult.status === 'fulfilled' ? rosterResult.value.classes : [];
+      if (rosterResult.status === 'rejected' && import.meta.env.DEV) {
+        console.warn(
+          '[MiniAppWidget] ClassLink fetch failed:',
+          rosterResult.reason
+        );
       }
+
+      const testList: ClassLinkClass[] =
+        testClassesResult.status === 'fulfilled' && testClassesResult.value
+          ? testClassesResult.value.docs.map((d) => {
+              const data = d.data() as { title?: string; subject?: string };
+              return {
+                sourcedId: d.id,
+                title: `${data.title ?? d.id} (test)`,
+                subject: data.subject,
+              };
+            })
+          : [];
+
+      setClassLinkClasses([...classLinkList, ...testList]);
     })();
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [isAdmin, orgId]);
 
   const buildDefaultAssignmentName = (appTitle: string) => {
     const formatted = new Date().toLocaleString([], {

--- a/components/widgets/MiniApp/Widget.tsx
+++ b/components/widgets/MiniApp/Widget.tsx
@@ -1,4 +1,10 @@
-import React, { useState, useRef, useEffect, useCallback } from 'react';
+import React, {
+  useState,
+  useRef,
+  useEffect,
+  useCallback,
+  useMemo,
+} from 'react';
 import { useDashboard } from '@/context/useDashboard';
 import {
   MiniAppItem,
@@ -267,7 +273,21 @@ export const MiniAppWidget: React.FC<WidgetComponentProps> = ({
   studentPin,
 }) => {
   const { updateWidget, addToast } = useDashboard();
-  const { user, isAdmin, orgId } = useAuth();
+  const { user, userRoles, orgId, roleId } = useAuth();
+  // Gate testClasses read on the same role check the Firestore rules enforce
+  // (`isSuperAdmin() || isDomainAdmin(orgId)`) rather than the legacy
+  // `/admins/` membership flag. Building admins appear in `/admins/` in some
+  // deployments — querying on that flag would trigger a permission-denied
+  // round-trip for them. See `resolveActorRole` in OrganizationPanel for the
+  // reference pattern.
+  const canReadTestClasses = Boolean(
+    (user?.email &&
+      userRoles?.superAdmins?.some(
+        (e) => e.toLowerCase() === user.email?.toLowerCase()
+      )) ||
+    roleId === 'super_admin' ||
+    roleId === 'domain_admin'
+  );
   const { showConfirm } = useDialog();
   const config = (widget.config ?? {}) as MiniAppConfig;
   const activeApp = config.activeApp ?? null;
@@ -370,51 +390,69 @@ export const MiniAppWidget: React.FC<WidgetComponentProps> = ({
   const [classLinkClasses, setClassLinkClasses] = useState<ClassLinkClass[]>(
     []
   );
+  const [testClasses, setTestClasses] = useState<ClassLinkClass[]>([]);
+
+  // ClassLink roster fetch runs once per mount and does not depend on admin
+  // state — splitting it from the test-class fetch avoids re-issuing the
+  // ClassLink request when `roleId` hydrates from null.
   useEffect(() => {
     let cancelled = false;
     void (async () => {
-      // Test-class fetch is gated on `isAdmin && orgId`. Super admins are
-      // seeded as `/organizations/{orgId}/members` with roleId 'super_admin'
-      // by the Phase 1 migration, so their `orgId` is populated through the
-      // same member-doc path as domain admins — this check does not exclude
-      // them in practice. Skipping the read when orgId is null is correct:
-      // testClasses docs live under a specific org, so there is no valid
-      // query to issue without one.
-      const [rosterResult, testClassesResult] = await Promise.allSettled([
-        classLinkService.getRosters(),
-        isAdmin && orgId
-          ? getDocs(collection(db, `organizations/${orgId}/testClasses`))
-          : Promise.resolve(null),
-      ]);
-      if (cancelled) return;
-
-      const classLinkList: ClassLinkClass[] =
-        rosterResult.status === 'fulfilled' ? rosterResult.value.classes : [];
-      if (rosterResult.status === 'rejected' && import.meta.env.DEV) {
-        console.warn(
-          '[MiniAppWidget] ClassLink fetch failed:',
-          rosterResult.reason
-        );
+      try {
+        const data = await classLinkService.getRosters();
+        if (cancelled) return;
+        setClassLinkClasses(data.classes);
+      } catch (err) {
+        if (import.meta.env.DEV) {
+          console.warn('[MiniAppWidget] ClassLink fetch failed:', err);
+        }
       }
-
-      const testList: ClassLinkClass[] =
-        testClassesResult.status === 'fulfilled' && testClassesResult.value
-          ? testClassesResult.value.docs.map((d) => {
-              const data = d.data() as { title?: string; subject?: string };
-              return {
-                sourcedId: d.id,
-                title: `${data.title ?? d.id} (test)`,
-                subject: data.subject,
-              };
-            })
-          : [];
-
-      setClassLinkClasses([...classLinkList, ...testList]);
     })();
     return () => {
       cancelled = true;
     };
-  }, [isAdmin, orgId]);
+  }, []);
+
+  // Test-class fetch is gated on the same role check Firestore rules use.
+  // Skipped when orgId is null — testClasses docs live under a specific org,
+  // so there is no valid query to issue without one.
+  useEffect(() => {
+    if (!canReadTestClasses || !orgId) {
+      setTestClasses([]);
+      return;
+    }
+    let cancelled = false;
+    void (async () => {
+      try {
+        const snap = await getDocs(
+          collection(db, `organizations/${orgId}/testClasses`)
+        );
+        if (cancelled) return;
+        setTestClasses(
+          snap.docs.map((d) => {
+            const data = d.data() as { title?: string; subject?: string };
+            return {
+              sourcedId: d.id,
+              title: `${data.title ?? d.id} (test)`,
+              subject: data.subject,
+            };
+          })
+        );
+      } catch (err) {
+        if (import.meta.env.DEV) {
+          console.warn('[MiniAppWidget] testClasses fetch failed:', err);
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [canReadTestClasses, orgId]);
+
+  const mergedClassList = useMemo(
+    () => [...classLinkClasses, ...testClasses],
+    [classLinkClasses, testClasses]
+  );
 
   const buildDefaultAssignmentName = (appTitle: string) => {
     const formatted = new Date().toLocaleString([], {
@@ -470,7 +508,7 @@ export const MiniAppWidget: React.FC<WidgetComponentProps> = ({
       // removed from the roster. Only forward a classId we can still see.
       const resolvedClassId =
         assignTargetClassId &&
-        classLinkClasses.some((c) => c.sourcedId === assignTargetClassId)
+        mergedClassList.some((c) => c.sourcedId === assignTargetClassId)
           ? assignTargetClassId
           : undefined;
       const sessionId = await createSession(
@@ -941,7 +979,7 @@ export const MiniAppWidget: React.FC<WidgetComponentProps> = ({
                 isCreating={isCreatingSession}
                 createdSessionId={createdSessionId}
                 error={assignError}
-                classLinkClasses={classLinkClasses}
+                classLinkClasses={mergedClassList}
                 selectedClassId={assignTargetClassId}
                 onClassIdChange={setAssignTargetClassId}
                 onConfirm={() => void handleConfirmAssign()}
@@ -1050,7 +1088,7 @@ export const MiniAppWidget: React.FC<WidgetComponentProps> = ({
                 isCreating={isCreatingSession}
                 createdSessionId={createdSessionId}
                 error={assignError}
-                classLinkClasses={classLinkClasses}
+                classLinkClasses={mergedClassList}
                 selectedClassId={assignTargetClassId}
                 onClassIdChange={setAssignTargetClassId}
                 onConfirm={() => void handleConfirmAssign()}

--- a/components/widgets/MiniApp/Widget.tsx
+++ b/components/widgets/MiniApp/Widget.tsx
@@ -280,14 +280,16 @@ export const MiniAppWidget: React.FC<WidgetComponentProps> = ({
   // deployments — querying on that flag would trigger a permission-denied
   // round-trip for them. See `resolveActorRole` in OrganizationPanel for the
   // reference pattern.
-  const canReadTestClasses = Boolean(
-    (user?.email &&
-      userRoles?.superAdmins?.some(
-        (e) => e.toLowerCase() === user.email?.toLowerCase()
-      )) ||
-    roleId === 'super_admin' ||
-    roleId === 'domain_admin'
+  const isSuperAdminByEmail = Boolean(
+    user?.email &&
+    userRoles?.superAdmins?.some(
+      (e) => e.toLowerCase() === user.email?.toLowerCase()
+    )
   );
+  const canReadTestClasses =
+    isSuperAdminByEmail ||
+    roleId === 'super_admin' ||
+    roleId === 'domain_admin';
   const { showConfirm } = useDialog();
   const config = (widget.config ?? {}) as MiniAppConfig;
   const activeApp = config.activeApp ?? null;

--- a/components/widgets/MiniApp/Widget.tsx
+++ b/components/widgets/MiniApp/Widget.tsx
@@ -373,6 +373,13 @@ export const MiniAppWidget: React.FC<WidgetComponentProps> = ({
   useEffect(() => {
     let cancelled = false;
     void (async () => {
+      // Test-class fetch is gated on `isAdmin && orgId`. Super admins are
+      // seeded as `/organizations/{orgId}/members` with roleId 'super_admin'
+      // by the Phase 1 migration, so their `orgId` is populated through the
+      // same member-doc path as domain admins — this check does not exclude
+      // them in practice. Skipping the read when orgId is null is correct:
+      // testClasses docs live under a specific org, so there is no valid
+      // query to issue without one.
       const [rosterResult, testClassesResult] = await Promise.allSettled([
         classLinkService.getRosters(),
         isAdmin && orgId

--- a/firestore.rules
+++ b/firestore.rules
@@ -321,6 +321,15 @@ service cloud.firestore {
         // from the client — Cloud Functions own this collection.
         allow read, write: if false; // TODO(phase-4)
       }
+
+      // Mock classes for PII-free student SSO testing. Admin-managed allowlist
+      // that the `studentLoginV1` function (Admin SDK, bypasses rules) reads
+      // to mint a custom token without calling OneRoster, and that the teacher
+      // assignment class pickers read to expose test targets. Invisible to
+      // non-admin teachers.
+      match /testClasses/{classId} {
+        allow read, write: if isSuperAdmin() || isDomainAdmin(orgId);
+      }
     }
 
     // Admins collection

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -2705,9 +2705,9 @@ export const studentLoginV1 = onCall(
       .limit(STUDENT_LOGIN_CLASS_IDS_MAX)
       .get();
     if (!testClassSnap.empty) {
-      const mockClassIds = testClassSnap.docs
-        .map((d) => d.id)
-        .slice(0, STUDENT_LOGIN_CLASS_IDS_MAX);
+      // Query is already bounded by `.limit(STUDENT_LOGIN_CLASS_IDS_MAX)` —
+      // no secondary slice needed.
+      const mockClassIds = testClassSnap.docs.map((d) => d.id);
       // Monitoring counter — surface any prod use of the bypass.
       console.warn('[studentLoginV1] test_bypass_used', { orgId });
       const uid = computeStudentUid(`test:${emailLower}`, hmacSecret);

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -2691,6 +2691,42 @@ export const studentLoginV1 = onCall(
       );
     }
 
+    // 2.5 Mock-class bypass. Admin-managed `testClasses` docs let us exercise
+    //     the end-to-end student SSO flow without provisioning the student in
+    //     ClassLink/OneRoster. If the email matches at least one testClasses
+    //     doc under this org, we short-circuit and mint a custom token whose
+    //     `classIds` are the testClasses doc ids — no OneRoster call is made.
+    //     Test uids are namespaced (`test:email`) so they never collide with
+    //     real OneRoster `sourcedId`-derived uids.
+    const emailLower = email.toLowerCase();
+    const testClassSnap = await db
+      .collection(`organizations/${orgId}/testClasses`)
+      .where('memberEmails', 'array-contains', emailLower)
+      .limit(STUDENT_LOGIN_CLASS_IDS_MAX)
+      .get();
+    if (!testClassSnap.empty) {
+      const mockClassIds = testClassSnap.docs
+        .map((d) => d.id)
+        .slice(0, STUDENT_LOGIN_CLASS_IDS_MAX);
+      // Monitoring counter — surface any prod use of the bypass.
+      console.warn('[studentLoginV1] test_bypass_used', { orgId });
+      const uid = computeStudentUid(`test:${emailLower}`, hmacSecret);
+      try {
+        const customToken = await admin.auth().createCustomToken(uid, {
+          studentRole: true,
+          orgId,
+          classIds: mockClassIds,
+        });
+        return { customToken, orgId, classCount: mockClassIds.length };
+      } catch (err) {
+        console.error(
+          '[studentLoginV1] createCustomToken failed (test bypass):',
+          err
+        );
+        throw new HttpsError('internal', 'Failed to mint auth token.');
+      }
+    }
+
     // 3. ClassLink OneRoster lookup — fetch the student's sourcedId and
     //    classes. Held in memory only, never written to Firestore.
     const cleanTenantUrl = tenantUrl.replace(/\/$/, '');

--- a/scripts/add-test-class.js
+++ b/scripts/add-test-class.js
@@ -1,0 +1,177 @@
+/**
+ * Seed/delete a "mock class" for PII-free student SSO testing.
+ *
+ * Writes to `/organizations/{orgId}/testClasses/{classId}`. The student login
+ * Cloud Function (studentLoginV1) reads this subcollection as an allowlist
+ * bypass of ClassLink/OneRoster, and admin-facing teacher class pickers merge
+ * it into their options so test assignments can target mock classes.
+ *
+ * Usage:
+ *   node scripts/add-test-class.js \
+ *     --org <orgId> \
+ *     --classId <classId> \
+ *     --title "Mock Period 1 (Paul QA)" \
+ *     [--subject Math] \
+ *     --emails a@school.org,b@school.org
+ *
+ *   node scripts/add-test-class.js --org <orgId> --classId <classId> --delete
+ *
+ * Credentials resolution (same as scripts/setup-organization.js):
+ *   1. FIREBASE_SERVICE_ACCOUNT env var (JSON) — used by CI
+ *   2. scripts/service-account-key.json — used by local dev
+ *   3. GOOGLE_APPLICATION_CREDENTIALS → Application Default Credentials
+ */
+
+import { initializeApp, applicationDefault, cert } from 'firebase-admin/app';
+import { getFirestore, FieldValue } from 'firebase-admin/firestore';
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+function parseArgs(argv) {
+  const args = { emails: [] };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    const next = () => argv[++i];
+    switch (a) {
+      case '--org':
+        args.org = next();
+        break;
+      case '--classId':
+        args.classId = next();
+        break;
+      case '--title':
+        args.title = next();
+        break;
+      case '--subject':
+        args.subject = next();
+        break;
+      case '--emails':
+        args.emails = next()
+          .split(',')
+          .map((e) => e.trim().toLowerCase())
+          .filter(Boolean);
+        break;
+      case '--createdBy':
+        args.createdBy = next();
+        break;
+      case '--delete':
+        args.delete = true;
+        break;
+      case '--help':
+      case '-h':
+        args.help = true;
+        break;
+      default:
+        throw new Error(`Unknown arg: ${a}`);
+    }
+  }
+  return args;
+}
+
+function loadCredentials() {
+  const envJson = process.env.FIREBASE_SERVICE_ACCOUNT;
+  if (envJson) {
+    try {
+      return {
+        source: 'FIREBASE_SERVICE_ACCOUNT env',
+        creds: JSON.parse(envJson),
+        useApplicationDefault: false,
+      };
+    } catch (e) {
+      throw new Error(
+        `Failed to parse FIREBASE_SERVICE_ACCOUNT env var as JSON: ${e.message}`
+      );
+    }
+  }
+  const path = join(__dirname, 'service-account-key.json');
+  try {
+    return {
+      source: 'scripts/service-account-key.json',
+      creds: JSON.parse(readFileSync(path, 'utf8')),
+      useApplicationDefault: false,
+    };
+  } catch {
+    // Fall through to ADC.
+  }
+  if (process.env.GOOGLE_APPLICATION_CREDENTIALS) {
+    return {
+      source: `GOOGLE_APPLICATION_CREDENTIALS=${process.env.GOOGLE_APPLICATION_CREDENTIALS}`,
+      creds: null,
+      useApplicationDefault: true,
+    };
+  }
+  throw new Error(
+    'Firebase Admin credentials not found. Options:\n' +
+      '  1. Set FIREBASE_SERVICE_ACCOUNT env var (JSON)\n' +
+      '  2. Save a service account key at scripts/service-account-key.json\n' +
+      '  3. Set GOOGLE_APPLICATION_CREDENTIALS to a credentials file'
+  );
+}
+
+async function run() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    console.log(
+      'Usage:\n' +
+        '  node scripts/add-test-class.js --org <orgId> --classId <classId> \\\n' +
+        '    --title "Mock Period 1" --emails a@x.org,b@x.org [--subject Math]\n' +
+        '  node scripts/add-test-class.js --org <orgId> --classId <classId> --delete'
+    );
+    process.exit(0);
+  }
+  if (!args.org || !args.classId) {
+    throw new Error('Missing required --org and/or --classId flag.');
+  }
+
+  const { source, creds, useApplicationDefault } = loadCredentials();
+  console.log(`✅ Using credentials from ${source}`);
+
+  initializeApp({
+    credential: useApplicationDefault ? applicationDefault() : cert(creds),
+    ...(useApplicationDefault && process.env.FIREBASE_PROJECT_ID
+      ? { projectId: process.env.FIREBASE_PROJECT_ID }
+      : {}),
+  });
+  const db = getFirestore();
+  const ref = db.doc(`organizations/${args.org}/testClasses/${args.classId}`);
+
+  if (args.delete) {
+    await ref.delete();
+    console.log(
+      `🗑️  Deleted organizations/${args.org}/testClasses/${args.classId}`
+    );
+    return;
+  }
+
+  if (!args.title) {
+    throw new Error('Missing --title (required when not deleting).');
+  }
+  if (args.emails.length === 0) {
+    throw new Error(
+      'Missing --emails (comma-separated, required when not deleting).'
+    );
+  }
+
+  const payload = {
+    title: args.title,
+    memberEmails: args.emails,
+    createdAt: FieldValue.serverTimestamp(),
+    createdBy: args.createdBy ?? 'script:add-test-class',
+  };
+  if (args.subject) payload.subject = args.subject;
+
+  await ref.set(payload, { merge: true });
+  console.log(
+    `✅ Wrote organizations/${args.org}/testClasses/${args.classId} ` +
+      `(${args.emails.length} member email${args.emails.length === 1 ? '' : 's'})`
+  );
+}
+
+run().catch((err) => {
+  console.error('❌', err.message);
+  process.exit(1);
+});

--- a/scripts/add-test-class.js
+++ b/scripts/add-test-class.js
@@ -35,28 +35,37 @@ function parseArgs(argv) {
   const args = { emails: [] };
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i];
-    const next = () => argv[++i];
+    // Takes the value immediately following `flag`. Rejects a missing value
+    // or one that looks like another flag so misuse crashes with a clear
+    // message instead of silently consuming the next flag as a value.
+    const requireValue = (flag) => {
+      const v = argv[++i];
+      if (v === undefined || v.startsWith('--')) {
+        throw new Error(`Missing value for ${flag}`);
+      }
+      return v;
+    };
     switch (a) {
       case '--org':
-        args.org = next();
+        args.org = requireValue(a);
         break;
       case '--classId':
-        args.classId = next();
+        args.classId = requireValue(a);
         break;
       case '--title':
-        args.title = next();
+        args.title = requireValue(a);
         break;
       case '--subject':
-        args.subject = next();
+        args.subject = requireValue(a);
         break;
       case '--emails':
-        args.emails = next()
+        args.emails = requireValue(a)
           .split(',')
           .map((e) => e.trim().toLowerCase())
           .filter(Boolean);
         break;
       case '--createdBy':
-        args.createdBy = next();
+        args.createdBy = requireValue(a);
         break;
       case '--delete':
         args.delete = true;

--- a/tests/rules/firestore-rules-organizations.test.ts
+++ b/tests/rules/firestore-rules-organizations.test.ts
@@ -1346,5 +1346,6 @@ describe('organizations/testClasses — admin-only read/write', () => {
       setDoc(doc(asOutsider(), TEST_CLASS_PATH), MOCK_CLASS_DATA)
     );
     await assertFails(getDoc(doc(asAnon(), TEST_CLASS_PATH)));
+    await assertFails(setDoc(doc(asAnon(), TEST_CLASS_PATH), MOCK_CLASS_DATA));
   });
 });

--- a/tests/rules/firestore-rules-organizations.test.ts
+++ b/tests/rules/firestore-rules-organizations.test.ts
@@ -1299,3 +1299,52 @@ describe('no regression on legacy /admins/{email}', () => {
     );
   });
 });
+
+describe('organizations/testClasses — admin-only read/write', () => {
+  // Mock-class allowlist consumed by studentLoginV1 (Admin SDK bypass) and
+  // the admin-gated teacher assignment class pickers. Invisible to non-admin
+  // teachers so it's safe to leave in prod.
+  const TEST_CLASS_PATH = `organizations/${ORG_ID}/testClasses/mock-period-1`;
+  const MOCK_CLASS_DATA = {
+    title: 'Mock Period 1',
+    memberEmails: ['sample-student@orono.k12.mn.us'],
+    createdAt: 0,
+    createdBy: 'test',
+  };
+
+  it('domain admin can read and write testClasses', async () => {
+    await assertSucceeds(
+      setDoc(doc(asDomainAdmin(), TEST_CLASS_PATH), MOCK_CLASS_DATA)
+    );
+    await assertSucceeds(getDoc(doc(asDomainAdmin(), TEST_CLASS_PATH)));
+  });
+
+  it('super admin can read and write testClasses', async () => {
+    await assertSucceeds(
+      setDoc(doc(asSuper(), TEST_CLASS_PATH), MOCK_CLASS_DATA)
+    );
+    await assertSucceeds(getDoc(doc(asSuper(), TEST_CLASS_PATH)));
+  });
+
+  it('building admin cannot read or write testClasses', async () => {
+    await assertFails(getDoc(doc(asBuildingAdmin(), TEST_CLASS_PATH)));
+    await assertFails(
+      setDoc(doc(asBuildingAdmin(), TEST_CLASS_PATH), MOCK_CLASS_DATA)
+    );
+  });
+
+  it('teacher cannot read or write testClasses', async () => {
+    await assertFails(getDoc(doc(asTeacher(), TEST_CLASS_PATH)));
+    await assertFails(
+      setDoc(doc(asTeacher(), TEST_CLASS_PATH), MOCK_CLASS_DATA)
+    );
+  });
+
+  it('outsider and unauthenticated cannot read or write testClasses', async () => {
+    await assertFails(getDoc(doc(asOutsider(), TEST_CLASS_PATH)));
+    await assertFails(
+      setDoc(doc(asOutsider(), TEST_CLASS_PATH), MOCK_CLASS_DATA)
+    );
+    await assertFails(getDoc(doc(asAnon(), TEST_CLASS_PATH)));
+  });
+});


### PR DESCRIPTION
## Summary

Unblocks end-to-end student SSO testing (PR #1376) for admins whose sample students aren't in ClassLink/OneRoster, and who have no ClassLink-provisioned classes of their own (e.g. instructional coaches). Adds an admin-managed Firestore allowlist `/organizations/{orgId}/testClasses/{classId}` that both the student-side Cloud Function and the teacher-side MiniApp class picker consult. The production ClassLink path is untouched.

### Changes

- **`firestore.rules`** — new `testClasses` subcollection under `/organizations/{orgId}`, gated to `isSuperAdmin() || isDomainAdmin(orgId)`.
- **`functions/src/index.ts`** — `studentLoginV1` gains an early-return "step 2.5" bypass: if the authenticated email is listed in any `testClasses` doc under the resolved org, the function mints a custom token whose `classIds` are the matching doc ids — **no OneRoster call is made**. Test uids are namespaced (`test:<email>`) to avoid collision with real `sourcedId`-derived uids. Emits a `test_bypass_used` warn log for monitoring.
- **`components/widgets/MiniApp/Widget.tsx`** — admin-gated parallel read of `testClasses`, merged into the class picker with a `(test)` suffix. Non-admin teachers see only ClassLink classes.
- **`scripts/add-test-class.js`** — CLI seed/delete helper using the Admin SDK.
- **`tests/rules/firestore-rules-organizations.test.ts`** — five new cases covering super admin, domain admin, building admin, teacher, outsider, and anonymous access to `testClasses`.

### Deferred to future PRs

- Teacher class pickers on Quiz / Video Activity / Guided Learning / Activity Wall widgets (same merge pattern). Not blocking for end-to-end SSO test — the function change covers all five session types universally via the `classIds` claim.
- Admin UI panel for managing test classes (currently via script).

## Test plan

- [ ] CI: `type-check`, `lint`, `format:check`, rules tests
- [ ] Deploy to `dev-paul` preview
- [ ] Seed: `node scripts/add-test-class.js --org orono --classId mock-period-1 --title "Mock Period 1 (Paul QA)" --emails <sample-student>@orono.k12.mn.us`
- [ ] Teacher side (as admin): open MiniApp widget → Assign → confirm "Mock Period 1 (test)" appears in class picker; create assignment
- [ ] Student side (incognito sample account): `/student/login` → confirm redirect to `/my-assignments`, assignment appears, submission succeeds
- [ ] Verify function logs show `test_bypass_used` and no ClassLink API call
- [ ] Safety: non-allowlisted @orono email still hits `students_not_in_roster`; non-admin teacher's picker does not include test classes

🤖 Generated with [Claude Code](https://claude.com/claude-code)