### PR TITLE
feat(my-assignments): class-aware student dashboard with slide-out sidebar

### DIFF
--- a/components/student/AssignmentFilterTabs.tsx
+++ b/components/student/AssignmentFilterTabs.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+
+export type AssignmentFilterMode = 'all' | 'active' | 'completed';
+
+interface AssignmentFilterTabsProps {
+  value: AssignmentFilterMode;
+  onChange: (mode: AssignmentFilterMode) => void;
+  counts?: {
+    all?: number;
+    active?: number;
+    completed?: number;
+  };
+}
+
+const TABS: ReadonlyArray<{ id: AssignmentFilterMode; label: string }> = [
+  { id: 'all', label: 'All' },
+  { id: 'active', label: 'Active' },
+  { id: 'completed', label: 'Completed' },
+];
+
+export const AssignmentFilterTabs: React.FC<AssignmentFilterTabsProps> = ({
+  value,
+  onChange,
+  counts,
+}) => (
+  <div
+    role="tablist"
+    aria-label="Filter assignments"
+    className="inline-flex items-center gap-1 rounded-full bg-white border border-slate-200 p-1 shadow-sm"
+  >
+    {TABS.map((tab) => {
+      const isActive = tab.id === value;
+      const count = counts?.[tab.id];
+      return (
+        <button
+          key={tab.id}
+          type="button"
+          role="tab"
+          aria-selected={isActive}
+          onClick={() => onChange(tab.id)}
+          className={`inline-flex items-center gap-1.5 rounded-full px-3 py-1.5 text-xs font-semibold transition focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue-primary focus-visible:ring-offset-1 ${
+            isActive
+              ? 'bg-brand-blue-primary text-white shadow-sm'
+              : 'text-slate-600 hover:text-slate-900'
+          }`}
+        >
+          <span>{tab.label}</span>
+          {typeof count === 'number' && (
+            <span
+              className={`inline-block min-w-[1.5em] text-center tabular-nums text-[11px] ${
+                isActive ? 'text-white/85' : 'text-slate-400'
+              }`}
+            >
+              {count}
+            </span>
+          )}
+        </button>
+      );
+    })}
+  </div>
+);

--- a/components/student/AssignmentListItem.tsx
+++ b/components/student/AssignmentListItem.tsx
@@ -1,0 +1,196 @@
+import React, { useEffect, useState } from 'react';
+import { doc, getDoc } from 'firebase/firestore';
+import { httpsCallable } from 'firebase/functions';
+import { CheckCircle2 } from 'lucide-react';
+import { db, functions } from '@/config/firebase';
+import {
+  KIND_CONFIG,
+  type AssignmentSummary,
+} from '@/hooks/useStudentAssignments';
+import type { ClassDirectoryEntry } from '@/hooks/useStudentClassDirectory';
+
+/**
+ * Lazy completion check — same pattern as the previous AssignmentCard but
+ * surfaced as a calmer list-row visual matching the redesign.
+ *
+ * Pseudonym cache: per-(uid, sessionId), de-dupes the callable across
+ * concurrent renders. Module-local; survives card remounts within a single
+ * page lifetime. Pseudonyms are stable for a given (uid, assignmentId).
+ */
+
+let pseudonymCacheOwnerUid: string | null = null;
+let pseudonymCache: Map<string, Promise<string>> = new Map();
+
+function getCachedPseudonym(
+  sessionId: string,
+  pseudonymUid: string
+): Promise<string> {
+  if (pseudonymCacheOwnerUid !== pseudonymUid) {
+    pseudonymCache = new Map();
+    pseudonymCacheOwnerUid = pseudonymUid;
+  }
+  const cached = pseudonymCache.get(sessionId);
+  if (cached) return cached;
+
+  const callable = httpsCallable<
+    { assignmentId: string },
+    { pseudonym?: string }
+  >(functions, 'getAssignmentPseudonymV1');
+
+  const promise = callable({ assignmentId: sessionId }).then((res) => {
+    const p = res.data?.pseudonym;
+    if (typeof p !== 'string' || p.length === 0) {
+      throw new Error('Pseudonym missing from callable response.');
+    }
+    return p;
+  });
+
+  pseudonymCache.set(sessionId, promise);
+  promise.catch(() => {
+    if (pseudonymCache.get(sessionId) === promise) {
+      pseudonymCache.delete(sessionId);
+    }
+  });
+  return promise;
+}
+
+/** Subcollection that holds per-student response/submission docs, keyed by pseudonym. */
+const RESPONSE_SUBCOLLECTION: Record<AssignmentSummary['kind'], string | null> =
+  {
+    quiz: 'responses',
+    'video-activity': 'responses',
+    'guided-learning': 'responses',
+    'mini-app': 'submissions',
+    'activity-wall': 'submissions',
+  };
+
+export type CompletionState = 'unknown' | 'completed' | 'not-completed';
+
+interface AssignmentListItemProps {
+  assignment: AssignmentSummary;
+  pseudonymUid: string | null;
+  /** Optional class directory entry for the assignment's primary class — used in the meta line. */
+  classEntry?: ClassDirectoryEntry;
+  /** Hide the class name (e.g. when rendered inside a per-class view). */
+  hideClassName?: boolean;
+  /**
+   * Called once the per-row completion check resolves to a non-'unknown'
+   * state. The parent uses this to partition rows into Active vs Completed.
+   */
+  onCompletionResolved?: (
+    sessionId: string,
+    kind: AssignmentSummary['kind'],
+    completion: CompletionState
+  ) => void;
+}
+
+export const AssignmentListItem: React.FC<AssignmentListItemProps> = ({
+  assignment,
+  pseudonymUid,
+  classEntry,
+  hideClassName,
+  onCompletionResolved,
+}) => {
+  const [completion, setCompletion] = useState<CompletionState>('unknown');
+  const config = KIND_CONFIG[assignment.kind];
+  const responseSub = RESPONSE_SUBCOLLECTION[assignment.kind];
+
+  useEffect(() => {
+    if (!pseudonymUid) return;
+    if (!responseSub) return;
+
+    let cancelled = false;
+    const run = async () => {
+      try {
+        const pseudonym = await getCachedPseudonym(
+          assignment.sessionId,
+          pseudonymUid
+        );
+        if (cancelled) return;
+        const snap = await getDoc(
+          doc(
+            db,
+            config.collectionName,
+            assignment.sessionId,
+            responseSub,
+            pseudonym
+          )
+        );
+        if (cancelled) return;
+        const next: CompletionState = snap.exists()
+          ? 'completed'
+          : 'not-completed';
+        setCompletion(next);
+        onCompletionResolved?.(assignment.sessionId, assignment.kind, next);
+      } catch {
+        // Silent: a failed completion check shouldn't block the student
+        // from opening the assignment. Leave completion as 'unknown'.
+      }
+    };
+    void run();
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    assignment.sessionId,
+    assignment.kind,
+    pseudonymUid,
+    config.collectionName,
+    responseSub,
+    onCompletionResolved,
+  ]);
+
+  const isCompleted = completion === 'completed';
+
+  return (
+    <a
+      href={assignment.openHref}
+      className={`group flex items-center gap-3 rounded-xl border border-slate-200 bg-white px-4 py-3 transition hover:border-slate-300 hover:shadow-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue-primary focus-visible:ring-offset-2 ${
+        isCompleted ? 'opacity-80' : ''
+      }`}
+    >
+      <span
+        className={`inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-full border-2 ${
+          isCompleted
+            ? 'border-emerald-500 bg-emerald-500 text-white'
+            : 'border-slate-300 text-transparent'
+        }`}
+        aria-hidden="true"
+      >
+        {isCompleted && <CheckCircle2 className="h-4 w-4" strokeWidth={2.5} />}
+      </span>
+
+      <div className="min-w-0 flex-1">
+        <p
+          className={`truncate text-sm font-semibold sm:text-base ${
+            isCompleted ? 'text-slate-500 line-through' : 'text-slate-800'
+          }`}
+        >
+          {assignment.title}
+        </p>
+        <p className="mt-0.5 truncate text-xs text-slate-500">
+          {!hideClassName && classEntry?.name && (
+            <span className="font-medium text-slate-600">
+              {classEntry.name}
+            </span>
+          )}
+          {!hideClassName && classEntry?.name && (
+            <span className="px-1.5 text-slate-300">·</span>
+          )}
+          <span>{config.label}</span>
+        </p>
+      </div>
+
+      <span
+        className={`hidden shrink-0 rounded-lg px-3 py-1.5 text-xs font-semibold transition sm:inline-flex ${
+          isCompleted
+            ? 'bg-slate-100 text-slate-500 group-hover:bg-slate-200'
+            : 'bg-brand-blue-primary text-white shadow-sm shadow-brand-blue-primary/20 group-hover:bg-brand-blue-dark'
+        }`}
+        aria-hidden="true"
+      >
+        {isCompleted ? 'Review' : 'Open'}
+      </span>
+    </a>
+  );
+};

--- a/components/student/AssignmentSections.tsx
+++ b/components/student/AssignmentSections.tsx
@@ -1,0 +1,165 @@
+import React from 'react';
+import { Inbox } from 'lucide-react';
+import { AssignmentListItem, type CompletionState } from './AssignmentListItem';
+import type { AssignmentSummary } from '@/hooks/useStudentAssignments';
+import type { ClassDirectoryEntry } from '@/hooks/useStudentClassDirectory';
+import type { AssignmentFilterMode } from './AssignmentFilterTabs';
+
+/**
+ * Renders the Active and/or Completed sections per the selected filter
+ * mode. Shared between StudentOverview (all classes) and StudentClassView
+ * (single class) so the partition rule lives in one place.
+ *
+ * Partition rule (matches the plan):
+ *   - completion === 'completed' → Completed section
+ *   - completion === 'not-completed' AND channel === 'active' → Active
+ *   - completion === 'not-completed' AND channel === 'ended' → hidden
+ *   - completion === 'unknown' → Active (with neutral pill, resolves later)
+ */
+
+interface AssignmentSectionsProps {
+  mode: AssignmentFilterMode;
+  active: AssignmentSummary[];
+  completed: AssignmentSummary[];
+  pseudonymUid: string | null;
+  directoryById: Record<string, ClassDirectoryEntry>;
+  hideClassName?: boolean;
+  onCompletionResolved: (
+    sessionId: string,
+    kind: AssignmentSummary['kind'],
+    completion: CompletionState
+  ) => void;
+  /** Optional override for the all-empty state (mode='all', both sections empty). */
+  emptyAll?: React.ReactNode;
+}
+
+export const AssignmentSections: React.FC<AssignmentSectionsProps> = ({
+  mode,
+  active,
+  completed,
+  pseudonymUid,
+  directoryById,
+  hideClassName,
+  onCompletionResolved,
+  emptyAll,
+}) => {
+  const showActive = mode === 'all' || mode === 'active';
+  const showCompleted = mode === 'all' || mode === 'completed';
+
+  // All-empty fallback for mode='all' so the page reads as "you're all caught
+  // up" instead of two empty headers.
+  if (mode === 'all' && active.length === 0 && completed.length === 0) {
+    return (
+      <>
+        {emptyAll ?? (
+          <CalmEmpty
+            title="All caught up"
+            body="You're all caught up — nothing active or completed yet."
+          />
+        )}
+      </>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-8">
+      {showActive && (
+        <Section
+          label="Active"
+          count={active.length}
+          empty={
+            mode === 'all' ? (
+              <p className="text-sm text-slate-500">
+                Nothing active right now.
+              </p>
+            ) : (
+              <CalmEmpty
+                title="All caught up"
+                body="You're all caught up — no active assignments right now."
+              />
+            )
+          }
+        >
+          {active.map((a) => (
+            <AssignmentListItem
+              key={a.compositeId}
+              assignment={a}
+              pseudonymUid={pseudonymUid}
+              classEntry={
+                a.classIds[0] ? directoryById[a.classIds[0]] : undefined
+              }
+              hideClassName={hideClassName}
+              onCompletionResolved={onCompletionResolved}
+            />
+          ))}
+        </Section>
+      )}
+      {showCompleted && (
+        <Section
+          label="Completed"
+          count={completed.length}
+          empty={
+            mode === 'all' ? (
+              <p className="text-sm text-slate-500">Nothing completed yet.</p>
+            ) : (
+              <CalmEmpty
+                title="Nothing completed yet"
+                body="Once you finish an assignment, it'll show up here."
+              />
+            )
+          }
+        >
+          {completed.map((a) => (
+            <AssignmentListItem
+              key={a.compositeId}
+              assignment={a}
+              pseudonymUid={pseudonymUid}
+              classEntry={
+                a.classIds[0] ? directoryById[a.classIds[0]] : undefined
+              }
+              hideClassName={hideClassName}
+              onCompletionResolved={onCompletionResolved}
+            />
+          ))}
+        </Section>
+      )}
+    </div>
+  );
+};
+
+interface SectionProps {
+  label: string;
+  count: number;
+  empty: React.ReactNode;
+  children?: React.ReactNode;
+}
+
+const Section: React.FC<SectionProps> = ({ label, count, empty, children }) => (
+  <section>
+    <header className="mb-3 flex items-baseline justify-between">
+      <h2 className="text-[11px] font-bold uppercase tracking-[0.14em] text-slate-500">
+        {label} · {count}
+      </h2>
+    </header>
+    {count === 0 ? (
+      empty
+    ) : (
+      <div className="flex flex-col gap-2">{children}</div>
+    )}
+  </section>
+);
+
+const CalmEmpty: React.FC<{ title: string; body: string }> = ({
+  title,
+  body,
+}) => (
+  <div className="flex min-h-[200px] flex-col items-center justify-center gap-3 rounded-2xl border border-dashed border-slate-200 px-6 py-10 text-center">
+    <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-slate-100">
+      <Inbox className="h-6 w-6 text-slate-400" strokeWidth={2} />
+    </div>
+    <div className="max-w-sm">
+      <h3 className="text-sm font-bold text-slate-700">{title}</h3>
+      <p className="mt-1 text-sm text-slate-500">{body}</p>
+    </div>
+  </div>
+);

--- a/components/student/MyAssignmentsPage.tsx
+++ b/components/student/MyAssignmentsPage.tsx
@@ -1,4 +1,10 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import {
   AlertCircle,
   AlertTriangle,
@@ -85,6 +91,34 @@ const MyAssignmentsPage: React.FC = () => {
       setSidebarOpen(false);
     }
   }, []);
+
+  // Hamburger-button ref so we can restore focus when the sidebar closes.
+  // The closed sidebar is `inert`, which means any focus left inside its
+  // subtree at close time would be stranded — restoring to the trigger is
+  // the standard a11y pattern (matches WAI-ARIA disclosure / dialog
+  // recommendations).
+  const menuButtonRef = useRef<HTMLButtonElement | null>(null);
+  const prevSidebarOpenRef = useRef(sidebarOpen);
+  useEffect(() => {
+    if (prevSidebarOpenRef.current && !sidebarOpen) {
+      menuButtonRef.current?.focus();
+    }
+    prevSidebarOpenRef.current = sidebarOpen;
+  }, [sidebarOpen]);
+
+  // Esc closes the sidebar. Mounted only while open so we don't add an
+  // always-on listener for what is otherwise a quiet page.
+  useEffect(() => {
+    if (!sidebarOpen) return;
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.stopPropagation();
+        setSidebarOpen(false);
+      }
+    };
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [sidebarOpen]);
 
   // Filter mode persists to sessionStorage so a refresh keeps it but the
   // choice never follows the student onto a shared device.
