### PR TITLE
fix(my-assignments): surface test-class-targeted assignments for SSO students

### DIFF
--- a/components/classes/ClassLinkImportDialog.tsx
+++ b/components/classes/ClassLinkImportDialog.tsx
@@ -14,10 +14,20 @@ import { mergeClassLinkStudents } from './mergeClassLinkStudents';
 const TEST_PREFIX = 'test:';
 
 /**
- * Build the ClassLink provenance metadata to persist on a roster document.
- * Returns `null` for test classes (they aren't real ClassLink classes and
- * must not claim `origin: 'classlink'` — they'd otherwise feed garbage
- * sourcedIds into session `classIds[]` and break the student SSO gate).
+ * Build the provenance metadata to persist on a roster document.
+ *
+ * For real ClassLink classes: stamps `origin: 'classlink'` and the full set of
+ * `classlink*` fields so downstream features (badge, merge dedup, sync) can
+ * recognize this as a ClassLink-imported roster.
+ *
+ * For admin test classes: returns only `testClassId` (the bare slug, with the
+ * `test:` prefix stripped). We deliberately do NOT set `origin: 'classlink'`
+ * or `classlinkClassId`, because the prefixed `cls.sourcedId` would corrupt
+ * real ClassLink session gates and the picker would mislabel test rosters
+ * with a "CL" badge. The bare slug routes through `deriveTargetsFromRoster
+ * List` into session `classIds[]` so test-bypass SSO students (whose custom
+ * token from `studentLoginV1` carries `classIds: [<slug>]`) can find the
+ * assignment on `/my-assignments`.
  *
  * NOTE: fields missing from `cls` (e.g., `classCode` cleared upstream) are
  * omitted rather than set to `deleteField()`, so `updateRoster` at merge
@@ -31,7 +41,9 @@ const buildClassLinkRosterMeta = (
   cls: ClassLinkClass,
   orgId: string | null | undefined
 ): Partial<ClassRosterMeta> | null => {
-  if (cls.sourcedId.startsWith(TEST_PREFIX)) return null;
+  if (cls.sourcedId.startsWith(TEST_PREFIX)) {
+    return { testClassId: cls.sourcedId.slice(TEST_PREFIX.length) };
+  }
   const meta: Partial<ClassRosterMeta> = {
     origin: 'classlink',
     classlinkClassId: cls.sourcedId,

--- a/components/classes/ClassLinkImportDialog.tsx
+++ b/components/classes/ClassLinkImportDialog.tsx
@@ -24,10 +24,10 @@ const TEST_PREFIX = 'test:';
  * `test:` prefix stripped). We deliberately do NOT set `origin: 'classlink'`
  * or `classlinkClassId`, because the prefixed `cls.sourcedId` would corrupt
  * real ClassLink session gates and the picker would mislabel test rosters
- * with a "CL" badge. The bare slug routes through `deriveTargetsFromRoster
- * List` into session `classIds[]` so test-bypass SSO students (whose custom
- * token from `studentLoginV1` carries `classIds: [<slug>]`) can find the
- * assignment on `/my-assignments`.
+ * with a "CL" badge. The bare slug routes through
+ * `deriveTargetsFromRosterList` into session `classIds[]` so test-bypass SSO
+ * students (whose custom token from `studentLoginV1` carries
+ * `classIds: [<slug>]`) can find the assignment on `/my-assignments`.
  *
  * NOTE: fields missing from `cls` (e.g., `classCode` cleared upstream) are
  * omitted rather than set to `deleteField()`, so `updateRoster` at merge

--- a/hooks/useRosters.ts
+++ b/hooks/useRosters.ts
@@ -225,13 +225,18 @@ const validateRosterMeta = (
   if (typeof d.classlinkSyncedAt === 'number') {
     meta.classlinkSyncedAt = d.classlinkSyncedAt;
   }
+  if (typeof d.testClassId === 'string') {
+    meta.testClassId = d.testClassId;
+  }
   return meta;
 };
 
 /**
- * Optional ClassLink metadata accepted by `addRoster`. Passed through to the
- * Firestore doc so assignment pickers can treat a ClassLink-imported roster as
- * the single source of truth (no more "is it ClassLink or local?" branching).
+ * Optional provenance metadata accepted by `addRoster`. Passed through to the
+ * Firestore doc so assignment pickers can treat an imported roster as the
+ * single source of truth. Carries the ClassLink fields for real ClassLink
+ * imports and `testClassId` for admin test-class imports — both feed
+ * `deriveTargetsFromRosterList` to populate session `classIds[]`.
  */
 export type RosterCreateMeta = Pick<
   ClassRosterMeta,
