### PR TITLE
fix(rules): hoist studentRole short-circuit on session reads to unbreak teacher creates

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -577,12 +577,10 @@ service cloud.firestore {
     // owns the document and stores their uid on the `teacherUid` field.
     // Multiple concurrent sessions per teacher are allowed.
     match /quiz_sessions/{sessionId} {
-      // Students need `list` access to find sessions by join code via a
-      // collection-group query (getDocs + where('code', '==',...)).
-      // Restricting enumeration fully requires a Cloud Function proxy; for now
-      // we accept that authenticated users can list session documents.
-      // `get` allows reading a single known document (students listening for
-      // question index updates after joining).
+      // Students need both `get` (single-doc reads after joining) and `list`
+      // (collection query by join code via `where('code', '==', ...)`) access.
+      // Restricting enumeration fully would require a Cloud Function proxy;
+      // for now we accept that authenticated users can list session documents.
       //
       // studentRole (GIS-authenticated) users must additionally have the
       // session's classId in their classIds custom claim. Non-student callers
@@ -596,10 +594,7 @@ service cloud.firestore {
       // inside a function-call wrapper, even though the OR would short-circuit
       // at runtime. Hoisting matches the pattern already used by
       // `mini_app_sessions` below.
-      allow get: if request.auth != null &&
-        (!isStudentRoleUser() ||
-         passesStudentClassGate(resource.data.get('classId', '')));
-      allow list: if request.auth != null &&
+      allow read: if request.auth != null &&
         (!isStudentRoleUser() ||
          passesStudentClassGate(resource.data.get('classId', '')));
       // Only the teacher (session owner) can create/update/delete the session document.

--- a/firestore.rules
+++ b/firestore.rules
@@ -587,10 +587,21 @@ service cloud.firestore {
       // studentRole (GIS-authenticated) users must additionally have the
       // session's classId in their classIds custom claim. Non-student callers
       // (teachers, admins, anonymous PIN students) are unaffected.
+      //
+      // The `!isStudentRoleUser()` short-circuit MUST appear at the top level
+      // of the rule rather than buried inside `passesStudentClassGate` — the
+      // Firestore rules engine performs static analysis on `list` queries and
+      // can reject teacher list calls (e.g. `useQuizAssignments.allocateJoinCode`
+      // doing `where code == X`) when a `resource.data` reference appears
+      // inside a function-call wrapper, even though the OR would short-circuit
+      // at runtime. Hoisting matches the pattern already used by
+      // `mini_app_sessions` below.
       allow get: if request.auth != null &&
-        passesStudentClassGate(resource.data.get('classId', ''));
+        (!isStudentRoleUser() ||
+         passesStudentClassGate(resource.data.get('classId', '')));
       allow list: if request.auth != null &&
-        passesStudentClassGate(resource.data.get('classId', ''));
+        (!isStudentRoleUser() ||
+         passesStudentClassGate(resource.data.get('classId', '')));
       // Only the teacher (session owner) can create/update/delete the session document.
       // Ownership is carried on the `teacherUid` field (no longer the doc id).
       allow create: if request.auth != null &&
@@ -724,9 +735,11 @@ service cloud.firestore {
     match /video_activity_sessions/{sessionId} {
       // Any authenticated user (including anonymous) can read session documents.
       // studentRole (GIS) users additionally must have the session's classId
-      // in their classIds claim.
+      // in their classIds claim. The `!isStudentRoleUser()` check is hoisted
+      // to the top level (see quiz_sessions for rationale).
       allow read: if request.auth != null &&
-        passesStudentClassGate(resource.data.get('classId', ''));
+        (!isStudentRoleUser() ||
+         passesStudentClassGate(resource.data.get('classId', '')));
       // Only authenticated (non-anonymous) users can create sessions (teachers)
       allow create: if request.auth != null && request.auth.token.firebase.sign_in_provider != 'anonymous';
       // Teacher owners may rename or end sessions, but not mutate session content.
@@ -902,9 +915,11 @@ service cloud.firestore {
     match /guided_learning_sessions/{sessionId} {
       // Any authenticated user (including anonymous) can read session documents.
       // studentRole (GIS) users additionally must have the session's classId
-      // in their classIds claim.
+      // in their classIds claim. The `!isStudentRoleUser()` check is hoisted
+      // to the top level (see quiz_sessions for rationale).
       allow read: if request.auth != null &&
-        passesStudentClassGate(resource.data.get('classId', ''));
+        (!isStudentRoleUser() ||
+         passesStudentClassGate(resource.data.get('classId', '')));
       // Only authenticated (non-anonymous) teachers can create sessions; they must own it
       allow create: if request.auth != null &&
         request.auth.token.firebase.sign_in_provider != 'anonymous' &&
@@ -961,9 +976,11 @@ service cloud.firestore {
     match /activity_wall_sessions/{sessionId} {
       // Any authenticated user can read the session metadata from a valid share link.
       // studentRole (GIS) users additionally must have the session's classId
-      // in their classIds claim.
+      // in their classIds claim. The `!isStudentRoleUser()` check is hoisted
+      // to the top level (see quiz_sessions for rationale).
       allow read: if request.auth != null &&
-        passesStudentClassGate(resource.data.get('classId', ''));
+        (!isStudentRoleUser() ||
+         passesStudentClassGate(resource.data.get('classId', '')));
       // Only authenticated non-anonymous teachers/admins can create or update the session document itself.
       allow create, update: if request.auth != null &&
                             request.auth.token.firebase.sign_in_provider != 'anonymous' &&


### PR DESCRIPTION
## Summary

Restores quiz / video-activity / guided-learning / activity-wall assignment creation, which has been silently failing for ~28 hours since the `be6fc294` deploy. Single-file change to `firestore.rules` that hoists the `!isStudentRoleUser()` short-circuit out of `passesStudentClassGate(...)` and to the top level of the affected `get`/`list`/`read` rules.

## Why teachers can't create assignments

`useQuizAssignments.allocateJoinCode` (and the equivalent in VA/GL) issues a `where('code','==',X)` **list** query against `quiz_sessions` before every create, to pick a non-colliding 6-char code. After `be6fc294` the list rule became:

```
allow list: if request.auth != null &&
  passesStudentClassGate(resource.data.get('classId', ''));
```

`passesStudentClassGate` is `!isStudentRoleUser() || studentRoleCanAccessClass(classId)`. At runtime, the `!isStudentRoleUser()` would short-circuit to `true` for teachers without ever evaluating `resource.data`. **But Firestore's rules engine does static analysis on `list` queries** and rejects calls when a `resource.data.get(...)` reference appears inside a function-call wrapper, even when the OR would short-circuit at runtime. Result: every teacher's `allocateJoinCode` throws `permission-denied`, the create batch never runs, the toast says "Failed to start session," and no docs appear.

The fix matches the pattern already used by `mini_app_sessions` (line 809), which the `be6fc294` author wrote correctly there but missed on the other four collections:

```diff
- allow read: if request.auth != null &&
-   passesStudentClassGate(resource.data.get('classId', ''));
+ allow read: if request.auth != null &&
+   (!isStudentRoleUser() ||
+    passesStudentClassGate(resource.data.get('classId', '')));
```

Student-side gating semantics are preserved — the check inside `passesStudentClassGate` already begins with `isStudentRoleUser()`, so the hoisted top-level branch is identity-equivalent at runtime. Only the engine's static analyzer sees a different shape.

## Empirical evidence (server-side diagnostic via Firebase MCP)

| Finding | Source |
|---|---|
| Most recent successful `quiz_session` create across the entire prod database predates the `be6fc294` deploy (2026-04-21 16:25 CDT) | `firestore_list_documents quiz_sessions` |
| 5 distinct super-admin accounts confirmed to have NO custom claims | `auth_get_users` |
| Affected user docs (`paul.ivers`, `jennifer.ivers`) are structurally identical | `firestore_get_document users/{uid}` |
| Deployed rules verified to match local rules byte-for-byte | `firebase_get_security_rules` |
| `mini_app_sessions` (line 809) already structured this way and is the one collection where teachers can still create assignments today | grep |

The user's framing of "works for me, fails for everyone else" was a memory artifact — Paul's last successful create was 5 hours BEFORE the deploy. The bug is universal, not account-discriminating.

## Affected rules

- `quiz_sessions` `get` + `list` (line 590-593)
- `video_activity_sessions` `read` (line 728-729)
- `guided_learning_sessions` `read` (line 906-907)
- `activity_wall_sessions` `read` (line 965-966)

`mini_app_sessions` (line 809-811) is already correct and untouched.

## Test plan

- [ ] CI: type-check + format-check + tests pass
- [ ] Firebase rules validator: `firebase deploy --only firestore:rules --dry-run` (or merge → CI handles it)
- [ ] Post-deploy manual smoke (any teacher account):
  - [ ] Quiz → Assign → Create → assignment appears in "In progress"
  - [ ] Video Activity → Assign → Create → same
  - [ ] Guided Learning → Assign → Create → same
- [ ] Post-deploy manual smoke (studentRole user via `/student/login`):
  - [ ] Student in class can see / open their assigned quiz
  - [ ] Student NOT in class cannot read sessions for that class

## Follow-up

Separate PR will land `tests/rules/sessions.test.ts` with rules-emulator unit tests covering: (a) teacher can `list` quiz_sessions, (b) studentRole user in class can `get`, (c) studentRole user not in class is rejected. This locks in the fix and prevents the next person who edits these rules from regressing.

## Out of scope

Workstream A (unified `AssignClassPicker` for Quiz + VA + GL) is queued behind this PR; we don't want to mix rules + UI in the same change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)