### PR TITLE
fix: quiz menu callback types + dialog focus on destructive variants

### DIFF
--- a/components/common/DialogContainer.tsx
+++ b/components/common/DialogContainer.tsx
@@ -203,6 +203,8 @@ const ConfirmDialog: React.FC<{
   onCancel,
 }) => {
   const cfg = getConfirmVariantConfig(variant);
+  const isDestructive =
+    variant === 'danger' || variant === 'error' || variant === 'warning';
 
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
@@ -210,7 +212,7 @@ const ConfirmDialog: React.FC<{
         e.preventDefault();
         e.stopImmediatePropagation();
         onCancel();
-      } else if (e.key === 'Enter') {
+      } else if (e.key === 'Enter' && !isDestructive) {
         e.preventDefault();
         e.stopImmediatePropagation();
         onConfirm();
@@ -219,18 +221,19 @@ const ConfirmDialog: React.FC<{
     window.addEventListener('keydown', handler, { capture: true });
     return () =>
       window.removeEventListener('keydown', handler, { capture: true });
-  }, [onConfirm, onCancel]);
+  }, [onConfirm, onCancel, isDestructive]);
 
   return (
     <DialogShell variant={variant} title={title} message={message} isConfirm>
       <button
+        autoFocus={isDestructive}
         onClick={onCancel}
         className="px-5 py-2 rounded-xl text-sm font-semibold transition-colors bg-slate-700 hover:bg-slate-600 text-slate-200"
       >
         {cancelLabel}
       </button>
       <button
-        autoFocus
+        autoFocus={!isDestructive}
         onClick={onConfirm}
         className={`px-5 py-2 rounded-xl text-sm font-semibold transition-colors ${cfg.confirmBg} ${cfg.confirmHover} ${cfg.confirmText}`}
       >

--- a/components/widgets/QuizWidget/components/QuizManager.tsx
+++ b/components/widgets/QuizWidget/components/QuizManager.tsx
@@ -256,16 +256,16 @@ interface QuizManagerProps {
   assignments?: QuizAssignment[];
   assignmentsLoading?: boolean;
   onArchiveCopyUrl?: (assignment: QuizAssignment) => void;
-  onArchiveMonitor?: (assignment: QuizAssignment) => void;
+  onArchiveMonitor?: (assignment: QuizAssignment) => void | Promise<void>;
   /** Start a paused assignment: resume + navigate to monitor. */
-  onArchiveStart?: (assignment: QuizAssignment) => void;
-  onArchiveResults?: (assignment: QuizAssignment) => void;
+  onArchiveStart?: (assignment: QuizAssignment) => void | Promise<void>;
+  onArchiveResults?: (assignment: QuizAssignment) => void | Promise<void>;
   onArchiveEditSettings?: (assignment: QuizAssignment) => void;
-  onArchiveShare?: (assignment: QuizAssignment) => void;
-  onArchivePauseResume?: (assignment: QuizAssignment) => void;
+  onArchiveShare?: (assignment: QuizAssignment) => void | Promise<void>;
+  onArchivePauseResume?: (assignment: QuizAssignment) => void | Promise<void>;
   onArchiveDeactivate?: (assignment: QuizAssignment) => void | Promise<void>;
   /** Reopen an ended assignment back to a paused state. */
-  onArchiveReopen?: (assignment: QuizAssignment) => void;
+  onArchiveReopen?: (assignment: QuizAssignment) => void | Promise<void>;
   onArchiveDelete?: (assignment: QuizAssignment) => void | Promise<void>;
   /** Persist the library grid/list toggle into widget config. */
   onLibraryViewModeChange?: (mode: 'grid' | 'list') => void;
@@ -561,12 +561,12 @@ export const QuizManager: React.FC<QuizManagerProps> = ({
         ? {
             label: 'Monitor',
             icon: Monitor,
-            onClick: () => (onArchiveMonitor ?? noop)(a),
+            onClick: () => void (onArchiveMonitor ?? noop)(a),
           }
         : {
             label: 'Start',
             icon: Rocket,
-            onClick: () => (onArchiveStart ?? noop)(a),
+            onClick: () => void (onArchiveStart ?? noop)(a),
           };
 
       secondaries.push({
@@ -581,14 +581,14 @@ export const QuizManager: React.FC<QuizManagerProps> = ({
           id: 'monitor',
           label: 'Monitor',
           icon: Monitor,
-          onClick: () => (onArchiveMonitor ?? noop)(a),
+          onClick: () => void (onArchiveMonitor ?? noop)(a),
         });
       }
       secondaries.push({
         id: 'results',
         label: 'Results',
         icon: BarChart3,
-        onClick: () => (onArchiveResults ?? noop)(a),
+        onClick: () => void (onArchiveResults ?? noop)(a),
       });
       secondaries.push({
         id: 'settings',
@@ -600,14 +600,14 @@ export const QuizManager: React.FC<QuizManagerProps> = ({
         id: 'share',
         label: 'Share',
         icon: Share2,
-        onClick: () => (onArchiveShare ?? noop)(a),
+        onClick: () => void (onArchiveShare ?? noop)(a),
       });
       if (isActive) {
         secondaries.push({
           id: 'pause',
           label: 'Pause',
           icon: Pause,
-          onClick: () => (onArchivePauseResume ?? noop)(a),
+          onClick: () => void (onArchivePauseResume ?? noop)(a),
         });
       }
       secondaries.push({
@@ -655,13 +655,13 @@ export const QuizManager: React.FC<QuizManagerProps> = ({
     const primary = {
       label: 'Results',
       icon: BarChart3,
-      onClick: () => (onArchiveResults ?? noop)(a),
+      onClick: () => void (onArchiveResults ?? noop)(a),
     };
     secondaries.push({
       id: 'monitor',
       label: 'Monitor',
       icon: Monitor,
-      onClick: () => (onArchiveMonitor ?? noop)(a),
+      onClick: () => void (onArchiveMonitor ?? noop)(a),
     });
     secondaries.push({
       id: 'settings',
@@ -673,13 +673,13 @@ export const QuizManager: React.FC<QuizManagerProps> = ({
       id: 'share',
       label: 'Share',
       icon: Share2,
-      onClick: () => (onArchiveShare ?? noop)(a),
+      onClick: () => void (onArchiveShare ?? noop)(a),
     });
     secondaries.push({
       id: 'reopen',
       label: 'Reopen',
       icon: RefreshCw,
-      onClick: () => (onArchiveReopen ?? noop)(a),
+      onClick: () => void (onArchiveReopen ?? noop)(a),
     });
     secondaries.push({
       id: 'delete',


### PR DESCRIPTION
## Summary

Follow-up to #1420 (quiz dialog migration). Two independent hardening fixes surfaced during the post-merge review pass, bundled into one PR per request:

### 1. DialogContainer: focus Cancel & suppress Enter for destructive variants

**Problem:** Every `showConfirm` dialog auto-focuses the Confirm button, and a global keydown handler triggers `onConfirm()` on any Enter press — *including* `variant: 'danger' / 'warning' / 'error'`. A teacher hitting Enter while a Make-Inactive or Delete dialog is on screen destroys data with zero friction, with no visual indication that Enter is the destructive default.

**Fix:** For destructive variants only:
- Auto-focus the **Cancel** button instead of Confirm.
- Skip the global Enter→`onConfirm` handler. Enter on the focused Cancel cancels via native browser behavior; Enter elsewhere does nothing. (Escape still cancels everywhere.)

For `info` / `success` variants, behavior is unchanged: Confirm stays auto-focused and global Enter still triggers `onConfirm`. Affects every consumer of `showConfirm` in the app — surveyed ~30 destructive-variant callsites; this is a deliberate, app-wide UX-safety improvement, not a regression.

### 2. QuizManager: widen archive callback types & discard nav promises explicitly

**Problem:** Six archive-menu callback props were declared `(a) => void` but the implementations in `QuizWidget/Widget.tsx` are `async (a) => {...}`. The narrow type let TypeScript treat each callsite as sync, so returned promises were silently discarded — exact same latent bug Copilot flagged on `onArchiveDeactivate` / `onArchiveDelete` in #1420, but on the navigation siblings (Monitor / Start / Results / Share / PauseResume / Reopen).

**Fix:**
- Widen six prop types to `(a) => void | Promise<void>`.
- Add explicit `void` at fire-and-forget callsites — these are navigation actions where blocking the kebab menu on a network round-trip would worsen UX, so `void` (not `await`) is the right pattern. (Contrast with the destructive paths in #1420, which `await` so rejections propagate.)

`onArchiveCopyUrl` and `onArchiveEditSettings` remain `() => void` — their implementations in Widget.tsx are genuinely sync.

## Test plan

- [x] `pnpm run type-check` clean
- [x] `pnpm run lint` clean (`--max-warnings 0`)
- [x] `pnpm run format:check` clean
- [x] `pnpm run test` — 1476 tests pass (159 files)
- [ ] Manual: any `showConfirm({ variant: 'danger' })` dialog — Cancel button is focused; pressing Enter does nothing; pressing Escape cancels; clicking Confirm still confirms
- [ ] Manual: any `showConfirm({ variant: 'info' })` or no variant — Confirm button stays focused; Enter still confirms (no behavior change)
- [ ] Manual: Quiz widget kebab → Monitor / Start / Results / Share / Pause / Resume / Reopen — all still navigate correctly with no awaiting on the menu
- [ ] Manual: Make Inactive / Delete still work end-to-end (already covered by #1420 but worth re-checking with the new focus behavior)

https://claude.ai/code/session_016iJ9AFUQQCVQdsutr7kdhy

---
_Generated by [Claude Code](https://claude.ai/code/session_016iJ9AFUQQCVQdsutr7kdhy)_