### PR TITLE
fix(lunchCount): prevent settings crash for users with short-form building IDs

### DIFF
--- a/components/layout/Dock.tsx
+++ b/components/layout/Dock.tsx
@@ -47,7 +47,7 @@ import {
   InternalToolType,
 } from '@/types';
 import { TOOLS } from '@/config/tools';
-import { isLunchCountBuilding } from '@/config/buildings';
+import { toLunchCountSchoolSite } from '@/config/buildings';
 import { matchesUserBuilding as matchesUserBuildingLevels } from '@/config/widgetGradeLevels';
 import { AddWidgetOverrides } from '@/types';
 import { getJoinUrl } from '@/utils/urlHelpers';
@@ -157,9 +157,11 @@ export const Dock: React.FC = () => {
   const getBuildingAwareOverrides = useCallback(
     (type: WidgetType): AddWidgetOverrides | undefined => {
       if (type === 'lunchCount') {
-        const schoolBuilding = selectedBuildings.find(isLunchCountBuilding);
-        if (schoolBuilding) {
-          return { config: { schoolSite: schoolBuilding } };
+        for (const id of selectedBuildings) {
+          const schoolSite = toLunchCountSchoolSite(id);
+          if (schoolSite) {
+            return { config: { schoolSite } };
+          }
         }
       }
       return undefined;

--- a/components/widgets/LunchCount/Settings.tsx
+++ b/components/widgets/LunchCount/Settings.tsx
@@ -5,6 +5,7 @@ import { RosterModeControl } from '@/components/common/RosterModeControl';
 import { Toggle } from '@/components/common/Toggle';
 import { SurfaceColorSettings } from '@/components/common/SurfaceColorSettings';
 import { TypographySettings } from '@/components/common/TypographySettings';
+import { toLunchCountSchoolSite } from '@/config/buildings';
 import { School, Users, Clock, GraduationCap } from 'lucide-react';
 
 const SCHOOL_OPTIONS = [
@@ -52,7 +53,7 @@ export const LunchCountSettings: React.FC<{ widget: WidgetData }> = ({
   const { updateWidget } = useDashboard();
   const config = widget.config as LunchCountConfig;
   const {
-    schoolSite = 'schumann-elementary',
+    schoolSite: rawSchoolSite,
     isManualMode = false,
     manualHotLunch = '',
     manualBentoBox = '',
@@ -63,6 +64,12 @@ export const LunchCountSettings: React.FC<{ widget: WidgetData }> = ({
     gradeLevel = '',
   } = config;
 
+  // Legacy widget configs may contain a canonical short-form building ID
+  // (e.g. `schumann`) instead of the long-form `schoolSite` this widget
+  // expects. Normalize before any lookup so the settings panel never crashes
+  // on stale data.
+  const schoolSite: LunchCountConfig['schoolSite'] =
+    toLunchCountSchoolSite(rawSchoolSite ?? '') ?? 'schumann-elementary';
   const gradeOptions = GRADE_OPTIONS[schoolSite];
 
   /** When the school site changes, clear the grade selection if it's no longer valid */

--- a/components/widgets/LunchCount/useNutrislice.ts
+++ b/components/widgets/LunchCount/useNutrislice.ts
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { LunchCountConfig, LunchMenuDay, WidgetData } from '@/types';
 import { httpsCallable } from 'firebase/functions';
 import { functions } from '@/config/firebase';
+import { toLunchCountSchoolSite } from '@/config/buildings';
 
 interface UseNutrisliceProps {
   widgetId: string;
@@ -75,7 +76,9 @@ export const useNutrislice = ({
       const year = now.getFullYear();
       const month = String(now.getMonth() + 1).padStart(2, '0');
       const day = String(now.getDate()).padStart(2, '0');
-      const schoolSite = configRef.current.schoolSite || 'schumann-elementary';
+      const schoolSite =
+        toLunchCountSchoolSite(configRef.current.schoolSite ?? '') ??
+        'schumann-elementary';
 
       const apiUrl = `https://orono.api.nutrislice.com/menu/api/weeks/school/${schoolSite}/menu-type/lunch/${year}/${month}/${day}/`;
       const data = await fetchWithFallback(apiUrl);

--- a/config/buildings.ts
+++ b/config/buildings.ts
@@ -182,15 +182,48 @@ export const LUNCH_COUNT_BUILDING_IDS: ReadonlySet<string> = new Set(
 );
 
 /**
- * Narrows a building ID string to the LunchCountConfig['schoolSite'] literal
- * union, allowing type-safe use of the value as a config field without
- * requiring `as` assertions at call sites. Normalizes legacy IDs first so
- * stored values like `schumann-elementary` are recognized.
+ * Canonical (short) → LunchCount long-form ID map.
+ *
+ * `LunchCountConfig['schoolSite']` still uses the legacy long-form IDs
+ * (`schumann-elementary`, `orono-high-school`, ...) as Firestore doc keys for
+ * Nutrislice menu lookups. User profiles, however, store `selectedBuildings`
+ * in canonical short form (`schumann`, `high`, ...) after being normalized on
+ * load. Callers that need to translate a canonical building ID into a valid
+ * `schoolSite` value should go through this map.
  */
-export function isLunchCountBuilding(
-  id: string
-): id is LunchCountConfig['schoolSite'] {
+const LUNCH_COUNT_SCHOOL_SITE_BY_CANONICAL: Readonly<
+  Record<string, LunchCountConfig['schoolSite']>
+> = {
+  schumann: 'schumann-elementary',
+  intermediate: 'orono-intermediate-school',
+  middle: 'orono-middle-school',
+  high: 'orono-high-school',
+};
+
+/**
+ * Returns true when a building ID — canonical or legacy long-form — maps to
+ * a building that supports the LunchCount widget.
+ *
+ * Note: does NOT narrow to `LunchCountConfig['schoolSite']`, because the
+ * runtime value may be a canonical short ID (e.g. `schumann`) that is not in
+ * that literal union. Use {@link toLunchCountSchoolSite} to get a value that
+ * is safe to store in `LunchCountConfig['schoolSite']`.
+ */
+export function isLunchCountBuilding(id: string): boolean {
   return LUNCH_COUNT_BUILDING_IDS.has(canonicalBuildingId(id));
+}
+
+/**
+ * Converts any recognized building ID (canonical short or legacy long form)
+ * to the long-form `LunchCountConfig['schoolSite']` value used by the widget
+ * config and Nutrislice API. Returns `null` for unknown or non-LunchCount
+ * buildings so callers can fall back to a safe default.
+ */
+export function toLunchCountSchoolSite(
+  id: string
+): LunchCountConfig['schoolSite'] | null {
+  const canonical = canonicalBuildingId(id);
+  return LUNCH_COUNT_SCHOOL_SITE_BY_CANONICAL[canonical] ?? null;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Fixes the white-screen crash (`Cannot read properties of undefined (reading 'map')`) that some teachers (e.g. `joel.mellor@orono.k12.mn.us`, `margo.mattei@orono.k12.mn.us`) hit when flipping the LunchCount widget to its settings panel.
- Root cause: the Dock's building-aware override wrote the raw building ID from `selectedBuildings` into the widget's `schoolSite` config. User profiles canonicalize those IDs to short form (`schumann`, `high`, ...), but `LunchCountConfig['schoolSite']` and `GRADE_OPTIONS` are keyed by the long-form legacy IDs (`schumann-elementary`, `orono-high-school`, ...). `isLunchCountBuilding`'s type predicate falsely narrowed the input to the long form, hiding the mismatch from TypeScript. `GRADE_OPTIONS[schoolSite]` then returned `undefined`, and the next `.map()` crashed the React tree.
- New `toLunchCountSchoolSite()` helper translates any recognized building ID (canonical short or legacy long) to a valid `LunchCountConfig['schoolSite']`. The Dock now uses it when seeding new widgets; `Settings.tsx` and `useNutrislice` normalize on read with a safe `schumann-elementary` fallback so already-corrupted widget configs recover without manual intervention. The misleading type predicate on `isLunchCountBuilding` was also dropped.

## Test plan

- [x] `pnpm exec vitest run components/widgets/LunchCount` — all 8 tests pass
- [x] `pnpm exec eslint` on the four touched files — clean
- [x] `pnpm exec prettier --check` on the four touched files — clean
- [x] `pnpm run type-check` — clean
- [ ] Manually verify: sign in as an affected user (or mock a widget with `schoolSite: 'schumann'`), flip the LunchCount widget to settings — panel renders, Grade Level buttons populate for Schumann, no console error.
- [ ] Add a new LunchCount widget from the Dock with a short-form building selected — stored config contains the long-form `schoolSite`.
- [ ] Nutrislice sync still works for both fresh widgets and legacy corrupted configs.

https://claude.ai/code/session_0129nmHNq2DfKCxs8K7HF2kq

---
_Generated by [Claude Code](https://claude.ai/code/session_0129nmHNq2DfKCxs8K7HF2kq)_