### PR TITLE
dev-paul → main: rules hardening + ClassLink roster unification + Phase 5A assign picker

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -77,6 +77,27 @@ jobs:
           path: playwright-report/
           retention-days: 30
 
+  rules:
+    runs-on: ubuntu-24.04
+    name: Firestore Rules Tests
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js and pnpm
+        uses: ./.github/actions/setup
+
+      # firebase-tools is in the root lockfile (pnpm exec firebase).
+      # The Firestore emulator is a Java process, so we need a JDK.
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - name: Run Firestore rules tests
+        run: pnpm run test:rules
+
   build:
     runs-on: ubuntu-24.04
     name: Build
@@ -101,12 +122,12 @@ jobs:
           VITE_PEXELS_API_KEY: ${{ secrets.VITE_PEXELS_API_KEY || 'test-key' }}
 
   summary:
-    needs: [quality, test, build, e2e]
+    needs: [quality, test, rules, build, e2e]
     runs-on: ubuntu-24.04
     if: always()
     steps:
       - name: Add PR Comment
-        if: ${{ needs.quality.result == 'success' && needs.test.result == 'success' && needs.build.result == 'success' && needs.e2e.result == 'success' }}
+        if: ${{ needs.quality.result == 'success' && needs.test.result == 'success' && needs.rules.result == 'success' && needs.build.result == 'success' && needs.e2e.result == 'success' }}
         continue-on-error: true
         uses: actions/github-script@v7
         with:
@@ -120,7 +141,7 @@ jobs:
             })
 
       - name: Add PR Comment on Failure
-        if: ${{ needs.quality.result == 'failure' || needs.test.result == 'failure' || needs.build.result == 'failure' || needs.e2e.result == 'failure' }}
+        if: ${{ needs.quality.result == 'failure' || needs.test.result == 'failure' || needs.rules.result == 'failure' || needs.build.result == 'failure' || needs.e2e.result == 'failure' }}
         continue-on-error: true
         uses: actions/github-script@v7
         with:

--- a/components/classes/ClassLinkImportDialog.tsx
+++ b/components/classes/ClassLinkImportDialog.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { collection, getDocs } from 'firebase/firestore';
 import { Download, Loader2, RefreshCw, AlertCircle } from 'lucide-react';
-import { ClassLinkClass, ClassRoster, Student } from '@/types';
+import { ClassLinkClass, ClassRoster, ClassRosterMeta, Student } from '@/types';
 import { Modal } from '@/components/common/Modal';
 import { db } from '@/config/firebase';
 import { classLinkService } from '@/utils/classlinkService';
@@ -12,6 +12,36 @@ import { useDashboard } from '@/context/useDashboard';
 import { mergeClassLinkStudents } from './mergeClassLinkStudents';
 
 const TEST_PREFIX = 'test:';
+
+/**
+ * Build the ClassLink provenance metadata to persist on a roster document.
+ * Returns `null` for test classes (they aren't real ClassLink classes and
+ * must not claim `origin: 'classlink'` — they'd otherwise feed garbage
+ * sourcedIds into session `classIds[]` and break the student SSO gate).
+ *
+ * NOTE: fields missing from `cls` (e.g., `classCode` cleared upstream) are
+ * omitted rather than set to `deleteField()`, so `updateRoster` at merge
+ * time additively refreshes metadata without wiping previously-stored
+ * values. ClassLink rarely drops these fields in practice; if upstream
+ * ever clears a classCode/subject, the badge tooltip shows stale data
+ * until the teacher re-imports. Acceptable tradeoff vs. an extra
+ * `deleteField()` code path on every merge.
+ */
+const buildClassLinkRosterMeta = (
+  cls: ClassLinkClass,
+  orgId: string | null | undefined
+): Partial<ClassRosterMeta> | null => {
+  if (cls.sourcedId.startsWith(TEST_PREFIX)) return null;
+  const meta: Partial<ClassRosterMeta> = {
+    origin: 'classlink',
+    classlinkClassId: cls.sourcedId,
+    classlinkSyncedAt: Date.now(),
+  };
+  if (cls.classCode) meta.classlinkClassCode = cls.classCode;
+  if (cls.subject) meta.classlinkSubject = cls.subject;
+  if (orgId) meta.classlinkOrgId = orgId;
+  return meta;
+};
 
 // PINs match the synthetic sidebar rosters in `useTestClassRosters.ts` so the
 // same test student uses the same PIN whether they're joining through the
