### PR TITLE
fix(dock): restore Widget Library when admin override is empty

### DIFF
--- a/components/admin/FeaturePermissionsManager.tsx
+++ b/components/admin/FeaturePermissionsManager.tsx
@@ -269,8 +269,14 @@ export const FeaturePermissionsManager: React.FC = () => {
       currentLevels.includes(l)
     );
 
+    // When toggling "ALL" off, reset to the widget's configured default
+    // rather than writing an empty array. An empty override is ambiguous and
+    // the Dock filter would hide the widget from every user whose buildings
+    // resolve to a non-empty grade set.
     updatePermission(widgetType, {
-      gradeLevels: allSelected ? [] : [...ALL_GRADE_LEVELS],
+      gradeLevels: allSelected
+        ? [...getWidgetGradeLevels(widgetType)]
+        : [...ALL_GRADE_LEVELS],
     });
   };
 

--- a/components/admin/FeaturePermissionsManager.tsx
+++ b/components/admin/FeaturePermissionsManager.tsx
@@ -255,9 +255,17 @@ export const FeaturePermissionsManager: React.FC = () => {
       newLevels = [...currentLevels, level];
     }
 
-    // NOTE: If newLevels is empty, the widget will be hidden from all specific grade filters
-    // but will still be visible when the 'All' filter is selected.
-    updatePermission(widgetType, { gradeLevels: newLevels });
+    // If deselecting the last level would leave an empty array, fall back to the
+    // widget's configured default instead. An empty override is read as "no
+    // override" by matchesUserBuilding, so writing [] here would silently reset
+    // to the default anyway — writing the default explicitly keeps the UI state
+    // consistent with the persisted state and mirrors toggleAllGradeLevels.
+    updatePermission(widgetType, {
+      gradeLevels:
+        newLevels.length > 0
+          ? newLevels
+          : [...getWidgetGradeLevels(widgetType)],
+    });
   };
 
   const toggleAllGradeLevels = (widgetType: WidgetType | InternalToolType) => {

--- a/components/layout/Dock.tsx
+++ b/components/layout/Dock.tsx
@@ -48,7 +48,7 @@ import {
 } from '@/types';
 import { TOOLS } from '@/config/tools';
 import { isLunchCountBuilding } from '@/config/buildings';
-import { getWidgetGradeLevels } from '@/config/widgetGradeLevels';
+import { matchesUserBuilding as matchesUserBuildingLevels } from '@/config/widgetGradeLevels';
 import { AddWidgetOverrides } from '@/types';
 import { getJoinUrl } from '@/utils/urlHelpers';
 import ClassRosterMenu from './ClassRosterMenu';
@@ -172,12 +172,8 @@ export const Dock: React.FC = () => {
    * buildings' grade levels. If no buildings are selected, all widgets match.
    */
   const matchesUserBuilding = useCallback(
-    (type: WidgetType | InternalToolType): boolean => {
-      if (userGradeLevels.length === 0) return true;
-      const permission = featurePermissions.find((p) => p.widgetType === type);
-      const levels = permission?.gradeLevels ?? getWidgetGradeLevels(type);
-      return levels.some((l) => userGradeLevels.includes(l));
-    },
+    (type: WidgetType | InternalToolType): boolean =>
+      matchesUserBuildingLevels(type, userGradeLevels, featurePermissions),
     [userGradeLevels, featurePermissions]
   );
 

--- a/config/widgetGradeLevels.ts
+++ b/config/widgetGradeLevels.ts
@@ -3,6 +3,7 @@ import {
   GradeLevel,
   GradeFilter,
   InternalToolType,
+  FeaturePermission,
 } from '../types';
 
 export const ALL_GRADE_LEVELS: GradeLevel[] = ['k-2', '3-5', '6-8', '9-12'];
@@ -131,6 +132,31 @@ export function getWidgetGradeLevels(
   if (safeLevels.length === 0) return ALL_GRADE_LEVELS;
 
   return safeLevels;
+}
+
+/**
+ * Returns true when a widget should be visible to a user whose buildings
+ * resolve to `userGradeLevels`. Empty `userGradeLevels` means "no building
+ * filter" — all widgets match.
+ *
+ * The admin override in `featurePermissions[].gradeLevels` only narrows
+ * visibility when it is non-empty. An empty array is treated as "no override"
+ * so an accidental deselect-all in Feature Permissions cannot hide a widget
+ * from every user with a non-empty grade set.
+ */
+export function matchesUserBuilding(
+  type: WidgetType | InternalToolType,
+  userGradeLevels: GradeLevel[],
+  featurePermissions: FeaturePermission[]
+): boolean {
+  if (userGradeLevels.length === 0) return true;
+  const permission = featurePermissions.find((p) => p.widgetType === type);
+  const permLevels = permission?.gradeLevels;
+  const levels =
+    permLevels && permLevels.length > 0
+      ? permLevels
+      : getWidgetGradeLevels(type);
+  return levels.some((l) => userGradeLevels.includes(l));
 }
 
 /**

--- a/scripts/fix-empty-feature-permission-gradelevels.js
+++ b/scripts/fix-empty-feature-permission-gradelevels.js
@@ -1,0 +1,187 @@
+/**
+ * One-shot repair for /feature_permissions/{widgetType} docs whose
+ * `gradeLevels` field is an empty array.
+ *
+ * WHY THIS EXISTS
+ *   A bug in FeaturePermissionsManager.toggleAllGradeLevels() previously wrote
+ *   `gradeLevels: []` whenever an admin tapped the "ALL" pill off. The Dock
+ *   filter then treated that empty array as a valid admin override and hid
+ *   the widget from every user whose buildings resolved to a non-empty grade
+ *   set — i.e. the Widget Library showed "No widgets available for your
+ *   buildings". Both the writer and the reader have been fixed, but existing
+ *   docs with `gradeLevels: []` still need to be cleaned up so affected users
+ *   get their widgets back without waiting for an admin to re-toggle.
+ *
+ * WHAT IT DOES
+ *   1. Scans every doc in /feature_permissions.
+ *   2. For any doc where `gradeLevels` is an empty array, removes the field
+ *      via FieldValue.delete() (a missing field is what the Dock now treats
+ *      as "no override"; writing the widget default here would freeze that
+ *      default into Firestore even if the seed changes later).
+ *   3. Leaves non-empty `gradeLevels` arrays and missing fields alone.
+ *
+ * It is safe to re-run. Docs that don't match the pattern are untouched.
+ *
+ * Usage:
+ *   node scripts/fix-empty-feature-permission-gradelevels.js [--dry-run] [--verbose]
+ *
+ * Flags:
+ *   --dry-run   No writes. Log what would change and exit.
+ *   --verbose   Log every doc inspected, not just the ones that change.
+ *
+ * Credentials resolution matches scripts/recount-org-members.js:
+ *   1. FIREBASE_SERVICE_ACCOUNT env var (JSON)
+ *   2. scripts/service-account-key.json
+ *   3. applicationDefault() via GOOGLE_APPLICATION_CREDENTIALS or gcloud ADC
+ */
+
+import { initializeApp, applicationDefault, cert } from 'firebase-admin/app';
+import { getFirestore, FieldValue } from 'firebase-admin/firestore';
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const PROJECT_ID = 'spartboard';
+
+function parseArgs(argv) {
+  const args = { dryRun: false, verbose: false, help: false };
+  for (const a of argv) {
+    if (a === '--dry-run' || a === '-n') args.dryRun = true;
+    else if (a === '--verbose' || a === '-v') args.verbose = true;
+    else if (a === '--help' || a === '-h') args.help = true;
+  }
+  return args;
+}
+
+function printHelp() {
+  console.log(
+    'Usage: node scripts/fix-empty-feature-permission-gradelevels.js [--dry-run] [--verbose]'
+  );
+}
+
+function loadCredentials() {
+  const envJson = process.env.FIREBASE_SERVICE_ACCOUNT;
+  if (envJson) {
+    return {
+      source: 'FIREBASE_SERVICE_ACCOUNT env',
+      creds: JSON.parse(envJson),
+      useApplicationDefault: false,
+    };
+  }
+  const keyPath = join(__dirname, 'service-account-key.json');
+  try {
+    const raw = readFileSync(keyPath, 'utf8');
+    return {
+      source: 'scripts/service-account-key.json',
+      creds: JSON.parse(raw),
+      useApplicationDefault: false,
+    };
+  } catch {
+    // Fall through to ADC.
+  }
+  if (process.env.GOOGLE_APPLICATION_CREDENTIALS) {
+    return {
+      source:
+        'GOOGLE_APPLICATION_CREDENTIALS=' +
+        process.env.GOOGLE_APPLICATION_CREDENTIALS,
+      creds: null,
+      useApplicationDefault: true,
+    };
+  }
+  return {
+    source: 'applicationDefault()',
+    creds: null,
+    useApplicationDefault: true,
+  };
+}
+
+async function run() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    printHelp();
+    process.exit(0);
+  }
+
+  const { source, creds, useApplicationDefault } = loadCredentials();
+  console.log('Using credentials from ' + source);
+
+  const initOpts = {
+    projectId: (creds && creds.project_id) || PROJECT_ID,
+  };
+  if (useApplicationDefault) {
+    initOpts.credential = applicationDefault();
+  } else {
+    initOpts.credential = cert(creds);
+  }
+  initializeApp(initOpts);
+
+  const db = getFirestore();
+  console.log(
+    'Scanning /feature_permissions' +
+      (args.dryRun ? '  [DRY RUN]' : '') +
+      (args.verbose ? '  [verbose]' : '')
+  );
+
+  const snap = await db.collection('feature_permissions').get();
+  console.log('Loaded ' + snap.size + ' feature_permissions docs.');
+
+  const toFix = [];
+  for (const doc of snap.docs) {
+    const data = doc.data() || {};
+    const levels = data.gradeLevels;
+    const isEmptyArray = Array.isArray(levels) && levels.length === 0;
+    if (args.verbose) {
+      console.log(
+        '  ' +
+          doc.id +
+          ': gradeLevels=' +
+          (levels === undefined ? '<missing>' : JSON.stringify(levels)) +
+          (isEmptyArray ? '  -> will clear' : '')
+      );
+    }
+    if (isEmptyArray) toFix.push(doc.id);
+  }
+
+  console.log('');
+  console.log(
+    'Docs with empty gradeLevels arrays: ' +
+      toFix.length +
+      (toFix.length ? ' (' + toFix.join(', ') + ')' : '')
+  );
+
+  if (args.dryRun || toFix.length === 0) {
+    if (args.dryRun) {
+      console.log('');
+      console.log('Dry run only -- no writes were committed.');
+    }
+    process.exit(0);
+  }
+
+  // Firestore batches cap at 500 ops; chunk to stay well clear.
+  const CHUNK = 400;
+  for (let i = 0; i < toFix.length; i += CHUNK) {
+    const batch = db.batch();
+    for (const id of toFix.slice(i, i + CHUNK)) {
+      batch.update(db.doc('feature_permissions/' + id), {
+        gradeLevels: FieldValue.delete(),
+      });
+    }
+    await batch.commit();
+  }
+
+  console.log('');
+  console.log('Cleared gradeLevels on ' + toFix.length + ' doc(s).');
+  process.exit(0);
+}
+
+run().catch((err) => {
+  console.error(
+    '\nfix-empty-feature-permission-gradelevels failed: ' +
+      (err && err.message ? err.message : err)
+  );
+  if (err && err.stack) console.error(err.stack);
+  process.exit(1);
+});

