### PR TITLE
fix: converge legacy and canonical building IDs across user data

### DIFF
--- a/components/admin/Analytics/AnalyticsManager.tsx
+++ b/components/admin/Analytics/AnalyticsManager.tsx
@@ -36,7 +36,11 @@ import {
 import { Modal } from '@/components/common/Modal';
 import { useAdminBuildings } from '@/hooks/useAdminBuildings';
 import { useAuth } from '@/context/useAuth';
-import type { Building } from '@/config/buildings';
+import {
+  canonicalBuildingId,
+  canonicalizeBuildingIds,
+  type Building,
+} from '@/config/buildings';
 import { TOOLS } from '@/config/tools';
 
 interface EngagementCounts {
@@ -110,14 +114,70 @@ const WIDGET_LABELS: Record<string, string> = TOOLS.reduce(
   {} as Record<string, string>
 );
 
+/**
+ * Folds a record keyed by raw building IDs into a record keyed by canonical
+ * IDs, summing {@link EngagementCounts} when legacy + canonical entries
+ * collide (e.g. `orono-high-school` and `high` both pointed at the same
+ * building). Preserves the special `none` bucket verbatim.
+ *
+ * Done once at the analytics load step so every downstream
+ * chart/table/dropdown sees a single bucket per building rather than a
+ * legacy/canonical pair that would render as two rows or a duplicate
+ * dropdown option.
+ */
+function foldBuildingsByCanonical(
+  buckets: Record<string, EngagementCounts>
+): Record<string, EngagementCounts> {
+  const out: Record<string, EngagementCounts> = {};
+  for (const [rawId, counts] of Object.entries(buckets)) {
+    const id = rawId === 'none' ? 'none' : canonicalBuildingId(rawId);
+    const existing = out[id];
+    if (existing) {
+      out[id] = {
+        total: existing.total + counts.total,
+        monthly: existing.monthly + counts.monthly,
+        daily: existing.daily + counts.daily,
+      };
+    } else {
+      out[id] = { ...counts };
+    }
+  }
+  return out;
+}
+
+/**
+ * Same fold applied to the `domainBuilding` two-level record so per-domain
+ * building breakdowns also collapse legacy + canonical IDs.
+ */
+function foldDomainBuildingsByCanonical(
+  buckets: Record<string, Record<string, EngagementCounts>>
+): Record<string, Record<string, EngagementCounts>> {
+  const out: Record<string, Record<string, EngagementCounts>> = {};
+  for (const [domain, inner] of Object.entries(buckets)) {
+    out[domain] = foldBuildingsByCanonical(inner);
+  }
+  return out;
+}
+
 // `KNOWN_BUILDINGS` is re-derived per component from `useAdminBuildings()`
-// below so analytics labels reflect the org's live building list.
-const useKnownBuildings = (): Map<string, Building> => {
+// below so analytics labels reflect the org's live building list. The
+// returned map exposes a `lookup` helper that normalizes legacy long-form
+// IDs (e.g. `orono-high-school`) to their canonical short forms (`high`)
+// before lookup, so user data written before the Organization buildings
+// panel shipped still resolves to the correct building name instead of
+// rendering as `Unknown (orono-high-school)`.
+interface KnownBuildingLookup {
+  /** Resolve an ID (legacy or canonical) to its `Building`, or undefined. */
+  lookup(id: string): Building | undefined;
+}
+const useKnownBuildings = (): KnownBuildingLookup => {
   const buildings = useAdminBuildings();
-  return React.useMemo(
-    () => new Map(buildings.map((b) => [b.id, b])),
-    [buildings]
-  );
+  return React.useMemo<KnownBuildingLookup>(() => {
+    const byId = new Map(buildings.map((b) => [b.id, b]));
+    return {
+      lookup: (id: string) => byId.get(canonicalBuildingId(id)),
+    };
+  }, [buildings]);
 };
 const _CHART_COLORS = [
   '#2d3f89',
@@ -918,7 +978,7 @@ const UsersPanel: React.FC<{ data: AnalyticsData }> = ({ data }) => {
           name:
             id === 'none'
               ? 'No Building Assigned'
-              : (KNOWN_BUILDINGS.get(id)?.name ?? `Unknown (${id})`),
+              : (KNOWN_BUILDINGS.lookup(id)?.name ?? `Unknown (${id})`),
           ...counts,
           monthlyRate:
             counts.total > 0 ? (counts.monthly / counts.total) * 100 : 0,
@@ -935,7 +995,7 @@ const UsersPanel: React.FC<{ data: AnalyticsData }> = ({ data }) => {
           name:
             id === 'none'
               ? 'No Building Assigned'
-              : (KNOWN_BUILDINGS.get(id)?.name ?? `Unknown (${id})`),
+              : (KNOWN_BUILDINGS.lookup(id)?.name ?? `Unknown (${id})`),
           total: counts.total,
         }))
         .sort((a, b) => b.total - a.total),
@@ -1090,7 +1150,7 @@ const KpiUserModal: React.FC<{
       list = list.filter((u) =>
         buildingFilter === 'none'
           ? u.buildings.length === 0
-          : u.buildings.includes(buildingFilter)
+          : u.buildings.some((b) => canonicalBuildingId(b) === buildingFilter)
       );
     }
 
@@ -1103,10 +1163,10 @@ const KpiUserModal: React.FC<{
           break;
         case 'building': {
           const aName = a.buildings[0]
-            ? (KNOWN_BUILDINGS.get(a.buildings[0])?.name ?? a.buildings[0])
+            ? (KNOWN_BUILDINGS.lookup(a.buildings[0])?.name ?? a.buildings[0])
             : '';
           const bName = b.buildings[0]
-            ? (KNOWN_BUILDINGS.get(b.buildings[0])?.name ?? b.buildings[0])
+            ? (KNOWN_BUILDINGS.lookup(b.buildings[0])?.name ?? b.buildings[0])
             : '';
           cmp = aName.localeCompare(bName);
           break;
@@ -1157,7 +1217,7 @@ const KpiUserModal: React.FC<{
               <option key={id} value={id}>
                 {id === 'none'
                   ? 'No Building Assigned'
-                  : (KNOWN_BUILDINGS.get(id)?.name ?? `Unknown (${id})`)}
+                  : (KNOWN_BUILDINGS.lookup(id)?.name ?? `Unknown (${id})`)}
               </option>
             ))}
           </select>
@@ -1224,7 +1284,8 @@ const KpiUserModal: React.FC<{
                         ? u.buildings
                             .map(
                               (b) =>
-                                KNOWN_BUILDINGS.get(b)?.name ?? `Unknown (${b})`
+                                KNOWN_BUILDINGS.lookup(b)?.name ??
+                                `Unknown (${b})`
                             )
                             .join(', ')
                         : '—'}
@@ -1432,9 +1493,14 @@ export const AnalyticsManager: React.FC = () => {
           daily: raw.users?.daily ?? 0,
           withDashboards: raw.users?.withDashboards ?? 0,
           domains: raw.users?.domains ?? {},
-          buildings: raw.users?.buildings ?? {},
-          domainBuilding: raw.users?.domainBuilding ?? {},
-          userList: raw.users?.userList,
+          buildings: foldBuildingsByCanonical(raw.users?.buildings ?? {}),
+          domainBuilding: foldDomainBuildingsByCanonical(
+            raw.users?.domainBuilding ?? {}
+          ),
+          userList: raw.users?.userList?.map((u) => ({
+            ...u,
+            buildings: canonicalizeBuildingIds(u.buildings),
+          })),
         },
         widgets: {
           totalInstances: raw.widgets?.totalInstances ?? {},
@@ -1530,7 +1596,12 @@ export const AnalyticsManager: React.FC = () => {
         if (selectedBuilding === 'none') {
           if (u.buildings.length > 0) return false;
         } else {
-          if (!u.buildings.includes(selectedBuilding)) return false;
+          if (
+            !u.buildings.some(
+              (b) => canonicalBuildingId(b) === selectedBuilding
+            )
+          )
+            return false;
         }
       }
       return true;
@@ -1542,19 +1613,28 @@ export const AnalyticsManager: React.FC = () => {
     [data]
   );
 
-  const buildingOptions = useMemo(
-    () =>
-      data
-        ? Object.keys(data.users.buildings)
-            .filter((id) => id !== 'none')
-            .sort()
-            .map((id) => ({
-              id,
-              name: KNOWN_BUILDINGS.get(id)?.name ?? `Unknown (${id})`,
-            }))
-        : [],
-    [data, KNOWN_BUILDINGS]
-  );
+  const buildingOptions = useMemo(() => {
+    if (!data) return [];
+    // Aggregate raw stored building IDs by their canonical form so legacy
+    // long-form IDs (e.g. `orono-high-school`) collapse onto the same
+    // dropdown entry as their canonical short form (`high`). The dropdown
+    // value is the canonical ID, which is what the filter comparisons above
+    // expect after they normalize each user's `buildings` entry.
+    const seen = new Set<string>();
+    const options: { id: string; name: string }[] = [];
+    for (const rawId of Object.keys(data.users.buildings)) {
+      if (rawId === 'none') continue;
+      const id = canonicalBuildingId(rawId);
+      if (seen.has(id)) continue;
+      seen.add(id);
+      options.push({
+        id,
+        name: KNOWN_BUILDINGS.lookup(id)?.name ?? `Unknown (${id})`,
+      });
+    }
+    options.sort((a, b) => a.name.localeCompare(b.name));
+    return options;
+  }, [data, KNOWN_BUILDINGS]);
 
   const hasNoBuildingUsers = Boolean(data?.users.buildings.none);
 

--- a/components/common/WidgetBuildingToggle.test.tsx
+++ b/components/common/WidgetBuildingToggle.test.tsx
@@ -97,8 +97,12 @@ describe('WidgetBuildingToggle', () => {
     expect(btn).toBeTruthy();
     fireEvent.click(btn as HTMLElement);
 
+    // Click writes the canonical short-form ID, not the legacy long form
+    // that was passed in as a selectedBuildings entry. Building IDs are
+    // canonicalized at every read/write boundary now (see
+    // BUILDING_ID_ALIASES in config/buildings.ts).
     expect(mockUpdateWidget).toHaveBeenCalledWith('w1', {
-      buildingId: 'orono-intermediate-school',
+      buildingId: 'intermediate',
     });
   });
 

--- a/components/common/WidgetBuildingToggle.tsx
+++ b/components/common/WidgetBuildingToggle.tsx
@@ -1,6 +1,7 @@
 import React, { useContext } from 'react';
 import { AuthContext } from '@/context/AuthContextValue';
 import { useAdminBuildings } from '@/hooks/useAdminBuildings';
+import { canonicalBuildingId } from '@/config/buildings';
 import { WidgetData } from '@/types';
 
 interface WidgetBuildingToggleProps {
@@ -23,15 +24,25 @@ export const WidgetBuildingToggle: React.FC<WidgetBuildingToggleProps> = ({
   const selectedBuildings = auth?.selectedBuildings ?? [];
   const BUILDINGS = useAdminBuildings();
 
-  const userBuildings = BUILDINGS.filter((b) =>
-    selectedBuildings.includes(b.id)
+  // Normalize legacy long-form IDs to canonical short-form so the toggle
+  // renders for users (or test fixtures) whose AuthContext data hasn't yet
+  // been canonicalized. AuthContext itself canonicalizes on read in the
+  // app, but defensive normalization here keeps the component robust to
+  // any non-AuthContext source that hands in raw stored IDs.
+  const canonicalSelected = new Set(
+    selectedBuildings.map((id) => canonicalBuildingId(id))
   );
+  const userBuildings = BUILDINGS.filter((b) => canonicalSelected.has(b.id));
 
   if (userBuildings.length < 2) return null;
 
+  const widgetBuildingCanonical = widget.buildingId
+    ? canonicalBuildingId(widget.buildingId)
+    : undefined;
   const effectiveBuildingId =
-    widget.buildingId && userBuildings.some((b) => b.id === widget.buildingId)
-      ? widget.buildingId
+    widgetBuildingCanonical &&
+    userBuildings.some((b) => b.id === widgetBuildingCanonical)
+      ? widgetBuildingCanonical
       : userBuildings[0]?.id;
 
   return (

--- a/config/buildings.ts
+++ b/config/buildings.ts
@@ -24,40 +24,124 @@ export interface Building {
  * buildings configured in Firestore yet. Production buildings now come from
  * `/organizations/{orgId}/buildings` via {@link useAdminBuildings}.
  *
+ * IDs MUST match the doc IDs that the Organization admin panel writes to
+ * `/organizations/{orgId}/buildings/{id}` so user-profile selections,
+ * member role assignments (`members.buildingIds`), and feature-permission
+ * filtering all line up. Legacy long-form IDs (e.g. `orono-high-school`)
+ * are handled via {@link BUILDING_ID_ALIASES} so existing stored data
+ * continues to work.
+ *
  * @deprecated Prefer the `useAdminBuildings()` hook in any component that
  * reads buildings. These constants remain only to support non-React callers
  * (e.g. the LunchCountConfig type narrowing) and initial-render fallback.
  */
 export const BUILDINGS: Building[] = [
   {
-    id: 'schumann-elementary',
+    id: 'schumann',
     name: 'Schumann Elementary',
     gradeLevels: ['k-2'],
     gradeLabel: 'K-2',
     supportsLunchCount: true,
   },
   {
-    id: 'orono-intermediate-school',
+    id: 'intermediate',
     name: 'Orono Intermediate',
     gradeLevels: ['3-5'],
     gradeLabel: '3-5',
     supportsLunchCount: true,
   },
   {
-    id: 'orono-middle-school',
+    id: 'middle',
     name: 'Orono Middle School',
     gradeLevels: ['6-8'],
     gradeLabel: '6-8',
     supportsLunchCount: true,
   },
   {
-    id: 'orono-high-school',
+    id: 'high',
     name: 'Orono High School',
     gradeLevels: ['9-12'],
     gradeLabel: '9-12',
     supportsLunchCount: true,
   },
+  {
+    id: 'orono-community-education',
+    name: 'Orono Community Education',
+    // K-12 building — show widgets across all grade bands.
+    gradeLevels: ['k-2', '3-5', '6-8', '9-12'],
+    gradeLabel: 'K-12',
+    supportsLunchCount: false,
+  },
+  {
+    id: 'orono-discovery-center',
+    name: 'Orono Discovery Center',
+    // Pre-K building. There is no Pre-K GradeLevel in the type union, so
+    // map to k-2 (the closest band) so users still see early-elementary
+    // widgets rather than nothing. Revisit if/when Pre-K becomes a first-
+    // class GradeLevel.
+    gradeLevels: ['k-2'],
+    gradeLabel: 'Pre-K',
+    supportsLunchCount: false,
+  },
 ];
+
+/**
+ * Legacy → canonical building ID alias map.
+ *
+ * Background: prior to the Organization Buildings admin panel shipping,
+ * the canonical IDs were the long forms below. User profiles, root user
+ * docs, and Feature Permissions all stored these. When the panel began
+ * writing short IDs (`high`, `intermediate`, etc.) to Firestore, the
+ * two ID spaces drifted apart:
+ *
+ *   - Sidebar wrote `selectedBuildings: ['orono-high-school']` (legacy)
+ *   - Org admin panel wrote `members.buildingIds: ['high']` (canonical)
+ *
+ * The two never matched, so feature-permission filtering, analytics
+ * labelling, grade-level inference, and the sidebar's own selected-state
+ * indicator all broke for affected users.
+ *
+ * The alias map lets every reader normalize legacy IDs to canonical IDs
+ * transparently. A one-off backfill script
+ * (`scripts/backfill-user-building-ids.js`) rewrites stored data to
+ * canonical IDs so the alias map can eventually be retired.
+ */
+export const BUILDING_ID_ALIASES: Readonly<Record<string, string>> = {
+  'orono-high-school': 'high',
+  'orono-middle-school': 'middle',
+  'orono-intermediate-school': 'intermediate',
+  'schumann-elementary': 'schumann',
+};
+
+/**
+ * Returns the canonical (current) building ID for a stored ID. If the
+ * stored ID is already canonical or unknown, it is returned unchanged.
+ *
+ * All consumers that read building IDs from user profiles, member docs,
+ * or Firestore should pass values through this before lookup so legacy
+ * data continues to work.
+ */
+export function canonicalBuildingId(id: string): string {
+  return BUILDING_ID_ALIASES[id] ?? id;
+}
+
+/**
+ * Normalizes an array of building IDs in-place: legacy IDs become
+ * canonical, and duplicates are dropped (preserving insertion order of
+ * first occurrence). Returns a new array; the input is not mutated.
+ */
+export function canonicalizeBuildingIds(ids: readonly string[]): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const id of ids) {
+    const canonical = canonicalBuildingId(id);
+    if (!seen.has(canonical)) {
+      seen.add(canonical);
+      out.push(canonical);
+    }
+  }
+  return out;
+}
 
 /**
  * O(1) lookup map for building details to avoid O(N) array scans during renders.
@@ -75,18 +159,23 @@ export const LUNCH_COUNT_BUILDING_IDS: ReadonlySet<string> = new Set(
 /**
  * Narrows a building ID string to the LunchCountConfig['schoolSite'] literal
  * union, allowing type-safe use of the value as a config field without
- * requiring `as` assertions at call sites.
+ * requiring `as` assertions at call sites. Normalizes legacy IDs first so
+ * stored values like `schumann-elementary` are recognized.
  */
 export function isLunchCountBuilding(
   id: string
 ): id is LunchCountConfig['schoolSite'] {
-  return LUNCH_COUNT_BUILDING_IDS.has(id);
+  return LUNCH_COUNT_BUILDING_IDS.has(canonicalBuildingId(id));
 }
 
 /**
  * Returns the union of grade levels for the given building IDs, resolving
  * against either the legacy hardcoded `BUILDINGS` list or an explicit list
  * passed by a caller that knows the org's buildings (e.g. from Firestore).
+ *
+ * Each input ID is normalized via {@link canonicalBuildingId} before
+ * lookup, so legacy stored IDs (e.g. `orono-high-school`) resolve to the
+ * same grade band as their canonical counterparts (`high`).
  *
  * Returns an empty array if no building IDs are provided, which widgets
  * should interpret as "show all content".
@@ -98,7 +187,8 @@ export function getBuildingGradeLevels(
   if (buildingIds.length === 0) return [];
   const byId = new Map(source.map((b) => [b.id, b]));
   const levels = new Set<GradeLevel>();
-  for (const id of buildingIds) {
+  for (const rawId of buildingIds) {
+    const id = canonicalBuildingId(rawId);
     const building = byId.get(id);
     if (building) {
       building.gradeLevels.forEach((l) => levels.add(l));

--- a/context/AuthContext.tsx
+++ b/context/AuthContext.tsx
@@ -42,6 +42,7 @@ import type { MemberRecord, BuildingRecord } from '../types/organization';
 import { AuthContext } from './AuthContextValue';
 import {
   buildingRecordToBuilding,
+  canonicalizeBuildingIds,
   getBuildingGradeLevels,
 } from '../config/buildings';
 import i18n from '../i18n';
@@ -718,7 +719,16 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
               Array.isArray(selectedBuildings) &&
               selectedBuildings.every((id) => typeof id === 'string')
             ) {
-              setSelectedBuildingsState(selectedBuildings);
+              // Normalize legacy long-form IDs (e.g. `orono-high-school`) to
+              // their canonical short forms (`high`) so all downstream
+              // comparisons and lookups against org-defined Firestore
+              // buildings line up. The on-disk value is rewritten to
+              // canonical form by `setSelectedBuildings` on the next save,
+              // and by `scripts/backfill-user-building-ids.js` for batch
+              // migration.
+              setSelectedBuildingsState(
+                canonicalizeBuildingIds(selectedBuildings)
+              );
             } else {
               setSelectedBuildingsState([]);
             }
@@ -854,20 +864,26 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
 
   const setSelectedBuildings = useCallback(
     async (buildings: string[]) => {
-      setSelectedBuildingsState(buildings);
+      // Canonicalize before persisting so legacy IDs that callers may have
+      // passed through (e.g. from old in-memory state) are normalized on the
+      // way to disk. This makes every save self-healing.
+      const canonical = canonicalizeBuildingIds(buildings);
+      setSelectedBuildingsState(canonical);
       if (!user || isAuthBypass) return;
       // Assign a token so we can detect if a newer call supersedes this one
       const myToken = ++writeTokenRef.current;
       try {
         await setDoc(
           doc(db, 'users', user.uid, 'userProfile', 'profile'),
-          { selectedBuildings: buildings },
+          { selectedBuildings: canonical },
           { merge: true }
         );
-        // Keep root doc buildings in sync for admin analytics
+        // Keep root doc buildings in sync for admin analytics. Use the
+        // canonicalized array so the analytics Cloud Function (which reads
+        // `users/{uid}.buildings` as a fallback) sees aligned IDs.
         void setDoc(
           doc(db, 'users', user.uid),
-          { buildings },
+          { buildings: canonical },
           { merge: true }
         ).catch((err: unknown) =>
           console.error('Error updating root doc buildings:', err)

--- a/hooks/useWidgetBuildingId.ts
+++ b/hooks/useWidgetBuildingId.ts
@@ -1,15 +1,27 @@
 import { useAuth } from '@/context/useAuth';
+import { canonicalBuildingId } from '@/config/buildings';
 import { WidgetData } from '@/types';
 
 /**
  * Returns the effective building ID for a widget.
  * Prefers `widget.buildingId` if it's still in the user's selected buildings,
  * otherwise falls back to the user's primary building.
+ *
+ * Both the widget's stored `buildingId` and the user's `selectedBuildings`
+ * are normalized via {@link canonicalBuildingId} before comparison so legacy
+ * long-form IDs (e.g. `orono-high-school`) match their canonical short-form
+ * equivalents (`high`).
  */
 export function useWidgetBuildingId(widget: WidgetData): string | undefined {
   const { selectedBuildings = [] } = useAuth();
-  if (widget.buildingId && selectedBuildings.includes(widget.buildingId)) {
-    return widget.buildingId;
+  const canonicalSelected = selectedBuildings.map((id) =>
+    canonicalBuildingId(id)
+  );
+  if (widget.buildingId) {
+    const widgetCanonical = canonicalBuildingId(widget.buildingId);
+    if (canonicalSelected.includes(widgetCanonical)) {
+      return widgetCanonical;
+    }
   }
-  return selectedBuildings[0];
+  return canonicalSelected[0];
 }

--- a/scripts/backfill-user-building-ids.js
+++ b/scripts/backfill-user-building-ids.js
@@ -1,0 +1,297 @@
+/**
+ * One-shot backfill: canonicalize legacy building IDs in user-owned data.
+ *
+ * BACKGROUND
+ *   Two parallel building-ID systems drifted apart:
+ *
+ *     A. The legacy hardcoded BUILDINGS array in config/buildings.ts used
+ *        long-form IDs (e.g. 'orono-high-school'). The sidebar's "My
+ *        Building(s)" picker wrote these into:
+ *          - /users/{uid}/userProfile/profile  →  field `selectedBuildings`
+ *          - /users/{uid}                      →  field `buildings`
+ *
+ *     B. The Organization admin panel
+ *        (/organizations/{orgId}/buildings/{id}) writes short-form IDs
+ *        ('schumann', 'intermediate', 'middle', 'high', plus newer
+ *        org-defined ones like 'orono-community-education'). Member docs
+ *        (/organizations/{orgId}/members/{emailLower}.buildingIds) and
+ *        feature-permission building filters all use these.
+ *
+ *   Because the two ID spaces never matched, Admin Settings → Analytics
+ *   showed user buildings as "Unknown (orono-high-school)" and feature-
+ *   permission filtering / instructional-routine grade matching silently
+ *   skipped affected users.
+ *
+ *   The app code now normalizes legacy → canonical IDs at every read/write
+ *   boundary via `canonicalizeBuildingIds()` in config/buildings.ts (so any
+ *   user logging in self-heals their own data on the next save). This
+ *   script does the same rewrite ahead of time so non-active users don't
+ *   linger with legacy IDs and so analytics buckets collapse cleanly.
+ *
+ * WHAT THIS SCRIPT DOES
+ *   - Enumerates every doc under /users/* (collection group not needed —
+ *     the two affected fields live on /users/{uid} and
+ *     /users/{uid}/userProfile/profile).
+ *   - Rewrites `selectedBuildings` (on userProfile/profile) and `buildings`
+ *     (on the root /users/{uid} doc) to canonical IDs, deduplicating in
+ *     the process.
+ *   - Skips writes when the array is already canonical (idempotent).
+ *
+ * WHAT THIS SCRIPT DOES NOT DO
+ *   - Does NOT touch /organizations/{orgId}/members/* — those are already
+ *     written using canonical short IDs by setup-organization.js,
+ *     backfill-org-members.js, and the live OrganizationPanel UI.
+ *   - Does NOT touch /admins/{email} or any admin-only collections.
+ *   - Does NOT delete unknown IDs. If a stored ID isn't in the alias map
+ *     and isn't a known canonical ID, it's left as-is so a future config
+ *     change can recognize it. The app side already shows these as
+ *     "Unknown (...)" in admin UIs but treats them as a no-op for filtering.
+ *
+ * SAFETY
+ *   - --dry-run logs every planned change without writing.
+ *   - Uses { merge: true } updates so unrelated fields are preserved.
+ *   - Skips writes when no IDs would change (no churn on already-canonical
+ *     data).
+ *
+ * Usage:
+ *   node scripts/backfill-user-building-ids.js [--dry-run] [--verbose]
+ *
+ * Credentials resolution (same order as backfill-org-members.js):
+ *   1. FIREBASE_SERVICE_ACCOUNT env var (JSON) — used by CI
+ *   2. scripts/service-account-key.json — used by local dev
+ *   3. applicationDefault() via GOOGLE_APPLICATION_CREDENTIALS or
+ *      `gcloud auth application-default login`
+ */
+
+import { initializeApp, applicationDefault, cert } from 'firebase-admin/app';
+import { getFirestore } from 'firebase-admin/firestore';
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const PROJECT_ID = 'spartboard';
+
+/**
+ * Legacy → canonical building-id map. Keep in sync with
+ * BUILDING_ID_ALIASES in config/buildings.ts. Duplicated here (vs.
+ * imported) so this Node script doesn't need a TypeScript build step.
+ */
+const BUILDING_ID_LEGACY_TO_CANONICAL = {
+  'orono-high-school': 'high',
+  'orono-middle-school': 'middle',
+  'orono-intermediate-school': 'intermediate',
+  'schumann-elementary': 'schumann',
+};
+
+function canonicalBuildingId(id) {
+  return BUILDING_ID_LEGACY_TO_CANONICAL[id] ?? id;
+}
+
+/**
+ * Returns { canonical, changed } where `canonical` is the deduplicated
+ * canonical-ID array and `changed` is true iff the input differed.
+ */
+function canonicalizeBuildingIds(ids) {
+  if (!Array.isArray(ids)) return { canonical: ids, changed: false };
+  const seen = new Set();
+  const out = [];
+  for (const raw of ids) {
+    if (typeof raw !== 'string') continue;
+    const c = canonicalBuildingId(raw);
+    if (!seen.has(c)) {
+      seen.add(c);
+      out.push(c);
+    }
+  }
+  // Cheap structural-equality check (same length, same order).
+  let changed = out.length !== ids.length;
+  if (!changed) {
+    for (let i = 0; i < out.length; i++) {
+      if (out[i] !== ids[i]) {
+        changed = true;
+        break;
+      }
+    }
+  }
+  return { canonical: out, changed };
+}
+
+function parseArgs(argv) {
+  const args = { dryRun: false, verbose: false, help: false };
+  for (const a of argv) {
+    if (a === '--dry-run' || a === '-n') args.dryRun = true;
+    else if (a === '--verbose' || a === '-v') args.verbose = true;
+    else if (a === '--help' || a === '-h') args.help = true;
+  }
+  return args;
+}
+
+function printHelp() {
+  console.log(
+    'Usage: node scripts/backfill-user-building-ids.js [--dry-run] [--verbose]'
+  );
+}
+
+function loadCredentials() {
+  const envJson = process.env.FIREBASE_SERVICE_ACCOUNT;
+  if (envJson) {
+    try {
+      return {
+        source: 'FIREBASE_SERVICE_ACCOUNT env',
+        creds: JSON.parse(envJson),
+        useApplicationDefault: false,
+      };
+    } catch (e) {
+      throw new Error(
+        'Failed to parse FIREBASE_SERVICE_ACCOUNT env var as JSON: ' + e.message
+      );
+    }
+  }
+  const keyPath = join(__dirname, 'service-account-key.json');
+  try {
+    const raw = readFileSync(keyPath, 'utf8');
+    return {
+      source: 'scripts/service-account-key.json',
+      creds: JSON.parse(raw),
+      useApplicationDefault: false,
+    };
+  } catch {
+    // Fall through to ADC.
+  }
+  if (process.env.GOOGLE_APPLICATION_CREDENTIALS) {
+    return {
+      source:
+        'GOOGLE_APPLICATION_CREDENTIALS=' +
+        process.env.GOOGLE_APPLICATION_CREDENTIALS,
+      creds: null,
+      useApplicationDefault: true,
+    };
+  }
+  return {
+    source: 'applicationDefault()',
+    creds: null,
+    useApplicationDefault: true,
+  };
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    printHelp();
+    return;
+  }
+
+  const cred = loadCredentials();
+  console.log(`[backfill-user-building-ids] credentials: ${cred.source}`);
+  initializeApp({
+    credential: cred.useApplicationDefault
+      ? applicationDefault()
+      : cert(cred.creds),
+    projectId: PROJECT_ID,
+  });
+
+  const db = getFirestore();
+  console.log(
+    `[backfill-user-building-ids] mode: ${args.dryRun ? 'DRY RUN (no writes)' : 'LIVE (writing)'}`
+  );
+
+  // Counters
+  let usersScanned = 0;
+  let rootBuildingsScanned = 0;
+  let rootBuildingsChanged = 0;
+  let profilesScanned = 0;
+  let profilesChanged = 0;
+
+  const usersSnap = await db.collection('users').get();
+  console.log(
+    `[backfill-user-building-ids] enumerated ${usersSnap.size} /users docs`
+  );
+
+  for (const userDoc of usersSnap.docs) {
+    usersScanned++;
+    const uid = userDoc.id;
+
+    // 1. Root /users/{uid}.buildings
+    const rootData = userDoc.data() ?? {};
+    if (Array.isArray(rootData.buildings)) {
+      rootBuildingsScanned++;
+      const { canonical, changed } = canonicalizeBuildingIds(
+        rootData.buildings
+      );
+      if (changed) {
+        rootBuildingsChanged++;
+        if (args.verbose || args.dryRun) {
+          console.log(
+            `  [users/${uid}] buildings: ${JSON.stringify(rootData.buildings)} → ${JSON.stringify(canonical)}`
+          );
+        }
+        if (!args.dryRun) {
+          await userDoc.ref.set({ buildings: canonical }, { merge: true });
+        }
+      } else if (args.verbose) {
+        console.log(`  [users/${uid}] buildings already canonical, skipping`);
+      }
+    }
+
+    // 2. /users/{uid}/userProfile/profile.selectedBuildings
+    const profileRef = db
+      .collection('users')
+      .doc(uid)
+      .collection('userProfile')
+      .doc('profile');
+    const profileSnap = await profileRef.get();
+    if (!profileSnap.exists) {
+      if (args.verbose) {
+        console.log(`  [users/${uid}/userProfile/profile] missing, skipping`);
+      }
+      continue;
+    }
+    profilesScanned++;
+    const profileData = profileSnap.data() ?? {};
+    if (!Array.isArray(profileData.selectedBuildings)) continue;
+    const { canonical, changed } = canonicalizeBuildingIds(
+      profileData.selectedBuildings
+    );
+    if (changed) {
+      profilesChanged++;
+      if (args.verbose || args.dryRun) {
+        console.log(
+          `  [users/${uid}/userProfile/profile] selectedBuildings: ${JSON.stringify(profileData.selectedBuildings)} → ${JSON.stringify(canonical)}`
+        );
+      }
+      if (!args.dryRun) {
+        await profileRef.set({ selectedBuildings: canonical }, { merge: true });
+      }
+    } else if (args.verbose) {
+      console.log(
+        `  [users/${uid}/userProfile/profile] selectedBuildings already canonical, skipping`
+      );
+    }
+  }
+
+  console.log('');
+  console.log('[backfill-user-building-ids] summary');
+  console.log(`  users scanned:                         ${usersScanned}`);
+  console.log(
+    `  root .buildings fields scanned:        ${rootBuildingsScanned}`
+  );
+  console.log(
+    `  root .buildings fields changed:        ${rootBuildingsChanged}`
+  );
+  console.log(`  userProfile/profile docs scanned:      ${profilesScanned}`);
+  console.log(`  userProfile/profile docs changed:      ${profilesChanged}`);
+  if (args.dryRun) {
+    console.log('');
+    console.log(
+      '  DRY RUN — no writes performed. Re-run without --dry-run to apply.'
+    );
+  }
+}
+
+main().catch((err) => {
+  console.error('[backfill-user-building-ids] fatal:', err);
+  process.exit(1);
+});

--- a/scripts/diagnose-building-ids.js
+++ b/scripts/diagnose-building-ids.js
@@ -1,0 +1,313 @@
+/**
+ * Diagnostic: Building ID alignment between user profiles, root user docs,
+ * org-defined buildings, and org member assignments.
+ *
+ * READ-ONLY. Makes no writes.
+ *
+ * Outputs:
+ *   - Distinct building IDs present in users/{uid}/userProfile/profile.selectedBuildings
+ *   - Distinct building IDs present in users/{uid}.buildings (root doc)
+ *   - All /organizations/{orgId}/buildings/{id} doc IDs
+ *   - All distinct buildingIds across /organizations/{orgId}/members/{email}.buildingIds
+ *   - Mismatch analysis: which IDs appear in user data but NOT in org-defined buildings
+ *
+ * Usage:
+ *   node scripts/diagnose-building-ids.js [--org <orgId>]
+ *
+ * Defaults to scanning all orgs found under /organizations.
+ *
+ * Credentials resolution (same as setup-organization.js):
+ *   1. FIREBASE_SERVICE_ACCOUNT env var (JSON)
+ *   2. scripts/service-account-key.json
+ *   3. GOOGLE_APPLICATION_CREDENTIALS (Application Default Credentials)
+ */
+
+import { initializeApp, applicationDefault, cert } from 'firebase-admin/app';
+import { getFirestore } from 'firebase-admin/firestore';
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+function parseArgs(argv) {
+  const args = { org: null };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--org') args.org = argv[++i];
+    else if (a === '--help' || a === '-h') args.help = true;
+  }
+  return args;
+}
+
+function loadCredentials() {
+  const envJson = process.env.FIREBASE_SERVICE_ACCOUNT;
+  if (envJson) {
+    return {
+      source: 'FIREBASE_SERVICE_ACCOUNT env',
+      creds: JSON.parse(envJson),
+      useApplicationDefault: false,
+    };
+  }
+  const path = join(__dirname, 'service-account-key.json');
+  try {
+    return {
+      source: 'scripts/service-account-key.json',
+      creds: JSON.parse(readFileSync(path, 'utf8')),
+      useApplicationDefault: false,
+    };
+  } catch {
+    // Fall through to ADC.
+  }
+  if (process.env.GOOGLE_APPLICATION_CREDENTIALS) {
+    return {
+      source: `GOOGLE_APPLICATION_CREDENTIALS=${process.env.GOOGLE_APPLICATION_CREDENTIALS}`,
+      creds: null,
+      useApplicationDefault: true,
+    };
+  }
+  throw new Error(
+    'Firebase Admin credentials not found. Place key at scripts/service-account-key.json'
+  );
+}
+
+function bumpCount(map, key) {
+  map.set(key, (map.get(key) ?? 0) + 1);
+}
+
+function fmtMapDesc(map) {
+  return [...map.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .map(([k, v]) => `    ${JSON.stringify(k)}  →  ${v}`)
+    .join('\n');
+}
+
+async function run() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    console.log(
+      'Usage: node scripts/diagnose-building-ids.js [--org <orgId>]\n\n' +
+        'Reads (no writes):\n' +
+        '  - users/{uid}/userProfile/profile.selectedBuildings\n' +
+        '  - users/{uid}.buildings\n' +
+        '  - /organizations/{orgId}/buildings/*\n' +
+        '  - /organizations/{orgId}/members/*.buildingIds'
+    );
+    process.exit(0);
+  }
+
+  const { source, creds, useApplicationDefault } = loadCredentials();
+  console.log(`✅ Using credentials from ${source}\n`);
+
+  initializeApp({
+    credential: useApplicationDefault ? applicationDefault() : cert(creds),
+    ...(useApplicationDefault && process.env.FIREBASE_PROJECT_ID
+      ? { projectId: process.env.FIREBASE_PROJECT_ID }
+      : {}),
+  });
+  const db = getFirestore();
+
+  // ─── 1. User profiles (selectedBuildings) ────────────────────────────────
+  console.log(
+    '📥 Reading users/{uid}/userProfile/profile.selectedBuildings via collectionGroup…'
+  );
+  const profileSnap = await db.collectionGroup('userProfile').get();
+  const selectedBuildingsCounts = new Map();
+  let profileCount = 0;
+  let profilesWithBuildings = 0;
+  for (const doc of profileSnap.docs) {
+    if (doc.id !== 'profile') continue;
+    profileCount += 1;
+    const data = doc.data();
+    if (
+      Array.isArray(data?.selectedBuildings) &&
+      data.selectedBuildings.length > 0
+    ) {
+      profilesWithBuildings += 1;
+      for (const id of data.selectedBuildings) {
+        bumpCount(selectedBuildingsCounts, String(id));
+      }
+    }
+  }
+  console.log(
+    `   Scanned ${profileCount} profile docs, ${profilesWithBuildings} have selectedBuildings.`
+  );
+
+  // ─── 2. Root user docs (.buildings) ──────────────────────────────────────
+  console.log('\n📥 Reading users/{uid}.buildings (root doc)…');
+  const usersSnap = await db.collection('users').get();
+  const rootBuildingsCounts = new Map();
+  let usersWithRootBuildings = 0;
+  for (const doc of usersSnap.docs) {
+    const data = doc.data();
+    if (Array.isArray(data?.buildings) && data.buildings.length > 0) {
+      usersWithRootBuildings += 1;
+      for (const id of data.buildings) {
+        bumpCount(rootBuildingsCounts, String(id));
+      }
+    }
+  }
+  console.log(
+    `   Scanned ${usersSnap.size} root user docs, ${usersWithRootBuildings} have .buildings.`
+  );
+
+  // ─── 3. Org-defined buildings ────────────────────────────────────────────
+  console.log('\n📥 Reading /organizations/*/buildings/*…');
+  const orgsSnap = await db.collection('organizations').get();
+  const targetOrgs = args.org
+    ? orgsSnap.docs.filter((d) => d.id === args.org)
+    : orgsSnap.docs;
+  if (args.org && targetOrgs.length === 0) {
+    console.warn(`   ⚠️  No organization found with id "${args.org}".`);
+  }
+  const orgBuildings = new Map(); // orgId → [{id, name}]
+  const orgMemberBuildingIds = new Map(); // orgId → Map<id, count>
+  for (const orgDoc of targetOrgs) {
+    const orgId = orgDoc.id;
+    const buildingsSnap = await db
+      .collection('organizations')
+      .doc(orgId)
+      .collection('buildings')
+      .get();
+    orgBuildings.set(
+      orgId,
+      buildingsSnap.docs.map((b) => ({
+        id: b.id,
+        name: b.data()?.name ?? '(no name)',
+      }))
+    );
+
+    const memberSnap = await db
+      .collection('organizations')
+      .doc(orgId)
+      .collection('members')
+      .get();
+    const counts = new Map();
+    for (const m of memberSnap.docs) {
+      const ids = m.data()?.buildingIds;
+      if (Array.isArray(ids)) {
+        for (const id of ids) bumpCount(counts, String(id));
+      }
+    }
+    orgMemberBuildingIds.set(orgId, counts);
+  }
+
+  // ─── 4. Report ───────────────────────────────────────────────────────────
+  const banner = (s) =>
+    console.log(`\n${'═'.repeat(72)}\n  ${s}\n${'═'.repeat(72)}`);
+
+  banner('USER PROFILE selectedBuildings (sidebar writes here)');
+  if (selectedBuildingsCounts.size === 0) {
+    console.log('  (none)');
+  } else {
+    console.log(fmtMapDesc(selectedBuildingsCounts));
+  }
+
+  banner('ROOT USER DOC .buildings (mirror for analytics)');
+  if (rootBuildingsCounts.size === 0) {
+    console.log('  (none)');
+  } else {
+    console.log(fmtMapDesc(rootBuildingsCounts));
+  }
+
+  banner('ORG-DEFINED BUILDINGS  /organizations/{orgId}/buildings/*');
+  if (orgBuildings.size === 0) {
+    console.log('  (no organizations found)');
+  } else {
+    for (const [orgId, list] of orgBuildings) {
+      console.log(`  org="${orgId}":`);
+      if (list.length === 0) {
+        console.log('    (no building docs)');
+      } else {
+        for (const b of list) {
+          console.log(`    ${JSON.stringify(b.id)}  (name: ${b.name})`);
+        }
+      }
+    }
+  }
+
+  banner('ORG MEMBER buildingIds  /organizations/{orgId}/members/*');
+  for (const [orgId, counts] of orgMemberBuildingIds) {
+    console.log(`  org="${orgId}":`);
+    if (counts.size === 0) {
+      console.log('    (no buildingIds set)');
+    } else {
+      console.log(fmtMapDesc(counts));
+    }
+  }
+
+  // ─── 5. Mismatch analysis ────────────────────────────────────────────────
+  banner('MISMATCH ANALYSIS');
+  const allOrgBuildingIds = new Set();
+  for (const list of orgBuildings.values()) {
+    for (const b of list) allOrgBuildingIds.add(b.id);
+  }
+
+  const profileNotInOrg = [...selectedBuildingsCounts.keys()].filter(
+    (id) => !allOrgBuildingIds.has(id)
+  );
+  const orgNotInProfile = [...allOrgBuildingIds].filter(
+    (id) => !selectedBuildingsCounts.has(id)
+  );
+
+  console.log(
+    `  user-profile IDs that are NOT defined in any org's buildings (${profileNotInOrg.length}):`
+  );
+  if (profileNotInOrg.length === 0) {
+    console.log('    (none — clean!)');
+  } else {
+    for (const id of profileNotInOrg) {
+      console.log(
+        `    ${JSON.stringify(id)}  (used by ${selectedBuildingsCounts.get(id)} user(s))`
+      );
+    }
+  }
+
+  console.log(
+    `\n  org-defined building IDs that NO user profile references (${orgNotInProfile.length}):`
+  );
+  if (orgNotInProfile.length === 0) {
+    console.log('    (none — clean!)');
+  } else {
+    for (const id of orgNotInProfile) {
+      console.log(`    ${JSON.stringify(id)}`);
+    }
+  }
+
+  // Profile vs root drift
+  const onlyInProfile = [...selectedBuildingsCounts.keys()].filter(
+    (id) => !rootBuildingsCounts.has(id)
+  );
+  const onlyInRoot = [...rootBuildingsCounts.keys()].filter(
+    (id) => !selectedBuildingsCounts.has(id)
+  );
+  if (onlyInProfile.length > 0 || onlyInRoot.length > 0) {
+    console.log(
+      `\n  ⚠️  Drift between user profile selectedBuildings and root .buildings:`
+    );
+    if (onlyInProfile.length > 0) {
+      console.log(
+        `     IDs only in profile: ${onlyInProfile.map((s) => JSON.stringify(s)).join(', ')}`
+      );
+    }
+    if (onlyInRoot.length > 0) {
+      console.log(
+        `     IDs only in root:    ${onlyInRoot.map((s) => JSON.stringify(s)).join(', ')}`
+      );
+    }
+  } else {
+    console.log(
+      '\n  ✅ Profile selectedBuildings and root .buildings are aligned.'
+    );
+  }
+
+  console.log('\n✨ Diagnostic complete.');
+  process.exit(0);
+}
+
+run().catch((err) => {
+  console.error('\n❌ diagnose-building-ids failed:', err.message ?? err);
+  if (err.stack) console.error(err.stack);
+  process.exit(1);
+});

--- a/scripts/inspect-org-buildings.js
+++ b/scripts/inspect-org-buildings.js
@@ -1,0 +1,40 @@
+/**
+ * Read-only: dump full content of /organizations/{orgId}/buildings/* docs
+ * so we can see what fields (grades, type, etc.) are stored.
+ */
+import { initializeApp, applicationDefault, cert } from 'firebase-admin/app';
+import { getFirestore } from 'firebase-admin/firestore';
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+function loadCredentials() {
+  const path = join(__dirname, 'service-account-key.json');
+  return cert(JSON.parse(readFileSync(path, 'utf8')));
+}
+
+initializeApp({ credential: loadCredentials() });
+const db = getFirestore();
+
+const orgsSnap = await db.collection('organizations').get();
+for (const org of orgsSnap.docs) {
+  console.log(`\n═══ org="${org.id}" ═══`);
+  const buildings = await db
+    .collection('organizations')
+    .doc(org.id)
+    .collection('buildings')
+    .get();
+  for (const b of buildings.docs) {
+    console.log(`\n  buildings/${b.id}:`);
+    console.log(
+      JSON.stringify(b.data(), null, 4)
+        .split('\n')
+        .map((l) => '    ' + l)
+        .join('\n')
+    );
+  }
+}
+process.exit(0);


### PR DESCRIPTION
## Summary

- Fixes the "Unknown (orono-high-school)" labels in Admin Settings → Analytics by reconciling the two parallel building-ID systems (legacy long IDs from the old hardcoded BUILDINGS array, vs canonical short IDs written by the Organization admin panel).
- Makes canonical short IDs the source of truth and adds a bidirectional alias map so legacy IDs continue to resolve transparently — both existing users (with legacy IDs in `selectedBuildings`) and new users (who get short IDs from Firestore) work without manual intervention.
- AuthContext canonicalizes `selectedBuildings` on read AND write, so any user who logs in self-heals their stored data on the next save.
- AnalyticsManager folds legacy + canonical buckets together at load time so no chart/table/dropdown shows two rows for the same building.
- Ships a one-shot `scripts/backfill-user-building-ids.js --dry-run` to canonicalize stored data ahead of time for non-active users.

## Why

The sidebar's "My Building(s)" picker historically wrote legacy long-form IDs (`orono-high-school`) into `users/{uid}/userProfile/profile.selectedBuildings`. The Organization admin panel writes canonical short IDs (`high`) to `/organizations/{orgId}/buildings/{id}` and `/organizations/{orgId}/members/*.buildingIds`. Because the two ID spaces never matched:

- Admin Settings → Analytics rendered `Unknown (orono-high-school)` for every legacy-ID user.
- Feature-permission filtering and instructional-routine grade matching silently skipped affected users.
- The sidebar's own "selected" indicator misrendered for users with mixed-source data.

## Key Changes

- `config/buildings.ts`: BUILDINGS uses canonical short IDs (`schumann`, `intermediate`, `middle`, `high`); adds `orono-community-education` and `orono-discovery-center` so the static fallback matches what live orgs already have. New `BUILDING_ID_ALIASES` + `canonicalBuildingId()` + `canonicalizeBuildingIds()` helpers. `getBuildingGradeLevels()` and `isLunchCountBuilding()` normalize inputs.
- `context/AuthContext.tsx`: canonicalizes `selectedBuildings` on profile load and on every `setSelectedBuildings` call. Self-healing.
- `components/admin/Analytics/AnalyticsManager.tsx`: `useKnownBuildings()` returns a `lookup()` helper that normalizes legacy IDs. `foldBuildingsByCanonical` + `foldDomainBuildingsByCanonical` collapse legacy/canonical buckets at load time. Building filter comparisons defensively normalize.
- `components/common/WidgetBuildingToggle.tsx` + test: defensively canonicalizes `selectedBuildings` and `widget.buildingId` so the toggle renders for any caller, and emits canonical IDs on click. Test updated to expect canonical IDs in the click write.
- `hooks/useWidgetBuildingId.ts`: normalizes both sides of the comparison.

## New Scripts

- `scripts/backfill-user-building-ids.js [--dry-run] [--verbose]` — idempotent rewrite of `/users/{uid}.buildings` and `/users/{uid}/userProfile/profile.selectedBuildings` to canonical IDs.
- `scripts/diagnose-building-ids.js` — read-only audit of ID alignment across user profiles, root user docs, org-defined buildings, and org member assignments.
- `scripts/inspect-org-buildings.js` — dumps full `/organizations/{orgId}/buildings/*` docs.

## Test plan

- [x] `pnpm run type-check:all` — green
- [x] `pnpm run lint` — green (zero errors/warnings)
- [x] `pnpm run format:check` — green
- [x] `pnpm run test` — 1423 tests pass
- [ ] Manually: sign in as a user with legacy `selectedBuildings` (e.g. `orono-high-school`); confirm sidebar shows the correct building selected, that re-saving rewrites the profile to canonical IDs, and that Admin Settings → Analytics now shows the building name (not "Unknown (...)")
- [ ] Run `node scripts/backfill-user-building-ids.js --dry-run` against production; review log output before re-running without `--dry-run`

🤖 Generated with [Claude Code](https://claude.com/claude-code)