### PR TITLE
docs(admin): fill in ClassLink auth secret setup (OAuth client ID + HMAC gen)

### DIFF
--- a/docs/ADMIN_SETUP.md
+++ b/docs/ADMIN_SETUP.md
@@ -123,13 +123,20 @@ UID and a `classIds` claim. No student PII is persisted in Firebase.
 **Secret:** `STUDENT_PSEUDONYM_HMAC_SECRET` (32+ random bytes).
 
 This secret is the keystone of the grading match-back system. Every response
-doc, submission doc, and pseudonym UID is derived from it.
+doc, submission doc, and pseudonym UID is derived from it. Pseudonyms are
+stable within a semester but unlinkable across semesters or without the
+server secret.
 
-**Set on first deploy:**
+**Generate and set on first deploy:**
 
 ```bash
+# Generate a 32-byte random hex string, then paste when prompted.
+openssl rand -hex 32
 firebase functions:secrets:set STUDENT_PSEUDONYM_HMAC_SECRET
 ```
+
+Consumed by `studentLoginV1`, `getAssignmentPseudonymV1`, and
+`getPseudonymsForAssignmentV1` in `functions/src/index.ts`.
 
 **Rotation rules — read before touching:**
 
@@ -143,6 +150,34 @@ firebase functions:secrets:set STUDENT_PSEUDONYM_HMAC_SECRET
   rotate. Implement dual-key verification first: `getPseudonymsForAssignmentV1`
   tries the new key, falls back to the old key for 30 days, then the old key
   is retired. Budget 1–2 days of dev time.
+
+### Google OAuth client ID
+
+**Secret:** `GOOGLE_OAUTH_CLIENT_ID` — the Web-type OAuth 2.0 client ID from
+your Firebase/GCP project. `studentLoginV1` uses it to verify Google ID
+tokens server-side; without it, student login returns an error.
+
+**Where to find it:**
+
+1. [Google Cloud Console](https://console.cloud.google.com) → your Firebase
+   project.
+2. **APIs & Services** → **Credentials**.
+3. Find the OAuth 2.0 Client ID of type "Web application".
+4. Copy the Client ID.
+
+**Set:**
+
+```bash
+firebase functions:secrets:set GOOGLE_OAUTH_CLIENT_ID
+```
+
+**Client-side counterpart:** the same value is exposed to the student login
+page as `VITE_GOOGLE_CLIENT_ID`. Set it in `.env.local` for local dev, and as
+a GitHub Actions repository secret (`secrets.VITE_GOOGLE_CLIENT_ID`) so the
+production and dev-branch deploy workflows bake it into the build. The
+server-side secret and the client-side Vite variable **must be the same
+client ID** — a mismatch produces audience-failure errors in
+`studentLoginV1`.
 
 ### Per-organization domain configuration
 

--- a/docs/ADMIN_SETUP.md
+++ b/docs/ADMIN_SETUP.md
@@ -179,6 +179,47 @@ server-side secret and the client-side Vite variable **must be the same
 client ID** — a mismatch produces audience-failure errors in
 `studentLoginV1`.
 
+### ClassLink OneRoster API credentials
+
+**Secrets:**
+
+- `CLASSLINK_CLIENT_ID`
+- `CLASSLINK_CLIENT_SECRET`
+- `CLASSLINK_TENANT_URL`
+
+These OAuth 1.0a (HMAC-SHA1-signed) credentials let SpartBoard's Cloud
+Functions talk to your district's ClassLink OneRoster API: `studentLoginV1`
+uses them to verify a student's class enrollment at login, and
+`getClassLinkRosterV1` uses them when teachers fetch their roster list.
+Without these, student login throws `internal: ClassLink configuration is
+missing on the server` and teacher roster sync silently returns empty.
+
+**Where to find them:**
+
+1. Log in to your **ClassLink Roster Server** management console.
+2. **Applications** → locate (or have ClassLink provision) the SpartBoard
+   application; copy the **Client ID** and **Client Secret**.
+3. **Tenant URL** is your district's ClassLink OneRoster base host — e.g.
+   `https://<tenantId>.oneroster.classlink.io` (no `/ims/oneroster/v1p1`
+   suffix; the functions append `/ims/oneroster/v1p1/users` and
+   `/ims/oneroster/v1p1/users/{sourcedId}/classes` themselves at
+   `functions/src/index.ts:366` and `:393`). Confirm with ClassLink support
+   if unsure — the wrong base host returns 404 on every call and login
+   silently rejects every student.
+
+**Set:**
+
+```bash
+firebase functions:secrets:set CLASSLINK_CLIENT_ID
+firebase functions:secrets:set CLASSLINK_CLIENT_SECRET
+firebase functions:secrets:set CLASSLINK_TENANT_URL
+```
+
+Consumed by `studentLoginV1` and `getClassLinkRosterV1` in
+`functions/src/index.ts`. Rotation is safe at any time — unlike
+`STUDENT_PSEUDONYM_HMAC_SECRET`, these secrets only authenticate outbound
+API calls and don't derive any persisted IDs.
+
 ### Per-organization domain configuration
 
 Each Organization document in Firestore carries a `domains: string[]` field.


### PR DESCRIPTION
## Summary

- Adds the missing `GOOGLE_OAUTH_CLIENT_ID` secret section — this secret is defined in [functions/src/index.ts:38](functions/src/index.ts#L38) and required by `studentLoginV1`, but `docs/ADMIN_SETUP.md` never documented how to set it. First-deploy setup would fail without reading source.
- Folds in an `openssl rand -hex 32` generate command next to the `STUDENT_PSEUDONYM_HMAC_SECRET` set command so the whole first-run flow is visible in one place.
- Name-drops which functions consume the HMAC secret (`studentLoginV1`, `getAssignmentPseudonymV1`, `getPseudonymsForAssignmentV1`).
- Calls out that the server-side `GOOGLE_OAUTH_CLIENT_ID` must match the client-side `VITE_GOOGLE_CLIENT_ID` — a mismatch produces audience-failure errors.

## Context

Recovered from uncommitted work on a stale `wave3-b-2-folder-wiring` local branch. The feature-code parts of that branch had already landed on dev-paul in more-evolved form, but these documentation additions hadn't. The operational content already on dev-paul (rotation rules, per-org domain config, Cloud Monitoring alerts, cold-start mitigation) is unchanged.

## Test plan

- [ ] Walk through the ClassLink auth section as a fresh admin and confirm both secrets can be set without consulting the source code.
- [ ] Verify `openssl rand -hex 32` produces output the `firebase functions:secrets:set` prompt accepts.
- [ ] Confirm the referenced function names still exist in `functions/src/index.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)