--- a/tests/utils/widgetGradeLevels.matchesUserBuilding.test.ts
+++ b/tests/utils/widgetGradeLevels.matchesUserBuilding.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest';
+import { matchesUserBuilding } from '@/config/widgetGradeLevels';
+import type { FeaturePermission, WidgetType } from '@/types';
+
+const perm = (
+  widgetType: WidgetType,
+  gradeLevels?: FeaturePermission['gradeLevels']
+): FeaturePermission => ({
+  widgetType,
+  accessLevel: 'public',
+  betaUsers: [],
+  enabled: true,
+  gradeLevels,
+});
+
+describe('matchesUserBuilding', () => {
+  it('returns true for any widget when userGradeLevels is empty', () => {
+    // Emulates a teacher with no building selected — filter is inert.
+    expect(matchesUserBuilding('clock', [], [])).toBe(true);
+    expect(matchesUserBuilding('qr', [], [perm('qr', [])])).toBe(true);
+    expect(
+      matchesUserBuilding('traffic', [], [perm('traffic', ['9-12'])])
+    ).toBe(true);
+  });
+
+  it('falls back to the widget default when permission.gradeLevels is empty', () => {
+    // Regression: `permission?.gradeLevels ?? default` used to keep `[]`, which
+    // caused `[].some(...)` to be false and hid the widget from every user.
+    // `clock` defaults to ALL_GRADE_LEVELS, so a 9-12 user should still match.
+    expect(matchesUserBuilding('clock', ['9-12'], [perm('clock', [])])).toBe(
+      true
+    );
+    // `traffic` defaults to ['k-2', '3-5']; a 9-12 user should NOT match the
+    // default, proving the fallback is applied (not an unconditional true).
+    expect(
+      matchesUserBuilding('traffic', ['9-12'], [perm('traffic', [])])
+    ).toBe(false);
+  });
+
+  it('honors a non-empty admin override that intersects userGradeLevels', () => {
+    expect(
+      matchesUserBuilding('clock', ['9-12'], [perm('clock', ['9-12'])])
+    ).toBe(true);
+  });
+
+  it('honors a non-empty admin override that does NOT intersect userGradeLevels', () => {
+    expect(
+      matchesUserBuilding('clock', ['9-12'], [perm('clock', ['k-2'])])
+    ).toBe(false);
+  });
+
+  it('falls back to the widget default when no permission exists for the type', () => {
+    // `qr` defaults to ['6-8', '9-12'].
+    expect(matchesUserBuilding('qr', ['9-12'], [])).toBe(true);
+    expect(matchesUserBuilding('qr', ['k-2'], [])).toBe(false);
+  });
+
+  it('ignores permissions for unrelated widget types', () => {
+    // A permission for `traffic` must not affect the `clock` lookup.
+    expect(
+      matchesUserBuilding('clock', ['9-12'], [perm('traffic', ['k-2'])])
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Fixes the production regression where Dock → `+` (Widget Library) shows **"No widgets available for your buildings"** for teachers whose buildings resolve to a non-empty grade set. Root cause: `permission?.gradeLevels ?? default` kept an empty array, so `[].some(...)` hid every widget. Writer (`toggleAllGradeLevels`) and reader (`matchesUserBuilding`) both patched; existing bad docs cleaned up by a repair script.
- `matchesUserBuilding` extracted from `Dock.tsx` into [config/widgetGradeLevels.ts](config/widgetGradeLevels.ts) as a pure util, so the regression is covered by a unit test instead of a heavy render mock.
- `toggleAllGradeLevels` in [FeaturePermissionsManager.tsx:263](components/admin/FeaturePermissionsManager.tsx:263) now writes the widget's configured default on deselect-all, never `[]`.

## Files
- [config/widgetGradeLevels.ts](config/widgetGradeLevels.ts) — new `matchesUserBuilding(type, userGradeLevels, featurePermissions)` export; empty admin override falls back to widget default.
- [components/layout/Dock.tsx:174](components/layout/Dock.tsx:174) — delegates to the util.
- [components/admin/FeaturePermissionsManager.tsx:263](components/admin/FeaturePermissionsManager.tsx:263) — no longer writes `gradeLevels: []`.
- [tests/utils/widgetGradeLevels.matchesUserBuilding.test.ts](tests/utils/widgetGradeLevels.matchesUserBuilding.test.ts) — 6-case regression suite.
- [scripts/fix-empty-feature-permission-gradelevels.js](scripts/fix-empty-feature-permission-gradelevels.js) — idempotent one-shot; `--dry-run` safe; clears the `gradeLevels` field on any `/feature_permissions/*` doc currently holding `[]` so the new code path falls back to the widget default.

## Test plan
- [x] `pnpm run type-check` — clean
- [x] `npx eslint` on the 4 changed/added TS files — clean
- [x] `pnpm run test` — 1399/1399 pass (incl. the new 6-case suite)
- [ ] Manually verify in preview: sign in as an affected teacher → open Dock `+` → Widget Library populates.
- [ ] Toggle edit mode → same populated set (proves edit-mode path unchanged).
- [ ] Admin → Feature Permissions → narrow one widget to `k-2` only → sign in as 9-12 teacher → that widget is hidden (narrowing path still works).
- [ ] Run `node scripts/fix-empty-feature-permission-gradelevels.js --dry-run --verbose` against prod creds, review planned deletions, then run without `--dry-run`. Re-verify the Library populates without any admin re-toggle.

## Notes
- Unrelated to the open Analytics PRs (#1371, #1375). This is the separate "Issue A" hotfix track.
- The plan targeted a hotfix branch off `main`. Targeting `dev-paul` here per request; once reviewed we can fast-forward / cherry-pick to `main` for the production hotfix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)