### PR TITLE
fix(auth): block studentRole users from teacher app + Firestore dashboards

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -147,20 +147,45 @@ const AuthenticatedApp: React.FC<{ isRemote?: boolean }> = ({
 
 /** Rendered inside DashboardProvider so it can access both auth and dashboard context. */
 const AppContent: React.FC = () => {
-  const { isAdmin, profileLoaded, setupCompleted, roleId, signOut } = useAuth();
+  const {
+    isAdmin,
+    profileLoaded,
+    setupCompleted,
+    roleId,
+    isStudentRole,
+    signOut,
+  } = useAuth();
   const { loading: dashLoading, activeDashboard } = useDashboard();
 
-  // Bounce studentRole members out of the teacher app. The Firestore rule on
-  // /users/{uid}/dashboards is the actual security boundary; this just keeps
-  // a student who lands on the main URL from briefly seeing the empty
-  // teacher shell before the rule denies their writes.
+  // Two paths to "this is a student":
+  //   - `isStudentRole` — token carries `studentRole: true`. Real SSO students
+  //     minted by `studentLoginV1`. They have a valid student session, so we
+  //     just redirect to /my-assignments without signing out — StudentAuth
+  //     -Provider on that route accepts the same token.
+  //   - `roleId === 'student'` — legacy student who signed in via regular
+  //     Google Sign-In and was invited into the org with a student role.
+  //     Their token has no studentRole claim, so /my-assignments would
+  //     bounce them anyway; sign them out so the next sign-in goes through
+  //     the proper student flow.
+  // The Firestore rule on /users/{uid}/dashboards is the actual security
+  // boundary; this just keeps either kind of student from briefly seeing
+  // the empty teacher shell before the rule denies their writes.
+  const isStudent = isStudentRole || roleId === 'student';
   useEffect(() => {
-    if (!profileLoaded || roleId !== 'student') return;
-    void signOut();
+    if (!profileLoaded || !isStudent) return;
+    if (!isStudentRole) {
+      // Legacy student — invalidate their teacher session.
+      signOut().catch((err) => {
+        console.error(
+          '[AppContent] Failed to sign legacy student out before redirect:',
+          err
+        );
+      });
+    }
     window.location.replace('/my-assignments');
-  }, [profileLoaded, roleId, signOut]);
+  }, [profileLoaded, isStudent, isStudentRole, signOut]);
 
-  if (roleId === 'student') {
+  if (isStudent) {
     return <FullPageLoader />;
   }
 

--- a/App.tsx
+++ b/App.tsx
@@ -153,15 +153,16 @@ const AppContent: React.FC = () => {
     setupCompleted,
     roleId,
     isStudentRole,
+    roleResolved,
     signOut,
   } = useAuth();
   const { loading: dashLoading, activeDashboard } = useDashboard();
 
   // Two paths to "this is a student":
-  //   - `isStudentRole` — token carries `studentRole: true`. Real SSO students
-  //     minted by `studentLoginV1`. They have a valid student session, so we
-  //     just redirect to /my-assignments without signing out — StudentAuth
-  //     -Provider on that route accepts the same token.
+  //   - `isStudentRole` — token carries `studentRole: true`. Real SSO
+  //     students minted by `studentLoginV1`. They have a valid student
+  //     session, so we just redirect to /my-assignments without signing
+  //     out — `StudentAuthProvider` on that route accepts the same token.
   //   - `roleId === 'student'` — legacy student who signed in via regular
   //     Google Sign-In and was invited into the org with a student role.
   //     Their token has no studentRole claim, so /my-assignments would
@@ -170,22 +171,52 @@ const AppContent: React.FC = () => {
   // The Firestore rule on /users/{uid}/dashboards is the actual security
   // boundary; this just keeps either kind of student from briefly seeing
   // the empty teacher shell before the rule denies their writes.
+  //
+  // We gate on `roleResolved` so the decision waits for both the
+  // `studentRole` claim AND the org-members snapshot to settle. Without
+  // that, a legacy student would slip past during the ~hundreds-of-ms
+  // window where `roleId` is still null.
   const isStudent = isStudentRole || roleId === 'student';
   useEffect(() => {
-    if (!profileLoaded || !isStudent) return;
-    if (!isStudentRole) {
-      // Legacy student — invalidate their teacher session.
+    if (!profileLoaded || !roleResolved || !isStudent) return;
+
+    let cancelled = false;
+    const redirect = () => {
+      if (!cancelled) window.location.replace('/my-assignments');
+    };
+
+    if (isStudentRole) {
+      // Real SSO session — token is already valid for /my-assignments.
+      // Don't sign out; just navigate.
+      redirect();
+      return () => {
+        cancelled = true;
+      };
+    }
+
+    // Legacy student — invalidate their teacher session before redirect so
+    // the next sign-in goes through the proper student flow. Race signOut
+    // against a 2-second cap so a hung sign-out doesn't strand them on the
+    // loader; the navigation tears the SPA down either way.
+    void Promise.race([
       signOut().catch((err) => {
         console.error(
           '[AppContent] Failed to sign legacy student out before redirect:',
           err
         );
-      });
-    }
-    window.location.replace('/my-assignments');
-  }, [profileLoaded, isStudent, isStudentRole, signOut]);
+      }),
+      new Promise<void>((resolve) => window.setTimeout(resolve, 2000)),
+    ]).then(redirect);
 
-  if (isStudent) {
+    return () => {
+      cancelled = true;
+    };
+  }, [profileLoaded, roleResolved, isStudent, isStudentRole, signOut]);
+
+  // Hold on the loader while role resolution is in flight so a legacy
+  // student doesn't briefly see the dashboard shell before the redirect
+  // fires, and once we know they're a student until the redirect lands.
+  if (!roleResolved || isStudent) {
     return <FullPageLoader />;
   }
 

