### PR TITLE
fix(quiz): scroll period picker when class list overflows viewport

### DIFF
--- a/components/quiz/QuizStudentApp.tsx
+++ b/components/quiz/QuizStudentApp.tsx
@@ -241,76 +241,85 @@ const QuizJoinFlow: React.FC<{ isStudentRole: boolean }> = ({
   // any class periods. SSO joiners skip this and join via the auto-join effect.
   if (periodStep && !joined) {
     return (
-      <div className="min-h-screen bg-slate-900 flex flex-col items-center justify-center p-6">
-        <div className="w-full max-w-sm">
-          <div className="flex items-center justify-center mb-8">
-            <ClipboardList className="w-5 h-5 text-violet-400 mr-2" />
-            <span className="text-sm text-slate-300 font-semibold">
-              Student Quiz
-            </span>
-          </div>
-
-          <h1 className="text-2xl font-black text-white mb-2 text-center">
-            Select Your Class
-          </h1>
-          <p className="text-slate-400 text-sm text-center mb-6">
-            Which class period are you in?
-          </p>
-
-          {error && (
-            <div className="mb-4 p-3 bg-red-500/20 border border-red-500/40 rounded-xl text-red-300 text-sm flex items-center gap-2">
-              <AlertCircle className="w-4 h-4 shrink-0" />
-              {error}
+      // Outer wrapper owns the scroll: body has `overflow: hidden` globally
+      // (index.css), so a `min-h-screen` child can't trigger document scroll
+      // when the period list is taller than the viewport. We give the outer
+      // an explicit viewport height + `overflow-y-auto`, then let the inner
+      // grow past 100% via `min-h-full` — content centers when it fits and
+      // the outer scrolls when it doesn't (e.g. teacher with 8+ periods on
+      // a phone-sized viewport).
+      <div className="h-screen overflow-y-auto bg-slate-900">
+        <div className="min-h-full flex flex-col items-center justify-center p-6">
+          <div className="w-full max-w-sm">
+            <div className="flex items-center justify-center mb-8">
+              <ClipboardList className="w-5 h-5 text-violet-400 mr-2" />
+              <span className="text-sm text-slate-300 font-semibold">
+                Student Quiz
+              </span>
             </div>
-          )}
 
-          <div className="space-y-2 mb-6">
-            {periodStep.map((period) => (
-              <button
-                key={period}
-                onClick={() => setSelectedPeriod(period)}
-                className={`w-full px-4 py-4 rounded-xl text-lg font-bold transition-all ${
-                  selectedPeriod === period
-                    ? 'bg-violet-600 text-white ring-2 ring-violet-400'
-                    : 'bg-slate-800 border border-slate-700 text-slate-300 hover:bg-slate-700'
-                }`}
-              >
-                {period}
-              </button>
-            ))}
-          </div>
+            <h1 className="text-2xl font-black text-white mb-2 text-center">
+              Select Your Class
+            </h1>
+            <p className="text-slate-400 text-sm text-center mb-6">
+              Which class period are you in?
+            </p>
 
-          <button
-            onClick={() => {
-              // joinQuizSession re-throws after populating `error` state for
-              // the UI. Catch here so the rejection isn't an unhandled
-              // promise — `void` would only silence the linter, not handle
-              // the rejection.
-              handlePeriodConfirm().catch((err: unknown) => {
-                console.warn('[QuizStudentApp] Period confirm failed:', err);
-              });
-            }}
-            disabled={loading || !selectedPeriod}
-            className="w-full py-4 bg-violet-600 hover:bg-violet-500 disabled:opacity-50 text-white font-bold text-lg rounded-xl flex items-center justify-center gap-2 transition-colors"
-          >
-            {loading ? (
-              <Loader2 className="w-5 h-5 animate-spin" />
-            ) : (
-              <>
-                Continue <ArrowRight className="w-5 h-5" />
-              </>
+            {error && (
+              <div className="mb-4 p-3 bg-red-500/20 border border-red-500/40 rounded-xl text-red-300 text-sm flex items-center gap-2">
+                <AlertCircle className="w-4 h-4 shrink-0" />
+                {error}
+              </div>
             )}
-          </button>
 
-          <button
-            onClick={() => {
-              setPeriodStep(null);
-              setSelectedPeriod(null);
-            }}
-            className="w-full mt-3 py-2 text-slate-500 hover:text-slate-300 text-sm font-medium transition-colors"
-          >
-            Go Back
-          </button>
+            <div className="space-y-2 mb-6">
+              {periodStep.map((period) => (
+                <button
+                  key={period}
+                  onClick={() => setSelectedPeriod(period)}
+                  className={`w-full px-4 py-4 rounded-xl text-lg font-bold transition-all ${
+                    selectedPeriod === period
+                      ? 'bg-violet-600 text-white ring-2 ring-violet-400'
+                      : 'bg-slate-800 border border-slate-700 text-slate-300 hover:bg-slate-700'
+                  }`}
+                >
+                  {period}
+                </button>
+              ))}
+            </div>
+
+            <button
+              onClick={() => {
+                // joinQuizSession re-throws after populating `error` state for
+                // the UI. Catch here so the rejection isn't an unhandled
+                // promise — `void` would only silence the linter, not handle
+                // the rejection.
+                handlePeriodConfirm().catch((err: unknown) => {
+                  console.warn('[QuizStudentApp] Period confirm failed:', err);
+                });
+              }}
+              disabled={loading || !selectedPeriod}
+              className="w-full py-4 bg-violet-600 hover:bg-violet-500 disabled:opacity-50 text-white font-bold text-lg rounded-xl flex items-center justify-center gap-2 transition-colors"
+            >
+              {loading ? (
+                <Loader2 className="w-5 h-5 animate-spin" />
+              ) : (
+                <>
+                  Continue <ArrowRight className="w-5 h-5" />
+                </>
+              )}
+            </button>
+
+            <button
+              onClick={() => {
+                setPeriodStep(null);
+                setSelectedPeriod(null);
+              }}
+              className="w-full mt-3 py-2 text-slate-500 hover:text-slate-300 text-sm font-medium transition-colors"
+            >
+              Go Back
+            </button>
+          </div>
         </div>
       </div>
     );


### PR DESCRIPTION
## Summary

Reported by Paul: a teacher with many class periods (8+) couldn't reach the lower options on the student-side period picker — the bottom buttons were clipped past the viewport edge with no way to scroll. \`index.css\` sets \`body { overflow: hidden }\` globally (drag/resize hygiene for the teacher dashboard), so a \`min-h-screen\` child can't trigger document scroll either.

Fix is route-local: the period-picker outer wrapper switches from \`min-h-screen flex justify-center\` to \`h-screen overflow-y-auto\`, with a \`min-h-full flex flex-col items-center justify-center\` inner that grows past 100% when content exceeds the viewport.

- Short period list (1–3): content centers exactly as before.
- Long period list (8+): outer scrolls; every period button + Continue + Go Back stays reachable.

Body's global \`overflow: hidden\` is unaffected — scroll lives only on the route container.

## Verification

Verified the CSS pattern in the dev preview at **375×812 (mobile) with 10 mock periods** by injecting the actual class structure into \`#root\`:

\`\`\`json
{ "viewport": {"w":375,"h":812},
  "outer":   {"clientH":812,"scrollH":1008,"scrollable":true},
  "inner":   {"clientH":1008},
  "bodyOverflow": "hidden" }
\`\`\`

After programmatically scrolling the outer container to the bottom: \`scrollTop=196\`, \`atBottom=true\`, "Go Back" button visible at the bottom. Body's global \`overflow: hidden\` confirmed unaffected.

Scoped intentionally to the period picker. The PIN form, waiting room, and other student screens have fixed short content and don't need the treatment yet.

## Test plan

- [x] \`pnpm run validate\` clean (type-check, lint, format).
- [x] CSS pattern verified at 375×812 with 10 simulated periods (above).
- [ ] Dev preview manual: open \`/quiz?code=…\` for an assignment with 8+ periods on a phone-sized viewport — confirm you can scroll to and tap the lower periods + the "Go Back" button.
- [ ] Sanity: an assignment with 1–3 periods still centers vertically as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)