### PR TITLE
feat(quiz): prompt for classes on PLC import + hide auto-created sheet URL

### DIFF
--- a/components/layout/DashboardView.tsx
+++ b/components/layout/DashboardView.tsx
@@ -147,6 +147,7 @@ export const DashboardView: React.FC = () => {
     clearPendingQuizShare,
     pendingAssignmentShareId,
     clearPendingAssignmentShare,
+    setPendingAssignmentSetup,
     // Widget grouping
     groupWidgets,
     groupBuildMode,
@@ -243,12 +244,14 @@ export const DashboardView: React.FC = () => {
       const meta = await saveQuiz(quiz);
       return { id: meta.id, driveFileId: meta.driveFileId };
     })
-      .then(() => {
-        addToast(
-          'Shared assignment imported! Click Start to begin.',
-          'success'
-        );
+      .then((newAssignmentId) => {
+        addToast('Shared assignment imported!', 'success');
         openQuizWidgetToTab('active');
+        // Prompt the importer to pick rosters/periods for the new
+        // assignment instead of leaving it paused with no targeting.
+        // The QuizWidget reads this and opens
+        // QuizAssignmentImportSetupModal.
+        setPendingAssignmentSetup(newAssignmentId);
       })
       .catch((err: unknown) => {
         const msg =
@@ -272,6 +275,7 @@ export const DashboardView: React.FC = () => {
     addToast,
     clearPendingAssignmentShare,
     openQuizWidgetToTab,
+    setPendingAssignmentSetup,
   ]);
 
   const [panOffset, setPanOffset] = React.useState({ x: 0, y: 0 });

--- a/components/layout/DashboardView.tsx
+++ b/components/layout/DashboardView.tsx
@@ -158,7 +158,7 @@ export const DashboardView: React.FC = () => {
     annotationActive,
   } = useDashboard();
 
-  const { importSharedQuiz, saveQuiz } = useQuiz(user?.uid);
+  const { importSharedQuiz, saveQuiz, deleteQuiz } = useQuiz(user?.uid);
   const { importSharedAssignment } = useQuizAssignments(user?.uid);
 
   // Helper: open (or create) a Quiz widget and set its managerTab.
@@ -240,10 +240,19 @@ export const DashboardView: React.FC = () => {
     // for the triple-import race rationale.
     const shareId = pendingAssignmentShareId;
     clearPendingAssignmentShare();
-    void importSharedAssignment(shareId, async (quiz) => {
-      const meta = await saveQuiz(quiz);
-      return { id: meta.id, driveFileId: meta.driveFileId };
-    })
+    void importSharedAssignment(
+      shareId,
+      async (quiz) => {
+        const meta = await saveQuiz(quiz);
+        return { id: meta.id, driveFileId: meta.driveFileId };
+      },
+      // Roll back the just-copied quiz if assignment creation fails
+      // mid-flight — otherwise the importer is left with a phantom
+      // quiz in their library and a generic "import failed" toast.
+      async (saved) => {
+        await deleteQuiz(saved.id, saved.driveFileId);
+      }
+    )
       .then((newAssignmentId) => {
         addToast('Shared assignment imported!', 'success');
         openQuizWidgetToTab('active');
@@ -272,6 +281,7 @@ export const DashboardView: React.FC = () => {
     user,
     importSharedAssignment,
     saveQuiz,
+    deleteQuiz,
     addToast,
     clearPendingAssignmentShare,
     openQuizWidgetToTab,

--- a/components/student/StudentContexts.tsx
+++ b/components/student/StudentContexts.tsx
@@ -264,6 +264,13 @@ const mockDashboard: DashboardContextValue = {
   clearPendingAssignmentShare: () => {
     // No-op
   },
+  pendingAssignmentSetupId: null,
+  setPendingAssignmentSetup: () => {
+    // No-op — student view never imports assignments.
+  },
+  clearPendingAssignmentSetup: () => {
+    // No-op
+  },
   // Roster mocks
   rosters: [],
   activeRosterId: null,

--- a/components/widgets/QuizWidget/Widget.tsx
+++ b/components/widgets/QuizWidget/Widget.tsx
@@ -166,6 +166,19 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
     [loadQuizData, addToast]
   );
 
+  // Drop any pending import-setup prompt when the QuizWidget unmounts.
+  // Without this, removing the widget while the modal is open (or before
+  // the user clicks Save/Skip/Edit) leaves `pendingAssignmentSetupId`
+  // set on DashboardContext indefinitely — the prompt would re-surface
+  // the next time any QuizWidget mounts on any board, against an
+  // assignment the user already walked away from. Closing the widget is
+  // an implicit dismiss.
+  React.useEffect(() => {
+    return () => {
+      clearPendingAssignmentSetup();
+    };
+  }, [clearPendingAssignmentSetup]);
+
   // Auto-load quiz data if we are in monitor view or have an active session, but data is missing
   // This allows for seamless resumption after page reload.
   React.useEffect(() => {
@@ -834,9 +847,20 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
                       ),
                     })
                     .catch((err: unknown) => {
+                      // The reconcile helper already swallows the
+                      // expected non-owner case (403 listing perms)
+                      // and the missing-sheet case (404), returning
+                      // `{ skipped: true }`. Anything that bubbles
+                      // here is a real failure — log AND toast so
+                      // the teacher knows the sheet's sharing state
+                      // may be stale rather than silently failing.
                       console.error(
                         '[QuizWidget] PLC sheet permission reconcile failed:',
                         err
+                      );
+                      addToast(
+                        "Couldn't update PLC sheet sharing — your teammate may need to re-share the sheet.",
+                        'error'
                       );
                     });
                 }

--- a/components/widgets/QuizWidget/Widget.tsx
+++ b/components/widgets/QuizWidget/Widget.tsx
@@ -23,6 +23,7 @@ import { QuizEditorModal } from './components/QuizEditorModal';
 import { QuizPreview } from './components/QuizPreview';
 import { QuizResults } from './components/QuizResults';
 import { QuizAssignmentSettingsModal } from './components/QuizAssignmentSettingsModal';
+import { QuizAssignmentImportSetupModal } from './components/QuizAssignmentImportSetupModal';
 import type { QuizAssignment } from '@/types';
 import {
   buildPinToNameMap,
@@ -45,8 +46,15 @@ import { QuizDriveService } from '@/utils/quizDriveService';
 import { getPlcTeammateEmails } from '@/utils/plc';
 
 export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
-  const { updateWidget, addWidget, addToast, rosters, activeDashboard } =
-    useDashboard();
+  const {
+    updateWidget,
+    addWidget,
+    addToast,
+    rosters,
+    activeDashboard,
+    pendingAssignmentSetupId,
+    clearPendingAssignmentSetup,
+  } = useDashboard();
   const { user, googleAccessToken, orgId } = useAuth();
   const { showConfirm } = useDialog();
   const config = widget.config as QuizConfig;
@@ -87,6 +95,7 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
     reopenAssignment,
     deleteAssignment,
     updateAssignmentSettings,
+    setAssignmentRosters,
     setAssignmentExportUrl,
     shareAssignment,
   } = useQuizAssignments(user?.uid);
@@ -1364,6 +1373,50 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
           }}
         />
       )}
+      {pendingAssignmentSetupId &&
+        (() => {
+          // Resolve the freshly-imported assignment from the live list.
+          // If the listener hasn't surfaced it yet (one snapshot tick of
+          // delay between createAssignment's batch.commit and the
+          // assignments onSnapshot callback), render nothing this pass —
+          // the next render will pick it up.
+          const target = assignments.find(
+            (a) => a.id === pendingAssignmentSetupId
+          );
+          if (!target) return null;
+          // Don't double-render the prompt over the full settings modal.
+          if (editingAssignment?.id === target.id) return null;
+          return (
+            <QuizAssignmentImportSetupModal
+              assignment={target}
+              rosters={rosters}
+              onSave={async (targets) => {
+                try {
+                  await setAssignmentRosters(target.id, targets);
+                  addToast(
+                    `Assigned to ${targets.rosterIds.length} ${
+                      targets.rosterIds.length === 1 ? 'class' : 'classes'
+                    }.`,
+                    'success'
+                  );
+                } catch (err) {
+                  addToast(
+                    err instanceof Error
+                      ? err.message
+                      : 'Failed to save class selection.',
+                    'error'
+                  );
+                  throw err;
+                }
+              }}
+              onEditAllSettings={() => {
+                clearPendingAssignmentSetup();
+                setEditingAssignment(target);
+              }}
+              onClose={clearPendingAssignmentSetup}
+            />
+          );
+        })()}
     </>
   );
 };

--- a/components/widgets/QuizWidget/Widget.tsx
+++ b/components/widgets/QuizWidget/Widget.tsx
@@ -1369,6 +1369,11 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
                 err instanceof Error ? err.message : 'Failed to save settings',
                 'error'
               );
+              // Re-throw so the modal's handleAssign sees the failure and
+              // skips its onClose() — keeping the modal open with the
+              // user's edits intact so they can retry. Without this,
+              // toast appears, modal disappears, edits are lost.
+              throw err;
             }
           }}
         />

--- a/components/widgets/QuizWidget/components/QuizAssignmentImportSetupModal.tsx
+++ b/components/widgets/QuizWidget/components/QuizAssignmentImportSetupModal.tsx
@@ -22,16 +22,15 @@ import {
   makeEmptyPickerValue,
   type AssignClassPickerValue,
 } from '@/components/common/AssignClassPicker.helpers';
-import { deriveSessionTargetsFromRosters } from '@/utils/resolveAssignmentTargets';
+import {
+  deriveSessionTargetsFromRosters,
+  type SessionTargets,
+} from '@/utils/resolveAssignmentTargets';
 
 interface QuizAssignmentImportSetupModalProps {
   assignment: QuizAssignment;
   rosters: ClassRoster[];
-  onSave: (targets: {
-    rosterIds: string[];
-    classIds: string[];
-    periodNames: string[];
-  }) => Promise<void> | void;
+  onSave: (targets: SessionTargets) => Promise<void> | void;
   onEditAllSettings: () => void;
   onClose: () => void;
 }
@@ -60,17 +59,40 @@ export const QuizAssignmentImportSetupModal: React.FC<
         periodNames: derived.periodNames,
       });
       onClose();
