### PR TITLE
feat(rosters): unify ClassLink-imported classes with local rosters

### DIFF
--- a/components/classes/ClassLinkImportDialog.tsx
+++ b/components/classes/ClassLinkImportDialog.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { collection, getDocs } from 'firebase/firestore';
 import { Download, Loader2, RefreshCw, AlertCircle } from 'lucide-react';
-import { ClassLinkClass, ClassRoster, Student } from '@/types';
+import { ClassLinkClass, ClassRoster, ClassRosterMeta, Student } from '@/types';
 import { Modal } from '@/components/common/Modal';
 import { db } from '@/config/firebase';
 import { classLinkService } from '@/utils/classlinkService';
@@ -12,6 +12,28 @@ import { useDashboard } from '@/context/useDashboard';
 import { mergeClassLinkStudents } from './mergeClassLinkStudents';
 
 const TEST_PREFIX = 'test:';
+
+/**
+ * Build the ClassLink provenance metadata to persist on a roster document.
+ * Returns `null` for test classes (they aren't real ClassLink classes and
+ * must not claim `origin: 'classlink'` — they'd otherwise feed garbage
+ * sourcedIds into session `classIds[]` and break the student SSO gate).
+ */
+const buildClassLinkRosterMeta = (
+  cls: ClassLinkClass,
+  orgId: string | null | undefined
+): Partial<ClassRosterMeta> | null => {
+  if (cls.sourcedId.startsWith(TEST_PREFIX)) return null;
+  const meta: Partial<ClassRosterMeta> = {
+    origin: 'classlink',
+    classlinkClassId: cls.sourcedId,
+    classlinkSyncedAt: Date.now(),
+  };
+  if (cls.classCode) meta.classlinkClassCode = cls.classCode;
+  if (cls.subject) meta.classlinkSubject = cls.subject;
+  if (orgId) meta.classlinkOrgId = orgId;
+  return meta;
+};
 
 // PINs match the synthetic sidebar rosters in `useTestClassRosters.ts` so the
 // same test student uses the same PIN whether they're joining through the
