### PR TITLE
fix(rules): drop resource.data gate from session `get` to unbreak teacher Start

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -77,6 +77,27 @@ jobs:
           path: playwright-report/
           retention-days: 30
 
+  rules:
+    runs-on: ubuntu-24.04
+    name: Firestore Rules Tests
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js and pnpm
+        uses: ./.github/actions/setup
+
+      # firebase-tools is in the root lockfile (pnpm exec firebase).
+      # The Firestore emulator is a Java process, so we need a JDK.
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - name: Run Firestore rules tests
+        run: pnpm run test:rules
+
   build:
     runs-on: ubuntu-24.04
     name: Build
@@ -101,12 +122,12 @@ jobs:
           VITE_PEXELS_API_KEY: ${{ secrets.VITE_PEXELS_API_KEY || 'test-key' }}
 
   summary:
-    needs: [quality, test, build, e2e]
+    needs: [quality, test, rules, build, e2e]
     runs-on: ubuntu-24.04
     if: always()
     steps:
       - name: Add PR Comment
-        if: ${{ needs.quality.result == 'success' && needs.test.result == 'success' && needs.build.result == 'success' && needs.e2e.result == 'success' }}
+        if: ${{ needs.quality.result == 'success' && needs.test.result == 'success' && needs.rules.result == 'success' && needs.build.result == 'success' && needs.e2e.result == 'success' }}
         continue-on-error: true
         uses: actions/github-script@v7
         with:
@@ -120,7 +141,7 @@ jobs:
             })
 
       - name: Add PR Comment on Failure
-        if: ${{ needs.quality.result == 'failure' || needs.test.result == 'failure' || needs.build.result == 'failure' || needs.e2e.result == 'failure' }}
+        if: ${{ needs.quality.result == 'failure' || needs.test.result == 'failure' || needs.rules.result == 'failure' || needs.build.result == 'failure' || needs.e2e.result == 'failure' }}
         continue-on-error: true
         uses: actions/github-script@v7
         with:

