### PR TITLE
fix(dock): unbreak widget library after stale-closure desync

### DIFF
--- a/components/layout/dock/WidgetLibrary.tsx
+++ b/components/layout/dock/WidgetLibrary.tsx
@@ -212,36 +212,39 @@ export const WidgetLibrary = forwardRef<HTMLDivElement, WidgetLibraryProps>(
       [effectiveOrder, onReorderLibrary]
     );
 
+    // Tools the user could add given their role + building — NOT accounting
+    // for what's already in the dock. Used to distinguish "your buildings
+    // match nothing" from "everything that matches is already in your dock"
+    // in the empty state, which otherwise always blamed the building filter.
+    const buildingAccessibleTools = useMemo(() => {
+      return effectiveOrder
+        .map((type) => TOOLS_MAP.get(type))
+        .filter((tool): tool is (typeof TOOLS)[0] => {
+          if (!tool) return false;
+          if (!canAccess(tool.type)) return false;
+          if (
+            !isEditMode &&
+            matchesUserBuilding &&
+            !matchesUserBuilding(tool.type)
+          )
+            return false;
+          return true;
+        });
+    }, [effectiveOrder, canAccess, isEditMode, matchesUserBuilding]);
+
     // Filter tools: must be accessible AND NOT already in the dock,
     // and in normal mode must match the user's selected buildings
     const availableTools = useMemo(() => {
       const visibleToolsSet = new Set(visibleTools);
-      return (
-        effectiveOrder
-          // Replaced TOOLS.find with TOOLS_MAP.get to eliminate O(N^2) complexity in rendering loop.
-          .map((type) => TOOLS_MAP.get(type))
-          .filter((tool): tool is (typeof TOOLS)[0] => {
-            if (!tool) return false;
-            if (!canAccess(tool.type)) return false;
-            // Hide if already in the dock
-            if (visibleToolsSet.has(tool.type)) return false;
-            // In normal (non-edit) mode, apply building-based grade-level filter
-            if (
-              !isEditMode &&
-              matchesUserBuilding &&
-              !matchesUserBuilding(tool.type)
-            )
-              return false;
-            return true;
-          })
+      return buildingAccessibleTools.filter(
+        (tool) => !visibleToolsSet.has(tool.type)
       );
-    }, [
-      effectiveOrder,
-      visibleTools,
-      canAccess,
-      isEditMode,
-      matchesUserBuilding,
-    ]);
+    }, [buildingAccessibleTools, visibleTools]);
+
+    const emptyStateMessage =
+      buildingAccessibleTools.length === 0
+        ? 'No widgets available for your buildings'
+        : 'All widgets are in your dock';
 
     return createPortal(
       <div className="fixed inset-0 z-modal flex items-center justify-center p-4 animate-in fade-in duration-200 pointer-events-none">
@@ -344,9 +347,7 @@ export const WidgetLibrary = forwardRef<HTMLDivElement, WidgetLibraryProps>(
               <div className="flex flex-col items-center justify-center py-12 text-center opacity-40">
                 <LayoutGrid className="w-12 h-12 mb-4 text-slate-400" />
                 <p className="text-sm font-black uppercase tracking-widest text-slate-600">
-                  {isEditMode
-                    ? 'All widgets are in your dock'
-                    : 'No widgets available for your buildings'}
+                  {emptyStateMessage}
                 </p>
               </div>
             )}
@@ -357,9 +358,7 @@ export const WidgetLibrary = forwardRef<HTMLDivElement, WidgetLibraryProps>(
                 ? isEditMode
                   ? 'Drag to reorder • Tap to add to dock'
                   : 'Drag to reorder • Tap to add to board'
-                : isEditMode
-                  ? 'All widgets are in your dock'
-                  : 'No widgets available for your selected buildings'}
+                : emptyStateMessage}
             </p>
 
             <button

