### PR TITLE
feat(widgets): add Need / Do / Put / Then widget

### DIFF
--- a/components/admin/FeatureConfigurationPanel.tsx
+++ b/components/admin/FeatureConfigurationPanel.tsx
@@ -685,6 +685,7 @@ export const FeatureConfigurationPanel: React.FC<
         'guided-learning',
         'instructionalRoutines',
         'miniApp',
+        'need-do-put-then',
         'quiz',
         'stickers',
         'talking-tool',

--- a/components/admin/FeatureConfigurationPanel.tsx
+++ b/components/admin/FeatureConfigurationPanel.tsx
@@ -59,6 +59,7 @@ import { CountdownConfigurationPanel } from './CountdownConfigurationPanel';
 import { First5ConfigurationPanel } from './First5ConfigurationPanel';
 import { DockDefaultsPanel } from './DockDefaultsPanel';
 import { LunchCountConfigurationPanel } from './LunchCountConfigurationPanel';
+import { NeedDoPutThenConfigurationPanel } from './NeedDoPutThenConfigurationPanel';
 import { Toggle } from '../common/Toggle';
 
 // Shared prop shape for all "building-defaults" config panels
@@ -134,6 +135,8 @@ const BUILDING_CONFIG_PANELS: Partial<Record<string, BuildingConfigPanel>> = {
   remote: RemoteConfigurationPanel as unknown as BuildingConfigPanel,
   countdown: CountdownConfigurationPanel as unknown as BuildingConfigPanel,
   'first-5': First5ConfigurationPanel as unknown as BuildingConfigPanel,
+  'need-do-put-then':
+    NeedDoPutThenConfigurationPanel as unknown as BuildingConfigPanel,
 };
 
 interface FeatureConfigurationPanelProps {
@@ -685,7 +688,6 @@ export const FeatureConfigurationPanel: React.FC<
         'guided-learning',
         'instructionalRoutines',
         'miniApp',
-        'need-do-put-then',
         'quiz',
         'stickers',
         'talking-tool',

--- a/components/admin/NeedDoPutThenConfigurationPanel.tsx
+++ b/components/admin/NeedDoPutThenConfigurationPanel.tsx
@@ -11,7 +11,6 @@ export interface NeedDoPutThenGlobalConfig {
 
 interface Props {
   config: NeedDoPutThenGlobalConfig;
-  onChange: (newConfig: NeedDoPutThenGlobalConfig) => void;
 }
 
 export const NeedDoPutThenConfigurationPanel: React.FC<Props> = ({

--- a/components/admin/NeedDoPutThenConfigurationPanel.tsx
+++ b/components/admin/NeedDoPutThenConfigurationPanel.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { ListTodo } from 'lucide-react';
+import { Card } from '@/components/common/Card';
+import { useAdminBuildings } from '@/hooks/useAdminBuildings';
+import { useBuildingSelection } from '@/hooks/useBuildingSelection';
+import { BuildingSelector } from './BuildingSelector';
+
+export interface NeedDoPutThenGlobalConfig {
+  buildingDefaults?: Record<string, Record<string, unknown>>;
+}
+
+interface Props {
+  config: NeedDoPutThenGlobalConfig;
+  onChange: (newConfig: NeedDoPutThenGlobalConfig) => void;
+}
+
+export const NeedDoPutThenConfigurationPanel: React.FC<Props> = ({
+  config,
+}) => {
+  const BUILDINGS = useAdminBuildings();
+  const [selectedBuildingId, setSelectedBuildingId] =
+    useBuildingSelection(BUILDINGS);
+  const building = BUILDINGS.find((b) => b.id === selectedBuildingId);
+  const hasBuildingEntry = Boolean(
+    config.buildingDefaults?.[selectedBuildingId]
+  );
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <label className="text-xxs font-bold text-slate-500 uppercase mb-2 block">
+          Configure Building Need / Do / Put / Then Defaults
+        </label>
+        <BuildingSelector
+          selectedId={selectedBuildingId}
+          onSelect={setSelectedBuildingId}
+        />
+      </div>
+
+      <Card rounded="xl" shadow="none" className="bg-slate-50 space-y-3">
+        <div className="flex items-start gap-3">
+          <div className="p-2 rounded-xl bg-indigo-500/10 text-indigo-600 shrink-0">
+            <ListTodo className="w-5 h-5" />
+          </div>
+          <div>
+            <p className="text-sm font-bold text-slate-700">
+              No building-level defaults yet
+            </p>
+            <p className="text-xxs text-slate-500 leading-snug mt-1">
+              Teachers at <b>{building?.name ?? 'this building'}</b> configure
+              the Need / Do / Put / Then widget per-instance today.
+              Building-wide defaults (preset materials, turn-in destinations,
+              common next-up options) can be added here in a future release.
+            </p>
+            {hasBuildingEntry && (
+              <p className="text-xxs text-slate-400 mt-2 italic">
+                Stored defaults exist for this building but are not yet consumed
+                by the widget.
+              </p>
+            )}
+          </div>
+        </div>
+      </Card>
+    </div>
+  );
+};

--- a/components/widgets/NeedDoPutThen/Settings.tsx
+++ b/components/widgets/NeedDoPutThen/Settings.tsx
@@ -1,0 +1,374 @@
+import React, { useState } from 'react';
+import {
+  ChevronDown,
+  ChevronRight,
+  ListTodo,
+  Package,
+  Plus,
+  RotateCcw,
+  Trash2,
+} from 'lucide-react';
+import { WidgetData, NeedDoPutThenConfig, NeedDoPutThenTile } from '@/types';
+import { useDashboard } from '@/context/useDashboard';
+import { TypographySettings } from '@/components/common/TypographySettings';
+import { TextSizePresetSettings } from '@/components/common/TextSizePresetSettings';
+import { SurfaceColorSettings } from '@/components/common/SurfaceColorSettings';
+import { IconPicker } from '@/components/widgets/InstructionalRoutines/IconPicker';
+import {
+  MATERIAL_COLOR_OPTIONS,
+  getContrastingTextColor,
+} from '@/components/widgets/MaterialsWidget/constants';
+import {
+  DEFAULT_NEED_ITEMS,
+  DEFAULT_PUT_ITEMS,
+  DEFAULT_DO_ITEMS,
+  DEFAULT_THEN_ITEMS,
+  MAX_LIST_ITEMS,
+  MIN_LIST_ITEMS,
+  MAX_TILE_ITEMS,
+  SECTION_COLORS,
+} from './constants';
+
+const newTileId = () =>
+  typeof crypto !== 'undefined' && 'randomUUID' in crypto
+    ? crypto.randomUUID()
+    : `tile-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+
+interface CollapsibleSectionProps {
+  label: string;
+  icon: typeof Package;
+  accentColor: string;
+  defaultOpen?: boolean;
+  children: React.ReactNode;
+}
+
+const CollapsibleSection: React.FC<CollapsibleSectionProps> = ({
+  label,
+  icon: Icon,
+  accentColor,
+  defaultOpen = false,
+  children,
+}) => {
+  const [isOpen, setIsOpen] = useState(defaultOpen);
+  return (
+    <div className="rounded-xl border border-slate-200 overflow-hidden bg-white">
+      <button
+        type="button"
+        onClick={() => setIsOpen((v) => !v)}
+        className="w-full flex items-center gap-2 px-3 py-2.5 bg-slate-50 hover:bg-slate-100 transition-colors"
+        aria-expanded={isOpen}
+      >
+        {isOpen ? (
+          <ChevronDown className="w-4 h-4 text-slate-500 shrink-0" />
+        ) : (
+          <ChevronRight className="w-4 h-4 text-slate-500 shrink-0" />
+        )}
+        <Icon className="w-4 h-4 shrink-0" style={{ color: accentColor }} />
+        <span className="text-xs font-bold uppercase tracking-wide text-slate-700">
+          {label}
+        </span>
+      </button>
+      {isOpen && <div className="p-3">{children}</div>}
+    </div>
+  );
+};
+
+interface TileEditorProps {
+  items: NeedDoPutThenTile[];
+  defaults: NeedDoPutThenTile[];
+  onChange: (items: NeedDoPutThenTile[]) => void;
+  showCheckbox?: boolean;
+}
+
+const TileEditor: React.FC<TileEditorProps> = ({
+  items,
+  defaults,
+  onChange,
+  showCheckbox = false,
+}) => {
+  const updateItem = (index: number, updates: Partial<NeedDoPutThenTile>) => {
+    const next = items.map((item, i) =>
+      i === index ? { ...item, ...updates } : item
+    );
+    onChange(next);
+  };
+
+  const addItem = () => {
+    if (items.length >= MAX_TILE_ITEMS) return;
+    onChange([
+      ...items,
+      {
+        id: newTileId(),
+        label: 'New item',
+        icon: 'Package',
+        color: '#3b82f6',
+        checked: true,
+      },
+    ]);
+  };
+
+  const removeItem = (index: number) => {
+    onChange(items.filter((_, i) => i !== index));
+  };
+
+  const restoreDefaults = () => {
+    onChange(defaults.map((d) => ({ ...d })));
+  };
+
+  return (
+    <div>
+      <div className="flex items-center justify-end mb-2">
+        <button
+          type="button"
+          onClick={restoreDefaults}
+          className="flex items-center gap-1 text-xxs font-bold uppercase tracking-wide text-slate-500 hover:text-brand-blue-primary transition-colors"
+          title="Restore defaults"
+        >
+          <RotateCcw className="w-3 h-3" />
+          Restore
+        </button>
+      </div>
+
+      <div className="space-y-2 max-h-64 overflow-y-auto custom-scrollbar pr-1">
+        {items.map((item, idx) => {
+          const textColor = getContrastingTextColor(item.color);
+          const isChecked = item.checked !== false;
+          return (
+            <div
+              key={item.id}
+              className="flex items-center gap-2 rounded-xl border border-slate-200 bg-white p-2"
+            >
+              {showCheckbox && (
+                <input
+                  type="checkbox"
+                  checked={isChecked}
+                  onChange={(e) =>
+                    updateItem(idx, { checked: e.target.checked })
+                  }
+                  className="w-4 h-4 rounded border-slate-300 text-brand-blue-primary focus:ring-brand-blue-primary shrink-0"
+                  aria-label={`Show ${item.label}`}
+                  title={isChecked ? 'Hide from widget' : 'Show on widget'}
+                />
+              )}
+              <IconPicker
+                currentIcon={item.icon}
+                onSelect={(icon) => updateItem(idx, { icon })}
+              />
+              <input
+                type="text"
+                value={item.label}
+                onChange={(e) => updateItem(idx, { label: e.target.value })}
+                className="flex-1 min-w-0 rounded-lg border border-slate-200 px-2 py-1.5 text-xs font-semibold text-slate-700 focus:ring-2 focus:ring-brand-blue-primary focus:outline-none"
+                placeholder="Label"
+                maxLength={80}
+              />
+              <div className="relative shrink-0">
+                <button
+                  type="button"
+                  className="h-7 w-7 rounded-lg border border-slate-200 shadow-sm"
+                  style={{ backgroundColor: item.color, color: textColor }}
+                  title="Pick color"
+                  aria-label="Pick color"
+                />
+                <input
+                  type="color"
+                  value={item.color}
+                  onChange={(e) => updateItem(idx, { color: e.target.value })}
+                  className="absolute inset-0 h-7 w-7 opacity-0 cursor-pointer"
+                  aria-label="Pick color"
+                />
+              </div>
+              <button
+                type="button"
+                onClick={() => removeItem(idx)}
+                className="p-1.5 text-slate-400 hover:text-red-500 hover:bg-red-50 rounded-lg transition-colors"
+                title="Remove item"
+              >
+                <Trash2 className="w-3.5 h-3.5" />
+              </button>
+            </div>
+          );
+        })}
+      </div>
+
+      <div className="mt-2 flex flex-wrap gap-1.5">
+        {MATERIAL_COLOR_OPTIONS.map((color) => (
+          <div
+            key={color}
+            className="w-4 h-4 rounded-full border border-slate-200"
+            style={{ backgroundColor: color }}
+            title={color}
+          />
+        ))}
+      </div>
+
+      <button
+        type="button"
+        onClick={addItem}
+        disabled={items.length >= MAX_TILE_ITEMS}
+        className="mt-3 w-full py-2 flex items-center justify-center gap-2 text-xs font-bold text-slate-500 border border-dashed border-slate-300 rounded-lg hover:border-brand-blue-primary hover:text-brand-blue-primary transition-all disabled:opacity-40 disabled:cursor-not-allowed"
+      >
+        <Plus className="w-3.5 h-3.5" />
+        Add item
+      </button>
+    </div>
+  );
+};
+
+interface ListEditorProps {
+  items: string[];
+  onChange: (items: string[]) => void;
+}
+
+const ListEditor: React.FC<ListEditorProps> = ({ items, onChange }) => {
+  const updateItem = (index: number, value: string) => {
+    const next = items.map((item, i) => (i === index ? value : item));
+    onChange(next);
+  };
+
+  const addItem = () => {
+    if (items.length >= MAX_LIST_ITEMS) return;
+    onChange([...items, '']);
+  };
+
+  const removeItem = (index: number) => {
+    if (items.length <= MIN_LIST_ITEMS) return;
+    onChange(items.filter((_, i) => i !== index));
+  };
+
+  return (
+    <div>
+      <div className="space-y-2">
+        {items.map((text, idx) => (
+          <div key={idx} className="flex items-start gap-2">
+            <span className="mt-2 text-xs font-black text-slate-500 w-5 shrink-0 text-center">
+              {idx + 1}.
+            </span>
+            <textarea
+              value={text}
+              onChange={(e) => updateItem(idx, e.target.value)}
+              rows={2}
+              className="flex-1 rounded-lg border border-slate-200 px-2 py-1.5 text-xs text-slate-700 focus:ring-2 focus:ring-brand-blue-primary focus:outline-none resize-none"
+              placeholder={`Step ${idx + 1}`}
+              maxLength={200}
+            />
+            {items.length > MIN_LIST_ITEMS && (
+              <button
+                type="button"
+                onClick={() => removeItem(idx)}
+                className="mt-1 p-1.5 text-slate-400 hover:text-red-500 hover:bg-red-50 rounded-lg transition-colors"
+                title="Remove line"
+              >
+                <Trash2 className="w-3.5 h-3.5" />
+              </button>
+            )}
+          </div>
+        ))}
+      </div>
+      {items.length < MAX_LIST_ITEMS && (
+        <button
+          type="button"
+          onClick={addItem}
+          className="mt-3 w-full py-2 flex items-center justify-center gap-2 text-xs font-bold text-slate-500 border border-dashed border-slate-300 rounded-lg hover:border-brand-blue-primary hover:text-brand-blue-primary transition-all"
+        >
+          <Plus className="w-3.5 h-3.5" />
+          Add line
+        </button>
+      )}
+    </div>
+  );
+};
+
+export const NeedDoPutThenSettings: React.FC<{ widget: WidgetData }> = ({
+  widget,
+}) => {
+  const { updateWidget } = useDashboard();
+  const config = (widget.config ?? {}) as NeedDoPutThenConfig;
+
+  const {
+    needItems = DEFAULT_NEED_ITEMS,
+    doItems = DEFAULT_DO_ITEMS,
+    putItems = DEFAULT_PUT_ITEMS,
+    thenItems = DEFAULT_THEN_ITEMS,
+  } = config;
+
+  const update = (updates: Partial<NeedDoPutThenConfig>) => {
+    updateWidget(widget.id, { config: { ...config, ...updates } });
+  };
+
+  return (
+    <div className="p-4 space-y-3">
+      <CollapsibleSection
+        label="What you need"
+        icon={Package}
+        accentColor={SECTION_COLORS.need}
+      >
+        <TileEditor
+          items={needItems}
+          defaults={DEFAULT_NEED_ITEMS}
+          onChange={(items) => update({ needItems: items })}
+          showCheckbox
+        />
+      </CollapsibleSection>
+
+      <CollapsibleSection
+        label="What you do"
+        icon={ListTodo}
+        accentColor={SECTION_COLORS.do}
+      >
+        <ListEditor
+          items={doItems}
+          onChange={(items) => update({ doItems: items })}
+        />
+      </CollapsibleSection>
+
+      <CollapsibleSection
+        label="Where it goes"
+        icon={Package}
+        accentColor={SECTION_COLORS.put}
+      >
+        <TileEditor
+          items={putItems}
+          defaults={DEFAULT_PUT_ITEMS}
+          onChange={(items) => update({ putItems: items })}
+          showCheckbox
+        />
+      </CollapsibleSection>
+
+      <CollapsibleSection
+        label="What's next"
+        icon={ListTodo}
+        accentColor={SECTION_COLORS.then}
+      >
+        <TileEditor
+          items={thenItems}
+          defaults={DEFAULT_THEN_ITEMS}
+          onChange={(items) => update({ thenItems: items })}
+        />
+      </CollapsibleSection>
+    </div>
+  );
+};
+
+export const NeedDoPutThenAppearanceSettings: React.FC<{
+  widget: WidgetData;
+}> = ({ widget }) => {
+  const { updateWidget } = useDashboard();
+  const config = (widget.config ?? {}) as NeedDoPutThenConfig;
+
+  const update = (updates: Partial<NeedDoPutThenConfig>) => {
+    updateWidget(widget.id, { config: { ...config, ...updates } });
+  };
+
+  return (
+    <div className="p-4 space-y-6">
+      <TypographySettings config={config} updateConfig={update} />
+      <TextSizePresetSettings
+        config={config}
+        updateConfig={update}
+        writeScaleMultiplier={false}
+      />
+      <SurfaceColorSettings config={config} updateConfig={update} />
+    </div>
+  );
+};

--- a/components/widgets/NeedDoPutThen/Settings.tsx
+++ b/components/widgets/NeedDoPutThen/Settings.tsx
@@ -14,10 +14,7 @@ import { TypographySettings } from '@/components/common/TypographySettings';
 import { TextSizePresetSettings } from '@/components/common/TextSizePresetSettings';
 import { SurfaceColorSettings } from '@/components/common/SurfaceColorSettings';
 import { IconPicker } from '@/components/widgets/InstructionalRoutines/IconPicker';
-import {
-  MATERIAL_COLOR_OPTIONS,
-  getContrastingTextColor,
-} from '@/components/widgets/MaterialsWidget/constants';
+import { getContrastingTextColor } from '@/components/widgets/MaterialsWidget/constants';
 import {
   DEFAULT_NEED_ITEMS,
   DEFAULT_PUT_ITEMS,
@@ -162,22 +159,19 @@ const TileEditor: React.FC<TileEditorProps> = ({
                 placeholder="Label"
                 maxLength={80}
               />
-              <div className="relative shrink-0">
-                <button
-                  type="button"
-                  className="h-7 w-7 rounded-lg border border-slate-200 shadow-sm"
-                  style={{ backgroundColor: item.color, color: textColor }}
-                  title="Pick color"
-                  aria-label="Pick color"
-                />
+              <label
+                className="relative shrink-0 h-7 w-7 rounded-lg border border-slate-200 shadow-sm cursor-pointer focus-within:ring-2 focus-within:ring-brand-blue-primary"
+                style={{ backgroundColor: item.color, color: textColor }}
+                title={`Pick color for ${item.label || 'item'}`}
+              >
                 <input
                   type="color"
                   value={item.color}
                   onChange={(e) => updateItem(idx, { color: e.target.value })}
-                  className="absolute inset-0 h-7 w-7 opacity-0 cursor-pointer"
-                  aria-label="Pick color"
+                  className="absolute inset-0 h-full w-full opacity-0 cursor-pointer"
+                  aria-label={`Pick color for ${item.label || 'item'}`}
                 />
-              </div>
+              </label>
               <button
                 type="button"
                 onClick={() => removeItem(idx)}
@@ -189,17 +183,6 @@ const TileEditor: React.FC<TileEditorProps> = ({
             </div>
           );
         })}
-      </div>
-
-      <div className="mt-2 flex flex-wrap gap-1.5">
-        {MATERIAL_COLOR_OPTIONS.map((color) => (
-          <div
-            key={color}
-            className="w-4 h-4 rounded-full border border-slate-200"
-            style={{ backgroundColor: color }}
-            title={color}
-          />
-        ))}
       </div>
 
       <button
@@ -217,10 +200,15 @@ const TileEditor: React.FC<TileEditorProps> = ({
 
 interface ListEditorProps {
   items: string[];
+  defaults: string[];
   onChange: (items: string[]) => void;
 }
 
-const ListEditor: React.FC<ListEditorProps> = ({ items, onChange }) => {
+const ListEditor: React.FC<ListEditorProps> = ({
+  items,
+  defaults,
+  onChange,
+}) => {
   const updateItem = (index: number, value: string) => {
     const next = items.map((item, i) => (i === index ? value : item));
     onChange(next);
@@ -236,8 +224,24 @@ const ListEditor: React.FC<ListEditorProps> = ({ items, onChange }) => {
     onChange(items.filter((_, i) => i !== index));
   };
 
+  const restoreDefaults = () => {
+    onChange([...defaults]);
+  };
+
   return (
     <div>
+      <div className="flex items-center justify-end mb-2">
+        <button
+          type="button"
+          onClick={restoreDefaults}
+          className="flex items-center gap-1 text-xxs font-bold uppercase tracking-wide text-slate-500 hover:text-brand-blue-primary transition-colors"
+          title="Restore defaults"
+        >
+          <RotateCcw className="w-3 h-3" />
+          Restore
+        </button>
+      </div>
+
       <div className="space-y-2">
         {items.map((text, idx) => (
           <div key={idx} className="flex items-start gap-2">
@@ -318,6 +322,7 @@ export const NeedDoPutThenSettings: React.FC<{ widget: WidgetData }> = ({
       >
         <ListEditor
           items={doItems}
+          defaults={DEFAULT_DO_ITEMS}
           onChange={(items) => update({ doItems: items })}
         />
       </CollapsibleSection>

--- a/components/widgets/NeedDoPutThen/Widget.tsx
+++ b/components/widgets/NeedDoPutThen/Widget.tsx
@@ -1,0 +1,706 @@
+import React, { useCallback, useMemo, useState } from 'react';
+import { createPortal } from 'react-dom';
+import * as LucideIcons from 'lucide-react';
+import {
+  ChevronDown,
+  ChevronLeft,
+  ChevronRight,
+  ChevronUp,
+  ListTodo,
+  Package,
+} from 'lucide-react';
+import {
+  WidgetData,
+  NeedDoPutThenConfig,
+  NeedDoPutThenTile,
+  DEFAULT_GLOBAL_STYLE,
+} from '@/types';
+import { useDashboard } from '@/context/useDashboard';
+import { WidgetLayout } from '@/components/widgets/WidgetLayout';
+import { ScaledEmptyState } from '@/components/common/ScaledEmptyState';
+import { getFontClass, hexToRgba } from '@/utils/styles';
+import { resolveTextPresetMultiplier } from '@/config/widgetAppearance';
+import { getContrastingTextColor } from '@/components/widgets/MaterialsWidget/constants';
+import {
+  DEFAULT_DO_ITEMS,
+  DEFAULT_NEED_ITEMS,
+  DEFAULT_PUT_ITEMS,
+  DEFAULT_THEN_ITEMS,
+  SECTION_COLORS,
+  SECTION_TITLES,
+} from './constants';
+
+const LUCIDE_ICON_MAP = LucideIcons as unknown as Record<
+  string,
+  React.ElementType | undefined
+>;
+
+const resolveIcon = (iconName?: string): React.ElementType =>
+  (iconName ? LUCIDE_ICON_MAP[iconName] : undefined) ?? LucideIcons.Package;
+
+const DRAWER_SIZE_PX = 200;
+const DRAWER_OVERLAP_PX = 22;
+const CORNER_SAFE_PX = 18;
+
+type TileOrientation = 'portrait' | 'landscape' | 'auto';
+
+interface TileGridProps {
+  items: NeedDoPutThenTile[];
+  fontClass: string;
+  sizeMultiplier: number;
+  orientation?: TileOrientation;
+}
+
+const TileGrid: React.FC<TileGridProps> = ({
+  items,
+  fontClass,
+  sizeMultiplier,
+  orientation = 'auto',
+}) => {
+  const numItems = items.length;
+
+  const cols = useMemo(() => {
+    if (numItems <= 1) return 1;
+    if (orientation === 'portrait') {
+      return numItems >= 7 ? 2 : 1;
+    }
+    if (orientation === 'landscape') {
+      if (numItems <= 2) return numItems;
+      if (numItems <= 6) return Math.ceil(numItems / 2);
+      return 4;
+    }
+    if (numItems <= 4) return 2;
+    if (numItems <= 9) return 3;
+    return 4;
+  }, [numItems, orientation]);
+
+  if (numItems === 0) {
+    return (
+      <div className="h-full w-full flex items-center justify-center text-slate-400">
+        <div className="flex flex-col items-center">
+          <Package
+            style={{
+              width: 'min(36px, 18cqmin)',
+              height: 'min(36px, 18cqmin)',
+            }}
+            className="opacity-30"
+          />
+          <span
+            className="mt-2 italic"
+            style={{ fontSize: 'min(12px, 5cqmin)' }}
+          >
+            Flip to add items
+          </span>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className="grid h-full w-full"
+      style={{
+        gridTemplateColumns: `repeat(${cols}, minmax(0, 1fr))`,
+        gap: 'min(8px, 3cqmin)',
+      }}
+    >
+      {items.map((item) => {
+        const Icon = resolveIcon(item.icon);
+        const textColor = getContrastingTextColor(item.color);
+        return (
+          <div
+            key={item.id}
+            className={`flex flex-col items-center justify-center rounded-xl shadow-md ${fontClass}`}
+            style={{
+              containerType: 'size',
+              background: item.color,
+              color: textColor,
+              padding: 'min(6px, 4cqmin)',
+              gap: 'min(6px, 3cqmin)',
+            }}
+          >
+            <Icon
+              strokeWidth={2.5}
+              style={{
+                width: 'min(52px, 38cqmin)',
+                height: 'min(52px, 38cqmin)',
+              }}
+            />
+            <span
+              className="font-black uppercase tracking-wide text-center leading-tight truncate w-full"
+              style={{
+                fontSize: `min(${16 * sizeMultiplier}px, ${14 * sizeMultiplier}cqmin)`,
+              }}
+            >
+              {item.label}
+            </span>
+          </div>
+        );
+      })}
+    </div>
+  );
+};
+
+interface NumberedListProps {
+  items: string[];
+  fontClass: string;
+  fontColor: string;
+  sizeMultiplier: number;
+}
+
+const NumberedList: React.FC<NumberedListProps> = ({
+  items,
+  fontClass,
+  fontColor,
+  sizeMultiplier,
+}) => {
+  if (items.length === 0) {
+    return (
+      <div className="h-full w-full flex items-center justify-center text-slate-400">
+        <span className="italic" style={{ fontSize: 'min(14px, 4.5cqmin)' }}>
+          Flip to add steps
+        </span>
+      </div>
+    );
+  }
+
+  return (
+    <ol
+      className={`h-full w-full flex flex-col justify-around ${fontClass}`}
+      style={{
+        gap: 'min(14px, 4cqmin)',
+        padding: 'min(6px, 2cqmin)',
+      }}
+    >
+      {items.map((text, idx) => (
+        <li
+          key={idx}
+          className="flex items-center"
+          style={{ gap: 'min(14px, 4.5cqmin)' }}
+        >
+          <span
+            className="rounded-full bg-slate-900 text-white font-bold flex items-center justify-center shrink-0"
+            style={{
+              width: `min(${36 * sizeMultiplier}px, ${14 * sizeMultiplier}cqmin)`,
+              height: `min(${36 * sizeMultiplier}px, ${14 * sizeMultiplier}cqmin)`,
+              fontSize: `min(${18 * sizeMultiplier}px, ${7 * sizeMultiplier}cqmin)`,
+            }}
+          >
+            {idx + 1}
+          </span>
+          <span
+            className="border-b border-slate-300 flex-1 break-words whitespace-normal leading-snug"
+            style={{
+              fontSize: `min(${22 * sizeMultiplier}px, ${9 * sizeMultiplier}cqmin)`,
+              paddingBottom: 'min(4px, 1.5cqmin)',
+              color: text ? fontColor : '#94a3b8',
+              fontStyle: text ? 'normal' : 'italic',
+            }}
+          >
+            {text || 'User provided text'}
+          </span>
+        </li>
+      ))}
+    </ol>
+  );
+};
+
+interface IconHeroProps {
+  item: NeedDoPutThenTile;
+  fontClass: string;
+  fontColor: string;
+  sizeMultiplier: number;
+}
+
+const IconHero: React.FC<IconHeroProps> = ({
+  item,
+  fontClass,
+  fontColor,
+  sizeMultiplier,
+}) => {
+  const iconTextColor = getContrastingTextColor(item.color);
+  return (
+    <div
+      className={`h-full w-full flex flex-col items-center justify-center ${fontClass}`}
+      style={{
+        containerType: 'size',
+        gap: 'min(14px, 5cqmin)',
+        padding: 'min(8px, 3cqmin)',
+      }}
+    >
+      <span
+        className="rounded-full flex items-center justify-center"
+        style={{
+          width: `min(${140 * sizeMultiplier}px, ${60 * sizeMultiplier}cqmin)`,
+          height: `min(${140 * sizeMultiplier}px, ${60 * sizeMultiplier}cqmin)`,
+          background: item.color,
+          color: iconTextColor,
+        }}
+      >
+        {React.createElement(resolveIcon(item.icon), {
+          strokeWidth: 2.5,
+          style: {
+            width: `min(${80 * sizeMultiplier}px, ${34 * sizeMultiplier}cqmin)`,
+            height: `min(${80 * sizeMultiplier}px, ${34 * sizeMultiplier}cqmin)`,
+          },
+        })}
+      </span>
+      <span
+        className="font-bold text-center leading-tight break-words w-full"
+        style={{
+          fontSize: `min(${28 * sizeMultiplier}px, ${13 * sizeMultiplier}cqmin)`,
+          color: item.label ? fontColor : '#94a3b8',
+          fontStyle: item.label ? 'normal' : 'italic',
+        }}
+      >
+        {item.label || 'User provided text'}
+      </span>
+    </div>
+  );
+};
+
+interface IconListProps {
+  items: NeedDoPutThenTile[];
+  fontClass: string;
+  fontColor: string;
+  sizeMultiplier: number;
+}
+
+const IconList: React.FC<IconListProps> = ({
+  items,
+  fontClass,
+  fontColor,
+  sizeMultiplier,
+}) => {
+  if (items.length === 0) {
+    return (
+      <div className="h-full w-full flex items-center justify-center text-slate-400">
+        <span className="italic" style={{ fontSize: 'min(14px, 4.5cqmin)' }}>
+          Flip to add options
+        </span>
+      </div>
+    );
+  }
+
+  if (items.length === 1) {
+    return (
+      <IconHero
+        item={items[0]}
+        fontClass={fontClass}
+        fontColor={fontColor}
+        sizeMultiplier={sizeMultiplier}
+      />
+    );
+  }
+
+  return (
+    <ul
+      className={`h-full w-full flex flex-col ${fontClass}`}
+      style={{
+        gap: 'min(8px, 2cqmin)',
+        padding: 'min(6px, 2cqmin)',
+      }}
+    >
+      {items.map((item) => {
+        const Icon = resolveIcon(item.icon);
+        const iconTextColor = getContrastingTextColor(item.color);
+        return (
+          <li
+            key={item.id}
+            className="flex items-center min-h-0"
+            style={{
+              flex: 1,
+              containerType: 'size',
+              gap: 'min(14px, 8cqh, 6cqw)',
+            }}
+          >
+            <span
+              className="rounded-full flex items-center justify-center shrink-0"
+              style={{
+                width: `min(${64 * sizeMultiplier}px, ${55 * sizeMultiplier}cqh, ${32 * sizeMultiplier}cqw)`,
+                height: `min(${64 * sizeMultiplier}px, ${55 * sizeMultiplier}cqh, ${32 * sizeMultiplier}cqw)`,
+                background: item.color,
+                color: iconTextColor,
+              }}
+            >
+              <Icon
+                strokeWidth={2.5}
+                style={{
+                  width: `min(${36 * sizeMultiplier}px, ${32 * sizeMultiplier}cqh, ${18 * sizeMultiplier}cqw)`,
+                  height: `min(${36 * sizeMultiplier}px, ${32 * sizeMultiplier}cqh, ${18 * sizeMultiplier}cqw)`,
+                }}
+              />
+            </span>
+            <span
+              className="border-b border-slate-300 flex-1 break-words whitespace-normal leading-snug"
+              style={{
+                fontSize: `min(${26 * sizeMultiplier}px, ${26 * sizeMultiplier}cqh, ${11 * sizeMultiplier}cqw)`,
+                paddingBottom: 'min(4px, 2cqh)',
+                color: item.label ? fontColor : '#94a3b8',
+                fontStyle: item.label ? 'normal' : 'italic',
+              }}
+            >
+              {item.label || 'User provided text'}
+            </span>
+          </li>
+        );
+      })}
+    </ul>
+  );
+};
+
+type DrawerSide = 'left' | 'right' | 'bottom';
+
+interface DrawerProps {
+  side: DrawerSide;
+  background: string;
+  fontColor: string;
+  fontClass: string;
+  sizeMultiplier: number;
+  titlePlain: string;
+  titleEmphasis: string;
+  accentColor: string;
+  children: React.ReactNode;
+}
+
+const Drawer: React.FC<DrawerProps> = ({
+  side,
+  background,
+  fontColor,
+  fontClass,
+  sizeMultiplier,
+  titlePlain,
+  titleEmphasis,
+  accentColor,
+  children,
+}) => {
+  const style: React.CSSProperties = {
+    position: 'absolute',
+    zIndex: -1,
+    background,
+    borderRadius: '1rem',
+    boxShadow: '0 8px 20px -8px rgba(0,0,0,0.25)',
+  };
+
+  const basePad: React.CSSProperties = {
+    padding: 'min(10px, 3cqmin)',
+  };
+
+  if (side === 'left') {
+    style.top = -1;
+    style.bottom = -1;
+    style.left = -(DRAWER_SIZE_PX - DRAWER_OVERLAP_PX);
+    style.width = DRAWER_SIZE_PX;
+    basePad.paddingTop = CORNER_SAFE_PX;
+    basePad.paddingBottom = CORNER_SAFE_PX;
+    basePad.paddingRight = DRAWER_OVERLAP_PX + 6;
+  } else if (side === 'right') {
+    style.top = -1;
+    style.bottom = -1;
+    style.right = -(DRAWER_SIZE_PX - DRAWER_OVERLAP_PX);
+    style.width = DRAWER_SIZE_PX;
+    basePad.paddingTop = CORNER_SAFE_PX;
+    basePad.paddingBottom = CORNER_SAFE_PX;
+    basePad.paddingLeft = DRAWER_OVERLAP_PX + 6;
+  } else {
+    style.left = -1;
+    style.right = -1;
+    style.bottom = -(DRAWER_SIZE_PX - DRAWER_OVERLAP_PX);
+    style.height = DRAWER_SIZE_PX;
+    basePad.paddingLeft = CORNER_SAFE_PX;
+    basePad.paddingRight = CORNER_SAFE_PX;
+    basePad.paddingTop = DRAWER_OVERLAP_PX + 6;
+  }
+
+  return (
+    <div
+      className={`${fontClass}`}
+      style={{
+        ...style,
+        containerType: 'size',
+        ...basePad,
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 'min(8px, 2.5cqmin)',
+      }}
+    >
+      <div
+        className="shrink-0 text-center truncate"
+        style={{
+          fontSize: `min(${22 * sizeMultiplier}px, ${12 * sizeMultiplier}cqmin)`,
+          color: accentColor,
+        }}
+      >
+        <span className="font-bold" style={{ color: fontColor, opacity: 0.75 }}>
+          {titlePlain}{' '}
+        </span>
+        <span className="font-black">{titleEmphasis}</span>
+      </div>
+      <div className="flex-1 min-h-0">{children}</div>
+    </div>
+  );
+};
+
+export const NeedDoPutThenWidget: React.FC<{ widget: WidgetData }> = ({
+  widget,
+}) => {
+  const { activeDashboard } = useDashboard();
+  const config = widget.config as NeedDoPutThenConfig;
+
+  const {
+    needItems = DEFAULT_NEED_ITEMS,
+    doItems = DEFAULT_DO_ITEMS,
+    putItems = DEFAULT_PUT_ITEMS,
+    thenItems = DEFAULT_THEN_ITEMS,
+    cardColor = '#ffffff',
+    cardOpacity = 1,
+    fontColor = '#1e293b',
+  } = config;
+
+  const visibleNeedItems = useMemo(
+    () => needItems.filter((t) => t.checked !== false),
+    [needItems]
+  );
+  const visiblePutItems = useMemo(
+    () => putItems.filter((t) => t.checked !== false),
+    [putItems]
+  );
+
+  const [openDrawers, setOpenDrawers] = useState<{
+    need: boolean;
+    put: boolean;
+    then: boolean;
+  }>({ need: true, put: true, then: true });
+
+  const toggle = (key: 'need' | 'put' | 'then') =>
+    setOpenDrawers((s) => ({ ...s, [key]: !s[key] }));
+
+  const [portalTarget, setPortalTarget] = useState<HTMLElement | null>(null);
+  const setCentralRef = useCallback((el: HTMLDivElement | null) => {
+    const target =
+      (el?.closest('[data-widget-id]') as HTMLElement | null) ?? null;
+    setPortalTarget((prev) => (prev === target ? prev : target));
+  }, []);
+
+  const globalFont =
+    activeDashboard?.globalStyle?.fontFamily ?? DEFAULT_GLOBAL_STYLE.fontFamily;
+  const fontClass = getFontClass(config.fontFamily ?? 'global', globalFont);
+  const sizeMultiplier = resolveTextPresetMultiplier(config.textSizePreset);
+
+  const nothingConfigured =
+    visibleNeedItems.length === 0 &&
+    visiblePutItems.length === 0 &&
+    doItems.every((t) => !t) &&
+    thenItems.length === 0;
+
+  if (nothingConfigured) {
+    return (
+      <WidgetLayout
+        padding="p-0"
+        content={
+          <ScaledEmptyState
+            icon={ListTodo}
+            title="Need / Do / Put / Then"
+            subtitle="Flip to set up each section."
+          />
+        }
+      />
+    );
+  }
+
+  const background = hexToRgba(cardColor, cardOpacity);
+
+  return (
+    <WidgetLayout
+      padding="p-0"
+      content={
+        <div
+          ref={setCentralRef}
+          className={`h-full w-full flex flex-col rounded-2xl overflow-hidden ${fontClass}`}
+          style={{
+            background,
+            padding: 'min(10px, 2.5cqmin)',
+            gap: 'min(6px, 1.5cqmin)',
+          }}
+        >
+          <div
+            className="flex items-center justify-between shrink-0"
+            style={{ gap: 'min(6px, 1.5cqmin)' }}
+          >
+            <button
+              type="button"
+              onClick={() => toggle('need')}
+              className="rounded-full text-slate-500 hover:bg-slate-100 hover:text-slate-800 transition-colors"
+              style={{ padding: 'min(4px, 1cqmin)' }}
+              aria-label={
+                openDrawers.need ? 'Close Need panel' : 'Open Need panel'
+              }
+              aria-expanded={openDrawers.need}
+            >
+              {openDrawers.need ? (
+                <ChevronRight
+                  style={{
+                    width: 'min(20px, 6cqmin)',
+                    height: 'min(20px, 6cqmin)',
+                  }}
+                />
+              ) : (
+                <ChevronLeft
+                  style={{
+                    width: 'min(20px, 6cqmin)',
+                    height: 'min(20px, 6cqmin)',
+                  }}
+                />
+              )}
+            </button>
+
+            <h3
+              className="flex-1 text-center truncate"
+              style={{
+                fontSize: `min(${26 * sizeMultiplier}px, ${10 * sizeMultiplier}cqmin)`,
+                color: SECTION_COLORS.do,
+              }}
+            >
+              <span
+                className="font-bold"
+                style={{ color: fontColor, opacity: 0.75 }}
+              >
+                {SECTION_TITLES[1].plain}{' '}
+              </span>
+              <span className="font-black">{SECTION_TITLES[1].emphasis}</span>
+            </h3>
+
+            <button
+              type="button"
+              onClick={() => toggle('then')}
+              className="rounded-full text-slate-500 hover:bg-slate-100 hover:text-slate-800 transition-colors"
+              style={{ padding: 'min(4px, 1cqmin)' }}
+              aria-label={
+                openDrawers.then ? 'Close Next panel' : 'Open Next panel'
+              }
+              aria-expanded={openDrawers.then}
+            >
+              {openDrawers.then ? (
+                <ChevronLeft
+                  style={{
+                    width: 'min(20px, 6cqmin)',
+                    height: 'min(20px, 6cqmin)',
+                  }}
+                />
+              ) : (
+                <ChevronRight
+                  style={{
+                    width: 'min(20px, 6cqmin)',
+                    height: 'min(20px, 6cqmin)',
+                  }}
+                />
+              )}
+            </button>
+          </div>
+
+          <div className="flex-1 min-h-0">
+            <NumberedList
+              items={doItems}
+              fontClass={fontClass}
+              fontColor={fontColor}
+              sizeMultiplier={sizeMultiplier}
+            />
+          </div>
+
+          <div className="flex items-center justify-center shrink-0">
+            <button
+              type="button"
+              onClick={() => toggle('put')}
+              className="rounded-full text-slate-500 hover:bg-slate-100 hover:text-slate-800 transition-colors"
+              style={{ padding: 'min(4px, 1cqmin)' }}
+              aria-label={
+                openDrawers.put ? 'Close Put panel' : 'Open Put panel'
+              }
+              aria-expanded={openDrawers.put}
+            >
+              {openDrawers.put ? (
+                <ChevronUp
+                  style={{
+                    width: 'min(20px, 6cqmin)',
+                    height: 'min(20px, 6cqmin)',
+                  }}
+                />
+              ) : (
+                <ChevronDown
+                  style={{
+                    width: 'min(20px, 6cqmin)',
+                    height: 'min(20px, 6cqmin)',
+                  }}
+                />
+              )}
+            </button>
+          </div>
+
+          {portalTarget &&
+            createPortal(
+              <>
+                {openDrawers.need && (
+                  <Drawer
+                    side="left"
+                    background={background}
+                    fontColor={fontColor}
+                    fontClass={fontClass}
+                    sizeMultiplier={sizeMultiplier}
+                    titlePlain={SECTION_TITLES[0].plain}
+                    titleEmphasis={SECTION_TITLES[0].emphasis}
+                    accentColor={SECTION_COLORS.need}
+                  >
+                    <TileGrid
+                      items={visibleNeedItems}
+                      fontClass={fontClass}
+                      sizeMultiplier={sizeMultiplier}
+                      orientation="portrait"
+                    />
+                  </Drawer>
+                )}
+                {openDrawers.then && (
+                  <Drawer
+                    side="right"
+                    background={background}
+                    fontColor={fontColor}
+                    fontClass={fontClass}
+                    sizeMultiplier={sizeMultiplier}
+                    titlePlain={SECTION_TITLES[3].plain}
+                    titleEmphasis={SECTION_TITLES[3].emphasis}
+                    accentColor={SECTION_COLORS.then}
+                  >
+                    <IconList
+                      items={thenItems}
+                      fontClass={fontClass}
+                      fontColor={fontColor}
+                      sizeMultiplier={sizeMultiplier}
+                    />
+                  </Drawer>
+                )}
+                {openDrawers.put && (
+                  <Drawer
+                    side="bottom"
+                    background={background}
+                    fontColor={fontColor}
+                    fontClass={fontClass}
+                    sizeMultiplier={sizeMultiplier}
+                    titlePlain={SECTION_TITLES[2].plain}
+                    titleEmphasis={SECTION_TITLES[2].emphasis}
+                    accentColor={SECTION_COLORS.put}
+                  >
+                    <TileGrid
+                      items={visiblePutItems}
+                      fontClass={fontClass}
+                      sizeMultiplier={sizeMultiplier}
+                      orientation="landscape"
+                    />
+                  </Drawer>
+                )}
+              </>,
+              portalTarget
+            )}
+        </div>
+      }
+    />
+  );
+};

--- a/components/widgets/NeedDoPutThen/Widget.tsx
+++ b/components/widgets/NeedDoPutThen/Widget.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useState } from 'react';
+import React, { useCallback, useState } from 'react';
 import { createPortal } from 'react-dom';
 import * as LucideIcons from 'lucide-react';
 import {
@@ -60,11 +60,9 @@ const TileGrid: React.FC<TileGridProps> = ({
 }) => {
   const numItems = items.length;
 
-  const cols = useMemo(() => {
+  const cols = (() => {
     if (numItems <= 1) return 1;
-    if (orientation === 'portrait') {
-      return numItems >= 7 ? 2 : 1;
-    }
+    if (orientation === 'portrait') return numItems >= 7 ? 2 : 1;
     if (orientation === 'landscape') {
       if (numItems <= 2) return numItems;
       if (numItems <= 6) return Math.ceil(numItems / 2);
@@ -73,7 +71,7 @@ const TileGrid: React.FC<TileGridProps> = ({
     if (numItems <= 4) return 2;
     if (numItems <= 9) return 3;
     return 4;
-  }, [numItems, orientation]);
+  })();
 
   if (numItems === 0) {
     return (
@@ -465,14 +463,8 @@ export const NeedDoPutThenWidget: React.FC<{ widget: WidgetData }> = ({
     fontColor = '#1e293b',
   } = config;
 
-  const visibleNeedItems = useMemo(
-    () => needItems.filter((t) => t.checked !== false),
-    [needItems]
-  );
-  const visiblePutItems = useMemo(
-    () => putItems.filter((t) => t.checked !== false),
-    [putItems]
-  );
+  const visibleNeedItems = needItems.filter((t) => t.checked !== false);
+  const visiblePutItems = putItems.filter((t) => t.checked !== false);
 
   const [openDrawers, setOpenDrawers] = useState<{
     need: boolean;

--- a/components/widgets/NeedDoPutThen/Widget.tsx
+++ b/components/widgets/NeedDoPutThen/Widget.tsx
@@ -38,9 +38,10 @@ const LUCIDE_ICON_MAP = LucideIcons as unknown as Record<
 const resolveIcon = (iconName?: string): React.ElementType =>
   (iconName ? LUCIDE_ICON_MAP[iconName] : undefined) ?? LucideIcons.Package;
 
-const DRAWER_SIZE_PX = 200;
-const DRAWER_OVERLAP_PX = 22;
-const CORNER_SAFE_PX = 18;
+const DRAWER_SIDE_SIZE = 'min(240px, 60%)';
+const DRAWER_BOTTOM_SIZE = 'min(240px, 65%)';
+const DRAWER_OVERLAP = 'min(28px, 7%)';
+const CORNER_SAFE = 'min(24px, 5.5%)';
 
 type TileOrientation = 'portrait' | 'landscape' | 'auto';
 
@@ -86,8 +87,11 @@ const TileGrid: React.FC<TileGridProps> = ({
             className="opacity-30"
           />
           <span
-            className="mt-2 italic"
-            style={{ fontSize: 'min(12px, 5cqmin)' }}
+            className="italic"
+            style={{
+              marginTop: 'min(8px, 2cqmin)',
+              fontSize: 'min(12px, 5cqmin)',
+            }}
           >
             Flip to add items
           </span>
@@ -197,7 +201,7 @@ const NumberedList: React.FC<NumberedListProps> = ({
               fontStyle: text ? 'normal' : 'italic',
             }}
           >
-            {text || 'User provided text'}
+            {text || `Step ${idx + 1}`}
           </span>
         </li>
       ))}
@@ -253,7 +257,7 @@ const IconHero: React.FC<IconHeroProps> = ({
           fontStyle: item.label ? 'normal' : 'italic',
         }}
       >
-        {item.label || 'User provided text'}
+        {item.label || 'Add a label'}
       </span>
     </div>
   );
@@ -311,14 +315,14 @@ const IconList: React.FC<IconListProps> = ({
             style={{
               flex: 1,
               containerType: 'size',
-              gap: 'min(14px, 8cqh, 6cqw)',
+              gap: 'min(14px, 7cqmin)',
             }}
           >
             <span
               className="rounded-full flex items-center justify-center shrink-0"
               style={{
-                width: `min(${64 * sizeMultiplier}px, ${55 * sizeMultiplier}cqh, ${32 * sizeMultiplier}cqw)`,
-                height: `min(${64 * sizeMultiplier}px, ${55 * sizeMultiplier}cqh, ${32 * sizeMultiplier}cqw)`,
+                width: `min(${64 * sizeMultiplier}px, ${55 * sizeMultiplier}cqmin)`,
+                height: `min(${64 * sizeMultiplier}px, ${55 * sizeMultiplier}cqmin)`,
                 background: item.color,
                 color: iconTextColor,
               }}
@@ -326,21 +330,21 @@ const IconList: React.FC<IconListProps> = ({
               <Icon
                 strokeWidth={2.5}
                 style={{
-                  width: `min(${36 * sizeMultiplier}px, ${32 * sizeMultiplier}cqh, ${18 * sizeMultiplier}cqw)`,
-                  height: `min(${36 * sizeMultiplier}px, ${32 * sizeMultiplier}cqh, ${18 * sizeMultiplier}cqw)`,
+                  width: `min(${36 * sizeMultiplier}px, ${32 * sizeMultiplier}cqmin)`,
+                  height: `min(${36 * sizeMultiplier}px, ${32 * sizeMultiplier}cqmin)`,
                 }}
               />
             </span>
             <span
               className="border-b border-slate-300 flex-1 break-words whitespace-normal leading-snug"
               style={{
-                fontSize: `min(${26 * sizeMultiplier}px, ${26 * sizeMultiplier}cqh, ${11 * sizeMultiplier}cqw)`,
-                paddingBottom: 'min(4px, 2cqh)',
+                fontSize: `min(${26 * sizeMultiplier}px, ${28 * sizeMultiplier}cqmin)`,
+                paddingBottom: 'min(4px, 2cqmin)',
                 color: item.label ? fontColor : '#94a3b8',
                 fontStyle: item.label ? 'normal' : 'italic',
               }}
             >
-              {item.label || 'User provided text'}
+              {item.label || 'Add a label'}
             </span>
           </li>
         );
@@ -386,30 +390,34 @@ const Drawer: React.FC<DrawerProps> = ({
     padding: 'min(10px, 3cqmin)',
   };
 
+  const overlapPlusGap = `calc(${DRAWER_OVERLAP} + 6px)`;
+  const sideOffset = `calc(${DRAWER_OVERLAP} - ${DRAWER_SIDE_SIZE})`;
+  const bottomOffset = `calc(${DRAWER_OVERLAP} - ${DRAWER_BOTTOM_SIZE})`;
+
   if (side === 'left') {
     style.top = -1;
     style.bottom = -1;
-    style.left = -(DRAWER_SIZE_PX - DRAWER_OVERLAP_PX);
-    style.width = DRAWER_SIZE_PX;
-    basePad.paddingTop = CORNER_SAFE_PX;
-    basePad.paddingBottom = CORNER_SAFE_PX;
-    basePad.paddingRight = DRAWER_OVERLAP_PX + 6;
+    style.left = sideOffset;
+    style.width = DRAWER_SIDE_SIZE;
+    basePad.paddingTop = CORNER_SAFE;
+    basePad.paddingBottom = CORNER_SAFE;
+    basePad.paddingRight = overlapPlusGap;
   } else if (side === 'right') {
     style.top = -1;
     style.bottom = -1;
-    style.right = -(DRAWER_SIZE_PX - DRAWER_OVERLAP_PX);
-    style.width = DRAWER_SIZE_PX;
-    basePad.paddingTop = CORNER_SAFE_PX;
-    basePad.paddingBottom = CORNER_SAFE_PX;
-    basePad.paddingLeft = DRAWER_OVERLAP_PX + 6;
+    style.right = sideOffset;
+    style.width = DRAWER_SIDE_SIZE;
+    basePad.paddingTop = CORNER_SAFE;
+    basePad.paddingBottom = CORNER_SAFE;
+    basePad.paddingLeft = overlapPlusGap;
   } else {
     style.left = -1;
     style.right = -1;
-    style.bottom = -(DRAWER_SIZE_PX - DRAWER_OVERLAP_PX);
-    style.height = DRAWER_SIZE_PX;
-    basePad.paddingLeft = CORNER_SAFE_PX;
-    basePad.paddingRight = CORNER_SAFE_PX;
-    basePad.paddingTop = DRAWER_OVERLAP_PX + 6;
+    style.bottom = bottomOffset;
+    style.height = DRAWER_BOTTOM_SIZE;
+    basePad.paddingLeft = CORNER_SAFE;
+    basePad.paddingRight = CORNER_SAFE;
+    basePad.paddingTop = overlapPlusGap;
   }
 
   return (

--- a/components/widgets/NeedDoPutThen/constants.ts
+++ b/components/widgets/NeedDoPutThen/constants.ts
@@ -1,0 +1,62 @@
+import { NeedDoPutThenTile } from '@/types';
+
+export const DEFAULT_NEED_ITEMS: NeedDoPutThenTile[] = [
+  { id: 'pencil', label: 'Pencil', icon: 'Pencil', color: '#facc15' },
+  { id: 'notebook', label: 'Notebook', icon: 'Notebook', color: '#ef4444' },
+  { id: 'chromebook', label: 'Chromebook', icon: 'Laptop', color: '#334155' },
+  {
+    id: 'headphones',
+    label: 'Headphones',
+    icon: 'Headphones',
+    color: '#ec4899',
+  },
+  { id: 'paper', label: 'Paper', icon: 'FileText', color: '#e2e8f0' },
+];
+
+export const DEFAULT_PUT_ITEMS: NeedDoPutThenTile[] = [
+  {
+    id: 'schoology',
+    label: 'Schoology',
+    icon: 'GraduationCap',
+    color: '#0ea5e9',
+  },
+  {
+    id: 'google-classroom',
+    label: 'Google Classroom',
+    icon: 'BookOpen',
+    color: '#22c55e',
+  },
+  { id: 'email', label: 'Email', icon: 'Mail', color: '#7c3aed' },
+  { id: 'turn-in-bin', label: 'Turn-in Bin', icon: 'Inbox', color: '#d97706' },
+];
+
+export const DEFAULT_DO_ITEMS: string[] = ['', '', ''];
+
+export const DEFAULT_THEN_ITEMS: NeedDoPutThenTile[] = [
+  { id: 'read', label: 'Read', icon: 'BookOpen', color: '#8b5cf6' },
+  {
+    id: 'silent-work',
+    label: 'Silent Work',
+    icon: 'PenLine',
+    color: '#0ea5e9',
+  },
+  { id: 'partner', label: 'Partner Up', icon: 'Users', color: '#f59e0b' },
+];
+
+export const SECTION_TITLES = [
+  { plain: 'What you', emphasis: 'need' },
+  { plain: 'What you', emphasis: 'do' },
+  { plain: 'Where it', emphasis: 'goes' },
+  { plain: "What's", emphasis: 'next' },
+] as const;
+
+export const SECTION_COLORS = {
+  need: '#10b981',
+  do: '#2563eb',
+  put: '#f59e0b',
+  then: '#8b5cf6',
+} as const;
+
+export const MIN_LIST_ITEMS = 1;
+export const MAX_LIST_ITEMS = 6;
+export const MAX_TILE_ITEMS = 12;

--- a/components/widgets/NeedDoPutThen/index.ts
+++ b/components/widgets/NeedDoPutThen/index.ts
@@ -1,0 +1,5 @@
+export { NeedDoPutThenWidget } from './Widget';
+export {
+  NeedDoPutThenSettings,
+  NeedDoPutThenAppearanceSettings,
+} from './Settings';

--- a/components/widgets/WidgetRegistry.ts
+++ b/components/widgets/WidgetRegistry.ts
@@ -192,6 +192,10 @@ export const WIDGET_COMPONENTS: Partial<Record<WidgetType, WidgetComponent>> = {
     () => import('./BloomsTaxonomy/DetailWidget'),
     'BloomsDetailWidget'
   ),
+  'need-do-put-then': lazyNamed(
+    () => import('./NeedDoPutThen/Widget'),
+    'NeedDoPutThenWidget'
+  ),
 };
 
 export const WIDGET_SETTINGS_COMPONENTS: Partial<
@@ -338,6 +342,10 @@ export const WIDGET_SETTINGS_COMPONENTS: Partial<
     () => import('./TalkingTool'),
     'TalkingToolSettings'
   ),
+  'need-do-put-then': lazyNamed(
+    () => import('./NeedDoPutThen/Settings'),
+    'NeedDoPutThenSettings'
+  ),
 };
 
 export const WIDGET_APPEARANCE_COMPONENTS: Partial<
@@ -437,6 +445,10 @@ export const WIDGET_APPEARANCE_COMPONENTS: Partial<
   'work-symbols': lazyNamed(
     () => import('./WorkSymbols/Settings'),
     'WorkSymbolsAppearanceSettings'
+  ),
+  'need-do-put-then': lazyNamed(
+    () => import('./NeedDoPutThen/Settings'),
+    'NeedDoPutThenAppearanceSettings'
   ),
 };
 
@@ -869,6 +881,13 @@ export const WIDGET_SCALING_CONFIG: Record<WidgetType, ScalingConfig> = {
   'blooms-detail': {
     baseWidth: 450,
     baseHeight: 300,
+    canSpread: true,
+    skipScaling: true,
+    padding: 0,
+  },
+  'need-do-put-then': {
+    baseWidth: 340,
+    baseHeight: 320,
     canSpread: true,
     skipScaling: true,
     padding: 0,

--- a/config/tools.ts
+++ b/config/tools.ts
@@ -44,6 +44,7 @@ import {
   MessagesSquare,
   Image as ImageIcon,
   Triangle,
+  Workflow,
 } from 'lucide-react';
 import { ToolMetadata } from '../types';
 
@@ -279,5 +280,11 @@ export const TOOLS: ToolMetadata[] = [
     icon: Triangle,
     label: "Bloom's Taxonomy",
     color: 'bg-indigo-600',
+  },
+  {
+    type: 'need-do-put-then',
+    icon: Workflow,
+    label: 'Need / Do / Put / Then',
+    color: 'bg-cyan-600',
   },
 ];

--- a/config/widgetDefaults.ts
+++ b/config/widgetDefaults.ts
@@ -8,8 +8,15 @@ import {
   QRConfig,
   BloomsTaxonomyConfig,
   BloomsDetailConfig,
+  NeedDoPutThenConfig,
 } from '@/types';
 import { STICKY_NOTE_COLORS } from './colors';
+import {
+  DEFAULT_NEED_ITEMS,
+  DEFAULT_PUT_ITEMS,
+  DEFAULT_DO_ITEMS,
+  DEFAULT_THEN_ITEMS,
+} from '@/components/widgets/NeedDoPutThen/constants';
 
 export const WIDGET_DEFAULTS: Record<WidgetType, Partial<WidgetData>> = {
   url: {
@@ -494,5 +501,15 @@ export const WIDGET_DEFAULTS: Record<WidgetType, Partial<WidgetData>> = {
       parentWidgetId: '',
       level: 'remember',
     } satisfies BloomsDetailConfig,
+  },
+  'need-do-put-then': {
+    w: 340,
+    h: 320,
+    config: {
+      needItems: DEFAULT_NEED_ITEMS,
+      doItems: DEFAULT_DO_ITEMS,
+      putItems: DEFAULT_PUT_ITEMS,
+      thenItems: DEFAULT_THEN_ITEMS,
+    } satisfies NeedDoPutThenConfig,
   },
 };

--- a/config/widgetGradeLevels.ts
+++ b/config/widgetGradeLevels.ts
@@ -106,6 +106,7 @@ export const WIDGET_GRADE_LEVELS: Record<
   'work-symbols': ALL_GRADE_LEVELS,
   'blooms-taxonomy': ALL_GRADE_LEVELS,
   'blooms-detail': ALL_GRADE_LEVELS,
+  'need-do-put-then': ALL_GRADE_LEVELS,
 };
 
 /**

--- a/types.ts
+++ b/types.ts
@@ -58,7 +58,8 @@ export type WidgetType =
   | 'first-5'
   | 'work-symbols'
   | 'blooms-taxonomy'
-  | 'blooms-detail';
+  | 'blooms-detail'
+  | 'need-do-put-then';
 
 // --- ROSTER SYSTEM TYPES ---
 
@@ -2774,6 +2775,27 @@ export interface GuidedLearningConfig {
   lastRosterIdsBySetId?: Record<string, string[]>;
 }
 
+export interface NeedDoPutThenTile {
+  id: string;
+  label: string;
+  icon: string;
+  color: string;
+  checked?: boolean;
+}
+
+export interface NeedDoPutThenConfig {
+  needItems?: NeedDoPutThenTile[];
+  doItems?: string[];
+  putItems?: NeedDoPutThenTile[];
+  thenItems?: NeedDoPutThenTile[];
+  fontFamily?: string;
+  fontColor?: string;
+  textSizePreset?: 'small' | 'medium' | 'large' | 'x-large';
+  scaleMultiplier?: number;
+  cardColor?: string;
+  cardOpacity?: number;
+}
+
 // Union of all widget configs
 export type WidgetConfig =
   | UrlWidgetConfig
@@ -2834,7 +2856,8 @@ export type WidgetConfig =
   | ActivityWallConfig
   | WorkSymbolsConfig
   | BloomsTaxonomyConfig
-  | BloomsDetailConfig;
+  | BloomsDetailConfig
+  | NeedDoPutThenConfig;
 
 // Helper type to get config type for a specific widget
 export type ConfigForWidget<T extends WidgetType> = T extends 'url'
@@ -2955,7 +2978,9 @@ export type ConfigForWidget<T extends WidgetType> = T extends 'url'
                                                                                                                     ? BloomsTaxonomyConfig
                                                                                                                     : T extends 'blooms-detail'
                                                                                                                       ? BloomsDetailConfig
-                                                                                                                      : never;
+                                                                                                                      : T extends 'need-do-put-then'
+                                                                                                                        ? NeedDoPutThenConfig
+                                                                                                                        : never;
 
 export interface WidgetComponentProps {
   widget: WidgetData;

--- a/types.ts
+++ b/types.ts
@@ -2790,8 +2790,7 @@ export interface NeedDoPutThenConfig {
   thenItems?: NeedDoPutThenTile[];
   fontFamily?: string;
   fontColor?: string;
-  textSizePreset?: 'small' | 'medium' | 'large' | 'x-large';
-  scaleMultiplier?: number;
+  textSizePreset?: TextSizePreset;
   cardColor?: string;
   cardOpacity?: number;
 }


### PR DESCRIPTION
## Summary
- New **Need / Do / Put / Then** widget: central *What you do* numbered list with three slideout drawers (Need on the left, Put on the bottom, Then on the right) that tuck under the central panel via portals.
- **Need** and **Put** render as icon tiles with per-item **checkbox toggles** in settings — teachers can hide/show items without deleting them. **Then** renders as an icon-badge list and auto-switches to a centered **hero tile** when only one option is configured.
- Settings panel has four **collapsible sections** (default collapsed) plus a standard appearance tab wired to `TypographySettings` / `TextSizePresetSettings` / `SurfaceColorSettings`.
- Per-section color accents (green/blue/amber/purple) and a colored emphasis word in each header so sections read at a glance.

## Test plan
- [ ] Drag the widget from the dock; confirm it spawns with default Need/Put/Then tiles and three empty Do rows.
- [ ] Click the left/right/bottom chevrons → verify drawers open/close, alignment is flush with the central panel edges, and content scales via `cqmin`.
- [ ] Open Settings → confirm all four sections are collapsed by default; expand each; verify Need and Put rows have checkboxes (default checked); uncheck an item and confirm it disappears from the front face without being deleted.
- [ ] Edit labels, swap icons via the picker, change colors; confirm *Restore defaults* reverts just that section.
- [ ] Delete Then items down to 1 → confirm the drawer switches to the centered hero tile.
- [ ] Flip to the *Style* tab → change font family, font color, text-size preset, card color / opacity; confirm all controls affect the front face.
- [ ] Resize the widget small and large; confirm header/body/drawers stay legible and nothing overflows.
- [ ] Refresh the page; confirm config survives via Firestore.

🤖 Generated with [Claude Code](https://claude.com/claude-code)