### PR TITLE
Enhance SSO student experience in assignments and quizzes

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -305,15 +305,17 @@ const App: React.FC = () => {
     );
   }
 
-  // Quiz student route — requires real Firebase auth (org Google account)
+  // Quiz student route — QuizStudentApp self-handles Firebase auth
+  // (signInAnonymously when no current user; preserves the SSO student-
+  // custom-token user otherwise). No teacher AuthContext consumers in the
+  // quiz tree, so wrapping in <AuthProvider> would only mount admin-only
+  // Firestore listeners that fail with permission-denied for students.
   if (isQuizRoute) {
     return (
       <DialogProvider>
-        <AuthProvider>
-          <Suspense fallback={<FullPageLoader />}>
-            <QuizStudentApp />
-          </Suspense>
-        </AuthProvider>
+        <Suspense fallback={<FullPageLoader />}>
+          <QuizStudentApp />
+        </Suspense>
         <DialogContainer />
       </DialogProvider>
     );

--- a/components/classes/ClassLinkImportDialog.tsx
+++ b/components/classes/ClassLinkImportDialog.tsx
@@ -60,12 +60,15 @@ const buildClassLinkRosterMeta = (
 // two-digit strings (01, 02, …) so the teacher has something to hand out
 // before editing. The imported roster is a normal user-owned roster and can
 // be renamed, PIN-edited, or deleted afterwards like any ClassLink import.
+// Email is preserved on the student record so it round-trips through the
+// editor and can be displayed in the optional EMAIL column.
 const materializeTestClassStudents = (emails: string[]): Student[] =>
   emails.map((email, i) => ({
     id: crypto.randomUUID(),
     firstName: email.split('@')[0] || email,
     lastName: '',
     pin: String(i + 1).padStart(2, '0'),
+    email,
   }));
 
 export type ClassLinkDialogMode =
@@ -216,6 +219,7 @@ export const ClassLinkImportDialog: React.FC<ClassLinkImportDialogProps> = ({
             lastName: s.familyName,
             pin: '',
             classLinkSourcedId: s.sourcedId,
+            ...(s.email ? { email: s.email } : {}),
           }));
       const subjectPrefix = cls.subject ? `${cls.subject} - ` : '';
       const codeSuffix = cls.classCode ? ` (${cls.classCode})` : '';

--- a/components/classes/ClassLinkImportDialog.tsx
+++ b/components/classes/ClassLinkImportDialog.tsx
@@ -14,10 +14,20 @@ import { mergeClassLinkStudents } from './mergeClassLinkStudents';
 const TEST_PREFIX = 'test:';
 
 /**
- * Build the ClassLink provenance metadata to persist on a roster document.
- * Returns `null` for test classes (they aren't real ClassLink classes and
- * must not claim `origin: 'classlink'` — they'd otherwise feed garbage
- * sourcedIds into session `classIds[]` and break the student SSO gate).
+ * Build the provenance metadata to persist on a roster document.
+ *
+ * For real ClassLink classes: stamps `origin: 'classlink'` and the full set of
+ * `classlink*` fields so downstream features (badge, merge dedup, sync) can
+ * recognize this as a ClassLink-imported roster.
+ *
+ * For admin test classes: returns only `testClassId` (the bare slug, with the
+ * `test:` prefix stripped). We deliberately do NOT set `origin: 'classlink'`
+ * or `classlinkClassId`, because the prefixed `cls.sourcedId` would corrupt
+ * real ClassLink session gates and the picker would mislabel test rosters
+ * with a "CL" badge. The bare slug routes through
+ * `deriveTargetsFromRosterList` into session `classIds[]` so test-bypass SSO
+ * students (whose custom token from `studentLoginV1` carries
+ * `classIds: [<slug>]`) can find the assignment on `/my-assignments`.
  *
  * NOTE: fields missing from `cls` (e.g., `classCode` cleared upstream) are
  * omitted rather than set to `deleteField()`, so `updateRoster` at merge
@@ -31,7 +41,9 @@ const buildClassLinkRosterMeta = (
   cls: ClassLinkClass,
   orgId: string | null | undefined
 ): Partial<ClassRosterMeta> | null => {
-  if (cls.sourcedId.startsWith(TEST_PREFIX)) return null;
+  if (cls.sourcedId.startsWith(TEST_PREFIX)) {
+    return { testClassId: cls.sourcedId.slice(TEST_PREFIX.length) };
+  }
   const meta: Partial<ClassRosterMeta> = {
     origin: 'classlink',
     classlinkClassId: cls.sourcedId,

--- a/components/classes/RosterEditorModal.tsx
+++ b/components/classes/RosterEditorModal.tsx
@@ -43,6 +43,8 @@ export const RosterEditorModal: React.FC<RosterEditorModalProps> = ({
     handleToggleLastNames,
     showPins,
     setShowPins,
+    showEmails,
+    setShowEmails,
     showRestrictions,
     setShowRestrictions,
     toggleRestriction,
@@ -130,6 +132,22 @@ export const RosterEditorModal: React.FC<RosterEditorModalProps> = ({
                   })}
             </button>
             <button
+              onClick={() => setShowEmails((v) => !v)}
+              className={`text-xs font-black uppercase tracking-wider transition-colors ${
+                showEmails
+                  ? 'text-slate-400 hover:text-red-500'
+                  : 'text-emerald-600 hover:text-emerald-700'
+              }`}
+            >
+              {showEmails
+                ? t('sidebar.classes.hideEmail', {
+                    defaultValue: '− Email',
+                  })
+                : t('sidebar.classes.addEmail', {
+                    defaultValue: '+ Email',
+                  })}
+            </button>
+            <button
               onClick={() => setShowRestrictions((v) => !v)}
               className={`text-xs font-black uppercase tracking-wider transition-colors ${
                 showRestrictions
@@ -183,6 +201,7 @@ export const RosterEditorModal: React.FC<RosterEditorModalProps> = ({
               <RosterHeader
                 showLastNames={showLastNames}
                 showPins={showPins}
+                showEmails={showEmails}
                 showRestrictions={showRestrictions}
                 firstLabel={
                   showLastNames
@@ -199,6 +218,9 @@ export const RosterEditorModal: React.FC<RosterEditorModalProps> = ({
                 pinLabel={t('sidebar.classes.quizPin', {
                   defaultValue: 'Quiz PIN',
                 })}
+                emailLabel={t('sidebar.classes.email', {
+                  defaultValue: 'Email',
+                })}
                 restrictionsLabel={t('sidebar.classes.restrictionsHeader', {
                   defaultValue: 'Restricted from working with',
                 })}
@@ -211,6 +233,7 @@ export const RosterEditorModal: React.FC<RosterEditorModalProps> = ({
                     index={idx}
                     showLastNames={showLastNames}
                     showPins={showPins}
+                    showEmails={showEmails}
                     showRestrictions={showRestrictions}
                     allRows={rows}
                     isDuplicatePin={
@@ -231,6 +254,9 @@ export const RosterEditorModal: React.FC<RosterEditorModalProps> = ({
                     )}
                     pinPlaceholder={t('sidebar.classes.pinPlaceholder', {
                       defaultValue: '01',
+                    })}
+                    emailPlaceholder={t('sidebar.classes.emailPlaceholder', {
+                      defaultValue: 'student@school.org',
                     })}
                     removeLabel={t('sidebar.classes.removeStudent', {
                       defaultValue: 'Remove student',
@@ -268,20 +294,24 @@ export const RosterEditorModal: React.FC<RosterEditorModalProps> = ({
 interface RosterHeaderProps {
   showLastNames: boolean;
   showPins: boolean;
+  showEmails: boolean;
   showRestrictions: boolean;
   firstLabel: string;
   lastLabel: string;
   pinLabel: string;
+  emailLabel: string;
   restrictionsLabel: string;
 }
 
 const RosterHeader: React.FC<RosterHeaderProps> = ({
   showLastNames,
   showPins,
+  showEmails,
   showRestrictions,
   firstLabel,
   lastLabel,
   pinLabel,
+  emailLabel,
   restrictionsLabel,
 }) => {
   return (
@@ -291,6 +321,7 @@ const RosterHeader: React.FC<RosterHeaderProps> = ({
         gridTemplateColumns: buildGridTemplate(
           showLastNames,
           showPins,
+          showEmails,
           showRestrictions
         ),
       }}
@@ -299,6 +330,7 @@ const RosterHeader: React.FC<RosterHeaderProps> = ({
       {showPins && <span>{pinLabel}</span>}
       <span>{firstLabel}</span>
       {showLastNames && <span>{lastLabel}</span>}
+      {showEmails && <span>{emailLabel}</span>}
       {showRestrictions && <span>{restrictionsLabel}</span>}
       <span />
     </div>
@@ -310,12 +342,14 @@ interface RosterRowProps {
   index: number;
   showLastNames: boolean;
   showPins: boolean;
+  showEmails: boolean;
   showRestrictions: boolean;
   allRows: DraftRow[];
   isDuplicatePin: boolean;
   firstNamePlaceholder: string;
   lastNamePlaceholder: string;
   pinPlaceholder: string;
+  emailPlaceholder: string;
   removeLabel: string;
   onChange: (patch: Partial<DraftRow>) => void;
   onDelete: () => void;
@@ -328,12 +362,14 @@ const RosterRow: React.FC<RosterRowProps> = ({
   index,
   showLastNames,
   showPins,
+  showEmails,
   showRestrictions,
   allRows,
   isDuplicatePin,
   firstNamePlaceholder,
   lastNamePlaceholder,
   pinPlaceholder,
+  emailPlaceholder,
   removeLabel,
   onChange,
   onDelete,
@@ -368,6 +404,7 @@ const RosterRow: React.FC<RosterRowProps> = ({
         gridTemplateColumns: buildGridTemplate(
           showLastNames,
           showPins,
+          showEmails,
           showRestrictions
         ),
       }}
@@ -402,6 +439,17 @@ const RosterRow: React.FC<RosterRowProps> = ({
           value={row.lastName}
           onChange={(e) => onChange({ lastName: e.target.value })}
           placeholder={lastNamePlaceholder}
+        />
+      )}
+      {showEmails && (
+        <input
+          type="email"
+          className="px-3 py-1.5 text-sm rounded-md border border-slate-200 bg-white outline-none focus:border-emerald-500 focus:ring-2 focus:ring-emerald-100 transition-colors"
+          value={row.email ?? ''}
+          onChange={(e) => onChange({ email: e.target.value })}
+          placeholder={emailPlaceholder}
+          autoComplete="off"
+          spellCheck={false}
         />
       )}
       {showRestrictions && (
@@ -456,17 +504,19 @@ const RosterEmptyState: React.FC<RosterEmptyStateProps> = ({
 );
 
 /**
- * Grid columns: [#] [PIN?] [First] [Last?] [Restrictions?] [Delete]
+ * Grid columns: [#] [PIN?] [First] [Last?] [Email?] [Restrictions?] [Delete]
  */
 function buildGridTemplate(
   showLastNames: boolean,
   showPins: boolean,
+  showEmails: boolean,
   showRestrictions: boolean
 ): string {
   const parts = ['2rem'];
   if (showPins) parts.push('5rem');
   parts.push('minmax(0, 1fr)');
   if (showLastNames) parts.push('minmax(0, 1fr)');
+  if (showEmails) parts.push('minmax(0, 1.4fr)');
   if (showRestrictions) parts.push('minmax(9rem, 14rem)');
   parts.push('2rem');
   return parts.join(' ');

--- a/components/classes/mergeClassLinkStudents.test.ts
+++ b/components/classes/mergeClassLinkStudents.test.ts
@@ -150,6 +150,89 @@ describe('mergeClassLinkStudents', () => {
     expect(result.students[0].pin).toBe('01');
   });
 
+  it('persists email on appended students and backfills it on matched ones', () => {
+    // Pre-existing students: one matched by sourcedId, one matched by name,
+    // one local-only. Each starts without an email; the merge should backfill
+    // emails from the ClassLink payload onto the two matched rows and stamp
+    // the email onto the newly appended row.
+    const existing = [
+      makeLocal({
+        firstName: 'Ada',
+        lastName: 'Lovelace',
+        pin: '01',
+        classLinkSourcedId: 'cl-ada',
+      }),
+      makeLocal({
+        firstName: 'Grace',
+        lastName: 'Hopper',
+        pin: '02',
+      }),
+      makeLocal({
+        firstName: 'Local',
+        lastName: 'Aide',
+        pin: '99',
+      }),
+    ];
+    const cl = [
+      makeCL({
+        sourcedId: 'cl-ada',
+        givenName: 'Ada',
+        familyName: 'Lovelace',
+        email: 'ada@school.org',
+      }),
+      makeCL({
+        sourcedId: 'cl-grace',
+        givenName: 'Grace',
+        familyName: 'Hopper',
+        email: 'grace@school.org',
+      }),
+      makeCL({
+        sourcedId: 'cl-alan',
+        givenName: 'Alan',
+        familyName: 'Turing',
+        email: 'alan@school.org',
+      }),
+    ];
+    const result = mergeClassLinkStudents(existing, cl);
+
+    const ada = result.students.find((s) => s.firstName === 'Ada');
+    expect(ada?.email).toBe('ada@school.org');
+    expect(ada?.pin).toBe('01'); // unchanged
+
+    const grace = result.students.find((s) => s.firstName === 'Grace');
+    expect(grace?.email).toBe('grace@school.org');
+    expect(grace?.pin).toBe('02'); // unchanged
+
+    const alan = result.students.find((s) => s.firstName === 'Alan');
+    expect(alan?.email).toBe('alan@school.org');
+
+    // Local aide must NOT receive an email (no upstream match).
+    const aide = result.students.find((s) => s.lastName === 'Aide');
+    expect(aide?.email).toBeUndefined();
+  });
+
+  it('does not overwrite an existing email on re-sync', () => {
+    // If a teacher already edited a student's email locally, the merge
+    // should preserve it even when ClassLink reports a different value.
+    const existing = makeLocal({
+      firstName: 'Ada',
+      lastName: 'Lovelace',
+      pin: '01',
+      classLinkSourcedId: 'cl-ada',
+      email: 'manual@school.org',
+    });
+    const cl = [
+      makeCL({
+        sourcedId: 'cl-ada',
+        givenName: 'Ada',
+        familyName: 'Lovelace',
+        email: 'upstream@school.org',
+      }),
+    ];
+    const result = mergeClassLinkStudents([existing], cl);
+    expect(result.students[0].email).toBe('manual@school.org');
+  });
+
   it('sourcedId match wins even if a different local row has matching name', () => {
     const existing = [
       makeLocal({

--- a/components/classes/mergeClassLinkStudents.ts
+++ b/components/classes/mergeClassLinkStudents.ts
@@ -65,6 +65,11 @@ export function mergeClassLinkStudents(
       consumed.add(sourcedIndex);
       matchedCount += 1;
       alreadySourcedCount += 1;
+      // Backfill email on re-sync: rosters imported before email was
+      // captured won't have it, so stamp the upstream value when present.
+      if (cls.email && !result[sourcedIndex].email) {
+        result[sourcedIndex] = { ...result[sourcedIndex], email: cls.email };
+      }
       continue;
     }
 
@@ -84,10 +89,14 @@ export function mergeClassLinkStudents(
     if (nameMatchIndex !== undefined) {
       consumed.add(nameMatchIndex);
       matchedCount += 1;
-      // Stamp the sourcedId onto the existing row (preserve id + pin)
+      // Stamp the sourcedId onto the existing row (preserve id + pin).
+      // Also backfill email if this is the first time we've seen it.
       result[nameMatchIndex] = {
         ...result[nameMatchIndex],
         classLinkSourcedId: cls.sourcedId,
+        ...(cls.email && !result[nameMatchIndex].email
+          ? { email: cls.email }
+          : {}),
       };
       continue;
     }
@@ -99,6 +108,7 @@ export function mergeClassLinkStudents(
       lastName: cls.familyName,
       pin: '',
       classLinkSourcedId: cls.sourcedId,
+      ...(cls.email ? { email: cls.email } : {}),
     });
     addedCount += 1;
   }

--- a/components/classes/useRosterRowsState.ts
+++ b/components/classes/useRosterRowsState.ts
@@ -12,6 +12,7 @@ export interface DraftRow {
   lastName: string;
   pin: string;
   classLinkSourcedId?: string;
+  email?: string;
   restrictedStudentIds?: string[];
 }
 
@@ -36,6 +37,7 @@ export function useRosterRowsState(roster: ClassRoster | null) {
         lastName: s.lastName,
         pin: s.pin,
         classLinkSourcedId: s.classLinkSourcedId,
+        email: s.email,
         restrictedStudentIds: s.restrictedStudentIds,
       })) ?? []
   );
@@ -44,6 +46,12 @@ export function useRosterRowsState(roster: ClassRoster | null) {
   );
   const [showPins, setShowPins] = useState(
     roster?.students.some((s) => s.pin.trim() !== '') ?? false
+  );
+  // Auto-show email column when at least one student has an email — so
+  // freshly imported ClassLink/test-class rosters reveal it immediately
+  // without requiring the teacher to find the toggle.
+  const [showEmails, setShowEmails] = useState(
+    roster?.students.some((s) => (s.email ?? '').trim() !== '') ?? false
   );
   const [showRestrictions, setShowRestrictions] = useState(
     roster?.students.some((s) => (s.restrictedStudentIds?.length ?? 0) > 0) ??
@@ -220,6 +228,10 @@ export function useRosterRowsState(roster: ClassRoster | null) {
             if (r.classLinkSourcedId !== undefined) {
               student.classLinkSourcedId = r.classLinkSourcedId;
             }
+            const trimmedEmail = (r.email ?? '').trim();
+            if (trimmedEmail) {
+              student.email = trimmedEmail;
+            }
             if (r.restrictedStudentIds && r.restrictedStudentIds.length > 0) {
               student.restrictedStudentIds = r.restrictedStudentIds;
             }
@@ -247,6 +259,8 @@ export function useRosterRowsState(roster: ClassRoster | null) {
     handleToggleLastNames,
     showPins,
     setShowPins,
+    showEmails,
+    setShowEmails,
     showRestrictions,
     setShowRestrictions,
     toggleRestriction,

--- a/components/quiz/QuizPausedPlaceholder.tsx
+++ b/components/quiz/QuizPausedPlaceholder.tsx
@@ -10,6 +10,7 @@ import { QuizSession } from '@/types';
 
 interface QuizPausedPlaceholderProps {
   session: QuizSession;
+  /** Roster PIN for anonymous joiners. Empty for SSO `studentRole` joiners. */
   pin: string;
 }
 
@@ -29,11 +30,13 @@ export const QuizPausedPlaceholder: React.FC<QuizPausedPlaceholderProps> = ({
       Your teacher will resume the session shortly. Keep this tab open — your
       place is saved.
     </p>
-    <div className="p-4 bg-slate-800 rounded-xl">
-      <p className="text-slate-300 text-sm">
-        Joined as PIN{' '}
-        <span className="font-semibold text-white font-mono">{pin}</span>
-      </p>
-    </div>
+    {pin && (
+      <div className="p-4 bg-slate-800 rounded-xl">
+        <p className="text-slate-300 text-sm">
+          Joined as PIN{' '}
+          <span className="font-semibold text-white font-mono">{pin}</span>
+        </p>
+      </div>
+    )}
   </div>
 );

--- a/components/quiz/QuizStudentApp.tsx
+++ b/components/quiz/QuizStudentApp.tsx
@@ -2,12 +2,18 @@
  * QuizStudentApp — the student-facing quiz experience.
  * Accessible at /quiz?code=XXXXXX
  *
- * Flow:
- *  1. Student must sign in with Google (org email required)
- *  2. Student enters a quiz code (or picks it up from URL param)
- *  3. Student waits in lobby for teacher to start
- *  4. Questions are shown one by one as teacher advances
- *  5. Student submits answers; teacher sees results
+ * Flow (anonymous /join):
+ *  1. Student is signed in anonymously on mount (no UI).
+ *  2. Student enters quiz code + their roster PIN.
+ *  3. Student waits in lobby for teacher to start.
+ *  4. Questions are shown one by one as teacher advances.
+ *  5. Student submits answers; teacher sees results.
+ *
+ * Flow (SSO `studentRole` from /my-assignments):
+ *  1. Student is already signed in via custom token (claims.studentRole).
+ *  2. Code is in the URL; PIN is unnecessary — identity = `auth.uid`.
+ *  3. We auto-join on mount (still showing the period picker for
+ *     multi-period sessions) and proceed straight to the waiting room.
  */
 
 import React, { useState, useEffect, useCallback, useRef } from 'react';
@@ -47,21 +53,35 @@ import {
 export const QuizStudentApp: React.FC = () => {
   const [authReady, setAuthReady] = useState(false);
   const [authFailed, setAuthFailed] = useState(false);
+  // True iff `auth.currentUser` carries the `studentRole: true` custom claim
+  // minted by `studentLoginV1`. Resolved at mount; used to drive the
+  // auto-join branch in `QuizJoinFlow`. Anonymous joiners stay `false`.
+  const [isStudentRole, setIsStudentRole] = useState(false);
 
-  // Sign in anonymously on mount — no user interaction required.
-  // This satisfies Firestore security rules (request.auth != null) without
-  // storing any student PII in Firebase Authentication.
+  // Sign in anonymously on mount only when nobody is signed in yet — SSO
+  // students arriving from `/my-assignments` already have a custom-token
+  // user we must keep. This satisfies Firestore security rules
+  // (`request.auth != null`) for direct `/quiz?code=…` visitors.
   useEffect(() => {
     const init = async () => {
-      if (!auth.currentUser) {
-        try {
+      try {
+        if (!auth.currentUser) {
           await signInAnonymously(auth);
-        } catch (err) {
-          console.warn('[QuizStudentApp] Anonymous auth failed:', err);
-          setAuthFailed(true);
         }
+        const user = auth.currentUser;
+        if (user && !user.isAnonymous) {
+          // Probe custom claims once. We don't refresh here — `studentLoginV1`
+          // is what minted these, and a stale token is fine for read-only
+          // identity. The Firestore rules re-validate on every write.
+          const tokenResult = await user.getIdTokenResult();
+          setIsStudentRole(tokenResult.claims?.studentRole === true);
+        }
+      } catch (err) {
+        console.warn('[QuizStudentApp] Auth init failed:', err);
+        setAuthFailed(true);
+      } finally {
+        setAuthReady(true);
       }
-      setAuthReady(true);
     };
     void init();
   }, []);
@@ -81,12 +101,14 @@ export const QuizStudentApp: React.FC = () => {
     );
   }
 
-  return <QuizJoinFlow />;
+  return <QuizJoinFlow isStudentRole={isStudentRole} />;
 };
 
 // ─── Join flow ────────────────────────────────────────────────────────────────
 
-const QuizJoinFlow: React.FC = () => {
+const QuizJoinFlow: React.FC<{ isStudentRole: boolean }> = ({
+  isStudentRole,
+}) => {
   const params = new URLSearchParams(window.location.search);
   const urlCode = params.get('code') ?? '';
 
@@ -98,6 +120,16 @@ const QuizJoinFlow: React.FC = () => {
   // multiple periodNames the student picks their class before joining.
   const [periodStep, setPeriodStep] = useState<string[] | null>(null);
   const [selectedPeriod, setSelectedPeriod] = useState<string | null>(null);
+
+  // SSO joiners auto-join on mount (no PIN). This guard prevents the effect
+  // below from triggering twice in StrictMode and keeps the form invisible
+  // while the lookup+join is in flight.
+  const ssoAutoJoinStartedRef = useRef(false);
+  // Local error state for SSO auto-join. The hook's `error` state only fires
+  // from `joinQuizSession` itself; if `lookupSession` throws first (network
+  // failure, Firestore unavailable) the hook stays silent, so without this
+  // the student would sit on the "Joining quiz…" loader forever.
+  const [ssoAutoJoinError, setSsoAutoJoinError] = useState<string | null>(null);
 
   const {
     session,
@@ -131,9 +163,57 @@ const QuizJoinFlow: React.FC = () => {
 
   const handlePeriodConfirm = useCallback(async () => {
     if (!selectedPeriod) return;
-    await joinQuizSession(code, pin, selectedPeriod);
+    // SSO joiners pass `undefined` as the PIN — the hook keys the response
+    // doc by auth.uid in that case. Anonymous joiners send the form `pin`.
+    const joinPin = isStudentRole ? undefined : pin;
+    await joinQuizSession(code, joinPin, selectedPeriod);
     setJoined(true);
-  }, [joinQuizSession, code, pin, selectedPeriod]);
+  }, [joinQuizSession, code, pin, selectedPeriod, isStudentRole]);
+
+  // SSO auto-join: bypass the PIN form entirely. lookupSession handles the
+  // multi-period branch (we still show the picker — periodNames are
+  // free-form labels and don't map 1:1 onto classIds, so we can't auto-pick).
+  useEffect(() => {
+    if (!isStudentRole) return;
+    if (!urlCode) return;
+    if (joined || periodStep) return;
+    if (ssoAutoJoinStartedRef.current) return;
+    ssoAutoJoinStartedRef.current = true;
+
+    const run = async () => {
+      try {
+        const sessionInfo = await lookupSession(urlCode);
+        if (sessionInfo && sessionInfo.periodNames.length > 1) {
+          setPeriodStep(sessionInfo.periodNames);
+          return;
+        }
+        const autoClassPeriod = sessionInfo?.periodNames[0];
+        await joinQuizSession(urlCode, undefined, autoClassPeriod);
+        setJoined(true);
+      } catch (err) {
+        console.warn('[QuizStudentApp] SSO auto-join failed:', err);
+        // Surface the failure to the UI. Either step (lookupSession or
+        // joinQuizSession) can throw; if it was joinQuizSession the hook's
+        // own `error` state will also be populated, and the render branch
+        // below prefers that more detailed message when available.
+        const message =
+          err instanceof Error
+            ? err.message
+            : "We couldn't load your quiz. Please refresh and try again.";
+        setSsoAutoJoinError(message);
+        // Re-arm so a retry button (if added later) can re-trigger.
+        ssoAutoJoinStartedRef.current = false;
+      }
+    };
+    void run();
+  }, [
+    isStudentRole,
+    urlCode,
+    joined,
+    periodStep,
+    lookupSession,
+    joinQuizSession,
+  ]);
 
   const handleAnswer = useCallback(
     async (questionId: string, answer: string, speedBonus?: number) => {
@@ -224,6 +304,28 @@ const QuizJoinFlow: React.FC = () => {
 
   // Not yet joined
   if (!joined || !session) {
+    // SSO students never see the PIN form — the auto-join effect above
+    // handles them. Show a quiet loader (or the error if lookup/join
+    // failed) until `joined` flips. Periods picker is rendered earlier in
+    // the function and short-circuits before we reach this branch.
+    //
+    // Prefer the hook's `error` (more specific, e.g. attempt-limit reached)
+    // when available, falling back to `ssoAutoJoinError` which captures
+    // failures from `lookupSession` that never reach the hook.
+    if (isStudentRole) {
+      const ssoError = error ?? ssoAutoJoinError;
+      if (ssoError) {
+        return (
+          <div className="min-h-screen bg-slate-900 flex flex-col items-center justify-center gap-4 p-6">
+            <AlertCircle className="w-10 h-10 text-red-400" />
+            <p className="text-slate-300 text-sm text-center max-w-sm">
+              {ssoError}
+            </p>
+          </div>
+        );
+      }
+      return <FullPageLoader message="Joining quiz…" />;
+    }
     return (
       <div className="min-h-screen bg-slate-900 flex flex-col items-center justify-center p-6">
         <div className="w-full max-w-sm">
@@ -357,6 +459,7 @@ const QuizJoinFlow: React.FC = () => {
       answeredCount={(myResponse?.answers ?? []).length}
       totalQuestions={session.totalQuestions}
       pin={pin}
+      myStudentUid={myResponse?.studentUid}
     />
   );
 };
@@ -365,6 +468,7 @@ const QuizJoinFlow: React.FC = () => {
 
 const WaitingRoom: React.FC<{
   session: QuizSession;
+  /** Empty string for SSO `studentRole` joiners — PIN line is hidden. */
   pin: string;
 }> = ({ session, pin }) => (
   <div className="min-h-screen bg-slate-900 flex flex-col items-center justify-center p-6 text-center">
@@ -378,12 +482,14 @@ const WaitingRoom: React.FC<{
     <p className="text-slate-500 text-xs mb-8">
       {session.totalQuestions} questions
     </p>
-    <div className="p-4 bg-slate-800 rounded-xl">
-      <p className="text-slate-300 text-sm">
-        Joined as PIN{' '}
-        <span className="font-semibold text-white font-mono">{pin}</span>
-      </p>
-    </div>
+    {pin && (
+      <div className="p-4 bg-slate-800 rounded-xl">
+        <p className="text-slate-300 text-sm">
+          Joined as PIN{' '}
+          <span className="font-semibold text-white font-mono">{pin}</span>
+        </p>
+      </div>
+    )}
   </div>
 );
 
@@ -1327,6 +1433,7 @@ const ReviewPhase: React.FC<{
           <StudentLeaderboard
             entries={session.liveLeaderboard}
             myPin={myResponse?.pin ?? ''}
+            myStudentUid={myResponse?.studentUid}
             scoreSuffix={getScoreSuffix(session)}
           />
           <div className="flex items-center gap-2 text-slate-500 text-sm">
@@ -1349,13 +1456,21 @@ const ResultsScreen: React.FC<{
   answeredCount: number;
   totalQuestions: number;
   pin: string;
-}> = ({ session, answeredCount, totalQuestions, pin }) => (
+  /** Auth uid — used by `StudentLeaderboard` to highlight the SSO student's row. */
+  myStudentUid?: string;
+}> = ({ session, answeredCount, totalQuestions, pin, myStudentUid }) => (
   <div className="min-h-screen bg-slate-900 flex flex-col items-center justify-center p-6 text-center">
     <Trophy className="w-16 h-16 text-amber-400 mb-6" />
     <h1 className="text-3xl font-black text-white mb-2">Quiz Complete!</h1>
     <p className="text-slate-400 text-sm mb-8">
-      Great job, PIN{' '}
-      <span className="font-mono font-bold text-white">{pin}</span>!
+      {pin ? (
+        <>
+          Great job, PIN{' '}
+          <span className="font-mono font-bold text-white">{pin}</span>!
+        </>
+      ) : (
+        'Great job!'
+      )}
     </p>
 
     <div className="mb-8 p-6 bg-slate-800 rounded-2xl">
@@ -1374,6 +1489,7 @@ const ResultsScreen: React.FC<{
         <StudentLeaderboard
           entries={session.liveLeaderboard}
           myPin={pin}
+          myStudentUid={myStudentUid}
           scoreSuffix={getScoreSuffix(session)}
         />
       </div>
@@ -1396,8 +1512,14 @@ const QuizSubmittedWaitScreen: React.FC<{
       <CheckCircle2 className="w-16 h-16 text-emerald-400 mb-6" />
       <h1 className="text-3xl font-black text-white mb-2">Quiz Submitted!</h1>
       <p className="text-slate-400 text-sm mb-6">
-        Great work, PIN{' '}
-        <span className="font-mono font-bold text-white">{pin}</span>.
+        {pin ? (
+          <>
+            Great work, PIN{' '}
+            <span className="font-mono font-bold text-white">{pin}</span>.
+          </>
+        ) : (
+          'Great work.'
+        )}
       </p>
 
       <div className="mb-6 p-5 bg-slate-800 rounded-2xl">
@@ -1420,6 +1542,7 @@ const QuizSubmittedWaitScreen: React.FC<{
           <StudentLeaderboard
             entries={session.liveLeaderboard}
             myPin={pin}
+            myStudentUid={myResponse.studentUid}
             scoreSuffix={scoreSuffix}
           />
         </div>

--- a/components/quiz/StudentLeaderboard.tsx
+++ b/components/quiz/StudentLeaderboard.tsx
@@ -5,7 +5,13 @@ import { QuizLeaderboardEntry } from '@/types';
 
 interface StudentLeaderboardProps {
   entries: QuizLeaderboardEntry[];
+  /** Roster PIN for anonymous joiners. Empty for SSO joiners. */
   myPin: string;
+  /**
+   * Auth uid for SSO `studentRole` joiners. Used as a fallback identity
+   * when `myPin` is empty so SSO students still see "(you)" on their row.
+   */
+  myStudentUid?: string;
   scoreSuffix: string;
 }
 
@@ -15,9 +21,20 @@ const medalByRank: Record<number, string> = {
   3: 'text-orange-500',
 };
 
+const matchesMe = (
+  entry: QuizLeaderboardEntry,
+  myPin: string,
+  myStudentUid: string | undefined
+): boolean => {
+  if (myPin && entry.pin === myPin) return true;
+  if (myStudentUid && entry.studentUid === myStudentUid) return true;
+  return false;
+};
+
 export const StudentLeaderboard: React.FC<StudentLeaderboardProps> = ({
   entries,
   myPin,
+  myStudentUid,
   scoreSuffix,
 }) => {
   const { t } = useTranslation();
@@ -30,10 +47,14 @@ export const StudentLeaderboard: React.FC<StudentLeaderboardProps> = ({
     );
   }
 
-  const myEntry = entries.find((entry) => entry.pin === myPin);
+  const myEntry = entries.find((entry) =>
+    matchesMe(entry, myPin, myStudentUid)
+  );
   const topFive = entries.slice(0, 5);
-  const isMyPinInTopFive = topFive.some((entry) => entry.pin === myPin);
-  const rows = isMyPinInTopFive
+  const isMeInTopFive = topFive.some((entry) =>
+    matchesMe(entry, myPin, myStudentUid)
+  );
+  const rows = isMeInTopFive
     ? topFive
     : myEntry
       ? [...entries.slice(0, 4), myEntry]
@@ -46,11 +67,15 @@ export const StudentLeaderboard: React.FC<StudentLeaderboardProps> = ({
       </p>
       <div className="space-y-2">
         {rows.map((entry, index) => {
-          const isMine = entry.pin === myPin;
-          const showDivider = !isMyPinInTopFive && index === 4;
+          const isMine = matchesMe(entry, myPin, myStudentUid);
+          const showDivider = !isMeInTopFive && index === 4;
+          // Stable per-entry key: pin for anonymous joiners, studentUid for
+          // SSO joiners. Combined with rank to disambiguate in the rare case
+          // of duplicate identifiers (e.g. legacy data).
+          const entryKey = `${entry.pin ?? entry.studentUid ?? 'anon'}-${entry.rank}`;
 
           return (
-            <React.Fragment key={entry.pin}>
+            <React.Fragment key={entryKey}>
               {showDivider && (
                 <div className="text-center text-slate-500 text-xs py-1">…</div>
               )}
@@ -69,7 +94,7 @@ export const StudentLeaderboard: React.FC<StudentLeaderboardProps> = ({
                   </span>
                 )}
                 <span className="flex-1 text-sm font-semibold text-white truncate">
-                  {entry.name ?? `PIN ${entry.pin}`}
+                  {entry.name ?? (entry.pin ? `PIN ${entry.pin}` : 'Student')}
                   {isMine ? ` ${t('widgets.quiz.leaderboard.youSuffix')}` : ''}
                 </span>
                 <span className="text-amber-300 text-sm font-black">

--- a/components/student/AssignmentFilterTabs.tsx
+++ b/components/student/AssignmentFilterTabs.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+
+export type AssignmentFilterMode = 'all' | 'active' | 'completed';
+
+interface AssignmentFilterTabsProps {
+  value: AssignmentFilterMode;
+  onChange: (mode: AssignmentFilterMode) => void;
+  counts?: {
+    all?: number;
+    active?: number;
+    completed?: number;
+  };
+}
+
+const TABS: ReadonlyArray<{ id: AssignmentFilterMode; label: string }> = [
+  { id: 'all', label: 'All' },
+  { id: 'active', label: 'Active' },
+  { id: 'completed', label: 'Completed' },
+];
+
+export const AssignmentFilterTabs: React.FC<AssignmentFilterTabsProps> = ({
+  value,
+  onChange,
+  counts,
+}) => (
+  <div
+    role="tablist"
+    aria-label="Filter assignments"
+    className="inline-flex items-center gap-1 rounded-full bg-white border border-slate-200 p-1 shadow-sm"
+  >
+    {TABS.map((tab) => {
+      const isActive = tab.id === value;
+      const count = counts?.[tab.id];
+      return (
+        <button
+          key={tab.id}
+          type="button"
+          role="tab"
+          aria-selected={isActive}
+          onClick={() => onChange(tab.id)}
+          className={`inline-flex items-center gap-1.5 rounded-full px-3 py-1.5 text-xs font-semibold transition focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue-primary focus-visible:ring-offset-1 ${
+            isActive
+              ? 'bg-brand-blue-primary text-white shadow-sm'
+              : 'text-slate-600 hover:text-slate-900'
+          }`}
+        >
+          <span>{tab.label}</span>
+          {typeof count === 'number' && (
+            <span
+              className={`inline-block min-w-[1.5em] text-center tabular-nums text-[11px] ${
+                isActive ? 'text-white/85' : 'text-slate-400'
+              }`}
+            >
+              {count}
+            </span>
+          )}
+        </button>
+      );
+    })}
+  </div>
+);

--- a/components/student/AssignmentListItem.tsx
+++ b/components/student/AssignmentListItem.tsx
@@ -1,0 +1,196 @@
+import React, { useEffect, useState } from 'react';
+import { doc, getDoc } from 'firebase/firestore';
+import { httpsCallable } from 'firebase/functions';
+import { CheckCircle2 } from 'lucide-react';
+import { db, functions } from '@/config/firebase';
+import {
+  KIND_CONFIG,
+  type AssignmentSummary,
+} from '@/hooks/useStudentAssignments';
+import type { ClassDirectoryEntry } from '@/hooks/useStudentClassDirectory';
+
+/**
+ * Lazy completion check — same pattern as the previous AssignmentCard but
+ * surfaced as a calmer list-row visual matching the redesign.
+ *
+ * Pseudonym cache: per-(uid, sessionId), de-dupes the callable across
+ * concurrent renders. Module-local; survives card remounts within a single
+ * page lifetime. Pseudonyms are stable for a given (uid, assignmentId).
+ */
+
+let pseudonymCacheOwnerUid: string | null = null;
+let pseudonymCache: Map<string, Promise<string>> = new Map();
+
+function getCachedPseudonym(
+  sessionId: string,
+  pseudonymUid: string
+): Promise<string> {
+  if (pseudonymCacheOwnerUid !== pseudonymUid) {
+    pseudonymCache = new Map();
+    pseudonymCacheOwnerUid = pseudonymUid;
+  }
+  const cached = pseudonymCache.get(sessionId);
+  if (cached) return cached;
+
+  const callable = httpsCallable<
+    { assignmentId: string },
+    { pseudonym?: string }
+  >(functions, 'getAssignmentPseudonymV1');
+
+  const promise = callable({ assignmentId: sessionId }).then((res) => {
+    const p = res.data?.pseudonym;
+    if (typeof p !== 'string' || p.length === 0) {
+      throw new Error('Pseudonym missing from callable response.');
+    }
+    return p;
+  });
+
+  pseudonymCache.set(sessionId, promise);
+  promise.catch(() => {
+    if (pseudonymCache.get(sessionId) === promise) {
+      pseudonymCache.delete(sessionId);
+    }
+  });
+  return promise;
+}
+
+/** Subcollection that holds per-student response/submission docs, keyed by pseudonym. */
+const RESPONSE_SUBCOLLECTION: Record<AssignmentSummary['kind'], string | null> =
+  {
+    quiz: 'responses',
+    'video-activity': 'responses',
+    'guided-learning': 'responses',
+    'mini-app': 'submissions',
+    'activity-wall': 'submissions',
+  };
+
+export type CompletionState = 'unknown' | 'completed' | 'not-completed';
+
+interface AssignmentListItemProps {
+  assignment: AssignmentSummary;
+  pseudonymUid: string | null;
+  /** Optional class directory entry for the assignment's primary class — used in the meta line. */
+  classEntry?: ClassDirectoryEntry;
+  /** Hide the class name (e.g. when rendered inside a per-class view). */
+  hideClassName?: boolean;
+  /**
+   * Called once the per-row completion check resolves to a non-'unknown'
+   * state. The parent uses this to partition rows into Active vs Completed.
+   */
+  onCompletionResolved?: (
+    sessionId: string,
+    kind: AssignmentSummary['kind'],
+    completion: CompletionState
+  ) => void;
+}
+
+export const AssignmentListItem: React.FC<AssignmentListItemProps> = ({
+  assignment,
+  pseudonymUid,
+  classEntry,
+  hideClassName,
+  onCompletionResolved,
+}) => {
+  const [completion, setCompletion] = useState<CompletionState>('unknown');
+  const config = KIND_CONFIG[assignment.kind];
+  const responseSub = RESPONSE_SUBCOLLECTION[assignment.kind];
+
+  useEffect(() => {
+    if (!pseudonymUid) return;
+    if (!responseSub) return;
+
+    let cancelled = false;
+    const run = async () => {
+      try {
+        const pseudonym = await getCachedPseudonym(
+          assignment.sessionId,
+          pseudonymUid
+        );
+        if (cancelled) return;
+        const snap = await getDoc(
+          doc(
+            db,
+            config.collectionName,
+            assignment.sessionId,
+            responseSub,
+            pseudonym
+          )
+        );
+        if (cancelled) return;
+        const next: CompletionState = snap.exists()
+          ? 'completed'
+          : 'not-completed';
+        setCompletion(next);
+        onCompletionResolved?.(assignment.sessionId, assignment.kind, next);
+      } catch {
+        // Silent: a failed completion check shouldn't block the student
+        // from opening the assignment. Leave completion as 'unknown'.
+      }
+    };
+    void run();
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    assignment.sessionId,
+    assignment.kind,
+    pseudonymUid,
+    config.collectionName,
+    responseSub,
+    onCompletionResolved,
+  ]);
+
+  const isCompleted = completion === 'completed';
+
+  return (
+    <a
+      href={assignment.openHref}
+      className={`group flex items-center gap-3 rounded-xl border border-slate-200 bg-white px-4 py-3 transition hover:border-slate-300 hover:shadow-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue-primary focus-visible:ring-offset-2 ${
+        isCompleted ? 'opacity-80' : ''
+      }`}
+    >
+      <span
+        className={`inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-full border-2 ${
+          isCompleted
+            ? 'border-emerald-500 bg-emerald-500 text-white'
+            : 'border-slate-300 text-transparent'
+        }`}
+        aria-hidden="true"
+      >
+        {isCompleted && <CheckCircle2 className="h-4 w-4" strokeWidth={2.5} />}
+      </span>
+
+      <div className="min-w-0 flex-1">
+        <p
+          className={`truncate text-sm font-semibold sm:text-base ${
+            isCompleted ? 'text-slate-500 line-through' : 'text-slate-800'
+          }`}
+        >
+          {assignment.title}
+        </p>
+        <p className="mt-0.5 truncate text-xs text-slate-500">
+          {!hideClassName && classEntry?.name && (
+            <span className="font-medium text-slate-600">
+              {classEntry.name}
+            </span>
+          )}
+          {!hideClassName && classEntry?.name && (
+            <span className="px-1.5 text-slate-300">·</span>
+          )}
+          <span>{config.label}</span>
+        </p>
+      </div>
+
+      <span
+        className={`hidden shrink-0 rounded-lg px-3 py-1.5 text-xs font-semibold transition sm:inline-flex ${
+          isCompleted
+            ? 'bg-slate-100 text-slate-500 group-hover:bg-slate-200'
+            : 'bg-brand-blue-primary text-white shadow-sm shadow-brand-blue-primary/20 group-hover:bg-brand-blue-dark'
+        }`}
+        aria-hidden="true"
+      >
+        {isCompleted ? 'Review' : 'Open'}
+      </span>
+    </a>
+  );
+};

--- a/components/student/AssignmentSections.tsx
+++ b/components/student/AssignmentSections.tsx
@@ -1,0 +1,165 @@
+import React from 'react';
+import { Inbox } from 'lucide-react';
+import { AssignmentListItem, type CompletionState } from './AssignmentListItem';
+import type { AssignmentSummary } from '@/hooks/useStudentAssignments';
+import type { ClassDirectoryEntry } from '@/hooks/useStudentClassDirectory';
+import type { AssignmentFilterMode } from './AssignmentFilterTabs';
+
+/**
+ * Renders the Active and/or Completed sections per the selected filter
+ * mode. Shared between StudentOverview (all classes) and StudentClassView
+ * (single class) so the partition rule lives in one place.
+ *
+ * Partition rule (matches the plan):
+ *   - completion === 'completed' → Completed section
+ *   - completion === 'not-completed' AND channel === 'active' → Active
+ *   - completion === 'not-completed' AND channel === 'ended' → hidden
+ *   - completion === 'unknown' → Active (with neutral pill, resolves later)
+ */
+
+interface AssignmentSectionsProps {
+  mode: AssignmentFilterMode;
+  active: AssignmentSummary[];
+  completed: AssignmentSummary[];
+  pseudonymUid: string | null;
+  directoryById: Record<string, ClassDirectoryEntry>;
+  hideClassName?: boolean;
+  onCompletionResolved: (
+    sessionId: string,
+    kind: AssignmentSummary['kind'],
+    completion: CompletionState
+  ) => void;
+  /** Optional override for the all-empty state (mode='all', both sections empty). */
+  emptyAll?: React.ReactNode;
+}
+
+export const AssignmentSections: React.FC<AssignmentSectionsProps> = ({
+  mode,
+  active,
+  completed,
+  pseudonymUid,
+  directoryById,
+  hideClassName,
+  onCompletionResolved,
+  emptyAll,
+}) => {
+  const showActive = mode === 'all' || mode === 'active';
+  const showCompleted = mode === 'all' || mode === 'completed';
+
+  // All-empty fallback for mode='all' so the page reads as "you're all caught
+  // up" instead of two empty headers.
+  if (mode === 'all' && active.length === 0 && completed.length === 0) {
+    return (
+      <>
+        {emptyAll ?? (
+          <CalmEmpty
+            title="All caught up"
+            body="You're all caught up — nothing active or completed yet."
+          />
+        )}
+      </>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-8">
+      {showActive && (
+        <Section
+          label="Active"
+          count={active.length}
+          empty={
+            mode === 'all' ? (
+              <p className="text-sm text-slate-500">
+                Nothing active right now.
+              </p>
+            ) : (
+              <CalmEmpty
+                title="All caught up"
+                body="You're all caught up — no active assignments right now."
+              />
+            )
+          }
+        >
+          {active.map((a) => (
+            <AssignmentListItem
+              key={a.compositeId}
+              assignment={a}
+              pseudonymUid={pseudonymUid}
+              classEntry={
+                a.classIds[0] ? directoryById[a.classIds[0]] : undefined
+              }
+              hideClassName={hideClassName}
+              onCompletionResolved={onCompletionResolved}
+            />
+          ))}
+        </Section>
+      )}
+      {showCompleted && (
+        <Section
+          label="Completed"
+          count={completed.length}
+          empty={
+            mode === 'all' ? (
+              <p className="text-sm text-slate-500">Nothing completed yet.</p>
+            ) : (
+              <CalmEmpty
+                title="Nothing completed yet"
+                body="Once you finish an assignment, it'll show up here."
+              />
+            )
+          }
+        >
+          {completed.map((a) => (
+            <AssignmentListItem
+              key={a.compositeId}
+              assignment={a}
+              pseudonymUid={pseudonymUid}
+              classEntry={
+                a.classIds[0] ? directoryById[a.classIds[0]] : undefined
+              }
+              hideClassName={hideClassName}
+              onCompletionResolved={onCompletionResolved}
+            />
+          ))}
+        </Section>
+      )}
+    </div>
+  );
+};
+
+interface SectionProps {
+  label: string;
+  count: number;
+  empty: React.ReactNode;
+  children?: React.ReactNode;
+}
+
+const Section: React.FC<SectionProps> = ({ label, count, empty, children }) => (
+  <section>
+    <header className="mb-3 flex items-baseline justify-between">
+      <h2 className="text-[11px] font-bold uppercase tracking-[0.14em] text-slate-500">
+        {label} · {count}
+      </h2>
+    </header>
+    {count === 0 ? (
+      empty
+    ) : (
+      <div className="flex flex-col gap-2">{children}</div>
+    )}
+  </section>
+);
+
+const CalmEmpty: React.FC<{ title: string; body: string }> = ({
+  title,
+  body,
+}) => (
+  <div className="flex min-h-[200px] flex-col items-center justify-center gap-3 rounded-2xl border border-dashed border-slate-200 px-6 py-10 text-center">
+    <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-slate-100">
+      <Inbox className="h-6 w-6 text-slate-400" strokeWidth={2} />
+    </div>
+    <div className="max-w-sm">
+      <h3 className="text-sm font-bold text-slate-700">{title}</h3>
+      <p className="mt-1 text-sm text-slate-500">{body}</p>
+    </div>
+  </div>
+);

--- a/components/student/MyAssignmentsPage.tsx
+++ b/components/student/MyAssignmentsPage.tsx
@@ -1,676 +1,498 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import {
-  collection,
-  doc,
-  getDoc,
-  onSnapshot,
-  query,
-  where,
-  type Query,
-  type QuerySnapshot,
-  type DocumentData,
-} from 'firebase/firestore';
-import { httpsCallable } from 'firebase/functions';
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import {
   AlertCircle,
   AlertTriangle,
-  CheckCircle2,
-  ClipboardList,
   GraduationCap,
-  Image as ImageIcon,
-  Inbox,
   Loader2,
   LogOut,
-  PlayCircle,
-  Puzzle,
+  Menu,
   RefreshCw,
-  Sparkles,
 } from 'lucide-react';
-import { db, functions } from '@/config/firebase';
 import { APP_NAME } from '@/config/constants';
 import { useStudentAuth } from '@/context/useStudentAuth';
+import {
+  useStudentAssignments,
+  type AssignmentSummary,
+} from '@/hooks/useStudentAssignments';
+import { useStudentClassDirectory } from '@/hooks/useStudentClassDirectory';
+import { StudentSidebar } from './StudentSidebar';
+import { StudentOverview } from './StudentOverview';
+import { StudentClassView } from './StudentClassView';
+import { type AssignmentFilterMode } from './AssignmentFilterTabs';
+import type { CompletionState } from './AssignmentListItem';
 
 /**
- * MyAssignmentsPage — Phase 2C of the ClassLink-via-Google auth flow.
+ * /my-assignments — class-aware student dashboard.
  *
- * Landing page for a signed-in student. Subscribes to the five session
- * collections (`quiz_sessions`, `video_activity_sessions`,
- * `guided_learning_sessions`, `mini_app_sessions`, `activity_wall_sessions`)
- * and renders the union as a single list.
+ * Layout: a slide-out sidebar (class list) toggled by a hamburger button in
+ * the page header, plus a main column (overview or per-class view). The
+ * sidebar opens by default on desktop, closed by default on mobile, where
+ * it presents as a slide-over with a tap-to-close backdrop.
  *
- * Query strategy: quiz / video-activity / guided-learning subscribe to TWO
- * queries each — one on the Phase 5A `classIds` array (array-contains-any)
- * and one on the legacy `classId` string (in) — merging by sessionId so
- * students in *any* class targeted by a multi-class assignment are covered
- * while legacy single-class sessions still surface. Mini-app is list-only
- * (its sessions have always been multi-class) and activity-wall is
- * single-only (has not been migrated to multi-class yet).
+ * Subscribes via `useStudentAssignments` to two channels (active + ended)
+ * per supported session kind, and resolves class names / teacher names via
+ * `useStudentClassDirectory`.
  *
- * PII-free: reads only session-level fields (title, status, code, classId).
- * Never reads, logs, or persists email / displayName / sub. The only
- * identifier we touch is the custom-token pseudonym UID from
- * `useStudentAuth`.
+ * PII guarantees still hold: only the opaque pseudonym uid + claim-bound
+ * classIds are read on the client. Teacher names are surfaced (org data,
+ * not student PII). The student's own name is never shown — claims don't
+ * carry it.
  *
- * Completion check strategy: LAZY per-row. Each `AssignmentCard` kicks off
- * a single `getAssignmentPseudonymV1` callable (results cached across the
- * page lifetime via a shared `Map` ref) and then a single `getDoc`
- * existence check against the correct response subcollection. This lets
- * React render the list immediately and fill in completion badges as they
- * resolve, rather than blocking on a large Promise.all.
- *
- * Firestore `in` cap: `classIds` is capped at 20 by `studentLoginV1`.
- * Firestore's `where('x', 'in', arr)` supports up to 30 values. Do NOT
- * raise the `studentLoginV1` cap past 30 without splitting this query
- * into chunks.
+ * Active vs Completed partition is computed client-side from the lazy
+ * completion check on each row. See AssignmentSections for the rule.
  */
 
-// ---------------------------------------------------------------------------
-// Types
-// ---------------------------------------------------------------------------
+const FILTER_STORAGE_KEY = 'sb_my_assignments_filter';
 
-type SessionKind =
-  | 'quiz'
-  | 'video-activity'
-  | 'guided-learning'
-  | 'mini-app'
-  | 'activity-wall';
+const isFilterMode = (v: unknown): v is AssignmentFilterMode =>
+  v === 'all' || v === 'active' || v === 'completed';
 
-interface AssignmentSummary {
-  /** `${kind}:${sessionId}` — stable React key across collections. */
-  compositeId: string;
-  kind: SessionKind;
-  sessionId: string;
-  title: string;
-  /** Fully-qualified path the student can click to open the session. */
-  openHref: string;
-  /** When the session was created (for sorting). May be undefined for ad-hoc docs. */
-  createdAt?: number;
-}
-
-type LoadState = 'loading' | 'ready';
-
-interface KindConfig {
-  collectionName: string;
-  /**
-   * When true, subscribe to TWO queries per kind and merge results by
-   * `sessionId` (de-duping any overlap):
-   *   - `list`   — `where('classIds', 'array-contains-any', classIds)` — Phase 5A multi-class
-   *   - `single` — `where('classId', 'in', classIds)`                   — legacy single-class
-   * This is required for quiz/video-activity/guided-learning so that
-   * multi-class assignments (Phase 5A) are discovered for students in
-   * *any* targeted class — not just `classIds[0]` — while legacy
-   * single-class sessions (with no `classIds` array) still surface.
-   *
-   * When false, a single query is issued using `classFilterShape`.
-   */
-  dualQuery: boolean;
-  /** Firestore status filter, or `null` when the collection has no status field. */
-  statusFilter:
-    | { field: 'status'; value: 'active' }
-    | { field: 'status'; valueIn: readonly string[] }
-    | null;
-  /**
-   * Shape used when `dualQuery` is false. Describes how this collection
-   * stores its class targeting:
-   *   - `single` — a string `classId` field (queried with `where(..., 'in', classIds)`)
-   *   - `list`   — an array `classIds` field (queried with `where(..., 'array-contains-any', classIds)`)
-   */
-  classFilterShape: 'single' | 'list';
-  /** Subcollection where per-student response/submission docs live; null when absent. */
-  responseSubcollection: string | null;
-  label: string;
-  icon: React.ComponentType<{ className?: string; strokeWidth?: number }>;
-  /** Tailwind gradient for the card accent badge. */
-  accent: string;
-  /** Given a raw session document, build the display title. */
-  titleFrom: (data: DocumentData) => string;
-  /** Given a session id and the raw session doc, build the /open URL. */
-  hrefFrom: (sessionId: string, data: DocumentData) => string;
-}
-
-// ---------------------------------------------------------------------------
-// Per-kind configuration
-// ---------------------------------------------------------------------------
-//
-// Fields verified against:
-//   - `types.ts` (QuizSession, VideoActivitySession, MiniAppSession,
-//     GuidedLearningSession)
-//   - `firestore.rules` — each collection's `passesStudentClassGate` read rule
-//   - `components/widgets/ActivityWall/Widget.tsx` (session doc is created
-//     ad-hoc without a TS interface — fields confirmed from the setDoc call)
-//
-// Notes:
-//   - guided_learning_sessions and activity_wall_sessions have NO status
-//     field on the session document. The GL assignment wrapper lives in
-//     /users/{teacherUid}/guided_learning_assignments and ActivityWall uses
-//     the session's existence as liveness. We intentionally do not filter
-//     those by status.
-//   - mini_app_sessions submissions live under the `submissions` subcollection
-//     (doc ID = per-assignment pseudonym for studentRole launches, auth uid
-//     for anonymous launches). See MiniAppStudentApp.tsx for the write path
-//     and firestore.rules for the matching read/create rules.
-
-const KIND_CONFIG: Record<SessionKind, KindConfig> = {
-  quiz: {
-    collectionName: 'quiz_sessions',
-    dualQuery: true,
-    // Include `waiting` so teacher-paced quizzes (which sit in 'waiting'
-    // after Play but before the teacher advances to Q1) surface on
-    // `/my-assignments` — matching the PIN-flow experience.
-    statusFilter: { field: 'status', valueIn: ['waiting', 'active'] },
-    classFilterShape: 'single',
-    responseSubcollection: 'responses',
-    label: 'Quiz',
-    icon: ClipboardList,
-    accent: 'from-blue-500 to-indigo-600',
-    titleFrom: (data) =>
-      typeof data.quizTitle === 'string' && data.quizTitle.length > 0
-        ? data.quizTitle
-        : 'Untitled quiz',
-    hrefFrom: (sessionId, data) => {
-      // Quiz student app joins via ?code=<code> (the 6-char join code) rather
-      // than sessionId. Fall back to sessionId if code isn't present on the
-      // doc (shouldn't happen in practice, but keeps the link functional).
-      const code =
-        typeof data.code === 'string' && data.code.length > 0
-          ? data.code
-          : sessionId;
-      return `/quiz?code=${encodeURIComponent(code)}`;
-    },
-  },
-  'video-activity': {
-    collectionName: 'video_activity_sessions',
-    dualQuery: true,
-    statusFilter: { field: 'status', value: 'active' },
-    classFilterShape: 'single',
-    responseSubcollection: 'responses',
-    label: 'Video Activity',
-    icon: PlayCircle,
-    accent: 'from-rose-500 to-red-600',
-    titleFrom: (data) => {
-      if (
-        typeof data.activityTitle === 'string' &&
-        data.activityTitle.length > 0
-      )
-        return data.activityTitle;
-      if (
-        typeof data.assignmentName === 'string' &&
-        data.assignmentName.length > 0
-      )
-        return data.assignmentName;
-      return 'Video activity';
-    },
-    hrefFrom: (sessionId) => `/activity/${encodeURIComponent(sessionId)}`,
-  },
-  'guided-learning': {
-    collectionName: 'guided_learning_sessions',
-    dualQuery: true,
-    statusFilter: null, // No status field; session presence = live.
-    classFilterShape: 'single',
-    responseSubcollection: 'responses',
-    label: 'Guided Learning',
-    icon: Sparkles,
-    accent: 'from-emerald-500 to-teal-600',
-    titleFrom: (data) =>
-      typeof data.title === 'string' && data.title.length > 0
-        ? data.title
-        : 'Guided learning',
-    hrefFrom: (sessionId) =>
-      `/guided-learning/${encodeURIComponent(sessionId)}`,
-  },
-  'mini-app': {
-    collectionName: 'mini_app_sessions',
-    dualQuery: false,
-    statusFilter: { field: 'status', value: 'active' },
-    classFilterShape: 'list',
-    responseSubcollection: 'submissions',
-    label: 'Mini App',
-    icon: Puzzle,
-    accent: 'from-violet-500 to-purple-600',
-    titleFrom: (data) => {
-      if (typeof data.appTitle === 'string' && data.appTitle.length > 0)
-        return data.appTitle;
-      if (
-        typeof data.assignmentName === 'string' &&
-        data.assignmentName.length > 0
-      )
-        return data.assignmentName;
-      return 'Mini app';
-    },
-    hrefFrom: (sessionId) => `/miniapp/${encodeURIComponent(sessionId)}`,
-  },
-  'activity-wall': {
-    collectionName: 'activity_wall_sessions',
-    dualQuery: false,
-    statusFilter: null, // No status field on the session doc.
-    classFilterShape: 'single',
-    // ActivityWall submissions are a LIST per student (students can post
-    // multiple). We still use existence as a "has the student participated
-    // yet?" signal — but the doc id is the pseudonym, so this is a
-    // best-effort hint, not a true completion.
-    responseSubcollection: 'submissions',
-    label: 'Activity Wall',
-    icon: ImageIcon,
-    accent: 'from-amber-500 to-orange-600',
-    titleFrom: (data) =>
-      typeof data.title === 'string' && data.title.length > 0
-        ? data.title
-        : 'Activity wall',
-    hrefFrom: (sessionId) => `/activity-wall/${encodeURIComponent(sessionId)}`,
-  },
-};
-
-const SESSION_KINDS: readonly SessionKind[] = [
-  'quiz',
-  'video-activity',
-  'guided-learning',
-  'mini-app',
-  'activity-wall',
-];
-
-// ---------------------------------------------------------------------------
-// Page component
-// ---------------------------------------------------------------------------
-
-interface AssignmentsByKind {
-  [kind: string]: AssignmentSummary[];
-}
+const formatTodayLong = (now: Date): string =>
+  now.toLocaleDateString(undefined, {
+    weekday: 'short',
+    month: 'short',
+    day: 'numeric',
+  });
 
 const MyAssignmentsPage: React.FC = () => {
-  const { classIds, pseudonymUid, signOut } = useStudentAuth();
-  const [byKind, setByKind] = useState<AssignmentsByKind>(() =>
-    Object.fromEntries(SESSION_KINDS.map((k) => [k, []]))
-  );
-  const [loadState, setLoadState] = useState<LoadState>('loading');
-  // Keyed on `${kind}:${shape}` so dual-query kinds (one list + one single
-  // subscription) track each bucket independently. Keying on `kind` alone
-  // let a succeeding shape clear the error for its still-failing sibling,
-  // which would hide half-missing data behind a "loaded" state.
-  const [erroredBuckets, setErroredBuckets] = useState<Set<string>>(
-    () => new Set()
-  );
-  const [retryNonce, setRetryNonce] = useState(0);
+  const { classIds, pseudonymUid, firstName, signOut } = useStudentAuth();
 
-  // Stable subscription identity: we only re-subscribe when classIds actually
-  // changes, not on every render.
-  const classIdsKey = useMemo(
-    () => classIds.slice().sort().join('|'),
-    [classIds]
-  );
+  const directory = useStudentClassDirectory({ classIds, pseudonymUid });
+  const { loadState, assignments, hasErrors, retry } = useStudentAssignments({
+    classIds,
+  });
 
-  useEffect(() => {
-    // No classes → no queries (Firestore rejects `in` with []).
-    if (classIds.length === 0) {
-      setByKind(Object.fromEntries(SESSION_KINDS.map((k) => [k, []])));
-      setErroredBuckets(new Set());
-      setLoadState('ready');
-      return;
+  // Active class selection — null = "All classes" overview.
+  const [activeClassId, setActiveClassId] = useState<string | null>(null);
+
+  // Slide-out sidebar visibility. Defaults open on desktop, closed on mobile
+  // — once the student toggles, we respect their choice. Initial state is
+  // derived from the viewport at first render and never auto-snaps back.
+  const [sidebarOpen, setSidebarOpen] = useState<boolean>(() => {
+    if (typeof window === 'undefined') return true;
+    return window.matchMedia('(min-width: 768px)').matches;
+  });
+  const toggleSidebar = useCallback(() => setSidebarOpen((o) => !o), []);
+  const closeSidebar = useCallback(() => setSidebarOpen(false), []);
+  // On mobile, picking a class auto-closes the sidebar so the student lands
+  // on the chosen view immediately. Desktop keeps it open across navigations.
+  const handleSelectClass = useCallback((classId: string | null) => {
+    setActiveClassId(classId);
+    if (
+      typeof window !== 'undefined' &&
+      !window.matchMedia('(min-width: 768px)').matches
+    ) {
+      setSidebarOpen(false);
     }
-
-    setLoadState('loading');
-    setErroredBuckets(new Set());
-
-    type QueryShape = 'list' | 'single';
-    const bucketKey = (kind: SessionKind, shape: QueryShape) =>
-      `${kind}:${shape}`;
-
-    // Plan every (kind, shape) subscription up front so we know the total
-    // count and can flip to `ready` exactly when every subscription has
-    // delivered its first snapshot (success OR error).
-    const subs: Array<{ kind: SessionKind; shape: QueryShape }> = [];
-    for (const kind of SESSION_KINDS) {
-      const config = KIND_CONFIG[kind];
-      if (config.dualQuery) {
-        subs.push({ kind, shape: 'list' }, { kind, shape: 'single' });
-      } else {
-        subs.push({ kind, shape: config.classFilterShape });
-      }
-    }
-    const totalSubscriptions = subs.length;
-
-    // Per-(kind, shape) result buckets. When a kind has two subscriptions
-    // we merge both buckets by `sessionId` before emitting `byKind`, so a
-    // Phase 5A session whose `classIds[0]` equals one of the student's
-    // classIds (and therefore matches BOTH queries) is counted exactly
-    // once.
-    const buckets = new Map<string, AssignmentSummary[]>();
-    const settled = new Set<string>();
-
-    const docToSummary = (
-      kind: SessionKind,
-      config: KindConfig,
-      d: QuerySnapshot<DocumentData>['docs'][number]
-    ): AssignmentSummary => {
-      const data = d.data();
-      const createdAtRaw: unknown = (data as Record<string, unknown>).createdAt;
-      return {
-        compositeId: `${kind}:${d.id}`,
-        kind,
-        sessionId: d.id,
-        title: config.titleFrom(data),
-        openHref: config.hrefFrom(d.id, data),
-        createdAt: typeof createdAtRaw === 'number' ? createdAtRaw : undefined,
-      };
-    };
-
-    const emitMerged = (kind: SessionKind) => {
-      const listBucket = buckets.get(bucketKey(kind, 'list')) ?? [];
-      const singleBucket = buckets.get(bucketKey(kind, 'single')) ?? [];
-      if (listBucket.length === 0 && singleBucket.length === 0) {
-        setByKind((prev) =>
-          prev[kind] && prev[kind].length === 0 ? prev : { ...prev, [kind]: [] }
-        );
-        return;
-      }
-      const merged = new Map<string, AssignmentSummary>();
-      for (const a of listBucket) merged.set(a.sessionId, a);
-      for (const a of singleBucket) merged.set(a.sessionId, a);
-      setByKind((prev) => ({ ...prev, [kind]: Array.from(merged.values()) }));
-    };
-
-    const markSettled = (kind: SessionKind, shape: QueryShape) => {
-      settled.add(bucketKey(kind, shape));
-      if (settled.size === totalSubscriptions) {
-        setLoadState('ready');
-      }
-    };
-
-    const clearBucketError = (kind: SessionKind, shape: QueryShape) => {
-      const key = bucketKey(kind, shape);
-      setErroredBuckets((prev) => {
-        if (!prev.has(key)) return prev;
-        const next = new Set(prev);
-        next.delete(key);
-        return next;
-      });
-    };
-
-    const markBucketErrored = (kind: SessionKind, shape: QueryShape) => {
-      const key = bucketKey(kind, shape);
-      setErroredBuckets((prev) => {
-        if (prev.has(key)) return prev;
-        const next = new Set(prev);
-        next.add(key);
-        return next;
-      });
-    };
-
-    const handleSnapshot = (
-      kind: SessionKind,
-      shape: QueryShape,
-      snap: QuerySnapshot<DocumentData>
-    ) => {
-      const config = KIND_CONFIG[kind];
-      buckets.set(
-        bucketKey(kind, shape),
-        snap.docs.map((d) => docToSummary(kind, config, d))
-      );
-      emitMerged(kind);
-      // Clear only this bucket's error. Dual-query kinds have a sibling
-      // bucket that may still be failing; its own error flag stays set
-      // independently so the banner reflects "half your data is missing"
-      // instead of "all good" just because the healthy half recovered.
-      clearBucketError(kind, shape);
-      markSettled(kind, shape);
-    };
-
-    const handleError = (
-      kind: SessionKind,
-      shape: QueryShape,
-      err: unknown
-    ) => {
-      const code =
-        err && typeof err === 'object' && 'code' in err
-          ? String((err as { code?: unknown }).code)
-          : 'unknown';
-      // Firestore missing-index errors embed a one-click index-creation
-      // URL in `err.message` — invaluable the next time something silently
-      // empties the list. Messages from Firestore do not include any of
-      // the classId values passed into the query, so this remains PII-safe.
-      const message =
-        err && typeof err === 'object' && 'message' in err
-          ? String((err as { message?: unknown }).message)
-          : '';
-      console.error(
-        `[MyAssignments] snapshot failed for ${KIND_CONFIG[kind].collectionName} (${shape}) [${code}]:`,
-        message
-      );
-      buckets.set(bucketKey(kind, shape), []);
-      emitMerged(kind);
-      markBucketErrored(kind, shape);
-      markSettled(kind, shape);
-    };
-
-    const buildQuery = (
-      config: KindConfig,
-      shape: QueryShape
-    ): Query<DocumentData> => {
-      const col = collection(db, config.collectionName);
-      const constraints =
-        shape === 'list'
-          ? [where('classIds', 'array-contains-any', classIds)]
-          : [where('classId', 'in', classIds)];
-      if (config.statusFilter) {
-        if ('valueIn' in config.statusFilter) {
-          constraints.push(
-            where(config.statusFilter.field, 'in', [
-              ...config.statusFilter.valueIn,
-            ])
-          );
-        } else {
-          constraints.push(
-            where(config.statusFilter.field, '==', config.statusFilter.value)
-          );
-        }
-      }
-      return query(col, ...constraints);
-    };
-
-    const unsubs: Array<() => void> = [];
-    for (const { kind, shape } of subs) {
-      const config = KIND_CONFIG[kind];
-      const q = buildQuery(config, shape);
-      unsubs.push(
-        onSnapshot(
-          q,
-          (snap) => handleSnapshot(kind, shape, snap),
-          (err) => handleError(kind, shape, err)
-        )
-      );
-    }
-
-    return () => {
-      for (const u of unsubs) u();
-    };
-    // `classIds` drives the `in` filter; re-subscribe only when the key
-    // changes. `classIdsKey` is derived from `classIds` and gives us a
-    // value-based comparison instead of reference identity. `retryNonce`
-    // bumps to force a fresh subscription cycle from the retry button.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [classIdsKey, retryNonce]);
-
-  const handleRetry = useCallback(() => {
-    setRetryNonce((n) => n + 1);
   }, []);
 
-  // Flatten + sort: newest first, grouped visually by kind order inside a
-  // single list. Sort is stable on `createdAt` (desc), then by title to
-  // keep ordering deterministic when createdAt is missing.
-  const assignments: AssignmentSummary[] = useMemo(() => {
-    const merged: AssignmentSummary[] = [];
-    for (const kind of SESSION_KINDS) {
-      const list = byKind[kind] ?? [];
-      merged.push(...list);
+  // Hamburger-button ref so we can restore focus when the sidebar closes.
+  // The closed sidebar is `inert`, which means any focus left inside its
+  // subtree at close time would be stranded — restoring to the trigger is
+  // the standard a11y pattern (matches WAI-ARIA disclosure / dialog
+  // recommendations).
+  const menuButtonRef = useRef<HTMLButtonElement | null>(null);
+  const prevSidebarOpenRef = useRef(sidebarOpen);
+  useEffect(() => {
+    if (prevSidebarOpenRef.current && !sidebarOpen) {
+      menuButtonRef.current?.focus();
     }
-    merged.sort((a, b) => {
-      const ac = a.createdAt ?? 0;
-      const bc = b.createdAt ?? 0;
-      if (ac !== bc) return bc - ac;
-      return a.title.localeCompare(b.title);
-    });
-    return merged;
-  }, [byKind]);
+    prevSidebarOpenRef.current = sidebarOpen;
+  }, [sidebarOpen]);
+
+  // Esc closes the sidebar. Mounted only while open so we don't add an
+  // always-on listener for what is otherwise a quiet page.
+  useEffect(() => {
+    if (!sidebarOpen) return;
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.stopPropagation();
+        setSidebarOpen(false);
+      }
+    };
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [sidebarOpen]);
+
+  // Filter mode persists to sessionStorage so a refresh keeps it but the
+  // choice never follows the student onto a shared device.
+  const [filterMode, setFilterMode] = useState<AssignmentFilterMode>(() => {
+    if (typeof window === 'undefined') return 'all';
+    try {
+      const raw = window.sessionStorage.getItem(FILTER_STORAGE_KEY);
+      return isFilterMode(raw) ? raw : 'all';
+    } catch {
+      return 'all';
+    }
+  });
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    try {
+      window.sessionStorage.setItem(FILTER_STORAGE_KEY, filterMode);
+    } catch {
+      // Ignored — sessionStorage may be disabled by privacy mode.
+    }
+  }, [filterMode]);
+
+  // If the student picks a class that vanishes from claims (e.g., schedule
+  // change mid-session), treat the selection as null so the page never
+  // shows an empty "phantom" class. Computed during render rather than via
+  // an effect — keeps setState out of effect bodies and avoids a stale
+  // intermediate render where the user sees a class that's no longer in
+  // their roster.
+  const effectiveClassId =
+    activeClassId && classIds.includes(activeClassId) ? activeClassId : null;
+
+  // Per-row completion resolutions, fed from AssignmentListItem callbacks.
+  // Stored at the page level so changing classes / filter modes doesn't
+  // discard already-resolved checks.
+  const [completionMap, setCompletionMap] = useState<
+    Record<string, CompletionState>
+  >({});
+  const onCompletionResolved = useCallback(
+    (
+      sessionId: string,
+      kind: AssignmentSummary['kind'],
+      completion: CompletionState
+    ) => {
+      setCompletionMap((prev) => {
+        const key = `${kind}:${sessionId}`;
+        if (prev[key] === completion) return prev;
+        return { ...prev, [key]: completion };
+      });
+    },
+    []
+  );
+
+  // Computed inline rather than memoized — `toLocaleDateString` is cheap
+  // and the empty-deps memo would otherwise stick to the date the page
+  // was first mounted across day transitions.
+  const todayDate = formatTodayLong(new Date());
+
+  // Partition assignments according to the rule in the plan. Compute once
+  // at the page level and slice per scope (overview vs class) below.
+  const partitioned = useMemo(() => {
+    const active: AssignmentSummary[] = [];
+    const completed: AssignmentSummary[] = [];
+    for (const a of assignments) {
+      const completion = completionMap[`${a.kind}:${a.sessionId}`] ?? 'unknown';
+      if (completion === 'completed') {
+        completed.push(a);
+        continue;
+      }
+      if (a.channel === 'ended') {
+        // Ended-channel rows the student didn't complete are hidden.
+        continue;
+      }
+      active.push(a);
+    }
+    return { active, completed };
+  }, [assignments, completionMap]);
+
+  // Per-class slices. Multi-class assignments appear under each matching
+  // class because `assignment.classIds` is the intersection with the
+  // student's claims (computed in useStudentAssignments).
+  const slicedForClass = useCallback(
+    (classId: string | null) => {
+      if (classId === null) {
+        return partitioned;
+      }
+      const inClass = (a: AssignmentSummary) => a.classIds.includes(classId);
+      return {
+        active: partitioned.active.filter(inClass),
+        completed: partitioned.completed.filter(inClass),
+      };
+    },
+    [partitioned]
+  );
+
+  const activeCountByClassId = useMemo<Record<string, number>>(() => {
+    const out: Record<string, number> = {};
+    for (const c of classIds) out[c] = 0;
+    for (const a of partitioned.active) {
+      for (const cid of a.classIds) {
+        if (cid in out) out[cid] = (out[cid] ?? 0) + 1;
+      }
+    }
+    return out;
+  }, [partitioned.active, classIds]);
+
+  const visibleScope = slicedForClass(effectiveClassId);
 
   const handleDone = useCallback(() => {
     void signOut();
   }, [signOut]);
 
-  return (
-    <div className="relative min-h-screen w-screen bg-slate-50 overflow-x-hidden font-sans">
-      {/* Ambient background, matches StudentLoginPage */}
-      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(#e5e7eb_1px,transparent_1px)] [background-size:16px_16px] opacity-50" />
-      <div className="pointer-events-none absolute top-[-10%] left-[-15%] w-[500px] h-[500px] rounded-full blur-[120px] bg-brand-blue-primary/15" />
-      <div className="pointer-events-none absolute bottom-[-15%] right-[-10%] w-[500px] h-[500px] bg-brand-red-primary/10 rounded-full blur-[120px]" />
-
-      <div className="relative z-10 flex flex-col min-h-screen">
-        <Header onDone={handleDone} />
-
-        <main className="flex-1 w-full max-w-3xl mx-auto px-4 sm:px-6 py-8 sm:py-12">
-          <div className="mb-8">
-            <h2 className="text-2xl sm:text-3xl font-black text-slate-800 tracking-tight">
-              My Assignments
-            </h2>
-            <p className="text-slate-500 text-sm sm:text-base mt-1.5 font-medium">
-              Everything your teachers have active for your classes right now.
-            </p>
-          </div>
-
-          <AssignmentsBody
-            loadState={loadState}
-            classIds={classIds}
-            assignments={assignments}
-            pseudonymUid={pseudonymUid}
-            hasErrors={erroredBuckets.size > 0}
-            onRetry={handleRetry}
-          />
-        </main>
-
-        <footer className="w-full max-w-3xl mx-auto px-4 sm:px-6 py-6 text-center text-xs text-slate-400 font-medium">
-          {APP_NAME}
-        </footer>
-      </div>
-    </div>
-  );
-};
-
-// ---------------------------------------------------------------------------
-// Header — brand + "Done" sign-out
-// ---------------------------------------------------------------------------
-
-const Header: React.FC<{ onDone: () => void }> = ({ onDone }) => (
-  <header className="w-full max-w-3xl mx-auto px-4 sm:px-6 pt-6 sm:pt-8 flex items-center justify-between gap-4">
-    <div className="flex items-center gap-3 min-w-0">
-      <div className="w-10 h-10 bg-gradient-to-br from-brand-blue-primary to-brand-blue-dark rounded-xl flex items-center justify-center shadow-md shadow-brand-blue-primary/20 shrink-0">
-        <GraduationCap className="w-5 h-5 text-white" strokeWidth={2.5} />
-      </div>
-      <span className="text-lg sm:text-xl font-black text-slate-800 tracking-tight truncate">
-        {APP_NAME}
-      </span>
-    </div>
-
-    <button
-      type="button"
-      onClick={onDone}
-      aria-label="Done — sign out"
-      className="inline-flex items-center gap-2 px-4 py-2 rounded-xl bg-white/70 backdrop-blur-sm border border-slate-200 text-slate-700 hover:bg-white hover:border-slate-300 text-sm font-semibold shadow-sm transition focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue-primary focus-visible:ring-offset-2 focus-visible:ring-offset-slate-50"
-    >
-      <LogOut className="w-4 h-4" strokeWidth={2.25} />
-      <span>Done</span>
-    </button>
-  </header>
-);
-
-// ---------------------------------------------------------------------------
-// Body — loading / empty / list
-// ---------------------------------------------------------------------------
-
-interface AssignmentsBodyProps {
-  loadState: LoadState;
-  classIds: string[];
-  assignments: AssignmentSummary[];
-  pseudonymUid: string | null;
-  hasErrors: boolean;
-  onRetry: () => void;
-}
-
-const AssignmentsBody: React.FC<AssignmentsBodyProps> = ({
-  loadState,
-  classIds,
-  assignments,
-  pseudonymUid,
-  hasErrors,
-  onRetry,
-}) => {
+  // ────────── Loading / no-classes / error gates (top-level guards) ──────────
   if (loadState === 'loading') {
     return (
-      <div className="min-h-[200px] flex flex-col items-center justify-center gap-3 text-slate-500">
-        <Loader2 className="w-8 h-8 animate-spin text-brand-blue-primary" />
-        <p className="text-sm font-medium">Loading your assignments…</p>
-      </div>
+      <PageShell onDone={handleDone}>
+        <div className="flex min-h-[200px] flex-col items-center justify-center gap-3 text-slate-500">
+          <Loader2 className="h-8 w-8 animate-spin text-brand-blue-primary" />
+          <p className="text-sm font-medium">Loading your assignments…</p>
+        </div>
+      </PageShell>
     );
   }
 
   if (classIds.length === 0) {
     return (
-      <EmptyState
-        icon={AlertCircle}
-        title="You're not on a roster yet"
-        body="You're not on any class rosters yet. If you just started at your school, ask a teacher to sync their roster."
-        tone="soft"
-      />
+      <PageShell onDone={handleDone}>
+        <FullEmpty
+          icon={AlertCircle}
+          title="You're not on a roster yet"
+          body="If you just started at your school, ask a teacher to sync their roster."
+        />
+      </PageShell>
     );
   }
 
   if (assignments.length === 0 && hasErrors) {
     return (
-      <EmptyState
-        icon={AlertTriangle}
-        title="We couldn't load your assignments"
-        body="Something went wrong loading your assignments. Refresh and try again."
-        tone="error"
-        action={{ label: 'Try again', onClick: onRetry }}
-      />
+      <PageShell onDone={handleDone}>
+        <FullEmpty
+          icon={AlertTriangle}
+          title="We couldn't load your assignments"
+          body="Something went wrong loading your assignments. Refresh and try again."
+          tone="error"
+          action={{ label: 'Try again', onClick: retry }}
+        />
+      </PageShell>
     );
   }
 
-  if (assignments.length === 0) {
-    return (
-      <EmptyState
-        icon={Inbox}
-        title="All caught up"
-        body="You're all caught up — no active assignments right now."
-        tone="soft"
-      />
-    );
-  }
-
+  // ────────── Main layout — slide-out sidebar + main column ──────────
   return (
-    <div className="space-y-3">
-      {hasErrors && <PartialFailureBanner onRetry={onRetry} />}
-      <ul className="space-y-3">
-        {assignments.map((a) => (
-          <li key={a.compositeId}>
-            <AssignmentCard assignment={a} pseudonymUid={pseudonymUid} />
-          </li>
-        ))}
-      </ul>
-    </div>
+    <>
+      <SlideOutSidebar open={sidebarOpen} onClose={closeSidebar}>
+        <StudentSidebar
+          classes={directory.classes}
+          claimedClassIds={classIds}
+          activeClassId={effectiveClassId}
+          activeCountByClassId={activeCountByClassId}
+          totalActiveCount={partitioned.active.length}
+          onSelect={handleSelectClass}
+          onSignOut={handleDone}
+          firstName={firstName}
+          classCount={classIds.length}
+        />
+      </SlideOutSidebar>
+
+      <PageShell
+        onDone={handleDone}
+        onToggleMenu={toggleSidebar}
+        menuOpen={sidebarOpen}
+        menuButtonRef={menuButtonRef}
+        hideDoneButton
+      >
+        {hasErrors && <PartialFailureBanner onRetry={retry} className="mb-4" />}
+        {effectiveClassId === null ? (
+          <StudentOverview
+            todayDate={todayDate}
+            active={visibleScope.active}
+            completed={visibleScope.completed}
+            filterMode={filterMode}
+            onFilterChange={setFilterMode}
+            pseudonymUid={pseudonymUid}
+            directoryById={directory.byId}
+            onCompletionResolved={onCompletionResolved}
+          />
+        ) : (
+          <StudentClassView
+            classId={effectiveClassId}
+            classEntry={directory.byId[effectiveClassId]}
+            todayDate={todayDate}
+            active={visibleScope.active}
+            completed={visibleScope.completed}
+            filterMode={filterMode}
+            onFilterChange={setFilterMode}
+            pseudonymUid={pseudonymUid}
+            directoryById={directory.byId}
+            onCompletionResolved={onCompletionResolved}
+          />
+        )}
+      </PageShell>
+    </>
   );
 };
 
-const PartialFailureBanner: React.FC<{ onRetry: () => void }> = ({
-  onRetry,
+// ---------------------------------------------------------------------------
+// Page shell (background, header, footer)
+// ---------------------------------------------------------------------------
+
+interface PageShellProps {
+  onDone: () => void;
+  /**
+   * When set, the brand icon is replaced with a hamburger menu button that
+   * toggles the slide-out class sidebar. Gate paths (loading / no-classes /
+   * error) omit it and render the brand chip as before.
+   */
+  onToggleMenu?: () => void;
+  menuOpen?: boolean;
+  /**
+   * Ref forwarded to the hamburger menu button so the page can restore
+   * focus there when the sidebar closes (e.g. via Esc, backdrop tap, or
+   * auto-close on class selection). Without this, focus left inside the
+   * now-`inert` sidebar would be stranded for keyboard users.
+   */
+  menuButtonRef?: React.Ref<HTMLButtonElement>;
+  /**
+   * When true, suppresses the header's Done button. Sign-out lives in the
+   * sidebar footer once the student is past the gate paths.
+   */
+  hideDoneButton?: boolean;
+  children: React.ReactNode;
+}
+
+const PageShell: React.FC<PageShellProps> = ({
+  onDone,
+  onToggleMenu,
+  menuOpen,
+  menuButtonRef,
+  hideDoneButton,
+  children,
 }) => (
+  <div className="relative min-h-screen w-screen overflow-x-hidden bg-slate-50 font-sans">
+    <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(#e5e7eb_1px,transparent_1px)] [background-size:16px_16px] opacity-40" />
+    <div className="pointer-events-none absolute left-[-15%] top-[-10%] h-[500px] w-[500px] rounded-full bg-brand-blue-primary/15 blur-[120px]" />
+    <div className="pointer-events-none absolute bottom-[-15%] right-[-10%] h-[500px] w-[500px] rounded-full bg-brand-red-primary/10 blur-[120px]" />
+
+    <div className="relative z-10 flex min-h-screen flex-col">
+      {/* Header — full-width, anchored. Brand-blue with white text. The
+          hamburger never shifts when the sidebar opens; the sidebar slides
+          in *below* this header (top: PAGE_HEADER_HEIGHT). */}
+      <header className="relative z-30 flex h-[72px] shrink-0 items-center justify-between gap-4 bg-gradient-to-r from-brand-blue-primary to-brand-blue-dark px-4 text-white shadow-md shadow-brand-blue-primary/20 sm:h-[80px] sm:px-8">
+        <div className="flex min-w-0 items-center gap-3">
+          {onToggleMenu ? (
+            <button
+              ref={menuButtonRef}
+              type="button"
+              onClick={onToggleMenu}
+              aria-label={menuOpen ? 'Close class menu' : 'Open class menu'}
+              aria-expanded={menuOpen}
+              className="inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-xl border border-white/20 bg-white/10 text-white shadow-sm transition hover:border-white/30 hover:bg-white/20 focus:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-brand-blue-primary"
+            >
+              <Menu className="h-5 w-5" strokeWidth={2.25} />
+            </button>
+          ) : (
+            <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-white/15 shadow-sm ring-1 ring-white/20">
+              <GraduationCap className="h-5 w-5 text-white" strokeWidth={2.5} />
+            </div>
+          )}
+          <span className="truncate text-lg font-bold tracking-tight text-white sm:text-xl">
+            {APP_NAME}
+          </span>
+        </div>
+        {!hideDoneButton && (
+          <button
+            type="button"
+            onClick={onDone}
+            aria-label="Done — sign out"
+            className="inline-flex items-center gap-2 rounded-xl border border-white/20 bg-white/10 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:border-white/30 hover:bg-white/20 focus:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-brand-blue-primary"
+          >
+            <LogOut className="h-4 w-4" strokeWidth={2.25} />
+            <span>Done</span>
+          </button>
+        )}
+      </header>
+
+      {/* Body — pushed right when sidebar is open on desktop. The header
+          above stays anchored. */}
+      <div
+        className={`flex flex-1 flex-col transition-[padding] duration-200 ${
+          onToggleMenu && menuOpen ? 'md:pl-[280px]' : ''
+        }`}
+      >
+        <div className="mx-auto w-full max-w-6xl flex-1 px-4 py-8 sm:px-8 sm:py-12">
+          {children}
+        </div>
+
+        <footer className="mx-auto w-full max-w-6xl px-4 pb-6 text-center text-xs font-medium text-slate-400 sm:px-8">
+          {APP_NAME}
+        </footer>
+      </div>
+    </div>
+  </div>
+);
+
+// ---------------------------------------------------------------------------
+// Slide-out sidebar wrapper
+// ---------------------------------------------------------------------------
+//
+// On desktop (≥ md), the sidebar is fixed to the left edge of the viewport
+// and the page shell adds `md:pl-[280px]` when open so content reflows
+// alongside the panel rather than disappearing under it. On mobile, the
+// sidebar slides in over the content with a tap-to-close backdrop.
+
+interface SlideOutSidebarProps {
+  open: boolean;
+  onClose: () => void;
+  children: React.ReactNode;
+}
+
+// Header heights kept in sync with the `<header>` in PageShell. Used to
+// position the sidebar so it slides IN UNDER the header, leaving the
+// hamburger and Done button anchored.
+const HEADER_OFFSET_CLASSES = 'top-[72px] sm:top-[80px]';
+
+const SlideOutSidebar: React.FC<SlideOutSidebarProps> = ({
+  open,
+  onClose,
+  children,
+}) => (
+  <>
+    {open && (
+      <button
+        type="button"
+        onClick={onClose}
+        aria-label="Close class menu"
+        className={`fixed bottom-0 left-0 right-0 z-20 bg-slate-900/30 backdrop-blur-sm md:hidden ${HEADER_OFFSET_CLASSES}`}
+      />
+    )}
+    <aside
+      aria-label="Class navigation"
+      aria-hidden={!open}
+      // `inert` removes the entire subtree from focus order, click events,
+      // and the a11y tree without unmounting it (preserves scroll/state on
+      // toggle). `pointer-events-none` hardens against older browsers that
+      // don't yet honor `inert` (Chromium ≥ 102, Safari ≥ 15.5, Firefox ≥
+      // 112) so an off-screen sidebar can't intercept clicks.
+      {...(open ? {} : { inert: true })}
+      className={`fixed bottom-0 left-0 z-20 flex w-[280px] flex-col shadow-xl transition-transform duration-200 ease-out md:shadow-none ${HEADER_OFFSET_CLASSES} ${
+        open
+          ? 'pointer-events-auto translate-x-0'
+          : 'pointer-events-none -translate-x-full'
+      }`}
+    >
+      {children}
+    </aside>
+  </>
+);
+
+// ---------------------------------------------------------------------------
+// Partial-failure banner — preserved from the previous implementation
+// ---------------------------------------------------------------------------
+
+const PartialFailureBanner: React.FC<{
+  onRetry: () => void;
+  className?: string;
+}> = ({ onRetry, className }) => (
   <div
     role="alert"
-    className="flex items-start gap-3 rounded-2xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm shadow-sm"
+    className={`flex items-start gap-3 rounded-2xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm shadow-sm ${className ?? ''}`}
   >
     <AlertTriangle
-      className="w-5 h-5 text-amber-600 shrink-0 mt-0.5"
+      className="mt-0.5 h-5 w-5 shrink-0 text-amber-600"
       strokeWidth={2.25}
       aria-hidden="true"
     />
-    <div className="flex-1 min-w-0">
+    <div className="min-w-0 flex-1">
       <p className="font-semibold text-amber-900">
         Some assignments couldn&apos;t be loaded.
       </p>
@@ -681,226 +503,61 @@ const PartialFailureBanner: React.FC<{ onRetry: () => void }> = ({
     <button
       type="button"
       onClick={onRetry}
-      className="inline-flex items-center gap-1.5 rounded-lg bg-amber-600 hover:bg-amber-700 text-white text-xs font-semibold px-3 py-1.5 shadow-sm transition focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-600 focus-visible:ring-offset-2 focus-visible:ring-offset-amber-50 shrink-0"
+      className="inline-flex shrink-0 items-center gap-1.5 rounded-lg bg-amber-600 px-3 py-1.5 text-xs font-semibold text-white shadow-sm transition hover:bg-amber-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-600 focus-visible:ring-offset-2 focus-visible:ring-offset-amber-50"
     >
-      <RefreshCw className="w-3.5 h-3.5" strokeWidth={2.5} />
+      <RefreshCw className="h-3.5 w-3.5" strokeWidth={2.5} />
       Try again
     </button>
   </div>
 );
 
 // ---------------------------------------------------------------------------
-// Empty state
+// Full-page empty state (used for no-classes / hard error gates)
 // ---------------------------------------------------------------------------
 
-interface EmptyStateProps {
+interface FullEmptyProps {
   icon: React.ComponentType<{ className?: string; strokeWidth?: number }>;
   title: string;
   body: string;
-  tone: 'soft' | 'error';
+  tone?: 'soft' | 'error';
   action?: { label: string; onClick: () => void };
 }
 
-const EmptyState: React.FC<EmptyStateProps> = ({
+const FullEmpty: React.FC<FullEmptyProps> = ({
   icon: Icon,
   title,
   body,
-  tone,
+  tone = 'soft',
   action,
 }) => {
   const isSoft = tone === 'soft';
   return (
-    <div className="min-h-[240px] flex flex-col items-center justify-center gap-4 text-center px-6 py-12">
+    <div className="flex min-h-[280px] flex-col items-center justify-center gap-4 px-6 py-12 text-center">
       <div
-        className={`w-14 h-14 rounded-2xl flex items-center justify-center ${
+        className={`flex h-14 w-14 items-center justify-center rounded-2xl ${
           isSoft ? 'bg-slate-100' : 'bg-brand-red-primary/10'
         }`}
       >
         <Icon
-          className={`w-7 h-7 ${
-            isSoft ? 'text-slate-400' : 'text-brand-red-primary'
-          }`}
+          className={`h-7 w-7 ${isSoft ? 'text-slate-400' : 'text-brand-red-primary'}`}
           strokeWidth={2}
         />
       </div>
       <div className="max-w-sm space-y-1.5">
         <h3 className="text-base font-bold text-slate-800">{title}</h3>
-        <p className="text-sm text-slate-500 leading-relaxed">{body}</p>
+        <p className="text-sm leading-relaxed text-slate-500">{body}</p>
       </div>
       {action && (
         <button
           type="button"
           onClick={action.onClick}
-          className="inline-flex items-center gap-2 px-4 py-2 rounded-xl bg-brand-blue-primary hover:bg-brand-blue-dark text-white text-sm font-semibold shadow-sm shadow-brand-blue-primary/20 transition focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue-primary focus-visible:ring-offset-2 focus-visible:ring-offset-slate-50"
+          className="inline-flex items-center gap-2 rounded-xl bg-brand-blue-primary px-4 py-2 text-sm font-semibold text-white shadow-sm shadow-brand-blue-primary/20 transition hover:bg-brand-blue-dark focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue-primary focus-visible:ring-offset-2 focus-visible:ring-offset-slate-50"
         >
-          <RefreshCw className="w-4 h-4" strokeWidth={2.25} />
+          <RefreshCw className="h-4 w-4" strokeWidth={2.25} />
           {action.label}
         </button>
       )}
     </div>
-  );
-};
-
-// ---------------------------------------------------------------------------
-// Assignment card — lazy completion check
-// ---------------------------------------------------------------------------
-//
-// Pseudonym cache: sessionId -> pseudonym (Promise-valued so concurrent
-// readers de-dupe the callable). This is module-local, so it survives
-// card remounts within a single page lifetime without re-fetching.
-// Pseudonyms are stable for a given (uid, assignmentId) within a session;
-// we rebuild the cache whenever the authenticated uid changes (tracked
-// via `pseudonymCacheOwnerUid`).
-
-let pseudonymCacheOwnerUid: string | null = null;
-let pseudonymCache: Map<string, Promise<string>> = new Map();
-
-function getCachedPseudonym(
-  sessionId: string,
-  pseudonymUid: string
-): Promise<string> {
-  if (pseudonymCacheOwnerUid !== pseudonymUid) {
-    pseudonymCache = new Map();
-    pseudonymCacheOwnerUid = pseudonymUid;
-  }
-  const cached = pseudonymCache.get(sessionId);
-  if (cached) return cached;
-
-  const callable = httpsCallable<
-    { assignmentId: string },
-    { pseudonym?: string }
-  >(functions, 'getAssignmentPseudonymV1');
-
-  const promise = callable({ assignmentId: sessionId }).then((res) => {
-    const p = res.data?.pseudonym;
-    if (typeof p !== 'string' || p.length === 0) {
-      throw new Error('Pseudonym missing from callable response.');
-    }
-    return p;
-  });
-
-  pseudonymCache.set(sessionId, promise);
-
-  // Evict on failure so a retry on a later card re-attempts the fetch.
-  promise.catch(() => {
-    if (pseudonymCache.get(sessionId) === promise) {
-      pseudonymCache.delete(sessionId);
-    }
-  });
-
-  return promise;
-}
-
-type CompletionState = 'unknown' | 'completed' | 'not-completed';
-
-const AssignmentCard: React.FC<{
-  assignment: AssignmentSummary;
-  pseudonymUid: string | null;
-}> = ({ assignment, pseudonymUid }) => {
-  const config = KIND_CONFIG[assignment.kind];
-  const [completion, setCompletion] = useState<CompletionState>('unknown');
-
-  // Lazy completion: fire one callable + one getDoc per card on mount.
-  // Pseudonym results are cached via `getCachedPseudonym`, so 30
-  // assignments from the same student = 30 callables (unavoidable —
-  // one per sessionId) and 30 doc reads. Same-kind retries reuse cached
-  // pseudonyms on remount.
-  useEffect(() => {
-    if (!pseudonymUid) return;
-    if (!config.responseSubcollection) {
-      // Collection has no per-student response docs — skip the badge.
-      return;
-    }
-
-    let cancelled = false;
-
-    const run = async () => {
-      try {
-        const pseudonym = await getCachedPseudonym(
-          assignment.sessionId,
-          pseudonymUid
-        );
-        if (cancelled) return;
-
-        const responseSub = config.responseSubcollection;
-        if (!responseSub) return;
-        const snap = await getDoc(
-          doc(
-            db,
-            config.collectionName,
-            assignment.sessionId,
-            responseSub,
-            pseudonym
-          )
-        );
-        if (cancelled) return;
-        setCompletion(snap.exists() ? 'completed' : 'not-completed');
-      } catch {
-        // Silent: a failed completion check shouldn't block the student
-        // from opening the assignment. Leave completion as 'unknown'.
-        if (cancelled) return;
-        setCompletion('unknown');
-      }
-    };
-
-    void run();
-
-    return () => {
-      cancelled = true;
-    };
-  }, [
-    assignment.sessionId,
-    pseudonymUid,
-    config.responseSubcollection,
-    config.collectionName,
-  ]);
-
-  const Icon = config.icon;
-  const isCompleted = completion === 'completed';
-
-  return (
-    <a
-      href={assignment.openHref}
-      className={`group block rounded-2xl border border-slate-200 bg-white/80 backdrop-blur-sm shadow-sm hover:shadow-md hover:border-slate-300 transition focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue-primary focus-visible:ring-offset-2 focus-visible:ring-offset-slate-50 ${
-        isCompleted ? 'opacity-75' : ''
-      }`}
-    >
-      <div className="flex items-center gap-4 p-4 sm:p-5">
-        <div
-          className={`w-11 h-11 sm:w-12 sm:h-12 rounded-xl bg-gradient-to-br ${config.accent} flex items-center justify-center shadow-sm shrink-0`}
-          aria-hidden="true"
-        >
-          <Icon
-            className="w-5 h-5 sm:w-6 sm:h-6 text-white"
-            strokeWidth={2.25}
-          />
-        </div>
-
-        <div className="flex-1 min-w-0">
-          <div className="flex items-center gap-2 flex-wrap">
-            <span className="text-[11px] sm:text-xs uppercase font-bold tracking-wider text-slate-400">
-              {config.label}
-            </span>
-            {isCompleted && (
-              <span className="inline-flex items-center gap-1 text-[11px] sm:text-xs font-semibold text-emerald-600 bg-emerald-50 px-2 py-0.5 rounded-full">
-                <CheckCircle2 className="w-3 h-3" strokeWidth={2.5} />
-                Completed
-              </span>
-            )}
-          </div>
-          <p className="mt-0.5 text-sm sm:text-base font-bold text-slate-800 truncate">
-            {assignment.title}
-          </p>
-        </div>
-
-        <span
-          className="hidden sm:inline-flex items-center px-3 py-1.5 rounded-lg bg-brand-blue-primary text-white text-xs font-semibold shadow-sm shadow-brand-blue-primary/20 group-hover:bg-brand-blue-dark transition shrink-0"
-          aria-hidden="true"
-        >
-          Open
-        </span>
-      </div>
-    </a>
   );
 };
 

--- a/components/student/StudentClassView.tsx
+++ b/components/student/StudentClassView.tsx
@@ -1,0 +1,93 @@
+import React from 'react';
+import {
+  AssignmentFilterTabs,
+  type AssignmentFilterMode,
+} from './AssignmentFilterTabs';
+import { AssignmentSections } from './AssignmentSections';
+import { getClassColor } from '@/utils/studentClassColors';
+import type { AssignmentSummary } from '@/hooks/useStudentAssignments';
+import type { ClassDirectoryEntry } from '@/hooks/useStudentClassDirectory';
+import type { CompletionState } from './AssignmentListItem';
+
+interface StudentClassViewProps {
+  classId: string;
+  classEntry: ClassDirectoryEntry | undefined;
+  todayDate: string;
+  active: AssignmentSummary[];
+  completed: AssignmentSummary[];
+  filterMode: AssignmentFilterMode;
+  onFilterChange: (mode: AssignmentFilterMode) => void;
+  pseudonymUid: string | null;
+  directoryById: Record<string, ClassDirectoryEntry>;
+  onCompletionResolved: (
+    sessionId: string,
+    kind: AssignmentSummary['kind'],
+    completion: CompletionState
+  ) => void;
+}
+
+export const StudentClassView: React.FC<StudentClassViewProps> = ({
+  classId,
+  classEntry,
+  todayDate,
+  active,
+  completed,
+  filterMode,
+  onFilterChange,
+  pseudonymUid,
+  directoryById,
+  onCompletionResolved,
+}) => {
+  const color = getClassColor(classId);
+  const className = classEntry?.name ?? 'Class';
+  const subject = classEntry?.subject;
+  const teacher = classEntry?.teacherDisplayName;
+  const code = classEntry?.code;
+
+  const subtitleBits = [subject, teacher, code].filter(
+    (b): b is string => Boolean(b) && typeof b === 'string'
+  );
+  const subtitle = subtitleBits.length > 0 ? subtitleBits.join(' · ') : null;
+
+  return (
+    <div className="flex flex-col gap-6">
+      <header className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between sm:gap-6">
+        <div className="flex items-start gap-3">
+          <span
+            aria-hidden="true"
+            className="mt-1.5 h-7 w-1 shrink-0 rounded-full sm:mt-2"
+            style={{ background: color.bar }}
+          />
+          <div>
+            <h1 className="text-2xl font-bold tracking-tight text-slate-900 sm:text-3xl">
+              {className}
+            </h1>
+            {subtitle && (
+              <p className="mt-1 text-sm text-slate-500">{subtitle}</p>
+            )}
+            <p className="mt-0.5 text-xs text-slate-400">{todayDate}</p>
+          </div>
+        </div>
+        <AssignmentFilterTabs
+          value={filterMode}
+          onChange={onFilterChange}
+          counts={{
+            all: active.length + completed.length,
+            active: active.length,
+            completed: completed.length,
+          }}
+        />
+      </header>
+
+      <AssignmentSections
+        mode={filterMode}
+        active={active}
+        completed={completed}
+        pseudonymUid={pseudonymUid}
+        directoryById={directoryById}
+        hideClassName
+        onCompletionResolved={onCompletionResolved}
+      />
+    </div>
+  );
+};

--- a/components/student/StudentLoginPage.tsx
+++ b/components/student/StudentLoginPage.tsx
@@ -4,15 +4,22 @@ import { httpsCallable, FunctionsError } from 'firebase/functions';
 import { Loader2, GraduationCap, AlertCircle, Inbox } from 'lucide-react';
 import { auth, functions } from '@/config/firebase';
 import { APP_NAME } from '@/config/constants';
+import { STUDENT_FIRST_NAME_KEY } from '@/context/StudentAuthContextValue';
 
 /**
  * Student login page (Phase 2A of the ClassLink-via-Google auth flow).
  *
- * This page is intentionally PII-free on the client:
- *   - We never render, log, or persist the student's email, name, or `sub`.
- *   - The Google ID token is passed directly to `studentLoginV1` and discarded.
+ * This page is intentionally Firestore-PII-free:
+ *   - We never log or persist the student's email or `sub` — anywhere.
+ *   - The Google ID token is passed to `studentLoginV1` and discarded.
  *   - Firebase Auth only ever sees the minted custom token, which contains an
  *     opaque pseudonym UID.
+ *
+ * The one personalization we keep: extracting the student's first name from
+ * the ID token at sign-in time and parking it in tab-scoped `sessionStorage`
+ * for the sidebar greeting on `/my-assignments`. The name never leaves the
+ * tab — never written to Firestore, never sent to any server we own, and
+ * cleared on `signOut()` (see `StudentAuthContext`).
  *
  * We use Google Identity Services (GIS) directly — NOT
  * `signInWithPopup(googleProvider)` — because the built-in provider writes
@@ -71,6 +78,64 @@ declare global {
     };
   }
 }
+
+// ---------------------------------------------------------------------------
+// Decode the student's first name from the Google ID token. The token's
+// signature has already been verified by GIS (the SDK rejects tampered
+// tokens before invoking our callback). We parse the payload purely to
+// read `given_name` (preferred) or fall back to the first word of `name`.
+//
+// The result is stored in tab-scoped `sessionStorage` and is the *only*
+// piece of student PII that ever survives the verifying step. It's
+// cleared on `signOut()` and never written to Firestore.
+// ---------------------------------------------------------------------------
+
+const base64UrlDecode = (input: string): string => {
+  const base64 = input.replace(/-/g, '+').replace(/_/g, '/');
+  const pad = base64.length % 4 === 0 ? 0 : 4 - (base64.length % 4);
+  // `atob` interprets the decoded bytes as Latin-1, which garbles any
+  // non-ASCII glyph in the JWT payload (accented student names, non-Latin
+  // scripts). Pipe through TextDecoder so the JSON parses as UTF-8.
+  const binary = atob(base64 + '='.repeat(pad));
+  const bytes = Uint8Array.from(binary, (c) => c.charCodeAt(0));
+  return new TextDecoder().decode(bytes);
+};
+
+const extractFirstNameFromIdToken = (idToken: string): string | null => {
+  try {
+    const parts = idToken.split('.');
+    if (parts.length !== 3) return null;
+    const json = base64UrlDecode(parts[1]);
+    const payload = JSON.parse(json) as Record<string, unknown>;
+    const givenName =
+      typeof payload.given_name === 'string' ? payload.given_name.trim() : '';
+    if (givenName.length > 0) return givenName;
+    const fullName =
+      typeof payload.name === 'string' ? payload.name.trim() : '';
+    if (fullName.length > 0) {
+      const first = fullName.split(/\s+/)[0];
+      if (first && first.length > 0) return first;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+};
+
+const persistFirstName = (idToken: string): void => {
+  if (typeof window === 'undefined') return;
+  const first = extractFirstNameFromIdToken(idToken);
+  try {
+    if (first && first.length > 0 && first.length <= 60) {
+      window.sessionStorage.setItem(STUDENT_FIRST_NAME_KEY, first);
+    } else {
+      window.sessionStorage.removeItem(STUDENT_FIRST_NAME_KEY);
+    }
+  } catch {
+    // Privacy mode / disabled storage — non-fatal. Footer falls back to
+    // the generic "Signed in" copy.
+  }
+};
 
 // ---------------------------------------------------------------------------
 // Response + error-code shapes for the studentLoginV1 callable.
@@ -209,6 +274,11 @@ const StudentLoginPage: React.FC = () => {
           setStatus({ kind: 'error', error: 'generic' });
           return;
         }
+
+        // Capture the first name into tab-scoped sessionStorage BEFORE
+        // we drop the ID token. Cleared on signOut(); never sent to
+        // Firestore. See class-doc at top of file.
+        persistFirstName(response.credential);
 
         await signInWithCustomToken(auth, customToken);
         setStatus({ kind: 'success' });

--- a/components/student/StudentOverview.tsx
+++ b/components/student/StudentOverview.tsx
@@ -1,0 +1,86 @@
+import React from 'react';
+import {
+  AssignmentFilterTabs,
+  type AssignmentFilterMode,
+} from './AssignmentFilterTabs';
+import { AssignmentSections } from './AssignmentSections';
+import type { AssignmentSummary } from '@/hooks/useStudentAssignments';
+import type { ClassDirectoryEntry } from '@/hooks/useStudentClassDirectory';
+import type { CompletionState } from './AssignmentListItem';
+
+interface StudentOverviewProps {
+  todayDate: string;
+  active: AssignmentSummary[];
+  completed: AssignmentSummary[];
+  filterMode: AssignmentFilterMode;
+  onFilterChange: (mode: AssignmentFilterMode) => void;
+  pseudonymUid: string | null;
+  directoryById: Record<string, ClassDirectoryEntry>;
+  onCompletionResolved: (
+    sessionId: string,
+    kind: AssignmentSummary['kind'],
+    completion: CompletionState
+  ) => void;
+}
+
+export const StudentOverview: React.FC<StudentOverviewProps> = ({
+  todayDate,
+  active,
+  completed,
+  filterMode,
+  onFilterChange,
+  pseudonymUid,
+  directoryById,
+  onCompletionResolved,
+}) => {
+  const total = active.length + completed.length;
+  const dueToday = active.length;
+  return (
+    <div className="flex flex-col gap-6">
+      <header className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between sm:gap-6">
+        <div>
+          <h1 className="text-2xl font-bold tracking-tight text-brand-blue-dark sm:text-3xl">
+            Today
+          </h1>
+          <p className="mt-1 text-sm text-slate-500">
+            {todayDate}
+            {dueToday > 0 && (
+              <>
+                <span className="px-1.5 text-slate-300">·</span>
+                <span>
+                  {dueToday} {dueToday === 1 ? 'thing' : 'things'} due today
+                </span>
+              </>
+            )}
+          </p>
+        </div>
+        <AssignmentFilterTabs
+          value={filterMode}
+          onChange={onFilterChange}
+          counts={{
+            all: total,
+            active: active.length,
+            completed: completed.length,
+          }}
+        />
+      </header>
+
+      {total > 0 && (
+        <p className="text-base font-medium text-slate-700">
+          {dueToday > 0
+            ? `You have ${dueToday} ${dueToday === 1 ? 'thing' : 'things'} due today. Pick a class on the left to see what's posted.`
+            : "Nothing due today. Pick a class on the left to see what's posted."}
+        </p>
+      )}
+
+      <AssignmentSections
+        mode={filterMode}
+        active={active}
+        completed={completed}
+        pseudonymUid={pseudonymUid}
+        directoryById={directoryById}
+        onCompletionResolved={onCompletionResolved}
+      />
+    </div>
+  );
+};

--- a/components/student/StudentSidebar.tsx
+++ b/components/student/StudentSidebar.tsx
@@ -1,0 +1,194 @@
+import React from 'react';
+import { GraduationCap, LayoutGrid, LogOut } from 'lucide-react';
+import { getClassColor } from '@/utils/studentClassColors';
+import type { ClassDirectoryEntry } from '@/hooks/useStudentClassDirectory';
+
+interface StudentSidebarProps {
+  classes: ClassDirectoryEntry[];
+  /** classIds the student has in claims — used to render fallbacks for any
+   *  ids the directory didn't resolve, so the sidebar never silently
+   *  drops a class. */
+  claimedClassIds: readonly string[];
+  activeClassId: string | null;
+  /** Active assignment counts per classId. Each value is the number of
+   *  *currently active* (not yet completed) assignments for that class. */
+  activeCountByClassId: Record<string, number>;
+  totalActiveCount: number;
+  onSelect: (classId: string | null) => void;
+  /** Sign-out handler. Renders the profile-style footer when provided. */
+  onSignOut?: () => void;
+  /**
+   * Student's first name from the Google ID token at sign-in. Tab-scoped,
+   * never written to Firestore. When `null`, the footer falls back to a
+   * generic "Signed in" greeting.
+   */
+  firstName?: string | null;
+  /** Total count of claim-bound classes. Shown in the footer meta line. */
+  classCount?: number;
+}
+
+export const StudentSidebar: React.FC<StudentSidebarProps> = ({
+  classes,
+  claimedClassIds,
+  activeClassId,
+  activeCountByClassId,
+  totalActiveCount,
+  onSelect,
+  onSignOut,
+  firstName,
+  classCount,
+}) => {
+  // Render in the order the directory returned, then any unresolved claim
+  // ids at the end so a slow-loading directory never hides a class.
+  const resolvedIds = new Set(classes.map((c) => c.classId));
+  const fallbackIds = claimedClassIds.filter((id) => !resolvedIds.has(id));
+  const fallbackEntries: ClassDirectoryEntry[] = fallbackIds.map((id) => ({
+    classId: id,
+    name: 'Class',
+    teacherDisplayName: '',
+  }));
+  const allEntries = [...classes, ...fallbackEntries];
+
+  return (
+    <div className="flex h-full w-full flex-col gap-3 overflow-y-auto border-r border-slate-200 bg-white/95 px-3 py-5 backdrop-blur-sm md:gap-4 md:bg-white/85 md:px-3.5 md:py-6">
+      <div className="flex flex-1 flex-col">
+        <div className="px-2 pb-1.5 text-[11px] font-bold uppercase tracking-[0.14em] text-slate-400">
+          My classes
+        </div>
+        <ul className="flex flex-col gap-0.5">
+          <li>
+            <ClassButton
+              isActive={activeClassId === null}
+              barColor="#1D2A5D"
+              title="All classes"
+              meta="Today's overview"
+              count={totalActiveCount}
+              icon={<LayoutGrid className="h-4 w-4" strokeWidth={2.25} />}
+              onClick={() => onSelect(null)}
+            />
+          </li>
+          {allEntries.map((c) => {
+            const color = getClassColor(c.classId);
+            const meta = c.teacherDisplayName
+              ? c.subject
+                ? `${c.subject} · ${c.teacherDisplayName}`
+                : c.teacherDisplayName
+              : (c.subject ?? c.code ?? ' ');
+            return (
+              <li key={c.classId}>
+                <ClassButton
+                  isActive={activeClassId === c.classId}
+                  barColor={color.bar}
+                  title={c.name}
+                  meta={meta}
+                  count={activeCountByClassId[c.classId] ?? 0}
+                  onClick={() => onSelect(c.classId)}
+                />
+              </li>
+            );
+          })}
+        </ul>
+      </div>
+
+      {onSignOut && (
+        <div className="mt-auto flex items-center gap-3 border-t border-slate-200 px-2 pt-3">
+          <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-brand-blue-primary/10 text-brand-blue-primary">
+            {firstName ? (
+              <span className="text-xs font-bold uppercase">
+                {firstName.charAt(0)}
+              </span>
+            ) : (
+              <GraduationCap className="h-4 w-4" strokeWidth={2.25} />
+            )}
+          </div>
+          <div className="min-w-0 flex-1">
+            <div className="truncate text-sm font-semibold text-slate-700">
+              {firstName ? `Hi, ${firstName}` : 'Signed in'}
+            </div>
+            {typeof classCount === 'number' && classCount > 0 && (
+              <div className="truncate text-[11px] text-slate-500">
+                {classCount} {classCount === 1 ? 'class' : 'classes'}
+              </div>
+            )}
+          </div>
+          <button
+            type="button"
+            onClick={onSignOut}
+            aria-label="Sign out"
+            className="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-lg border border-slate-200 bg-white text-slate-600 transition hover:border-slate-300 hover:bg-slate-50 hover:text-slate-800 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue-primary focus-visible:ring-offset-1"
+          >
+            <LogOut className="h-4 w-4" strokeWidth={2.25} />
+          </button>
+        </div>
+      )}
+    </div>
+  );
+};
+
+interface ClassButtonProps {
+  isActive: boolean;
+  barColor: string;
+  title: string;
+  meta: string;
+  count: number;
+  icon?: React.ReactNode;
+  onClick: () => void;
+}
+
+const ClassButton: React.FC<ClassButtonProps> = ({
+  isActive,
+  barColor,
+  title,
+  meta,
+  count,
+  icon,
+  onClick,
+}) => (
+  <button
+    type="button"
+    onClick={onClick}
+    className={`group flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-left transition focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue-primary focus-visible:ring-offset-1 ${
+      isActive
+        ? 'bg-white shadow-sm ring-1 ring-slate-200'
+        : 'hover:bg-slate-100/80'
+    }`}
+  >
+    <span
+      aria-hidden="true"
+      className="h-9 w-1 shrink-0 rounded-full"
+      style={{ background: barColor }}
+    />
+    {icon && (
+      <span
+        aria-hidden="true"
+        className="text-slate-400 group-hover:text-slate-600"
+      >
+        {icon}
+      </span>
+    )}
+    <span className="min-w-0 flex-1">
+      <span
+        className={`block truncate text-sm font-semibold leading-tight ${
+          isActive ? 'text-slate-900' : 'text-slate-700'
+        }`}
+      >
+        {title}
+      </span>
+      <span className="mt-0.5 block truncate text-[11px] text-slate-500">
+        {meta}
+      </span>
+    </span>
+    {count > 0 && (
+      <span
+        aria-label={`${count} active`}
+        className={`shrink-0 rounded-full px-1.5 py-0.5 text-[11px] font-semibold tabular-nums ${
+          isActive
+            ? 'bg-brand-blue-primary text-white'
+            : 'bg-slate-100 text-slate-500'
+        }`}
+      >
+        {count}
+      </span>
+    )}
+  </button>
+);

--- a/components/widgets/GuidedLearning/components/GuidedLearningResults.tsx
+++ b/components/widgets/GuidedLearning/components/GuidedLearningResults.tsx
@@ -18,6 +18,7 @@ import {
   useAssignmentPseudonyms,
   formatStudentName,
 } from '@/hooks/useAssignmentPseudonyms';
+import { useAuth } from '@/context/useAuth';
 
 interface Props {
   set: GuidedLearningSet;
@@ -64,7 +65,8 @@ export const GuidedLearningResults: React.FC<Props> = ({
     };
   }, [sessionId]);
 
-  const { byStudentUid } = useAssignmentPseudonyms(sessionId, classId);
+  const { orgId } = useAuth();
+  const { byStudentUid } = useAssignmentPseudonyms(sessionId, classId, orgId);
 
   const {
     questionSteps,

--- a/components/widgets/MiniApp/components/SubmissionsModal.tsx
+++ b/components/widgets/MiniApp/components/SubmissionsModal.tsx
@@ -22,6 +22,7 @@ import {
   useAssignmentPseudonymsMulti,
   formatStudentName,
 } from '@/hooks/useAssignmentPseudonyms';
+import { useAuth } from '@/context/useAuth';
 
 interface SubmissionRow {
   id: string;
@@ -42,9 +43,11 @@ export const SubmissionsModal: React.FC<SubmissionsModalProps> = ({
   classIds,
   onClose,
 }) => {
+  const { orgId } = useAuth();
   const { byAssignmentPseudonym } = useAssignmentPseudonymsMulti(
     sessionId,
-    classIds ?? null
+    classIds ?? null,
+    orgId
   );
   const [submissions, setSubmissions] = useState<SubmissionRow[]>([]);
   const [loading, setLoading] = useState(true);

--- a/components/widgets/QuizWidget/Widget.tsx
+++ b/components/widgets/QuizWidget/Widget.tsx
@@ -47,7 +47,7 @@ import { getPlcTeammateEmails } from '@/utils/plc';
 export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
   const { updateWidget, addWidget, addToast, rosters, activeDashboard } =
     useDashboard();
-  const { user, googleAccessToken } = useAuth();
+  const { user, googleAccessToken, orgId } = useAuth();
   const { showConfirm } = useDialog();
   const config = widget.config as QuizConfig;
 
@@ -217,7 +217,8 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
         : [];
   const { byStudentUid } = useAssignmentPseudonymsMulti(
     liveSession?.id ?? null,
-    liveClassIds
+    liveClassIds,
+    orgId
   );
   const byStudentUidRef = useRef(byStudentUid);
   byStudentUidRef.current = byStudentUid;

--- a/components/widgets/QuizWidget/Widget.tsx
+++ b/components/widgets/QuizWidget/Widget.tsx
@@ -30,6 +30,12 @@ import {
   getEarnedPoints,
   isGamificationActive,
 } from './utils/quizScoreboard';
+import {
+  resolveResponseDisplayName,
+  responseTeamId,
+  responseColorIndex,
+} from './utils/resolveDisplayName';
+import { useAssignmentPseudonymsMulti } from '@/hooks/useAssignmentPseudonyms';
 import { QuizLiveMonitor } from './components/QuizLiveMonitor';
 import { Loader2, AlertTriangle, LogIn } from 'lucide-react';
 import { SCOREBOARD_COLORS } from '@/config/scoreboard';
@@ -199,6 +205,23 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
   const widgetsRef = useRef(activeDashboard?.widgets);
   widgetsRef.current = activeDashboard?.widgets;
 
+  // ClassLink name lookup for SSO `studentRole` joiners. The live scoreboard
+  // sync below runs inside a debounced callback that captures the latest
+  // map via `byStudentUidRef`, so name resolution stays current without
+  // having to make `byStudentUid` a sync trigger.
+  const liveClassIds =
+    liveSession?.classIds && liveSession.classIds.length > 0
+      ? liveSession.classIds
+      : liveSession?.classId
+        ? [liveSession.classId]
+        : [];
+  const { byStudentUid } = useAssignmentPseudonymsMulti(
+    liveSession?.id ?? null,
+    liveClassIds
+  );
+  const byStudentUidRef = useRef(byStudentUid);
+  byStudentUidRef.current = byStudentUid;
+
   // ─── Callback for child components to update quiz config ────────────────────
   const handleUpdateQuizConfig = useCallback(
     (updates: Partial<QuizConfig>) => {
@@ -217,11 +240,13 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
     }
 
     // Compute a fingerprint including answer content to detect changes.
-    // First-run detection uses the empty-prev check below.
+    // First-run detection uses the empty-prev check below. Use studentUid
+    // as the row identity since SSO joiners have no `pin` — anonymous
+    // joiners' studentUid is their (stable) anon Firebase Auth uid.
     const fingerprint = responses
       .map(
         (r) =>
-          `${r.pin}:${r.status}:${r.answers.map((a) => `${a.questionId}=${a.answer}@${a.answeredAt ?? 0}+${a.speedBonus ?? 0}`).join(',')}`
+          `${r.studentUid}:${r.status}:${r.answers.map((a) => `${a.questionId}=${a.answer}@${a.answeredAt ?? 0}+${a.speedBonus ?? 0}`).join(',')}`
       )
       .sort()
       .join('|');
@@ -260,6 +285,12 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
           // by total points and would show low percentages for students mid-quiz.
           const questions = loadedQuizData.questions;
           const gamified = isGamificationActive(liveSession);
+          // SSO `studentRole` rows have no `pin` — fall back to studentUid
+          // for both the team id and the color hash, and pull names from
+          // the ClassLink lookup. `byStudentUidRef.current` is the latest
+          // map, captured here so we don't need to wire it as a debounce
+          // dependency.
+          const ssoNames = byStudentUidRef.current;
           newTeams = allResponses
             .map((r) => {
               let maxAnsweredPoints = 0;
@@ -277,18 +308,25 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
               return { response: r, score };
             })
             .sort((a, b) => b.score - a.score)
-            .map(({ response, score }) => ({
-              id: `pin-${response.pin}`,
-              name:
-                displayMode === 'name'
-                  ? (pinToName[response.pin] ?? `PIN ${response.pin}`)
-                  : `PIN ${response.pin}`,
-              score,
-              color:
-                SCOREBOARD_COLORS[
-                  parseInt(response.pin, 10) % SCOREBOARD_COLORS.length
-                ],
-            }));
+            .map(({ response, score }) => {
+              const resolvedName = resolveResponseDisplayName(
+                response,
+                pinToName,
+                ssoNames
+              );
+              const pinModeName = response.pin
+                ? `PIN ${response.pin}`
+                : resolvedName;
+              return {
+                id: responseTeamId(response),
+                name: displayMode === 'name' ? resolvedName : pinModeName,
+                score,
+                color:
+                  SCOREBOARD_COLORS[
+                    responseColorIndex(response, SCOREBOARD_COLORS.length)
+                  ],
+              };
+            });
         } else {
           // Completion mode: uses total quiz points as denominator, so
           // in-progress students show partial scores proportional to
@@ -298,7 +336,8 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
             loadedQuizData.questions,
             displayMode,
             pinToName,
-            liveSession
+            liveSession,
+            byStudentUidRef.current
           );
         }
 

--- a/components/widgets/QuizWidget/components/QuizLiveMonitor.tsx
+++ b/components/widgets/QuizWidget/components/QuizLiveMonitor.tsx
@@ -57,6 +57,7 @@ import {
 import { resolveResponseDisplayName } from '../utils/resolveDisplayName';
 import { useAssignmentPseudonymsMulti } from '@/hooks/useAssignmentPseudonyms';
 import { db } from '@/config/firebase';
+import { useAuth } from '@/context/useAuth';
 import { useDialog } from '@/context/useDialog';
 import { useClickOutside } from '@/hooks/useClickOutside';
 import {
@@ -266,6 +267,7 @@ export const QuizLiveMonitor: React.FC<QuizLiveMonitorProps> = ({
   onBack,
 }) => {
   const { showConfirm } = useDialog();
+  const { orgId } = useAuth();
   const pinToName = useMemo(
     () =>
       buildPinToNameMap(
@@ -286,7 +288,8 @@ export const QuizLiveMonitor: React.FC<QuizLiveMonitorProps> = ({
   }, [session.classIds, session.classId]);
   const { byStudentUid } = useAssignmentPseudonymsMulti(
     session.id,
-    sessionClassIds
+    sessionClassIds,
+    orgId
   );
   const scoringConfig = useMemo(
     () => ({

--- a/components/widgets/QuizWidget/components/QuizLiveMonitor.tsx
+++ b/components/widgets/QuizWidget/components/QuizLiveMonitor.tsx
@@ -54,6 +54,8 @@ import {
   getScoreSuffix,
   isGamificationActive,
 } from '../utils/quizScoreboard';
+import { resolveResponseDisplayName } from '../utils/resolveDisplayName';
+import { useAssignmentPseudonymsMulti } from '@/hooks/useAssignmentPseudonyms';
 import { db } from '@/config/firebase';
 import { useDialog } from '@/context/useDialog';
 import { useClickOutside } from '@/hooks/useClickOutside';
@@ -272,6 +274,20 @@ export const QuizLiveMonitor: React.FC<QuizLiveMonitorProps> = ({
       ),
     [rosters, config.periodNames, config.periodName]
   );
+  // ClassLink name resolution for SSO `studentRole` joiners. Empty for
+  // legacy code+PIN-only sessions (`classIds` and `classId` both unset);
+  // pinToName handles those rows. Use the multi variant so Phase 5A
+  // multi-class quizzes resolve names from any targeted class, not just
+  // the legacy `classIds[0]` shadowed onto `classId`.
+  const sessionClassIds = useMemo(() => {
+    if (session.classIds && session.classIds.length > 0)
+      return session.classIds;
+    return session.classId ? [session.classId] : [];
+  }, [session.classIds, session.classId]);
+  const { byStudentUid } = useAssignmentPseudonymsMulti(
+    session.id,
+    sessionClassIds
+  );
   const scoringConfig = useMemo(
     () => ({
       speedBonusEnabled: session.speedBonusEnabled,
@@ -356,7 +372,8 @@ export const QuizLiveMonitor: React.FC<QuizLiveMonitorProps> = ({
         responses,
         quizData.questions,
         scoringConfig,
-        pinToName
+        pinToName,
+        byStudentUid
       );
 
       const fingerprint = JSON.stringify(entries);
@@ -376,6 +393,7 @@ export const QuizLiveMonitor: React.FC<QuizLiveMonitorProps> = ({
     responses,
     quizData.questions,
     pinToName,
+    byStudentUid,
     session.id,
     session.status,
     scoringConfig,
@@ -523,25 +541,32 @@ export const QuizLiveMonitor: React.FC<QuizLiveMonitorProps> = ({
       let _inProgress = 0;
       let _joined = 0;
       const byStatus: {
-        joined: { pin: string; name: string }[];
-        active: { pin: string; name: string }[];
-        finished: { pin: string; name: string }[];
+        joined: StatBoxStudent[];
+        active: StatBoxStudent[];
+        finished: StatBoxStudent[];
       } = { joined: [], active: [], finished: [] };
 
       for (const r of responses) {
         if (currentQ && r.answers.some((a) => a.questionId === currentQ.id)) {
           _answered++;
         }
-        const name = pinToName[r.pin] ?? `PIN ${r.pin}`;
+        const name = resolveResponseDisplayName(r, pinToName, byStudentUid);
+        // SSO joiners have no PIN — key the stat-row by studentUid so React
+        // gets a stable, unique key. Either side guarantees uniqueness
+        // within a session.
+        const row: StatBoxStudent = {
+          key: r.pin ?? r.studentUid,
+          name,
+        };
         if (r.status === 'completed') {
           _completed++;
-          byStatus.finished.push({ pin: r.pin, name });
+          byStatus.finished.push(row);
         } else if (r.status === 'in-progress') {
           _inProgress++;
-          byStatus.active.push({ pin: r.pin, name });
+          byStatus.active.push(row);
         } else if (r.status === 'joined') {
           _joined++;
-          byStatus.joined.push({ pin: r.pin, name });
+          byStatus.joined.push(row);
         }
       }
 
@@ -552,7 +577,7 @@ export const QuizLiveMonitor: React.FC<QuizLiveMonitorProps> = ({
         joined: _joined,
         studentsByStatus: byStatus,
       };
-    }, [responses, currentQ, pinToName]);
+    }, [responses, currentQ, pinToName, byStudentUid]);
 
   const modeIcon =
     session.sessionMode === 'auto' ? (
@@ -986,6 +1011,7 @@ export const QuizLiveMonitor: React.FC<QuizLiveMonitorProps> = ({
                   questions={quizData.questions}
                   session={session}
                   pinToName={pinToName}
+                  byStudentUid={byStudentUid}
                   onDismiss={() => {
                     /* persists until teacher clicks advance */
                   }}
@@ -1293,7 +1319,9 @@ export const QuizLiveMonitor: React.FC<QuizLiveMonitorProps> = ({
                     >
                       {responses
                         .slice()
-                        .sort((a, b) => a.pin.localeCompare(b.pin))
+                        .sort((a, b) =>
+                          (a.pin ?? '').localeCompare(b.pin ?? '')
+                        )
                         .map((r) => (
                           <StudentRow
                             key={r.studentUid}
@@ -1326,6 +1354,7 @@ export const QuizLiveMonitor: React.FC<QuizLiveMonitorProps> = ({
                                 : undefined
                             }
                             pinToName={pinToName}
+                            byStudentUid={byStudentUid}
                           />
                         ))}
                     </div>
@@ -1671,7 +1700,9 @@ export const QuizLiveMonitor: React.FC<QuizLiveMonitorProps> = ({
                     >
                       {responses
                         .slice()
-                        .sort((a, b) => a.pin.localeCompare(b.pin))
+                        .sort((a, b) =>
+                          (a.pin ?? '').localeCompare(b.pin ?? '')
+                        )
                         .map((r) => (
                           <StudentRow
                             key={r.studentUid}
@@ -1704,6 +1735,7 @@ export const QuizLiveMonitor: React.FC<QuizLiveMonitorProps> = ({
                                 : undefined
                             }
                             pinToName={pinToName}
+                            byStudentUid={byStudentUid}
                           />
                         ))}
                     </div>
@@ -1815,6 +1847,16 @@ const StatBox: React.FC<{
   );
 };
 
+/**
+ * Row shape passed to `InteractiveStatBox`. `key` is whatever uniquely
+ * identifies the student within the session — `pin` for anonymous joiners,
+ * `studentUid` for SSO joiners.
+ */
+interface StatBoxStudent {
+  key: string;
+  name: string;
+}
+
 const InteractiveStatBox: React.FC<{
   label: string;
   value: number;
@@ -1822,7 +1864,7 @@ const InteractiveStatBox: React.FC<{
   color: 'blue' | 'amber' | 'green';
   expanded: boolean;
   onToggle: () => void;
-  students: { pin: string; name: string }[];
+  students: StatBoxStudent[];
 }> = ({ label, value, icon, color, expanded, onToggle, students }) => {
   const themes = {
     blue: 'bg-brand-blue-lighter border-brand-blue-primary/10 text-brand-blue-primary',
@@ -1880,7 +1922,7 @@ const InteractiveStatBox: React.FC<{
         >
           {students.map((s) => (
             <p
-              key={s.pin}
+              key={s.key}
               className="truncate font-bold"
               style={{
                 fontSize: 'min(10px, 2.8cqmin)',
@@ -1907,6 +1949,10 @@ const StudentRow: React.FC<{
   onConfirmRemoveToggle: () => void;
   onRemove?: () => void;
   pinToName: Record<string, string>;
+  byStudentUid?: Map<
+    string,
+    import('@/hooks/useAssignmentPseudonyms').StudentName
+  >;
 }> = ({
   response,
   totalQuestions,
@@ -1918,6 +1964,7 @@ const StudentRow: React.FC<{
   onConfirmRemoveToggle,
   onRemove,
   pinToName,
+  byStudentUid,
 }) => {
   const warnings = response.tabSwitchWarnings ?? 0;
 
@@ -1960,9 +2007,11 @@ const StudentRow: React.FC<{
     joined: 'text-brand-gray-primary font-medium',
   };
 
-  const displayName = pinToName[response.pin]
-    ? pinToName[response.pin]
-    : `PIN ${response.pin}`;
+  const displayName = resolveResponseDisplayName(
+    response,
+    pinToName,
+    byStudentUid
+  );
 
   if (confirmRemove) {
     return (
@@ -2019,7 +2068,16 @@ const StudentRow: React.FC<{
         className="flex-1 flex items-center gap-1.5 text-brand-blue-dark font-bold truncate"
         style={{ fontSize: 'min(12px, 3.5cqmin)' }}
       >
-        <span className={pinToName[response.pin] ? '' : 'font-mono'}>
+        <span
+          className={
+            // Use the mono face only when we're rendering a literal `PIN <num>`
+            // fallback (no roster or ClassLink name resolved) — names should
+            // render in the regular sans face.
+            response.pin && displayName === `PIN ${response.pin}`
+              ? 'font-mono'
+              : ''
+          }
+        >
           {displayName}
         </span>
 
@@ -2075,15 +2133,27 @@ const PodiumView: React.FC<{
   questions: QuizQuestion[];
   session: QuizSession;
   pinToName: Record<string, string>;
+  byStudentUid?: Map<
+    string,
+    import('@/hooks/useAssignmentPseudonyms').StudentName
+  >;
   onDismiss: () => void;
-}> = ({ responses, questions, session, pinToName, onDismiss }) => {
+}> = ({
+  responses,
+  questions,
+  session,
+  pinToName,
+  byStudentUid,
+  onDismiss,
+}) => {
   // Use shared scoring utility for consistency with scoreboard
   const suffix = getScoreSuffix(session);
   const scored = responses
     .map((r) => {
       const score = getDisplayScore(r, questions, session);
-      const name = pinToName[r.pin] ?? `PIN ${r.pin}`;
-      return { name, score, pin: r.pin };
+      const name = resolveResponseDisplayName(r, pinToName, byStudentUid);
+      // `key` disambiguates rows for React: PIN for anonymous, uid for SSO.
+      return { name, score, key: r.pin ?? r.studentUid };
     })
     .sort((a, b) => b.score - a.score);
 
@@ -2130,7 +2200,7 @@ const PodiumView: React.FC<{
       <div className="flex flex-col" style={{ gap: 'min(6px, 1.5cqmin)' }}>
         {top3.map((entry, i) => (
           <div
-            key={entry.pin}
+            key={entry.key}
             className="flex items-center bg-slate-50 border border-slate-100 rounded-xl"
             style={{
               gap: 'min(10px, 2.5cqmin)',

--- a/components/widgets/QuizWidget/components/QuizResults.tsx
+++ b/components/widgets/QuizWidget/components/QuizResults.tsx
@@ -102,7 +102,7 @@ export const QuizResults: React.FC<QuizResultsProps> = ({
 }) => {
   const { activeDashboard, updateWidget, addWidget, addToast, rosters } =
     useDashboard();
-  const { googleAccessToken, user } = useAuth();
+  const { googleAccessToken, user, orgId } = useAuth();
   const { plcs, clearPlcSharedSheetUrl, setPlcSharedSheetUrl } = usePlcs();
   const [exporting, setExporting] = useState(false);
   const [exportUrl, setExportUrl] = useState<string | null>(
@@ -158,7 +158,8 @@ export const QuizResults: React.FC<QuizResultsProps> = ({
   // maps are empty and pinToName handles display.
   const { byStudentUid } = useAssignmentPseudonyms(
     session?.id ?? null,
-    session?.classId ?? null
+    session?.classId ?? null,
+    orgId
   );
   const exportPinToName = useMemo(
     () => buildPinToExportNameMap(rosters, resolvedPeriods),

--- a/components/widgets/QuizWidget/components/QuizResults.tsx
+++ b/components/widgets/QuizWidget/components/QuizResults.tsx
@@ -49,11 +49,9 @@ import {
   getEarnedPoints,
   isGamificationActive,
 } from '../utils/quizScoreboard';
+import { resolveResponseDisplayName } from '../utils/resolveDisplayName';
 import { useClickOutside } from '@/hooks/useClickOutside';
-import {
-  useAssignmentPseudonyms,
-  formatStudentName,
-} from '@/hooks/useAssignmentPseudonyms';
+import { useAssignmentPseudonyms } from '@/hooks/useAssignmentPseudonyms';
 
 interface QuizResultsProps {
   quiz: QuizData;
@@ -213,7 +211,8 @@ export const QuizResults: React.FC<QuizResultsProps> = ({
         quiz.questions,
         mode,
         pinToName,
-        session
+        session,
+        byStudentUid
       );
 
       const existingScoreboard = activeDashboard?.widgets.find(
@@ -247,6 +246,7 @@ export const QuizResults: React.FC<QuizResultsProps> = ({
       completed,
       quiz.questions,
       pinToName,
+      byStudentUid,
       session,
       activeDashboard?.widgets,
       updateWidget,
@@ -280,6 +280,7 @@ export const QuizResults: React.FC<QuizResultsProps> = ({
       const svc = new QuizDriveService(googleAccessToken);
       const exportOpts = {
         pinToName: exportPinToName,
+        byStudentUid,
         teacherName: config.teacherName,
         periodName: config.periodName,
         plcMode: config.plcMode,
@@ -1021,12 +1022,16 @@ const StudentsTab: React.FC<{
             const earned = getEarnedPoints(r, questions, session);
             const warnings = r.tabSwitchWarnings ?? 0;
 
-            const classLinkName = formatStudentName(
-              byStudentUid.get(r.studentUid)
+            const displayName = resolveResponseDisplayName(
+              r,
+              pinToName,
+              byStudentUid
             );
-            const rosterName = pinToName[r.pin];
-            const displayName = classLinkName || rosterName || `PIN ${r.pin}`;
-            const isResolved = Boolean(classLinkName || rosterName);
+            // Mono face is reserved for the literal `PIN <num>` fallback —
+            // anything else (real name, ClassLink name, or the "Student"
+            // SSO fallback) renders in the regular sans face. Mirrors the
+            // contract used by QuizLiveMonitor's StudentRow.
+            const isResolved = !r.pin || displayName !== `PIN ${r.pin}`;
             const rowKey = getResponseDocKey(r);
             const canDelete = Boolean(onDeleteResponse);
             const isConfirming = confirmDeleteKey === rowKey;

--- a/components/widgets/QuizWidget/utils/quizScoreboard.test.ts
+++ b/components/widgets/QuizWidget/utils/quizScoreboard.test.ts
@@ -665,9 +665,19 @@ describe('quizScoreboard', () => {
         '01': 'Alice',
       });
 
+      // Roster-PIN match resolves to "Alice"; the unmapped row falls back to
+      // its literal `PIN <pin>` label rather than `undefined` so the student-
+      // side leaderboard always has something legible to render.
+      // `studentUid` is now also surfaced so SSO joiners can self-identify.
       expect(entries).toEqual([
-        { pin: '01', name: 'Alice', score: 100, rank: 1 },
-        { pin: '02', name: undefined, score: 0, rank: 2 },
+        { pin: '01', studentUid: 'uid-01', name: 'Alice', score: 100, rank: 1 },
+        {
+          pin: '02',
+          studentUid: 'uid-02',
+          name: 'PIN 02',
+          score: 0,
+          rank: 2,
+        },
       ]);
     });
 

--- a/components/widgets/QuizWidget/utils/quizScoreboard.ts
+++ b/components/widgets/QuizWidget/utils/quizScoreboard.ts
@@ -13,6 +13,12 @@ import {
 } from '@/types';
 import { gradeAnswer } from '@/hooks/useQuizSession';
 import { SCOREBOARD_COLORS } from '@/config/scoreboard';
+import type { StudentName } from '@/hooks/useAssignmentPseudonyms';
+import {
+  resolveResponseDisplayName,
+  responseColorIndex,
+  responseTeamId,
+} from './resolveDisplayName';
 
 type QuizScoringSession =
   | Pick<QuizSession, 'speedBonusEnabled' | 'streakBonusEnabled'>
@@ -195,13 +201,20 @@ export function buildPinToExportNameMap(
 
 /**
  * Build scoreboard teams from quiz responses.
+ *
+ * `byStudentUid` (optional) supplies ClassLink names for SSO `studentRole`
+ * joiners that have no `pin`. When omitted, SSO rows fall back to the
+ * generic `Student` label (see `resolveResponseDisplayName`). For pin-mode
+ * scoreboards SSO rows render their resolved name regardless of mode,
+ * because the literal `PIN undefined` is never useful.
  */
 export function buildScoreboardTeams(
   completedResponses: QuizResponse[],
   questions: QuizQuestion[],
   mode: 'pin' | 'name',
   pinToName: Record<string, string>,
-  session?: QuizSession | null
+  session?: QuizSession | null,
+  byStudentUid?: Map<string, StudentName>
 ): ScoreboardTeam[] {
   return completedResponses
     .map((r) => ({
@@ -209,34 +222,47 @@ export function buildScoreboardTeams(
       score: getDisplayScore(r, questions, session),
     }))
     .sort((a, b) => b.score - a.score)
-    .map(({ response, score }) => ({
-      id: `pin-${response.pin}`,
-      name:
-        mode === 'name'
-          ? (pinToName[response.pin] ?? `PIN ${response.pin}`)
-          : `PIN ${response.pin}`,
-      score,
-      color:
-        SCOREBOARD_COLORS[
-          parseInt(response.pin, 10) % SCOREBOARD_COLORS.length
-        ],
-    }));
+    .map(({ response, score }) => {
+      const resolvedName = resolveResponseDisplayName(
+        response,
+        pinToName,
+        byStudentUid
+      );
+      const pinModeName = response.pin ? `PIN ${response.pin}` : resolvedName;
+      return {
+        id: responseTeamId(response),
+        name: mode === 'name' ? resolvedName : pinModeName,
+        score,
+        color:
+          SCOREBOARD_COLORS[
+            responseColorIndex(response, SCOREBOARD_COLORS.length)
+          ],
+      };
+    });
 }
 
 /**
  * Build ranked leaderboard entries for student-facing live leaderboard views.
+ *
+ * Mirrors `buildScoreboardTeams` for SSO support: `byStudentUid` resolves
+ * names for `studentRole` joiners. The leaderboard's `pin` field stays
+ * optional in the entry type — students see `name` (or `Student` fallback).
  */
 export function buildLiveLeaderboard(
   responses: QuizResponse[],
   questions: QuizQuestion[],
   session: QuizScoringSession,
-  pinToName: Record<string, string>
+  pinToName: Record<string, string>,
+  byStudentUid?: Map<string, StudentName>
 ): QuizLeaderboardEntry[] {
   return responses
     .filter((response) => response.status !== 'joined')
     .map((response) => ({
-      pin: response.pin,
-      name: pinToName[response.pin],
+      // `pin` is set only for anonymous joiners; SSO joiners use `studentUid`
+      // for self-identification on the student-side leaderboard view.
+      ...(response.pin ? { pin: response.pin } : {}),
+      studentUid: response.studentUid,
+      name: resolveResponseDisplayName(response, pinToName, byStudentUid),
       score: getDisplayScore(response, questions, session),
     }))
     .sort((a, b) => b.score - a.score)

--- a/components/widgets/QuizWidget/utils/resolveDisplayName.ts
+++ b/components/widgets/QuizWidget/utils/resolveDisplayName.ts
@@ -1,0 +1,112 @@
+/**
+ * Shared display-name resolution for QuizResponse rows on the teacher side.
+ *
+ * A QuizResponse can come from one of two student auth flows:
+ *   - Anonymous PIN join (the original `/join` and `/quiz?code=…` flow).
+ *     Identity is the teacher-assigned roster PIN; names come from
+ *     `pinToName` built off ClassRosters.
+ *   - SSO `studentRole` join (ClassLink-via-Google, launched from
+ *     `/my-assignments`). The response has no PIN; identity is the auth uid,
+ *     and names come from `byStudentUid` populated by
+ *     `useAssignmentPseudonyms` (`getPseudonymsForAssignmentV1`).
+ *
+ * Resolution priority:
+ *   1. ClassLink name (authoritative for SSO students).
+ *   2. Roster PIN match (teacher-built name list for anonymous students).
+ *   3. Literal `PIN <pin>` for anonymous students with no roster name.
+ *   4. `Student` for SSO students whose pseudonym lookup hasn't resolved yet
+ *      or whose classId isn't synced — never `PIN undefined`.
+ *
+ * Also exposes id/color helpers because the scoreboard utilities key on
+ * `response.pin`, which is now optional. Use these to keep keys stable
+ * across both auth flows.
+ */
+
+import type { QuizResponse } from '@/types';
+import {
+  formatStudentName,
+  type StudentName,
+} from '@/hooks/useAssignmentPseudonyms';
+
+/** Fallback rendered when no name source resolves. */
+export const UNKNOWN_STUDENT_LABEL = 'Student';
+
+/**
+ * Resolve a friendly display name for a response. See module docstring for
+ * resolution priority. Always returns a non-empty string.
+ */
+export function resolveResponseDisplayName(
+  response: QuizResponse,
+  pinToName: Record<string, string>,
+  byStudentUid: Map<string, StudentName> | undefined
+): string {
+  const ssoName = byStudentUid
+    ? formatStudentName(byStudentUid.get(response.studentUid))
+    : '';
+  if (ssoName) return ssoName;
+
+  if (response.pin) {
+    const rosterName = pinToName[response.pin];
+    if (rosterName) return rosterName;
+    return `PIN ${response.pin}`;
+  }
+
+  return UNKNOWN_STUDENT_LABEL;
+}
+
+/**
+ * Returns true when the response came in via PIN auth (i.e. the response
+ * has a usable `pin` value the teacher view can show in pin-mode).
+ */
+export function hasPinIdentity(response: QuizResponse): boolean {
+  return typeof response.pin === 'string' && response.pin.length > 0;
+}
+
+/**
+ * Stable, unique team id for scoreboard rows. PIN joiners keep their
+ * historical `pin-{pin}` shape so existing scoreboard widgets that reference
+ * those ids (via `parseInt(response.pin, 10)`) keep working. SSO students
+ * fall back to `uid-{studentUid}`.
+ */
+export function responseTeamId(response: QuizResponse): string {
+  if (response.pin) return `pin-${response.pin}`;
+  return `uid-${response.studentUid}`;
+}
+
+/**
+ * djb2-style hash of a string. Returns a non-negative integer suitable for
+ * indexing into a fixed-size palette via modulo. Stable across runs and
+ * across browsers.
+ */
+function stableHash(value: string): number {
+  let hash = 5381;
+  for (let i = 0; i < value.length; i++) {
+    hash = ((hash << 5) + hash + value.charCodeAt(i)) | 0;
+  }
+  // Force unsigned so the modulo result is always non-negative.
+  return hash >>> 0;
+}
+
+/**
+ * Stable color-palette index for a response. PIN joiners preserve their
+ * existing numeric-pin-modulo behavior so a single session's colors don't
+ * shuffle around when SSO students join. SSO students hash their studentUid.
+ */
+export function responseColorIndex(
+  response: QuizResponse,
+  paletteLength: number
+): number {
+  if (paletteLength <= 0) return 0;
+  // True modulo: JS `%` keeps the sign of the dividend, so a negative-string
+  // PIN (e.g. "-1") would yield a negative index and indexing into the
+  // palette would return undefined. `((n % m) + m) % m` always lands in
+  // [0, paletteLength). `stableHash` already returns an unsigned integer.
+  const mod = (n: number) =>
+    ((n % paletteLength) + paletteLength) % paletteLength;
+  if (response.pin) {
+    const numeric = parseInt(response.pin, 10);
+    if (Number.isFinite(numeric)) return mod(numeric);
+    return stableHash(response.pin) % paletteLength;
+  }
+  return stableHash(response.studentUid) % paletteLength;
+}

--- a/components/widgets/VideoActivityWidget/components/Results.tsx
+++ b/components/widgets/VideoActivityWidget/components/Results.tsx
@@ -35,10 +35,11 @@ export const Results: React.FC<ResultsProps> = ({
   responses,
   onBack,
 }) => {
-  const { googleAccessToken } = useAuth();
+  const { googleAccessToken, orgId } = useAuth();
   const { byStudentUid } = useAssignmentPseudonyms(
     session.id,
-    session.classId ?? null
+    session.classId ?? null,
+    orgId
   );
   const [exporting, setExporting] = useState(false);
   const [exportUrl, setExportUrl] = useState<string | null>(null);

--- a/context/StudentAuthContext.tsx
+++ b/context/StudentAuthContext.tsx
@@ -18,9 +18,27 @@ import {
 } from '@/hooks/useStudentIdleTimeout';
 import {
   StudentAuthContext,
+  STUDENT_FIRST_NAME_KEY,
+  clearStudentFirstName,
   type StudentAuthStatus,
   type StudentAuthValue,
 } from './StudentAuthContextValue';
+
+/**
+ * Read the student's first name from tab-scoped `sessionStorage`. Stored at
+ * sign-in by `StudentLoginPage`. The name lives only in this tab, never in
+ * Firestore. `null` when not available (storage disabled, never written, or
+ * cleared by signOut).
+ */
+const readFirstName = (): string | null => {
+  if (typeof window === 'undefined') return null;
+  try {
+    const raw = window.sessionStorage.getItem(STUDENT_FIRST_NAME_KEY);
+    return raw && raw.length > 0 ? raw : null;
+  } catch {
+    return null;
+  }
+};
 
 /**
  * StudentAuthContext — Phase 2B of the ClassLink-via-Google auth flow.
@@ -123,6 +141,7 @@ const MOCK_STUDENT: Omit<StudentAuthValue, 'signOut'> & {
   pseudonymUid: 'mock-student',
   orgId: 'mock-org',
   classIds: ['mock-class-1'],
+  firstName: 'Demo',
 };
 
 // ---------------------------------------------------------------------------
@@ -134,6 +153,7 @@ interface ProviderState {
   pseudonymUid: string | null;
   orgId: string | null;
   classIds: string[];
+  firstName: string | null;
 }
 
 const INITIAL_STATE: ProviderState = {
@@ -141,6 +161,7 @@ const INITIAL_STATE: ProviderState = {
   pseudonymUid: null,
   orgId: null,
   classIds: [],
+  firstName: null,
 };
 
 const UNAUTH_STATE: ProviderState = {
@@ -148,6 +169,7 @@ const UNAUTH_STATE: ProviderState = {
   pseudonymUid: null,
   orgId: null,
   classIds: [],
+  firstName: null,
 };
 
 /**
@@ -178,6 +200,7 @@ export const StudentAuthProvider: React.FC<{ children: React.ReactNode }> = ({
           pseudonymUid: MOCK_STUDENT.pseudonymUid,
           orgId: MOCK_STUDENT.orgId,
           classIds: MOCK_STUDENT.classIds,
+          firstName: MOCK_STUDENT.firstName,
         }
       : INITIAL_STATE
   );
@@ -220,7 +243,10 @@ export const StudentAuthProvider: React.FC<{ children: React.ReactNode }> = ({
             // are malformed, OR the student is valid but isn't on any
             // roster yet. Force a sign-out so the stale session can't
             // linger on a shared device, then redirect with a reason so
-            // the login screen can explain the bounce.
+            // the login screen can explain the bounce. Clear the cached
+            // first name so a non-student bounce doesn't leave the
+            // previous session's greeting parked in sessionStorage.
+            clearStudentFirstName();
             void firebaseSignOut(auth).catch(() => {
               // Swallow — the redirect below is the actual remediation.
             });
@@ -234,10 +260,14 @@ export const StudentAuthProvider: React.FC<{ children: React.ReactNode }> = ({
             pseudonymUid: user.uid,
             orgId: outcome.value.orgId,
             classIds: outcome.value.classIds,
+            firstName: readFirstName(),
           });
         },
         () => {
           if (!mountedRef.current) return;
+          // Claim resolution threw — no firstName remains valid for this
+          // session. Clear before bouncing back to login.
+          clearStudentFirstName();
           setState(UNAUTH_STATE);
           redirectToLoginIfProtected('invalid-claims');
         }
@@ -254,6 +284,10 @@ export const StudentAuthProvider: React.FC<{ children: React.ReactNode }> = ({
 
   // --- Imperative sign-out (exposed on context) -----------------------------
   const signOut = useCallback(async () => {
+    // Always clear the first-name cache before tearing down the session so
+    // the next student on a shared device doesn't inherit the previous
+    // student's greeting.
+    clearStudentFirstName();
     if (isAuthBypass) {
       // Bypass mode: simulate a sign-out by flipping to unauthenticated and
       // redirecting. Real Firebase Auth isn't involved.
@@ -280,9 +314,17 @@ export const StudentAuthProvider: React.FC<{ children: React.ReactNode }> = ({
       pseudonymUid: state.pseudonymUid,
       orgId: state.orgId,
       classIds: state.classIds,
+      firstName: state.firstName,
       signOut,
     }),
-    [state.status, state.pseudonymUid, state.orgId, state.classIds, signOut]
+    [
+      state.status,
+      state.pseudonymUid,
+      state.orgId,
+      state.classIds,
+      state.firstName,
+      signOut,
+    ]
   );
 
   return (

--- a/context/StudentAuthContextValue.ts
+++ b/context/StudentAuthContextValue.ts
@@ -16,10 +16,18 @@ export type StudentAuthStatus = 'loading' | 'authenticated' | 'unauthenticated';
 /**
  * Minimal auth surface for student-facing protected routes.
  *
- * This context is intentionally PII-free:
+ * This context is intentionally Firestore-PII-free:
  *   - `pseudonymUid` is the opaque pseudonym minted by `studentLoginV1`.
  *   - `orgId` / `classIds` come from the custom claims on that custom token.
- *   - No email, name, photo, or `sub` is ever read, rendered, or persisted.
+ *   - No email, full name, photo, or `sub` is ever read, rendered, or
+ *     persisted to any server we own.
+ *
+ * `firstName` is the one exception, and only as the student's own name in
+ * their own browser tab: read from the Google ID token at login and parked
+ * in tab-scoped `sessionStorage`, never sent to Firestore, never logged,
+ * cleared on `signOut()`. Used purely for the personalized greeting in the
+ * sidebar footer. `null` when unavailable (legacy session, Google declined
+ * to include `given_name`, or the storage read failed).
  */
 export interface StudentAuthValue {
   /** Auth lifecycle status. */
@@ -31,13 +39,38 @@ export interface StudentAuthValue {
   /** ClassLink class sourcedIds the student is enrolled in. Empty when not authenticated. */
   classIds: string[];
   /**
-   * Sign out of Firebase and redirect to `/student/login`.
-   *
-   * Exposed so that UI (e.g. a "Done" button on `/my-assignments`) can end
-   * a session on shared-device carts without depending on the idle timeout.
+   * Student's given/first name from the Google ID token at sign-in. Stored
+   * in sessionStorage, never in Firestore. See class-doc above. `null` when
+   * not available — UI must render a sensible fallback.
+   */
+  firstName: string | null;
+  /**
+   * Sign out of Firebase and redirect to `/student/login`. Also clears the
+   * sessionStorage `firstName` so the next session on a shared device
+   * doesn't inherit the previous student's name.
    */
   signOut: () => Promise<void>;
 }
+
+/** Tab-scoped sessionStorage key for the student's first name. */
+export const STUDENT_FIRST_NAME_KEY = 'sb_student_first_name';
+
+/**
+ * Remove the student's first name from tab-scoped `sessionStorage`. Must be
+ * called on every sign-out path (explicit `signOut()`, idle-timeout
+ * auto-logout, and the StudentAuthContext claim-rejection path) so the
+ * next student on a shared device never inherits the previous student's
+ * greeting. Safe to call when storage is empty or disabled.
+ */
+export const clearStudentFirstName = (): void => {
+  if (typeof window === 'undefined') return;
+  try {
+    window.sessionStorage.removeItem(STUDENT_FIRST_NAME_KEY);
+  } catch {
+    // Storage disabled — nothing to clear; the value couldn't have been
+    // written either.
+  }
+};
 
 export const StudentAuthContext = createContext<StudentAuthValue | undefined>(
   undefined

--- a/docs/classroom-addon-integration-plan.md
+++ b/docs/classroom-addon-integration-plan.md
@@ -1,0 +1,1000 @@
+# SpartBoard ↔ Google Classroom Add-ons Integration Plan
+
+> **Status tracking document.** Every AI agent (orchestrator + sub-agents) working on this integration MUST update this file as they go. See [§ Tracking Protocol](#tracking-protocol) at the bottom before starting work.
+
+---
+
+## 📌 Current Status — read this first
+
+**Last updated:** 2026-04-28 by review agent (initial draft, no implementation work started)
+
+**Active phase:** _none — awaiting kickoff_
+
+**Active agent(s):** _none_
+
+**Next action for the next agent:** Review [§ Tracking Protocol](#tracking-protocol), then begin Phase 0A (Sonnet 4.6, GCP config). Phase 0A and Phase 1 (most agents) and Phase 0.5 can run in parallel — see [§ Order of Operations](#order-of-operations).
+
+**Blockers / open items:** None.
+
+**Resume instructions if picking up cold:**
+
+1. Read [§ Phase Status Dashboard](#phase-status-dashboard) — find the first `⬜ Not started` or `🟡 In progress` agent task that has all its dependencies satisfied.
+2. Read that agent's "Steps" and "Completion criteria" checkboxes — pick up wherever the last checked box left off.
+3. Skim the [§ Progress Log](#progress-log) for the last 3–5 entries to understand recent context.
+4. Before merging anything, run the [§ Cross-phase verification gates](#cross-phase-verification-gates).
+
+---
+
+## 🗂 Phase Status Dashboard
+
+Status legend: ⬜ Not started · 🟡 In progress · ✅ Complete · ⚠️ Blocked · ⏭ Skipped/N/A
+
+| Phase     | Agent                                   | Model      | Status | Owner (Claude session id or human) | Last update |
+| --------- | --------------------------------------- | ---------- | ------ | ---------------------------------- | ----------- |
+| 0A        | GCP `gcloud` automation                 | Sonnet 4.6 | ⬜     | —                                  | —           |
+| 0B        | Manual Console + Marketplace install    | _(human)_  | ⬜     | —                                  | —           |
+| 0.5-cf    | Server-side OAuth code grant CF         | Opus 4.7   | ⬜     | —                                  | —           |
+| 0.5-rules | Lock down `/users/{uid}/google_oauth/`  | Opus 4.7   | ⬜     | —                                  | —           |
+| 0.5-ui    | "Connect to Classroom gradebook" button | Sonnet 4.6 | ⬜     | —                                  | —           |
+| 1A        | Types + Firestore rules + CSP           | Opus 4.7   | ⬜     | —                                  | —           |
+| 1B        | `classroomAddonLoginV1` Cloud Function  | Opus 4.7   | ⬜     | —                                  | —           |
+| 1C        | Roster `classIds` synthesis             | Sonnet 4.6 | ⬜     | —                                  | —           |
+| 1D        | VideoActivity SSO branch                | Opus 4.7   | ⬜     | —                                  | —           |
+| 2-shell   | Teacher route + widget-type picker      | Opus 4.7   | ⬜     | —                                  | —           |
+| 2-cf      | `createClassroomAttachment` CF          | Opus 4.7   | ⬜     | —                                  | —           |
+| 2-quiz    | Quiz selection panel                    | Sonnet 4.6 | ⬜     | —                                  | —           |
+| 2-va      | Video Activity selection panel          | Sonnet 4.6 | ⬜     | —                                  | —           |
+| 3-shell   | Student route + auth handshake          | Opus 4.7   | ⬜     | —                                  | —           |
+| 3-quiz    | Quiz student adapter                    | Sonnet 4.6 | ⬜     | —                                  | —           |
+| 3-va      | Video Activity student adapter          | Sonnet 4.6 | ⬜     | —                                  | —           |
+| 4-cf      | `pushClassroomGrade` Cloud Function     | Opus 4.7   | ⬜     | —                                  | —           |
+| 4-quiz    | Quiz submission hook wiring             | Sonnet 4.6 | ⬜     | —                                  | —           |
+| 4-va      | VA submission hook wiring               | Sonnet 4.6 | ⬜     | —                                  | —           |
+| 5         | Polish                                  | Sonnet 4.6 | ⬜     | —                                  | —           |
+
+---
+
+## Context
+
+**Goal:** A teacher in Google Classroom clicks "Add → SpartBoard," picks Quiz or Video Activity, selects a library item, and attaches it. Students click the attachment, complete the activity inside the Classroom iframe, and grades flow into Classroom's gradebook automatically.
+
+**Why this approach:** Education Plus is confirmed at Orono and the Workspace OAuth consent screen is configured Internal. SpartBoard ships as a **private app** — installable by the district admin domain-wide, no Marketplace review, no OAuth verification, no CASA. Same deployment pattern as the existing Docs extension at Orono.
+
+**Project context:** The GCP project already exists and is linked to the SpartBoard Firebase project. **Do not create a new project** — extend the existing one. Use `gcloud` and `firebase` CLI in place of Console UI work wherever possible.
+
+**Scope:** Quiz + Video Activity only. Guided Learning and MiniApp are deferred. Paul's longer-term direction is for all four student runners to share the same auth/data foundation; track that as a separate refactor _after_ this integration ships.
+
+**Resolved decisions (from review with Paul, 2026-04-28):**
+
+1. ✅ One-time "Connect SpartBoard to Classroom gradebook" consent step is approved (Phase 0.5).
+2. ✅ Lifting the "no widget runners change" restriction _for VideoActivity only_ is approved (Agent 1D mirrors PR #1431). Quiz, MiniApp, GL untouched.
+3. 📌 Exact grade-write OAuth scope set must be `[VERIFY]`'d from current Google docs and brought back for written confirmation before any production deploy.
+
+---
+
+## 🚧 Architectural gates (blocking constraints — every phase verifies)
+
+1. **No student PII in Firestore.** Names, PINs, emails live exclusively in Google Drive. The Classroom launch token may carry display names — those must NOT be persisted to Firestore. Already enforced (`ClassRosterMeta` at [types.ts:117](../types.ts) explicitly comments "contains NO student PII"; response docs key by deterministic pseudonym/PIN keys without `name`/`email` fields). Don't regress.
+
+2. **No Google `userId` storage.** Classroom Add-ons use _attachment-scoped student IDs_. SpartBoard never needs to map to Google's domain-wide `userId`. Do not add a Google `userId` field anywhere.
+
+3. **Existing student auth flows must keep working unchanged.** ClassLink SSO (`/my-assignments` → `studentLoginV1`) and anonymous PIN joins must continue to function for the same Quiz and Video Activity sessions. The Classroom Add-on entry is _additive_.
+
+4. **Widget-runner change scope:**
+   - **Quiz student runner:** read-only. SSO branch already exists (PR #1431).
+   - **Video Activity student runner:** ✅ authorized to modify — Agent 1D adds the `studentRole` SSO branch, mirroring Quiz. Existing PIN-joined students keep working unchanged.
+   - **MiniApp / GuidedLearning runners:** read-only, out of scope.
+
+5. **`firestore.rules` PII gate must extend cleanly.** `classroomAddonLoginV1` mints custom tokens with the same `{ studentRole: true, orgId, classIds }` shape as `studentLoginV1`. The existing `passesStudentClassGate*` helpers do format-agnostic string matching ([firestore.rules:45](../firestore.rules), [firestore.rules:76](../firestore.rules)) — `classroom:abc123` works without modifying any helper.
+
+6. **Zero disruption to existing functionality during development.** No teacher- or student-facing widget functionality breaks at any point during rollout. Concretely:
+   - All schema changes are strictly additive (`?: optional` fields). No renames, no required-field additions, no enum removals.
+   - All Firestore rules changes are additive. After each rules edit, the full `tests/rules/` suite still passes.
+   - `useQuizAssignments.createAssignment` keeps generating join codes unconditionally; Classroom-attached assignments get a harmless unused PIN.
+   - Existing `/quiz?code=...` and `/activity/:sessionId` routes are read-only references. New routes live under `/classroom-addon/**`.
+   - The new server-side OAuth code grant is a _parallel_ path. Existing GIS + Firebase popup flow continues unchanged for teachers who don't use Classroom.
+   - No backfill / migration / rewrite of existing response, assignment, or session docs.
+   - **Verification cadence (mandatory every phase):** PIN-joined Quiz, ClassLink-SSO Quiz from `/my-assignments`, PIN-joined VideoActivity all complete end-to-end successfully.
+
+7. **API surface uncertainty.** `[VERIFY]` markers throughout indicate fields that may have shifted since training cutoff. Fetch current docs at https://developers.google.com/workspace/classroom/add-ons/reference/rest before implementing. The single highest-stakes verify is the **JWKS URL for launch-token signature verification** — getting this wrong silently lets attackers mint `studentRole` tokens.
+
+---
+
+## 🔍 Reference implementations (verified to exist; study before writing)
+
+| Pattern                                                  | File:Line                                                                                                                                                            | What to learn                                                                                                                      |
+| -------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| Custom token mint with `studentRole` claims              | [functions/src/index.ts:2761](../functions/src/index.ts) (`studentLoginV1`)                                                                                          | Exact claim shape (line 2870), HMAC pseudonym (line 2687), validation, error responses                                             |
+| PII-free claim extraction                                | [context/StudentAuthContext.tsx:100](../context/StudentAuthContext.tsx) (`extractStudentClaims`); `<RequireStudentAuth>` at line 353                                 | What we read vs. ignore from the ID token                                                                                          |
+| Class-gate enforcement                                   | [firestore.rules:45](../firestore.rules) (`studentRoleCanAccessClass`), [firestore.rules:76](../firestore.rules) (`passesStudentClassGateList`)                      | Format-agnostic string overlap; safe-default `request.auth.token.get('studentRole', false)`                                        |
+| Quiz assignment lifecycle                                | [hooks/useQuizAssignments.ts:75](../hooks/useQuizAssignments.ts) (`createAssignment`)                                                                                | Accepts `(quiz, settings, status?, classIds?, rosterIds?)`; `allocateJoinCode()` is unconditional (line 210); writeBatch atomicity |
+| VA assignment lifecycle                                  | [hooks/useVideoActivityAssignments.ts:66](../hooks/useVideoActivityAssignments.ts) (`createAssignment`)                                                              | Same shape, no join code                                                                                                           |
+| Quiz library listing                                     | [hooks/useQuiz.ts:59](../hooks/useQuiz.ts) (`useQuiz`)                                                                                                               | `onSnapshot` on `/users/{userId}/quizzes`                                                                                          |
+| VA library listing                                       | [hooks/useVideoActivity.ts](../hooks/useVideoActivity.ts) (singular — _not_ `useVideoActivities`)                                                                    | Same pattern as `useQuiz`                                                                                                          |
+| Quiz student SSO branch (template for VA Agent 1D)       | [components/quiz/QuizStudentApp.tsx:56-77](../components/quiz/QuizStudentApp.tsx)                                                                                    | `tokenResult.claims?.studentRole === true` skips PIN — PR #1431                                                                    |
+| Quiz student-side join                                   | [hooks/useQuizSession.ts:565](../hooks/useQuizSession.ts) (`joinQuizSession(code, pin?, classPeriod?)`)                                                              | Code-based join; `lookupSession(code)` resolves session-by-code                                                                    |
+| VA student-side join (target of Agent 1D)                | [hooks/useVideoActivitySession.ts:335](../hooks/useVideoActivitySession.ts) (`joinSession(sessionId, pin, name, classPeriod?)`)                                      | Currently always requires `pin + name`; response-doc write at line 496                                                             |
+| Class-ID derivation                                      | [utils/resolveAssignmentTargets.ts:77](../utils/resolveAssignmentTargets.ts) (`deriveTargetsFromRosterList`)                                                         | Flatmaps `classlinkClassId` and `testClassId` into deduped `classIds`                                                              |
+| Existing SSO assignment href                             | [hooks/useStudentAssignments.ts:130](../hooks/useStudentAssignments.ts)                                                                                              | `/quiz?code=${encodeURIComponent(code)}` — Classroom adapter mirrors                                                               |
+| Tested rules patterns                                    | [tests/rules/studentRoleClassGate.test.ts:495-536](../tests/rules/studentRoleClassGate.test.ts)                                                                      | Auth-fixture pattern; bare-anon-token edge case                                                                                    |
+| Existing CSP frame-ancestors                             | [firebase.json:40-46](../firebase.json)                                                                                                                              | `/activity/**` already lists `https://classroom.google.com`                                                                        |
+| Current access-token-only OAuth (Phase 0.5 changes here) | [context/AuthContext.tsx:190](../context/AuthContext.tsx), [context/AuthContext.tsx:278](../context/AuthContext.tsx), [config/firebase.ts:31](../config/firebase.ts) | No `access_type: 'offline'`; no refresh tokens stored                                                                              |
+
+---
+
+## 🧭 Order of Operations
+
+```
+Phase 0A (gcloud, ~1 hr)  ──┐
+Phase 0B (manual Console, ~30 min) ──┘  (sequential within Phase 0)
+   │
+   ├─ Phase 0.5 (parallel with 0; OAuth refresh tokens)
+   │   ├─ 0.5-cf, 0.5-rules ──┐  (parallel)
+   │   └─ 0.5-ui ──────────────┘  (after 0.5-cf merge)
+   │
+   └─ Phase 1 (parallel with 0/0.5)
+       ├─ 1A ──┐
+       ├─ 1B ──┤  (parallel)
+       ├─ 1D ──┤  (parallel)
+       └─ 1C ──┘  (after 1A merge)
+
+Phase 2 (after Phase 0B install completes)
+   ├─ 2-shell ──┐
+   ├─ 2-cf ─────┤  (parallel with 2-shell)
+   ├─ 2-quiz ───┤  (after 2-shell merge)
+   └─ 2-va ─────┘  (parallel with 2-quiz)
+
+Phase 3 (after 1D + 2 merge)
+   ├─ 3-shell ──┐
+   ├─ 3-quiz ───┤  (after 3-shell merge)
+   └─ 3-va ─────┘  (parallel with 3-quiz)
+
+Phase 4 (after Phase 0.5 + 3)
+   ├─ 4-cf ─────┐
+   ├─ 4-quiz ───┤  (all parallel)
+   └─ 4-va ─────┘
+
+Phase 5 — Polish (sequential, single agent)
+```
+
+**Realistic timeline:** Phase 0 same day · Phases 0.5 + 1 in parallel ~2-3 days · Phase 2 ~3-5 days · Phase 3 ~2-3 days · Phase 4 ~2-3 days (gated on 0.5) · Phase 5 ~2-3 days. **Total: ~3 weeks** of code work, end-to-end testable from end of Phase 0.
+
+---
+
+## Phase 0 — GCP configuration
+
+### Phase 0A — `gcloud`-automatable
+
+- **Status:** ⬜ Not started
+- **Model:** Sonnet 4.6 (mechanical config work)
+- **Owner:** _unassigned_
+- **Dependencies:** none
+- **Outputs:** `docs/classroom-addon-gcp-state.md`; gates passed for Phase 0B handoff
+
+#### Steps (check off as completed)
+
+- [ ] Confirm project alignment: `gcloud config get-value project` and `firebase projects:list` both show the same project ID. If not, **stop and surface to Paul** before proceeding.
+- [ ] Enable required APIs:
+  - [ ] `gcloud services enable classroom.googleapis.com`
+  - [ ] `gcloud services enable appsmarket-component.googleapis.com`
+  - [ ] `gcloud services enable workspacemarketplace.googleapis.com`
+  - [ ] `[VERIFY]` Marketplace SDK API name with `gcloud services list --available | grep -i marketplace`; over-enabling is harmless.
+- [ ] Attempt to query consent-screen User Type. **Soft gate** — if no clean `gcloud` path exists, fall through to Phase 0B's Console check rather than blocking. (Original prompt's `gcloud alpha iap oauth-brands list` is the wrong API for non-IAP apps.)
+- [ ] List currently authorized OAuth scopes; capture for the snapshot.
+- [ ] Verify Education Plus license:
+
+  ```bash
+  curl -H "Authorization: Bearer $(gcloud auth print-access-token)" \
+       "https://classroom.googleapis.com/v1/courses?pageSize=1"
+  ```
+
+  - 200 → Plus is associated.
+  - 403 with license error → **stop and surface to Paul**.
+
+- [ ] Generate config snapshot at `docs/classroom-addon-gcp-state.md` summarizing: enabled APIs, consent-screen User Type (or "unverified — check 0B"), existing scopes, Marketplace SDK status.
+
+#### Completion criteria
+
+- [ ] All three Classroom-related APIs show as enabled in `gcloud services list --enabled`.
+- [ ] `curl` to Classroom API returns 200 (or 403 has been raised to Paul as a license gate).
+- [ ] `docs/classroom-addon-gcp-state.md` exists and contains all required sections.
+- [ ] Update Phase Status Dashboard row → ✅ Complete with timestamp.
+- [ ] Append a Progress Log entry summarizing the snapshot.
+
+#### Notes / handoff
+
+_(append findings here as you work; especially anything Phase 0B will need)_
+
+---
+
+### Phase 0B — Manual Console work
+
+- **Status:** ⬜ Not started
+- **Owner:** _human (Paul or Workspace admin)_
+- **Dependencies:** Phase 0A complete
+- **Estimated time:** ~30 min
+
+#### Steps (developer/admin checks off)
+
+In **Google Cloud Console:**
+
+- [ ] **OAuth consent screen → Edit App** — confirm User Type = Internal.
+- [ ] Add scopes:
+  - [ ] `https://www.googleapis.com/auth/classroom.addons.teacher`
+  - [ ] `https://www.googleapis.com/auth/classroom.addons.student`
+  - [ ] **`[VERIFY]` and pin the exact grade-write scope set** before adding. Bring the verified list to Paul for written confirmation before adding any scope. (Historically `classroom.coursework.students` has been required; Add-ons-specific path may differ.)
+- [ ] **Marketplace SDK → App Configuration:**
+  - [ ] App Visibility: **Private** (critical — Public triggers Marketplace review)
+  - [ ] Setup URI: `https://<spartboard-domain>/classroom-addon/teacher`
+  - [ ] Attachment URI prefixes: `https://<spartboard-domain>/classroom-addon/`
+  - [ ] Additional Scopes match the consent screen.
+- [ ] **Marketplace SDK → Store Listing:** Application Name, descriptions, 192px icon, screenshot (placeholder OK for private). Click **PUBLISH**.
+
+In **Workspace Admin Console:**
+
+- [ ] As Orono Workspace admin, **Apps → Google Workspace Marketplace apps → Add app → Install for the entire domain**.
+- [ ] Confirm install propagated by signing in as a test teacher and verifying SpartBoard appears in Classroom's "Add" menu.
+
+#### Completion criteria
+
+- [ ] Add-on installed and discoverable in Classroom's "Add" menu for at least one test teacher account.
+- [ ] Update Phase Status Dashboard row → ✅ Complete with timestamp and the verified grade-write scope set noted in the row's "Last update" cell.
+- [ ] Append a Progress Log entry.
+
+---
+
+## Phase 0.5 — Server-side OAuth refresh-token capture (NEW)
+
+> **Why a new phase:** The current OAuth flow ([context/AuthContext.tsx:190](../context/AuthContext.tsx)) only stores 1-hour access tokens in `localStorage` and never requests `access_type: 'offline'`. Without this phase, Phase 4 fails the moment a teacher's session expires (~1 hour). Decision (Paul, 2026-04-28): one-time consent step is acceptable friction.
+
+### Agent 0.5-cf — OAuth code-grant Cloud Function
+
+- **Status:** ⬜ Not started
+- **Model:** Opus 4.7 (long-lived credential storage; security-critical)
+- **Owner:** _unassigned_
+- **Dependencies:** Phase 0A complete (so we know the GCP project state)
+- **Outputs:** new module `functions/src/classroomGradebookOAuth.ts` exported from `functions/src/index.ts`; helper `getValidClassroomAccessToken(uid)` for Phase 4 reuse.
+
+#### Steps
+
+- [ ] Create new file `functions/src/classroomGradebookOAuth.ts`.
+- [ ] Implement callable `connectClassroomGradebookV1`:
+  - [ ] Input: `{ authCode: string, redirectUri: string }`
+  - [ ] Validate `request.auth.uid` is the teacher; code grant returns claims matching teacher's email.
+  - [ ] Exchange `authCode` for `refresh_token` + `access_token` server-side (Google OAuth token endpoint).
+  - [ ] Persist `{ refreshToken, accessToken, accessTokenExpiresAt, scopes, connectedAt }` to `/users/{uid}/google_oauth/classroomGradebook`.
+  - [ ] Return `{ ok: true, scopes: string[] }` — **never return tokens to the client.**
+- [ ] Implement helper `getValidClassroomAccessToken(uid)`:
+  - [ ] Read stored refresh token; if `accessTokenExpiresAt` is past, refresh against Google; write the new access token back; return live access token.
+  - [ ] Structured error shape on missing/revoked refresh token (Phase 4 surfaces this to user).
+- [ ] Export both from `functions/src/index.ts`.
+- [ ] Unit tests in `functions/test/` (mirror existing patterns):
+  - [ ] Valid code → token persisted.
+  - [ ] Invalid code → rejected.
+  - [ ] `getValidClassroomAccessToken`: expired access token → refreshed.
+  - [ ] `getValidClassroomAccessToken`: missing refresh token → structured error.
+- [ ] **Do not auto-deploy.** Stop and request human deploy gate.
+
+#### Completion criteria
+
+- [ ] Unit tests pass.
+- [ ] Code reviewed by human before deploy.
+- [ ] Non-disruption smoke ([§ Cross-phase verification gates](#cross-phase-verification-gates)).
+- [ ] Update Phase Status Dashboard → ✅.
+- [ ] Append Progress Log entry.
+
+#### Notes / handoff
+
+_(append findings here)_
+
+---
+
+### Agent 0.5-rules — Lock down `/users/{uid}/google_oauth/`
+
+- **Status:** ⬜ Not started
+- **Model:** Opus 4.7 (Firestore rules + tokens at rest = security blast radius)
+- **Owner:** _unassigned_
+- **Dependencies:** can run in parallel with 0.5-cf (no schema dependency)
+
+#### Steps
+
+- [ ] Edit [firestore.rules](../firestore.rules):
+  ```
+  match /users/{userId}/google_oauth/{doc} {
+    allow read, write: if false;  // Functions admin SDK only
+  }
+  ```
+- [ ] Add tests in `tests/rules/` confirming no client read or write succeeds (authenticated owner, anonymous, admin — all denied).
+- [ ] Run `pnpm test tests/rules/` and confirm full suite still passes (no previously-passing test breaks).
+
+#### Completion criteria
+
+- [ ] New tests pass; full rules suite still green.
+- [ ] `git diff firestore.rules` shows only the new `match` block — no other changes.
+- [ ] Non-disruption smoke.
+- [ ] Update Dashboard + Progress Log.
+
+---
+
+### Agent 0.5-ui — "Connect to Classroom gradebook" button
+
+- **Status:** ⬜ Not started
+- **Model:** Sonnet 4.6 (wiring work)
+- **Owner:** _unassigned_
+- **Dependencies:** 0.5-cf merged (callable must exist)
+
+#### Steps
+
+- [ ] Add a "Connect to Classroom gradebook" button in admin/teacher settings (suggest: `components/admin/AdminSettings.tsx` or a new sub-tab).
+- [ ] Trigger Google OAuth code-grant flow with `access_type=offline&prompt=consent` and the verified Classroom scopes (from Phase 0B).
+- [ ] On callback, POST `authCode` to `connectClassroomGradebookV1`.
+- [ ] Display connection status: connected/not connected, scopes granted, last connected timestamp.
+- [ ] **Critical scoping:** the new flow runs in **parallel to** the existing GIS + Firebase popup auth in `AuthContext.tsx`. It is _not_ a replacement. Verify by:
+  - [ ] Sign in as an existing teacher who hasn't clicked the button. Behavior identical to today.
+  - [ ] Click the button. Consent prompt appears. Approve. Doc exists in Firestore. Doc unreadable from client SDK (verify via dev-tools eval).
+
+#### Completion criteria
+
+- [ ] Existing teacher sign-in unchanged for users who don't click the button.
+- [ ] Button consent flow completes successfully.
+- [ ] Refresh token persisted; client cannot read it.
+- [ ] Non-disruption smoke.
+- [ ] Update Dashboard + Progress Log.
+
+---
+
+## Phase 1 — Foundation (parallel with Phases 0/0.5)
+
+### Agent 1A — Types + Firestore rules + CSP
+
+- **Status:** ⬜ Not started
+- **Model:** Opus 4.7 (touches `firestore.rules`)
+- **Owner:** _unassigned_
+- **Dependencies:** none
+
+#### Steps
+
+- [ ] **`types.ts`** — additive only:
+  - [ ] On `ClassRosterMeta`: add `classroomCourseId?: string` with comment explaining the `classroom:{courseId}` synthesis pattern.
+  - [ ] On `QuizAssignment`: add `classroomCourseId?: string` and `classroomAttachmentId?: string`.
+  - [ ] On `VideoActivityAssignment`: add the same two fields.
+  - [ ] **Verify** `ClassRosterMeta.origin` already includes `'classroom'` ([types.ts:117](../types.ts)) — no enum change needed. If you find yourself "adding `'classroom'`," stop — it's already there.
+- [ ] **`firestore.rules`:**
+  - [ ] Read [firestore.rules:45](../firestore.rules) and [firestore.rules:76](../firestore.rules); confirm `passesStudentClassGate*` does format-agnostic matching. **Do not rewrite the helpers.**
+  - [ ] If you find yourself rewriting any helper, stop and re-read this section.
+- [ ] **`firebase.json`** — append a parallel block for `/classroom-addon/**` mirroring the existing `/activity/**` host list at [firebase.json:40](../firebase.json):
+
+  ```json
+  {
+    "source": "/classroom-addon/**",
+    "headers": [
+      {
+        "key": "Content-Security-Policy",
+        "value": "frame-ancestors 'self' https://*.instructure.com https://*.schoology.com https://classroom.google.com"
+      }
+    ]
+  }
+  ```
+
+  - [ ] `[VERIFY]` whether Classroom Add-on iframes come from additional `*.google.com` subdomains (e.g., `addons.gstatic.com`) and append as needed.
+
+- [ ] **Tests** in [tests/rules/studentRoleClassGate.test.ts](../tests/rules/studentRoleClassGate.test.ts):
+  - [ ] Add: `studentRole` user with `classIds: ['classroom:abc123']` claim can read/write a session targeted at `classIds: ['classroom:abc123']`.
+  - [ ] Add: same user is denied for `classIds: ['classroom:other']`.
+  - [ ] Cover both `quiz_sessions` and `video_activity_sessions`.
+  - [ ] Mirror the bare-anon-token edge case at lines 495–536.
+
+#### Completion criteria
+
+- [ ] `pnpm run type-check` clean.
+- [ ] `pnpm test tests/rules/` passes including new cases AND every previously-passing test still passes.
+- [ ] `git diff types.ts` shows only `?:` field _additions_ — no renames, no required-field additions, no enum changes.
+- [ ] Non-disruption smoke.
+- [ ] Update Dashboard + Progress Log.
+
+---
+
+### Agent 1B — `classroomAddonLoginV1` Cloud Function
+
+- **Status:** ⬜ Not started
+- **Model:** Opus 4.7 (JWT verify, custom-token mint, security-critical)
+- **Owner:** _unassigned_
+- **Dependencies:** none (independent of 1A)
+
+#### Steps
+
+- [ ] Create new module `functions/src/classroomAddonAuth.ts`. Model on `studentLoginV1` at [functions/src/index.ts:2761](../functions/src/index.ts).
+- [ ] **Input:** Classroom Add-on launch token (`login_hint`, `addOnToken` query params). `[VERIFY]` exact param shape against current docs.
+- [ ] **JWT validation against Google's published JWKS for Classroom add-ons** — **highest-stakes step.**
+  - [ ] `[VERIFY]` the JWKS URL.
+  - [ ] Verify signature.
+  - [ ] Verify audience matches SpartBoard's registered Classroom add-on client.
+  - [ ] Verify expiry.
+- [ ] **Claim extraction from validated JWT:**
+  - [ ] `courseId` (Classroom course id)
+  - [ ] Attachment-scoped student identifier (NOT domain-wide `userId`)
+  - [ ] `attachmentId` if launch is from an existing attachment
+- [ ] **Pseudonym mint:** HMAC-SHA256 of canonical input, same secret as `studentLoginV1`. Deterministic for the same student in the same course.
+- [ ] **Custom claims (exact shape — must match `studentLoginV1`):**
+
+  ```ts
+  { studentRole: true, orgId: <derived>, classIds: [`classroom:${courseId}`] }
+  ```
+
+  - `studentRole` is boolean (not string `"true"`)
+  - `orgId` non-empty string
+  - `classIds` array of non-empty strings
+
+- [ ] **Operational hygiene:**
+  - [ ] Rate-limit per-IP (reuse `studentLoginV1`'s pattern if any).
+  - [ ] Never log raw JWT, studentInfo, or courseId at info level. Debug-only, redacted.
+- [ ] Export from `functions/src/index.ts`.
+- [ ] **Adversarial unit tests (required — all must pass):**
+  - [ ] Valid JWT → custom token returned.
+  - [ ] Invalid signature → 401, no token minted.
+  - [ ] Expired token → 401.
+  - [ ] Wrong audience → 401.
+  - [ ] Missing required claims → 401.
+- [ ] **Do not auto-deploy.** Human deploy gate.
+
+#### Completion criteria
+
+- [ ] All adversarial unit tests pass.
+- [ ] Code reviewed by human before deploy.
+- [ ] Non-disruption smoke.
+- [ ] Update Dashboard + Progress Log.
+
+---
+
+### Agent 1C — Roster `classIds` synthesis
+
+- **Status:** ⬜ Not started
+- **Model:** Sonnet 4.6 (well-specified utility extension)
+- **Owner:** _unassigned_
+- **Dependencies:** **1A merged** (so `classroomCourseId` field exists on `ClassRosterMeta`)
+
+#### Steps
+
+- [ ] Edit [utils/resolveAssignmentTargets.ts:77](../utils/resolveAssignmentTargets.ts) — extend the flatmap:
+  ```ts
+  .flatMap((r) => [r.classlinkClassId, r.testClassId, r.classroomCourseId])
+  ```
+- [ ] **Decide and document** where the `classroom:` prefix is added — at roster creation (preferred — Firestore field stores namespaced id) or at derivation. Document the choice in this file's Progress Log.
+- [ ] Add tests in `tests/utils/resolveAssignmentTargets.test.ts`:
+  - [ ] Roster with only `classroomCourseId` → `classIds: ['classroom:<id>']`.
+  - [ ] Roster with both `classlinkClassId` and `classroomCourseId` → both entries.
+  - [ ] Two rosters sharing a `classroomCourseId` → de-duped.
+
+#### Completion criteria
+
+- [ ] `pnpm test tests/utils/resolveAssignmentTargets.test.ts` passes.
+- [ ] `pnpm run type-check` clean.
+- [ ] Non-disruption smoke.
+- [ ] Update Dashboard + Progress Log (note the prefix-placement decision).
+
+#### Out of scope
+
+UI for teachers to _create_ a Classroom-sourced roster — that's Phase 2.
+
+---
+
+### Agent 1D — VideoActivity SSO branch (NEW)
+
+- **Status:** ⬜ Not started
+- **Model:** Opus 4.7 (PII-aware response-doc write — getting the conditional wrong leaks names)
+- **Owner:** _unassigned_
+- **Dependencies:** none (parallel with 1A/1B)
+
+> **Authorization:** This is the **only** widget-runner change authorized by this plan. Quiz, MiniApp, GuidedLearning runners stay untouched.
+
+#### Steps
+
+- [ ] **Lock-in regression test FIRST** (before any code changes):
+  - [ ] In `tests/hooks/useVideoActivitySession.test.ts`, write a test that exercises the existing PIN flow and asserts the response doc contains `pin` and `name` fields with their current values.
+  - [ ] Run it; it must pass against the unmodified code. This locks in the existing shape so regressions surface immediately.
+- [ ] **Edit [hooks/useVideoActivitySession.ts](../hooks/useVideoActivitySession.ts):**
+  - [ ] Add `isStudentRole` detection mirroring [hooks/useQuizSession.ts:72-77](../hooks/useQuizSession.ts):
+    ```ts
+    const isStudentRole =
+      !auth.currentUser?.isAnonymous &&
+      (await auth.currentUser?.getIdTokenResult()).claims?.studentRole === true;
+    ```
+  - [ ] Branch [line 496](../hooks/useVideoActivitySession.ts) response-doc write:
+    - **For SSO callers (`isStudentRole === true`):** key the response doc by `auth.currentUser.uid` (pseudonym from `classroomAddonLoginV1`); write the response doc **without** `pin` or `name` fields.
+    - **For existing PIN callers:** behavior unchanged. `pin` and `name` still written exactly as today.
+  - [ ] **Branching must be on `studentRole === true`, never on absence of PIN.**
+- [ ] **Edit [components/videoActivity/VideoActivityStudentApp.tsx](../components/videoActivity/VideoActivityStudentApp.tsx):**
+  - [ ] Use [components/quiz/QuizStudentApp.tsx:56-77](../components/quiz/QuizStudentApp.tsx) as the template.
+  - [ ] If `studentRole === true`: skip PIN/name entry, auto-join.
+  - [ ] PIN-joined fallback unchanged.
+- [ ] **Add SSO-flow test** to `tests/hooks/useVideoActivitySession.test.ts`:
+  - [ ] `studentRole: true` joiner with no PIN/name; assert response doc exists, keyed by uid, with no `pin`/`name` fields.
+- [ ] **Add rules test** in [tests/rules/studentRoleClassGate.test.ts](../tests/rules/studentRoleClassGate.test.ts):
+  - [ ] Extend `video_activity_sessions` cases to mirror existing `quiz_sessions` SSO pattern with `classroom:*` class ids.
+
+#### Completion criteria
+
+- [ ] Lock-in regression test passes (PIN flow shape preserved).
+- [ ] New SSO test passes.
+- [ ] Rules test passes.
+- [ ] **Manual smoke (mandatory):** PIN-joined VA still works end-to-end.
+- [ ] **Manual smoke:** SSO branch exercised by minting a fake `studentRole` token via `firebase-admin` in a test script (no Classroom dependency required).
+- [ ] Non-disruption smoke for Quiz flows.
+- [ ] Update Dashboard + Progress Log.
+
+---
+
+## Phase 2 — Teacher discovery view (depends on Phase 0B install)
+
+### Agent 2-shell — Teacher route shell
+
+- **Status:** ⬜ Not started
+- **Model:** Opus 4.7 (defines the panel contract; expensive to revise later)
+- **Owner:** _unassigned_
+- **Dependencies:** Phase 0B install confirmed, Phase 1A + 1B merged
+- **Must merge before:** 2-quiz, 2-va
+
+#### Steps
+
+- [ ] Create `components/classroomAddon/types.ts`:
+  ```ts
+  export interface ClassroomAddonContext {
+    courseId: string;
+    teacherUid: string;
+    addOnToken: string;
+  }
+  export interface AddonSelectionPanelProps {
+    context: ClassroomAddonContext;
+    onAttachmentCreated: (attachmentId: string) => void;
+    onCancel: () => void;
+  }
+  ```
+- [ ] Create `components/classroomAddon/TeacherDiscoveryRoute.tsx`:
+  - [ ] Read launch token from URL query params (`login_hint`, `addOnToken`, `courseId`, `itemId`, `itemType` — `[VERIFY]`).
+  - [ ] Call a small CF (or extend `classroomAddonLoginV1` with a teacher mode) to validate the launch and return `{ courseId, teacherUid }`. Reuse 1B's JWKS-verify code.
+  - [ ] Render widget-type picker: Quiz, Video Activity. Leave a clear extension point for GL/MiniApp later.
+  - [ ] On selection, render the per-widget panel as a child component.
+- [ ] Register `/classroom-addon/teacher` route in `App.tsx`. Render OUTSIDE the normal teacher dashboard chrome (no sidebar, no header). Mirror the lazy-load pattern of student routes.
+
+#### Completion criteria
+
+- [ ] Valid launch params → picker renders.
+- [ ] Invalid/missing params → clear error state, NOT a redirect to dashboard.
+- [ ] No Firebase popup ever fires on this route.
+- [ ] `pnpm run type-check` clean.
+- [ ] Non-disruption smoke.
+- [ ] Update Dashboard + Progress Log.
+
+---
+
+### Agent 2-cf — `createClassroomAttachment` Cloud Function
+
+- **Status:** ⬜ Not started
+- **Model:** Opus 4.7 (REST integration with transactional idempotency)
+- **Owner:** _unassigned_
+- **Dependencies:** Phase 1A merged; can run parallel to 2-shell
+
+#### Steps
+
+- [ ] Create new module `functions/src/classroomAttachments.ts`.
+- [ ] Implement callable with input:
+  ```ts
+  {
+    addOnToken: string,
+    widgetType: 'quiz' | 'video-activity',
+    spartboardAssignmentId: string,
+    spartboardSessionId: string,
+    itemTitle: string,
+    pointsPossible: number | null,
+  }
+  ```
+- [ ] **Behavior:**
+  - [ ] Validate `addOnToken`. Extract `courseId`, `itemId`, `teacherUid`.
+  - [ ] Build student URL: `${origin}/classroom-addon/student/{spartboardAssignmentId}?widget={widgetType}`.
+  - [ ] Call Classroom REST: `POST /v1/courses/{courseId}/courseWork/{itemId}/addOnAttachments`. `[VERIFY]` exact endpoint and payload.
+  - [ ] **Idempotency (must be transactional):** Firestore transaction reads the assignment doc; if `classroomAttachmentId` is already set, return it without calling Classroom; otherwise call Classroom and atomically write the result. Prevents double-click duplicates.
+  - [ ] Return `{ attachmentId }`.
+- [ ] **Error handling:** Classroom rejects after SpartBoard already created the assignment → return structured error; client offers "retry attaching" or "delete orphaned assignment." Do NOT auto-delete.
+- [ ] Unit tests:
+  - [ ] Happy path.
+  - [ ] Partial-failure path (Classroom rejects).
+  - [ ] Idempotency (same `spartboardAssignmentId` twice → returns existing `attachmentId`, does not call Classroom).
+- [ ] Manual end-to-end against a real Orono Classroom course (Paul's account is sufficient post-Phase 0B).
+
+#### Completion criteria
+
+- [ ] Unit tests pass.
+- [ ] Manual end-to-end attachment created in real Classroom course.
+- [ ] Code reviewed by human before deploy.
+- [ ] Non-disruption smoke.
+- [ ] Update Dashboard + Progress Log.
+
+---
+
+### Agent 2-quiz — Quiz selection panel
+
+- **Status:** ⬜ Not started
+- **Model:** Sonnet 4.6 (wiring against existing primitives)
+- **Owner:** _unassigned_
+- **Dependencies:** 2-shell merged, 2-cf merged
+
+#### Steps
+
+- [ ] Create `components/classroomAddon/QuizSelectionPanel.tsx` implementing `AddonSelectionPanelProps`.
+- [ ] Use [hooks/useQuiz.ts:59](../hooks/useQuiz.ts) (`useQuiz`) filtered by `context.teacherUid`.
+- [ ] Render `LibraryShell` + `LibraryGrid` (reference [components/widgets/QuizWidget/components/QuizManager.tsx](../components/widgets/QuizWidget/components/QuizManager.tsx)). **Reuse existing primitives — do NOT build custom UI.**
+- [ ] On selection, show `AssignModal` for session settings. **Skip `AssignClassPicker`** entirely.
+- [ ] On confirm:
+  - [ ] Call `createAssignment` from `useQuizAssignments` with `classIds: [\`classroom:${context.courseId}\`]`and empty`rosterIds`.
+  - [ ] **Note:** a 6-character join code WILL be allocated ([line 210](../hooks/useQuizAssignments.ts)). Accept as harmless. Do not branch the hook.
+  - [ ] Call `createClassroomAttachment` with `widgetType: 'quiz'` and the new assignment id.
+  - [ ] On success, `props.onAttachmentCreated(attachmentId)`.
+
+#### Completion criteria
+
+- [ ] Local mock against `ClassroomAddonContext` fixtures works.
+- [ ] Renders correctly at ~800×600 iframe dimensions.
+- [ ] No new custom UI primitives — only existing library components reused.
+- [ ] Non-disruption smoke.
+- [ ] Update Dashboard + Progress Log.
+
+#### Out of scope
+
+Creating new quizzes inline. V1 attaches existing library items only.
+
+---
+
+### Agent 2-va — Video Activity selection panel
+
+- **Status:** ⬜ Not started
+- **Model:** Sonnet 4.6
+- **Owner:** _unassigned_
+- **Dependencies:** 2-shell merged, 2-cf merged
+
+#### Steps
+
+Identical structure to 2-quiz, with these differences:
+
+- [ ] New file: `components/classroomAddon/VideoActivitySelectionPanel.tsx`.
+- [ ] Use `useVideoActivity()` (singular — _not_ `useVideoActivities`).
+- [ ] Use `useVideoActivityAssignments`'s `createAssignment` (no join code).
+- [ ] Pass `widgetType: 'video-activity'` to `createClassroomAttachment`.
+
+#### Completion criteria
+
+Same as 2-quiz.
+
+---
+
+## Phase 3 — Student view (depends on Phases 1D + 2)
+
+### Agent 3-shell — Student route + auth handshake
+
+- **Status:** ⬜ Not started
+- **Model:** Opus 4.7 (custom-token exchange, security-critical)
+- **Owner:** _unassigned_
+- **Dependencies:** Phase 2 merged, Phase 1D merged
+
+#### Steps
+
+- [ ] Create `components/classroomAddon/StudentRoute.tsx` at `/classroom-addon/student/:assignmentId`.
+- [ ] Read launch token from URL query params.
+- [ ] Call `classroomAddonLoginV1` with the launch token → Firebase custom token.
+- [ ] `signInWithCustomToken`. User now has `studentRole` claim.
+- [ ] Wrap in `<RequireStudentAuth>` ([context/StudentAuthContext.tsx:353](../context/StudentAuthContext.tsx)).
+- [ ] Read `widget` query param → which adapter to render.
+- [ ] Look up SpartBoard assignment by `assignmentId`; resolve matching session.
+- [ ] Capture attachment-scoped student id and `submissionId` from launch context (via `getAddOnContext` — `[VERIFY]` exact response field names). These flow into the response doc when written so Phase 4 has its grade-passback keys.
+- [ ] Delegate to existing widget student runner (Quiz: code-based via the assignment's join code; VA: sessionId-based via 1D's SSO branch).
+- [ ] **Critical:** Quiz student runner needs no changes (PR #1431). VA student runner has 1D's SSO branch. Do NOT modify either runner here.
+
+#### Completion criteria
+
+- [ ] Valid launch token → student signs in → widget renders.
+- [ ] Invalid token → error state, never teacher login screen.
+- [ ] Student's Firebase user is non-anonymous with expected claims (verified in dev tools).
+- [ ] Response doc keyed by pseudonym UID (no PIN, no `name`/`email`).
+- [ ] Response doc carries `classroomSubmissionId` and `classroomAttachmentStudentId` (or canonical names per `getAddOnContext`).
+- [ ] Non-disruption smoke.
+- [ ] Update Dashboard + Progress Log.
+
+---
+
+### Agent 3-quiz — Quiz student adapter
+
+- **Status:** ⬜ Not started
+- **Model:** Sonnet 4.6 (5-line redirect)
+- **Owner:** _unassigned_
+- **Dependencies:** 3-shell merged
+
+#### Steps
+
+- [ ] Create `components/classroomAddon/QuizStudentAdapter.tsx`.
+- [ ] Resolve `assignmentId → assignment.code` (the unconditionally-allocated join code from Phase 2-quiz).
+- [ ] Redirect/render at `/quiz?code=...` with the existing `studentRole` Firebase auth in place.
+- [ ] Reference: [hooks/useStudentAssignments.ts:130](../hooks/useStudentAssignments.ts) `openHref` pattern.
+
+#### Completion criteria
+
+- [ ] Adapter ≤ ~30 lines (it's a thin redirect).
+- [ ] Nothing inside `components/widgets/QuizWidget/` or `components/quiz/` modified.
+- [ ] Non-disruption smoke.
+- [ ] Update Dashboard + Progress Log.
+
+---
+
+### Agent 3-va — Video Activity student adapter
+
+- **Status:** ⬜ Not started
+- **Model:** Sonnet 4.6
+- **Owner:** _unassigned_
+- **Dependencies:** 3-shell merged, 1D merged
+
+#### Steps
+
+- [ ] Create `components/classroomAddon/VideoActivityStudentAdapter.tsx`.
+- [ ] Resolve `assignmentId → sessionId`.
+- [ ] Render at `/activity/:sessionId` with `studentRole` Firebase auth in place. The 1D-added SSO branch in `VideoActivityStudentApp.tsx` skips PIN/name entry.
+
+#### Completion criteria
+
+- [ ] Adapter is thin.
+- [ ] Nothing inside `components/widgets/VideoActivityWidget/` modified.
+- [ ] Non-disruption smoke.
+- [ ] Update Dashboard + Progress Log.
+
+---
+
+## Phase 4 — Grade passback (depends on Phase 0.5 + Phase 3)
+
+> **Hard dependency:** Phase 0.5 must be complete. Without stored refresh tokens, this phase cannot work.
+
+### Agent 4-cf — `pushClassroomGrade` Cloud Function
+
+- **Status:** ⬜ Not started
+- **Model:** Opus 4.7 (grading semantics, REST, refresh-token use)
+- **Owner:** _unassigned_
+- **Dependencies:** Phase 0.5 complete, Phase 3 merged
+
+#### Steps
+
+- [ ] Create new module `functions/src/classroomGradePassback.ts`.
+- [ ] Implement callable with input:
+  ```ts
+  {
+    classroomCourseId: string,
+    classroomCourseWorkId: string,
+    classroomAttachmentId: string,
+    classroomSubmissionId: string,
+    pointsEarned: number | null,
+  }
+  ```
+- [ ] Auth: caller is the teacher who owns the assignment (verify against assignment doc).
+- [ ] Use `getValidClassroomAccessToken(uid)` from Phase 0.5.
+- [ ] Call: `PATCH /v1/courses/{courseId}/courseWork/{courseWorkId}/addOnAttachments/{attachmentId}/studentSubmissions/{submissionId}` with `pointsEarned` in body. `[VERIFY]` exact endpoint.
+- [ ] Return `{ ok: true, classroomSubmissionId }` or structured error.
+- [ ] Unit tests:
+  - [ ] Happy path.
+  - [ ] "Teacher doesn't own assignment" → rejected.
+  - [ ] Refresh-token expired/revoked → structured error pointing teacher to re-connect.
+- [ ] Manual end-to-end: complete an activity as a test student, grade appears in Classroom gradebook within 30 seconds (Google's stated upper bound).
+
+#### Completion criteria
+
+- [ ] Unit tests pass.
+- [ ] Manual end-to-end grade appears in real Classroom gradebook.
+- [ ] Code reviewed by human before deploy.
+- [ ] Non-disruption smoke.
+- [ ] Update Dashboard + Progress Log.
+
+---
+
+### Agent 4-quiz — Quiz submission hook wiring
+
+- **Status:** ⬜ Not started
+- **Model:** Sonnet 4.6
+- **Owner:** _unassigned_
+- **Dependencies:** 4-cf merged
+
+#### Steps
+
+- [ ] Edit [hooks/useQuizSession.ts](../hooks/useQuizSession.ts).
+- [ ] When student-side `submitQuiz` (or equivalent) completes, check if response doc has `classroomSubmissionId` set.
+  - If yes: fire-and-forget `pushClassroomGrade`. Compute `pointsEarned` from existing `gradeAnswer()`.
+  - If no: existing behavior unchanged.
+- [ ] Don't block submission UI on grade-push. Toast on failure: "Grade saved in SpartBoard but couldn't sync to Classroom — try the Resync button."
+- [ ] Add manual "Resync to Classroom" button in teacher's Quiz Results view for failed pushes.
+- [ ] **Critical non-disruption:** new code path only fires when `classroomSubmissionId` is present. Existing PIN/SSO flows write no such field; their submission path is byte-identical to today.
+
+#### Completion criteria
+
+- [ ] PIN-joined Quiz submission unchanged (response doc shape and timing identical).
+- [ ] ClassLink-SSO Quiz submission unchanged.
+- [ ] Classroom-launched Quiz submission triggers grade-push.
+- [ ] Resync button works.
+- [ ] Non-disruption smoke.
+- [ ] Update Dashboard + Progress Log.
+
+---
+
+### Agent 4-va — VA submission hook wiring
+
+- **Status:** ⬜ Not started
+- **Model:** Sonnet 4.6
+- **Owner:** _unassigned_
+- **Dependencies:** 4-cf merged
+
+#### Steps
+
+Identical pattern to 4-quiz, against [hooks/useVideoActivitySession.ts](../hooks/useVideoActivitySession.ts). Same non-disruption guarantee.
+
+#### Completion criteria
+
+Same as 4-quiz.
+
+---
+
+## Phase 5 — Polish (sequential, single agent)
+
+- **Status:** ⬜ Not started
+- **Model:** Sonnet 4.6 (visual iteration)
+- **Owner:** _unassigned_
+- **Dependencies:** all of Phases 0–4 complete
+
+#### Steps
+
+- [ ] Tighten visual layouts of teacher discovery + student views for Classroom iframe dimensions. Test at 800×600, 1024×768, narrow embed.
+- [ ] Add "Published to Classroom" badge on Quiz and VA assignment archive rows when `classroomAttachmentId` is set.
+- [ ] Add "Push grades to Classroom" bulk action in Results view for assignments where Phase 4 wiring exists.
+- [ ] Suppress / re-label the unused join-code chip on Classroom-attached assignments (pick: hide entirely OR label as "Backup PIN").
+- [ ] Make the "Connect to Classroom gradebook" button discoverable in teacher settings + onboarding hint on first add-on attempt without a stored refresh token.
+- [ ] Help text and onboarding hints for first-time teachers.
+
+#### Completion criteria
+
+- [ ] All visual checks pass at three iframe widths.
+- [ ] Badge appears correctly on Classroom-attached assignments only.
+- [ ] Bulk-resync action works on a real assignment with multiple responses.
+- [ ] Non-disruption smoke (final).
+- [ ] Final verification end-to-end ([§ Final verification](#final-verification-before-shipping)).
+- [ ] Update Dashboard + Progress Log → 🎉 Plan complete.
+
+---
+
+## ✅ Cross-phase verification gates
+
+Before merging any phase's PR, the implementing agent confirms:
+
+1. [ ] `pnpm run type-check` clean across the whole repo.
+2. [ ] `pnpm test` passes including all new tests added in that phase.
+3. [ ] `pnpm test tests/rules/` passes if the phase touched `firestore.rules` or referenced types — **AND no previously-passing test starts failing.**
+4. [ ] No unintended diff outside files listed for that phase. `git diff --stat main` and visually scan.
+5. [ ] **PII gate audit:** `grep -r "email\|displayName\|fullName" components/classroomAddon/` returns empty.
+6. [ ] **Non-disruption smoke (mandatory every phase):**
+   - [ ] PIN-joined Quiz completes end-to-end.
+   - [ ] ClassLink-SSO Quiz from `/my-assignments` completes end-to-end.
+   - [ ] PIN-joined VideoActivity completes end-to-end.
+7. [ ] **In-progress assignments invariant:** with a live test session in flight (PIN + SSO students mid-quiz), submit a response after the deploy and confirm the write succeeds.
+8. [ ] `pnpm run lint` clean (zero errors AND warnings — repo enforces `--max-warnings 0`).
+9. [ ] `pnpm run format:check` clean.
+
+---
+
+## 🔒 Final verification before shipping
+
+End-to-end test, in order:
+
+1. [ ] Phase 0B install propagated: SpartBoard appears in test teacher's Classroom Add menu.
+2. [ ] Phase 0.5: test teacher clicks "Connect to Classroom gradebook," consent flow completes, refresh token persisted in `/users/{uid}/google_oauth/classroomGradebook`, doc unreadable from client.
+3. [ ] Phase 2: teacher creates a Quiz attachment from inside Classroom; assignment doc has `classroomCourseId` and `classroomAttachmentId` set.
+4. [ ] Phase 3: test student (different account) clicks attachment, lands in `/classroom-addon/student/:id`, signs in with custom token, completes the quiz. Response doc keyed by pseudonym UID, no `name`/`email`/`pin` fields, carries `classroomSubmissionId`.
+5. [ ] Phase 4: grade appears in Classroom gradebook within 30 seconds.
+6. [ ] Repeat 2–5 for Video Activity.
+7. [ ] **Non-disruption final check:** PIN-joined Quiz, ClassLink-SSO Quiz, PIN-joined VideoActivity all complete end-to-end on the same deployed build.
+8. [ ] **PII gate final audit:** `grep -r "email\|displayName\|fullName" components/classroomAddon/` empty; no Classroom-related Firestore document contains a student name, email, or PIN.
+
+---
+
+## 🚫 What NOT to do
+
+- ❌ Create a new GCP project. Extend the existing Firebase-linked one.
+- ❌ Add Google `userId` to any type or Firestore field.
+- ❌ Store student names / emails / PINs in Firestore. Drive only, or not at all.
+- ❌ Modify Quiz, MiniApp, or GuidedLearning student runners. The single authorized runner change is the VA SSO branch (Agent 1D).
+- ❌ Build a parallel student auth system. `classroomAddonLoginV1` mirrors `studentLoginV1`'s claim shape exactly.
+- ❌ Skip JWKS signature verification on launch tokens. Highest-severity bug class.
+- ❌ Pull Classroom rosters via the Classroom REST API. Not needed.
+- ❌ Auto-deploy Cloud Functions. Every CF in this plan requires a human deploy gate.
+- ❌ Touch MiniApp or GuidedLearning. Out of scope.
+- ❌ Set Marketplace SDK App Visibility to "Public." Triggers Marketplace review.
+- ❌ Use Console UI when `gcloud`/`firebase` CLI would do. UI clicks are last resort.
+- ❌ Remove or branch around the unconditional `allocateJoinCode()` in `useQuizAssignments.createAssignment`. Accept the harmless unused PIN.
+- ❌ Migrate or backfill any existing response/assignment/session doc.
+- ❌ Tighten any existing Firestore rule or remove any enum value. All schema and rules changes are strictly additive.
+
+---
+
+## 🧰 Quick-start commands
+
+```bash
+# Confirm project alignment
+gcloud config get-value project
+firebase projects:list
+
+# Inspect current state
+gcloud services list --enabled | grep -E '(classroom|marketplace|appsmarket)'
+cat firebase.json | grep -A 5 "frame-ancestors"
+
+# Inventory existing custom-token / auth references
+ls functions/src/
+grep -l "studentLoginV1\|customToken" functions/src/
+
+# Confirm OAuth flow currently has no offline-access (Phase 0.5 changes this)
+grep -r "access_type\|prompt:\s*'consent'" config/ context/
+
+# Verify hooks naming (singular, not plural)
+ls hooks/useVideoActiv*.ts
+
+# Read the Quiz SSO template you'll mirror for VA in Agent 1D
+sed -n '50,100p' components/quiz/QuizStudentApp.tsx
+```
+
+---
+
+## Tracking Protocol
+
+**Every AI agent (orchestrator + sub-agents) working on this integration MUST follow these rules.** The whole point of this document is so work can be paused and resumed. If you do not update this file, the next agent has no idea where things stand.
+
+### Before starting any sub-agent work
+
+1. **Read [§ Phase Status Dashboard](#phase-status-dashboard)** to find the agent task you're about to start.
+2. **Verify dependencies are satisfied** (the task's "Dependencies" line must all be ✅).
+3. **Update the Dashboard row** for your task: status `🟡 In progress`, owner `your-session-id-or-name`, last-update timestamp.
+4. **Append a Progress Log entry** announcing what you're starting.
+
+### While working
+
+- **Check off Steps and Completion criteria** as you complete them. Do this _as you go_, not at the end. If you stop mid-task, the partial checkboxes are how the next agent picks up.
+- **Append findings to the task's "Notes / handoff" section** for anything the next phase needs to know — design decisions, surprises, blockers you worked around.
+- **Use `[VERIFY]` markers** when you fetch info from external docs and cite the source URL.
+
+### When pausing/stopping mid-task
+
+- Set the Dashboard row status back to `🟡 In progress` (it should already be) and update the timestamp.
+- Append a Progress Log entry: "**Paused**: <task>, last completed step: <step>, next step: <step>, blockers: <none / list>."
+
+### When completing a task
+
+- Verify all "Completion criteria" boxes are checked.
+- Run the [§ Cross-phase verification gates](#cross-phase-verification-gates).
+- Update the Dashboard row → ✅ Complete with timestamp.
+- Append a Progress Log entry summarizing what shipped + any caveats for downstream phases.
+- If your work unblocks downstream agents, mention them by name in the log entry so the orchestrator knows what's now eligible.
+
+### When blocked
+
+- Update the Dashboard row → ⚠️ Blocked.
+- Append a Progress Log entry describing the block and what's needed to unblock.
+- Surface to Paul (the human owner) before continuing — do not silently work around blockers, especially around grade-write scopes, JWKS verification, or anything in the [§ What NOT to do](#-what-not-to-do) list.
+
+### Orchestrator (main Claude) responsibilities
+
+- **Spawn sub-agents** with the model specified in the Dashboard.
+- **Verify the sub-agent updated this file** before considering its work complete (trust but verify — read the actual file diff).
+- **Run the non-disruption smoke** between phases.
+- **Surface decisions to Paul** for: any `[VERIFY]` item that resolves differently than the plan assumes; any time a "What NOT to do" item is tempting; any blocker.
+- **Final completion:** the orchestrator marks the plan complete only after [§ Final verification](#final-verification-before-shipping) passes end-to-end.
+
+---
+
+## Progress Log
+
+> Append-only. Newest entries first. Each entry: `### YYYY-MM-DD HH:MM — <agent name or "orchestrator"> — <one-line summary>` followed by 2-5 bullet points of detail.
+
+### 2026-04-28 — review agent — Initial plan drafted, no implementation work started
+
+- Verified all architectural claims against the actual codebase. PII model, custom-token shape, class-gate Firestore rules, and library-primitive reuse all align with how the codebase works.
+- Surfaced and resolved 3 gaps in the original prompt: OAuth refresh-token storage (now Phase 0.5), VideoActivity SSO branch (now Agent 1D), grade-passback scope verification (still `[VERIFY]`, gated on Phase 0B).
+- Resolved decisions with Paul: (1) one-time consent step approved, (2) VA runner change authorized, (3) scope set must be verified before adding.
+- Plan written to `docs/classroom-addon-integration-plan.md`. Ready for Phase 0A kickoff.
+- Next agent: pick up Phase 0A (Sonnet 4.6) — see [§ Phase 0A — `gcloud`-automatable](#phase-0a--gcloud-automatable).

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -161,7 +161,130 @@
           "order": "ASCENDING"
         }
       ]
+    },
+    {
+      "collectionGroup": "quiz_sessions",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "classIds",
+          "arrayConfig": "CONTAINS"
+        },
+        {
+          "fieldPath": "status",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "endedAt",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "quiz_sessions",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "classId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "status",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "endedAt",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "video_activity_sessions",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "classIds",
+          "arrayConfig": "CONTAINS"
+        },
+        {
+          "fieldPath": "status",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "endedAt",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "video_activity_sessions",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "classId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "status",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "endedAt",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "mini_app_sessions",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "classIds",
+          "arrayConfig": "CONTAINS"
+        },
+        {
+          "fieldPath": "status",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "mini_app_sessions",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "classIds",
+          "arrayConfig": "CONTAINS"
+        },
+        {
+          "fieldPath": "status",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "endedAt",
+          "order": "DESCENDING"
+        }
+      ]
     }
   ],
-  "fieldOverrides": []
+  "fieldOverrides": [
+    {
+      "collectionGroup": "rosters",
+      "fieldPath": "classlinkClassId",
+      "indexes": [
+        { "order": "ASCENDING", "queryScope": "COLLECTION" },
+        { "order": "DESCENDING", "queryScope": "COLLECTION" },
+        { "order": "ASCENDING", "queryScope": "COLLECTION_GROUP" }
+      ]
+    },
+    {
+      "collectionGroup": "rosters",
+      "fieldPath": "testClassId",
+      "indexes": [
+        { "order": "ASCENDING", "queryScope": "COLLECTION" },
+        { "order": "DESCENDING", "queryScope": "COLLECTION" },
+        { "order": "ASCENDING", "queryScope": "COLLECTION_GROUP" }
+      ]
+    }
+  ]
 }

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -282,8 +282,7 @@
       "fieldPath": "testClassId",
       "indexes": [
         { "order": "ASCENDING", "queryScope": "COLLECTION" },
-        { "order": "DESCENDING", "queryScope": "COLLECTION" },
-        { "order": "ASCENDING", "queryScope": "COLLECTION_GROUP" }
+        { "order": "DESCENDING", "queryScope": "COLLECTION" }
       ]
     }
   ]

--- a/firestore.rules
+++ b/firestore.rules
@@ -910,8 +910,14 @@ service cloud.firestore {
           (request.auth.uid == resource.data.studentUid &&
            passesStudentClassGateCompat(sessionClassIds(), sessionClassId()) &&
            request.resource.data.studentUid == resource.data.studentUid &&
-           request.resource.data.pin == resource.data.pin &&
-           request.resource.data.joinedAt == resource.data.joinedAt &&
+           // SSO studentRole responses omit `pin` entirely (no PIN was used
+           // to join), so direct dot-access on `resource.data.pin` would
+           // throw a Null-value error and deny the write. Use `.get(_, null)`
+           // so the immutability check tolerates the field being absent on
+           // both sides — the `hasOnly([...])` clause below still prevents
+           // a student from adding/changing `pin` or `joinedAt`.
+           request.resource.data.get('pin', null) == resource.data.get('pin', null) &&
+           request.resource.data.get('joinedAt', null) == resource.data.get('joinedAt', null) &&
            request.resource.data.score == null &&
            request.resource.data.diff(resource.data)
              .changedKeys().hasOnly(['answers', 'status', 'submittedAt', 'tabSwitchWarnings', 'completedAttempts', 'classPeriod', 'score']) &&
@@ -1061,9 +1067,14 @@ service cloud.firestore {
           studentUid == request.auth.uid &&
           passesStudentClassGateCompat(vaSessionClassIds(), vaSessionClassId()) &&
           request.resource.data.studentUid == resource.data.studentUid &&
-          request.resource.data.pin == resource.data.pin &&
-          request.resource.data.name == resource.data.name &&
-          request.resource.data.joinedAt == resource.data.joinedAt &&
+          // Same fragility class as the quiz_sessions/responses rule: SSO
+          // studentRole responses may omit `pin` and `name` entirely, so
+          // direct dot-access would throw and deny the write. The
+          // `affectedKeys().hasOnly(['answers', 'completedAt'])` clause
+          // below still prevents a student from adding/changing them.
+          request.resource.data.get('pin', null) == resource.data.get('pin', null) &&
+          request.resource.data.get('name', null) == resource.data.get('name', null) &&
+          request.resource.data.get('joinedAt', null) == resource.data.get('joinedAt', null) &&
           request.resource.data.score == resource.data.score &&
           request.resource.data.diff(resource.data).affectedKeys().hasOnly(['answers', 'completedAt']) &&
           request.resource.data.answers.size() >= resource.data.answers.size() &&

--- a/functions/src/index.test.ts
+++ b/functions/src/index.test.ts
@@ -1515,5 +1515,236 @@ describe('getPseudonymsForAssignmentV1', () => {
     ).rejects.toThrow('Teacher account required.');
   });
 
-  /* eslint-enable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-assignment */
+  // ── Test-class branch ─────────────────────────────────────────────────
+  // These tests cover the branch added to resolve names for SSO students
+  // who logged in via the `studentLoginV1` test bypass (test classes are
+  // admin-managed mocks under `organizations/{orgId}/testClasses` that
+  // bypass ClassLink/OneRoster entirely).
+
+  /* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-return */
+
+  /**
+   * Wires up the mockFirestore primitives for the test-class branch:
+   *   db.doc('organizations/{org}/members/{email}')   — membership gate
+   *   db.doc('organizations/{org}/testClasses/{cid}') — test-class doc
+   *   db.collection('users/{uid}/rosters').where('testClassId','==',cid)
+   *                                                   — ownership gate
+   *
+   * Pass `null` for `testClass` to simulate a non-existent test-class doc
+   * (so the function falls through to the ClassLink branch).
+   */
+  const installTestClassMocks = (opts: {
+    orgId: string;
+    teacherEmailLower: string;
+    teacherUid: string;
+    isMember: boolean;
+    testClassPath: string;
+    testClass: { memberEmails?: string[] } | null;
+    ownsRoster: boolean;
+  }) => {
+    const memberPath = `organizations/${opts.orgId}/members/${opts.teacherEmailLower}`;
+    mockFirestore.doc.mockImplementation((path: string) => {
+      if (path === memberPath) {
+        return {
+          path,
+          get: vi.fn(() =>
+            Promise.resolve({ exists: opts.isMember, data: () => ({}) })
+          ),
+        } as any;
+      }
+      if (path === opts.testClassPath) {
+        return {
+          path,
+          get: vi.fn(() =>
+            Promise.resolve(
+              opts.testClass
+                ? { exists: true, data: () => opts.testClass }
+                : { exists: false, data: () => ({}) }
+            )
+          ),
+        } as any;
+      }
+      return { path, get: vi.fn(() => Promise.resolve({ exists: false })) };
+    });
+
+    const rostersPath = `users/${opts.teacherUid}/rosters`;
+    const baseCollectionImpl = mockFirestore.collection.getMockImplementation();
+    mockFirestore.collection.mockImplementation((name: string) => {
+      if (name === rostersPath) {
+        return {
+          where: vi.fn(() => ({
+            limit: vi.fn(() => ({
+              get: vi.fn(() =>
+                Promise.resolve({ empty: !opts.ownsRoster, docs: [] })
+              ),
+            })),
+          })),
+        } as any;
+      }
+      // Fall back to the existing collection mock for unrelated collections.
+      return baseCollectionImpl ? baseCollectionImpl(name) : ({} as any);
+    });
+  };
+
+  it('returns pseudonyms keyed by HMAC("test:{email}") for a test-class assignment', async () => {
+    installTestClassMocks({
+      orgId: 'orono',
+      teacherEmailLower: 'teacher@district.org',
+      teacherUid: 'teacher-uid',
+      isMember: true,
+      testClassPath: 'organizations/orono/testClasses/mock-period-1',
+      testClass: {
+        memberEmails: [
+          'sstudent25@orono.k12.mn.us',
+          'OtherStudent@orono.k12.mn.us',
+        ],
+      },
+      ownsRoster: true,
+    });
+    // axios.get must NOT be called for the test-class branch — assert by
+    // not installing any URL-aware responses (default reject would surface
+    // an unexpected ClassLink call as a test failure).
+
+    const handler = getPseudonymsForAssignmentV1 as any;
+    const result = (await handler(
+      {
+        assignmentId: 'asn-1',
+        classId: 'mock-period-1',
+        orgId: 'orono',
+      },
+      { auth: TEACHER_AUTH }
+    )) as {
+      pseudonyms: Record<
+        string,
+        {
+          studentUid: string;
+          assignmentPseudonym: string;
+          givenName: string;
+          familyName: string;
+        }
+      >;
+    };
+
+    // Two members → two pseudonym entries, keyed by lowercased email.
+    expect(Object.keys(result.pseudonyms).sort()).toEqual([
+      'otherstudent@orono.k12.mn.us',
+      'sstudent25@orono.k12.mn.us',
+    ]);
+
+    // Display name is the email local-part (matches the import dialog).
+    expect(result.pseudonyms['sstudent25@orono.k12.mn.us'].givenName).toBe(
+      'sstudent25'
+    );
+    expect(result.pseudonyms['sstudent25@orono.k12.mn.us'].familyName).toBe('');
+    expect(result.pseudonyms['otherstudent@orono.k12.mn.us'].givenName).toBe(
+      'otherstudent'
+    );
+
+    // The studentUid is the same HMAC formula `studentLoginV1` uses for
+    // test-bypass tokens (`HMAC(secret, "sid:test:{emailLower}")`). If the
+    // formulas drift, name resolution silently breaks — pin them together.
+    const cryptoJs = await import('crypto-js');
+    const expectedSstudent25Uid = cryptoJs
+      .HmacSHA256('sid:test:sstudent25@orono.k12.mn.us', 'test-hmac-secret')
+      .toString(cryptoJs.enc.Hex);
+    expect(result.pseudonyms['sstudent25@orono.k12.mn.us'].studentUid).toBe(
+      expectedSstudent25Uid
+    );
+
+    // Axios was NOT called — confirms the test-class branch short-circuits
+    // before any ClassLink lookup.
+    expect(vi.mocked(axios.get)).not.toHaveBeenCalled();
+  });
+
+  it('rejects when the teacher is not a member of the claimed orgId', async () => {
+    installTestClassMocks({
+      orgId: 'orono',
+      teacherEmailLower: 'teacher@district.org',
+      teacherUid: 'teacher-uid',
+      isMember: false, // ← not in the org members collection
+      testClassPath: 'organizations/orono/testClasses/mock-period-1',
+      testClass: { memberEmails: ['s1@orono.k12.mn.us'] },
+      ownsRoster: true,
+    });
+
+    const handler = getPseudonymsForAssignmentV1 as any;
+    await expect(
+      handler(
+        {
+          assignmentId: 'asn-1',
+          classId: 'mock-period-1',
+          orgId: 'orono',
+        },
+        { auth: TEACHER_AUTH }
+      )
+    ).rejects.toThrow('Not a member of this organization.');
+  });
+
+  it("rejects when the teacher doesn't own a roster with matching testClassId", async () => {
+    installTestClassMocks({
+      orgId: 'orono',
+      teacherEmailLower: 'teacher@district.org',
+      teacherUid: 'teacher-uid',
+      isMember: true,
+      testClassPath: 'organizations/orono/testClasses/mock-period-1',
+      testClass: { memberEmails: ['s1@orono.k12.mn.us'] },
+      ownsRoster: false, // ← teacher hasn't imported this test class
+    });
+
+    const handler = getPseudonymsForAssignmentV1 as any;
+    await expect(
+      handler(
+        {
+          assignmentId: 'asn-1',
+          classId: 'mock-period-1',
+          orgId: 'orono',
+        },
+        { auth: TEACHER_AUTH }
+      )
+    ).rejects.toThrow('Not a teacher of this test class.');
+  });
+
+  it('falls through to the ClassLink branch when the testClasses doc does not exist', async () => {
+    installTestClassMocks({
+      orgId: 'orono',
+      teacherEmailLower: 'teacher@district.org',
+      teacherUid: 'teacher-uid',
+      isMember: true,
+      testClassPath: 'organizations/orono/testClasses/c-1',
+      testClass: null, // ← real ClassLink class, not a test class
+      ownsRoster: false, // ← irrelevant; ownership gate is only for test classes
+    });
+    // Configure the standard ClassLink mocks so the fall-through path
+    // can complete and we can assert the existing branch behavior.
+    installAxiosMock({
+      teacher: {
+        users: [{ sourcedId: 'teacher-sid', email: 'teacher@district.org' }],
+      },
+      classes: { classes: [{ sourcedId: 'c-1', title: 'Period 1' }] },
+      students: {
+        users: [
+          {
+            sourcedId: 'student-1-sid',
+            givenName: 'Alex',
+            familyName: 'Stone',
+            email: 's1@district.org',
+          },
+        ],
+      },
+    });
+
+    const handler = getPseudonymsForAssignmentV1 as any;
+    const result = (await handler(
+      { assignmentId: 'asn-1', classId: 'c-1', orgId: 'orono' },
+      { auth: TEACHER_AUTH }
+    )) as { pseudonyms: Record<string, unknown> };
+
+    // The ClassLink branch keys by sourcedId, NOT by email. If this assertion
+    // ever fails, double-check that the test-class branch isn't accidentally
+    // catching real ClassLink classes.
+    expect(result.pseudonyms['student-1-sid']).toBeDefined();
+    expect(vi.mocked(axios.get)).toHaveBeenCalled();
+  });
+
+  /* eslint-enable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-return */
 });

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -3016,6 +3016,230 @@ export const getAssignmentPseudonymV1 = onCall(
 );
 
 /**
+ * getStudentClassDirectoryV1
+ *
+ * Returns class metadata (name, teacher display name, subject, code) for the
+ * authenticated student's claim-bound `classIds`. Powers the sidebar on
+ * `/my-assignments` so a student sees "English 9 / Ms. Halverson" instead of
+ * an opaque sourcedId.
+ *
+ * Lookup order per classId:
+ *   1. `collectionGroup('rosters').where('classlinkClassId', '==', classId)` —
+ *      real ClassLink imports. Parent path gives teacher uid.
+ *   2. `collectionGroup('rosters').where('testClassId', '==', classId)` —
+ *      admin-managed test classes a teacher has imported.
+ *   3. `organizations/{orgId}/testClasses/{classId}` — admin-managed test
+ *      class with no teacher import yet (graceful fallback).
+ *
+ * PII: this function never returns student names, emails, or any field from
+ * the per-roster Drive file. Only Firestore-side roster meta (which is
+ * itself PII-free) plus the teacher's own `displayName` from Firebase Auth.
+ * Teacher names are organizational data, not student PII.
+ *
+ * Failure: classIds that match nothing are silently dropped from the
+ * response so the sidebar simply omits them. The page renders a fallback
+ * label client-side rather than treating a missing entry as an error.
+ */
+export const getStudentClassDirectoryV1 = onCall(
+  {
+    memory: '256MiB',
+    invoker: 'public',
+  },
+  async (request) => {
+    if (!request.auth) {
+      throw new HttpsError('unauthenticated', 'Sign in required.');
+    }
+    if (request.auth.token.studentRole !== true) {
+      throw new HttpsError('permission-denied', 'Student role required.');
+    }
+
+    const rawClassIds: unknown = request.auth.token.classIds;
+    if (!Array.isArray(rawClassIds)) {
+      throw new HttpsError('failed-precondition', 'No classes on token.');
+    }
+    const classIds = rawClassIds
+      .filter((c): c is string => typeof c === 'string' && c.length > 0)
+      .slice(0, STUDENT_LOGIN_CLASS_IDS_MAX);
+    if (classIds.length === 0) {
+      return { classes: [] };
+    }
+
+    const orgId =
+      typeof request.auth.token.orgId === 'string'
+        ? request.auth.token.orgId
+        : '';
+
+    const db = admin.firestore();
+
+    // Per-call cache: many classes may share a teacher; one Auth lookup
+    // suffices.
+    const teacherNameCache = new Map<string, string>();
+    const resolveTeacherName = async (teacherUid: string): Promise<string> => {
+      const cached = teacherNameCache.get(teacherUid);
+      if (cached !== undefined) return cached;
+      try {
+        const user = await admin.auth().getUser(teacherUid);
+        const displayName =
+          (typeof user.displayName === 'string' && user.displayName) ||
+          (typeof user.email === 'string' ? user.email.split('@')[0] : '') ||
+          '';
+        teacherNameCache.set(teacherUid, displayName);
+        return displayName;
+      } catch {
+        // Auth lookup can fail for legacy / deleted teacher accounts. Caller
+        // falls back to an empty teacher name; the row still renders.
+        teacherNameCache.set(teacherUid, '');
+        return '';
+      }
+    };
+
+    interface DirectoryEntry {
+      classId: string;
+      name: string;
+      teacherDisplayName: string;
+      subject?: string;
+      code?: string;
+    }
+
+    // Batch the per-classId collectionGroup queries instead of fanning out
+    // 2-3 queries per id (up to 60 queries for STUDENT_LOGIN_CLASS_IDS_MAX
+    // = 20). Firestore caps `in`-array size at 30; we chunk at 10 to stay
+    // safely under the limit and to fit the typical `STUDENT_LOGIN_CLASS_IDS_MAX`
+    // payload in 2-3 chunks.
+    const FIRESTORE_IN_CHUNK_SIZE = 10;
+    const chunk = <T>(arr: readonly T[], size: number): T[][] => {
+      const chunks: T[][] = [];
+      for (let i = 0; i < arr.length; i += size) {
+        chunks.push(arr.slice(i, i + size));
+      }
+      return chunks;
+    };
+
+    /**
+     * Run `collectionGroup('rosters').where(field, 'in', chunk)` for every
+     * chunk of `ids`, then index the matching roster docs by their
+     * `field`-value. First match wins on duplicates so the teacher whose
+     * roster Firestore returns first deterministically owns the directory
+     * entry for that class.
+     */
+    const batchLookupByField = async (
+      field: 'classlinkClassId' | 'testClassId',
+      ids: readonly string[]
+    ): Promise<Map<string, FirebaseFirestore.QueryDocumentSnapshot>> => {
+      const out = new Map<string, FirebaseFirestore.QueryDocumentSnapshot>();
+      if (ids.length === 0) return out;
+      const snapshots = await Promise.all(
+        chunk(ids, FIRESTORE_IN_CHUNK_SIZE).map((idChunk) =>
+          db.collectionGroup('rosters').where(field, 'in', idChunk).get()
+        )
+      );
+      for (const snap of snapshots) {
+        for (const doc of snap.docs) {
+          const value: unknown = doc.get(field);
+          if (typeof value === 'string' && !out.has(value)) {
+            out.set(value, doc);
+          }
+        }
+      }
+      return out;
+    };
+
+    const buildEntryFromRoster = async (
+      classId: string,
+      rosterDoc: FirebaseFirestore.QueryDocumentSnapshot,
+      includeCode: boolean
+    ): Promise<DirectoryEntry> => {
+      const data = rosterDoc.data();
+      const teacherUid = rosterDoc.ref.parent.parent?.id ?? '';
+      const teacherDisplayName = teacherUid
+        ? await resolveTeacherName(teacherUid)
+        : '';
+      return {
+        classId,
+        name: typeof data.name === 'string' ? data.name : classId,
+        teacherDisplayName,
+        subject:
+          typeof data.classlinkSubject === 'string'
+            ? data.classlinkSubject
+            : undefined,
+        code:
+          includeCode && typeof data.classlinkClassCode === 'string'
+            ? data.classlinkClassCode
+            : undefined,
+      };
+    };
+
+    // 1 + 2. Batched collectionGroup lookups: classlinkClassId first, then
+    // testClassId for whatever didn't resolve. Two `in` queries per field
+    // chunk replace what was up to 40 separate equality queries.
+    const classlinkMatches = await batchLookupByField(
+      'classlinkClassId',
+      classIds
+    );
+    const unresolvedAfterClasslink = classIds.filter(
+      (id) => !classlinkMatches.has(id)
+    );
+    const testIdMatches = await batchLookupByField(
+      'testClassId',
+      unresolvedAfterClasslink
+    );
+
+    // 3. Direct testClasses doc reads — only for classIds still unresolved
+    // after the two batched roster passes. These are the admin-managed
+    // test classes that no teacher has imported yet.
+    const unresolvedAfterTestId = unresolvedAfterClasslink.filter(
+      (id) => !testIdMatches.has(id)
+    );
+    const testClassDocs = new Map<string, FirebaseFirestore.DocumentSnapshot>();
+    if (orgId && unresolvedAfterTestId.length > 0) {
+      const docs = await Promise.all(
+        unresolvedAfterTestId.map((id) =>
+          db
+            .doc(`organizations/${orgId}/testClasses/${id}`)
+            .get()
+            .catch(() => null)
+        )
+      );
+      for (let i = 0; i < unresolvedAfterTestId.length; i++) {
+        const d = docs[i];
+        if (d && d.exists) testClassDocs.set(unresolvedAfterTestId[i], d);
+      }
+    }
+
+    const entries = await Promise.all(
+      classIds.map(async (classId): Promise<DirectoryEntry | null> => {
+        const fromClasslink = classlinkMatches.get(classId);
+        if (fromClasslink) {
+          return buildEntryFromRoster(classId, fromClasslink, true);
+        }
+        const fromTestId = testIdMatches.get(classId);
+        if (fromTestId) {
+          return buildEntryFromRoster(classId, fromTestId, false);
+        }
+        const fromTestClassDoc = testClassDocs.get(classId);
+        if (fromTestClassDoc) {
+          const data = fromTestClassDoc.data() ?? {};
+          return {
+            classId,
+            name:
+              typeof data.title === 'string' && data.title.length > 0
+                ? data.title
+                : classId,
+            teacherDisplayName: '',
+            subject:
+              typeof data.subject === 'string' ? data.subject : undefined,
+          };
+        }
+        return null;
+      })
+    );
+
+    const classes = entries.filter((e): e is DirectoryEntry => e !== null);
+    return { classes };
+  }
+);
+
+/**
  * getPseudonymsForAssignmentV1
  *
  * Called by a teacher's client when rendering the grading view for an

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -3025,11 +3025,13 @@ export const getAssignmentPseudonymV1 = onCall(
  *
  * Lookup order per classId:
  *   1. `collectionGroup('rosters').where('classlinkClassId', '==', classId)` —
- *      real ClassLink imports. Parent path gives teacher uid.
- *   2. `collectionGroup('rosters').where('testClassId', '==', classId)` —
- *      admin-managed test classes a teacher has imported.
- *   3. `organizations/{orgId}/testClasses/{classId}` — admin-managed test
- *      class with no teacher import yet (graceful fallback).
+ *      real ClassLink imports. Parent path gives teacher uid. Safe across
+ *      orgs because ClassLink-issued sourcedIds are not admin-controlled.
+ *   2. `organizations/{orgId}/testClasses/{classId}` — admin-managed test
+ *      classes. Always read via the org-scoped doc path (never via a
+ *      collectionGroup lookup on `testClassId`) because test class IDs are
+ *      admin-chosen slugs that can collide across orgs; a collectionGroup
+ *      query would risk returning another org's roster.
  *
  * PII: this function never returns student names, emails, or any field from
  * the per-roster Drive file. Only Firestore-side roster meta (which is
@@ -3102,10 +3104,9 @@ export const getStudentClassDirectoryV1 = onCall(
     }
 
     // Batch the per-classId collectionGroup queries instead of fanning out
-    // 2-3 queries per id (up to 60 queries for STUDENT_LOGIN_CLASS_IDS_MAX
-    // = 20). Firestore caps `in`-array size at 30; we chunk at 10 to stay
-    // safely under the limit and to fit the typical `STUDENT_LOGIN_CLASS_IDS_MAX`
-    // payload in 2-3 chunks.
+    // a separate equality query per id. Firestore caps `in`-array size at
+    // 30; we chunk at 10 to stay safely under the limit and to fit the
+    // typical `STUDENT_LOGIN_CLASS_IDS_MAX = 20` payload in 2 chunks.
     const FIRESTORE_IN_CHUNK_SIZE = 10;
     const chunk = <T>(arr: readonly T[], size: number): T[][] => {
       const chunks: T[][] = [];
@@ -3123,7 +3124,7 @@ export const getStudentClassDirectoryV1 = onCall(
      * entry for that class.
      */
     const batchLookupByField = async (
-      field: 'classlinkClassId' | 'testClassId',
+      field: 'classlinkClassId',
       ids: readonly string[]
     ): Promise<Map<string, FirebaseFirestore.QueryDocumentSnapshot>> => {
       const out = new Map<string, FirebaseFirestore.QueryDocumentSnapshot>();
@@ -3169,9 +3170,11 @@ export const getStudentClassDirectoryV1 = onCall(
       };
     };
 
-    // 1 + 2. Batched collectionGroup lookups: classlinkClassId first, then
-    // testClassId for whatever didn't resolve. Two `in` queries per field
-    // chunk replace what was up to 40 separate equality queries.
+    // 1. Batched collectionGroup lookup for ClassLink classes. Two `in`
+    // queries per field chunk replace what was up to 20 separate equality
+    // queries. Real ClassLink sourcedIds are issued globally by ClassLink
+    // and are not admin-controlled, so collisions across orgs are not a
+    // realistic risk on this branch.
     const classlinkMatches = await batchLookupByField(
       'classlinkClassId',
       classIds
@@ -3179,30 +3182,32 @@ export const getStudentClassDirectoryV1 = onCall(
     const unresolvedAfterClasslink = classIds.filter(
       (id) => !classlinkMatches.has(id)
     );
-    const testIdMatches = await batchLookupByField(
-      'testClassId',
-      unresolvedAfterClasslink
-    );
 
-    // 3. Direct testClasses doc reads — only for classIds still unresolved
-    // after the two batched roster passes. These are the admin-managed
-    // test classes that no teacher has imported yet.
-    const unresolvedAfterTestId = unresolvedAfterClasslink.filter(
-      (id) => !testIdMatches.has(id)
-    );
+    // 2. Direct testClasses doc reads — for every classId not resolved as
+    // ClassLink. We deliberately do NOT use a `collectionGroup('rosters')
+    // .where('testClassId', 'in', …)` lookup here: testClassIds are
+    // admin-chosen slugs (default `testclass`, or a slugified title) and
+    // can collide across orgs, so a collectionGroup query would risk
+    // returning another org's roster doc and leaking that teacher's name
+    // and class metadata to the student. The org-scoped document path is
+    // gated by the student's verified `orgId` claim, so it cannot cross
+    // org boundaries. The trade-off is that we no longer surface the
+    // importing teacher's display name on test-class directory entries —
+    // these are admin-managed mocks where teacher attribution is
+    // cosmetic.
     const testClassDocs = new Map<string, FirebaseFirestore.DocumentSnapshot>();
-    if (orgId && unresolvedAfterTestId.length > 0) {
+    if (orgId && unresolvedAfterClasslink.length > 0) {
       const docs = await Promise.all(
-        unresolvedAfterTestId.map((id) =>
+        unresolvedAfterClasslink.map((id) =>
           db
             .doc(`organizations/${orgId}/testClasses/${id}`)
             .get()
             .catch(() => null)
         )
       );
-      for (let i = 0; i < unresolvedAfterTestId.length; i++) {
+      for (let i = 0; i < unresolvedAfterClasslink.length; i++) {
         const d = docs[i];
-        if (d && d.exists) testClassDocs.set(unresolvedAfterTestId[i], d);
+        if (d && d.exists) testClassDocs.set(unresolvedAfterClasslink[i], d);
       }
     }
 
@@ -3211,10 +3216,6 @@ export const getStudentClassDirectoryV1 = onCall(
         const fromClasslink = classlinkMatches.get(classId);
         if (fromClasslink) {
           return buildEntryFromRoster(classId, fromClasslink, true);
-        }
-        const fromTestId = testIdMatches.get(classId);
-        if (fromTestId) {
-          return buildEntryFromRoster(classId, fromTestId, false);
         }
         const fromTestClassDoc = testClassDocs.get(classId);
         if (fromTestClassDoc) {

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -3059,10 +3059,15 @@ export const getPseudonymsForAssignmentV1 = onCall(
     const data = request.data as {
       assignmentId?: unknown;
       classId?: unknown;
+      orgId?: unknown;
     };
     const assignmentId =
       typeof data?.assignmentId === 'string' ? data.assignmentId : '';
     const classId = typeof data?.classId === 'string' ? data.classId : '';
+    // orgId is optional for backwards compatibility (older clients). The
+    // test-class branch only activates when it's provided AND the requested
+    // classId resolves to a `testClasses` doc under that org.
+    const orgId = typeof data?.orgId === 'string' ? data.orgId : '';
     if (!assignmentId || !classId) {
       throw new HttpsError(
         'invalid-argument',
@@ -3081,6 +3086,99 @@ export const getPseudonymsForAssignmentV1 = onCall(
       !tenantUrl
     ) {
       throw new HttpsError('internal', 'Server configuration missing.');
+    }
+
+    // ── Test-class branch ────────────────────────────────────────────────
+    // Test classes (admin-managed mocks under `organizations/{orgId}/testClasses`)
+    // bypass ClassLink entirely. Their students log in via the `studentLoginV1`
+    // test bypass, which mints UIDs as `HMAC("sid:test:{emailLower}", secret)`.
+    // ClassLink OneRoster has no record of them, so the standard branch returns
+    // an empty pseudonym map and the teacher monitor falls back to "Student".
+    // This branch resolves names from the `memberEmails` array on the test-class
+    // doc, using the email local-part as the display name (matching what
+    // `materializeTestClassStudents` shows in the import dialog).
+    if (orgId) {
+      const db = admin.firestore();
+      const teacherEmailLower = teacherEmail.toLowerCase();
+      const memberRef = db.doc(
+        `organizations/${orgId}/members/${teacherEmailLower}`
+      );
+      const memberSnap = await memberRef.get();
+      if (!memberSnap.exists) {
+        throw new HttpsError(
+          'permission-denied',
+          'Not a member of this organization.'
+        );
+      }
+
+      const testClassRef = db.doc(
+        `organizations/${orgId}/testClasses/${classId}`
+      );
+      const testClassSnap = await testClassRef.get();
+      if (testClassSnap.exists) {
+        // Authorize: teacher must own a roster whose `testClassId` matches.
+        // Roster metadata lives in Firestore (no Drive read needed for this
+        // gate). Same trust model as the ClassLink branch's "teaches this
+        // class" check, but anchored to the teacher's own roster ownership.
+        const ownedRosters = await db
+          .collection(`users/${request.auth.uid}/rosters`)
+          .where('testClassId', '==', classId)
+          .limit(1)
+          .get();
+        if (ownedRosters.empty) {
+          throw new HttpsError(
+            'permission-denied',
+            'Not a teacher of this test class.'
+          );
+        }
+
+        const testClassData = (testClassSnap.data() ?? {}) as {
+          memberEmails?: unknown;
+        };
+        const memberEmails = Array.isArray(testClassData.memberEmails)
+          ? testClassData.memberEmails.filter(
+              (e): e is string => typeof e === 'string' && e.length > 0
+            )
+          : [];
+
+        const pseudonyms: Record<
+          string,
+          {
+            studentUid: string;
+            assignmentPseudonym: string;
+            givenName: string;
+            familyName: string;
+          }
+        > = {};
+        for (const rawEmail of memberEmails) {
+          const emailLower = rawEmail.toLowerCase();
+          // Mirrors `studentLoginV1` test-bypass UID minting at
+          // functions/src/index.ts ~2868: HMAC over "sid:test:{emailLower}".
+          const studentUid = computeStudentUid(
+            `test:${emailLower}`,
+            hmacSecret
+          );
+          // Display name = email local-part. This matches what the import
+          // dialog already shows (`materializeTestClassStudents` line 66:
+          // `firstName: email.split('@')[0]`), so the monitor view stays
+          // consistent with the roster.
+          const localPart = emailLower.split('@')[0] || emailLower;
+          // Key by the lowercased email (no `sourcedId` exists for test
+          // students). The client-side hook only iterates `Object.values`
+          // and re-keys by `studentUid`, so the key choice is internal.
+          pseudonyms[emailLower] = {
+            studentUid,
+            assignmentPseudonym: computeAssignmentPseudonym(
+              studentUid,
+              assignmentId,
+              hmacSecret
+            ),
+            givenName: localPart,
+            familyName: '',
+          };
+        }
+        return { pseudonyms };
+      }
     }
 
     const cleanTenantUrl = tenantUrl.replace(/\/$/, '');

--- a/hooks/useAssignmentPseudonyms.ts
+++ b/hooks/useAssignmentPseudonyms.ts
@@ -59,29 +59,40 @@ const EMPTY_MAPS: AssignmentPseudonymMaps = {
 let cacheOwnerUid: string | null = null;
 let cache: Map<string, Promise<AssignmentPseudonymMaps>> = new Map();
 
-function cacheKey(assignmentId: string, classId: string): string {
-  return `${assignmentId}::${classId}`;
+function cacheKey(
+  assignmentId: string,
+  classId: string,
+  orgId: string
+): string {
+  // orgId is part of the key so a teacher who belongs to multiple orgs
+  // doesn't get a cached test-class result from the wrong org. For ClassLink
+  // classes (no test-class doc under any org) the lookup result is identical
+  // regardless of orgId, so the duplicate cache cost is negligible.
+  return `${assignmentId}::${classId}::${orgId}`;
 }
 
 function fetchPseudonymMaps(
   assignmentId: string,
   classId: string,
+  orgId: string,
   teacherUid: string
 ): Promise<AssignmentPseudonymMaps> {
   if (cacheOwnerUid !== teacherUid) {
     cache = new Map();
     cacheOwnerUid = teacherUid;
   }
-  const key = cacheKey(assignmentId, classId);
+  const key = cacheKey(assignmentId, classId, orgId);
   const cached = cache.get(key);
   if (cached) return cached;
 
   const callable = httpsCallable<
-    { assignmentId: string; classId: string },
+    { assignmentId: string; classId: string; orgId?: string },
     CallableResponse
   >(functions, 'getPseudonymsForAssignmentV1');
 
-  const promise = callable({ assignmentId, classId }).then((res) => {
+  const promise = callable(
+    orgId ? { assignmentId, classId, orgId } : { assignmentId, classId }
+  ).then((res) => {
     const entries = res.data?.pseudonyms ?? {};
     const byStudentUid = new Map<string, StudentName>();
     const byAssignmentPseudonym = new Map<string, StudentName>();
@@ -112,14 +123,18 @@ interface ResolvedMaps {
 
 function pairKey(
   assignmentId: string | null | undefined,
-  classId: string | null | undefined
+  classId: string | null | undefined,
+  orgId: string | null | undefined
 ): string {
-  return assignmentId && classId ? `${assignmentId}::${classId}` : '';
+  return assignmentId && classId
+    ? `${assignmentId}::${classId}::${orgId ?? ''}`
+    : '';
 }
 
 export function useAssignmentPseudonyms(
   assignmentId: string | null | undefined,
-  classId: string | null | undefined
+  classId: string | null | undefined,
+  orgId: string | null | undefined
 ): AssignmentPseudonymMaps {
   const [resolved, setResolved] = useState<ResolvedMaps>({
     key: '',
@@ -127,12 +142,12 @@ export function useAssignmentPseudonyms(
   });
 
   useEffect(() => {
-    const key = pairKey(assignmentId, classId);
+    const key = pairKey(assignmentId, classId, orgId);
     if (!key || !assignmentId || !classId) return;
     const teacherUid = auth.currentUser?.uid ?? '';
     if (!teacherUid) return;
     let cancelled = false;
-    fetchPseudonymMaps(assignmentId, classId, teacherUid)
+    fetchPseudonymMaps(assignmentId, classId, orgId ?? '', teacherUid)
       .then((maps) => {
         if (!cancelled) setResolved({ key, maps });
       })
@@ -142,9 +157,9 @@ export function useAssignmentPseudonyms(
     return () => {
       cancelled = true;
     };
-  }, [assignmentId, classId]);
+  }, [assignmentId, classId, orgId]);
 
-  const currentKey = pairKey(assignmentId, classId);
+  const currentKey = pairKey(assignmentId, classId, orgId);
   return resolved.key === currentKey && currentKey !== ''
     ? resolved.maps
     : EMPTY_MAPS;
@@ -165,7 +180,8 @@ export function formatStudentName(name: StudentName | undefined): string {
  */
 export function useAssignmentPseudonymsMulti(
   assignmentId: string | null | undefined,
-  classIds: readonly string[] | null | undefined
+  classIds: readonly string[] | null | undefined,
+  orgId: string | null | undefined
 ): AssignmentPseudonymMaps {
   // `classIdsKey` is the canonical, value-stable identity for the caller's
   // class list. Deriving it from the raw prop (instead of from a pre-filtered
@@ -177,6 +193,7 @@ export function useAssignmentPseudonymsMulti(
     .slice()
     .sort()
     .join('|');
+  const orgKey = orgId ?? '';
   const [resolved, setResolved] = useState<{
     key: string;
     maps: AssignmentPseudonymMaps;
@@ -188,10 +205,10 @@ export function useAssignmentPseudonymsMulti(
     if (!teacherUid) return;
     const cleanedInEffect = classIdsKey.split('|');
     let cancelled = false;
-    const key = `${assignmentId}::${classIdsKey}`;
+    const key = `${assignmentId}::${classIdsKey}::${orgKey}`;
     Promise.all(
       cleanedInEffect.map((cid) =>
-        fetchPseudonymMaps(assignmentId, cid, teacherUid)
+        fetchPseudonymMaps(assignmentId, cid, orgKey, teacherUid)
       )
     )
       .then((all) => {
@@ -214,11 +231,11 @@ export function useAssignmentPseudonymsMulti(
     return () => {
       cancelled = true;
     };
-  }, [assignmentId, classIdsKey]);
+  }, [assignmentId, classIdsKey, orgKey]);
 
   const currentKey =
     assignmentId && classIdsKey.length > 0
-      ? `${assignmentId}::${classIdsKey}`
+      ? `${assignmentId}::${classIdsKey}::${orgKey}`
       : '';
   return resolved.key === currentKey && currentKey !== ''
     ? resolved.maps

--- a/hooks/useQuizSession.ts
+++ b/hooks/useQuizSession.ts
@@ -942,9 +942,26 @@ export const useQuizSessionStudent = (): UseQuizSessionStudentResult => {
       myResponseRef.current?.tabSwitchWarnings ?? 0
     );
 
-    await updateDoc(responseRef, {
-      tabSwitchWarnings: increment(1),
-    });
+    try {
+      await updateDoc(responseRef, {
+        tabSwitchWarnings: increment(1),
+      });
+    } catch (err) {
+      // Re-throw with extra context so the caller's catch surfaces enough
+      // diagnostic info to bisect intermittent rule failures (PIN-bypass
+      // SSO students vs anonymous PIN students, missing fields, etc.).
+      console.error('[reportTabSwitch] update failed', {
+        sessionId,
+        responseKey,
+        authUid: auth.currentUser?.uid,
+        isAnonymous: auth.currentUser?.isAnonymous,
+        baseCount,
+        hasPinField: myResponseRef.current?.pin !== undefined,
+        hasTabSwitchField:
+          myResponseRef.current?.tabSwitchWarnings !== undefined,
+      });
+      throw err;
+    }
 
     const newCount = baseCount + 1;
     warningCountRef.current = newCount;

--- a/hooks/useQuizSession.ts
+++ b/hooks/useQuizSession.ts
@@ -553,9 +553,18 @@ export interface UseQuizSessionStudentResult {
    * before the student commits to joining.
    */
   lookupSession: (code: string) => Promise<{ periodNames: string[] } | null>;
+  /**
+   * Join a quiz session.
+   *
+   * `pin` is required for anonymous joiners (the original `/quiz?code=…` and
+   * `/join` flows) and omitted for SSO `studentRole` joiners launched from
+   * `/my-assignments` — their identity is the auth uid carried on the
+   * custom token, so no roster PIN is needed. The hook validates this at
+   * call time: anonymous + missing pin throws "PIN is required".
+   */
   joinQuizSession: (
     code: string,
-    pin: string,
+    pin?: string,
     classPeriod?: string
   ) => Promise<string>;
   submitAnswer: (
@@ -675,7 +684,7 @@ export const useQuizSessionStudent = (): UseQuizSessionStudentResult => {
   const joinQuizSession = useCallback(
     async (
       code: string,
-      pin: string,
+      pin?: string,
       classPeriod?: string
     ): Promise<string> => {
       setLoading(true);
@@ -687,12 +696,10 @@ export const useQuizSessionStudent = (): UseQuizSessionStudentResult => {
           .toUpperCase();
         if (!normCode) throw new Error('Invalid code');
 
-        // Prevent storage abuse on the PIN field
-        const sanitizedPin = pin.trim().substring(0, 10);
-        if (!sanitizedPin) throw new Error('PIN is required');
-
         // Ensure we have an anonymous Firebase Auth session so Firestore
-        // security rules (request.auth != null) are satisfied.
+        // security rules (request.auth != null) are satisfied. SSO students
+        // arriving from /my-assignments already have a non-anonymous custom-
+        // token user — keep that identity.
         if (!auth.currentUser) {
           await signInAnonymously(auth);
         }
@@ -700,6 +707,19 @@ export const useQuizSessionStudent = (): UseQuizSessionStudentResult => {
         if (!currentUser)
           throw new Error('Anonymous auth failed — no current user.');
         const studentUid = currentUser.uid;
+
+        // Contract: PIN is required iff the caller is an anonymous Firebase
+        // user. Anonymous joiners arrived via the public `/join` /
+        // `/quiz?code=…` URL with no other identity, so the PIN is what
+        // ties them to a roster row. Non-anonymous joiners (SSO
+        // `studentRole` from `/my-assignments`, plus dev auth-bypass) carry
+        // a stable uid in `auth.uid` — `computeResponseKey` keys their
+        // response doc by that uid, and Firestore rules are the source of
+        // truth for whether the uid is actually allowed to write.
+        const sanitizedPin = (pin ?? '').trim().substring(0, 10);
+        if (currentUser.isAnonymous && !sanitizedPin) {
+          throw new Error('PIN is required');
+        }
 
         const snap = await getDocs(
           query(
@@ -806,19 +826,21 @@ export const useQuizSessionStudent = (): UseQuizSessionStudentResult => {
         setResponseKeyState(responseKey);
 
         if (!existingSnap.exists()) {
-          // No PII stored — only the PIN for teacher cross-reference.
-          // `studentUid` field carries the auth uid; the doc key may differ
-          // (for PIN auth it's pin-based), so Firestore rules enforce
-          // ownership against the field, not the key.
+          // No PII stored. `studentUid` field carries the auth uid; the doc
+          // key may differ (for PIN auth it's pin-based), so Firestore rules
+          // enforce ownership against the field, not the key. The `pin`
+          // field is omitted entirely for SSO `studentRole` joiners — the
+          // teacher's grading view resolves their name from `studentUid`
+          // via `getPseudonymsForAssignmentV1`.
           const newResponse: QuizResponse = {
             studentUid,
-            pin: sanitizedPin,
             joinedAt: Date.now(),
             status: 'joined',
             answers: [],
             score: null,
             submittedAt: null,
             completedAttempts: 0,
+            ...(sanitizedPin ? { pin: sanitizedPin } : {}),
             ...(classPeriod ? { classPeriod } : {}),
           };
           await setDoc(responseRef, newResponse);

--- a/hooks/useRosters.ts
+++ b/hooks/useRosters.ts
@@ -225,13 +225,18 @@ const validateRosterMeta = (
   if (typeof d.classlinkSyncedAt === 'number') {
     meta.classlinkSyncedAt = d.classlinkSyncedAt;
   }
+  if (typeof d.testClassId === 'string') {
+    meta.testClassId = d.testClassId;
+  }
   return meta;
 };
 
 /**
- * Optional ClassLink metadata accepted by `addRoster`. Passed through to the
- * Firestore doc so assignment pickers can treat a ClassLink-imported roster as
- * the single source of truth (no more "is it ClassLink or local?" branching).
+ * Optional provenance metadata accepted by `addRoster`. Passed through to the
+ * Firestore doc so assignment pickers can treat an imported roster as the
+ * single source of truth. Carries the ClassLink fields for real ClassLink
+ * imports and `testClassId` for admin test-class imports — both feed
+ * `deriveTargetsFromRosterList` to populate session `classIds[]`.
  */
 export type RosterCreateMeta = Pick<
   ClassRosterMeta,
@@ -241,6 +246,7 @@ export type RosterCreateMeta = Pick<
   | 'classlinkSubject'
   | 'classlinkOrgId'
   | 'classlinkSyncedAt'
+  | 'testClassId'
 >;
 
 // ─── Hook ──────────────────────────────────────────────────────────────────────

--- a/hooks/useStudentAssignments.ts
+++ b/hooks/useStudentAssignments.ts
@@ -1,0 +1,538 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  collection,
+  limit as firestoreLimit,
+  onSnapshot,
+  orderBy,
+  query,
+  where,
+  type DocumentData,
+  type Query,
+  type QueryConstraint,
+  type QuerySnapshot,
+} from 'firebase/firestore';
+import {
+  ClipboardList,
+  Image as ImageIcon,
+  PlayCircle,
+  Puzzle,
+  Sparkles,
+} from 'lucide-react';
+import { db, isAuthBypass } from '@/config/firebase';
+
+/**
+ * useStudentAssignments
+ *
+ * Owns every Firestore subscription that powers the student `/my-assignments`
+ * page. Lifted out of the page component so the new sidebar+content shell
+ * can share state across the Overview and per-class views without re-running
+ * subscriptions on each tab switch.
+ *
+ * Subscribes to two channels per supported session kind:
+ *   A. Active   — the existing flow ("status: active", or no status filter
+ *                 for collections without one).
+ *   B. Ended    — quiz / video-activity / mini-app, filtered to
+ *                 status === 'ended', ordered by endedAt desc, capped at 50
+ *                 per shape so the Completed list bounds Firestore reads.
+ *
+ * Dual-query (classIds array + legacy classId field) is preserved for
+ * quiz / video-activity / guided-learning. Mini-app and activity-wall stay
+ * single-query as today.
+ *
+ * The page applies the Active/Completed partition rule using the per-row
+ * lazy completion check (see AssignmentListItem). This hook does not
+ * compute completion itself — it only delivers the row plus its source
+ * channel so the partition can resolve client-side.
+ *
+ * Bounded growth: the limit(50) on the Ended channel caps reads. The
+ * Completed list is therefore a "recent history" view, not a full archive
+ * — surfacing roughly the last 50 ended sessions per kind per query shape.
+ */
+
+export type SessionKind =
+  | 'quiz'
+  | 'video-activity'
+  | 'guided-learning'
+  | 'mini-app'
+  | 'activity-wall';
+
+export type AssignmentChannel = 'active' | 'ended';
+
+export interface AssignmentSummary {
+  /** `${kind}:${sessionId}` — stable React key across collections. */
+  compositeId: string;
+  kind: SessionKind;
+  sessionId: string;
+  title: string;
+  /** Fully-qualified path the student can click to open the session. */
+  openHref: string;
+  /** Source channel — used by the page to partition Active vs Completed. */
+  channel: AssignmentChannel;
+  /** classIds this assignment targets, intersected with the student's claims. */
+  classIds: string[];
+  createdAt?: number;
+  endedAt?: number;
+}
+
+export type LoadState = 'loading' | 'ready';
+
+type StatusFilter =
+  | { field: 'status'; value: string }
+  | { field: 'status'; valueIn: readonly string[] }
+  | null;
+
+interface KindConfig {
+  collectionName: string;
+  /** Run BOTH a list query (classIds array-contains-any) AND a single query (classId in). */
+  dualQuery: boolean;
+  /** When dualQuery is false, this picks which shape to issue. */
+  classFilterShape: 'list' | 'single';
+  /** Filter for the Active channel. */
+  activeFilter: StatusFilter;
+  /**
+   * Filter for the Ended channel. When `null`, this kind has no status field
+   * and the Active channel is the only subscription.
+   */
+  endedFilter: StatusFilter;
+  /** Ordering field for the Ended channel (used with limit). */
+  endedOrderBy?: 'endedAt' | 'updatedAt';
+  /** Cap on Ended results per shape per kind. */
+  endedLimit: number;
+  label: string;
+  icon: React.ComponentType<{ className?: string; strokeWidth?: number }>;
+  /** Tailwind gradient for the card accent badge. */
+  accent: string;
+  titleFrom: (data: DocumentData) => string;
+  hrefFrom: (sessionId: string, data: DocumentData) => string;
+}
+
+export const KIND_CONFIG: Record<SessionKind, KindConfig> = {
+  quiz: {
+    collectionName: 'quiz_sessions',
+    dualQuery: true,
+    classFilterShape: 'single',
+    activeFilter: { field: 'status', valueIn: ['waiting', 'active'] },
+    endedFilter: { field: 'status', value: 'ended' },
+    endedOrderBy: 'endedAt',
+    endedLimit: 50,
+    label: 'Quiz',
+    icon: ClipboardList,
+    accent: 'from-blue-500 to-indigo-600',
+    titleFrom: (data) =>
+      typeof data.quizTitle === 'string' && data.quizTitle.length > 0
+        ? data.quizTitle
+        : 'Untitled quiz',
+    hrefFrom: (sessionId, data) => {
+      const code =
+        typeof data.code === 'string' && data.code.length > 0
+          ? data.code
+          : sessionId;
+      return `/quiz?code=${encodeURIComponent(code)}`;
+    },
+  },
+  'video-activity': {
+    collectionName: 'video_activity_sessions',
+    dualQuery: true,
+    classFilterShape: 'single',
+    activeFilter: { field: 'status', value: 'active' },
+    endedFilter: { field: 'status', value: 'ended' },
+    endedOrderBy: 'endedAt',
+    endedLimit: 50,
+    label: 'Video Activity',
+    icon: PlayCircle,
+    accent: 'from-rose-500 to-red-600',
+    titleFrom: (data) => {
+      if (
+        typeof data.activityTitle === 'string' &&
+        data.activityTitle.length > 0
+      )
+        return data.activityTitle;
+      if (
+        typeof data.assignmentName === 'string' &&
+        data.assignmentName.length > 0
+      )
+        return data.assignmentName;
+      return 'Video activity';
+    },
+    hrefFrom: (sessionId) => `/activity/${encodeURIComponent(sessionId)}`,
+  },
+  'guided-learning': {
+    collectionName: 'guided_learning_sessions',
+    dualQuery: true,
+    classFilterShape: 'single',
+    activeFilter: null, // No status field; existence = live.
+    endedFilter: null, // No ended channel — partitioned by completion alone.
+    endedLimit: 0,
+    label: 'Guided Learning',
+    icon: Sparkles,
+    accent: 'from-emerald-500 to-teal-600',
+    titleFrom: (data) =>
+      typeof data.title === 'string' && data.title.length > 0
+        ? data.title
+        : 'Guided learning',
+    hrefFrom: (sessionId) =>
+      `/guided-learning/${encodeURIComponent(sessionId)}`,
+  },
+  'mini-app': {
+    collectionName: 'mini_app_sessions',
+    dualQuery: false,
+    classFilterShape: 'list',
+    activeFilter: { field: 'status', value: 'active' },
+    endedFilter: { field: 'status', value: 'ended' },
+    endedOrderBy: 'endedAt',
+    endedLimit: 50,
+    label: 'Mini App',
+    icon: Puzzle,
+    accent: 'from-violet-500 to-purple-600',
+    titleFrom: (data) => {
+      if (typeof data.appTitle === 'string' && data.appTitle.length > 0)
+        return data.appTitle;
+      if (
+        typeof data.assignmentName === 'string' &&
+        data.assignmentName.length > 0
+      )
+        return data.assignmentName;
+      return 'Mini app';
+    },
+    hrefFrom: (sessionId) => `/miniapp/${encodeURIComponent(sessionId)}`,
+  },
+  'activity-wall': {
+    collectionName: 'activity_wall_sessions',
+    dualQuery: false,
+    classFilterShape: 'single',
+    activeFilter: null, // No status field on the session doc.
+    endedFilter: null,
+    endedLimit: 0,
+    label: 'Activity Wall',
+    icon: ImageIcon,
+    accent: 'from-amber-500 to-orange-600',
+    titleFrom: (data) =>
+      typeof data.title === 'string' && data.title.length > 0
+        ? data.title
+        : 'Activity wall',
+    hrefFrom: (sessionId) => `/activity-wall/${encodeURIComponent(sessionId)}`,
+  },
+};
+
+export const SESSION_KINDS: readonly SessionKind[] = [
+  'quiz',
+  'video-activity',
+  'guided-learning',
+  'mini-app',
+  'activity-wall',
+];
+
+// ---------------------------------------------------------------------------
+
+interface SubscriptionPlan {
+  kind: SessionKind;
+  channel: AssignmentChannel;
+  shape: 'list' | 'single';
+  /**
+   * Concrete status value for this subscription, or `null` when the kind has
+   * no status filter. Filters with multiple values (e.g., quiz active =
+   * `['waiting', 'active']`) fan out into one plan per value: Firestore
+   * forbids combining `in` with `array-contains-any` (or two `in` clauses)
+   * in the same query, so each subscription must carry at most one
+   * disjunctive constraint.
+   */
+  statusValue: string | null;
+}
+
+const planKey = (p: SubscriptionPlan): string =>
+  `${p.kind}:${p.channel}:${p.shape}:${p.statusValue ?? '_'}`;
+
+interface UseStudentAssignmentsResult {
+  loadState: LoadState;
+  /** All assignments, deduped by `(kind, sessionId)`, sorted newest-first. */
+  assignments: AssignmentSummary[];
+  /** True when at least one subscription bucket has errored. */
+  hasErrors: boolean;
+  retry: () => void;
+}
+
+interface UseStudentAssignmentsArgs {
+  classIds: readonly string[];
+}
+
+export function useStudentAssignments({
+  classIds,
+}: UseStudentAssignmentsArgs): UseStudentAssignmentsResult {
+  const [byKindChannel, setByKindChannel] = useState<
+    Record<string, AssignmentSummary[]>
+  >({});
+  const [loadState, setLoadState] = useState<LoadState>(() =>
+    isAuthBypass ? 'ready' : 'loading'
+  );
+  const [erroredBuckets, setErroredBuckets] = useState<Set<string>>(
+    () => new Set()
+  );
+  const [retryNonce, setRetryNonce] = useState(0);
+
+  const classIdsKey = useMemo(
+    () => classIds.slice().sort().join('|'),
+    [classIds]
+  );
+
+  // Reset bucket / error / load state when the subscription identity
+  // changes — a new claim set or a retry. We use the "adjusting state
+  // while rendering" pattern (https://react.dev/reference/react/useState
+  // #storing-information-from-previous-renders) so the resets don't
+  // become synchronous setStates inside the effect body. Whether the
+  // post-reset state is `ready` (empty/bypass) or `loading` (about to
+  // subscribe) is decided here too.
+  const [resetIdentity, setResetIdentity] = useState<string>(
+    `${classIdsKey}#${retryNonce}`
+  );
+  const currentIdentity = `${classIdsKey}#${retryNonce}`;
+  if (resetIdentity !== currentIdentity) {
+    setResetIdentity(currentIdentity);
+    setByKindChannel({});
+    setErroredBuckets(new Set());
+    setLoadState(
+      isAuthBypass || classIdsKey.length === 0 ? 'ready' : 'loading'
+    );
+  }
+
+  useEffect(() => {
+    // Bypass mode renders the layout against an empty assignment list so the
+    // page is exercisable in dev without a real Firestore backend. The
+    // render-time reset above already left state in the correct shape;
+    // the effect just skips the subscriptions.
+    if (isAuthBypass) return;
+    // Reconstitute the classIds list from the value-based key so the effect
+    // can depend on `classIdsKey` alone (and not on `classIds` reference
+    // identity, which would re-subscribe whenever the auth context emits a
+    // fresh array even though the contents didn't change).
+    const ids = classIdsKey ? classIdsKey.split('|').filter(Boolean) : [];
+    if (ids.length === 0) return;
+
+    // Plan every (kind, channel, shape, statusValue) subscription up front.
+    // Active channel always runs; Ended channel only for kinds that have a
+    // status field. Dual-query kinds run BOTH list and single shapes.
+    // Multi-value status filters (e.g., quiz active = waiting+active) fan
+    // out into one plan per status so each query stays inside Firestore's
+    // single-disjunctive-clause limit.
+    const subs: SubscriptionPlan[] = [];
+    for (const kind of SESSION_KINDS) {
+      const config = KIND_CONFIG[kind];
+      const channels: AssignmentChannel[] = ['active'];
+      if (config.endedFilter !== null) channels.push('ended');
+      for (const channel of channels) {
+        const filter =
+          channel === 'active' ? config.activeFilter : config.endedFilter;
+        const statusValues: (string | null)[] =
+          filter === null
+            ? [null]
+            : 'valueIn' in filter
+              ? [...filter.valueIn]
+              : [filter.value];
+        for (const statusValue of statusValues) {
+          if (config.dualQuery) {
+            subs.push({ kind, channel, shape: 'list', statusValue });
+            subs.push({ kind, channel, shape: 'single', statusValue });
+          } else {
+            subs.push({
+              kind,
+              channel,
+              shape: config.classFilterShape,
+              statusValue,
+            });
+          }
+        }
+      }
+    }
+    const totalSubscriptions = subs.length;
+
+    const buckets = new Map<string, AssignmentSummary[]>();
+    const settled = new Set<string>();
+
+    // Local copy of the student's classIds for fast intersection.
+    const studentClassIds = new Set(ids);
+
+    const docToSummary = (
+      kind: SessionKind,
+      channel: AssignmentChannel,
+      config: KindConfig,
+      d: QuerySnapshot<DocumentData>['docs'][number]
+    ): AssignmentSummary => {
+      const data = d.data();
+      const createdAtRaw: unknown = (data as Record<string, unknown>).createdAt;
+      const endedAtRaw: unknown = (data as Record<string, unknown>).endedAt;
+
+      // Compute the intersection of session classIds with student claims so
+      // multi-class assignments fan out under each matching class. Falls
+      // back to the legacy single-class field when classIds is absent.
+      const sessionClassIds: string[] = Array.isArray(
+        (data as Record<string, unknown>).classIds
+      )
+        ? ((data as Record<string, unknown>).classIds as unknown[]).filter(
+            (c): c is string => typeof c === 'string'
+          )
+        : [];
+      const legacyClassId =
+        typeof (data as Record<string, unknown>).classId === 'string'
+          ? ((data as Record<string, unknown>).classId as string)
+          : '';
+      const candidates =
+        sessionClassIds.length > 0
+          ? sessionClassIds
+          : legacyClassId
+            ? [legacyClassId]
+            : [];
+      const intersected = candidates.filter((c) => studentClassIds.has(c));
+
+      return {
+        compositeId: `${kind}:${d.id}`,
+        kind,
+        sessionId: d.id,
+        title: config.titleFrom(data),
+        openHref: config.hrefFrom(d.id, data),
+        channel,
+        classIds: intersected,
+        createdAt: typeof createdAtRaw === 'number' ? createdAtRaw : undefined,
+        endedAt: typeof endedAtRaw === 'number' ? endedAtRaw : undefined,
+      };
+    };
+
+    const emit = (kind: SessionKind, channel: AssignmentChannel) => {
+      // Merge across every (shape, statusValue) bucket for this kind+channel.
+      // The status fan-out can produce multiple buckets per channel (e.g.,
+      // quiz active fans out into `waiting` and `active` per shape).
+      const prefix = `${kind}:${channel}:`;
+      const merged = new Map<string, AssignmentSummary>();
+      for (const [key, rows] of buckets) {
+        if (key.startsWith(prefix)) {
+          for (const a of rows) merged.set(a.sessionId, a);
+        }
+      }
+      const channelKey = `${kind}:${channel}`;
+      setByKindChannel((prev) => ({
+        ...prev,
+        [channelKey]: Array.from(merged.values()),
+      }));
+    };
+
+    const markSettled = (key: string) => {
+      settled.add(key);
+      if (settled.size === totalSubscriptions) {
+        setLoadState('ready');
+      }
+    };
+
+    const buildQuery = (
+      config: KindConfig,
+      channel: AssignmentChannel,
+      shape: 'list' | 'single',
+      statusValue: string | null
+    ): Query<DocumentData> => {
+      const col = collection(db, config.collectionName);
+      const constraints: QueryConstraint[] =
+        shape === 'list'
+          ? [where('classIds', 'array-contains-any', ids)]
+          : [where('classId', 'in', ids)];
+      if (statusValue !== null) {
+        constraints.push(where('status', '==', statusValue));
+      }
+      if (channel === 'ended' && config.endedOrderBy) {
+        constraints.push(orderBy(config.endedOrderBy, 'desc'));
+        constraints.push(firestoreLimit(config.endedLimit));
+      }
+      return query(col, ...constraints);
+    };
+
+    const handleSnapshot = (
+      plan: SubscriptionPlan,
+      snap: QuerySnapshot<DocumentData>
+    ) => {
+      const config = KIND_CONFIG[plan.kind];
+      const key = planKey(plan);
+      buckets.set(
+        key,
+        snap.docs.map((d) => docToSummary(plan.kind, plan.channel, config, d))
+      );
+      emit(plan.kind, plan.channel);
+      setErroredBuckets((prev) => {
+        if (!prev.has(key)) return prev;
+        const next = new Set(prev);
+        next.delete(key);
+        return next;
+      });
+      markSettled(key);
+    };
+
+    const handleError = (plan: SubscriptionPlan, err: unknown) => {
+      const code =
+        err && typeof err === 'object' && 'code' in err
+          ? String((err as { code?: unknown }).code)
+          : 'unknown';
+      const message =
+        err && typeof err === 'object' && 'message' in err
+          ? String((err as { message?: unknown }).message)
+          : '';
+      console.error(
+        `[useStudentAssignments] snapshot failed for ${KIND_CONFIG[plan.kind].collectionName} (${plan.channel}/${plan.shape}/${plan.statusValue ?? '_'}) [${code}]:`,
+        message
+      );
+      const key = planKey(plan);
+      buckets.set(key, []);
+      emit(plan.kind, plan.channel);
+      setErroredBuckets((prev) => {
+        if (prev.has(key)) return prev;
+        const next = new Set(prev);
+        next.add(key);
+        return next;
+      });
+      markSettled(key);
+    };
+
+    const unsubs: Array<() => void> = [];
+    for (const plan of subs) {
+      const config = KIND_CONFIG[plan.kind];
+      const q = buildQuery(config, plan.channel, plan.shape, plan.statusValue);
+      unsubs.push(
+        onSnapshot(
+          q,
+          (snap) => handleSnapshot(plan, snap),
+          (err) => handleError(plan, err)
+        )
+      );
+    }
+
+    return () => {
+      for (const u of unsubs) u();
+    };
+  }, [classIdsKey, retryNonce]);
+
+  const assignments: AssignmentSummary[] = useMemo(() => {
+    // Dedupe by (kind, sessionId): a row may show up in both Active and
+    // Ended during a brief status transition. Prefer the Ended copy
+    // because it carries `endedAt` for sorting.
+    const merged = new Map<string, AssignmentSummary>();
+    for (const kind of SESSION_KINDS) {
+      const activeKey = `${kind}:active`;
+      const endedKey = `${kind}:ended`;
+      const active = byKindChannel[activeKey] ?? [];
+      const ended = byKindChannel[endedKey] ?? [];
+      for (const a of active) merged.set(`${kind}:${a.sessionId}`, a);
+      for (const a of ended) merged.set(`${kind}:${a.sessionId}`, a); // Ended overrides
+    }
+    const out = Array.from(merged.values());
+    out.sort((a, b) => {
+      const at = a.endedAt ?? a.createdAt ?? 0;
+      const bt = b.endedAt ?? b.createdAt ?? 0;
+      if (at !== bt) return bt - at;
+      return a.title.localeCompare(b.title);
+    });
+    return out;
+  }, [byKindChannel]);
+
+  const retry = useCallback(() => setRetryNonce((n) => n + 1), []);
+
+  return {
+    loadState,
+    assignments,
+    hasErrors: erroredBuckets.size > 0,
+    retry,
+  };
+}

--- a/hooks/useStudentClassDirectory.ts
+++ b/hooks/useStudentClassDirectory.ts
@@ -1,0 +1,159 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { httpsCallable } from 'firebase/functions';
+import { functions, isAuthBypass } from '@/config/firebase';
+
+/**
+ * Class metadata returned by the `getStudentClassDirectoryV1` callable.
+ * Mirror of the server type. Teacher names are the only personally-identifying
+ * field — they are organizational data, NOT student PII.
+ */
+export interface ClassDirectoryEntry {
+  classId: string;
+  name: string;
+  teacherDisplayName: string;
+  subject?: string;
+  code?: string;
+}
+
+export type DirectoryStatus = 'loading' | 'ready' | 'error';
+
+export interface ClassDirectoryResult {
+  status: DirectoryStatus;
+  /** Resolved entries in the order returned by the server (may be a subset of classIds). */
+  classes: ClassDirectoryEntry[];
+  /** Lookup table keyed by classId for fast UI access. */
+  byId: Record<string, ClassDirectoryEntry>;
+  retry: () => void;
+}
+
+/**
+ * Module-local cache so a remount of the page doesn't refetch what we
+ * already have. Keyed by `${pseudonymUid}:${classIdsKey}`. Pseudonym
+ * scoping flushes the cache on sign-out (a different student's session
+ * would compute a different uid).
+ */
+const directoryCache = new Map<string, ClassDirectoryEntry[]>();
+
+const cacheKeyOf = (pseudonymUid: string, classIdsKey: string): string =>
+  `${pseudonymUid}:${classIdsKey}`;
+
+/**
+ * Bypass-mode mock — keeps the page render path consistent with real auth so
+ * `pnpm run dev` with VITE_AUTH_BYPASS=true can exercise the new sidebar.
+ */
+const BYPASS_DIRECTORY: ClassDirectoryEntry[] = [
+  {
+    classId: 'mock-class-1',
+    name: 'Demo Class',
+    teacherDisplayName: 'Demo Teacher',
+    subject: 'Demo',
+  },
+];
+
+interface FetchedSnapshot {
+  key: string;
+  status: 'ready' | 'error';
+  classes: ClassDirectoryEntry[];
+}
+
+interface UseStudentClassDirectoryArgs {
+  classIds: readonly string[];
+  pseudonymUid: string | null;
+}
+
+export function useStudentClassDirectory({
+  classIds,
+  pseudonymUid,
+}: UseStudentClassDirectoryArgs): ClassDirectoryResult {
+  const classIdsKey = useMemo(
+    () => classIds.slice().sort().join('|'),
+    [classIds]
+  );
+
+  // The cache key for the *current* (uid, classIds) pair. `null` means we
+  // shouldn't fetch (bypass mode or no classes claimed).
+  const cacheKey: string | null = useMemo(() => {
+    if (isAuthBypass) return null;
+    if (!pseudonymUid || classIds.length === 0) return null;
+    return cacheKeyOf(pseudonymUid, classIdsKey);
+  }, [pseudonymUid, classIds.length, classIdsKey]);
+
+  // Async resolution snapshot. The effect writes this *after* the callable
+  // settles — never synchronously, which avoids cascading renders. The
+  // current cache state is read directly from `directoryCache` during render
+  // so a fresh cache hit is reflected immediately without setState.
+  const [fetched, setFetched] = useState<FetchedSnapshot | null>(null);
+  const [retryNonce, setRetryNonce] = useState(0);
+
+  // Render-time resolution. Order:
+  //   1. bypass / no claims  → instant 'ready'
+  //   2. module cache hit    → instant 'ready' (fresh remount uses prior result)
+  //   3. matching fetched    → reflect last async result for THIS key
+  //   4. otherwise           → 'loading'
+  const { status, classes } = ((): {
+    status: DirectoryStatus;
+    classes: ClassDirectoryEntry[];
+  } => {
+    if (isAuthBypass) {
+      return { status: 'ready', classes: BYPASS_DIRECTORY };
+    }
+    if (cacheKey === null) {
+      return { status: 'ready', classes: [] };
+    }
+    const cached = directoryCache.get(cacheKey);
+    if (cached) {
+      return { status: 'ready', classes: cached };
+    }
+    if (fetched && fetched.key === cacheKey) {
+      return { status: fetched.status, classes: fetched.classes };
+    }
+    return { status: 'loading', classes: [] };
+  })();
+
+  useEffect(() => {
+    if (cacheKey === null) return;
+    if (directoryCache.has(cacheKey) && retryNonce === 0) return;
+
+    let cancelled = false;
+    const callable = httpsCallable<
+      Record<string, never>,
+      { classes?: ClassDirectoryEntry[] }
+    >(functions, 'getStudentClassDirectoryV1');
+
+    callable({})
+      .then((res) => {
+        if (cancelled) return;
+        const list = Array.isArray(res.data?.classes)
+          ? (res.data?.classes ?? [])
+          : [];
+        directoryCache.set(cacheKey, list);
+        setFetched({ key: cacheKey, status: 'ready', classes: list });
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        const code =
+          err && typeof err === 'object' && 'code' in err
+            ? String((err as { code?: unknown }).code)
+            : 'unknown';
+        console.error(`[useStudentClassDirectory] callable failed [${code}]`);
+        setFetched({ key: cacheKey, status: 'error', classes: [] });
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [cacheKey, retryNonce]);
+
+  const byId = useMemo<Record<string, ClassDirectoryEntry>>(() => {
+    const out: Record<string, ClassDirectoryEntry> = {};
+    for (const c of classes) out[c.classId] = c;
+    return out;
+  }, [classes]);
+
+  const retry = useCallback(() => {
+    if (cacheKey !== null) directoryCache.delete(cacheKey);
+    setRetryNonce((n) => n + 1);
+  }, [cacheKey]);
+
+  return { status, classes, byId, retry };
+}

--- a/hooks/useStudentIdleTimeout.ts
+++ b/hooks/useStudentIdleTimeout.ts
@@ -14,6 +14,7 @@
 import { useEffect } from 'react';
 import { signOut as firebaseSignOut } from 'firebase/auth';
 import { auth } from '@/config/firebase';
+import { clearStudentFirstName } from '@/context/StudentAuthContextValue';
 
 export const STUDENT_IDLE_TIMEOUT_MS = 15 * 60 * 1000;
 const INTERACTION_THROTTLE_MS = 5 * 1000;
@@ -31,6 +32,12 @@ export function useStudentIdleTimeout(
     let lastInteractionAt = Date.now();
 
     const triggerIdleSignOut = () => {
+      // Always clear the cached first name before tearing down the
+      // session — same hygiene as the explicit `signOut()` and the
+      // claim-rejection path. Without this, a tab that idles out on a
+      // shared cart leaves the previous student's greeting in
+      // sessionStorage until the next successful login overwrites it.
+      clearStudentFirstName();
       void firebaseSignOut(auth).catch(() => {
         // Swallow — redirect below is the actual remediation.
       });

--- a/tests/hooks/useQuizSession.test.ts
+++ b/tests/hooks/useQuizSession.test.ts
@@ -268,6 +268,12 @@ describe('useQuizSessionStudent — lookupSession', () => {
 describe('useQuizSessionStudent — joinQuizSession', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // Default current user has no `isAnonymous` flag (falsy), matching the
+    // pre-SSO test expectations: response doc is keyed by `auth.uid` and the
+    // legacy-key probe is skipped. Tests that need the anonymous PIN-join
+    // semantics (PIN-required guard, legacy-key probe path) override
+    // `isAnonymous: true` locally; SSO branch tests assert against
+    // `isAnonymous: false` explicitly.
     (auth as unknown as { currentUser: { uid: string } | null }).currentUser = {
       uid: 'student-uid-1',
     };
@@ -293,7 +299,14 @@ describe('useQuizSessionStudent — joinQuizSession', () => {
     ).rejects.toThrow('Invalid code');
   });
 
-  it('throws "PIN is required" when the PIN is only whitespace', async () => {
+  it('throws "PIN is required" when the PIN is only whitespace (anonymous joiner)', async () => {
+    // Anonymous PIN joiners must always supply a PIN — that's their identity.
+    // Non-anonymous (SSO) users skip this guard; covered separately below.
+    (
+      auth as unknown as {
+        currentUser: { uid: string; isAnonymous: boolean } | null;
+      }
+    ).currentUser = { uid: 'anon-uid', isAnonymous: true };
     const { result } = renderHook(() => useQuizSessionStudent());
     await expect(
       result.current.joinQuizSession('ABC123', '   ')
@@ -526,6 +539,104 @@ describe('useQuizSessionStudent — joinQuizSession', () => {
         result.current.joinQuizSession('ABC123', '1234')
       ).rejects.toThrow('Backend unavailable.');
     });
+  });
+
+  // ─── SSO `studentRole` branch ───────────────────────────────────────────────
+  // Students arriving from /my-assignments are signed in via custom token
+  // (non-anonymous Firebase user with `claims.studentRole === true`). The
+  // hook keys the response doc by `auth.uid` and omits the `pin` field — the
+  // teacher's grading view resolves their name via getPseudonymsForAssignmentV1.
+
+  it('does not require a PIN for non-anonymous (studentRole) joiners', async () => {
+    (
+      auth as unknown as {
+        currentUser: { uid: string; isAnonymous: boolean } | null;
+      }
+    ).currentUser = { uid: 'sso-uid-1', isAnonymous: false };
+
+    (
+      firestore.getDocs as unknown as ReturnType<typeof vi.fn>
+    ).mockResolvedValueOnce({
+      empty: false,
+      docs: [buildSessionDoc('s1', { status: 'waiting' })],
+    });
+    (
+      firestore.getDoc as unknown as ReturnType<typeof vi.fn>
+    ).mockResolvedValueOnce({ exists: () => false });
+    const setDocMock = firestore.setDoc as unknown as ReturnType<typeof vi.fn>;
+    setDocMock.mockResolvedValueOnce(undefined);
+
+    const { result } = renderHook(() => useQuizSessionStudent());
+    let sessionId = '';
+    await act(async () => {
+      // Note: no PIN argument.
+      sessionId = await result.current.joinQuizSession('ABC123');
+    });
+
+    expect(sessionId).toBe('s1');
+    expect(setDocMock).toHaveBeenCalledTimes(1);
+    const writtenResponse = setDocMock.mock.calls[0][1] as Record<
+      string,
+      unknown
+    >;
+    // studentUid is the SSO auth uid, and `pin` is omitted entirely so the
+    // teacher's name-resolution path falls through to byStudentUid.
+    expect(writtenResponse.studentUid).toBe('sso-uid-1');
+    expect(writtenResponse).not.toHaveProperty('pin');
+    expect(writtenResponse.status).toBe('joined');
+  });
+
+  it('keys the studentRole response doc by auth.uid (not by pin-{period}-{pin})', async () => {
+    (
+      auth as unknown as {
+        currentUser: { uid: string; isAnonymous: boolean } | null;
+      }
+    ).currentUser = { uid: 'sso-uid-2', isAnonymous: false };
+
+    (
+      firestore.getDocs as unknown as ReturnType<typeof vi.fn>
+    ).mockResolvedValueOnce({
+      empty: false,
+      docs: [buildSessionDoc('s1', { status: 'waiting' })],
+    });
+    (
+      firestore.getDoc as unknown as ReturnType<typeof vi.fn>
+    ).mockResolvedValueOnce({ exists: () => false });
+    (
+      firestore.setDoc as unknown as ReturnType<typeof vi.fn>
+    ).mockResolvedValueOnce(undefined);
+
+    const docMock = firestore.doc as unknown as ReturnType<typeof vi.fn>;
+
+    const { result } = renderHook(() => useQuizSessionStudent());
+    await act(async () => {
+      await result.current.joinQuizSession('ABC123', undefined, 'Period 1');
+    });
+
+    // The hook calls `doc(db, QUIZ_SESSIONS_COLLECTION, sessionId,
+    // RESPONSES_COLLECTION, responseKey)` once for the existence probe
+    // (handled by getDoc) and once for the eventual write. Find a call
+    // whose final segment is the response-doc key.
+    const responseKeys: string[] = (docMock.mock.calls as unknown[][])
+      .map((args) => args[args.length - 1])
+      .filter((v): v is string => typeof v === 'string');
+    expect(responseKeys).toContain('sso-uid-2');
+    // No pin-derived key should ever be requested for an SSO joiner.
+    expect(
+      responseKeys.some((k) => typeof k === 'string' && k.startsWith('pin-'))
+    ).toBe(false);
+  });
+
+  it('still rejects anonymous joiners with no PIN', async () => {
+    (
+      auth as unknown as {
+        currentUser: { uid: string; isAnonymous: boolean } | null;
+      }
+    ).currentUser = { uid: 'anon-uid', isAnonymous: true };
+    const { result } = renderHook(() => useQuizSessionStudent());
+    await expect(result.current.joinQuizSession('ABC123')).rejects.toThrow(
+      'PIN is required'
+    );
   });
 });
 

--- a/tests/utils/resolveAssignmentTargets.test.ts
+++ b/tests/utils/resolveAssignmentTargets.test.ts
@@ -117,6 +117,33 @@ describe('resolveAssignmentTargets', () => {
     expect(out.classIds).toEqual(['cl-1']);
     expect(out.rosterIds).toEqual(['r1', 'r2']);
   });
+
+  it('includes testClassId in derived classIds for test-class rosters', () => {
+    // Roster imported from an admin-managed test class. The test-bypass SSO
+    // student's custom token carries `classIds: ['mock-period-1']`, so the
+    // session must surface that slug or the student sees an empty list.
+    const r1 = roster('r1', 'Mock Period 1 (test)', [s1], {
+      testClassId: 'mock-period-1',
+    });
+    const out = resolveAssignmentTargets({ rosterIds: ['r1'] }, [r1]);
+    expect(out.classIds).toEqual(['mock-period-1']);
+  });
+
+  it('merges classIds across mixed ClassLink + test-class rosters', () => {
+    const r1 = roster('r1', 'Period 1', [s1], { classlinkClassId: 'cl-1' });
+    const r2 = roster('r2', 'Mock Period 1 (test)', [s2], {
+      testClassId: 'mock-period-1',
+    });
+    const out = resolveAssignmentTargets({ rosterIds: ['r1', 'r2'] }, [r1, r2]);
+    expect(out.classIds.sort()).toEqual(['cl-1', 'mock-period-1']);
+  });
+
+  it('omits rosters with neither classlinkClassId nor testClassId', () => {
+    const r1 = roster('r1', 'Local only', [s1]); // truly local, both absent
+    const out = resolveAssignmentTargets({ rosterIds: ['r1'] }, [r1]);
+    expect(out.classIds).toEqual([]);
+    expect(out.rosterIds).toEqual(['r1']);
+  });
 });
 
 describe('deriveSessionTargetsFromRosters', () => {

--- a/tests/utils/studentClassColors.test.ts
+++ b/tests/utils/studentClassColors.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import { getClassColor, CLASS_COLOR_PALETTE } from '@/utils/studentClassColors';
+
+describe('studentClassColors', () => {
+  describe('getClassColor', () => {
+    it('returns a palette entry for any non-empty classId', () => {
+      const color = getClassColor('classlink-12345');
+      expect(CLASS_COLOR_PALETTE).toContainEqual(color);
+    });
+
+    it('is deterministic — same classId always returns the same color', () => {
+      const a = getClassColor('classlink-abc-period-3');
+      const b = getClassColor('classlink-abc-period-3');
+      expect(a).toEqual(b);
+    });
+
+    it('returns the first palette entry for empty input', () => {
+      expect(getClassColor('')).toEqual(CLASS_COLOR_PALETTE[0]);
+    });
+
+    it('spreads many distinct classIds across at least half the palette', () => {
+      // Synthetic but realistic-looking sourcedIds. The hash should land
+      // somewhere in the palette for each, and across enough inputs we
+      // should see meaningful spread (not collapse to one or two buckets).
+      const ids = Array.from(
+        { length: 200 },
+        (_, i) => `roster-${i}-period-${i % 7}`
+      );
+      const seen = new Set(ids.map((id) => getClassColor(id).bar));
+      expect(seen.size).toBeGreaterThanOrEqual(
+        Math.ceil(CLASS_COLOR_PALETTE.length / 2)
+      );
+    });
+
+    it('every palette entry has the brand-aligned shape', () => {
+      for (const entry of CLASS_COLOR_PALETTE) {
+        expect(entry.bar).toMatch(/^#[0-9A-F]{6}$/i);
+        expect(entry.soft).toMatch(/^#[0-9A-F]{6}$/i);
+        expect(entry.ink).toMatch(/^#[0-9A-F]{6}$/i);
+      }
+    });
+  });
+});

--- a/types.ts
+++ b/types.ts
@@ -95,6 +95,14 @@ export interface Student {
    */
   classLinkSourcedId?: string;
   /**
+   * Student email. Captured from ClassLink imports and from test-class member
+   * lists. Lives only in the Drive student-list JSON alongside name/PIN — per
+   * the existing PII architecture (see `useRosters.ts` PII migration), this
+   * field is NOT written to any Firestore document. Surfaced as an optional
+   * column in `RosterEditorModal` so teachers can verify imports.
+   */
+  email?: string;
+  /**
    * Stable IDs of classmates this student must never be grouped with in the
    * Randomizer's group-maker mode. Maintained bidirectionally: if B is in A's
    * list, A is in B's list.

--- a/types.ts
+++ b/types.ts
@@ -1760,7 +1760,14 @@ export interface QuizPublicQuestion {
 }
 
 export interface QuizLeaderboardEntry {
-  pin: string;
+  /** Optional — SSO `studentRole` joiners have no PIN; identity is `name`. */
+  pin?: string;
+  /**
+   * Auth uid of the student who owns this row. Lets the student-side
+   * leaderboard highlight "my row" for SSO joiners (whose `pin` is missing)
+   * by matching `auth.currentUser.uid` instead of a roster PIN.
+   */
+  studentUid?: string;
   name?: string;
   score: number;
   rank: number;
@@ -1907,8 +1914,13 @@ export interface QuizResponse {
   /**
    * Student's roster PIN. Teacher cross-references this with the Drive roster
    * to identify the student. No name or email is stored in Firestore.
+   *
+   * Optional because SSO `studentRole` joiners (launched from /my-assignments)
+   * have no PIN — their identity is `studentUid`, resolved to a name via
+   * `getPseudonymsForAssignmentV1` on the teacher side. Anonymous PIN joiners
+   * always set this field.
    */
-  pin: string;
+  pin?: string;
   joinedAt: number;
   status: QuizResponseStatus;
   answers: QuizResponseAnswer[];

--- a/types.ts
+++ b/types.ts
@@ -130,6 +130,16 @@ export interface ClassRosterMeta {
    * resolves without the assignment layer having to know about ClassLink.
    */
   classlinkClassId?: string;
+  /**
+   * Test-class slug (the `testClasses/{id}` doc id, without the `test:` prefix).
+   * Present iff the roster was imported from an admin-managed test class. Drives
+   * session `classIds[]` derivation so the test-bypass SSO student's custom-token
+   * claim (`classIds: [<slug>]`, minted by `studentLoginV1`) matches the
+   * assignment session — without claiming `origin: 'classlink'`, which would
+   * falsely tag this as a real ClassLink roster in the picker badge and merge
+   * logic.
+   */
+  testClassId?: string;
   /** ClassLink class code (e.g. "MATH-7-P3"); rendered in the picker badge tooltip. */
   classlinkClassCode?: string;
   /** ClassLink subject label; used for reconciliation and teacher-visible filters. */

--- a/utils/quizDriveService.ts
+++ b/utils/quizDriveService.ts
@@ -466,6 +466,12 @@ export class QuizDriveService {
     questions: QuizQuestion[],
     options?: {
       pinToName?: Record<string, string>;
+      /**
+       * ClassLink name lookup for SSO `studentRole` joiners (no PIN). Keyed
+       * by `response.studentUid`. Optional — when omitted (legacy code+PIN
+       * sessions), SSO rows fall back to the generic `Student` label.
+       */
+      byStudentUid?: Map<string, { givenName: string; familyName: string }>;
       teacherName?: string;
       periodName?: string;
       plcMode?: boolean;
@@ -473,6 +479,7 @@ export class QuizDriveService {
     }
   ): Promise<string> {
     const pinToName = options?.pinToName ?? {};
+    const byStudentUid = options?.byStudentUid;
     const teacherName =
       (options?.teacherName?.trim() ? options.teacherName.trim() : null) ??
       'Unknown Teacher';
@@ -481,8 +488,19 @@ export class QuizDriveService {
       'Unknown Period';
     const timestamp = new Date().toISOString();
 
-    const resolveStudent = (pin: string): string =>
-      pinToName[pin] ?? `Student (PIN: ${pin})`;
+    const resolveStudent = (r: QuizResponse): string => {
+      // ClassLink name (SSO) wins; then roster PIN match; then literal PIN;
+      // then generic "Student" fallback for SSO rows that didn't resolve.
+      const sso = byStudentUid?.get(r.studentUid);
+      if (sso) {
+        const full = `${sso.givenName ?? ''} ${sso.familyName ?? ''}`.trim();
+        if (full) return full;
+      }
+      if (r.pin) {
+        return pinToName[r.pin] ?? `Student (PIN: ${r.pin})`;
+      }
+      return 'Student';
+    };
 
     const maxPoints = questions.reduce((sum, q) => sum + (q.points ?? 1), 0);
 
@@ -532,8 +550,10 @@ export class QuizDriveService {
         teacherName,
         periodName,
         r.classPeriod ?? '',
-        resolveStudent(r.pin),
-        r.pin,
+        resolveStudent(r),
+        // PIN column is left blank for SSO students (no roster PIN); their
+        // identity is captured in the Student column instead.
+        r.pin ?? '',
         r.status,
         scoreDisplay,
         String(earnedPoints),

--- a/utils/resolveAssignmentTargets.ts
+++ b/utils/resolveAssignmentTargets.ts
@@ -5,7 +5,8 @@
  * `classIds[]` (ClassLink-only) or local roster names under `periodNames[]`
  * (local-only). After the roster-as-single-source-of-truth unification,
  * new assignments write `rosterIds[]` — rosters imported from ClassLink carry
- * their own `classlinkClassId` metadata so the student SSO gate still works.
+ * their own `classlinkClassId` metadata, and rosters imported from admin
+ * test classes carry `testClassId`, so the student SSO gate still works.
  *
  * Legacy in-flight assignments are NOT migrated; they continue reading via
  * their existing `classIds`/`periodNames` fields until they expire.
@@ -30,9 +31,12 @@ export interface ResolvedAssignmentTargets {
   /** Roster IDs backing this assignment (empty for legacy docs). */
   rosterIds: string[];
   /**
-   * ClassLink `sourcedId`s to write onto the session doc for the student
-   * SSO gate. Empty when no selected roster has `classlinkClassId` (purely
-   * local targeting — SSO students get blocked, PIN students still pass).
+   * Class identifiers to write onto the session doc for the student SSO gate.
+   * Sourced from `classlinkClassId` (real ClassLink rosters) and `testClassId`
+   * (admin test-class imports); both end up in this same array since the
+   * student-side claim and Firestore gate read a single `classIds[]` field.
+   * Empty when no selected roster carries either (purely local targeting —
+   * SSO students get blocked, PIN students still pass).
    */
   classIds: string[];
   /** Period names (local roster names) for PIN-flow routing. */
@@ -57,7 +61,13 @@ export interface ResolvedAssignmentTargets {
  * Dedup rationale:
  * - `classIds`: two rosters can share the same `classlinkClassId` (teacher
  *   imported the same ClassLink class twice under different local names);
- *   we'd otherwise waste the Firestore rules' 20-entry budget.
+ *   we'd otherwise waste the Firestore rules' 20-entry budget. Test-class
+ *   `testClassId` slugs share this output array because the student-side SSO
+ *   gate (`MyAssignmentsPage` queries + `firestore.rules`) keys on a single
+ *   `classIds[]` field — the cloud function (`studentLoginV1`) populates the
+ *   same claim from either source. Collisions are not possible: ClassLink
+ *   sourcedIds are opaque OneRoster identifiers, test-class IDs are
+ *   admin-chosen slugs.
  * - `students`: a student enrolled in two targeted classes shouldn't appear
  *   twice in the session student list.
  * - `periodNames`: two local rosters can share a name; the student app keys
@@ -73,7 +83,7 @@ function deriveTargetsFromRosterList(rosters: ClassRoster[]): {
   const classIds = Array.from(
     new Set(
       rosters
-        .map((r) => r.classlinkClassId)
+        .flatMap((r) => [r.classlinkClassId, r.testClassId])
         .filter((id): id is string => typeof id === 'string' && id.length > 0)
     )
   );

--- a/utils/studentClassColors.ts
+++ b/utils/studentClassColors.ts
@@ -1,0 +1,66 @@
+/**
+ * Deterministic class color assignment for the student `/my-assignments`
+ * sidebar. Hashes the ClassLink `sourcedId` (or test-class id) into a small
+ * brand-aligned palette so a given class always paints the same color across
+ * sessions and devices, without any persisted state.
+ *
+ * The palette is hand-picked to keep visual differentiation high while
+ * staying in the SpartBoard / Orono Technology brand range — anchored on
+ * the brand blue (`#2D3F89`) and brand red (`#AD2122`), with subject-style
+ * hues filling out the spread.
+ */
+export interface ClassColor {
+  /** Solid color for the 4px sidebar bar. */
+  bar: string;
+  /** Soft tint for hover/active surfaces (≈8% alpha equivalent, opaque). */
+  soft: string;
+  /** High-contrast ink for text rendered on `soft`. */
+  ink: string;
+}
+
+const PALETTE: readonly ClassColor[] = [
+  { bar: '#2D3F89', soft: '#EAECF5', ink: '#1D2A5D' }, // brand blue
+  { bar: '#AD2122', soft: '#F7E3E3', ink: '#7A1718' }, // brand red
+  { bar: '#0F6B3A', soft: '#DCEFE2', ink: '#0A4D2A' }, // forest
+  { bar: '#7A1718', soft: '#F0DADB', ink: '#561011' }, // brand red dark
+  { bar: '#4356A0', soft: '#E1E5F1', ink: '#2D3F89' }, // brand blue light
+  { bar: '#B8860B', soft: '#F4EAD0', ink: '#7C5B07' }, // amber
+  { bar: '#2A6F8F', soft: '#DBE8EF', ink: '#1A4A60' }, // teal blue
+  { bar: '#6B3FA0', soft: '#E5DCEF', ink: '#4A2C70' }, // muted violet
+];
+
+/**
+ * 32-bit FNV-1a hash. Compact, dependency-free, and good enough for
+ * "spread N classIds across 8 buckets without obvious clumping". Same
+ * implementation a teacher's color picker would use — switching the input
+ * string but not the algorithm yields a stable assignment.
+ */
+function fnv1a(input: string): number {
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < input.length; i++) {
+    hash ^= input.charCodeAt(i);
+    // 32-bit FNV prime multiply, kept in unsigned 32-bit range.
+    hash =
+      (hash +
+        ((hash << 1) +
+          (hash << 4) +
+          (hash << 7) +
+          (hash << 8) +
+          (hash << 24))) >>>
+      0;
+  }
+  return hash >>> 0;
+}
+
+/**
+ * Returns the palette entry for a given classId. Stable across calls;
+ * different classIds spread across the palette via FNV-1a modulo.
+ */
+export function getClassColor(classId: string): ClassColor {
+  if (!classId) return PALETTE[0];
+  const idx = fnv1a(classId) % PALETTE.length;
+  return PALETTE[idx];
+}
+
+/** Exposed for tests — kept stable as part of the public contract. */
+export const CLASS_COLOR_PALETTE = PALETTE;


### PR DESCRIPTION
This pull request introduces significant improvements to roster management, particularly around handling student email addresses in class rosters (including ClassLink imports and test classes), and enhances the usability of the roster editor UI. The main changes include persisting and displaying student emails, updating merge logic to backfill and preserve emails, and adding UI controls for toggling the email column in the roster editor.

**Roster email handling and persistence:**

* Student email addresses are now preserved on import from ClassLink and test classes, allowing them to round-trip through the roster editor and be displayed in the optional email column. The merge logic for ClassLink imports backfills emails onto matched students and ensures existing manually-entered emails are not overwritten on re-sync. [[1]](diffhunk://#diff-29aa520bba03822d765e96a8cd60c7e336830023a4b74ad592dd467f7e1ce0f1R222) [[2]](diffhunk://#diff-6ba85168d8f3c133fda82286baad5afe74ad73b2cb325ee5f4973cae5e884b29R68-R72) [[3]](diffhunk://#diff-6ba85168d8f3c133fda82286baad5afe74ad73b2cb325ee5f4973cae5e884b29L87-R99) [[4]](diffhunk://#diff-6ba85168d8f3c133fda82286baad5afe74ad73b2cb325ee5f4973cae5e884b29R111) [[5]](diffhunk://#diff-ea1809aeae0aaa4ae7db755dc776653e1565f8cb473a75629831fffdb033f571R15) [[6]](diffhunk://#diff-ea1809aeae0aaa4ae7db755dc776653e1565f8cb473a75629831fffdb033f571R40) [[7]](diffhunk://#diff-ea1809aeae0aaa4ae7db755dc776653e1565f8cb473a75629831fffdb033f571R231-R234) [[8]](diffhunk://#diff-29aa520bba03822d765e96a8cd60c7e336830023a4b74ad592dd467f7e1ce0f1R63-R71) [[9]](diffhunk://#diff-d53582b095d5bd15f8490a9c7e174bf33b1b930a9868de8b137fda2438bf555cR153-R235)

* For admin test classes, the roster meta now includes only the test class ID (with the `test:` prefix stripped) and omits ClassLink fields to avoid polluting session gates and UI badges. [[1]](diffhunk://#diff-29aa520bba03822d765e96a8cd60c7e336830023a4b74ad592dd467f7e1ce0f1L17-R30) [[2]](diffhunk://#diff-29aa520bba03822d765e96a8cd60c7e336830023a4b74ad592dd467f7e1ce0f1L34-R46)

**Roster editor UI enhancements:**

* The roster editor modal now includes a toggle button to show or hide the email column. The column is auto-shown if any student has an email address, and appropriate placeholders and labels are provided. [[1]](diffhunk://#diff-d1d98a238fe3c38082f14c1e341893b9f5de80ef6c47bb94c33e87638827c32dR46-R47) [[2]](diffhunk://#diff-d1d98a238fe3c38082f14c1e341893b9f5de80ef6c47bb94c33e87638827c32dR134-R149) [[3]](diffhunk://#diff-d1d98a238fe3c38082f14c1e341893b9f5de80ef6c47bb94c33e87638827c32dR204) [[4]](diffhunk://#diff-d1d98a238fe3c38082f14c1e341893b9f5de80ef6c47bb94c33e87638827c32dR221-R223) [[5]](diffhunk://#diff-d1d98a238fe3c38082f14c1e341893b9f5de80ef6c47bb94c33e87638827c32dR236) [[6]](diffhunk://#diff-d1d98a238fe3c38082f14c1e341893b9f5de80ef6c47bb94c33e87638827c32dR258-R260) [[7]](diffhunk://#diff-d1d98a238fe3c38082f14c1e341893b9f5de80ef6c47bb94c33e87638827c32dR297-R314) [[8]](diffhunk://#diff-d1d98a238fe3c38082f14c1e341893b9f5de80ef6c47bb94c33e87638827c32dR324) [[9]](diffhunk://#diff-d1d98a238fe3c38082f14c1e341893b9f5de80ef6c47bb94c33e87638827c32dR333) [[10]](diffhunk://#diff-d1d98a238fe3c38082f14c1e341893b9f5de80ef6c47bb94c33e87638827c32dR345-R352) [[11]](diffhunk://#diff-d1d98a238fe3c38082f14c1e341893b9f5de80ef6c47bb94c33e87638827c32dR365-R372) [[12]](diffhunk://#diff-d1d98a238fe3c38082f14c1e341893b9f5de80ef6c47bb94c33e87638827c32dR407) [[13]](diffhunk://#diff-d1d98a238fe3c38082f14c1e341893b9f5de80ef6c47bb94c33e87638827c32dR444-R454) [[14]](diffhunk://#diff-d1d98a238fe3c38082f14c1e341893b9f5de80ef6c47bb94c33e87638827c32dL459-R519) [[15]](diffhunk://#diff-ea1809aeae0aaa4ae7db755dc776653e1565f8cb473a75629831fffdb033f571R50-R55)

**Routing and authentication:**

* The quiz student route now relies on the `QuizStudentApp` to handle Firebase authentication directly, avoiding unnecessary admin-only listeners that would fail for students.

**Testing improvements:**

* New tests ensure that email addresses are correctly persisted, backfilled, and preserved during ClassLink merges, and that unmatched local students do not receive emails erroneously.