### PR TITLE
fix(quiz): per-period PIN lookup + monitor UX overhaul

### DIFF
--- a/components/common/library/PeriodSelector.tsx
+++ b/components/common/library/PeriodSelector.tsx
@@ -10,7 +10,7 @@
  * ports over unchanged.
  */
 
-import React, { useCallback, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useId, useRef, useState } from 'react';
 import { X, Check } from 'lucide-react';
 import { useClickOutside } from '@/hooks/useClickOutside';
 import type { PeriodSelectorProps } from './types';
@@ -24,7 +24,17 @@ export const PeriodSelector: React.FC<PeriodSelectorProps> = ({
 }) => {
   const [selected, setSelected] = useState<string[]>(selectedPeriodNames);
   const ref = useRef<HTMLDivElement>(null);
+  const titleId = useId();
   useClickOutside(ref, onClose);
+
+  // Dismiss on Escape so the popover behaves like a real dialog.
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    document.addEventListener('keydown', handleKey);
+    return () => document.removeEventListener('keydown', handleKey);
+  }, [onClose]);
 
   const lockedSet = new Set(lockedPeriodNames);
 
@@ -34,14 +44,22 @@ export const PeriodSelector: React.FC<PeriodSelectorProps> = ({
     );
   };
 
+  // Save is disabled when nothing is selected: a zero-period selection
+  // would silently filter the consuming view to empty without giving the
+  // user any signal as to why.
+  const canSave = selected.length > 0;
   const handleSave = useCallback(() => {
+    if (!canSave) return;
     onSave(selected);
     onClose();
-  }, [selected, onSave, onClose]);
+  }, [canSave, selected, onSave, onClose]);
 
   return (
     <div
       ref={ref}
+      role="dialog"
+      aria-modal="false"
+      aria-labelledby={titleId}
       className="absolute z-50 bg-white rounded-xl shadow-xl border border-slate-200 overflow-hidden animate-in zoom-in-95 duration-150"
       style={{
         width: 'min(240px, 60cqmin)',
@@ -51,7 +69,10 @@ export const PeriodSelector: React.FC<PeriodSelectorProps> = ({
       }}
     >
       <div className="flex items-center justify-between px-3 py-2 border-b border-slate-100">
-        <span className="text-xs font-bold text-slate-500 uppercase tracking-widest">
+        <span
+          id={titleId}
+          className="text-xs font-bold text-slate-500 uppercase tracking-widest"
+        >
           Class Periods
         </span>
         <button
@@ -102,20 +123,30 @@ export const PeriodSelector: React.FC<PeriodSelectorProps> = ({
           </p>
         )}
       </div>
-      <div className="flex items-center justify-end gap-2 border-t border-slate-100 px-3 py-2">
-        <button
-          onClick={onClose}
-          className="text-xs font-medium text-slate-500 hover:text-slate-700 px-2 py-1 rounded transition-colors"
-        >
-          Cancel
-        </button>
-        <button
-          onClick={handleSave}
-          className="flex items-center gap-1 text-xs font-bold text-white bg-indigo-600 hover:bg-indigo-700 px-3 py-1.5 rounded-lg transition-colors"
-        >
-          <Check className="w-3 h-3" />
-          Save
-        </button>
+      <div className="flex items-center justify-between gap-2 border-t border-slate-100 px-3 py-2">
+        {!canSave ? (
+          <span className="text-xxs text-rose-500 font-medium">
+            Select at least one period
+          </span>
+        ) : (
+          <span />
+        )}
+        <div className="flex items-center gap-2">
+          <button
+            onClick={onClose}
+            className="text-xs font-medium text-slate-500 hover:text-slate-700 px-2 py-1 rounded transition-colors"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handleSave}
+            disabled={!canSave}
+            className="flex items-center gap-1 text-xs font-bold text-white bg-indigo-600 hover:bg-indigo-700 px-3 py-1.5 rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            <Check className="w-3 h-3" />
+            Save
+          </button>
+        </div>
       </div>
     </div>
   );

--- a/components/student/StudentContexts.tsx
+++ b/components/student/StudentContexts.tsx
@@ -58,6 +58,8 @@ const mockAuth: AuthContextType = {
   disableCloseConfirmation: false,
   remoteControlEnabled: true,
   dockPosition: 'bottom',
+  quizMonitorColorsEnabled: true,
+  quizMonitorScoreDisplay: 'percent',
   updateAccountPreferences: async () => {
     // No-op in student view
   },

--- a/components/widgets/Embed/Widget.test.tsx
+++ b/components/widgets/Embed/Widget.test.tsx
@@ -65,6 +65,8 @@ vi.mock('@/context/useAuth', () => ({
     disableCloseConfirmation: false,
     remoteControlEnabled: true,
     dockPosition: 'bottom',
+    quizMonitorColorsEnabled: true,
+    quizMonitorScoreDisplay: 'percent',
     updateAccountPreferences: vi.fn(),
   })),
 }));
