### PR TITLE
feat(widgets): Stations widget with rotate, shuffle, and Nexus links

### DIFF
--- a/components/widgets/Stations/Settings.tsx
+++ b/components/widgets/Stations/Settings.tsx
@@ -1,0 +1,303 @@
+import React, { useCallback, useMemo } from 'react';
+import { Plus, Send, LayoutGrid, Type, Palette } from 'lucide-react';
+import { StationsConfig, RandomConfig, Station, WidgetData } from '@/types';
+import { useDashboard } from '@/context/useDashboard';
+import { SettingsLabel } from '@/components/common/SettingsLabel';
+import { WIDGET_PALETTE } from '@/config/colors';
+import { StationEditor } from './components/StationEditor';
+import { SavedPresetsPanel } from './components/SavedPresetsPanel';
+
+const DEFAULT_STATION_COLORS = WIDGET_PALETTE;
+
+const buildEmptyStation = (order: number, color: string): Station => ({
+  id: crypto.randomUUID(),
+  title: '',
+  color,
+  order,
+});
+
+export const StationsSettings: React.FC<{ widget: WidgetData }> = ({
+  widget,
+}) => {
+  const { updateWidget, addToast, activeDashboard } = useDashboard();
+  const config = widget.config as StationsConfig;
+  const stations = useMemo(
+    () => [...(config.stations ?? [])].sort((a, b) => a.order - b.order),
+    [config.stations]
+  );
+
+  const persistStations = useCallback(
+    (next: Station[]) => {
+      // Renormalize order so it always reads 0..N-1, regardless of how the
+      // caller left things.
+      const renormalized = next.map((s, i) => ({ ...s, order: i }));
+      updateWidget(widget.id, {
+        config: { ...config, stations: renormalized },
+      });
+    },
+    [widget.id, config, updateWidget]
+  );
+
+  const handleAddStation = () => {
+    const color =
+      DEFAULT_STATION_COLORS[stations.length % DEFAULT_STATION_COLORS.length];
+    const next = [...stations, buildEmptyStation(stations.length, color)];
+    persistStations(next);
+  };
+
+  const handleStationChange = (id: string, updates: Partial<Station>) => {
+    const next = stations.map((s) => (s.id === id ? { ...s, ...updates } : s));
+    persistStations(next);
+  };
+
+  const handleStationDelete = (id: string) => {
+    const station = stations.find((s) => s.id === id);
+    const hasMembers =
+      station && Object.values(config.assignments ?? {}).some((v) => v === id);
+    if (
+      hasMembers &&
+      !window.confirm(
+        'This station has students in it. Deleting will return them to unassigned. Continue?'
+      )
+    ) {
+      return;
+    }
+    const next = stations.filter((s) => s.id !== id);
+    // Strip the deleted id from any assignment.
+    const nextAssignments: Record<string, string | null> = {};
+    for (const [name, value] of Object.entries(config.assignments ?? {})) {
+      nextAssignments[name] = value === id ? null : value;
+    }
+    updateWidget(widget.id, {
+      config: {
+        ...config,
+        stations: next.map((s, i) => ({ ...s, order: i })),
+        assignments: nextAssignments,
+      },
+    });
+  };
+
+  const handleMove = (id: string, delta: number) => {
+    const idx = stations.findIndex((s) => s.id === id);
+    if (idx < 0) return;
+    const target = idx + delta;
+    if (target < 0 || target >= stations.length) return;
+    const next = [...stations];
+    [next[idx], next[target]] = [next[target], next[idx]];
+    persistStations(next);
+  };
+
+  const handleLoadPreset = (presetStations: Station[]) => {
+    const renormalized = presetStations.map((s, i) => ({ ...s, order: i }));
+    updateWidget(widget.id, {
+      config: {
+        ...config,
+        stations: renormalized,
+        // Wipe assignments — preset doesn't include them, and old keys would
+        // point at stale station ids.
+        assignments: {},
+      },
+    });
+  };
+
+  // Find the first Randomizer widget on the active dashboard. Matches the
+  // "find-first" pattern used by Timer→Randomizer/Traffic/NextUp Nexus.
+  const randomizerWidget = activeDashboard?.widgets.find(
+    (w) => w.type === 'random'
+  );
+
+  const handleSendToRandomizer = () => {
+    if (!randomizerWidget) {
+      addToast('Add a Randomizer widget to the board first.', 'info');
+      return;
+    }
+    const titles = stations.map((s) =>
+      s.title.trim() ? s.title : `Station ${s.order + 1}`
+    );
+    if (titles.length === 0) {
+      addToast('Add at least one station first.', 'info');
+      return;
+    }
+    if (
+      !window.confirm(
+        `Send ${titles.length} station name${titles.length === 1 ? '' : 's'} to the Randomizer? This sets its first/last names to your station titles so it can pick from them.`
+      )
+    ) {
+      return;
+    }
+    const randomConfig = randomizerWidget.config as RandomConfig;
+    updateWidget(randomizerWidget.id, {
+      config: {
+        ...randomConfig,
+        firstNames: titles.join('\n'),
+        lastNames: '',
+        rosterMode: 'custom',
+      },
+    });
+    addToast('Sent station names to Randomizer.', 'success');
+  };
+
+  return (
+    <div className="space-y-6 p-1">
+      <div>
+        <div className="flex items-center justify-between mb-2">
+          <SettingsLabel icon={LayoutGrid}>Stations</SettingsLabel>
+          <button
+            type="button"
+            onClick={handleAddStation}
+            className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-brand-blue-primary text-white text-xxs font-black uppercase tracking-widest hover:bg-brand-blue-dark transition-colors shadow-sm"
+          >
+            <Plus size={12} />
+            Add Station
+          </button>
+        </div>
+
+        {stations.length === 0 ? (
+          <div className="text-center py-8 border-2 border-dashed border-slate-200 rounded-2xl bg-white">
+            <LayoutGrid className="w-8 h-8 text-slate-300 mx-auto mb-2" />
+            <p className="text-sm font-bold text-slate-500">No stations yet.</p>
+            <p className="text-xs text-slate-400 mt-1">
+              Add a station to get started.
+            </p>
+          </div>
+        ) : (
+          <div className="space-y-2">
+            {stations.map((station, index) => (
+              <StationEditor
+                key={station.id}
+                station={station}
+                index={index}
+                total={stations.length}
+                onChange={(updates) => handleStationChange(station.id, updates)}
+                onDelete={() => handleStationDelete(station.id)}
+                onMoveUp={() => handleMove(station.id, -1)}
+                onMoveDown={() => handleMove(station.id, 1)}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Nexus: Send to Randomizer */}
+      <div className="pt-4 border-t border-slate-100">
+        <SettingsLabel icon={Send}>Connect with Randomizer</SettingsLabel>
+        {!randomizerWidget ? (
+          <div className="text-xs text-brand-blue-primary bg-brand-blue-lighter/20 p-3 rounded-xl border border-brand-blue-lighter/30 leading-snug">
+            Add a Randomizer widget to send your station names to it.
+          </div>
+        ) : (
+          <button
+            type="button"
+            onClick={handleSendToRandomizer}
+            disabled={stations.length === 0}
+            className="w-full flex items-center justify-center gap-2 px-3 py-2 rounded-xl bg-indigo-50 border border-indigo-100 text-indigo-700 font-black uppercase tracking-widest text-xxs hover:bg-indigo-100 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            <Send size={13} />
+            Send Station Names to Randomizer
+          </button>
+        )}
+      </div>
+
+      {/* Saved presets */}
+      <div className="pt-4 border-t border-slate-100">
+        <SavedPresetsPanel stations={stations} onLoad={handleLoadPreset} />
+      </div>
+    </div>
+  );
+};
+
+// =============================================================================
+// Appearance settings (back-face style tab)
+// =============================================================================
+
+const FONT_OPTIONS: {
+  id: NonNullable<StationsConfig['fontFamily']>;
+  label: string;
+}[] = [
+  { id: 'sans', label: 'Sans' },
+  { id: 'mono', label: 'Mono' },
+  { id: 'handwritten', label: 'Hand' },
+  { id: 'rounded', label: 'Round' },
+];
+
+export const StationsAppearanceSettings: React.FC<{ widget: WidgetData }> = ({
+  widget,
+}) => {
+  const { updateWidget } = useDashboard();
+  const config = widget.config as StationsConfig;
+
+  return (
+    <div className="space-y-6 p-1">
+      <div>
+        <SettingsLabel icon={Type}>Typography</SettingsLabel>
+        <div className="grid grid-cols-4 gap-2">
+          {FONT_OPTIONS.map((f) => (
+            <button
+              key={f.id}
+              type="button"
+              onClick={() =>
+                updateWidget(widget.id, {
+                  config: { ...config, fontFamily: f.id },
+                })
+              }
+              className={`p-2 rounded-lg border-2 flex items-center justify-center text-xxs font-black uppercase tracking-widest transition-all ${
+                config.fontFamily === f.id
+                  ? 'bg-blue-600 border-blue-600 text-white shadow-sm'
+                  : 'bg-white border-slate-200 text-slate-600'
+              }`}
+            >
+              {f.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div>
+        <SettingsLabel icon={Palette}>Card surface</SettingsLabel>
+        <div className="space-y-2">
+          <div className="flex items-center gap-2">
+            <input
+              type="color"
+              value={config.cardColor ?? '#f8fafc'}
+              onChange={(e) =>
+                updateWidget(widget.id, {
+                  config: { ...config, cardColor: e.target.value },
+                })
+              }
+              className="w-9 h-9 rounded-lg border border-slate-200 cursor-pointer"
+              aria-label="Card background color"
+            />
+            <input
+              type="text"
+              value={config.cardColor ?? '#f8fafc'}
+              onChange={(e) =>
+                updateWidget(widget.id, {
+                  config: { ...config, cardColor: e.target.value },
+                })
+              }
+              className="flex-1 px-2.5 py-1.5 text-sm border border-slate-200 rounded-lg focus:ring-2 focus:ring-brand-blue-primary focus:outline-none"
+            />
+          </div>
+          <div>
+            <label className="block text-xxs font-bold text-slate-500 uppercase tracking-widest mb-1">
+              Opacity
+            </label>
+            <input
+              type="range"
+              min={0}
+              max={1}
+              step={0.05}
+              value={config.cardOpacity ?? 0.4}
+              onChange={(e) =>
+                updateWidget(widget.id, {
+                  config: { ...config, cardOpacity: Number(e.target.value) },
+                })
+              }
+              className="w-full"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/components/widgets/Stations/Settings.tsx
+++ b/components/widgets/Stations/Settings.tsx
@@ -1,8 +1,13 @@
 import React, { useCallback, useMemo } from 'react';
-import { Plus, Send, LayoutGrid, Type, Palette } from 'lucide-react';
+import { Plus, Send, LayoutGrid } from 'lucide-react';
 import { StationsConfig, RandomConfig, Station, WidgetData } from '@/types';
+import { useAuth } from '@/context/useAuth';
 import { useDashboard } from '@/context/useDashboard';
+import { useDialog } from '@/context/useDialog';
+import { useStorage } from '@/hooks/useStorage';
 import { SettingsLabel } from '@/components/common/SettingsLabel';
+import { TypographySettings } from '@/components/common/TypographySettings';
+import { SurfaceColorSettings } from '@/components/common/SurfaceColorSettings';
 import { WIDGET_PALETTE } from '@/config/colors';
 import { StationEditor } from './components/StationEditor';
 import { SavedPresetsPanel } from './components/SavedPresetsPanel';
@@ -16,10 +21,33 @@ const buildEmptyStation = (order: number, color: string): Station => ({
   order,
 });
 
+/**
+ * Best-effort destructive cleanup of an uploaded image. Failures are
+ * non-fatal — Drive may already be missing the file, the user might be
+ * offline, or the URL might still be referenced elsewhere. We log and move on.
+ */
+const tryDeleteUrl = async (
+  url: string | undefined,
+  deleteFile: (path: string) => Promise<void>,
+  context: string
+): Promise<boolean> => {
+  if (!url) return true;
+  try {
+    await deleteFile(url);
+    return true;
+  } catch (err) {
+    console.warn(`[StationsSettings] ${context} cleanup failed`, err);
+    return false;
+  }
+};
+
 export const StationsSettings: React.FC<{ widget: WidgetData }> = ({
   widget,
 }) => {
   const { updateWidget, addToast, activeDashboard } = useDashboard();
+  const { showConfirm } = useDialog();
+  const { savedWidgetConfigs } = useAuth();
+  const { deleteFile } = useStorage();
   const config = widget.config as StationsConfig;
   const stations = useMemo(
     () => [...(config.stations ?? [])].sort((a, b) => a.order - b.order),
@@ -38,6 +66,24 @@ export const StationsSettings: React.FC<{ widget: WidgetData }> = ({
     [widget.id, config, updateWidget]
   );
 
+  /**
+   * Build the set of imageUrls referenced by saved presets so we know which
+   * Drive blobs are *not* safe to delete when the live widget swaps out a
+   * station/preset. Used by handleStationDelete and handleLoadPreset.
+   */
+  const protectedImageUrls = useMemo(() => {
+    const set = new Set<string>();
+    const lib =
+      (savedWidgetConfigs.stations as Partial<StationsConfig> | undefined)
+        ?.savedLibrary ?? [];
+    for (const preset of lib) {
+      for (const s of preset.stations) {
+        if (s.imageUrl) set.add(s.imageUrl);
+      }
+    }
+    return set;
+  }, [savedWidgetConfigs]);
+
   const handleAddStation = () => {
     const color =
       DEFAULT_STATION_COLORS[stations.length % DEFAULT_STATION_COLORS.length];
@@ -50,17 +96,22 @@ export const StationsSettings: React.FC<{ widget: WidgetData }> = ({
     persistStations(next);
   };
 
-  const handleStationDelete = (id: string) => {
+  const handleStationDelete = async (id: string) => {
     const station = stations.find((s) => s.id === id);
-    const hasMembers =
-      station && Object.values(config.assignments ?? {}).some((v) => v === id);
-    if (
-      hasMembers &&
-      !window.confirm(
-        'This station has students in it. Deleting will return them to unassigned. Continue?'
-      )
-    ) {
-      return;
+    if (!station) return;
+    const hasMembers = Object.values(config.assignments ?? {}).some(
+      (v) => v === id
+    );
+    if (hasMembers) {
+      const ok = await showConfirm(
+        'This station has students in it. Deleting will return them to unassigned. Any uploaded image for this station will be removed from your Drive.',
+        {
+          title: 'Delete station?',
+          confirmLabel: 'Delete',
+          variant: 'danger',
+        }
+      );
+      if (!ok) return;
     }
     const next = stations.filter((s) => s.id !== id);
     // Strip the deleted id from any assignment.
@@ -75,6 +126,11 @@ export const StationsSettings: React.FC<{ widget: WidgetData }> = ({
         assignments: nextAssignments,
       },
     });
+    // Destructive Drive cleanup AFTER the config update commits, and only if
+    // no preset still references this URL.
+    if (station.imageUrl && !protectedImageUrls.has(station.imageUrl)) {
+      void tryDeleteUrl(station.imageUrl, deleteFile, 'station-delete');
+    }
   };
 
   const handleMove = (id: string, delta: number) => {
@@ -89,6 +145,15 @@ export const StationsSettings: React.FC<{ widget: WidgetData }> = ({
 
   const handleLoadPreset = (presetStations: Station[]) => {
     const renormalized = presetStations.map((s, i) => ({ ...s, order: i }));
+    // Snapshot the live-widget URLs that are about to be replaced.
+    const outgoingUrls = stations
+      .map((s) => s.imageUrl)
+      .filter((u): u is string => !!u);
+    // Don't delete URLs referenced by the incoming preset (would break it
+    // immediately), nor URLs referenced by any other saved preset.
+    const incomingUrls = new Set(
+      renormalized.map((s) => s.imageUrl).filter((u): u is string => !!u)
+    );
     updateWidget(widget.id, {
       config: {
         ...config,
@@ -98,6 +163,11 @@ export const StationsSettings: React.FC<{ widget: WidgetData }> = ({
         assignments: {},
       },
     });
+    for (const url of outgoingUrls) {
+      if (incomingUrls.has(url)) continue;
+      if (protectedImageUrls.has(url)) continue;
+      void tryDeleteUrl(url, deleteFile, 'preset-load');
+    }
   };
 
   // Find the first Randomizer widget on the active dashboard. Matches the
@@ -106,26 +176,44 @@ export const StationsSettings: React.FC<{ widget: WidgetData }> = ({
     (w) => w.type === 'random'
   );
 
-  const handleSendToRandomizer = () => {
+  const handleSendToRandomizer = async () => {
     if (!randomizerWidget) {
       addToast('Add a Randomizer widget to the board first.', 'info');
       return;
     }
     const titles = stations.map((s) =>
-      s.title.trim() ? s.title : `Station ${s.order + 1}`
+      s.title.trim() ? s.title.trim() : `Station ${s.order + 1}`
     );
     if (titles.length === 0) {
       addToast('Add at least one station first.', 'info');
       return;
     }
-    if (
-      !window.confirm(
-        `Send ${titles.length} station name${titles.length === 1 ? '' : 's'} to the Randomizer? This sets its first/last names to your station titles so it can pick from them.`
-      )
-    ) {
-      return;
-    }
     const randomConfig = randomizerWidget.config as RandomConfig;
+    const willOverwriteCustom =
+      (randomConfig.firstNames ?? '').trim().length > 0 ||
+      (randomConfig.lastNames ?? '').trim().length > 0;
+    const willSwitchMode = randomConfig.rosterMode !== 'custom';
+    const messageParts = [
+      `This will replace the Randomizer's name list with ${titles.length} station name${titles.length === 1 ? '' : 's'}.`,
+    ];
+    if (willSwitchMode) {
+      messageParts.push(
+        "Roster mode will switch to 'Custom Names' (you can switch back to a class roster afterwards)."
+      );
+    }
+    if (willOverwriteCustom) {
+      messageParts.push(
+        'Any custom names currently typed into the Randomizer will be lost.'
+      );
+    }
+    const ok = await showConfirm(messageParts.join(' '), {
+      title: 'Send station names to Randomizer?',
+      confirmLabel: 'Send',
+      ...(willOverwriteCustom || willSwitchMode
+        ? { variant: 'danger' as const }
+        : {}),
+    });
+    if (!ok) return;
     updateWidget(randomizerWidget.id, {
       config: {
         ...randomConfig,
@@ -210,94 +298,27 @@ export const StationsSettings: React.FC<{ widget: WidgetData }> = ({
 // Appearance settings (back-face style tab)
 // =============================================================================
 
-const FONT_OPTIONS: {
-  id: NonNullable<StationsConfig['fontFamily']>;
-  label: string;
-}[] = [
-  { id: 'sans', label: 'Sans' },
-  { id: 'mono', label: 'Mono' },
-  { id: 'handwritten', label: 'Hand' },
-  { id: 'rounded', label: 'Round' },
-];
-
 export const StationsAppearanceSettings: React.FC<{ widget: WidgetData }> = ({
   widget,
 }) => {
   const { updateWidget } = useDashboard();
   const config = widget.config as StationsConfig;
 
+  const updateConfig = useCallback(
+    (updates: Partial<StationsConfig>) => {
+      updateWidget(widget.id, { config: { ...config, ...updates } });
+    },
+    [widget.id, config, updateWidget]
+  );
+
   return (
     <div className="space-y-6 p-1">
-      <div>
-        <SettingsLabel icon={Type}>Typography</SettingsLabel>
-        <div className="grid grid-cols-4 gap-2">
-          {FONT_OPTIONS.map((f) => (
-            <button
-              key={f.id}
-              type="button"
-              onClick={() =>
-                updateWidget(widget.id, {
-                  config: { ...config, fontFamily: f.id },
-                })
-              }
-              className={`p-2 rounded-lg border-2 flex items-center justify-center text-xxs font-black uppercase tracking-widest transition-all ${
-                config.fontFamily === f.id
-                  ? 'bg-blue-600 border-blue-600 text-white shadow-sm'
-                  : 'bg-white border-slate-200 text-slate-600'
-              }`}
-            >
-              {f.label}
-            </button>
-          ))}
-        </div>
-      </div>
-
-      <div>
-        <SettingsLabel icon={Palette}>Card surface</SettingsLabel>
-        <div className="space-y-2">
-          <div className="flex items-center gap-2">
-            <input
-              type="color"
-              value={config.cardColor ?? '#f8fafc'}
-              onChange={(e) =>
-                updateWidget(widget.id, {
-                  config: { ...config, cardColor: e.target.value },
-                })
-              }
-              className="w-9 h-9 rounded-lg border border-slate-200 cursor-pointer"
-              aria-label="Card background color"
-            />
-            <input
-              type="text"
-              value={config.cardColor ?? '#f8fafc'}
-              onChange={(e) =>
-                updateWidget(widget.id, {
-                  config: { ...config, cardColor: e.target.value },
-                })
-              }
-              className="flex-1 px-2.5 py-1.5 text-sm border border-slate-200 rounded-lg focus:ring-2 focus:ring-brand-blue-primary focus:outline-none"
-            />
-          </div>
-          <div>
-            <label className="block text-xxs font-bold text-slate-500 uppercase tracking-widest mb-1">
-              Opacity
-            </label>
-            <input
-              type="range"
-              min={0}
-              max={1}
-              step={0.05}
-              value={config.cardOpacity ?? 0.4}
-              onChange={(e) =>
-                updateWidget(widget.id, {
-                  config: { ...config, cardOpacity: Number(e.target.value) },
-                })
-              }
-              className="w-full"
-            />
-          </div>
-        </div>
-      </div>
+      <TypographySettings config={config} updateConfig={updateConfig} />
+      <SurfaceColorSettings
+        config={config}
+        updateConfig={updateConfig}
+        label="Card surface"
+      />
     </div>
   );
 };

--- a/components/widgets/Stations/Widget.tsx
+++ b/components/widgets/Stations/Widget.tsx
@@ -27,9 +27,10 @@ import { WidgetLayout } from '@/components/widgets/WidgetLayout';
 import { DraggableStudent } from '@/components/widgets/LunchCount/components/DraggableStudent';
 import { DroppableZone } from '@/components/widgets/LunchCount/components/DroppableZone';
 import { beginWidgetDrag, endWidgetDrag } from '@/utils/widgetDragFlag';
-import { hexToRgba } from '@/utils/styles';
+import { getFontClass, hexToRgba } from '@/utils/styles';
 import { ScaledEmptyState } from '@/components/common/ScaledEmptyState';
 import { StationCard } from './components/StationCard';
+import { studentChipClass, studentChipStyle } from './components/studentChip';
 import {
   rotateAssignments,
   shuffleStudentsIntoStations,
@@ -41,18 +42,11 @@ import {
 const UNASSIGNED_DROP_ID = 'stations:unassigned';
 const STATION_DROP_PREFIX = 'station:';
 
-const studentChipClass =
-  'bg-white border-b-2 border-slate-200 rounded-xl font-black text-slate-700 shadow-sm hover:border-brand-blue-primary hover:-translate-y-0.5 transition-all active:scale-90';
-
-const studentChipStyle: React.CSSProperties = {
-  fontSize: 'min(14px, 5cqmin)',
-  padding: 'min(6px, 1.6cqmin) min(12px, 3cqmin)',
-};
-
 export const StationsWidget: React.FC<{ widget: WidgetData }> = ({
   widget,
 }) => {
-  const { updateWidget, addToast, rosters, activeRosterId } = useDashboard();
+  const { updateWidget, addToast, rosters, activeRosterId, activeDashboard } =
+    useDashboard();
   const config = widget.config as StationsConfig;
   const stations = useMemo(() => config.stations ?? [], [config.stations]);
   const assignments = useMemo(
@@ -204,11 +198,15 @@ export const StationsWidget: React.FC<{ widget: WidgetData }> = ({
   }, [orderedStations, activeRoster, persistAssignments, addToast]);
 
   // Watch rotationTrigger from a linked Timer — bumps to Date.now() invoke rotate.
+  // Mirrors `externalTrigger` in RandomWidget.tsx: assign the latest callback
+  // to a ref during render so the effect's body always sees the freshest
+  // closure without listing the callback as a dep (which would re-run the
+  // effect every render and risk firing the rotation more than once for the
+  // same trigger value).
   const lastTriggerRef = useRef(config.rotationTrigger ?? 0);
   const handleRotateRef = useRef(handleRotate);
-  useEffect(() => {
-    handleRotateRef.current = handleRotate;
-  }, [handleRotate]);
+  // eslint-disable-next-line react-hooks/refs
+  handleRotateRef.current = handleRotate;
   useEffect(() => {
     const trigger = config.rotationTrigger ?? 0;
     if (trigger > lastTriggerRef.current) {
@@ -237,6 +235,15 @@ export const StationsWidget: React.FC<{ widget: WidgetData }> = ({
   const cardColor = config.cardColor ?? '#f8fafc';
   const cardOpacity = config.cardOpacity ?? 0.4;
 
+  // Resolve typography from widget config + active dashboard global style. The
+  // shared TypographySettings primitive writes values like 'global', 'font-sans',
+  // etc.; getFontClass() returns a Tailwind class string ready to apply.
+  const fontClassName = getFontClass(
+    config.fontFamily ?? 'global',
+    activeDashboard?.globalStyle?.fontFamily ?? 'sans'
+  );
+  const fontColor = config.fontColor;
+
   // Adapt grid columns to station count — keeps cards roomy when there are few
   // stations and stays tidy when there are many.
   const cols = Math.min(
@@ -256,7 +263,7 @@ export const StationsWidget: React.FC<{ widget: WidgetData }> = ({
         padding="p-0"
         header={
           <div
-            className="flex justify-between items-center border-b border-slate-100"
+            className={`flex justify-between items-center border-b border-slate-100 ${fontClassName}`}
             style={{
               backgroundColor: hexToRgba(cardColor, cardOpacity),
               padding: 'min(8px, 2cqmin) min(12px, 2.5cqmin)',
@@ -268,8 +275,11 @@ export const StationsWidget: React.FC<{ widget: WidgetData }> = ({
               style={{ gap: 'min(8px, 2cqmin)' }}
             >
               <h3
-                className="font-black text-slate-700 uppercase tracking-widest truncate"
-                style={{ fontSize: 'min(13px, 4.2cqmin)' }}
+                className="font-black uppercase tracking-widest truncate"
+                style={{
+                  fontSize: 'min(13px, 4.2cqmin)',
+                  color: fontColor ?? '#334155',
+                }}
               >
                 Stations
               </h3>
@@ -357,7 +367,7 @@ export const StationsWidget: React.FC<{ widget: WidgetData }> = ({
         }
         content={
           <div
-            className="flex flex-col h-full w-full overflow-hidden"
+            className={`flex flex-col h-full w-full overflow-hidden ${fontClassName}`}
             style={{
               padding: 'min(10px, 2cqmin)',
               gap: 'min(10px, 2cqmin)',
@@ -387,6 +397,8 @@ export const StationsWidget: React.FC<{ widget: WidgetData }> = ({
                     }}
                     onResetStation={() => handleResetStation(station.id)}
                     isFull={isFull}
+                    fontClassName={fontClassName}
+                    bodyTextColor={fontColor}
                   />
                 );
               })}
@@ -441,7 +453,10 @@ export const StationsWidget: React.FC<{ widget: WidgetData }> = ({
                         id={student}
                         name={student}
                         className={studentChipClass}
-                        style={studentChipStyle}
+                        style={{
+                          ...studentChipStyle,
+                          ...(fontColor ? { color: fontColor } : {}),
+                        }}
                       />
                     ))}
                   </div>

--- a/components/widgets/Stations/Widget.tsx
+++ b/components/widgets/Stations/Widget.tsx
@@ -1,0 +1,474 @@
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import {
+  DndContext,
+  DragEndEvent,
+  DragOverlay,
+  DragStartEvent,
+  MouseSensor,
+  TouchSensor,
+  defaultDropAnimationSideEffects,
+  pointerWithin,
+  useSensor,
+  useSensors,
+} from '@dnd-kit/core';
+import { snapCenterToCursor } from '@dnd-kit/modifiers';
+import { LayoutGrid, RefreshCw, RotateCcw, Shuffle, Users } from 'lucide-react';
+import { StationsConfig, WidgetData } from '@/types';
+import { useDashboard } from '@/context/useDashboard';
+import { ActiveClassChip } from '@/components/common/ActiveClassChip';
+import { Button } from '@/components/common/Button';
+import { WidgetLayout } from '@/components/widgets/WidgetLayout';
+import { DraggableStudent } from '@/components/widgets/LunchCount/components/DraggableStudent';
+import { DroppableZone } from '@/components/widgets/LunchCount/components/DroppableZone';
+import { beginWidgetDrag, endWidgetDrag } from '@/utils/widgetDragFlag';
+import { hexToRgba } from '@/utils/styles';
+import { ScaledEmptyState } from '@/components/common/ScaledEmptyState';
+import { StationCard } from './components/StationCard';
+import {
+  rotateAssignments,
+  shuffleStudentsIntoStations,
+  resetAllAssignments,
+  resetStation,
+  stationCount,
+} from './hooks/stationsActions';
+
+const UNASSIGNED_DROP_ID = 'stations:unassigned';
+const STATION_DROP_PREFIX = 'station:';
+
+const studentChipClass =
+  'bg-white border-b-2 border-slate-200 rounded-xl font-black text-slate-700 shadow-sm hover:border-brand-blue-primary hover:-translate-y-0.5 transition-all active:scale-90';
+
+const studentChipStyle: React.CSSProperties = {
+  fontSize: 'min(14px, 5cqmin)',
+  padding: 'min(6px, 1.6cqmin) min(12px, 3cqmin)',
+};
+
+export const StationsWidget: React.FC<{ widget: WidgetData }> = ({
+  widget,
+}) => {
+  const { updateWidget, addToast, rosters, activeRosterId } = useDashboard();
+  const config = widget.config as StationsConfig;
+  const stations = useMemo(() => config.stations ?? [], [config.stations]);
+  const assignments = useMemo(
+    () => config.assignments ?? {},
+    [config.assignments]
+  );
+
+  const sensors = useSensors(
+    useSensor(MouseSensor, { activationConstraint: { distance: 10 } }),
+    useSensor(TouchSensor, {
+      activationConstraint: { delay: 250, tolerance: 5 },
+    })
+  );
+
+  const [activeId, setActiveId] = useState<string | null>(null);
+
+  const orderedStations = useMemo(
+    () => [...stations].sort((a, b) => a.order - b.order),
+    [stations]
+  );
+
+  const activeRoster = useMemo((): string[] => {
+    if (config.rosterMode === 'custom') return config.customRoster ?? [];
+    const currentRoster =
+      rosters.find((r) => r.id === activeRosterId) ?? rosters[0];
+    return (
+      currentRoster?.students.map((s) =>
+        `${s.firstName} ${s.lastName}`.trim()
+      ) ?? []
+    );
+  }, [config.rosterMode, config.customRoster, rosters, activeRosterId]);
+
+  // Group students by station id (for chip lists) plus an unassigned bucket.
+  // Stale assignments (students no longer in roster) survive silently — we
+  // only render chips for roster members so missing-from-roster keys don't
+  // appear, but they remain in `assignments` until the next reset.
+  const grouped = useMemo(() => {
+    const byStation: Record<string, string[]> = {};
+    for (const station of orderedStations) byStation[station.id] = [];
+    const unassigned: string[] = [];
+    for (const name of activeRoster) {
+      const value = assignments[name];
+      if (value && byStation[value]) {
+        byStation[value].push(name);
+      } else {
+        unassigned.push(name);
+      }
+    }
+    return { byStation, unassigned };
+  }, [orderedStations, activeRoster, assignments]);
+
+  const persistAssignments = useCallback(
+    (next: Record<string, string | null>) => {
+      updateWidget(widget.id, {
+        config: { ...config, assignments: next },
+      });
+    },
+    [widget.id, config, updateWidget]
+  );
+
+  const handleDragStart = useCallback((event: DragStartEvent) => {
+    beginWidgetDrag();
+    setActiveId(event.active.id as string);
+  }, []);
+
+  const handleDragCancel = useCallback(() => {
+    endWidgetDrag();
+    setActiveId(null);
+  }, []);
+
+  const handleDragEnd = useCallback(
+    (event: DragEndEvent) => {
+      endWidgetDrag();
+      setActiveId(null);
+      const { active, over } = event;
+      if (!over) return;
+      const studentName = String(active.id);
+      const overId = String(over.id);
+
+      if (overId === UNASSIGNED_DROP_ID) {
+        const next = { ...assignments, [studentName]: null };
+        persistAssignments(next);
+        return;
+      }
+      if (overId.startsWith(STATION_DROP_PREFIX)) {
+        const stationId = overId.slice(STATION_DROP_PREFIX.length);
+        const station = orderedStations.find((s) => s.id === stationId);
+        if (!station) return;
+        // Capacity guard: refuse and toast if full (and the student isn't
+        // already there — moving within the same station is a no-op).
+        if (assignments[studentName] === stationId) return;
+        if (
+          station.maxStudents != null &&
+          stationCount(assignments, stationId) >= station.maxStudents
+        ) {
+          addToast(`${station.title || 'Station'} is full.`, 'info');
+          return;
+        }
+        const next = { ...assignments, [studentName]: stationId };
+        persistAssignments(next);
+      }
+    },
+    [assignments, orderedStations, persistAssignments, addToast]
+  );
+
+  const handleResetAll = useCallback(() => {
+    persistAssignments(resetAllAssignments(activeRoster));
+  }, [persistAssignments, activeRoster]);
+
+  const handleResetStation = useCallback(
+    (stationId: string) => {
+      persistAssignments(resetStation(assignments, stationId));
+    },
+    [persistAssignments, assignments]
+  );
+
+  const handleRotate = useCallback(() => {
+    if (orderedStations.length < 2) {
+      addToast('Add at least two stations to rotate.', 'info');
+      return;
+    }
+    const result = rotateAssignments(orderedStations, assignments);
+    persistAssignments(result.assignments);
+    if (result.stuckStudents.length > 0) {
+      addToast(
+        `${result.stuckStudents.length} student${result.stuckStudents.length === 1 ? '' : 's'} could not rotate (stations full).`,
+        'info'
+      );
+    }
+  }, [orderedStations, assignments, persistAssignments, addToast]);
+
+  const handleShuffle = useCallback(() => {
+    if (orderedStations.length === 0) {
+      addToast('Add at least one station first.', 'info');
+      return;
+    }
+    if (activeRoster.length === 0) {
+      addToast('No students in the active class.', 'info');
+      return;
+    }
+    const result = shuffleStudentsIntoStations(orderedStations, activeRoster);
+    persistAssignments(result.assignments);
+    if (result.overflowStudents.length > 0) {
+      addToast(
+        `${result.overflowStudents.length} student${result.overflowStudents.length === 1 ? '' : 's'} unassigned (over capacity).`,
+        'info'
+      );
+    }
+  }, [orderedStations, activeRoster, persistAssignments, addToast]);
+
+  // Watch rotationTrigger from a linked Timer — bumps to Date.now() invoke rotate.
+  const lastTriggerRef = useRef(config.rotationTrigger ?? 0);
+  const handleRotateRef = useRef(handleRotate);
+  useEffect(() => {
+    handleRotateRef.current = handleRotate;
+  }, [handleRotate]);
+  useEffect(() => {
+    const trigger = config.rotationTrigger ?? 0;
+    if (trigger > lastTriggerRef.current) {
+      lastTriggerRef.current = trigger;
+      handleRotateRef.current();
+    }
+  }, [config.rotationTrigger]);
+
+  const dropAnimation = {
+    sideEffects: defaultDropAnimationSideEffects({
+      styles: { active: { opacity: '0.5' } },
+    }),
+  };
+
+  // Empty state when the teacher hasn't configured any stations yet.
+  if (orderedStations.length === 0) {
+    return (
+      <ScaledEmptyState
+        icon={LayoutGrid}
+        title="No stations yet"
+        subtitle="Flip to add your first station."
+      />
+    );
+  }
+
+  const cardColor = config.cardColor ?? '#f8fafc';
+  const cardOpacity = config.cardOpacity ?? 0.4;
+
+  // Adapt grid columns to station count — keeps cards roomy when there are few
+  // stations and stays tidy when there are many.
+  const cols = Math.min(
+    4,
+    Math.max(1, Math.ceil(Math.sqrt(orderedStations.length)))
+  );
+
+  return (
+    <DndContext
+      sensors={sensors}
+      collisionDetection={pointerWithin}
+      onDragStart={handleDragStart}
+      onDragCancel={handleDragCancel}
+      onDragEnd={handleDragEnd}
+    >
+      <WidgetLayout
+        padding="p-0"
+        header={
+          <div
+            className="flex justify-between items-center border-b border-slate-100"
+            style={{
+              backgroundColor: hexToRgba(cardColor, cardOpacity),
+              padding: 'min(8px, 2cqmin) min(12px, 2.5cqmin)',
+              gap: 'min(10px, 2cqmin)',
+            }}
+          >
+            <div
+              className="flex items-center min-w-0"
+              style={{ gap: 'min(8px, 2cqmin)' }}
+            >
+              <h3
+                className="font-black text-slate-700 uppercase tracking-widest truncate"
+                style={{ fontSize: 'min(13px, 4.2cqmin)' }}
+              >
+                Stations
+              </h3>
+              {config.rosterMode !== 'custom' && rosters.length > 0 && (
+                <ActiveClassChip />
+              )}
+            </div>
+
+            <div
+              className="flex items-center shrink-0"
+              style={{ gap: 'min(6px, 1.5cqmin)' }}
+            >
+              <Button
+                onClick={handleShuffle}
+                variant="ghost"
+                size="sm"
+                className="rounded-xl bg-white border border-slate-200 text-slate-600 hover:text-brand-blue-primary"
+                style={{
+                  padding: 'min(6px, 1.5cqmin) min(10px, 2.5cqmin)',
+                  height: 'min(32px, 8cqmin)',
+                  fontSize: 'min(11px, 3.5cqmin)',
+                }}
+                title="Shuffle students into stations"
+              >
+                <Shuffle
+                  style={{
+                    width: 'min(14px, 4cqmin)',
+                    height: 'min(14px, 4cqmin)',
+                  }}
+                />
+                <span
+                  className="ml-1 font-black uppercase tracking-widest"
+                  style={{ fontSize: 'min(11px, 3.5cqmin)' }}
+                >
+                  Shuffle
+                </span>
+              </Button>
+              <Button
+                onClick={handleRotate}
+                variant="ghost"
+                size="sm"
+                className="rounded-xl bg-white border border-slate-200 text-slate-600 hover:text-brand-blue-primary"
+                style={{
+                  padding: 'min(6px, 1.5cqmin) min(10px, 2.5cqmin)',
+                  height: 'min(32px, 8cqmin)',
+                  fontSize: 'min(11px, 3.5cqmin)',
+                }}
+                title="Rotate clockwise"
+              >
+                <RefreshCw
+                  style={{
+                    width: 'min(14px, 4cqmin)',
+                    height: 'min(14px, 4cqmin)',
+                  }}
+                />
+                <span
+                  className="ml-1 font-black uppercase tracking-widest"
+                  style={{ fontSize: 'min(11px, 3.5cqmin)' }}
+                >
+                  Rotate
+                </span>
+              </Button>
+              <Button
+                onClick={handleResetAll}
+                variant="ghost"
+                size="sm"
+                className="rounded-xl bg-white border border-slate-200 text-slate-400 hover:text-brand-red-primary"
+                style={{
+                  padding: 'min(6px, 1.5cqmin)',
+                  width: 'min(32px, 8cqmin)',
+                  height: 'min(32px, 8cqmin)',
+                }}
+                title="Reset all"
+                aria-label="Reset all"
+              >
+                <RotateCcw
+                  style={{
+                    width: 'min(14px, 4cqmin)',
+                    height: 'min(14px, 4cqmin)',
+                  }}
+                />
+              </Button>
+            </div>
+          </div>
+        }
+        content={
+          <div
+            className="flex flex-col h-full w-full overflow-hidden"
+            style={{
+              padding: 'min(10px, 2cqmin)',
+              gap: 'min(10px, 2cqmin)',
+            }}
+          >
+            <div
+              className="grid flex-1"
+              style={{
+                gap: 'min(10px, 2cqmin)',
+                gridTemplateColumns: `repeat(${cols}, minmax(0, 1fr))`,
+                minHeight: 0,
+              }}
+            >
+              {orderedStations.map((station) => {
+                const members = grouped.byStation[station.id] ?? [];
+                const isFull =
+                  station.maxStudents != null &&
+                  members.length >= station.maxStudents;
+                return (
+                  <StationCard
+                    key={station.id}
+                    station={station}
+                    members={members}
+                    onUnassign={(student) => {
+                      const next = { ...assignments, [student]: null };
+                      persistAssignments(next);
+                    }}
+                    onResetStation={() => handleResetStation(station.id)}
+                    isFull={isFull}
+                  />
+                );
+              })}
+            </div>
+
+            <div className="flex flex-col" style={{ maxHeight: '40cqh' }}>
+              <DroppableZone
+                id={UNASSIGNED_DROP_ID}
+                className={`${grouped.unassigned.length > 0 ? 'flex-1' : 'flex-none'} border-2 border-dashed border-slate-200 rounded-3xl overflow-y-auto custom-scrollbar shadow-inner`}
+                style={{
+                  backgroundColor: hexToRgba(cardColor, cardOpacity),
+                  padding: 'min(10px, 2cqmin)',
+                  minHeight: 'min(56px, 10cqmin)',
+                }}
+                activeClassName="bg-slate-100 border-brand-blue-primary ring-4 ring-brand-blue-lighter/20"
+              >
+                <div
+                  className={`flex flex-col items-center ${grouped.unassigned.length > 0 ? 'h-full' : ''}`}
+                >
+                  <div
+                    className="flex items-center"
+                    style={{
+                      gap: 'min(6px, 1.5cqmin)',
+                      marginBottom:
+                        grouped.unassigned.length > 0
+                          ? 'min(8px, 2cqmin)'
+                          : '0',
+                    }}
+                  >
+                    <Users
+                      style={{
+                        width: 'min(14px, 4cqmin)',
+                        height: 'min(14px, 4cqmin)',
+                      }}
+                      className="text-slate-300"
+                    />
+                    <span
+                      className="font-black uppercase text-slate-400 tracking-widest"
+                      style={{ fontSize: 'min(11px, 4cqmin)' }}
+                    >
+                      Unassigned ({grouped.unassigned.length})
+                    </span>
+                  </div>
+
+                  <div
+                    className="flex flex-wrap justify-center w-full"
+                    style={{ gap: 'min(6px, 1.5cqmin)' }}
+                  >
+                    {grouped.unassigned.map((student) => (
+                      <DraggableStudent
+                        key={student}
+                        id={student}
+                        name={student}
+                        className={studentChipClass}
+                        style={studentChipStyle}
+                      />
+                    ))}
+                  </div>
+                </div>
+              </DroppableZone>
+            </div>
+          </div>
+        }
+      />
+
+      <DragOverlay
+        dropAnimation={dropAnimation}
+        modifiers={[snapCenterToCursor]}
+      >
+        {activeId ? (
+          <div
+            data-no-drag="true"
+            className="bg-brand-blue-primary border-b-4 border-brand-blue-dark rounded-2xl font-black text-white shadow-2xl scale-110 opacity-95 cursor-grabbing pointer-events-none"
+            style={{
+              padding: 'min(8px, 2cqmin) min(16px, 4cqmin)',
+              fontSize: 'min(14px, 6cqmin)',
+            }}
+          >
+            {activeId}
+          </div>
+        ) : null}
+      </DragOverlay>
+    </DndContext>
+  );
+};

--- a/components/widgets/Stations/components/IconOrImageInput.tsx
+++ b/components/widgets/Stations/components/IconOrImageInput.tsx
@@ -1,0 +1,296 @@
+import React, { useEffect, useRef, useState } from 'react';
+import * as Icons from 'lucide-react';
+import { Image as ImageIcon, Upload, Loader2, Trash2, X } from 'lucide-react';
+import { COMMON_INSTRUCTIONAL_ICONS } from '@/config/instructionalIcons';
+import { useStorage } from '@/hooks/useStorage';
+import { useAuth } from '@/context/useAuth';
+import { useDashboard } from '@/context/useDashboard';
+import { renderCatalystIcon } from '@/components/widgets/Catalyst/catalystHelpers';
+
+const MAX_BYTES = 5 * 1024 * 1024;
+
+interface IconOrImageInputProps {
+  iconName?: string;
+  imageUrl?: string;
+  /**
+   * Always called with the next (iconName, imageUrl) pair. Caller is responsible
+   * for persisting via updateWidget. The component asks the caller to delete the
+   * old Drive file via `onRequestDeletePreviousImage` only AFTER this resolves.
+   */
+  onChange: (next: { iconName?: string; imageUrl?: string }) => void;
+}
+
+const ICON_LIST: string[] = COMMON_INSTRUCTIONAL_ICONS;
+
+export const IconOrImageInput: React.FC<IconOrImageInputProps> = ({
+  iconName,
+  imageUrl,
+  onChange,
+}) => {
+  const [tab, setTab] = useState<'icon' | 'image'>(imageUrl ? 'image' : 'icon');
+  const [iconSearch, setIconSearch] = useState('');
+  const [uploading, setUploading] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const { user } = useAuth();
+  const { addToast } = useDashboard();
+  const { uploadSticker, deleteFile } = useStorage();
+
+  const filteredIcons = iconSearch
+    ? ICON_LIST.filter((name) =>
+        name.toLowerCase().includes(iconSearch.toLowerCase())
+      )
+    : ICON_LIST;
+
+  const handleUpload = async (file: File) => {
+    if (!user) {
+      addToast('Sign in to upload images.', 'error');
+      return;
+    }
+    if (!file.type.startsWith('image/')) {
+      addToast('Please choose an image file.', 'error');
+      return;
+    }
+    if (file.size > MAX_BYTES) {
+      addToast('Image too large. 5 MB maximum.', 'error');
+      return;
+    }
+    const previousUrl = imageUrl;
+    setUploading(true);
+    try {
+      const url = await uploadSticker(user.uid, file);
+      // Commit the new URL FIRST so a failed delete cannot orphan us with no image.
+      onChange({ iconName: undefined, imageUrl: url });
+      // Best-effort cleanup of the old image once the new one is in place.
+      if (previousUrl) {
+        try {
+          await deleteFile(previousUrl);
+        } catch (deleteErr) {
+          // Non-fatal — log and move on; teacher can clean up manually if needed.
+          console.warn(
+            '[StationsIconOrImageInput] Failed to delete previous image; the file may now be orphaned in Drive/Storage.',
+            deleteErr
+          );
+        }
+      }
+      addToast('Image uploaded.', 'success');
+    } catch (err) {
+      console.error('[StationsIconOrImageInput] Upload failed', err);
+      addToast('Failed to upload image.', 'error');
+    } finally {
+      setUploading(false);
+      if (fileInputRef.current) fileInputRef.current.value = '';
+    }
+  };
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) void handleUpload(file);
+  };
+
+  const handlePickIcon = async (name: string) => {
+    const previousImage = imageUrl;
+    onChange({ iconName: name, imageUrl: undefined });
+    if (previousImage) {
+      try {
+        await deleteFile(previousImage);
+      } catch (deleteErr) {
+        console.warn(
+          '[StationsIconOrImageInput] Failed to delete previous image when switching to icon.',
+          deleteErr
+        );
+      }
+    }
+  };
+
+  const handleClearImage = async () => {
+    const previousImage = imageUrl;
+    onChange({ iconName: undefined, imageUrl: undefined });
+    if (previousImage) {
+      try {
+        await deleteFile(previousImage);
+      } catch (deleteErr) {
+        console.warn(
+          '[StationsIconOrImageInput] Failed to delete cleared image.',
+          deleteErr
+        );
+      }
+    }
+  };
+
+  // Paste support — listens only while the inline panel is mounted to avoid
+  // global conflicts with text inputs elsewhere on the page.
+  useEffect(() => {
+    if (tab !== 'image') return;
+    const onPaste = (e: ClipboardEvent) => {
+      const target = e.target as HTMLElement | null;
+      if (!containerRef.current?.contains(target)) return;
+      const items = e.clipboardData?.items;
+      if (!items) return;
+      for (const item of Array.from(items)) {
+        if (item.type.startsWith('image/')) {
+          const file = item.getAsFile();
+          if (file) {
+            e.preventDefault();
+            void handleUpload(file);
+            break;
+          }
+        }
+      }
+    };
+    document.addEventListener('paste', onPaste);
+    return () => document.removeEventListener('paste', onPaste);
+    // handleUpload is stable enough — dependency is intentionally minimal.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [tab, imageUrl]);
+
+  return (
+    <div ref={containerRef} className="space-y-2">
+      <div className="grid grid-cols-2 gap-2">
+        <button
+          type="button"
+          onClick={() => setTab('icon')}
+          className={`flex items-center justify-center gap-1.5 py-1.5 rounded-lg text-xxs font-black uppercase tracking-widest transition-all border-2 ${
+            tab === 'icon'
+              ? 'bg-blue-600 border-blue-600 text-white shadow-sm'
+              : 'bg-white border-slate-200 text-slate-600'
+          }`}
+        >
+          <Icons.Smile size={12} />
+          Icon
+        </button>
+        <button
+          type="button"
+          onClick={() => setTab('image')}
+          className={`flex items-center justify-center gap-1.5 py-1.5 rounded-lg text-xxs font-black uppercase tracking-widest transition-all border-2 ${
+            tab === 'image'
+              ? 'bg-blue-600 border-blue-600 text-white shadow-sm'
+              : 'bg-white border-slate-200 text-slate-600'
+          }`}
+        >
+          <ImageIcon size={12} />
+          Image
+        </button>
+      </div>
+
+      {tab === 'icon' && (
+        <div className="space-y-2">
+          <input
+            type="text"
+            value={iconSearch}
+            onChange={(e) => setIconSearch(e.target.value)}
+            placeholder="Search icons..."
+            className="w-full px-2.5 py-1.5 text-xs border border-slate-200 rounded-lg focus:ring-2 focus:ring-brand-blue-primary focus:outline-none"
+          />
+          <div className="grid grid-cols-8 gap-1.5 max-h-48 overflow-y-auto custom-scrollbar p-1 border border-slate-200 rounded-lg bg-white">
+            {filteredIcons.map((name) => {
+              const IconComp = (
+                Icons as unknown as Record<string, React.ElementType>
+              )[name];
+              if (!IconComp) return null;
+              const isActive = iconName === name && !imageUrl;
+              return (
+                <button
+                  key={name}
+                  type="button"
+                  onClick={() => void handlePickIcon(name)}
+                  title={name}
+                  className={`p-1.5 rounded-md transition-all flex items-center justify-center ${
+                    isActive
+                      ? 'bg-brand-blue-primary text-white shadow-md scale-110'
+                      : 'text-slate-500 hover:bg-blue-50 hover:text-brand-blue-primary'
+                  }`}
+                >
+                  <IconComp size={14} />
+                </button>
+              );
+            })}
+            {filteredIcons.length === 0 && (
+              <div className="col-span-8 text-center text-xs text-slate-400 py-3">
+                No matching icons.
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+
+      {tab === 'image' && (
+        <div className="space-y-2">
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept="image/*"
+            className="hidden"
+            onChange={handleFileChange}
+          />
+          {imageUrl ? (
+            <div className="flex items-center gap-3 p-3 border border-slate-200 rounded-lg bg-white">
+              {renderCatalystIcon(imageUrl, 48, 'rounded-md')}
+              <div className="flex-1 min-w-0">
+                <div className="text-xs font-bold text-slate-700 truncate">
+                  Custom image
+                </div>
+                <div className="text-xxs text-slate-400 truncate">
+                  Saved to your Google Drive
+                </div>
+              </div>
+              <button
+                type="button"
+                onClick={() => fileInputRef.current?.click()}
+                disabled={uploading}
+                className="p-1.5 rounded-md text-slate-400 hover:text-brand-blue-primary hover:bg-blue-50 transition-colors"
+                title="Replace image"
+              >
+                {uploading ? (
+                  <Loader2 size={14} className="animate-spin" />
+                ) : (
+                  <Upload size={14} />
+                )}
+              </button>
+              <button
+                type="button"
+                onClick={() => void handleClearImage()}
+                disabled={uploading}
+                className="p-1.5 rounded-md text-slate-400 hover:text-brand-red-primary hover:bg-red-50 transition-colors"
+                title="Remove image"
+              >
+                <Trash2 size={14} />
+              </button>
+            </div>
+          ) : (
+            <button
+              type="button"
+              onClick={() => fileInputRef.current?.click()}
+              disabled={uploading}
+              className="w-full p-4 rounded-lg border-2 border-dashed border-slate-200 text-slate-500 hover:border-brand-blue-primary hover:bg-blue-50 transition-all flex flex-col items-center gap-2"
+            >
+              {uploading ? (
+                <Loader2 size={20} className="animate-spin" />
+              ) : (
+                <Upload size={20} />
+              )}
+              <div className="text-xs font-bold text-slate-600">
+                {uploading ? 'Uploading...' : 'Upload or paste image'}
+              </div>
+              <div className="text-xxs text-slate-400">
+                Drag, click to browse, or Cmd/Ctrl-V to paste
+              </div>
+            </button>
+          )}
+          {iconName && imageUrl == null && !uploading && (
+            <button
+              type="button"
+              onClick={() =>
+                onChange({ iconName: undefined, imageUrl: undefined })
+              }
+              className="w-full text-xxs font-bold uppercase tracking-widest text-slate-400 hover:text-brand-red-primary py-1 flex items-center justify-center gap-1.5"
+            >
+              <X size={11} />
+              Clear icon (no preview)
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/components/widgets/Stations/components/IconOrImageInput.tsx
+++ b/components/widgets/Stations/components/IconOrImageInput.tsx
@@ -30,6 +30,11 @@ export const IconOrImageInput: React.FC<IconOrImageInputProps> = ({
   const [tab, setTab] = useState<'icon' | 'image'>(imageUrl ? 'image' : 'icon');
   const [iconSearch, setIconSearch] = useState('');
   const [uploading, setUploading] = useState(false);
+  // Synchronous in-flight guard. `setUploading(true)` won't reflect in
+  // closures captured before the next render, so a button click that fires
+  // before React re-renders (or a paste event that bypasses `disabled`) can
+  // start a second upload and orphan the first. This ref short-circuits that.
+  const inFlightRef = useRef(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const { user } = useAuth();
@@ -43,6 +48,10 @@ export const IconOrImageInput: React.FC<IconOrImageInputProps> = ({
     : ICON_LIST;
 
   const handleUpload = async (file: File) => {
+    if (inFlightRef.current) {
+      addToast('An upload is already in progress.', 'info');
+      return;
+    }
     if (!user) {
       addToast('Sign in to upload images.', 'error');
       return;
@@ -56,6 +65,7 @@ export const IconOrImageInput: React.FC<IconOrImageInputProps> = ({
       return;
     }
     const previousUrl = imageUrl;
+    inFlightRef.current = true;
     setUploading(true);
     try {
       const url = await uploadSticker(user.uid, file);
@@ -78,6 +88,7 @@ export const IconOrImageInput: React.FC<IconOrImageInputProps> = ({
       console.error('[StationsIconOrImageInput] Upload failed', err);
       addToast('Failed to upload image.', 'error');
     } finally {
+      inFlightRef.current = false;
       setUploading(false);
       if (fileInputRef.current) fileInputRef.current.value = '';
     }

--- a/components/widgets/Stations/components/SavedPresetsPanel.tsx
+++ b/components/widgets/Stations/components/SavedPresetsPanel.tsx
@@ -3,6 +3,7 @@ import { Save, Download, Trash2 } from 'lucide-react';
 import { Station, SavedStationsPreset, StationsConfig } from '@/types';
 import { useAuth } from '@/context/useAuth';
 import { useDashboard } from '@/context/useDashboard';
+import { useDialog } from '@/context/useDialog';
 import { useStorage } from '@/hooks/useStorage';
 
 interface SavedPresetsPanelProps {
@@ -16,22 +17,27 @@ export const SavedPresetsPanel: React.FC<SavedPresetsPanelProps> = ({
 }) => {
   const { savedWidgetConfigs, saveWidgetConfig } = useAuth();
   const { addToast } = useDashboard();
+  const { showConfirm, showPrompt } = useDialog();
   const { deleteFile } = useStorage();
 
   const savedLibrary: SavedStationsPreset[] =
     (savedWidgetConfigs.stations as Partial<StationsConfig> | undefined)
       ?.savedLibrary ?? [];
 
-  const handleSave = () => {
+  const handleSave = async () => {
     if (stations.length === 0) {
       addToast('Add at least one station before saving.', 'info');
       return;
     }
-    const name = window.prompt('Name this station set:');
-    if (!name) return;
+    const name = await showPrompt('What should we call this station set?', {
+      title: 'Save station set',
+      placeholder: 'e.g. Wednesday lab rotation',
+      confirmLabel: 'Save',
+    });
+    if (!name?.trim()) return;
     const preset: SavedStationsPreset = {
       id: crypto.randomUUID(),
-      name,
+      name: name.trim(),
       // Snapshot stations only — assignments belong to the live widget instance.
       stations: stations.map((s) => ({ ...s })),
       createdAt: Date.now(),
@@ -39,17 +45,20 @@ export const SavedPresetsPanel: React.FC<SavedPresetsPanelProps> = ({
     saveWidgetConfig('stations', {
       savedLibrary: [...savedLibrary, preset],
     });
-    addToast(`Saved "${name}" to your station library.`, 'success');
+    addToast(`Saved "${preset.name}" to your station library.`, 'success');
   };
 
-  const handleLoad = (preset: SavedStationsPreset) => {
-    if (
-      stations.length > 0 &&
-      !window.confirm(
-        'Load this preset? The stations currently on this widget will be replaced. Student assignments will be cleared.'
-      )
-    ) {
-      return;
+  const handleLoad = async (preset: SavedStationsPreset) => {
+    if (stations.length > 0) {
+      const ok = await showConfirm(
+        'The stations currently on this widget will be replaced. Student assignments will be cleared.',
+        {
+          title: `Load "${preset.name}"?`,
+          confirmLabel: 'Load',
+          variant: 'danger',
+        }
+      );
+      if (!ok) return;
     }
     // Re-stamp ids so loading the same preset twice doesn't collide with
     // assignment keys from the previous instance.
@@ -62,30 +71,49 @@ export const SavedPresetsPanel: React.FC<SavedPresetsPanelProps> = ({
   };
 
   const handleDelete = async (preset: SavedStationsPreset) => {
-    if (
-      !window.confirm(
-        `Delete "${preset.name}"? Any uploaded images for this preset will be removed from your Drive.`
-      )
-    ) {
-      return;
+    const ok = await showConfirm(
+      'Any uploaded images for this preset will be removed from your Drive.',
+      {
+        title: `Delete "${preset.name}"?`,
+        confirmLabel: 'Delete',
+        variant: 'danger',
+      }
+    );
+    if (!ok) return;
+    // Determine which images on this preset are also referenced elsewhere
+    // (other presets) and skip deleting those — only delete URLs uniquely
+    // owned by this preset, so we don't break a sibling preset by mistake.
+    const otherPresetUrls = new Set<string>();
+    for (const p of savedLibrary) {
+      if (p.id === preset.id) continue;
+      for (const s of p.stations) {
+        if (s.imageUrl) otherPresetUrls.add(s.imageUrl);
+      }
     }
     saveWidgetConfig('stations', {
       savedLibrary: savedLibrary.filter((p) => p.id !== preset.id),
     });
-    // Destructive cleanup — best-effort. Failures are logged, not surfaced.
+    // Destructive cleanup — best-effort. Aggregate failures so the teacher
+    // sees a single toast rather than silent dev-only console warnings.
+    let failedCount = 0;
     for (const station of preset.stations) {
-      if (station.imageUrl) {
-        try {
-          await deleteFile(station.imageUrl);
-        } catch (err) {
-          console.warn(
-            '[SavedPresetsPanel] Failed to delete preset image',
-            err
-          );
-        }
+      if (!station.imageUrl) continue;
+      if (otherPresetUrls.has(station.imageUrl)) continue;
+      try {
+        await deleteFile(station.imageUrl);
+      } catch (err) {
+        failedCount++;
+        console.warn('[SavedPresetsPanel] Failed to delete preset image', err);
       }
     }
-    addToast(`Deleted "${preset.name}".`, 'info');
+    if (failedCount > 0) {
+      addToast(
+        `Deleted "${preset.name}", but ${failedCount} image${failedCount === 1 ? '' : 's'} couldn't be removed from Drive — you may want to clean up manually.`,
+        'info'
+      );
+    } else {
+      addToast(`Deleted "${preset.name}".`, 'info');
+    }
   };
 
   return (

--- a/components/widgets/Stations/components/SavedPresetsPanel.tsx
+++ b/components/widgets/Stations/components/SavedPresetsPanel.tsx
@@ -1,0 +1,159 @@
+import React from 'react';
+import { Save, Download, Trash2 } from 'lucide-react';
+import { Station, SavedStationsPreset, StationsConfig } from '@/types';
+import { useAuth } from '@/context/useAuth';
+import { useDashboard } from '@/context/useDashboard';
+import { useStorage } from '@/hooks/useStorage';
+
+interface SavedPresetsPanelProps {
+  stations: Station[];
+  onLoad: (stations: Station[]) => void;
+}
+
+export const SavedPresetsPanel: React.FC<SavedPresetsPanelProps> = ({
+  stations,
+  onLoad,
+}) => {
+  const { savedWidgetConfigs, saveWidgetConfig } = useAuth();
+  const { addToast } = useDashboard();
+  const { deleteFile } = useStorage();
+
+  const savedLibrary: SavedStationsPreset[] =
+    (savedWidgetConfigs.stations as Partial<StationsConfig> | undefined)
+      ?.savedLibrary ?? [];
+
+  const handleSave = () => {
+    if (stations.length === 0) {
+      addToast('Add at least one station before saving.', 'info');
+      return;
+    }
+    const name = window.prompt('Name this station set:');
+    if (!name) return;
+    const preset: SavedStationsPreset = {
+      id: crypto.randomUUID(),
+      name,
+      // Snapshot stations only — assignments belong to the live widget instance.
+      stations: stations.map((s) => ({ ...s })),
+      createdAt: Date.now(),
+    };
+    saveWidgetConfig('stations', {
+      savedLibrary: [...savedLibrary, preset],
+    });
+    addToast(`Saved "${name}" to your station library.`, 'success');
+  };
+
+  const handleLoad = (preset: SavedStationsPreset) => {
+    if (
+      stations.length > 0 &&
+      !window.confirm(
+        'Load this preset? The stations currently on this widget will be replaced. Student assignments will be cleared.'
+      )
+    ) {
+      return;
+    }
+    // Re-stamp ids so loading the same preset twice doesn't collide with
+    // assignment keys from the previous instance.
+    const restamped = preset.stations.map((s) => ({
+      ...s,
+      id: crypto.randomUUID(),
+    }));
+    onLoad(restamped);
+    addToast(`Loaded "${preset.name}".`, 'success');
+  };
+
+  const handleDelete = async (preset: SavedStationsPreset) => {
+    if (
+      !window.confirm(
+        `Delete "${preset.name}"? Any uploaded images for this preset will be removed from your Drive.`
+      )
+    ) {
+      return;
+    }
+    saveWidgetConfig('stations', {
+      savedLibrary: savedLibrary.filter((p) => p.id !== preset.id),
+    });
+    // Destructive cleanup — best-effort. Failures are logged, not surfaced.
+    for (const station of preset.stations) {
+      if (station.imageUrl) {
+        try {
+          await deleteFile(station.imageUrl);
+        } catch (err) {
+          console.warn(
+            '[SavedPresetsPanel] Failed to delete preset image',
+            err
+          );
+        }
+      }
+    }
+    addToast(`Deleted "${preset.name}".`, 'info');
+  };
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between">
+        <div>
+          <p className="text-xs font-black text-slate-700 uppercase tracking-widest">
+            Saved Presets
+          </p>
+          <p className="text-xxs text-slate-400">
+            Reuse a station setup later. Stations only — student assignments
+            aren&apos;t saved.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={handleSave}
+          className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-brand-blue-primary text-white text-xxs font-black uppercase tracking-widest hover:bg-brand-blue-dark transition-colors shadow-sm"
+        >
+          <Save size={12} />
+          Save Current
+        </button>
+      </div>
+
+      {savedLibrary.length === 0 ? (
+        <div className="text-center py-6 border-2 border-dashed border-slate-200 rounded-2xl bg-white">
+          <p className="text-xs text-slate-400">
+            No saved presets yet. Build a station set and click &ldquo;Save
+            Current.&rdquo;
+          </p>
+        </div>
+      ) : (
+        <div className="space-y-2">
+          {savedLibrary.map((preset) => (
+            <div
+              key={preset.id}
+              className="flex items-center gap-2 p-2.5 bg-white rounded-xl border border-slate-200 hover:border-slate-300 transition-colors"
+            >
+              <div className="flex-1 min-w-0">
+                <div className="text-sm font-black text-slate-700 truncate">
+                  {preset.name}
+                </div>
+                <div className="text-xxs text-slate-400">
+                  {preset.stations.length} station
+                  {preset.stations.length === 1 ? '' : 's'} ·{' '}
+                  {new Date(preset.createdAt).toLocaleDateString()}
+                </div>
+              </div>
+              <button
+                type="button"
+                onClick={() => handleLoad(preset)}
+                className="flex items-center gap-1 px-2.5 py-1.5 rounded-lg bg-slate-100 hover:bg-emerald-100 hover:text-emerald-700 text-slate-600 text-xxs font-bold uppercase tracking-widest transition-colors"
+              >
+                <Download size={11} />
+                Load
+              </button>
+              <button
+                type="button"
+                onClick={() => void handleDelete(preset)}
+                className="p-1.5 rounded-lg text-slate-400 hover:text-brand-red-primary hover:bg-red-50 transition-colors"
+                aria-label={`Delete preset ${preset.name}`}
+              >
+                <Trash2 size={13} />
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/components/widgets/Stations/components/StationCard.tsx
+++ b/components/widgets/Stations/components/StationCard.tsx
@@ -1,0 +1,165 @@
+import React from 'react';
+import { Station } from '@/types';
+import { DroppableZone } from '@/components/widgets/LunchCount/components/DroppableZone';
+import { DraggableStudent } from '@/components/widgets/LunchCount/components/DraggableStudent';
+import { renderCatalystIcon } from '@/components/widgets/Catalyst/catalystHelpers';
+import { LayoutGrid, RotateCcw } from 'lucide-react';
+import { hexToRgba } from '@/utils/styles';
+
+interface StationCardProps {
+  station: Station;
+  members: string[];
+  onUnassign: (student: string) => void;
+  onResetStation: () => void;
+  isFull: boolean;
+}
+
+const studentChipClass =
+  'bg-white border-b-2 border-slate-200 rounded-xl font-black text-slate-700 shadow-sm hover:border-brand-blue-primary hover:-translate-y-0.5 transition-all active:scale-90';
+
+const studentChipStyle: React.CSSProperties = {
+  fontSize: 'min(14px, 5cqmin)',
+  padding: 'min(6px, 1.6cqmin) min(12px, 3cqmin)',
+};
+
+export const StationCard: React.FC<StationCardProps> = ({
+  station,
+  members,
+  onUnassign,
+  onResetStation,
+  isFull,
+}) => {
+  const accent = station.color?.trim() ? station.color : '#10b981';
+  const tint = hexToRgba(accent, 0.08);
+  const tintHover = hexToRgba(accent, 0.16);
+  const capLabel =
+    station.maxStudents != null
+      ? `${members.length} / ${station.maxStudents}`
+      : `${members.length}`;
+  const iconSource = station.imageUrl?.trim()
+    ? station.imageUrl
+    : station.iconName?.trim()
+      ? station.iconName
+      : 'LayoutGrid';
+
+  return (
+    <DroppableZone
+      id={`station:${station.id}`}
+      className="relative rounded-2xl border-2 border-dashed flex flex-col transition-all group h-full overflow-hidden"
+      style={{
+        borderColor: accent,
+        backgroundColor: tint,
+        padding: 'min(10px, 2cqmin)',
+      }}
+      activeClassName={isFull ? '' : 'border-solid scale-[1.02]'}
+    >
+      {/* Subtle hover background that respects the accent color */}
+      <div
+        aria-hidden
+        className="absolute inset-0 opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none"
+        style={{ backgroundColor: tintHover }}
+      />
+
+      {/* Per-station reset button — small but reachable */}
+      <button
+        type="button"
+        onClick={onResetStation}
+        className="absolute top-1 right-1 rounded-full bg-white/80 hover:bg-white border border-slate-200 text-slate-400 hover:text-brand-red-primary transition-colors opacity-0 group-hover:opacity-100 focus:opacity-100"
+        style={{
+          padding: 'min(4px, 1cqmin)',
+          width: 'min(24px, 6cqmin)',
+          height: 'min(24px, 6cqmin)',
+        }}
+        aria-label={`Reset ${station.title}`}
+        title={`Reset ${station.title}`}
+      >
+        <RotateCcw
+          style={{
+            width: 'min(12px, 3.5cqmin)',
+            height: 'min(12px, 3.5cqmin)',
+          }}
+        />
+      </button>
+
+      <div
+        className="flex items-start relative z-10"
+        style={{ gap: 'min(8px, 2cqmin)' }}
+      >
+        <div
+          className="shrink-0 rounded-xl bg-white/90 border border-white shadow-sm flex items-center justify-center"
+          style={{
+            width: 'min(44px, 12cqmin)',
+            height: 'min(44px, 12cqmin)',
+          }}
+        >
+          {renderCatalystIcon(iconSource, 'min(28px, 8cqmin)', '')}
+        </div>
+        <div className="flex flex-col min-w-0 flex-1">
+          <div
+            className="font-black text-slate-900 leading-tight truncate"
+            style={{
+              fontSize: 'min(16px, 6cqmin)',
+              color: accent,
+            }}
+            title={station.title}
+          >
+            {station.title || 'Untitled'}
+          </div>
+          {station.description && (
+            <div
+              className="text-slate-500 leading-tight line-clamp-2"
+              style={{ fontSize: 'min(11px, 4cqmin)' }}
+            >
+              {station.description}
+            </div>
+          )}
+          <div
+            className="text-white rounded-full font-black w-max mt-1"
+            style={{
+              backgroundColor: accent,
+              fontSize: 'min(11px, 3.5cqmin)',
+              padding: 'min(2px, 0.5cqmin) min(8px, 2cqmin)',
+            }}
+          >
+            {capLabel}
+          </div>
+        </div>
+      </div>
+
+      <div
+        className="flex-1 flex flex-wrap content-start overflow-y-auto custom-scrollbar relative z-10"
+        style={{
+          gap: 'min(6px, 1.5cqmin)',
+          marginTop: 'min(10px, 2cqmin)',
+          paddingRight: 'min(4px, 1cqmin)',
+        }}
+      >
+        {members.length === 0 && (
+          <div
+            className="w-full h-full flex items-center justify-center text-slate-400 italic"
+            style={{ fontSize: 'min(11px, 4cqmin)' }}
+          >
+            <LayoutGrid
+              style={{
+                width: 'min(14px, 4cqmin)',
+                height: 'min(14px, 4cqmin)',
+                marginRight: 'min(6px, 1.5cqmin)',
+              }}
+            />
+            Drop students here
+          </div>
+        )}
+        {members.map((student) => (
+          <DraggableStudent
+            key={student}
+            id={student}
+            name={student}
+            onClick={() => onUnassign(student)}
+            className={studentChipClass}
+            style={studentChipStyle}
+          />
+        ))}
+      </div>
+    </DroppableZone>
+  );
+};

--- a/components/widgets/Stations/components/StationCard.tsx
+++ b/components/widgets/Stations/components/StationCard.tsx
@@ -5,6 +5,8 @@ import { DraggableStudent } from '@/components/widgets/LunchCount/components/Dra
 import { renderCatalystIcon } from '@/components/widgets/Catalyst/catalystHelpers';
 import { LayoutGrid, RotateCcw } from 'lucide-react';
 import { hexToRgba } from '@/utils/styles';
+import { studentChipClass, studentChipStyle } from './studentChip';
+import { getAccessibleAccentText } from './accentText';
 
 interface StationCardProps {
   station: Station;
@@ -12,15 +14,11 @@ interface StationCardProps {
   onUnassign: (student: string) => void;
   onResetStation: () => void;
   isFull: boolean;
+  /** Active typography class (from `getFontClass`) inherited from widget config. */
+  fontClassName?: string;
+  /** Accessible accent override is computed locally; this is text color for body copy (description). */
+  bodyTextColor?: string;
 }
-
-const studentChipClass =
-  'bg-white border-b-2 border-slate-200 rounded-xl font-black text-slate-700 shadow-sm hover:border-brand-blue-primary hover:-translate-y-0.5 transition-all active:scale-90';
-
-const studentChipStyle: React.CSSProperties = {
-  fontSize: 'min(14px, 5cqmin)',
-  padding: 'min(6px, 1.6cqmin) min(12px, 3cqmin)',
-};
 
 export const StationCard: React.FC<StationCardProps> = ({
   station,
@@ -28,8 +26,11 @@ export const StationCard: React.FC<StationCardProps> = ({
   onUnassign,
   onResetStation,
   isFull,
+  fontClassName = '',
+  bodyTextColor,
 }) => {
   const accent = station.color?.trim() ? station.color : '#10b981';
+  const accentTextColor = getAccessibleAccentText(accent);
   const tint = hexToRgba(accent, 0.08);
   const tintHover = hexToRgba(accent, 0.16);
   const capLabel =
@@ -45,7 +46,7 @@ export const StationCard: React.FC<StationCardProps> = ({
   return (
     <DroppableZone
       id={`station:${station.id}`}
-      className="relative rounded-2xl border-2 border-dashed flex flex-col transition-all group h-full overflow-hidden"
+      className={`relative rounded-2xl border-2 border-dashed flex flex-col transition-all group h-full overflow-hidden ${fontClassName}`}
       style={{
         borderColor: accent,
         backgroundColor: tint,
@@ -60,23 +61,29 @@ export const StationCard: React.FC<StationCardProps> = ({
         style={{ backgroundColor: tintHover }}
       />
 
-      {/* Per-station reset button — small but reachable */}
+      {/*
+        Per-station reset button — visible at reduced opacity at rest so
+        teachers can see it on a projected/touch display, fully opaque on
+        hover/focus for desktop polish. Larger touch target than the original
+        4cqmin variant.
+      */}
       <button
         type="button"
         onClick={onResetStation}
-        className="absolute top-1 right-1 rounded-full bg-white/80 hover:bg-white border border-slate-200 text-slate-400 hover:text-brand-red-primary transition-colors opacity-0 group-hover:opacity-100 focus:opacity-100"
+        className="absolute top-1 right-1 rounded-full bg-white/90 hover:bg-white border border-slate-200 text-slate-500 hover:text-brand-red-primary opacity-70 group-hover:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue-primary transition-all"
         style={{
-          padding: 'min(4px, 1cqmin)',
-          width: 'min(24px, 6cqmin)',
-          height: 'min(24px, 6cqmin)',
+          padding: 'min(5px, 1.2cqmin)',
+          width: 'min(28px, 7cqmin)',
+          height: 'min(28px, 7cqmin)',
         }}
-        aria-label={`Reset ${station.title}`}
-        title={`Reset ${station.title}`}
+        aria-label={`Reset students in ${station.title || 'this station'}`}
+        title={`Reset students in ${station.title || 'this station'}`}
       >
         <RotateCcw
+          aria-hidden
           style={{
-            width: 'min(12px, 3.5cqmin)',
-            height: 'min(12px, 3.5cqmin)',
+            width: 'min(14px, 3.8cqmin)',
+            height: 'min(14px, 3.8cqmin)',
           }}
         />
       </button>
@@ -96,10 +103,13 @@ export const StationCard: React.FC<StationCardProps> = ({
         </div>
         <div className="flex flex-col min-w-0 flex-1">
           <div
-            className="font-black text-slate-900 leading-tight truncate"
+            className="font-black leading-tight truncate"
             style={{
               fontSize: 'min(16px, 6cqmin)',
-              color: accent,
+              color: accentTextColor,
+              // Reserve the right-side area occupied by the absolute reset
+              // button so long titles don't render under it.
+              paddingRight: 'min(32px, 8cqmin)',
             }}
             title={station.title}
           >
@@ -107,8 +117,11 @@ export const StationCard: React.FC<StationCardProps> = ({
           </div>
           {station.description && (
             <div
-              className="text-slate-500 leading-tight line-clamp-2"
-              style={{ fontSize: 'min(11px, 4cqmin)' }}
+              className="leading-tight line-clamp-2"
+              style={{
+                fontSize: 'min(11px, 4cqmin)',
+                color: bodyTextColor ?? '#64748b',
+              }}
             >
               {station.description}
             </div>
@@ -156,7 +169,10 @@ export const StationCard: React.FC<StationCardProps> = ({
             name={student}
             onClick={() => onUnassign(student)}
             className={studentChipClass}
-            style={studentChipStyle}
+            style={{
+              ...studentChipStyle,
+              ...(bodyTextColor ? { color: bodyTextColor } : {}),
+            }}
           />
         ))}
       </div>

--- a/components/widgets/Stations/components/StationEditor.tsx
+++ b/components/widgets/Stations/components/StationEditor.tsx
@@ -1,0 +1,198 @@
+import React, { useState } from 'react';
+import { Station } from '@/types';
+import {
+  ChevronDown,
+  ChevronUp,
+  Trash2,
+  ArrowUp,
+  ArrowDown,
+} from 'lucide-react';
+import { WIDGET_PALETTE } from '@/config/colors';
+import { renderCatalystIcon } from '@/components/widgets/Catalyst/catalystHelpers';
+import { IconOrImageInput } from './IconOrImageInput';
+
+interface StationEditorProps {
+  station: Station;
+  index: number;
+  total: number;
+  onChange: (updates: Partial<Station>) => void;
+  onDelete: () => void;
+  onMoveUp: () => void;
+  onMoveDown: () => void;
+}
+
+export const StationEditor: React.FC<StationEditorProps> = ({
+  station,
+  index,
+  total,
+  onChange,
+  onDelete,
+  onMoveUp,
+  onMoveDown,
+}) => {
+  const [expanded, setExpanded] = useState(true);
+  const iconSource = station.imageUrl?.trim()
+    ? station.imageUrl
+    : station.iconName?.trim()
+      ? station.iconName
+      : 'LayoutGrid';
+
+  return (
+    <div
+      className="rounded-2xl border-2 bg-white overflow-hidden transition-shadow shadow-sm hover:shadow-md"
+      style={{ borderColor: station.color || '#e2e8f0' }}
+    >
+      <div
+        className="flex items-center gap-2 px-3 py-2"
+        style={{ backgroundColor: `${station.color || '#94a3b8'}10` }}
+      >
+        <div
+          className="shrink-0 rounded-lg bg-white border border-slate-200 flex items-center justify-center"
+          style={{ width: 36, height: 36 }}
+        >
+          {renderCatalystIcon(iconSource, 22, '')}
+        </div>
+        <div className="flex-1 min-w-0">
+          <div
+            className="text-sm font-black truncate"
+            style={{ color: station.color || '#0f172a' }}
+          >
+            {station.title || 'Untitled station'}
+          </div>
+          <div className="text-xxs font-bold text-slate-400 uppercase tracking-widest">
+            Station {index + 1} of {total}
+            {station.maxStudents != null && ` · max ${station.maxStudents}`}
+          </div>
+        </div>
+        <button
+          type="button"
+          onClick={onMoveUp}
+          disabled={index === 0}
+          className="p-1.5 rounded-md text-slate-400 enabled:hover:text-slate-700 enabled:hover:bg-slate-100 disabled:opacity-30 transition-colors"
+          aria-label="Move up"
+        >
+          <ArrowUp size={14} />
+        </button>
+        <button
+          type="button"
+          onClick={onMoveDown}
+          disabled={index === total - 1}
+          className="p-1.5 rounded-md text-slate-400 enabled:hover:text-slate-700 enabled:hover:bg-slate-100 disabled:opacity-30 transition-colors"
+          aria-label="Move down"
+        >
+          <ArrowDown size={14} />
+        </button>
+        <button
+          type="button"
+          onClick={() => setExpanded((v) => !v)}
+          className="p-1.5 rounded-md text-slate-400 hover:text-slate-700 hover:bg-slate-100 transition-colors"
+          aria-label={expanded ? 'Collapse' : 'Expand'}
+        >
+          {expanded ? <ChevronUp size={14} /> : <ChevronDown size={14} />}
+        </button>
+        <button
+          type="button"
+          onClick={onDelete}
+          className="p-1.5 rounded-md text-slate-400 hover:text-brand-red-primary hover:bg-red-50 transition-colors"
+          aria-label="Delete station"
+        >
+          <Trash2 size={14} />
+        </button>
+      </div>
+
+      {expanded && (
+        <div className="p-3 space-y-3 border-t border-slate-100">
+          <div>
+            <label className="block text-xxs font-bold text-slate-500 uppercase tracking-widest mb-1">
+              Title
+            </label>
+            <input
+              type="text"
+              value={station.title}
+              onChange={(e) => onChange({ title: e.target.value })}
+              placeholder="e.g. Reading Corner"
+              className="w-full px-2.5 py-1.5 text-sm border border-slate-200 rounded-lg focus:ring-2 focus:ring-brand-blue-primary focus:outline-none"
+            />
+          </div>
+
+          <div>
+            <label className="block text-xxs font-bold text-slate-500 uppercase tracking-widest mb-1">
+              Description (optional)
+            </label>
+            <input
+              type="text"
+              value={station.description ?? ''}
+              onChange={(e) =>
+                onChange({ description: e.target.value || undefined })
+              }
+              placeholder="Short instruction for students"
+              className="w-full px-2.5 py-1.5 text-sm border border-slate-200 rounded-lg focus:ring-2 focus:ring-brand-blue-primary focus:outline-none"
+            />
+          </div>
+
+          <div className="grid grid-cols-2 gap-3">
+            <div>
+              <label className="block text-xxs font-bold text-slate-500 uppercase tracking-widest mb-1">
+                Max students
+              </label>
+              <input
+                type="number"
+                min={1}
+                value={station.maxStudents ?? ''}
+                onChange={(e) => {
+                  const v = e.target.value;
+                  if (v === '') return onChange({ maxStudents: undefined });
+                  const parsed = Math.max(1, Number(v));
+                  if (Number.isFinite(parsed))
+                    onChange({ maxStudents: parsed });
+                }}
+                placeholder="No limit"
+                className="w-full px-2.5 py-1.5 text-sm border border-slate-200 rounded-lg focus:ring-2 focus:ring-brand-blue-primary focus:outline-none"
+              />
+            </div>
+
+            <div>
+              <label className="block text-xxs font-bold text-slate-500 uppercase tracking-widest mb-1">
+                Color
+              </label>
+              <div className="flex items-center gap-1.5 flex-wrap">
+                {WIDGET_PALETTE.map((c) => (
+                  <button
+                    key={c}
+                    type="button"
+                    onClick={() => onChange({ color: c })}
+                    className={`w-6 h-6 rounded-full border-2 transition-all ${
+                      station.color === c
+                        ? 'border-slate-800 scale-110 shadow-md'
+                        : 'border-transparent hover:scale-110'
+                    }`}
+                    style={{ backgroundColor: c }}
+                    aria-label={`Color ${c}`}
+                  />
+                ))}
+                <input
+                  type="color"
+                  value={station.color}
+                  onChange={(e) => onChange({ color: e.target.value })}
+                  className="w-6 h-6 rounded border border-slate-200 cursor-pointer"
+                  aria-label="Custom color"
+                />
+              </div>
+            </div>
+          </div>
+
+          <div>
+            <label className="block text-xxs font-bold text-slate-500 uppercase tracking-widest mb-1">
+              Icon or image
+            </label>
+            <IconOrImageInput
+              iconName={station.iconName}
+              imageUrl={station.imageUrl}
+              onChange={(next) => onChange(next)}
+            />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/components/widgets/Stations/components/accentText.ts
+++ b/components/widgets/Stations/components/accentText.ts
@@ -1,0 +1,117 @@
+/**
+ * Returns a text-safe variant of `accent` so titles colored with the station's
+ * accent stay legible over a near-white background. Light accents (yellow,
+ * lime, sky, etc.) get pushed darker via HSL until the relative luminance
+ * gives ≥ 4.5:1 contrast against white (the WCAG AA threshold for body text).
+ *
+ * Returns the original color when its contrast against white already passes.
+ */
+
+const TARGET_CONTRAST = 4.5;
+const WHITE_LUMINANCE = 1;
+
+const parseHex = (hex: string): [number, number, number] | null => {
+  const m = /^#?([0-9a-f]{3}|[0-9a-f]{6})$/i.exec((hex ?? '').trim());
+  if (!m) return null;
+  let body = m[1];
+  if (body.length === 3) {
+    body = body[0] + body[0] + body[1] + body[1] + body[2] + body[2];
+  }
+  return [
+    parseInt(body.slice(0, 2), 16) / 255,
+    parseInt(body.slice(2, 4), 16) / 255,
+    parseInt(body.slice(4, 6), 16) / 255,
+  ];
+};
+
+const channelLuminance = (v: number): number =>
+  v <= 0.03928 ? v / 12.92 : Math.pow((v + 0.055) / 1.055, 2.4);
+
+const relativeLuminance = (rgb: [number, number, number]): number => {
+  const [r, g, b] = rgb.map(channelLuminance) as [number, number, number];
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+};
+
+const contrastVsWhite = (rgb: [number, number, number]): number => {
+  const lum = relativeLuminance(rgb);
+  return (WHITE_LUMINANCE + 0.05) / (lum + 0.05);
+};
+
+const rgbToHsl = (
+  r: number,
+  g: number,
+  b: number
+): [number, number, number] => {
+  const max = Math.max(r, g, b);
+  const min = Math.min(r, g, b);
+  const l = (max + min) / 2;
+  if (max === min) return [0, 0, l];
+  const d = max - min;
+  const s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
+  let h = 0;
+  switch (max) {
+    case r:
+      h = (g - b) / d + (g < b ? 6 : 0);
+      break;
+    case g:
+      h = (b - r) / d + 2;
+      break;
+    case b:
+      h = (r - g) / d + 4;
+      break;
+  }
+  h /= 6;
+  return [h, s, l];
+};
+
+const hslToRgb = (
+  h: number,
+  s: number,
+  l: number
+): [number, number, number] => {
+  if (s === 0) return [l, l, l];
+  const q = l < 0.5 ? l * (1 + s) : l + s - l * s;
+  const p = 2 * l - q;
+  const hue2rgb = (t: number): number => {
+    if (t < 0) t += 1;
+    if (t > 1) t -= 1;
+    if (t < 1 / 6) return p + (q - p) * 6 * t;
+    if (t < 1 / 2) return q;
+    if (t < 2 / 3) return p + (q - p) * (2 / 3 - t) * 6;
+    return p;
+  };
+  return [hue2rgb(h + 1 / 3), hue2rgb(h), hue2rgb(h - 1 / 3)];
+};
+
+const toHex = (rgb: [number, number, number]): string => {
+  const [r, g, b] = rgb;
+  const channel = (v: number): string =>
+    Math.round(Math.max(0, Math.min(1, v)) * 255)
+      .toString(16)
+      .padStart(2, '0');
+  return `#${channel(r)}${channel(g)}${channel(b)}`;
+};
+
+export function getAccessibleAccentText(accent: string): string {
+  const rgb = parseHex(accent);
+  if (!rgb) return accent;
+
+  // Already passes the contrast check? Preserve the original color.
+  if (contrastVsWhite(rgb) >= TARGET_CONTRAST) {
+    // Always re-emit normalized #rrggbb so callers don't see a mix of formats.
+    return toHex(rgb);
+  }
+
+  const [h, s] = rgbToHsl(...rgb);
+  // Step lightness down until contrast clears the bar (or we hit black).
+  let l = 0.5;
+  for (let i = 0; i < 50; i++) {
+    const candidate = hslToRgb(h, s, l);
+    if (contrastVsWhite(candidate) >= TARGET_CONTRAST) {
+      return toHex(candidate);
+    }
+    l -= 0.02;
+    if (l <= 0) break;
+  }
+  return '#000000';
+}

--- a/components/widgets/Stations/components/studentChip.ts
+++ b/components/widgets/Stations/components/studentChip.ts
@@ -1,0 +1,17 @@
+import React from 'react';
+
+/**
+ * Shared visual style for the draggable student name chip. Defined in one
+ * place so the unassigned bucket and the per-station chip lists stay in sync.
+ *
+ * Caller is responsible for layering text-color/font overrides via inline
+ * style — those depend on the active typography settings and live in the
+ * widget's render path.
+ */
+export const studentChipClass =
+  'bg-white border-b-2 border-slate-200 rounded-xl font-black text-slate-700 shadow-sm hover:border-brand-blue-primary hover:-translate-y-0.5 transition-all active:scale-90';
+
+export const studentChipStyle: React.CSSProperties = {
+  fontSize: 'min(14px, 5cqmin)',
+  padding: 'min(6px, 1.6cqmin) min(12px, 3cqmin)',
+};

--- a/components/widgets/Stations/hooks/stationsActions.ts
+++ b/components/widgets/Stations/hooks/stationsActions.ts
@@ -1,0 +1,180 @@
+import { Station } from '@/types';
+
+type Assignments = Record<string, string | null>;
+
+export interface RotateResult {
+  assignments: Assignments;
+  /** Students who could not be moved because every later station was full. */
+  stuckStudents: string[];
+}
+
+export interface ShuffleResult {
+  assignments: Assignments;
+  /** Students who didn't fit because total cap < roster size. */
+  overflowStudents: string[];
+}
+
+const sortByOrder = (stations: Station[]): Station[] =>
+  [...stations].sort((a, b) => a.order - b.order);
+
+const stationCount = (assignments: Assignments, stationId: string): number => {
+  let count = 0;
+  for (const value of Object.values(assignments)) {
+    if (value === stationId) count++;
+  }
+  return count;
+};
+
+const findFirstUnderCapStation = (
+  ordered: Station[],
+  startIdx: number,
+  counts: Map<string, number>
+): Station | null => {
+  const n = ordered.length;
+  for (let step = 0; step < n; step++) {
+    const candidate = ordered[(startIdx + step) % n];
+    const limit = candidate.maxStudents;
+    if (limit == null || (counts.get(candidate.id) ?? 0) < limit) {
+      return candidate;
+    }
+  }
+  return null;
+};
+
+/**
+ * Rotate clockwise: every student in station i moves to station (i+1)%N.
+ * If the next station is full, push to the next under-capacity station; if
+ * every station is full the student stays put and is reported as stuck.
+ */
+export function rotateAssignments(
+  stations: Station[],
+  assignments: Assignments
+): RotateResult {
+  const ordered = sortByOrder(stations);
+  if (ordered.length === 0) {
+    return { assignments, stuckStudents: [] };
+  }
+
+  const indexById = new Map(ordered.map((s, i) => [s.id, i]));
+  const next: Assignments = {};
+  // Carry over any unassigned students unchanged.
+  for (const [name, value] of Object.entries(assignments)) {
+    if (value == null) next[name] = value;
+  }
+
+  // Bucket students by their CURRENT station, preserve order they had so the
+  // rotate result is stable for tests and predictable for teachers.
+  const buckets = new Map<string, string[]>();
+  for (const station of ordered) buckets.set(station.id, []);
+  for (const [name, value] of Object.entries(assignments)) {
+    if (value) {
+      const bucket = buckets.get(value);
+      if (bucket) bucket.push(name);
+    }
+  }
+
+  const counts = new Map<string, number>(ordered.map((s) => [s.id, 0]));
+  const stuck: string[] = [];
+
+  for (const station of ordered) {
+    const fromIdx = indexById.get(station.id) ?? 0;
+    const targetIdx = (fromIdx + 1) % ordered.length;
+    const students = buckets.get(station.id) ?? [];
+    for (const name of students) {
+      const target = findFirstUnderCapStation(ordered, targetIdx, counts);
+      if (target) {
+        next[name] = target.id;
+        counts.set(target.id, (counts.get(target.id) ?? 0) + 1);
+      } else {
+        // Every station full — keep them where they were.
+        next[name] = station.id;
+        counts.set(station.id, (counts.get(station.id) ?? 0) + 1);
+        stuck.push(name);
+      }
+    }
+  }
+
+  return { assignments: next, stuckStudents: stuck };
+}
+
+/**
+ * Fisher-Yates shuffle that does NOT mutate the input array.
+ * `rng` is injectable so tests can pass a deterministic source.
+ */
+export function shuffleArray<T>(
+  input: T[],
+  rng: () => number = Math.random
+): T[] {
+  const arr = [...input];
+  for (let i = arr.length - 1; i > 0; i--) {
+    const j = Math.floor(rng() * (i + 1));
+    [arr[i], arr[j]] = [arr[j], arr[i]];
+  }
+  return arr;
+}
+
+/**
+ * Distribute `roster` evenly across `stations`, respecting `maxStudents` caps.
+ * Round-robin order so caps fill bottom-up; overflow stays unassigned.
+ */
+export function shuffleStudentsIntoStations(
+  stations: Station[],
+  roster: string[],
+  rng: () => number = Math.random
+): ShuffleResult {
+  const ordered = sortByOrder(stations);
+  if (ordered.length === 0) {
+    const next: Assignments = {};
+    for (const name of roster) next[name] = null;
+    return { assignments: next, overflowStudents: roster.slice() };
+  }
+
+  const shuffled = shuffleArray(roster, rng);
+  const next: Assignments = {};
+  const counts = new Map<string, number>(ordered.map((s) => [s.id, 0]));
+  const overflow: string[] = [];
+
+  let cursor = 0;
+  for (const name of shuffled) {
+    let placed = false;
+    for (let attempt = 0; attempt < ordered.length; attempt++) {
+      const candidate = ordered[(cursor + attempt) % ordered.length];
+      const limit = candidate.maxStudents;
+      const used = counts.get(candidate.id) ?? 0;
+      if (limit == null || used < limit) {
+        next[name] = candidate.id;
+        counts.set(candidate.id, used + 1);
+        cursor = (cursor + attempt + 1) % ordered.length;
+        placed = true;
+        break;
+      }
+    }
+    if (!placed) {
+      next[name] = null;
+      overflow.push(name);
+    }
+  }
+
+  return { assignments: next, overflowStudents: overflow };
+}
+
+/** Reset every student back to unassigned. */
+export function resetAllAssignments(roster: string[]): Assignments {
+  const next: Assignments = {};
+  for (const name of roster) next[name] = null;
+  return next;
+}
+
+/** Clear only students currently in `stationId`. Other assignments untouched. */
+export function resetStation(
+  assignments: Assignments,
+  stationId: string
+): Assignments {
+  const next: Assignments = {};
+  for (const [name, value] of Object.entries(assignments)) {
+    next[name] = value === stationId ? null : value;
+  }
+  return next;
+}
+
+export { stationCount };

--- a/components/widgets/Stations/hooks/stationsActions.ts
+++ b/components/widgets/Stations/hooks/stationsActions.ts
@@ -57,9 +57,17 @@ export function rotateAssignments(
 
   const indexById = new Map(ordered.map((s, i) => [s.id, i]));
   const next: Assignments = {};
-  // Carry over any unassigned students unchanged.
+  // Carry over unassigned students unchanged. Students whose previous station
+  // no longer exists (cap removed, station deleted between save & rotate)
+  // also need to be carried — silently dropping them would lose roster
+  // membership. Treat those as unassigned, matching the front-face semantic
+  // where unknown station ids fall through to the unassigned bucket.
   for (const [name, value] of Object.entries(assignments)) {
-    if (value == null) next[name] = value;
+    if (value == null) {
+      next[name] = null;
+    } else if (!indexById.has(value)) {
+      next[name] = null;
+    }
   }
 
   // Bucket students by their CURRENT station, preserve order they had so the

--- a/components/widgets/Stations/index.ts
+++ b/components/widgets/Stations/index.ts
@@ -1,0 +1,2 @@
+export { StationsWidget } from './Widget';
+export { StationsSettings, StationsAppearanceSettings } from './Settings';

--- a/components/widgets/Stations/nexus.ts
+++ b/components/widgets/Stations/nexus.ts
@@ -1,0 +1,27 @@
+import { RandomGroup, Station } from '@/types';
+import { WIDGET_PALETTE } from '@/config/colors';
+
+/**
+ * Convert Randomizer groups into a Stations widget config payload. Used by
+ * the "Send Groups → Stations" button on the Randomizer settings panel; lives
+ * in its own file so re-exporting it from Settings.tsx doesn't trip the
+ * `react-refresh/only-export-components` lint rule.
+ */
+export const buildStationsFromRandomGroups = (
+  groups: RandomGroup[]
+): { stations: Station[]; assignments: Record<string, string | null> } => {
+  const stations: Station[] = groups.map((group, i) => ({
+    id: crypto.randomUUID(),
+    title: group.id?.trim() ? group.id : `Group ${i + 1}`,
+    color: WIDGET_PALETTE[i % WIDGET_PALETTE.length],
+    order: i,
+  }));
+  const assignments: Record<string, string | null> = {};
+  groups.forEach((group, i) => {
+    const station = stations[i];
+    for (const name of group.names) {
+      assignments[name] = station.id;
+    }
+  });
+  return { stations, assignments };
+};

--- a/components/widgets/Stations/nexus.ts
+++ b/components/widgets/Stations/nexus.ts
@@ -10,16 +10,21 @@ import { WIDGET_PALETTE } from '@/config/colors';
 export const buildStationsFromRandomGroups = (
   groups: RandomGroup[]
 ): { stations: Station[]; assignments: Record<string, string | null> } => {
-  const stations: Station[] = groups.map((group, i) => ({
-    id: crypto.randomUUID(),
-    title: group.id?.trim() ? group.id : `Group ${i + 1}`,
-    color: WIDGET_PALETTE[i % WIDGET_PALETTE.length],
-    order: i,
-  }));
+  const stations: Station[] = groups.map((group, i) => {
+    const trimmed = group.id?.trim();
+    return {
+      id: crypto.randomUUID(),
+      title: trimmed && trimmed.length > 0 ? trimmed : `Group ${i + 1}`,
+      color: WIDGET_PALETTE[i % WIDGET_PALETTE.length],
+      order: i,
+    };
+  });
   const assignments: Record<string, string | null> = {};
   groups.forEach((group, i) => {
     const station = stations[i];
     for (const name of group.names) {
+      // Last write wins for duplicate names across groups — that's the only
+      // sane choice given assignments are keyed by display name.
       assignments[name] = station.id;
     }
   });

--- a/components/widgets/TimeTool/Settings.tsx
+++ b/components/widgets/TimeTool/Settings.tsx
@@ -28,6 +28,7 @@ export const TimeToolSettings: React.FC<{ widget: WidgetData }> = ({
     timerEndTrafficColor,
     timerEndTriggerRandom,
     timerEndTriggerNextUp,
+    timerEndTriggerStationsRotate,
   } = config;
 
   const hasExpectations = activeDashboard?.widgets.some(
@@ -43,6 +44,10 @@ export const TimeToolSettings: React.FC<{ widget: WidgetData }> = ({
   );
 
   const hasNextUp = activeDashboard?.widgets.some((w) => w.type === 'nextUp');
+
+  const hasStations = activeDashboard?.widgets.some(
+    (w) => w.type === 'stations'
+  );
 
   return (
     <div className="space-y-6 p-1">
@@ -308,6 +313,45 @@ export const TimeToolSettings: React.FC<{ widget: WidgetData }> = ({
                 onChange={(checked) =>
                   updateWidget(widget.id, {
                     config: { ...config, timerEndTriggerRandom: checked },
+                  })
+                }
+                size="md"
+              />
+            </div>
+          )}
+        </div>
+
+        {/* Nexus Connection: Stations Auto-Rotate */}
+        <div className="pt-2 border-t border-slate-100 mt-4">
+          <p className="text-xxs font-bold text-slate-500 uppercase tracking-tight mb-2">
+            Auto-rotate stations:
+          </p>
+          {!hasStations ? (
+            <div className="text-xs text-brand-blue-primary bg-brand-blue-lighter/20 p-3 rounded-xl border border-brand-blue-lighter/30 flex items-start gap-2">
+              <span className="text-lg mt-px">&#128161;</span>
+              <p className="font-medium leading-snug">
+                Add a Stations widget to rotate students automatically when this
+                timer ends.
+              </p>
+            </div>
+          ) : (
+            <div className="flex items-center justify-between p-3 bg-emerald-50 border border-emerald-100 rounded-2xl shadow-sm">
+              <div className="space-y-0.5">
+                <p className="text-xs font-bold text-emerald-900">
+                  Rotate stations clockwise
+                </p>
+                <p className="text-xxxs text-emerald-600 uppercase">
+                  Move every student one station when timer ends
+                </p>
+              </div>
+              <Toggle
+                checked={!!timerEndTriggerStationsRotate}
+                onChange={(checked) =>
+                  updateWidget(widget.id, {
+                    config: {
+                      ...config,
+                      timerEndTriggerStationsRotate: checked,
+                    },
                   })
                 }
                 size="md"

--- a/components/widgets/TimeTool/useTimeTool.ts
+++ b/components/widgets/TimeTool/useTimeTool.ts
@@ -5,6 +5,7 @@ import {
   ExpectationsConfig,
   WidgetConfig,
   TrafficConfig,
+  StationsConfig,
 } from '@/types';
 import { useDashboard } from '@/context/useDashboard';
 import { playTimerAlert, resumeAudio } from '@/utils/timeToolAudio';
@@ -184,6 +185,25 @@ export const useTimeTool = (widget: WidgetData) => {
             }
           }
 
+          // Auto-rotate the first Stations widget
+          if (
+            config.timerEndTriggerStationsRotate &&
+            activeDashboard &&
+            config.duration > 0
+          ) {
+            const stationsWidget = activeDashboard.widgets.find(
+              (w) => w.type === 'stations'
+            );
+            if (stationsWidget) {
+              updateWidget(stationsWidget.id, {
+                config: {
+                  ...(stationsWidget.config as StationsConfig),
+                  rotationTrigger: Date.now(),
+                } as WidgetConfig,
+              });
+            }
+          }
+
           return;
         }
       } else {
@@ -206,6 +226,7 @@ export const useTimeTool = (widget: WidgetData) => {
     config.timerEndTrafficColor,
     config.timerEndTriggerRandom,
     config.timerEndTriggerNextUp,
+    config.timerEndTriggerStationsRotate,
     config.duration,
     activeDashboard,
     updateWidget,

--- a/components/widgets/WidgetRegistry.ts
+++ b/components/widgets/WidgetRegistry.ts
@@ -211,6 +211,7 @@ export const WIDGET_COMPONENTS: Partial<Record<WidgetType, WidgetComponent>> = {
     () => import('./NeedDoPutThen/Widget'),
     'NeedDoPutThenWidget'
   ),
+  stations: lazyNamed(() => import('./Stations/Widget'), 'StationsWidget'),
 };
 
 export const WIDGET_SETTINGS_COMPONENTS: Partial<
@@ -361,6 +362,7 @@ export const WIDGET_SETTINGS_COMPONENTS: Partial<
     () => import('./NeedDoPutThen/Settings'),
     'NeedDoPutThenSettings'
   ),
+  stations: lazyNamed(() => import('./Stations/Settings'), 'StationsSettings'),
 };
 
 export const WIDGET_APPEARANCE_COMPONENTS: Partial<
@@ -464,6 +466,10 @@ export const WIDGET_APPEARANCE_COMPONENTS: Partial<
   'need-do-put-then': lazyNamed(
     () => import('./NeedDoPutThen/Settings'),
     'NeedDoPutThenAppearanceSettings'
+  ),
+  stations: lazyNamed(
+    () => import('./Stations/Settings'),
+    'StationsAppearanceSettings'
   ),
 };
 
@@ -903,6 +909,13 @@ export const WIDGET_SCALING_CONFIG: Record<WidgetType, ScalingConfig> = {
   'need-do-put-then': {
     baseWidth: 340,
     baseHeight: 320,
+    canSpread: true,
+    skipScaling: true,
+    padding: 0,
+  },
+  stations: {
+    baseWidth: 600,
+    baseHeight: 420,
     canSpread: true,
     skipScaling: true,
     padding: 0,

--- a/components/widgets/random/RandomSettings.tsx
+++ b/components/widgets/random/RandomSettings.tsx
@@ -42,6 +42,7 @@ export const RandomSettings: React.FC<{ widget: WidgetData }> = ({
     }
     const result = (widget.config as RandomConfig).lastResult;
     let groups: RandomGroup[] = [];
+    let isStaleSinglePick = false;
     if (Array.isArray(result) && result.length > 0) {
       const first = result[0];
       if (
@@ -49,13 +50,27 @@ export const RandomSettings: React.FC<{ widget: WidgetData }> = ({
         first !== null &&
         'names' in (first as object)
       ) {
+        // Group-mode result: RandomGroup[]
         groups = result as RandomGroup[];
       } else if (Array.isArray(first)) {
+        // Legacy group-mode result: string[][]
         groups = (result as unknown as string[][]).map((names, i) => ({
           id: `Group ${i + 1}`,
           names: names ?? [],
         }));
+      } else if (typeof first === 'string') {
+        // Single-pick result that survived a mode switch — flat string list
+        // is meaningless as "groups". Surface a clearer message rather than
+        // the generic "generate groups first" hint.
+        isStaleSinglePick = true;
       }
+    }
+    if (isStaleSinglePick) {
+      addToast(
+        'Switch to Groups mode and click Pick before sending — the last result was a single-name pick.',
+        'info'
+      );
+      return;
     }
     if (groups.length === 0) {
       addToast(

--- a/components/widgets/random/RandomSettings.tsx
+++ b/components/widgets/random/RandomSettings.tsx
@@ -1,7 +1,8 @@
 import React, { useState, useRef, useEffect } from 'react';
 import { useDashboard } from '@/context/useDashboard';
 import { useDialog } from '@/context/useDialog';
-import { WidgetData, RandomConfig } from '@/types';
+import { WidgetData, RandomConfig, RandomGroup, StationsConfig } from '@/types';
+import { buildStationsFromRandomGroups } from '@/components/widgets/Stations/nexus';
 import { RosterModeControl } from '@/components/common/RosterModeControl';
 import { Toggle } from '@/components/common/Toggle';
 import { Card } from '@/components/common/Card';
@@ -18,6 +19,7 @@ import {
   VolumeX,
   Clock,
   RefreshCw,
+  Send,
 } from 'lucide-react';
 import { Button } from '@/components/common/Button';
 import { SettingsLabel } from '@/components/common/SettingsLabel';
@@ -25,9 +27,66 @@ import { SettingsLabel } from '@/components/common/SettingsLabel';
 export const RandomSettings: React.FC<{ widget: WidgetData }> = ({
   widget,
 }) => {
-  const { updateWidget, activeDashboard, rosters, activeRosterId } =
+  const { updateWidget, activeDashboard, rosters, activeRosterId, addToast } =
     useDashboard();
   const { showConfirm } = useDialog();
+
+  const stationsWidget = activeDashboard?.widgets.find(
+    (w) => w.type === 'stations'
+  );
+
+  const handleSendGroupsToStations = async () => {
+    if (!stationsWidget) {
+      addToast('Add a Stations widget to the board first.', 'info');
+      return;
+    }
+    const result = (widget.config as RandomConfig).lastResult;
+    let groups: RandomGroup[] = [];
+    if (Array.isArray(result) && result.length > 0) {
+      const first = result[0];
+      if (
+        typeof first === 'object' &&
+        first !== null &&
+        'names' in (first as object)
+      ) {
+        groups = result as RandomGroup[];
+      } else if (Array.isArray(first)) {
+        groups = (result as unknown as string[][]).map((names, i) => ({
+          id: `Group ${i + 1}`,
+          names: names ?? [],
+        }));
+      }
+    }
+    if (groups.length === 0) {
+      addToast(
+        'Generate groups first (set mode to Groups, then Pick) and try again.',
+        'info'
+      );
+      return;
+    }
+    const existingStations =
+      (stationsWidget.config as StationsConfig).stations ?? [];
+    if (existingStations.length > 0) {
+      const ok = await showConfirm(
+        `The Stations widget already has ${existingStations.length} station${existingStations.length === 1 ? '' : 's'}. Sending will replace them.`,
+        {
+          title: 'Replace existing stations?',
+          confirmLabel: 'Replace',
+          variant: 'danger',
+        }
+      );
+      if (!ok) return;
+    }
+    const { stations, assignments } = buildStationsFromRandomGroups(groups);
+    updateWidget(stationsWidget.id, {
+      config: {
+        ...(stationsWidget.config as StationsConfig),
+        stations,
+        assignments,
+      },
+    });
+    addToast(`Sent ${groups.length} groups to Stations.`, 'success');
+  };
 
   const config = widget.config as RandomConfig;
 
@@ -220,6 +279,27 @@ export const RandomSettings: React.FC<{ widget: WidgetData }> = ({
             ⚠️ Timer widget required for automation.
           </div>
         )}
+
+      {/* Nexus Connection: Send Groups → Stations */}
+      {mode === 'group' && (
+        <div className="space-y-1">
+          <button
+            type="button"
+            onClick={() => void handleSendGroupsToStations()}
+            disabled={!stationsWidget}
+            className="w-full flex items-center justify-center gap-2 px-3 py-2 rounded-xl bg-emerald-50 border border-emerald-100 text-emerald-700 font-black uppercase tracking-widest text-xxs hover:bg-emerald-100 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            <Send size={13} />
+            Send Groups to Stations
+          </button>
+          {!stationsWidget && (
+            <div className="text-xxxs text-slate-500 leading-snug">
+              Add a Stations widget to send your generated groups there as
+              station assignments.
+            </div>
+          )}
+        </div>
+      )}
 
       <div>
         <label className="text-xxs  text-slate-400 uppercase tracking-widest mb-3 block">

--- a/config/tools.ts
+++ b/config/tools.ts
@@ -287,4 +287,10 @@ export const TOOLS: ToolMetadata[] = [
     label: 'Need / Do / Put / Then',
     color: 'bg-cyan-600',
   },
+  {
+    type: 'stations',
+    icon: LayoutGrid,
+    label: 'Stations',
+    color: 'bg-emerald-500',
+  },
 ];

--- a/config/widgetDefaults.ts
+++ b/config/widgetDefaults.ts
@@ -1,5 +1,6 @@
 import {
   SoundboardConfig,
+  StationsConfig,
   WidgetData,
   WidgetType,
   SpecialistScheduleConfig,
@@ -511,5 +512,14 @@ export const WIDGET_DEFAULTS: Record<WidgetType, Partial<WidgetData>> = {
       putItems: DEFAULT_PUT_ITEMS,
       thenItems: DEFAULT_THEN_ITEMS,
     } satisfies NeedDoPutThenConfig,
+  },
+  stations: {
+    w: 600,
+    h: 420,
+    config: {
+      stations: [],
+      assignments: {},
+      rosterMode: 'class',
+    } satisfies StationsConfig,
   },
 };

--- a/config/widgetGradeLevels.ts
+++ b/config/widgetGradeLevels.ts
@@ -107,6 +107,7 @@ export const WIDGET_GRADE_LEVELS: Record<
   'blooms-taxonomy': ALL_GRADE_LEVELS,
   'blooms-detail': ALL_GRADE_LEVELS,
   'need-do-put-then': ALL_GRADE_LEVELS,
+  stations: ALL_GRADE_LEVELS,
 };
 
 /**

--- a/tests/components/widgets/Stations/accentText.test.ts
+++ b/tests/components/widgets/Stations/accentText.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { getAccessibleAccentText } from '@/components/widgets/Stations/components/accentText';
+
+const luminance = (hex: string): number => {
+  const m = /^#?([0-9a-f]{6})$/i.exec(hex);
+  if (!m) return 0;
+  const body = m[1];
+  const channel = (start: number): number => {
+    const v = parseInt(body.slice(start, start + 2), 16) / 255;
+    return v <= 0.03928 ? v / 12.92 : Math.pow((v + 0.055) / 1.055, 2.4);
+  };
+  return 0.2126 * channel(0) + 0.7152 * channel(2) + 0.0722 * channel(4);
+};
+
+const contrastVsWhite = (hex: string): number => {
+  const l = luminance(hex);
+  return (1 + 0.05) / (l + 0.05);
+};
+
+describe('getAccessibleAccentText', () => {
+  it('returns a result with WCAG AA contrast (>= 4.5) over white for light accents', () => {
+    const lightAccents = [
+      '#fbbf24', // yellow / amber
+      '#facc15', // yellow-400
+      '#a3e635', // lime-400
+      '#22c55e', // emerald-500 (borderline)
+      '#06b6d4', // cyan-500
+    ];
+    for (const accent of lightAccents) {
+      const result = getAccessibleAccentText(accent);
+      expect(contrastVsWhite(result)).toBeGreaterThanOrEqual(4.5);
+    }
+  });
+
+  it('preserves the original color when it is already dark enough', () => {
+    const darkAccents = [
+      '#1e293b', // slate-800
+      '#7f1d1d', // red-900
+      '#1e3a8a', // blue-900
+    ];
+    for (const accent of darkAccents) {
+      expect(getAccessibleAccentText(accent)).toBe(accent);
+    }
+  });
+
+  it('returns input unchanged for malformed values', () => {
+    expect(getAccessibleAccentText('not-a-color')).toBe('not-a-color');
+    expect(getAccessibleAccentText('')).toBe('');
+  });
+});

--- a/tests/components/widgets/Stations/nexus.test.ts
+++ b/tests/components/widgets/Stations/nexus.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { RandomGroup } from '@/types';
+import { buildStationsFromRandomGroups } from '@/components/widgets/Stations/nexus';
+
+describe('buildStationsFromRandomGroups', () => {
+  it('returns empty stations and assignments for an empty group list', () => {
+    const result = buildStationsFromRandomGroups([]);
+    expect(result.stations).toEqual([]);
+    expect(result.assignments).toEqual({});
+  });
+
+  it('falls back to "Group N" when group.id is missing or whitespace', () => {
+    const groups: RandomGroup[] = [
+      { id: '   ', names: ['Alice'] },
+      { names: ['Bob'] },
+      { id: 'Reading Corner', names: ['Carol'] },
+    ];
+    const { stations } = buildStationsFromRandomGroups(groups);
+    expect(stations.map((s) => s.title)).toEqual([
+      'Group 1',
+      'Group 2',
+      'Reading Corner',
+    ]);
+  });
+
+  it('trims surrounding whitespace from non-empty group ids', () => {
+    const groups: RandomGroup[] = [{ id: '  Math  ', names: [] }];
+    const { stations } = buildStationsFromRandomGroups(groups);
+    expect(stations[0].title).toBe('Math');
+  });
+
+  it('assigns names to the matching station id', () => {
+    const groups: RandomGroup[] = [
+      { id: 'A', names: ['Alice', 'Bob'] },
+      { id: 'B', names: ['Carol'] },
+    ];
+    const { stations, assignments } = buildStationsFromRandomGroups(groups);
+    expect(assignments.Alice).toBe(stations[0].id);
+    expect(assignments.Bob).toBe(stations[0].id);
+    expect(assignments.Carol).toBe(stations[1].id);
+  });
+
+  it('last write wins when a name appears in multiple groups', () => {
+    const groups: RandomGroup[] = [
+      { id: 'A', names: ['Alice'] },
+      { id: 'B', names: ['Alice'] },
+    ];
+    const { stations, assignments } = buildStationsFromRandomGroups(groups);
+    // Alice should land in the second group's station, not the first.
+    expect(assignments.Alice).toBe(stations[1].id);
+  });
+});

--- a/tests/components/widgets/Stations/stationsActions.test.ts
+++ b/tests/components/widgets/Stations/stationsActions.test.ts
@@ -143,6 +143,73 @@ describe('shuffleStudentsIntoStations', () => {
     expect(assignments).toEqual({ s1: null, s2: null });
     expect(overflowStudents).toEqual(['s1', 's2']);
   });
+
+  it('returns empty result for empty stations and empty roster', () => {
+    const result = shuffleStudentsIntoStations([], []);
+    expect(result.assignments).toEqual({});
+    expect(result.overflowStudents).toEqual([]);
+  });
+
+  it('skips a station with maxStudents = 0 instead of looping forever', () => {
+    // Stale data path: a station the teacher set to 0 capacity. The
+    // round-robin must not infinite-loop trying to place students there.
+    const stations = [
+      makeStation('a', 0, 0),
+      makeStation('b', 1),
+      makeStation('c', 2),
+    ];
+    const roster = ['s1', 's2', 's3', 's4'];
+    const { assignments, overflowStudents } = shuffleStudentsIntoStations(
+      stations,
+      roster
+    );
+    // No one lands in 'a'.
+    const aCount = Object.values(assignments).filter((v) => v === 'a').length;
+    expect(aCount).toBe(0);
+    // Everyone is placed in b or c (4 people across 2 unbounded stations).
+    expect(overflowStudents).toEqual([]);
+    expect(Object.keys(assignments).sort()).toEqual(roster);
+  });
+});
+
+describe('rotateAssignments — extra cases', () => {
+  it('drops students assigned to a no-longer-present station back to unassigned', () => {
+    // Station 'b' was deleted between assignment and rotate. Carol's stale
+    // assignment must not pin her to a phantom station, and she must not be
+    // silently lost — the algorithm carries her over as unassigned (null).
+    const stations = [makeStation('a', 0), makeStation('c', 1)];
+    const before: Record<string, string | null> = {
+      Alice: 'a',
+      Bob: 'c',
+      Carol: 'b', // station 'b' is no longer in the stations array
+    };
+    const { assignments } = rotateAssignments(stations, before);
+    // Alice and Bob rotate normally.
+    expect(assignments.Alice).toBe('c');
+    expect(assignments.Bob).toBe('a');
+    // Carol survives the rotate but is now unassigned.
+    expect('Carol' in assignments).toBe(true);
+    expect(assignments.Carol).toBeNull();
+  });
+
+  it('handles a station whose existing members exceed maxStudents (cap was lowered)', () => {
+    const stations = [
+      makeStation('a', 0, 1),
+      makeStation('b', 1, 1),
+      makeStation('c', 2, 1),
+    ];
+    // 'a' currently has 2 students even though cap is 1 — happens when the
+    // teacher lowers maxStudents after assignment.
+    const before: Record<string, string | null> = {
+      Alice: 'a',
+      Bob: 'a',
+    };
+    const { assignments, stuckStudents } = rotateAssignments(stations, before);
+    // Both rotate forward and find slots in b/c.
+    expect(stuckStudents).toEqual([]);
+    const placed = Object.values(assignments).filter((v) => v != null);
+    expect(placed).toHaveLength(2);
+  });
 });
 
 describe('resetAllAssignments', () => {

--- a/tests/components/widgets/Stations/stationsActions.test.ts
+++ b/tests/components/widgets/Stations/stationsActions.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect } from 'vitest';
+import { Station } from '@/types';
+import {
+  rotateAssignments,
+  shuffleStudentsIntoStations,
+  resetAllAssignments,
+  resetStation,
+} from '@/components/widgets/Stations/hooks/stationsActions';
+
+const makeStation = (
+  id: string,
+  order: number,
+  maxStudents?: number
+): Station => ({
+  id,
+  title: id.toUpperCase(),
+  color: '#10b981',
+  order,
+  maxStudents,
+});
+
+describe('rotateAssignments', () => {
+  it('cycles students clockwise through three stations', () => {
+    const stations = [
+      makeStation('a', 0),
+      makeStation('b', 1),
+      makeStation('c', 2),
+    ];
+    const before = {
+      Alice: 'a',
+      Bob: 'a',
+      Carol: 'b',
+      Dave: 'c',
+    };
+    const { assignments, stuckStudents } = rotateAssignments(stations, before);
+    expect(stuckStudents).toEqual([]);
+    expect(assignments).toEqual({
+      Alice: 'b',
+      Bob: 'b',
+      Carol: 'c',
+      Dave: 'a',
+    });
+  });
+
+  it('returns unchanged assignments when stations array is empty', () => {
+    const before = { Alice: 'a' };
+    const { assignments, stuckStudents } = rotateAssignments([], before);
+    expect(assignments).toBe(before);
+    expect(stuckStudents).toEqual([]);
+  });
+
+  it('preserves unassigned (null) entries', () => {
+    const stations = [makeStation('a', 0), makeStation('b', 1)];
+    const before = { Alice: null, Bob: 'a' };
+    const { assignments } = rotateAssignments(stations, before);
+    expect(assignments.Alice).toBeNull();
+    expect(assignments.Bob).toBe('b');
+  });
+
+  it('overflows displaced students to the next under-cap station', () => {
+    // Cap b at 1 — when rotating, only one of Alice/Bob can land in b; the
+    // other must keep walking to c.
+    const stations = [
+      makeStation('a', 0),
+      makeStation('b', 1, 1),
+      makeStation('c', 2),
+    ];
+    const before = { Alice: 'a', Bob: 'a' };
+    const { assignments, stuckStudents } = rotateAssignments(stations, before);
+    expect(stuckStudents).toEqual([]);
+    // First student in 'a' fills 'b', second flows to 'c'.
+    expect(assignments).toEqual({ Alice: 'b', Bob: 'c' });
+  });
+
+  it('reports stuck students when every station is full and keeps them put', () => {
+    // Three students, two stations each capped at 1 → total capacity 2 < 3.
+    // The first two rotate fine, the third has nowhere to land.
+    const stations = [makeStation('a', 0, 1), makeStation('b', 1, 1)];
+    const before: Record<string, string | null> = {
+      Alice: 'a',
+      Bob: 'a',
+      Carol: 'b',
+    };
+    const { assignments, stuckStudents } = rotateAssignments(stations, before);
+    expect(stuckStudents).toHaveLength(1);
+    // Every student still has an assignment somewhere.
+    expect(Object.keys(assignments).sort()).toEqual(['Alice', 'Bob', 'Carol']);
+    // The stuck student kept their original station.
+    const stuck = stuckStudents[0];
+    expect(assignments[stuck]).toBe(before[stuck]);
+  });
+});
+
+describe('shuffleStudentsIntoStations', () => {
+  it('distributes students evenly across stations with no caps', () => {
+    const stations = [
+      makeStation('a', 0),
+      makeStation('b', 1),
+      makeStation('c', 2),
+    ];
+    const roster = ['s1', 's2', 's3', 's4', 's5', 's6'];
+    const { assignments, overflowStudents } = shuffleStudentsIntoStations(
+      stations,
+      roster
+    );
+    expect(overflowStudents).toEqual([]);
+    // 6 students across 3 stations → exactly 2 each.
+    const aCount = Object.values(assignments).filter((v) => v === 'a').length;
+    const bCount = Object.values(assignments).filter((v) => v === 'b').length;
+    const cCount = Object.values(assignments).filter((v) => v === 'c').length;
+    expect(aCount).toBe(2);
+    expect(bCount).toBe(2);
+    expect(cCount).toBe(2);
+    // Every roster member is placed somewhere.
+    expect(Object.keys(assignments).sort()).toEqual([...roster].sort());
+  });
+
+  it('respects capacity caps and reports overflow', () => {
+    const stations = [makeStation('a', 0, 2), makeStation('b', 1, 2)];
+    const roster = ['s1', 's2', 's3', 's4', 's5'];
+    const { assignments, overflowStudents } = shuffleStudentsIntoStations(
+      stations,
+      roster,
+      () => 0
+    );
+    // Total capacity = 4, roster = 5 → exactly one overflow student.
+    expect(overflowStudents).toHaveLength(1);
+    const placed = Object.values(assignments).filter((v) => v != null);
+    expect(placed).toHaveLength(4);
+    // Each cap respected.
+    const aCount = Object.values(assignments).filter((v) => v === 'a').length;
+    const bCount = Object.values(assignments).filter((v) => v === 'b').length;
+    expect(aCount).toBe(2);
+    expect(bCount).toBe(2);
+  });
+
+  it('returns all-unassigned when there are no stations', () => {
+    const roster = ['s1', 's2'];
+    const { assignments, overflowStudents } = shuffleStudentsIntoStations(
+      [],
+      roster
+    );
+    expect(assignments).toEqual({ s1: null, s2: null });
+    expect(overflowStudents).toEqual(['s1', 's2']);
+  });
+});
+
+describe('resetAllAssignments', () => {
+  it('returns a map with every roster entry set to null', () => {
+    const result = resetAllAssignments(['Alice', 'Bob', 'Carol']);
+    expect(result).toEqual({ Alice: null, Bob: null, Carol: null });
+  });
+});
+
+describe('resetStation', () => {
+  it('clears only members of the named station', () => {
+    const before = { Alice: 'a', Bob: 'a', Carol: 'b', Dave: null };
+    const result = resetStation(before, 'a');
+    expect(result).toEqual({ Alice: null, Bob: null, Carol: 'b', Dave: null });
+  });
+});

--- a/types.ts
+++ b/types.ts
@@ -3052,8 +3052,14 @@ export interface StationsConfig {
    * in `savedWidgetConfigs.stations`, never on a live widget instance.
    */
   savedLibrary?: SavedStationsPreset[];
-  /** Appearance — consumed by both the front-face card grid and the unassigned bucket. */
-  fontFamily?: GlobalFontFamily;
+  /**
+   * Appearance — consumed by both the front-face card grid and the unassigned
+   * bucket. `fontFamily` matches the value space written by the shared
+   * `TypographySettings` primitive: `'global'` (inherit from dashboard) or one
+   * of the prefixed font keys (`'font-sans'`, `'font-mono'`, etc.). Decoded
+   * via `getFontClass()` from `utils/styles.ts`.
+   */
+  fontFamily?: string;
   fontColor?: string;
   cardColor?: string;
   cardOpacity?: number;

--- a/types.ts
+++ b/types.ts
@@ -59,7 +59,8 @@ export type WidgetType =
   | 'work-symbols'
   | 'blooms-taxonomy'
   | 'blooms-detail'
-  | 'need-do-put-then';
+  | 'need-do-put-then'
+  | 'stations';
 
 // --- ROSTER SYSTEM TYPES ---
 
@@ -1288,6 +1289,7 @@ export interface TimeToolConfig {
   timerEndTrafficColor?: 'red' | 'yellow' | 'green' | null;
   timerEndTriggerRandom?: boolean; // Whether to trigger random picker when timer ends
   timerEndTriggerNextUp?: boolean; // Whether to advance NextUp queue when timer ends
+  timerEndTriggerStationsRotate?: boolean; // Whether to rotate the first Stations widget when timer ends
   themeColor?: string;
   glow?: boolean;
   fontFamily?: string;
@@ -3001,6 +3003,62 @@ export interface NeedDoPutThenConfig {
   cardOpacity?: number;
 }
 
+/**
+ * One station in the Stations widget. Stations are defined by the teacher in the
+ * settings panel; students drag their name chips into the corresponding StationCard
+ * on the front face. `iconName` and `imageUrl` are mutually exclusive — `imageUrl`
+ * wins when both are present so the renderer can show either via
+ * `renderCatalystIcon`.
+ */
+export interface Station {
+  id: string;
+  title: string;
+  description?: string;
+  /** Maximum students permitted in this station; undefined = unlimited. */
+  maxStudents?: number;
+  /** Lucide icon name (e.g. 'BookOpen'). */
+  iconName?: string;
+  /** Drive/Storage URL for an uploaded or pasted image. Takes precedence over iconName. */
+  imageUrl?: string;
+  /** Hex string for the card accent color (e.g. '#10b981'). */
+  color: string;
+  /** Stable order index used by Rotate. Lowest first. */
+  order: number;
+}
+
+/** A saved Stations preset (just the station definitions, never assignments). */
+export interface SavedStationsPreset {
+  id: string;
+  name: string;
+  stations: Station[];
+  createdAt: number;
+}
+
+export interface StationsConfig {
+  /** Teacher-defined stations. Sorted by `order` for rotation/display. */
+  stations: Station[];
+  /** Map: studentName -> stationId, or null/missing for unassigned. */
+  assignments: Record<string, string | null>;
+  rosterMode?: 'class' | 'custom';
+  customRoster?: string[];
+  /**
+   * Bumped (e.g. to Date.now()) by a linked Timer when its countdown hits zero.
+   * The widget watches this with a useRef and fires the rotate action when the
+   * value increases. Mirrors the `externalTrigger` pattern used by Random/NextUp.
+   */
+  rotationTrigger?: number;
+  /**
+   * Saved-library snapshot — populated only when this config object is stored
+   * in `savedWidgetConfigs.stations`, never on a live widget instance.
+   */
+  savedLibrary?: SavedStationsPreset[];
+  /** Appearance — consumed by both the front-face card grid and the unassigned bucket. */
+  fontFamily?: GlobalFontFamily;
+  fontColor?: string;
+  cardColor?: string;
+  cardOpacity?: number;
+}
+
 // Union of all widget configs
 export type WidgetConfig =
   | UrlWidgetConfig
@@ -3062,7 +3120,8 @@ export type WidgetConfig =
   | WorkSymbolsConfig
   | BloomsTaxonomyConfig
   | BloomsDetailConfig
-  | NeedDoPutThenConfig;
+  | NeedDoPutThenConfig
+  | StationsConfig;
 
 // Helper type to get config type for a specific widget
 export type ConfigForWidget<T extends WidgetType> = T extends 'url'
@@ -3185,7 +3244,9 @@ export type ConfigForWidget<T extends WidgetType> = T extends 'url'
                                                                                                                       ? BloomsDetailConfig
                                                                                                                       : T extends 'need-do-put-then'
                                                                                                                         ? NeedDoPutThenConfig
-                                                                                                                        : never;
+                                                                                                                        : T extends 'stations'
+                                                                                                                          ? StationsConfig
+                                                                                                                          : never;
 
 export interface WidgetComponentProps {
   widget: WidgetData;


### PR DESCRIPTION
## Summary

- New **Stations** widget: teachers create 2–N stations (title, optional description, optional capacity cap, lucide icon **or** Drive-uploaded image, accent color); students drag name chips between stations on the projected board.
- Header actions: **Shuffle** (even distribution, respects caps), **Rotate** (clockwise, displaces overflow into the next under-cap station, reports stuck students), **Reset all**, plus a per-station reset.
- **Saved presets** library via `savedWidgetConfigs.stations` — name a station set, reload it on any board, delete with destructive Drive cleanup for uploaded images.
- **Nexus links** (no new framework — matches the existing `externalTrigger` pattern):
  - Timer end → rotate Stations (toggle in Timer settings)
  - Randomizer → Stations: "Send Groups to Stations" button (visible in Group mode)
  - Stations → Randomizer: "Send Station Names to Randomizer" button
- Drive uploads via existing `useStorage().uploadSticker`; destructive delete via `deleteFile` on swap/remove (best-effort, non-fatal failures log to console).

## Implementation notes

- Reuses LunchCount's `DraggableStudent`, `DroppableZone`, and `DndContext` setup verbatim.
- Reuses Randomizer's `ActiveClassChip` for class selection.
- Pure rotate/shuffle/reset logic lives in `hooks/stationsActions.ts` and is covered by 10 unit tests (capacity overflow, stuck-students, even distribution, etc.).
- Container-query scaling throughout the front face — no hardcoded sizes.
- Settings panel uses standard Tailwind (back face).

## Test plan

- [ ] Drop a Stations widget → empty state ("No stations yet") renders.
- [ ] Flip → add 3+ stations with mixed icons, uploaded images, and pasted images. Confirm uploads land in your Drive `SpartBoard/Assets/Stickers/` folder.
- [ ] Replace one image → confirm the previous Drive file is deleted (Drive trash).
- [ ] Activate a class roster → unassigned chips populate. Drag chips between stations and into/out of unassigned. Try to drop a 6th student into a station capped at 5 → toast appears, drop rejected.
- [ ] Per-station Reset (small × on each card) clears just that station; header Reset clears all.
- [ ] **Rotate** with mixed station populations → chips cycle clockwise; capacity overflow displaces correctly.
- [ ] **Shuffle** with more students than total capacity → overflow stays unassigned, toast surfaces the count.
- [ ] **Class switch** via the chip → new students populate unassigned, old assignments don't crash.
- [ ] Drop a Timer, enable "Auto-rotate stations" toggle, set 10s timer → on 0, all assigned students rotate one station.
- [ ] Drop a Randomizer in Group mode, generate groups, click "Send Groups to Stations" → stations created with group names + students pre-assigned.
- [ ] In Stations Settings, "Send Station Names to Randomizer" → Randomizer's first-names list matches station titles.
- [ ] Save preset "Wednesday lab rotation" → remove the widget → add a fresh one → load preset → stations match.
- [ ] Delete a preset that contains an uploaded image → Drive file is removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)