--- a/App.tsx
+++ b/App.tsx
@@ -162,7 +162,8 @@ const AppContent: React.FC = () => {
   //   - `isStudentRole` — token carries `studentRole: true`. Real SSO
   //     students minted by `studentLoginV1`. They have a valid student
   //     session, so we just redirect to /my-assignments without signing
-  //     out — `StudentAuthProvider` on that route accepts the same token.
+  //     out — `RequireStudentAuth` on that route validates the same
+  //     `studentRole` claim and lets them through.
   //   - `roleId === 'student'` — legacy student who signed in via regular
   //     Google Sign-In and was invited into the org with a student role.
   //     Their token has no studentRole claim, so /my-assignments would
@@ -180,24 +181,20 @@ const AppContent: React.FC = () => {
   useEffect(() => {
     if (!profileLoaded || !roleResolved || !isStudent) return;
 
-    let cancelled = false;
-    const redirect = () => {
-      if (!cancelled) window.location.replace('/my-assignments');
-    };
-
     if (isStudentRole) {
       // Real SSO session — token is already valid for /my-assignments.
       // Don't sign out; just navigate.
-      redirect();
-      return () => {
-        cancelled = true;
-      };
+      window.location.replace('/my-assignments');
+      return;
     }
 
     // Legacy student — invalidate their teacher session before redirect so
     // the next sign-in goes through the proper student flow. Race signOut
-    // against a 2-second cap so a hung sign-out doesn't strand them on the
-    // loader; the navigation tears the SPA down either way.
+    // against an arbitrary 2-second upper bound so a hung sign-out doesn't
+    // strand them on the loader; the navigation tears the SPA down either
+    // way, and `window.location.replace` is idempotent so we don't gate the
+    // call on an effect-cleanup flag (a sign-out-induced effect re-run
+    // could otherwise cancel a redirect we still want to fire).
     void Promise.race([
       signOut().catch((err) => {
         console.error(
@@ -206,11 +203,9 @@ const AppContent: React.FC = () => {
         );
       }),
       new Promise<void>((resolve) => window.setTimeout(resolve, 2000)),
-    ]).then(redirect);
-
-    return () => {
-      cancelled = true;
-    };
+    ]).then(() => {
+      window.location.replace('/my-assignments');
+    });
   }, [profileLoaded, roleResolved, isStudent, isStudentRole, signOut]);
 
   // Hold on the loader while role resolution is in flight so a legacy

--- a/App.tsx
+++ b/App.tsx
@@ -1,4 +1,4 @@
-import React, { lazy, Suspense } from 'react';
+import React, { lazy, Suspense, useEffect } from 'react';
 import { Loader2 } from 'lucide-react';
 import { AuthProvider } from './context/AuthContext';
 import { useAuth } from './context/useAuth';
@@ -147,8 +147,22 @@ const AuthenticatedApp: React.FC<{ isRemote?: boolean }> = ({
 
 /** Rendered inside DashboardProvider so it can access both auth and dashboard context. */
 const AppContent: React.FC = () => {
-  const { isAdmin, profileLoaded, setupCompleted } = useAuth();
+  const { isAdmin, profileLoaded, setupCompleted, roleId, signOut } = useAuth();
   const { loading: dashLoading, activeDashboard } = useDashboard();
+
+  // Bounce studentRole members out of the teacher app. The Firestore rule on
+  // /users/{uid}/dashboards is the actual security boundary; this just keeps
+  // a student who lands on the main URL from briefly seeing the empty
+  // teacher shell before the rule denies their writes.
+  useEffect(() => {
+    if (!profileLoaded || roleId !== 'student') return;
+    void signOut();
+    window.location.replace('/my-assignments');
+  }, [profileLoaded, roleId, signOut]);
+
+  if (roleId === 'student') {
+    return <FullPageLoader />;
+  }
 
   // Wait for the user's profile and first dashboard load before deciding what to show.
   // Also wait for an active dashboard: DashboardContext can emit loading=false before

--- a/components/student/StudentContexts.tsx
+++ b/components/student/StudentContexts.tsx
@@ -63,6 +63,7 @@ const mockAuth: AuthContextType = {
   },
   orgId: null,
   roleId: null,
+  isStudentRole: false,
   buildingIds: [],
   orgBuildings: [],
 };

--- a/components/student/StudentContexts.tsx
+++ b/components/student/StudentContexts.tsx
@@ -64,6 +64,7 @@ const mockAuth: AuthContextType = {
   orgId: null,
   roleId: null,
   isStudentRole: false,
+  roleResolved: true,
   buildingIds: [],
   orgBuildings: [],
 };

--- a/components/widgets/Embed/Widget.test.tsx
+++ b/components/widgets/Embed/Widget.test.tsx
@@ -415,6 +415,7 @@ describe('EmbedWidget', () => {
         updateAccountPreferences: vi.fn(),
         orgId: null,
         roleId: null,
+        isStudentRole: false,
         buildingIds: [],
         orgBuildings: [],
       });

--- a/components/widgets/Embed/Widget.test.tsx
+++ b/components/widgets/Embed/Widget.test.tsx
@@ -416,6 +416,7 @@ describe('EmbedWidget', () => {
         orgId: null,
         roleId: null,
         isStudentRole: false,
+        roleResolved: true,
         buildingIds: [],
         orgBuildings: [],
       });

--- a/components/widgets/TalkingTool/Widget.test.tsx
+++ b/components/widgets/TalkingTool/Widget.test.tsx
@@ -73,6 +73,7 @@ const mockAuthContext = (
   },
   orgId: null,
   roleId: null,
+  isStudentRole: false,
   buildingIds: [],
   orgBuildings: [],
   ...overrides,

--- a/components/widgets/TalkingTool/Widget.test.tsx
+++ b/components/widgets/TalkingTool/Widget.test.tsx
@@ -74,6 +74,7 @@ const mockAuthContext = (
   orgId: null,
   roleId: null,
   isStudentRole: false,
+  roleResolved: true,
   buildingIds: [],
   orgBuildings: [],
   ...overrides,

--- a/context/AuthContext.tsx
+++ b/context/AuthContext.tsx
@@ -241,6 +241,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
   const [roleId, setRoleId] = useState<string | null>(
     isAuthBypass ? 'super_admin' : null
   );
+  const [isStudentRole, setIsStudentRole] = useState<boolean>(false);
   const [buildingIds, setBuildingIds] = useState<string[]>([]);
   const [orgBuildings, setOrgBuildings] = useState<BuildingRecord[]>([]);
   // Tracks the latest setSelectedBuildings / setLanguage call to detect and suppress stale writes
@@ -561,6 +562,36 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
     };
 
     void checkAdminStatus();
+  }, [user]);
+
+  // Resolve the `studentRole` custom claim on the signed-in Firebase user.
+  // Real SSO students minted by `studentLoginV1` have `email: null`, so the
+  // org-members snapshot below never fires for them — meaning `roleId`
+  // stays null and a `roleId === 'student'` guard alone misses them.
+  // The claim is the only reliable client-side signal for an SSO student;
+  // App.tsx and DashboardContext.tsx both consume `isStudentRole` to keep
+  // them out of the teacher app.
+  useEffect(() => {
+    if (isAuthBypass) return;
+    if (!user) {
+      setIsStudentRole(false);
+      return;
+    }
+    let cancelled = false;
+    user
+      .getIdTokenResult()
+      .then((result) => {
+        if (cancelled) return;
+        setIsStudentRole(result.claims.studentRole === true);
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        console.error('[AuthContext] Failed to read studentRole claim:', err);
+        setIsStudentRole(false);
+      });
+    return () => {
+      cancelled = true;
+    };
   }, [user]);
 
   // Subscribe to organization membership. Phase 2 hard-codes the single seeded
@@ -1376,6 +1407,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
         updateAccountPreferences,
         orgId,
         roleId,
+        isStudentRole,
         buildingIds,
         orgBuildings,
       }}

