### PR TITLE
fix(quiz): attempt limits, reopen, delete responses, z-index, MC change

### DIFF
--- a/components/common/library/AssignmentArchiveCard.tsx
+++ b/components/common/library/AssignmentArchiveCard.tsx
@@ -16,7 +16,8 @@
  * shared `LibraryBadgeTone` convention.
  */
 
-import React, { useRef, useState } from 'react';
+import React, { useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 import { MoreHorizontal } from 'lucide-react';
 import { useClickOutside } from '@/hooks/useClickOutside';
 import type {
@@ -75,8 +76,41 @@ interface OverflowMenuProps {
 
 const OverflowMenu: React.FC<OverflowMenuProps> = ({ actions }) => {
   const [open, setOpen] = useState(false);
-  const ref = useRef<HTMLDivElement>(null);
-  useClickOutside(ref, () => setOpen(false));
+  const [menuPos, setMenuPos] = useState<{ top: number; right: number } | null>(
+    null
+  );
+  const wrapperRef = useRef<HTMLDivElement>(null);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  // Dismiss on outside click — covers both the trigger wrapper and the
+  // portalled menu, so clicks inside the menu don't close it.
+  useClickOutside(wrapperRef, () => setOpen(false), [menuRef]);
+
+  // Measure trigger position when the menu opens so the portal renders
+  // flush under it. `opacity-70` on archive cards creates a stacking
+  // context that traps absolute-positioned children, hence the portal.
+  useLayoutEffect(() => {
+    if (!open || !buttonRef.current) return;
+    const rect = buttonRef.current.getBoundingClientRect();
+    setMenuPos({
+      top: rect.bottom + 4,
+      right: window.innerWidth - rect.right,
+    });
+  }, [open]);
+
+  // Close the menu if the page scrolls or resizes (portal position is
+  // fixed at open time; staying open after layout shifts looks broken).
+  useEffect(() => {
+    if (!open) return;
+    const close = () => setOpen(false);
+    window.addEventListener('scroll', close, true);
+    window.addEventListener('resize', close);
+    return () => {
+      window.removeEventListener('scroll', close, true);
+      window.removeEventListener('resize', close);
+    };
+  }, [open]);
 
   if (actions.length === 0) return null;
 
@@ -87,8 +121,9 @@ const OverflowMenu: React.FC<OverflowMenuProps> = ({ actions }) => {
   const orderedActions = [...normalActions, ...destructiveActions];
 
   return (
-    <div ref={ref} className="relative">
+    <div ref={wrapperRef} className="relative">
       <button
+        ref={buttonRef}
         type="button"
         onClick={() => setOpen((v) => !v)}
         className="flex items-center justify-center w-7 h-7 rounded-lg text-brand-blue-dark/60 hover:text-brand-blue-dark hover:bg-brand-blue-lighter/30 transition-colors"
@@ -99,38 +134,48 @@ const OverflowMenu: React.FC<OverflowMenuProps> = ({ actions }) => {
       >
         <MoreHorizontal size={16} />
       </button>
-      {open && (
-        <div
-          role="menu"
-          className="absolute right-0 top-full mt-1 min-w-[160px] bg-white rounded-lg shadow-lg border border-brand-blue-primary/15 py-1 z-50"
-        >
-          {orderedActions.map((item) => {
-            const Icon = item.icon;
-            return (
-              <button
-                key={item.id}
-                type="button"
-                role="menuitem"
-                onClick={() => {
-                  if (item.disabled) return;
-                  setOpen(false);
-                  item.onClick();
-                }}
-                disabled={item.disabled}
-                title={item.disabled ? item.disabledReason : undefined}
-                className={`w-full flex items-center gap-2 text-left px-3 py-1.5 text-xs font-semibold transition-colors disabled:opacity-40 disabled:cursor-not-allowed ${
-                  item.destructive
-                    ? 'text-brand-red-dark hover:bg-brand-red-lighter/30'
-                    : 'text-brand-blue-dark hover:bg-brand-blue-lighter/30'
-                }`}
-              >
-                {Icon && <Icon size={12} className="shrink-0" />}
-                <span className="truncate">{item.label}</span>
-              </button>
-            );
-          })}
-        </div>
-      )}
+      {open &&
+        menuPos &&
+        createPortal(
+          <div
+            ref={menuRef}
+            role="menu"
+            style={{
+              position: 'fixed',
+              top: menuPos.top,
+              right: menuPos.right,
+              zIndex: 60,
+            }}
+            className="min-w-[160px] bg-white rounded-lg shadow-lg border border-brand-blue-primary/15 py-1"
+          >
+            {orderedActions.map((item) => {
+              const Icon = item.icon;
+              return (
+                <button
+                  key={item.id}
+                  type="button"
+                  role="menuitem"
+                  onClick={() => {
+                    if (item.disabled) return;
+                    setOpen(false);
+                    item.onClick();
+                  }}
+                  disabled={item.disabled}
+                  title={item.disabled ? item.disabledReason : undefined}
+                  className={`w-full flex items-center gap-2 text-left px-3 py-1.5 text-xs font-semibold transition-colors disabled:opacity-40 disabled:cursor-not-allowed ${
+                    item.destructive
+                      ? 'text-brand-red-dark hover:bg-brand-red-lighter/30'
+                      : 'text-brand-blue-dark hover:bg-brand-blue-lighter/30'
+                  }`}
+                >
+                  {Icon && <Icon size={12} className="shrink-0" />}
+                  <span className="truncate">{item.label}</span>
+                </button>
+              );
+            })}
+          </div>,
+          document.body
+        )}
     </div>
   );
 };

--- a/components/common/library/AssignmentArchiveCard.tsx
+++ b/components/common/library/AssignmentArchiveCard.tsx
@@ -16,7 +16,13 @@
  * shared `LibraryBadgeTone` convention.
  */
 
-import React, { useEffect, useLayoutEffect, useRef, useState } from 'react';
+import React, {
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import { createPortal } from 'react-dom';
 import { MoreHorizontal } from 'lucide-react';
 import { useClickOutside } from '@/hooks/useClickOutside';
@@ -84,8 +90,10 @@ const OverflowMenu: React.FC<OverflowMenuProps> = ({ actions }) => {
   const menuRef = useRef<HTMLDivElement>(null);
 
   // Dismiss on outside click — covers both the trigger wrapper and the
-  // portalled menu, so clicks inside the menu don't close it.
-  useClickOutside(wrapperRef, () => setOpen(false), [menuRef]);
+  // portalled menu, so clicks inside the menu don't close it. Memoized
+  // so `useClickOutside` doesn't re-subscribe DOM listeners every render.
+  const ignoreRefs = useMemo(() => [menuRef], []);
+  useClickOutside(wrapperRef, () => setOpen(false), ignoreRefs);
 
   // Measure trigger position when the menu opens so the portal renders
   // flush under it. `opacity-70` on archive cards creates a stacking

--- a/components/quiz/QuizStudentApp.tsx
+++ b/components/quiz/QuizStudentApp.tsx
@@ -512,6 +512,7 @@ const ActiveQuiz: React.FC<{
   const [selectedAnswer, setSelectedAnswer] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
   const [fibAnswer, setFibAnswer] = useState('');
+  const [draftMcAnswer, setDraftMcAnswer] = useState<string | null>(null);
 
   const [submitted, setSubmitted] = useState(alreadyAnswered);
   const [timeLeft, setTimeLeft] = useState<number | null>(
@@ -546,6 +547,7 @@ const ActiveQuiz: React.FC<{
     setSelectedAnswer(null);
     setSubmitted(alreadyAnswered);
     setFibAnswer('');
+    setDraftMcAnswer(null);
     setAutoSubmitTriggeredFor(null);
     setAnswerFeedback(null);
     setRevealedAnswer(null);
@@ -572,14 +574,16 @@ const ActiveQuiz: React.FC<{
   const currentQuestionRef = useRef(currentQuestion);
   const selectedAnswerRef = useRef(selectedAnswer);
   const fibAnswerRef = useRef(fibAnswer);
+  const draftMcAnswerRef = useRef(draftMcAnswer);
   const onAnswerRef = useRef(onAnswer);
 
   useEffect(() => {
     currentQuestionRef.current = currentQuestion;
     selectedAnswerRef.current = selectedAnswer;
     fibAnswerRef.current = fibAnswer;
+    draftMcAnswerRef.current = draftMcAnswer;
     onAnswerRef.current = onAnswer;
-  }, [currentQuestion, selectedAnswer, fibAnswer, onAnswer]);
+  }, [currentQuestion, selectedAnswer, fibAnswer, draftMcAnswer, onAnswer]);
 
   // Countdown — only runs the interval; auto-submit is handled above.
   useEffect(() => {
@@ -611,7 +615,10 @@ const ActiveQuiz: React.FC<{
     void onAnswerRef
       .current(
         autoSubmitTriggeredFor,
-        selectedAnswerRef.current ?? fibAnswerRef.current ?? '',
+        selectedAnswerRef.current ??
+          draftMcAnswerRef.current ??
+          fibAnswerRef.current ??
+          '',
         0 // Speed bonus is 0 when timer expires
       )
       .catch((err: unknown) => {
@@ -847,7 +854,9 @@ const ActiveQuiz: React.FC<{
         {currentQuestion.type === 'MC' && (
           <div className="space-y-3 flex-1">
             {options.map((opt) => {
-              const isSelected = selectedAnswer === opt;
+              const isSelected = submitted
+                ? selectedAnswer === opt
+                : draftMcAnswer === opt;
               let cls =
                 'w-full text-left px-5 py-4 rounded-2xl border-2 text-sm font-medium transition-all ';
               if (!submitted) {
@@ -862,7 +871,7 @@ const ActiveQuiz: React.FC<{
               return (
                 <button
                   key={opt}
-                  onClick={() => !submitted && void handleSubmit(opt)}
+                  onClick={() => !submitted && setDraftMcAnswer(opt)}
                   disabled={submitted || submitting}
                   className={cls}
                 >
@@ -871,34 +880,51 @@ const ActiveQuiz: React.FC<{
               );
             })}
 
-            {submitted && (
-              <div className="pt-4 animate-in fade-in slide-in-from-bottom-2 space-y-3">
-                <AnswerFeedbackBanner
-                  feedback={answerFeedback}
-                  revealedAnswer={revealedAnswer}
-                  speedBonus={speedBonusEarned}
-                  streakCount={streakCount}
-                  streakEnabled={session.streakBonusEnabled}
-                />
-                {isStudentPaced && currentIndex < session.totalQuestions - 1 ? (
-                  <button
-                    onClick={handleNext}
-                    className="w-full py-4 bg-emerald-600 hover:bg-emerald-500 text-white font-black rounded-2xl flex items-center justify-center gap-2 transition-all shadow-lg active:scale-95"
-                  >
-                    NEXT QUESTION <ArrowRight className="w-5 h-5" />
-                  </button>
-                ) : (
-                  <div className="p-4 bg-emerald-500/15 border border-emerald-500/30 rounded-2xl flex items-center justify-center gap-3">
-                    <CheckCircle2 className="w-5 h-5 text-emerald-400 shrink-0" />
-                    <p className="text-emerald-300 text-sm font-bold">
-                      {currentIndex < session.totalQuestions - 1
-                        ? 'Waiting for teacher…'
-                        : 'Quiz complete!'}
-                    </p>
-                  </div>
-                )}
-              </div>
-            )}
+            <div className="animate-in fade-in slide-in-from-bottom-2">
+              {!submitted ? (
+                <button
+                  onClick={() =>
+                    draftMcAnswer && void handleSubmit(draftMcAnswer)
+                  }
+                  disabled={!draftMcAnswer || submitting}
+                  className="w-full py-4 bg-violet-600 hover:bg-violet-500 disabled:opacity-50 text-white font-bold rounded-2xl flex items-center justify-center gap-2 transition-colors"
+                >
+                  {submitting ? (
+                    <Loader2 className="w-5 h-5 animate-spin" />
+                  ) : (
+                    'Submit Answer'
+                  )}
+                </button>
+              ) : (
+                <div className="space-y-3">
+                  <AnswerFeedbackBanner
+                    feedback={answerFeedback}
+                    revealedAnswer={revealedAnswer}
+                    speedBonus={speedBonusEarned}
+                    streakCount={streakCount}
+                    streakEnabled={session.streakBonusEnabled}
+                  />
+                  {isStudentPaced &&
+                  currentIndex < session.totalQuestions - 1 ? (
+                    <button
+                      onClick={handleNext}
+                      className="w-full py-4 bg-emerald-600 hover:bg-emerald-500 text-white font-black rounded-2xl flex items-center justify-center gap-2 transition-all shadow-lg active:scale-95"
+                    >
+                      NEXT QUESTION <ArrowRight className="w-5 h-5" />
+                    </button>
+                  ) : (
+                    <div className="p-4 bg-emerald-500/15 border border-emerald-500/30 rounded-2xl flex items-center justify-center gap-3">
+                      <CheckCircle2 className="w-5 h-5 text-emerald-400 shrink-0" />
+                      <p className="text-emerald-300 text-sm font-bold">
+                        {currentIndex < session.totalQuestions - 1
+                          ? 'Waiting for teacher…'
+                          : 'Quiz complete!'}
+                      </p>
+                    </div>
+                  )}
+                </div>
+              )}
+            </div>
           </div>
         )}
 

--- a/components/widgets/QuizWidget/Widget.tsx
+++ b/components/widgets/QuizWidget/Widget.tsx
@@ -73,6 +73,7 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
     pauseAssignment,
     resumeAssignment,
     deactivateAssignment,
+    reopenAssignment,
     deleteAssignment,
     updateAssignmentSettings,
     shareAssignment,
@@ -543,6 +544,7 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
         }}
         tabWarningsEnabled={liveSession?.tabWarningsEnabled ?? true}
         session={liveSession}
+        onDeleteResponse={removeStudent}
       />
     );
   }
@@ -669,7 +671,8 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
           mode,
           plcOptions: PlcOptions,
           sessionOptions: QuizSessionOptions,
-          rosterIds: string[]
+          rosterIds: string[],
+          attemptLimit: number | null
         ) => {
           const data = await loadQuiz(meta);
           if (!data) return;
@@ -691,6 +694,7 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
               {
                 sessionMode: mode,
                 sessionOptions,
+                attemptLimit,
                 plcMode: plcOptions.plcMode,
                 teacherName: plcOptions.teacherName,
                 periodName:
@@ -1085,6 +1089,20 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
           } catch (err) {
             addToast(
               err instanceof Error ? err.message : 'Failed to deactivate',
+              'error'
+            );
+          }
+        }}
+        onArchiveReopen={async (a) => {
+          try {
+            await reopenAssignment(a.id);
+            addToast(
+              'Reopened — click Resume to accept submissions.',
+              'success'
+            );
+          } catch (err) {
+            addToast(
+              err instanceof Error ? err.message : 'Failed to reopen',
               'error'
             );
           }

--- a/components/widgets/QuizWidget/components/AttemptLimitRow.tsx
+++ b/components/widgets/QuizWidget/components/AttemptLimitRow.tsx
@@ -1,0 +1,61 @@
+/**
+ * Shared "Attempts Allowed" segmented-control row, used by both the
+ * new-assignment flow (QuizManager) and the mid-assignment settings editor
+ * (QuizAssignmentSettingsModal). Keeping the options and layout in one
+ * place prevents the two surfaces from drifting apart.
+ */
+
+import React from 'react';
+
+interface AttemptOption {
+  label: string;
+  value: number | null;
+}
+
+const ATTEMPT_OPTIONS: AttemptOption[] = [
+  { label: '1', value: 1 },
+  { label: '2', value: 2 },
+  { label: '3', value: 3 },
+  { label: 'Unlimited', value: null },
+];
+
+export interface AttemptLimitRowProps {
+  value: number | null;
+  onChange: (v: number | null) => void;
+}
+
+export const AttemptLimitRow: React.FC<AttemptLimitRowProps> = ({
+  value,
+  onChange,
+}) => (
+  <div>
+    <div className="flex items-center justify-between gap-3">
+      <span className="text-sm font-bold text-brand-blue-dark">
+        Attempts Allowed
+      </span>
+      <div className="inline-flex rounded-lg border border-slate-200 bg-white overflow-hidden">
+        {ATTEMPT_OPTIONS.map((opt) => {
+          const active = value === opt.value;
+          return (
+            <button
+              key={opt.label}
+              type="button"
+              onClick={() => onChange(opt.value)}
+              className={
+                'px-3 py-1.5 text-xs font-bold transition ' +
+                (active
+                  ? 'bg-brand-blue-primary text-white'
+                  : 'text-slate-600 hover:bg-slate-50')
+              }
+            >
+              {opt.label}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+    <p className="text-xxs text-slate-500 mt-0.5">
+      Remove a student from the live monitor to reset their attempt.
+    </p>
+  </div>
+);

--- a/components/widgets/QuizWidget/components/QuizAssignmentSettingsModal.tsx
+++ b/components/widgets/QuizWidget/components/QuizAssignmentSettingsModal.tsx
@@ -20,6 +20,7 @@ import type {
   ClassRoster,
 } from '@/types';
 import { Toggle } from '@/components/common/Toggle';
+import { AttemptLimitRow } from './AttemptLimitRow';
 import {
   AssignModal,
   type AssignModeOption,
@@ -396,49 +397,6 @@ const SectionHeader: React.FC<{ label: string }> = ({ label }) => (
   <p className="text-xxs font-bold text-brand-blue-primary/60 uppercase tracking-widest pt-1">
     {label}
   </p>
-);
-
-const ATTEMPT_OPTIONS: { label: string; value: number | null }[] = [
-  { label: '1', value: 1 },
-  { label: '2', value: 2 },
-  { label: '3', value: 3 },
-  { label: 'Unlimited', value: null },
-];
-
-const AttemptLimitRow: React.FC<{
-  value: number | null;
-  onChange: (v: number | null) => void;
-}> = ({ value, onChange }) => (
-  <div>
-    <div className="flex items-center justify-between gap-3">
-      <span className="text-sm font-bold text-brand-blue-dark">
-        Attempts Allowed
-      </span>
-      <div className="inline-flex rounded-lg border border-slate-200 bg-white overflow-hidden">
-        {ATTEMPT_OPTIONS.map((opt) => {
-          const active = value === opt.value;
-          return (
-            <button
-              key={opt.label}
-              type="button"
-              onClick={() => onChange(opt.value)}
-              className={
-                'px-3 py-1.5 text-xs font-bold transition ' +
-                (active
-                  ? 'bg-brand-blue-primary text-white'
-                  : 'text-slate-600 hover:bg-slate-50')
-              }
-            >
-              {opt.label}
-            </button>
-          );
-        })}
-      </div>
-    </div>
-    <p className="text-xxs text-slate-500 mt-0.5">
-      Remove a student from the live monitor to reset their attempt.
-    </p>
-  </div>
 );
 
 const ToggleRow: React.FC<{

--- a/components/widgets/QuizWidget/components/QuizAssignmentSettingsModal.tsx
+++ b/components/widgets/QuizWidget/components/QuizAssignmentSettingsModal.tsx
@@ -43,6 +43,8 @@ interface SettingsOptions {
   streakBonusEnabled: boolean;
   showPodiumBetweenQuestions: boolean;
   soundEffectsEnabled: boolean;
+  /** null = unlimited; any positive int = hard cap. */
+  attemptLimit: number | null;
   plcMode: boolean;
   teacherName: string;
   selectedPeriodNames: string[];
@@ -61,6 +63,9 @@ function initialOptionsFor(a: QuizAssignment): SettingsOptions {
     streakBonusEnabled: opts.streakBonusEnabled ?? false,
     showPodiumBetweenQuestions: opts.showPodiumBetweenQuestions ?? true,
     soundEffectsEnabled: opts.soundEffectsEnabled ?? false,
+    // Legacy assignments have no attemptLimit — preserve "unlimited" for
+    // those rather than retroactively capping ongoing sessions.
+    attemptLimit: a.attemptLimit ?? null,
     plcMode: a.plcMode ?? false,
     teacherName: a.teacherName ?? '',
     selectedPeriodNames: a.periodNames ?? (a.periodName ? [a.periodName] : []),
@@ -132,6 +137,7 @@ export const QuizAssignmentSettingsModal: React.FC<
       className: options.className.trim(),
       sessionMode: modeLocked ? assignment.sessionMode : sessionMode,
       sessionOptions,
+      attemptLimit: options.attemptLimit,
       plcMode: options.plcMode,
       teacherName: options.teacherName.trim(),
       periodName: options.selectedPeriodNames[0] ?? '',
@@ -179,6 +185,10 @@ export const QuizAssignmentSettingsModal: React.FC<
           )}
 
           <SectionHeader label="Quiz Integrity" />
+          <AttemptLimitRow
+            value={options.attemptLimit}
+            onChange={(v) => setOptions((p) => ({ ...p, attemptLimit: v }))}
+          />
           <ToggleRow
             label="Tab Switch Detection"
             checked={options.tabWarningsEnabled}
@@ -386,6 +396,49 @@ const SectionHeader: React.FC<{ label: string }> = ({ label }) => (
   <p className="text-xxs font-bold text-brand-blue-primary/60 uppercase tracking-widest pt-1">
     {label}
   </p>
+);
+
+const ATTEMPT_OPTIONS: { label: string; value: number | null }[] = [
+  { label: '1', value: 1 },
+  { label: '2', value: 2 },
+  { label: '3', value: 3 },
+  { label: 'Unlimited', value: null },
+];
+
+const AttemptLimitRow: React.FC<{
+  value: number | null;
+  onChange: (v: number | null) => void;
+}> = ({ value, onChange }) => (
+  <div>
+    <div className="flex items-center justify-between gap-3">
+      <span className="text-sm font-bold text-brand-blue-dark">
+        Attempts Allowed
+      </span>
+      <div className="inline-flex rounded-lg border border-slate-200 bg-white overflow-hidden">
+        {ATTEMPT_OPTIONS.map((opt) => {
+          const active = value === opt.value;
+          return (
+            <button
+              key={opt.label}
+              type="button"
+              onClick={() => onChange(opt.value)}
+              className={
+                'px-3 py-1.5 text-xs font-bold transition ' +
+                (active
+                  ? 'bg-brand-blue-primary text-white'
+                  : 'text-slate-600 hover:bg-slate-50')
+              }
+            >
+              {opt.label}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+    <p className="text-xxs text-slate-500 mt-0.5">
+      Remove a student from the live monitor to reset their attempt.
+    </p>
+  </div>
 );
 
 const ToggleRow: React.FC<{

--- a/components/widgets/QuizWidget/components/QuizLiveMonitor.tsx
+++ b/components/widgets/QuizWidget/components/QuizLiveMonitor.tsx
@@ -79,7 +79,13 @@ interface QuizLiveMonitorProps {
   config: QuizConfig;
   rosters: ClassRoster[];
   onUpdateConfig: (updates: Partial<QuizConfig>) => void;
-  onRemoveStudent?: (studentUid: string) => Promise<void>;
+  /**
+   * Remove a student by Firestore response-doc key. For PIN/anonymous
+   * joiners the key is `pin-{period}-{pin}`; for studentRole joiners it
+   * equals the auth uid. Pass `response._responseKey` (snapshot doc id),
+   * NOT the `studentUid` field.
+   */
+  onRemoveStudent?: (responseKey: string) => Promise<void>;
   onRevealAnswer?: (questionId: string, correctAnswer: string) => Promise<void>;
   onHideAnswer?: (questionId: string) => Promise<void>;
   /** Navigate back to the manager view without ending the quiz. */
@@ -1304,9 +1310,13 @@ export const QuizLiveMonitor: React.FC<QuizLiveMonitorProps> = ({
                             onRemove={
                               onRemoveStudent
                                 ? () => {
-                                    void Promise.resolve(
-                                      onRemoveStudent(r.studentUid)
-                                    )
+                                    // _responseKey is the Firestore doc id
+                                    // populated by the teacher snapshot
+                                    // listener. Legacy docs (old keying
+                                    // scheme) had the key equal studentUid,
+                                    // so the fallback preserves behavior.
+                                    const key = r._responseKey ?? r.studentUid;
+                                    void Promise.resolve(onRemoveStudent(key))
                                       .then(() => setConfirmRemove(null))
                                       .catch(() => undefined);
                                   }
@@ -1682,9 +1692,13 @@ export const QuizLiveMonitor: React.FC<QuizLiveMonitorProps> = ({
                             onRemove={
                               onRemoveStudent
                                 ? () => {
-                                    void Promise.resolve(
-                                      onRemoveStudent(r.studentUid)
-                                    )
+                                    // _responseKey is the Firestore doc id
+                                    // populated by the teacher snapshot
+                                    // listener. Legacy docs (old keying
+                                    // scheme) had the key equal studentUid,
+                                    // so the fallback preserves behavior.
+                                    const key = r._responseKey ?? r.studentUid;
+                                    void Promise.resolve(onRemoveStudent(key))
                                       .then(() => setConfirmRemove(null))
                                       .catch(() => undefined);
                                   }

--- a/components/widgets/QuizWidget/components/QuizLiveMonitor.tsx
+++ b/components/widgets/QuizWidget/components/QuizLiveMonitor.tsx
@@ -46,7 +46,7 @@ import {
   QuizConfig,
   ClassRoster,
 } from '@/types';
-import { gradeAnswer } from '@/hooks/useQuizSession';
+import { gradeAnswer, getResponseDocKey } from '@/hooks/useQuizSession';
 import {
   buildLiveLeaderboard,
   buildPinToNameMap,
@@ -1310,13 +1310,9 @@ export const QuizLiveMonitor: React.FC<QuizLiveMonitorProps> = ({
                             onRemove={
                               onRemoveStudent
                                 ? () => {
-                                    // _responseKey is the Firestore doc id
-                                    // populated by the teacher snapshot
-                                    // listener. Legacy docs (old keying
-                                    // scheme) had the key equal studentUid,
-                                    // so the fallback preserves behavior.
-                                    const key = r._responseKey ?? r.studentUid;
-                                    void Promise.resolve(onRemoveStudent(key))
+                                    void Promise.resolve(
+                                      onRemoveStudent(getResponseDocKey(r))
+                                    )
                                       .then(() => setConfirmRemove(null))
                                       .catch(() => undefined);
                                   }
@@ -1692,13 +1688,9 @@ export const QuizLiveMonitor: React.FC<QuizLiveMonitorProps> = ({
                             onRemove={
                               onRemoveStudent
                                 ? () => {
-                                    // _responseKey is the Firestore doc id
-                                    // populated by the teacher snapshot
-                                    // listener. Legacy docs (old keying
-                                    // scheme) had the key equal studentUid,
-                                    // so the fallback preserves behavior.
-                                    const key = r._responseKey ?? r.studentUid;
-                                    void Promise.resolve(onRemoveStudent(key))
+                                    void Promise.resolve(
+                                      onRemoveStudent(getResponseDocKey(r))
+                                    )
                                       .then(() => setConfirmRemove(null))
                                       .catch(() => undefined);
                                   }

--- a/components/widgets/QuizWidget/components/QuizManager.tsx
+++ b/components/widgets/QuizWidget/components/QuizManager.tsx
@@ -36,6 +36,7 @@ import {
   Settings as SettingsIcon,
   Pause,
   PowerOff,
+  RefreshCw,
   Calendar,
   Radio,
   Inbox,
@@ -109,6 +110,8 @@ interface QuizAssignOptions {
   streakBonusEnabled: boolean;
   showPodiumBetweenQuestions: boolean;
   soundEffectsEnabled: boolean;
+  /** Max completed submissions per student. null = unlimited. Default 1. */
+  attemptLimit: number | null;
   plcMode: boolean;
   teacherName: string;
   plcSheetUrl: string;
@@ -157,6 +160,9 @@ function buildDefaultAssignOptions(
     streakBonusEnabled: false,
     showPodiumBetweenQuestions: true,
     soundEffectsEnabled: false,
+    // Default: one attempt per student. Teachers can switch to 2/3/Unlimited
+    // in the assign modal or later in the assignment settings.
+    attemptLimit: 1,
     plcMode: config.plcMode ?? false,
     teacherName: config.teacherName ?? '',
     plcSheetUrl: config.plcSheetUrl ?? '',
@@ -206,7 +212,9 @@ interface QuizManagerProps {
     plcOptions: PlcOptions,
     sessionOptions: QuizSessionOptions,
     /** Selected roster IDs (unified picker output). */
-    rosterIds: string[]
+    rosterIds: string[],
+    /** Max completed submissions per student; null = unlimited. */
+    attemptLimit: number | null
   ) => void;
   onResults: (quiz: QuizMetadata) => void;
   onDelete: (quiz: QuizMetadata) => void | Promise<void>;
@@ -237,6 +245,8 @@ interface QuizManagerProps {
   onArchiveShare?: (assignment: QuizAssignment) => void;
   onArchivePauseResume?: (assignment: QuizAssignment) => void;
   onArchiveDeactivate?: (assignment: QuizAssignment) => void;
+  /** Reopen an ended assignment back to a paused state. */
+  onArchiveReopen?: (assignment: QuizAssignment) => void;
   onArchiveDelete?: (assignment: QuizAssignment) => void;
   /** Persist the library grid/list toggle into widget config. */
   onLibraryViewModeChange?: (mode: 'grid' | 'list') => void;
@@ -335,6 +345,7 @@ export const QuizManager: React.FC<QuizManagerProps> = ({
   onArchiveShare,
   onArchivePauseResume,
   onArchiveDeactivate,
+  onArchiveReopen,
   onArchiveDelete,
   onLibraryViewModeChange,
 }) => {
@@ -625,6 +636,12 @@ export const QuizManager: React.FC<QuizManagerProps> = ({
       onClick: () => (onArchiveShare ?? noop)(a),
     });
     secondaries.push({
+      id: 'reopen',
+      label: 'Reopen',
+      icon: RefreshCw,
+      onClick: () => (onArchiveReopen ?? noop)(a),
+    });
+    secondaries.push({
       id: 'delete',
       label: 'Delete',
       icon: Trash2,
@@ -690,7 +707,8 @@ export const QuizManager: React.FC<QuizManagerProps> = ({
       selectedMode,
       plcOptions,
       sessionOptions,
-      validRosterIds
+      validRosterIds,
+      assignOptions.attemptLimit
     );
     setAssignTarget(null);
     setSelectedMode(null);
@@ -1307,6 +1325,10 @@ const AssignExtraSlot: React.FC<{
       />
 
       <SectionHeader label="Quiz Integrity" />
+      <AttemptLimitRow
+        value={options.attemptLimit}
+        onChange={(v) => update('attemptLimit', v)}
+      />
       <ToggleRow
         label="Tab Switch Detection"
         checked={options.tabWarningsEnabled}
@@ -1476,6 +1498,49 @@ const ToggleRow: React.FC<{
       <Toggle checked={checked} onChange={onChange} size="sm" showLabels />
     </div>
     {hint && <p className="text-xxs text-slate-500 mt-0.5">{hint}</p>}
+  </div>
+);
+
+const ATTEMPT_OPTIONS: { label: string; value: number | null }[] = [
+  { label: '1', value: 1 },
+  { label: '2', value: 2 },
+  { label: '3', value: 3 },
+  { label: 'Unlimited', value: null },
+];
+
+const AttemptLimitRow: React.FC<{
+  value: number | null;
+  onChange: (v: number | null) => void;
+}> = ({ value, onChange }) => (
+  <div>
+    <div className="flex items-center justify-between gap-3">
+      <span className="text-sm font-bold text-brand-blue-dark">
+        Attempts Allowed
+      </span>
+      <div className="inline-flex rounded-lg border border-slate-200 bg-white overflow-hidden">
+        {ATTEMPT_OPTIONS.map((opt) => {
+          const active = value === opt.value;
+          return (
+            <button
+              key={opt.label}
+              type="button"
+              onClick={() => onChange(opt.value)}
+              className={
+                'px-3 py-1.5 text-xs font-bold transition ' +
+                (active
+                  ? 'bg-brand-blue-primary text-white'
+                  : 'text-slate-600 hover:bg-slate-50')
+              }
+            >
+              {opt.label}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+    <p className="text-xxs text-slate-500 mt-0.5">
+      Remove a student from the live monitor to reset their attempt.
+    </p>
   </div>
 );
 

--- a/components/widgets/QuizWidget/components/QuizManager.tsx
+++ b/components/widgets/QuizWidget/components/QuizManager.tsx
@@ -52,6 +52,7 @@ import {
   QuizAssignment,
 } from '@/types';
 import { type QuizSessionOptions } from '@/hooks/useQuizSession';
+import { AttemptLimitRow } from './AttemptLimitRow';
 import { Toggle } from '@/components/common/Toggle';
 import { AssignClassPicker } from '@/components/common/AssignClassPicker';
 import {
@@ -1498,49 +1499,6 @@ const ToggleRow: React.FC<{
       <Toggle checked={checked} onChange={onChange} size="sm" showLabels />
     </div>
     {hint && <p className="text-xxs text-slate-500 mt-0.5">{hint}</p>}
-  </div>
-);
-
-const ATTEMPT_OPTIONS: { label: string; value: number | null }[] = [
-  { label: '1', value: 1 },
-  { label: '2', value: 2 },
-  { label: '3', value: 3 },
-  { label: 'Unlimited', value: null },
-];
-
-const AttemptLimitRow: React.FC<{
-  value: number | null;
-  onChange: (v: number | null) => void;
-}> = ({ value, onChange }) => (
-  <div>
-    <div className="flex items-center justify-between gap-3">
-      <span className="text-sm font-bold text-brand-blue-dark">
-        Attempts Allowed
-      </span>
-      <div className="inline-flex rounded-lg border border-slate-200 bg-white overflow-hidden">
-        {ATTEMPT_OPTIONS.map((opt) => {
-          const active = value === opt.value;
-          return (
-            <button
-              key={opt.label}
-              type="button"
-              onClick={() => onChange(opt.value)}
-              className={
-                'px-3 py-1.5 text-xs font-bold transition ' +
-                (active
-                  ? 'bg-brand-blue-primary text-white'
-                  : 'text-slate-600 hover:bg-slate-50')
-              }
-            >
-              {opt.label}
-            </button>
-          );
-        })}
-      </div>
-    </div>
-    <p className="text-xxs text-slate-500 mt-0.5">
-      Remove a student from the live monitor to reset their attempt.
-    </p>
   </div>
 );
 

--- a/components/widgets/QuizWidget/components/QuizResults.tsx
+++ b/components/widgets/QuizWidget/components/QuizResults.tsx
@@ -535,6 +535,7 @@ export const QuizResults: React.FC<QuizResultsProps> = ({
                 tabWarningsEnabled={tabWarningsEnabled ?? true}
                 session={session}
                 onDeleteResponse={onDeleteResponse}
+                addToast={addToast}
               />
             )}
           </div>
@@ -807,6 +808,7 @@ const StudentsTab: React.FC<{
   tabWarningsEnabled: boolean;
   session?: import('@/types').QuizSession | null;
   onDeleteResponse?: (responseKey: string) => Promise<void>;
+  addToast: (message: string, type?: import('@/types').Toast['type']) => void;
 }> = ({
   responses,
   questions,
@@ -815,6 +817,7 @@ const StudentsTab: React.FC<{
   tabWarningsEnabled,
   session,
   onDeleteResponse,
+  addToast,
 }) => {
   const [showResults, setShowResults] = useState(false);
   const [confirmDeleteKey, setConfirmDeleteKey] = useState<string | null>(null);
@@ -920,8 +923,9 @@ const StudentsTab: React.FC<{
                             '[QuizResults] failed to delete response',
                             err
                           );
-                          window.alert(
-                            `Failed to delete ${displayName}\u2019s submission. Please try again.`
+                          addToast(
+                            `Failed to delete ${displayName}\u2019s submission. Please try again.`,
+                            'error'
                           );
                         })
                         .finally(() => {

--- a/components/widgets/QuizWidget/components/QuizResults.tsx
+++ b/components/widgets/QuizWidget/components/QuizResults.tsx
@@ -32,7 +32,7 @@ import {
 import { QuizResponse, QuizData, QuizQuestion, QuizConfig } from '@/types';
 import { useAuth } from '@/context/useAuth';
 import { QuizDriveService } from '@/utils/quizDriveService';
-import { gradeAnswer } from '@/hooks/useQuizSession';
+import { gradeAnswer, getResponseDocKey } from '@/hooks/useQuizSession';
 import { useDashboard } from '@/context/useDashboard';
 import {
   buildPinToNameMap,
@@ -888,7 +888,7 @@ const StudentsTab: React.FC<{
             const rosterName = pinToName[r.pin];
             const displayName = classLinkName || rosterName || `PIN ${r.pin}`;
             const isResolved = Boolean(classLinkName || rosterName);
-            const rowKey = r._responseKey ?? r.studentUid;
+            const rowKey = getResponseDocKey(r);
             const canDelete = Boolean(onDeleteResponse);
             const isConfirming = confirmDeleteKey === rowKey;
             const isDeleting = deletingKey === rowKey;

--- a/components/widgets/QuizWidget/components/QuizResults.tsx
+++ b/components/widgets/QuizWidget/components/QuizResults.tsx
@@ -909,9 +909,24 @@ const StudentsTab: React.FC<{
                     onClick={() => {
                       setDeletingKey(rowKey);
                       setConfirmDeleteKey(null);
-                      void onDeleteResponse?.(rowKey).finally(() => {
+                      const pending = onDeleteResponse?.(rowKey);
+                      if (!pending) {
                         setDeletingKey((k) => (k === rowKey ? null : k));
-                      });
+                        return;
+                      }
+                      void pending
+                        .catch((err: unknown) => {
+                          console.error(
+                            '[QuizResults] failed to delete response',
+                            err
+                          );
+                          window.alert(
+                            `Failed to delete ${displayName}\u2019s submission. Please try again.`
+                          );
+                        })
+                        .finally(() => {
+                          setDeletingKey((k) => (k === rowKey ? null : k));
+                        });
                     }}
                     disabled={isDeleting}
                     className="bg-red-500 hover:bg-red-600 disabled:opacity-50 text-white font-bold rounded-lg px-3 py-1"

--- a/components/widgets/QuizWidget/components/QuizResults.tsx
+++ b/components/widgets/QuizWidget/components/QuizResults.tsx
@@ -27,6 +27,7 @@ import {
   EyeOff,
   User,
   Hash,
+  Trash2,
 } from 'lucide-react';
 import { QuizResponse, QuizData, QuizQuestion, QuizConfig } from '@/types';
 import { useAuth } from '@/context/useAuth';
@@ -56,6 +57,13 @@ interface QuizResultsProps {
   onBack: () => void;
   tabWarningsEnabled?: boolean;
   session?: import('@/types').QuizSession | null;
+  /**
+   * Delete a single student response by its deterministic Firestore doc key
+   * (falls back to `studentUid` for legacy docs written before keying moved
+   * to `pin-{period}-{pin}`). The snapshot listener will remove the row and
+   * all derived stats/exports will recompute automatically.
+   */
+  onDeleteResponse?: (responseKey: string) => Promise<void>;
 }
 
 export const QuizResults: React.FC<QuizResultsProps> = ({
@@ -65,6 +73,7 @@ export const QuizResults: React.FC<QuizResultsProps> = ({
   onBack,
   tabWarningsEnabled,
   session,
+  onDeleteResponse,
 }) => {
   const { activeDashboard, updateWidget, addWidget, addToast, rosters } =
     useDashboard();
@@ -525,6 +534,7 @@ export const QuizResults: React.FC<QuizResultsProps> = ({
                 byStudentUid={byStudentUid}
                 tabWarningsEnabled={tabWarningsEnabled ?? true}
                 session={session}
+                onDeleteResponse={onDeleteResponse}
               />
             )}
           </div>
@@ -796,6 +806,7 @@ const StudentsTab: React.FC<{
   >;
   tabWarningsEnabled: boolean;
   session?: import('@/types').QuizSession | null;
+  onDeleteResponse?: (responseKey: string) => Promise<void>;
 }> = ({
   responses,
   questions,
@@ -803,8 +814,11 @@ const StudentsTab: React.FC<{
   byStudentUid,
   tabWarningsEnabled,
   session,
+  onDeleteResponse,
 }) => {
   const [showResults, setShowResults] = useState(false);
+  const [confirmDeleteKey, setConfirmDeleteKey] = useState<string | null>(null);
+  const [deletingKey, setDeletingKey] = useState<string | null>(null);
   const maxPoints = questions.reduce((sum, q) => sum + (q.points ?? 1), 0);
   const gamified = isGamificationActive(session);
   const suffix = getScoreSuffix(session);
@@ -874,10 +888,51 @@ const StudentsTab: React.FC<{
             const rosterName = pinToName[r.pin];
             const displayName = classLinkName || rosterName || `PIN ${r.pin}`;
             const isResolved = Boolean(classLinkName || rosterName);
+            const rowKey = r._responseKey ?? r.studentUid;
+            const canDelete = Boolean(onDeleteResponse);
+            const isConfirming = confirmDeleteKey === rowKey;
+            const isDeleting = deletingKey === rowKey;
+
+            if (isConfirming) {
+              return (
+                <div
+                  key={rowKey}
+                  className="flex items-center rounded-xl border bg-red-50 border-red-200 p-3 gap-2"
+                >
+                  <span
+                    className="flex-1 text-red-700 font-bold truncate"
+                    style={{ fontSize: 'min(12px, 4cqmin)' }}
+                  >
+                    Delete {displayName}&rsquo;s submission?
+                  </span>
+                  <button
+                    onClick={() => {
+                      setDeletingKey(rowKey);
+                      setConfirmDeleteKey(null);
+                      void onDeleteResponse?.(rowKey).finally(() => {
+                        setDeletingKey((k) => (k === rowKey ? null : k));
+                      });
+                    }}
+                    disabled={isDeleting}
+                    className="bg-red-500 hover:bg-red-600 disabled:opacity-50 text-white font-bold rounded-lg px-3 py-1"
+                    style={{ fontSize: 'min(11px, 3cqmin)' }}
+                  >
+                    Yes
+                  </button>
+                  <button
+                    onClick={() => setConfirmDeleteKey(null)}
+                    className="bg-slate-200 hover:bg-slate-300 text-slate-700 font-bold rounded-lg px-3 py-1"
+                    style={{ fontSize: 'min(11px, 3cqmin)' }}
+                  >
+                    Cancel
+                  </button>
+                </div>
+              );
+            }
 
             return (
               <div
-                key={r.studentUid}
+                key={rowKey}
                 className="flex items-center bg-white border border-brand-blue-primary/10 rounded-xl p-3 shadow-sm hover:shadow-md transition-all"
               >
                 <div className="flex-1 min-w-0">
@@ -928,6 +983,33 @@ const StudentsTab: React.FC<{
                     </div>
                   )}
                 </div>
+
+                {canDelete && (
+                  <button
+                    onClick={() => setConfirmDeleteKey(rowKey)}
+                    disabled={isDeleting}
+                    title="Delete this submission"
+                    aria-label={`Delete ${displayName}'s submission`}
+                    className="ml-2 shrink-0 p-1.5 rounded-lg text-brand-red-primary/50 hover:text-brand-red-primary hover:bg-brand-red-primary/10 disabled:opacity-30 transition-colors"
+                  >
+                    {isDeleting ? (
+                      <Loader2
+                        className="animate-spin"
+                        style={{
+                          width: 'min(14px, 4cqmin)',
+                          height: 'min(14px, 4cqmin)',
+                        }}
+                      />
+                    ) : (
+                      <Trash2
+                        style={{
+                          width: 'min(14px, 4cqmin)',
+                          height: 'min(14px, 4cqmin)',
+                        }}
+                      />
+                    )}
+                  </button>
+                )}
               </div>
             );
           })}

--- a/firestore.rules
+++ b/firestore.rules
@@ -675,8 +675,15 @@ service cloud.firestore {
           return get(/databases/$(database)/documents/quiz_sessions/$(sessionId)).data.get('classIds', []);
         }
 
+        // `resource == null` short-circuits reads on non-existent docs: the
+        // student-app join flow calls getDoc() to probe whether a response
+        // already exists before deciding to create or resume, and the rules
+        // engine throws a Null value error on `resource.data.studentUid`
+        // when the doc doesn't exist. Permitting the empty-snapshot read
+        // leaks nothing (response keys are already predictable via PIN).
         allow read: if request.auth != null &&
-          (request.auth.uid == sessionTeacherUid() ||
+          (resource == null ||
+           request.auth.uid == sessionTeacherUid() ||
            (request.auth.uid == resource.data.studentUid && passesStudentClassGateCompat(sessionClassIds(), sessionClassId())) ||
            isAdmin());
         // Create is only ever invoked when the doc doesn't yet exist

--- a/firestore.rules
+++ b/firestore.rules
@@ -675,17 +675,20 @@ service cloud.firestore {
           return get(/databases/$(database)/documents/quiz_sessions/$(sessionId)).data.get('classIds', []);
         }
 
-        // `resource == null` short-circuits reads on non-existent docs: the
-        // student-app join flow calls getDoc() to probe whether a response
-        // already exists before deciding to create or resume, and the rules
-        // engine throws a Null value error on `resource.data.studentUid`
-        // when the doc doesn't exist. Permitting the empty-snapshot read
-        // leaks nothing (response keys are already predictable via PIN).
-        allow read: if request.auth != null &&
-          (resource == null ||
-           request.auth.uid == sessionTeacherUid() ||
-           (request.auth.uid == resource.data.studentUid && passesStudentClassGateCompat(sessionClassIds(), sessionClassId())) ||
-           isAdmin());
+        // Student branch allows `resource == null` so the student-app join
+        // flow can call getDoc() to probe whether a response already exists
+        // before deciding to create or resume — without it the rules engine
+        // throws a Null value error on `resource.data.studentUid`. The
+        // class-gate check is kept as a hard prerequisite so a studentRole
+        // user can't probe responses in a session they're not enrolled in
+        // (anonymous PIN users pass the gate by definition, matching the
+        // legacy "any authenticated joiner can probe" behavior).
+        allow read: if request.auth != null && (
+          request.auth.uid == sessionTeacherUid() ||
+          isAdmin() ||
+          (passesStudentClassGateCompat(sessionClassIds(), sessionClassId()) &&
+           (resource == null || request.auth.uid == resource.data.studentUid))
+        );
         // Create is only ever invoked when the doc doesn't yet exist
         // (Firestore semantics), so the deterministic response key naturally
         // enforces one-doc-per-roster-student. Field-based ownership: the

--- a/firestore.rules
+++ b/firestore.rules
@@ -652,10 +652,15 @@ service cloud.firestore {
       allow update, delete: if request.auth != null &&
         resource.data.teacherUid == request.auth.uid;
 
-      match /responses/{studentUid} {
+      match /responses/{responseKey} {
         // Quiz response records store only a PIN — no student name or email.
-        // Students join using anonymous Firebase Auth; their anonymous UID is
-        // the document key. This satisfies request.auth != null without PII.
+        //
+        // Doc-keying note: {responseKey} is no longer guaranteed to equal the
+        // student's auth uid. For studentRole (SSO) joiners it still does;
+        // for anonymous PIN joiners it is `pin-{classPeriod}-{pin}` so the
+        // attempt limit survives device/storage resets. Ownership checks
+        // therefore compare against the `studentUid` field on the doc, not
+        // against the wildcard key.
         //
         // Teacher ownership is looked up from the parent session doc because
         // the sessionId is no longer the teacher's uid. This adds one get()
@@ -672,11 +677,14 @@ service cloud.firestore {
 
         allow read: if request.auth != null &&
           (request.auth.uid == sessionTeacherUid() ||
-           (request.auth.uid == studentUid && passesStudentClassGateCompat(sessionClassIds(), sessionClassId())) ||
+           (request.auth.uid == resource.data.studentUid && passesStudentClassGateCompat(sessionClassIds(), sessionClassId())) ||
            isAdmin());
+        // Create is only ever invoked when the doc doesn't yet exist
+        // (Firestore semantics), so the deterministic response key naturally
+        // enforces one-doc-per-roster-student. Field-based ownership: the
+        // writer's auth.uid must match the `studentUid` they're writing.
         allow create: if request.auth != null &&
-          request.auth.uid == studentUid &&
-          request.resource.data.studentUid == studentUid &&
+          request.resource.data.studentUid == request.auth.uid &&
           // Students cannot forge a score on creation
           request.resource.data.score == null &&
           // studentRole users must be enrolled in the session's class
@@ -685,11 +693,13 @@ service cloud.firestore {
           // Teacher and admins can update any field
           request.auth.uid == sessionTeacherUid() || isAdmin() ||
           // Students may only update their own response to submit answers.
+          // Ownership is enforced against the `studentUid` field, not the
+          // doc key (which may be pin-derived for anonymous joiners).
           // pin and join metadata are immutable; only answers, status,
           // submittedAt, and tabSwitchWarnings may change.
           // score is never written by students.
           // tabSwitchWarnings may only increase (monotonic) to prevent tampering.
-          (request.auth.uid == studentUid &&
+          (request.auth.uid == resource.data.studentUid &&
            passesStudentClassGateCompat(sessionClassIds(), sessionClassId()) &&
            request.resource.data.studentUid == resource.data.studentUid &&
            request.resource.data.pin == resource.data.pin &&

--- a/firestore.rules
+++ b/firestore.rules
@@ -693,32 +693,60 @@ service cloud.firestore {
         // (Firestore semantics), so the deterministic response key naturally
         // enforces one-doc-per-roster-student. Field-based ownership: the
         // writer's auth.uid must match the `studentUid` they're writing.
+        //
+        // Key-format constraint: with deterministic keys any authenticated
+        // roster-mate who knows PIN+period could otherwise grief-create a
+        // victim's doc under an arbitrary key. We tighten this by requiring:
+        //   - studentRole (SSO) writers use `responseKey == auth.uid` (the
+        //     same key scheme the client computes for them).
+        //   - Anonymous (PIN) writers use a key matching the shape
+        //     `pin-{encodedPeriod}-{encodedPin}` with `[a-z0-9_]` segments.
+        //     This mirrors `encodeResponseKeySegment()` on the client.
+        // Classmate-on-classmate grief with both parties on the same
+        // PIN+period is not fully preventable here (shared-secret design);
+        // the cross-auth-type paths are now closed.
         allow create: if request.auth != null &&
           request.resource.data.studentUid == request.auth.uid &&
           // Students cannot forge a score on creation
           request.resource.data.score == null &&
+          // Students cannot forge prior completions
+          request.resource.data.get('completedAttempts', 0) == 0 &&
           // studentRole users must be enrolled in the session's class
-          passesStudentClassGateCompat(sessionClassIds(), sessionClassId());
+          passesStudentClassGateCompat(sessionClassIds(), sessionClassId()) &&
+          (isStudentRoleAuth()
+            ? responseKey == request.auth.uid
+            : responseKey.matches('^pin-[a-z0-9_]+-[a-z0-9_]+$'));
         allow update: if request.auth != null && (
           // Teacher and admins can update any field
           request.auth.uid == sessionTeacherUid() || isAdmin() ||
-          // Students may only update their own response to submit answers.
-          // Ownership is enforced against the `studentUid` field, not the
-          // doc key (which may be pin-derived for anonymous joiners).
-          // pin and join metadata are immutable; only answers, status,
-          // submittedAt, and tabSwitchWarnings may change.
-          // score is never written by students.
-          // tabSwitchWarnings may only increase (monotonic) to prevent tampering.
+          // Students may only update their own response to submit answers
+          // or to re-join under the attempt cap. Ownership is enforced
+          // against the `studentUid` field, not the doc key (which may be
+          // pin-derived for anonymous joiners).
+          //
+          // Mutable fields: answers, status, submittedAt, tabSwitchWarnings,
+          // completedAttempts, classPeriod, score (score is reset to null on
+          // rejoin; students still can't forge a real score — see below).
+          // pin and join metadata are immutable.
+          //
+          // Monotonic fields (prevent rollback tampering): tabSwitchWarnings
+          // and completedAttempts may only stay the same or increase.
+          //
+          // Score guard: students may only ever write null to `score` — this
+          // blocks a forged high score while still allowing the rejoin reset
+          // flow to clear a previously null value to null.
           (request.auth.uid == resource.data.studentUid &&
            passesStudentClassGateCompat(sessionClassIds(), sessionClassId()) &&
            request.resource.data.studentUid == resource.data.studentUid &&
            request.resource.data.pin == resource.data.pin &&
            request.resource.data.joinedAt == resource.data.joinedAt &&
-           request.resource.data.score == resource.data.score &&
+           request.resource.data.score == null &&
            request.resource.data.diff(resource.data)
-             .changedKeys().hasOnly(['answers', 'status', 'submittedAt', 'tabSwitchWarnings']) &&
+             .changedKeys().hasOnly(['answers', 'status', 'submittedAt', 'tabSwitchWarnings', 'completedAttempts', 'classPeriod', 'score']) &&
            (!request.resource.data.diff(resource.data).affectedKeys().hasAny(['tabSwitchWarnings']) ||
-            request.resource.data.tabSwitchWarnings >= resource.data.get('tabSwitchWarnings', 0)))
+            request.resource.data.tabSwitchWarnings >= resource.data.get('tabSwitchWarnings', 0)) &&
+           (!request.resource.data.diff(resource.data).affectedKeys().hasAny(['completedAttempts']) ||
+            request.resource.data.get('completedAttempts', 0) >= resource.data.get('completedAttempts', 0)))
         );
         allow delete: if request.auth != null &&
           (request.auth.uid == sessionTeacherUid() || isAdmin());

--- a/firestore.rules
+++ b/firestore.rules
@@ -713,7 +713,7 @@ service cloud.firestore {
           request.resource.data.get('completedAttempts', 0) == 0 &&
           // studentRole users must be enrolled in the session's class
           passesStudentClassGateCompat(sessionClassIds(), sessionClassId()) &&
-          (isStudentRoleAuth()
+          (isStudentRoleUser()
             ? responseKey == request.auth.uid
             : responseKey.matches('^pin-[a-z0-9_]+-[a-z0-9_]+$'));
         allow update: if request.auth != null && (

--- a/hooks/useQuizAssignments.ts
+++ b/hooks/useQuizAssignments.ts
@@ -307,7 +307,14 @@ export const useQuizAssignments = (
       if (sessionStatus === 'paused' || sessionStatus === 'ended') {
         sessionPatch.autoProgressAt = null;
       }
-      if (sessionStatus === 'ended') sessionPatch.endedAt = now;
+      if (sessionStatus === 'ended') {
+        sessionPatch.endedAt = now;
+      } else {
+        // Clear `endedAt` on any transition away from 'ended' so a reopened
+        // session doesn't carry stale end-timestamp state that downstream
+        // consumers would misread as "session is over".
+        sessionPatch.endedAt = null;
+      }
       batch.update(
         doc(db, QUIZ_SESSIONS_COLLECTION, assignmentId),
         sessionPatch

--- a/hooks/useQuizAssignments.ts
+++ b/hooks/useQuizAssignments.ts
@@ -84,6 +84,12 @@ export interface UseQuizAssignmentsResult {
   resumeAssignment: (assignmentId: string) => Promise<void>;
   /** Kills the student URL; preserves responses. assignment='inactive', session='ended'. */
   deactivateAssignment: (assignmentId: string) => Promise<void>;
+  /**
+   * Reopen a previously deactivated (inactive) assignment. Returns it to
+   * 'paused' so the teacher can review state before resuming; they must
+   * explicitly call `resumeAssignment` to start accepting submissions again.
+   */
+  reopenAssignment: (assignmentId: string) => Promise<void>;
   /** Permanently delete assignment + session + all responses. */
   deleteAssignment: (assignmentId: string) => Promise<void>;
   /** Update editable settings (className, PLC fields, session toggles). */
@@ -215,6 +221,7 @@ export const useQuizAssignments = (
         periodName: settings.periodName,
         periodNames: settings.periodNames,
         plcMemberEmails: settings.plcMemberEmails,
+        attemptLimit: settings.attemptLimit ?? null,
         ...(targetRosterIds.length > 0 ? { rosterIds: targetRosterIds } : {}),
       };
 
@@ -264,6 +271,7 @@ export const useQuizAssignments = (
           ? { classIds: targetClassIds, classId: targetClassIds[0] }
           : {}),
         ...(targetRosterIds.length > 0 ? { rosterIds: targetRosterIds } : {}),
+        attemptLimit: settings.attemptLimit ?? null,
       };
 
       const batch = writeBatch(db);
@@ -353,6 +361,15 @@ export const useQuizAssignments = (
     [setStatus]
   );
 
+  const reopenAssignment = useCallback<
+    UseQuizAssignmentsResult['reopenAssignment']
+  >(
+    async (assignmentId) => {
+      await setStatus(assignmentId, 'paused', 'paused');
+    },
+    [setStatus]
+  );
+
   const deleteAssignment = useCallback<
     UseQuizAssignmentsResult['deleteAssignment']
   >(
@@ -404,6 +421,8 @@ export const useQuizAssignments = (
       const sessionPatch: Record<string, unknown> = {};
       if ('periodNames' in patch) sessionPatch.periodNames = patch.periodNames;
       if ('periodName' in patch) sessionPatch.periodName = patch.periodName;
+      if ('attemptLimit' in patch)
+        sessionPatch.attemptLimit = patch.attemptLimit ?? null;
       if (patch.sessionOptions) {
         const o = patch.sessionOptions;
         if (o.tabWarningsEnabled !== undefined)
@@ -535,6 +554,7 @@ export const useQuizAssignments = (
     pauseAssignment,
     resumeAssignment,
     deactivateAssignment,
+    reopenAssignment,
     deleteAssignment,
     updateAssignmentSettings,
     shareAssignment,

--- a/hooks/useQuizSession.ts
+++ b/hooks/useQuizSession.ts
@@ -28,6 +28,7 @@ import {
   writeBatch,
   increment,
   deleteField,
+  type DocumentSnapshot,
 } from 'firebase/firestore';
 import { db, auth } from '../config/firebase';
 import { signInAnonymously } from 'firebase/auth';
@@ -157,6 +158,58 @@ function computeResponseKey(
   if (!isAnonymous) return authUid;
   const period = classPeriod ?? 'default';
   return `pin-${period}-${pin}`;
+}
+
+/**
+ * Resolve the Firestore doc id for a given response. The snapshot listeners
+ * attach `_responseKey` to every row so teacher-side UI can target the
+ * underlying doc without knowing the keying scheme; legacy rows predating
+ * that field still equate the key with `studentUid`, hence the fallback.
+ */
+export function getResponseDocKey(response: QuizResponse): string {
+  return response._responseKey ?? response.studentUid;
+}
+
+/**
+ * Look up the student's response doc for a session, trying the deterministic
+ * key first and falling back to the legacy auth-uid key for anonymous PIN
+ * joiners whose in-progress doc was written under the old keying scheme.
+ * Returns the resolved key and the snapshot (existent or not) so the caller
+ * can branch on `snap.exists()` without re-fetching.
+ */
+async function findExistingResponseDoc(
+  sessionId: string,
+  authUid: string,
+  isAnonymous: boolean,
+  deterministicKey: string
+): Promise<{ key: string; snap: DocumentSnapshot }> {
+  const deterministicSnap = await getDoc(
+    doc(
+      db,
+      QUIZ_SESSIONS_COLLECTION,
+      sessionId,
+      RESPONSES_COLLECTION,
+      deterministicKey
+    )
+  );
+  if (deterministicSnap.exists()) {
+    return { key: deterministicKey, snap: deterministicSnap };
+  }
+  if (isAnonymous && deterministicKey !== authUid) {
+    const legacySnap = await getDoc(
+      doc(
+        db,
+        QUIZ_SESSIONS_COLLECTION,
+        sessionId,
+        RESPONSES_COLLECTION,
+        authUid
+      )
+    );
+    if (legacySnap.exists()) {
+      return { key: authUid, snap: legacySnap };
+    }
+  }
+  return { key: deterministicKey, snap: deterministicSnap };
 }
 
 // ─── Teacher hook ─────────────────────────────────────────────────────────────
@@ -648,49 +701,21 @@ export const useQuizSessionStudent = (): UseQuizSessionStudentResult => {
         // Deterministic doc key: stable per-roster-student for PIN auth so
         // the attempt limit can't be bypassed by clearing storage / switching
         // device. studentRole users still key by their auth uid (stable per
-        // user already).
+        // user already). The helper also handles the legacy-key fallback
+        // for anonymous students rejoining pre-deterministic-keying sessions.
         const deterministicKey = computeResponseKey(
           studentUid,
           currentUser.isAnonymous,
           sanitizedPin,
           classPeriod
         );
-
-        // Legacy-key fallback: before deterministic keying, every response
-        // (including anonymous PIN joiners) was keyed by `auth.uid`. If the
-        // student is rejoining an in-progress session that was created under
-        // the old scheme, resume at the legacy key so their in-flight work
-        // isn't lost and the teacher doesn't see a duplicate row. New docs
-        // are always created at the deterministic key.
-        let responseKey = deterministicKey;
-        let existingSnap = await getDoc(
-          doc(
-            db,
-            QUIZ_SESSIONS_COLLECTION,
+        const { key: responseKey, snap: existingSnap } =
+          await findExistingResponseDoc(
             sessionDoc.id,
-            RESPONSES_COLLECTION,
+            studentUid,
+            currentUser.isAnonymous,
             deterministicKey
-          )
-        );
-        if (
-          !existingSnap.exists() &&
-          currentUser.isAnonymous &&
-          deterministicKey !== studentUid
-        ) {
-          const legacySnap = await getDoc(
-            doc(
-              db,
-              QUIZ_SESSIONS_COLLECTION,
-              sessionDoc.id,
-              RESPONSES_COLLECTION,
-              studentUid
-            )
           );
-          if (legacySnap.exists()) {
-            responseKey = studentUid;
-            existingSnap = legacySnap;
-          }
-        }
 
         sessionIdRef.current = sessionDoc.id;
         responseKeyRef.current = responseKey;

--- a/hooks/useQuizSession.ts
+++ b/hooks/useQuizSession.ts
@@ -137,6 +137,29 @@ export class AttemptLimitReachedError extends Error {
 }
 
 /**
+ * Normalize a string for use as a segment inside a Firestore response doc id.
+ *
+ * Roster period names and pins are teacher-defined free text and can contain
+ * `/`, whitespace, or other characters that would either split the doc path
+ * or break the `pin-{period}-{pin}` parse contract enforced by
+ * `firestore.rules`. We collapse everything non-alphanumeric to `_` and
+ * lowercase the result so the encoding is stable across the client and the
+ * rules predicate (`^pin-[a-z0-9_]+-[a-z0-9_]+$`).
+ *
+ * Empty / all-separator inputs fall back to `'default'` rather than producing
+ * a zero-length segment that would collapse the doc path.
+ *
+ * Exported so firestore rules tests can assert the same mapping.
+ */
+export function encodeResponseKeySegment(value: string | undefined): string {
+  const trimmed = (value ?? '').trim();
+  if (!trimmed) return 'default';
+  const normalized = trimmed.toLowerCase().replace(/[^a-z0-9]+/g, '_');
+  const stripped = normalized.replace(/^_+|_+$/g, '');
+  return stripped || 'default';
+}
+
+/**
  * Compute the deterministic response-doc key.
  *
  * For studentRole (real SSO) auth, we continue to key by `auth.uid` because
@@ -146,18 +169,17 @@ export class AttemptLimitReachedError extends Error {
  * is stable per-roster-student.
  *
  * Known limitation: two rosters assigned to the same session with overlapping
- * PINs under the same classPeriod would collide on the same doc key. Rosters
- * are normally period-scoped, so this is expected to be rare.
+ * PINs under the same (normalized) classPeriod would collide on the same doc
+ * key. Rosters are normally period-scoped, so this is expected to be rare.
  */
-function computeResponseKey(
+export function computeResponseKey(
   authUid: string,
   isAnonymous: boolean,
   pin: string,
   classPeriod: string | undefined
 ): string {
   if (!isAnonymous) return authUid;
-  const period = classPeriod ?? 'default';
-  return `pin-${period}-${pin}`;
+  return `pin-${encodeResponseKeySegment(classPeriod)}-${encodeResponseKeySegment(pin)}`;
 }
 
 /**
@@ -733,14 +755,39 @@ export const useQuizSessionStudent = (): UseQuizSessionStudentResult => {
           responseKey
         );
 
+        // Attempt-limit enforcement.
+        //   - `attemptLimit == null/undefined` means unlimited (legacy).
+        //   - Limit is compared against `completedAttempts` (counter field).
+        //   - Legacy docs with `status === 'completed'` but no counter are
+        //     treated as 1 completed attempt so pre-upgrade submissions still
+        //     count against the cap.
+        //   - If the student is under the limit, reset the completed doc to
+        //     a fresh 'joined' state so the next join starts a new attempt,
+        //     preserving `completedAttempts` to enforce the cap on future
+        //     submissions.
+        const limit = sessionData.attemptLimit ?? null;
         if (existingSnap.exists()) {
           const existing = existingSnap.data() as QuizResponse;
-          // Attempt-limit enforcement. `attemptLimit == null/undefined` means
-          // unlimited (legacy sessions). A completed doc occupies the slot;
-          // teachers reset by deleting it via removeStudent.
-          const limit = sessionData.attemptLimit ?? null;
-          if (limit !== null && existing.status === 'completed') {
-            throw new AttemptLimitReachedError();
+          if (existing.status === 'completed') {
+            const completed = existing.completedAttempts ?? 1;
+            if (limit !== null && completed >= limit) {
+              throw new AttemptLimitReachedError();
+            }
+            // Under the cap (or unlimited): reset for a new attempt.
+            await updateDoc(responseRef, {
+              status: 'joined',
+              answers: [],
+              score: null,
+              submittedAt: null,
+              ...(classPeriod && existing.classPeriod !== classPeriod
+                ? { classPeriod }
+                : {}),
+            });
+          } else if (classPeriod && existing.classPeriod !== classPeriod) {
+            // Backfill classPeriod on an in-flight response (e.g. student
+            // joined before periods were configured or reloaded after a
+            // change).
+            await updateDoc(responseRef, { classPeriod });
           }
         }
 
@@ -760,16 +807,10 @@ export const useQuizSessionStudent = (): UseQuizSessionStudentResult => {
             answers: [],
             score: null,
             submittedAt: null,
+            completedAttempts: 0,
             ...(classPeriod ? { classPeriod } : {}),
           };
           await setDoc(responseRef, newResponse);
-        } else if (classPeriod) {
-          // Backfill classPeriod on existing response (e.g. student joined
-          // before periods were configured, or reloaded after a change).
-          const existing = existingSnap.data() as QuizResponse;
-          if (existing.classPeriod !== classPeriod) {
-            await updateDoc(responseRef, { classPeriod });
-          }
         }
 
         setSession(sessionData);
@@ -830,6 +871,8 @@ export const useQuizSessionStudent = (): UseQuizSessionStudentResult => {
 
     // Score is computed from gradeAnswer() by the teacher/results view,
     // not written by the student, to prevent client-side forgery of the score field.
+    // Increment `completedAttempts` so the attempt-limit check on the next
+    // join can count this submission (and block once the cap is reached).
     await updateDoc(
       doc(
         db,
@@ -838,7 +881,11 @@ export const useQuizSessionStudent = (): UseQuizSessionStudentResult => {
         RESPONSES_COLLECTION,
         responseKey
       ),
-      { status: 'completed', submittedAt: Date.now() }
+      {
+        status: 'completed',
+        submittedAt: Date.now(),
+        completedAttempts: increment(1),
+      }
     );
   }, []);
 

--- a/hooks/useQuizSession.ts
+++ b/hooks/useQuizSession.ts
@@ -120,6 +120,45 @@ export function gradeAnswer(
   return false;
 }
 
+/**
+ * Thrown by `joinQuizSession` when a student attempts to join a session they've
+ * already completed and the assignment's attempt limit has been reached. The
+ * UI should catch this and render a friendly "ask your teacher" message; the
+ * teacher can reset by removing the student from the live monitor.
+ */
+export class AttemptLimitReachedError extends Error {
+  constructor() {
+    super(
+      "You've already submitted this quiz. Talk to your teacher if you need another attempt."
+    );
+    this.name = 'AttemptLimitReachedError';
+  }
+}
+
+/**
+ * Compute the deterministic response-doc key.
+ *
+ * For studentRole (real SSO) auth, we continue to key by `auth.uid` because
+ * the uid is stable per-user. For anonymous PIN auth the uid rotates every
+ * time the student clears storage or switches device, which would let them
+ * bypass attempt limits — so we derive a key from `pin + classPeriod` that
+ * is stable per-roster-student.
+ *
+ * Known limitation: two rosters assigned to the same session with overlapping
+ * PINs under the same classPeriod would collide on the same doc key. Rosters
+ * are normally period-scoped, so this is expected to be rare.
+ */
+function computeResponseKey(
+  authUid: string,
+  isAnonymous: boolean,
+  pin: string,
+  classPeriod: string | undefined
+): string {
+  if (!isAnonymous) return authUid;
+  const period = classPeriod ?? 'default';
+  return `pin-${period}-${pin}`;
+}
+
 // ─── Teacher hook ─────────────────────────────────────────────────────────────
 
 export interface UseQuizSessionTeacherResult {
@@ -134,8 +173,16 @@ export interface UseQuizSessionTeacherResult {
    * assignment's lifecycle state flipped to `inactive`.
    */
   endQuizSession: () => Promise<void>;
-  /** Remove a student from the live session roster */
-  removeStudent: (studentUid: string) => Promise<void>;
+  /**
+   * Remove a student from the live session roster by deleting their response
+   * doc. `responseKey` is the Firestore doc key (e.g. `pin-{period}-{pin}`
+   * for PIN auth, or the student's auth uid for studentRole auth) — NOT the
+   * `studentUid` field inside the doc. Callers should pass the snapshot
+   * doc.id they're iterating over.
+   *
+   * Deleting the doc also frees the attempt slot so the student can rejoin.
+   */
+  removeStudent: (responseKey: string) => Promise<void>;
   /** Reveal the correct answer for a question (writes to session doc) */
   revealAnswer: (questionId: string, correctAnswer: string) => Promise<void>;
   /** Hide a previously revealed answer (removes from session doc) */
@@ -195,7 +242,16 @@ export const useQuizSessionTeacher = (
     return onSnapshot(
       responsesRef,
       (snap) => {
-        const list = snap.docs.map((d) => d.data() as QuizResponse);
+        // Carry the doc id through as `_responseKey` so the live monitor
+        // can remove/delete by the actual Firestore key rather than the
+        // `studentUid` field, which may differ for PIN-authed joiners.
+        const list = snap.docs.map(
+          (d) =>
+            ({
+              ...(d.data() as QuizResponse),
+              _responseKey: d.id,
+            }) as QuizResponse
+        );
         setResponses(list);
       },
       (err) => console.error('[useQuizSessionTeacher] responses:', err)
@@ -229,14 +285,14 @@ export const useQuizSessionTeacher = (
   }, [sessionId]);
 
   const removeStudent = useCallback(
-    async (studentUid: string) => {
+    async (responseKey: string) => {
       if (!sessionId) return;
       const responseRef = doc(
         db,
         QUIZ_SESSIONS_COLLECTION,
         sessionId,
         RESPONSES_COLLECTION,
-        studentUid
+        responseKey
       );
       await deleteDoc(responseRef);
     },
@@ -436,7 +492,11 @@ export const useQuizSessionStudent = (): UseQuizSessionStudentResult => {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const sessionIdRef = useRef<string | null>(null);
-  const studentUidRef = useRef<string | null>(null);
+  // The Firestore doc key under /responses. For studentRole auth this equals
+  // the auth uid; for PIN/anonymous auth it is derived from pin+classPeriod
+  // (see computeResponseKey) so an attempt limit survives device/storage
+  // resets. Historically named `studentUidRef`.
+  const responseKeyRef = useRef<string | null>(null);
   // Keep a ref to current answers to avoid stale closure issues
   const myResponseRef = useRef<QuizResponse | null>(null);
   myResponseRef.current = myResponse;
@@ -469,23 +529,28 @@ export const useQuizSessionStudent = (): UseQuizSessionStudentResult => {
     );
   }, [sessionIdState]);
 
-  // My response listener
-  const [studentUidState, setStudentUidState] = useState<string | null>(null);
+  // My response listener — subscribed on the deterministic response-doc key
+  // (not necessarily equal to auth.uid for anonymous PIN users).
+  const [responseKeyState, setResponseKeyState] = useState<string | null>(null);
 
   useEffect(() => {
-    if (!sessionIdState || !studentUidState) return;
+    if (!sessionIdState || !responseKeyState) return;
     return onSnapshot(
       doc(
         db,
         QUIZ_SESSIONS_COLLECTION,
         sessionIdState,
         RESPONSES_COLLECTION,
-        studentUidState
+        responseKeyState
       ),
       (snap) =>
-        setMyResponse(snap.exists() ? (snap.data() as QuizResponse) : null)
+        setMyResponse(
+          snap.exists()
+            ? { ...(snap.data() as QuizResponse), _responseKey: snap.id }
+            : null
+        )
     );
-  }, [sessionIdState, studentUidState]);
+  }, [sessionIdState, responseKeyState]);
 
   const lookupSession = useCallback(
     async (code: string): Promise<{ periodNames: string[] } | null> => {
@@ -580,30 +645,88 @@ export const useQuizSessionStudent = (): UseQuizSessionStudentResult => {
         const sessionDoc = joinable[0];
         const sessionData = sessionDoc.data() as QuizSession;
 
+        // Deterministic doc key: stable per-roster-student for PIN auth so
+        // the attempt limit can't be bypassed by clearing storage / switching
+        // device. studentRole users still key by their auth uid (stable per
+        // user already).
+        const deterministicKey = computeResponseKey(
+          studentUid,
+          currentUser.isAnonymous,
+          sanitizedPin,
+          classPeriod
+        );
+
+        // Legacy-key fallback: before deterministic keying, every response
+        // (including anonymous PIN joiners) was keyed by `auth.uid`. If the
+        // student is rejoining an in-progress session that was created under
+        // the old scheme, resume at the legacy key so their in-flight work
+        // isn't lost and the teacher doesn't see a duplicate row. New docs
+        // are always created at the deterministic key.
+        let responseKey = deterministicKey;
+        let existingSnap = await getDoc(
+          doc(
+            db,
+            QUIZ_SESSIONS_COLLECTION,
+            sessionDoc.id,
+            RESPONSES_COLLECTION,
+            deterministicKey
+          )
+        );
+        if (
+          !existingSnap.exists() &&
+          currentUser.isAnonymous &&
+          deterministicKey !== studentUid
+        ) {
+          const legacySnap = await getDoc(
+            doc(
+              db,
+              QUIZ_SESSIONS_COLLECTION,
+              sessionDoc.id,
+              RESPONSES_COLLECTION,
+              studentUid
+            )
+          );
+          if (legacySnap.exists()) {
+            responseKey = studentUid;
+            existingSnap = legacySnap;
+          }
+        }
+
         sessionIdRef.current = sessionDoc.id;
-        studentUidRef.current = studentUid;
+        responseKeyRef.current = responseKey;
         // Reset warning count before activating snapshot listeners so a
         // late-arriving snapshot from a previous session can't race with
         // the finally-block reset and leave the counter stuck at 0.
         warningCountRef.current = 0;
         setWarningCount(0);
-        setSessionIdState(sessionDoc.id);
-        setStudentUidState(studentUid);
 
         const responseRef = doc(
           db,
           QUIZ_SESSIONS_COLLECTION,
           sessionDoc.id,
           RESPONSES_COLLECTION,
-          studentUid
+          responseKey
         );
 
-        // Use getDoc to check whether the student already has a response
-        // document (e.g. after a page reload), rather than relying on the
-        // in-memory ref which may still be null before the snapshot arrives.
-        const existingSnap = await getDoc(responseRef);
+        if (existingSnap.exists()) {
+          const existing = existingSnap.data() as QuizResponse;
+          // Attempt-limit enforcement. `attemptLimit == null/undefined` means
+          // unlimited (legacy sessions). A completed doc occupies the slot;
+          // teachers reset by deleting it via removeStudent.
+          const limit = sessionData.attemptLimit ?? null;
+          if (limit !== null && existing.status === 'completed') {
+            throw new AttemptLimitReachedError();
+          }
+        }
+
+        setSessionIdState(sessionDoc.id);
+        setResponseKeyState(responseKey);
+
         if (!existingSnap.exists()) {
-          // No PII stored — only the PIN for teacher cross-reference
+          // No PII stored — only the PIN for teacher cross-reference.
+          // `studentUid` field carries the auth uid; the doc key may differ
+          // (for PIN auth it's pin-based), so Firestore rules enforce
+          // ownership against the field, not the key.
           const newResponse: QuizResponse = {
             studentUid,
             pin: sanitizedPin,
@@ -640,8 +763,8 @@ export const useQuizSessionStudent = (): UseQuizSessionStudentResult => {
   const submitAnswer = useCallback(
     async (questionId: string, answer: string, speedBonus?: number) => {
       const sessionId = sessionIdRef.current;
-      const studentUid = studentUidRef.current;
-      if (!sessionId || !studentUid) return;
+      const responseKey = responseKeyRef.current;
+      if (!sessionId || !responseKey) return;
 
       // isCorrect is intentionally not written by the student to prevent
       // client-side forgery. It is computed by the teacher's results view
@@ -667,7 +790,7 @@ export const useQuizSessionStudent = (): UseQuizSessionStudentResult => {
           QUIZ_SESSIONS_COLLECTION,
           sessionId,
           RESPONSES_COLLECTION,
-          studentUid
+          responseKey
         ),
         { status: 'in-progress', answers: updated }
       );
@@ -677,8 +800,8 @@ export const useQuizSessionStudent = (): UseQuizSessionStudentResult => {
 
   const completeQuiz = useCallback(async () => {
     const sessionId = sessionIdRef.current;
-    const studentUid = studentUidRef.current;
-    if (!sessionId || !studentUid) return;
+    const responseKey = responseKeyRef.current;
+    if (!sessionId || !responseKey) return;
 
     // Score is computed from gradeAnswer() by the teacher/results view,
     // not written by the student, to prevent client-side forgery of the score field.
@@ -688,7 +811,7 @@ export const useQuizSessionStudent = (): UseQuizSessionStudentResult => {
         QUIZ_SESSIONS_COLLECTION,
         sessionId,
         RESPONSES_COLLECTION,
-        studentUid
+        responseKey
       ),
       { status: 'completed', submittedAt: Date.now() }
     );
@@ -696,15 +819,15 @@ export const useQuizSessionStudent = (): UseQuizSessionStudentResult => {
 
   const reportTabSwitch = useCallback(async (): Promise<number> => {
     const sessionId = sessionIdRef.current;
-    const studentUid = studentUidRef.current;
-    if (!sessionId || !studentUid) return 0;
+    const responseKey = responseKeyRef.current;
+    if (!sessionId || !responseKey) return 0;
 
     const responseRef = doc(
       db,
       QUIZ_SESSIONS_COLLECTION,
       sessionId,
       RESPONSES_COLLECTION,
-      studentUid
+      responseKey
     );
 
     // Capture pre-increment count BEFORE Firestore write so the snapshot

--- a/tests/rules/studentRoleClassGate.test.ts
+++ b/tests/rules/studentRoleClassGate.test.ts
@@ -415,11 +415,14 @@ describe('quiz_sessions/responses — student-role gate', () => {
   });
 
   it('anonymous PIN student can create response without studentRole restriction', async () => {
+    // Anon students use deterministic doc keys matching
+    // `^pin-[a-z0-9_]+-[a-z0-9_]+$` (see `encodeResponseKeySegment` /
+    // firestore.rules).
     await assertSucceeds(
       setDoc(
         doc(
           asAnonStudent(),
-          `quiz_sessions/${SESSION_A}/responses/${ANON_UID}`
+          `quiz_sessions/${SESSION_A}/responses/pin-p1-5678`
         ),
         {
           studentUid: ANON_UID,
@@ -430,6 +433,40 @@ describe('quiz_sessions/responses — student-role gate', () => {
           status: 'active',
           tabSwitchWarnings: 0,
         }
+      )
+    );
+  });
+
+  it('anonymous PIN student cannot create response with arbitrary key shape', async () => {
+    // Locks in the key-format tightening: a grief-create that tries to
+    // occupy a victim's slot under an unrelated key is rejected at the
+    // rules layer even if studentUid == auth.uid.
+    await assertFails(
+      setDoc(
+        doc(
+          asAnonStudent(),
+          `quiz_sessions/${SESSION_A}/responses/victim-arbitrary-key`
+        ),
+        {
+          studentUid: ANON_UID,
+          pin: '5678',
+          joinedAt: 2000,
+          score: null,
+          answers: [],
+          status: 'active',
+          tabSwitchWarnings: 0,
+        }
+      )
+    );
+  });
+
+  it('studentRole user cannot create response under a pin-scheme key', async () => {
+    // Cross-auth-type grief is also blocked: an SSO user cannot pretend
+    // to be an anon PIN joiner by writing to `pin-...` keys.
+    await assertFails(
+      setDoc(
+        doc(asStudentA(), `quiz_sessions/${SESSION_A}/responses/pin-p1-1234`),
+        { ...baseResp(), joinedAt: 2000 }
       )
     );
   });
@@ -456,9 +493,12 @@ describe('quiz_sessions/responses — student-role gate', () => {
   // All three must succeed under a bare anon token for real answer
   // submission to work end-to-end.
   it('anonymous PIN student with bare token (no custom claims) can get + create + update response', async () => {
+    // Uses the new deterministic anon key format `pin-{period}-{pin}` that
+    // the client computes via encodeResponseKeySegment(). The rules layer
+    // enforces this shape via regex on create.
     const responseRef = doc(
       asAnonStudentBareToken(),
-      `quiz_sessions/${SESSION_A}/responses/${ANON_UID}`
+      `quiz_sessions/${SESSION_A}/responses/pin-p1-5678`
     );
 
     await assertSucceeds(getDoc(responseRef));
@@ -472,11 +512,14 @@ describe('quiz_sessions/responses — student-role gate', () => {
         answers: [],
         status: 'active',
         tabSwitchWarnings: 0,
+        completedAttempts: 0,
       })
     );
 
     // Submit an answer: update only the fields the rule allows students
-    // to change (answers, status, submittedAt, tabSwitchWarnings).
+    // to change (answers, status, submittedAt, tabSwitchWarnings,
+    // completedAttempts, classPeriod, score). completedAttempts is
+    // monotonic — we hold it at 0 here since this is a mid-attempt update.
     await assertSucceeds(
       setDoc(responseRef, {
         studentUid: ANON_UID,
@@ -487,6 +530,7 @@ describe('quiz_sessions/responses — student-role gate', () => {
         status: 'submitted',
         submittedAt: 3000,
         tabSwitchWarnings: 0,
+        completedAttempts: 0,
       })
     );
   });

--- a/types.ts
+++ b/types.ts
@@ -1852,6 +1852,17 @@ export interface QuizResponse {
   tabSwitchWarnings?: number;
   /** Which class period the student selected when joining (multi-class support). */
   classPeriod?: string;
+  /**
+   * Number of times this student has completed the quiz under this response
+   * doc. Incremented on the transition `in-progress -> completed` via
+   * `completeQuiz`. Used together with `QuizSession.attemptLimit` to enforce
+   * the attempts cap: a student can re-join (and the doc is reset to
+   * `status: 'joined'`) until `completedAttempts >= attemptLimit`.
+   *
+   * Undefined on legacy docs written before multi-attempt support; the hook
+   * treats missing+`status==='completed'` as a single completed attempt.
+   */
+  completedAttempts?: number;
 }
 
 /** Global admin configuration for the Quiz widget */

--- a/types.ts
+++ b/types.ts
@@ -1774,6 +1774,13 @@ export interface QuizSession {
    * derived from these rosters' `classlinkClassId` metadata.
    */
   rosterIds?: string[];
+
+  /**
+   * Max completed submissions allowed per student (mirrored from the
+   * assignment so student-side code can read it without a second fetch).
+   * `null`/`undefined` = unlimited (legacy sessions).
+   */
+  attemptLimit?: number | null;
 }
 
 export interface QuizResponseAnswer {
@@ -1794,11 +1801,32 @@ export interface QuizResponseAnswer {
 
 export type QuizResponseStatus = 'joined' | 'in-progress' | 'completed';
 
-/** Per-student response document in Firestore (/quiz_sessions/{sessionId}/responses/{anonymousUid}) */
+/**
+ * Per-student response document in Firestore
+ * (/quiz_sessions/{sessionId}/responses/{responseKey}).
+ *
+ * `responseKey` (the Firestore doc id) is deterministic:
+ *   - For studentRole (SSO) auth: equals the student's auth uid.
+ *   - For PIN/anonymous auth: derived from pin + classPeriod so it survives
+ *     storage/device resets, preventing attempt-limit bypass.
+ *
+ * The `studentUid` field below still carries the Firebase auth uid of whoever
+ * wrote the doc — Firestore rules enforce ownership against this field
+ * (not the key), since the key is no longer guaranteed to match the uid.
+ */
 export interface QuizResponse {
   /**
-   * Firebase anonymous auth UID — used as the Firestore document key.
-   * Not PII: ephemeral, not linked to any identity without the Drive roster.
+   * The Firestore doc key under /responses. Populated at read time by the
+   * teacher/student hooks from snapshot.doc.id; never persisted as a field.
+   * Callers should use this (rather than `studentUid`) when deleting a
+   * response, since the key may be pin-derived for anonymous joiners.
+   */
+  _responseKey?: string;
+  /**
+   * Firebase Auth UID of the student who wrote the doc — anonymous for PIN
+   * joiners, the SSO uid for studentRole joiners. Used for ownership checks
+   * in Firestore rules. Historically also served as the doc key; that is no
+   * longer guaranteed for anonymous joiners (see `_responseKey`).
    */
   studentUid: string;
   /**
@@ -1910,6 +1938,14 @@ export interface QuizAssignmentSettings {
   /** Selected class period roster names. Replaces singular periodName. */
   periodNames?: string[];
   plcMemberEmails?: string[];
+  /**
+   * Max completed submissions allowed per student. `null`/`undefined` means
+   * unlimited (legacy). `1` (default for new assignments) means one-and-done.
+   * Enforced at `joinQuizSession` time by checking the student's own existing
+   * response doc; teachers can reset a student's attempt by removing them from
+   * the live monitor, which deletes the response doc.
+   */
+  attemptLimit?: number | null;
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes five quiz-widget bugs blocking teacher workflows (PLC work is deferred to a separate plan).

- **Attempt limits** — teachers cap per-student submissions (1/2/3/Unlimited). PIN students can't bypass the cap by clearing storage because response docs are now deterministically keyed by `pin-{period}-{pin}` instead of anon auth uid. Firestore rules switched to field-based ownership on `studentUid`.
- **Reopen archived assignments** — `reopenAssignment()` returns an inactive assignment to *paused*, preserving all existing responses. Wired as a non-destructive kebab action in the Archive tab.
- **Delete a single submission** — trash icon per row in Results → Students with an inline confirm. Stats and exports recompute automatically via the existing snapshot listener.
- **Archive kebab z-index** — the overflow menu now portals to `document.body` with fixed positioning, so `opacity-70` stacking contexts on archived cards can't clip it behind later rows.
- **MC students can change answer** — multiple-choice options now set a draft selection; Submit commits. Mirrors the existing FIB pattern. Timer auto-submit still captures the draft.

## Backward compatibility

The doc-keying change is the only spot with real migration risk. Mitigations in place:

- `joinQuizSession` falls back to the legacy `auth.uid` key when the deterministic key has no doc, so in-progress PIN sessions survive the deploy without lost progress or duplicate monitor rows.
- `attemptLimit ?? null` means legacy sessions (field unset) remain unlimited — no spurious "already submitted" errors.
- `_responseKey ?? r.studentUid` in every teacher-side call site keeps delete/remove identical for legacy docs (where doc.id == studentUid).
- Firestore rules compare `request.auth.uid == resource.data.studentUid`; legacy docs have the field set to the auth uid, so same-user writes still pass.

## Test plan

- [ ] `pnpm run type-check` — passes
- [ ] `pnpm run lint` — passes
- [ ] `pnpm run format:check` — passes
- [ ] `pnpm run test` — 1441/1441 passing
- [ ] **Attempt limit**: create assignment with `attemptLimit = 1`. Join from incognito, submit. Rejoin with same PIN+period → blocked with "You've already submitted…" message. Teacher clicks Remove → rejoin succeeds.
- [ ] **Kebab z-index**: end 3+ quizzes, open the kebab on the first Archive row. Menu renders above all subsequent rows. Scroll → menu closes.
- [ ] **Delete submission**: submit 2–3 responses, end the quiz, open Results → Students. Delete one row; verify Overview average and question stats update. Export and confirm the deleted row is absent.
- [ ] **Reopen**: end an assignment, open the Archive kebab, click Reopen. Status flips to PAUSED; primary action becomes Resume. Student can rejoin after Resume.
- [ ] **MC change answer**: tap option A (nothing submitted, A highlighted). Tap B (selection moves). Hit Submit → B recorded in the teacher monitor.
- [ ] **Legacy response docs**: verify an in-progress pre-deploy session still resumes correctly for a same-device PIN student (legacy-key fallback).

🤖 Generated with [Claude Code](https://claude.com/claude-code)