### PR TITLE
feat(assign): unified multi-class picker across Quiz/VA/GL (Phase 5A)

### DIFF
--- a/components/common/AssignClassPicker.helpers.ts
+++ b/components/common/AssignClassPicker.helpers.ts
@@ -1,0 +1,36 @@
+/**
+ * Shared helper + type definitions for `AssignClassPicker`. Kept in a
+ * `.ts` sibling so the `.tsx` component file only exports components
+ * (required for Vite's fast-refresh contract).
+ */
+
+import type { ClassLinkClass } from '@/types';
+
+export type AssignClassSource = 'classlink' | 'local';
+
+export interface AssignClassPickerValue {
+  /** Which source list is currently active. */
+  source: AssignClassSource;
+  /** Selected ClassLink class `sourcedId`s (populated when source === 'classlink'). */
+  classIds: string[];
+  /** Selected local roster names (populated when source === 'local'). */
+  periodNames: string[];
+}
+
+/**
+ * Build a human-readable label for a ClassLink class. Mirrors the format
+ * used elsewhere (ClassLinkImportDialog, legacy QuizManager) so teachers
+ * see the same class names across flows.
+ */
+export function formatClassLinkClassLabel(cls: ClassLinkClass): string {
+  const subjectPrefix = cls.subject ? `${cls.subject} - ` : '';
+  const codeSuffix = cls.classCode ? ` (${cls.classCode})` : '';
+  return `${subjectPrefix}${cls.title}${codeSuffix}`;
+}
+
+/** Default-empty value helper used by callers to seed initial picker state. */
+export function makeEmptyPickerValue(
+  source: AssignClassSource = 'classlink'
+): AssignClassPickerValue {
+  return { source, classIds: [], periodNames: [] };
+}

