### PR TITLE
fix(reset-password): surface resetUrl when email queue is disabled

### DIFF
--- a/components/admin/Organization/OrganizationPanel.tsx
+++ b/components/admin/Organization/OrganizationPanel.tsx
@@ -496,10 +496,41 @@ export const OrganizationPanel: React.FC = () => {
 
   // Password reset goes through a dedicated callable (`resetOrganizationUserPassword`)
   // that uses the Admin SDK and gates on domain-admin-of-orgId.
+  //
+  // The CF returns `{ sent, email, resetUrl }`. When `sent === true` the
+  // Trigger Email extension delivered the link; when `sent === false`
+  // (e.g. `global_permissions/invite-emails.enabled` is off) we mirror the
+  // invite `claimUrl` flow: copy the URL to the clipboard and tell the admin
+  // to paste it. NEVER show an unconditional success toast — that's the
+  // silent-auth-failure bug we're fixing here.
   const handleResetPassword = (target: UserRecord) => {
     if (!writesEnabled) return comingSoon('Reset password');
     resetPassword(target.email)
-      .then(() => showToast(`Sent reset email to ${target.email}`, 'success'))
+      .then(async (result) => {
+        if (result.sent) {
+          showToast(`Sent reset email to ${target.email}`, 'success');
+          return;
+        }
+        try {
+          if (navigator.clipboard?.writeText) {
+            await navigator.clipboard.writeText(result.resetUrl);
+            showToast(
+              `Email delivery is off. Reset link copied for ${target.email}. Paste it into your email or chat.`,
+              'success'
+            );
+          } else {
+            showToast(
+              `Email delivery is off. Reset link for ${target.email}: ${result.resetUrl}`,
+              'success'
+            );
+          }
+        } catch {
+          showToast(
+            `Email delivery is off. Reset link for ${target.email}: ${result.resetUrl}`,
+            'success'
+          );
+        }
+      })
       .catch((err: unknown) => {
         const msg = err instanceof Error ? err.message : String(err);
         showToast(`Reset failed: ${msg}`, 'error');

--- a/functions/src/organizationResetPassword.test.ts
+++ b/functions/src/organizationResetPassword.test.ts
@@ -1,12 +1,50 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
+// Shared mock state so individual tests can wire up Firestore docs and the
+// Auth `generatePasswordResetLink` return value per scenario.
+const firestoreState: {
+  docs: Map<string, { exists: boolean; data?: Record<string, unknown> }>;
+  setCalls: Array<{ path: string; data: Record<string, unknown> }>;
+} = {
+  docs: new Map(),
+  setCalls: [],
+};
+
+const generatePasswordResetLinkMock = vi.fn();
+
+function makeDocRef(path: string) {
+  return {
+    get: vi.fn(() => {
+      const doc = firestoreState.docs.get(path) ?? { exists: false };
+      return Promise.resolve({
+        exists: doc.exists,
+        data: () => doc.data,
+      });
+    }),
+    set: vi.fn((data: Record<string, unknown>) => {
+      firestoreState.setCalls.push({ path, data });
+      firestoreState.docs.set(path, { exists: true, data });
+      return Promise.resolve();
+    }),
+    collection: (name: string) => makeCollectionRef(`${path}/${name}`),
+  };
+}
+
+function makeCollectionRef(path: string) {
+  return {
+    doc: (id: string) => makeDocRef(`${path}/${id}`),
+  };
+}
+
 vi.mock('firebase-admin', () => {
   return {
     apps: [{ name: '[DEFAULT]' }],
     initializeApp: vi.fn(),
-    firestore: vi.fn(() => ({})),
+    firestore: vi.fn(() => ({
+      collection: (name: string) => makeCollectionRef(name),
+    })),
     auth: vi.fn(() => ({
-      generatePasswordResetLink: vi.fn(),
+      generatePasswordResetLink: generatePasswordResetLinkMock,
     })),
   };
 });
@@ -31,13 +69,15 @@ import { resetOrganizationUserPassword } from './organizationResetPassword';
 type CallableHandler = (request: {
   auth?: { uid: string; token: { email?: string } };
   data: unknown;
-}) => Promise<unknown>;
+}) => Promise<{ sent: boolean; email: string; resetUrl: string }>;
 
 const handler = resetOrganizationUserPassword as unknown as CallableHandler;
 
 describe('resetOrganizationUserPassword — input validation', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    firestoreState.docs.clear();
+    firestoreState.setCalls = [];
   });
 
   it('rejects unauthenticated callers', async () => {
@@ -80,5 +120,133 @@ describe('resetOrganizationUserPassword — input validation', () => {
         data: 'not-an-object',
       })
     ).rejects.toMatchObject({ code: 'invalid-argument' });
+  });
+});
+
+// Happy-path coverage for the silent-auth-failure fix: the CF must always
+// return `resetUrl` so the UI can hand-deliver the link when email queueing
+// is disabled. Both branches (sent vs. not-sent) are asserted because the
+// whole point of the bug was that the CF dropped the URL on the floor when
+// `invite-emails.enabled === false`.
+describe('resetOrganizationUserPassword — happy path', () => {
+  const adminEmail = 'admin@orono.k12.mn.us';
+  const targetEmail = 'teacher@orono.k12.mn.us';
+  const orgId = 'orono';
+  const resetUrl =
+    'https://spartboard.firebaseapp.com/__/auth/action?mode=resetPassword&oobCode=fake';
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    firestoreState.docs.clear();
+    firestoreState.setCalls = [];
+
+    // Both caller and target must exist as members; caller needs an admin role.
+    firestoreState.docs.set(`organizations/${orgId}/members/${adminEmail}`, {
+      exists: true,
+      data: { email: adminEmail, orgId, roleId: 'domain_admin' },
+    });
+    firestoreState.docs.set(`organizations/${orgId}/members/${targetEmail}`, {
+      exists: true,
+      data: { email: targetEmail, orgId, roleId: 'teacher' },
+    });
+
+    generatePasswordResetLinkMock.mockResolvedValue(resetUrl);
+  });
+
+  it('returns resetUrl and queues mail when invite-emails is enabled', async () => {
+    firestoreState.docs.set('global_permissions/invite-emails', {
+      exists: true,
+      data: { enabled: true, from: 'noreply@spartboard.app' },
+    });
+
+    const result = await handler({
+      auth: { uid: 'uid1', token: { email: adminEmail } },
+      data: { orgId, email: targetEmail },
+    });
+
+    expect(result).toMatchObject({
+      sent: true,
+      email: targetEmail,
+      resetUrl,
+    });
+    // Mail doc should have been written under /mail/pwreset-*.
+    const mailWrite = firestoreState.setCalls.find((c) =>
+      c.path.startsWith('mail/pwreset-')
+    );
+    expect(mailWrite).toBeDefined();
+    expect(mailWrite?.data).toMatchObject({
+      to: [targetEmail],
+      from: 'noreply@spartboard.app',
+    });
+  });
+
+  it('returns resetUrl with sent=false when invite-emails is disabled (the silent-failure fix)', async () => {
+    firestoreState.docs.set('global_permissions/invite-emails', {
+      exists: true,
+      data: { enabled: false },
+    });
+
+    const result = await handler({
+      auth: { uid: 'uid1', token: { email: adminEmail } },
+      data: { orgId, email: targetEmail },
+    });
+
+    expect(result).toEqual({
+      sent: false,
+      email: targetEmail,
+      resetUrl,
+    });
+    // No mail doc should have been written.
+    const mailWrites = firestoreState.setCalls.filter((c) =>
+      c.path.startsWith('mail/')
+    );
+    expect(mailWrites).toHaveLength(0);
+  });
+
+  it('returns resetUrl with sent=false when the global_permissions doc is missing', async () => {
+    // Default (no doc) → enabled: false. Same hand-deliver branch.
+    const result = await handler({
+      auth: { uid: 'uid1', token: { email: adminEmail } },
+      data: { orgId, email: targetEmail },
+    });
+
+    expect(result).toEqual({
+      sent: false,
+      email: targetEmail,
+      resetUrl,
+    });
+  });
+
+  it('rejects non-admin callers with permission-denied', async () => {
+    firestoreState.docs.set(`organizations/${orgId}/members/${adminEmail}`, {
+      exists: true,
+      data: { email: adminEmail, orgId, roleId: 'teacher' },
+    });
+
+    await expect(
+      handler({
+        auth: { uid: 'uid1', token: { email: adminEmail } },
+        data: { orgId, email: targetEmail },
+      })
+    ).rejects.toMatchObject({ code: 'permission-denied' });
+  });
+
+  it('returns failed-precondition when target has no Auth account yet', async () => {
+    firestoreState.docs.set('global_permissions/invite-emails', {
+      exists: true,
+      data: { enabled: true },
+    });
+    generatePasswordResetLinkMock.mockRejectedValueOnce(
+      Object.assign(new Error('user not found'), {
+        code: 'auth/user-not-found',
+      })
+    );
+
+    await expect(
+      handler({
+        auth: { uid: 'uid1', token: { email: adminEmail } },
+        data: { orgId, email: targetEmail },
+      })
+    ).rejects.toMatchObject({ code: 'failed-precondition' });
   });
 });

