### PR TITLE
fix(quiz): address PR 1442 review blockers + importants

### DIFF
--- a/components/layout/DashboardView.tsx
+++ b/components/layout/DashboardView.tsx
@@ -161,7 +161,7 @@ export const DashboardView: React.FC = () => {
 
   const { importSharedQuiz, saveQuiz, deleteQuiz } = useQuiz(user?.uid);
   const { importSharedAssignment } = useQuizAssignments(user?.uid);
-  const { plcs } = usePlcs();
+  const { plcs, loading: plcsLoading } = usePlcs();
 
   // Helper: open (or create) a Quiz widget and set its managerTab.
   // Used by pending-share effects to surface the imported content to the user.
@@ -238,6 +238,12 @@ export const DashboardView: React.FC = () => {
   // shows live and paused assignments (Archive only shows inactive ones).
   useEffect(() => {
     if (!pendingAssignmentShareId || !user) return;
+    // Wait for the /plcs listener to hydrate before deciding membership.
+    // Otherwise a deep-link import that fires before the snapshot arrives
+    // sees an empty plcs array, the predicate returns false, and a
+    // legitimate PLC member gets demoted to non-member with the "you're
+    // not a member" toast — even though they are.
+    if (plcsLoading) return;
     // Clear synchronously BEFORE awaiting — see the quiz-share effect above
     // for the triple-import race rationale.
     const shareId = pendingAssignmentShareId;
@@ -314,6 +320,7 @@ export const DashboardView: React.FC = () => {
     openQuizWidgetToTab,
     setPendingAssignmentSetup,
     plcs,
+    plcsLoading,
   ]);
 
   const [panOffset, setPanOffset] = React.useState({ x: 0, y: 0 });

--- a/components/quiz/QuizStudentApp.tsx
+++ b/components/quiz/QuizStudentApp.tsx
@@ -651,6 +651,9 @@ const ActiveQuiz: React.FC<{
   const [revealedAnswer, setRevealedAnswer] = useState<string | null>(null);
   const [speedBonusEarned, setSpeedBonusEarned] = useState<number | null>(null);
   const [streakCount, setStreakCount] = useState(0);
+  // Surfaced when onAnswer or onComplete rejects (offline, perm denied, etc.)
+  // so the student doesn't think their tap silently committed.
+  const [submitError, setSubmitError] = useState<string | null>(null);
 
   // Derived state: reset local UI state on new question or when global alreadyAnswered state arrives
   if (
@@ -667,6 +670,7 @@ const ActiveQuiz: React.FC<{
     setAnswerFeedback(null);
     setRevealedAnswer(null);
     setSpeedBonusEarned(null);
+    setSubmitError(null);
     const tl = currentQuestion?.timeLimit ?? 0;
     setTimeLeft(tl > 0 && !alreadyAnswered ? tl : null);
   }
@@ -691,6 +695,11 @@ const ActiveQuiz: React.FC<{
   const fibAnswerRef = useRef(fibAnswer);
   const draftMcAnswerRef = useRef(draftMcAnswer);
   const onAnswerRef = useRef(onAnswer);
+  // Synchronous re-entry guard for handleSubmitAndAdvance. The setSubmitting
+  // state setter doesn't apply until the next render, so two near-simultaneous
+  // taps (or React 19 transition reordering) could both pass the gate before
+  // the state flips. The ref blocks the second call immediately.
+  const submittingRef = useRef(false);
 
   useEffect(() => {
     currentQuestionRef.current = currentQuestion;
@@ -888,8 +897,10 @@ const ActiveQuiz: React.FC<{
   // who want feedback should run the quiz in teacher-paced mode and reveal
   // answers manually.
   const handleSubmitAndAdvance = async (answer: string) => {
-    if (submitting || submitted) return;
+    if (submittingRef.current || submitted) return;
+    submittingRef.current = true;
     setSubmitting(true);
+    setSubmitError(null);
     try {
       let computedSpeedBonus: number | undefined;
       if (session.speedBonusEnabled && currentQuestion.timeLimit > 0) {
@@ -899,19 +910,44 @@ const ActiveQuiz: React.FC<{
         );
         if (bonusPct > 0) computedSpeedBonus = bonusPct;
       }
-      await onAnswer(currentQuestion.id, answer, computedSpeedBonus);
+
+      try {
+        await onAnswer(currentQuestion.id, answer, computedSpeedBonus);
+      } catch (err) {
+        // Answer write rejected (offline, perm denied, etc.). Without this
+        // catch the rejection vanishes into a void-promise console error and
+        // the student silently keeps their selection.
+        console.error('[QuizStudentApp] onAnswer failed:', err);
+        setSubmitError(
+          "Couldn't save your answer. Check your connection and try again."
+        );
+        return;
+      }
 
       const isLast = currentIndex >= session.totalQuestions - 1;
       if (isLast) {
         setSelectedAnswer(answer);
         setSubmitted(true);
         if (myResponse?.status !== 'completed') {
-          await onComplete();
+          try {
+            await onComplete();
+          } catch (err) {
+            // Answer is saved but the completion flip failed. Roll the UI
+            // back so the SUBMIT button reappears for the student to retry,
+            // otherwise they'd see "Quiz complete!" while their doc stays
+            // in_progress on the teacher's monitor.
+            console.error('[QuizStudentApp] onComplete failed:', err);
+            setSubmitted(false);
+            setSubmitError(
+              "Couldn't finish submitting. Check your connection and tap SUBMIT again."
+            );
+          }
         }
       } else {
         setLocalIndex(localIndex + 1);
       }
     } finally {
+      submittingRef.current = false;
       setSubmitting(false);
     }
   };
@@ -997,6 +1033,16 @@ const ActiveQuiz: React.FC<{
         <h2 className="text-xl font-bold text-white mb-8 leading-snug">
           {currentQuestion.text}
         </h2>
+
+        {submitError && (
+          <div
+            role="alert"
+            className="mb-6 p-4 bg-red-500/15 border border-red-500/40 rounded-2xl flex items-start gap-3 animate-in fade-in slide-in-from-top-2"
+          >
+            <AlertCircle className="w-5 h-5 text-red-400 shrink-0 mt-0.5" />
+            <p className="text-red-200 text-sm font-medium">{submitError}</p>
+          </div>
+        )}
 
         {/* Answer area */}
         {currentQuestion.type === 'MC' && (

--- a/components/widgets/QuizWidget/components/QuizResults.tsx
+++ b/components/widgets/QuizWidget/components/QuizResults.tsx
@@ -293,6 +293,84 @@ export const QuizResults: React.FC<QuizResultsProps> = ({
     }
   }, [completed.length, hasNames, addToast, handleSendToScoreboard]);
 
+  // Stale PLC sheet recovery, shared by handleExport and handleUpdateSheet.
+  //   - 404 = the sheet is gone in Drive. Clear cached URL on the owning
+  //     PLC, create a fresh sheet in this teacher's Drive, share with
+  //     teammates, return the new URL so the caller retries. Safe because
+  //     no one else has a working URL either.
+  //   - 403 = the sheet exists, but THIS teacher lacks access. Almost
+  //     always a member who joined after the sheet was created and
+  //     reconciliation hasn't run. Do NOT regenerate — that would orphan
+  //     the existing sheet for every teammate who can still reach it.
+  //     Surface a clear "ask the PLC lead for access" toast and rethrow
+  //     so the caller stops.
+  //
+  // Returns the new canonical URL on a successful 404 regenerate, or
+  // rethrows otherwise. Caller is responsible for retrying with the
+  // returned URL.
+  const recoverFromStalePlcSheet = async (
+    err: unknown,
+    sheetUrl: string,
+    plcMode: boolean | undefined,
+    svc: QuizDriveService
+  ): Promise<string> => {
+    if (
+      !(err instanceof PlcSheetMissingError) ||
+      !plcMode ||
+      !sheetUrl ||
+      !user
+    ) {
+      throw err;
+    }
+    // Use filter + require exactly-one match. `find` would silently pick
+    // the first when two PLCs accidentally share the same URL (legacy
+    // manual-paste assignments); we'd rather surface the original error
+    // than touch the wrong plcs/{id}.
+    const matchingPlcs = plcs.filter((p) => p.sharedSheetUrl === sheetUrl);
+    const owningPlc = matchingPlcs.length === 1 ? matchingPlcs[0] : null;
+    if (err.status === 403) {
+      // Rethrow with the actionable message so the inline banner matches
+      // the toast — the raw PlcSheetMissingError message ("Shared PLC
+      // sheet is missing or inaccessible.") would be confusing here since
+      // the sheet isn't actually missing, this user just lacks writer access.
+      const accessDeniedMessage = owningPlc
+        ? `You don't have access to the ${owningPlc.name} PLC sheet yet — ask the PLC lead to grant you writer access.`
+        : "You don't have access to this PLC sheet — ask the PLC lead to grant you writer access.";
+      addToast(accessDeniedMessage, 'error');
+      throw new Error(accessDeniedMessage);
+    }
+    // 404 → regenerate, but only when we can pin the URL to a single PLC.
+    // Multiple matches → ambiguous, no match → we don't know which
+    // plcs/{id} to update.
+    if (!owningPlc) {
+      throw err;
+    }
+    await clearPlcSharedSheetUrl(owningPlc.id);
+    const created = await svc.createPlcSheetAndShare({
+      plcName: owningPlc.name,
+      memberEmailsToShareWith: getPlcTeammateEmails(owningPlc, user.uid),
+    });
+    const canonical = await setPlcSharedSheetUrl(owningPlc.id, created.url);
+    // Persist the new canonical URL onto the widget config + active
+    // assignment so the next export doesn't re-trigger the 404 path
+    // against the stale URL still cached on those docs.
+    if (onPlcSheetUrlReplaced) {
+      try {
+        await onPlcSheetUrlReplaced(canonical);
+      } catch (persistErr) {
+        console.error(
+          '[QuizResults] Failed to persist regenerated PLC URL:',
+          persistErr
+        );
+      }
+    }
+    addToast(
+      'The previous PLC sheet was missing — created a fresh one.',
+      'info'
+    );
+    return canonical;
+  };
+
   const handleExport = async () => {
     if (!googleAccessToken) {
       setExportError(
@@ -321,79 +399,17 @@ export const QuizResults: React.FC<QuizResultsProps> = ({
           exportOpts
         );
       } catch (exportErr) {
-        // Stale PLC sheet recovery, narrow:
-        //   - 404 = the sheet is gone in Drive. Clear cached URL on the
-        //     owning PLC, create a fresh sheet in this teacher's Drive,
-        //     share with teammates, retry. Safe because no one else has
-        //     a working URL either.
-        //   - 403 = the sheet exists, but THIS teacher lacks access.
-        //     Almost always means they're a member who joined after the
-        //     sheet was created and reconciliation hasn't run / failed.
-        //     Do NOT regenerate — that would orphan the existing sheet
-        //     for every teammate who can still reach it. Instead surface
-        //     a clear "ask the PLC lead for access" toast.
-        if (
-          !(exportErr instanceof PlcSheetMissingError) ||
-          !config.plcMode ||
-          !config.plcSheetUrl ||
-          !user
-        ) {
-          throw exportErr;
-        }
-        // Use filter + require exactly-one match. `find` would silently
-        // pick the first when two PLCs accidentally share the same URL
-        // (legacy manual-paste assignments); we'd rather surface the
-        // original error than touch the wrong plcs/{id}.
-        const matchingPlcs = plcs.filter(
-          (p) => p.sharedSheetUrl === config.plcSheetUrl
+        const canonical = await recoverFromStalePlcSheet(
+          exportErr,
+          config.plcSheetUrl ?? '',
+          config.plcMode,
+          svc
         );
-        const owningPlc = matchingPlcs.length === 1 ? matchingPlcs[0] : null;
-        if (exportErr.status === 403) {
-          // Rethrow with the actionable message so the inline export
-          // banner matches the toast — the raw PlcSheetMissingError
-          // message ("Shared PLC sheet is missing or inaccessible.")
-          // would be confusing here since the sheet isn't actually
-          // missing, this user just lacks writer access.
-          const accessDeniedMessage = owningPlc
-            ? `You don't have access to the ${owningPlc.name} PLC sheet yet — ask the PLC lead to grant you writer access.`
-            : "You don't have access to this PLC sheet — ask the PLC lead to grant you writer access.";
-          addToast(accessDeniedMessage, 'error');
-          throw new Error(accessDeniedMessage);
-        }
-        // 404 → regenerate, but only when we can pin the URL to a single
-        // PLC. Multiple matches → ambiguous, single none → we don't know
-        // which plcs/{id} to update.
-        if (!owningPlc) {
-          throw exportErr;
-        }
-        await clearPlcSharedSheetUrl(owningPlc.id);
-        const created = await svc.createPlcSheetAndShare({
-          plcName: owningPlc.name,
-          memberEmailsToShareWith: getPlcTeammateEmails(owningPlc, user.uid),
-        });
-        const canonical = await setPlcSharedSheetUrl(owningPlc.id, created.url);
-        // Persist the new canonical URL onto the widget config + active
-        // assignment so the next export doesn't re-trigger the 404 path
-        // against the stale URL still cached on those docs.
-        if (onPlcSheetUrlReplaced) {
-          try {
-            await onPlcSheetUrlReplaced(canonical);
-          } catch (persistErr) {
-            console.error(
-              '[QuizResults] Failed to persist regenerated PLC URL:',
-              persistErr
-            );
-          }
-        }
         url = await svc.exportResultsToSheet(
           quiz.title,
           responses,
           quiz.questions,
           { ...exportOpts, plcSheetUrl: canonical }
-        );
-        addToast(
-          'The previous PLC sheet was missing — created a fresh one.',
-          'info'
         );
       }
       setExportUrl(url);
@@ -416,14 +432,23 @@ export const QuizResults: React.FC<QuizResultsProps> = ({
         });
       }
       if (onExportedResponseIdsSaved) {
-        void Promise.resolve(onExportedResponseIdsSaved(exportedIds)).catch(
-          (err: unknown) => {
-            console.warn(
-              '[QuizResults] failed to persist exportedResponseIds to assignment doc',
-              err
-            );
-          }
-        );
+        // Await so a silent persistence failure can be surfaced. If we
+        // returned early on the void promise, a reload would re-seed
+        // exportedResponseIds from stale Firestore and the next UPDATE
+        // SHEET would re-append already-exported rows.
+        try {
+          await Promise.resolve(onExportedResponseIdsSaved(exportedIds));
+        } catch (saveErr) {
+          console.warn(
+            '[QuizResults] failed to persist exportedResponseIds to assignment doc',
+            saveErr
+          );
+          addToast(
+            "Sheet exported, but couldn't record which rows were exported. " +
+              'Reload before tapping UPDATE SHEET to avoid duplicate rows.',
+            'error'
+          );
+        }
       }
       if (config.plcMode) {
         addToast('Results exported to shared PLC sheet', 'success');
@@ -453,39 +478,70 @@ export const QuizResults: React.FC<QuizResultsProps> = ({
     setExportError(null);
     try {
       const svc = new QuizDriveService(googleAccessToken);
+      const appendOpts = {
+        pinToName: exportPinToName,
+        byStudentUid,
+        teacherName: config.teacherName,
+        periodName: config.periodName,
+        plcMode: true,
+        plcSheetUrl: exportUrl,
+      };
       // Reuse the PLC-mode append path: it builds the same headers + rows
       // as the original export and uses appendToExistingSheet under the
       // hood. Works whether the original export was solo or PLC — both
       // produce a sheet whose first tab accepts row appends.
-      await svc.exportResultsToSheet(
-        quiz.title,
-        newResponsesToAppend,
-        quiz.questions,
-        {
-          pinToName: exportPinToName,
-          byStudentUid,
-          teacherName: config.teacherName,
-          periodName: config.periodName,
-          plcMode: true,
-          plcSheetUrl: exportUrl,
-        }
-      );
+      let appendUrl = exportUrl;
+      try {
+        await svc.exportResultsToSheet(
+          quiz.title,
+          newResponsesToAppend,
+          quiz.questions,
+          appendOpts
+        );
+      } catch (appendErr) {
+        // Same stale-sheet recovery as the initial export: 404 → regenerate
+        // and retry, 403 → "ask the PLC lead". Without this branch UPDATE
+        // SHEET dead-ends on a stale URL with a raw error message.
+        const canonical = await recoverFromStalePlcSheet(
+          appendErr,
+          exportUrl,
+          config.plcMode,
+          svc
+        );
+        appendUrl = canonical;
+        setExportUrl(canonical);
+        await svc.exportResultsToSheet(
+          quiz.title,
+          newResponsesToAppend,
+          quiz.questions,
+          { ...appendOpts, plcSheetUrl: canonical }
+        );
+      }
       const allIds = responses.map((r) => getResponseDocKey(r));
       setExportedResponseIds(allIds);
+      // Await the save: a silent failure here lets the assignment doc keep
+      // stale exportedResponseIds, so a reload re-seeds in-memory state from
+      // stale Firestore and the next UPDATE SHEET re-appends already-exported
+      // rows into the shared PLC sheet (corrupting it across teammates).
       if (onExportedResponseIdsSaved) {
-        void Promise.resolve(onExportedResponseIdsSaved(allIds)).catch(
-          (err: unknown) => {
-            console.warn(
-              '[QuizResults] failed to persist exportedResponseIds after update',
-              err
-            );
-          }
-        );
+        try {
+          await Promise.resolve(onExportedResponseIdsSaved(allIds));
+        } catch (saveErr) {
+          console.warn(
+            '[QuizResults] failed to persist exportedResponseIds after update',
+            saveErr
+          );
+          addToast(
+            "Sheet updated, but couldn't record which rows were exported. " +
+              'Reload before tapping UPDATE SHEET again to avoid duplicate rows.',
+            'error'
+          );
+        }
       }
       addToast(
         `Added ${newResponsesToAppend.length} new response${
           newResponsesToAppend.length === 1 ? '' : 's'
-        } to the sheet.`,
+        } to the sheet${appendUrl !== exportUrl ? ' (regenerated)' : ''}.`,
         'success'
       );
     } catch (err) {


### PR DESCRIPTION
## Summary

Stacks on top of #1442 with the six fixes from the review synthesis (blockers #1, #2 + importants #3-#6). Scoped to the same files PR 1442 touches.

### Blockers
1. **`handleSubmitAndAdvance` silently swallowed `onAnswer` rejection.** The try/finally had no catch and the JSX wrapper is `void handleSubmitAndAdvance(...)`, so a Firestore reject vanished — the student saw their selection still highlighted, tapped NEXT again, same failure, and their answer was lost. Wrapped `onAnswer` in try/catch and surfaced an inline red error banner so the student knows to retry.
2. **Last-question `onComplete()` rejection left an inconsistent terminal state** ("Quiz complete!" UI but doc still `in_progress`). Wrapped in try/catch; on failure roll `setSubmitted` back to `false` so the SUBMIT button reappears for retry, and surface the same banner.

### Importants
3. **`handleUpdateSheet` had no `PlcSheetMissingError` recovery** — UPDATE SHEET dead-ended on a stale URL with raw error text. Extracted the 404-regenerate / 403-ask-the-PLC-lead logic from `handleExport` into a shared `recoverFromStalePlcSheet` helper and reused it from `handleUpdateSheet`, including wiring `onPlcSheetUrlReplaced` so the regenerated URL replaces the stale `exportUrl` everywhere.
4. **`plcs` race in `DashboardView` demoted legitimate PLC members.** Gated the pending-assignment import effect on `plcsLoading` from `usePlcs` so the membership predicate waits for the `/plcs` listener to hydrate.
5. **`onExportedResponseIdsSaved` fire-and-forget could corrupt the shared sheet across sessions.** Now `await`ed inside the try on both `handleExport` and `handleUpdateSheet`; a save failure surfaces a clear "reload before tapping again to avoid duplicate rows" toast instead of an invisible `console.warn`.
6. **Double-tap race in `handleSubmitAndAdvance`.** The non-last branch never set `submitted=true` before the `await`, so a tap-storm or React 19 transition reorder could re-enter with stale `currentQuestion`/`localIndex` and double-submit. Added a `submittingRef` synchronous gate that flips immediately and blocks re-entry before the `setSubmitting` state setter applies on the next render.

## Test plan
- [x] `pnpm run type-check`, `pnpm run lint`, `pnpm run format:check` clean
- [x] `pnpm run test` — 1530 / 1530 green
- [ ] Self-paced student with offline / dropped Firestore: error banner appears under the question, selection still editable, retry succeeds
- [ ] Last-question `onComplete` failure: SUBMIT button reappears with banner; retry flips status to `completed`
- [ ] UPDATE SHEET against a deleted PLC sheet: regenerates, persists new URL, appends only new rows
- [ ] UPDATE SHEET as a PLC member who lacks writer access: clear "ask the PLC lead" toast, no orphaned regenerate
- [ ] Cold-load deep-link import as a PLC member (slow `/plcs` snapshot): linkage preserved, no false "you're not a member" toast
- [ ] Tap-storm on the NEXT button: only one answer is committed

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ed9gmCY8JLTRxXD2NzRPQU)_