--- a/context/AuthContext.tsx
+++ b/context/AuthContext.tsx
@@ -242,6 +242,15 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
     isAuthBypass ? 'super_admin' : null
   );
   const [isStudentRole, setIsStudentRole] = useState<boolean>(false);
+  // Two-part "have we figured out who this user is" gate. Both flags must be
+  // true for `roleResolved` to flip true. They're reset synchronously when
+  // `user` changes (see the adjusting-state block below) so a transition
+  // between users doesn't briefly carry the previous user's resolved state.
+  const [studentRoleResolved, setStudentRoleResolved] =
+    useState<boolean>(isAuthBypass);
+  const [membershipResolved, setMembershipResolved] =
+    useState<boolean>(isAuthBypass);
+  const [resolvedForUser, setResolvedForUser] = useState<User | null>(null);
   const [buildingIds, setBuildingIds] = useState<string[]>([]);
   const [orgBuildings, setOrgBuildings] = useState<BuildingRecord[]>([]);
   // Tracks the latest setSelectedBuildings / setLanguage call to detect and suppress stale writes
@@ -257,6 +266,21 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
   // re-arms the write. A plain boolean would latch the first target
   // forever within a session.
   const memberLastActiveSyncedKeyRef = useRef<string | null>(null);
+
+  // Reset role-resolution flags synchronously when `user` changes. Without
+  // this, a re-render between users would briefly carry the previous user's
+  // resolved=true state, causing AppContent's student guard or
+  // DashboardContext's auto-create gate to act on stale data. Setting state
+  // during render (a supported React pattern: react.dev/learn/you-might-not-
+  // need-an-effect#adjusting-some-state-when-a-prop-changes) avoids the
+  // extra render that an effect would introduce.
+  if (resolvedForUser !== user) {
+    setResolvedForUser(user);
+    setStudentRoleResolved(isAuthBypass);
+    setMembershipResolved(isAuthBypass);
+    setIsStudentRole(false);
+  }
+  const roleResolved = studentRoleResolved && membershipResolved;
 
   // Keep language state in sync with i18next, including the async startup
   // detection that may resolve after the first render.