@@ -176,7 +198,8 @@ export const ClassLinkImportDialog: React.FC<ClassLinkImportDialogProps> = ({
       const subjectPrefix = cls.subject ? `${cls.subject} - ` : '';
       const codeSuffix = cls.classCode ? ` (${cls.classCode})` : '';
       const displayName = `${subjectPrefix}${cls.title}${codeSuffix}`;
-      await addRoster(displayName, students);
+      const rosterMeta = buildClassLinkRosterMeta(cls, orgId);
+      await addRoster(displayName, students, rosterMeta ?? undefined);
       addToast(
         t('toasts.classLink.imported', {
           defaultValue: 'Imported {{name}}',
@@ -220,7 +243,15 @@ export const ClassLinkImportDialog: React.FC<ClassLinkImportDialogProps> = ({
         target.students,
         studentsByClass[cls.sourcedId] ?? []
       );
-      await updateRoster(mode.rosterId, { students: result.students });
+      // Backfill ClassLink provenance on the roster doc itself — rosters
+      // imported before the metadata fields existed (or merged with a new
+      // ClassLink class) still need `classlinkClassId` so the student SSO
+      // gate resolves via session `classIds[]` derivation downstream.
+      const rosterMeta = buildClassLinkRosterMeta(cls, orgId);
+      await updateRoster(mode.rosterId, {
+        students: result.students,
+        ...(rosterMeta ?? {}),
+      });
       if (result.addedCount === 0 && result.matchedCount === 0) {
         addToast(
           t('toasts.classLink.noStudents', {

--- a/components/classes/ClassLinkImportDialog.tsx
+++ b/components/classes/ClassLinkImportDialog.tsx
@@ -18,6 +18,14 @@ const TEST_PREFIX = 'test:';
  * Returns `null` for test classes (they aren't real ClassLink classes and
  * must not claim `origin: 'classlink'` — they'd otherwise feed garbage
  * sourcedIds into session `classIds[]` and break the student SSO gate).
+ *
+ * NOTE: fields missing from `cls` (e.g., `classCode` cleared upstream) are
+ * omitted rather than set to `deleteField()`, so `updateRoster` at merge
+ * time additively refreshes metadata without wiping previously-stored
+ * values. ClassLink rarely drops these fields in practice; if upstream
+ * ever clears a classCode/subject, the badge tooltip shows stale data
+ * until the teacher re-imports. Acceptable tradeoff vs. an extra
+ * `deleteField()` code path on every merge.
  */
 const buildClassLinkRosterMeta = (
   cls: ClassLinkClass,

--- a/components/common/AssignClassPicker.helpers.ts
+++ b/components/common/AssignClassPicker.helpers.ts
@@ -4,23 +4,27 @@
  * (required for Vite's fast-refresh contract).
  */
 
-import type { ClassLinkClass } from '@/types';
+import type { ClassLinkClass, ClassRoster } from '@/types';
 
-export type AssignClassSource = 'classlink' | 'local';
-
+/**
+ * Unified picker value. Rosters are the single source of truth for assignment
+ * targeting — ClassLink-imported rosters carry `classlinkClassId` metadata so
+ * the session-creation layer can still derive ClassLink sourcedIds for the
+ * student SSO gate without the assignment UI having to branch.
+ */
 export interface AssignClassPickerValue {
-  /** Which source list is currently active. */
-  source: AssignClassSource;
-  /** Selected ClassLink class `sourcedId`s (populated when source === 'classlink'). */
-  classIds: string[];
-  /** Selected local roster names (populated when source === 'local'). */
-  periodNames: string[];
+  rosterIds: string[];
+}
+
+/** Default-empty value helper used by callers to seed initial picker state. */
+export function makeEmptyPickerValue(): AssignClassPickerValue {
+  return { rosterIds: [] };
 }
 
 /**
- * Build a human-readable label for a ClassLink class. Mirrors the format
- * used elsewhere (ClassLinkImportDialog, legacy QuizManager) so teachers
- * see the same class names across flows.
+ * Build a human-readable label for a ClassLink class. Retained for the Import
+ * dialog, which still lists live ClassLink classes (the import flow is the
+ * only place live ClassLink data surfaces after the unification).
  */
 export function formatClassLinkClassLabel(cls: ClassLinkClass): string {
   const subjectPrefix = cls.subject ? `${cls.subject} - ` : '';
@@ -28,9 +32,18 @@ export function formatClassLinkClassLabel(cls: ClassLinkClass): string {
   return `${subjectPrefix}${cls.title}${codeSuffix}`;
 }
 
-/** Default-empty value helper used by callers to seed initial picker state. */
-export function makeEmptyPickerValue(
-  source: AssignClassSource = 'classlink'
-): AssignClassPickerValue {
-  return { source, classIds: [], periodNames: [] };
+/**
+ * Derive the selected rosters from the picker value. Filters out IDs that no
+ * longer exist (roster deleted after the value was saved as a teacher
+ * preference) so downstream consumers never see dangling references.
+ */
+export function resolveSelectedRosters(
+  value: AssignClassPickerValue,
+  rosters: ClassRoster[]
+): ClassRoster[] {
+  if (value.rosterIds.length === 0) return [];
+  const byId = new Map(rosters.map((r) => [r.id, r]));
+  return value.rosterIds
+    .map((id) => byId.get(id))
+    .filter((r): r is ClassRoster => r !== undefined);
 }

--- a/components/common/AssignClassPicker.tsx
+++ b/components/common/AssignClassPicker.tsx
@@ -1,28 +1,24 @@
 /**
- * AssignClassPicker — shared class-assignment picker used by the Quiz, Video
- * Activity, and Guided Learning assign modals.
+ * AssignClassPicker — shared class-assignment picker used by Quiz, Video
+ * Activity, Guided Learning, and Mini-App assign modals.
  *
- * Replaces the previous split between a single-select ClassLink dropdown and
- * a separate multi-select local-rosters checklist. Teachers pick a source
- * (ClassLink classes XOR local rosters), then multi-select from the filtered
- * list. Zero selection falls through to the classic code/PIN-only flow.
+ * Shows a single multi-select list of the teacher's local rosters. Rosters
+ * imported from ClassLink carry a "CL" badge (their `classlinkClassId`
+ * metadata drives the student SSO gate downstream). Live ClassLink data is
+ * NOT fetched here — it lives only in the Import dialog, keeping the
+ * assignment flow uniform regardless of roster provenance.
  *
- * The component is controlled — parents own the value and pass it back in
- * via `value` / `onChange`. Source-switching clears the other source's
- * selection automatically so the shape stays consistent.
+ * Controlled component: parents own the value and pass it back in via
+ * `value` / `onChange`. Zero selection falls through to the classic
+ * code/PIN-only join flow.
  */
 
 import React from 'react';
-import { Users, Check } from 'lucide-react';
-import type { ClassLinkClass, ClassRoster } from '@/types';
-import {
-  formatClassLinkClassLabel,
-  type AssignClassSource,
-  type AssignClassPickerValue,
-} from './AssignClassPicker.helpers';
+import { Users, Check, Link2 } from 'lucide-react';
+import type { ClassRoster } from '@/types';
+import type { AssignClassPickerValue } from './AssignClassPicker.helpers';
 
 export interface AssignClassPickerProps {
-  classLinkClasses: ClassLinkClass[];
   rosters: ClassRoster[];
   value: AssignClassPickerValue;
   onChange: (next: AssignClassPickerValue) => void;
@@ -30,87 +26,28 @@ export interface AssignClassPickerProps {
 }
 
 export const AssignClassPicker: React.FC<AssignClassPickerProps> = ({
-  classLinkClasses,
   rosters,
   value,
   onChange,
   disabled = false,
 }) => {
-  const hasClassLink = classLinkClasses.length > 0;
-  const hasLocal = rosters.length > 0;
-
-  const effectiveSource: AssignClassSource = hasClassLink
-    ? value.source
-    : 'local';
-
-  const handleSourceChange = (next: AssignClassSource): void => {
-    if (next === value.source) return;
-    // Clear the other source's selection so the shape stays consistent.
-    onChange({
-      source: next,
-      classIds: [],
-      periodNames: [],
-    });
-  };
-
-  const toggleClassId = (id: string): void => {
-    const next = value.classIds.includes(id)
-      ? value.classIds.filter((x) => x !== id)
-      : [...value.classIds, id];
-    // Always pin `source` to the list being mutated. Without this, callers
-    // whose `value.source` is stale (e.g., the default `'classlink'` seeded
-    // via `makeEmptyPickerValue` even when only local rosters are available)
-    // would see a mismatched `source` vs. populated list and silently drop
-    // the selection in downstream `source === 'classlink'` branches.
-    onChange({
-      ...value,
-      source: 'classlink',
-      classIds: next,
-      periodNames: [],
-    });
-  };
-
-  const togglePeriodName = (name: string): void => {
-    const next = value.periodNames.includes(name)
-      ? value.periodNames.filter((x) => x !== name)
-      : [...value.periodNames, name];
-    onChange({
-      ...value,
-      source: 'local',
-      classIds: [],
-      periodNames: next,
-    });
+  const toggleRosterId = (id: string): void => {
+    const next = value.rosterIds.includes(id)
+      ? value.rosterIds.filter((x) => x !== id)
+      : [...value.rosterIds, id];
+    onChange({ rosterIds: next });
   };
 
   const selectAll = (): void => {
-    if (effectiveSource === 'classlink') {
-      onChange({
-        ...value,
-        source: 'classlink',
-        classIds: classLinkClasses.map((c) => c.sourcedId),
-        periodNames: [],
-      });
-    } else {
-      onChange({
-        ...value,
-        source: 'local',
-        classIds: [],
-        periodNames: rosters.map((r) => r.name),
-      });
-    }
+    onChange({ rosterIds: rosters.map((r) => r.id) });
   };
 
   const clearAll = (): void => {
-    onChange({ ...value, classIds: [], periodNames: [] });
+    onChange({ rosterIds: [] });
   };
 
-  const selectedCount =
-    effectiveSource === 'classlink'
-      ? value.classIds.length
-      : value.periodNames.length;
-
-  const totalCount =
-    effectiveSource === 'classlink' ? classLinkClasses.length : rosters.length;
+  const selectedCount = value.rosterIds.length;
+  const totalCount = rosters.length;
 
   return (
     <div
@@ -126,35 +63,20 @@ export const AssignClassPicker: React.FC<AssignClassPickerProps> = ({
         </label>
       </div>
 
-      {hasClassLink && (
-        <div
-          role="radiogroup"
-          aria-label="Class source"
-          className="inline-flex items-center rounded-lg border border-slate-200 bg-slate-50 p-0.5"
-        >
-          <SourceToggleButton
-            label="ClassLink classes"
-            active={effectiveSource === 'classlink'}
-            onClick={() => handleSourceChange('classlink')}
-          />
-          <SourceToggleButton
-            label="Local rosters"
-            active={effectiveSource === 'local'}
-            onClick={() => handleSourceChange('local')}
-            disabled={!hasLocal}
-            disabledHint="No local rosters"
-          />
-        </div>
+      {rosters.length === 0 ? (
+        <EmptyStub message="No classes yet. Create one in My Classes or import from ClassLink to assign here." />
+      ) : (
+        <CheckList>
+          {rosters.map((r) => (
+            <RosterCheckItem
+              key={r.id}
+              roster={r}
+              checked={value.rosterIds.includes(r.id)}
+              onToggle={() => toggleRosterId(r.id)}
+            />
+          ))}
+        </CheckList>
       )}
-
-      <PickerList
-        source={effectiveSource}
-        classLinkClasses={classLinkClasses}
-        rosters={rosters}
-        value={value}
-        onToggleClassId={toggleClassId}
-        onTogglePeriodName={togglePeriodName}
-      />
 
       {totalCount > 0 && (
         <div className="flex items-center justify-between text-xxs text-slate-500">
@@ -189,118 +111,57 @@ export const AssignClassPicker: React.FC<AssignClassPickerProps> = ({
   );
 };
 
-const SourceToggleButton: React.FC<{
-  label: string;
-  active: boolean;
-  onClick: () => void;
-  disabled?: boolean;
-  disabledHint?: string;
-}> = ({ label, active, onClick, disabled = false, disabledHint }) => (
-  <button
-    type="button"
-    role="radio"
-    aria-checked={active}
-    onClick={onClick}
-    disabled={disabled}
-    title={disabled ? disabledHint : undefined}
-    className={`px-3 py-1 text-xs font-bold rounded-md transition-colors ${
-      active
-        ? 'bg-white text-brand-blue-dark shadow-sm'
-        : 'text-slate-500 hover:text-slate-700'
-    } ${disabled ? 'opacity-50 cursor-not-allowed' : ''}`}
-  >
-    {label}
-  </button>
-);
-
-interface PickerListProps {
-  source: AssignClassSource;
-  classLinkClasses: ClassLinkClass[];
-  rosters: ClassRoster[];
-  value: AssignClassPickerValue;
-  onToggleClassId: (id: string) => void;
-  onTogglePeriodName: (name: string) => void;
-}
-
-const PickerList: React.FC<PickerListProps> = ({
-  source,
-  classLinkClasses,
-  rosters,
-  value,
-  onToggleClassId,
-  onTogglePeriodName,
-}) => {
-  if (source === 'classlink') {
-    if (classLinkClasses.length === 0) {
-      return (
-        <EmptyStub message="No ClassLink classes found. Switch to Local rosters or assign with a code/PIN only." />
-      );
-    }
-    return (
-      <CheckList>
-        {classLinkClasses.map((cls) => (
-          <CheckItem
-            key={cls.sourcedId}
-            checked={value.classIds.includes(cls.sourcedId)}
-            label={formatClassLinkClassLabel(cls)}
-            onToggle={() => onToggleClassId(cls.sourcedId)}
-          />
-        ))}
-      </CheckList>
-    );
-  }
-
-  // source === 'local'
-  if (rosters.length === 0) {
-    return (
-      <EmptyStub message="No local rosters. Import a roster from the Classes panel, or assign with a code/PIN only." />
-    );
-  }
-  return (
-    <CheckList>
-      {rosters.map((r) => (
-        <CheckItem
-          key={r.id}
-          checked={value.periodNames.includes(r.name)}
-          label={r.name}
-          onToggle={() => onTogglePeriodName(r.name)}
-        />
-      ))}
-    </CheckList>
-  );
-};
-
 const CheckList: React.FC<{ children: React.ReactNode }> = ({ children }) => (
   <div className="space-y-1 max-h-40 overflow-y-auto rounded-lg border border-slate-200 bg-white p-2">
     {children}
   </div>
 );
 
-const CheckItem: React.FC<{
+const RosterCheckItem: React.FC<{
+  roster: ClassRoster;
   checked: boolean;
-  label: string;
   onToggle: () => void;
-}> = ({ checked, label, onToggle }) => (
-  <label className="flex items-center gap-2 cursor-pointer hover:bg-slate-50 rounded px-1.5 py-1">
-    <span
-      aria-hidden="true"
-      className={`flex items-center justify-center w-4 h-4 rounded border transition-colors ${
-        checked
-          ? 'bg-brand-blue-primary border-brand-blue-primary text-white'
-          : 'bg-white border-slate-300'
-      }`}
-    >
-      {checked && <Check className="w-3 h-3" strokeWidth={3} />}
-    </span>
-    <input
-      type="checkbox"
-      className="sr-only"
-      checked={checked}
-      onChange={onToggle}
-    />
-    <span className="text-sm text-slate-800">{label}</span>
-  </label>
-);
+}> = ({ roster, checked, onToggle }) => {
+  const isClassLink = Boolean(roster.classlinkClassId);
+  const badgeTitle = isClassLink
+    ? [roster.classlinkSubject, roster.classlinkClassCode]
+        .filter(Boolean)
+        .join(' · ') || 'Imported from ClassLink'
+    : undefined;
+
+  return (
+    <label className="flex items-center gap-2 cursor-pointer hover:bg-slate-50 rounded px-1.5 py-1">
+      <span
+        aria-hidden="true"
+        className={`flex items-center justify-center w-4 h-4 rounded border transition-colors ${
+          checked
+            ? 'bg-brand-blue-primary border-brand-blue-primary text-white'
+            : 'bg-white border-slate-300'
+        }`}
+      >
+        {checked && <Check className="w-3 h-3" strokeWidth={3} />}
+      </span>
+      <input
+        type="checkbox"
+        className="sr-only"
+        checked={checked}
+        onChange={onToggle}
+      />
+      <span className="text-sm text-slate-800 flex-1 truncate">
+        {roster.name}
+      </span>
+      {isClassLink && (
+        <span
+          className="shrink-0 inline-flex items-center gap-0.5 text-[9px] font-bold uppercase tracking-wider px-1.5 py-0.5 rounded bg-brand-blue-lighter text-brand-blue-dark border border-brand-blue-light"
+          title={badgeTitle}
+        >
+          <Link2 className="w-2.5 h-2.5" />
+          CL
+        </span>
+      )}
+    </label>
+  );
+};
 
 const EmptyStub: React.FC<{ message: string }> = ({ message }) => (
   <p className="text-xxs text-slate-500 rounded-lg border border-dashed border-slate-200 bg-slate-50 px-3 py-2">

--- a/components/common/AssignClassPicker.tsx
+++ b/components/common/AssignClassPicker.tsx
@@ -39,7 +39,11 @@ export const AssignClassPicker: React.FC<AssignClassPickerProps> = ({
   };
 
   const selectAll = (): void => {
-    onChange({ rosterIds: rosters.map((r) => r.id) });
+    // Skip rosters whose Drive students failed to load — selecting them
+    // would produce a session with zero PINs that nobody can join.
+    onChange({
+      rosterIds: rosters.filter((r) => !r.loadError).map((r) => r.id),
+    });
   };
 
   const clearAll = (): void => {
@@ -56,11 +60,15 @@ export const AssignClassPicker: React.FC<AssignClassPickerProps> = ({
       }
     >
       <div className="flex items-center gap-2">
-        <Users className="w-4 h-4 text-brand-blue-primary" />
-        <label className="text-sm font-bold text-brand-blue-dark">
+        <Users
+          aria-hidden="true"
+          focusable="false"
+          className="w-4 h-4 text-brand-blue-primary"
+        />
+        <p className="text-sm font-bold text-brand-blue-dark">
           Assign to classes{' '}
           <span className="text-slate-400 font-normal">(optional)</span>
-        </label>
+        </p>
       </div>
 
       {rosters.length === 0 ? (
@@ -128,9 +136,20 @@ const RosterCheckItem: React.FC<{
         .filter(Boolean)
         .join(' · ') || 'Imported from ClassLink'
     : undefined;
+  // Rosters whose Drive students failed to load produce sessions with zero
+  // PINs that no student can join. Disable selection and surface the reason
+  // inline so teachers aren't surprised by a broken assignment later.
+  const disabled = Boolean(roster.loadError);
 
   return (
-    <label className="flex items-center gap-2 cursor-pointer hover:bg-slate-50 rounded px-1.5 py-1">
+    <label
+      className={`flex items-center gap-2 rounded px-1.5 py-1 ${
+        disabled
+          ? 'cursor-not-allowed opacity-50'
+          : 'cursor-pointer hover:bg-slate-50'
+      }`}
+      title={disabled ? roster.loadError : undefined}
+    >
       <span
         aria-hidden="true"
         className={`flex items-center justify-center w-4 h-4 rounded border transition-colors ${
@@ -145,17 +164,23 @@ const RosterCheckItem: React.FC<{
         type="checkbox"
         className="sr-only"
         checked={checked}
+        disabled={disabled}
         onChange={onToggle}
       />
       <span className="text-sm text-slate-800 flex-1 truncate">
         {roster.name}
       </span>
+      {disabled && (
+        <span className="shrink-0 text-[9px] font-bold uppercase tracking-wider text-red-500">
+          Unavailable
+        </span>
+      )}
       {isClassLink && (
         <span
           className="shrink-0 inline-flex items-center gap-0.5 text-[9px] font-bold uppercase tracking-wider px-1.5 py-0.5 rounded bg-brand-blue-lighter text-brand-blue-dark border border-brand-blue-light"
           title={badgeTitle}
         >
-          <Link2 className="w-2.5 h-2.5" />
+          <Link2 aria-hidden="true" focusable="false" className="w-2.5 h-2.5" />
           CL
         </span>
       )}

--- a/components/layout/sidebar/SidebarClasses.tsx
+++ b/components/layout/sidebar/SidebarClasses.tsx
@@ -279,27 +279,50 @@ export const SidebarClasses: React.FC<SidebarClassesProps> = ({
                               >
                                 <Pencil className="w-3.5 h-3.5" />
                               </button>
-                              {classLinkEnabled && (
-                                <button
-                                  onClick={() =>
-                                    setClassLinkMode({
-                                      kind: 'merge',
-                                      rosterId: r.id,
-                                      rosterName: r.name,
-                                    })
-                                  }
-                                  className="p-1.5 text-slate-400 hover:text-brand-blue-primary hover:bg-brand-blue-lighter rounded-lg transition-colors"
-                                  title={t('sidebar.classes.syncClassLink', {
-                                    defaultValue: 'Sync with ClassLink',
-                                  })}
-                                  aria-label={t(
-                                    'sidebar.classes.syncClassLink',
-                                    { defaultValue: 'Sync with ClassLink' }
-                                  )}
-                                >
-                                  <RefreshCw className="w-3.5 h-3.5" />
-                                </button>
-                              )}
+                              {classLinkEnabled &&
+                                (() => {
+                                  // Rosters whose students carry
+                                  // `classLinkSourcedId` but whose doc lacks
+                                  // `classlinkClassId` predate the unified
+                                  // metadata and are invisible to the student
+                                  // SSO gate. Surface an amber dot on Sync so
+                                  // the teacher knows to re-sync — the merge
+                                  // handler now backfills metadata for them.
+                                  const needsBackfill =
+                                    !r.classlinkClassId &&
+                                    r.students.some(
+                                      (s) => s.classLinkSourcedId
+                                    );
+                                  const syncLabel = needsBackfill
+                                    ? t('sidebar.classes.linkClassLink', {
+                                        defaultValue: 'Link to ClassLink class',
+                                      })
+                                    : t('sidebar.classes.syncClassLink', {
+                                        defaultValue: 'Sync with ClassLink',
+                                      });
+                                  return (
+                                    <button
+                                      onClick={() =>
+                                        setClassLinkMode({
+                                          kind: 'merge',
+                                          rosterId: r.id,
+                                          rosterName: r.name,
+                                        })
+                                      }
+                                      className="relative p-1.5 text-slate-400 hover:text-brand-blue-primary hover:bg-brand-blue-lighter rounded-lg transition-colors"
+                                      title={syncLabel}
+                                      aria-label={syncLabel}
+                                    >
+                                      <RefreshCw className="w-3.5 h-3.5" />
+                                      {needsBackfill && (
+                                        <span
+                                          aria-hidden="true"
+                                          className="absolute top-1 right-1 w-1.5 h-1.5 rounded-full bg-amber-500"
+                                        />
+                                      )}
+                                    </button>
+                                  );
+                                })()}
                               <button
                                 onClick={() => void handleDelete(r)}
                                 className="p-1.5 text-slate-400 hover:text-red-500 hover:bg-red-50 rounded-lg transition-colors"

--- a/components/widgets/GuidedLearning/Widget.tsx
+++ b/components/widgets/GuidedLearning/Widget.tsx
@@ -21,7 +21,10 @@ import {
   makeEmptyPickerValue,
   type AssignClassPickerValue,
 } from '@/components/common/AssignClassPicker.helpers';
-import { deriveSessionTargetsFromRosters } from '@/utils/resolveAssignmentTargets';
+import {
+  deriveSessionTargetsFromRosters,
+  mapLegacyClassIdsToRosterIds,
+} from '@/utils/resolveAssignmentTargets';
 import { GuidedLearningManager } from './components/GuidedLearningManager';
 import { GuidedLearningEditorModal } from './components/GuidedLearningEditorModal';
 import { GuidedLearningPlayer } from './components/GuidedLearningPlayer';
@@ -123,8 +126,23 @@ export const GuidedLearningWidget: React.FC<{ widget: WidgetData }> = ({
   if (assignTarget !== prevAssignTarget) {
     setPrevAssignTarget(assignTarget);
     if (assignTarget) {
-      const rememberedRosters =
+      // Prefer unified roster memory; fall back to legacy ClassLink-sourcedId
+      // maps so teachers upgrading from pre-unification configs don't lose
+      // their per-set preselection on first launch.
+      let rememberedRosters =
         config.lastRosterIdsBySetId?.[assignTarget.originSetId] ?? [];
+      if (rememberedRosters.length === 0) {
+        const legacyMulti =
+          config.lastClassIdsBySetId?.[assignTarget.originSetId];
+        const legacySingle =
+          config.lastClassIdBySetId?.[assignTarget.originSetId];
+        const legacyClassIds =
+          legacyMulti ?? (legacySingle ? [legacySingle] : undefined);
+        rememberedRosters = mapLegacyClassIdsToRosterIds(
+          legacyClassIds,
+          rosters
+        );
+      }
       setPickerValue({ rosterIds: rememberedRosters });
     }
   }

--- a/components/widgets/GuidedLearning/Widget.tsx
+++ b/components/widgets/GuidedLearning/Widget.tsx
@@ -1,8 +1,7 @@
-import React, { useState, useCallback, useEffect, useMemo } from 'react';
+import React, { useState, useCallback, useMemo } from 'react';
 import { doc, writeBatch } from 'firebase/firestore';
 import {
   WidgetData,
-  ClassLinkClass,
   GuidedLearningConfig,
   GuidedLearningSet,
   GuidedLearningSetMetadata,
@@ -15,15 +14,14 @@ import { useGuidedLearning } from '@/hooks/useGuidedLearning';
 import { useGuidedLearningSessionTeacher } from '@/hooks/useGuidedLearningSession';
 import { useGuidedLearningAssignments } from '@/hooks/useGuidedLearningAssignments';
 import { useFolders } from '@/hooks/useFolders';
-import { classLinkService } from '@/utils/classlinkService';
 import { WidgetLayout } from '@/components/widgets/WidgetLayout';
 import { AssignModal } from '@/components/common/library';
 import { AssignClassPicker } from '@/components/common/AssignClassPicker';
 import {
-  formatClassLinkClassLabel,
   makeEmptyPickerValue,
   type AssignClassPickerValue,
 } from '@/components/common/AssignClassPicker.helpers';
+import { deriveSessionTargetsFromRosters } from '@/utils/resolveAssignmentTargets';
 import { GuidedLearningManager } from './components/GuidedLearningManager';
 import { GuidedLearningEditorModal } from './components/GuidedLearningEditorModal';
 import { GuidedLearningPlayer } from './components/GuidedLearningPlayer';
@@ -103,46 +101,19 @@ export const GuidedLearningWidget: React.FC<{ widget: WidgetData }> = ({
     Record<string, string>
   >({});
 
-  // ─── ClassLink target-class fetch (Phase 3C) ────────────────────────────────
-  // Teacher's ClassLink classes (if provisioned). Fetched once per Widget
-  // mount via the shared `classLinkService` (5-min cache). If the teacher
-  // isn't on a ClassLink-provisioned org, the list stays empty and the
-  // Assign dialog is skipped entirely. Errors are swallowed: ClassLink
-  // being unreachable must not block classic join-link launches.
-  const [classLinkClasses, setClassLinkClasses] = useState<ClassLinkClass[]>(
-    []
-  );
-  useEffect(() => {
-    let cancelled = false;
-    void (async () => {
-      try {
-        const data = await classLinkService.getRosters();
-        if (cancelled) return;
-        setClassLinkClasses(data.classes);
-      } catch (err) {
-        // Silent: no-ClassLink orgs and transient failures both fall back
-        // to classic join-link-only launches, so the selector stays hidden.
-        if (import.meta.env.DEV) {
-          console.warn('[GuidedLearning] ClassLink fetch failed:', err);
-        }
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, []);
+  // Live ClassLink fetching is no longer performed at assign time; imported
+  // ClassLink rosters carry their own `classlinkClassId` metadata so the
+  // student SSO gate resolves purely from rosters. Live ClassLink data is
+  // reached only via the Classes sidebar's Import dialog.
 
-  // ─── Assign dialog state (Phase 3C, Phase 5A multi-class) ─────────────────
+  // ─── Assign dialog state ─────────────────────────────────────────────────
   // When a teacher clicks "Assign", we pause to let them optionally pick
-  // target classes (ClassLink) or period rosters (local) before actually
-  // creating the session. `assignTarget` holds the already-loaded set along
-  // with the source hint so we can create the assignment doc after
-  // confirmation.
+  // target rosters before actually creating the session.
   const [assignTarget, setAssignTarget] = useState<AssignDialogTarget | null>(
     null
   );
   const [pickerValue, setPickerValue] = useState<AssignClassPickerValue>(() =>
-    makeEmptyPickerValue('classlink')
+    makeEmptyPickerValue()
   );
 
   // Reset the picker when the dialog re-opens for a different set
@@ -152,17 +123,9 @@ export const GuidedLearningWidget: React.FC<{ widget: WidgetData }> = ({
   if (assignTarget !== prevAssignTarget) {
     setPrevAssignTarget(assignTarget);
     if (assignTarget) {
-      const rememberedMulti =
-        config.lastClassIdsBySetId?.[assignTarget.originSetId];
-      const rememberedSingle =
-        config.lastClassIdBySetId?.[assignTarget.originSetId];
-      const classIds =
-        rememberedMulti ?? (rememberedSingle ? [rememberedSingle] : []);
-      setPickerValue(
-        classIds.length > 0
-          ? { source: 'classlink', classIds, periodNames: [] }
-          : makeEmptyPickerValue('classlink')
-      );
+      const rememberedRosters =
+        config.lastRosterIdsBySetId?.[assignTarget.originSetId] ?? [];
+      setPickerValue({ rosterIds: rememberedRosters });
     }
   }
 
@@ -270,11 +233,17 @@ export const GuidedLearningWidget: React.FC<{ widget: WidgetData }> = ({
       data: GuidedLearningSet,
       source: 'personal' | 'building',
       originSetId: string,
-      classIds: string[],
-      periodNames: string[]
+      rosterIds: string[]
     ) => {
       try {
-        const url = await createSession(data, classIds, periodNames);
+        const selectedRosters = rosters.filter((r) => rosterIds.includes(r.id));
+        const derived = deriveSessionTargetsFromRosters(selectedRosters);
+        const url = await createSession(
+          data,
+          derived.classIds,
+          derived.periodNames,
+          derived.rosterIds
+        );
         const sessionId = url.split('/').pop() ?? '';
         setRecentSessionIds((prev) => ({
           ...prev,
@@ -287,28 +256,24 @@ export const GuidedLearningWidget: React.FC<{ widget: WidgetData }> = ({
               setId: data.id,
               setTitle: data.title,
               source,
+              rosterIds: derived.rosterIds,
             });
           } catch (err) {
             console.warn('[GuidedLearning] Failed to record assignment:', err);
           }
         }
-        // Persist the teacher's last-used ClassLink selection per set.
-        const prevMap = config.lastClassIdsBySetId ?? {};
+        // Persist the teacher's last-used roster selection per set.
+        const prevMap = config.lastRosterIdsBySetId ?? {};
         const nextMap: Record<string, string[]> = { ...prevMap };
-        if (classIds.length > 0) {
-          nextMap[originSetId] = classIds;
+        if (rosterIds.length > 0) {
+          nextMap[originSetId] = rosterIds;
         } else {
           delete nextMap[originSetId];
         }
-        // Drop any legacy single-class entry.
-        const prevLegacyMap = config.lastClassIdBySetId ?? {};
-        const nextLegacyMap: Record<string, string> = { ...prevLegacyMap };
-        delete nextLegacyMap[originSetId];
         updateWidget(widget.id, {
           config: {
             ...config,
-            lastClassIdsBySetId: nextMap,
-            lastClassIdBySetId: nextLegacyMap,
+            lastRosterIdsBySetId: nextMap,
           } as GuidedLearningConfig,
         });
         await navigator.clipboard.writeText(url);
@@ -319,7 +284,15 @@ export const GuidedLearningWidget: React.FC<{ widget: WidgetData }> = ({
         addToast(msg, 'error');
       }
     },
-    [createSession, createAssignment, addToast, config, updateWidget, widget.id]
+    [
+      rosters,
+      createSession,
+      createAssignment,
+      addToast,
+      config,
+      updateWidget,
+      widget.id,
+    ]
   );
 
   const handleAssign = async (
@@ -332,42 +305,27 @@ export const GuidedLearningWidget: React.FC<{ widget: WidgetData }> = ({
     const source: 'personal' | 'building' = buildingSet
       ? 'building'
       : 'personal';
-    // If the teacher has neither ClassLink nor local rosters, skip the
-    // dialog entirely and preserve the classic join-link flow.
-    if (classLinkClasses.length === 0 && rosters.length === 0) {
-      await performAssign(data, source, setId, [], []);
+    // If the teacher has no rosters at all, skip the dialog entirely and
+    // preserve the classic join-link flow.
+    if (rosters.length === 0) {
+      await performAssign(data, source, setId, []);
       return;
     }
-    // Otherwise open the dialog so they can optionally pick targets.
+    // Otherwise open the dialog so they can optionally pick rosters.
     setAssignTarget({ set: data, source, originSetId: setId });
   };
 
   const handleAssignConfirm = async (): Promise<void> => {
     if (!assignTarget) return;
-    // Guard: filter stale sourcedIds that aren't in the latest ClassLink
-    // list. Local roster names fall through unchanged.
-    const validClassIds =
-      pickerValue.source === 'classlink'
-        ? pickerValue.classIds.filter((id) =>
-            classLinkClasses.some((c) => c.sourcedId === id)
-          )
-        : [];
-    const selectedPeriodNames =
-      pickerValue.source === 'classlink'
-        ? validClassIds
-            .map((id) => classLinkClasses.find((c) => c.sourcedId === id))
-            .filter((cls): cls is ClassLinkClass => Boolean(cls))
-            .map(formatClassLinkClassLabel)
-        : pickerValue.periodNames;
+    // Guard against stale selections — rosters can be deleted between the
+    // teacher's last assignment and the current one.
+    const visibleRosterIds = new Set(rosters.map((r) => r.id));
+    const validRosterIds = pickerValue.rosterIds.filter((id) =>
+      visibleRosterIds.has(id)
+    );
     const { set, source, originSetId } = assignTarget;
     setAssignTarget(null);
-    await performAssign(
-      set,
-      source,
-      originSetId,
-      validClassIds,
-      selectedPeriodNames
-    );
+    await performAssign(set, source, originSetId, validRosterIds);
   };
 
   const handleViewResultsForRecent = async (sessionId: string) => {
@@ -666,7 +624,6 @@ export const GuidedLearningWidget: React.FC<{ widget: WidgetData }> = ({
           onOptionsChange={setPickerValue}
           extraSlot={
             <AssignClassPicker
-              classLinkClasses={classLinkClasses}
               rosters={rosters}
               value={pickerValue}
               onChange={setPickerValue}

--- a/components/widgets/GuidedLearning/Widget.tsx
+++ b/components/widgets/GuidedLearning/Widget.tsx
@@ -335,9 +335,11 @@ export const GuidedLearningWidget: React.FC<{ widget: WidgetData }> = ({
 
   const handleAssignConfirm = async (): Promise<void> => {
     if (!assignTarget) return;
-    // Guard against stale selections — rosters can be deleted between the
-    // teacher's last assignment and the current one.
-    const visibleRosterIds = new Set(rosters.map((r) => r.id));
+    // Guard against stale rosterIds — rosters can be deleted or fail to
+    // load (`loadError`) after the teacher's last assignment.
+    const visibleRosterIds = new Set(
+      rosters.filter((r) => !r.loadError).map((r) => r.id)
+    );
     const validRosterIds = pickerValue.rosterIds.filter((id) =>
       visibleRosterIds.has(id)
     );

--- a/components/widgets/MiniApp/Widget.tsx
+++ b/components/widgets/MiniApp/Widget.tsx
@@ -1,10 +1,4 @@
-import React, {
-  useState,
-  useRef,
-  useEffect,
-  useCallback,
-  useMemo,
-} from 'react';
+import React, { useState, useRef, useEffect, useCallback } from 'react';
 import { useDashboard } from '@/context/useDashboard';
 import {
   MiniAppItem,
@@ -12,7 +6,6 @@ import {
   GlobalMiniAppItem,
   MiniAppAssignment,
   WidgetComponentProps,
-  ClassLinkClass,
 } from '@/types';
 import {
   LayoutGrid,
@@ -25,9 +18,7 @@ import {
   Loader2,
   CheckCircle2,
   ExternalLink,
-  Users,
 } from 'lucide-react';
-import { classLinkService } from '@/utils/classlinkService';
 import { WidgetLayout } from '../WidgetLayout';
 import { useAuth } from '@/context/useAuth';
 import { useMiniAppSessionTeacher } from '@/hooks/useMiniAppSession';
@@ -36,12 +27,18 @@ import { useFolders } from '@/hooks/useFolders';
 import {
   collection,
   doc,
-  getDocs,
   setDoc,
   deleteDoc,
   writeBatch,
 } from 'firebase/firestore';
 import { db } from '@/config/firebase';
+import { AssignClassPicker } from '@/components/common/AssignClassPicker';
+import {
+  makeEmptyPickerValue,
+  resolveSelectedRosters,
+  type AssignClassPickerValue,
+} from '@/components/common/AssignClassPicker.helpers';
+import { deriveSessionTargetsFromRosters } from '@/utils/resolveAssignmentTargets';
 import { MiniAppEditorModal } from './components/MiniAppEditorModal';
 import { AssignmentsModal } from './components/AssignmentsModal';
 import { MiniAppManager } from './components/MiniAppManager';
@@ -64,26 +61,15 @@ interface MiniAppAssignModalProps {
   error: string | null;
   onConfirm: () => void;
   onClose: () => void;
-  /** ClassLink classes for the target-class picker. Hidden when empty. */
-  classLinkClasses: ClassLinkClass[];
-  /** Currently-selected ClassLink class sourcedIds (multi-select). */
-  selectedClassIds: string[];
-  onSelectedClassIdsChange: (next: string[]) => void;
+  /** Rosters available for targeting (unified picker). */
+  rosters: import('@/types').ClassRoster[];
+  /** Current picker selection. */
+  pickerValue: AssignClassPickerValue;
+  onPickerChange: (next: AssignClassPickerValue) => void;
   /** Whether submissions are enabled (Submit button shown, writes allowed). */
   submissionsEnabled: boolean;
   onSubmissionsEnabledChange: (next: boolean) => void;
 }
-
-/**
- * Human-readable label for a ClassLink class. Mirrors the format used by
- * `QuizManager` / `ActivityWallWidget` / etc. so teachers see the same class
- * names across every assignment-targeting flow.
- */
-const formatClassLinkClassLabel = (cls: ClassLinkClass): string => {
-  const subjectPrefix = cls.subject ? `${cls.subject} - ` : '';
-  const codeSuffix = cls.classCode ? ` (${cls.classCode})` : '';
-  return `${subjectPrefix}${cls.title}${codeSuffix}`;
-};
 
 const MiniAppAssignModal: React.FC<MiniAppAssignModalProps> = ({
   appTitle,
@@ -94,21 +80,12 @@ const MiniAppAssignModal: React.FC<MiniAppAssignModalProps> = ({
   error,
   onConfirm,
   onClose,
-  classLinkClasses,
-  selectedClassIds,
-  onSelectedClassIdsChange,
+  rosters,
+  pickerValue,
+  onPickerChange,
   submissionsEnabled,
   onSubmissionsEnabledChange,
 }) => {
-  const toggleClassId = (sourcedId: string) => {
-    if (selectedClassIds.includes(sourcedId)) {
-      onSelectedClassIdsChange(
-        selectedClassIds.filter((id) => id !== sourcedId)
-      );
-    } else {
-      onSelectedClassIdsChange([...selectedClassIds, sourcedId]);
-    }
-  };
   const link = createdSessionId
     ? `${window.location.origin}/miniapp/${createdSessionId}`
     : null;
@@ -224,41 +201,17 @@ const MiniAppAssignModal: React.FC<MiniAppAssignModalProps> = ({
                   className="w-full rounded-xl border border-slate-200 px-3 py-2 text-sm font-medium text-slate-700 outline-none focus:border-brand-blue-primary"
                 />
               </div>
-              {classLinkClasses.length > 0 && (
-                <div className="bg-slate-50 border border-slate-200 rounded-xl p-3">
-                  <div className="flex items-center gap-2 mb-1.5">
-                    <Users className="w-4 h-4 text-brand-blue-primary" />
-                    <span className="text-sm font-bold text-slate-700">
-                      Target classes (optional)
-                    </span>
-                  </div>
-                  <div className="max-h-40 overflow-y-auto flex flex-col gap-1.5 pr-1">
-                    {classLinkClasses.map((cls) => {
-                      const checked = selectedClassIds.includes(cls.sourcedId);
-                      return (
-                        <label
-                          key={cls.sourcedId}
-                          className="flex items-center gap-2 text-sm text-slate-700 cursor-pointer rounded-lg px-2 py-1 hover:bg-white"
-                        >
-                          <input
-                            type="checkbox"
-                            checked={checked}
-                            onChange={() => toggleClassId(cls.sourcedId)}
-                            className="w-4 h-4 accent-brand-blue-primary"
-                          />
-                          <span className="truncate">
-                            {formatClassLinkClassLabel(cls)}
-                          </span>
-                        </label>
-                      );
-                    })}
-                  </div>
-                  <p className="text-[11px] text-slate-500 mt-2">
-                    Enrolled students will see this in their assignments list.
-                    Leave all boxes unchecked to share a link directly.
-                  </p>
-                </div>
-              )}
+              <div className="bg-slate-50 border border-slate-200 rounded-xl p-3">
+                <AssignClassPicker
+                  rosters={rosters}
+                  value={pickerValue}
+                  onChange={onPickerChange}
+                />
+                <p className="text-[11px] text-slate-500 mt-2">
+                  Enrolled students will see this in their assignments list.
+                  Leave unselected to share the link directly.
+                </p>
+              </div>
               <div className="bg-slate-50 border border-slate-200 rounded-xl p-3">
                 <span className="block text-sm font-bold text-slate-700 mb-2">
                   Submissions
@@ -323,24 +276,8 @@ export const MiniAppWidget: React.FC<WidgetComponentProps> = ({
   widget,
   isStudentView,
 }) => {
-  const { updateWidget, addToast } = useDashboard();
-  const { user, userRoles, orgId, roleId } = useAuth();
-  // Gate testClasses read on the same role check the Firestore rules enforce
-  // (`isSuperAdmin() || isDomainAdmin(orgId)`) rather than the legacy
-  // `/admins/` membership flag. Building admins appear in `/admins/` in some
-  // deployments — querying on that flag would trigger a permission-denied
-  // round-trip for them. See `resolveActorRole` in OrganizationPanel for the
-  // reference pattern.
-  const isSuperAdminByEmail = Boolean(
-    user?.email &&
-    userRoles?.superAdmins?.some(
-      (e) => e.toLowerCase() === user.email?.toLowerCase()
-    )
-  );
-  const canReadTestClasses =
-    isSuperAdminByEmail ||
-    roleId === 'super_admin' ||
-    roleId === 'domain_admin';
+  const { updateWidget, addToast, rosters } = useDashboard();
+  const { user } = useAuth();
   const { showConfirm } = useDialog();
   const config = (widget.config ?? {}) as MiniAppConfig;
   const activeApp = config.activeApp ?? null;
@@ -378,85 +315,12 @@ export const MiniAppWidget: React.FC<WidgetComponentProps> = ({
   const [isCreatingSession, setIsCreatingSession] = useState(false);
   const [createdSessionId, setCreatedSessionId] = useState<string | null>(null);
   const [assignError, setAssignError] = useState<string | null>(null);
-  const [assignTargetClassIds, setAssignTargetClassIds] = useState<string[]>(
-    []
-  );
+  const [assignPickerValue, setAssignPickerValue] =
+    useState<AssignClassPickerValue>(makeEmptyPickerValue());
   const [assignSubmissionsEnabled, setAssignSubmissionsEnabled] =
     useState(false);
   const [assignmentsForApp, setAssignmentsForApp] =
     useState<MiniAppItem | null>(null);
-
-  // ─── ClassLink target-class fetch (Phase 3E) ────────────────────────────────
-  // Fetched once per widget mount via the shared classLinkService (5-min
-  // cache). Hidden entirely when the teacher isn't on a ClassLink-provisioned
-  // org. Errors are swallowed: ClassLink being unreachable must not block
-  // shareable-link launches.
-  const [classLinkClasses, setClassLinkClasses] = useState<ClassLinkClass[]>(
-    []
-  );
-  const [testClasses, setTestClasses] = useState<ClassLinkClass[]>([]);
-
-  // ClassLink roster fetch runs once per mount and does not depend on admin
-  // state — splitting it from the test-class fetch avoids re-issuing the
-  // ClassLink request when `roleId` hydrates from null.
-  useEffect(() => {
-    let cancelled = false;
-    void (async () => {
-      try {
-        const data = await classLinkService.getRosters();
-        if (cancelled) return;
-        setClassLinkClasses(data.classes);
-      } catch (err) {
-        if (import.meta.env.DEV) {
-          console.warn('[MiniAppWidget] ClassLink fetch failed:', err);
-        }
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, []);
-
-  // Test-class fetch is gated on the same role check Firestore rules use.
-  // Skipped when orgId is null — testClasses docs live under a specific org,
-  // so there is no valid query to issue without one.
-  useEffect(() => {
-    if (!canReadTestClasses || !orgId) {
-      setTestClasses([]);
-      return;
-    }
-    let cancelled = false;
-    void (async () => {
-      try {
-        const snap = await getDocs(
-          collection(db, `organizations/${orgId}/testClasses`)
-        );
-        if (cancelled) return;
-        setTestClasses(
-          snap.docs.map((d) => {
-            const data = d.data() as { title?: string; subject?: string };
-            return {
-              sourcedId: d.id,
-              title: `${data.title ?? d.id} (test)`,
-              subject: data.subject,
-            };
-          })
-        );
-      } catch (err) {
-        if (import.meta.env.DEV) {
-          console.warn('[MiniAppWidget] testClasses fetch failed:', err);
-        }
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, [canReadTestClasses, orgId]);
-
-  const mergedClassList = useMemo(
-    () => [...classLinkClasses, ...testClasses],
-    [classLinkClasses, testClasses]
-  );
 
   const buildDefaultAssignmentName = (appTitle: string) => {
     const formatted = new Date().toLocaleString([], {
@@ -473,10 +337,12 @@ export const MiniAppWidget: React.FC<WidgetComponentProps> = ({
     setAssignmentName(buildDefaultAssignmentName(app.title));
     setCreatedSessionId(null);
     setAssignError(null);
-    // Pre-populate the class picker and toggle with whatever the teacher
-    // picked last time for this app, so repeated assignments don't require
-    // re-picking.
-    setAssignTargetClassIds(config.lastClassIdsByAppId?.[app.id] ?? []);
+    // Pre-populate the roster picker with the teacher's last selection for
+    // this app. Only new-shape `lastRosterIdsByAppId` is honored — legacy
+    // `lastClassIdsByAppId` held ClassLink sourcedIds that no longer map
+    // cleanly to the roster-only picker, so those defaults simply reset.
+    const lastRosterIds = config.lastRosterIdsByAppId?.[app.id] ?? [];
+    setAssignPickerValue({ rosterIds: lastRosterIds });
     setAssignSubmissionsEnabled(
       config.lastSubmissionsEnabledByAppId?.[app.id] ?? false
     );
@@ -516,19 +382,28 @@ export const MiniAppWidget: React.FC<WidgetComponentProps> = ({
     setIsCreatingSession(true);
     setAssignError(null);
     try {
-      // Guard against stale selections: the class list refreshes on mount,
-      // and a teacher could have picked classes that have since been removed
-      // from the roster. Drop any sourcedIds we can't still see.
-      const visibleClassIds = new Set(mergedClassList.map((c) => c.sourcedId));
-      const resolvedClassIds = assignTargetClassIds.filter((id) =>
-        visibleClassIds.has(id)
+      // Resolve the picker selection against current rosters — dropped IDs
+      // (e.g., rosters deleted after last assignment) are silently filtered.
+      const selectedRosters = resolveSelectedRosters(
+        assignPickerValue,
+        rosters
       );
+      const derived = deriveSessionTargetsFromRosters(selectedRosters);
+
+      // NOTE ON GATING ASYMMETRY: `mini_app_sessions` Firestore rules use
+      // `passesStudentClassGateList`, which treats an empty `classIds[]` as
+      // "open to any student-role user." This means local-only rosters (no
+      // `classlinkClassId` metadata) still let any SSO student see the
+      // session — matching today's behavior. For the strict-gate collections
+      // (quiz, video activity, guided learning), empty classIds block SSO
+      // students entirely; PIN-joining students still pass.
       const sessionId = await createSession(
         assigningApp,
         user.uid,
         assignmentName,
         {
-          classIds: resolvedClassIds,
+          classIds: derived.classIds,
+          rosterIds: derived.rosterIds,
           submissionsEnabled: assignSubmissionsEnabled,
         }
       );
@@ -540,7 +415,8 @@ export const MiniAppWidget: React.FC<WidgetComponentProps> = ({
           sessionId,
           app: { id: assigningApp.id, title: assigningApp.title },
           assignmentName,
-          classIds: resolvedClassIds,
+          rosterIds: derived.rosterIds,
+          classIds: derived.classIds,
           submissionsEnabled: assignSubmissionsEnabled,
         });
       } catch (archiveErr) {
@@ -551,12 +427,12 @@ export const MiniAppWidget: React.FC<WidgetComponentProps> = ({
       }
       // Remember the teacher's choices for next time.
       try {
-        const prevClasses = config.lastClassIdsByAppId ?? {};
-        const nextClasses: Record<string, string[]> = { ...prevClasses };
-        if (resolvedClassIds.length > 0) {
-          nextClasses[assigningApp.id] = resolvedClassIds;
+        const prevRosters = config.lastRosterIdsByAppId ?? {};
+        const nextRosters: Record<string, string[]> = { ...prevRosters };
+        if (derived.rosterIds.length > 0) {
+          nextRosters[assigningApp.id] = derived.rosterIds;
         } else {
-          delete nextClasses[assigningApp.id];
+          delete nextRosters[assigningApp.id];
         }
         const prevToggle = config.lastSubmissionsEnabledByAppId ?? {};
         const nextToggle: Record<string, boolean> = {
@@ -566,7 +442,7 @@ export const MiniAppWidget: React.FC<WidgetComponentProps> = ({
         updateWidget(widget.id, {
           config: {
             ...config,
-            lastClassIdsByAppId: nextClasses,
+            lastRosterIdsByAppId: nextRosters,
             lastSubmissionsEnabledByAppId: nextToggle,
           } as MiniAppConfig,
         });
@@ -999,9 +875,9 @@ export const MiniAppWidget: React.FC<WidgetComponentProps> = ({
                 isCreating={isCreatingSession}
                 createdSessionId={createdSessionId}
                 error={assignError}
-                classLinkClasses={mergedClassList}
-                selectedClassIds={assignTargetClassIds}
-                onSelectedClassIdsChange={setAssignTargetClassIds}
+                rosters={rosters}
+                pickerValue={assignPickerValue}
+                onPickerChange={setAssignPickerValue}
                 submissionsEnabled={assignSubmissionsEnabled}
                 onSubmissionsEnabledChange={setAssignSubmissionsEnabled}
                 onConfirm={() => void handleConfirmAssign()}
@@ -1009,7 +885,7 @@ export const MiniAppWidget: React.FC<WidgetComponentProps> = ({
                   setAssigningApp(null);
                   setCreatedSessionId(null);
                   setAssignError(null);
-                  setAssignTargetClassIds([]);
+                  setAssignPickerValue(makeEmptyPickerValue());
                   setAssignSubmissionsEnabled(false);
                 }}
               />
@@ -1110,9 +986,9 @@ export const MiniAppWidget: React.FC<WidgetComponentProps> = ({
                 isCreating={isCreatingSession}
                 createdSessionId={createdSessionId}
                 error={assignError}
-                classLinkClasses={mergedClassList}
-                selectedClassIds={assignTargetClassIds}
-                onSelectedClassIdsChange={setAssignTargetClassIds}
+                rosters={rosters}
+                pickerValue={assignPickerValue}
+                onPickerChange={setAssignPickerValue}
                 submissionsEnabled={assignSubmissionsEnabled}
                 onSubmissionsEnabledChange={setAssignSubmissionsEnabled}
                 onConfirm={() => void handleConfirmAssign()}
@@ -1120,7 +996,7 @@ export const MiniAppWidget: React.FC<WidgetComponentProps> = ({
                   setAssigningApp(null);
                   setCreatedSessionId(null);
                   setAssignError(null);
-                  setAssignTargetClassIds([]);
+                  setAssignPickerValue(makeEmptyPickerValue());
                   setAssignSubmissionsEnabled(false);
                 }}
               />

--- a/components/widgets/MiniApp/Widget.tsx
+++ b/components/widgets/MiniApp/Widget.tsx
@@ -420,14 +420,15 @@ export const MiniAppWidget: React.FC<WidgetComponentProps> = ({
       );
       // Mirror the new session into the per-teacher archive so it shows up
       // in the In Progress / Archive tabs. Failures here are non-fatal —
-      // the session itself still exists.
+      // the session itself still exists. NOTE: only roster-level targeting
+      // (`rosterIds`) is mirrored; `classIds` lives on the session doc for
+      // the student SSO gate, matching the Quiz/VA/GL assignment shape.
       try {
         await createAssignment({
           sessionId,
           app: { id: assigningApp.id, title: assigningApp.title },
           assignmentName,
           rosterIds: derived.rosterIds,
-          classIds: derived.classIds,
           submissionsEnabled: assignSubmissionsEnabled,
         });
       } catch (archiveErr) {

--- a/components/widgets/MiniApp/Widget.tsx
+++ b/components/widgets/MiniApp/Widget.tsx
@@ -38,7 +38,10 @@ import {
   resolveSelectedRosters,
   type AssignClassPickerValue,
 } from '@/components/common/AssignClassPicker.helpers';
-import { deriveSessionTargetsFromRosters } from '@/utils/resolveAssignmentTargets';
+import {
+  deriveSessionTargetsFromRosters,
+  mapLegacyClassIdsToRosterIds,
+} from '@/utils/resolveAssignmentTargets';
 import { MiniAppEditorModal } from './components/MiniAppEditorModal';
 import { AssignmentsModal } from './components/AssignmentsModal';
 import { MiniAppManager } from './components/MiniAppManager';
@@ -338,10 +341,16 @@ export const MiniAppWidget: React.FC<WidgetComponentProps> = ({
     setCreatedSessionId(null);
     setAssignError(null);
     // Pre-populate the roster picker with the teacher's last selection for
-    // this app. Only new-shape `lastRosterIdsByAppId` is honored — legacy
-    // `lastClassIdsByAppId` held ClassLink sourcedIds that no longer map
-    // cleanly to the roster-only picker, so those defaults simply reset.
-    const lastRosterIds = config.lastRosterIdsByAppId?.[app.id] ?? [];
+    // this app. Prefer unified roster memory; fall back to the legacy
+    // ClassLink-sourcedId map so teachers upgrading from pre-unification
+    // configs keep their preselection.
+    let lastRosterIds = config.lastRosterIdsByAppId?.[app.id] ?? [];
+    if (lastRosterIds.length === 0) {
+      lastRosterIds = mapLegacyClassIdsToRosterIds(
+        config.lastClassIdsByAppId?.[app.id],
+        rosters
+      );
+    }
     setAssignPickerValue({ rosterIds: lastRosterIds });
     setAssignSubmissionsEnabled(
       config.lastSubmissionsEnabledByAppId?.[app.id] ?? false

--- a/components/widgets/MiniApp/Widget.tsx
+++ b/components/widgets/MiniApp/Widget.tsx
@@ -392,11 +392,13 @@ export const MiniAppWidget: React.FC<WidgetComponentProps> = ({
     setAssignError(null);
     try {
       // Resolve the picker selection against current rosters — dropped IDs
-      // (e.g., rosters deleted after last assignment) are silently filtered.
+      // (deleted) or rosters that failed to load students from Drive
+      // (`loadError`) are silently filtered so we never produce a session
+      // with zero PINs that no student can join.
       const selectedRosters = resolveSelectedRosters(
         assignPickerValue,
         rosters
-      );
+      ).filter((r) => !r.loadError);
       const derived = deriveSessionTargetsFromRosters(selectedRosters);
 
       // NOTE ON GATING ASYMMETRY: `mini_app_sessions` Firestore rules use

--- a/components/widgets/QuizWidget/Widget.tsx
+++ b/components/widgets/QuizWidget/Widget.tsx
@@ -32,6 +32,7 @@ import {
 import { QuizLiveMonitor } from './components/QuizLiveMonitor';
 import { Loader2, AlertTriangle, LogIn } from 'lucide-react';
 import { SCOREBOARD_COLORS } from '@/config/scoreboard';
+import { deriveSessionTargetsFromRosters } from '@/utils/resolveAssignmentTargets';
 
 export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
   const { updateWidget, addWidget, addToast, rosters, activeDashboard } =
@@ -668,10 +669,17 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
           mode,
           plcOptions: PlcOptions,
           sessionOptions: QuizSessionOptions,
-          classIds: string[]
+          rosterIds: string[]
         ) => {
           const data = await loadQuiz(meta);
           if (!data) return;
+          // Derive session targets from selected rosters — `classIds` feeds
+          // the student SSO gate via Firestore rules; `rosterIds` is mirrored
+          // onto both assignment and session for reverse lookup.
+          const selectedRosters = rosters.filter((r) =>
+            rosterIds.includes(r.id)
+          );
+          const derived = deriveSessionTargetsFromRosters(selectedRosters);
           try {
             const { id: assignmentId, code } = await createAssignment(
               {
@@ -691,24 +699,18 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
                 plcSheetUrl: plcOptions.plcSheetUrl,
               },
               'paused',
-              classIds
+              derived.classIds,
+              derived.rosterIds
             );
-            // Persist the teacher's last-used ClassLink classes per quiz so
+            // Persist the teacher's last-used rosters per quiz so
             // re-launching the same quiz pre-selects the same classes.
-            // Clearing removes the entry rather than writing an empty array.
-            const prevMap = config.lastClassIdsByQuizId ?? {};
+            const prevMap = config.lastRosterIdsByQuizId ?? {};
             const nextMap: Record<string, string[]> = { ...prevMap };
-            if (classIds.length > 0) {
-              nextMap[meta.id] = classIds;
+            if (rosterIds.length > 0) {
+              nextMap[meta.id] = rosterIds;
             } else {
               delete nextMap[meta.id];
             }
-            // Also clear the legacy single-class map entry so the picker
-            // doesn't see a stale single-id override after the teacher
-            // explicitly cleared or changed their selection.
-            const prevLegacyMap = config.lastClassIdByQuizId ?? {};
-            const nextLegacyMap: Record<string, string> = { ...prevLegacyMap };
-            delete nextLegacyMap[meta.id];
             updateWidget(widget.id, {
               config: {
                 ...config,
@@ -723,8 +725,7 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
                   plcOptions.periodNames?.[0] ?? plcOptions.periodName ?? '',
                 periodNames: plcOptions.periodNames ?? [],
                 plcSheetUrl: plcOptions.plcSheetUrl ?? '',
-                lastClassIdsByQuizId: nextMap,
-                lastClassIdByQuizId: nextLegacyMap,
+                lastRosterIdsByQuizId: nextMap,
               } as QuizConfig,
             });
             const url = `${window.location.origin}/quiz?code=${code}`;

--- a/components/widgets/QuizWidget/components/QuizManager.tsx
+++ b/components/widgets/QuizWidget/components/QuizManager.tsx
@@ -123,10 +123,13 @@ function resolveEffectivePeriodNames(
 ): string[] {
   if (picker.rosterIds.length === 0) return [];
   const byId = new Map(rosters.map((r) => [r.id, r]));
-  return picker.rosterIds
+  const names = picker.rosterIds
     .map((id) => byId.get(id))
     .filter((r): r is ClassRoster => r !== undefined)
     .map((r) => r.name);
+  // De-dupe — roster names aren't unique, and the student app keys its
+  // post-PIN period picker on the period string.
+  return Array.from(new Set(names));
 }
 
 function buildDefaultAssignOptions(

--- a/components/widgets/QuizWidget/components/QuizManager.tsx
+++ b/components/widgets/QuizWidget/components/QuizManager.tsx
@@ -16,7 +16,7 @@
  * only, not functionality.
  */
 
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import {
   Plus,
   FileUp,
@@ -44,19 +44,16 @@ import {
   CheckSquare,
 } from 'lucide-react';
 import {
-  ClassLinkClass,
   QuizMetadata,
   QuizSessionMode,
   QuizConfig,
   ClassRoster,
   QuizAssignment,
 } from '@/types';
-import { classLinkService } from '@/utils/classlinkService';
 import { type QuizSessionOptions } from '@/hooks/useQuizSession';
 import { Toggle } from '@/components/common/Toggle';
 import { AssignClassPicker } from '@/components/common/AssignClassPicker';
 import {
-  formatClassLinkClassLabel,
   makeEmptyPickerValue,
   type AssignClassPickerValue,
 } from '@/components/common/AssignClassPicker.helpers';
@@ -111,46 +108,34 @@ interface QuizAssignOptions {
   plcMode: boolean;
   teacherName: string;
   plcSheetUrl: string;
-  /**
-   * Unified class-target picker state (Phase 5A). `classIds` is the list of
-   * ClassLink class `sourcedId`s when source === 'classlink'. `periodNames`
-   * is the list of local roster names when source === 'local'. One of the
-   * two is populated at a time — switching source clears the other.
-   */
+  /** Unified roster picker state. */
   picker: AssignClassPickerValue;
 }
 
 /**
- * Resolve the effective class-period labels for a picker value. When the
- * teacher picks ClassLink classes, the labels used for the post-PIN period
- * picker and the PLC Google Sheet export are the ClassLink class titles
- * themselves; when they pick local rosters, the labels are the roster names.
+ * Resolve the effective period-name labels from selected rosters. These
+ * labels drive the post-PIN period picker on the student app and the PLC
+ * Google Sheet export.
  */
 function resolveEffectivePeriodNames(
   picker: AssignClassPickerValue,
-  classLinkClasses: ClassLinkClass[]
+  rosters: ClassRoster[]
 ): string[] {
-  if (picker.source === 'classlink') {
-    return picker.classIds
-      .map((id) => classLinkClasses.find((c) => c.sourcedId === id))
-      .filter((cls): cls is ClassLinkClass => Boolean(cls))
-      .map(formatClassLinkClassLabel);
-  }
-  return picker.periodNames;
+  if (picker.rosterIds.length === 0) return [];
+  const byId = new Map(rosters.map((r) => [r.id, r]));
+  return picker.rosterIds
+    .map((id) => byId.get(id))
+    .filter((r): r is ClassRoster => r !== undefined)
+    .map((r) => r.name);
 }
 
 function buildDefaultAssignOptions(
   config: QuizConfig,
   quizId?: string
 ): QuizAssignOptions {
-  const rememberedMulti = quizId
-    ? (config.lastClassIdsByQuizId?.[quizId] ?? null)
-    : null;
-  const rememberedSingle = quizId
-    ? (config.lastClassIdByQuizId?.[quizId] ?? null)
-    : null;
-  const classIds =
-    rememberedMulti ?? (rememberedSingle ? [rememberedSingle] : []);
+  const rememberedRosters = quizId
+    ? (config.lastRosterIdsByQuizId?.[quizId] ?? [])
+    : [];
   return {
     tabWarningsEnabled: true,
     showResultToStudent: false,
@@ -164,17 +149,9 @@ function buildDefaultAssignOptions(
     teacherName: config.teacherName ?? '',
     plcSheetUrl: config.plcSheetUrl ?? '',
     picker:
-      classIds.length > 0
-        ? { source: 'classlink', classIds, periodNames: [] }
-        : config.periodNames && config.periodNames.length > 0
-          ? { source: 'local', classIds: [], periodNames: config.periodNames }
-          : config.periodName
-            ? {
-                source: 'local',
-                classIds: [],
-                periodNames: [config.periodName],
-              }
-            : makeEmptyPickerValue('classlink'),
+      rememberedRosters.length > 0
+        ? { rosterIds: rememberedRosters }
+        : makeEmptyPickerValue(),
   };
 }
 
@@ -216,12 +193,8 @@ interface QuizManagerProps {
     mode: QuizSessionMode,
     plcOptions: PlcOptions,
     sessionOptions: QuizSessionOptions,
-    /**
-     * Selected ClassLink class `sourcedId`s (Phase 5A multi-class). Empty
-     * array when the teacher chose local rosters or no classes at all —
-     * preserves the classic code/PIN-only flow.
-     */
-    classIds: string[]
+    /** Selected roster IDs (unified picker output). */
+    rosterIds: string[]
   ) => void;
   onResults: (quiz: QuizMetadata) => void;
   onDelete: (quiz: QuizMetadata) => void | Promise<void>;
@@ -378,34 +351,10 @@ export const QuizManager: React.FC<QuizManagerProps> = ({
     }
   }
 
-  // ─── ClassLink target-class fetch (Phase 3A) ──────────────────────────────
-  // Teacher's ClassLink classes (if provisioned). Fetched once per QuizManager
-  // mount via the existing `classLinkService` (5-min cache — cheap). If the
-  // teacher isn't on a ClassLink-provisioned org, the list stays empty and
-  // the selector is hidden entirely. Errors are swallowed: ClassLink being
-  // unreachable must not block code+PIN launches.
-  const [classLinkClasses, setClassLinkClasses] = useState<ClassLinkClass[]>(
-    []
-  );
-  useEffect(() => {
-    let cancelled = false;
-    void (async () => {
-      try {
-        const data = await classLinkService.getRosters();
-        if (cancelled) return;
-        setClassLinkClasses(data.classes);
-      } catch (err) {
-        // Silent: no-ClassLink orgs and transient failures both fall back
-        // to code+PIN-only launches, so the selector stays hidden.
-        if (import.meta.env.DEV) {
-          console.warn('[QuizManager] ClassLink fetch failed:', err);
-        }
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, []);
+  // Live ClassLink fetching is no longer performed at assign time. Imported
+  // ClassLink rosters carry their own `classlinkClassId` metadata so the
+  // student SSO gate resolves purely from rosters; live ClassLink data is
+  // reached only via the Classes sidebar's Import dialog.
 
   // ─── Folder navigation (Wave 3-B-3) ───────────────────────────────────────
   const folderState = useFolders(userId, 'quiz');
@@ -689,18 +638,15 @@ export const QuizManager: React.FC<QuizManagerProps> = ({
   // ─── Assign confirm handler ───────────────────────────────────────────────
   const handleAssignConfirm = (): void => {
     if (!assignTarget || !selectedMode) return;
-    // Guard: filter out any selected classId that's no longer in the fetched
-    // ClassLink list (e.g. rosters changed between fetch and confirm), so we
-    // never write stale sourcedIds.
-    const validClassIds =
-      assignOptions.picker.source === 'classlink'
-        ? assignOptions.picker.classIds.filter((id) =>
-            classLinkClasses.some((c) => c.sourcedId === id)
-          )
-        : [];
+    // Guard against stale rosterIds — rosters can be deleted between the
+    // teacher's last assignment and the current one.
+    const visibleRosterIds = new Set(rosters.map((r) => r.id));
+    const validRosterIds = assignOptions.picker.rosterIds.filter((id) =>
+      visibleRosterIds.has(id)
+    );
     const effectivePeriodNames = resolveEffectivePeriodNames(
-      { ...assignOptions.picker, classIds: validClassIds },
-      classLinkClasses
+      { rosterIds: validRosterIds },
+      rosters
     );
     const plcOptions: PlcOptions = {
       plcMode: assignOptions.plcMode,
@@ -725,7 +671,7 @@ export const QuizManager: React.FC<QuizManagerProps> = ({
       selectedMode,
       plcOptions,
       sessionOptions,
-      validClassIds
+      validRosterIds
     );
     setAssignTarget(null);
     setSelectedMode(null);
@@ -1047,7 +993,6 @@ export const QuizManager: React.FC<QuizManagerProps> = ({
             <AssignExtraSlot
               options={assignOptions}
               onChange={setAssignOptions}
-              classLinkClasses={classLinkClasses}
               rosters={rosters}
             />
           }
@@ -1057,10 +1002,8 @@ export const QuizManager: React.FC<QuizManagerProps> = ({
               onChange={setAssignOptions}
               plcSheetUrlInvalid={plcSheetUrlInvalid}
               effectivePeriodCount={
-                resolveEffectivePeriodNames(
-                  assignOptions.picker,
-                  classLinkClasses
-                ).length
+                resolveEffectivePeriodNames(assignOptions.picker, rosters)
+                  .length
               }
             />
           }
@@ -1329,9 +1272,8 @@ const AssignmentsList: React.FC<{
 const AssignExtraSlot: React.FC<{
   options: QuizAssignOptions;
   onChange: (next: QuizAssignOptions) => void;
-  classLinkClasses: ClassLinkClass[];
   rosters: ClassRoster[];
-}> = ({ options, onChange, classLinkClasses, rosters }) => {
+}> = ({ options, onChange, rosters }) => {
   const update = <K extends keyof QuizAssignOptions>(
     key: K,
     value: QuizAssignOptions[K]
@@ -1340,7 +1282,6 @@ const AssignExtraSlot: React.FC<{
   return (
     <>
       <AssignClassPicker
-        classLinkClasses={classLinkClasses}
         rosters={rosters}
         value={options.picker}
         onChange={(picker) => update('picker', picker)}

--- a/components/widgets/QuizWidget/components/QuizManager.tsx
+++ b/components/widgets/QuizWidget/components/QuizManager.tsx
@@ -57,6 +57,7 @@ import {
   makeEmptyPickerValue,
   type AssignClassPickerValue,
 } from '@/components/common/AssignClassPicker.helpers';
+import { mapLegacyClassIdsToRosterIds } from '@/utils/resolveAssignmentTargets';
 import {
   LibraryShell,
   LibraryToolbar,
@@ -134,11 +135,23 @@ function resolveEffectivePeriodNames(
 
 function buildDefaultAssignOptions(
   config: QuizConfig,
-  quizId?: string
+  quizId: string | undefined,
+  rosters: ClassRoster[]
 ): QuizAssignOptions {
-  const rememberedRosters = quizId
+  // Prefer the unified `lastRosterIdsByQuizId` memory. Fall back to legacy
+  // ClassLink-sourcedId maps (`lastClassIdsByQuizId` / `lastClassIdByQuizId`)
+  // so teachers who upgraded from pre-unification configs don't lose their
+  // per-quiz preselection on first launch.
+  let rememberedRosters = quizId
     ? (config.lastRosterIdsByQuizId?.[quizId] ?? [])
     : [];
+  if (rememberedRosters.length === 0 && quizId) {
+    const legacyMulti = config.lastClassIdsByQuizId?.[quizId];
+    const legacySingle = config.lastClassIdByQuizId?.[quizId];
+    const legacyClassIds =
+      legacyMulti ?? (legacySingle ? [legacySingle] : undefined);
+    rememberedRosters = mapLegacyClassIdsToRosterIds(legacyClassIds, rosters);
+  }
   return {
     tabWarningsEnabled: true,
     showResultToStudent: false,
@@ -339,7 +352,7 @@ export const QuizManager: React.FC<QuizManagerProps> = ({
     null
   );
   const [assignOptions, setAssignOptions] = useState<QuizAssignOptions>(() =>
-    buildDefaultAssignOptions(config)
+    buildDefaultAssignOptions(config, undefined, rosters)
   );
 
   // Reset assign form when modal re-opens (adjust-state-while-rendering)
@@ -350,7 +363,9 @@ export const QuizManager: React.FC<QuizManagerProps> = ({
     setPrevAssignTarget(assignTarget);
     if (assignTarget) {
       setSelectedMode(null);
-      setAssignOptions(buildDefaultAssignOptions(config, assignTarget.id));
+      setAssignOptions(
+        buildDefaultAssignOptions(config, assignTarget.id, rosters)
+      );
     }
   }
 

--- a/components/widgets/QuizWidget/components/QuizManager.tsx
+++ b/components/widgets/QuizWidget/components/QuizManager.tsx
@@ -57,7 +57,10 @@ import {
   makeEmptyPickerValue,
   type AssignClassPickerValue,
 } from '@/components/common/AssignClassPicker.helpers';
-import { mapLegacyClassIdsToRosterIds } from '@/utils/resolveAssignmentTargets';
+import {
+  mapLegacyClassIdsToRosterIds,
+  resolveAssignmentTargets,
+} from '@/utils/resolveAssignmentTargets';
 import {
   LibraryShell,
   LibraryToolbar,
@@ -116,21 +119,14 @@ interface QuizAssignOptions {
 /**
  * Resolve the effective period-name labels from selected rosters. These
  * labels drive the post-PIN period picker on the student app and the PLC
- * Google Sheet export.
+ * Google Sheet export. Delegates to the shared `resolveAssignmentTargets`
+ * so roster lookup + period-name dedup live in one place.
  */
 function resolveEffectivePeriodNames(
   picker: AssignClassPickerValue,
   rosters: ClassRoster[]
 ): string[] {
-  if (picker.rosterIds.length === 0) return [];
-  const byId = new Map(rosters.map((r) => [r.id, r]));
-  const names = picker.rosterIds
-    .map((id) => byId.get(id))
-    .filter((r): r is ClassRoster => r !== undefined)
-    .map((r) => r.name);
-  // De-dupe — roster names aren't unique, and the student app keys its
-  // post-PIN period picker on the period string.
-  return Array.from(new Set(names));
+  return resolveAssignmentTargets(picker, rosters).periodNames;
 }
 
 function buildDefaultAssignOptions(

--- a/components/widgets/QuizWidget/components/QuizManager.tsx
+++ b/components/widgets/QuizWidget/components/QuizManager.tsx
@@ -656,9 +656,14 @@ export const QuizManager: React.FC<QuizManagerProps> = ({
   // ─── Assign confirm handler ───────────────────────────────────────────────
   const handleAssignConfirm = (): void => {
     if (!assignTarget || !selectedMode) return;
-    // Guard against stale rosterIds — rosters can be deleted between the
-    // teacher's last assignment and the current one.
-    const visibleRosterIds = new Set(rosters.map((r) => r.id));
+    // Guard against stale rosterIds — rosters can be deleted or fail to load
+    // (`loadError`) between the teacher's last assignment and the current one.
+    // A roster without students can't produce a joinable session, so treat
+    // `loadError` rosters as unavailable at confirm time in addition to the
+    // picker-side disabled state.
+    const visibleRosterIds = new Set(
+      rosters.filter((r) => !r.loadError).map((r) => r.id)
+    );
     const validRosterIds = assignOptions.picker.rosterIds.filter((id) =>
       visibleRosterIds.has(id)
     );

--- a/components/widgets/VideoActivityWidget/Widget.tsx
+++ b/components/widgets/VideoActivityWidget/Widget.tsx
@@ -360,6 +360,8 @@ export const VideoActivityWidget: React.FC<{ widget: WidgetData }> = ({
           return sessionId;
         }}
         lastRosterIdsByActivityId={config.lastRosterIdsByActivityId}
+        lastClassIdsByActivityId={config.lastClassIdsByActivityId}
+        lastClassIdByActivityId={config.lastClassIdByActivityId}
         onDelete={async (meta) => {
           try {
             await deleteActivity(meta.id, meta.driveFileId);

--- a/components/widgets/VideoActivityWidget/Widget.tsx
+++ b/components/widgets/VideoActivityWidget/Widget.tsx
@@ -29,6 +29,7 @@ import { Creator } from './components/Creator';
 import { Results } from './components/Results';
 import { VideoActivityEditorModal } from './components/VideoActivityEditorModal';
 import { Loader2, AlertTriangle, LogIn } from 'lucide-react';
+import { deriveSessionTargetsFromRosters } from '@/utils/resolveAssignmentTargets';
 
 /**
  * Shared clipboard helper — centralizes the feature-detection + toast flow
@@ -311,47 +312,43 @@ export const VideoActivityWidget: React.FC<{ widget: WidgetData }> = ({
         }}
         defaultSessionSettings={defaultSessionSettings}
         rosters={rosters}
-        onAssign={async (
-          meta,
-          sessionSettings,
-          assignmentName,
-          classIds,
-          selectedPeriodNames
-        ) => {
+        onAssign={async (meta, sessionSettings, assignmentName, rosterIds) => {
           // Use loadActivityData directly to avoid setting loadingActivity
           // which would cause the Manager component to unmount and destroy the modal
           const data = await loadActivityData(meta.driveFileId);
           if (!data) throw new Error('Failed to load activity data');
+          // Resolve rosterIds against the current rosters and derive
+          // ClassLink sourcedIds / period names / students in one shot.
+          const selectedRosters = rosters.filter((r) =>
+            rosterIds.includes(r.id)
+          );
+          const derived = deriveSessionTargetsFromRosters(selectedRosters);
           const sessionId = await createSession(
             data,
             user.uid,
             [],
             sessionSettings,
             assignmentName,
-            classIds,
-            selectedPeriodNames
+            derived.classIds,
+            derived.periodNames,
+            derived.rosterIds
           );
 
-          // Phase 5A: persist per-activity memory of the last ClassLink
-          // target classes so the next launch pre-selects the same set.
-          const prevMap = config.lastClassIdsByActivityId ?? {};
+          // Persist per-activity memory of the last roster selection so
+          // subsequent launches pre-fill the picker.
+          const prevMap = config.lastRosterIdsByActivityId ?? {};
           const nextMap: Record<string, string[]> = { ...prevMap };
-          if (classIds.length > 0) {
-            nextMap[meta.id] = classIds;
+          if (rosterIds.length > 0) {
+            nextMap[meta.id] = rosterIds;
           } else {
             delete nextMap[meta.id];
           }
-          // Drop any legacy single-class entry to avoid stale pre-selection.
-          const prevLegacyMap = config.lastClassIdByActivityId ?? {};
-          const nextLegacyMap: Record<string, string> = { ...prevLegacyMap };
-          delete nextLegacyMap[meta.id];
 
           updateWidget(widget.id, {
             config: {
               ...config,
               resultsSessionId: sessionId,
-              lastClassIdsByActivityId: nextMap,
-              lastClassIdByActivityId: nextLegacyMap,
+              lastRosterIdsByActivityId: nextMap,
             } as VideoActivityConfig,
           });
 
@@ -362,8 +359,7 @@ export const VideoActivityWidget: React.FC<{ widget: WidgetData }> = ({
           });
           return sessionId;
         }}
-        lastClassIdByActivityId={config.lastClassIdByActivityId}
-        lastClassIdsByActivityId={config.lastClassIdsByActivityId}
+        lastRosterIdsByActivityId={config.lastRosterIdsByActivityId}
         onDelete={async (meta) => {
           try {
             await deleteActivity(meta.id, meta.driveFileId);

--- a/components/widgets/VideoActivityWidget/components/VideoActivityManager.tsx
+++ b/components/widgets/VideoActivityWidget/components/VideoActivityManager.tsx
@@ -17,7 +17,7 @@
  *     specific toggles flow through that slot, not by forking the primitive.
  */
 
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import {
   Activity,
   AlertCircle,
@@ -62,7 +62,6 @@ import type {
   LibraryTab,
 } from '@/components/common/library/types';
 import type {
-  ClassLinkClass,
   ClassRoster,
   VideoActivityAssignment,
   VideoActivityAssignmentStatus,
@@ -70,10 +69,8 @@ import type {
   VideoActivitySession,
   VideoActivitySessionSettings,
 } from '@/types';
-import { classLinkService } from '@/utils/classlinkService';
 import { AssignClassPicker } from '@/components/common/AssignClassPicker';
 import {
-  formatClassLinkClassLabel,
   makeEmptyPickerValue,
   type AssignClassPickerValue,
 } from '@/components/common/AssignClassPicker.helpers';
@@ -101,30 +98,16 @@ export interface VideoActivityManagerProps {
     activity: VideoActivityMetadata,
     settings: VideoActivitySessionSettings,
     assignmentName: string,
-    /**
-     * Selected ClassLink class `sourcedId`s (Phase 5A multi-class). Empty
-     * array means the teacher targeted local rosters or no classes at all.
-     */
-    classIds: string[],
-    /**
-     * Selected local-roster period names (Phase 5A). Populated when the
-     * teacher picked local rosters; when they picked ClassLink classes these
-     * are the ClassLink class labels so the post-PIN period picker + any
-     * export respect the teacher's intent.
-     */
-    selectedPeriodNames: string[]
+    /** Selected roster IDs (unified picker output). */
+    rosterIds: string[]
   ) => Promise<string>;
-  /** Local rosters used to populate the "Local rosters" source in the picker. */
+  /** Rosters to populate the picker. */
   rosters: ClassRoster[];
   /**
-   * @deprecated Phase 5A — replaced by `lastClassIdsByActivityId`.
+   * Per-activity memory of the last roster selection. Pre-selects the picker
+   * on re-launch.
    */
-  lastClassIdByActivityId?: Record<string, string>;
-  /**
-   * Multi-class per-activity memory of the last ClassLink classes the
-   * teacher targeted. Pre-selects the picker on re-launch.
-   */
-  lastClassIdsByActivityId?: Record<string, string[]>;
+  lastRosterIdsByActivityId?: Record<string, string[]>;
   /**
    * Optional persistence hook for manual drag-reorder of the library. Drag
    * reordering is only enabled when this callback is provided; otherwise the
@@ -245,8 +228,7 @@ export const VideoActivityManager: React.FC<VideoActivityManagerProps> = ({
   initialLibraryViewMode,
   onLibraryViewModeChange,
   rosters,
-  lastClassIdByActivityId,
-  lastClassIdsByActivityId,
+  lastRosterIdsByActivityId,
 }) => {
   const [tab, setTab] = useState<LibraryTab>('library');
 
@@ -257,10 +239,10 @@ export const VideoActivityManager: React.FC<VideoActivityManagerProps> = ({
     useState<VideoActivitySessionSettings>(defaultSessionSettings);
   const [assignmentName, setAssignmentName] = useState<string>('');
   const [assignError, setAssignError] = useState<string | null>(null);
-  // Phase 5A: unified class-assignment picker state. Source defaults to
-  // ClassLink when any classes are available, otherwise falls back to Local.
+  // Unified roster picker state. Seeded from the per-activity roster memory
+  // on open so repeated assignments don't require re-picking.
   const [pickerValue, setPickerValue] = useState<AssignClassPickerValue>(() =>
-    makeEmptyPickerValue('classlink')
+    makeEmptyPickerValue()
   );
 
   // Adjust state during render when the assign target changes — avoids the
@@ -273,47 +255,18 @@ export const VideoActivityManager: React.FC<VideoActivityManagerProps> = ({
     setAssignOptions(defaultSessionSettings);
     setAssignmentName(buildDefaultAssignmentName(assignTarget.title));
     setAssignError(null);
-    const rememberedMulti = lastClassIdsByActivityId?.[assignTarget.id];
-    const rememberedSingle = lastClassIdByActivityId?.[assignTarget.id];
-    const classIds =
-      rememberedMulti ?? (rememberedSingle ? [rememberedSingle] : []);
-    setPickerValue(
-      classIds.length > 0
-        ? { source: 'classlink', classIds, periodNames: [] }
-        : makeEmptyPickerValue('classlink')
-    );
+    const rememberedRosters =
+      lastRosterIdsByActivityId?.[assignTarget.id] ?? [];
+    setPickerValue({ rosterIds: rememberedRosters });
   } else if (!assignTarget && prevAssignTargetId !== null) {
     setPrevAssignTargetId(null);
   }
 
-  // ─── ClassLink target-class fetch (Phase 3B) ──────────────────────────────
-  // Teacher's ClassLink classes (if provisioned). Fetched once per manager
-  // mount via the existing `classLinkService` (5-min cache — cheap). If the
-  // teacher isn't on a ClassLink-provisioned org, the list stays empty and
-  // the selector is hidden entirely. Errors are swallowed: ClassLink being
-  // unreachable must not block classic join-URL launches.
-  const [classLinkClasses, setClassLinkClasses] = useState<ClassLinkClass[]>(
-    []
-  );
-  useEffect(() => {
-    let cancelled = false;
-    void (async () => {
-      try {
-        const data = await classLinkService.getRosters();
-        if (cancelled) return;
-        setClassLinkClasses(data.classes);
-      } catch (err) {
-        // Silent: no-ClassLink orgs and transient failures both fall back
-        // to join-URL-only launches, so the selector stays hidden.
-        if (import.meta.env.DEV) {
-          console.warn('[VideoActivityManager] ClassLink fetch failed:', err);
-        }
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, []);
+  // NOTE: The legacy `classLinkService.getRosters()` fetch was removed when
+  // the picker moved to roster-only targeting. Imported ClassLink rosters
+  // carry their own metadata (classlinkClassId) so the student SSO gate
+  // still works; live ClassLink data is now reached only via the Import
+  // dialog.
 
   // Delete confirmation state
   const [confirmDeleteActivityId, setConfirmDeleteActivityId] = useState<
@@ -501,28 +454,18 @@ export const VideoActivityManager: React.FC<VideoActivityManagerProps> = ({
       return;
     }
     setAssignError(null);
-    // Guard: filter stale sourcedIds that aren't in the latest ClassLink
-    // list. Selected local-roster names fall through unchanged.
-    const validClassIds =
-      pickerValue.source === 'classlink'
-        ? pickerValue.classIds.filter((id) =>
-            classLinkClasses.some((c) => c.sourcedId === id)
-          )
-        : [];
-    const selectedPeriodNames =
-      pickerValue.source === 'classlink'
-        ? validClassIds
-            .map((id) => classLinkClasses.find((c) => c.sourcedId === id))
-            .filter((cls): cls is ClassLinkClass => Boolean(cls))
-            .map(formatClassLinkClassLabel)
-        : pickerValue.periodNames;
+    // Guard against stale selections — rosters can be deleted after the
+    // teacher's last assignment. Drop any rosterIds that no longer exist.
+    const visibleRosterIds = new Set(rosters.map((r) => r.id));
+    const validRosterIds = pickerValue.rosterIds.filter((id) =>
+      visibleRosterIds.has(id)
+    );
     try {
       await onAssign(
         assignTarget,
         assignOptions,
         assignmentName.trim(),
-        validClassIds,
-        selectedPeriodNames
+        validRosterIds
       );
       setAssignTarget(null);
     } catch (err) {
@@ -1009,7 +952,6 @@ export const VideoActivityManager: React.FC<VideoActivityManagerProps> = ({
           extraSlot={
             <div className="space-y-3">
               <AssignClassPicker
-                classLinkClasses={classLinkClasses}
                 rosters={rosters}
                 value={pickerValue}
                 onChange={setPickerValue}

--- a/components/widgets/VideoActivityWidget/components/VideoActivityManager.tsx
+++ b/components/widgets/VideoActivityWidget/components/VideoActivityManager.tsx
@@ -74,6 +74,7 @@ import {
   makeEmptyPickerValue,
   type AssignClassPickerValue,
 } from '@/components/common/AssignClassPicker.helpers';
+import { mapLegacyClassIdsToRosterIds } from '@/utils/resolveAssignmentTargets';
 
 /* ─── Props ───────────────────────────────────────────────────────────────── */
 
@@ -108,6 +109,14 @@ export interface VideoActivityManagerProps {
    * on re-launch.
    */
   lastRosterIdsByActivityId?: Record<string, string[]>;
+  /**
+   * @deprecated Read-only fallback for pre-unification widget configs.
+   * Holds ClassLink class `sourcedId`s; mapped to rosterIds via
+   * `mapLegacyClassIdsToRosterIds` when `lastRosterIdsByActivityId` is absent.
+   */
+  lastClassIdsByActivityId?: Record<string, string[]>;
+  /** @deprecated See `lastClassIdsByActivityId`. */
+  lastClassIdByActivityId?: Record<string, string>;
   /**
    * Optional persistence hook for manual drag-reorder of the library. Drag
    * reordering is only enabled when this callback is provided; otherwise the
@@ -229,6 +238,8 @@ export const VideoActivityManager: React.FC<VideoActivityManagerProps> = ({
   onLibraryViewModeChange,
   rosters,
   lastRosterIdsByActivityId,
+  lastClassIdsByActivityId,
+  lastClassIdByActivityId,
 }) => {
   const [tab, setTab] = useState<LibraryTab>('library');
 
@@ -255,8 +266,17 @@ export const VideoActivityManager: React.FC<VideoActivityManagerProps> = ({
     setAssignOptions(defaultSessionSettings);
     setAssignmentName(buildDefaultAssignmentName(assignTarget.title));
     setAssignError(null);
-    const rememberedRosters =
-      lastRosterIdsByActivityId?.[assignTarget.id] ?? [];
+    // Prefer unified roster memory; fall back to legacy ClassLink-sourcedId
+    // maps so teachers upgrading from pre-unification configs don't lose
+    // their per-activity preselection on first launch.
+    let rememberedRosters = lastRosterIdsByActivityId?.[assignTarget.id] ?? [];
+    if (rememberedRosters.length === 0) {
+      const legacyMulti = lastClassIdsByActivityId?.[assignTarget.id];
+      const legacySingle = lastClassIdByActivityId?.[assignTarget.id];
+      const legacyClassIds =
+        legacyMulti ?? (legacySingle ? [legacySingle] : undefined);
+      rememberedRosters = mapLegacyClassIdsToRosterIds(legacyClassIds, rosters);
+    }
     setPickerValue({ rosterIds: rememberedRosters });
   } else if (!assignTarget && prevAssignTargetId !== null) {
     setPrevAssignTargetId(null);

--- a/components/widgets/VideoActivityWidget/components/VideoActivityManager.tsx
+++ b/components/widgets/VideoActivityWidget/components/VideoActivityManager.tsx
@@ -474,9 +474,11 @@ export const VideoActivityManager: React.FC<VideoActivityManagerProps> = ({
       return;
     }
     setAssignError(null);
-    // Guard against stale selections — rosters can be deleted after the
-    // teacher's last assignment. Drop any rosterIds that no longer exist.
-    const visibleRosterIds = new Set(rosters.map((r) => r.id));
+    // Guard against stale rosterIds — rosters can be deleted or fail to
+    // load (`loadError`) after the teacher's last assignment.
+    const visibleRosterIds = new Set(
+      rosters.filter((r) => !r.loadError).map((r) => r.id)
+    );
     const validRosterIds = pickerValue.rosterIds.filter((id) =>
       visibleRosterIds.has(id)
     );

--- a/context/DashboardContextValue.ts
+++ b/context/DashboardContextValue.ts
@@ -15,6 +15,7 @@ import {
   GridPosition,
   DrawableObject,
 } from '../types';
+import type { RosterCreateMeta } from '../hooks/useRosters';
 
 export interface AnnotationState {
   objects: DrawableObject[];
@@ -124,7 +125,11 @@ export interface DashboardContextValue {
   // Roster system
   rosters: ClassRoster[];
   activeRosterId: string | null;
-  addRoster: (name: string, students: Student[]) => Promise<string>;
+  addRoster: (
+    name: string,
+    students: Student[],
+    meta?: RosterCreateMeta
+  ) => Promise<string>;
   updateRoster: (id: string, updates: Partial<ClassRoster>) => Promise<void>;
   deleteRoster: (id: string) => Promise<void>;
   setActiveRoster: (id: string | null) => void;

--- a/hooks/useGuidedLearningAssignments.ts
+++ b/hooks/useGuidedLearningAssignments.ts
@@ -42,6 +42,10 @@ export interface CreateAssignmentInput {
   setTitle: string;
   /** Whether the set came from the personal (Drive) or building library. */
   source?: 'personal' | 'building';
+  /** Unified roster targeting (rosters are the single source of truth for
+   *  assignments; ClassLink-imported rosters carry `classlinkClassId` so the
+   *  student SSO gate resolves via session derivation). */
+  rosterIds?: string[];
 }
 
 export interface UseGuidedLearningAssignmentsResult {
@@ -116,6 +120,9 @@ export const useGuidedLearningAssignments = (
     async (input) => {
       if (!userId) throw new Error('Not authenticated');
       const now = Date.now();
+      const rosterIds = (input.rosterIds ?? []).filter(
+        (id): id is string => typeof id === 'string' && id.length > 0
+      );
       const assignment: GuidedLearningAssignment = {
         id: input.sessionId,
         sessionId: input.sessionId,
@@ -127,6 +134,7 @@ export const useGuidedLearningAssignments = (
         updatedAt: now,
         archivedAt: null,
         source: input.source,
+        ...(rosterIds.length > 0 ? { rosterIds } : {}),
       };
       await setDoc(
         doc(db, 'users', userId, GL_ASSIGNMENTS_COLLECTION, input.sessionId),

--- a/hooks/useGuidedLearningSession.ts
+++ b/hooks/useGuidedLearningSession.ts
@@ -146,7 +146,8 @@ export interface UseGuidedLearningSessionTeacherResult {
   createSession: (
     set: GuidedLearningSet,
     classIds?: string[],
-    periodNames?: string[]
+    periodNames?: string[],
+    rosterIds?: string[]
   ) => Promise<string>;
   /** Load responses for a given session ID */
   subscribeToResponses: (sessionId: string) => () => void;
@@ -167,7 +168,8 @@ export const useGuidedLearningSessionTeacher = (
     async (
       set: GuidedLearningSet,
       classIds: string[] = [],
-      periodNames: string[] = []
+      periodNames: string[] = [],
+      rosterIds: string[] = []
     ): Promise<string> => {
       if (!teacherUid) throw new Error('Not authenticated');
 
@@ -188,6 +190,7 @@ export const useGuidedLearningSessionTeacher = (
         // Firestore rules keep gating correctly.
         ...(classIds.length > 0 ? { classIds, classId: classIds[0] } : {}),
         ...(periodNames.length > 0 ? { periodNames } : {}),
+        ...(rosterIds.length > 0 ? { rosterIds } : {}),
       };
 
       await setDoc(doc(db, GL_SESSIONS_COLLECTION, sessionId), session);

--- a/hooks/useGuidedLearningSession.ts
+++ b/hooks/useGuidedLearningSession.ts
@@ -137,11 +137,23 @@ export interface UseGuidedLearningSessionTeacherResult {
   /**
    * Create a new session and return its URL.
    *
-   * `classIds` is the list of ClassLink class `sourcedId`s this session is
-   * targeted at (Phase 5A multi-class). When non-empty, the session doc
-   * stores them on `classIds` (and transitionally mirrors `classIds[0]` to
-   * `classId`). `periodNames` is the list of class-period labels used by
-   * the post-PIN picker on the student app.
+   * Post-unification, `rosterIds` is the canonical input — callers derive
+   * it from the shared `AssignClassPicker` selection. `classIds` and
+   * `periodNames` are the denormalised outputs the caller computes via
+   * `deriveSessionTargetsFromRosters(selectedRosters)`:
+   *
+   * - `classIds`: ClassLink `sourcedId`s drawn from the selected rosters'
+   *   `classlinkClassId` metadata. Drives the student SSO gate
+   *   (`passesStudentClassGate` in firestore.rules). `classIds[0]` is also
+   *   mirrored onto the session's legacy `classId` field so pre-Phase-5A
+   *   rules keep working.
+   * - `periodNames`: roster names (de-duped) used for the student app's
+   *   post-PIN period picker.
+   * - `rosterIds`: written onto the session doc for reverse lookup and
+   *   future migration to a single-source-of-truth roster-only model.
+   *
+   * All three are optional and independent for backwards compatibility
+   * with callers that still target the legacy shapes directly.
    */
   createSession: (
     set: GuidedLearningSet,

--- a/hooks/useMiniAppAssignments.ts
+++ b/hooks/useMiniAppAssignments.ts
@@ -36,12 +36,11 @@ export interface CreateMiniAppAssignmentInput {
   sessionId: string;
   app: Pick<MiniAppItem, 'id' | 'title'>;
   assignmentName: string;
-  /** Roster IDs the teacher targeted (unified picker output). */
+  /** Roster IDs the teacher targeted (unified picker output). Mirrored onto
+   *  the assignment doc to match the Quiz/VA/GL shape so any future filtering
+   *  in the Library shell can key off the assignment list without a
+   *  session-doc join. */
   rosterIds?: string[];
-  /** ClassLink `sourcedId`s derived from the targeted rosters'
-   *  `classlinkClassId`. Written to the session doc so the student SSO gate
-   *  resolves; mirrored onto the assignment for legacy readers. */
-  classIds?: string[];
   /** Whether submissions are enabled for this assignment. Mirrors
    *  MiniAppSession.submissionsEnabled. */
   submissionsEnabled?: boolean;
@@ -117,13 +116,16 @@ export const useMiniAppAssignments = (
       const now = Date.now();
       const trimmedName = input.assignmentName.trim();
 
-      const cleanedClassIds = (input.classIds ?? []).filter(
-        (c): c is string => typeof c === 'string' && c.length > 0
-      );
       const cleanedRosterIds = (input.rosterIds ?? []).filter(
         (r): r is string => typeof r === 'string' && r.length > 0
       );
 
+      // Intentionally do NOT mirror `classIds` onto the assignment doc.
+      // The student SSO gate reads `classIds[]` from the MiniAppSession (see
+      // `mini_app_sessions` Firestore rules); the assignment archive only
+      // needs targeting metadata that teacher-side code actually reads back,
+      // and no caller reads `assignment.classIds`. Matches the Quiz/VA/GL
+      // shape (their assignment docs also store `rosterIds` only).
       const assignment: MiniAppAssignment = {
         id: assignmentId,
         sessionId: input.sessionId,
@@ -138,7 +140,6 @@ export const useMiniAppAssignments = (
         createdAt: now,
         updatedAt: now,
         ...(cleanedRosterIds.length > 0 ? { rosterIds: cleanedRosterIds } : {}),
-        ...(cleanedClassIds.length > 0 ? { classIds: cleanedClassIds } : {}),
         submissionsEnabled: input.submissionsEnabled === true,
       };
 

--- a/hooks/useMiniAppAssignments.ts
+++ b/hooks/useMiniAppAssignments.ts
@@ -36,7 +36,11 @@ export interface CreateMiniAppAssignmentInput {
   sessionId: string;
   app: Pick<MiniAppItem, 'id' | 'title'>;
   assignmentName: string;
-  /** ClassLink class sourcedIds the teacher targeted (multi-select). */
+  /** Roster IDs the teacher targeted (unified picker output). */
+  rosterIds?: string[];
+  /** ClassLink `sourcedId`s derived from the targeted rosters'
+   *  `classlinkClassId`. Written to the session doc so the student SSO gate
+   *  resolves; mirrored onto the assignment for legacy readers. */
   classIds?: string[];
   /** Whether submissions are enabled for this assignment. Mirrors
    *  MiniAppSession.submissionsEnabled. */
@@ -116,6 +120,9 @@ export const useMiniAppAssignments = (
       const cleanedClassIds = (input.classIds ?? []).filter(
         (c): c is string => typeof c === 'string' && c.length > 0
       );
+      const cleanedRosterIds = (input.rosterIds ?? []).filter(
+        (r): r is string => typeof r === 'string' && r.length > 0
+      );
 
       const assignment: MiniAppAssignment = {
         id: assignmentId,
@@ -130,6 +137,7 @@ export const useMiniAppAssignments = (
         status: 'active',
         createdAt: now,
         updatedAt: now,
+        ...(cleanedRosterIds.length > 0 ? { rosterIds: cleanedRosterIds } : {}),
         ...(cleanedClassIds.length > 0 ? { classIds: cleanedClassIds } : {}),
         submissionsEnabled: input.submissionsEnabled === true,
       };

--- a/hooks/useMiniAppSession.ts
+++ b/hooks/useMiniAppSession.ts
@@ -38,6 +38,12 @@ const normalizeSession = (
       )
     : [];
 
+  const rosterIds = Array.isArray(data.rosterIds)
+    ? data.rosterIds.filter(
+        (r): r is string => typeof r === 'string' && r.length > 0
+      )
+    : [];
+
   return {
     id: sessionId,
     appId: data.appId ?? '',
@@ -52,13 +58,22 @@ const normalizeSession = (
     createdAt,
     ...(typeof data.endedAt === 'number' ? { endedAt: data.endedAt } : {}),
     ...(classIds.length > 0 ? { classIds } : {}),
+    ...(rosterIds.length > 0 ? { rosterIds } : {}),
     ...(data.submissionsEnabled === true ? { submissionsEnabled: true } : {}),
   };
 };
 
 export interface CreateMiniAppSessionOptions {
-  /** ClassLink class sourcedIds the teacher targeted (multi-select). */
+  /**
+   * ClassLink `sourcedId`s for the student SSO gate. Derived upstream from
+   * the targeted rosters' `classlinkClassId` metadata. Empty when all
+   * targeted rosters are locally created — the rules' `passesStudentClassGateList`
+   * treats the empty list as "open to any student-role user," which matches
+   * today's behavior for the MiniApp session collection.
+   */
   classIds?: string[];
+  /** Roster IDs backing this session (unified targeting). */
+  rosterIds?: string[];
   /** Whether the runner should reveal the Submit button and persist
    *  submissions. Defaults to `false` (view-only). */
   submissionsEnabled?: boolean;
@@ -102,6 +117,9 @@ export const useMiniAppSessionTeacher = (): UseMiniAppSessionTeacherResult => {
       const cleanedClassIds = (options?.classIds ?? []).filter(
         (c): c is string => typeof c === 'string' && c.length > 0
       );
+      const cleanedRosterIds = (options?.rosterIds ?? []).filter(
+        (r): r is string => typeof r === 'string' && r.length > 0
+      );
       const submissionsEnabled = options?.submissionsEnabled === true;
 
       const session: MiniAppSession = {
@@ -117,6 +135,7 @@ export const useMiniAppSessionTeacher = (): UseMiniAppSessionTeacherResult => {
         status: 'active',
         createdAt: Date.now(),
         ...(cleanedClassIds.length > 0 ? { classIds: cleanedClassIds } : {}),
+        ...(cleanedRosterIds.length > 0 ? { rosterIds: cleanedRosterIds } : {}),
         submissionsEnabled,
       };
 

--- a/hooks/useQuizAssignments.ts
+++ b/hooks/useQuizAssignments.ts
@@ -507,6 +507,11 @@ export const useQuizAssignments = (
         periodName: undefined,
         periodNames: undefined,
       };
+      // Intentionally omit classIds/rosterIds: the shared doc's targeting
+      // refers to rosters in the ORIGINATOR's account and would be dangling
+      // refs here. The importer retargets on first launch via AssignClassPicker,
+      // which pre-seeds empty because lastRosterIdsByQuizId is only written at
+      // assign-confirm time (QuizWidget/Widget.tsx) — never during import.
       const created = await createAssignment(
         {
           id: savedMeta.id,

--- a/hooks/useQuizAssignments.ts
+++ b/hooks/useQuizAssignments.ts
@@ -75,7 +75,8 @@ export interface UseQuizAssignmentsResult {
     quiz: AssignmentQuizRef,
     settings: QuizAssignmentSettings,
     initialStatus?: QuizAssignmentStatus,
-    classIds?: string[]
+    classIds?: string[],
+    rosterIds?: string[]
   ) => Promise<{ id: string; code: string }>;
   /** Set both assignment.status and session.status to 'paused'. */
   pauseAssignment: (assignmentId: string) => Promise<void>;
@@ -184,9 +185,12 @@ export const useQuizAssignments = (
   const createAssignment = useCallback<
     UseQuizAssignmentsResult['createAssignment']
   >(
-    async (quiz, settings, initialStatus = 'active', classIds) => {
+    async (quiz, settings, initialStatus = 'active', classIds, rosterIds) => {
       if (!userId) throw new Error('Not authenticated');
       const targetClassIds = classIds ?? [];
+      const targetRosterIds = (rosterIds ?? []).filter(
+        (id): id is string => typeof id === 'string' && id.length > 0
+      );
 
       const assignmentId = crypto.randomUUID();
       const code = await allocateJoinCode();
@@ -211,6 +215,7 @@ export const useQuizAssignments = (
         periodName: settings.periodName,
         periodNames: settings.periodNames,
         plcMemberEmails: settings.plcMemberEmails,
+        ...(targetRosterIds.length > 0 ? { rosterIds: targetRosterIds } : {}),
       };
 
       const mode = settings.sessionMode;
@@ -258,6 +263,7 @@ export const useQuizAssignments = (
         ...(targetClassIds.length > 0
           ? { classIds: targetClassIds, classId: targetClassIds[0] }
           : {}),
+        ...(targetRosterIds.length > 0 ? { rosterIds: targetRosterIds } : {}),
       };
 
       const batch = writeBatch(db);

--- a/hooks/useRosters.ts
+++ b/hooks/useRosters.ts
@@ -100,7 +100,12 @@ class MockRosterStore {
     return [...this.rosters].sort((a, b) => a.name.localeCompare(b.name));
   }
 
-  addRoster(id: string, name: string, students: Student[]): void {
+  addRoster(
+    id: string,
+    name: string,
+    students: Student[],
+    meta?: Partial<ClassRosterMeta>
+  ): void {
     const withPins = assignPins(students);
     const newRoster: ClassRoster = {
       id,
@@ -109,6 +114,7 @@ class MockRosterStore {
       driveFileId: null,
       studentCount: withPins.length,
       createdAt: Date.now(),
+      ...meta,
     };
     this.rosters.push(newRoster);
     this.notifyListeners();
@@ -201,8 +207,41 @@ const validateRosterMeta = (
       };
     }
   }
+  if (d.origin === 'classlink' || d.origin === 'local') {
+    meta.origin = d.origin;
+  }
+  if (typeof d.classlinkClassId === 'string') {
+    meta.classlinkClassId = d.classlinkClassId;
+  }
+  if (typeof d.classlinkClassCode === 'string') {
+    meta.classlinkClassCode = d.classlinkClassCode;
+  }
+  if (typeof d.classlinkSubject === 'string') {
+    meta.classlinkSubject = d.classlinkSubject;
+  }
+  if (typeof d.classlinkOrgId === 'string') {
+    meta.classlinkOrgId = d.classlinkOrgId;
+  }
+  if (typeof d.classlinkSyncedAt === 'number') {
+    meta.classlinkSyncedAt = d.classlinkSyncedAt;
+  }
   return meta;
 };
+
+/**
+ * Optional ClassLink metadata accepted by `addRoster`. Passed through to the
+ * Firestore doc so assignment pickers can treat a ClassLink-imported roster as
+ * the single source of truth (no more "is it ClassLink or local?" branching).
+ */
+export type RosterCreateMeta = Pick<
+  ClassRosterMeta,
+  | 'origin'
+  | 'classlinkClassId'
+  | 'classlinkClassCode'
+  | 'classlinkSubject'
+  | 'classlinkOrgId'
+  | 'classlinkSyncedAt'
+>;
 
 // ─── Hook ──────────────────────────────────────────────────────────────────────
 
@@ -487,23 +526,27 @@ export const useRosters = (user: User | null) => {
   // ─── CRUD actions ─────────────────────────────────────────────────────────
 
   const addRoster = useCallback(
-    async (name: string, students: Student[] = []) => {
+    async (name: string, students: Student[] = [], meta?: RosterCreateMeta) => {
       if (!user) throw new Error('No user');
 
       if (isAuthBypass) {
         const id = 'mock-roster-id-' + Date.now();
-        mockRosterStore.addRoster(id, name, students);
+        mockRosterStore.addRoster(id, name, students, meta);
         return id;
       }
 
       const withPins = assignPins(students);
 
-      // Write metadata-only to Firestore first to get the document ID
+      // Write metadata-only to Firestore first to get the document ID.
+      // ClassLink metadata (origin, classlinkClassId, etc.) is spread in here
+      // so the roster doc itself carries its provenance; individual students
+      // continue to track their own classLinkSourcedId separately.
       const firestoreData: Omit<ClassRosterMeta, 'id'> = {
         name,
         driveFileId: null,
         studentCount: withPins.length,
         createdAt: Date.now(),
+        ...meta,
       };
       const ref = await addDoc(
         collection(db, 'users', user.uid, 'rosters'),

--- a/hooks/useVideoActivityAssignments.ts
+++ b/hooks/useVideoActivityAssignments.ts
@@ -68,7 +68,8 @@ export interface UseVideoActivityAssignmentsResult {
     settings: VideoActivityAssignmentSettings,
     initialStatus?: VideoActivityAssignmentStatus,
     classIds?: string[],
-    periodNames?: string[]
+    periodNames?: string[],
+    rosterIds?: string[]
   ) => Promise<{ id: string }>;
   /** Set both assignment.status and session.status to 'paused' (assignment) / 'ended' (session). */
   pauseAssignment: (assignmentId: string) => Promise<void>;
@@ -141,11 +142,13 @@ export const useVideoActivityAssignments = (
       settings,
       initialStatus = 'active',
       classIds,
-      periodNames
+      periodNames,
+      rosterIds
     ) => {
       if (!userId) throw new Error('Not authenticated');
       const targetClassIds = classIds ?? [];
       const targetPeriodNames = periodNames ?? [];
+      const targetRosterIds = rosterIds ?? [];
       const assignmentId = crypto.randomUUID();
       const now = Date.now();
 
@@ -160,6 +163,7 @@ export const useVideoActivityAssignments = (
         updatedAt: now,
         className: settings.className,
         sessionSettings: settings.sessionSettings,
+        ...(targetRosterIds.length > 0 ? { rosterIds: targetRosterIds } : {}),
       };
 
       // Session's status is binary — if the assignment is paused or inactive,
@@ -191,6 +195,7 @@ export const useVideoActivityAssignments = (
         ...(targetPeriodNames.length > 0
           ? { periodNames: targetPeriodNames }
           : {}),
+        ...(targetRosterIds.length > 0 ? { rosterIds: targetRosterIds } : {}),
       };
 
       const batch = writeBatch(db);

--- a/hooks/useVideoActivitySession.ts
+++ b/hooks/useVideoActivitySession.ts
@@ -91,7 +91,8 @@ export interface UseVideoActivitySessionTeacherResult {
     settings?: Partial<VideoActivitySessionSettings>,
     assignmentName?: string,
     classIds?: string[],
-    periodNames?: string[]
+    periodNames?: string[],
+    rosterIds?: string[]
   ) => Promise<string>;
   /** Sessions created by the current teacher for the selected activity. */
   sessions: VideoActivitySession[];
@@ -130,7 +131,8 @@ export const useVideoActivitySessionTeacher =
         settings?: Partial<VideoActivitySessionSettings>,
         assignmentName?: string,
         classIds: string[] = [],
-        periodNames: string[] = []
+        periodNames: string[] = [],
+        rosterIds: string[] = []
       ): Promise<string> => {
         const sessionId = crypto.randomUUID();
         const trimmedAssignmentName = assignmentName?.trim();
@@ -161,6 +163,7 @@ export const useVideoActivitySessionTeacher =
           // Firestore rules keep gating correctly.
           ...(classIds.length > 0 ? { classIds, classId: classIds[0] } : {}),
           ...(periodNames.length > 0 ? { periodNames } : {}),
+          ...(rosterIds.length > 0 ? { rosterIds } : {}),
         };
 
         await setDoc(doc(db, SESSIONS_COLLECTION, sessionId), session);

--- a/hooks/useVideoActivitySession.ts
+++ b/hooks/useVideoActivitySession.ts
@@ -77,12 +77,22 @@ export interface UseVideoActivitySessionTeacherResult {
   /**
    * Create a session for a class and return the sessionId (used as the share link).
    *
-   * `classIds` is the list of ClassLink class `sourcedId`s this session is
-   * targeted at (Phase 5A multi-class). When non-empty, the session doc
-   * stores them on `classIds` (and transitionally mirrors `classIds[0]` to
-   * `classId`). `periodNames` drives the post-PIN class-period picker and
-   * is either the list of chosen local roster names or the ClassLink class
-   * labels (mirroring the teacher's picker source).
+   * Post-unification, `rosterIds` is the canonical input — callers derive
+   * it from the shared `AssignClassPicker` selection. `classIds` and
+   * `periodNames` are denormalised outputs the caller computes via
+   * `deriveSessionTargetsFromRosters(selectedRosters)`:
+   *
+   * - `classIds`: ClassLink `sourcedId`s drawn from the selected rosters'
+   *   `classlinkClassId` metadata. Drives the student SSO gate
+   *   (`passesStudentClassGate` in firestore.rules). `classIds[0]` is also
+   *   mirrored onto the session's legacy `classId` field so pre-Phase-5A
+   *   rules keep working.
+   * - `periodNames`: roster names (de-duped) used for the student app's
+   *   post-PIN period picker.
+   * - `rosterIds`: written onto the session doc for reverse lookup.
+   *
+   * All three are optional and independent for backwards compatibility
+   * with callers that still target the legacy shapes directly.
    */
   createSession: (
     activity: VideoActivityData,

--- a/tests/utils/resolveAssignmentTargets.test.ts
+++ b/tests/utils/resolveAssignmentTargets.test.ts
@@ -1,0 +1,192 @@
+import { describe, it, expect } from 'vitest';
+import {
+  resolveAssignmentTargets,
+  deriveSessionTargetsFromRosters,
+  mapLegacyClassIdsToRosterIds,
+} from '@/utils/resolveAssignmentTargets';
+import type { ClassRoster, Student } from '@/types';
+
+const student = (id: string, name: string, pin: string): Student => ({
+  id,
+  firstName: name,
+  lastName: '',
+  pin,
+});
+
+const roster = (
+  id: string,
+  name: string,
+  students: Student[],
+  extra: Partial<ClassRoster> = {}
+): ClassRoster => ({
+  id,
+  name,
+  students,
+  driveFileId: null,
+  studentCount: students.length,
+  createdAt: 0,
+  ...extra,
+});
+
+const s1 = student('s1', 'Ada', '01');
+const s2 = student('s2', 'Blake', '02');
+const s3 = student('s3', 'Cody', '03');
+
+describe('resolveAssignmentTargets', () => {
+  it('uses rosterIds when present (new path) and derives everything from rosters', () => {
+    const r1 = roster('r1', 'Period 1', [s1, s2], {
+      classlinkClassId: 'cl-1',
+    });
+    const r2 = roster('r2', 'Period 2', [s3], { classlinkClassId: 'cl-2' });
+    const out = resolveAssignmentTargets(
+      { rosterIds: ['r1', 'r2'], classIds: ['ignored'], periodNames: ['x'] },
+      [r1, r2]
+    );
+    expect(out.source).toBe('rosterIds');
+    expect(out.rosterIds).toEqual(['r1', 'r2']);
+    expect(out.classIds.sort()).toEqual(['cl-1', 'cl-2']);
+    expect(out.periodNames.sort()).toEqual(['Period 1', 'Period 2']);
+    expect(out.students.map((s) => s.id).sort()).toEqual(['s1', 's2', 's3']);
+  });
+
+  it('falls back to legacy classIds when rosterIds is empty/absent', () => {
+    const out = resolveAssignmentTargets(
+      { classIds: ['cl-legacy-1', 'cl-legacy-2'] },
+      []
+    );
+    expect(out.source).toBe('classIds');
+    expect(out.classIds).toEqual(['cl-legacy-1', 'cl-legacy-2']);
+    expect(out.rosterIds).toEqual([]);
+    expect(out.periodNames).toEqual([]);
+  });
+
+  it('falls back to legacy periodNames when only it is present', () => {
+    const out = resolveAssignmentTargets({ periodNames: ['Period 1'] }, []);
+    expect(out.source).toBe('periodNames');
+    expect(out.periodNames).toEqual(['Period 1']);
+  });
+
+  it('returns source="none" when nothing is targeted', () => {
+    expect(resolveAssignmentTargets({}, []).source).toBe('none');
+  });
+
+  it('silently drops rosterIds that no longer exist', () => {
+    const r1 = roster('r1', 'Period 1', [s1], { classlinkClassId: 'cl-1' });
+    const out = resolveAssignmentTargets({ rosterIds: ['r1', 'deleted'] }, [
+      r1,
+    ]);
+    expect(out.rosterIds).toEqual(['r1']);
+    expect(out.classIds).toEqual(['cl-1']);
+  });
+
+  it('de-dupes students shared across multiple selected rosters', () => {
+    const shared = student('shared', 'Shared', '04');
+    const r1 = roster('r1', 'Period 1', [s1, shared]);
+    const r2 = roster('r2', 'Period 2', [s2, shared]);
+    const out = resolveAssignmentTargets({ rosterIds: ['r1', 'r2'] }, [r1, r2]);
+    expect(out.students.map((s) => s.id).sort()).toEqual([
+      's1',
+      's2',
+      'shared',
+    ]);
+  });
+
+  it('de-dupes classIds when two rosters share a classlinkClassId', () => {
+    // Teacher imported the same ClassLink class twice under different names.
+    const r1 = roster('r1', 'MATH-7 (copy A)', [s1], {
+      classlinkClassId: 'cl-dup',
+    });
+    const r2 = roster('r2', 'MATH-7 (copy B)', [s2], {
+      classlinkClassId: 'cl-dup',
+    });
+    const out = resolveAssignmentTargets({ rosterIds: ['r1', 'r2'] }, [r1, r2]);
+    expect(out.classIds).toEqual(['cl-dup']);
+  });
+
+  it('de-dupes periodNames when rosters share a name', () => {
+    const r1 = roster('r1', 'Period 1', [s1]);
+    const r2 = roster('r2', 'Period 1', [s2]);
+    const out = resolveAssignmentTargets({ rosterIds: ['r1', 'r2'] }, [r1, r2]);
+    expect(out.periodNames).toEqual(['Period 1']);
+  });
+
+  it('omits rosters without a classlinkClassId from derived classIds', () => {
+    const r1 = roster('r1', 'Period 1', [s1], { classlinkClassId: 'cl-1' });
+    const r2 = roster('r2', 'Local only', [s2]); // no classlinkClassId
+    const out = resolveAssignmentTargets({ rosterIds: ['r1', 'r2'] }, [r1, r2]);
+    expect(out.classIds).toEqual(['cl-1']);
+    expect(out.rosterIds).toEqual(['r1', 'r2']);
+  });
+});
+
+describe('deriveSessionTargetsFromRosters', () => {
+  it('derives classIds, periodNames, and de-duped students', () => {
+    const r1 = roster('r1', 'Period 1', [s1, s2], {
+      classlinkClassId: 'cl-1',
+    });
+    const r2 = roster('r2', 'Period 2', [s3], { classlinkClassId: 'cl-2' });
+    const out = deriveSessionTargetsFromRosters([r1, r2]);
+    expect(out.rosterIds).toEqual(['r1', 'r2']);
+    expect(out.classIds.sort()).toEqual(['cl-1', 'cl-2']);
+    expect(out.periodNames.sort()).toEqual(['Period 1', 'Period 2']);
+    expect(out.students.map((s) => s.id).sort()).toEqual(['s1', 's2', 's3']);
+  });
+
+  it('de-dupes classIds (two rosters with same classlinkClassId)', () => {
+    const r1 = roster('r1', 'A', [s1], { classlinkClassId: 'cl-dup' });
+    const r2 = roster('r2', 'B', [s2], { classlinkClassId: 'cl-dup' });
+    expect(deriveSessionTargetsFromRosters([r1, r2]).classIds).toEqual([
+      'cl-dup',
+    ]);
+  });
+
+  it('returns empty arrays for empty input', () => {
+    expect(deriveSessionTargetsFromRosters([])).toEqual({
+      rosterIds: [],
+      classIds: [],
+      periodNames: [],
+      students: [],
+    });
+  });
+});
+
+describe('mapLegacyClassIdsToRosterIds', () => {
+  it('maps legacy ClassLink sourcedIds to rosterIds via classlinkClassId', () => {
+    const r1 = roster('r1', 'A', [], { classlinkClassId: 'cl-1' });
+    const r2 = roster('r2', 'B', [], { classlinkClassId: 'cl-2' });
+    expect(mapLegacyClassIdsToRosterIds(['cl-1', 'cl-2'], [r1, r2])).toEqual([
+      'r1',
+      'r2',
+    ]);
+  });
+
+  it('returns an empty array when legacy input is undefined/empty', () => {
+    expect(mapLegacyClassIdsToRosterIds(undefined, [])).toEqual([]);
+    expect(mapLegacyClassIdsToRosterIds([], [])).toEqual([]);
+  });
+
+  it('returns partial matches — silently drops legacy IDs with no matching roster', () => {
+    const r1 = roster('r1', 'A', [], { classlinkClassId: 'cl-1' });
+    expect(
+      mapLegacyClassIdsToRosterIds(['cl-1', 'cl-never-imported'], [r1])
+    ).toEqual(['r1']);
+  });
+
+  it('returns empty array when no roster has matching classlinkClassId', () => {
+    const r1 = roster('r1', 'A', [], { classlinkClassId: 'cl-1' });
+    expect(mapLegacyClassIdsToRosterIds(['cl-never-imported'], [r1])).toEqual(
+      []
+    );
+  });
+
+  it('first-wins tie-break when two rosters share a classlinkClassId', () => {
+    const r1 = roster('r1', 'A', [], { classlinkClassId: 'cl-dup' });
+    const r2 = roster('r2', 'B', [], { classlinkClassId: 'cl-dup' });
+    expect(mapLegacyClassIdsToRosterIds(['cl-dup'], [r1, r2])).toEqual(['r1']);
+  });
+
+  it('ignores rosters without classlinkClassId', () => {
+    const r1 = roster('r1', 'Local only', []); // no classlinkClassId
+    expect(mapLegacyClassIdsToRosterIds(['cl-1'], [r1])).toEqual([]);
+  });
+});

--- a/types.ts
+++ b/types.ts
@@ -1263,9 +1263,10 @@ export interface MiniAppConfig {
   /** Persisted library grid/list toggle. */
   libraryViewMode?: 'grid' | 'list';
   /**
-   * @deprecated Read-only fallback for pre-unification configs. Written as
-   * ClassLink class `sourcedId`s; new code uses `lastRosterIdsByAppId`.
-   * Still read when present so teachers don't lose their per-app last-selection.
+   * @deprecated Pre-unification memory, written as ClassLink class
+   * `sourcedId`s. Read as a fallback (via `mapLegacyClassIdsToRosterIds`) to
+   * seed the picker only when `lastRosterIdsByAppId` is absent; never written
+   * by new code.
    */
   lastClassIdsByAppId?: Record<string, string[]>;
   /**

--- a/types.ts
+++ b/types.ts
@@ -3838,11 +3838,15 @@ export interface MiniAppAssignment {
   status: 'active' | 'inactive';
   createdAt: number;
   updatedAt: number;
-  /** Mirrors `MiniAppSession.classIds` — ClassLink `sourcedId`s derived from
-   *  targeted rosters (via `classlinkClassId`) for the student SSO gate. */
-  classIds?: string[];
-  /** Unified roster targeting. Present on new (post-unification) assignments;
-   *  legacy assignments read via `classIds` only. See
+  /** Unified roster targeting. Present on new (post-unification) assignments.
+   *
+   *  The student SSO gate lives on the session doc (`MiniAppSession.classIds`,
+   *  derived at assign time from these rosters' `classlinkClassId`); the
+   *  assignment doc intentionally does NOT mirror `classIds`, matching the
+   *  Quiz / VideoActivity / GuidedLearning assignment shapes.
+   *
+   *  Legacy pre-unification assignments may have no targeting fields at all
+   *  and read their targeting via the paired session doc. See
    *  `utils/resolveAssignmentTargets.ts`. */
   rosterIds?: string[];
   /** Mirrors `MiniAppSession.submissionsEnabled`. When true, the runner

--- a/types.ts
+++ b/types.ts
@@ -120,6 +120,27 @@ export interface ClassRosterMeta {
    * from prior days are auto-ignored without needing cleanup.
    */
   absent?: { date: string; studentIds: string[] };
+  /**
+   * Where the roster originated. Absent on legacy docs → treat as 'local'.
+   * Named `origin` (not `source`) to avoid collision with `ClassRoster.source`
+   * ('user' | 'testClass'), which describes storage location, not provenance.
+   */
+  origin?: 'classlink' | 'local';
+  /**
+   * ClassLink class `sourcedId`. Present iff the roster was imported or merged
+   * from a ClassLink class. Drives session `classIds[]` derivation so the
+   * student-side ClassLink SSO gate (firestore.rules `passesStudentClassGate`)
+   * resolves without the assignment layer having to know about ClassLink.
+   */
+  classlinkClassId?: string;
+  /** ClassLink class code (e.g. "MATH-7-P3"); rendered in the picker badge tooltip. */
+  classlinkClassCode?: string;
+  /** ClassLink subject label; used for reconciliation and teacher-visible filters. */
+  classlinkSubject?: string;
+  /** ClassLink tenant/organization ID; required to scope re-sync API calls. */
+  classlinkOrgId?: string;
+  /** Epoch ms of the last ClassLink import or merge for this roster. */
+  classlinkSyncedAt?: number;
 }
 
 /**
@@ -1242,12 +1263,16 @@ export interface MiniAppConfig {
   /** Persisted library grid/list toggle. */
   libraryViewMode?: 'grid' | 'list';
   /**
-   * Remembers the last ClassLink class selection the teacher made per app,
-   * keyed by appId. Used to pre-populate the target-class picker on
-   * subsequent assigns so teachers don't have to re-pick the same classes
-   * each time.
+   * @deprecated Read-only fallback for pre-unification configs. Written as
+   * ClassLink class `sourcedId`s; new code uses `lastRosterIdsByAppId`.
+   * Still read when present so teachers don't lose their per-app last-selection.
    */
   lastClassIdsByAppId?: Record<string, string[]>;
+  /**
+   * Remembers the last roster selection the teacher made per app, keyed by
+   * appId. Used to pre-populate the picker on subsequent assigns.
+   */
+  lastRosterIdsByAppId?: Record<string, string[]>;
   /**
    * Remembers the last submissions-enabled choice the teacher made per app,
    * keyed by appId. Used to pre-populate the toggle on subsequent assigns.
@@ -1278,6 +1303,12 @@ export interface MiniAppSession {
    * student across any of the selected classes.
    */
   classIds?: string[];
+  /**
+   * Roster IDs backing this session (new unified path). Derived from the
+   * teacher's picker selection; `classIds[]` above is derived from these
+   * rosters' `classlinkClassId` for the SSO gate. Absent on legacy sessions.
+   */
+  rosterIds?: string[];
   /**
    * Whether the sandboxed mini-app iframe should show its Submit button and
    * accept student submissions into the `submissions/` subcollection. Absent
@@ -1755,6 +1786,11 @@ export interface QuizSession {
    * no-op for non-studentRole users.
    */
   classIds?: string[];
+  /**
+   * Roster IDs backing this session (unified targeting). `classIds` above is
+   * derived from these rosters' `classlinkClassId` metadata.
+   */
+  rosterIds?: string[];
 }
 
 export interface QuizResponseAnswer {
@@ -1848,20 +1884,19 @@ export interface QuizConfig {
   /** Persisted library grid/list toggle. */
   libraryViewMode?: 'grid' | 'list';
   /**
-   * @deprecated Phase 5A — replaced by `lastClassIdsByQuizId` (multi-class).
-   * Retained for a transitional release so existing widget configs don't
-   * lose their pre-selection on first render. Readers prefer the multi-
-   * class map; fallback to this when the new key is absent.
+   * @deprecated Pre-Phase-5A single-class memory. Read-only fallback now.
    */
   lastClassIdByQuizId?: Record<string, string>;
   /**
-   * Per-quiz memory of the last ClassLink target classes (`sourcedId`s) the
-   * teacher picked in the Assign modal. Key is quizId, value is a list of
-   * ClassLink class sourcedIds. Used to pre-select the picker on re-launch
-   * of the same quiz so teachers don't have to re-pick every time. Missing
-   * keys mean "use the default (no classes selected)".
+   * @deprecated Phase 5A ClassLink-sourcedId map. Read-only fallback for
+   * pre-unification configs; new code writes `lastRosterIdsByQuizId`.
    */
   lastClassIdsByQuizId?: Record<string, string[]>;
+  /**
+   * Per-quiz memory of the last roster selection in the Assign modal.
+   * Pre-selects the picker on re-launch.
+   */
+  lastRosterIdsByQuizId?: Record<string, string[]>;
 }
 
 // --- QUIZ ASSIGNMENT TYPES ---
@@ -1912,6 +1947,9 @@ export interface QuizAssignment extends QuizAssignmentSettings {
   status: QuizAssignmentStatus;
   createdAt: number;
   updatedAt: number;
+  /** Unified roster targeting (new post-unification assignments). Legacy
+   *  assignments read via `periodNames` / session `classIds` only. */
+  rosterIds?: string[];
 }
 
 /**
@@ -1991,22 +2029,19 @@ export interface VideoActivityConfig {
   /** Persisted library grid/list toggle. */
   libraryViewMode?: 'grid' | 'list';
   /**
-   * Per-activity memory of the last ClassLink target class (`sourcedId`) the
-   * teacher picked in the Assign modal. Key is activityId, value is the
-   * ClassLink class sourcedId. Used to pre-select the selector on re-launch
-   * of the same activity so teachers don't have to re-pick every time.
-   * Undefined means "use the default (No class)".
-   *
-   * @deprecated Phase 5A — replaced by `lastClassIdsByActivityId` (multi).
-   * Retained for a transitional release so existing widget configs don't
-   * lose their pre-selection on first render.
+   * @deprecated Pre-Phase-5A single-class memory. Read-only fallback now.
    */
   lastClassIdByActivityId?: Record<string, string>;
   /**
-   * Multi-class variant of the per-activity memory (Phase 5A). Preferred
-   * over the legacy single-class map.
+   * @deprecated Phase 5A ClassLink-sourcedId map. Read-only fallback for
+   * pre-unification configs; new code writes `lastRosterIdsByActivityId`.
    */
   lastClassIdsByActivityId?: Record<string, string[]>;
+  /**
+   * Per-activity memory of the last roster selection in the Assign modal.
+   * Pre-selects the picker on re-launch.
+   */
+  lastRosterIdsByActivityId?: Record<string, string[]>;
 }
 
 export interface VideoActivitySessionSettings {
@@ -2071,6 +2106,11 @@ export interface VideoActivitySession {
    * the response's `classPeriod` field. Mirrors the QuizSession pattern.
    */
   periodNames?: string[];
+  /**
+   * Roster IDs backing this session (unified targeting). `classIds` above is
+   * derived from these rosters' `classlinkClassId` metadata.
+   */
+  rosterIds?: string[];
 }
 
 /** A single answer submitted by a student for a video activity question. */
@@ -2698,6 +2738,11 @@ export interface GuidedLearningSession {
    * the response's `classPeriod` field. Mirrors the QuizSession pattern.
    */
   periodNames?: string[];
+  /**
+   * Roster IDs backing this session (unified targeting). `classIds` above is
+   * derived from these rosters' `classlinkClassId` metadata.
+   */
+  rosterIds?: string[];
 }
 
 /** Per-student response in /guided_learning_sessions/{id}/responses/{studentUid} */
@@ -2731,22 +2776,19 @@ export interface GuidedLearningConfig {
   /** Persisted library grid/list toggle. */
   libraryViewMode?: 'grid' | 'list';
   /**
-   * Per-set memory of the last ClassLink target class (`sourcedId`) the
-   * teacher picked in the Assign dialog. Key is the Guided Learning set id,
-   * value is the ClassLink class sourcedId. Used to pre-select the selector
-   * on re-launch of the same set so teachers don't have to re-pick every
-   * time. Undefined means "use the default (No class)".
-   *
-   * @deprecated Phase 5A — replaced by `lastClassIdsBySetId` (multi).
-   * Retained for a transitional release so existing widget configs don't
-   * lose their pre-selection on first render.
+   * @deprecated Pre-Phase-5A single-class memory. Read-only fallback now.
    */
   lastClassIdBySetId?: Record<string, string>;
   /**
-   * Multi-class variant of the per-set memory (Phase 5A). Preferred over
-   * the legacy single-class map.
+   * @deprecated Phase 5A ClassLink-sourcedId map. Read-only fallback for
+   * pre-unification configs; new code writes `lastRosterIdsBySetId`.
    */
   lastClassIdsBySetId?: Record<string, string[]>;
+  /**
+   * Per-set memory of the last roster selection in the Assign dialog.
+   * Pre-selects the picker on re-launch.
+   */
+  lastRosterIdsBySetId?: Record<string, string[]>;
 }
 
 // Union of all widget configs
@@ -3763,6 +3805,10 @@ export interface VideoActivityAssignment extends VideoActivityAssignmentSettings
   status: VideoActivityAssignmentStatus;
   createdAt: number;
   updatedAt: number;
+  /** Unified roster targeting. New (post-unification) assignments write this;
+   *  legacy assignments read via `className` / session.classIds only. See
+   *  `utils/resolveAssignmentTargets.ts`. */
+  rosterIds?: string[];
 }
 
 // === MiniApp assignments ===
@@ -3791,9 +3837,13 @@ export interface MiniAppAssignment {
   status: 'active' | 'inactive';
   createdAt: number;
   updatedAt: number;
-  /** Mirrors `MiniAppSession.classIds`. Present when assigned via the
-   * class-targeted picker; absent (or empty) for shareable-link launches. */
+  /** Mirrors `MiniAppSession.classIds` — ClassLink `sourcedId`s derived from
+   *  targeted rosters (via `classlinkClassId`) for the student SSO gate. */
   classIds?: string[];
+  /** Unified roster targeting. Present on new (post-unification) assignments;
+   *  legacy assignments read via `classIds` only. See
+   *  `utils/resolveAssignmentTargets.ts`. */
+  rosterIds?: string[];
   /** Mirrors `MiniAppSession.submissionsEnabled`. When true, the runner
    * reveals the Submit button and persists student submissions. */
   submissionsEnabled?: boolean;
@@ -3830,6 +3880,8 @@ export interface GuidedLearningAssignment {
   archivedAt?: number | null;
   /** Optional origin set: 'personal' (Drive) or 'building' (Firestore). */
   source?: 'personal' | 'building';
+  /** Unified roster targeting (new post-unification assignments). */
+  rosterIds?: string[];
 }
 
 // === Library folders (Wave 3) ===

--- a/utils/resolveAssignmentTargets.ts
+++ b/utils/resolveAssignmentTargets.ts
@@ -17,7 +17,7 @@
  *   4. none          → untargeted (code/PIN-only join).
  */
 
-import type { ClassRoster, Student } from '../types';
+import type { ClassRoster, Student } from '@/types';
 
 /** Minimal shape of any assignment doc's class-targeting fields. */
 export interface AssignmentTargetInput {
@@ -117,6 +117,36 @@ export function resolveAssignmentTargets(
     students: [],
     source: 'none',
   };
+}
+
+/**
+ * Map legacy ClassLink `sourcedId`s (from pre-unification per-app config keys
+ * like `lastClassIdsByQuizId`) to rosterIds by matching against the current
+ * rosters' `classlinkClassId` metadata. Used to seed the picker default for
+ * teachers whose configs predate the unified `lastRosterIdsBy*` keys.
+ *
+ * Returns an empty array when the teacher hasn't (re-)imported the ClassLink
+ * class — we can't recover a preselection that no longer has a roster.
+ */
+export function mapLegacyClassIdsToRosterIds(
+  legacyClassIds: string[] | undefined,
+  rosters: ClassRoster[]
+): string[] {
+  if (!legacyClassIds || legacyClassIds.length === 0) return [];
+  const rosterByClassLinkId = new Map<string, string>();
+  for (const r of rosters) {
+    if (r.classlinkClassId) rosterByClassLinkId.set(r.classlinkClassId, r.id);
+  }
+  const mapped: string[] = [];
+  const seen = new Set<string>();
+  for (const cid of legacyClassIds) {
+    const rosterId = rosterByClassLinkId.get(cid);
+    if (rosterId && !seen.has(rosterId)) {
+      mapped.push(rosterId);
+      seen.add(rosterId);
+    }
+  }
+  return mapped;
 }
 
 /**

--- a/utils/resolveAssignmentTargets.ts
+++ b/utils/resolveAssignmentTargets.ts
@@ -1,0 +1,148 @@
+/**
+ * Dual-read helper for unified class targeting on assignments.
+ *
+ * Context: assignment documents historically stored ClassLink sourcedIds under
+ * `classIds[]` (ClassLink-only) or local roster names under `periodNames[]`
+ * (local-only). After the roster-as-single-source-of-truth unification,
+ * new assignments write `rosterIds[]` — rosters imported from ClassLink carry
+ * their own `classlinkClassId` metadata so the student SSO gate still works.
+ *
+ * Legacy in-flight assignments are NOT migrated; they continue reading via
+ * their existing `classIds`/`periodNames` fields until they expire.
+ *
+ * Precedence:
+ *   1. `rosterIds`   → resolve via rosters, derive everything fresh.
+ *   2. `classIds`    → legacy ClassLink targeting (SSO claim match).
+ *   3. `periodNames` → legacy local-roster targeting (name match).
+ *   4. none          → untargeted (code/PIN-only join).
+ */
+
+import type { ClassRoster, Student } from '../types';
+
+/** Minimal shape of any assignment doc's class-targeting fields. */
+export interface AssignmentTargetInput {
+  rosterIds?: string[];
+  classIds?: string[];
+  periodNames?: string[];
+}
+
+export interface ResolvedAssignmentTargets {
+  /** Roster IDs backing this assignment (empty for legacy docs). */
+  rosterIds: string[];
+  /**
+   * ClassLink `sourcedId`s to write onto the session doc for the student
+   * SSO gate. Empty when no selected roster has `classlinkClassId` (purely
+   * local targeting — SSO students get blocked, PIN students still pass).
+   */
+  classIds: string[];
+  /** Period names (local roster names) for PIN-flow routing. */
+  periodNames: string[];
+  /** Union of students across all targeted rosters (new path only). */
+  students: Student[];
+  /**
+   * Which branch resolved the targets. Useful for telemetry / debug logs so
+   * we can tell when the legacy paths stop being hit and the code can retire.
+   */
+  source: 'rosterIds' | 'classIds' | 'periodNames' | 'none';
+}
+
+/**
+ * Resolve an assignment's class targets against the current rosters list.
+ * Never throws — unknown roster IDs or missing legacy fields simply drop
+ * through to the next precedence level or to the untargeted result.
+ */
+export function resolveAssignmentTargets(
+  assignment: AssignmentTargetInput,
+  rosters: ClassRoster[]
+): ResolvedAssignmentTargets {
+  // 1. New path: rosterIds on the assignment doc.
+  if (assignment.rosterIds && assignment.rosterIds.length > 0) {
+    const byId = new Map(rosters.map((r) => [r.id, r]));
+    const matched = assignment.rosterIds
+      .map((id) => byId.get(id))
+      .filter((r): r is ClassRoster => r !== undefined);
+
+    const classIds = matched
+      .map((r) => r.classlinkClassId)
+      .filter((id): id is string => typeof id === 'string' && id.length > 0);
+
+    // De-dupe students across rosters by ID so a student enrolled in two
+    // targeted classes doesn't double up in the session student list.
+    const studentsById = new Map<string, Student>();
+    for (const r of matched) {
+      for (const s of r.students) {
+        if (!studentsById.has(s.id)) studentsById.set(s.id, s);
+      }
+    }
+
+    return {
+      rosterIds: matched.map((r) => r.id),
+      classIds,
+      periodNames: matched.map((r) => r.name),
+      students: Array.from(studentsById.values()),
+      source: 'rosterIds',
+    };
+  }
+
+  // 2. Legacy ClassLink path.
+  if (assignment.classIds && assignment.classIds.length > 0) {
+    return {
+      rosterIds: [],
+      classIds: [...assignment.classIds],
+      periodNames: [],
+      students: [],
+      source: 'classIds',
+    };
+  }
+
+  // 3. Legacy local path.
+  if (assignment.periodNames && assignment.periodNames.length > 0) {
+    return {
+      rosterIds: [],
+      classIds: [],
+      periodNames: [...assignment.periodNames],
+      students: [],
+      source: 'periodNames',
+    };
+  }
+
+  // 4. Untargeted.
+  return {
+    rosterIds: [],
+    classIds: [],
+    periodNames: [],
+    students: [],
+    source: 'none',
+  };
+}
+
+/**
+ * Convenience: given selected rosters (e.g., from the picker at assignment-
+ * create time), derive the fields a session doc needs. Mirrors the
+ * `rosterIds` branch of `resolveAssignmentTargets` but skips the lookup step
+ * since the caller already holds the full roster objects.
+ */
+export function deriveSessionTargetsFromRosters(
+  rosters: ClassRoster[]
+): Pick<
+  ResolvedAssignmentTargets,
+  'rosterIds' | 'classIds' | 'periodNames' | 'students'
+> {
+  const classIds = rosters
+    .map((r) => r.classlinkClassId)
+    .filter((id): id is string => typeof id === 'string' && id.length > 0);
+
+  const studentsById = new Map<string, Student>();
+  for (const r of rosters) {
+    for (const s of r.students) {
+      if (!studentsById.has(s.id)) studentsById.set(s.id, s);
+    }
+  }
+
+  return {
+    rosterIds: rosters.map((r) => r.id),
+    classIds,
+    periodNames: rosters.map((r) => r.name),
+    students: Array.from(studentsById.values()),
+  };
+}

--- a/utils/resolveAssignmentTargets.ts
+++ b/utils/resolveAssignmentTargets.ts
@@ -75,10 +75,13 @@ export function resolveAssignmentTargets(
       }
     }
 
+    // De-dupe periodNames — two local rosters can share a name, and the
+    // student app keys its post-PIN period picker on the period string, so
+    // duplicates collide on React keys.
     return {
       rosterIds: matched.map((r) => r.id),
       classIds,
-      periodNames: matched.map((r) => r.name),
+      periodNames: Array.from(new Set(matched.map((r) => r.name))),
       students: Array.from(studentsById.values()),
       source: 'rosterIds',
     };
@@ -142,7 +145,8 @@ export function deriveSessionTargetsFromRosters(
   return {
     rosterIds: rosters.map((r) => r.id),
     classIds,
-    periodNames: rosters.map((r) => r.name),
+    // De-dupe periodNames — see note in `resolveAssignmentTargets`.
+    periodNames: Array.from(new Set(rosters.map((r) => r.name))),
     students: Array.from(studentsById.values()),
   };
 }

--- a/utils/resolveAssignmentTargets.ts
+++ b/utils/resolveAssignmentTargets.ts
@@ -47,6 +47,53 @@ export interface ResolvedAssignmentTargets {
 }
 
 /**
+ * Core "rosters → session shape" derivation shared by
+ * `resolveAssignmentTargets` (lookup-then-derive) and
+ * `deriveSessionTargetsFromRosters` (already-resolved rosters). Centralizing
+ * the logic guarantees the two paths stay in lock-step on de-duplication
+ * rules and makes the cap on Firestore's `array-contains-any` budget a
+ * single-source-of-truth concern.
+ *
+ * Dedup rationale:
+ * - `classIds`: two rosters can share the same `classlinkClassId` (teacher
+ *   imported the same ClassLink class twice under different local names);
+ *   we'd otherwise waste the Firestore rules' 20-entry budget.
+ * - `students`: a student enrolled in two targeted classes shouldn't appear
+ *   twice in the session student list.
+ * - `periodNames`: two local rosters can share a name; the student app keys
+ *   its post-PIN period picker on the string, so duplicates collide on
+ *   React keys.
+ */
+function deriveTargetsFromRosterList(rosters: ClassRoster[]): {
+  rosterIds: string[];
+  classIds: string[];
+  periodNames: string[];
+  students: Student[];
+} {
+  const classIds = Array.from(
+    new Set(
+      rosters
+        .map((r) => r.classlinkClassId)
+        .filter((id): id is string => typeof id === 'string' && id.length > 0)
+    )
+  );
+
+  const studentsById = new Map<string, Student>();
+  for (const r of rosters) {
+    for (const s of r.students) {
+      if (!studentsById.has(s.id)) studentsById.set(s.id, s);
+    }
+  }
+
+  return {
+    rosterIds: rosters.map((r) => r.id),
+    classIds,
+    periodNames: Array.from(new Set(rosters.map((r) => r.name))),
+    students: Array.from(studentsById.values()),
+  };
+}
+
+/**
  * Resolve an assignment's class targets against the current rosters list.
  * Never throws — unknown roster IDs or missing legacy fields simply drop
  * through to the next precedence level or to the untargeted result.
@@ -62,37 +109,7 @@ export function resolveAssignmentTargets(
       .map((id) => byId.get(id))
       .filter((r): r is ClassRoster => r !== undefined);
 
-    // De-dupe `classIds` — two rosters can share the same `classlinkClassId`
-    // (e.g., teacher imported the same ClassLink class twice under different
-    // local names) and we'd otherwise waste the Firestore rules' 20-entry
-    // `array-contains-any` budget in the session-read path.
-    const classIds = Array.from(
-      new Set(
-        matched
-          .map((r) => r.classlinkClassId)
-          .filter((id): id is string => typeof id === 'string' && id.length > 0)
-      )
-    );
-
-    // De-dupe students across rosters by ID so a student enrolled in two
-    // targeted classes doesn't double up in the session student list.
-    const studentsById = new Map<string, Student>();
-    for (const r of matched) {
-      for (const s of r.students) {
-        if (!studentsById.has(s.id)) studentsById.set(s.id, s);
-      }
-    }
-
-    // De-dupe periodNames — two local rosters can share a name, and the
-    // student app keys its post-PIN period picker on the period string, so
-    // duplicates collide on React keys.
-    return {
-      rosterIds: matched.map((r) => r.id),
-      classIds,
-      periodNames: Array.from(new Set(matched.map((r) => r.name))),
-      students: Array.from(studentsById.values()),
-      source: 'rosterIds',
-    };
+    return { ...deriveTargetsFromRosterList(matched), source: 'rosterIds' };
   }
 
   // 2. Legacy ClassLink path.
@@ -181,28 +198,5 @@ export function deriveSessionTargetsFromRosters(
   ResolvedAssignmentTargets,
   'rosterIds' | 'classIds' | 'periodNames' | 'students'
 > {
-  // See note in `resolveAssignmentTargets` — dedupe both for correctness and
-  // to stay inside the Firestore `array-contains-any` 20-entry budget.
-  const classIds = Array.from(
-    new Set(
-      rosters
-        .map((r) => r.classlinkClassId)
-        .filter((id): id is string => typeof id === 'string' && id.length > 0)
-    )
-  );
-
-  const studentsById = new Map<string, Student>();
-  for (const r of rosters) {
-    for (const s of r.students) {
-      if (!studentsById.has(s.id)) studentsById.set(s.id, s);
-    }
-  }
-
-  return {
-    rosterIds: rosters.map((r) => r.id),
-    classIds,
-    // De-dupe periodNames — see note in `resolveAssignmentTargets`.
-    periodNames: Array.from(new Set(rosters.map((r) => r.name))),
-    students: Array.from(studentsById.values()),
-  };
+  return deriveTargetsFromRosterList(rosters);
 }

--- a/utils/resolveAssignmentTargets.ts
+++ b/utils/resolveAssignmentTargets.ts
@@ -62,9 +62,17 @@ export function resolveAssignmentTargets(
       .map((id) => byId.get(id))
       .filter((r): r is ClassRoster => r !== undefined);
 
-    const classIds = matched
-      .map((r) => r.classlinkClassId)
-      .filter((id): id is string => typeof id === 'string' && id.length > 0);
+    // De-dupe `classIds` — two rosters can share the same `classlinkClassId`
+    // (e.g., teacher imported the same ClassLink class twice under different
+    // local names) and we'd otherwise waste the Firestore rules' 20-entry
+    // `array-contains-any` budget in the session-read path.
+    const classIds = Array.from(
+      new Set(
+        matched
+          .map((r) => r.classlinkClassId)
+          .filter((id): id is string => typeof id === 'string' && id.length > 0)
+      )
+    );
 
     // De-dupe students across rosters by ID so a student enrolled in two
     // targeted classes doesn't double up in the session student list.
@@ -125,17 +133,29 @@ export function resolveAssignmentTargets(
  * rosters' `classlinkClassId` metadata. Used to seed the picker default for
  * teachers whose configs predate the unified `lastRosterIdsBy*` keys.
  *
+ * Partial matches are returned — if the teacher had three legacy sourcedIds
+ * but only re-imported two of them, the other one is silently dropped rather
+ * than refusing the preselection wholesale (better UX than all-or-nothing).
+ *
+ * Tie-break: if two rosters share the same `classlinkClassId` (teacher
+ * imported the same ClassLink class twice), the first one wins — which is
+ * stable per Firestore's default name-ordered roster stream.
+ *
  * Returns an empty array when the teacher hasn't (re-)imported the ClassLink
- * class — we can't recover a preselection that no longer has a roster.
+ * class at all — we can't recover a preselection that no longer has a roster.
  */
 export function mapLegacyClassIdsToRosterIds(
   legacyClassIds: string[] | undefined,
   rosters: ClassRoster[]
 ): string[] {
   if (!legacyClassIds || legacyClassIds.length === 0) return [];
+  // First-wins: earlier rosters in the array win the mapping. Rosters are
+  // typically streamed name-ordered from Firestore, so this is stable.
   const rosterByClassLinkId = new Map<string, string>();
   for (const r of rosters) {
-    if (r.classlinkClassId) rosterByClassLinkId.set(r.classlinkClassId, r.id);
+    if (r.classlinkClassId && !rosterByClassLinkId.has(r.classlinkClassId)) {
+      rosterByClassLinkId.set(r.classlinkClassId, r.id);
+    }
   }
   const mapped: string[] = [];
   const seen = new Set<string>();
@@ -161,9 +181,15 @@ export function deriveSessionTargetsFromRosters(
   ResolvedAssignmentTargets,
   'rosterIds' | 'classIds' | 'periodNames' | 'students'
 > {
-  const classIds = rosters
-    .map((r) => r.classlinkClassId)
-    .filter((id): id is string => typeof id === 'string' && id.length > 0);
+  // See note in `resolveAssignmentTargets` — dedupe both for correctness and
+  // to stay inside the Firestore `array-contains-any` 20-entry budget.
+  const classIds = Array.from(
+    new Set(
+      rosters
+        .map((r) => r.classlinkClassId)
+        .filter((id): id is string => typeof id === 'string' && id.length > 0)
+    )
+  );
 
   const studentsById = new Map<string, Student>();
   for (const r of rosters) {


### PR DESCRIPTION
## Summary

- Makes rosters the single source of truth for assignment targeting across Quiz, Mini-App, Guided Learning, and Video Activity. Imported ClassLink classes carry their provenance (`classlinkClassId`, `classlinkClassCode`, `classlinkSubject`, `classlinkOrgId`, `classlinkSyncedAt`, `origin`) on the roster doc itself — not just on individual students.
- `AssignClassPicker` is now a single multi-select list of the teacher's rosters with a "CL" badge on ClassLink-imported ones. The old `source: 'classlink' | 'local'` branching and the live ClassLink fetch are gone from the picker; live ClassLink data surfaces only in the Import dialog.
- Sessions derive `classIds[]` from each roster's `classlinkClassId` at create time, so `firestore.rules` `passesStudentClassGate` is unchanged and the student SSO gate keeps working.
- New assignments write `rosterIds[]`; legacy assignments continue reading via `classIds[]` / `periodNames[]` via the new `utils/resolveAssignmentTargets.ts` helper — no in-flight session is migrated.

## Key changes

**Data model**
- `types.ts` — `ClassRosterMeta` gains `origin`, `classlinkClassId`, `classlinkClassCode`, `classlinkSubject`, `classlinkOrgId`, `classlinkSyncedAt`. Named `origin` (not `source`) to avoid collision with the existing `ClassRoster.source: 'user' | 'testClass'`.
- Session docs (Quiz, Mini-App, Guided Learning, Video Activity) and assignment docs all gain `rosterIds?: string[]`.
- Per-app teacher memory: `lastRosterIdsByQuizId` / `…ByActivityId` / `…BySetId` / `…ByAppId`. Legacy `lastClassIdsBy*` keys retained as read-only fallback.

**Import dialog** (`components/classes/ClassLinkImportDialog.tsx`)
- New `buildClassLinkRosterMeta()` helper. On import/merge, roster doc is stamped with ClassLink metadata (test classes are skipped — they aren't real ClassLink classes and must not feed garbage sourcedIds into session `classIds[]`).

**Backfill UI** (`components/layout/sidebar/SidebarClasses.tsx`)
- Sync button now shows an amber dot on rosters that have `classLinkSourcedId` students but no `classlinkClassId` on the roster (pre-unification imports). One click re-syncs and backfills metadata.

**Dual-read helper** (`utils/resolveAssignmentTargets.ts`)
- Precedence: `rosterIds` → `classIds` → `periodNames` → untargeted. Also exports `deriveSessionTargetsFromRosters()` used at session create time.

**Gating asymmetry**
- Local-only rosters produce empty session `classIds[]`. For Quiz / VideoActivity / Guided Learning this blocks SSO students (PIN still passes). For Mini-App, `passesStudentClassGateList` treats empty as open — matches today's behavior. Documented in `useMiniAppSession.ts`.

## Test plan

- [x] `pnpm run type-check` — clean
- [x] `pnpm run lint` — clean (zero errors, zero warnings)
- [x] `pnpm run format:check` — clean
- [x] `pnpm run test` — 1,423 tests across 153 files pass
- [ ] Manual E2E per app (Quiz / VideoActivity / Guided Learning / Mini-App):
  - [ ] Import a ClassLink class → verify roster doc has `classlinkClassId` in Firestore console
  - [ ] Create an assignment → verify `rosterIds` on assignment doc and `classIds[]` on session doc
  - [ ] Student joins via ClassLink SSO → gate passes
  - [ ] Student joins via PIN → `periodNames` resolves from roster names
  - [ ] Open a pre-existing legacy assignment → dual-read fallback returns via `classIds` / `periodNames`
  - [ ] Create assignment against a purely-local roster (no ClassLink metadata) → SSO student blocked, PIN student allowed; Mini-App stays open-by-default
  - [ ] Pre-unification roster (has `classLinkSourcedId` students but no `classlinkClassId`) shows amber dot on Sync button; clicking Sync → picking the ClassLink class → metadata backfilled

https://claude.ai/code/session_01VecqgMCRycvfrpG9xqKLK8

---
_Generated by [Claude Code](https://claude.ai/code/session_01VecqgMCRycvfrpG9xqKLK8)_