### PR TITLE
fix(mini-app): gate session-list listener on Assignments modal

### DIFF
--- a/components/widgets/MiniApp/Widget.tsx
+++ b/components/widgets/MiniApp/Widget.tsx
@@ -490,8 +490,13 @@ export const MiniAppWidget: React.FC<WidgetComponentProps> = ({
     setAssignmentsForApp(null);
   };
 
-  // Subscribe to sessions for whichever app the teacher is managing
-  const targetAppId = assignmentsForApp?.id ?? activeApp?.id;
+  // Subscribe to sessions only when the Assignments modal is open. The
+  // previous `?? activeApp?.id` fallback kept this listener live whenever a
+  // teacher had ever opened a mini-app (since `activeApp` is persisted in
+  // `widget.config.activeApp`), producing constant `mini_app_sessions`
+  // listener traffic and "requires an index" console spam for users who
+  // never open the Assignments modal.
+  const targetAppId = assignmentsForApp?.id;
   useEffect(() => {
     if (!user?.uid || !targetAppId) {
       unsubscribeFromAppSessions();


### PR DESCRIPTION
## Summary

- The MiniApp widget was subscribing to `mini_app_sessions` via `assignmentsForApp?.id ?? activeApp?.id`. Because `activeApp` is persisted in `widget.config.activeApp`, the fallback kept the listener live for any teacher who had ever opened a mini-app — even when the Assignments modal was closed and even after the widget was minimized.
- Drop the `?? activeApp?.id` fallback so the listener fires only while the Assignments modal is actually open, eliminating the spurious `[useMiniAppSessionTeacher] Session list error: ... requires an index` console spam users were seeing on dashboards with no visibly active mini-app.
- Pairs with #1386 (the missing `mini_app_sessions` composite index). With this PR, the listener simply doesn't run when nobody is looking at the session list.

## Background

A teacher reported repeated `Session list error` log spam from `useMiniAppSessionTeacher` even though no mini-app widget appeared to be active on the board. Re-grepping confirmed there is exactly one call site for `useMiniAppSessionTeacher` (`components/widgets/MiniApp/Widget.tsx:356`), so the only way for that listener to fire is through this widget — but the listener was being triggered by the persisted `activeApp` config rather than by the modal that actually consumes the data.

## Test plan

- [ ] Teacher opens a board with a MiniApp widget that has an `activeApp` selected (the previous trigger condition). Confirm DevTools → Network → WS shows no `mini_app_sessions` Listen channel until the Assignments modal is opened.
- [ ] Open the Assignments modal — the session-list listener should attach and the existing list UI should populate.
- [ ] Close the Assignments modal — the listener should detach (no `Listen` channel for `mini_app_sessions`).
- [ ] Confirm no `[useMiniAppSessionTeacher] Session list error: ... requires an index` console messages on a board where the Assignments modal is never opened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)