### PR TITLE
fix(firestore): add mini_app_sessions composite index

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -87,6 +87,24 @@
           "order": "DESCENDING"
         }
       ]
+    },
+    {
+      "collectionGroup": "mini_app_sessions",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "appId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "teacherUid",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "createdAt",
+          "order": "DESCENDING"
+        }
+      ]
     }
   ],
   "fieldOverrides": []


### PR DESCRIPTION
## Summary
- Adds the missing `mini_app_sessions` composite index on `(appId ASC, teacherUid ASC, createdAt DESC)`.
- `useMiniAppSession.subscribeToAppSessions` (`hooks/useMiniAppSession.ts:137-143`) has been issuing this composite query without a matching index since the recent mini-app PRs landed, causing repeated `FAILED_PRECONDITION: requires an index` console errors for any teacher with a mini-app widget mounted.
- Mirrors the existing `video_activity_sessions` composite (same listener shape).

## Why this is its own PR
Index changes deploy via `firebase deploy --only firestore:indexes` and take a few minutes to build server-side. Keeping it isolated lets it ship and propagate before the larger UX/rules work that's queued behind it.

## Test plan
- [ ] CI green on `pr-validation`
- [ ] After merge, confirm Firebase Console shows the new composite index built
- [ ] Open SpartBoard, mount a Mini App widget, open the Assignments modal — confirm no `[useMiniAppSessionTeacher] Session list error` in DevTools console

## Notes for separate workstreams
Two related issues from the same user report are tracked separately and are NOT in this PR:
- The same listener appears to fire even when no mini-app widget is mounted (`B3` in plan) — root cause unknown, will be a separate PR after we identify the hidden mount point.
- Quiz-assignment creation fails for every account except the reporter's super-admin account (`C` in plan) — blocked on a network-tab capture from a failing account; will be a separate PR once root cause is known.

🤖 Generated with [Claude Code](https://claude.com/claude-code)