### PR TITLE
fix(quiz): recompute results aggregates after deleting a submission

### DIFF
--- a/components/widgets/QuizWidget/Widget.tsx
+++ b/components/widgets/QuizWidget/Widget.tsx
@@ -96,6 +96,19 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
   const [loadingQuizData, setLoadingQuizData] = useState(false);
   const [dataError, setDataError] = useState<string | null>(null);
 
+  // Bump a token whenever the user navigates INTO the results view so the
+  // QuizResults consumer remounts with fresh memos over the current live
+  // `responses` — guarantees aggregate stats recompute after a mid-view
+  // submission delete even if the upstream snapshot state lagged.
+  const [resultsEnterToken, setResultsEnterToken] = useState(0);
+  const [prevView, setPrevView] = useState(config.view);
+  if (config.view !== prevView) {
+    setPrevView(config.view);
+    if (config.view === 'results') {
+      setResultsEnterToken((n) => n + 1);
+    }
+  }
+
   // Editor modal state — ephemeral, not persisted to Firestore.
   const [editingQuiz, setEditingQuiz] = useState<QuizData | null>(null);
   const [editingMeta, setEditingMeta] = useState<QuizMetadata | null>(null);
@@ -535,6 +548,7 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
     // separately; config.resultsSessionId is reserved for future per-session history.
     return (
       <QuizResults
+        key={`${config.activeAssignmentId ?? 'none'}-${resultsEnterToken}`}
         quiz={loadedQuizData}
         responses={responses}
         config={config}


### PR DESCRIPTION
## Summary
- When a teacher deleted a submission from the Results → Students tab, the Overview (Class Average, Score Distribution, Finished count) and Questions (per-question accuracy) tabs did not reflect the deletion. Re-opening Results from the archive also showed stale stats.
- Fix: key `<QuizResults>` by `activeAssignmentId` + a re-entry token that bumps on each non-results → results transition. Entering Results remounts the consumer so every aggregate memo recomputes against the current live `responses`. Mid-view deletes still flow through the live snapshot listener without remounting, preserving `periodFilter`, `activeTab`, and scroll position.
- Implementation uses render-time state synchronization (CLAUDE.md "adjusting state while rendering" pattern) — no new `useEffect`.

## Test plan
- [ ] Create a quiz, assign it, and have 3+ test students submit.
- [ ] End the assignment from the live monitor.
- [ ] Open Results from the archive card → Overview → note "Finished" count and Class Average.
- [ ] Switch to Students → delete one submission → row disappears.
- [ ] Switch to Overview → Finished count and Class Average reflect the deletion.
- [ ] Delete a second submission from Students → list updates live (no remount flicker), `periodFilter` / active sub-tab / scroll preserved.
- [ ] Click "Back" → re-open Results → aggregate counts persist and match Firestore.
- [ ] `pnpm run type-check` and `pnpm run lint` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)