### PR TITLE
feat(miniapp): save mini app as a widget shortcut

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -3,6 +3,7 @@ import { Loader2 } from 'lucide-react';
 import { AuthProvider } from './context/AuthContext';
 import { useAuth } from './context/useAuth';
 import { CustomWidgetsProvider } from './context/CustomWidgetsContext';
+import { SavedWidgetsProvider } from './context/SavedWidgetsContext';
 import { DashboardProvider } from './context/DashboardContext';
 import { useDashboard } from './context/useDashboard';
 import { DialogProvider } from './context/DialogContext';
@@ -127,20 +128,24 @@ const AuthenticatedApp: React.FC<{ isRemote?: boolean }> = ({
   if (isRemote) {
     return (
       <CustomWidgetsProvider>
-        <DashboardProvider>
-          <Suspense fallback={<FullPageLoader />}>
-            <MobileRemoteApp />
-          </Suspense>
-        </DashboardProvider>
+        <SavedWidgetsProvider>
+          <DashboardProvider>
+            <Suspense fallback={<FullPageLoader />}>
+              <MobileRemoteApp />
+            </Suspense>
+          </DashboardProvider>
+        </SavedWidgetsProvider>
       </CustomWidgetsProvider>
     );
   }
 
   return (
     <CustomWidgetsProvider>
-      <DashboardProvider>
-        <AppContent />
-      </DashboardProvider>
+      <SavedWidgetsProvider>
+        <DashboardProvider>
+          <AppContent />
+        </DashboardProvider>
+      </SavedWidgetsProvider>
     </CustomWidgetsProvider>
   );
 };

--- a/components/layout/Dock.tsx
+++ b/components/layout/Dock.tsx
@@ -135,9 +135,17 @@ export const Dock: React.FC = () => {
     [customWidgets]
   );
 
+  // Saved widgets must clear the same permission gate as the underlying
+  // widget type — otherwise a teacher whose access to a widget gets revoked
+  // after saving still sees their old shortcut and can re-instantiate.
+  const accessibleSavedWidgets = useMemo(
+    () => savedWidgets.filter((w) => canAccessWidget(w.widgetType)),
+    [savedWidgets, canAccessWidget]
+  );
+
   const pinnedSavedWidgets = useMemo(
-    () => savedWidgets.filter((w) => w.pinnedToDock),
-    [savedWidgets]
+    () => accessibleSavedWidgets.filter((w) => w.pinnedToDock),
+    [accessibleSavedWidgets]
   );
 
   const handleAddCustomWidget = useCallback(
@@ -159,9 +167,16 @@ export const Dock: React.FC = () => {
     (savedWidgetId: string) => {
       const sw = savedWidgets.find((w) => w.id === savedWidgetId);
       if (!sw) return;
+      if (!canAccessWidget(sw.widgetType)) {
+        addToast(
+          `"${sw.title}" is unavailable — you no longer have access to this widget.`,
+          'error'
+        );
+        return;
+      }
       addWidget(sw.widgetType, { config: sw.config });
     },
-    [savedWidgets, addWidget]
+    [savedWidgets, addWidget, canAccessWidget, addToast]
   );
 
   const handleDeleteSavedWidget = useCallback(
@@ -1044,7 +1059,7 @@ export const Dock: React.FC = () => {
               getToolLabel={getToolLabel}
               customWidgets={publishedCustomWidgets}
               onAddCustomWidget={handleAddCustomWidget}
-              savedWidgets={savedWidgets}
+              savedWidgets={accessibleSavedWidgets}
               onAddSavedWidget={handleAddSavedWidget}
               onToggleSavedWidgetPin={(id, pinned) =>
                 void setPinnedToDock(id, pinned).catch((err) => {

--- a/components/layout/Dock.tsx
+++ b/components/layout/Dock.tsx
@@ -37,6 +37,8 @@ import {
 import { useDashboard } from '@/context/useDashboard';
 import { useAuth } from '@/context/useAuth';
 import { useCustomWidgets } from '@/context/useCustomWidgets';
+import { useSavedWidgets } from '@/context/useSavedWidgets';
+import { useDialog } from '@/context/useDialog';
 import { useLiveSession } from '@/hooks/useLiveSession';
 import { useClickOutside } from '@/hooks/useClickOutside';
 import {
@@ -78,6 +80,7 @@ import { DockLabel } from './dock/DockLabel';
 import { ToolDockItem } from './dock/ToolDockItem';
 import { FolderItem } from './dock/FolderItem';
 import { QuickAccessButton } from './dock/QuickAccessButton';
+import { SavedWidgetDockItem } from './dock/SavedWidgetDockItem';
 import { useScreenRecord } from '@/hooks/useScreenRecord';
 import { useGoogleDrive } from '@/hooks/useGoogleDrive';
 import { useCatalystSets } from '@/hooks/useCatalystSets';
@@ -123,10 +126,18 @@ export const Dock: React.FC = () => {
   const { driveService } = useGoogleDrive();
   const { sets: catalystSets, executeRoutine } = useCatalystSets();
   const { customWidgets } = useCustomWidgets();
+  const { savedWidgets, setPinnedToDock, deleteSavedWidget } =
+    useSavedWidgets();
+  const { showConfirm } = useDialog();
 
   const publishedCustomWidgets = useMemo(
     () => customWidgets.filter((w) => w.published && w.enabled),
     [customWidgets]
+  );
+
+  const pinnedSavedWidgets = useMemo(
+    () => savedWidgets.filter((w) => w.pinnedToDock),
+    [savedWidgets]
   );
 
   const handleAddCustomWidget = useCallback(
@@ -142,6 +153,51 @@ export const Dock: React.FC = () => {
       });
     },
     [customWidgets, addWidget]
+  );
+
+  const handleAddSavedWidget = useCallback(
+    (savedWidgetId: string) => {
+      const sw = savedWidgets.find((w) => w.id === savedWidgetId);
+      if (!sw) return;
+      addWidget(sw.widgetType, { config: sw.config });
+    },
+    [savedWidgets, addWidget]
+  );
+
+  const handleDeleteSavedWidget = useCallback(
+    async (savedWidgetId: string) => {
+      const sw = savedWidgets.find((w) => w.id === savedWidgetId);
+      if (!sw) return;
+      const confirmed = await showConfirm(
+        `Delete "${sw.title}" from your saved widgets? This can't be undone.`,
+        {
+          title: 'Delete Saved Widget',
+          variant: 'danger',
+          confirmLabel: 'Delete',
+        }
+      );
+      if (!confirmed) return;
+      try {
+        await deleteSavedWidget(savedWidgetId);
+        addToast(`"${sw.title}" deleted`, 'info');
+      } catch (err) {
+        console.error('[Dock] Failed to delete saved widget', err);
+        addToast('Failed to delete saved widget', 'error');
+      }
+    },
+    [savedWidgets, deleteSavedWidget, showConfirm, addToast]
+  );
+
+  const handleUnpinSavedWidget = useCallback(
+    async (savedWidgetId: string) => {
+      try {
+        await setPinnedToDock(savedWidgetId, false);
+      } catch (err) {
+        console.error('[Dock] Failed to unpin saved widget', err);
+        addToast('Failed to remove from dock', 'error');
+      }
+    },
+    [setPinnedToDock, addToast]
   );
 
   const getToolLabel = useCallback(
@@ -988,6 +1044,18 @@ export const Dock: React.FC = () => {
               getToolLabel={getToolLabel}
               customWidgets={publishedCustomWidgets}
               onAddCustomWidget={handleAddCustomWidget}
+              savedWidgets={savedWidgets}
+              onAddSavedWidget={handleAddSavedWidget}
+              onToggleSavedWidgetPin={(id, pinned) =>
+                void setPinnedToDock(id, pinned).catch((err) => {
+                  console.error(
+                    '[Dock] Failed to toggle saved widget pin',
+                    err
+                  );
+                  addToast('Failed to update pin', 'error');
+                })
+              }
+              onDeleteSavedWidget={(id) => void handleDeleteSavedWidget(id)}
             />
           )}
 
@@ -1417,6 +1485,33 @@ export const Dock: React.FC = () => {
                     </GlassCard>,
                     document.body
                   )}
+
+                {/* Pinned saved widgets — per-user shortcuts (e.g. saved
+                    Mini Apps). Sit alongside the standard tools but live
+                    outside the visibleTools/dockItems machinery so they
+                    don't clash with the WidgetType-keyed reorder/folder
+                    logic. */}
+                {pinnedSavedWidgets.length > 0 && (
+                  <>
+                    <div
+                      className={`bg-slate-200 flex-shrink-0 ${
+                        isVerticalDock ? 'h-px w-8 my-1' : 'w-px h-8 mx-1'
+                      }`}
+                    />
+                    {pinnedSavedWidgets.map((sw) => (
+                      <SavedWidgetDockItem
+                        key={sw.id}
+                        widget={sw}
+                        isEditMode={isEditMode}
+                        onAdd={() => handleAddSavedWidget(sw.id)}
+                        onUnpin={() => void handleUnpinSavedWidget(sw.id)}
+                        onDelete={() => void handleDeleteSavedWidget(sw.id)}
+                        onLongPress={handleLongPress}
+                        dockPosition={dockPosition}
+                      />
+                    ))}
+                  </>
+                )}
 
                 {/* Minimized custom widgets — not in static TOOLS list so
                     surfaced here so they can always be restored */}

--- a/components/layout/dock/SavedWidgetDockItem.tsx
+++ b/components/layout/dock/SavedWidgetDockItem.tsx
@@ -1,0 +1,133 @@
+import React from 'react';
+import { Trash2, X, Puzzle } from 'lucide-react';
+import { SavedWidget, DockPosition } from '@/types';
+import { getCustomWidgetIcon } from '@/config/customWidgetIcons';
+import { DockIcon } from './DockIcon';
+import { DockLabel } from './DockLabel';
+
+interface SavedWidgetDockItemProps {
+  widget: SavedWidget;
+  isEditMode: boolean;
+  onAdd: () => void;
+  onUnpin: () => void;
+  onDelete: () => void;
+  onLongPress: () => void;
+  dockPosition?: DockPosition;
+}
+
+/**
+ * Dock item for a user-saved widget shortcut. In edit mode it surfaces TWO
+ * controls so "remove from dock" (the standard X every dock icon shows) and
+ * "delete the saved widget entirely" (the trash) stay distinct.
+ */
+export const SavedWidgetDockItem: React.FC<SavedWidgetDockItemProps> = ({
+  widget,
+  isEditMode,
+  onAdd,
+  onUnpin,
+  onDelete,
+  onLongPress,
+  dockPosition = 'bottom',
+}) => {
+  // Long-press to enter edit mode, mirroring ToolDockItem's behavior so
+  // saved widgets feel consistent with the rest of the dock.
+  const longPressTimer = React.useRef<number | null>(null);
+  const longPressFired = React.useRef(false);
+
+  const startLongPress = () => {
+    if (isEditMode) return;
+    longPressFired.current = false;
+    longPressTimer.current = window.setTimeout(() => {
+      longPressFired.current = true;
+      onLongPress();
+    }, 500);
+  };
+
+  const cancelLongPress = () => {
+    if (longPressTimer.current !== null) {
+      window.clearTimeout(longPressTimer.current);
+      longPressTimer.current = null;
+    }
+  };
+
+  const handleClick = (e: React.MouseEvent) => {
+    if (isEditMode) {
+      e.preventDefault();
+      e.stopPropagation();
+      return;
+    }
+    if (longPressFired.current) {
+      e.preventDefault();
+      return;
+    }
+    onAdd();
+  };
+
+  return (
+    <div className="relative flex flex-col items-center">
+      <div
+        className={`relative group/icon ${isEditMode ? 'animate-jiggle' : ''}`}
+      >
+        {/* Delete (trash) — only on saved widgets, only in edit mode. Top-LEFT
+            so it can never be confused with the universal top-right "Remove
+            from dock" X every dock icon shows. */}
+        {isEditMode && (
+          <button
+            onClick={(e) => {
+              e.stopPropagation();
+              onDelete();
+            }}
+            className="absolute -top-2 -left-2 z-controls bg-slate-700 hover:bg-slate-900 text-white rounded-full p-1 shadow-md hover:scale-110 transition-transform animate-in zoom-in duration-200"
+            aria-label="Delete saved widget"
+            title="Delete saved widget (permanent)"
+          >
+            <Trash2 className="w-2.5 h-2.5" />
+          </button>
+        )}
+
+        {/* Remove from dock — same UX as ToolDockItem's X */}
+        {isEditMode && (
+          <button
+            onClick={(e) => {
+              e.stopPropagation();
+              onUnpin();
+            }}
+            className="absolute -top-2 -right-2 z-controls bg-red-500 text-white rounded-full p-1 shadow-md hover:scale-110 transition-transform animate-in zoom-in duration-200"
+            aria-label="Remove from Dock"
+            title="Remove from Dock"
+          >
+            <X className="w-2.5 h-2.5" />
+          </button>
+        )}
+
+        <button
+          onPointerDown={startLongPress}
+          onPointerUp={cancelLongPress}
+          onPointerLeave={cancelLongPress}
+          onPointerCancel={cancelLongPress}
+          onClick={handleClick}
+          className={`group flex flex-col items-center gap-1 min-w-[50px] transition-transform active:scale-90 relative ${
+            isEditMode
+              ? 'cursor-default touch-none'
+              : dockPosition === 'left' || dockPosition === 'right'
+                ? 'touch-pan-y'
+                : 'touch-pan-x'
+          }`}
+        >
+          <DockIcon
+            color={widget.color}
+            className={`flex items-center justify-center ${
+              isEditMode ? '' : 'group-hover:scale-110'
+            }`}
+            title={widget.title}
+          >
+            {React.createElement(getCustomWidgetIcon(widget.icon) ?? Puzzle, {
+              className: 'w-5 h-5 md:w-6 md:h-6',
+            })}
+          </DockIcon>
+          <DockLabel>{widget.title}</DockLabel>
+        </button>
+      </div>
+    </div>
+  );
+};

--- a/components/layout/dock/SavedWidgetDockItem.tsx
+++ b/components/layout/dock/SavedWidgetDockItem.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Trash2, X, Puzzle } from 'lucide-react';
 import { SavedWidget, DockPosition } from '@/types';
 import { getCustomWidgetIcon } from '@/config/customWidgetIcons';
+import { useLongPress } from '@/hooks/useLongPress';
 import { DockIcon } from './DockIcon';
 import { DockLabel } from './DockLabel';
 
@@ -29,35 +30,14 @@ export const SavedWidgetDockItem: React.FC<SavedWidgetDockItemProps> = ({
   onLongPress,
   dockPosition = 'bottom',
 }) => {
-  // Long-press to enter edit mode, mirroring ToolDockItem's behavior so
-  // saved widgets feel consistent with the rest of the dock.
-  const longPressTimer = React.useRef<number | null>(null);
-  const longPressFired = React.useRef(false);
-
-  const startLongPress = () => {
-    if (isEditMode) return;
-    longPressFired.current = false;
-    longPressTimer.current = window.setTimeout(() => {
-      longPressFired.current = true;
-      onLongPress();
-    }, 500);
-  };
-
-  const cancelLongPress = () => {
-    if (longPressTimer.current !== null) {
-      window.clearTimeout(longPressTimer.current);
-      longPressTimer.current = null;
-    }
-  };
+  // Reuse the shared long-press hook so the saved-widget icon matches the
+  // cancel-on-drag / hold-delay behavior of every other dock icon.
+  const longPress = useLongPress(onLongPress, { disabled: isEditMode });
 
   const handleClick = (e: React.MouseEvent) => {
     if (isEditMode) {
       e.preventDefault();
       e.stopPropagation();
-      return;
-    }
-    if (longPressFired.current) {
-      e.preventDefault();
       return;
     }
     onAdd();
@@ -101,10 +81,11 @@ export const SavedWidgetDockItem: React.FC<SavedWidgetDockItemProps> = ({
         )}
 
         <button
-          onPointerDown={startLongPress}
-          onPointerUp={cancelLongPress}
-          onPointerLeave={cancelLongPress}
-          onPointerCancel={cancelLongPress}
+          onPointerDown={longPress.onPointerDown}
+          onPointerUp={longPress.onPointerUp}
+          onPointerLeave={longPress.onPointerUp}
+          onPointerMove={longPress.onPointerMove}
+          onPointerCancel={longPress.onPointerCancel}
           onClick={handleClick}
           className={`group flex flex-col items-center gap-1 min-w-[50px] transition-transform active:scale-90 relative ${
             isEditMode

--- a/components/layout/dock/WidgetLibrary.tsx
+++ b/components/layout/dock/WidgetLibrary.tsx
@@ -10,7 +10,8 @@ import {
 } from 'lucide-react';
 import { Z_INDEX } from '@/config/zIndex';
 import { getCustomWidgetIcon } from '@/config/customWidgetIcons';
-import { CustomWidgetDoc } from '@/types';
+import { CustomWidgetDoc, SavedWidget } from '@/types';
+import { Bookmark, Pin, PinOff, Trash2 } from 'lucide-react';
 import {
   DndContext,
   closestCenter,
@@ -59,6 +60,14 @@ interface WidgetLibraryProps {
   customWidgets?: CustomWidgetDoc[];
   /** Called when a custom widget card is clicked */
   onAddCustomWidget?: (customWidgetId: string) => void;
+  /** User's saved-widget shortcuts (e.g. saved Mini Apps) */
+  savedWidgets?: SavedWidget[];
+  /** Called when a saved widget card is clicked — adds an instance to the board */
+  onAddSavedWidget?: (savedWidgetId: string) => void;
+  /** Called to toggle whether a saved widget is pinned to the dock */
+  onToggleSavedWidgetPin?: (savedWidgetId: string, pinned: boolean) => void;
+  /** Called when the trash icon is clicked on a saved widget card */
+  onDeleteSavedWidget?: (savedWidgetId: string) => void;
 }
 
 const SortableLibraryTool = React.memo(
@@ -150,6 +159,10 @@ export const WidgetLibrary = forwardRef<HTMLDivElement, WidgetLibraryProps>(
       getToolLabel,
       customWidgets = [],
       onAddCustomWidget,
+      savedWidgets = [],
+      onAddSavedWidget,
+      onToggleSavedWidgetPin,
+      onDeleteSavedWidget,
     },
     ref
   ) => {
@@ -288,6 +301,88 @@ export const WidgetLibrary = forwardRef<HTMLDivElement, WidgetLibraryProps>(
             />
           </div>
           <div className="flex-1 overflow-y-auto p-6 custom-scrollbar space-y-6">
+            {savedWidgets.length > 0 && (
+              <div>
+                <div className="flex items-center gap-2 mb-3">
+                  <Bookmark className="w-3.5 h-3.5 text-slate-400" />
+                  <p className="text-xxs font-bold text-slate-400 uppercase tracking-widest">
+                    My Saved Widgets
+                  </p>
+                </div>
+                <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-3">
+                  {savedWidgets.map((sw) => {
+                    const Icon = getCustomWidgetIcon(sw.icon) ?? Puzzle;
+                    return (
+                      <div
+                        key={sw.id}
+                        className="relative group flex flex-col items-center gap-2 p-3 rounded-xl bg-white/60 border border-white/40 hover:bg-white hover:shadow-md transition-all text-center"
+                      >
+                        {/* Top-left: delete (with confirm) */}
+                        {onDeleteSavedWidget && (
+                          <button
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              onDeleteSavedWidget(sw.id);
+                            }}
+                            className="absolute top-1 left-1 p-1 rounded-md text-slate-400 hover:text-brand-red-primary hover:bg-red-50 opacity-0 group-hover:opacity-100 transition-all"
+                            aria-label="Delete saved widget"
+                            title="Delete saved widget"
+                          >
+                            <Trash2 className="w-3.5 h-3.5" />
+                          </button>
+                        )}
+                        {/* Top-right: pin toggle */}
+                        {onToggleSavedWidgetPin && (
+                          <button
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              onToggleSavedWidgetPin(sw.id, !sw.pinnedToDock);
+                            }}
+                            className={`absolute top-1 right-1 p-1 rounded-md transition-all ${
+                              sw.pinnedToDock
+                                ? 'text-brand-blue-primary opacity-100'
+                                : 'text-slate-400 hover:text-brand-blue-primary opacity-0 group-hover:opacity-100'
+                            }`}
+                            aria-label={
+                              sw.pinnedToDock
+                                ? 'Unpin from dock'
+                                : 'Pin to dock'
+                            }
+                            title={
+                              sw.pinnedToDock
+                                ? 'Unpin from dock'
+                                : 'Pin to dock'
+                            }
+                          >
+                            {sw.pinnedToDock ? (
+                              <Pin className="w-3.5 h-3.5" />
+                            ) : (
+                              <PinOff className="w-3.5 h-3.5" />
+                            )}
+                          </button>
+                        )}
+                        <button
+                          onClick={() => {
+                            onAddSavedWidget?.(sw.id);
+                            onClose();
+                          }}
+                          className="flex flex-col items-center gap-2 w-full focus:outline-none"
+                        >
+                          <div
+                            className={`w-10 h-10 rounded-xl ${sw.color} flex items-center justify-center text-white shadow-sm group-hover:scale-110 transition-transform`}
+                          >
+                            <Icon size={20} />
+                          </div>
+                          <span className="text-xs font-semibold text-slate-700 leading-tight line-clamp-2">
+                            {sw.title}
+                          </span>
+                        </button>
+                      </div>
+                    );
+                  })}
+                </div>
+              </div>
+            )}
             {customWidgets.length > 0 && (
               <div>
                 <div className="flex items-center gap-2 mb-3">

--- a/components/layout/dock/WidgetLibrary.tsx
+++ b/components/layout/dock/WidgetLibrary.tsx
@@ -1,17 +1,20 @@
 import React, { forwardRef, useCallback, useMemo } from 'react';
 import { createPortal } from 'react-dom';
 import {
-  LayoutGrid,
-  Plus,
-  X,
+  Bookmark,
   FolderPlus,
-  RotateCcw,
+  LayoutGrid,
+  Pin,
+  PinOff,
+  Plus,
   Puzzle,
+  RotateCcw,
+  Trash2,
+  X,
 } from 'lucide-react';
 import { Z_INDEX } from '@/config/zIndex';
 import { getCustomWidgetIcon } from '@/config/customWidgetIcons';
 import { CustomWidgetDoc, SavedWidget } from '@/types';
-import { Bookmark, Pin, PinOff, Trash2 } from 'lucide-react';
 import {
   DndContext,
   closestCenter,

--- a/components/widgets/MiniApp/Widget.tsx
+++ b/components/widgets/MiniApp/Widget.tsx
@@ -18,6 +18,7 @@ import {
   Loader2,
   CheckCircle2,
   ExternalLink,
+  Bookmark,
 } from 'lucide-react';
 import { WidgetLayout } from '../WidgetLayout';
 import { useAuth } from '@/context/useAuth';
@@ -49,8 +50,10 @@ import {
 import { MiniAppEditorModal } from './components/MiniAppEditorModal';
 import { AssignmentsModal } from './components/AssignmentsModal';
 import { MiniAppManager } from './components/MiniAppManager';
+import { SaveAsWidgetModal } from './components/SaveAsWidgetModal';
 import { useMiniAppSync } from './hooks/useMiniAppSync';
 import { useDialog } from '@/context/useDialog';
+import { useSavedWidgets } from '@/context/useSavedWidgets';
 import { ImportWizard } from '@/components/common/library/importer';
 import {
   createMiniAppImportAdapter,
@@ -286,6 +289,7 @@ export const MiniAppWidget: React.FC<WidgetComponentProps> = ({
   const { updateWidget, addToast, rosters } = useDashboard();
   const { user } = useAuth();
   const { showConfirm } = useDialog();
+  const { saveSavedWidget } = useSavedWidgets();
   const config = (widget.config ?? {}) as MiniAppConfig;
   const activeApp = config.activeApp ?? null;
 
@@ -494,6 +498,46 @@ export const MiniAppWidget: React.FC<WidgetComponentProps> = ({
   // Unsaved paste state: shown as an overlay when activeAppUnsaved is true
   const [showSaveForm, setShowSaveForm] = useState(false);
   const [pendingSaveTitle, setPendingSaveTitle] = useState('');
+
+  // "Save as Widget" — surface the active mini app as a one-tap shortcut in
+  // the user's dock + Widget Library. Distinct from `showSaveForm` (which
+  // saves an unsaved-paste app to the user's Mini App library).
+  const [showSaveAsWidget, setShowSaveAsWidget] = useState(false);
+  const [isSavingAsWidget, setIsSavingAsWidget] = useState(false);
+
+  const handleSaveAsWidget = useCallback(
+    async (values: { title: string; icon: string; color: string }) => {
+      if (!activeApp) return;
+      setIsSavingAsWidget(true);
+      try {
+        await saveSavedWidget({
+          widgetType: 'miniApp',
+          title: values.title,
+          icon: values.icon,
+          color: values.color,
+          pinnedToDock: true,
+          // Snapshot the mini app so the saved widget keeps working even if
+          // the original library entry is renamed or deleted.
+          config: {
+            activeApp: {
+              id: activeApp.id,
+              title: values.title,
+              html: activeApp.html,
+              createdAt: activeApp.createdAt,
+            },
+          },
+        });
+        addToast(`"${values.title}" added to your dock!`, 'success');
+        setShowSaveAsWidget(false);
+      } catch (err) {
+        console.error('[MiniAppWidget] Failed to save as widget', err);
+        addToast('Failed to save widget', 'error');
+      } finally {
+        setIsSavingAsWidget(false);
+      }
+    },
+    [activeApp, saveSavedWidget, addToast]
+  );
 
   // --- HANDLERS ---
 
@@ -868,6 +912,26 @@ export const MiniAppWidget: React.FC<WidgetComponentProps> = ({
                       </button>
                     </>
                   )}
+                  {!config.activeAppUnsaved && user && (
+                    <button
+                      onClick={() => setShowSaveAsWidget(true)}
+                      className="bg-white/90 hover:bg-white text-slate-700 backdrop-blur-sm rounded-lg uppercase tracking-wider flex items-center shadow-sm border border-slate-200/50 font-black transition-all"
+                      style={{
+                        padding: 'min(4px, 1cqmin) min(8px, 2cqmin)',
+                        fontSize: 'min(10px, 2.5cqmin)',
+                        gap: 'min(6px, 1.5cqmin)',
+                      }}
+                      title="Save as widget — pin this mini app to your dock"
+                    >
+                      <Bookmark
+                        style={{
+                          width: 'min(10px, 2.5cqmin)',
+                          height: 'min(10px, 2.5cqmin)',
+                        }}
+                      />
+                      <span className="hidden sm:inline">Save as Widget</span>
+                    </button>
+                  )}
                   <button
                     onClick={handleCloseActive}
                     className="bg-white/90 hover:bg-white text-slate-700 backdrop-blur-sm rounded-lg uppercase tracking-wider flex items-center shadow-sm border border-slate-200/50 font-black transition-all"
@@ -966,6 +1030,16 @@ export const MiniAppWidget: React.FC<WidgetComponentProps> = ({
                 onClose={handleCloseAssignments}
                 onRenameSession={renameSession}
                 onEndSession={handleEndSessionFromModal}
+              />
+            )}
+            {/* Save-as-Widget modal */}
+            {!isStudentView && activeApp && (
+              <SaveAsWidgetModal
+                isOpen={showSaveAsWidget}
+                defaultTitle={activeApp.title}
+                isSaving={isSavingAsWidget}
+                onSave={(values) => void handleSaveAsWidget(values)}
+                onClose={() => setShowSaveAsWidget(false)}
               />
             )}
           </div>

--- a/components/widgets/MiniApp/Widget.tsx
+++ b/components/widgets/MiniApp/Widget.tsx
@@ -517,11 +517,15 @@ export const MiniAppWidget: React.FC<WidgetComponentProps> = ({
           color: values.color,
           pinnedToDock: true,
           // Snapshot the mini app so the saved widget keeps working even if
-          // the original library entry is renamed or deleted.
+          // the original library entry is renamed or deleted. Keep the
+          // original `title` on the MiniAppItem so the assignment flow,
+          // session names, and the in-widget chrome still show the app's
+          // real name — `values.title` is the *widget shortcut* label, not
+          // the mini app's name.
           config: {
             activeApp: {
               id: activeApp.id,
-              title: values.title,
+              title: activeApp.title,
               html: activeApp.html,
               createdAt: activeApp.createdAt,
             },

--- a/components/widgets/MiniApp/components/SaveAsWidgetModal.tsx
+++ b/components/widgets/MiniApp/components/SaveAsWidgetModal.tsx
@@ -1,0 +1,225 @@
+import React, { useState } from 'react';
+import { Bookmark, X, Check, Loader2 } from 'lucide-react';
+import {
+  CUSTOM_WIDGET_ICON_OPTIONS,
+  getCustomWidgetIcon,
+} from '@/config/customWidgetIcons';
+
+const COLOR_PRESETS: ReadonlyArray<{ label: string; value: string }> = [
+  { label: 'Blue', value: 'bg-blue-500' },
+  { label: 'Indigo', value: 'bg-indigo-600' },
+  { label: 'Violet', value: 'bg-violet-600' },
+  { label: 'Purple', value: 'bg-purple-500' },
+  { label: 'Pink', value: 'bg-pink-500' },
+  { label: 'Red', value: 'bg-red-500' },
+  { label: 'Orange', value: 'bg-orange-500' },
+  { label: 'Amber', value: 'bg-amber-500' },
+  { label: 'Green', value: 'bg-green-500' },
+  { label: 'Emerald', value: 'bg-emerald-500' },
+  { label: 'Teal', value: 'bg-teal-500' },
+  { label: 'Slate', value: 'bg-slate-700' },
+];
+
+interface SaveAsWidgetModalProps {
+  isOpen: boolean;
+  defaultTitle: string;
+  /** Pre-filled when re-saving an existing entry */
+  initialIcon?: string;
+  initialColor?: string;
+  isSaving?: boolean;
+  onSave: (values: { title: string; icon: string; color: string }) => void;
+  onClose: () => void;
+}
+
+export const SaveAsWidgetModal: React.FC<SaveAsWidgetModalProps> = ({
+  isOpen,
+  defaultTitle,
+  initialIcon,
+  initialColor,
+  isSaving = false,
+  onSave,
+  onClose,
+}) => {
+  const [title, setTitle] = useState(defaultTitle);
+  const [icon, setIcon] = useState(
+    initialIcon ?? CUSTOM_WIDGET_ICON_OPTIONS[0].key
+  );
+  const [color, setColor] = useState(initialColor ?? COLOR_PRESETS[0].value);
+
+  // Reset form fields when the modal transitions from closed → open. Tracking
+  // the previous `isOpen` in state and adjusting during render avoids the
+  // cascading-render pitfall of doing this in a useEffect.
+  const [wasOpen, setWasOpen] = useState(isOpen);
+  if (isOpen !== wasOpen) {
+    setWasOpen(isOpen);
+    if (isOpen) {
+      setTitle(defaultTitle);
+      setIcon(initialIcon ?? CUSTOM_WIDGET_ICON_OPTIONS[0].key);
+      setColor(initialColor ?? COLOR_PRESETS[0].value);
+    }
+  }
+
+  if (!isOpen) return null;
+
+  const trimmed = title.trim();
+  const canSave = trimmed.length > 0 && !isSaving;
+
+  const handleSubmit = () => {
+    if (!canSave) return;
+    onSave({ title: trimmed, icon, color });
+  };
+
+  return (
+    <div className="absolute inset-0 z-overlay bg-slate-900/70 backdrop-blur-sm flex items-center justify-center p-4 animate-in fade-in duration-150">
+      <div
+        className="bg-white rounded-3xl w-full max-w-md shadow-2xl overflow-hidden animate-in zoom-in-95 duration-200 flex flex-col max-h-[90vh]"
+        onKeyDown={(e) => {
+          if (e.key === 'Escape') onClose();
+        }}
+      >
+        {/* Header */}
+        <div className="p-4 flex items-center justify-between bg-brand-blue-primary">
+          <div className="flex items-center gap-2 text-white">
+            <Bookmark className="w-5 h-5" />
+            <span className="font-black uppercase tracking-tight">
+              Save as Widget
+            </span>
+          </div>
+          <button
+            onClick={onClose}
+            className="text-white/70 hover:text-white transition-colors"
+            aria-label="Close"
+          >
+            <X className="w-5 h-5" />
+          </button>
+        </div>
+
+        <div className="p-5 space-y-5 overflow-y-auto">
+          {/* Live preview chip */}
+          <div className="flex items-center gap-3 bg-slate-50 border border-slate-200 rounded-xl p-3">
+            <div
+              className={`w-12 h-12 rounded-2xl ${color} flex items-center justify-center text-white shadow-sm shrink-0`}
+            >
+              {React.createElement(getCustomWidgetIcon(icon) ?? Bookmark, {
+                size: 22,
+              })}
+            </div>
+            <div className="min-w-0">
+              <p className="text-xxs font-black uppercase text-slate-400 tracking-widest">
+                Preview
+              </p>
+              <p className="text-sm font-bold text-slate-700 truncate">
+                {trimmed.length > 0 ? trimmed : 'Untitled widget'}
+              </p>
+            </div>
+          </div>
+
+          {/* Title */}
+          <div className="space-y-1.5">
+            <label
+              htmlFor="save-as-widget-title"
+              className="block text-xs font-black uppercase tracking-widest text-slate-500"
+            >
+              Title
+            </label>
+            <input
+              id="save-as-widget-title"
+              type="text"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              placeholder="My Mini App"
+              autoFocus
+              className="w-full rounded-xl border border-slate-200 px-3 py-2 text-sm font-medium text-slate-700 outline-none focus:border-brand-blue-primary"
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' && canSave) handleSubmit();
+              }}
+            />
+          </div>
+
+          {/* Icon */}
+          <div className="space-y-2">
+            <label className="block text-xs font-black uppercase tracking-widest text-slate-500">
+              Icon
+            </label>
+            <div className="grid grid-cols-6 gap-1.5">
+              {CUSTOM_WIDGET_ICON_OPTIONS.map((option) => {
+                const Icon = option.icon;
+                const active = option.key === icon;
+                return (
+                  <button
+                    key={option.key}
+                    type="button"
+                    onClick={() => setIcon(option.key)}
+                    title={option.label}
+                    aria-label={option.label}
+                    aria-pressed={active}
+                    className={`aspect-square rounded-xl flex items-center justify-center border-2 transition-all ${
+                      active
+                        ? 'border-brand-blue-primary bg-brand-blue-primary/10 text-brand-blue-primary'
+                        : 'border-slate-200 bg-white text-slate-500 hover:border-slate-300 hover:text-slate-700'
+                    }`}
+                  >
+                    <Icon className="w-4 h-4" />
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+
+          {/* Color */}
+          <div className="space-y-2">
+            <label className="block text-xs font-black uppercase tracking-widest text-slate-500">
+              Color
+            </label>
+            <div className="flex flex-wrap gap-2">
+              {COLOR_PRESETS.map((preset) => {
+                const active = preset.value === color;
+                return (
+                  <button
+                    key={preset.value}
+                    type="button"
+                    onClick={() => setColor(preset.value)}
+                    title={preset.label}
+                    aria-label={preset.label}
+                    aria-pressed={active}
+                    className={`w-8 h-8 rounded-full ${preset.value} flex items-center justify-center text-white transition-all shadow-sm ${
+                      active
+                        ? 'ring-2 ring-offset-2 ring-brand-blue-primary scale-110'
+                        : 'hover:scale-105'
+                    }`}
+                  >
+                    {active ? <Check className="w-4 h-4" /> : null}
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+        </div>
+
+        {/* Footer */}
+        <div className="px-5 py-4 bg-slate-50 border-t border-slate-100 flex items-center justify-end gap-2">
+          <button
+            type="button"
+            onClick={onClose}
+            className="px-4 py-2 rounded-xl text-sm font-bold text-slate-600 hover:bg-slate-100 transition-colors"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={handleSubmit}
+            disabled={!canSave}
+            className="px-4 py-2 rounded-xl text-sm font-black uppercase tracking-widest bg-brand-blue-primary hover:bg-brand-blue-dark text-white transition-all active:scale-95 disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2 shadow-sm"
+          >
+            {isSaving ? (
+              <Loader2 className="w-4 h-4 animate-spin" />
+            ) : (
+              <Bookmark className="w-4 h-4" />
+            )}
+            <span>{isSaving ? 'Saving…' : 'Save Widget'}</span>
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/components/widgets/MiniApp/components/SaveAsWidgetModal.tsx
+++ b/components/widgets/MiniApp/components/SaveAsWidgetModal.tsx
@@ -23,9 +23,6 @@ const COLOR_PRESETS: ReadonlyArray<{ label: string; value: string }> = [
 interface SaveAsWidgetModalProps {
   isOpen: boolean;
   defaultTitle: string;
-  /** Pre-filled when re-saving an existing entry */
-  initialIcon?: string;
-  initialColor?: string;
   isSaving?: boolean;
   onSave: (values: { title: string; icon: string; color: string }) => void;
   onClose: () => void;
@@ -34,17 +31,13 @@ interface SaveAsWidgetModalProps {
 export const SaveAsWidgetModal: React.FC<SaveAsWidgetModalProps> = ({
   isOpen,
   defaultTitle,
-  initialIcon,
-  initialColor,
   isSaving = false,
   onSave,
   onClose,
 }) => {
   const [title, setTitle] = useState(defaultTitle);
-  const [icon, setIcon] = useState(
-    initialIcon ?? CUSTOM_WIDGET_ICON_OPTIONS[0].key
-  );
-  const [color, setColor] = useState(initialColor ?? COLOR_PRESETS[0].value);
+  const [icon, setIcon] = useState(CUSTOM_WIDGET_ICON_OPTIONS[0].key);
+  const [color, setColor] = useState(COLOR_PRESETS[0].value);
 
   // Reset form fields when the modal transitions from closed → open. Tracking
   // the previous `isOpen` in state and adjusting during render avoids the
@@ -54,8 +47,8 @@ export const SaveAsWidgetModal: React.FC<SaveAsWidgetModalProps> = ({
     setWasOpen(isOpen);
     if (isOpen) {
       setTitle(defaultTitle);
-      setIcon(initialIcon ?? CUSTOM_WIDGET_ICON_OPTIONS[0].key);
-      setColor(initialColor ?? COLOR_PRESETS[0].value);
+      setIcon(CUSTOM_WIDGET_ICON_OPTIONS[0].key);
+      setColor(COLOR_PRESETS[0].value);
     }
   }
 

--- a/context/SavedWidgetsContext.tsx
+++ b/context/SavedWidgetsContext.tsx
@@ -1,0 +1,121 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  collection,
+  deleteDoc,
+  doc,
+  onSnapshot,
+  orderBy,
+  query,
+  setDoc,
+  updateDoc,
+} from 'firebase/firestore';
+import { db, isConfigured, isAuthBypass } from '../config/firebase';
+import { SavedWidget } from '../types';
+import { useAuth } from './useAuth';
+import { SavedWidgetsContext } from './SavedWidgetsContextValue';
+
+export { SavedWidgetsContext } from './SavedWidgetsContextValue';
+
+export const SavedWidgetsProvider: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => {
+  const { user } = useAuth();
+  const [savedWidgets, setSavedWidgets] = useState<SavedWidget[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!user || !isConfigured || isAuthBypass) {
+      // Defer to a microtask so the initial render commits before the state
+      // resets — calling setState synchronously inside an effect causes
+      // cascading renders flagged by react-hooks/set-state-in-effect.
+      const timer = setTimeout(() => {
+        setSavedWidgets([]);
+        setLoading(false);
+      }, 0);
+      return () => clearTimeout(timer);
+    }
+
+    const ref = collection(db, 'users', user.uid, 'saved_widgets');
+    const q = query(ref, orderBy('createdAt', 'asc'));
+    const unsub = onSnapshot(
+      q,
+      (snap) => {
+        const docs = snap.docs.map((d) => ({
+          ...d.data(),
+          id: d.id,
+        })) as SavedWidget[];
+        setSavedWidgets(docs);
+        setLoading(false);
+      },
+      (err) => {
+        console.error('[SavedWidgetsContext] Listener error', err);
+        setLoading(false);
+      }
+    );
+
+    return unsub;
+  }, [user]);
+
+  const saveSavedWidget = useCallback(
+    async (
+      widget: Omit<SavedWidget, 'id' | 'createdAt' | 'updatedAt'> & {
+        id?: string;
+      }
+    ) => {
+      if (!user) throw new Error('Not authenticated');
+      if (!isConfigured || isAuthBypass)
+        return widget.id ?? crypto.randomUUID();
+      const id = widget.id ?? crypto.randomUUID();
+      const now = Date.now();
+      const ref = doc(db, 'users', user.uid, 'saved_widgets', id);
+      const existing = savedWidgets.find((w) => w.id === id);
+      const payload: SavedWidget = {
+        ...widget,
+        id,
+        createdAt: existing?.createdAt ?? now,
+        updatedAt: now,
+      };
+      await setDoc(ref, payload);
+      return id;
+    },
+    [user, savedWidgets]
+  );
+
+  const setPinnedToDock = useCallback(
+    async (id: string, pinned: boolean) => {
+      if (!user) return;
+      if (!isConfigured || isAuthBypass) return;
+      await updateDoc(doc(db, 'users', user.uid, 'saved_widgets', id), {
+        pinnedToDock: pinned,
+        updatedAt: Date.now(),
+      });
+    },
+    [user]
+  );
+
+  const deleteSavedWidget = useCallback(
+    async (id: string) => {
+      if (!user) return;
+      if (!isConfigured || isAuthBypass) return;
+      await deleteDoc(doc(db, 'users', user.uid, 'saved_widgets', id));
+    },
+    [user]
+  );
+
+  const value = useMemo(
+    () => ({
+      savedWidgets,
+      loading,
+      saveSavedWidget,
+      setPinnedToDock,
+      deleteSavedWidget,
+    }),
+    [savedWidgets, loading, saveSavedWidget, setPinnedToDock, deleteSavedWidget]
+  );
+
+  return (
+    <SavedWidgetsContext.Provider value={value}>
+      {children}
+    </SavedWidgetsContext.Provider>
+  );
+};

--- a/context/SavedWidgetsContextValue.ts
+++ b/context/SavedWidgetsContextValue.ts
@@ -1,0 +1,22 @@
+import { createContext } from 'react';
+import { SavedWidget } from '../types';
+
+export interface SavedWidgetsContextValue {
+  /** All of the signed-in user's saved widgets */
+  savedWidgets: SavedWidget[];
+  /** Whether the initial load is still in flight */
+  loading: boolean;
+  /** Create or update a saved widget */
+  saveSavedWidget: (
+    widget: Omit<SavedWidget, 'id' | 'createdAt' | 'updatedAt'> & {
+      id?: string;
+    }
+  ) => Promise<string>;
+  /** Toggle whether a saved widget is pinned to the dock */
+  setPinnedToDock: (id: string, pinned: boolean) => Promise<void>;
+  /** Permanently delete a saved widget */
+  deleteSavedWidget: (id: string) => Promise<void>;
+}
+
+export const SavedWidgetsContext =
+  createContext<SavedWidgetsContextValue | null>(null);

--- a/context/useSavedWidgets.ts
+++ b/context/useSavedWidgets.ts
@@ -1,0 +1,10 @@
+import { useContext } from 'react';
+import { SavedWidgetsContext } from './SavedWidgetsContextValue';
+
+export function useSavedWidgets() {
+  const ctx = useContext(SavedWidgetsContext);
+  if (!ctx) {
+    throw new Error('useSavedWidgets must be used inside SavedWidgetsProvider');
+  }
+  return ctx;
+}

--- a/firestore.rules
+++ b/firestore.rules
@@ -418,6 +418,12 @@ service cloud.firestore {
       allow read, write: if request.auth != null && request.auth.uid == userId;
     }
 
+    // Saved Widgets - per-user "Save as widget" shortcuts (frozen widget configs
+    // surfaced as dock/library entries). Owner-only.
+    match /users/{userId}/saved_widgets/{savedWidgetId} {
+      allow read, write: if request.auth != null && request.auth.uid == userId;
+    }
+
     // Notebooks - users can only access their own notebooks in their subcollection
     match /users/{userId}/notebooks/{notebookId} {
       allow read, write: if request.auth != null && request.auth.uid == userId;

--- a/types.ts
+++ b/types.ts
@@ -3989,10 +3989,17 @@ export interface CustomWidgetConfig {
  * into `config` and surfaced as a one-tap entry in the user's dock and
  * Widget Library. Per-user; lives at /users/{uid}/saved_widgets/{id}.
  */
+/**
+ * Narrow union of widget types eligible to be saved as user shortcuts.
+ * Only `miniApp` produces saved widgets today; widening this requires
+ * deciding what `config` shape each new type freezes (see SavedWidget.config).
+ */
+export type SavedWidgetType = 'miniApp';
+
 export interface SavedWidget {
   id: string;
   /** The underlying widget type to instantiate */
-  widgetType: WidgetType;
+  widgetType: SavedWidgetType;
   /** Display name shown in the dock and library */
   title: string;
   /** Icon key from CUSTOM_WIDGET_ICON_OPTIONS */
@@ -4000,7 +4007,7 @@ export interface SavedWidget {
   /** Tailwind bg-* class (e.g. 'bg-purple-500') */
   color: string;
   /** Frozen config snapshot used to instantiate the widget */
-  config: DistributedPartial<WidgetConfig>;
+  config: Partial<MiniAppConfig>;
   /** Whether this saved widget is pinned to the dock toolbar */
   pinnedToDock: boolean;
   createdAt: number;

--- a/types.ts
+++ b/types.ts
@@ -3983,6 +3983,30 @@ export interface CustomWidgetConfig {
   adminSettings?: Record<string, string | number | boolean>;
 }
 
+/**
+ * A user-saved widget shortcut. Created when a user taps "Save as widget" on
+ * a configurable widget (currently Mini Apps) — the widget's config is frozen
+ * into `config` and surfaced as a one-tap entry in the user's dock and
+ * Widget Library. Per-user; lives at /users/{uid}/saved_widgets/{id}.
+ */
+export interface SavedWidget {
+  id: string;
+  /** The underlying widget type to instantiate */
+  widgetType: WidgetType;
+  /** Display name shown in the dock and library */
+  title: string;
+  /** Icon key from CUSTOM_WIDGET_ICON_OPTIONS */
+  icon: string;
+  /** Tailwind bg-* class (e.g. 'bg-purple-500') */
+  color: string;
+  /** Frozen config snapshot used to instantiate the widget */
+  config: DistributedPartial<WidgetConfig>;
+  /** Whether this saved widget is pinned to the dock toolbar */
+  pinnedToDock: boolean;
+  createdAt: number;
+  updatedAt: number;
+}
+
 export interface RemoteGlobalConfig {
   dockDefaults?: Record<string, boolean>;
 }


### PR DESCRIPTION
## Summary
- Adds a **Save as Widget** button to the Mini App widget header. Tapping it opens a modal where the teacher picks a title, an icon (curated lucide set), and an accent color. The active mini app is snapshotted into a per-user shortcut at `/users/{uid}/saved_widgets`.
- Saved widgets surface in the dock as pinned items (separator between the standard tools and the More button) and in the Widget Library under a new **My Saved Widgets** section. Tapping either re-instantiates the underlying widget (currently `miniApp`) on the board with the frozen config.
- Dock edit mode keeps the standard top-right `X` (remove from dock → just unpins the saved widget) and adds a new top-left trash button on saved widgets that deletes them entirely after a confirm dialog. Pin/unpin and delete are also available on each card in the Widget Library so unpinned shortcuts stay recoverable.

## Architecture notes
- New `SavedWidgetsContext` / `useSavedWidgets()` mirrors the existing `CustomWidgetsContext` pattern. Owner-scoped Firestore listener; `pinnedToDock`, `setPinnedToDock`, `deleteSavedWidget` actions.
- New `SavedWidget` type in `types.ts` and new Firestore rule in `firestore.rules` (`/users/{userId}/saved_widgets/{id}` — owner read/write only).
- HTML is **snapshotted** into the saved widget rather than referenced by Mini App ID so the shortcut keeps working after the source mini app is renamed or deleted.
- Saved widgets live outside the existing `dockItems`/`visibleTools` machinery (which is keyed by `WidgetType`) — instead they render as a dedicated section after the sortable dock items, similar to the existing minimized-custom-widget restore chips.

## Test plan
- [ ] Open a Mini App, run an app from the library, and click **Save as Widget** — modal opens prefilled with the app's title.
- [ ] Pick a title/icon/color and save — toast confirms, the new widget appears in the dock and Widget Library.
- [ ] Tap the saved widget in the dock — a new Mini App widget instantiates on the board running the saved HTML.
- [ ] Long-press the dock to enter edit mode — saved widget shows top-right `X` (unpin) and top-left trash. The X unpins (saved widget moves to library only); trash prompts a confirm and deletes.
- [ ] Open the Widget Library — saved widget shows pin/unpin and trash on hover; pin re-pins to the dock.
- [ ] Sign in as a different user — none of user A's saved widgets appear (per-user scope).
- [ ] `pnpm run validate` — type-check, lint, format, and unit tests all pass.

https://claude.ai/code/session_01PAc11vxqh7dMEmTvnEL4ky

---
_Generated by [Claude Code](https://claude.ai/code/session_01PAc11vxqh7dMEmTvnEL4ky)_