### PR TITLE
feat(quiz): skip PIN entry for SSO students from /my-assignments

### DIFF
--- a/components/quiz/QuizPausedPlaceholder.tsx
+++ b/components/quiz/QuizPausedPlaceholder.tsx
@@ -10,6 +10,7 @@ import { QuizSession } from '@/types';
 
 interface QuizPausedPlaceholderProps {
   session: QuizSession;
+  /** Roster PIN for anonymous joiners. Empty for SSO `studentRole` joiners. */
   pin: string;
 }
 
@@ -29,11 +30,13 @@ export const QuizPausedPlaceholder: React.FC<QuizPausedPlaceholderProps> = ({
       Your teacher will resume the session shortly. Keep this tab open — your
       place is saved.
     </p>
-    <div className="p-4 bg-slate-800 rounded-xl">
-      <p className="text-slate-300 text-sm">
-        Joined as PIN{' '}
-        <span className="font-semibold text-white font-mono">{pin}</span>
-      </p>
-    </div>
+    {pin && (
+      <div className="p-4 bg-slate-800 rounded-xl">
+        <p className="text-slate-300 text-sm">
+          Joined as PIN{' '}
+          <span className="font-semibold text-white font-mono">{pin}</span>
+        </p>
+      </div>
+    )}
   </div>
 );

--- a/components/quiz/QuizStudentApp.tsx
+++ b/components/quiz/QuizStudentApp.tsx
@@ -125,6 +125,11 @@ const QuizJoinFlow: React.FC<{ isStudentRole: boolean }> = ({
   // below from triggering twice in StrictMode and keeps the form invisible
   // while the lookup+join is in flight.
   const ssoAutoJoinStartedRef = useRef(false);
+  // Local error state for SSO auto-join. The hook's `error` state only fires
+  // from `joinQuizSession` itself; if `lookupSession` throws first (network
+  // failure, Firestore unavailable) the hook stays silent, so without this
+  // the student would sit on the "Joining quiz…" loader forever.
+  const [ssoAutoJoinError, setSsoAutoJoinError] = useState<string | null>(null);
 
   const {
     session,
@@ -186,9 +191,16 @@ const QuizJoinFlow: React.FC<{ isStudentRole: boolean }> = ({
         await joinQuizSession(urlCode, undefined, autoClassPeriod);
         setJoined(true);
       } catch (err) {
-        // The hook's `error` state surfaces the message in the UI; we only
-        // log here to aid debugging shared-device sign-in issues.
         console.warn('[QuizStudentApp] SSO auto-join failed:', err);
+        // Surface the failure to the UI. Either step (lookupSession or
+        // joinQuizSession) can throw; if it was joinQuizSession the hook's
+        // own `error` state will also be populated, and the render branch
+        // below prefers that more detailed message when available.
+        const message =
+          err instanceof Error
+            ? err.message
+            : "We couldn't load your quiz. Please refresh and try again.";
+        setSsoAutoJoinError(message);
         // Re-arm so a retry button (if added later) can re-trigger.
         ssoAutoJoinStartedRef.current = false;
       }
@@ -293,16 +305,21 @@ const QuizJoinFlow: React.FC<{ isStudentRole: boolean }> = ({
   // Not yet joined
   if (!joined || !session) {
     // SSO students never see the PIN form — the auto-join effect above
-    // handles them. Show a quiet loader (or the error if lookup failed)
-    // until `joined` flips. Periods picker is rendered earlier in the
-    // function and short-circuits before we reach this branch.
+    // handles them. Show a quiet loader (or the error if lookup/join
+    // failed) until `joined` flips. Periods picker is rendered earlier in
+    // the function and short-circuits before we reach this branch.
+    //
+    // Prefer the hook's `error` (more specific, e.g. attempt-limit reached)
+    // when available, falling back to `ssoAutoJoinError` which captures
+    // failures from `lookupSession` that never reach the hook.
     if (isStudentRole) {
-      if (error) {
+      const ssoError = error ?? ssoAutoJoinError;
+      if (ssoError) {
         return (
           <div className="min-h-screen bg-slate-900 flex flex-col items-center justify-center gap-4 p-6">
             <AlertCircle className="w-10 h-10 text-red-400" />
             <p className="text-slate-300 text-sm text-center max-w-sm">
-              {error}
+              {ssoError}
             </p>
           </div>
         );

--- a/components/quiz/QuizStudentApp.tsx
+++ b/components/quiz/QuizStudentApp.tsx
@@ -2,12 +2,18 @@
  * QuizStudentApp — the student-facing quiz experience.
  * Accessible at /quiz?code=XXXXXX
  *
- * Flow:
- *  1. Student must sign in with Google (org email required)
- *  2. Student enters a quiz code (or picks it up from URL param)
- *  3. Student waits in lobby for teacher to start
- *  4. Questions are shown one by one as teacher advances
- *  5. Student submits answers; teacher sees results
+ * Flow (anonymous /join):
+ *  1. Student is signed in anonymously on mount (no UI).
+ *  2. Student enters quiz code + their roster PIN.
+ *  3. Student waits in lobby for teacher to start.
+ *  4. Questions are shown one by one as teacher advances.
+ *  5. Student submits answers; teacher sees results.
+ *
+ * Flow (SSO `studentRole` from /my-assignments):
+ *  1. Student is already signed in via custom token (claims.studentRole).
+ *  2. Code is in the URL; PIN is unnecessary — identity = `auth.uid`.
+ *  3. We auto-join on mount (still showing the period picker for
+ *     multi-period sessions) and proceed straight to the waiting room.
  */
 
 import React, { useState, useEffect, useCallback, useRef } from 'react';
@@ -47,21 +53,35 @@ import {
 export const QuizStudentApp: React.FC = () => {
   const [authReady, setAuthReady] = useState(false);
   const [authFailed, setAuthFailed] = useState(false);
+  // True iff `auth.currentUser` carries the `studentRole: true` custom claim
+  // minted by `studentLoginV1`. Resolved at mount; used to drive the
+  // auto-join branch in `QuizJoinFlow`. Anonymous joiners stay `false`.
+  const [isStudentRole, setIsStudentRole] = useState(false);
 
-  // Sign in anonymously on mount — no user interaction required.
-  // This satisfies Firestore security rules (request.auth != null) without
-  // storing any student PII in Firebase Authentication.
+  // Sign in anonymously on mount only when nobody is signed in yet — SSO
+  // students arriving from `/my-assignments` already have a custom-token
+  // user we must keep. This satisfies Firestore security rules
+  // (`request.auth != null`) for direct `/quiz?code=…` visitors.
   useEffect(() => {
     const init = async () => {
-      if (!auth.currentUser) {
-        try {
+      try {
+        if (!auth.currentUser) {
           await signInAnonymously(auth);
-        } catch (err) {
-          console.warn('[QuizStudentApp] Anonymous auth failed:', err);
-          setAuthFailed(true);
         }
+        const user = auth.currentUser;
+        if (user && !user.isAnonymous) {
+          // Probe custom claims once. We don't refresh here — `studentLoginV1`
+          // is what minted these, and a stale token is fine for read-only
+          // identity. The Firestore rules re-validate on every write.
+          const tokenResult = await user.getIdTokenResult();
+          setIsStudentRole(tokenResult.claims?.studentRole === true);
+        }
+      } catch (err) {
+        console.warn('[QuizStudentApp] Auth init failed:', err);
+        setAuthFailed(true);
+      } finally {
+        setAuthReady(true);
       }
-      setAuthReady(true);
     };
     void init();
   }, []);
@@ -81,12 +101,14 @@ export const QuizStudentApp: React.FC = () => {
     );
   }
 
-  return <QuizJoinFlow />;
+  return <QuizJoinFlow isStudentRole={isStudentRole} />;
 };
 
 // ─── Join flow ────────────────────────────────────────────────────────────────
 
-const QuizJoinFlow: React.FC = () => {
+const QuizJoinFlow: React.FC<{ isStudentRole: boolean }> = ({
+  isStudentRole,
+}) => {
   const params = new URLSearchParams(window.location.search);
   const urlCode = params.get('code') ?? '';
 
@@ -98,6 +120,11 @@ const QuizJoinFlow: React.FC = () => {
   // multiple periodNames the student picks their class before joining.
   const [periodStep, setPeriodStep] = useState<string[] | null>(null);
   const [selectedPeriod, setSelectedPeriod] = useState<string | null>(null);
+
+  // SSO joiners auto-join on mount (no PIN). This guard prevents the effect
+  // below from triggering twice in StrictMode and keeps the form invisible
+  // while the lookup+join is in flight.
+  const ssoAutoJoinStartedRef = useRef(false);
 
   const {
     session,
@@ -131,9 +158,50 @@ const QuizJoinFlow: React.FC = () => {
 
   const handlePeriodConfirm = useCallback(async () => {
     if (!selectedPeriod) return;
-    await joinQuizSession(code, pin, selectedPeriod);
+    // SSO joiners pass `undefined` as the PIN — the hook keys the response
+    // doc by auth.uid in that case. Anonymous joiners send the form `pin`.
+    const joinPin = isStudentRole ? undefined : pin;
+    await joinQuizSession(code, joinPin, selectedPeriod);
     setJoined(true);
-  }, [joinQuizSession, code, pin, selectedPeriod]);
+  }, [joinQuizSession, code, pin, selectedPeriod, isStudentRole]);
+
+  // SSO auto-join: bypass the PIN form entirely. lookupSession handles the
+  // multi-period branch (we still show the picker — periodNames are
+  // free-form labels and don't map 1:1 onto classIds, so we can't auto-pick).
+  useEffect(() => {
+    if (!isStudentRole) return;
+    if (!urlCode) return;
+    if (joined || periodStep) return;
+    if (ssoAutoJoinStartedRef.current) return;
+    ssoAutoJoinStartedRef.current = true;
+
+    const run = async () => {
+      try {
+        const sessionInfo = await lookupSession(urlCode);
+        if (sessionInfo && sessionInfo.periodNames.length > 1) {
+          setPeriodStep(sessionInfo.periodNames);
+          return;
+        }
+        const autoClassPeriod = sessionInfo?.periodNames[0];
+        await joinQuizSession(urlCode, undefined, autoClassPeriod);
+        setJoined(true);
+      } catch (err) {
+        // The hook's `error` state surfaces the message in the UI; we only
+        // log here to aid debugging shared-device sign-in issues.
+        console.warn('[QuizStudentApp] SSO auto-join failed:', err);
+        // Re-arm so a retry button (if added later) can re-trigger.
+        ssoAutoJoinStartedRef.current = false;
+      }
+    };
+    void run();
+  }, [
+    isStudentRole,
+    urlCode,
+    joined,
+    periodStep,
+    lookupSession,
+    joinQuizSession,
+  ]);
 
   const handleAnswer = useCallback(
     async (questionId: string, answer: string, speedBonus?: number) => {
@@ -224,6 +292,23 @@ const QuizJoinFlow: React.FC = () => {
 
   // Not yet joined
   if (!joined || !session) {
+    // SSO students never see the PIN form — the auto-join effect above
+    // handles them. Show a quiet loader (or the error if lookup failed)
+    // until `joined` flips. Periods picker is rendered earlier in the
+    // function and short-circuits before we reach this branch.
+    if (isStudentRole) {
+      if (error) {
+        return (
+          <div className="min-h-screen bg-slate-900 flex flex-col items-center justify-center gap-4 p-6">
+            <AlertCircle className="w-10 h-10 text-red-400" />
+            <p className="text-slate-300 text-sm text-center max-w-sm">
+              {error}
+            </p>
+          </div>
+        );
+      }
+      return <FullPageLoader message="Joining quiz…" />;
+    }
     return (
       <div className="min-h-screen bg-slate-900 flex flex-col items-center justify-center p-6">
         <div className="w-full max-w-sm">
@@ -357,6 +442,7 @@ const QuizJoinFlow: React.FC = () => {
       answeredCount={(myResponse?.answers ?? []).length}
       totalQuestions={session.totalQuestions}
       pin={pin}
+      myStudentUid={myResponse?.studentUid}
     />
   );
 };
@@ -365,6 +451,7 @@ const QuizJoinFlow: React.FC = () => {
 
 const WaitingRoom: React.FC<{
   session: QuizSession;
+  /** Empty string for SSO `studentRole` joiners — PIN line is hidden. */
   pin: string;
 }> = ({ session, pin }) => (
   <div className="min-h-screen bg-slate-900 flex flex-col items-center justify-center p-6 text-center">
@@ -378,12 +465,14 @@ const WaitingRoom: React.FC<{
     <p className="text-slate-500 text-xs mb-8">
       {session.totalQuestions} questions
     </p>
-    <div className="p-4 bg-slate-800 rounded-xl">
-      <p className="text-slate-300 text-sm">
-        Joined as PIN{' '}
-        <span className="font-semibold text-white font-mono">{pin}</span>
-      </p>
-    </div>
+    {pin && (
+      <div className="p-4 bg-slate-800 rounded-xl">
+        <p className="text-slate-300 text-sm">
+          Joined as PIN{' '}
+          <span className="font-semibold text-white font-mono">{pin}</span>
+        </p>
+      </div>
+    )}
   </div>
 );
 
@@ -1327,6 +1416,7 @@ const ReviewPhase: React.FC<{
           <StudentLeaderboard
             entries={session.liveLeaderboard}
             myPin={myResponse?.pin ?? ''}
+            myStudentUid={myResponse?.studentUid}
             scoreSuffix={getScoreSuffix(session)}
           />
           <div className="flex items-center gap-2 text-slate-500 text-sm">
@@ -1349,13 +1439,21 @@ const ResultsScreen: React.FC<{
   answeredCount: number;
   totalQuestions: number;
   pin: string;
-}> = ({ session, answeredCount, totalQuestions, pin }) => (
+  /** Auth uid — used by `StudentLeaderboard` to highlight the SSO student's row. */
+  myStudentUid?: string;
+}> = ({ session, answeredCount, totalQuestions, pin, myStudentUid }) => (
   <div className="min-h-screen bg-slate-900 flex flex-col items-center justify-center p-6 text-center">
     <Trophy className="w-16 h-16 text-amber-400 mb-6" />
     <h1 className="text-3xl font-black text-white mb-2">Quiz Complete!</h1>
     <p className="text-slate-400 text-sm mb-8">
-      Great job, PIN{' '}
-      <span className="font-mono font-bold text-white">{pin}</span>!
+      {pin ? (
+        <>
+          Great job, PIN{' '}
+          <span className="font-mono font-bold text-white">{pin}</span>!
+        </>
+      ) : (
+        'Great job!'
+      )}
     </p>
 
     <div className="mb-8 p-6 bg-slate-800 rounded-2xl">
@@ -1374,6 +1472,7 @@ const ResultsScreen: React.FC<{
         <StudentLeaderboard
           entries={session.liveLeaderboard}
           myPin={pin}
+          myStudentUid={myStudentUid}
           scoreSuffix={getScoreSuffix(session)}
         />
       </div>
@@ -1396,8 +1495,14 @@ const QuizSubmittedWaitScreen: React.FC<{
       <CheckCircle2 className="w-16 h-16 text-emerald-400 mb-6" />
       <h1 className="text-3xl font-black text-white mb-2">Quiz Submitted!</h1>
       <p className="text-slate-400 text-sm mb-6">
-        Great work, PIN{' '}
-        <span className="font-mono font-bold text-white">{pin}</span>.
+        {pin ? (
+          <>
+            Great work, PIN{' '}
+            <span className="font-mono font-bold text-white">{pin}</span>.
+          </>
+        ) : (
+          'Great work.'
+        )}
       </p>
 
       <div className="mb-6 p-5 bg-slate-800 rounded-2xl">
@@ -1420,6 +1525,7 @@ const QuizSubmittedWaitScreen: React.FC<{
           <StudentLeaderboard
             entries={session.liveLeaderboard}
             myPin={pin}
+            myStudentUid={myResponse.studentUid}
             scoreSuffix={scoreSuffix}
           />
         </div>

--- a/components/quiz/StudentLeaderboard.tsx
+++ b/components/quiz/StudentLeaderboard.tsx
@@ -51,10 +51,10 @@ export const StudentLeaderboard: React.FC<StudentLeaderboardProps> = ({
     matchesMe(entry, myPin, myStudentUid)
   );
   const topFive = entries.slice(0, 5);
-  const isMyPinInTopFive = topFive.some((entry) =>
+  const isMeInTopFive = topFive.some((entry) =>
     matchesMe(entry, myPin, myStudentUid)
   );
-  const rows = isMyPinInTopFive
+  const rows = isMeInTopFive
     ? topFive
     : myEntry
       ? [...entries.slice(0, 4), myEntry]
@@ -68,7 +68,7 @@ export const StudentLeaderboard: React.FC<StudentLeaderboardProps> = ({
       <div className="space-y-2">
         {rows.map((entry, index) => {
           const isMine = matchesMe(entry, myPin, myStudentUid);
-          const showDivider = !isMyPinInTopFive && index === 4;
+          const showDivider = !isMeInTopFive && index === 4;
           // Stable per-entry key: pin for anonymous joiners, studentUid for
           // SSO joiners. Combined with rank to disambiguate in the rare case
           // of duplicate identifiers (e.g. legacy data).

--- a/components/quiz/StudentLeaderboard.tsx
+++ b/components/quiz/StudentLeaderboard.tsx
@@ -5,7 +5,13 @@ import { QuizLeaderboardEntry } from '@/types';
 
 interface StudentLeaderboardProps {
   entries: QuizLeaderboardEntry[];
+  /** Roster PIN for anonymous joiners. Empty for SSO joiners. */
   myPin: string;
+  /**
+   * Auth uid for SSO `studentRole` joiners. Used as a fallback identity
+   * when `myPin` is empty so SSO students still see "(you)" on their row.
+   */
+  myStudentUid?: string;
   scoreSuffix: string;
 }
 
@@ -15,9 +21,20 @@ const medalByRank: Record<number, string> = {
   3: 'text-orange-500',
 };
 
+const matchesMe = (
+  entry: QuizLeaderboardEntry,
+  myPin: string,
+  myStudentUid: string | undefined
+): boolean => {
+  if (myPin && entry.pin === myPin) return true;
+  if (myStudentUid && entry.studentUid === myStudentUid) return true;
+  return false;
+};
+
 export const StudentLeaderboard: React.FC<StudentLeaderboardProps> = ({
   entries,
   myPin,
+  myStudentUid,
   scoreSuffix,
 }) => {
   const { t } = useTranslation();
@@ -30,9 +47,13 @@ export const StudentLeaderboard: React.FC<StudentLeaderboardProps> = ({
     );
   }
 
-  const myEntry = entries.find((entry) => entry.pin === myPin);
+  const myEntry = entries.find((entry) =>
+    matchesMe(entry, myPin, myStudentUid)
+  );
   const topFive = entries.slice(0, 5);
-  const isMyPinInTopFive = topFive.some((entry) => entry.pin === myPin);
+  const isMyPinInTopFive = topFive.some((entry) =>
+    matchesMe(entry, myPin, myStudentUid)
+  );
   const rows = isMyPinInTopFive
     ? topFive
     : myEntry
@@ -46,11 +67,15 @@ export const StudentLeaderboard: React.FC<StudentLeaderboardProps> = ({
       </p>
       <div className="space-y-2">
         {rows.map((entry, index) => {
-          const isMine = entry.pin === myPin;
+          const isMine = matchesMe(entry, myPin, myStudentUid);
           const showDivider = !isMyPinInTopFive && index === 4;
+          // Stable per-entry key: pin for anonymous joiners, studentUid for
+          // SSO joiners. Combined with rank to disambiguate in the rare case
+          // of duplicate identifiers (e.g. legacy data).
+          const entryKey = `${entry.pin ?? entry.studentUid ?? 'anon'}-${entry.rank}`;
 
           return (
-            <React.Fragment key={entry.pin}>
+            <React.Fragment key={entryKey}>
               {showDivider && (
                 <div className="text-center text-slate-500 text-xs py-1">…</div>
               )}
@@ -69,7 +94,7 @@ export const StudentLeaderboard: React.FC<StudentLeaderboardProps> = ({
                   </span>
                 )}
                 <span className="flex-1 text-sm font-semibold text-white truncate">
-                  {entry.name ?? `PIN ${entry.pin}`}
+                  {entry.name ?? (entry.pin ? `PIN ${entry.pin}` : 'Student')}
                   {isMine ? ` ${t('widgets.quiz.leaderboard.youSuffix')}` : ''}
                 </span>
                 <span className="text-amber-300 text-sm font-black">

--- a/components/widgets/QuizWidget/Widget.tsx
+++ b/components/widgets/QuizWidget/Widget.tsx
@@ -30,6 +30,12 @@ import {
   getEarnedPoints,
   isGamificationActive,
 } from './utils/quizScoreboard';
+import {
+  resolveResponseDisplayName,
+  responseTeamId,
+  responseColorIndex,
+} from './utils/resolveDisplayName';
+import { useAssignmentPseudonymsMulti } from '@/hooks/useAssignmentPseudonyms';
 import { QuizLiveMonitor } from './components/QuizLiveMonitor';
 import { Loader2, AlertTriangle, LogIn } from 'lucide-react';
 import { SCOREBOARD_COLORS } from '@/config/scoreboard';
@@ -199,6 +205,23 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
   const widgetsRef = useRef(activeDashboard?.widgets);
   widgetsRef.current = activeDashboard?.widgets;
 
+  // ClassLink name lookup for SSO `studentRole` joiners. The live scoreboard
+  // sync below runs inside a debounced callback that captures the latest
+  // map via `byStudentUidRef`, so name resolution stays current without
+  // having to make `byStudentUid` a sync trigger.
+  const liveClassIds =
+    liveSession?.classIds && liveSession.classIds.length > 0
+      ? liveSession.classIds
+      : liveSession?.classId
+        ? [liveSession.classId]
+        : [];
+  const { byStudentUid } = useAssignmentPseudonymsMulti(
+    liveSession?.id ?? null,
+    liveClassIds
+  );
+  const byStudentUidRef = useRef(byStudentUid);
+  byStudentUidRef.current = byStudentUid;
+
   // ─── Callback for child components to update quiz config ────────────────────
   const handleUpdateQuizConfig = useCallback(
     (updates: Partial<QuizConfig>) => {
@@ -217,11 +240,13 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
     }
 
     // Compute a fingerprint including answer content to detect changes.
-    // First-run detection uses the empty-prev check below.
+    // First-run detection uses the empty-prev check below. Use studentUid
+    // as the row identity since SSO joiners have no `pin` — anonymous
+    // joiners' studentUid is their (stable) anon Firebase Auth uid.
     const fingerprint = responses
       .map(
         (r) =>
-          `${r.pin}:${r.status}:${r.answers.map((a) => `${a.questionId}=${a.answer}@${a.answeredAt ?? 0}+${a.speedBonus ?? 0}`).join(',')}`
+          `${r.studentUid}:${r.status}:${r.answers.map((a) => `${a.questionId}=${a.answer}@${a.answeredAt ?? 0}+${a.speedBonus ?? 0}`).join(',')}`
       )
       .sort()
       .join('|');
@@ -260,6 +285,12 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
           // by total points and would show low percentages for students mid-quiz.
           const questions = loadedQuizData.questions;
           const gamified = isGamificationActive(liveSession);
+          // SSO `studentRole` rows have no `pin` — fall back to studentUid
+          // for both the team id and the color hash, and pull names from
+          // the ClassLink lookup. `byStudentUidRef.current` is the latest
+          // map, captured here so we don't need to wire it as a debounce
+          // dependency.
+          const ssoNames = byStudentUidRef.current;
           newTeams = allResponses
             .map((r) => {
               let maxAnsweredPoints = 0;
@@ -277,18 +308,25 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
               return { response: r, score };
             })
             .sort((a, b) => b.score - a.score)
-            .map(({ response, score }) => ({
-              id: `pin-${response.pin}`,
-              name:
-                displayMode === 'name'
-                  ? (pinToName[response.pin] ?? `PIN ${response.pin}`)
-                  : `PIN ${response.pin}`,
-              score,
-              color:
-                SCOREBOARD_COLORS[
-                  parseInt(response.pin, 10) % SCOREBOARD_COLORS.length
-                ],
-            }));
+            .map(({ response, score }) => {
+              const resolvedName = resolveResponseDisplayName(
+                response,
+                pinToName,
+                ssoNames
+              );
+              const pinModeName = response.pin
+                ? `PIN ${response.pin}`
+                : resolvedName;
+              return {
+                id: responseTeamId(response),
+                name: displayMode === 'name' ? resolvedName : pinModeName,
+                score,
+                color:
+                  SCOREBOARD_COLORS[
+                    responseColorIndex(response, SCOREBOARD_COLORS.length)
+                  ],
+              };
+            });
         } else {
           // Completion mode: uses total quiz points as denominator, so
           // in-progress students show partial scores proportional to
@@ -298,7 +336,8 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
             loadedQuizData.questions,
             displayMode,
             pinToName,
-            liveSession
+            liveSession,
+            byStudentUidRef.current
           );
         }
 

--- a/components/widgets/QuizWidget/components/QuizLiveMonitor.tsx
+++ b/components/widgets/QuizWidget/components/QuizLiveMonitor.tsx
@@ -54,6 +54,8 @@ import {
   getScoreSuffix,
   isGamificationActive,
 } from '../utils/quizScoreboard';
+import { resolveResponseDisplayName } from '../utils/resolveDisplayName';
+import { useAssignmentPseudonymsMulti } from '@/hooks/useAssignmentPseudonyms';
 import { db } from '@/config/firebase';
 import { useDialog } from '@/context/useDialog';
 import { useClickOutside } from '@/hooks/useClickOutside';
@@ -272,6 +274,20 @@ export const QuizLiveMonitor: React.FC<QuizLiveMonitorProps> = ({
       ),
     [rosters, config.periodNames, config.periodName]
   );
+  // ClassLink name resolution for SSO `studentRole` joiners. Empty for
+  // legacy code+PIN-only sessions (`classIds` and `classId` both unset);
+  // pinToName handles those rows. Use the multi variant so Phase 5A
+  // multi-class quizzes resolve names from any targeted class, not just
+  // the legacy `classIds[0]` shadowed onto `classId`.
+  const sessionClassIds = useMemo(() => {
+    if (session.classIds && session.classIds.length > 0)
+      return session.classIds;
+    return session.classId ? [session.classId] : [];
+  }, [session.classIds, session.classId]);
+  const { byStudentUid } = useAssignmentPseudonymsMulti(
+    session.id,
+    sessionClassIds
+  );
   const scoringConfig = useMemo(
     () => ({
       speedBonusEnabled: session.speedBonusEnabled,
@@ -356,7 +372,8 @@ export const QuizLiveMonitor: React.FC<QuizLiveMonitorProps> = ({
         responses,
         quizData.questions,
         scoringConfig,
-        pinToName
+        pinToName,
+        byStudentUid
       );
 
       const fingerprint = JSON.stringify(entries);
@@ -376,6 +393,7 @@ export const QuizLiveMonitor: React.FC<QuizLiveMonitorProps> = ({
     responses,
     quizData.questions,
     pinToName,
+    byStudentUid,
     session.id,
     session.status,
     scoringConfig,
@@ -523,25 +541,32 @@ export const QuizLiveMonitor: React.FC<QuizLiveMonitorProps> = ({
       let _inProgress = 0;
       let _joined = 0;
       const byStatus: {
-        joined: { pin: string; name: string }[];
-        active: { pin: string; name: string }[];
-        finished: { pin: string; name: string }[];
+        joined: StatBoxStudent[];
+        active: StatBoxStudent[];
+        finished: StatBoxStudent[];
       } = { joined: [], active: [], finished: [] };
 
       for (const r of responses) {
         if (currentQ && r.answers.some((a) => a.questionId === currentQ.id)) {
           _answered++;
         }
-        const name = pinToName[r.pin] ?? `PIN ${r.pin}`;
+        const name = resolveResponseDisplayName(r, pinToName, byStudentUid);
+        // SSO joiners have no PIN — key the stat-row by studentUid so React
+        // gets a stable, unique key. Either side guarantees uniqueness
+        // within a session.
+        const row: StatBoxStudent = {
+          key: r.pin ?? r.studentUid,
+          name,
+        };
         if (r.status === 'completed') {
           _completed++;
-          byStatus.finished.push({ pin: r.pin, name });
+          byStatus.finished.push(row);
         } else if (r.status === 'in-progress') {
           _inProgress++;
-          byStatus.active.push({ pin: r.pin, name });
+          byStatus.active.push(row);
         } else if (r.status === 'joined') {
           _joined++;
-          byStatus.joined.push({ pin: r.pin, name });
+          byStatus.joined.push(row);
         }
       }
 
@@ -552,7 +577,7 @@ export const QuizLiveMonitor: React.FC<QuizLiveMonitorProps> = ({
         joined: _joined,
         studentsByStatus: byStatus,
       };
-    }, [responses, currentQ, pinToName]);
+    }, [responses, currentQ, pinToName, byStudentUid]);
 
   const modeIcon =
     session.sessionMode === 'auto' ? (
@@ -986,6 +1011,7 @@ export const QuizLiveMonitor: React.FC<QuizLiveMonitorProps> = ({
                   questions={quizData.questions}
                   session={session}
                   pinToName={pinToName}
+                  byStudentUid={byStudentUid}
                   onDismiss={() => {
                     /* persists until teacher clicks advance */
                   }}
@@ -1293,7 +1319,9 @@ export const QuizLiveMonitor: React.FC<QuizLiveMonitorProps> = ({
                     >
                       {responses
                         .slice()
-                        .sort((a, b) => a.pin.localeCompare(b.pin))
+                        .sort((a, b) =>
+                          (a.pin ?? '').localeCompare(b.pin ?? '')
+                        )
                         .map((r) => (
                           <StudentRow
                             key={r.studentUid}
@@ -1326,6 +1354,7 @@ export const QuizLiveMonitor: React.FC<QuizLiveMonitorProps> = ({
                                 : undefined
                             }
                             pinToName={pinToName}
+                            byStudentUid={byStudentUid}
                           />
                         ))}
                     </div>
@@ -1671,7 +1700,9 @@ export const QuizLiveMonitor: React.FC<QuizLiveMonitorProps> = ({
                     >
                       {responses
                         .slice()
-                        .sort((a, b) => a.pin.localeCompare(b.pin))
+                        .sort((a, b) =>
+                          (a.pin ?? '').localeCompare(b.pin ?? '')
+                        )
                         .map((r) => (
                           <StudentRow
                             key={r.studentUid}
@@ -1704,6 +1735,7 @@ export const QuizLiveMonitor: React.FC<QuizLiveMonitorProps> = ({
                                 : undefined
                             }
                             pinToName={pinToName}
+                            byStudentUid={byStudentUid}
                           />
                         ))}
                     </div>
@@ -1815,6 +1847,16 @@ const StatBox: React.FC<{
   );
 };
 
+/**
+ * Row shape passed to `InteractiveStatBox`. `key` is whatever uniquely
+ * identifies the student within the session — `pin` for anonymous joiners,
+ * `studentUid` for SSO joiners.
+ */
+interface StatBoxStudent {
+  key: string;
+  name: string;
+}
+
 const InteractiveStatBox: React.FC<{
   label: string;
   value: number;
@@ -1822,7 +1864,7 @@ const InteractiveStatBox: React.FC<{
   color: 'blue' | 'amber' | 'green';
   expanded: boolean;
   onToggle: () => void;
-  students: { pin: string; name: string }[];
+  students: StatBoxStudent[];
 }> = ({ label, value, icon, color, expanded, onToggle, students }) => {
   const themes = {
     blue: 'bg-brand-blue-lighter border-brand-blue-primary/10 text-brand-blue-primary',
@@ -1880,7 +1922,7 @@ const InteractiveStatBox: React.FC<{
         >
           {students.map((s) => (
             <p
-              key={s.pin}
+              key={s.key}
               className="truncate font-bold"
               style={{
                 fontSize: 'min(10px, 2.8cqmin)',
@@ -1907,6 +1949,10 @@ const StudentRow: React.FC<{
   onConfirmRemoveToggle: () => void;
   onRemove?: () => void;
   pinToName: Record<string, string>;
+  byStudentUid?: Map<
+    string,
+    import('@/hooks/useAssignmentPseudonyms').StudentName
+  >;
 }> = ({
   response,
   totalQuestions,
@@ -1918,6 +1964,7 @@ const StudentRow: React.FC<{
   onConfirmRemoveToggle,
   onRemove,
   pinToName,
+  byStudentUid,
 }) => {
   const warnings = response.tabSwitchWarnings ?? 0;
 
@@ -1960,9 +2007,11 @@ const StudentRow: React.FC<{
     joined: 'text-brand-gray-primary font-medium',
   };
 
-  const displayName = pinToName[response.pin]
-    ? pinToName[response.pin]
-    : `PIN ${response.pin}`;
+  const displayName = resolveResponseDisplayName(
+    response,
+    pinToName,
+    byStudentUid
+  );
 
   if (confirmRemove) {
     return (
@@ -2019,7 +2068,16 @@ const StudentRow: React.FC<{
         className="flex-1 flex items-center gap-1.5 text-brand-blue-dark font-bold truncate"
         style={{ fontSize: 'min(12px, 3.5cqmin)' }}
       >
-        <span className={pinToName[response.pin] ? '' : 'font-mono'}>
+        <span
+          className={
+            // Use the mono face only when we're rendering a literal `PIN <num>`
+            // fallback (no roster or ClassLink name resolved) — names should
+            // render in the regular sans face.
+            response.pin && displayName === `PIN ${response.pin}`
+              ? 'font-mono'
+              : ''
+          }
+        >
           {displayName}
         </span>
 
@@ -2075,15 +2133,27 @@ const PodiumView: React.FC<{
   questions: QuizQuestion[];
   session: QuizSession;
   pinToName: Record<string, string>;
+  byStudentUid?: Map<
+    string,
+    import('@/hooks/useAssignmentPseudonyms').StudentName
+  >;
   onDismiss: () => void;
-}> = ({ responses, questions, session, pinToName, onDismiss }) => {
+}> = ({
+  responses,
+  questions,
+  session,
+  pinToName,
+  byStudentUid,
+  onDismiss,
+}) => {
   // Use shared scoring utility for consistency with scoreboard
   const suffix = getScoreSuffix(session);
   const scored = responses
     .map((r) => {
       const score = getDisplayScore(r, questions, session);
-      const name = pinToName[r.pin] ?? `PIN ${r.pin}`;
-      return { name, score, pin: r.pin };
+      const name = resolveResponseDisplayName(r, pinToName, byStudentUid);
+      // `key` disambiguates rows for React: PIN for anonymous, uid for SSO.
+      return { name, score, key: r.pin ?? r.studentUid };
     })
     .sort((a, b) => b.score - a.score);
 
@@ -2130,7 +2200,7 @@ const PodiumView: React.FC<{
       <div className="flex flex-col" style={{ gap: 'min(6px, 1.5cqmin)' }}>
         {top3.map((entry, i) => (
           <div
-            key={entry.pin}
+            key={entry.key}
             className="flex items-center bg-slate-50 border border-slate-100 rounded-xl"
             style={{
               gap: 'min(10px, 2.5cqmin)',

--- a/components/widgets/QuizWidget/components/QuizResults.tsx
+++ b/components/widgets/QuizWidget/components/QuizResults.tsx
@@ -51,10 +51,7 @@ import {
 } from '../utils/quizScoreboard';
 import { resolveResponseDisplayName } from '../utils/resolveDisplayName';
 import { useClickOutside } from '@/hooks/useClickOutside';
-import {
-  useAssignmentPseudonyms,
-  formatStudentName,
-} from '@/hooks/useAssignmentPseudonyms';
+import { useAssignmentPseudonyms } from '@/hooks/useAssignmentPseudonyms';
 
 interface QuizResultsProps {
   quiz: QuizData;
@@ -1030,14 +1027,11 @@ const StudentsTab: React.FC<{
               pinToName,
               byStudentUid
             );
-            // "Resolved" = a real name was found (ClassLink or roster PIN
-            // match), as opposed to the literal `PIN <num>` or `Student`
-            // fallback. Drives the mono-face vs sans-face decision below.
-            const classLinkName = formatStudentName(
-              byStudentUid.get(r.studentUid)
-            );
-            const rosterName = r.pin ? pinToName[r.pin] : undefined;
-            const isResolved = Boolean(classLinkName || rosterName);
+            // Mono face is reserved for the literal `PIN <num>` fallback —
+            // anything else (real name, ClassLink name, or the "Student"
+            // SSO fallback) renders in the regular sans face. Mirrors the
+            // contract used by QuizLiveMonitor's StudentRow.
+            const isResolved = !r.pin || displayName !== `PIN ${r.pin}`;
             const rowKey = getResponseDocKey(r);
             const canDelete = Boolean(onDeleteResponse);
             const isConfirming = confirmDeleteKey === rowKey;

--- a/components/widgets/QuizWidget/components/QuizResults.tsx
+++ b/components/widgets/QuizWidget/components/QuizResults.tsx
@@ -49,6 +49,7 @@ import {
   getEarnedPoints,
   isGamificationActive,
 } from '../utils/quizScoreboard';
+import { resolveResponseDisplayName } from '../utils/resolveDisplayName';
 import { useClickOutside } from '@/hooks/useClickOutside';
 import {
   useAssignmentPseudonyms,
@@ -213,7 +214,8 @@ export const QuizResults: React.FC<QuizResultsProps> = ({
         quiz.questions,
         mode,
         pinToName,
-        session
+        session,
+        byStudentUid
       );
 
       const existingScoreboard = activeDashboard?.widgets.find(
@@ -247,6 +249,7 @@ export const QuizResults: React.FC<QuizResultsProps> = ({
       completed,
       quiz.questions,
       pinToName,
+      byStudentUid,
       session,
       activeDashboard?.widgets,
       updateWidget,
@@ -280,6 +283,7 @@ export const QuizResults: React.FC<QuizResultsProps> = ({
       const svc = new QuizDriveService(googleAccessToken);
       const exportOpts = {
         pinToName: exportPinToName,
+        byStudentUid,
         teacherName: config.teacherName,
         periodName: config.periodName,
         plcMode: config.plcMode,
@@ -1021,11 +1025,18 @@ const StudentsTab: React.FC<{
             const earned = getEarnedPoints(r, questions, session);
             const warnings = r.tabSwitchWarnings ?? 0;
 
+            const displayName = resolveResponseDisplayName(
+              r,
+              pinToName,
+              byStudentUid
+            );
+            // "Resolved" = a real name was found (ClassLink or roster PIN
+            // match), as opposed to the literal `PIN <num>` or `Student`
+            // fallback. Drives the mono-face vs sans-face decision below.
             const classLinkName = formatStudentName(
               byStudentUid.get(r.studentUid)
             );
-            const rosterName = pinToName[r.pin];
-            const displayName = classLinkName || rosterName || `PIN ${r.pin}`;
+            const rosterName = r.pin ? pinToName[r.pin] : undefined;
             const isResolved = Boolean(classLinkName || rosterName);
             const rowKey = getResponseDocKey(r);
             const canDelete = Boolean(onDeleteResponse);

--- a/components/widgets/QuizWidget/utils/quizScoreboard.test.ts
+++ b/components/widgets/QuizWidget/utils/quizScoreboard.test.ts
@@ -665,9 +665,19 @@ describe('quizScoreboard', () => {
         '01': 'Alice',
       });
 
+      // Roster-PIN match resolves to "Alice"; the unmapped row falls back to
+      // its literal `PIN <pin>` label rather than `undefined` so the student-
+      // side leaderboard always has something legible to render.
+      // `studentUid` is now also surfaced so SSO joiners can self-identify.
       expect(entries).toEqual([
-        { pin: '01', name: 'Alice', score: 100, rank: 1 },
-        { pin: '02', name: undefined, score: 0, rank: 2 },
+        { pin: '01', studentUid: 'uid-01', name: 'Alice', score: 100, rank: 1 },
+        {
+          pin: '02',
+          studentUid: 'uid-02',
+          name: 'PIN 02',
+          score: 0,
+          rank: 2,
+        },
       ]);
     });
 

--- a/components/widgets/QuizWidget/utils/quizScoreboard.ts
+++ b/components/widgets/QuizWidget/utils/quizScoreboard.ts
@@ -13,6 +13,12 @@ import {
 } from '@/types';
 import { gradeAnswer } from '@/hooks/useQuizSession';
 import { SCOREBOARD_COLORS } from '@/config/scoreboard';
+import type { StudentName } from '@/hooks/useAssignmentPseudonyms';
+import {
+  resolveResponseDisplayName,
+  responseColorIndex,
+  responseTeamId,
+} from './resolveDisplayName';
 
 type QuizScoringSession =
   | Pick<QuizSession, 'speedBonusEnabled' | 'streakBonusEnabled'>
@@ -195,13 +201,20 @@ export function buildPinToExportNameMap(
 
 /**
  * Build scoreboard teams from quiz responses.
+ *
+ * `byStudentUid` (optional) supplies ClassLink names for SSO `studentRole`
+ * joiners that have no `pin`. When omitted, SSO rows fall back to the
+ * generic `Student` label (see `resolveResponseDisplayName`). For pin-mode
+ * scoreboards SSO rows render their resolved name regardless of mode,
+ * because the literal `PIN undefined` is never useful.
  */
 export function buildScoreboardTeams(
   completedResponses: QuizResponse[],
   questions: QuizQuestion[],
   mode: 'pin' | 'name',
   pinToName: Record<string, string>,
-  session?: QuizSession | null
+  session?: QuizSession | null,
+  byStudentUid?: Map<string, StudentName>
 ): ScoreboardTeam[] {
   return completedResponses
     .map((r) => ({
@@ -209,34 +222,47 @@ export function buildScoreboardTeams(
       score: getDisplayScore(r, questions, session),
     }))
     .sort((a, b) => b.score - a.score)
-    .map(({ response, score }) => ({
-      id: `pin-${response.pin}`,
-      name:
-        mode === 'name'
-          ? (pinToName[response.pin] ?? `PIN ${response.pin}`)
-          : `PIN ${response.pin}`,
-      score,
-      color:
-        SCOREBOARD_COLORS[
-          parseInt(response.pin, 10) % SCOREBOARD_COLORS.length
-        ],
-    }));
+    .map(({ response, score }) => {
+      const resolvedName = resolveResponseDisplayName(
+        response,
+        pinToName,
+        byStudentUid
+      );
+      const pinModeName = response.pin ? `PIN ${response.pin}` : resolvedName;
+      return {
+        id: responseTeamId(response),
+        name: mode === 'name' ? resolvedName : pinModeName,
+        score,
+        color:
+          SCOREBOARD_COLORS[
+            responseColorIndex(response, SCOREBOARD_COLORS.length)
+          ],
+      };
+    });
 }
 
 /**
  * Build ranked leaderboard entries for student-facing live leaderboard views.
+ *
+ * Mirrors `buildScoreboardTeams` for SSO support: `byStudentUid` resolves
+ * names for `studentRole` joiners. The leaderboard's `pin` field stays
+ * optional in the entry type — students see `name` (or `Student` fallback).
  */
 export function buildLiveLeaderboard(
   responses: QuizResponse[],
   questions: QuizQuestion[],
   session: QuizScoringSession,
-  pinToName: Record<string, string>
+  pinToName: Record<string, string>,
+  byStudentUid?: Map<string, StudentName>
 ): QuizLeaderboardEntry[] {
   return responses
     .filter((response) => response.status !== 'joined')
     .map((response) => ({
-      pin: response.pin,
-      name: pinToName[response.pin],
+      // `pin` is set only for anonymous joiners; SSO joiners use `studentUid`
+      // for self-identification on the student-side leaderboard view.
+      ...(response.pin ? { pin: response.pin } : {}),
+      studentUid: response.studentUid,
+      name: resolveResponseDisplayName(response, pinToName, byStudentUid),
       score: getDisplayScore(response, questions, session),
     }))
     .sort((a, b) => b.score - a.score)

--- a/components/widgets/QuizWidget/utils/resolveDisplayName.ts
+++ b/components/widgets/QuizWidget/utils/resolveDisplayName.ts
@@ -29,7 +29,7 @@ import {
 } from '@/hooks/useAssignmentPseudonyms';
 
 /** Fallback rendered when no name source resolves. */
-export const ANONYMOUS_SSO_LABEL = 'Student';
+export const UNKNOWN_STUDENT_LABEL = 'Student';
 
 /**
  * Resolve a friendly display name for a response. See module docstring for
@@ -51,7 +51,7 @@ export function resolveResponseDisplayName(
     return `PIN ${response.pin}`;
   }
 
-  return ANONYMOUS_SSO_LABEL;
+  return UNKNOWN_STUDENT_LABEL;
 }
 
 /**

--- a/components/widgets/QuizWidget/utils/resolveDisplayName.ts
+++ b/components/widgets/QuizWidget/utils/resolveDisplayName.ts
@@ -97,9 +97,15 @@ export function responseColorIndex(
   paletteLength: number
 ): number {
   if (paletteLength <= 0) return 0;
+  // True modulo: JS `%` keeps the sign of the dividend, so a negative-string
+  // PIN (e.g. "-1") would yield a negative index and indexing into the
+  // palette would return undefined. `((n % m) + m) % m` always lands in
+  // [0, paletteLength). `stableHash` already returns an unsigned integer.
+  const mod = (n: number) =>
+    ((n % paletteLength) + paletteLength) % paletteLength;
   if (response.pin) {
     const numeric = parseInt(response.pin, 10);
-    if (Number.isFinite(numeric)) return numeric % paletteLength;
+    if (Number.isFinite(numeric)) return mod(numeric);
     return stableHash(response.pin) % paletteLength;
   }
   return stableHash(response.studentUid) % paletteLength;

--- a/components/widgets/QuizWidget/utils/resolveDisplayName.ts
+++ b/components/widgets/QuizWidget/utils/resolveDisplayName.ts
@@ -1,0 +1,106 @@
+/**
+ * Shared display-name resolution for QuizResponse rows on the teacher side.
+ *
+ * A QuizResponse can come from one of two student auth flows:
+ *   - Anonymous PIN join (the original `/join` and `/quiz?code=…` flow).
+ *     Identity is the teacher-assigned roster PIN; names come from
+ *     `pinToName` built off ClassRosters.
+ *   - SSO `studentRole` join (ClassLink-via-Google, launched from
+ *     `/my-assignments`). The response has no PIN; identity is the auth uid,
+ *     and names come from `byStudentUid` populated by
+ *     `useAssignmentPseudonyms` (`getPseudonymsForAssignmentV1`).
+ *
+ * Resolution priority:
+ *   1. ClassLink name (authoritative for SSO students).
+ *   2. Roster PIN match (teacher-built name list for anonymous students).
+ *   3. Literal `PIN <pin>` for anonymous students with no roster name.
+ *   4. `Student` for SSO students whose pseudonym lookup hasn't resolved yet
+ *      or whose classId isn't synced — never `PIN undefined`.
+ *
+ * Also exposes id/color helpers because the scoreboard utilities key on
+ * `response.pin`, which is now optional. Use these to keep keys stable
+ * across both auth flows.
+ */
+
+import type { QuizResponse } from '@/types';
+import {
+  formatStudentName,
+  type StudentName,
+} from '@/hooks/useAssignmentPseudonyms';
+
+/** Fallback rendered when no name source resolves. */
+export const ANONYMOUS_SSO_LABEL = 'Student';
+
+/**
+ * Resolve a friendly display name for a response. See module docstring for
+ * resolution priority. Always returns a non-empty string.
+ */
+export function resolveResponseDisplayName(
+  response: QuizResponse,
+  pinToName: Record<string, string>,
+  byStudentUid: Map<string, StudentName> | undefined
+): string {
+  const ssoName = byStudentUid
+    ? formatStudentName(byStudentUid.get(response.studentUid))
+    : '';
+  if (ssoName) return ssoName;
+
+  if (response.pin) {
+    const rosterName = pinToName[response.pin];
+    if (rosterName) return rosterName;
+    return `PIN ${response.pin}`;
+  }
+
+  return ANONYMOUS_SSO_LABEL;
+}
+
+/**
+ * Returns true when the response came in via PIN auth (i.e. the response
+ * has a usable `pin` value the teacher view can show in pin-mode).
+ */
+export function hasPinIdentity(response: QuizResponse): boolean {
+  return typeof response.pin === 'string' && response.pin.length > 0;
+}
+
+/**
+ * Stable, unique team id for scoreboard rows. PIN joiners keep their
+ * historical `pin-{pin}` shape so existing scoreboard widgets that reference
+ * those ids (via `parseInt(response.pin, 10)`) keep working. SSO students
+ * fall back to `uid-{studentUid}`.
+ */
+export function responseTeamId(response: QuizResponse): string {
+  if (response.pin) return `pin-${response.pin}`;
+  return `uid-${response.studentUid}`;
+}
+
+/**
+ * djb2-style hash of a string. Returns a non-negative integer suitable for
+ * indexing into a fixed-size palette via modulo. Stable across runs and
+ * across browsers.
+ */
+function stableHash(value: string): number {
+  let hash = 5381;
+  for (let i = 0; i < value.length; i++) {
+    hash = ((hash << 5) + hash + value.charCodeAt(i)) | 0;
+  }
+  // Force unsigned so the modulo result is always non-negative.
+  return hash >>> 0;
+}
+
+/**
+ * Stable color-palette index for a response. PIN joiners preserve their
+ * existing numeric-pin-modulo behavior so a single session's colors don't
+ * shuffle around when SSO students join. SSO students hash their studentUid.
+ */
+export function responseColorIndex(
+  response: QuizResponse,
+  paletteLength: number
+): number {
+  if (paletteLength <= 0) return 0;
+  if (response.pin) {
+    const numeric = parseInt(response.pin, 10);
+    if (Number.isFinite(numeric)) return numeric % paletteLength;
+    return stableHash(response.pin) % paletteLength;
+  }
+  return stableHash(response.studentUid) % paletteLength;
+}

--- a/hooks/useQuizSession.ts
+++ b/hooks/useQuizSession.ts
@@ -708,9 +708,14 @@ export const useQuizSessionStudent = (): UseQuizSessionStudentResult => {
           throw new Error('Anonymous auth failed — no current user.');
         const studentUid = currentUser.uid;
 
-        // PIN is required only for anonymous joiners. SSO `studentRole`
-        // users identify by `auth.uid` (carried in `studentUid` and used as
-        // the response doc key by `computeResponseKey`).
+        // Contract: PIN is required iff the caller is an anonymous Firebase
+        // user. Anonymous joiners arrived via the public `/join` /
+        // `/quiz?code=…` URL with no other identity, so the PIN is what
+        // ties them to a roster row. Non-anonymous joiners (SSO
+        // `studentRole` from `/my-assignments`, plus dev auth-bypass) carry
+        // a stable uid in `auth.uid` — `computeResponseKey` keys their
+        // response doc by that uid, and Firestore rules are the source of
+        // truth for whether the uid is actually allowed to write.
         const sanitizedPin = (pin ?? '').trim().substring(0, 10);
         if (currentUser.isAnonymous && !sanitizedPin) {
           throw new Error('PIN is required');

--- a/hooks/useQuizSession.ts
+++ b/hooks/useQuizSession.ts
@@ -553,9 +553,18 @@ export interface UseQuizSessionStudentResult {
    * before the student commits to joining.
    */
   lookupSession: (code: string) => Promise<{ periodNames: string[] } | null>;
+  /**
+   * Join a quiz session.
+   *
+   * `pin` is required for anonymous joiners (the original `/quiz?code=…` and
+   * `/join` flows) and omitted for SSO `studentRole` joiners launched from
+   * `/my-assignments` — their identity is the auth uid carried on the
+   * custom token, so no roster PIN is needed. The hook validates this at
+   * call time: anonymous + missing pin throws "PIN is required".
+   */
   joinQuizSession: (
     code: string,
-    pin: string,
+    pin?: string,
     classPeriod?: string
   ) => Promise<string>;
   submitAnswer: (
@@ -675,7 +684,7 @@ export const useQuizSessionStudent = (): UseQuizSessionStudentResult => {
   const joinQuizSession = useCallback(
     async (
       code: string,
-      pin: string,
+      pin?: string,
       classPeriod?: string
     ): Promise<string> => {
       setLoading(true);
@@ -687,12 +696,10 @@ export const useQuizSessionStudent = (): UseQuizSessionStudentResult => {
           .toUpperCase();
         if (!normCode) throw new Error('Invalid code');
 
-        // Prevent storage abuse on the PIN field
-        const sanitizedPin = pin.trim().substring(0, 10);
-        if (!sanitizedPin) throw new Error('PIN is required');
-
         // Ensure we have an anonymous Firebase Auth session so Firestore
-        // security rules (request.auth != null) are satisfied.
+        // security rules (request.auth != null) are satisfied. SSO students
+        // arriving from /my-assignments already have a non-anonymous custom-
+        // token user — keep that identity.
         if (!auth.currentUser) {
           await signInAnonymously(auth);
         }
@@ -700,6 +707,14 @@ export const useQuizSessionStudent = (): UseQuizSessionStudentResult => {
         if (!currentUser)
           throw new Error('Anonymous auth failed — no current user.');
         const studentUid = currentUser.uid;
+
+        // PIN is required only for anonymous joiners. SSO `studentRole`
+        // users identify by `auth.uid` (carried in `studentUid` and used as
+        // the response doc key by `computeResponseKey`).
+        const sanitizedPin = (pin ?? '').trim().substring(0, 10);
+        if (currentUser.isAnonymous && !sanitizedPin) {
+          throw new Error('PIN is required');
+        }
 
         const snap = await getDocs(
           query(
@@ -806,19 +821,21 @@ export const useQuizSessionStudent = (): UseQuizSessionStudentResult => {
         setResponseKeyState(responseKey);
 
         if (!existingSnap.exists()) {
-          // No PII stored — only the PIN for teacher cross-reference.
-          // `studentUid` field carries the auth uid; the doc key may differ
-          // (for PIN auth it's pin-based), so Firestore rules enforce
-          // ownership against the field, not the key.
+          // No PII stored. `studentUid` field carries the auth uid; the doc
+          // key may differ (for PIN auth it's pin-based), so Firestore rules
+          // enforce ownership against the field, not the key. The `pin`
+          // field is omitted entirely for SSO `studentRole` joiners — the
+          // teacher's grading view resolves their name from `studentUid`
+          // via `getPseudonymsForAssignmentV1`.
           const newResponse: QuizResponse = {
             studentUid,
-            pin: sanitizedPin,
             joinedAt: Date.now(),
             status: 'joined',
             answers: [],
             score: null,
             submittedAt: null,
             completedAttempts: 0,
+            ...(sanitizedPin ? { pin: sanitizedPin } : {}),
             ...(classPeriod ? { classPeriod } : {}),
           };
           await setDoc(responseRef, newResponse);

--- a/tests/hooks/useQuizSession.test.ts
+++ b/tests/hooks/useQuizSession.test.ts
@@ -268,6 +268,12 @@ describe('useQuizSessionStudent — lookupSession', () => {
 describe('useQuizSessionStudent — joinQuizSession', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // Default current user has no `isAnonymous` flag (falsy), matching the
+    // pre-SSO test expectations: response doc is keyed by `auth.uid` and the
+    // legacy-key probe is skipped. Tests that need the anonymous PIN-join
+    // semantics (PIN-required guard, legacy-key probe path) override
+    // `isAnonymous: true` locally; SSO branch tests assert against
+    // `isAnonymous: false` explicitly.
     (auth as unknown as { currentUser: { uid: string } | null }).currentUser = {
       uid: 'student-uid-1',
     };
@@ -293,7 +299,14 @@ describe('useQuizSessionStudent — joinQuizSession', () => {
     ).rejects.toThrow('Invalid code');
   });
 
-  it('throws "PIN is required" when the PIN is only whitespace', async () => {
+  it('throws "PIN is required" when the PIN is only whitespace (anonymous joiner)', async () => {
+    // Anonymous PIN joiners must always supply a PIN — that's their identity.
+    // Non-anonymous (SSO) users skip this guard; covered separately below.
+    (
+      auth as unknown as {
+        currentUser: { uid: string; isAnonymous: boolean } | null;
+      }
+    ).currentUser = { uid: 'anon-uid', isAnonymous: true };
     const { result } = renderHook(() => useQuizSessionStudent());
     await expect(
       result.current.joinQuizSession('ABC123', '   ')
@@ -526,6 +539,104 @@ describe('useQuizSessionStudent — joinQuizSession', () => {
         result.current.joinQuizSession('ABC123', '1234')
       ).rejects.toThrow('Backend unavailable.');
     });
+  });
+
+  // ─── SSO `studentRole` branch ───────────────────────────────────────────────
+  // Students arriving from /my-assignments are signed in via custom token
+  // (non-anonymous Firebase user with `claims.studentRole === true`). The
+  // hook keys the response doc by `auth.uid` and omits the `pin` field — the
+  // teacher's grading view resolves their name via getPseudonymsForAssignmentV1.
+
+  it('does not require a PIN for non-anonymous (studentRole) joiners', async () => {
+    (
+      auth as unknown as {
+        currentUser: { uid: string; isAnonymous: boolean } | null;
+      }
+    ).currentUser = { uid: 'sso-uid-1', isAnonymous: false };
+
+    (
+      firestore.getDocs as unknown as ReturnType<typeof vi.fn>
+    ).mockResolvedValueOnce({
+      empty: false,
+      docs: [buildSessionDoc('s1', { status: 'waiting' })],
+    });
+    (
+      firestore.getDoc as unknown as ReturnType<typeof vi.fn>
+    ).mockResolvedValueOnce({ exists: () => false });
+    const setDocMock = firestore.setDoc as unknown as ReturnType<typeof vi.fn>;
+    setDocMock.mockResolvedValueOnce(undefined);
+
+    const { result } = renderHook(() => useQuizSessionStudent());
+    let sessionId = '';
+    await act(async () => {
+      // Note: no PIN argument.
+      sessionId = await result.current.joinQuizSession('ABC123');
+    });
+
+    expect(sessionId).toBe('s1');
+    expect(setDocMock).toHaveBeenCalledTimes(1);
+    const writtenResponse = setDocMock.mock.calls[0][1] as Record<
+      string,
+      unknown
+    >;
+    // studentUid is the SSO auth uid, and `pin` is omitted entirely so the
+    // teacher's name-resolution path falls through to byStudentUid.
+    expect(writtenResponse.studentUid).toBe('sso-uid-1');
+    expect(writtenResponse).not.toHaveProperty('pin');
+    expect(writtenResponse.status).toBe('joined');
+  });
+
+  it('keys the studentRole response doc by auth.uid (not by pin-{period}-{pin})', async () => {
+    (
+      auth as unknown as {
+        currentUser: { uid: string; isAnonymous: boolean } | null;
+      }
+    ).currentUser = { uid: 'sso-uid-2', isAnonymous: false };
+
+    (
+      firestore.getDocs as unknown as ReturnType<typeof vi.fn>
+    ).mockResolvedValueOnce({
+      empty: false,
+      docs: [buildSessionDoc('s1', { status: 'waiting' })],
+    });
+    (
+      firestore.getDoc as unknown as ReturnType<typeof vi.fn>
+    ).mockResolvedValueOnce({ exists: () => false });
+    (
+      firestore.setDoc as unknown as ReturnType<typeof vi.fn>
+    ).mockResolvedValueOnce(undefined);
+
+    const docMock = firestore.doc as unknown as ReturnType<typeof vi.fn>;
+
+    const { result } = renderHook(() => useQuizSessionStudent());
+    await act(async () => {
+      await result.current.joinQuizSession('ABC123', undefined, 'Period 1');
+    });
+
+    // The hook calls `doc(db, QUIZ_SESSIONS_COLLECTION, sessionId,
+    // RESPONSES_COLLECTION, responseKey)` once for the existence probe
+    // (handled by getDoc) and once for the eventual write. Find a call
+    // whose final segment is the response-doc key.
+    const responseKeys: string[] = (docMock.mock.calls as unknown[][])
+      .map((args) => args[args.length - 1])
+      .filter((v): v is string => typeof v === 'string');
+    expect(responseKeys).toContain('sso-uid-2');
+    // No pin-derived key should ever be requested for an SSO joiner.
+    expect(
+      responseKeys.some((k) => typeof k === 'string' && k.startsWith('pin-'))
+    ).toBe(false);
+  });
+
+  it('still rejects anonymous joiners with no PIN', async () => {
+    (
+      auth as unknown as {
+        currentUser: { uid: string; isAnonymous: boolean } | null;
+      }
+    ).currentUser = { uid: 'anon-uid', isAnonymous: true };
+    const { result } = renderHook(() => useQuizSessionStudent());
+    await expect(result.current.joinQuizSession('ABC123')).rejects.toThrow(
+      'PIN is required'
+    );
   });
 });
 

--- a/types.ts
+++ b/types.ts
@@ -1760,7 +1760,14 @@ export interface QuizPublicQuestion {
 }
 
 export interface QuizLeaderboardEntry {
-  pin: string;
+  /** Optional — SSO `studentRole` joiners have no PIN; identity is `name`. */
+  pin?: string;
+  /**
+   * Auth uid of the student who owns this row. Lets the student-side
+   * leaderboard highlight "my row" for SSO joiners (whose `pin` is missing)
+   * by matching `auth.currentUser.uid` instead of a roster PIN.
+   */
+  studentUid?: string;
   name?: string;
   score: number;
   rank: number;
@@ -1907,8 +1914,13 @@ export interface QuizResponse {
   /**
    * Student's roster PIN. Teacher cross-references this with the Drive roster
    * to identify the student. No name or email is stored in Firestore.
+   *
+   * Optional because SSO `studentRole` joiners (launched from /my-assignments)
+   * have no PIN — their identity is `studentUid`, resolved to a name via
+   * `getPseudonymsForAssignmentV1` on the teacher side. Anonymous PIN joiners
+   * always set this field.
    */
-  pin: string;
+  pin?: string;
   joinedAt: number;
   status: QuizResponseStatus;
   answers: QuizResponseAnswer[];

--- a/utils/quizDriveService.ts
+++ b/utils/quizDriveService.ts
@@ -466,6 +466,12 @@ export class QuizDriveService {
     questions: QuizQuestion[],
     options?: {
       pinToName?: Record<string, string>;
+      /**
+       * ClassLink name lookup for SSO `studentRole` joiners (no PIN). Keyed
+       * by `response.studentUid`. Optional — when omitted (legacy code+PIN
+       * sessions), SSO rows fall back to the generic `Student` label.
+       */
+      byStudentUid?: Map<string, { givenName: string; familyName: string }>;
       teacherName?: string;
       periodName?: string;
       plcMode?: boolean;
@@ -473,6 +479,7 @@ export class QuizDriveService {
     }
   ): Promise<string> {
     const pinToName = options?.pinToName ?? {};
+    const byStudentUid = options?.byStudentUid;
     const teacherName =
       (options?.teacherName?.trim() ? options.teacherName.trim() : null) ??
       'Unknown Teacher';
@@ -481,8 +488,19 @@ export class QuizDriveService {
       'Unknown Period';
     const timestamp = new Date().toISOString();
 
-    const resolveStudent = (pin: string): string =>
-      pinToName[pin] ?? `Student (PIN: ${pin})`;
+    const resolveStudent = (r: QuizResponse): string => {
+      // ClassLink name (SSO) wins; then roster PIN match; then literal PIN;
+      // then generic "Student" fallback for SSO rows that didn't resolve.
+      const sso = byStudentUid?.get(r.studentUid);
+      if (sso) {
+        const full = `${sso.givenName ?? ''} ${sso.familyName ?? ''}`.trim();
+        if (full) return full;
+      }
+      if (r.pin) {
+        return pinToName[r.pin] ?? `Student (PIN: ${r.pin})`;
+      }
+      return 'Student';
+    };
 
     const maxPoints = questions.reduce((sum, q) => sum + (q.points ?? 1), 0);
 
@@ -532,8 +550,10 @@ export class QuizDriveService {
         teacherName,
         periodName,
         r.classPeriod ?? '',
-        resolveStudent(r.pin),
-        r.pin,
+        resolveStudent(r),
+        // PIN column is left blank for SSO students (no roster PIN); their
+        // identity is captured in the Student column instead.
+        r.pin ?? '',
         r.status,
         scoreDisplay,
         String(earnedPoints),


### PR DESCRIPTION
## Summary

- SSO `studentRole` students arriving at `/quiz?code=…` from /my-assignments now auto-join on mount — no PIN screen. Anonymous `/join` and direct `/quiz?code=…` visits keep PIN entry exactly as today.
- Teacher live monitor + results view resolve SSO student names via the existing `getPseudonymsForAssignmentV1` callable (`useAssignmentPseudonymsMulti` hook) instead of rendering `PIN undefined`.
- Pattern mirrors `MiniAppStudentApp`'s SSO handling — already proven in production. Quiz first; Video Activity / Guided Learning / Activity Wall follow in separate PRs.

### What changes structurally

- `QuizResponse.pin` is now optional. SSO writes omit the `pin` field entirely (response doc keyed by `auth.uid` via existing `computeResponseKey`).
- `joinQuizSession(code, pin?, classPeriod?)` — PIN guard only fires for anonymous joiners.
- New shared `resolveDisplayName.ts` util used across `QuizLiveMonitor`, `QuizResults`, `Widget.tsx`, and the live scoreboard sync. Resolution priority: ClassLink name → roster PIN match → literal `PIN N` → generic `Student` fallback.
- `QuizLeaderboardEntry` now also carries optional `studentUid` so the student-side leaderboard can highlight "(you)" for SSO joiners with no PIN.
- Sheets export (`quizDriveService.ts`) accepts `byStudentUid` and writes ClassLink names with a blank PIN column for SSO rows.

### Open known limits

- Multi-period quizzes still show the period picker for SSO students (`periodNames` are free-form labels, not bound to ClassLink classIds — auto-pick would be brittle).
- Video Activity, Guided Learning, Activity Wall, and `/quiz` route's parent `AuthProvider` wrapping are deliberately out of scope (next PRs).
- Multi-class Phase 5A grading view in `QuizResults` still uses `useAssignmentPseudonyms` (single-class). `QuizLiveMonitor` was upgraded to `useAssignmentPseudonymsMulti` since live names matter most there. Easy follow-up.

## Test plan

Verified locally:
- [x] `pnpm run type-check` — clean
- [x] `pnpm run lint` — clean (zero warnings)
- [x] `pnpm run test` — 1504 / 1504 passing, including 3 new tests covering the SSO `studentRole` join branch (no PIN required, doc keyed by `auth.uid`, no `pin` field on the doc)

To verify on the dev preview (needs real Firebase / ClassLink):
- [ ] **SSO happy path** (single-period quiz): sign in at `/student/login` → open `/my-assignments` → click an active quiz → land directly in the waiting room (no PIN screen).
- [ ] **SSO multi-period quiz**: same flow, period picker should appear; selecting a period drops into the waiting room.
- [ ] **Anonymous regression**: open `/quiz?code=…` in an incognito window — PIN-entry form must render and behave exactly as today.
- [ ] **Teacher live monitor**: open the monitor for the same session; SSO student renders by ClassLink name (Names mode) and by name (Pin mode falls back to the resolved name when no pin). Mix in an anonymous joiner with a PIN — both render side-by-side.
- [ ] **Pseudonym lookup failure**: throttle / block `getPseudonymsForAssignmentV1`; SSO row renders as `Student`, not `PIN undefined`.
- [ ] **Cross-device attempt limit**: SSO student joins, completes, switches device, signs back in, opens the same quiz — limit still enforces (auth.uid is stable).
- [ ] **Class-gate enforcement**: hand-craft a `/quiz?code=X` URL for a session whose `classIds` doesn't intersect with the student's — Firestore rules must reject the response write.

🤖 Generated with [Claude Code](https://claude.com/claude-code)