### PR TITLE
fix(quiz): swallow uncaught PIN-collision rejection in student join

### DIFF
--- a/components/quiz/QuizStudentApp.tsx
+++ b/components/quiz/QuizStudentApp.tsx
@@ -146,17 +146,28 @@ const QuizJoinFlow: React.FC<{ isStudentRole: boolean }> = ({
 
   const handleJoin = useCallback(
     async (joinCode: string, joinPin: string) => {
-      // Look up the session to check for multi-period selection
-      const sessionInfo = await lookupSession(joinCode);
-      if (sessionInfo && sessionInfo.periodNames.length > 1) {
-        // Show period selector step
-        setPeriodStep(sessionInfo.periodNames);
-        return;
+      // Look up the session to check for multi-period selection. Failures
+      // here (network blip, transient permission-denied from a stale doc)
+      // are surfaced to the form via the hook's `error` state — we still
+      // need to swallow the rejection locally so the form's `void
+      // handleJoin(...)` doesn't escape into an unhandled promise.
+      try {
+        const sessionInfo = await lookupSession(joinCode);
+        if (sessionInfo && sessionInfo.periodNames.length > 1) {
+          setPeriodStep(sessionInfo.periodNames);
+          return;
+        }
+        const autoClassPeriod = sessionInfo?.periodNames[0];
+        await joinQuizSession(joinCode, joinPin, autoClassPeriod);
+        setJoined(true);
+      } catch (err) {
+        // joinQuizSession already calls setError before re-throwing, so the
+        // user sees the friendly message rendered above the form. This
+        // catch exists purely to keep the rejection from bubbling into the
+        // global unhandled-rejection handler (the form's onSubmit uses
+        // `void handleJoin(...)`).
+        console.warn('[QuizStudentApp] join failed:', err);
       }
-      // Single or no period — join directly (auto-select if exactly 1)
-      const autoClassPeriod = sessionInfo?.periodNames[0];
-      await joinQuizSession(joinCode, joinPin, autoClassPeriod);
-      setJoined(true);
     },
     [lookupSession, joinQuizSession]
   );
@@ -166,8 +177,15 @@ const QuizJoinFlow: React.FC<{ isStudentRole: boolean }> = ({
     // SSO joiners pass `undefined` as the PIN — the hook keys the response
     // doc by auth.uid in that case. Anonymous joiners send the form `pin`.
     const joinPin = isStudentRole ? undefined : pin;
-    await joinQuizSession(code, joinPin, selectedPeriod);
-    setJoined(true);
+    try {
+      await joinQuizSession(code, joinPin, selectedPeriod);
+      setJoined(true);
+    } catch (err) {
+      // Same rationale as handleJoin — keep `void handlePeriodConfirm()`
+      // from leaking an unhandled rejection. UI error state is already
+      // populated by the hook.
+      console.warn('[QuizStudentApp] period confirm failed:', err);
+    }
   }, [joinQuizSession, code, pin, selectedPeriod, isStudentRole]);
 
   // SSO auto-join: bypass the PIN form entirely. lookupSession handles the

--- a/hooks/useQuizSession.ts
+++ b/hooks/useQuizSession.ts
@@ -199,21 +199,56 @@ export function getResponseDocKey(response: QuizResponse): string {
  * Returns the resolved key and the snapshot (existent or not) so the caller
  * can branch on `snap.exists()` without re-fetching.
  */
+/**
+ * Thrown when an anonymous student's deterministic response key collides
+ * with an existing doc owned by a different anon UID — i.e. another student
+ * (or this same student from a different device whose anon UID has rotated)
+ * has already claimed this PIN+period slot. The Firestore read rule rejects
+ * the cross-uid read with `permission-denied`; we map that to a friendly
+ * "PIN already in use" message rather than letting the raw FirebaseError
+ * surface as a generic "Missing or insufficient permissions" toast.
+ */
+export class PinAlreadyInUseError extends Error {
+  constructor() {
+    super(
+      'That PIN is already in use on this quiz. Double-check your PIN with your teacher, or ask them to clear your previous attempt.'
+    );
+    this.name = 'PinAlreadyInUseError';
+  }
+}
+
 async function findExistingResponseDoc(
   sessionId: string,
   authUid: string,
   isAnonymous: boolean,
   deterministicKey: string
 ): Promise<{ key: string; snap: DocumentSnapshot }> {
-  const deterministicSnap = await getDoc(
-    doc(
-      db,
-      QUIZ_SESSIONS_COLLECTION,
-      sessionId,
-      RESPONSES_COLLECTION,
-      deterministicKey
-    )
-  );
+  let deterministicSnap: DocumentSnapshot;
+  try {
+    deterministicSnap = await getDoc(
+      doc(
+        db,
+        QUIZ_SESSIONS_COLLECTION,
+        sessionId,
+        RESPONSES_COLLECTION,
+        deterministicKey
+      )
+    );
+  } catch (err) {
+    // The response read rule rejects cross-uid reads of an existing doc:
+    // it allows `resource == null` (doc absent) or
+    // `request.auth.uid == resource.data.studentUid` (it's ours), and
+    // denies anything else. So a permission-denied here means the slot
+    // exists but is owned by a different uid — typically a PIN collision
+    // between two anonymous students. Surface that as a friendly,
+    // recoverable error rather than the raw FirebaseError. Any other code
+    // (network failure, rules deployment mismatch) keeps bubbling.
+    const code = (err as { code?: unknown }).code;
+    if (isAnonymous && code === 'permission-denied') {
+      throw new PinAlreadyInUseError();
+    }
+    throw err;
+  }
   if (deterministicSnap.exists()) {
     return { key: deterministicKey, snap: deterministicSnap };
   }

--- a/hooks/useQuizSession.ts
+++ b/hooks/useQuizSession.ts
@@ -193,13 +193,6 @@ export function getResponseDocKey(response: QuizResponse): string {
 }
 
 /**
- * Look up the student's response doc for a session, trying the deterministic
- * key first and falling back to the legacy auth-uid key for anonymous PIN
- * joiners whose in-progress doc was written under the old keying scheme.
- * Returns the resolved key and the snapshot (existent or not) so the caller
- * can branch on `snap.exists()` without re-fetching.
- */
-/**
  * Thrown when an anonymous student's deterministic response key collides
  * with an existing doc owned by a different anon UID — i.e. another student
  * (or this same student from a different device whose anon UID has rotated)
@@ -217,6 +210,13 @@ export class PinAlreadyInUseError extends Error {
   }
 }
 
+/**
+ * Look up the student's response doc for a session, trying the deterministic
+ * key first and falling back to the legacy auth-uid key for anonymous PIN
+ * joiners whose in-progress doc was written under the old keying scheme.
+ * Returns the resolved key and the snapshot (existent or not) so the caller
+ * can branch on `snap.exists()` without re-fetching.
+ */
 async function findExistingResponseDoc(
   sessionId: string,
   authUid: string,
@@ -744,12 +744,27 @@ export const useQuizSessionStudent = (): UseQuizSessionStudentResult => {
         .replace(/[^a-zA-Z0-9]/g, '')
         .toUpperCase();
       if (!normCode) return null;
-      const snap = await getDocs(
-        query(
-          collection(db, QUIZ_SESSIONS_COLLECTION),
-          where('code', '==', normCode)
-        )
-      );
+      // Mirror joinQuizSession's error-state contract: surface Firestore
+      // failures via `setError` before re-throwing so the form can render
+      // the friendly banner. Without this the form's catch only console.warns
+      // a lookupSession failure (it has no local error state) and the
+      // student stares at an unchanged form with no feedback.
+      let snap;
+      try {
+        snap = await getDocs(
+          query(
+            collection(db, QUIZ_SESSIONS_COLLECTION),
+            where('code', '==', normCode)
+          )
+        );
+      } catch (err) {
+        const msg =
+          err instanceof Error
+            ? err.message
+            : 'Could not look up the quiz. Please try again.';
+        setError(msg);
+        throw err;
+      }
       if (snap.empty) return null;
       const joinable = snap.docs.filter((d) => {
         const s = (d.data() as QuizSession).status;

--- a/tests/hooks/useQuizSession.test.ts
+++ b/tests/hooks/useQuizSession.test.ts
@@ -7,6 +7,7 @@ import {
   toPublicQuestion,
   useQuizSessionStudent,
   useQuizSessionTeacher,
+  PinAlreadyInUseError,
 } from '@/hooks/useQuizSession';
 import { auth } from '@/config/firebase';
 import type {
@@ -504,6 +505,49 @@ describe('useQuizSessionStudent — joinQuizSession', () => {
     };
     expect(writtenResponse.studentUid).toBe('new-anon-uid');
     expect(writtenResponse.status).toBe('joined');
+  });
+
+  // Regression: PIN collision between two anonymous students sharing the
+  // same PIN+period within a session. The first student claims the
+  // deterministic key `pin-{period}-{pin}`; the second student's
+  // joinQuizSession reads that same key, but Firestore rules reject the
+  // cross-uid read (the doc's studentUid is the first student's auth.uid)
+  // with permission-denied. The hook must surface a friendly
+  // PinAlreadyInUseError instead of letting the raw FirebaseError bubble
+  // up as a generic "Missing or insufficient permissions" toast.
+  it('surfaces PinAlreadyInUseError when the deterministic-key getDoc is permission-denied for an anon joiner', async () => {
+    (
+      auth as unknown as {
+        currentUser: { uid: string; isAnonymous: boolean } | null;
+      }
+    ).currentUser = {
+      uid: 'second-anon-uid',
+      isAnonymous: true,
+    };
+
+    (
+      firestore.getDocs as unknown as ReturnType<typeof vi.fn>
+    ).mockResolvedValueOnce({
+      empty: false,
+      docs: [buildSessionDoc('s1', { status: 'active' })],
+    });
+
+    const getDocMock = firestore.getDoc as unknown as ReturnType<typeof vi.fn>;
+    // Deterministic key probe — the doc exists but it's owned by a
+    // different anon uid (first student with same PIN), so the read rule
+    // rejects the cross-uid read.
+    const permissionDenied = Object.assign(
+      new Error('Missing or insufficient permissions.'),
+      { code: 'permission-denied' }
+    );
+    getDocMock.mockRejectedValueOnce(permissionDenied);
+
+    const { result } = renderHook(() => useQuizSessionStudent());
+    await act(async () => {
+      await expect(
+        result.current.joinQuizSession('ABC123', '1234')
+      ).rejects.toBeInstanceOf(PinAlreadyInUseError);
+    });
   });
 
   // Guard the blast radius of the above catch: only permission-denied is


### PR DESCRIPTION
## Summary

Two related fixes for the `Uncaught (in promise) FirebaseError: Missing or insufficient permissions` error students see in the console when entering a PIN to join a quiz session (reported in the PLC-share-with-Teacher-B → student-PIN-join flow).

### 1. PIN form discards its rejection

`QuizStudentApp.tsx`'s PIN form `onSubmit` and the period-picker's Continue button call `void handleJoin(...)` / `void handlePeriodConfirm()`. The `joinQuizSession` hook re-throws after populating `setError` (which renders the friendly red banner above the form) — but the discarded rejection escapes into the global unhandled-rejection handler and surfaces as a console error.

Fix: `handleJoin` / `handlePeriodConfirm` now wrap the await in try/catch and log+swallow. The visible UI banner is unchanged (still driven by `setError` on the hook), but the FirebaseError no longer leaks to the console.

### 2. PIN-collision permission-denied is unguarded

`findExistingResponseDoc`'s deterministic-key `getDoc` was unguarded. When two anonymous students share the same PIN+period on a session (e.g. PIN collision across students from the same imported PLC roster, or an anon UID rotation between sessions on the same device), the first student's response doc sits at `pin-{period}-{pin}` with their `auth.uid` stamped into `studentUid`. The second student's read of that same doc is rejected by the response-read rule with `permission-denied`.

The legacy auth-uid-keyed probe already handled this case (catches `permission-denied` → treats as "no legacy doc"); the deterministic-key probe now does the analogous thing: maps a `permission-denied` for an anonymous joiner into a new `PinAlreadyInUseError` whose message tells the student to double-check their PIN with their teacher. The hook surfaces this via `setError` and the form re-renders the friendly banner.

## Test plan

- [x] `pnpm vitest run tests/hooks/useQuizSession.test.ts` — 44 passed (1 new test for the deterministic-key permission-denied → `PinAlreadyInUseError` mapping)
- [x] `pnpm run type-check` — clean
- [x] `pnpm run lint` — clean
- [x] `pnpm run format:check` — clean
- [ ] Manual: Teacher A creates PLC quiz, shares with Teacher B; Teacher B's student enters PIN and confirms (a) no console FirebaseError, (b) friendly banner if PIN collides

https://claude.ai/code/session_01N2PSny933DdCMTTHfhhAUA

---
_Generated by [Claude Code](https://claude.ai/code/session_01N2PSny933DdCMTTHfhhAUA)_