### PR TITLE
fix(my-assignments): surface ClassLink-targeted quiz/VA/GL for SSO students

### DIFF
--- a/components/common/AssignClassPicker.helpers.ts
+++ b/components/common/AssignClassPicker.helpers.ts
@@ -1,0 +1,36 @@
+/**
+ * Shared helper + type definitions for `AssignClassPicker`. Kept in a
+ * `.ts` sibling so the `.tsx` component file only exports components
+ * (required for Vite's fast-refresh contract).
+ */
+
+import type { ClassLinkClass } from '@/types';
+
+export type AssignClassSource = 'classlink' | 'local';
+
+export interface AssignClassPickerValue {
+  /** Which source list is currently active. */
+  source: AssignClassSource;
+  /** Selected ClassLink class `sourcedId`s (populated when source === 'classlink'). */
+  classIds: string[];
+  /** Selected local roster names (populated when source === 'local'). */
+  periodNames: string[];
+}
+
+/**
+ * Build a human-readable label for a ClassLink class. Mirrors the format
+ * used elsewhere (ClassLinkImportDialog, legacy QuizManager) so teachers
+ * see the same class names across flows.
+ */
+export function formatClassLinkClassLabel(cls: ClassLinkClass): string {
+  const subjectPrefix = cls.subject ? `${cls.subject} - ` : '';
+  const codeSuffix = cls.classCode ? ` (${cls.classCode})` : '';
+  return `${subjectPrefix}${cls.title}${codeSuffix}`;
+}
+
+/** Default-empty value helper used by callers to seed initial picker state. */
+export function makeEmptyPickerValue(
+  source: AssignClassSource = 'classlink'
+): AssignClassPickerValue {
+  return { source, classIds: [], periodNames: [] };
+}

