### PR TITLE
feat(plc): auto-create + share Google Sheet on PLC assignment

### DIFF
--- a/components/widgets/QuizWidget/Widget.tsx
+++ b/components/widgets/QuizWidget/Widget.tsx
@@ -35,6 +35,7 @@ import { SCOREBOARD_COLORS } from '@/config/scoreboard';
 import { deriveSessionTargetsFromRosters } from '@/utils/resolveAssignmentTargets';
 import { usePlcs } from '@/hooks/usePlcs';
 import { QuizDriveService } from '@/utils/quizDriveService';
+import { getPlcTeammateEmails } from '@/utils/plc';
 
 export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
   const { updateWidget, addWidget, addToast, rosters, activeDashboard } =
@@ -731,20 +732,44 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
               const cached = await getPlcSharedSheetUrl(plcOptions.plcId);
               if (cached) {
                 resolvedPlcSheetUrl = cached;
+                // Even though invite-accept already runs reconcilation,
+                // it can fail silently (no Drive token at accept time,
+                // accepter wasn't the sheet owner). Re-running on every
+                // PLC assignment costs one Drive list call per assign
+                // and lets the actual sheet owner top up writer access
+                // for teammates joined since the sheet was created.
+                // Best-effort — failures here don't block the assignment.
+                if (plc && user) {
+                  const driveService = new QuizDriveService(googleAccessToken);
+                  void driveService
+                    .reconcilePlcSheetPermissions({
+                      sheetUrl: cached,
+                      memberEmailsToShareWith: getPlcTeammateEmails(
+                        plc,
+                        user.uid
+                      ),
+                    })
+                    .catch((err: unknown) => {
+                      console.error(
+                        '[QuizWidget] PLC sheet permission reconcile failed:',
+                        err
+                      );
+                    });
+                }
               } else if (plc && user) {
-                const teammateEmails = plc.memberUids
-                  .filter((uid) => uid !== user.uid)
-                  .map((uid) => plc.memberEmails[uid])
-                  .filter(
-                    (e): e is string => typeof e === 'string' && e.length > 0
-                  );
                 const driveService = new QuizDriveService(googleAccessToken);
                 const created = await driveService.createPlcSheetAndShare({
                   plcName: plc.name,
-                  memberEmailsToShareWith: teammateEmails,
+                  memberEmailsToShareWith: getPlcTeammateEmails(plc, user.uid),
                 });
-                await setPlcSharedSheetUrl(plcOptions.plcId, created.url);
-                resolvedPlcSheetUrl = created.url;
+                // Transactional set-if-empty — if a racing teammate beat
+                // us to the punch, switch to their canonical URL and
+                // accept that our just-created sheet is orphaned in our
+                // Drive (rare race).
+                resolvedPlcSheetUrl = await setPlcSharedSheetUrl(
+                  plcOptions.plcId,
+                  created.url
+                );
               }
             } catch (err) {
               console.error('[QuizWidget] PLC sheet auto-create failed:', err);

--- a/components/widgets/QuizWidget/Widget.tsx
+++ b/components/widgets/QuizWidget/Widget.tsx
@@ -33,6 +33,8 @@ import { QuizLiveMonitor } from './components/QuizLiveMonitor';
 import { Loader2, AlertTriangle, LogIn } from 'lucide-react';
 import { SCOREBOARD_COLORS } from '@/config/scoreboard';
 import { deriveSessionTargetsFromRosters } from '@/utils/resolveAssignmentTargets';
+import { usePlcs } from '@/hooks/usePlcs';
+import { QuizDriveService } from '@/utils/quizDriveService';
 
 export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
   const { updateWidget, addWidget, addToast, rosters, activeDashboard } =
@@ -86,6 +88,11 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
     user?.uid,
     'quiz'
   );
+
+  // PLC subscription — needed at the widget level (not just inside the
+  // Assign modal) so we can auto-create + cache the shared sheet URL on
+  // the right `plcs/{id}` doc when Share-with-PLC fires.
+  const { plcs, getPlcSharedSheetUrl, setPlcSharedSheetUrl } = usePlcs();
 
   // Ephemeral modal state for per-assignment settings editing.
   const [editingAssignment, setEditingAssignment] =
@@ -697,6 +704,59 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
             rosterIds.includes(r.id)
           );
           const derived = deriveSessionTargetsFromRosters(selectedRosters);
+
+          // PLC auto-create: when the teacher enabled Share-with-PLC AND
+          // picked a PLC AND didn't paste a manual URL, resolve the shared
+          // sheet URL before writing the assignment. Read the PLC's
+          // cached sharedSheetUrl first (strong get, not the snapshot); if
+          // absent, create a new Sheet under the teacher's Drive and
+          // share it with every teammate, then cache the URL on the PLC
+          // doc so the next assignment in this PLC just reuses it.
+          //
+          // Failures here don't block the assignment — we fall through
+          // to the manual-paste behavior with an empty URL and toast the
+          // teacher so they can recover.
+          let resolvedPlcSheetUrl = plcOptions.plcSheetUrl;
+          if (
+            plcOptions.plcMode &&
+            plcOptions.plcId &&
+            !resolvedPlcSheetUrl &&
+            googleAccessToken
+          ) {
+            const plc = plcs.find((p) => p.id === plcOptions.plcId);
+            try {
+              // Strong read beats the snapshot for the "already created?"
+              // check — two teachers kicking off their first PLC
+              // assignment simultaneously is rare but worth guarding.
+              const cached = await getPlcSharedSheetUrl(plcOptions.plcId);
+              if (cached) {
+                resolvedPlcSheetUrl = cached;
+              } else if (plc && user) {
+                const teammateEmails = plc.memberUids
+                  .filter((uid) => uid !== user.uid)
+                  .map((uid) => plc.memberEmails[uid])
+                  .filter(
+                    (e): e is string => typeof e === 'string' && e.length > 0
+                  );
+                const driveService = new QuizDriveService(googleAccessToken);
+                const created = await driveService.createPlcSheetAndShare({
+                  plcName: plc.name,
+                  memberEmailsToShareWith: teammateEmails,
+                });
+                await setPlcSharedSheetUrl(plcOptions.plcId, created.url);
+                resolvedPlcSheetUrl = created.url;
+              }
+            } catch (err) {
+              console.error('[QuizWidget] PLC sheet auto-create failed:', err);
+              addToast(
+                err instanceof Error && err.message
+                  ? err.message
+                  : 'Could not create the shared PLC sheet — you can still paste a URL manually.',
+                'error'
+              );
+            }
+          }
+
           try {
             const { id: assignmentId, code } = await createAssignment(
               {
@@ -714,7 +774,7 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
                 periodName:
                   plcOptions.periodNames?.[0] ?? plcOptions.periodName,
                 periodNames: plcOptions.periodNames,
-                plcSheetUrl: plcOptions.plcSheetUrl,
+                plcSheetUrl: resolvedPlcSheetUrl,
               },
               'paused',
               derived.classIds,
@@ -742,7 +802,7 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
                 periodName:
                   plcOptions.periodNames?.[0] ?? plcOptions.periodName ?? '',
                 periodNames: plcOptions.periodNames ?? [],
-                plcSheetUrl: plcOptions.plcSheetUrl ?? '',
+                plcSheetUrl: resolvedPlcSheetUrl ?? '',
                 lastRosterIdsByQuizId: nextMap,
               } as QuizConfig,
             });

--- a/components/widgets/QuizWidget/Widget.tsx
+++ b/components/widgets/QuizWidget/Widget.tsx
@@ -567,6 +567,28 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
         tabWarningsEnabled={liveSession?.tabWarningsEnabled ?? true}
         session={liveSession}
         onDeleteResponse={removeStudent}
+        onPlcSheetUrlReplaced={async (newUrl) => {
+          // After QuizResults regenerates a stale PLC sheet (404
+          // recovery), replace the URL on this widget's config so future
+          // exports don't re-trigger the regenerate dance, AND on the
+          // active assignment doc so other consumers (assignment list,
+          // settings modal, copy-to-clipboard menu) see the live URL.
+          updateWidget(widget.id, {
+            config: { ...config, plcSheetUrl: newUrl } as QuizConfig,
+          });
+          if (config.activeAssignmentId) {
+            try {
+              await updateAssignmentSettings(config.activeAssignmentId, {
+                plcSheetUrl: newUrl,
+              });
+            } catch (err) {
+              console.error(
+                '[QuizWidget] Failed to persist regenerated PLC URL on assignment:',
+                err
+              );
+            }
+          }
+        }}
       />
     );
   }
@@ -732,7 +754,7 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
               const cached = await getPlcSharedSheetUrl(plcOptions.plcId);
               if (cached) {
                 resolvedPlcSheetUrl = cached;
-                // Even though invite-accept already runs reconcilation,
+                // Even though invite-accept already runs reconciliation,
                 // it can fail silently (no Drive token at accept time,
                 // accepter wasn't the sheet owner). Re-running on every
                 // PLC assignment costs one Drive list call per assign

--- a/components/widgets/QuizWidget/components/QuizAssignmentSettingsModal.tsx
+++ b/components/widgets/QuizWidget/components/QuizAssignmentSettingsModal.tsx
@@ -380,7 +380,9 @@ export const QuizAssignmentSettingsModal: React.FC<
                   </div>
                 )}
                 <p className="text-xxs text-slate-400 mt-0.5">
-                  Paste the URL of the Google Sheet shared by your PLC lead
+                  New PLC assignments now auto-create and share this sheet for
+                  you. You can still edit the URL here to point an older
+                  assignment at a different sheet.
                 </p>
               </div>
             </div>

