### PR TITLE
fix(quiz): friendly student message on join permission-denied + drop mount log

### DIFF
--- a/components/quiz/QuizStudentApp.tsx
+++ b/components/quiz/QuizStudentApp.tsx
@@ -80,27 +80,13 @@ export const QuizStudentApp: React.FC = () => {
           await signInAnonymously(auth);
         }
         const user = auth.currentUser;
-        let isStudentRoleClaim = false;
         if (user && !user.isAnonymous) {
           // Probe custom claims once. We don't refresh here — `studentLoginV1`
           // is what minted these, and a stale token is fine for read-only
           // identity. The Firestore rules re-validate on every write.
           const tokenResult = await user.getIdTokenResult();
-          isStudentRoleClaim = tokenResult.claims?.studentRole === true;
-          setIsStudentRole(isStudentRoleClaim);
+          setIsStudentRole(tokenResult.claims?.studentRole === true);
         }
-        // Phase-A diagnostic: log resolved auth state once at mount so we can
-        // tell from a console capture whether a "fresh incognito" join really
-        // landed on an anonymous Firebase user, or if a stale custom-token /
-        // teacher session bled across (which would explain a no-PIN response
-        // in the PLC-import bug). Uses warn (not info) because the project
-        // ESLint config restricts console to warn/error. Remove once the
-        // join bugs are root-caused.
-        console.warn('[QuizStudentApp] auth state', {
-          uid: user?.uid,
-          isAnonymous: user?.isAnonymous,
-          studentRole: isStudentRoleClaim,
-        });
       } catch (err) {
         console.warn('[QuizStudentApp] Auth init failed:', err);
         setAuthFailed(true);

--- a/hooks/useQuizSession.ts
+++ b/hooks/useQuizSession.ts
@@ -1103,7 +1103,43 @@ export const useQuizSessionStudent = (): UseQuizSessionStudentResult => {
         setSession(sessionData);
         return sessionDoc.id;
       } catch (err) {
-        const msg = err instanceof Error ? err.message : 'Failed to join quiz';
+        // Translate Firestore `permission-denied` into a student-friendly
+        // message. The raw FirebaseError says "Missing or insufficient
+        // permissions" which reads to a student like the page is broken
+        // rather than "you can't do this" — so the click feels silent.
+        //
+        // Anonymous joiners hit permission-denied in one realistic shape:
+        // the deterministic-key collision path where another anon UID
+        // already wrote a response at the same `pin-{period}-{pin}` key.
+        // The class gate doesn't apply to anon (anon tokens lack the
+        // studentRole claim, so passesStudentClassGate short-circuits to
+        // true), so this is the only common cause.
+        //
+        // Non-anonymous joiners (custom-token studentRole users from
+        // /my-assignments) hit permission-denied when the session targets
+        // a class their `classIds` claim doesn't include — the response
+        // create rule's class gate denies. Surface that as an enrollment
+        // hint so the student knows to ping the teacher rather than think
+        // the link is broken.
+        //
+        // Other failures (network, code-not-found, attempt-limit) keep
+        // their existing messages — `AttemptLimitReachedError` already
+        // ships a friendly "ask your teacher" message of its own.
+        let msg: string;
+        if (
+          getErrorCode(err) === 'permission-denied' &&
+          auth.currentUser?.isAnonymous
+        ) {
+          msg =
+            "Looks like that PIN has already joined this quiz. Ask your teacher to clear it for you, or double-check that you've selected the right class period.";
+        } else if (getErrorCode(err) === 'permission-denied') {
+          msg =
+            "You can't join this quiz. Ask your teacher to make sure you're enrolled in the right class.";
+        } else if (err instanceof Error) {
+          msg = err.message;
+        } else {
+          msg = 'Failed to join quiz';
+        }
         setError(msg);
         throw err;
       } finally {


### PR DESCRIPTION
## Summary

Follow-up to [#1461](https://github.com/OPS-PIvers/SpartBoard/pull/1461) (which only landed the Phase-A breadcrumbs). Both reported quiz-join bugs turned out to be the same root cause — a stale SSO student session in another incognito tab was bleeding into the "fresh" tab, so joins went through the SSO auto-join branch (no PIN, no period picker → `Student` fallback on monitor), and a re-attempt hit the deterministic-key collision rule and got silently denied.

The actual product bug is **UX**: the raw FirebaseError `Missing or insufficient permissions` reads to a student like the page is broken, not "you can't do this," so the click feels silent.

Two changes:

1. **`joinQuizSession`'s outer catch translates `permission-denied`** into a student-readable hint before calling `setError`:
   - Anonymous joiners (the realistic collision case): _"Looks like that PIN has already joined this quiz. Ask your teacher to clear it for you, or double-check that you've selected the right class period."_
   - Non-anonymous (`studentRole`) joiners (class-gate denial): _"You can't join this quiz. Ask your teacher to make sure you're enrolled in the right class."_
   - `AttemptLimitReachedError` already carries its own friendly message and passes through unchanged.
   - Network / code-not-found / other errors keep their existing messages.

2. **Drop the mount-time `[QuizStudentApp] auth state` log.** Useful during diagnosis, noisy on every student page load in production.

The structured `logQuizJoinFirestoreError` breadcrumbs from #1461 stay — only fire on actual `permission-denied` (zero happy-path cost), real value for future support tickets.

## Test plan

- [x] `pnpm run validate` clean: type-check, lint, format, 1672/1672 tests, build.
- [ ] Dev preview: deliberately reproduce a deterministic-key collision (same PIN+period from a second incognito) → confirm the new friendly message appears in the red banner, not `Missing or insufficient permissions`.
- [ ] Sanity: a clean first-time anon join still works (PIN form → period picker → waiting room).
- [ ] Sanity: SSO student auto-join from `/my-assignments` still works for an actually-enrolled session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)