--- a/components/common/AssignClassPicker.tsx
+++ b/components/common/AssignClassPicker.tsx
@@ -1,0 +1,292 @@
+/**
+ * AssignClassPicker — shared class-assignment picker used by the Quiz, Video
+ * Activity, and Guided Learning assign modals.
+ *
+ * Replaces the previous split between a single-select ClassLink dropdown and
+ * a separate multi-select local-rosters checklist. Teachers pick a source
+ * (ClassLink classes XOR local rosters), then multi-select from the filtered
+ * list. Zero selection falls through to the classic code/PIN-only flow.
+ *
+ * The component is controlled — parents own the value and pass it back in
+ * via `value` / `onChange`. Source-switching clears the other source's
+ * selection automatically so the shape stays consistent.
+ */
+
+import React from 'react';
+import { Users, Check } from 'lucide-react';
+import type { ClassLinkClass, ClassRoster } from '@/types';
+import {
+  formatClassLinkClassLabel,
+  type AssignClassSource,
+  type AssignClassPickerValue,
+} from './AssignClassPicker.helpers';
+
+export interface AssignClassPickerProps {
+  classLinkClasses: ClassLinkClass[];
+  rosters: ClassRoster[];
+  value: AssignClassPickerValue;
+  onChange: (next: AssignClassPickerValue) => void;
+  disabled?: boolean;
+}
+
+export const AssignClassPicker: React.FC<AssignClassPickerProps> = ({
+  classLinkClasses,
+  rosters,
+  value,
+  onChange,
+  disabled = false,
+}) => {
+  const hasClassLink = classLinkClasses.length > 0;
+  const hasLocal = rosters.length > 0;
+
+  const effectiveSource: AssignClassSource = hasClassLink
+    ? value.source
+    : 'local';
+
+  const handleSourceChange = (next: AssignClassSource): void => {
+    if (next === value.source) return;
+    // Clear the other source's selection so the shape stays consistent.
+    onChange({
+      source: next,
+      classIds: [],
+      periodNames: [],
+    });
+  };
+
+  const toggleClassId = (id: string): void => {
+    const next = value.classIds.includes(id)
+      ? value.classIds.filter((x) => x !== id)
+      : [...value.classIds, id];
+    onChange({ ...value, classIds: next });
+  };
+
+  const togglePeriodName = (name: string): void => {
+    const next = value.periodNames.includes(name)
+      ? value.periodNames.filter((x) => x !== name)
+      : [...value.periodNames, name];
+    onChange({ ...value, periodNames: next });
+  };
+
+  const selectAll = (): void => {
+    if (effectiveSource === 'classlink') {
+      onChange({
+        ...value,
+        source: 'classlink',
+        classIds: classLinkClasses.map((c) => c.sourcedId),
+      });
+    } else {
+      onChange({
+        ...value,
+        source: 'local',
+        periodNames: rosters.map((r) => r.name),
+      });
+    }
+  };
+
+  const clearAll = (): void => {
+    onChange({ ...value, classIds: [], periodNames: [] });
+  };
+
+  const selectedCount =
+    effectiveSource === 'classlink'
+      ? value.classIds.length
+      : value.periodNames.length;
+
+  const totalCount =
+    effectiveSource === 'classlink' ? classLinkClasses.length : rosters.length;
+
+  return (
+    <div
+      className={
+        disabled ? 'opacity-50 pointer-events-none space-y-2' : 'space-y-2'
+      }
+    >
+      <div className="flex items-center gap-2">
+        <Users className="w-4 h-4 text-brand-blue-primary" />
+        <label className="text-sm font-bold text-brand-blue-dark">
+          Assign to classes{' '}
+          <span className="text-slate-400 font-normal">(optional)</span>
+        </label>
+      </div>
+
+      {hasClassLink && (
+        <div
+          role="radiogroup"
+          aria-label="Class source"
+          className="inline-flex items-center rounded-lg border border-slate-200 bg-slate-50 p-0.5"
+        >
+          <SourceToggleButton
+            label="ClassLink classes"
+            active={effectiveSource === 'classlink'}
+            onClick={() => handleSourceChange('classlink')}
+          />
+          <SourceToggleButton
+            label="Local rosters"
+            active={effectiveSource === 'local'}
+            onClick={() => handleSourceChange('local')}
+            disabled={!hasLocal}
+            disabledHint="No local rosters"
+          />
+        </div>
+      )}
+
+      <PickerList
+        source={effectiveSource}
+        classLinkClasses={classLinkClasses}
+        rosters={rosters}
+        value={value}
+        onToggleClassId={toggleClassId}
+        onTogglePeriodName={togglePeriodName}
+      />
+
+      {totalCount > 0 && (
+        <div className="flex items-center justify-between text-xxs text-slate-500">
+          <span>
+            {selectedCount === 0
+              ? 'None selected — students join with the code only.'
+              : `${selectedCount} of ${totalCount} selected.`}
+          </span>
+          <div className="flex items-center gap-2">
+            {selectedCount < totalCount && (
+              <button
+                type="button"
+                onClick={selectAll}
+                className="font-bold text-brand-blue-primary hover:text-brand-blue-dark"
+              >
+                Select all ({totalCount})
+              </button>
+            )}
+            {selectedCount > 0 && (
+              <button
+                type="button"
+                onClick={clearAll}
+                className="font-bold text-slate-500 hover:text-slate-700"
+              >
+                Clear
+              </button>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+const SourceToggleButton: React.FC<{
+  label: string;
+  active: boolean;
+  onClick: () => void;
+  disabled?: boolean;
+  disabledHint?: string;
+}> = ({ label, active, onClick, disabled = false, disabledHint }) => (
+  <button
+    type="button"
+    role="radio"
+    aria-checked={active}
+    onClick={onClick}
+    disabled={disabled}
+    title={disabled ? disabledHint : undefined}
+    className={`px-3 py-1 text-xs font-bold rounded-md transition-colors ${
+      active
+        ? 'bg-white text-brand-blue-dark shadow-sm'
+        : 'text-slate-500 hover:text-slate-700'
+    } ${disabled ? 'opacity-50 cursor-not-allowed' : ''}`}
+  >
+    {label}
+  </button>
+);
+
+interface PickerListProps {
+  source: AssignClassSource;
+  classLinkClasses: ClassLinkClass[];
+  rosters: ClassRoster[];
+  value: AssignClassPickerValue;
+  onToggleClassId: (id: string) => void;
+  onTogglePeriodName: (name: string) => void;
+}
+
+const PickerList: React.FC<PickerListProps> = ({
+  source,
+  classLinkClasses,
+  rosters,
+  value,
+  onToggleClassId,
+  onTogglePeriodName,
+}) => {
+  if (source === 'classlink') {
+    if (classLinkClasses.length === 0) {
+      return (
+        <EmptyStub message="No ClassLink classes found. Switch to Local rosters or assign with a code/PIN only." />
+      );
+    }
+    return (
+      <CheckList>
+        {classLinkClasses.map((cls) => (
+          <CheckItem
+            key={cls.sourcedId}
+            checked={value.classIds.includes(cls.sourcedId)}
+            label={formatClassLinkClassLabel(cls)}
+            onToggle={() => onToggleClassId(cls.sourcedId)}
+          />
+        ))}
+      </CheckList>
+    );
+  }
+
+  // source === 'local'
+  if (rosters.length === 0) {
+    return (
+      <EmptyStub message="No local rosters. Import a roster from the Classes panel, or assign with a code/PIN only." />
+    );
+  }
+  return (
+    <CheckList>
+      {rosters.map((r) => (
+        <CheckItem
+          key={r.id}
+          checked={value.periodNames.includes(r.name)}
+          label={r.name}
+          onToggle={() => onTogglePeriodName(r.name)}
+        />
+      ))}
+    </CheckList>
+  );
+};
+
+const CheckList: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+  <div className="space-y-1 max-h-40 overflow-y-auto rounded-lg border border-slate-200 bg-white p-2">
+    {children}
+  </div>
+);
+
+const CheckItem: React.FC<{
+  checked: boolean;
+  label: string;
+  onToggle: () => void;
+}> = ({ checked, label, onToggle }) => (
+  <label className="flex items-center gap-2 cursor-pointer hover:bg-slate-50 rounded px-1.5 py-1">
+    <span
+      aria-hidden="true"
+      className={`flex items-center justify-center w-4 h-4 rounded border transition-colors ${
+        checked
+          ? 'bg-brand-blue-primary border-brand-blue-primary text-white'
+          : 'bg-white border-slate-300'
+      }`}
+    >
+      {checked && <Check className="w-3 h-3" strokeWidth={3} />}
+    </span>
+    <input
+      type="checkbox"
+      className="sr-only"
+      checked={checked}
+      onChange={onToggle}
+    />
+    <span className="text-sm text-slate-800">{label}</span>
+  </label>
+);
+
+const EmptyStub: React.FC<{ message: string }> = ({ message }) => (
+  <p className="text-xxs text-slate-500 rounded-lg border border-dashed border-slate-200 bg-slate-50 px-3 py-2">
+    {message}
+  </p>
+);

--- a/components/common/AssignClassPicker.tsx
+++ b/components/common/AssignClassPicker.tsx
@@ -88,11 +88,13 @@ export const AssignClassPicker: React.FC<AssignClassPickerProps> = ({
         ...value,
         source: 'classlink',
         classIds: classLinkClasses.map((c) => c.sourcedId),
+        periodNames: [],
       });
     } else {
       onChange({
         ...value,
         source: 'local',
+        classIds: [],
         periodNames: rosters.map((r) => r.name),
       });
     }

--- a/components/common/AssignClassPicker.tsx
+++ b/components/common/AssignClassPicker.tsx
@@ -57,14 +57,29 @@ export const AssignClassPicker: React.FC<AssignClassPickerProps> = ({
     const next = value.classIds.includes(id)
       ? value.classIds.filter((x) => x !== id)
       : [...value.classIds, id];
-    onChange({ ...value, classIds: next });
+    // Always pin `source` to the list being mutated. Without this, callers
+    // whose `value.source` is stale (e.g., the default `'classlink'` seeded
+    // via `makeEmptyPickerValue` even when only local rosters are available)
+    // would see a mismatched `source` vs. populated list and silently drop
+    // the selection in downstream `source === 'classlink'` branches.
+    onChange({
+      ...value,
+      source: 'classlink',
+      classIds: next,
+      periodNames: [],
+    });
   };
 
   const togglePeriodName = (name: string): void => {
     const next = value.periodNames.includes(name)
       ? value.periodNames.filter((x) => x !== name)
       : [...value.periodNames, name];
-    onChange({ ...value, periodNames: next });
+    onChange({
+      ...value,
+      source: 'local',
+      classIds: [],
+      periodNames: next,
+    });
   };
 
   const selectAll = (): void => {

--- a/components/guidedLearning/GuidedLearningStudentApp.tsx
+++ b/components/guidedLearning/GuidedLearningStudentApp.tsx
@@ -13,7 +13,9 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { signInAnonymously } from 'firebase/auth';
 import {
+  ArrowRight,
   BookOpen,
+  ClipboardList,
   Loader2,
   AlertCircle,
   CheckCircle2,
@@ -94,6 +96,10 @@ const StudentExperience: React.FC<{ anonymousUid: string }> = ({
   const [completed, setCompleted] = useState(false);
   const [score, setScore] = useState<number | null>(null);
   const [answers, setAnswers] = useState<GuidedLearningResponse['answers']>([]);
+  // Phase 5A: post-PIN class-period picker. When the session has multiple
+  // periods configured, the student chooses one before the experience
+  // begins; the value is persisted on their response doc.
+  const [classPeriod, setClassPeriod] = useState<string | null>(null);
   const startedAt = React.useRef<number>(0);
   useEffect(() => {
     if (startedAt.current === 0) {
@@ -132,12 +138,21 @@ const StudentExperience: React.FC<{ anonymousUid: string }> = ({
       startedAt: startedAt.current,
       completedAt: Date.now(),
       score: computedScore,
+      ...(classPeriod ? { classPeriod } : {}),
     };
 
     await submitResponse(response).catch((err) => {
       console.error('[GuidedLearningStudentApp] Submit error:', err);
     });
-  }, [session, answers, pin, anonymousUid, sessionId, submitResponse]);
+  }, [
+    session,
+    answers,
+    pin,
+    anonymousUid,
+    sessionId,
+    submitResponse,
+    classPeriod,
+  ]);
 
   if (loading) return <FullPageLoader />;
   if (error) return <ErrorScreen message={error} />;
@@ -153,7 +168,17 @@ const StudentExperience: React.FC<{ anonymousUid: string }> = ({
         session={session}
         pin={pin}
         onPinChange={setPin}
-        onStart={() => setStarted(true)}
+        selectedPeriod={classPeriod}
+        onPeriodChange={setClassPeriod}
+        onStart={() => {
+          // Auto-select the single period if there's exactly one so the
+          // response still gets tagged consistently.
+          const periods = session.periodNames ?? [];
+          if (periods.length === 1 && !classPeriod) {
+            setClassPeriod(periods[0]);
+          }
+          setStarted(true);
+        }}
       />
     );
   }
@@ -199,39 +224,101 @@ const StartScreen: React.FC<{
   session: GuidedLearningSession;
   pin: string;
   onPinChange: (v: string) => void;
+  selectedPeriod: string | null;
+  onPeriodChange: (v: string | null) => void;
   onStart: () => void;
-}> = ({ session, pin, onPinChange, onStart }) => (
-  <div className="min-h-screen bg-slate-950 flex items-center justify-center p-6">
-    <div className="bg-slate-900 border border-white/10 rounded-2xl p-8 max-w-sm w-full text-center shadow-2xl">
-      <BookOpen className="w-10 h-10 text-indigo-400 mx-auto mb-3" />
-      <h1 className="text-white font-bold text-xl mb-1">{session.title}</h1>
-      <p className="text-slate-400 text-sm mb-6 capitalize">
-        {session.mode} mode · {session.publicSteps.length} steps
-      </p>
+}> = ({
+  session,
+  pin,
+  onPinChange,
+  selectedPeriod,
+  onPeriodChange,
+  onStart,
+}) => {
+  const periods = session.periodNames ?? [];
+  const needsPeriodPicker = periods.length > 1 && !selectedPeriod;
 
-      <div className="mb-6">
-        <label className="block text-slate-400 text-xs mb-1.5 text-left">
-          Your PIN <span className="text-slate-600">(optional)</span>
-        </label>
-        <input
-          type="text"
-          value={pin}
-          onChange={(e) => onPinChange(e.target.value)}
-          placeholder="Enter your class PIN"
-          className="w-full bg-slate-800 border border-slate-600 rounded-xl px-4 py-2.5 text-white text-sm text-center tracking-widest"
-          maxLength={10}
-        />
+  if (needsPeriodPicker) {
+    return (
+      <div className="min-h-screen bg-slate-950 flex items-center justify-center p-6">
+        <div className="bg-slate-900 border border-white/10 rounded-2xl p-8 max-w-sm w-full text-center shadow-2xl">
+          <ClipboardList className="w-8 h-8 text-indigo-400 mx-auto mb-3" />
+          <h1 className="text-white font-bold text-xl mb-1">
+            Select Your Class
+          </h1>
+          <p className="text-slate-400 text-sm mb-5">
+            Which class period are you in?
+          </p>
+          <div className="space-y-2 mb-5 text-left">
+            {periods.map((p) => (
+              <button
+                key={p}
+                onClick={() => onPeriodChange(p)}
+                className="w-full px-4 py-3 rounded-xl text-base font-bold transition-all bg-slate-800 border border-slate-700 text-slate-200 hover:bg-slate-700"
+              >
+                {p}
+              </button>
+            ))}
+          </div>
+          <p className="text-xxs text-slate-500">
+            Pick one to continue. You can enter your PIN after this step.
+          </p>
+        </div>
       </div>
+    );
+  }
 
-      <button
-        onClick={onStart}
-        className="w-full py-3 bg-indigo-600 hover:bg-indigo-500 text-white font-semibold rounded-xl transition-colors"
-      >
-        Start
-      </button>
+  return (
+    <div className="min-h-screen bg-slate-950 flex items-center justify-center p-6">
+      <div className="bg-slate-900 border border-white/10 rounded-2xl p-8 max-w-sm w-full text-center shadow-2xl">
+        <BookOpen className="w-10 h-10 text-indigo-400 mx-auto mb-3" />
+        <h1 className="text-white font-bold text-xl mb-1">{session.title}</h1>
+        <p className="text-slate-400 text-sm mb-6 capitalize">
+          {session.mode} mode · {session.publicSteps.length} steps
+        </p>
+
+        {selectedPeriod && periods.length > 1 && (
+          <div className="mb-4 flex items-center justify-between rounded-lg border border-slate-700 bg-slate-800/60 px-3 py-2">
+            <span className="text-xs text-slate-400">Class</span>
+            <div className="flex items-center gap-2">
+              <span className="text-sm font-bold text-white">
+                {selectedPeriod}
+              </span>
+              <button
+                onClick={() => onPeriodChange(null)}
+                className="text-xxs text-slate-500 hover:text-slate-300"
+              >
+                Change
+              </button>
+            </div>
+          </div>
+        )}
+
+        <div className="mb-6">
+          <label className="block text-slate-400 text-xs mb-1.5 text-left">
+            Your PIN <span className="text-slate-600">(optional)</span>
+          </label>
+          <input
+            type="text"
+            value={pin}
+            onChange={(e) => onPinChange(e.target.value)}
+            placeholder="Enter your class PIN"
+            className="w-full bg-slate-800 border border-slate-600 rounded-xl px-4 py-2.5 text-white text-sm text-center tracking-widest"
+            maxLength={10}
+          />
+        </div>
+
+        <button
+          onClick={onStart}
+          className="w-full py-3 bg-indigo-600 hover:bg-indigo-500 text-white font-semibold rounded-xl transition-colors flex items-center justify-center gap-2"
+        >
+          Start
+          <ArrowRight className="w-4 h-4" />
+        </button>
+      </div>
     </div>
-  </div>
-);
+  );
+};
 
 const CompletionScreen: React.FC<{
   session: GuidedLearningSession;

--- a/components/student/MyAssignmentsPage.tsx
+++ b/components/student/MyAssignmentsPage.tsx
@@ -1,10 +1,4 @@
-import React, {
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   collection,
   doc,
@@ -12,6 +6,7 @@ import {
   onSnapshot,
   query,
   where,
+  type Query,
   type QuerySnapshot,
   type DocumentData,
 } from 'firebase/firestore';
@@ -38,8 +33,16 @@ import { useStudentAuth } from '@/context/useStudentAuth';
  *
  * Landing page for a signed-in student. Subscribes to the five session
  * collections (`quiz_sessions`, `video_activity_sessions`,
- * `guided_learning_sessions`, `mini_app_sessions`, `activity_wall_sessions`),
- * filtered by `classId in classIds`, and renders the union as a single list.
+ * `guided_learning_sessions`, `mini_app_sessions`, `activity_wall_sessions`)
+ * and renders the union as a single list.
+ *
+ * Query strategy: quiz / video-activity / guided-learning subscribe to TWO
+ * queries each — one on the Phase 5A `classIds` array (array-contains-any)
+ * and one on the legacy `classId` string (in) — merging by sessionId so
+ * students in *any* class targeted by a multi-class assignment are covered
+ * while legacy single-class sessions still surface. Mini-app is list-only
+ * (its sessions have always been multi-class) and activity-wall is
+ * single-only (has not been migrated to multi-class yet).
  *
  * PII-free: reads only session-level fields (title, status, code, classId).
  * Never reads, logs, or persists email / displayName / sub. The only
@@ -86,14 +89,29 @@ type LoadState = 'loading' | 'ready';
 
 interface KindConfig {
   collectionName: string;
-  /** Firestore status filter, or `null` when the collection has no status field. */
-  statusFilter: { field: 'status'; value: 'active' } | null;
   /**
-   * How this collection stores its class targeting:
+   * When true, subscribe to TWO queries per kind and merge results by
+   * `sessionId` (de-duping any overlap):
+   *   - `list`   — `where('classIds', 'array-contains-any', classIds)` — Phase 5A multi-class
+   *   - `single` — `where('classId', 'in', classIds)`                   — legacy single-class
+   * This is required for quiz/video-activity/guided-learning so that
+   * multi-class assignments (Phase 5A) are discovered for students in
+   * *any* targeted class — not just `classIds[0]` — while legacy
+   * single-class sessions (with no `classIds` array) still surface.
+   *
+   * When false, a single query is issued using `classFilterShape`.
+   */
+  dualQuery: boolean;
+  /** Firestore status filter, or `null` when the collection has no status field. */
+  statusFilter:
+    | { field: 'status'; value: 'active' }
+    | { field: 'status'; valueIn: readonly string[] }
+    | null;
+  /**
+   * Shape used when `dualQuery` is false. Describes how this collection
+   * stores its class targeting:
    *   - `single` — a string `classId` field (queried with `where(..., 'in', classIds)`)
    *   - `list`   — an array `classIds` field (queried with `where(..., 'array-contains-any', classIds)`)
-   * Mini-app sessions are `list` (multi-class targeting); every other kind
-   * is still single-class.
    */
   classFilterShape: 'single' | 'list';
   /** Subcollection where per-student response/submission docs live; null when absent. */
@@ -133,7 +151,11 @@ interface KindConfig {
 const KIND_CONFIG: Record<SessionKind, KindConfig> = {
   quiz: {
     collectionName: 'quiz_sessions',
-    statusFilter: { field: 'status', value: 'active' },
+    dualQuery: true,
+    // Include `waiting` so teacher-paced quizzes (which sit in 'waiting'
+    // after Play but before the teacher advances to Q1) surface on
+    // `/my-assignments` — matching the PIN-flow experience.
+    statusFilter: { field: 'status', valueIn: ['waiting', 'active'] },
     classFilterShape: 'single',
     responseSubcollection: 'responses',
     label: 'Quiz',
@@ -156,6 +178,7 @@ const KIND_CONFIG: Record<SessionKind, KindConfig> = {
   },
   'video-activity': {
     collectionName: 'video_activity_sessions',
+    dualQuery: true,
     statusFilter: { field: 'status', value: 'active' },
     classFilterShape: 'single',
     responseSubcollection: 'responses',
@@ -179,6 +202,7 @@ const KIND_CONFIG: Record<SessionKind, KindConfig> = {
   },
   'guided-learning': {
     collectionName: 'guided_learning_sessions',
+    dualQuery: true,
     statusFilter: null, // No status field; session presence = live.
     classFilterShape: 'single',
     responseSubcollection: 'responses',
@@ -194,6 +218,7 @@ const KIND_CONFIG: Record<SessionKind, KindConfig> = {
   },
   'mini-app': {
     collectionName: 'mini_app_sessions',
+    dualQuery: false,
     statusFilter: { field: 'status', value: 'active' },
     classFilterShape: 'list',
     responseSubcollection: 'submissions',
@@ -214,6 +239,7 @@ const KIND_CONFIG: Record<SessionKind, KindConfig> = {
   },
   'activity-wall': {
     collectionName: 'activity_wall_sessions',
+    dualQuery: false,
     statusFilter: null, // No status field on the session doc.
     classFilterShape: 'single',
     // ActivityWall submissions are a LIST per student (students can post
@@ -260,10 +286,6 @@ const MyAssignmentsPage: React.FC = () => {
   );
   const [loadState, setLoadState] = useState<LoadState>('loading');
 
-  // Track which kinds have delivered their first snapshot so we can flip
-  // from `loading` -> `ready` only once every subscription has settled.
-  const settledKindsRef = useRef<Set<SessionKind>>(new Set());
-
   // Stable subscription identity: we only re-subscribe when classIds actually
   // changes, not on every render.
   const classIdsKey = useMemo(
@@ -280,76 +302,148 @@ const MyAssignmentsPage: React.FC = () => {
     }
 
     setLoadState('loading');
-    settledKindsRef.current = new Set();
 
-    const unsubs: Array<() => void> = [];
+    type QueryShape = 'list' | 'single';
+    const bucketKey = (kind: SessionKind, shape: QueryShape) =>
+      `${kind}:${shape}`;
 
-    const handleSnapshot = (
-      kind: SessionKind,
-      snap: QuerySnapshot<DocumentData>
-    ) => {
+    // Plan every (kind, shape) subscription up front so we know the total
+    // count and can flip to `ready` exactly when every subscription has
+    // delivered its first snapshot (success OR error).
+    const subs: Array<{ kind: SessionKind; shape: QueryShape }> = [];
+    for (const kind of SESSION_KINDS) {
       const config = KIND_CONFIG[kind];
-      const items: AssignmentSummary[] = snap.docs.map((d) => {
-        const data = d.data();
-        const createdAtRaw: unknown = (data as Record<string, unknown>)
-          .createdAt;
-        return {
-          compositeId: `${kind}:${d.id}`,
-          kind,
-          sessionId: d.id,
-          title: config.titleFrom(data),
-          openHref: config.hrefFrom(d.id, data),
-          createdAt:
-            typeof createdAtRaw === 'number' ? createdAtRaw : undefined,
-        };
-      });
+      if (config.dualQuery) {
+        subs.push({ kind, shape: 'list' }, { kind, shape: 'single' });
+      } else {
+        subs.push({ kind, shape: config.classFilterShape });
+      }
+    }
+    const totalSubscriptions = subs.length;
 
-      setByKind((prev) => ({ ...prev, [kind]: items }));
-      settledKindsRef.current.add(kind);
-      if (settledKindsRef.current.size === SESSION_KINDS.length) {
+    // Per-(kind, shape) result buckets. When a kind has two subscriptions
+    // we merge both buckets by `sessionId` before emitting `byKind`, so a
+    // Phase 5A session whose `classIds[0]` equals one of the student's
+    // classIds (and therefore matches BOTH queries) is counted exactly
+    // once.
+    const buckets = new Map<string, AssignmentSummary[]>();
+    const settled = new Set<string>();
+
+    const docToSummary = (
+      kind: SessionKind,
+      config: KindConfig,
+      d: QuerySnapshot<DocumentData>['docs'][number]
+    ): AssignmentSummary => {
+      const data = d.data();
+      const createdAtRaw: unknown = (data as Record<string, unknown>).createdAt;
+      return {
+        compositeId: `${kind}:${d.id}`,
+        kind,
+        sessionId: d.id,
+        title: config.titleFrom(data),
+        openHref: config.hrefFrom(d.id, data),
+        createdAt: typeof createdAtRaw === 'number' ? createdAtRaw : undefined,
+      };
+    };
+
+    const emitMerged = (kind: SessionKind) => {
+      const listBucket = buckets.get(bucketKey(kind, 'list')) ?? [];
+      const singleBucket = buckets.get(bucketKey(kind, 'single')) ?? [];
+      if (listBucket.length === 0 && singleBucket.length === 0) {
+        setByKind((prev) =>
+          prev[kind] && prev[kind].length === 0 ? prev : { ...prev, [kind]: [] }
+        );
+        return;
+      }
+      const merged = new Map<string, AssignmentSummary>();
+      for (const a of listBucket) merged.set(a.sessionId, a);
+      for (const a of singleBucket) merged.set(a.sessionId, a);
+      setByKind((prev) => ({ ...prev, [kind]: Array.from(merged.values()) }));
+    };
+
+    const markSettled = (kind: SessionKind, shape: QueryShape) => {
+      settled.add(bucketKey(kind, shape));
+      if (settled.size === totalSubscriptions) {
         setLoadState('ready');
       }
     };
 
-    const handleError = (kind: SessionKind, err: unknown) => {
-      // PII safety: never log the error message or data — it may contain
-      // diagnostic data derived from the query. Log only the collection
-      // name and Firestore error code.
+    const handleSnapshot = (
+      kind: SessionKind,
+      shape: QueryShape,
+      snap: QuerySnapshot<DocumentData>
+    ) => {
+      const config = KIND_CONFIG[kind];
+      buckets.set(
+        bucketKey(kind, shape),
+        snap.docs.map((d) => docToSummary(kind, config, d))
+      );
+      emitMerged(kind);
+      markSettled(kind, shape);
+    };
+
+    const handleError = (
+      kind: SessionKind,
+      shape: QueryShape,
+      err: unknown
+    ) => {
       const code =
         err && typeof err === 'object' && 'code' in err
           ? String((err as { code?: unknown }).code)
           : 'unknown';
-      console.warn(
-        `[MyAssignments] snapshot failed for ${KIND_CONFIG[kind].collectionName}:`,
-        code
+      // Firestore missing-index errors embed a one-click index-creation
+      // URL in `err.message` — invaluable the next time something silently
+      // empties the list. Messages from Firestore do not include any of
+      // the classId values passed into the query, so this remains PII-safe.
+      const message =
+        err && typeof err === 'object' && 'message' in err
+          ? String((err as { message?: unknown }).message)
+          : '';
+      console.error(
+        `[MyAssignments] snapshot failed for ${KIND_CONFIG[kind].collectionName} (${shape}) [${code}]:`,
+        message
       );
-      // Mark as settled with an empty list so loading state can progress.
-      setByKind((prev) => ({ ...prev, [kind]: [] }));
-      settledKindsRef.current.add(kind);
-      if (settledKindsRef.current.size === SESSION_KINDS.length) {
-        setLoadState('ready');
-      }
+      buckets.set(bucketKey(kind, shape), []);
+      emitMerged(kind);
+      markSettled(kind, shape);
     };
 
-    for (const kind of SESSION_KINDS) {
-      const config = KIND_CONFIG[kind];
+    const buildQuery = (
+      config: KindConfig,
+      shape: QueryShape
+    ): Query<DocumentData> => {
       const col = collection(db, config.collectionName);
       const constraints =
-        config.classFilterShape === 'list'
+        shape === 'list'
           ? [where('classIds', 'array-contains-any', classIds)]
           : [where('classId', 'in', classIds)];
       if (config.statusFilter) {
-        constraints.push(
-          where(config.statusFilter.field, '==', config.statusFilter.value)
-        );
+        if ('valueIn' in config.statusFilter) {
+          constraints.push(
+            where(config.statusFilter.field, 'in', [
+              ...config.statusFilter.valueIn,
+            ])
+          );
+        } else {
+          constraints.push(
+            where(config.statusFilter.field, '==', config.statusFilter.value)
+          );
+        }
       }
-      const q = query(col, ...constraints);
-      const unsub = onSnapshot(
-        q,
-        (snap) => handleSnapshot(kind, snap),
-        (err) => handleError(kind, err)
+      return query(col, ...constraints);
+    };
+
+    const unsubs: Array<() => void> = [];
+    for (const { kind, shape } of subs) {
+      const config = KIND_CONFIG[kind];
+      const q = buildQuery(config, shape);
+      unsubs.push(
+        onSnapshot(
+          q,
+          (snap) => handleSnapshot(kind, shape, snap),
+          (err) => handleError(kind, shape, err)
+        )
       );
-      unsubs.push(unsub);
     }
 
     return () => {

--- a/components/videoActivity/VideoActivityStudentApp.tsx
+++ b/components/videoActivity/VideoActivityStudentApp.tsx
@@ -15,7 +15,9 @@ import {
   PlayCircle,
   Loader2,
   AlertCircle,
+  ArrowRight,
   CheckCircle2,
+  ClipboardList,
   Trophy,
 } from 'lucide-react';
 import { auth } from '@/config/firebase';
@@ -79,10 +81,17 @@ const JoinAndPlay: React.FC = () => {
     myResponse,
     joinStatus,
     error,
+    lookupSession,
     joinSession,
     submitAnswer,
     completeActivity,
   } = useVideoActivitySessionStudent();
+
+  // Multi-period selection step — shown when the session has more than one
+  // class-period name configured, so students pick their period before the
+  // response doc is created (mirrors the Quiz pattern).
+  const [periodStep, setPeriodStep] = useState<string[] | null>(null);
+  const [selectedPeriod, setSelectedPeriod] = useState<string | null>(null);
 
   // Track answered question IDs for anti-skip enforcement in VideoPlayer
   const answeredQuestionIds = React.useMemo(
@@ -96,8 +105,20 @@ const JoinAndPlay: React.FC = () => {
   const handleJoin = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!name.trim() || !pin.trim() || !sessionId) return;
-    await joinSession(sessionId, pin.trim(), name.trim());
+    const sessionInfo = await lookupSession(sessionId);
+    const periodNames = sessionInfo?.periodNames ?? [];
+    if (periodNames.length > 1) {
+      setPeriodStep(periodNames);
+      return;
+    }
+    const autoClassPeriod = periodNames[0];
+    await joinSession(sessionId, pin.trim(), name.trim(), autoClassPeriod);
   };
+
+  const handlePeriodConfirm = useCallback(async () => {
+    if (!selectedPeriod || !sessionId) return;
+    await joinSession(sessionId, pin.trim(), name.trim(), selectedPeriod);
+  }, [joinSession, sessionId, pin, name, selectedPeriod]);
 
   const handleQuestionTrigger = useCallback(
     (question: VideoActivityQuestion) => {
@@ -148,6 +169,77 @@ const JoinAndPlay: React.FC = () => {
   if (!sessionId || sessionId.includes('/')) {
     return (
       <ErrorScreen message="Invalid activity link. Please ask your teacher for the correct URL." />
+    );
+  }
+
+  // ── Period selection step (multi-period sessions) ────────────────────────
+
+  if (periodStep && joinStatus !== 'joined') {
+    return (
+      <div className="min-h-screen bg-slate-900 flex flex-col items-center justify-center p-6">
+        <div className="w-full max-w-sm">
+          <div className="flex items-center justify-center mb-8">
+            <ClipboardList className="w-5 h-5 text-brand-blue-primary mr-2" />
+            <span className="text-sm text-slate-300 font-semibold">
+              Video Activity
+            </span>
+          </div>
+
+          <h1 className="text-2xl font-black text-white mb-2 text-center">
+            Select Your Class
+          </h1>
+          <p className="text-slate-400 text-sm text-center mb-6">
+            Which class period are you in?
+          </p>
+
+          {error && (
+            <div className="mb-4 p-3 bg-red-500/20 border border-red-500/40 rounded-xl text-red-300 text-sm flex items-center gap-2">
+              <AlertCircle className="w-4 h-4 shrink-0" />
+              {error}
+            </div>
+          )}
+
+          <div className="space-y-2 mb-6">
+            {periodStep.map((period) => (
+              <button
+                key={period}
+                onClick={() => setSelectedPeriod(period)}
+                className={`w-full px-4 py-4 rounded-xl text-lg font-bold transition-all ${
+                  selectedPeriod === period
+                    ? 'bg-brand-blue-primary text-white ring-2 ring-brand-blue-light'
+                    : 'bg-slate-800 border border-slate-700 text-slate-300 hover:bg-slate-700'
+                }`}
+              >
+                {period}
+              </button>
+            ))}
+          </div>
+
+          <button
+            onClick={() => void handlePeriodConfirm()}
+            disabled={joinStatus === 'loading' || !selectedPeriod}
+            className="w-full py-4 bg-brand-blue-primary hover:bg-brand-blue-dark disabled:opacity-50 text-white font-bold text-lg rounded-xl flex items-center justify-center gap-2 transition-colors"
+          >
+            {joinStatus === 'loading' ? (
+              <Loader2 className="w-5 h-5 animate-spin" />
+            ) : (
+              <>
+                Continue <ArrowRight className="w-5 h-5" />
+              </>
+            )}
+          </button>
+
+          <button
+            onClick={() => {
+              setPeriodStep(null);
+              setSelectedPeriod(null);
+            }}
+            className="w-full mt-3 py-2 text-slate-500 hover:text-slate-300 text-sm font-medium transition-colors"
+          >
+            Go Back
+          </button>
+        </div>
+      </div>
     );
   }
 

--- a/components/videoActivity/VideoActivityStudentApp.tsx
+++ b/components/videoActivity/VideoActivityStudentApp.tsx
@@ -92,6 +92,11 @@ const JoinAndPlay: React.FC = () => {
   // response doc is created (mirrors the Quiz pattern).
   const [periodStep, setPeriodStep] = useState<string[] | null>(null);
   const [selectedPeriod, setSelectedPeriod] = useState<string | null>(null);
+  // Local guard for the async `lookupSession` leg of `handleJoin` — the
+  // hook's `joinStatus` only flips to `loading` once `joinSession` starts,
+  // so without this the button would stay clickable during the lookup and
+  // a double-tap could fan out parallel requests.
+  const [lookingUp, setLookingUp] = useState(false);
 
   // Track answered question IDs for anti-skip enforcement in VideoPlayer
   const answeredQuestionIds = React.useMemo(
@@ -105,14 +110,20 @@ const JoinAndPlay: React.FC = () => {
   const handleJoin = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!name.trim() || !pin.trim() || !sessionId) return;
-    const sessionInfo = await lookupSession(sessionId);
-    const periodNames = sessionInfo?.periodNames ?? [];
-    if (periodNames.length > 1) {
-      setPeriodStep(periodNames);
-      return;
+    if (lookingUp || joinStatus === 'loading') return;
+    setLookingUp(true);
+    try {
+      const sessionInfo = await lookupSession(sessionId);
+      const periodNames = sessionInfo?.periodNames ?? [];
+      if (periodNames.length > 1) {
+        setPeriodStep(periodNames);
+        return;
+      }
+      const autoClassPeriod = periodNames[0];
+      await joinSession(sessionId, pin.trim(), name.trim(), autoClassPeriod);
+    } finally {
+      setLookingUp(false);
     }
-    const autoClassPeriod = periodNames[0];
-    await joinSession(sessionId, pin.trim(), name.trim(), autoClassPeriod);
   };
 
   const handlePeriodConfirm = useCallback(async () => {
@@ -312,11 +323,14 @@ const JoinAndPlay: React.FC = () => {
               <button
                 type="submit"
                 disabled={
-                  joinStatus === 'loading' || !name.trim() || !pin.trim()
+                  joinStatus === 'loading' ||
+                  lookingUp ||
+                  !name.trim() ||
+                  !pin.trim()
                 }
                 className="w-full bg-brand-blue-primary hover:bg-brand-blue-dark disabled:bg-slate-200 disabled:text-slate-400 text-white font-bold rounded-xl py-3 text-sm transition-all active:scale-95 flex items-center justify-center gap-2"
               >
-                {joinStatus === 'loading' ? (
+                {joinStatus === 'loading' || lookingUp ? (
                   <>
                     <Loader2 className="w-4 h-4 animate-spin" />
                     Joining…

--- a/components/widgets/GuidedLearning/Widget.tsx
+++ b/components/widgets/GuidedLearning/Widget.tsx
@@ -18,11 +18,17 @@ import { useFolders } from '@/hooks/useFolders';
 import { classLinkService } from '@/utils/classlinkService';
 import { WidgetLayout } from '@/components/widgets/WidgetLayout';
 import { AssignModal } from '@/components/common/library';
+import { AssignClassPicker } from '@/components/common/AssignClassPicker';
+import {
+  formatClassLinkClassLabel,
+  makeEmptyPickerValue,
+  type AssignClassPickerValue,
+} from '@/components/common/AssignClassPicker.helpers';
 import { GuidedLearningManager } from './components/GuidedLearningManager';
 import { GuidedLearningEditorModal } from './components/GuidedLearningEditorModal';
 import { GuidedLearningPlayer } from './components/GuidedLearningPlayer';
 import { GuidedLearningResults } from './components/GuidedLearningResults';
-import { Loader2, Users } from 'lucide-react';
+import { Loader2 } from 'lucide-react';
 
 // ─── AI generation modal (admin only) ────────────────────────────────────────
 import { GuidedLearningAIGenerator } from './components/GuidedLearningAIGenerator';
@@ -45,7 +51,7 @@ interface AssignDialogTarget {
 export const GuidedLearningWidget: React.FC<{ widget: WidgetData }> = ({
   widget,
 }) => {
-  const { updateWidget, addToast } = useDashboard();
+  const { updateWidget, addToast, rosters } = useDashboard();
   const { user, isAdmin } = useAuth();
   const rawConfig = widget.config as GuidedLearningConfig;
   // Normalize legacy 'editor' view — the inline editor is removed; use the modal instead
@@ -126,29 +132,37 @@ export const GuidedLearningWidget: React.FC<{ widget: WidgetData }> = ({
     };
   }, []);
 
-  // ─── Assign dialog state (Phase 3C) ─────────────────────────────────────────
-  // When a teacher clicks "Assign" and a ClassLink-provisioned org is in
-  // play, we pause to let them optionally pick a target class before
-  // actually creating the session. `assignTarget` holds the already-loaded
-  // set along with the source hint so we can create the assignment doc
-  // after confirmation.
+  // ─── Assign dialog state (Phase 3C, Phase 5A multi-class) ─────────────────
+  // When a teacher clicks "Assign", we pause to let them optionally pick
+  // target classes (ClassLink) or period rosters (local) before actually
+  // creating the session. `assignTarget` holds the already-loaded set along
+  // with the source hint so we can create the assignment doc after
+  // confirmation.
   const [assignTarget, setAssignTarget] = useState<AssignDialogTarget | null>(
     null
   );
-  const [assignOptions, setAssignOptions] = useState<{ classId: string }>({
-    classId: '',
-  });
+  const [pickerValue, setPickerValue] = useState<AssignClassPickerValue>(() =>
+    makeEmptyPickerValue('classlink')
+  );
 
-  // Reset the pending classId when the dialog re-opens for a different set
+  // Reset the picker when the dialog re-opens for a different set
   // (adjust-state-while-rendering pattern — no effect needed).
   const [prevAssignTarget, setPrevAssignTarget] =
     useState<AssignDialogTarget | null>(null);
   if (assignTarget !== prevAssignTarget) {
     setPrevAssignTarget(assignTarget);
     if (assignTarget) {
-      setAssignOptions({
-        classId: config.lastClassIdBySetId?.[assignTarget.originSetId] ?? '',
-      });
+      const rememberedMulti =
+        config.lastClassIdsBySetId?.[assignTarget.originSetId];
+      const rememberedSingle =
+        config.lastClassIdBySetId?.[assignTarget.originSetId];
+      const classIds =
+        rememberedMulti ?? (rememberedSingle ? [rememberedSingle] : []);
+      setPickerValue(
+        classIds.length > 0
+          ? { source: 'classlink', classIds, periodNames: [] }
+          : makeEmptyPickerValue('classlink')
+      );
     }
   }
 
@@ -247,18 +261,20 @@ export const GuidedLearningWidget: React.FC<{ widget: WidgetData }> = ({
   };
 
   // Actually create the session + matching assignment doc. Shared between
-  // the classic direct-assign path (no ClassLink org) and the target-class
-  // dialog confirm path. `classId` is the ClassLink class sourcedId, or
-  // `null` for "No class".
+  // the classic direct-assign path (no ClassLink/rosters) and the picker
+  // dialog confirm path. `classIds` is the selected ClassLink sourcedId
+  // list; `periodNames` is the list of post-PIN period labels (empty when
+  // the teacher targeted nothing).
   const performAssign = useCallback(
     async (
       data: GuidedLearningSet,
       source: 'personal' | 'building',
       originSetId: string,
-      classId: string | null
+      classIds: string[],
+      periodNames: string[]
     ) => {
       try {
-        const url = await createSession(data, classId ?? undefined);
+        const url = await createSession(data, classIds, periodNames);
         const sessionId = url.split('/').pop() ?? '';
         setRecentSessionIds((prev) => ({
           ...prev,
@@ -276,21 +292,23 @@ export const GuidedLearningWidget: React.FC<{ widget: WidgetData }> = ({
             console.warn('[GuidedLearning] Failed to record assignment:', err);
           }
         }
-        // Persist the teacher's last-used classId per set so re-launching
-        // the same set pre-selects the same class. Clearing (picking "No
-        // class") removes the entry rather than writing an empty string to
-        // keep the config map small.
-        const prevMap = config.lastClassIdBySetId ?? {};
-        const nextMap: Record<string, string> = { ...prevMap };
-        if (classId) {
-          nextMap[originSetId] = classId;
+        // Persist the teacher's last-used ClassLink selection per set.
+        const prevMap = config.lastClassIdsBySetId ?? {};
+        const nextMap: Record<string, string[]> = { ...prevMap };
+        if (classIds.length > 0) {
+          nextMap[originSetId] = classIds;
         } else {
           delete nextMap[originSetId];
         }
+        // Drop any legacy single-class entry.
+        const prevLegacyMap = config.lastClassIdBySetId ?? {};
+        const nextLegacyMap: Record<string, string> = { ...prevLegacyMap };
+        delete nextLegacyMap[originSetId];
         updateWidget(widget.id, {
           config: {
             ...config,
-            lastClassIdBySetId: nextMap,
+            lastClassIdsBySetId: nextMap,
+            lastClassIdBySetId: nextLegacyMap,
           } as GuidedLearningConfig,
         });
         await navigator.clipboard.writeText(url);
@@ -314,30 +332,42 @@ export const GuidedLearningWidget: React.FC<{ widget: WidgetData }> = ({
     const source: 'personal' | 'building' = buildingSet
       ? 'building'
       : 'personal';
-    // If the teacher isn't on a ClassLink-provisioned org (or the fetch
-    // failed), skip the dialog entirely and preserve the classic
-    // join-link flow.
-    if (classLinkClasses.length === 0) {
-      await performAssign(data, source, setId, null);
+    // If the teacher has neither ClassLink nor local rosters, skip the
+    // dialog entirely and preserve the classic join-link flow.
+    if (classLinkClasses.length === 0 && rosters.length === 0) {
+      await performAssign(data, source, setId, [], []);
       return;
     }
-    // Otherwise open the dialog so they can optionally pick a target class.
+    // Otherwise open the dialog so they can optionally pick targets.
     setAssignTarget({ set: data, source, originSetId: setId });
   };
 
   const handleAssignConfirm = async (): Promise<void> => {
     if (!assignTarget) return;
-    // Guard: if the teacher somehow picked a classId that's no longer in the
-    // fetched ClassLink list (e.g. rosters changed between fetch and confirm),
-    // fall through to no-class rather than writing a stale id.
-    const selectedClassId =
-      assignOptions.classId &&
-      classLinkClasses.some((c) => c.sourcedId === assignOptions.classId)
-        ? assignOptions.classId
-        : null;
+    // Guard: filter stale sourcedIds that aren't in the latest ClassLink
+    // list. Local roster names fall through unchanged.
+    const validClassIds =
+      pickerValue.source === 'classlink'
+        ? pickerValue.classIds.filter((id) =>
+            classLinkClasses.some((c) => c.sourcedId === id)
+          )
+        : [];
+    const selectedPeriodNames =
+      pickerValue.source === 'classlink'
+        ? validClassIds
+            .map((id) => classLinkClasses.find((c) => c.sourcedId === id))
+            .filter((cls): cls is ClassLinkClass => Boolean(cls))
+            .map(formatClassLinkClassLabel)
+        : pickerValue.periodNames;
     const { set, source, originSetId } = assignTarget;
     setAssignTarget(null);
-    await performAssign(set, source, originSetId, selectedClassId);
+    await performAssign(
+      set,
+      source,
+      originSetId,
+      validClassIds,
+      selectedPeriodNames
+    );
   };
 
   const handleViewResultsForRecent = async (sessionId: string) => {
@@ -628,17 +658,18 @@ export const GuidedLearningWidget: React.FC<{ widget: WidgetData }> = ({
       />
 
       {assignTarget && (
-        <AssignModal<{ classId: string }>
+        <AssignModal<AssignClassPickerValue>
           isOpen={!!assignTarget}
           onClose={() => setAssignTarget(null)}
           itemTitle={assignTarget.set.title || 'Untitled set'}
-          options={assignOptions}
-          onOptionsChange={setAssignOptions}
+          options={pickerValue}
+          onOptionsChange={setPickerValue}
           extraSlot={
-            <GuidedLearningAssignTargetClassRow
-              classes={classLinkClasses}
-              value={assignOptions.classId}
-              onChange={(v) => setAssignOptions({ classId: v })}
+            <AssignClassPicker
+              classLinkClasses={classLinkClasses}
+              rosters={rosters}
+              value={pickerValue}
+              onChange={setPickerValue}
             />
           }
           onAssign={() => handleAssignConfirm()}
@@ -646,59 +677,5 @@ export const GuidedLearningWidget: React.FC<{ widget: WidgetData }> = ({
         />
       )}
     </>
-  );
-};
-
-/**
- * Build a human-readable label for a ClassLink class. Mirrors the format
- * used by `ClassLinkImportDialog` and `QuizManager` so teachers see the
- * same class names across flows.
- */
-function formatClassLinkClassLabel(cls: ClassLinkClass): string {
-  const subjectPrefix = cls.subject ? `${cls.subject} - ` : '';
-  const codeSuffix = cls.classCode ? ` (${cls.classCode})` : '';
-  return `${subjectPrefix}${cls.title}${codeSuffix}`;
-}
-
-/**
- * Target-class selector rendered inside the Guided Learning Assign modal's
- * `extraSlot`. Lets the teacher pick an optional ClassLink class to target
- * this set at so that students who signed in via ClassLink see it on their
- * `/my-assignments` page. Phase 3C — fan-out of the Quiz pilot.
- */
-const GuidedLearningAssignTargetClassRow: React.FC<{
-  classes: ClassLinkClass[];
-  value: string;
-  onChange: (next: string) => void;
-}> = ({ classes, value, onChange }) => {
-  return (
-    <div>
-      <div className="flex items-center gap-2 mb-1">
-        <Users className="w-4 h-4 text-brand-blue-primary" />
-        <label
-          htmlFor="gl-assign-target-class"
-          className="text-sm font-bold text-brand-blue-dark"
-        >
-          Target class (optional)
-        </label>
-      </div>
-      <select
-        id="gl-assign-target-class"
-        value={value}
-        onChange={(e) => onChange(e.target.value)}
-        className="w-full px-3 py-2 bg-white border border-slate-200 rounded-lg text-slate-800 text-sm focus:outline-none focus:ring-2 focus:ring-brand-blue-primary"
-      >
-        <option value="">No class (use join code)</option>
-        {classes.map((cls) => (
-          <option key={cls.sourcedId} value={cls.sourcedId}>
-            {formatClassLinkClassLabel(cls)}
-          </option>
-        ))}
-      </select>
-      <p className="text-xxs text-slate-500 mt-1">
-        Students in this class will see this activity in their assignments list.
-        Leave blank to use a join code.
-      </p>
-    </div>
   );
 };

--- a/components/widgets/QuizWidget/Widget.tsx
+++ b/components/widgets/QuizWidget/Widget.tsx
@@ -668,7 +668,7 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
           mode,
           plcOptions: PlcOptions,
           sessionOptions: QuizSessionOptions,
-          classId: string | null
+          classIds: string[]
         ) => {
           const data = await loadQuiz(meta);
           if (!data) return;
@@ -691,19 +691,24 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
                 plcSheetUrl: plcOptions.plcSheetUrl,
               },
               'paused',
-              classId ?? undefined
+              classIds
             );
-            // Persist the teacher's last-used classId per quiz so re-launching
-            // the same quiz pre-selects the same class. Clearing (picking "No
-            // class") removes the entry rather than writing an empty string
-            // to keep the config map small.
-            const prevMap = config.lastClassIdByQuizId ?? {};
-            const nextMap: Record<string, string> = { ...prevMap };
-            if (classId) {
-              nextMap[meta.id] = classId;
+            // Persist the teacher's last-used ClassLink classes per quiz so
+            // re-launching the same quiz pre-selects the same classes.
+            // Clearing removes the entry rather than writing an empty array.
+            const prevMap = config.lastClassIdsByQuizId ?? {};
+            const nextMap: Record<string, string[]> = { ...prevMap };
+            if (classIds.length > 0) {
+              nextMap[meta.id] = classIds;
             } else {
               delete nextMap[meta.id];
             }
+            // Also clear the legacy single-class map entry so the picker
+            // doesn't see a stale single-id override after the teacher
+            // explicitly cleared or changed their selection.
+            const prevLegacyMap = config.lastClassIdByQuizId ?? {};
+            const nextLegacyMap: Record<string, string> = { ...prevLegacyMap };
+            delete nextLegacyMap[meta.id];
             updateWidget(widget.id, {
               config: {
                 ...config,
@@ -718,7 +723,8 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
                   plcOptions.periodNames?.[0] ?? plcOptions.periodName ?? '',
                 periodNames: plcOptions.periodNames ?? [],
                 plcSheetUrl: plcOptions.plcSheetUrl ?? '',
-                lastClassIdByQuizId: nextMap,
+                lastClassIdsByQuizId: nextMap,
+                lastClassIdByQuizId: nextLegacyMap,
               } as QuizConfig,
             });
             const url = `${window.location.origin}/quiz?code=${code}`;

--- a/components/widgets/QuizWidget/components/QuizManager.tsx
+++ b/components/widgets/QuizWidget/components/QuizManager.tsx
@@ -42,7 +42,6 @@ import {
   Loader2,
   AlertCircle,
   CheckSquare,
-  Users,
 } from 'lucide-react';
 import {
   ClassLinkClass,
@@ -55,6 +54,12 @@ import {
 import { classLinkService } from '@/utils/classlinkService';
 import { type QuizSessionOptions } from '@/hooks/useQuizSession';
 import { Toggle } from '@/components/common/Toggle';
+import { AssignClassPicker } from '@/components/common/AssignClassPicker';
+import {
+  formatClassLinkClassLabel,
+  makeEmptyPickerValue,
+  type AssignClassPickerValue,
+} from '@/components/common/AssignClassPicker.helpers';
 import {
   LibraryShell,
   LibraryToolbar,
@@ -105,21 +110,47 @@ interface QuizAssignOptions {
   soundEffectsEnabled: boolean;
   plcMode: boolean;
   teacherName: string;
-  selectedPeriodNames: string[];
   plcSheetUrl: string;
   /**
-   * ClassLink class `sourcedId` this quiz is targeted at, or `''` for the
-   * "No class" option (classic code/PIN-only flow). Written onto the
-   * `quiz_sessions/{sessionId}` document when non-empty so students who
-   * signed in via ClassLink see the session on their /my-assignments page.
+   * Unified class-target picker state (Phase 5A). `classIds` is the list of
+   * ClassLink class `sourcedId`s when source === 'classlink'. `periodNames`
+   * is the list of local roster names when source === 'local'. One of the
+   * two is populated at a time — switching source clears the other.
    */
-  classId: string;
+  picker: AssignClassPickerValue;
+}
+
+/**
+ * Resolve the effective class-period labels for a picker value. When the
+ * teacher picks ClassLink classes, the labels used for the post-PIN period
+ * picker and the PLC Google Sheet export are the ClassLink class titles
+ * themselves; when they pick local rosters, the labels are the roster names.
+ */
+function resolveEffectivePeriodNames(
+  picker: AssignClassPickerValue,
+  classLinkClasses: ClassLinkClass[]
+): string[] {
+  if (picker.source === 'classlink') {
+    return picker.classIds
+      .map((id) => classLinkClasses.find((c) => c.sourcedId === id))
+      .filter((cls): cls is ClassLinkClass => Boolean(cls))
+      .map(formatClassLinkClassLabel);
+  }
+  return picker.periodNames;
 }
 
 function buildDefaultAssignOptions(
   config: QuizConfig,
   quizId?: string
 ): QuizAssignOptions {
+  const rememberedMulti = quizId
+    ? (config.lastClassIdsByQuizId?.[quizId] ?? null)
+    : null;
+  const rememberedSingle = quizId
+    ? (config.lastClassIdByQuizId?.[quizId] ?? null)
+    : null;
+  const classIds =
+    rememberedMulti ?? (rememberedSingle ? [rememberedSingle] : []);
   return {
     tabWarningsEnabled: true,
     showResultToStudent: false,
@@ -131,10 +162,19 @@ function buildDefaultAssignOptions(
     soundEffectsEnabled: false,
     plcMode: config.plcMode ?? false,
     teacherName: config.teacherName ?? '',
-    selectedPeriodNames:
-      config.periodNames ?? (config.periodName ? [config.periodName] : []),
     plcSheetUrl: config.plcSheetUrl ?? '',
-    classId: (quizId && config.lastClassIdByQuizId?.[quizId]) ?? '',
+    picker:
+      classIds.length > 0
+        ? { source: 'classlink', classIds, periodNames: [] }
+        : config.periodNames && config.periodNames.length > 0
+          ? { source: 'local', classIds: [], periodNames: config.periodNames }
+          : config.periodName
+            ? {
+                source: 'local',
+                classIds: [],
+                periodNames: [config.periodName],
+              }
+            : makeEmptyPickerValue('classlink'),
   };
 }
 
@@ -177,10 +217,11 @@ interface QuizManagerProps {
     plcOptions: PlcOptions,
     sessionOptions: QuizSessionOptions,
     /**
-     * ClassLink target class `sourcedId`, or `null` when the teacher chose
-     * "No class" (classic code/PIN-only flow). Phase 3A.
+     * Selected ClassLink class `sourcedId`s (Phase 5A multi-class). Empty
+     * array when the teacher chose local rosters or no classes at all —
+     * preserves the classic code/PIN-only flow.
      */
-    classId: string | null
+    classIds: string[]
   ) => void;
   onResults: (quiz: QuizMetadata) => void;
   onDelete: (quiz: QuizMetadata) => void | Promise<void>;
@@ -648,14 +689,25 @@ export const QuizManager: React.FC<QuizManagerProps> = ({
   // ─── Assign confirm handler ───────────────────────────────────────────────
   const handleAssignConfirm = (): void => {
     if (!assignTarget || !selectedMode) return;
+    // Guard: filter out any selected classId that's no longer in the fetched
+    // ClassLink list (e.g. rosters changed between fetch and confirm), so we
+    // never write stale sourcedIds.
+    const validClassIds =
+      assignOptions.picker.source === 'classlink'
+        ? assignOptions.picker.classIds.filter((id) =>
+            classLinkClasses.some((c) => c.sourcedId === id)
+          )
+        : [];
+    const effectivePeriodNames = resolveEffectivePeriodNames(
+      { ...assignOptions.picker, classIds: validClassIds },
+      classLinkClasses
+    );
     const plcOptions: PlcOptions = {
       plcMode: assignOptions.plcMode,
       teacherName: assignOptions.teacherName || undefined,
-      periodName: assignOptions.selectedPeriodNames[0] || undefined,
+      periodName: effectivePeriodNames[0] || undefined,
       periodNames:
-        assignOptions.selectedPeriodNames.length > 0
-          ? assignOptions.selectedPeriodNames
-          : undefined,
+        effectivePeriodNames.length > 0 ? effectivePeriodNames : undefined,
       plcSheetUrl: assignOptions.plcSheetUrl || undefined,
     };
     const sessionOptions: QuizSessionOptions = {
@@ -668,20 +720,12 @@ export const QuizManager: React.FC<QuizManagerProps> = ({
       showPodiumBetweenQuestions: assignOptions.showPodiumBetweenQuestions,
       soundEffectsEnabled: assignOptions.soundEffectsEnabled,
     };
-    // Guard: if the teacher somehow picked a classId that's no longer in the
-    // fetched ClassLink list (e.g. rosters changed between fetch and confirm),
-    // fall through to no-class rather than writing a stale id.
-    const selectedClassId =
-      assignOptions.classId &&
-      classLinkClasses.some((c) => c.sourcedId === assignOptions.classId)
-        ? assignOptions.classId
-        : null;
     onAssign(
       assignTarget,
       selectedMode,
       plcOptions,
       sessionOptions,
-      selectedClassId
+      validClassIds
     );
     setAssignTarget(null);
     setSelectedMode(null);
@@ -1004,14 +1048,20 @@ export const QuizManager: React.FC<QuizManagerProps> = ({
               options={assignOptions}
               onChange={setAssignOptions}
               classLinkClasses={classLinkClasses}
+              rosters={rosters}
             />
           }
           plcSlot={
             <AssignPlcSlot
-              rosters={rosters}
               options={assignOptions}
               onChange={setAssignOptions}
               plcSheetUrlInvalid={plcSheetUrlInvalid}
+              effectivePeriodCount={
+                resolveEffectivePeriodNames(
+                  assignOptions.picker,
+                  classLinkClasses
+                ).length
+              }
             />
           }
           onAssign={() => handleAssignConfirm()}
@@ -1280,7 +1330,8 @@ const AssignExtraSlot: React.FC<{
   options: QuizAssignOptions;
   onChange: (next: QuizAssignOptions) => void;
   classLinkClasses: ClassLinkClass[];
-}> = ({ options, onChange, classLinkClasses }) => {
+  rosters: ClassRoster[];
+}> = ({ options, onChange, classLinkClasses, rosters }) => {
   const update = <K extends keyof QuizAssignOptions>(
     key: K,
     value: QuizAssignOptions[K]
@@ -1288,13 +1339,12 @@ const AssignExtraSlot: React.FC<{
 
   return (
     <>
-      {classLinkClasses.length > 0 && (
-        <AssignTargetClassRow
-          classes={classLinkClasses}
-          value={options.classId}
-          onChange={(v) => update('classId', v)}
-        />
-      )}
+      <AssignClassPicker
+        classLinkClasses={classLinkClasses}
+        rosters={rosters}
+        value={options.picker}
+        onChange={(picker) => update('picker', picker)}
+      />
 
       <SectionHeader label="Quiz Integrity" />
       <ToggleRow
@@ -1354,79 +1404,21 @@ const AssignExtraSlot: React.FC<{
   );
 };
 
-/**
- * Build a human-readable label for a ClassLink class. Mirrors the format
- * used by `ClassLinkImportDialog` so teachers see the same class names in
- * both flows.
- */
-function formatClassLinkClassLabel(cls: ClassLinkClass): string {
-  const subjectPrefix = cls.subject ? `${cls.subject} - ` : '';
-  const codeSuffix = cls.classCode ? ` (${cls.classCode})` : '';
-  return `${subjectPrefix}${cls.title}${codeSuffix}`;
-}
-
-/**
- * Target-class selector rendered inside the Assign modal's `extraSlot`.
- * Lets the teacher pick an optional ClassLink class to target this quiz at
- * so that students who signed in via ClassLink see it on their
- * `/my-assignments` page. Phase 3A — pilot for class-targeted session
- * launches. Hidden entirely when the teacher isn't on a ClassLink org
- * (empty classes list).
- */
-const AssignTargetClassRow: React.FC<{
-  classes: ClassLinkClass[];
-  value: string;
-  onChange: (next: string) => void;
-}> = ({ classes, value, onChange }) => {
-  return (
-    <div>
-      <div className="flex items-center gap-2 mb-1">
-        <Users className="w-4 h-4 text-brand-blue-primary" />
-        <label
-          htmlFor="quiz-assign-target-class"
-          className="text-sm font-bold text-brand-blue-dark"
-        >
-          Target class (optional)
-        </label>
-      </div>
-      <select
-        id="quiz-assign-target-class"
-        value={value}
-        onChange={(e) => onChange(e.target.value)}
-        className="w-full px-3 py-2 bg-white border border-slate-200 rounded-lg text-slate-800 text-sm focus:outline-none focus:ring-2 focus:ring-brand-blue-primary"
-      >
-        <option value="">No class (use code/PIN only)</option>
-        {classes.map((cls) => (
-          <option key={cls.sourcedId} value={cls.sourcedId}>
-            {formatClassLinkClassLabel(cls)}
-          </option>
-        ))}
-      </select>
-      <p className="text-xxs text-slate-500 mt-1">
-        Students in this class will see this quiz in their assignments list.
-        Leave blank to use a join code.
-      </p>
-    </div>
-  );
-};
-
 const AssignPlcSlot: React.FC<{
-  rosters: ClassRoster[];
   options: QuizAssignOptions;
   onChange: (next: QuizAssignOptions) => void;
   plcSheetUrlInvalid: boolean;
-}> = ({ rosters, options, onChange, plcSheetUrlInvalid }) => {
+  /**
+   * Number of class periods the picker is contributing (ClassLink class
+   * labels or local roster names). Drives the "students will see a picker"
+   * hint without this slot needing to recompute the derivation itself.
+   */
+  effectivePeriodCount: number;
+}> = ({ options, onChange, plcSheetUrlInvalid, effectivePeriodCount }) => {
   const update = <K extends keyof QuizAssignOptions>(
     key: K,
     value: QuizAssignOptions[K]
   ) => onChange({ ...options, [key]: value });
-
-  const togglePeriod = (name: string) => {
-    const next = options.selectedPeriodNames.includes(name)
-      ? options.selectedPeriodNames.filter((n) => n !== name)
-      : [...options.selectedPeriodNames, name];
-    update('selectedPeriodNames', next);
-  };
 
   return (
     <>
@@ -1445,54 +1437,16 @@ const AssignPlcSlot: React.FC<{
         />
       </div>
       <p className="text-xxs text-slate-500 -mt-1">
-        Export results to a shared Google Sheet for your PLC team.
-      </p>
-
-      <div>
-        <label className="block text-xxs font-bold text-slate-400 uppercase tracking-widest mb-1">
-          Class Periods
-        </label>
-        {rosters.length > 0 ? (
-          <div className="space-y-1.5 max-h-36 overflow-y-auto rounded-lg border border-slate-200 bg-white p-2">
-            {rosters.map((r) => {
-              const checked = options.selectedPeriodNames.includes(r.name);
-              return (
-                <label
-                  key={r.id}
-                  className="flex items-center gap-2 cursor-pointer hover:bg-slate-50 rounded px-1.5 py-1"
-                >
-                  <input
-                    type="checkbox"
-                    checked={checked}
-                    onChange={() => togglePeriod(r.name)}
-                    className="rounded border-slate-300 text-indigo-600 focus:ring-indigo-500"
-                  />
-                  <span className="text-sm text-slate-800">{r.name}</span>
-                </label>
-              );
-            })}
-          </div>
+        Export results to a shared Google Sheet for your PLC team.{' '}
+        {effectivePeriodCount > 1 ? (
+          <>Students will see a class-period picker after entering their PIN.</>
         ) : (
-          <input
-            type="text"
-            value={options.selectedPeriodNames.join(', ')}
-            onChange={(e) => {
-              const names = e.target.value
-                .split(',')
-                .map((n) => n.trim())
-                .filter(Boolean);
-              update('selectedPeriodNames', [...new Set(names)]);
-            }}
-            placeholder="e.g. Period 1, Period 2"
-            className="w-full px-3 py-2 bg-white border border-slate-200 rounded-lg text-slate-800 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
-          />
+          <>
+            Pick two or more classes above to give students a period picker when
+            they join.
+          </>
         )}
-        <p className="text-xxs text-slate-400 mt-0.5">
-          {options.selectedPeriodNames.length > 1
-            ? 'Students will see a class-period picker after entering their PIN.'
-            : 'Select class periods for this assignment. Pick two or more to give students a picker when they join.'}
-        </p>
-      </div>
+      </p>
 
       {options.plcMode && (
         <div className="space-y-3 bg-slate-50 rounded-xl p-3 border border-slate-100">

--- a/components/widgets/VideoActivityWidget/Widget.tsx
+++ b/components/widgets/VideoActivityWidget/Widget.tsx
@@ -62,7 +62,7 @@ async function copyUrlToClipboard(
 export const VideoActivityWidget: React.FC<{ widget: WidgetData }> = ({
   widget,
 }) => {
-  const { updateWidget, addToast } = useDashboard();
+  const { updateWidget, addToast, rosters } = useDashboard();
   const {
     user,
     googleAccessToken,
@@ -310,7 +310,14 @@ export const VideoActivityWidget: React.FC<{ widget: WidgetData }> = ({
           }
         }}
         defaultSessionSettings={defaultSessionSettings}
-        onAssign={async (meta, sessionSettings, assignmentName, classId) => {
+        rosters={rosters}
+        onAssign={async (
+          meta,
+          sessionSettings,
+          assignmentName,
+          classIds,
+          selectedPeriodNames
+        ) => {
           // Use loadActivityData directly to avoid setting loadingActivity
           // which would cause the Manager component to unmount and destroy the modal
           const data = await loadActivityData(meta.driveFileId);
@@ -321,26 +328,30 @@ export const VideoActivityWidget: React.FC<{ widget: WidgetData }> = ({
             [],
             sessionSettings,
             assignmentName,
-            classId ?? undefined
+            classIds,
+            selectedPeriodNames
           );
 
-          // Phase 3B: persist per-activity memory of the last ClassLink target
-          // so the next launch of the same activity pre-selects the class the
-          // teacher used last time. Clearing the selection ("No class") also
-          // clears the remembered id so we don't stick on stale values.
-          const prevMap = config.lastClassIdByActivityId ?? {};
-          const nextMap: Record<string, string> = { ...prevMap };
-          if (classId) {
-            nextMap[meta.id] = classId;
+          // Phase 5A: persist per-activity memory of the last ClassLink
+          // target classes so the next launch pre-selects the same set.
+          const prevMap = config.lastClassIdsByActivityId ?? {};
+          const nextMap: Record<string, string[]> = { ...prevMap };
+          if (classIds.length > 0) {
+            nextMap[meta.id] = classIds;
           } else {
             delete nextMap[meta.id];
           }
+          // Drop any legacy single-class entry to avoid stale pre-selection.
+          const prevLegacyMap = config.lastClassIdByActivityId ?? {};
+          const nextLegacyMap: Record<string, string> = { ...prevLegacyMap };
+          delete nextLegacyMap[meta.id];
 
           updateWidget(widget.id, {
             config: {
               ...config,
               resultsSessionId: sessionId,
-              lastClassIdByActivityId: nextMap,
+              lastClassIdsByActivityId: nextMap,
+              lastClassIdByActivityId: nextLegacyMap,
             } as VideoActivityConfig,
           });
 
@@ -352,6 +363,7 @@ export const VideoActivityWidget: React.FC<{ widget: WidgetData }> = ({
           return sessionId;
         }}
         lastClassIdByActivityId={config.lastClassIdByActivityId}
+        lastClassIdsByActivityId={config.lastClassIdsByActivityId}
         onDelete={async (meta) => {
           try {
             await deleteActivity(meta.id, meta.driveFileId);

--- a/components/widgets/VideoActivityWidget/components/VideoActivityManager.tsx
+++ b/components/widgets/VideoActivityWidget/components/VideoActivityManager.tsx
@@ -32,7 +32,6 @@ import {
   PlayCircle,
   Plus,
   Trash2,
-  Users,
 } from 'lucide-react';
 import { LibraryShell } from '@/components/common/library/LibraryShell';
 import { LibraryToolbar } from '@/components/common/library/LibraryToolbar';
@@ -64,6 +63,7 @@ import type {
 } from '@/components/common/library/types';
 import type {
   ClassLinkClass,
+  ClassRoster,
   VideoActivityAssignment,
   VideoActivityAssignmentStatus,
   VideoActivityMetadata,
@@ -71,6 +71,12 @@ import type {
   VideoActivitySessionSettings,
 } from '@/types';
 import { classLinkService } from '@/utils/classlinkService';
+import { AssignClassPicker } from '@/components/common/AssignClassPicker';
+import {
+  formatClassLinkClassLabel,
+  makeEmptyPickerValue,
+  type AssignClassPickerValue,
+} from '@/components/common/AssignClassPicker.helpers';
 
 /* ─── Props ───────────────────────────────────────────────────────────────── */
 
@@ -96,18 +102,29 @@ export interface VideoActivityManagerProps {
     settings: VideoActivitySessionSettings,
     assignmentName: string,
     /**
-     * ClassLink target class `sourcedId`, or `null` when the teacher chose
-     * "No class" (classic join-URL-only flow). Phase 3B.
+     * Selected ClassLink class `sourcedId`s (Phase 5A multi-class). Empty
+     * array means the teacher targeted local rosters or no classes at all.
      */
-    classId: string | null
+    classIds: string[],
+    /**
+     * Selected local-roster period names (Phase 5A). Populated when the
+     * teacher picked local rosters; when they picked ClassLink classes these
+     * are the ClassLink class labels so the post-PIN period picker + any
+     * export respect the teacher's intent.
+     */
+    selectedPeriodNames: string[]
   ) => Promise<string>;
+  /** Local rosters used to populate the "Local rosters" source in the picker. */
+  rosters: ClassRoster[];
   /**
-   * Per-activity memory of the last ClassLink class the teacher targeted.
-   * Used to pre-select the target-class selector on re-launch of the same
-   * activity. Passed through from widget config; missing keys fall through
-   * to "No class". Phase 3B.
+   * @deprecated Phase 5A — replaced by `lastClassIdsByActivityId`.
    */
   lastClassIdByActivityId?: Record<string, string>;
+  /**
+   * Multi-class per-activity memory of the last ClassLink classes the
+   * teacher targeted. Pre-selects the picker on re-launch.
+   */
+  lastClassIdsByActivityId?: Record<string, string[]>;
   /**
    * Optional persistence hook for manual drag-reorder of the library. Drag
    * reordering is only enabled when this callback is provided; otherwise the
@@ -227,7 +244,9 @@ export const VideoActivityManager: React.FC<VideoActivityManagerProps> = ({
   onArchiveResults,
   initialLibraryViewMode,
   onLibraryViewModeChange,
+  rosters,
   lastClassIdByActivityId,
+  lastClassIdsByActivityId,
 }) => {
   const [tab, setTab] = useState<LibraryTab>('library');
 
@@ -238,9 +257,11 @@ export const VideoActivityManager: React.FC<VideoActivityManagerProps> = ({
     useState<VideoActivitySessionSettings>(defaultSessionSettings);
   const [assignmentName, setAssignmentName] = useState<string>('');
   const [assignError, setAssignError] = useState<string | null>(null);
-  // Phase 3B: selected ClassLink target class `sourcedId`, or `''` for
-  // "No class" (classic join-URL-only flow).
-  const [assignClassId, setAssignClassId] = useState<string>('');
+  // Phase 5A: unified class-assignment picker state. Source defaults to
+  // ClassLink when any classes are available, otherwise falls back to Local.
+  const [pickerValue, setPickerValue] = useState<AssignClassPickerValue>(() =>
+    makeEmptyPickerValue('classlink')
+  );
 
   // Adjust state during render when the assign target changes — avoids the
   // set-state-in-effect anti-pattern while keeping form fields reset per open.
@@ -252,7 +273,15 @@ export const VideoActivityManager: React.FC<VideoActivityManagerProps> = ({
     setAssignOptions(defaultSessionSettings);
     setAssignmentName(buildDefaultAssignmentName(assignTarget.title));
     setAssignError(null);
-    setAssignClassId(lastClassIdByActivityId?.[assignTarget.id] ?? '');
+    const rememberedMulti = lastClassIdsByActivityId?.[assignTarget.id];
+    const rememberedSingle = lastClassIdByActivityId?.[assignTarget.id];
+    const classIds =
+      rememberedMulti ?? (rememberedSingle ? [rememberedSingle] : []);
+    setPickerValue(
+      classIds.length > 0
+        ? { source: 'classlink', classIds, periodNames: [] }
+        : makeEmptyPickerValue('classlink')
+    );
   } else if (!assignTarget && prevAssignTargetId !== null) {
     setPrevAssignTargetId(null);
   }
@@ -472,20 +501,28 @@ export const VideoActivityManager: React.FC<VideoActivityManagerProps> = ({
       return;
     }
     setAssignError(null);
-    // Guard: if the teacher somehow picked a classId that's no longer in the
-    // fetched ClassLink list (e.g. rosters changed between fetch and confirm),
-    // fall through to no-class rather than writing a stale id.
-    const selectedClassId =
-      assignClassId &&
-      classLinkClasses.some((c) => c.sourcedId === assignClassId)
-        ? assignClassId
-        : null;
+    // Guard: filter stale sourcedIds that aren't in the latest ClassLink
+    // list. Selected local-roster names fall through unchanged.
+    const validClassIds =
+      pickerValue.source === 'classlink'
+        ? pickerValue.classIds.filter((id) =>
+            classLinkClasses.some((c) => c.sourcedId === id)
+          )
+        : [];
+    const selectedPeriodNames =
+      pickerValue.source === 'classlink'
+        ? validClassIds
+            .map((id) => classLinkClasses.find((c) => c.sourcedId === id))
+            .filter((cls): cls is ClassLinkClass => Boolean(cls))
+            .map(formatClassLinkClassLabel)
+        : pickerValue.periodNames;
     try {
       await onAssign(
         assignTarget,
         assignOptions,
         assignmentName.trim(),
-        selectedClassId
+        validClassIds,
+        selectedPeriodNames
       );
       setAssignTarget(null);
     } catch (err) {
@@ -971,13 +1008,12 @@ export const VideoActivityManager: React.FC<VideoActivityManagerProps> = ({
           onAssign={handleAssignConfirm}
           extraSlot={
             <div className="space-y-3">
-              {classLinkClasses.length > 0 && (
-                <AssignTargetClassRow
-                  classes={classLinkClasses}
-                  value={assignClassId}
-                  onChange={setAssignClassId}
-                />
-              )}
+              <AssignClassPicker
+                classLinkClasses={classLinkClasses}
+                rosters={rosters}
+                value={pickerValue}
+                onChange={setPickerValue}
+              />
 
               {assignError && (
                 <div className="flex items-start gap-2 rounded-xl border border-brand-red-primary/30 bg-brand-red-lighter/40 px-3 py-2 text-sm font-medium text-brand-red-dark">
@@ -1066,61 +1102,3 @@ const ToggleRow: React.FC<ToggleRowProps> = ({
     />
   </div>
 );
-
-/* ─── AssignTargetClassRow — ClassLink target-class selector (Phase 3B) ──── */
-
-/**
- * Build a human-readable label for a ClassLink class. Mirrors the format
- * used by `ClassLinkImportDialog` and `QuizManager` so teachers see the same
- * class names across all assign flows.
- */
-function formatClassLinkClassLabel(cls: ClassLinkClass): string {
-  const subjectPrefix = cls.subject ? `${cls.subject} - ` : '';
-  const codeSuffix = cls.classCode ? ` (${cls.classCode})` : '';
-  return `${subjectPrefix}${cls.title}${codeSuffix}`;
-}
-
-/**
- * Target-class selector rendered inside the Assign modal's `extraSlot`.
- * Lets the teacher pick an optional ClassLink class to target this activity
- * at so that students who signed in via ClassLink see it on their
- * `/my-assignments` page. Phase 3B — fan-out of the Phase 3A quiz pilot.
- * Hidden entirely when the teacher isn't on a ClassLink org (empty classes
- * list).
- */
-const AssignTargetClassRow: React.FC<{
-  classes: ClassLinkClass[];
-  value: string;
-  onChange: (next: string) => void;
-}> = ({ classes, value, onChange }) => {
-  return (
-    <div>
-      <div className="flex items-center gap-2 mb-1">
-        <Users className="w-4 h-4 text-brand-blue-primary" />
-        <label
-          htmlFor="video-activity-assign-target-class"
-          className="text-sm font-bold text-brand-blue-dark"
-        >
-          Target class (optional)
-        </label>
-      </div>
-      <select
-        id="video-activity-assign-target-class"
-        value={value}
-        onChange={(e) => onChange(e.target.value)}
-        className="w-full px-3 py-2 bg-white border border-slate-200 rounded-lg text-slate-800 text-sm focus:outline-none focus:ring-2 focus:ring-brand-blue-primary"
-      >
-        <option value="">No class (use code/PIN only)</option>
-        {classes.map((cls) => (
-          <option key={cls.sourcedId} value={cls.sourcedId}>
-            {formatClassLinkClassLabel(cls)}
-          </option>
-        ))}
-      </select>
-      <p className="text-xxs text-slate-500 mt-1">
-        Students in this class will see this activity in their assignments list.
-        Leave blank to use a join code.
-      </p>
-    </div>
-  );
-};

--- a/docs/superpowers/specs/2026-04-22-assign-class-picker-design.md
+++ b/docs/superpowers/specs/2026-04-22-assign-class-picker-design.md
@@ -1,0 +1,222 @@
+# AssignClassPicker — Unified Class Picker for Quiz + Video Activity
+
+**Date:** 2026-04-22
+**Target branch:** `dev-paul`
+**Driver:** Three-teacher Quiz pilot tomorrow needs a working multi-class assignment flow.
+
+## Problem
+
+Today's Quiz assign modal exposes two separate controls that both answer the question _"which classes get this assignment?"_:
+
+1. **Single-select dropdown** ("Target class (optional)") — `AssignTargetClassRow` at `components/widgets/QuizWidget/components/QuizManager.tsx:1376–1411`. Binds to a ClassLink class via its `sourcedId`. Used by Firestore rules (`passesStudentClassGate`) so ClassLink-SSO students see the assignment on their `/my-assignments` page.
+2. **Multi-select checkbox list** ("Class Periods") inside `AssignPlcSlot` — `components/widgets/QuizWidget/components/QuizManager.tsx:1451–1495`. Binds to local `ClassRoster` names. Drives the post-PIN class-period picker for students and labels columns in the PLC Google-Sheet export.
+
+The two controls have different sources (ClassLink classes vs. local rosters), different cardinality (one vs. many), and different downstream effects, but the UI presents them as if they're optional add-ons in the same dialog. **A teacher with 4 ClassLink classes can only assign to one of them.** That's the headline pain point for tomorrow's pilot.
+
+Video Activity has the same single-select limitation (`components/widgets/VideoActivityWidget/components/VideoActivityManager.tsx:1091–1127`) but no period-checkbox concept at all — it has no PLC mode, no `selectedPeriodNames` field, and no student-side period flow.
+
+Guided Learning has _no class targeting at all_ today and is intentionally out of scope for this PR (see "Out of scope").
+
+## Goals
+
+1. Replace the two Quiz controls with one shared component that supports a strict source toggle (ClassLink XOR local rosters) and multi-select within each source.
+2. Apply the same component to Video Activity in a `classlink-only` mode (no source toggle, no period UI).
+3. Update Firestore rules for both `quiz_sessions` and `video_activity_sessions` so ClassLink-SSO students whose `classIds` claim intersects any of the session's targeted classes can read it. Today's `passesStudentClassGate(classId)` only checks a single class.
+4. Preserve all existing assignments — old session docs (with only `classId`, no `classIds`) must keep working for ClassLink-SSO students after rules ship.
+5. Keep PLC mode functional and orthogonal to the picker — PLC is "shared quiz settings + shared spreadsheet for data," not a feature that depends on local rosters.
+
+## Non-goals
+
+- Guided Learning class targeting (separate follow-up — net-new infrastructure).
+- Renaming `selectedPeriodNames` to something more honest (out of scope; too many downstream touches).
+- Mini-app (already on `classIds` + `passesStudentClassGateList`).
+- Cleanup PR to drop the `classId` write + rules fallback (planned for later, not timed against pilot).
+- Restructuring how PIN-flow students join (the PIN code path is unchanged).
+
+---
+
+## Design
+
+### 1. Component shape
+
+A single shared component at `components/common/AssignClassPicker.tsx`, ~200 lines, with one mode prop that toggles between dual-source (Quiz) and ClassLink-only (VA):
+
+```ts
+type AssignClassPickerValue = {
+  source: 'classlink' | 'local'; // ignored when mode === 'classlink-only'
+  classIds: string[]; // ClassLink sourcedIds
+  periodNames: string[]; // local roster names; always [] when mode === 'classlink-only'
+};
+
+type AssignClassPickerProps = {
+  mode: 'dual' | 'classlink-only';
+  classLinkClasses: ClassLinkClass[];
+  rosters?: ClassRoster[]; // required when mode === 'dual', ignored otherwise
+  value: AssignClassPickerValue;
+  onChange: (next: AssignClassPickerValue) => void;
+  disabled?: boolean;
+};
+```
+
+Quiz passes `mode="dual"`. VA passes `mode="classlink-only"` and omits `rosters`.
+
+**Rejected alternatives:**
+
+- Base + variants split (`<DualSourceClassPicker>` composing `<ClassLinkClassPicker>`) — over-engineered for two callers; one would always import the other.
+- Hook + presentation split (`useAssignClassSelection()` returning a state machine, each widget rendering its own UI) — defeats the purpose of unifying the UI; styles would diverge within a release.
+
+### 2. Layout
+
+**Quiz (`mode="dual"`):**
+
+```
+┌─ Assign to classes ─────────────────────────────────┐
+│  [ ClassLink classes ]  [ Local rosters ]           │ ← segmented pill, 2 options
+│                                                      │
+│  ☑ Math 6 — Period 1                                │ ← multi-select, filtered by source
+│  ☑ Math 6 — Period 3                                │
+│  ☐ Algebra — Period 5                               │
+│  ☐ Algebra — Period 7                               │
+│                                                      │
+│  Select all (4) · Clear                             │ ← inline links
+└──────────────────────────────────────────────────────┘
+```
+
+**VA (`mode="classlink-only"`):**
+
+```
+┌─ Assign to classes ─────────────────────────────────┐
+│  ☑ Math 6 — Period 1                                │ ← no source toggle
+│  ☑ Math 6 — Period 3                                │
+│  ☐ Algebra — Period 5                               │
+│  ☐ Algebra — Period 7                               │
+│                                                      │
+│  Select all (4) · Clear                             │
+└──────────────────────────────────────────────────────┘
+```
+
+**Empty / fallback states:**
+
+- ClassLink source with zero classes: render _"No ClassLink classes connected. Switch to Local rosters or use the join code."_ with the segmented control still visible so the teacher can switch.
+- Local rosters source with zero rosters: _"No saved rosters. Add one in Sidebar → Classes, or switch to ClassLink."_
+- Zero selection (any mode): no error — assignment falls back to "code/PIN only" join (current default behavior). Inline note: _"No classes selected — students will join with the code only."_
+
+The segmented control is small custom markup (two `<button>`s in a styled flex container). The existing `Toggle` component in `components/common/Toggle.tsx` is boolean-only and not suitable.
+
+### 3. PLC mode interaction (Quiz only)
+
+PLC mode is just _"shared quiz settings + shared Google Sheet for data."_ It's orthogonal to the picker.
+
+- The PLC toggle stays in `AssignPlcSlot`. The period checkbox block inside that slot (lines 1451–1495) is **removed** — periods now come from the picker for any widget that wants to label results by period.
+- The PLC toggle is **never disabled** by the picker's source choice.
+- PLC export consumes whatever the picker emitted as the "period axis":
+  - If `value.source === 'local'` → use `value.periodNames` as column headers (today's behavior).
+  - If `value.source === 'classlink'` → translate each `classId` through the existing `formatClassLinkClassLabel(cls)` helper (`components/widgets/QuizWidget/components/QuizManager.tsx:1362–1366`) to get `"Math 6 - Period 1"`-style headers. The session doc still stores raw `classIds`; the label translation happens at export time.
+  - If teacher selected zero classes → PLC sheet has no per-period columns; results land in a single "All students" column (matches today's fallback for PLC-on-with-no-periods).
+
+The picker doesn't know about PLC. The PLC slot reads `value.classIds` / `value.periodNames` from parent state. Clean separation.
+
+### 4. Pre-population on existing assignments
+
+When the assign modal opens for an existing assignment (or re-opens for editing), source the initial `AssignClassPickerValue` in this priority order:
+
+1. `classIds: [...]` present and non-empty → `{ source: 'classlink', classIds: [saved], periodNames: [] }`.
+2. Else `classId: 'x'` present (old single-field assignment) → `{ source: 'classlink', classIds: ['x'], periodNames: [] }`. Migration shim — the old single field maps to the new multi field with one element.
+3. Else `selectedPeriodNames: [...]` present and non-empty → `{ source: 'local', classIds: [], periodNames: [saved] }`.
+4. Else (fresh assignment) → `{ source: 'classlink', classIds: [], periodNames: [] }`.
+
+ClassLink wins over local when both are present (more specific targeting). Source defaults to `classlink` on fresh assignments because that's the most common new-teacher-with-SSO path.
+
+### 5. What gets written
+
+**`hooks/useQuizAssignments.ts createAssignment`** — current signature accepts `classId: string | null` as the 4th positional arg (`hooks/useQuizAssignments.ts:181–268`). New signature replaces that parameter with an options object:
+
+```ts
+createAssignment(quiz, settings, initialStatus, {
+  classIds: string[],            // [] for no targeting
+  selectedPeriodNames: string[], // [] when source === 'classlink'
+})
+```
+
+Writes onto `quiz_sessions/{id}`:
+
+- `classIds: string[]` — always present (possibly empty)
+- `classId: string` — set to `classIds[0]` when non-empty, omitted when empty (migration shim)
+- `selectedPeriodNames: string[]` — existing field, unchanged semantics
+
+**`hooks/useVideoActivityAssignments.ts createAssignment`** — current signature (`hooks/useVideoActivityAssignments.ts:135–181`) accepts `classId` as a positional arg. New signature replaces it with `classIds: string[]`. Writes both `classIds` and `classId = classIds[0]` to `video_activity_sessions/{id}`. No `selectedPeriodNames` — VA has no concept of local-roster periods today and we are not adding it.
+
+### 6. Firestore rules
+
+Per Q2's option (a): dual-write with rules fallback. Old sessions (no `classIds` field) keep working via fallback to the single `classId`.
+
+**`quiz_sessions` `allow get`** (currently `firestore.rules:603–605`):
+
+```
+allow get: if request.auth != null &&
+  (!isStudentRoleUser() ||
+   passesStudentClassGateList(
+     resource.data.get('classIds', [resource.data.get('classId', '')])
+   ));
+```
+
+**`quiz_sessions/responses`** (currently `firestore.rules:625–627`): change `sessionClassId()` helper to return the same fallback list, and switch all `passesStudentClassGate(...)` calls in the responses rules (lines 631, 639, 649) to `passesStudentClassGateList(...)`.
+
+**`video_activity_sessions` `allow get`** (currently `firestore.rules:741–743`): same pattern.
+
+**`video_activity_sessions/responses`** (currently `firestore.rules:773–775`): change `vaSessionClassId()` helper and switch `passesStudentClassGate(...)` → `passesStudentClassGateList(...)` (lines 781, 790, 795).
+
+**`guided_learning_sessions`**: unchanged. GL is out of scope for this PR.
+
+The `passesStudentClassGateList` helper already exists at `firestore.rules:51–57` and is in production use for `mini_app_sessions`.
+
+### 7. Type changes
+
+**`types.ts`:**
+
+- Add `classIds?: string[]` to `QuizSession` and `VideoActivitySession` interfaces.
+- Update `QuizAssignOptions` (currently `components/widgets/QuizWidget/components/QuizManager.tsx:97–117`): drop `classId: string`, add `classIds: string[]`. `selectedPeriodNames: string[]` stays.
+
+The mini-app session type already has `classIds`; this brings Quiz and VA in line with that shape.
+
+### 8. Files touched
+
+| File                                                                         | Change                                                                                                                                                                                                                            |
+| ---------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `components/common/AssignClassPicker.tsx`                                    | **NEW** (~200 lines)                                                                                                                                                                                                              |
+| `components/widgets/QuizWidget/components/QuizManager.tsx`                   | Replace `AssignTargetClassRow` (1376–1411) and the period checkbox block in `AssignPlcSlot` (1451–1495) with a single `<AssignClassPicker mode="dual" />`. Update `handleAssignConfirm` (649–688) to pass the new options object. |
+| `components/widgets/VideoActivityWidget/components/VideoActivityManager.tsx` | Replace `AssignTargetClassRow` (1091–1127) with `<AssignClassPicker mode="classlink-only" />`. Update `handleAssignConfirm` (468–497) to pass `classIds: string[]`.                                                               |
+| `hooks/useQuizAssignments.ts`                                                | Change `createAssignment` (181–268) signature; write both `classIds` and `classId` per Section 5.                                                                                                                                 |
+| `hooks/useVideoActivityAssignments.ts`                                       | Change `createAssignment` (135–181) signature; write both `classIds` and `classId`.                                                                                                                                               |
+| `types.ts`                                                                   | Add `classIds?: string[]` to `QuizSession` and `VideoActivitySession`.                                                                                                                                                            |
+| `firestore.rules`                                                            | Update `quiz_sessions` and `video_activity_sessions` `get` + responses rules per Section 6.                                                                                                                                       |
+| `utils/quizDriveService.ts`                                                  | If this is where PLC sheet column headers are computed (see Section 3), update to translate `classIds` → labels via `formatClassLinkClassLabel`. Confirm location during implementation.                                          |
+
+## Verification
+
+Run before opening the PR:
+
+- `pnpm run validate` (typecheck + lint + format-check + tests)
+- `pnpm -C functions test`
+- `pnpm run test:rules` if it covers the affected collections
+
+Manual smoke on the dev-paul Firebase preview after deploy:
+
+1. **Multi-class ClassLink assignment.** Teacher with 4 ClassLink classes: open Quiz → Assign → ClassLink source → select all 4 → Create. In Firebase Console, confirm the new `quiz_sessions/{id}` doc has `classIds: [4 ids]` and `classId: <first of the 4>`.
+2. **ClassLink-SSO student visibility.** Sign in as a ClassLink-SSO student in class #2 of the 4. Navigate to `/my-assignments`. Confirm the new quiz appears (rules check via `passesStudentClassGateList`).
+3. **Local-rosters with PLC.** Same teacher: Assign → Local rosters source → pick 2 → enable PLC → Create. Confirm session doc has `selectedPeriodNames: [2]`, no `classIds`. Confirm PLC export has 2 period columns.
+4. **ClassLink with PLC.** Same teacher: Assign → ClassLink source → pick 3 → enable PLC → Create. Confirm session doc has `classIds: [3]`. Confirm PLC export has 3 columns labeled with the human-readable ClassLink class names.
+5. **Empty selection fallback.** Same teacher: Assign with no classes selected (either source) → Create. Confirm session doc has `classIds: []` and no `classId`. Confirm a PIN-flow student can still join via code.
+6. **VA multi-class.** Repeat scenarios 1 and 2 for Video Activity.
+7. **Backward compat.** Verify an assignment created on the OLD code (with only `classId`, no `classIds`) is still visible to a ClassLink-SSO student in that class after the new rules deploy. This exercises the `resource.data.get('classIds', [resource.data.get('classId', '')])` fallback.
+
+## Migration / rollout
+
+- Single PR targeting `dev-paul`. Firebase rules + Firestore indexes deploy automatically on push to dev-paul.
+- After CI green and the smoke tests above pass on the preview URL, open a follow-up `dev-paul → main` promotion PR.
+- Cleanup PR to drop the `classId` write + rules fallback can come weeks later, untimed against the pilot. Defer until we've confirmed no pre-PR sessions remain in active use.
+
+## Open questions deferred to implementation
+
+- Exact location of the PLC export column-header logic (Section 8 lists `utils/quizDriveService.ts` as the likely site; confirm during implementation).
+- Whether the segmented control should be promoted to `components/common/SegmentedControl.tsx` for future reuse, or kept inline in `AssignClassPicker.tsx`. Default: keep inline for this PR; promote if a second caller materializes.

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -105,6 +105,62 @@
           "order": "DESCENDING"
         }
       ]
+    },
+    {
+      "collectionGroup": "quiz_sessions",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "classIds",
+          "arrayConfig": "CONTAINS"
+        },
+        {
+          "fieldPath": "status",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "quiz_sessions",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "classId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "status",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "video_activity_sessions",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "classIds",
+          "arrayConfig": "CONTAINS"
+        },
+        {
+          "fieldPath": "status",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "video_activity_sessions",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "classId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "status",
+          "order": "ASCENDING"
+        }
+      ]
     }
   ],
   "fieldOverrides": []

--- a/firestore.rules
+++ b/firestore.rules
@@ -72,6 +72,21 @@ service cloud.firestore {
               sessionClassIds.hasAny(request.auth.token.classIds));
     }
 
+    // Phase 5A transitional compatibility helper. Sessions created after
+    // Phase 5A write a multi-value `classIds` list; sessions created before
+    // Phase 5A write the single `classId` field. This helper selects the
+    // right gate based on which field is populated on the session doc:
+    //   - if `classIds` is a non-empty list, use `passesStudentClassGateList`
+    //   - otherwise, fall back to the legacy single-class gate
+    // Callers pass `resource.data.get('classIds', [])` and
+    // `resource.data.get('classId', '')` so the field-absent case safely
+    // falls through (empty list / empty string → no-op gate).
+    function passesStudentClassGateCompat(sessionClassIds, sessionClassId) {
+      return sessionClassIds is list && sessionClassIds.size() > 0
+             ? passesStudentClassGateList(sessionClassIds)
+             : passesStudentClassGate(sessionClassId);
+    }
+
     // ---- Organization helpers (see docs/organization_wiring_implementation.md) ----
 
     // Super admins are listed on the legacy admin_settings/user_roles doc.
@@ -642,10 +657,13 @@ service cloud.firestore {
         function sessionClassId() {
           return get(/databases/$(database)/documents/quiz_sessions/$(sessionId)).data.get('classId', '');
         }
+        function sessionClassIds() {
+          return get(/databases/$(database)/documents/quiz_sessions/$(sessionId)).data.get('classIds', []);
+        }
 
         allow read: if request.auth != null &&
           (request.auth.uid == sessionTeacherUid() ||
-           (request.auth.uid == studentUid && passesStudentClassGate(sessionClassId())) ||
+           (request.auth.uid == studentUid && passesStudentClassGateCompat(sessionClassIds(), sessionClassId())) ||
            isAdmin());
         allow create: if request.auth != null &&
           request.auth.uid == studentUid &&
@@ -653,7 +671,7 @@ service cloud.firestore {
           // Students cannot forge a score on creation
           request.resource.data.score == null &&
           // studentRole users must be enrolled in the session's class
-          passesStudentClassGate(sessionClassId());
+          passesStudentClassGateCompat(sessionClassIds(), sessionClassId());
         allow update: if request.auth != null && (
           // Teacher and admins can update any field
           request.auth.uid == sessionTeacherUid() || isAdmin() ||
@@ -663,7 +681,7 @@ service cloud.firestore {
           // score is never written by students.
           // tabSwitchWarnings may only increase (monotonic) to prevent tampering.
           (request.auth.uid == studentUid &&
-           passesStudentClassGate(sessionClassId()) &&
+           passesStudentClassGateCompat(sessionClassIds(), sessionClassId()) &&
            request.resource.data.studentUid == resource.data.studentUid &&
            request.resource.data.pin == resource.data.pin &&
            request.resource.data.joinedAt == resource.data.joinedAt &&
@@ -790,12 +808,15 @@ service cloud.firestore {
         function vaSessionClassId() {
           return get(/databases/$(database)/documents/video_activity_sessions/$(sessionId)).data.get('classId', '');
         }
+        function vaSessionClassIds() {
+          return get(/databases/$(database)/documents/video_activity_sessions/$(sessionId)).data.get('classIds', []);
+        }
 
         // Teacher can read all responses; students can only read their own (doc ID == auth UID)
         allow read: if request.auth != null && (
           isAdmin() ||
           get(/databases/$(database)/documents/video_activity_sessions/$(sessionId)).data.teacherUid == request.auth.uid ||
-          (studentUid == request.auth.uid && passesStudentClassGate(vaSessionClassId()))
+          (studentUid == request.auth.uid && passesStudentClassGateCompat(vaSessionClassIds(), vaSessionClassId()))
         );
         // Students create their own response; document ID and studentUid field must match their auth UID.
         // studentRole users must also be enrolled in the session's class.
@@ -804,12 +825,12 @@ service cloud.firestore {
           request.resource.data.studentUid == request.auth.uid &&
           request.resource.data.score == null &&
           request.resource.data.completedAt == null &&
-          passesStudentClassGate(vaSessionClassId());
+          passesStudentClassGateCompat(vaSessionClassIds(), vaSessionClassId());
         // Students can update only their own response to add answers or set completedAt;
         // identity fields and score are immutable from the client; answers array may only grow
         allow update: if request.auth != null &&
           studentUid == request.auth.uid &&
-          passesStudentClassGate(vaSessionClassId()) &&
+          passesStudentClassGateCompat(vaSessionClassIds(), vaSessionClassId()) &&
           request.resource.data.studentUid == resource.data.studentUid &&
           request.resource.data.pin == resource.data.pin &&
           request.resource.data.name == resource.data.name &&
@@ -955,12 +976,15 @@ service cloud.firestore {
         function glSessionClassId() {
           return get(/databases/$(database)/documents/guided_learning_sessions/$(sessionId)).data.get('classId', '');
         }
+        function glSessionClassIds() {
+          return get(/databases/$(database)/documents/guided_learning_sessions/$(sessionId)).data.get('classIds', []);
+        }
 
         // Teacher can read all responses; students can only read their own
         allow read: if request.auth != null && (
           isAdmin() ||
           get(/databases/$(database)/documents/guided_learning_sessions/$(sessionId)).data.teacherUid == request.auth.uid ||
-          (studentUid == request.auth.uid && passesStudentClassGate(glSessionClassId()))
+          (studentUid == request.auth.uid && passesStudentClassGateCompat(glSessionClassIds(), glSessionClassId()))
         );
         // Students create their own response; doc ID, studentAnonymousId, and sessionId must match.
         // studentRole users must also be enrolled in the session's class.
@@ -969,12 +993,12 @@ service cloud.firestore {
           request.resource.data.studentAnonymousId == request.auth.uid &&
           request.resource.data.sessionId == sessionId &&
           request.resource.data.score == null &&
-          passesStudentClassGate(glSessionClassId());
+          passesStudentClassGateCompat(glSessionClassIds(), glSessionClassId());
         // Students can update only their own response to add answers or set completedAt;
         // identity fields and score are immutable from the client
         allow update: if request.auth != null &&
           studentUid == request.auth.uid &&
-          passesStudentClassGate(glSessionClassId()) &&
+          passesStudentClassGateCompat(glSessionClassIds(), glSessionClassId()) &&
           request.resource.data.studentAnonymousId == resource.data.studentAnonymousId &&
           request.resource.data.sessionId == resource.data.sessionId &&
           request.resource.data.startedAt == resource.data.startedAt &&

--- a/hooks/useGuidedLearningSession.ts
+++ b/hooks/useGuidedLearningSession.ts
@@ -137,13 +137,17 @@ export interface UseGuidedLearningSessionTeacherResult {
   /**
    * Create a new session and return its URL.
    *
-   * `classId` is an optional ClassLink class `sourcedId`. When provided, it's
-   * written onto the session doc so that ClassLink-authenticated students
-   * see this session on their `/my-assignments` page, and Firestore rules
-   * (`passesStudentClassGate`) enforce class-based access. Omitting it
-   * preserves the classic join-link flow.
+   * `classIds` is the list of ClassLink class `sourcedId`s this session is
+   * targeted at (Phase 5A multi-class). When non-empty, the session doc
+   * stores them on `classIds` (and transitionally mirrors `classIds[0]` to
+   * `classId`). `periodNames` is the list of class-period labels used by
+   * the post-PIN picker on the student app.
    */
-  createSession: (set: GuidedLearningSet, classId?: string) => Promise<string>;
+  createSession: (
+    set: GuidedLearningSet,
+    classIds?: string[],
+    periodNames?: string[]
+  ) => Promise<string>;
   /** Load responses for a given session ID */
   subscribeToResponses: (sessionId: string) => () => void;
   /** Export responses as a CSV blob string */
@@ -160,7 +164,11 @@ export const useGuidedLearningSessionTeacher = (
   const [responsesLoading, setResponsesLoading] = useState(false);
 
   const createSession = useCallback(
-    async (set: GuidedLearningSet, classId?: string): Promise<string> => {
+    async (
+      set: GuidedLearningSet,
+      classIds: string[] = [],
+      periodNames: string[] = []
+    ): Promise<string> => {
       if (!teacherUid) throw new Error('Not authenticated');
 
       const sessionId = crypto.randomUUID();
@@ -174,11 +182,12 @@ export const useGuidedLearningSessionTeacher = (
         publicSteps,
         teacherUid,
         createdAt: Date.now(),
-        // Phase 3C: optional ClassLink target class. Only write when a
-        // non-empty sourcedId was supplied so sessions created without a
-        // target keep a clean doc shape (and the rules no-op branch kicks in
-        // via `resource.data.get('classId', '')`).
-        ...(classId ? { classId } : {}),
+        // Phase 5A: multi-class ClassLink targeting + post-PIN period
+        // picker support. `classIds` is authoritative; `classId` is
+        // transitionally mirrored to `classIds[0]` so pre-Phase-5A
+        // Firestore rules keep gating correctly.
+        ...(classIds.length > 0 ? { classIds, classId: classIds[0] } : {}),
+        ...(periodNames.length > 0 ? { periodNames } : {}),
       };
 
       await setDoc(doc(db, GL_SESSIONS_COLLECTION, sessionId), session);

--- a/hooks/useQuizAssignments.ts
+++ b/hooks/useQuizAssignments.ts
@@ -253,9 +253,8 @@ export const useQuizAssignments = (
         periodNames: settings.periodNames,
         // Phase 5A: multi-class ClassLink targeting. Write `classIds` when
         // non-empty; also mirror `classIds[0]` to the legacy `classId` field
-        // so the transitional Firestore rule (which reads
-        // `resource.data.get('classIds', [resource.data.get('classId', '')])`)
-        // keeps gating correctly until the fallback is removed.
+        // so both multi-class targeting and the legacy single-class fallback
+        // continue to gate access correctly until the fallback is removed.
         ...(targetClassIds.length > 0
           ? { classIds: targetClassIds, classId: targetClassIds[0] }
           : {}),

--- a/hooks/useQuizAssignments.ts
+++ b/hooks/useQuizAssignments.ts
@@ -62,17 +62,20 @@ export interface UseQuizAssignmentsResult {
    * Create a new assignment + its matching session doc in one batch.
    * Returns the new assignment's id (== sessionId) and the allocated join code.
    *
-   * `classId` is an optional ClassLink class `sourcedId`. When provided, it's
-   * written onto the session doc so that ClassLink-authenticated students
-   * see this session on their `/my-assignments` page, and Firestore rules
-   * (`passesStudentClassGate`) enforce class-based access. Omitting it
-   * preserves the classic code/PIN-only flow.
+   * `classIds` is the list of ClassLink class `sourcedId`s this session is
+   * targeted at (Phase 5A multi-class). When non-empty, the session doc
+   * stores them on `classIds` (and transitionally mirrors `classIds[0]` to
+   * `classId` so pre-Phase-5A Firestore rules still gate correctly).
+   * Firestore rules (`passesStudentClassGateList`) enforce that ClassLink-
+   * authenticated students can only read sessions whose classIds overlap
+   * their auth-token classIds claim. An empty/missing list preserves the
+   * classic code/PIN-only flow.
    */
   createAssignment: (
     quiz: AssignmentQuizRef,
     settings: QuizAssignmentSettings,
     initialStatus?: QuizAssignmentStatus,
-    classId?: string
+    classIds?: string[]
   ) => Promise<{ id: string; code: string }>;
   /** Set both assignment.status and session.status to 'paused'. */
   pauseAssignment: (assignmentId: string) => Promise<void>;
@@ -181,8 +184,9 @@ export const useQuizAssignments = (
   const createAssignment = useCallback<
     UseQuizAssignmentsResult['createAssignment']
   >(
-    async (quiz, settings, initialStatus = 'active', classId) => {
+    async (quiz, settings, initialStatus = 'active', classIds) => {
       if (!userId) throw new Error('Not authenticated');
+      const targetClassIds = classIds ?? [];
 
       const assignmentId = crypto.randomUUID();
       const code = await allocateJoinCode();
@@ -247,11 +251,14 @@ export const useQuizAssignments = (
         soundEffectsEnabled: opts.soundEffectsEnabled ?? false,
         questionPhase: 'answering',
         periodNames: settings.periodNames,
-        // Phase 3A: optional ClassLink target class. Only write when a
-        // non-empty sourcedId was supplied so sessions created without a
-        // target keep a clean doc shape (and the rules no-op branch kicks in
-        // via `resource.data.get('classId', '')`).
-        ...(classId ? { classId } : {}),
+        // Phase 5A: multi-class ClassLink targeting. Write `classIds` when
+        // non-empty; also mirror `classIds[0]` to the legacy `classId` field
+        // so the transitional Firestore rule (which reads
+        // `resource.data.get('classIds', [resource.data.get('classId', '')])`)
+        // keeps gating correctly until the fallback is removed.
+        ...(targetClassIds.length > 0
+          ? { classIds: targetClassIds, classId: targetClassIds[0] }
+          : {}),
       };
 
       const batch = writeBatch(db);

--- a/hooks/useVideoActivityAssignments.ts
+++ b/hooks/useVideoActivityAssignments.ts
@@ -57,17 +57,18 @@ export interface UseVideoActivityAssignmentsResult {
    * Create a new assignment + its matching session doc in one batch.
    * Returns the new assignment's id (== sessionId).
    *
-   * `classId` is an optional ClassLink class `sourcedId`. When provided, it's
-   * written onto the session doc so that ClassLink-authenticated students
-   * see this session on their `/my-assignments` page, and Firestore rules
-   * (`passesStudentClassGate(vaSessionClassId())`) enforce class-based
-   * access. Omitting it preserves the classic join-URL-only flow.
+   * `classIds` is the list of ClassLink class `sourcedId`s this session is
+   * targeted at (Phase 5A multi-class). When non-empty, the session doc
+   * stores them on `classIds` (and transitionally mirrors `classIds[0]` to
+   * `classId`). `periodNames` is the list of class-period labels available
+   * for the post-PIN picker.
    */
   createAssignment: (
     activity: AssignmentActivityRef,
     settings: VideoActivityAssignmentSettings,
     initialStatus?: VideoActivityAssignmentStatus,
-    classId?: string
+    classIds?: string[],
+    periodNames?: string[]
   ) => Promise<{ id: string }>;
   /** Set both assignment.status and session.status to 'paused' (assignment) / 'ended' (session). */
   pauseAssignment: (assignmentId: string) => Promise<void>;
@@ -135,9 +136,16 @@ export const useVideoActivityAssignments = (
   const createAssignment = useCallback<
     UseVideoActivityAssignmentsResult['createAssignment']
   >(
-    async (activity, settings, initialStatus = 'active', classId) => {
+    async (
+      activity,
+      settings,
+      initialStatus = 'active',
+      classIds,
+      periodNames
+    ) => {
       if (!userId) throw new Error('Not authenticated');
-
+      const targetClassIds = classIds ?? [];
+      const targetPeriodNames = periodNames ?? [];
       const assignmentId = crypto.randomUUID();
       const now = Date.now();
 
@@ -173,11 +181,16 @@ export const useVideoActivityAssignments = (
         allowedPins: [],
         createdAt: now,
         ...(sessionStatus === 'ended' ? { endedAt: now } : {}),
-        // Phase 3B: optional ClassLink target class. Only write when a
-        // non-empty sourcedId was supplied so sessions created without a
-        // target keep a clean doc shape (and the rules no-op branch kicks in
-        // via `resource.data.get('classId', '')`).
-        ...(classId ? { classId } : {}),
+        // Phase 5A: multi-class ClassLink targeting + post-PIN period picker.
+        // Mirror `classIds[0]` into the legacy `classId` field so
+        // pre-Phase-5A rules keep gating correctly until the fallback is
+        // removed.
+        ...(targetClassIds.length > 0
+          ? { classIds: targetClassIds, classId: targetClassIds[0] }
+          : {}),
+        ...(targetPeriodNames.length > 0
+          ? { periodNames: targetPeriodNames }
+          : {}),
       };
 
       const batch = writeBatch(db);

--- a/hooks/useVideoActivitySession.ts
+++ b/hooks/useVideoActivitySession.ts
@@ -77,11 +77,12 @@ export interface UseVideoActivitySessionTeacherResult {
   /**
    * Create a session for a class and return the sessionId (used as the share link).
    *
-   * `classId` is an optional ClassLink class `sourcedId`. When provided, it's
-   * written onto the session doc so that ClassLink-authenticated students
-   * see this session on their `/my-assignments` page, and Firestore rules
-   * (`passesStudentClassGate(vaSessionClassId())`) enforce class-based
-   * access. Omitting it preserves the classic code/PIN-only flow.
+   * `classIds` is the list of ClassLink class `sourcedId`s this session is
+   * targeted at (Phase 5A multi-class). When non-empty, the session doc
+   * stores them on `classIds` (and transitionally mirrors `classIds[0]` to
+   * `classId`). `periodNames` drives the post-PIN class-period picker and
+   * is either the list of chosen local roster names or the ClassLink class
+   * labels (mirroring the teacher's picker source).
    */
   createSession: (
     activity: VideoActivityData,
@@ -89,7 +90,8 @@ export interface UseVideoActivitySessionTeacherResult {
     allowedPins?: string[],
     settings?: Partial<VideoActivitySessionSettings>,
     assignmentName?: string,
-    classId?: string
+    classIds?: string[],
+    periodNames?: string[]
   ) => Promise<string>;
   /** Sessions created by the current teacher for the selected activity. */
   sessions: VideoActivitySession[];
@@ -127,7 +129,8 @@ export const useVideoActivitySessionTeacher =
         allowedPins: string[] = [],
         settings?: Partial<VideoActivitySessionSettings>,
         assignmentName?: string,
-        classId?: string
+        classIds: string[] = [],
+        periodNames: string[] = []
       ): Promise<string> => {
         const sessionId = crypto.randomUUID();
         const trimmedAssignmentName = assignmentName?.trim();
@@ -152,11 +155,12 @@ export const useVideoActivitySessionTeacher =
           status: 'active',
           allowedPins,
           createdAt: Date.now(),
-          // Phase 3B: optional ClassLink target class. Only write when a
-          // non-empty sourcedId was supplied so sessions created without a
-          // target keep a clean doc shape (and the rules no-op branch kicks in
-          // via `resource.data.get('classId', '')`).
-          ...(classId ? { classId } : {}),
+          // Phase 5A: multi-class ClassLink targeting + post-PIN period
+          // picker support. `classIds` is authoritative; `classId` is
+          // transitionally mirrored to `classIds[0]` so pre-Phase-5A
+          // Firestore rules keep gating correctly.
+          ...(classIds.length > 0 ? { classIds, classId: classIds[0] } : {}),
+          ...(periodNames.length > 0 ? { periodNames } : {}),
         };
 
         await setDoc(doc(db, SESSIONS_COLLECTION, sessionId), session);
@@ -309,7 +313,18 @@ export interface UseVideoActivitySessionStudentResult {
   myResponse: VideoActivityResponse | null;
   joinStatus: StudentJoinStatus;
   error: string | null;
-  joinSession: (sessionId: string, pin: string, name: string) => Promise<void>;
+  /**
+   * Look up a session by id without creating a response — used by the
+   * student-app join flow to decide whether to show a post-PIN period
+   * picker before committing the join.
+   */
+  lookupSession: (sessionId: string) => Promise<VideoActivitySession | null>;
+  joinSession: (
+    sessionId: string,
+    pin: string,
+    name: string,
+    classPeriod?: string
+  ) => Promise<void>;
   submitAnswer: (questionId: string, answer: string) => Promise<void>;
   completeActivity: () => Promise<void>;
 }
@@ -376,11 +391,31 @@ export const useVideoActivitySessionStudent =
       return unsub;
     }, [sessionId, responseDocId]);
 
+    const lookupSession = useCallback(
+      async (targetSessionId: string): Promise<VideoActivitySession | null> => {
+        try {
+          const snap = await getDoc(
+            doc(db, SESSIONS_COLLECTION, targetSessionId)
+          );
+          if (!snap.exists()) return null;
+          return snap.data() as VideoActivitySession;
+        } catch (err) {
+          console.error(
+            '[useVideoActivitySessionStudent] lookupSession error:',
+            err
+          );
+          return null;
+        }
+      },
+      []
+    );
+
     const joinSession = useCallback(
       async (
         targetSessionId: string,
         studentPin: string,
-        studentName: string
+        studentName: string,
+        classPeriod?: string
       ): Promise<void> => {
         setJoinStatus('loading');
         setError(null);
@@ -454,6 +489,7 @@ export const useVideoActivitySessionStudent =
               answers: [],
               completedAt: null,
               score: null,
+              ...(classPeriod ? { classPeriod } : {}),
             };
             await setDoc(responseRef, newResponse);
           }
@@ -527,6 +563,7 @@ export const useVideoActivitySessionStudent =
       myResponse,
       joinStatus,
       error,
+      lookupSession,
       joinSession,
       submitAnswer,
       completeActivity,

--- a/types.ts
+++ b/types.ts
@@ -1737,17 +1737,24 @@ export interface QuizSession {
   /** Selected class period roster names available for students to join. */
   periodNames?: string[];
 
-  // ─── ClassLink target class (Phase 3A) ─────────────────────────────────────
+  // ─── ClassLink target class (Phase 3A, Phase 5A multi-class) ───────────────
   /**
-   * Optional ClassLink class `sourcedId` this session is targeted at. When
-   * present, students who signed in via the ClassLink / Google flow will see
-   * this session on their `/my-assignments` page, and Firestore rules
-   * enforce (via `passesStudentClassGate`) that only students enrolled in
-   * this class can read the session doc. Omit (or leave as an empty string)
-   * to preserve the classic code/PIN-only flow — the gate is a no-op for
-   * non-studentRole users.
+   * @deprecated Phase 5A — retained only for transitional compatibility.
+   * Populated to `classIds[0]` when `classIds` is non-empty so older clients
+   * and pre-migration Firestore rules keep working. Prefer `classIds`.
    */
   classId?: string;
+  /**
+   * Multi-class ClassLink target: the list of ClassLink class `sourcedId`s
+   * this session is targeted at. When non-empty, students who signed in via
+   * the ClassLink / Google flow will see this session on their
+   * `/my-assignments` page, and Firestore rules (via
+   * `passesStudentClassGateList`) enforce that the student has at least one
+   * of these classes in their `classIds` auth-token claim. An empty or
+   * missing list preserves the classic code/PIN-only flow — the gate is a
+   * no-op for non-studentRole users.
+   */
+  classIds?: string[];
 }
 
 export interface QuizResponseAnswer {
@@ -1841,13 +1848,20 @@ export interface QuizConfig {
   /** Persisted library grid/list toggle. */
   libraryViewMode?: 'grid' | 'list';
   /**
-   * Per-quiz memory of the last ClassLink target class (`sourcedId`) the
-   * teacher picked in the Assign modal. Key is quizId, value is the
-   * ClassLink class sourcedId. Used to pre-select the selector on re-launch
-   * of the same quiz so teachers don't have to re-pick every time.
-   * Undefined means "use the default (No class)".
+   * @deprecated Phase 5A — replaced by `lastClassIdsByQuizId` (multi-class).
+   * Retained for a transitional release so existing widget configs don't
+   * lose their pre-selection on first render. Readers prefer the multi-
+   * class map; fallback to this when the new key is absent.
    */
   lastClassIdByQuizId?: Record<string, string>;
+  /**
+   * Per-quiz memory of the last ClassLink target classes (`sourcedId`s) the
+   * teacher picked in the Assign modal. Key is quizId, value is a list of
+   * ClassLink class sourcedIds. Used to pre-select the picker on re-launch
+   * of the same quiz so teachers don't have to re-pick every time. Missing
+   * keys mean "use the default (no classes selected)".
+   */
+  lastClassIdsByQuizId?: Record<string, string[]>;
 }
 
 // --- QUIZ ASSIGNMENT TYPES ---
@@ -1982,8 +1996,17 @@ export interface VideoActivityConfig {
    * ClassLink class sourcedId. Used to pre-select the selector on re-launch
    * of the same activity so teachers don't have to re-pick every time.
    * Undefined means "use the default (No class)".
+   *
+   * @deprecated Phase 5A — replaced by `lastClassIdsByActivityId` (multi).
+   * Retained for a transitional release so existing widget configs don't
+   * lose their pre-selection on first render.
    */
   lastClassIdByActivityId?: Record<string, string>;
+  /**
+   * Multi-class variant of the per-activity memory (Phase 5A). Preferred
+   * over the legacy single-class map.
+   */
+  lastClassIdsByActivityId?: Record<string, string[]>;
 }
 
 export interface VideoActivitySessionSettings {
@@ -2028,13 +2051,26 @@ export interface VideoActivitySession {
   /** Optional Unix timestamp when the session link expires. */
   expiresAt?: number;
   /**
-   * Optional ClassLink class `sourcedId` this session is targeted at. When
-   * set, ClassLink-authenticated students whose token includes this classId
-   * see the session on their `/my-assignments` page, and Firestore rules
-   * (`passesStudentClassGate(vaSessionClassId())`) enforce class-based
-   * access. Undefined preserves the classic code/PIN-only flow.
+   * @deprecated Phase 5A — retained only for transitional compatibility.
+   * Populated to `classIds[0]` when `classIds` is non-empty so older clients
+   * and pre-migration Firestore rules keep working. Prefer `classIds`.
    */
   classId?: string;
+  /**
+   * Multi-class ClassLink target list. ClassLink-authenticated students whose
+   * token `classIds` claim overlaps this list see the session on their
+   * `/my-assignments` page; Firestore rules (`passesStudentClassGateList`)
+   * enforce the class gate. An empty/missing list preserves the classic
+   * PIN-only flow.
+   */
+  classIds?: string[];
+  /**
+   * Optional class-period names (typically local roster names) available for
+   * students to choose from after entering their PIN. When present and > 1,
+   * the student app shows a post-PIN picker and writes the chosen value to
+   * the response's `classPeriod` field. Mirrors the QuizSession pattern.
+   */
+  periodNames?: string[];
 }
 
 /** A single answer submitted by a student for a video activity question. */
@@ -2061,6 +2097,8 @@ export interface VideoActivityResponse {
   answers: VideoActivityAnswer[];
   completedAt: number | null;
   score: number | null;
+  /** Which class period the student selected when joining (multi-class support). */
+  classPeriod?: string;
 }
 
 export interface TalkingToolConfig {
@@ -2638,17 +2676,28 @@ export interface GuidedLearningSession {
   teacherUid: string;
   createdAt: number;
   expiresAt?: number;
-  // ─── ClassLink target class (Phase 3C) ─────────────────────────────────────
+  // ─── ClassLink target class (Phase 3C, Phase 5A multi-class) ───────────────
   /**
-   * Optional ClassLink class `sourcedId` this session is targeted at. When
-   * present, students who signed in via the ClassLink / Google flow will see
-   * this session on their `/my-assignments` page, and Firestore rules
-   * enforce (via `passesStudentClassGate`) that only students enrolled in
-   * this class can read the session doc. Omit (or leave as an empty string)
-   * to preserve the classic join-link flow — the gate is a no-op for
-   * non-studentRole users.
+   * @deprecated Phase 5A — retained only for transitional compatibility.
+   * Populated to `classIds[0]` when `classIds` is non-empty so older clients
+   * and pre-migration Firestore rules keep working. Prefer `classIds`.
    */
   classId?: string;
+  /**
+   * Multi-class ClassLink target list. ClassLink-authenticated students whose
+   * token `classIds` claim overlaps this list see the session on their
+   * `/my-assignments` page; Firestore rules (`passesStudentClassGateList`)
+   * enforce the class gate. An empty/missing list preserves the classic
+   * join-link flow.
+   */
+  classIds?: string[];
+  /**
+   * Optional class-period names (typically local roster names) available for
+   * students to choose from after entering their PIN. When present and > 1,
+   * the student app shows a post-PIN picker and writes the chosen value to
+   * the response's `classPeriod` field. Mirrors the QuizSession pattern.
+   */
+  periodNames?: string[];
 }
 
 /** Per-student response in /guided_learning_sessions/{id}/responses/{studentUid} */
@@ -2664,6 +2713,8 @@ export interface GuidedLearningResponse {
   completedAt: number | null;
   startedAt: number;
   score: number | null;
+  /** Which class period the student selected when joining (multi-class support). */
+  classPeriod?: string;
 }
 
 export interface GuidedLearningGlobalConfig {
@@ -2685,8 +2736,17 @@ export interface GuidedLearningConfig {
    * value is the ClassLink class sourcedId. Used to pre-select the selector
    * on re-launch of the same set so teachers don't have to re-pick every
    * time. Undefined means "use the default (No class)".
+   *
+   * @deprecated Phase 5A — replaced by `lastClassIdsBySetId` (multi).
+   * Retained for a transitional release so existing widget configs don't
+   * lose their pre-selection on first render.
    */
   lastClassIdBySetId?: Record<string, string>;
+  /**
+   * Multi-class variant of the per-set memory (Phase 5A). Preferred over
+   * the legacy single-class map.
+   */
+  lastClassIdsBySetId?: Record<string, string[]>;
 }
 
 // Union of all widget configs


### PR DESCRIPTION
## Summary

Fixes three compounding bugs that were hiding ClassLink-targeted assignments from Google-SSO students on `/my-assignments` (PIN join was unaffected and continues to work).

Built on top of [PR #1392](https://github.com/OPS-PIvers/SpartBoard/pull/1392) (Phase 5A multi-class picker) — base branch `dev-paul` is behind that PR, so this branch includes #1392's commits plus the fix. Ship them together.

## Root cause (three bugs)

1. **Missing composite indexes** (primary). `where('classId', 'in', classIds)` + `where('status', '==', 'active')` requires a composite index. Without it Firestore returns `failed-precondition`, which the page silently swallowed into an empty list. Quiz and video-activity both hit this.
2. **Teacher-paced quizzes sit in `'waiting'`** between Play and Q1. Page queried `status == 'active'` only, so SSO students never saw the waiting room that PIN joiners could enter.
3. **Multi-class discovery gap** (introduced by #1392). Phase 5A writes `classIds: string[]` + `classId = classIds[0]`. Querying only the legacy `classId` means students in `classIds[1..]` never find the assignment — multi-class targeting is visible for class A only.

## Changes

- **`firestore.indexes.json`** — +4 composite indexes:
  - `quiz_sessions`: `(classIds array-contains, status)` and `(classId, status)`
  - `video_activity_sessions`: same pair
  - GuidedLearning needs no composite (no status filter).
- **`components/student/MyAssignmentsPage.tsx`**:
  - Quiz / video-activity / guided-learning now each subscribe to **two** queries (`classIds array-contains-any` + legacy `classId 'in'`), de-duped by `sessionId`.
  - Quiz status filter widened to `['waiting', 'active']` using `where(..., 'in', [...])`.
  - `handleError` upgraded from `console.warn` (code only) to `console.error` with `err.message` — Firestore's missing-index error embeds a one-click index-creation URL, invaluable the next time something silently empties the list. Still PII-safe (Firestore messages don't echo classId values).
  - Mini-app (already list-shape) and activity-wall (no multi-class yet) are unchanged.
- **No changes** to rules, session writers, or types — #1392 already handled `passesStudentClassGateCompat` and dual-writes.

## Safety for in-flight quizzes

Paul's morning-paused, afternoon-resumed quizzes are safe:
- No data migration — existing docs are not read-modify-written.
- **Paused stays hidden.** Widened filter includes `'waiting'` only, never `'paused'` or `'ended'`.
- **Resume behavior unchanged.** `resumeAssignment` logic untouched — student-paced → `'active'`, teacher-paced never-past-Q1 → `'waiting'` (now visible, matching PIN), teacher-paced past-Q1 → `'active'`.
- **Legacy single-class sessions keep working.** The fallback `classId 'in' classIds` query preserves discovery for pre-#1392 sessions.
- **Class targeting stays strict.** Both queries filter on the student's own classIds claim. No cross-class leakage.
- **PIN flow untouched.** Anonymous-auth PIN path never touches this query or rules branch.

## Deploy order

1. Merge this PR (or deploy first on preview).
2. `firebase deploy --only firestore:indexes`. **Wait** in Firebase console until all four new indexes show **Enabled** (not Building).
3. Deploy code. The currently-deployed code's legacy single-`in` + `==` query starts succeeding as soon as indexes Enable — an immediate, risk-free recovery for student-paced assignments that were already broken.

## Test plan

- [ ] `pnpm run type-check` — clean ✅ (verified locally)
- [ ] `pnpm run lint` — clean ✅ (verified locally)
- [ ] `pnpm run format:check` — clean ✅ (verified locally)
- [ ] `pnpm run test` — 1423/1423 ✅ (verified locally)

### Manual end-to-end (requires teacher + ClassLink-SSO student profiles)

- [ ] **Single-class, student-paced (Bug 1 regression).** Teacher assigns quiz, ClassLink → single class → student mode → Play. Student sees quiz; pause hides it, resume shows it, end hides it.
- [ ] **Single-class, teacher-paced (Bug 2 regression).** Teacher assigns quiz, ClassLink → single class → teacher mode → Play, do NOT advance. Student sees it; clicking lands in waiting room. Teacher advances to Q1 → still visible; student transitions to active view.
- [ ] **Multi-class, student-paced (Bug 3 regression).** Teacher with ≥3 ClassLink classes → assign quiz → pick 3 classes → Play. Three students (one per class) each see it on their `/my-assignments`. A fourth student not in any of the 3 does NOT see it.
- [ ] **Multi-class, teacher-paced.** Same as above with teacher mode + "Play but don't advance".
- [ ] **Video Activity + Guided Learning, multi-class.** Repeat the multi-class test for VA and GL.
- [ ] **Legacy single-class session.** A pre-#1392 session (only `classId`, no `classIds`) still discoverable via the fallback `classId 'in' classIds` subscription.
- [ ] **PIN flow (MUST remain intact).** Teacher-paced quiz in waiting → incognito → `/quiz?code=XXXXXX` → PIN join → name → waiting room. No sign-in, unchanged from today.
- [ ] **No-target quiz (regression guard).** Assign with no target class → no student's `/my-assignments` shows it; PIN join still works.

## Explicitly out of scope

- `mini_app_sessions` discovery multi-class cleanup — tracked as #1392's "B1" follow-up.
- Session-writer, rules, type, or `AssignClassPicker` changes — all owned by #1392.
- Dropping the legacy single-class query after all pre-#1392 sessions expire — later cleanup.
- Multi-class UI for ActivityWall — not yet in #1392.

🤖 Generated with [Claude Code](https://claude.com/claude-code)