--- a/components/widgets/QuizWidget/components/QuizManager.tsx
+++ b/components/widgets/QuizWidget/components/QuizManager.tsx
@@ -1502,7 +1502,15 @@ const AssignPlcSlot: React.FC<{
                 onChange={(e) => update('plcId', e.target.value)}
                 className="w-full px-3 py-2 bg-white border border-slate-200 rounded-lg text-slate-800 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
               >
-                <option value="">Select a PLC…</option>
+                {/*
+                 * Only render the empty placeholder when there are 2+ PLCs.
+                 * With exactly one PLC, `effectivePlcId` always derives to
+                 * that PLC's id, so picking "Select a PLC…" would snap right
+                 * back to the auto-selection — the option was unreachable
+                 * UI debt. Teachers in a one-PLC org opt out by toggling
+                 * Share-with-PLC off entirely.
+                 */}
+                {plcs.length > 1 && <option value="">Select a PLC…</option>}
                 {plcs.map((p) => (
                   <option key={p.id} value={p.id}>
                     {p.name}

--- a/components/widgets/QuizWidget/components/QuizManager.tsx
+++ b/components/widgets/QuizWidget/components/QuizManager.tsx
@@ -380,6 +380,10 @@ export const QuizManager: React.FC<QuizManagerProps> = ({
     buildDefaultAssignOptions(config, undefined, rosters)
   );
 
+  // Subscribed at the parent so both AssignPlcSlot (UI) and
+  // handleAssignConfirm (effective-id resolution) read the same source.
+  const { plcs } = usePlcs();
+
   // Reset assign form when modal re-opens (adjust-state-while-rendering)
   const [prevAssignTarget, setPrevAssignTarget] = useState<QuizMetadata | null>(
     null
@@ -702,6 +706,13 @@ export const QuizManager: React.FC<QuizManagerProps> = ({
       { rosterIds: validRosterIds },
       rosters
     );
+    // Mirror AssignPlcSlot's effective-id derivation: an explicit choice
+    // wins; otherwise auto-select when there's exactly one PLC. Computed
+    // inline here so a teacher who never touched the dropdown (because
+    // there's only one PLC) still gets that PLC piped through.
+    const explicitPlc = plcs.find((p) => p.id === assignOptions.plcId);
+    const effectivePlcId =
+      explicitPlc?.id ?? (plcs.length === 1 ? plcs[0].id : '');
     const plcOptions: PlcOptions = {
       plcMode: assignOptions.plcMode,
       teacherName: assignOptions.teacherName || undefined,
@@ -709,7 +720,7 @@ export const QuizManager: React.FC<QuizManagerProps> = ({
       periodNames:
         effectivePeriodNames.length > 0 ? effectivePeriodNames : undefined,
       plcSheetUrl: assignOptions.plcSheetUrl || undefined,
-      plcId: assignOptions.plcId || undefined,
+      plcId: effectivePlcId || undefined,
     };
     const sessionOptions: QuizSessionOptions = {
       tabWarningsEnabled: assignOptions.tabWarningsEnabled,
@@ -1056,6 +1067,7 @@ export const QuizManager: React.FC<QuizManagerProps> = ({
             <AssignPlcSlot
               options={assignOptions}
               onChange={setAssignOptions}
+              plcs={plcs}
               plcSheetUrlInvalid={plcSheetUrlInvalid}
               effectivePeriodCount={
                 resolveEffectivePeriodNames(assignOptions.picker, rosters)
@@ -1408,6 +1420,12 @@ const AssignExtraSlot: React.FC<{
 const AssignPlcSlot: React.FC<{
   options: QuizAssignOptions;
   onChange: (next: QuizAssignOptions) => void;
+  /**
+   * Teacher's PLC memberships, threaded down from the parent so the
+   * parent can also derive the effective PLC selection at
+   * handleAssignConfirm time without re-subscribing to the same hook.
+   */
+  plcs: import('@/types').Plc[];
   plcSheetUrlInvalid: boolean;
   /**
    * Number of class periods the picker is contributing (ClassLink class
@@ -1415,35 +1433,32 @@ const AssignPlcSlot: React.FC<{
    * hint without this slot needing to recompute the derivation itself.
    */
   effectivePeriodCount: number;
-}> = ({ options, onChange, plcSheetUrlInvalid, effectivePeriodCount }) => {
+}> = ({
+  options,
+  onChange,
+  plcs,
+  plcSheetUrlInvalid,
+  effectivePeriodCount,
+}) => {
   const update = <K extends keyof QuizAssignOptions>(
     key: K,
     value: QuizAssignOptions[K]
   ) => onChange({ ...options, [key]: value });
 
-  // Teacher's PLC memberships drive the selector below. If the teacher
-  // belongs to zero PLCs, the modal falls back to the manual-URL field so
-  // the feature isn't locked behind joining a PLC first. When they
-  // belong to exactly one PLC, pre-select it so enabling Share-with-PLC is
-  // truly a one-toggle action.
-  const { plcs } = usePlcs();
-
-  // Auto-select the sole PLC so toggling Share-with-PLC doesn't stall on
-  // an empty selector. Uses the "adjust state during render" pattern to
-  // avoid an effect-driven sync loop.
-  const [prevPlcKey, setPrevPlcKey] = useState('');
-  const plcKey = plcs.map((p) => p.id).join(',');
-  if (prevPlcKey !== plcKey) {
-    setPrevPlcKey(plcKey);
-    if (plcs.length === 1 && options.plcId !== plcs[0].id) {
-      onChange({ ...options, plcId: plcs[0].id });
-    } else if (options.plcId && !plcs.some((p) => p.id === options.plcId)) {
-      // Selected PLC disappeared (deleted / member removed) — clear it.
-      onChange({ ...options, plcId: '' });
-    }
-  }
-
-  const selectedPlc = plcs.find((p) => p.id === options.plcId) ?? null;
+  // Compute the effective selection on the fly instead of syncing with
+  // an effect. Two cases:
+  //   1. User has explicitly picked a still-existing PLC → use it
+  //   2. Otherwise → auto-select the sole PLC when there's exactly one,
+  //      else show no selection
+  // A stale options.plcId (PLC was deleted while the modal was open)
+  // collapses to ''; the assign-flow in Widget.tsx already tolerates an
+  // empty plcId, so no separate cleanup is required. Computing this
+  // derived value inline avoids the "calling a parent setter during
+  // render" / "useEffect to sync state across components" antipatterns.
+  const explicitlyChosen = plcs.find((p) => p.id === options.plcId) ?? null;
+  const effectivePlcId =
+    explicitlyChosen?.id ?? (plcs.length === 1 ? plcs[0].id : '');
+  const selectedPlc = explicitlyChosen ?? (plcs.length === 1 ? plcs[0] : null);
   const hasCachedSheet = Boolean(selectedPlc?.sharedSheetUrl);
   const hasPlcs = plcs.length > 0;
 
@@ -1483,7 +1498,7 @@ const AssignPlcSlot: React.FC<{
                 PLC
               </label>
               <select
-                value={options.plcId}
+                value={effectivePlcId}
                 onChange={(e) => update('plcId', e.target.value)}
                 className="w-full px-3 py-2 bg-white border border-slate-200 rounded-lg text-slate-800 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
               >

--- a/components/widgets/QuizWidget/components/QuizManager.tsx
+++ b/components/widgets/QuizWidget/components/QuizManager.tsx
@@ -59,6 +59,7 @@ import {
   makeEmptyPickerValue,
   type AssignClassPickerValue,
 } from '@/components/common/AssignClassPicker.helpers';
+import { usePlcs } from '@/hooks/usePlcs';
 import {
   mapLegacyClassIdsToRosterIds,
   resolveAssignmentTargets,
@@ -98,6 +99,16 @@ export interface PlcOptions {
   periodName?: string;
   periodNames?: string[];
   plcSheetUrl?: string;
+  /**
+   * Selected PLC whose shared sheet should receive this assignment's
+   * results. When set and `plcMode === true`, the caller (QuizWidget)
+   * resolves `plcSheetUrl` by either reading `plcs/{plcId}.sharedSheetUrl`
+   * or auto-creating a new sheet and caching it back onto the PLC doc.
+   * `undefined` means the teacher is opting into the legacy
+   * manual-paste-URL flow (e.g. they aren't a member of any PLC or
+   * auto-create failed).
+   */
+  plcId?: string;
 }
 
 /* ─── Assign-modal options shape (internal) ───────────────────────────────── */
@@ -116,6 +127,11 @@ interface QuizAssignOptions {
   plcMode: boolean;
   teacherName: string;
   plcSheetUrl: string;
+  /**
+   * Selected PLC id when the teacher is a member of one or more PLCs.
+   * Empty string = no PLC selected (manual-URL fallback).
+   */
+  plcId: string;
   /** Unified roster picker state. */
   picker: AssignClassPickerValue;
 }
@@ -167,6 +183,7 @@ function buildDefaultAssignOptions(
     plcMode: config.plcMode ?? false,
     teacherName: config.teacherName ?? '',
     plcSheetUrl: config.plcSheetUrl ?? '',
+    plcId: '',
     picker:
       rememberedRosters.length > 0
         ? { rosterIds: rememberedRosters }
@@ -692,6 +709,7 @@ export const QuizManager: React.FC<QuizManagerProps> = ({
       periodNames:
         effectivePeriodNames.length > 0 ? effectivePeriodNames : undefined,
       plcSheetUrl: assignOptions.plcSheetUrl || undefined,
+      plcId: assignOptions.plcId || undefined,
     };
     const sessionOptions: QuizSessionOptions = {
       tabWarningsEnabled: assignOptions.tabWarningsEnabled,
@@ -1403,6 +1421,32 @@ const AssignPlcSlot: React.FC<{
     value: QuizAssignOptions[K]
   ) => onChange({ ...options, [key]: value });
 
+  // Teacher's PLC memberships drive the selector below. If the teacher
+  // belongs to zero PLCs, the modal falls back to the manual-URL field so
+  // the feature isn't locked behind joining a PLC first. When they
+  // belong to exactly one PLC, pre-select it so enabling Share-with-PLC is
+  // truly a one-toggle action.
+  const { plcs } = usePlcs();
+
+  // Auto-select the sole PLC so toggling Share-with-PLC doesn't stall on
+  // an empty selector. Uses the "adjust state during render" pattern to
+  // avoid an effect-driven sync loop.
+  const [prevPlcKey, setPrevPlcKey] = useState('');
+  const plcKey = plcs.map((p) => p.id).join(',');
+  if (prevPlcKey !== plcKey) {
+    setPrevPlcKey(plcKey);
+    if (plcs.length === 1 && options.plcId !== plcs[0].id) {
+      onChange({ ...options, plcId: plcs[0].id });
+    } else if (options.plcId && !plcs.some((p) => p.id === options.plcId)) {
+      // Selected PLC disappeared (deleted / member removed) — clear it.
+      onChange({ ...options, plcId: '' });
+    }
+  }
+
+  const selectedPlc = plcs.find((p) => p.id === options.plcId) ?? null;
+  const hasCachedSheet = Boolean(selectedPlc?.sharedSheetUrl);
+  const hasPlcs = plcs.length > 0;
+
   return (
     <>
       <div className="flex items-center justify-between">
@@ -1433,6 +1477,38 @@ const AssignPlcSlot: React.FC<{
 
       {options.plcMode && (
         <div className="space-y-3 bg-slate-50 rounded-xl p-3 border border-slate-100">
+          {hasPlcs && (
+            <div>
+              <label className="block text-xxs font-bold text-slate-400 uppercase tracking-widest mb-1">
+                PLC
+              </label>
+              <select
+                value={options.plcId}
+                onChange={(e) => update('plcId', e.target.value)}
+                className="w-full px-3 py-2 bg-white border border-slate-200 rounded-lg text-slate-800 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+              >
+                <option value="">Select a PLC…</option>
+                {plcs.map((p) => (
+                  <option key={p.id} value={p.id}>
+                    {p.name}
+                  </option>
+                ))}
+              </select>
+              {selectedPlc && (
+                <p className="text-xxs text-slate-400 mt-0.5">
+                  {hasCachedSheet
+                    ? 'Using your PLC’s existing Google Sheet — teammates already have access.'
+                    : 'A Google Sheet will be created in your Drive and shared with every teammate automatically.'}
+                </p>
+              )}
+              {!selectedPlc && (
+                <p className="text-xxs text-slate-400 mt-0.5">
+                  Pick a PLC so results land in its shared Google Sheet.
+                </p>
+              )}
+            </div>
+          )}
+
           <div>
             <label className="block text-xxs font-bold text-slate-400 uppercase tracking-widest mb-1">
               Your Name
@@ -1449,29 +1525,46 @@ const AssignPlcSlot: React.FC<{
             </p>
           </div>
 
-          <div>
-            <label className="block text-xxs font-bold text-slate-400 uppercase tracking-widest mb-1">
-              Shared Google Sheet URL
-            </label>
-            <input
-              type="text"
-              value={options.plcSheetUrl}
-              onChange={(e) => update('plcSheetUrl', e.target.value)}
-              placeholder="https://docs.google.com/spreadsheets/d/..."
-              className="w-full px-3 py-2 bg-white border border-slate-200 rounded-lg text-slate-800 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
-            />
-            {plcSheetUrlInvalid && (
-              <div className="flex items-center gap-1 mt-1 text-amber-600">
-                <AlertTriangle className="w-3 h-3" />
-                <span className="text-xxs">
-                  This doesn&apos;t look like a Google Sheets URL
-                </span>
-              </div>
-            )}
-            <p className="text-xxs text-slate-400 mt-0.5">
-              Paste the URL of the Google Sheet shared by your PLC lead
-            </p>
-          </div>
+          {/*
+           * Manual URL fallback: surfaced only when the teacher has NO
+           * PLCs (so they can still paste a URL shared out-of-band) or
+           * they've pasted one already (editing a legacy assignment
+           * created pre-auto-create). Hidden in the normal auto-create
+           * path so PLC members aren't asked to paste what we'll create
+           * for them.
+           */}
+          {(!hasPlcs || options.plcSheetUrl) && (
+            <div>
+              <label className="block text-xxs font-bold text-slate-400 uppercase tracking-widest mb-1">
+                Shared Google Sheet URL{' '}
+                {hasPlcs && (
+                  <span className="font-normal normal-case tracking-normal text-slate-400">
+                    (optional fallback)
+                  </span>
+                )}
+              </label>
+              <input
+                type="text"
+                value={options.plcSheetUrl}
+                onChange={(e) => update('plcSheetUrl', e.target.value)}
+                placeholder="https://docs.google.com/spreadsheets/d/..."
+                className="w-full px-3 py-2 bg-white border border-slate-200 rounded-lg text-slate-800 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+              />
+              {plcSheetUrlInvalid && (
+                <div className="flex items-center gap-1 mt-1 text-amber-600">
+                  <AlertTriangle className="w-3 h-3" />
+                  <span className="text-xxs">
+                    This doesn&apos;t look like a Google Sheets URL
+                  </span>
+                </div>
+              )}
+              <p className="text-xxs text-slate-400 mt-0.5">
+                {hasPlcs
+                  ? 'Leave blank to let SpartBoard auto-create and share a sheet for your PLC.'
+                  : 'Paste the URL of the Google Sheet shared by your PLC lead.'}
+              </p>
+            </div>
+          )}
         </div>
       )}
     </>

--- a/components/widgets/QuizWidget/components/QuizResults.tsx
+++ b/components/widgets/QuizWidget/components/QuizResults.tsx
@@ -33,6 +33,7 @@ import { QuizResponse, QuizData, QuizQuestion, QuizConfig } from '@/types';
 import { useAuth } from '@/context/useAuth';
 import { usePlcs } from '@/hooks/usePlcs';
 import { PlcSheetMissingError } from '@/utils/quizDriveService';
+import { getPlcTeammateEmails } from '@/utils/plc';
 import { QuizDriveService } from '@/utils/quizDriveService';
 import { gradeAnswer, getResponseDocKey } from '@/hooks/useQuizSession';
 import { useDashboard } from '@/context/useDashboard';
@@ -254,51 +255,64 @@ export const QuizResults: React.FC<QuizResultsProps> = ({
           exportOpts
         );
       } catch (exportErr) {
-        // Stale PLC sheet recovery: the cached URL points at a sheet
-        // that's been deleted (404) or unshared (403). Clear the cached
-        // URL on the owning PLC doc, create a fresh sheet in this
-        // teacher's Drive, share it with teammates, and retry the
-        // append. Only attempt this when we can pin the URL to exactly
-        // one PLC the teacher is a member of — otherwise we don't know
-        // which plcs/{id} to update.
+        // Stale PLC sheet recovery, narrow:
+        //   - 404 = the sheet is gone in Drive. Clear cached URL on the
+        //     owning PLC, create a fresh sheet in this teacher's Drive,
+        //     share with teammates, retry. Safe because no one else has
+        //     a working URL either.
+        //   - 403 = the sheet exists, but THIS teacher lacks access.
+        //     Almost always means they're a member who joined after the
+        //     sheet was created and reconciliation hasn't run / failed.
+        //     Do NOT regenerate — that would orphan the existing sheet
+        //     for every teammate who can still reach it. Instead surface
+        //     a clear "ask the PLC lead for access" toast.
         if (
-          exportErr instanceof PlcSheetMissingError &&
-          config.plcMode &&
-          config.plcSheetUrl &&
-          user
+          !(exportErr instanceof PlcSheetMissingError) ||
+          !config.plcMode ||
+          !config.plcSheetUrl ||
+          !user
         ) {
-          const owningPlc = plcs.find(
-            (p) => p.sharedSheetUrl === config.plcSheetUrl
-          );
-          if (owningPlc) {
-            await clearPlcSharedSheetUrl(owningPlc.id);
-            const teammateEmails = owningPlc.memberUids
-              .filter((uid) => uid !== user.uid)
-              .map((uid) => owningPlc.memberEmails[uid])
-              .filter(
-                (e): e is string => typeof e === 'string' && e.length > 0
-              );
-            const created = await svc.createPlcSheetAndShare({
-              plcName: owningPlc.name,
-              memberEmailsToShareWith: teammateEmails,
-            });
-            await setPlcSharedSheetUrl(owningPlc.id, created.url);
-            url = await svc.exportResultsToSheet(
-              quiz.title,
-              responses,
-              quiz.questions,
-              { ...exportOpts, plcSheetUrl: created.url }
-            );
-            addToast(
-              'The previous PLC sheet was missing — created a fresh one.',
-              'info'
-            );
-          } else {
-            throw exportErr;
-          }
-        } else {
           throw exportErr;
         }
+        // Use filter + require exactly-one match. `find` would silently
+        // pick the first when two PLCs accidentally share the same URL
+        // (legacy manual-paste assignments); we'd rather surface the
+        // original error than touch the wrong plcs/{id}.
+        const matchingPlcs = plcs.filter(
+          (p) => p.sharedSheetUrl === config.plcSheetUrl
+        );
+        const owningPlc = matchingPlcs.length === 1 ? matchingPlcs[0] : null;
+        if (exportErr.status === 403) {
+          addToast(
+            owningPlc
+              ? `You don't have access to the ${owningPlc.name} PLC sheet yet — ask the PLC lead to grant you writer access.`
+              : "You don't have access to this PLC sheet — ask the PLC lead to grant you writer access.",
+            'error'
+          );
+          throw exportErr;
+        }
+        // 404 → regenerate, but only when we can pin the URL to a single
+        // PLC. Multiple matches → ambiguous, single none → we don't know
+        // which plcs/{id} to update.
+        if (!owningPlc) {
+          throw exportErr;
+        }
+        await clearPlcSharedSheetUrl(owningPlc.id);
+        const created = await svc.createPlcSheetAndShare({
+          plcName: owningPlc.name,
+          memberEmailsToShareWith: getPlcTeammateEmails(owningPlc, user.uid),
+        });
+        const canonical = await setPlcSharedSheetUrl(owningPlc.id, created.url);
+        url = await svc.exportResultsToSheet(
+          quiz.title,
+          responses,
+          quiz.questions,
+          { ...exportOpts, plcSheetUrl: canonical }
+        );
+        addToast(
+          'The previous PLC sheet was missing — created a fresh one.',
+          'info'
+        );
       }
       setExportUrl(url);
       if (config.plcMode) {

--- a/components/widgets/QuizWidget/components/QuizResults.tsx
+++ b/components/widgets/QuizWidget/components/QuizResults.tsx
@@ -32,9 +32,11 @@ import {
 import { QuizResponse, QuizData, QuizQuestion, QuizConfig } from '@/types';
 import { useAuth } from '@/context/useAuth';
 import { usePlcs } from '@/hooks/usePlcs';
-import { PlcSheetMissingError } from '@/utils/quizDriveService';
+import {
+  PlcSheetMissingError,
+  QuizDriveService,
+} from '@/utils/quizDriveService';
 import { getPlcTeammateEmails } from '@/utils/plc';
-import { QuizDriveService } from '@/utils/quizDriveService';
 import { gradeAnswer, getResponseDocKey } from '@/hooks/useQuizSession';
 import { useDashboard } from '@/context/useDashboard';
 import {
@@ -67,6 +69,13 @@ interface QuizResultsProps {
    * all derived stats/exports will recompute automatically.
    */
   onDeleteResponse?: (responseKey: string) => Promise<void>;
+  /**
+   * Called after the 404 stale-sheet recovery replaces a missing PLC sheet
+   * with a fresh one. Lets the parent widget persist the new URL onto the
+   * widget config and the active assignment doc so future exports don't
+   * keep re-triggering the regenerate flow against the stale URL.
+   */
+  onPlcSheetUrlReplaced?: (newUrl: string) => Promise<void> | void;
 }
 
 export const QuizResults: React.FC<QuizResultsProps> = ({
@@ -77,6 +86,7 @@ export const QuizResults: React.FC<QuizResultsProps> = ({
   tabWarningsEnabled,
   session,
   onDeleteResponse,
+  onPlcSheetUrlReplaced,
 }) => {
   const { activeDashboard, updateWidget, addWidget, addToast, rosters } =
     useDashboard();
@@ -283,13 +293,16 @@ export const QuizResults: React.FC<QuizResultsProps> = ({
         );
         const owningPlc = matchingPlcs.length === 1 ? matchingPlcs[0] : null;
         if (exportErr.status === 403) {
-          addToast(
-            owningPlc
-              ? `You don't have access to the ${owningPlc.name} PLC sheet yet — ask the PLC lead to grant you writer access.`
-              : "You don't have access to this PLC sheet — ask the PLC lead to grant you writer access.",
-            'error'
-          );
-          throw exportErr;
+          // Rethrow with the actionable message so the inline export
+          // banner matches the toast — the raw PlcSheetMissingError
+          // message ("Shared PLC sheet is missing or inaccessible.")
+          // would be confusing here since the sheet isn't actually
+          // missing, this user just lacks writer access.
+          const accessDeniedMessage = owningPlc
+            ? `You don't have access to the ${owningPlc.name} PLC sheet yet — ask the PLC lead to grant you writer access.`
+            : "You don't have access to this PLC sheet — ask the PLC lead to grant you writer access.";
+          addToast(accessDeniedMessage, 'error');
+          throw new Error(accessDeniedMessage);
         }
         // 404 → regenerate, but only when we can pin the URL to a single
         // PLC. Multiple matches → ambiguous, single none → we don't know
@@ -303,6 +316,19 @@ export const QuizResults: React.FC<QuizResultsProps> = ({
           memberEmailsToShareWith: getPlcTeammateEmails(owningPlc, user.uid),
         });
         const canonical = await setPlcSharedSheetUrl(owningPlc.id, created.url);
+        // Persist the new canonical URL onto the widget config + active
+        // assignment so the next export doesn't re-trigger the 404 path
+        // against the stale URL still cached on those docs.
+        if (onPlcSheetUrlReplaced) {
+          try {
+            await onPlcSheetUrlReplaced(canonical);
+          } catch (persistErr) {
+            console.error(
+              '[QuizResults] Failed to persist regenerated PLC URL:',
+              persistErr
+            );
+          }
+        }
         url = await svc.exportResultsToSheet(
           quiz.title,
           responses,

--- a/components/widgets/QuizWidget/components/QuizResults.tsx
+++ b/components/widgets/QuizWidget/components/QuizResults.tsx
@@ -31,6 +31,8 @@ import {
 } from 'lucide-react';
 import { QuizResponse, QuizData, QuizQuestion, QuizConfig } from '@/types';
 import { useAuth } from '@/context/useAuth';
+import { usePlcs } from '@/hooks/usePlcs';
+import { PlcSheetMissingError } from '@/utils/quizDriveService';
 import { QuizDriveService } from '@/utils/quizDriveService';
 import { gradeAnswer, getResponseDocKey } from '@/hooks/useQuizSession';
 import { useDashboard } from '@/context/useDashboard';
@@ -77,7 +79,8 @@ export const QuizResults: React.FC<QuizResultsProps> = ({
 }) => {
   const { activeDashboard, updateWidget, addWidget, addToast, rosters } =
     useDashboard();
-  const { googleAccessToken } = useAuth();
+  const { googleAccessToken, user } = useAuth();
+  const { plcs, clearPlcSharedSheetUrl, setPlcSharedSheetUrl } = usePlcs();
   const [exporting, setExporting] = useState(false);
   const [exportUrl, setExportUrl] = useState<string | null>(null);
   const [exportError, setExportError] = useState<string | null>(null);
@@ -235,18 +238,68 @@ export const QuizResults: React.FC<QuizResultsProps> = ({
     setExportError(null);
     try {
       const svc = new QuizDriveService(googleAccessToken);
-      const url = await svc.exportResultsToSheet(
-        quiz.title,
-        responses,
-        quiz.questions,
-        {
-          pinToName: exportPinToName,
-          teacherName: config.teacherName,
-          periodName: config.periodName,
-          plcMode: config.plcMode,
-          plcSheetUrl: config.plcSheetUrl,
+      const exportOpts = {
+        pinToName: exportPinToName,
+        teacherName: config.teacherName,
+        periodName: config.periodName,
+        plcMode: config.plcMode,
+        plcSheetUrl: config.plcSheetUrl,
+      };
+      let url: string;
+      try {
+        url = await svc.exportResultsToSheet(
+          quiz.title,
+          responses,
+          quiz.questions,
+          exportOpts
+        );
+      } catch (exportErr) {
+        // Stale PLC sheet recovery: the cached URL points at a sheet
+        // that's been deleted (404) or unshared (403). Clear the cached
+        // URL on the owning PLC doc, create a fresh sheet in this
+        // teacher's Drive, share it with teammates, and retry the
+        // append. Only attempt this when we can pin the URL to exactly
+        // one PLC the teacher is a member of — otherwise we don't know
+        // which plcs/{id} to update.
+        if (
+          exportErr instanceof PlcSheetMissingError &&
+          config.plcMode &&
+          config.plcSheetUrl &&
+          user
+        ) {
+          const owningPlc = plcs.find(
+            (p) => p.sharedSheetUrl === config.plcSheetUrl
+          );
+          if (owningPlc) {
+            await clearPlcSharedSheetUrl(owningPlc.id);
+            const teammateEmails = owningPlc.memberUids
+              .filter((uid) => uid !== user.uid)
+              .map((uid) => owningPlc.memberEmails[uid])
+              .filter(
+                (e): e is string => typeof e === 'string' && e.length > 0
+              );
+            const created = await svc.createPlcSheetAndShare({
+              plcName: owningPlc.name,
+              memberEmailsToShareWith: teammateEmails,
+            });
+            await setPlcSharedSheetUrl(owningPlc.id, created.url);
+            url = await svc.exportResultsToSheet(
+              quiz.title,
+              responses,
+              quiz.questions,
+              { ...exportOpts, plcSheetUrl: created.url }
+            );
+            addToast(
+              'The previous PLC sheet was missing — created a fresh one.',
+              'info'
+            );
+          } else {
+            throw exportErr;
+          }
+        } else {
+          throw exportErr;
         }
-      );
+      }
       setExportUrl(url);
       if (config.plcMode) {
         addToast('Results exported to shared PLC sheet', 'success');

--- a/firestore.rules
+++ b/firestore.rules
@@ -631,8 +631,16 @@ service cloud.firestore {
     // does. Constrained so this branch can't be used to smuggle other
     // field changes (memberUids, leadUid, name, etc.).
     //
-    // The value may be a string (setting the URL) or null (clearing after
-    // a stale-sheet 404/403, so the next assignment regenerates).
+    // Allowed transitions:
+    //   - null/absent → string  (first member sets the URL)
+    //   - string → null         (clear, e.g. after a 404 stale-sheet)
+    //   - string → same string  (idempotent set, e.g. retried write)
+    //
+    // Rejected: string → different string. That would let one member
+    // overwrite another's already-cached PLC sheet URL and orphan the
+    // original sheet for everyone else. The client-side
+    // `setPlcSharedSheetUrl` is also transactional, but we enforce the
+    // invariant in rules too as defense-in-depth.
     function isSettingPlcSharedSheetUrl() {
       return (request.auth.uid in resource.data.memberUids)
         && request.resource.data.diff(resource.data).affectedKeys()
@@ -640,6 +648,11 @@ service cloud.firestore {
         && (
              request.resource.data.sharedSheetUrl is string
              || request.resource.data.sharedSheetUrl == null
+           )
+        && (
+             resource.data.get('sharedSheetUrl', null) == null
+             || request.resource.data.sharedSheetUrl == null
+             || request.resource.data.sharedSheetUrl == resource.data.sharedSheetUrl
            );
     }
 

--- a/firestore.rules
+++ b/firestore.rules
@@ -643,8 +643,14 @@ service cloud.firestore {
     // invariant in rules too as defense-in-depth.
     function isSettingPlcSharedSheetUrl() {
       return (request.auth.uid in resource.data.memberUids)
+        // hasOnly + hasAny: the diff must be exactly the sharedSheetUrl
+        // (and the customary updatedAt bump). hasAny ensures this branch
+        // can't be exercised for an updatedAt-only ping that would let a
+        // member reset the doc's mtime without actually setting the URL.
         && request.resource.data.diff(resource.data).affectedKeys()
              .hasOnly(['sharedSheetUrl', 'updatedAt'])
+        && request.resource.data.diff(resource.data).affectedKeys()
+             .hasAny(['sharedSheetUrl'])
         && (
              request.resource.data.sharedSheetUrl is string
              || request.resource.data.sharedSheetUrl == null

--- a/firestore.rules
+++ b/firestore.rules
@@ -623,6 +623,26 @@ service cloud.firestore {
         && get(/databases/$(database)/documents/plc_invitations/$(plcInviteDocId(plcId, emailLower))).data.status == 'pending';
     }
 
+    // True iff the pending update is any current member setting (or
+    // clearing) `sharedSheetUrl` and nothing else. `sharedSheetUrl` is
+    // populated by the first PLC member who creates a Share-with-PLC
+    // assignment — auto-created sheets can't require lead rights, because
+    // a teammate may kick off the first PLC assignment before the lead
+    // does. Constrained so this branch can't be used to smuggle other
+    // field changes (memberUids, leadUid, name, etc.).
+    //
+    // The value may be a string (setting the URL) or null (clearing after
+    // a stale-sheet 404/403, so the next assignment regenerates).
+    function isSettingPlcSharedSheetUrl() {
+      return (request.auth.uid in resource.data.memberUids)
+        && request.resource.data.diff(resource.data).affectedKeys()
+             .hasOnly(['sharedSheetUrl', 'updatedAt'])
+        && (
+             request.resource.data.sharedSheetUrl is string
+             || request.resource.data.sharedSheetUrl == null
+           );
+    }
+
     // True iff the pending update is the caller self-removing from
     // memberUids (i.e. leaving the PLC). The lead can't use this path —
     // they must transfer leadership first or delete the PLC outright.
@@ -668,6 +688,7 @@ service cloud.firestore {
         )
         || isAcceptingPlcInvite(plcId)
         || isLeavingPlc()
+        || isSettingPlcSharedSheetUrl()
       );
 
       // Only the lead can dissolve the PLC.

--- a/hooks/usePlcInvitations.ts
+++ b/hooks/usePlcInvitations.ts
@@ -16,6 +16,7 @@ import { db, isAuthBypass } from '@/config/firebase';
 import { useAuth } from '@/context/useAuth';
 import { PlcInvitation } from '@/types';
 import { QuizDriveService } from '@/utils/quizDriveService';
+import { getPlcMemberEmails } from '@/utils/plc';
 
 const INVITATIONS_COLLECTION = 'plc_invitations';
 const PLCS_COLLECTION = 'plcs';
@@ -277,16 +278,40 @@ export const usePlcInvitations = (): UsePlcInvitationsResult => {
             const data = plcSnap.data() as {
               sharedSheetUrl?: unknown;
               memberEmails?: Record<string, unknown>;
+              memberUids?: unknown;
+              leadUid?: unknown;
+              name?: unknown;
+              createdAt?: unknown;
+              updatedAt?: unknown;
             };
             const sheetUrl =
               typeof data.sharedSheetUrl === 'string'
                 ? data.sharedSheetUrl
                 : null;
             if (sheetUrl) {
-              const emails: string[] = [];
-              for (const v of Object.values(data.memberEmails ?? {})) {
-                if (typeof v === 'string' && v.length > 0) emails.push(v);
+              // Reconstruct the minimal Plc shape the helper consumes.
+              // The accept transaction has just committed so the post-
+              // accept doc must include this user in memberEmails.
+              const memberEmails: Record<string, string> = {};
+              for (const [k, v] of Object.entries(data.memberEmails ?? {})) {
+                if (typeof v === 'string') memberEmails[k] = v;
               }
+              const emails = getPlcMemberEmails({
+                id: invite.plcId,
+                name: typeof data.name === 'string' ? data.name : '',
+                leadUid: typeof data.leadUid === 'string' ? data.leadUid : '',
+                memberUids: Array.isArray(data.memberUids)
+                  ? data.memberUids.filter(
+                      (u): u is string => typeof u === 'string'
+                    )
+                  : [],
+                memberEmails,
+                sharedSheetUrl: sheetUrl,
+                createdAt:
+                  typeof data.createdAt === 'number' ? data.createdAt : 0,
+                updatedAt:
+                  typeof data.updatedAt === 'number' ? data.updatedAt : 0,
+              });
               const service = new QuizDriveService(googleAccessToken);
               await service.reconcilePlcSheetPermissions({
                 sheetUrl,

--- a/hooks/usePlcInvitations.ts
+++ b/hooks/usePlcInvitations.ts
@@ -247,30 +247,41 @@ export const usePlcInvitations = (): UsePlcInvitationsResult => {
         // between send and accept. The rule's `newMembers.size() ==
         // oldMembers.size() + 1` check then refuses the PLC update (arrayUnion
         // becomes a no-op). Close out the invite on its own so the UI stops
-        // showing it as pending.
+        // showing it as pending. Don't `return` — fall through to the
+        // post-accept Drive reconcile below so the (now-confirmed) member
+        // still gets best-effort permission top-up.
         const code = (err as { code?: string } | null)?.code;
         if (code === 'permission-denied') {
           await updateDoc(inviteRef, {
             status: 'accepted',
             respondedAt: Date.now(),
           });
-          return;
+        } else {
+          throw err;
         }
-        throw err;
       }
 
-      // Post-accept: if the PLC already has a shared Google Sheet, best-
-      // effort grant the new member writer access so they can append
-      // submissions immediately. No-op when:
-      //   - the sheet hasn't been created yet (first PLC assignment will
-      //     pick up the new member via memberEmails)
-      //   - the accepter doesn't have a Google OAuth token (rare, but
-      //     sign-in could still be in progress)
-      //   - the accepter isn't the sheet owner (403 on permissions list) —
-      //     the actual owner will reconcile next time they assign
-      // Any failure here is swallowed; membership has already been
-      // persisted, so the invite-accept flow shouldn't regress on a
-      // Drive-side hiccup.
+      // Post-accept: if the PLC already has a shared Google Sheet,
+      // attempt a best-effort permission reconcile. In the common case
+      // the accepter is NOT the sheet owner, so Drive returns 403 on
+      // listing permissions and `reconcilePlcSheetPermissions` short-
+      // circuits to a no-op (`skipped: true`). In rarer cases — e.g. a
+      // Workspace-domain admin whose policy lets them list permissions
+      // on a domain-shared file — this top-up succeeds. The actual
+      // load-bearing reconcile happens on the *owner's* next assign
+      // flow (see `Widget.tsx` cached-URL path).
+      //
+      // Runs after both the transactional happy path and the
+      // permission-denied fallback (where membership was already in
+      // place), so a pre-existing member who completes the invite-
+      // accept handshake still benefits.
+      //
+      // No-ops when: the sheet hasn't been created yet (first PLC
+      // assignment will pick up the new member via memberEmails); the
+      // accepter has no Google OAuth token; or the accepter isn't the
+      // sheet owner (403 on permissions list). Any failure is swallowed
+      // so the invite-accept flow doesn't regress on a Drive-side
+      // hiccup.
       try {
         if (googleAccessToken) {
           const plcSnap = await getDoc(plcRef);

--- a/hooks/usePlcInvitations.ts
+++ b/hooks/usePlcInvitations.ts
@@ -5,6 +5,7 @@ import {
   where,
   onSnapshot,
   doc,
+  getDoc,
   setDoc,
   deleteDoc,
   runTransaction,
@@ -14,6 +15,7 @@ import {
 import { db, isAuthBypass } from '@/config/firebase';
 import { useAuth } from '@/context/useAuth';
 import { PlcInvitation } from '@/types';
+import { QuizDriveService } from '@/utils/quizDriveService';
 
 const INVITATIONS_COLLECTION = 'plc_invitations';
 const PLCS_COLLECTION = 'plcs';
@@ -102,7 +104,7 @@ function parseInvite(
  * the deterministic doc id and email-normalization logic.
  */
 export const usePlcInvitations = (): UsePlcInvitationsResult => {
-  const { user } = useAuth();
+  const { user, googleAccessToken } = useAuth();
   const [pendingInvites, setPendingInvites] = useState<PlcInvitation[]>([]);
   const [sentInvites, setSentInvites] = useState<PlcInvitation[]>([]);
   const [pendingLoaded, setPendingLoaded] = useState(false);
@@ -255,8 +257,52 @@ export const usePlcInvitations = (): UsePlcInvitationsResult => {
         }
         throw err;
       }
+
+      // Post-accept: if the PLC already has a shared Google Sheet, best-
+      // effort grant the new member writer access so they can append
+      // submissions immediately. No-op when:
+      //   - the sheet hasn't been created yet (first PLC assignment will
+      //     pick up the new member via memberEmails)
+      //   - the accepter doesn't have a Google OAuth token (rare, but
+      //     sign-in could still be in progress)
+      //   - the accepter isn't the sheet owner (403 on permissions list) —
+      //     the actual owner will reconcile next time they assign
+      // Any failure here is swallowed; membership has already been
+      // persisted, so the invite-accept flow shouldn't regress on a
+      // Drive-side hiccup.
+      try {
+        if (googleAccessToken) {
+          const plcSnap = await getDoc(plcRef);
+          if (plcSnap.exists()) {
+            const data = plcSnap.data() as {
+              sharedSheetUrl?: unknown;
+              memberEmails?: Record<string, unknown>;
+            };
+            const sheetUrl =
+              typeof data.sharedSheetUrl === 'string'
+                ? data.sharedSheetUrl
+                : null;
+            if (sheetUrl) {
+              const emails: string[] = [];
+              for (const v of Object.values(data.memberEmails ?? {})) {
+                if (typeof v === 'string' && v.length > 0) emails.push(v);
+              }
+              const service = new QuizDriveService(googleAccessToken);
+              await service.reconcilePlcSheetPermissions({
+                sheetUrl,
+                memberEmailsToShareWith: emails,
+              });
+            }
+          }
+        }
+      } catch (reconcileErr) {
+        console.error(
+          '[usePlcInvitations] PLC sheet reconcile after accept failed:',
+          reconcileErr
+        );
+      }
     },
-    [user, myEmailLower]
+    [user, myEmailLower, googleAccessToken]
   );
 
   const declineInvite = useCallback(

--- a/hooks/usePlcs.ts
+++ b/hooks/usePlcs.ts
@@ -36,11 +36,18 @@ interface UsePlcsResult {
   deletePlc: (plcId: string) => Promise<void>;
   /**
    * Any member: persist the auto-created PLC Google Sheet URL on the PLC
-   * doc so teammates reuse it on subsequent assignments. No-ops when the
-   * PLC already has a URL set (first-writer-wins). Rejected by rules if
-   * the caller is not a member.
+   * doc so teammates reuse it on subsequent assignments. Implemented as a
+   * transactional "set-if-empty" so two members assigning their first
+   * PLC quiz simultaneously can't both stomp `sharedSheetUrl`. The caller
+   * passes the URL of the sheet they just created; the resolved URL the
+   * PLC actually ended up with is returned (so the caller can detect a
+   * race-loss and switch to the canonical URL — their own freshly-
+   * created sheet may be orphaned in their Drive in that case, which is
+   * an acceptable rare-race outcome).
+   *
+   * Rejected by rules if the caller is not a member of the PLC.
    */
-  setPlcSharedSheetUrl: (plcId: string, url: string) => Promise<void>;
+  setPlcSharedSheetUrl: (plcId: string, url: string) => Promise<string>;
   /**
    * Any member: clear the cached sheet URL (e.g. after discovering the
    * sheet was deleted in Drive). The next PLC assignment will create a
@@ -260,12 +267,41 @@ export const usePlcs = (): UsePlcsResult => {
   // Any member of the PLC can set sharedSheetUrl when it is currently
   // null/absent. The rule branch restricts the diff to sharedSheetUrl +
   // updatedAt so one member can't also mutate memberUids on this path.
+  //
+  // Transactional set-if-empty: two members concurrently assigning their
+  // first PLC quiz could both call this. Without the transaction, the
+  // last write wins and one teammate's freshly-created sheet would be
+  // pointed at by the URL while the other's becomes a phantom in their
+  // Drive. With the transaction, we read the current value first; if a
+  // racing teammate has already populated `sharedSheetUrl`, we skip our
+  // write and return the existing URL — the caller then uses that
+  // canonical URL (and reconciles permissions for it) instead of the
+  // sheet they just created.
   const setPlcSharedSheetUrl = useCallback(
-    async (plcId: string, url: string) => {
-      if (!user) return;
-      await updateDoc(doc(db, PLCS_COLLECTION, plcId), {
-        sharedSheetUrl: url,
-        updatedAt: Date.now(),
+    async (plcId: string, url: string): Promise<string> => {
+      if (!user) return url;
+      return runTransaction(db, async (tx) => {
+        const ref = doc(db, PLCS_COLLECTION, plcId);
+        const snap = await tx.get(ref);
+        if (!snap.exists()) {
+          throw new Error('PLC not found');
+        }
+        const data = snap.data() as { sharedSheetUrl?: unknown };
+        const existing =
+          typeof data.sharedSheetUrl === 'string' && data.sharedSheetUrl
+            ? data.sharedSheetUrl
+            : null;
+        if (existing) {
+          // Race lost — keep the canonical URL, our own sheet becomes
+          // orphaned (rare; acceptable for a true concurrent-create
+          // collision).
+          return existing;
+        }
+        tx.update(ref, {
+          sharedSheetUrl: url,
+          updatedAt: Date.now(),
+        });
+        return url;
       });
     },
     [user]

--- a/hooks/usePlcs.ts
+++ b/hooks/usePlcs.ts
@@ -10,7 +10,6 @@ import {
   getDocs,
   writeBatch,
   runTransaction,
-  updateDoc,
 } from 'firebase/firestore';
 import { db, isAuthBypass } from '@/config/firebase';
 import { useAuth } from '@/context/useAuth';
@@ -311,12 +310,31 @@ export const usePlcs = (): UsePlcsResult => {
     [user]
   );
 
+  // Idempotent transactional clear: only writes when sharedSheetUrl is
+  // currently a non-empty string. The tightened rule
+  // `isSettingPlcSharedSheetUrl()` requires `sharedSheetUrl` to appear
+  // in `affectedKeys()`, so a redundant null→null write would be
+  // rejected with PERMISSION_DENIED. This guards the 404 recovery
+  // flow against the case where a racing teammate already cleared the
+  // URL between our 404 detection and our own clear call.
   const clearPlcSharedSheetUrl = useCallback(
     async (plcId: string) => {
       if (!user) return;
-      await updateDoc(doc(db, PLCS_COLLECTION, plcId), {
-        sharedSheetUrl: null,
-        updatedAt: Date.now(),
+      await runTransaction(db, async (tx) => {
+        const ref = doc(db, PLCS_COLLECTION, plcId);
+        const snap = await tx.get(ref);
+        if (!snap.exists()) return;
+        const raw = (snap.data() as { sharedSheetUrl?: unknown })
+          .sharedSheetUrl;
+        const isNonEmptyString = typeof raw === 'string' && raw.length > 0;
+        if (!isNonEmptyString) {
+          // Already null/absent — nothing to clear. Skip the write.
+          return;
+        }
+        tx.update(ref, {
+          sharedSheetUrl: null,
+          updatedAt: Date.now(),
+        });
       });
     },
     [user]

--- a/hooks/usePlcs.ts
+++ b/hooks/usePlcs.ts
@@ -6,9 +6,11 @@ import {
   onSnapshot,
   doc,
   setDoc,
+  getDoc,
   getDocs,
   writeBatch,
   runTransaction,
+  updateDoc,
 } from 'firebase/firestore';
 import { db, isAuthBypass } from '@/config/firebase';
 import { useAuth } from '@/context/useAuth';
@@ -32,6 +34,26 @@ interface UsePlcsResult {
   leavePlc: (plcId: string) => Promise<void>;
   /** Lead-only: dissolve the PLC entirely. */
   deletePlc: (plcId: string) => Promise<void>;
+  /**
+   * Any member: persist the auto-created PLC Google Sheet URL on the PLC
+   * doc so teammates reuse it on subsequent assignments. No-ops when the
+   * PLC already has a URL set (first-writer-wins). Rejected by rules if
+   * the caller is not a member.
+   */
+  setPlcSharedSheetUrl: (plcId: string, url: string) => Promise<void>;
+  /**
+   * Any member: clear the cached sheet URL (e.g. after discovering the
+   * sheet was deleted in Drive). The next PLC assignment will create a
+   * fresh sheet.
+   */
+  clearPlcSharedSheetUrl: (plcId: string) => Promise<void>;
+  /**
+   * One-off read of a PLC's sharedSheetUrl. Used at assignment-create
+   * time when we need the current value without waiting for the next
+   * snapshot tick (the snapshot is trustworthy but we want a strong-read
+   * for the "already created?" check to avoid racing two teachers).
+   */
+  getPlcSharedSheetUrl: (plcId: string) => Promise<string | null>;
 }
 
 function parsePlc(id: string, data: Record<string, unknown>): Plc | null {
@@ -48,12 +70,20 @@ function parsePlc(id: string, data: Record<string, unknown>): Plc | null {
   for (const [k, v] of Object.entries(rawEmails)) {
     if (typeof v === 'string') memberEmails[k] = v;
   }
+  // sharedSheetUrl: optional string OR explicit null. Treat any other
+  // shape (including absent) as null so downstream code can rely on the
+  // "absent ⇒ null" equivalence.
+  let sharedSheetUrl: string | null = null;
+  if (typeof data.sharedSheetUrl === 'string') {
+    sharedSheetUrl = data.sharedSheetUrl;
+  }
   return {
     id,
     name: data.name,
     leadUid: data.leadUid,
     memberUids: data.memberUids,
     memberEmails,
+    sharedSheetUrl,
     createdAt: typeof data.createdAt === 'number' ? data.createdAt : 0,
     updatedAt: typeof data.updatedAt === 'number' ? data.updatedAt : 0,
   };
@@ -227,6 +257,41 @@ export const usePlcs = (): UsePlcsResult => {
     [user]
   );
 
+  // Any member of the PLC can set sharedSheetUrl when it is currently
+  // null/absent. The rule branch restricts the diff to sharedSheetUrl +
+  // updatedAt so one member can't also mutate memberUids on this path.
+  const setPlcSharedSheetUrl = useCallback(
+    async (plcId: string, url: string) => {
+      if (!user) return;
+      await updateDoc(doc(db, PLCS_COLLECTION, plcId), {
+        sharedSheetUrl: url,
+        updatedAt: Date.now(),
+      });
+    },
+    [user]
+  );
+
+  const clearPlcSharedSheetUrl = useCallback(
+    async (plcId: string) => {
+      if (!user) return;
+      await updateDoc(doc(db, PLCS_COLLECTION, plcId), {
+        sharedSheetUrl: null,
+        updatedAt: Date.now(),
+      });
+    },
+    [user]
+  );
+
+  const getPlcSharedSheetUrl = useCallback(
+    async (plcId: string): Promise<string | null> => {
+      const snap = await getDoc(doc(db, PLCS_COLLECTION, plcId));
+      if (!snap.exists()) return null;
+      const raw = (snap.data() as { sharedSheetUrl?: unknown }).sharedSheetUrl;
+      return typeof raw === 'string' && raw.length > 0 ? raw : null;
+    },
+    []
+  );
+
   return useMemo(
     () => ({
       plcs,
@@ -236,7 +301,21 @@ export const usePlcs = (): UsePlcsResult => {
       removeMember,
       leavePlc,
       deletePlc,
+      setPlcSharedSheetUrl,
+      clearPlcSharedSheetUrl,
+      getPlcSharedSheetUrl,
     }),
-    [plcs, loading, createPlc, renamePlc, removeMember, leavePlc, deletePlc]
+    [
+      plcs,
+      loading,
+      createPlc,
+      renamePlc,
+      removeMember,
+      leavePlc,
+      deletePlc,
+      setPlcSharedSheetUrl,
+      clearPlcSharedSheetUrl,
+      getPlcSharedSheetUrl,
+    ]
   );
 };

--- a/hooks/usePlcs.ts
+++ b/hooks/usePlcs.ts
@@ -279,7 +279,11 @@ export const usePlcs = (): UsePlcsResult => {
   // sheet they just created.
   const setPlcSharedSheetUrl = useCallback(
     async (plcId: string, url: string): Promise<string> => {
-      if (!user) return url;
+      // Throw rather than silently no-op + return the input URL —
+      // returning would mislead the caller into thinking the URL was
+      // persisted, and they'd skip the auto-create retry that should
+      // run on next sign-in. Mirrors the pattern in createPlc / leavePlc.
+      if (!user) throw new Error('Not signed in');
       return runTransaction(db, async (tx) => {
         const ref = doc(db, PLCS_COLLECTION, plcId);
         const snap = await tx.get(ref);

--- a/tests/utils/quizDriveService.test.ts
+++ b/tests/utils/quizDriveService.test.ts
@@ -1,0 +1,353 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  QuizDriveService,
+  PlcSheetMissingError,
+} from '@/utils/quizDriveService';
+
+/**
+ * Mock helper: enqueues `fetch` responses in order so the tests can
+ * simulate Drive/Sheets multi-call flows (e.g. create sheet, then grant
+ * permission) without maintaining an elaborate scripted double.
+ */
+type FetchSpy = ReturnType<typeof vi.spyOn>;
+
+function queueFetchResponses(
+  responses: Array<{
+    ok?: boolean;
+    status?: number;
+    json?: () => Promise<unknown>;
+    text?: () => Promise<string>;
+  }>
+): FetchSpy {
+  const spy = vi.spyOn(global, 'fetch');
+  for (const r of responses) {
+    spy.mockResolvedValueOnce({
+      ok: r.ok ?? true,
+      status: r.status ?? 200,
+      statusText: '',
+      json: r.json ?? (() => Promise.resolve({})),
+      text: r.text ?? (() => Promise.resolve('')),
+      headers: new Headers(),
+    } as Response);
+  }
+  return spy;
+}
+
+/** Safely decode a fetch call's JSON body. */
+function parseBody(init: RequestInit | undefined): Record<string, unknown> {
+  if (!init || typeof init.body !== 'string') return {};
+  return JSON.parse(init.body) as Record<string, unknown>;
+}
+
+describe('QuizDriveService.createPlcSheetAndShare', () => {
+  const token = 'test-token';
+  let service: QuizDriveService;
+
+  beforeEach(() => {
+    service = new QuizDriveService(token);
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('creates a new sheet and grants writer permission to every teammate email', async () => {
+    const fetchSpy = queueFetchResponses([
+      // 1. POST /spreadsheets — create the sheet
+      {
+        json: () =>
+          Promise.resolve({
+            spreadsheetId: 'sheet-abc',
+            spreadsheetUrl: 'https://docs.google.com/spreadsheets/d/sheet-abc',
+          }),
+      },
+      // 2. POST /files/sheet-abc/permissions — grant teacher-b
+      { json: () => Promise.resolve({ id: 'perm-1' }) },
+      // 3. POST /files/sheet-abc/permissions — grant teacher-c
+      { json: () => Promise.resolve({ id: 'perm-2' }) },
+    ]);
+
+    const result = await service.createPlcSheetAndShare({
+      plcName: '6th Grade Math',
+      memberEmailsToShareWith: [
+        'teacher.b@example.org',
+        'TEACHER.C@example.org',
+      ],
+    });
+
+    expect(result).toEqual({
+      url: 'https://docs.google.com/spreadsheets/d/sheet-abc',
+      spreadsheetId: 'sheet-abc',
+    });
+
+    // First call = create sheet with the PLC-titled spreadsheet body.
+    // `fetchSpy.mock.calls` is typed as `any` through the vi.spyOn return,
+    // so we coerce once into the shape we care about.
+    const calls = (fetchSpy as unknown as { mock: { calls: unknown[][] } }).mock
+      .calls as Array<[string, RequestInit]>;
+    const [createUrl, createInit] = calls[0];
+    expect(createUrl).toBe('https://sheets.googleapis.com/v4/spreadsheets');
+    const createBody = parseBody(createInit);
+    const properties = createBody.properties as { title?: unknown };
+    expect(properties.title).toBe('6th Grade Math – PLC Results');
+    const sheetsArr = createBody.sheets as Array<{
+      properties?: { title?: unknown };
+    }>;
+    expect(sheetsArr[0].properties?.title).toBe('Results');
+
+    // Remaining calls = permission grants, normalized to lowercase, with
+    // sendNotificationEmail=false so Drive doesn't spam a separate email.
+    const permCalls = calls.slice(1);
+    expect(permCalls).toHaveLength(2);
+    for (const [url, init] of permCalls) {
+      expect(url).toContain('/files/sheet-abc/permissions');
+      expect(url).toContain('sendNotificationEmail=false');
+      const body = parseBody(init);
+      expect(body.role).toBe('writer');
+      expect(body.type).toBe('user');
+      expect(body.emailAddress as string).toMatch(
+        /^teacher\.(b|c)@example\.org$/
+      );
+    }
+  });
+
+  it('continues and returns the URL even when a single grant fails', async () => {
+    queueFetchResponses([
+      // Create succeeds
+      {
+        json: () =>
+          Promise.resolve({
+            spreadsheetId: 'sheet-xyz',
+            spreadsheetUrl: 'https://docs.google.com/spreadsheets/d/sheet-xyz',
+          }),
+      },
+      // First grant fails — e.g. stale email outside the org
+      {
+        ok: false,
+        status: 400,
+        text: () => Promise.resolve('invalid email'),
+      },
+      // Second grant succeeds
+      { json: () => Promise.resolve({ id: 'perm-2' }) },
+    ]);
+
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {
+      /* suppress */
+    });
+    const result = await service.createPlcSheetAndShare({
+      plcName: 'My PLC',
+      memberEmailsToShareWith: ['bogus@nope', 'ok@example.org'],
+    });
+    errSpy.mockRestore();
+
+    expect(result.spreadsheetId).toBe('sheet-xyz');
+  });
+
+  it('throws a friendly error when Sheets scope is missing (401/403 on create)', async () => {
+    queueFetchResponses([
+      {
+        ok: false,
+        status: 403,
+        text: () => Promise.resolve('insufficient scope'),
+      },
+    ]);
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {
+      /* suppress */
+    });
+    await expect(
+      service.createPlcSheetAndShare({
+        plcName: 'X',
+        memberEmailsToShareWith: [],
+      })
+    ).rejects.toThrow(/Google Sheets access is not granted/);
+    errSpy.mockRestore();
+  });
+
+  it('dedupes member emails and skips empty / invalid entries', async () => {
+    const fetchSpy = queueFetchResponses([
+      {
+        json: () =>
+          Promise.resolve({
+            spreadsheetId: 'sheet-dedupe',
+            spreadsheetUrl:
+              'https://docs.google.com/spreadsheets/d/sheet-dedupe',
+          }),
+      },
+      { json: () => Promise.resolve({ id: 'perm-1' }) },
+    ]);
+
+    await service.createPlcSheetAndShare({
+      plcName: 'D',
+      memberEmailsToShareWith: [
+        'dupe@example.org',
+        'DUPE@example.org',
+        '',
+        '   ',
+        'no-at-sign',
+      ],
+    });
+
+    // Create + exactly ONE permission grant (dupe collapsed).
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('QuizDriveService.reconcilePlcSheetPermissions', () => {
+  const token = 'test-token';
+  let service: QuizDriveService;
+
+  beforeEach(() => {
+    service = new QuizDriveService(token);
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('grants writer to teammates missing from the current permission list', async () => {
+    const fetchSpy = queueFetchResponses([
+      // LIST existing permissions — teacher-a already has access, teacher-c does not
+      {
+        json: () =>
+          Promise.resolve({
+            permissions: [
+              {
+                id: 'p1',
+                type: 'user',
+                role: 'owner',
+                emailAddress: 'owner@example.org',
+              },
+              {
+                id: 'p2',
+                type: 'user',
+                role: 'writer',
+                emailAddress: 'teacher-a@example.org',
+              },
+            ],
+          }),
+      },
+      // GRANT teacher-c
+      { json: () => Promise.resolve({ id: 'perm-new' }) },
+    ]);
+
+    const result = await service.reconcilePlcSheetPermissions({
+      sheetUrl: 'https://docs.google.com/spreadsheets/d/sheet-123/edit',
+      memberEmailsToShareWith: [
+        'teacher-a@example.org',
+        'teacher-c@example.org',
+      ],
+    });
+
+    expect(result.granted).toEqual(['teacher-c@example.org']);
+    expect(result.skipped).toBe(false);
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('returns skipped=true without throwing when the caller cannot list permissions (403)', async () => {
+    queueFetchResponses([
+      { ok: false, status: 403, text: () => Promise.resolve('forbidden') },
+    ]);
+    const result = await service.reconcilePlcSheetPermissions({
+      sheetUrl: 'https://docs.google.com/spreadsheets/d/sheet-xyz/edit',
+      memberEmailsToShareWith: ['anyone@example.org'],
+    });
+    expect(result).toEqual({ granted: [], skipped: true });
+  });
+
+  it('returns skipped=true on 404 (sheet deleted in Drive)', async () => {
+    queueFetchResponses([
+      { ok: false, status: 404, text: () => Promise.resolve('not found') },
+    ]);
+    const result = await service.reconcilePlcSheetPermissions({
+      sheetUrl: 'https://docs.google.com/spreadsheets/d/gone/edit',
+      memberEmailsToShareWith: ['anyone@example.org'],
+    });
+    expect(result.skipped).toBe(true);
+  });
+
+  it('returns skipped=true for malformed sheet URLs without calling fetch', async () => {
+    const fetchSpy = vi.spyOn(global, 'fetch');
+    const result = await service.reconcilePlcSheetPermissions({
+      sheetUrl: 'not-a-sheet-url',
+      memberEmailsToShareWith: ['x@example.org'],
+    });
+    expect(result).toEqual({ granted: [], skipped: true });
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('is a no-op when no teammates need access', async () => {
+    const fetchSpy = vi.spyOn(global, 'fetch');
+    const result = await service.reconcilePlcSheetPermissions({
+      sheetUrl: 'https://docs.google.com/spreadsheets/d/sheet-1/edit',
+      memberEmailsToShareWith: [],
+    });
+    expect(result).toEqual({ granted: [], skipped: false });
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe('QuizDriveService appendToExistingSheet error surfacing', () => {
+  const token = 'test-token';
+  let service: QuizDriveService;
+
+  beforeEach(() => {
+    service = new QuizDriveService(token);
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('throws PlcSheetMissingError when the sheet is gone (404)', async () => {
+    queueFetchResponses([
+      // Title metadata lookup — succeeds with a default tab name
+      {
+        json: () =>
+          Promise.resolve({
+            sheets: [{ properties: { title: 'Results' } }],
+          }),
+      },
+      // A1 existence check — 404 Not Found
+      { ok: false, status: 404, text: () => Promise.resolve('gone') },
+    ]);
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {
+      /* suppress */
+    });
+    await expect(
+      service.exportResultsToSheet('Q', [], [], {
+        plcMode: true,
+        plcSheetUrl: 'https://docs.google.com/spreadsheets/d/gone/edit',
+      })
+    ).rejects.toBeInstanceOf(PlcSheetMissingError);
+    errSpy.mockRestore();
+  });
+
+  it('throws PlcSheetMissingError when the caller lost access (403)', async () => {
+    queueFetchResponses([
+      {
+        json: () =>
+          Promise.resolve({
+            sheets: [{ properties: { title: 'Results' } }],
+          }),
+      },
+      {
+        ok: false,
+        status: 403,
+        text: () => Promise.resolve('forbidden'),
+      },
+    ]);
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {
+      /* suppress */
+    });
+    await expect(
+      service.exportResultsToSheet('Q', [], [], {
+        plcMode: true,
+        plcSheetUrl: 'https://docs.google.com/spreadsheets/d/locked/edit',
+      })
+    ).rejects.toBeInstanceOf(PlcSheetMissingError);
+    errSpy.mockRestore();
+  });
+});

--- a/types.ts
+++ b/types.ts
@@ -176,6 +176,16 @@ export interface Plc {
    * per export. Always written alongside `memberUids`.
    */
   memberEmails: Record<string, string>;
+  /**
+   * URL of the single Google Sheet that aggregates this PLC's assignment
+   * results. Auto-created the first time any member assigns a quiz with
+   * Share-with-PLC enabled. Subsequent PLC assignments reuse this URL
+   * instead of prompting the teacher to paste one. `null` (or absent) means
+   * "not yet created — the next Share-with-PLC assignment should create it."
+   * Cleared back to `null` if the sheet is later deleted in Drive so the
+   * next assignment regenerates transparently.
+   */
+  sharedSheetUrl?: string | null;
   createdAt: number;
   updatedAt: number;
 }

--- a/utils/plc.ts
+++ b/utils/plc.ts
@@ -1,0 +1,41 @@
+/**
+ * PLC helpers shared across the Quiz widget, the invite hook, and the
+ * results recovery path. Centralized to avoid the email-extraction logic
+ * drifting out of sync — every call site needs to enumerate the PLC's
+ * teammates the same way (skip self, lowercase + de-dup) before passing
+ * the list to Drive permission grants.
+ */
+
+import { Plc } from '@/types';
+
+/**
+ * Return every member email recorded on a PLC, normalized + de-duped.
+ * Used by the invite-accept reconciliation flow (where "self" was just
+ * added and should also be granted access).
+ */
+export function getPlcMemberEmails(plc: Plc): string[] {
+  const seen = new Set<string>();
+  for (const v of Object.values(plc.memberEmails ?? {})) {
+    if (typeof v !== 'string') continue;
+    const normalized = v.trim().toLowerCase();
+    if (normalized.length > 0) seen.add(normalized);
+  }
+  return Array.from(seen);
+}
+
+/**
+ * Return every PLC member email except the caller's own. Used by the
+ * assignment-create flow (the caller already owns the sheet so they
+ * don't need a separate writer permission grant).
+ */
+export function getPlcTeammateEmails(plc: Plc, selfUid: string): string[] {
+  const teammateUids = plc.memberUids.filter((uid) => uid !== selfUid);
+  const seen = new Set<string>();
+  for (const uid of teammateUids) {
+    const raw = plc.memberEmails[uid];
+    if (typeof raw !== 'string') continue;
+    const normalized = raw.trim().toLowerCase();
+    if (normalized.length > 0) seen.add(normalized);
+  }
+  return Array.from(seen);
+}

--- a/utils/quizDriveService.ts
+++ b/utils/quizDriveService.ts
@@ -58,6 +58,34 @@ interface SheetsValueRange {
   values?: string[][];
 }
 
+interface DrivePermission {
+  id: string;
+  type?: string;
+  role?: string;
+  emailAddress?: string;
+}
+
+interface DrivePermissionsListResponse {
+  permissions?: DrivePermission[];
+}
+
+/**
+ * Thrown by `appendToExistingSheet` when the shared PLC sheet is either
+ * missing (404) or the caller has lost access (403). Callers catch this
+ * to clear the cached `sharedSheetUrl` on `plcs/{id}` and regenerate a
+ * fresh sheet before retrying the append, rather than surfacing the
+ * raw API error to students mid-submission.
+ */
+export class PlcSheetMissingError extends Error {
+  constructor(
+    message: string,
+    public readonly status: number
+  ) {
+    super(message);
+    this.name = 'PlcSheetMissingError';
+  }
+}
+
 export class QuizDriveService {
   private accessToken: string;
 
@@ -673,6 +701,17 @@ export class QuizDriveService {
     if (!checkRes.ok) {
       const err = await checkRes.text();
       console.error('Sheets read error:', err);
+      // 404 = sheet was deleted in Drive. 403 = caller lost access (e.g.
+      // the creator revoked the share, or the sheet's owner transferred
+      // ownership to a domain that refuses external writers). Either way,
+      // signal the caller to clear the cached URL and regenerate rather
+      // than bubbling a raw API failure to a student mid-submission.
+      if (checkRes.status === 404 || checkRes.status === 403) {
+        throw new PlcSheetMissingError(
+          'Shared PLC sheet is missing or inaccessible.',
+          checkRes.status
+        );
+      }
       throw new Error(
         'Failed to access the shared sheet. Check that the URL is correct and the sheet is shared with you.'
       );
@@ -701,12 +740,177 @@ export class QuizDriveService {
     if (!appendRes.ok) {
       const err = await appendRes.text();
       console.error('Sheets append error:', err);
+      if (appendRes.status === 404 || appendRes.status === 403) {
+        throw new PlcSheetMissingError(
+          'Shared PLC sheet is missing or inaccessible.',
+          appendRes.status
+        );
+      }
       throw new Error(
         'Failed to append results to the shared sheet. Check your permissions.'
       );
     }
 
     return `https://docs.google.com/spreadsheets/d/${spreadsheetId}`;
+  }
+
+  // ─── PLC shared-sheet provisioning ─────────────────────────────────────────
+
+  /**
+   * Create a new Google Sheet owned by the caller for use as a PLC's
+   * shared export destination, and grant `writer` permission to every
+   * email in `memberEmailsToShareWith`. The caller's own email must NOT
+   * appear in the list — they already own the sheet.
+   *
+   * Returns the spreadsheet URL for persisting onto `plcs/{id}.sharedSheetUrl`
+   * and the assignment's `plcSheetUrl`. Permission-grant failures are
+   * logged and swallowed individually so that one teammate with an invalid
+   * email doesn't block the sheet from being created — reconciliation on
+   * invite-accept will retry missing grants.
+   */
+  async createPlcSheetAndShare(args: {
+    plcName: string;
+    memberEmailsToShareWith: string[];
+  }): Promise<{ url: string; spreadsheetId: string }> {
+    const title = `${args.plcName} – PLC Results`;
+    const createRes = await fetch(SHEETS_API_URL, {
+      method: 'POST',
+      headers: this.jsonHeaders,
+      body: JSON.stringify({
+        properties: { title },
+        // Start with a blank Results tab — headers are written on the
+        // first appendToExistingSheet call when dataRows arrive.
+        sheets: [{ properties: { title: 'Results' } }],
+      }),
+    });
+    if (!createRes.ok) {
+      const err = await createRes.text();
+      console.error('PLC sheet create error:', err);
+      if (createRes.status === 401 || createRes.status === 403) {
+        throw new Error(
+          'Google Sheets access is not granted. Sign in again to enable PLC sharing.'
+        );
+      }
+      throw new Error('Failed to create the PLC shared sheet.');
+    }
+    const sheet = (await createRes.json()) as {
+      spreadsheetId: string;
+      spreadsheetUrl: string;
+    };
+
+    // Grant writer permission to every teammate email. Best-effort: we
+    // don't let a single failed grant abort the whole flow, since the
+    // sheet itself is already created and usable by the owner.
+    const unique = new Set(
+      args.memberEmailsToShareWith
+        .map((e) => e.trim().toLowerCase())
+        .filter((e) => e.length > 0 && e.includes('@'))
+    );
+    for (const email of unique) {
+      try {
+        await this.grantSheetWriterPermission(sheet.spreadsheetId, email);
+      } catch (err) {
+        console.error(`Failed to share PLC sheet with ${email}:`, err);
+      }
+    }
+
+    return { url: sheet.spreadsheetUrl, spreadsheetId: sheet.spreadsheetId };
+  }
+
+  /**
+   * Ensure every email in `memberEmailsToShareWith` has writer access on
+   * the PLC sheet. Called from the invite-accept path so a teammate
+   * admitted after the sheet was created still gets access automatically.
+   *
+   * Silent no-op when the caller is not the sheet owner (listing
+   * permissions returns 403) — the actual owner will reconcile next time
+   * they assign something. A 404 is treated the same way; the caller
+   * should clear `plcs/{id}.sharedSheetUrl` if it can be confirmed
+   * elsewhere that the sheet is truly gone.
+   */
+  async reconcilePlcSheetPermissions(args: {
+    sheetUrl: string;
+    memberEmailsToShareWith: string[];
+  }): Promise<{ granted: string[]; skipped: boolean }> {
+    const spreadsheetId = QuizDriveService.extractSheetId(args.sheetUrl);
+    if (!spreadsheetId) return { granted: [], skipped: true };
+
+    const wanted = new Set(
+      args.memberEmailsToShareWith
+        .map((e) => e.trim().toLowerCase())
+        .filter((e) => e.length > 0 && e.includes('@'))
+    );
+    if (wanted.size === 0) return { granted: [], skipped: false };
+
+    // List existing permissions so we only grant what's missing. fields=
+    // restricts the payload to the keys we consume.
+    const listRes = await fetch(
+      `${DRIVE_API_URL}/files/${spreadsheetId}/permissions?fields=permissions(id,type,role,emailAddress)`,
+      { headers: this.authHeaders }
+    );
+    if (!listRes.ok) {
+      // 403 = caller isn't the owner (so can't list permissions); 404 =
+      // sheet gone. Either way we can't do anything here — the actual
+      // owner (or the next assignment create) will reconcile.
+      if (listRes.status === 403 || listRes.status === 404) {
+        return { granted: [], skipped: true };
+      }
+      throw new Error(
+        `Failed to list PLC sheet permissions (${listRes.status})`
+      );
+    }
+    const listData = (await listRes.json()) as DrivePermissionsListResponse;
+    const existing = new Set(
+      (listData.permissions ?? [])
+        .map((p) => (p.emailAddress ?? '').toLowerCase())
+        .filter((e) => e.length > 0)
+    );
+
+    const granted: string[] = [];
+    for (const email of wanted) {
+      if (existing.has(email)) continue;
+      try {
+        await this.grantSheetWriterPermission(spreadsheetId, email);
+        granted.push(email);
+      } catch (err) {
+        console.error(`Failed to grant PLC sheet access to ${email}:`, err);
+      }
+    }
+    return { granted, skipped: false };
+  }
+
+  /**
+   * Low-level helper: grant a single `writer` permission on a Drive file
+   * by email. Extracted so `createPlcSheetAndShare` and
+   * `reconcilePlcSheetPermissions` share one code path.
+   *
+   * `sendNotificationEmail=false` because the sheet URL is surfaced inside
+   * SpartBoard — a separate Drive-generated email would be noise. Drive
+   * rejects the argument silently when the caller lacks the scope, so we
+   * still rely on the response check below to detect failure.
+   */
+  private async grantSheetWriterPermission(
+    spreadsheetId: string,
+    email: string
+  ): Promise<void> {
+    const res = await fetch(
+      `${DRIVE_API_URL}/files/${spreadsheetId}/permissions?sendNotificationEmail=false`,
+      {
+        method: 'POST',
+        headers: this.jsonHeaders,
+        body: JSON.stringify({
+          role: 'writer',
+          type: 'user',
+          emailAddress: email,
+        }),
+      }
+    );
+    if (!res.ok) {
+      const body = await res.text();
+      throw new Error(
+        `Drive permission grant failed (${res.status}): ${body.slice(0, 200)}`
+      );
+    }
   }
 
   /**


### PR DESCRIPTION
## Summary

Auto-create + auto-share a Google Sheet when a PLC member turns on **Share with PLC** for a Quiz assignment. The first member's assignment creates the sheet in their Drive, shares writer access with every teammate via Drive permissions, and caches the URL on `plcs/{id}.sharedSheetUrl`. Every subsequent PLC assignment reuses the same sheet — teammates never paste a URL.

## What changed

**Data model**
- `Plc.sharedSheetUrl?: string | null` (new field on `plcs/{id}` Firestore docs)

**Firestore rules**
- New `isSettingPlcSharedSheetUrl()` branch on the `plcs/{id}` update rule. Any current member can set or clear `sharedSheetUrl`; the diff is constrained to `sharedSheetUrl` + `updatedAt`, so this branch can't be used to smuggle other field changes. Lead-only and accept/leave branches unchanged.

**`utils/quizDriveService.ts`**
- `createPlcSheetAndShare({ plcName, memberEmailsToShareWith })` — creates a Sheet under the caller's Drive (titled `${plcName} – PLC Results`), grants `writer` to every teammate via `permissions.create` with `sendNotificationEmail=false`. Best-effort per email so one bad address can't abort the whole flow.
- `reconcilePlcSheetPermissions({ sheetUrl, memberEmailsToShareWith })` — diffs requested emails against current permissions, grants only the missing ones, no-ops when the caller can't list permissions (403 = not the owner) or the sheet is gone (404). Used at invite-accept time.
- `PlcSheetMissingError` — typed 404/403 from the append path so callers can clear the cached URL and regenerate without crashing the export.

**Quiz UI / wiring**
- `QuizManager.AssignPlcSlot` — adds a PLC selector (auto-selects the sole PLC when there's exactly one), with copy that switches between "A Google Sheet will be created…" and "Using your PLC's existing Google Sheet…". Manual URL field is hidden in the auto-create path and surfaces only when the teacher has no PLCs or is editing a pre-auto-create URL.
- `QuizWidget.tsx onAssign` — when `plcMode + plcId + no manual URL`, reads `plcs/{id}.sharedSheetUrl` (strong get); if absent, calls `createPlcSheetAndShare` with teammate emails from `memberEmails` and persists the URL on both the PLC doc and the assignment.
- `QuizResults.handleExport` — catches `PlcSheetMissingError`, clears the cached URL on the owning PLC, regenerates a fresh sheet (sharing it with current teammates), and retries the append. Surfaces an "info" toast so the teacher knows the sheet was rebuilt.
- `QuizAssignmentSettingsModal` — copy update so the manual URL helper text reads as a fallback, not the primary path.

**`hooks/usePlcs.ts`**
- `parsePlc` now reads `sharedSheetUrl`.
- New actions: `setPlcSharedSheetUrl`, `clearPlcSharedSheetUrl`, `getPlcSharedSheetUrl` (one-off strong read for the assign-flow race guard).

**`hooks/usePlcInvitations.ts`**
- After a successful `acceptInvite` transaction, best-effort calls `reconcilePlcSheetPermissions` so the new teammate gets writer access on any already-created sheet. Reads the PLC doc post-accept (member access is now granted by the transaction). Failures are logged + swallowed — the membership write has already committed.

**Tests**
- 11 new unit tests in `tests/utils/quizDriveService.test.ts` covering: create + multi-email share, single-grant failure tolerance, missing-Sheets-scope error mapping, email dedup, reconcile-grants-missing-only, reconcile skip on 403/404/malformed-URL, append-path 404/403 surfacing as `PlcSheetMissingError`.

## Out of scope

- **Video Activity has no PLC mode today.** The task description references "VA equivalent" but there's no `plcMode` field on `useVideoActivityAssignments` or in `VideoActivityManager`'s assign flow. Adding PLC mode to VA would be a separate, much larger feature and is not in this PR.
- Solo-mode (`plcMode: false`) sheet creation is untouched.
- The `firestore-send-email` extension config is unrelated and unchanged.
- Pre-existing assignments created before this PR keep whatever (possibly-manual) `plcSheetUrl` they had — only new assignments hit the auto-create path.

## Test plan

- [x] `pnpm run validate` — typecheck (root + functions), lint (zero warnings), prettier check, unit tests (1476 pass), functions tests (189 pass)
- [x] `pnpm run build` — succeeds
- [ ] Smoke on dev-paul preview after deploy:
  - [ ] Teacher A creates a PLC + invites Teacher B. Teacher A assigns a quiz with Share-with-PLC on. Sheet auto-created in A's Drive; Teacher B has writer access.
  - [ ] Teacher B creates a different quiz assignment with Share-with-PLC on. URL pre-fills automatically; submissions append to the same sheet.
  - [ ] Teacher A invites Teacher C. After C accepts, C has writer access on the sheet (reconcile fired on accept).
  - [ ] Delete the sheet in Drive; export results from Teacher A's quiz; verify graceful regeneration toast and that the new URL is persisted on the PLC doc.
  - [ ] Sign in as a user without Sheets scope (or revoke locally) and confirm the in-toast "Google Sheets access is not granted — sign in again" path fires cleanly.

https://claude.ai/code/session_01GoAd7dWLJJgT3CRSHt6SvG

---
_Generated by [Claude Code](https://claude.ai/code/session_01GoAd7dWLJJgT3CRSHt6SvG)_