### PR TITLE
fix(firestore): add composite index for domains collectionGroup

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -57,6 +57,20 @@
       ]
     },
     {
+      "collectionGroup": "domains",
+      "queryScope": "COLLECTION_GROUP",
+      "fields": [
+        {
+          "fieldPath": "domain",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "status",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
       "collectionGroup": "video_activity_sessions",
       "queryScope": "COLLECTION",
       "fields": [


### PR DESCRIPTION
Root cause of "Roster service is unreachable" on /student/login.

`studentLoginV1` runs `collectionGroup('domains').where('domain','==',X).where('status','==','verified')` for its domain-gate (step 2), which needs a composite index. Without it the callable fails `FAILED_PRECONDITION` and the client shows the generic unavailable message.

Already deployed the index manually via `firebase deploy --only firestore:indexes` to unblock testing; this PR lands the config in git so future `firebase-dev-deploy` / `firebase-deploy` runs carry it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)