### PR TITLE
fix(quiz): stop mounting teacher AuthProvider on the /quiz student route

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -305,15 +305,17 @@ const App: React.FC = () => {
     );
   }
 
-  // Quiz student route — requires real Firebase auth (org Google account)
+  // Quiz student route — QuizStudentApp self-handles Firebase auth
+  // (signInAnonymously when no current user; preserves the SSO student-
+  // custom-token user otherwise). No teacher AuthContext consumers in the
+  // quiz tree, so wrapping in <AuthProvider> would only mount admin-only
+  // Firestore listeners that fail with permission-denied for students.
   if (isQuizRoute) {
     return (
       <DialogProvider>
-        <AuthProvider>
-          <Suspense fallback={<FullPageLoader />}>
-            <QuizStudentApp />
-          </Suspense>
-        </AuthProvider>
+        <Suspense fallback={<FullPageLoader />}>
+          <QuizStudentApp />
+        </Suspense>
         <DialogContainer />
       </DialogProvider>
     );

--- a/hooks/useQuizSession.ts
+++ b/hooks/useQuizSession.ts
@@ -942,9 +942,26 @@ export const useQuizSessionStudent = (): UseQuizSessionStudentResult => {
       myResponseRef.current?.tabSwitchWarnings ?? 0
     );
 
-    await updateDoc(responseRef, {
-      tabSwitchWarnings: increment(1),
-    });
+    try {
+      await updateDoc(responseRef, {
+        tabSwitchWarnings: increment(1),
+      });
+    } catch (err) {
+      // Re-throw with extra context so the caller's catch surfaces enough
+      // diagnostic info to bisect intermittent rule failures (PIN-bypass
+      // SSO students vs anonymous PIN students, missing fields, etc.).
+      console.error('[reportTabSwitch] update failed', {
+        sessionId,
+        responseKey,
+        authUid: auth.currentUser?.uid,
+        isAnonymous: auth.currentUser?.isAnonymous,
+        baseCount,
+        hasPinField: myResponseRef.current?.pin !== undefined,
+        hasTabSwitchField:
+          myResponseRef.current?.tabSwitchWarnings !== undefined,
+      });
+      throw err;
+    }
 
     const newCount = baseCount + 1;
     warningCountRef.current = newCount;


### PR DESCRIPTION
## Summary

- The `/quiz` route was wrapping `QuizStudentApp` in `<AuthProvider>` (the teacher AuthContext), which unconditionally subscribes to `admin_settings/user_roles` and `admin_settings/app_settings` for any authenticated user. Both are admin-only per `firestore.rules`, so non-admin students hit *Missing or insufficient permissions* in the console on every quiz load — surfaced more visibly after #1431 gave SSO students an already-authenticated identity at mount time.
- `QuizStudentApp` self-handles Firebase auth (`signInAnonymously` when no current user; preserves the SSO student-custom-token user otherwise) and nothing in the quiz subtree consumes `useAuth()`, so the teacher provider was unnecessary. Drop it to match every other student-only route.
- Bonus: wraps `reportTabSwitch`'s `updateDoc` in a `try`/`catch` that logs `sessionId`, `responseKey`, `authUid`, `isAnonymous`, `baseCount`, `hasPinField`, `hasTabSwitchField` before re-throwing — so the next intermittent *Failed to report tab switch* denial gives us enough state to bisect without a speculative rule change.

Files changed: `App.tsx`, `hooks/useQuizSession.ts`.

## Test plan

- [x] `pnpm run type-check` clean
- [x] `pnpm run format:check` clean
- [x] `pnpm exec eslint App.tsx hooks/useQuizSession.ts` clean
- [x] `pnpm exec vitest run tests/hooks/useQuizSession.test.ts` — 43/43 pass
- [x] Local preview at `/quiz?code=…` — PIN form renders; no `Error loading user roles`, `Error loading app settings`, or `Failed to report tab switch` in the post-navigation console
- [ ] Dev preview as an SSO student opening a quiz from `/my-assignments` — confirm clean console, answers persist, tab-switch warning increments
- [ ] Dev preview as an anonymous student via direct `/quiz?code=…` — PIN flow still gates entry, sign-in-anonymously still fires, tab switch still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)