+    } catch {
+      // The parent's onSave wrapper already surfaces the failure via
+      // toast; we deliberately swallow here so the modal stays open
+      // (saving=false, edits intact) for the user to retry. Without
+      // the catch the rejection escapes into an unhandled promise
+      // since the click handler uses `void handleSave()`.
     } finally {
       setSaving(false);
     }
   };
 
+  // While Save is in flight we lock the dismissal controls (X /
+  // backdrop / Skip / Edit-all). Without this guard, clicking any of
+  // them mid-save would unmount the modal while `setAssignmentRosters`
+  // is still pending — React then warns about state updates on an
+  // unmounted component, and "Edit all settings…" would open the full
+  // settings modal against pre-update assignment data.
+  const handleBackdropMouseDown = (e: React.MouseEvent<HTMLDivElement>) => {
+    if (saving) return;
+    if (e.target === e.currentTarget) onClose();
+  };
+  const handleClose = () => {
+    if (saving) return;
+    onClose();
+  };
+  const handleEditAllSettings = () => {
+    if (saving) return;
+    onEditAllSettings();
+  };
+
   return (
     <div
       className="fixed inset-0 z-[200] bg-slate-900/60 backdrop-blur-sm flex items-center justify-center p-4"
-      onMouseDown={(e) => {
-        if (e.target === e.currentTarget) onClose();
-      }}
+      onMouseDown={handleBackdropMouseDown}
     >
       <div className="w-full max-w-md bg-white rounded-2xl shadow-2xl overflow-hidden">
         <div className="flex items-start justify-between px-5 pt-5 pb-3 border-b border-slate-100">
@@ -89,8 +111,9 @@ export const QuizAssignmentImportSetupModal: React.FC<
           </div>
           <button
             type="button"
-            onClick={onClose}
-            className="text-slate-400 hover:text-slate-600 p-1 -m-1"
+            onClick={handleClose}
+            disabled={saving}
+            className="text-slate-400 hover:text-slate-600 p-1 -m-1 disabled:opacity-50 disabled:cursor-not-allowed"
             aria-label="Close"
           >
             <X className="w-4 h-4" />
@@ -114,6 +137,7 @@ export const QuizAssignmentImportSetupModal: React.FC<
                 rosters={rosters}
                 value={pickerValue}
                 onChange={setPickerValue}
+                disabled={saving}
               />
             </>
           )}
@@ -122,16 +146,18 @@ export const QuizAssignmentImportSetupModal: React.FC<
         <div className="px-5 py-3 bg-slate-50 border-t border-slate-100 flex items-center justify-between gap-3">
           <button
             type="button"
-            onClick={onEditAllSettings}
-            className="text-xs font-medium text-indigo-600 hover:text-indigo-700"
+            onClick={handleEditAllSettings}
+            disabled={saving}
+            className="text-xs font-medium text-indigo-600 hover:text-indigo-700 disabled:opacity-50 disabled:cursor-not-allowed"
           >
             Edit all settings…
           </button>
           <div className="flex items-center gap-2">
             <button
               type="button"
-              onClick={onClose}
-              className="px-3 py-1.5 text-sm font-medium text-slate-600 hover:text-slate-800"
+              onClick={handleClose}
+              disabled={saving}
+              className="px-3 py-1.5 text-sm font-medium text-slate-600 hover:text-slate-800 disabled:opacity-50 disabled:cursor-not-allowed"
             >
               Skip for now
             </button>

