### PR TITLE
fix(plc): unbreak invite accept + add invitation email trigger

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -84,6 +84,11 @@ const InviteAcceptance = lazy(() =>
     default: module.InviteAcceptance,
   }))
 );
+const PlcInviteAcceptance = lazy(() =>
+  import('./components/auth/PlcInviteAcceptance').then((module) => ({
+    default: module.PlcInviteAcceptance,
+  }))
+);
 const DashboardView = lazy(() =>
   import('./components/layout/DashboardView').then((module) => ({
     default: module.DashboardView,
@@ -192,6 +197,7 @@ const App: React.FC = () => {
   const isActivityWallRoute =
     pathname === '/activity-wall' || pathname.startsWith('/activity-wall/');
   const isInviteRoute = pathname.startsWith('/invite/');
+  const isPlcInviteRoute = pathname.startsWith('/plc-invite/');
   const isStudentLoginRoute =
     pathname === '/student/login' || pathname.startsWith('/student/login/');
   const isMyAssignmentsRoute =
@@ -360,6 +366,23 @@ const App: React.FC = () => {
         <AuthProvider>
           <Suspense fallback={<FullPageLoader />}>
             <InviteAcceptance />
+          </Suspense>
+        </AuthProvider>
+        <DialogContainer />
+      </DialogProvider>
+    );
+  }
+
+  // PLC-invite landing route — separate from the org-invite route because
+  // PLC invites live in a different collection (`plc_invitations`) and are
+  // sent/accepted through `usePlcInvitations` rather than the callable
+  // claim function.
+  if (isPlcInviteRoute) {
+    return (
+      <DialogProvider>
+        <AuthProvider>
+          <Suspense fallback={<FullPageLoader />}>
+            <PlcInviteAcceptance />
           </Suspense>
         </AuthProvider>
         <DialogContainer />

--- a/components/auth/PlcInviteAcceptance.tsx
+++ b/components/auth/PlcInviteAcceptance.tsx
@@ -1,0 +1,449 @@
+import React from 'react';
+import {
+  Loader2,
+  LogIn,
+  CheckCircle2,
+  AlertCircle,
+  Users2,
+} from 'lucide-react';
+import { doc, getDoc } from 'firebase/firestore';
+import { APP_NAME } from '@/config/constants';
+import { db } from '@/config/firebase';
+import { useAuth } from '@/context/useAuth';
+import { usePlcInvitations } from '@/hooks/usePlcInvitations';
+import type { PlcInvitation } from '@/types';
+
+const INVITATIONS_COLLECTION = 'plc_invitations';
+
+/**
+ * Extract the invite id from the current URL.
+ *
+ * Strips the leading `/plc-invite/` segment, stops at a query string or
+ * trailing slash, and returns an empty string when the id is missing or
+ * blank.
+ */
+const extractInviteId = (): string => {
+  const pathname =
+    typeof window !== 'undefined' ? window.location.pathname : '';
+  const prefix = '/plc-invite/';
+  if (!pathname.startsWith(prefix)) return '';
+  const rest = pathname.slice(prefix.length);
+  const stopAt = rest.search(/[/?#]/);
+  const id = stopAt === -1 ? rest : rest.slice(0, stopAt);
+  return id.trim();
+};
+
+type LoadState =
+  | { kind: 'idle' }
+  | { kind: 'loading' }
+  | { kind: 'ready'; invite: PlcInvitation }
+  | { kind: 'not-found' }
+  | { kind: 'wrong-account'; expectedEmail: string }
+  | { kind: 'already-used'; status: 'accepted' | 'declined' }
+  | { kind: 'error'; message: string };
+
+type ActionState =
+  | { kind: 'idle' }
+  | { kind: 'accepting' }
+  | { kind: 'declining' }
+  | { kind: 'accepted' }
+  | { kind: 'declined' }
+  | { kind: 'action-error'; message: string };
+
+const FullPageSpinner: React.FC = () => (
+  <div className="h-screen w-screen flex items-center justify-center bg-slate-50">
+    <Loader2 className="w-12 h-12 text-brand-blue-primary animate-spin" />
+  </div>
+);
+
+const AuthShell: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+  <div className="relative h-screen w-screen flex items-center justify-center bg-slate-50 overflow-hidden font-sans">
+    <div className="absolute inset-0 bg-[radial-gradient(#e5e7eb_1px,transparent_1px)] [background-size:16px_16px] opacity-50" />
+    <div className="absolute top-1/4 -left-1/4 w-[500px] h-[500px] rounded-full blur-[100px] bg-brand-blue-primary/20" />
+    <div className="absolute -bottom-1/4 -right-1/4 w-[500px] h-[500px] bg-brand-red-primary/10 rounded-full blur-[100px]" />
+    <div className="relative z-10 bg-white/90 backdrop-blur-xl p-8 sm:p-10 rounded-3xl shadow-[0_8px_30px_rgb(0,0,0,0.04)] border border-slate-100/60 ring-1 ring-slate-900/5 max-w-md w-full mx-4">
+      {children}
+    </div>
+  </div>
+);
+
+const ErrorCard: React.FC<{
+  title: string;
+  message: string;
+  action?: React.ReactNode;
+}> = ({ title, message, action }) => (
+  <AuthShell>
+    <div className="flex flex-col items-center text-center">
+      <div className="w-14 h-14 rounded-2xl bg-brand-red-primary/10 flex items-center justify-center mb-5">
+        <AlertCircle className="w-7 h-7 text-brand-red-primary" />
+      </div>
+      <h1 className="text-2xl font-bold text-slate-800 tracking-tight mb-3">
+        {title}
+      </h1>
+      <p className="text-slate-600 mb-6 text-sm sm:text-base leading-relaxed">
+        {message}
+      </p>
+      {action}
+      <a
+        href="/"
+        className="mt-4 text-sm text-brand-blue-primary hover:text-brand-blue-dark font-medium"
+      >
+        Return to {APP_NAME}
+      </a>
+    </div>
+  </AuthShell>
+);
+
+const SignInPromptCard: React.FC<{ plcName?: string }> = ({ plcName }) => {
+  const { signInWithGoogle } = useAuth();
+  const [signingIn, setSigningIn] = React.useState(false);
+
+  const handleSignIn = async () => {
+    setSigningIn(true);
+    try {
+      await signInWithGoogle();
+    } catch (error) {
+      console.error('PLC invite sign-in failed:', error);
+      setSigningIn(false);
+    }
+  };
+
+  return (
+    <AuthShell>
+      <div className="flex flex-col items-center text-center">
+        <div className="w-14 h-14 rounded-2xl bg-brand-blue-primary/10 flex items-center justify-center mb-5">
+          <Users2 className="w-7 h-7 text-brand-blue-primary" />
+        </div>
+        <h1 className="text-2xl font-bold text-slate-800 tracking-tight mb-3">
+          You&rsquo;re invited to a PLC
+        </h1>
+        <p className="text-slate-600 mb-7 text-sm sm:text-base leading-relaxed">
+          {plcName
+            ? `Sign in to accept your invitation to "${plcName}" on ${APP_NAME}.`
+            : `Sign in to accept your invitation to ${APP_NAME}.`}
+        </p>
+        <button
+          onClick={handleSignIn}
+          disabled={signingIn}
+          className="group relative w-full bg-brand-blue-primary text-white py-4 rounded-2xl font-bold flex items-center justify-center gap-3 overflow-hidden shadow-lg shadow-brand-blue-primary/25 hover:shadow-brand-blue-primary/40 hover:bg-brand-blue-dark transition-all duration-200 active:scale-[0.98] disabled:opacity-70 disabled:active:scale-100 disabled:cursor-not-allowed"
+        >
+          {signingIn ? (
+            <Loader2 className="w-5 h-5 animate-spin relative z-10" />
+          ) : (
+            <span className="flex items-center gap-3 relative z-10">
+              <LogIn className="w-5 h-5 transition-transform group-hover:-translate-x-1" />
+              Sign in with Google
+            </span>
+          )}
+        </button>
+      </div>
+    </AuthShell>
+  );
+};
+
+const AcceptedCard: React.FC<{ plcName: string }> = ({ plcName }) => (
+  <AuthShell>
+    <div className="flex flex-col items-center text-center">
+      <div className="w-14 h-14 rounded-2xl bg-emerald-500/10 flex items-center justify-center mb-5">
+        <CheckCircle2 className="w-7 h-7 text-emerald-600" />
+      </div>
+      <h1 className="text-2xl font-bold text-slate-800 tracking-tight mb-3">
+        Welcome to {plcName}
+      </h1>
+      <p className="text-slate-600 mb-2 text-sm sm:text-base">
+        Redirecting you to {APP_NAME}…
+      </p>
+      <Loader2 className="w-5 h-5 text-brand-blue-primary animate-spin mt-2" />
+    </div>
+  </AuthShell>
+);
+
+const DeclinedCard: React.FC<{ plcName: string }> = ({ plcName }) => (
+  <AuthShell>
+    <div className="flex flex-col items-center text-center">
+      <div className="w-14 h-14 rounded-2xl bg-slate-200 flex items-center justify-center mb-5">
+        <Users2 className="w-7 h-7 text-slate-500" />
+      </div>
+      <h1 className="text-2xl font-bold text-slate-800 tracking-tight mb-3">
+        Invitation declined
+      </h1>
+      <p className="text-slate-600 mb-6 text-sm sm:text-base">
+        You&rsquo;ve declined the invitation to {plcName}. The lead can send a
+        new invite anytime.
+      </p>
+      <a
+        href="/"
+        className="text-sm text-brand-blue-primary hover:text-brand-blue-dark font-medium"
+      >
+        Return to {APP_NAME}
+      </a>
+    </div>
+  </AuthShell>
+);
+
+const AcceptPanel: React.FC<{
+  invite: PlcInvitation;
+  action: ActionState;
+  onAccept: () => void;
+  onDecline: () => void;
+}> = ({ invite, action, onAccept, onDecline }) => {
+  const busy = action.kind === 'accepting' || action.kind === 'declining';
+  return (
+    <AuthShell>
+      <div className="flex flex-col items-center text-center">
+        <div className="w-14 h-14 rounded-2xl bg-brand-blue-primary/10 flex items-center justify-center mb-5">
+          <Users2 className="w-7 h-7 text-brand-blue-primary" />
+        </div>
+        <h1 className="text-2xl font-bold text-slate-800 tracking-tight mb-2">
+          Join &ldquo;{invite.plcName}&rdquo;
+        </h1>
+        <p className="text-slate-600 mb-7 text-sm sm:text-base leading-relaxed">
+          <span className="font-semibold">{invite.invitedByName}</span> has
+          invited you to join this Professional Learning Community on {APP_NAME}
+          .
+        </p>
+        <div className="w-full flex flex-col gap-3">
+          <button
+            onClick={onAccept}
+            disabled={busy}
+            className="group relative w-full bg-brand-blue-primary text-white py-4 rounded-2xl font-bold flex items-center justify-center gap-3 shadow-lg shadow-brand-blue-primary/25 hover:shadow-brand-blue-primary/40 hover:bg-brand-blue-dark transition-all duration-200 active:scale-[0.98] disabled:opacity-70 disabled:active:scale-100 disabled:cursor-not-allowed"
+          >
+            {action.kind === 'accepting' ? (
+              <Loader2 className="w-5 h-5 animate-spin" />
+            ) : (
+              'Accept invitation'
+            )}
+          </button>
+          <button
+            onClick={onDecline}
+            disabled={busy}
+            className="w-full bg-white text-slate-700 py-4 rounded-2xl font-semibold border border-slate-200 hover:bg-slate-50 transition-colors active:scale-[0.98] disabled:opacity-70 disabled:active:scale-100 disabled:cursor-not-allowed"
+          >
+            {action.kind === 'declining' ? (
+              <Loader2 className="w-5 h-5 animate-spin mx-auto" />
+            ) : (
+              'Decline'
+            )}
+          </button>
+        </div>
+        {action.kind === 'action-error' && (
+          <p className="mt-4 text-sm text-brand-red-primary" role="alert">
+            {action.message}
+          </p>
+        )}
+      </div>
+    </AuthShell>
+  );
+};
+
+export const PlcInviteAcceptance: React.FC = () => {
+  const [inviteId] = React.useState(() => extractInviteId());
+  const { user, loading, signOut } = useAuth();
+  const { acceptInvite, declineInvite } = usePlcInvitations();
+  const [load, setLoad] = React.useState<LoadState>({ kind: 'idle' });
+  const [action, setAction] = React.useState<ActionState>({ kind: 'idle' });
+
+  const myEmailLower = (user?.email ?? '').toLowerCase();
+
+  // Read the invite doc once we have an authenticated user. The rules only
+  // allow the invitee (by email) or inviter (by uid) to read it, so we need
+  // auth before reading. Bad reads map to friendly error states rather than
+  // leaking a raw PERMISSION_DENIED.
+  React.useEffect(() => {
+    if (!inviteId) return;
+    if (loading) return;
+    if (!user) return;
+    if (load.kind !== 'idle') return;
+
+    setLoad({ kind: 'loading' });
+    const run = async () => {
+      try {
+        const snap = await getDoc(doc(db, INVITATIONS_COLLECTION, inviteId));
+        if (!snap.exists()) {
+          setLoad({ kind: 'not-found' });
+          return;
+        }
+        const data = snap.data();
+        const expectedEmail =
+          typeof data.inviteeEmailLower === 'string'
+            ? data.inviteeEmailLower
+            : '';
+        if (expectedEmail && expectedEmail !== myEmailLower) {
+          setLoad({ kind: 'wrong-account', expectedEmail });
+          return;
+        }
+        const status = typeof data.status === 'string' ? data.status : '';
+        if (status === 'accepted' || status === 'declined') {
+          setLoad({ kind: 'already-used', status });
+          return;
+        }
+        if (status !== 'pending') {
+          setLoad({ kind: 'not-found' });
+          return;
+        }
+        const invite: PlcInvitation = {
+          id: snap.id,
+          plcId: String(data.plcId ?? ''),
+          plcName: String(data.plcName ?? 'a Professional Learning Community'),
+          inviteeEmailLower: expectedEmail,
+          invitedByUid: String(data.invitedByUid ?? ''),
+          invitedByName: String(data.invitedByName ?? 'A teacher'),
+          invitedAt:
+            typeof data.invitedAt === 'number' ? data.invitedAt : Date.now(),
+          status: 'pending',
+        };
+        setLoad({ kind: 'ready', invite });
+      } catch (error) {
+        console.error('Failed to load PLC invite:', error);
+        const code = (error as { code?: string } | null)?.code;
+        if (code === 'permission-denied') {
+          // Signed in with an account the rules won't let read this doc —
+          // most commonly, a different email than the invitee.
+          setLoad({ kind: 'wrong-account', expectedEmail: '' });
+          return;
+        }
+        setLoad({
+          kind: 'error',
+          message: error instanceof Error ? error.message : 'Unexpected error',
+        });
+      }
+    };
+
+    void run();
+  }, [inviteId, loading, user, myEmailLower, load.kind]);
+
+  const handleAccept = async () => {
+    if (load.kind !== 'ready') return;
+    setAction({ kind: 'accepting' });
+    try {
+      await acceptInvite(load.invite);
+      setAction({ kind: 'accepted' });
+      window.setTimeout(() => {
+        window.location.href = '/';
+      }, 1000);
+    } catch (error) {
+      console.error('Failed to accept PLC invite:', error);
+      setAction({
+        kind: 'action-error',
+        message:
+          error instanceof Error
+            ? error.message
+            : 'Could not accept this invitation. Try again in a moment.',
+      });
+    }
+  };
+
+  const handleDecline = async () => {
+    if (load.kind !== 'ready') return;
+    setAction({ kind: 'declining' });
+    try {
+      await declineInvite(load.invite);
+      setAction({ kind: 'declined' });
+    } catch (error) {
+      console.error('Failed to decline PLC invite:', error);
+      setAction({
+        kind: 'action-error',
+        message:
+          error instanceof Error
+            ? error.message
+            : 'Could not decline this invitation. Try again in a moment.',
+      });
+    }
+  };
+
+  if (!inviteId) {
+    return (
+      <ErrorCard
+        title="Invalid invite link"
+        message="This invitation link is missing its id. Ask the teacher who invited you for a new link."
+      />
+    );
+  }
+
+  if (loading) {
+    return <FullPageSpinner />;
+  }
+
+  if (!user) {
+    return <SignInPromptCard />;
+  }
+
+  if (load.kind === 'idle' || load.kind === 'loading') {
+    return <FullPageSpinner />;
+  }
+
+  if (load.kind === 'not-found') {
+    return (
+      <ErrorCard
+        title="Invitation not found"
+        message="This invitation is no longer available. It may have been revoked by the lead. Ask them for a new link."
+      />
+    );
+  }
+
+  if (load.kind === 'already-used') {
+    if (load.status === 'accepted') {
+      return (
+        <ErrorCard
+          title="Already accepted"
+          message={`You've already accepted this invitation. Head to ${APP_NAME} to find your PLC in the sidebar.`}
+        />
+      );
+    }
+    return (
+      <ErrorCard
+        title="Invitation declined"
+        message="This invitation was declined. Ask the lead to send a new one if you'd like to reconsider."
+      />
+    );
+  }
+
+  if (load.kind === 'wrong-account') {
+    const expected = load.expectedEmail
+      ? ` to ${load.expectedEmail}`
+      : ' to a different account';
+    return (
+      <ErrorCard
+        title="Wrong account"
+        message={`This invitation was sent${expected}. Sign out and sign in with the invited email.`}
+        action={
+          <button
+            onClick={() => {
+              void signOut();
+            }}
+            className="w-full bg-brand-blue-primary text-white py-3 rounded-2xl font-semibold hover:bg-brand-blue-dark transition-colors"
+          >
+            Sign out
+          </button>
+        }
+      />
+    );
+  }
+
+  if (load.kind === 'error') {
+    return <ErrorCard title="Something went wrong" message={load.message} />;
+  }
+
+  // load.kind === 'ready'
+  if (action.kind === 'accepted') {
+    return <AcceptedCard plcName={load.invite.plcName} />;
+  }
+  if (action.kind === 'declined') {
+    return <DeclinedCard plcName={load.invite.plcName} />;
+  }
+
+  return (
+    <AcceptPanel
+      invite={load.invite}
+      action={action}
+      onAccept={() => {
+        void handleAccept();
+      }}
+      onDecline={() => {
+        void handleDecline();
+      }}
+    />
+  );
+};
+
+export default PlcInviteAcceptance;

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -25,6 +25,7 @@ export { organizationMemberCounters } from './organizationMemberCounters';
 export { organizationBuildingCounters } from './organizationBuildingCounters';
 export { resetOrganizationUserPassword } from './organizationResetPassword';
 export { getOrgUserActivity } from './organizationUserActivity';
+export { plcInvitationEmail } from './plcInviteEmails';
 
 setGlobalOptions({ region: 'us-central1' });
 

--- a/functions/src/plcInviteEmails.test.ts
+++ b/functions/src/plcInviteEmails.test.ts
@@ -1,0 +1,424 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+type TriggerHandler = (event: unknown) => Promise<void>;
+
+const triggerHolder = vi.hoisted(() => ({
+  handler: null as TriggerHandler | null,
+}));
+
+vi.mock('firebase-functions/v2/firestore', () => ({
+  onDocumentWritten: (_path: string, handler: TriggerHandler) => {
+    triggerHolder.handler = handler;
+    return handler;
+  },
+}));
+
+const loggerMock = vi.hoisted(() => ({
+  warn: vi.fn(),
+  info: vi.fn(),
+  error: vi.fn(),
+}));
+
+vi.mock('firebase-functions/logger', () => loggerMock);
+
+// Per-test shared state for the firebase-admin mock. Each test seeds the
+// data it needs and inspects the recorded mail-collection write.
+const adminMock = vi.hoisted(() => ({
+  configDoc: null as Record<string, unknown> | null,
+  plcDocs: new Map<string, Record<string, unknown>>(),
+  mailSets: [] as Array<{ id: string; payload: Record<string, unknown> }>,
+  mailSetFailure: null as Error | null,
+}));
+
+vi.mock('firebase-admin', () => {
+  const firestoreFn = vi.fn(() => ({
+    collection: vi.fn((name: string) => {
+      if (name === 'global_permissions') {
+        return {
+          doc: vi.fn(() => ({
+            get: () =>
+              Promise.resolve({
+                exists: adminMock.configDoc !== null,
+                data: () => adminMock.configDoc ?? {},
+              }),
+          })),
+        };
+      }
+      if (name === 'plcs') {
+        return {
+          doc: vi.fn((id: string) => ({
+            get: () => {
+              const data = adminMock.plcDocs.get(id);
+              return Promise.resolve({
+                exists: data !== undefined,
+                data: () => data ?? {},
+              });
+            },
+          })),
+        };
+      }
+      if (name === 'mail') {
+        return {
+          doc: vi.fn((id: string) => ({
+            set: (payload: Record<string, unknown>) => {
+              adminMock.mailSets.push({ id, payload });
+              if (adminMock.mailSetFailure) {
+                return Promise.reject(adminMock.mailSetFailure);
+              }
+              return Promise.resolve();
+            },
+          })),
+        };
+      }
+      throw new Error(`Unexpected collection: ${name}`);
+    }),
+  }));
+
+  return {
+    apps: [{ name: '[DEFAULT]' }],
+    initializeApp: vi.fn(),
+    firestore: firestoreFn,
+  };
+});
+
+// Import AFTER mocks so the module's onDocumentWritten registration lands in
+// our stub and admin.firestore() resolves to the mock above.
+import {
+  parseInviteDoc,
+  shouldSendEmail,
+  buildPlcInvitationEmail,
+  buildPlcAcceptUrl,
+  escapeHtml,
+  CLAIM_URL_ORIGIN,
+  type PlcInvitationDoc,
+} from './plcInviteEmails';
+// Importing the module registers the trigger handler via the mocked
+// onDocumentWritten factory above — side-effect import.
+import './plcInviteEmails';
+
+const INVITE_ID = 'plc-1_invitee@example.com';
+
+const pendingInvite = (
+  overrides: Partial<PlcInvitationDoc> = {}
+): PlcInvitationDoc => ({
+  plcId: 'plc-1',
+  plcName: 'Grade 3 Math',
+  inviteeEmailLower: 'invitee@example.com',
+  invitedByUid: 'lead-uid',
+  invitedByName: 'Lead Teacher',
+  invitedAt: 1_700_000_000_000,
+  status: 'pending',
+  ...overrides,
+});
+
+function makeEvent(opts: {
+  beforeExists: boolean;
+  beforeData?: PlcInvitationDoc | Record<string, unknown>;
+  afterExists: boolean;
+  afterData?: PlcInvitationDoc | Record<string, unknown>;
+}) {
+  return {
+    params: { inviteId: INVITE_ID },
+    data: {
+      before: {
+        exists: opts.beforeExists,
+        data: () => opts.beforeData ?? {},
+      },
+      after: {
+        exists: opts.afterExists,
+        data: () => opts.afterData ?? {},
+      },
+    },
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  adminMock.configDoc = { enabled: true };
+  adminMock.plcDocs = new Map([
+    [
+      'plc-1',
+      { leadUid: 'lead-uid', memberUids: ['lead-uid'], name: 'Grade 3 Math' },
+    ],
+  ]);
+  adminMock.mailSets = [];
+  adminMock.mailSetFailure = null;
+});
+
+// ---------------------------------------------------------------------------
+// Pure helpers
+// ---------------------------------------------------------------------------
+
+describe('parseInviteDoc', () => {
+  it('returns the parsed doc for valid pending input', () => {
+    const parsed = parseInviteDoc(pendingInvite());
+    expect(parsed).not.toBeNull();
+    expect(parsed?.plcId).toBe('plc-1');
+    expect(parsed?.status).toBe('pending');
+  });
+
+  it('returns null for missing required fields', () => {
+    const { plcId: _plcId, ...rest } = pendingInvite();
+    void _plcId;
+    expect(parseInviteDoc(rest)).toBeNull();
+  });
+
+  it('returns null for an unknown status string', () => {
+    expect(parseInviteDoc({ ...pendingInvite(), status: 'bogus' })).toBeNull();
+  });
+
+  it('carries respondedAt when present', () => {
+    const parsed = parseInviteDoc({
+      ...pendingInvite({ status: 'accepted' }),
+      respondedAt: 123,
+    });
+    expect(parsed?.respondedAt).toBe(123);
+  });
+});
+
+describe('shouldSendEmail', () => {
+  it('sends on fresh create (pending)', () => {
+    expect(shouldSendEmail(null, pendingInvite())).toBe(true);
+  });
+
+  it('sends on re-send (pending -> pending with new invitedAt)', () => {
+    expect(
+      shouldSendEmail(
+        pendingInvite({ invitedAt: 1 }),
+        pendingInvite({ invitedAt: 2 })
+      )
+    ).toBe(true);
+  });
+
+  it('skips no-op writes (pending -> pending with same invitedAt)', () => {
+    expect(shouldSendEmail(pendingInvite(), pendingInvite())).toBe(false);
+  });
+
+  it('skips terminal transitions (pending -> accepted/declined)', () => {
+    expect(
+      shouldSendEmail(pendingInvite(), pendingInvite({ status: 'accepted' }))
+    ).toBe(false);
+    expect(
+      shouldSendEmail(pendingInvite(), pendingInvite({ status: 'declined' }))
+    ).toBe(false);
+  });
+
+  it('skips deletes (no post-state)', () => {
+    expect(shouldSendEmail(pendingInvite(), null)).toBe(false);
+  });
+});
+
+describe('buildPlcAcceptUrl', () => {
+  it('points at the dedicated landing page', () => {
+    expect(buildPlcAcceptUrl(INVITE_ID)).toBe(
+      `${CLAIM_URL_ORIGIN}/plc-invite/${INVITE_ID}`
+    );
+  });
+});
+
+describe('escapeHtml', () => {
+  it('escapes HTML-significant characters', () => {
+    expect(escapeHtml('<b>"x\' & y</b>')).toBe(
+      '&lt;b&gt;&quot;x&#39; &amp; y&lt;/b&gt;'
+    );
+  });
+});
+
+describe('buildPlcInvitationEmail', () => {
+  it('uses plc name and inviter in the subject and body', () => {
+    const { subject, text, html } = buildPlcInvitationEmail({
+      plcName: 'Grade 3 Math',
+      invitedByName: 'Ms. Rivers',
+      acceptUrl: 'https://spartboard.web.app/plc-invite/abc',
+    });
+    expect(subject).toContain('Ms. Rivers');
+    expect(subject).toContain('Grade 3 Math');
+    expect(text).toContain('https://spartboard.web.app/plc-invite/abc');
+    expect(html).toContain('Ms. Rivers');
+    expect(html).toContain('Grade 3 Math');
+    expect(html).toContain('https://spartboard.web.app/plc-invite/abc');
+  });
+
+  it('escapes injected HTML in the plc name and inviter', () => {
+    const { html } = buildPlcInvitationEmail({
+      plcName: '<script>alert(1)</script>',
+      invitedByName: 'Evil " Name',
+      acceptUrl: 'https://spartboard.web.app/plc-invite/x',
+    });
+    expect(html).not.toContain('<script>alert(1)</script>');
+    expect(html).toContain('&lt;script&gt;alert(1)&lt;/script&gt;');
+    expect(html).toContain('Evil &quot; Name');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Trigger
+// ---------------------------------------------------------------------------
+
+describe('plcInvitationEmail trigger', () => {
+  const runTrigger = async (event: ReturnType<typeof makeEvent>) => {
+    if (!triggerHolder.handler) {
+      throw new Error('Trigger handler not registered');
+    }
+    await triggerHolder.handler(event);
+  };
+
+  it('queues a mail doc on fresh create (pending)', async () => {
+    await runTrigger(
+      makeEvent({
+        beforeExists: false,
+        afterExists: true,
+        afterData: pendingInvite(),
+      })
+    );
+
+    expect(adminMock.mailSets).toHaveLength(1);
+    const [entry] = adminMock.mailSets;
+    expect(entry.id).toBe(INVITE_ID);
+    expect(entry.payload.to).toEqual(['invitee@example.com']);
+    const message = entry.payload.message as {
+      subject: string;
+      text: string;
+      html: string;
+    };
+    expect(message.subject).toContain('Grade 3 Math');
+    expect(message.text).toContain('/plc-invite/' + INVITE_ID);
+  });
+
+  it('re-queues on re-send (pending -> pending with new invitedAt)', async () => {
+    await runTrigger(
+      makeEvent({
+        beforeExists: true,
+        beforeData: pendingInvite({ invitedAt: 1 }),
+        afterExists: true,
+        afterData: pendingInvite({ invitedAt: 2 }),
+      })
+    );
+    expect(adminMock.mailSets).toHaveLength(1);
+  });
+
+  it('skips on accept transition', async () => {
+    await runTrigger(
+      makeEvent({
+        beforeExists: true,
+        beforeData: pendingInvite(),
+        afterExists: true,
+        afterData: pendingInvite({ status: 'accepted' }),
+      })
+    );
+    expect(adminMock.mailSets).toHaveLength(0);
+  });
+
+  it('skips on decline transition', async () => {
+    await runTrigger(
+      makeEvent({
+        beforeExists: true,
+        beforeData: pendingInvite(),
+        afterExists: true,
+        afterData: pendingInvite({ status: 'declined' }),
+      })
+    );
+    expect(adminMock.mailSets).toHaveLength(0);
+  });
+
+  it('skips on delete', async () => {
+    await runTrigger(
+      makeEvent({
+        beforeExists: true,
+        beforeData: pendingInvite(),
+        afterExists: false,
+      })
+    );
+    expect(adminMock.mailSets).toHaveLength(0);
+  });
+
+  it('skips on no-op writes (same invitedAt)', async () => {
+    await runTrigger(
+      makeEvent({
+        beforeExists: true,
+        beforeData: pendingInvite(),
+        afterExists: true,
+        afterData: pendingInvite(),
+      })
+    );
+    expect(adminMock.mailSets).toHaveLength(0);
+  });
+
+  it('skips when the kill switch is off (config doc enabled=false)', async () => {
+    adminMock.configDoc = { enabled: false };
+    await runTrigger(
+      makeEvent({
+        beforeExists: false,
+        afterExists: true,
+        afterData: pendingInvite(),
+      })
+    );
+    expect(adminMock.mailSets).toHaveLength(0);
+  });
+
+  it('skips when the kill switch doc is missing entirely', async () => {
+    adminMock.configDoc = null;
+    await runTrigger(
+      makeEvent({
+        beforeExists: false,
+        afterExists: true,
+        afterData: pendingInvite(),
+      })
+    );
+    expect(adminMock.mailSets).toHaveLength(0);
+  });
+
+  it('skips + logs when the parent PLC is missing', async () => {
+    adminMock.plcDocs = new Map();
+    await runTrigger(
+      makeEvent({
+        beforeExists: false,
+        afterExists: true,
+        afterData: pendingInvite(),
+      })
+    );
+    expect(adminMock.mailSets).toHaveLength(0);
+    expect(loggerMock.warn).toHaveBeenCalledWith(
+      'plcInvitationEmail: parent PLC missing — skipping',
+      expect.objectContaining({ inviteId: INVITE_ID })
+    );
+  });
+
+  it('applies from / replyTo overrides from the config doc', async () => {
+    adminMock.configDoc = {
+      enabled: true,
+      from: 'SpartBoard <noreply@spartboard.app>',
+      replyTo: 'support@spartboard.app',
+    };
+    await runTrigger(
+      makeEvent({
+        beforeExists: false,
+        afterExists: true,
+        afterData: pendingInvite(),
+      })
+    );
+    expect(adminMock.mailSets[0].payload.from).toBe(
+      'SpartBoard <noreply@spartboard.app>'
+    );
+    expect(adminMock.mailSets[0].payload.replyTo).toBe(
+      'support@spartboard.app'
+    );
+  });
+
+  it('swallows mail-write failures (does not throw, so Firestore will not retry)', async () => {
+    adminMock.mailSetFailure = new Error('mail backend down');
+    await expect(
+      runTrigger(
+        makeEvent({
+          beforeExists: false,
+          afterExists: true,
+          afterData: pendingInvite(),
+        })
+      )
+    ).resolves.not.toThrow();
+    expect(loggerMock.error).toHaveBeenCalledWith(
+      'plcInvitationEmail: failed to queue mail',
+      expect.objectContaining({ inviteId: INVITE_ID })
+    );
+  });
+});

--- a/functions/src/plcInviteEmails.ts
+++ b/functions/src/plcInviteEmails.ts
@@ -1,0 +1,326 @@
+/**
+ * PLC invitation email trigger.
+ *
+ * Fires on any write to `/plc_invitations/{inviteId}` and queues a
+ * transactional email via the `firestore-send-email` extension by writing
+ * to `/mail/{inviteId}`. Handles creates AND re-sends (the client overwrites
+ * the same deterministic doc id `${plcId}_${emailLower}` when an admin
+ * re-invites the same email).
+ *
+ * Gate: `/global_permissions/invite-emails.enabled` — same kill switch the
+ * organization-invite path uses. When disabled, the invite doc still lands
+ * (the sidebar UI keeps working for the invitee), but no email goes out.
+ *
+ * Security: `/mail/*` writes are denied to clients in `firestore.rules`; the
+ * Admin SDK inside this function is the only path that can create these docs,
+ * which is why the extension is safe to point at a user-writable collection.
+ *
+ * Shape of the email body is mirrored from `organizationInvites.ts`
+ * (`buildInvitationEmail`, `escapeHtml`, `MailDoc`) rather than imported,
+ * to keep the two invite pipelines independent — each can evolve its own
+ * template without one breaking the other.
+ */
+
+import { onDocumentWritten } from 'firebase-functions/v2/firestore';
+import * as logger from 'firebase-functions/logger';
+import * as admin from 'firebase-admin';
+
+if (!admin.apps.length) {
+  admin.initializeApp();
+}
+
+// ---------------------------------------------------------------------------
+// Types (shape matches types.ts PlcInvitation — kept local because the
+// functions package doesn't share a tsconfig with the root.)
+// ---------------------------------------------------------------------------
+
+export type PlcInviteStatus = 'pending' | 'accepted' | 'declined';
+
+export interface PlcInvitationDoc {
+  plcId: string;
+  plcName: string;
+  inviteeEmailLower: string;
+  invitedByUid: string;
+  invitedByName: string;
+  invitedAt: number;
+  status: PlcInviteStatus;
+  respondedAt?: number;
+}
+
+export interface InviteEmailConfig {
+  enabled: boolean;
+  from?: string;
+  replyTo?: string;
+}
+
+export interface MailDoc {
+  to: string[];
+  from?: string;
+  replyTo?: string;
+  message: {
+    subject: string;
+    text: string;
+    html: string;
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/**
+ * Prod claim URL origin. Hardcoded to match `organizationInvites.ts` — a
+ * future refactor can hoist this into a shared config if we need per-env
+ * origins.
+ */
+export const CLAIM_URL_ORIGIN = 'https://spartboard.web.app';
+
+// ---------------------------------------------------------------------------
+// Pure helpers — exported for test coverage
+// ---------------------------------------------------------------------------
+
+export function escapeHtml(raw: string): string {
+  return raw
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+/** Builds the user-facing accept URL for a given invite id. */
+export function buildPlcAcceptUrl(inviteId: string): string {
+  return `${CLAIM_URL_ORIGIN}/plc-invite/${inviteId}`;
+}
+
+/**
+ * Validates the parsed invite doc. Returns null for shape-mismatched data so
+ * the trigger can skip without throwing (throws trigger Firestore retries,
+ * which would keep re-queuing the same broken mail).
+ */
+export function parseInviteDoc(raw: unknown): PlcInvitationDoc | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const data = raw as Record<string, unknown>;
+  if (
+    typeof data.plcId !== 'string' ||
+    typeof data.plcName !== 'string' ||
+    typeof data.inviteeEmailLower !== 'string' ||
+    typeof data.invitedByUid !== 'string' ||
+    typeof data.invitedByName !== 'string' ||
+    typeof data.invitedAt !== 'number'
+  ) {
+    return null;
+  }
+  const status = data.status;
+  if (status !== 'pending' && status !== 'accepted' && status !== 'declined') {
+    return null;
+  }
+  const doc: PlcInvitationDoc = {
+    plcId: data.plcId,
+    plcName: data.plcName,
+    inviteeEmailLower: data.inviteeEmailLower,
+    invitedByUid: data.invitedByUid,
+    invitedByName: data.invitedByName,
+    invitedAt: data.invitedAt,
+    status,
+  };
+  if (typeof data.respondedAt === 'number') {
+    doc.respondedAt = data.respondedAt;
+  }
+  return doc;
+}
+
+/**
+ * Decides whether the trigger should queue an email for this write.
+ *
+ * Queue when the post-state is a pending invite AND either:
+ *   - the doc didn't exist before (fresh invite), OR
+ *   - the previous `invitedAt` differs (re-send: same deterministic id with
+ *     a new timestamp stamp).
+ *
+ * Skip for:
+ *   - deletes (no post-state)
+ *   - accept/decline transitions (post-state status != 'pending')
+ *   - no-op writes (pending -> pending with the same invitedAt)
+ *   - malformed docs
+ */
+export function shouldSendEmail(
+  before: PlcInvitationDoc | null,
+  after: PlcInvitationDoc | null
+): boolean {
+  if (!after) return false;
+  if (after.status !== 'pending') return false;
+  if (!before) return true;
+  if (before.status !== 'pending') return true;
+  return before.invitedAt !== after.invitedAt;
+}
+
+export function buildPlcInvitationEmail(opts: {
+  plcName: string;
+  invitedByName: string;
+  acceptUrl: string;
+}): { subject: string; text: string; html: string } {
+  const { plcName, invitedByName, acceptUrl } = opts;
+
+  const subject = `${invitedByName} invited you to join "${plcName}" on SpartBoard`;
+
+  const text = [
+    `${invitedByName} has invited you to join the Professional Learning Community "${plcName}" on SpartBoard.`,
+    '',
+    'Accept your invitation:',
+    acceptUrl,
+    '',
+    "If you weren't expecting this email, you can safely ignore it.",
+  ].join('\n');
+
+  const safePlc = escapeHtml(plcName);
+  const safeInviter = escapeHtml(invitedByName);
+  const safeUrl = escapeHtml(acceptUrl);
+
+  const html = `<!doctype html>
+<html>
+  <body style="margin:0;padding:0;background:#f1f5f9;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;color:#0f172a;">
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background:#f1f5f9;padding:24px 0;">
+      <tr><td align="center">
+        <table role="presentation" width="560" cellpadding="0" cellspacing="0" style="max-width:560px;background:#ffffff;border-radius:12px;padding:32px;">
+          <tr><td style="padding:0 0 16px 0;">
+            <div style="font-size:20px;font-weight:600;color:#1d2a5d;">You're invited to a PLC</div>
+          </td></tr>
+          <tr><td style="padding:0 0 16px 0;color:#334155;font-size:15px;line-height:1.5;">
+            <strong>${safeInviter}</strong> has invited you to join the Professional Learning Community <strong>${safePlc}</strong> on SpartBoard.
+          </td></tr>
+          <tr><td style="padding:16px 0;">
+            <a href="${safeUrl}" style="display:inline-block;background:#2d3f89;color:#ffffff;text-decoration:none;padding:12px 20px;border-radius:8px;font-weight:600;font-size:15px;">Accept invitation</a>
+          </td></tr>
+          <tr><td style="padding:16px 0 0 0;color:#64748b;font-size:13px;line-height:1.5;">
+            If the button doesn't work, paste this link into your browser:<br>
+            <span style="word-break:break-all;color:#2d3f89;">${safeUrl}</span>
+          </td></tr>
+          <tr><td style="padding:24px 0 0 0;border-top:1px solid #e2e8f0;color:#94a3b8;font-size:12px;line-height:1.5;">
+            If you weren't expecting this email, you can safely ignore it.
+          </td></tr>
+        </table>
+      </td></tr>
+    </table>
+  </body>
+</html>`;
+
+  return { subject, text, html };
+}
+
+// ---------------------------------------------------------------------------
+// Firestore helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Reads the invite-email kill switch from `/global_permissions/invite-emails`.
+ * Missing doc / missing `enabled` field defaults to `false` so email never
+ * sends accidentally — operator has to opt-in explicitly once the extension
+ * is installed and a smoke-test send has landed.
+ */
+export async function loadInviteEmailConfig(
+  db: admin.firestore.Firestore
+): Promise<InviteEmailConfig> {
+  const snap = await db
+    .collection('global_permissions')
+    .doc('invite-emails')
+    .get();
+  if (!snap.exists) return { enabled: false };
+  const data = snap.data() ?? {};
+  return {
+    enabled: data.enabled === true,
+    from: typeof data.from === 'string' ? data.from : undefined,
+    replyTo: typeof data.replyTo === 'string' ? data.replyTo : undefined,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Trigger
+// ---------------------------------------------------------------------------
+
+export const plcInvitationEmail = onDocumentWritten(
+  'plc_invitations/{inviteId}',
+  async (event) => {
+    const { inviteId } = event.params;
+    const change = event.data;
+    if (!change) {
+      logger.warn('plcInvitationEmail: received event without data', {
+        inviteId,
+      });
+      return;
+    }
+
+    const before = change.before.exists
+      ? parseInviteDoc(change.before.data())
+      : null;
+    const after = change.after.exists
+      ? parseInviteDoc(change.after.data())
+      : null;
+
+    if (!shouldSendEmail(before, after)) {
+      logger.info('plcInvitationEmail: skipping — not a fresh pending invite', {
+        inviteId,
+        beforeStatus: before?.status ?? null,
+        afterStatus: after?.status ?? null,
+      });
+      return;
+    }
+
+    // Narrowed by shouldSendEmail: `after` is non-null and pending.
+    const invite = after as PlcInvitationDoc;
+
+    const db = admin.firestore();
+    const emailConfig = await loadInviteEmailConfig(db);
+    if (!emailConfig.enabled) {
+      logger.info(
+        'plcInvitationEmail: kill switch off — skipping email queue',
+        { inviteId }
+      );
+      return;
+    }
+
+    // Parent-PLC sanity check. The invite doc's plcName is denormalized so
+    // the email renders fine without the parent doc, but if the PLC has
+    // been deleted we shouldn't broadcast an invite for a ghost community.
+    const plcSnap = await db.collection('plcs').doc(invite.plcId).get();
+    if (!plcSnap.exists) {
+      logger.warn('plcInvitationEmail: parent PLC missing — skipping', {
+        inviteId,
+        plcId: invite.plcId,
+      });
+      return;
+    }
+
+    const body = buildPlcInvitationEmail({
+      plcName: invite.plcName,
+      invitedByName: invite.invitedByName,
+      acceptUrl: buildPlcAcceptUrl(inviteId),
+    });
+    const mailDoc: MailDoc = {
+      to: [invite.inviteeEmailLower],
+      message: body,
+    };
+    if (emailConfig.from) mailDoc.from = emailConfig.from;
+    if (emailConfig.replyTo) mailDoc.replyTo = emailConfig.replyTo;
+
+    // Mail doc id = invite id. Re-sends overwrite the same doc so the
+    // extension re-delivers cleanly and the `/mail/{id}` record stays
+    // traceable back to its source invite.
+    try {
+      await db.collection('mail').doc(inviteId).set(mailDoc);
+      logger.info('plcInvitationEmail: queued mail', {
+        inviteId,
+        plcId: invite.plcId,
+        to: invite.inviteeEmailLower,
+      });
+    } catch (err) {
+      // Log and swallow. A thrown trigger is retried by Firestore, which
+      // could amplify a transient mail-write failure into a retry loop.
+      // Operators watch the logs for these errors.
+      logger.error('plcInvitationEmail: failed to queue mail', {
+        inviteId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+);

--- a/hooks/usePlcInvitations.ts
+++ b/hooks/usePlcInvitations.ts
@@ -8,6 +8,8 @@ import {
   setDoc,
   deleteDoc,
   runTransaction,
+  arrayUnion,
+  updateDoc,
 } from 'firebase/firestore';
 import { db, isAuthBypass } from '@/config/firebase';
 import { useAuth } from '@/context/useAuth';
@@ -219,35 +221,40 @@ export const usePlcInvitations = (): UsePlcInvitationsResult => {
       }
       const inviteRef = doc(db, INVITATIONS_COLLECTION, invite.id);
       const plcRef = doc(db, PLCS_COLLECTION, invite.plcId);
-      await runTransaction(db, async (tx) => {
-        const plcSnap = await tx.get(plcRef);
-        if (!plcSnap.exists()) {
-          throw new Error('PLC no longer exists');
-        }
-        const plcData = plcSnap.data();
-        const memberUids = (plcData.memberUids ?? []) as string[];
-        if (memberUids.includes(user.uid)) {
-          // Already a member — just close out the invite.
+      // Blind write: the accept-flow rule (isAcceptingPlcInvite) validates
+      // the update without requiring the invitee to read the PLC doc first —
+      // which they can't, because non-members can't read `/plcs/{plcId}`.
+      // `arrayUnion` satisfies the rule's size-delta check and dotted-path
+      // `memberEmails.<uid>` keeps the diff scoped to a single key.
+      try {
+        await runTransaction(db, (tx) => {
+          tx.update(plcRef, {
+            memberUids: arrayUnion(user.uid),
+            [`memberEmails.${user.uid}`]: myEmailLower,
+            updatedAt: Date.now(),
+          });
           tx.update(inviteRef, {
+            status: 'accepted',
+            respondedAt: Date.now(),
+          });
+          return Promise.resolve();
+        });
+      } catch (err) {
+        // Edge case: the lead added this teacher to memberUids manually
+        // between send and accept. The rule's `newMembers.size() ==
+        // oldMembers.size() + 1` check then refuses the PLC update (arrayUnion
+        // becomes a no-op). Close out the invite on its own so the UI stops
+        // showing it as pending.
+        const code = (err as { code?: string } | null)?.code;
+        if (code === 'permission-denied') {
+          await updateDoc(inviteRef, {
             status: 'accepted',
             respondedAt: Date.now(),
           });
           return;
         }
-        const memberEmails = {
-          ...((plcData.memberEmails ?? {}) as Record<string, string>),
-          [user.uid]: myEmailLower,
-        };
-        tx.update(plcRef, {
-          memberUids: [...memberUids, user.uid],
-          memberEmails,
-          updatedAt: Date.now(),
-        });
-        tx.update(inviteRef, {
-          status: 'accepted',
-          respondedAt: Date.now(),
-        });
-      });
+        throw err;
+      }
     },
     [user, myEmailLower]
   );

--- a/tests/hooks/usePlcInvitations.test.ts
+++ b/tests/hooks/usePlcInvitations.test.ts
@@ -1,0 +1,152 @@
+import { renderHook, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, Mock } from 'vitest';
+import * as firestore from 'firebase/firestore';
+import { usePlcInvitations } from '@/hooks/usePlcInvitations';
+import { useAuth } from '@/context/useAuth';
+import type { PlcInvitation } from '@/types';
+
+vi.mock('firebase/firestore');
+
+vi.mock('../../context/useAuth', () => ({
+  useAuth: vi.fn(),
+}));
+
+vi.mock('@/config/firebase', () => ({
+  db: {},
+  isAuthBypass: false,
+}));
+
+const mockUseAuth = useAuth as unknown as Mock;
+
+const makeInvite = (overrides: Partial<PlcInvitation> = {}): PlcInvitation => ({
+  id: 'plc-1_invitee@example.com',
+  plcId: 'plc-1',
+  plcName: 'Grade 3 Math',
+  inviteeEmailLower: 'invitee@example.com',
+  invitedByUid: 'lead-uid',
+  invitedByName: 'Lead Teacher',
+  invitedAt: 1_700_000_000_000,
+  status: 'pending',
+  ...overrides,
+});
+
+describe('usePlcInvitations — acceptInvite', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseAuth.mockReturnValue({
+      user: {
+        uid: 'invitee-uid',
+        email: 'Invitee@Example.com',
+        displayName: 'Invitee Teacher',
+      },
+    });
+
+    // onSnapshot subscribes twice (pending + sent). Return a no-op unsubscribe
+    // and don't deliver any snapshot so state stays quiet.
+    (firestore.onSnapshot as unknown as Mock).mockImplementation(() => vi.fn());
+    (firestore.collection as unknown as Mock).mockReturnValue({});
+    (firestore.query as unknown as Mock).mockReturnValue({});
+    (firestore.where as unknown as Mock).mockReturnValue({});
+    (firestore.doc as unknown as Mock).mockImplementation(
+      (_db: unknown, col: string, id: string) => ({ __ref: `${col}/${id}` })
+    );
+
+    // arrayUnion is opaque — return a sentinel we can assert on.
+    (firestore.arrayUnion as unknown as Mock).mockImplementation(
+      (...values: unknown[]) => ({ __arrayUnion: values })
+    );
+  });
+
+  it('issues a blind PLC update with arrayUnion + dotted memberEmails path', async () => {
+    const updates: Array<{ ref: unknown; patch: Record<string, unknown> }> = [];
+    type TxShape = {
+      update: (ref: unknown, patch: Record<string, unknown>) => void;
+    };
+    const tx: TxShape = {
+      update: (ref, patch) => {
+        updates.push({ ref, patch });
+      },
+    };
+    (firestore.runTransaction as unknown as Mock).mockImplementation(
+      async (_db: unknown, fn: (tx: TxShape) => Promise<void>) => {
+        await fn(tx);
+      }
+    );
+
+    const { result } = renderHook(() => usePlcInvitations());
+    await act(async () => {
+      await result.current.acceptInvite(makeInvite());
+    });
+
+    // No `tx.get` should have been attempted — blind write only.
+    expect(updates).toHaveLength(2);
+
+    const plcUpdate = updates.find(
+      (u) => (u.ref as { __ref: string }).__ref === 'plcs/plc-1'
+    );
+    expect(plcUpdate).toBeDefined();
+    expect(plcUpdate?.patch).toMatchObject({
+      memberUids: { __arrayUnion: ['invitee-uid'] },
+      'memberEmails.invitee-uid': 'invitee@example.com',
+    });
+    expect(plcUpdate?.patch).toHaveProperty('updatedAt');
+
+    const inviteUpdate = updates.find(
+      (u) =>
+        (u.ref as { __ref: string }).__ref ===
+        'plc_invitations/plc-1_invitee@example.com'
+    );
+    expect(inviteUpdate?.patch).toMatchObject({ status: 'accepted' });
+    expect(inviteUpdate?.patch).toHaveProperty('respondedAt');
+  });
+
+  it('falls back to closing out the invite on permission-denied (already-a-member edge case)', async () => {
+    (firestore.runTransaction as unknown as Mock).mockRejectedValueOnce(
+      Object.assign(new Error('denied'), { code: 'permission-denied' })
+    );
+    (firestore.updateDoc as unknown as Mock).mockResolvedValueOnce(undefined);
+
+    const { result } = renderHook(() => usePlcInvitations());
+    await act(async () => {
+      await result.current.acceptInvite(makeInvite());
+    });
+
+    expect(firestore.updateDoc).toHaveBeenCalledTimes(1);
+    const [ref, patch] = (firestore.updateDoc as unknown as Mock).mock.calls[0];
+    expect((ref as { __ref: string }).__ref).toBe(
+      'plc_invitations/plc-1_invitee@example.com'
+    );
+    expect(patch).toMatchObject({ status: 'accepted' });
+    expect(patch).toHaveProperty('respondedAt');
+  });
+
+  it('rethrows non-permission errors from the transaction', async () => {
+    (firestore.runTransaction as unknown as Mock).mockRejectedValueOnce(
+      Object.assign(new Error('boom'), { code: 'unavailable' })
+    );
+
+    const { result } = renderHook(() => usePlcInvitations());
+    await expect(result.current.acceptInvite(makeInvite())).rejects.toThrow(
+      'boom'
+    );
+    expect(firestore.updateDoc).not.toHaveBeenCalled();
+  });
+
+  it('rejects an invite addressed to a different account before touching Firestore', async () => {
+    const { result } = renderHook(() => usePlcInvitations());
+    await expect(
+      result.current.acceptInvite(
+        makeInvite({ inviteeEmailLower: 'someone.else@example.com' })
+      )
+    ).rejects.toThrow('different account');
+    expect(firestore.runTransaction).not.toHaveBeenCalled();
+  });
+
+  it('rejects a stale non-pending invite with a friendly message', async () => {
+    const { result } = renderHook(() => usePlcInvitations());
+    await expect(
+      result.current.acceptInvite(makeInvite({ status: 'declined' }))
+    ).rejects.toThrow('no longer pending');
+    expect(firestore.runTransaction).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Fixes the two bugs hit while testing **Sidebar → My PLCs → Invites**:

- **Accept failed with `Missing or insufficient permissions`.** The client ran `tx.get(plcRef)` before the update, but non-members can't read `/plcs/{plcId}` — the rule's accept path is a *blind* write. Rewrote `acceptInvite` to use `arrayUnion(uid)` + dotted `memberEmails.<uid>` path, which satisfies the existing `isAcceptingPlcInvite` rule without any rules change. Added a `permission-denied` fallback that closes out the invite on its own (covers the edge case where the lead added the teacher manually between send and accept).
- **No email on send.** No PLC Cloud Function existed. Added `plcInvitationEmail` (`onDocumentWritten` on `plc_invitations/{inviteId}`) mirroring the org-invite pattern — gated by `global_permissions/invite-emails`, queues to `/mail/{inviteId}` for the `firestore-send-email` extension, CTA → `/plc-invite/<inviteId>`.
- **New `/plc-invite/:inviteId` landing page** so the email CTA produces friendly error states (not-found, wrong-account, already-used) instead of raw Firestore errors. Modeled after `components/auth/InviteAcceptance.tsx`.

No `firestore.rules` change — the existing accept-flow rule already permitted the blind write; the client just wasn't using it.

## Files

- `hooks/usePlcInvitations.ts` — blind-write `acceptInvite` + permission-denied fallback
- `functions/src/plcInviteEmails.ts` — new onDocumentWritten trigger (create / re-send / accept / decline / delete / no-op / kill-switch branches)
- `functions/src/plcInviteEmails.test.ts` — 20+ tests covering helper purity + every trigger branch
- `functions/src/index.ts` — exports the new trigger
- `components/auth/PlcInviteAcceptance.tsx` — new landing page
- `App.tsx` — lazy import + `/plc-invite/:inviteId` route branch
- `tests/hooks/usePlcInvitations.test.ts` — 5 tests covering blind-write payload, permission-denied fallback, rethrow non-permission errors, wrong-account rejection, stale-invite rejection

## Validation

Pre-push locally:
- `pnpm run type-check:all` ✓
- `pnpm run lint` (`--max-warnings 0`) ✓
- `pnpm run format:check` ✓
- `pnpm run test` — 1465/1465 ✓
- `pnpm -C functions test` — 189/189 ✓

## Test plan

- [ ] Sign in as PLC lead on `dev-paul` preview, invite a teacher → invite doc written; confirm `/mail/<inviteId>` is created by the trigger and delivery succeeds.
- [ ] Invited teacher gets the email, clicks CTA → lands on `/plc-invite/<inviteId>` → Accept succeeds (no permission toast).
- [ ] Teacher now appears in the PLC member list; invite leaves "pending" for both sides.
- [ ] Open a known-stale invite URL while signed in as the wrong account → "signed in as X but invite is for Y" error (not a blank page / raw Firestore error).
- [ ] Open an invite that's already `accepted` → friendly "already used" state.
- [ ] Toggle `global_permissions/invite-emails.enabled = false` → invite doc still writes; no `/mail/<id>` appears.
- [ ] Seed a PLC with the invitee's uid already in `memberUids`, leaving the invite `pending`; Accept should still succeed (via the permission-denied fallback closing the invite only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)