### PR TITLE
fix(quiz): silence anon PIN-join permission-denied + always require period for anon

### DIFF
--- a/components/quiz/QuizStudentApp.tsx
+++ b/components/quiz/QuizStudentApp.tsx
@@ -167,12 +167,13 @@ const QuizJoinFlow: React.FC<{ isStudentRole: boolean }> = ({
 
   const handlePeriodConfirm = useCallback(async () => {
     if (!selectedPeriod) return;
-    // SSO joiners pass `undefined` as the PIN — the hook keys the response
-    // doc by auth.uid in that case. Anonymous joiners send the form `pin`.
-    const joinPin = isStudentRole ? undefined : pin;
-    await joinQuizSession(code, joinPin, selectedPeriod);
+    // Only anonymous joiners reach the period picker (SSO students auto-join
+    // via the effect below and skip period selection entirely), so PIN is
+    // always populated here. The hook keys their response doc by
+    // `pin-{period}-{pin}`.
+    await joinQuizSession(code, pin, selectedPeriod);
     setJoined(true);
-  }, [joinQuizSession, code, pin, selectedPeriod, isStudentRole]);
+  }, [joinQuizSession, code, pin, selectedPeriod]);
 
   // SSO auto-join: bypass the PIN form AND the period picker entirely. SSO
   // students arrive with a stable identity (auth.uid via /student/login),

