### PR TITLE
chore(pr1466-cleanup): refactor effect-based ref reset, setState deferral, and Drive error classification

### DIFF
--- a/components/widgets/QuizWidget/components/QuizLiveMonitor.tsx
+++ b/components/widgets/QuizWidget/components/QuizLiveMonitor.tsx
@@ -445,10 +445,16 @@ export const QuizLiveMonitor: React.FC<QuizLiveMonitorProps> = ({
   const lastLeaderboardFingerprintRef = useRef<string | null>(null);
   const hasClearedLeaderboardRef = useRef(false);
 
-  useEffect(() => {
+  // Reset leaderboard tracking refs when the session id changes. Done during
+  // render via the "adjusting state while rendering" pattern (see React docs)
+  // instead of an effect — useEffect is reserved for syncing with external
+  // systems, and ref assignment is purely local.
+  const [prevSessionId, setPrevSessionId] = useState(session.id);
+  if (prevSessionId !== session.id) {
+    setPrevSessionId(session.id);
     lastLeaderboardFingerprintRef.current = null;
     hasClearedLeaderboardRef.current = false;
-  }, [session.id]);
+  }
 
   // Broadcast student-safe live leaderboard snapshot for gamified sessions.
   useEffect(() => {

--- a/context/SavedWidgetsContext.tsx
+++ b/context/SavedWidgetsContext.tsx
@@ -20,20 +20,25 @@ export const SavedWidgetsProvider: React.FC<{ children: React.ReactNode }> = ({
   children,
 }) => {
   const { user } = useAuth();
+  // Whether a Firestore listener should be active for the current user.
+  // When false (signed out, Firebase not configured, or auth-bypass test
+  // mode), we don't subscribe and the state stays at its empty defaults.
+  const shouldSubscribe = Boolean(user) && isConfigured && !isAuthBypass;
   const [savedWidgets, setSavedWidgets] = useState<SavedWidget[]>([]);
-  const [loading, setLoading] = useState(true);
+  const [loading, setLoading] = useState(shouldSubscribe);
+
+  // Reset state during render when the user changes (signs in/out). Adjusting
+  // state while rendering avoids the setState-in-effect cascade that the old
+  // setTimeout(..., 0) workaround was papering over.
+  const [prevUid, setPrevUid] = useState(user?.uid);
+  if (prevUid !== user?.uid) {
+    setPrevUid(user?.uid);
+    setSavedWidgets([]);
+    setLoading(shouldSubscribe);
+  }
 
   useEffect(() => {
-    if (!user || !isConfigured || isAuthBypass) {
-      // Defer to a microtask so the initial render commits before the state
-      // resets — calling setState synchronously inside an effect causes
-      // cascading renders flagged by react-hooks/set-state-in-effect.
-      const timer = setTimeout(() => {
-        setSavedWidgets([]);
-        setLoading(false);
-      }, 0);
-      return () => clearTimeout(timer);
-    }
+    if (!shouldSubscribe || !user) return;
 
     const ref = collection(db, 'users', user.uid, 'saved_widgets');
     const q = query(ref, orderBy('createdAt', 'asc'));
@@ -54,7 +59,7 @@ export const SavedWidgetsProvider: React.FC<{ children: React.ReactNode }> = ({
     );
 
     return unsub;
-  }, [user]);
+  }, [user, shouldSubscribe]);
 
   const saveSavedWidget = useCallback(
     async (

--- a/tests/utils/driveAuthErrors.test.ts
+++ b/tests/utils/driveAuthErrors.test.ts
@@ -5,6 +5,7 @@ import {
   setDriveAuthErrorHandler,
   onDriveTokenChange,
   authError,
+  DriveAuthError,
   __resetDriveAuthErrorsForTests,
 } from '@/utils/driveAuthErrors';
 
@@ -14,6 +15,15 @@ describe('driveAuthErrors', () => {
   });
 
   describe('isDriveAuthError', () => {
+    it('matches a DriveAuthError instance regardless of message content', () => {
+      // The `instanceof` branch is the preferred classification path —
+      // tests should pass even when the message contains nothing
+      // auth-related.
+      expect(isDriveAuthError(new DriveAuthError('anything at all'))).toBe(
+        true
+      );
+    });
+
     it('matches the explicit "Google Drive access expired" message', () => {
       expect(
         isDriveAuthError(
@@ -131,22 +141,23 @@ describe('driveAuthErrors', () => {
   });
 
   describe('authError', () => {
-    it('returns an Error and reports it through the auth surface', () => {
+    it('returns a DriveAuthError and reports it through the auth surface', () => {
       const handler = vi.fn();
       setDriveAuthErrorHandler(handler);
       const err = authError(
         'Google Drive access expired. Please sign in again.'
       );
+      expect(err).toBeInstanceOf(DriveAuthError);
       expect(err).toBeInstanceOf(Error);
       expect(err.message).toContain('access expired');
       expect(handler).toHaveBeenCalledTimes(1);
     });
 
-    it('still constructs an Error when no handler is registered', () => {
+    it('still constructs a DriveAuthError when no handler is registered', () => {
       const err = authError(
         'Google Drive access expired. Please sign in again.'
       );
-      expect(err).toBeInstanceOf(Error);
+      expect(err).toBeInstanceOf(DriveAuthError);
     });
   });
 });

--- a/utils/driveAuthErrors.ts
+++ b/utils/driveAuthErrors.ts
@@ -27,22 +27,45 @@
  */
 
 /**
+ * Marker subclass for errors the Drive/Sheets services throw to indicate
+ * an auth failure. Preferred over message-matching: any error built via
+ * `authError()` is an instance of this class, so `isDriveAuthError` can
+ * classify it without sniffing the message.
+ *
+ * Plain `Error` instances thrown from raw network responses (e.g. fetch
+ * failures that surface "401" / "403" in the message) still fall through
+ * to message-matching below.
+ */
+export class DriveAuthError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'DriveAuthError';
+    // Restore the prototype chain when targeting older transpile targets.
+    Object.setPrototypeOf(this, DriveAuthError.prototype);
+  }
+}
+
+/**
  * True for auth-related Drive failures — i.e. anything we'd surface to the
  * user as "your Drive session went stale, click Reconnect."
  *
- * The services throw plain `Error` instances (no custom subclass), so we
- * have to match on message content. Three signals:
- *  1. The explicit "Google Drive access expired" message thrown when a 401
- *     comes back AND `onTokenExpire` couldn't refresh the token.
- *  2. Any thrown message that embeds the literal HTTP status `401`.
- *  3. Any thrown message that embeds `403` (Drive returns 403 when the
- *     token has been revoked or its scopes were downgraded).
+ * Classification order:
+ *  1. `instanceof DriveAuthError` — set by `authError()` at every Drive /
+ *     Sheets throw site we control. Cheap and unambiguous.
+ *  2. Message-matching fallback for raw errors that bubble up without going
+ *     through `authError()` (e.g. third-party catch-and-rethrow, or older
+ *     code paths still using plain `Error`):
+ *     - The explicit "Google Drive access expired" / "Google Sheets access
+ *       is not granted" messages.
+ *     - HTTP `401` (token expired / unauthorized).
+ *     - HTTP `403` (token revoked / scopes downgraded).
  *
- * Message-matching is brittle, but the alternative is plumbing a custom
- * error class through every throw site and that's a much larger refactor
- * for a fix that's about user-visible surfacing, not error taxonomy.
+ * Message-matching is brittle, which is exactly why the `DriveAuthError`
+ * class exists — code under our control should throw via `authError()` so
+ * the `instanceof` branch handles classification.
  */
 export function isDriveAuthError(err: unknown): boolean {
+  if (err instanceof DriveAuthError) return true;
   if (!(err instanceof Error)) return false;
   const message = err.message;
   if (!message) return false;
@@ -89,15 +112,15 @@ export const reportDriveAuthError = (err: unknown): boolean => {
 };
 
 /**
- * Construct an `Error` and route it through `reportDriveAuthError` before
- * returning it for the caller to throw. Use at every Drive/Sheets throw
- * site that represents an auth failure so the toast surfaces even when
- * the upstream caller swallows or transforms the error.
+ * Construct a `DriveAuthError` and route it through `reportDriveAuthError`
+ * before returning it for the caller to throw. Use at every Drive/Sheets
+ * throw site that represents an auth failure so the toast surfaces even
+ * when the upstream caller swallows or transforms the error.
  *
  * Usage: `throw authError('Google Sheets access is not granted...')`.
  */
-export const authError = (message: string): Error => {
-  const err = new Error(message);
+export const authError = (message: string): DriveAuthError => {
+  const err = new DriveAuthError(message);
   reportDriveAuthError(err);
   return err;
 };


### PR DESCRIPTION
## Summary

Post-merge cleanup for PR #1466 — three nice-to-have refactors flagged in review but not blocking. None change runtime behavior; they're code-quality improvements aligned with the project's React patterns.

### Fixes

- **`QuizLiveMonitor.tsx` — drop the `useEffect`-only-resets-refs pattern.** Two refs (`lastLeaderboardFingerprintRef`, `hasClearedLeaderboardRef`) were being cleared in a `useEffect` keyed on `session.id`. Per `CLAUDE.md` ("useEffect is an escape hatch, not a default"), ref assignment doesn't belong in an effect. Refactored to the **"adjusting state while rendering"** pattern (the same one already used for `lastSessionPeriodsRef` a few lines above), which avoids the extra render pass.

- **`SavedWidgetsContext.tsx` — remove `setTimeout(..., 0)` deferral.** The old code was using a microtask to defer `setSavedWidgets([]) / setLoading(false)` to dodge the `react-hooks/set-state-in-effect` rule when the user signed out. Refactored two ways:
  1. Gate the listener with a `shouldSubscribe` boolean — when there's no user / Firebase isn't configured / auth-bypass is on, no subscribe, no need to reset.
  2. Reset state during render via the `prevUid`/`setPrevUid` pattern when the user identity changes (sign in/out), instead of inside an effect.

- **`utils/driveAuthErrors.ts` — introduce `DriveAuthError` class.** The file's own comment acknowledged that classifying via substring-matching `401`, `403`, and `"Google Drive access expired"` was brittle. Added a `DriveAuthError` subclass; `authError()` now constructs and returns it, so every throw site we control (`googleDriveService.ts`, `quizDriveService.ts`) produces a typed instance. `isDriveAuthError` checks `instanceof DriveAuthError` first, then falls back to message-matching for raw 401/403 errors that bubble up from the Drive API without going through `authError()`. Backwards-compatible: tests that pass plain `new Error('...')` still classify correctly via the fallback path. Added a `DriveAuthError` instance test and updated existing `authError` tests to assert the new return type.

### Verification

All `pnpm run validate` checks pass on this branch:

- `pnpm run type-check` — 0 errors
- `pnpm run lint` — 0 errors, 0 warnings (`--max-warnings 0`)
- `pnpm run format:check` — clean
- `pnpm run test` — 1678 / 1678 tests passing across 175 test files

## Test plan

- [x] Type-check passes
- [x] Lint passes (zero warnings)
- [x] Prettier passes
- [x] Full unit test suite passes (1678 tests)
- [x] Targeted: `tests/utils/driveAuthErrors.test.ts` — 14 tests, including new `DriveAuthError` instance assertion
- [x] Targeted: `tests/components/widgets/QuizLiveMonitor.test.tsx` — 8 tests


---
_Generated by [Claude Code](https://claude.ai/code/session_01KynyVenLDyA4oodoaGfygt)_