### PR TITLE
Improve joinQuizSession error handling and user messaging

### DIFF
--- a/components/quiz/QuizStudentApp.tsx
+++ b/components/quiz/QuizStudentApp.tsx
@@ -80,13 +80,27 @@ export const QuizStudentApp: React.FC = () => {
           await signInAnonymously(auth);
         }
         const user = auth.currentUser;
+        let isStudentRoleClaim = false;
         if (user && !user.isAnonymous) {
           // Probe custom claims once. We don't refresh here — `studentLoginV1`
           // is what minted these, and a stale token is fine for read-only
           // identity. The Firestore rules re-validate on every write.
           const tokenResult = await user.getIdTokenResult();
-          setIsStudentRole(tokenResult.claims?.studentRole === true);
+          isStudentRoleClaim = tokenResult.claims?.studentRole === true;
+          setIsStudentRole(isStudentRoleClaim);
         }
+        // Phase-A diagnostic: log resolved auth state once at mount so we can
+        // tell from a console capture whether a "fresh incognito" join really
+        // landed on an anonymous Firebase user, or if a stale custom-token /
+        // teacher session bled across (which would explain a no-PIN response
+        // in the PLC-import bug). Uses warn (not info) because the project
+        // ESLint config restricts console to warn/error. Remove once the
+        // join bugs are root-caused.
+        console.warn('[QuizStudentApp] auth state', {
+          uid: user?.uid,
+          isAnonymous: user?.isAnonymous,
+          studentRole: isStudentRoleClaim,
+        });
       } catch (err) {
         console.warn('[QuizStudentApp] Auth init failed:', err);
         setAuthFailed(true);

--- a/components/quiz/QuizStudentApp.tsx
+++ b/components/quiz/QuizStudentApp.tsx
@@ -80,27 +80,13 @@ export const QuizStudentApp: React.FC = () => {
           await signInAnonymously(auth);
         }
         const user = auth.currentUser;
-        let isStudentRoleClaim = false;
         if (user && !user.isAnonymous) {
           // Probe custom claims once. We don't refresh here — `studentLoginV1`
           // is what minted these, and a stale token is fine for read-only
           // identity. The Firestore rules re-validate on every write.
           const tokenResult = await user.getIdTokenResult();
-          isStudentRoleClaim = tokenResult.claims?.studentRole === true;
-          setIsStudentRole(isStudentRoleClaim);
+          setIsStudentRole(tokenResult.claims?.studentRole === true);
         }
-        // Phase-A diagnostic: log resolved auth state once at mount so we can
-        // tell from a console capture whether a "fresh incognito" join really
-        // landed on an anonymous Firebase user, or if a stale custom-token /
-        // teacher session bled across (which would explain a no-PIN response
-        // in the PLC-import bug). Uses warn (not info) because the project
-        // ESLint config restricts console to warn/error. Remove once the
-        // join bugs are root-caused.
-        console.warn('[QuizStudentApp] auth state', {
-          uid: user?.uid,
-          isAnonymous: user?.isAnonymous,
-          studentRole: isStudentRoleClaim,
-        });
       } catch (err) {
         console.warn('[QuizStudentApp] Auth init failed:', err);
         setAuthFailed(true);

--- a/hooks/useQuizSession.ts
+++ b/hooks/useQuizSession.ts
@@ -213,6 +213,33 @@ function getErrorCode(err: unknown): string | undefined {
   return typeof code === 'string' ? code : undefined;
 }
 
+// Phase-A diagnostic helper: when a Firestore op inside joinQuizSession
+// rejects, emit a structured breadcrumb naming the op + the join's auth/PIN
+// state, then re-throw. The outer catch in joinQuizSession only sees
+// `err.message`, which is "Missing or insufficient permissions" verbatim —
+// the breadcrumb is the only place we can correlate the denial back to which
+// of the (lookup / read-existing / create / update-reset / update-period /
+// update-classid) operations actually tripped, and what the request shape
+// looked like at that moment.
+//
+// Always re-throws so callers' control flow is unchanged. Type is `never`
+// so TS narrows correctly when used in `catch` blocks that don't want a
+// dangling promise return path.
+function logQuizJoinFirestoreError(
+  op: string,
+  err: unknown,
+  ctx: Record<string, unknown>
+): never {
+  const code = getErrorCode(err);
+  if (code === 'permission-denied') {
+    console.warn(
+      `[useQuizSession] permission-denied during joinQuizSession op=${op}:`,
+      { op, code, ...ctx, err }
+    );
+  }
+  throw err;
+}
+
 /**
  * Look up the student's response doc for a session, trying the deterministic
  * key first and falling back to the legacy auth-uid key for anonymous PIN
@@ -844,6 +871,12 @@ export const useQuizSessionStudent = (): UseQuizSessionStudentResult => {
             collection(db, QUIZ_SESSIONS_COLLECTION),
             where('code', '==', normCode)
           )
+        ).catch((err: unknown) =>
+          logQuizJoinFirestoreError('lookup-sessions', err, {
+            codeNorm: normCode,
+            studentUid,
+            isAnonymous: currentUser.isAnonymous,
+          })
         );
         if (snap.empty) throw new Error('No active quiz found with that code.');
 
@@ -931,12 +964,31 @@ export const useQuizSessionStudent = (): UseQuizSessionStudentResult => {
               ...(classPeriod && existing.classPeriod !== classPeriod
                 ? { classPeriod }
                 : {}),
-            });
+            }).catch((err: unknown) =>
+              logQuizJoinFirestoreError('update-reset-completed', err, {
+                sessionId: sessionDoc.id,
+                responseKey,
+                studentUid,
+                existingStudentUid: existing.studentUid,
+                isAnonymous: currentUser.isAnonymous,
+                hasPin: !!sanitizedPin,
+                hasClassPeriod: !!classPeriod,
+              })
+            );
           } else if (classPeriod && existing.classPeriod !== classPeriod) {
             // Backfill classPeriod on an in-flight response (e.g. student
             // joined before periods were configured or reloaded after a
             // change).
-            await updateDoc(responseRef, { classPeriod });
+            await updateDoc(responseRef, { classPeriod }).catch(
+              (err: unknown) =>
+                logQuizJoinFirestoreError('update-backfill-period', err, {
+                  sessionId: sessionDoc.id,
+                  responseKey,
+                  studentUid,
+                  existingStudentUid: existing.studentUid,
+                  isAnonymous: currentUser.isAnonymous,
+                })
+            );
           }
         }
 
@@ -1011,14 +1063,40 @@ export const useQuizSessionStudent = (): UseQuizSessionStudentResult => {
             ...(classPeriod ? { classPeriod } : {}),
             ...(resolvedClassId ? { classId: resolvedClassId } : {}),
           };
-          await setDoc(responseRef, newResponse);
+          await setDoc(responseRef, newResponse).catch((err: unknown) =>
+            logQuizJoinFirestoreError('create-response', err, {
+              sessionId: sessionDoc.id,
+              responseKey,
+              studentUid,
+              isAnonymous: currentUser.isAnonymous,
+              hasPin: !!sanitizedPin,
+              hasClassPeriod: !!classPeriod,
+              hasResolvedClassId: !!resolvedClassId,
+              sessionClassIds: Array.isArray(sessionData.classIds)
+                ? sessionData.classIds
+                : undefined,
+              sessionClassId: sessionData.classId,
+              sessionTeacherUid: sessionData.teacherUid,
+              sessionStatus: sessionData.status,
+            })
+          );
         } else if (resolvedClassId) {
           // Backfill classId on an existing SSO response that joined before
           // this code shipped, so the period filter and sheet column are
           // self-healing on rejoin without a separate migration.
           const existing = existingSnap.data() as QuizResponse;
           if (existing.classId !== resolvedClassId) {
-            await updateDoc(responseRef, { classId: resolvedClassId });
+            await updateDoc(responseRef, { classId: resolvedClassId }).catch(
+              (err: unknown) =>
+                logQuizJoinFirestoreError('update-backfill-classid', err, {
+                  sessionId: sessionDoc.id,
+                  responseKey,
+                  studentUid,
+                  existingClassId: existing.classId,
+                  resolvedClassId,
+                  isAnonymous: currentUser.isAnonymous,
+                })
+            );
           }
         }
 

--- a/hooks/useQuizSession.ts
+++ b/hooks/useQuizSession.ts
@@ -1103,7 +1103,43 @@ export const useQuizSessionStudent = (): UseQuizSessionStudentResult => {
         setSession(sessionData);
         return sessionDoc.id;
       } catch (err) {
-        const msg = err instanceof Error ? err.message : 'Failed to join quiz';
+        // Translate Firestore `permission-denied` into a student-friendly
+        // message. The raw FirebaseError says "Missing or insufficient
+        // permissions" which reads to a student like the page is broken
+        // rather than "you can't do this" — so the click feels silent.
+        //
+        // Anonymous joiners hit permission-denied in one realistic shape:
+        // the deterministic-key collision path where another anon UID
+        // already wrote a response at the same `pin-{period}-{pin}` key.
+        // The class gate doesn't apply to anon (anon tokens lack the
+        // studentRole claim, so passesStudentClassGate short-circuits to
+        // true), so this is the only common cause.
+        //
+        // Non-anonymous joiners (custom-token studentRole users from
+        // /my-assignments) hit permission-denied when the session targets
+        // a class their `classIds` claim doesn't include — the response
+        // create rule's class gate denies. Surface that as an enrollment
+        // hint so the student knows to ping the teacher rather than think
+        // the link is broken.
+        //
+        // Other failures (network, code-not-found, attempt-limit) keep
+        // their existing messages — `AttemptLimitReachedError` already
+        // ships a friendly "ask your teacher" message of its own.
+        let msg: string;
+        if (
+          getErrorCode(err) === 'permission-denied' &&
+          auth.currentUser?.isAnonymous
+        ) {
+          msg =
+            "Looks like that PIN has already joined this quiz. Ask your teacher to clear it for you, or double-check that you've selected the right class period.";
+        } else if (getErrorCode(err) === 'permission-denied') {
+          msg =
+            "You can't join this quiz. Ask your teacher to make sure you're enrolled in the right class.";
+        } else if (err instanceof Error) {
+          msg = err.message;
+        } else {
+          msg = 'Failed to join quiz';
+        }
         setError(msg);
         throw err;
       } finally {


### PR DESCRIPTION
This pull request enhances error handling and diagnostics in the `useQuizSessionStudent` hook by introducing structured logging for Firestore permission errors. The main goal is to make it easier to diagnose which Firestore operation failed during the quiz join process and to provide clearer, student-friendly error messages when permission issues occur. The changes also ensure that all Firestore operations in the join flow emit detailed breadcrumbs before re-throwing, improving observability without altering control flow.

**Error handling and diagnostics improvements:**

* Added a new helper function `logQuizJoinFirestoreError` that logs detailed context when a Firestore operation fails with a `permission-denied` error, then re-throws the error to preserve existing control flow. This function attaches operation names and relevant request context to the log for easier debugging.
* Wrapped all relevant Firestore operations (`lookup-sessions`, `update-reset-completed`, `update-backfill-period`, `create-response`, `update-backfill-classid`) in the join flow with `.catch()` blocks that invoke `logQuizJoinFirestoreError`, ensuring consistent diagnostic logging for each operation. [[1]](diffhunk://#diff-c3df9b2601aa95b7241a4e7891e3e652338904d1cf5594edded74f51a30ee13dR874-R879) [[2]](diffhunk://#diff-c3df9b2601aa95b7241a4e7891e3e652338904d1cf5594edded74f51a30ee13dL934-R991) [[3]](diffhunk://#diff-c3df9b2601aa95b7241a4e7891e3e652338904d1cf5594edded74f51a30ee13dL1014-R1142)

**User-facing error message improvements:**

* Improved error messaging for students by translating Firestore `permission-denied` errors into actionable, friendly messages. Anonymous users now see a message about PIN collisions, while authenticated students are prompted to check their class enrollment with their teacher. Other errors retain their existing handling.