@@ -575,6 +599,10 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
     if (isAuthBypass) return;
     if (!user) {
       setIsStudentRole(false);
+      // No user means there's nothing to resolve — keep `roleResolved`
+      // accurate for the signed-out state so the LoginScreen/redirect
+      // pipeline can still depend on it without stalling.
+      setStudentRoleResolved(true);
       return;
     }
     let cancelled = false;
@@ -583,11 +611,13 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
       .then((result) => {
         if (cancelled) return;
         setIsStudentRole(result.claims.studentRole === true);
+        setStudentRoleResolved(true);
       })
       .catch((err) => {
         if (cancelled) return;
         console.error('[AuthContext] Failed to read studentRole claim:', err);
         setIsStudentRole(false);
+        setStudentRoleResolved(true);
       });
     return () => {
       cancelled = true;
@@ -605,6 +635,11 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
       setOrgId(null);
       setRoleId(null);
       setBuildingIds([]);
+      // No email means there's no member doc to look up — including the
+      // signed-out state and real SSO students whose custom token carries
+      // no email claim. Mark membership resolved immediately so consumers
+      // don't stall waiting for a snapshot that will never fire.
+      setMembershipResolved(true);
       return;
     }
 
@@ -622,12 +657,16 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
           setRoleId(null);
           setBuildingIds([]);
         }
+        setMembershipResolved(true);
       },
       (error) => {
         console.error('[AuthContext] Error loading org membership:', error);
         setOrgId(null);
         setRoleId(null);
         setBuildingIds([]);
+        // Even an error counts as "resolved" — we know there's no usable
+        // member data, and consumers shouldn't stall indefinitely.
+        setMembershipResolved(true);
       }
     );
 
@@ -1408,6 +1447,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
         orgId,
         roleId,
         isStudentRole,
+        roleResolved,
         buildingIds,
         orgBuildings,
       }}

--- a/context/AuthContext.tsx
+++ b/context/AuthContext.tsx
@@ -605,16 +605,23 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
       setStudentRoleResolved(true);
       return;
     }
