### PR TITLE
fix(rules): unbreak SSO student quiz/VA submits when response has no pin field

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -910,8 +910,14 @@ service cloud.firestore {
           (request.auth.uid == resource.data.studentUid &&
            passesStudentClassGateCompat(sessionClassIds(), sessionClassId()) &&
            request.resource.data.studentUid == resource.data.studentUid &&
-           request.resource.data.pin == resource.data.pin &&
-           request.resource.data.joinedAt == resource.data.joinedAt &&
+           // SSO studentRole responses omit `pin` entirely (no PIN was used
+           // to join), so direct dot-access on `resource.data.pin` would
+           // throw a Null-value error and deny the write. Use `.get(_, null)`
+           // so the immutability check tolerates the field being absent on
+           // both sides — the `hasOnly([...])` clause below still prevents
+           // a student from adding/changing `pin` or `joinedAt`.
+           request.resource.data.get('pin', null) == resource.data.get('pin', null) &&
+           request.resource.data.get('joinedAt', null) == resource.data.get('joinedAt', null) &&
            request.resource.data.score == null &&
            request.resource.data.diff(resource.data)
              .changedKeys().hasOnly(['answers', 'status', 'submittedAt', 'tabSwitchWarnings', 'completedAttempts', 'classPeriod', 'score']) &&
@@ -1061,9 +1067,14 @@ service cloud.firestore {
           studentUid == request.auth.uid &&
           passesStudentClassGateCompat(vaSessionClassIds(), vaSessionClassId()) &&
           request.resource.data.studentUid == resource.data.studentUid &&
-          request.resource.data.pin == resource.data.pin &&
-          request.resource.data.name == resource.data.name &&
-          request.resource.data.joinedAt == resource.data.joinedAt &&
+          // Same fragility class as the quiz_sessions/responses rule: SSO
+          // studentRole responses may omit `pin` and `name` entirely, so
+          // direct dot-access would throw and deny the write. The
+          // `affectedKeys().hasOnly(['answers', 'completedAt'])` clause
+          // below still prevents a student from adding/changing them.
+          request.resource.data.get('pin', null) == resource.data.get('pin', null) &&
+          request.resource.data.get('name', null) == resource.data.get('name', null) &&
+          request.resource.data.get('joinedAt', null) == resource.data.get('joinedAt', null) &&
           request.resource.data.score == resource.data.score &&
           request.resource.data.diff(resource.data).affectedKeys().hasOnly(['answers', 'completedAt']) &&
           request.resource.data.answers.size() >= resource.data.answers.size() &&


### PR DESCRIPTION
## Summary

- Fixes the `Missing or insufficient permissions` error SSO students hit the moment they click **Next** on an assigned quiz from `/my-assignments`. Same fix applied preemptively to the parallel video_activity_sessions response rule.
- Root cause: in Firestore Rules, dot-access on a missing field (`resource.data.pin` when the doc has no `pin` key) throws a Null-value runtime error and denies the write. SSO studentRole responses omit `pin` entirely (no PIN was used to join), so every `submitAnswer` / `completeQuiz` / `reportTabSwitch` `updateDoc` was failing.
- Switched the immutability checks to the `.get(field, null)` pattern already used elsewhere in `firestore.rules`. The existing `changedKeys().hasOnly([...])` / `affectedKeys().hasOnly([...])` clauses still block students from adding or changing those fields, so the immutability guarantee is intact.

PR #1433's try/catch around `reportTabSwitch` is what surfaced the secondary `[reportTabSwitch] update failed` log in the console — the primary `submitAnswer` denial throws unhandled. Both fail on the same rule and both clear with this change.

## Test plan

- [ ] Deploy rules to dev Firebase project: `firebase deploy --only firestore:rules`
- [ ] As a teacher, build a quiz and assign it to a ClassLink-targeted class
- [ ] In a separate browser, sign in at `/student/login` with a Google account on that class roster
- [ ] Teacher resumes the assignment
- [ ] Student opens `/my-assignments`, clicks the quiz (PIN screen skipped per #1431)
- [ ] Student selects an answer, clicks Next — question advances, no `FirebaseError` in console, no `[reportTabSwitch] update failed` log
- [ ] Regression: anonymous PIN joiner via `/quiz` + PIN can still complete a quiz end-to-end with zero permission denials
- [ ] Same regression check for a Video Activity assignment (SSO + anonymous)

🤖 Generated with [Claude Code](https://claude.com/claude-code)