### PR TITLE
fix(quiz): replace native window.confirm with app DialogContext

### DIFF
--- a/components/widgets/QuizWidget/Widget.tsx
+++ b/components/widgets/QuizWidget/Widget.tsx
@@ -907,10 +907,11 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
                 `${withArchived.length} ${withArchived.length === 1 ? 'has' : 'have'} archived assignments — ` +
                 `deleting will prevent viewing their monitor and results. This cannot be undone.`
               : `Delete ${deletable.length} quiz${deletable.length === 1 ? '' : 'zes'}? This cannot be undone.`;
+          const hasArchivedWarning = withArchived.length > 0;
           const ok = await showConfirm(confirmMsg, {
             title: 'Delete Quizzes',
-            variant: 'danger',
-            confirmLabel: 'Delete',
+            variant: hasArchivedWarning ? 'warning' : 'danger',
+            confirmLabel: hasArchivedWarning ? 'Delete Anyway' : 'Delete',
           });
           if (!ok) return false;
 

--- a/components/widgets/QuizWidget/Widget.tsx
+++ b/components/widgets/QuizWidget/Widget.tsx
@@ -8,6 +8,7 @@ import {
 } from '@/types';
 import { useDashboard } from '@/context/useDashboard';
 import { useAuth } from '@/context/useAuth';
