### PR TITLE
fix(graphic-organizer): convert hardcoded padding to cqmin scaling

### DIFF
--- a/components/widgets/GraphicOrganizer/Widget.tsx
+++ b/components/widgets/GraphicOrganizer/Widget.tsx
@@ -131,8 +131,11 @@ export const GraphicOrganizerWidget: React.FC<{ widget: WidgetData }> = ({
   const renderFrayer = () => (
     <div className="grid grid-cols-2 grid-rows-2 h-full gap-2 p-2 relative">
       <div
-        className="border-2 border-slate-300 rounded p-4 relative"
-        style={{ backgroundColor: cellBg }}
+        className="border-2 border-slate-300 rounded relative"
+        style={{
+          backgroundColor: cellBg,
+          padding: 'min(16px, 3cqmin)',
+        }}
       >
         <div
           className="absolute top-2 left-2 font-bold text-slate-500 uppercase"
@@ -149,8 +152,11 @@ export const GraphicOrganizerWidget: React.FC<{ widget: WidgetData }> = ({
         />
       </div>
       <div
-        className="border-2 border-slate-300 rounded p-4 relative"
-        style={{ backgroundColor: cellBg }}
+        className="border-2 border-slate-300 rounded relative"
+        style={{
+          backgroundColor: cellBg,
+          padding: 'min(16px, 3cqmin)',
+        }}
       >
         <div
           className="absolute top-2 left-2 font-bold text-slate-500 uppercase"
@@ -167,8 +173,11 @@ export const GraphicOrganizerWidget: React.FC<{ widget: WidgetData }> = ({
         />
       </div>
       <div
-        className="border-2 border-slate-300 rounded p-4 relative"
-        style={{ backgroundColor: cellBg }}
+        className="border-2 border-slate-300 rounded relative"
+        style={{
+          backgroundColor: cellBg,
+          padding: 'min(16px, 3cqmin)',
+        }}
       >
         <div
           className="absolute top-2 left-2 font-bold text-slate-500 uppercase"
@@ -185,8 +194,11 @@ export const GraphicOrganizerWidget: React.FC<{ widget: WidgetData }> = ({
         />
       </div>
       <div
-        className="border-2 border-slate-300 rounded p-4 relative"
-        style={{ backgroundColor: cellBg }}
+        className="border-2 border-slate-300 rounded relative"
+        style={{
+          backgroundColor: cellBg,
+          padding: 'min(16px, 3cqmin)',
+        }}
       >
         <div
           className="absolute top-2 left-2 font-bold text-slate-500 uppercase"
@@ -202,7 +214,14 @@ export const GraphicOrganizerWidget: React.FC<{ widget: WidgetData }> = ({
           placeholder={`Type ${selectedTemplate?.defaultNodes?.bottomRight ?? 'non-examples'}...`}
         />
       </div>
-      <div className="absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 bg-indigo-100 border-4 border-indigo-300 rounded-full w-32 h-32 flex items-center justify-center p-4 shadow-lg text-center z-10">
+      <div
+        className="absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 bg-indigo-100 border-4 border-indigo-300 rounded-full flex items-center justify-center shadow-lg text-center z-10"
+        style={{
+          width: 'min(128px, 22cqmin)',
+          height: 'min(128px, 22cqmin)',
+          padding: 'min(16px, 3cqmin)',
+        }}
+      >
         <EditableNode
           id="center"
           initialText={nodes['center']?.text ?? ''}
@@ -216,15 +235,26 @@ export const GraphicOrganizerWidget: React.FC<{ widget: WidgetData }> = ({
 
   const renderTChart = () => (
     <div
-      className="grid grid-cols-2 h-full gap-0 p-4 relative"
-      style={{ backgroundColor: cellBg }}
+      className="grid grid-cols-2 h-full gap-0 relative"
+      style={{
+        backgroundColor: cellBg,
+        padding: 'min(16px, 3cqmin)',
+      }}
     >
-      <div className="border-r-4 border-slate-400 p-4">
+      <div
+        className="border-r-4 border-slate-400"
+        style={{ padding: 'min(16px, 3cqmin)' }}
+      >
         <EditableNode
           id="left-header"
           initialText={nodes['left-header']?.text ?? ''}
           onUpdate={handleUpdate}
-          className="font-bold text-center border-b-4 border-slate-400 pb-2 mb-4 text-xl"
+          className="font-bold text-center border-b-4 border-slate-400"
+          style={{
+            fontSize: 'min(20px, 7cqmin)',
+            paddingBottom: 'min(8px, 2cqmin)',
+            marginBottom: 'min(16px, 3cqmin)',
+          }}
           placeholder={selectedTemplate?.defaultNodes?.leftHeader ?? 'Pros'}
         />
         <EditableNode
@@ -237,12 +267,17 @@ export const GraphicOrganizerWidget: React.FC<{ widget: WidgetData }> = ({
           }
         />
       </div>
-      <div className="p-4">
+      <div style={{ padding: 'min(16px, 3cqmin)' }}>
         <EditableNode
           id="right-header"
           initialText={nodes['right-header']?.text ?? ''}
           onUpdate={handleUpdate}
-          className="font-bold text-center border-b-4 border-slate-400 pb-2 mb-4 text-xl"
+          className="font-bold text-center border-b-4 border-slate-400"
+          style={{
+            fontSize: 'min(20px, 7cqmin)',
+            paddingBottom: 'min(8px, 2cqmin)',
+            marginBottom: 'min(16px, 3cqmin)',
+          }}
           placeholder={selectedTemplate?.defaultNodes?.rightHeader ?? 'Cons'}
         />
         <EditableNode
@@ -260,14 +295,20 @@ export const GraphicOrganizerWidget: React.FC<{ widget: WidgetData }> = ({
 
   const renderVenn = () => (
     <div
-      className="flex h-full items-center justify-center relative overflow-hidden p-4"
-      style={{ backgroundColor: cellBg }}
+      className="flex h-full items-center justify-center relative overflow-hidden"
+      style={{
+        backgroundColor: cellBg,
+        padding: 'min(16px, 3cqmin)',
+      }}
     >
       <div className="absolute w-[60%] h-[80%] left-[10%] border-4 border-blue-400 rounded-full opacity-30 bg-blue-100" />
       <div className="absolute w-[60%] h-[80%] right-[10%] border-4 border-green-400 rounded-full opacity-30 bg-green-100" />
 
       <div className="flex w-full h-[60%] z-10 text-center">
-        <div className="w-[35%] p-4 flex flex-col justify-center">
+        <div
+          className="w-[35%] flex flex-col justify-center"
+          style={{ padding: 'min(16px, 3cqmin)' }}
+        >
           <EditableNode
             id="left-header"
             initialText={nodes['left-header']?.text ?? ''}
@@ -285,7 +326,10 @@ export const GraphicOrganizerWidget: React.FC<{ widget: WidgetData }> = ({
             placeholder="Unique to A"
           />
         </div>
-        <div className="w-[30%] p-4 flex flex-col justify-center border-x-2 border-dashed border-slate-300">
+        <div
+          className="w-[30%] flex flex-col justify-center border-x-2 border-dashed border-slate-300"
+          style={{ padding: 'min(16px, 3cqmin)' }}
+        >
           <EditableNode
             id="center-header"
             initialText={nodes['center-header']?.text ?? ''}
@@ -301,7 +345,10 @@ export const GraphicOrganizerWidget: React.FC<{ widget: WidgetData }> = ({
             placeholder="Shared"
           />
         </div>
-        <div className="w-[35%] p-4 flex flex-col justify-center">
+        <div
+          className="w-[35%] flex flex-col justify-center"
+          style={{ padding: 'min(16px, 3cqmin)' }}
+        >
           <EditableNode
             id="right-header"
             initialText={nodes['right-header']?.text ?? ''}
@@ -329,7 +376,10 @@ export const GraphicOrganizerWidget: React.FC<{ widget: WidgetData }> = ({
       style={{ backgroundColor: cellBg }}
     >
       <div className="border-r-2 border-slate-300 flex flex-col h-full">
-        <div className="bg-blue-100 p-3 text-center border-b-2 border-slate-300">
+        <div
+          className="bg-blue-100 text-center border-b-2 border-slate-300"
+          style={{ padding: 'min(12px, 3cqmin)' }}
+        >
           <div
             className="font-black text-blue-800"
             style={{ fontSize: 'min(30px, 12cqmin)' }}
@@ -347,12 +397,16 @@ export const GraphicOrganizerWidget: React.FC<{ widget: WidgetData }> = ({
           id="know"
           initialText={nodes['know']?.text ?? ''}
           onUpdate={handleUpdate}
-          className="p-4 flex-grow h-full"
+          className="flex-grow h-full"
+          style={{ padding: 'min(16px, 3cqmin)' }}
           placeholder="Type here..."
         />
       </div>
       <div className="border-r-2 border-slate-300 flex flex-col h-full">
-        <div className="bg-amber-100 p-3 text-center border-b-2 border-slate-300">
+        <div
+          className="bg-amber-100 text-center border-b-2 border-slate-300"
+          style={{ padding: 'min(12px, 3cqmin)' }}
+        >
           <div
             className="font-black text-amber-800"
             style={{ fontSize: 'min(30px, 12cqmin)' }}
@@ -370,12 +424,16 @@ export const GraphicOrganizerWidget: React.FC<{ widget: WidgetData }> = ({
           id="wonder"
           initialText={nodes['wonder']?.text ?? ''}
           onUpdate={handleUpdate}
-          className="p-4 flex-grow h-full"
+          className="flex-grow h-full"
+          style={{ padding: 'min(16px, 3cqmin)' }}
           placeholder="Type here..."
         />
       </div>
       <div className="flex flex-col h-full">
-        <div className="bg-green-100 p-3 text-center border-b-2 border-slate-300">
+        <div
+          className="bg-green-100 text-center border-b-2 border-slate-300"
+          style={{ padding: 'min(12px, 3cqmin)' }}
+        >
           <div
             className="font-black text-green-800"
             style={{ fontSize: 'min(30px, 12cqmin)' }}
@@ -393,7 +451,8 @@ export const GraphicOrganizerWidget: React.FC<{ widget: WidgetData }> = ({
           id="learn"
           initialText={nodes['learn']?.text ?? ''}
           onUpdate={handleUpdate}
-          className="p-4 flex-grow h-full"
+          className="flex-grow h-full"
+          style={{ padding: 'min(16px, 3cqmin)' }}
           placeholder="Type here..."
         />
       </div>
@@ -402,8 +461,11 @@ export const GraphicOrganizerWidget: React.FC<{ widget: WidgetData }> = ({
 
   const renderCauseEffect = () => (
     <div
-      className="flex items-center justify-center h-full p-6 gap-4"
-      style={{ backgroundColor: cellBg }}
+      className="flex items-center justify-center h-full gap-4"
+      style={{
+        backgroundColor: cellBg,
+        padding: 'min(24px, 5cqmin)',
+      }}
     >
       <div
         className="flex-1 border-2 border-rose-300 rounded-lg shadow-sm h-full flex flex-col"
@@ -416,7 +478,8 @@ export const GraphicOrganizerWidget: React.FC<{ widget: WidgetData }> = ({
           id="cause"
           initialText={nodes['cause']?.text ?? ''}
           onUpdate={handleUpdate}
-          className="p-4 flex-grow"
+          className="flex-grow"
+          style={{ padding: 'min(16px, 3cqmin)' }}
           placeholder={
             selectedTemplate?.defaultNodes?.cause1 ?? 'Why it happened...'
           }
@@ -450,7 +513,8 @@ export const GraphicOrganizerWidget: React.FC<{ widget: WidgetData }> = ({
           id="effect"
           initialText={nodes['effect']?.text ?? ''}
           onUpdate={handleUpdate}
-          className="p-4 flex-grow"
+          className="flex-grow"
+          style={{ padding: 'min(16px, 3cqmin)' }}
           placeholder={
             selectedTemplate?.defaultNodes?.effect ?? 'What happened...'
           }

--- a/components/widgets/GraphicOrganizer/Widget.tsx
+++ b/components/widgets/GraphicOrganizer/Widget.tsx
@@ -461,16 +461,14 @@ export const GraphicOrganizerWidget: React.FC<{ widget: WidgetData }> = ({
 
   const renderCauseEffect = () => (
     <div
-      className="flex items-center justify-center h-full gap-4"
+      className="flex items-center justify-center h-full"
       style={{
         backgroundColor: cellBg,
         padding: 'min(24px, 5cqmin)',
+        gap: 'min(16px, 3.5cqmin)',
       }}
     >
-      <div
-        className="flex-1 border-2 border-rose-300 rounded-lg shadow-sm h-full flex flex-col"
-        style={{ backgroundColor: cellBg }}
-      >
+      <div className="flex-1 border-2 border-rose-300 rounded-lg shadow-sm h-full flex flex-col">
         <div className="bg-rose-100 p-2 text-center rounded-t-md border-b-2 border-rose-300 font-bold text-rose-800 uppercase tracking-wider">
           Cause
         </div>
@@ -502,10 +500,7 @@ export const GraphicOrganizerWidget: React.FC<{ widget: WidgetData }> = ({
         </svg>
       </div>
 
-      <div
-        className="flex-1 border-2 border-emerald-300 rounded-lg shadow-sm h-full flex flex-col"
-        style={{ backgroundColor: cellBg }}
-      >
+      <div className="flex-1 border-2 border-emerald-300 rounded-lg shadow-sm h-full flex flex-col">
         <div className="bg-emerald-100 p-2 text-center rounded-t-md border-b-2 border-emerald-300 font-bold text-emerald-800 uppercase tracking-wider">
           Effect
         </div>

--- a/components/widgets/GraphicOrganizer/Widget.tsx
+++ b/components/widgets/GraphicOrganizer/Widget.tsx
@@ -129,7 +129,13 @@ export const GraphicOrganizerWidget: React.FC<{ widget: WidgetData }> = ({
   };
 
   const renderFrayer = () => (
-    <div className="grid grid-cols-2 grid-rows-2 h-full gap-2 p-2 relative">
+    <div
+      className="grid grid-cols-2 grid-rows-2 h-full relative"
+      style={{
+        gap: 'min(8px, 2cqmin)',
+        padding: 'min(8px, 2cqmin)',
+      }}
+    >
       <div
         className="border-2 border-slate-300 rounded relative"
         style={{

--- a/docs/scheduled-tasks/ai-integration.md
+++ b/docs/scheduled-tasks/ai-integration.md
@@ -3,27 +3,27 @@
 _Audit model: claude-sonnet-4-6_
 _Action model: claude-opus-4-6_
 _Audit cadence: weekly — Friday_
-_Last audited: 2026-04-17_
+_Last audited: 2026-04-24_
 _Last action: never_
 
 ---
 
-## AI Generation Type Map (as of 2026-04-17)
+## AI Generation Type Map (as of 2026-04-24)
 
-| Generation Type         | Cloud Function              | Client Caller                            | Rate Limit                          | Loading State      | Error State        | Feature Gate                              |
-| ----------------------- | --------------------------- | ---------------------------------------- | ----------------------------------- | ------------------ | ------------------ | ----------------------------------------- |
-| `mini-app`              | `generateWithAI`            | utils/ai.ts `generateMiniAppCode`        | `embed-mini-app` specific + global  | ✓                  | ✓                  | `canAccessFeature('embed-mini-app')`      |
-| `poll`                  | `generateWithAI`            | utils/ai.ts `generatePoll`               | `smart-poll` specific + global      | ✓                  | ✓                  | `canAccessFeature('smart-poll')`          |
-| `dashboard-layout`      | `generateWithAI`            | utils/ai.ts `generateDashboardLayout`    | global only                         | ✓ (`isGenerating`) | ✓ (toast)          | `canAccessFeature('magic-layout')` ✓      |
-| `instructional-routine` | `generateWithAI`            | InstructionalRoutines/LibraryManager.tsx | global only                         | ✓ (`isGenerating`) | ✓ (`errorMessage`) | ✗ **missing client gate**                 |
-| `ocr`                   | `generateWithAI`            | utils/ai.ts `extractTextWithGemini`      | `ocr` specific + global             | ✓ (`isBusy`)       | ✓                  | `canAccessFeature('gemini-functions')` ✓  |
-| `quiz`                  | `generateWithAI`            | utils/ai.ts `generateQuiz`               | `quiz` specific + global            | ✓                  | ✓                  | widget-level quiz access                  |
-| `widget-builder`        | `generateWithAI`            | admin/WidgetBuilder/GeminiPanel.tsx      | global only                         | ✓ (`loading`)      | ✓ (`error`)        | admin-only panel                          |
-| `widget-explainer`      | `generateWithAI`            | admin/WidgetBuilder/GeminiPanel.tsx      | global only                         | ✓ (`loading`)      | ✓ (`error`)        | admin-only panel                          |
-| `blooms-ai`             | `generateWithAI`            | utils/ai.ts `generateBloomsContent`      | `blooms-ai` specific + global       | ✓ (`aiLoading`)    | ✓ (toast)          | `aiEnabled` flag in admin building config |
-| `video-activity`        | `generateVideoActivity`     | utils/ai.ts `generateVideoActivity`      | per-function rate limit             | ✓                  | ✓                  | feature perm checked                      |
-| `transcription`         | `transcribeVideoWithGemini` | utils/ai.ts `transcribeVideoWithGemini`  | per-function rate limit             | ✓                  | ✓                  | feature perm checked                      |
-| `guided-learning`       | `generateGuidedLearning`    | utils/ai.ts `generateGuidedLearning`     | `guided-learning` specific + global | ✓                  | ✓                  | feature perm checked                      |
+| Generation Type         | Cloud Function              | Client Caller                                       | Rate Limit                         | Loading State      | Error State        | Feature Gate                              |
+| ----------------------- | --------------------------- | --------------------------------------------------- | ---------------------------------- | ------------------ | ------------------ | ----------------------------------------- |
+| `mini-app`              | `generateWithAI`            | utils/ai.ts `generateMiniAppCode`                   | `embed-mini-app` specific + global | ✓                  | ✓                  | `canAccessFeature('embed-mini-app')`      |
+| `poll`                  | `generateWithAI`            | utils/ai.ts `generatePoll`                          | `smart-poll` specific + global     | ✓                  | ✓                  | `canAccessFeature('smart-poll')`          |
+| `dashboard-layout`      | `generateWithAI`            | utils/ai.ts `generateDashboardLayout`               | global only                        | ✓ (`isGenerating`) | ✓ (toast)          | `canAccessFeature('magic-layout')` ✓      |
+| `instructional-routine` | `generateWithAI`            | InstructionalRoutines/LibraryManager.tsx            | global only                        | ✓ (`isGenerating`) | ✓ (`errorMessage`) | ✗ **missing client gate**                 |
+| `ocr`                   | `generateWithAI`            | utils/ai.ts `extractTextWithGemini`                 | `ocr` specific + global            | ✓ (`isBusy`)       | ✓                  | `canAccessFeature('gemini-functions')` ✓  |
+| `quiz`                  | `generateWithAI`            | utils/ai.ts `generateQuiz`                          | `quiz` specific + global           | ✓                  | ✓                  | widget-level quiz access                  |
+| `widget-builder`        | `generateWithAI`            | admin/WidgetBuilder/GeminiPanel.tsx                 | global only                        | ✓ (`loading`)      | ✓ (`error`)        | admin-only panel                          |
+| `widget-explainer`      | `generateWithAI`            | admin/WidgetBuilder/GeminiPanel.tsx                 | global only                        | ✓ (`loading`)      | ✓ (`error`)        | admin-only panel                          |
+| `blooms-ai`             | `generateWithAI`            | utils/ai.ts `generateBloomsContent`                 | `blooms-ai` specific + global      | ✓ (`aiLoading`)    | ✓ (toast)          | `aiEnabled` flag in admin building config |
+| `video-activity`        | `generateVideoActivity`     | utils/ai.ts `generateVideoActivity`                 | per-function rate limit            | ✓                  | ✓                  | feature perm checked                      |
+| `transcription`         | `transcribeVideoWithGemini` | utils/ai.ts `transcribeVideoWithGemini`             | per-function rate limit            | ✓                  | ✓                  | feature perm checked                      |
+| `guided-learning`       | `generateGuidedLearning`    | GuidedLearning/components/GuidedLearningAIGenerator | None (admin-only server check)     | ✓                  | ✓                  | `isAdmin` check in Widget.tsx (not perm)  |
 
 ---
 
@@ -42,11 +42,18 @@ _Nothing currently in progress._
 - **Detail:** The "Magic Design" AI button in the InstructionalRoutines library manager calls `generateWithAI` with `type: 'instructional-routine'` without any `canAccessFeature()` or admin check. Any user with access to the `instructionalRoutines` widget can call the AI. Server-side rate limiting still applies via the global `gemini-functions` daily limit (no specific per-feature limit exists for this type), so quota exhaustion is the only protection. There is no way for an admin to disable the AI button for this widget without removing widget access entirely.
 - **Fix:** (a) Add a specific `instructional-routine` entry to `GlobalFeature` in types.ts and `GlobalPermissionsManager.tsx`, set `specificFeatureId = 'instructional-routine'` in the cloud function's rate-limit logic. (b) In `LibraryManager.tsx`, wrap the Magic Design button with `canAccessFeature('instructional-routine')` from `useAuth()`, so admins can toggle it independently of the widget.
 
-### LOW Hardcoded model string at functions/src/index.ts:1616
+### MEDIUM `guided-learning` AI entry stale after #1368 rebuild
+
+- **Detected:** 2026-04-24
+- **File:** functions/src/index.ts:1823, components/widgets/GuidedLearning/Widget.tsx:591, components/widgets/GuidedLearning/components/GuidedLearningAIGenerator.tsx
+- **Detail:** PR #1368 (merged April 21, 2026) rebuilt `generateGuidedLearning` from a single-image function with rate limiting into a multi-image function (up to 10 images, 20 MB cap) gated admin-only server-side. Two regressions relative to the April 17 audit: (1) the cloud function no longer performs any `ai_usage` rate-limit check — any admin can call it unlimited times per day; (2) the client-side gate changed from a feature permission check to a direct `isAdmin` check in `GuidedLearning/Widget.tsx`, meaning no admin can selectively disable this AI feature for certain buildings without removing the widget entirely. The journal table has been updated to reflect current state (see above).
+- **Fix:** (a) Restore per-user rate limiting in `generateGuidedLearning` by adding an `ai_usage` check against the global `gemini-functions` daily limit (consistent with other `generateWithAI` functions that are not admin-only). (b) Either keep admin-only behavior (acceptable since GL AI is an admin authoring tool) and document the design intent explicitly in the function's docblock, OR add a `canAccessFeature('guided-learning-ai')` check in `GuidedLearning/Widget.tsx` for finer-grained access control. At minimum, add a JSDoc comment explaining why rate limiting is omitted.
+
+### LOW Hardcoded model string at functions/src/index.ts:1714 (was :1616)
 
 - **Detected:** 2026-04-17
-- **File:** functions/src/index.ts:1616
-- **Detail:** The `generateVideoActivity` function selects a model with `perm.config?.model ?? 'gemini-3.1-flash-lite-preview'`. This duplicates the literal string defined by the `DEFAULT_STANDARD_MODEL` constant at line 75. If the default model is updated, line 1616 will not automatically follow.
+- **File:** functions/src/index.ts:1714 (line number shifts with function additions)
+- **Detail:** The `generateVideoActivity` function selects a model with `perm.config?.model ?? 'gemini-3.1-flash-lite-preview'`. This duplicates the literal string defined by the `DEFAULT_STANDARD_MODEL` constant at line 97. If the default model is updated, this line will not automatically follow.
 - **Fix:** Replace the hardcoded string with `DEFAULT_STANDARD_MODEL`: `perm.config?.model ?? DEFAULT_STANDARD_MODEL`.
 
 ### LOW RevealGrid "Sparkles" button uses AI icon for a paste-import feature

--- a/docs/scheduled-tasks/css-scaling.md
+++ b/docs/scheduled-tasks/css-scaling.md
@@ -3,7 +3,7 @@
 _Audit model: claude-sonnet-4-6_
 _Action model: claude-opus-4-6_
 _Audit cadence: daily_
-_Last audited: 2026-04-23_
+_Last audited: 2026-04-24_
 _Last action: 2026-04-19_
 
 ---

--- a/docs/scheduled-tasks/css-scaling.md
+++ b/docs/scheduled-tasks/css-scaling.md
@@ -3,7 +3,7 @@
 _Audit model: claude-sonnet-4-6_
 _Action model: claude-opus-4-6_
 _Audit cadence: daily_
-_Last audited: 2026-04-22_
+_Last audited: 2026-04-23_
 _Last action: 2026-04-19_
 
 ---

--- a/docs/scheduled-tasks/css-scaling.md
+++ b/docs/scheduled-tasks/css-scaling.md
@@ -4,7 +4,7 @@ _Audit model: claude-sonnet-4-6_
 _Action model: claude-opus-4-6_
 _Audit cadence: daily_
 _Last audited: 2026-04-24_
-_Last action: 2026-04-19_
+_Last action: 2026-04-24_
 
 ---
 
@@ -21,13 +21,6 @@ _Nothing currently in progress._
 ---
 
 ## Open
-
-### MEDIUM GraphicOrganizerWidget has hardcoded padding throughout node layouts (post-text-fix)
-
-- **Detected:** 2026-04-14
-- **File:** components/widgets/GraphicOrganizer/Widget.tsx
-- **Detail:** The previous fix (2026-04-13) converted all hardcoded Tailwind text-size classes to `cqmin`. However, structural padding remains hardcoded: `p-4` on Frayer cell divs (×4), `w-32 h-32` on the Frayer center circle, `pb-2 mb-4` and `text-xl` on T-chart headers, and multiple `p-3`/`p-4`/`p-6` instances in Venn, KWL, and Cause-Effect layouts. Widget has `skipScaling: true`. Fixed padding compresses content proportionally less as the widget grows, creating a poor density experience at large sizes.
-- **Fix:** Convert all `p-4`, `p-3`, `p-6` padding to `style={{ padding: 'min(16px, 3cqmin)' }}` pattern. Convert `w-32 h-32` Frayer center circle to `style={{ width: 'min(128px, 22cqmin)', height: 'min(128px, 22cqmin)' }}`. Replace `text-xl` T-chart header with `style={{ fontSize: 'min(20px, 7cqmin)' }}`.
 
 ### MEDIUM StarterPackWidget has hardcoded icon size and spacing in addition to text sizes
 
@@ -63,6 +56,22 @@ _Nothing currently in progress._
 ---
 
 ## Completed
+
+### MEDIUM GraphicOrganizerWidget has hardcoded padding throughout node layouts (post-text-fix)
+
+- **Detected:** 2026-04-14
+- **Completed:** 2026-04-24
+- **File:** components/widgets/GraphicOrganizer/Widget.tsx
+- **Detail:** Structural padding remained hardcoded after the 2026-04-13 text-size fix: `p-4` on Frayer cell divs (×4), `w-32 h-32` + `p-4` on the Frayer center circle, `pb-2 mb-4` and `text-xl` on T-chart headers, `p-4` outer + column wrappers on Venn, `p-3` headers and `p-4` EditableNode wrappers on KWL (×3 each), and `p-6` outer + `p-4` EditableNode wrappers on Cause-Effect. Widget has `skipScaling: true`, so fixed-pixel padding compressed content proportionally less as the widget grew.
+- **Resolution:** Converted all `p-4`, `p-3`, `p-6` instances to inline `cqmin` styles using the project pattern:
+  - `p-4` → `padding: 'min(16px, 3cqmin)'` (15 instances across Frayer cells, T-chart cells, Venn outer + columns, KWL EditableNodes, Cause-Effect EditableNodes)
+  - `p-3` → `padding: 'min(12px, 3cqmin)'` (3 KWL header containers)
+  - `p-6` → `padding: 'min(24px, 5cqmin)'` (Cause-Effect outer wrapper)
+  - `w-32 h-32` (Frayer center circle) → `width: 'min(128px, 22cqmin)', height: 'min(128px, 22cqmin)'`
+  - `text-xl` (T-chart headers) → `fontSize: 'min(20px, 7cqmin)'`
+  - `pb-2 mb-4` (T-chart headers) → `paddingBottom: 'min(8px, 2cqmin)', marginBottom: 'min(16px, 3cqmin)'`
+  - Moved padding out of `EditableNode` `className` prop into its `style` prop to avoid className/style conflicts.
+    `pnpm type-check`, `pnpm lint --max-warnings 0`, and `pnpm format:check` all clean.
 
 ### MEDIUM MathToolsWidget uses `h-32` to cap an empty-state content container
 

--- a/docs/scheduled-tasks/pr-review-log.md
+++ b/docs/scheduled-tasks/pr-review-log.md
@@ -146,3 +146,41 @@ _Automated nightly review by claude-opus-4-6_
   - PR #1371 head SHA `15cfb658` — cumulative merge, 160+ files; organization management (new Cloud Functions for reset-password/counters/activity), library folder subsystem, `DriveImagePicker`, migration of every admin panel from static `BUILDINGS` to dynamic `useAdminBuildings`
   - PR #1366 head SHA `7ffde284` — single doc (194 lines); no code impact; execution gated on "all open PRs merged" precondition
   - Branch-safety: PR #1371 is on `dev-paul` (matches `dev-*`) — pushes prohibited by policy; comment-only scope observed
+
+## 2026-04-23
+
+- PRs reviewed:
+  - #1394 — fix(graphic-organizer): convert hardcoded padding/sizing to cqmin scaling (head `claude/beautiful-sagan-0wgop`, base `dev-paul`, DRAFT)
+  - #1393 — audit: scheduled task journals — 2026-04-23 (Thursday) (head `scheduled-tasks`, base `dev-paul`, DRAFT)
+  - #1392 — feat(assign): unified multi-class picker across Quiz/VA/GL (Phase 5A) (head `claude/phase-5a-planning-7y3lz`, base `main`, DRAFT)
+  - #1391 — fix(rules): drop resource.data gate from session `get` to unbreak teacher Start (head `claude/fix-quiz-paused-status-ODQwk`, base `dev-paul`)
+  - #1385 — fix(reset-password): surface resetUrl when email queue is disabled (head `paul/fix-reset-link-silent-failure`, base `main`)
+  - #1382 — docs(admin): fill in ClassLink auth secret setup (OAuth client ID + HMAC gen) (head `docs/admin-setup-classlink-merge`, base `dev-paul`)
+  - #1366 — docs: plan for repo-wide line-ending normalization (head `docs/line-endings-normalization-plan`, base `main`)
+- Comments processed: 18 total — 0 new fixes, 18 explained
+  - PR #1394: 3 inline threads (gemini) all `is_outdated: true` — verified each suggestion is already applied in the current branch HEAD `ebb9389` (Frayer marginTop/fontSize, KWL content padding/fontSize, Cause/Effect header padding/fontSize); replied to each with the current code location
+  - PR #1393: 0 inline threads
+  - PR #1392: 1 inline thread (gemini) — race-condition guard on `VideoActivityStudentApp.handleJoin`; replied as UX/product decision flagged for human review
+  - PR #1391: 5 inline threads (copilot) — all requesting a `get`/`list` split on the five session collections' read rules. That's the exact shape PR #1390 shipped and which this PR is backing out because it empirically denied teacher single-doc subscriptions. Replied to each noting the architectural tradeoff is already addressed in the PR description's **Security impact** section and routing the decision to a human.
+  - PR #1385: 5 inline threads — 2 already resolved, 3 unresolved but already have author rationale replies (declined data-migration, declined pagination on a short-lived script, confirmed docblock-only reconciliation); no further action needed
+  - PR #1382: 1 inline thread already resolved by author
+  - PR #1366: 6 inline threads — all have author replies from the 2026-04-21 iteration; no further action needed
+- Fixes pushed: none
+  - No unaddressed comments remained requiring a code fix on any PR. The PR #1394 gemini threads are already-applied suggestions (outdated line refs), PR #1391 copilot threads are architectural tradeoffs intentional to the PR, and PR #1385/#1382/#1366 threads all had prior author replies.
+- Reviews posted: 7
+  - PR #1394: Ready with minor notes — clean scaling follow-up; only gap is the unchecked visual-resize checklist item across all five layouts
+  - PR #1393: Ready — routine journal bookkeeping, zero runtime impact
+  - PR #1392: Ready with minor notes — Phase 5A multi-class picker across Quiz/VA/GL with sensible backward-compat rules helper; flagged `pnpm test:rules` still unchecked, `classIds[0] === undefined` edge case in four session hooks, and absence of automated coverage for the new multi-class + period-picker behaviors
+  - PR #1391: Ready with minor notes — fixes empirically-observed teacher Start regression from #1390 and actively closes the rules-test gap with an end-to-end lifecycle suite + regression smoke across all five session collections + new CI `rules` job; flagged the deployed-rules diff + post-deploy smoke as still-unchecked
+  - PR #1385: Ready — silent-auth-failure fix + backfill PASS 2 with solid CF test coverage; author's rationale on declined gemini suggestions is well-reasoned for a short-lived admin script
+  - PR #1382: Ready — docs-only recovery of ClassLink + Google OAuth secret setup
+  - PR #1366: Ready — doc-only 3-PR plan, internally consistent, six prior review threads all addressed
+- Notes:
+  - PR #1394 head SHA `ebb93899` — single-file cqmin rollout across 5 GraphicOrganizer layouts; 1423 unit tests clean; closes a scheduled-task journal item
+  - PR #1393 head SHA `e47a3e8e` — 3 journal markdown files, date-only changes plus one sentence rewrite in typescript-eslint.md
+  - PR #1392 head SHA `7dce8622` — 15 files: new `AssignClassPicker.{tsx,helpers.ts}` (+36/+292), 4 session hooks widened, `firestore.rules` +104/-45, `types.ts` +86/-26. Dual-write compat pattern (`classIds` + `classId = classIds[0]`) is sound.
+  - PR #1391 head SHA `13934e92` — `firestore.rules` +52/-70 (five collections collapsed to `allow read`), `tests/rules/studentRoleClassGate.test.ts` +422/-21 (adds end-to-end lifecycle + PR #1391 regression suites), new `rules` job in `.github/workflows/pr-validation.yml`
+  - PR #1385 head SHA `742b0ffb` — CF +15/-1, hook return-type widened, UI clipboard fallback (3 levels), backfill script PASS 2 +73/-8; 5 new CF tests
+  - PR #1382 head SHA `73f71664` — single-file doc addition (`docs/ADMIN_SETUP.md` +78/-2) for `GOOGLE_OAUTH_CLIENT_ID`, `CLASSLINK_CLIENT_*` / `CLASSLINK_TENANT_URL`, and `openssl rand -hex 32` generation step
+  - PR #1366 head SHA `7ffde284` — unchanged from 2026-04-22 log entry
+  - Branch-safety: no head branches match `main` or `dev-*`; all 7 PRs are eligible for pushes, but no pushes were needed this run

--- a/docs/scheduled-tasks/simplification.md
+++ b/docs/scheduled-tasks/simplification.md
@@ -3,7 +3,7 @@
 _Audit model: claude-sonnet-4-6_
 _Action model: claude-opus-4-6_
 _Audit cadence: weekly — Friday_
-_Last audited: 2026-04-17_
+_Last audited: 2026-04-24_
 _Last action: never_
 
 ---
@@ -19,7 +19,7 @@ _Nothing currently in progress._
 ### MEDIUM Duplicated config layer-merge pattern in DashboardContext — extraction candidate
 
 - **Detected:** 2026-04-17
-- **File:** context/DashboardContext.tsx:2464, :2543
+- **File:** context/DashboardContext.tsx:2482, :2561 (line numbers shift with each context addition)
 - **Detail:** Two `Object.assign` call sites (one for the widget-open path at line 2464, one for the add-widget path at line 2543) implement an identical four-layer config merge: `defaults.config → adminConfig → savedWidgetConfigs → overrides`. The pattern and argument list are visually identical; only variable names differ. Any change to the merge order or the inclusion of a new layer (e.g. user preferences) must be made in two places.
 - **Fix:** Extract a helper function such as `mergeWidgetConfig(defaults, adminConfig, saved, overrides)` that performs the `Object.assign` and documents the layer order. Call it from both sites. The function is a pure utility — no hook dependencies — and belongs in utils/ or as a module-level function in DashboardContext.tsx.
 
@@ -33,9 +33,16 @@ _Nothing currently in progress._
 ### LOW useQuizSession and useVideoActivitySession have high internal state density
 
 - **Detected:** 2026-04-17
-- **File:** hooks/useQuizSession.ts (17 useState/useRef calls), hooks/useVideoActivitySession.ts (13 useState/useRef calls)
+- **File:** hooks/useQuizSession.ts (18 useState/useRef calls as of 2026-04-24), hooks/useVideoActivitySession.ts (13 useState/useRef calls)
 - **Detail:** Both hooks accumulate many individual `useState`/`useRef` declarations rather than grouping related values into a single state object or sub-hook. High state density increases cognitive load when tracing data flow and makes it easy to introduce stale-closure bugs via missing dependencies.
 - **Fix:** Audit both hooks and group tightly-coupled state variables into sub-objects (e.g. `sessionStatus`, `studentResponses`, `timerState`) using a single `useState` or `useReducer` per group. Extract repeated logic (e.g. Firestore listener setup) into smaller helper hooks. Prioritize `useQuizSession.ts` first as it has the highest count.
+
+### LOW useScreenRecord and useLiveSession exceed 5 state/ref calls
+
+- **Detected:** 2026-04-24
+- **File:** hooks/useScreenRecord.ts (7 useState/useRef: 3 state + 4 refs), hooks/useLiveSession.ts (7 useState/useRef calls)
+- **Detail:** Both hooks exceed the 5-call threshold. `useScreenRecord` manages 3 logically-grouped pieces of UI state (isRecording, duration, error) plus 4 DOM/API refs (MediaRecorder, Blob[], timer, MediaStream). `useLiveSession` has 6 useState calls (session, students, loading, studentId, studentPin, individualFrozen, prevDeps). The refs in useScreenRecord are all distinct external resources, so grouping has lower ROI here than in the session hooks. However, they should be documented.
+- **Fix:** For `useScreenRecord`, group `{ isRecording, duration, error }` into a single `useState` object to reduce the state surface. The 4 refs are all distinct external handles and should remain individual. For `useLiveSession`, group `{ studentId, studentPin }` (always set/cleared together) into a single state object. Severity is LOW because the individual state declarations are cohesive and readable.
 
 ---
 

--- a/docs/scheduled-tasks/typescript-eslint.md
+++ b/docs/scheduled-tasks/typescript-eslint.md
@@ -3,7 +3,7 @@
 _Audit model: claude-sonnet-4-6_
 _Action model: claude-opus-4-6_
 _Audit cadence: daily_
-_Last audited: 2026-04-22_
+_Last audited: 2026-04-23_
 _Last action: never_
 
 ---
@@ -16,7 +16,7 @@ _Nothing currently in progress._
 
 ## Open
 
-_No open items. Both `pnpm type-check` and `pnpm lint` pass cleanly as of 2026-04-22. TypeScript: 0 errors. ESLint: 0 errors, 0 warnings (`--max-warnings 0`). Test suite: 1393 tests across 151 files — all passing (up from 1094 tests noted 2026-04-15)._
+_No open items. Both `pnpm type-check` and `pnpm lint` pass cleanly as of 2026-04-23. TypeScript: 0 errors. ESLint: 0 errors, 0 warnings (`--max-warnings 0`)._
 
 ---
 

--- a/docs/scheduled-tasks/typescript-eslint.md
+++ b/docs/scheduled-tasks/typescript-eslint.md
@@ -3,7 +3,7 @@
 _Audit model: claude-sonnet-4-6_
 _Action model: claude-opus-4-6_
 _Audit cadence: daily_
-_Last audited: 2026-04-23_
+_Last audited: 2026-04-24_
 _Last action: never_
 
 ---
@@ -16,7 +16,7 @@ _Nothing currently in progress._
 
 ## Open
 
-_No open items. Both `pnpm type-check` and `pnpm lint` pass cleanly as of 2026-04-23. TypeScript: 0 errors. ESLint: 0 errors, 0 warnings (`--max-warnings 0`)._
+_No open items. Both `pnpm type-check` and `pnpm lint` pass cleanly as of 2026-04-24. TypeScript: 0 errors. ESLint: 0 errors, 0 warnings (`--max-warnings 0`)._
 
 ---
 

--- a/docs/scheduled-tasks/widget-registry.md
+++ b/docs/scheduled-tasks/widget-registry.md
@@ -3,7 +3,7 @@
 _Audit model: claude-sonnet-4-6_
 _Action model: claude-opus-4-6_
 _Audit cadence: daily_
-_Last audited: 2026-04-22_
+_Last audited: 2026-04-23_
 _Last action: never_
 
 ---

--- a/docs/scheduled-tasks/widget-registry.md
+++ b/docs/scheduled-tasks/widget-registry.md
@@ -3,7 +3,7 @@
 _Audit model: claude-sonnet-4-6_
 _Action model: claude-opus-4-6_
 _Audit cadence: daily_
-_Last audited: 2026-04-23_
+_Last audited: 2026-04-24_
 _Last action: never_
 
 ---


### PR DESCRIPTION
## Summary

- Resolves the MEDIUM item **"GraphicOrganizerWidget has hardcoded padding throughout node layouts (post-text-fix)"** from `docs/scheduled-tasks/css-scaling.md`.
- `GraphicOrganizer/Widget.tsx` has `skipScaling: true`, so its structural padding must use container-query units to respond to widget resizing. Prior fix (2026-04-13) converted text sizes; this fix completes the conversion for structural spacing.

> **Note:** PR #1394 covers a superset of these cqmin conversions (extra absolute-position pins, EditableNode margins, Cause-Effect header strips, arrow SVG dimensions). See the automated review thread for the consolidation recommendation.

## Changes

In `components/widgets/GraphicOrganizer/Widget.tsx`, converted the Tailwind classes called out in the journal fix guidance to inline `cqmin` styles:

| From | To | Count / Location |
|---|---|---|
| `p-4` | `padding: 'min(16px, 3cqmin)'` | 15× — Frayer cells, T-chart cells, Venn outer + columns, KWL EditableNodes, Cause-Effect EditableNodes |
| `p-3` | `padding: 'min(12px, 3cqmin)'` | 3× — KWL header containers |
| `p-6` | `padding: 'min(24px, 5cqmin)'` | 1× — Cause-Effect outer wrapper |
| `w-32 h-32` | `width/height: 'min(128px, 22cqmin)'` | Frayer center circle |
| `text-xl` | `fontSize: 'min(20px, 7cqmin)'` | T-chart headers |
| `pb-2 mb-4` | `paddingBottom: 'min(8px, 2cqmin)', marginBottom: 'min(16px, 3cqmin)'` | T-chart headers |
| `gap-4` | `gap: 'min(16px, 3.5cqmin)'` | Cause-Effect outer wrapper (follow-up in `bb06e899`) |

Padding on `EditableNode` children was moved from `className` into the `style` prop to avoid className/style conflict.

Additionally, removed duplicate `backgroundColor: cellBg` from the inner Cause and Effect boxes in `renderCauseEffect`. The outer wrapper already paints `cellBg`, so stacking it on the inner boxes caused opacity² artifacts whenever `cardOpacity < 1` (follow-up in `bb06e899`, responding to the gemini-code-assist review).

Journal entry moved from `## Open` → `## Completed` in `docs/scheduled-tasks/css-scaling.md`.

## Test plan

- [x] `pnpm run type-check` — clean
- [x] `pnpm run lint` (`--max-warnings 0`) — clean
- [x] `pnpm run format:check` — clean
- [x] `pnpm run test` — 154 files / 1441 tests pass, including the 7 existing GraphicOrganizer tests at `components/widgets/GraphicOrganizer/Widget.test.tsx` (Frayer/T-chart/Venn/KWL/Cause-Effect layout rendering, edit-event debounce, blur flush, initial-text from config, custom building templates, fallback to Frayer). The tests assert behavior, not styling, so they are unaffected by these purely presentational changes; no assertions were added or modified.
- [ ] Visual: confirm Frayer, T-chart, Venn, KWL, and Cause-Effect layouts still read correctly at small, default, and very large widget sizes
- [ ] Visual: confirm `cqmin` values logically fill the widget at extreme aspect ratios (per journal audit guidance)

https://claude.ai/code/session_011h7UsnjA8gAuvB6TAs344L