@@ -412,6 +414,8 @@ describe('EmbedWidget', () => {
         disableCloseConfirmation: false,
         remoteControlEnabled: true,
         dockPosition: 'bottom',
+        quizMonitorColorsEnabled: true,
+        quizMonitorScoreDisplay: 'percent',
         updateAccountPreferences: vi.fn(),
         orgId: null,
         roleId: null,

--- a/components/widgets/QuizWidget/components/QuizLiveMonitor.tsx
+++ b/components/widgets/QuizWidget/components/QuizLiveMonitor.tsx
@@ -66,6 +66,7 @@ import { useAssignmentPseudonymsMulti } from '@/hooks/useAssignmentPseudonyms';
 import { db } from '@/config/firebase';
 import { useAuth } from '@/context/useAuth';
 import { useDialog } from '@/context/useDialog';
+import { useDashboard } from '@/context/useDashboard';
 import { useClickOutside } from '@/hooks/useClickOutside';
 import {
   playPodiumFanfare,
@@ -360,39 +361,58 @@ export const QuizLiveMonitor: React.FC<QuizLiveMonitorProps> = ({
   );
   // If the assignment's targeted periods change (e.g. teacher edits the
   // assignment in another tab), reset the selection rather than letting it go
-  // stale and silently filter to nothing.
+  // stale and silently filter to nothing. Two hardening details:
+  //   - skip when the new list is empty: a transient `onSnapshot` mid-write
+  //     can briefly observe `periodNames: []` and would otherwise wipe the
+  //     teacher's manual narrowing; wait for a real list to arrive.
+  //   - skip when the previous list was already non-empty AND the new
+  //     content is identical (same `Set`); the ref guard above already
+  //     handles length changes, but order-only changes shouldn't reset.
   const lastSessionPeriodsRef = useRef<string[]>(sessionPeriodNames);
-  if (
-    lastSessionPeriodsRef.current.length !== sessionPeriodNames.length ||
-    lastSessionPeriodsRef.current.some((p, i) => p !== sessionPeriodNames[i])
-  ) {
+  const prevPeriods = lastSessionPeriodsRef.current;
+  const periodsChanged =
+    prevPeriods.length !== sessionPeriodNames.length ||
+    prevPeriods.some((p, i) => p !== sessionPeriodNames[i]);
+  if (periodsChanged && sessionPeriodNames.length > 0) {
     lastSessionPeriodsRef.current = sessionPeriodNames;
     setSelectedPeriodNames(sessionPeriodNames);
   }
+
+  // True when the user has narrowed the session's targeted periods. Used
+  // both as the filter switch below and to keep the toolbar visible when
+  // the narrowed view is empty (so the teacher can recover).
+  const filterActive =
+    sessionPeriodNames.length > 1 &&
+    selectedPeriodNames.length < sessionPeriodNames.length;
 
   // Apply the class-period filter to the response stream that drives the
   // monitor's KPIs and roster. Leaderboard broadcasts intentionally use the
   // unfiltered `responses` so the student-facing leaderboard stays global.
   const filteredResponses = useMemo(() => {
-    // No filter active when the assignment targets a single period or when
-    // the selection covers every targeted period.
-    if (
-      sessionPeriodNames.length < 2 ||
-      selectedPeriodNames.length === sessionPeriodNames.length
-    ) {
-      return responses;
-    }
+    if (!filterActive) return responses;
     const allow = new Set(selectedPeriodNames);
+    // Drop SSO/legacy rows that have no `classPeriod`: when the teacher
+    // narrows to a specific period they expect a clean view, and a row
+    // with no period claim should not silently leak through.
     return responses.filter((r) =>
-      r.classPeriod ? allow.has(r.classPeriod) : true
+      r.classPeriod ? allow.has(r.classPeriod) : false
     );
-  }, [responses, selectedPeriodNames, sessionPeriodNames]);
+  }, [responses, selectedPeriodNames, filterActive]);
+
+  const { addToast } = useDashboard();
 
   const handleToggleColors = useCallback(() => {
-    void updateAccountPreferences({
-      quizMonitorColorsEnabled: !quizMonitorColorsEnabled,
-    });
-  }, [quizMonitorColorsEnabled, updateAccountPreferences]);
+    const next = !quizMonitorColorsEnabled;
+    updateAccountPreferences({ quizMonitorColorsEnabled: next }).catch(
+      (err: unknown) => {
+        console.error('[QuizLiveMonitor] persist colors toggle failed:', err);
+        addToast(
+          'Could not save the Colors preference — try again or check your connection.',
+          'error'
+        );
+      }
+    );
+  }, [quizMonitorColorsEnabled, updateAccountPreferences, addToast]);
 
   const handleCycleScoreDisplay = useCallback(() => {
     const next: 'percent' | 'count' | 'hidden' =
@@ -401,8 +421,19 @@ export const QuizLiveMonitor: React.FC<QuizLiveMonitorProps> = ({
         : quizMonitorScoreDisplay === 'count'
           ? 'hidden'
           : 'percent';
-    void updateAccountPreferences({ quizMonitorScoreDisplay: next });
-  }, [quizMonitorScoreDisplay, updateAccountPreferences]);
+    updateAccountPreferences({ quizMonitorScoreDisplay: next }).catch(
+      (err: unknown) => {
+        console.error(
+          '[QuizLiveMonitor] persist score-display cycle failed:',
+          err
+        );
+        addToast(
+          'Could not save the score display preference — try again or check your connection.',
+          'error'
+        );
+      }
+    );
+  }, [quizMonitorScoreDisplay, updateAccountPreferences, addToast]);
   const [confirmRemove, setConfirmRemove] = useState<ResponseDocKey | null>(
     null
   );
@@ -1310,8 +1341,12 @@ export const QuizLiveMonitor: React.FC<QuizLiveMonitorProps> = ({
                 </div>
               )}
 
-              {/* 5. ROSTER show/hide + student list */}
-              {filteredResponses.length > 0 && (
+              {/* 5. ROSTER show/hide + student list. The gate also stays
+                   open when a class-period filter is active even if the
+                   filter currently produces zero rows — otherwise the
+                   filter button itself would disappear and there'd be
+                   no way for the teacher to widen the selection again. */}
+              {(responses.length > 0 || filterActive) && (
                 <div className="space-y-2">
                   <div className="flex items-center justify-between border-b border-brand-blue-primary/10 pb-1">
                     <button
@@ -1343,142 +1378,52 @@ export const QuizLiveMonitor: React.FC<QuizLiveMonitorProps> = ({
                       )}
                     </button>
                     {showRoster && (
-                      <div className="flex items-center gap-2">
-                        {sessionPeriodNames.length > 1 && (
-                          <div className="relative">
-                            <button
-                              onClick={() =>
-                                setShowPeriodFilter(!showPeriodFilter)
-                              }
-                              className={`flex items-center gap-1 font-bold rounded-md transition-all ${
-                                selectedPeriodNames.length <
-                                sessionPeriodNames.length
-                                  ? 'text-brand-blue-primary bg-brand-blue-lighter/50'
-                                  : 'text-brand-blue-primary/40 hover:text-brand-blue-primary/60'
-                              }`}
-                              style={{
-                                fontSize: 'min(9px, 2.5cqmin)',
-                                padding:
-                                  'min(3px, 0.7cqmin) min(6px, 1.5cqmin)',
-                              }}
-                              title="Filter monitor by class period"
-                              aria-label="Filter by class period"
-                              aria-expanded={showPeriodFilter}
-                            >
-                              <Filter
-                                style={{
-                                  width: 'min(12px, 3cqmin)',
-                                  height: 'min(12px, 3cqmin)',
-                                }}
-                              />
-                              {selectedPeriodNames.length ===
-                              sessionPeriodNames.length
-                                ? 'All Periods'
-                                : `${selectedPeriodNames.length}/${sessionPeriodNames.length}`}
-                            </button>
-                            {showPeriodFilter && (
-                              <PeriodSelector
-                                rosters={rosters.filter((r) =>
-                                  sessionPeriodNames.includes(r.name)
-                                )}
-                                selectedPeriodNames={selectedPeriodNames}
-                                onSave={setSelectedPeriodNames}
-                                onClose={() => setShowPeriodFilter(false)}
-                              />
-                            )}
-                          </div>
-                        )}
-                        <button
-                          onClick={handleToggleColors}
-                          className={`flex items-center gap-1 font-bold rounded-md transition-all ${
-                            quizMonitorColorsEnabled
-                              ? 'text-brand-blue-primary bg-brand-blue-lighter/50'
-                              : 'text-brand-blue-primary/40 hover:text-brand-blue-primary/60'
-                          }`}
-                          style={{
-                            fontSize: 'min(9px, 2.5cqmin)',
-                            padding: 'min(3px, 0.7cqmin) min(6px, 1.5cqmin)',
-                          }}
-                          title="Tint completed rows by score band (≥80% green, 60-79% amber, <60% rose)"
-                          aria-pressed={quizMonitorColorsEnabled}
-                        >
-                          <Palette
-                            style={{
-                              width: 'min(12px, 3cqmin)',
-                              height: 'min(12px, 3cqmin)',
-                            }}
-                          />
-                          Colors
-                        </button>
-                        <button
-                          onClick={handleCycleScoreDisplay}
-                          className="flex items-center gap-1 font-bold rounded-md transition-all text-brand-blue-primary/70 hover:text-brand-blue-primary bg-brand-blue-lighter/30"
-                          style={{
-                            fontSize: 'min(9px, 2.5cqmin)',
-                            padding: 'min(3px, 0.7cqmin) min(6px, 1.5cqmin)',
-                          }}
-                          title={`Score display: ${quizMonitorScoreDisplay} — click to cycle (% → answered/total → hidden)`}
-                          aria-label="Cycle score display"
-                        >
-                          {quizMonitorScoreDisplay === 'percent' && (
-                            <>
-                              <Percent
-                                style={{
-                                  width: 'min(12px, 3cqmin)',
-                                  height: 'min(12px, 3cqmin)',
-                                }}
-                              />
-                              %
-                            </>
-                          )}
-                          {quizMonitorScoreDisplay === 'count' && (
-                            <>
-                              <BarChart3
-                                style={{
-                                  width: 'min(12px, 3cqmin)',
-                                  height: 'min(12px, 3cqmin)',
-                                }}
-                              />
-                              n/N
-                            </>
-                          )}
-                          {quizMonitorScoreDisplay === 'hidden' && (
-                            <>
-                              <EyeOff
-                                style={{
-                                  width: 'min(12px, 3cqmin)',
-                                  height: 'min(12px, 3cqmin)',
-                                }}
-                              />
-                            </>
-                          )}
-                        </button>
-                        {session.tabWarningsEnabled !== false && (
-                          <button
-                            onClick={() => setShowTabWarnings(!showTabWarnings)}
-                            className={`flex items-center gap-1 font-bold rounded-md transition-all ${
-                              showTabWarnings
-                                ? 'text-red-500 bg-red-50'
-                                : 'text-brand-blue-primary/40 hover:text-brand-blue-primary/60'
-                            }`}
-                            style={{
-                              fontSize: 'min(9px, 2.5cqmin)',
-                              padding: 'min(3px, 0.7cqmin) min(6px, 1.5cqmin)',
-                            }}
-                            title="Show/hide tab switch warnings in roster"
-                          >
-                            <AlertTriangle
-                              style={{
-                                width: 'min(12px, 3cqmin)',
-                                height: 'min(12px, 3cqmin)',
-                              }}
-                            />
-                          </button>
-                        )}
-                      </div>
+                      <RosterToolbar
+                        rosters={rosters}
+                        sessionPeriodNames={sessionPeriodNames}
+                        selectedPeriodNames={selectedPeriodNames}
+                        onChangeSelectedPeriods={setSelectedPeriodNames}
+                        showPeriodFilter={showPeriodFilter}
+                        onTogglePeriodFilter={() =>
+                          setShowPeriodFilter(!showPeriodFilter)
+                        }
+                        onClosePeriodFilter={() => setShowPeriodFilter(false)}
+                        colorsEnabled={quizMonitorColorsEnabled}
+                        onToggleColors={handleToggleColors}
+                        scoreDisplay={quizMonitorScoreDisplay}
+                        onCycleScoreDisplay={handleCycleScoreDisplay}
+                        tabWarningsAllowed={
+                          session.tabWarningsEnabled !== false
+                        }
+                        showTabWarnings={showTabWarnings}
+                        onToggleTabWarnings={() =>
+                          setShowTabWarnings(!showTabWarnings)
+                        }
+                      />
                     )}
                   </div>
-                  {showRoster && (
+                  {showRoster && filteredResponses.length === 0 && (
+                    <div
+                      className="flex items-center justify-between rounded-xl border border-dashed border-brand-blue-primary/20 bg-white/60"
+                      style={{
+                        padding: 'min(8px, 2cqmin) min(12px, 3cqmin)',
+                        fontSize: 'min(11px, 3cqmin)',
+                      }}
+                    >
+                      <span className="text-brand-blue-primary/70 font-medium">
+                        No students match the active class-period filter.
+                      </span>
+                      <button
+                        onClick={() =>
+                          setSelectedPeriodNames(sessionPeriodNames)
+                        }
+                        className="text-brand-blue-primary font-bold hover:underline"
+                      >
+                        Clear filter
+                      </button>
+                    </div>
+                  )}
+                  {showRoster && filteredResponses.length > 0 && (
                     <div
                       className="max-h-60 overflow-y-auto pr-1 custom-scrollbar"
                       style={{
@@ -1500,6 +1445,7 @@ export const QuizLiveMonitor: React.FC<QuizLiveMonitorProps> = ({
                               response={r}
                               totalQuestions={session.totalQuestions}
                               questions={quizData.questions}
+                              scoringConfig={scoringConfig}
                               colorsEnabled={quizMonitorColorsEnabled}
                               scoreDisplay={quizMonitorScoreDisplay}
                               showTabWarnings={
@@ -1780,8 +1726,11 @@ export const QuizLiveMonitor: React.FC<QuizLiveMonitorProps> = ({
                 </div>
               )}
 
-              {/* Student roster for waiting/ended */}
-              {filteredResponses.length > 0 && (
+              {/* Student roster for waiting/ended. Same gate semantics as
+                   the active-session roster above: keep the toolbar
+                   reachable when an active filter narrows the view to
+                   zero rows. */}
+              {(responses.length > 0 || filterActive) && (
                 <div className="space-y-2 mt-2">
                   <div className="flex items-center justify-between border-b border-brand-blue-primary/10 pb-1">
                     <button
@@ -1813,142 +1762,52 @@ export const QuizLiveMonitor: React.FC<QuizLiveMonitorProps> = ({
                       )}
                     </button>
                     {showRoster && (
-                      <div className="flex items-center gap-2">
-                        {sessionPeriodNames.length > 1 && (
-                          <div className="relative">
-                            <button
-                              onClick={() =>
-                                setShowPeriodFilter(!showPeriodFilter)
-                              }
-                              className={`flex items-center gap-1 font-bold rounded-md transition-all ${
-                                selectedPeriodNames.length <
-                                sessionPeriodNames.length
-                                  ? 'text-brand-blue-primary bg-brand-blue-lighter/50'
-                                  : 'text-brand-blue-primary/40 hover:text-brand-blue-primary/60'
-                              }`}
-                              style={{
-                                fontSize: 'min(9px, 2.5cqmin)',
-                                padding:
-                                  'min(3px, 0.7cqmin) min(6px, 1.5cqmin)',
-                              }}
-                              title="Filter monitor by class period"
-                              aria-label="Filter by class period"
-                              aria-expanded={showPeriodFilter}
-                            >
-                              <Filter
-                                style={{
-                                  width: 'min(12px, 3cqmin)',
-                                  height: 'min(12px, 3cqmin)',
-                                }}
-                              />
-                              {selectedPeriodNames.length ===
-                              sessionPeriodNames.length
-                                ? 'All Periods'
-                                : `${selectedPeriodNames.length}/${sessionPeriodNames.length}`}
-                            </button>
-                            {showPeriodFilter && (
-                              <PeriodSelector
-                                rosters={rosters.filter((r) =>
-                                  sessionPeriodNames.includes(r.name)
-                                )}
-                                selectedPeriodNames={selectedPeriodNames}
-                                onSave={setSelectedPeriodNames}
-                                onClose={() => setShowPeriodFilter(false)}
-                              />
-                            )}
-                          </div>
-                        )}
-                        <button
-                          onClick={handleToggleColors}
-                          className={`flex items-center gap-1 font-bold rounded-md transition-all ${
-                            quizMonitorColorsEnabled
-                              ? 'text-brand-blue-primary bg-brand-blue-lighter/50'
-                              : 'text-brand-blue-primary/40 hover:text-brand-blue-primary/60'
-                          }`}
-                          style={{
-                            fontSize: 'min(9px, 2.5cqmin)',
-                            padding: 'min(3px, 0.7cqmin) min(6px, 1.5cqmin)',
-                          }}
-                          title="Tint completed rows by score band (≥80% green, 60-79% amber, <60% rose)"
-                          aria-pressed={quizMonitorColorsEnabled}
-                        >
-                          <Palette
-                            style={{
-                              width: 'min(12px, 3cqmin)',
-                              height: 'min(12px, 3cqmin)',
-                            }}
-                          />
-                          Colors
-                        </button>
-                        <button
-                          onClick={handleCycleScoreDisplay}
-                          className="flex items-center gap-1 font-bold rounded-md transition-all text-brand-blue-primary/70 hover:text-brand-blue-primary bg-brand-blue-lighter/30"
-                          style={{
-                            fontSize: 'min(9px, 2.5cqmin)',
-                            padding: 'min(3px, 0.7cqmin) min(6px, 1.5cqmin)',
-                          }}
-                          title={`Score display: ${quizMonitorScoreDisplay} — click to cycle (% → answered/total → hidden)`}
-                          aria-label="Cycle score display"
-                        >
-                          {quizMonitorScoreDisplay === 'percent' && (
-                            <>
-                              <Percent
-                                style={{
-                                  width: 'min(12px, 3cqmin)',
-                                  height: 'min(12px, 3cqmin)',
-                                }}
-                              />
-                              %
-                            </>
-                          )}
-                          {quizMonitorScoreDisplay === 'count' && (
-                            <>
-                              <BarChart3
-                                style={{
-                                  width: 'min(12px, 3cqmin)',
-                                  height: 'min(12px, 3cqmin)',
-                                }}
-                              />
-                              n/N
-                            </>
-                          )}
-                          {quizMonitorScoreDisplay === 'hidden' && (
-                            <>
-                              <EyeOff
-                                style={{
-                                  width: 'min(12px, 3cqmin)',
-                                  height: 'min(12px, 3cqmin)',
-                                }}
-                              />
-                            </>
-                          )}
-                        </button>
-                        {session.tabWarningsEnabled !== false && (
-                          <button
-                            onClick={() => setShowTabWarnings(!showTabWarnings)}
-                            className={`flex items-center gap-1 font-bold rounded-md transition-all ${
-                              showTabWarnings
-                                ? 'text-red-500 bg-red-50'
-                                : 'text-brand-blue-primary/40 hover:text-brand-blue-primary/60'
-                            }`}
-                            style={{
-                              fontSize: 'min(9px, 2.5cqmin)',
-                              padding: 'min(3px, 0.7cqmin) min(6px, 1.5cqmin)',
-                            }}
-                            title="Show/hide tab switch warnings in roster"
-                          >
-                            <AlertTriangle
-                              style={{
-                                width: 'min(12px, 3cqmin)',
-                                height: 'min(12px, 3cqmin)',
-                              }}
-                            />
-                          </button>
-                        )}
-                      </div>
+                      <RosterToolbar
+                        rosters={rosters}
+                        sessionPeriodNames={sessionPeriodNames}
+                        selectedPeriodNames={selectedPeriodNames}
+                        onChangeSelectedPeriods={setSelectedPeriodNames}
+                        showPeriodFilter={showPeriodFilter}
+                        onTogglePeriodFilter={() =>
+                          setShowPeriodFilter(!showPeriodFilter)
+                        }
+                        onClosePeriodFilter={() => setShowPeriodFilter(false)}
+                        colorsEnabled={quizMonitorColorsEnabled}
+                        onToggleColors={handleToggleColors}
+                        scoreDisplay={quizMonitorScoreDisplay}
+                        onCycleScoreDisplay={handleCycleScoreDisplay}
+                        tabWarningsAllowed={
+                          session.tabWarningsEnabled !== false
+                        }
+                        showTabWarnings={showTabWarnings}
+                        onToggleTabWarnings={() =>
+                          setShowTabWarnings(!showTabWarnings)
+                        }
+                      />
                     )}
                   </div>
-                  {showRoster && (
+                  {showRoster && filteredResponses.length === 0 && (
+                    <div
+                      className="flex items-center justify-between rounded-xl border border-dashed border-brand-blue-primary/20 bg-white/60"
+                      style={{
+                        padding: 'min(8px, 2cqmin) min(12px, 3cqmin)',
+                        fontSize: 'min(11px, 3cqmin)',
+                      }}
+                    >
+                      <span className="text-brand-blue-primary/70 font-medium">
+                        No students match the active class-period filter.
+                      </span>
+                      <button
+                        onClick={() =>
+                          setSelectedPeriodNames(sessionPeriodNames)
+                        }
+                        className="text-brand-blue-primary font-bold hover:underline"
+                      >
+                        Clear filter
+                      </button>
+                    </div>
+                  )}
+                  {showRoster && filteredResponses.length > 0 && (
                     <div
                       className="max-h-60 overflow-y-auto pr-1 custom-scrollbar"
                       style={{
@@ -1970,6 +1829,7 @@ export const QuizLiveMonitor: React.FC<QuizLiveMonitorProps> = ({
                               response={r}
                               totalQuestions={session.totalQuestions}
                               questions={quizData.questions}
+                              scoringConfig={scoringConfig}
                               colorsEnabled={quizMonitorColorsEnabled}
                               scoreDisplay={quizMonitorScoreDisplay}
                               showTabWarnings={
@@ -2198,10 +2058,198 @@ const InteractiveStatBox: React.FC<{
   );
 };
 
+/**
+ * Right-side controls in the roster header: period filter, Colors toggle,
+ * score-display cycle, and tab-warnings toggle. Extracted because the same
+ * cluster is rendered in two layouts (active in-question view and
+ * waiting/ended view) and the previous inline duplication was already
+ * starting to drift across edits.
+ */
+const RosterToolbar: React.FC<{
+  rosters: ClassRoster[];
+  sessionPeriodNames: string[];
+  selectedPeriodNames: string[];
+  onChangeSelectedPeriods: (names: string[]) => void;
+  showPeriodFilter: boolean;
+  onTogglePeriodFilter: () => void;
+  onClosePeriodFilter: () => void;
+  colorsEnabled: boolean;
+  onToggleColors: () => void;
+  scoreDisplay: 'percent' | 'count' | 'hidden';
+  onCycleScoreDisplay: () => void;
+  tabWarningsAllowed: boolean;
+  showTabWarnings: boolean;
+  onToggleTabWarnings: () => void;
+}> = ({
+  rosters,
+  sessionPeriodNames,
+  selectedPeriodNames,
+  onChangeSelectedPeriods,
+  showPeriodFilter,
+  onTogglePeriodFilter,
+  onClosePeriodFilter,
+  colorsEnabled,
+  onToggleColors,
+  scoreDisplay,
+  onCycleScoreDisplay,
+  tabWarningsAllowed,
+  showTabWarnings,
+  onToggleTabWarnings,
+}) => {
+  const filterActive =
+    sessionPeriodNames.length > 1 &&
+    selectedPeriodNames.length < sessionPeriodNames.length;
+  const scoreDisplayLabels = {
+    percent: 'showing percent',
+    count: 'showing answered / total',
+    hidden: 'hidden',
+  } as const;
+  return (
+    <div className="flex items-center gap-2">
+      {sessionPeriodNames.length > 1 && (
+        <div className="relative">
+          <button
+            onClick={onTogglePeriodFilter}
+            className={`flex items-center gap-1 font-bold rounded-md transition-all ${
+              filterActive
+                ? 'text-brand-blue-primary bg-brand-blue-lighter/50'
+                : 'text-brand-blue-primary/40 hover:text-brand-blue-primary/60'
+            }`}
+            style={{
+              fontSize: 'min(9px, 2.5cqmin)',
+              padding: 'min(3px, 0.7cqmin) min(6px, 1.5cqmin)',
+            }}
+            title="Filter monitor by class period"
+            aria-label="Filter by class period"
+            aria-haspopup="dialog"
+            aria-expanded={showPeriodFilter}
+          >
+            <Filter
+              style={{
+                width: 'min(12px, 3cqmin)',
+                height: 'min(12px, 3cqmin)',
+              }}
+            />
+            {filterActive
+              ? `${selectedPeriodNames.length}/${sessionPeriodNames.length}`
+              : 'All Periods'}
+          </button>
+          {showPeriodFilter && (
+            <PeriodSelector
+              rosters={rosters.filter((r) =>
+                sessionPeriodNames.includes(r.name)
+              )}
+              selectedPeriodNames={selectedPeriodNames}
+              onSave={onChangeSelectedPeriods}
+              onClose={onClosePeriodFilter}
+            />
+          )}
+        </div>
+      )}
+      <button
+        onClick={onToggleColors}
+        className={`flex items-center gap-1 font-bold rounded-md transition-all ${
+          colorsEnabled
+            ? 'text-brand-blue-primary bg-brand-blue-lighter/50'
+            : 'text-brand-blue-primary/40 hover:text-brand-blue-primary/60'
+        }`}
+        style={{
+          fontSize: 'min(9px, 2.5cqmin)',
+          padding: 'min(3px, 0.7cqmin) min(6px, 1.5cqmin)',
+        }}
+        title="Tint completed rows by score band (≥80% green, 60-79% amber, <60% rose)"
+        aria-pressed={colorsEnabled}
+      >
+        <Palette
+          style={{
+            width: 'min(12px, 3cqmin)',
+            height: 'min(12px, 3cqmin)',
+          }}
+        />
+        Colors
+      </button>
+      <button
+        onClick={onCycleScoreDisplay}
+        className="flex items-center gap-1 font-bold rounded-md transition-all text-brand-blue-primary/70 hover:text-brand-blue-primary bg-brand-blue-lighter/30"
+        style={{
+          fontSize: 'min(9px, 2.5cqmin)',
+          padding: 'min(3px, 0.7cqmin) min(6px, 1.5cqmin)',
+        }}
+        title={`Score display — ${scoreDisplayLabels[scoreDisplay]}. Click to cycle: percent → answered / total → hidden.`}
+        aria-label="Cycle score display"
+      >
+        {scoreDisplay === 'percent' && (
+          <>
+            <Percent
+              style={{
+                width: 'min(12px, 3cqmin)',
+                height: 'min(12px, 3cqmin)',
+              }}
+            />
+            %
+          </>
+        )}
+        {scoreDisplay === 'count' && (
+          <>
+            <BarChart3
+              style={{
+                width: 'min(12px, 3cqmin)',
+                height: 'min(12px, 3cqmin)',
+              }}
+            />
+            n/N
+          </>
+        )}
+        {scoreDisplay === 'hidden' && (
+          <EyeOff
+            style={{
+              width: 'min(12px, 3cqmin)',
+              height: 'min(12px, 3cqmin)',
+            }}
+          />
+        )}
+      </button>
+      {tabWarningsAllowed && (
+        <button
+          onClick={onToggleTabWarnings}
+          className={`flex items-center gap-1 font-bold rounded-md transition-all ${
+            showTabWarnings
+              ? 'text-red-500 bg-red-50'
+              : 'text-brand-blue-primary/40 hover:text-brand-blue-primary/60'
+          }`}
+          style={{
+            fontSize: 'min(9px, 2.5cqmin)',
+            padding: 'min(3px, 0.7cqmin) min(6px, 1.5cqmin)',
+          }}
+          title="Show/hide tab switch warnings in roster"
+        >
+          <AlertTriangle
+            style={{
+              width: 'min(12px, 3cqmin)',
+              height: 'min(12px, 3cqmin)',
+            }}
+          />
+        </button>
+      )}
+    </div>
+  );
+};
+
 const StudentRow: React.FC<{
   response: QuizResponse;
   totalQuestions: number;
   questions: QuizQuestion[];
+  /**
+   * Session scoring config (speed bonus, streak multiplier). When the
+   * session is gamified the percent-mode pill renders raw points (matching
+   * the gamified scoreboard) instead of a stale percentage. The score-band
+   * tinting still uses the un-bonused percentage so the proficiency tier
+   * doesn't get distorted by streak luck.
+   */
+  scoringConfig: {
+    speedBonusEnabled?: boolean;
+    streakBonusEnabled?: boolean;
+  };
   /** When true, completed-row backgrounds tint by score band; otherwise white. */
   colorsEnabled: boolean;
   /** Right-column score pill content. */
@@ -2219,6 +2267,7 @@ const StudentRow: React.FC<{
   response,
   totalQuestions,
   questions,
+  scoringConfig,
   colorsEnabled,
   scoreDisplay,
   showTabWarnings,
@@ -2230,21 +2279,30 @@ const StudentRow: React.FC<{
 }) => {
   const warnings = response.tabSwitchWarnings ?? 0;
 
-  const score =
+  // Two scores: the unmodified percentage drives the tint band (so
+  // gamification bonuses don't distort the proficiency tier), and the
+  // gamification-aware display score drives the pill text (so it agrees
+  // with the live scoreboard).
+  const bandScore =
     response.status === 'completed'
       ? getResponseScore(response, questions)
       : null;
+  const displayScore =
+    response.status === 'completed'
+      ? getDisplayScore(response, questions, scoringConfig)
+      : null;
+  const scoreSuffix = getScoreSuffix(scoringConfig);
 
   // Row background. When colors are enabled AND the student has finished,
   // tint by score band (≥80% green / 60-79% amber / <60% rose). Active and
   // joined rows always render as a clean white surface — there's no score
   // to encode yet. With colors off, every row is white.
   const rowBg = (() => {
-    if (!colorsEnabled || score == null) {
+    if (!colorsEnabled || bandScore == null) {
       return 'bg-white border-slate-200';
     }
-    if (score >= 80) return 'bg-emerald-50 border-emerald-200';
-    if (score >= 60) return 'bg-amber-50 border-amber-200';
+    if (bandScore >= 80) return 'bg-emerald-50 border-emerald-200';
+    if (bandScore >= 60) return 'bg-amber-50 border-amber-200';
     return 'bg-rose-50 border-rose-200';
   })();
 
@@ -2309,14 +2367,18 @@ const StudentRow: React.FC<{
     );
   }
 
-  // Right-column pill content.
+  // Right-column pill content. `count` mode is intentionally
+  // "answered / total" (progress), not "correct / total" — teachers
+  // running self-paced sessions want to see where each student is in
+  // the quiz, which is why the toolbar button title spells out
+  // "Answered / Total" rather than the ambiguous "n/N".
   let pillText: string | null;
   if (scoreDisplay === 'hidden') {
     pillText = null;
   } else if (scoreDisplay === 'count') {
     pillText = `${response.answers.length}/${totalQuestions}`;
-  } else if (response.status === 'completed' && score != null) {
-    pillText = `${score}%`;
+  } else if (response.status === 'completed' && displayScore != null) {
+    pillText = `${displayScore}${scoreSuffix}`;
   } else {
     // No completed score yet — fall back to progress so teachers always see
     // *something* about in-progress students even when "percent" is selected.

--- a/components/widgets/QuizWidget/components/QuizLiveMonitor.tsx
+++ b/components/widgets/QuizWidget/components/QuizLiveMonitor.tsx
@@ -32,6 +32,8 @@ import {
   Volume2,
   VolumeX,
   Palette,
+  Percent,
+  Filter,
   Medal,
   Pause,
   Play,
@@ -55,6 +57,7 @@ import {
   buildLiveLeaderboard,
   buildPinToNameMap,
   getDisplayScore,
+  getResponseScore,
   getScoreSuffix,
   isGamificationActive,
 } from '../utils/quizScoreboard';
@@ -68,6 +71,7 @@ import {
   playPodiumFanfare,
   playQuizCompleteCelebration,
 } from '@/utils/quizAudio';
+import { PeriodSelector } from '@/components/common/library/PeriodSelector';
 
 interface QuizLiveMonitorProps {
   session: QuizSession;
@@ -271,7 +275,12 @@ export const QuizLiveMonitor: React.FC<QuizLiveMonitorProps> = ({
   onBack,
 }) => {
   const { showConfirm } = useDialog();
-  const { orgId } = useAuth();
+  const {
+    orgId,
+    quizMonitorColorsEnabled,
+    quizMonitorScoreDisplay,
+    updateAccountPreferences,
+  } = useAuth();
   const pinToName = useMemo(
     () =>
       buildPinToNameMap(
@@ -331,8 +340,69 @@ export const QuizLiveMonitor: React.FC<QuizLiveMonitorProps> = ({
   const showScoreboardControl = isGamifiedSession || isLiveScoreboardActive;
 
   // New state for Phase 1 & 2 features
-  const [showAnswerColors, setShowAnswerColors] = useState(false);
   const [showTabWarnings, setShowTabWarnings] = useState(true);
+  const [showPeriodFilter, setShowPeriodFilter] = useState(false);
+
+  // Periods this assignment was launched against, deduped while preserving
+  // order. Drives the class-period filter UI: hidden when there's only a
+  // single targeted period (no filtering value), shown otherwise.
+  const sessionPeriodNames = useMemo(() => {
+    const list = session.periodNames ?? [];
+    return Array.from(new Set(list.filter((p) => typeof p === 'string' && p)));
+  }, [session.periodNames]);
+
+  // Selected periods for the live monitor view. Default = all targeted periods
+  // so a fresh open shows the same data the teacher is used to. Local state —
+  // resets between sessions, which is the right default for a transient
+  // monitor filter (teachers usually want to start with everyone visible).
+  const [selectedPeriodNames, setSelectedPeriodNames] = useState<string[]>(
+    () => sessionPeriodNames
+  );
+  // If the assignment's targeted periods change (e.g. teacher edits the
+  // assignment in another tab), reset the selection rather than letting it go
+  // stale and silently filter to nothing.
+  const lastSessionPeriodsRef = useRef<string[]>(sessionPeriodNames);
+  if (
+    lastSessionPeriodsRef.current.length !== sessionPeriodNames.length ||
+    lastSessionPeriodsRef.current.some((p, i) => p !== sessionPeriodNames[i])
+  ) {
+    lastSessionPeriodsRef.current = sessionPeriodNames;
+    setSelectedPeriodNames(sessionPeriodNames);
+  }
+
+  // Apply the class-period filter to the response stream that drives the
+  // monitor's KPIs and roster. Leaderboard broadcasts intentionally use the
+  // unfiltered `responses` so the student-facing leaderboard stays global.
+  const filteredResponses = useMemo(() => {
+    // No filter active when the assignment targets a single period or when
+    // the selection covers every targeted period.
+    if (
+      sessionPeriodNames.length < 2 ||
+      selectedPeriodNames.length === sessionPeriodNames.length
+    ) {
+      return responses;
+    }
+    const allow = new Set(selectedPeriodNames);
+    return responses.filter((r) =>
+      r.classPeriod ? allow.has(r.classPeriod) : true
+    );
+  }, [responses, selectedPeriodNames, sessionPeriodNames]);
+
+  const handleToggleColors = useCallback(() => {
+    void updateAccountPreferences({
+      quizMonitorColorsEnabled: !quizMonitorColorsEnabled,
+    });
+  }, [quizMonitorColorsEnabled, updateAccountPreferences]);
+
+  const handleCycleScoreDisplay = useCallback(() => {
+    const next: 'percent' | 'count' | 'hidden' =
+      quizMonitorScoreDisplay === 'percent'
+        ? 'count'
+        : quizMonitorScoreDisplay === 'count'
+          ? 'hidden'
+          : 'percent';
+    void updateAccountPreferences({ quizMonitorScoreDisplay: next });
+  }, [quizMonitorScoreDisplay, updateAccountPreferences]);
   const [confirmRemove, setConfirmRemove] = useState<ResponseDocKey | null>(
     null
   );
@@ -542,7 +612,10 @@ export const QuizLiveMonitor: React.FC<QuizLiveMonitorProps> = ({
       : undefined;
 
   // ⚡ Bolt: Optimize multiple array iterations inside the render loop
-  // Instead of 4 separate .filter() passes, calculate all stats in one O(N) loop
+  // Instead of 4 separate .filter() passes, calculate all stats in one O(N) loop.
+  // Iterates `filteredResponses` so the KPI counts and roster lists honor the
+  // active class-period filter; the live leaderboard broadcast above stays on
+  // the unfiltered `responses` so students see the full session leaderboard.
   const { answered, completed, inProgress, joined, studentsByStatus } =
     React.useMemo(() => {
       let _answered = 0;
@@ -555,7 +628,7 @@ export const QuizLiveMonitor: React.FC<QuizLiveMonitorProps> = ({
         finished: StatBoxStudent[];
       } = { joined: [], active: [], finished: [] };
 
-      for (const r of responses) {
+      for (const r of filteredResponses) {
         if (currentQ && r.answers.some((a) => a.questionId === currentQ.id)) {
           _answered++;
         }
@@ -586,7 +659,7 @@ export const QuizLiveMonitor: React.FC<QuizLiveMonitorProps> = ({
         joined: _joined,
         studentsByStatus: byStatus,
       };
-    }, [responses, currentQ, pinToName, byStudentUid]);
+    }, [filteredResponses, currentQ, pinToName, byStudentUid]);
 
   const modeIcon =
     session.sessionMode === 'auto' ? (
@@ -791,9 +864,9 @@ export const QuizLiveMonitor: React.FC<QuizLiveMonitorProps> = ({
                       marginTop: 'min(4px, 1cqmin)',
                     }}
                   >
-                    {completed} of {responses.length} finished
-                    {responses.length > 0 &&
-                      ` (${Math.round((completed / responses.length) * 100)}%)`}
+                    {completed} of {filteredResponses.length} finished
+                    {filteredResponses.length > 0 &&
+                      ` (${Math.round((completed / filteredResponses.length) * 100)}%)`}
                   </p>
                 </div>
               ) : (
@@ -979,7 +1052,7 @@ export const QuizLiveMonitor: React.FC<QuizLiveMonitorProps> = ({
                     >
                       <span>Answered</span>
                       <span>
-                        {answered} / {responses.length}
+                        {answered} / {filteredResponses.length}
                       </span>
                     </div>
                     <div
@@ -989,7 +1062,7 @@ export const QuizLiveMonitor: React.FC<QuizLiveMonitorProps> = ({
                       <div
                         className="h-full bg-emerald-500 rounded-full transition-all duration-500 shadow-[0_0_8px_rgba(16,185,129,0.3)]"
                         style={{
-                          width: `${responses.length > 0 ? (answered / responses.length) * 100 : 0}%`,
+                          width: `${filteredResponses.length > 0 ? (answered / filteredResponses.length) * 100 : 0}%`,
                         }}
                       />
                     </div>
@@ -1238,7 +1311,7 @@ export const QuizLiveMonitor: React.FC<QuizLiveMonitorProps> = ({
               )}
 
               {/* 5. ROSTER show/hide + student list */}
-              {responses.length > 0 && (
+              {filteredResponses.length > 0 && (
                 <div className="space-y-2">
                   <div className="flex items-center justify-between border-b border-brand-blue-primary/10 pb-1">
                     <button
@@ -1249,7 +1322,7 @@ export const QuizLiveMonitor: React.FC<QuizLiveMonitorProps> = ({
                         className="text-brand-blue-primary/60 font-black uppercase tracking-widest"
                         style={{ fontSize: 'min(10px, 3cqmin)' }}
                       >
-                        Roster · {responses.length}
+                        Roster · {filteredResponses.length}
                       </span>
                       {showRoster ? (
                         <EyeOff
@@ -1271,10 +1344,54 @@ export const QuizLiveMonitor: React.FC<QuizLiveMonitorProps> = ({
                     </button>
                     {showRoster && (
                       <div className="flex items-center gap-2">
+                        {sessionPeriodNames.length > 1 && (
+                          <div className="relative">
+                            <button
+                              onClick={() =>
+                                setShowPeriodFilter(!showPeriodFilter)
+                              }
+                              className={`flex items-center gap-1 font-bold rounded-md transition-all ${
+                                selectedPeriodNames.length <
+                                sessionPeriodNames.length
+                                  ? 'text-brand-blue-primary bg-brand-blue-lighter/50'
+                                  : 'text-brand-blue-primary/40 hover:text-brand-blue-primary/60'
+                              }`}
+                              style={{
+                                fontSize: 'min(9px, 2.5cqmin)',
+                                padding:
+                                  'min(3px, 0.7cqmin) min(6px, 1.5cqmin)',
+                              }}
+                              title="Filter monitor by class period"
+                              aria-label="Filter by class period"
+                              aria-expanded={showPeriodFilter}
+                            >
+                              <Filter
+                                style={{
+                                  width: 'min(12px, 3cqmin)',
+                                  height: 'min(12px, 3cqmin)',
+                                }}
+                              />
+                              {selectedPeriodNames.length ===
+                              sessionPeriodNames.length
+                                ? 'All Periods'
+                                : `${selectedPeriodNames.length}/${sessionPeriodNames.length}`}
+                            </button>
+                            {showPeriodFilter && (
+                              <PeriodSelector
+                                rosters={rosters.filter((r) =>
+                                  sessionPeriodNames.includes(r.name)
+                                )}
+                                selectedPeriodNames={selectedPeriodNames}
+                                onSave={setSelectedPeriodNames}
+                                onClose={() => setShowPeriodFilter(false)}
+                              />
+                            )}
+                          </div>
+                        )}
                         <button
-                          onClick={() => setShowAnswerColors(!showAnswerColors)}
+                          onClick={handleToggleColors}
                           className={`flex items-center gap-1 font-bold rounded-md transition-all ${
-                            showAnswerColors
+                            quizMonitorColorsEnabled
                               ? 'text-brand-blue-primary bg-brand-blue-lighter/50'
                               : 'text-brand-blue-primary/40 hover:text-brand-blue-primary/60'
                           }`}
@@ -1282,7 +1399,8 @@ export const QuizLiveMonitor: React.FC<QuizLiveMonitorProps> = ({
                             fontSize: 'min(9px, 2.5cqmin)',
                             padding: 'min(3px, 0.7cqmin) min(6px, 1.5cqmin)',
                           }}
-                          title="Color-code answers for current question"
+                          title="Tint completed rows by score band (≥80% green, 60-79% amber, <60% rose)"
+                          aria-pressed={quizMonitorColorsEnabled}
                         >
                           <Palette
                             style={{
@@ -1291,6 +1409,49 @@ export const QuizLiveMonitor: React.FC<QuizLiveMonitorProps> = ({
                             }}
                           />
                           Colors
+                        </button>
+                        <button
+                          onClick={handleCycleScoreDisplay}
+                          className="flex items-center gap-1 font-bold rounded-md transition-all text-brand-blue-primary/70 hover:text-brand-blue-primary bg-brand-blue-lighter/30"
+                          style={{
+                            fontSize: 'min(9px, 2.5cqmin)',
+                            padding: 'min(3px, 0.7cqmin) min(6px, 1.5cqmin)',
+                          }}
+                          title={`Score display: ${quizMonitorScoreDisplay} — click to cycle (% → answered/total → hidden)`}
+                          aria-label="Cycle score display"
+                        >
+                          {quizMonitorScoreDisplay === 'percent' && (
+                            <>
+                              <Percent
+                                style={{
+                                  width: 'min(12px, 3cqmin)',
+                                  height: 'min(12px, 3cqmin)',
+                                }}
+                              />
+                              %
+                            </>
+                          )}
+                          {quizMonitorScoreDisplay === 'count' && (
+                            <>
+                              <BarChart3
+                                style={{
+                                  width: 'min(12px, 3cqmin)',
+                                  height: 'min(12px, 3cqmin)',
+                                }}
+                              />
+                              n/N
+                            </>
+                          )}
+                          {quizMonitorScoreDisplay === 'hidden' && (
+                            <>
+                              <EyeOff
+                                style={{
+                                  width: 'min(12px, 3cqmin)',
+                                  height: 'min(12px, 3cqmin)',
+                                }}
+                              />
+                            </>
+                          )}
                         </button>
                         {session.tabWarningsEnabled !== false && (
                           <button
@@ -1326,7 +1487,7 @@ export const QuizLiveMonitor: React.FC<QuizLiveMonitorProps> = ({
                         flexDirection: 'column',
                       }}
                     >
-                      {responses
+                      {filteredResponses
                         .slice()
                         .sort((a, b) =>
                           (a.pin ?? '').localeCompare(b.pin ?? '')
@@ -1339,8 +1500,8 @@ export const QuizLiveMonitor: React.FC<QuizLiveMonitorProps> = ({
                               response={r}
                               totalQuestions={session.totalQuestions}
                               questions={quizData.questions}
-                              currentQuestion={currentQ}
-                              showAnswerColors={showAnswerColors}
+                              colorsEnabled={quizMonitorColorsEnabled}
+                              scoreDisplay={quizMonitorScoreDisplay}
                               showTabWarnings={
                                 showTabWarnings &&
                                 session.tabWarningsEnabled !== false
@@ -1620,7 +1781,7 @@ export const QuizLiveMonitor: React.FC<QuizLiveMonitorProps> = ({
               )}
 
               {/* Student roster for waiting/ended */}
-              {responses.length > 0 && (
+              {filteredResponses.length > 0 && (
                 <div className="space-y-2 mt-2">
                   <div className="flex items-center justify-between border-b border-brand-blue-primary/10 pb-1">
                     <button
@@ -1631,7 +1792,7 @@ export const QuizLiveMonitor: React.FC<QuizLiveMonitorProps> = ({
                         className="text-brand-blue-primary/60 font-black uppercase tracking-widest"
                         style={{ fontSize: 'min(10px, 3cqmin)' }}
                       >
-                        Roster · {responses.length}
+                        Roster · {filteredResponses.length}
                       </span>
                       {showRoster ? (
                         <EyeOff
@@ -1653,10 +1814,54 @@ export const QuizLiveMonitor: React.FC<QuizLiveMonitorProps> = ({
                     </button>
                     {showRoster && (
                       <div className="flex items-center gap-2">
+                        {sessionPeriodNames.length > 1 && (
+                          <div className="relative">
+                            <button
+                              onClick={() =>
+                                setShowPeriodFilter(!showPeriodFilter)
+                              }
+                              className={`flex items-center gap-1 font-bold rounded-md transition-all ${
+                                selectedPeriodNames.length <
+                                sessionPeriodNames.length
+                                  ? 'text-brand-blue-primary bg-brand-blue-lighter/50'
+                                  : 'text-brand-blue-primary/40 hover:text-brand-blue-primary/60'
+                              }`}
+                              style={{
+                                fontSize: 'min(9px, 2.5cqmin)',
+                                padding:
+                                  'min(3px, 0.7cqmin) min(6px, 1.5cqmin)',
+                              }}
+                              title="Filter monitor by class period"
+                              aria-label="Filter by class period"
+                              aria-expanded={showPeriodFilter}
+                            >
+                              <Filter
+                                style={{
+                                  width: 'min(12px, 3cqmin)',
+                                  height: 'min(12px, 3cqmin)',
+                                }}
+                              />
+                              {selectedPeriodNames.length ===
+                              sessionPeriodNames.length
+                                ? 'All Periods'
+                                : `${selectedPeriodNames.length}/${sessionPeriodNames.length}`}
+                            </button>
+                            {showPeriodFilter && (
+                              <PeriodSelector
+                                rosters={rosters.filter((r) =>
+                                  sessionPeriodNames.includes(r.name)
+                                )}
+                                selectedPeriodNames={selectedPeriodNames}
+                                onSave={setSelectedPeriodNames}
+                                onClose={() => setShowPeriodFilter(false)}
+                              />
+                            )}
+                          </div>
+                        )}
                         <button
-                          onClick={() => setShowAnswerColors(!showAnswerColors)}
+                          onClick={handleToggleColors}
                           className={`flex items-center gap-1 font-bold rounded-md transition-all ${
-                            showAnswerColors
+                            quizMonitorColorsEnabled
                               ? 'text-brand-blue-primary bg-brand-blue-lighter/50'
                               : 'text-brand-blue-primary/40 hover:text-brand-blue-primary/60'
                           }`}
@@ -1664,7 +1869,8 @@ export const QuizLiveMonitor: React.FC<QuizLiveMonitorProps> = ({
                             fontSize: 'min(9px, 2.5cqmin)',
                             padding: 'min(3px, 0.7cqmin) min(6px, 1.5cqmin)',
                           }}
-                          title="Color-code answers for current question"
+                          title="Tint completed rows by score band (≥80% green, 60-79% amber, <60% rose)"
+                          aria-pressed={quizMonitorColorsEnabled}
                         >
                           <Palette
                             style={{
@@ -1673,6 +1879,49 @@ export const QuizLiveMonitor: React.FC<QuizLiveMonitorProps> = ({
                             }}
                           />
                           Colors
+                        </button>
+                        <button
+                          onClick={handleCycleScoreDisplay}
+                          className="flex items-center gap-1 font-bold rounded-md transition-all text-brand-blue-primary/70 hover:text-brand-blue-primary bg-brand-blue-lighter/30"
+                          style={{
+                            fontSize: 'min(9px, 2.5cqmin)',
+                            padding: 'min(3px, 0.7cqmin) min(6px, 1.5cqmin)',
+                          }}
+                          title={`Score display: ${quizMonitorScoreDisplay} — click to cycle (% → answered/total → hidden)`}
+                          aria-label="Cycle score display"
+                        >
+                          {quizMonitorScoreDisplay === 'percent' && (
+                            <>
+                              <Percent
+                                style={{
+                                  width: 'min(12px, 3cqmin)',
+                                  height: 'min(12px, 3cqmin)',
+                                }}
+                              />
+                              %
+                            </>
+                          )}
+                          {quizMonitorScoreDisplay === 'count' && (
+                            <>
+                              <BarChart3
+                                style={{
+                                  width: 'min(12px, 3cqmin)',
+                                  height: 'min(12px, 3cqmin)',
+                                }}
+                              />
+                              n/N
+                            </>
+                          )}
+                          {quizMonitorScoreDisplay === 'hidden' && (
+                            <>
+                              <EyeOff
+                                style={{
+                                  width: 'min(12px, 3cqmin)',
+                                  height: 'min(12px, 3cqmin)',
+                                }}
+                              />
+                            </>
+                          )}
                         </button>
                         {session.tabWarningsEnabled !== false && (
                           <button
@@ -1708,7 +1957,7 @@ export const QuizLiveMonitor: React.FC<QuizLiveMonitorProps> = ({
                         flexDirection: 'column',
                       }}
                     >
-                      {responses
+                      {filteredResponses
                         .slice()
                         .sort((a, b) =>
                           (a.pin ?? '').localeCompare(b.pin ?? '')
@@ -1721,8 +1970,8 @@ export const QuizLiveMonitor: React.FC<QuizLiveMonitorProps> = ({
                               response={r}
                               totalQuestions={session.totalQuestions}
                               questions={quizData.questions}
-                              currentQuestion={currentQ}
-                              showAnswerColors={showAnswerColors}
+                              colorsEnabled={quizMonitorColorsEnabled}
+                              scoreDisplay={quizMonitorScoreDisplay}
                               showTabWarnings={
                                 showTabWarnings &&
                                 session.tabWarningsEnabled !== false
@@ -1953,8 +2202,10 @@ const StudentRow: React.FC<{
   response: QuizResponse;
   totalQuestions: number;
   questions: QuizQuestion[];
-  currentQuestion?: QuizQuestion;
-  showAnswerColors: boolean;
+  /** When true, completed-row backgrounds tint by score band; otherwise white. */
+  colorsEnabled: boolean;
+  /** Right-column score pill content. */
+  scoreDisplay: 'percent' | 'count' | 'hidden';
   showTabWarnings: boolean;
   confirmRemove: boolean;
   onConfirmRemoveToggle: () => void;
@@ -1968,8 +2219,8 @@ const StudentRow: React.FC<{
   response,
   totalQuestions,
   questions,
-  currentQuestion,
-  showAnswerColors,
+  colorsEnabled,
+  scoreDisplay,
   showTabWarnings,
   confirmRemove,
   onConfirmRemoveToggle,
@@ -1979,44 +2230,39 @@ const StudentRow: React.FC<{
 }) => {
   const warnings = response.tabSwitchWarnings ?? 0;
 
-  const correctCount = response.answers.filter((a) => {
-    const q = questions.find((qn) => qn.id === a.questionId);
-    return q ? gradeAnswer(q, a.answer) : false;
-  }).length;
+  const score =
+    response.status === 'completed'
+      ? getResponseScore(response, questions)
+      : null;
 
-  // Answer color for current question
-  let answerColorDot = 'bg-brand-gray-light'; // not answered yet
-  if (showAnswerColors && currentQuestion) {
-    const ans = response.answers.find(
-      (a) => a.questionId === currentQuestion.id
-    );
-    if (ans) {
-      answerColorDot = gradeAnswer(currentQuestion, ans.answer)
-        ? 'bg-emerald-500 shadow-[0_0_6px_rgba(16,185,129,0.4)]'
-        : 'bg-red-500 shadow-[0_0_6px_rgba(239,68,68,0.4)]';
-    } else {
-      answerColorDot = 'bg-amber-400';
+  // Row background. When colors are enabled AND the student has finished,
+  // tint by score band (≥80% green / 60-79% amber / <60% rose). Active and
+  // joined rows always render as a clean white surface — there's no score
+  // to encode yet. With colors off, every row is white.
+  const rowBg = (() => {
+    if (!colorsEnabled || score == null) {
+      return 'bg-white border-slate-200';
     }
-  } else {
-    // Status-based coloring
-    const statusDots = {
-      completed: 'bg-emerald-500 shadow-[0_0_6px_rgba(16,185,129,0.4)]',
-      'in-progress': 'bg-amber-500',
-      joined: 'bg-brand-gray-light',
-    };
-    answerColorDot = statusDots[response.status];
-  }
+    if (score >= 80) return 'bg-emerald-50 border-emerald-200';
+    if (score >= 60) return 'bg-amber-50 border-amber-200';
+    return 'bg-rose-50 border-rose-200';
+  })();
 
-  const statusBg = {
-    completed: 'bg-emerald-50 border-emerald-100',
-    'in-progress': 'bg-amber-50/50 border-amber-100',
-    joined: 'bg-white border-brand-blue-primary/5',
-  };
-  const statusText = {
-    completed: 'text-emerald-700 font-black',
-    'in-progress': 'text-amber-700 font-bold',
-    joined: 'text-brand-gray-primary font-medium',
-  };
+  // Status icon mirrors the KPI cards above (Joined → Users, Active → Clock,
+  // Finished → CheckCircle2). Renders in a neutral slate so the row band
+  // carries the semantic color.
+  const StatusIcon =
+    response.status === 'completed'
+      ? CheckCircle2
+      : response.status === 'in-progress'
+        ? Clock
+        : Users;
+  const statusIconColor =
+    response.status === 'completed'
+      ? 'text-emerald-600'
+      : response.status === 'in-progress'
+        ? 'text-amber-600'
+        : 'text-slate-400';
 
   const displayName = resolveResponseDisplayName(
     response,
@@ -2063,17 +2309,47 @@ const StudentRow: React.FC<{
     );
   }
 
+  // Right-column pill content.
+  let pillText: string | null;
+  if (scoreDisplay === 'hidden') {
+    pillText = null;
+  } else if (scoreDisplay === 'count') {
+    pillText = `${response.answers.length}/${totalQuestions}`;
+  } else if (response.status === 'completed' && score != null) {
+    pillText = `${score}%`;
+  } else {
+    // No completed score yet — fall back to progress so teachers always see
+    // *something* about in-progress students even when "percent" is selected.
+    pillText = `${response.answers.length}/${totalQuestions}`;
+  }
+  const pillTextClass =
+    response.status === 'completed'
+      ? 'text-emerald-700 font-black'
+      : response.status === 'in-progress'
+        ? 'text-amber-700 font-bold'
+        : 'text-brand-gray-primary font-medium';
+
   return (
     <div
-      className={`flex items-center rounded-xl border transition-all group/row ${statusBg[response.status]}`}
+      className={`flex items-center rounded-xl border transition-all group/row ${rowBg}`}
       style={{
         gap: 'min(8px, 2cqmin)',
         padding: 'min(8px, 2cqmin)',
       }}
     >
-      <div
-        className={`rounded-full shrink-0 ${answerColorDot}`}
-        style={{ width: 'min(8px, 2cqmin)', height: 'min(8px, 2cqmin)' }}
+      <StatusIcon
+        className={`shrink-0 ${statusIconColor}`}
+        style={{
+          width: 'min(14px, 3.5cqmin)',
+          height: 'min(14px, 3.5cqmin)',
+        }}
+        aria-label={
+          response.status === 'completed'
+            ? 'Finished'
+            : response.status === 'in-progress'
+              ? 'Active'
+              : 'Joined'
+        }
       />
       <span
         className="flex-1 flex items-center gap-1.5 text-brand-blue-dark font-bold truncate"
@@ -2108,14 +2384,14 @@ const StudentRow: React.FC<{
           </span>
         )}
       </span>
-      <span
-        className={`px-1.5 py-0.5 rounded-md bg-white/60 border border-white/80 ${statusText[response.status]}`}
-        style={{ fontSize: 'min(11px, 3cqmin)' }}
-      >
-        {response.status === 'completed'
-          ? `${Math.round((correctCount / Math.max(totalQuestions, 1)) * 100)}%`
-          : `${response.answers.length}/${totalQuestions}`}
-      </span>
+      {pillText !== null && (
+        <span
+          className={`px-1.5 py-0.5 rounded-md bg-white/60 border border-white/80 ${pillTextClass}`}
+          style={{ fontSize: 'min(11px, 3cqmin)' }}
+        >
+          {pillText}
+        </span>
+      )}
       {/* Remove button */}
       {onRemove && (
         <button

--- a/components/widgets/QuizWidget/components/QuizResults.tsx
+++ b/components/widgets/QuizWidget/components/QuizResults.tsx
@@ -410,7 +410,6 @@ export const QuizResults: React.FC<QuizResultsProps> = ({
         pinToName: exportPinToName,
         byStudentUid,
         teacherName: config.teacherName,
-        periodName: config.periodName,
         plcMode: config.plcMode,
         // Prefer the active assignment's `plc.sheetUrl` (per-assignment
         // model). Fall back to `config.plcSheetUrl` for legacy assignments
@@ -532,7 +531,6 @@ export const QuizResults: React.FC<QuizResultsProps> = ({
         pinToName: exportPinToName,
         byStudentUid,
         teacherName: config.teacherName,
-        periodName: config.periodName,
         plcMode: true,
         plcSheetUrl: exportUrl,
       };

--- a/components/widgets/QuizWidget/utils/quizScoreboard.test.ts
+++ b/components/widgets/QuizWidget/utils/quizScoreboard.test.ts
@@ -451,8 +451,9 @@ describe('quizScoreboard', () => {
       ];
       const map = buildPinToNameMap(rosters, ['Period 1']);
       expect(resolvePinName(map, 'Period 1', '02')).toBe('Bob Jones');
-      // The empty-PIN student isn't reachable
-      expect(Object.values(map)).not.toContain('Alice Smith');
+      // The empty-PIN student is not reachable from any path. Exhaustive
+      // assertion: Alice's name appears nowhere in the resulting map.
+      expect(Object.values(map)).toEqual(['Bob Jones', 'Bob Jones']);
     });
 
     it('handles students with only first name', () => {
@@ -488,6 +489,43 @@ describe('quizScoreboard', () => {
       expect(resolvePinName(map, 'Period 2', '1')).toBe('Alice2 Smith2');
     });
 
+    it('period-scoped tier short-circuits before any fallback', () => {
+      // Defensive: if a future refactor reorders the fallback ladder so
+      // the suffix scan runs before the period-scoped lookup, this test
+      // would catch it. Period 1's Alice must win even though Period 2
+      // also has someone at PIN 01.
+      const rosters = [
+        makeRoster('Period 1', [
+          { firstName: 'Alice', lastName: 'Smith', pin: '01' },
+        ]),
+        makeRoster('Period 2', [
+          { firstName: 'Bob', lastName: 'Jones', pin: '01' },
+        ]),
+      ];
+      const map = buildPinToNameMap(rosters, ['Period 1', 'Period 2']);
+      expect(resolvePinName(map, 'Period 1', '01')).toBe('Alice Smith');
+      expect(resolvePinName(map, 'Period 1', '1')).toBe('Alice Smith');
+    });
+
+    it('returns undefined when classPeriod is provided but does not match any roster', () => {
+      // Wrong-period responses (typo, deleted roster, drift between
+      // periodNames and rosters) used to silently fall through to the
+      // legacy suffix scan and resolve to whichever student happens to
+      // share the PIN. The fix returns `undefined` so the UI renders
+      // `PIN <n>` and the mismatch is visible.
+      const rosters = [
+        makeRoster('Period 1', [
+          { firstName: 'Alice', lastName: 'Smith', pin: '01' },
+        ]),
+        makeRoster('Period 2', [
+          { firstName: 'Bob', lastName: 'Jones', pin: '01' },
+        ]),
+      ];
+      const map = buildPinToNameMap(rosters, ['Period 1', 'Period 2']);
+      expect(resolvePinName(map, 'Period 9', '01')).toBeUndefined();
+      expect(resolvePinName(map, 'Nonexistent', '1')).toBeUndefined();
+    });
+
     it('falls back to suffix scan when classPeriod is missing (legacy path)', () => {
       // SSO joiners and pre-period-scoping responses may have no
       // `classPeriod`. Behave like the old "first match wins" lookup so
@@ -501,6 +539,30 @@ describe('quizScoreboard', () => {
       expect(resolvePinName(map, undefined, '01')).toBe('Alice Smith');
       expect(resolvePinName(map, '', '01')).toBe('Alice Smith');
       expect(resolvePinName(map, null, '1')).toBe('Alice Smith');
+    });
+
+    it('warns when the legacy suffix scan finds multiple distinct candidates', () => {
+      const rosters = [
+        makeRoster('Period 1', [
+          { firstName: 'Alice', lastName: 'Smith', pin: '01' },
+        ]),
+        makeRoster('Period 2', [
+          { firstName: 'Bob', lastName: 'Jones', pin: '01' },
+        ]),
+      ];
+      const map = buildPinToNameMap(rosters, ['Period 1', 'Period 2']);
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {
+        /* suppress expected warning */
+      });
+      try {
+        const result = resolvePinName(map, undefined, '01');
+        expect(['Alice Smith', 'Bob Jones']).toContain(result);
+        expect(warnSpy).toHaveBeenCalledWith(
+          expect.stringContaining('Ambiguous PIN 01')
+        );
+      } finally {
+        warnSpy.mockRestore();
+      }
     });
 
     it('returns undefined for unknown PINs', () => {

--- a/components/widgets/QuizWidget/utils/quizScoreboard.test.ts
+++ b/components/widgets/QuizWidget/utils/quizScoreboard.test.ts
@@ -31,6 +31,7 @@ import {
   buildPinToExportNameMap,
   buildScoreboardTeams,
   buildLiveLeaderboard,
+  resolvePinName,
 } from './quizScoreboard';
 import type {
   QuizResponse,
@@ -406,7 +407,7 @@ describe('quizScoreboard', () => {
   });
 
   describe('buildPinToNameMap', () => {
-    it('returns a map from PIN to full name when roster matches', () => {
+    it('resolves a PIN to a full name when roster matches', () => {
       const rosters = [
         makeRoster('Period 1', [
           { firstName: 'Alice', lastName: 'Smith', pin: '01' },
@@ -414,13 +415,11 @@ describe('quizScoreboard', () => {
         ]),
       ];
       const map = buildPinToNameMap(rosters, ['Period 1']);
-      // Includes both zero-padded and stripped forms for flexible matching
-      expect(map).toEqual({
-        '01': 'Alice Smith',
-        '1': 'Alice Smith',
-        '02': 'Bob Jones',
-        '2': 'Bob Jones',
-      });
+      // Both zero-padded and stripped forms work
+      expect(resolvePinName(map, 'Period 1', '01')).toBe('Alice Smith');
+      expect(resolvePinName(map, 'Period 1', '1')).toBe('Alice Smith');
+      expect(resolvePinName(map, 'Period 1', '02')).toBe('Bob Jones');
+      expect(resolvePinName(map, 'Period 1', '2')).toBe('Bob Jones');
     });
 
     it('returns empty map when no matching roster is found', () => {
@@ -451,10 +450,9 @@ describe('quizScoreboard', () => {
         ]),
       ];
       const map = buildPinToNameMap(rosters, ['Period 1']);
-      expect(map).toEqual({
-        '02': 'Bob Jones',
-        '2': 'Bob Jones',
-      });
+      expect(resolvePinName(map, 'Period 1', '02')).toBe('Bob Jones');
+      // The empty-PIN student isn't reachable
+      expect(Object.values(map)).not.toContain('Alice Smith');
     });
 
     it('handles students with only first name', () => {
@@ -464,10 +462,14 @@ describe('quizScoreboard', () => {
         ]),
       ];
       const map = buildPinToNameMap(rosters, ['Period 1']);
-      expect(map).toEqual({ '01': 'Cher', '1': 'Cher' });
+      expect(resolvePinName(map, 'Period 1', '01')).toBe('Cher');
+      expect(resolvePinName(map, 'Period 1', '1')).toBe('Cher');
     });
 
-    it('merges students from multiple periods (first roster wins for PIN collision)', () => {
+    it('disambiguates same PIN across multiple periods', () => {
+      // The bug this fix addresses: each roster numbers its students 01, 02,
+      // 03... so PIN 01 exists in every section. The map must scope lookups
+      // by classPeriod or all PIN-1 students collapse onto roster #1's row.
       const rosters = [
         makeRoster('Period 1', [
           { firstName: 'Alice', lastName: 'Smith', pin: '01' },
@@ -478,12 +480,39 @@ describe('quizScoreboard', () => {
         ]),
       ];
       const map = buildPinToNameMap(rosters, ['Period 1', 'Period 2']);
-      // Period 1 wins for PIN '01'
-      expect(map['01']).toBe('Alice Smith');
-      expect(map['1']).toBe('Alice Smith');
-      // Period 2 adds PIN '03'
-      expect(map['03']).toBe('Charlie Brown');
-      expect(map['3']).toBe('Charlie Brown');
+      expect(resolvePinName(map, 'Period 1', '01')).toBe('Alice Smith');
+      expect(resolvePinName(map, 'Period 2', '01')).toBe('Alice2 Smith2');
+      expect(resolvePinName(map, 'Period 2', '03')).toBe('Charlie Brown');
+      // Stripped form works the same way
+      expect(resolvePinName(map, 'Period 1', '1')).toBe('Alice Smith');
+      expect(resolvePinName(map, 'Period 2', '1')).toBe('Alice2 Smith2');
+    });
+
+    it('falls back to suffix scan when classPeriod is missing (legacy path)', () => {
+      // SSO joiners and pre-period-scoping responses may have no
+      // `classPeriod`. Behave like the old "first match wins" lookup so
+      // those paths keep working.
+      const rosters = [
+        makeRoster('Period 1', [
+          { firstName: 'Alice', lastName: 'Smith', pin: '01' },
+        ]),
+      ];
+      const map = buildPinToNameMap(rosters, ['Period 1']);
+      expect(resolvePinName(map, undefined, '01')).toBe('Alice Smith');
+      expect(resolvePinName(map, '', '01')).toBe('Alice Smith');
+      expect(resolvePinName(map, null, '1')).toBe('Alice Smith');
+    });
+
+    it('returns undefined for unknown PINs', () => {
+      const rosters = [
+        makeRoster('Period 1', [
+          { firstName: 'Alice', lastName: 'Smith', pin: '01' },
+        ]),
+      ];
+      const map = buildPinToNameMap(rosters, ['Period 1']);
+      expect(resolvePinName(map, 'Period 1', '99')).toBeUndefined();
+      expect(resolvePinName(map, 'Period 1', '')).toBeUndefined();
+      expect(resolvePinName(map, 'Period 1', undefined)).toBeUndefined();
     });
   });
 
@@ -496,8 +525,8 @@ describe('quizScoreboard', () => {
         ]),
       ];
       const map = buildPinToExportNameMap(rosters, ['Period 1']);
-      expect(map['01']).toBe('Smith, Alice');
-      expect(map['02']).toBe('Jones, Bob');
+      expect(resolvePinName(map, 'Period 1', '01')).toBe('Smith, Alice');
+      expect(resolvePinName(map, 'Period 1', '02')).toBe('Jones, Bob');
     });
 
     it('returns just first name when last name is empty', () => {
@@ -507,8 +536,8 @@ describe('quizScoreboard', () => {
         ]),
       ];
       const map = buildPinToExportNameMap(rosters, ['Period 1']);
-      expect(map['01']).toBe('Cher');
-      expect(map['1']).toBe('Cher');
+      expect(resolvePinName(map, 'Period 1', '01')).toBe('Cher');
+      expect(resolvePinName(map, 'Period 1', '1')).toBe('Cher');
     });
 
     it('returns just last name when first name is empty', () => {
@@ -518,19 +547,22 @@ describe('quizScoreboard', () => {
         ]),
       ];
       const map = buildPinToExportNameMap(rosters, ['Period 1']);
-      expect(map['03']).toBe('Madonna');
-      expect(map['3']).toBe('Madonna');
+      expect(resolvePinName(map, 'Period 1', '03')).toBe('Madonna');
+      expect(resolvePinName(map, 'Period 1', '3')).toBe('Madonna');
     });
 
-    it('stores both zero-padded and stripped PIN forms', () => {
+    it('disambiguates same PIN across multiple periods (export naming)', () => {
       const rosters = [
         makeRoster('Period 1', [
           { firstName: 'Alice', lastName: 'Smith', pin: '01' },
         ]),
+        makeRoster('Period 2', [
+          { firstName: 'Bob', lastName: 'Jones', pin: '01' },
+        ]),
       ];
-      const map = buildPinToExportNameMap(rosters, ['Period 1']);
-      expect(map['01']).toBe('Smith, Alice');
-      expect(map['1']).toBe('Smith, Alice');
+      const map = buildPinToExportNameMap(rosters, ['Period 1', 'Period 2']);
+      expect(resolvePinName(map, 'Period 1', '01')).toBe('Smith, Alice');
+      expect(resolvePinName(map, 'Period 2', '01')).toBe('Jones, Bob');
     });
 
     it('returns empty map when no matching roster is found', () => {

--- a/components/widgets/QuizWidget/utils/quizScoreboard.test.ts
+++ b/components/widgets/QuizWidget/utils/quizScoreboard.test.ts
@@ -32,6 +32,7 @@ import {
   buildScoreboardTeams,
   buildLiveLeaderboard,
   resolvePinName,
+  __resetPinNameWarnDedupe,
 } from './quizScoreboard';
 import type {
   QuizResponse,
@@ -542,6 +543,7 @@ describe('quizScoreboard', () => {
     });
 
     it('warns when the legacy suffix scan finds multiple distinct candidates', () => {
+      __resetPinNameWarnDedupe();
       const rosters = [
         makeRoster('Period 1', [
           { firstName: 'Alice', lastName: 'Smith', pin: '01' },
@@ -560,6 +562,32 @@ describe('quizScoreboard', () => {
         expect(warnSpy).toHaveBeenCalledWith(
           expect.stringContaining('Ambiguous PIN 01')
         );
+      } finally {
+        warnSpy.mockRestore();
+      }
+    });
+
+    it('dedupes the ambiguity warn so live-monitor renders do not flood', () => {
+      __resetPinNameWarnDedupe();
+      const rosters = [
+        makeRoster('Period 1', [
+          { firstName: 'Alice', lastName: 'Smith', pin: '01' },
+        ]),
+        makeRoster('Period 2', [
+          { firstName: 'Bob', lastName: 'Jones', pin: '01' },
+        ]),
+      ];
+      const map = buildPinToNameMap(rosters, ['Period 1', 'Period 2']);
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {
+        /* suppress */
+      });
+      try {
+        // Five lookups for the same ambiguous (pin, candidates) pair —
+        // simulates one render pass over five anonymous PIN joiners.
+        for (let i = 0; i < 5; i++) {
+          resolvePinName(map, undefined, '01');
+        }
+        expect(warnSpy).toHaveBeenCalledTimes(1);
       } finally {
         warnSpy.mockRestore();
       }

--- a/components/widgets/QuizWidget/utils/quizScoreboard.ts
+++ b/components/widgets/QuizWidget/utils/quizScoreboard.ts
@@ -158,6 +158,20 @@ function makePinKey(classPeriod: string, pin: string): string {
 }
 
 /**
+ * Module-scoped dedupe for the legacy-fallback ambiguity warn in
+ * `resolvePinName`. Without this, a live monitor with many anonymous PIN
+ * joiners on a session that pre-dates per-period scoping would emit the
+ * warn on every render — hundreds per minute. Cleared between tests via
+ * the exported `__resetPinNameWarnDedupe`.
+ */
+const warnedAmbiguities = new Set<string>();
+
+/** Reset the ambiguity-warn dedupe state. Test-only. */
+export function __resetPinNameWarnDedupe(): void {
+  warnedAmbiguities.clear();
+}
+
+/**
  * Look up the roster name for a `(classPeriod, pin)` pair.
  *
  * Resolution order:
@@ -213,11 +227,19 @@ export function resolvePinName(
     }
   }
   if (seen.size > 1) {
-    console.warn(
-      `[resolvePinName] Ambiguous PIN ${pin} matched ${seen.size} rosters with no classPeriod; returning first match. Candidates: ${Array.from(
-        seen
-      ).join(', ')}`
-    );
+    // Dedupe by `(pin, sorted-candidates)` so a live monitor with N legacy
+    // PIN-only joiners that all hit the same collision warns once, not
+    // once per render × per response. The set survives the JS context;
+    // tests that need fresh warns should call `__resetPinNameWarnDedupe`.
+    const dedupeKey = `${pin}:${Array.from(seen).sort().join('|')}`;
+    if (!warnedAmbiguities.has(dedupeKey)) {
+      warnedAmbiguities.add(dedupeKey);
+      console.warn(
+        `[resolvePinName] Ambiguous PIN ${pin} matched ${seen.size} rosters with no classPeriod; returning first match. Candidates: ${Array.from(
+          seen
+        ).join(', ')}`
+      );
+    }
   }
   if (firstHit) return firstHit;
 

--- a/components/widgets/QuizWidget/utils/quizScoreboard.ts
+++ b/components/widgets/QuizWidget/utils/quizScoreboard.ts
@@ -140,10 +140,69 @@ export function getScoreSuffix(session?: QuizScoringSession): string {
 }
 
 /**
- * Build a PIN → student full-name lookup from matching rosters.
- * Accepts an array of period names to support multi-class assignments.
- * Stores both canonical (zero-padded) and stripped PIN forms. First roster
- * wins for a given PIN when multiple rosters overlap.
+ * Composite-key separator used by `buildPinToNameMap` /
+ * `buildPinToExportNameMap`. Map keys are `${classPeriod}${PIN_KEY_SEP}${pin}`
+ * so that the same PIN in two different rosters resolves to two different
+ * students. The separator is U+0001 (Start of Heading), which can't appear in
+ * a roster name or a PIN — both are user-typed strings, but no editable text
+ * field accepts control characters.
+ */
+const PIN_KEY_SEP = '';
+
+function makePinKey(classPeriod: string, pin: string): string {
+  return `${classPeriod}${PIN_KEY_SEP}${pin}`;
+}
+
+/**
+ * Look up the roster name for a `(classPeriod, pin)` pair.
+ *
+ * Tries the period-scoped key first (correct path). Falls back to a suffix
+ * scan over the whole map when `classPeriod` is missing — preserves legacy
+ * behavior for SSO joiners and any older response docs that predate
+ * per-period scoping. Returns `undefined` when nothing matches.
+ *
+ * Both zero-padded (`"01"`) and stripped (`"1"`) forms are accepted.
+ */
+export function resolvePinName(
+  map: Record<string, string>,
+  classPeriod: string | null | undefined,
+  pin: string | null | undefined
+): string | undefined {
+  if (!pin) return undefined;
+  const stripped = pin.replace(/^0+/, '');
+  const variants = stripped && stripped !== pin ? [pin, stripped] : [pin];
+
+  if (classPeriod) {
+    for (const v of variants) {
+      const hit = map[makePinKey(classPeriod, v)];
+      if (hit) return hit;
+    }
+  }
+
+  // No-classPeriod / no-match fallback. Scan composite keys for a matching
+  // PIN suffix (legacy SSO + pre-period-scoping responses).
+  for (const v of variants) {
+    const suffix = `${PIN_KEY_SEP}${v}`;
+    for (const k in map) {
+      if (k.endsWith(suffix)) return map[k];
+    }
+  }
+
+  // Final fallback: maps built by hand (e.g., older callers, tests) may key
+  // directly on the bare PIN with no period prefix. Honor those too.
+  for (const v of variants) {
+    const hit = map[v];
+    if (hit) return hit;
+  }
+
+  return undefined;
+}
+
+/**
+ * Build a (classPeriod, PIN) → student full-name lookup from matching
+ * rosters. Accepts an array of period names to support multi-class
+ * assignments. Keys are composite (see `PIN_KEY_SEP`); always look up via
+ * `resolvePinName`, never index the map directly.
  */
 export function buildPinToNameMap(
   rosters: ClassRoster[],
@@ -157,10 +216,10 @@ export function buildPinToNameMap(
     for (const s of roster.students) {
       if (s.pin && (s.firstName || s.lastName)) {
         const name = [s.firstName, s.lastName].filter(Boolean).join(' ');
-        if (!(s.pin in map)) map[s.pin] = name;
+        map[makePinKey(pName, s.pin)] = name;
         const stripped = s.pin.replace(/^0+/, '');
-        if (stripped && stripped !== s.pin && !(stripped in map)) {
-          map[stripped] = name;
+        if (stripped && stripped !== s.pin) {
+          map[makePinKey(pName, stripped)] = name;
         }
       }
     }
@@ -169,9 +228,10 @@ export function buildPinToNameMap(
 }
 
 /**
- * Build a PIN → student name lookup formatted for spreadsheet export:
- * "Last, First" when both names exist, just first or last name alone otherwise.
- * Accepts an array of period names to support multi-class assignments.
+ * Build a (classPeriod, PIN) → student name lookup formatted for spreadsheet
+ * export: "Last, First" when both names exist, just first or last name alone
+ * otherwise. Keys are composite (see `PIN_KEY_SEP`); always look up via
+ * `resolvePinName`.
  */
 export function buildPinToExportNameMap(
   rosters: ClassRoster[],
@@ -188,10 +248,10 @@ export function buildPinToExportNameMap(
           s.lastName && s.firstName
             ? `${s.lastName}, ${s.firstName}`
             : s.lastName || s.firstName;
-        if (!(s.pin in map)) map[s.pin] = name;
+        map[makePinKey(pName, s.pin)] = name;
         const stripped = s.pin.replace(/^0+/, '');
-        if (stripped && stripped !== s.pin && !(stripped in map)) {
-          map[stripped] = name;
+        if (stripped && stripped !== s.pin) {
+          map[makePinKey(pName, stripped)] = name;
         }
       }
     }

--- a/components/widgets/QuizWidget/utils/quizScoreboard.ts
+++ b/components/widgets/QuizWidget/utils/quizScoreboard.ts
@@ -143,9 +143,13 @@ export function getScoreSuffix(session?: QuizScoringSession): string {
  * Composite-key separator used by `buildPinToNameMap` /
  * `buildPinToExportNameMap`. Map keys are `${classPeriod}${PIN_KEY_SEP}${pin}`
  * so that the same PIN in two different rosters resolves to two different
- * students. The separator is U+0001 (Start of Heading), which can't appear in
- * a roster name or a PIN — both are user-typed strings, but no editable text
- * field accepts control characters.
+ * students. U+0001 (Start of Heading) is highly unlikely to appear in a
+ * roster name or a PIN — PINs are zero-padded numerics, and roster name
+ * inputs in the SPART Board UIs don't surface control characters. Treat
+ * the separator as a soft guarantee, not a hard input invariant; if a
+ * pathological roster name ever embeds U+0001 the worst outcome is a
+ * lookup miss (resolved as `PIN <n>`), which is the visible-failure mode
+ * we already prefer.
  */
 const PIN_KEY_SEP = '';
 
@@ -156,12 +160,20 @@ function makePinKey(classPeriod: string, pin: string): string {
 /**
  * Look up the roster name for a `(classPeriod, pin)` pair.
  *
- * Tries the period-scoped key first (correct path). Falls back to a suffix
- * scan over the whole map when `classPeriod` is missing — preserves legacy
- * behavior for SSO joiners and any older response docs that predate
- * per-period scoping. Returns `undefined` when nothing matches.
+ * Resolution order:
+ *   1. Period-scoped composite key — the correct path. When `classPeriod`
+ *      is provided we ONLY trust this tier; a miss returns `undefined`
+ *      so the caller renders `PIN <n>` rather than risk a wrong-period
+ *      collision via suffix scan.
+ *   2. Composite-key suffix scan — only when `classPeriod` is missing
+ *      (legacy SSO and pre-period-scoping responses). When more than
+ *      one distinct candidate matches the same PIN the function still
+ *      returns the first hit (preserves pre-PR behavior) but emits a
+ *      `console.warn` so observability picks up the ambiguity.
+ *   3. Bare-PIN flat lookup — for older callers and tests that build
+ *      maps without composite keys. Also gated on missing `classPeriod`.
  *
- * Both zero-padded (`"01"`) and stripped (`"1"`) forms are accepted.
+ * Both zero-padded (`"01"`) and stripped (`"1"`) PIN forms are accepted.
  */
 export function resolvePinName(
   map: Record<string, string>,
@@ -177,19 +189,39 @@ export function resolvePinName(
       const hit = map[makePinKey(classPeriod, v)];
       if (hit) return hit;
     }
+    // classPeriod was provided but nothing matched. Don't fall through to
+    // the legacy suffix scan: a wrong-period response (typo, deleted
+    // roster, drift between periodNames and rosters) would otherwise
+    // resolve to whichever student happens to share the PIN in any
+    // roster, attributing the wrong name confidently. Returning
+    // undefined surfaces the mismatch as `PIN <n>` in the UI.
+    return undefined;
   }
 
-  // No-classPeriod / no-match fallback. Scan composite keys for a matching
-  // PIN suffix (legacy SSO + pre-period-scoping responses).
+  // Tier 2 — legacy / SSO path with no classPeriod. Detect ambiguity so
+  // observability can flag PIN collisions across rosters.
+  const seen = new Set<string>();
+  let firstHit: string | undefined;
   for (const v of variants) {
     const suffix = `${PIN_KEY_SEP}${v}`;
     for (const k in map) {
-      if (k.endsWith(suffix)) return map[k];
+      if (k.endsWith(suffix)) {
+        const name = map[k];
+        firstHit ??= name;
+        seen.add(name);
+      }
     }
   }
+  if (seen.size > 1) {
+    console.warn(
+      `[resolvePinName] Ambiguous PIN ${pin} matched ${seen.size} rosters with no classPeriod; returning first match. Candidates: ${Array.from(
+        seen
+      ).join(', ')}`
+    );
+  }
+  if (firstHit) return firstHit;
 
-  // Final fallback: maps built by hand (e.g., older callers, tests) may key
-  // directly on the bare PIN with no period prefix. Honor those too.
+  // Tier 3 — bare-PIN map (hand-built, older callers, tests).
   for (const v of variants) {
     const hit = map[v];
     if (hit) return hit;

--- a/components/widgets/QuizWidget/utils/resolveDisplayName.ts
+++ b/components/widgets/QuizWidget/utils/resolveDisplayName.ts
@@ -27,6 +27,7 @@ import {
   formatStudentName,
   type StudentName,
 } from '@/hooks/useAssignmentPseudonyms';
+import { resolvePinName } from './quizScoreboard';
 
 /** Fallback rendered when no name source resolves. */
 export const UNKNOWN_STUDENT_LABEL = 'Student';
@@ -46,7 +47,14 @@ export function resolveResponseDisplayName(
   if (ssoName) return ssoName;
 
   if (response.pin) {
-    const rosterName = pinToName[response.pin];
+    // Disambiguate by classPeriod so the same PIN in two rosters resolves
+    // to two different students. `resolvePinName` falls back to a global
+    // suffix scan when classPeriod is missing (legacy responses).
+    const rosterName = resolvePinName(
+      pinToName,
+      response.classPeriod,
+      response.pin
+    );
     if (rosterName) return rosterName;
     return `PIN ${response.pin}`;
   }

--- a/components/widgets/TalkingTool/Widget.test.tsx
+++ b/components/widgets/TalkingTool/Widget.test.tsx
@@ -68,6 +68,8 @@ const mockAuthContext = (
   disableCloseConfirmation: false,
   remoteControlEnabled: true,
   dockPosition: 'bottom',
+  quizMonitorColorsEnabled: true,
+  quizMonitorScoreDisplay: 'percent',
   updateAccountPreferences: async () => {
     /* mock */
   },

--- a/context/AuthContext.tsx
+++ b/context/AuthContext.tsx
@@ -235,6 +235,14 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
     useState(false);
   const [remoteControlEnabled, setRemoteControlEnabledState] = useState(true);
   const [dockPosition, setDockPositionState] = useState<DockPosition>('bottom');
+  // Default colors-on so existing teachers see the same tinted rows they're
+  // used to. When the field is absent from a profile doc (older accounts)
+  // we still treat them as opted-in.
+  const [quizMonitorColorsEnabled, setQuizMonitorColorsEnabledState] =
+    useState(true);
+  const [quizMonitorScoreDisplay, setQuizMonitorScoreDisplayState] = useState<
+    'percent' | 'count' | 'hidden'
+  >('percent');
   const [orgId, setOrgId] = useState<string | null>(
     isAuthBypass ? DEFAULT_ORG_ID : null
   );
@@ -888,6 +896,24 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
           } else {
             setDockPositionState('bottom');
           }
+          if (
+            'quizMonitorColorsEnabled' in data &&
+            typeof data.quizMonitorColorsEnabled === 'boolean'
+          ) {
+            setQuizMonitorColorsEnabledState(data.quizMonitorColorsEnabled);
+          } else {
+            setQuizMonitorColorsEnabledState(true);
+          }
+          if (
+            'quizMonitorScoreDisplay' in data &&
+            (data.quizMonitorScoreDisplay === 'percent' ||
+              data.quizMonitorScoreDisplay === 'count' ||
+              data.quizMonitorScoreDisplay === 'hidden')
+          ) {
+            setQuizMonitorScoreDisplayState(data.quizMonitorScoreDisplay);
+          } else {
+            setQuizMonitorScoreDisplayState('percent');
+          }
 
           setProfileLoaded(true);
           return;
@@ -1054,6 +1080,8 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
       disableCloseConfirmation?: boolean;
       remoteControlEnabled?: boolean;
       dockPosition?: DockPosition;
+      quizMonitorColorsEnabled?: boolean;
+      quizMonitorScoreDisplay?: 'percent' | 'count' | 'hidden';
     }) => {
       if (updates.disableCloseConfirmation !== undefined) {
         setDisableCloseConfirmationState(updates.disableCloseConfirmation);
@@ -1064,12 +1092,20 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
       if (updates.dockPosition !== undefined) {
         setDockPositionState(updates.dockPosition);
       }
+      if (updates.quizMonitorColorsEnabled !== undefined) {
+        setQuizMonitorColorsEnabledState(updates.quizMonitorColorsEnabled);
+      }
+      if (updates.quizMonitorScoreDisplay !== undefined) {
+        setQuizMonitorScoreDisplayState(updates.quizMonitorScoreDisplay);
+      }
 
       // Build a sanitized payload — Firestore rejects `undefined` field values
       const sanitizedUpdates: {
         disableCloseConfirmation?: boolean;
         remoteControlEnabled?: boolean;
         dockPosition?: DockPosition;
+        quizMonitorColorsEnabled?: boolean;
+        quizMonitorScoreDisplay?: 'percent' | 'count' | 'hidden';
       } = {};
       if (typeof updates.disableCloseConfirmation === 'boolean') {
         sanitizedUpdates.disableCloseConfirmation =
@@ -1084,6 +1120,18 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
         updates.dockPosition === 'right'
       ) {
         sanitizedUpdates.dockPosition = updates.dockPosition;
+      }
+      if (typeof updates.quizMonitorColorsEnabled === 'boolean') {
+        sanitizedUpdates.quizMonitorColorsEnabled =
+          updates.quizMonitorColorsEnabled;
+      }
+      if (
+        updates.quizMonitorScoreDisplay === 'percent' ||
+        updates.quizMonitorScoreDisplay === 'count' ||
+        updates.quizMonitorScoreDisplay === 'hidden'
+      ) {
+        sanitizedUpdates.quizMonitorScoreDisplay =
+          updates.quizMonitorScoreDisplay;
       }
 
       if (!user || isAuthBypass || Object.keys(sanitizedUpdates).length === 0) {
@@ -1458,6 +1506,8 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
         disableCloseConfirmation,
         remoteControlEnabled,
         dockPosition,
+        quizMonitorColorsEnabled,
+        quizMonitorScoreDisplay,
         updateAccountPreferences,
         orgId,
         roleId,

--- a/context/AuthContext.tsx
+++ b/context/AuthContext.tsx
@@ -1148,6 +1148,12 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
         if (myToken === writeTokenRef.current) {
           console.error('Error saving account preferences:', error);
         }
+        // Rethrow so callers that DO care about the failure (e.g. the
+        // QuizLiveMonitor toggles, which catch this and toast) can react.
+        // Pre-existing fire-and-forget callers are unaffected — an unhandled
+        // rejection on those is fine because the inner console.error has
+        // already logged the failure.
+        throw error;
       }
     },
     [user]

--- a/context/AuthContextValue.ts
+++ b/context/AuthContextValue.ts
@@ -70,11 +70,21 @@ export interface AuthContextType {
   remoteControlEnabled: boolean;
   /** Where the dock is anchored on screen (account-level preference) */
   dockPosition: DockPosition;
+  /**
+   * Whether the quiz live-monitor tints completed-student rows by score
+   * band (≥80% green, 60-79% amber, <60% rose). When false the roster
+   * renders monochrome white.
+   */
+  quizMonitorColorsEnabled: boolean;
+  /** What the quiz live-monitor shows in the right-side score pill. */
+  quizMonitorScoreDisplay: 'percent' | 'count' | 'hidden';
   /** Update account-level preferences */
   updateAccountPreferences: (updates: {
     disableCloseConfirmation?: boolean;
     remoteControlEnabled?: boolean;
     dockPosition?: DockPosition;
+    quizMonitorColorsEnabled?: boolean;
+    quizMonitorScoreDisplay?: 'percent' | 'count' | 'hidden';
   }) => Promise<void>;
   /**
    * The organization this user belongs to, derived from their membership doc.

--- a/tests/components/widgets/QuizResults.regenerate.test.tsx
+++ b/tests/components/widgets/QuizResults.regenerate.test.tsx
@@ -124,7 +124,6 @@ function makePlcConfig(): QuizConfig {
     view: 'results',
     plcMode: true,
     teacherName: 'Teacher A',
-    periodName: 'Period 1',
   } as unknown as QuizConfig;
 }
 

--- a/tests/utils/quizDriveService.test.ts
+++ b/tests/utils/quizDriveService.test.ts
@@ -2,7 +2,9 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import {
   QuizDriveService,
   PlcSheetMissingError,
+  PlcSheetSchemaMismatchError,
 } from '@/utils/quizDriveService';
+import type { QuizQuestion, QuizResponse } from '@/types';
 
 /**
  * Mock helper: enqueues `fetch` responses in order so the tests can
@@ -353,5 +355,245 @@ describe('QuizDriveService appendToExistingSheet error surfacing', () => {
       })
     ).rejects.toBeInstanceOf(PlcSheetMissingError);
     errSpy.mockRestore();
+  });
+});
+
+// ─── Helpers for column-shape and PLC schema-guard tests ──────────────────
+
+function makeQuestion(id: string, points = 1): QuizQuestion {
+  return {
+    id,
+    text: `Question ${id}`,
+    type: 'MC',
+    correctAnswer: 'A',
+    incorrectAnswers: ['B', 'C'],
+    timeLimit: 0,
+    points,
+  };
+}
+
+function makeResponse(overrides: Partial<QuizResponse>): QuizResponse {
+  return {
+    studentUid: overrides.pin ?? overrides.studentUid ?? 'uid',
+    pin: overrides.pin,
+    classPeriod: overrides.classPeriod,
+    joinedAt: 0,
+    status: overrides.status ?? 'completed',
+    answers: overrides.answers ?? [
+      { questionId: 'q1', answer: 'A', answeredAt: 0 },
+    ],
+    submittedAt: overrides.submittedAt ?? 0,
+    tabSwitchWarnings: overrides.tabSwitchWarnings ?? 0,
+    score: overrides.score ?? null,
+    ...overrides,
+  };
+}
+
+describe('QuizDriveService.exportResultsToSheet — column shape', () => {
+  let service: QuizDriveService;
+  beforeEach(() => {
+    service = new QuizDriveService('test-token');
+    vi.clearAllMocks();
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('writes the post-PR header schema with no "Period" column', async () => {
+    const fetchSpy = queueFetchResponses([
+      {
+        json: () =>
+          Promise.resolve({
+            spreadsheetUrl: 'https://docs.google.com/spreadsheets/d/abc',
+          }),
+      },
+    ]);
+
+    await service.exportResultsToSheet(
+      'Title',
+      [
+        makeResponse({ pin: '01', classPeriod: 'P1' }),
+        makeResponse({ pin: '02', classPeriod: 'P2' }),
+      ],
+      [makeQuestion('q1')]
+    );
+
+    const calls = (fetchSpy as unknown as { mock: { calls: unknown[][] } }).mock
+      .calls as Array<[string, RequestInit]>;
+    const body = parseBody(calls[0][1]);
+    const sheets = body.sheets as Array<{
+      data: Array<{
+        rowData: Array<{
+          values: Array<{ userEnteredValue: { stringValue: string } }>;
+        }>;
+      }>;
+    }>;
+    const header = sheets[0].data[0].rowData[0].values.map(
+      (v) => v.userEnteredValue.stringValue
+    );
+
+    // Strict ordering: any change here flags a column-shape regression.
+    expect(header.slice(0, 11)).toEqual([
+      'Timestamp',
+      'Teacher',
+      'Class Period',
+      'Student',
+      'PIN',
+      'Status',
+      'Score (%)',
+      'Points Earned',
+      'Max Points',
+      'Warnings',
+      'Submitted At',
+    ]);
+    // No legacy "Period" column anywhere.
+    expect(header).not.toContain('Period');
+  });
+
+  it('sorts data rows by Student column at index 3 (post-Period-removal)', async () => {
+    const fetchSpy = queueFetchResponses([
+      {
+        json: () =>
+          Promise.resolve({
+            spreadsheetUrl: 'https://docs.google.com/spreadsheets/d/abc',
+          }),
+      },
+    ]);
+
+    await service.exportResultsToSheet(
+      'Title',
+      [
+        makeResponse({ pin: '01', classPeriod: 'P1' }),
+        makeResponse({ pin: '02', classPeriod: 'P1' }),
+      ],
+      [makeQuestion('q1')],
+      {
+        // Names are looked up by classPeriod. Use the period-scoped key
+        // shape `${period}${pin}` (matches `buildPinToNameMap`).
+        pinToName: {
+          ['P1' + String.fromCharCode(0x01) + '01']: 'Zeta, Alex',
+          ['P1' + String.fromCharCode(0x01) + '02']: 'Alpha, Sam',
+        },
+      }
+    );
+
+    const calls = (fetchSpy as unknown as { mock: { calls: unknown[][] } }).mock
+      .calls as Array<[string, RequestInit]>;
+    const body = parseBody(calls[0][1]);
+    const sheets = body.sheets as Array<{
+      data: Array<{
+        rowData: Array<{
+          values: Array<{ userEnteredValue: { stringValue: string } }>;
+        }>;
+      }>;
+    }>;
+    const allRows = sheets[0].data[0].rowData.map((row) =>
+      row.values.map((v) => v.userEnteredValue.stringValue)
+    );
+    // Header + 2 data rows + question-analysis stats block
+    const dataRows = [allRows[1], allRows[2]];
+    // Sorted by Student (index 3): Alpha, Sam comes before Zeta, Alex.
+    expect(dataRows[0][3]).toBe('Alpha, Sam');
+    expect(dataRows[1][3]).toBe('Zeta, Alex');
+  });
+
+  it('throws PlcSheetSchemaMismatchError when appending to an old-schema PLC sheet', async () => {
+    queueFetchResponses([
+      // Tab metadata
+      {
+        json: () =>
+          Promise.resolve({
+            sheets: [{ properties: { title: 'Results' } }],
+          }),
+      },
+      // Row-1 read returns the OLD 13-column header that includes "Period"
+      {
+        json: () =>
+          Promise.resolve({
+            values: [
+              [
+                'Timestamp',
+                'Teacher',
+                'Period',
+                'Class Period',
+                'Student',
+                'PIN',
+                'Status',
+                'Score (%)',
+                'Points Earned',
+                'Max Points',
+                'Warnings',
+                'Submitted At',
+                'Q1 (1pt): Question q1',
+              ],
+            ],
+          }),
+      },
+    ]);
+
+    await expect(
+      service.exportResultsToSheet(
+        'Q',
+        [makeResponse({ pin: '01' })],
+        [makeQuestion('q1')],
+        {
+          plcMode: true,
+          plcSheetUrl: 'https://docs.google.com/spreadsheets/d/old-schema/edit',
+        }
+      )
+    ).rejects.toBeInstanceOf(PlcSheetSchemaMismatchError);
+  });
+
+  it('appends cleanly when the existing PLC sheet header matches the current schema', async () => {
+    const fetchSpy = queueFetchResponses([
+      // Tab metadata
+      {
+        json: () =>
+          Promise.resolve({
+            sheets: [{ properties: { title: 'Results' } }],
+          }),
+      },
+      // Row-1 read returns the matching 12-column header
+      {
+        json: () =>
+          Promise.resolve({
+            values: [
+              [
+                'Timestamp',
+                'Teacher',
+                'Class Period',
+                'Student',
+                'PIN',
+                'Status',
+                'Score (%)',
+                'Points Earned',
+                'Max Points',
+                'Warnings',
+                'Submitted At',
+                'Q1 (1pt): Question q1',
+              ],
+            ],
+          }),
+      },
+      // Append succeeds
+      { json: () => Promise.resolve({}) },
+    ]);
+
+    await expect(
+      service.exportResultsToSheet(
+        'Q',
+        [makeResponse({ pin: '01', classPeriod: 'P1' })],
+        [makeQuestion('q1')],
+        {
+          plcMode: true,
+          plcSheetUrl: 'https://docs.google.com/spreadsheets/d/ok/edit',
+        }
+      )
+    ).resolves.toBe('https://docs.google.com/spreadsheets/d/ok');
+
+    // Last fetch call is the append; verify it ran (i.e. we didn't throw early).
+    const calls = (fetchSpy as unknown as { mock: { calls: unknown[][] } }).mock
+      .calls;
+    expect(calls.length).toBe(3);
   });
 });

--- a/types.ts
+++ b/types.ts
@@ -3318,6 +3318,18 @@ export interface UserProfile {
   remoteControlEnabled?: boolean;
   /** Where the dock is anchored on screen (account-level) */
   dockPosition?: DockPosition;
+  /**
+   * Quiz live-monitor row tinting toggle. When `true` (default), rows are
+   * tinted by score band for completed students; when `false`, rows render
+   * white. Per-teacher account-level preference.
+   */
+  quizMonitorColorsEnabled?: boolean;
+  /**
+   * Quiz live-monitor right-column display. `percent` = score percentage
+   * (default), `count` = "answered/total" progress, `hidden` = blank.
+   * Per-teacher account-level preference.
+   */
+  quizMonitorScoreDisplay?: 'percent' | 'count' | 'hidden';
 }
 
 export interface SharedGroup {

--- a/utils/quizDriveService.ts
+++ b/utils/quizDriveService.ts
@@ -18,6 +18,7 @@ import {
 import { gradeAnswer } from '../hooks/useQuizSession';
 import { APP_NAME } from '../config/constants';
 import { authError } from './driveAuthErrors';
+import { resolvePinName } from '../components/widgets/QuizWidget/utils/quizScoreboard';
 
 const DRIVE_API_URL = 'https://www.googleapis.com/drive/v3';
 const UPLOAD_API_URL = 'https://www.googleapis.com/upload/drive/v3';
@@ -474,7 +475,6 @@ export class QuizDriveService {
        */
       byStudentUid?: Map<string, { givenName: string; familyName: string }>;
       teacherName?: string;
-      periodName?: string;
       plcMode?: boolean;
       plcSheetUrl?: string;
     }
@@ -484,9 +484,6 @@ export class QuizDriveService {
     const teacherName =
       (options?.teacherName?.trim() ? options.teacherName.trim() : null) ??
       'Unknown Teacher';
-    const periodName =
-      (options?.periodName?.trim() ? options.periodName.trim() : null) ??
-      'Unknown Period';
     const timestamp = new Date().toISOString();
 
     const resolveStudent = (r: QuizResponse): string => {
@@ -498,18 +495,25 @@ export class QuizDriveService {
         if (full) return full;
       }
       if (r.pin) {
-        return pinToName[r.pin] ?? `Student (PIN: ${r.pin})`;
+        // Disambiguate by classPeriod: the same PIN in two rosters belongs
+        // to two different students, so we must scope the lookup.
+        const name = resolvePinName(pinToName, r.classPeriod, r.pin);
+        return name ?? `Student (PIN: ${r.pin})`;
       }
       return 'Student';
     };
 
     const maxPoints = questions.reduce((sum, q) => sum + (q.points ?? 1), 0);
 
-    // Build header row — question columns show point value
+    // Build header row — question columns show point value.
+    // "Class Period" is the period the student selected at join time
+    // (`response.classPeriod`); the older static "Period" column was
+    // dropped in 2026-04-29 because it was just the assignment's primary
+    // period repeated on every row, which is misleading for anonymous
+    // joiners spanning multiple sections.
     const headers = [
       'Timestamp',
       'Teacher',
-      'Period',
       'Class Period',
       'Student',
       'PIN',
@@ -549,7 +553,6 @@ export class QuizDriveService {
       return [
         timestamp,
         teacherName,
-        periodName,
         r.classPeriod ?? '',
         resolveStudent(r),
         // PIN column is left blank for SSO students (no roster PIN); their
@@ -565,8 +568,8 @@ export class QuizDriveService {
       ];
     });
 
-    // Sort rows by student name (column index 4) for consistent export order
-    dataRows.sort((a, b) => a[4].localeCompare(b[4]));
+    // Sort rows by student name (column index 3) for consistent export order
+    dataRows.sort((a, b) => a[3].localeCompare(b[3]));
 
     // PLC mode: append to existing shared sheet
     if (options?.plcMode) {

--- a/utils/quizDriveService.ts
+++ b/utils/quizDriveService.ts
@@ -767,17 +767,23 @@ export class QuizDriveService {
     }
 
     const checkData = (await checkRes.json()) as {
-      values?: string[][];
+      values?: (string | null | undefined)[][];
     };
     const existingHeaderRow = checkData.values?.[0] ?? [];
-    const sheetIsEmpty = existingHeaderRow.length === 0;
+
+    // Trim trailing empties — the Sheets API can pad with `''`, `null`, or
+    // `undefined` depending on how a cell was last cleared. Treat all three
+    // as "no value here" so a sheet whose last column was deleted in the
+    // UI doesn't trigger a false-positive schema mismatch.
+    const trimmed: string[] = existingHeaderRow.map((c) => c ?? '');
+    while (trimmed.length > 0 && trimmed[trimmed.length - 1] === '') {
+      trimmed.pop();
+    }
+    // After trimming, an effectively-empty header row (`[]` or `['']`)
+    // means the sheet was never written. Append cleanly with our headers.
+    const sheetIsEmpty = trimmed.length === 0;
 
     if (!sheetIsEmpty) {
-      // Trim trailing empty cells the API sometimes pads in.
-      const trimmed = [...existingHeaderRow];
-      while (trimmed.length > 0 && trimmed[trimmed.length - 1] === '') {
-        trimmed.pop();
-      }
       const matches =
         trimmed.length === headers.length &&
         trimmed.every((cell, i) => cell === headers[i]);

--- a/utils/quizDriveService.ts
+++ b/utils/quizDriveService.ts
@@ -88,6 +88,26 @@ export class PlcSheetMissingError extends Error {
   }
 }
 
+/**
+ * Thrown by `appendToExistingSheet` when the existing sheet's header row
+ * does not match the headers the current code produces. This prevents
+ * silently appending column-shifted rows underneath an old-schema header
+ * (the most likely cause: a sheet created before the "Period" column was
+ * dropped). Carries the `existingHeaders` and `expectedHeaders` so the
+ * caller can render a precise message telling the teacher to recreate
+ * the sheet.
+ */
+export class PlcSheetSchemaMismatchError extends Error {
+  constructor(
+    message: string,
+    public readonly existingHeaders: string[],
+    public readonly expectedHeaders: string[]
+  ) {
+    super(message);
+    this.name = 'PlcSheetSchemaMismatchError';
+  }
+}
+
 export class QuizDriveService {
   private accessToken: string;
 
@@ -716,9 +736,14 @@ export class QuizDriveService {
 
     const encodedTitle = encodeURIComponent(sheetTitle);
 
-    // Check if sheet already has content by reading A1
+    // Read row 1 (header row) to (a) detect whether the sheet is empty and
+    // (b) if not, validate that its existing schema matches what we're
+    // about to append. Without this guard, dropping or reordering a column
+    // in the export would silently shift every subsequent column on PLC
+    // sheets created with an older schema — wrong student names, wrong
+    // PINs, wrong answers — with no API error.
     const checkRes = await fetch(
-      `${SHEETS_API_URL}/${spreadsheetId}/values/${encodedTitle}!A1`,
+      `${SHEETS_API_URL}/${spreadsheetId}/values/${encodedTitle}!1:1`,
       { headers: this.authHeaders }
     );
 
@@ -744,7 +769,27 @@ export class QuizDriveService {
     const checkData = (await checkRes.json()) as {
       values?: string[][];
     };
-    const sheetIsEmpty = !checkData.values || checkData.values.length === 0;
+    const existingHeaderRow = checkData.values?.[0] ?? [];
+    const sheetIsEmpty = existingHeaderRow.length === 0;
+
+    if (!sheetIsEmpty) {
+      // Trim trailing empty cells the API sometimes pads in.
+      const trimmed = [...existingHeaderRow];
+      while (trimmed.length > 0 && trimmed[trimmed.length - 1] === '') {
+        trimmed.pop();
+      }
+      const matches =
+        trimmed.length === headers.length &&
+        trimmed.every((cell, i) => cell === headers[i]);
+      if (!matches) {
+        throw new PlcSheetSchemaMismatchError(
+          "This PLC sheet was created with an older schema and can't be appended to safely. " +
+            'Ask the PLC lead to recreate the shared sheet (the next export will create a fresh one).',
+          trimmed,
+          headers
+        );
+      }
+    }
 
     // Build rows to append: include headers if sheet is empty
     const rowsToAppend = sheetIsEmpty ? [headers, ...dataRows] : dataRows;


### PR DESCRIPTION
## Summary

- **Bug — PIN→name collision across sections.** `buildPinToNameMap` keyed by PIN alone, so PIN 1 from sections 2 and 3 collapsed onto section 1's first student in both the live monitor and the Sheets export. Map now keys by composite `period|pin` via a shared `resolvePinName` helper; SSO and legacy rows fall through to a suffix scan, so they're unaffected.
- **Bug — redundant "Period" column in the export.** Always equal to the assignment's primary period (same value on every row) and misleading next to the correct `Class Period` column. Removed.
- **Monitor UX — replace the dot with the KPI icon, repurpose Colors, add Score and Period filter.** Per-student rows now lead with the matching `Users` / `Clock` / `CheckCircle2` icon. The "Colors" toggle tints completed rows by score band (≥80 % emerald · 60-79 % amber · <60 % rose); off → all rows white. New tri-state score-display button cycles `% → answered/total → hidden`. New class-period filter (reuses `PeriodSelector`) hides itself when the assignment targets a single period; when active it filters KPIs and the roster while the live student-facing leaderboard intentionally stays on the unfiltered set.
- **Persistence.** `quizMonitorColorsEnabled` and `quizMonitorScoreDisplay` persist to the user profile via `updateAccountPreferences` (cross-device). Period filter is local-only — a transient view filter that resets between sessions.

## Migration note

Existing PLC team sheets created with the old 13-column layout will misalign on the next append. Recreate the sheet (the per-assignment `plc.sheetUrl` will auto-regenerate) — flagged this in the plan.

## Test plan

- [x] `pnpm tsc --noEmit` clean
- [x] `pnpm lint` clean (max-warnings 0)
- [x] `pnpm format:check` clean
- [x] Targeted unit tests pass (51 scoreboard + 11 driveService + 8 AuthContext + 8 StudentAuthContext + QuizResults regenerate)
- [ ] Manual smoke test on the dev preview URL: assign a quiz to two rosters, join PIN 1 from each, confirm two distinct names in the monitor and the exported Sheet
- [ ] Toggle Colors off / on; cycle Score display; deselect a period and confirm KPI counts + roster narrow accordingly
- [ ] Refresh the monitor — Colors and Score-display selections survive (Firestore-persisted); period filter resets to all (intended)

🤖 Generated with [Claude Code](https://claude.com/claude-code)