--- a/components/layout/dock/WidgetLibrary.tsx
+++ b/components/layout/dock/WidgetLibrary.tsx
@@ -241,10 +241,17 @@ export const WidgetLibrary = forwardRef<HTMLDivElement, WidgetLibraryProps>(
       );
     }, [buildingAccessibleTools, visibleTools]);
 
+    // "Built-in" qualifier matters because custom widgets render in their
+    // own section above and aren't counted here — without it, the message
+    // reads as a lie whenever there are still custom widgets to add.
+    // Edit mode bypasses the building filter entirely, so wording has to
+    // fork on isEditMode as well.
     const emptyStateMessage =
       buildingAccessibleTools.length === 0
-        ? 'No widgets available for your buildings'
-        : 'All widgets are in your dock';
+        ? isEditMode
+          ? 'No built-in widgets available with your current access'
+          : 'No built-in widgets available for your selected buildings'
+        : 'All built-in widgets are in your dock';
 
     return createPortal(
       <div className="fixed inset-0 z-modal flex items-center justify-center p-4 animate-in fade-in duration-200 pointer-events-none">

--- a/context/DashboardContext.tsx
+++ b/context/DashboardContext.tsx
@@ -1474,11 +1474,20 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
         return next;
       });
 
+      // Derive add vs remove from `prev` (dockItems) itself, not from the
+      // outer `visibleTools` closure. Reading the closure desyncs the two
+      // stores when React batches a previous setVisibleTools update that
+      // hasn't flushed yet — the library then filters using a visibleTools
+      // that no longer matches dockItems.
       setDockItems((prev) => {
-        const isVisible = visibleTools.includes(type);
+        const exists = prev.some(
+          (item) =>
+            (item.type === 'tool' && item.toolType === type) ||
+            (item.type === 'folder' && item.folder.items.includes(type))
+        );
         let next: DockItem[];
 
-        if (isVisible) {
+        if (exists) {
           // Remove from dockItems (search globally in tools and folders)
           next = prev
             .map((item) => {
@@ -1497,20 +1506,14 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
               (item) => !(item.type === 'tool' && item.toolType === type)
             );
         } else {
-          // Add to dockItems (if not already present)
-          const exists = prev.some(
-            (item) =>
-              (item.type === 'tool' && item.toolType === type) ||
-              (item.type === 'folder' && item.folder.items.includes(type))
-          );
-          next = exists ? prev : [...prev, { type: 'tool', toolType: type }];
+          next = [...prev, { type: 'tool', toolType: type }];
         }
 
         localStorage.setItem('classroom_dock_items', JSON.stringify(next));
         return next;
       });
     },
-    [visibleTools]
+    []
   );
 
   const setAllToolsVisibility = useCallback((visible: boolean) => {


### PR DESCRIPTION
## Summary

- `toggleToolVisibility` in `DashboardContext` read `visibleTools` from the outer closure inside its `setDockItems` updater. Under React batching, that value can lag behind the `setVisibleTools` update queued one line above, so a toggle would decide add-vs-remove against a stale snapshot and leave `visibleTools` and `dockItems` pointing at different sets. The library filters by `visibleTools`, so when they desync the library can hide every widget that's actually in the dock — which is what Tatum hit: two widgets on her dock, but the library said "no widgets available for your building." Fix: derive add-vs-remove from `prev` (the dockItems snapshot) inside the updater, and drop `visibleTools` from the deps.
- Library empty-state copy now distinguishes "nothing matches your building" from "everything that matches is already in your dock." The old message always blamed the building filter in non-edit mode, which masked exactly this kind of desync and made the bug invisible from the UI.

## Test plan

- [ ] Open the widget library with zero widgets in the dock — see widgets for your building.
- [ ] Add several widgets, reopen library — remaining widgets still visible; copy reads "All widgets are in your dock" only when every building-matching widget is in the dock.
- [ ] Rapid-toggle the same widget — `visibleTools` and `dockItems` stay in sync (dock renders match library state).
- [ ] Log in as a user whose building matches no widgets — empty state reads "No widgets available for your buildings."

🤖 Generated with [Claude Code](https://claude.com/claude-code)