### PR TITLE
fix(graphic-organizer): drop duplicate cellBg from inner Cause/Effect boxes

### DIFF
--- a/components/widgets/GraphicOrganizer/Widget.tsx
+++ b/components/widgets/GraphicOrganizer/Widget.tsx
@@ -503,10 +503,7 @@ export const GraphicOrganizerWidget: React.FC<{ widget: WidgetData }> = ({
         gap: 'min(16px, 3cqmin)',
       }}
     >
-      <div
-        className="flex-1 border-2 border-rose-300 rounded-lg shadow-sm h-full flex flex-col"
-        style={{ backgroundColor: cellBg }}
-      >
+      <div className="flex-1 border-2 border-rose-300 rounded-lg shadow-sm h-full flex flex-col">
         <div
           className="bg-rose-100 text-center rounded-t-md border-b-2 border-rose-300 font-bold text-rose-800 uppercase tracking-wider"
           style={{
@@ -549,10 +546,7 @@ export const GraphicOrganizerWidget: React.FC<{ widget: WidgetData }> = ({
         </svg>
       </div>
 
-      <div
-        className="flex-1 border-2 border-emerald-300 rounded-lg shadow-sm h-full flex flex-col"
-        style={{ backgroundColor: cellBg }}
-      >
+      <div className="flex-1 border-2 border-emerald-300 rounded-lg shadow-sm h-full flex flex-col">
         <div
           className="bg-emerald-100 text-center rounded-t-md border-b-2 border-emerald-300 font-bold text-emerald-800 uppercase tracking-wider"
           style={{


### PR DESCRIPTION
## Summary

Carries over the one unique fix from #1405 (closed as superseded by #1394). #1394 completed the `cqmin` conversion across all five GraphicOrganizer layouts, but did not include the cellBg duplicate-removal. This PR lands that remaining fix.

The outer Cause-Effect wrapper already paints `cellBg`. Stacking another `backgroundColor: cellBg` on the inner `flex-1 border-rose-300` and `flex-1 border-emerald-300` boxes caused opacity² artifacts whenever `cardOpacity < 1` — the cell background appeared darker on the inner boxes than on the rest of the widget.

## Changes

- `components/widgets/GraphicOrganizer/Widget.tsx` — dropped `style={{ backgroundColor: cellBg }}` from the inner Cause and Effect `flex-1` divs in `renderCauseEffect`. The outer `flex items-center justify-center` wrapper retains it.

## Test plan

- [x] `pnpm run type-check` — clean
- [x] `pnpm run lint --max-warnings 0` — clean
- [x] `pnpm prettier --check` on changed file — clean
- [ ] Visual: confirm Cause-Effect layout still reads correctly and that lowering `cardOpacity` no longer produces a darker inner-box artifact

---
_Generated by [Claude Code](https://claude.ai/code/session_01A3Zi8vANGJ6NcGT4SM65H3)_