### PR TITLE
Address Copilot review comments on PR #1466

### DIFF
--- a/components/widgets/MiniApp/Widget.tsx
+++ b/components/widgets/MiniApp/Widget.tsx
@@ -1036,10 +1036,10 @@ export const MiniAppWidget: React.FC<WidgetComponentProps> = ({
                 onEndSession={handleEndSessionFromModal}
               />
             )}
-            {/* Save-as-Widget modal */}
-            {!isStudentView && activeApp && (
+            {/* Save-as-Widget modal — conditional render so each open is a
+                fresh mount with state derived from `activeApp.title`. */}
+            {!isStudentView && activeApp && showSaveAsWidget && (
               <SaveAsWidgetModal
-                isOpen={showSaveAsWidget}
                 defaultTitle={activeApp.title}
                 isSaving={isSavingAsWidget}
                 onSave={(values) => void handleSaveAsWidget(values)}

--- a/components/widgets/MiniApp/components/SaveAsWidgetModal.tsx
+++ b/components/widgets/MiniApp/components/SaveAsWidgetModal.tsx
@@ -21,7 +21,6 @@ const COLOR_PRESETS: ReadonlyArray<{ label: string; value: string }> = [
 ];
 
 interface SaveAsWidgetModalProps {
-  isOpen: boolean;
   defaultTitle: string;
   isSaving?: boolean;
   onSave: (values: { title: string; icon: string; color: string }) => void;
@@ -29,30 +28,17 @@ interface SaveAsWidgetModalProps {
 }
 
 export const SaveAsWidgetModal: React.FC<SaveAsWidgetModalProps> = ({
-  isOpen,
   defaultTitle,
   isSaving = false,
   onSave,
   onClose,
 }) => {
+  // Parent renders this modal conditionally on `showSaveAsWidget`, so each
+  // open is a fresh mount and useState initializers naturally re-derive from
+  // the current `defaultTitle` without any reset effect or setState-in-render.
   const [title, setTitle] = useState(defaultTitle);
   const [icon, setIcon] = useState(CUSTOM_WIDGET_ICON_OPTIONS[0].key);
   const [color, setColor] = useState(COLOR_PRESETS[0].value);
-
-  // Reset form fields when the modal transitions from closed → open. Tracking
-  // the previous `isOpen` in state and adjusting during render avoids the
-  // cascading-render pitfall of doing this in a useEffect.
-  const [wasOpen, setWasOpen] = useState(isOpen);
-  if (isOpen !== wasOpen) {
-    setWasOpen(isOpen);
-    if (isOpen) {
-      setTitle(defaultTitle);
-      setIcon(CUSTOM_WIDGET_ICON_OPTIONS[0].key);
-      setColor(COLOR_PRESETS[0].value);
-    }
-  }
-
-  if (!isOpen) return null;
 
   const trimmed = title.trim();
   const canSave = trimmed.length > 0 && !isSaving;

--- a/components/widgets/Stations/components/IconOrImageInput.tsx
+++ b/components/widgets/Stations/components/IconOrImageInput.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import * as Icons from 'lucide-react';
 import { Image as ImageIcon, Upload, Loader2, Trash2, X } from 'lucide-react';
 import { COMMON_INSTRUCTIONAL_ICONS } from '@/config/instructionalIcons';
@@ -47,52 +47,55 @@ export const IconOrImageInput: React.FC<IconOrImageInputProps> = ({
       )
     : ICON_LIST;
 
-  const handleUpload = async (file: File) => {
-    if (inFlightRef.current) {
-      addToast('An upload is already in progress.', 'info');
-      return;
-    }
-    if (!user) {
-      addToast('Sign in to upload images.', 'error');
-      return;
-    }
-    if (!file.type.startsWith('image/')) {
-      addToast('Please choose an image file.', 'error');
-      return;
-    }
-    if (file.size > MAX_BYTES) {
-      addToast('Image too large. 5 MB maximum.', 'error');
-      return;
-    }
-    const previousUrl = imageUrl;
-    inFlightRef.current = true;
-    setUploading(true);
-    try {
-      const url = await uploadSticker(user.uid, file);
-      // Commit the new URL FIRST so a failed delete cannot orphan us with no image.
-      onChange({ iconName: undefined, imageUrl: url });
-      // Best-effort cleanup of the old image once the new one is in place.
-      if (previousUrl) {
-        try {
-          await deleteFile(previousUrl);
-        } catch (deleteErr) {
-          // Non-fatal — log and move on; teacher can clean up manually if needed.
-          console.warn(
-            '[StationsIconOrImageInput] Failed to delete previous image; the file may now be orphaned in Drive/Storage.',
-            deleteErr
-          );
-        }
+  const handleUpload = useCallback(
+    async (file: File) => {
+      if (inFlightRef.current) {
+        addToast('An upload is already in progress.', 'info');
+        return;
       }
-      addToast('Image uploaded.', 'success');
-    } catch (err) {
-      console.error('[StationsIconOrImageInput] Upload failed', err);
-      addToast('Failed to upload image.', 'error');
-    } finally {
-      inFlightRef.current = false;
-      setUploading(false);
-      if (fileInputRef.current) fileInputRef.current.value = '';
-    }
-  };
+      if (!user) {
+        addToast('Sign in to upload images.', 'error');
+        return;
+      }
+      if (!file.type.startsWith('image/')) {
+        addToast('Please choose an image file.', 'error');
+        return;
+      }
+      if (file.size > MAX_BYTES) {
+        addToast('Image too large. 5 MB maximum.', 'error');
+        return;
+      }
+      const previousUrl = imageUrl;
+      inFlightRef.current = true;
+      setUploading(true);
+      try {
+        const url = await uploadSticker(user.uid, file);
+        // Commit the new URL FIRST so a failed delete cannot orphan us with no image.
+        onChange({ iconName: undefined, imageUrl: url });
+        // Best-effort cleanup of the old image once the new one is in place.
+        if (previousUrl) {
+          try {
+            await deleteFile(previousUrl);
+          } catch (deleteErr) {
+            // Non-fatal — log and move on; teacher can clean up manually if needed.
+            console.warn(
+              '[StationsIconOrImageInput] Failed to delete previous image; the file may now be orphaned in Drive/Storage.',
+              deleteErr
+            );
+          }
+        }
+        addToast('Image uploaded.', 'success');
+      } catch (err) {
+        console.error('[StationsIconOrImageInput] Upload failed', err);
+        addToast('Failed to upload image.', 'error');
+      } finally {
+        inFlightRef.current = false;
+        setUploading(false);
+        if (fileInputRef.current) fileInputRef.current.value = '';
+      }
+    },
+    [user, addToast, uploadSticker, deleteFile, onChange, imageUrl]
+  );
 
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
@@ -151,9 +154,7 @@ export const IconOrImageInput: React.FC<IconOrImageInputProps> = ({
     };
     document.addEventListener('paste', onPaste);
     return () => document.removeEventListener('paste', onPaste);
-    // handleUpload is stable enough — dependency is intentionally minimal.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [tab, imageUrl]);
+  }, [tab, handleUpload]);
 
   return (
     <div ref={containerRef} className="space-y-2">

--- a/components/widgets/Stations/components/StationCard.tsx
+++ b/components/widgets/Stations/components/StationCard.tsx
@@ -60,10 +60,13 @@ export const StationCard: React.FC<StationCardProps> = ({
   // oversized `data:` payloads). If the URL fails the check, fall back to
   // icon mode so the card still renders cleanly.
   const hasImage = trimmedImageUrl ? isSafeIconUrl(trimmedImageUrl) : false;
-  // Use `||` (not `??`) so an empty trimmed string also falls back to the
-  // default — `??` would keep `''` and break the lucide lookup.
-  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-  const iconName = station.iconName?.trim() || 'LayoutGrid';
+  // Empty-string after trim must also fall back to the default — `??` alone
+  // would keep `''` and break the lucide lookup, so explicitly gate on length.
+  const trimmedIconName = station.iconName?.trim();
+  const iconName =
+    trimmedIconName != null && trimmedIconName.length > 0
+      ? trimmedIconName
+      : 'LayoutGrid';
   // Chip column overlay — an internal readability layer (not a user-visible
   // "card surface"). It uses `cardColor` and is deliberately bumped above
   // `cardOpacity` so chip text stays legible even when the accent tint behind


### PR DESCRIPTION
## Summary

Addresses the 3 Copilot review comments on [#1466](https://github.com/OPS-PIvers/SpartBoard/pull/1466) without changing behavior:

- **IconOrImageInput.tsx** — wrap `handleUpload` in `useCallback` with full deps and include it in the paste-effect deps; drop the `react-hooks/exhaustive-deps` suppression.
- **SaveAsWidgetModal.tsx** — remove the `wasOpen`/setState-in-render reset hack and the `isOpen` prop; parent now conditionally renders the modal so each open is a fresh mount, naturally re-deriving initial state from `defaultTitle`.
- **StationCard.tsx** — replace `||` + `eslint-disable @typescript-eslint/prefer-nullish-coalescing` with an explicit `!= null && length > 0` check on the trimmed icon name.

Targets `dev-paul` so PR #1466 (`dev-paul → main`) auto-picks up these fixes.

## Test plan

- [x] `pnpm run type-check` — clean
- [x] `pnpm run lint` (max-warnings 0) — clean
- [x] `pnpm run format:check` — clean
- [x] `pnpm run test` — 1677/1677 tests pass
- [ ] Visual smoke on preview URL: open Stations widget → upload an image, paste an image, swap to icon mode → verify behavior unchanged
- [ ] Visual smoke on preview URL: in MiniApp, click Save as Widget → close → reopen → confirm fields reset to current app title each time

🤖 Generated with [Claude Code](https://claude.com/claude-code)