### PR TITLE
fix(rules): open untargeted sessions to studentRole joiners

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -50,11 +50,20 @@ service cloud.firestore {
              classId in request.auth.token.classIds;
     }
 
-    // Gate helper used inside session rules: "either this caller is NOT a
-    // studentRole user, OR the session's classId is in their classIds claim".
-    // Used on both reads (resource.data) and writes (parent get()).
+    // Gate helper used inside session rules: passes when the caller is NOT a
+    // studentRole user, when the session has no class targeting (empty/missing
+    // classId — treat as "open to any studentRole holder with the PIN"), or
+    // when the session's classId is in their classIds claim.
+    //
+    // The untargeted-open branch mirrors the policy already documented on
+    // passesStudentClassGateList. Without it, a studentRole token (real SSO
+    // student or test-class-bypass super admin) joining a session whose
+    // creator did not pick a ClassLink class is denied — the per-join PIN is
+    // the secret in that path, not class membership.
     function passesStudentClassGate(sessionClassId) {
       return !isStudentRoleUser() ||
+             !(sessionClassId is string) ||
+             sessionClassId.size() == 0 ||
              studentRoleCanAccessClass(sessionClassId);
     }
 

--- a/tests/rules/studentRoleClassGate.test.ts
+++ b/tests/rules/studentRoleClassGate.test.ts
@@ -388,6 +388,29 @@ describe('quiz_sessions/responses — student-role gate', () => {
     );
   });
 
+  // Covers the test-class-bypass path (and the equivalent real-SSO case): a
+  // studentRole user joining a session whose creator did not pick a class.
+  // Such sessions omit `classId`/`classIds` entirely, so the compat wrapper
+  // falls through to `passesStudentClassGate('')`. Before the untargeted-open
+  // branch was added, this denied any studentRole token — breaking the
+  // super-admin "log in as test student" workflow and any real SSO student
+  // PIN-joining a quiz that wasn't targeted to a ClassLink class.
+  it('student-role user can create response on untargeted session (no classId)', async () => {
+    const UNTARGETED = 'session-untargeted';
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      await setDoc(doc(ctx.firestore(), `quiz_sessions/${UNTARGETED}`), {
+        teacherUid: TEACHER_UID,
+        status: 'active',
+      });
+    });
+    await assertSucceeds(
+      setDoc(
+        doc(asStudentA(), `quiz_sessions/${UNTARGETED}/responses/${STUDENT_A_UID}`),
+        { ...baseResp(), joinedAt: 2000 }
+      )
+    );
+  });
+
   it('anonymous PIN student can create response without studentRole restriction', async () => {
     await assertSucceeds(
       setDoc(

--- a/tests/rules/studentRoleClassGate.test.ts
+++ b/tests/rules/studentRoleClassGate.test.ts
@@ -405,7 +405,10 @@ describe('quiz_sessions/responses — student-role gate', () => {
     });
     await assertSucceeds(
       setDoc(
-        doc(asStudentA(), `quiz_sessions/${UNTARGETED}/responses/${STUDENT_A_UID}`),
+        doc(
+          asStudentA(),
+          `quiz_sessions/${UNTARGETED}/responses/${STUDENT_A_UID}`
+        ),
         { ...baseResp(), joinedAt: 2000 }
       )
     );


### PR DESCRIPTION
## Summary

- Fix `passesStudentClassGate` so studentRole tokens are no longer denied on sessions with empty/missing `classId`. Mirrors the untargeted-open branch already documented on `passesStudentClassGateList`.
- Unblocks the super-admin test-class bypass path: a studentRole token minted by [studentLoginV1](functions/src/index.ts#L2869-L2873) could not PIN-join any quiz session that wasn't explicitly targeted to one of the tester's testClass ids — which is most dev/test sessions.
- Closes a latent edge case where a real SSO student PIN-joining an untargeted quiz (teacher used only local rosters, or picked no class) would get the same `permission-denied`.

## Why this was hard to catch

The real-world happy path (ClassLink teacher + ClassLink-targeted quiz + ClassLink-provisioned student) has overlapping `classIds` and routes through [passesStudentClassGateList](firestore.rules#L67-L73), which *does* have the untargeted-open branch. The test-class bypass is the first path that combined `studentRole: true` with a session the teacher created without picking a class, so the asymmetry only surfaces there.

## Test plan

- [x] New rules test `student-role user can create response on untargeted session (no classId)` added to [studentRoleClassGate.test.ts](tests/rules/studentRoleClassGate.test.ts) — locks in the fix and would red without it.
- [x] Existing tests for class-A-to-class-B denial and anon PIN unchanged — short-circuits ahead of the new branch cover them.
- [ ] Manual: super admin (with email in `testClasses.memberEmails`) opens `/quiz?code=XXXXXX`, enters PIN for an untargeted teacher session, joins successfully.
- [ ] Manual: teacher-paced quiz targeted at a real ClassLink class — SSO student still gated correctly (no regression on the primary path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)