+    // Capture the uid this effect run is resolving for, so a fast
+    // sign-out/in transition can't let the previous user's claim
+    // promise overwrite the new user's state. The effect-cleanup
+    // `cancelled` flag covers the common case via React's lifecycle,
+    // but a uid check is a cheap belt-and-suspenders against any
+    // microtask-ordering edge case.
+    const startUid = user.uid;
     let cancelled = false;
     user
       .getIdTokenResult()
       .then((result) => {
-        if (cancelled) return;
+        if (cancelled || auth.currentUser?.uid !== startUid) return;
         setIsStudentRole(result.claims.studentRole === true);
         setStudentRoleResolved(true);
       })
       .catch((err) => {
-        if (cancelled) return;
+        if (cancelled || auth.currentUser?.uid !== startUid) return;
         console.error('[AuthContext] Failed to read studentRole claim:', err);
         setIsStudentRole(false);
         setStudentRoleResolved(true);
@@ -643,10 +650,17 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
       return;
     }
 
+    // Capture the uid + email at subscription time so a late onSnapshot
+    // delivery (after `user` has changed but before unsubscribe is wired
+    // up) cannot overwrite the new user's state. React's effect cleanup
+    // covers the typical case, but defending in depth against snapshot
+    // -callback ordering is cheap and explicit.
+    const startUid = user.uid;
     const emailLower = user.email.toLowerCase();
     const unsub = onSnapshot(
       doc(db, 'organizations', DEFAULT_ORG_ID, 'members', emailLower),
       (snap) => {
+        if (auth.currentUser?.uid !== startUid) return;
         if (snap.exists()) {
           const member = snap.data() as MemberRecord;
           setOrgId(member.orgId ?? DEFAULT_ORG_ID);
@@ -660,6 +674,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
         setMembershipResolved(true);
       },
       (error) => {
+        if (auth.currentUser?.uid !== startUid) return;
         console.error('[AuthContext] Error loading org membership:', error);
         setOrgId(null);
         setRoleId(null);

--- a/context/AuthContextValue.ts
+++ b/context/AuthContextValue.ts
@@ -87,6 +87,14 @@ export interface AuthContextType {
   /** The user's role id within `orgId` (from the members doc). Null until resolved. */
   roleId: string | null;
   /**
+   * True when the signed-in Firebase user holds a `studentRole: true` custom
+   * claim — i.e. the token was minted by `studentLoginV1`. Real SSO students
+   * have no email and therefore no member doc, so `roleId` stays null for
+   * them; this flag is the only reliable client-side signal that a student
+   * is at the controls. False for teachers, admins, and unauthenticated.
+   */
+  isStudentRole: boolean;
+  /**
    * Building ids the user has scoped admin access to (from the members doc).
    * Distinct from `selectedBuildings`, which is a UI filter the user picks
    * themselves. Empty array when the user is not a member or has org-wide scope.

--- a/context/AuthContextValue.ts
+++ b/context/AuthContextValue.ts
@@ -95,6 +95,15 @@ export interface AuthContextType {
    */
   isStudentRole: boolean;
   /**
+   * True once both `isStudentRole` (from the token claim) AND `roleId` (from
+   * the org-members snapshot, or short-circuited when the user has no email)
+   * have settled to their final values for the current user. Consumers that
+   * need to make a "student vs teacher" decision should gate on this to avoid
+   * acting on stale or partially-resolved state during the window between
+   * sign-in and the async claim/Firestore resolution.
+   */
+  roleResolved: boolean;
+  /**
    * Building ids the user has scoped admin access to (from the members doc).
    * Distinct from `selectedBuildings`, which is a UI filter the user picks
    * themselves. Empty array when the user is not a member or has org-wide scope.

--- a/context/DashboardContext.tsx
+++ b/context/DashboardContext.tsx
@@ -92,6 +92,7 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
     user,
     isAdmin,
     roleId,
+    isStudentRole,
     refreshGoogleToken,
     featurePermissions,
     selectedBuildings,
@@ -1074,14 +1075,17 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
           updateActiveId(defaultDb ? defaultDb.id : migratedDashboards[0].id);
         }
 
-        // Create default dashboard if none exist. Skip for studentRole
-        // members — students should never own a teacher-style board, and
-        // the Firestore rule will reject the write anyway. AppContent
+        // Create default dashboard if none exist. Skip for student users —
+        // both real SSO students (`isStudentRole` from the token claim) and
+        // legacy students (`roleId === 'student'` from the org member doc).
+        // Students should never own a teacher-style board, and the
+        // Firestore rule will reject the write anyway. AppContent
         // redirects them to /my-assignments; this just avoids a noisy
         // permission-denied error in the gap before that fires.
         if (
           updatedDashboards.length === 0 &&
           !migrated &&
+          !isStudentRole &&
           roleId !== 'student'
         ) {
           const defaultDb: Dashboard = {
@@ -1149,6 +1153,7 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
     saveDashboard,
     updateActiveId,
     roleId,
+    isStudentRole,
   ]);
 
   // Auto-save to Firestore with debouncing

--- a/context/DashboardContext.tsx
+++ b/context/DashboardContext.tsx
@@ -270,6 +270,11 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
   const [loading, setLoading] = useState(true);
   const [isSaving, setIsSaving] = useState(false);
   const [migrated, setMigrated] = useState(false);
+  // Guards against re-kicking off the localStorage→Firestore migration when
+  // this effect re-runs before `migrated` flips true (the role-flag deps
+  // below cause re-runs as `roleResolved`/`roleId`/`isStudentRole` resolve).
+  // Scoped per-uid so a sign-out → sign-in as a different user re-arms it.
+  const migrationStartedForUidRef = useRef<string | null>(null);
 
   const removeToast = useCallback((id: string) => {
     setToasts((prev) => prev.filter((t) => t.id !== id));
@@ -1122,9 +1127,17 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
       }
     );
 
-    // Migrate localStorage data on first sign-in
+    // Migrate localStorage data on first sign-in. Per-uid ref guards
+    // against double-kickoff: the role-flag deps in this effect's array
+    // can cause re-runs while migration is still in flight, and without
+    // the ref we'd start a second migration that races with the first.
     const localData = localStorage.getItem('classroom_dashboards');
-    if (localData && !migrated) {
+    if (
+      localData &&
+      !migrated &&
+      migrationStartedForUidRef.current !== user.uid
+    ) {
+      migrationStartedForUidRef.current = user.uid;
       migrateLocalStorageToFirestore(user.uid, saveDashboard)
         .then((count) => {
           if (count > 0) {
@@ -1149,6 +1162,10 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
               type: 'error' as const,
             },
           ]);
+          // Reset the kickoff guard so a future effect re-run can retry.
+          // Without this, a transient migration failure would permanently
+          // block retry until the user signs out and back in.
+          migrationStartedForUidRef.current = null;
         });
     }
 

--- a/context/DashboardContext.tsx
+++ b/context/DashboardContext.tsx
@@ -91,6 +91,7 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
   const {
     user,
     isAdmin,
+    roleId,
     refreshGoogleToken,
     featurePermissions,
     selectedBuildings,
@@ -1073,8 +1074,16 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
           updateActiveId(defaultDb ? defaultDb.id : migratedDashboards[0].id);
         }
 
-        // Create default dashboard if none exist
-        if (updatedDashboards.length === 0 && !migrated) {
+        // Create default dashboard if none exist. Skip for studentRole
+        // members — students should never own a teacher-style board, and
+        // the Firestore rule will reject the write anyway. AppContent
+        // redirects them to /my-assignments; this just avoids a noisy
+        // permission-denied error in the gap before that fires.
+        if (
+          updatedDashboards.length === 0 &&
+          !migrated &&
+          roleId !== 'student'
+        ) {
           const defaultDb: Dashboard = {
             id: crypto.randomUUID(),
             name: 'My First Board',
@@ -1133,7 +1142,14 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
     return () => {
       unsubscribe();
     };
-  }, [user, subscribeToDashboards, migrated, saveDashboard, updateActiveId]);
+  }, [
+    user,
+    subscribeToDashboards,
+    migrated,
+    saveDashboard,
+    updateActiveId,
+    roleId,
+  ]);
 
   // Auto-save to Firestore with debouncing
   const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);

--- a/context/DashboardContext.tsx
+++ b/context/DashboardContext.tsx
@@ -93,6 +93,7 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
     isAdmin,
     roleId,
     isStudentRole,
+    roleResolved,
     refreshGoogleToken,
     featurePermissions,
     selectedBuildings,
@@ -1082,9 +1083,17 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
         // Firestore rule will reject the write anyway. AppContent
         // redirects them to /my-assignments; this just avoids a noisy
         // permission-denied error in the gap before that fires.
+        //
+        // We also wait for `roleResolved` so a legacy student isn't briefly
+        // seen as `roleId === null` (the "non-member" state) and accidentally
+        // gets a default board created before the org-members snapshot
+        // arrives. Non-member teachers without a member doc resolve cleanly
+        // to `roleId === null` AND `roleResolved === true`, so they still
+        // get their default board.
         if (
           updatedDashboards.length === 0 &&
           !migrated &&
+          roleResolved &&
           !isStudentRole &&
           roleId !== 'student'
         ) {
@@ -1154,6 +1163,7 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
     updateActiveId,
     roleId,
     isStudentRole,
+    roleResolved,
   ]);
 
   // Auto-save to Firestore with debouncing

--- a/firestore.rules
+++ b/firestore.rules
@@ -396,9 +396,16 @@ service cloud.firestore {
       allow write: if false; // Only create via Firebase Console or Admin SDK
     }
 
-    // Dashboards - users can only access their own dashboards in their subcollection
+    // Dashboards - users can only access their own dashboards in their subcollection.
+    // studentRole tokens (minted by studentLoginV1) are denied outright: students
+    // do not own a teacher-style dashboard, and the main app's AppContent guard
+    // will redirect them to /my-assignments. This rule is the actual security
+    // boundary — without it, a studentRole user calling Firestore directly
+    // could still create a dashboard doc under their own uid.
     match /users/{userId}/dashboards/{dashboardId} {
-      allow read, write: if request.auth != null && request.auth.uid == userId;
+      allow read, write: if request.auth != null
+                         && request.auth.uid == userId
+                         && !isStudentRoleUser();
     }
 
     // Rosters - users can only access their own rosters in their subcollection

--- a/firestore.rules
+++ b/firestore.rules
@@ -398,10 +398,10 @@ service cloud.firestore {
 
     // Dashboards - users can only access their own dashboards in their subcollection.
     // studentRole tokens (minted by studentLoginV1) are denied outright: students
-    // do not own a teacher-style dashboard, and the main app's AppContent guard
-    // will redirect them to /my-assignments. This rule is the actual security
-    // boundary — without it, a studentRole user calling Firestore directly
-    // could still create a dashboard doc under their own uid.
+    // do not own a teacher-style dashboard, and the client app redirects them
+    // to /my-assignments. This rule is the actual security boundary — without
+    // it, a studentRole user calling Firestore directly could still create a
+    // dashboard doc under their own uid.
     match /users/{userId}/dashboards/{dashboardId} {
       allow read, write: if request.auth != null
                          && request.auth.uid == userId

--- a/tests/rules/dashboardsAccess.test.ts
+++ b/tests/rules/dashboardsAccess.test.ts
@@ -1,0 +1,271 @@
+// Firestore security-rules tests for /users/{uid}/dashboards/{dashboardId}.
+//
+// Covers the studentRole denial added alongside the AppContent + DashboardContext
+// guards: a token carrying `studentRole: true` (minted by `studentLoginV1`)
+// must not be able to read or write under any user's dashboards subcollection,
+// even their own. Teachers retain full access to their own dashboards and
+// remain locked out of other users'.
+//
+// Requires a running Firestore emulator. Invoke via:
+//   pnpm run test:rules
+
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { afterAll, beforeAll, beforeEach, describe, it } from 'vitest';
+import {
+  initializeTestEnvironment,
+  assertSucceeds,
+  assertFails,
+  type RulesTestEnvironment,
+} from '@firebase/rules-unit-testing';
+import { setDoc, getDoc, deleteDoc, doc } from 'firebase/firestore';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const PROJECT_ID = 'spartboard-dashboards-rules-test';
+const TEACHER_UID = 'teacher-uid-1';
+const OTHER_TEACHER_UID = 'teacher-uid-2';
+const STUDENT_UID = 'student-uid-1';
+const ANON_UID = 'anon-pin-uid';
+const DASHBOARD_ID = 'dash-1';
+
+const RULES_PATH = fileURLToPath(
+  new URL('../../firestore.rules', import.meta.url)
+);
+
+// Token-shape note: the rules engine in the emulator throws "Property X is
+// undefined" on direct claim access when the claim is missing, even behind a
+// short-circuit. Spell out every claim the rules touch so test contexts
+// match the production token surface — see studentRoleClassGate.test.ts for
+// the full justification.
+
+let testEnv: RulesTestEnvironment;
+
+const asTeacher = () =>
+  testEnv
+    .authenticatedContext(TEACHER_UID, {
+      email: 'teacher@school.edu',
+      studentRole: false,
+      classIds: [],
+      firebase: { sign_in_provider: 'google.com' },
+    })
+    .firestore();
+
+const asOtherTeacher = () =>
+  testEnv
+    .authenticatedContext(OTHER_TEACHER_UID, {
+      email: 'other.teacher@school.edu',
+      studentRole: false,
+      classIds: [],
+      firebase: { sign_in_provider: 'google.com' },
+    })
+    .firestore();
+
+const asStudentRoleSelf = () =>
+  testEnv
+    .authenticatedContext(STUDENT_UID, {
+      email: '',
+      studentRole: true,
+      classIds: ['class-A'],
+      firebase: { sign_in_provider: 'custom' },
+    })
+    .firestore();
+
+const asStudentRoleAttackerOnTeacher = () =>
+  testEnv
+    .authenticatedContext(STUDENT_UID, {
+      email: '',
+      studentRole: true,
+      classIds: ['class-A'],
+      firebase: { sign_in_provider: 'custom' },
+    })
+    .firestore();
+
+const asAnonPin = () =>
+  testEnv
+    .authenticatedContext(ANON_UID, {
+      email: '',
+      studentRole: false,
+      classIds: [],
+      firebase: { sign_in_provider: 'anonymous' },
+    })
+    .firestore();
+
+const asUnauth = () => testEnv.unauthenticatedContext().firestore();
+
+const teacherDashboardPath = `users/${TEACHER_UID}/dashboards/${DASHBOARD_ID}`;
+const studentDashboardPath = `users/${STUDENT_UID}/dashboards/${DASHBOARD_ID}`;
+
+const dashboardFields = () => ({
+  id: DASHBOARD_ID,
+  name: 'My Board',
+  background: 'bg-slate-900',
+  widgets: [],
+  createdAt: 1000,
+});
+
+beforeAll(async () => {
+  testEnv = await initializeTestEnvironment({
+    projectId: PROJECT_ID,
+    firestore: {
+      rules: readFileSync(RULES_PATH, 'utf8'),
+      host: process.env.FIRESTORE_EMULATOR_HOST?.split(':')[0] ?? '127.0.0.1',
+      port: Number(
+        process.env.FIRESTORE_EMULATOR_HOST?.split(':')[1] ?? '8080'
+      ),
+    },
+  });
+});
+
+afterAll(async () => {
+  await testEnv?.cleanup();
+});
+
+beforeEach(async () => {
+  await testEnv.clearFirestore();
+  // Seed an existing dashboard under the teacher's uid so read/update/delete
+  // paths can be exercised. Bypasses rules so the seed itself is not the
+  // thing under test.
+  await testEnv.withSecurityRulesDisabled(async (ctx) => {
+    await setDoc(doc(ctx.firestore(), teacherDashboardPath), dashboardFields());
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Teacher (non-studentRole) — full access to own, denied on others
+// ---------------------------------------------------------------------------
+
+describe('/users/{uid}/dashboards — teacher access', () => {
+  it('teacher can read their own dashboard', async () => {
+    await assertSucceeds(getDoc(doc(asTeacher(), teacherDashboardPath)));
+  });
+
+  it('teacher can create a dashboard under their own uid', async () => {
+    await assertSucceeds(
+      setDoc(doc(asTeacher(), `users/${TEACHER_UID}/dashboards/dash-2`), {
+        ...dashboardFields(),
+        id: 'dash-2',
+      })
+    );
+  });
+
+  it('teacher can update their own dashboard', async () => {
+    await assertSucceeds(
+      setDoc(doc(asTeacher(), teacherDashboardPath), {
+        ...dashboardFields(),
+        name: 'Renamed',
+      })
+    );
+  });
+
+  it('teacher can delete their own dashboard', async () => {
+    await assertSucceeds(deleteDoc(doc(asTeacher(), teacherDashboardPath)));
+  });
+
+  it("teacher cannot read another user's dashboard", async () => {
+    await assertFails(getDoc(doc(asOtherTeacher(), teacherDashboardPath)));
+  });
+
+  it("teacher cannot write to another user's dashboard", async () => {
+    await assertFails(
+      setDoc(doc(asOtherTeacher(), teacherDashboardPath), {
+        ...dashboardFields(),
+        name: 'Hijacked',
+      })
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// studentRole — denied even on their own uid
+// ---------------------------------------------------------------------------
+
+describe('/users/{uid}/dashboards — studentRole denial', () => {
+  it('studentRole user cannot read a dashboard under their own uid', async () => {
+    // Seed a dashboard at the student's uid so the read has a doc to find.
+    // Without this we cannot distinguish "rule denied" from "no doc here".
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      await setDoc(
+        doc(ctx.firestore(), studentDashboardPath),
+        dashboardFields()
+      );
+    });
+    await assertFails(getDoc(doc(asStudentRoleSelf(), studentDashboardPath)));
+  });
+
+  it('studentRole user cannot create a dashboard under their own uid', async () => {
+    await assertFails(
+      setDoc(doc(asStudentRoleSelf(), studentDashboardPath), dashboardFields())
+    );
+  });
+
+  it('studentRole user cannot update a dashboard under their own uid', async () => {
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      await setDoc(
+        doc(ctx.firestore(), studentDashboardPath),
+        dashboardFields()
+      );
+    });
+    await assertFails(
+      setDoc(doc(asStudentRoleSelf(), studentDashboardPath), {
+        ...dashboardFields(),
+        name: 'Smuggled',
+      })
+    );
+  });
+
+  it('studentRole user cannot delete a dashboard under their own uid', async () => {
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      await setDoc(
+        doc(ctx.firestore(), studentDashboardPath),
+        dashboardFields()
+      );
+    });
+    await assertFails(
+      deleteDoc(doc(asStudentRoleSelf(), studentDashboardPath))
+    );
+  });
+
+  it("studentRole user cannot read a teacher's dashboard", async () => {
+    await assertFails(
+      getDoc(doc(asStudentRoleAttackerOnTeacher(), teacherDashboardPath))
+    );
+  });
+
+  it("studentRole user cannot write to a teacher's dashboard", async () => {
+    await assertFails(
+      setDoc(
+        doc(asStudentRoleAttackerOnTeacher(), teacherDashboardPath),
+        dashboardFields()
+      )
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Other auth shapes — confirm the rule still rejects them as before
+// ---------------------------------------------------------------------------
+
+describe('/users/{uid}/dashboards — other auth shapes', () => {
+  it('anonymous PIN-token user cannot read a teacher dashboard', async () => {
+    await assertFails(getDoc(doc(asAnonPin(), teacherDashboardPath)));
+  });
+
+  it('anonymous PIN-token user cannot write to a teacher dashboard', async () => {
+    await assertFails(
+      setDoc(doc(asAnonPin(), teacherDashboardPath), dashboardFields())
+    );
+  });
+
+  it('unauthenticated caller cannot read a teacher dashboard', async () => {
+    await assertFails(getDoc(doc(asUnauth(), teacherDashboardPath)));
+  });
+
+  it('unauthenticated caller cannot write to a teacher dashboard', async () => {
+    await assertFails(
+      setDoc(doc(asUnauth(), teacherDashboardPath), dashboardFields())
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Three layered guards prevent a studentRole user (real SSO via `studentLoginV1`, or legacy Google Sign-In with `roleId: 'student'` on their org members doc) from landing on the main teacher app and having a default board auto-created under their uid.
- Discovered while auditing Firestore for student data: a legacy student account (`Mrvcx3Qa…`) had two empty `My First Board` dashboards auto-created when they first signed in via the regular Google flow, before role-aware SSO existed.

## Changes
1. **`App.tsx` `AppContent`** — when `profileLoaded && roleId === 'student'`, fire `signOut()` and `window.location.replace('/my-assignments')`. `RequireStudentAuth` on that route bounces them to `/student/login` if their token lacks the `studentRole` claim.
2. **`context/DashboardContext.tsx`** — skip the empty-dashboards auto-create branch when `roleId === 'student'`. Avoids a noisy permission-denied toast in the gap between sign-in and the AppContent redirect firing.
3. **`firestore.rules` `/users/{uid}/dashboards`** — deny when the token has `studentRole: true`. This is the actual security boundary; (1) and (2) are UX/defense-in-depth.

## Coverage
| Account type | Token claim | Member doc roleId | Outcome |
|---|---|---|---|
| Real SSO student (HMAC uid) | `studentRole: true` | `'student'` or absent | Rule denies write; AppContent redirects |
| Legacy student via Google Sign-In | none | `'student'` | AppContent redirects (rule doesn't fire — no claim) |
| Teacher / admin | none | non-student | Unchanged |
| Uninvited domain account | none | `null` | Unchanged (deferred — would also affect legacy admins without member docs) |

## Test plan
- [x] `pnpm run type-check` clean
- [x] `pnpm run lint --max-warnings 0` clean
- [x] `pnpm run format:check` clean
- [ ] Sign in as `sstudent25@orono.k12.mn.us` on the dev preview → should redirect to `/my-assignments` instead of seeing an empty board (note: their legacy auth account/dashboards must still be cleaned up manually for the redirect to be the only outcome)
- [ ] Sign in as a teacher account → unchanged behavior, default board still auto-creates on first sign-in
- [ ] After deploy, attempt a direct Firestore SDK write to `/users/{ssoStudentUid}/dashboards/foo` with a `studentRole` token → permission-denied
- [ ] `firebase deploy --only firestore:rules` once merged through main

🤖 Generated with [Claude Code](https://claude.com/claude-code)