### PR TITLE
docs(widget-registry): document sticker exception in WIDGET_COMPONENTS

### DIFF
--- a/components/widgets/WidgetRegistry.ts
+++ b/components/widgets/WidgetRegistry.ts
@@ -48,6 +48,21 @@ const MiniAppSettings = lazyNamed(
   'MiniAppSettings'
 );
 
+/**
+ * Maps widget types to their lazily-loaded React components.
+ *
+ * Note: This map is intentionally NOT exhaustive over all `WidgetType`s.
+ * Some widget types are handled outside the registry pattern:
+ *
+ * - `sticker`: Handled by a hard-coded branch in `WidgetRenderer.tsx`
+ *   (`if (widget.type === 'sticker') return <StickerItemWidget ... />`).
+ *   `StickerItemWidget` is intentionally absent from this map. Do NOT
+ *   add a `sticker` entry here without also removing the special-case
+ *   branch in WidgetRenderer.
+ *
+ * Do not assume `WIDGET_COMPONENTS[widgetType]` is defined for every
+ * `WidgetType` value — always handle the `undefined` case at call sites.
+ */
 export const WIDGET_COMPONENTS: Partial<Record<WidgetType, WidgetComponent>> = {
   url: lazyNamed(() => import('./UrlWidget/Widget'), 'UrlWidget'),
   soundboard: lazyNamed(

--- a/docs/scheduled-tasks/admin-settings-alignment.md
+++ b/docs/scheduled-tasks/admin-settings-alignment.md
@@ -3,7 +3,7 @@
 _Audit model: claude-sonnet-4-6_
 _Action model: claude-opus-4-6_
 _Audit cadence: weekly — Thursday_
-_Last audited: 2026-04-16_
+_Last audited: 2026-04-26_
 _Last action: 2026-04-16_
 
 ---
@@ -52,6 +52,13 @@ _Nothing currently in progress._
 - **File:** types.ts (ChecklistConfig / BuildingChecklistDefaults), context/DashboardContext.tsx (~line 2183)
 - **Detail:** `ChecklistConfig` has a `rosterMode` field that controls whether the checklist uses a manually-entered list or a synced class roster. Users can toggle this in Settings.tsx. `BuildingChecklistDefaults` does not include `rosterMode`, so admins cannot set a default roster mode per building.
 - **Fix:** Add `rosterMode` to `BuildingChecklistDefaults` in types.ts. Add it to the `case 'checklist'` handler in `getAdminBuildingConfig()`. Expose a toggle in `ChecklistConfigurationPanel.tsx`.
+
+### MEDIUM `need-do-put-then` has stub admin config panel but no getAdminBuildingConfig handler
+
+- **Detected:** 2026-04-26
+- **File:** components/admin/NeedDoPutThenConfigurationPanel.tsx, context/DashboardContext.tsx (getAdminBuildingConfig)
+- **Detail:** `need-do-put-then` was added with `NeedDoPutThenConfigurationPanel.tsx` registered in `BUILDING_CONFIG_PANELS`. However: (1) the panel is a non-functional stub showing "No building-level defaults yet" with no input controls; (2) there is no `case 'need-do-put-then':` in `getAdminBuildingConfig()` in DashboardContext.tsx; (3) `NeedDoPutThenConfig` (types.ts:2897) has no building defaults interface. When a teacher adds the widget, `getAdminBuildingConfig('need-do-put-then')` falls through to `default: break` and returns `{}`. The admin gear button for this widget opens a panel but provides no functional controls and stores nothing useful.
+- **Fix:** Either (a) implement building-level defaults for the widget: add a `NeedDoPutThenBuildingDefaults` interface to types.ts, add a `case 'need-do-put-then':` handler in `getAdminBuildingConfig()`, and replace the stub panel with actual form controls for preset items per column; or (b) remove `NeedDoPutThenConfigurationPanel` from `BUILDING_CONFIG_PANELS` so the admin UI shows the standard "No global settings available" placeholder instead of a misleading stub.
 
 ---
 

--- a/docs/scheduled-tasks/css-scaling.md
+++ b/docs/scheduled-tasks/css-scaling.md
@@ -3,7 +3,7 @@
 _Audit model: claude-sonnet-4-6_
 _Action model: claude-opus-4-6_
 _Audit cadence: daily_
-_Last audited: 2026-04-25_
+_Last audited: 2026-04-26_
 _Last action: 2026-04-25_
 
 ---
@@ -45,6 +45,20 @@ _Nothing currently in progress._
   - `TalkingTool/Widget.tsx:80, :109, :135` — `p-2 space-y-2`, `mb-2`, `mb-4`
   - `Webcam/Widget.tsx:457, :470, :480, :497, :527, :531, :542, :547, :558` — `p-6`, `p-6 mb-4`, `px-4 py-2`, `gap-2`, `p-4` (multiple), `gap-3`, `gap-2` (multiple)
 - **Fix:** For each widget, convert hardcoded spacing and icon-size Tailwind classes to inline `cqmin` equivalents. Example: `gap-2` → `style={{ gap: 'min(8px, 2cqmin)' }}`, `w-8 h-8` → `style={{ width: 'min(32px, 8cqmin)', height: 'min(32px, 8cqmin)' }}`. Prioritize widgets visible in default-size teacher dashboards (DiceWidget, NextUp, SoundWidget) over utility widgets.
+
+### LOW MiniApp internal dialog overlays use hardcoded Tailwind text sizes
+
+- **Detected:** 2026-04-26
+- **File:** components/widgets/MiniApp/Widget.tsx:134, :138, :142, :148, :166, :177, :187, :194, :204, :219, :226, :237, :253, :260, :848, :866, :874
+- **Detail:** The widget has two internal overlay dialogs rendered inside the container-query context: (1) the "Start Live Session" / "Share Link" dialog shown when the user launches a live session (lines 120–260), and (2) the "Save to Library" overlay shown when pasting HTML into the widget (lines 848–880). Both use hardcoded Tailwind classes `text-base`, `text-sm`, `text-xs` on labels, body text, code blocks, and buttons. Widget has `skipScaling: true`. At small widget sizes these overlays will show unscaled text and potentially overflow the widget bounds. The prior 2026-04-14 completion entry "MiniAppWidget uses hardcoded Tailwind text sizes — Resolved outside journal workflow" was inaccurate; these overlay states were not assessed.
+- **Fix:** For both overlay dialogs, replace `text-base` → `style={{ fontSize: 'min(16px, 6cqmin)' }}`, `text-sm` → `style={{ fontSize: 'min(14px, 5.5cqmin)' }}`, `text-xs` → `style={{ fontSize: 'min(11px, 4cqmin)' }}`. Also convert any `w-4 h-4` icon sizes and `gap-2`, `p-3`/`p-5` spacing to `cqmin` equivalents.
+
+### LOW NumberLineWidget hover hint `text-xs` still present — prior completion was inaccurate
+
+- **Detected:** 2026-04-26 (re-flagged; originally detected 2026-04-12, incorrectly closed 2026-04-14)
+- **File:** components/widgets/NumberLine/Widget.tsx:339
+- **Detail:** `className="absolute bottom-2 left-4 text-xs text-slate-400 pointer-events-none opacity-0 group-hover:opacity-100 transition-opacity"` is still present. The 2026-04-14 completion note "Resolved outside journal workflow. 2026-04-14 audit confirmed widget is clean" was inaccurate — the `text-xs` at line 339 was never removed. The hint is invisible by default (opacity-0) and only visible on hover, so impact is very low, but the pattern is inconsistent for a `skipScaling: true` widget.
+- **Fix:** Replace `text-xs` with `style={{ fontSize: 'min(12px, 6cqmin)' }}` on the hint div and remove the `bottom-2 left-4` Tailwind positional classes, replacing them with equivalent inline styles `style={{ bottom: 'min(8px, 4cqmin)', left: 'min(16px, 8cqmin)' }}`. (cqmin percentages chosen to reach the px caps at the widget's default size of 700×200, where `cqmin = 2px`; this preserves the original Tailwind dimensions at default size and only shrinks if the widget is sized smaller.)
 
 ---
 

--- a/docs/scheduled-tasks/legacy-cleanup.md
+++ b/docs/scheduled-tasks/legacy-cleanup.md
@@ -3,7 +3,7 @@
 _Audit model: claude-sonnet-4-6_
 _Action model: claude-opus-4-6_
 _Audit cadence: weekly — Thursday_
-_Last audited: 2026-04-16_
+_Last audited: 2026-04-26_
 _Last action: never_
 
 ---
@@ -27,17 +27,17 @@ _Nothing currently in progress._
 
 ## Clean (no issues found)
 
-Migration code audit (2026-04-16):
+Migration code audit (2026-04-26):
 
-- Old type strings 'timer', 'stopwatch': Only referenced in `utils/migration.ts` migrateWidget() handler — correct.
-- Old type string 'workSymbols': Zero usage outside `utils/migration.ts` — data fully migrated.
-- `migrateLocalStorageToFirestore()`: Actively called in `context/DashboardContext.tsx` lines 1065–1089 with proper guard (`!migrated`). Still needed.
+- Old type strings 'timer', 'stopwatch': Only referenced in `utils/migration.ts` migrateWidget() handler — correct. `utils/migration.ts:71-80` transforms to 'time-tool'.
+- Old type string 'workSymbols': Only referenced in `utils/migration.ts:93` — transforms to 'expectations'. Zero usage elsewhere.
+- `migrateLocalStorageToFirestore()`: Actively called in `context/DashboardContext.tsx:1092-1094` with proper guard. Still needed.
 
-Commented-out code (2026-04-16): No blocks of 10+ consecutive commented lines found in components/, context/, hooks/, or utils/.
+Commented-out code (2026-04-26): No blocks of 10+ consecutive commented lines found in components/, context/, hooks/, or utils/.
 
-Dead exports (2026-04-16): All sampled utils/ exports are actively used. No abandoned exports found.
+Dead exports (2026-04-26): No new abandoned exports found.
 
-console.log() calls (2026-04-16): Zero `console.log()` calls in components/, context/, hooks/, utils/. Only `console.error()` and `console.warn()` calls exist (by design).
+console.log() calls (2026-04-26): Zero `console.log()` calls in components/, context/, hooks/, utils/. Clean.
 
 ---
 

--- a/docs/scheduled-tasks/typescript-eslint.md
+++ b/docs/scheduled-tasks/typescript-eslint.md
@@ -3,7 +3,7 @@
 _Audit model: claude-sonnet-4-6_
 _Action model: claude-opus-4-6_
 _Audit cadence: daily_
-_Last audited: 2026-04-25_
+_Last audited: 2026-04-26_
 _Last action: never_
 
 ---
@@ -16,7 +16,7 @@ _Nothing currently in progress._
 
 ## Open
 
-_No open items. Both `pnpm type-check` and `pnpm lint` pass cleanly as of 2026-04-25. TypeScript: 0 errors. ESLint: 0 errors, 0 warnings (`--max-warnings 0`)._
+_No open items. Both `pnpm type-check` and `pnpm lint` pass cleanly as of 2026-04-26. TypeScript: 0 errors. ESLint: 0 errors, 0 warnings (`--max-warnings 0`)._
 
 ---
 

--- a/docs/scheduled-tasks/widget-registry.md
+++ b/docs/scheduled-tasks/widget-registry.md
@@ -3,8 +3,8 @@
 _Audit model: claude-sonnet-4-6_
 _Action model: claude-opus-4-6_
 _Audit cadence: daily_
-_Last audited: 2026-04-25_
-_Last action: never_
+_Last audited: 2026-04-26_
+_Last action: 2026-04-26_
 
 ---
 
@@ -15,13 +15,6 @@ _Nothing currently in progress._
 ---
 
 ## Open
-
-### LOW `sticker` widget bypasses WIDGET_COMPONENTS via WidgetRenderer special-case
-
-- **Detected:** 2026-04-12
-- **File:** components/widgets/WidgetRenderer.tsx:277, components/widgets/WidgetRegistry.ts:468
-- **Detail:** `sticker` is a valid WidgetType in types.ts and has entries in widgetDefaults.ts and WIDGET_SCALING_CONFIG, but is intentionally absent from WIDGET_COMPONENTS and WIDGET_SETTINGS_COMPONENTS. WidgetRenderer handles it via a hard-coded branch (`if (widget.type === 'sticker') return <StickerItemWidget ... />`). This special-casing bypasses the standard registry pattern and is a silent failure point if any other code looks up WIDGET_COMPONENTS['sticker'].
-- **Fix:** Either (a) register StickerItemWidget in WIDGET_COMPONENTS to normalize the pattern, or (b) add a JSDoc comment on the WIDGET_COMPONENTS object explaining the sticker exception so future developers do not accidentally rely on WIDGET_COMPONENTS being exhaustive over all WidgetTypes.
 
 ### LOW `catalyst-instruction`, `catalyst-visual` absent from config/tools.ts
 
@@ -55,4 +48,10 @@ _Nothing currently in progress._
 
 ## Completed
 
-_No completed items yet._
+### LOW `sticker` widget bypasses WIDGET_COMPONENTS via WidgetRenderer special-case
+
+- **Detected:** 2026-04-12
+- **Completed:** 2026-04-26
+- **File:** components/widgets/WidgetRegistry.ts, components/widgets/WidgetRenderer.tsx:271-273
+- **Detail:** `sticker` is a valid WidgetType in types.ts and has entries in widgetDefaults.ts and WIDGET_SCALING_CONFIG, but is intentionally absent from WIDGET_COMPONENTS and WIDGET_SETTINGS_COMPONENTS. WidgetRenderer handles it via a hard-coded branch (`if (widget.type === 'sticker') return <StickerItemWidget ... />`). This special-casing bypasses the standard registry pattern and is a silent failure point if any other code looks up WIDGET_COMPONENTS['sticker'].
+- **Resolution:** Chose option (b) — added a JSDoc block on the `WIDGET_COMPONENTS` export in `components/widgets/WidgetRegistry.ts` documenting that the map is intentionally not exhaustive over all `WidgetType`s. The note specifically calls out `sticker` (handled via the hard-coded branch in `WidgetRenderer.tsx:271-273`), warns against adding a `sticker` entry without also removing the special-case branch, and tells future developers to handle the `undefined` case at call sites. Documentation-only change — no behavioral impact, all 1476 tests still pass; `pnpm type-check`, `pnpm lint --max-warnings 0`, and `pnpm format:check` all clean.


### PR DESCRIPTION
## Summary

`sticker` is a valid `WidgetType` and has entries in `widgetDefaults.ts` and `WIDGET_SCALING_CONFIG`, but it is intentionally absent from `WIDGET_COMPONENTS` because `WidgetRenderer.tsx:271-273` handles it via a hard-coded branch:

```ts
if (widget.type === 'sticker') {
  return <StickerItemWidget widget={widget} />;
}
```

That special case was undocumented, leaving future developers no warning that `WIDGET_COMPONENTS` is not exhaustive over `WidgetType`. A reasonable assumption that `WIDGET_COMPONENTS[widgetType]` is always defined would silently break for stickers.

This PR adds a JSDoc block on the `WIDGET_COMPONENTS` export that:

- Documents the sticker exception and points at the special-case branch in `WidgetRenderer.tsx`.
- Warns against adding a `sticker` entry without also removing the special-case branch.
- Reminds callers to handle the `undefined` case.

Resolves the LOW open item _"sticker widget bypasses WIDGET_COMPONENTS via WidgetRenderer special-case"_ in `docs/scheduled-tasks/widget-registry.md` (detected 2026-04-12). Journal entry moved to **Completed**.

## Test plan

- [x] `pnpm run type-check` — clean
- [x] `pnpm run lint` (`--max-warnings 0`) — clean
- [x] `pnpm prettier --check` on changed files — clean
- [x] `pnpm run test --run` — 1476/1476 passing
- [x] Documentation-only change to `WIDGET_COMPONENTS` — no behavioral impact

https://claude.ai/code/session_01La6nRspWwqbjgNRNBh5AYt

---
_Generated by [Claude Code](https://claude.ai/code/session_01La6nRspWwqbjgNRNBh5AYt)_