### PR TITLE
test(quiz): cover resolveResponseDisplayName name-resolution paths

### DIFF
--- a/components/widgets/QuizWidget/utils/resolveDisplayName.test.ts
+++ b/components/widgets/QuizWidget/utils/resolveDisplayName.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect } from 'vitest';
+
+import {
+  resolveResponseDisplayName,
+  UNKNOWN_STUDENT_LABEL,
+} from './resolveDisplayName';
+import { buildPinToNameMap } from './quizScoreboard';
+import {
+  formatStudentName,
+  type StudentName,
+} from '@/hooks/useAssignmentPseudonyms';
+import type { ClassRoster, QuizResponse } from '@/types';
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function makeRoster(
+  name: string,
+  students: { firstName: string; lastName: string; pin: string }[]
+): ClassRoster {
+  return {
+    id: `roster-${name}`,
+    name,
+    driveFileId: null,
+    studentCount: students.length,
+    createdAt: Date.now(),
+    students: students.map((s) => ({
+      id: `student-${s.pin}`,
+      ...s,
+    })),
+  };
+}
+
+function makeResponse(overrides: Partial<QuizResponse> = {}): QuizResponse {
+  return {
+    studentUid: 'uid-default',
+    pin: '01',
+    joinedAt: Date.now(),
+    status: 'completed',
+    answers: [],
+    score: null,
+    submittedAt: Date.now(),
+    ...overrides,
+  };
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+describe('resolveResponseDisplayName', () => {
+  it('returns the formatted ClassLink name for SSO students and ignores PIN', () => {
+    const ssoStudent: StudentName = {
+      givenName: 'Ada',
+      familyName: 'Lovelace',
+    };
+    const byStudentUid = new Map<string, StudentName>([
+      ['sso-uid-1', ssoStudent],
+    ]);
+    // The roster name at PIN '01' must NOT win — SSO is tier 1.
+    const pinToName = buildPinToNameMap(
+      [
+        makeRoster('Period 1', [
+          { firstName: 'Wrong', lastName: 'Person', pin: '01' },
+        ]),
+      ],
+      ['Period 1']
+    );
+    const response = makeResponse({
+      studentUid: 'sso-uid-1',
+      pin: '01',
+      classPeriod: 'Period 1',
+    });
+
+    expect(resolveResponseDisplayName(response, pinToName, byStudentUid)).toBe(
+      formatStudentName(ssoStudent)
+    );
+  });
+
+  it('resolves a pin-mode response by composite (classPeriod, pin) without cross-resolving rosters', () => {
+    // Two rosters, same PIN '01' in each. The period-scoped lookup must
+    // disambiguate so each Period's PIN 01 resolves to the right student.
+    const rosters = [
+      makeRoster('Period 1', [
+        { firstName: 'Alice', lastName: 'Smith', pin: '01' },
+      ]),
+      makeRoster('Period 2', [
+        { firstName: 'Bob', lastName: 'Jones', pin: '01' },
+      ]),
+    ];
+    const pinToName = buildPinToNameMap(rosters, ['Period 1', 'Period 2']);
+
+    const period1Response = makeResponse({
+      studentUid: 'anon-1',
+      pin: '01',
+      classPeriod: 'Period 1',
+    });
+    const period2Response = makeResponse({
+      studentUid: 'anon-2',
+      pin: '01',
+      classPeriod: 'Period 2',
+    });
+
+    expect(
+      resolveResponseDisplayName(period1Response, pinToName, new Map())
+    ).toBe('Alice Smith');
+    expect(
+      resolveResponseDisplayName(period2Response, pinToName, new Map())
+    ).toBe('Bob Jones');
+  });
+
+  it('falls through resolvePinName legacy suffix scan when classPeriod is missing', () => {
+    // Pre-period-scoping responses have no classPeriod. The legacy tier
+    // returns the first matching roster's name so those rows still display.
+    const pinToName = buildPinToNameMap(
+      [
+        makeRoster('Period 1', [
+          { firstName: 'Alice', lastName: 'Smith', pin: '01' },
+        ]),
+      ],
+      ['Period 1']
+    );
+    const response = makeResponse({
+      studentUid: 'anon-legacy',
+      pin: '01',
+      classPeriod: undefined,
+    });
+
+    expect(resolveResponseDisplayName(response, pinToName, new Map())).toBe(
+      'Alice Smith'
+    );
+  });
+
+  it('returns the literal "PIN <n>" fallback when the PIN does not match any roster', () => {
+    const pinToName = buildPinToNameMap(
+      [
+        makeRoster('Period 1', [
+          { firstName: 'Alice', lastName: 'Smith', pin: '01' },
+        ]),
+      ],
+      ['Period 1']
+    );
+    const response = makeResponse({
+      studentUid: 'anon-mystery',
+      pin: '99',
+      classPeriod: 'Period 1',
+    });
+
+    expect(resolveResponseDisplayName(response, pinToName, new Map())).toBe(
+      'PIN 99'
+    );
+  });
+
+  it('returns UNKNOWN_STUDENT_LABEL when no SSO name resolves and the response has no pin', () => {
+    const pinToName = buildPinToNameMap(
+      [
+        makeRoster('Period 1', [
+          { firstName: 'Alice', lastName: 'Smith', pin: '01' },
+        ]),
+      ],
+      ['Period 1']
+    );
+    const response = makeResponse({
+      studentUid: 'sso-uid-unsynced',
+      pin: undefined,
+    });
+
+    expect(resolveResponseDisplayName(response, pinToName, new Map())).toBe(
+      UNKNOWN_STUDENT_LABEL
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Adds the missing colocated test file for `resolveResponseDisplayName`, the single source of truth for putting a student name on every row in the live monitor and the Sheets export. Locks in the post-#1449 behavior so a future refactor of the lookup ladder can't silently break name display in either consumer.

## Targeting

Based on `feat/quiz-monitor-fixes` (PR #1449) rather than `dev-paul` because the test scenarios exercise `resolvePinName(pinToName, classPeriod, pin)` and the composite-keyed `buildPinToNameMap`, which only exist on this branch — the originally-requested base `dev-paul` doesn't have these yet. Targeting #1449's branch keeps the diff to just the new test file. Once #1449 merges to `dev-paul`, retarget this PR.

## Coverage

One `describe('resolveResponseDisplayName', ...)` with five `it`s, one per resolution tier:

1. **SSO student** — `byStudentUid` hit returns the formatted ClassLink name and the PIN/roster path is bypassed.
2. **Pin-mode, period-scoped match** — composite `(classPeriod, pin)` lookup picks the right student when two rosters share a PIN; cross-resolution is impossible.
3. **Pin-mode, missing classPeriod** — legacy / pre-period-scoping responses fall through `resolvePinName`'s suffix-scan and still resolve.
4. **Pin-mode, unknown PIN** — `'PIN <n>'` literal fallback (visible-mismatch surface).
5. **No identity** — exported `UNKNOWN_STUDENT_LABEL` constant returned (never `PIN undefined`).

## Test plan

- [x] `pnpm vitest run components/widgets/QuizWidget/utils/resolveDisplayName.test.ts` — 5/5 pass
- [x] `pnpm run type-check`
- [x] `pnpm run lint` (max-warnings 0)
- [x] `pnpm run format:check`
- [x] `pnpm run test` — full suite: 1631/1631 pass

---
_Generated by [Claude Code](https://claude.ai/code/session_018BGgqQRLT5StYHm4vu4maK)_