### PR TITLE
fix(quiz): persist Results export URL on assignment doc

### DIFF
--- a/components/widgets/QuizWidget/Widget.tsx
+++ b/components/widgets/QuizWidget/Widget.tsx
@@ -81,6 +81,7 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
     reopenAssignment,
     deleteAssignment,
     updateAssignmentSettings,
+    setAssignmentExportUrl,
     shareAssignment,
   } = useQuizAssignments(user?.uid);
 
@@ -556,6 +557,10 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
     // This means results are only available while the session data is in Firestore
     // (immediately after or during a session). Historical sessions are not yet persisted
     // separately; config.resultsSessionId is reserved for future per-session history.
+    const activeAssignmentId = config.activeAssignmentId;
+    const activeAssignment = activeAssignmentId
+      ? assignments.find((a) => a.id === activeAssignmentId)
+      : undefined;
     return (
       <QuizResults
         key={`${config.activeAssignmentId ?? 'none'}-${resultsEnterToken}`}
@@ -591,6 +596,12 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
             }
           }
         }}
+        initialExportUrl={activeAssignment?.exportUrl ?? null}
+        onExportUrlSaved={
+          activeAssignmentId
+            ? (url) => setAssignmentExportUrl(activeAssignmentId, url)
+            : undefined
+        }
       />
     );
   }

