### PR TITLE
chore(test): exclude .pnpm-store from Vitest discovery

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -23,6 +23,7 @@ export default mergeConfig(
         'tests/rules/**',
         'functions/**',
         '.claude/worktrees/**',
+        '.pnpm-store/**',
       ],
       coverage: { exclude: ['locales/**'] },
     },


### PR DESCRIPTION
## Summary
- pnpm's content-addressed store hardlinks `functions/src/*.test.ts` into `.pnpm-store/v10/projects/<hash>/src/`. Vitest discovers both copies, and the hardlinked copy fails on `vi.mock('crypto')` because its resolution path goes through Vite's `__vite-browser-external` shim instead of the Node mock.
- Adds `.pnpm-store/**` to the `exclude` array in `vitest.config.ts`, mirroring the ESLint-side ignore added in 2000fe1f.
- Out-of-scope follow-up to PR #1445 — same root cause, Vitest side.

## Test plan
- [x] `pnpm exec vitest list 2>&1 | grep .pnpm-store` returns nothing
- [x] `pnpm run test` — 167 test files / 1583 tests passing, zero failures (was previously `1 failed | 176 passed` on machines with a populated `.pnpm-store/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)