### PR TITLE
fix: unblock mini-app assignment submission and session lifecycle

### DIFF
--- a/components/miniApp/MiniAppStudentApp.tsx
+++ b/components/miniApp/MiniAppStudentApp.tsx
@@ -18,7 +18,7 @@
 
 import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { signInAnonymously } from 'firebase/auth';
-import { doc, onSnapshot, setDoc } from 'firebase/firestore';
+import { doc, getDoc, onSnapshot, setDoc } from 'firebase/firestore';
 import { httpsCallable } from 'firebase/functions';
 import {
   Loader2,
@@ -185,6 +185,30 @@ const AppViewer: React.FC<{ session: MiniAppSession }> = ({ session }) => {
   const [hasSubmitted, setHasSubmitted] = useState(false);
   const submissionsEnabled = session.submissionsEnabled === true;
 
+  // On mount, check Firestore for an existing submission so `hasSubmitted`
+  // survives page refreshes. If the doc already exists we hide the "I'm Done"
+  // button immediately without waiting for a user action.
+  useEffect(() => {
+    const checkExisting = async () => {
+      const currentUser = auth.currentUser;
+      if (!currentUser) return;
+      try {
+        const tokenResult = await currentUser.getIdTokenResult();
+        const isStudentRole = tokenResult.claims?.studentRole === true;
+        const docId = isStudentRole
+          ? await getCachedPseudonym(session.id, currentUser.uid)
+          : currentUser.uid;
+        const snap = await getDoc(
+          doc(db, SESSIONS_COLLECTION, session.id, 'submissions', docId)
+        );
+        if (snap.exists()) setHasSubmitted(true);
+      } catch {
+        // Doc doesn't exist yet or network error — leave hasSubmitted false.
+      }
+    };
+    void checkExisting();
+  }, [session.id]);
+
   // Handshake: post SPART_MINIAPP_INIT into the iframe once it loads so the
   // app knows whether to reveal its [data-spart-submit] button. The app is
   // expected to listen for this message and hide submit controls when
@@ -292,9 +316,16 @@ const AppViewer: React.FC<{ session: MiniAppSession }> = ({ session }) => {
         studentUid: currentUser.uid,
         payload: { completed: true },
       };
+      // Use mergeFields so we only touch these specific fields. This avoids
+      // overwriting a real submission payload if the student already submitted
+      // work via the app's own SPART_MINIAPP_RESULT button and then reloaded
+      // the page (resetting hasSubmitted) before clicking "I'm Done".
+      // payload.completed is merged into the existing payload map rather than
+      // replacing it, preserving any prior work data.
       await setDoc(
         doc(db, SESSIONS_COLLECTION, session.id, 'submissions', docId),
-        completion
+        completion,
+        { mergeFields: ['submittedAt', 'studentUid', 'payload.completed'] }
       );
       setStatus({ kind: 'saved', at: Date.now() });
       setHasSubmitted(true);

--- a/components/miniApp/MiniAppStudentApp.tsx
+++ b/components/miniApp/MiniAppStudentApp.tsx
@@ -26,6 +26,7 @@ import {
   CheckCircle2,
   Box,
   RefreshCw,
+  Flag,
 } from 'lucide-react';
 import { auth, db, functions } from '@/config/firebase';
 import { MiniAppSession, MiniAppSubmission } from '@/types';
@@ -179,6 +180,9 @@ function getCachedPseudonym(
 const AppViewer: React.FC<{ session: MiniAppSession }> = ({ session }) => {
   const iframeRef = useRef<HTMLIFrameElement>(null);
   const [status, setStatus] = useState<SubmissionStatus>({ kind: 'idle' });
+  // Tracks whether the student has submitted anything (via app or "I'm Done")
+  // in this session. Prevents the Done button from reappearing after auto-clear.
+  const [hasSubmitted, setHasSubmitted] = useState(false);
   const submissionsEnabled = session.submissionsEnabled === true;
 
   // Handshake: post SPART_MINIAPP_INIT into the iframe once it loads so the
@@ -256,6 +260,7 @@ const AppViewer: React.FC<{ session: MiniAppSession }> = ({ session }) => {
           submission
         );
         setStatus({ kind: 'saved', at: Date.now() });
+        setHasSubmitted(true);
       } catch (err) {
         console.error('[MiniAppStudentApp] Submission write failed:', err);
         setStatus({ kind: 'error', payload });
@@ -263,6 +268,41 @@ const AppViewer: React.FC<{ session: MiniAppSession }> = ({ session }) => {
     },
     [session.id, submissionsEnabled, status.kind]
   );
+
+  // Writes a minimal {completed: true} completion marker so the student's
+  // assignment badge in /my-assignments shows "Completed". Works for both
+  // view-only (submissionsEnabled=false) and submission-enabled sessions.
+  // The Firestore rule allows this write regardless of submissionsEnabled.
+  const markDone = useCallback(async () => {
+    if (hasSubmitted || status.kind === 'submitting') return;
+    const currentUser = auth.currentUser;
+    if (!currentUser) {
+      console.warn('[MiniAppStudentApp] No auth user; skipping mark-done.');
+      return;
+    }
+    setStatus({ kind: 'submitting' });
+    try {
+      const tokenResult = await currentUser.getIdTokenResult();
+      const isStudentRole = tokenResult.claims?.studentRole === true;
+      const docId = isStudentRole
+        ? await getCachedPseudonym(session.id, currentUser.uid)
+        : currentUser.uid;
+      const completion: MiniAppSubmission = {
+        submittedAt: Date.now(),
+        studentUid: currentUser.uid,
+        payload: { completed: true },
+      };
+      await setDoc(
+        doc(db, SESSIONS_COLLECTION, session.id, 'submissions', docId),
+        completion
+      );
+      setStatus({ kind: 'saved', at: Date.now() });
+      setHasSubmitted(true);
+    } catch (err) {
+      console.error('[MiniAppStudentApp] Mark-done write failed:', err);
+      setStatus({ kind: 'idle' });
+    }
+  }, [session.id, hasSubmitted, status.kind]);
 
   const handleMessage = useCallback(
     (event: MessageEvent) => {
@@ -300,6 +340,30 @@ const AppViewer: React.FC<{ session: MiniAppSession }> = ({ session }) => {
         onLoad={handleIframeLoad}
       />
       <SubmissionStatusOverlay status={status} onRetry={submit} />
+      {/* "I'm Done" button — allows students to mark the assignment complete
+          regardless of whether the mini-app itself has a submit button.
+          Hidden once the student has submitted (via app or this button). */}
+      {!hasSubmitted && (
+        <button
+          type="button"
+          onClick={() => void markDone()}
+          disabled={status.kind === 'submitting'}
+          aria-label="Mark this assignment as done"
+          className="fixed bottom-4 right-4 z-20 inline-flex items-center gap-2 px-3 py-2 rounded-xl bg-slate-800/90 text-white text-xs font-semibold hover:bg-slate-700 border border-slate-600/50 shadow-lg backdrop-blur-sm transition-all disabled:opacity-50 select-none"
+        >
+          {status.kind === 'submitting' ? (
+            <>
+              <Loader2 className="w-3.5 h-3.5 animate-spin" />
+              Saving…
+            </>
+          ) : (
+            <>
+              <Flag className="w-3.5 h-3.5 text-emerald-400" />
+              I&apos;m Done
+            </>
+          )}
+        </button>
+      )}
     </div>
   );
 };

--- a/components/widgets/MiniApp/Widget.tsx
+++ b/components/widgets/MiniApp/Widget.tsx
@@ -662,6 +662,26 @@ export const MiniAppWidget: React.FC<WidgetComponentProps> = ({
     addToast('Library exported successfully', 'success');
   };
 
+  // Ends a session from the AssignmentsModal and keeps the miniapp_assignments
+  // archive row in sync. If an active assignment row already exists for the
+  // session, endAssignment handles both the row and the session doc. For old
+  // sessions that predate the miniapp_assignments collection (no row exists),
+  // we fall back to ending the session doc directly so the student's
+  // /my-assignments view clears immediately.
+  const handleEndSessionFromModal = useCallback(
+    async (sessionId: string) => {
+      const match = assignments.find(
+        (a) => a.sessionId === sessionId && a.status === 'active'
+      );
+      if (match) {
+        await endAssignment(match.id);
+      } else {
+        await endSession(sessionId);
+      }
+    },
+    [endSession, endAssignment, assignments]
+  );
+
   // Archive / In Progress handlers ─────────────────────────────────────────
   const handleArchiveCopyUrl = useCallback(
     async (assignment: MiniAppAssignment) => {
@@ -910,7 +930,7 @@ export const MiniAppWidget: React.FC<WidgetComponentProps> = ({
                 loading={sessionsLoading}
                 onClose={handleCloseAssignments}
                 onRenameSession={renameSession}
-                onEndSession={endSession}
+                onEndSession={handleEndSessionFromModal}
               />
             )}
           </div>
@@ -1021,7 +1041,7 @@ export const MiniAppWidget: React.FC<WidgetComponentProps> = ({
                 loading={sessionsLoading}
                 onClose={handleCloseAssignments}
                 onRenameSession={renameSession}
-                onEndSession={endSession}
+                onEndSession={handleEndSessionFromModal}
               />
             )}
           </div>

--- a/components/widgets/MiniApp/Widget.tsx
+++ b/components/widgets/MiniApp/Widget.tsx
@@ -27,8 +27,12 @@ import { useFolders } from '@/hooks/useFolders';
 import {
   collection,
   doc,
+  getDocs,
+  limit,
+  query,
   setDoc,
   deleteDoc,
+  where,
   writeBatch,
 } from 'firebase/firestore';
 import { db } from '@/config/firebase';
@@ -668,18 +672,49 @@ export const MiniAppWidget: React.FC<WidgetComponentProps> = ({
   // sessions that predate the miniapp_assignments collection (no row exists),
   // we fall back to ending the session doc directly so the student's
   // /my-assignments view clears immediately.
+  //
+  // The local `assignments` snapshot can be stale (still loading, or the
+  // row was just created and the listener hasn't fired yet). When the
+  // local lookup misses we re-query Firestore by sessionId before falling
+  // back to a bare `endSession`, otherwise the archive row could stay
+  // stuck as `active` even though the session ended.
   const handleEndSessionFromModal = useCallback(
     async (sessionId: string) => {
-      const match = assignments.find(
+      const localMatch = assignments.find(
         (a) => a.sessionId === sessionId && a.status === 'active'
       );
-      if (match) {
-        await endAssignment(match.id);
-      } else {
-        await endSession(sessionId);
+      if (localMatch) {
+        await endAssignment(localMatch.id);
+        return;
       }
+
+      if (user?.uid) {
+        try {
+          const snap = await getDocs(
+            query(
+              collection(db, 'users', user.uid, 'miniapp_assignments'),
+              where('sessionId', '==', sessionId),
+              where('status', '==', 'active'),
+              limit(1)
+            )
+          );
+          const row = snap.docs[0];
+          if (row) {
+            await endAssignment(row.id);
+            return;
+          }
+        } catch (err) {
+          // Fall through to endSession; logging only.
+          console.warn(
+            '[MiniAppWidget] miniapp_assignments lookup failed; ending session directly',
+            err
+          );
+        }
+      }
+
+      await endSession(sessionId);
     },
-    [endSession, endAssignment, assignments]
+    [endSession, endAssignment, assignments, user?.uid]
   );
 
   // Archive / In Progress handlers ─────────────────────────────────────────

--- a/firestore.rules
+++ b/firestore.rules
@@ -1149,10 +1149,11 @@ service cloud.firestore {
         // Two write paths are allowed:
         //   1. Full submission (submissionsEnabled must be true) — payload
         //      can be any valid map up to 50 keys.
-        //   2. Completion marker (any session) — payload must be exactly
-        //      {completed: true}. This lets students mark view-only (no
-        //      submissions) assignments as done so the completion badge
-        //      appears in /my-assignments without requiring submissionsEnabled.
+        //   2. Completion marker (any active session regardless of
+        //      submissionsEnabled) — payload must be exactly {completed: true}.
+        //      This lets students mark view-only (no submissions) assignments
+        //      as done so the completion badge appears in /my-assignments
+        //      without requiring submissionsEnabled.
         allow create, update: if request.auth != null &&
           maSessionData().status == 'active' &&
           passesStudentClassGateList(maSessionClassIds()) &&

--- a/firestore.rules
+++ b/firestore.rules
@@ -1131,8 +1131,7 @@ service cloud.firestore {
         );
 
         // Any authenticated user (anonymous or studentRole) may create or
-        // update their own submission while the session is active and
-        // submissions are enabled.
+        // update their own submission while the session is active.
         // - Every submission must carry a `studentUid` field equal to the
         //   caller's auth.uid so the doc is attributable and the student
         //   can read it back via the rule above.
@@ -1146,16 +1145,28 @@ service cloud.firestore {
         //   authorization and accountability.
         // Payload shape is validated to prevent junk writes bloating the
         // subcollection.
+        //
+        // Two write paths are allowed:
+        //   1. Full submission (submissionsEnabled must be true) — payload
+        //      can be any valid map up to 50 keys.
+        //   2. Completion marker (any session) — payload must be exactly
+        //      {completed: true}. This lets students mark view-only (no
+        //      submissions) assignments as done so the completion badge
+        //      appears in /my-assignments without requiring submissionsEnabled.
         allow create, update: if request.auth != null &&
           maSessionData().status == 'active' &&
-          maSessionData().get('submissionsEnabled', false) == true &&
           passesStudentClassGateList(maSessionClassIds()) &&
           (isStudentRoleUser() || submissionId == request.auth.uid) &&
           request.resource.data.studentUid == request.auth.uid &&
           request.resource.data.keys().hasOnly(['submittedAt', 'studentUid', 'payload']) &&
           request.resource.data.submittedAt is int &&
           request.resource.data.payload is map &&
-          request.resource.data.payload.size() <= 50;
+          request.resource.data.payload.size() <= 50 &&
+          (
+            maSessionData().get('submissionsEnabled', false) == true ||
+            (request.resource.data.payload.keys().hasOnly(['completed']) &&
+             request.resource.data.payload.completed == true)
+          );
 
         // Only the owning teacher or an admin may delete submissions —
         // used when a teacher wipes an assignment.


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Student side**: Adds an "I'm Done" floating button to the mini-app student page (`/miniapp/:sessionId`) so students can mark any assignment complete — including view-only ones with no in-app submit button. Writes a `{completed: true}` completion marker to the submissions subcollection, which the `/my-assignments` completion-badge check already reads.
- **Firestore rules**: Extends the `mini_app_sessions/submissions` write rule to allow the `{completed: true}` marker write regardless of `submissionsEnabled`. Full-payload submissions still require `submissionsEnabled: true`.
- **Teacher side**: Fixes `Widget.tsx` so ending a session from the Assignments modal properly syncs the `miniapp_assignments` archive row. Previously, only the session doc was updated, leaving In Progress rows stuck as "active". For legacy sessions that predate the `miniapp_assignments` collection, falls back to ending the session doc directly (sufficient to clear the student's `/my-assignments` view).

## Test plan

- [ ] As a student on `/my-assignments`, open a view-only mini-app assignment → confirm "I'm Done" button appears in the bottom-right corner of the page
- [ ] Click "I'm Done" → button shows "Saving…" then disappears; "Completed" badge appears on the card in `/my-assignments`
- [ ] As a student on a submission-enabled assignment, submit via the app's own button → "I'm Done" button should disappear after submission
- [ ] As a teacher, open MiniApp widget → Library tab → kebab menu → "View assignments" → End Session on a session → verify the In Progress tab updates the row to Archive
- [ ] End an old session (no `miniapp_assignments` row) via Assignments modal → session doc is marked ended, student's assignment disappears from `/my-assignments`

https://claude.ai/code/session_015KNnH7prmDV3yVPsYcmFwB
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_015KNnH7prmDV3yVPsYcmFwB)_