--- a/components/common/AssignClassPicker.tsx
+++ b/components/common/AssignClassPicker.tsx
@@ -1,0 +1,292 @@
+/**
+ * AssignClassPicker — shared class-assignment picker used by the Quiz, Video
+ * Activity, and Guided Learning assign modals.
+ *
+ * Replaces the previous split between a single-select ClassLink dropdown and
+ * a separate multi-select local-rosters checklist. Teachers pick a source
+ * (ClassLink classes XOR local rosters), then multi-select from the filtered
+ * list. Zero selection falls through to the classic code/PIN-only flow.
+ *
+ * The component is controlled — parents own the value and pass it back in
+ * via `value` / `onChange`. Source-switching clears the other source's
+ * selection automatically so the shape stays consistent.
+ */
+
+import React from 'react';
+import { Users, Check } from 'lucide-react';
+import type { ClassLinkClass, ClassRoster } from '@/types';
+import {
+  formatClassLinkClassLabel,
+  type AssignClassSource,
+  type AssignClassPickerValue,
+} from './AssignClassPicker.helpers';
+
+export interface AssignClassPickerProps {
+  classLinkClasses: ClassLinkClass[];
+  rosters: ClassRoster[];
+  value: AssignClassPickerValue;
+  onChange: (next: AssignClassPickerValue) => void;
+  disabled?: boolean;
+}
+
+export const AssignClassPicker: React.FC<AssignClassPickerProps> = ({
+  classLinkClasses,
+  rosters,
+  value,
+  onChange,
+  disabled = false,
+}) => {
+  const hasClassLink = classLinkClasses.length > 0;
+  const hasLocal = rosters.length > 0;
+
+  const effectiveSource: AssignClassSource = hasClassLink
+    ? value.source
+    : 'local';
+
+  const handleSourceChange = (next: AssignClassSource): void => {
+    if (next === value.source) return;
+    // Clear the other source's selection so the shape stays consistent.
+    onChange({
+      source: next,
+      classIds: [],
+      periodNames: [],
+    });
+  };
+
+  const toggleClassId = (id: string): void => {
+    const next = value.classIds.includes(id)
+      ? value.classIds.filter((x) => x !== id)
+      : [...value.classIds, id];
+    onChange({ ...value, classIds: next });
+  };
+
+  const togglePeriodName = (name: string): void => {
+    const next = value.periodNames.includes(name)
+      ? value.periodNames.filter((x) => x !== name)
+      : [...value.periodNames, name];
+    onChange({ ...value, periodNames: next });
+  };
+
+  const selectAll = (): void => {
+    if (effectiveSource === 'classlink') {
+      onChange({
+        ...value,
+        source: 'classlink',
+        classIds: classLinkClasses.map((c) => c.sourcedId),
+      });
+    } else {
+      onChange({
+        ...value,
+        source: 'local',
+        periodNames: rosters.map((r) => r.name),
+      });
+    }
+  };
+
+  const clearAll = (): void => {
+    onChange({ ...value, classIds: [], periodNames: [] });
+  };
+
+  const selectedCount =
+    effectiveSource === 'classlink'
+      ? value.classIds.length
+      : value.periodNames.length;
+
+  const totalCount =
+    effectiveSource === 'classlink' ? classLinkClasses.length : rosters.length;
+
+  return (
+    <div
+      className={
+        disabled ? 'opacity-50 pointer-events-none space-y-2' : 'space-y-2'
+      }
+    >
+      <div className="flex items-center gap-2">
+        <Users className="w-4 h-4 text-brand-blue-primary" />
+        <label className="text-sm font-bold text-brand-blue-dark">
+          Assign to classes{' '}
+          <span className="text-slate-400 font-normal">(optional)</span>
+        </label>
+      </div>
+
+      {hasClassLink && (
+        <div
+          role="radiogroup"
+          aria-label="Class source"
+          className="inline-flex items-center rounded-lg border border-slate-200 bg-slate-50 p-0.5"
+        >
+          <SourceToggleButton
+            label="ClassLink classes"
+            active={effectiveSource === 'classlink'}
+            onClick={() => handleSourceChange('classlink')}
+          />
+          <SourceToggleButton
+            label="Local rosters"
+            active={effectiveSource === 'local'}
+            onClick={() => handleSourceChange('local')}
+            disabled={!hasLocal}
+            disabledHint="No local rosters"
+          />
+        </div>
+      )}
+
+      <PickerList
+        source={effectiveSource}
+        classLinkClasses={classLinkClasses}
+        rosters={rosters}
+        value={value}
+        onToggleClassId={toggleClassId}
+        onTogglePeriodName={togglePeriodName}
+      />
+
+      {totalCount > 0 && (
+        <div className="flex items-center justify-between text-xxs text-slate-500">
+          <span>
+            {selectedCount === 0
+              ? 'None selected — students join with the code only.'
+              : `${selectedCount} of ${totalCount} selected.`}
+          </span>
+          <div className="flex items-center gap-2">
+            {selectedCount < totalCount && (
+              <button
+                type="button"
+                onClick={selectAll}
+                className="font-bold text-brand-blue-primary hover:text-brand-blue-dark"
+              >
+                Select all ({totalCount})
+              </button>
+            )}
+            {selectedCount > 0 && (
+              <button
+                type="button"
+                onClick={clearAll}
+                className="font-bold text-slate-500 hover:text-slate-700"
+              >
+                Clear
+              </button>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+const SourceToggleButton: React.FC<{
+  label: string;
+  active: boolean;
+  onClick: () => void;
+  disabled?: boolean;
+  disabledHint?: string;
+}> = ({ label, active, onClick, disabled = false, disabledHint }) => (
+  <button
+    type="button"
+    role="radio"
+    aria-checked={active}
+    onClick={onClick}
+    disabled={disabled}
+    title={disabled ? disabledHint : undefined}
+    className={`px-3 py-1 text-xs font-bold rounded-md transition-colors ${
+      active
+        ? 'bg-white text-brand-blue-dark shadow-sm'
+        : 'text-slate-500 hover:text-slate-700'
+    } ${disabled ? 'opacity-50 cursor-not-allowed' : ''}`}
+  >
+    {label}
+  </button>
+);
+
+interface PickerListProps {
+  source: AssignClassSource;
+  classLinkClasses: ClassLinkClass[];
+  rosters: ClassRoster[];
+  value: AssignClassPickerValue;
+  onToggleClassId: (id: string) => void;
+  onTogglePeriodName: (name: string) => void;
+}
+
+const PickerList: React.FC<PickerListProps> = ({
+  source,
+  classLinkClasses,
+  rosters,
+  value,
+  onToggleClassId,
+  onTogglePeriodName,
+}) => {
+  if (source === 'classlink') {
+    if (classLinkClasses.length === 0) {
+      return (
+        <EmptyStub message="No ClassLink classes found. Switch to Local rosters or assign with a code/PIN only." />
+      );
+    }
+    return (
+      <CheckList>
+        {classLinkClasses.map((cls) => (
+          <CheckItem
+            key={cls.sourcedId}
+            checked={value.classIds.includes(cls.sourcedId)}
+            label={formatClassLinkClassLabel(cls)}
+            onToggle={() => onToggleClassId(cls.sourcedId)}
+          />
+        ))}
+      </CheckList>
+    );
+  }
+
+  // source === 'local'
+  if (rosters.length === 0) {
+    return (
+      <EmptyStub message="No local rosters. Import a roster from the Classes panel, or assign with a code/PIN only." />
+    );
+  }
+  return (
+    <CheckList>
+      {rosters.map((r) => (
+        <CheckItem
+          key={r.id}
+          checked={value.periodNames.includes(r.name)}
+          label={r.name}
+          onToggle={() => onTogglePeriodName(r.name)}
+        />
+      ))}
+    </CheckList>
+  );
+};
+
+const CheckList: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+  <div className="space-y-1 max-h-40 overflow-y-auto rounded-lg border border-slate-200 bg-white p-2">
+    {children}
+  </div>
+);
+
+const CheckItem: React.FC<{
+  checked: boolean;
+  label: string;
+  onToggle: () => void;
+}> = ({ checked, label, onToggle }) => (
+  <label className="flex items-center gap-2 cursor-pointer hover:bg-slate-50 rounded px-1.5 py-1">
+    <span
+      aria-hidden="true"
+      className={`flex items-center justify-center w-4 h-4 rounded border transition-colors ${
+        checked
+          ? 'bg-brand-blue-primary border-brand-blue-primary text-white'
+          : 'bg-white border-slate-300'
+      }`}
+    >
+      {checked && <Check className="w-3 h-3" strokeWidth={3} />}
+    </span>
+    <input
+      type="checkbox"
+      className="sr-only"
+      checked={checked}
+      onChange={onToggle}
+    />
+    <span className="text-sm text-slate-800">{label}</span>
+  </label>
+);
+
+const EmptyStub: React.FC<{ message: string }> = ({ message }) => (
+  <p className="text-xxs text-slate-500 rounded-lg border border-dashed border-slate-200 bg-slate-50 px-3 py-2">
+    {message}
+  </p>
+);

--- a/components/common/AssignClassPicker.tsx
+++ b/components/common/AssignClassPicker.tsx
@@ -57,14 +57,29 @@ export const AssignClassPicker: React.FC<AssignClassPickerProps> = ({
     const next = value.classIds.includes(id)
       ? value.classIds.filter((x) => x !== id)
       : [...value.classIds, id];
-    onChange({ ...value, classIds: next });
+    // Always pin `source` to the list being mutated. Without this, callers
+    // whose `value.source` is stale (e.g., the default `'classlink'` seeded
+    // via `makeEmptyPickerValue` even when only local rosters are available)
+    // would see a mismatched `source` vs. populated list and silently drop
+    // the selection in downstream `source === 'classlink'` branches.
+    onChange({
+      ...value,
+      source: 'classlink',
+      classIds: next,
+      periodNames: [],
+    });
   };
 
   const togglePeriodName = (name: string): void => {
     const next = value.periodNames.includes(name)
       ? value.periodNames.filter((x) => x !== name)
       : [...value.periodNames, name];
-    onChange({ ...value, periodNames: next });
+    onChange({
+      ...value,
+      source: 'local',
+      classIds: [],
+      periodNames: next,
+    });
   };
 
   const selectAll = (): void => {

--- a/components/guidedLearning/GuidedLearningStudentApp.tsx
+++ b/components/guidedLearning/GuidedLearningStudentApp.tsx
@@ -13,7 +13,9 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { signInAnonymously } from 'firebase/auth';
 import {
+  ArrowRight,
   BookOpen,
+  ClipboardList,
   Loader2,
   AlertCircle,
   CheckCircle2,
@@ -94,6 +96,10 @@ const StudentExperience: React.FC<{ anonymousUid: string }> = ({
   const [completed, setCompleted] = useState(false);
   const [score, setScore] = useState<number | null>(null);
   const [answers, setAnswers] = useState<GuidedLearningResponse['answers']>([]);
+  // Phase 5A: post-PIN class-period picker. When the session has multiple
+  // periods configured, the student chooses one before the experience
+  // begins; the value is persisted on their response doc.
+  const [classPeriod, setClassPeriod] = useState<string | null>(null);
   const startedAt = React.useRef<number>(0);
   useEffect(() => {
     if (startedAt.current === 0) {
@@ -132,12 +138,21 @@ const StudentExperience: React.FC<{ anonymousUid: string }> = ({
       startedAt: startedAt.current,
       completedAt: Date.now(),
       score: computedScore,
+      ...(classPeriod ? { classPeriod } : {}),
     };
 
     await submitResponse(response).catch((err) => {
       console.error('[GuidedLearningStudentApp] Submit error:', err);
     });
-  }, [session, answers, pin, anonymousUid, sessionId, submitResponse]);
+  }, [
+    session,
+    answers,
+    pin,
+    anonymousUid,
+    sessionId,
+    submitResponse,
+    classPeriod,
+  ]);
 
   if (loading) return <FullPageLoader />;
   if (error) return <ErrorScreen message={error} />;
@@ -153,7 +168,17 @@ const StudentExperience: React.FC<{ anonymousUid: string }> = ({
         session={session}
         pin={pin}
         onPinChange={setPin}
-        onStart={() => setStarted(true)}
+        selectedPeriod={classPeriod}
+        onPeriodChange={setClassPeriod}
+        onStart={() => {
+          // Auto-select the single period if there's exactly one so the
+          // response still gets tagged consistently.
+          const periods = session.periodNames ?? [];
+          if (periods.length === 1 && !classPeriod) {
+            setClassPeriod(periods[0]);
+          }
+          setStarted(true);
+        }}
       />
     );
   }
@@ -199,39 +224,101 @@ const StartScreen: React.FC<{
   session: GuidedLearningSession;
   pin: string;
   onPinChange: (v: string) => void;
+  selectedPeriod: string | null;
+  onPeriodChange: (v: string | null) => void;
   onStart: () => void;
-}> = ({ session, pin, onPinChange, onStart }) => (
-  <div className="min-h-screen bg-slate-950 flex items-center justify-center p-6">
-    <div className="bg-slate-900 border border-white/10 rounded-2xl p-8 max-w-sm w-full text-center shadow-2xl">
-      <BookOpen className="w-10 h-10 text-indigo-400 mx-auto mb-3" />
-      <h1 className="text-white font-bold text-xl mb-1">{session.title}</h1>
-      <p className="text-slate-400 text-sm mb-6 capitalize">
-        {session.mode} mode · {session.publicSteps.length} steps
-      </p>
+}> = ({
+  session,
+  pin,
+  onPinChange,
+  selectedPeriod,
+  onPeriodChange,
+  onStart,
+}) => {
+  const periods = session.periodNames ?? [];
+  const needsPeriodPicker = periods.length > 1 && !selectedPeriod;
 
-      <div className="mb-6">
-        <label className="block text-slate-400 text-xs mb-1.5 text-left">
-          Your PIN <span className="text-slate-600">(optional)</span>
-        </label>
-        <input
-          type="text"
-          value={pin}
-          onChange={(e) => onPinChange(e.target.value)}
-          placeholder="Enter your class PIN"
-          className="w-full bg-slate-800 border border-slate-600 rounded-xl px-4 py-2.5 text-white text-sm text-center tracking-widest"
-          maxLength={10}
-        />
+  if (needsPeriodPicker) {
+    return (
+      <div className="min-h-screen bg-slate-950 flex items-center justify-center p-6">
+        <div className="bg-slate-900 border border-white/10 rounded-2xl p-8 max-w-sm w-full text-center shadow-2xl">
+          <ClipboardList className="w-8 h-8 text-indigo-400 mx-auto mb-3" />
+          <h1 className="text-white font-bold text-xl mb-1">
+            Select Your Class
+          </h1>
+          <p className="text-slate-400 text-sm mb-5">
+            Which class period are you in?
+          </p>
+          <div className="space-y-2 mb-5 text-left">
+            {periods.map((p) => (
+              <button
+                key={p}
+                onClick={() => onPeriodChange(p)}
+                className="w-full px-4 py-3 rounded-xl text-base font-bold transition-all bg-slate-800 border border-slate-700 text-slate-200 hover:bg-slate-700"
+              >
+                {p}
+              </button>
+            ))}
+          </div>
+          <p className="text-xxs text-slate-500">
+            Pick one to continue. You can enter your PIN after this step.
+          </p>
+        </div>
       </div>
+    );
+  }
 
-      <button
-        onClick={onStart}
-        className="w-full py-3 bg-indigo-600 hover:bg-indigo-500 text-white font-semibold rounded-xl transition-colors"
-      >
-        Start
-      </button>
+  return (
+    <div className="min-h-screen bg-slate-950 flex items-center justify-center p-6">
+      <div className="bg-slate-900 border border-white/10 rounded-2xl p-8 max-w-sm w-full text-center shadow-2xl">
+        <BookOpen className="w-10 h-10 text-indigo-400 mx-auto mb-3" />
+        <h1 className="text-white font-bold text-xl mb-1">{session.title}</h1>
+        <p className="text-slate-400 text-sm mb-6 capitalize">
+          {session.mode} mode · {session.publicSteps.length} steps
+        </p>
+
+        {selectedPeriod && periods.length > 1 && (
+          <div className="mb-4 flex items-center justify-between rounded-lg border border-slate-700 bg-slate-800/60 px-3 py-2">
+            <span className="text-xs text-slate-400">Class</span>
+            <div className="flex items-center gap-2">
+              <span className="text-sm font-bold text-white">
+                {selectedPeriod}
+              </span>
+              <button
+                onClick={() => onPeriodChange(null)}
+                className="text-xxs text-slate-500 hover:text-slate-300"
+              >
+                Change
+              </button>
+            </div>
+          </div>
+        )}
+
+        <div className="mb-6">
+          <label className="block text-slate-400 text-xs mb-1.5 text-left">
+            Your PIN <span className="text-slate-600">(optional)</span>
+          </label>
+          <input
+            type="text"
+            value={pin}
+            onChange={(e) => onPinChange(e.target.value)}
+            placeholder="Enter your class PIN"
+            className="w-full bg-slate-800 border border-slate-600 rounded-xl px-4 py-2.5 text-white text-sm text-center tracking-widest"
+            maxLength={10}
+          />
+        </div>
+
+        <button
+          onClick={onStart}
+          className="w-full py-3 bg-indigo-600 hover:bg-indigo-500 text-white font-semibold rounded-xl transition-colors flex items-center justify-center gap-2"
+        >
+          Start
+          <ArrowRight className="w-4 h-4" />
+        </button>
+      </div>
     </div>
-  </div>
-);
+  );
+};
 
 const CompletionScreen: React.FC<{
   session: GuidedLearningSession;

--- a/components/videoActivity/VideoActivityStudentApp.tsx
+++ b/components/videoActivity/VideoActivityStudentApp.tsx
@@ -15,7 +15,9 @@ import {
   PlayCircle,
   Loader2,
   AlertCircle,
+  ArrowRight,
   CheckCircle2,
+  ClipboardList,
   Trophy,
 } from 'lucide-react';
 import { auth } from '@/config/firebase';
@@ -79,10 +81,17 @@ const JoinAndPlay: React.FC = () => {
     myResponse,
     joinStatus,
     error,
+    lookupSession,
     joinSession,
     submitAnswer,
     completeActivity,
   } = useVideoActivitySessionStudent();
+
+  // Multi-period selection step — shown when the session has more than one
+  // class-period name configured, so students pick their period before the
+  // response doc is created (mirrors the Quiz pattern).
+  const [periodStep, setPeriodStep] = useState<string[] | null>(null);
+  const [selectedPeriod, setSelectedPeriod] = useState<string | null>(null);
 
   // Track answered question IDs for anti-skip enforcement in VideoPlayer
   const answeredQuestionIds = React.useMemo(
@@ -96,8 +105,20 @@ const JoinAndPlay: React.FC = () => {
   const handleJoin = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!name.trim() || !pin.trim() || !sessionId) return;
-    await joinSession(sessionId, pin.trim(), name.trim());
+    const sessionInfo = await lookupSession(sessionId);
+    const periodNames = sessionInfo?.periodNames ?? [];
+    if (periodNames.length > 1) {
+      setPeriodStep(periodNames);
+      return;
+    }
+    const autoClassPeriod = periodNames[0];
+    await joinSession(sessionId, pin.trim(), name.trim(), autoClassPeriod);
   };
+
+  const handlePeriodConfirm = useCallback(async () => {
+    if (!selectedPeriod || !sessionId) return;
+    await joinSession(sessionId, pin.trim(), name.trim(), selectedPeriod);
+  }, [joinSession, sessionId, pin, name, selectedPeriod]);
 
   const handleQuestionTrigger = useCallback(
     (question: VideoActivityQuestion) => {
@@ -148,6 +169,77 @@ const JoinAndPlay: React.FC = () => {
   if (!sessionId || sessionId.includes('/')) {
     return (
       <ErrorScreen message="Invalid activity link. Please ask your teacher for the correct URL." />
+    );
+  }
+
+  // ── Period selection step (multi-period sessions) ────────────────────────
+
+  if (periodStep && joinStatus !== 'joined') {
+    return (
+      <div className="min-h-screen bg-slate-900 flex flex-col items-center justify-center p-6">
+        <div className="w-full max-w-sm">
+          <div className="flex items-center justify-center mb-8">
+            <ClipboardList className="w-5 h-5 text-brand-blue-primary mr-2" />
+            <span className="text-sm text-slate-300 font-semibold">
+              Video Activity
+            </span>
+          </div>
+
+          <h1 className="text-2xl font-black text-white mb-2 text-center">
+            Select Your Class
+          </h1>
+          <p className="text-slate-400 text-sm text-center mb-6">
+            Which class period are you in?
+          </p>
+
+          {error && (
+            <div className="mb-4 p-3 bg-red-500/20 border border-red-500/40 rounded-xl text-red-300 text-sm flex items-center gap-2">
+              <AlertCircle className="w-4 h-4 shrink-0" />
+              {error}
+            </div>
+          )}
+
+          <div className="space-y-2 mb-6">
+            {periodStep.map((period) => (
+              <button
+                key={period}
+                onClick={() => setSelectedPeriod(period)}
+                className={`w-full px-4 py-4 rounded-xl text-lg font-bold transition-all ${
+                  selectedPeriod === period
+                    ? 'bg-brand-blue-primary text-white ring-2 ring-brand-blue-light'
+                    : 'bg-slate-800 border border-slate-700 text-slate-300 hover:bg-slate-700'
+                }`}
+              >
+                {period}
+              </button>
+            ))}
+          </div>
+
+          <button
+            onClick={() => void handlePeriodConfirm()}
+            disabled={joinStatus === 'loading' || !selectedPeriod}
+            className="w-full py-4 bg-brand-blue-primary hover:bg-brand-blue-dark disabled:opacity-50 text-white font-bold text-lg rounded-xl flex items-center justify-center gap-2 transition-colors"
+          >
+            {joinStatus === 'loading' ? (
+              <Loader2 className="w-5 h-5 animate-spin" />
+            ) : (
+              <>
+                Continue <ArrowRight className="w-5 h-5" />
+              </>
+            )}
+          </button>
+
+          <button
+            onClick={() => {
+              setPeriodStep(null);
+              setSelectedPeriod(null);
+            }}
+            className="w-full mt-3 py-2 text-slate-500 hover:text-slate-300 text-sm font-medium transition-colors"
+          >
+            Go Back
+          </button>
+        </div>
+      </div>
     );
   }
 

--- a/components/videoActivity/VideoActivityStudentApp.tsx
+++ b/components/videoActivity/VideoActivityStudentApp.tsx
@@ -92,6 +92,11 @@ const JoinAndPlay: React.FC = () => {
   // response doc is created (mirrors the Quiz pattern).
   const [periodStep, setPeriodStep] = useState<string[] | null>(null);
   const [selectedPeriod, setSelectedPeriod] = useState<string | null>(null);
+  // Local guard for the async `lookupSession` leg of `handleJoin` — the
+  // hook's `joinStatus` only flips to `loading` once `joinSession` starts,
+  // so without this the button would stay clickable during the lookup and
+  // a double-tap could fan out parallel requests.
+  const [lookingUp, setLookingUp] = useState(false);
 
   // Track answered question IDs for anti-skip enforcement in VideoPlayer
   const answeredQuestionIds = React.useMemo(
@@ -105,14 +110,20 @@ const JoinAndPlay: React.FC = () => {
   const handleJoin = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!name.trim() || !pin.trim() || !sessionId) return;
-    const sessionInfo = await lookupSession(sessionId);
-    const periodNames = sessionInfo?.periodNames ?? [];
-    if (periodNames.length > 1) {
-      setPeriodStep(periodNames);
-      return;
+    if (lookingUp || joinStatus === 'loading') return;
+    setLookingUp(true);
+    try {
+      const sessionInfo = await lookupSession(sessionId);
+      const periodNames = sessionInfo?.periodNames ?? [];
+      if (periodNames.length > 1) {
+        setPeriodStep(periodNames);
+        return;
+      }
+      const autoClassPeriod = periodNames[0];
+      await joinSession(sessionId, pin.trim(), name.trim(), autoClassPeriod);
+    } finally {
+      setLookingUp(false);
     }
-    const autoClassPeriod = periodNames[0];
-    await joinSession(sessionId, pin.trim(), name.trim(), autoClassPeriod);
   };
 
   const handlePeriodConfirm = useCallback(async () => {
@@ -312,11 +323,14 @@ const JoinAndPlay: React.FC = () => {
               <button
                 type="submit"
                 disabled={
-                  joinStatus === 'loading' || !name.trim() || !pin.trim()
+                  joinStatus === 'loading' ||
+                  lookingUp ||
+                  !name.trim() ||
+                  !pin.trim()
                 }
                 className="w-full bg-brand-blue-primary hover:bg-brand-blue-dark disabled:bg-slate-200 disabled:text-slate-400 text-white font-bold rounded-xl py-3 text-sm transition-all active:scale-95 flex items-center justify-center gap-2"
               >
-                {joinStatus === 'loading' ? (
+                {joinStatus === 'loading' || lookingUp ? (
                   <>
                     <Loader2 className="w-4 h-4 animate-spin" />
                     Joining…

--- a/components/widgets/GuidedLearning/Widget.tsx
+++ b/components/widgets/GuidedLearning/Widget.tsx
@@ -18,11 +18,17 @@ import { useFolders } from '@/hooks/useFolders';
 import { classLinkService } from '@/utils/classlinkService';
 import { WidgetLayout } from '@/components/widgets/WidgetLayout';
 import { AssignModal } from '@/components/common/library';
+import { AssignClassPicker } from '@/components/common/AssignClassPicker';
+import {
+  formatClassLinkClassLabel,
+  makeEmptyPickerValue,
+  type AssignClassPickerValue,
+} from '@/components/common/AssignClassPicker.helpers';
 import { GuidedLearningManager } from './components/GuidedLearningManager';
 import { GuidedLearningEditorModal } from './components/GuidedLearningEditorModal';
 import { GuidedLearningPlayer } from './components/GuidedLearningPlayer';
 import { GuidedLearningResults } from './components/GuidedLearningResults';
-import { Loader2, Users } from 'lucide-react';
+import { Loader2 } from 'lucide-react';
 
 // ─── AI generation modal (admin only) ────────────────────────────────────────
 import { GuidedLearningAIGenerator } from './components/GuidedLearningAIGenerator';
@@ -45,7 +51,7 @@ interface AssignDialogTarget {
 export const GuidedLearningWidget: React.FC<{ widget: WidgetData }> = ({
   widget,
 }) => {
-  const { updateWidget, addToast } = useDashboard();
+  const { updateWidget, addToast, rosters } = useDashboard();
   const { user, isAdmin } = useAuth();
   const rawConfig = widget.config as GuidedLearningConfig;
   // Normalize legacy 'editor' view — the inline editor is removed; use the modal instead
@@ -126,29 +132,37 @@ export const GuidedLearningWidget: React.FC<{ widget: WidgetData }> = ({
     };
   }, []);
 
-  // ─── Assign dialog state (Phase 3C) ─────────────────────────────────────────
-  // When a teacher clicks "Assign" and a ClassLink-provisioned org is in
-  // play, we pause to let them optionally pick a target class before
-  // actually creating the session. `assignTarget` holds the already-loaded
-  // set along with the source hint so we can create the assignment doc
-  // after confirmation.
+  // ─── Assign dialog state (Phase 3C, Phase 5A multi-class) ─────────────────
+  // When a teacher clicks "Assign", we pause to let them optionally pick
+  // target classes (ClassLink) or period rosters (local) before actually
+  // creating the session. `assignTarget` holds the already-loaded set along
+  // with the source hint so we can create the assignment doc after
+  // confirmation.
   const [assignTarget, setAssignTarget] = useState<AssignDialogTarget | null>(
     null
   );
-  const [assignOptions, setAssignOptions] = useState<{ classId: string }>({
-    classId: '',
-  });
+  const [pickerValue, setPickerValue] = useState<AssignClassPickerValue>(() =>
+    makeEmptyPickerValue('classlink')
+  );
 
-  // Reset the pending classId when the dialog re-opens for a different set
+  // Reset the picker when the dialog re-opens for a different set
   // (adjust-state-while-rendering pattern — no effect needed).
   const [prevAssignTarget, setPrevAssignTarget] =
     useState<AssignDialogTarget | null>(null);
   if (assignTarget !== prevAssignTarget) {
     setPrevAssignTarget(assignTarget);
     if (assignTarget) {
-      setAssignOptions({
-        classId: config.lastClassIdBySetId?.[assignTarget.originSetId] ?? '',
-      });
+      const rememberedMulti =
+        config.lastClassIdsBySetId?.[assignTarget.originSetId];
+      const rememberedSingle =
+        config.lastClassIdBySetId?.[assignTarget.originSetId];
+      const classIds =
+        rememberedMulti ?? (rememberedSingle ? [rememberedSingle] : []);
+      setPickerValue(
+        classIds.length > 0
+          ? { source: 'classlink', classIds, periodNames: [] }
+          : makeEmptyPickerValue('classlink')
+      );
     }
   }
 
@@ -247,18 +261,20 @@ export const GuidedLearningWidget: React.FC<{ widget: WidgetData }> = ({
   };
 
   // Actually create the session + matching assignment doc. Shared between
-  // the classic direct-assign path (no ClassLink org) and the target-class
-  // dialog confirm path. `classId` is the ClassLink class sourcedId, or
-  // `null` for "No class".
+  // the classic direct-assign path (no ClassLink/rosters) and the picker
+  // dialog confirm path. `classIds` is the selected ClassLink sourcedId
+  // list; `periodNames` is the list of post-PIN period labels (empty when
+  // the teacher targeted nothing).
   const performAssign = useCallback(
     async (
       data: GuidedLearningSet,
       source: 'personal' | 'building',
       originSetId: string,
-      classId: string | null
+      classIds: string[],
+      periodNames: string[]
     ) => {
       try {
-        const url = await createSession(data, classId ?? undefined);
+        const url = await createSession(data, classIds, periodNames);
         const sessionId = url.split('/').pop() ?? '';
         setRecentSessionIds((prev) => ({
           ...prev,
@@ -276,21 +292,23 @@ export const GuidedLearningWidget: React.FC<{ widget: WidgetData }> = ({
             console.warn('[GuidedLearning] Failed to record assignment:', err);
           }
         }
-        // Persist the teacher's last-used classId per set so re-launching
-        // the same set pre-selects the same class. Clearing (picking "No
-        // class") removes the entry rather than writing an empty string to
-        // keep the config map small.
-        const prevMap = config.lastClassIdBySetId ?? {};
-        const nextMap: Record<string, string> = { ...prevMap };
-        if (classId) {
-          nextMap[originSetId] = classId;
+        // Persist the teacher's last-used ClassLink selection per set.
+        const prevMap = config.lastClassIdsBySetId ?? {};
+        const nextMap: Record<string, string[]> = { ...prevMap };
+        if (classIds.length > 0) {
+          nextMap[originSetId] = classIds;
         } else {
           delete nextMap[originSetId];
         }
+        // Drop any legacy single-class entry.
+        const prevLegacyMap = config.lastClassIdBySetId ?? {};
+        const nextLegacyMap: Record<string, string> = { ...prevLegacyMap };
+        delete nextLegacyMap[originSetId];
         updateWidget(widget.id, {
           config: {
             ...config,
-            lastClassIdBySetId: nextMap,
+            lastClassIdsBySetId: nextMap,
+            lastClassIdBySetId: nextLegacyMap,
           } as GuidedLearningConfig,
         });
         await navigator.clipboard.writeText(url);
@@ -314,30 +332,42 @@ export const GuidedLearningWidget: React.FC<{ widget: WidgetData }> = ({
     const source: 'personal' | 'building' = buildingSet
       ? 'building'
       : 'personal';
-    // If the teacher isn't on a ClassLink-provisioned org (or the fetch
-    // failed), skip the dialog entirely and preserve the classic
-    // join-link flow.
-    if (classLinkClasses.length === 0) {
-      await performAssign(data, source, setId, null);
+    // If the teacher has neither ClassLink nor local rosters, skip the
+    // dialog entirely and preserve the classic join-link flow.
+    if (classLinkClasses.length === 0 && rosters.length === 0) {
+      await performAssign(data, source, setId, [], []);
       return;
     }
-    // Otherwise open the dialog so they can optionally pick a target class.
+    // Otherwise open the dialog so they can optionally pick targets.
     setAssignTarget({ set: data, source, originSetId: setId });
   };
 
   const handleAssignConfirm = async (): Promise<void> => {
     if (!assignTarget) return;
-    // Guard: if the teacher somehow picked a classId that's no longer in the
-    // fetched ClassLink list (e.g. rosters changed between fetch and confirm),
-    // fall through to no-class rather than writing a stale id.
-    const selectedClassId =
-      assignOptions.classId &&
-      classLinkClasses.some((c) => c.sourcedId === assignOptions.classId)
-        ? assignOptions.classId
-        : null;
+    // Guard: filter stale sourcedIds that aren't in the latest ClassLink
+    // list. Local roster names fall through unchanged.
+    const validClassIds =
+      pickerValue.source === 'classlink'
+        ? pickerValue.classIds.filter((id) =>
+            classLinkClasses.some((c) => c.sourcedId === id)
+          )
+        : [];
+    const selectedPeriodNames =
+      pickerValue.source === 'classlink'
+        ? validClassIds
+            .map((id) => classLinkClasses.find((c) => c.sourcedId === id))
+            .filter((cls): cls is ClassLinkClass => Boolean(cls))
+            .map(formatClassLinkClassLabel)
+        : pickerValue.periodNames;
     const { set, source, originSetId } = assignTarget;
     setAssignTarget(null);
-    await performAssign(set, source, originSetId, selectedClassId);
+    await performAssign(
+      set,
+      source,
+      originSetId,
+      validClassIds,
+      selectedPeriodNames
+    );
   };
 
   const handleViewResultsForRecent = async (sessionId: string) => {
@@ -628,17 +658,18 @@ export const GuidedLearningWidget: React.FC<{ widget: WidgetData }> = ({
       />
 
       {assignTarget && (
-        <AssignModal<{ classId: string }>
+        <AssignModal<AssignClassPickerValue>
           isOpen={!!assignTarget}
           onClose={() => setAssignTarget(null)}
           itemTitle={assignTarget.set.title || 'Untitled set'}
-          options={assignOptions}
-          onOptionsChange={setAssignOptions}
+          options={pickerValue}
+          onOptionsChange={setPickerValue}
           extraSlot={
-            <GuidedLearningAssignTargetClassRow
-              classes={classLinkClasses}
-              value={assignOptions.classId}
-              onChange={(v) => setAssignOptions({ classId: v })}
+            <AssignClassPicker
+              classLinkClasses={classLinkClasses}
+              rosters={rosters}
+              value={pickerValue}
+              onChange={setPickerValue}
             />
           }
           onAssign={() => handleAssignConfirm()}
@@ -646,59 +677,5 @@ export const GuidedLearningWidget: React.FC<{ widget: WidgetData }> = ({
         />
       )}
     </>
-  );
-};
-
-/**
- * Build a human-readable label for a ClassLink class. Mirrors the format
- * used by `ClassLinkImportDialog` and `QuizManager` so teachers see the
- * same class names across flows.
- */
-function formatClassLinkClassLabel(cls: ClassLinkClass): string {
-  const subjectPrefix = cls.subject ? `${cls.subject} - ` : '';
-  const codeSuffix = cls.classCode ? ` (${cls.classCode})` : '';
-  return `${subjectPrefix}${cls.title}${codeSuffix}`;
-}
-
-/**
- * Target-class selector rendered inside the Guided Learning Assign modal's
- * `extraSlot`. Lets the teacher pick an optional ClassLink class to target
- * this set at so that students who signed in via ClassLink see it on their
- * `/my-assignments` page. Phase 3C — fan-out of the Quiz pilot.
- */
-const GuidedLearningAssignTargetClassRow: React.FC<{
-  classes: ClassLinkClass[];
-  value: string;
-  onChange: (next: string) => void;
-}> = ({ classes, value, onChange }) => {
-  return (
-    <div>
-      <div className="flex items-center gap-2 mb-1">
-        <Users className="w-4 h-4 text-brand-blue-primary" />
-        <label
-          htmlFor="gl-assign-target-class"
-          className="text-sm font-bold text-brand-blue-dark"
-        >
-          Target class (optional)
-        </label>
-      </div>
-      <select
-        id="gl-assign-target-class"
-        value={value}
-        onChange={(e) => onChange(e.target.value)}
-        className="w-full px-3 py-2 bg-white border border-slate-200 rounded-lg text-slate-800 text-sm focus:outline-none focus:ring-2 focus:ring-brand-blue-primary"
-      >
-        <option value="">No class (use join code)</option>
-        {classes.map((cls) => (
-          <option key={cls.sourcedId} value={cls.sourcedId}>
-            {formatClassLinkClassLabel(cls)}
-          </option>
-        ))}
-      </select>
-      <p className="text-xxs text-slate-500 mt-1">
-        Students in this class will see this activity in their assignments list.
-        Leave blank to use a join code.
-      </p>
-    </div>
   );
 };

--- a/components/widgets/QuizWidget/Widget.tsx
+++ b/components/widgets/QuizWidget/Widget.tsx
@@ -668,7 +668,7 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
           mode,
           plcOptions: PlcOptions,
           sessionOptions: QuizSessionOptions,
-          classId: string | null
+          classIds: string[]
         ) => {
           const data = await loadQuiz(meta);
           if (!data) return;
@@ -691,19 +691,24 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
                 plcSheetUrl: plcOptions.plcSheetUrl,
               },
               'paused',
-              classId ?? undefined
+              classIds
             );
-            // Persist the teacher's last-used classId per quiz so re-launching
-            // the same quiz pre-selects the same class. Clearing (picking "No
-            // class") removes the entry rather than writing an empty string
-            // to keep the config map small.
-            const prevMap = config.lastClassIdByQuizId ?? {};
-            const nextMap: Record<string, string> = { ...prevMap };
-            if (classId) {
-              nextMap[meta.id] = classId;
+            // Persist the teacher's last-used ClassLink classes per quiz so
+            // re-launching the same quiz pre-selects the same classes.
+            // Clearing removes the entry rather than writing an empty array.
+            const prevMap = config.lastClassIdsByQuizId ?? {};
+            const nextMap: Record<string, string[]> = { ...prevMap };
+            if (classIds.length > 0) {
+              nextMap[meta.id] = classIds;
             } else {
               delete nextMap[meta.id];
             }
+            // Also clear the legacy single-class map entry so the picker
+            // doesn't see a stale single-id override after the teacher
+            // explicitly cleared or changed their selection.
+            const prevLegacyMap = config.lastClassIdByQuizId ?? {};
+            const nextLegacyMap: Record<string, string> = { ...prevLegacyMap };
+            delete nextLegacyMap[meta.id];
             updateWidget(widget.id, {
               config: {
                 ...config,
@@ -718,7 +723,8 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
                   plcOptions.periodNames?.[0] ?? plcOptions.periodName ?? '',
                 periodNames: plcOptions.periodNames ?? [],
                 plcSheetUrl: plcOptions.plcSheetUrl ?? '',
-                lastClassIdByQuizId: nextMap,
+                lastClassIdsByQuizId: nextMap,
+                lastClassIdByQuizId: nextLegacyMap,
               } as QuizConfig,
             });
             const url = `${window.location.origin}/quiz?code=${code}`;

--- a/components/widgets/QuizWidget/components/QuizManager.tsx
+++ b/components/widgets/QuizWidget/components/QuizManager.tsx
@@ -42,7 +42,6 @@ import {
   Loader2,
   AlertCircle,
   CheckSquare,
-  Users,
 } from 'lucide-react';
 import {
   ClassLinkClass,
@@ -55,6 +54,12 @@ import {
 import { classLinkService } from '@/utils/classlinkService';
 import { type QuizSessionOptions } from '@/hooks/useQuizSession';
 import { Toggle } from '@/components/common/Toggle';
+import { AssignClassPicker } from '@/components/common/AssignClassPicker';
+import {
+  formatClassLinkClassLabel,
+  makeEmptyPickerValue,
+  type AssignClassPickerValue,
+} from '@/components/common/AssignClassPicker.helpers';
 import {
   LibraryShell,
   LibraryToolbar,
@@ -105,21 +110,47 @@ interface QuizAssignOptions {
   soundEffectsEnabled: boolean;
   plcMode: boolean;
   teacherName: string;
-  selectedPeriodNames: string[];
   plcSheetUrl: string;
   /**
-   * ClassLink class `sourcedId` this quiz is targeted at, or `''` for the
-   * "No class" option (classic code/PIN-only flow). Written onto the
-   * `quiz_sessions/{sessionId}` document when non-empty so students who
-   * signed in via ClassLink see the session on their /my-assignments page.
+   * Unified class-target picker state (Phase 5A). `classIds` is the list of
+   * ClassLink class `sourcedId`s when source === 'classlink'. `periodNames`
+   * is the list of local roster names when source === 'local'. One of the
+   * two is populated at a time — switching source clears the other.
    */
-  classId: string;
+  picker: AssignClassPickerValue;
+}
+
+/**
+ * Resolve the effective class-period labels for a picker value. When the
+ * teacher picks ClassLink classes, the labels used for the post-PIN period
+ * picker and the PLC Google Sheet export are the ClassLink class titles
+ * themselves; when they pick local rosters, the labels are the roster names.
+ */
+function resolveEffectivePeriodNames(
+  picker: AssignClassPickerValue,
+  classLinkClasses: ClassLinkClass[]
+): string[] {
+  if (picker.source === 'classlink') {
+    return picker.classIds
+      .map((id) => classLinkClasses.find((c) => c.sourcedId === id))
+      .filter((cls): cls is ClassLinkClass => Boolean(cls))
+      .map(formatClassLinkClassLabel);
+  }
+  return picker.periodNames;
 }
 
 function buildDefaultAssignOptions(
   config: QuizConfig,
   quizId?: string
 ): QuizAssignOptions {
+  const rememberedMulti = quizId
+    ? (config.lastClassIdsByQuizId?.[quizId] ?? null)
+    : null;
+  const rememberedSingle = quizId
+    ? (config.lastClassIdByQuizId?.[quizId] ?? null)
+    : null;
+  const classIds =
+    rememberedMulti ?? (rememberedSingle ? [rememberedSingle] : []);
   return {
     tabWarningsEnabled: true,
     showResultToStudent: false,
@@ -131,10 +162,19 @@ function buildDefaultAssignOptions(
     soundEffectsEnabled: false,
     plcMode: config.plcMode ?? false,
     teacherName: config.teacherName ?? '',
-    selectedPeriodNames:
-      config.periodNames ?? (config.periodName ? [config.periodName] : []),
     plcSheetUrl: config.plcSheetUrl ?? '',
-    classId: (quizId && config.lastClassIdByQuizId?.[quizId]) ?? '',
+    picker:
+      classIds.length > 0
+        ? { source: 'classlink', classIds, periodNames: [] }
+        : config.periodNames && config.periodNames.length > 0
+          ? { source: 'local', classIds: [], periodNames: config.periodNames }
+          : config.periodName
+            ? {
+                source: 'local',
+                classIds: [],
+                periodNames: [config.periodName],
+              }
+            : makeEmptyPickerValue('classlink'),
   };
 }
 
@@ -177,10 +217,11 @@ interface QuizManagerProps {
     plcOptions: PlcOptions,
     sessionOptions: QuizSessionOptions,
     /**
-     * ClassLink target class `sourcedId`, or `null` when the teacher chose
-     * "No class" (classic code/PIN-only flow). Phase 3A.
+     * Selected ClassLink class `sourcedId`s (Phase 5A multi-class). Empty
+     * array when the teacher chose local rosters or no classes at all —
+     * preserves the classic code/PIN-only flow.
      */
-    classId: string | null
+    classIds: string[]
   ) => void;
   onResults: (quiz: QuizMetadata) => void;
   onDelete: (quiz: QuizMetadata) => void | Promise<void>;
@@ -648,14 +689,25 @@ export const QuizManager: React.FC<QuizManagerProps> = ({
   // ─── Assign confirm handler ───────────────────────────────────────────────
   const handleAssignConfirm = (): void => {
     if (!assignTarget || !selectedMode) return;
+    // Guard: filter out any selected classId that's no longer in the fetched
+    // ClassLink list (e.g. rosters changed between fetch and confirm), so we
+    // never write stale sourcedIds.
+    const validClassIds =
+      assignOptions.picker.source === 'classlink'
+        ? assignOptions.picker.classIds.filter((id) =>
+            classLinkClasses.some((c) => c.sourcedId === id)
+          )
+        : [];
+    const effectivePeriodNames = resolveEffectivePeriodNames(
+      { ...assignOptions.picker, classIds: validClassIds },
+      classLinkClasses
+    );
     const plcOptions: PlcOptions = {
       plcMode: assignOptions.plcMode,
       teacherName: assignOptions.teacherName || undefined,
-      periodName: assignOptions.selectedPeriodNames[0] || undefined,
+      periodName: effectivePeriodNames[0] || undefined,
       periodNames:
-        assignOptions.selectedPeriodNames.length > 0
-          ? assignOptions.selectedPeriodNames
-          : undefined,
+        effectivePeriodNames.length > 0 ? effectivePeriodNames : undefined,
       plcSheetUrl: assignOptions.plcSheetUrl || undefined,
     };
     const sessionOptions: QuizSessionOptions = {
@@ -668,20 +720,12 @@ export const QuizManager: React.FC<QuizManagerProps> = ({
       showPodiumBetweenQuestions: assignOptions.showPodiumBetweenQuestions,
       soundEffectsEnabled: assignOptions.soundEffectsEnabled,
     };
-    // Guard: if the teacher somehow picked a classId that's no longer in the
-    // fetched ClassLink list (e.g. rosters changed between fetch and confirm),
-    // fall through to no-class rather than writing a stale id.
-    const selectedClassId =
-      assignOptions.classId &&
-      classLinkClasses.some((c) => c.sourcedId === assignOptions.classId)
-        ? assignOptions.classId
-        : null;
     onAssign(
       assignTarget,
       selectedMode,
       plcOptions,
       sessionOptions,
-      selectedClassId
+      validClassIds
     );
     setAssignTarget(null);
     setSelectedMode(null);
@@ -1004,14 +1048,20 @@ export const QuizManager: React.FC<QuizManagerProps> = ({
               options={assignOptions}
               onChange={setAssignOptions}
               classLinkClasses={classLinkClasses}
+              rosters={rosters}
             />
           }
           plcSlot={
             <AssignPlcSlot
-              rosters={rosters}
               options={assignOptions}
               onChange={setAssignOptions}
               plcSheetUrlInvalid={plcSheetUrlInvalid}
+              effectivePeriodCount={
+                resolveEffectivePeriodNames(
+                  assignOptions.picker,
+                  classLinkClasses
+                ).length
+              }
             />
           }
           onAssign={() => handleAssignConfirm()}
@@ -1280,7 +1330,8 @@ const AssignExtraSlot: React.FC<{
   options: QuizAssignOptions;
   onChange: (next: QuizAssignOptions) => void;
   classLinkClasses: ClassLinkClass[];
-}> = ({ options, onChange, classLinkClasses }) => {
+  rosters: ClassRoster[];
+}> = ({ options, onChange, classLinkClasses, rosters }) => {
   const update = <K extends keyof QuizAssignOptions>(
     key: K,
     value: QuizAssignOptions[K]
@@ -1288,13 +1339,12 @@ const AssignExtraSlot: React.FC<{
 
   return (
     <>
-      {classLinkClasses.length > 0 && (
-        <AssignTargetClassRow
-          classes={classLinkClasses}
-          value={options.classId}
-          onChange={(v) => update('classId', v)}
-        />
-      )}
+      <AssignClassPicker
+        classLinkClasses={classLinkClasses}
+        rosters={rosters}
+        value={options.picker}
+        onChange={(picker) => update('picker', picker)}
+      />
 
       <SectionHeader label="Quiz Integrity" />
       <ToggleRow
@@ -1354,79 +1404,21 @@ const AssignExtraSlot: React.FC<{
   );
 };
 
-/**
- * Build a human-readable label for a ClassLink class. Mirrors the format
- * used by `ClassLinkImportDialog` so teachers see the same class names in
- * both flows.
- */
-function formatClassLinkClassLabel(cls: ClassLinkClass): string {
-  const subjectPrefix = cls.subject ? `${cls.subject} - ` : '';
-  const codeSuffix = cls.classCode ? ` (${cls.classCode})` : '';
-  return `${subjectPrefix}${cls.title}${codeSuffix}`;
-}
-
-/**
- * Target-class selector rendered inside the Assign modal's `extraSlot`.
- * Lets the teacher pick an optional ClassLink class to target this quiz at
- * so that students who signed in via ClassLink see it on their
- * `/my-assignments` page. Phase 3A — pilot for class-targeted session
- * launches. Hidden entirely when the teacher isn't on a ClassLink org
- * (empty classes list).
- */
-const AssignTargetClassRow: React.FC<{
-  classes: ClassLinkClass[];
-  value: string;
-  onChange: (next: string) => void;
-}> = ({ classes, value, onChange }) => {
-  return (
-    <div>
-      <div className="flex items-center gap-2 mb-1">
-        <Users className="w-4 h-4 text-brand-blue-primary" />
-        <label
-          htmlFor="quiz-assign-target-class"
-          className="text-sm font-bold text-brand-blue-dark"
-        >
-          Target class (optional)
-        </label>
-      </div>
-      <select
-        id="quiz-assign-target-class"
-        value={value}
-        onChange={(e) => onChange(e.target.value)}
-        className="w-full px-3 py-2 bg-white border border-slate-200 rounded-lg text-slate-800 text-sm focus:outline-none focus:ring-2 focus:ring-brand-blue-primary"
-      >
-        <option value="">No class (use code/PIN only)</option>
-        {classes.map((cls) => (
-          <option key={cls.sourcedId} value={cls.sourcedId}>
-            {formatClassLinkClassLabel(cls)}
-          </option>
-        ))}
-      </select>
-      <p className="text-xxs text-slate-500 mt-1">
-        Students in this class will see this quiz in their assignments list.
-        Leave blank to use a join code.
-      </p>
-    </div>
-  );
-};
-
 const AssignPlcSlot: React.FC<{
-  rosters: ClassRoster[];
   options: QuizAssignOptions;
   onChange: (next: QuizAssignOptions) => void;
   plcSheetUrlInvalid: boolean;
-}> = ({ rosters, options, onChange, plcSheetUrlInvalid }) => {
+  /**
+   * Number of class periods the picker is contributing (ClassLink class
+   * labels or local roster names). Drives the "students will see a picker"
+   * hint without this slot needing to recompute the derivation itself.
+   */
+  effectivePeriodCount: number;
+}> = ({ options, onChange, plcSheetUrlInvalid, effectivePeriodCount }) => {
   const update = <K extends keyof QuizAssignOptions>(
     key: K,
     value: QuizAssignOptions[K]
   ) => onChange({ ...options, [key]: value });
-
-  const togglePeriod = (name: string) => {
-    const next = options.selectedPeriodNames.includes(name)
-      ? options.selectedPeriodNames.filter((n) => n !== name)
-      : [...options.selectedPeriodNames, name];
-    update('selectedPeriodNames', next);
-  };
 
   return (
     <>
@@ -1445,54 +1437,16 @@ const AssignPlcSlot: React.FC<{
         />
       </div>
       <p className="text-xxs text-slate-500 -mt-1">
-        Export results to a shared Google Sheet for your PLC team.
-      </p>
-
-      <div>
-        <label className="block text-xxs font-bold text-slate-400 uppercase tracking-widest mb-1">
-          Class Periods
-        </label>
-        {rosters.length > 0 ? (
-          <div className="space-y-1.5 max-h-36 overflow-y-auto rounded-lg border border-slate-200 bg-white p-2">
-            {rosters.map((r) => {
-              const checked = options.selectedPeriodNames.includes(r.name);
-              return (
-                <label
-                  key={r.id}
-                  className="flex items-center gap-2 cursor-pointer hover:bg-slate-50 rounded px-1.5 py-1"
-                >
-                  <input
-                    type="checkbox"
-                    checked={checked}
-                    onChange={() => togglePeriod(r.name)}
-                    className="rounded border-slate-300 text-indigo-600 focus:ring-indigo-500"
-                  />
-                  <span className="text-sm text-slate-800">{r.name}</span>
-                </label>
-              );
-            })}
-          </div>
+        Export results to a shared Google Sheet for your PLC team.{' '}
+        {effectivePeriodCount > 1 ? (
+          <>Students will see a class-period picker after entering their PIN.</>
         ) : (
-          <input
-            type="text"
-            value={options.selectedPeriodNames.join(', ')}
-            onChange={(e) => {
-              const names = e.target.value
-                .split(',')
-                .map((n) => n.trim())
-                .filter(Boolean);
-              update('selectedPeriodNames', [...new Set(names)]);
-            }}
-            placeholder="e.g. Period 1, Period 2"
-            className="w-full px-3 py-2 bg-white border border-slate-200 rounded-lg text-slate-800 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
-          />
+          <>
+            Pick two or more classes above to give students a period picker when
+            they join.
+          </>
         )}
-        <p className="text-xxs text-slate-400 mt-0.5">
-          {options.selectedPeriodNames.length > 1
-            ? 'Students will see a class-period picker after entering their PIN.'
-            : 'Select class periods for this assignment. Pick two or more to give students a picker when they join.'}
-        </p>
-      </div>
+      </p>
 
       {options.plcMode && (
         <div className="space-y-3 bg-slate-50 rounded-xl p-3 border border-slate-100">

--- a/components/widgets/VideoActivityWidget/Widget.tsx
+++ b/components/widgets/VideoActivityWidget/Widget.tsx
@@ -62,7 +62,7 @@ async function copyUrlToClipboard(
 export const VideoActivityWidget: React.FC<{ widget: WidgetData }> = ({
   widget,
 }) => {
-  const { updateWidget, addToast } = useDashboard();
+  const { updateWidget, addToast, rosters } = useDashboard();
   const {
     user,
     googleAccessToken,
@@ -310,7 +310,14 @@ export const VideoActivityWidget: React.FC<{ widget: WidgetData }> = ({
           }
         }}
         defaultSessionSettings={defaultSessionSettings}
-        onAssign={async (meta, sessionSettings, assignmentName, classId) => {
+        rosters={rosters}
+        onAssign={async (
+          meta,
+          sessionSettings,
+          assignmentName,
+          classIds,
+          selectedPeriodNames
+        ) => {
           // Use loadActivityData directly to avoid setting loadingActivity
           // which would cause the Manager component to unmount and destroy the modal
           const data = await loadActivityData(meta.driveFileId);
@@ -321,26 +328,30 @@ export const VideoActivityWidget: React.FC<{ widget: WidgetData }> = ({
             [],
             sessionSettings,
             assignmentName,
-            classId ?? undefined
+            classIds,
+            selectedPeriodNames
           );
 
-          // Phase 3B: persist per-activity memory of the last ClassLink target
-          // so the next launch of the same activity pre-selects the class the
-          // teacher used last time. Clearing the selection ("No class") also
-          // clears the remembered id so we don't stick on stale values.
-          const prevMap = config.lastClassIdByActivityId ?? {};
-          const nextMap: Record<string, string> = { ...prevMap };
-          if (classId) {
-            nextMap[meta.id] = classId;
+          // Phase 5A: persist per-activity memory of the last ClassLink
+          // target classes so the next launch pre-selects the same set.
+          const prevMap = config.lastClassIdsByActivityId ?? {};
+          const nextMap: Record<string, string[]> = { ...prevMap };
+          if (classIds.length > 0) {
+            nextMap[meta.id] = classIds;
           } else {
             delete nextMap[meta.id];
           }
+          // Drop any legacy single-class entry to avoid stale pre-selection.
+          const prevLegacyMap = config.lastClassIdByActivityId ?? {};
+          const nextLegacyMap: Record<string, string> = { ...prevLegacyMap };
+          delete nextLegacyMap[meta.id];
 
           updateWidget(widget.id, {
             config: {
               ...config,
               resultsSessionId: sessionId,
-              lastClassIdByActivityId: nextMap,
+              lastClassIdsByActivityId: nextMap,
+              lastClassIdByActivityId: nextLegacyMap,
             } as VideoActivityConfig,
           });
 
@@ -352,6 +363,7 @@ export const VideoActivityWidget: React.FC<{ widget: WidgetData }> = ({
           return sessionId;
         }}
         lastClassIdByActivityId={config.lastClassIdByActivityId}
+        lastClassIdsByActivityId={config.lastClassIdsByActivityId}
         onDelete={async (meta) => {
           try {
             await deleteActivity(meta.id, meta.driveFileId);

--- a/components/widgets/VideoActivityWidget/components/VideoActivityManager.tsx
+++ b/components/widgets/VideoActivityWidget/components/VideoActivityManager.tsx
@@ -32,7 +32,6 @@ import {
   PlayCircle,
   Plus,
   Trash2,
-  Users,
 } from 'lucide-react';
 import { LibraryShell } from '@/components/common/library/LibraryShell';
 import { LibraryToolbar } from '@/components/common/library/LibraryToolbar';
@@ -64,6 +63,7 @@ import type {
 } from '@/components/common/library/types';
 import type {
   ClassLinkClass,
+  ClassRoster,
   VideoActivityAssignment,
   VideoActivityAssignmentStatus,
   VideoActivityMetadata,
@@ -71,6 +71,12 @@ import type {
   VideoActivitySessionSettings,
 } from '@/types';
 import { classLinkService } from '@/utils/classlinkService';
+import { AssignClassPicker } from '@/components/common/AssignClassPicker';
+import {
+  formatClassLinkClassLabel,
+  makeEmptyPickerValue,
+  type AssignClassPickerValue,
+} from '@/components/common/AssignClassPicker.helpers';
 
 /* ─── Props ───────────────────────────────────────────────────────────────── */
 
@@ -96,18 +102,29 @@ export interface VideoActivityManagerProps {
     settings: VideoActivitySessionSettings,
     assignmentName: string,
     /**
-     * ClassLink target class `sourcedId`, or `null` when the teacher chose
-     * "No class" (classic join-URL-only flow). Phase 3B.
+     * Selected ClassLink class `sourcedId`s (Phase 5A multi-class). Empty
+     * array means the teacher targeted local rosters or no classes at all.
      */
-    classId: string | null
+    classIds: string[],
+    /**
+     * Selected local-roster period names (Phase 5A). Populated when the
+     * teacher picked local rosters; when they picked ClassLink classes these
+     * are the ClassLink class labels so the post-PIN period picker + any
+     * export respect the teacher's intent.
+     */
+    selectedPeriodNames: string[]
   ) => Promise<string>;
+  /** Local rosters used to populate the "Local rosters" source in the picker. */
+  rosters: ClassRoster[];
   /**
-   * Per-activity memory of the last ClassLink class the teacher targeted.
-   * Used to pre-select the target-class selector on re-launch of the same
-   * activity. Passed through from widget config; missing keys fall through
-   * to "No class". Phase 3B.
+   * @deprecated Phase 5A — replaced by `lastClassIdsByActivityId`.
    */
   lastClassIdByActivityId?: Record<string, string>;
+  /**
+   * Multi-class per-activity memory of the last ClassLink classes the
+   * teacher targeted. Pre-selects the picker on re-launch.
+   */
+  lastClassIdsByActivityId?: Record<string, string[]>;
   /**
    * Optional persistence hook for manual drag-reorder of the library. Drag
    * reordering is only enabled when this callback is provided; otherwise the
@@ -227,7 +244,9 @@ export const VideoActivityManager: React.FC<VideoActivityManagerProps> = ({
   onArchiveResults,
   initialLibraryViewMode,
   onLibraryViewModeChange,
+  rosters,
   lastClassIdByActivityId,
+  lastClassIdsByActivityId,
 }) => {
   const [tab, setTab] = useState<LibraryTab>('library');
 
@@ -238,9 +257,11 @@ export const VideoActivityManager: React.FC<VideoActivityManagerProps> = ({
     useState<VideoActivitySessionSettings>(defaultSessionSettings);
   const [assignmentName, setAssignmentName] = useState<string>('');
   const [assignError, setAssignError] = useState<string | null>(null);
-  // Phase 3B: selected ClassLink target class `sourcedId`, or `''` for
-  // "No class" (classic join-URL-only flow).
-  const [assignClassId, setAssignClassId] = useState<string>('');
+  // Phase 5A: unified class-assignment picker state. Source defaults to
+  // ClassLink when any classes are available, otherwise falls back to Local.
+  const [pickerValue, setPickerValue] = useState<AssignClassPickerValue>(() =>
+    makeEmptyPickerValue('classlink')
+  );
 
   // Adjust state during render when the assign target changes — avoids the
   // set-state-in-effect anti-pattern while keeping form fields reset per open.
@@ -252,7 +273,15 @@ export const VideoActivityManager: React.FC<VideoActivityManagerProps> = ({
     setAssignOptions(defaultSessionSettings);
     setAssignmentName(buildDefaultAssignmentName(assignTarget.title));
     setAssignError(null);
-    setAssignClassId(lastClassIdByActivityId?.[assignTarget.id] ?? '');
+    const rememberedMulti = lastClassIdsByActivityId?.[assignTarget.id];
+    const rememberedSingle = lastClassIdByActivityId?.[assignTarget.id];
+    const classIds =
+      rememberedMulti ?? (rememberedSingle ? [rememberedSingle] : []);
+    setPickerValue(
+      classIds.length > 0
+        ? { source: 'classlink', classIds, periodNames: [] }
+        : makeEmptyPickerValue('classlink')
+    );
   } else if (!assignTarget && prevAssignTargetId !== null) {
     setPrevAssignTargetId(null);
   }
@@ -472,20 +501,28 @@ export const VideoActivityManager: React.FC<VideoActivityManagerProps> = ({
       return;
     }
     setAssignError(null);
-    // Guard: if the teacher somehow picked a classId that's no longer in the
-    // fetched ClassLink list (e.g. rosters changed between fetch and confirm),
-    // fall through to no-class rather than writing a stale id.
-    const selectedClassId =
-      assignClassId &&
-      classLinkClasses.some((c) => c.sourcedId === assignClassId)
-        ? assignClassId
-        : null;
+    // Guard: filter stale sourcedIds that aren't in the latest ClassLink
+    // list. Selected local-roster names fall through unchanged.
+    const validClassIds =
+      pickerValue.source === 'classlink'
+        ? pickerValue.classIds.filter((id) =>
+            classLinkClasses.some((c) => c.sourcedId === id)
+          )
+        : [];
+    const selectedPeriodNames =
+      pickerValue.source === 'classlink'
+        ? validClassIds
+            .map((id) => classLinkClasses.find((c) => c.sourcedId === id))
+            .filter((cls): cls is ClassLinkClass => Boolean(cls))
+            .map(formatClassLinkClassLabel)
+        : pickerValue.periodNames;
     try {
       await onAssign(
         assignTarget,
         assignOptions,
         assignmentName.trim(),
-        selectedClassId
+        validClassIds,
+        selectedPeriodNames
       );
       setAssignTarget(null);
     } catch (err) {
@@ -971,13 +1008,12 @@ export const VideoActivityManager: React.FC<VideoActivityManagerProps> = ({
           onAssign={handleAssignConfirm}
           extraSlot={
             <div className="space-y-3">
-              {classLinkClasses.length > 0 && (
-                <AssignTargetClassRow
-                  classes={classLinkClasses}
-                  value={assignClassId}
-                  onChange={setAssignClassId}
-                />
-              )}
+              <AssignClassPicker
+                classLinkClasses={classLinkClasses}
+                rosters={rosters}
+                value={pickerValue}
+                onChange={setPickerValue}
+              />
 
               {assignError && (
                 <div className="flex items-start gap-2 rounded-xl border border-brand-red-primary/30 bg-brand-red-lighter/40 px-3 py-2 text-sm font-medium text-brand-red-dark">
@@ -1066,61 +1102,3 @@ const ToggleRow: React.FC<ToggleRowProps> = ({
     />
   </div>
 );
-
-/* ─── AssignTargetClassRow — ClassLink target-class selector (Phase 3B) ──── */
-
-/**
- * Build a human-readable label for a ClassLink class. Mirrors the format
- * used by `ClassLinkImportDialog` and `QuizManager` so teachers see the same
- * class names across all assign flows.
- */
-function formatClassLinkClassLabel(cls: ClassLinkClass): string {
-  const subjectPrefix = cls.subject ? `${cls.subject} - ` : '';
-  const codeSuffix = cls.classCode ? ` (${cls.classCode})` : '';
-  return `${subjectPrefix}${cls.title}${codeSuffix}`;
-}
-
-/**
- * Target-class selector rendered inside the Assign modal's `extraSlot`.
- * Lets the teacher pick an optional ClassLink class to target this activity
- * at so that students who signed in via ClassLink see it on their
- * `/my-assignments` page. Phase 3B — fan-out of the Phase 3A quiz pilot.
- * Hidden entirely when the teacher isn't on a ClassLink org (empty classes
- * list).
- */
-const AssignTargetClassRow: React.FC<{
-  classes: ClassLinkClass[];
-  value: string;
-  onChange: (next: string) => void;
-}> = ({ classes, value, onChange }) => {
-  return (
-    <div>
-      <div className="flex items-center gap-2 mb-1">
-        <Users className="w-4 h-4 text-brand-blue-primary" />
-        <label
-          htmlFor="video-activity-assign-target-class"
-          className="text-sm font-bold text-brand-blue-dark"
-        >
-          Target class (optional)
-        </label>
-      </div>
-      <select
-        id="video-activity-assign-target-class"
-        value={value}
-        onChange={(e) => onChange(e.target.value)}
-        className="w-full px-3 py-2 bg-white border border-slate-200 rounded-lg text-slate-800 text-sm focus:outline-none focus:ring-2 focus:ring-brand-blue-primary"
-      >
-        <option value="">No class (use code/PIN only)</option>
-        {classes.map((cls) => (
-          <option key={cls.sourcedId} value={cls.sourcedId}>
-            {formatClassLinkClassLabel(cls)}
-          </option>
-        ))}
-      </select>
-      <p className="text-xxs text-slate-500 mt-1">
-        Students in this class will see this activity in their assignments list.
-        Leave blank to use a join code.
-      </p>
-    </div>
-  );
-};

--- a/firestore.rules
+++ b/firestore.rules
@@ -72,6 +72,21 @@ service cloud.firestore {
               sessionClassIds.hasAny(request.auth.token.classIds));
     }
 
+    // Phase 5A transitional compatibility helper. Sessions created after
+    // Phase 5A write a multi-value `classIds` list; sessions created before
+    // Phase 5A write the single `classId` field. This helper selects the
+    // right gate based on which field is populated on the session doc:
+    //   - if `classIds` is a non-empty list, use `passesStudentClassGateList`
+    //   - otherwise, fall back to the legacy single-class gate
+    // Callers pass `resource.data.get('classIds', [])` and
+    // `resource.data.get('classId', '')` so the field-absent case safely
+    // falls through (empty list / empty string → no-op gate).
+    function passesStudentClassGateCompat(sessionClassIds, sessionClassId) {
+      return sessionClassIds is list && sessionClassIds.size() > 0
+             ? passesStudentClassGateList(sessionClassIds)
+             : passesStudentClassGate(sessionClassId);
+    }
+
     // ---- Organization helpers (see docs/organization_wiring_implementation.md) ----
 
     // Super admins are listed on the legacy admin_settings/user_roles doc.
@@ -642,10 +657,13 @@ service cloud.firestore {
         function sessionClassId() {
           return get(/databases/$(database)/documents/quiz_sessions/$(sessionId)).data.get('classId', '');
         }
+        function sessionClassIds() {
+          return get(/databases/$(database)/documents/quiz_sessions/$(sessionId)).data.get('classIds', []);
+        }
 
         allow read: if request.auth != null &&
           (request.auth.uid == sessionTeacherUid() ||
-           (request.auth.uid == studentUid && passesStudentClassGate(sessionClassId())) ||
+           (request.auth.uid == studentUid && passesStudentClassGateCompat(sessionClassIds(), sessionClassId())) ||
            isAdmin());
         allow create: if request.auth != null &&
           request.auth.uid == studentUid &&
@@ -653,7 +671,7 @@ service cloud.firestore {
           // Students cannot forge a score on creation
           request.resource.data.score == null &&
           // studentRole users must be enrolled in the session's class
-          passesStudentClassGate(sessionClassId());
+          passesStudentClassGateCompat(sessionClassIds(), sessionClassId());
         allow update: if request.auth != null && (
           // Teacher and admins can update any field
           request.auth.uid == sessionTeacherUid() || isAdmin() ||
@@ -663,7 +681,7 @@ service cloud.firestore {
           // score is never written by students.
           // tabSwitchWarnings may only increase (monotonic) to prevent tampering.
           (request.auth.uid == studentUid &&
-           passesStudentClassGate(sessionClassId()) &&
+           passesStudentClassGateCompat(sessionClassIds(), sessionClassId()) &&
            request.resource.data.studentUid == resource.data.studentUid &&
            request.resource.data.pin == resource.data.pin &&
            request.resource.data.joinedAt == resource.data.joinedAt &&
@@ -790,12 +808,15 @@ service cloud.firestore {
         function vaSessionClassId() {
           return get(/databases/$(database)/documents/video_activity_sessions/$(sessionId)).data.get('classId', '');
         }
+        function vaSessionClassIds() {
+          return get(/databases/$(database)/documents/video_activity_sessions/$(sessionId)).data.get('classIds', []);
+        }
 
         // Teacher can read all responses; students can only read their own (doc ID == auth UID)
         allow read: if request.auth != null && (
           isAdmin() ||
           get(/databases/$(database)/documents/video_activity_sessions/$(sessionId)).data.teacherUid == request.auth.uid ||
-          (studentUid == request.auth.uid && passesStudentClassGate(vaSessionClassId()))
+          (studentUid == request.auth.uid && passesStudentClassGateCompat(vaSessionClassIds(), vaSessionClassId()))
         );
         // Students create their own response; document ID and studentUid field must match their auth UID.
         // studentRole users must also be enrolled in the session's class.
@@ -804,12 +825,12 @@ service cloud.firestore {
           request.resource.data.studentUid == request.auth.uid &&
           request.resource.data.score == null &&
           request.resource.data.completedAt == null &&
-          passesStudentClassGate(vaSessionClassId());
+          passesStudentClassGateCompat(vaSessionClassIds(), vaSessionClassId());
         // Students can update only their own response to add answers or set completedAt;
         // identity fields and score are immutable from the client; answers array may only grow
         allow update: if request.auth != null &&
           studentUid == request.auth.uid &&
-          passesStudentClassGate(vaSessionClassId()) &&
+          passesStudentClassGateCompat(vaSessionClassIds(), vaSessionClassId()) &&
           request.resource.data.studentUid == resource.data.studentUid &&
           request.resource.data.pin == resource.data.pin &&
           request.resource.data.name == resource.data.name &&
@@ -955,12 +976,15 @@ service cloud.firestore {
         function glSessionClassId() {
           return get(/databases/$(database)/documents/guided_learning_sessions/$(sessionId)).data.get('classId', '');
         }
+        function glSessionClassIds() {
+          return get(/databases/$(database)/documents/guided_learning_sessions/$(sessionId)).data.get('classIds', []);
+        }
 
         // Teacher can read all responses; students can only read their own
         allow read: if request.auth != null && (
           isAdmin() ||
           get(/databases/$(database)/documents/guided_learning_sessions/$(sessionId)).data.teacherUid == request.auth.uid ||
-          (studentUid == request.auth.uid && passesStudentClassGate(glSessionClassId()))
+          (studentUid == request.auth.uid && passesStudentClassGateCompat(glSessionClassIds(), glSessionClassId()))
         );
         // Students create their own response; doc ID, studentAnonymousId, and sessionId must match.
         // studentRole users must also be enrolled in the session's class.
@@ -969,12 +993,12 @@ service cloud.firestore {
           request.resource.data.studentAnonymousId == request.auth.uid &&
           request.resource.data.sessionId == sessionId &&
           request.resource.data.score == null &&
-          passesStudentClassGate(glSessionClassId());
+          passesStudentClassGateCompat(glSessionClassIds(), glSessionClassId());
         // Students can update only their own response to add answers or set completedAt;
         // identity fields and score are immutable from the client
         allow update: if request.auth != null &&
           studentUid == request.auth.uid &&
-          passesStudentClassGate(glSessionClassId()) &&
+          passesStudentClassGateCompat(glSessionClassIds(), glSessionClassId()) &&
           request.resource.data.studentAnonymousId == resource.data.studentAnonymousId &&
           request.resource.data.sessionId == resource.data.sessionId &&
           request.resource.data.startedAt == resource.data.startedAt &&

--- a/hooks/useGuidedLearningSession.ts
+++ b/hooks/useGuidedLearningSession.ts
@@ -137,13 +137,17 @@ export interface UseGuidedLearningSessionTeacherResult {
   /**
    * Create a new session and return its URL.
    *
-   * `classId` is an optional ClassLink class `sourcedId`. When provided, it's
-   * written onto the session doc so that ClassLink-authenticated students
-   * see this session on their `/my-assignments` page, and Firestore rules
-   * (`passesStudentClassGate`) enforce class-based access. Omitting it
-   * preserves the classic join-link flow.
+   * `classIds` is the list of ClassLink class `sourcedId`s this session is
+   * targeted at (Phase 5A multi-class). When non-empty, the session doc
+   * stores them on `classIds` (and transitionally mirrors `classIds[0]` to
+   * `classId`). `periodNames` is the list of class-period labels used by
+   * the post-PIN picker on the student app.
    */
-  createSession: (set: GuidedLearningSet, classId?: string) => Promise<string>;
+  createSession: (
+    set: GuidedLearningSet,
+    classIds?: string[],
+    periodNames?: string[]
+  ) => Promise<string>;
   /** Load responses for a given session ID */
   subscribeToResponses: (sessionId: string) => () => void;
   /** Export responses as a CSV blob string */
@@ -160,7 +164,11 @@ export const useGuidedLearningSessionTeacher = (
   const [responsesLoading, setResponsesLoading] = useState(false);
 
   const createSession = useCallback(
-    async (set: GuidedLearningSet, classId?: string): Promise<string> => {
+    async (
+      set: GuidedLearningSet,
+      classIds: string[] = [],
+      periodNames: string[] = []
+    ): Promise<string> => {
       if (!teacherUid) throw new Error('Not authenticated');
 
       const sessionId = crypto.randomUUID();
@@ -174,11 +182,12 @@ export const useGuidedLearningSessionTeacher = (
         publicSteps,
         teacherUid,
         createdAt: Date.now(),
-        // Phase 3C: optional ClassLink target class. Only write when a
-        // non-empty sourcedId was supplied so sessions created without a
-        // target keep a clean doc shape (and the rules no-op branch kicks in
-        // via `resource.data.get('classId', '')`).
-        ...(classId ? { classId } : {}),
+        // Phase 5A: multi-class ClassLink targeting + post-PIN period
+        // picker support. `classIds` is authoritative; `classId` is
+        // transitionally mirrored to `classIds[0]` so pre-Phase-5A
+        // Firestore rules keep gating correctly.
+        ...(classIds.length > 0 ? { classIds, classId: classIds[0] } : {}),
+        ...(periodNames.length > 0 ? { periodNames } : {}),
       };
 
       await setDoc(doc(db, GL_SESSIONS_COLLECTION, sessionId), session);

--- a/hooks/useQuizAssignments.ts
+++ b/hooks/useQuizAssignments.ts
@@ -62,17 +62,20 @@ export interface UseQuizAssignmentsResult {
    * Create a new assignment + its matching session doc in one batch.
    * Returns the new assignment's id (== sessionId) and the allocated join code.
    *
-   * `classId` is an optional ClassLink class `sourcedId`. When provided, it's
-   * written onto the session doc so that ClassLink-authenticated students
-   * see this session on their `/my-assignments` page, and Firestore rules
-   * (`passesStudentClassGate`) enforce class-based access. Omitting it
-   * preserves the classic code/PIN-only flow.
+   * `classIds` is the list of ClassLink class `sourcedId`s this session is
+   * targeted at (Phase 5A multi-class). When non-empty, the session doc
+   * stores them on `classIds` (and transitionally mirrors `classIds[0]` to
+   * `classId` so pre-Phase-5A Firestore rules still gate correctly).
+   * Firestore rules (`passesStudentClassGateList`) enforce that ClassLink-
+   * authenticated students can only read sessions whose classIds overlap
+   * their auth-token classIds claim. An empty/missing list preserves the
+   * classic code/PIN-only flow.
    */
   createAssignment: (
     quiz: AssignmentQuizRef,
     settings: QuizAssignmentSettings,
     initialStatus?: QuizAssignmentStatus,
-    classId?: string
+    classIds?: string[]
   ) => Promise<{ id: string; code: string }>;
   /** Set both assignment.status and session.status to 'paused'. */
   pauseAssignment: (assignmentId: string) => Promise<void>;
@@ -181,8 +184,9 @@ export const useQuizAssignments = (
   const createAssignment = useCallback<
     UseQuizAssignmentsResult['createAssignment']
   >(
-    async (quiz, settings, initialStatus = 'active', classId) => {
+    async (quiz, settings, initialStatus = 'active', classIds) => {
       if (!userId) throw new Error('Not authenticated');
+      const targetClassIds = classIds ?? [];
 
       const assignmentId = crypto.randomUUID();
       const code = await allocateJoinCode();
@@ -247,11 +251,14 @@ export const useQuizAssignments = (
         soundEffectsEnabled: opts.soundEffectsEnabled ?? false,
         questionPhase: 'answering',
         periodNames: settings.periodNames,
-        // Phase 3A: optional ClassLink target class. Only write when a
-        // non-empty sourcedId was supplied so sessions created without a
-        // target keep a clean doc shape (and the rules no-op branch kicks in
-        // via `resource.data.get('classId', '')`).
-        ...(classId ? { classId } : {}),
+        // Phase 5A: multi-class ClassLink targeting. Write `classIds` when
+        // non-empty; also mirror `classIds[0]` to the legacy `classId` field
+        // so the transitional Firestore rule (which reads
+        // `resource.data.get('classIds', [resource.data.get('classId', '')])`)
+        // keeps gating correctly until the fallback is removed.
+        ...(targetClassIds.length > 0
+          ? { classIds: targetClassIds, classId: targetClassIds[0] }
+          : {}),
       };
 
       const batch = writeBatch(db);

--- a/hooks/useVideoActivityAssignments.ts
+++ b/hooks/useVideoActivityAssignments.ts
@@ -57,17 +57,18 @@ export interface UseVideoActivityAssignmentsResult {
    * Create a new assignment + its matching session doc in one batch.
    * Returns the new assignment's id (== sessionId).
    *
-   * `classId` is an optional ClassLink class `sourcedId`. When provided, it's
-   * written onto the session doc so that ClassLink-authenticated students
-   * see this session on their `/my-assignments` page, and Firestore rules
-   * (`passesStudentClassGate(vaSessionClassId())`) enforce class-based
-   * access. Omitting it preserves the classic join-URL-only flow.
+   * `classIds` is the list of ClassLink class `sourcedId`s this session is
+   * targeted at (Phase 5A multi-class). When non-empty, the session doc
+   * stores them on `classIds` (and transitionally mirrors `classIds[0]` to
+   * `classId`). `periodNames` is the list of class-period labels available
+   * for the post-PIN picker.
    */
   createAssignment: (
     activity: AssignmentActivityRef,
     settings: VideoActivityAssignmentSettings,
     initialStatus?: VideoActivityAssignmentStatus,
-    classId?: string
+    classIds?: string[],
+    periodNames?: string[]
   ) => Promise<{ id: string }>;
   /** Set both assignment.status and session.status to 'paused' (assignment) / 'ended' (session). */
   pauseAssignment: (assignmentId: string) => Promise<void>;
@@ -135,9 +136,16 @@ export const useVideoActivityAssignments = (
   const createAssignment = useCallback<
     UseVideoActivityAssignmentsResult['createAssignment']
   >(
-    async (activity, settings, initialStatus = 'active', classId) => {
+    async (
+      activity,
+      settings,
+      initialStatus = 'active',
+      classIds,
+      periodNames
+    ) => {
       if (!userId) throw new Error('Not authenticated');
-
+      const targetClassIds = classIds ?? [];
+      const targetPeriodNames = periodNames ?? [];
       const assignmentId = crypto.randomUUID();
       const now = Date.now();
 
@@ -173,11 +181,16 @@ export const useVideoActivityAssignments = (
         allowedPins: [],
         createdAt: now,
         ...(sessionStatus === 'ended' ? { endedAt: now } : {}),
-        // Phase 3B: optional ClassLink target class. Only write when a
-        // non-empty sourcedId was supplied so sessions created without a
-        // target keep a clean doc shape (and the rules no-op branch kicks in
-        // via `resource.data.get('classId', '')`).
-        ...(classId ? { classId } : {}),
+        // Phase 5A: multi-class ClassLink targeting + post-PIN period picker.
+        // Mirror `classIds[0]` into the legacy `classId` field so
+        // pre-Phase-5A rules keep gating correctly until the fallback is
+        // removed.
+        ...(targetClassIds.length > 0
+          ? { classIds: targetClassIds, classId: targetClassIds[0] }
+          : {}),
+        ...(targetPeriodNames.length > 0
+          ? { periodNames: targetPeriodNames }
+          : {}),
       };
 
       const batch = writeBatch(db);

--- a/hooks/useVideoActivitySession.ts
+++ b/hooks/useVideoActivitySession.ts
@@ -77,11 +77,12 @@ export interface UseVideoActivitySessionTeacherResult {
   /**
    * Create a session for a class and return the sessionId (used as the share link).
    *
-   * `classId` is an optional ClassLink class `sourcedId`. When provided, it's
-   * written onto the session doc so that ClassLink-authenticated students
-   * see this session on their `/my-assignments` page, and Firestore rules
-   * (`passesStudentClassGate(vaSessionClassId())`) enforce class-based
-   * access. Omitting it preserves the classic code/PIN-only flow.
+   * `classIds` is the list of ClassLink class `sourcedId`s this session is
+   * targeted at (Phase 5A multi-class). When non-empty, the session doc
+   * stores them on `classIds` (and transitionally mirrors `classIds[0]` to
+   * `classId`). `periodNames` drives the post-PIN class-period picker and
+   * is either the list of chosen local roster names or the ClassLink class
+   * labels (mirroring the teacher's picker source).
    */
   createSession: (
     activity: VideoActivityData,
@@ -89,7 +90,8 @@ export interface UseVideoActivitySessionTeacherResult {
     allowedPins?: string[],
     settings?: Partial<VideoActivitySessionSettings>,
     assignmentName?: string,
-    classId?: string
+    classIds?: string[],
+    periodNames?: string[]
   ) => Promise<string>;
   /** Sessions created by the current teacher for the selected activity. */
   sessions: VideoActivitySession[];
@@ -127,7 +129,8 @@ export const useVideoActivitySessionTeacher =
         allowedPins: string[] = [],
         settings?: Partial<VideoActivitySessionSettings>,
         assignmentName?: string,
-        classId?: string
+        classIds: string[] = [],
+        periodNames: string[] = []
       ): Promise<string> => {
         const sessionId = crypto.randomUUID();
         const trimmedAssignmentName = assignmentName?.trim();
@@ -152,11 +155,12 @@ export const useVideoActivitySessionTeacher =
           status: 'active',
           allowedPins,
           createdAt: Date.now(),
-          // Phase 3B: optional ClassLink target class. Only write when a
-          // non-empty sourcedId was supplied so sessions created without a
-          // target keep a clean doc shape (and the rules no-op branch kicks in
-          // via `resource.data.get('classId', '')`).
-          ...(classId ? { classId } : {}),
+          // Phase 5A: multi-class ClassLink targeting + post-PIN period
+          // picker support. `classIds` is authoritative; `classId` is
+          // transitionally mirrored to `classIds[0]` so pre-Phase-5A
+          // Firestore rules keep gating correctly.
+          ...(classIds.length > 0 ? { classIds, classId: classIds[0] } : {}),
+          ...(periodNames.length > 0 ? { periodNames } : {}),
         };
 
         await setDoc(doc(db, SESSIONS_COLLECTION, sessionId), session);
@@ -309,7 +313,18 @@ export interface UseVideoActivitySessionStudentResult {
   myResponse: VideoActivityResponse | null;
   joinStatus: StudentJoinStatus;
   error: string | null;
-  joinSession: (sessionId: string, pin: string, name: string) => Promise<void>;
+  /**
+   * Look up a session by id without creating a response — used by the
+   * student-app join flow to decide whether to show a post-PIN period
+   * picker before committing the join.
+   */
+  lookupSession: (sessionId: string) => Promise<VideoActivitySession | null>;
+  joinSession: (
+    sessionId: string,
+    pin: string,
+    name: string,
+    classPeriod?: string
+  ) => Promise<void>;
   submitAnswer: (questionId: string, answer: string) => Promise<void>;
   completeActivity: () => Promise<void>;
 }
@@ -376,11 +391,31 @@ export const useVideoActivitySessionStudent =
       return unsub;
     }, [sessionId, responseDocId]);
 
+    const lookupSession = useCallback(
+      async (targetSessionId: string): Promise<VideoActivitySession | null> => {
+        try {
+          const snap = await getDoc(
+            doc(db, SESSIONS_COLLECTION, targetSessionId)
+          );
+          if (!snap.exists()) return null;
+          return snap.data() as VideoActivitySession;
+        } catch (err) {
+          console.error(
+            '[useVideoActivitySessionStudent] lookupSession error:',
+            err
+          );
+          return null;
+        }
+      },
+      []
+    );
+
     const joinSession = useCallback(
       async (
         targetSessionId: string,
         studentPin: string,
-        studentName: string
+        studentName: string,
+        classPeriod?: string
       ): Promise<void> => {
         setJoinStatus('loading');
         setError(null);
@@ -454,6 +489,7 @@ export const useVideoActivitySessionStudent =
               answers: [],
               completedAt: null,
               score: null,
+              ...(classPeriod ? { classPeriod } : {}),
             };
             await setDoc(responseRef, newResponse);
           }
@@ -527,6 +563,7 @@ export const useVideoActivitySessionStudent =
       myResponse,
       joinStatus,
       error,
+      lookupSession,
       joinSession,
       submitAnswer,
       completeActivity,

--- a/types.ts
+++ b/types.ts
@@ -1737,17 +1737,24 @@ export interface QuizSession {
   /** Selected class period roster names available for students to join. */
   periodNames?: string[];
 
-  // ─── ClassLink target class (Phase 3A) ─────────────────────────────────────
+  // ─── ClassLink target class (Phase 3A, Phase 5A multi-class) ───────────────
   /**
-   * Optional ClassLink class `sourcedId` this session is targeted at. When
-   * present, students who signed in via the ClassLink / Google flow will see
-   * this session on their `/my-assignments` page, and Firestore rules
-   * enforce (via `passesStudentClassGate`) that only students enrolled in
-   * this class can read the session doc. Omit (or leave as an empty string)
-   * to preserve the classic code/PIN-only flow — the gate is a no-op for
-   * non-studentRole users.
+   * @deprecated Phase 5A — retained only for transitional compatibility.
+   * Populated to `classIds[0]` when `classIds` is non-empty so older clients
+   * and pre-migration Firestore rules keep working. Prefer `classIds`.
    */
   classId?: string;
+  /**
+   * Multi-class ClassLink target: the list of ClassLink class `sourcedId`s
+   * this session is targeted at. When non-empty, students who signed in via
+   * the ClassLink / Google flow will see this session on their
+   * `/my-assignments` page, and Firestore rules (via
+   * `passesStudentClassGateList`) enforce that the student has at least one
+   * of these classes in their `classIds` auth-token claim. An empty or
+   * missing list preserves the classic code/PIN-only flow — the gate is a
+   * no-op for non-studentRole users.
+   */
+  classIds?: string[];
 }
 
 export interface QuizResponseAnswer {
@@ -1841,13 +1848,20 @@ export interface QuizConfig {
   /** Persisted library grid/list toggle. */
   libraryViewMode?: 'grid' | 'list';
   /**
-   * Per-quiz memory of the last ClassLink target class (`sourcedId`) the
-   * teacher picked in the Assign modal. Key is quizId, value is the
-   * ClassLink class sourcedId. Used to pre-select the selector on re-launch
-   * of the same quiz so teachers don't have to re-pick every time.
-   * Undefined means "use the default (No class)".
+   * @deprecated Phase 5A — replaced by `lastClassIdsByQuizId` (multi-class).
+   * Retained for a transitional release so existing widget configs don't
+   * lose their pre-selection on first render. Readers prefer the multi-
+   * class map; fallback to this when the new key is absent.
    */
   lastClassIdByQuizId?: Record<string, string>;
+  /**
+   * Per-quiz memory of the last ClassLink target classes (`sourcedId`s) the
+   * teacher picked in the Assign modal. Key is quizId, value is a list of
+   * ClassLink class sourcedIds. Used to pre-select the picker on re-launch
+   * of the same quiz so teachers don't have to re-pick every time. Missing
+   * keys mean "use the default (no classes selected)".
+   */
+  lastClassIdsByQuizId?: Record<string, string[]>;
 }
 
 // --- QUIZ ASSIGNMENT TYPES ---
@@ -1982,8 +1996,17 @@ export interface VideoActivityConfig {
    * ClassLink class sourcedId. Used to pre-select the selector on re-launch
    * of the same activity so teachers don't have to re-pick every time.
    * Undefined means "use the default (No class)".
+   *
+   * @deprecated Phase 5A — replaced by `lastClassIdsByActivityId` (multi).
+   * Retained for a transitional release so existing widget configs don't
+   * lose their pre-selection on first render.
    */
   lastClassIdByActivityId?: Record<string, string>;
+  /**
+   * Multi-class variant of the per-activity memory (Phase 5A). Preferred
+   * over the legacy single-class map.
+   */
+  lastClassIdsByActivityId?: Record<string, string[]>;
 }
 
 export interface VideoActivitySessionSettings {
@@ -2028,13 +2051,26 @@ export interface VideoActivitySession {
   /** Optional Unix timestamp when the session link expires. */
   expiresAt?: number;
   /**
-   * Optional ClassLink class `sourcedId` this session is targeted at. When
-   * set, ClassLink-authenticated students whose token includes this classId
-   * see the session on their `/my-assignments` page, and Firestore rules
-   * (`passesStudentClassGate(vaSessionClassId())`) enforce class-based
-   * access. Undefined preserves the classic code/PIN-only flow.
+   * @deprecated Phase 5A — retained only for transitional compatibility.
+   * Populated to `classIds[0]` when `classIds` is non-empty so older clients
+   * and pre-migration Firestore rules keep working. Prefer `classIds`.
    */
   classId?: string;
+  /**
+   * Multi-class ClassLink target list. ClassLink-authenticated students whose
+   * token `classIds` claim overlaps this list see the session on their
+   * `/my-assignments` page; Firestore rules (`passesStudentClassGateList`)
+   * enforce the class gate. An empty/missing list preserves the classic
+   * PIN-only flow.
+   */
+  classIds?: string[];
+  /**
+   * Optional class-period names (typically local roster names) available for
+   * students to choose from after entering their PIN. When present and > 1,
+   * the student app shows a post-PIN picker and writes the chosen value to
+   * the response's `classPeriod` field. Mirrors the QuizSession pattern.
+   */
+  periodNames?: string[];
 }
 
 /** A single answer submitted by a student for a video activity question. */
@@ -2061,6 +2097,8 @@ export interface VideoActivityResponse {
   answers: VideoActivityAnswer[];
   completedAt: number | null;
   score: number | null;
+  /** Which class period the student selected when joining (multi-class support). */
+  classPeriod?: string;
 }
 
 export interface TalkingToolConfig {
@@ -2638,17 +2676,28 @@ export interface GuidedLearningSession {
   teacherUid: string;
   createdAt: number;
   expiresAt?: number;
-  // ─── ClassLink target class (Phase 3C) ─────────────────────────────────────
+  // ─── ClassLink target class (Phase 3C, Phase 5A multi-class) ───────────────
   /**
-   * Optional ClassLink class `sourcedId` this session is targeted at. When
-   * present, students who signed in via the ClassLink / Google flow will see
-   * this session on their `/my-assignments` page, and Firestore rules
-   * enforce (via `passesStudentClassGate`) that only students enrolled in
-   * this class can read the session doc. Omit (or leave as an empty string)
-   * to preserve the classic join-link flow — the gate is a no-op for
-   * non-studentRole users.
+   * @deprecated Phase 5A — retained only for transitional compatibility.
+   * Populated to `classIds[0]` when `classIds` is non-empty so older clients
+   * and pre-migration Firestore rules keep working. Prefer `classIds`.
    */
   classId?: string;
+  /**
+   * Multi-class ClassLink target list. ClassLink-authenticated students whose
+   * token `classIds` claim overlaps this list see the session on their
+   * `/my-assignments` page; Firestore rules (`passesStudentClassGateList`)
+   * enforce the class gate. An empty/missing list preserves the classic
+   * join-link flow.
+   */
+  classIds?: string[];
+  /**
+   * Optional class-period names (typically local roster names) available for
+   * students to choose from after entering their PIN. When present and > 1,
+   * the student app shows a post-PIN picker and writes the chosen value to
+   * the response's `classPeriod` field. Mirrors the QuizSession pattern.
+   */
+  periodNames?: string[];
 }
 
 /** Per-student response in /guided_learning_sessions/{id}/responses/{studentUid} */
@@ -2664,6 +2713,8 @@ export interface GuidedLearningResponse {
   completedAt: number | null;
   startedAt: number;
   score: number | null;
+  /** Which class period the student selected when joining (multi-class support). */
+  classPeriod?: string;
 }
 
 export interface GuidedLearningGlobalConfig {
@@ -2685,8 +2736,17 @@ export interface GuidedLearningConfig {
    * value is the ClassLink class sourcedId. Used to pre-select the selector
    * on re-launch of the same set so teachers don't have to re-pick every
    * time. Undefined means "use the default (No class)".
+   *
+   * @deprecated Phase 5A — replaced by `lastClassIdsBySetId` (multi).
+   * Retained for a transitional release so existing widget configs don't
+   * lose their pre-selection on first render.
    */
   lastClassIdBySetId?: Record<string, string>;
+  /**
+   * Multi-class variant of the per-set memory (Phase 5A). Preferred over
+   * the legacy single-class map.
+   */
+  lastClassIdsBySetId?: Record<string, string[]>;
 }
 
 // Union of all widget configs


### PR DESCRIPTION
## Summary

Replaces the split single-select ClassLink dropdown + separate period checkboxes with one shared `AssignClassPicker` that offers a source toggle (ClassLink classes XOR local rosters) and multi-select from the active list. Teachers with multiple ClassLink classes can now target more than one in a single assignment; Video Activity and Guided Learning pick up multi-class targeting plus a post-PIN class-period picker at parity with Quiz.

- **New**: `components/common/AssignClassPicker.{tsx,helpers.ts}` — shared segmented-toggle multi-select picker.
- **Quiz/VA/GL Managers + Widgets**: adopt the picker; `onAssign` now passes `classIds[]` + `selectedPeriodNames[]`. Quiz PLC mode derives period labels from ClassLink class titles when source = ClassLink so PLC export still works.
- **Hooks** (`useQuizAssignments`, `useVideoActivitySession`, `useVideoActivityAssignments`, `useGuidedLearningSession`): write multi-class `classIds` and mirror `classIds[0]` to the legacy `classId` field for one transitional release.
- **Types**: `QuizSession` / `VideoActivitySession` / `GuidedLearningSession` gain `classIds?: string[]`; VA + GL sessions gain `periodNames?: string[]`; VA + GL responses gain `classPeriod?: string`.
- **Student apps**: VA and GL gain the post-PIN class-period picker step mirroring the existing Quiz pattern; picked period is persisted on the response doc.
- **Firestore rules**: new `passesStudentClassGateCompat(classIds, classId)` helper selects the list gate when `classIds` is populated and falls back to the legacy single-class gate otherwise, preserving backward compatibility for sessions created pre-Phase-5A. Applied to `quiz_sessions`, `video_activity_sessions`, and `guided_learning_sessions` (both the session `get` rule and every response-subcollection read/create/update gate).

## Test plan

- [x] `pnpm run validate` — type-check + lint + format + unit tests (1423 passed) + functions tests (143 passed)
- [ ] `pnpm run test:rules` (CI) — verify the existing `studentRoleClassGate` suite still passes with the new compat helper (seeds use legacy `classId` only, which exercises the fallback branch)
- [ ] Manual on dev preview (per verification plan in `/root/.claude/plans/yes-lazy-spindle.md`):
  - [ ] Teacher with 4 ClassLink classes → Quiz Assign → select all 4 → session doc has `classIds: [4]` AND transitional `classId: <first>`
  - [ ] Teacher selects 2 local rosters → session doc has `periodNames: [2]`
  - [ ] ClassLink-SSO student (one of the 4 classes) sees the assignment on `/my-assignments`
  - [ ] PIN-joining student sees post-PIN period picker for multi-period sessions; `classPeriod` is recorded on the response
  - [ ] Same checks for Video Activity and Guided Learning
  - [ ] Quiz PLC mode + ClassLink source: PLC export rows reflect ClassLink class labels
  - [ ] Pre-Phase-5A assignment (legacy `classId` only) still readable by ClassLink-SSO students after rules deploy

## Backward compatibility

- Session writes dual-write `classIds` + `classId = classIds[0]` for one release.
- Rule compat helper preserves single-class gating for sessions with only `classId` (no `classIds` field).
- Per-widget pre-select maps (`lastClassIdBy{Quiz,Activity,Set}Id`) are retained alongside new `lastClassIdsBy{Quiz,Activity,Set}Id` maps so existing widget configs don't lose their memory on first render.

## Out of scope

Listed in the plan file: mini-app index PR (B1), mini-app listener gating (B2), listener-ghost diagnostic (B3), Quiz creation account-state failure (C). Those ship separately.

https://claude.ai/code/session_01Jf5iNcdzDmZjtpBntzFLkL

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jf5iNcdzDmZjtpBntzFLkL)_