--- a/components/widgets/QuizWidget/components/QuizResults.tsx
+++ b/components/widgets/QuizWidget/components/QuizResults.tsx
@@ -76,6 +76,18 @@ interface QuizResultsProps {
    * keep re-triggering the regenerate flow against the stale URL.
    */
   onPlcSheetUrlReplaced?: (newUrl: string) => Promise<void> | void;
+  /**
+   * Previously saved export URL for this assignment, read from the
+   * `quiz_assignments` doc. When present, the Export button is replaced by
+   * "Open Sheet" on mount so re-entering Results doesn't require re-exporting.
+   */
+  initialExportUrl?: string | null;
+  /**
+   * Persist a fresh export URL back to the assignment doc so it survives
+   * QuizResults remounts (the parent remounts it on Results re-entry to
+   * recompute aggregate stats) and full tab reloads.
+   */
+  onExportUrlSaved?: (url: string) => Promise<void> | void;
 }
 
 export const QuizResults: React.FC<QuizResultsProps> = ({
@@ -87,13 +99,30 @@ export const QuizResults: React.FC<QuizResultsProps> = ({
   session,
   onDeleteResponse,
   onPlcSheetUrlReplaced,
+  initialExportUrl,
+  onExportUrlSaved,
 }) => {
   const { activeDashboard, updateWidget, addWidget, addToast, rosters } =
     useDashboard();
   const { googleAccessToken, user } = useAuth();
   const { plcs, clearPlcSharedSheetUrl, setPlcSharedSheetUrl } = usePlcs();
   const [exporting, setExporting] = useState(false);
-  const [exportUrl, setExportUrl] = useState<string | null>(null);
+  const [exportUrl, setExportUrl] = useState<string | null>(
+    initialExportUrl ?? null
+  );
+  // Sync from the prop when the parent hydrates assignments after mount —
+  // e.g. a hard reload where `assignments` is briefly empty before Firestore
+  // populates it, so `initialExportUrl` starts null and transitions to a real
+  // URL. Uses the "adjusting state while rendering" pattern so the button
+  // swap ("EXPORT" → "OPEN SHEET") happens in the same commit as the prop
+  // change, without an extra render pass from useEffect.
+  const [lastInitialExportUrl, setLastInitialExportUrl] = useState<
+    string | null | undefined
+  >(initialExportUrl);
+  if (initialExportUrl !== lastInitialExportUrl) {
+    setLastInitialExportUrl(initialExportUrl);
+    setExportUrl(initialExportUrl ?? null);
+  }
   const [exportError, setExportError] = useState<string | null>(null);
   const [activeTab, setActiveTab] = useState<
     'overview' | 'questions' | 'students'
@@ -341,6 +370,20 @@ export const QuizResults: React.FC<QuizResultsProps> = ({
         );
       }
       setExportUrl(url);
+      if (onExportUrlSaved) {
+        // Fire-and-forget: the sheet already exists and the local button is
+        // wired up for this session, so we don't want to keep `exporting`
+        // true (and delay the success toast) waiting on a Firestore round
+        // trip. A failed persist just means the button reverts to EXPORT
+        // on the next remount; log so the teacher isn't surprised without
+        // any diagnostic trail.
+        void Promise.resolve(onExportUrlSaved(url)).catch((err: unknown) => {
+          console.warn(
+            '[QuizResults] failed to persist exportUrl to assignment doc',
+            err
+          );
+        });
+      }
       if (config.plcMode) {
         addToast('Results exported to shared PLC sheet', 'success');
       }

--- a/hooks/useQuizAssignments.ts
+++ b/hooks/useQuizAssignments.ts
@@ -22,6 +22,7 @@ import {
   query,
   where,
   orderBy,
+  updateDoc,
   writeBatch,
 } from 'firebase/firestore';
 import { db } from '../config/firebase';
@@ -97,6 +98,13 @@ export interface UseQuizAssignmentsResult {
     assignmentId: string,
     patch: Partial<QuizAssignmentSettings>
   ) => Promise<void>;
+  /**
+   * Persist the Drive export URL onto the assignment doc so re-entering
+   * Results after navigating away (which remounts QuizResults and wipes its
+   * local state) shows the "Open Sheet" shortcut instead of reverting to
+   * "Export".
+   */
+  setAssignmentExportUrl: (assignmentId: string, url: string) => Promise<void>;
   /** Publish this assignment as a shareable link. Returns the /share/assignment/{id} URL. */
   shareAssignment: (
     assignmentId: string,
@@ -494,6 +502,19 @@ export const useQuizAssignments = (
     [userId]
   );
 
+  const setAssignmentExportUrl = useCallback<
+    UseQuizAssignmentsResult['setAssignmentExportUrl']
+  >(
+    async (assignmentId, url) => {
+      if (!userId) throw new Error('Not authenticated');
+      await updateDoc(
+        doc(db, 'users', userId, QUIZ_ASSIGNMENTS_COLLECTION, assignmentId),
+        { exportUrl: url, updatedAt: Date.now() }
+      );
+    },
+    [userId]
+  );
+
   const shareAssignment = useCallback<
     UseQuizAssignmentsResult['shareAssignment']
   >(
@@ -596,6 +617,7 @@ export const useQuizAssignments = (
     reopenAssignment,
     deleteAssignment,
     updateAssignmentSettings,
+    setAssignmentExportUrl,
     shareAssignment,
     importSharedAssignment,
   };

--- a/types.ts
+++ b/types.ts
@@ -2045,6 +2045,14 @@ export interface QuizAssignment extends QuizAssignmentSettings {
   /** Unified roster targeting (new post-unification assignments). Legacy
    *  assignments read via `periodNames` / session `classIds` only. */
   rosterIds?: string[];
+  /**
+   * URL of the Google Sheet produced by the teacher's last Results → Export.
+   * Persisted so re-entering the Results view after navigating away keeps the
+   * "Open Sheet" shortcut instead of reverting to "Export". Export is
+   * idempotent (same title ⇒ same sheet) so a stale URL safely regenerates
+   * the same sheet if re-exported.
+   */
+  exportUrl?: string;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Adds `exportUrl?: string` to the `QuizAssignment` doc shape so the Drive sheet URL survives the `QuizResults` remount that #1417 introduced (keyed on `activeAssignmentId`/`resultsEnterToken` so aggregate stats recompute on Results re-entry), and survives full tab reloads for free.
- Wires a new `setAssignmentExportUrl` writer through `useQuizAssignments`; `QuizWidget` passes the assignment's saved URL as `initialExportUrl` and a persist callback as `onExportUrlSaved` into `QuizResults`.
- `QuizResults` seeds its local `exportUrl` state from the prop on mount and fires-and-forgets the persist call after a successful export (so the `Open Sheet` shortcut returns immediately, before Firestore round-trips).

Export remains idempotent (same title ⇒ same sheet), so a stale URL safely regenerates the same sheet if the underlying file is deleted — no data-loss risk from the persisted value.

## Test plan

- [ ] Open Results for an assignment that has never been exported → button reads `EXPORT`.
- [ ] Click `EXPORT` → button becomes `OPEN SHEET`, link opens the sheet.
- [ ] Click `Back`, re-open Results for the same assignment → button still reads `OPEN SHEET`, link still works.
- [ ] Hard-reload the tab, reopen the same assignment's Results → button still reads `OPEN SHEET`.
- [ ] Pick a different assignment that hasn't been exported → button reads `EXPORT` (i.e. the saved URL didn't leak across assignments).
- [ ] Teacher without a Google access token clicks `EXPORT` → existing error path still shows the sign-in-again message; no persist attempt.

https://claude.ai/code/session_014jAgCfEPYHQQoeHf2rUCKE

---
_Generated by [Claude Code](https://claude.ai/code/session_014jAgCfEPYHQQoeHf2rUCKE)_