### PR TITLE
feat(test-classes): admin UI + sidebar + import dialog

### DIFF
--- a/components/admin/Organization/OrganizationPanel.tsx
+++ b/components/admin/Organization/OrganizationPanel.tsx
@@ -9,6 +9,7 @@ import {
   GraduationCap,
   ChevronLeft,
   Loader2,
+  FlaskConical,
 } from 'lucide-react';
 import { useAuth } from '@/context/useAuth';
 import { useOrganizations } from '@/hooks/useOrganizations';
@@ -18,6 +19,7 @@ import { useOrgDomains } from '@/hooks/useOrgDomains';
 import { useOrgRoles } from '@/hooks/useOrgRoles';
 import { useOrgMembers } from '@/hooks/useOrgMembers';
 import { useOrgStudentPage } from '@/hooks/useOrgStudentPage';
+import { useTestClasses } from '@/hooks/useTestClasses';
 import type {
   ActorRole,
   BuildingRecord,
@@ -35,6 +37,7 @@ import { BuildingsView } from './views/BuildingsView';
 import { RolesView } from './views/RolesView';
 import { UsersView } from './views/UsersView';
 import { StudentPageView } from './views/StudentPageView';
+import { TestClassesView } from './views/TestClassesView';
 import {
   OrgLogoTile,
   OrgToast,
@@ -48,7 +51,8 @@ type SectionId =
   | 'buildings'
   | 'roles'
   | 'users'
-  | 'student';
+  | 'student'
+  | 'testClasses';
 
 interface SectionDef {
   id: SectionId;
@@ -104,6 +108,13 @@ const SECTIONS: SectionDef[] = [
     label: 'Student page',
     sublabel: 'What students see.',
     icon: GraduationCap,
+    domainAdminOnly: true,
+  },
+  {
+    id: 'testClasses',
+    label: 'Test classes',
+    sublabel: 'Mock classes for PII-free SSO testing.',
+    icon: FlaskConical,
     domainAdminOnly: true,
   },
 ];
@@ -246,12 +257,20 @@ export const OrganizationPanel: React.FC = () => {
     loading: studentPageLoadingRaw,
     updateStudentPage,
   } = useOrgStudentPage(orgScopedOrgId);
+  const {
+    testClasses,
+    loading: testClassesLoadingRaw,
+    addTestClass,
+    updateTestClass,
+    removeTestClass,
+  } = useTestClasses(orgScopedOrgId);
   const orgLoading = orgLoadingRaw || isMembershipHydrating;
   const buildingsLoading = buildingsLoadingRaw || isMembershipHydrating;
   const domainsLoading = domainsLoadingRaw || isMembershipHydrating;
   const rolesLoading = rolesLoadingRaw || isMembershipHydrating;
   const usersLoading = usersLoadingRaw || isMembershipHydrating;
   const studentPageLoading = studentPageLoadingRaw || isMembershipHydrating;
+  const testClassesLoading = testClassesLoadingRaw || isMembershipHydrating;
 
   const [toast, setToast] = useState<{
     message: string;
@@ -478,6 +497,32 @@ export const OrganizationPanel: React.FC = () => {
     if (!writesEnabled) return comingSoon('Student page edits');
     run('Update student page', () => updateStudentPage(patch));
   };
+  // Test-class writes sit behind the same `org-admin-writes` gate so they
+  // match the coming-soon behavior of the other admin CRUD flows.
+  const handleAddTestClass = (input: {
+    classId?: string;
+    title: string;
+    subject?: string;
+    memberEmails: string;
+  }) => {
+    if (!writesEnabled) return comingSoon('Create test class');
+    run(
+      'Create test class',
+      () => addTestClass(input),
+      `Created "${input.title}"`
+    );
+  };
+  const handleUpdateTestClass = (
+    id: string,
+    patch: { title?: string; subject?: string; memberEmails?: string }
+  ) => {
+    if (!writesEnabled) return comingSoon('Update test class');
+    run('Update test class', () => updateTestClass(id, patch));
+  };
+  const handleRemoveTestClass = (id: string) => {
+    if (!writesEnabled) return comingSoon('Delete test class');
+    run('Delete test class', () => removeTestClass(id), 'Test class deleted');
+  };
 
   // Re-invite uses the existing `createOrganizationInvites` callable, which
   // overwrites the prior invitation doc with a fresh token. We auto-copy the
@@ -540,6 +585,7 @@ export const OrganizationPanel: React.FC = () => {
     roles: rolesLoading,
     users: usersLoading || rolesLoading,
     student: studentPageLoading,
+    testClasses: testClassesLoading,
   };
 
   return (
@@ -769,6 +815,14 @@ export const OrganizationPanel: React.FC = () => {
                 ) : (
                   <PanelEmpty message="Student page config has not been seeded yet." />
                 ))}
+              {effectiveSection === 'testClasses' && (
+                <TestClassesView
+                  testClasses={testClasses}
+                  onAdd={handleAddTestClass}
+                  onUpdate={handleUpdateTestClass}
+                  onRemove={handleRemoveTestClass}
+                />
+              )}
             </>
           )}
         </main>

