### PR TITLE
fix(stations): teacher-feedback UI pass on station cards

### DIFF
--- a/components/common/ActiveClassChip.tsx
+++ b/components/common/ActiveClassChip.tsx
@@ -6,10 +6,19 @@ import { Z_INDEX } from '@/config/zIndex';
 
 interface ActiveClassChipProps {
   className?: string;
+  /**
+   * When true, render the trigger as a compact button matching the
+   * Shuffle/Rotate-style header buttons used in the Stations widget
+   * (white shell, slate border, brand-blue icon/label, smaller height).
+   * Default keeps the original pill visual used by Random / SeatingChart /
+   * LunchCount.
+   */
+  compact?: boolean;
 }
 
 export const ActiveClassChip: React.FC<ActiveClassChipProps> = ({
   className,
+  compact = false,
 }) => {
   const { rosters, activeRosterId, setActiveRoster } = useDashboard();
   const activeRoster = rosters.find((r) => r.id === activeRosterId);
@@ -123,18 +132,33 @@ export const ActiveClassChip: React.FC<ActiveClassChipProps> = ({
 
   if (!activeRoster) return null;
 
+  const iconSizeStyle = compact
+    ? { width: 'min(14px, 4cqmin)', height: 'min(14px, 4cqmin)' }
+    : {
+        width: 'clamp(14px, 3.6cqmin, 28px)',
+        height: 'clamp(14px, 3.6cqmin, 28px)',
+      };
+  const labelFontStyle = compact
+    ? { fontSize: 'min(11px, 3.5cqmin)' }
+    : { fontSize: 'clamp(12px, 3cqmin, 20px)' };
+  const chevronSizeStyle = compact
+    ? { width: 'min(12px, 3.5cqmin)', height: 'min(12px, 3.5cqmin)' }
+    : {
+        width: 'clamp(12px, 3cqmin, 22px)',
+        height: 'clamp(12px, 3cqmin, 22px)',
+      };
+
   const chipContent = (
     <>
       <Target
         className="text-brand-blue-primary shrink-0"
-        style={{
-          width: 'clamp(14px, 3.6cqmin, 28px)',
-          height: 'clamp(14px, 3.6cqmin, 28px)',
-        }}
+        style={iconSizeStyle}
       />
       <span
-        className="font-black uppercase text-brand-blue-primary tracking-wider truncate min-w-0"
-        style={{ fontSize: 'clamp(12px, 3cqmin, 20px)' }}
+        className={`font-black uppercase text-brand-blue-primary truncate min-w-0 ${
+          compact ? 'tracking-widest' : 'tracking-wider'
+        }`}
+        style={labelFontStyle}
       >
         {activeRoster.name}
       </span>
@@ -142,8 +166,7 @@ export const ActiveClassChip: React.FC<ActiveClassChipProps> = ({
         <ChevronDown
           className="text-brand-blue-primary shrink-0 opacity-70"
           style={{
-            width: 'clamp(12px, 3cqmin, 22px)',
-            height: 'clamp(12px, 3cqmin, 22px)',
+            ...chevronSizeStyle,
             transition: 'transform 150ms ease',
             transform: open ? 'rotate(180deg)' : 'rotate(0deg)',
           }}
@@ -152,13 +175,24 @@ export const ActiveClassChip: React.FC<ActiveClassChipProps> = ({
     </>
   );
 
-  const chipClass =
-    'flex items-center bg-brand-blue-lighter rounded-full border border-brand-blue-light';
-  const chipStyle: React.CSSProperties = {
-    gap: 'clamp(6px, 2cqmin, 14px)',
-    padding: 'clamp(6px, 1.6cqmin, 12px) clamp(12px, 3cqmin, 22px)',
-    minHeight: 'clamp(32px, 8cqmin, 48px)',
-  };
+  const chipClass = compact
+    ? 'flex items-center rounded-xl bg-white border border-slate-200'
+    : 'flex items-center bg-brand-blue-lighter rounded-full border border-brand-blue-light';
+  const chipStyle: React.CSSProperties = compact
+    ? {
+        gap: 'min(6px, 1.5cqmin)',
+        padding: 'min(6px, 1.5cqmin) min(10px, 2.5cqmin)',
+        height: 'min(32px, 8cqmin)',
+      }
+    : {
+        gap: 'clamp(6px, 2cqmin, 14px)',
+        padding: 'clamp(6px, 1.6cqmin, 12px) clamp(12px, 3cqmin, 22px)',
+        minHeight: 'clamp(32px, 8cqmin, 48px)',
+      };
+
+  const interactiveHoverClass = compact
+    ? 'hover:bg-slate-50 transition-colors cursor-pointer'
+    : 'hover:bg-brand-blue-light/40 transition-colors cursor-pointer';
 
   if (!interactive) {
     return (
@@ -195,7 +229,7 @@ export const ActiveClassChip: React.FC<ActiveClassChipProps> = ({
         ref={anchorRef}
         type="button"
         onClick={() => (open ? closeMenu() : openMenu())}
-        className={`${chipClass} hover:bg-brand-blue-light/40 transition-colors cursor-pointer ${className ?? ''}`.trim()}
+        className={`${chipClass} ${interactiveHoverClass} ${className ?? ''}`.trim()}
         style={chipStyle}
         aria-haspopup="menu"
         aria-expanded={open}

--- a/components/widgets/Stations/Widget.tsx
+++ b/components/widgets/Stations/Widget.tsx
@@ -284,15 +284,15 @@ export const StationsWidget: React.FC<{ widget: WidgetData }> = ({
               >
                 Stations
               </h3>
-              {config.rosterMode !== 'custom' && rosters.length > 0 && (
-                <ActiveClassChip />
-              )}
             </div>
 
             <div
               className="flex items-center shrink-0"
               style={{ gap: 'min(6px, 1.5cqmin)' }}
             >
+              {config.rosterMode !== 'custom' && rosters.length > 0 && (
+                <ActiveClassChip compact />
+              )}
               <Button
                 onClick={handleShuffle}
                 variant="ghost"

--- a/components/widgets/Stations/components/StationCard.tsx
+++ b/components/widgets/Stations/components/StationCard.tsx
@@ -2,7 +2,10 @@ import React from 'react';
 import { Station } from '@/types';
 import { DroppableZone } from '@/components/widgets/LunchCount/components/DroppableZone';
 import { DraggableStudent } from '@/components/widgets/LunchCount/components/DraggableStudent';
-import { renderCatalystIcon } from '@/components/widgets/Catalyst/catalystHelpers';
+import {
+  isSafeIconUrl,
+  renderCatalystIcon,
+} from '@/components/widgets/Catalyst/catalystHelpers';
 import { LayoutGrid, RotateCcw } from 'lucide-react';
 import { hexToRgba } from '@/utils/styles';
 import { studentChipClass, studentChipStyle } from './studentChip';
@@ -52,8 +55,13 @@ export const StationCard: React.FC<StationCardProps> = ({
       ? `${members.length} / ${station.maxStudents}`
       : `${members.length}`;
   const trimmedImageUrl = station.imageUrl?.trim();
-  const hasImage = Boolean(trimmedImageUrl);
-  const iconName = station.iconName?.trim() ? station.iconName : 'LayoutGrid';
+  // Validate the URL with the same safety check `renderCatalystIcon` uses for
+  // the icon-mode case so we don't silently load unsafe URLs (non-https, or
+  // oversized `data:` payloads). If the URL fails the check, fall back to
+  // icon mode so the card still renders cleanly.
+  const hasImage = Boolean(trimmedImageUrl) && isSafeIconUrl(trimmedImageUrl!);
+  const trimmedIconName = station.iconName?.trim();
+  const iconName = trimmedIconName || 'LayoutGrid';
   // Chip column overlay — an internal readability layer (not a user-visible
   // "card surface"). It uses `cardColor` and is deliberately bumped above
   // `cardOpacity` so chip text stays legible even when the accent tint behind

--- a/components/widgets/Stations/components/StationCard.tsx
+++ b/components/widgets/Stations/components/StationCard.tsx
@@ -6,7 +6,6 @@ import { renderCatalystIcon } from '@/components/widgets/Catalyst/catalystHelper
 import { LayoutGrid, RotateCcw } from 'lucide-react';
 import { hexToRgba } from '@/utils/styles';
 import { studentChipClass, studentChipStyle } from './studentChip';
-import { getAccessibleAccentText } from './accentText';
 
 interface StationCardProps {
   station: Station;
@@ -48,25 +47,13 @@ export const StationCard: React.FC<StationCardProps> = ({
   const SURFACE_ALPHA_CAP = 0.85;
   const surfaceAlpha = Math.min(SURFACE_ALPHA_CAP, clampedOpacity);
   const surface = hexToRgba(accent, surfaceAlpha);
-  const tintHover = hexToRgba(
-    accent,
-    Math.min(SURFACE_ALPHA_CAP, surfaceAlpha + 0.15)
-  );
-  // `getAccessibleAccentText` darkens the accent until it contrasts with white
-  // — accurate while the card is mostly transparent (low opacity → near-white
-  // surface). Once the surface gets dark/saturated the darkened accent text
-  // collides with its own background, so flip to white above ~50% opacity.
-  const titleColor =
-    surfaceAlpha > 0.5 ? '#ffffff' : getAccessibleAccentText(accent);
   const capLabel =
     station.maxStudents != null
       ? `${members.length} / ${station.maxStudents}`
       : `${members.length}`;
-  const iconSource = station.imageUrl?.trim()
-    ? station.imageUrl
-    : station.iconName?.trim()
-      ? station.iconName
-      : 'LayoutGrid';
+  const trimmedImageUrl = station.imageUrl?.trim();
+  const hasImage = Boolean(trimmedImageUrl);
+  const iconName = station.iconName?.trim() ? station.iconName : 'LayoutGrid';
   // Chip column overlay — an internal readability layer (not a user-visible
   // "card surface"). It uses `cardColor` and is deliberately bumped above
   // `cardOpacity` so chip text stays legible even when the accent tint behind
@@ -80,103 +67,100 @@ export const StationCard: React.FC<StationCardProps> = ({
       style={{
         borderColor: accent,
         backgroundColor: surface,
-        padding: 'min(10px, 2cqmin)',
-        gap: 'min(10px, 2cqmin)',
+        padding: 'min(10px, 4cqmin)',
+        gap: 'min(10px, 4cqmin)',
+        // Make the card itself a container-query container so the title,
+        // description, chips, and badges inside size against the CARD's
+        // dimensions rather than the widget's. This is what lets the title
+        // shrink as more stations are added (each card gets narrower) and
+        // the chips fit without scroll.
+        containerType: 'size',
       }}
       activeClassName={isFull ? '' : 'border-solid scale-[1.02]'}
     >
-      {/* Subtle hover background that respects the accent color */}
+      {/* LEFT COLUMN — hero (image or giant icon) fills the upper area;
+          a dark translucent plate is pinned to the bottom edge (aligned with
+          the chip column's bottom) carrying title / description / count. In
+          icon mode the lucide glyph fills the area above the plate so it
+          reads in full; in image mode the photo fills edge-to-edge and the
+          plate floats over its bottom. */}
       <div
-        aria-hidden
-        className="absolute inset-0 opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none"
-        style={{ backgroundColor: tintHover }}
-      />
-
-      {/*
-        Per-station reset button — z-30 keeps it above the icon/title column
-        (z-10) and the chip column (z-10), otherwise the column wrappers sit
-        on top of the absolute button and swallow clicks.
-      */}
-      <button
-        type="button"
-        onClick={onResetStation}
-        className="absolute top-1 right-1 z-30 rounded-full bg-white/90 hover:bg-white border border-slate-200 text-slate-500 hover:text-brand-red-primary opacity-70 group-hover:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue-primary transition-all"
-        style={{
-          padding: 'min(5px, 1.2cqmin)',
-          width: 'min(28px, 7cqmin)',
-          height: 'min(28px, 7cqmin)',
-        }}
-        aria-label={`Reset students in ${station.title || 'this station'}`}
-        title={`Reset students in ${station.title || 'this station'}`}
-      >
-        <RotateCcw
-          aria-hidden
-          style={{
-            width: 'min(14px, 3.8cqmin)',
-            height: 'min(14px, 3.8cqmin)',
-          }}
-        />
-      </button>
-
-      {/* LEFT COLUMN — icon, title, description, count badge.
-          Sized larger so kids can read the station from across the room. */}
-      <div
-        className="relative z-10 flex flex-col items-center justify-center text-center min-w-0"
+        className="relative z-10 flex flex-col items-center justify-end text-center min-w-0 rounded-xl overflow-hidden"
         style={{
           flexBasis: '50%',
           flexGrow: 1,
           flexShrink: 1,
-          gap: 'min(6px, 1.5cqmin)',
-          // Reserve space for the absolute reset button so the icon doesn't
-          // visually collide with it.
-          paddingTop: 'min(20px, 5cqmin)',
         }}
       >
-        <div
-          className="shrink-0 rounded-2xl bg-white/90 border border-white shadow-sm flex items-center justify-center"
-          style={{
-            width: 'min(96px, 28cqmin)',
-            height: 'min(96px, 28cqmin)',
-          }}
-        >
-          {renderCatalystIcon(iconSource, 'min(64px, 20cqmin)', '')}
-        </div>
-        <div
-          className="font-black leading-tight w-full line-clamp-2"
-          style={{
-            fontSize: 'min(28px, 11cqmin)',
-            color: titleColor,
-          }}
-          title={station.title}
-        >
-          {station.title || 'Untitled'}
-        </div>
-        {station.description && (
+        {hasImage ? (
+          <img
+            src={trimmedImageUrl}
+            alt=""
+            referrerPolicy="no-referrer"
+            loading="lazy"
+            aria-hidden
+            className="absolute inset-0 w-full h-full object-cover pointer-events-none"
+          />
+        ) : (
           <div
-            className="leading-tight w-full line-clamp-2"
+            aria-hidden
+            className="relative z-0 flex-1 min-h-0 w-full flex items-center justify-center pointer-events-none overflow-hidden"
             style={{
-              fontSize: 'min(13px, 5cqmin)',
-              color: bodyTextColor ?? '#64748b',
+              color: 'rgba(255, 255, 255, 0.95)',
+              padding: 'min(8px, 4cqmin)',
             }}
           >
-            {station.description}
+            {renderCatalystIcon(iconName, '100%', 'max-w-full max-h-full')}
           </div>
         )}
         <div
-          className="text-white rounded-full font-black w-max"
+          className="relative z-10 flex flex-col items-center justify-center w-full"
           style={{
-            backgroundColor: accent,
-            fontSize: 'min(13px, 4.5cqmin)',
-            padding: 'min(2px, 0.5cqmin) min(10px, 2.5cqmin)',
+            gap: 'min(4px, 2cqmin)',
+            // Plate fills the column edge-to-edge at the bottom. Its rounded
+            // corners match the column's rounded corners — the bottom corners
+            // overlap the column's rounded bottom for a clean drawer look,
+            // and the top corners curve into the icon hero area above.
+            margin: 0,
+            padding: 'min(8px, 4cqmin) min(10px, 5cqmin)',
+            backgroundColor: 'rgba(15, 23, 42, 0.42)',
+            backdropFilter: 'blur(4px)',
+            WebkitBackdropFilter: 'blur(4px)',
+            borderRadius: '0.75rem',
           }}
         >
-          {capLabel}
+          <div
+            className="font-black leading-tight w-full line-clamp-2 break-words"
+            style={{
+              // Title cap dropped from 28 → 22 so it doesn't dominate the
+              // card at typical widget sizes; the lower cqmin coefficient
+              // keeps the cap reachable on wider cards without ballooning.
+              fontSize: 'min(22px, 14cqmin)',
+              color: '#ffffff',
+            }}
+            title={station.title}
+          >
+            {station.title || 'Untitled'}
+          </div>
+          {station.description && (
+            <div
+              className="leading-tight w-full line-clamp-3 break-words"
+              style={{
+                fontSize: 'min(11px, 5.5cqmin)',
+                color: 'rgba(255, 255, 255, 0.9)',
+                fontWeight: 600,
+              }}
+            >
+              {station.description}
+            </div>
+          )}
         </div>
       </div>
 
-      {/* RIGHT COLUMN — student chips, stacked top-to-bottom in a grid that
-          auto-fills more columns as the card grows wider (single column on
-          narrow cards). */}
+      {/* RIGHT COLUMN — student chips packed via flex-wrap so every name stays
+          visible at narrow widget widths. Chips size to their content; only as
+          a last-resort fallback (very tall rosters in tiny widgets) does the
+          inner block scroll. */}
       <div
         className="relative z-10 flex flex-col rounded-xl overflow-hidden"
         style={{
@@ -184,42 +168,72 @@ export const StationCard: React.FC<StationCardProps> = ({
           flexGrow: 1,
           flexShrink: 1,
           backgroundColor: chipSurface,
-          // Top padding reserves room for the absolute reset button (which
-          // sits over this column's top-right corner) so the first chip row
-          // never renders underneath it.
-          padding: 'min(20px, 5cqmin) min(8px, 2cqmin) min(8px, 2cqmin)',
+          // Top padding reserves room for the absolute count badge (top-left)
+          // and reset button (top-right) plus extra breathing room before the
+          // first chip row.
+          padding: 'min(36px, 16cqmin) min(8px, 4cqmin) min(8px, 4cqmin)',
         }}
       >
         <div
-          className="flex-1 overflow-y-auto custom-scrollbar"
-          style={{ paddingRight: 'min(4px, 1cqmin)' }}
+          className="absolute top-1 left-1 z-20 text-white rounded-full font-black tabular-nums pointer-events-none flex items-center"
+          style={{
+            backgroundColor: accent,
+            fontSize: 'min(11px, 7cqmin)',
+            padding: 'min(2px, 1cqmin) min(8px, 4cqmin)',
+            height: 'min(24px, 12cqmin)',
+          }}
+          aria-label={`${members.length} students assigned${station.maxStudents != null ? ` of ${station.maxStudents} max` : ''}`}
+        >
+          {capLabel}
+        </div>
+        {/*
+          Per-station reset button — sits in the chip column's top-right
+          corner, mirroring the count badge in the top-left. Same accent-pill
+          treatment so the two corners read as a matched pair; hover flips it
+          to brand-red to signal the destructive action.
+        */}
+        <button
+          type="button"
+          onClick={onResetStation}
+          className="absolute top-1 right-1 z-30 rounded-full text-white font-black flex items-center justify-center hover:bg-brand-red-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue-primary transition-colors"
+          style={{
+            backgroundColor: accent,
+            width: 'min(24px, 12cqmin)',
+            height: 'min(24px, 12cqmin)',
+          }}
+          aria-label={`Reset students in ${station.title || 'this station'}`}
+          title={`Reset students in ${station.title || 'this station'}`}
+        >
+          <RotateCcw
+            aria-hidden
+            style={{
+              width: 'min(13px, 7cqmin)',
+              height: 'min(13px, 7cqmin)',
+            }}
+          />
+        </button>
+        <div
+          className="flex-1 min-h-0 overflow-y-auto custom-scrollbar"
+          style={{ paddingRight: 'min(4px, 2cqmin)' }}
         >
           {members.length === 0 ? (
             <div
               className="w-full h-full flex items-center justify-center text-slate-400 italic text-center"
-              style={{ fontSize: 'min(11px, 4cqmin)' }}
+              style={{ fontSize: 'min(11px, 7cqmin)' }}
             >
               <LayoutGrid
                 style={{
-                  width: 'min(14px, 4cqmin)',
-                  height: 'min(14px, 4cqmin)',
-                  marginRight: 'min(6px, 1.5cqmin)',
+                  width: 'min(14px, 7cqmin)',
+                  height: 'min(14px, 7cqmin)',
+                  marginRight: 'min(6px, 3cqmin)',
                 }}
               />
               Drop students here
             </div>
           ) : (
             <div
-              className="grid w-full content-start"
-              style={{
-                gap: 'min(6px, 1.5cqmin)',
-                // Auto-fill as many columns as the chip column width allows.
-                // The per-chip min-width keeps each chip wide enough to read
-                // a student name; on narrow cards this naturally collapses
-                // to a single column.
-                gridTemplateColumns:
-                  'repeat(auto-fill, minmax(min(80px, 30cqmin), 1fr))',
-              }}
+              className="flex flex-wrap content-start justify-center w-full"
+              style={{ gap: 'min(5px, 2cqmin)' }}
             >
               {members.map((student) => (
                 <DraggableStudent
@@ -227,9 +241,16 @@ export const StationCard: React.FC<StationCardProps> = ({
                   id={student}
                   name={student}
                   onClick={() => onUnassign(student)}
-                  className={`${studentChipClass} w-full justify-center text-center`}
+                  className={`${studentChipClass} justify-center text-center`}
                   style={{
+                    // Override studentChipStyle's widget-relative cqmin values
+                    // with card-relative ones since the card is now its own
+                    // container query container. Chips stay content-sized and
+                    // flex-wrap onto subsequent rows as space allows — they
+                    // never stretch to fill leftover row space.
                     ...studentChipStyle,
+                    fontSize: 'min(13px, 7cqmin)',
+                    padding: 'min(2px, 1cqmin) min(6px, 3cqmin)',
                     ...(bodyTextColor ? { color: bodyTextColor } : {}),
                   }}
                 />

--- a/components/widgets/Stations/components/StationCard.tsx
+++ b/components/widgets/Stations/components/StationCard.tsx
@@ -59,9 +59,11 @@ export const StationCard: React.FC<StationCardProps> = ({
   // the icon-mode case so we don't silently load unsafe URLs (non-https, or
   // oversized `data:` payloads). If the URL fails the check, fall back to
   // icon mode so the card still renders cleanly.
-  const hasImage = Boolean(trimmedImageUrl) && isSafeIconUrl(trimmedImageUrl!);
-  const trimmedIconName = station.iconName?.trim();
-  const iconName = trimmedIconName || 'LayoutGrid';
+  const hasImage = trimmedImageUrl ? isSafeIconUrl(trimmedImageUrl) : false;
+  // Use `||` (not `??`) so an empty trimmed string also falls back to the
+  // default — `??` would keep `''` and break the lucide lookup.
+  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+  const iconName = station.iconName?.trim() || 'LayoutGrid';
   // Chip column overlay — an internal readability layer (not a user-visible
   // "card surface"). It uses `cardColor` and is deliberately bumped above
   // `cardOpacity` so chip text stays legible even when the accent tint behind

--- a/components/widgets/Stations/components/StationCard.tsx
+++ b/components/widgets/Stations/components/StationCard.tsx
@@ -123,18 +123,25 @@ export const StationCard: React.FC<StationCardProps> = ({
             // and the top corners curve into the icon hero area above.
             margin: 0,
             padding: 'min(8px, 4cqmin) min(10px, 5cqmin)',
+            // Plate background and text colors are intentionally fixed (dark
+            // navy + white) rather than themed via cardColor / fontColor so
+            // the title and description remain legible no matter the station
+            // accent color or uploaded image behind them. cardColor still
+            // drives the chip-column surface; fontColor still drives chip text.
             backgroundColor: 'rgba(15, 23, 42, 0.42)',
-            backdropFilter: 'blur(4px)',
-            WebkitBackdropFilter: 'blur(4px)',
-            borderRadius: '0.75rem',
+            backdropFilter: 'blur(min(4px, 2cqmin))',
+            WebkitBackdropFilter: 'blur(min(4px, 2cqmin))',
+            borderRadius: 'min(12px, 6cqmin)',
           }}
         >
           <div
             className="font-black leading-tight w-full line-clamp-2 break-words"
             style={{
-              // Title cap dropped from 28 → 22 so it doesn't dominate the
-              // card at typical widget sizes; the lower cqmin coefficient
-              // keeps the cap reachable on wider cards without ballooning.
+              // Cap dropped from 28 → 22 so the title doesn't dominate the
+              // card at typical widget sizes. The 14cqmin coefficient keeps
+              // the cap reachable on the smaller card-relative cqmin (the
+              // card is its own container query container, so cqmin here
+              // is much smaller than the widget-cqmin used pre-refactor).
               fontSize: 'min(22px, 14cqmin)',
               color: '#ffffff',
             }}
@@ -147,6 +154,8 @@ export const StationCard: React.FC<StationCardProps> = ({
               className="leading-tight w-full line-clamp-3 break-words"
               style={{
                 fontSize: 'min(11px, 5.5cqmin)',
+                // Hardcoded for the same readability reason as the title
+                // (see plate `backgroundColor` comment above).
                 color: 'rgba(255, 255, 255, 0.9)',
                 fontWeight: 600,
               }}

--- a/components/widgets/Stations/components/studentChip.ts
+++ b/components/widgets/Stations/components/studentChip.ts
@@ -12,6 +12,6 @@ export const studentChipClass =
   'bg-white border-b-2 border-slate-200 rounded-xl font-black text-slate-700 shadow-sm hover:border-brand-blue-primary hover:-translate-y-0.5 transition-all active:scale-90';
 
 export const studentChipStyle: React.CSSProperties = {
-  fontSize: 'min(14px, 5cqmin)',
-  padding: 'min(6px, 1.6cqmin) min(12px, 3cqmin)',
+  fontSize: 'min(13px, 3.8cqmin)',
+  padding: 'min(5px, 1.2cqmin) min(9px, 2.2cqmin)',
 };


### PR DESCRIPTION
## Summary
- Compact `ActiveClassChip` variant so it stops dwarfing the Shuffle/Rotate buttons in the Stations header
- Each station card is now a `container-type: size` container so titles/chips/icons scale against the card itself, not the widget
- Image-as-hero treatment with a dark "drawer" plate at the bottom; icon mode mirrors the same structure
- Count badge + reset button paired in matching accent pills at the chip column corners
- Student chips blob via flex-wrap (content-sized, fill rows when there's room)
- Removed the hover tint that was washing out cards outside hover state

## Test plan
- [ ] Open the Stations widget at typical widget sizes (4 stations 2×2 / 5 stations 3-col) and verify titles fit on one line
- [ ] Confirm all student chips are visible without scroll for 6–9 chips per station
- [ ] Verify a station with an uploaded image shows the photo filling the left column with the dark text plate
- [ ] Verify icon-only stations show the lucide glyph in white above the plate
- [ ] Spot-check Random / SeatingChart / LunchCount widgets — they don't pass `compact` so the `ActiveClassChip` should look identical to before

🤖 Generated with [Claude Code](https://claude.com/claude-code)