--- a/components/quiz/QuizStudentApp.tsx
+++ b/components/quiz/QuizStudentApp.tsx
@@ -116,8 +116,9 @@ const QuizJoinFlow: React.FC<{ isStudentRole: boolean }> = ({
   const [pin, setPin] = useState('');
   const [joined, setJoined] = useState(false);
 
-  // Multi-period selection step: after entering code+PIN, if the session has
-  // multiple periodNames the student picks their class before joining.
+  // Period selection step: after entering code+PIN, anon students always pick
+  // their class period before joining (PIN+period is the disambiguator on the
+  // response doc key). SSO joiners skip this step entirely.
   const [periodStep, setPeriodStep] = useState<string[] | null>(null);
   const [selectedPeriod, setSelectedPeriod] = useState<string | null>(null);
 
@@ -146,16 +147,19 @@ const QuizJoinFlow: React.FC<{ isStudentRole: boolean }> = ({
 
   const handleJoin = useCallback(
     async (joinCode: string, joinPin: string) => {
-      // Look up the session to check for multi-period selection
+      // Anon (PIN) joiners must always disambiguate by period — same PIN can
+      // recur across periods, and `pin-{period}-{pin}` is what keys the
+      // response doc. Show the picker whenever the assignment declares any
+      // periods, even when there is only one. (handleJoin is only reached on
+      // the anon path; the SSO auto-join effect short-circuits before render.)
       const sessionInfo = await lookupSession(joinCode);
-      if (sessionInfo && sessionInfo.periodNames.length > 1) {
-        // Show period selector step
-        setPeriodStep(sessionInfo.periodNames);
+      const periods = sessionInfo?.periodNames ?? [];
+      if (periods.length > 0) {
+        setPeriodStep(periods);
         return;
       }
-      // Single or no period — join directly (auto-select if exactly 1)
-      const autoClassPeriod = sessionInfo?.periodNames[0];
-      await joinQuizSession(joinCode, joinPin, autoClassPeriod);
+      // No periods configured — join with classPeriod undefined.
+      await joinQuizSession(joinCode, joinPin, undefined);
       setJoined(true);
     },
     [lookupSession, joinQuizSession]
@@ -170,32 +174,28 @@ const QuizJoinFlow: React.FC<{ isStudentRole: boolean }> = ({
     setJoined(true);
   }, [joinQuizSession, code, pin, selectedPeriod, isStudentRole]);
 
-  // SSO auto-join: bypass the PIN form entirely. lookupSession handles the
-  // multi-period branch (we still show the picker — periodNames are
-  // free-form labels and don't map 1:1 onto classIds, so we can't auto-pick).
+  // SSO auto-join: bypass the PIN form AND the period picker entirely. SSO
+  // students arrive with a stable identity (auth.uid via /student/login),
+  // already matched to their class via classId — so the response doc is
+  // keyed by auth.uid and classPeriod is irrelevant for join. The teacher
+  // monitor view can resolve a student's period from their classId via the
+  // roster if it needs to group by period.
   useEffect(() => {
     if (!isStudentRole) return;
     if (!urlCode) return;
-    if (joined || periodStep) return;
+    if (joined) return;
     if (ssoAutoJoinStartedRef.current) return;
     ssoAutoJoinStartedRef.current = true;
 
     const run = async () => {
       try {
-        const sessionInfo = await lookupSession(urlCode);
-        if (sessionInfo && sessionInfo.periodNames.length > 1) {
-          setPeriodStep(sessionInfo.periodNames);
-          return;
-        }
-        const autoClassPeriod = sessionInfo?.periodNames[0];
-        await joinQuizSession(urlCode, undefined, autoClassPeriod);
+        await joinQuizSession(urlCode, undefined, undefined);
         setJoined(true);
       } catch (err) {
         console.warn('[QuizStudentApp] SSO auto-join failed:', err);
-        // Surface the failure to the UI. Either step (lookupSession or
-        // joinQuizSession) can throw; if it was joinQuizSession the hook's
-        // own `error` state will also be populated, and the render branch
-        // below prefers that more detailed message when available.
+        // Surface the failure to the UI. The hook's own `error` state will
+        // also be populated, and the render branch below prefers that more
+        // detailed message when available.
         const message =
           err instanceof Error
             ? err.message
@@ -206,14 +206,7 @@ const QuizJoinFlow: React.FC<{ isStudentRole: boolean }> = ({
       }
     };
     void run();
-  }, [
-    isStudentRole,
-    urlCode,
-    joined,
-    periodStep,
-    lookupSession,
-    joinQuizSession,
-  ]);
+  }, [isStudentRole, urlCode, joined, joinQuizSession]);
 
   const handleAnswer = useCallback(
     async (questionId: string, answer: string, speedBonus?: number) => {
@@ -232,7 +225,8 @@ const QuizJoinFlow: React.FC<{ isStudentRole: boolean }> = ({
   // (If you want URL-based pin support: ?code=XXXXXX&pin=01 is an option for
   // future work, but not implemented here to avoid leaking PINs in URL logs.)
 
-  // Period selection step — shown when session has multiple class periods
+  // Period selection step — shown to anon joiners when the session declares
+  // any class periods. SSO joiners skip this and join via the auto-join effect.
   if (periodStep && !joined) {
     return (
       <div className="min-h-screen bg-slate-900 flex flex-col items-center justify-center p-6">
@@ -275,7 +269,15 @@ const QuizJoinFlow: React.FC<{ isStudentRole: boolean }> = ({
           </div>
 
           <button
-            onClick={() => void handlePeriodConfirm()}
+            onClick={() => {
+              // joinQuizSession re-throws after populating `error` state for
+              // the UI. Catch here so the rejection isn't an unhandled
+              // promise — `void` would only silence the linter, not handle
+              // the rejection.
+              handlePeriodConfirm().catch((err: unknown) => {
+                console.warn('[QuizStudentApp] Period confirm failed:', err);
+              });
+            }}
             disabled={loading || !selectedPeriod}
             className="w-full py-4 bg-violet-600 hover:bg-violet-500 disabled:opacity-50 text-white font-bold text-lg rounded-xl flex items-center justify-center gap-2 transition-colors"
           >
@@ -353,7 +355,13 @@ const QuizJoinFlow: React.FC<{ isStudentRole: boolean }> = ({
           <form
             onSubmit={(e) => {
               e.preventDefault();
-              void handleJoin(code, pin);
+              // joinQuizSession re-throws after populating `error` state for
+              // the UI. Catch here so the rejection isn't an unhandled
+              // promise — `void` would only silence the linter, not handle
+              // the rejection.
+              handleJoin(code, pin).catch((err: unknown) => {
+                console.warn('[QuizStudentApp] Join failed:', err);
+              });
             }}
             className="space-y-4"
           >

--- a/hooks/useQuizSession.ts
+++ b/hooks/useQuizSession.ts
@@ -204,17 +204,32 @@ async function findExistingResponseDoc(
   authUid: string,
   isAnonymous: boolean,
   deterministicKey: string
-): Promise<{ key: string; snap: DocumentSnapshot }> {
-  const deterministicSnap = await getDoc(
-    doc(
-      db,
-      QUIZ_SESSIONS_COLLECTION,
-      sessionId,
-      RESPONSES_COLLECTION,
-      deterministicKey
-    )
-  );
-  if (deterministicSnap.exists()) {
+): Promise<{ key: string; snap: DocumentSnapshot | null }> {
+  // Probe the deterministic key. If a doc exists at this key but was written
+  // by a different anon UID — either a real PIN collision (two students
+  // sharing pin+period) or the same student rejoining from a fresh browser
+  // session — the response read rule denies because
+  // `request.auth.uid != resource.data.studentUid`. Treat that as
+  // "doc inaccessible from here" so the caller can fall through to the
+  // legacy probe / setDoc path; if the underlying collision is real, the
+  // subsequent setDoc/updateDoc rule denial surfaces a coherent error
+  // through joinQuizSession's outer catch instead of an unhandled rejection.
+  let deterministicSnap: DocumentSnapshot | null = null;
+  try {
+    deterministicSnap = await getDoc(
+      doc(
+        db,
+        QUIZ_SESSIONS_COLLECTION,
+        sessionId,
+        RESPONSES_COLLECTION,
+        deterministicKey
+      )
+    );
+  } catch (err) {
+    const code = (err as { code?: unknown }).code;
+    if (code !== 'permission-denied') throw err;
+  }
+  if (deterministicSnap?.exists()) {
     return { key: deterministicKey, snap: deterministicSnap };
   }
   if (isAnonymous && deterministicKey !== authUid) {
@@ -852,7 +867,7 @@ export const useQuizSessionStudent = (): UseQuizSessionStudentResult => {
         //     preserving `completedAttempts` to enforce the cap on future
         //     submissions.
         const limit = sessionData.attemptLimit ?? null;
-        if (existingSnap.exists()) {
+        if (existingSnap?.exists()) {
           const existing = existingSnap.data() as QuizResponse;
           if (existing.status === 'completed') {
             const completed = existing.completedAttempts ?? 1;
@@ -880,7 +895,7 @@ export const useQuizSessionStudent = (): UseQuizSessionStudentResult => {
         setSessionIdState(sessionDoc.id);
         setResponseKeyState(responseKey);
 
-        if (!existingSnap.exists()) {
+        if (!existingSnap?.exists()) {
           // No PII stored. `studentUid` field carries the auth uid; the doc
           // key may differ (for PIN auth it's pin-based), so Firestore rules
           // enforce ownership against the field, not the key. The `pin`

--- a/hooks/useQuizSession.ts
+++ b/hooks/useQuizSession.ts
@@ -192,6 +192,15 @@ export function getResponseDocKey(response: QuizResponse): string {
   return response._responseKey ?? response.studentUid;
 }
 
+// Safe extraction of FirestoreError.code (or any error-like object's `code`
+// field). Returns undefined when err isn't an object or has no string `code`,
+// so callers don't blow up on non-Error throws or stringly-typed values.
+function getErrorCode(err: unknown): string | undefined {
+  if (typeof err !== 'object' || err === null) return undefined;
+  const code = (err as { code?: unknown }).code;
+  return typeof code === 'string' ? code : undefined;
+}
+
 /**
  * Look up the student's response doc for a session, trying the deterministic
  * key first and falling back to the legacy auth-uid key for anonymous PIN
@@ -205,15 +214,22 @@ async function findExistingResponseDoc(
   isAnonymous: boolean,
   deterministicKey: string
 ): Promise<{ key: string; snap: DocumentSnapshot | null }> {
-  // Probe the deterministic key. If a doc exists at this key but was written
-  // by a different anon UID — either a real PIN collision (two students
-  // sharing pin+period) or the same student rejoining from a fresh browser
-  // session — the response read rule denies because
-  // `request.auth.uid != resource.data.studentUid`. Treat that as
-  // "doc inaccessible from here" so the caller can fall through to the
-  // legacy probe / setDoc path; if the underlying collision is real, the
-  // subsequent setDoc/updateDoc rule denial surfaces a coherent error
-  // through joinQuizSession's outer catch instead of an unhandled rejection.
+  // Probe the deterministic key. For anonymous joiners, `permission-denied`
+  // here means a doc exists at this key but was written by a different anon
+  // UID — either a real PIN collision (two students sharing pin+period) or
+  // the same student rejoining from a fresh browser session. The response
+  // read rule denies because `request.auth.uid != resource.data.studentUid`.
+  // Treat that as "doc inaccessible from here" so the caller falls through
+  // to the legacy probe / setDoc path; the rule denial on the subsequent
+  // setDoc/updateDoc surfaces a coherent UI error via joinQuizSession's
+  // outer catch instead of an unhandled rejection.
+  //
+  // For SSO/studentRole users, `permission-denied` is a legitimate
+  // class-gate denial (and `deterministicKey === authUid`, so the legacy
+  // probe wouldn't run anyway) — let it propagate so the join fails fast
+  // instead of attempting a doomed write. The breadcrumb log catches
+  // anything else permission-denied could mask (App Check misconfig,
+  // emulator vs prod rules drift) on the anon path.
   let deterministicSnap: DocumentSnapshot | null = null;
   try {
     deterministicSnap = await getDoc(
@@ -226,8 +242,11 @@ async function findExistingResponseDoc(
       )
     );
   } catch (err) {
-    const code = (err as { code?: unknown }).code;
-    if (code !== 'permission-denied') throw err;
+    if (!isAnonymous || getErrorCode(err) !== 'permission-denied') throw err;
+    console.warn(
+      '[useQuizSession] permission-denied on deterministic response probe; falling through to legacy/create path.',
+      { sessionId, deterministicKey, err }
+    );
   }
   if (deterministicSnap?.exists()) {
     return { key: deterministicKey, snap: deterministicSnap };
@@ -253,8 +272,11 @@ async function findExistingResponseDoc(
         return { key: authUid, snap: legacySnap };
       }
     } catch (err) {
-      const code = (err as { code?: unknown }).code;
-      if (code !== 'permission-denied') throw err;
+      if (getErrorCode(err) !== 'permission-denied') throw err;
+      console.warn(
+        '[useQuizSession] permission-denied on legacy response probe; treating as no doc.',
+        { sessionId, authUid, err }
+      );
     }
   }
   return { key: deterministicKey, snap: deterministicSnap };
@@ -719,34 +741,48 @@ export const useQuizSessionStudent = (): UseQuizSessionStudentResult => {
 
   const lookupSession = useCallback(
     async (code: string): Promise<{ periodNames: string[] } | null> => {
-      const normCode = code
-        .trim()
-        .replace(/[^a-zA-Z0-9]/g, '')
-        .toUpperCase();
-      if (!normCode) return null;
-      const snap = await getDocs(
-        query(
-          collection(db, QUIZ_SESSIONS_COLLECTION),
-          where('code', '==', normCode)
-        )
-      );
-      if (snap.empty) return null;
-      const joinable = snap.docs.filter((d) => {
-        const s = (d.data() as QuizSession).status;
-        return s === 'waiting' || s === 'active' || s === 'paused';
-      });
-      if (joinable.length === 0) return null;
-      // Match joinQuizSession's selection: prefer the most recently created.
-      joinable.sort((a, b) => {
-        const at = (a.data() as QuizSession).startedAt ?? 0;
-        const bt = (b.data() as QuizSession).startedAt ?? 0;
-        return bt - at;
-      });
-      const sessionData = joinable[0].data() as QuizSession;
-      // resolvePeriodNames normalises legacy periodName + new periodNames
-      // into a typed string[], avoiding the `any[]` from Firestore's
-      // DocumentData bleed-through.
-      return { periodNames: resolvePeriodNames(sessionData) };
+      // Populate the hook's `error` state on failure so callers' .catch
+      // handlers (which only console.warn) still produce visible UI feedback.
+      // Without this a network/Firestore failure during code lookup silently
+      // strands the student on the join form with no spinner and no error.
+      try {
+        const normCode = code
+          .trim()
+          .replace(/[^a-zA-Z0-9]/g, '')
+          .toUpperCase();
+        if (!normCode) return null;
+        setError(null);
+        const snap = await getDocs(
+          query(
+            collection(db, QUIZ_SESSIONS_COLLECTION),
+            where('code', '==', normCode)
+          )
+        );
+        if (snap.empty) return null;
+        const joinable = snap.docs.filter((d) => {
+          const s = (d.data() as QuizSession).status;
+          return s === 'waiting' || s === 'active' || s === 'paused';
+        });
+        if (joinable.length === 0) return null;
+        // Match joinQuizSession's selection: prefer the most recently created.
+        joinable.sort((a, b) => {
+          const at = (a.data() as QuizSession).startedAt ?? 0;
+          const bt = (b.data() as QuizSession).startedAt ?? 0;
+          return bt - at;
+        });
+        const sessionData = joinable[0].data() as QuizSession;
+        // resolvePeriodNames normalises legacy periodName + new periodNames
+        // into a typed string[], avoiding the `any[]` from Firestore's
+        // DocumentData bleed-through.
+        return { periodNames: resolvePeriodNames(sessionData) };
+      } catch (err) {
+        const msg =
+          err instanceof Error
+            ? err.message
+            : 'Could not look up quiz. Please check the code and try again.';
+        setError(msg);
+        throw err;
+      }
     },
     []
   );

--- a/tests/hooks/useQuizSession.test.ts
+++ b/tests/hooks/useQuizSession.test.ts
@@ -449,6 +449,126 @@ describe('useQuizSessionStudent — joinQuizSession', () => {
     expect(updateDocMock.mock.calls[0][1]).toEqual({ classPeriod: 'Period 2' });
   });
 
+  // Regression: PR #1441. Same shape as the legacy-key permission-denied
+  // case below, but for the FIRST getDoc — the deterministic pin-based
+  // probe. A doc may already exist at `pin-{period}-{pin}` written by a
+  // different anon UID (real PIN+period collision across two students,
+  // OR same student rejoining from a fresh browser session under a rotated
+  // anon UID). The response read rule denies because
+  // `request.auth.uid != resource.data.studentUid`; the fix swallows the
+  // denial so the join falls through to the legacy probe / setDoc path.
+  // Without this, the rejection propagated as an "Uncaught (in promise)
+  // FirebaseError: Missing or insufficient permissions." in the browser.
+  it('treats permission-denied on the deterministic-key getDoc as "no doc" for anon joiners', async () => {
+    (
+      auth as unknown as {
+        currentUser: { uid: string; isAnonymous: boolean } | null;
+      }
+    ).currentUser = { uid: 'fresh-anon-uid', isAnonymous: true };
+
+    (
+      firestore.getDocs as unknown as ReturnType<typeof vi.fn>
+    ).mockResolvedValueOnce({
+      empty: false,
+      docs: [buildSessionDoc('s1', { status: 'active' })],
+    });
+
+    const getDocMock = firestore.getDoc as unknown as ReturnType<typeof vi.fn>;
+    // 1st call: deterministic pin-based key — colliding doc owned by a
+    // different (older) anon UID, so the rule rejects the read.
+    const permissionDenied = Object.assign(
+      new Error('Missing or insufficient permissions.'),
+      { code: 'permission-denied' }
+    );
+    getDocMock.mockRejectedValueOnce(permissionDenied);
+    // 2nd call: legacy authUid-keyed slot — no doc.
+    getDocMock.mockResolvedValueOnce({ exists: () => false });
+
+    const setDocMock = firestore.setDoc as unknown as ReturnType<typeof vi.fn>;
+    setDocMock.mockResolvedValueOnce(undefined);
+
+    const { result } = renderHook(() => useQuizSessionStudent());
+    let sessionId = '';
+    await act(async () => {
+      sessionId = await result.current.joinQuizSession('ABC123', '1234');
+    });
+
+    expect(sessionId).toBe('s1');
+    // Join proceeded to write a new response doc at the deterministic key;
+    // the permission-denied did NOT propagate.
+    expect(setDocMock).toHaveBeenCalledTimes(1);
+    const writtenResponse = setDocMock.mock.calls[0][1] as {
+      studentUid: string;
+      status: string;
+    };
+    expect(writtenResponse.studentUid).toBe('fresh-anon-uid');
+    expect(writtenResponse.status).toBe('joined');
+  });
+
+  // Symmetric blast-radius guard for the deterministic probe: only
+  // permission-denied is swallowed. Any other Firestore failure must still
+  // propagate so it isn't silently treated as "no doc, write a new one".
+  it('still propagates non-permission-denied errors from the deterministic-key getDoc', async () => {
+    (
+      auth as unknown as {
+        currentUser: { uid: string; isAnonymous: boolean } | null;
+      }
+    ).currentUser = { uid: 'fresh-anon-uid', isAnonymous: true };
+
+    (
+      firestore.getDocs as unknown as ReturnType<typeof vi.fn>
+    ).mockResolvedValueOnce({
+      empty: false,
+      docs: [buildSessionDoc('s1', { status: 'active' })],
+    });
+
+    const getDocMock = firestore.getDoc as unknown as ReturnType<typeof vi.fn>;
+    const unavailable = Object.assign(new Error('Backend unavailable.'), {
+      code: 'unavailable',
+    });
+    getDocMock.mockRejectedValueOnce(unavailable);
+
+    const { result } = renderHook(() => useQuizSessionStudent());
+    await act(async () => {
+      await expect(
+        result.current.joinQuizSession('ABC123', '1234')
+      ).rejects.toThrow('Backend unavailable.');
+    });
+  });
+
+  // Companion guard: for SSO/studentRole users (non-anonymous), a
+  // permission-denied on the deterministic probe means a legitimate
+  // class-gate denial — it must propagate (fail fast) instead of being
+  // swallowed and falling through to a doomed setDoc.
+  it('propagates permission-denied on the deterministic-key getDoc for non-anonymous (studentRole) joiners', async () => {
+    (
+      auth as unknown as {
+        currentUser: { uid: string; isAnonymous: boolean } | null;
+      }
+    ).currentUser = { uid: 'sso-uid-1', isAnonymous: false };
+
+    (
+      firestore.getDocs as unknown as ReturnType<typeof vi.fn>
+    ).mockResolvedValueOnce({
+      empty: false,
+      docs: [buildSessionDoc('s1', { status: 'active' })],
+    });
+
+    const getDocMock = firestore.getDoc as unknown as ReturnType<typeof vi.fn>;
+    const permissionDenied = Object.assign(
+      new Error('Missing or insufficient permissions.'),
+      { code: 'permission-denied' }
+    );
+    getDocMock.mockRejectedValueOnce(permissionDenied);
+
+    const { result } = renderHook(() => useQuizSessionStudent());
+    await act(async () => {
+      await expect(result.current.joinQuizSession('ABC123')).rejects.toThrow(
+        'Missing or insufficient permissions.'
+      );
+    });
+  });
+
   // Regression: PR #1409 review. An anonymous student whose device has a
   // stale in-flight response doc keyed by a PRIOR anon uid will trigger a
   // legacy-key getDoc that Firestore rejects with permission-denied (the

--- a/tests/rules/quizPinCollision.test.ts
+++ b/tests/rules/quizPinCollision.test.ts
@@ -38,8 +38,8 @@ const ANON_A_UID = 'anon-a-uid';
 const ANON_B_UID = 'anon-b-uid';
 
 // Deterministic key encoding mirrors `encodeResponseKeySegment()` on the
-// client (utils/quizSession). For inputs without special characters the
-// encoding is identity, which is all this test needs.
+// client (`hooks/useQuizSession.ts`). For inputs without special characters
+// the encoding is identity, which is all this test needs.
 const PERIOD = 'period_1';
 const PIN = '01';
 const COLLIDING_KEY = `pin-${PERIOD}-${PIN}`;

--- a/tests/rules/quizPinCollision.test.ts
+++ b/tests/rules/quizPinCollision.test.ts
@@ -1,0 +1,163 @@
+// Firestore security-rules regression for the anonymous-PIN deterministic
+// response key. Locks in the response-doc read/update denial when two
+// different anonymous UIDs hash to the same key (real PIN+period collision
+// across students, OR same student rejoining from a fresh browser session
+// where the anonymous UID has rotated).
+//
+// The denial itself is correct/intended (the rule binds ownership to the
+// `studentUid` field, not the doc key). What this test guards is:
+//   1. The rule still denies cross-anon reads/writes — preventing data
+//      leakage if someone widens the read/update rule too aggressively.
+//   2. The bug surface is documented: any client code path that probes the
+//      deterministic key without handling permission-denied will reproduce
+//      the original "Uncaught (in promise) FirebaseError: Missing or
+//      insufficient permissions" against this test scenario.
+//
+// Requires a running Firestore emulator. Invoke via:
+//   pnpm run test:rules
+
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { afterAll, beforeAll, beforeEach, describe, it } from 'vitest';
+import {
+  initializeTestEnvironment,
+  assertSucceeds,
+  assertFails,
+  type RulesTestEnvironment,
+} from '@firebase/rules-unit-testing';
+import { setDoc, getDoc, doc } from 'firebase/firestore';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const PROJECT_ID = 'spartboard-quiz-pin-collision';
+const SESSION_ID = 'pin-collision-session';
+const TEACHER_UID = 'teacher-uid-pc';
+const ANON_A_UID = 'anon-a-uid';
+const ANON_B_UID = 'anon-b-uid';
+
+// Deterministic key encoding mirrors `encodeResponseKeySegment()` on the
+// client (utils/quizSession). For inputs without special characters the
+// encoding is identity, which is all this test needs.
+const PERIOD = 'period_1';
+const PIN = '01';
+const COLLIDING_KEY = `pin-${PERIOD}-${PIN}`;
+
+const RULES_PATH = fileURLToPath(
+  new URL('../../firestore.rules', import.meta.url)
+);
+
+// ---------------------------------------------------------------------------
+// Auth contexts — match the bare-token shape that production Firebase
+// anonymous sign-in produces (no studentRole, classIds, or email claims).
+// ---------------------------------------------------------------------------
+
+let testEnv: RulesTestEnvironment;
+
+const asAnonA = () =>
+  testEnv
+    .authenticatedContext(ANON_A_UID, {
+      firebase: { sign_in_provider: 'anonymous' },
+    })
+    .firestore();
+
+const asAnonB = () =>
+  testEnv
+    .authenticatedContext(ANON_B_UID, {
+      firebase: { sign_in_provider: 'anonymous' },
+    })
+    .firestore();
+
+beforeAll(async () => {
+  testEnv = await initializeTestEnvironment({
+    projectId: PROJECT_ID,
+    firestore: {
+      rules: readFileSync(RULES_PATH, 'utf8'),
+      host: process.env.FIRESTORE_EMULATOR_HOST?.split(':')[0] ?? '127.0.0.1',
+      port: Number(
+        process.env.FIRESTORE_EMULATOR_HOST?.split(':')[1] ?? '8080'
+      ),
+    },
+  });
+});
+
+afterAll(async () => {
+  await testEnv?.cleanup();
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('quiz_sessions/responses — anonymous PIN deterministic-key collision', () => {
+  const responsePath = `quiz_sessions/${SESSION_ID}/responses/${COLLIDING_KEY}`;
+
+  const respDoc = (ownerUid: string) => ({
+    studentUid: ownerUid,
+    pin: PIN,
+    classPeriod: PERIOD,
+    joinedAt: 1000,
+    score: null,
+    answers: [],
+    status: 'joined',
+    completedAttempts: 0,
+  });
+
+  beforeEach(async () => {
+    await testEnv.clearFirestore();
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      const db = ctx.firestore();
+      // Untargeted session (no classId/classIds) — the open class-gate path
+      // anonymous PIN joiners use in production.
+      await setDoc(doc(db, `quiz_sessions/${SESSION_ID}`), {
+        teacherUid: TEACHER_UID,
+        status: 'active',
+        code: 'PCTEST',
+      });
+      // Anon A has already joined: their response doc occupies the
+      // deterministic key.
+      await setDoc(doc(db, responsePath), respDoc(ANON_A_UID));
+    });
+  });
+
+  it('owner anon A can read their own response at the deterministic key', async () => {
+    // Sanity check: ownership-based read still works for the original
+    // joiner. This proves the test fixture is wired correctly before we
+    // assert the cross-anon denials below.
+    await assertSucceeds(getDoc(doc(asAnonA(), responsePath)));
+  });
+
+  it('different anon B is DENIED reading anon A’s response at the same deterministic key', async () => {
+    // This is the exact path `findExistingResponseDoc` exercises on the
+    // first probe: getDoc on the deterministic key. Pre-fix, the denial
+    // bubbled out as an unhandled promise rejection in the browser console;
+    // the rule itself denying is correct and locked in here.
+    await assertFails(getDoc(doc(asAnonB(), responsePath)));
+  });
+
+  it('different anon B is DENIED creating/overwriting at anon A’s deterministic key', async () => {
+    // setDoc on an existing doc owned by another anon UID resolves to the
+    // `update` rule — denied because `request.auth.uid != resource.data.studentUid`.
+    // This is what surfaces to `joinQuizSession`'s outer catch after the
+    // read probe is silenced; the .catch on the form submit / period
+    // confirm prevents it from bubbling as an unhandled rejection.
+    await assertFails(
+      setDoc(doc(asAnonB(), responsePath), respDoc(ANON_B_UID))
+    );
+  });
+
+  it('different anon B CAN read at a non-colliding deterministic key (no doc) and CAN create their own', async () => {
+    // Same period, different PIN — different deterministic key, no
+    // existing doc. The read returns `resource == null` (allowed) and the
+    // create succeeds (key shape matches the regex, studentUid == auth.uid).
+    const noConflictPath = `quiz_sessions/${SESSION_ID}/responses/pin-${PERIOD}-02`;
+    await assertSucceeds(getDoc(doc(asAnonB(), noConflictPath)));
+    await assertSucceeds(
+      setDoc(doc(asAnonB(), noConflictPath), {
+        ...respDoc(ANON_B_UID),
+        pin: '02',
+      })
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- `findExistingResponseDoc` wraps the deterministic-key `getDoc` in the same `permission-denied` try/catch the legacy auth-uid probe already uses — stops the "Uncaught (in promise) FirebaseError: Missing or insufficient permissions" when two anon UIDs hash to the same `pin-{period}-{pin}` key (real PIN collision across students, or one student rejoining from a fresh browser/incognito session under a rotated anon UID).
- `QuizJoinFlow` form submit and period-confirm button replace `void handleJoin(...)` / `void handlePeriodConfirm()` with `.catch(...)`. `void` only suppresses the unused-promise lint — it does NOT catch the rejection. `joinQuizSession` re-throws after populating `error` state for the UI; the new `.catch` keeps that rejection from bubbling as an unhandled promise.
- **UX**: anon students now always see the class-period picker when the assignment declares any periods (PIN+period is the response-doc disambiguator on `pin-{period}-{pin}`; same PIN can recur across periods). SSO students from `/student/login` skip the picker entirely — they're keyed by `auth.uid` and matched to their class via `classId`.
- New `tests/rules/quizPinCollision.test.ts` locks in the rule behavior: anon B is denied reading or overwriting anon A's response doc at the same deterministic key, and can read/create at a non-colliding key.

## Test plan
- [ ] CI pipeline green (`pr-validation` workflow)
- [ ] `pnpm run test:rules` passes (the new `quizPinCollision.test.ts` regression test — couldn't run locally because the emulator needs JDK 21+ on this machine)
- [ ] Manual on the dev preview URL: open the same teacher's `/quiz?code=…` in two incognito windows, both anon, both enter the same PIN+period. First lands in the waiting room; second sees a clear in-UI error message (no "Uncaught (in promise)" in the console).
- [ ] Manual: anon student joining a single-period assignment — confirm the picker still appears with that one period as the only option (rather than auto-picking).
- [ ] Manual: SSO student via `/student/login` flow on a multi-period assignment — confirm they never see the picker (auto-joins with `classPeriod === undefined`, response doc keyed by `auth.uid`).
- [ ] Manual: tab between question screens during a real quiz — `submitAnswer` / `tabSwitchWarnings` flow still works (no regression on the main response update path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)