--- a/components/admin/Organization/views/TestClassesView.tsx
+++ b/components/admin/Organization/views/TestClassesView.tsx
@@ -1,0 +1,317 @@
+import React, { useMemo, useState } from 'react';
+import { FlaskConical, Plus, Users, Mail } from 'lucide-react';
+import { useDialog } from '@/context/useDialog';
+import type { TestClassRecord } from '@/hooks/useTestClasses';
+import {
+  Badge,
+  Btn,
+  EmptyState,
+  Field,
+  Input,
+  RowMenu,
+  Textarea,
+  ViewHeader,
+  LocalModal,
+} from '../components/primitives';
+
+interface Props {
+  testClasses: TestClassRecord[];
+  onAdd: (input: {
+    classId?: string;
+    title: string;
+    subject?: string;
+    memberEmails: string;
+  }) => void;
+  onUpdate: (
+    id: string,
+    patch: { title?: string; subject?: string; memberEmails?: string }
+  ) => void;
+  onRemove: (id: string) => void;
+}
+
+export const TestClassesView: React.FC<Props> = ({
+  testClasses,
+  onAdd,
+  onUpdate,
+  onRemove,
+}) => {
+  const { showConfirm } = useDialog();
+  const [showAdd, setShowAdd] = useState(false);
+  const [editing, setEditing] = useState<TestClassRecord | null>(null);
+
+  const totalMembers = useMemo(
+    () => testClasses.reduce((a, c) => a + c.memberEmails.length, 0),
+    [testClasses]
+  );
+
+  const handleDelete = async (cls: TestClassRecord) => {
+    const confirmed = await showConfirm(
+      `Delete test class "${cls.title}"? Any students signed in via this class will lose access.`,
+      {
+        title: 'Delete Test Class',
+        variant: 'danger',
+        confirmLabel: 'Delete',
+      }
+    );
+    if (confirmed) onRemove(cls.id);
+  };
+
+  return (
+    <div>
+      <ViewHeader
+        title="Test classes"
+        blurb="Admin-managed mock classes for PII-free student SSO testing. Listed students can sign in via /join without going through ClassLink, and teachers see these classes with a TEST badge in their sidebar."
+        actions={
+          <Btn
+            variant="primary"
+            icon={<Plus size={14} />}
+            onClick={() => setShowAdd(true)}
+          >
+            New test class
+          </Btn>
+        }
+      />
+
+      {testClasses.length === 0 ? (
+        <EmptyState
+          icon={<FlaskConical size={26} />}
+          title="No test classes yet"
+          message="Create a test class with a few member emails to enable PII-free student SSO testing without ClassLink."
+          cta={
+            <Btn
+              variant="primary"
+              icon={<Plus size={14} />}
+              onClick={() => setShowAdd(true)}
+            >
+              New test class
+            </Btn>
+          }
+        />
+      ) : (
+        <>
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-3 mb-4">
+            <Stat
+              icon={<FlaskConical size={14} />}
+              label="Test classes"
+              value={testClasses.length.toString()}
+            />
+            <Stat
+              icon={<Users size={14} />}
+              label="Total member emails"
+              value={totalMembers.toString()}
+            />
+            <Stat
+              icon={<Mail size={14} />}
+              label="Bypass path"
+              value={
+                <span className="text-sm font-mono text-slate-700">/join</span>
+              }
+            />
+          </div>
+
+          <div className="bg-white rounded-xl border border-slate-200 shadow-[0_1px_2px_rgba(29,42,93,.06),0_1px_3px_rgba(29,42,93,.08)] overflow-hidden">
+            <div className="overflow-x-auto">
+              <div className="min-w-[640px]">
+                <div className="grid grid-cols-[2fr_1fr_0.7fr_auto] gap-4 px-5 py-3 border-b border-slate-200 text-[11px] font-semibold uppercase tracking-wide text-slate-500">
+                  <div>Class</div>
+                  <div>Subject</div>
+                  <div className="text-right">Members</div>
+                  <div />
+                </div>
+                {testClasses.map((cls) => (
+                  <div
+                    key={cls.id}
+                    className="grid grid-cols-[2fr_1fr_0.7fr_auto] items-center gap-4 px-5 py-3 border-b border-slate-100 last:border-b-0 hover:bg-slate-50 transition-colors min-w-0"
+                  >
+                    <div className="flex items-center gap-3 min-w-0">
+                      <div className="h-8 w-8 rounded-lg bg-amber-50 text-amber-600 flex items-center justify-center shrink-0">
+                        <FlaskConical size={16} />
+                      </div>
+                      <div className="min-w-0">
+                        <div className="text-sm font-semibold text-slate-800 truncate">
+                          {cls.title}
+                        </div>
+                        <div className="text-xs font-mono text-slate-500 truncate">
+                          {cls.id}
+                        </div>
+                      </div>
+                    </div>
+                    <div className="text-sm text-slate-700 truncate">
+                      {cls.subject ?? <span className="text-slate-400">—</span>}
+                    </div>
+                    <div className="text-right">
+                      <Badge color="amber">
+                        {cls.memberEmails.length} email
+                        {cls.memberEmails.length === 1 ? '' : 's'}
+                      </Badge>
+                    </div>
+                    <RowMenu
+                      items={[
+                        {
+                          label: 'Edit',
+                          onClick: () => setEditing(cls),
+                        },
+                        {
+                          label: 'Delete',
+                          onClick: () => void handleDelete(cls),
+                          danger: true,
+                        },
+                      ]}
+                    />
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+        </>
+      )}
+
+      {showAdd && (
+        <TestClassModal
+          mode="add"
+          onClose={() => setShowAdd(false)}
+          onSubmit={(input) => {
+            onAdd(input);
+            setShowAdd(false);
+          }}
+        />
+      )}
+      {editing && (
+        <TestClassModal
+          mode="edit"
+          initial={editing}
+          onClose={() => setEditing(null)}
+          onSubmit={(input) => {
+            onUpdate(editing.id, {
+              title: input.title,
+              subject: input.subject,
+              memberEmails: input.memberEmails,
+            });
+            setEditing(null);
+          }}
+        />
+      )}
+    </div>
+  );
+};
+
+const Stat: React.FC<{
+  icon: React.ReactNode;
+  label: string;
+  value: React.ReactNode;
+}> = ({ icon, label, value }) => (
+  <div className="bg-white rounded-xl border border-slate-200 p-4 shadow-[0_1px_2px_rgba(29,42,93,.06)]">
+    <div className="flex items-center gap-2 text-[11px] font-semibold uppercase tracking-wide text-slate-500">
+      <span className="text-slate-400">{icon}</span>
+      {label}
+    </div>
+    <div className="mt-2 text-2xl font-bold text-slate-900">{value}</div>
+  </div>
+);
+
+interface ModalProps {
+  mode: 'add' | 'edit';
+  initial?: TestClassRecord;
+  onClose: () => void;
+  onSubmit: (input: {
+    classId?: string;
+    title: string;
+    subject?: string;
+    memberEmails: string;
+  }) => void;
+}
+
+const TestClassModal: React.FC<ModalProps> = ({
+  mode,
+  initial,
+  onClose,
+  onSubmit,
+}) => {
+  const [classId, setClassId] = useState(initial?.id ?? '');
+  const [title, setTitle] = useState(initial?.title ?? '');
+  const [subject, setSubject] = useState(initial?.subject ?? '');
+  const [emails, setEmails] = useState(initial?.memberEmails.join('\n') ?? '');
+
+  const titleValid = title.trim().length > 0;
+  const emailsValid = emails.split(/[,\n]+/).some((e) => e.trim().length > 0);
+  const canSubmit = titleValid && emailsValid;
+
+  return (
+    <LocalModal
+      isOpen
+      onClose={onClose}
+      title={mode === 'add' ? 'New test class' : 'Edit test class'}
+      icon={<FlaskConical size={18} />}
+      footer={
+        <>
+          <Btn variant="ghost" onClick={onClose}>
+            Cancel
+          </Btn>
+          <Btn
+            variant="primary"
+            disabled={!canSubmit}
+            onClick={() =>
+              onSubmit({
+                classId:
+                  mode === 'add' ? classId.trim() || undefined : undefined,
+                title: title.trim(),
+                subject: subject.trim() || undefined,
+                memberEmails: emails,
+              })
+            }
+          >
+            {mode === 'add' ? 'Create' : 'Save'}
+          </Btn>
+        </>
+      }
+    >
+      <div className="space-y-4">
+        {mode === 'add' && (
+          <Field
+            label="Class ID"
+            hint="Optional. Leave blank to auto-generate from the title. Used as the Firestore doc ID and in student PINs."
+            htmlFor="test-class-id"
+          >
+            <Input
+              id="test-class-id"
+              value={classId}
+              onChange={(e) => setClassId(e.target.value)}
+              placeholder="mock-period-1"
+            />
+          </Field>
+        )}
+        <Field label="Title" required htmlFor="test-class-title">
+          <Input
+            id="test-class-title"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            placeholder="Mock Period 1 (QA)"
+            autoFocus
+          />
+        </Field>
+        <Field label="Subject" htmlFor="test-class-subject">
+          <Input
+            id="test-class-subject"
+            value={subject}
+            onChange={(e) => setSubject(e.target.value)}
+            placeholder="Math"
+          />
+        </Field>
+        <Field
+          label="Member emails"
+          required
+          hint="One per line or comma-separated. Emails are lowercased and deduplicated on save."
+          htmlFor="test-class-emails"
+        >
+          <Textarea
+            id="test-class-emails"
+            rows={6}
+            value={emails}
+            onChange={(e) => setEmails(e.target.value)}
+            placeholder={'student1@school.org\nstudent2@school.org'}
+          />
+        </Field>
+      </div>
+    </LocalModal>
+  );
+};

--- a/components/classes/ClassLinkImportDialog.tsx
+++ b/components/classes/ClassLinkImportDialog.tsx
@@ -1,11 +1,24 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { collection, getDocs } from 'firebase/firestore';
 import { Download, Loader2, RefreshCw, AlertCircle } from 'lucide-react';
 import { ClassLinkClass, ClassRoster, Student } from '@/types';
 import { Modal } from '@/components/common/Modal';
+import { db } from '@/config/firebase';
 import { classLinkService } from '@/utils/classlinkService';
+import { useAuth } from '@/context/useAuth';
 import { useDashboard } from '@/context/useDashboard';
 import { mergeClassLinkStudents } from './mergeClassLinkStudents';
+
+const TEST_PREFIX = 'test:';
+
+const materializeTestClassStudents = (emails: string[]): Student[] =>
+  emails.map((email) => ({
+    id: crypto.randomUUID(),
+    firstName: email.split('@')[0] || email,
+    lastName: '',
+    pin: '',
+  }));
 
 export type ClassLinkDialogMode =
   | { kind: 'new' }
@@ -33,12 +46,34 @@ export const ClassLinkImportDialog: React.FC<ClassLinkImportDialogProps> = ({
 }) => {
   const { t } = useTranslation();
   const { rosters, addRoster, updateRoster, addToast } = useDashboard();
+  const { user, userRoles, orgId, roleId } = useAuth();
+
+  const canReadTestClasses = useMemo(() => {
+    if (!orgId) return false;
+    const isSuperAdminByEmail = Boolean(
+      user?.email &&
+      userRoles?.superAdmins?.some(
+        (e) => e.toLowerCase() === user.email?.toLowerCase()
+      )
+    );
+    return (
+      isSuperAdminByEmail ||
+      roleId === 'super_admin' ||
+      roleId === 'domain_admin'
+    );
+  }, [orgId, roleId, userRoles, user?.email]);
 
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [classes, setClasses] = useState<ClassLinkClass[]>([]);
   const [studentsByClass, setStudentsByClass] = useState<
     Record<string, import('@/types').ClassLinkStudent[]>
+  >({});
+  // Emails per synthetic test class, keyed by `test:<classId>`. Kept separate
+  // from studentsByClass (which is typed for ClassLink students) so the import
+  // handler can branch cleanly on the id prefix.
+  const [testEmailsByClass, setTestEmailsByClass] = useState<
+    Record<string, string[]>
   >({});
   const [pendingId, setPendingId] = useState<string | null>(null);
 
@@ -49,12 +84,65 @@ export const ClassLinkImportDialog: React.FC<ClassLinkImportDialogProps> = ({
     setError(null);
     setClasses([]);
     setStudentsByClass({});
+    setTestEmailsByClass({});
     void (async () => {
+      // ClassLink fetch + test-class fetch run in parallel. Test-class fetch is
+      // only attempted when the actor clears the super/domain admin gate
+      // Firestore rules enforce; otherwise it's skipped entirely to avoid a
+      // guaranteed permission-denied round-trip.
+      const testPromise =
+        canReadTestClasses && orgId
+          ? getDocs(collection(db, 'organizations', orgId, 'testClasses'))
+              .then((snap) => {
+                const extraClasses: ClassLinkClass[] = [];
+                const extraEmails: Record<string, string[]> = {};
+                for (const d of snap.docs) {
+                  const data = d.data() as {
+                    title?: string;
+                    subject?: string;
+                    memberEmails?: unknown;
+                  };
+                  const emails = Array.isArray(data.memberEmails)
+                    ? data.memberEmails.filter(
+                        (e): e is string => typeof e === 'string'
+                      )
+                    : [];
+                  const key = `${TEST_PREFIX}${d.id}`;
+                  extraClasses.push({
+                    sourcedId: key,
+                    title: `${data.title ?? d.id} (test)`,
+                    subject: data.subject,
+                  });
+                  extraEmails[key] = emails;
+                }
+                return { extraClasses, extraEmails };
+              })
+              .catch((err) => {
+                if (import.meta.env.DEV) {
+                  console.warn(
+                    '[ClassLinkImportDialog] testClasses fetch failed:',
+                    err
+                  );
+                }
+                return {
+                  extraClasses: [] as ClassLinkClass[],
+                  extraEmails: {} as Record<string, string[]>,
+                };
+              })
+          : Promise.resolve({
+              extraClasses: [] as ClassLinkClass[],
+              extraEmails: {} as Record<string, string[]>,
+            });
+
       try {
-        const data = await classLinkService.getRosters(true);
+        const [data, testResult] = await Promise.all([
+          classLinkService.getRosters(true),
+          testPromise,
+        ]);
         if (cancelled) return;
-        setClasses(data.classes);
+        setClasses([...data.classes, ...testResult.extraClasses]);
         setStudentsByClass(data.studentsByClass);
+        setTestEmailsByClass(testResult.extraEmails);
       } catch (err) {
         if (cancelled) return;
         console.error('Failed to fetch from ClassLink', err);
@@ -70,20 +158,21 @@ export const ClassLinkImportDialog: React.FC<ClassLinkImportDialogProps> = ({
     return () => {
       cancelled = true;
     };
-  }, [isOpen, t]);
+  }, [isOpen, t, canReadTestClasses, orgId]);
 
   const handleImportNew = async (cls: ClassLinkClass) => {
     setPendingId(cls.sourcedId);
     try {
-      const students: Student[] = (studentsByClass[cls.sourcedId] ?? []).map(
-        (s) => ({
-          id: crypto.randomUUID(),
-          firstName: s.givenName,
-          lastName: s.familyName,
-          pin: '',
-          classLinkSourcedId: s.sourcedId,
-        })
-      );
+      const isTestClass = cls.sourcedId.startsWith(TEST_PREFIX);
+      const students: Student[] = isTestClass
+        ? materializeTestClassStudents(testEmailsByClass[cls.sourcedId] ?? [])
+        : (studentsByClass[cls.sourcedId] ?? []).map((s) => ({
+            id: crypto.randomUUID(),
+            firstName: s.givenName,
+            lastName: s.familyName,
+            pin: '',
+            classLinkSourcedId: s.sourcedId,
+          }));
       const subjectPrefix = cls.subject ? `${cls.subject} - ` : '';
       const codeSuffix = cls.classCode ? ` (${cls.classCode})` : '';
       const displayName = `${subjectPrefix}${cls.title}${codeSuffix}`;
@@ -232,54 +321,76 @@ export const ClassLinkImportDialog: React.FC<ClassLinkImportDialogProps> = ({
 
       {!loading && !error && classes.length > 0 && (
         <div className="flex flex-col gap-2 max-h-[60vh] overflow-y-auto custom-scrollbar pr-1">
-          {classes.map((cls) => {
-            const count = studentsByClass[cls.sourcedId]?.length ?? 0;
-            const isPending = pendingId === cls.sourcedId;
-            return (
-              <div
-                key={cls.sourcedId}
-                className="flex items-center justify-between gap-3 p-3 border border-slate-200 rounded-xl bg-white hover:border-brand-blue-primary hover:shadow-sm transition-all"
-              >
-                <div className="min-w-0 flex-1">
-                  <div className="text-sm font-bold text-slate-800 truncate">
-                    {cls.title}
-                  </div>
-                  <div className="text-xxs font-semibold text-slate-400 uppercase tracking-widest">
-                    {t('sidebar.classes.studentCount', {
-                      count,
-                      defaultValue: '{{count}} Student',
-                      defaultValue_other: '{{count}} Students',
-                    })}
-                    {cls.classCode ? ` · ${cls.classCode}` : ''}
-                  </div>
-                </div>
-                <button
-                  onClick={() =>
-                    mode.kind === 'new'
-                      ? void handleImportNew(cls)
-                      : void handleMergeInto(cls)
-                  }
-                  disabled={isPending}
-                  className="shrink-0 bg-brand-blue-primary text-white px-3 py-2 rounded-xl text-xxs font-bold uppercase tracking-wider hover:bg-brand-blue-dark transition-colors disabled:opacity-50 flex items-center gap-1.5"
+          {classes
+            // Test classes don't carry ClassLinkStudent records (no sourcedIds
+            // or full names), so `mergeClassLinkStudents` can't diff them
+            // against an existing roster. Hide them in merge mode.
+            .filter(
+              (cls) =>
+                !(
+                  mode.kind === 'merge' && cls.sourcedId.startsWith(TEST_PREFIX)
+                )
+            )
+            .map((cls) => {
+              const isTestClass = cls.sourcedId.startsWith(TEST_PREFIX);
+              const count = isTestClass
+                ? (testEmailsByClass[cls.sourcedId]?.length ?? 0)
+                : (studentsByClass[cls.sourcedId]?.length ?? 0);
+              const isPending = pendingId === cls.sourcedId;
+              return (
+                <div
+                  key={cls.sourcedId}
+                  className="flex items-center justify-between gap-3 p-3 border border-slate-200 rounded-xl bg-white hover:border-brand-blue-primary hover:shadow-sm transition-all"
                 >
-                  {isPending ? (
-                    <Loader2 className="w-3 h-3 animate-spin" />
-                  ) : mode.kind === 'new' ? (
-                    <Download className="w-3 h-3" />
-                  ) : (
-                    <RefreshCw className="w-3 h-3" />
-                  )}
-                  {mode.kind === 'new'
-                    ? t('sidebar.classes.classLinkImport', {
-                        defaultValue: 'Import',
-                      })
-                    : t('sidebar.classes.classLinkMerge', {
-                        defaultValue: 'Merge',
+                  <div className="min-w-0 flex-1">
+                    <div className="flex items-center gap-1.5 min-w-0">
+                      <div className="text-sm font-bold text-slate-800 truncate">
+                        {cls.title}
+                      </div>
+                      {isTestClass && (
+                        <span className="shrink-0 text-[9px] font-bold uppercase tracking-wider px-1.5 py-0.5 rounded bg-amber-100 text-amber-700 border border-amber-200">
+                          {t('sidebar.classes.testBadge', {
+                            defaultValue: 'TEST',
+                          })}
+                        </span>
+                      )}
+                    </div>
+                    <div className="text-xxs font-semibold text-slate-400 uppercase tracking-widest">
+                      {t('sidebar.classes.studentCount', {
+                        count,
+                        defaultValue: '{{count}} Student',
+                        defaultValue_other: '{{count}} Students',
                       })}
-                </button>
-              </div>
-            );
-          })}
+                      {cls.classCode ? ` · ${cls.classCode}` : ''}
+                    </div>
+                  </div>
+                  <button
+                    onClick={() =>
+                      mode.kind === 'new'
+                        ? void handleImportNew(cls)
+                        : void handleMergeInto(cls)
+                    }
+                    disabled={isPending}
+                    className="shrink-0 bg-brand-blue-primary text-white px-3 py-2 rounded-xl text-xxs font-bold uppercase tracking-wider hover:bg-brand-blue-dark transition-colors disabled:opacity-50 flex items-center gap-1.5"
+                  >
+                    {isPending ? (
+                      <Loader2 className="w-3 h-3 animate-spin" />
+                    ) : mode.kind === 'new' ? (
+                      <Download className="w-3 h-3" />
+                    ) : (
+                      <RefreshCw className="w-3 h-3" />
+                    )}
+                    {mode.kind === 'new'
+                      ? t('sidebar.classes.classLinkImport', {
+                          defaultValue: 'Import',
+                        })
+                      : t('sidebar.classes.classLinkMerge', {
+                          defaultValue: 'Merge',
+                        })}
+                  </button>
+                </div>
+              );
+            })}
         </div>
       )}
     </Modal>

--- a/components/classes/ClassLinkImportDialog.tsx
+++ b/components/classes/ClassLinkImportDialog.tsx
@@ -6,18 +6,22 @@ import { ClassLinkClass, ClassRoster, Student } from '@/types';
 import { Modal } from '@/components/common/Modal';
 import { db } from '@/config/firebase';
 import { classLinkService } from '@/utils/classlinkService';
+import { canReadTestClasses } from '@/utils/testClassAccess';
 import { useAuth } from '@/context/useAuth';
 import { useDashboard } from '@/context/useDashboard';
 import { mergeClassLinkStudents } from './mergeClassLinkStudents';
 
 const TEST_PREFIX = 'test:';
 
+// PINs match the synthetic sidebar rosters in `useTestClassRosters.ts` so the
+// same test student uses the same PIN whether they're joining through the
+// sidebar roster or a freshly-imported copy.
 const materializeTestClassStudents = (emails: string[]): Student[] =>
-  emails.map((email) => ({
+  emails.map((email, i) => ({
     id: crypto.randomUUID(),
     firstName: email.split('@')[0] || email,
     lastName: '',
-    pin: '',
+    pin: String(i + 1).padStart(2, '0'),
   }));
 
 export type ClassLinkDialogMode =
@@ -48,20 +52,10 @@ export const ClassLinkImportDialog: React.FC<ClassLinkImportDialogProps> = ({
   const { rosters, addRoster, updateRoster, addToast } = useDashboard();
   const { user, userRoles, orgId, roleId } = useAuth();
 
-  const canReadTestClasses = useMemo(() => {
-    if (!orgId) return false;
-    const isSuperAdminByEmail = Boolean(
-      user?.email &&
-      userRoles?.superAdmins?.some(
-        (e) => e.toLowerCase() === user.email?.toLowerCase()
-      )
-    );
-    return (
-      isSuperAdminByEmail ||
-      roleId === 'super_admin' ||
-      roleId === 'domain_admin'
-    );
-  }, [orgId, roleId, userRoles, user?.email]);
+  const canReadTestClassesForOrg = useMemo(
+    () => canReadTestClasses(orgId, roleId, userRoles, user?.email),
+    [orgId, roleId, userRoles, user?.email]
+  );
 
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -91,7 +85,7 @@ export const ClassLinkImportDialog: React.FC<ClassLinkImportDialogProps> = ({
       // Firestore rules enforce; otherwise it's skipped entirely to avoid a
       // guaranteed permission-denied round-trip.
       const testPromise =
-        canReadTestClasses && orgId
+        canReadTestClassesForOrg && orgId
           ? getDocs(collection(db, 'organizations', orgId, 'testClasses'))
               .then((snap) => {
                 const extraClasses: ClassLinkClass[] = [];
@@ -140,7 +134,13 @@ export const ClassLinkImportDialog: React.FC<ClassLinkImportDialogProps> = ({
           testPromise,
         ]);
         if (cancelled) return;
-        setClasses([...data.classes, ...testResult.extraClasses]);
+        // Sort the merged list alphabetically so the real ClassLink rosters
+        // and synthetic test classes interleave predictably in the picker.
+        const combinedClasses = [
+          ...data.classes,
+          ...testResult.extraClasses,
+        ].sort((a, b) => a.title.localeCompare(b.title));
+        setClasses(combinedClasses);
         setStudentsByClass(data.studentsByClass);
         setTestEmailsByClass(testResult.extraEmails);
       } catch (err) {
@@ -158,7 +158,7 @@ export const ClassLinkImportDialog: React.FC<ClassLinkImportDialogProps> = ({
     return () => {
       cancelled = true;
     };
-  }, [isOpen, t, canReadTestClasses, orgId]);
+  }, [isOpen, t, canReadTestClassesForOrg, orgId]);
 
   const handleImportNew = async (cls: ClassLinkClass) => {
     setPendingId(cls.sourcedId);

--- a/components/layout/sidebar/SidebarClasses.tsx
+++ b/components/layout/sidebar/SidebarClasses.tsx
@@ -54,7 +54,7 @@ export const SidebarClasses: React.FC<SidebarClassesProps> = ({
 
   const editingRoster: ClassRoster | null =
     editingRosterId && editingRosterId !== 'new'
-      ? (rosters.find((r) => r.id === editingRosterId) ?? null)
+      ? (rosters.find((r) => r.id === editingRosterId && !r.readOnly) ?? null)
       : null;
 
   const handleSaveRoster = async (name: string, students: Student[]) => {
@@ -183,6 +183,7 @@ export const SidebarClasses: React.FC<SidebarClassesProps> = ({
                 <div className="flex flex-col gap-2">
                   {rosters.map((r) => {
                     const isActive = activeRosterId === r.id;
+                    const isTestClass = r.source === 'testClass';
                     return (
                       <div
                         key={r.id}
@@ -226,8 +227,23 @@ export const SidebarClasses: React.FC<SidebarClassesProps> = ({
                           />
                         </button>
                         <div className="flex-1 min-w-0">
-                          <div className="text-sm font-bold text-slate-800 truncate">
-                            {r.name}
+                          <div className="flex items-center gap-1.5 min-w-0">
+                            <div className="text-sm font-bold text-slate-800 truncate">
+                              {r.name}
+                            </div>
+                            {isTestClass && (
+                              <span
+                                className="shrink-0 text-[9px] font-bold uppercase tracking-wider px-1.5 py-0.5 rounded bg-amber-100 text-amber-700 border border-amber-200"
+                                title={t('sidebar.classes.testBadgeTitle', {
+                                  defaultValue:
+                                    'Admin-managed mock class for SSO testing',
+                                })}
+                              >
+                                {t('sidebar.classes.testBadge', {
+                                  defaultValue: 'TEST',
+                                })}
+                              </span>
+                            )}
                           </div>
                           {r.loadError ? (
                             <div
@@ -249,50 +265,55 @@ export const SidebarClasses: React.FC<SidebarClassesProps> = ({
                           )}
                         </div>
                         <div className="flex items-center gap-0.5 shrink-0">
-                          <button
-                            onClick={() => setEditingRosterId(r.id)}
-                            className="p-1.5 text-slate-400 hover:text-brand-blue-primary hover:bg-brand-blue-lighter rounded-lg transition-colors"
-                            title={t('sidebar.classes.edit', {
-                              defaultValue: 'Edit Class',
-                            })}
-                            aria-label={t('sidebar.classes.edit', {
-                              defaultValue: 'Edit Class',
-                            })}
-                          >
-                            <Pencil className="w-3.5 h-3.5" />
-                          </button>
-                          {classLinkEnabled && (
-                            <button
-                              onClick={() =>
-                                setClassLinkMode({
-                                  kind: 'merge',
-                                  rosterId: r.id,
-                                  rosterName: r.name,
-                                })
-                              }
-                              className="p-1.5 text-slate-400 hover:text-brand-blue-primary hover:bg-brand-blue-lighter rounded-lg transition-colors"
-                              title={t('sidebar.classes.syncClassLink', {
-                                defaultValue: 'Sync with ClassLink',
-                              })}
-                              aria-label={t('sidebar.classes.syncClassLink', {
-                                defaultValue: 'Sync with ClassLink',
-                              })}
-                            >
-                              <RefreshCw className="w-3.5 h-3.5" />
-                            </button>
+                          {!isTestClass && (
+                            <>
+                              <button
+                                onClick={() => setEditingRosterId(r.id)}
+                                className="p-1.5 text-slate-400 hover:text-brand-blue-primary hover:bg-brand-blue-lighter rounded-lg transition-colors"
+                                title={t('sidebar.classes.edit', {
+                                  defaultValue: 'Edit Class',
+                                })}
+                                aria-label={t('sidebar.classes.edit', {
+                                  defaultValue: 'Edit Class',
+                                })}
+                              >
+                                <Pencil className="w-3.5 h-3.5" />
+                              </button>
+                              {classLinkEnabled && (
+                                <button
+                                  onClick={() =>
+                                    setClassLinkMode({
+                                      kind: 'merge',
+                                      rosterId: r.id,
+                                      rosterName: r.name,
+                                    })
+                                  }
+                                  className="p-1.5 text-slate-400 hover:text-brand-blue-primary hover:bg-brand-blue-lighter rounded-lg transition-colors"
+                                  title={t('sidebar.classes.syncClassLink', {
+                                    defaultValue: 'Sync with ClassLink',
+                                  })}
+                                  aria-label={t(
+                                    'sidebar.classes.syncClassLink',
+                                    { defaultValue: 'Sync with ClassLink' }
+                                  )}
+                                >
+                                  <RefreshCw className="w-3.5 h-3.5" />
+                                </button>
+                              )}
+                              <button
+                                onClick={() => void handleDelete(r)}
+                                className="p-1.5 text-slate-400 hover:text-red-500 hover:bg-red-50 rounded-lg transition-colors"
+                                title={t('sidebar.classes.delete', {
+                                  defaultValue: 'Delete Class',
+                                })}
+                                aria-label={t('sidebar.classes.delete', {
+                                  defaultValue: 'Delete Class',
+                                })}
+                              >
+                                <Trash2 className="w-3.5 h-3.5" />
+                              </button>
+                            </>
                           )}
-                          <button
-                            onClick={() => void handleDelete(r)}
-                            className="p-1.5 text-slate-400 hover:text-red-500 hover:bg-red-50 rounded-lg transition-colors"
-                            title={t('sidebar.classes.delete', {
-                              defaultValue: 'Delete Class',
-                            })}
-                            aria-label={t('sidebar.classes.delete', {
-                              defaultValue: 'Delete Class',
-                            })}
-                          >
-                            <Trash2 className="w-3.5 h-3.5" />
-                          </button>
                         </div>
                       </div>
                     );

--- a/context/DashboardContext.tsx
+++ b/context/DashboardContext.tsx
@@ -23,6 +23,7 @@ import {
   FeaturePermission,
   MaterialsGlobalConfig,
   DrawableObject,
+  ClassRoster,
 } from '../types';
 import { useAuth } from './useAuth';
 import { stripTransientKeys } from '../utils/widgetConfigPersistence';
@@ -40,6 +41,10 @@ import {
   dashboardHasPII,
 } from '../utils/dashboardPII';
 import { useRosters } from '../hooks/useRosters';
+import {
+  useTestClassRosters,
+  isTestClassRosterId,
+} from '../hooks/useTestClassRosters';
 import { useGoogleDrive } from '../hooks/useGoogleDrive';
 import { DashboardContext } from './DashboardContextValue';
 import { validateGridConfig, sanitizeAIConfig } from '../utils/ai_security';
@@ -96,6 +101,9 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
     savedWidgetConfigs,
     saveWidgetConfig,
     remoteControlEnabled: accountRemoteControlEnabled,
+    orgId,
+    roleId,
+    userRoles,
   } = useAuth();
   const { driveService, userDomain } = useGoogleDrive();
   const {
@@ -454,14 +462,55 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
 
   // --- ROSTER LOGIC ---
   const {
-    rosters,
+    rosters: userRosters,
     activeRosterId,
     addRoster,
-    updateRoster,
-    deleteRoster,
+    updateRoster: baseUpdateRoster,
+    deleteRoster: baseDeleteRoster,
     setActiveRoster,
-    setAbsentStudents,
+    setAbsentStudents: baseSetAbsentStudents,
   } = useRosters(user);
+
+  // Admin-managed mock classes surface as synthetic read-only rosters so the
+  // sidebar and pickers don't need two different data shapes.
+  const testClassRosters = useTestClassRosters(
+    orgId,
+    roleId,
+    userRoles,
+    user?.email
+  );
+
+  const rosters = useMemo(
+    () => [...userRosters, ...testClassRosters],
+    [userRosters, testClassRosters]
+  );
+
+  // Short-circuit mutations targeting test-class rosters. They are managed
+  // from the admin panel, not the per-user roster CRUD path, so any write
+  // here would target a non-existent `/users/{uid}/rosters/` doc.
+  const updateRoster = useCallback(
+    async (id: string, updates: Partial<ClassRoster>) => {
+      if (isTestClassRosterId(id)) return;
+      return baseUpdateRoster(id, updates);
+    },
+    [baseUpdateRoster]
+  );
+
+  const deleteRoster = useCallback(
+    async (id: string) => {
+      if (isTestClassRosterId(id)) return;
+      return baseDeleteRoster(id);
+    },
+    [baseDeleteRoster]
+  );
+
+  const setAbsentStudents = useCallback(
+    async (rosterId: string, studentIds: string[]) => {
+      if (isTestClassRosterId(rosterId)) return;
+      return baseSetAbsentStudents(rosterId, studentIds);
+    },
+    [baseSetAbsentStudents]
+  );
 
   // Refs to prevent race conditions
   const lastLocalUpdateAt = useRef<number>(0);

--- a/hooks/useTestClassRosters.ts
+++ b/hooks/useTestClassRosters.ts
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { collection, onSnapshot } from 'firebase/firestore';
 import { db } from '../config/firebase';
 import { ClassRoster, Student, UserRolesConfig } from '../types';
+import { canReadTestClasses } from '../utils/testClassAccess';
 
 /**
  * Prefix used for synthetic roster IDs, student IDs, and Drive-less student
@@ -69,20 +70,10 @@ export const useTestClassRosters = (
 ): ClassRoster[] => {
   const [rosters, setRosters] = useState<ClassRoster[]>([]);
 
-  const canRead = useMemo(() => {
-    if (!orgId) return false;
-    const isSuperAdminByEmail = Boolean(
-      userEmail &&
-      userRoles?.superAdmins?.some(
-        (e) => e.toLowerCase() === userEmail.toLowerCase()
-      )
-    );
-    return (
-      isSuperAdminByEmail ||
-      roleId === 'super_admin' ||
-      roleId === 'domain_admin'
-    );
-  }, [orgId, roleId, userRoles, userEmail]);
+  const canRead = useMemo(
+    () => canReadTestClasses(orgId, roleId, userRoles, userEmail),
+    [orgId, roleId, userRoles, userEmail]
+  );
 
   // Render-time reset: when the subscription key changes (can't read anymore
   // or the org switched), clear stale rosters immediately rather than letting

--- a/hooks/useTestClassRosters.ts
+++ b/hooks/useTestClassRosters.ts
@@ -1,0 +1,122 @@
+import { useEffect, useMemo, useState } from 'react';
+import { collection, onSnapshot } from 'firebase/firestore';
+import { db } from '../config/firebase';
+import { ClassRoster, Student, UserRolesConfig } from '../types';
+
+/**
+ * Prefix used for synthetic roster IDs, student IDs, and Drive-less student
+ * records derived from test-class member emails. Namespaced so these IDs can
+ * never collide with Firestore-generated user roster IDs.
+ */
+export const TEST_CLASS_ROSTER_PREFIX = 'test:';
+
+export const isTestClassRosterId = (id: string): boolean =>
+  id.startsWith(TEST_CLASS_ROSTER_PREFIX);
+
+interface TestClassDoc {
+  title?: string;
+  subject?: string;
+  memberEmails?: unknown;
+  createdAt?: { toMillis?: () => number } | number;
+}
+
+/**
+ * Adapt the admin-managed testClass doc shape into a synthetic ClassRoster so
+ * the sidebar "My Classes" list can render it alongside real rosters. Member
+ * emails become students with the email local-part as the baseline name —
+ * proper display names only exist after the student logs in and is resolved
+ * by the grading path.
+ */
+const adaptTestClass = (classId: string, data: TestClassDoc): ClassRoster => {
+  const emails: string[] = Array.isArray(data.memberEmails)
+    ? data.memberEmails.filter((e): e is string => typeof e === 'string')
+    : [];
+  const students: Student[] = emails.map((email, i) => ({
+    id: `${TEST_CLASS_ROSTER_PREFIX}${email.toLowerCase()}`,
+    firstName: email.split('@')[0] || email,
+    lastName: '',
+    pin: String(i + 1).padStart(2, '0'),
+  }));
+  const createdAt =
+    typeof data.createdAt === 'number'
+      ? data.createdAt
+      : typeof data.createdAt?.toMillis === 'function'
+        ? data.createdAt.toMillis()
+        : Date.now();
+  return {
+    id: `${TEST_CLASS_ROSTER_PREFIX}${classId}`,
+    name: `${data.title ?? classId} (test)`,
+    driveFileId: null,
+    studentCount: students.length,
+    createdAt,
+    students,
+    source: 'testClass',
+    readOnly: true,
+  };
+};
+
+/**
+ * Subscribe to the admin-managed testClasses subcollection and expose its docs
+ * as synthetic read-only ClassRosters. Mirrors the role gate Firestore rules
+ * enforce at `firestore.rules:345`; returns [] when the actor can't read it so
+ * we never issue a doomed query.
+ */
+export const useTestClassRosters = (
+  orgId: string | null,
+  roleId: string | null,
+  userRoles: UserRolesConfig | null,
+  userEmail: string | null | undefined
+): ClassRoster[] => {
+  const [rosters, setRosters] = useState<ClassRoster[]>([]);
+
+  const canRead = useMemo(() => {
+    if (!orgId) return false;
+    const isSuperAdminByEmail = Boolean(
+      userEmail &&
+      userRoles?.superAdmins?.some(
+        (e) => e.toLowerCase() === userEmail.toLowerCase()
+      )
+    );
+    return (
+      isSuperAdminByEmail ||
+      roleId === 'super_admin' ||
+      roleId === 'domain_admin'
+    );
+  }, [orgId, roleId, userRoles, userEmail]);
+
+  // Render-time reset: when the subscription key changes (can't read anymore
+  // or the org switched), clear stale rosters immediately rather than letting
+  // the previous org's test classes flash before the effect re-runs. Using
+  // the "adjusting state while rendering" pattern avoids a setState-in-effect
+  // lint error.
+  const subKey = canRead && orgId ? orgId : '';
+  const [prevSubKey, setPrevSubKey] = useState(subKey);
+  if (prevSubKey !== subKey) {
+    setPrevSubKey(subKey);
+    if (rosters.length > 0) setRosters([]);
+  }
+
+  useEffect(() => {
+    if (!canRead || !orgId) return;
+    const col = collection(db, 'organizations', orgId, 'testClasses');
+    const unsub = onSnapshot(
+      col,
+      (snap) => {
+        setRosters(
+          snap.docs
+            .map((d) => adaptTestClass(d.id, d.data() as TestClassDoc))
+            .sort((a, b) => a.name.localeCompare(b.name))
+        );
+      },
+      (err) => {
+        if (import.meta.env.DEV) {
+          console.warn('[useTestClassRosters] snapshot failed:', err);
+        }
+        setRosters([]);
+      }
+    );
+    return () => unsub();
+  }, [canRead, orgId]);
+
+  return rosters;
+};

--- a/hooks/useTestClasses.ts
+++ b/hooks/useTestClasses.ts
@@ -3,6 +3,7 @@ import {
   collection,
   deleteDoc,
   doc,
+  getDoc,
   onSnapshot,
   serverTimestamp,
   setDoc,
@@ -130,6 +131,16 @@ export const useTestClasses = (orgId: string | null) => {
       trimmedId && trimmedId.length > 0
         ? trimmedId
         : slugOrFallback(input.title, 'testclass');
+    // Guard against slug collisions (explicit ids or auto-slugs that happen
+    // to match an existing class). setDoc without an existence check would
+    // silently overwrite the other admin's class.
+    const ref = doc(db, 'organizations', orgId, 'testClasses', id);
+    const existing = await getDoc(ref);
+    if (existing.exists()) {
+      throw new Error(
+        `A test class with id "${id}" already exists. Choose a different title or class id.`
+      );
+    }
     const payload: Record<string, unknown> = {
       title: input.title.trim(),
       memberEmails: emails,
@@ -137,7 +148,7 @@ export const useTestClasses = (orgId: string | null) => {
       createdBy: user?.uid ?? 'unknown',
     };
     if (input.subject?.trim()) payload.subject = input.subject.trim();
-    await setDoc(doc(db, 'organizations', orgId, 'testClasses', id), payload);
+    await setDoc(ref, payload);
   };
 
   const updateTestClass = async (

--- a/hooks/useTestClasses.ts
+++ b/hooks/useTestClasses.ts
@@ -1,0 +1,182 @@
+import { useEffect, useState } from 'react';
+import {
+  collection,
+  deleteDoc,
+  doc,
+  onSnapshot,
+  serverTimestamp,
+  setDoc,
+  updateDoc,
+} from 'firebase/firestore';
+import { db, isAuthBypass } from '@/config/firebase';
+import { useAuth } from '@/context/useAuth';
+import { slugOrFallback } from '@/utils/slug';
+
+export interface TestClassRecord {
+  id: string;
+  title: string;
+  subject?: string;
+  memberEmails: string[];
+  createdAt?: number | null;
+  createdBy?: string;
+}
+
+interface TestClassDoc {
+  title?: string;
+  subject?: string;
+  memberEmails?: unknown;
+  createdAt?: { toMillis?: () => number } | number | null;
+  createdBy?: string;
+}
+
+const normalizeEmails = (input: string | string[]): string[] => {
+  const raw = Array.isArray(input) ? input : input.split(/[,\n]+/);
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const e of raw) {
+    const trimmed = e.trim().toLowerCase();
+    if (!trimmed) continue;
+    if (seen.has(trimmed)) continue;
+    seen.add(trimmed);
+    out.push(trimmed);
+  }
+  return out;
+};
+
+/**
+ * Subscribes to `/organizations/{orgId}/testClasses` — the admin-managed mock
+ * class allowlist used by the studentLoginV1 Cloud Function to bypass
+ * ClassLink/OneRoster for PII-free SSO testing.
+ *
+ * Writes (add/update/remove) are gated by Firestore rules to super/domain
+ * admins of the org (see `firestore.rules:344`).
+ */
+export const useTestClasses = (orgId: string | null) => {
+  const { user } = useAuth();
+  const [testClasses, setTestClasses] = useState<TestClassRecord[]>([]);
+  const [error, setError] = useState<Error | null>(null);
+
+  const shouldSubscribe = !isAuthBypass && Boolean(user) && Boolean(orgId);
+  const [loading, setLoading] = useState<boolean>(shouldSubscribe);
+
+  const [prevKey, setPrevKey] = useState(`${shouldSubscribe}:${orgId ?? ''}`);
+  const nextKey = `${shouldSubscribe}:${orgId ?? ''}`;
+  if (prevKey !== nextKey) {
+    setPrevKey(nextKey);
+    setLoading(shouldSubscribe);
+    if (!shouldSubscribe) {
+      setTestClasses([]);
+      setError(null);
+    }
+  }
+
+  useEffect(() => {
+    if (!shouldSubscribe || !orgId) return;
+
+    const unsub = onSnapshot(
+      collection(db, 'organizations', orgId, 'testClasses'),
+      (snapshot) => {
+        const items: TestClassRecord[] = snapshot.docs
+          .map((d) => {
+            const data = d.data() as TestClassDoc;
+            const createdAt =
+              typeof data.createdAt === 'number'
+                ? data.createdAt
+                : typeof data.createdAt?.toMillis === 'function'
+                  ? data.createdAt.toMillis()
+                  : null;
+            const memberEmails = Array.isArray(data.memberEmails)
+              ? data.memberEmails.filter(
+                  (e): e is string => typeof e === 'string'
+                )
+              : [];
+            return {
+              id: d.id,
+              title: data.title ?? d.id,
+              subject: data.subject,
+              memberEmails,
+              createdAt,
+              createdBy: data.createdBy,
+            };
+          })
+          .sort((a, b) => a.title.localeCompare(b.title));
+        setTestClasses(items);
+        setError(null);
+        setLoading(false);
+      },
+      (err) => {
+        console.error(`[useTestClasses:${orgId}] snapshot error:`, err);
+        setError(err);
+        setLoading(false);
+      }
+    );
+    return unsub;
+  }, [shouldSubscribe, orgId]);
+
+  const addTestClass = async (input: {
+    classId?: string;
+    title: string;
+    subject?: string;
+    memberEmails: string | string[];
+  }): Promise<void> => {
+    if (!orgId) throw new Error('No organization selected.');
+    if (!input.title.trim()) throw new Error('Title is required.');
+    const emails = normalizeEmails(input.memberEmails);
+    if (emails.length === 0) {
+      throw new Error('At least one member email is required.');
+    }
+    const trimmedId = input.classId?.trim();
+    const id =
+      trimmedId && trimmedId.length > 0
+        ? trimmedId
+        : slugOrFallback(input.title, 'testclass');
+    const payload: Record<string, unknown> = {
+      title: input.title.trim(),
+      memberEmails: emails,
+      createdAt: serverTimestamp(),
+      createdBy: user?.uid ?? 'unknown',
+    };
+    if (input.subject?.trim()) payload.subject = input.subject.trim();
+    await setDoc(doc(db, 'organizations', orgId, 'testClasses', id), payload);
+  };
+
+  const updateTestClass = async (
+    id: string,
+    patch: {
+      title?: string;
+      subject?: string;
+      memberEmails?: string | string[];
+    }
+  ): Promise<void> => {
+    if (!orgId) throw new Error('No organization selected.');
+    const update: Record<string, unknown> = {};
+    if (patch.title !== undefined) update.title = patch.title.trim();
+    if (patch.subject !== undefined) {
+      const s = patch.subject.trim();
+      update.subject = s.length > 0 ? s : null;
+    }
+    if (patch.memberEmails !== undefined) {
+      const emails = normalizeEmails(patch.memberEmails);
+      if (emails.length === 0) {
+        throw new Error('At least one member email is required.');
+      }
+      update.memberEmails = emails;
+    }
+    if (Object.keys(update).length === 0) return;
+    await updateDoc(doc(db, 'organizations', orgId, 'testClasses', id), update);
+  };
+
+  const removeTestClass = async (id: string): Promise<void> => {
+    if (!orgId) throw new Error('No organization selected.');
+    await deleteDoc(doc(db, 'organizations', orgId, 'testClasses', id));
+  };
+
+  return {
+    testClasses,
+    loading,
+    error,
+    addTestClass,
+    updateTestClass,
+    removeTestClass,
+  };
+};

--- a/types.ts
+++ b/types.ts
@@ -134,6 +134,20 @@ export interface ClassRoster extends ClassRosterMeta {
    * unknown" so the UI can show a retry banner instead of "0 students".
    */
   loadError?: string;
+  /**
+   * Where this roster came from. `'user'` (default, omitted) means it lives in
+   * `/users/{uid}/rosters/` and is editable. `'testClass'` means it's a
+   * synthetic adapter for an admin-managed `/organizations/{orgId}/testClasses/`
+   * doc, surfaced read-only so admins can target it without import.
+   */
+  source?: 'user' | 'testClass';
+  /**
+   * True for rosters that must not be mutated through the normal
+   * add/update/delete paths (e.g., testClass-sourced rosters are managed from
+   * the admin panel instead). UI hides Edit/Delete/Sync affordances; the hook
+   * short-circuits mutations defensively.
+   */
+  readOnly?: boolean;
 }
 
 // --- LIVE SESSION TYPES ---

--- a/utils/testClassAccess.ts
+++ b/utils/testClassAccess.ts
@@ -1,0 +1,25 @@
+import { UserRolesConfig } from '@/types';
+
+/**
+ * Whether the actor can read `/organizations/{orgId}/testClasses`. Mirrors the
+ * role gate Firestore rules enforce at `firestore.rules:345`. Kept in one
+ * place so the sidebar hook and the ClassLink import dialog stay in lock-step
+ * with the rule.
+ */
+export const canReadTestClasses = (
+  orgId: string | null | undefined,
+  roleId: string | null | undefined,
+  userRoles: UserRolesConfig | null | undefined,
+  userEmail: string | null | undefined
+): boolean => {
+  if (!orgId) return false;
+  const isSuperAdminByEmail = Boolean(
+    userEmail &&
+    userRoles?.superAdmins?.some(
+      (e) => e.toLowerCase() === userEmail.toLowerCase()
+    )
+  );
+  return (
+    isSuperAdminByEmail || roleId === 'super_admin' || roleId === 'domain_admin'
+  );
+};


### PR DESCRIPTION
## Summary

Surfaces admin-managed test classes (`/organizations/{orgId}/testClasses`) in three places so mock rosters for PII-free student SSO testing can be created, edited, and used without running `scripts/add-test-class.js` with a service-account key.

- **Admin CRUD panel** — new "Test classes" section under Organization admin (domain-admin-only) with list, create/edit modal, and delete confirmation.
- **Sidebar "My Classes"** — test classes render as synthetic read-only rosters with a TEST badge; Edit/Sync/Delete are hidden.
- **ClassLink Import Dialog** — test classes appear alongside real ClassLink classes and can be imported into a teacher's own rosters.

## Changes

| File | Purpose |
| --- | --- |
| `hooks/useTestClasses.ts` (new) | Admin CRUD hook. Normalizes + dedupes emails, stamps `createdBy` + `serverTimestamp`. Auth delegated to existing Firestore rules. |
| `components/admin/Organization/views/TestClassesView.tsx` (new) | Admin panel view — list, modal, confirm-delete. |
| `components/admin/Organization/OrganizationPanel.tsx` | Registers `Test classes` section (domain-admin-only), wires handlers. |
| `hooks/useTestClassRosters.ts` (new) | Teacher-facing hook that adapts test classes into synthetic `ClassRoster`s (`id: "test:<classId>"`, `readOnly: true`). |
| `context/DashboardContext.tsx` | Merges test rosters; mutations short-circuit on `test:` ids. |
| `components/layout/sidebar/SidebarClasses.tsx` | TEST badge + hides Edit/Sync/Delete for `readOnly` rosters. |
| `components/classes/ClassLinkImportDialog.tsx` | Fetches test classes in parallel; materializes students from `memberEmails`. |
| `types.ts` | `ClassRoster` gains optional `source` + `readOnly`. |

## Test plan

- [ ] `pnpm run validate` passes (type-check + lint + format + tests)
- [ ] As super admin: open Admin Settings → Organization → Test classes; create/edit/delete a class; verify rows persist in Firestore
- [ ] As the same admin: open sidebar "My Classes" — test class renders with TEST badge, no Edit/Sync/Delete; Set-active works
- [ ] Click ClassLink Import — test class appears in the picker; importing produces a normal user roster that can be edited
- [ ] As non-admin teacher in the same org: Test classes tab is hidden, no test classes in sidebar/import, no permission-denied errors in console
- [ ] `/join` SSO bypass with a test member still works (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)