--- a/functions/src/organizationResetPassword.ts
+++ b/functions/src/organizationResetPassword.ts
@@ -38,8 +38,22 @@ export interface ResetPasswordPayload {
 }
 
 export interface ResetPasswordResponse {
+  /**
+   * True iff the email was successfully queued via the Trigger Email
+   * extension (i.e. global_permissions/invite-emails.enabled is true).
+   * When false, the email was NOT delivered — the caller is responsible
+   * for surfacing `resetUrl` to the admin so they can hand-deliver it
+   * (copy/paste, Slack, etc.). The link is still valid either way.
+   */
   sent: boolean;
   email: string;
+  /**
+   * The Firebase password-reset URL. Always present (it's minted before
+   * the email-queue branch). Sensitive: anyone with this URL can set the
+   * target user's password until it expires (~1 hour). Caller must not
+   * log it or display it outside the org-admin UI.
+   */
+  resetUrl: string;
 }
 
 function parsePayload(data: unknown): ResetPasswordPayload {
@@ -218,6 +232,6 @@ export const resetOrganizationUserPassword = onCall(
       sent = true;
     }
 
-    return { sent, email };
+    return { sent, email, resetUrl };
   }
 );

--- a/hooks/useOrgMembers.ts
+++ b/hooks/useOrgMembers.ts
@@ -371,19 +371,24 @@ export const useOrgMembers = (orgId: string | null) => {
     return rewriteClaimUrls(result.data);
   };
 
