### PR TITLE
fix(quiz): resolve names for test-class SSO students in monitor view

### DIFF
--- a/components/classes/ClassLinkImportDialog.tsx
+++ b/components/classes/ClassLinkImportDialog.tsx
@@ -60,12 +60,15 @@ const buildClassLinkRosterMeta = (
 // two-digit strings (01, 02, …) so the teacher has something to hand out
 // before editing. The imported roster is a normal user-owned roster and can
 // be renamed, PIN-edited, or deleted afterwards like any ClassLink import.
+// Email is preserved on the student record so it round-trips through the
+// editor and can be displayed in the optional EMAIL column.
 const materializeTestClassStudents = (emails: string[]): Student[] =>
   emails.map((email, i) => ({
     id: crypto.randomUUID(),
     firstName: email.split('@')[0] || email,
     lastName: '',
     pin: String(i + 1).padStart(2, '0'),
+    email,
   }));
 
 export type ClassLinkDialogMode =
@@ -216,6 +219,7 @@ export const ClassLinkImportDialog: React.FC<ClassLinkImportDialogProps> = ({
             lastName: s.familyName,
             pin: '',
             classLinkSourcedId: s.sourcedId,
+            ...(s.email ? { email: s.email } : {}),
           }));
       const subjectPrefix = cls.subject ? `${cls.subject} - ` : '';
       const codeSuffix = cls.classCode ? ` (${cls.classCode})` : '';

