### PR TITLE
fix: address dev-paul review findings (quiz reopen, anon legacy probe, reset URL)

### DIFF
--- a/components/admin/Organization/OrganizationPanel.tsx
+++ b/components/admin/Organization/OrganizationPanel.tsx
@@ -1,4 +1,10 @@
-import React, { useEffect, useMemo, useRef, useState } from 'react';
+import React, {
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import {
   Building2,
   LayoutGrid,
@@ -284,11 +290,16 @@ export const OrganizationPanel: React.FC = () => {
   } | null>(null);
   // When the org's email queue is disabled, the reset-password CF returns the
   // minted URL so the admin can deliver it manually. We surface it in a modal
-  // (sensitive — never logged, never toasted, never persisted).
-  const [manualResetLink, setManualResetLink] = useState<{
-    email: string;
-    url: string;
-  } | null>(null);
+  // (sensitive — never logged, never toasted, never persisted). The URL itself
+  // lives in a ref rather than state so it doesn't appear in component-state
+  // snapshots (React DevTools state panel, error-boundary breadcrumbs, future
+  // session-replay tooling). Email-as-state is fine — it's not the credential.
+  const manualResetUrlRef = useRef<string | null>(null);
+  const [manualResetEmail, setManualResetEmail] = useState<string | null>(null);
+  const closeManualResetLink = () => {
+    manualResetUrlRef.current = null;
+    setManualResetEmail(null);
+  };
   const toastTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const showToast = (message: string, type: OrgToastType = 'info') => {
     if (toastTimer.current) clearTimeout(toastTimer.current);
@@ -562,7 +573,8 @@ export const OrganizationPanel: React.FC = () => {
     resetPassword(target.email)
       .then((response) => {
         if (response.resetUrl) {
-          setManualResetLink({ email: target.email, url: response.resetUrl });
+          manualResetUrlRef.current = response.resetUrl;
+          setManualResetEmail(target.email);
           return;
         }
         showToast(`Sent reset email to ${target.email}`, 'success');
@@ -854,8 +866,9 @@ export const OrganizationPanel: React.FC = () => {
       {toast && <OrgToast message={toast.message} type={toast.type} />}
 
       <ManualResetLinkModal
-        link={manualResetLink}
-        onClose={() => setManualResetLink(null)}
+        email={manualResetEmail}
+        getUrl={() => manualResetUrlRef.current}
+        onClose={closeManualResetLink}
       />
     </div>
   );
@@ -865,26 +878,42 @@ export const OrganizationPanel: React.FC = () => {
 // queue is disabled. Sensitive — rendered in a modal, click-to-copy only;
 // never toasted, never logged. Local to this file because there's no other
 // caller and we want the security posture to live next to the handler.
+//
+// The URL itself is *not* a prop: the parent passes a `getUrl` callback that
+// closes over its ref. The modal writes the value imperatively into the input
+// after mount and reads it on copy. This keeps the URL out of the React
+// state/props/hooks tree of every component that touches it (only the parent's
+// ref holds it), so DevTools and any state-snapshotting observability tooling
+// see only the email + a function reference.
 const ManualResetLinkModal: React.FC<{
-  link: { email: string; url: string } | null;
+  email: string | null;
+  getUrl: () => string | null;
   onClose: () => void;
-}> = ({ link, onClose }) => {
+}> = ({ email, getUrl, onClose }) => {
   type CopyState = 'idle' | 'copied' | 'failed';
   const [copyState, setCopyState] = useState<CopyState>('idle');
   const copyTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const urlInputRef = useRef<HTMLInputElement | null>(null);
 
-  // Reset the copy-affordance state whenever a fresh link opens. We compare the
-  // url in render rather than reaching for useEffect; CLAUDE.md flags effect
-  // chains for derived state as the wrong tool here.
-  const [lastUrl, setLastUrl] = useState<string | null>(null);
-  if (link && link.url !== lastUrl) {
-    setLastUrl(link.url);
+  // Reset the copy-affordance state whenever a fresh link opens. We compare in
+  // render rather than reaching for useEffect; CLAUDE.md flags effect chains
+  // for derived state as the wrong tool here.
+  const [lastEmail, setLastEmail] = useState<string | null>(null);
+  if (email !== null && email !== lastEmail) {
+    setLastEmail(email);
     setCopyState('idle');
   }
-  if (!link && lastUrl !== null) {
-    setLastUrl(null);
+  if (email === null && lastEmail !== null) {
+    setLastEmail(null);
   }
+
+  // Push the URL into the DOM imperatively (rather than through `value` /
+  // `defaultValue`) so it never appears as a prop on the input element.
+  useLayoutEffect(() => {
+    if (urlInputRef.current) {
+      urlInputRef.current.value = email !== null ? (getUrl() ?? '') : '';
+    }
+  }, [email, getUrl]);
 
   useEffect(
     () => () => {
@@ -894,9 +923,10 @@ const ManualResetLinkModal: React.FC<{
   );
 
   const handleCopy = async () => {
-    if (!link) return;
+    const url = getUrl();
+    if (!url) return;
     try {
-      await navigator.clipboard.writeText(link.url);
+      await navigator.clipboard.writeText(url);
       setCopyState('copied');
       if (copyTimer.current) clearTimeout(copyTimer.current);
       copyTimer.current = setTimeout(() => setCopyState('idle'), 2000);
@@ -923,7 +953,7 @@ const ManualResetLinkModal: React.FC<{
 
   return (
     <LocalModal
-      isOpen={link !== null}
+      isOpen={email !== null}
       onClose={onClose}
       title="Copy password-reset link"
       icon={<KeyRound size={18} />}
@@ -937,15 +967,15 @@ const ManualResetLinkModal: React.FC<{
         <p>
           Email delivery is disabled for this organization. Copy the link below
           and send it to{' '}
-          <strong className="text-slate-900">{link?.email ?? ''}</strong>{' '}
-          through your preferred channel.
+          <strong className="text-slate-900">{email ?? ''}</strong> through your
+          preferred channel.
         </p>
         <div className="flex items-stretch gap-2">
           <input
             ref={urlInputRef}
             type="text"
             readOnly
-            value={link?.url ?? ''}
+            defaultValue=""
             onFocus={(e) => e.currentTarget.select()}
             aria-label="Password reset URL"
             className="flex-1 rounded-lg border border-slate-200 bg-slate-50 px-3 py-2 text-xs font-mono text-slate-800 focus:outline-none focus-visible:ring-[3px] focus-visible:ring-brand-blue-primary/30"

--- a/hooks/useQuizAssignments.ts
+++ b/hooks/useQuizAssignments.ts
@@ -372,9 +372,41 @@ export const useQuizAssignments = (
     UseQuizAssignmentsResult['reopenAssignment']
   >(
     async (assignmentId) => {
-      await setStatus(assignmentId, 'paused', 'paused');
+      if (!userId) throw new Error('Not authenticated');
+      // Auto-end advances `currentQuestionIndex` to `totalQuestions` (see the
+      // end-of-quiz branch in useQuizSession.advanceQuestion). If we just
+      // flipped status back to 'paused' here, the next resume would jump to
+      // 'active' and every student would look up `publicQuestions[totalQuestions]`
+      // — undefined — and stall on the loading UI. Clamp the index back into
+      // bounds (last question) so stragglers can finish, and re-arm
+      // `questionPhase` to 'answering'.
+      const sessionRef = doc(db, QUIZ_SESSIONS_COLLECTION, assignmentId);
+      const snap = await getDoc(sessionRef);
+      const session = snap.data() as QuizSession | undefined;
+      const now = Date.now();
+      const batch = writeBatch(db);
+      batch.update(
+        doc(db, 'users', userId, QUIZ_ASSIGNMENTS_COLLECTION, assignmentId),
+        { status: 'paused', updatedAt: now }
+      );
+      const sessionPatch: Record<string, unknown> = {
+        status: 'paused',
+        autoProgressAt: null,
+        endedAt: null,
+      };
+      if (
+        session &&
+        typeof session.totalQuestions === 'number' &&
+        session.totalQuestions > 0 &&
+        session.currentQuestionIndex >= session.totalQuestions
+      ) {
+        sessionPatch.currentQuestionIndex = session.totalQuestions - 1;
+        sessionPatch.questionPhase = 'answering';
+      }
+      batch.update(sessionRef, sessionPatch);
+      await batch.commit();
     },
-    [setStatus]
+    [userId]
   );
 
   const deleteAssignment = useCallback<

--- a/hooks/useQuizSession.ts
+++ b/hooks/useQuizSession.ts
@@ -218,17 +218,28 @@ async function findExistingResponseDoc(
     return { key: deterministicKey, snap: deterministicSnap };
   }
   if (isAnonymous && deterministicKey !== authUid) {
-    const legacySnap = await getDoc(
-      doc(
-        db,
-        QUIZ_SESSIONS_COLLECTION,
-        sessionId,
-        RESPONSES_COLLECTION,
-        authUid
-      )
-    );
-    if (legacySnap.exists()) {
-      return { key: authUid, snap: legacySnap };
+    // Probe the legacy authUid-keyed slot. The doc, if it exists, was created
+    // by a previous device/session whose anon UID is no longer ours, so its
+    // `studentUid` field will not match `request.auth.uid` — and the response
+    // read rule rejects with permission-denied. Treat that rejection as
+    // "no legacy doc here" rather than letting it bubble out as a generic
+    // joinQuizSession error toast on the student side.
+    try {
+      const legacySnap = await getDoc(
+        doc(
+          db,
+          QUIZ_SESSIONS_COLLECTION,
+          sessionId,
+          RESPONSES_COLLECTION,
+          authUid
+        )
+      );
+      if (legacySnap.exists()) {
+        return { key: authUid, snap: legacySnap };
+      }
+    } catch (err) {
+      const code = (err as { code?: unknown }).code;
+      if (code !== 'permission-denied') throw err;
     }
   }
   return { key: deterministicKey, snap: deterministicSnap };


### PR DESCRIPTION
## Summary

Addresses three of the four Should-Fix items the code-reviewer agent surfaced on the dev-paul → main integration PR ([#1409](https://github.com/OPS-PIvers/SpartBoard/pull/1409)). Each fix is its own commit; none of them affects the happy path for new users / sessions.

The fourth finding (org-counter staleness banner) is feature-scope work — Cloud Function + status doc + admin UI — left as a tracked follow-up rather than bundled here.

## Fixes

- **`fix(quiz): clamp currentQuestionIndex on reopen so resume isn't a dead-end`** — Auto-end advanced ``currentQuestionIndex`` to ``totalQuestions``; reopen didn't reset it, so resume left students on a perpetual loading screen. Now clamps to ``totalQuestions - 1`` and re-arms ``questionPhase``. Stragglers can finish on the last question.
- **`fix(quiz): swallow permission-denied on legacy anon response probe`** — ``findExistingResponseDoc``'s legacy fallback hit ``permission-denied`` for anon docs whose ``studentUid`` no longer matched the device's anon UID. Error bubbled out as a generic toast on join. Now caught and treated as "no legacy doc here".
- **`fix(org-admin): keep manual reset URL out of React state/props tree`** — Sensitive minted URL was readable via React DevTools (state + props). Now lives only in a ref + the DOM input value (set imperatively via ``useLayoutEffect``); modal receives an opaque ``getUrl`` callback rather than the URL itself.

## Test plan

- [x] ``pnpm validate`` clean (1460 root + 165 functions tests passing)
- [ ] CI on this PR
- [ ] Manual: trigger a teacher-paced quiz auto-end, hit reopen → resume → confirm students see the last question (not loading)
- [ ] Manual: open the password-reset modal as a domain admin with org email queue disabled, inspect React DevTools — confirm the URL doesn't appear under ``OrganizationPanel`` state, ``ManualResetLinkModal`` props, or the input element's props

## Out of scope

- Counter-staleness admin banner (left as tracked follow-up — needs Cloud Function status doc + new UI surface + recount script update)

🤖 Generated with [Claude Code](https://claude.com/claude-code)