@@ -176,7 +206,8 @@ export const ClassLinkImportDialog: React.FC<ClassLinkImportDialogProps> = ({
       const subjectPrefix = cls.subject ? `${cls.subject} - ` : '';
       const codeSuffix = cls.classCode ? ` (${cls.classCode})` : '';
       const displayName = `${subjectPrefix}${cls.title}${codeSuffix}`;
-      await addRoster(displayName, students);
+      const rosterMeta = buildClassLinkRosterMeta(cls, orgId);
+      await addRoster(displayName, students, rosterMeta ?? undefined);
       addToast(
         t('toasts.classLink.imported', {
           defaultValue: 'Imported {{name}}',
@@ -220,7 +251,15 @@ export const ClassLinkImportDialog: React.FC<ClassLinkImportDialogProps> = ({
         target.students,
         studentsByClass[cls.sourcedId] ?? []
       );
-      await updateRoster(mode.rosterId, { students: result.students });
+      // Backfill ClassLink provenance on the roster doc itself — rosters
+      // imported before the metadata fields existed (or merged with a new
+      // ClassLink class) still need `classlinkClassId` so the student SSO
+      // gate resolves via session `classIds[]` derivation downstream.
+      const rosterMeta = buildClassLinkRosterMeta(cls, orgId);
+      await updateRoster(mode.rosterId, {
+        students: result.students,
+        ...(rosterMeta ?? {}),
+      });
       if (result.addedCount === 0 && result.matchedCount === 0) {
         addToast(
           t('toasts.classLink.noStudents', {

--- a/components/common/AssignClassPicker.helpers.ts
+++ b/components/common/AssignClassPicker.helpers.ts
@@ -1,0 +1,36 @@
+/**
+ * Shared helper + type definitions for `AssignClassPicker`. Kept in a
+ * `.ts` sibling so the `.tsx` component file only exports components
+ * (required for Vite's fast-refresh contract).
+ */
+
+import type { ClassLinkClass } from '@/types';
+
+export type AssignClassSource = 'classlink' | 'local';
+
+export interface AssignClassPickerValue {
+  /** Which source list is currently active. */
+  source: AssignClassSource;
+  /** Selected ClassLink class `sourcedId`s (populated when source === 'classlink'). */
+  classIds: string[];
+  /** Selected local roster names (populated when source === 'local'). */
+  periodNames: string[];
+}
+
+/**
+ * Build a human-readable label for a ClassLink class. Mirrors the format
+ * used elsewhere (ClassLinkImportDialog, legacy QuizManager) so teachers
+ * see the same class names across flows.
+ */
+export function formatClassLinkClassLabel(cls: ClassLinkClass): string {
+  const subjectPrefix = cls.subject ? `${cls.subject} - ` : '';
+  const codeSuffix = cls.classCode ? ` (${cls.classCode})` : '';
+  return `${subjectPrefix}${cls.title}${codeSuffix}`;
+}
+
+/** Default-empty value helper used by callers to seed initial picker state. */
+export function makeEmptyPickerValue(
+  source: AssignClassSource = 'classlink'
+): AssignClassPickerValue {
+  return { source, classIds: [], periodNames: [] };
+}

--- a/components/common/AssignClassPicker.helpers.ts
+++ b/components/common/AssignClassPicker.helpers.ts
@@ -4,23 +4,27 @@
  * (required for Vite's fast-refresh contract).
  */
 
-import type { ClassLinkClass } from '@/types';
+import type { ClassLinkClass, ClassRoster } from '@/types';
 
-export type AssignClassSource = 'classlink' | 'local';
-
+/**
+ * Unified picker value. Rosters are the single source of truth for assignment
+ * targeting — ClassLink-imported rosters carry `classlinkClassId` metadata so
+ * the session-creation layer can still derive ClassLink sourcedIds for the
+ * student SSO gate without the assignment UI having to branch.
+ */
 export interface AssignClassPickerValue {
-  /** Which source list is currently active. */
-  source: AssignClassSource;
-  /** Selected ClassLink class `sourcedId`s (populated when source === 'classlink'). */
-  classIds: string[];
-  /** Selected local roster names (populated when source === 'local'). */
-  periodNames: string[];
+  rosterIds: string[];
+}
+
+/** Default-empty value helper used by callers to seed initial picker state. */
+export function makeEmptyPickerValue(): AssignClassPickerValue {
+  return { rosterIds: [] };
 }
 
 /**
- * Build a human-readable label for a ClassLink class. Mirrors the format
- * used elsewhere (ClassLinkImportDialog, legacy QuizManager) so teachers
- * see the same class names across flows.
+ * Build a human-readable label for a ClassLink class. Retained for the Import
+ * dialog, which still lists live ClassLink classes (the import flow is the
+ * only place live ClassLink data surfaces after the unification).
  */
 export function formatClassLinkClassLabel(cls: ClassLinkClass): string {
   const subjectPrefix = cls.subject ? `${cls.subject} - ` : '';
@@ -28,9 +32,18 @@ export function formatClassLinkClassLabel(cls: ClassLinkClass): string {
   return `${subjectPrefix}${cls.title}${codeSuffix}`;
 }
 
-/** Default-empty value helper used by callers to seed initial picker state. */
-export function makeEmptyPickerValue(
-  source: AssignClassSource = 'classlink'
-): AssignClassPickerValue {
-  return { source, classIds: [], periodNames: [] };
+/**
+ * Derive the selected rosters from the picker value. Filters out IDs that no
+ * longer exist (roster deleted after the value was saved as a teacher
+ * preference) so downstream consumers never see dangling references.
+ */
+export function resolveSelectedRosters(
+  value: AssignClassPickerValue,
+  rosters: ClassRoster[]
+): ClassRoster[] {
+  if (value.rosterIds.length === 0) return [];
+  const byId = new Map(rosters.map((r) => [r.id, r]));
+  return value.rosterIds
+    .map((id) => byId.get(id))
+    .filter((r): r is ClassRoster => r !== undefined);
 }

--- a/components/common/AssignClassPicker.tsx
+++ b/components/common/AssignClassPicker.tsx
@@ -1,28 +1,24 @@
 /**
- * AssignClassPicker — shared class-assignment picker used by the Quiz, Video
- * Activity, and Guided Learning assign modals.
+ * AssignClassPicker — shared class-assignment picker used by Quiz, Video
+ * Activity, Guided Learning, and Mini-App assign modals.
  *
- * Replaces the previous split between a single-select ClassLink dropdown and
- * a separate multi-select local-rosters checklist. Teachers pick a source
- * (ClassLink classes XOR local rosters), then multi-select from the filtered
- * list. Zero selection falls through to the classic code/PIN-only flow.
+ * Shows a single multi-select list of the teacher's local rosters. Rosters
+ * imported from ClassLink carry a "CL" badge (their `classlinkClassId`
+ * metadata drives the student SSO gate downstream). Live ClassLink data is
+ * NOT fetched here — it lives only in the Import dialog, keeping the
+ * assignment flow uniform regardless of roster provenance.
  *
- * The component is controlled — parents own the value and pass it back in
- * via `value` / `onChange`. Source-switching clears the other source's
- * selection automatically so the shape stays consistent.
+ * Controlled component: parents own the value and pass it back in via
+ * `value` / `onChange`. Zero selection falls through to the classic
+ * code/PIN-only join flow.
  */
 
 import React from 'react';
-import { Users, Check } from 'lucide-react';
-import type { ClassLinkClass, ClassRoster } from '@/types';
-import {
-  formatClassLinkClassLabel,
-  type AssignClassSource,
-  type AssignClassPickerValue,
-} from './AssignClassPicker.helpers';
+import { Users, Check, Link2 } from 'lucide-react';
+import type { ClassRoster } from '@/types';
+import type { AssignClassPickerValue } from './AssignClassPicker.helpers';
 
 export interface AssignClassPickerProps {
-  classLinkClasses: ClassLinkClass[];
   rosters: ClassRoster[];
   value: AssignClassPickerValue;
   onChange: (next: AssignClassPickerValue) => void;
@@ -30,87 +26,32 @@ export interface AssignClassPickerProps {
 }
 
 export const AssignClassPicker: React.FC<AssignClassPickerProps> = ({
-  classLinkClasses,
   rosters,
   value,
   onChange,
   disabled = false,
 }) => {
-  const hasClassLink = classLinkClasses.length > 0;
-  const hasLocal = rosters.length > 0;
-
-  const effectiveSource: AssignClassSource = hasClassLink
-    ? value.source
-    : 'local';
-
-  const handleSourceChange = (next: AssignClassSource): void => {
-    if (next === value.source) return;
-    // Clear the other source's selection so the shape stays consistent.
-    onChange({
-      source: next,
-      classIds: [],
-      periodNames: [],
-    });
-  };
-
-  const toggleClassId = (id: string): void => {
-    const next = value.classIds.includes(id)
-      ? value.classIds.filter((x) => x !== id)
-      : [...value.classIds, id];
-    // Always pin `source` to the list being mutated. Without this, callers
-    // whose `value.source` is stale (e.g., the default `'classlink'` seeded
-    // via `makeEmptyPickerValue` even when only local rosters are available)
-    // would see a mismatched `source` vs. populated list and silently drop
-    // the selection in downstream `source === 'classlink'` branches.
-    onChange({
-      ...value,
-      source: 'classlink',
-      classIds: next,
-      periodNames: [],
-    });
-  };
-
-  const togglePeriodName = (name: string): void => {
-    const next = value.periodNames.includes(name)
-      ? value.periodNames.filter((x) => x !== name)
-      : [...value.periodNames, name];
-    onChange({
-      ...value,
-      source: 'local',
-      classIds: [],
-      periodNames: next,
-    });
+  const toggleRosterId = (id: string): void => {
+    const next = value.rosterIds.includes(id)
+      ? value.rosterIds.filter((x) => x !== id)
+      : [...value.rosterIds, id];
+    onChange({ rosterIds: next });
   };
 
   const selectAll = (): void => {
-    if (effectiveSource === 'classlink') {
-      onChange({
-        ...value,
-        source: 'classlink',
-        classIds: classLinkClasses.map((c) => c.sourcedId),
-        periodNames: [],
-      });
-    } else {
-      onChange({
-        ...value,
-        source: 'local',
-        classIds: [],
-        periodNames: rosters.map((r) => r.name),
-      });
-    }
+    // Skip rosters whose Drive students failed to load — selecting them
+    // would produce a session with zero PINs that nobody can join.
+    onChange({
+      rosterIds: rosters.filter((r) => !r.loadError).map((r) => r.id),
+    });
   };
 
   const clearAll = (): void => {
-    onChange({ ...value, classIds: [], periodNames: [] });
+    onChange({ rosterIds: [] });
   };
 
-  const selectedCount =
-    effectiveSource === 'classlink'
-      ? value.classIds.length
-      : value.periodNames.length;
-
-  const totalCount =
-    effectiveSource === 'classlink' ? classLinkClasses.length : rosters.length;
+  const selectedCount = value.rosterIds.length;
+  const totalCount = rosters.length;
 
   return (
     <div
@@ -119,42 +60,31 @@ export const AssignClassPicker: React.FC<AssignClassPickerProps> = ({
       }
     >
       <div className="flex items-center gap-2">
-        <Users className="w-4 h-4 text-brand-blue-primary" />
-        <label className="text-sm font-bold text-brand-blue-dark">
+        <Users
+          aria-hidden="true"
+          focusable="false"
+          className="w-4 h-4 text-brand-blue-primary"
+        />
+        <p className="text-sm font-bold text-brand-blue-dark">
           Assign to classes{' '}
           <span className="text-slate-400 font-normal">(optional)</span>
-        </label>
+        </p>
       </div>
 
-      {hasClassLink && (
-        <div
-          role="radiogroup"
-          aria-label="Class source"
-          className="inline-flex items-center rounded-lg border border-slate-200 bg-slate-50 p-0.5"
-        >
-          <SourceToggleButton
-            label="ClassLink classes"
-            active={effectiveSource === 'classlink'}
-            onClick={() => handleSourceChange('classlink')}
-          />
-          <SourceToggleButton
-            label="Local rosters"
-            active={effectiveSource === 'local'}
-            onClick={() => handleSourceChange('local')}
-            disabled={!hasLocal}
-            disabledHint="No local rosters"
-          />
-        </div>
+      {rosters.length === 0 ? (
+        <EmptyStub message="No classes yet. Create one in My Classes or import from ClassLink to assign here." />
+      ) : (
+        <CheckList>
+          {rosters.map((r) => (
+            <RosterCheckItem
+              key={r.id}
+              roster={r}
+              checked={value.rosterIds.includes(r.id)}
+              onToggle={() => toggleRosterId(r.id)}
+            />
+          ))}
+        </CheckList>
       )}
-
-      <PickerList
-        source={effectiveSource}
-        classLinkClasses={classLinkClasses}
-        rosters={rosters}
-        value={value}
-        onToggleClassId={toggleClassId}
-        onTogglePeriodName={togglePeriodName}
-      />
 
       {totalCount > 0 && (
         <div className="flex items-center justify-between text-xxs text-slate-500">
@@ -189,118 +119,74 @@ export const AssignClassPicker: React.FC<AssignClassPickerProps> = ({
   );
 };
 
-const SourceToggleButton: React.FC<{
-  label: string;
-  active: boolean;
-  onClick: () => void;
-  disabled?: boolean;
-  disabledHint?: string;
-}> = ({ label, active, onClick, disabled = false, disabledHint }) => (
-  <button
-    type="button"
-    role="radio"
-    aria-checked={active}
-    onClick={onClick}
-    disabled={disabled}
-    title={disabled ? disabledHint : undefined}
-    className={`px-3 py-1 text-xs font-bold rounded-md transition-colors ${
-      active
-        ? 'bg-white text-brand-blue-dark shadow-sm'
-        : 'text-slate-500 hover:text-slate-700'
-    } ${disabled ? 'opacity-50 cursor-not-allowed' : ''}`}
-  >
-    {label}
-  </button>
-);
-
-interface PickerListProps {
-  source: AssignClassSource;
-  classLinkClasses: ClassLinkClass[];
-  rosters: ClassRoster[];
-  value: AssignClassPickerValue;
-  onToggleClassId: (id: string) => void;
-  onTogglePeriodName: (name: string) => void;
-}
-
-const PickerList: React.FC<PickerListProps> = ({
-  source,
-  classLinkClasses,
-  rosters,
-  value,
-  onToggleClassId,
-  onTogglePeriodName,
-}) => {
-  if (source === 'classlink') {
-    if (classLinkClasses.length === 0) {
-      return (
-        <EmptyStub message="No ClassLink classes found. Switch to Local rosters or assign with a code/PIN only." />
-      );
-    }
-    return (
-      <CheckList>
-        {classLinkClasses.map((cls) => (
-          <CheckItem
-            key={cls.sourcedId}
-            checked={value.classIds.includes(cls.sourcedId)}
-            label={formatClassLinkClassLabel(cls)}
-            onToggle={() => onToggleClassId(cls.sourcedId)}
-          />
-        ))}
-      </CheckList>
-    );
-  }
-
-  // source === 'local'
-  if (rosters.length === 0) {
-    return (
-      <EmptyStub message="No local rosters. Import a roster from the Classes panel, or assign with a code/PIN only." />
-    );
-  }
-  return (
-    <CheckList>
-      {rosters.map((r) => (
-        <CheckItem
-          key={r.id}
-          checked={value.periodNames.includes(r.name)}
-          label={r.name}
-          onToggle={() => onTogglePeriodName(r.name)}
-        />
-      ))}
-    </CheckList>
-  );
-};
-
 const CheckList: React.FC<{ children: React.ReactNode }> = ({ children }) => (
   <div className="space-y-1 max-h-40 overflow-y-auto rounded-lg border border-slate-200 bg-white p-2">
     {children}
   </div>
 );
 
-const CheckItem: React.FC<{
+const RosterCheckItem: React.FC<{
+  roster: ClassRoster;
   checked: boolean;
-  label: string;
   onToggle: () => void;
-}> = ({ checked, label, onToggle }) => (
-  <label className="flex items-center gap-2 cursor-pointer hover:bg-slate-50 rounded px-1.5 py-1">
-    <span
-      aria-hidden="true"
-      className={`flex items-center justify-center w-4 h-4 rounded border transition-colors ${
-        checked
-          ? 'bg-brand-blue-primary border-brand-blue-primary text-white'
-          : 'bg-white border-slate-300'
+}> = ({ roster, checked, onToggle }) => {
+  const isClassLink = Boolean(roster.classlinkClassId);
+  const badgeTitle = isClassLink
+    ? [roster.classlinkSubject, roster.classlinkClassCode]
+        .filter(Boolean)
+        .join(' · ') || 'Imported from ClassLink'
+    : undefined;
+  // Rosters whose Drive students failed to load produce sessions with zero
+  // PINs that no student can join. Disable selection and surface the reason
+  // inline so teachers aren't surprised by a broken assignment later.
+  const disabled = Boolean(roster.loadError);
+
+  return (
+    <label
+      className={`flex items-center gap-2 rounded px-1.5 py-1 ${
+        disabled
+          ? 'cursor-not-allowed opacity-50'
+          : 'cursor-pointer hover:bg-slate-50'
       }`}
+      title={disabled ? roster.loadError : undefined}
     >
-      {checked && <Check className="w-3 h-3" strokeWidth={3} />}
-    </span>
-    <input
-      type="checkbox"
-      className="sr-only"
-      checked={checked}
-      onChange={onToggle}
-    />
-    <span className="text-sm text-slate-800">{label}</span>
-  </label>
-);
+      <span
+        aria-hidden="true"
+        className={`flex items-center justify-center w-4 h-4 rounded border transition-colors ${
+          checked
+            ? 'bg-brand-blue-primary border-brand-blue-primary text-white'
+            : 'bg-white border-slate-300'
+        }`}
+      >
+        {checked && <Check className="w-3 h-3" strokeWidth={3} />}
+      </span>
+      <input
+        type="checkbox"
+        className="sr-only"
+        checked={checked}
+        disabled={disabled}
+        onChange={onToggle}
+      />
+      <span className="text-sm text-slate-800 flex-1 truncate">
+        {roster.name}
+      </span>
+      {disabled && (
+        <span className="shrink-0 text-[9px] font-bold uppercase tracking-wider text-red-500">
+          Unavailable
+        </span>
+      )}
+      {isClassLink && (
+        <span
+          className="shrink-0 inline-flex items-center gap-0.5 text-[9px] font-bold uppercase tracking-wider px-1.5 py-0.5 rounded bg-brand-blue-lighter text-brand-blue-dark border border-brand-blue-light"
+          title={badgeTitle}
+        >
+          <Link2 aria-hidden="true" focusable="false" className="w-2.5 h-2.5" />
+          CL
+        </span>
+      )}
+    </label>
+  );
+};
 
 const EmptyStub: React.FC<{ message: string }> = ({ message }) => (
   <p className="text-xxs text-slate-500 rounded-lg border border-dashed border-slate-200 bg-slate-50 px-3 py-2">

--- a/components/common/AssignClassPicker.tsx
+++ b/components/common/AssignClassPicker.tsx
@@ -1,0 +1,309 @@
+/**
+ * AssignClassPicker — shared class-assignment picker used by the Quiz, Video
+ * Activity, and Guided Learning assign modals.
+ *
+ * Replaces the previous split between a single-select ClassLink dropdown and
+ * a separate multi-select local-rosters checklist. Teachers pick a source
+ * (ClassLink classes XOR local rosters), then multi-select from the filtered
+ * list. Zero selection falls through to the classic code/PIN-only flow.
+ *
+ * The component is controlled — parents own the value and pass it back in
+ * via `value` / `onChange`. Source-switching clears the other source's
+ * selection automatically so the shape stays consistent.
+ */
+
+import React from 'react';
+import { Users, Check } from 'lucide-react';
+import type { ClassLinkClass, ClassRoster } from '@/types';
+import {
+  formatClassLinkClassLabel,
+  type AssignClassSource,
+  type AssignClassPickerValue,
+} from './AssignClassPicker.helpers';
+
+export interface AssignClassPickerProps {
+  classLinkClasses: ClassLinkClass[];
+  rosters: ClassRoster[];
+  value: AssignClassPickerValue;
+  onChange: (next: AssignClassPickerValue) => void;
+  disabled?: boolean;
+}
+
+export const AssignClassPicker: React.FC<AssignClassPickerProps> = ({
+  classLinkClasses,
+  rosters,
+  value,
+  onChange,
+  disabled = false,
+}) => {
+  const hasClassLink = classLinkClasses.length > 0;
+  const hasLocal = rosters.length > 0;
+
+  const effectiveSource: AssignClassSource = hasClassLink
+    ? value.source
+    : 'local';
+
+  const handleSourceChange = (next: AssignClassSource): void => {
+    if (next === value.source) return;
+    // Clear the other source's selection so the shape stays consistent.
+    onChange({
+      source: next,
+      classIds: [],
+      periodNames: [],
+    });
+  };
+
+  const toggleClassId = (id: string): void => {
+    const next = value.classIds.includes(id)
+      ? value.classIds.filter((x) => x !== id)
+      : [...value.classIds, id];
+    // Always pin `source` to the list being mutated. Without this, callers
+    // whose `value.source` is stale (e.g., the default `'classlink'` seeded
+    // via `makeEmptyPickerValue` even when only local rosters are available)
+    // would see a mismatched `source` vs. populated list and silently drop
+    // the selection in downstream `source === 'classlink'` branches.
+    onChange({
+      ...value,
+      source: 'classlink',
+      classIds: next,
+      periodNames: [],
+    });
+  };
+
+  const togglePeriodName = (name: string): void => {
+    const next = value.periodNames.includes(name)
+      ? value.periodNames.filter((x) => x !== name)
+      : [...value.periodNames, name];
+    onChange({
+      ...value,
+      source: 'local',
+      classIds: [],
+      periodNames: next,
+    });
+  };
+
+  const selectAll = (): void => {
+    if (effectiveSource === 'classlink') {
+      onChange({
+        ...value,
+        source: 'classlink',
+        classIds: classLinkClasses.map((c) => c.sourcedId),
+        periodNames: [],
+      });
+    } else {
+      onChange({
+        ...value,
+        source: 'local',
+        classIds: [],
+        periodNames: rosters.map((r) => r.name),
+      });
+    }
+  };
+
+  const clearAll = (): void => {
+    onChange({ ...value, classIds: [], periodNames: [] });
+  };
+
+  const selectedCount =
+    effectiveSource === 'classlink'
+      ? value.classIds.length
+      : value.periodNames.length;
+
+  const totalCount =
+    effectiveSource === 'classlink' ? classLinkClasses.length : rosters.length;
+
+  return (
+    <div
+      className={
+        disabled ? 'opacity-50 pointer-events-none space-y-2' : 'space-y-2'
+      }
+    >
+      <div className="flex items-center gap-2">
+        <Users className="w-4 h-4 text-brand-blue-primary" />
+        <label className="text-sm font-bold text-brand-blue-dark">
+          Assign to classes{' '}
+          <span className="text-slate-400 font-normal">(optional)</span>
+        </label>
+      </div>
+
+      {hasClassLink && (
+        <div
+          role="radiogroup"
+          aria-label="Class source"
+          className="inline-flex items-center rounded-lg border border-slate-200 bg-slate-50 p-0.5"
+        >
+          <SourceToggleButton
+            label="ClassLink classes"
+            active={effectiveSource === 'classlink'}
+            onClick={() => handleSourceChange('classlink')}
+          />
+          <SourceToggleButton
+            label="Local rosters"
+            active={effectiveSource === 'local'}
+            onClick={() => handleSourceChange('local')}
+            disabled={!hasLocal}
+            disabledHint="No local rosters"
+          />
+        </div>
+      )}
+
+      <PickerList
+        source={effectiveSource}
+        classLinkClasses={classLinkClasses}
+        rosters={rosters}
+        value={value}
+        onToggleClassId={toggleClassId}
+        onTogglePeriodName={togglePeriodName}
+      />
+
+      {totalCount > 0 && (
+        <div className="flex items-center justify-between text-xxs text-slate-500">
+          <span>
+            {selectedCount === 0
+              ? 'None selected — students join with the code only.'
+              : `${selectedCount} of ${totalCount} selected.`}
+          </span>
+          <div className="flex items-center gap-2">
+            {selectedCount < totalCount && (
+              <button
+                type="button"
+                onClick={selectAll}
+                className="font-bold text-brand-blue-primary hover:text-brand-blue-dark"
+              >
+                Select all ({totalCount})
+              </button>
+            )}
+            {selectedCount > 0 && (
+              <button
+                type="button"
+                onClick={clearAll}
+                className="font-bold text-slate-500 hover:text-slate-700"
+              >
+                Clear
+              </button>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+const SourceToggleButton: React.FC<{
+  label: string;
+  active: boolean;
+  onClick: () => void;
+  disabled?: boolean;
+  disabledHint?: string;
+}> = ({ label, active, onClick, disabled = false, disabledHint }) => (
+  <button
+    type="button"
+    role="radio"
+    aria-checked={active}
+    onClick={onClick}
+    disabled={disabled}
+    title={disabled ? disabledHint : undefined}
+    className={`px-3 py-1 text-xs font-bold rounded-md transition-colors ${
+      active
+        ? 'bg-white text-brand-blue-dark shadow-sm'
+        : 'text-slate-500 hover:text-slate-700'
+    } ${disabled ? 'opacity-50 cursor-not-allowed' : ''}`}
+  >
+    {label}
+  </button>
+);
+
+interface PickerListProps {
+  source: AssignClassSource;
+  classLinkClasses: ClassLinkClass[];
+  rosters: ClassRoster[];
+  value: AssignClassPickerValue;
+  onToggleClassId: (id: string) => void;
+  onTogglePeriodName: (name: string) => void;
+}
+
+const PickerList: React.FC<PickerListProps> = ({
+  source,
+  classLinkClasses,
+  rosters,
+  value,
+  onToggleClassId,
+  onTogglePeriodName,
+}) => {
+  if (source === 'classlink') {
+    if (classLinkClasses.length === 0) {
+      return (
+        <EmptyStub message="No ClassLink classes found. Switch to Local rosters or assign with a code/PIN only." />
+      );
+    }
+    return (
+      <CheckList>
+        {classLinkClasses.map((cls) => (
+          <CheckItem
+            key={cls.sourcedId}
+            checked={value.classIds.includes(cls.sourcedId)}
+            label={formatClassLinkClassLabel(cls)}
+            onToggle={() => onToggleClassId(cls.sourcedId)}
+          />
+        ))}
+      </CheckList>
+    );
+  }
+
+  // source === 'local'
+  if (rosters.length === 0) {
+    return (
+      <EmptyStub message="No local rosters. Import a roster from the Classes panel, or assign with a code/PIN only." />
+    );
+  }
+  return (
+    <CheckList>
+      {rosters.map((r) => (
+        <CheckItem
+          key={r.id}
+          checked={value.periodNames.includes(r.name)}
+          label={r.name}
+          onToggle={() => onTogglePeriodName(r.name)}
+        />
+      ))}
+    </CheckList>
+  );
+};
+
+const CheckList: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+  <div className="space-y-1 max-h-40 overflow-y-auto rounded-lg border border-slate-200 bg-white p-2">
+    {children}
+  </div>
+);
+
+const CheckItem: React.FC<{
+  checked: boolean;
+  label: string;
+  onToggle: () => void;
+}> = ({ checked, label, onToggle }) => (
+  <label className="flex items-center gap-2 cursor-pointer hover:bg-slate-50 rounded px-1.5 py-1">
+    <span
+      aria-hidden="true"
+      className={`flex items-center justify-center w-4 h-4 rounded border transition-colors ${
+        checked
+          ? 'bg-brand-blue-primary border-brand-blue-primary text-white'
+          : 'bg-white border-slate-300'
+      }`}
+    >
+      {checked && <Check className="w-3 h-3" strokeWidth={3} />}
+    </span>
+    <input
+      type="checkbox"
+      className="sr-only"
+      checked={checked}
+      onChange={onToggle}
+    />
+    <span className="text-sm text-slate-800">{label}</span>
+  </label>
+);
+
+const EmptyStub: React.FC<{ message: string }> = ({ message }) => (
+  <p className="text-xxs text-slate-500 rounded-lg border border-dashed border-slate-200 bg-slate-50 px-3 py-2">
+    {message}
+  </p>
+);

--- a/components/guidedLearning/GuidedLearningStudentApp.tsx
+++ b/components/guidedLearning/GuidedLearningStudentApp.tsx
@@ -13,7 +13,9 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { signInAnonymously } from 'firebase/auth';
 import {
+  ArrowRight,
   BookOpen,
+  ClipboardList,
   Loader2,
   AlertCircle,
   CheckCircle2,
@@ -94,6 +96,10 @@ const StudentExperience: React.FC<{ anonymousUid: string }> = ({
   const [completed, setCompleted] = useState(false);
   const [score, setScore] = useState<number | null>(null);
   const [answers, setAnswers] = useState<GuidedLearningResponse['answers']>([]);
+  // Phase 5A: post-PIN class-period picker. When the session has multiple
+  // periods configured, the student chooses one before the experience
+  // begins; the value is persisted on their response doc.
+  const [classPeriod, setClassPeriod] = useState<string | null>(null);
   const startedAt = React.useRef<number>(0);
   useEffect(() => {
     if (startedAt.current === 0) {
@@ -132,12 +138,21 @@ const StudentExperience: React.FC<{ anonymousUid: string }> = ({
       startedAt: startedAt.current,
       completedAt: Date.now(),
       score: computedScore,
+      ...(classPeriod ? { classPeriod } : {}),
     };
 
     await submitResponse(response).catch((err) => {
       console.error('[GuidedLearningStudentApp] Submit error:', err);
     });
-  }, [session, answers, pin, anonymousUid, sessionId, submitResponse]);
+  }, [
+    session,
+    answers,
+    pin,
+    anonymousUid,
+    sessionId,
+    submitResponse,
+    classPeriod,
+  ]);
 
   if (loading) return <FullPageLoader />;
   if (error) return <ErrorScreen message={error} />;
@@ -153,7 +168,17 @@ const StudentExperience: React.FC<{ anonymousUid: string }> = ({
         session={session}
         pin={pin}
         onPinChange={setPin}
-        onStart={() => setStarted(true)}
+        selectedPeriod={classPeriod}
+        onPeriodChange={setClassPeriod}
+        onStart={() => {
+          // Auto-select the single period if there's exactly one so the
+          // response still gets tagged consistently.
+          const periods = session.periodNames ?? [];
+          if (periods.length === 1 && !classPeriod) {
+            setClassPeriod(periods[0]);
+          }
+          setStarted(true);
+        }}
       />
     );
   }
@@ -199,39 +224,101 @@ const StartScreen: React.FC<{
   session: GuidedLearningSession;
   pin: string;
   onPinChange: (v: string) => void;
+  selectedPeriod: string | null;
+  onPeriodChange: (v: string | null) => void;
   onStart: () => void;
-}> = ({ session, pin, onPinChange, onStart }) => (
-  <div className="min-h-screen bg-slate-950 flex items-center justify-center p-6">
-    <div className="bg-slate-900 border border-white/10 rounded-2xl p-8 max-w-sm w-full text-center shadow-2xl">
-      <BookOpen className="w-10 h-10 text-indigo-400 mx-auto mb-3" />
-      <h1 className="text-white font-bold text-xl mb-1">{session.title}</h1>
-      <p className="text-slate-400 text-sm mb-6 capitalize">
-        {session.mode} mode · {session.publicSteps.length} steps
-      </p>
+}> = ({
+  session,
+  pin,
+  onPinChange,
+  selectedPeriod,
+  onPeriodChange,
+  onStart,
+}) => {
+  const periods = session.periodNames ?? [];
+  const needsPeriodPicker = periods.length > 1 && !selectedPeriod;
 
-      <div className="mb-6">
-        <label className="block text-slate-400 text-xs mb-1.5 text-left">
-          Your PIN <span className="text-slate-600">(optional)</span>
-        </label>
-        <input
-          type="text"
-          value={pin}
-          onChange={(e) => onPinChange(e.target.value)}
-          placeholder="Enter your class PIN"
-          className="w-full bg-slate-800 border border-slate-600 rounded-xl px-4 py-2.5 text-white text-sm text-center tracking-widest"
-          maxLength={10}
-        />
+  if (needsPeriodPicker) {
+    return (
+      <div className="min-h-screen bg-slate-950 flex items-center justify-center p-6">
+        <div className="bg-slate-900 border border-white/10 rounded-2xl p-8 max-w-sm w-full text-center shadow-2xl">
+          <ClipboardList className="w-8 h-8 text-indigo-400 mx-auto mb-3" />
+          <h1 className="text-white font-bold text-xl mb-1">
+            Select Your Class
+          </h1>
+          <p className="text-slate-400 text-sm mb-5">
+            Which class period are you in?
+          </p>
+          <div className="space-y-2 mb-5 text-left">
+            {periods.map((p) => (
+              <button
+                key={p}
+                onClick={() => onPeriodChange(p)}
+                className="w-full px-4 py-3 rounded-xl text-base font-bold transition-all bg-slate-800 border border-slate-700 text-slate-200 hover:bg-slate-700"
+              >
+                {p}
+              </button>
+            ))}
+          </div>
+          <p className="text-xxs text-slate-500">
+            Pick one to continue. You can enter your PIN after this step.
+          </p>
+        </div>
       </div>
+    );
+  }
 
-      <button
-        onClick={onStart}
-        className="w-full py-3 bg-indigo-600 hover:bg-indigo-500 text-white font-semibold rounded-xl transition-colors"
-      >
-        Start
-      </button>
+  return (
+    <div className="min-h-screen bg-slate-950 flex items-center justify-center p-6">
+      <div className="bg-slate-900 border border-white/10 rounded-2xl p-8 max-w-sm w-full text-center shadow-2xl">
+        <BookOpen className="w-10 h-10 text-indigo-400 mx-auto mb-3" />
+        <h1 className="text-white font-bold text-xl mb-1">{session.title}</h1>
+        <p className="text-slate-400 text-sm mb-6 capitalize">
+          {session.mode} mode · {session.publicSteps.length} steps
+        </p>
+
+        {selectedPeriod && periods.length > 1 && (
+          <div className="mb-4 flex items-center justify-between rounded-lg border border-slate-700 bg-slate-800/60 px-3 py-2">
+            <span className="text-xs text-slate-400">Class</span>
+            <div className="flex items-center gap-2">
+              <span className="text-sm font-bold text-white">
+                {selectedPeriod}
+              </span>
+              <button
+                onClick={() => onPeriodChange(null)}
+                className="text-xxs text-slate-500 hover:text-slate-300"
+              >
+                Change
+              </button>
+            </div>
+          </div>
+        )}
+
+        <div className="mb-6">
+          <label className="block text-slate-400 text-xs mb-1.5 text-left">
+            Your PIN <span className="text-slate-600">(optional)</span>
+          </label>
+          <input
+            type="text"
+            value={pin}
+            onChange={(e) => onPinChange(e.target.value)}
+            placeholder="Enter your class PIN"
+            className="w-full bg-slate-800 border border-slate-600 rounded-xl px-4 py-2.5 text-white text-sm text-center tracking-widest"
+            maxLength={10}
+          />
+        </div>
+
+        <button
+          onClick={onStart}
+          className="w-full py-3 bg-indigo-600 hover:bg-indigo-500 text-white font-semibold rounded-xl transition-colors flex items-center justify-center gap-2"
+        >
+          Start
+          <ArrowRight className="w-4 h-4" />
+        </button>
+      </div>
     </div>
-  </div>
-);
+  );
+};
 
 const CompletionScreen: React.FC<{
   session: GuidedLearningSession;

--- a/components/layout/sidebar/SidebarClasses.tsx
+++ b/components/layout/sidebar/SidebarClasses.tsx
@@ -279,27 +279,50 @@ export const SidebarClasses: React.FC<SidebarClassesProps> = ({
                               >
                                 <Pencil className="w-3.5 h-3.5" />
                               </button>
-                              {classLinkEnabled && (
-                                <button
-                                  onClick={() =>
-                                    setClassLinkMode({
-                                      kind: 'merge',
-                                      rosterId: r.id,
-                                      rosterName: r.name,
-                                    })
-                                  }
-                                  className="p-1.5 text-slate-400 hover:text-brand-blue-primary hover:bg-brand-blue-lighter rounded-lg transition-colors"
-                                  title={t('sidebar.classes.syncClassLink', {
-                                    defaultValue: 'Sync with ClassLink',
-                                  })}
-                                  aria-label={t(
-                                    'sidebar.classes.syncClassLink',
-                                    { defaultValue: 'Sync with ClassLink' }
-                                  )}
-                                >
-                                  <RefreshCw className="w-3.5 h-3.5" />
-                                </button>
-                              )}
+                              {classLinkEnabled &&
+                                (() => {
+                                  // Rosters whose students carry
+                                  // `classLinkSourcedId` but whose doc lacks
+                                  // `classlinkClassId` predate the unified
+                                  // metadata and are invisible to the student
+                                  // SSO gate. Surface an amber dot on Sync so
+                                  // the teacher knows to re-sync — the merge
+                                  // handler now backfills metadata for them.
+                                  const needsBackfill =
+                                    !r.classlinkClassId &&
+                                    r.students.some(
+                                      (s) => s.classLinkSourcedId
+                                    );
+                                  const syncLabel = needsBackfill
+                                    ? t('sidebar.classes.linkClassLink', {
+                                        defaultValue: 'Link to ClassLink class',
+                                      })
+                                    : t('sidebar.classes.syncClassLink', {
+                                        defaultValue: 'Sync with ClassLink',
+                                      });
+                                  return (
+                                    <button
+                                      onClick={() =>
+                                        setClassLinkMode({
+                                          kind: 'merge',
+                                          rosterId: r.id,
+                                          rosterName: r.name,
+                                        })
+                                      }
+                                      className="relative p-1.5 text-slate-400 hover:text-brand-blue-primary hover:bg-brand-blue-lighter rounded-lg transition-colors"
+                                      title={syncLabel}
+                                      aria-label={syncLabel}
+                                    >
+                                      <RefreshCw className="w-3.5 h-3.5" />
+                                      {needsBackfill && (
+                                        <span
+                                          aria-hidden="true"
+                                          className="absolute top-1 right-1 w-1.5 h-1.5 rounded-full bg-amber-500"
+                                        />
+                                      )}
+                                    </button>
+                                  );
+                                })()}
                               <button
                                 onClick={() => void handleDelete(r)}
                                 className="p-1.5 text-slate-400 hover:text-red-500 hover:bg-red-50 rounded-lg transition-colors"

--- a/components/student/MyAssignmentsPage.tsx
+++ b/components/student/MyAssignmentsPage.tsx
@@ -1,10 +1,4 @@
-import React, {
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   collection,
   doc,
@@ -12,6 +6,7 @@ import {
   onSnapshot,
   query,
   where,
+  type Query,
   type QuerySnapshot,
   type DocumentData,
 } from 'firebase/firestore';
@@ -38,8 +33,16 @@ import { useStudentAuth } from '@/context/useStudentAuth';
  *
  * Landing page for a signed-in student. Subscribes to the five session
  * collections (`quiz_sessions`, `video_activity_sessions`,
- * `guided_learning_sessions`, `mini_app_sessions`, `activity_wall_sessions`),
- * filtered by `classId in classIds`, and renders the union as a single list.
+ * `guided_learning_sessions`, `mini_app_sessions`, `activity_wall_sessions`)
+ * and renders the union as a single list.
+ *
+ * Query strategy: quiz / video-activity / guided-learning subscribe to TWO
+ * queries each — one on the Phase 5A `classIds` array (array-contains-any)
+ * and one on the legacy `classId` string (in) — merging by sessionId so
+ * students in *any* class targeted by a multi-class assignment are covered
+ * while legacy single-class sessions still surface. Mini-app is list-only
+ * (its sessions have always been multi-class) and activity-wall is
+ * single-only (has not been migrated to multi-class yet).
  *
  * PII-free: reads only session-level fields (title, status, code, classId).
  * Never reads, logs, or persists email / displayName / sub. The only
@@ -86,14 +89,29 @@ type LoadState = 'loading' | 'ready';
 
 interface KindConfig {
   collectionName: string;
-  /** Firestore status filter, or `null` when the collection has no status field. */
-  statusFilter: { field: 'status'; value: 'active' } | null;
   /**
-   * How this collection stores its class targeting:
+   * When true, subscribe to TWO queries per kind and merge results by
+   * `sessionId` (de-duping any overlap):
+   *   - `list`   — `where('classIds', 'array-contains-any', classIds)` — Phase 5A multi-class
+   *   - `single` — `where('classId', 'in', classIds)`                   — legacy single-class
+   * This is required for quiz/video-activity/guided-learning so that
+   * multi-class assignments (Phase 5A) are discovered for students in
+   * *any* targeted class — not just `classIds[0]` — while legacy
+   * single-class sessions (with no `classIds` array) still surface.
+   *
+   * When false, a single query is issued using `classFilterShape`.
+   */
+  dualQuery: boolean;
+  /** Firestore status filter, or `null` when the collection has no status field. */
+  statusFilter:
+    | { field: 'status'; value: 'active' }
+    | { field: 'status'; valueIn: readonly string[] }
+    | null;
+  /**
+   * Shape used when `dualQuery` is false. Describes how this collection
+   * stores its class targeting:
    *   - `single` — a string `classId` field (queried with `where(..., 'in', classIds)`)
    *   - `list`   — an array `classIds` field (queried with `where(..., 'array-contains-any', classIds)`)
-   * Mini-app sessions are `list` (multi-class targeting); every other kind
-   * is still single-class.
    */
   classFilterShape: 'single' | 'list';
   /** Subcollection where per-student response/submission docs live; null when absent. */
@@ -133,7 +151,11 @@ interface KindConfig {
 const KIND_CONFIG: Record<SessionKind, KindConfig> = {
   quiz: {
     collectionName: 'quiz_sessions',
-    statusFilter: { field: 'status', value: 'active' },
+    dualQuery: true,
+    // Include `waiting` so teacher-paced quizzes (which sit in 'waiting'
+    // after Play but before the teacher advances to Q1) surface on
+    // `/my-assignments` — matching the PIN-flow experience.
+    statusFilter: { field: 'status', valueIn: ['waiting', 'active'] },
     classFilterShape: 'single',
     responseSubcollection: 'responses',
     label: 'Quiz',
@@ -156,6 +178,7 @@ const KIND_CONFIG: Record<SessionKind, KindConfig> = {
   },
   'video-activity': {
     collectionName: 'video_activity_sessions',
+    dualQuery: true,
     statusFilter: { field: 'status', value: 'active' },
     classFilterShape: 'single',
     responseSubcollection: 'responses',
@@ -179,6 +202,7 @@ const KIND_CONFIG: Record<SessionKind, KindConfig> = {
   },
   'guided-learning': {
     collectionName: 'guided_learning_sessions',
+    dualQuery: true,
     statusFilter: null, // No status field; session presence = live.
     classFilterShape: 'single',
     responseSubcollection: 'responses',
@@ -194,6 +218,7 @@ const KIND_CONFIG: Record<SessionKind, KindConfig> = {
   },
   'mini-app': {
     collectionName: 'mini_app_sessions',
+    dualQuery: false,
     statusFilter: { field: 'status', value: 'active' },
     classFilterShape: 'list',
     responseSubcollection: 'submissions',
@@ -214,6 +239,7 @@ const KIND_CONFIG: Record<SessionKind, KindConfig> = {
   },
   'activity-wall': {
     collectionName: 'activity_wall_sessions',
+    dualQuery: false,
     statusFilter: null, // No status field on the session doc.
     classFilterShape: 'single',
     // ActivityWall submissions are a LIST per student (students can post
@@ -260,10 +286,6 @@ const MyAssignmentsPage: React.FC = () => {
   );
   const [loadState, setLoadState] = useState<LoadState>('loading');
 
-  // Track which kinds have delivered their first snapshot so we can flip
-  // from `loading` -> `ready` only once every subscription has settled.
-  const settledKindsRef = useRef<Set<SessionKind>>(new Set());
-
   // Stable subscription identity: we only re-subscribe when classIds actually
   // changes, not on every render.
   const classIdsKey = useMemo(
@@ -280,76 +302,148 @@ const MyAssignmentsPage: React.FC = () => {
     }
 
     setLoadState('loading');
-    settledKindsRef.current = new Set();
 
-    const unsubs: Array<() => void> = [];
+    type QueryShape = 'list' | 'single';
+    const bucketKey = (kind: SessionKind, shape: QueryShape) =>
+      `${kind}:${shape}`;
 
-    const handleSnapshot = (
-      kind: SessionKind,
-      snap: QuerySnapshot<DocumentData>
-    ) => {
+    // Plan every (kind, shape) subscription up front so we know the total
+    // count and can flip to `ready` exactly when every subscription has
+    // delivered its first snapshot (success OR error).
+    const subs: Array<{ kind: SessionKind; shape: QueryShape }> = [];
+    for (const kind of SESSION_KINDS) {
       const config = KIND_CONFIG[kind];
-      const items: AssignmentSummary[] = snap.docs.map((d) => {
-        const data = d.data();
-        const createdAtRaw: unknown = (data as Record<string, unknown>)
-          .createdAt;
-        return {
-          compositeId: `${kind}:${d.id}`,
-          kind,
-          sessionId: d.id,
-          title: config.titleFrom(data),
-          openHref: config.hrefFrom(d.id, data),
-          createdAt:
-            typeof createdAtRaw === 'number' ? createdAtRaw : undefined,
-        };
-      });
+      if (config.dualQuery) {
+        subs.push({ kind, shape: 'list' }, { kind, shape: 'single' });
+      } else {
+        subs.push({ kind, shape: config.classFilterShape });
+      }
+    }
+    const totalSubscriptions = subs.length;
 
-      setByKind((prev) => ({ ...prev, [kind]: items }));
-      settledKindsRef.current.add(kind);
-      if (settledKindsRef.current.size === SESSION_KINDS.length) {
+    // Per-(kind, shape) result buckets. When a kind has two subscriptions
+    // we merge both buckets by `sessionId` before emitting `byKind`, so a
+    // Phase 5A session whose `classIds[0]` equals one of the student's
+    // classIds (and therefore matches BOTH queries) is counted exactly
+    // once.
+    const buckets = new Map<string, AssignmentSummary[]>();
+    const settled = new Set<string>();
+
+    const docToSummary = (
+      kind: SessionKind,
+      config: KindConfig,
+      d: QuerySnapshot<DocumentData>['docs'][number]
+    ): AssignmentSummary => {
+      const data = d.data();
+      const createdAtRaw: unknown = (data as Record<string, unknown>).createdAt;
+      return {
+        compositeId: `${kind}:${d.id}`,
+        kind,
+        sessionId: d.id,
+        title: config.titleFrom(data),
+        openHref: config.hrefFrom(d.id, data),
+        createdAt: typeof createdAtRaw === 'number' ? createdAtRaw : undefined,
+      };
+    };
+
+    const emitMerged = (kind: SessionKind) => {
+      const listBucket = buckets.get(bucketKey(kind, 'list')) ?? [];
+      const singleBucket = buckets.get(bucketKey(kind, 'single')) ?? [];
+      if (listBucket.length === 0 && singleBucket.length === 0) {
+        setByKind((prev) =>
+          prev[kind] && prev[kind].length === 0 ? prev : { ...prev, [kind]: [] }
+        );
+        return;
+      }
+      const merged = new Map<string, AssignmentSummary>();
+      for (const a of listBucket) merged.set(a.sessionId, a);
+      for (const a of singleBucket) merged.set(a.sessionId, a);
+      setByKind((prev) => ({ ...prev, [kind]: Array.from(merged.values()) }));
+    };
+
+    const markSettled = (kind: SessionKind, shape: QueryShape) => {
+      settled.add(bucketKey(kind, shape));
+      if (settled.size === totalSubscriptions) {
         setLoadState('ready');
       }
     };
 
-    const handleError = (kind: SessionKind, err: unknown) => {
-      // PII safety: never log the error message or data — it may contain
-      // diagnostic data derived from the query. Log only the collection
-      // name and Firestore error code.
+    const handleSnapshot = (
+      kind: SessionKind,
+      shape: QueryShape,
+      snap: QuerySnapshot<DocumentData>
+    ) => {
+      const config = KIND_CONFIG[kind];
+      buckets.set(
+        bucketKey(kind, shape),
+        snap.docs.map((d) => docToSummary(kind, config, d))
+      );
+      emitMerged(kind);
+      markSettled(kind, shape);
+    };
+
+    const handleError = (
+      kind: SessionKind,
+      shape: QueryShape,
+      err: unknown
+    ) => {
       const code =
         err && typeof err === 'object' && 'code' in err
           ? String((err as { code?: unknown }).code)
           : 'unknown';
-      console.warn(
-        `[MyAssignments] snapshot failed for ${KIND_CONFIG[kind].collectionName}:`,
-        code
+      // Firestore missing-index errors embed a one-click index-creation
+      // URL in `err.message` — invaluable the next time something silently
+      // empties the list. Messages from Firestore do not include any of
+      // the classId values passed into the query, so this remains PII-safe.
+      const message =
+        err && typeof err === 'object' && 'message' in err
+          ? String((err as { message?: unknown }).message)
+          : '';
+      console.error(
+        `[MyAssignments] snapshot failed for ${KIND_CONFIG[kind].collectionName} (${shape}) [${code}]:`,
+        message
       );
-      // Mark as settled with an empty list so loading state can progress.
-      setByKind((prev) => ({ ...prev, [kind]: [] }));
-      settledKindsRef.current.add(kind);
-      if (settledKindsRef.current.size === SESSION_KINDS.length) {
-        setLoadState('ready');
-      }
+      buckets.set(bucketKey(kind, shape), []);
+      emitMerged(kind);
+      markSettled(kind, shape);
     };
 
-    for (const kind of SESSION_KINDS) {
-      const config = KIND_CONFIG[kind];
+    const buildQuery = (
+      config: KindConfig,
+      shape: QueryShape
+    ): Query<DocumentData> => {
       const col = collection(db, config.collectionName);
       const constraints =
-        config.classFilterShape === 'list'
+        shape === 'list'
           ? [where('classIds', 'array-contains-any', classIds)]
           : [where('classId', 'in', classIds)];
       if (config.statusFilter) {
-        constraints.push(
-          where(config.statusFilter.field, '==', config.statusFilter.value)
-        );
+        if ('valueIn' in config.statusFilter) {
+          constraints.push(
+            where(config.statusFilter.field, 'in', [
+              ...config.statusFilter.valueIn,
+            ])
+          );
+        } else {
+          constraints.push(
+            where(config.statusFilter.field, '==', config.statusFilter.value)
+          );
+        }
       }
-      const q = query(col, ...constraints);
-      const unsub = onSnapshot(
-        q,
-        (snap) => handleSnapshot(kind, snap),
-        (err) => handleError(kind, err)
+      return query(col, ...constraints);
+    };
+
+    const unsubs: Array<() => void> = [];
+    for (const { kind, shape } of subs) {
+      const config = KIND_CONFIG[kind];
+      const q = buildQuery(config, shape);
+      unsubs.push(
+        onSnapshot(
+          q,
+          (snap) => handleSnapshot(kind, shape, snap),
+          (err) => handleError(kind, shape, err)
+        )
       );
-      unsubs.push(unsub);
     }
 
     return () => {

--- a/components/videoActivity/VideoActivityStudentApp.tsx
+++ b/components/videoActivity/VideoActivityStudentApp.tsx
@@ -15,7 +15,9 @@ import {
   PlayCircle,
   Loader2,
   AlertCircle,
+  ArrowRight,
   CheckCircle2,
+  ClipboardList,
   Trophy,
 } from 'lucide-react';
 import { auth } from '@/config/firebase';
@@ -79,10 +81,22 @@ const JoinAndPlay: React.FC = () => {
     myResponse,
     joinStatus,
     error,
+    lookupSession,
     joinSession,
     submitAnswer,
     completeActivity,
   } = useVideoActivitySessionStudent();
+
+  // Multi-period selection step — shown when the session has more than one
+  // class-period name configured, so students pick their period before the
+  // response doc is created (mirrors the Quiz pattern).
+  const [periodStep, setPeriodStep] = useState<string[] | null>(null);
+  const [selectedPeriod, setSelectedPeriod] = useState<string | null>(null);
+  // Local guard for the async `lookupSession` leg of `handleJoin` — the
+  // hook's `joinStatus` only flips to `loading` once `joinSession` starts,
+  // so without this the button would stay clickable during the lookup and
+  // a double-tap could fan out parallel requests.
+  const [lookingUp, setLookingUp] = useState(false);
 
   // Track answered question IDs for anti-skip enforcement in VideoPlayer
   const answeredQuestionIds = React.useMemo(
@@ -96,8 +110,26 @@ const JoinAndPlay: React.FC = () => {
   const handleJoin = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!name.trim() || !pin.trim() || !sessionId) return;
-    await joinSession(sessionId, pin.trim(), name.trim());
+    if (lookingUp || joinStatus === 'loading') return;
+    setLookingUp(true);
+    try {
+      const sessionInfo = await lookupSession(sessionId);
+      const periodNames = sessionInfo?.periodNames ?? [];
+      if (periodNames.length > 1) {
+        setPeriodStep(periodNames);
+        return;
+      }
+      const autoClassPeriod = periodNames[0];
+      await joinSession(sessionId, pin.trim(), name.trim(), autoClassPeriod);
+    } finally {
+      setLookingUp(false);
+    }
   };
+
+  const handlePeriodConfirm = useCallback(async () => {
+    if (!selectedPeriod || !sessionId) return;
+    await joinSession(sessionId, pin.trim(), name.trim(), selectedPeriod);
+  }, [joinSession, sessionId, pin, name, selectedPeriod]);
 
   const handleQuestionTrigger = useCallback(
     (question: VideoActivityQuestion) => {
@@ -148,6 +180,77 @@ const JoinAndPlay: React.FC = () => {
   if (!sessionId || sessionId.includes('/')) {
     return (
       <ErrorScreen message="Invalid activity link. Please ask your teacher for the correct URL." />
+    );
+  }
+
+  // ── Period selection step (multi-period sessions) ────────────────────────
+
+  if (periodStep && joinStatus !== 'joined') {
+    return (
+      <div className="min-h-screen bg-slate-900 flex flex-col items-center justify-center p-6">
+        <div className="w-full max-w-sm">
+          <div className="flex items-center justify-center mb-8">
+            <ClipboardList className="w-5 h-5 text-brand-blue-primary mr-2" />
+            <span className="text-sm text-slate-300 font-semibold">
+              Video Activity
+            </span>
+          </div>
+
+          <h1 className="text-2xl font-black text-white mb-2 text-center">
+            Select Your Class
+          </h1>
+          <p className="text-slate-400 text-sm text-center mb-6">
+            Which class period are you in?
+          </p>
+
+          {error && (
+            <div className="mb-4 p-3 bg-red-500/20 border border-red-500/40 rounded-xl text-red-300 text-sm flex items-center gap-2">
+              <AlertCircle className="w-4 h-4 shrink-0" />
+              {error}
+            </div>
+          )}
+
+          <div className="space-y-2 mb-6">
+            {periodStep.map((period) => (
+              <button
+                key={period}
+                onClick={() => setSelectedPeriod(period)}
+                className={`w-full px-4 py-4 rounded-xl text-lg font-bold transition-all ${
+                  selectedPeriod === period
+                    ? 'bg-brand-blue-primary text-white ring-2 ring-brand-blue-light'
+                    : 'bg-slate-800 border border-slate-700 text-slate-300 hover:bg-slate-700'
+                }`}
+              >
+                {period}
+              </button>
+            ))}
+          </div>
+
+          <button
+            onClick={() => void handlePeriodConfirm()}
+            disabled={joinStatus === 'loading' || !selectedPeriod}
+            className="w-full py-4 bg-brand-blue-primary hover:bg-brand-blue-dark disabled:opacity-50 text-white font-bold text-lg rounded-xl flex items-center justify-center gap-2 transition-colors"
+          >
+            {joinStatus === 'loading' ? (
+              <Loader2 className="w-5 h-5 animate-spin" />
+            ) : (
+              <>
+                Continue <ArrowRight className="w-5 h-5" />
+              </>
+            )}
+          </button>
+
+          <button
+            onClick={() => {
+              setPeriodStep(null);
+              setSelectedPeriod(null);
+            }}
+            className="w-full mt-3 py-2 text-slate-500 hover:text-slate-300 text-sm font-medium transition-colors"
+          >
+            Go Back
+          </button>
+        </div>
+      </div>
     );
   }
 
@@ -220,11 +323,14 @@ const JoinAndPlay: React.FC = () => {
               <button
                 type="submit"
                 disabled={
-                  joinStatus === 'loading' || !name.trim() || !pin.trim()
+                  joinStatus === 'loading' ||
+                  lookingUp ||
+                  !name.trim() ||
+                  !pin.trim()
                 }
                 className="w-full bg-brand-blue-primary hover:bg-brand-blue-dark disabled:bg-slate-200 disabled:text-slate-400 text-white font-bold rounded-xl py-3 text-sm transition-all active:scale-95 flex items-center justify-center gap-2"
               >
-                {joinStatus === 'loading' ? (
+                {joinStatus === 'loading' || lookingUp ? (
                   <>
                     <Loader2 className="w-4 h-4 animate-spin" />
                     Joining…

--- a/components/widgets/GuidedLearning/Widget.tsx
+++ b/components/widgets/GuidedLearning/Widget.tsx
@@ -1,8 +1,7 @@
-import React, { useState, useCallback, useEffect, useMemo } from 'react';
+import React, { useState, useCallback, useMemo } from 'react';
 import { doc, writeBatch } from 'firebase/firestore';
 import {
   WidgetData,
-  ClassLinkClass,
   GuidedLearningConfig,
   GuidedLearningSet,
   GuidedLearningSetMetadata,
@@ -15,15 +14,17 @@ import { useGuidedLearning } from '@/hooks/useGuidedLearning';
 import { useGuidedLearningSessionTeacher } from '@/hooks/useGuidedLearningSession';
 import { useGuidedLearningAssignments } from '@/hooks/useGuidedLearningAssignments';
 import { useFolders } from '@/hooks/useFolders';
-import { classLinkService } from '@/utils/classlinkService';
 import { WidgetLayout } from '@/components/widgets/WidgetLayout';
 import { AssignModal } from '@/components/common/library';
 import { AssignClassPicker } from '@/components/common/AssignClassPicker';
 import {
-  formatClassLinkClassLabel,
   makeEmptyPickerValue,
   type AssignClassPickerValue,
 } from '@/components/common/AssignClassPicker.helpers';
+import {
+  deriveSessionTargetsFromRosters,
+  mapLegacyClassIdsToRosterIds,
+} from '@/utils/resolveAssignmentTargets';
 import { GuidedLearningManager } from './components/GuidedLearningManager';
 import { GuidedLearningEditorModal } from './components/GuidedLearningEditorModal';
 import { GuidedLearningPlayer } from './components/GuidedLearningPlayer';
@@ -103,46 +104,19 @@ export const GuidedLearningWidget: React.FC<{ widget: WidgetData }> = ({
     Record<string, string>
   >({});
 
-  // ─── ClassLink target-class fetch (Phase 3C) ────────────────────────────────
-  // Teacher's ClassLink classes (if provisioned). Fetched once per Widget
-  // mount via the shared `classLinkService` (5-min cache). If the teacher
-  // isn't on a ClassLink-provisioned org, the list stays empty and the
-  // Assign dialog is skipped entirely. Errors are swallowed: ClassLink
-  // being unreachable must not block classic join-link launches.
-  const [classLinkClasses, setClassLinkClasses] = useState<ClassLinkClass[]>(
-    []
-  );
-  useEffect(() => {
-    let cancelled = false;
-    void (async () => {
-      try {
-        const data = await classLinkService.getRosters();
-        if (cancelled) return;
-        setClassLinkClasses(data.classes);
-      } catch (err) {
-        // Silent: no-ClassLink orgs and transient failures both fall back
-        // to classic join-link-only launches, so the selector stays hidden.
-        if (import.meta.env.DEV) {
-          console.warn('[GuidedLearning] ClassLink fetch failed:', err);
-        }
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, []);
+  // Live ClassLink fetching is no longer performed at assign time; imported
+  // ClassLink rosters carry their own `classlinkClassId` metadata so the
+  // student SSO gate resolves purely from rosters. Live ClassLink data is
+  // reached only via the Classes sidebar's Import dialog.
 
-  // ─── Assign dialog state (Phase 3C, Phase 5A multi-class) ─────────────────
+  // ─── Assign dialog state ─────────────────────────────────────────────────
   // When a teacher clicks "Assign", we pause to let them optionally pick
-  // target classes (ClassLink) or period rosters (local) before actually
-  // creating the session. `assignTarget` holds the already-loaded set along
-  // with the source hint so we can create the assignment doc after
-  // confirmation.
+  // target rosters before actually creating the session.
   const [assignTarget, setAssignTarget] = useState<AssignDialogTarget | null>(
     null
   );
   const [pickerValue, setPickerValue] = useState<AssignClassPickerValue>(() =>
-    makeEmptyPickerValue('classlink')
+    makeEmptyPickerValue()
   );
 
   // Reset the picker when the dialog re-opens for a different set
@@ -152,17 +126,24 @@ export const GuidedLearningWidget: React.FC<{ widget: WidgetData }> = ({
   if (assignTarget !== prevAssignTarget) {
     setPrevAssignTarget(assignTarget);
     if (assignTarget) {
-      const rememberedMulti =
-        config.lastClassIdsBySetId?.[assignTarget.originSetId];
-      const rememberedSingle =
-        config.lastClassIdBySetId?.[assignTarget.originSetId];
-      const classIds =
-        rememberedMulti ?? (rememberedSingle ? [rememberedSingle] : []);
-      setPickerValue(
-        classIds.length > 0
-          ? { source: 'classlink', classIds, periodNames: [] }
-          : makeEmptyPickerValue('classlink')
-      );
+      // Prefer unified roster memory; fall back to legacy ClassLink-sourcedId
+      // maps so teachers upgrading from pre-unification configs don't lose
+      // their per-set preselection on first launch.
+      let rememberedRosters =
+        config.lastRosterIdsBySetId?.[assignTarget.originSetId] ?? [];
+      if (rememberedRosters.length === 0) {
+        const legacyMulti =
+          config.lastClassIdsBySetId?.[assignTarget.originSetId];
+        const legacySingle =
+          config.lastClassIdBySetId?.[assignTarget.originSetId];
+        const legacyClassIds =
+          legacyMulti ?? (legacySingle ? [legacySingle] : undefined);
+        rememberedRosters = mapLegacyClassIdsToRosterIds(
+          legacyClassIds,
+          rosters
+        );
+      }
+      setPickerValue({ rosterIds: rememberedRosters });
     }
   }
 
@@ -270,11 +251,17 @@ export const GuidedLearningWidget: React.FC<{ widget: WidgetData }> = ({
       data: GuidedLearningSet,
       source: 'personal' | 'building',
       originSetId: string,
-      classIds: string[],
-      periodNames: string[]
+      rosterIds: string[]
     ) => {
       try {
-        const url = await createSession(data, classIds, periodNames);
+        const selectedRosters = rosters.filter((r) => rosterIds.includes(r.id));
+        const derived = deriveSessionTargetsFromRosters(selectedRosters);
+        const url = await createSession(
+          data,
+          derived.classIds,
+          derived.periodNames,
+          derived.rosterIds
+        );
         const sessionId = url.split('/').pop() ?? '';
         setRecentSessionIds((prev) => ({
           ...prev,
@@ -287,28 +274,24 @@ export const GuidedLearningWidget: React.FC<{ widget: WidgetData }> = ({
               setId: data.id,
               setTitle: data.title,
               source,
+              rosterIds: derived.rosterIds,
             });
           } catch (err) {
             console.warn('[GuidedLearning] Failed to record assignment:', err);
           }
         }
-        // Persist the teacher's last-used ClassLink selection per set.
-        const prevMap = config.lastClassIdsBySetId ?? {};
+        // Persist the teacher's last-used roster selection per set.
+        const prevMap = config.lastRosterIdsBySetId ?? {};
         const nextMap: Record<string, string[]> = { ...prevMap };
-        if (classIds.length > 0) {
-          nextMap[originSetId] = classIds;
+        if (rosterIds.length > 0) {
+          nextMap[originSetId] = rosterIds;
         } else {
           delete nextMap[originSetId];
         }
-        // Drop any legacy single-class entry.
-        const prevLegacyMap = config.lastClassIdBySetId ?? {};
-        const nextLegacyMap: Record<string, string> = { ...prevLegacyMap };
-        delete nextLegacyMap[originSetId];
         updateWidget(widget.id, {
           config: {
             ...config,
-            lastClassIdsBySetId: nextMap,
-            lastClassIdBySetId: nextLegacyMap,
+            lastRosterIdsBySetId: nextMap,
           } as GuidedLearningConfig,
         });
         await navigator.clipboard.writeText(url);
@@ -319,7 +302,15 @@ export const GuidedLearningWidget: React.FC<{ widget: WidgetData }> = ({
         addToast(msg, 'error');
       }
     },
-    [createSession, createAssignment, addToast, config, updateWidget, widget.id]
+    [
+      rosters,
+      createSession,
+      createAssignment,
+      addToast,
+      config,
+      updateWidget,
+      widget.id,
+    ]
   );
 
   const handleAssign = async (
@@ -332,42 +323,29 @@ export const GuidedLearningWidget: React.FC<{ widget: WidgetData }> = ({
     const source: 'personal' | 'building' = buildingSet
       ? 'building'
       : 'personal';
-    // If the teacher has neither ClassLink nor local rosters, skip the
-    // dialog entirely and preserve the classic join-link flow.
-    if (classLinkClasses.length === 0 && rosters.length === 0) {
-      await performAssign(data, source, setId, [], []);
+    // If the teacher has no rosters at all, skip the dialog entirely and
+    // preserve the classic join-link flow.
+    if (rosters.length === 0) {
+      await performAssign(data, source, setId, []);
       return;
     }
-    // Otherwise open the dialog so they can optionally pick targets.
+    // Otherwise open the dialog so they can optionally pick rosters.
     setAssignTarget({ set: data, source, originSetId: setId });
   };
 
   const handleAssignConfirm = async (): Promise<void> => {
     if (!assignTarget) return;
-    // Guard: filter stale sourcedIds that aren't in the latest ClassLink
-    // list. Local roster names fall through unchanged.
-    const validClassIds =
-      pickerValue.source === 'classlink'
-        ? pickerValue.classIds.filter((id) =>
-            classLinkClasses.some((c) => c.sourcedId === id)
-          )
-        : [];
-    const selectedPeriodNames =
-      pickerValue.source === 'classlink'
-        ? validClassIds
-            .map((id) => classLinkClasses.find((c) => c.sourcedId === id))
-            .filter((cls): cls is ClassLinkClass => Boolean(cls))
-            .map(formatClassLinkClassLabel)
-        : pickerValue.periodNames;
+    // Guard against stale rosterIds — rosters can be deleted or fail to
+    // load (`loadError`) after the teacher's last assignment.
+    const visibleRosterIds = new Set(
+      rosters.filter((r) => !r.loadError).map((r) => r.id)
+    );
+    const validRosterIds = pickerValue.rosterIds.filter((id) =>
+      visibleRosterIds.has(id)
+    );
     const { set, source, originSetId } = assignTarget;
     setAssignTarget(null);
-    await performAssign(
-      set,
-      source,
-      originSetId,
-      validClassIds,
-      selectedPeriodNames
-    );
+    await performAssign(set, source, originSetId, validRosterIds);
   };
 
   const handleViewResultsForRecent = async (sessionId: string) => {
@@ -666,7 +644,6 @@ export const GuidedLearningWidget: React.FC<{ widget: WidgetData }> = ({
           onOptionsChange={setPickerValue}
           extraSlot={
             <AssignClassPicker
-              classLinkClasses={classLinkClasses}
               rosters={rosters}
               value={pickerValue}
               onChange={setPickerValue}

--- a/components/widgets/GuidedLearning/Widget.tsx
+++ b/components/widgets/GuidedLearning/Widget.tsx
@@ -18,11 +18,17 @@ import { useFolders } from '@/hooks/useFolders';
 import { classLinkService } from '@/utils/classlinkService';
 import { WidgetLayout } from '@/components/widgets/WidgetLayout';
 import { AssignModal } from '@/components/common/library';
+import { AssignClassPicker } from '@/components/common/AssignClassPicker';
+import {
+  formatClassLinkClassLabel,
+  makeEmptyPickerValue,
+  type AssignClassPickerValue,
+} from '@/components/common/AssignClassPicker.helpers';
 import { GuidedLearningManager } from './components/GuidedLearningManager';
 import { GuidedLearningEditorModal } from './components/GuidedLearningEditorModal';
 import { GuidedLearningPlayer } from './components/GuidedLearningPlayer';
 import { GuidedLearningResults } from './components/GuidedLearningResults';
-import { Loader2, Users } from 'lucide-react';
+import { Loader2 } from 'lucide-react';
 
 // ─── AI generation modal (admin only) ────────────────────────────────────────
 import { GuidedLearningAIGenerator } from './components/GuidedLearningAIGenerator';
@@ -45,7 +51,7 @@ interface AssignDialogTarget {
 export const GuidedLearningWidget: React.FC<{ widget: WidgetData }> = ({
   widget,
 }) => {
-  const { updateWidget, addToast } = useDashboard();
+  const { updateWidget, addToast, rosters } = useDashboard();
   const { user, isAdmin } = useAuth();
   const rawConfig = widget.config as GuidedLearningConfig;
   // Normalize legacy 'editor' view — the inline editor is removed; use the modal instead
@@ -126,29 +132,37 @@ export const GuidedLearningWidget: React.FC<{ widget: WidgetData }> = ({
     };
   }, []);
 
-  // ─── Assign dialog state (Phase 3C) ─────────────────────────────────────────
-  // When a teacher clicks "Assign" and a ClassLink-provisioned org is in
-  // play, we pause to let them optionally pick a target class before
-  // actually creating the session. `assignTarget` holds the already-loaded
-  // set along with the source hint so we can create the assignment doc
-  // after confirmation.
+  // ─── Assign dialog state (Phase 3C, Phase 5A multi-class) ─────────────────
+  // When a teacher clicks "Assign", we pause to let them optionally pick
+  // target classes (ClassLink) or period rosters (local) before actually
+  // creating the session. `assignTarget` holds the already-loaded set along
+  // with the source hint so we can create the assignment doc after
+  // confirmation.
   const [assignTarget, setAssignTarget] = useState<AssignDialogTarget | null>(
     null
   );
-  const [assignOptions, setAssignOptions] = useState<{ classId: string }>({
-    classId: '',
-  });
+  const [pickerValue, setPickerValue] = useState<AssignClassPickerValue>(() =>
+    makeEmptyPickerValue('classlink')
+  );
 
-  // Reset the pending classId when the dialog re-opens for a different set
+  // Reset the picker when the dialog re-opens for a different set
   // (adjust-state-while-rendering pattern — no effect needed).
   const [prevAssignTarget, setPrevAssignTarget] =
     useState<AssignDialogTarget | null>(null);
   if (assignTarget !== prevAssignTarget) {
     setPrevAssignTarget(assignTarget);
     if (assignTarget) {
-      setAssignOptions({
-        classId: config.lastClassIdBySetId?.[assignTarget.originSetId] ?? '',
-      });
+      const rememberedMulti =
+        config.lastClassIdsBySetId?.[assignTarget.originSetId];
+      const rememberedSingle =
+        config.lastClassIdBySetId?.[assignTarget.originSetId];
+      const classIds =
+        rememberedMulti ?? (rememberedSingle ? [rememberedSingle] : []);
+      setPickerValue(
+        classIds.length > 0
+          ? { source: 'classlink', classIds, periodNames: [] }
+          : makeEmptyPickerValue('classlink')
+      );
     }
   }
 
@@ -247,18 +261,20 @@ export const GuidedLearningWidget: React.FC<{ widget: WidgetData }> = ({
   };
 
   // Actually create the session + matching assignment doc. Shared between
-  // the classic direct-assign path (no ClassLink org) and the target-class
-  // dialog confirm path. `classId` is the ClassLink class sourcedId, or
-  // `null` for "No class".
+  // the classic direct-assign path (no ClassLink/rosters) and the picker
+  // dialog confirm path. `classIds` is the selected ClassLink sourcedId
+  // list; `periodNames` is the list of post-PIN period labels (empty when
+  // the teacher targeted nothing).
   const performAssign = useCallback(
     async (
       data: GuidedLearningSet,
       source: 'personal' | 'building',
       originSetId: string,
-      classId: string | null
+      classIds: string[],
+      periodNames: string[]
     ) => {
       try {
-        const url = await createSession(data, classId ?? undefined);
+        const url = await createSession(data, classIds, periodNames);
         const sessionId = url.split('/').pop() ?? '';
         setRecentSessionIds((prev) => ({
           ...prev,
@@ -276,21 +292,23 @@ export const GuidedLearningWidget: React.FC<{ widget: WidgetData }> = ({
             console.warn('[GuidedLearning] Failed to record assignment:', err);
           }
         }
-        // Persist the teacher's last-used classId per set so re-launching
-        // the same set pre-selects the same class. Clearing (picking "No
-        // class") removes the entry rather than writing an empty string to
-        // keep the config map small.
-        const prevMap = config.lastClassIdBySetId ?? {};
-        const nextMap: Record<string, string> = { ...prevMap };
-        if (classId) {
-          nextMap[originSetId] = classId;
+        // Persist the teacher's last-used ClassLink selection per set.
+        const prevMap = config.lastClassIdsBySetId ?? {};
+        const nextMap: Record<string, string[]> = { ...prevMap };
+        if (classIds.length > 0) {
+          nextMap[originSetId] = classIds;
         } else {
           delete nextMap[originSetId];
         }
+        // Drop any legacy single-class entry.
+        const prevLegacyMap = config.lastClassIdBySetId ?? {};
+        const nextLegacyMap: Record<string, string> = { ...prevLegacyMap };
+        delete nextLegacyMap[originSetId];
         updateWidget(widget.id, {
           config: {
             ...config,
-            lastClassIdBySetId: nextMap,
+            lastClassIdsBySetId: nextMap,
+            lastClassIdBySetId: nextLegacyMap,
           } as GuidedLearningConfig,
         });
         await navigator.clipboard.writeText(url);
@@ -314,30 +332,42 @@ export const GuidedLearningWidget: React.FC<{ widget: WidgetData }> = ({
     const source: 'personal' | 'building' = buildingSet
       ? 'building'
       : 'personal';
-    // If the teacher isn't on a ClassLink-provisioned org (or the fetch
-    // failed), skip the dialog entirely and preserve the classic
-    // join-link flow.
-    if (classLinkClasses.length === 0) {
-      await performAssign(data, source, setId, null);
+    // If the teacher has neither ClassLink nor local rosters, skip the
+    // dialog entirely and preserve the classic join-link flow.
+    if (classLinkClasses.length === 0 && rosters.length === 0) {
+      await performAssign(data, source, setId, [], []);
       return;
     }
-    // Otherwise open the dialog so they can optionally pick a target class.
+    // Otherwise open the dialog so they can optionally pick targets.
     setAssignTarget({ set: data, source, originSetId: setId });
   };
 
   const handleAssignConfirm = async (): Promise<void> => {
     if (!assignTarget) return;
-    // Guard: if the teacher somehow picked a classId that's no longer in the
-    // fetched ClassLink list (e.g. rosters changed between fetch and confirm),
-    // fall through to no-class rather than writing a stale id.
-    const selectedClassId =
-      assignOptions.classId &&
-      classLinkClasses.some((c) => c.sourcedId === assignOptions.classId)
-        ? assignOptions.classId
-        : null;
+    // Guard: filter stale sourcedIds that aren't in the latest ClassLink
+    // list. Local roster names fall through unchanged.
+    const validClassIds =
+      pickerValue.source === 'classlink'
+        ? pickerValue.classIds.filter((id) =>
+            classLinkClasses.some((c) => c.sourcedId === id)
+          )
+        : [];
+    const selectedPeriodNames =
+      pickerValue.source === 'classlink'
+        ? validClassIds
+            .map((id) => classLinkClasses.find((c) => c.sourcedId === id))
+            .filter((cls): cls is ClassLinkClass => Boolean(cls))
+            .map(formatClassLinkClassLabel)
+        : pickerValue.periodNames;
     const { set, source, originSetId } = assignTarget;
     setAssignTarget(null);
-    await performAssign(set, source, originSetId, selectedClassId);
+    await performAssign(
+      set,
+      source,
+      originSetId,
+      validClassIds,
+      selectedPeriodNames
+    );
   };
 
   const handleViewResultsForRecent = async (sessionId: string) => {
@@ -628,17 +658,18 @@ export const GuidedLearningWidget: React.FC<{ widget: WidgetData }> = ({
       />
 
       {assignTarget && (
-        <AssignModal<{ classId: string }>
+        <AssignModal<AssignClassPickerValue>
           isOpen={!!assignTarget}
           onClose={() => setAssignTarget(null)}
           itemTitle={assignTarget.set.title || 'Untitled set'}
-          options={assignOptions}
-          onOptionsChange={setAssignOptions}
+          options={pickerValue}
+          onOptionsChange={setPickerValue}
           extraSlot={
-            <GuidedLearningAssignTargetClassRow
-              classes={classLinkClasses}
-              value={assignOptions.classId}
-              onChange={(v) => setAssignOptions({ classId: v })}
+            <AssignClassPicker
+              classLinkClasses={classLinkClasses}
+              rosters={rosters}
+              value={pickerValue}
+              onChange={setPickerValue}
             />
           }
           onAssign={() => handleAssignConfirm()}
@@ -646,59 +677,5 @@ export const GuidedLearningWidget: React.FC<{ widget: WidgetData }> = ({
         />
       )}
     </>
-  );
-};
-
-/**
- * Build a human-readable label for a ClassLink class. Mirrors the format
- * used by `ClassLinkImportDialog` and `QuizManager` so teachers see the
- * same class names across flows.
- */
-function formatClassLinkClassLabel(cls: ClassLinkClass): string {
-  const subjectPrefix = cls.subject ? `${cls.subject} - ` : '';
-  const codeSuffix = cls.classCode ? ` (${cls.classCode})` : '';
-  return `${subjectPrefix}${cls.title}${codeSuffix}`;
-}
-
-/**
- * Target-class selector rendered inside the Guided Learning Assign modal's
- * `extraSlot`. Lets the teacher pick an optional ClassLink class to target
- * this set at so that students who signed in via ClassLink see it on their
- * `/my-assignments` page. Phase 3C — fan-out of the Quiz pilot.
- */
-const GuidedLearningAssignTargetClassRow: React.FC<{
-  classes: ClassLinkClass[];
-  value: string;
-  onChange: (next: string) => void;
-}> = ({ classes, value, onChange }) => {
-  return (
-    <div>
-      <div className="flex items-center gap-2 mb-1">
-        <Users className="w-4 h-4 text-brand-blue-primary" />
-        <label
-          htmlFor="gl-assign-target-class"
-          className="text-sm font-bold text-brand-blue-dark"
-        >
-          Target class (optional)
-        </label>
-      </div>
-      <select
-        id="gl-assign-target-class"
-        value={value}
-        onChange={(e) => onChange(e.target.value)}
-        className="w-full px-3 py-2 bg-white border border-slate-200 rounded-lg text-slate-800 text-sm focus:outline-none focus:ring-2 focus:ring-brand-blue-primary"
-      >
-        <option value="">No class (use join code)</option>
-        {classes.map((cls) => (
-          <option key={cls.sourcedId} value={cls.sourcedId}>
-            {formatClassLinkClassLabel(cls)}
-          </option>
-        ))}
-      </select>
-      <p className="text-xxs text-slate-500 mt-1">
-        Students in this class will see this activity in their assignments list.
-        Leave blank to use a join code.
-      </p>
-    </div>
   );
 };

--- a/components/widgets/MiniApp/Widget.tsx
+++ b/components/widgets/MiniApp/Widget.tsx
@@ -1,10 +1,4 @@
-import React, {
-  useState,
-  useRef,
-  useEffect,
-  useCallback,
-  useMemo,
-} from 'react';
+import React, { useState, useRef, useEffect, useCallback } from 'react';
 import { useDashboard } from '@/context/useDashboard';
 import {
   MiniAppItem,
@@ -12,7 +6,6 @@ import {
   GlobalMiniAppItem,
   MiniAppAssignment,
   WidgetComponentProps,
-  ClassLinkClass,
 } from '@/types';
 import {
   LayoutGrid,
@@ -25,9 +18,7 @@ import {
   Loader2,
   CheckCircle2,
   ExternalLink,
-  Users,
 } from 'lucide-react';
-import { classLinkService } from '@/utils/classlinkService';
 import { WidgetLayout } from '../WidgetLayout';
 import { useAuth } from '@/context/useAuth';
 import { useMiniAppSessionTeacher } from '@/hooks/useMiniAppSession';
@@ -36,12 +27,21 @@ import { useFolders } from '@/hooks/useFolders';
 import {
   collection,
   doc,
-  getDocs,
   setDoc,
   deleteDoc,
   writeBatch,
 } from 'firebase/firestore';
 import { db } from '@/config/firebase';
+import { AssignClassPicker } from '@/components/common/AssignClassPicker';
+import {
+  makeEmptyPickerValue,
+  resolveSelectedRosters,
+  type AssignClassPickerValue,
+} from '@/components/common/AssignClassPicker.helpers';
+import {
+  deriveSessionTargetsFromRosters,
+  mapLegacyClassIdsToRosterIds,
+} from '@/utils/resolveAssignmentTargets';
 import { MiniAppEditorModal } from './components/MiniAppEditorModal';
 import { AssignmentsModal } from './components/AssignmentsModal';
 import { MiniAppManager } from './components/MiniAppManager';
@@ -64,26 +64,15 @@ interface MiniAppAssignModalProps {
   error: string | null;
   onConfirm: () => void;
   onClose: () => void;
-  /** ClassLink classes for the target-class picker. Hidden when empty. */
-  classLinkClasses: ClassLinkClass[];
-  /** Currently-selected ClassLink class sourcedIds (multi-select). */
-  selectedClassIds: string[];
-  onSelectedClassIdsChange: (next: string[]) => void;
+  /** Rosters available for targeting (unified picker). */
+  rosters: import('@/types').ClassRoster[];
+  /** Current picker selection. */
+  pickerValue: AssignClassPickerValue;
+  onPickerChange: (next: AssignClassPickerValue) => void;
   /** Whether submissions are enabled (Submit button shown, writes allowed). */
   submissionsEnabled: boolean;
   onSubmissionsEnabledChange: (next: boolean) => void;
 }
-
-/**
- * Human-readable label for a ClassLink class. Mirrors the format used by
- * `QuizManager` / `ActivityWallWidget` / etc. so teachers see the same class
- * names across every assignment-targeting flow.
- */
-const formatClassLinkClassLabel = (cls: ClassLinkClass): string => {
-  const subjectPrefix = cls.subject ? `${cls.subject} - ` : '';
-  const codeSuffix = cls.classCode ? ` (${cls.classCode})` : '';
-  return `${subjectPrefix}${cls.title}${codeSuffix}`;
-};
 
 const MiniAppAssignModal: React.FC<MiniAppAssignModalProps> = ({
   appTitle,
@@ -94,21 +83,12 @@ const MiniAppAssignModal: React.FC<MiniAppAssignModalProps> = ({
   error,
   onConfirm,
   onClose,
-  classLinkClasses,
-  selectedClassIds,
-  onSelectedClassIdsChange,
+  rosters,
+  pickerValue,
+  onPickerChange,
   submissionsEnabled,
   onSubmissionsEnabledChange,
 }) => {
-  const toggleClassId = (sourcedId: string) => {
-    if (selectedClassIds.includes(sourcedId)) {
-      onSelectedClassIdsChange(
-        selectedClassIds.filter((id) => id !== sourcedId)
-      );
-    } else {
-      onSelectedClassIdsChange([...selectedClassIds, sourcedId]);
-    }
-  };
   const link = createdSessionId
     ? `${window.location.origin}/miniapp/${createdSessionId}`
     : null;
@@ -224,41 +204,17 @@ const MiniAppAssignModal: React.FC<MiniAppAssignModalProps> = ({
                   className="w-full rounded-xl border border-slate-200 px-3 py-2 text-sm font-medium text-slate-700 outline-none focus:border-brand-blue-primary"
                 />
               </div>
-              {classLinkClasses.length > 0 && (
-                <div className="bg-slate-50 border border-slate-200 rounded-xl p-3">
-                  <div className="flex items-center gap-2 mb-1.5">
-                    <Users className="w-4 h-4 text-brand-blue-primary" />
-                    <span className="text-sm font-bold text-slate-700">
-                      Target classes (optional)
-                    </span>
-                  </div>
-                  <div className="max-h-40 overflow-y-auto flex flex-col gap-1.5 pr-1">
-                    {classLinkClasses.map((cls) => {
-                      const checked = selectedClassIds.includes(cls.sourcedId);
-                      return (
-                        <label
-                          key={cls.sourcedId}
-                          className="flex items-center gap-2 text-sm text-slate-700 cursor-pointer rounded-lg px-2 py-1 hover:bg-white"
-                        >
-                          <input
-                            type="checkbox"
-                            checked={checked}
-                            onChange={() => toggleClassId(cls.sourcedId)}
-                            className="w-4 h-4 accent-brand-blue-primary"
-                          />
-                          <span className="truncate">
-                            {formatClassLinkClassLabel(cls)}
-                          </span>
-                        </label>
-                      );
-                    })}
-                  </div>
-                  <p className="text-[11px] text-slate-500 mt-2">
-                    Enrolled students will see this in their assignments list.
-                    Leave all boxes unchecked to share a link directly.
-                  </p>
-                </div>
-              )}
+              <div className="bg-slate-50 border border-slate-200 rounded-xl p-3">
+                <AssignClassPicker
+                  rosters={rosters}
+                  value={pickerValue}
+                  onChange={onPickerChange}
+                />
+                <p className="text-[11px] text-slate-500 mt-2">
+                  Enrolled students will see this in their assignments list.
+                  Leave unselected to share the link directly.
+                </p>
+              </div>
               <div className="bg-slate-50 border border-slate-200 rounded-xl p-3">
                 <span className="block text-sm font-bold text-slate-700 mb-2">
                   Submissions
@@ -323,24 +279,8 @@ export const MiniAppWidget: React.FC<WidgetComponentProps> = ({
   widget,
   isStudentView,
 }) => {
-  const { updateWidget, addToast } = useDashboard();
-  const { user, userRoles, orgId, roleId } = useAuth();
-  // Gate testClasses read on the same role check the Firestore rules enforce
-  // (`isSuperAdmin() || isDomainAdmin(orgId)`) rather than the legacy
-  // `/admins/` membership flag. Building admins appear in `/admins/` in some
-  // deployments — querying on that flag would trigger a permission-denied
-  // round-trip for them. See `resolveActorRole` in OrganizationPanel for the
-  // reference pattern.
-  const isSuperAdminByEmail = Boolean(
-    user?.email &&
-    userRoles?.superAdmins?.some(
-      (e) => e.toLowerCase() === user.email?.toLowerCase()
-    )
-  );
-  const canReadTestClasses =
-    isSuperAdminByEmail ||
-    roleId === 'super_admin' ||
-    roleId === 'domain_admin';
+  const { updateWidget, addToast, rosters } = useDashboard();
+  const { user } = useAuth();
   const { showConfirm } = useDialog();
   const config = (widget.config ?? {}) as MiniAppConfig;
   const activeApp = config.activeApp ?? null;
@@ -378,85 +318,12 @@ export const MiniAppWidget: React.FC<WidgetComponentProps> = ({
   const [isCreatingSession, setIsCreatingSession] = useState(false);
   const [createdSessionId, setCreatedSessionId] = useState<string | null>(null);
   const [assignError, setAssignError] = useState<string | null>(null);
-  const [assignTargetClassIds, setAssignTargetClassIds] = useState<string[]>(
-    []
-  );
+  const [assignPickerValue, setAssignPickerValue] =
+    useState<AssignClassPickerValue>(makeEmptyPickerValue());
   const [assignSubmissionsEnabled, setAssignSubmissionsEnabled] =
     useState(false);
   const [assignmentsForApp, setAssignmentsForApp] =
     useState<MiniAppItem | null>(null);
-
-  // ─── ClassLink target-class fetch (Phase 3E) ────────────────────────────────
-  // Fetched once per widget mount via the shared classLinkService (5-min
-  // cache). Hidden entirely when the teacher isn't on a ClassLink-provisioned
-  // org. Errors are swallowed: ClassLink being unreachable must not block
-  // shareable-link launches.
-  const [classLinkClasses, setClassLinkClasses] = useState<ClassLinkClass[]>(
-    []
-  );
-  const [testClasses, setTestClasses] = useState<ClassLinkClass[]>([]);
-
-  // ClassLink roster fetch runs once per mount and does not depend on admin
-  // state — splitting it from the test-class fetch avoids re-issuing the
-  // ClassLink request when `roleId` hydrates from null.
-  useEffect(() => {
-    let cancelled = false;
-    void (async () => {
-      try {
-        const data = await classLinkService.getRosters();
-        if (cancelled) return;
-        setClassLinkClasses(data.classes);
-      } catch (err) {
-        if (import.meta.env.DEV) {
-          console.warn('[MiniAppWidget] ClassLink fetch failed:', err);
-        }
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, []);
-
-  // Test-class fetch is gated on the same role check Firestore rules use.
-  // Skipped when orgId is null — testClasses docs live under a specific org,
-  // so there is no valid query to issue without one.
-  useEffect(() => {
-    if (!canReadTestClasses || !orgId) {
-      setTestClasses([]);
-      return;
-    }
-    let cancelled = false;
-    void (async () => {
-      try {
-        const snap = await getDocs(
-          collection(db, `organizations/${orgId}/testClasses`)
-        );
-        if (cancelled) return;
-        setTestClasses(
-          snap.docs.map((d) => {
-            const data = d.data() as { title?: string; subject?: string };
-            return {
-              sourcedId: d.id,
-              title: `${data.title ?? d.id} (test)`,
-              subject: data.subject,
-            };
-          })
-        );
-      } catch (err) {
-        if (import.meta.env.DEV) {
-          console.warn('[MiniAppWidget] testClasses fetch failed:', err);
-        }
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, [canReadTestClasses, orgId]);
-
-  const mergedClassList = useMemo(
-    () => [...classLinkClasses, ...testClasses],
-    [classLinkClasses, testClasses]
-  );
 
   const buildDefaultAssignmentName = (appTitle: string) => {
     const formatted = new Date().toLocaleString([], {
@@ -473,10 +340,18 @@ export const MiniAppWidget: React.FC<WidgetComponentProps> = ({
     setAssignmentName(buildDefaultAssignmentName(app.title));
     setCreatedSessionId(null);
     setAssignError(null);
-    // Pre-populate the class picker and toggle with whatever the teacher
-    // picked last time for this app, so repeated assignments don't require
-    // re-picking.
-    setAssignTargetClassIds(config.lastClassIdsByAppId?.[app.id] ?? []);
+    // Pre-populate the roster picker with the teacher's last selection for
+    // this app. Prefer unified roster memory; fall back to the legacy
+    // ClassLink-sourcedId map so teachers upgrading from pre-unification
+    // configs keep their preselection.
+    let lastRosterIds = config.lastRosterIdsByAppId?.[app.id] ?? [];
+    if (lastRosterIds.length === 0) {
+      lastRosterIds = mapLegacyClassIdsToRosterIds(
+        config.lastClassIdsByAppId?.[app.id],
+        rosters
+      );
+    }
+    setAssignPickerValue({ rosterIds: lastRosterIds });
     setAssignSubmissionsEnabled(
       config.lastSubmissionsEnabledByAppId?.[app.id] ?? false
     );
@@ -516,31 +391,44 @@ export const MiniAppWidget: React.FC<WidgetComponentProps> = ({
     setIsCreatingSession(true);
     setAssignError(null);
     try {
-      // Guard against stale selections: the class list refreshes on mount,
-      // and a teacher could have picked classes that have since been removed
-      // from the roster. Drop any sourcedIds we can't still see.
-      const visibleClassIds = new Set(mergedClassList.map((c) => c.sourcedId));
-      const resolvedClassIds = assignTargetClassIds.filter((id) =>
-        visibleClassIds.has(id)
-      );
+      // Resolve the picker selection against current rosters — dropped IDs
+      // (deleted) or rosters that failed to load students from Drive
+      // (`loadError`) are silently filtered so we never produce a session
+      // with zero PINs that no student can join.
+      const selectedRosters = resolveSelectedRosters(
+        assignPickerValue,
+        rosters
+      ).filter((r) => !r.loadError);
+      const derived = deriveSessionTargetsFromRosters(selectedRosters);
+
+      // NOTE ON GATING ASYMMETRY: `mini_app_sessions` Firestore rules use
+      // `passesStudentClassGateList`, which treats an empty `classIds[]` as
+      // "open to any student-role user." This means local-only rosters (no
+      // `classlinkClassId` metadata) still let any SSO student see the
+      // session — matching today's behavior. For the strict-gate collections
+      // (quiz, video activity, guided learning), empty classIds block SSO
+      // students entirely; PIN-joining students still pass.
       const sessionId = await createSession(
         assigningApp,
         user.uid,
         assignmentName,
         {
-          classIds: resolvedClassIds,
+          classIds: derived.classIds,
+          rosterIds: derived.rosterIds,
           submissionsEnabled: assignSubmissionsEnabled,
         }
       );
       // Mirror the new session into the per-teacher archive so it shows up
       // in the In Progress / Archive tabs. Failures here are non-fatal —
-      // the session itself still exists.
+      // the session itself still exists. NOTE: only roster-level targeting
+      // (`rosterIds`) is mirrored; `classIds` lives on the session doc for
+      // the student SSO gate, matching the Quiz/VA/GL assignment shape.
       try {
         await createAssignment({
           sessionId,
           app: { id: assigningApp.id, title: assigningApp.title },
           assignmentName,
-          classIds: resolvedClassIds,
+          rosterIds: derived.rosterIds,
           submissionsEnabled: assignSubmissionsEnabled,
         });
       } catch (archiveErr) {
@@ -551,12 +439,12 @@ export const MiniAppWidget: React.FC<WidgetComponentProps> = ({
       }
       // Remember the teacher's choices for next time.
       try {
-        const prevClasses = config.lastClassIdsByAppId ?? {};
-        const nextClasses: Record<string, string[]> = { ...prevClasses };
-        if (resolvedClassIds.length > 0) {
-          nextClasses[assigningApp.id] = resolvedClassIds;
+        const prevRosters = config.lastRosterIdsByAppId ?? {};
+        const nextRosters: Record<string, string[]> = { ...prevRosters };
+        if (derived.rosterIds.length > 0) {
+          nextRosters[assigningApp.id] = derived.rosterIds;
         } else {
-          delete nextClasses[assigningApp.id];
+          delete nextRosters[assigningApp.id];
         }
         const prevToggle = config.lastSubmissionsEnabledByAppId ?? {};
         const nextToggle: Record<string, boolean> = {
@@ -566,7 +454,7 @@ export const MiniAppWidget: React.FC<WidgetComponentProps> = ({
         updateWidget(widget.id, {
           config: {
             ...config,
-            lastClassIdsByAppId: nextClasses,
+            lastRosterIdsByAppId: nextRosters,
             lastSubmissionsEnabledByAppId: nextToggle,
           } as MiniAppConfig,
         });
@@ -999,9 +887,9 @@ export const MiniAppWidget: React.FC<WidgetComponentProps> = ({
                 isCreating={isCreatingSession}
                 createdSessionId={createdSessionId}
                 error={assignError}
-                classLinkClasses={mergedClassList}
-                selectedClassIds={assignTargetClassIds}
-                onSelectedClassIdsChange={setAssignTargetClassIds}
+                rosters={rosters}
+                pickerValue={assignPickerValue}
+                onPickerChange={setAssignPickerValue}
                 submissionsEnabled={assignSubmissionsEnabled}
                 onSubmissionsEnabledChange={setAssignSubmissionsEnabled}
                 onConfirm={() => void handleConfirmAssign()}
@@ -1009,7 +897,7 @@ export const MiniAppWidget: React.FC<WidgetComponentProps> = ({
                   setAssigningApp(null);
                   setCreatedSessionId(null);
                   setAssignError(null);
-                  setAssignTargetClassIds([]);
+                  setAssignPickerValue(makeEmptyPickerValue());
                   setAssignSubmissionsEnabled(false);
                 }}
               />
@@ -1110,9 +998,9 @@ export const MiniAppWidget: React.FC<WidgetComponentProps> = ({
                 isCreating={isCreatingSession}
                 createdSessionId={createdSessionId}
                 error={assignError}
-                classLinkClasses={mergedClassList}
-                selectedClassIds={assignTargetClassIds}
-                onSelectedClassIdsChange={setAssignTargetClassIds}
+                rosters={rosters}
+                pickerValue={assignPickerValue}
+                onPickerChange={setAssignPickerValue}
                 submissionsEnabled={assignSubmissionsEnabled}
                 onSubmissionsEnabledChange={setAssignSubmissionsEnabled}
                 onConfirm={() => void handleConfirmAssign()}
@@ -1120,7 +1008,7 @@ export const MiniAppWidget: React.FC<WidgetComponentProps> = ({
                   setAssigningApp(null);
                   setCreatedSessionId(null);
                   setAssignError(null);
-                  setAssignTargetClassIds([]);
+                  setAssignPickerValue(makeEmptyPickerValue());
                   setAssignSubmissionsEnabled(false);
                 }}
               />

--- a/components/widgets/QuizWidget/Widget.tsx
+++ b/components/widgets/QuizWidget/Widget.tsx
@@ -32,6 +32,7 @@ import {
 import { QuizLiveMonitor } from './components/QuizLiveMonitor';
 import { Loader2, AlertTriangle, LogIn } from 'lucide-react';
 import { SCOREBOARD_COLORS } from '@/config/scoreboard';
+import { deriveSessionTargetsFromRosters } from '@/utils/resolveAssignmentTargets';
 
 export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
   const { updateWidget, addWidget, addToast, rosters, activeDashboard } =
@@ -668,10 +669,17 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
           mode,
           plcOptions: PlcOptions,
           sessionOptions: QuizSessionOptions,
-          classIds: string[]
+          rosterIds: string[]
         ) => {
           const data = await loadQuiz(meta);
           if (!data) return;
+          // Derive session targets from selected rosters — `classIds` feeds
+          // the student SSO gate via Firestore rules; `rosterIds` is mirrored
+          // onto both assignment and session for reverse lookup.
+          const selectedRosters = rosters.filter((r) =>
+            rosterIds.includes(r.id)
+          );
+          const derived = deriveSessionTargetsFromRosters(selectedRosters);
           try {
             const { id: assignmentId, code } = await createAssignment(
               {
@@ -691,24 +699,18 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
                 plcSheetUrl: plcOptions.plcSheetUrl,
               },
               'paused',
-              classIds
+              derived.classIds,
+              derived.rosterIds
             );
-            // Persist the teacher's last-used ClassLink classes per quiz so
+            // Persist the teacher's last-used rosters per quiz so
             // re-launching the same quiz pre-selects the same classes.
-            // Clearing removes the entry rather than writing an empty array.
-            const prevMap = config.lastClassIdsByQuizId ?? {};
+            const prevMap = config.lastRosterIdsByQuizId ?? {};
             const nextMap: Record<string, string[]> = { ...prevMap };
-            if (classIds.length > 0) {
-              nextMap[meta.id] = classIds;
+            if (rosterIds.length > 0) {
+              nextMap[meta.id] = rosterIds;
             } else {
               delete nextMap[meta.id];
             }
-            // Also clear the legacy single-class map entry so the picker
-            // doesn't see a stale single-id override after the teacher
-            // explicitly cleared or changed their selection.
-            const prevLegacyMap = config.lastClassIdByQuizId ?? {};
-            const nextLegacyMap: Record<string, string> = { ...prevLegacyMap };
-            delete nextLegacyMap[meta.id];
             updateWidget(widget.id, {
               config: {
                 ...config,
@@ -723,8 +725,7 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
                   plcOptions.periodNames?.[0] ?? plcOptions.periodName ?? '',
                 periodNames: plcOptions.periodNames ?? [],
                 plcSheetUrl: plcOptions.plcSheetUrl ?? '',
-                lastClassIdsByQuizId: nextMap,
-                lastClassIdByQuizId: nextLegacyMap,
+                lastRosterIdsByQuizId: nextMap,
               } as QuizConfig,
             });
             const url = `${window.location.origin}/quiz?code=${code}`;

--- a/components/widgets/QuizWidget/Widget.tsx
+++ b/components/widgets/QuizWidget/Widget.tsx
@@ -668,7 +668,7 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
           mode,
           plcOptions: PlcOptions,
           sessionOptions: QuizSessionOptions,
-          classId: string | null
+          classIds: string[]
         ) => {
           const data = await loadQuiz(meta);
           if (!data) return;
@@ -691,19 +691,24 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
                 plcSheetUrl: plcOptions.plcSheetUrl,
               },
               'paused',
-              classId ?? undefined
+              classIds
             );
-            // Persist the teacher's last-used classId per quiz so re-launching
-            // the same quiz pre-selects the same class. Clearing (picking "No
-            // class") removes the entry rather than writing an empty string
-            // to keep the config map small.
-            const prevMap = config.lastClassIdByQuizId ?? {};
-            const nextMap: Record<string, string> = { ...prevMap };
-            if (classId) {
-              nextMap[meta.id] = classId;
+            // Persist the teacher's last-used ClassLink classes per quiz so
+            // re-launching the same quiz pre-selects the same classes.
+            // Clearing removes the entry rather than writing an empty array.
+            const prevMap = config.lastClassIdsByQuizId ?? {};
+            const nextMap: Record<string, string[]> = { ...prevMap };
+            if (classIds.length > 0) {
+              nextMap[meta.id] = classIds;
             } else {
               delete nextMap[meta.id];
             }
+            // Also clear the legacy single-class map entry so the picker
+            // doesn't see a stale single-id override after the teacher
+            // explicitly cleared or changed their selection.
+            const prevLegacyMap = config.lastClassIdByQuizId ?? {};
+            const nextLegacyMap: Record<string, string> = { ...prevLegacyMap };
+            delete nextLegacyMap[meta.id];
             updateWidget(widget.id, {
               config: {
                 ...config,
@@ -718,7 +723,8 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
                   plcOptions.periodNames?.[0] ?? plcOptions.periodName ?? '',
                 periodNames: plcOptions.periodNames ?? [],
                 plcSheetUrl: plcOptions.plcSheetUrl ?? '',
-                lastClassIdByQuizId: nextMap,
+                lastClassIdsByQuizId: nextMap,
+                lastClassIdByQuizId: nextLegacyMap,
               } as QuizConfig,
             });
             const url = `${window.location.origin}/quiz?code=${code}`;

--- a/components/widgets/QuizWidget/components/QuizManager.tsx
+++ b/components/widgets/QuizWidget/components/QuizManager.tsx
@@ -42,7 +42,6 @@ import {
   Loader2,
   AlertCircle,
   CheckSquare,
-  Users,
 } from 'lucide-react';
 import {
   ClassLinkClass,
@@ -55,6 +54,12 @@ import {
 import { classLinkService } from '@/utils/classlinkService';
 import { type QuizSessionOptions } from '@/hooks/useQuizSession';
 import { Toggle } from '@/components/common/Toggle';
+import { AssignClassPicker } from '@/components/common/AssignClassPicker';
+import {
+  formatClassLinkClassLabel,
+  makeEmptyPickerValue,
+  type AssignClassPickerValue,
+} from '@/components/common/AssignClassPicker.helpers';
 import {
   LibraryShell,
   LibraryToolbar,
@@ -105,21 +110,47 @@ interface QuizAssignOptions {
   soundEffectsEnabled: boolean;
   plcMode: boolean;
   teacherName: string;
-  selectedPeriodNames: string[];
   plcSheetUrl: string;
   /**
-   * ClassLink class `sourcedId` this quiz is targeted at, or `''` for the
-   * "No class" option (classic code/PIN-only flow). Written onto the
-   * `quiz_sessions/{sessionId}` document when non-empty so students who
-   * signed in via ClassLink see the session on their /my-assignments page.
+   * Unified class-target picker state (Phase 5A). `classIds` is the list of
+   * ClassLink class `sourcedId`s when source === 'classlink'. `periodNames`
+   * is the list of local roster names when source === 'local'. One of the
+   * two is populated at a time — switching source clears the other.
    */
-  classId: string;
+  picker: AssignClassPickerValue;
+}
+
+/**
+ * Resolve the effective class-period labels for a picker value. When the
+ * teacher picks ClassLink classes, the labels used for the post-PIN period
+ * picker and the PLC Google Sheet export are the ClassLink class titles
+ * themselves; when they pick local rosters, the labels are the roster names.
+ */
+function resolveEffectivePeriodNames(
+  picker: AssignClassPickerValue,
+  classLinkClasses: ClassLinkClass[]
+): string[] {
+  if (picker.source === 'classlink') {
+    return picker.classIds
+      .map((id) => classLinkClasses.find((c) => c.sourcedId === id))
+      .filter((cls): cls is ClassLinkClass => Boolean(cls))
+      .map(formatClassLinkClassLabel);
+  }
+  return picker.periodNames;
 }
 
 function buildDefaultAssignOptions(
   config: QuizConfig,
   quizId?: string
 ): QuizAssignOptions {
+  const rememberedMulti = quizId
+    ? (config.lastClassIdsByQuizId?.[quizId] ?? null)
+    : null;
+  const rememberedSingle = quizId
+    ? (config.lastClassIdByQuizId?.[quizId] ?? null)
+    : null;
+  const classIds =
+    rememberedMulti ?? (rememberedSingle ? [rememberedSingle] : []);
   return {
     tabWarningsEnabled: true,
     showResultToStudent: false,
@@ -131,10 +162,19 @@ function buildDefaultAssignOptions(
     soundEffectsEnabled: false,
     plcMode: config.plcMode ?? false,
     teacherName: config.teacherName ?? '',
-    selectedPeriodNames:
-      config.periodNames ?? (config.periodName ? [config.periodName] : []),
     plcSheetUrl: config.plcSheetUrl ?? '',
-    classId: (quizId && config.lastClassIdByQuizId?.[quizId]) ?? '',
+    picker:
+      classIds.length > 0
+        ? { source: 'classlink', classIds, periodNames: [] }
+        : config.periodNames && config.periodNames.length > 0
+          ? { source: 'local', classIds: [], periodNames: config.periodNames }
+          : config.periodName
+            ? {
+                source: 'local',
+                classIds: [],
+                periodNames: [config.periodName],
+              }
+            : makeEmptyPickerValue('classlink'),
   };
 }
 
@@ -177,10 +217,11 @@ interface QuizManagerProps {
     plcOptions: PlcOptions,
     sessionOptions: QuizSessionOptions,
     /**
-     * ClassLink target class `sourcedId`, or `null` when the teacher chose
-     * "No class" (classic code/PIN-only flow). Phase 3A.
+     * Selected ClassLink class `sourcedId`s (Phase 5A multi-class). Empty
+     * array when the teacher chose local rosters or no classes at all —
+     * preserves the classic code/PIN-only flow.
      */
-    classId: string | null
+    classIds: string[]
   ) => void;
   onResults: (quiz: QuizMetadata) => void;
   onDelete: (quiz: QuizMetadata) => void | Promise<void>;
@@ -648,14 +689,25 @@ export const QuizManager: React.FC<QuizManagerProps> = ({
   // ─── Assign confirm handler ───────────────────────────────────────────────
   const handleAssignConfirm = (): void => {
     if (!assignTarget || !selectedMode) return;
+    // Guard: filter out any selected classId that's no longer in the fetched
+    // ClassLink list (e.g. rosters changed between fetch and confirm), so we
+    // never write stale sourcedIds.
+    const validClassIds =
+      assignOptions.picker.source === 'classlink'
+        ? assignOptions.picker.classIds.filter((id) =>
+            classLinkClasses.some((c) => c.sourcedId === id)
+          )
+        : [];
+    const effectivePeriodNames = resolveEffectivePeriodNames(
+      { ...assignOptions.picker, classIds: validClassIds },
+      classLinkClasses
+    );
     const plcOptions: PlcOptions = {
       plcMode: assignOptions.plcMode,
       teacherName: assignOptions.teacherName || undefined,
-      periodName: assignOptions.selectedPeriodNames[0] || undefined,
+      periodName: effectivePeriodNames[0] || undefined,
       periodNames:
-        assignOptions.selectedPeriodNames.length > 0
-          ? assignOptions.selectedPeriodNames
-          : undefined,
+        effectivePeriodNames.length > 0 ? effectivePeriodNames : undefined,
       plcSheetUrl: assignOptions.plcSheetUrl || undefined,
     };
     const sessionOptions: QuizSessionOptions = {
@@ -668,20 +720,12 @@ export const QuizManager: React.FC<QuizManagerProps> = ({
       showPodiumBetweenQuestions: assignOptions.showPodiumBetweenQuestions,
       soundEffectsEnabled: assignOptions.soundEffectsEnabled,
     };
-    // Guard: if the teacher somehow picked a classId that's no longer in the
-    // fetched ClassLink list (e.g. rosters changed between fetch and confirm),
-    // fall through to no-class rather than writing a stale id.
-    const selectedClassId =
-      assignOptions.classId &&
-      classLinkClasses.some((c) => c.sourcedId === assignOptions.classId)
-        ? assignOptions.classId
-        : null;
     onAssign(
       assignTarget,
       selectedMode,
       plcOptions,
       sessionOptions,
-      selectedClassId
+      validClassIds
     );
     setAssignTarget(null);
     setSelectedMode(null);
@@ -1004,14 +1048,20 @@ export const QuizManager: React.FC<QuizManagerProps> = ({
               options={assignOptions}
               onChange={setAssignOptions}
               classLinkClasses={classLinkClasses}
+              rosters={rosters}
             />
           }
           plcSlot={
             <AssignPlcSlot
-              rosters={rosters}
               options={assignOptions}
               onChange={setAssignOptions}
               plcSheetUrlInvalid={plcSheetUrlInvalid}
+              effectivePeriodCount={
+                resolveEffectivePeriodNames(
+                  assignOptions.picker,
+                  classLinkClasses
+                ).length
+              }
             />
           }
           onAssign={() => handleAssignConfirm()}
@@ -1280,7 +1330,8 @@ const AssignExtraSlot: React.FC<{
   options: QuizAssignOptions;
   onChange: (next: QuizAssignOptions) => void;
   classLinkClasses: ClassLinkClass[];
-}> = ({ options, onChange, classLinkClasses }) => {
+  rosters: ClassRoster[];
+}> = ({ options, onChange, classLinkClasses, rosters }) => {
   const update = <K extends keyof QuizAssignOptions>(
     key: K,
     value: QuizAssignOptions[K]
@@ -1288,13 +1339,12 @@ const AssignExtraSlot: React.FC<{
 
   return (
     <>
-      {classLinkClasses.length > 0 && (
-        <AssignTargetClassRow
-          classes={classLinkClasses}
-          value={options.classId}
-          onChange={(v) => update('classId', v)}
-        />
-      )}
+      <AssignClassPicker
+        classLinkClasses={classLinkClasses}
+        rosters={rosters}
+        value={options.picker}
+        onChange={(picker) => update('picker', picker)}
+      />
 
       <SectionHeader label="Quiz Integrity" />
       <ToggleRow
@@ -1354,79 +1404,21 @@ const AssignExtraSlot: React.FC<{
   );
 };
 
-/**
- * Build a human-readable label for a ClassLink class. Mirrors the format
- * used by `ClassLinkImportDialog` so teachers see the same class names in
- * both flows.
- */
-function formatClassLinkClassLabel(cls: ClassLinkClass): string {
-  const subjectPrefix = cls.subject ? `${cls.subject} - ` : '';
-  const codeSuffix = cls.classCode ? ` (${cls.classCode})` : '';
-  return `${subjectPrefix}${cls.title}${codeSuffix}`;
-}
-
-/**
- * Target-class selector rendered inside the Assign modal's `extraSlot`.
- * Lets the teacher pick an optional ClassLink class to target this quiz at
- * so that students who signed in via ClassLink see it on their
- * `/my-assignments` page. Phase 3A — pilot for class-targeted session
- * launches. Hidden entirely when the teacher isn't on a ClassLink org
- * (empty classes list).
- */
-const AssignTargetClassRow: React.FC<{
-  classes: ClassLinkClass[];
-  value: string;
-  onChange: (next: string) => void;
-}> = ({ classes, value, onChange }) => {
-  return (
-    <div>
-      <div className="flex items-center gap-2 mb-1">
-        <Users className="w-4 h-4 text-brand-blue-primary" />
-        <label
-          htmlFor="quiz-assign-target-class"
-          className="text-sm font-bold text-brand-blue-dark"
-        >
-          Target class (optional)
-        </label>
-      </div>
-      <select
-        id="quiz-assign-target-class"
-        value={value}
-        onChange={(e) => onChange(e.target.value)}
-        className="w-full px-3 py-2 bg-white border border-slate-200 rounded-lg text-slate-800 text-sm focus:outline-none focus:ring-2 focus:ring-brand-blue-primary"
-      >
-        <option value="">No class (use code/PIN only)</option>
-        {classes.map((cls) => (
-          <option key={cls.sourcedId} value={cls.sourcedId}>
-            {formatClassLinkClassLabel(cls)}
-          </option>
-        ))}
-      </select>
-      <p className="text-xxs text-slate-500 mt-1">
-        Students in this class will see this quiz in their assignments list.
-        Leave blank to use a join code.
-      </p>
-    </div>
-  );
-};
-
 const AssignPlcSlot: React.FC<{
-  rosters: ClassRoster[];
   options: QuizAssignOptions;
   onChange: (next: QuizAssignOptions) => void;
   plcSheetUrlInvalid: boolean;
-}> = ({ rosters, options, onChange, plcSheetUrlInvalid }) => {
+  /**
+   * Number of class periods the picker is contributing (ClassLink class
+   * labels or local roster names). Drives the "students will see a picker"
+   * hint without this slot needing to recompute the derivation itself.
+   */
+  effectivePeriodCount: number;
+}> = ({ options, onChange, plcSheetUrlInvalid, effectivePeriodCount }) => {
   const update = <K extends keyof QuizAssignOptions>(
     key: K,
     value: QuizAssignOptions[K]
   ) => onChange({ ...options, [key]: value });
-
-  const togglePeriod = (name: string) => {
-    const next = options.selectedPeriodNames.includes(name)
-      ? options.selectedPeriodNames.filter((n) => n !== name)
-      : [...options.selectedPeriodNames, name];
-    update('selectedPeriodNames', next);
-  };
 
   return (
     <>
@@ -1445,54 +1437,16 @@ const AssignPlcSlot: React.FC<{
         />
       </div>
       <p className="text-xxs text-slate-500 -mt-1">
-        Export results to a shared Google Sheet for your PLC team.
-      </p>
-
-      <div>
-        <label className="block text-xxs font-bold text-slate-400 uppercase tracking-widest mb-1">
-          Class Periods
-        </label>
-        {rosters.length > 0 ? (
-          <div className="space-y-1.5 max-h-36 overflow-y-auto rounded-lg border border-slate-200 bg-white p-2">
-            {rosters.map((r) => {
-              const checked = options.selectedPeriodNames.includes(r.name);
-              return (
-                <label
-                  key={r.id}
-                  className="flex items-center gap-2 cursor-pointer hover:bg-slate-50 rounded px-1.5 py-1"
-                >
-                  <input
-                    type="checkbox"
-                    checked={checked}
-                    onChange={() => togglePeriod(r.name)}
-                    className="rounded border-slate-300 text-indigo-600 focus:ring-indigo-500"
-                  />
-                  <span className="text-sm text-slate-800">{r.name}</span>
-                </label>
-              );
-            })}
-          </div>
+        Export results to a shared Google Sheet for your PLC team.{' '}
+        {effectivePeriodCount > 1 ? (
+          <>Students will see a class-period picker after entering their PIN.</>
         ) : (
-          <input
-            type="text"
-            value={options.selectedPeriodNames.join(', ')}
-            onChange={(e) => {
-              const names = e.target.value
-                .split(',')
-                .map((n) => n.trim())
-                .filter(Boolean);
-              update('selectedPeriodNames', [...new Set(names)]);
-            }}
-            placeholder="e.g. Period 1, Period 2"
-            className="w-full px-3 py-2 bg-white border border-slate-200 rounded-lg text-slate-800 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
-          />
+          <>
+            Pick two or more classes above to give students a period picker when
+            they join.
+          </>
         )}
-        <p className="text-xxs text-slate-400 mt-0.5">
-          {options.selectedPeriodNames.length > 1
-            ? 'Students will see a class-period picker after entering their PIN.'
-            : 'Select class periods for this assignment. Pick two or more to give students a picker when they join.'}
-        </p>
-      </div>
+      </p>
 
       {options.plcMode && (
         <div className="space-y-3 bg-slate-50 rounded-xl p-3 border border-slate-100">

--- a/components/widgets/QuizWidget/components/QuizManager.tsx
+++ b/components/widgets/QuizWidget/components/QuizManager.tsx
@@ -16,7 +16,7 @@
  * only, not functionality.
  */
 
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import {
   Plus,
   FileUp,
@@ -44,22 +44,23 @@ import {
   CheckSquare,
 } from 'lucide-react';
 import {
-  ClassLinkClass,
   QuizMetadata,
   QuizSessionMode,
   QuizConfig,
   ClassRoster,
   QuizAssignment,
 } from '@/types';
-import { classLinkService } from '@/utils/classlinkService';
 import { type QuizSessionOptions } from '@/hooks/useQuizSession';
 import { Toggle } from '@/components/common/Toggle';
 import { AssignClassPicker } from '@/components/common/AssignClassPicker';
 import {
-  formatClassLinkClassLabel,
   makeEmptyPickerValue,
   type AssignClassPickerValue,
 } from '@/components/common/AssignClassPicker.helpers';
+import {
+  mapLegacyClassIdsToRosterIds,
+  resolveAssignmentTargets,
+} from '@/utils/resolveAssignmentTargets';
 import {
   LibraryShell,
   LibraryToolbar,
@@ -111,46 +112,42 @@ interface QuizAssignOptions {
   plcMode: boolean;
   teacherName: string;
   plcSheetUrl: string;
-  /**
-   * Unified class-target picker state (Phase 5A). `classIds` is the list of
-   * ClassLink class `sourcedId`s when source === 'classlink'. `periodNames`
-   * is the list of local roster names when source === 'local'. One of the
-   * two is populated at a time — switching source clears the other.
-   */
+  /** Unified roster picker state. */
   picker: AssignClassPickerValue;
 }
 
 /**
- * Resolve the effective class-period labels for a picker value. When the
- * teacher picks ClassLink classes, the labels used for the post-PIN period
- * picker and the PLC Google Sheet export are the ClassLink class titles
- * themselves; when they pick local rosters, the labels are the roster names.
+ * Resolve the effective period-name labels from selected rosters. These
+ * labels drive the post-PIN period picker on the student app and the PLC
+ * Google Sheet export. Delegates to the shared `resolveAssignmentTargets`
+ * so roster lookup + period-name dedup live in one place.
  */
 function resolveEffectivePeriodNames(
   picker: AssignClassPickerValue,
-  classLinkClasses: ClassLinkClass[]
+  rosters: ClassRoster[]
 ): string[] {
-  if (picker.source === 'classlink') {
-    return picker.classIds
-      .map((id) => classLinkClasses.find((c) => c.sourcedId === id))
-      .filter((cls): cls is ClassLinkClass => Boolean(cls))
-      .map(formatClassLinkClassLabel);
-  }
-  return picker.periodNames;
+  return resolveAssignmentTargets(picker, rosters).periodNames;
 }
 
 function buildDefaultAssignOptions(
   config: QuizConfig,
-  quizId?: string
+  quizId: string | undefined,
+  rosters: ClassRoster[]
 ): QuizAssignOptions {
-  const rememberedMulti = quizId
-    ? (config.lastClassIdsByQuizId?.[quizId] ?? null)
-    : null;
-  const rememberedSingle = quizId
-    ? (config.lastClassIdByQuizId?.[quizId] ?? null)
-    : null;
-  const classIds =
-    rememberedMulti ?? (rememberedSingle ? [rememberedSingle] : []);
+  // Prefer the unified `lastRosterIdsByQuizId` memory. Fall back to legacy
+  // ClassLink-sourcedId maps (`lastClassIdsByQuizId` / `lastClassIdByQuizId`)
+  // so teachers who upgraded from pre-unification configs don't lose their
+  // per-quiz preselection on first launch.
+  let rememberedRosters = quizId
+    ? (config.lastRosterIdsByQuizId?.[quizId] ?? [])
+    : [];
+  if (rememberedRosters.length === 0 && quizId) {
+    const legacyMulti = config.lastClassIdsByQuizId?.[quizId];
+    const legacySingle = config.lastClassIdByQuizId?.[quizId];
+    const legacyClassIds =
+      legacyMulti ?? (legacySingle ? [legacySingle] : undefined);
+    rememberedRosters = mapLegacyClassIdsToRosterIds(legacyClassIds, rosters);
+  }
   return {
     tabWarningsEnabled: true,
     showResultToStudent: false,
@@ -164,17 +161,9 @@ function buildDefaultAssignOptions(
     teacherName: config.teacherName ?? '',
     plcSheetUrl: config.plcSheetUrl ?? '',
     picker:
-      classIds.length > 0
-        ? { source: 'classlink', classIds, periodNames: [] }
-        : config.periodNames && config.periodNames.length > 0
-          ? { source: 'local', classIds: [], periodNames: config.periodNames }
-          : config.periodName
-            ? {
-                source: 'local',
-                classIds: [],
-                periodNames: [config.periodName],
-              }
-            : makeEmptyPickerValue('classlink'),
+      rememberedRosters.length > 0
+        ? { rosterIds: rememberedRosters }
+        : makeEmptyPickerValue(),
   };
 }
 
@@ -216,12 +205,8 @@ interface QuizManagerProps {
     mode: QuizSessionMode,
     plcOptions: PlcOptions,
     sessionOptions: QuizSessionOptions,
-    /**
-     * Selected ClassLink class `sourcedId`s (Phase 5A multi-class). Empty
-     * array when the teacher chose local rosters or no classes at all —
-     * preserves the classic code/PIN-only flow.
-     */
-    classIds: string[]
+    /** Selected roster IDs (unified picker output). */
+    rosterIds: string[]
   ) => void;
   onResults: (quiz: QuizMetadata) => void;
   onDelete: (quiz: QuizMetadata) => void | Promise<void>;
@@ -363,7 +348,7 @@ export const QuizManager: React.FC<QuizManagerProps> = ({
     null
   );
   const [assignOptions, setAssignOptions] = useState<QuizAssignOptions>(() =>
-    buildDefaultAssignOptions(config)
+    buildDefaultAssignOptions(config, undefined, rosters)
   );
 
   // Reset assign form when modal re-opens (adjust-state-while-rendering)
@@ -374,38 +359,16 @@ export const QuizManager: React.FC<QuizManagerProps> = ({
     setPrevAssignTarget(assignTarget);
     if (assignTarget) {
       setSelectedMode(null);
-      setAssignOptions(buildDefaultAssignOptions(config, assignTarget.id));
+      setAssignOptions(
+        buildDefaultAssignOptions(config, assignTarget.id, rosters)
+      );
     }
   }
 
-  // ─── ClassLink target-class fetch (Phase 3A) ──────────────────────────────
-  // Teacher's ClassLink classes (if provisioned). Fetched once per QuizManager
-  // mount via the existing `classLinkService` (5-min cache — cheap). If the
-  // teacher isn't on a ClassLink-provisioned org, the list stays empty and
-  // the selector is hidden entirely. Errors are swallowed: ClassLink being
-  // unreachable must not block code+PIN launches.
-  const [classLinkClasses, setClassLinkClasses] = useState<ClassLinkClass[]>(
-    []
-  );
-  useEffect(() => {
-    let cancelled = false;
-    void (async () => {
-      try {
-        const data = await classLinkService.getRosters();
-        if (cancelled) return;
-        setClassLinkClasses(data.classes);
-      } catch (err) {
-        // Silent: no-ClassLink orgs and transient failures both fall back
-        // to code+PIN-only launches, so the selector stays hidden.
-        if (import.meta.env.DEV) {
-          console.warn('[QuizManager] ClassLink fetch failed:', err);
-        }
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, []);
+  // Live ClassLink fetching is no longer performed at assign time. Imported
+  // ClassLink rosters carry their own `classlinkClassId` metadata so the
+  // student SSO gate resolves purely from rosters; live ClassLink data is
+  // reached only via the Classes sidebar's Import dialog.
 
   // ─── Folder navigation (Wave 3-B-3) ───────────────────────────────────────
   const folderState = useFolders(userId, 'quiz');
@@ -689,18 +652,20 @@ export const QuizManager: React.FC<QuizManagerProps> = ({
   // ─── Assign confirm handler ───────────────────────────────────────────────
   const handleAssignConfirm = (): void => {
     if (!assignTarget || !selectedMode) return;
-    // Guard: filter out any selected classId that's no longer in the fetched
-    // ClassLink list (e.g. rosters changed between fetch and confirm), so we
-    // never write stale sourcedIds.
-    const validClassIds =
-      assignOptions.picker.source === 'classlink'
-        ? assignOptions.picker.classIds.filter((id) =>
-            classLinkClasses.some((c) => c.sourcedId === id)
-          )
-        : [];
+    // Guard against stale rosterIds — rosters can be deleted or fail to load
+    // (`loadError`) between the teacher's last assignment and the current one.
+    // A roster without students can't produce a joinable session, so treat
+    // `loadError` rosters as unavailable at confirm time in addition to the
+    // picker-side disabled state.
+    const visibleRosterIds = new Set(
+      rosters.filter((r) => !r.loadError).map((r) => r.id)
+    );
+    const validRosterIds = assignOptions.picker.rosterIds.filter((id) =>
+      visibleRosterIds.has(id)
+    );
     const effectivePeriodNames = resolveEffectivePeriodNames(
-      { ...assignOptions.picker, classIds: validClassIds },
-      classLinkClasses
+      { rosterIds: validRosterIds },
+      rosters
     );
     const plcOptions: PlcOptions = {
       plcMode: assignOptions.plcMode,
@@ -725,7 +690,7 @@ export const QuizManager: React.FC<QuizManagerProps> = ({
       selectedMode,
       plcOptions,
       sessionOptions,
-      validClassIds
+      validRosterIds
     );
     setAssignTarget(null);
     setSelectedMode(null);
@@ -1047,7 +1012,6 @@ export const QuizManager: React.FC<QuizManagerProps> = ({
             <AssignExtraSlot
               options={assignOptions}
               onChange={setAssignOptions}
-              classLinkClasses={classLinkClasses}
               rosters={rosters}
             />
           }
@@ -1057,10 +1021,8 @@ export const QuizManager: React.FC<QuizManagerProps> = ({
               onChange={setAssignOptions}
               plcSheetUrlInvalid={plcSheetUrlInvalid}
               effectivePeriodCount={
-                resolveEffectivePeriodNames(
-                  assignOptions.picker,
-                  classLinkClasses
-                ).length
+                resolveEffectivePeriodNames(assignOptions.picker, rosters)
+                  .length
               }
             />
           }
@@ -1329,9 +1291,8 @@ const AssignmentsList: React.FC<{
 const AssignExtraSlot: React.FC<{
   options: QuizAssignOptions;
   onChange: (next: QuizAssignOptions) => void;
-  classLinkClasses: ClassLinkClass[];
   rosters: ClassRoster[];
-}> = ({ options, onChange, classLinkClasses, rosters }) => {
+}> = ({ options, onChange, rosters }) => {
   const update = <K extends keyof QuizAssignOptions>(
     key: K,
     value: QuizAssignOptions[K]
@@ -1340,7 +1301,6 @@ const AssignExtraSlot: React.FC<{
   return (
     <>
       <AssignClassPicker
-        classLinkClasses={classLinkClasses}
         rosters={rosters}
         value={options.picker}
         onChange={(picker) => update('picker', picker)}

--- a/components/widgets/VideoActivityWidget/Widget.tsx
+++ b/components/widgets/VideoActivityWidget/Widget.tsx
@@ -29,6 +29,7 @@ import { Creator } from './components/Creator';
 import { Results } from './components/Results';
 import { VideoActivityEditorModal } from './components/VideoActivityEditorModal';
 import { Loader2, AlertTriangle, LogIn } from 'lucide-react';
+import { deriveSessionTargetsFromRosters } from '@/utils/resolveAssignmentTargets';
 
 /**
  * Shared clipboard helper — centralizes the feature-detection + toast flow
@@ -311,47 +312,43 @@ export const VideoActivityWidget: React.FC<{ widget: WidgetData }> = ({
         }}
         defaultSessionSettings={defaultSessionSettings}
         rosters={rosters}
-        onAssign={async (
-          meta,
-          sessionSettings,
-          assignmentName,
-          classIds,
-          selectedPeriodNames
-        ) => {
+        onAssign={async (meta, sessionSettings, assignmentName, rosterIds) => {
           // Use loadActivityData directly to avoid setting loadingActivity
           // which would cause the Manager component to unmount and destroy the modal
           const data = await loadActivityData(meta.driveFileId);
           if (!data) throw new Error('Failed to load activity data');
+          // Resolve rosterIds against the current rosters and derive
+          // ClassLink sourcedIds / period names / students in one shot.
+          const selectedRosters = rosters.filter((r) =>
+            rosterIds.includes(r.id)
+          );
+          const derived = deriveSessionTargetsFromRosters(selectedRosters);
           const sessionId = await createSession(
             data,
             user.uid,
             [],
             sessionSettings,
             assignmentName,
-            classIds,
-            selectedPeriodNames
+            derived.classIds,
+            derived.periodNames,
+            derived.rosterIds
           );
 
-          // Phase 5A: persist per-activity memory of the last ClassLink
-          // target classes so the next launch pre-selects the same set.
-          const prevMap = config.lastClassIdsByActivityId ?? {};
+          // Persist per-activity memory of the last roster selection so
+          // subsequent launches pre-fill the picker.
+          const prevMap = config.lastRosterIdsByActivityId ?? {};
           const nextMap: Record<string, string[]> = { ...prevMap };
-          if (classIds.length > 0) {
-            nextMap[meta.id] = classIds;
+          if (rosterIds.length > 0) {
+            nextMap[meta.id] = rosterIds;
           } else {
             delete nextMap[meta.id];
           }
-          // Drop any legacy single-class entry to avoid stale pre-selection.
-          const prevLegacyMap = config.lastClassIdByActivityId ?? {};
-          const nextLegacyMap: Record<string, string> = { ...prevLegacyMap };
-          delete nextLegacyMap[meta.id];
 
           updateWidget(widget.id, {
             config: {
               ...config,
               resultsSessionId: sessionId,
-              lastClassIdsByActivityId: nextMap,
-              lastClassIdByActivityId: nextLegacyMap,
+              lastRosterIdsByActivityId: nextMap,
             } as VideoActivityConfig,
           });
 
@@ -362,8 +359,9 @@ export const VideoActivityWidget: React.FC<{ widget: WidgetData }> = ({
           });
           return sessionId;
         }}
-        lastClassIdByActivityId={config.lastClassIdByActivityId}
+        lastRosterIdsByActivityId={config.lastRosterIdsByActivityId}
         lastClassIdsByActivityId={config.lastClassIdsByActivityId}
+        lastClassIdByActivityId={config.lastClassIdByActivityId}
         onDelete={async (meta) => {
           try {
             await deleteActivity(meta.id, meta.driveFileId);

--- a/components/widgets/VideoActivityWidget/Widget.tsx
+++ b/components/widgets/VideoActivityWidget/Widget.tsx
@@ -62,7 +62,7 @@ async function copyUrlToClipboard(
 export const VideoActivityWidget: React.FC<{ widget: WidgetData }> = ({
   widget,
 }) => {
-  const { updateWidget, addToast } = useDashboard();
+  const { updateWidget, addToast, rosters } = useDashboard();
   const {
     user,
     googleAccessToken,
@@ -310,7 +310,14 @@ export const VideoActivityWidget: React.FC<{ widget: WidgetData }> = ({
           }
         }}
         defaultSessionSettings={defaultSessionSettings}
-        onAssign={async (meta, sessionSettings, assignmentName, classId) => {
+        rosters={rosters}
+        onAssign={async (
+          meta,
+          sessionSettings,
+          assignmentName,
+          classIds,
+          selectedPeriodNames
+        ) => {
           // Use loadActivityData directly to avoid setting loadingActivity
           // which would cause the Manager component to unmount and destroy the modal
           const data = await loadActivityData(meta.driveFileId);
@@ -321,26 +328,30 @@ export const VideoActivityWidget: React.FC<{ widget: WidgetData }> = ({
             [],
             sessionSettings,
             assignmentName,
-            classId ?? undefined
+            classIds,
+            selectedPeriodNames
           );
 
-          // Phase 3B: persist per-activity memory of the last ClassLink target
-          // so the next launch of the same activity pre-selects the class the
-          // teacher used last time. Clearing the selection ("No class") also
-          // clears the remembered id so we don't stick on stale values.
-          const prevMap = config.lastClassIdByActivityId ?? {};
-          const nextMap: Record<string, string> = { ...prevMap };
-          if (classId) {
-            nextMap[meta.id] = classId;
+          // Phase 5A: persist per-activity memory of the last ClassLink
+          // target classes so the next launch pre-selects the same set.
+          const prevMap = config.lastClassIdsByActivityId ?? {};
+          const nextMap: Record<string, string[]> = { ...prevMap };
+          if (classIds.length > 0) {
+            nextMap[meta.id] = classIds;
           } else {
             delete nextMap[meta.id];
           }
+          // Drop any legacy single-class entry to avoid stale pre-selection.
+          const prevLegacyMap = config.lastClassIdByActivityId ?? {};
+          const nextLegacyMap: Record<string, string> = { ...prevLegacyMap };
+          delete nextLegacyMap[meta.id];
 
           updateWidget(widget.id, {
             config: {
               ...config,
               resultsSessionId: sessionId,
-              lastClassIdByActivityId: nextMap,
+              lastClassIdsByActivityId: nextMap,
+              lastClassIdByActivityId: nextLegacyMap,
             } as VideoActivityConfig,
           });
 
@@ -352,6 +363,7 @@ export const VideoActivityWidget: React.FC<{ widget: WidgetData }> = ({
           return sessionId;
         }}
         lastClassIdByActivityId={config.lastClassIdByActivityId}
+        lastClassIdsByActivityId={config.lastClassIdsByActivityId}
         onDelete={async (meta) => {
           try {
             await deleteActivity(meta.id, meta.driveFileId);

--- a/components/widgets/VideoActivityWidget/components/VideoActivityManager.tsx
+++ b/components/widgets/VideoActivityWidget/components/VideoActivityManager.tsx
@@ -17,7 +17,7 @@
  *     specific toggles flow through that slot, not by forking the primitive.
  */
 
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import {
   Activity,
   AlertCircle,
@@ -62,7 +62,6 @@ import type {
   LibraryTab,
 } from '@/components/common/library/types';
 import type {
-  ClassLinkClass,
   ClassRoster,
   VideoActivityAssignment,
   VideoActivityAssignmentStatus,
@@ -70,13 +69,12 @@ import type {
   VideoActivitySession,
   VideoActivitySessionSettings,
 } from '@/types';
-import { classLinkService } from '@/utils/classlinkService';
 import { AssignClassPicker } from '@/components/common/AssignClassPicker';
 import {
-  formatClassLinkClassLabel,
   makeEmptyPickerValue,
   type AssignClassPickerValue,
 } from '@/components/common/AssignClassPicker.helpers';
+import { mapLegacyClassIdsToRosterIds } from '@/utils/resolveAssignmentTargets';
 
 /* ─── Props ───────────────────────────────────────────────────────────────── */
 
@@ -101,30 +99,24 @@ export interface VideoActivityManagerProps {
     activity: VideoActivityMetadata,
     settings: VideoActivitySessionSettings,
     assignmentName: string,
-    /**
-     * Selected ClassLink class `sourcedId`s (Phase 5A multi-class). Empty
-     * array means the teacher targeted local rosters or no classes at all.
-     */
-    classIds: string[],
-    /**
-     * Selected local-roster period names (Phase 5A). Populated when the
-     * teacher picked local rosters; when they picked ClassLink classes these
-     * are the ClassLink class labels so the post-PIN period picker + any
-     * export respect the teacher's intent.
-     */
-    selectedPeriodNames: string[]
+    /** Selected roster IDs (unified picker output). */
+    rosterIds: string[]
   ) => Promise<string>;
-  /** Local rosters used to populate the "Local rosters" source in the picker. */
+  /** Rosters to populate the picker. */
   rosters: ClassRoster[];
   /**
-   * @deprecated Phase 5A — replaced by `lastClassIdsByActivityId`.
+   * Per-activity memory of the last roster selection. Pre-selects the picker
+   * on re-launch.
    */
-  lastClassIdByActivityId?: Record<string, string>;
+  lastRosterIdsByActivityId?: Record<string, string[]>;
   /**
-   * Multi-class per-activity memory of the last ClassLink classes the
-   * teacher targeted. Pre-selects the picker on re-launch.
+   * @deprecated Read-only fallback for pre-unification widget configs.
+   * Holds ClassLink class `sourcedId`s; mapped to rosterIds via
+   * `mapLegacyClassIdsToRosterIds` when `lastRosterIdsByActivityId` is absent.
    */
   lastClassIdsByActivityId?: Record<string, string[]>;
+  /** @deprecated See `lastClassIdsByActivityId`. */
+  lastClassIdByActivityId?: Record<string, string>;
   /**
    * Optional persistence hook for manual drag-reorder of the library. Drag
    * reordering is only enabled when this callback is provided; otherwise the
@@ -245,8 +237,9 @@ export const VideoActivityManager: React.FC<VideoActivityManagerProps> = ({
   initialLibraryViewMode,
   onLibraryViewModeChange,
   rosters,
-  lastClassIdByActivityId,
+  lastRosterIdsByActivityId,
   lastClassIdsByActivityId,
+  lastClassIdByActivityId,
 }) => {
   const [tab, setTab] = useState<LibraryTab>('library');
 
@@ -257,10 +250,10 @@ export const VideoActivityManager: React.FC<VideoActivityManagerProps> = ({
     useState<VideoActivitySessionSettings>(defaultSessionSettings);
   const [assignmentName, setAssignmentName] = useState<string>('');
   const [assignError, setAssignError] = useState<string | null>(null);
-  // Phase 5A: unified class-assignment picker state. Source defaults to
-  // ClassLink when any classes are available, otherwise falls back to Local.
+  // Unified roster picker state. Seeded from the per-activity roster memory
+  // on open so repeated assignments don't require re-picking.
   const [pickerValue, setPickerValue] = useState<AssignClassPickerValue>(() =>
-    makeEmptyPickerValue('classlink')
+    makeEmptyPickerValue()
   );
 
   // Adjust state during render when the assign target changes — avoids the
@@ -273,47 +266,27 @@ export const VideoActivityManager: React.FC<VideoActivityManagerProps> = ({
     setAssignOptions(defaultSessionSettings);
     setAssignmentName(buildDefaultAssignmentName(assignTarget.title));
     setAssignError(null);
-    const rememberedMulti = lastClassIdsByActivityId?.[assignTarget.id];
-    const rememberedSingle = lastClassIdByActivityId?.[assignTarget.id];
-    const classIds =
-      rememberedMulti ?? (rememberedSingle ? [rememberedSingle] : []);
-    setPickerValue(
-      classIds.length > 0
-        ? { source: 'classlink', classIds, periodNames: [] }
-        : makeEmptyPickerValue('classlink')
-    );
+    // Prefer unified roster memory; fall back to legacy ClassLink-sourcedId
+    // maps so teachers upgrading from pre-unification configs don't lose
+    // their per-activity preselection on first launch.
+    let rememberedRosters = lastRosterIdsByActivityId?.[assignTarget.id] ?? [];
+    if (rememberedRosters.length === 0) {
+      const legacyMulti = lastClassIdsByActivityId?.[assignTarget.id];
+      const legacySingle = lastClassIdByActivityId?.[assignTarget.id];
+      const legacyClassIds =
+        legacyMulti ?? (legacySingle ? [legacySingle] : undefined);
+      rememberedRosters = mapLegacyClassIdsToRosterIds(legacyClassIds, rosters);
+    }
+    setPickerValue({ rosterIds: rememberedRosters });
   } else if (!assignTarget && prevAssignTargetId !== null) {
     setPrevAssignTargetId(null);
   }
 
-  // ─── ClassLink target-class fetch (Phase 3B) ──────────────────────────────
-  // Teacher's ClassLink classes (if provisioned). Fetched once per manager
-  // mount via the existing `classLinkService` (5-min cache — cheap). If the
-  // teacher isn't on a ClassLink-provisioned org, the list stays empty and
-  // the selector is hidden entirely. Errors are swallowed: ClassLink being
-  // unreachable must not block classic join-URL launches.
-  const [classLinkClasses, setClassLinkClasses] = useState<ClassLinkClass[]>(
-    []
-  );
-  useEffect(() => {
-    let cancelled = false;
-    void (async () => {
-      try {
-        const data = await classLinkService.getRosters();
-        if (cancelled) return;
-        setClassLinkClasses(data.classes);
-      } catch (err) {
-        // Silent: no-ClassLink orgs and transient failures both fall back
-        // to join-URL-only launches, so the selector stays hidden.
-        if (import.meta.env.DEV) {
-          console.warn('[VideoActivityManager] ClassLink fetch failed:', err);
-        }
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, []);
+  // NOTE: The legacy `classLinkService.getRosters()` fetch was removed when
+  // the picker moved to roster-only targeting. Imported ClassLink rosters
+  // carry their own metadata (classlinkClassId) so the student SSO gate
+  // still works; live ClassLink data is now reached only via the Import
+  // dialog.
 
   // Delete confirmation state
   const [confirmDeleteActivityId, setConfirmDeleteActivityId] = useState<
@@ -501,28 +474,20 @@ export const VideoActivityManager: React.FC<VideoActivityManagerProps> = ({
       return;
     }
     setAssignError(null);
-    // Guard: filter stale sourcedIds that aren't in the latest ClassLink
-    // list. Selected local-roster names fall through unchanged.
-    const validClassIds =
-      pickerValue.source === 'classlink'
-        ? pickerValue.classIds.filter((id) =>
-            classLinkClasses.some((c) => c.sourcedId === id)
-          )
-        : [];
-    const selectedPeriodNames =
-      pickerValue.source === 'classlink'
-        ? validClassIds
-            .map((id) => classLinkClasses.find((c) => c.sourcedId === id))
-            .filter((cls): cls is ClassLinkClass => Boolean(cls))
-            .map(formatClassLinkClassLabel)
-        : pickerValue.periodNames;
+    // Guard against stale rosterIds — rosters can be deleted or fail to
+    // load (`loadError`) after the teacher's last assignment.
+    const visibleRosterIds = new Set(
+      rosters.filter((r) => !r.loadError).map((r) => r.id)
+    );
+    const validRosterIds = pickerValue.rosterIds.filter((id) =>
+      visibleRosterIds.has(id)
+    );
     try {
       await onAssign(
         assignTarget,
         assignOptions,
         assignmentName.trim(),
-        validClassIds,
-        selectedPeriodNames
+        validRosterIds
       );
       setAssignTarget(null);
     } catch (err) {
@@ -1009,7 +974,6 @@ export const VideoActivityManager: React.FC<VideoActivityManagerProps> = ({
           extraSlot={
             <div className="space-y-3">
               <AssignClassPicker
-                classLinkClasses={classLinkClasses}
                 rosters={rosters}
                 value={pickerValue}
                 onChange={setPickerValue}

--- a/components/widgets/VideoActivityWidget/components/VideoActivityManager.tsx
+++ b/components/widgets/VideoActivityWidget/components/VideoActivityManager.tsx
@@ -32,7 +32,6 @@ import {
   PlayCircle,
   Plus,
   Trash2,
-  Users,
 } from 'lucide-react';
 import { LibraryShell } from '@/components/common/library/LibraryShell';
 import { LibraryToolbar } from '@/components/common/library/LibraryToolbar';
@@ -64,6 +63,7 @@ import type {
 } from '@/components/common/library/types';
 import type {
   ClassLinkClass,
+  ClassRoster,
   VideoActivityAssignment,
   VideoActivityAssignmentStatus,
   VideoActivityMetadata,
@@ -71,6 +71,12 @@ import type {
   VideoActivitySessionSettings,
 } from '@/types';
 import { classLinkService } from '@/utils/classlinkService';
+import { AssignClassPicker } from '@/components/common/AssignClassPicker';
+import {
+  formatClassLinkClassLabel,
+  makeEmptyPickerValue,
+  type AssignClassPickerValue,
+} from '@/components/common/AssignClassPicker.helpers';
 
 /* ─── Props ───────────────────────────────────────────────────────────────── */
 
@@ -96,18 +102,29 @@ export interface VideoActivityManagerProps {
     settings: VideoActivitySessionSettings,
     assignmentName: string,
     /**
-     * ClassLink target class `sourcedId`, or `null` when the teacher chose
-     * "No class" (classic join-URL-only flow). Phase 3B.
+     * Selected ClassLink class `sourcedId`s (Phase 5A multi-class). Empty
+     * array means the teacher targeted local rosters or no classes at all.
      */
-    classId: string | null
+    classIds: string[],
+    /**
+     * Selected local-roster period names (Phase 5A). Populated when the
+     * teacher picked local rosters; when they picked ClassLink classes these
+     * are the ClassLink class labels so the post-PIN period picker + any
+     * export respect the teacher's intent.
+     */
+    selectedPeriodNames: string[]
   ) => Promise<string>;
+  /** Local rosters used to populate the "Local rosters" source in the picker. */
+  rosters: ClassRoster[];
   /**
-   * Per-activity memory of the last ClassLink class the teacher targeted.
-   * Used to pre-select the target-class selector on re-launch of the same
-   * activity. Passed through from widget config; missing keys fall through
-   * to "No class". Phase 3B.
+   * @deprecated Phase 5A — replaced by `lastClassIdsByActivityId`.
    */
   lastClassIdByActivityId?: Record<string, string>;
+  /**
+   * Multi-class per-activity memory of the last ClassLink classes the
+   * teacher targeted. Pre-selects the picker on re-launch.
+   */
+  lastClassIdsByActivityId?: Record<string, string[]>;
   /**
    * Optional persistence hook for manual drag-reorder of the library. Drag
    * reordering is only enabled when this callback is provided; otherwise the
@@ -227,7 +244,9 @@ export const VideoActivityManager: React.FC<VideoActivityManagerProps> = ({
   onArchiveResults,
   initialLibraryViewMode,
   onLibraryViewModeChange,
+  rosters,
   lastClassIdByActivityId,
+  lastClassIdsByActivityId,
 }) => {
   const [tab, setTab] = useState<LibraryTab>('library');
 
@@ -238,9 +257,11 @@ export const VideoActivityManager: React.FC<VideoActivityManagerProps> = ({
     useState<VideoActivitySessionSettings>(defaultSessionSettings);
   const [assignmentName, setAssignmentName] = useState<string>('');
   const [assignError, setAssignError] = useState<string | null>(null);
-  // Phase 3B: selected ClassLink target class `sourcedId`, or `''` for
-  // "No class" (classic join-URL-only flow).
-  const [assignClassId, setAssignClassId] = useState<string>('');
+  // Phase 5A: unified class-assignment picker state. Source defaults to
+  // ClassLink when any classes are available, otherwise falls back to Local.
+  const [pickerValue, setPickerValue] = useState<AssignClassPickerValue>(() =>
+    makeEmptyPickerValue('classlink')
+  );
 
   // Adjust state during render when the assign target changes — avoids the
   // set-state-in-effect anti-pattern while keeping form fields reset per open.
@@ -252,7 +273,15 @@ export const VideoActivityManager: React.FC<VideoActivityManagerProps> = ({
     setAssignOptions(defaultSessionSettings);
     setAssignmentName(buildDefaultAssignmentName(assignTarget.title));
     setAssignError(null);
-    setAssignClassId(lastClassIdByActivityId?.[assignTarget.id] ?? '');
+    const rememberedMulti = lastClassIdsByActivityId?.[assignTarget.id];
+    const rememberedSingle = lastClassIdByActivityId?.[assignTarget.id];
+    const classIds =
+      rememberedMulti ?? (rememberedSingle ? [rememberedSingle] : []);
+    setPickerValue(
+      classIds.length > 0
+        ? { source: 'classlink', classIds, periodNames: [] }
+        : makeEmptyPickerValue('classlink')
+    );
   } else if (!assignTarget && prevAssignTargetId !== null) {
     setPrevAssignTargetId(null);
   }
@@ -472,20 +501,28 @@ export const VideoActivityManager: React.FC<VideoActivityManagerProps> = ({
       return;
     }
     setAssignError(null);
-    // Guard: if the teacher somehow picked a classId that's no longer in the
-    // fetched ClassLink list (e.g. rosters changed between fetch and confirm),
-    // fall through to no-class rather than writing a stale id.
-    const selectedClassId =
-      assignClassId &&
-      classLinkClasses.some((c) => c.sourcedId === assignClassId)
-        ? assignClassId
-        : null;
+    // Guard: filter stale sourcedIds that aren't in the latest ClassLink
+    // list. Selected local-roster names fall through unchanged.
+    const validClassIds =
+      pickerValue.source === 'classlink'
+        ? pickerValue.classIds.filter((id) =>
+            classLinkClasses.some((c) => c.sourcedId === id)
+          )
+        : [];
+    const selectedPeriodNames =
+      pickerValue.source === 'classlink'
+        ? validClassIds
+            .map((id) => classLinkClasses.find((c) => c.sourcedId === id))
+            .filter((cls): cls is ClassLinkClass => Boolean(cls))
+            .map(formatClassLinkClassLabel)
+        : pickerValue.periodNames;
     try {
       await onAssign(
         assignTarget,
         assignOptions,
         assignmentName.trim(),
-        selectedClassId
+        validClassIds,
+        selectedPeriodNames
       );
       setAssignTarget(null);
     } catch (err) {
@@ -971,13 +1008,12 @@ export const VideoActivityManager: React.FC<VideoActivityManagerProps> = ({
           onAssign={handleAssignConfirm}
           extraSlot={
             <div className="space-y-3">
-              {classLinkClasses.length > 0 && (
-                <AssignTargetClassRow
-                  classes={classLinkClasses}
-                  value={assignClassId}
-                  onChange={setAssignClassId}
-                />
-              )}
+              <AssignClassPicker
+                classLinkClasses={classLinkClasses}
+                rosters={rosters}
+                value={pickerValue}
+                onChange={setPickerValue}
+              />
 
               {assignError && (
                 <div className="flex items-start gap-2 rounded-xl border border-brand-red-primary/30 bg-brand-red-lighter/40 px-3 py-2 text-sm font-medium text-brand-red-dark">
@@ -1066,61 +1102,3 @@ const ToggleRow: React.FC<ToggleRowProps> = ({
     />
   </div>
 );
-
-/* ─── AssignTargetClassRow — ClassLink target-class selector (Phase 3B) ──── */
-
-/**
- * Build a human-readable label for a ClassLink class. Mirrors the format
- * used by `ClassLinkImportDialog` and `QuizManager` so teachers see the same
- * class names across all assign flows.
- */
-function formatClassLinkClassLabel(cls: ClassLinkClass): string {
-  const subjectPrefix = cls.subject ? `${cls.subject} - ` : '';
-  const codeSuffix = cls.classCode ? ` (${cls.classCode})` : '';
-  return `${subjectPrefix}${cls.title}${codeSuffix}`;
-}
-
-/**
- * Target-class selector rendered inside the Assign modal's `extraSlot`.
- * Lets the teacher pick an optional ClassLink class to target this activity
- * at so that students who signed in via ClassLink see it on their
- * `/my-assignments` page. Phase 3B — fan-out of the Phase 3A quiz pilot.
- * Hidden entirely when the teacher isn't on a ClassLink org (empty classes
- * list).
- */
-const AssignTargetClassRow: React.FC<{
-  classes: ClassLinkClass[];
-  value: string;
-  onChange: (next: string) => void;
-}> = ({ classes, value, onChange }) => {
-  return (
-    <div>
-      <div className="flex items-center gap-2 mb-1">
-        <Users className="w-4 h-4 text-brand-blue-primary" />
-        <label
-          htmlFor="video-activity-assign-target-class"
-          className="text-sm font-bold text-brand-blue-dark"
-        >
-          Target class (optional)
-        </label>
-      </div>
-      <select
-        id="video-activity-assign-target-class"
-        value={value}
-        onChange={(e) => onChange(e.target.value)}
-        className="w-full px-3 py-2 bg-white border border-slate-200 rounded-lg text-slate-800 text-sm focus:outline-none focus:ring-2 focus:ring-brand-blue-primary"
-      >
-        <option value="">No class (use code/PIN only)</option>
-        {classes.map((cls) => (
-          <option key={cls.sourcedId} value={cls.sourcedId}>
-            {formatClassLinkClassLabel(cls)}
-          </option>
-        ))}
-      </select>
-      <p className="text-xxs text-slate-500 mt-1">
-        Students in this class will see this activity in their assignments list.
-        Leave blank to use a join code.
-      </p>
-    </div>
-  );
-};

--- a/context/DashboardContextValue.ts
+++ b/context/DashboardContextValue.ts
@@ -15,6 +15,7 @@ import {
   GridPosition,
   DrawableObject,
 } from '../types';
+import type { RosterCreateMeta } from '../hooks/useRosters';
 
 export interface AnnotationState {
   objects: DrawableObject[];
@@ -124,7 +125,11 @@ export interface DashboardContextValue {
   // Roster system
   rosters: ClassRoster[];
   activeRosterId: string | null;
-  addRoster: (name: string, students: Student[]) => Promise<string>;
+  addRoster: (
+    name: string,
+    students: Student[],
+    meta?: RosterCreateMeta
+  ) => Promise<string>;
   updateRoster: (id: string, updates: Partial<ClassRoster>) => Promise<void>;
   deleteRoster: (id: string) => Promise<void>;
   setActiveRoster: (id: string | null) => void;

--- a/docs/rules-followups.md
+++ b/docs/rules-followups.md
@@ -1,0 +1,27 @@
+# Firestore rules follow-ups
+
+Deferred from the PR #1401 review (dev-paul → main). Neither blocks correctness today; both are worth picking up before the next major rules change.
+
+## 1. Collapse triple `get()` per response rule evaluation
+
+**Where:** `firestore.rules` — `sessionTeacherUid()`, `sessionClassId()`, `sessionClassIds()` (and the `va*`, `gl*`, `ma*`, `aw*` variants).
+
+**What:** Each response `allow read/create/update/delete` calls three separate helpers that each do `get(/databases/.../<collection>/$(sessionId))`. Firestore caches the doc within a single rule evaluation, so this is **not billed 3x** — but the code duplicates the path and eats into the 20-`get()`-per-evaluation budget.
+
+**Fix sketch:** one helper per collection that pulls the doc once and returns the `data` map; read `.teacherUid`, `.get('classId','')`, `.get('classIds',[])` from the cached result at the callsite.
+
+**Trigger to do it:** next time we add a rule that reads another session field (we'd be adding a 4th `get()` helper otherwise), or if a rule evaluation starts pushing the budget.
+
+**Origin:** flagged on [#1397](https://github.com/OPS-PIvers/SpartBoard/pull/1397#discussion_r3131871374); the third `get()` landed in #1401.
+
+## 2. Migrate `activity_wall_sessions` to `passesStudentClassGateCompat`
+
+**Where:** `firestore.rules` — `activity_wall_sessions/{sessionId}/submissions` still uses `passesStudentClassGate(awSessionClassId())`.
+
+**What:** Quiz / video-activity / guided-learning response rules now call `passesStudentClassGateCompat(sessionClassIds(), sessionClassId())` to handle Phase 5A `classIds[]` sessions. Activity Wall was left on the single-class gate because its hook hasn't been migrated. If a future PR migrates the AW hook to write `classIds[]` without also updating the gate, the "empty classId → open" branch in `passesStudentClassGate` would let any studentRole user through.
+
+**Fix:** when the AW hook migrates to Phase 5A, also swap the rule to `passesStudentClassGateCompat(awSessionClassIds(), awSessionClassId())` and add the `awSessionClassIds()` helper.
+
+**Trigger to do it:** whoever migrates `useActivityWallAssignments` / `useActivityWallSession` to Phase 5A owns this rule change in the same PR.
+
+**Origin:** latent trap surfaced during the PR #1401 review; not exploitable today (no Phase 5A AW writes exist).

--- a/docs/superpowers/specs/2026-04-22-assign-class-picker-design.md
+++ b/docs/superpowers/specs/2026-04-22-assign-class-picker-design.md
@@ -1,0 +1,222 @@
+# AssignClassPicker — Unified Class Picker for Quiz + Video Activity
+
+**Date:** 2026-04-22
+**Target branch:** `dev-paul`
+**Driver:** Three-teacher Quiz pilot tomorrow needs a working multi-class assignment flow.
+
+## Problem
+
+Today's Quiz assign modal exposes two separate controls that both answer the question _"which classes get this assignment?"_:
+
+1. **Single-select dropdown** ("Target class (optional)") — `AssignTargetClassRow` at `components/widgets/QuizWidget/components/QuizManager.tsx:1376–1411`. Binds to a ClassLink class via its `sourcedId`. Used by Firestore rules (`passesStudentClassGate`) so ClassLink-SSO students see the assignment on their `/my-assignments` page.
+2. **Multi-select checkbox list** ("Class Periods") inside `AssignPlcSlot` — `components/widgets/QuizWidget/components/QuizManager.tsx:1451–1495`. Binds to local `ClassRoster` names. Drives the post-PIN class-period picker for students and labels columns in the PLC Google-Sheet export.
+
+The two controls have different sources (ClassLink classes vs. local rosters), different cardinality (one vs. many), and different downstream effects, but the UI presents them as if they're optional add-ons in the same dialog. **A teacher with 4 ClassLink classes can only assign to one of them.** That's the headline pain point for tomorrow's pilot.
+
+Video Activity has the same single-select limitation (`components/widgets/VideoActivityWidget/components/VideoActivityManager.tsx:1091–1127`) but no period-checkbox concept at all — it has no PLC mode, no `selectedPeriodNames` field, and no student-side period flow.
+
+Guided Learning has _no class targeting at all_ today and is intentionally out of scope for this PR (see "Out of scope").
+
+## Goals
+
+1. Replace the two Quiz controls with one shared component that supports a strict source toggle (ClassLink XOR local rosters) and multi-select within each source.
+2. Apply the same component to Video Activity in a `classlink-only` mode (no source toggle, no period UI).
+3. Update Firestore rules for both `quiz_sessions` and `video_activity_sessions` so ClassLink-SSO students whose `classIds` claim intersects any of the session's targeted classes can read it. Today's `passesStudentClassGate(classId)` only checks a single class.
+4. Preserve all existing assignments — old session docs (with only `classId`, no `classIds`) must keep working for ClassLink-SSO students after rules ship.
+5. Keep PLC mode functional and orthogonal to the picker — PLC is "shared quiz settings + shared spreadsheet for data," not a feature that depends on local rosters.
+
+## Non-goals
+
+- Guided Learning class targeting (separate follow-up — net-new infrastructure).
+- Renaming `selectedPeriodNames` to something more honest (out of scope; too many downstream touches).
+- Mini-app (already on `classIds` + `passesStudentClassGateList`).
+- Cleanup PR to drop the `classId` write + rules fallback (planned for later, not timed against pilot).
+- Restructuring how PIN-flow students join (the PIN code path is unchanged).
+
+---
+
+## Design
+
+### 1. Component shape
+
+A single shared component at `components/common/AssignClassPicker.tsx`, ~200 lines, with one mode prop that toggles between dual-source (Quiz) and ClassLink-only (VA):
+
+```ts
+type AssignClassPickerValue = {
+  source: 'classlink' | 'local'; // ignored when mode === 'classlink-only'
+  classIds: string[]; // ClassLink sourcedIds
+  periodNames: string[]; // local roster names; always [] when mode === 'classlink-only'
+};
+
+type AssignClassPickerProps = {
+  mode: 'dual' | 'classlink-only';
+  classLinkClasses: ClassLinkClass[];
+  rosters?: ClassRoster[]; // required when mode === 'dual', ignored otherwise
+  value: AssignClassPickerValue;
+  onChange: (next: AssignClassPickerValue) => void;
+  disabled?: boolean;
+};
+```
+
+Quiz passes `mode="dual"`. VA passes `mode="classlink-only"` and omits `rosters`.
+
+**Rejected alternatives:**
+
+- Base + variants split (`<DualSourceClassPicker>` composing `<ClassLinkClassPicker>`) — over-engineered for two callers; one would always import the other.
+- Hook + presentation split (`useAssignClassSelection()` returning a state machine, each widget rendering its own UI) — defeats the purpose of unifying the UI; styles would diverge within a release.
+
+### 2. Layout
+
+**Quiz (`mode="dual"`):**
+
+```
+┌─ Assign to classes ─────────────────────────────────┐
+│  [ ClassLink classes ]  [ Local rosters ]           │ ← segmented pill, 2 options
+│                                                      │
+│  ☑ Math 6 — Period 1                                │ ← multi-select, filtered by source
+│  ☑ Math 6 — Period 3                                │
+│  ☐ Algebra — Period 5                               │
+│  ☐ Algebra — Period 7                               │
+│                                                      │
+│  Select all (4) · Clear                             │ ← inline links
+└──────────────────────────────────────────────────────┘
+```
+
+**VA (`mode="classlink-only"`):**
+
+```
+┌─ Assign to classes ─────────────────────────────────┐
+│  ☑ Math 6 — Period 1                                │ ← no source toggle
+│  ☑ Math 6 — Period 3                                │
+│  ☐ Algebra — Period 5                               │
+│  ☐ Algebra — Period 7                               │
+│                                                      │
+│  Select all (4) · Clear                             │
+└──────────────────────────────────────────────────────┘
+```
+
+**Empty / fallback states:**
+
+- ClassLink source with zero classes: render _"No ClassLink classes connected. Switch to Local rosters or use the join code."_ with the segmented control still visible so the teacher can switch.
+- Local rosters source with zero rosters: _"No saved rosters. Add one in Sidebar → Classes, or switch to ClassLink."_
+- Zero selection (any mode): no error — assignment falls back to "code/PIN only" join (current default behavior). Inline note: _"No classes selected — students will join with the code only."_
+
+The segmented control is small custom markup (two `<button>`s in a styled flex container). The existing `Toggle` component in `components/common/Toggle.tsx` is boolean-only and not suitable.
+
+### 3. PLC mode interaction (Quiz only)
+
+PLC mode is just _"shared quiz settings + shared Google Sheet for data."_ It's orthogonal to the picker.
+
+- The PLC toggle stays in `AssignPlcSlot`. The period checkbox block inside that slot (lines 1451–1495) is **removed** — periods now come from the picker for any widget that wants to label results by period.
+- The PLC toggle is **never disabled** by the picker's source choice.
+- PLC export consumes whatever the picker emitted as the "period axis":
+  - If `value.source === 'local'` → use `value.periodNames` as column headers (today's behavior).
+  - If `value.source === 'classlink'` → translate each `classId` through the existing `formatClassLinkClassLabel(cls)` helper (`components/widgets/QuizWidget/components/QuizManager.tsx:1362–1366`) to get `"Math 6 - Period 1"`-style headers. The session doc still stores raw `classIds`; the label translation happens at export time.
+  - If teacher selected zero classes → PLC sheet has no per-period columns; results land in a single "All students" column (matches today's fallback for PLC-on-with-no-periods).
+
+The picker doesn't know about PLC. The PLC slot reads `value.classIds` / `value.periodNames` from parent state. Clean separation.
+
+### 4. Pre-population on existing assignments
+
+When the assign modal opens for an existing assignment (or re-opens for editing), source the initial `AssignClassPickerValue` in this priority order:
+
+1. `classIds: [...]` present and non-empty → `{ source: 'classlink', classIds: [saved], periodNames: [] }`.
+2. Else `classId: 'x'` present (old single-field assignment) → `{ source: 'classlink', classIds: ['x'], periodNames: [] }`. Migration shim — the old single field maps to the new multi field with one element.
+3. Else `selectedPeriodNames: [...]` present and non-empty → `{ source: 'local', classIds: [], periodNames: [saved] }`.
+4. Else (fresh assignment) → `{ source: 'classlink', classIds: [], periodNames: [] }`.
+
+ClassLink wins over local when both are present (more specific targeting). Source defaults to `classlink` on fresh assignments because that's the most common new-teacher-with-SSO path.
+
+### 5. What gets written
+
+**`hooks/useQuizAssignments.ts createAssignment`** — current signature accepts `classId: string | null` as the 4th positional arg (`hooks/useQuizAssignments.ts:181–268`). New signature replaces that parameter with an options object:
+
+```ts
+createAssignment(quiz, settings, initialStatus, {
+  classIds: string[],            // [] for no targeting
+  selectedPeriodNames: string[], // [] when source === 'classlink'
+})
+```
+
+Writes onto `quiz_sessions/{id}`:
+
+- `classIds: string[]` — always present (possibly empty)
+- `classId: string` — set to `classIds[0]` when non-empty, omitted when empty (migration shim)
+- `selectedPeriodNames: string[]` — existing field, unchanged semantics
+
+**`hooks/useVideoActivityAssignments.ts createAssignment`** — current signature (`hooks/useVideoActivityAssignments.ts:135–181`) accepts `classId` as a positional arg. New signature replaces it with `classIds: string[]`. Writes both `classIds` and `classId = classIds[0]` to `video_activity_sessions/{id}`. No `selectedPeriodNames` — VA has no concept of local-roster periods today and we are not adding it.
+
+### 6. Firestore rules
+
+Per Q2's option (a): dual-write with rules fallback. Old sessions (no `classIds` field) keep working via fallback to the single `classId`.
+
+**`quiz_sessions` `allow get`** (currently `firestore.rules:603–605`):
+
+```
+allow get: if request.auth != null &&
+  (!isStudentRoleUser() ||
+   passesStudentClassGateList(
+     resource.data.get('classIds', [resource.data.get('classId', '')])
+   ));
+```
+
+**`quiz_sessions/responses`** (currently `firestore.rules:625–627`): change `sessionClassId()` helper to return the same fallback list, and switch all `passesStudentClassGate(...)` calls in the responses rules (lines 631, 639, 649) to `passesStudentClassGateList(...)`.
+
+**`video_activity_sessions` `allow get`** (currently `firestore.rules:741–743`): same pattern.
+
+**`video_activity_sessions/responses`** (currently `firestore.rules:773–775`): change `vaSessionClassId()` helper and switch `passesStudentClassGate(...)` → `passesStudentClassGateList(...)` (lines 781, 790, 795).
+
+**`guided_learning_sessions`**: unchanged. GL is out of scope for this PR.
+
+The `passesStudentClassGateList` helper already exists at `firestore.rules:51–57` and is in production use for `mini_app_sessions`.
+
+### 7. Type changes
+
+**`types.ts`:**
+
+- Add `classIds?: string[]` to `QuizSession` and `VideoActivitySession` interfaces.
+- Update `QuizAssignOptions` (currently `components/widgets/QuizWidget/components/QuizManager.tsx:97–117`): drop `classId: string`, add `classIds: string[]`. `selectedPeriodNames: string[]` stays.
+
+The mini-app session type already has `classIds`; this brings Quiz and VA in line with that shape.
+
+### 8. Files touched
+
+| File                                                                         | Change                                                                                                                                                                                                                            |
+| ---------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `components/common/AssignClassPicker.tsx`                                    | **NEW** (~200 lines)                                                                                                                                                                                                              |
+| `components/widgets/QuizWidget/components/QuizManager.tsx`                   | Replace `AssignTargetClassRow` (1376–1411) and the period checkbox block in `AssignPlcSlot` (1451–1495) with a single `<AssignClassPicker mode="dual" />`. Update `handleAssignConfirm` (649–688) to pass the new options object. |
+| `components/widgets/VideoActivityWidget/components/VideoActivityManager.tsx` | Replace `AssignTargetClassRow` (1091–1127) with `<AssignClassPicker mode="classlink-only" />`. Update `handleAssignConfirm` (468–497) to pass `classIds: string[]`.                                                               |
+| `hooks/useQuizAssignments.ts`                                                | Change `createAssignment` (181–268) signature; write both `classIds` and `classId` per Section 5.                                                                                                                                 |
+| `hooks/useVideoActivityAssignments.ts`                                       | Change `createAssignment` (135–181) signature; write both `classIds` and `classId`.                                                                                                                                               |
+| `types.ts`                                                                   | Add `classIds?: string[]` to `QuizSession` and `VideoActivitySession`.                                                                                                                                                            |
+| `firestore.rules`                                                            | Update `quiz_sessions` and `video_activity_sessions` `get` + responses rules per Section 6.                                                                                                                                       |
+| `utils/quizDriveService.ts`                                                  | If this is where PLC sheet column headers are computed (see Section 3), update to translate `classIds` → labels via `formatClassLinkClassLabel`. Confirm location during implementation.                                          |
+
+## Verification
+
+Run before opening the PR:
+
+- `pnpm run validate` (typecheck + lint + format-check + tests)
+- `pnpm -C functions test`
+- `pnpm run test:rules` if it covers the affected collections
+
+Manual smoke on the dev-paul Firebase preview after deploy:
+
+1. **Multi-class ClassLink assignment.** Teacher with 4 ClassLink classes: open Quiz → Assign → ClassLink source → select all 4 → Create. In Firebase Console, confirm the new `quiz_sessions/{id}` doc has `classIds: [4 ids]` and `classId: <first of the 4>`.
+2. **ClassLink-SSO student visibility.** Sign in as a ClassLink-SSO student in class #2 of the 4. Navigate to `/my-assignments`. Confirm the new quiz appears (rules check via `passesStudentClassGateList`).
+3. **Local-rosters with PLC.** Same teacher: Assign → Local rosters source → pick 2 → enable PLC → Create. Confirm session doc has `selectedPeriodNames: [2]`, no `classIds`. Confirm PLC export has 2 period columns.
+4. **ClassLink with PLC.** Same teacher: Assign → ClassLink source → pick 3 → enable PLC → Create. Confirm session doc has `classIds: [3]`. Confirm PLC export has 3 columns labeled with the human-readable ClassLink class names.
+5. **Empty selection fallback.** Same teacher: Assign with no classes selected (either source) → Create. Confirm session doc has `classIds: []` and no `classId`. Confirm a PIN-flow student can still join via code.
+6. **VA multi-class.** Repeat scenarios 1 and 2 for Video Activity.
+7. **Backward compat.** Verify an assignment created on the OLD code (with only `classId`, no `classIds`) is still visible to a ClassLink-SSO student in that class after the new rules deploy. This exercises the `resource.data.get('classIds', [resource.data.get('classId', '')])` fallback.
+
+## Migration / rollout
+
+- Single PR targeting `dev-paul`. Firebase rules + Firestore indexes deploy automatically on push to dev-paul.
+- After CI green and the smoke tests above pass on the preview URL, open a follow-up `dev-paul → main` promotion PR.
+- Cleanup PR to drop the `classId` write + rules fallback can come weeks later, untimed against the pilot. Defer until we've confirmed no pre-PR sessions remain in active use.
+
+## Open questions deferred to implementation
+
+- Exact location of the PLC export column-header logic (Section 8 lists `utils/quizDriveService.ts` as the likely site; confirm during implementation).
+- Whether the segmented control should be promoted to `components/common/SegmentedControl.tsx` for future reuse, or kept inline in `AssignClassPicker.tsx`. Default: keep inline for this PR; promote if a second caller materializes.

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -105,6 +105,62 @@
           "order": "DESCENDING"
         }
       ]
+    },
+    {
+      "collectionGroup": "quiz_sessions",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "classIds",
+          "arrayConfig": "CONTAINS"
+        },
+        {
+          "fieldPath": "status",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "quiz_sessions",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "classId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "status",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "video_activity_sessions",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "classIds",
+          "arrayConfig": "CONTAINS"
+        },
+        {
+          "fieldPath": "status",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "video_activity_sessions",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "classId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "status",
+          "order": "ASCENDING"
+        }
+      ]
     }
   ],
   "fieldOverrides": []

--- a/firestore.rules
+++ b/firestore.rules
@@ -577,26 +577,37 @@ service cloud.firestore {
     // owns the document and stores their uid on the `teacherUid` field.
     // Multiple concurrent sessions per teacher are allowed.
     match /quiz_sessions/{sessionId} {
-      // Students need both `get` (single-doc reads after joining) and `list`
-      // (collection query by join code via `where('code', '==', ...)`) access.
-      // Restricting enumeration fully would require a Cloud Function proxy;
-      // for now we accept that authenticated users can list session documents.
+      // Reads are split into `get` (single doc) and `list` (collection query)
+      // because Firestore's rules engine treats them differently:
       //
-      // studentRole (GIS-authenticated) users must additionally have the
-      // session's classId in their classIds custom claim. Non-student callers
-      // (teachers, admins, anonymous PIN students) are unaffected.
+      //   - `get` evaluates per-document at read time. The studentRole class
+      //     gate can safely reference `resource.data` because the engine has
+      //     a concrete document to evaluate against.
+      //   - `list` is statically analyzed BEFORE execution. Any `resource.data`
+      //     reference in the predicate is treated as "unprovable for arbitrary
+      //     docs" and the entire list is denied — even when an earlier OR
+      //     branch (`!isStudentRoleUser()`) would short-circuit at runtime.
+      //     This is the failure mode that broke teacher assignment creation
+      //     for ~2 days; the previous "hoist" fix in #1389 was insufficient
+      //     because the static analyzer does not respect short-circuit OR.
       //
-      // The `!isStudentRoleUser()` short-circuit MUST appear at the top level
-      // of the rule rather than buried inside `passesStudentClassGate` — the
-      // Firestore rules engine performs static analysis on `list` queries and
-      // can reject teacher list calls (e.g. `useQuizAssignments.allocateJoinCode`
-      // doing `where code == X`) when a `resource.data` reference appears
-      // inside a function-call wrapper, even though the OR would short-circuit
-      // at runtime. Hoisting matches the pattern already used by
-      // `mini_app_sessions` below.
-      allow read: if request.auth != null &&
+      // Splitting the rule lets the `list` predicate stay free of any
+      // `resource.data` reference. The list rule is the broad "any
+      // authenticated caller can enumerate session docs" allowance —
+      // studentRole users need this so MyAssignmentsPage can run its
+      // `where('classId', 'in', myClassIds)` discovery query, and PIN-flow
+      // students need it for code lookups. Per-class gating is still
+      // enforced at the `get` rule (and at write time on responses), so
+      // a studentRole user can list metadata but cannot open the contents
+      // of a session outside their classIds claim.
+      //
+      // Restricting enumeration further would require a Cloud Function
+      // proxy; for now we accept that any authenticated user can list
+      // session documents (matches the pre-SSO behavior).
+      allow get: if request.auth != null &&
         (!isStudentRoleUser() ||
          passesStudentClassGate(resource.data.get('classId', '')));
+      allow list: if request.auth != null;
       // Only the teacher (session owner) can create/update/delete the session document.
       // Ownership is carried on the `teacherUid` field (no longer the doc id).
       allow create: if request.auth != null &&
@@ -728,13 +739,16 @@ service cloud.firestore {
 
     // Video Activity Sessions — Teacher creates, anonymous students can read and submit responses
     match /video_activity_sessions/{sessionId} {
-      // Any authenticated user (including anonymous) can read session documents.
-      // studentRole (GIS) users additionally must have the session's classId
-      // in their classIds claim. The `!isStudentRoleUser()` check is hoisted
-      // to the top level (see quiz_sessions for rationale).
-      allow read: if request.auth != null &&
+      // Reads split into `get` + `list`; see quiz_sessions for the rationale
+      // (Firestore static-analyzes `list` predicates and rejects any rule
+      // that touches `resource.data`, even behind a short-circuit OR).
+      // The `list` rule allows any authenticated caller so studentRole users
+      // can run their MyAssignmentsPage class-filtered discovery queries;
+      // per-doc class gating still happens at `get`.
+      allow get: if request.auth != null &&
         (!isStudentRoleUser() ||
          passesStudentClassGate(resource.data.get('classId', '')));
+      allow list: if request.auth != null;
       // Only authenticated (non-anonymous) users can create sessions (teachers)
       allow create: if request.auth != null && request.auth.token.firebase.sign_in_provider != 'anonymous';
       // Teacher owners may rename or end sessions, but not mutate session content.
@@ -810,13 +824,19 @@ service cloud.firestore {
 
     // MiniApp Assignment Sessions — Teacher creates, anonymous students can read
     match /mini_app_sessions/{sessionId} {
-      // Any authenticated user (including anonymous) can read session documents.
+      // Reads split into `get` + `list`; see quiz_sessions for the rationale
+      // (Firestore static-analyzes `list` predicates and rejects any rule
+      // that touches `resource.data`, even behind a short-circuit OR).
+      // The `list` rule allows any authenticated caller so studentRole users
+      // can run their MyAssignmentsPage `array-contains-any` discovery query;
+      // per-doc class gating still happens at `get`.
       // studentRole (GIS) users additionally must have at least one of the
       // session's classIds in their classIds claim (or the session must be
       // untargeted — empty classIds — for shareable-link launches).
-      allow read: if request.auth != null &&
+      allow get: if request.auth != null &&
         (!isStudentRoleUser() ||
          passesStudentClassGateList(resource.data.get('classIds', [])));
+      allow list: if request.auth != null;
       // Only authenticated (non-anonymous) teachers can create sessions they own
       allow create: if request.auth != null &&
         request.auth.token.firebase.sign_in_provider != 'anonymous' &&
@@ -908,13 +928,16 @@ service cloud.firestore {
 
     // Guided Learning Sessions — Teacher creates, authenticated (incl. anonymous) students read and submit
     match /guided_learning_sessions/{sessionId} {
-      // Any authenticated user (including anonymous) can read session documents.
-      // studentRole (GIS) users additionally must have the session's classId
-      // in their classIds claim. The `!isStudentRoleUser()` check is hoisted
-      // to the top level (see quiz_sessions for rationale).
-      allow read: if request.auth != null &&
+      // Reads split into `get` + `list`; see quiz_sessions for the rationale
+      // (Firestore static-analyzes `list` predicates and rejects any rule
+      // that touches `resource.data`, even behind a short-circuit OR).
+      // The `list` rule allows any authenticated caller so studentRole users
+      // can run their MyAssignmentsPage class-filtered discovery queries;
+      // per-doc class gating still happens at `get`.
+      allow get: if request.auth != null &&
         (!isStudentRoleUser() ||
          passesStudentClassGate(resource.data.get('classId', '')));
+      allow list: if request.auth != null;
       // Only authenticated (non-anonymous) teachers can create sessions; they must own it
       allow create: if request.auth != null &&
         request.auth.token.firebase.sign_in_provider != 'anonymous' &&
@@ -969,13 +992,16 @@ service cloud.firestore {
     // Activity Wall Sessions — Teacher owns it (UID prefix in sessionId), students submit entries
     // sessionId is formatted as {teacherUid}_{activityId}
     match /activity_wall_sessions/{sessionId} {
-      // Any authenticated user can read the session metadata from a valid share link.
-      // studentRole (GIS) users additionally must have the session's classId
-      // in their classIds claim. The `!isStudentRoleUser()` check is hoisted
-      // to the top level (see quiz_sessions for rationale).
-      allow read: if request.auth != null &&
+      // Reads split into `get` + `list`; see quiz_sessions for the rationale
+      // (Firestore static-analyzes `list` predicates and rejects any rule
+      // that touches `resource.data`, even behind a short-circuit OR).
+      // The `list` rule allows any authenticated caller so studentRole users
+      // can run their MyAssignmentsPage class-filtered discovery queries;
+      // per-doc class gating still happens at `get`.
+      allow get: if request.auth != null &&
         (!isStudentRoleUser() ||
          passesStudentClassGate(resource.data.get('classId', '')));
+      allow list: if request.auth != null;
       // Only authenticated non-anonymous teachers/admins can create or update the session document itself.
       allow create, update: if request.auth != null &&
                             request.auth.token.firebase.sign_in_provider != 'anonymous' &&

--- a/firestore.rules
+++ b/firestore.rules
@@ -72,6 +72,21 @@ service cloud.firestore {
               sessionClassIds.hasAny(request.auth.token.classIds));
     }
 
+    // Phase 5A transitional compatibility helper. Sessions created after
+    // Phase 5A write a multi-value `classIds` list; sessions created before
+    // Phase 5A write the single `classId` field. This helper selects the
+    // right gate based on which field is populated on the session doc:
+    //   - if `classIds` is a non-empty list, use `passesStudentClassGateList`
+    //   - otherwise, fall back to the legacy single-class gate
+    // Callers pass `resource.data.get('classIds', [])` and
+    // `resource.data.get('classId', '')` so the field-absent case safely
+    // falls through (empty list / empty string → no-op gate).
+    function passesStudentClassGateCompat(sessionClassIds, sessionClassId) {
+      return sessionClassIds is list && sessionClassIds.size() > 0
+             ? passesStudentClassGateList(sessionClassIds)
+             : passesStudentClassGate(sessionClassId);
+    }
+
     // ---- Organization helpers (see docs/organization_wiring_implementation.md) ----
 
     // Super admins are listed on the legacy admin_settings/user_roles doc.
@@ -642,10 +657,13 @@ service cloud.firestore {
         function sessionClassId() {
           return get(/databases/$(database)/documents/quiz_sessions/$(sessionId)).data.get('classId', '');
         }
+        function sessionClassIds() {
+          return get(/databases/$(database)/documents/quiz_sessions/$(sessionId)).data.get('classIds', []);
+        }
 
         allow read: if request.auth != null &&
           (request.auth.uid == sessionTeacherUid() ||
-           (request.auth.uid == studentUid && passesStudentClassGate(sessionClassId())) ||
+           (request.auth.uid == studentUid && passesStudentClassGateCompat(sessionClassIds(), sessionClassId())) ||
            isAdmin());
         allow create: if request.auth != null &&
           request.auth.uid == studentUid &&
@@ -653,7 +671,7 @@ service cloud.firestore {
           // Students cannot forge a score on creation
           request.resource.data.score == null &&
           // studentRole users must be enrolled in the session's class
-          passesStudentClassGate(sessionClassId());
+          passesStudentClassGateCompat(sessionClassIds(), sessionClassId());
         allow update: if request.auth != null && (
           // Teacher and admins can update any field
           request.auth.uid == sessionTeacherUid() || isAdmin() ||
@@ -663,7 +681,7 @@ service cloud.firestore {
           // score is never written by students.
           // tabSwitchWarnings may only increase (monotonic) to prevent tampering.
           (request.auth.uid == studentUid &&
-           passesStudentClassGate(sessionClassId()) &&
+           passesStudentClassGateCompat(sessionClassIds(), sessionClassId()) &&
            request.resource.data.studentUid == resource.data.studentUid &&
            request.resource.data.pin == resource.data.pin &&
            request.resource.data.joinedAt == resource.data.joinedAt &&
@@ -790,12 +808,15 @@ service cloud.firestore {
         function vaSessionClassId() {
           return get(/databases/$(database)/documents/video_activity_sessions/$(sessionId)).data.get('classId', '');
         }
+        function vaSessionClassIds() {
+          return get(/databases/$(database)/documents/video_activity_sessions/$(sessionId)).data.get('classIds', []);
+        }
 
         // Teacher can read all responses; students can only read their own (doc ID == auth UID)
         allow read: if request.auth != null && (
           isAdmin() ||
           get(/databases/$(database)/documents/video_activity_sessions/$(sessionId)).data.teacherUid == request.auth.uid ||
-          (studentUid == request.auth.uid && passesStudentClassGate(vaSessionClassId()))
+          (studentUid == request.auth.uid && passesStudentClassGateCompat(vaSessionClassIds(), vaSessionClassId()))
         );
         // Students create their own response; document ID and studentUid field must match their auth UID.
         // studentRole users must also be enrolled in the session's class.
@@ -804,12 +825,12 @@ service cloud.firestore {
           request.resource.data.studentUid == request.auth.uid &&
           request.resource.data.score == null &&
           request.resource.data.completedAt == null &&
-          passesStudentClassGate(vaSessionClassId());
+          passesStudentClassGateCompat(vaSessionClassIds(), vaSessionClassId());
         // Students can update only their own response to add answers or set completedAt;
         // identity fields and score are immutable from the client; answers array may only grow
         allow update: if request.auth != null &&
           studentUid == request.auth.uid &&
-          passesStudentClassGate(vaSessionClassId()) &&
+          passesStudentClassGateCompat(vaSessionClassIds(), vaSessionClassId()) &&
           request.resource.data.studentUid == resource.data.studentUid &&
           request.resource.data.pin == resource.data.pin &&
           request.resource.data.name == resource.data.name &&
@@ -955,12 +976,15 @@ service cloud.firestore {
         function glSessionClassId() {
           return get(/databases/$(database)/documents/guided_learning_sessions/$(sessionId)).data.get('classId', '');
         }
+        function glSessionClassIds() {
+          return get(/databases/$(database)/documents/guided_learning_sessions/$(sessionId)).data.get('classIds', []);
+        }
 
         // Teacher can read all responses; students can only read their own
         allow read: if request.auth != null && (
           isAdmin() ||
           get(/databases/$(database)/documents/guided_learning_sessions/$(sessionId)).data.teacherUid == request.auth.uid ||
-          (studentUid == request.auth.uid && passesStudentClassGate(glSessionClassId()))
+          (studentUid == request.auth.uid && passesStudentClassGateCompat(glSessionClassIds(), glSessionClassId()))
         );
         // Students create their own response; doc ID, studentAnonymousId, and sessionId must match.
         // studentRole users must also be enrolled in the session's class.
@@ -969,12 +993,12 @@ service cloud.firestore {
           request.resource.data.studentAnonymousId == request.auth.uid &&
           request.resource.data.sessionId == sessionId &&
           request.resource.data.score == null &&
-          passesStudentClassGate(glSessionClassId());
+          passesStudentClassGateCompat(glSessionClassIds(), glSessionClassId());
         // Students can update only their own response to add answers or set completedAt;
         // identity fields and score are immutable from the client
         allow update: if request.auth != null &&
           studentUid == request.auth.uid &&
-          passesStudentClassGate(glSessionClassId()) &&
+          passesStudentClassGateCompat(glSessionClassIds(), glSessionClassId()) &&
           request.resource.data.studentAnonymousId == resource.data.studentAnonymousId &&
           request.resource.data.sessionId == resource.data.sessionId &&
           request.resource.data.startedAt == resource.data.startedAt &&

--- a/firestore.rules
+++ b/firestore.rules
@@ -50,11 +50,20 @@ service cloud.firestore {
              classId in request.auth.token.classIds;
     }
 
-    // Gate helper used inside session rules: "either this caller is NOT a
-    // studentRole user, OR the session's classId is in their classIds claim".
-    // Used on both reads (resource.data) and writes (parent get()).
+    // Gate helper used inside session rules: passes when the caller is NOT a
+    // studentRole user, when the session has no class targeting (empty/missing
+    // classId — treat as "open to any studentRole holder with the PIN"), or
+    // when the session's classId is in their classIds claim.
+    //
+    // The untargeted-open branch mirrors the policy already documented on
+    // passesStudentClassGateList. Without it, a studentRole token (real SSO
+    // student or test-class-bypass super admin) joining a session whose
+    // creator did not pick a ClassLink class is denied — the per-join PIN is
+    // the secret in that path, not class membership.
     function passesStudentClassGate(sessionClassId) {
       return !isStudentRoleUser() ||
+             !(sessionClassId is string) ||
+             sessionClassId.size() == 0 ||
              studentRoleCanAccessClass(sessionClassId);
     }
 

--- a/firestore.rules
+++ b/firestore.rules
@@ -3,10 +3,21 @@ rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents {
 
-    // Helper function to check if user is an admin
+    // Helper function to check if user is an admin.
+    //
+    // Uses `request.auth.token.get('email', '')` rather than direct
+    // `.email` access. The rules engine throws "Property email is
+    // undefined" when the claim is absent (production Firebase anonymous
+    // tokens carry no `email`), even behind a `!= null` guard on
+    // `request.auth`. After the `.get(...) != ''` check succeeds, the
+    // claim is guaranteed to exist, so the subsequent direct `.email`
+    // access below is safe. Matters for `allow update` on quiz responses
+    // (`isAdmin()` sits before the student branch in the OR chain there,
+    // so any throw during isAdmin evaluation could block anon PIN answer
+    // submission depending on CEL semantics).
     function isAdmin() {
       return request.auth != null &&
-             request.auth.token.email != null &&
+             request.auth.token.get('email', '') != '' &&
              exists(/databases/$(database)/documents/admins/$(request.auth.token.email.lower()));
     }
 
@@ -19,8 +30,13 @@ service cloud.firestore {
     // their own classes without affecting any other auth path (teachers,
     // admins, or anonymous PIN students).
 
+    // Uses .get(key, default) rather than direct token.studentRole access.
+    // The rules engine throws "Property studentRole is undefined" when a claim
+    // is absent (e.g. on anon PIN tokens), even behind a `!= null` short-circuit;
+    // .get(...) returns the default instead. Without this guard, every
+    // passesStudentClassGate() callsite denies anon PIN students.
     function isStudentRoleUser() {
-      return request.auth != null && request.auth.token.studentRole == true;
+      return request.auth != null && request.auth.token.get('studentRole', false) == true;
     }
 
     // True iff the caller is a studentRole user AND the given classId is in

--- a/firestore.rules
+++ b/firestore.rules
@@ -577,37 +577,34 @@ service cloud.firestore {
     // owns the document and stores their uid on the `teacherUid` field.
     // Multiple concurrent sessions per teacher are allowed.
     match /quiz_sessions/{sessionId} {
-      // Reads are split into `get` (single doc) and `list` (collection query)
-      // because Firestore's rules engine treats them differently:
+      // Reads are intentionally permissive: any authenticated caller can
+      // `get` and `list` session documents. PR #1390 split this into
+      // `get`/`list` and kept a `resource.data`-based studentRole class gate
+      // on `get`, on the theory that `get` rules have `resource.data`
+      // available at evaluation time. Empirically that still denied teacher
+      // single-doc subscriptions after a paused→active transition, breaking
+      // the Start flow; removing the `resource.data` reference unblocks it
+      // without widening enumeration beyond what the list rule already
+      // allows.
       //
-      //   - `get` evaluates per-document at read time. The studentRole class
-      //     gate can safely reference `resource.data` because the engine has
-      //     a concrete document to evaluate against.
-      //   - `list` is statically analyzed BEFORE execution. Any `resource.data`
-      //     reference in the predicate is treated as "unprovable for arbitrary
-      //     docs" and the entire list is denied — even when an earlier OR
-      //     branch (`!isStudentRoleUser()`) would short-circuit at runtime.
-      //     This is the failure mode that broke teacher assignment creation
-      //     for ~2 days; the previous "hoist" fix in #1389 was insufficient
-      //     because the static analyzer does not respect short-circuit OR.
-      //
-      // Splitting the rule lets the `list` predicate stay free of any
-      // `resource.data` reference. The list rule is the broad "any
-      // authenticated caller can enumerate session docs" allowance —
-      // studentRole users need this so MyAssignmentsPage can run its
-      // `where('classId', 'in', myClassIds)` discovery query, and PIN-flow
-      // students need it for code lookups. Per-class gating is still
-      // enforced at the `get` rule (and at write time on responses), so
-      // a studentRole user can list metadata but cannot open the contents
-      // of a session outside their classIds claim.
+      // studentRole (ClassLink-via-Google SSO) class gating is now enforced
+      // exclusively on the response write rules below, which dereference
+      // the parent session's `classId` via a runtime `get()` — a per-write
+      // fetch, not a predicate the analyzer has to reason about ahead of
+      // time. Students can see session metadata by id but cannot submit a
+      // response to a session outside their classIds claim.
       //
       // Restricting enumeration further would require a Cloud Function
-      // proxy; for now we accept that any authenticated user can list
+      // proxy; for now we accept that any authenticated user can read
       // session documents (matches the pre-SSO behavior).
-      allow get: if request.auth != null &&
-        (!isStudentRoleUser() ||
-         passesStudentClassGate(resource.data.get('classId', '')));
-      allow list: if request.auth != null;
+      //
+      // Privacy impact: any authenticated user who knows a sessionId (a
+      // v4 UUID — unguessable in practice) can read `code`, `classId`,
+      // `publicQuestions` (answer-key-stripped by schema — see types.ts
+      // `QuizPublicQuestion`), and `revealedAnswers` (populated only when
+      // the teacher has intentionally broadcast a reveal). No PII fields
+      // live on the session doc itself.
+      allow read: if request.auth != null;
       // Only the teacher (session owner) can create/update/delete the session document.
       // Ownership is carried on the `teacherUid` field (no longer the doc id).
       allow create: if request.auth != null &&
@@ -739,16 +736,13 @@ service cloud.firestore {
 
     // Video Activity Sessions — Teacher creates, anonymous students can read and submit responses
     match /video_activity_sessions/{sessionId} {
-      // Reads split into `get` + `list`; see quiz_sessions for the rationale
-      // (Firestore static-analyzes `list` predicates and rejects any rule
-      // that touches `resource.data`, even behind a short-circuit OR).
-      // The `list` rule allows any authenticated caller so studentRole users
-      // can run their MyAssignmentsPage class-filtered discovery queries;
-      // per-doc class gating still happens at `get`.
-      allow get: if request.auth != null &&
-        (!isStudentRoleUser() ||
-         passesStudentClassGate(resource.data.get('classId', '')));
-      allow list: if request.auth != null;
+      // Reads are intentionally permissive for any authenticated caller.
+      // See quiz_sessions for the rationale: a `resource.data`-based
+      // studentRole class gate on `get` still denied teacher single-doc
+      // subscriptions after a status transition; the class gate is now
+      // enforced on the response write rules below, which dereference the
+      // parent session's `classId` via a runtime `get()`.
+      allow read: if request.auth != null;
       // Only authenticated (non-anonymous) users can create sessions (teachers)
       allow create: if request.auth != null && request.auth.token.firebase.sign_in_provider != 'anonymous';
       // Teacher owners may rename or end sessions, but not mutate session content.
@@ -824,19 +818,13 @@ service cloud.firestore {
 
     // MiniApp Assignment Sessions — Teacher creates, anonymous students can read
     match /mini_app_sessions/{sessionId} {
-      // Reads split into `get` + `list`; see quiz_sessions for the rationale
-      // (Firestore static-analyzes `list` predicates and rejects any rule
-      // that touches `resource.data`, even behind a short-circuit OR).
-      // The `list` rule allows any authenticated caller so studentRole users
-      // can run their MyAssignmentsPage `array-contains-any` discovery query;
-      // per-doc class gating still happens at `get`.
-      // studentRole (GIS) users additionally must have at least one of the
-      // session's classIds in their classIds claim (or the session must be
-      // untargeted — empty classIds — for shareable-link launches).
-      allow get: if request.auth != null &&
-        (!isStudentRoleUser() ||
-         passesStudentClassGateList(resource.data.get('classIds', [])));
-      allow list: if request.auth != null;
+      // Reads are intentionally permissive for any authenticated caller.
+      // See quiz_sessions for the rationale: a `resource.data`-based
+      // studentRole class gate on `get` still denied teacher single-doc
+      // subscriptions; the class gate is now enforced on the submission
+      // write rules below, which dereference the parent session's
+      // `classIds` via a runtime `get()`.
+      allow read: if request.auth != null;
       // Only authenticated (non-anonymous) teachers can create sessions they own
       allow create: if request.auth != null &&
         request.auth.token.firebase.sign_in_provider != 'anonymous' &&
@@ -928,16 +916,13 @@ service cloud.firestore {
 
     // Guided Learning Sessions — Teacher creates, authenticated (incl. anonymous) students read and submit
     match /guided_learning_sessions/{sessionId} {
-      // Reads split into `get` + `list`; see quiz_sessions for the rationale
-      // (Firestore static-analyzes `list` predicates and rejects any rule
-      // that touches `resource.data`, even behind a short-circuit OR).
-      // The `list` rule allows any authenticated caller so studentRole users
-      // can run their MyAssignmentsPage class-filtered discovery queries;
-      // per-doc class gating still happens at `get`.
-      allow get: if request.auth != null &&
-        (!isStudentRoleUser() ||
-         passesStudentClassGate(resource.data.get('classId', '')));
-      allow list: if request.auth != null;
+      // Reads are intentionally permissive for any authenticated caller.
+      // See quiz_sessions for the rationale: a `resource.data`-based
+      // studentRole class gate on `get` still denied teacher single-doc
+      // subscriptions; the class gate is now enforced on the response
+      // write rules below, which dereference the parent session's
+      // `classId` via a runtime `get()`.
+      allow read: if request.auth != null;
       // Only authenticated (non-anonymous) teachers can create sessions; they must own it
       allow create: if request.auth != null &&
         request.auth.token.firebase.sign_in_provider != 'anonymous' &&
@@ -992,16 +977,13 @@ service cloud.firestore {
     // Activity Wall Sessions — Teacher owns it (UID prefix in sessionId), students submit entries
     // sessionId is formatted as {teacherUid}_{activityId}
     match /activity_wall_sessions/{sessionId} {
-      // Reads split into `get` + `list`; see quiz_sessions for the rationale
-      // (Firestore static-analyzes `list` predicates and rejects any rule
-      // that touches `resource.data`, even behind a short-circuit OR).
-      // The `list` rule allows any authenticated caller so studentRole users
-      // can run their MyAssignmentsPage class-filtered discovery queries;
-      // per-doc class gating still happens at `get`.
-      allow get: if request.auth != null &&
-        (!isStudentRoleUser() ||
-         passesStudentClassGate(resource.data.get('classId', '')));
-      allow list: if request.auth != null;
+      // Reads are intentionally permissive for any authenticated caller.
+      // See quiz_sessions for the rationale: a `resource.data`-based
+      // studentRole class gate on `get` still denied teacher single-doc
+      // subscriptions; the class gate is now enforced on the submission
+      // write rules below, which dereference the parent session's
+      // `classId` via a runtime `get()`.
+      allow read: if request.auth != null;
       // Only authenticated non-anonymous teachers/admins can create or update the session document itself.
       allow create, update: if request.auth != null &&
                             request.auth.token.firebase.sign_in_provider != 'anonymous' &&

--- a/hooks/useGuidedLearningAssignments.ts
+++ b/hooks/useGuidedLearningAssignments.ts
@@ -42,6 +42,10 @@ export interface CreateAssignmentInput {
   setTitle: string;
   /** Whether the set came from the personal (Drive) or building library. */
   source?: 'personal' | 'building';
+  /** Unified roster targeting (rosters are the single source of truth for
+   *  assignments; ClassLink-imported rosters carry `classlinkClassId` so the
+   *  student SSO gate resolves via session derivation). */
+  rosterIds?: string[];
 }
 
 export interface UseGuidedLearningAssignmentsResult {
@@ -116,6 +120,9 @@ export const useGuidedLearningAssignments = (
     async (input) => {
       if (!userId) throw new Error('Not authenticated');
       const now = Date.now();
+      const rosterIds = (input.rosterIds ?? []).filter(
+        (id): id is string => typeof id === 'string' && id.length > 0
+      );
       const assignment: GuidedLearningAssignment = {
         id: input.sessionId,
         sessionId: input.sessionId,
@@ -127,6 +134,7 @@ export const useGuidedLearningAssignments = (
         updatedAt: now,
         archivedAt: null,
         source: input.source,
+        ...(rosterIds.length > 0 ? { rosterIds } : {}),
       };
       await setDoc(
         doc(db, 'users', userId, GL_ASSIGNMENTS_COLLECTION, input.sessionId),

--- a/hooks/useGuidedLearningSession.ts
+++ b/hooks/useGuidedLearningSession.ts
@@ -137,16 +137,29 @@ export interface UseGuidedLearningSessionTeacherResult {
   /**
    * Create a new session and return its URL.
    *
-   * `classIds` is the list of ClassLink class `sourcedId`s this session is
-   * targeted at (Phase 5A multi-class). When non-empty, the session doc
-   * stores them on `classIds` (and transitionally mirrors `classIds[0]` to
-   * `classId`). `periodNames` is the list of class-period labels used by
-   * the post-PIN picker on the student app.
+   * Post-unification, `rosterIds` is the canonical input — callers derive
+   * it from the shared `AssignClassPicker` selection. `classIds` and
+   * `periodNames` are the denormalised outputs the caller computes via
+   * `deriveSessionTargetsFromRosters(selectedRosters)`:
+   *
+   * - `classIds`: ClassLink `sourcedId`s drawn from the selected rosters'
+   *   `classlinkClassId` metadata. Drives the student SSO gate
+   *   (`passesStudentClassGate` in firestore.rules). `classIds[0]` is also
+   *   mirrored onto the session's legacy `classId` field so pre-Phase-5A
+   *   rules keep working.
+   * - `periodNames`: roster names (de-duped) used for the student app's
+   *   post-PIN period picker.
+   * - `rosterIds`: written onto the session doc for reverse lookup and
+   *   future migration to a single-source-of-truth roster-only model.
+   *
+   * All three are optional and independent for backwards compatibility
+   * with callers that still target the legacy shapes directly.
    */
   createSession: (
     set: GuidedLearningSet,
     classIds?: string[],
-    periodNames?: string[]
+    periodNames?: string[],
+    rosterIds?: string[]
   ) => Promise<string>;
   /** Load responses for a given session ID */
   subscribeToResponses: (sessionId: string) => () => void;
@@ -167,7 +180,8 @@ export const useGuidedLearningSessionTeacher = (
     async (
       set: GuidedLearningSet,
       classIds: string[] = [],
-      periodNames: string[] = []
+      periodNames: string[] = [],
+      rosterIds: string[] = []
     ): Promise<string> => {
       if (!teacherUid) throw new Error('Not authenticated');
 
@@ -188,6 +202,7 @@ export const useGuidedLearningSessionTeacher = (
         // Firestore rules keep gating correctly.
         ...(classIds.length > 0 ? { classIds, classId: classIds[0] } : {}),
         ...(periodNames.length > 0 ? { periodNames } : {}),
+        ...(rosterIds.length > 0 ? { rosterIds } : {}),
       };
 
       await setDoc(doc(db, GL_SESSIONS_COLLECTION, sessionId), session);

--- a/hooks/useGuidedLearningSession.ts
+++ b/hooks/useGuidedLearningSession.ts
@@ -137,13 +137,17 @@ export interface UseGuidedLearningSessionTeacherResult {
   /**
    * Create a new session and return its URL.
    *
-   * `classId` is an optional ClassLink class `sourcedId`. When provided, it's
-   * written onto the session doc so that ClassLink-authenticated students
-   * see this session on their `/my-assignments` page, and Firestore rules
-   * (`passesStudentClassGate`) enforce class-based access. Omitting it
-   * preserves the classic join-link flow.
+   * `classIds` is the list of ClassLink class `sourcedId`s this session is
+   * targeted at (Phase 5A multi-class). When non-empty, the session doc
+   * stores them on `classIds` (and transitionally mirrors `classIds[0]` to
+   * `classId`). `periodNames` is the list of class-period labels used by
+   * the post-PIN picker on the student app.
    */
-  createSession: (set: GuidedLearningSet, classId?: string) => Promise<string>;
+  createSession: (
+    set: GuidedLearningSet,
+    classIds?: string[],
+    periodNames?: string[]
+  ) => Promise<string>;
   /** Load responses for a given session ID */
   subscribeToResponses: (sessionId: string) => () => void;
   /** Export responses as a CSV blob string */
@@ -160,7 +164,11 @@ export const useGuidedLearningSessionTeacher = (
   const [responsesLoading, setResponsesLoading] = useState(false);
 
   const createSession = useCallback(
-    async (set: GuidedLearningSet, classId?: string): Promise<string> => {
+    async (
+      set: GuidedLearningSet,
+      classIds: string[] = [],
+      periodNames: string[] = []
+    ): Promise<string> => {
       if (!teacherUid) throw new Error('Not authenticated');
 
       const sessionId = crypto.randomUUID();
@@ -174,11 +182,12 @@ export const useGuidedLearningSessionTeacher = (
         publicSteps,
         teacherUid,
         createdAt: Date.now(),
-        // Phase 3C: optional ClassLink target class. Only write when a
-        // non-empty sourcedId was supplied so sessions created without a
-        // target keep a clean doc shape (and the rules no-op branch kicks in
-        // via `resource.data.get('classId', '')`).
-        ...(classId ? { classId } : {}),
+        // Phase 5A: multi-class ClassLink targeting + post-PIN period
+        // picker support. `classIds` is authoritative; `classId` is
+        // transitionally mirrored to `classIds[0]` so pre-Phase-5A
+        // Firestore rules keep gating correctly.
+        ...(classIds.length > 0 ? { classIds, classId: classIds[0] } : {}),
+        ...(periodNames.length > 0 ? { periodNames } : {}),
       };
 
       await setDoc(doc(db, GL_SESSIONS_COLLECTION, sessionId), session);

--- a/hooks/useMiniAppAssignments.ts
+++ b/hooks/useMiniAppAssignments.ts
@@ -36,8 +36,11 @@ export interface CreateMiniAppAssignmentInput {
   sessionId: string;
   app: Pick<MiniAppItem, 'id' | 'title'>;
   assignmentName: string;
-  /** ClassLink class sourcedIds the teacher targeted (multi-select). */
-  classIds?: string[];
+  /** Roster IDs the teacher targeted (unified picker output). Mirrored onto
+   *  the assignment doc to match the Quiz/VA/GL shape so any future filtering
+   *  in the Library shell can key off the assignment list without a
+   *  session-doc join. */
+  rosterIds?: string[];
   /** Whether submissions are enabled for this assignment. Mirrors
    *  MiniAppSession.submissionsEnabled. */
   submissionsEnabled?: boolean;
@@ -113,10 +116,16 @@ export const useMiniAppAssignments = (
       const now = Date.now();
       const trimmedName = input.assignmentName.trim();
 
-      const cleanedClassIds = (input.classIds ?? []).filter(
-        (c): c is string => typeof c === 'string' && c.length > 0
+      const cleanedRosterIds = (input.rosterIds ?? []).filter(
+        (r): r is string => typeof r === 'string' && r.length > 0
       );
 
+      // Intentionally do NOT mirror `classIds` onto the assignment doc.
+      // The student SSO gate reads `classIds[]` from the MiniAppSession (see
+      // `mini_app_sessions` Firestore rules); the assignment archive only
+      // needs targeting metadata that teacher-side code actually reads back,
+      // and no caller reads `assignment.classIds`. Matches the Quiz/VA/GL
+      // shape (their assignment docs also store `rosterIds` only).
       const assignment: MiniAppAssignment = {
         id: assignmentId,
         sessionId: input.sessionId,
@@ -130,7 +139,7 @@ export const useMiniAppAssignments = (
         status: 'active',
         createdAt: now,
         updatedAt: now,
-        ...(cleanedClassIds.length > 0 ? { classIds: cleanedClassIds } : {}),
+        ...(cleanedRosterIds.length > 0 ? { rosterIds: cleanedRosterIds } : {}),
         submissionsEnabled: input.submissionsEnabled === true,
       };
 

--- a/hooks/useMiniAppSession.ts
+++ b/hooks/useMiniAppSession.ts
@@ -38,6 +38,12 @@ const normalizeSession = (
       )
     : [];
 
+  const rosterIds = Array.isArray(data.rosterIds)
+    ? data.rosterIds.filter(
+        (r): r is string => typeof r === 'string' && r.length > 0
+      )
+    : [];
+
   return {
     id: sessionId,
     appId: data.appId ?? '',
@@ -52,13 +58,22 @@ const normalizeSession = (
     createdAt,
     ...(typeof data.endedAt === 'number' ? { endedAt: data.endedAt } : {}),
     ...(classIds.length > 0 ? { classIds } : {}),
+    ...(rosterIds.length > 0 ? { rosterIds } : {}),
     ...(data.submissionsEnabled === true ? { submissionsEnabled: true } : {}),
   };
 };
 
 export interface CreateMiniAppSessionOptions {
-  /** ClassLink class sourcedIds the teacher targeted (multi-select). */
+  /**
+   * ClassLink `sourcedId`s for the student SSO gate. Derived upstream from
+   * the targeted rosters' `classlinkClassId` metadata. Empty when all
+   * targeted rosters are locally created — the rules' `passesStudentClassGateList`
+   * treats the empty list as "open to any student-role user," which matches
+   * today's behavior for the MiniApp session collection.
+   */
   classIds?: string[];
+  /** Roster IDs backing this session (unified targeting). */
+  rosterIds?: string[];
   /** Whether the runner should reveal the Submit button and persist
    *  submissions. Defaults to `false` (view-only). */
   submissionsEnabled?: boolean;
@@ -102,6 +117,9 @@ export const useMiniAppSessionTeacher = (): UseMiniAppSessionTeacherResult => {
       const cleanedClassIds = (options?.classIds ?? []).filter(
         (c): c is string => typeof c === 'string' && c.length > 0
       );
+      const cleanedRosterIds = (options?.rosterIds ?? []).filter(
+        (r): r is string => typeof r === 'string' && r.length > 0
+      );
       const submissionsEnabled = options?.submissionsEnabled === true;
 
       const session: MiniAppSession = {
@@ -117,6 +135,7 @@ export const useMiniAppSessionTeacher = (): UseMiniAppSessionTeacherResult => {
         status: 'active',
         createdAt: Date.now(),
         ...(cleanedClassIds.length > 0 ? { classIds: cleanedClassIds } : {}),
+        ...(cleanedRosterIds.length > 0 ? { rosterIds: cleanedRosterIds } : {}),
         submissionsEnabled,
       };
 

--- a/hooks/useQuizAssignments.ts
+++ b/hooks/useQuizAssignments.ts
@@ -75,7 +75,8 @@ export interface UseQuizAssignmentsResult {
     quiz: AssignmentQuizRef,
     settings: QuizAssignmentSettings,
     initialStatus?: QuizAssignmentStatus,
-    classIds?: string[]
+    classIds?: string[],
+    rosterIds?: string[]
   ) => Promise<{ id: string; code: string }>;
   /** Set both assignment.status and session.status to 'paused'. */
   pauseAssignment: (assignmentId: string) => Promise<void>;
@@ -184,9 +185,12 @@ export const useQuizAssignments = (
   const createAssignment = useCallback<
     UseQuizAssignmentsResult['createAssignment']
   >(
-    async (quiz, settings, initialStatus = 'active', classIds) => {
+    async (quiz, settings, initialStatus = 'active', classIds, rosterIds) => {
       if (!userId) throw new Error('Not authenticated');
       const targetClassIds = classIds ?? [];
+      const targetRosterIds = (rosterIds ?? []).filter(
+        (id): id is string => typeof id === 'string' && id.length > 0
+      );
 
       const assignmentId = crypto.randomUUID();
       const code = await allocateJoinCode();
@@ -211,6 +215,7 @@ export const useQuizAssignments = (
         periodName: settings.periodName,
         periodNames: settings.periodNames,
         plcMemberEmails: settings.plcMemberEmails,
+        ...(targetRosterIds.length > 0 ? { rosterIds: targetRosterIds } : {}),
       };
 
       const mode = settings.sessionMode;
@@ -258,6 +263,7 @@ export const useQuizAssignments = (
         ...(targetClassIds.length > 0
           ? { classIds: targetClassIds, classId: targetClassIds[0] }
           : {}),
+        ...(targetRosterIds.length > 0 ? { rosterIds: targetRosterIds } : {}),
       };
 
       const batch = writeBatch(db);
@@ -501,6 +507,11 @@ export const useQuizAssignments = (
         periodName: undefined,
         periodNames: undefined,
       };
+      // Intentionally omit classIds/rosterIds: the shared doc's targeting
+      // refers to rosters in the ORIGINATOR's account and would be dangling
+      // refs here. The importer retargets on first launch via AssignClassPicker,
+      // which pre-seeds empty because lastRosterIdsByQuizId is only written at
+      // assign-confirm time (QuizWidget/Widget.tsx) — never during import.
       const created = await createAssignment(
         {
           id: savedMeta.id,

--- a/hooks/useQuizAssignments.ts
+++ b/hooks/useQuizAssignments.ts
@@ -62,17 +62,20 @@ export interface UseQuizAssignmentsResult {
    * Create a new assignment + its matching session doc in one batch.
    * Returns the new assignment's id (== sessionId) and the allocated join code.
    *
-   * `classId` is an optional ClassLink class `sourcedId`. When provided, it's
-   * written onto the session doc so that ClassLink-authenticated students
-   * see this session on their `/my-assignments` page, and Firestore rules
-   * (`passesStudentClassGate`) enforce class-based access. Omitting it
-   * preserves the classic code/PIN-only flow.
+   * `classIds` is the list of ClassLink class `sourcedId`s this session is
+   * targeted at (Phase 5A multi-class). When non-empty, the session doc
+   * stores them on `classIds` (and transitionally mirrors `classIds[0]` to
+   * `classId` so pre-Phase-5A Firestore rules still gate correctly).
+   * Firestore rules (`passesStudentClassGateList`) enforce that ClassLink-
+   * authenticated students can only read sessions whose classIds overlap
+   * their auth-token classIds claim. An empty/missing list preserves the
+   * classic code/PIN-only flow.
    */
   createAssignment: (
     quiz: AssignmentQuizRef,
     settings: QuizAssignmentSettings,
     initialStatus?: QuizAssignmentStatus,
-    classId?: string
+    classIds?: string[]
   ) => Promise<{ id: string; code: string }>;
   /** Set both assignment.status and session.status to 'paused'. */
   pauseAssignment: (assignmentId: string) => Promise<void>;
@@ -181,8 +184,9 @@ export const useQuizAssignments = (
   const createAssignment = useCallback<
     UseQuizAssignmentsResult['createAssignment']
   >(
-    async (quiz, settings, initialStatus = 'active', classId) => {
+    async (quiz, settings, initialStatus = 'active', classIds) => {
       if (!userId) throw new Error('Not authenticated');
+      const targetClassIds = classIds ?? [];
 
       const assignmentId = crypto.randomUUID();
       const code = await allocateJoinCode();
@@ -247,11 +251,13 @@ export const useQuizAssignments = (
         soundEffectsEnabled: opts.soundEffectsEnabled ?? false,
         questionPhase: 'answering',
         periodNames: settings.periodNames,
-        // Phase 3A: optional ClassLink target class. Only write when a
-        // non-empty sourcedId was supplied so sessions created without a
-        // target keep a clean doc shape (and the rules no-op branch kicks in
-        // via `resource.data.get('classId', '')`).
-        ...(classId ? { classId } : {}),
+        // Phase 5A: multi-class ClassLink targeting. Write `classIds` when
+        // non-empty; also mirror `classIds[0]` to the legacy `classId` field
+        // so both multi-class targeting and the legacy single-class fallback
+        // continue to gate access correctly until the fallback is removed.
+        ...(targetClassIds.length > 0
+          ? { classIds: targetClassIds, classId: targetClassIds[0] }
+          : {}),
       };
 
       const batch = writeBatch(db);

--- a/hooks/useRosters.ts
+++ b/hooks/useRosters.ts
@@ -100,7 +100,12 @@ class MockRosterStore {
     return [...this.rosters].sort((a, b) => a.name.localeCompare(b.name));
   }
 
-  addRoster(id: string, name: string, students: Student[]): void {
+  addRoster(
+    id: string,
+    name: string,
+    students: Student[],
+    meta?: Partial<ClassRosterMeta>
+  ): void {
     const withPins = assignPins(students);
     const newRoster: ClassRoster = {
       id,
@@ -109,6 +114,7 @@ class MockRosterStore {
       driveFileId: null,
       studentCount: withPins.length,
       createdAt: Date.now(),
+      ...meta,
     };
     this.rosters.push(newRoster);
     this.notifyListeners();
@@ -201,8 +207,41 @@ const validateRosterMeta = (
       };
     }
   }
+  if (d.origin === 'classlink' || d.origin === 'local') {
+    meta.origin = d.origin;
+  }
+  if (typeof d.classlinkClassId === 'string') {
+    meta.classlinkClassId = d.classlinkClassId;
+  }
+  if (typeof d.classlinkClassCode === 'string') {
+    meta.classlinkClassCode = d.classlinkClassCode;
+  }
+  if (typeof d.classlinkSubject === 'string') {
+    meta.classlinkSubject = d.classlinkSubject;
+  }
+  if (typeof d.classlinkOrgId === 'string') {
+    meta.classlinkOrgId = d.classlinkOrgId;
+  }
+  if (typeof d.classlinkSyncedAt === 'number') {
+    meta.classlinkSyncedAt = d.classlinkSyncedAt;
+  }
   return meta;
 };
+
+/**
+ * Optional ClassLink metadata accepted by `addRoster`. Passed through to the
+ * Firestore doc so assignment pickers can treat a ClassLink-imported roster as
+ * the single source of truth (no more "is it ClassLink or local?" branching).
+ */
+export type RosterCreateMeta = Pick<
+  ClassRosterMeta,
+  | 'origin'
+  | 'classlinkClassId'
+  | 'classlinkClassCode'
+  | 'classlinkSubject'
+  | 'classlinkOrgId'
+  | 'classlinkSyncedAt'
+>;
 
 // ─── Hook ──────────────────────────────────────────────────────────────────────
 
@@ -487,23 +526,27 @@ export const useRosters = (user: User | null) => {
   // ─── CRUD actions ─────────────────────────────────────────────────────────
 
   const addRoster = useCallback(
-    async (name: string, students: Student[] = []) => {
+    async (name: string, students: Student[] = [], meta?: RosterCreateMeta) => {
       if (!user) throw new Error('No user');
 
       if (isAuthBypass) {
         const id = 'mock-roster-id-' + Date.now();
-        mockRosterStore.addRoster(id, name, students);
+        mockRosterStore.addRoster(id, name, students, meta);
         return id;
       }
 
       const withPins = assignPins(students);
 
-      // Write metadata-only to Firestore first to get the document ID
+      // Write metadata-only to Firestore first to get the document ID.
+      // ClassLink metadata (origin, classlinkClassId, etc.) is spread in here
+      // so the roster doc itself carries its provenance; individual students
+      // continue to track their own classLinkSourcedId separately.
       const firestoreData: Omit<ClassRosterMeta, 'id'> = {
         name,
         driveFileId: null,
         studentCount: withPins.length,
         createdAt: Date.now(),
+        ...meta,
       };
       const ref = await addDoc(
         collection(db, 'users', user.uid, 'rosters'),

--- a/hooks/useVideoActivityAssignments.ts
+++ b/hooks/useVideoActivityAssignments.ts
@@ -57,17 +57,18 @@ export interface UseVideoActivityAssignmentsResult {
    * Create a new assignment + its matching session doc in one batch.
    * Returns the new assignment's id (== sessionId).
    *
-   * `classId` is an optional ClassLink class `sourcedId`. When provided, it's
-   * written onto the session doc so that ClassLink-authenticated students
-   * see this session on their `/my-assignments` page, and Firestore rules
-   * (`passesStudentClassGate(vaSessionClassId())`) enforce class-based
-   * access. Omitting it preserves the classic join-URL-only flow.
+   * `classIds` is the list of ClassLink class `sourcedId`s this session is
+   * targeted at (Phase 5A multi-class). When non-empty, the session doc
+   * stores them on `classIds` (and transitionally mirrors `classIds[0]` to
+   * `classId`). `periodNames` is the list of class-period labels available
+   * for the post-PIN picker.
    */
   createAssignment: (
     activity: AssignmentActivityRef,
     settings: VideoActivityAssignmentSettings,
     initialStatus?: VideoActivityAssignmentStatus,
-    classId?: string
+    classIds?: string[],
+    periodNames?: string[]
   ) => Promise<{ id: string }>;
   /** Set both assignment.status and session.status to 'paused' (assignment) / 'ended' (session). */
   pauseAssignment: (assignmentId: string) => Promise<void>;
@@ -135,9 +136,16 @@ export const useVideoActivityAssignments = (
   const createAssignment = useCallback<
     UseVideoActivityAssignmentsResult['createAssignment']
   >(
-    async (activity, settings, initialStatus = 'active', classId) => {
+    async (
+      activity,
+      settings,
+      initialStatus = 'active',
+      classIds,
+      periodNames
+    ) => {
       if (!userId) throw new Error('Not authenticated');
-
+      const targetClassIds = classIds ?? [];
+      const targetPeriodNames = periodNames ?? [];
       const assignmentId = crypto.randomUUID();
       const now = Date.now();
 
@@ -173,11 +181,16 @@ export const useVideoActivityAssignments = (
         allowedPins: [],
         createdAt: now,
         ...(sessionStatus === 'ended' ? { endedAt: now } : {}),
-        // Phase 3B: optional ClassLink target class. Only write when a
-        // non-empty sourcedId was supplied so sessions created without a
-        // target keep a clean doc shape (and the rules no-op branch kicks in
-        // via `resource.data.get('classId', '')`).
-        ...(classId ? { classId } : {}),
+        // Phase 5A: multi-class ClassLink targeting + post-PIN period picker.
+        // Mirror `classIds[0]` into the legacy `classId` field so
+        // pre-Phase-5A rules keep gating correctly until the fallback is
+        // removed.
+        ...(targetClassIds.length > 0
+          ? { classIds: targetClassIds, classId: targetClassIds[0] }
+          : {}),
+        ...(targetPeriodNames.length > 0
+          ? { periodNames: targetPeriodNames }
+          : {}),
       };
 
       const batch = writeBatch(db);

--- a/hooks/useVideoActivityAssignments.ts
+++ b/hooks/useVideoActivityAssignments.ts
@@ -68,7 +68,8 @@ export interface UseVideoActivityAssignmentsResult {
     settings: VideoActivityAssignmentSettings,
     initialStatus?: VideoActivityAssignmentStatus,
     classIds?: string[],
-    periodNames?: string[]
+    periodNames?: string[],
+    rosterIds?: string[]
   ) => Promise<{ id: string }>;
   /** Set both assignment.status and session.status to 'paused' (assignment) / 'ended' (session). */
   pauseAssignment: (assignmentId: string) => Promise<void>;
@@ -141,11 +142,13 @@ export const useVideoActivityAssignments = (
       settings,
       initialStatus = 'active',
       classIds,
-      periodNames
+      periodNames,
+      rosterIds
     ) => {
       if (!userId) throw new Error('Not authenticated');
       const targetClassIds = classIds ?? [];
       const targetPeriodNames = periodNames ?? [];
+      const targetRosterIds = rosterIds ?? [];
       const assignmentId = crypto.randomUUID();
       const now = Date.now();
 
@@ -160,6 +163,7 @@ export const useVideoActivityAssignments = (
         updatedAt: now,
         className: settings.className,
         sessionSettings: settings.sessionSettings,
+        ...(targetRosterIds.length > 0 ? { rosterIds: targetRosterIds } : {}),
       };
 
       // Session's status is binary — if the assignment is paused or inactive,
@@ -191,6 +195,7 @@ export const useVideoActivityAssignments = (
         ...(targetPeriodNames.length > 0
           ? { periodNames: targetPeriodNames }
           : {}),
+        ...(targetRosterIds.length > 0 ? { rosterIds: targetRosterIds } : {}),
       };
 
       const batch = writeBatch(db);

--- a/hooks/useVideoActivitySession.ts
+++ b/hooks/useVideoActivitySession.ts
@@ -77,12 +77,22 @@ export interface UseVideoActivitySessionTeacherResult {
   /**
    * Create a session for a class and return the sessionId (used as the share link).
    *
-   * `classIds` is the list of ClassLink class `sourcedId`s this session is
-   * targeted at (Phase 5A multi-class). When non-empty, the session doc
-   * stores them on `classIds` (and transitionally mirrors `classIds[0]` to
-   * `classId`). `periodNames` drives the post-PIN class-period picker and
-   * is either the list of chosen local roster names or the ClassLink class
-   * labels (mirroring the teacher's picker source).
+   * Post-unification, `rosterIds` is the canonical input — callers derive
+   * it from the shared `AssignClassPicker` selection. `classIds` and
+   * `periodNames` are denormalised outputs the caller computes via
+   * `deriveSessionTargetsFromRosters(selectedRosters)`:
+   *
+   * - `classIds`: ClassLink `sourcedId`s drawn from the selected rosters'
+   *   `classlinkClassId` metadata. Drives the student SSO gate
+   *   (`passesStudentClassGate` in firestore.rules). `classIds[0]` is also
+   *   mirrored onto the session's legacy `classId` field so pre-Phase-5A
+   *   rules keep working.
+   * - `periodNames`: roster names (de-duped) used for the student app's
+   *   post-PIN period picker.
+   * - `rosterIds`: written onto the session doc for reverse lookup.
+   *
+   * All three are optional and independent for backwards compatibility
+   * with callers that still target the legacy shapes directly.
    */
   createSession: (
     activity: VideoActivityData,
@@ -91,7 +101,8 @@ export interface UseVideoActivitySessionTeacherResult {
     settings?: Partial<VideoActivitySessionSettings>,
     assignmentName?: string,
     classIds?: string[],
-    periodNames?: string[]
+    periodNames?: string[],
+    rosterIds?: string[]
   ) => Promise<string>;
   /** Sessions created by the current teacher for the selected activity. */
   sessions: VideoActivitySession[];
@@ -130,7 +141,8 @@ export const useVideoActivitySessionTeacher =
         settings?: Partial<VideoActivitySessionSettings>,
         assignmentName?: string,
         classIds: string[] = [],
-        periodNames: string[] = []
+        periodNames: string[] = [],
+        rosterIds: string[] = []
       ): Promise<string> => {
         const sessionId = crypto.randomUUID();
         const trimmedAssignmentName = assignmentName?.trim();
@@ -161,6 +173,7 @@ export const useVideoActivitySessionTeacher =
           // Firestore rules keep gating correctly.
           ...(classIds.length > 0 ? { classIds, classId: classIds[0] } : {}),
           ...(periodNames.length > 0 ? { periodNames } : {}),
+          ...(rosterIds.length > 0 ? { rosterIds } : {}),
         };
 
         await setDoc(doc(db, SESSIONS_COLLECTION, sessionId), session);

--- a/hooks/useVideoActivitySession.ts
+++ b/hooks/useVideoActivitySession.ts
@@ -77,11 +77,12 @@ export interface UseVideoActivitySessionTeacherResult {
   /**
    * Create a session for a class and return the sessionId (used as the share link).
    *
-   * `classId` is an optional ClassLink class `sourcedId`. When provided, it's
-   * written onto the session doc so that ClassLink-authenticated students
-   * see this session on their `/my-assignments` page, and Firestore rules
-   * (`passesStudentClassGate(vaSessionClassId())`) enforce class-based
-   * access. Omitting it preserves the classic code/PIN-only flow.
+   * `classIds` is the list of ClassLink class `sourcedId`s this session is
+   * targeted at (Phase 5A multi-class). When non-empty, the session doc
+   * stores them on `classIds` (and transitionally mirrors `classIds[0]` to
+   * `classId`). `periodNames` drives the post-PIN class-period picker and
+   * is either the list of chosen local roster names or the ClassLink class
+   * labels (mirroring the teacher's picker source).
    */
   createSession: (
     activity: VideoActivityData,
@@ -89,7 +90,8 @@ export interface UseVideoActivitySessionTeacherResult {
     allowedPins?: string[],
     settings?: Partial<VideoActivitySessionSettings>,
     assignmentName?: string,
-    classId?: string
+    classIds?: string[],
+    periodNames?: string[]
   ) => Promise<string>;
   /** Sessions created by the current teacher for the selected activity. */
   sessions: VideoActivitySession[];
@@ -127,7 +129,8 @@ export const useVideoActivitySessionTeacher =
         allowedPins: string[] = [],
         settings?: Partial<VideoActivitySessionSettings>,
         assignmentName?: string,
-        classId?: string
+        classIds: string[] = [],
+        periodNames: string[] = []
       ): Promise<string> => {
         const sessionId = crypto.randomUUID();
         const trimmedAssignmentName = assignmentName?.trim();
@@ -152,11 +155,12 @@ export const useVideoActivitySessionTeacher =
           status: 'active',
           allowedPins,
           createdAt: Date.now(),
-          // Phase 3B: optional ClassLink target class. Only write when a
-          // non-empty sourcedId was supplied so sessions created without a
-          // target keep a clean doc shape (and the rules no-op branch kicks in
-          // via `resource.data.get('classId', '')`).
-          ...(classId ? { classId } : {}),
+          // Phase 5A: multi-class ClassLink targeting + post-PIN period
+          // picker support. `classIds` is authoritative; `classId` is
+          // transitionally mirrored to `classIds[0]` so pre-Phase-5A
+          // Firestore rules keep gating correctly.
+          ...(classIds.length > 0 ? { classIds, classId: classIds[0] } : {}),
+          ...(periodNames.length > 0 ? { periodNames } : {}),
         };
 
         await setDoc(doc(db, SESSIONS_COLLECTION, sessionId), session);
@@ -309,7 +313,18 @@ export interface UseVideoActivitySessionStudentResult {
   myResponse: VideoActivityResponse | null;
   joinStatus: StudentJoinStatus;
   error: string | null;
-  joinSession: (sessionId: string, pin: string, name: string) => Promise<void>;
+  /**
+   * Look up a session by id without creating a response — used by the
+   * student-app join flow to decide whether to show a post-PIN period
+   * picker before committing the join.
+   */
+  lookupSession: (sessionId: string) => Promise<VideoActivitySession | null>;
+  joinSession: (
+    sessionId: string,
+    pin: string,
+    name: string,
+    classPeriod?: string
+  ) => Promise<void>;
   submitAnswer: (questionId: string, answer: string) => Promise<void>;
   completeActivity: () => Promise<void>;
 }
@@ -376,11 +391,31 @@ export const useVideoActivitySessionStudent =
       return unsub;
     }, [sessionId, responseDocId]);
 
+    const lookupSession = useCallback(
+      async (targetSessionId: string): Promise<VideoActivitySession | null> => {
+        try {
+          const snap = await getDoc(
+            doc(db, SESSIONS_COLLECTION, targetSessionId)
+          );
+          if (!snap.exists()) return null;
+          return snap.data() as VideoActivitySession;
+        } catch (err) {
+          console.error(
+            '[useVideoActivitySessionStudent] lookupSession error:',
+            err
+          );
+          return null;
+        }
+      },
+      []
+    );
+
     const joinSession = useCallback(
       async (
         targetSessionId: string,
         studentPin: string,
-        studentName: string
+        studentName: string,
+        classPeriod?: string
       ): Promise<void> => {
         setJoinStatus('loading');
         setError(null);
@@ -454,6 +489,7 @@ export const useVideoActivitySessionStudent =
               answers: [],
               completedAt: null,
               score: null,
+              ...(classPeriod ? { classPeriod } : {}),
             };
             await setDoc(responseRef, newResponse);
           }
@@ -527,6 +563,7 @@ export const useVideoActivitySessionStudent =
       myResponse,
       joinStatus,
       error,
+      lookupSession,
       joinSession,
       submitAnswer,
       completeActivity,

--- a/tests/rules/studentRoleClassGate.test.ts
+++ b/tests/rules/studentRoleClassGate.test.ts
@@ -71,6 +71,12 @@ let testEnv: RulesTestEnvironment;
 // `firebase.sign_in_provider` — in every context, using empty/false
 // defaults for claims that don't apply to that role. This matches what
 // production Auth tokens look like for real sign-ins.
+//
+// Intentional exception: `asAnonStudentBareToken` below deliberately omits
+// `email`, `studentRole`, and `classIds` to reproduce the shape of a
+// production Firebase anonymous-auth token verbatim, which carries none of
+// those claims. That lock-in context exists to catch regressions in any
+// rule helper that reads a custom claim via direct dot access.
 
 const asStudentA = () =>
   testEnv
@@ -108,6 +114,22 @@ const asAnonStudent = () =>
       email: '',
       studentRole: false,
       classIds: [],
+      firebase: { sign_in_provider: 'anonymous' },
+    })
+    .firestore();
+
+// Real production anonymous Firebase Auth tokens do NOT carry `studentRole`,
+// `classIds`, or `email` at all — those claims are only minted for
+// ClassLink SSO via studentLoginV1 (or for Google sign-in via GIS in the
+// case of `email`). Prior to the isStudentRoleUser() hardening, any rule
+// that reached a direct claim access threw "Property X is undefined" and
+// denied the operation. This context reproduces that token shape verbatim
+// — omitting every custom claim — so the test suite locks in the fix and
+// catches regressions on any helper that reads a claim without the safe
+// `.get(key, default)` accessor.
+const asAnonStudentBareToken = () =>
+  testEnv
+    .authenticatedContext(ANON_UID, {
       firebase: { sign_in_provider: 'anonymous' },
     })
     .firestore();
@@ -383,6 +405,63 @@ describe('quiz_sessions/responses — student-role gate', () => {
           tabSwitchWarnings: 0,
         }
       )
+    );
+  });
+
+  // Lock-in for the missing-claim hardening. Real production anon tokens
+  // omit studentRole / classIds / email entirely; if any rule helper
+  // reverts to direct dot-access on one of those claims, the rules
+  // engine can throw "Property X is undefined" and this test reds.
+  //
+  // Exercises the full anon PIN quiz lifecycle inside
+  // `match /quiz_sessions/{sessionId}/responses/{studentUid}`:
+  //   1. `getDoc(responseRef)` — traverses `allow read`. Guards
+  //      `isStudentRoleUser()` (now `.get()`-safe).
+  //   2. `setDoc(responseRef, …)` on a non-existent doc — traverses
+  //      `allow create`. Guards `passesStudentClassGate` →
+  //      `isStudentRoleUser()`.
+  //   3. `setDoc(responseRef, …)` on the existing doc to submit an
+  //      answer — traverses `allow update`. In that OR chain
+  //      `isAdmin()` sits BEFORE the student branch, which is why
+  //      this PR hardens `isAdmin()` alongside `isStudentRoleUser()`:
+  //      if `isAdmin()` threw on a missing `email` claim, the throw
+  //      could deny the update before the student branch is reached.
+  //
+  // All three must succeed under a bare anon token for real answer
+  // submission to work end-to-end.
+  it('anonymous PIN student with bare token (no custom claims) can get + create + update response', async () => {
+    const responseRef = doc(
+      asAnonStudentBareToken(),
+      `quiz_sessions/${SESSION_A}/responses/${ANON_UID}`
+    );
+
+    await assertSucceeds(getDoc(responseRef));
+
+    await assertSucceeds(
+      setDoc(responseRef, {
+        studentUid: ANON_UID,
+        pin: '5678',
+        joinedAt: 2000,
+        score: null,
+        answers: [],
+        status: 'active',
+        tabSwitchWarnings: 0,
+      })
+    );
+
+    // Submit an answer: update only the fields the rule allows students
+    // to change (answers, status, submittedAt, tabSwitchWarnings).
+    await assertSucceeds(
+      setDoc(responseRef, {
+        studentUid: ANON_UID,
+        pin: '5678',
+        joinedAt: 2000,
+        score: null,
+        answers: [{ questionId: 'q1', value: 'B' }],
+        status: 'submitted',
+        submittedAt: 3000,
+        tabSwitchWarnings: 0,
+      })
     );
   });
 });

--- a/tests/rules/studentRoleClassGate.test.ts
+++ b/tests/rules/studentRoleClassGate.test.ts
@@ -388,6 +388,32 @@ describe('quiz_sessions/responses — student-role gate', () => {
     );
   });
 
+  // Covers the test-class-bypass path (and the equivalent real-SSO case): a
+  // studentRole user joining a session whose creator did not pick a class.
+  // Such sessions omit `classId`/`classIds` entirely, so the compat wrapper
+  // falls through to `passesStudentClassGate('')`. Before the untargeted-open
+  // branch was added, this denied any studentRole token — breaking the
+  // super-admin "log in as test student" workflow and any real SSO student
+  // PIN-joining a quiz that wasn't targeted to a ClassLink class.
+  it('student-role user can create response on untargeted session (no classId)', async () => {
+    const UNTARGETED = 'session-untargeted';
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      await setDoc(doc(ctx.firestore(), `quiz_sessions/${UNTARGETED}`), {
+        teacherUid: TEACHER_UID,
+        status: 'active',
+      });
+    });
+    await assertSucceeds(
+      setDoc(
+        doc(
+          asStudentA(),
+          `quiz_sessions/${UNTARGETED}/responses/${STUDENT_A_UID}`
+        ),
+        { ...baseResp(), joinedAt: 2000 }
+      )
+    );
+  });
+
   it('anonymous PIN student can create response without studentRole restriction', async () => {
     await assertSucceeds(
       setDoc(

--- a/tests/rules/studentRoleClassGate.test.ts
+++ b/tests/rules/studentRoleClassGate.test.ts
@@ -7,6 +7,14 @@
 // Covers the five session collections where passesStudentClassGate() is applied:
 //   quiz_sessions, video_activity_sessions, guided_learning_sessions,
 //   mini_app_sessions, activity_wall_sessions
+//
+// Contract: session reads are intentionally permissive for any authenticated
+// caller (teacher single-doc subscriptions otherwise fail with
+// permission-denied after a status transition — see PR #1391). studentRole
+// class gating is enforced exclusively on the response/submission *write*
+// rules, which dereference the parent session's `classId` via a runtime
+// `get()`. A studentRole user can see session metadata by id but cannot
+// submit to a session outside their `classIds` claim.
 
 import { readFileSync } from 'fs';
 import { fileURLToPath } from 'url';
@@ -17,7 +25,17 @@ import {
   assertFails,
   type RulesTestEnvironment,
 } from '@firebase/rules-unit-testing';
-import { setDoc, getDoc, addDoc, collection, doc } from 'firebase/firestore';
+import {
+  setDoc,
+  getDoc,
+  getDocs,
+  addDoc,
+  collection,
+  deleteDoc,
+  doc,
+  query,
+  where,
+} from 'firebase/firestore';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -44,19 +62,33 @@ const RULES_PATH = fileURLToPath(
 
 let testEnv: RulesTestEnvironment;
 
+// Token shape note: the Firestore rules engine in the emulator throws
+// "Property X is undefined on object" when a rule expression reads a token
+// claim that isn't present (even behind a `!= null` short-circuit). Real
+// Firebase Auth tokens carry the full claim surface; the emulator test
+// harness does not auto-populate it. We therefore spell out every claim
+// the rules may touch — `email`, `studentRole`, `classIds`, and
+// `firebase.sign_in_provider` — in every context, using empty/false
+// defaults for claims that don't apply to that role. This matches what
+// production Auth tokens look like for real sign-ins.
+
 const asStudentA = () =>
   testEnv
     .authenticatedContext(STUDENT_A_UID, {
+      email: '',
       studentRole: true,
       classIds: [CLASS_A],
+      firebase: { sign_in_provider: 'custom' },
     })
     .firestore();
 
 const asStudentEmpty = () =>
   testEnv
     .authenticatedContext(STUDENT_EMPTY_UID, {
+      email: '',
       studentRole: true,
       classIds: [],
+      firebase: { sign_in_provider: 'custom' },
     })
     .firestore();
 
@@ -64,6 +96,8 @@ const asTeacher = () =>
   testEnv
     .authenticatedContext(TEACHER_UID, {
       email: 'teacher@school.edu',
+      studentRole: false,
+      classIds: [],
       firebase: { sign_in_provider: 'google.com' },
     })
     .firestore();
@@ -71,6 +105,9 @@ const asTeacher = () =>
 const asAnonStudent = () =>
   testEnv
     .authenticatedContext(ANON_UID, {
+      email: '',
+      studentRole: false,
+      classIds: [],
       firebase: { sign_in_provider: 'anonymous' },
     })
     .firestore();
@@ -174,6 +211,7 @@ async function seedSessions(cols: string[], opts: SeedOptions = {}) {
             {
               studentAnonymousId: STUDENT_A_UID,
               sessionId: SESSION_A,
+              startedAt: 1000,
               score: null,
               answers: [],
             }
@@ -196,7 +234,7 @@ const ALL_SESSION_COLS = [
   'activity_wall_sessions',
 ];
 
-describe('student-role class gate — session reads', () => {
+describe('session reads — authenticated access (class gate moved to writes)', () => {
   beforeEach(async () => {
     await testEnv.clearFirestore();
     await seedSessions(ALL_SESSION_COLS);
@@ -208,13 +246,17 @@ describe('student-role class gate — session reads', () => {
         await assertSucceeds(getDoc(doc(asStudentA(), `${col}/${SESSION_A}`)));
       });
 
-      it('student with matching classId cannot read session-B (wrong class)', async () => {
-        await assertFails(getDoc(doc(asStudentA(), `${col}/${SESSION_B}`)));
+      it('student can read session-B (out-of-class metadata is no longer gated at reads; write rules enforce the class gate)', async () => {
+        await assertSucceeds(getDoc(doc(asStudentA(), `${col}/${SESSION_B}`)));
       });
 
-      it('student with empty classIds cannot read any session', async () => {
-        await assertFails(getDoc(doc(asStudentEmpty(), `${col}/${SESSION_A}`)));
-        await assertFails(getDoc(doc(asStudentEmpty(), `${col}/${SESSION_B}`)));
+      it('student with empty classIds can still read session metadata', async () => {
+        await assertSucceeds(
+          getDoc(doc(asStudentEmpty(), `${col}/${SESSION_A}`))
+        );
+        await assertSucceeds(
+          getDoc(doc(asStudentEmpty(), `${col}/${SESSION_B}`))
+        );
       });
 
       it('teacher (no studentRole claim) can read any session', async () => {
@@ -261,6 +303,11 @@ describe('quiz_sessions/responses — student-role gate', () => {
   });
 
   it('student in class-A can create response on session-A', async () => {
+    // seedSessions(withResponses) pre-creates a response for STUDENT_A_UID.
+    // Clear it so this test truly exercises the create rule.
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      await deleteDoc(doc(ctx.firestore(), respPath(SESSION_A)));
+    });
     await assertSucceeds(
       setDoc(doc(asStudentA(), respPath(SESSION_A)), {
         ...baseResp(),
@@ -364,6 +411,11 @@ describe('video_activity_sessions/responses — student-role gate', () => {
   });
 
   it('student in class-A can create response on session-A', async () => {
+    // seedSessions(withResponses) pre-creates a response for STUDENT_A_UID.
+    // Clear it so this test truly exercises the create rule.
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      await deleteDoc(doc(ctx.firestore(), respPath(SESSION_A)));
+    });
     await assertSucceeds(
       setDoc(doc(asStudentA(), respPath(SESSION_A)), {
         ...baseResp(),
@@ -438,6 +490,7 @@ describe('guided_learning_sessions/responses — student-role gate', () => {
   const baseResp = (session = SESSION_A) => ({
     studentAnonymousId: STUDENT_A_UID,
     sessionId: session,
+    startedAt: 1000,
     score: null,
     answers: [],
   });
@@ -448,6 +501,12 @@ describe('guided_learning_sessions/responses — student-role gate', () => {
   });
 
   it('student in class-A can create response on session-A', async () => {
+    // seedSessions(withResponses) pre-creates a response for STUDENT_A_UID,
+    // so a bare setDoc would hit the update rule, not create. Clear the
+    // seeded doc first so this test actually exercises the create path.
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      await deleteDoc(doc(ctx.firestore(), respPath(SESSION_A)));
+    });
     await assertSucceeds(
       setDoc(doc(asStudentA(), respPath(SESSION_A)), baseResp())
     );
@@ -575,25 +634,54 @@ describe('mini_app_sessions/submissions — student-role gate', () => {
   const col = 'mini_app_sessions';
   const subPath = (session: string, uid: string) =>
     `${col}/${session}/submissions/${uid}`;
-  const validSub = () => ({
+  // The mini_app submission rule enforces a strict key whitelist:
+  // ['submittedAt', 'studentUid', 'payload']. `studentUid` must equal
+  // request.auth.uid. validSub() takes the submitter uid so the test
+  // parameterizes it correctly.
+  const validSub = (uid: string) => ({
     submittedAt: 1000,
+    studentUid: uid,
     payload: { score: 42, answers: [1, 2, 3] } as Record<string, unknown>,
   });
 
   beforeEach(async () => {
     await testEnv.clearFirestore();
-    await seedSessions([col]);
+    // mini_app_sessions docs require `submissionsEnabled: true` on the
+    // parent session for submissions to be accepted. The generic seed
+    // helper doesn't set that field (it seeds a bare sessionDoc), so we
+    // re-seed here with the mini-app-specific shape.
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      const db = ctx.firestore();
+      await setDoc(doc(db, `${col}/${SESSION_A}`), {
+        teacherUid: TEACHER_UID,
+        classIds: [CLASS_A],
+        status: 'active',
+        submissionsEnabled: true,
+      });
+      await setDoc(doc(db, `${col}/${SESSION_B}`), {
+        teacherUid: TEACHER_UID,
+        classIds: [CLASS_B],
+        status: 'active',
+        submissionsEnabled: true,
+      });
+    });
   });
 
   it('student in class-A can submit to session-A under their own pseudonym', async () => {
     await assertSucceeds(
-      setDoc(doc(asStudentA(), subPath(SESSION_A, STUDENT_A_UID)), validSub())
+      setDoc(
+        doc(asStudentA(), subPath(SESSION_A, STUDENT_A_UID)),
+        validSub(STUDENT_A_UID)
+      )
     );
   });
 
   it('student in class-A cannot submit to session-B (wrong class)', async () => {
     await assertFails(
-      setDoc(doc(asStudentA(), subPath(SESSION_B, STUDENT_A_UID)), validSub())
+      setDoc(
+        doc(asStudentA(), subPath(SESSION_B, STUDENT_A_UID)),
+        validSub(STUDENT_A_UID)
+      )
     );
   });
 
@@ -601,14 +689,17 @@ describe('mini_app_sessions/submissions — student-role gate', () => {
     await assertFails(
       setDoc(
         doc(asStudentEmpty(), subPath(SESSION_A, STUDENT_EMPTY_UID)),
-        validSub()
+        validSub(STUDENT_EMPTY_UID)
       )
     );
   });
 
   it('anonymous PIN student can submit under their own auth uid', async () => {
     await assertSucceeds(
-      setDoc(doc(asAnonStudent(), subPath(SESSION_A, ANON_UID)), validSub())
+      setDoc(
+        doc(asAnonStudent(), subPath(SESSION_A, ANON_UID)),
+        validSub(ANON_UID)
+      )
     );
   });
 
@@ -616,21 +707,21 @@ describe('mini_app_sessions/submissions — student-role gate', () => {
     await assertFails(
       setDoc(
         doc(asAnonStudent(), subPath(SESSION_A, 'some-other-uid')),
-        validSub()
+        validSub('some-other-uid')
       )
     );
   });
 
   it('unauthenticated caller cannot submit', async () => {
     await assertFails(
-      setDoc(doc(asUnauth(), subPath(SESSION_A, 'x')), validSub())
+      setDoc(doc(asUnauth(), subPath(SESSION_A, 'x')), validSub('x'))
     );
   });
 
   it('submission with extra keys is rejected', async () => {
     await assertFails(
       setDoc(doc(asStudentA(), subPath(SESSION_A, STUDENT_A_UID)), {
-        ...validSub(),
+        ...validSub(STUDENT_A_UID),
         sneaky: 'extra-field',
       })
     );
@@ -640,6 +731,7 @@ describe('mini_app_sessions/submissions — student-role gate', () => {
     await assertFails(
       setDoc(doc(asStudentA(), subPath(SESSION_A, STUDENT_A_UID)), {
         submittedAt: 1000,
+        studentUid: STUDENT_A_UID,
         payload: 'just-a-string',
       })
     );
@@ -649,6 +741,7 @@ describe('mini_app_sessions/submissions — student-role gate', () => {
     await assertFails(
       setDoc(doc(asStudentA(), subPath(SESSION_A, STUDENT_A_UID)), {
         submittedAt: 'not-a-number',
+        studentUid: STUDENT_A_UID,
         payload: { score: 1 },
       })
     );
@@ -658,12 +751,16 @@ describe('mini_app_sessions/submissions — student-role gate', () => {
     await testEnv.withSecurityRulesDisabled(async (ctx) => {
       await setDoc(doc(ctx.firestore(), `${col}/${SESSION_A}`), {
         teacherUid: TEACHER_UID,
-        classId: CLASS_A,
+        classIds: [CLASS_A],
         status: 'ended',
+        submissionsEnabled: true,
       });
     });
     await assertFails(
-      setDoc(doc(asStudentA(), subPath(SESSION_A, STUDENT_A_UID)), validSub())
+      setDoc(
+        doc(asStudentA(), subPath(SESSION_A, STUDENT_A_UID)),
+        validSub(STUDENT_A_UID)
+      )
     );
   });
 
@@ -671,11 +768,11 @@ describe('mini_app_sessions/submissions — student-role gate', () => {
     await testEnv.withSecurityRulesDisabled(async (ctx) => {
       await setDoc(
         doc(ctx.firestore(), subPath(SESSION_A, STUDENT_A_UID)),
-        validSub()
+        validSub(STUDENT_A_UID)
       );
       await setDoc(
         doc(ctx.firestore(), subPath(SESSION_A, 'other-uid')),
-        validSub()
+        validSub('other-uid')
       );
     });
     await assertSucceeds(
@@ -690,11 +787,315 @@ describe('mini_app_sessions/submissions — student-role gate', () => {
     await testEnv.withSecurityRulesDisabled(async (ctx) => {
       await setDoc(
         doc(ctx.firestore(), subPath(SESSION_A, 'anyone')),
-        validSub()
+        validSub('anyone')
       );
     });
     await assertSucceeds(
       getDoc(doc(asTeacher(), subPath(SESSION_A, 'anyone')))
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// End-to-end lifecycle — walks the real client sequence for the full quiz
+// flow so a rules regression on any step fails a test. Reproduces:
+//   - The join-code probe (where('code', '==', X)) from PR #1390.
+//   - The single-doc onSnapshot listener from PR #1391.
+//   - The studentRole MyAssignmentsPage discovery query.
+//   - The response create + submit-answers + teacher-finalize sequence.
+// ---------------------------------------------------------------------------
+
+describe('quiz_sessions — end-to-end lifecycle', () => {
+  const SESSION_ID = 'lifecycle-session';
+  const JOIN_CODE = 'TESTCD';
+  const STUDENT_B_UID = 'student-b-uid';
+
+  const asStudentB = () =>
+    testEnv
+      .authenticatedContext(STUDENT_B_UID, {
+        studentRole: true,
+        classIds: [CLASS_B],
+      })
+      .firestore();
+
+  const baseSessionShape = {
+    id: SESSION_ID,
+    assignmentId: SESSION_ID,
+    teacherUid: TEACHER_UID,
+    classId: CLASS_A,
+    code: JOIN_CODE,
+    sessionMode: 'teacher',
+    currentQuestionIndex: -1,
+    startedAt: null,
+    endedAt: null,
+    totalQuestions: 2,
+    publicQuestions: [],
+  };
+
+  const baseStudentResp = (uid: string, pin: string) => ({
+    studentUid: uid,
+    pin,
+    joinedAt: 1000,
+    score: null,
+    answers: [] as unknown[],
+    status: 'active',
+    tabSwitchWarnings: 0,
+  });
+
+  beforeEach(async () => {
+    await testEnv.clearFirestore();
+  });
+
+  it('teacher create → query by code → get → resume → advance — no permission-denied', async () => {
+    // 1. createAssignment: teacher writes a paused session doc.
+    await assertSucceeds(
+      setDoc(doc(asTeacher(), `quiz_sessions/${SESSION_ID}`), {
+        ...baseSessionShape,
+        status: 'paused',
+      })
+    );
+
+    // 2. allocateJoinCode: teacher LIST query by code (was broken pre-#1390).
+    await assertSucceeds(
+      getDocs(
+        query(
+          collection(asTeacher(), 'quiz_sessions'),
+          where('code', '==', JOIN_CODE)
+        )
+      )
+    );
+
+    // 3. useQuizSessionTeacher: single-doc GET (was broken pre-#1391 — the
+    //    Start bug this PR fixes).
+    await assertSucceeds(
+      getDoc(doc(asTeacher(), `quiz_sessions/${SESSION_ID}`))
+    );
+
+    // 4. resumeAssignment: paused → waiting.
+    await assertSucceeds(
+      setDoc(
+        doc(asTeacher(), `quiz_sessions/${SESSION_ID}`),
+        { status: 'waiting' },
+        { merge: true }
+      )
+    );
+
+    // 5. advanceQuestion: waiting → active, currentQuestionIndex = 0.
+    await assertSucceeds(
+      setDoc(
+        doc(asTeacher(), `quiz_sessions/${SESSION_ID}`),
+        { status: 'active', currentQuestionIndex: 0, startedAt: 1000 },
+        { merge: true }
+      )
+    );
+  });
+
+  it('studentRole in-class: discovery → get → create response → submit answers', async () => {
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      await setDoc(doc(ctx.firestore(), `quiz_sessions/${SESSION_ID}`), {
+        ...baseSessionShape,
+        status: 'active',
+      });
+    });
+
+    // 6. MyAssignmentsPage: where('classId', 'in', myClassIds).
+    await assertSucceeds(
+      getDocs(
+        query(
+          collection(asStudentA(), 'quiz_sessions'),
+          where('classId', 'in', [CLASS_A])
+        )
+      )
+    );
+
+    // 7. Student renders the session: single-doc GET.
+    await assertSucceeds(
+      getDoc(doc(asStudentA(), `quiz_sessions/${SESSION_ID}`))
+    );
+
+    // 8. Student joins: creates response doc.
+    const respPath = `quiz_sessions/${SESSION_ID}/responses/${STUDENT_A_UID}`;
+    await assertSucceeds(
+      setDoc(
+        doc(asStudentA(), respPath),
+        baseStudentResp(STUDENT_A_UID, '1234')
+      )
+    );
+
+    // 9. Student submits answers: update with only allowed field changes.
+    await assertSucceeds(
+      setDoc(doc(asStudentA(), respPath), {
+        ...baseStudentResp(STUDENT_A_UID, '1234'),
+        answers: [{ questionId: 'q1', answer: 'A' }],
+        status: 'submitted',
+        submittedAt: 2000,
+      })
+    );
+  });
+
+  it('studentRole out-of-class: can read session metadata but cannot submit', async () => {
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      await setDoc(doc(ctx.firestore(), `quiz_sessions/${SESSION_ID}`), {
+        ...baseSessionShape,
+        status: 'active',
+      });
+    });
+
+    // Out-of-class student CAN get the session doc (intentional post-PR #1391).
+    await assertSucceeds(
+      getDoc(doc(asStudentB(), `quiz_sessions/${SESSION_ID}`))
+    );
+
+    // But CANNOT create a response: write-side class gate denies.
+    const respPath = `quiz_sessions/${SESSION_ID}/responses/${STUDENT_B_UID}`;
+    await assertFails(
+      setDoc(
+        doc(asStudentB(), respPath),
+        baseStudentResp(STUDENT_B_UID, '5555')
+      )
+    );
+
+    // Nor update an existing response (even if one were seeded).
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      await setDoc(
+        doc(ctx.firestore(), respPath),
+        baseStudentResp(STUDENT_B_UID, '5555')
+      );
+    });
+    await assertFails(
+      setDoc(doc(asStudentB(), respPath), {
+        ...baseStudentResp(STUDENT_B_UID, '5555'),
+        answers: [{ questionId: 'q1', answer: 'A' }],
+        status: 'submitted',
+        submittedAt: 2000,
+      })
+    );
+  });
+
+  it('studentRole cannot read another student response', async () => {
+    const otherUid = 'student-other-uid';
+    const otherRespPath = `quiz_sessions/${SESSION_ID}/responses/${otherUid}`;
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      await setDoc(doc(ctx.firestore(), `quiz_sessions/${SESSION_ID}`), {
+        ...baseSessionShape,
+        status: 'active',
+      });
+      await setDoc(
+        doc(ctx.firestore(), otherRespPath),
+        baseStudentResp(otherUid, '7777')
+      );
+    });
+
+    await assertFails(getDoc(doc(asStudentA(), otherRespPath)));
+  });
+
+  it('teacher reads all responses (list) and finalizes a score', async () => {
+    const respPath = `quiz_sessions/${SESSION_ID}/responses/${STUDENT_A_UID}`;
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      await setDoc(doc(ctx.firestore(), `quiz_sessions/${SESSION_ID}`), {
+        ...baseSessionShape,
+        status: 'ended',
+      });
+      await setDoc(doc(ctx.firestore(), respPath), {
+        ...baseStudentResp(STUDENT_A_UID, '1234'),
+        answers: [{ questionId: 'q1', answer: 'A' }],
+        status: 'submitted',
+        submittedAt: 2000,
+      });
+    });
+
+    // 13. Teacher lists all responses on the session.
+    await assertSucceeds(
+      getDocs(collection(asTeacher(), `quiz_sessions/${SESSION_ID}/responses`))
+    );
+
+    // 14. Teacher sets score — a field students are forbidden from writing.
+    await assertSucceeds(
+      setDoc(doc(asTeacher(), respPath), { score: 85 }, { merge: true })
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PR #1391 regression smoke — teacher create → teacher single-doc read on
+// every session collection that uses the `allow read: if request.auth != null;`
+// shape. A rules regression that re-introduces `resource.data` into any of
+// these read rules will show up here.
+// ---------------------------------------------------------------------------
+
+describe('PR #1391 regression — teacher create + single-doc read on all session collections', () => {
+  const SESSION_ID = 'pr1391-regression';
+
+  beforeEach(async () => {
+    await testEnv.clearFirestore();
+  });
+
+  it('quiz_sessions: teacher create → single-doc get succeeds', async () => {
+    await assertSucceeds(
+      setDoc(doc(asTeacher(), `quiz_sessions/${SESSION_ID}`), {
+        teacherUid: TEACHER_UID,
+        classId: CLASS_A,
+        code: 'CODE01',
+        status: 'paused',
+      })
+    );
+    await assertSucceeds(
+      getDoc(doc(asTeacher(), `quiz_sessions/${SESSION_ID}`))
+    );
+  });
+
+  it('video_activity_sessions: teacher create → single-doc get succeeds', async () => {
+    await assertSucceeds(
+      setDoc(
+        doc(asTeacher(), `video_activity_sessions/${SESSION_ID}`),
+        vaFields(SESSION_ID, CLASS_A)
+      )
+    );
+    await assertSucceeds(
+      getDoc(doc(asTeacher(), `video_activity_sessions/${SESSION_ID}`))
+    );
+  });
+
+  it('guided_learning_sessions: teacher create → single-doc get succeeds', async () => {
+    await assertSucceeds(
+      setDoc(doc(asTeacher(), `guided_learning_sessions/${SESSION_ID}`), {
+        teacherUid: TEACHER_UID,
+        classId: CLASS_A,
+        status: 'active',
+      })
+    );
+    await assertSucceeds(
+      getDoc(doc(asTeacher(), `guided_learning_sessions/${SESSION_ID}`))
+    );
+  });
+
+  it('mini_app_sessions: teacher create → single-doc get succeeds', async () => {
+    await assertSucceeds(
+      setDoc(doc(asTeacher(), `mini_app_sessions/${SESSION_ID}`), {
+        teacherUid: TEACHER_UID,
+        classIds: [CLASS_A],
+        status: 'active',
+        assignmentName: 'Mini',
+        submissionsEnabled: true,
+      })
+    );
+    await assertSucceeds(
+      getDoc(doc(asTeacher(), `mini_app_sessions/${SESSION_ID}`))
+    );
+  });
+
+  it('activity_wall_sessions: teacher create → single-doc get succeeds', async () => {
+    // activity_wall sessionId convention: {teacherUid}_{activityId}
+    const awSessionId = `${TEACHER_UID}_activity-x`;
+    await assertSucceeds(
+      setDoc(doc(asTeacher(), `activity_wall_sessions/${awSessionId}`), {
+        teacherUid: TEACHER_UID,
+        classId: CLASS_A,
+        status: 'active',
+      })
+    );
+    await assertSucceeds(
+      getDoc(doc(asTeacher(), `activity_wall_sessions/${awSessionId}`))
     );
   });
 });

--- a/tests/utils/resolveAssignmentTargets.test.ts
+++ b/tests/utils/resolveAssignmentTargets.test.ts
@@ -1,0 +1,192 @@
+import { describe, it, expect } from 'vitest';
+import {
+  resolveAssignmentTargets,
+  deriveSessionTargetsFromRosters,
+  mapLegacyClassIdsToRosterIds,
+} from '@/utils/resolveAssignmentTargets';
+import type { ClassRoster, Student } from '@/types';
+
+const student = (id: string, name: string, pin: string): Student => ({
+  id,
+  firstName: name,
+  lastName: '',
+  pin,
+});
+
+const roster = (
+  id: string,
+  name: string,
+  students: Student[],
+  extra: Partial<ClassRoster> = {}
+): ClassRoster => ({
+  id,
+  name,
+  students,
+  driveFileId: null,
+  studentCount: students.length,
+  createdAt: 0,
+  ...extra,
+});
+
+const s1 = student('s1', 'Ada', '01');
+const s2 = student('s2', 'Blake', '02');
+const s3 = student('s3', 'Cody', '03');
+
+describe('resolveAssignmentTargets', () => {
+  it('uses rosterIds when present (new path) and derives everything from rosters', () => {
+    const r1 = roster('r1', 'Period 1', [s1, s2], {
+      classlinkClassId: 'cl-1',
+    });
+    const r2 = roster('r2', 'Period 2', [s3], { classlinkClassId: 'cl-2' });
+    const out = resolveAssignmentTargets(
+      { rosterIds: ['r1', 'r2'], classIds: ['ignored'], periodNames: ['x'] },
+      [r1, r2]
+    );
+    expect(out.source).toBe('rosterIds');
+    expect(out.rosterIds).toEqual(['r1', 'r2']);
+    expect(out.classIds.sort()).toEqual(['cl-1', 'cl-2']);
+    expect(out.periodNames.sort()).toEqual(['Period 1', 'Period 2']);
+    expect(out.students.map((s) => s.id).sort()).toEqual(['s1', 's2', 's3']);
+  });
+
+  it('falls back to legacy classIds when rosterIds is empty/absent', () => {
+    const out = resolveAssignmentTargets(
+      { classIds: ['cl-legacy-1', 'cl-legacy-2'] },
+      []
+    );
+    expect(out.source).toBe('classIds');
+    expect(out.classIds).toEqual(['cl-legacy-1', 'cl-legacy-2']);
+    expect(out.rosterIds).toEqual([]);
+    expect(out.periodNames).toEqual([]);
+  });
+
+  it('falls back to legacy periodNames when only it is present', () => {
+    const out = resolveAssignmentTargets({ periodNames: ['Period 1'] }, []);
+    expect(out.source).toBe('periodNames');
+    expect(out.periodNames).toEqual(['Period 1']);
+  });
+
+  it('returns source="none" when nothing is targeted', () => {
+    expect(resolveAssignmentTargets({}, []).source).toBe('none');
+  });
+
+  it('silently drops rosterIds that no longer exist', () => {
+    const r1 = roster('r1', 'Period 1', [s1], { classlinkClassId: 'cl-1' });
+    const out = resolveAssignmentTargets({ rosterIds: ['r1', 'deleted'] }, [
+      r1,
+    ]);
+    expect(out.rosterIds).toEqual(['r1']);
+    expect(out.classIds).toEqual(['cl-1']);
+  });
+
+  it('de-dupes students shared across multiple selected rosters', () => {
+    const shared = student('shared', 'Shared', '04');
+    const r1 = roster('r1', 'Period 1', [s1, shared]);
+    const r2 = roster('r2', 'Period 2', [s2, shared]);
+    const out = resolveAssignmentTargets({ rosterIds: ['r1', 'r2'] }, [r1, r2]);
+    expect(out.students.map((s) => s.id).sort()).toEqual([
+      's1',
+      's2',
+      'shared',
+    ]);
+  });
+
+  it('de-dupes classIds when two rosters share a classlinkClassId', () => {
+    // Teacher imported the same ClassLink class twice under different names.
+    const r1 = roster('r1', 'MATH-7 (copy A)', [s1], {
+      classlinkClassId: 'cl-dup',
+    });
+    const r2 = roster('r2', 'MATH-7 (copy B)', [s2], {
+      classlinkClassId: 'cl-dup',
+    });
+    const out = resolveAssignmentTargets({ rosterIds: ['r1', 'r2'] }, [r1, r2]);
+    expect(out.classIds).toEqual(['cl-dup']);
+  });
+
+  it('de-dupes periodNames when rosters share a name', () => {
+    const r1 = roster('r1', 'Period 1', [s1]);
+    const r2 = roster('r2', 'Period 1', [s2]);
+    const out = resolveAssignmentTargets({ rosterIds: ['r1', 'r2'] }, [r1, r2]);
+    expect(out.periodNames).toEqual(['Period 1']);
+  });
+
+  it('omits rosters without a classlinkClassId from derived classIds', () => {
+    const r1 = roster('r1', 'Period 1', [s1], { classlinkClassId: 'cl-1' });
+    const r2 = roster('r2', 'Local only', [s2]); // no classlinkClassId
+    const out = resolveAssignmentTargets({ rosterIds: ['r1', 'r2'] }, [r1, r2]);
+    expect(out.classIds).toEqual(['cl-1']);
+    expect(out.rosterIds).toEqual(['r1', 'r2']);
+  });
+});
+
+describe('deriveSessionTargetsFromRosters', () => {
+  it('derives classIds, periodNames, and de-duped students', () => {
+    const r1 = roster('r1', 'Period 1', [s1, s2], {
+      classlinkClassId: 'cl-1',
+    });
+    const r2 = roster('r2', 'Period 2', [s3], { classlinkClassId: 'cl-2' });
+    const out = deriveSessionTargetsFromRosters([r1, r2]);
+    expect(out.rosterIds).toEqual(['r1', 'r2']);
+    expect(out.classIds.sort()).toEqual(['cl-1', 'cl-2']);
+    expect(out.periodNames.sort()).toEqual(['Period 1', 'Period 2']);
+    expect(out.students.map((s) => s.id).sort()).toEqual(['s1', 's2', 's3']);
+  });
+
+  it('de-dupes classIds (two rosters with same classlinkClassId)', () => {
+    const r1 = roster('r1', 'A', [s1], { classlinkClassId: 'cl-dup' });
+    const r2 = roster('r2', 'B', [s2], { classlinkClassId: 'cl-dup' });
+    expect(deriveSessionTargetsFromRosters([r1, r2]).classIds).toEqual([
+      'cl-dup',
+    ]);
+  });
+
+  it('returns empty arrays for empty input', () => {
+    expect(deriveSessionTargetsFromRosters([])).toEqual({
+      rosterIds: [],
+      classIds: [],
+      periodNames: [],
+      students: [],
+    });
+  });
+});
+
+describe('mapLegacyClassIdsToRosterIds', () => {
+  it('maps legacy ClassLink sourcedIds to rosterIds via classlinkClassId', () => {
+    const r1 = roster('r1', 'A', [], { classlinkClassId: 'cl-1' });
+    const r2 = roster('r2', 'B', [], { classlinkClassId: 'cl-2' });
+    expect(mapLegacyClassIdsToRosterIds(['cl-1', 'cl-2'], [r1, r2])).toEqual([
+      'r1',
+      'r2',
+    ]);
+  });
+
+  it('returns an empty array when legacy input is undefined/empty', () => {
+    expect(mapLegacyClassIdsToRosterIds(undefined, [])).toEqual([]);
+    expect(mapLegacyClassIdsToRosterIds([], [])).toEqual([]);
+  });
+
+  it('returns partial matches — silently drops legacy IDs with no matching roster', () => {
+    const r1 = roster('r1', 'A', [], { classlinkClassId: 'cl-1' });
+    expect(
+      mapLegacyClassIdsToRosterIds(['cl-1', 'cl-never-imported'], [r1])
+    ).toEqual(['r1']);
+  });
+
+  it('returns empty array when no roster has matching classlinkClassId', () => {
+    const r1 = roster('r1', 'A', [], { classlinkClassId: 'cl-1' });
+    expect(mapLegacyClassIdsToRosterIds(['cl-never-imported'], [r1])).toEqual(
+      []
+    );
+  });
+
+  it('first-wins tie-break when two rosters share a classlinkClassId', () => {
+    const r1 = roster('r1', 'A', [], { classlinkClassId: 'cl-dup' });
+    const r2 = roster('r2', 'B', [], { classlinkClassId: 'cl-dup' });
+    expect(mapLegacyClassIdsToRosterIds(['cl-dup'], [r1, r2])).toEqual(['r1']);
+  });
+
+  it('ignores rosters without classlinkClassId', () => {
+    const r1 = roster('r1', 'Local only', []); // no classlinkClassId
+    expect(mapLegacyClassIdsToRosterIds(['cl-1'], [r1])).toEqual([]);
+  });
+});

--- a/types.ts
+++ b/types.ts
@@ -1737,17 +1737,24 @@ export interface QuizSession {
   /** Selected class period roster names available for students to join. */
   periodNames?: string[];
 
-  // ─── ClassLink target class (Phase 3A) ─────────────────────────────────────
+  // ─── ClassLink target class (Phase 3A, Phase 5A multi-class) ───────────────
   /**
-   * Optional ClassLink class `sourcedId` this session is targeted at. When
-   * present, students who signed in via the ClassLink / Google flow will see
-   * this session on their `/my-assignments` page, and Firestore rules
-   * enforce (via `passesStudentClassGate`) that only students enrolled in
-   * this class can read the session doc. Omit (or leave as an empty string)
-   * to preserve the classic code/PIN-only flow — the gate is a no-op for
-   * non-studentRole users.
+   * @deprecated Phase 5A — retained only for transitional compatibility.
+   * Populated to `classIds[0]` when `classIds` is non-empty so older clients
+   * and pre-migration Firestore rules keep working. Prefer `classIds`.
    */
   classId?: string;
+  /**
+   * Multi-class ClassLink target: the list of ClassLink class `sourcedId`s
+   * this session is targeted at. When non-empty, students who signed in via
+   * the ClassLink / Google flow will see this session on their
+   * `/my-assignments` page, and Firestore rules (via
+   * `passesStudentClassGateList`) enforce that the student has at least one
+   * of these classes in their `classIds` auth-token claim. An empty or
+   * missing list preserves the classic code/PIN-only flow — the gate is a
+   * no-op for non-studentRole users.
+   */
+  classIds?: string[];
 }
 
 export interface QuizResponseAnswer {
@@ -1841,13 +1848,20 @@ export interface QuizConfig {
   /** Persisted library grid/list toggle. */
   libraryViewMode?: 'grid' | 'list';
   /**
-   * Per-quiz memory of the last ClassLink target class (`sourcedId`) the
-   * teacher picked in the Assign modal. Key is quizId, value is the
-   * ClassLink class sourcedId. Used to pre-select the selector on re-launch
-   * of the same quiz so teachers don't have to re-pick every time.
-   * Undefined means "use the default (No class)".
+   * @deprecated Phase 5A — replaced by `lastClassIdsByQuizId` (multi-class).
+   * Retained for a transitional release so existing widget configs don't
+   * lose their pre-selection on first render. Readers prefer the multi-
+   * class map; fallback to this when the new key is absent.
    */
   lastClassIdByQuizId?: Record<string, string>;
+  /**
+   * Per-quiz memory of the last ClassLink target classes (`sourcedId`s) the
+   * teacher picked in the Assign modal. Key is quizId, value is a list of
+   * ClassLink class sourcedIds. Used to pre-select the picker on re-launch
+   * of the same quiz so teachers don't have to re-pick every time. Missing
+   * keys mean "use the default (no classes selected)".
+   */
+  lastClassIdsByQuizId?: Record<string, string[]>;
 }
 
 // --- QUIZ ASSIGNMENT TYPES ---
@@ -1982,8 +1996,17 @@ export interface VideoActivityConfig {
    * ClassLink class sourcedId. Used to pre-select the selector on re-launch
    * of the same activity so teachers don't have to re-pick every time.
    * Undefined means "use the default (No class)".
+   *
+   * @deprecated Phase 5A — replaced by `lastClassIdsByActivityId` (multi).
+   * Retained for a transitional release so existing widget configs don't
+   * lose their pre-selection on first render.
    */
   lastClassIdByActivityId?: Record<string, string>;
+  /**
+   * Multi-class variant of the per-activity memory (Phase 5A). Preferred
+   * over the legacy single-class map.
+   */
+  lastClassIdsByActivityId?: Record<string, string[]>;
 }
 
 export interface VideoActivitySessionSettings {
@@ -2028,13 +2051,26 @@ export interface VideoActivitySession {
   /** Optional Unix timestamp when the session link expires. */
   expiresAt?: number;
   /**
-   * Optional ClassLink class `sourcedId` this session is targeted at. When
-   * set, ClassLink-authenticated students whose token includes this classId
-   * see the session on their `/my-assignments` page, and Firestore rules
-   * (`passesStudentClassGate(vaSessionClassId())`) enforce class-based
-   * access. Undefined preserves the classic code/PIN-only flow.
+   * @deprecated Phase 5A — retained only for transitional compatibility.
+   * Populated to `classIds[0]` when `classIds` is non-empty so older clients
+   * and pre-migration Firestore rules keep working. Prefer `classIds`.
    */
   classId?: string;
+  /**
+   * Multi-class ClassLink target list. ClassLink-authenticated students whose
+   * token `classIds` claim overlaps this list see the session on their
+   * `/my-assignments` page; Firestore rules (`passesStudentClassGateList`)
+   * enforce the class gate. An empty/missing list preserves the classic
+   * PIN-only flow.
+   */
+  classIds?: string[];
+  /**
+   * Optional class-period names (typically local roster names) available for
+   * students to choose from after entering their PIN. When present and > 1,
+   * the student app shows a post-PIN picker and writes the chosen value to
+   * the response's `classPeriod` field. Mirrors the QuizSession pattern.
+   */
+  periodNames?: string[];
 }
 
 /** A single answer submitted by a student for a video activity question. */
@@ -2061,6 +2097,8 @@ export interface VideoActivityResponse {
   answers: VideoActivityAnswer[];
   completedAt: number | null;
   score: number | null;
+  /** Which class period the student selected when joining (multi-class support). */
+  classPeriod?: string;
 }
 
 export interface TalkingToolConfig {
@@ -2638,17 +2676,28 @@ export interface GuidedLearningSession {
   teacherUid: string;
   createdAt: number;
   expiresAt?: number;
-  // ─── ClassLink target class (Phase 3C) ─────────────────────────────────────
+  // ─── ClassLink target class (Phase 3C, Phase 5A multi-class) ───────────────
   /**
-   * Optional ClassLink class `sourcedId` this session is targeted at. When
-   * present, students who signed in via the ClassLink / Google flow will see
-   * this session on their `/my-assignments` page, and Firestore rules
-   * enforce (via `passesStudentClassGate`) that only students enrolled in
-   * this class can read the session doc. Omit (or leave as an empty string)
-   * to preserve the classic join-link flow — the gate is a no-op for
-   * non-studentRole users.
+   * @deprecated Phase 5A — retained only for transitional compatibility.
+   * Populated to `classIds[0]` when `classIds` is non-empty so older clients
+   * and pre-migration Firestore rules keep working. Prefer `classIds`.
    */
   classId?: string;
+  /**
+   * Multi-class ClassLink target list. ClassLink-authenticated students whose
+   * token `classIds` claim overlaps this list see the session on their
+   * `/my-assignments` page; Firestore rules (`passesStudentClassGateList`)
+   * enforce the class gate. An empty/missing list preserves the classic
+   * join-link flow.
+   */
+  classIds?: string[];
+  /**
+   * Optional class-period names (typically local roster names) available for
+   * students to choose from after entering their PIN. When present and > 1,
+   * the student app shows a post-PIN picker and writes the chosen value to
+   * the response's `classPeriod` field. Mirrors the QuizSession pattern.
+   */
+  periodNames?: string[];
 }
 
 /** Per-student response in /guided_learning_sessions/{id}/responses/{studentUid} */
@@ -2664,6 +2713,8 @@ export interface GuidedLearningResponse {
   completedAt: number | null;
   startedAt: number;
   score: number | null;
+  /** Which class period the student selected when joining (multi-class support). */
+  classPeriod?: string;
 }
 
 export interface GuidedLearningGlobalConfig {
@@ -2685,8 +2736,17 @@ export interface GuidedLearningConfig {
    * value is the ClassLink class sourcedId. Used to pre-select the selector
    * on re-launch of the same set so teachers don't have to re-pick every
    * time. Undefined means "use the default (No class)".
+   *
+   * @deprecated Phase 5A — replaced by `lastClassIdsBySetId` (multi).
+   * Retained for a transitional release so existing widget configs don't
+   * lose their pre-selection on first render.
    */
   lastClassIdBySetId?: Record<string, string>;
+  /**
+   * Multi-class variant of the per-set memory (Phase 5A). Preferred over
+   * the legacy single-class map.
+   */
+  lastClassIdsBySetId?: Record<string, string[]>;
 }
 
 // Union of all widget configs

--- a/types.ts
+++ b/types.ts
@@ -120,6 +120,27 @@ export interface ClassRosterMeta {
    * from prior days are auto-ignored without needing cleanup.
    */
   absent?: { date: string; studentIds: string[] };
+  /**
+   * Where the roster originated. Absent on legacy docs → treat as 'local'.
+   * Named `origin` (not `source`) to avoid collision with `ClassRoster.source`
+   * ('user' | 'testClass'), which describes storage location, not provenance.
+   */
+  origin?: 'classlink' | 'local';
+  /**
+   * ClassLink class `sourcedId`. Present iff the roster was imported or merged
+   * from a ClassLink class. Drives session `classIds[]` derivation so the
+   * student-side ClassLink SSO gate (firestore.rules `passesStudentClassGate`)
+   * resolves without the assignment layer having to know about ClassLink.
+   */
+  classlinkClassId?: string;
+  /** ClassLink class code (e.g. "MATH-7-P3"); rendered in the picker badge tooltip. */
+  classlinkClassCode?: string;
+  /** ClassLink subject label; used for reconciliation and teacher-visible filters. */
+  classlinkSubject?: string;
+  /** ClassLink tenant/organization ID; required to scope re-sync API calls. */
+  classlinkOrgId?: string;
+  /** Epoch ms of the last ClassLink import or merge for this roster. */
+  classlinkSyncedAt?: number;
 }
 
 /**
@@ -1242,12 +1263,17 @@ export interface MiniAppConfig {
   /** Persisted library grid/list toggle. */
   libraryViewMode?: 'grid' | 'list';
   /**
-   * Remembers the last ClassLink class selection the teacher made per app,
-   * keyed by appId. Used to pre-populate the target-class picker on
-   * subsequent assigns so teachers don't have to re-pick the same classes
-   * each time.
+   * @deprecated Pre-unification memory, written as ClassLink class
+   * `sourcedId`s. Read as a fallback (via `mapLegacyClassIdsToRosterIds`) to
+   * seed the picker only when `lastRosterIdsByAppId` is absent; never written
+   * by new code.
    */
   lastClassIdsByAppId?: Record<string, string[]>;
+  /**
+   * Remembers the last roster selection the teacher made per app, keyed by
+   * appId. Used to pre-populate the picker on subsequent assigns.
+   */
+  lastRosterIdsByAppId?: Record<string, string[]>;
   /**
    * Remembers the last submissions-enabled choice the teacher made per app,
    * keyed by appId. Used to pre-populate the toggle on subsequent assigns.
@@ -1278,6 +1304,12 @@ export interface MiniAppSession {
    * student across any of the selected classes.
    */
   classIds?: string[];
+  /**
+   * Roster IDs backing this session (new unified path). Derived from the
+   * teacher's picker selection; `classIds[]` above is derived from these
+   * rosters' `classlinkClassId` for the SSO gate. Absent on legacy sessions.
+   */
+  rosterIds?: string[];
   /**
    * Whether the sandboxed mini-app iframe should show its Submit button and
    * accept student submissions into the `submissions/` subcollection. Absent
@@ -1755,6 +1787,11 @@ export interface QuizSession {
    * no-op for non-studentRole users.
    */
   classIds?: string[];
+  /**
+   * Roster IDs backing this session (unified targeting). `classIds` above is
+   * derived from these rosters' `classlinkClassId` metadata.
+   */
+  rosterIds?: string[];
 }
 
 export interface QuizResponseAnswer {
@@ -1848,20 +1885,19 @@ export interface QuizConfig {
   /** Persisted library grid/list toggle. */
   libraryViewMode?: 'grid' | 'list';
   /**
-   * @deprecated Phase 5A — replaced by `lastClassIdsByQuizId` (multi-class).
-   * Retained for a transitional release so existing widget configs don't
-   * lose their pre-selection on first render. Readers prefer the multi-
-   * class map; fallback to this when the new key is absent.
+   * @deprecated Pre-Phase-5A single-class memory. Read-only fallback now.
    */
   lastClassIdByQuizId?: Record<string, string>;
   /**
-   * Per-quiz memory of the last ClassLink target classes (`sourcedId`s) the
-   * teacher picked in the Assign modal. Key is quizId, value is a list of
-   * ClassLink class sourcedIds. Used to pre-select the picker on re-launch
-   * of the same quiz so teachers don't have to re-pick every time. Missing
-   * keys mean "use the default (no classes selected)".
+   * @deprecated Phase 5A ClassLink-sourcedId map. Read-only fallback for
+   * pre-unification configs; new code writes `lastRosterIdsByQuizId`.
    */
   lastClassIdsByQuizId?: Record<string, string[]>;
+  /**
+   * Per-quiz memory of the last roster selection in the Assign modal.
+   * Pre-selects the picker on re-launch.
+   */
+  lastRosterIdsByQuizId?: Record<string, string[]>;
 }
 
 // --- QUIZ ASSIGNMENT TYPES ---
@@ -1912,6 +1948,9 @@ export interface QuizAssignment extends QuizAssignmentSettings {
   status: QuizAssignmentStatus;
   createdAt: number;
   updatedAt: number;
+  /** Unified roster targeting (new post-unification assignments). Legacy
+   *  assignments read via `periodNames` / session `classIds` only. */
+  rosterIds?: string[];
 }
 
 /**
@@ -1991,22 +2030,19 @@ export interface VideoActivityConfig {
   /** Persisted library grid/list toggle. */
   libraryViewMode?: 'grid' | 'list';
   /**
-   * Per-activity memory of the last ClassLink target class (`sourcedId`) the
-   * teacher picked in the Assign modal. Key is activityId, value is the
-   * ClassLink class sourcedId. Used to pre-select the selector on re-launch
-   * of the same activity so teachers don't have to re-pick every time.
-   * Undefined means "use the default (No class)".
-   *
-   * @deprecated Phase 5A — replaced by `lastClassIdsByActivityId` (multi).
-   * Retained for a transitional release so existing widget configs don't
-   * lose their pre-selection on first render.
+   * @deprecated Pre-Phase-5A single-class memory. Read-only fallback now.
    */
   lastClassIdByActivityId?: Record<string, string>;
   /**
-   * Multi-class variant of the per-activity memory (Phase 5A). Preferred
-   * over the legacy single-class map.
+   * @deprecated Phase 5A ClassLink-sourcedId map. Read-only fallback for
+   * pre-unification configs; new code writes `lastRosterIdsByActivityId`.
    */
   lastClassIdsByActivityId?: Record<string, string[]>;
+  /**
+   * Per-activity memory of the last roster selection in the Assign modal.
+   * Pre-selects the picker on re-launch.
+   */
+  lastRosterIdsByActivityId?: Record<string, string[]>;
 }
 
 export interface VideoActivitySessionSettings {
@@ -2071,6 +2107,11 @@ export interface VideoActivitySession {
    * the response's `classPeriod` field. Mirrors the QuizSession pattern.
    */
   periodNames?: string[];
+  /**
+   * Roster IDs backing this session (unified targeting). `classIds` above is
+   * derived from these rosters' `classlinkClassId` metadata.
+   */
+  rosterIds?: string[];
 }
 
 /** A single answer submitted by a student for a video activity question. */
@@ -2698,6 +2739,11 @@ export interface GuidedLearningSession {
    * the response's `classPeriod` field. Mirrors the QuizSession pattern.
    */
   periodNames?: string[];
+  /**
+   * Roster IDs backing this session (unified targeting). `classIds` above is
+   * derived from these rosters' `classlinkClassId` metadata.
+   */
+  rosterIds?: string[];
 }
 
 /** Per-student response in /guided_learning_sessions/{id}/responses/{studentUid} */
@@ -2731,22 +2777,19 @@ export interface GuidedLearningConfig {
   /** Persisted library grid/list toggle. */
   libraryViewMode?: 'grid' | 'list';
   /**
-   * Per-set memory of the last ClassLink target class (`sourcedId`) the
-   * teacher picked in the Assign dialog. Key is the Guided Learning set id,
-   * value is the ClassLink class sourcedId. Used to pre-select the selector
-   * on re-launch of the same set so teachers don't have to re-pick every
-   * time. Undefined means "use the default (No class)".
-   *
-   * @deprecated Phase 5A — replaced by `lastClassIdsBySetId` (multi).
-   * Retained for a transitional release so existing widget configs don't
-   * lose their pre-selection on first render.
+   * @deprecated Pre-Phase-5A single-class memory. Read-only fallback now.
    */
   lastClassIdBySetId?: Record<string, string>;
   /**
-   * Multi-class variant of the per-set memory (Phase 5A). Preferred over
-   * the legacy single-class map.
+   * @deprecated Phase 5A ClassLink-sourcedId map. Read-only fallback for
+   * pre-unification configs; new code writes `lastRosterIdsBySetId`.
    */
   lastClassIdsBySetId?: Record<string, string[]>;
+  /**
+   * Per-set memory of the last roster selection in the Assign dialog.
+   * Pre-selects the picker on re-launch.
+   */
+  lastRosterIdsBySetId?: Record<string, string[]>;
 }
 
 // Union of all widget configs
@@ -3763,6 +3806,10 @@ export interface VideoActivityAssignment extends VideoActivityAssignmentSettings
   status: VideoActivityAssignmentStatus;
   createdAt: number;
   updatedAt: number;
+  /** Unified roster targeting. New (post-unification) assignments write this;
+   *  legacy assignments read via `className` / session.classIds only. See
+   *  `utils/resolveAssignmentTargets.ts`. */
+  rosterIds?: string[];
 }
 
 // === MiniApp assignments ===
@@ -3791,9 +3838,17 @@ export interface MiniAppAssignment {
   status: 'active' | 'inactive';
   createdAt: number;
   updatedAt: number;
-  /** Mirrors `MiniAppSession.classIds`. Present when assigned via the
-   * class-targeted picker; absent (or empty) for shareable-link launches. */
-  classIds?: string[];
+  /** Unified roster targeting. Present on new (post-unification) assignments.
+   *
+   *  The student SSO gate lives on the session doc (`MiniAppSession.classIds`,
+   *  derived at assign time from these rosters' `classlinkClassId`); the
+   *  assignment doc intentionally does NOT mirror `classIds`, matching the
+   *  Quiz / VideoActivity / GuidedLearning assignment shapes.
+   *
+   *  Legacy pre-unification assignments may have no targeting fields at all
+   *  and read their targeting via the paired session doc. See
+   *  `utils/resolveAssignmentTargets.ts`. */
+  rosterIds?: string[];
   /** Mirrors `MiniAppSession.submissionsEnabled`. When true, the runner
    * reveals the Submit button and persists student submissions. */
   submissionsEnabled?: boolean;
@@ -3830,6 +3885,8 @@ export interface GuidedLearningAssignment {
   archivedAt?: number | null;
   /** Optional origin set: 'personal' (Drive) or 'building' (Firestore). */
   source?: 'personal' | 'building';
+  /** Unified roster targeting (new post-unification assignments). */
+  rosterIds?: string[];
 }
 
 // === Library folders (Wave 3) ===

--- a/utils/resolveAssignmentTargets.ts
+++ b/utils/resolveAssignmentTargets.ts
@@ -1,0 +1,202 @@
+/**
+ * Dual-read helper for unified class targeting on assignments.
+ *
+ * Context: assignment documents historically stored ClassLink sourcedIds under
+ * `classIds[]` (ClassLink-only) or local roster names under `periodNames[]`
+ * (local-only). After the roster-as-single-source-of-truth unification,
+ * new assignments write `rosterIds[]` — rosters imported from ClassLink carry
+ * their own `classlinkClassId` metadata so the student SSO gate still works.
+ *
+ * Legacy in-flight assignments are NOT migrated; they continue reading via
+ * their existing `classIds`/`periodNames` fields until they expire.
+ *
+ * Precedence:
+ *   1. `rosterIds`   → resolve via rosters, derive everything fresh.
+ *   2. `classIds`    → legacy ClassLink targeting (SSO claim match).
+ *   3. `periodNames` → legacy local-roster targeting (name match).
+ *   4. none          → untargeted (code/PIN-only join).
+ */
+
+import type { ClassRoster, Student } from '@/types';
+
+/** Minimal shape of any assignment doc's class-targeting fields. */
+export interface AssignmentTargetInput {
+  rosterIds?: string[];
+  classIds?: string[];
+  periodNames?: string[];
+}
+
+export interface ResolvedAssignmentTargets {
+  /** Roster IDs backing this assignment (empty for legacy docs). */
+  rosterIds: string[];
+  /**
+   * ClassLink `sourcedId`s to write onto the session doc for the student
+   * SSO gate. Empty when no selected roster has `classlinkClassId` (purely
+   * local targeting — SSO students get blocked, PIN students still pass).
+   */
+  classIds: string[];
+  /** Period names (local roster names) for PIN-flow routing. */
+  periodNames: string[];
+  /** Union of students across all targeted rosters (new path only). */
+  students: Student[];
+  /**
+   * Which branch resolved the targets. Useful for telemetry / debug logs so
+   * we can tell when the legacy paths stop being hit and the code can retire.
+   */
+  source: 'rosterIds' | 'classIds' | 'periodNames' | 'none';
+}
+
+/**
+ * Core "rosters → session shape" derivation shared by
+ * `resolveAssignmentTargets` (lookup-then-derive) and
+ * `deriveSessionTargetsFromRosters` (already-resolved rosters). Centralizing
+ * the logic guarantees the two paths stay in lock-step on de-duplication
+ * rules and makes the cap on Firestore's `array-contains-any` budget a
+ * single-source-of-truth concern.
+ *
+ * Dedup rationale:
+ * - `classIds`: two rosters can share the same `classlinkClassId` (teacher
+ *   imported the same ClassLink class twice under different local names);
+ *   we'd otherwise waste the Firestore rules' 20-entry budget.
+ * - `students`: a student enrolled in two targeted classes shouldn't appear
+ *   twice in the session student list.
+ * - `periodNames`: two local rosters can share a name; the student app keys
+ *   its post-PIN period picker on the string, so duplicates collide on
+ *   React keys.
+ */
+function deriveTargetsFromRosterList(rosters: ClassRoster[]): {
+  rosterIds: string[];
+  classIds: string[];
+  periodNames: string[];
+  students: Student[];
+} {
+  const classIds = Array.from(
+    new Set(
+      rosters
+        .map((r) => r.classlinkClassId)
+        .filter((id): id is string => typeof id === 'string' && id.length > 0)
+    )
+  );
+
+  const studentsById = new Map<string, Student>();
+  for (const r of rosters) {
+    for (const s of r.students) {
+      if (!studentsById.has(s.id)) studentsById.set(s.id, s);
+    }
+  }
+
+  return {
+    rosterIds: rosters.map((r) => r.id),
+    classIds,
+    periodNames: Array.from(new Set(rosters.map((r) => r.name))),
+    students: Array.from(studentsById.values()),
+  };
+}
+
+/**
+ * Resolve an assignment's class targets against the current rosters list.
+ * Never throws — unknown roster IDs or missing legacy fields simply drop
+ * through to the next precedence level or to the untargeted result.
+ */
+export function resolveAssignmentTargets(
+  assignment: AssignmentTargetInput,
+  rosters: ClassRoster[]
+): ResolvedAssignmentTargets {
+  // 1. New path: rosterIds on the assignment doc.
+  if (assignment.rosterIds && assignment.rosterIds.length > 0) {
+    const byId = new Map(rosters.map((r) => [r.id, r]));
+    const matched = assignment.rosterIds
+      .map((id) => byId.get(id))
+      .filter((r): r is ClassRoster => r !== undefined);
+
+    return { ...deriveTargetsFromRosterList(matched), source: 'rosterIds' };
+  }
+
+  // 2. Legacy ClassLink path.
+  if (assignment.classIds && assignment.classIds.length > 0) {
+    return {
+      rosterIds: [],
+      classIds: [...assignment.classIds],
+      periodNames: [],
+      students: [],
+      source: 'classIds',
+    };
+  }
+
+  // 3. Legacy local path.
+  if (assignment.periodNames && assignment.periodNames.length > 0) {
+    return {
+      rosterIds: [],
+      classIds: [],
+      periodNames: [...assignment.periodNames],
+      students: [],
+      source: 'periodNames',
+    };
+  }
+
+  // 4. Untargeted.
+  return {
+    rosterIds: [],
+    classIds: [],
+    periodNames: [],
+    students: [],
+    source: 'none',
+  };
+}
+
+/**
+ * Map legacy ClassLink `sourcedId`s (from pre-unification per-app config keys
+ * like `lastClassIdsByQuizId`) to rosterIds by matching against the current
+ * rosters' `classlinkClassId` metadata. Used to seed the picker default for
+ * teachers whose configs predate the unified `lastRosterIdsBy*` keys.
+ *
+ * Partial matches are returned — if the teacher had three legacy sourcedIds
+ * but only re-imported two of them, the other one is silently dropped rather
+ * than refusing the preselection wholesale (better UX than all-or-nothing).
+ *
+ * Tie-break: if two rosters share the same `classlinkClassId` (teacher
+ * imported the same ClassLink class twice), the first one wins — which is
+ * stable per Firestore's default name-ordered roster stream.
+ *
+ * Returns an empty array when the teacher hasn't (re-)imported the ClassLink
+ * class at all — we can't recover a preselection that no longer has a roster.
+ */
+export function mapLegacyClassIdsToRosterIds(
+  legacyClassIds: string[] | undefined,
+  rosters: ClassRoster[]
+): string[] {
+  if (!legacyClassIds || legacyClassIds.length === 0) return [];
+  // First-wins: earlier rosters in the array win the mapping. Rosters are
+  // typically streamed name-ordered from Firestore, so this is stable.
+  const rosterByClassLinkId = new Map<string, string>();
+  for (const r of rosters) {
+    if (r.classlinkClassId && !rosterByClassLinkId.has(r.classlinkClassId)) {
+      rosterByClassLinkId.set(r.classlinkClassId, r.id);
+    }
+  }
+  const mapped: string[] = [];
+  const seen = new Set<string>();
+  for (const cid of legacyClassIds) {
+    const rosterId = rosterByClassLinkId.get(cid);
+    if (rosterId && !seen.has(rosterId)) {
+      mapped.push(rosterId);
+      seen.add(rosterId);
+    }
+  }
+  return mapped;
+}
+
+/**
+ * Convenience: given selected rosters (e.g., from the picker at assignment-
+ * create time), derive the fields a session doc needs. Mirrors the
+ * `rosterIds` branch of `resolveAssignmentTargets` but skips the lookup step
+ * since the caller already holds the full roster objects.
+ */
+export function deriveSessionTargetsFromRosters(
+  rosters: ClassRoster[]
+): Pick<
+  ResolvedAssignmentTargets,
+  'rosterIds' | 'classIds' | 'periodNames' | 'students'
+> {
+  return deriveTargetsFromRosterList(rosters);
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -14,10 +14,12 @@ export default mergeConfig(
       exclude: [
         ...configDefaults.exclude,
         'tests/e2e/**',
-        // Firestore rules tests need the Firestore emulator; they run via
-        // the `test:rules` script under `firebase emulators:exec`. Excluded
-        // from the default vitest run so `pnpm test` / CI stays green
-        // without an emulator.
+        // Firestore rules tests need the Firestore emulator. Excluded from
+        // the default vitest run (`pnpm test`) so a dev doesn't need Java
+        // installed locally; they run via `pnpm test:rules` (which wraps
+        // them in `firebase emulators:exec --only firestore`). CI runs
+        // them as a dedicated job — see `.github/workflows/pr-validation.yml`
+        // (the `rules` job).
         'tests/rules/**',
         'functions/**',
         '.claude/worktrees/**',


### PR DESCRIPTION
## Summary

Six commits on dev-paul, covering the rules-hardening stack, the unified Quiz/VA/GL class picker, ClassLink roster unification, and today's test-student regression fix.

### Commits (chronological)

1. [#1390](https://github.com/OPS-PIvers/SpartBoard/pull/1390) — split `quiz_sessions` rule into `get`/`list` to unbreak teacher assignment creation after the studentRole gate was added.
2. [#1391](https://github.com/OPS-PIvers/SpartBoard/pull/1391) — drop `resource.data` gate from session `get` so teacher single-doc subscriptions don't deny after a paused→active transition.
3. [#1395](https://github.com/OPS-PIvers/SpartBoard/pull/1395) — guard `isStudentRoleUser()` (and `isAdmin()`) with `.get(key, default)` so rules don't throw "Property studentRole is undefined" on bare anon PIN tokens.
4. [#1397](https://github.com/OPS-PIvers/SpartBoard/pull/1397) — unified `AssignClassPicker` across Quiz / VA / GL (Phase 5A multi-class targeting), dual-write `classIds` + legacy `classId`, new composite indexes for `classIds array-contains + status`, `MyAssignmentsPage` widened to `['waiting','active']`.
5. [#1398](https://github.com/OPS-PIvers/SpartBoard/pull/1398) — unify ClassLink-imported classes with local rosters so all targeting flows through the same `resolveAssignmentTargets` precedence (`rosterIds → classIds → periodNames → none`).
6. [#1400](https://github.com/OPS-PIvers/SpartBoard/pull/1400) — open untargeted sessions to studentRole joiners. Mirrors the untargeted-open branch from `passesStudentClassGateList` onto the single-class `passesStudentClassGate`. Unblocks super-admin test-class bypass + real SSO students PIN-joining untargeted quizzes.

### Risk surface

- **Firestore rules** — four rule-change PRs (#1390, #1391, #1395, #1397's compat helper, #1400). Each was deployed to dev-paul on its own merge via the `firebase-dev-deploy.yml` workflow (`--only functions,firestore,storage`) and survived on the live ruleset since. Primary pilot path (ClassLink teacher + ClassLink-targeted quiz + ClassLink-provisioned student) verified working.
- **Student assignment discovery** — #1397 added four composite indexes. Must confirm all four are Enabled on prod before this merges, otherwise `MyAssignmentsPage` will silently empty the list for SSO students (the exact regression #1397 fixed on dev).
- **No data migration needed.** Phase 5A is dual-write; pre-Phase-5A sessions (legacy single `classId`) still gate correctly via the compat helper.

## Test plan

- [ ] Confirm the four composite indexes added in #1397 (`classIds array-contains + status`, `classId + status` for quiz_sessions and video_activity_sessions) are Enabled on the prod project before merge.
- [ ] Post-merge: verify ClassLink-targeted quiz session creation + teacher Start flow on prod.
- [ ] Post-merge: verify anon PIN join on prod.
- [ ] Post-merge: verify SSO student PIN join against a ClassLink-targeted quiz on prod.
- [ ] Post-merge: verify `/my-assignments` surfaces ClassLink-targeted quiz/VA/GL for an SSO student on prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)