+import { useDialog } from '@/context/useDialog';
 import { useQuiz } from '@/hooks/useQuiz';
 import {
   useQuizSessionTeacher,
@@ -38,6 +39,7 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
   const { updateWidget, addWidget, addToast, rosters, activeDashboard } =
     useDashboard();
   const { user, googleAccessToken } = useAuth();
+  const { showConfirm } = useDialog();
   const config = widget.config as QuizConfig;
 
   const {
@@ -812,10 +814,15 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
             return;
           }
           if (related.length > 0) {
-            const ok = window.confirm(
+            const ok = await showConfirm(
               `This quiz has ${related.length} archived assignment(s). ` +
                 `Deleting the quiz will prevent viewing their monitor and results. ` +
-                `Continue anyway?`
+                `Continue anyway?`,
+              {
+                title: 'Delete Quiz',
+                variant: 'warning',
+                confirmLabel: 'Delete Anyway',
+              }
             );
             if (!ok) return;
           }
@@ -900,7 +907,11 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
                 `${withArchived.length} ${withArchived.length === 1 ? 'has' : 'have'} archived assignments — ` +
                 `deleting will prevent viewing their monitor and results. This cannot be undone.`
               : `Delete ${deletable.length} quiz${deletable.length === 1 ? '' : 'zes'}? This cannot be undone.`;
-          const ok = window.confirm(confirmMsg);
+          const ok = await showConfirm(confirmMsg, {
+            title: 'Delete Quizzes',
+            variant: 'danger',
+            confirmLabel: 'Delete',
+          });
           if (!ok) return false;
 
           const results = await Promise.allSettled(

--- a/components/widgets/QuizWidget/components/QuizLiveMonitor.tsx
+++ b/components/widgets/QuizWidget/components/QuizLiveMonitor.tsx
@@ -55,6 +55,7 @@ import {
   isGamificationActive,
 } from '../utils/quizScoreboard';
 import { db } from '@/config/firebase';
+import { useDialog } from '@/context/useDialog';
 import { useClickOutside } from '@/hooks/useClickOutside';
 import {
   playPodiumFanfare,
@@ -262,6 +263,7 @@ export const QuizLiveMonitor: React.FC<QuizLiveMonitorProps> = ({
   onHideAnswer,
   onBack,
 }) => {
+  const { showConfirm } = useDialog();
   const pinToName = useMemo(
     () =>
       buildPinToNameMap(
@@ -475,8 +477,13 @@ export const QuizLiveMonitor: React.FC<QuizLiveMonitorProps> = ({
   };
 
   const handleEnd = async () => {
-    const ok = window.confirm(
-      'Make this assignment inactive?\n\nThe student URL will stop working. Responses are preserved and will still be viewable from the Archive.'
+    const ok = await showConfirm(
+      'Make this assignment inactive? The student URL will stop working. Responses are preserved and will still be viewable from the Archive.',
+      {
+        title: 'Make Inactive',
+        variant: 'warning',
+        confirmLabel: 'Make Inactive',
+      }
     );
     if (!ok) return;
     setEnding(true);

--- a/components/widgets/QuizWidget/components/QuizManager.tsx
+++ b/components/widgets/QuizWidget/components/QuizManager.tsx
@@ -246,10 +246,10 @@ interface QuizManagerProps {
   onArchiveEditSettings?: (assignment: QuizAssignment) => void;
   onArchiveShare?: (assignment: QuizAssignment) => void;
   onArchivePauseResume?: (assignment: QuizAssignment) => void;
-  onArchiveDeactivate?: (assignment: QuizAssignment) => void;
+  onArchiveDeactivate?: (assignment: QuizAssignment) => void | Promise<void>;
   /** Reopen an ended assignment back to a paused state. */
   onArchiveReopen?: (assignment: QuizAssignment) => void;
-  onArchiveDelete?: (assignment: QuizAssignment) => void;
+  onArchiveDelete?: (assignment: QuizAssignment) => void | Promise<void>;
   /** Persist the library grid/list toggle into widget config. */
   onLibraryViewModeChange?: (mode: 'grid' | 'list') => void;
 }
@@ -603,7 +603,7 @@ export const QuizManager: React.FC<QuizManagerProps> = ({
               confirmLabel: 'Make Inactive',
             }
           );
-          if (ok) (onArchiveDeactivate ?? noop)(a);
+          if (ok) await (onArchiveDeactivate ?? noop)(a);
         },
       });
       secondaries.push({
@@ -620,7 +620,7 @@ export const QuizManager: React.FC<QuizManagerProps> = ({
               confirmLabel: 'Delete',
             }
           );
-          if (ok) (onArchiveDelete ?? noop)(a);
+          if (ok) await (onArchiveDelete ?? noop)(a);
         },
       });
       // Filter any item matching the primary label to avoid duplication.
@@ -674,7 +674,7 @@ export const QuizManager: React.FC<QuizManagerProps> = ({
             confirmLabel: 'Delete',
           }
         );
-        if (ok) (onArchiveDelete ?? noop)(a);
+        if (ok) await (onArchiveDelete ?? noop)(a);
       },
     });
     return {

--- a/components/widgets/QuizWidget/components/QuizManager.tsx
+++ b/components/widgets/QuizWidget/components/QuizManager.tsx
@@ -90,6 +90,7 @@ import {
   filterByFolder,
 } from '@/components/common/library/folderFilters';
 import { useFolders } from '@/hooks/useFolders';
+import { useDialog } from '@/context/useDialog';
 
 export interface PlcOptions {
   plcMode: boolean;
@@ -354,6 +355,8 @@ export const QuizManager: React.FC<QuizManagerProps> = ({
     /* action not wired */
   };
 
+  const { showConfirm } = useDialog();
+
   // ─── Assign modal state (2-stage: mode → settings) ────────────────────────
   const [assignTarget, setAssignTarget] = useState<QuizMetadata | null>(null);
   const [selectedMode, setSelectedMode] = useState<QuizSessionMode | null>(
@@ -500,9 +503,14 @@ export const QuizManager: React.FC<QuizManagerProps> = ({
       label: 'Delete',
       icon: Trash2,
       destructive: true,
-      onClick: () => {
-        const ok = window.confirm(
-          `Delete "${quiz.title}"? This cannot be undone.`
+      onClick: async () => {
+        const ok = await showConfirm(
+          `Delete "${quiz.title}"? This cannot be undone.`,
+          {
+            title: 'Delete Quiz',
+            variant: 'danger',
+            confirmLabel: 'Delete',
+          }
         );
         if (ok) void onDelete(quiz);
       },
@@ -586,9 +594,14 @@ export const QuizManager: React.FC<QuizManagerProps> = ({
         label: 'Make Inactive',
         icon: PowerOff,
         destructive: true,
-        onClick: () => {
-          const ok = window.confirm(
-            'Make assignment inactive? The join URL will stop working. Responses are preserved.'
+        onClick: async () => {
+          const ok = await showConfirm(
+            'Make assignment inactive? The join URL will stop working. Responses are preserved.',
+            {
+              title: 'Make Inactive',
+              variant: 'warning',
+              confirmLabel: 'Make Inactive',
+            }
           );
           if (ok) (onArchiveDeactivate ?? noop)(a);
         },
@@ -598,9 +611,14 @@ export const QuizManager: React.FC<QuizManagerProps> = ({
         label: 'Delete',
         icon: Trash2,
         destructive: true,
-        onClick: () => {
-          const ok = window.confirm(
-            'Delete this assignment and all responses? This cannot be undone.'
+        onClick: async () => {
+          const ok = await showConfirm(
+            'Delete this assignment and all responses? This cannot be undone.',
+            {
+              title: 'Delete Assignment',
+              variant: 'danger',
+              confirmLabel: 'Delete',
+            }
           );
           if (ok) (onArchiveDelete ?? noop)(a);
         },
@@ -647,9 +665,14 @@ export const QuizManager: React.FC<QuizManagerProps> = ({
       label: 'Delete',
       icon: Trash2,
       destructive: true,
-      onClick: () => {
-        const ok = window.confirm(
-          'Delete this assignment and all responses? This cannot be undone.'
+      onClick: async () => {
+        const ok = await showConfirm(
+          'Delete this assignment and all responses? This cannot be undone.',
+          {
+            title: 'Delete Assignment',
+            variant: 'danger',
+            confirmLabel: 'Delete',
+          }
         );
         if (ok) (onArchiveDelete ?? noop)(a);
       },
@@ -772,8 +795,13 @@ export const QuizManager: React.FC<QuizManagerProps> = ({
         // Widget-level handler owns confirmation + summary toasts.
         didAttempt = await onBulkDelete(targets);
       } else {
-        const ok = window.confirm(
-          `Delete ${targets.length} quiz${targets.length === 1 ? '' : 'zes'}? This cannot be undone.`
+        const ok = await showConfirm(
+          `Delete ${targets.length} quiz${targets.length === 1 ? '' : 'zes'}? This cannot be undone.`,
+          {
+            title: 'Delete Quizzes',
+            variant: 'danger',
+            confirmLabel: 'Delete',
+          }
         );
         if (ok) {
           const results = await Promise.allSettled(
@@ -798,7 +826,7 @@ export const QuizManager: React.FC<QuizManagerProps> = ({
     } finally {
       setBulkBusy(false);
     }
-  }, [selection, quizzes, onDelete, onBulkDelete]);
+  }, [selection, quizzes, onDelete, onBulkDelete, showConfirm]);
 
   // ─── Folder sidebar (Library tab only) ────────────────────────────────────
   const folderSidebarSlot =

--- a/components/widgets/QuizWidget/components/QuizManager.tsx
+++ b/components/widgets/QuizWidget/components/QuizManager.tsx
@@ -512,7 +512,7 @@ export const QuizManager: React.FC<QuizManagerProps> = ({
             confirmLabel: 'Delete',
           }
         );
-        if (ok) void onDelete(quiz);
+        if (ok) await onDelete(quiz);
       },
     },
   ];


### PR DESCRIPTION
## Summary

In the Quiz widget's **In Progress** tab (and a few other surfaces), clicking the kebab → **Make Inactive** triggered the raw browser confirmation ("spartboard--dev-paul-g42pu859.web.app says…"). That's the same anti-pattern every other confirmation in SpartBoard moved off — the app already has a unified `DialogContext` (`showConfirm` / `showAlert` / `showPrompt`) that renders a glassmorphism modal matching the app theme, supports `variant` (`danger` / `warning` / etc.), returns a promise, and is queueable/accessible.

This PR migrates **all 8** native `window.confirm()` callsites in the Quiz widget to `useDialog().showConfirm(...)`, using variant/label conventions that match existing callers like `CatalystConfigurationModal.tsx` and `FeaturePermissionsManager.tsx`.

- `QuizManager.tsx` — library delete, archive **Make Inactive**, 2× archive delete, fallback bulk delete (5 sites)
- `Widget.tsx` — "quiz has archived assignments" warning + aggregated `onBulkDelete` confirmation (2 sites)
- `QuizLiveMonitor.tsx` — `handleEnd` "Make Inactive" from live session (1 site)

Variant choice:
- `danger` — irreversible deletes (quiz, assignment, bulk)
- `warning` — reversible/recoverable actions (Make Inactive preserves responses; "delete anyway" warning)

Zero changes to `DialogContext` itself — existing API covered every callsite.

## Test plan

- [x] `pnpm run type-check` — clean
- [x] `pnpm run lint` — clean (`--max-warnings 0`)
- [x] `pnpm run format:check` — clean
- [x] `pnpm run test` — 1465 tests pass
- [x] `rg 'window\.(confirm|alert|prompt)' components/widgets/QuizWidget` returns zero
- [ ] Manual: In Progress tab → kebab → **Make Inactive** renders themed warning modal; Confirm flips assignment to inactive; Cancel no-ops
- [ ] Manual: In Progress / Archive tab → kebab → **Delete** renders themed danger modal
- [ ] Manual: Library tab single + bulk **Delete** render themed danger modal with quiz title / count
- [ ] Manual: Delete a quiz with archived assignments → warning-copy modal
- [ ] Manual: Live Monitor → **End** → warning modal

https://claude.ai/code/session_016iJ9AFUQQCVQdsutr7kdhy

---
_Generated by [Claude Code](https://claude.ai/code/session_016iJ9AFUQQCVQdsutr7kdhy)_