### PR TITLE
fix(quiz): tighten PLC quiz assignment workflow (5 bugs)

### DIFF
--- a/components/layout/DashboardView.tsx
+++ b/components/layout/DashboardView.tsx
@@ -161,7 +161,7 @@ export const DashboardView: React.FC = () => {
 
   const { importSharedQuiz, saveQuiz, deleteQuiz } = useQuiz(user?.uid);
   const { importSharedAssignment } = useQuizAssignments(user?.uid);
-  const { plcs } = usePlcs();
+  const { plcs, loading: plcsLoading } = usePlcs();
 
   // Helper: open (or create) a Quiz widget and set its managerTab.
   // Used by pending-share effects to surface the imported content to the user.
@@ -238,6 +238,12 @@ export const DashboardView: React.FC = () => {
   // shows live and paused assignments (Archive only shows inactive ones).
   useEffect(() => {
     if (!pendingAssignmentShareId || !user) return;
+    // Wait for the /plcs listener to hydrate before deciding membership.
+    // Otherwise a deep-link import that fires before the snapshot arrives
+    // sees an empty plcs array, the predicate returns false, and a
+    // legitimate PLC member gets demoted to non-member with the "you're
+    // not a member" toast — even though they are.
+    if (plcsLoading) return;
     // Clear synchronously BEFORE awaiting — see the quiz-share effect above
     // for the triple-import race rationale.
     const shareId = pendingAssignmentShareId;
@@ -314,6 +320,7 @@ export const DashboardView: React.FC = () => {
     openQuizWidgetToTab,
     setPendingAssignmentSetup,
     plcs,
+    plcsLoading,
   ]);
 
   const [panOffset, setPanOffset] = React.useState({ x: 0, y: 0 });

--- a/components/layout/DashboardView.tsx
+++ b/components/layout/DashboardView.tsx
@@ -13,6 +13,7 @@ import { useAuth } from '@/context/useAuth';
 import { useLiveSession } from '@/hooks/useLiveSession';
 import { useQuiz } from '@/hooks/useQuiz';
 import { useQuizAssignments } from '@/hooks/useQuizAssignments';
+import { usePlcs } from '@/hooks/usePlcs';
 import { useStorage, MAX_PDF_SIZE_BYTES } from '@/hooks/useStorage';
 import { Sidebar } from './sidebar/Sidebar';
 import { Dock } from './Dock';
@@ -160,6 +161,7 @@ export const DashboardView: React.FC = () => {
 
   const { importSharedQuiz, saveQuiz, deleteQuiz } = useQuiz(user?.uid);
   const { importSharedAssignment } = useQuizAssignments(user?.uid);
+  const { plcs } = usePlcs();
 
   // Helper: open (or create) a Quiz widget and set its managerTab.
   // Used by pending-share effects to surface the imported content to the user.
@@ -251,6 +253,31 @@ export const DashboardView: React.FC = () => {
       // quiz in their library and a generic "import failed" toast.
       async (saved) => {
         await deleteQuiz(saved.id, saved.driveFileId);
+      },
+      // Membership predicate: when the share carries a plcId, preserve
+      // PLC linkage iff the importer is a current member of that PLC.
+      (plcId) =>
+        !!user &&
+        plcs.some((p) => p.id === plcId && p.memberUids.includes(user.uid)),
+      // Non-member nudge: import still succeeds (the quiz is usable),
+      // but PLC sheet wiring is stripped — surface a CTA toast that
+      // opens the Sidebar's PLCs panel so the teacher can join the PLC
+      // or set up their own.
+      ({ plcName }) => {
+        addToast(
+          `This is a PLC quiz assignment for "${plcName}". You're not a member, so your results will export to your own sheet.`,
+          'info',
+          {
+            label: 'PLC Settings',
+            onClick: () => {
+              window.dispatchEvent(
+                new CustomEvent('open-sidebar', {
+                  detail: { section: 'plcs' },
+                })
+              );
+            },
+          }
+        );
       }
     )
       .then((newAssignmentId) => {
@@ -286,6 +313,7 @@ export const DashboardView: React.FC = () => {
     clearPendingAssignmentShare,
     openQuizWidgetToTab,
     setPendingAssignmentSetup,
+    plcs,
   ]);
 
   const [panOffset, setPanOffset] = React.useState({ x: 0, y: 0 });

--- a/components/layout/DashboardView.tsx
+++ b/components/layout/DashboardView.tsx
@@ -238,11 +238,11 @@ export const DashboardView: React.FC = () => {
   // shows live and paused assignments (Archive only shows inactive ones).
   useEffect(() => {
     if (!pendingAssignmentShareId || !user) return;
-    // Wait for the /plcs listener to hydrate before deciding membership.
-    // Otherwise a deep-link import that fires before the snapshot arrives
-    // sees an empty plcs array, the predicate returns false, and a
-    // legitimate PLC member gets demoted to non-member with the "you're
-    // not a member" toast — even though they are.
+    // Wait for /plcs to hydrate before evaluating membership. Without this
+    // gate, a deep-link import that fires before the listener populates
+    // `plcs` sees `[]`, the `isPlcMember` predicate returns false, and a
+    // legitimate member is silently demoted to non-member. Once
+    // plcsLoading flips to false the effect re-runs with the real list.
     if (plcsLoading) return;
     // Clear synchronously BEFORE awaiting — see the quiz-share effect above
     // for the triple-import race rationale.
@@ -260,30 +260,34 @@ export const DashboardView: React.FC = () => {
       async (saved) => {
         await deleteQuiz(saved.id, saved.driveFileId);
       },
-      // Membership predicate: when the share carries a plcId, preserve
-      // PLC linkage iff the importer is a current member of that PLC.
-      (plcId) =>
-        !!user &&
-        plcs.some((p) => p.id === plcId && p.memberUids.includes(user.uid)),
-      // Non-member nudge: import still succeeds (the quiz is usable),
-      // but PLC sheet wiring is stripped — surface a CTA toast that
-      // opens the Sidebar's PLCs panel so the teacher can join the PLC
-      // or set up their own.
-      ({ plcName }) => {
-        addToast(
-          `This is a PLC quiz assignment for "${plcName}". You're not a member, so your results will export to your own sheet.`,
-          'info',
-          {
-            label: 'PLC Settings',
-            onClick: () => {
-              window.dispatchEvent(
-                new CustomEvent('open-sidebar', {
-                  detail: { section: 'plcs' },
-                })
-              );
-            },
-          }
-        );
+      // PLC handling: bundled isMember + onNonMember so the contract
+      // "PLC handling is opt-in as a unit" is visible at the call site.
+      {
+        // Membership predicate: when the share carries plc.id, preserve
+        // PLC linkage iff the importer is a current member of that PLC.
+        isMember: (plcId) =>
+          !!user &&
+          plcs.some((p) => p.id === plcId && p.memberUids.includes(user.uid)),
+        // Non-member nudge: import still succeeds (the quiz is usable),
+        // but PLC sheet wiring is stripped — surface a CTA toast that
+        // opens the Sidebar's PLCs panel so the teacher can join the PLC
+        // or set up their own.
+        onNonMember: ({ plcName }) => {
+          addToast(
+            `This is a PLC quiz assignment for "${plcName}". You're not a member, so your results will export to your own sheet.`,
+            'info',
+            {
+              label: 'PLC Settings',
+              onClick: () => {
+                window.dispatchEvent(
+                  new CustomEvent('open-sidebar', {
+                    detail: { section: 'plcs' },
+                  })
+                );
+              },
+            }
+          );
+        },
       }
     )
       .then((newAssignmentId) => {

--- a/components/quiz/QuizStudentApp.tsx
+++ b/components/quiz/QuizStudentApp.tsx
@@ -651,6 +651,9 @@ const ActiveQuiz: React.FC<{
   const [revealedAnswer, setRevealedAnswer] = useState<string | null>(null);
   const [speedBonusEarned, setSpeedBonusEarned] = useState<number | null>(null);
   const [streakCount, setStreakCount] = useState(0);
+  // Surfaced when onAnswer or onComplete rejects (offline, perm denied, etc.)
+  // so the student doesn't think their tap silently committed.
+  const [submitError, setSubmitError] = useState<string | null>(null);
 
   // Derived state: reset local UI state on new question or when global alreadyAnswered state arrives
   if (
@@ -667,6 +670,7 @@ const ActiveQuiz: React.FC<{
     setAnswerFeedback(null);
     setRevealedAnswer(null);
     setSpeedBonusEarned(null);
+    setSubmitError(null);
     const tl = currentQuestion?.timeLimit ?? 0;
     setTimeLeft(tl > 0 && !alreadyAnswered ? tl : null);
   }
@@ -691,6 +695,11 @@ const ActiveQuiz: React.FC<{
   const fibAnswerRef = useRef(fibAnswer);
   const draftMcAnswerRef = useRef(draftMcAnswer);
   const onAnswerRef = useRef(onAnswer);
+  // Synchronous re-entry guard for handleSubmitAndAdvance. The setSubmitting
+  // state setter doesn't apply until the next render, so two near-simultaneous
+  // taps (or React 19 transition reordering) could both pass the gate before
+  // the state flips. The ref blocks the second call immediately.
+  const submittingRef = useRef(false);
 
   useEffect(() => {
     currentQuestionRef.current = currentQuestion;
@@ -888,8 +897,10 @@ const ActiveQuiz: React.FC<{
   // who want feedback should run the quiz in teacher-paced mode and reveal
   // answers manually.
   const handleSubmitAndAdvance = async (answer: string) => {
-    if (submitting || submitted) return;
+    if (submittingRef.current || submitted) return;
+    submittingRef.current = true;
     setSubmitting(true);
+    setSubmitError(null);
     try {
       let computedSpeedBonus: number | undefined;
       if (session.speedBonusEnabled && currentQuestion.timeLimit > 0) {
@@ -899,19 +910,44 @@ const ActiveQuiz: React.FC<{
         );
         if (bonusPct > 0) computedSpeedBonus = bonusPct;
       }
-      await onAnswer(currentQuestion.id, answer, computedSpeedBonus);
+
+      try {
+        await onAnswer(currentQuestion.id, answer, computedSpeedBonus);
+      } catch (err) {
+        // Answer write rejected (offline, perm denied, etc.). Without this
+        // catch the rejection vanishes into a void-promise console error and
+        // the student silently keeps their selection.
+        console.error('[QuizStudentApp] onAnswer failed:', err);
+        setSubmitError(
+          "Couldn't save your answer. Check your connection and try again."
+        );
+        return;
+      }
 
       const isLast = currentIndex >= session.totalQuestions - 1;
       if (isLast) {
         setSelectedAnswer(answer);
         setSubmitted(true);
         if (myResponse?.status !== 'completed') {
-          await onComplete();
+          try {
+            await onComplete();
+          } catch (err) {
+            // Answer is saved but the completion flip failed. Roll the UI
+            // back so the SUBMIT button reappears for the student to retry,
+            // otherwise they'd see "Quiz complete!" while their doc stays
+            // in_progress on the teacher's monitor.
+            console.error('[QuizStudentApp] onComplete failed:', err);
+            setSubmitted(false);
+            setSubmitError(
+              "Couldn't finish submitting. Check your connection and tap SUBMIT again."
+            );
+          }
         }
       } else {
         setLocalIndex(localIndex + 1);
       }
     } finally {
+      submittingRef.current = false;
       setSubmitting(false);
     }
   };
@@ -997,6 +1033,16 @@ const ActiveQuiz: React.FC<{
         <h2 className="text-xl font-bold text-white mb-8 leading-snug">
           {currentQuestion.text}
         </h2>
+
+        {submitError && (
+          <div
+            role="alert"
+            className="mb-6 p-4 bg-red-500/15 border border-red-500/40 rounded-2xl flex items-start gap-3 animate-in fade-in slide-in-from-top-2"
+          >
+            <AlertCircle className="w-5 h-5 text-red-400 shrink-0 mt-0.5" />
+            <p className="text-red-200 text-sm font-medium">{submitError}</p>
+          </div>
+        )}
 
         {/* Answer area */}
         {currentQuestion.type === 'MC' && (

--- a/components/quiz/QuizStudentApp.tsx
+++ b/components/quiz/QuizStudentApp.tsx
@@ -883,6 +883,39 @@ const ActiveQuiz: React.FC<{
     }
   };
 
+  // Self-paced unified action: persist the answer, then advance (or complete
+  // on the final question). Skips the per-question feedback banner — teachers
+  // who want feedback should run the quiz in teacher-paced mode and reveal
+  // answers manually.
+  const handleSubmitAndAdvance = async (answer: string) => {
+    if (submitting || submitted) return;
+    setSubmitting(true);
+    try {
+      let computedSpeedBonus: number | undefined;
+      if (session.speedBonusEnabled && currentQuestion.timeLimit > 0) {
+        const remaining = Math.max(0, timeLeft ?? 0);
+        const bonusPct = Math.round(
+          (remaining / currentQuestion.timeLimit) * 50
+        );
+        if (bonusPct > 0) computedSpeedBonus = bonusPct;
+      }
+      await onAnswer(currentQuestion.id, answer, computedSpeedBonus);
+
+      const isLast = currentIndex >= session.totalQuestions - 1;
+      if (isLast) {
+        setSelectedAnswer(answer);
+        setSubmitted(true);
+        if (myResponse?.status !== 'completed') {
+          await onComplete();
+        }
+      } else {
+        setLocalIndex(localIndex + 1);
+      }
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
   const progress = ((currentIndex + 1) / session.totalQuestions) * 100;
 
   // Choices are pre-shuffled in publicQuestions by the teacher side
@@ -996,7 +1029,46 @@ const ActiveQuiz: React.FC<{
             })}
 
             <div className="animate-in fade-in slide-in-from-bottom-2">
-              {!submitted ? (
+              {isStudentPaced ? (
+                !submitted ? (
+                  <button
+                    onClick={() =>
+                      draftMcAnswer &&
+                      void handleSubmitAndAdvance(draftMcAnswer)
+                    }
+                    disabled={!draftMcAnswer || submitting}
+                    className="w-full py-4 bg-emerald-600 hover:bg-emerald-500 disabled:opacity-50 disabled:cursor-not-allowed text-white font-black rounded-2xl flex items-center justify-center gap-2 transition-all shadow-lg active:scale-95"
+                  >
+                    {submitting ? (
+                      <Loader2 className="w-5 h-5 animate-spin" />
+                    ) : currentIndex >= session.totalQuestions - 1 ? (
+                      <>
+                        SUBMIT <CheckCircle2 className="w-5 h-5" />
+                      </>
+                    ) : (
+                      <>
+                        NEXT <ArrowRight className="w-5 h-5" />
+                      </>
+                    )}
+                  </button>
+                ) : currentIndex < session.totalQuestions - 1 ? (
+                  // Timeout-auto-submit fallback: timer expired, give student
+                  // a way to advance.
+                  <button
+                    onClick={handleNext}
+                    className="w-full py-4 bg-emerald-600 hover:bg-emerald-500 text-white font-black rounded-2xl flex items-center justify-center gap-2 transition-all shadow-lg active:scale-95"
+                  >
+                    NEXT QUESTION <ArrowRight className="w-5 h-5" />
+                  </button>
+                ) : (
+                  <div className="p-4 bg-emerald-500/15 border border-emerald-500/30 rounded-2xl flex items-center justify-center gap-3">
+                    <CheckCircle2 className="w-5 h-5 text-emerald-400 shrink-0" />
+                    <p className="text-emerald-300 text-sm font-bold">
+                      Quiz complete!
+                    </p>
+                  </div>
+                )
+              ) : !submitted ? (
                 <button
                   onClick={() =>
                     draftMcAnswer && void handleSubmit(draftMcAnswer)
@@ -1019,24 +1091,14 @@ const ActiveQuiz: React.FC<{
                     streakCount={streakCount}
                     streakEnabled={session.streakBonusEnabled}
                   />
-                  {isStudentPaced &&
-                  currentIndex < session.totalQuestions - 1 ? (
-                    <button
-                      onClick={handleNext}
-                      className="w-full py-4 bg-emerald-600 hover:bg-emerald-500 text-white font-black rounded-2xl flex items-center justify-center gap-2 transition-all shadow-lg active:scale-95"
-                    >
-                      NEXT QUESTION <ArrowRight className="w-5 h-5" />
-                    </button>
-                  ) : (
-                    <div className="p-4 bg-emerald-500/15 border border-emerald-500/30 rounded-2xl flex items-center justify-center gap-3">
-                      <CheckCircle2 className="w-5 h-5 text-emerald-400 shrink-0" />
-                      <p className="text-emerald-300 text-sm font-bold">
-                        {currentIndex < session.totalQuestions - 1
-                          ? 'Waiting for teacher…'
-                          : 'Quiz complete!'}
-                      </p>
-                    </div>
-                  )}
+                  <div className="p-4 bg-emerald-500/15 border border-emerald-500/30 rounded-2xl flex items-center justify-center gap-3">
+                    <CheckCircle2 className="w-5 h-5 text-emerald-400 shrink-0" />
+                    <p className="text-emerald-300 text-sm font-bold">
+                      {currentIndex < session.totalQuestions - 1
+                        ? 'Waiting for teacher…'
+                        : 'Quiz complete!'}
+                    </p>
+                  </div>
                 </div>
               )}
             </div>
@@ -1052,15 +1114,56 @@ const ActiveQuiz: React.FC<{
               disabled={submitted}
               placeholder="Type your answer…"
               className="w-full px-5 py-4 bg-slate-800 border-2 border-slate-700 rounded-2xl text-white text-sm focus:outline-none focus:ring-0 focus:border-violet-500 disabled:opacity-50"
-              onKeyDown={(e) =>
-                e.key === 'Enter' &&
-                fibAnswer.trim() &&
-                !submitted &&
-                void handleSubmit(fibAnswer.trim())
-              }
+              onKeyDown={(e) => {
+                if (e.key !== 'Enter') return;
+                const trimmed = fibAnswer.trim();
+                if (!trimmed || submitted) return;
+                if (isStudentPaced) {
+                  void handleSubmitAndAdvance(trimmed);
+                } else {
+                  void handleSubmit(trimmed);
+                }
+              }}
             />
             <div className="animate-in fade-in slide-in-from-bottom-2">
-              {!submitted ? (
+              {isStudentPaced ? (
+                !submitted ? (
+                  <button
+                    onClick={() =>
+                      fibAnswer.trim() &&
+                      void handleSubmitAndAdvance(fibAnswer.trim())
+                    }
+                    disabled={!fibAnswer.trim() || submitting}
+                    className="w-full py-4 bg-emerald-600 hover:bg-emerald-500 disabled:opacity-50 disabled:cursor-not-allowed text-white font-black rounded-2xl flex items-center justify-center gap-2 transition-all shadow-lg active:scale-95"
+                  >
+                    {submitting ? (
+                      <Loader2 className="w-5 h-5 animate-spin" />
+                    ) : currentIndex >= session.totalQuestions - 1 ? (
+                      <>
+                        SUBMIT <CheckCircle2 className="w-5 h-5" />
+                      </>
+                    ) : (
+                      <>
+                        NEXT <ArrowRight className="w-5 h-5" />
+                      </>
+                    )}
+                  </button>
+                ) : currentIndex < session.totalQuestions - 1 ? (
+                  <button
+                    onClick={handleNext}
+                    className="w-full py-4 bg-emerald-600 hover:bg-emerald-500 text-white font-black rounded-2xl flex items-center justify-center gap-2 transition-all shadow-lg active:scale-95"
+                  >
+                    NEXT QUESTION <ArrowRight className="w-5 h-5" />
+                  </button>
+                ) : (
+                  <div className="p-4 bg-emerald-500/15 border border-emerald-500/30 rounded-2xl flex items-center justify-center gap-3">
+                    <CheckCircle2 className="w-5 h-5 text-emerald-400 shrink-0" />
+                    <p className="text-emerald-300 text-sm font-bold">
+                      Quiz complete!
+                    </p>
+                  </div>
+                )
+              ) : !submitted ? (
                 <button
                   onClick={() =>
                     fibAnswer.trim() && void handleSubmit(fibAnswer.trim())
@@ -1083,24 +1186,14 @@ const ActiveQuiz: React.FC<{
                     streakCount={streakCount}
                     streakEnabled={session.streakBonusEnabled}
                   />
-                  {isStudentPaced &&
-                  currentIndex < session.totalQuestions - 1 ? (
-                    <button
-                      onClick={handleNext}
-                      className="w-full py-4 bg-emerald-600 hover:bg-emerald-500 text-white font-black rounded-2xl flex items-center justify-center gap-2 transition-all shadow-lg active:scale-95"
-                    >
-                      NEXT QUESTION <ArrowRight className="w-5 h-5" />
-                    </button>
-                  ) : (
-                    <div className="p-4 bg-emerald-500/15 border border-emerald-500/30 rounded-2xl flex items-center justify-center gap-3">
-                      <CheckCircle2 className="w-5 h-5 text-emerald-400 shrink-0" />
-                      <p className="text-emerald-300 text-sm font-bold">
-                        {currentIndex < session.totalQuestions - 1
-                          ? 'Waiting for teacher…'
-                          : 'Quiz complete!'}
-                      </p>
-                    </div>
-                  )}
+                  <div className="p-4 bg-emerald-500/15 border border-emerald-500/30 rounded-2xl flex items-center justify-center gap-3">
+                    <CheckCircle2 className="w-5 h-5 text-emerald-400 shrink-0" />
+                    <p className="text-emerald-300 text-sm font-bold">
+                      {currentIndex < session.totalQuestions - 1
+                        ? 'Waiting for teacher…'
+                        : 'Quiz complete!'}
+                    </p>
+                  </div>
                 </div>
               )}
             </div>
@@ -1114,6 +1207,7 @@ const ActiveQuiz: React.FC<{
             question={currentQuestion}
             submitted={submitted}
             onSubmit={(answer) => void handleSubmit(answer)}
+            onSubmitAndAdvance={(answer) => void handleSubmitAndAdvance(answer)}
             submitting={submitting}
             isStudentPaced={isStudentPaced}
             isLastQuestion={currentIndex >= session.totalQuestions - 1}
@@ -1131,6 +1225,7 @@ const StructuredQuestionInput: React.FC<{
   question: QuizPublicQuestion;
   submitted: boolean;
   onSubmit: (answer: string) => void;
+  onSubmitAndAdvance: (answer: string) => void;
   submitting: boolean;
   isStudentPaced: boolean;
   isLastQuestion: boolean;
@@ -1139,6 +1234,7 @@ const StructuredQuestionInput: React.FC<{
   question,
   submitted,
   onSubmit,
+  onSubmitAndAdvance,
   submitting,
   isStudentPaced,
   isLastQuestion,
@@ -1164,16 +1260,21 @@ const StructuredQuestionInput: React.FC<{
     ? Object.values(matchings).every((v: string) => !!v)
     : order.length > 0 && order.length === leftItems.length;
 
-  const handleSubmitStructured = () => {
-    let answer: string;
+  const buildAnswer = (): string => {
     if (isMatching) {
-      answer = leftItems
+      return leftItems
         .map((l: string) => `${l}:${matchings[l] || ''}`)
         .join('|');
-    } else {
-      answer = order.join('|');
     }
-    onSubmit(answer);
+    return order.join('|');
+  };
+
+  const handleSubmitStructured = () => {
+    if (isStudentPaced) {
+      onSubmitAndAdvance(buildAnswer());
+    } else {
+      onSubmit(buildAnswer());
+    }
   };
 
   // ─── Drag and Drop Handlers ────────────────────────────────────────────────
@@ -1282,10 +1383,24 @@ const StructuredQuestionInput: React.FC<{
           <button
             onClick={handleSubmitStructured}
             disabled={!canSubmit || submitting}
-            className="w-full py-4 bg-violet-600 hover:bg-violet-500 disabled:opacity-50 disabled:cursor-not-allowed text-white font-bold rounded-2xl flex items-center justify-center gap-2 transition-colors"
+            className={`w-full py-4 disabled:opacity-50 disabled:cursor-not-allowed text-white font-bold rounded-2xl flex items-center justify-center gap-2 transition-all ${
+              isStudentPaced
+                ? 'bg-emerald-600 hover:bg-emerald-500 font-black shadow-lg active:scale-95'
+                : 'bg-violet-600 hover:bg-violet-500'
+            }`}
           >
             {submitting ? (
               <Loader2 className="w-5 h-5 animate-spin" />
+            ) : isStudentPaced ? (
+              isLastQuestion ? (
+                <>
+                  SUBMIT <CheckCircle2 className="w-5 h-5" />
+                </>
+              ) : (
+                <>
+                  NEXT <ArrowRight className="w-5 h-5" />
+                </>
+              )
             ) : (
               'Submit Answer'
             )}
@@ -1294,6 +1409,7 @@ const StructuredQuestionInput: React.FC<{
       ) : (
         <div className="animate-in fade-in slide-in-from-bottom-2">
           {isStudentPaced && !isLastQuestion ? (
+            // Timeout-auto-submit fallback for self-paced.
             <button
               onClick={onNext}
               className="w-full py-4 bg-emerald-600 hover:bg-emerald-500 text-white font-black rounded-2xl flex items-center justify-center gap-2 transition-all shadow-lg active:scale-95"

--- a/components/quiz/QuizStudentApp.tsx
+++ b/components/quiz/QuizStudentApp.tsx
@@ -651,9 +651,14 @@ const ActiveQuiz: React.FC<{
   const [revealedAnswer, setRevealedAnswer] = useState<string | null>(null);
   const [speedBonusEarned, setSpeedBonusEarned] = useState<number | null>(null);
   const [streakCount, setStreakCount] = useState(0);
-  // Surfaced when onAnswer or onComplete rejects (offline, perm denied, etc.)
-  // so the student doesn't think their tap silently committed.
-  const [submitError, setSubmitError] = useState<string | null>(null);
+
+  // Self-paced save errors. `saveError` surfaces a retry banner above the
+  // NEXT/SUBMIT button when `onAnswer`/`onComplete` rejects (offline,
+  // permission-denied, etc.). `advancingRef` is a synchronous re-entry guard
+  // so a tap-storm can't double-fire `handleSubmitAndAdvance` in the window
+  // between calling `setSubmitting(true)` and React committing the render.
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const advancingRef = useRef(false);
 
   // Derived state: reset local UI state on new question or when global alreadyAnswered state arrives
   if (
@@ -670,7 +675,7 @@ const ActiveQuiz: React.FC<{
     setAnswerFeedback(null);
     setRevealedAnswer(null);
     setSpeedBonusEarned(null);
-    setSubmitError(null);
+    setSaveError(null);
     const tl = currentQuestion?.timeLimit ?? 0;
     setTimeLeft(tl > 0 && !alreadyAnswered ? tl : null);
   }
@@ -695,11 +700,6 @@ const ActiveQuiz: React.FC<{
   const fibAnswerRef = useRef(fibAnswer);
   const draftMcAnswerRef = useRef(draftMcAnswer);
   const onAnswerRef = useRef(onAnswer);
-  // Synchronous re-entry guard for handleSubmitAndAdvance. The setSubmitting
-  // state setter doesn't apply until the next render, so two near-simultaneous
-  // taps (or React 19 transition reordering) could both pass the gate before
-  // the state flips. The ref blocks the second call immediately.
-  const submittingRef = useRef(false);
 
   useEffect(() => {
     currentQuestionRef.current = currentQuestion;
@@ -896,11 +896,17 @@ const ActiveQuiz: React.FC<{
   // on the final question). Skips the per-question feedback banner — teachers
   // who want feedback should run the quiz in teacher-paced mode and reveal
   // answers manually.
+  //
+  // `advancingRef` is the synchronous re-entry guard (the `submitting` state
+  // alone has a window between setSubmitting(true) and React committing).
+  // On rejection we surface a retry banner via `saveError` instead of letting
+  // the failure vanish into the console; the student's selection is still
+  // intact (we never reset it on error) so the same tap retries.
   const handleSubmitAndAdvance = async (answer: string) => {
-    if (submittingRef.current || submitted) return;
-    submittingRef.current = true;
+    if (advancingRef.current || submitting || submitted) return;
+    advancingRef.current = true;
     setSubmitting(true);
-    setSubmitError(null);
+    setSaveError(null);
     try {
       let computedSpeedBonus: number | undefined;
       if (session.speedBonusEnabled && currentQuestion.timeLimit > 0) {
@@ -914,13 +920,12 @@ const ActiveQuiz: React.FC<{
       try {
         await onAnswer(currentQuestion.id, answer, computedSpeedBonus);
       } catch (err) {
-        // Answer write rejected (offline, perm denied, etc.). Without this
-        // catch the rejection vanishes into a void-promise console error and
-        // the student silently keeps their selection.
-        console.error('[QuizStudentApp] onAnswer failed:', err);
-        setSubmitError(
-          "Couldn't save your answer. Check your connection and try again."
+        console.error(
+          '[QuizStudentApp] onAnswer failed for question',
+          currentQuestion.id,
+          err
         );
+        setSaveError("Couldn't save your answer. Tap to try again.");
         return;
       }
 
@@ -932,23 +937,17 @@ const ActiveQuiz: React.FC<{
           try {
             await onComplete();
           } catch (err) {
-            // Answer is saved but the completion flip failed. Roll the UI
-            // back so the SUBMIT button reappears for the student to retry,
-            // otherwise they'd see "Quiz complete!" while their doc stays
-            // in_progress on the teacher's monitor.
             console.error('[QuizStudentApp] onComplete failed:', err);
             setSubmitted(false);
-            setSubmitError(
-              "Couldn't finish submitting. Check your connection and tap SUBMIT again."
-            );
+            setSaveError("Couldn't submit your quiz. Tap to try again.");
           }
         }
       } else {
         setLocalIndex(localIndex + 1);
       }
     } finally {
-      submittingRef.current = false;
       setSubmitting(false);
+      advancingRef.current = false;
     }
   };
 
@@ -1034,16 +1033,6 @@ const ActiveQuiz: React.FC<{
           {currentQuestion.text}
         </h2>
 
-        {submitError && (
-          <div
-            role="alert"
-            className="mb-6 p-4 bg-red-500/15 border border-red-500/40 rounded-2xl flex items-start gap-3 animate-in fade-in slide-in-from-top-2"
-          >
-            <AlertCircle className="w-5 h-5 text-red-400 shrink-0 mt-0.5" />
-            <p className="text-red-200 text-sm font-medium">{submitError}</p>
-          </div>
-        )}
-
         {/* Answer area */}
         {currentQuestion.type === 'MC' && (
           <div className="space-y-3 flex-1">
@@ -1074,29 +1063,34 @@ const ActiveQuiz: React.FC<{
               );
             })}
 
-            <div className="animate-in fade-in slide-in-from-bottom-2">
+            <div className="animate-in fade-in slide-in-from-bottom-2 space-y-3">
               {isStudentPaced ? (
                 !submitted ? (
-                  <button
-                    onClick={() =>
-                      draftMcAnswer &&
-                      void handleSubmitAndAdvance(draftMcAnswer)
-                    }
-                    disabled={!draftMcAnswer || submitting}
-                    className="w-full py-4 bg-emerald-600 hover:bg-emerald-500 disabled:opacity-50 disabled:cursor-not-allowed text-white font-black rounded-2xl flex items-center justify-center gap-2 transition-all shadow-lg active:scale-95"
-                  >
-                    {submitting ? (
-                      <Loader2 className="w-5 h-5 animate-spin" />
-                    ) : currentIndex >= session.totalQuestions - 1 ? (
-                      <>
-                        SUBMIT <CheckCircle2 className="w-5 h-5" />
-                      </>
-                    ) : (
-                      <>
-                        NEXT <ArrowRight className="w-5 h-5" />
-                      </>
-                    )}
-                  </button>
+                  <>
+                    {saveError && <SaveErrorBanner message={saveError} />}
+                    <button
+                      onClick={() =>
+                        draftMcAnswer &&
+                        void handleSubmitAndAdvance(draftMcAnswer)
+                      }
+                      disabled={!draftMcAnswer || submitting}
+                      className="w-full py-4 bg-emerald-600 hover:bg-emerald-500 disabled:opacity-50 disabled:cursor-not-allowed text-white font-black rounded-2xl flex items-center justify-center gap-2 transition-all shadow-lg active:scale-95"
+                    >
+                      {submitting ? (
+                        <Loader2 className="w-5 h-5 animate-spin" />
+                      ) : currentIndex >= session.totalQuestions - 1 ? (
+                        <>
+                          {saveError ? 'Retry Submit' : 'SUBMIT'}{' '}
+                          <CheckCircle2 className="w-5 h-5" />
+                        </>
+                      ) : (
+                        <>
+                          {saveError ? 'Retry' : 'NEXT'}{' '}
+                          <ArrowRight className="w-5 h-5" />
+                        </>
+                      )}
+                    </button>
+                  </>
                 ) : currentIndex < session.totalQuestions - 1 ? (
                   // Timeout-auto-submit fallback: timer expired, give student
                   // a way to advance.
@@ -1171,29 +1165,34 @@ const ActiveQuiz: React.FC<{
                 }
               }}
             />
-            <div className="animate-in fade-in slide-in-from-bottom-2">
+            <div className="animate-in fade-in slide-in-from-bottom-2 space-y-3">
               {isStudentPaced ? (
                 !submitted ? (
-                  <button
-                    onClick={() =>
-                      fibAnswer.trim() &&
-                      void handleSubmitAndAdvance(fibAnswer.trim())
-                    }
-                    disabled={!fibAnswer.trim() || submitting}
-                    className="w-full py-4 bg-emerald-600 hover:bg-emerald-500 disabled:opacity-50 disabled:cursor-not-allowed text-white font-black rounded-2xl flex items-center justify-center gap-2 transition-all shadow-lg active:scale-95"
-                  >
-                    {submitting ? (
-                      <Loader2 className="w-5 h-5 animate-spin" />
-                    ) : currentIndex >= session.totalQuestions - 1 ? (
-                      <>
-                        SUBMIT <CheckCircle2 className="w-5 h-5" />
-                      </>
-                    ) : (
-                      <>
-                        NEXT <ArrowRight className="w-5 h-5" />
-                      </>
-                    )}
-                  </button>
+                  <>
+                    {saveError && <SaveErrorBanner message={saveError} />}
+                    <button
+                      onClick={() =>
+                        fibAnswer.trim() &&
+                        void handleSubmitAndAdvance(fibAnswer.trim())
+                      }
+                      disabled={!fibAnswer.trim() || submitting}
+                      className="w-full py-4 bg-emerald-600 hover:bg-emerald-500 disabled:opacity-50 disabled:cursor-not-allowed text-white font-black rounded-2xl flex items-center justify-center gap-2 transition-all shadow-lg active:scale-95"
+                    >
+                      {submitting ? (
+                        <Loader2 className="w-5 h-5 animate-spin" />
+                      ) : currentIndex >= session.totalQuestions - 1 ? (
+                        <>
+                          {saveError ? 'Retry Submit' : 'SUBMIT'}{' '}
+                          <CheckCircle2 className="w-5 h-5" />
+                        </>
+                      ) : (
+                        <>
+                          {saveError ? 'Retry' : 'NEXT'}{' '}
+                          <ArrowRight className="w-5 h-5" />
+                        </>
+                      )}
+                    </button>
+                  </>
                 ) : currentIndex < session.totalQuestions - 1 ? (
                   <button
                     onClick={handleNext}
@@ -1258,6 +1257,7 @@ const ActiveQuiz: React.FC<{
             isStudentPaced={isStudentPaced}
             isLastQuestion={currentIndex >= session.totalQuestions - 1}
             onNext={handleNext}
+            saveError={saveError}
           />
         )}
       </div>
@@ -1276,6 +1276,7 @@ const StructuredQuestionInput: React.FC<{
   isStudentPaced: boolean;
   isLastQuestion: boolean;
   onNext: () => void;
+  saveError?: string | null;
 }> = ({
   question,
   submitted,
@@ -1285,6 +1286,7 @@ const StructuredQuestionInput: React.FC<{
   isStudentPaced,
   isLastQuestion,
   onNext,
+  saveError,
 }) => {
   const isMatching = question.type === 'Matching';
 
@@ -1426,6 +1428,9 @@ const StructuredQuestionInput: React.FC<{
             </div>
           )}
 
+          {isStudentPaced && saveError && (
+            <SaveErrorBanner message={saveError} />
+          )}
           <button
             onClick={handleSubmitStructured}
             disabled={!canSubmit || submitting}
@@ -1440,11 +1445,13 @@ const StructuredQuestionInput: React.FC<{
             ) : isStudentPaced ? (
               isLastQuestion ? (
                 <>
-                  SUBMIT <CheckCircle2 className="w-5 h-5" />
+                  {saveError ? 'Retry Submit' : 'SUBMIT'}{' '}
+                  <CheckCircle2 className="w-5 h-5" />
                 </>
               ) : (
                 <>
-                  NEXT <ArrowRight className="w-5 h-5" />
+                  {saveError ? 'Retry' : 'NEXT'}{' '}
+                  <ArrowRight className="w-5 h-5" />
                 </>
               )
             ) : (
@@ -1475,6 +1482,18 @@ const StructuredQuestionInput: React.FC<{
     </div>
   );
 };
+
+// ─── Save-error banner (self-paced retry affordance) ────────────────────────
+
+const SaveErrorBanner: React.FC<{ message: string }> = ({ message }) => (
+  <div
+    role="alert"
+    className="p-3 bg-red-500/20 border border-red-500/40 rounded-xl text-red-300 text-sm flex items-center gap-2"
+  >
+    <AlertCircle className="w-4 h-4 shrink-0" />
+    <span>{message}</span>
+  </div>
+);
 
 // ─── Answer feedback banner ──────────────────────────────────────────────────
 

--- a/components/widgets/QuizWidget/Widget.tsx
+++ b/components/widgets/QuizWidget/Widget.tsx
@@ -916,10 +916,15 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
             // PLC name won't be persisted onto the assignment doc. The
             // downstream non-member toast guard requires both plcId AND
             // plcName, so a missing snapshot silently disables the toast
-            // for downstream non-member importers.
+            // for downstream non-member importers. Surface a toast so the
+            // teacher knows their PLC selection didn't take and can retry.
             console.warn(
               '[QuizWidget] PLC name unresolved at assignment-create time — downstream non-member toast will be skipped',
               { plcId: plcOptions.plcId }
+            );
+            addToast(
+              "PLC info wasn't ready yet — the assignment was created without PLC sharing. Try again in a moment.",
+              'warning'
             );
           }
 

--- a/components/widgets/QuizWidget/Widget.tsx
+++ b/components/widgets/QuizWidget/Widget.tsx
@@ -97,6 +97,7 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
     updateAssignmentSettings,
     setAssignmentRosters,
     setAssignmentExportUrl,
+    setAssignmentExportedResponseIds,
     shareAssignment,
   } = useQuizAssignments(user?.uid);
 
@@ -664,6 +665,14 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
             ? (url) => setAssignmentExportUrl(activeAssignmentId, url)
             : undefined
         }
+        initialExportedResponseIds={
+          activeAssignment?.exportedResponseIds ?? null
+        }
+        onExportedResponseIdsSaved={
+          activeAssignmentId
+            ? (ids) => setAssignmentExportedResponseIds(activeAssignmentId, ids)
+            : undefined
+        }
       />
     );
   }
@@ -890,6 +899,15 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
             }
           }
 
+          // Snapshot the PLC name onto the assignment doc so a downstream
+          // share carries it through to the importer — the importer can't
+          // read /plcs/{plcId} directly (rules block non-members) so the
+          // name has to ride on the share doc itself for the non-member
+          // toast to be informative.
+          const resolvedPlcName = plcOptions.plcMode
+            ? plcs.find((p) => p.id === plcOptions.plcId)?.name
+            : undefined;
+
           try {
             const { id: assignmentId, code } = await createAssignment(
               {
@@ -908,6 +926,8 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
                   plcOptions.periodNames?.[0] ?? plcOptions.periodName,
                 periodNames: plcOptions.periodNames,
                 plcSheetUrl: resolvedPlcSheetUrl,
+                plcId: plcOptions.plcMode ? plcOptions.plcId : undefined,
+                plcName: resolvedPlcName,
               },
               'paused',
               derived.classIds,

--- a/components/widgets/QuizWidget/Widget.tsx
+++ b/components/widgets/QuizWidget/Widget.tsx
@@ -43,7 +43,7 @@ import { SCOREBOARD_COLORS } from '@/config/scoreboard';
 import { deriveSessionTargetsFromRosters } from '@/utils/resolveAssignmentTargets';
 import { usePlcs } from '@/hooks/usePlcs';
 import { QuizDriveService } from '@/utils/quizDriveService';
-import { getPlcTeammateEmails } from '@/utils/plc';
+import { getPlcMemberEmails, getPlcTeammateEmails } from '@/utils/plc';
 
 export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
   const {
@@ -646,10 +646,14 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
           updateWidget(widget.id, {
             config: { ...config, plcSheetUrl: newUrl } as QuizConfig,
           });
-          if (config.activeAssignmentId) {
+          if (config.activeAssignmentId && activeAssignment?.plc) {
             try {
+              // Persist the full PlcLinkage with the new sheetUrl —
+              // Firestore replaces the entire `plc` field on update, so
+              // we have to carry every other field through to avoid
+              // wiping the linkage.
               await updateAssignmentSettings(config.activeAssignmentId, {
-                plcSheetUrl: newUrl,
+                plc: { ...activeAssignment.plc, sheetUrl: newUrl },
               });
             } catch (err) {
               console.error(
@@ -907,7 +911,43 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
           const resolvedPlcName = plcOptions.plcMode
             ? plcs.find((p) => p.id === plcOptions.plcId)?.name
             : undefined;
+          if (plcOptions.plcMode && plcOptions.plcId && !resolvedPlcName) {
+            // Cold-load race: `plcs` snapshot hasn't hydrated yet, so the
+            // PLC name won't be persisted onto the assignment doc. The
+            // downstream non-member toast guard requires both plcId AND
+            // plcName, so a missing snapshot silently disables the toast
+            // for downstream non-member importers.
+            console.warn(
+              '[QuizWidget] PLC name unresolved at assignment-create time — downstream non-member toast will be skipped',
+              { plcId: plcOptions.plcId }
+            );
+          }
 
+          // Build the PlcLinkage sub-object iff the teacher opted into PLC
+          // mode AND we successfully resolved every required field. Partial
+          // resolution (e.g. cold-load race losing the PLC name) falls
+          // back to non-PLC linkage rather than persisting a degraded
+          // shape — the read mapper would strip it on next load anyway.
+          const selectedPlc = plcOptions.plcMode
+            ? plcs.find((p) => p.id === plcOptions.plcId)
+            : undefined;
+          const plcLinkage =
+            plcOptions.plcMode &&
+            plcOptions.plcId &&
+            resolvedPlcName &&
+            resolvedPlcSheetUrl
+              ? {
+                  id: plcOptions.plcId,
+                  name: resolvedPlcName,
+                  sheetUrl: resolvedPlcSheetUrl,
+                  // Snapshot the full PLC roster (including self) so the
+                  // share doc carries enough info for downstream importers
+                  // to render the membership list without a separate read.
+                  memberEmails: selectedPlc
+                    ? getPlcMemberEmails(selectedPlc)
+                    : [],
+                }
+              : undefined;
           try {
             const { id: assignmentId, code } = await createAssignment(
               {
@@ -920,14 +960,11 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
                 sessionMode: mode,
                 sessionOptions,
                 attemptLimit,
-                plcMode: plcOptions.plcMode,
                 teacherName: plcOptions.teacherName,
                 periodName:
                   plcOptions.periodNames?.[0] ?? plcOptions.periodName,
                 periodNames: plcOptions.periodNames,
-                plcSheetUrl: resolvedPlcSheetUrl,
-                plcId: plcOptions.plcMode ? plcOptions.plcId : undefined,
-                plcName: resolvedPlcName,
+                plc: plcLinkage,
               },
               'paused',
               derived.classIds,
@@ -1198,8 +1235,8 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
               periodName: a.periodName ?? '',
               periodNames: a.periodNames ?? [],
               teacherName: a.teacherName ?? '',
-              plcMode: a.plcMode,
-              plcSheetUrl: a.plcSheetUrl ?? '',
+              plcMode: !!a.plc,
+              plcSheetUrl: a.plc?.sheetUrl ?? '',
             } as QuizConfig,
           });
         }}
@@ -1245,8 +1282,8 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
               periodName: a.periodName ?? '',
               periodNames: a.periodNames ?? [],
               teacherName: a.teacherName ?? '',
-              plcMode: a.plcMode,
-              plcSheetUrl: a.plcSheetUrl ?? '',
+              plcMode: !!a.plc,
+              plcSheetUrl: a.plc?.sheetUrl ?? '',
             } as QuizConfig,
           });
         }}

--- a/components/widgets/QuizWidget/components/QuizAssignmentSettingsModal.tsx
+++ b/components/widgets/QuizWidget/components/QuizAssignmentSettingsModal.tsx
@@ -163,10 +163,18 @@ export const QuizAssignmentSettingsModal: React.FC<
     // a valid PLC linkage — that breaks sharing/membership checks and sheet
     // export. The teacher should re-run assignment-create to acquire a real
     // linkage. (Copilot review on PR #1442.)
+    //
+    // Empty `trimmedSheetUrl` is a Hide / cancel: the user collapsed the
+    // manual-attach disclosure, which clears the form input. We keep the
+    // assignment's existing `plc` unchanged rather than overwriting
+    // `sheetUrl` with `''` — the empty value would be dropped by the
+    // read-side validator on next snapshot and silently lose PLC mode.
     const trimmedSheetUrl = options.plcSheetUrl.trim();
     const plcPatch: QuizAssignmentSettings['plc'] =
       options.plcMode && assignment.plc
-        ? { ...assignment.plc, sheetUrl: trimmedSheetUrl }
+        ? trimmedSheetUrl === ''
+          ? assignment.plc
+          : { ...assignment.plc, sheetUrl: trimmedSheetUrl }
         : undefined;
     const patch: Partial<QuizAssignmentSettings> = {
       className: options.className.trim(),

--- a/components/widgets/QuizWidget/components/QuizAssignmentSettingsModal.tsx
+++ b/components/widgets/QuizWidget/components/QuizAssignmentSettingsModal.tsx
@@ -157,21 +157,17 @@ export const QuizAssignmentSettingsModal: React.FC<
     // entirely. The current `assignment.plc` is the safe carrier — it was
     // either set at create time (Widget.tsx → createAssignment) or by a
     // prior save through this modal.
+    // Only patch `plc` when we have a real existing linkage to overlay onto.
+    // Toggling PLC mode on without an `assignment.plc` record would persist
+    // a placeholder with empty `id`/`name`, which downstream code treats as
+    // a valid PLC linkage — that breaks sharing/membership checks and sheet
+    // export. The teacher should re-run assignment-create to acquire a real
+    // linkage. (Copilot review on PR #1442.)
     const trimmedSheetUrl = options.plcSheetUrl.trim();
-    const plcPatch: QuizAssignmentSettings['plc'] = options.plcMode
-      ? assignment.plc
+    const plcPatch: QuizAssignmentSettings['plc'] =
+      options.plcMode && assignment.plc
         ? { ...assignment.plc, sheetUrl: trimmedSheetUrl }
-        : // No prior linkage to inherit from. Write a degraded-shape
-          // placeholder; the read mapper will strip it on next load
-          // since `id` and `name` are empty. The teacher should rerun
-          // assignment-create to get a real linkage.
-          {
-            id: '',
-            name: '',
-            sheetUrl: trimmedSheetUrl,
-            memberEmails: [],
-          }
-      : undefined;
+        : undefined;
     const patch: Partial<QuizAssignmentSettings> = {
       className: options.className.trim(),
       sessionMode: modeLocked ? assignment.sessionMode : sessionMode,

--- a/components/widgets/QuizWidget/components/QuizAssignmentSettingsModal.tsx
+++ b/components/widgets/QuizWidget/components/QuizAssignmentSettingsModal.tsx
@@ -76,10 +76,10 @@ function initialOptionsFor(a: QuizAssignment): SettingsOptions {
     // Legacy assignments have no attemptLimit — preserve "unlimited" for
     // those rather than retroactively capping ongoing sessions.
     attemptLimit: a.attemptLimit ?? null,
-    plcMode: a.plcMode ?? false,
+    plcMode: !!a.plc,
     teacherName: a.teacherName ?? '',
     selectedPeriodNames: a.periodNames ?? (a.periodName ? [a.periodName] : []),
-    plcSheetUrl: a.plcSheetUrl ?? '',
+    plcSheetUrl: a.plc?.sheetUrl ?? '',
   };
 }
 
@@ -124,7 +124,7 @@ export const QuizAssignmentSettingsModal: React.FC<
   // URL is already attached (legacy assignments / explicit overrides),
   // because new PLC assignments auto-create and share a sheet.
   const [showSheetUrl, setShowSheetUrl] = useState(
-    Boolean(assignment.plcSheetUrl)
+    Boolean(assignment.plc?.sheetUrl)
   );
 
   const plcSheetUrlInvalid =
@@ -150,16 +150,37 @@ export const QuizAssignmentSettingsModal: React.FC<
     // Intentionally pass empty strings (not undefined) so that clearing a
     // field actually writes '' to Firestore. Using `|| undefined` would cause
     // updateDoc to skip the field and leave the previous value in place.
+    //
+    // PLC linkage rebuild rules: when the toggle is on, carry the current
+    // linkage's id/name/memberEmails through and overlay the (possibly
+    // edited) sheet URL. When off, write `undefined` to clear the linkage
+    // entirely. The current `assignment.plc` is the safe carrier — it was
+    // either set at create time (Widget.tsx → createAssignment) or by a
+    // prior save through this modal.
+    const trimmedSheetUrl = options.plcSheetUrl.trim();
+    const plcPatch: QuizAssignmentSettings['plc'] = options.plcMode
+      ? assignment.plc
+        ? { ...assignment.plc, sheetUrl: trimmedSheetUrl }
+        : // No prior linkage to inherit from. Write a degraded-shape
+          // placeholder; the read mapper will strip it on next load
+          // since `id` and `name` are empty. The teacher should rerun
+          // assignment-create to get a real linkage.
+          {
+            id: '',
+            name: '',
+            sheetUrl: trimmedSheetUrl,
+            memberEmails: [],
+          }
+      : undefined;
     const patch: Partial<QuizAssignmentSettings> = {
       className: options.className.trim(),
       sessionMode: modeLocked ? assignment.sessionMode : sessionMode,
       sessionOptions,
       attemptLimit: options.attemptLimit,
-      plcMode: options.plcMode,
+      plc: plcPatch,
       teacherName: options.teacherName.trim(),
       periodName: options.selectedPeriodNames[0] ?? '',
       periodNames: options.selectedPeriodNames,
-      plcSheetUrl: options.plcSheetUrl.trim(),
     };
     try {
       await onSave(patch);

--- a/components/widgets/QuizWidget/components/QuizLiveMonitor.tsx
+++ b/components/widgets/QuizWidget/components/QuizLiveMonitor.tsx
@@ -1325,41 +1325,42 @@ export const QuizLiveMonitor: React.FC<QuizLiveMonitorProps> = ({
                         .sort((a, b) =>
                           (a.pin ?? '').localeCompare(b.pin ?? '')
                         )
-                        .map((r) => (
-                          <StudentRow
-                            key={r.studentUid}
-                            response={r}
-                            totalQuestions={session.totalQuestions}
-                            questions={quizData.questions}
-                            currentQuestion={currentQ}
-                            showAnswerColors={showAnswerColors}
-                            showTabWarnings={
-                              showTabWarnings &&
-                              session.tabWarningsEnabled !== false
-                            }
-                            confirmRemove={confirmRemove === r.studentUid}
-                            onConfirmRemoveToggle={() =>
-                              setConfirmRemove(
-                                confirmRemove === r.studentUid
-                                  ? null
-                                  : r.studentUid
-                              )
-                            }
-                            onRemove={
-                              onRemoveStudent
-                                ? () => {
-                                    void Promise.resolve(
-                                      onRemoveStudent(getResponseDocKey(r))
-                                    )
-                                      .then(() => setConfirmRemove(null))
-                                      .catch(() => undefined);
-                                  }
-                                : undefined
-                            }
-                            pinToName={pinToName}
-                            byStudentUid={byStudentUid}
-                          />
-                        ))}
+                        .map((r) => {
+                          const rowKey = getResponseDocKey(r);
+                          return (
+                            <StudentRow
+                              key={rowKey}
+                              response={r}
+                              totalQuestions={session.totalQuestions}
+                              questions={quizData.questions}
+                              currentQuestion={currentQ}
+                              showAnswerColors={showAnswerColors}
+                              showTabWarnings={
+                                showTabWarnings &&
+                                session.tabWarningsEnabled !== false
+                              }
+                              confirmRemove={confirmRemove === rowKey}
+                              onConfirmRemoveToggle={() =>
+                                setConfirmRemove(
+                                  confirmRemove === rowKey ? null : rowKey
+                                )
+                              }
+                              onRemove={
+                                onRemoveStudent
+                                  ? () => {
+                                      void Promise.resolve(
+                                        onRemoveStudent(rowKey)
+                                      )
+                                        .then(() => setConfirmRemove(null))
+                                        .catch(() => undefined);
+                                    }
+                                  : undefined
+                              }
+                              pinToName={pinToName}
+                              byStudentUid={byStudentUid}
+                            />
+                          );
+                        })}
                     </div>
                   )}
                 </div>
@@ -1706,41 +1707,42 @@ export const QuizLiveMonitor: React.FC<QuizLiveMonitorProps> = ({
                         .sort((a, b) =>
                           (a.pin ?? '').localeCompare(b.pin ?? '')
                         )
-                        .map((r) => (
-                          <StudentRow
-                            key={r.studentUid}
-                            response={r}
-                            totalQuestions={session.totalQuestions}
-                            questions={quizData.questions}
-                            currentQuestion={currentQ}
-                            showAnswerColors={showAnswerColors}
-                            showTabWarnings={
-                              showTabWarnings &&
-                              session.tabWarningsEnabled !== false
-                            }
-                            confirmRemove={confirmRemove === r.studentUid}
-                            onConfirmRemoveToggle={() =>
-                              setConfirmRemove(
-                                confirmRemove === r.studentUid
-                                  ? null
-                                  : r.studentUid
-                              )
-                            }
-                            onRemove={
-                              onRemoveStudent
-                                ? () => {
-                                    void Promise.resolve(
-                                      onRemoveStudent(getResponseDocKey(r))
-                                    )
-                                      .then(() => setConfirmRemove(null))
-                                      .catch(() => undefined);
-                                  }
-                                : undefined
-                            }
-                            pinToName={pinToName}
-                            byStudentUid={byStudentUid}
-                          />
-                        ))}
+                        .map((r) => {
+                          const rowKey = getResponseDocKey(r);
+                          return (
+                            <StudentRow
+                              key={rowKey}
+                              response={r}
+                              totalQuestions={session.totalQuestions}
+                              questions={quizData.questions}
+                              currentQuestion={currentQ}
+                              showAnswerColors={showAnswerColors}
+                              showTabWarnings={
+                                showTabWarnings &&
+                                session.tabWarningsEnabled !== false
+                              }
+                              confirmRemove={confirmRemove === rowKey}
+                              onConfirmRemoveToggle={() =>
+                                setConfirmRemove(
+                                  confirmRemove === rowKey ? null : rowKey
+                                )
+                              }
+                              onRemove={
+                                onRemoveStudent
+                                  ? () => {
+                                      void Promise.resolve(
+                                        onRemoveStudent(rowKey)
+                                      )
+                                        .then(() => setConfirmRemove(null))
+                                        .catch(() => undefined);
+                                    }
+                                  : undefined
+                              }
+                              pinToName={pinToName}
+                              byStudentUid={byStudentUid}
+                            />
+                          );
+                        })}
                     </div>
                   )}
                 </div>

--- a/components/widgets/QuizWidget/components/QuizLiveMonitor.tsx
+++ b/components/widgets/QuizWidget/components/QuizLiveMonitor.tsx
@@ -46,7 +46,11 @@ import {
   QuizConfig,
   ClassRoster,
 } from '@/types';
-import { gradeAnswer, getResponseDocKey } from '@/hooks/useQuizSession';
+import {
+  gradeAnswer,
+  getResponseDocKey,
+  type ResponseDocKey,
+} from '@/hooks/useQuizSession';
 import {
   buildLiveLeaderboard,
   buildPinToNameMap,
@@ -329,7 +333,9 @@ export const QuizLiveMonitor: React.FC<QuizLiveMonitorProps> = ({
   // New state for Phase 1 & 2 features
   const [showAnswerColors, setShowAnswerColors] = useState(false);
   const [showTabWarnings, setShowTabWarnings] = useState(true);
-  const [confirmRemove, setConfirmRemove] = useState<string | null>(null);
+  const [confirmRemove, setConfirmRemove] = useState<ResponseDocKey | null>(
+    null
+  );
   const [soundMuted, setSoundMuted] = useState(false);
   const [expandedStat, setExpandedStat] = useState<
     'joined' | 'active' | 'finished' | null

--- a/components/widgets/QuizWidget/components/QuizManager.tsx
+++ b/components/widgets/QuizWidget/components/QuizManager.tsx
@@ -684,12 +684,6 @@ export const QuizManager: React.FC<QuizManagerProps> = ({
       onClick: () => void (onArchiveReopen ?? noop)(a),
     });
     secondaries.push({
-      id: 'reopen',
-      label: 'Reopen',
-      icon: RefreshCw,
-      onClick: () => (onArchiveReopen ?? noop)(a),
-    });
-    secondaries.push({
       id: 'delete',
       label: 'Delete',
       icon: Trash2,

--- a/components/widgets/QuizWidget/components/QuizResults.tsx
+++ b/components/widgets/QuizWidget/components/QuizResults.tsx
@@ -293,6 +293,84 @@ export const QuizResults: React.FC<QuizResultsProps> = ({
     }
   }, [completed.length, hasNames, addToast, handleSendToScoreboard]);
 
+  // Stale PLC sheet recovery, shared by handleExport and handleUpdateSheet.
+  //   - 404 = the sheet is gone in Drive. Clear cached URL on the owning
+  //     PLC, create a fresh sheet in this teacher's Drive, share with
+  //     teammates, return the new URL so the caller retries. Safe because
+  //     no one else has a working URL either.
+  //   - 403 = the sheet exists, but THIS teacher lacks access. Almost
+  //     always a member who joined after the sheet was created and
+  //     reconciliation hasn't run. Do NOT regenerate — that would orphan
+  //     the existing sheet for every teammate who can still reach it.
+  //     Surface a clear "ask the PLC lead for access" toast and rethrow
+  //     so the caller stops.
+  //
+  // Returns the new canonical URL on a successful 404 regenerate, or
+  // rethrows otherwise. Caller is responsible for retrying with the
+  // returned URL.
+  const recoverFromStalePlcSheet = async (
+    err: unknown,
+    sheetUrl: string,
+    plcMode: boolean | undefined,
+    svc: QuizDriveService
+  ): Promise<string> => {
+    if (
+      !(err instanceof PlcSheetMissingError) ||
+      !plcMode ||
+      !sheetUrl ||
+      !user
+    ) {
+      throw err;
+    }
+    // Use filter + require exactly-one match. `find` would silently pick
+    // the first when two PLCs accidentally share the same URL (legacy
+    // manual-paste assignments); we'd rather surface the original error
+    // than touch the wrong plcs/{id}.
+    const matchingPlcs = plcs.filter((p) => p.sharedSheetUrl === sheetUrl);
+    const owningPlc = matchingPlcs.length === 1 ? matchingPlcs[0] : null;
+    if (err.status === 403) {
+      // Rethrow with the actionable message so the inline banner matches
+      // the toast — the raw PlcSheetMissingError message ("Shared PLC
+      // sheet is missing or inaccessible.") would be confusing here since
+      // the sheet isn't actually missing, this user just lacks writer access.
+      const accessDeniedMessage = owningPlc
+        ? `You don't have access to the ${owningPlc.name} PLC sheet yet — ask the PLC lead to grant you writer access.`
+        : "You don't have access to this PLC sheet — ask the PLC lead to grant you writer access.";
+      addToast(accessDeniedMessage, 'error');
+      throw new Error(accessDeniedMessage);
+    }
+    // 404 → regenerate, but only when we can pin the URL to a single PLC.
+    // Multiple matches → ambiguous, no match → we don't know which
+    // plcs/{id} to update.
+    if (!owningPlc) {
+      throw err;
+    }
+    await clearPlcSharedSheetUrl(owningPlc.id);
+    const created = await svc.createPlcSheetAndShare({
+      plcName: owningPlc.name,
+      memberEmailsToShareWith: getPlcTeammateEmails(owningPlc, user.uid),
+    });
+    const canonical = await setPlcSharedSheetUrl(owningPlc.id, created.url);
+    // Persist the new canonical URL onto the widget config + active
+    // assignment so the next export doesn't re-trigger the 404 path
+    // against the stale URL still cached on those docs.
+    if (onPlcSheetUrlReplaced) {
+      try {
+        await onPlcSheetUrlReplaced(canonical);
+      } catch (persistErr) {
+        console.error(
+          '[QuizResults] Failed to persist regenerated PLC URL:',
+          persistErr
+        );
+      }
+    }
+    addToast(
+      'The previous PLC sheet was missing — created a fresh one.',
+      'info'
+    );
+    return canonical;
+  };
+
   const handleExport = async () => {
     if (!googleAccessToken) {
       setExportError(
@@ -321,79 +399,17 @@ export const QuizResults: React.FC<QuizResultsProps> = ({
           exportOpts
         );
       } catch (exportErr) {
-        // Stale PLC sheet recovery, narrow:
-        //   - 404 = the sheet is gone in Drive. Clear cached URL on the
-        //     owning PLC, create a fresh sheet in this teacher's Drive,
-        //     share with teammates, retry. Safe because no one else has
-        //     a working URL either.
-        //   - 403 = the sheet exists, but THIS teacher lacks access.
-        //     Almost always means they're a member who joined after the
-        //     sheet was created and reconciliation hasn't run / failed.
-        //     Do NOT regenerate — that would orphan the existing sheet
-        //     for every teammate who can still reach it. Instead surface
-        //     a clear "ask the PLC lead for access" toast.
-        if (
-          !(exportErr instanceof PlcSheetMissingError) ||
-          !config.plcMode ||
-          !config.plcSheetUrl ||
-          !user
-        ) {
-          throw exportErr;
-        }
-        // Use filter + require exactly-one match. `find` would silently
-        // pick the first when two PLCs accidentally share the same URL
-        // (legacy manual-paste assignments); we'd rather surface the
-        // original error than touch the wrong plcs/{id}.
-        const matchingPlcs = plcs.filter(
-          (p) => p.sharedSheetUrl === config.plcSheetUrl
+        const canonical = await recoverFromStalePlcSheet(
+          exportErr,
+          config.plcSheetUrl ?? '',
+          config.plcMode,
+          svc
         );
-        const owningPlc = matchingPlcs.length === 1 ? matchingPlcs[0] : null;
-        if (exportErr.status === 403) {
-          // Rethrow with the actionable message so the inline export
-          // banner matches the toast — the raw PlcSheetMissingError
-          // message ("Shared PLC sheet is missing or inaccessible.")
-          // would be confusing here since the sheet isn't actually
-          // missing, this user just lacks writer access.
-          const accessDeniedMessage = owningPlc
-            ? `You don't have access to the ${owningPlc.name} PLC sheet yet — ask the PLC lead to grant you writer access.`
-            : "You don't have access to this PLC sheet — ask the PLC lead to grant you writer access.";
-          addToast(accessDeniedMessage, 'error');
-          throw new Error(accessDeniedMessage);
-        }
-        // 404 → regenerate, but only when we can pin the URL to a single
-        // PLC. Multiple matches → ambiguous, single none → we don't know
-        // which plcs/{id} to update.
-        if (!owningPlc) {
-          throw exportErr;
-        }
-        await clearPlcSharedSheetUrl(owningPlc.id);
-        const created = await svc.createPlcSheetAndShare({
-          plcName: owningPlc.name,
-          memberEmailsToShareWith: getPlcTeammateEmails(owningPlc, user.uid),
-        });
-        const canonical = await setPlcSharedSheetUrl(owningPlc.id, created.url);
-        // Persist the new canonical URL onto the widget config + active
-        // assignment so the next export doesn't re-trigger the 404 path
-        // against the stale URL still cached on those docs.
-        if (onPlcSheetUrlReplaced) {
-          try {
-            await onPlcSheetUrlReplaced(canonical);
-          } catch (persistErr) {
-            console.error(
-              '[QuizResults] Failed to persist regenerated PLC URL:',
-              persistErr
-            );
-          }
-        }
         url = await svc.exportResultsToSheet(
           quiz.title,
           responses,
           quiz.questions,
           { ...exportOpts, plcSheetUrl: canonical }
-        );
-        addToast(
-          'The previous PLC sheet was missing — created a fresh one.',
-          'info'
         );
       }
       setExportUrl(url);
@@ -416,14 +432,23 @@ export const QuizResults: React.FC<QuizResultsProps> = ({
         });
       }
       if (onExportedResponseIdsSaved) {
-        void Promise.resolve(onExportedResponseIdsSaved(exportedIds)).catch(
-          (err: unknown) => {
-            console.warn(
-              '[QuizResults] failed to persist exportedResponseIds to assignment doc',
-              err
-            );
-          }
-        );
+        // Await so a silent persistence failure can be surfaced. If we
+        // returned early on the void promise, a reload would re-seed
+        // exportedResponseIds from stale Firestore and the next UPDATE
+        // SHEET would re-append already-exported rows.
+        try {
+          await Promise.resolve(onExportedResponseIdsSaved(exportedIds));
+        } catch (saveErr) {
+          console.warn(
+            '[QuizResults] failed to persist exportedResponseIds to assignment doc',
+            saveErr
+          );
+          addToast(
+            "Sheet exported, but couldn't record which rows were exported. " +
+              'Reload before tapping UPDATE SHEET to avoid duplicate rows.',
+            'error'
+          );
+        }
       }
       if (config.plcMode) {
         addToast('Results exported to shared PLC sheet', 'success');
@@ -453,39 +478,70 @@ export const QuizResults: React.FC<QuizResultsProps> = ({
     setExportError(null);
     try {
       const svc = new QuizDriveService(googleAccessToken);
+      const appendOpts = {
+        pinToName: exportPinToName,
+        byStudentUid,
+        teacherName: config.teacherName,
+        periodName: config.periodName,
+        plcMode: true,
+        plcSheetUrl: exportUrl,
+      };
       // Reuse the PLC-mode append path: it builds the same headers + rows
       // as the original export and uses appendToExistingSheet under the
       // hood. Works whether the original export was solo or PLC — both
       // produce a sheet whose first tab accepts row appends.
-      await svc.exportResultsToSheet(
-        quiz.title,
-        newResponsesToAppend,
-        quiz.questions,
-        {
-          pinToName: exportPinToName,
-          byStudentUid,
-          teacherName: config.teacherName,
-          periodName: config.periodName,
-          plcMode: true,
-          plcSheetUrl: exportUrl,
-        }
-      );
+      let appendUrl = exportUrl;
+      try {
+        await svc.exportResultsToSheet(
+          quiz.title,
+          newResponsesToAppend,
+          quiz.questions,
+          appendOpts
+        );
+      } catch (appendErr) {
+        // Same stale-sheet recovery as the initial export: 404 → regenerate
+        // and retry, 403 → "ask the PLC lead". Without this branch UPDATE
+        // SHEET dead-ends on a stale URL with a raw error message.
+        const canonical = await recoverFromStalePlcSheet(
+          appendErr,
+          exportUrl,
+          config.plcMode,
+          svc
+        );
+        appendUrl = canonical;
+        setExportUrl(canonical);
+        await svc.exportResultsToSheet(
+          quiz.title,
+          newResponsesToAppend,
+          quiz.questions,
+          { ...appendOpts, plcSheetUrl: canonical }
+        );
+      }
       const allIds = responses.map((r) => getResponseDocKey(r));
       setExportedResponseIds(allIds);
+      // Await the save: a silent failure here lets the assignment doc keep
+      // stale exportedResponseIds, so a reload re-seeds in-memory state from
+      // stale Firestore and the next UPDATE SHEET re-appends already-exported
+      // rows into the shared PLC sheet (corrupting it across teammates).
       if (onExportedResponseIdsSaved) {
-        void Promise.resolve(onExportedResponseIdsSaved(allIds)).catch(
-          (err: unknown) => {
-            console.warn(
-              '[QuizResults] failed to persist exportedResponseIds after update',
-              err
-            );
-          }
-        );
+        try {
+          await Promise.resolve(onExportedResponseIdsSaved(allIds));
+        } catch (saveErr) {
+          console.warn(
+            '[QuizResults] failed to persist exportedResponseIds after update',
+            saveErr
+          );
+          addToast(
+            "Sheet updated, but couldn't record which rows were exported. " +
+              'Reload before tapping UPDATE SHEET again to avoid duplicate rows.',
+            'error'
+          );
+        }
       }
       addToast(
         `Added ${newResponsesToAppend.length} new response${
           newResponsesToAppend.length === 1 ? '' : 's'
-        } to the sheet.`,
+        } to the sheet${appendUrl !== exportUrl ? ' (regenerated)' : ''}.`,
         'success'
       );
     } catch (err) {

--- a/components/widgets/QuizWidget/components/QuizResults.tsx
+++ b/components/widgets/QuizWidget/components/QuizResults.tsx
@@ -506,10 +506,12 @@ export const QuizResults: React.FC<QuizResultsProps> = ({
     setExportError(null);
     try {
       const svc = new QuizDriveService(googleAccessToken);
-      // Reuse the PLC-mode append path: it builds the same headers + rows
-      // as the original export and uses appendToExistingSheet under the
-      // hood. Works whether the original export was solo or PLC — both
-      // produce a sheet whose first tab accepts row appends.
+      // Reuse the PLC-mode append path for this PLC-only update flow: it
+      // rebuilds the same headers + rows shape as the original PLC export
+      // and uses appendToExistingSheet under the hood for the linked PLC
+      // sheet. UPDATE SHEET is gated on `config.plcMode` upstream
+      // (`canShowUpdateSheet`) — solo-mode sheets carry a trailing stats
+      // block that would be fragmented by an append.
       const exportOpts = {
         pinToName: exportPinToName,
         byStudentUid,

--- a/components/widgets/QuizWidget/components/QuizResults.tsx
+++ b/components/widgets/QuizWidget/components/QuizResults.tsx
@@ -552,6 +552,22 @@ export const QuizResults: React.FC<QuizResultsProps> = ({
         // Sync local "OPEN SHEET" link to the new sheet so the teacher
         // doesn't click through to the now-stale URL.
         setExportUrl(recovered.canonical);
+        // Persist the regenerated URL onto the assignment doc too —
+        // without this, a reload rehydrates `initialExportUrl` from the
+        // stale dead URL, OPEN SHEET points at the wrong place, and the
+        // next UPDATE SHEET re-triggers the same 404 → regenerate cycle
+        // creating yet another orphan sheet. (Final-review finding on
+        // PR #1442.)
+        if (onExportUrlSaved) {
+          void Promise.resolve(onExportUrlSaved(recovered.canonical)).catch(
+            (persistErr: unknown) => {
+              console.error(
+                '[QuizResults] failed to persist regenerated exportUrl after update',
+                persistErr
+              );
+            }
+          );
+        }
       }
       // After a regenerated-sheet retry the sheet now contains every
       // response (we passed `responses` to retry), so the exported set

--- a/components/widgets/QuizWidget/components/QuizResults.tsx
+++ b/components/widgets/QuizWidget/components/QuizResults.tsx
@@ -38,7 +38,11 @@ import {
   QuizDriveService,
 } from '@/utils/quizDriveService';
 import { getPlcTeammateEmails } from '@/utils/plc';
-import { gradeAnswer, getResponseDocKey } from '@/hooks/useQuizSession';
+import {
+  gradeAnswer,
+  getResponseDocKey,
+  type ResponseDocKey,
+} from '@/hooks/useQuizSession';
 import { useDashboard } from '@/context/useDashboard';
 import {
   buildPinToNameMap,
@@ -96,9 +100,11 @@ interface QuizResultsProps {
   /**
    * Persist the latest set of exported response keys back to the assignment
    * doc so re-entering Results doesn't re-export rows that were already
-   * appended.
+   * appended. Accepts `ResponseDocKey[]` to enforce caller-side correctness
+   * — the implementation re-casts to `string[]` at the Firestore write
+   * boundary (the wire format hasn't changed).
    */
-  onExportedResponseIdsSaved?: (ids: string[]) => Promise<void> | void;
+  onExportedResponseIdsSaved?: (ids: ResponseDocKey[]) => Promise<void> | void;
 }
 
 export const QuizResults: React.FC<QuizResultsProps> = ({
@@ -136,14 +142,23 @@ export const QuizResults: React.FC<QuizResultsProps> = ({
     setLastInitialExportUrl(initialExportUrl);
     setExportUrl(initialExportUrl ?? null);
   }
-  const [exportedResponseIds, setExportedResponseIds] = useState<string[]>(
-    initialExportedResponseIds ?? []
-  );
+  // Internally we use the ResponseDocKey brand to enforce that callers
+  // never confuse a raw `string` with a response-doc key. The wire format
+  // (initialExportedResponseIds prop / Firestore `exportedResponseIds`)
+  // stays `string[]` for backwards compatibility — the cast happens at the
+  // boundary on read; the persist callback (`onExportedResponseIdsSaved`)
+  // accepts `ResponseDocKey[]` so the implementation can re-cast for
+  // Firestore.
+  const [exportedResponseIds, setExportedResponseIds] = useState<
+    ResponseDocKey[]
+  >((initialExportedResponseIds ?? []) as ResponseDocKey[]);
   const [lastInitialExportedResponseIds, setLastInitialExportedResponseIds] =
     useState<string[] | null | undefined>(initialExportedResponseIds);
   if (initialExportedResponseIds !== lastInitialExportedResponseIds) {
     setLastInitialExportedResponseIds(initialExportedResponseIds);
-    setExportedResponseIds(initialExportedResponseIds ?? []);
+    setExportedResponseIds(
+      (initialExportedResponseIds ?? []) as ResponseDocKey[]
+    );
   }
   const [updatingSheet, setUpdatingSheet] = useState(false);
   const [exportError, setExportError] = useState<string | null>(null);
@@ -293,67 +308,60 @@ export const QuizResults: React.FC<QuizResultsProps> = ({
     }
   }, [completed.length, hasNames, addToast, handleSendToScoreboard]);
 
-  // Stale PLC sheet recovery, shared by handleExport and handleUpdateSheet.
-  //   - 404 = the sheet is gone in Drive. Clear cached URL on the owning
-  //     PLC, create a fresh sheet in this teacher's Drive, share with
-  //     teammates, return the new URL so the caller retries. Safe because
-  //     no one else has a working URL either.
-  //   - 403 = the sheet exists, but THIS teacher lacks access. Almost
-  //     always a member who joined after the sheet was created and
-  //     reconciliation hasn't run. Do NOT regenerate — that would orphan
-  //     the existing sheet for every teammate who can still reach it.
-  //     Surface a clear "ask the PLC lead for access" toast and rethrow
-  //     so the caller stops.
-  //
-  // Returns the new canonical URL on a successful 404 regenerate, or
-  // rethrows otherwise. Caller is responsible for retrying with the
-  // returned URL.
-  const recoverFromStalePlcSheet = async (
-    err: unknown,
-    sheetUrl: string,
-    plcMode: boolean | undefined,
-    svc: QuizDriveService
-  ): Promise<string> => {
+  // Recovery path shared by handleExport (initial export) and
+  // handleUpdateSheet (delta append). When the configured PLC sheet is
+  // gone (404) or this teacher lacks access (403):
+  //   - 404 with a uniquely-resolved owning PLC: clear the cached URL,
+  //     create a fresh sheet in this teacher's Drive, share with
+  //     teammates, persist the canonical URL, then re-run the caller's
+  //     export via `retryExport` with the new URL substituted in.
+  //   - 403 with a uniquely-resolved owning PLC: throw a clear
+  //     "ask the PLC lead for access to {plcName}" message — the sheet
+  //     exists, regenerating would orphan it for teammates.
+  //   - Ambiguous matches or no PLC match: re-throw the original error
+  //     so we don't touch the wrong plcs/{id}.
+  // Returns the new sheet URL on successful regenerate, so callers can
+  // sync local state (e.g. `exportUrl`) to the canonical URL.
+  const recoverFromPlcSheetError = async (
+    exportErr: unknown,
+    exportOpts: Parameters<QuizDriveService['exportResultsToSheet']>[3],
+    retryExport: (
+      newOpts: Parameters<QuizDriveService['exportResultsToSheet']>[3]
+    ) => Promise<string>
+  ): Promise<{ url: string; canonical: string }> => {
     if (
-      !(err instanceof PlcSheetMissingError) ||
-      !plcMode ||
-      !sheetUrl ||
-      !user
+      !(exportErr instanceof PlcSheetMissingError) ||
+      !user ||
+      !googleAccessToken ||
+      !exportOpts?.plcSheetUrl
     ) {
-      throw err;
+      throw exportErr;
     }
-    // Use filter + require exactly-one match. `find` would silently pick
-    // the first when two PLCs accidentally share the same URL (legacy
-    // manual-paste assignments); we'd rather surface the original error
-    // than touch the wrong plcs/{id}.
-    const matchingPlcs = plcs.filter((p) => p.sharedSheetUrl === sheetUrl);
+    // Use filter + require exactly-one match. `find` would silently
+    // pick the first when two PLCs accidentally share the same URL
+    // (legacy manual-paste assignments); we'd rather surface the
+    // original error than touch the wrong plcs/{id}.
+    const matchingPlcs = plcs.filter(
+      (p) => p.sharedSheetUrl === exportOpts.plcSheetUrl
+    );
     const owningPlc = matchingPlcs.length === 1 ? matchingPlcs[0] : null;
-    if (err.status === 403) {
-      // Rethrow with the actionable message so the inline banner matches
-      // the toast — the raw PlcSheetMissingError message ("Shared PLC
-      // sheet is missing or inaccessible.") would be confusing here since
-      // the sheet isn't actually missing, this user just lacks writer access.
+    if (exportErr.status === 403) {
       const accessDeniedMessage = owningPlc
         ? `You don't have access to the ${owningPlc.name} PLC sheet yet — ask the PLC lead to grant you writer access.`
         : "You don't have access to this PLC sheet — ask the PLC lead to grant you writer access.";
       addToast(accessDeniedMessage, 'error');
       throw new Error(accessDeniedMessage);
     }
-    // 404 → regenerate, but only when we can pin the URL to a single PLC.
-    // Multiple matches → ambiguous, no match → we don't know which
-    // plcs/{id} to update.
     if (!owningPlc) {
-      throw err;
+      throw exportErr;
     }
+    const svc = new QuizDriveService(googleAccessToken);
     await clearPlcSharedSheetUrl(owningPlc.id);
     const created = await svc.createPlcSheetAndShare({
       plcName: owningPlc.name,
       memberEmailsToShareWith: getPlcTeammateEmails(owningPlc, user.uid),
     });
     const canonical = await setPlcSharedSheetUrl(owningPlc.id, created.url);
-    // Persist the new canonical URL onto the widget config + active
-    // assignment so the next export doesn't re-trigger the 404 path
-    // against the stale URL still cached on those docs.
     if (onPlcSheetUrlReplaced) {
       try {
         await onPlcSheetUrlReplaced(canonical);
@@ -364,11 +372,12 @@ export const QuizResults: React.FC<QuizResultsProps> = ({
         );
       }
     }
+    const url = await retryExport({ ...exportOpts, plcSheetUrl: canonical });
     addToast(
       'The previous PLC sheet was missing — created a fresh one.',
       'info'
     );
-    return canonical;
+    return { url, canonical };
   };
 
   const handleExport = async () => {
@@ -399,18 +408,21 @@ export const QuizResults: React.FC<QuizResultsProps> = ({
           exportOpts
         );
       } catch (exportErr) {
-        const canonical = await recoverFromStalePlcSheet(
+        if (!config.plcMode) {
+          throw exportErr;
+        }
+        const recovered = await recoverFromPlcSheetError(
           exportErr,
-          config.plcSheetUrl ?? '',
-          config.plcMode,
-          svc
+          exportOpts,
+          (newOpts) =>
+            svc.exportResultsToSheet(
+              quiz.title,
+              responses,
+              quiz.questions,
+              newOpts
+            )
         );
-        url = await svc.exportResultsToSheet(
-          quiz.title,
-          responses,
-          quiz.questions,
-          { ...exportOpts, plcSheetUrl: canonical }
-        );
+        url = recovered.url;
       }
       setExportUrl(url);
       // Snapshot every response key we just exported so the UPDATE SHEET
@@ -418,36 +430,32 @@ export const QuizResults: React.FC<QuizResultsProps> = ({
       const exportedIds = responses.map((r) => getResponseDocKey(r));
       setExportedResponseIds(exportedIds);
       if (onExportUrlSaved) {
-        // Fire-and-forget: the sheet already exists and the local button is
-        // wired up for this session, so we don't want to keep `exporting`
-        // true (and delay the success toast) waiting on a Firestore round
-        // trip. A failed persist just means the button reverts to EXPORT
-        // on the next remount; log so the teacher isn't surprised without
-        // any diagnostic trail.
+        // Fire-and-forget: lower-stakes than the exported-IDs persist
+        // below. Worst case the button reverts to EXPORT on next remount.
         void Promise.resolve(onExportUrlSaved(url)).catch((err: unknown) => {
-          console.warn(
+          console.error(
             '[QuizResults] failed to persist exportUrl to assignment doc',
             err
           );
         });
       }
       if (onExportedResponseIdsSaved) {
-        // Await so a silent persistence failure can be surfaced. If we
-        // returned early on the void promise, a reload would re-seed
-        // exportedResponseIds from stale Firestore and the next UPDATE
-        // SHEET would re-append already-exported rows.
+        // Await: a failed persist here means the assignment doc keeps
+        // stale exported IDs. Next session re-seeds from stale Firestore
+        // and UPDATE SHEET re-appends already-exported rows. Surface a
+        // warning toast and don't claim success.
         try {
-          await Promise.resolve(onExportedResponseIdsSaved(exportedIds));
-        } catch (saveErr) {
-          console.warn(
+          await onExportedResponseIdsSaved(exportedIds);
+        } catch (persistErr) {
+          console.error(
             '[QuizResults] failed to persist exportedResponseIds to assignment doc',
-            saveErr
+            persistErr
           );
           addToast(
-            "Sheet exported, but couldn't record which rows were exported. " +
-              'Reload before tapping UPDATE SHEET to avoid duplicate rows.',
+            'Export succeeded, but we could not record which rows were saved. Avoid using UPDATE SHEET in this session.',
             'error'
           );
+          return;
         }
       }
       if (config.plcMode) {
@@ -466,6 +474,21 @@ export const QuizResults: React.FC<QuizResultsProps> = ({
     return responses.filter((r) => !exportedSet.has(getResponseDocKey(r)));
   }, [exportUrl, exportedResponseIds, responses]);
 
+  // Tracking is "initialized" once a per-response export-id snapshot exists
+  // for this assignment. Two cases set it: (1) the prop hydrated with a
+  // non-null array from Firestore, (2) we just ran an in-session export which
+  // populated `exportedResponseIds` locally. Without tracking, an UPDATE
+  // SHEET click would treat the empty set as "everything is new" and
+  // duplicate-append every row to the sheet — see Copilot review on PR #1442.
+  const trackingInitialized =
+    exportedResponseIds.length > 0 || initialExportedResponseIds != null;
+  // Solo-mode export sheets carry a "Question Analysis" stats block at the
+  // bottom (see quizDriveService.exportResultsToSheet solo branch). Appending
+  // would land NEW response rows AFTER the stats, fragmenting the sheet.
+  // PLC-mode sheets are append-friendly by construction (Results tab is
+  // header + rows, no trailing blocks).
+  const canShowUpdateSheet = !!config.plcMode && trackingInitialized;
+
   const handleUpdateSheet = async () => {
     if (!exportUrl || newResponsesToAppend.length === 0) return;
     if (!googleAccessToken) {
@@ -478,7 +501,11 @@ export const QuizResults: React.FC<QuizResultsProps> = ({
     setExportError(null);
     try {
       const svc = new QuizDriveService(googleAccessToken);
-      const appendOpts = {
+      // Reuse the PLC-mode append path: it builds the same headers + rows
+      // as the original export and uses appendToExistingSheet under the
+      // hood. Works whether the original export was solo or PLC — both
+      // produce a sheet whose first tab accepts row appends.
+      const exportOpts = {
         pinToName: exportPinToName,
         byStudentUid,
         teacherName: config.teacherName,
@@ -486,62 +513,72 @@ export const QuizResults: React.FC<QuizResultsProps> = ({
         plcMode: true,
         plcSheetUrl: exportUrl,
       };
-      // Reuse the PLC-mode append path: it builds the same headers + rows
-      // as the original export and uses appendToExistingSheet under the
-      // hood. Works whether the original export was solo or PLC — both
-      // produce a sheet whose first tab accepts row appends.
-      let appendUrl = exportUrl;
+      let regeneratedSheet = false;
       try {
         await svc.exportResultsToSheet(
           quiz.title,
           newResponsesToAppend,
           quiz.questions,
-          appendOpts
+          exportOpts
         );
-      } catch (appendErr) {
-        // Same stale-sheet recovery as the initial export: 404 → regenerate
-        // and retry, 403 → "ask the PLC lead". Without this branch UPDATE
-        // SHEET dead-ends on a stale URL with a raw error message.
-        const canonical = await recoverFromStalePlcSheet(
-          appendErr,
-          exportUrl,
-          config.plcMode,
-          svc
+      } catch (updateErr) {
+        // Only attempt PLC recovery for PLC-linked sheets; a solo sheet
+        // 404/403 has no plcs/{id} to update and we should surface as-is.
+        if (!config.plcMode) {
+          throw updateErr;
+        }
+        const recovered = await recoverFromPlcSheetError(
+          updateErr,
+          exportOpts,
+          (newOpts) =>
+            // The regenerated sheet is empty, so we re-export ALL
+            // responses (not just the previously-pending delta). The
+            // exportedResponseIds reset below mirrors that.
+            svc.exportResultsToSheet(
+              quiz.title,
+              responses,
+              quiz.questions,
+              newOpts
+            )
         );
-        appendUrl = canonical;
-        setExportUrl(canonical);
-        await svc.exportResultsToSheet(
-          quiz.title,
-          newResponsesToAppend,
-          quiz.questions,
-          { ...appendOpts, plcSheetUrl: canonical }
-        );
+        regeneratedSheet = true;
+        // Sync local "OPEN SHEET" link to the new sheet so the teacher
+        // doesn't click through to the now-stale URL.
+        setExportUrl(recovered.canonical);
       }
+      // After a regenerated-sheet retry the sheet now contains every
+      // response (we passed `responses` to retry), so the exported set
+      // is the full list. The non-recovery path also lands here with
+      // the same all-IDs snapshot — newResponsesToAppend was the delta
+      // BEFORE the append, so post-append the union is every response.
       const allIds = responses.map((r) => getResponseDocKey(r));
       setExportedResponseIds(allIds);
-      // Await the save: a silent failure here lets the assignment doc keep
-      // stale exportedResponseIds, so a reload re-seeds in-memory state from
-      // stale Firestore and the next UPDATE SHEET re-appends already-exported
-      // rows into the shared PLC sheet (corrupting it across teammates).
       if (onExportedResponseIdsSaved) {
+        // Await: same rationale as handleExport — fire-and-forget here
+        // would let UPDATE SHEET silently re-append duplicate rows on
+        // the next session if the persist fails.
         try {
-          await Promise.resolve(onExportedResponseIdsSaved(allIds));
-        } catch (saveErr) {
-          console.warn(
+          await onExportedResponseIdsSaved(allIds);
+        } catch (persistErr) {
+          console.error(
             '[QuizResults] failed to persist exportedResponseIds after update',
-            saveErr
+            persistErr
           );
           addToast(
-            "Sheet updated, but couldn't record which rows were exported. " +
-              'Reload before tapping UPDATE SHEET again to avoid duplicate rows.',
+            'Update succeeded, but we could not record which rows were saved. Avoid using UPDATE SHEET again in this session.',
             'error'
           );
+          return;
         }
       }
       addToast(
-        `Added ${newResponsesToAppend.length} new response${
-          newResponsesToAppend.length === 1 ? '' : 's'
-        } to the sheet${appendUrl !== exportUrl ? ' (regenerated)' : ''}.`,
+        regeneratedSheet
+          ? `The previous PLC sheet was missing — created a fresh one and exported all ${responses.length} response${
+              responses.length === 1 ? '' : 's'
+            }.`
+          : `Added ${newResponsesToAppend.length} new response${
+              newResponsesToAppend.length === 1 ? '' : 's'
+            } to the sheet.`,
         'success'
       );
     } catch (err) {
@@ -690,48 +727,69 @@ export const QuizResults: React.FC<QuizResultsProps> = ({
               />
               OPEN SHEET
             </a>
-            <button
-              onClick={() => void handleUpdateSheet()}
-              disabled={updatingSheet || newResponsesToAppend.length === 0}
-              title={
-                newResponsesToAppend.length === 0
-                  ? 'Sheet is up to date'
-                  : `Add ${newResponsesToAppend.length} new response${
-                      newResponsesToAppend.length === 1 ? '' : 's'
-                    } to the sheet`
-              }
-              className="flex items-center bg-brand-blue-primary hover:bg-brand-blue-dark disabled:bg-brand-gray-lighter disabled:cursor-not-allowed text-white font-bold rounded-xl transition-all shadow-md active:scale-95 shrink-0"
-              style={{
-                gap: 'min(6px, 1.5cqmin)',
-                padding: 'min(8px, 2cqmin) min(12px, 3cqmin)',
-                fontSize: 'min(11px, 3.5cqmin)',
-              }}
-            >
-              {updatingSheet ? (
-                <Loader2 className="w-4 h-4 animate-spin" />
-              ) : (
-                <RefreshCw
+            {canShowUpdateSheet && (
+              // Wrapping span owns the title attribute so the "Sheet is up
+              // to date" hover hint still renders when the button itself
+              // is disabled — most browsers swallow `title` on disabled
+              // <button> elements (Copilot review on PR #1442).
+              <span
+                title={
+                  newResponsesToAppend.length === 0
+                    ? 'Sheet is up to date'
+                    : `Add ${newResponsesToAppend.length} new response${
+                        newResponsesToAppend.length === 1 ? '' : 's'
+                      } to the sheet`
+                }
+                className="shrink-0 inline-flex"
+              >
+                <button
+                  onClick={() => void handleUpdateSheet()}
+                  disabled={updatingSheet || newResponsesToAppend.length === 0}
+                  aria-label={
+                    newResponsesToAppend.length === 0
+                      ? 'Update sheet (already up to date)'
+                      : `Update sheet (${newResponsesToAppend.length} pending)`
+                  }
+                  className="flex items-center bg-brand-blue-primary hover:bg-brand-blue-dark disabled:opacity-50 disabled:cursor-not-allowed text-white font-bold rounded-xl transition-all shadow-md active:scale-95"
                   style={{
-                    width: 'min(14px, 4cqmin)',
-                    height: 'min(14px, 4cqmin)',
-                  }}
-                />
-              )}
-              UPDATE SHEET
-              {newResponsesToAppend.length > 0 && (
-                <span
-                  className="ml-1 inline-flex items-center justify-center bg-white/25 rounded-full font-black"
-                  style={{
-                    minWidth: 'min(18px, 5cqmin)',
-                    height: 'min(18px, 5cqmin)',
-                    padding: '0 min(6px, 1.5cqmin)',
-                    fontSize: 'min(10px, 3cqmin)',
+                    gap: 'min(6px, 1.5cqmin)',
+                    padding: 'min(8px, 2cqmin) min(12px, 3cqmin)',
+                    fontSize: 'min(11px, 3.5cqmin)',
                   }}
                 >
-                  {newResponsesToAppend.length}
-                </span>
-              )}
-            </button>
+                  {updatingSheet ? (
+                    <Loader2
+                      className="animate-spin"
+                      style={{
+                        width: 'min(14px, 4cqmin)',
+                        height: 'min(14px, 4cqmin)',
+                      }}
+                    />
+                  ) : (
+                    <RefreshCw
+                      style={{
+                        width: 'min(14px, 4cqmin)',
+                        height: 'min(14px, 4cqmin)',
+                      }}
+                    />
+                  )}
+                  UPDATE SHEET
+                  {newResponsesToAppend.length > 0 && (
+                    <span
+                      className="ml-1 inline-flex items-center justify-center bg-white/25 rounded-full font-black"
+                      style={{
+                        minWidth: 'min(18px, 5cqmin)',
+                        height: 'min(18px, 5cqmin)',
+                        padding: '0 min(6px, 1.5cqmin)',
+                        fontSize: 'min(10px, 3cqmin)',
+                      }}
+                    >
+                      {newResponsesToAppend.length}
+                    </span>
+                  )}
+                </button>
+              </span>
+            )}
           </>
         ) : (
           <button
@@ -745,7 +803,13 @@ export const QuizResults: React.FC<QuizResultsProps> = ({
             }}
           >
             {exporting ? (
-              <Loader2 className="w-4 h-4 animate-spin" />
+              <Loader2
+                className="animate-spin"
+                style={{
+                  width: 'min(14px, 4cqmin)',
+                  height: 'min(14px, 4cqmin)',
+                }}
+              />
             ) : (
               <Download
                 style={{
@@ -1159,8 +1223,9 @@ const StudentsTab: React.FC<{
   addToast,
 }) => {
   const [showResults, setShowResults] = useState(false);
-  const [confirmDeleteKey, setConfirmDeleteKey] = useState<string | null>(null);
-  const [deletingKey, setDeletingKey] = useState<string | null>(null);
+  const [confirmDeleteKey, setConfirmDeleteKey] =
+    useState<ResponseDocKey | null>(null);
+  const [deletingKey, setDeletingKey] = useState<ResponseDocKey | null>(null);
   const maxPoints = questions.reduce((sum, q) => sum + (q.points ?? 1), 0);
   const gamified = isGamificationActive(session);
   const suffix = getScoreSuffix(session);

--- a/components/widgets/QuizWidget/components/QuizResults.tsx
+++ b/components/widgets/QuizWidget/components/QuizResults.tsx
@@ -346,10 +346,13 @@ export const QuizResults: React.FC<QuizResultsProps> = ({
     );
     const owningPlc = matchingPlcs.length === 1 ? matchingPlcs[0] : null;
     if (exportErr.status === 403) {
+      // Don't toast here — both `handleExport` and `handleUpdateSheet` catch
+      // and toast `err.message`, so toasting from inside the helper produced
+      // duplicate toasts (Copilot review on PR #1442). The thrown Error
+      // carries the actionable message so the call-site toast stays clear.
       const accessDeniedMessage = owningPlc
         ? `You don't have access to the ${owningPlc.name} PLC sheet yet — ask the PLC lead to grant you writer access.`
         : "You don't have access to this PLC sheet — ask the PLC lead to grant you writer access.";
-      addToast(accessDeniedMessage, 'error');
       throw new Error(accessDeniedMessage);
     }
     if (!owningPlc) {
@@ -462,7 +465,9 @@ export const QuizResults: React.FC<QuizResultsProps> = ({
         addToast('Results exported to shared PLC sheet', 'success');
       }
     } catch (err) {
-      setExportError(err instanceof Error ? err.message : 'Export failed');
+      const msg = err instanceof Error ? err.message : 'Export failed';
+      setExportError(msg);
+      addToast(msg, 'error');
     } finally {
       setExporting(false);
     }

--- a/components/widgets/QuizWidget/components/QuizResults.tsx
+++ b/components/widgets/QuizWidget/components/QuizResults.tsx
@@ -28,6 +28,7 @@ import {
   User,
   Hash,
   Trash2,
+  RefreshCw,
 } from 'lucide-react';
 import { QuizResponse, QuizData, QuizQuestion, QuizConfig } from '@/types';
 import { useAuth } from '@/context/useAuth';
@@ -86,6 +87,18 @@ interface QuizResultsProps {
    * recompute aggregate stats) and full tab reloads.
    */
   onExportUrlSaved?: (url: string) => Promise<void> | void;
+  /**
+   * Response keys ALREADY exported to the linked sheet, read from the
+   * assignment doc. Used by the UPDATE SHEET button to determine which
+   * responses still need to be appended.
+   */
+  initialExportedResponseIds?: string[] | null;
+  /**
+   * Persist the latest set of exported response keys back to the assignment
+   * doc so re-entering Results doesn't re-export rows that were already
+   * appended.
+   */
+  onExportedResponseIdsSaved?: (ids: string[]) => Promise<void> | void;
 }
 
 export const QuizResults: React.FC<QuizResultsProps> = ({
@@ -99,6 +112,8 @@ export const QuizResults: React.FC<QuizResultsProps> = ({
   onPlcSheetUrlReplaced,
   initialExportUrl,
   onExportUrlSaved,
+  initialExportedResponseIds,
+  onExportedResponseIdsSaved,
 }) => {
   const { activeDashboard, updateWidget, addWidget, addToast, rosters } =
     useDashboard();
@@ -121,6 +136,16 @@ export const QuizResults: React.FC<QuizResultsProps> = ({
     setLastInitialExportUrl(initialExportUrl);
     setExportUrl(initialExportUrl ?? null);
   }
+  const [exportedResponseIds, setExportedResponseIds] = useState<string[]>(
+    initialExportedResponseIds ?? []
+  );
+  const [lastInitialExportedResponseIds, setLastInitialExportedResponseIds] =
+    useState<string[] | null | undefined>(initialExportedResponseIds);
+  if (initialExportedResponseIds !== lastInitialExportedResponseIds) {
+    setLastInitialExportedResponseIds(initialExportedResponseIds);
+    setExportedResponseIds(initialExportedResponseIds ?? []);
+  }
+  const [updatingSheet, setUpdatingSheet] = useState(false);
   const [exportError, setExportError] = useState<string | null>(null);
   const [activeTab, setActiveTab] = useState<
     'overview' | 'questions' | 'students'
@@ -372,6 +397,10 @@ export const QuizResults: React.FC<QuizResultsProps> = ({
         );
       }
       setExportUrl(url);
+      // Snapshot every response key we just exported so the UPDATE SHEET
+      // button can later append only the rows that come in afterwards.
+      const exportedIds = responses.map((r) => getResponseDocKey(r));
+      setExportedResponseIds(exportedIds);
       if (onExportUrlSaved) {
         // Fire-and-forget: the sheet already exists and the local button is
         // wired up for this session, so we don't want to keep `exporting`
@@ -386,6 +415,16 @@ export const QuizResults: React.FC<QuizResultsProps> = ({
           );
         });
       }
+      if (onExportedResponseIdsSaved) {
+        void Promise.resolve(onExportedResponseIdsSaved(exportedIds)).catch(
+          (err: unknown) => {
+            console.warn(
+              '[QuizResults] failed to persist exportedResponseIds to assignment doc',
+              err
+            );
+          }
+        );
+      }
       if (config.plcMode) {
         addToast('Results exported to shared PLC sheet', 'success');
       }
@@ -393,6 +432,68 @@ export const QuizResults: React.FC<QuizResultsProps> = ({
       setExportError(err instanceof Error ? err.message : 'Export failed');
     } finally {
       setExporting(false);
+    }
+  };
+
+  const newResponsesToAppend = useMemo(() => {
+    if (!exportUrl) return [];
+    const exportedSet = new Set(exportedResponseIds);
+    return responses.filter((r) => !exportedSet.has(getResponseDocKey(r)));
+  }, [exportUrl, exportedResponseIds, responses]);
+
+  const handleUpdateSheet = async () => {
+    if (!exportUrl || newResponsesToAppend.length === 0) return;
+    if (!googleAccessToken) {
+      setExportError(
+        'Google access token not available. Please sign in again.'
+      );
+      return;
+    }
+    setUpdatingSheet(true);
+    setExportError(null);
+    try {
+      const svc = new QuizDriveService(googleAccessToken);
+      // Reuse the PLC-mode append path: it builds the same headers + rows
+      // as the original export and uses appendToExistingSheet under the
+      // hood. Works whether the original export was solo or PLC — both
+      // produce a sheet whose first tab accepts row appends.
+      await svc.exportResultsToSheet(
+        quiz.title,
+        newResponsesToAppend,
+        quiz.questions,
+        {
+          pinToName: exportPinToName,
+          byStudentUid,
+          teacherName: config.teacherName,
+          periodName: config.periodName,
+          plcMode: true,
+          plcSheetUrl: exportUrl,
+        }
+      );
+      const allIds = responses.map((r) => getResponseDocKey(r));
+      setExportedResponseIds(allIds);
+      if (onExportedResponseIdsSaved) {
+        void Promise.resolve(onExportedResponseIdsSaved(allIds)).catch(
+          (err: unknown) => {
+            console.warn(
+              '[QuizResults] failed to persist exportedResponseIds after update',
+              err
+            );
+          }
+        );
+      }
+      addToast(
+        `Added ${newResponsesToAppend.length} new response${
+          newResponsesToAppend.length === 1 ? '' : 's'
+        } to the sheet.`,
+        'success'
+      );
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Update failed';
+      setExportError(msg);
+      addToast(msg, 'error');
+    } finally {
+      setUpdatingSheet(false);
     }
   };
 
@@ -513,25 +614,69 @@ export const QuizResults: React.FC<QuizResultsProps> = ({
           </div>
         )}
         {exportUrl ? (
-          <a
-            href={exportUrl}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="flex items-center bg-emerald-600 hover:bg-emerald-700 text-white font-bold rounded-xl transition-all shadow-md active:scale-95 shrink-0"
-            style={{
-              gap: 'min(6px, 1.5cqmin)',
-              padding: 'min(8px, 2cqmin) min(12px, 3cqmin)',
-              fontSize: 'min(11px, 3.5cqmin)',
-            }}
-          >
-            <ExternalLink
+          <>
+            <a
+              href={exportUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex items-center bg-emerald-600 hover:bg-emerald-700 text-white font-bold rounded-xl transition-all shadow-md active:scale-95 shrink-0"
               style={{
-                width: 'min(14px, 4cqmin)',
-                height: 'min(14px, 4cqmin)',
+                gap: 'min(6px, 1.5cqmin)',
+                padding: 'min(8px, 2cqmin) min(12px, 3cqmin)',
+                fontSize: 'min(11px, 3.5cqmin)',
               }}
-            />
-            OPEN SHEET
-          </a>
+            >
+              <ExternalLink
+                style={{
+                  width: 'min(14px, 4cqmin)',
+                  height: 'min(14px, 4cqmin)',
+                }}
+              />
+              OPEN SHEET
+            </a>
+            <button
+              onClick={() => void handleUpdateSheet()}
+              disabled={updatingSheet || newResponsesToAppend.length === 0}
+              title={
+                newResponsesToAppend.length === 0
+                  ? 'Sheet is up to date'
+                  : `Add ${newResponsesToAppend.length} new response${
+                      newResponsesToAppend.length === 1 ? '' : 's'
+                    } to the sheet`
+              }
+              className="flex items-center bg-brand-blue-primary hover:bg-brand-blue-dark disabled:bg-brand-gray-lighter disabled:cursor-not-allowed text-white font-bold rounded-xl transition-all shadow-md active:scale-95 shrink-0"
+              style={{
+                gap: 'min(6px, 1.5cqmin)',
+                padding: 'min(8px, 2cqmin) min(12px, 3cqmin)',
+                fontSize: 'min(11px, 3.5cqmin)',
+              }}
+            >
+              {updatingSheet ? (
+                <Loader2 className="w-4 h-4 animate-spin" />
+              ) : (
+                <RefreshCw
+                  style={{
+                    width: 'min(14px, 4cqmin)',
+                    height: 'min(14px, 4cqmin)',
+                  }}
+                />
+              )}
+              UPDATE SHEET
+              {newResponsesToAppend.length > 0 && (
+                <span
+                  className="ml-1 inline-flex items-center justify-center bg-white/25 rounded-full font-black"
+                  style={{
+                    minWidth: 'min(18px, 5cqmin)',
+                    height: 'min(18px, 5cqmin)',
+                    padding: '0 min(6px, 1.5cqmin)',
+                    fontSize: 'min(10px, 3cqmin)',
+                  }}
+                >
+                  {newResponsesToAppend.length}
+                </span>
+              )}
+            </button>
+          </>
         ) : (
           <button
             onClick={() => void handleExport()}

--- a/context/DashboardContextValue.ts
+++ b/context/DashboardContextValue.ts
@@ -34,7 +34,11 @@ export interface DashboardContextValue {
   isSaving: boolean;
   gradeFilter: GradeFilter;
   setGradeFilter: (filter: GradeFilter) => void;
-  addToast: (message: string, type?: Toast['type']) => void;
+  addToast: (
+    message: string,
+    type?: Toast['type'],
+    action?: Toast['action']
+  ) => void;
   removeToast: (id: string) => void;
   createNewDashboard: (name: string, data?: Dashboard) => Promise<void>;
   saveCurrentDashboard: () => Promise<void>;

--- a/hooks/useQuizAssignments.ts
+++ b/hooks/useQuizAssignments.ts
@@ -41,6 +41,7 @@ import {
   QUIZ_SESSIONS_COLLECTION,
   RESPONSES_COLLECTION,
   toPublicQuestion,
+  type ResponseDocKey,
 } from './useQuizSession';
 
 const QUIZ_ASSIGNMENTS_COLLECTION = 'quiz_assignments';
@@ -130,10 +131,15 @@ export interface UseQuizAssignmentsResult {
    * sheet. Powers the "Update Sheet" affordance in QuizResults — the next
    * incremental append filters out responses already in this list so we
    * don't duplicate already-exported rows.
+   *
+   * Accepts `ResponseDocKey[]` so the compiler enforces that callers pass
+   * the branded keys returned by `getResponseDocKey` (not arbitrary
+   * strings). The implementation casts to `string[]` at the Firestore
+   * write boundary — the wire format hasn't changed.
    */
   setAssignmentExportedResponseIds: (
     assignmentId: string,
-    responseIds: string[]
+    responseIds: ResponseDocKey[]
   ) => Promise<void>;
   /** Publish this assignment as a shareable link. Returns the /share/assignment/{id} URL. */
   shareAssignment: (
@@ -737,7 +743,12 @@ export const useQuizAssignments = (
       if (!userId) throw new Error('Not authenticated');
       await updateDoc(
         doc(db, 'users', userId, QUIZ_ASSIGNMENTS_COLLECTION, assignmentId),
-        { exportedResponseIds: responseIds, updatedAt: Date.now() }
+        {
+          // Cast to plain string[] at the Firestore boundary — the brand
+          // is application-level only, the wire format is `string[]`.
+          exportedResponseIds: responseIds as string[],
+          updatedAt: Date.now(),
+        }
       );
     },
     [userId]

--- a/hooks/useQuizAssignments.ts
+++ b/hooks/useQuizAssignments.ts
@@ -14,6 +14,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import {
   collection,
+  deleteField,
   doc,
   onSnapshot,
   getDoc,
@@ -626,10 +627,27 @@ export const useQuizAssignments = (
     async (assignmentId, patch) => {
       if (!userId) throw new Error('Not authenticated');
       const now = Date.now();
+      // Firestore is initialized with `ignoreUndefinedProperties: true`
+      // (config/firebase.ts), which silently drops keys whose value is
+      // `undefined`. That breaks the toggle-OFF use case for `plc` —
+      // the modal sends `{ plc: undefined }` to mean "clear it" but the
+      // existing field stays on the doc. Translate explicit-undefined on
+      // the `plc` key to `deleteField()` so the doc actually loses PLC
+      // mode. (Final-review finding on PR #1442.)
+      const assignmentPatch: Record<string, unknown> = {
+        ...patch,
+        updatedAt: now,
+      };
+      if (
+        Object.prototype.hasOwnProperty.call(patch, 'plc') &&
+        patch.plc === undefined
+      ) {
+        assignmentPatch.plc = deleteField();
+      }
       const batch = writeBatch(db);
       batch.update(
         doc(db, 'users', userId, QUIZ_ASSIGNMENTS_COLLECTION, assignmentId),
-        { ...patch, updatedAt: now } as Record<string, unknown>
+        assignmentPatch
       );
       // Mirror period and session-option changes to the session doc so
       // students can read available periods and updated toggles.

--- a/hooks/useQuizAssignments.ts
+++ b/hooks/useQuizAssignments.ts
@@ -27,6 +27,7 @@ import {
 } from 'firebase/firestore';
 import { db } from '../config/firebase';
 import type {
+  PlcLinkage,
   QuizAssignment,
   QuizAssignmentSettings,
   QuizAssignmentStatus,
@@ -160,17 +161,96 @@ export interface UseQuizAssignmentsResult {
       driveFileId: string;
     }) => Promise<void>,
     /**
-     * Optional membership predicate: given the originating PLC's id, returns
-     * true iff the importer is currently a member. When the share doc carries
-     * `plcId` and the predicate returns true, PLC linkage (mode, sheet URL,
-     * member emails, plcId) is preserved on the imported doc so the importer's
-     * exports route to the same shared sheet. Otherwise PLC fields are
-     * stripped (current behaviour) and `onNonMemberPlc` is invoked so the
-     * caller can surface a "not in this PLC" toast.
+     * Optional PLC handling. Bundled into a single object so the contract
+     * "PLC handling is opt-in as a unit" is visible in the type — both
+     * `isMember` and `onNonMember` are required when the caller opts in.
+     *
+     * - `isMember(plcId)`: returns true iff the importer is a current member
+     *   of the share's originating PLC. When the share doc carries a
+     *   `plc.id` and this returns true, PLC linkage is preserved on the
+     *   imported doc so the importer's exports route to the same shared
+     *   sheet. Otherwise the linkage is stripped.
+     * - `onNonMember`: invoked when the share carries a PLC linkage but the
+     *   importer is not a member, so the caller can surface a "not in this
+     *   PLC" nudge toast.
      */
-    isPlcMember?: (plcId: string) => boolean,
-    onNonMemberPlc?: (info: { plcId: string; plcName: string }) => void
+    plcHandling?: {
+      isMember: (plcId: string) => boolean;
+      onNonMember: (info: { plcId: string; plcName: string }) => void;
+    }
   ) => Promise<string>;
+}
+
+/**
+ * Read-side compatibility mapper for the pre-PlcLinkage flat shape. Existing
+ * Firestore docs were written with `plcMode`/`plcSheetUrl`/`plcId`/
+ * `plcName`/`plcMemberEmails` as flat fields on the assignment (or
+ * SharedQuizAssignment.assignmentSettings). The refactor consolidates those
+ * into a single `plc: PlcLinkage` sub-object.
+ *
+ * Behaviour:
+ * - If `plc` is already set, the doc is post-refactor — pass through.
+ * - If the legacy fields form a complete linkage (`plcMode === true` AND
+ *   `plcSheetUrl` AND `plcId` AND `plcName` are all populated), build a
+ *   `plc` sub-object and strip the legacy fields so downstream code only
+ *   sees one shape.
+ * - Partial-legacy docs (e.g. `plcMode: true` but missing one of `plcId`/
+ *   `plcName`/`plcSheetUrl`, possible for assignments created before
+ *   PR #1442 added `plcId`/`plcName`) pass through WITHOUT a `plc` field
+ *   and with the legacy fields stripped — degraded state, treated as
+ *   non-PLC mode rather than crashing. This matches the non-PLC path and
+ *   is safe.
+ *
+ * Generic over the doc shape so it can be applied to both QuizAssignment
+ * (returns `Omit<T, legacyKeys> & { plc?: PlcLinkage }`) and the inner
+ * `assignmentSettings` shape on SharedQuizAssignment.
+ */
+type LegacyPlcShape = {
+  plcMode?: boolean;
+  plcSheetUrl?: string;
+  plcId?: string;
+  plcName?: string;
+  plcMemberEmails?: string[];
+  plc?: PlcLinkage;
+};
+const LEGACY_PLC_KEYS = [
+  'plcMode',
+  'plcSheetUrl',
+  'plcId',
+  'plcName',
+  'plcMemberEmails',
+] as const;
+function migrateLegacyAssignmentShape<T extends LegacyPlcShape>(
+  data: T
+): Omit<T, (typeof LEGACY_PLC_KEYS)[number]> & { plc?: PlcLinkage } {
+  // Already migrated: leave the doc alone but still strip any stale legacy
+  // fields the writer may have left in place.
+  if (data.plc) {
+    const cleaned = { ...data };
+    for (const key of LEGACY_PLC_KEYS) delete cleaned[key];
+    return cleaned;
+  }
+
+  const { plcMode, plcSheetUrl, plcId, plcName, plcMemberEmails } = data;
+  const completeLegacy =
+    plcMode === true && !!plcSheetUrl && !!plcId && !!plcName;
+
+  const cleaned = { ...data };
+  for (const key of LEGACY_PLC_KEYS) delete cleaned[key];
+
+  if (completeLegacy) {
+    return {
+      ...cleaned,
+      plc: {
+        id: plcId,
+        name: plcName,
+        sheetUrl: plcSheetUrl,
+        memberEmails: plcMemberEmails ?? [],
+      },
+    };
+  }
+  // Degraded-state or non-PLC doc: pass through without `plc`.
+  return cleaned;
 }
 
 /** Unique 6-char join code generator with collision check against live sessions. */
@@ -235,7 +315,11 @@ export const useQuizAssignments = (
       q,
       (snap) => {
         setAssignments(
-          snap.docs.map((d) => ({ ...d.data(), id: d.id }) as QuizAssignment)
+          snap.docs.map((d) => {
+            const raw = { ...d.data(), id: d.id } as QuizAssignment &
+              LegacyPlcShape;
+            return migrateLegacyAssignmentShape(raw) as QuizAssignment;
+          })
         );
         setLoading(false);
       },
@@ -275,14 +359,12 @@ export const useQuizAssignments = (
         className: settings.className,
         sessionMode: settings.sessionMode,
         sessionOptions: settings.sessionOptions,
-        plcMode: settings.plcMode,
-        plcSheetUrl: settings.plcSheetUrl,
-        plcId: settings.plcId,
-        plcName: settings.plcName,
+        // PLC linkage: present iff the caller opted into PLC mode at create
+        // time. Stored as the new sub-object shape (PR #1442 follow-up).
+        ...(settings.plc ? { plc: settings.plc } : {}),
         teacherName: settings.teacherName,
         periodName: settings.periodName,
         periodNames: settings.periodNames,
-        plcMemberEmails: settings.plcMemberEmails,
         attemptLimit: settings.attemptLimit ?? null,
         ...(targetRosterIds.length > 0 ? { rosterIds: targetRosterIds } : {}),
       };
@@ -649,7 +731,9 @@ export const useQuizAssignments = (
         doc(db, 'users', userId, QUIZ_ASSIGNMENTS_COLLECTION, assignmentId)
       );
       if (!snap.exists()) throw new Error('Assignment not found');
-      const assignment = snap.data() as QuizAssignment;
+      const assignment = migrateLegacyAssignmentShape(
+        snap.data() as QuizAssignment & LegacyPlcShape
+      ) as QuizAssignment;
 
       const payload: Omit<SharedQuizAssignment, 'id'> = {
         title: quizData.title,
@@ -660,14 +744,10 @@ export const useQuizAssignments = (
           className: assignment.className,
           sessionMode: assignment.sessionMode,
           sessionOptions: assignment.sessionOptions,
-          plcMode: assignment.plcMode,
-          plcSheetUrl: assignment.plcSheetUrl,
-          plcId: assignment.plcId,
-          plcName: assignment.plcName,
+          ...(assignment.plc ? { plc: assignment.plc } : {}),
           teacherName: assignment.teacherName,
           periodName: assignment.periodName,
           periodNames: assignment.periodNames,
-          plcMemberEmails: assignment.plcMemberEmails,
         },
         originalAuthor: userId,
         sharedAt: Date.now(),
@@ -684,14 +764,25 @@ export const useQuizAssignments = (
   const importSharedAssignment = useCallback<
     UseQuizAssignmentsResult['importSharedAssignment']
   >(
-    async (shareId, saveQuiz, rollbackQuiz, isPlcMember, onNonMemberPlc) => {
+    async (shareId, saveQuiz, rollbackQuiz, plcHandling) => {
       if (!userId) throw new Error('Not authenticated');
 
       const snap = await getDoc(
         doc(db, SHARED_ASSIGNMENTS_COLLECTION, shareId)
       );
       if (!snap.exists()) throw new Error('Shared assignment not found');
-      const shared = snap.data() as SharedQuizAssignment;
+      // Apply legacy-shape migration so older share docs (written before
+      // the PlcLinkage refactor with flat `plcMode`/`plcSheetUrl`/etc.
+      // fields on `assignmentSettings`) read as the canonical `plc`
+      // sub-object shape — every downstream branch below sees one shape.
+      const sharedRaw = snap.data() as SharedQuizAssignment;
+      const shared: SharedQuizAssignment = {
+        ...sharedRaw,
+        assignmentSettings: migrateLegacyAssignmentShape(
+          sharedRaw.assignmentSettings as QuizAssignmentSettings &
+            LegacyPlcShape
+        ) as QuizAssignmentSettings,
+      };
 
       // 1. Copy the quiz into the importer's library.
       const now = Date.now();
@@ -713,71 +804,49 @@ export const useQuizAssignments = (
       //     3rd Period"). Cosmetic-only but confusing UX if left in
       //     place — Teacher B sees Teacher A's label as the subtitle
       //     on her own assignment card.
-      //   - plcSheetUrl: points at the ORIGINATOR's PLC Google Sheet.
-      //     If left in place, the importer's first results export
-      //     takes this URL (see QuizResults.tsx → exportResultsToSheet)
-      //     and calls Drive against a sheet the importer isn't shared
-      //     on — a 403, which used to surface as a silent
-      //     "Missing or insufficient permissions" console error.
-      //     Clearing it lets the auto-create path on first PLC
-      //     assignment populate the importer's own sheet instead.
-      //   - plcMemberEmails: originator's PLC roster. Not consumed
-      //     by the importer's start-flow today (Widget.tsx derives
-      //     sharing from the live `plc` doc via getPlcTeammateEmails),
-      //     but cleared for hygiene — leaving someone else's email
-      //     roster on the doc is a future-foot-gun.
-      //   - plcMode: cleared so the importer explicitly opts in to
-      //     PLC mode for their own assignment via the settings modal,
-      //     keeping plcSheetUrl/plcMemberEmails repopulation tied to
-      //     the importer's own PLC selection rather than the
-      //     originator's.
+      //   - plc.sheetUrl: points at the ORIGINATOR's PLC Google Sheet.
+      //     If left in place, the importer's first results export takes
+      //     this URL (see QuizResults.tsx → exportResultsToSheet) and
+      //     calls Drive against a sheet the importer isn't shared on —
+      //     a 403. Clearing the whole `plc` linkage lets the auto-create
+      //     path on first PLC assignment populate the importer's own
+      //     sheet instead.
+      //   - plc.memberEmails: originator's PLC roster. Not consumed by
+      //     the importer's start-flow today (Widget.tsx derives sharing
+      //     from the live `plc` doc via getPlcTeammateEmails), but
+      //     cleared for hygiene — leaving someone else's email roster
+      //     on the doc is a future-foot-gun.
+      //   - plc itself: cleared so the importer explicitly opts back in
+      //     to PLC mode for their own assignment via the settings modal,
+      //     keeping repopulation tied to the importer's own PLC selection
+      //     rather than the originator's.
       //
-      // EXCEPTION: when the share carries a `plcId` and the importer is
-      // a member of that PLC (per `isPlcMember`), preserve the PLC linkage
-      // so their exports route to the same shared sheet that all PLC peers
-      // use. The sheet was already shared with every member at creation
-      // time (Widget.tsx → createPlcSheetAndShare).
-      const sharedPlcId = shared.assignmentSettings.plcId;
-      const sharedPlcName = shared.assignmentSettings.plcName;
+      // EXCEPTION: members of the share's PLC keep `plc` wiring so their
+      // exports route to the same shared sheet that the originator and
+      // every other peer use (already shared with all members at sheet
+      // creation time in Widget.tsx → createPlcSheetAndShare).
+      const sharedPlc = shared.assignmentSettings.plc;
       const importerIsPlcMember =
-        !!sharedPlcId && !!isPlcMember && isPlcMember(sharedPlcId);
+        !!sharedPlc && !!plcHandling && plcHandling.isMember(sharedPlc.id);
 
-      const importedSettings = importerIsPlcMember
-        ? {
-            ...shared.assignmentSettings,
-            className: undefined,
-            teacherName: undefined,
-            periodName: undefined,
-            periodNames: undefined,
-            // Preserve plcMode, plcSheetUrl, plcMemberEmails, plcId, plcName.
-          }
-        : {
-            ...shared.assignmentSettings,
-            className: undefined,
-            teacherName: undefined,
-            periodName: undefined,
-            periodNames: undefined,
-            plcMode: undefined,
-            plcSheetUrl: undefined,
-            plcMemberEmails: undefined,
-            plcId: undefined,
-            plcName: undefined,
-          };
+      const importedSettings: QuizAssignmentSettings = {
+        ...shared.assignmentSettings,
+        className: undefined,
+        teacherName: undefined,
+        periodName: undefined,
+        periodNames: undefined,
+        plc: importerIsPlcMember ? shared.assignmentSettings.plc : undefined,
+      };
 
-      // Surface the non-member case to the caller so it can prompt the
-      // importer to join the PLC (or set up their own) — fire-and-forget,
-      // doesn't gate the import itself since the quiz is still usable.
-      if (
-        sharedPlcId &&
-        sharedPlcName &&
-        !importerIsPlcMember &&
-        onNonMemberPlc
-      ) {
+      if (sharedPlc && !importerIsPlcMember && plcHandling) {
         try {
-          onNonMemberPlc({ plcId: sharedPlcId, plcName: sharedPlcName });
+          plcHandling.onNonMember({
+            plcId: sharedPlc.id,
+            plcName: sharedPlc.name,
+          });
         } catch (cbErr) {
           console.error(
-            '[importSharedAssignment] onNonMemberPlc threw:',
+            '[importSharedAssignment] plcHandling.onNonMember threw:',
             cbErr
           );
         }

--- a/hooks/useQuizAssignments.ts
+++ b/hooks/useQuizAssignments.ts
@@ -124,6 +124,16 @@ export interface UseQuizAssignmentsResult {
    * "Export".
    */
   setAssignmentExportUrl: (assignmentId: string, url: string) => Promise<void>;
+  /**
+   * Persist the set of response keys that have been written to the linked
+   * sheet. Powers the "Update Sheet" affordance in QuizResults — the next
+   * incremental append filters out responses already in this list so we
+   * don't duplicate already-exported rows.
+   */
+  setAssignmentExportedResponseIds: (
+    assignmentId: string,
+    responseIds: string[]
+  ) => Promise<void>;
   /** Publish this assignment as a shareable link. Returns the /share/assignment/{id} URL. */
   shareAssignment: (
     assignmentId: string,
@@ -145,7 +155,21 @@ export interface UseQuizAssignmentsResult {
   importSharedAssignment: (
     shareId: string,
     saveQuiz: (quiz: QuizData) => Promise<{ id: string; driveFileId: string }>,
-    rollbackQuiz?: (saved: { id: string; driveFileId: string }) => Promise<void>
+    rollbackQuiz?: (saved: {
+      id: string;
+      driveFileId: string;
+    }) => Promise<void>,
+    /**
+     * Optional membership predicate: given the originating PLC's id, returns
+     * true iff the importer is currently a member. When the share doc carries
+     * `plcId` and the predicate returns true, PLC linkage (mode, sheet URL,
+     * member emails, plcId) is preserved on the imported doc so the importer's
+     * exports route to the same shared sheet. Otherwise PLC fields are
+     * stripped (current behaviour) and `onNonMemberPlc` is invoked so the
+     * caller can surface a "not in this PLC" toast.
+     */
+    isPlcMember?: (plcId: string) => boolean,
+    onNonMemberPlc?: (info: { plcId: string; plcName: string }) => void
   ) => Promise<string>;
 }
 
@@ -253,6 +277,8 @@ export const useQuizAssignments = (
         sessionOptions: settings.sessionOptions,
         plcMode: settings.plcMode,
         plcSheetUrl: settings.plcSheetUrl,
+        plcId: settings.plcId,
+        plcName: settings.plcName,
         teacherName: settings.teacherName,
         periodName: settings.periodName,
         periodNames: settings.periodNames,
@@ -601,6 +627,19 @@ export const useQuizAssignments = (
     [userId]
   );
 
+  const setAssignmentExportedResponseIds = useCallback<
+    UseQuizAssignmentsResult['setAssignmentExportedResponseIds']
+  >(
+    async (assignmentId, responseIds) => {
+      if (!userId) throw new Error('Not authenticated');
+      await updateDoc(
+        doc(db, 'users', userId, QUIZ_ASSIGNMENTS_COLLECTION, assignmentId),
+        { exportedResponseIds: responseIds, updatedAt: Date.now() }
+      );
+    },
+    [userId]
+  );
+
   const shareAssignment = useCallback<
     UseQuizAssignmentsResult['shareAssignment']
   >(
@@ -623,6 +662,8 @@ export const useQuizAssignments = (
           sessionOptions: assignment.sessionOptions,
           plcMode: assignment.plcMode,
           plcSheetUrl: assignment.plcSheetUrl,
+          plcId: assignment.plcId,
+          plcName: assignment.plcName,
           teacherName: assignment.teacherName,
           periodName: assignment.periodName,
           periodNames: assignment.periodNames,
@@ -643,7 +684,7 @@ export const useQuizAssignments = (
   const importSharedAssignment = useCallback<
     UseQuizAssignmentsResult['importSharedAssignment']
   >(
-    async (shareId, saveQuiz, rollbackQuiz) => {
+    async (shareId, saveQuiz, rollbackQuiz, isPlcMember, onNonMemberPlc) => {
       if (!userId) throw new Error('Not authenticated');
 
       const snap = await getDoc(
@@ -690,16 +731,57 @@ export const useQuizAssignments = (
       //     keeping plcSheetUrl/plcMemberEmails repopulation tied to
       //     the importer's own PLC selection rather than the
       //     originator's.
-      const importedSettings = {
-        ...shared.assignmentSettings,
-        className: undefined,
-        teacherName: undefined,
-        periodName: undefined,
-        periodNames: undefined,
-        plcMode: undefined,
-        plcSheetUrl: undefined,
-        plcMemberEmails: undefined,
-      };
+      //
+      // EXCEPTION: when the share carries a `plcId` and the importer is
+      // a member of that PLC (per `isPlcMember`), preserve the PLC linkage
+      // so their exports route to the same shared sheet that all PLC peers
+      // use. The sheet was already shared with every member at creation
+      // time (Widget.tsx → createPlcSheetAndShare).
+      const sharedPlcId = shared.assignmentSettings.plcId;
+      const sharedPlcName = shared.assignmentSettings.plcName;
+      const importerIsPlcMember =
+        !!sharedPlcId && !!isPlcMember && isPlcMember(sharedPlcId);
+
+      const importedSettings = importerIsPlcMember
+        ? {
+            ...shared.assignmentSettings,
+            className: undefined,
+            teacherName: undefined,
+            periodName: undefined,
+            periodNames: undefined,
+            // Preserve plcMode, plcSheetUrl, plcMemberEmails, plcId, plcName.
+          }
+        : {
+            ...shared.assignmentSettings,
+            className: undefined,
+            teacherName: undefined,
+            periodName: undefined,
+            periodNames: undefined,
+            plcMode: undefined,
+            plcSheetUrl: undefined,
+            plcMemberEmails: undefined,
+            plcId: undefined,
+            plcName: undefined,
+          };
+
+      // Surface the non-member case to the caller so it can prompt the
+      // importer to join the PLC (or set up their own) — fire-and-forget,
+      // doesn't gate the import itself since the quiz is still usable.
+      if (
+        sharedPlcId &&
+        sharedPlcName &&
+        !importerIsPlcMember &&
+        onNonMemberPlc
+      ) {
+        try {
+          onNonMemberPlc({ plcId: sharedPlcId, plcName: sharedPlcName });
+        } catch (cbErr) {
+          console.error(
+            '[importSharedAssignment] onNonMemberPlc threw:',
+            cbErr
+          );
+        }
+      }
       // Intentionally omit classIds/rosterIds: the shared doc's targeting
       // refers to rosters in the ORIGINATOR's account and would be dangling
       // refs here. The importer retargets on first launch via AssignClassPicker,
@@ -756,6 +838,7 @@ export const useQuizAssignments = (
     updateAssignmentSettings,
     setAssignmentRosters,
     setAssignmentExportUrl,
+    setAssignmentExportedResponseIds,
     shareAssignment,
     importSharedAssignment,
   };

--- a/hooks/useQuizAssignments.ts
+++ b/hooks/useQuizAssignments.ts
@@ -220,25 +220,46 @@ const LEGACY_PLC_KEYS = [
   'plcName',
   'plcMemberEmails',
 ] as const;
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+// Validate an inbound `plc` sub-object before trusting it. A partial or
+// malformed shape would otherwise propagate downstream where consumers
+// assume "present-and-complete." Returns a fresh object (no aliasing) or
+// `undefined` to drop the linkage.
+function getValidPlcLinkage(
+  plc: PlcLinkage | undefined
+): PlcLinkage | undefined {
+  if (!plc) return undefined;
+  const { id, name, sheetUrl, memberEmails } = plc;
+  const ok =
+    isNonEmptyString(id) &&
+    isNonEmptyString(name) &&
+    isNonEmptyString(sheetUrl) &&
+    Array.isArray(memberEmails) &&
+    memberEmails.every((e) => isNonEmptyString(e));
+  if (!ok) return undefined;
+  return { id, name, sheetUrl, memberEmails: [...memberEmails] };
+}
+
 function migrateLegacyAssignmentShape<T extends LegacyPlcShape>(
   data: T
 ): Omit<T, (typeof LEGACY_PLC_KEYS)[number]> & { plc?: PlcLinkage } {
-  // Already migrated: leave the doc alone but still strip any stale legacy
-  // fields the writer may have left in place.
-  if (data.plc) {
-    const cleaned = { ...data };
-    for (const key of LEGACY_PLC_KEYS) delete cleaned[key];
-    return cleaned;
-  }
-
-  const { plcMode, plcSheetUrl, plcId, plcName, plcMemberEmails } = data;
-  const completeLegacy =
-    plcMode === true && !!plcSheetUrl && !!plcId && !!plcName;
-
   const cleaned = { ...data };
   for (const key of LEGACY_PLC_KEYS) delete cleaned[key];
 
-  if (completeLegacy) {
+  // Already migrated (or partially-bad nested shape): trust the nested
+  // object only if it passes structural validation; otherwise drop it
+  // (downgrades to non-PLC mode rather than silently propagating a
+  // broken state).
+  if (data.plc) {
+    const valid = getValidPlcLinkage(data.plc);
+    return valid ? { ...cleaned, plc: valid } : cleaned;
+  }
+
+  const { plcMode, plcSheetUrl, plcId, plcName, plcMemberEmails } = data;
+  if (plcMode === true && !!plcSheetUrl && !!plcId && !!plcName) {
     return {
       ...cleaned,
       plc: {

--- a/hooks/useQuizSession.ts
+++ b/hooks/useQuizSession.ts
@@ -183,13 +183,25 @@ export function computeResponseKey(
 }
 
 /**
+ * Branded type for the deterministic response-doc key (computed by
+ * `computeResponseKey` / read off `_responseKey`). Pure type-level brand —
+ * no wire-format change. Lets call sites (delete-confirm state, exported-id
+ * sets) enforce that they never accidentally store a raw `string` where a
+ * keyed-by-response-doc value is expected.
+ *
+ * The Firestore wire format stays `string[]` for backwards compatibility;
+ * cast at the boundary (read from / write to assignment doc).
+ */
+export type ResponseDocKey = string & { readonly __brand: 'ResponseDocKey' };
+
+/**
  * Resolve the Firestore doc id for a given response. The snapshot listeners
  * attach `_responseKey` to every row so teacher-side UI can target the
  * underlying doc without knowing the keying scheme; legacy rows predating
  * that field still equate the key with `studentUid`, hence the fallback.
  */
-export function getResponseDocKey(response: QuizResponse): string {
-  return response._responseKey ?? response.studentUid;
+export function getResponseDocKey(response: QuizResponse): ResponseDocKey {
+  return (response._responseKey ?? response.studentUid) as ResponseDocKey;
 }
 
 // Safe extraction of FirestoreError.code (or any error-like object's `code`

--- a/tests/components/layout/DashboardView.test.tsx
+++ b/tests/components/layout/DashboardView.test.tsx
@@ -56,6 +56,21 @@ vi.mock('@/hooks/useQuizAssignments', () => ({
   }),
 }));
 
+vi.mock('@/hooks/usePlcs', () => ({
+  usePlcs: vi.fn().mockReturnValue({
+    plcs: [],
+    loading: false,
+    createPlc: vi.fn(),
+    renamePlc: vi.fn(),
+    removeMember: vi.fn(),
+    leavePlc: vi.fn(),
+    deletePlc: vi.fn(),
+    setPlcSharedSheetUrl: vi.fn(),
+    clearPlcSharedSheetUrl: vi.fn(),
+    getPlcSharedSheetUrl: vi.fn(),
+  }),
+}));
+
 vi.mock('@use-gesture/react', () => ({
   useGesture: mockUseGesture,
 }));

--- a/tests/components/widgets/QuizAssignmentSettingsModal.test.tsx
+++ b/tests/components/widgets/QuizAssignmentSettingsModal.test.tsx
@@ -79,7 +79,7 @@ describe('QuizAssignmentSettingsModal — sheet URL disclosure', () => {
     ).not.toBeInTheDocument();
   });
 
-  it('clicking "Hide" clears plc.sheetUrl in the saved patch (destructive disclosure)', async () => {
+  it('clicking "Hide" preserves the existing plc.sheetUrl (cancel, not clear)', async () => {
     const onSave = vi.fn().mockResolvedValue(undefined);
     render(
       <QuizAssignmentSettingsModal
@@ -104,13 +104,14 @@ describe('QuizAssignmentSettingsModal — sheet URL disclosure', () => {
     // Save (the modal's confirm button label is just "Save").
     fireEvent.click(screen.getByRole('button', { name: /^Save$/ }));
     await waitFor(() => expect(onSave).toHaveBeenCalled());
-    // PLC mode stays on; the linkage is preserved with sheetUrl cleared
-    // (membership/id/name still come from the original linkage).
+    // Hide is a cancel: the form input was cleared, but the saved plc keeps
+    // the existing sheetUrl. Saving an empty sheetUrl would be dropped by
+    // the read-side validator on next snapshot, silently losing PLC mode.
     expect(onSave.mock.calls[0][0]).toMatchObject({
       plc: {
         id: 'plc-1',
         name: 'Test PLC',
-        sheetUrl: '',
+        sheetUrl: 'https://docs.google.com/spreadsheets/d/legacy-sheet-id',
         memberEmails: ['a@example.com'],
       },
     });

--- a/tests/components/widgets/QuizAssignmentSettingsModal.test.tsx
+++ b/tests/components/widgets/QuizAssignmentSettingsModal.test.tsx
@@ -19,8 +19,14 @@ function makePlcAssignment(
     updatedAt: 1,
     sessionMode: 'teacher',
     sessionOptions: {},
-    plcMode: true,
-    plcSheetUrl: '',
+    // Mirror the new PlcLinkage sub-object shape — `plcMode` is now derived
+    // as `!!assignment.plc`, and the sheet URL lives on `plc.sheetUrl`.
+    plc: {
+      id: 'plc-1',
+      name: 'Test PLC',
+      sheetUrl: '',
+      memberEmails: [],
+    },
     teacherName: '',
     periodNames: [],
     ...overrides,
@@ -32,7 +38,7 @@ describe('QuizAssignmentSettingsModal — sheet URL disclosure', () => {
     vi.clearAllMocks();
   });
 
-  it('starts collapsed when the assignment has no plcSheetUrl', () => {
+  it('starts collapsed when the assignment has no plc.sheetUrl', () => {
     render(
       <QuizAssignmentSettingsModal
         assignment={makePlcAssignment()}
@@ -49,11 +55,16 @@ describe('QuizAssignmentSettingsModal — sheet URL disclosure', () => {
     ).not.toBeInTheDocument();
   });
 
-  it('starts expanded when the assignment already has a plcSheetUrl (legacy)', () => {
+  it('starts expanded when the assignment already has a plc.sheetUrl (legacy)', () => {
     render(
       <QuizAssignmentSettingsModal
         assignment={makePlcAssignment({
-          plcSheetUrl: 'https://docs.google.com/spreadsheets/d/legacy-sheet-id',
+          plc: {
+            id: 'plc-1',
+            name: 'Test PLC',
+            sheetUrl: 'https://docs.google.com/spreadsheets/d/legacy-sheet-id',
+            memberEmails: [],
+          },
         })}
         rosters={[] as ClassRoster[]}
         onSave={vi.fn()}
@@ -68,7 +79,7 @@ describe('QuizAssignmentSettingsModal — sheet URL disclosure', () => {
     ).not.toBeInTheDocument();
   });
 
-  it('clicking "Hide" clears plcSheetUrl in the saved patch (destructive disclosure)', async () => {
+  it('clicking "Hide" clears plc.sheetUrl in the saved patch (destructive disclosure)', async () => {
     const onSave = vi.fn().mockResolvedValue(undefined);
     render(
       <QuizAssignmentSettingsModal
@@ -77,7 +88,12 @@ describe('QuizAssignmentSettingsModal — sheet URL disclosure', () => {
           // the modeLocked path keeps everything else editable —
           // 'paused' still allows save here since the modal's
           // confirm gate is permissive.
-          plcSheetUrl: 'https://docs.google.com/spreadsheets/d/legacy-sheet-id',
+          plc: {
+            id: 'plc-1',
+            name: 'Test PLC',
+            sheetUrl: 'https://docs.google.com/spreadsheets/d/legacy-sheet-id',
+            memberEmails: ['a@example.com'],
+          },
         })}
         rosters={[] as ClassRoster[]}
         onSave={onSave}
@@ -88,6 +104,15 @@ describe('QuizAssignmentSettingsModal — sheet URL disclosure', () => {
     // Save (the modal's confirm button label is just "Save").
     fireEvent.click(screen.getByRole('button', { name: /^Save$/ }));
     await waitFor(() => expect(onSave).toHaveBeenCalled());
-    expect(onSave.mock.calls[0][0]).toMatchObject({ plcSheetUrl: '' });
+    // PLC mode stays on; the linkage is preserved with sheetUrl cleared
+    // (membership/id/name still come from the original linkage).
+    expect(onSave.mock.calls[0][0]).toMatchObject({
+      plc: {
+        id: 'plc-1',
+        name: 'Test PLC',
+        sheetUrl: '',
+        memberEmails: ['a@example.com'],
+      },
+    });
   });
 });

--- a/tests/components/widgets/QuizResults.regenerate.test.tsx
+++ b/tests/components/widgets/QuizResults.regenerate.test.tsx
@@ -1,0 +1,196 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import type { QuizConfig, QuizData, QuizResponse } from '@/types';
+
+// Minimal hook stubs — QuizResults's render path reaches into useDashboard,
+// useAuth, usePlcs, useAssignmentPseudonyms, and useClickOutside. We mock
+// each at module-scope so the focused recovery test stays self-contained.
+const addToast = vi.fn();
+const updateWidget = vi.fn();
+const addWidget = vi.fn();
+vi.mock('@/context/useDashboard', () => ({
+  useDashboard: () => ({
+    activeDashboard: { widgets: [] },
+    updateWidget,
+    addWidget,
+    addToast,
+    rosters: [],
+  }),
+}));
+vi.mock('@/context/useAuth', () => ({
+  useAuth: () => ({
+    googleAccessToken: 'token-1',
+    user: { uid: 'user-1' },
+    orgId: null,
+  }),
+}));
+const clearPlcSharedSheetUrl = vi.fn().mockResolvedValue(undefined);
+const setPlcSharedSheetUrl = vi
+  .fn()
+  .mockResolvedValue(
+    'https://docs.google.com/spreadsheets/d/regenerated-sheet-id'
+  );
+vi.mock('@/hooks/usePlcs', () => ({
+  usePlcs: () => ({
+    plcs: [
+      {
+        id: 'plc-1',
+        name: 'Test PLC',
+        leadUid: 'user-1',
+        memberUids: ['user-1', 'user-2'],
+        memberEmails: {
+          'user-1': 'self@example.com',
+          'user-2': 'b@example.com',
+        },
+        sharedSheetUrl: 'https://docs.google.com/spreadsheets/d/stale-sheet-id',
+        createdAt: 1,
+        updatedAt: 1,
+      },
+    ],
+    clearPlcSharedSheetUrl,
+    setPlcSharedSheetUrl,
+  }),
+}));
+vi.mock('@/hooks/useAssignmentPseudonyms', () => ({
+  useAssignmentPseudonyms: () => ({ byStudentUid: new Map() }),
+}));
+vi.mock('@/hooks/useClickOutside', () => ({ useClickOutside: vi.fn() }));
+
+// Spy on the production QuizDriveService so we can simulate the 404 →
+// regenerate → retry sequence without hitting Drive. The constructor mock
+// returns the same shared instance every time so per-test wiring of
+// exportResultsToSheet/createPlcSheetAndShare is observable through the
+// imported references.
+const mockExportResultsToSheet = vi.fn();
+const mockCreatePlcSheetAndShare = vi.fn();
+vi.mock('@/utils/quizDriveService', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@/utils/quizDriveService')>();
+  class MockQuizDriveService {
+    exportResultsToSheet = mockExportResultsToSheet;
+    createPlcSheetAndShare = mockCreatePlcSheetAndShare;
+  }
+  return {
+    ...actual,
+    QuizDriveService: MockQuizDriveService,
+  };
+});
+
+// Lazy-import the component AFTER mocks are registered. PlcSheetMissingError
+// is re-exported through the partial mock so `new PlcSheetMissingError(...)`
+// uses the real class definition.
+import { QuizResults } from '@/components/widgets/QuizWidget/components/QuizResults';
+import { PlcSheetMissingError } from '@/utils/quizDriveService';
+
+const STALE_SHEET_URL = 'https://docs.google.com/spreadsheets/d/stale-sheet-id';
+const REGEN_SHEET_URL =
+  'https://docs.google.com/spreadsheets/d/regenerated-sheet-id';
+
+function makeQuiz(): QuizData {
+  return {
+    id: 'quiz-1',
+    title: 'Sample Quiz',
+    questions: [
+      {
+        id: 'q1',
+        type: 'MC',
+        text: 'Q1',
+        correctAnswer: 'a',
+        incorrectAnswers: ['b'],
+        timeLimit: 30,
+        points: 1,
+      },
+    ],
+    createdAt: 1,
+    updatedAt: 1,
+  };
+}
+
+function makeResponse(pin: string): QuizResponse {
+  return {
+    studentUid: `uid-${pin}`,
+    pin,
+    classPeriod: 'Period 1',
+    answers: [{ questionId: 'q1', answer: 'a', timestamp: 100 }],
+    status: 'completed',
+    submittedAt: 200,
+    tabSwitchWarnings: 0,
+  } as unknown as QuizResponse;
+}
+
+function makePlcConfig(): QuizConfig {
+  return {
+    view: 'results',
+    plcMode: true,
+    teacherName: 'Teacher A',
+    periodName: 'Period 1',
+  } as unknown as QuizConfig;
+}
+
+describe('QuizResults — UPDATE SHEET 404 regenerate-sheet recovery', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setPlcSharedSheetUrl.mockResolvedValue(REGEN_SHEET_URL);
+    clearPlcSharedSheetUrl.mockResolvedValue(undefined);
+    // First call (initial UPDATE SHEET append) throws 404 — sheet gone in
+    // Drive. The catch path regenerates a fresh sheet and retries the
+    // export against the new URL, which succeeds.
+    mockExportResultsToSheet
+      .mockReset()
+      .mockRejectedValueOnce(
+        new PlcSheetMissingError(
+          'Shared PLC sheet is missing or inaccessible.',
+          404
+        )
+      )
+      .mockResolvedValueOnce(REGEN_SHEET_URL);
+    mockCreatePlcSheetAndShare.mockReset().mockResolvedValue({
+      url: REGEN_SHEET_URL,
+      spreadsheetId: 'regenerated-sheet-id',
+    });
+  });
+
+  it('persists the regenerated sheet URL via onExportUrlSaved so a reload does not rehydrate the stale URL', async () => {
+    const onExportUrlSaved = vi.fn().mockResolvedValue(undefined);
+    const onPlcSheetUrlReplaced = vi.fn().mockResolvedValue(undefined);
+    const onExportedResponseIdsSaved = vi.fn().mockResolvedValue(undefined);
+
+    render(
+      <QuizResults
+        quiz={makeQuiz()}
+        responses={[makeResponse('1111'), makeResponse('2222')]}
+        config={makePlcConfig()}
+        onBack={vi.fn()}
+        // exportUrl set + plcMode true + tracking initialized as empty
+        // means trackingInitialized=true (initialExportedResponseIds is
+        // an array, not null) AND there are 2 new responses to append,
+        // so UPDATE SHEET button is enabled.
+        initialExportUrl={STALE_SHEET_URL}
+        initialExportedResponseIds={[]}
+        onExportUrlSaved={onExportUrlSaved}
+        onPlcSheetUrlReplaced={onPlcSheetUrlReplaced}
+        onExportedResponseIdsSaved={onExportedResponseIdsSaved}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /update sheet/i }));
+
+    await waitFor(() => {
+      expect(mockExportResultsToSheet).toHaveBeenCalledTimes(2);
+    });
+
+    // Recovery path: PLC's stale URL was cleared, a fresh sheet was created
+    // and shared, and the canonical URL was persisted to BOTH the PLC's
+    // /plcs/{id} doc (via onPlcSheetUrlReplaced) AND the assignment's
+    // /quiz_assignments/{id} doc (via onExportUrlSaved). The latter is the
+    // bug this test guards: without it, a reload rehydrates from the stale
+    // URL and the 404→regenerate cycle repeats forever.
+    await waitFor(() => {
+      expect(onExportUrlSaved).toHaveBeenCalledWith(REGEN_SHEET_URL);
+    });
+    expect(clearPlcSharedSheetUrl).toHaveBeenCalledWith('plc-1');
+    expect(mockCreatePlcSheetAndShare).toHaveBeenCalledTimes(1);
+    expect(onPlcSheetUrlReplaced).toHaveBeenCalledWith(REGEN_SHEET_URL);
+  });
+});

--- a/tests/escapeInteraction.test.tsx
+++ b/tests/escapeInteraction.test.tsx
@@ -85,6 +85,20 @@ vi.mock('../hooks/useQuizAssignments', () => ({
     importSharedAssignment: vi.fn().mockResolvedValue('a1'),
   }),
 }));
+vi.mock('../hooks/usePlcs', () => ({
+  usePlcs: () => ({
+    plcs: [],
+    loading: false,
+    createPlc: vi.fn(),
+    renamePlc: vi.fn(),
+    removeMember: vi.fn(),
+    leavePlc: vi.fn(),
+    deletePlc: vi.fn(),
+    setPlcSharedSheetUrl: vi.fn(),
+    clearPlcSharedSheetUrl: vi.fn(),
+    getPlcSharedSheetUrl: vi.fn(),
+  }),
+}));
 
 const mockGlobalStyle: GlobalStyle = {
   fontFamily: 'sans',

--- a/tests/hooks/useQuizAssignments.test.ts
+++ b/tests/hooks/useQuizAssignments.test.ts
@@ -306,8 +306,11 @@ describe('useQuizAssignments - importSharedAssignment', () => {
     return call[1] as Record<string, unknown>;
   }
 
-  it('clears originator-scoped PLC fields (plcMode, plcSheetUrl, plcMemberEmails) so the importer is not bound to the originator’s PLC', async () => {
-    const sharedDoc: Partial<SharedQuizAssignment> = {
+  it('clears the originator-scoped PLC linkage (plc sub-object) so the importer is not bound to the originator’s PLC', async () => {
+    // Pre-PlcLinkage docs were flat; the migration mapper folds them into
+    // `plc` on read. Use the LEGACY shape here to exercise the mapper
+    // path inside importSharedAssignment.
+    const sharedDoc = {
       title: 'Quiz Title',
       questions: [],
       createdAt: 1000,
@@ -316,6 +319,8 @@ describe('useQuizAssignments - importSharedAssignment', () => {
         sessionMode: 'teacher',
         sessionOptions: {},
         plcMode: true,
+        plcId: 'originator-plc',
+        plcName: 'Originator PLC',
         plcSheetUrl:
           'https://docs.google.com/spreadsheets/d/originator-sheet-id',
         plcMemberEmails: ['origA@example.com', 'origB@example.com'],
@@ -325,7 +330,7 @@ describe('useQuizAssignments - importSharedAssignment', () => {
       },
       originalAuthor: 'originator-uid',
       sharedAt: 1000,
-    };
+    } as unknown as SharedQuizAssignment;
     mockGetDoc.mockResolvedValueOnce({
       exists: () => true,
       data: () => sharedDoc,
@@ -342,6 +347,10 @@ describe('useQuizAssignments - importSharedAssignment', () => {
     });
 
     const assignment = findAssignmentSet();
+    // After refactor: a single `plc` sub-object replaces the flat fields.
+    // For a non-member importer the linkage is stripped entirely, AND
+    // the legacy fields must not leak through onto the imported doc.
+    expect(assignment.plc).toBeUndefined();
     expect(assignment.plcMode).toBeUndefined();
     expect(assignment.plcSheetUrl).toBeUndefined();
     expect(assignment.plcMemberEmails).toBeUndefined();
@@ -351,6 +360,57 @@ describe('useQuizAssignments - importSharedAssignment', () => {
     expect(assignment.periodNames).toBeUndefined();
     // The teacherUid on the assignment must be the importer, not the originator:
     expect(assignment.teacherUid).toBe(TEACHER_UID);
+  });
+
+  it('preserves the PLC linkage for an importer that is a current member of the share’s PLC', async () => {
+    const sharedDoc = {
+      title: 'Quiz Title',
+      questions: [],
+      createdAt: 1,
+      updatedAt: 1,
+      assignmentSettings: {
+        sessionMode: 'teacher',
+        sessionOptions: {},
+        plc: {
+          id: 'plc-shared',
+          name: 'Shared PLC',
+          sheetUrl: 'https://docs.google.com/spreadsheets/d/shared-sheet',
+          memberEmails: ['a@example.com', 'b@example.com'],
+        },
+      },
+      originalAuthor: 'originator-uid',
+      sharedAt: 1,
+    } as unknown as SharedQuizAssignment;
+    mockGetDoc.mockResolvedValueOnce({
+      exists: () => true,
+      data: () => sharedDoc,
+    });
+
+    const saveQuiz = vi.fn().mockResolvedValue({ id: 'q', driveFileId: 'd' });
+    const onNonMember = vi.fn();
+
+    const { result } = renderHook(() => useQuizAssignments(TEACHER_UID));
+    await act(async () => {
+      await result.current.importSharedAssignment(
+        'share-id',
+        saveQuiz,
+        undefined,
+        {
+          isMember: (id) => id === 'plc-shared',
+          onNonMember,
+        }
+      );
+    });
+
+    const assignment = findAssignmentSet();
+    expect(assignment.plc).toEqual({
+      id: 'plc-shared',
+      name: 'Shared PLC',
+      sheetUrl: 'https://docs.google.com/spreadsheets/d/shared-sheet',
+      memberEmails: ['a@example.com', 'b@example.com'],
+    });
+    // Member path: the non-member nudge must NOT fire.
+    expect(onNonMember).not.toHaveBeenCalled();
   });
 
   it('creates the imported assignment in paused state so students cannot join before the teacher targets it', async () => {

--- a/tests/hooks/useQuizAssignments.test.ts
+++ b/tests/hooks/useQuizAssignments.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
 import { act, renderHook } from '@testing-library/react';
 import {
   collection,
+  deleteField,
   doc,
   getDoc,
   getDocs,
@@ -15,8 +16,14 @@ import type {
   SharedQuizAssignment,
 } from '@/types';
 
+// `deleteField()` returns a Firestore sentinel; the production code stores
+// the sentinel in the patch object and Firestore SDK interprets it on the
+// wire. For tests we use a unique branded marker so assertions can verify
+// the sentinel landed in the right field without depending on the real SDK.
+const DELETE_FIELD_SENTINEL = Symbol('test:deleteField()');
 vi.mock('firebase/firestore', () => ({
   collection: vi.fn(),
+  deleteField: vi.fn(() => DELETE_FIELD_SENTINEL),
   doc: vi.fn(),
   getDoc: vi.fn(),
   getDocs: vi.fn(),
@@ -33,6 +40,7 @@ vi.mock('@/config/firebase', () => ({
 }));
 
 const mockCollection = collection as Mock;
+const mockDeleteField = deleteField as Mock;
 const mockDoc = doc as Mock;
 const mockGetDoc = getDoc as Mock;
 const mockOnSnapshot = onSnapshot as Mock;
@@ -648,5 +656,88 @@ describe('useQuizAssignments - setAssignmentRosters', () => {
       periodName: '',
       rosterIds: [],
     });
+  });
+});
+
+describe('useQuizAssignments - updateAssignmentSettings', () => {
+  const batchUpdate = vi.fn();
+  const batchCommit = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDoc.mockImplementation((_db: unknown, ...segs: string[]) =>
+      segs.join('/')
+    );
+    mockCollection.mockReturnValue('coll-ref');
+    mockOnSnapshot.mockReturnValue(() => undefined);
+    batchUpdate.mockReset();
+    batchCommit.mockReset().mockResolvedValue(undefined);
+    mockWriteBatch.mockReturnValue({
+      update: batchUpdate,
+      commit: batchCommit,
+    });
+  });
+
+  function findAssignmentPatch(): Record<string, unknown> {
+    const call = batchUpdate.mock.calls.find(
+      ([ref]) =>
+        typeof ref === 'string' &&
+        ref.startsWith(`users/${TEACHER_UID}/quiz_assignments/`)
+    );
+    if (!call) throw new Error('expected batch.update on assignment doc');
+    return call[1] as Record<string, unknown>;
+  }
+
+  it('translates explicit-undefined plc into deleteField() so toggle-OFF actually clears the linkage', async () => {
+    // Firestore is initialized with `ignoreUndefinedProperties: true`, so a
+    // raw `{ plc: undefined }` patch would be silently dropped on the wire
+    // and the existing `plc` field would stay on the doc. The hook must
+    // translate explicit-undefined into the deleteField() sentinel.
+    const { result } = renderHook(() => useQuizAssignments(TEACHER_UID));
+
+    await act(async () => {
+      await result.current.updateAssignmentSettings(ASSIGNMENT_ID, {
+        plc: undefined,
+      });
+    });
+
+    const patch = findAssignmentPatch();
+    expect(patch.plc).toBe(DELETE_FIELD_SENTINEL);
+    expect(mockDeleteField).toHaveBeenCalledTimes(1);
+  });
+
+  it('passes a real plc patch through unchanged (no deleteField translation)', async () => {
+    const { result } = renderHook(() => useQuizAssignments(TEACHER_UID));
+    const linkage = {
+      id: 'plc-1',
+      name: 'Test PLC',
+      sheetUrl: 'https://docs.google.com/spreadsheets/d/sheet-id',
+      memberEmails: ['a@example.com'],
+    };
+
+    await act(async () => {
+      await result.current.updateAssignmentSettings(ASSIGNMENT_ID, {
+        plc: linkage,
+      });
+    });
+
+    const patch = findAssignmentPatch();
+    expect(patch.plc).toEqual(linkage);
+    // No clear-intent, so the deleteField sentinel was never minted.
+    expect(mockDeleteField).not.toHaveBeenCalled();
+  });
+
+  it('does not translate to deleteField() when the plc key is absent from the patch (only explicit-undefined triggers clear)', async () => {
+    const { result } = renderHook(() => useQuizAssignments(TEACHER_UID));
+
+    await act(async () => {
+      await result.current.updateAssignmentSettings(ASSIGNMENT_ID, {
+        className: 'Period 3',
+      });
+    });
+
+    const patch = findAssignmentPatch();
+    expect(patch).not.toHaveProperty('plc');
+    expect(mockDeleteField).not.toHaveBeenCalled();
   });
 });

--- a/types.ts
+++ b/types.ts
@@ -2126,6 +2126,18 @@ export interface QuizAssignment extends QuizAssignmentSettings {
    * the linked sheet. Powers the "Update Sheet" affordance: the next update
    * appends only the responses NOT in this set, so re-exporting after more
    * students finish doesn't duplicate already-exported rows.
+   *
+   * Set chosen over a (createdAt, key) cursor because the set is correct
+   * even when responses arrive out-of-order (network hiccups, retroactive
+   * writes from anonymous students reconnecting), whereas a cursor would
+   * silently miss any response with `createdAt < cursor`. The unbounded-
+   * growth concern is real but distant: each key is ~15-20 bytes, and the
+   * realistic ceiling for a single PLC assignment shared across a team is
+   * a few hundred to low thousands of rows — orders of magnitude under
+   * Firestore's 1MiB doc limit. If a PLC ever sustains tens of thousands
+   * of rows on one assignment, switch this to a separate subcollection or
+   * a (createdAt, key) cursor with a deterministic sort order at append
+   * time.
    */
   exportedResponseIds?: string[];
 }

--- a/types.ts
+++ b/types.ts
@@ -2027,6 +2027,40 @@ export interface QuizConfig {
 export type QuizAssignmentStatus = 'active' | 'paused' | 'inactive';
 
 /**
+ * PLC linkage for a quiz assignment. Present iff the assignment is in PLC
+ * mode (the originator opted into "Share with PLC" at create time, or the
+ * importer is a member of the originator's PLC). The presence of this
+ * sub-object is the canonical predicate — `plcMode` was a separate boolean
+ * pre-refactor and is now derived as `!!settings.plc`.
+ *
+ * All four fields are required-when-present so the type makes the implicit
+ * invariant explicit: a PLC-mode assignment always has an id, a name, a
+ * sheet URL, and a member-email roster snapshot. Pre-refactor docs that
+ * had `plcMode === true` but were missing one of `plcId`/`plcName`/
+ * `plcSheetUrl` are degraded-state — the read mapper passes them through
+ * WITHOUT a `plc` field, matching the non-PLC code path so downstream
+ * consumers don't see partial-PLC objects.
+ */
+export interface PlcLinkage {
+  /**
+   * Id of the PLC this assignment is shared with. Used by the importer to
+   * decide whether to preserve PLC linkage (member) or strip it and surface
+   * a "you're not in this PLC" prompt (non-member).
+   */
+  id: string;
+  /**
+   * Display name of the PLC at the time of assignment creation. Snapshotted
+   * onto the share doc so the non-member toast can name the PLC even though
+   * the importer can't read the live `/plcs/{plcId}` doc (rules block it).
+   */
+  name: string;
+  /** URL of the shared Google Sheet that PLC results export to. */
+  sheetUrl: string;
+  /** Snapshot of the PLC member emails at create time. */
+  memberEmails: string[];
+}
+
+/**
  * Settings that can be carried between assignments and are shareable in PLCs.
  * These do NOT include the quiz content itself — content is always sourced from the library.
  */
@@ -2035,28 +2069,19 @@ export interface QuizAssignmentSettings {
   className?: string;
   sessionMode: QuizSessionMode;
   sessionOptions: QuizSessionOptions;
-  /** PLC mode: export results to a shared Google Sheet */
-  plcMode?: boolean;
-  plcSheetUrl?: string;
   /**
-   * Id of the PLC this assignment is shared with. Persisted so a shared
-   * assignment doc can carry it through to the importer, who uses it to
-   * decide whether to preserve the PLC linkage (member) or strip it and
-   * surface a "you're not in this PLC" prompt (non-member).
+   * PLC linkage. Present iff the assignment is "PLC mode" — exporting to
+   * a shared Google Sheet for the PLC team. Use `!!settings.plc` as the
+   * canonical predicate; pre-refactor flat fields (`plcMode`, `plcSheetUrl`,
+   * `plcId`, `plcName`, `plcMemberEmails`) are mapped into this sub-object
+   * by `migrateLegacyAssignmentShape` on read.
    */
-  plcId?: string;
-  /**
-   * Display name of the PLC at the time of assignment creation. Snapshotted
-   * onto the share doc so the non-member toast can name the PLC even though
-   * the importer can't read the live `/plcs/{plcId}` doc (rules block it).
-   */
-  plcName?: string;
+  plc?: PlcLinkage;
   teacherName?: string;
   /** @deprecated Use periodNames instead. Kept for backwards compat. */
   periodName?: string;
   /** Selected class period roster names. Replaces singular periodName. */
   periodNames?: string[];
-  plcMemberEmails?: string[];
   /**
    * Max completed submissions allowed per student. `null`/`undefined` means
    * unlimited (legacy). `1` (default for new assignments) means one-and-done.

--- a/types.ts
+++ b/types.ts
@@ -2038,6 +2038,19 @@ export interface QuizAssignmentSettings {
   /** PLC mode: export results to a shared Google Sheet */
   plcMode?: boolean;
   plcSheetUrl?: string;
+  /**
+   * Id of the PLC this assignment is shared with. Persisted so a shared
+   * assignment doc can carry it through to the importer, who uses it to
+   * decide whether to preserve the PLC linkage (member) or strip it and
+   * surface a "you're not in this PLC" prompt (non-member).
+   */
+  plcId?: string;
+  /**
+   * Display name of the PLC at the time of assignment creation. Snapshotted
+   * onto the share doc so the non-member toast can name the PLC even though
+   * the importer can't read the live `/plcs/{plcId}` doc (rules block it).
+   */
+  plcName?: string;
   teacherName?: string;
   /** @deprecated Use periodNames instead. Kept for backwards compat. */
   periodName?: string;
@@ -2083,6 +2096,13 @@ export interface QuizAssignment extends QuizAssignmentSettings {
    * the same sheet if re-exported.
    */
   exportUrl?: string;
+  /**
+   * Response keys (`getResponseDocKey`) that have already been written to
+   * the linked sheet. Powers the "Update Sheet" affordance: the next update
+   * appends only the responses NOT in this set, so re-exporting after more
+   * students finish doesn't duplicate already-exported rows.
+   */
+  exportedResponseIds?: string[];
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes five distinct bugs in the PLC quiz assignment workflow. They all touch the same paths and several share types, so they're shipped together rather than as five tiny PRs.

1. **Self-paced student answer flow merged into one tap.** Previously: select → Submit Answer → NEXT (3 actions per question). Now: select (changeable) → NEXT/SUBMIT (commits + advances). Teacher-paced flow unchanged. Per-question feedback banner skipped in self-paced (PLC assignments are for assessment, not instructional feedback). Timeout-auto-submit fallback NEXT button preserved for the rare case a self-paced question has a timer.
2. **PIN-student rows no longer all highlight when removing one.** `confirmRemove` was keyed on `r.studentUid` (collision-prone for PIN students); switched to `getResponseDocKey(r)` at both render sites in `QuizLiveMonitor`. Removal logic itself was already correct — this was visual-only.
3. **Removed duplicate "Reopen" entry** in the archived-assignment kebab.
4. **Preserve PLC sheet linkage when a PLC peer imports a shared assignment.** The originator's auto-created sheet is already shared with every PLC member at create-time; the import was stripping `plcMode` / `plcSheetUrl` / `plcMemberEmails` unconditionally so peers' exports landed in their own private sheets. Now: share doc carries `plcId` + `plcName`; member-importer keeps the linkage; non-member import succeeds with a clear toast + a **PLC Settings** CTA that opens the Sidebar's PLCs panel.
5. **New "Update Sheet" button** alongside "Open Sheet" after the first export. Tracks `exportedResponseIds` on the assignment doc; an incremental append sends only NOT-yet-exported responses, so late finishers can be added without duplicating prior rows. Disabled with "Sheet is up to date" tooltip when nothing new; shows a count badge for pending rows. Reuses existing `appendToExistingSheet` — no new Sheets API surface.

Also surfaces the existing `action?` parameter on `addToast` in `DashboardContextValue` so the toast CTA pattern works without a type assertion. Two existing tests (`DashboardView`, `escapeInteraction`) gained `usePlcs` mocks since the import was added to `DashboardView`.

## Test plan

- [ ] **Bug 3** — open kebab on any archived assignment → only one Reopen entry.
- [ ] **Bug 1** — start a self-paced PLC assignment, join as student → confirm one tap commits + advances; selection editable until tap; teacher-paced still shows "Submit Answer" → "Waiting for teacher…".
- [ ] **Bug 2** — have 2-3 PIN students join, click X on one → only that row turns red.
- [ ] **Bug 4 (member)** — Teacher A creates PLC assignment, shares URL to Teacher B (same PLC) → Teacher B's exports go to the same sheet.
- [ ] **Bug 4 (non-member)** — Teacher C imports same URL → toast: *"This is a PLC quiz assignment for {plcName}. You're not a member…"* with **PLC Settings** button that opens the Sidebar's PLCs panel.
- [ ] **Bug 5** — export results once → both **OPEN SHEET** and **UPDATE SHEET** appear; Update Sheet is disabled with "Sheet is up to date" tooltip when nothing new; have one more student finish → button enables with a count badge → click → only the new row appended (no duplicates of prior rows).
- [x] CI gates: \`pnpm run validate\` (type-check + lint + format-check + 1530 tests) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)