--- a/components/classes/RosterEditorModal.tsx
+++ b/components/classes/RosterEditorModal.tsx
@@ -43,6 +43,8 @@ export const RosterEditorModal: React.FC<RosterEditorModalProps> = ({
     handleToggleLastNames,
     showPins,
     setShowPins,
+    showEmails,
+    setShowEmails,
     showRestrictions,
     setShowRestrictions,
     toggleRestriction,
@@ -130,6 +132,22 @@ export const RosterEditorModal: React.FC<RosterEditorModalProps> = ({
                   })}
             </button>
             <button
+              onClick={() => setShowEmails((v) => !v)}
+              className={`text-xs font-black uppercase tracking-wider transition-colors ${
+                showEmails
+                  ? 'text-slate-400 hover:text-red-500'
+                  : 'text-emerald-600 hover:text-emerald-700'
+              }`}
+            >
+              {showEmails
+                ? t('sidebar.classes.hideEmail', {
+                    defaultValue: '− Email',
+                  })
+                : t('sidebar.classes.addEmail', {
+                    defaultValue: '+ Email',
+                  })}
+            </button>
+            <button
               onClick={() => setShowRestrictions((v) => !v)}
               className={`text-xs font-black uppercase tracking-wider transition-colors ${
                 showRestrictions
@@ -183,6 +201,7 @@ export const RosterEditorModal: React.FC<RosterEditorModalProps> = ({
               <RosterHeader
                 showLastNames={showLastNames}
                 showPins={showPins}
+                showEmails={showEmails}
                 showRestrictions={showRestrictions}
                 firstLabel={
                   showLastNames
@@ -199,6 +218,9 @@ export const RosterEditorModal: React.FC<RosterEditorModalProps> = ({
                 pinLabel={t('sidebar.classes.quizPin', {
                   defaultValue: 'Quiz PIN',
                 })}
+                emailLabel={t('sidebar.classes.email', {
+                  defaultValue: 'Email',
+                })}
                 restrictionsLabel={t('sidebar.classes.restrictionsHeader', {
                   defaultValue: 'Restricted from working with',
                 })}
@@ -211,6 +233,7 @@ export const RosterEditorModal: React.FC<RosterEditorModalProps> = ({
                     index={idx}
                     showLastNames={showLastNames}
                     showPins={showPins}
+                    showEmails={showEmails}
                     showRestrictions={showRestrictions}
                     allRows={rows}
                     isDuplicatePin={
@@ -231,6 +254,9 @@ export const RosterEditorModal: React.FC<RosterEditorModalProps> = ({
                     )}
                     pinPlaceholder={t('sidebar.classes.pinPlaceholder', {
                       defaultValue: '01',
+                    })}
+                    emailPlaceholder={t('sidebar.classes.emailPlaceholder', {
+                      defaultValue: 'student@school.org',
                     })}
                     removeLabel={t('sidebar.classes.removeStudent', {
                       defaultValue: 'Remove student',
@@ -268,20 +294,24 @@ export const RosterEditorModal: React.FC<RosterEditorModalProps> = ({
 interface RosterHeaderProps {
   showLastNames: boolean;
   showPins: boolean;
+  showEmails: boolean;
   showRestrictions: boolean;
   firstLabel: string;
   lastLabel: string;
   pinLabel: string;
+  emailLabel: string;
   restrictionsLabel: string;
 }
 
 const RosterHeader: React.FC<RosterHeaderProps> = ({
   showLastNames,
   showPins,
+  showEmails,
   showRestrictions,
   firstLabel,
   lastLabel,
   pinLabel,
+  emailLabel,
   restrictionsLabel,
 }) => {
   return (
@@ -291,6 +321,7 @@ const RosterHeader: React.FC<RosterHeaderProps> = ({
         gridTemplateColumns: buildGridTemplate(
           showLastNames,
           showPins,
+          showEmails,
           showRestrictions
         ),
       }}
@@ -299,6 +330,7 @@ const RosterHeader: React.FC<RosterHeaderProps> = ({
       {showPins && <span>{pinLabel}</span>}
       <span>{firstLabel}</span>
       {showLastNames && <span>{lastLabel}</span>}
+      {showEmails && <span>{emailLabel}</span>}
       {showRestrictions && <span>{restrictionsLabel}</span>}
       <span />
     </div>
@@ -310,12 +342,14 @@ interface RosterRowProps {
   index: number;
   showLastNames: boolean;
   showPins: boolean;
+  showEmails: boolean;
   showRestrictions: boolean;
   allRows: DraftRow[];
   isDuplicatePin: boolean;
   firstNamePlaceholder: string;
   lastNamePlaceholder: string;
   pinPlaceholder: string;
+  emailPlaceholder: string;
   removeLabel: string;
   onChange: (patch: Partial<DraftRow>) => void;
   onDelete: () => void;
@@ -328,12 +362,14 @@ const RosterRow: React.FC<RosterRowProps> = ({
   index,
   showLastNames,
   showPins,
+  showEmails,
   showRestrictions,
   allRows,
   isDuplicatePin,
   firstNamePlaceholder,
   lastNamePlaceholder,
   pinPlaceholder,
+  emailPlaceholder,
   removeLabel,
   onChange,
   onDelete,
@@ -368,6 +404,7 @@ const RosterRow: React.FC<RosterRowProps> = ({
         gridTemplateColumns: buildGridTemplate(
           showLastNames,
           showPins,
+          showEmails,
           showRestrictions
         ),
       }}
@@ -402,6 +439,17 @@ const RosterRow: React.FC<RosterRowProps> = ({
           value={row.lastName}
           onChange={(e) => onChange({ lastName: e.target.value })}
           placeholder={lastNamePlaceholder}
+        />
+      )}
+      {showEmails && (
+        <input
+          type="email"
+          className="px-3 py-1.5 text-sm rounded-md border border-slate-200 bg-white outline-none focus:border-emerald-500 focus:ring-2 focus:ring-emerald-100 transition-colors"
+          value={row.email ?? ''}
+          onChange={(e) => onChange({ email: e.target.value })}
+          placeholder={emailPlaceholder}
+          autoComplete="off"
+          spellCheck={false}
         />
       )}
       {showRestrictions && (
@@ -456,17 +504,19 @@ const RosterEmptyState: React.FC<RosterEmptyStateProps> = ({
 );
 
 /**
- * Grid columns: [#] [PIN?] [First] [Last?] [Restrictions?] [Delete]
+ * Grid columns: [#] [PIN?] [First] [Last?] [Email?] [Restrictions?] [Delete]
  */
 function buildGridTemplate(
   showLastNames: boolean,
   showPins: boolean,
+  showEmails: boolean,
   showRestrictions: boolean
 ): string {
   const parts = ['2rem'];
   if (showPins) parts.push('5rem');
   parts.push('minmax(0, 1fr)');
   if (showLastNames) parts.push('minmax(0, 1fr)');
+  if (showEmails) parts.push('minmax(0, 1.4fr)');
   if (showRestrictions) parts.push('minmax(9rem, 14rem)');
   parts.push('2rem');
   return parts.join(' ');

--- a/components/classes/mergeClassLinkStudents.test.ts
+++ b/components/classes/mergeClassLinkStudents.test.ts
@@ -150,6 +150,89 @@ describe('mergeClassLinkStudents', () => {
     expect(result.students[0].pin).toBe('01');
   });
 
+  it('persists email on appended students and backfills it on matched ones', () => {
+    // Pre-existing students: one matched by sourcedId, one matched by name,
+    // one local-only. Each starts without an email; the merge should backfill
+    // emails from the ClassLink payload onto the two matched rows and stamp
+    // the email onto the newly appended row.
+    const existing = [
+      makeLocal({
+        firstName: 'Ada',
+        lastName: 'Lovelace',
+        pin: '01',
+        classLinkSourcedId: 'cl-ada',
+      }),
+      makeLocal({
+        firstName: 'Grace',
+        lastName: 'Hopper',
+        pin: '02',
+      }),
+      makeLocal({
+        firstName: 'Local',
+        lastName: 'Aide',
+        pin: '99',
+      }),
+    ];
+    const cl = [
+      makeCL({
+        sourcedId: 'cl-ada',
+        givenName: 'Ada',
+        familyName: 'Lovelace',
+        email: 'ada@school.org',
+      }),
+      makeCL({
+        sourcedId: 'cl-grace',
+        givenName: 'Grace',
+        familyName: 'Hopper',
+        email: 'grace@school.org',
+      }),
+      makeCL({
+        sourcedId: 'cl-alan',
+        givenName: 'Alan',
+        familyName: 'Turing',
+        email: 'alan@school.org',
+      }),
+    ];
+    const result = mergeClassLinkStudents(existing, cl);
+
+    const ada = result.students.find((s) => s.firstName === 'Ada');
+    expect(ada?.email).toBe('ada@school.org');
+    expect(ada?.pin).toBe('01'); // unchanged
+
+    const grace = result.students.find((s) => s.firstName === 'Grace');
+    expect(grace?.email).toBe('grace@school.org');
+    expect(grace?.pin).toBe('02'); // unchanged
+
+    const alan = result.students.find((s) => s.firstName === 'Alan');
+    expect(alan?.email).toBe('alan@school.org');
+
+    // Local aide must NOT receive an email (no upstream match).
+    const aide = result.students.find((s) => s.lastName === 'Aide');
+    expect(aide?.email).toBeUndefined();
+  });
+
+  it('does not overwrite an existing email on re-sync', () => {
+    // If a teacher already edited a student's email locally, the merge
+    // should preserve it even when ClassLink reports a different value.
+    const existing = makeLocal({
+      firstName: 'Ada',
+      lastName: 'Lovelace',
+      pin: '01',
+      classLinkSourcedId: 'cl-ada',
+      email: 'manual@school.org',
+    });
+    const cl = [
+      makeCL({
+        sourcedId: 'cl-ada',
+        givenName: 'Ada',
+        familyName: 'Lovelace',
+        email: 'upstream@school.org',
+      }),
+    ];
+    const result = mergeClassLinkStudents([existing], cl);
+    expect(result.students[0].email).toBe('manual@school.org');
+  });
+
   it('sourcedId match wins even if a different local row has matching name', () => {
     const existing = [
       makeLocal({

--- a/components/classes/mergeClassLinkStudents.ts
+++ b/components/classes/mergeClassLinkStudents.ts
@@ -65,6 +65,11 @@ export function mergeClassLinkStudents(
       consumed.add(sourcedIndex);
       matchedCount += 1;
       alreadySourcedCount += 1;
+      // Backfill email on re-sync: rosters imported before email was
+      // captured won't have it, so stamp the upstream value when present.
+      if (cls.email && !result[sourcedIndex].email) {
+        result[sourcedIndex] = { ...result[sourcedIndex], email: cls.email };
+      }
       continue;
     }
 
@@ -84,10 +89,14 @@ export function mergeClassLinkStudents(
     if (nameMatchIndex !== undefined) {
       consumed.add(nameMatchIndex);
       matchedCount += 1;
-      // Stamp the sourcedId onto the existing row (preserve id + pin)
+      // Stamp the sourcedId onto the existing row (preserve id + pin).
+      // Also backfill email if this is the first time we've seen it.
       result[nameMatchIndex] = {
         ...result[nameMatchIndex],
         classLinkSourcedId: cls.sourcedId,
+        ...(cls.email && !result[nameMatchIndex].email
+          ? { email: cls.email }
+          : {}),
       };
       continue;
     }
@@ -99,6 +108,7 @@ export function mergeClassLinkStudents(
       lastName: cls.familyName,
       pin: '',
       classLinkSourcedId: cls.sourcedId,
+      ...(cls.email ? { email: cls.email } : {}),
     });
     addedCount += 1;
   }

--- a/components/classes/useRosterRowsState.ts
+++ b/components/classes/useRosterRowsState.ts
@@ -12,6 +12,7 @@ export interface DraftRow {
   lastName: string;
   pin: string;
   classLinkSourcedId?: string;
+  email?: string;
   restrictedStudentIds?: string[];
 }
 
@@ -36,6 +37,7 @@ export function useRosterRowsState(roster: ClassRoster | null) {
         lastName: s.lastName,
         pin: s.pin,
         classLinkSourcedId: s.classLinkSourcedId,
+        email: s.email,
         restrictedStudentIds: s.restrictedStudentIds,
       })) ?? []
   );
@@ -44,6 +46,12 @@ export function useRosterRowsState(roster: ClassRoster | null) {
   );
   const [showPins, setShowPins] = useState(
     roster?.students.some((s) => s.pin.trim() !== '') ?? false
+  );
+  // Auto-show email column when at least one student has an email — so
+  // freshly imported ClassLink/test-class rosters reveal it immediately
+  // without requiring the teacher to find the toggle.
+  const [showEmails, setShowEmails] = useState(
+    roster?.students.some((s) => (s.email ?? '').trim() !== '') ?? false
   );
   const [showRestrictions, setShowRestrictions] = useState(
     roster?.students.some((s) => (s.restrictedStudentIds?.length ?? 0) > 0) ??
@@ -220,6 +228,10 @@ export function useRosterRowsState(roster: ClassRoster | null) {
             if (r.classLinkSourcedId !== undefined) {
               student.classLinkSourcedId = r.classLinkSourcedId;
             }
+            const trimmedEmail = (r.email ?? '').trim();
+            if (trimmedEmail) {
+              student.email = trimmedEmail;
+            }
             if (r.restrictedStudentIds && r.restrictedStudentIds.length > 0) {
               student.restrictedStudentIds = r.restrictedStudentIds;
             }
@@ -247,6 +259,8 @@ export function useRosterRowsState(roster: ClassRoster | null) {
     handleToggleLastNames,
     showPins,
     setShowPins,
+    showEmails,
+    setShowEmails,
     showRestrictions,
     setShowRestrictions,
     toggleRestriction,

--- a/components/widgets/GuidedLearning/components/GuidedLearningResults.tsx
+++ b/components/widgets/GuidedLearning/components/GuidedLearningResults.tsx
@@ -18,6 +18,7 @@ import {
   useAssignmentPseudonyms,
   formatStudentName,
 } from '@/hooks/useAssignmentPseudonyms';
+import { useAuth } from '@/context/useAuth';
 
 interface Props {
   set: GuidedLearningSet;
@@ -64,7 +65,8 @@ export const GuidedLearningResults: React.FC<Props> = ({
     };
   }, [sessionId]);
 
-  const { byStudentUid } = useAssignmentPseudonyms(sessionId, classId);
+  const { orgId } = useAuth();
+  const { byStudentUid } = useAssignmentPseudonyms(sessionId, classId, orgId);
 
   const {
     questionSteps,

--- a/components/widgets/MiniApp/components/SubmissionsModal.tsx
+++ b/components/widgets/MiniApp/components/SubmissionsModal.tsx
@@ -22,6 +22,7 @@ import {
   useAssignmentPseudonymsMulti,
   formatStudentName,
 } from '@/hooks/useAssignmentPseudonyms';
+import { useAuth } from '@/context/useAuth';
 
 interface SubmissionRow {
   id: string;
@@ -42,9 +43,11 @@ export const SubmissionsModal: React.FC<SubmissionsModalProps> = ({
   classIds,
   onClose,
 }) => {
+  const { orgId } = useAuth();
   const { byAssignmentPseudonym } = useAssignmentPseudonymsMulti(
     sessionId,
-    classIds ?? null
+    classIds ?? null,
+    orgId
   );
   const [submissions, setSubmissions] = useState<SubmissionRow[]>([]);
   const [loading, setLoading] = useState(true);

--- a/components/widgets/QuizWidget/Widget.tsx
+++ b/components/widgets/QuizWidget/Widget.tsx
@@ -47,7 +47,7 @@ import { getPlcTeammateEmails } from '@/utils/plc';
 export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
   const { updateWidget, addWidget, addToast, rosters, activeDashboard } =
     useDashboard();
-  const { user, googleAccessToken } = useAuth();
+  const { user, googleAccessToken, orgId } = useAuth();
   const { showConfirm } = useDialog();
   const config = widget.config as QuizConfig;
 
@@ -217,7 +217,8 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
         : [];
   const { byStudentUid } = useAssignmentPseudonymsMulti(
     liveSession?.id ?? null,
-    liveClassIds
+    liveClassIds,
+    orgId
   );
   const byStudentUidRef = useRef(byStudentUid);
   byStudentUidRef.current = byStudentUid;

--- a/components/widgets/QuizWidget/components/QuizLiveMonitor.tsx
+++ b/components/widgets/QuizWidget/components/QuizLiveMonitor.tsx
@@ -57,6 +57,7 @@ import {
 import { resolveResponseDisplayName } from '../utils/resolveDisplayName';
 import { useAssignmentPseudonymsMulti } from '@/hooks/useAssignmentPseudonyms';
 import { db } from '@/config/firebase';
+import { useAuth } from '@/context/useAuth';
 import { useDialog } from '@/context/useDialog';
 import { useClickOutside } from '@/hooks/useClickOutside';
 import {
@@ -266,6 +267,7 @@ export const QuizLiveMonitor: React.FC<QuizLiveMonitorProps> = ({
   onBack,
 }) => {
   const { showConfirm } = useDialog();
+  const { orgId } = useAuth();
   const pinToName = useMemo(
     () =>
       buildPinToNameMap(
@@ -286,7 +288,8 @@ export const QuizLiveMonitor: React.FC<QuizLiveMonitorProps> = ({
   }, [session.classIds, session.classId]);
   const { byStudentUid } = useAssignmentPseudonymsMulti(
     session.id,
-    sessionClassIds
+    sessionClassIds,
+    orgId
   );
   const scoringConfig = useMemo(
     () => ({

--- a/components/widgets/QuizWidget/components/QuizResults.tsx
+++ b/components/widgets/QuizWidget/components/QuizResults.tsx
@@ -102,7 +102,7 @@ export const QuizResults: React.FC<QuizResultsProps> = ({
 }) => {
   const { activeDashboard, updateWidget, addWidget, addToast, rosters } =
     useDashboard();
-  const { googleAccessToken, user } = useAuth();
+  const { googleAccessToken, user, orgId } = useAuth();
   const { plcs, clearPlcSharedSheetUrl, setPlcSharedSheetUrl } = usePlcs();
   const [exporting, setExporting] = useState(false);
   const [exportUrl, setExportUrl] = useState<string | null>(
@@ -158,7 +158,8 @@ export const QuizResults: React.FC<QuizResultsProps> = ({
   // maps are empty and pinToName handles display.
   const { byStudentUid } = useAssignmentPseudonyms(
     session?.id ?? null,
-    session?.classId ?? null
+    session?.classId ?? null,
+    orgId
   );
   const exportPinToName = useMemo(
     () => buildPinToExportNameMap(rosters, resolvedPeriods),

--- a/components/widgets/VideoActivityWidget/components/Results.tsx
+++ b/components/widgets/VideoActivityWidget/components/Results.tsx
@@ -35,10 +35,11 @@ export const Results: React.FC<ResultsProps> = ({
   responses,
   onBack,
 }) => {
-  const { googleAccessToken } = useAuth();
+  const { googleAccessToken, orgId } = useAuth();
   const { byStudentUid } = useAssignmentPseudonyms(
     session.id,
-    session.classId ?? null
+    session.classId ?? null,
+    orgId
   );
   const [exporting, setExporting] = useState(false);
   const [exportUrl, setExportUrl] = useState<string | null>(null);

--- a/functions/src/index.test.ts
+++ b/functions/src/index.test.ts
@@ -1515,5 +1515,236 @@ describe('getPseudonymsForAssignmentV1', () => {
     ).rejects.toThrow('Teacher account required.');
   });
 
-  /* eslint-enable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-assignment */
+  // ── Test-class branch ─────────────────────────────────────────────────
+  // These tests cover the branch added to resolve names for SSO students
+  // who logged in via the `studentLoginV1` test bypass (test classes are
+  // admin-managed mocks under `organizations/{orgId}/testClasses` that
+  // bypass ClassLink/OneRoster entirely).
+
+  /* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-return */
+
+  /**
+   * Wires up the mockFirestore primitives for the test-class branch:
+   *   db.doc('organizations/{org}/members/{email}')   — membership gate
+   *   db.doc('organizations/{org}/testClasses/{cid}') — test-class doc
+   *   db.collection('users/{uid}/rosters').where('testClassId','==',cid)
+   *                                                   — ownership gate
+   *
+   * Pass `null` for `testClass` to simulate a non-existent test-class doc
+   * (so the function falls through to the ClassLink branch).
+   */
+  const installTestClassMocks = (opts: {
+    orgId: string;
+    teacherEmailLower: string;
+    teacherUid: string;
+    isMember: boolean;
+    testClassPath: string;
+    testClass: { memberEmails?: string[] } | null;
+    ownsRoster: boolean;
+  }) => {
+    const memberPath = `organizations/${opts.orgId}/members/${opts.teacherEmailLower}`;
+    mockFirestore.doc.mockImplementation((path: string) => {
+      if (path === memberPath) {
+        return {
+          path,
+          get: vi.fn(() =>
+            Promise.resolve({ exists: opts.isMember, data: () => ({}) })
+          ),
+        } as any;
+      }
+      if (path === opts.testClassPath) {
+        return {
+          path,
+          get: vi.fn(() =>
+            Promise.resolve(
+              opts.testClass
+                ? { exists: true, data: () => opts.testClass }
+                : { exists: false, data: () => ({}) }
+            )
+          ),
+        } as any;
+      }
+      return { path, get: vi.fn(() => Promise.resolve({ exists: false })) };
+    });
+
+    const rostersPath = `users/${opts.teacherUid}/rosters`;
+    const baseCollectionImpl = mockFirestore.collection.getMockImplementation();
+    mockFirestore.collection.mockImplementation((name: string) => {
+      if (name === rostersPath) {
+        return {
+          where: vi.fn(() => ({
+            limit: vi.fn(() => ({
+              get: vi.fn(() =>
+                Promise.resolve({ empty: !opts.ownsRoster, docs: [] })
+              ),
+            })),
+          })),
+        } as any;
+      }
+      // Fall back to the existing collection mock for unrelated collections.
+      return baseCollectionImpl ? baseCollectionImpl(name) : ({} as any);
+    });
+  };
+
+  it('returns pseudonyms keyed by HMAC("test:{email}") for a test-class assignment', async () => {
+    installTestClassMocks({
+      orgId: 'orono',
+      teacherEmailLower: 'teacher@district.org',
+      teacherUid: 'teacher-uid',
+      isMember: true,
+      testClassPath: 'organizations/orono/testClasses/mock-period-1',
+      testClass: {
+        memberEmails: [
+          'sstudent25@orono.k12.mn.us',
+          'OtherStudent@orono.k12.mn.us',
+        ],
+      },
+      ownsRoster: true,
+    });
+    // axios.get must NOT be called for the test-class branch — assert by
+    // not installing any URL-aware responses (default reject would surface
+    // an unexpected ClassLink call as a test failure).
+
+    const handler = getPseudonymsForAssignmentV1 as any;
+    const result = (await handler(
+      {
+        assignmentId: 'asn-1',
+        classId: 'mock-period-1',
+        orgId: 'orono',
+      },
+      { auth: TEACHER_AUTH }
+    )) as {
+      pseudonyms: Record<
+        string,
+        {
+          studentUid: string;
+          assignmentPseudonym: string;
+          givenName: string;
+          familyName: string;
+        }
+      >;
+    };
+
+    // Two members → two pseudonym entries, keyed by lowercased email.
+    expect(Object.keys(result.pseudonyms).sort()).toEqual([
+      'otherstudent@orono.k12.mn.us',
+      'sstudent25@orono.k12.mn.us',
+    ]);
+
+    // Display name is the email local-part (matches the import dialog).
+    expect(result.pseudonyms['sstudent25@orono.k12.mn.us'].givenName).toBe(
+      'sstudent25'
+    );
+    expect(result.pseudonyms['sstudent25@orono.k12.mn.us'].familyName).toBe('');
+    expect(result.pseudonyms['otherstudent@orono.k12.mn.us'].givenName).toBe(
+      'otherstudent'
+    );
+
+    // The studentUid is the same HMAC formula `studentLoginV1` uses for
+    // test-bypass tokens (`HMAC(secret, "sid:test:{emailLower}")`). If the
+    // formulas drift, name resolution silently breaks — pin them together.
+    const cryptoJs = await import('crypto-js');
+    const expectedSstudent25Uid = cryptoJs
+      .HmacSHA256('sid:test:sstudent25@orono.k12.mn.us', 'test-hmac-secret')
+      .toString(cryptoJs.enc.Hex);
+    expect(result.pseudonyms['sstudent25@orono.k12.mn.us'].studentUid).toBe(
+      expectedSstudent25Uid
+    );
+
+    // Axios was NOT called — confirms the test-class branch short-circuits
+    // before any ClassLink lookup.
+    expect(vi.mocked(axios.get)).not.toHaveBeenCalled();
+  });
+
+  it('rejects when the teacher is not a member of the claimed orgId', async () => {
+    installTestClassMocks({
+      orgId: 'orono',
+      teacherEmailLower: 'teacher@district.org',
+      teacherUid: 'teacher-uid',
+      isMember: false, // ← not in the org members collection
+      testClassPath: 'organizations/orono/testClasses/mock-period-1',
+      testClass: { memberEmails: ['s1@orono.k12.mn.us'] },
+      ownsRoster: true,
+    });
+
+    const handler = getPseudonymsForAssignmentV1 as any;
+    await expect(
+      handler(
+        {
+          assignmentId: 'asn-1',
+          classId: 'mock-period-1',
+          orgId: 'orono',
+        },
+        { auth: TEACHER_AUTH }
+      )
+    ).rejects.toThrow('Not a member of this organization.');
+  });
+
+  it("rejects when the teacher doesn't own a roster with matching testClassId", async () => {
+    installTestClassMocks({
+      orgId: 'orono',
+      teacherEmailLower: 'teacher@district.org',
+      teacherUid: 'teacher-uid',
+      isMember: true,
+      testClassPath: 'organizations/orono/testClasses/mock-period-1',
+      testClass: { memberEmails: ['s1@orono.k12.mn.us'] },
+      ownsRoster: false, // ← teacher hasn't imported this test class
+    });
+
+    const handler = getPseudonymsForAssignmentV1 as any;
+    await expect(
+      handler(
+        {
+          assignmentId: 'asn-1',
+          classId: 'mock-period-1',
+          orgId: 'orono',
+        },
+        { auth: TEACHER_AUTH }
+      )
+    ).rejects.toThrow('Not a teacher of this test class.');
+  });
+
+  it('falls through to the ClassLink branch when the testClasses doc does not exist', async () => {
+    installTestClassMocks({
+      orgId: 'orono',
+      teacherEmailLower: 'teacher@district.org',
+      teacherUid: 'teacher-uid',
+      isMember: true,
+      testClassPath: 'organizations/orono/testClasses/c-1',
+      testClass: null, // ← real ClassLink class, not a test class
+      ownsRoster: false, // ← irrelevant; ownership gate is only for test classes
+    });
+    // Configure the standard ClassLink mocks so the fall-through path
+    // can complete and we can assert the existing branch behavior.
+    installAxiosMock({
+      teacher: {
+        users: [{ sourcedId: 'teacher-sid', email: 'teacher@district.org' }],
+      },
+      classes: { classes: [{ sourcedId: 'c-1', title: 'Period 1' }] },
+      students: {
+        users: [
+          {
+            sourcedId: 'student-1-sid',
+            givenName: 'Alex',
+            familyName: 'Stone',
+            email: 's1@district.org',
+          },
+        ],
+      },
+    });
+
+    const handler = getPseudonymsForAssignmentV1 as any;
+    const result = (await handler(
+      { assignmentId: 'asn-1', classId: 'c-1', orgId: 'orono' },
+      { auth: TEACHER_AUTH }
+    )) as { pseudonyms: Record<string, unknown> };
+
+    // The ClassLink branch keys by sourcedId, NOT by email. If this assertion
+    // ever fails, double-check that the test-class branch isn't accidentally
+    // catching real ClassLink classes.
+    expect(result.pseudonyms['student-1-sid']).toBeDefined();
+    expect(vi.mocked(axios.get)).toHaveBeenCalled();
+  });
+
+  /* eslint-enable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-return */
 });

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -3059,10 +3059,15 @@ export const getPseudonymsForAssignmentV1 = onCall(
     const data = request.data as {
       assignmentId?: unknown;
       classId?: unknown;
+      orgId?: unknown;
     };
     const assignmentId =
       typeof data?.assignmentId === 'string' ? data.assignmentId : '';
     const classId = typeof data?.classId === 'string' ? data.classId : '';
+    // orgId is optional for backwards compatibility (older clients). The
+    // test-class branch only activates when it's provided AND the requested
+    // classId resolves to a `testClasses` doc under that org.
+    const orgId = typeof data?.orgId === 'string' ? data.orgId : '';
     if (!assignmentId || !classId) {
       throw new HttpsError(
         'invalid-argument',
@@ -3081,6 +3086,99 @@ export const getPseudonymsForAssignmentV1 = onCall(
       !tenantUrl
     ) {
       throw new HttpsError('internal', 'Server configuration missing.');
+    }
+
+    // ── Test-class branch ────────────────────────────────────────────────
+    // Test classes (admin-managed mocks under `organizations/{orgId}/testClasses`)
+    // bypass ClassLink entirely. Their students log in via the `studentLoginV1`
+    // test bypass, which mints UIDs as `HMAC("sid:test:{emailLower}", secret)`.
+    // ClassLink OneRoster has no record of them, so the standard branch returns
+    // an empty pseudonym map and the teacher monitor falls back to "Student".
+    // This branch resolves names from the `memberEmails` array on the test-class
+    // doc, using the email local-part as the display name (matching what
+    // `materializeTestClassStudents` shows in the import dialog).
+    if (orgId) {
+      const db = admin.firestore();
+      const teacherEmailLower = teacherEmail.toLowerCase();
+      const memberRef = db.doc(
+        `organizations/${orgId}/members/${teacherEmailLower}`
+      );
+      const memberSnap = await memberRef.get();
+      if (!memberSnap.exists) {
+        throw new HttpsError(
+          'permission-denied',
+          'Not a member of this organization.'
+        );
+      }
+
+      const testClassRef = db.doc(
+        `organizations/${orgId}/testClasses/${classId}`
+      );
+      const testClassSnap = await testClassRef.get();
+      if (testClassSnap.exists) {
+        // Authorize: teacher must own a roster whose `testClassId` matches.
+        // Roster metadata lives in Firestore (no Drive read needed for this
+        // gate). Same trust model as the ClassLink branch's "teaches this
+        // class" check, but anchored to the teacher's own roster ownership.
+        const ownedRosters = await db
+          .collection(`users/${request.auth.uid}/rosters`)
+          .where('testClassId', '==', classId)
+          .limit(1)
+          .get();
+        if (ownedRosters.empty) {
+          throw new HttpsError(
+            'permission-denied',
+            'Not a teacher of this test class.'
+          );
+        }
+
+        const testClassData = (testClassSnap.data() ?? {}) as {
+          memberEmails?: unknown;
+        };
+        const memberEmails = Array.isArray(testClassData.memberEmails)
+          ? testClassData.memberEmails.filter(
+              (e): e is string => typeof e === 'string' && e.length > 0
+            )
+          : [];
+
+        const pseudonyms: Record<
+          string,
+          {
+            studentUid: string;
+            assignmentPseudonym: string;
+            givenName: string;
+            familyName: string;
+          }
+        > = {};
+        for (const rawEmail of memberEmails) {
+          const emailLower = rawEmail.toLowerCase();
+          // Mirrors `studentLoginV1` test-bypass UID minting at
+          // functions/src/index.ts ~2868: HMAC over "sid:test:{emailLower}".
+          const studentUid = computeStudentUid(
+            `test:${emailLower}`,
+            hmacSecret
+          );
+          // Display name = email local-part. This matches what the import
+          // dialog already shows (`materializeTestClassStudents` line 66:
+          // `firstName: email.split('@')[0]`), so the monitor view stays
+          // consistent with the roster.
+          const localPart = emailLower.split('@')[0] || emailLower;
+          // Key by the lowercased email (no `sourcedId` exists for test
+          // students). The client-side hook only iterates `Object.values`
+          // and re-keys by `studentUid`, so the key choice is internal.
+          pseudonyms[emailLower] = {
+            studentUid,
+            assignmentPseudonym: computeAssignmentPseudonym(
+              studentUid,
+              assignmentId,
+              hmacSecret
+            ),
+            givenName: localPart,
+            familyName: '',
+          };
+        }
+        return { pseudonyms };
+      }
     }
 
     const cleanTenantUrl = tenantUrl.replace(/\/$/, '');

--- a/hooks/useAssignmentPseudonyms.ts
+++ b/hooks/useAssignmentPseudonyms.ts
@@ -59,29 +59,40 @@ const EMPTY_MAPS: AssignmentPseudonymMaps = {
 let cacheOwnerUid: string | null = null;
 let cache: Map<string, Promise<AssignmentPseudonymMaps>> = new Map();
 
-function cacheKey(assignmentId: string, classId: string): string {
-  return `${assignmentId}::${classId}`;
+function cacheKey(
+  assignmentId: string,
+  classId: string,
+  orgId: string
+): string {
+  // orgId is part of the key so a teacher who belongs to multiple orgs
+  // doesn't get a cached test-class result from the wrong org. For ClassLink
+  // classes (no test-class doc under any org) the lookup result is identical
+  // regardless of orgId, so the duplicate cache cost is negligible.
+  return `${assignmentId}::${classId}::${orgId}`;
 }
 
 function fetchPseudonymMaps(
   assignmentId: string,
   classId: string,
+  orgId: string,
   teacherUid: string
 ): Promise<AssignmentPseudonymMaps> {
   if (cacheOwnerUid !== teacherUid) {
     cache = new Map();
     cacheOwnerUid = teacherUid;
   }
-  const key = cacheKey(assignmentId, classId);
+  const key = cacheKey(assignmentId, classId, orgId);
   const cached = cache.get(key);
   if (cached) return cached;
 
   const callable = httpsCallable<
-    { assignmentId: string; classId: string },
+    { assignmentId: string; classId: string; orgId?: string },
     CallableResponse
   >(functions, 'getPseudonymsForAssignmentV1');
 
-  const promise = callable({ assignmentId, classId }).then((res) => {
+  const promise = callable(
+    orgId ? { assignmentId, classId, orgId } : { assignmentId, classId }
+  ).then((res) => {
     const entries = res.data?.pseudonyms ?? {};
     const byStudentUid = new Map<string, StudentName>();
     const byAssignmentPseudonym = new Map<string, StudentName>();
@@ -112,14 +123,18 @@ interface ResolvedMaps {
 
 function pairKey(
   assignmentId: string | null | undefined,
-  classId: string | null | undefined
+  classId: string | null | undefined,
+  orgId: string | null | undefined
 ): string {
-  return assignmentId && classId ? `${assignmentId}::${classId}` : '';
+  return assignmentId && classId
+    ? `${assignmentId}::${classId}::${orgId ?? ''}`
+    : '';
 }
 
 export function useAssignmentPseudonyms(
   assignmentId: string | null | undefined,
-  classId: string | null | undefined
+  classId: string | null | undefined,
+  orgId: string | null | undefined
 ): AssignmentPseudonymMaps {
   const [resolved, setResolved] = useState<ResolvedMaps>({
     key: '',
@@ -127,12 +142,12 @@ export function useAssignmentPseudonyms(
   });
 
   useEffect(() => {
-    const key = pairKey(assignmentId, classId);
+    const key = pairKey(assignmentId, classId, orgId);
     if (!key || !assignmentId || !classId) return;
     const teacherUid = auth.currentUser?.uid ?? '';
     if (!teacherUid) return;
     let cancelled = false;
-    fetchPseudonymMaps(assignmentId, classId, teacherUid)
+    fetchPseudonymMaps(assignmentId, classId, orgId ?? '', teacherUid)
       .then((maps) => {
         if (!cancelled) setResolved({ key, maps });
       })
@@ -142,9 +157,9 @@ export function useAssignmentPseudonyms(
     return () => {
       cancelled = true;
     };
-  }, [assignmentId, classId]);
+  }, [assignmentId, classId, orgId]);
 
-  const currentKey = pairKey(assignmentId, classId);
+  const currentKey = pairKey(assignmentId, classId, orgId);
   return resolved.key === currentKey && currentKey !== ''
     ? resolved.maps
     : EMPTY_MAPS;
@@ -165,7 +180,8 @@ export function formatStudentName(name: StudentName | undefined): string {
  */
 export function useAssignmentPseudonymsMulti(
   assignmentId: string | null | undefined,
-  classIds: readonly string[] | null | undefined
+  classIds: readonly string[] | null | undefined,
+  orgId: string | null | undefined
 ): AssignmentPseudonymMaps {
   // `classIdsKey` is the canonical, value-stable identity for the caller's
   // class list. Deriving it from the raw prop (instead of from a pre-filtered
@@ -177,6 +193,7 @@ export function useAssignmentPseudonymsMulti(
     .slice()
     .sort()
     .join('|');
+  const orgKey = orgId ?? '';
   const [resolved, setResolved] = useState<{
     key: string;
     maps: AssignmentPseudonymMaps;
@@ -188,10 +205,10 @@ export function useAssignmentPseudonymsMulti(
     if (!teacherUid) return;
     const cleanedInEffect = classIdsKey.split('|');
     let cancelled = false;
-    const key = `${assignmentId}::${classIdsKey}`;
+    const key = `${assignmentId}::${classIdsKey}::${orgKey}`;
     Promise.all(
       cleanedInEffect.map((cid) =>
-        fetchPseudonymMaps(assignmentId, cid, teacherUid)
+        fetchPseudonymMaps(assignmentId, cid, orgKey, teacherUid)
       )
     )
       .then((all) => {
@@ -214,11 +231,11 @@ export function useAssignmentPseudonymsMulti(
     return () => {
       cancelled = true;
     };
-  }, [assignmentId, classIdsKey]);
+  }, [assignmentId, classIdsKey, orgKey]);
 
   const currentKey =
     assignmentId && classIdsKey.length > 0
-      ? `${assignmentId}::${classIdsKey}`
+      ? `${assignmentId}::${classIdsKey}::${orgKey}`
       : '';
   return resolved.key === currentKey && currentKey !== ''
     ? resolved.maps

--- a/types.ts
+++ b/types.ts
@@ -95,6 +95,14 @@ export interface Student {
    */
   classLinkSourcedId?: string;
   /**
+   * Student email. Captured from ClassLink imports and from test-class member
+   * lists. Lives only in the Drive student-list JSON alongside name/PIN — per
+   * the existing PII architecture (see `useRosters.ts` PII migration), this
+   * field is NOT written to any Firestore document. Surfaced as an optional
+   * column in `RosterEditorModal` so teachers can verify imports.
+   */
+  email?: string;
+  /**
    * Stable IDs of classmates this student must never be grouped with in the
    * Randomizer's group-maker mode. Maintained bidirectionally: if B is in A's
    * list, A is in B's list.


### PR DESCRIPTION
## Summary

- Fixes the `"Student"` fallback in the teacher quiz/activity monitor for SSO students who joined via the test-class bypass (admin-managed mocks under `organizations/{orgId}/testClasses`). Adds a test-class branch to `getPseudonymsForAssignmentV1` that mirrors `studentLoginV1`'s `HMAC("sid:test:{email}", secret)` UID formula and resolves display names from the testClasses doc's `memberEmails` (local-part). Gated on the teacher owning a roster with the matching `testClassId` and being a member of the claimed `orgId`.
- Threads `orgId` through `useAssignmentPseudonyms` / `useAssignmentPseudonymsMulti` and the 6 monitor/results callsites (Quiz live + results, Video Activity, Guided Learning, MiniApp). `orgId` is optional on the callable for backwards compat — old in-flight clients still flow through the existing ClassLink branch unchanged.
- Adds an optional `EMAIL` column toggle in the Edit Class modal (matches the existing `+ Last Name` / `+ Quiz PIN` / `+ Restrictions` pattern). Email is captured from ClassLink + test-class imports, round-trips through the editor, and is backfilled on re-sync without overwriting local edits. Per the existing PII architecture, email lives in the Drive student-list JSON only — never written to Firestore.

## Why

Paul's test student `sstudent25@orono.k12.mn.us` showed up as the literal string `"Student"` in the quiz monitor instead of their name. Root cause: `getPseudonymsForAssignmentV1` only fetched names from ClassLink OneRoster, but test-class students are not in ClassLink — so the pseudonym map was empty, the `pin` field is also omitted on SSO responses (per commit `6e81e02c`), and the resolver fell all the way through to `"Student"`. The fix adds the missing test-class branch server-side; no client/monitor display-logic change needed beyond passing `orgId`.

## Test plan
- [x] `pnpm run validate` (type-check + lint + format-check + tests) — passes
- [x] `pnpm test` — 1506 tests pass (incl. 2 new mergeClassLinkStudents email backfill cases)
- [x] `pnpm -C functions test` — 193 tests pass (incl. 4 new test-class-branch cases: happy path, org-membership rejection, roster-ownership rejection, ClassLink fall-through)
- [ ] Smoke test in dev preview: launch a quiz against the test-class roster, sign in as `sstudent25@orono.k12.mn.us` via `/my-assignments`, submit a response, confirm the monitor shows `sstudent25` (not `"Student"`).
- [ ] Real-ClassLink regression: confirm SSO student names from a real ClassLink roster still resolve via the OneRoster branch.
- [ ] Toggle `+ Email` in the Edit Class modal on a fresh ClassLink import — confirm email column populates per row, edits round-trip on save/reopen.

## Notes
- No Firestore schema changes; no `add-test-class.js` re-seeding required.
- `orgId` validation reads `organizations/{orgId}/members/{teacherEmailLower}` — the same gate pattern already used in `firestore.rules`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)