--- a/components/widgets/QuizWidget/components/QuizAssignmentImportSetupModal.tsx
+++ b/components/widgets/QuizWidget/components/QuizAssignmentImportSetupModal.tsx
@@ -1,0 +1,151 @@
+/**
+ * QuizAssignmentImportSetupModal — minimal "pick classes" prompt that
+ * appears immediately after a teacher pastes a shared-assignment URL.
+ *
+ * Background: `importSharedAssignment` intentionally drops
+ * `rosterIds`/`classIds` from the originator's settings (those refer to
+ * rosters in the originator's account). Without this prompt the imported
+ * assignment lands paused with no targeting, and teachers don't realize
+ * they need to dig into Settings → Class Periods to make it usable.
+ *
+ * Reuses `AssignClassPicker` so roster selection looks identical to the
+ * primary assign flow. Period selection is implicit — derived from the
+ * picked rosters via `deriveSessionTargetsFromRosters`, the same helper
+ * `createAssignment` uses at first-create time.
+ */
+
+import React, { useState } from 'react';
+import { ClipboardList, X } from 'lucide-react';
+import type { ClassRoster, QuizAssignment } from '@/types';
+import { AssignClassPicker } from '@/components/common/AssignClassPicker';
+import {
+  makeEmptyPickerValue,
+  type AssignClassPickerValue,
+} from '@/components/common/AssignClassPicker.helpers';
+import { deriveSessionTargetsFromRosters } from '@/utils/resolveAssignmentTargets';
+
+interface QuizAssignmentImportSetupModalProps {
+  assignment: QuizAssignment;
+  rosters: ClassRoster[];
+  onSave: (targets: {
+    rosterIds: string[];
+    classIds: string[];
+    periodNames: string[];
+  }) => Promise<void> | void;
+  onEditAllSettings: () => void;
+  onClose: () => void;
+}
+
+export const QuizAssignmentImportSetupModal: React.FC<
+  QuizAssignmentImportSetupModalProps
+> = ({ assignment, rosters, onSave, onEditAllSettings, onClose }) => {
+  const [pickerValue, setPickerValue] =
+    useState<AssignClassPickerValue>(makeEmptyPickerValue);
+  const [saving, setSaving] = useState(false);
+
+  const selectedRosters = rosters.filter((r) =>
+    pickerValue.rosterIds.includes(r.id)
+  );
+  const canSave = selectedRosters.length > 0 && !saving;
+  const noRosters = rosters.length === 0;
+
+  const handleSave = async () => {
+    if (!canSave) return;
+    setSaving(true);
+    try {
+      const derived = deriveSessionTargetsFromRosters(selectedRosters);
+      await onSave({
+        rosterIds: derived.rosterIds,
+        classIds: derived.classIds,
+        periodNames: derived.periodNames,
+      });
+      onClose();
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-[200] bg-slate-900/60 backdrop-blur-sm flex items-center justify-center p-4"
+      onMouseDown={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <div className="w-full max-w-md bg-white rounded-2xl shadow-2xl overflow-hidden">
+        <div className="flex items-start justify-between px-5 pt-5 pb-3 border-b border-slate-100">
+          <div className="flex items-start gap-3">
+            <div className="shrink-0 w-9 h-9 rounded-lg bg-violet-100 text-violet-700 flex items-center justify-center">
+              <ClipboardList className="w-5 h-5" />
+            </div>
+            <div>
+              <h2 className="text-base font-bold text-slate-900">
+                Set up imported assignment
+              </h2>
+              <p className="text-xs text-slate-500 mt-0.5 truncate max-w-[18rem]">
+                {assignment.quizTitle}
+              </p>
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="text-slate-400 hover:text-slate-600 p-1 -m-1"
+            aria-label="Close"
+          >
+            <X className="w-4 h-4" />
+          </button>
+        </div>
+
+        <div className="px-5 py-4 space-y-4">
+          {noRosters ? (
+            <p className="text-sm text-slate-600 rounded-lg border border-dashed border-slate-200 bg-slate-50 px-3 py-3">
+              You don&apos;t have any classes yet. Add a class in{' '}
+              <span className="font-bold">My Classes</span> first, then come
+              back to assign this quiz.
+            </p>
+          ) : (
+            <>
+              <p className="text-sm text-slate-600">
+                Pick the classes that should take this quiz. Students will pick
+                their period after entering the join code.
+              </p>
+              <AssignClassPicker
+                rosters={rosters}
+                value={pickerValue}
+                onChange={setPickerValue}
+              />
+            </>
+          )}
+        </div>
+
+        <div className="px-5 py-3 bg-slate-50 border-t border-slate-100 flex items-center justify-between gap-3">
+          <button
+            type="button"
+            onClick={onEditAllSettings}
+            className="text-xs font-medium text-indigo-600 hover:text-indigo-700"
+          >
+            Edit all settings…
+          </button>
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={onClose}
+              className="px-3 py-1.5 text-sm font-medium text-slate-600 hover:text-slate-800"
+            >
+              Skip for now
+            </button>
+            <button
+              type="button"
+              disabled={!canSave}
+              onClick={() => void handleSave()}
+              className="px-4 py-1.5 text-sm font-bold text-white bg-brand-blue-primary hover:bg-brand-blue-dark disabled:bg-slate-300 disabled:cursor-not-allowed rounded-lg transition-colors"
+            >
+              {saving ? 'Saving…' : 'Save'}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/components/widgets/QuizWidget/components/QuizAssignmentImportSetupModal.tsx
+++ b/components/widgets/QuizWidget/components/QuizAssignmentImportSetupModal.tsx
@@ -12,11 +12,16 @@
  * primary assign flow. Period selection is implicit — derived from the
  * picked rosters via `deriveSessionTargetsFromRosters`, the same helper
  * `createAssignment` uses at first-create time.
+ *
+ * Built on the shared `Modal` primitive so it inherits `role="dialog"`,
+ * `aria-modal="true"`, Escape-to-close, body scroll locking, and portal
+ * rendering — no need to re-roll any of those concerns here.
  */
 
 import React, { useState } from 'react';
 import { ClipboardList, X } from 'lucide-react';
 import type { ClassRoster, QuizAssignment } from '@/types';
+import { Modal } from '@/components/common/Modal';
 import { AssignClassPicker } from '@/components/common/AssignClassPicker';
 import {
   makeEmptyPickerValue,
@@ -70,17 +75,15 @@ export const QuizAssignmentImportSetupModal: React.FC<
     }
   };
 
-  // While Save is in flight we lock the dismissal controls (X /
-  // backdrop / Skip / Edit-all). Without this guard, clicking any of
-  // them mid-save would unmount the modal while `setAssignmentRosters`
-  // is still pending — React then warns about state updates on an
-  // unmounted component, and "Edit all settings…" would open the full
-  // settings modal against pre-update assignment data.
-  const handleBackdropMouseDown = (e: React.MouseEvent<HTMLDivElement>) => {
-    if (saving) return;
-    if (e.target === e.currentTarget) onClose();
-  };
-  const handleClose = () => {
+  // While Save is in flight every dismissal path (Escape, X button,
+  // backdrop click, Skip, Edit-all) becomes a no-op. Without this guard,
+  // any of them would unmount the modal mid-Firestore-write — React then
+  // warns about state updates on an unmounted component, and "Edit all
+  // settings…" specifically would open the full settings modal against
+  // pre-update assignment data. Gating onClose at the Modal boundary
+  // handles Escape + backdrop in one shot; the inline buttons gate
+  // themselves below.
+  const guardedClose = () => {
     if (saving) return;
     onClose();
   };
@@ -90,11 +93,13 @@ export const QuizAssignmentImportSetupModal: React.FC<
   };
 
   return (
-    <div
-      className="fixed inset-0 z-[200] bg-slate-900/60 backdrop-blur-sm flex items-center justify-center p-4"
-      onMouseDown={handleBackdropMouseDown}
-    >
-      <div className="w-full max-w-md bg-white rounded-2xl shadow-2xl overflow-hidden">
+    <Modal
+      isOpen
+      onClose={guardedClose}
+      ariaLabel="Set up imported assignment"
+      maxWidth="max-w-md"
+      contentClassName=""
+      customHeader={
         <div className="flex items-start justify-between px-5 pt-5 pb-3 border-b border-slate-100">
           <div className="flex items-start gap-3">
             <div className="shrink-0 w-9 h-9 rounded-lg bg-violet-100 text-violet-700 flex items-center justify-center">
@@ -111,7 +116,7 @@ export const QuizAssignmentImportSetupModal: React.FC<
           </div>
           <button
             type="button"
-            onClick={handleClose}
+            onClick={guardedClose}
             disabled={saving}
             className="text-slate-400 hover:text-slate-600 p-1 -m-1 disabled:opacity-50 disabled:cursor-not-allowed"
             aria-label="Close"
@@ -119,31 +124,9 @@ export const QuizAssignmentImportSetupModal: React.FC<
             <X className="w-4 h-4" />
           </button>
         </div>
-
-        <div className="px-5 py-4 space-y-4">
-          {noRosters ? (
-            <p className="text-sm text-slate-600 rounded-lg border border-dashed border-slate-200 bg-slate-50 px-3 py-3">
-              You don&apos;t have any classes yet. Add a class in{' '}
-              <span className="font-bold">My Classes</span> first, then come
-              back to assign this quiz.
-            </p>
-          ) : (
-            <>
-              <p className="text-sm text-slate-600">
-                Pick the classes that should take this quiz. Students will pick
-                their period after entering the join code.
-              </p>
-              <AssignClassPicker
-                rosters={rosters}
-                value={pickerValue}
-                onChange={setPickerValue}
-                disabled={saving}
-              />
-            </>
-          )}
-        </div>
-
-        <div className="px-5 py-3 bg-slate-50 border-t border-slate-100 flex items-center justify-between gap-3">
+      }
+      footer={
+        <div className="flex items-center justify-between gap-3">
           <button
             type="button"
             onClick={handleEditAllSettings}
@@ -155,7 +138,7 @@ export const QuizAssignmentImportSetupModal: React.FC<
           <div className="flex items-center gap-2">
             <button
               type="button"
-              onClick={handleClose}
+              onClick={guardedClose}
               disabled={saving}
               className="px-3 py-1.5 text-sm font-medium text-slate-600 hover:text-slate-800 disabled:opacity-50 disabled:cursor-not-allowed"
             >
@@ -171,7 +154,31 @@ export const QuizAssignmentImportSetupModal: React.FC<
             </button>
           </div>
         </div>
+      }
+      footerClassName="px-5 py-3 bg-slate-50 border-t border-slate-100 shrink-0"
+    >
+      <div className="px-5 py-4 space-y-4">
+        {noRosters ? (
+          <p className="text-sm text-slate-600 rounded-lg border border-dashed border-slate-200 bg-slate-50 px-3 py-3">
+            You don&apos;t have any classes yet. Add a class in{' '}
+            <span className="font-bold">My Classes</span> first, then come back
+            to assign this quiz.
+          </p>
+        ) : (
+          <>
+            <p className="text-sm text-slate-600">
+              Pick the classes that should take this quiz. Students will pick
+              their period after entering the join code.
+            </p>
+            <AssignClassPicker
+              rosters={rosters}
+              value={pickerValue}
+              onChange={setPickerValue}
+              disabled={saving}
+            />
+          </>
+        )}
       </div>
-    </div>
+    </Modal>
   );
 };

--- a/components/widgets/QuizWidget/components/QuizAssignmentSettingsModal.tsx
+++ b/components/widgets/QuizWidget/components/QuizAssignmentSettingsModal.tsx
@@ -11,7 +11,16 @@
  */
 
 import React, { useState } from 'react';
-import { AlertTriangle, Lock, User, Zap, Clock, Share2 } from 'lucide-react';
+import {
+  AlertTriangle,
+  Lock,
+  User,
+  Zap,
+  Clock,
+  Share2,
+  ChevronDown,
+  ChevronRight,
+} from 'lucide-react';
 import type {
   QuizAssignment,
   QuizAssignmentSettings,
@@ -109,6 +118,13 @@ export const QuizAssignmentSettingsModal: React.FC<
   );
   const [sessionMode, setSessionMode] = useState<QuizSessionMode>(
     assignment.sessionMode
+  );
+
+  // The manual sheet-URL field stays hidden behind a disclosure unless a
+  // URL is already attached (legacy assignments / explicit overrides),
+  // because new PLC assignments auto-create and share a sheet.
+  const [showSheetUrl, setShowSheetUrl] = useState(
+    Boolean(assignment.plcSheetUrl)
   );
 
   const plcSheetUrlInvalid =
@@ -358,33 +374,64 @@ export const QuizAssignmentSettingsModal: React.FC<
                 </p>
               </div>
 
-              <div>
-                <label className="block text-xxs font-bold text-slate-400 uppercase tracking-widest mb-1">
-                  Shared Google Sheet URL
-                </label>
-                <input
-                  type="text"
-                  value={options.plcSheetUrl}
-                  onChange={(e) =>
-                    setOptions((p) => ({ ...p, plcSheetUrl: e.target.value }))
-                  }
-                  placeholder="https://docs.google.com/spreadsheets/d/..."
-                  className="w-full px-3 py-2 bg-white border border-slate-200 rounded-lg text-slate-800 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
-                />
-                {plcSheetUrlInvalid && (
-                  <div className="flex items-center gap-1 mt-1 text-amber-600">
-                    <AlertTriangle className="w-3 h-3" />
-                    <span className="text-xxs">
-                      This doesn&apos;t look like a Google Sheets URL
-                    </span>
+              {!showSheetUrl ? (
+                <div>
+                  <button
+                    type="button"
+                    onClick={() => setShowSheetUrl(true)}
+                    className="text-xs font-medium text-indigo-600 hover:text-indigo-700 inline-flex items-center gap-1"
+                  >
+                    <ChevronRight className="w-3 h-3" />
+                    Manually attach a sheet URL
+                  </button>
+                  <p className="text-xxs text-slate-400 mt-1">
+                    SpartBoard auto-creates and shares a results sheet for your
+                    PLC. Use this only to point an older assignment at a
+                    different sheet.
+                  </p>
+                </div>
+              ) : (
+                <div>
+                  <div className="flex items-center justify-between mb-1">
+                    <label className="block text-xxs font-bold text-slate-400 uppercase tracking-widest">
+                      Shared Google Sheet URL
+                    </label>
+                    <button
+                      type="button"
+                      onClick={() => {
+                        setShowSheetUrl(false);
+                        setOptions((p) => ({ ...p, plcSheetUrl: '' }));
+                      }}
+                      className="text-xxs text-slate-500 hover:text-slate-700 inline-flex items-center gap-1"
+                    >
+                      <ChevronDown className="w-3 h-3" />
+                      Hide
+                    </button>
                   </div>
-                )}
-                <p className="text-xxs text-slate-400 mt-0.5">
-                  New PLC assignments now auto-create and share this sheet for
-                  you. You can still edit the URL here to point an older
-                  assignment at a different sheet.
-                </p>
-              </div>
+                  <input
+                    type="text"
+                    value={options.plcSheetUrl}
+                    onChange={(e) =>
+                      setOptions((p) => ({ ...p, plcSheetUrl: e.target.value }))
+                    }
+                    placeholder="https://docs.google.com/spreadsheets/d/..."
+                    className="w-full px-3 py-2 bg-white border border-slate-200 rounded-lg text-slate-800 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                  />
+                  {plcSheetUrlInvalid && (
+                    <div className="flex items-center gap-1 mt-1 text-amber-600">
+                      <AlertTriangle className="w-3 h-3" />
+                      <span className="text-xxs">
+                        This doesn&apos;t look like a Google Sheets URL
+                      </span>
+                    </div>
+                  )}
+                  <p className="text-xxs text-slate-400 mt-0.5">
+                    New PLC assignments now auto-create and share this sheet for
+                    you. Use this to point an older assignment at a different
+                    sheet.
+                  </p>
+                </div>
+              )}
             </div>
           )}
         </>