@@ -254,6 +288,7 @@ const MyAssignmentsPage: React.FC = () => {
         onDone={handleDone}
         onToggleMenu={toggleSidebar}
         menuOpen={sidebarOpen}
+        menuButtonRef={menuButtonRef}
         hideDoneButton
       >
         {hasErrors && <PartialFailureBanner onRetry={retry} className="mb-4" />}
@@ -301,6 +336,13 @@ interface PageShellProps {
   onToggleMenu?: () => void;
   menuOpen?: boolean;
   /**
+   * Ref forwarded to the hamburger menu button so the page can restore
+   * focus there when the sidebar closes (e.g. via Esc, backdrop tap, or
+   * auto-close on class selection). Without this, focus left inside the
+   * now-`inert` sidebar would be stranded for keyboard users.
+   */
+  menuButtonRef?: React.Ref<HTMLButtonElement>;
+  /**
    * When true, suppresses the header's Done button. Sign-out lives in the
    * sidebar footer once the student is past the gate paths.
    */
@@ -312,6 +354,7 @@ const PageShell: React.FC<PageShellProps> = ({
   onDone,
   onToggleMenu,
   menuOpen,
+  menuButtonRef,
   hideDoneButton,
   children,
 }) => (
@@ -328,6 +371,7 @@ const PageShell: React.FC<PageShellProps> = ({
         <div className="flex min-w-0 items-center gap-3">
           {onToggleMenu ? (
             <button
+              ref={menuButtonRef}
               type="button"
               onClick={onToggleMenu}
               aria-label={menuOpen ? 'Close class menu' : 'Open class menu'}

--- a/components/student/MyAssignmentsPage.tsx
+++ b/components/student/MyAssignmentsPage.tsx
@@ -136,7 +136,10 @@ const MyAssignmentsPage: React.FC = () => {
     []
   );
 
-  const todayDate = useMemo(() => formatTodayLong(new Date()), []);
+  // Computed inline rather than memoized — `toLocaleDateString` is cheap
+  // and the empty-deps memo would otherwise stick to the date the page
+  // was first mounted across day transitions.
+  const todayDate = formatTodayLong(new Date());
 
   // Partition assignments according to the rule in the plan. Compute once
   // at the page level and slice per scope (overview vs class) below.

--- a/components/student/MyAssignmentsPage.tsx
+++ b/components/student/MyAssignmentsPage.tsx
@@ -1,676 +1,443 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import {
-  collection,
-  doc,
-  getDoc,
-  onSnapshot,
-  query,
-  where,
-  type Query,
-  type QuerySnapshot,
-  type DocumentData,
-} from 'firebase/firestore';
-import { httpsCallable } from 'firebase/functions';
-import {
   AlertCircle,
   AlertTriangle,
-  CheckCircle2,
-  ClipboardList,
   GraduationCap,
-  Image as ImageIcon,
-  Inbox,
   Loader2,
   LogOut,
-  PlayCircle,
-  Puzzle,
+  Menu,
   RefreshCw,
-  Sparkles,
 } from 'lucide-react';
-import { db, functions } from '@/config/firebase';
 import { APP_NAME } from '@/config/constants';
 import { useStudentAuth } from '@/context/useStudentAuth';
+import {
+  useStudentAssignments,
+  type AssignmentSummary,
+} from '@/hooks/useStudentAssignments';
+import { useStudentClassDirectory } from '@/hooks/useStudentClassDirectory';
+import { StudentSidebar } from './StudentSidebar';
+import { StudentOverview } from './StudentOverview';
+import { StudentClassView } from './StudentClassView';
+import { type AssignmentFilterMode } from './AssignmentFilterTabs';
+import type { CompletionState } from './AssignmentListItem';
 
 /**
- * MyAssignmentsPage — Phase 2C of the ClassLink-via-Google auth flow.
+ * /my-assignments — class-aware student dashboard.
  *
- * Landing page for a signed-in student. Subscribes to the five session
- * collections (`quiz_sessions`, `video_activity_sessions`,
- * `guided_learning_sessions`, `mini_app_sessions`, `activity_wall_sessions`)
- * and renders the union as a single list.
+ * Layout: a slide-out sidebar (class list) toggled by a hamburger button in
+ * the page header, plus a main column (overview or per-class view). The
+ * sidebar opens by default on desktop, closed by default on mobile, where
+ * it presents as a slide-over with a tap-to-close backdrop.
  *
- * Query strategy: quiz / video-activity / guided-learning subscribe to TWO
- * queries each — one on the Phase 5A `classIds` array (array-contains-any)
- * and one on the legacy `classId` string (in) — merging by sessionId so
- * students in *any* class targeted by a multi-class assignment are covered
- * while legacy single-class sessions still surface. Mini-app is list-only
- * (its sessions have always been multi-class) and activity-wall is
- * single-only (has not been migrated to multi-class yet).
+ * Subscribes via `useStudentAssignments` to two channels (active + ended)
+ * per supported session kind, and resolves class names / teacher names via
+ * `useStudentClassDirectory`.
  *
- * PII-free: reads only session-level fields (title, status, code, classId).
- * Never reads, logs, or persists email / displayName / sub. The only
- * identifier we touch is the custom-token pseudonym UID from
- * `useStudentAuth`.
+ * PII guarantees still hold: only the opaque pseudonym uid + claim-bound
+ * classIds are read on the client. Teacher names are surfaced (org data,
+ * not student PII). The student's own name is never shown — claims don't
+ * carry it.
  *
- * Completion check strategy: LAZY per-row. Each `AssignmentCard` kicks off
- * a single `getAssignmentPseudonymV1` callable (results cached across the
- * page lifetime via a shared `Map` ref) and then a single `getDoc`
- * existence check against the correct response subcollection. This lets
- * React render the list immediately and fill in completion badges as they
- * resolve, rather than blocking on a large Promise.all.
- *
- * Firestore `in` cap: `classIds` is capped at 20 by `studentLoginV1`.
- * Firestore's `where('x', 'in', arr)` supports up to 30 values. Do NOT
- * raise the `studentLoginV1` cap past 30 without splitting this query
- * into chunks.
+ * Active vs Completed partition is computed client-side from the lazy
+ * completion check on each row. See AssignmentSections for the rule.
  */
 
-// ---------------------------------------------------------------------------
-// Types
-// ---------------------------------------------------------------------------
+const FILTER_STORAGE_KEY = 'sb_my_assignments_filter';
 
-type SessionKind =
-  | 'quiz'
-  | 'video-activity'
-  | 'guided-learning'
-  | 'mini-app'
-  | 'activity-wall';
+const isFilterMode = (v: unknown): v is AssignmentFilterMode =>
+  v === 'all' || v === 'active' || v === 'completed';
 
-interface AssignmentSummary {
-  /** `${kind}:${sessionId}` — stable React key across collections. */
-  compositeId: string;
-  kind: SessionKind;
-  sessionId: string;
-  title: string;
-  /** Fully-qualified path the student can click to open the session. */
-  openHref: string;
-  /** When the session was created (for sorting). May be undefined for ad-hoc docs. */
-  createdAt?: number;
-}
-
-type LoadState = 'loading' | 'ready';
-
-interface KindConfig {
-  collectionName: string;
-  /**
-   * When true, subscribe to TWO queries per kind and merge results by
-   * `sessionId` (de-duping any overlap):
-   *   - `list`   — `where('classIds', 'array-contains-any', classIds)` — Phase 5A multi-class
-   *   - `single` — `where('classId', 'in', classIds)`                   — legacy single-class
-   * This is required for quiz/video-activity/guided-learning so that
-   * multi-class assignments (Phase 5A) are discovered for students in
-   * *any* targeted class — not just `classIds[0]` — while legacy
-   * single-class sessions (with no `classIds` array) still surface.
-   *
-   * When false, a single query is issued using `classFilterShape`.
-   */
-  dualQuery: boolean;
-  /** Firestore status filter, or `null` when the collection has no status field. */
-  statusFilter:
-    | { field: 'status'; value: 'active' }
-    | { field: 'status'; valueIn: readonly string[] }
-    | null;
-  /**
-   * Shape used when `dualQuery` is false. Describes how this collection
-   * stores its class targeting:
-   *   - `single` — a string `classId` field (queried with `where(..., 'in', classIds)`)
-   *   - `list`   — an array `classIds` field (queried with `where(..., 'array-contains-any', classIds)`)
-   */
-  classFilterShape: 'single' | 'list';
-  /** Subcollection where per-student response/submission docs live; null when absent. */
-  responseSubcollection: string | null;
-  label: string;
-  icon: React.ComponentType<{ className?: string; strokeWidth?: number }>;
-  /** Tailwind gradient for the card accent badge. */
-  accent: string;
-  /** Given a raw session document, build the display title. */
-  titleFrom: (data: DocumentData) => string;
-  /** Given a session id and the raw session doc, build the /open URL. */
-  hrefFrom: (sessionId: string, data: DocumentData) => string;
-}
-
-// ---------------------------------------------------------------------------
-// Per-kind configuration
-// ---------------------------------------------------------------------------
-//
-// Fields verified against:
-//   - `types.ts` (QuizSession, VideoActivitySession, MiniAppSession,
-//     GuidedLearningSession)
-//   - `firestore.rules` — each collection's `passesStudentClassGate` read rule
-//   - `components/widgets/ActivityWall/Widget.tsx` (session doc is created
-//     ad-hoc without a TS interface — fields confirmed from the setDoc call)
-//
-// Notes:
-//   - guided_learning_sessions and activity_wall_sessions have NO status
-//     field on the session document. The GL assignment wrapper lives in
-//     /users/{teacherUid}/guided_learning_assignments and ActivityWall uses
-//     the session's existence as liveness. We intentionally do not filter
-//     those by status.
-//   - mini_app_sessions submissions live under the `submissions` subcollection
-//     (doc ID = per-assignment pseudonym for studentRole launches, auth uid
-//     for anonymous launches). See MiniAppStudentApp.tsx for the write path
-//     and firestore.rules for the matching read/create rules.
-
-const KIND_CONFIG: Record<SessionKind, KindConfig> = {
-  quiz: {
-    collectionName: 'quiz_sessions',
-    dualQuery: true,
-    // Include `waiting` so teacher-paced quizzes (which sit in 'waiting'
-    // after Play but before the teacher advances to Q1) surface on
-    // `/my-assignments` — matching the PIN-flow experience.
-    statusFilter: { field: 'status', valueIn: ['waiting', 'active'] },
-    classFilterShape: 'single',
-    responseSubcollection: 'responses',
-    label: 'Quiz',
-    icon: ClipboardList,
-    accent: 'from-blue-500 to-indigo-600',
-    titleFrom: (data) =>
-      typeof data.quizTitle === 'string' && data.quizTitle.length > 0
-        ? data.quizTitle
-        : 'Untitled quiz',
-    hrefFrom: (sessionId, data) => {
-      // Quiz student app joins via ?code=<code> (the 6-char join code) rather
-      // than sessionId. Fall back to sessionId if code isn't present on the
-      // doc (shouldn't happen in practice, but keeps the link functional).
-      const code =
-        typeof data.code === 'string' && data.code.length > 0
-          ? data.code
-          : sessionId;
-      return `/quiz?code=${encodeURIComponent(code)}`;
-    },
-  },
-  'video-activity': {
-    collectionName: 'video_activity_sessions',
-    dualQuery: true,
-    statusFilter: { field: 'status', value: 'active' },
-    classFilterShape: 'single',
-    responseSubcollection: 'responses',
-    label: 'Video Activity',
-    icon: PlayCircle,
-    accent: 'from-rose-500 to-red-600',
-    titleFrom: (data) => {
-      if (
-        typeof data.activityTitle === 'string' &&
-        data.activityTitle.length > 0
-      )
-        return data.activityTitle;
-      if (
-        typeof data.assignmentName === 'string' &&
-        data.assignmentName.length > 0
-      )
-        return data.assignmentName;
-      return 'Video activity';
-    },
-    hrefFrom: (sessionId) => `/activity/${encodeURIComponent(sessionId)}`,
-  },
-  'guided-learning': {
-    collectionName: 'guided_learning_sessions',
-    dualQuery: true,
-    statusFilter: null, // No status field; session presence = live.
-    classFilterShape: 'single',
-    responseSubcollection: 'responses',
-    label: 'Guided Learning',
-    icon: Sparkles,
-    accent: 'from-emerald-500 to-teal-600',
-    titleFrom: (data) =>
-      typeof data.title === 'string' && data.title.length > 0
-        ? data.title
-        : 'Guided learning',
-    hrefFrom: (sessionId) =>
-      `/guided-learning/${encodeURIComponent(sessionId)}`,
-  },
-  'mini-app': {
-    collectionName: 'mini_app_sessions',
-    dualQuery: false,
-    statusFilter: { field: 'status', value: 'active' },
-    classFilterShape: 'list',
-    responseSubcollection: 'submissions',
-    label: 'Mini App',
-    icon: Puzzle,
-    accent: 'from-violet-500 to-purple-600',
-    titleFrom: (data) => {
-      if (typeof data.appTitle === 'string' && data.appTitle.length > 0)
-        return data.appTitle;
-      if (
-        typeof data.assignmentName === 'string' &&
-        data.assignmentName.length > 0
-      )
-        return data.assignmentName;
-      return 'Mini app';
-    },
-    hrefFrom: (sessionId) => `/miniapp/${encodeURIComponent(sessionId)}`,
-  },
-  'activity-wall': {
-    collectionName: 'activity_wall_sessions',
-    dualQuery: false,
-    statusFilter: null, // No status field on the session doc.
-    classFilterShape: 'single',
-    // ActivityWall submissions are a LIST per student (students can post
-    // multiple). We still use existence as a "has the student participated
-    // yet?" signal — but the doc id is the pseudonym, so this is a
-    // best-effort hint, not a true completion.
-    responseSubcollection: 'submissions',
-    label: 'Activity Wall',
-    icon: ImageIcon,
-    accent: 'from-amber-500 to-orange-600',
-    titleFrom: (data) =>
-      typeof data.title === 'string' && data.title.length > 0
-        ? data.title
-        : 'Activity wall',
-    hrefFrom: (sessionId) => `/activity-wall/${encodeURIComponent(sessionId)}`,
-  },
-};
-
-const SESSION_KINDS: readonly SessionKind[] = [
-  'quiz',
-  'video-activity',
-  'guided-learning',
-  'mini-app',
-  'activity-wall',
-];
-
-// ---------------------------------------------------------------------------
-// Page component
-// ---------------------------------------------------------------------------
-
-interface AssignmentsByKind {
-  [kind: string]: AssignmentSummary[];
-}
+const formatTodayLong = (now: Date): string =>
+  now.toLocaleDateString(undefined, {
+    weekday: 'short',
+    month: 'short',
+    day: 'numeric',
+  });
 
 const MyAssignmentsPage: React.FC = () => {
-  const { classIds, pseudonymUid, signOut } = useStudentAuth();
-  const [byKind, setByKind] = useState<AssignmentsByKind>(() =>
-    Object.fromEntries(SESSION_KINDS.map((k) => [k, []]))
-  );
-  const [loadState, setLoadState] = useState<LoadState>('loading');
-  // Keyed on `${kind}:${shape}` so dual-query kinds (one list + one single
-  // subscription) track each bucket independently. Keying on `kind` alone
-  // let a succeeding shape clear the error for its still-failing sibling,
-  // which would hide half-missing data behind a "loaded" state.
-  const [erroredBuckets, setErroredBuckets] = useState<Set<string>>(
-    () => new Set()
-  );
-  const [retryNonce, setRetryNonce] = useState(0);
+  const { classIds, pseudonymUid, firstName, signOut } = useStudentAuth();
 
-  // Stable subscription identity: we only re-subscribe when classIds actually
-  // changes, not on every render.
-  const classIdsKey = useMemo(
-    () => classIds.slice().sort().join('|'),
-    [classIds]
-  );
+  const directory = useStudentClassDirectory({ classIds, pseudonymUid });
+  const { loadState, assignments, hasErrors, retry } = useStudentAssignments({
+    classIds,
+  });
 
-  useEffect(() => {
-    // No classes → no queries (Firestore rejects `in` with []).
-    if (classIds.length === 0) {
-      setByKind(Object.fromEntries(SESSION_KINDS.map((k) => [k, []])));
-      setErroredBuckets(new Set());
-      setLoadState('ready');
-      return;
+  // Active class selection — null = "All classes" overview.
+  const [activeClassId, setActiveClassId] = useState<string | null>(null);
+
+  // Slide-out sidebar visibility. Defaults open on desktop, closed on mobile
+  // — once the student toggles, we respect their choice. Initial state is
+  // derived from the viewport at first render and never auto-snaps back.
+  const [sidebarOpen, setSidebarOpen] = useState<boolean>(() => {
+    if (typeof window === 'undefined') return true;
+    return window.matchMedia('(min-width: 768px)').matches;
+  });
+  const toggleSidebar = useCallback(() => setSidebarOpen((o) => !o), []);
+  const closeSidebar = useCallback(() => setSidebarOpen(false), []);
+  // On mobile, picking a class auto-closes the sidebar so the student lands
+  // on the chosen view immediately. Desktop keeps it open across navigations.
+  const handleSelectClass = useCallback((classId: string | null) => {
+    setActiveClassId(classId);
+    if (
+      typeof window !== 'undefined' &&
+      !window.matchMedia('(min-width: 768px)').matches
+    ) {
+      setSidebarOpen(false);
     }
-
-    setLoadState('loading');
-    setErroredBuckets(new Set());
-
-    type QueryShape = 'list' | 'single';
-    const bucketKey = (kind: SessionKind, shape: QueryShape) =>
-      `${kind}:${shape}`;
-
-    // Plan every (kind, shape) subscription up front so we know the total
-    // count and can flip to `ready` exactly when every subscription has
-    // delivered its first snapshot (success OR error).
-    const subs: Array<{ kind: SessionKind; shape: QueryShape }> = [];
-    for (const kind of SESSION_KINDS) {
-      const config = KIND_CONFIG[kind];
-      if (config.dualQuery) {
-        subs.push({ kind, shape: 'list' }, { kind, shape: 'single' });
-      } else {
-        subs.push({ kind, shape: config.classFilterShape });
-      }
-    }
-    const totalSubscriptions = subs.length;
-
-    // Per-(kind, shape) result buckets. When a kind has two subscriptions
-    // we merge both buckets by `sessionId` before emitting `byKind`, so a
-    // Phase 5A session whose `classIds[0]` equals one of the student's
-    // classIds (and therefore matches BOTH queries) is counted exactly
-    // once.
-    const buckets = new Map<string, AssignmentSummary[]>();
-    const settled = new Set<string>();
-
-    const docToSummary = (
-      kind: SessionKind,
-      config: KindConfig,
-      d: QuerySnapshot<DocumentData>['docs'][number]
-    ): AssignmentSummary => {
-      const data = d.data();
-      const createdAtRaw: unknown = (data as Record<string, unknown>).createdAt;
-      return {
-        compositeId: `${kind}:${d.id}`,
-        kind,
-        sessionId: d.id,
-        title: config.titleFrom(data),
-        openHref: config.hrefFrom(d.id, data),
-        createdAt: typeof createdAtRaw === 'number' ? createdAtRaw : undefined,
-      };
-    };
-
-    const emitMerged = (kind: SessionKind) => {
-      const listBucket = buckets.get(bucketKey(kind, 'list')) ?? [];
-      const singleBucket = buckets.get(bucketKey(kind, 'single')) ?? [];
-      if (listBucket.length === 0 && singleBucket.length === 0) {
-        setByKind((prev) =>
-          prev[kind] && prev[kind].length === 0 ? prev : { ...prev, [kind]: [] }
-        );
-        return;
-      }
-      const merged = new Map<string, AssignmentSummary>();
-      for (const a of listBucket) merged.set(a.sessionId, a);
-      for (const a of singleBucket) merged.set(a.sessionId, a);
-      setByKind((prev) => ({ ...prev, [kind]: Array.from(merged.values()) }));
-    };
-
-    const markSettled = (kind: SessionKind, shape: QueryShape) => {
-      settled.add(bucketKey(kind, shape));
-      if (settled.size === totalSubscriptions) {
-        setLoadState('ready');
-      }
-    };
-
-    const clearBucketError = (kind: SessionKind, shape: QueryShape) => {
-      const key = bucketKey(kind, shape);
-      setErroredBuckets((prev) => {
-        if (!prev.has(key)) return prev;
-        const next = new Set(prev);
-        next.delete(key);
-        return next;
-      });
-    };
-
-    const markBucketErrored = (kind: SessionKind, shape: QueryShape) => {
-      const key = bucketKey(kind, shape);
-      setErroredBuckets((prev) => {
-        if (prev.has(key)) return prev;
-        const next = new Set(prev);
-        next.add(key);
-        return next;
-      });
-    };
-
-    const handleSnapshot = (
-      kind: SessionKind,
-      shape: QueryShape,
-      snap: QuerySnapshot<DocumentData>
-    ) => {
-      const config = KIND_CONFIG[kind];
-      buckets.set(
-        bucketKey(kind, shape),
-        snap.docs.map((d) => docToSummary(kind, config, d))
-      );
-      emitMerged(kind);
-      // Clear only this bucket's error. Dual-query kinds have a sibling
-      // bucket that may still be failing; its own error flag stays set
-      // independently so the banner reflects "half your data is missing"
-      // instead of "all good" just because the healthy half recovered.
-      clearBucketError(kind, shape);
-      markSettled(kind, shape);
-    };
-
-    const handleError = (
-      kind: SessionKind,
-      shape: QueryShape,
-      err: unknown
-    ) => {
-      const code =
-        err && typeof err === 'object' && 'code' in err
-          ? String((err as { code?: unknown }).code)
-          : 'unknown';
-      // Firestore missing-index errors embed a one-click index-creation
-      // URL in `err.message` — invaluable the next time something silently
-      // empties the list. Messages from Firestore do not include any of
-      // the classId values passed into the query, so this remains PII-safe.
-      const message =
-        err && typeof err === 'object' && 'message' in err
-          ? String((err as { message?: unknown }).message)
-          : '';
-      console.error(
-        `[MyAssignments] snapshot failed for ${KIND_CONFIG[kind].collectionName} (${shape}) [${code}]:`,
-        message
-      );
-      buckets.set(bucketKey(kind, shape), []);
-      emitMerged(kind);
-      markBucketErrored(kind, shape);
-      markSettled(kind, shape);
-    };
-
-    const buildQuery = (
-      config: KindConfig,
-      shape: QueryShape
-    ): Query<DocumentData> => {
-      const col = collection(db, config.collectionName);
-      const constraints =
-        shape === 'list'
-          ? [where('classIds', 'array-contains-any', classIds)]
-          : [where('classId', 'in', classIds)];
-      if (config.statusFilter) {
-        if ('valueIn' in config.statusFilter) {
-          constraints.push(
-            where(config.statusFilter.field, 'in', [
-              ...config.statusFilter.valueIn,
-            ])
-          );
-        } else {
-          constraints.push(
-            where(config.statusFilter.field, '==', config.statusFilter.value)
-          );
-        }
-      }
-      return query(col, ...constraints);
-    };
-
-    const unsubs: Array<() => void> = [];
-    for (const { kind, shape } of subs) {
-      const config = KIND_CONFIG[kind];
-      const q = buildQuery(config, shape);
-      unsubs.push(
-        onSnapshot(
-          q,
-          (snap) => handleSnapshot(kind, shape, snap),
-          (err) => handleError(kind, shape, err)
-        )
-      );
-    }
-
-    return () => {
-      for (const u of unsubs) u();
-    };
-    // `classIds` drives the `in` filter; re-subscribe only when the key
-    // changes. `classIdsKey` is derived from `classIds` and gives us a
-    // value-based comparison instead of reference identity. `retryNonce`
-    // bumps to force a fresh subscription cycle from the retry button.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [classIdsKey, retryNonce]);
-
-  const handleRetry = useCallback(() => {
-    setRetryNonce((n) => n + 1);
   }, []);
 
-  // Flatten + sort: newest first, grouped visually by kind order inside a
-  // single list. Sort is stable on `createdAt` (desc), then by title to
-  // keep ordering deterministic when createdAt is missing.
-  const assignments: AssignmentSummary[] = useMemo(() => {
-    const merged: AssignmentSummary[] = [];
-    for (const kind of SESSION_KINDS) {
-      const list = byKind[kind] ?? [];
-      merged.push(...list);
+  // Filter mode persists to sessionStorage so a refresh keeps it but the
+  // choice never follows the student onto a shared device.
+  const [filterMode, setFilterMode] = useState<AssignmentFilterMode>(() => {
+    if (typeof window === 'undefined') return 'all';
+    try {
+      const raw = window.sessionStorage.getItem(FILTER_STORAGE_KEY);
+      return isFilterMode(raw) ? raw : 'all';
+    } catch {
+      return 'all';
     }
-    merged.sort((a, b) => {
-      const ac = a.createdAt ?? 0;
-      const bc = b.createdAt ?? 0;
-      if (ac !== bc) return bc - ac;
-      return a.title.localeCompare(b.title);
-    });
-    return merged;
-  }, [byKind]);
+  });
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    try {
+      window.sessionStorage.setItem(FILTER_STORAGE_KEY, filterMode);
+    } catch {
+      // Ignored — sessionStorage may be disabled by privacy mode.
+    }
+  }, [filterMode]);
+
+  // If the student picks a class that vanishes from claims (e.g., schedule
+  // change mid-session), treat the selection as null so the page never
+  // shows an empty "phantom" class. Computed during render rather than via
+  // an effect — keeps setState out of effect bodies and avoids a stale
+  // intermediate render where the user sees a class that's no longer in
+  // their roster.
+  const effectiveClassId =
+    activeClassId && classIds.includes(activeClassId) ? activeClassId : null;
+
+  // Per-row completion resolutions, fed from AssignmentListItem callbacks.
+  // Stored at the page level so changing classes / filter modes doesn't
+  // discard already-resolved checks.
+  const [completionMap, setCompletionMap] = useState<
+    Record<string, CompletionState>
+  >({});
+  const onCompletionResolved = useCallback(
+    (
+      sessionId: string,
+      kind: AssignmentSummary['kind'],
+      completion: CompletionState
+    ) => {
+      setCompletionMap((prev) => {
+        const key = `${kind}:${sessionId}`;
+        if (prev[key] === completion) return prev;
+        return { ...prev, [key]: completion };
+      });
+    },
+    []
+  );
+
+  const todayDate = useMemo(() => formatTodayLong(new Date()), []);
+
+  // Partition assignments according to the rule in the plan. Compute once
+  // at the page level and slice per scope (overview vs class) below.
+  const partitioned = useMemo(() => {
+    const active: AssignmentSummary[] = [];
+    const completed: AssignmentSummary[] = [];
+    for (const a of assignments) {
+      const completion = completionMap[`${a.kind}:${a.sessionId}`] ?? 'unknown';
+      if (completion === 'completed') {
+        completed.push(a);
+        continue;
+      }
+      if (a.channel === 'ended') {
+        // Ended-channel rows the student didn't complete are hidden.
+        continue;
+      }
+      active.push(a);
+    }
+    return { active, completed };
+  }, [assignments, completionMap]);
+
+  // Per-class slices. Multi-class assignments appear under each matching
+  // class because `assignment.classIds` is the intersection with the
+  // student's claims (computed in useStudentAssignments).
+  const slicedForClass = useCallback(
+    (classId: string | null) => {
+      if (classId === null) {
+        return partitioned;
+      }
+      const inClass = (a: AssignmentSummary) => a.classIds.includes(classId);
+      return {
+        active: partitioned.active.filter(inClass),
+        completed: partitioned.completed.filter(inClass),
+      };
+    },
+    [partitioned]
+  );
+
+  const activeCountByClassId = useMemo<Record<string, number>>(() => {
+    const out: Record<string, number> = {};
+    for (const c of classIds) out[c] = 0;
+    for (const a of partitioned.active) {
+      for (const cid of a.classIds) {
+        if (cid in out) out[cid] = (out[cid] ?? 0) + 1;
+      }
+    }
+    return out;
+  }, [partitioned.active, classIds]);
+
+  const visibleScope = slicedForClass(effectiveClassId);
 
   const handleDone = useCallback(() => {
     void signOut();
   }, [signOut]);
 
-  return (
-    <div className="relative min-h-screen w-screen bg-slate-50 overflow-x-hidden font-sans">
-      {/* Ambient background, matches StudentLoginPage */}
-      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(#e5e7eb_1px,transparent_1px)] [background-size:16px_16px] opacity-50" />
-      <div className="pointer-events-none absolute top-[-10%] left-[-15%] w-[500px] h-[500px] rounded-full blur-[120px] bg-brand-blue-primary/15" />
-      <div className="pointer-events-none absolute bottom-[-15%] right-[-10%] w-[500px] h-[500px] bg-brand-red-primary/10 rounded-full blur-[120px]" />
-
-      <div className="relative z-10 flex flex-col min-h-screen">
-        <Header onDone={handleDone} />
-
-        <main className="flex-1 w-full max-w-3xl mx-auto px-4 sm:px-6 py-8 sm:py-12">
-          <div className="mb-8">
-            <h2 className="text-2xl sm:text-3xl font-black text-slate-800 tracking-tight">
-              My Assignments
-            </h2>
-            <p className="text-slate-500 text-sm sm:text-base mt-1.5 font-medium">
-              Everything your teachers have active for your classes right now.
-            </p>
-          </div>
-
-          <AssignmentsBody
-            loadState={loadState}
-            classIds={classIds}
-            assignments={assignments}
-            pseudonymUid={pseudonymUid}
-            hasErrors={erroredBuckets.size > 0}
-            onRetry={handleRetry}
-          />
-        </main>
-
-        <footer className="w-full max-w-3xl mx-auto px-4 sm:px-6 py-6 text-center text-xs text-slate-400 font-medium">
-          {APP_NAME}
-        </footer>
-      </div>
-    </div>
-  );
-};
-
-// ---------------------------------------------------------------------------
-// Header — brand + "Done" sign-out
-// ---------------------------------------------------------------------------
-
-const Header: React.FC<{ onDone: () => void }> = ({ onDone }) => (
-  <header className="w-full max-w-3xl mx-auto px-4 sm:px-6 pt-6 sm:pt-8 flex items-center justify-between gap-4">
-    <div className="flex items-center gap-3 min-w-0">
-      <div className="w-10 h-10 bg-gradient-to-br from-brand-blue-primary to-brand-blue-dark rounded-xl flex items-center justify-center shadow-md shadow-brand-blue-primary/20 shrink-0">
-        <GraduationCap className="w-5 h-5 text-white" strokeWidth={2.5} />
-      </div>
-      <span className="text-lg sm:text-xl font-black text-slate-800 tracking-tight truncate">
-        {APP_NAME}
-      </span>
-    </div>
-
-    <button
-      type="button"
-      onClick={onDone}
-      aria-label="Done — sign out"
-      className="inline-flex items-center gap-2 px-4 py-2 rounded-xl bg-white/70 backdrop-blur-sm border border-slate-200 text-slate-700 hover:bg-white hover:border-slate-300 text-sm font-semibold shadow-sm transition focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue-primary focus-visible:ring-offset-2 focus-visible:ring-offset-slate-50"
-    >
-      <LogOut className="w-4 h-4" strokeWidth={2.25} />
-      <span>Done</span>
-    </button>
-  </header>
-);
-
-// ---------------------------------------------------------------------------
-// Body — loading / empty / list
-// ---------------------------------------------------------------------------
-
-interface AssignmentsBodyProps {
-  loadState: LoadState;
-  classIds: string[];
-  assignments: AssignmentSummary[];
-  pseudonymUid: string | null;
-  hasErrors: boolean;
-  onRetry: () => void;
-}
-
-const AssignmentsBody: React.FC<AssignmentsBodyProps> = ({
-  loadState,
-  classIds,
-  assignments,
-  pseudonymUid,
-  hasErrors,
-  onRetry,
-}) => {
+  // ────────── Loading / no-classes / error gates (top-level guards) ──────────
   if (loadState === 'loading') {
     return (
-      <div className="min-h-[200px] flex flex-col items-center justify-center gap-3 text-slate-500">
-        <Loader2 className="w-8 h-8 animate-spin text-brand-blue-primary" />
-        <p className="text-sm font-medium">Loading your assignments…</p>
-      </div>
+      <PageShell onDone={handleDone}>
+        <div className="flex min-h-[200px] flex-col items-center justify-center gap-3 text-slate-500">
+          <Loader2 className="h-8 w-8 animate-spin text-brand-blue-primary" />
+          <p className="text-sm font-medium">Loading your assignments…</p>
+        </div>
+      </PageShell>
     );
   }
 
   if (classIds.length === 0) {
     return (
-      <EmptyState
-        icon={AlertCircle}
-        title="You're not on a roster yet"
-        body="You're not on any class rosters yet. If you just started at your school, ask a teacher to sync their roster."
-        tone="soft"
-      />
+      <PageShell onDone={handleDone}>
+        <FullEmpty
+          icon={AlertCircle}
+          title="You're not on a roster yet"
+          body="If you just started at your school, ask a teacher to sync their roster."
+        />
+      </PageShell>
     );
   }
 
   if (assignments.length === 0 && hasErrors) {
     return (
-      <EmptyState
-        icon={AlertTriangle}
-        title="We couldn't load your assignments"
-        body="Something went wrong loading your assignments. Refresh and try again."
-        tone="error"
-        action={{ label: 'Try again', onClick: onRetry }}
-      />
+      <PageShell onDone={handleDone}>
+        <FullEmpty
+          icon={AlertTriangle}
+          title="We couldn't load your assignments"
+          body="Something went wrong loading your assignments. Refresh and try again."
+          tone="error"
+          action={{ label: 'Try again', onClick: retry }}
+        />
+      </PageShell>
     );
   }
 
-  if (assignments.length === 0) {
-    return (
-      <EmptyState
-        icon={Inbox}
-        title="All caught up"
-        body="You're all caught up — no active assignments right now."
-        tone="soft"
-      />
-    );
-  }
-
+  // ────────── Main layout — slide-out sidebar + main column ──────────
   return (
-    <div className="space-y-3">
-      {hasErrors && <PartialFailureBanner onRetry={onRetry} />}
-      <ul className="space-y-3">
-        {assignments.map((a) => (
-          <li key={a.compositeId}>
-            <AssignmentCard assignment={a} pseudonymUid={pseudonymUid} />
-          </li>
-        ))}
-      </ul>
-    </div>
+    <>
+      <SlideOutSidebar open={sidebarOpen} onClose={closeSidebar}>
+        <StudentSidebar
+          classes={directory.classes}
+          claimedClassIds={classIds}
+          activeClassId={effectiveClassId}
+          activeCountByClassId={activeCountByClassId}
+          totalActiveCount={partitioned.active.length}
+          onSelect={handleSelectClass}
+          onSignOut={handleDone}
+          firstName={firstName}
+          classCount={classIds.length}
+        />
+      </SlideOutSidebar>
+
+      <PageShell
+        onDone={handleDone}
+        onToggleMenu={toggleSidebar}
+        menuOpen={sidebarOpen}
+        hideDoneButton
+      >
+        {hasErrors && <PartialFailureBanner onRetry={retry} className="mb-4" />}
+        {effectiveClassId === null ? (
+          <StudentOverview
+            todayDate={todayDate}
+            active={visibleScope.active}
+            completed={visibleScope.completed}
+            filterMode={filterMode}
+            onFilterChange={setFilterMode}
+            pseudonymUid={pseudonymUid}
+            directoryById={directory.byId}
+            onCompletionResolved={onCompletionResolved}
+          />
+        ) : (
+          <StudentClassView
+            classId={effectiveClassId}
+            classEntry={directory.byId[effectiveClassId]}
+            todayDate={todayDate}
+            active={visibleScope.active}
+            completed={visibleScope.completed}
+            filterMode={filterMode}
+            onFilterChange={setFilterMode}
+            pseudonymUid={pseudonymUid}
+            directoryById={directory.byId}
+            onCompletionResolved={onCompletionResolved}
+          />
+        )}
+      </PageShell>
+    </>
   );
 };
 
-const PartialFailureBanner: React.FC<{ onRetry: () => void }> = ({
-  onRetry,
+// ---------------------------------------------------------------------------
+// Page shell (background, header, footer)
+// ---------------------------------------------------------------------------
+
+interface PageShellProps {
+  onDone: () => void;
+  /**
+   * When set, the brand icon is replaced with a hamburger menu button that
+   * toggles the slide-out class sidebar. Gate paths (loading / no-classes /
+   * error) omit it and render the brand chip as before.
+   */
+  onToggleMenu?: () => void;
+  menuOpen?: boolean;
+  /**
+   * When true, suppresses the header's Done button. Sign-out lives in the
+   * sidebar footer once the student is past the gate paths.
+   */
+  hideDoneButton?: boolean;
+  children: React.ReactNode;
+}
+
+const PageShell: React.FC<PageShellProps> = ({
+  onDone,
+  onToggleMenu,
+  menuOpen,
+  hideDoneButton,
+  children,
 }) => (
+  <div className="relative min-h-screen w-screen overflow-x-hidden bg-slate-50 font-sans">
+    <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(#e5e7eb_1px,transparent_1px)] [background-size:16px_16px] opacity-40" />
+    <div className="pointer-events-none absolute left-[-15%] top-[-10%] h-[500px] w-[500px] rounded-full bg-brand-blue-primary/15 blur-[120px]" />
+    <div className="pointer-events-none absolute bottom-[-15%] right-[-10%] h-[500px] w-[500px] rounded-full bg-brand-red-primary/10 blur-[120px]" />
+
+    <div className="relative z-10 flex min-h-screen flex-col">
+      {/* Header — full-width, anchored. Brand-blue with white text. The
+          hamburger never shifts when the sidebar opens; the sidebar slides
+          in *below* this header (top: PAGE_HEADER_HEIGHT). */}
+      <header className="relative z-30 flex h-[72px] shrink-0 items-center justify-between gap-4 bg-gradient-to-r from-brand-blue-primary to-brand-blue-dark px-4 text-white shadow-md shadow-brand-blue-primary/20 sm:h-[80px] sm:px-8">
+        <div className="flex min-w-0 items-center gap-3">
+          {onToggleMenu ? (
+            <button
+              type="button"
+              onClick={onToggleMenu}
+              aria-label={menuOpen ? 'Close class menu' : 'Open class menu'}
+              aria-expanded={menuOpen}
+              className="inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-xl border border-white/20 bg-white/10 text-white shadow-sm transition hover:border-white/30 hover:bg-white/20 focus:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-brand-blue-primary"
+            >
+              <Menu className="h-5 w-5" strokeWidth={2.25} />
+            </button>
+          ) : (
+            <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-white/15 shadow-sm ring-1 ring-white/20">
+              <GraduationCap className="h-5 w-5 text-white" strokeWidth={2.5} />
+            </div>
+          )}
+          <span className="truncate text-lg font-bold tracking-tight text-white sm:text-xl">
+            {APP_NAME}
+          </span>
+        </div>
+        {!hideDoneButton && (
+          <button
+            type="button"
+            onClick={onDone}
+            aria-label="Done — sign out"
+            className="inline-flex items-center gap-2 rounded-xl border border-white/20 bg-white/10 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:border-white/30 hover:bg-white/20 focus:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-brand-blue-primary"
+          >
+            <LogOut className="h-4 w-4" strokeWidth={2.25} />
+            <span>Done</span>
+          </button>
+        )}
+      </header>
+
+      {/* Body — pushed right when sidebar is open on desktop. The header
+          above stays anchored. */}
+      <div
+        className={`flex flex-1 flex-col transition-[padding] duration-200 ${
+          onToggleMenu && menuOpen ? 'md:pl-[280px]' : ''
+        }`}
+      >
+        <div className="mx-auto w-full max-w-6xl flex-1 px-4 py-8 sm:px-8 sm:py-12">
+          {children}
+        </div>
+
+        <footer className="mx-auto w-full max-w-6xl px-4 pb-6 text-center text-xs font-medium text-slate-400 sm:px-8">
+          {APP_NAME}
+        </footer>
+      </div>
+    </div>
+  </div>
+);
+
+// ---------------------------------------------------------------------------
+// Slide-out sidebar wrapper
+// ---------------------------------------------------------------------------
+//
+// On desktop (≥ md), the sidebar is fixed to the left edge of the viewport
+// and the page shell adds `md:pl-[280px]` when open so content reflows
+// alongside the panel rather than disappearing under it. On mobile, the
+// sidebar slides in over the content with a tap-to-close backdrop.
+
+interface SlideOutSidebarProps {
+  open: boolean;
+  onClose: () => void;
+  children: React.ReactNode;
+}
+
+// Header heights kept in sync with the `<header>` in PageShell. Used to
+// position the sidebar so it slides IN UNDER the header, leaving the
+// hamburger and Done button anchored.
+const HEADER_OFFSET_CLASSES = 'top-[72px] sm:top-[80px]';
+
+const SlideOutSidebar: React.FC<SlideOutSidebarProps> = ({
+  open,
+  onClose,
+  children,
+}) => (
+  <>
+    {open && (
+      <button
+        type="button"
+        onClick={onClose}
+        aria-label="Close class menu"
+        className={`fixed bottom-0 left-0 right-0 z-20 bg-slate-900/30 backdrop-blur-sm md:hidden ${HEADER_OFFSET_CLASSES}`}
+      />
+    )}
+    <aside
+      aria-label="Class navigation"
+      aria-hidden={!open}
+      className={`fixed bottom-0 left-0 z-20 flex w-[280px] flex-col shadow-xl transition-transform duration-200 ease-out md:shadow-none ${HEADER_OFFSET_CLASSES} ${
+        open ? 'translate-x-0' : '-translate-x-full'
+      }`}
+    >
+      {children}
+    </aside>
+  </>
+);
+
+// ---------------------------------------------------------------------------
+// Partial-failure banner — preserved from the previous implementation
+// ---------------------------------------------------------------------------
+
+const PartialFailureBanner: React.FC<{
+  onRetry: () => void;
+  className?: string;
+}> = ({ onRetry, className }) => (
   <div
     role="alert"
-    className="flex items-start gap-3 rounded-2xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm shadow-sm"
+    className={`flex items-start gap-3 rounded-2xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm shadow-sm ${className ?? ''}`}
   >
     <AlertTriangle
-      className="w-5 h-5 text-amber-600 shrink-0 mt-0.5"
+      className="mt-0.5 h-5 w-5 shrink-0 text-amber-600"
       strokeWidth={2.25}
       aria-hidden="true"
     />
-    <div className="flex-1 min-w-0">
+    <div className="min-w-0 flex-1">
       <p className="font-semibold text-amber-900">
         Some assignments couldn&apos;t be loaded.
       </p>
@@ -681,226 +448,61 @@ const PartialFailureBanner: React.FC<{ onRetry: () => void }> = ({
     <button
       type="button"
       onClick={onRetry}
-      className="inline-flex items-center gap-1.5 rounded-lg bg-amber-600 hover:bg-amber-700 text-white text-xs font-semibold px-3 py-1.5 shadow-sm transition focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-600 focus-visible:ring-offset-2 focus-visible:ring-offset-amber-50 shrink-0"
+      className="inline-flex shrink-0 items-center gap-1.5 rounded-lg bg-amber-600 px-3 py-1.5 text-xs font-semibold text-white shadow-sm transition hover:bg-amber-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-600 focus-visible:ring-offset-2 focus-visible:ring-offset-amber-50"
     >
-      <RefreshCw className="w-3.5 h-3.5" strokeWidth={2.5} />
+      <RefreshCw className="h-3.5 w-3.5" strokeWidth={2.5} />
       Try again
     </button>
   </div>
 );
 
 // ---------------------------------------------------------------------------
-// Empty state
+// Full-page empty state (used for no-classes / hard error gates)
 // ---------------------------------------------------------------------------
 
-interface EmptyStateProps {
+interface FullEmptyProps {
   icon: React.ComponentType<{ className?: string; strokeWidth?: number }>;
   title: string;
   body: string;
-  tone: 'soft' | 'error';
+  tone?: 'soft' | 'error';
   action?: { label: string; onClick: () => void };
 }
 
-const EmptyState: React.FC<EmptyStateProps> = ({
+const FullEmpty: React.FC<FullEmptyProps> = ({
   icon: Icon,
   title,
   body,
-  tone,
+  tone = 'soft',
   action,
 }) => {
   const isSoft = tone === 'soft';
   return (
-    <div className="min-h-[240px] flex flex-col items-center justify-center gap-4 text-center px-6 py-12">
+    <div className="flex min-h-[280px] flex-col items-center justify-center gap-4 px-6 py-12 text-center">
       <div
-        className={`w-14 h-14 rounded-2xl flex items-center justify-center ${
+        className={`flex h-14 w-14 items-center justify-center rounded-2xl ${
           isSoft ? 'bg-slate-100' : 'bg-brand-red-primary/10'
         }`}
       >
         <Icon
-          className={`w-7 h-7 ${
-            isSoft ? 'text-slate-400' : 'text-brand-red-primary'
-          }`}
+          className={`h-7 w-7 ${isSoft ? 'text-slate-400' : 'text-brand-red-primary'}`}
           strokeWidth={2}
         />
       </div>
       <div className="max-w-sm space-y-1.5">
         <h3 className="text-base font-bold text-slate-800">{title}</h3>
-        <p className="text-sm text-slate-500 leading-relaxed">{body}</p>
+        <p className="text-sm leading-relaxed text-slate-500">{body}</p>
       </div>
       {action && (
         <button
           type="button"
           onClick={action.onClick}
-          className="inline-flex items-center gap-2 px-4 py-2 rounded-xl bg-brand-blue-primary hover:bg-brand-blue-dark text-white text-sm font-semibold shadow-sm shadow-brand-blue-primary/20 transition focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue-primary focus-visible:ring-offset-2 focus-visible:ring-offset-slate-50"
+          className="inline-flex items-center gap-2 rounded-xl bg-brand-blue-primary px-4 py-2 text-sm font-semibold text-white shadow-sm shadow-brand-blue-primary/20 transition hover:bg-brand-blue-dark focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue-primary focus-visible:ring-offset-2 focus-visible:ring-offset-slate-50"
         >
-          <RefreshCw className="w-4 h-4" strokeWidth={2.25} />
+          <RefreshCw className="h-4 w-4" strokeWidth={2.25} />
           {action.label}
         </button>
       )}
     </div>
-  );
-};
-
-// ---------------------------------------------------------------------------
-// Assignment card — lazy completion check
-// ---------------------------------------------------------------------------
-//
-// Pseudonym cache: sessionId -> pseudonym (Promise-valued so concurrent
-// readers de-dupe the callable). This is module-local, so it survives
-// card remounts within a single page lifetime without re-fetching.
-// Pseudonyms are stable for a given (uid, assignmentId) within a session;
-// we rebuild the cache whenever the authenticated uid changes (tracked
-// via `pseudonymCacheOwnerUid`).
-
-let pseudonymCacheOwnerUid: string | null = null;
-let pseudonymCache: Map<string, Promise<string>> = new Map();
-
-function getCachedPseudonym(
-  sessionId: string,
-  pseudonymUid: string
-): Promise<string> {
-  if (pseudonymCacheOwnerUid !== pseudonymUid) {
-    pseudonymCache = new Map();
-    pseudonymCacheOwnerUid = pseudonymUid;
-  }
-  const cached = pseudonymCache.get(sessionId);
-  if (cached) return cached;
-
-  const callable = httpsCallable<
-    { assignmentId: string },
-    { pseudonym?: string }
-  >(functions, 'getAssignmentPseudonymV1');
-
-  const promise = callable({ assignmentId: sessionId }).then((res) => {
-    const p = res.data?.pseudonym;
-    if (typeof p !== 'string' || p.length === 0) {
-      throw new Error('Pseudonym missing from callable response.');
-    }
-    return p;
-  });
-
-  pseudonymCache.set(sessionId, promise);
-
-  // Evict on failure so a retry on a later card re-attempts the fetch.
-  promise.catch(() => {
-    if (pseudonymCache.get(sessionId) === promise) {
-      pseudonymCache.delete(sessionId);
-    }
-  });
-
-  return promise;
-}
-
-type CompletionState = 'unknown' | 'completed' | 'not-completed';
-
-const AssignmentCard: React.FC<{
-  assignment: AssignmentSummary;
-  pseudonymUid: string | null;
-}> = ({ assignment, pseudonymUid }) => {
-  const config = KIND_CONFIG[assignment.kind];
-  const [completion, setCompletion] = useState<CompletionState>('unknown');
-
-  // Lazy completion: fire one callable + one getDoc per card on mount.
-  // Pseudonym results are cached via `getCachedPseudonym`, so 30
-  // assignments from the same student = 30 callables (unavoidable —
-  // one per sessionId) and 30 doc reads. Same-kind retries reuse cached
-  // pseudonyms on remount.
-  useEffect(() => {
-    if (!pseudonymUid) return;
-    if (!config.responseSubcollection) {
-      // Collection has no per-student response docs — skip the badge.
-      return;
-    }
-
-    let cancelled = false;
-
-    const run = async () => {
-      try {
-        const pseudonym = await getCachedPseudonym(
-          assignment.sessionId,
-          pseudonymUid
-        );
-        if (cancelled) return;
-
-        const responseSub = config.responseSubcollection;
-        if (!responseSub) return;
-        const snap = await getDoc(
-          doc(
-            db,
-            config.collectionName,
-            assignment.sessionId,
-            responseSub,
-            pseudonym
-          )
-        );
-        if (cancelled) return;
-        setCompletion(snap.exists() ? 'completed' : 'not-completed');
-      } catch {
-        // Silent: a failed completion check shouldn't block the student
-        // from opening the assignment. Leave completion as 'unknown'.
-        if (cancelled) return;
-        setCompletion('unknown');
-      }
-    };
-
-    void run();
-
-    return () => {
-      cancelled = true;
-    };
-  }, [
-    assignment.sessionId,
-    pseudonymUid,
-    config.responseSubcollection,
-    config.collectionName,
-  ]);
-
-  const Icon = config.icon;
-  const isCompleted = completion === 'completed';
-
-  return (
-    <a
-      href={assignment.openHref}
-      className={`group block rounded-2xl border border-slate-200 bg-white/80 backdrop-blur-sm shadow-sm hover:shadow-md hover:border-slate-300 transition focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue-primary focus-visible:ring-offset-2 focus-visible:ring-offset-slate-50 ${
-        isCompleted ? 'opacity-75' : ''
-      }`}
-    >
-      <div className="flex items-center gap-4 p-4 sm:p-5">
-        <div
-          className={`w-11 h-11 sm:w-12 sm:h-12 rounded-xl bg-gradient-to-br ${config.accent} flex items-center justify-center shadow-sm shrink-0`}
-          aria-hidden="true"
-        >
-          <Icon
-            className="w-5 h-5 sm:w-6 sm:h-6 text-white"
-            strokeWidth={2.25}
-          />
-        </div>
-
-        <div className="flex-1 min-w-0">
-          <div className="flex items-center gap-2 flex-wrap">
-            <span className="text-[11px] sm:text-xs uppercase font-bold tracking-wider text-slate-400">
-              {config.label}
-            </span>
-            {isCompleted && (
-              <span className="inline-flex items-center gap-1 text-[11px] sm:text-xs font-semibold text-emerald-600 bg-emerald-50 px-2 py-0.5 rounded-full">
-                <CheckCircle2 className="w-3 h-3" strokeWidth={2.5} />
-                Completed
-              </span>
-            )}
-          </div>
-          <p className="mt-0.5 text-sm sm:text-base font-bold text-slate-800 truncate">
-            {assignment.title}
-          </p>
-        </div>
-
-        <span
-          className="hidden sm:inline-flex items-center px-3 py-1.5 rounded-lg bg-brand-blue-primary text-white text-xs font-semibold shadow-sm shadow-brand-blue-primary/20 group-hover:bg-brand-blue-dark transition shrink-0"
-          aria-hidden="true"
-        >
-          Open
-        </span>
-      </div>
-    </a>
   );
 };
 

--- a/components/student/MyAssignmentsPage.tsx
+++ b/components/student/MyAssignmentsPage.tsx
@@ -414,8 +414,16 @@ const SlideOutSidebar: React.FC<SlideOutSidebarProps> = ({
     <aside
       aria-label="Class navigation"
       aria-hidden={!open}
+      // `inert` removes the entire subtree from focus order, click events,
+      // and the a11y tree without unmounting it (preserves scroll/state on
+      // toggle). `pointer-events-none` hardens against older browsers that
+      // don't yet honor `inert` (Chromium ≥ 102, Safari ≥ 15.5, Firefox ≥
+      // 112) so an off-screen sidebar can't intercept clicks.
+      {...(open ? {} : { inert: true })}
       className={`fixed bottom-0 left-0 z-20 flex w-[280px] flex-col shadow-xl transition-transform duration-200 ease-out md:shadow-none ${HEADER_OFFSET_CLASSES} ${
-        open ? 'translate-x-0' : '-translate-x-full'
+        open
+          ? 'pointer-events-auto translate-x-0'
+          : 'pointer-events-none -translate-x-full'
       }`}
     >
       {children}

--- a/components/student/StudentClassView.tsx
+++ b/components/student/StudentClassView.tsx
@@ -1,0 +1,93 @@
+import React from 'react';
+import {
+  AssignmentFilterTabs,
+  type AssignmentFilterMode,
+} from './AssignmentFilterTabs';
+import { AssignmentSections } from './AssignmentSections';
+import { getClassColor } from '@/utils/studentClassColors';
+import type { AssignmentSummary } from '@/hooks/useStudentAssignments';
+import type { ClassDirectoryEntry } from '@/hooks/useStudentClassDirectory';
+import type { CompletionState } from './AssignmentListItem';
+
+interface StudentClassViewProps {
+  classId: string;
+  classEntry: ClassDirectoryEntry | undefined;
+  todayDate: string;
+  active: AssignmentSummary[];
+  completed: AssignmentSummary[];
+  filterMode: AssignmentFilterMode;
+  onFilterChange: (mode: AssignmentFilterMode) => void;
+  pseudonymUid: string | null;
+  directoryById: Record<string, ClassDirectoryEntry>;
+  onCompletionResolved: (
+    sessionId: string,
+    kind: AssignmentSummary['kind'],
+    completion: CompletionState
+  ) => void;
+}
+
+export const StudentClassView: React.FC<StudentClassViewProps> = ({
+  classId,
+  classEntry,
+  todayDate,
+  active,
+  completed,
+  filterMode,
+  onFilterChange,
+  pseudonymUid,
+  directoryById,
+  onCompletionResolved,
+}) => {
+  const color = getClassColor(classId);
+  const className = classEntry?.name ?? 'Class';
+  const subject = classEntry?.subject;
+  const teacher = classEntry?.teacherDisplayName;
+  const code = classEntry?.code;
+
+  const subtitleBits = [subject, teacher, code].filter(
+    (b): b is string => Boolean(b) && typeof b === 'string'
+  );
+  const subtitle = subtitleBits.length > 0 ? subtitleBits.join(' · ') : null;
+
+  return (
+    <div className="flex flex-col gap-6">
+      <header className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between sm:gap-6">
+        <div className="flex items-start gap-3">
+          <span
+            aria-hidden="true"
+            className="mt-1.5 h-7 w-1 shrink-0 rounded-full sm:mt-2"
+            style={{ background: color.bar }}
+          />
+          <div>
+            <h1 className="text-2xl font-bold tracking-tight text-slate-900 sm:text-3xl">
+              {className}
+            </h1>
+            {subtitle && (
+              <p className="mt-1 text-sm text-slate-500">{subtitle}</p>
+            )}
+            <p className="mt-0.5 text-xs text-slate-400">{todayDate}</p>
+          </div>
+        </div>
+        <AssignmentFilterTabs
+          value={filterMode}
+          onChange={onFilterChange}
+          counts={{
+            all: active.length + completed.length,
+            active: active.length,
+            completed: completed.length,
+          }}
+        />
+      </header>
+
+      <AssignmentSections
+        mode={filterMode}
+        active={active}
+        completed={completed}
+        pseudonymUid={pseudonymUid}
+        directoryById={directoryById}
+        hideClassName
+        onCompletionResolved={onCompletionResolved}
+      />
+    </div>
+  );
+};

--- a/components/student/StudentLoginPage.tsx
+++ b/components/student/StudentLoginPage.tsx
@@ -93,7 +93,12 @@ declare global {
 const base64UrlDecode = (input: string): string => {
   const base64 = input.replace(/-/g, '+').replace(/_/g, '/');
   const pad = base64.length % 4 === 0 ? 0 : 4 - (base64.length % 4);
-  return atob(base64 + '='.repeat(pad));
+  // `atob` interprets the decoded bytes as Latin-1, which garbles any
+  // non-ASCII glyph in the JWT payload (accented student names, non-Latin
+  // scripts). Pipe through TextDecoder so the JSON parses as UTF-8.
+  const binary = atob(base64 + '='.repeat(pad));
+  const bytes = Uint8Array.from(binary, (c) => c.charCodeAt(0));
+  return new TextDecoder().decode(bytes);
 };
 
 const extractFirstNameFromIdToken = (idToken: string): string | null => {

--- a/components/student/StudentLoginPage.tsx
+++ b/components/student/StudentLoginPage.tsx
@@ -4,15 +4,22 @@ import { httpsCallable, FunctionsError } from 'firebase/functions';
 import { Loader2, GraduationCap, AlertCircle, Inbox } from 'lucide-react';
 import { auth, functions } from '@/config/firebase';
 import { APP_NAME } from '@/config/constants';
+import { STUDENT_FIRST_NAME_KEY } from '@/context/StudentAuthContextValue';
 
 /**
  * Student login page (Phase 2A of the ClassLink-via-Google auth flow).
  *
- * This page is intentionally PII-free on the client:
- *   - We never render, log, or persist the student's email, name, or `sub`.
- *   - The Google ID token is passed directly to `studentLoginV1` and discarded.
+ * This page is intentionally Firestore-PII-free:
+ *   - We never log or persist the student's email or `sub` — anywhere.
+ *   - The Google ID token is passed to `studentLoginV1` and discarded.
  *   - Firebase Auth only ever sees the minted custom token, which contains an
  *     opaque pseudonym UID.
+ *
+ * The one personalization we keep: extracting the student's first name from
+ * the ID token at sign-in time and parking it in tab-scoped `sessionStorage`
+ * for the sidebar greeting on `/my-assignments`. The name never leaves the
+ * tab — never written to Firestore, never sent to any server we own, and
+ * cleared on `signOut()` (see `StudentAuthContext`).
  *
  * We use Google Identity Services (GIS) directly — NOT
  * `signInWithPopup(googleProvider)` — because the built-in provider writes
@@ -71,6 +78,59 @@ declare global {
     };
   }
 }
+
+// ---------------------------------------------------------------------------
+// Decode the student's first name from the Google ID token. The token's
+// signature has already been verified by GIS (the SDK rejects tampered
+// tokens before invoking our callback). We parse the payload purely to
+// read `given_name` (preferred) or fall back to the first word of `name`.
+//
+// The result is stored in tab-scoped `sessionStorage` and is the *only*
+// piece of student PII that ever survives the verifying step. It's
+// cleared on `signOut()` and never written to Firestore.
+// ---------------------------------------------------------------------------
+
+const base64UrlDecode = (input: string): string => {
+  const base64 = input.replace(/-/g, '+').replace(/_/g, '/');
+  const pad = base64.length % 4 === 0 ? 0 : 4 - (base64.length % 4);
+  return atob(base64 + '='.repeat(pad));
+};
+
+const extractFirstNameFromIdToken = (idToken: string): string | null => {
+  try {
+    const parts = idToken.split('.');
+    if (parts.length !== 3) return null;
+    const json = base64UrlDecode(parts[1]);
+    const payload = JSON.parse(json) as Record<string, unknown>;
+    const givenName =
+      typeof payload.given_name === 'string' ? payload.given_name.trim() : '';
+    if (givenName.length > 0) return givenName;
+    const fullName =
+      typeof payload.name === 'string' ? payload.name.trim() : '';
+    if (fullName.length > 0) {
+      const first = fullName.split(/\s+/)[0];
+      if (first && first.length > 0) return first;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+};
+
+const persistFirstName = (idToken: string): void => {
+  if (typeof window === 'undefined') return;
+  const first = extractFirstNameFromIdToken(idToken);
+  try {
+    if (first && first.length > 0 && first.length <= 60) {
+      window.sessionStorage.setItem(STUDENT_FIRST_NAME_KEY, first);
+    } else {
+      window.sessionStorage.removeItem(STUDENT_FIRST_NAME_KEY);
+    }
+  } catch {
+    // Privacy mode / disabled storage — non-fatal. Footer falls back to
+    // the generic "Signed in" copy.
+  }
+};
 
 // ---------------------------------------------------------------------------
 // Response + error-code shapes for the studentLoginV1 callable.
@@ -209,6 +269,11 @@ const StudentLoginPage: React.FC = () => {
           setStatus({ kind: 'error', error: 'generic' });
           return;
         }
+
+        // Capture the first name into tab-scoped sessionStorage BEFORE
+        // we drop the ID token. Cleared on signOut(); never sent to
+        // Firestore. See class-doc at top of file.
+        persistFirstName(response.credential);
 
         await signInWithCustomToken(auth, customToken);
         setStatus({ kind: 'success' });

--- a/components/student/StudentOverview.tsx
+++ b/components/student/StudentOverview.tsx
@@ -1,0 +1,86 @@
+import React from 'react';
+import {
+  AssignmentFilterTabs,
+  type AssignmentFilterMode,
+} from './AssignmentFilterTabs';
+import { AssignmentSections } from './AssignmentSections';
+import type { AssignmentSummary } from '@/hooks/useStudentAssignments';
+import type { ClassDirectoryEntry } from '@/hooks/useStudentClassDirectory';
+import type { CompletionState } from './AssignmentListItem';
+
+interface StudentOverviewProps {
+  todayDate: string;
+  active: AssignmentSummary[];
+  completed: AssignmentSummary[];
+  filterMode: AssignmentFilterMode;
+  onFilterChange: (mode: AssignmentFilterMode) => void;
+  pseudonymUid: string | null;
+  directoryById: Record<string, ClassDirectoryEntry>;
+  onCompletionResolved: (
+    sessionId: string,
+    kind: AssignmentSummary['kind'],
+    completion: CompletionState
+  ) => void;
+}
+
+export const StudentOverview: React.FC<StudentOverviewProps> = ({
+  todayDate,
+  active,
+  completed,
+  filterMode,
+  onFilterChange,
+  pseudonymUid,
+  directoryById,
+  onCompletionResolved,
+}) => {
+  const total = active.length + completed.length;
+  const dueToday = active.length;
+  return (
+    <div className="flex flex-col gap-6">
+      <header className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between sm:gap-6">
+        <div>
+          <h1 className="text-2xl font-bold tracking-tight text-brand-blue-dark sm:text-3xl">
+            Today
+          </h1>
+          <p className="mt-1 text-sm text-slate-500">
+            {todayDate}
+            {dueToday > 0 && (
+              <>
+                <span className="px-1.5 text-slate-300">·</span>
+                <span>
+                  {dueToday} {dueToday === 1 ? 'thing' : 'things'} due today
+                </span>
+              </>
+            )}
+          </p>
+        </div>
+        <AssignmentFilterTabs
+          value={filterMode}
+          onChange={onFilterChange}
+          counts={{
+            all: total,
+            active: active.length,
+            completed: completed.length,
+          }}
+        />
+      </header>
+
+      {total > 0 && (
+        <p className="text-base font-medium text-slate-700">
+          {dueToday > 0
+            ? `You have ${dueToday} ${dueToday === 1 ? 'thing' : 'things'} due today. Pick a class on the left to see what's posted.`
+            : "Nothing due today. Pick a class on the left to see what's posted."}
+        </p>
+      )}
+
+      <AssignmentSections
+        mode={filterMode}
+        active={active}
+        completed={completed}
+        pseudonymUid={pseudonymUid}
+        directoryById={directoryById}
+        onCompletionResolved={onCompletionResolved}
+      />
+    </div>
+  );
+};

--- a/components/student/StudentSidebar.tsx
+++ b/components/student/StudentSidebar.tsx
@@ -1,0 +1,194 @@
+import React from 'react';
+import { GraduationCap, LayoutGrid, LogOut } from 'lucide-react';
+import { getClassColor } from '@/utils/studentClassColors';
+import type { ClassDirectoryEntry } from '@/hooks/useStudentClassDirectory';
+
+interface StudentSidebarProps {
+  classes: ClassDirectoryEntry[];
+  /** classIds the student has in claims — used to render fallbacks for any
+   *  ids the directory didn't resolve, so the sidebar never silently
+   *  drops a class. */
+  claimedClassIds: readonly string[];
+  activeClassId: string | null;
+  /** Active assignment counts per classId. Each value is the number of
+   *  *currently active* (not yet completed) assignments for that class. */
+  activeCountByClassId: Record<string, number>;
+  totalActiveCount: number;
+  onSelect: (classId: string | null) => void;
+  /** Sign-out handler. Renders the profile-style footer when provided. */
+  onSignOut?: () => void;
+  /**
+   * Student's first name from the Google ID token at sign-in. Tab-scoped,
+   * never written to Firestore. When `null`, the footer falls back to a
+   * generic "Signed in" greeting.
+   */
+  firstName?: string | null;
+  /** Total count of claim-bound classes. Shown in the footer meta line. */
+  classCount?: number;
+}
+
+export const StudentSidebar: React.FC<StudentSidebarProps> = ({
+  classes,
+  claimedClassIds,
+  activeClassId,
+  activeCountByClassId,
+  totalActiveCount,
+  onSelect,
+  onSignOut,
+  firstName,
+  classCount,
+}) => {
+  // Render in the order the directory returned, then any unresolved claim
+  // ids at the end so a slow-loading directory never hides a class.
+  const resolvedIds = new Set(classes.map((c) => c.classId));
+  const fallbackIds = claimedClassIds.filter((id) => !resolvedIds.has(id));
+  const fallbackEntries: ClassDirectoryEntry[] = fallbackIds.map((id) => ({
+    classId: id,
+    name: 'Class',
+    teacherDisplayName: '',
+  }));
+  const allEntries = [...classes, ...fallbackEntries];
+
+  return (
+    <div className="flex h-full w-full flex-col gap-3 overflow-y-auto border-r border-slate-200 bg-white/95 px-3 py-5 backdrop-blur-sm md:gap-4 md:bg-white/85 md:px-3.5 md:py-6">
+      <div className="flex flex-1 flex-col">
+        <div className="px-2 pb-1.5 text-[11px] font-bold uppercase tracking-[0.14em] text-slate-400">
+          My classes
+        </div>
+        <ul className="flex flex-col gap-0.5">
+          <li>
+            <ClassButton
+              isActive={activeClassId === null}
+              barColor="#1D2A5D"
+              title="All classes"
+              meta="Today's overview"
+              count={totalActiveCount}
+              icon={<LayoutGrid className="h-4 w-4" strokeWidth={2.25} />}
+              onClick={() => onSelect(null)}
+            />
+          </li>
+          {allEntries.map((c) => {
+            const color = getClassColor(c.classId);
+            const meta = c.teacherDisplayName
+              ? c.subject
+                ? `${c.subject} · ${c.teacherDisplayName}`
+                : c.teacherDisplayName
+              : (c.subject ?? c.code ?? ' ');
+            return (
+              <li key={c.classId}>
+                <ClassButton
+                  isActive={activeClassId === c.classId}
+                  barColor={color.bar}
+                  title={c.name}
+                  meta={meta}
+                  count={activeCountByClassId[c.classId] ?? 0}
+                  onClick={() => onSelect(c.classId)}
+                />
+              </li>
+            );
+          })}
+        </ul>
+      </div>
+
+      {onSignOut && (
+        <div className="mt-auto flex items-center gap-3 border-t border-slate-200 px-2 pt-3">
+          <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-brand-blue-primary/10 text-brand-blue-primary">
+            {firstName ? (
+              <span className="text-xs font-bold uppercase">
+                {firstName.charAt(0)}
+              </span>
+            ) : (
+              <GraduationCap className="h-4 w-4" strokeWidth={2.25} />
+            )}
+          </div>
+          <div className="min-w-0 flex-1">
+            <div className="truncate text-sm font-semibold text-slate-700">
+              {firstName ? `Hi, ${firstName}` : 'Signed in'}
+            </div>
+            {typeof classCount === 'number' && classCount > 0 && (
+              <div className="truncate text-[11px] text-slate-500">
+                {classCount} {classCount === 1 ? 'class' : 'classes'}
+              </div>
+            )}
+          </div>
+          <button
+            type="button"
+            onClick={onSignOut}
+            aria-label="Sign out"
+            className="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-lg border border-slate-200 bg-white text-slate-600 transition hover:border-slate-300 hover:bg-slate-50 hover:text-slate-800 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue-primary focus-visible:ring-offset-1"
+          >
+            <LogOut className="h-4 w-4" strokeWidth={2.25} />
+          </button>
+        </div>
+      )}
+    </div>
+  );
+};
+
+interface ClassButtonProps {
+  isActive: boolean;
+  barColor: string;
+  title: string;
+  meta: string;
+  count: number;
+  icon?: React.ReactNode;
+  onClick: () => void;
+}
+
+const ClassButton: React.FC<ClassButtonProps> = ({
+  isActive,
+  barColor,
+  title,
+  meta,
+  count,
+  icon,
+  onClick,
+}) => (
+  <button
+    type="button"
+    onClick={onClick}
+    className={`group flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-left transition focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue-primary focus-visible:ring-offset-1 ${
+      isActive
+        ? 'bg-white shadow-sm ring-1 ring-slate-200'
+        : 'hover:bg-slate-100/80'
+    }`}
+  >
+    <span
+      aria-hidden="true"
+      className="h-9 w-1 shrink-0 rounded-full"
+      style={{ background: barColor }}
+    />
+    {icon && (
+      <span
+        aria-hidden="true"
+        className="text-slate-400 group-hover:text-slate-600"
+      >
+        {icon}
+      </span>
+    )}
+    <span className="min-w-0 flex-1">
+      <span
+        className={`block truncate text-sm font-semibold leading-tight ${
+          isActive ? 'text-slate-900' : 'text-slate-700'
+        }`}
+      >
+        {title}
+      </span>
+      <span className="mt-0.5 block truncate text-[11px] text-slate-500">
+        {meta}
+      </span>
+    </span>
+    {count > 0 && (
+      <span
+        aria-label={`${count} active`}
+        className={`shrink-0 rounded-full px-1.5 py-0.5 text-[11px] font-semibold tabular-nums ${
+          isActive
+            ? 'bg-brand-blue-primary text-white'
+            : 'bg-slate-100 text-slate-500'
+        }`}
+      >
+        {count}
+      </span>
+    )}
+  </button>
+);

--- a/context/StudentAuthContext.tsx
+++ b/context/StudentAuthContext.tsx
@@ -19,6 +19,7 @@ import {
 import {
   StudentAuthContext,
   STUDENT_FIRST_NAME_KEY,
+  clearStudentFirstName,
   type StudentAuthStatus,
   type StudentAuthValue,
 } from './StudentAuthContextValue';
@@ -36,16 +37,6 @@ const readFirstName = (): string | null => {
     return raw && raw.length > 0 ? raw : null;
   } catch {
     return null;
-  }
-};
-
-const clearFirstName = (): void => {
-  if (typeof window === 'undefined') return;
-  try {
-    window.sessionStorage.removeItem(STUDENT_FIRST_NAME_KEY);
-  } catch {
-    // Storage disabled — nothing to clear; the value couldn't have been
-    // written either.
   }
 };
 
@@ -252,7 +243,10 @@ export const StudentAuthProvider: React.FC<{ children: React.ReactNode }> = ({
             // are malformed, OR the student is valid but isn't on any
             // roster yet. Force a sign-out so the stale session can't
             // linger on a shared device, then redirect with a reason so
-            // the login screen can explain the bounce.
+            // the login screen can explain the bounce. Clear the cached
+            // first name so a non-student bounce doesn't leave the
+            // previous session's greeting parked in sessionStorage.
+            clearStudentFirstName();
             void firebaseSignOut(auth).catch(() => {
               // Swallow — the redirect below is the actual remediation.
             });
@@ -271,6 +265,9 @@ export const StudentAuthProvider: React.FC<{ children: React.ReactNode }> = ({
         },
         () => {
           if (!mountedRef.current) return;
+          // Claim resolution threw — no firstName remains valid for this
+          // session. Clear before bouncing back to login.
+          clearStudentFirstName();
           setState(UNAUTH_STATE);
           redirectToLoginIfProtected('invalid-claims');
         }
@@ -290,7 +287,7 @@ export const StudentAuthProvider: React.FC<{ children: React.ReactNode }> = ({
     // Always clear the first-name cache before tearing down the session so
     // the next student on a shared device doesn't inherit the previous
     // student's greeting.
-    clearFirstName();
+    clearStudentFirstName();
     if (isAuthBypass) {
       // Bypass mode: simulate a sign-out by flipping to unauthenticated and
       // redirecting. Real Firebase Auth isn't involved.

--- a/context/StudentAuthContext.tsx
+++ b/context/StudentAuthContext.tsx
@@ -18,9 +18,36 @@ import {
 } from '@/hooks/useStudentIdleTimeout';
 import {
   StudentAuthContext,
+  STUDENT_FIRST_NAME_KEY,
   type StudentAuthStatus,
   type StudentAuthValue,
 } from './StudentAuthContextValue';
+
+/**
+ * Read the student's first name from tab-scoped `sessionStorage`. Stored at
+ * sign-in by `StudentLoginPage`. The name lives only in this tab, never in
+ * Firestore. `null` when not available (storage disabled, never written, or
+ * cleared by signOut).
+ */
+const readFirstName = (): string | null => {
+  if (typeof window === 'undefined') return null;
+  try {
+    const raw = window.sessionStorage.getItem(STUDENT_FIRST_NAME_KEY);
+    return raw && raw.length > 0 ? raw : null;
+  } catch {
+    return null;
+  }
+};
+
+const clearFirstName = (): void => {
+  if (typeof window === 'undefined') return;
+  try {
+    window.sessionStorage.removeItem(STUDENT_FIRST_NAME_KEY);
+  } catch {
+    // Storage disabled — nothing to clear; the value couldn't have been
+    // written either.
+  }
+};
 
 /**
  * StudentAuthContext — Phase 2B of the ClassLink-via-Google auth flow.
@@ -123,6 +150,7 @@ const MOCK_STUDENT: Omit<StudentAuthValue, 'signOut'> & {
   pseudonymUid: 'mock-student',
   orgId: 'mock-org',
   classIds: ['mock-class-1'],
+  firstName: 'Demo',
 };
 
 // ---------------------------------------------------------------------------
@@ -134,6 +162,7 @@ interface ProviderState {
   pseudonymUid: string | null;
   orgId: string | null;
   classIds: string[];
+  firstName: string | null;
 }
 
 const INITIAL_STATE: ProviderState = {
@@ -141,6 +170,7 @@ const INITIAL_STATE: ProviderState = {
   pseudonymUid: null,
   orgId: null,
   classIds: [],
+  firstName: null,
 };
 
 const UNAUTH_STATE: ProviderState = {
@@ -148,6 +178,7 @@ const UNAUTH_STATE: ProviderState = {
   pseudonymUid: null,
   orgId: null,
   classIds: [],
+  firstName: null,
 };
 
 /**
@@ -178,6 +209,7 @@ export const StudentAuthProvider: React.FC<{ children: React.ReactNode }> = ({
           pseudonymUid: MOCK_STUDENT.pseudonymUid,
           orgId: MOCK_STUDENT.orgId,
           classIds: MOCK_STUDENT.classIds,
+          firstName: MOCK_STUDENT.firstName,
         }
       : INITIAL_STATE
   );
@@ -234,6 +266,7 @@ export const StudentAuthProvider: React.FC<{ children: React.ReactNode }> = ({
             pseudonymUid: user.uid,
             orgId: outcome.value.orgId,
             classIds: outcome.value.classIds,
+            firstName: readFirstName(),
           });
         },
         () => {
@@ -254,6 +287,10 @@ export const StudentAuthProvider: React.FC<{ children: React.ReactNode }> = ({
 
   // --- Imperative sign-out (exposed on context) -----------------------------
   const signOut = useCallback(async () => {
+    // Always clear the first-name cache before tearing down the session so
+    // the next student on a shared device doesn't inherit the previous
+    // student's greeting.
+    clearFirstName();
     if (isAuthBypass) {
       // Bypass mode: simulate a sign-out by flipping to unauthenticated and
       // redirecting. Real Firebase Auth isn't involved.
@@ -280,9 +317,17 @@ export const StudentAuthProvider: React.FC<{ children: React.ReactNode }> = ({
       pseudonymUid: state.pseudonymUid,
       orgId: state.orgId,
       classIds: state.classIds,
+      firstName: state.firstName,
       signOut,
     }),
-    [state.status, state.pseudonymUid, state.orgId, state.classIds, signOut]
+    [
+      state.status,
+      state.pseudonymUid,
+      state.orgId,
+      state.classIds,
+      state.firstName,
+      signOut,
+    ]
   );
 
   return (

--- a/context/StudentAuthContextValue.ts
+++ b/context/StudentAuthContextValue.ts
@@ -55,6 +55,23 @@ export interface StudentAuthValue {
 /** Tab-scoped sessionStorage key for the student's first name. */
 export const STUDENT_FIRST_NAME_KEY = 'sb_student_first_name';
 
+/**
+ * Remove the student's first name from tab-scoped `sessionStorage`. Must be
+ * called on every sign-out path (explicit `signOut()`, idle-timeout
+ * auto-logout, and the StudentAuthContext claim-rejection path) so the
+ * next student on a shared device never inherits the previous student's
+ * greeting. Safe to call when storage is empty or disabled.
+ */
+export const clearStudentFirstName = (): void => {
+  if (typeof window === 'undefined') return;
+  try {
+    window.sessionStorage.removeItem(STUDENT_FIRST_NAME_KEY);
+  } catch {
+    // Storage disabled — nothing to clear; the value couldn't have been
+    // written either.
+  }
+};
+
 export const StudentAuthContext = createContext<StudentAuthValue | undefined>(
   undefined
 );

--- a/context/StudentAuthContextValue.ts
+++ b/context/StudentAuthContextValue.ts
@@ -16,10 +16,18 @@ export type StudentAuthStatus = 'loading' | 'authenticated' | 'unauthenticated';
 /**
  * Minimal auth surface for student-facing protected routes.
  *
- * This context is intentionally PII-free:
+ * This context is intentionally Firestore-PII-free:
  *   - `pseudonymUid` is the opaque pseudonym minted by `studentLoginV1`.
  *   - `orgId` / `classIds` come from the custom claims on that custom token.
- *   - No email, name, photo, or `sub` is ever read, rendered, or persisted.
+ *   - No email, full name, photo, or `sub` is ever read, rendered, or
+ *     persisted to any server we own.
+ *
+ * `firstName` is the one exception, and only as the student's own name in
+ * their own browser tab: read from the Google ID token at login and parked
+ * in tab-scoped `sessionStorage`, never sent to Firestore, never logged,
+ * cleared on `signOut()`. Used purely for the personalized greeting in the
+ * sidebar footer. `null` when unavailable (legacy session, Google declined
+ * to include `given_name`, or the storage read failed).
  */
 export interface StudentAuthValue {
   /** Auth lifecycle status. */
@@ -31,13 +39,21 @@ export interface StudentAuthValue {
   /** ClassLink class sourcedIds the student is enrolled in. Empty when not authenticated. */
   classIds: string[];
   /**
-   * Sign out of Firebase and redirect to `/student/login`.
-   *
-   * Exposed so that UI (e.g. a "Done" button on `/my-assignments`) can end
-   * a session on shared-device carts without depending on the idle timeout.
+   * Student's given/first name from the Google ID token at sign-in. Stored
+   * in sessionStorage, never in Firestore. See class-doc above. `null` when
+   * not available — UI must render a sensible fallback.
+   */
+  firstName: string | null;
+  /**
+   * Sign out of Firebase and redirect to `/student/login`. Also clears the
+   * sessionStorage `firstName` so the next session on a shared device
+   * doesn't inherit the previous student's name.
    */
   signOut: () => Promise<void>;
 }
+
+/** Tab-scoped sessionStorage key for the student's first name. */
+export const STUDENT_FIRST_NAME_KEY = 'sb_student_first_name';
 
 export const StudentAuthContext = createContext<StudentAuthValue | undefined>(
   undefined

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -245,6 +245,20 @@
         {
           "fieldPath": "status",
           "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "mini_app_sessions",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "classIds",
+          "arrayConfig": "CONTAINS"
+        },
+        {
+          "fieldPath": "status",
+          "order": "ASCENDING"
         },
         {
           "fieldPath": "endedAt",

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -257,12 +257,20 @@
     {
       "collectionGroup": "rosters",
       "fieldPath": "classlinkClassId",
-      "indexes": [{ "order": "ASCENDING", "queryScope": "COLLECTION_GROUP" }]
+      "indexes": [
+        { "order": "ASCENDING", "queryScope": "COLLECTION" },
+        { "order": "DESCENDING", "queryScope": "COLLECTION" },
+        { "order": "ASCENDING", "queryScope": "COLLECTION_GROUP" }
+      ]
     },
     {
       "collectionGroup": "rosters",
       "fieldPath": "testClassId",
-      "indexes": [{ "order": "ASCENDING", "queryScope": "COLLECTION_GROUP" }]
+      "indexes": [
+        { "order": "ASCENDING", "queryScope": "COLLECTION" },
+        { "order": "DESCENDING", "queryScope": "COLLECTION" },
+        { "order": "ASCENDING", "queryScope": "COLLECTION_GROUP" }
+      ]
     }
   ]
 }

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -161,6 +161,96 @@
           "order": "ASCENDING"
         }
       ]
+    },
+    {
+      "collectionGroup": "quiz_sessions",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "classIds",
+          "arrayConfig": "CONTAINS"
+        },
+        {
+          "fieldPath": "status",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "endedAt",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "quiz_sessions",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "classId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "status",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "endedAt",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "video_activity_sessions",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "classIds",
+          "arrayConfig": "CONTAINS"
+        },
+        {
+          "fieldPath": "status",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "endedAt",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "video_activity_sessions",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "classId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "status",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "endedAt",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "mini_app_sessions",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "classIds",
+          "arrayConfig": "CONTAINS"
+        },
+        {
+          "fieldPath": "status",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "endedAt",
+          "order": "DESCENDING"
+        }
+      ]
     }
   ],
   "fieldOverrides": []

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -253,5 +253,16 @@
       ]
     }
   ],
-  "fieldOverrides": []
+  "fieldOverrides": [
+    {
+      "collectionGroup": "rosters",
+      "fieldPath": "classlinkClassId",
+      "indexes": [{ "order": "ASCENDING", "queryScope": "COLLECTION_GROUP" }]
+    },
+    {
+      "collectionGroup": "rosters",
+      "fieldPath": "testClassId",
+      "indexes": [{ "order": "ASCENDING", "queryScope": "COLLECTION_GROUP" }]
+    }
+  ]
 }

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -3101,90 +3101,140 @@ export const getStudentClassDirectoryV1 = onCall(
       code?: string;
     }
 
-    const lookupOne = async (
-      classId: string
-    ): Promise<DirectoryEntry | null> => {
-      // 1. Real ClassLink roster.
-      const rosterByClasslink = await db
-        .collectionGroup('rosters')
-        .where('classlinkClassId', '==', classId)
-        .limit(1)
-        .get();
-      if (!rosterByClasslink.empty) {
-        const rosterDoc = rosterByClasslink.docs[0];
-        const data = rosterDoc.data();
-        const teacherUid = rosterDoc.ref.parent.parent?.id ?? '';
-        const teacherDisplayName = teacherUid
-          ? await resolveTeacherName(teacherUid)
-          : '';
-        return {
-          classId,
-          name: typeof data.name === 'string' ? data.name : classId,
-          teacherDisplayName,
-          subject:
-            typeof data.classlinkSubject === 'string'
-              ? data.classlinkSubject
-              : undefined,
-          code:
-            typeof data.classlinkClassCode === 'string'
-              ? data.classlinkClassCode
-              : undefined,
-        };
+    // Batch the per-classId collectionGroup queries instead of fanning out
+    // 2-3 queries per id (up to 60 queries for STUDENT_LOGIN_CLASS_IDS_MAX
+    // = 20). Firestore caps `in`-array size at 30; we chunk at 10 to stay
+    // safely under the limit and to fit the typical `STUDENT_LOGIN_CLASS_IDS_MAX`
+    // payload in 2-3 chunks.
+    const FIRESTORE_IN_CHUNK_SIZE = 10;
+    const chunk = <T>(arr: readonly T[], size: number): T[][] => {
+      const chunks: T[][] = [];
+      for (let i = 0; i < arr.length; i += size) {
+        chunks.push(arr.slice(i, i + size));
       }
-
-      // 2. Test-class roster (teacher imported an admin-managed test class).
-      const rosterByTestId = await db
-        .collectionGroup('rosters')
-        .where('testClassId', '==', classId)
-        .limit(1)
-        .get();
-      if (!rosterByTestId.empty) {
-        const rosterDoc = rosterByTestId.docs[0];
-        const data = rosterDoc.data();
-        const teacherUid = rosterDoc.ref.parent.parent?.id ?? '';
-        const teacherDisplayName = teacherUid
-          ? await resolveTeacherName(teacherUid)
-          : '';
-        return {
-          classId,
-          name: typeof data.name === 'string' ? data.name : classId,
-          teacherDisplayName,
-          subject:
-            typeof data.classlinkSubject === 'string'
-              ? data.classlinkSubject
-              : undefined,
-        };
-      }
-
-      // 3. Direct testClasses fallback (no teacher has imported it yet).
-      if (orgId) {
-        try {
-          const testDoc = await db
-            .doc(`organizations/${orgId}/testClasses/${classId}`)
-            .get();
-          if (testDoc.exists) {
-            const data = testDoc.data() ?? {};
-            return {
-              classId,
-              name:
-                typeof data.title === 'string' && data.title.length > 0
-                  ? data.title
-                  : classId,
-              teacherDisplayName: '',
-              subject:
-                typeof data.subject === 'string' ? data.subject : undefined,
-            };
-          }
-        } catch {
-          // Fall through to "not found".
-        }
-      }
-
-      return null;
+      return chunks;
     };
 
-    const settled = await Promise.all(classIds.map(lookupOne));
-    const classes = settled.filter((e): e is DirectoryEntry => e !== null);
+    /**
+     * Run `collectionGroup('rosters').where(field, 'in', chunk)` for every
+     * chunk of `ids`, then index the matching roster docs by their
+     * `field`-value. First match wins on duplicates so the teacher whose
+     * roster Firestore returns first deterministically owns the directory
+     * entry for that class.
+     */
+    const batchLookupByField = async (
+      field: 'classlinkClassId' | 'testClassId',
+      ids: readonly string[]
+    ): Promise<Map<string, FirebaseFirestore.QueryDocumentSnapshot>> => {
+      const out = new Map<string, FirebaseFirestore.QueryDocumentSnapshot>();
+      if (ids.length === 0) return out;
+      const snapshots = await Promise.all(
+        chunk(ids, FIRESTORE_IN_CHUNK_SIZE).map((idChunk) =>
+          db.collectionGroup('rosters').where(field, 'in', idChunk).get()
+        )
+      );
+      for (const snap of snapshots) {
+        for (const doc of snap.docs) {
+          const value: unknown = doc.get(field);
+          if (typeof value === 'string' && !out.has(value)) {
+            out.set(value, doc);
+          }
+        }
+      }
+      return out;
+    };
+
+    const buildEntryFromRoster = async (
+      classId: string,
+      rosterDoc: FirebaseFirestore.QueryDocumentSnapshot,
+      includeCode: boolean
+    ): Promise<DirectoryEntry> => {
+      const data = rosterDoc.data();
+      const teacherUid = rosterDoc.ref.parent.parent?.id ?? '';
+      const teacherDisplayName = teacherUid
+        ? await resolveTeacherName(teacherUid)
+        : '';
+      return {
+        classId,
+        name: typeof data.name === 'string' ? data.name : classId,
+        teacherDisplayName,
+        subject:
+          typeof data.classlinkSubject === 'string'
+            ? data.classlinkSubject
+            : undefined,
+        code:
+          includeCode && typeof data.classlinkClassCode === 'string'
+            ? data.classlinkClassCode
+            : undefined,
+      };
+    };
+
+    // 1 + 2. Batched collectionGroup lookups: classlinkClassId first, then
+    // testClassId for whatever didn't resolve. Two `in` queries per field
+    // chunk replace what was up to 40 separate equality queries.
+    const classlinkMatches = await batchLookupByField(
+      'classlinkClassId',
+      classIds
+    );
+    const unresolvedAfterClasslink = classIds.filter(
+      (id) => !classlinkMatches.has(id)
+    );
+    const testIdMatches = await batchLookupByField(
+      'testClassId',
+      unresolvedAfterClasslink
+    );
+
+    // 3. Direct testClasses doc reads — only for classIds still unresolved
+    // after the two batched roster passes. These are the admin-managed
+    // test classes that no teacher has imported yet.
+    const unresolvedAfterTestId = unresolvedAfterClasslink.filter(
+      (id) => !testIdMatches.has(id)
+    );
+    const testClassDocs = new Map<string, FirebaseFirestore.DocumentSnapshot>();
+    if (orgId && unresolvedAfterTestId.length > 0) {
+      const docs = await Promise.all(
+        unresolvedAfterTestId.map((id) =>
+          db
+            .doc(`organizations/${orgId}/testClasses/${id}`)
+            .get()
+            .catch(() => null)
+        )
+      );
+      for (let i = 0; i < unresolvedAfterTestId.length; i++) {
+        const d = docs[i];
+        if (d && d.exists) testClassDocs.set(unresolvedAfterTestId[i], d);
+      }
+    }
+
+    const entries = await Promise.all(
+      classIds.map(async (classId): Promise<DirectoryEntry | null> => {
+        const fromClasslink = classlinkMatches.get(classId);
+        if (fromClasslink) {
+          return buildEntryFromRoster(classId, fromClasslink, true);
+        }
+        const fromTestId = testIdMatches.get(classId);
+        if (fromTestId) {
+          return buildEntryFromRoster(classId, fromTestId, false);
+        }
+        const fromTestClassDoc = testClassDocs.get(classId);
+        if (fromTestClassDoc) {
+          const data = fromTestClassDoc.data() ?? {};
+          return {
+            classId,
+            name:
+              typeof data.title === 'string' && data.title.length > 0
+                ? data.title
+                : classId,
+            teacherDisplayName: '',
+            subject:
+              typeof data.subject === 'string' ? data.subject : undefined,
+          };
+        }
+        return null;
+      })
+    );
+
+    const classes = entries.filter((e): e is DirectoryEntry => e !== null);
     return { classes };
   }
 );

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -3016,6 +3016,180 @@ export const getAssignmentPseudonymV1 = onCall(
 );
 
 /**
+ * getStudentClassDirectoryV1
+ *
+ * Returns class metadata (name, teacher display name, subject, code) for the
+ * authenticated student's claim-bound `classIds`. Powers the sidebar on
+ * `/my-assignments` so a student sees "English 9 / Ms. Halverson" instead of
+ * an opaque sourcedId.
+ *
+ * Lookup order per classId:
+ *   1. `collectionGroup('rosters').where('classlinkClassId', '==', classId)` —
+ *      real ClassLink imports. Parent path gives teacher uid.
+ *   2. `collectionGroup('rosters').where('testClassId', '==', classId)` —
+ *      admin-managed test classes a teacher has imported.
+ *   3. `organizations/{orgId}/testClasses/{classId}` — admin-managed test
+ *      class with no teacher import yet (graceful fallback).
+ *
+ * PII: this function never returns student names, emails, or any field from
+ * the per-roster Drive file. Only Firestore-side roster meta (which is
+ * itself PII-free) plus the teacher's own `displayName` from Firebase Auth.
+ * Teacher names are organizational data, not student PII.
+ *
+ * Failure: classIds that match nothing are silently dropped from the
+ * response so the sidebar simply omits them. The page renders a fallback
+ * label client-side rather than treating a missing entry as an error.
+ */
+export const getStudentClassDirectoryV1 = onCall(
+  {
+    memory: '256MiB',
+    invoker: 'public',
+  },
+  async (request) => {
+    if (!request.auth) {
+      throw new HttpsError('unauthenticated', 'Sign in required.');
+    }
+    if (request.auth.token.studentRole !== true) {
+      throw new HttpsError('permission-denied', 'Student role required.');
+    }
+
+    const rawClassIds: unknown = request.auth.token.classIds;
+    if (!Array.isArray(rawClassIds)) {
+      throw new HttpsError('failed-precondition', 'No classes on token.');
+    }
+    const classIds = rawClassIds
+      .filter((c): c is string => typeof c === 'string' && c.length > 0)
+      .slice(0, STUDENT_LOGIN_CLASS_IDS_MAX);
+    if (classIds.length === 0) {
+      return { classes: [] };
+    }
+
+    const orgId =
+      typeof request.auth.token.orgId === 'string'
+        ? request.auth.token.orgId
+        : '';
+
+    const db = admin.firestore();
+
+    // Per-call cache: many classes may share a teacher; one Auth lookup
+    // suffices.
+    const teacherNameCache = new Map<string, string>();
+    const resolveTeacherName = async (teacherUid: string): Promise<string> => {
+      const cached = teacherNameCache.get(teacherUid);
+      if (cached !== undefined) return cached;
+      try {
+        const user = await admin.auth().getUser(teacherUid);
+        const displayName =
+          (typeof user.displayName === 'string' && user.displayName) ||
+          (typeof user.email === 'string' ? user.email.split('@')[0] : '') ||
+          '';
+        teacherNameCache.set(teacherUid, displayName);
+        return displayName;
+      } catch {
+        // Auth lookup can fail for legacy / deleted teacher accounts. Caller
+        // falls back to an empty teacher name; the row still renders.
+        teacherNameCache.set(teacherUid, '');
+        return '';
+      }
+    };
+
+    interface DirectoryEntry {
+      classId: string;
+      name: string;
+      teacherDisplayName: string;
+      subject?: string;
+      code?: string;
+    }
+
+    const lookupOne = async (
+      classId: string
+    ): Promise<DirectoryEntry | null> => {
+      // 1. Real ClassLink roster.
+      const rosterByClasslink = await db
+        .collectionGroup('rosters')
+        .where('classlinkClassId', '==', classId)
+        .limit(1)
+        .get();
+      if (!rosterByClasslink.empty) {
+        const rosterDoc = rosterByClasslink.docs[0];
+        const data = rosterDoc.data();
+        const teacherUid = rosterDoc.ref.parent.parent?.id ?? '';
+        const teacherDisplayName = teacherUid
+          ? await resolveTeacherName(teacherUid)
+          : '';
+        return {
+          classId,
+          name: typeof data.name === 'string' ? data.name : classId,
+          teacherDisplayName,
+          subject:
+            typeof data.classlinkSubject === 'string'
+              ? data.classlinkSubject
+              : undefined,
+          code:
+            typeof data.classlinkClassCode === 'string'
+              ? data.classlinkClassCode
+              : undefined,
+        };
+      }
+
+      // 2. Test-class roster (teacher imported an admin-managed test class).
+      const rosterByTestId = await db
+        .collectionGroup('rosters')
+        .where('testClassId', '==', classId)
+        .limit(1)
+        .get();
+      if (!rosterByTestId.empty) {
+        const rosterDoc = rosterByTestId.docs[0];
+        const data = rosterDoc.data();
+        const teacherUid = rosterDoc.ref.parent.parent?.id ?? '';
+        const teacherDisplayName = teacherUid
+          ? await resolveTeacherName(teacherUid)
+          : '';
+        return {
+          classId,
+          name: typeof data.name === 'string' ? data.name : classId,
+          teacherDisplayName,
+          subject:
+            typeof data.classlinkSubject === 'string'
+              ? data.classlinkSubject
+              : undefined,
+        };
+      }
+
+      // 3. Direct testClasses fallback (no teacher has imported it yet).
+      if (orgId) {
+        try {
+          const testDoc = await db
+            .doc(`organizations/${orgId}/testClasses/${classId}`)
+            .get();
+          if (testDoc.exists) {
+            const data = testDoc.data() ?? {};
+            return {
+              classId,
+              name:
+                typeof data.title === 'string' && data.title.length > 0
+                  ? data.title
+                  : classId,
+              teacherDisplayName: '',
+              subject:
+                typeof data.subject === 'string' ? data.subject : undefined,
+            };
+          }
+        } catch {
+          // Fall through to "not found".
+        }
+      }
+
+      return null;
+    };
+
+    const settled = await Promise.all(classIds.map(lookupOne));
+    const classes = settled.filter((e): e is DirectoryEntry => e !== null);
+    return { classes };
+  }
+);
+
+/**
  * getPseudonymsForAssignmentV1
  *
  * Called by a teacher's client when rendering the grading view for an

--- a/hooks/useStudentAssignments.ts
+++ b/hooks/useStudentAssignments.ts
@@ -1,0 +1,496 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  collection,
+  limit as firestoreLimit,
+  onSnapshot,
+  orderBy,
+  query,
+  where,
+  type DocumentData,
+  type Query,
+  type QueryConstraint,
+  type QuerySnapshot,
+} from 'firebase/firestore';
+import {
+  ClipboardList,
+  Image as ImageIcon,
+  PlayCircle,
+  Puzzle,
+  Sparkles,
+} from 'lucide-react';
+import { db, isAuthBypass } from '@/config/firebase';
+
+/**
+ * useStudentAssignments
+ *
+ * Owns every Firestore subscription that powers the student `/my-assignments`
+ * page. Lifted out of the page component so the new sidebar+content shell
+ * can share state across the Overview and per-class views without re-running
+ * subscriptions on each tab switch.
+ *
+ * Subscribes to two channels per supported session kind:
+ *   A. Active   — the existing flow ("status: active", or no status filter
+ *                 for collections without one).
+ *   B. Ended    — quiz / video-activity / mini-app, filtered to
+ *                 status === 'ended', ordered by endedAt desc, capped at 50
+ *                 per shape so the Completed list bounds Firestore reads.
+ *
+ * Dual-query (classIds array + legacy classId field) is preserved for
+ * quiz / video-activity / guided-learning. Mini-app and activity-wall stay
+ * single-query as today.
+ *
+ * The page applies the Active/Completed partition rule using the per-row
+ * lazy completion check (see AssignmentListItem). This hook does not
+ * compute completion itself — it only delivers the row plus its source
+ * channel so the partition can resolve client-side.
+ *
+ * Bounded growth: the limit(50) on the Ended channel caps reads. The
+ * Completed list is therefore a "recent history" view, not a full archive
+ * — surfacing roughly the last 50 ended sessions per kind per query shape.
+ */
+
+export type SessionKind =
+  | 'quiz'
+  | 'video-activity'
+  | 'guided-learning'
+  | 'mini-app'
+  | 'activity-wall';
+
+export type AssignmentChannel = 'active' | 'ended';
+
+export interface AssignmentSummary {
+  /** `${kind}:${sessionId}` — stable React key across collections. */
+  compositeId: string;
+  kind: SessionKind;
+  sessionId: string;
+  title: string;
+  /** Fully-qualified path the student can click to open the session. */
+  openHref: string;
+  /** Source channel — used by the page to partition Active vs Completed. */
+  channel: AssignmentChannel;
+  /** classIds this assignment targets, intersected with the student's claims. */
+  classIds: string[];
+  createdAt?: number;
+  endedAt?: number;
+}
+
+export type LoadState = 'loading' | 'ready';
+
+type StatusFilter =
+  | { field: 'status'; value: string }
+  | { field: 'status'; valueIn: readonly string[] }
+  | null;
+
+interface KindConfig {
+  collectionName: string;
+  /** Run BOTH a list query (classIds array-contains-any) AND a single query (classId in). */
+  dualQuery: boolean;
+  /** When dualQuery is false, this picks which shape to issue. */
+  classFilterShape: 'list' | 'single';
+  /** Filter for the Active channel. */
+  activeFilter: StatusFilter;
+  /**
+   * Filter for the Ended channel. When `null`, this kind has no status field
+   * and the Active channel is the only subscription.
+   */
+  endedFilter: StatusFilter;
+  /** Ordering field for the Ended channel (used with limit). */
+  endedOrderBy?: 'endedAt' | 'updatedAt';
+  /** Cap on Ended results per shape per kind. */
+  endedLimit: number;
+  label: string;
+  icon: React.ComponentType<{ className?: string; strokeWidth?: number }>;
+  /** Tailwind gradient for the card accent badge. */
+  accent: string;
+  titleFrom: (data: DocumentData) => string;
+  hrefFrom: (sessionId: string, data: DocumentData) => string;
+}
+
+export const KIND_CONFIG: Record<SessionKind, KindConfig> = {
+  quiz: {
+    collectionName: 'quiz_sessions',
+    dualQuery: true,
+    classFilterShape: 'single',
+    activeFilter: { field: 'status', valueIn: ['waiting', 'active'] },
+    endedFilter: { field: 'status', value: 'ended' },
+    endedOrderBy: 'endedAt',
+    endedLimit: 50,
+    label: 'Quiz',
+    icon: ClipboardList,
+    accent: 'from-blue-500 to-indigo-600',
+    titleFrom: (data) =>
+      typeof data.quizTitle === 'string' && data.quizTitle.length > 0
+        ? data.quizTitle
+        : 'Untitled quiz',
+    hrefFrom: (sessionId, data) => {
+      const code =
+        typeof data.code === 'string' && data.code.length > 0
+          ? data.code
+          : sessionId;
+      return `/quiz?code=${encodeURIComponent(code)}`;
+    },
+  },
+  'video-activity': {
+    collectionName: 'video_activity_sessions',
+    dualQuery: true,
+    classFilterShape: 'single',
+    activeFilter: { field: 'status', value: 'active' },
+    endedFilter: { field: 'status', value: 'ended' },
+    endedOrderBy: 'endedAt',
+    endedLimit: 50,
+    label: 'Video Activity',
+    icon: PlayCircle,
+    accent: 'from-rose-500 to-red-600',
+    titleFrom: (data) => {
+      if (
+        typeof data.activityTitle === 'string' &&
+        data.activityTitle.length > 0
+      )
+        return data.activityTitle;
+      if (
+        typeof data.assignmentName === 'string' &&
+        data.assignmentName.length > 0
+      )
+        return data.assignmentName;
+      return 'Video activity';
+    },
+    hrefFrom: (sessionId) => `/activity/${encodeURIComponent(sessionId)}`,
+  },
+  'guided-learning': {
+    collectionName: 'guided_learning_sessions',
+    dualQuery: true,
+    classFilterShape: 'single',
+    activeFilter: null, // No status field; existence = live.
+    endedFilter: null, // No ended channel — partitioned by completion alone.
+    endedLimit: 0,
+    label: 'Guided Learning',
+    icon: Sparkles,
+    accent: 'from-emerald-500 to-teal-600',
+    titleFrom: (data) =>
+      typeof data.title === 'string' && data.title.length > 0
+        ? data.title
+        : 'Guided learning',
+    hrefFrom: (sessionId) =>
+      `/guided-learning/${encodeURIComponent(sessionId)}`,
+  },
+  'mini-app': {
+    collectionName: 'mini_app_sessions',
+    dualQuery: false,
+    classFilterShape: 'list',
+    activeFilter: { field: 'status', value: 'active' },
+    endedFilter: { field: 'status', value: 'ended' },
+    endedOrderBy: 'endedAt',
+    endedLimit: 50,
+    label: 'Mini App',
+    icon: Puzzle,
+    accent: 'from-violet-500 to-purple-600',
+    titleFrom: (data) => {
+      if (typeof data.appTitle === 'string' && data.appTitle.length > 0)
+        return data.appTitle;
+      if (
+        typeof data.assignmentName === 'string' &&
+        data.assignmentName.length > 0
+      )
+        return data.assignmentName;
+      return 'Mini app';
+    },
+    hrefFrom: (sessionId) => `/miniapp/${encodeURIComponent(sessionId)}`,
+  },
+  'activity-wall': {
+    collectionName: 'activity_wall_sessions',
+    dualQuery: false,
+    classFilterShape: 'single',
+    activeFilter: null, // No status field on the session doc.
+    endedFilter: null,
+    endedLimit: 0,
+    label: 'Activity Wall',
+    icon: ImageIcon,
+    accent: 'from-amber-500 to-orange-600',
+    titleFrom: (data) =>
+      typeof data.title === 'string' && data.title.length > 0
+        ? data.title
+        : 'Activity wall',
+    hrefFrom: (sessionId) => `/activity-wall/${encodeURIComponent(sessionId)}`,
+  },
+};
+
+export const SESSION_KINDS: readonly SessionKind[] = [
+  'quiz',
+  'video-activity',
+  'guided-learning',
+  'mini-app',
+  'activity-wall',
+];
+
+// ---------------------------------------------------------------------------
+
+interface SubscriptionPlan {
+  kind: SessionKind;
+  channel: AssignmentChannel;
+  shape: 'list' | 'single';
+}
+
+const planKey = (p: SubscriptionPlan): string =>
+  `${p.kind}:${p.channel}:${p.shape}`;
+
+interface UseStudentAssignmentsResult {
+  loadState: LoadState;
+  /** All assignments, deduped by `(kind, sessionId)`, sorted newest-first. */
+  assignments: AssignmentSummary[];
+  /** True when at least one subscription bucket has errored. */
+  hasErrors: boolean;
+  retry: () => void;
+}
+
+interface UseStudentAssignmentsArgs {
+  classIds: readonly string[];
+}
+
+export function useStudentAssignments({
+  classIds,
+}: UseStudentAssignmentsArgs): UseStudentAssignmentsResult {
+  const [byKindChannel, setByKindChannel] = useState<
+    Record<string, AssignmentSummary[]>
+  >({});
+  const [loadState, setLoadState] = useState<LoadState>(() =>
+    isAuthBypass ? 'ready' : 'loading'
+  );
+  const [erroredBuckets, setErroredBuckets] = useState<Set<string>>(
+    () => new Set()
+  );
+  const [retryNonce, setRetryNonce] = useState(0);
+
+  const classIdsKey = useMemo(
+    () => classIds.slice().sort().join('|'),
+    [classIds]
+  );
+
+  useEffect(() => {
+    // Bypass mode renders the layout against an empty assignment list so the
+    // page is exercisable in dev without a real Firestore backend. Initial
+    // state already covers this; the effect just skips the subscriptions.
+    if (isAuthBypass) return;
+    if (classIds.length === 0) {
+      setByKindChannel({});
+      setErroredBuckets(new Set());
+      setLoadState('ready');
+      return;
+    }
+
+    setLoadState('loading');
+    setErroredBuckets(new Set());
+
+    // Plan every (kind, channel, shape) subscription up front. Active
+    // channel always runs; Ended channel only for kinds that have a status
+    // field. Dual-query kinds run BOTH list and single shapes.
+    const subs: SubscriptionPlan[] = [];
+    for (const kind of SESSION_KINDS) {
+      const config = KIND_CONFIG[kind];
+      const channels: AssignmentChannel[] = ['active'];
+      if (config.endedFilter !== null) channels.push('ended');
+      for (const channel of channels) {
+        if (config.dualQuery) {
+          subs.push({ kind, channel, shape: 'list' });
+          subs.push({ kind, channel, shape: 'single' });
+        } else {
+          subs.push({ kind, channel, shape: config.classFilterShape });
+        }
+      }
+    }
+    const totalSubscriptions = subs.length;
+
+    const buckets = new Map<string, AssignmentSummary[]>();
+    const settled = new Set<string>();
+
+    // Local copy of the student's classIds for fast intersection.
+    const studentClassIds = new Set(classIds);
+
+    const docToSummary = (
+      kind: SessionKind,
+      channel: AssignmentChannel,
+      config: KindConfig,
+      d: QuerySnapshot<DocumentData>['docs'][number]
+    ): AssignmentSummary => {
+      const data = d.data();
+      const createdAtRaw: unknown = (data as Record<string, unknown>).createdAt;
+      const endedAtRaw: unknown = (data as Record<string, unknown>).endedAt;
+
+      // Compute the intersection of session classIds with student claims so
+      // multi-class assignments fan out under each matching class. Falls
+      // back to the legacy single-class field when classIds is absent.
+      const sessionClassIds: string[] = Array.isArray(
+        (data as Record<string, unknown>).classIds
+      )
+        ? ((data as Record<string, unknown>).classIds as unknown[]).filter(
+            (c): c is string => typeof c === 'string'
+          )
+        : [];
+      const legacyClassId =
+        typeof (data as Record<string, unknown>).classId === 'string'
+          ? ((data as Record<string, unknown>).classId as string)
+          : '';
+      const candidates =
+        sessionClassIds.length > 0
+          ? sessionClassIds
+          : legacyClassId
+            ? [legacyClassId]
+            : [];
+      const intersected = candidates.filter((c) => studentClassIds.has(c));
+
+      return {
+        compositeId: `${kind}:${d.id}`,
+        kind,
+        sessionId: d.id,
+        title: config.titleFrom(data),
+        openHref: config.hrefFrom(d.id, data),
+        channel,
+        classIds: intersected,
+        createdAt: typeof createdAtRaw === 'number' ? createdAtRaw : undefined,
+        endedAt: typeof endedAtRaw === 'number' ? endedAtRaw : undefined,
+      };
+    };
+
+    const emit = (kind: SessionKind, channel: AssignmentChannel) => {
+      const listBucket =
+        buckets.get(planKey({ kind, channel, shape: 'list' })) ?? [];
+      const singleBucket =
+        buckets.get(planKey({ kind, channel, shape: 'single' })) ?? [];
+      const merged = new Map<string, AssignmentSummary>();
+      for (const a of listBucket) merged.set(a.sessionId, a);
+      for (const a of singleBucket) merged.set(a.sessionId, a);
+      const channelKey = `${kind}:${channel}`;
+      setByKindChannel((prev) => ({
+        ...prev,
+        [channelKey]: Array.from(merged.values()),
+      }));
+    };
+
+    const markSettled = (key: string) => {
+      settled.add(key);
+      if (settled.size === totalSubscriptions) {
+        setLoadState('ready');
+      }
+    };
+
+    const buildQuery = (
+      config: KindConfig,
+      channel: AssignmentChannel,
+      shape: 'list' | 'single'
+    ): Query<DocumentData> => {
+      const col = collection(db, config.collectionName);
+      const constraints: QueryConstraint[] =
+        shape === 'list'
+          ? [where('classIds', 'array-contains-any', [...classIds])]
+          : [where('classId', 'in', [...classIds])];
+      const filter =
+        channel === 'active' ? config.activeFilter : config.endedFilter;
+      if (filter) {
+        if ('valueIn' in filter) {
+          constraints.push(where(filter.field, 'in', [...filter.valueIn]));
+        } else {
+          constraints.push(where(filter.field, '==', filter.value));
+        }
+      }
+      if (channel === 'ended' && config.endedOrderBy) {
+        constraints.push(orderBy(config.endedOrderBy, 'desc'));
+        constraints.push(firestoreLimit(config.endedLimit));
+      }
+      return query(col, ...constraints);
+    };
+
+    const handleSnapshot = (
+      plan: SubscriptionPlan,
+      snap: QuerySnapshot<DocumentData>
+    ) => {
+      const config = KIND_CONFIG[plan.kind];
+      const key = planKey(plan);
+      buckets.set(
+        key,
+        snap.docs.map((d) => docToSummary(plan.kind, plan.channel, config, d))
+      );
+      emit(plan.kind, plan.channel);
+      setErroredBuckets((prev) => {
+        if (!prev.has(key)) return prev;
+        const next = new Set(prev);
+        next.delete(key);
+        return next;
+      });
+      markSettled(key);
+    };
+
+    const handleError = (plan: SubscriptionPlan, err: unknown) => {
+      const code =
+        err && typeof err === 'object' && 'code' in err
+          ? String((err as { code?: unknown }).code)
+          : 'unknown';
+      const message =
+        err && typeof err === 'object' && 'message' in err
+          ? String((err as { message?: unknown }).message)
+          : '';
+      console.error(
+        `[useStudentAssignments] snapshot failed for ${KIND_CONFIG[plan.kind].collectionName} (${plan.channel}/${plan.shape}) [${code}]:`,
+        message
+      );
+      const key = planKey(plan);
+      buckets.set(key, []);
+      emit(plan.kind, plan.channel);
+      setErroredBuckets((prev) => {
+        if (prev.has(key)) return prev;
+        const next = new Set(prev);
+        next.add(key);
+        return next;
+      });
+      markSettled(key);
+    };
+
+    const unsubs: Array<() => void> = [];
+    for (const plan of subs) {
+      const config = KIND_CONFIG[plan.kind];
+      const q = buildQuery(config, plan.channel, plan.shape);
+      unsubs.push(
+        onSnapshot(
+          q,
+          (snap) => handleSnapshot(plan, snap),
+          (err) => handleError(plan, err)
+        )
+      );
+    }
+
+    return () => {
+      for (const u of unsubs) u();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [classIdsKey, retryNonce]);
+
+  const assignments: AssignmentSummary[] = useMemo(() => {
+    // Dedupe by (kind, sessionId): a row may show up in both Active and
+    // Ended during a brief status transition. Prefer the Ended copy
+    // because it carries `endedAt` for sorting.
+    const merged = new Map<string, AssignmentSummary>();
+    for (const kind of SESSION_KINDS) {
+      const activeKey = `${kind}:active`;
+      const endedKey = `${kind}:ended`;
+      const active = byKindChannel[activeKey] ?? [];
+      const ended = byKindChannel[endedKey] ?? [];
+      for (const a of active) merged.set(`${kind}:${a.sessionId}`, a);
+      for (const a of ended) merged.set(`${kind}:${a.sessionId}`, a); // Ended overrides
+    }
+    const out = Array.from(merged.values());
+    out.sort((a, b) => {
+      const at = a.endedAt ?? a.createdAt ?? 0;
+      const bt = b.endedAt ?? b.createdAt ?? 0;
+      if (at !== bt) return bt - at;
+      return a.title.localeCompare(b.title);
+    });
+    return out;
+  }, [byKindChannel]);
+
+  const retry = useCallback(() => setRetryNonce((n) => n + 1), []);
+
+  return {
+    loadState,
+    assignments,
+    hasErrors: erroredBuckets.size > 0,
+    retry,
+  };
+}

--- a/hooks/useStudentAssignments.ts
+++ b/hooks/useStudentAssignments.ts
@@ -228,10 +228,19 @@ interface SubscriptionPlan {
   kind: SessionKind;
   channel: AssignmentChannel;
   shape: 'list' | 'single';
+  /**
+   * Concrete status value for this subscription, or `null` when the kind has
+   * no status filter. Filters with multiple values (e.g., quiz active =
+   * `['waiting', 'active']`) fan out into one plan per value: Firestore
+   * forbids combining `in` with `array-contains-any` (or two `in` clauses)
+   * in the same query, so each subscription must carry at most one
+   * disjunctive constraint.
+   */
+  statusValue: string | null;
 }
 
 const planKey = (p: SubscriptionPlan): string =>
-  `${p.kind}:${p.channel}:${p.shape}`;
+  `${p.kind}:${p.channel}:${p.shape}:${p.statusValue ?? '_'}`;
 
 interface UseStudentAssignmentsResult {
   loadState: LoadState;
@@ -280,20 +289,38 @@ export function useStudentAssignments({
     setLoadState('loading');
     setErroredBuckets(new Set());
 
-    // Plan every (kind, channel, shape) subscription up front. Active
-    // channel always runs; Ended channel only for kinds that have a status
-    // field. Dual-query kinds run BOTH list and single shapes.
+    // Plan every (kind, channel, shape, statusValue) subscription up front.
+    // Active channel always runs; Ended channel only for kinds that have a
+    // status field. Dual-query kinds run BOTH list and single shapes.
+    // Multi-value status filters (e.g., quiz active = waiting+active) fan
+    // out into one plan per status so each query stays inside Firestore's
+    // single-disjunctive-clause limit.
     const subs: SubscriptionPlan[] = [];
     for (const kind of SESSION_KINDS) {
       const config = KIND_CONFIG[kind];
       const channels: AssignmentChannel[] = ['active'];
       if (config.endedFilter !== null) channels.push('ended');
       for (const channel of channels) {
-        if (config.dualQuery) {
-          subs.push({ kind, channel, shape: 'list' });
-          subs.push({ kind, channel, shape: 'single' });
-        } else {
-          subs.push({ kind, channel, shape: config.classFilterShape });
+        const filter =
+          channel === 'active' ? config.activeFilter : config.endedFilter;
+        const statusValues: (string | null)[] =
+          filter === null
+            ? [null]
+            : 'valueIn' in filter
+              ? [...filter.valueIn]
+              : [filter.value];
+        for (const statusValue of statusValues) {
+          if (config.dualQuery) {
+            subs.push({ kind, channel, shape: 'list', statusValue });
+            subs.push({ kind, channel, shape: 'single', statusValue });
+          } else {
+            subs.push({
+              kind,
+              channel,
+              shape: config.classFilterShape,
+              statusValue,
+            });
+          }
         }
       }
     }
@@ -351,13 +378,16 @@ export function useStudentAssignments({
     };
 
     const emit = (kind: SessionKind, channel: AssignmentChannel) => {
-      const listBucket =
-        buckets.get(planKey({ kind, channel, shape: 'list' })) ?? [];
-      const singleBucket =
-        buckets.get(planKey({ kind, channel, shape: 'single' })) ?? [];
+      // Merge across every (shape, statusValue) bucket for this kind+channel.
+      // The status fan-out can produce multiple buckets per channel (e.g.,
+      // quiz active fans out into `waiting` and `active` per shape).
+      const prefix = `${kind}:${channel}:`;
       const merged = new Map<string, AssignmentSummary>();
-      for (const a of listBucket) merged.set(a.sessionId, a);
-      for (const a of singleBucket) merged.set(a.sessionId, a);
+      for (const [key, rows] of buckets) {
+        if (key.startsWith(prefix)) {
+          for (const a of rows) merged.set(a.sessionId, a);
+        }
+      }
       const channelKey = `${kind}:${channel}`;
       setByKindChannel((prev) => ({
         ...prev,
@@ -375,21 +405,16 @@ export function useStudentAssignments({
     const buildQuery = (
       config: KindConfig,
       channel: AssignmentChannel,
-      shape: 'list' | 'single'
+      shape: 'list' | 'single',
+      statusValue: string | null
     ): Query<DocumentData> => {
       const col = collection(db, config.collectionName);
       const constraints: QueryConstraint[] =
         shape === 'list'
           ? [where('classIds', 'array-contains-any', [...classIds])]
           : [where('classId', 'in', [...classIds])];
-      const filter =
-        channel === 'active' ? config.activeFilter : config.endedFilter;
-      if (filter) {
-        if ('valueIn' in filter) {
-          constraints.push(where(filter.field, 'in', [...filter.valueIn]));
-        } else {
-          constraints.push(where(filter.field, '==', filter.value));
-        }
+      if (statusValue !== null) {
+        constraints.push(where('status', '==', statusValue));
       }
       if (channel === 'ended' && config.endedOrderBy) {
         constraints.push(orderBy(config.endedOrderBy, 'desc'));
@@ -428,7 +453,7 @@ export function useStudentAssignments({
           ? String((err as { message?: unknown }).message)
           : '';
       console.error(
-        `[useStudentAssignments] snapshot failed for ${KIND_CONFIG[plan.kind].collectionName} (${plan.channel}/${plan.shape}) [${code}]:`,
+        `[useStudentAssignments] snapshot failed for ${KIND_CONFIG[plan.kind].collectionName} (${plan.channel}/${plan.shape}/${plan.statusValue ?? '_'}) [${code}]:`,
         message
       );
       const key = planKey(plan);
@@ -446,7 +471,7 @@ export function useStudentAssignments({
     const unsubs: Array<() => void> = [];
     for (const plan of subs) {
       const config = KIND_CONFIG[plan.kind];
-      const q = buildQuery(config, plan.channel, plan.shape);
+      const q = buildQuery(config, plan.channel, plan.shape, plan.statusValue);
       unsubs.push(
         onSnapshot(
           q,

--- a/hooks/useStudentAssignments.ts
+++ b/hooks/useStudentAssignments.ts
@@ -274,20 +274,38 @@ export function useStudentAssignments({
     [classIds]
   );
 
+  // Reset bucket / error / load state when the subscription identity
+  // changes — a new claim set or a retry. We use the "adjusting state
+  // while rendering" pattern (https://react.dev/reference/react/useState
+  // #storing-information-from-previous-renders) so the resets don't
+  // become synchronous setStates inside the effect body. Whether the
+  // post-reset state is `ready` (empty/bypass) or `loading` (about to
+  // subscribe) is decided here too.
+  const [resetIdentity, setResetIdentity] = useState<string>(
+    `${classIdsKey}#${retryNonce}`
+  );
+  const currentIdentity = `${classIdsKey}#${retryNonce}`;
+  if (resetIdentity !== currentIdentity) {
+    setResetIdentity(currentIdentity);
+    setByKindChannel({});
+    setErroredBuckets(new Set());
+    setLoadState(
+      isAuthBypass || classIdsKey.length === 0 ? 'ready' : 'loading'
+    );
+  }
+
   useEffect(() => {
     // Bypass mode renders the layout against an empty assignment list so the
-    // page is exercisable in dev without a real Firestore backend. Initial
-    // state already covers this; the effect just skips the subscriptions.
+    // page is exercisable in dev without a real Firestore backend. The
+    // render-time reset above already left state in the correct shape;
+    // the effect just skips the subscriptions.
     if (isAuthBypass) return;
-    if (classIds.length === 0) {
-      setByKindChannel({});
-      setErroredBuckets(new Set());
-      setLoadState('ready');
-      return;
-    }
-
-    setLoadState('loading');
-    setErroredBuckets(new Set());
+    // Reconstitute the classIds list from the value-based key so the effect
+    // can depend on `classIdsKey` alone (and not on `classIds` reference
+    // identity, which would re-subscribe whenever the auth context emits a
+    // fresh array even though the contents didn't change).
+    const ids = classIdsKey ? classIdsKey.split('|').filter(Boolean) : [];
+    if (ids.length === 0) return;
 
     // Plan every (kind, channel, shape, statusValue) subscription up front.
     // Active channel always runs; Ended channel only for kinds that have a
@@ -330,7 +348,7 @@ export function useStudentAssignments({
     const settled = new Set<string>();
 
     // Local copy of the student's classIds for fast intersection.
-    const studentClassIds = new Set(classIds);
+    const studentClassIds = new Set(ids);
 
     const docToSummary = (
       kind: SessionKind,
@@ -411,8 +429,8 @@ export function useStudentAssignments({
       const col = collection(db, config.collectionName);
       const constraints: QueryConstraint[] =
         shape === 'list'
-          ? [where('classIds', 'array-contains-any', [...classIds])]
-          : [where('classId', 'in', [...classIds])];
+          ? [where('classIds', 'array-contains-any', ids)]
+          : [where('classId', 'in', ids)];
       if (statusValue !== null) {
         constraints.push(where('status', '==', statusValue));
       }
@@ -484,7 +502,6 @@ export function useStudentAssignments({
     return () => {
       for (const u of unsubs) u();
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [classIdsKey, retryNonce]);
 
   const assignments: AssignmentSummary[] = useMemo(() => {

--- a/hooks/useStudentClassDirectory.ts
+++ b/hooks/useStudentClassDirectory.ts
@@ -1,0 +1,159 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { httpsCallable } from 'firebase/functions';
+import { functions, isAuthBypass } from '@/config/firebase';
+
+/**
+ * Class metadata returned by the `getStudentClassDirectoryV1` callable.
+ * Mirror of the server type. Teacher names are the only personally-identifying
+ * field — they are organizational data, NOT student PII.
+ */
+export interface ClassDirectoryEntry {
+  classId: string;
+  name: string;
+  teacherDisplayName: string;
+  subject?: string;
+  code?: string;
+}
+
+export type DirectoryStatus = 'loading' | 'ready' | 'error';
+
+export interface ClassDirectoryResult {
+  status: DirectoryStatus;
+  /** Resolved entries in the order returned by the server (may be a subset of classIds). */
+  classes: ClassDirectoryEntry[];
+  /** Lookup table keyed by classId for fast UI access. */
+  byId: Record<string, ClassDirectoryEntry>;
+  retry: () => void;
+}
+
+/**
+ * Module-local cache so a remount of the page doesn't refetch what we
+ * already have. Keyed by `${pseudonymUid}:${classIdsKey}`. Pseudonym
+ * scoping flushes the cache on sign-out (a different student's session
+ * would compute a different uid).
+ */
+const directoryCache = new Map<string, ClassDirectoryEntry[]>();
+
+const cacheKeyOf = (pseudonymUid: string, classIdsKey: string): string =>
+  `${pseudonymUid}:${classIdsKey}`;
+
+/**
+ * Bypass-mode mock — keeps the page render path consistent with real auth so
+ * `pnpm run dev` with VITE_AUTH_BYPASS=true can exercise the new sidebar.
+ */
+const BYPASS_DIRECTORY: ClassDirectoryEntry[] = [
+  {
+    classId: 'mock-class-1',
+    name: 'Demo Class',
+    teacherDisplayName: 'Demo Teacher',
+    subject: 'Demo',
+  },
+];
+
+interface FetchedSnapshot {
+  key: string;
+  status: 'ready' | 'error';
+  classes: ClassDirectoryEntry[];
+}
+
+interface UseStudentClassDirectoryArgs {
+  classIds: readonly string[];
+  pseudonymUid: string | null;
+}
+
+export function useStudentClassDirectory({
+  classIds,
+  pseudonymUid,
+}: UseStudentClassDirectoryArgs): ClassDirectoryResult {
+  const classIdsKey = useMemo(
+    () => classIds.slice().sort().join('|'),
+    [classIds]
+  );
+
+  // The cache key for the *current* (uid, classIds) pair. `null` means we
+  // shouldn't fetch (bypass mode or no classes claimed).
+  const cacheKey: string | null = useMemo(() => {
+    if (isAuthBypass) return null;
+    if (!pseudonymUid || classIds.length === 0) return null;
+    return cacheKeyOf(pseudonymUid, classIdsKey);
+  }, [pseudonymUid, classIds.length, classIdsKey]);
+
+  // Async resolution snapshot. The effect writes this *after* the callable
+  // settles — never synchronously, which avoids cascading renders. The
+  // current cache state is read directly from `directoryCache` during render
+  // so a fresh cache hit is reflected immediately without setState.
+  const [fetched, setFetched] = useState<FetchedSnapshot | null>(null);
+  const [retryNonce, setRetryNonce] = useState(0);
+
+  // Render-time resolution. Order:
+  //   1. bypass / no claims  → instant 'ready'
+  //   2. module cache hit    → instant 'ready' (fresh remount uses prior result)
+  //   3. matching fetched    → reflect last async result for THIS key
+  //   4. otherwise           → 'loading'
+  const { status, classes } = ((): {
+    status: DirectoryStatus;
+    classes: ClassDirectoryEntry[];
+  } => {
+    if (isAuthBypass) {
+      return { status: 'ready', classes: BYPASS_DIRECTORY };
+    }
+    if (cacheKey === null) {
+      return { status: 'ready', classes: [] };
+    }
+    const cached = directoryCache.get(cacheKey);
+    if (cached) {
+      return { status: 'ready', classes: cached };
+    }
+    if (fetched && fetched.key === cacheKey) {
+      return { status: fetched.status, classes: fetched.classes };
+    }
+    return { status: 'loading', classes: [] };
+  })();
+
+  useEffect(() => {
+    if (cacheKey === null) return;
+    if (directoryCache.has(cacheKey) && retryNonce === 0) return;
+
+    let cancelled = false;
+    const callable = httpsCallable<
+      Record<string, never>,
+      { classes?: ClassDirectoryEntry[] }
+    >(functions, 'getStudentClassDirectoryV1');
+
+    callable({})
+      .then((res) => {
+        if (cancelled) return;
+        const list = Array.isArray(res.data?.classes)
+          ? (res.data?.classes ?? [])
+          : [];
+        directoryCache.set(cacheKey, list);
+        setFetched({ key: cacheKey, status: 'ready', classes: list });
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        const code =
+          err && typeof err === 'object' && 'code' in err
+            ? String((err as { code?: unknown }).code)
+            : 'unknown';
+        console.error(`[useStudentClassDirectory] callable failed [${code}]`);
+        setFetched({ key: cacheKey, status: 'error', classes: [] });
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [cacheKey, retryNonce]);
+
+  const byId = useMemo<Record<string, ClassDirectoryEntry>>(() => {
+    const out: Record<string, ClassDirectoryEntry> = {};
+    for (const c of classes) out[c.classId] = c;
+    return out;
+  }, [classes]);
+
+  const retry = useCallback(() => {
+    if (cacheKey !== null) directoryCache.delete(cacheKey);
+    setRetryNonce((n) => n + 1);
+  }, [cacheKey]);
+
+  return { status, classes, byId, retry };
+}

--- a/hooks/useStudentIdleTimeout.ts
+++ b/hooks/useStudentIdleTimeout.ts
@@ -14,6 +14,7 @@
 import { useEffect } from 'react';
 import { signOut as firebaseSignOut } from 'firebase/auth';
 import { auth } from '@/config/firebase';
+import { clearStudentFirstName } from '@/context/StudentAuthContextValue';
 
 export const STUDENT_IDLE_TIMEOUT_MS = 15 * 60 * 1000;
 const INTERACTION_THROTTLE_MS = 5 * 1000;
@@ -31,6 +32,12 @@ export function useStudentIdleTimeout(
     let lastInteractionAt = Date.now();
 
     const triggerIdleSignOut = () => {
+      // Always clear the cached first name before tearing down the
+      // session — same hygiene as the explicit `signOut()` and the
+      // claim-rejection path. Without this, a tab that idles out on a
+      // shared cart leaves the previous student's greeting in
+      // sessionStorage until the next successful login overwrites it.
+      clearStudentFirstName();
       void firebaseSignOut(auth).catch(() => {
         // Swallow — redirect below is the actual remediation.
       });

--- a/tests/utils/studentClassColors.test.ts
+++ b/tests/utils/studentClassColors.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import { getClassColor, CLASS_COLOR_PALETTE } from '@/utils/studentClassColors';
+
+describe('studentClassColors', () => {
+  describe('getClassColor', () => {
+    it('returns a palette entry for any non-empty classId', () => {
+      const color = getClassColor('classlink-12345');
+      expect(CLASS_COLOR_PALETTE).toContainEqual(color);
+    });
+
+    it('is deterministic — same classId always returns the same color', () => {
+      const a = getClassColor('classlink-abc-period-3');
+      const b = getClassColor('classlink-abc-period-3');
+      expect(a).toEqual(b);
+    });
+
+    it('returns the first palette entry for empty input', () => {
+      expect(getClassColor('')).toEqual(CLASS_COLOR_PALETTE[0]);
+    });
+
+    it('spreads many distinct classIds across at least half the palette', () => {
+      // Synthetic but realistic-looking sourcedIds. The hash should land
+      // somewhere in the palette for each, and across enough inputs we
+      // should see meaningful spread (not collapse to one or two buckets).
+      const ids = Array.from(
+        { length: 200 },
+        (_, i) => `roster-${i}-period-${i % 7}`
+      );
+      const seen = new Set(ids.map((id) => getClassColor(id).bar));
+      expect(seen.size).toBeGreaterThanOrEqual(
+        Math.ceil(CLASS_COLOR_PALETTE.length / 2)
+      );
+    });
+
+    it('every palette entry has the brand-aligned shape', () => {
+      for (const entry of CLASS_COLOR_PALETTE) {
+        expect(entry.bar).toMatch(/^#[0-9A-F]{6}$/i);
+        expect(entry.soft).toMatch(/^#[0-9A-F]{6}$/i);
+        expect(entry.ink).toMatch(/^#[0-9A-F]{6}$/i);
+      }
+    });
+  });
+});

--- a/utils/studentClassColors.ts
+++ b/utils/studentClassColors.ts
@@ -1,0 +1,66 @@
+/**
+ * Deterministic class color assignment for the student `/my-assignments`
+ * sidebar. Hashes the ClassLink `sourcedId` (or test-class id) into a small
+ * brand-aligned palette so a given class always paints the same color across
+ * sessions and devices, without any persisted state.
+ *
+ * The palette is hand-picked to keep visual differentiation high while
+ * staying in the SpartBoard / Orono Technology brand range — anchored on
+ * the brand blue (`#2D3F89`) and brand red (`#AD2122`), with subject-style
+ * hues filling out the spread.
+ */
+export interface ClassColor {
+  /** Solid color for the 4px sidebar bar. */
+  bar: string;
+  /** Soft tint for hover/active surfaces (≈8% alpha equivalent, opaque). */
+  soft: string;
+  /** High-contrast ink for text rendered on `soft`. */
+  ink: string;
+}
+
+const PALETTE: readonly ClassColor[] = [
+  { bar: '#2D3F89', soft: '#EAECF5', ink: '#1D2A5D' }, // brand blue
+  { bar: '#AD2122', soft: '#F7E3E3', ink: '#7A1718' }, // brand red
+  { bar: '#0F6B3A', soft: '#DCEFE2', ink: '#0A4D2A' }, // forest
+  { bar: '#7A1718', soft: '#F0DADB', ink: '#561011' }, // brand red dark
+  { bar: '#4356A0', soft: '#E1E5F1', ink: '#2D3F89' }, // brand blue light
+  { bar: '#B8860B', soft: '#F4EAD0', ink: '#7C5B07' }, // amber
+  { bar: '#2A6F8F', soft: '#DBE8EF', ink: '#1A4A60' }, // teal blue
+  { bar: '#6B3FA0', soft: '#E5DCEF', ink: '#4A2C70' }, // muted violet
+];
+
+/**
+ * 32-bit FNV-1a hash. Compact, dependency-free, and good enough for
+ * "spread N classIds across 8 buckets without obvious clumping". Same
+ * implementation a teacher's color picker would use — switching the input
+ * string but not the algorithm yields a stable assignment.
+ */
+function fnv1a(input: string): number {
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < input.length; i++) {
+    hash ^= input.charCodeAt(i);
+    // 32-bit FNV prime multiply, kept in unsigned 32-bit range.
+    hash =
+      (hash +
+        ((hash << 1) +
+          (hash << 4) +
+          (hash << 7) +
+          (hash << 8) +
+          (hash << 24))) >>>
+      0;
+  }
+  return hash >>> 0;
+}
+
+/**
+ * Returns the palette entry for a given classId. Stable across calls;
+ * different classIds spread across the palette via FNV-1a modulo.
+ */
+export function getClassColor(classId: string): ClassColor {
+  if (!classId) return PALETTE[0];
+  const idx = fnv1a(classId) % PALETTE.length;
+  return PALETTE[idx];
+}
+
+/** Exposed for tests — kept stable as part of the public contract. */
+export const CLASS_COLOR_PALETTE = PALETTE;


### PR DESCRIPTION
## Summary

Replaces the flat list at `/my-assignments` with a class-grouped two-pane layout: a slide-out sidebar listing every ClassLink class the student is enrolled in, plus a main column with All-classes overview and per-class views. Each view has an All / Active / Completed filter, and "Completed" is now a real channel (ended sessions the student finished) — not derived state. Student gets a personalized greeting in a profile-style sidebar footer; the brand-blue header stays anchored above the sliding sidebar.

## Highlights

- **New sidebar** (`StudentSidebar`) with deterministic per-class color bars, active-count chips, "All classes" overview entry, and a profile footer (avatar / "Hi, {firstName}" / class count / sign-out).
- **Slide-out behavior**: hamburger in the brand-blue header toggles. Open by default on desktop, closed on mobile (slides over with backdrop). Header stays anchored — the hamburger never shifts when the panel opens.
- **Class directory**: new Cloud Function `getStudentClassDirectoryV1` resolves classIds → name + teacher displayName via `collectionGroup('rosters')` (real ClassLink) and `testClasses` (admin fallback). PII-clean: returns only org-level metadata; never reads student names.
- **Active + Ended channels**: `useStudentAssignments` now subscribes to both `status='active'` and `status='ended'` for quiz / video-activity / mini-app, ordered by `endedAt desc, limit 50`. Lazy completion check partitions rows into Active vs Completed.
- **Filter control**: All / Active / Completed segmented tabs above each view, with counts. Mode persists in `sessionStorage` (per-tab — never follows a student onto a shared device).
- **Student first name**: parsed from the Google ID token at sign-in, parked in tab-scoped `sessionStorage`, exposed via `StudentAuthContext.firstName`. Cleared on `signOut()`. Never sent to Firestore.

## PII Guarantees

All existing rules preserved:
- Only opaque pseudonym uid + claim-bound `classIds` are read on the client.
- Teacher names are surfaced (org data, not student PII).
- The student's own first name is the one personalization we keep — it lives in their tab only, never in Firestore, cleared on sign-out and idle timeout.
- The new callable returns only roster metadata + teacher `displayName` (Admin SDK lookup); no student fields ever leave the server side.

## New Composite Indexes

`firestore.indexes.json` adds five composite indexes for the ended-session queries:
- `quiz_sessions`: `(classIds CONTAINS, status, endedAt desc)` and `(classId, status, endedAt desc)`
- `video_activity_sessions`: same two shapes
- `mini_app_sessions`: `(classIds CONTAINS, status, endedAt desc)`

These need to be deployed alongside the merge.

## Test plan

- [ ] Sign in via `/student/login` with a real Google account; verify the sidebar renders class names + teacher names from the org's rosters.
- [ ] Verify the personalized greeting in the sidebar footer ("Hi, {firstName}") and that signing out clears the name (next sign-in by another student doesn't inherit it).
- [ ] Toggle the hamburger — sidebar slides in/out, content reflows beside it on desktop, overlays on mobile with backdrop.
- [ ] Pick a class → main column filters to that class's assignments. "All classes" entry shows merged list.
- [ ] Filter tabs: All shows both sections; Active hides Completed; Completed hides Active. Counts update per scope.
- [ ] Submit a quiz → row moves from Active to Completed without a refresh. End a quiz from teacher side → row appears in Completed (assuming student already submitted).
- [ ] Verify Firestore composite indexes are created (the first ended-session query will surface a one-click index URL if anything is missing).
- [ ] Mobile: sidebar slides in over content; backdrop tap closes; selecting a class auto-closes the panel.
- [ ] No-classes / loading / error gates still render the original empty/error UI with a working "Done" sign-out.

## Out of scope (deferred)

- Per-class "Today's focus" + widget bento (needs a teacher posting flow).
- Tweaks panel (text size / reduce motion).
- i18n for student-facing strings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)