--- a/firestore.rules
+++ b/firestore.rules
@@ -577,37 +577,27 @@ service cloud.firestore {
     // owns the document and stores their uid on the `teacherUid` field.
     // Multiple concurrent sessions per teacher are allowed.
     match /quiz_sessions/{sessionId} {
-      // Reads are split into `get` (single doc) and `list` (collection query)
-      // because Firestore's rules engine treats them differently:
+      // Reads are intentionally permissive: any authenticated caller can
+      // `get` and `list` session documents. PR #1390 split this into
+      // `get`/`list` and kept a `resource.data`-based studentRole class gate
+      // on `get`, on the theory that `get` rules have `resource.data`
+      // available at evaluation time. Empirically that still denied teacher
+      // single-doc subscriptions after a paused→active transition, breaking
+      // the Start flow; removing the `resource.data` reference unblocks it
+      // without widening enumeration beyond what the list rule already
+      // allows.
       //
-      //   - `get` evaluates per-document at read time. The studentRole class
-      //     gate can safely reference `resource.data` because the engine has
-      //     a concrete document to evaluate against.
-      //   - `list` is statically analyzed BEFORE execution. Any `resource.data`
-      //     reference in the predicate is treated as "unprovable for arbitrary
-      //     docs" and the entire list is denied — even when an earlier OR
-      //     branch (`!isStudentRoleUser()`) would short-circuit at runtime.
-      //     This is the failure mode that broke teacher assignment creation
-      //     for ~2 days; the previous "hoist" fix in #1389 was insufficient
-      //     because the static analyzer does not respect short-circuit OR.
-      //
-      // Splitting the rule lets the `list` predicate stay free of any
-      // `resource.data` reference. The list rule is the broad "any
-      // authenticated caller can enumerate session docs" allowance —
-      // studentRole users need this so MyAssignmentsPage can run its
-      // `where('classId', 'in', myClassIds)` discovery query, and PIN-flow
-      // students need it for code lookups. Per-class gating is still
-      // enforced at the `get` rule (and at write time on responses), so
-      // a studentRole user can list metadata but cannot open the contents
-      // of a session outside their classIds claim.
+      // studentRole (ClassLink-via-Google SSO) class gating is now enforced
+      // exclusively on the response write rules below, which dereference
+      // the parent session's `classId` via a runtime `get()` — a per-write
+      // fetch, not a predicate the analyzer has to reason about ahead of
+      // time. Students can see session metadata by id but cannot submit a
+      // response to a session outside their classIds claim.
       //
       // Restricting enumeration further would require a Cloud Function
-      // proxy; for now we accept that any authenticated user can list
+      // proxy; for now we accept that any authenticated user can read
       // session documents (matches the pre-SSO behavior).
-      allow get: if request.auth != null &&
-        (!isStudentRoleUser() ||
-         passesStudentClassGate(resource.data.get('classId', '')));
-      allow list: if request.auth != null;
+      allow read: if request.auth != null;
       // Only the teacher (session owner) can create/update/delete the session document.
       // Ownership is carried on the `teacherUid` field (no longer the doc id).
       allow create: if request.auth != null &&
@@ -739,16 +729,13 @@ service cloud.firestore {
 
     // Video Activity Sessions — Teacher creates, anonymous students can read and submit responses
     match /video_activity_sessions/{sessionId} {
-      // Reads split into `get` + `list`; see quiz_sessions for the rationale
-      // (Firestore static-analyzes `list` predicates and rejects any rule
-      // that touches `resource.data`, even behind a short-circuit OR).
-      // The `list` rule allows any authenticated caller so studentRole users
-      // can run their MyAssignmentsPage class-filtered discovery queries;
-      // per-doc class gating still happens at `get`.
-      allow get: if request.auth != null &&
-        (!isStudentRoleUser() ||
-         passesStudentClassGate(resource.data.get('classId', '')));
-      allow list: if request.auth != null;
+      // Reads are intentionally permissive for any authenticated caller.
+      // See quiz_sessions for the rationale: a `resource.data`-based
+      // studentRole class gate on `get` still denied teacher single-doc
+      // subscriptions after a status transition; the class gate is now
+      // enforced on the response write rules below, which dereference the
+      // parent session's `classId` via a runtime `get()`.
+      allow read: if request.auth != null;
       // Only authenticated (non-anonymous) users can create sessions (teachers)
       allow create: if request.auth != null && request.auth.token.firebase.sign_in_provider != 'anonymous';
       // Teacher owners may rename or end sessions, but not mutate session content.
@@ -824,19 +811,13 @@ service cloud.firestore {
 
     // MiniApp Assignment Sessions — Teacher creates, anonymous students can read
     match /mini_app_sessions/{sessionId} {
-      // Reads split into `get` + `list`; see quiz_sessions for the rationale
-      // (Firestore static-analyzes `list` predicates and rejects any rule
-      // that touches `resource.data`, even behind a short-circuit OR).
-      // The `list` rule allows any authenticated caller so studentRole users
-      // can run their MyAssignmentsPage `array-contains-any` discovery query;
-      // per-doc class gating still happens at `get`.
-      // studentRole (GIS) users additionally must have at least one of the
-      // session's classIds in their classIds claim (or the session must be
-      // untargeted — empty classIds — for shareable-link launches).
-      allow get: if request.auth != null &&
-        (!isStudentRoleUser() ||
-         passesStudentClassGateList(resource.data.get('classIds', [])));
-      allow list: if request.auth != null;
+      // Reads are intentionally permissive for any authenticated caller.
+      // See quiz_sessions for the rationale: a `resource.data`-based
+      // studentRole class gate on `get` still denied teacher single-doc
+      // subscriptions; the class gate is now enforced on the submission
+      // write rules below, which dereference the parent session's
+      // `classIds` via a runtime `get()`.
+      allow read: if request.auth != null;
       // Only authenticated (non-anonymous) teachers can create sessions they own
       allow create: if request.auth != null &&
         request.auth.token.firebase.sign_in_provider != 'anonymous' &&
@@ -928,16 +909,13 @@ service cloud.firestore {
 
     // Guided Learning Sessions — Teacher creates, authenticated (incl. anonymous) students read and submit
     match /guided_learning_sessions/{sessionId} {
-      // Reads split into `get` + `list`; see quiz_sessions for the rationale
-      // (Firestore static-analyzes `list` predicates and rejects any rule
-      // that touches `resource.data`, even behind a short-circuit OR).
-      // The `list` rule allows any authenticated caller so studentRole users
-      // can run their MyAssignmentsPage class-filtered discovery queries;
-      // per-doc class gating still happens at `get`.
-      allow get: if request.auth != null &&
-        (!isStudentRoleUser() ||
-         passesStudentClassGate(resource.data.get('classId', '')));
-      allow list: if request.auth != null;
+      // Reads are intentionally permissive for any authenticated caller.
+      // See quiz_sessions for the rationale: a `resource.data`-based
+      // studentRole class gate on `get` still denied teacher single-doc
+      // subscriptions; the class gate is now enforced on the response
+      // write rules below, which dereference the parent session's
+      // `classId` via a runtime `get()`.
+      allow read: if request.auth != null;
       // Only authenticated (non-anonymous) teachers can create sessions; they must own it
       allow create: if request.auth != null &&
         request.auth.token.firebase.sign_in_provider != 'anonymous' &&
@@ -992,16 +970,13 @@ service cloud.firestore {
     // Activity Wall Sessions — Teacher owns it (UID prefix in sessionId), students submit entries
     // sessionId is formatted as {teacherUid}_{activityId}
     match /activity_wall_sessions/{sessionId} {
-      // Reads split into `get` + `list`; see quiz_sessions for the rationale
-      // (Firestore static-analyzes `list` predicates and rejects any rule
-      // that touches `resource.data`, even behind a short-circuit OR).
-      // The `list` rule allows any authenticated caller so studentRole users
-      // can run their MyAssignmentsPage class-filtered discovery queries;
-      // per-doc class gating still happens at `get`.
-      allow get: if request.auth != null &&
-        (!isStudentRoleUser() ||
-         passesStudentClassGate(resource.data.get('classId', '')));
-      allow list: if request.auth != null;
+      // Reads are intentionally permissive for any authenticated caller.
+      // See quiz_sessions for the rationale: a `resource.data`-based
+      // studentRole class gate on `get` still denied teacher single-doc
+      // subscriptions; the class gate is now enforced on the submission
+      // write rules below, which dereference the parent session's
+      // `classId` via a runtime `get()`.
+      allow read: if request.auth != null;
       // Only authenticated non-anonymous teachers/admins can create or update the session document itself.
       allow create, update: if request.auth != null &&
                             request.auth.token.firebase.sign_in_provider != 'anonymous' &&

--- a/firestore.rules
+++ b/firestore.rules
@@ -597,6 +597,13 @@ service cloud.firestore {
       // Restricting enumeration further would require a Cloud Function
       // proxy; for now we accept that any authenticated user can read
       // session documents (matches the pre-SSO behavior).
+      //
+      // Privacy impact: any authenticated user who knows a sessionId (a
+      // v4 UUID — unguessable in practice) can read `code`, `classId`,
+      // `publicQuestions` (answer-key-stripped by schema — see types.ts
+      // `QuizPublicQuestion`), and `revealedAnswers` (populated only when
+      // the teacher has intentionally broadcast a reveal). No PII fields
+      // live on the session doc itself.
       allow read: if request.auth != null;
       // Only the teacher (session owner) can create/update/delete the session document.
       // Ownership is carried on the `teacherUid` field (no longer the doc id).

--- a/tests/rules/studentRoleClassGate.test.ts
+++ b/tests/rules/studentRoleClassGate.test.ts
@@ -7,6 +7,14 @@
 // Covers the five session collections where passesStudentClassGate() is applied:
 //   quiz_sessions, video_activity_sessions, guided_learning_sessions,
 //   mini_app_sessions, activity_wall_sessions
+//
+// Contract: session reads are intentionally permissive for any authenticated
+// caller (teacher single-doc subscriptions otherwise fail with
+// permission-denied after a status transition — see PR #1391). studentRole
+// class gating is enforced exclusively on the response/submission *write*
+// rules, which dereference the parent session's `classId` via a runtime
+// `get()`. A studentRole user can see session metadata by id but cannot
+// submit to a session outside their `classIds` claim.
 
 import { readFileSync } from 'fs';
 import { fileURLToPath } from 'url';
@@ -196,7 +204,7 @@ const ALL_SESSION_COLS = [
   'activity_wall_sessions',
 ];
 
-describe('student-role class gate — session reads', () => {
+describe('session reads — authenticated access (class gate moved to writes)', () => {
   beforeEach(async () => {
     await testEnv.clearFirestore();
     await seedSessions(ALL_SESSION_COLS);
@@ -208,13 +216,17 @@ describe('student-role class gate — session reads', () => {
         await assertSucceeds(getDoc(doc(asStudentA(), `${col}/${SESSION_A}`)));
       });
 
-      it('student with matching classId cannot read session-B (wrong class)', async () => {
-        await assertFails(getDoc(doc(asStudentA(), `${col}/${SESSION_B}`)));
+      it('student can read session-B (out-of-class metadata is no longer gated at reads; write rules enforce the class gate)', async () => {
+        await assertSucceeds(getDoc(doc(asStudentA(), `${col}/${SESSION_B}`)));
       });
 
-      it('student with empty classIds cannot read any session', async () => {
-        await assertFails(getDoc(doc(asStudentEmpty(), `${col}/${SESSION_A}`)));
-        await assertFails(getDoc(doc(asStudentEmpty(), `${col}/${SESSION_B}`)));
+      it('student with empty classIds can still read session metadata', async () => {
+        await assertSucceeds(
+          getDoc(doc(asStudentEmpty(), `${col}/${SESSION_A}`))
+        );
+        await assertSucceeds(
+          getDoc(doc(asStudentEmpty(), `${col}/${SESSION_B}`))
+        );
       });
 
       it('teacher (no studentRole claim) can read any session', async () => {

--- a/tests/rules/studentRoleClassGate.test.ts
+++ b/tests/rules/studentRoleClassGate.test.ts
@@ -25,7 +25,16 @@ import {
   assertFails,
   type RulesTestEnvironment,
 } from '@firebase/rules-unit-testing';
-import { setDoc, getDoc, addDoc, collection, doc } from 'firebase/firestore';
+import {
+  setDoc,
+  getDoc,
+  getDocs,
+  addDoc,
+  collection,
+  doc,
+  query,
+  where,
+} from 'firebase/firestore';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -707,6 +716,310 @@ describe('mini_app_sessions/submissions — student-role gate', () => {
     });
     await assertSucceeds(
       getDoc(doc(asTeacher(), subPath(SESSION_A, 'anyone')))
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// End-to-end lifecycle — walks the real client sequence for the full quiz
+// flow so a rules regression on any step fails a test. Reproduces:
+//   - The join-code probe (where('code', '==', X)) from PR #1390.
+//   - The single-doc onSnapshot listener from PR #1391.
+//   - The studentRole MyAssignmentsPage discovery query.
+//   - The response create + submit-answers + teacher-finalize sequence.
+// ---------------------------------------------------------------------------
+
+describe('quiz_sessions — end-to-end lifecycle', () => {
+  const SESSION_ID = 'lifecycle-session';
+  const JOIN_CODE = 'TESTCD';
+  const STUDENT_B_UID = 'student-b-uid';
+
+  const asStudentB = () =>
+    testEnv
+      .authenticatedContext(STUDENT_B_UID, {
+        studentRole: true,
+        classIds: [CLASS_B],
+      })
+      .firestore();
+
+  const baseSessionShape = {
+    id: SESSION_ID,
+    assignmentId: SESSION_ID,
+    teacherUid: TEACHER_UID,
+    classId: CLASS_A,
+    code: JOIN_CODE,
+    sessionMode: 'teacher',
+    currentQuestionIndex: -1,
+    startedAt: null,
+    endedAt: null,
+    totalQuestions: 2,
+    publicQuestions: [],
+  };
+
+  const baseStudentResp = (uid: string, pin: string) => ({
+    studentUid: uid,
+    pin,
+    joinedAt: 1000,
+    score: null,
+    answers: [] as unknown[],
+    status: 'active',
+    tabSwitchWarnings: 0,
+  });
+
+  beforeEach(async () => {
+    await testEnv.clearFirestore();
+  });
+
+  it('teacher create → query by code → get → resume → advance — no permission-denied', async () => {
+    // 1. createAssignment: teacher writes a paused session doc.
+    await assertSucceeds(
+      setDoc(doc(asTeacher(), `quiz_sessions/${SESSION_ID}`), {
+        ...baseSessionShape,
+        status: 'paused',
+      })
+    );
+
+    // 2. allocateJoinCode: teacher LIST query by code (was broken pre-#1390).
+    await assertSucceeds(
+      getDocs(
+        query(
+          collection(asTeacher(), 'quiz_sessions'),
+          where('code', '==', JOIN_CODE)
+        )
+      )
+    );
+
+    // 3. useQuizSessionTeacher: single-doc GET (was broken pre-#1391 — the
+    //    Start bug this PR fixes).
+    await assertSucceeds(
+      getDoc(doc(asTeacher(), `quiz_sessions/${SESSION_ID}`))
+    );
+
+    // 4. resumeAssignment: paused → waiting.
+    await assertSucceeds(
+      setDoc(
+        doc(asTeacher(), `quiz_sessions/${SESSION_ID}`),
+        { status: 'waiting' },
+        { merge: true }
+      )
+    );
+
+    // 5. advanceQuestion: waiting → active, currentQuestionIndex = 0.
+    await assertSucceeds(
+      setDoc(
+        doc(asTeacher(), `quiz_sessions/${SESSION_ID}`),
+        { status: 'active', currentQuestionIndex: 0, startedAt: 1000 },
+        { merge: true }
+      )
+    );
+  });
+
+  it('studentRole in-class: discovery → get → create response → submit answers', async () => {
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      await setDoc(doc(ctx.firestore(), `quiz_sessions/${SESSION_ID}`), {
+        ...baseSessionShape,
+        status: 'active',
+      });
+    });
+
+    // 6. MyAssignmentsPage: where('classId', 'in', myClassIds).
+    await assertSucceeds(
+      getDocs(
+        query(
+          collection(asStudentA(), 'quiz_sessions'),
+          where('classId', 'in', [CLASS_A])
+        )
+      )
+    );
+
+    // 7. Student renders the session: single-doc GET.
+    await assertSucceeds(
+      getDoc(doc(asStudentA(), `quiz_sessions/${SESSION_ID}`))
+    );
+
+    // 8. Student joins: creates response doc.
+    const respPath = `quiz_sessions/${SESSION_ID}/responses/${STUDENT_A_UID}`;
+    await assertSucceeds(
+      setDoc(
+        doc(asStudentA(), respPath),
+        baseStudentResp(STUDENT_A_UID, '1234')
+      )
+    );
+
+    // 9. Student submits answers: update with only allowed field changes.
+    await assertSucceeds(
+      setDoc(doc(asStudentA(), respPath), {
+        ...baseStudentResp(STUDENT_A_UID, '1234'),
+        answers: [{ questionId: 'q1', answer: 'A' }],
+        status: 'submitted',
+        submittedAt: 2000,
+      })
+    );
+  });
+
+  it('studentRole out-of-class: can read session metadata but cannot submit', async () => {
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      await setDoc(doc(ctx.firestore(), `quiz_sessions/${SESSION_ID}`), {
+        ...baseSessionShape,
+        status: 'active',
+      });
+    });
+
+    // Out-of-class student CAN get the session doc (intentional post-PR #1391).
+    await assertSucceeds(
+      getDoc(doc(asStudentB(), `quiz_sessions/${SESSION_ID}`))
+    );
+
+    // But CANNOT create a response: write-side class gate denies.
+    const respPath = `quiz_sessions/${SESSION_ID}/responses/${STUDENT_B_UID}`;
+    await assertFails(
+      setDoc(
+        doc(asStudentB(), respPath),
+        baseStudentResp(STUDENT_B_UID, '5555')
+      )
+    );
+
+    // Nor update an existing response (even if one were seeded).
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      await setDoc(
+        doc(ctx.firestore(), respPath),
+        baseStudentResp(STUDENT_B_UID, '5555')
+      );
+    });
+    await assertFails(
+      setDoc(doc(asStudentB(), respPath), {
+        ...baseStudentResp(STUDENT_B_UID, '5555'),
+        answers: [{ questionId: 'q1', answer: 'A' }],
+        status: 'submitted',
+        submittedAt: 2000,
+      })
+    );
+  });
+
+  it('studentRole cannot read another student response', async () => {
+    const otherUid = 'student-other-uid';
+    const otherRespPath = `quiz_sessions/${SESSION_ID}/responses/${otherUid}`;
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      await setDoc(doc(ctx.firestore(), `quiz_sessions/${SESSION_ID}`), {
+        ...baseSessionShape,
+        status: 'active',
+      });
+      await setDoc(
+        doc(ctx.firestore(), otherRespPath),
+        baseStudentResp(otherUid, '7777')
+      );
+    });
+
+    await assertFails(getDoc(doc(asStudentA(), otherRespPath)));
+  });
+
+  it('teacher reads all responses (list) and finalizes a score', async () => {
+    const respPath = `quiz_sessions/${SESSION_ID}/responses/${STUDENT_A_UID}`;
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      await setDoc(doc(ctx.firestore(), `quiz_sessions/${SESSION_ID}`), {
+        ...baseSessionShape,
+        status: 'ended',
+      });
+      await setDoc(doc(ctx.firestore(), respPath), {
+        ...baseStudentResp(STUDENT_A_UID, '1234'),
+        answers: [{ questionId: 'q1', answer: 'A' }],
+        status: 'submitted',
+        submittedAt: 2000,
+      });
+    });
+
+    // 13. Teacher lists all responses on the session.
+    await assertSucceeds(
+      getDocs(collection(asTeacher(), `quiz_sessions/${SESSION_ID}/responses`))
+    );
+
+    // 14. Teacher sets score — a field students are forbidden from writing.
+    await assertSucceeds(
+      setDoc(doc(asTeacher(), respPath), { score: 85 }, { merge: true })
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PR #1391 regression smoke — teacher create → teacher single-doc read on
+// every session collection that uses the `allow read: if request.auth != null;`
+// shape. A rules regression that re-introduces `resource.data` into any of
+// these read rules will show up here.
+// ---------------------------------------------------------------------------
+
+describe('PR #1391 regression — teacher create + single-doc read on all session collections', () => {
+  const SESSION_ID = 'pr1391-regression';
+
+  beforeEach(async () => {
+    await testEnv.clearFirestore();
+  });
+
+  it('quiz_sessions: teacher create → single-doc get succeeds', async () => {
+    await assertSucceeds(
+      setDoc(doc(asTeacher(), `quiz_sessions/${SESSION_ID}`), {
+        teacherUid: TEACHER_UID,
+        classId: CLASS_A,
+        code: 'CODE01',
+        status: 'paused',
+      })
+    );
+    await assertSucceeds(
+      getDoc(doc(asTeacher(), `quiz_sessions/${SESSION_ID}`))
+    );
+  });
+
+  it('video_activity_sessions: teacher create → single-doc get succeeds', async () => {
+    await assertSucceeds(
+      setDoc(
+        doc(asTeacher(), `video_activity_sessions/${SESSION_ID}`),
+        vaFields(SESSION_ID, CLASS_A)
+      )
+    );
+    await assertSucceeds(
+      getDoc(doc(asTeacher(), `video_activity_sessions/${SESSION_ID}`))
+    );
+  });
+
+  it('guided_learning_sessions: teacher create → single-doc get succeeds', async () => {
+    await assertSucceeds(
+      setDoc(doc(asTeacher(), `guided_learning_sessions/${SESSION_ID}`), {
+        teacherUid: TEACHER_UID,
+        classId: CLASS_A,
+        status: 'active',
+      })
+    );
+    await assertSucceeds(
+      getDoc(doc(asTeacher(), `guided_learning_sessions/${SESSION_ID}`))
+    );
+  });
+
+  it('mini_app_sessions: teacher create → single-doc get succeeds', async () => {
+    await assertSucceeds(
+      setDoc(doc(asTeacher(), `mini_app_sessions/${SESSION_ID}`), {
+        teacherUid: TEACHER_UID,
+        classIds: [CLASS_A],
+        status: 'active',
+        assignmentName: 'Mini',
+        submissionsEnabled: true,
+      })
+    );
+    await assertSucceeds(
+      getDoc(doc(asTeacher(), `mini_app_sessions/${SESSION_ID}`))
+    );
+  });
+
+  it('activity_wall_sessions: teacher create → single-doc get succeeds', async () => {
+    // activity_wall sessionId convention: {teacherUid}_{activityId}
+    const awSessionId = `${TEACHER_UID}_activity-x`;
+    await assertSucceeds(
+      setDoc(doc(asTeacher(), `activity_wall_sessions/${awSessionId}`), {
+        teacherUid: TEACHER_UID,
+        classId: CLASS_A,
+        status: 'active',
+      })
+    );
+    await assertSucceeds(
+      getDoc(doc(asTeacher(), `activity_wall_sessions/${awSessionId}`))
     );
   });
 });

--- a/tests/rules/studentRoleClassGate.test.ts
+++ b/tests/rules/studentRoleClassGate.test.ts
@@ -31,6 +31,7 @@ import {
   getDocs,
   addDoc,
   collection,
+  deleteDoc,
   doc,
   query,
   where,
@@ -61,19 +62,33 @@ const RULES_PATH = fileURLToPath(
 
 let testEnv: RulesTestEnvironment;
 
+// Token shape note: the Firestore rules engine in the emulator throws
+// "Property X is undefined on object" when a rule expression reads a token
+// claim that isn't present (even behind a `!= null` short-circuit). Real
+// Firebase Auth tokens carry the full claim surface; the emulator test
+// harness does not auto-populate it. We therefore spell out every claim
+// the rules may touch — `email`, `studentRole`, `classIds`, and
+// `firebase.sign_in_provider` — in every context, using empty/false
+// defaults for claims that don't apply to that role. This matches what
+// production Auth tokens look like for real sign-ins.
+
 const asStudentA = () =>
   testEnv
     .authenticatedContext(STUDENT_A_UID, {
+      email: '',
       studentRole: true,
       classIds: [CLASS_A],
+      firebase: { sign_in_provider: 'custom' },
     })
     .firestore();
 
 const asStudentEmpty = () =>
   testEnv
     .authenticatedContext(STUDENT_EMPTY_UID, {
+      email: '',
       studentRole: true,
       classIds: [],
+      firebase: { sign_in_provider: 'custom' },
     })
     .firestore();
 
@@ -81,6 +96,8 @@ const asTeacher = () =>
   testEnv
     .authenticatedContext(TEACHER_UID, {
       email: 'teacher@school.edu',
+      studentRole: false,
+      classIds: [],
       firebase: { sign_in_provider: 'google.com' },
     })
     .firestore();
@@ -88,6 +105,9 @@ const asTeacher = () =>
 const asAnonStudent = () =>
   testEnv
     .authenticatedContext(ANON_UID, {
+      email: '',
+      studentRole: false,
+      classIds: [],
       firebase: { sign_in_provider: 'anonymous' },
     })
     .firestore();
@@ -191,6 +211,7 @@ async function seedSessions(cols: string[], opts: SeedOptions = {}) {
             {
               studentAnonymousId: STUDENT_A_UID,
               sessionId: SESSION_A,
+              startedAt: 1000,
               score: null,
               answers: [],
             }
@@ -282,6 +303,11 @@ describe('quiz_sessions/responses — student-role gate', () => {
   });
 
   it('student in class-A can create response on session-A', async () => {
+    // seedSessions(withResponses) pre-creates a response for STUDENT_A_UID.
+    // Clear it so this test truly exercises the create rule.
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      await deleteDoc(doc(ctx.firestore(), respPath(SESSION_A)));
+    });
     await assertSucceeds(
       setDoc(doc(asStudentA(), respPath(SESSION_A)), {
         ...baseResp(),
@@ -385,6 +411,11 @@ describe('video_activity_sessions/responses — student-role gate', () => {
   });
 
   it('student in class-A can create response on session-A', async () => {
+    // seedSessions(withResponses) pre-creates a response for STUDENT_A_UID.
+    // Clear it so this test truly exercises the create rule.
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      await deleteDoc(doc(ctx.firestore(), respPath(SESSION_A)));
+    });
     await assertSucceeds(
       setDoc(doc(asStudentA(), respPath(SESSION_A)), {
         ...baseResp(),
@@ -459,6 +490,7 @@ describe('guided_learning_sessions/responses — student-role gate', () => {
   const baseResp = (session = SESSION_A) => ({
     studentAnonymousId: STUDENT_A_UID,
     sessionId: session,
+    startedAt: 1000,
     score: null,
     answers: [],
   });
@@ -469,6 +501,12 @@ describe('guided_learning_sessions/responses — student-role gate', () => {
   });
 
   it('student in class-A can create response on session-A', async () => {
+    // seedSessions(withResponses) pre-creates a response for STUDENT_A_UID,
+    // so a bare setDoc would hit the update rule, not create. Clear the
+    // seeded doc first so this test actually exercises the create path.
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      await deleteDoc(doc(ctx.firestore(), respPath(SESSION_A)));
+    });
     await assertSucceeds(
       setDoc(doc(asStudentA(), respPath(SESSION_A)), baseResp())
     );
@@ -596,25 +634,54 @@ describe('mini_app_sessions/submissions — student-role gate', () => {
   const col = 'mini_app_sessions';
   const subPath = (session: string, uid: string) =>
     `${col}/${session}/submissions/${uid}`;
-  const validSub = () => ({
+  // The mini_app submission rule enforces a strict key whitelist:
+  // ['submittedAt', 'studentUid', 'payload']. `studentUid` must equal
+  // request.auth.uid. validSub() takes the submitter uid so the test
+  // parameterizes it correctly.
+  const validSub = (uid: string) => ({
     submittedAt: 1000,
+    studentUid: uid,
     payload: { score: 42, answers: [1, 2, 3] } as Record<string, unknown>,
   });
 
   beforeEach(async () => {
     await testEnv.clearFirestore();
-    await seedSessions([col]);
+    // mini_app_sessions docs require `submissionsEnabled: true` on the
+    // parent session for submissions to be accepted. The generic seed
+    // helper doesn't set that field (it seeds a bare sessionDoc), so we
+    // re-seed here with the mini-app-specific shape.
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      const db = ctx.firestore();
+      await setDoc(doc(db, `${col}/${SESSION_A}`), {
+        teacherUid: TEACHER_UID,
+        classIds: [CLASS_A],
+        status: 'active',
+        submissionsEnabled: true,
+      });
+      await setDoc(doc(db, `${col}/${SESSION_B}`), {
+        teacherUid: TEACHER_UID,
+        classIds: [CLASS_B],
+        status: 'active',
+        submissionsEnabled: true,
+      });
+    });
   });
 
   it('student in class-A can submit to session-A under their own pseudonym', async () => {
     await assertSucceeds(
-      setDoc(doc(asStudentA(), subPath(SESSION_A, STUDENT_A_UID)), validSub())
+      setDoc(
+        doc(asStudentA(), subPath(SESSION_A, STUDENT_A_UID)),
+        validSub(STUDENT_A_UID)
+      )
     );
   });
 
   it('student in class-A cannot submit to session-B (wrong class)', async () => {
     await assertFails(
-      setDoc(doc(asStudentA(), subPath(SESSION_B, STUDENT_A_UID)), validSub())
+      setDoc(
+        doc(asStudentA(), subPath(SESSION_B, STUDENT_A_UID)),
+        validSub(STUDENT_A_UID)
+      )
     );
   });
 
@@ -622,14 +689,17 @@ describe('mini_app_sessions/submissions — student-role gate', () => {
     await assertFails(
       setDoc(
         doc(asStudentEmpty(), subPath(SESSION_A, STUDENT_EMPTY_UID)),
-        validSub()
+        validSub(STUDENT_EMPTY_UID)
       )
     );
   });
 
   it('anonymous PIN student can submit under their own auth uid', async () => {
     await assertSucceeds(
-      setDoc(doc(asAnonStudent(), subPath(SESSION_A, ANON_UID)), validSub())
+      setDoc(
+        doc(asAnonStudent(), subPath(SESSION_A, ANON_UID)),
+        validSub(ANON_UID)
+      )
     );
   });
 
@@ -637,21 +707,21 @@ describe('mini_app_sessions/submissions — student-role gate', () => {
     await assertFails(
       setDoc(
         doc(asAnonStudent(), subPath(SESSION_A, 'some-other-uid')),
-        validSub()
+        validSub('some-other-uid')
       )
     );
   });
 
   it('unauthenticated caller cannot submit', async () => {
     await assertFails(
-      setDoc(doc(asUnauth(), subPath(SESSION_A, 'x')), validSub())
+      setDoc(doc(asUnauth(), subPath(SESSION_A, 'x')), validSub('x'))
     );
   });
 
   it('submission with extra keys is rejected', async () => {
     await assertFails(
       setDoc(doc(asStudentA(), subPath(SESSION_A, STUDENT_A_UID)), {
-        ...validSub(),
+        ...validSub(STUDENT_A_UID),
         sneaky: 'extra-field',
       })
     );
@@ -661,6 +731,7 @@ describe('mini_app_sessions/submissions — student-role gate', () => {
     await assertFails(
       setDoc(doc(asStudentA(), subPath(SESSION_A, STUDENT_A_UID)), {
         submittedAt: 1000,
+        studentUid: STUDENT_A_UID,
         payload: 'just-a-string',
       })
     );
@@ -670,6 +741,7 @@ describe('mini_app_sessions/submissions — student-role gate', () => {
     await assertFails(
       setDoc(doc(asStudentA(), subPath(SESSION_A, STUDENT_A_UID)), {
         submittedAt: 'not-a-number',
+        studentUid: STUDENT_A_UID,
         payload: { score: 1 },
       })
     );
@@ -679,12 +751,16 @@ describe('mini_app_sessions/submissions — student-role gate', () => {
     await testEnv.withSecurityRulesDisabled(async (ctx) => {
       await setDoc(doc(ctx.firestore(), `${col}/${SESSION_A}`), {
         teacherUid: TEACHER_UID,
-        classId: CLASS_A,
+        classIds: [CLASS_A],
         status: 'ended',
+        submissionsEnabled: true,
       });
     });
     await assertFails(
-      setDoc(doc(asStudentA(), subPath(SESSION_A, STUDENT_A_UID)), validSub())
+      setDoc(
+        doc(asStudentA(), subPath(SESSION_A, STUDENT_A_UID)),
+        validSub(STUDENT_A_UID)
+      )
     );
   });
 
@@ -692,11 +768,11 @@ describe('mini_app_sessions/submissions — student-role gate', () => {
     await testEnv.withSecurityRulesDisabled(async (ctx) => {
       await setDoc(
         doc(ctx.firestore(), subPath(SESSION_A, STUDENT_A_UID)),
-        validSub()
+        validSub(STUDENT_A_UID)
       );
       await setDoc(
         doc(ctx.firestore(), subPath(SESSION_A, 'other-uid')),
-        validSub()
+        validSub('other-uid')
       );
     });
     await assertSucceeds(
@@ -711,7 +787,7 @@ describe('mini_app_sessions/submissions — student-role gate', () => {
     await testEnv.withSecurityRulesDisabled(async (ctx) => {
       await setDoc(
         doc(ctx.firestore(), subPath(SESSION_A, 'anyone')),
-        validSub()
+        validSub('anyone')
       );
     });
     await assertSucceeds(

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -14,10 +14,12 @@ export default mergeConfig(
       exclude: [
         ...configDefaults.exclude,
         'tests/e2e/**',
-        // Firestore rules tests need the Firestore emulator; they run via
-        // the `test:rules` script under `firebase emulators:exec`. Excluded
-        // from the default vitest run so `pnpm test` / CI stays green
-        // without an emulator.
+        // Firestore rules tests need the Firestore emulator. Excluded from
+        // the default vitest run (`pnpm test`) so a dev doesn't need Java
+        // installed locally; they run via `pnpm test:rules` (which wraps
+        // them in `firebase emulators:exec --only firestore`). CI runs
+        // them as a dedicated job — see `.github/workflows/pr-validation.yml`
+        // (the `rules` job).
         'tests/rules/**',
         'functions/**',
         '.claude/worktrees/**',


### PR DESCRIPTION
## Summary

After PR #1390 (4ec4c40), teachers can *create* quiz assignments again — but clicking **Start** on a paused assignment immediately fails with `permission-denied`, blocking them from reaching the monitor view.

The failure surfaces in the console as:

```
[useQuizSessionTeacher] FirebaseError: Missing or insufficient permissions.
```

Traced to `hooks/useQuizSession.ts:178` — the single-doc `onSnapshot(doc(db, 'quiz_sessions', sessionId))` listener. The listener mounts when `Widget.tsx:64` re-renders with the new `activeAssignmentId` after `resumeAssignment` commits the paused→waiting transition.

PR #1390 split the session read rule into `get`/`list` and kept a `resource.data`-based studentRole class gate on `get`, on the theory (supported by Firestore docs) that `get` rules have `resource.data` concretely available at evaluation time. Empirically that still denies teacher subscriptions. Fix by removing the `resource.data` reference and collapsing `get`/`list` into a single `allow read: if request.auth != null;` on all five session collections.

## Changes

- `firestore.rules` — five collections, same transformation:
  - `quiz_sessions`
  - `video_activity_sessions`
  - `mini_app_sessions`
  - `guided_learning_sessions`
  - `activity_wall_sessions`
- Comment blocks updated to reflect the new posture and drop the stale `get`-vs-`list` rationale.
- No client code changes.

## Security impact

- Enumeration surface **unchanged**: PR #1390's `list` rule already allowed any authenticated caller.
- studentRole class gating **preserved** on the response/submission *write* rules, which dereference the parent session's `classId`/`classIds` via a runtime `get()` — evaluated per-write, not statically analyzed. A studentRole user gains the ability to `get` a session doc by id outside their `classIds` claim, but **cannot submit** to it.
- Session schema is already designed to be student-readable (no answer keys leaked). `revealedAnswers` is populated only when a teacher intentionally broadcasts a reveal; that's the one additional field an out-of-class studentRole user can now see on a session-by-id read, and it's acceptable because reveal is explicitly a broadcast action.

## Test plan

- [ ] Pre-deploy: `firebase firestore:rules:get` diffs clean against this branch's `firestore.rules` (rules out deploy-skew as the real culprit).
- [ ] Deploy: `firebase deploy --only firestore:rules`.
- [ ] Non-admin teacher creates a quiz assignment → lands Paused (baseline unchanged).
- [ ] Same teacher clicks **Start** → no `[useQuizSessionTeacher]` console error; monitor view loads; join code copied to clipboard.
- [ ] Repeat the Start smoke on video activity / guided learning / activity wall / mini-app assignments (same rule pattern, ~10s each).
- [ ] Negative check: ClassLink-SSO student out-of-class attempts a response submit → denied (`passesStudentClassGate` still enforced on write rules).
- [ ] Regression: ClassLink-SSO student's `/my-assignments` page still lists in-class sessions.

## Out of scope

- `Error loading app settings` / `Error loading user roles` noise in console for every non-admin sign-in (`context/AuthContext.tsx:496-522`) — pre-existing, rules-intended (`admin_settings/*` is admin-read). Separate cleanup.
- Rules-emulator unit tests covering teacher-get, studentRole-in-class submit, and studentRole-out-of-class denied submit. Promised in PR #1389's commit message; belongs in a follow-up PR.

https://claude.ai/code/session_01K2bgkbYbBLc6pbgHuPLCW6

---
_Generated by [Claude Code](https://claude.ai/code/session_01K2bgkbYbBLc6pbgHuPLCW6)_