-  // Triggers a password reset email via the `resetOrganizationUserPassword`
-  // callable. The CF uses the Admin SDK to mint a reset link and sends it
-  // through the same mail transport as invites. Auth/membership checks run
-  // server-side; we only need to provide orgId + target email here.
+  // Triggers a password reset via the `resetOrganizationUserPassword`
+  // callable. The CF uses the Admin SDK to mint a reset link and (when the
+  // `invite-emails` flag is on) sends it through the same mail transport as
+  // invites. Auth/membership checks run server-side.
+  //
+  // The CF always returns `resetUrl` so the caller can surface it for
+  // copy/paste when `sent === false` (email queue disabled, future failure
+  // path, etc.). Without that, an admin would see no error but the user
+  // would never receive a reset link — silent auth failure.
   const resetPassword = async (
     email: string
-  ): Promise<{ sent: boolean; email: string }> => {
+  ): Promise<{ sent: boolean; email: string; resetUrl: string }> => {
     if (!orgId) {
       throw new Error('No organization selected.');
     }
     const callable = httpsCallable<
       { orgId: string; email: string },
-      { sent: boolean; email: string }
+      { sent: boolean; email: string; resetUrl: string }
     >(functions, 'resetOrganizationUserPassword');
     const result = await callable({ orgId, email: email.toLowerCase() });
     return result.data;

--- a/scripts/backfill-user-building-ids.js
+++ b/scripts/backfill-user-building-ids.js
@@ -29,13 +29,17 @@
  *   linger with legacy IDs and so analytics buckets collapse cleanly.
  *
  * WHAT THIS SCRIPT DOES
- *   - Enumerates every doc under /users/* (collection group not needed —
- *     the two affected fields live on /users/{uid} and
- *     /users/{uid}/userProfile/profile).
- *   - Rewrites `selectedBuildings` (on userProfile/profile) and `buildings`
- *     (on the root /users/{uid} doc) to canonical IDs, deduplicating in
- *     the process.
- *   - Skips writes when the array is already canonical (idempotent).
+ *   - PASS 1: enumerates /users/* and rewrites BOTH fields:
+ *       /users/{uid}.buildings        (root doc)
+ *       /users/{uid}/userProfile/profile.selectedBuildings
+ *   - PASS 2: collectionGroup sweep over `userProfile` docs to catch
+ *     orphan profiles whose parent /users/{uid} doc is a Firestore
+ *     "phantom" (exists only as the implicit ancestor of subcollection
+ *     writes, no fields, so PASS 1's collection() query skips it).
+ *   - Rewrites `selectedBuildings` and `buildings` to canonical IDs,
+ *     deduplicating in the process.
+ *   - Skips writes when the array is already canonical (idempotent —
+ *     safe to re-run).
  *
  * WHAT THIS SCRIPT DOES NOT DO
  *   - Does NOT touch /organizations/{orgId}/members/* — those are already
@@ -205,9 +209,15 @@ async function main() {
   let profilesScanned = 0;
   let profilesChanged = 0;
 
+  // Track which UIDs PASS 1 already covered, so PASS 2 can skip them.
+  // PASS 1 is needed because it's the only place we read & rewrite the
+  // root /users/{uid}.buildings field (collectionGroup can't reach
+  // arbitrary root-doc fields).
+  const profilesProcessed = new Set();
+
   const usersSnap = await db.collection('users').get();
   console.log(
-    `[backfill-user-building-ids] enumerated ${usersSnap.size} /users docs`
+    `[backfill-user-building-ids] PASS 1: enumerated ${usersSnap.size} /users docs`
   );
 
   for (const userDoc of usersSnap.docs) {
@@ -243,6 +253,7 @@ async function main() {
       .collection('userProfile')
       .doc('profile');
     const profileSnap = await profileRef.get();
+    profilesProcessed.add(uid);
     if (!profileSnap.exists) {
       if (args.verbose) {
         console.log(`  [users/${uid}/userProfile/profile] missing, skipping`);
@@ -271,6 +282,56 @@ async function main() {
       );
     }
   }
+
+  // PASS 2: collectionGroup sweep for orphan profile docs whose parent
+  // /users/{uid} doc is a Firestore "phantom" (no fields → invisible to
+  // collection().get()). We discovered 33 such profiles in prod the
+  // first time we ran this script with PASS 1 only.
+  console.log('');
+  console.log(
+    '[backfill-user-building-ids] PASS 2: collectionGroup sweep for orphan profile docs…'
+  );
+  let orphanProfilesScanned = 0;
+  let orphanProfilesChanged = 0;
+  const cgSnap = await db.collectionGroup('userProfile').get();
+  for (const profileDoc of cgSnap.docs) {
+    if (profileDoc.id !== 'profile') continue;
+    // Walk up to verify the parent is /users/{uid}, not some other
+    // collection that also happens to have a `userProfile` subcollection.
+    const parentUserRef = profileDoc.ref.parent.parent;
+    if (!parentUserRef || parentUserRef.parent.id !== 'users') continue;
+    const uid = parentUserRef.id;
+    if (profilesProcessed.has(uid)) continue;
+    orphanProfilesScanned++;
+    const profileData = profileDoc.data() ?? {};
+    if (!Array.isArray(profileData.selectedBuildings)) continue;
+    const { canonical, changed } = canonicalizeBuildingIds(
+      profileData.selectedBuildings
+    );
+    if (changed) {
+      orphanProfilesChanged++;
+      if (args.verbose || args.dryRun) {
+        console.log(
+          `  [orphan users/${uid}/userProfile/profile] selectedBuildings: ${JSON.stringify(profileData.selectedBuildings)} → ${JSON.stringify(canonical)}`
+        );
+      }
+      if (!args.dryRun) {
+        await profileDoc.ref.set(
+          { selectedBuildings: canonical },
+          { merge: true }
+        );
+      }
+    } else if (args.verbose) {
+      console.log(
+        `  [orphan users/${uid}/userProfile/profile] selectedBuildings already canonical, skipping`
+      );
+    }
+  }
+  profilesScanned += orphanProfilesScanned;
+  profilesChanged += orphanProfilesChanged;
+  console.log(
+    `[backfill-user-building-ids] PASS 2 found ${orphanProfilesScanned} orphan profiles, ${orphanProfilesChanged} needed canonicalization`
+  );
 
   console.log('');
   console.log('[backfill-user-building-ids] summary');

--- a/scripts/backfill-user-building-ids.js
+++ b/scripts/backfill-user-building-ids.js
@@ -35,9 +35,13 @@
  *   - PASS 2: collectionGroup sweep over `userProfile` docs to catch
  *     orphan profiles whose parent /users/{uid} doc is a Firestore
  *     "phantom" (exists only as the implicit ancestor of subcollection
- *     writes, no fields, so PASS 1's collection() query skips it).
- *   - Rewrites `selectedBuildings` and `buildings` to canonical IDs,
- *     deduplicating in the process.
+ *     writes, no fields, so PASS 1's collection() query skips it), and
+ *     rewrites only `selectedBuildings` on those profile docs. PASS 2
+ *     does NOT write a root `buildings` field — phantom parents have no
+ *     existing `buildings` to canonicalize, and the app self-heals the
+ *     root field on next login via `canonicalizeBuildingIds()`.
+ *   - Rewrites stored building-ID arrays to canonical IDs, deduplicating
+ *     in the process.
  *   - Skips writes when the array is already canonical (idempotent —
  *     safe to re-run).
  *
@@ -210,10 +214,10 @@ async function main() {
   let profilesChanged = 0;
 
   // Track which UIDs PASS 1 already covered, so PASS 2 can skip them.
-  // PASS 1 is needed because it's the only place we read & rewrite the
-  // root /users/{uid}.buildings field (collectionGroup can't reach
-  // arbitrary root-doc fields).
-  const profilesProcessed = new Set();
+  // PASS 1 is needed because it's the only way we can enumerate the root
+  // /users/{uid}.buildings field via a straightforward collection().get()
+  // (collectionGroup can't reach arbitrary root-doc fields).
+  const uidsProcessed = new Set();
 
   const usersSnap = await db.collection('users').get();
   console.log(
@@ -253,7 +257,7 @@ async function main() {
       .collection('userProfile')
       .doc('profile');
     const profileSnap = await profileRef.get();
-    profilesProcessed.add(uid);
+    uidsProcessed.add(uid);
     if (!profileSnap.exists) {
       if (args.verbose) {
         console.log(`  [users/${uid}/userProfile/profile] missing, skipping`);
@@ -301,7 +305,7 @@ async function main() {
     const parentUserRef = profileDoc.ref.parent.parent;
     if (!parentUserRef || parentUserRef.parent.id !== 'users') continue;
     const uid = parentUserRef.id;
-    if (profilesProcessed.has(uid)) continue;
+    if (uidsProcessed.has(uid)) continue;
     orphanProfilesScanned++;
     const profileData = profileDoc.data() ?? {};
     if (!Array.isArray(profileData.selectedBuildings)) continue;


### PR DESCRIPTION
## Summary

- **F4 silent-auth-failure fix**: `resetOrganizationUserPassword` always minted a Firebase reset link via the Admin SDK, but only returned `{ sent, email }`. When `global_permissions/invite-emails.enabled === false`, the function skipped the mail-queue write and the UI's `.then()` showed an unconditional success toast — the admin saw "Sent reset email" but no email ever went out. The CF now returns `resetUrl`, the UI branches on `result.sent`, and on `false` it copies the URL to the clipboard (mirroring the invite `claimUrl` flow) and tells the admin to paste it.
- **Backfill PASS 2**: `scripts/backfill-user-building-ids.js` originally enumerated `/users` via `collection().get()`, which silently skips Firestore "phantom" parent docs (root docs that exist only as the implicit ancestor of subcollection writes). 33 prod profiles sat under such phantoms. Added a `collectionGroup('userProfile')` sweep that walks `ref.parent.parent` to canonicalize orphans skipped by PASS 1. Verified in prod: 31 orphans canonicalized, 2 already matched.

## Why two commits in one PR

The backfill PASS 2 patch was uncovered while shipping the building-ID convergence work in #1371; bundling it here keeps the per-user-data fix surface coherent and avoids a one-line PR.

## Test plan

- [x] `pnpm -C functions test` — 148/148 pass (5 new happy-path tests for `resetOrganizationUserPassword`)
- [x] `pnpm test` — 456/456 root tests pass
- [x] `pnpm type-check:all` — clean (root + functions)
- [x] Lint clean on all modified files
- [ ] After merge: smoke test — flip `global_permissions/invite-emails.enabled` to `false` in dev, trigger a reset, verify clipboard copy + accurate toast
- [ ] After merge: re-run backfill in prod (`--dry-run` first) to confirm PASS 2 finds zero remaining orphans (idempotency check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)