--- a/components/widgets/QuizWidget/components/QuizManager.tsx
+++ b/components/widgets/QuizWidget/components/QuizManager.tsx
@@ -43,6 +43,8 @@ import {
   Loader2,
   AlertCircle,
   CheckSquare,
+  ChevronDown,
+  ChevronRight,
 } from 'lucide-react';
 import {
   QuizMetadata,
@@ -1496,6 +1498,15 @@ const AssignPlcSlot: React.FC<{
   const hasCachedSheet = Boolean(selectedPlc?.sharedSheetUrl);
   const hasPlcs = plcs.length > 0;
 
+  // The manual-URL field stays hidden behind a "Manually attach a sheet
+  // URL" disclosure so teachers don't think a paste is required — auto-
+  // create handles it for PLC members. Pre-expanded only for legacy
+  // assignments that already have a URL set, so the existing value isn't
+  // hidden behind a click.
+  const [showSheetUrl, setShowSheetUrl] = useState(
+    Boolean(options.plcSheetUrl)
+  );
+
   return (
     <>
       <div className="flex items-center justify-between">
@@ -1583,23 +1594,47 @@ const AssignPlcSlot: React.FC<{
           </div>
 
           {/*
-           * Manual URL fallback: surfaced only when the teacher has NO
-           * PLCs (so they can still paste a URL shared out-of-band) or
-           * they've pasted one already (editing a legacy assignment
-           * created pre-auto-create). Hidden in the normal auto-create
-           * path so PLC members aren't asked to paste what we'll create
-           * for them.
+           * Manual URL field — hidden behind a disclosure button so
+           * teachers don't think a paste is required. Auto-create
+           * handles it for PLC members; non-PLC users can still expand
+           * the disclosure to paste a URL their PLC lead shared with
+           * them out-of-band. Pre-expanded only when a URL is already
+           * stored (legacy assignments created pre-auto-create).
            */}
-          {(!hasPlcs || options.plcSheetUrl) && (
+          {!showSheetUrl ? (
             <div>
-              <label className="block text-xxs font-bold text-slate-400 uppercase tracking-widest mb-1">
-                Shared Google Sheet URL{' '}
-                {hasPlcs && (
-                  <span className="font-normal normal-case tracking-normal text-slate-400">
-                    (optional fallback)
-                  </span>
-                )}
-              </label>
+              <button
+                type="button"
+                onClick={() => setShowSheetUrl(true)}
+                className="text-xs font-medium text-indigo-600 hover:text-indigo-700 inline-flex items-center gap-1"
+              >
+                <ChevronRight className="w-3 h-3" />
+                Manually attach a sheet URL
+              </button>
+              <p className="text-xxs text-slate-400 mt-1">
+                {hasPlcs
+                  ? 'SpartBoard auto-creates and shares a results sheet for your PLC.'
+                  : 'Only needed if your PLC lead has shared a sheet with you out-of-band.'}
+              </p>
+            </div>
+          ) : (
+            <div>
+              <div className="flex items-center justify-between mb-1">
+                <label className="block text-xxs font-bold text-slate-400 uppercase tracking-widest">
+                  Shared Google Sheet URL
+                </label>
+                <button
+                  type="button"
+                  onClick={() => {
+                    setShowSheetUrl(false);
+                    update('plcSheetUrl', '');
+                  }}
+                  className="text-xxs text-slate-500 hover:text-slate-700 inline-flex items-center gap-1"
+                >
+                  <ChevronDown className="w-3 h-3" />
+                  Hide
+                </button>
+              </div>
               <input
                 type="text"
                 value={options.plcSheetUrl}

--- a/context/DashboardContext.tsx
+++ b/context/DashboardContext.tsx
@@ -158,6 +158,18 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
     window.history.replaceState(null, '', '/');
   }, []);
 
+  // Tracks an imported assignment that hasn't been targeted at any rosters
+  // yet, so the QuizWidget can prompt the teacher to pick classes
+  // immediately after import. Not derived from URL state — purely a
+  // post-import signal between DashboardView and the QuizWidget.
+  const [pendingAssignmentSetupId, setPendingAssignmentSetup] = useState<
+    string | null
+  >(null);
+
+  const clearPendingAssignmentSetup = useCallback(() => {
+    setPendingAssignmentSetup(null);
+  }, []);
+
   const [activeId, setActiveId] = useState<string | null>(null);
   const activeIdRef = useRef(activeId);
   // Keep a ref to account-level remote control so the Firestore snapshot
@@ -3304,6 +3316,9 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
       pendingAssignmentShareId,
       setPendingAssignmentShareId,
       clearPendingAssignmentShare,
+      pendingAssignmentSetupId,
+      setPendingAssignmentSetup,
+      clearPendingAssignmentSetup,
       zoom,
       setZoom,
       annotationActive,
@@ -3394,6 +3409,9 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
       pendingAssignmentShareId,
       setPendingAssignmentShareId,
       clearPendingAssignmentShare,
+      pendingAssignmentSetupId,
+      setPendingAssignmentSetup,
+      clearPendingAssignmentSetup,
       zoom,
       setZoom,
       annotationActive,

--- a/context/DashboardContextValue.ts
+++ b/context/DashboardContextValue.ts
@@ -121,6 +121,14 @@ export interface DashboardContextValue {
   setPendingAssignmentShareId: (shareId: string | null) => void;
   clearPendingAssignmentShare: () => void;
   setPendingQuizShareId: (shareId: string | null) => void;
+  /**
+   * Set after a successful `importSharedAssignment` to signal the QuizWidget
+   * to open a "pick classes" prompt for the freshly-imported assignment.
+   * Cleared by the modal once the user saves, opens full settings, or skips.
+   */
+  pendingAssignmentSetupId: string | null;
+  setPendingAssignmentSetup: (assignmentId: string | null) => void;
+  clearPendingAssignmentSetup: () => void;
 
   // Roster system
   rosters: ClassRoster[];

--- a/hooks/useQuizAssignments.ts
+++ b/hooks/useQuizAssignments.ts
@@ -99,6 +99,24 @@ export interface UseQuizAssignmentsResult {
     patch: Partial<QuizAssignmentSettings>
   ) => Promise<void>;
   /**
+   * Retarget an existing assignment at a new set of rosters. Mirrors
+   * `rosterIds`/`periodNames` to the assignment doc and `classIds`/
+   * `classId`/`rosterIds`/`periodNames` to the session doc so the
+   * student SSO gate, the legacy single-class fallback, and the post-PIN
+   * period picker all stay in sync. Used by the post-import "pick
+   * classes" prompt — `updateAssignmentSettings` doesn't touch
+   * `rosterIds`/`classIds`, so it can't fully retarget on its own.
+   *
+   * Callers derive `classIds`, `rosterIds`, and `periodNames` via
+   * `deriveSessionTargetsFromRosters` (same helper used at create-time)
+   * so the de-duplication rules stay identical between create and
+   * retarget paths.
+   */
+  setAssignmentRosters: (
+    assignmentId: string,
+    targets: { rosterIds: string[]; classIds: string[]; periodNames: string[] }
+  ) => Promise<void>;
+  /**
    * Persist the Drive export URL onto the assignment doc so re-entering
    * Results after navigating away (which remounts QuizResults and wipes its
    * local state) shows the "Open Sheet" shortcut instead of reverting to
@@ -507,6 +525,58 @@ export const useQuizAssignments = (
     [userId]
   );
 
+  const setAssignmentRosters = useCallback<
+    UseQuizAssignmentsResult['setAssignmentRosters']
+  >(
+    async (assignmentId, targets) => {
+      if (!userId) throw new Error('Not authenticated');
+      const now = Date.now();
+      const cleanedRosterIds = targets.rosterIds.filter(
+        (id): id is string => typeof id === 'string' && id.length > 0
+      );
+      const cleanedClassIds = targets.classIds.filter(
+        (id): id is string => typeof id === 'string' && id.length > 0
+      );
+      const cleanedPeriodNames = targets.periodNames.filter(
+        (n): n is string => typeof n === 'string' && n.length > 0
+      );
+
+      const assignmentPatch: Record<string, unknown> = {
+        updatedAt: now,
+        // Always overwrite — deleteField semantics aren't needed here
+        // because empty arrays are equivalent to "no targeting" for the
+        // resolver in resolveAssignmentTargets.
+        rosterIds: cleanedRosterIds,
+        periodNames: cleanedPeriodNames,
+        // Mirror periodName legacy field to the first selected period so
+        // pre-Phase-5A consumers (if any remain) still see a value.
+        periodName: cleanedPeriodNames[0] ?? '',
+      };
+
+      // Session doc carries the same targeting. classIds[0] is mirrored
+      // to classId for the legacy single-class gate (see createAssignment
+      // at line ~278 for the same dual-write rationale).
+      const sessionPatch: Record<string, unknown> = {
+        rosterIds: cleanedRosterIds,
+        classIds: cleanedClassIds,
+        classId: cleanedClassIds[0] ?? '',
+        periodNames: cleanedPeriodNames,
+      };
+
+      const batch = writeBatch(db);
+      batch.update(
+        doc(db, 'users', userId, QUIZ_ASSIGNMENTS_COLLECTION, assignmentId),
+        assignmentPatch
+      );
+      batch.update(
+        doc(db, QUIZ_SESSIONS_COLLECTION, assignmentId),
+        sessionPatch
+      );
+      await batch.commit();
+    },
+    [userId]
+  );
+
   const setAssignmentExportUrl = useCallback<
     UseQuizAssignmentsResult['setAssignmentExportUrl']
   >(
@@ -583,13 +653,32 @@ export const useQuizAssignments = (
       const savedMeta = await saveQuiz(newQuiz);
 
       // 2. Create a Paused assignment with the shared settings.
-      // Clear teacher-specific fields so the importer starts fresh with
-      // their own periods and name.
+      // Clear all originator-scoped fields so the importer starts fresh
+      // with their own targeting, identity, and PLC wiring:
+      //   - teacherName / periodName / periodNames: originator's free text
+      //     and class periods.
+      //   - plcSheetUrl: points at the ORIGINATOR's PLC Google Sheet. If
+      //     left in place, Widget.tsx's start-flow feeds it (along with
+      //     plcMemberEmails) into reconcilePlcSheetPermissions(), which
+      //     issues Drive calls against a sheet the importer doesn't own
+      //     and does Firestore reads on plcs/{originatorPlcId} where the
+      //     importer is not in memberUids — surfacing as silent
+      //     "Missing or insufficient permissions" console errors.
+      //   - plcMemberEmails: originator's PLC roster, irrelevant to the
+      //     importer's PLC (if any).
+      //   - plcMode: cleared so the importer explicitly opts in to PLC
+      //     mode for their own assignment via the settings modal — both
+      //     consistent with how their other settings behave and the only
+      //     way to guarantee plcMemberEmails / plcSheetUrl are repopulated
+      //     against the importer's own PLC instead of the originator's.
       const importedSettings = {
         ...shared.assignmentSettings,
         teacherName: undefined,
         periodName: undefined,
         periodNames: undefined,
+        plcMode: undefined,
+        plcSheetUrl: undefined,
+        plcMemberEmails: undefined,
       };
       // Intentionally omit classIds/rosterIds: the shared doc's targeting
       // refers to rosters in the ORIGINATOR's account and would be dangling
@@ -622,6 +711,7 @@ export const useQuizAssignments = (
     reopenAssignment,
     deleteAssignment,
     updateAssignmentSettings,
+    setAssignmentRosters,
     setAssignmentExportUrl,
     shareAssignment,
     importSharedAssignment,

--- a/hooks/useQuizAssignments.ts
+++ b/hooks/useQuizAssignments.ts
@@ -554,8 +554,9 @@ export const useQuizAssignments = (
       };
 
       // Session doc carries the same targeting. classIds[0] is mirrored
-      // to classId for the legacy single-class gate (see createAssignment
-      // at line ~278 for the same dual-write rationale).
+      // to classId for the legacy single-class gate — same dual-write
+      // the "Phase 5A: multi-class ClassLink targeting" branch in
+      // createAssignment uses at create time.
       const sessionPatch: Record<string, unknown> = {
         rosterIds: cleanedRosterIds,
         classIds: cleanedClassIds,
@@ -657,22 +658,31 @@ export const useQuizAssignments = (
       // with their own targeting, identity, and PLC wiring:
       //   - teacherName / periodName / periodNames: originator's free text
       //     and class periods.
-      //   - plcSheetUrl: points at the ORIGINATOR's PLC Google Sheet. If
-      //     left in place, Widget.tsx's start-flow feeds it (along with
-      //     plcMemberEmails) into reconcilePlcSheetPermissions(), which
-      //     issues Drive calls against a sheet the importer doesn't own
-      //     and does Firestore reads on plcs/{originatorPlcId} where the
-      //     importer is not in memberUids — surfacing as silent
-      //     "Missing or insufficient permissions" console errors.
-      //   - plcMemberEmails: originator's PLC roster, irrelevant to the
-      //     importer's PLC (if any).
-      //   - plcMode: cleared so the importer explicitly opts in to PLC
-      //     mode for their own assignment via the settings modal — both
-      //     consistent with how their other settings behave and the only
-      //     way to guarantee plcMemberEmails / plcSheetUrl are repopulated
-      //     against the importer's own PLC instead of the originator's.
+      //   - className: originator's class label (e.g. "Mrs. Smith's
+      //     3rd Period"). Cosmetic-only but confusing UX if left in
+      //     place — Teacher B sees Teacher A's label as the subtitle
+      //     on her own assignment card.
+      //   - plcSheetUrl: points at the ORIGINATOR's PLC Google Sheet.
+      //     If left in place, the importer's first results export
+      //     takes this URL (see QuizResults.tsx → exportResultsToSheet)
+      //     and calls Drive against a sheet the importer isn't shared
+      //     on — a 403, which used to surface as a silent
+      //     "Missing or insufficient permissions" console error.
+      //     Clearing it lets the auto-create path on first PLC
+      //     assignment populate the importer's own sheet instead.
+      //   - plcMemberEmails: originator's PLC roster. Not consumed
+      //     by the importer's start-flow today (Widget.tsx derives
+      //     sharing from the live `plc` doc via getPlcTeammateEmails),
+      //     but cleared for hygiene — leaving someone else's email
+      //     roster on the doc is a future-foot-gun.
+      //   - plcMode: cleared so the importer explicitly opts in to
+      //     PLC mode for their own assignment via the settings modal,
+      //     keeping plcSheetUrl/plcMemberEmails repopulation tied to
+      //     the importer's own PLC selection rather than the
+      //     originator's.
       const importedSettings = {
         ...shared.assignmentSettings,
+        className: undefined,
         teacherName: undefined,
         periodName: undefined,
         periodNames: undefined,

--- a/hooks/useQuizAssignments.ts
+++ b/hooks/useQuizAssignments.ts
@@ -35,6 +35,7 @@ import type {
   QuizSession,
   SharedQuizAssignment,
 } from '../types';
+import type { SessionTargets } from '../utils/resolveAssignmentTargets';
 import {
   QUIZ_SESSIONS_COLLECTION,
   RESPONSES_COLLECTION,
@@ -114,7 +115,7 @@ export interface UseQuizAssignmentsResult {
    */
   setAssignmentRosters: (
     assignmentId: string,
-    targets: { rosterIds: string[]; classIds: string[]; periodNames: string[] }
+    targets: SessionTargets
   ) => Promise<void>;
   /**
    * Persist the Drive export URL onto the assignment doc so re-entering
@@ -132,10 +133,19 @@ export interface UseQuizAssignmentsResult {
    * Import a shared assignment. Delegates quiz copy to the injected saveQuiz
    * (from useQuiz.ts) and creates a new paused assignment under the importer's
    * collection. Returns the new assignmentId.
+   *
+   * `rollbackQuiz` is optional but strongly recommended — it's invoked
+   * best-effort if assignment creation fails AFTER the quiz copy already
+   * succeeded, preventing an orphan quiz in the importer's library.
+   * Receives the just-saved quiz's `{id, driveFileId}` so the caller
+   * can dispatch to its own `deleteQuiz` (which needs both). A failed
+   * rollback is swallowed (logged only); the original error still
+   * propagates so the caller can surface a useful message.
    */
   importSharedAssignment: (
     shareId: string,
-    saveQuiz: (quiz: QuizData) => Promise<{ id: string; driveFileId: string }>
+    saveQuiz: (quiz: QuizData) => Promise<{ id: string; driveFileId: string }>,
+    rollbackQuiz?: (saved: { id: string; driveFileId: string }) => Promise<void>
   ) => Promise<string>;
 }
 
@@ -633,7 +643,7 @@ export const useQuizAssignments = (
   const importSharedAssignment = useCallback<
     UseQuizAssignmentsResult['importSharedAssignment']
   >(
-    async (shareId, saveQuiz) => {
+    async (shareId, saveQuiz, rollbackQuiz) => {
       if (!userId) throw new Error('Not authenticated');
 
       const snap = await getDoc(
@@ -695,16 +705,39 @@ export const useQuizAssignments = (
       // refs here. The importer retargets on first launch via AssignClassPicker,
       // which pre-seeds empty because lastRosterIdsByQuizId is only written at
       // assign-confirm time (QuizWidget/Widget.tsx) — never during import.
-      const created = await createAssignment(
-        {
-          id: savedMeta.id,
-          title: newQuiz.title,
-          driveFileId: savedMeta.driveFileId,
-          questions: newQuiz.questions,
-        },
-        importedSettings,
-        'paused'
-      );
+      // 3. Stand up the assignment + its session doc. If this fails
+      // AFTER the quiz copy already succeeded, the importer is left
+      // with an orphan quiz in their library and a generic "Failed to
+      // import" toast. Roll back best-effort, and re-throw with the
+      // orphaned quiz id surfaced so the caller can be specific.
+      let created: { id: string; code: string };
+      try {
+        created = await createAssignment(
+          {
+            id: savedMeta.id,
+            title: newQuiz.title,
+            driveFileId: savedMeta.driveFileId,
+            questions: newQuiz.questions,
+          },
+          importedSettings,
+          'paused'
+        );
+      } catch (err) {
+        if (rollbackQuiz) {
+          try {
+            await rollbackQuiz(savedMeta);
+          } catch (rollbackErr) {
+            // Don't mask the original error — orphan quiz is the
+            // lesser problem; the caller still needs to know what
+            // really failed.
+            console.error(
+              `[importSharedAssignment] Failed to roll back quiz ${savedMeta.id} after assignment-create error:`,
+              rollbackErr
+            );
+          }
+        }
+        throw err;
+      }
       return created.id;
     },
     [userId, createAssignment]

--- a/hooks/useQuizSession.ts
+++ b/hooks/useQuizSession.ts
@@ -632,7 +632,28 @@ export const useQuizSessionStudent = (): UseQuizSessionStudentResult => {
     if (!sessionIdState) return;
     return onSnapshot(
       doc(db, QUIZ_SESSIONS_COLLECTION, sessionIdState),
-      (snap) => setSession(snap.exists() ? (snap.data() as QuizSession) : null)
+      (snap) => {
+        setSession(snap.exists() ? (snap.data() as QuizSession) : null);
+        setError(null);
+      },
+      (err) => {
+        // Without an onError callback, a permission-denied or transport
+        // failure here causes the session listener to silently stop and
+        // the student stares at a frozen screen. Surface it so the join
+        // flow can show "Couldn't connect to the quiz" instead of
+        // hanging.
+        const code = (err as { code?: string }).code;
+        const path = `${QUIZ_SESSIONS_COLLECTION}/${sessionIdState}`;
+        console.error(
+          `[useQuizSessionStudent] session listener error at ${path} (code=${code ?? 'unknown'}):`,
+          err
+        );
+        setError(
+          code === 'permission-denied'
+            ? "You don't have access to this quiz session."
+            : 'Lost connection to the quiz. Please refresh.'
+        );
+      }
     );
   }, [sessionIdState]);
 
@@ -655,7 +676,23 @@ export const useQuizSessionStudent = (): UseQuizSessionStudentResult => {
           snap.exists()
             ? { ...(snap.data() as QuizResponse), _responseKey: snap.id }
             : null
-        )
+        ),
+      (err) => {
+        // Same rationale as the session listener above — without this
+        // callback a permission-denied silently freezes the student's
+        // submit-and-see-feedback loop.
+        const code = (err as { code?: string }).code;
+        const path = `${QUIZ_SESSIONS_COLLECTION}/${sessionIdState}/${RESPONSES_COLLECTION}/${responseKeyState}`;
+        console.error(
+          `[useQuizSessionStudent] response listener error at ${path} (code=${code ?? 'unknown'}):`,
+          err
+        );
+        setError(
+          code === 'permission-denied'
+            ? 'Lost permission to read your answers. Ask your teacher.'
+            : 'Lost connection to the quiz. Please refresh.'
+        );
+      }
     );
   }, [sessionIdState, responseKeyState]);
 

--- a/hooks/useQuizSession.ts
+++ b/hooks/useQuizSession.ts
@@ -308,7 +308,12 @@ export const useQuizSessionTeacher = (
         setLoading(false);
       },
       (err) => {
-        console.error('[useQuizSessionTeacher]', err);
+        const code = (err as { code?: string }).code;
+        const path = `${QUIZ_SESSIONS_COLLECTION}/${sessionId}`;
+        console.error(
+          `[useQuizSessionTeacher] session listener error at ${path} (code=${code ?? 'unknown'}):`,
+          err
+        );
         setLoading(false);
       }
     );
@@ -340,7 +345,14 @@ export const useQuizSessionTeacher = (
         );
         setResponses(list);
       },
-      (err) => console.error('[useQuizSessionTeacher] responses:', err)
+      (err) => {
+        const code = (err as { code?: string }).code;
+        const path = `${QUIZ_SESSIONS_COLLECTION}/${sessionId}/${RESPONSES_COLLECTION}`;
+        console.error(
+          `[useQuizSessionTeacher] responses listener error at ${path} (code=${code ?? 'unknown'}):`,
+          err
+        );
+      }
     );
   }, [sessionId, hasSession]);
 

--- a/hooks/useQuizSession.ts
+++ b/hooks/useQuizSession.ts
@@ -671,12 +671,18 @@ export const useQuizSessionStudent = (): UseQuizSessionStudentResult => {
         RESPONSES_COLLECTION,
         responseKeyState
       ),
-      (snap) =>
+      (snap) => {
         setMyResponse(
           snap.exists()
             ? { ...(snap.data() as QuizResponse), _responseKey: snap.id }
             : null
-        ),
+        );
+        // Mirror the session-listener pattern at L630 — clear any
+        // stale error from a transient transport blip so the UI
+        // doesn't stay stuck on "Lost connection" once the snapshot
+        // recovers.
+        setError(null);
+      },
       (err) => {
         // Same rationale as the session listener above — without this
         // callback a permission-denied silently freezes the student's

--- a/tests/components/widgets/QuizAssignmentImportSetupModal.test.tsx
+++ b/tests/components/widgets/QuizAssignmentImportSetupModal.test.tsx
@@ -1,0 +1,178 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { QuizAssignmentImportSetupModal } from '@/components/widgets/QuizWidget/components/QuizAssignmentImportSetupModal';
+import type { ClassRoster, QuizAssignment } from '@/types';
+
+// Stub AssignClassPicker to a controlled checkbox list. The real
+// component pulls in ClassLink helpers and visual chrome we don't need
+// for this behavioral test — focus on the modal's own contracts: which
+// roster ids it gathers, what it derives, what it forwards to onSave.
+vi.mock('@/components/common/AssignClassPicker', () => ({
+  AssignClassPicker: ({
+    rosters,
+    value,
+    onChange,
+    disabled,
+  }: {
+    rosters: ClassRoster[];
+    value: { rosterIds: string[] };
+    onChange: (next: { rosterIds: string[] }) => void;
+    disabled?: boolean;
+  }) => (
+    <div data-testid="picker">
+      {rosters.map((r) => (
+        <label key={r.id}>
+          <input
+            type="checkbox"
+            data-testid={`roster-${r.id}`}
+            disabled={disabled}
+            checked={value.rosterIds.includes(r.id)}
+            onChange={(e) =>
+              onChange({
+                rosterIds: e.target.checked
+                  ? [...value.rosterIds, r.id]
+                  : value.rosterIds.filter((id) => id !== r.id),
+              })
+            }
+          />
+          {r.name}
+        </label>
+      ))}
+    </div>
+  ),
+}));
+
+const assignment = {
+  id: 'a1',
+  quizTitle: 'Imported Quiz',
+} as unknown as QuizAssignment;
+
+const rosters: ClassRoster[] = [
+  {
+    id: 'r1',
+    name: 'Math 1',
+    students: [],
+    classlinkClassId: 'cl-A',
+  } as unknown as ClassRoster,
+  {
+    id: 'r2',
+    name: 'Math 2',
+    students: [],
+  } as unknown as ClassRoster,
+];
+
+describe('QuizAssignmentImportSetupModal', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('disables Save until at least one roster is selected', () => {
+    render(
+      <QuizAssignmentImportSetupModal
+        assignment={assignment}
+        rosters={rosters}
+        onSave={vi.fn()}
+        onEditAllSettings={vi.fn()}
+        onClose={vi.fn()}
+      />
+    );
+    const save = screen.getByRole('button', { name: /^Save$/ });
+    expect(save).toBeDisabled();
+    fireEvent.click(screen.getByTestId('roster-r1'));
+    expect(save).not.toBeDisabled();
+  });
+
+  it('passes derived targets (rosterIds, classIds, periodNames) to onSave then closes', async () => {
+    const onSave = vi.fn().mockResolvedValue(undefined);
+    const onClose = vi.fn();
+    render(
+      <QuizAssignmentImportSetupModal
+        assignment={assignment}
+        rosters={rosters}
+        onSave={onSave}
+        onEditAllSettings={vi.fn()}
+        onClose={onClose}
+      />
+    );
+    fireEvent.click(screen.getByTestId('roster-r1'));
+    fireEvent.click(screen.getByRole('button', { name: /^Save$/ }));
+    await waitFor(() => expect(onSave).toHaveBeenCalledTimes(1));
+    expect(onSave.mock.calls[0][0]).toMatchObject({
+      rosterIds: expect.arrayContaining(['r1']),
+      classIds: expect.arrayContaining(['cl-A']),
+      periodNames: expect.arrayContaining(['Math 1']),
+    });
+    // Modal closes only after the save promise resolves — guards
+    // against the lost-error pattern where onClose runs before we
+    // know whether the write succeeded.
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps the modal open and does NOT call onClose when onSave throws', async () => {
+    const saveError = new Error('Firestore down');
+    const onSave = vi.fn().mockRejectedValue(saveError);
+    const onClose = vi.fn();
+    render(
+      <QuizAssignmentImportSetupModal
+        assignment={assignment}
+        rosters={rosters}
+        onSave={onSave}
+        onEditAllSettings={vi.fn()}
+        onClose={onClose}
+      />
+    );
+    fireEvent.click(screen.getByTestId('roster-r1'));
+    fireEvent.click(screen.getByRole('button', { name: /^Save$/ }));
+    await waitFor(() => expect(onSave).toHaveBeenCalled());
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('renders the no-classes empty state and disables Save when rosters is empty', () => {
+    render(
+      <QuizAssignmentImportSetupModal
+        assignment={assignment}
+        rosters={[]}
+        onSave={vi.fn()}
+        onEditAllSettings={vi.fn()}
+        onClose={vi.fn()}
+      />
+    );
+    expect(screen.getByText(/don't have any classes yet/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /^Save$/ })).toBeDisabled();
+  });
+
+  it('"Edit all settings…" calls onEditAllSettings (not onClose)', () => {
+    const onEditAllSettings = vi.fn();
+    const onClose = vi.fn();
+    render(
+      <QuizAssignmentImportSetupModal
+        assignment={assignment}
+        rosters={rosters}
+        onSave={vi.fn()}
+        onEditAllSettings={onEditAllSettings}
+        onClose={onClose}
+      />
+    );
+    fireEvent.click(screen.getByRole('button', { name: /Edit all settings/i }));
+    expect(onEditAllSettings).toHaveBeenCalledTimes(1);
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('"Skip for now" closes without invoking onSave', () => {
+    const onSave = vi.fn();
+    const onClose = vi.fn();
+    render(
+      <QuizAssignmentImportSetupModal
+        assignment={assignment}
+        rosters={rosters}
+        onSave={onSave}
+        onEditAllSettings={vi.fn()}
+        onClose={onClose}
+      />
+    );
+    fireEvent.click(screen.getByRole('button', { name: /Skip for now/i }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(onSave).not.toHaveBeenCalled();
+  });
+});

--- a/tests/components/widgets/QuizAssignmentSettingsModal.test.tsx
+++ b/tests/components/widgets/QuizAssignmentSettingsModal.test.tsx
@@ -1,0 +1,93 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { QuizAssignmentSettingsModal } from '@/components/widgets/QuizWidget/components/QuizAssignmentSettingsModal';
+import type { ClassRoster, QuizAssignment } from '@/types';
+
+function makePlcAssignment(
+  overrides: Partial<QuizAssignment> = {}
+): QuizAssignment {
+  return {
+    id: 'a1',
+    quizId: 'q1',
+    quizTitle: 'PLC Quiz',
+    quizDriveFileId: 'drive1',
+    teacherUid: 'teacher-1',
+    code: 'ABC123',
+    status: 'paused',
+    createdAt: 1,
+    updatedAt: 1,
+    sessionMode: 'teacher',
+    sessionOptions: {},
+    plcMode: true,
+    plcSheetUrl: '',
+    teacherName: '',
+    periodNames: [],
+    ...overrides,
+  } as unknown as QuizAssignment;
+}
+
+describe('QuizAssignmentSettingsModal — sheet URL disclosure', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('starts collapsed when the assignment has no plcSheetUrl', () => {
+    render(
+      <QuizAssignmentSettingsModal
+        assignment={makePlcAssignment()}
+        rosters={[] as ClassRoster[]}
+        onSave={vi.fn()}
+        onClose={vi.fn()}
+      />
+    );
+    expect(
+      screen.getByRole('button', { name: /Manually attach a sheet URL/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByPlaceholderText(/docs\.google\.com\/spreadsheets/i)
+    ).not.toBeInTheDocument();
+  });
+
+  it('starts expanded when the assignment already has a plcSheetUrl (legacy)', () => {
+    render(
+      <QuizAssignmentSettingsModal
+        assignment={makePlcAssignment({
+          plcSheetUrl: 'https://docs.google.com/spreadsheets/d/legacy-sheet-id',
+        })}
+        rosters={[] as ClassRoster[]}
+        onSave={vi.fn()}
+        onClose={vi.fn()}
+      />
+    );
+    // Field is rendered with the legacy URL pre-populated.
+    expect(screen.getByDisplayValue(/legacy-sheet-id/)).toBeInTheDocument();
+    // No disclosure button when expanded.
+    expect(
+      screen.queryByRole('button', { name: /Manually attach a sheet URL/i })
+    ).not.toBeInTheDocument();
+  });
+
+  it('clicking "Hide" clears plcSheetUrl in the saved patch (destructive disclosure)', async () => {
+    const onSave = vi.fn().mockResolvedValue(undefined);
+    render(
+      <QuizAssignmentSettingsModal
+        assignment={makePlcAssignment({
+          // status must be 'inactive' for Save to be enabled when
+          // the modeLocked path keeps everything else editable —
+          // 'paused' still allows save here since the modal's
+          // confirm gate is permissive.
+          plcSheetUrl: 'https://docs.google.com/spreadsheets/d/legacy-sheet-id',
+        })}
+        rosters={[] as ClassRoster[]}
+        onSave={onSave}
+        onClose={vi.fn()}
+      />
+    );
+    fireEvent.click(screen.getByRole('button', { name: /Hide/i }));
+    // Save (the modal's confirm button label is just "Save").
+    fireEvent.click(screen.getByRole('button', { name: /^Save$/ }));
+    await waitFor(() => expect(onSave).toHaveBeenCalled());
+    expect(onSave.mock.calls[0][0]).toMatchObject({ plcSheetUrl: '' });
+  });
+});

--- a/tests/hooks/useQuizAssignments.test.ts
+++ b/tests/hooks/useQuizAssignments.test.ts
@@ -319,6 +319,7 @@ describe('useQuizAssignments - importSharedAssignment', () => {
         plcSheetUrl:
           'https://docs.google.com/spreadsheets/d/originator-sheet-id',
         plcMemberEmails: ['origA@example.com', 'origB@example.com'],
+        className: "Mrs. Smith's 3rd Period",
         teacherName: 'Originator Teacher',
         periodNames: ['Period 1'],
       },
@@ -344,11 +345,136 @@ describe('useQuizAssignments - importSharedAssignment', () => {
     expect(assignment.plcMode).toBeUndefined();
     expect(assignment.plcSheetUrl).toBeUndefined();
     expect(assignment.plcMemberEmails).toBeUndefined();
-    // teacherName / periodNames are also originator-scoped and must clear:
+    // className / teacherName / periodNames are also originator-scoped:
+    expect(assignment.className).toBeUndefined();
     expect(assignment.teacherName).toBeUndefined();
     expect(assignment.periodNames).toBeUndefined();
     // The teacherUid on the assignment must be the importer, not the originator:
     expect(assignment.teacherUid).toBe(TEACHER_UID);
+  });
+
+  it('creates the imported assignment in paused state so students cannot join before the teacher targets it', async () => {
+    const sharedDoc: Partial<SharedQuizAssignment> = {
+      title: 'Quiz',
+      questions: [],
+      createdAt: 1,
+      updatedAt: 1,
+      assignmentSettings: { sessionMode: 'teacher', sessionOptions: {} },
+      originalAuthor: 'originator-uid',
+      sharedAt: 1,
+    };
+    mockGetDoc.mockResolvedValueOnce({
+      exists: () => true,
+      data: () => sharedDoc,
+    });
+
+    const saveQuiz = vi.fn().mockResolvedValue({
+      id: 'q',
+      driveFileId: 'd',
+    });
+
+    const { result } = renderHook(() => useQuizAssignments(TEACHER_UID));
+    await act(async () => {
+      await result.current.importSharedAssignment('share-id', saveQuiz);
+    });
+
+    const assignment = findAssignmentSet();
+    expect(assignment.status).toBe('paused');
+
+    // The session doc set in the same batch must also be non-active —
+    // for a teacher-paced session with initialStatus='paused', the
+    // session status maps to 'paused' (see createAssignment session
+    // status branch).
+    const sessionCall = batchSet.mock.calls.find(
+      ([ref]) => typeof ref === 'string' && ref.startsWith('quiz_sessions/')
+    );
+    if (!sessionCall) throw new Error('expected batch.set on session doc');
+    expect(sessionCall[1]).toMatchObject({ status: 'paused' });
+  });
+
+  it('does not carry classIds/rosterIds onto the importer session even when the shared doc carries them', async () => {
+    // shareAssignment doesn't write these fields today, but a future
+    // bug or migration could. Defend at the import layer so a
+    // regression doesn't silently send the importer's students to the
+    // ORIGINATOR's ClassLink classes.
+    const sharedDoc: Record<string, unknown> = {
+      title: 'Quiz',
+      questions: [],
+      createdAt: 1,
+      updatedAt: 1,
+      assignmentSettings: {
+        sessionMode: 'teacher',
+        sessionOptions: {},
+        // simulate a defensively-tested polluted shared doc
+        classIds: ['originator-cl-class-A'],
+        rosterIds: ['originator-roster-1'],
+      },
+      originalAuthor: 'originator-uid',
+      sharedAt: 1,
+    };
+    mockGetDoc.mockResolvedValueOnce({
+      exists: () => true,
+      data: () => sharedDoc,
+    });
+
+    const saveQuiz = vi.fn().mockResolvedValue({ id: 'q', driveFileId: 'd' });
+    const { result } = renderHook(() => useQuizAssignments(TEACHER_UID));
+    await act(async () => {
+      await result.current.importSharedAssignment('share-id', saveQuiz);
+    });
+
+    const sessionCall = batchSet.mock.calls.find(
+      ([ref]) => typeof ref === 'string' && ref.startsWith('quiz_sessions/')
+    );
+    if (!sessionCall) throw new Error('expected batch.set on session doc');
+    const session = sessionCall[1] as Record<string, unknown>;
+    // createAssignment only writes classIds/classId when targetClassIds
+    // is non-empty. importSharedAssignment passes neither classIds nor
+    // rosterIds, so these fields must not appear on the session.
+    expect(session.classIds).toBeUndefined();
+    expect(session.classId).toBeUndefined();
+    expect(session.rosterIds).toBeUndefined();
+  });
+
+  it('rolls back the just-saved quiz when assignment creation fails', async () => {
+    const sharedDoc: Partial<SharedQuizAssignment> = {
+      title: 'Q',
+      questions: [],
+      createdAt: 1,
+      updatedAt: 1,
+      assignmentSettings: { sessionMode: 'teacher', sessionOptions: {} },
+      originalAuthor: 'orig',
+      sharedAt: 1,
+    };
+    mockGetDoc.mockResolvedValueOnce({
+      exists: () => true,
+      data: () => sharedDoc,
+    });
+    // Make the batch commit fail to simulate the assignment-create error.
+    batchCommit.mockReset().mockRejectedValueOnce(new Error('Firestore down'));
+
+    const saveQuiz = vi.fn().mockResolvedValue({
+      id: 'orphan-quiz',
+      driveFileId: 'orphan-drive',
+    });
+    const rollbackQuiz = vi.fn().mockResolvedValue(undefined);
+
+    const { result } = renderHook(() => useQuizAssignments(TEACHER_UID));
+    await act(async () => {
+      await expect(
+        result.current.importSharedAssignment(
+          'share-id',
+          saveQuiz,
+          rollbackQuiz
+        )
+      ).rejects.toThrow('Firestore down');
+    });
+
+    expect(rollbackQuiz).toHaveBeenCalledTimes(1);
+    expect(rollbackQuiz).toHaveBeenCalledWith({
+      id: 'orphan-quiz',
+      driveFileId: 'orphan-drive',
+    });
   });
 });
 
@@ -407,5 +533,60 @@ describe('useQuizAssignments - setAssignmentRosters', () => {
     });
 
     expect(batchCommit).toHaveBeenCalledTimes(1);
+  });
+
+  it('drops empty-string entries from rosterIds/classIds/periodNames before writing', async () => {
+    const { result } = renderHook(() => useQuizAssignments(TEACHER_UID));
+    await act(async () => {
+      await result.current.setAssignmentRosters(ASSIGNMENT_ID, {
+        rosterIds: ['r1', '', 'r2'],
+        classIds: ['', 'cl-A'],
+        periodNames: ['', 'Period 2'],
+      });
+    });
+
+    const sessionCall = batchUpdate.mock.calls.find(
+      ([ref]) => typeof ref === 'string' && ref.startsWith('quiz_sessions/')
+    );
+    if (!sessionCall) throw new Error('expected batch.update on session doc');
+    expect(sessionCall[1]).toMatchObject({
+      rosterIds: ['r1', 'r2'],
+      classIds: ['cl-A'],
+      classId: 'cl-A',
+      periodNames: ['Period 2'],
+    });
+  });
+
+  it('writes empty arrays + empty classId/periodName when all inputs are empty (untargeted)', async () => {
+    const { result } = renderHook(() => useQuizAssignments(TEACHER_UID));
+    await act(async () => {
+      await result.current.setAssignmentRosters(ASSIGNMENT_ID, {
+        rosterIds: [],
+        classIds: [],
+        periodNames: [],
+      });
+    });
+
+    const sessionCall = batchUpdate.mock.calls.find(
+      ([ref]) => typeof ref === 'string' && ref.startsWith('quiz_sessions/')
+    );
+    if (!sessionCall) throw new Error('expected batch.update on session doc');
+    expect(sessionCall[1]).toMatchObject({
+      classId: '',
+      rosterIds: [],
+      classIds: [],
+    });
+
+    const assignmentCall = batchUpdate.mock.calls.find(
+      ([ref]) =>
+        typeof ref === 'string' &&
+        ref.startsWith(`users/${TEACHER_UID}/quiz_assignments/`)
+    );
+    if (!assignmentCall)
+      throw new Error('expected batch.update on assignment doc');
+    expect(assignmentCall[1]).toMatchObject({
+      periodName: '',
+      rosterIds: [],
+    });
   });
 });

--- a/tests/hooks/useQuizAssignments.test.ts
+++ b/tests/hooks/useQuizAssignments.test.ts
@@ -4,11 +4,16 @@ import {
   collection,
   doc,
   getDoc,
+  getDocs,
   onSnapshot,
   writeBatch,
 } from 'firebase/firestore';
 import { useQuizAssignments } from '@/hooks/useQuizAssignments';
-import type { QuizPublicQuestion, QuizSession } from '@/types';
+import type {
+  QuizPublicQuestion,
+  QuizSession,
+  SharedQuizAssignment,
+} from '@/types';
 
 vi.mock('firebase/firestore', () => ({
   collection: vi.fn(),
@@ -262,5 +267,145 @@ describe('useQuizAssignments - reopenAssignment', () => {
     if (!resumeSessionCall)
       throw new Error('expected resume batch.update on quiz_sessions/*');
     expect(resumeSessionCall[1]).toMatchObject({ status: 'waiting' });
+  });
+});
+
+describe('useQuizAssignments - importSharedAssignment', () => {
+  const batchSet = vi.fn();
+  const batchUpdate = vi.fn();
+  const batchCommit = vi.fn();
+  const mockGetDocs = getDocs as Mock;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDoc.mockImplementation((_db: unknown, ...segs: string[]) =>
+      segs.join('/')
+    );
+    mockCollection.mockReturnValue('coll-ref');
+    mockOnSnapshot.mockReturnValue(() => undefined);
+    // allocateJoinCode probes for code collisions; return empty so the
+    // first generated code wins.
+    mockGetDocs.mockResolvedValue({ docs: [], empty: true });
+    batchSet.mockReset();
+    batchUpdate.mockReset();
+    batchCommit.mockReset().mockResolvedValue(undefined);
+    mockWriteBatch.mockReturnValue({
+      set: batchSet,
+      update: batchUpdate,
+      commit: batchCommit,
+    });
+  });
+
+  function findAssignmentSet(): Record<string, unknown> {
+    const call = batchSet.mock.calls.find(
+      ([ref]) =>
+        typeof ref === 'string' &&
+        ref.startsWith(`users/${TEACHER_UID}/quiz_assignments/`)
+    );
+    if (!call) throw new Error('expected batch.set on assignment doc');
+    return call[1] as Record<string, unknown>;
+  }
+
+  it('clears originator-scoped PLC fields (plcMode, plcSheetUrl, plcMemberEmails) so the importer is not bound to the originator’s PLC', async () => {
+    const sharedDoc: Partial<SharedQuizAssignment> = {
+      title: 'Quiz Title',
+      questions: [],
+      createdAt: 1000,
+      updatedAt: 1000,
+      assignmentSettings: {
+        sessionMode: 'teacher',
+        sessionOptions: {},
+        plcMode: true,
+        plcSheetUrl:
+          'https://docs.google.com/spreadsheets/d/originator-sheet-id',
+        plcMemberEmails: ['origA@example.com', 'origB@example.com'],
+        teacherName: 'Originator Teacher',
+        periodNames: ['Period 1'],
+      },
+      originalAuthor: 'originator-uid',
+      sharedAt: 1000,
+    };
+    mockGetDoc.mockResolvedValueOnce({
+      exists: () => true,
+      data: () => sharedDoc,
+    });
+
+    const saveQuiz = vi.fn().mockResolvedValue({
+      id: 'importer-quiz-id',
+      driveFileId: 'importer-drive-id',
+    });
+
+    const { result } = renderHook(() => useQuizAssignments(TEACHER_UID));
+    await act(async () => {
+      await result.current.importSharedAssignment('share-id', saveQuiz);
+    });
+
+    const assignment = findAssignmentSet();
+    expect(assignment.plcMode).toBeUndefined();
+    expect(assignment.plcSheetUrl).toBeUndefined();
+    expect(assignment.plcMemberEmails).toBeUndefined();
+    // teacherName / periodNames are also originator-scoped and must clear:
+    expect(assignment.teacherName).toBeUndefined();
+    expect(assignment.periodNames).toBeUndefined();
+    // The teacherUid on the assignment must be the importer, not the originator:
+    expect(assignment.teacherUid).toBe(TEACHER_UID);
+  });
+});
+
+describe('useQuizAssignments - setAssignmentRosters', () => {
+  const batchUpdate = vi.fn();
+  const batchCommit = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDoc.mockImplementation((_db: unknown, ...segs: string[]) =>
+      segs.join('/')
+    );
+    mockCollection.mockReturnValue('coll-ref');
+    mockOnSnapshot.mockReturnValue(() => undefined);
+    batchUpdate.mockReset();
+    batchCommit.mockReset().mockResolvedValue(undefined);
+    mockWriteBatch.mockReturnValue({
+      update: batchUpdate,
+      commit: batchCommit,
+    });
+  });
+
+  it('mirrors targets to BOTH the assignment doc and the session doc so the student class-gate stays in sync', async () => {
+    const { result } = renderHook(() => useQuizAssignments(TEACHER_UID));
+
+    await act(async () => {
+      await result.current.setAssignmentRosters(ASSIGNMENT_ID, {
+        rosterIds: ['roster-1', 'roster-2'],
+        classIds: ['cl-class-A'],
+        periodNames: ['Period 1', 'Period 2'],
+      });
+    });
+
+    const assignmentCall = batchUpdate.mock.calls.find(
+      ([ref]) =>
+        typeof ref === 'string' &&
+        ref.startsWith(`users/${TEACHER_UID}/quiz_assignments/`)
+    );
+    if (!assignmentCall)
+      throw new Error('expected batch.update on assignment doc');
+    expect(assignmentCall[1]).toMatchObject({
+      rosterIds: ['roster-1', 'roster-2'],
+      periodNames: ['Period 1', 'Period 2'],
+      periodName: 'Period 1',
+    });
+
+    const sessionCall = batchUpdate.mock.calls.find(
+      ([ref]) => typeof ref === 'string' && ref.startsWith('quiz_sessions/')
+    );
+    if (!sessionCall) throw new Error('expected batch.update on session doc');
+    expect(sessionCall[1]).toMatchObject({
+      rosterIds: ['roster-1', 'roster-2'],
+      classIds: ['cl-class-A'],
+      classId: 'cl-class-A',
+      periodNames: ['Period 1', 'Period 2'],
+    });
+
+    expect(batchCommit).toHaveBeenCalledTimes(1);
   });
 });

--- a/utils/resolveAssignmentTargets.ts
+++ b/utils/resolveAssignmentTargets.ts
@@ -51,6 +51,19 @@ export interface ResolvedAssignmentTargets {
 }
 
 /**
+ * Triple of targeting fields that flow together onto an assignment +
+ * session doc. Always derived as a unit by `deriveSessionTargetsFromRosters`
+ * — the three arrays are not independent inputs even though they ride
+ * separate Firestore fields. Use this type wherever a function takes or
+ * produces these three fields together so callers can't accidentally pass
+ * a hand-rolled triple that violates the joint-derivation invariant.
+ */
+export type SessionTargets = Pick<
+  ResolvedAssignmentTargets,
+  'rosterIds' | 'classIds' | 'periodNames'
+>;
+
+/**
  * Core "rosters → session shape" derivation shared by
  * `resolveAssignmentTargets` (lookup-then-derive) and
  * `deriveSessionTargetsFromRosters` (already-resolved rosters). Centralizing


### PR DESCRIPTION
## Summary

Three connected fixes for the PLC shared-assignment flow:

- **Class-selector prompt on import.** Pasting a `share/assignment/<id>` URL now opens a focused **Set up imported assignment** modal so the teacher picks rosters/periods immediately, instead of leaving the imported assignment paused with no targeting. Reuses `AssignClassPicker`. Includes Skip and *Edit all settings…* (which routes to the existing full settings modal). Adds a new `setAssignmentRosters` API on `useQuizAssignments` that writes `rosterIds`/`classIds`/`periodNames` to both the assignment and session docs — `updateAssignmentSettings` didn't touch those fields, so retargeting after creation wasn't possible before.

- **Sheet URL is hidden by default.** The "Shared Google Sheet URL" field in both [QuizManager](components/widgets/QuizWidget/components/QuizManager.tsx:1604) (create flow) and [QuizAssignmentSettingsModal](components/widgets/QuizWidget/components/QuizAssignmentSettingsModal.tsx:368) (settings) is now collapsed behind a **Manually attach a sheet URL** disclosure. SpartBoard auto-creates and shares the sheet for PLC members; the field is only there for the rare manual-override case. Pre-expanded when a URL is already attached so legacy assignments aren't surprised.

- **Permission-error fix on import.** `importSharedAssignment` now also clears `plcMode`, `plcSheetUrl`, and `plcMemberEmails`. These were originator-scoped and caused silent Drive 403s (importer isn't the sheet owner) plus Firestore permission-denied on `plcs/{originatorPlcId}` because the importer isn't in that PLC's `memberUids`. Surfaces the doc path + Firestore error code on the previously bare `[useQuizSessionTeacher]` listener logs so any remaining denial is diagnosable instead of silent.

## Test plan

Unit tests:
- [x] `pnpm run test` — 1500 tests pass, including 2 new tests asserting the import field-clearing and `setAssignmentRosters` writing both docs.
- [x] `pnpm run type-check` clean.
- [x] `pnpm run lint` (`--max-warnings 0`) clean.
- [x] `pnpm run format:check` clean.

Manual on the dev preview URL once the deploy lands:
- [ ] Quiz widget → New Assignment → toggle PLC mode → confirm URL field is collapsed behind "Manually attach a sheet URL". Click; field appears. Type non-Google URL → existing validation warning appears. Click Hide → field clears.
- [ ] Open settings on an existing PLC assignment with no URL set → same disclosure behavior. Open one that already has a `plcSheetUrl` → field is pre-expanded.
- [ ] Auto-create still works: new PLC assignment with field collapsed and PLC selected → Drive sheet created, `assignment.plcSheetUrl` populated.
- [ ] Manual override still works: paste a valid Google Sheets URL → auto-create skipped (`resolvedPlcSheetUrl` truthy in [Widget.tsx:755](components/widgets/QuizWidget/Widget.tsx:755)).
- [ ] From a second account, share → paste on the importer's board: Quiz widget opens to Active tab, "Set up imported assignment" appears, picking rosters → Save persists `rosterIds`/`periodNames` and the session doc updates so students can join. *Edit all settings* swaps to the full settings modal. *Skip for now* leaves the assignment paused with no rosters.
- [ ] Imported assignment's settings show URL collapsed (originator's URL not carried over) and PLC mode OFF.
- [ ] Browser devtools open during the full Teacher A → Teacher B flow: no `[useQuizSessionTeacher]` permission-denied errors. Students join end-to-end without permission errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)