### PR TITLE
fix(stations): clickable reset, larger card content, slider drives surface

### DIFF
--- a/components/widgets/Stations/Widget.tsx
+++ b/components/widgets/Stations/Widget.tsx
@@ -399,6 +399,8 @@ export const StationsWidget: React.FC<{ widget: WidgetData }> = ({
                     isFull={isFull}
                     fontClassName={fontClassName}
                     bodyTextColor={fontColor}
+                    cardColor={cardColor}
+                    cardOpacity={cardOpacity}
                   />
                 );
               })}

--- a/components/widgets/Stations/Widget.tsx
+++ b/components/widgets/Stations/Widget.tsx
@@ -244,10 +244,11 @@ export const StationsWidget: React.FC<{ widget: WidgetData }> = ({
   );
   const fontColor = config.fontColor;
 
-  // Adapt grid columns to station count — keeps cards roomy when there are few
-  // stations and stays tidy when there are many.
+  // Adapt grid columns to station count. Capped at 3 so each card stays
+  // wide enough for the horizontal icon/title + chip-column split inside
+  // StationCard — beyond 9 stations we add rows rather than narrow columns.
   const cols = Math.min(
-    4,
+    3,
     Math.max(1, Math.ceil(Math.sqrt(orderedStations.length)))
   );
 

--- a/components/widgets/Stations/components/StationCard.tsx
+++ b/components/widgets/Stations/components/StationCard.tsx
@@ -18,6 +18,10 @@ interface StationCardProps {
   fontClassName?: string;
   /** Accessible accent override is computed locally; this is text color for body copy (description). */
   bodyTextColor?: string;
+  /** Surface color from widget appearance settings (cardColor). */
+  cardColor?: string;
+  /** Surface opacity from widget appearance settings (cardOpacity). */
+  cardOpacity?: number;
 }
 
 export const StationCard: React.FC<StationCardProps> = ({
@@ -28,11 +32,17 @@ export const StationCard: React.FC<StationCardProps> = ({
   isFull,
   fontClassName = '',
   bodyTextColor,
+  cardColor = '#f8fafc',
+  cardOpacity = 0.4,
 }) => {
   const accent = station.color?.trim() ? station.color : '#10b981';
   const accentTextColor = getAccessibleAccentText(accent);
-  const tint = hexToRgba(accent, 0.08);
-  const tintHover = hexToRgba(accent, 0.16);
+  // The card surface blends the configurable card color with the station accent
+  // so the cardOpacity slider drives readability while preserving color coding.
+  // At cardOpacity=0 the card is fully transparent; at 1.0 it reaches a
+  // moderately-tinted surface that's still readable for chips.
+  const surface = hexToRgba(accent, Math.max(0, cardOpacity) * 0.4);
+  const tintHover = hexToRgba(accent, Math.max(0.08, cardOpacity * 0.5));
   const capLabel =
     station.maxStudents != null
       ? `${members.length} / ${station.maxStudents}`
@@ -42,15 +52,19 @@ export const StationCard: React.FC<StationCardProps> = ({
     : station.iconName?.trim()
       ? station.iconName
       : 'LayoutGrid';
+  // Chip surface: a translucent neutral that contrasts the accent tint behind
+  // it, so chip text stays readable regardless of station accent.
+  const chipSurface = hexToRgba(cardColor, Math.min(1, cardOpacity + 0.25));
 
   return (
     <DroppableZone
       id={`station:${station.id}`}
-      className={`relative rounded-2xl border-2 border-dashed flex flex-col transition-all group h-full overflow-hidden ${fontClassName}`}
+      className={`relative rounded-2xl border-2 border-dashed flex transition-all group h-full overflow-hidden ${fontClassName}`}
       style={{
         borderColor: accent,
-        backgroundColor: tint,
+        backgroundColor: surface,
         padding: 'min(10px, 2cqmin)',
+        gap: 'min(10px, 2cqmin)',
       }}
       activeClassName={isFull ? '' : 'border-solid scale-[1.02]'}
     >
@@ -62,15 +76,14 @@ export const StationCard: React.FC<StationCardProps> = ({
       />
 
       {/*
-        Per-station reset button — visible at reduced opacity at rest so
-        teachers can see it on a projected/touch display, fully opaque on
-        hover/focus for desktop polish. Larger touch target than the original
-        4cqmin variant.
+        Per-station reset button — z-30 keeps it above the icon/title column
+        (z-10) and the chip column (z-10), otherwise the column wrappers sit
+        on top of the absolute button and swallow clicks.
       */}
       <button
         type="button"
         onClick={onResetStation}
-        className="absolute top-1 right-1 rounded-full bg-white/90 hover:bg-white border border-slate-200 text-slate-500 hover:text-brand-red-primary opacity-70 group-hover:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue-primary transition-all"
+        className="absolute top-1 right-1 z-30 rounded-full bg-white/90 hover:bg-white border border-slate-200 text-slate-500 hover:text-brand-red-primary opacity-70 group-hover:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue-primary transition-all"
         style={{
           padding: 'min(5px, 1.2cqmin)',
           width: 'min(28px, 7cqmin)',
@@ -88,93 +101,128 @@ export const StationCard: React.FC<StationCardProps> = ({
         />
       </button>
 
+      {/* LEFT COLUMN — icon, title, description, count badge.
+          Sized larger so kids can read the station from across the room. */}
       <div
-        className="flex items-start relative z-10"
-        style={{ gap: 'min(8px, 2cqmin)' }}
+        className="relative z-10 flex flex-col items-center justify-center text-center min-w-0"
+        style={{
+          flexBasis: '50%',
+          flexGrow: 1,
+          flexShrink: 1,
+          gap: 'min(6px, 1.5cqmin)',
+          // Reserve space for the absolute reset button so the icon doesn't
+          // visually collide with it.
+          paddingTop: 'min(20px, 5cqmin)',
+        }}
       >
         <div
-          className="shrink-0 rounded-xl bg-white/90 border border-white shadow-sm flex items-center justify-center"
+          className="shrink-0 rounded-2xl bg-white/90 border border-white shadow-sm flex items-center justify-center"
           style={{
-            width: 'min(44px, 12cqmin)',
-            height: 'min(44px, 12cqmin)',
+            width: 'min(96px, 28cqmin)',
+            height: 'min(96px, 28cqmin)',
           }}
         >
-          {renderCatalystIcon(iconSource, 'min(28px, 8cqmin)', '')}
+          {renderCatalystIcon(iconSource, 'min(64px, 20cqmin)', '')}
         </div>
-        <div className="flex flex-col min-w-0 flex-1">
+        <div
+          className="font-black leading-tight w-full"
+          style={{
+            fontSize: 'min(28px, 11cqmin)',
+            color: accentTextColor,
+            // Allow a 2-line title; clamp so very long names don't blow out
+            // the layout.
+            display: '-webkit-box',
+            WebkitLineClamp: 2,
+            WebkitBoxOrient: 'vertical',
+            overflow: 'hidden',
+          }}
+          title={station.title}
+        >
+          {station.title || 'Untitled'}
+        </div>
+        {station.description && (
           <div
-            className="font-black leading-tight truncate"
+            className="leading-tight w-full"
             style={{
-              fontSize: 'min(16px, 6cqmin)',
-              color: accentTextColor,
-              // Reserve the right-side area occupied by the absolute reset
-              // button so long titles don't render under it.
-              paddingRight: 'min(32px, 8cqmin)',
-            }}
-            title={station.title}
-          >
-            {station.title || 'Untitled'}
-          </div>
-          {station.description && (
-            <div
-              className="leading-tight line-clamp-2"
-              style={{
-                fontSize: 'min(11px, 4cqmin)',
-                color: bodyTextColor ?? '#64748b',
-              }}
-            >
-              {station.description}
-            </div>
-          )}
-          <div
-            className="text-white rounded-full font-black w-max mt-1"
-            style={{
-              backgroundColor: accent,
-              fontSize: 'min(11px, 3.5cqmin)',
-              padding: 'min(2px, 0.5cqmin) min(8px, 2cqmin)',
+              fontSize: 'min(13px, 5cqmin)',
+              color: bodyTextColor ?? '#64748b',
+              display: '-webkit-box',
+              WebkitLineClamp: 2,
+              WebkitBoxOrient: 'vertical',
+              overflow: 'hidden',
             }}
           >
-            {capLabel}
+            {station.description}
           </div>
+        )}
+        <div
+          className="text-white rounded-full font-black w-max"
+          style={{
+            backgroundColor: accent,
+            fontSize: 'min(13px, 4.5cqmin)',
+            padding: 'min(2px, 0.5cqmin) min(10px, 2.5cqmin)',
+          }}
+        >
+          {capLabel}
         </div>
       </div>
 
+      {/* RIGHT COLUMN — student chips, stacked top-to-bottom and wrapping
+          into 1–3 columns as the card grows wider. */}
       <div
-        className="flex-1 flex flex-wrap content-start overflow-y-auto custom-scrollbar relative z-10"
+        className="relative z-10 flex flex-col rounded-xl overflow-hidden"
         style={{
-          gap: 'min(6px, 1.5cqmin)',
-          marginTop: 'min(10px, 2cqmin)',
-          paddingRight: 'min(4px, 1cqmin)',
+          flexBasis: '50%',
+          flexGrow: 1,
+          flexShrink: 1,
+          backgroundColor: chipSurface,
+          padding: 'min(8px, 2cqmin)',
         }}
       >
-        {members.length === 0 && (
-          <div
-            className="w-full h-full flex items-center justify-center text-slate-400 italic"
-            style={{ fontSize: 'min(11px, 4cqmin)' }}
-          >
-            <LayoutGrid
+        <div
+          className="flex-1 overflow-y-auto custom-scrollbar"
+          style={{ paddingRight: 'min(4px, 1cqmin)' }}
+        >
+          {members.length === 0 ? (
+            <div
+              className="w-full h-full flex items-center justify-center text-slate-400 italic text-center"
+              style={{ fontSize: 'min(11px, 4cqmin)' }}
+            >
+              <LayoutGrid
+                style={{
+                  width: 'min(14px, 4cqmin)',
+                  height: 'min(14px, 4cqmin)',
+                  marginRight: 'min(6px, 1.5cqmin)',
+                }}
+              />
+              Drop students here
+            </div>
+          ) : (
+            <div
+              className="grid w-full content-start"
               style={{
-                width: 'min(14px, 4cqmin)',
-                height: 'min(14px, 4cqmin)',
-                marginRight: 'min(6px, 1.5cqmin)',
+                gap: 'min(6px, 1.5cqmin)',
+                // auto-fill into 1–3 columns based on available width.
+                gridTemplateColumns:
+                  'repeat(auto-fill, minmax(min(80px, 30cqmin), 1fr))',
               }}
-            />
-            Drop students here
-          </div>
-        )}
-        {members.map((student) => (
-          <DraggableStudent
-            key={student}
-            id={student}
-            name={student}
-            onClick={() => onUnassign(student)}
-            className={studentChipClass}
-            style={{
-              ...studentChipStyle,
-              ...(bodyTextColor ? { color: bodyTextColor } : {}),
-            }}
-          />
-        ))}
+            >
+              {members.map((student) => (
+                <DraggableStudent
+                  key={student}
+                  id={student}
+                  name={student}
+                  onClick={() => onUnassign(student)}
+                  className={`${studentChipClass} w-full justify-center text-center`}
+                  style={{
+                    ...studentChipStyle,
+                    ...(bodyTextColor ? { color: bodyTextColor } : {}),
+                  }}
+                />
+              ))}
+            </div>
+          )}
+        </div>
       </div>
     </DroppableZone>
   );

--- a/components/widgets/Stations/components/StationCard.tsx
+++ b/components/widgets/Stations/components/StationCard.tsx
@@ -37,12 +37,14 @@ export const StationCard: React.FC<StationCardProps> = ({
 }) => {
   const accent = station.color?.trim() ? station.color : '#10b981';
   const accentTextColor = getAccessibleAccentText(accent);
-  // The card surface blends the configurable card color with the station accent
-  // so the cardOpacity slider drives readability while preserving color coding.
-  // At cardOpacity=0 the card is fully transparent; at 1.0 it reaches a
-  // moderately-tinted surface that's still readable for chips.
-  const surface = hexToRgba(accent, Math.max(0, cardOpacity) * 0.4);
-  const tintHover = hexToRgba(accent, Math.max(0.08, cardOpacity * 0.5));
+  // The card surface uses the station accent (preserving per-station color
+  // coding) and applies `cardOpacity` directly — the same direct mapping the
+  // widget header and unassigned bucket use against `cardColor`. Keeping the
+  // alpha mapping uniform across surfaces means the "Card surface" slider
+  // behaves the same everywhere in the widget.
+  const clampedOpacity = Math.max(0, Math.min(1, cardOpacity));
+  const surface = hexToRgba(accent, clampedOpacity);
+  const tintHover = hexToRgba(accent, Math.min(1, clampedOpacity + 0.15));
   const capLabel =
     station.maxStudents != null
       ? `${members.length} / ${station.maxStudents}`
@@ -52,9 +54,11 @@ export const StationCard: React.FC<StationCardProps> = ({
     : station.iconName?.trim()
       ? station.iconName
       : 'LayoutGrid';
-  // Chip surface: a translucent neutral that contrasts the accent tint behind
-  // it, so chip text stays readable regardless of station accent.
-  const chipSurface = hexToRgba(cardColor, Math.min(1, cardOpacity + 0.25));
+  // Chip column overlay — an internal readability layer (not a user-visible
+  // "card surface"). It uses `cardColor` and is deliberately bumped above
+  // `cardOpacity` so chip text stays legible even when the accent tint behind
+  // it is heavy.
+  const chipSurface = hexToRgba(cardColor, Math.min(1, clampedOpacity + 0.25));
 
   return (
     <DroppableZone
@@ -167,8 +171,9 @@ export const StationCard: React.FC<StationCardProps> = ({
         </div>
       </div>
 
-      {/* RIGHT COLUMN — student chips, stacked top-to-bottom and wrapping
-          into 1–3 columns as the card grows wider. */}
+      {/* RIGHT COLUMN — student chips, stacked top-to-bottom in a grid that
+          auto-fills more columns as the card grows wider (single column on
+          narrow cards). */}
       <div
         className="relative z-10 flex flex-col rounded-xl overflow-hidden"
         style={{
@@ -202,7 +207,10 @@ export const StationCard: React.FC<StationCardProps> = ({
               className="grid w-full content-start"
               style={{
                 gap: 'min(6px, 1.5cqmin)',
-                // auto-fill into 1–3 columns based on available width.
+                // Auto-fill as many columns as the chip column width allows.
+                // The per-chip min-width keeps each chip wide enough to read
+                // a student name; on narrow cards this naturally collapses
+                // to a single column.
                 gridTemplateColumns:
                   'repeat(auto-fill, minmax(min(80px, 30cqmin), 1fr))',
               }}

--- a/components/widgets/Stations/components/StationCard.tsx
+++ b/components/widgets/Stations/components/StationCard.tsx
@@ -36,15 +36,28 @@ export const StationCard: React.FC<StationCardProps> = ({
   cardOpacity = 0.4,
 }) => {
   const accent = station.color?.trim() ? station.color : '#10b981';
-  const accentTextColor = getAccessibleAccentText(accent);
   // The card surface uses the station accent (preserving per-station color
   // coding) and applies `cardOpacity` directly — the same direct mapping the
   // widget header and unassigned bucket use against `cardColor`. Keeping the
   // alpha mapping uniform across surfaces means the "Card surface" slider
   // behaves the same everywhere in the widget.
   const clampedOpacity = Math.max(0, Math.min(1, cardOpacity));
-  const surface = hexToRgba(accent, clampedOpacity);
-  const tintHover = hexToRgba(accent, Math.min(1, clampedOpacity + 0.15));
+  // Hard cap the visible surface alpha so the dashed accent border and the
+  // solid-accent count badge never fully merge into the background at the top
+  // of the slider's range.
+  const SURFACE_ALPHA_CAP = 0.85;
+  const surfaceAlpha = Math.min(SURFACE_ALPHA_CAP, clampedOpacity);
+  const surface = hexToRgba(accent, surfaceAlpha);
+  const tintHover = hexToRgba(
+    accent,
+    Math.min(SURFACE_ALPHA_CAP, surfaceAlpha + 0.15)
+  );
+  // `getAccessibleAccentText` darkens the accent until it contrasts with white
+  // — accurate while the card is mostly transparent (low opacity → near-white
+  // surface). Once the surface gets dark/saturated the darkened accent text
+  // collides with its own background, so flip to white above ~50% opacity.
+  const titleColor =
+    surfaceAlpha > 0.5 ? '#ffffff' : getAccessibleAccentText(accent);
   const capLabel =
     station.maxStudents != null
       ? `${members.length} / ${station.maxStudents}`
@@ -129,16 +142,10 @@ export const StationCard: React.FC<StationCardProps> = ({
           {renderCatalystIcon(iconSource, 'min(64px, 20cqmin)', '')}
         </div>
         <div
-          className="font-black leading-tight w-full"
+          className="font-black leading-tight w-full line-clamp-2"
           style={{
             fontSize: 'min(28px, 11cqmin)',
-            color: accentTextColor,
-            // Allow a 2-line title; clamp so very long names don't blow out
-            // the layout.
-            display: '-webkit-box',
-            WebkitLineClamp: 2,
-            WebkitBoxOrient: 'vertical',
-            overflow: 'hidden',
+            color: titleColor,
           }}
           title={station.title}
         >
@@ -146,14 +153,10 @@ export const StationCard: React.FC<StationCardProps> = ({
         </div>
         {station.description && (
           <div
-            className="leading-tight w-full"
+            className="leading-tight w-full line-clamp-2"
             style={{
               fontSize: 'min(13px, 5cqmin)',
               color: bodyTextColor ?? '#64748b',
-              display: '-webkit-box',
-              WebkitLineClamp: 2,
-              WebkitBoxOrient: 'vertical',
-              overflow: 'hidden',
             }}
           >
             {station.description}
@@ -181,7 +184,10 @@ export const StationCard: React.FC<StationCardProps> = ({
           flexGrow: 1,
           flexShrink: 1,
           backgroundColor: chipSurface,
-          padding: 'min(8px, 2cqmin)',
+          // Top padding reserves room for the absolute reset button (which
+          // sits over this column's top-right corner) so the first chip row
+          // never renders underneath it.
+          padding: 'min(20px, 5cqmin) min(8px, 2cqmin) min(8px, 2cqmin)',
         }}
       >
         <div


### PR DESCRIPTION
## Summary

Fixes three bugs reported on the Stations widget:

- **Per-station Reset button was unclickable.** The button is absolutely positioned at the top-right of the card, but the icon/title row and chip area both sat at `relative z-10` and stacked above it, swallowing every click. The button now sits at `z-30`.
- **Icons / titles / subtitles were way too small to read from across the room.** `StationCard` is now a horizontal split: the left half is a large icon + title + description + count badge sized via `cqmin` so it actually fills the card. The right half is a chip column that auto-fills into 1–3 columns of stacked student chips depending on width.
- **The cardOpacity slider only changed the header and unassigned bucket.** The station card backgrounds were hardcoded to a fixed 0.08 accent tint, so the slider felt broken. The slider now drives the station surface tint and the chip column surface in addition to the existing header/unassigned surfaces — dialing it down makes the drop areas readable, sliding it up tints them more.

## Test plan

- [ ] Open the Stations widget, click each per-station Reset button — should clear that station's students with no other side effects.
- [ ] Add 1, 2, 4, and 9 stations and confirm the icon/title/description scales legibly at each grid size and remains readable on a projected display.
- [ ] In the style tab, drag the surface opacity slider from 0% → 100% and confirm the station card backgrounds, header, and unassigned bucket all respond.
- [ ] Drag students into a station and confirm chips wrap into 1–3 stacked columns inside the right half of the card.
- [ ] Hover a station card — the accent hover tint should still appear and the reset button should be fully opaque on hover.

https://claude.ai/code/session_019X8HgNfHuEkp6VVBMvYNv5

---
_Generated by [Claude Code](https://claude.ai/code/session_019X8HgNfHuEkp6VVBMvYNv5)_