@@ -241,6 +246,7 @@ export type RosterCreateMeta = Pick<
   | 'classlinkSubject'
   | 'classlinkOrgId'
   | 'classlinkSyncedAt'
+  | 'testClassId'
 >;
 
 // ─── Hook ──────────────────────────────────────────────────────────────────────

--- a/tests/utils/resolveAssignmentTargets.test.ts
+++ b/tests/utils/resolveAssignmentTargets.test.ts
@@ -117,6 +117,33 @@ describe('resolveAssignmentTargets', () => {
     expect(out.classIds).toEqual(['cl-1']);
     expect(out.rosterIds).toEqual(['r1', 'r2']);
   });
+
+  it('includes testClassId in derived classIds for test-class rosters', () => {
+    // Roster imported from an admin-managed test class. The test-bypass SSO
+    // student's custom token carries `classIds: ['mock-period-1']`, so the
+    // session must surface that slug or the student sees an empty list.
+    const r1 = roster('r1', 'Mock Period 1 (test)', [s1], {
+      testClassId: 'mock-period-1',
+    });
+    const out = resolveAssignmentTargets({ rosterIds: ['r1'] }, [r1]);
+    expect(out.classIds).toEqual(['mock-period-1']);
+  });
+
+  it('merges classIds across mixed ClassLink + test-class rosters', () => {
+    const r1 = roster('r1', 'Period 1', [s1], { classlinkClassId: 'cl-1' });
+    const r2 = roster('r2', 'Mock Period 1 (test)', [s2], {
+      testClassId: 'mock-period-1',
+    });
+    const out = resolveAssignmentTargets({ rosterIds: ['r1', 'r2'] }, [r1, r2]);
+    expect(out.classIds.sort()).toEqual(['cl-1', 'mock-period-1']);
+  });
+
+  it('omits rosters with neither classlinkClassId nor testClassId', () => {
+    const r1 = roster('r1', 'Local only', [s1]); // truly local, both absent
+    const out = resolveAssignmentTargets({ rosterIds: ['r1'] }, [r1]);
+    expect(out.classIds).toEqual([]);
+    expect(out.rosterIds).toEqual(['r1']);
+  });
 });
 
 describe('deriveSessionTargetsFromRosters', () => {

--- a/types.ts
+++ b/types.ts
@@ -130,6 +130,16 @@ export interface ClassRosterMeta {
    * resolves without the assignment layer having to know about ClassLink.
    */
   classlinkClassId?: string;
+  /**
+   * Test-class slug (the `testClasses/{id}` doc id, without the `test:` prefix).
+   * Present iff the roster was imported from an admin-managed test class. Drives
+   * session `classIds[]` derivation so the test-bypass SSO student's custom-token
+   * claim (`classIds: [<slug>]`, minted by `studentLoginV1`) matches the
+   * assignment session — without claiming `origin: 'classlink'`, which would
+   * falsely tag this as a real ClassLink roster in the picker badge and merge
+   * logic.
+   */
+  testClassId?: string;
   /** ClassLink class code (e.g. "MATH-7-P3"); rendered in the picker badge tooltip. */
   classlinkClassCode?: string;
   /** ClassLink subject label; used for reconciliation and teacher-visible filters. */

--- a/utils/resolveAssignmentTargets.ts
+++ b/utils/resolveAssignmentTargets.ts
@@ -5,7 +5,8 @@
  * `classIds[]` (ClassLink-only) or local roster names under `periodNames[]`
  * (local-only). After the roster-as-single-source-of-truth unification,
  * new assignments write `rosterIds[]` — rosters imported from ClassLink carry
- * their own `classlinkClassId` metadata so the student SSO gate still works.
+ * their own `classlinkClassId` metadata, and rosters imported from admin
+ * test classes carry `testClassId`, so the student SSO gate still works.
  *
  * Legacy in-flight assignments are NOT migrated; they continue reading via
  * their existing `classIds`/`periodNames` fields until they expire.
@@ -30,9 +31,12 @@ export interface ResolvedAssignmentTargets {
   /** Roster IDs backing this assignment (empty for legacy docs). */
   rosterIds: string[];
   /**
-   * ClassLink `sourcedId`s to write onto the session doc for the student
-   * SSO gate. Empty when no selected roster has `classlinkClassId` (purely
-   * local targeting — SSO students get blocked, PIN students still pass).
+   * Class identifiers to write onto the session doc for the student SSO gate.
+   * Sourced from `classlinkClassId` (real ClassLink rosters) and `testClassId`
+   * (admin test-class imports); both end up in this same array since the
+   * student-side claim and Firestore gate read a single `classIds[]` field.
+   * Empty when no selected roster carries either (purely local targeting —
+   * SSO students get blocked, PIN students still pass).
    */
   classIds: string[];
   /** Period names (local roster names) for PIN-flow routing. */
@@ -57,7 +61,13 @@ export interface ResolvedAssignmentTargets {
  * Dedup rationale:
  * - `classIds`: two rosters can share the same `classlinkClassId` (teacher
  *   imported the same ClassLink class twice under different local names);
- *   we'd otherwise waste the Firestore rules' 20-entry budget.
+ *   we'd otherwise waste the Firestore rules' 20-entry budget. Test-class
+ *   `testClassId` slugs share this output array because the student-side SSO
+ *   gate (`MyAssignmentsPage` queries + `firestore.rules`) keys on a single
+ *   `classIds[]` field — the cloud function (`studentLoginV1`) populates the
+ *   same claim from either source. Collisions are not possible: ClassLink
+ *   sourcedIds are opaque OneRoster identifiers, test-class IDs are
+ *   admin-chosen slugs.
  * - `students`: a student enrolled in two targeted classes shouldn't appear
  *   twice in the session student list.
  * - `periodNames`: two local rosters can share a name; the student app keys
@@ -73,7 +83,7 @@ function deriveTargetsFromRosterList(rosters: ClassRoster[]): {
   const classIds = Array.from(
     new Set(
       rosters
-        .map((r) => r.classlinkClassId)
+        .flatMap((r) => [r.classlinkClassId, r.testClassId])
         .filter((id): id is string => typeof id === 'string' && id.length > 0)
     )
   );


### PR DESCRIPTION
## Summary

- Test-class roster imports were stripping the source slug, so assignments anchored to those rosters wrote no `classIds[]` and the test-bypass student's `/my-assignments` page rendered empty.
- Persist the bare slug as a new `testClassId` field on the roster meta and fold it into `deriveTargetsFromRosterList` alongside ClassLink sourcedIds.
- Kept `testClassId` separate from `classlinkClassId` so the picker keeps the TEST label and merge logic doesn't see a phantom ClassLink roster.

## Why

`buildClassLinkRosterMeta` was returning `null` for test classes by design — the prefixed `test:` sourcedId would have polluted real ClassLink session gates if treated as a `classlinkClassId`. But that mitigation also dropped the slug entirely, breaking the link between the student's `studentLoginV1` token claim (`classIds: ["mock-period-1"]`) and the assignment session doc (which had no `classIds` field set at all). End state: the bypass-SSO student saw `/my-assignments` but no assignments, blocking QA of the entire student-side assignment flow.

## Files changed

- `types.ts` — add `testClassId?: string` to `ClassRosterMeta`
- `components/classes/ClassLinkImportDialog.tsx` — return `{ testClassId }` for test-class imports instead of `null`
- `utils/resolveAssignmentTargets.ts` — include `r.testClassId` in derived `classIds[]`
- `hooks/useRosters.ts` — read `testClassId` from Firestore and accept it in `RosterCreateMeta`
- `tests/utils/resolveAssignmentTargets.test.ts` — three new cases covering test-class rosters

No changes to: Firestore rules, the `studentLoginV1` cloud function, the student page query, the assignment-creation hooks, or the picker.

## Test plan

- [x] `pnpm run validate` — type-check, lint, format-check, all 1,501 root tests + 189 functions tests pass
- [ ] Sidebar > My Classes — **delete & re-import** the existing "Mock Period 1 (Paul QA) (test)" roster (existing roster has no `testClassId` because it was created before this fix)
- [ ] Verify in Firestore that the new roster doc has `testClassId: "mock-period-1"` and **no** `classlinkClassId`/`origin`
- [ ] Create an active quiz assignment targeting the re-imported roster
- [ ] Verify `/quiz_sessions/{sessionId}` has `classIds: ["mock-period-1"]` and `classId: "mock-period-1"`
- [ ] Sign in (incognito) as `sstudent25@orono.k12.mn.us` at `/join` → quiz appears on `/my-assignments`
- [ ] Smoke-test one other assignment type (video activity, mini-app, guided-learning, or activity-wall) — they all share the same derivation path

🤖 Generated with [Claude Code](https://claude.com/claude-code)