### PR TITLE
feat(navigation): replace top-toolbar board picker with bottom-left FAB cluster

### DIFF
--- a/components/layout/BoardNavFab.tsx
+++ b/components/layout/BoardNavFab.tsx
@@ -5,6 +5,8 @@ import {
   useMemo,
   useRef,
   useState,
+  type FC,
+  type KeyboardEvent as ReactKeyboardEvent,
 } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ChevronLeft, ChevronRight, MoreVertical, Star } from 'lucide-react';
@@ -14,7 +16,7 @@ import { useClickOutside } from '@/hooks/useClickOutside';
 const FAB_BASE =
   'w-8 h-8 rounded-full bg-white/10 hover:bg-white/20 border border-white/20 text-white/60 hover:text-white/90 flex items-center justify-center transition-colors backdrop-blur-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue-primary disabled:opacity-40 disabled:cursor-not-allowed';
 
-export const BoardNavFab: React.FC = () => {
+export const BoardNavFab: FC = () => {
   const { t } = useTranslation();
   const { dashboards, activeDashboard, loadDashboard } = useDashboard();
   const [isPickerOpen, setIsPickerOpen] = useState(false);
@@ -36,7 +38,11 @@ export const BoardNavFab: React.FC = () => {
     [setIsPickerOpen]
   );
 
-  useClickOutside(containerRef, () => closePicker(false));
+  const handleClickOutside = useCallback(() => {
+    closePicker(false);
+  }, [closePicker]);
+
+  useClickOutside(containerRef, handleClickOutside);
 
   // Move focus into the menu when it opens; default to the active board.
   useEffect(() => {
@@ -44,6 +50,12 @@ export const BoardNavFab: React.FC = () => {
     const targetIdx = currentIndex >= 0 ? currentIndex : 0;
     itemRefs.current[targetIdx]?.focus();
   }, [isPickerOpen, currentIndex]);
+
+  // Drop trailing ref slots when the dashboard list shrinks so we don't
+  // dispatch focus to detached buttons after a board is deleted.
+  useEffect(() => {
+    itemRefs.current.length = dashboards.length;
+  }, [dashboards.length]);
 
   if (dashboards.length <= 1) return null;
 
@@ -65,7 +77,7 @@ export const BoardNavFab: React.FC = () => {
     itemRefs.current[wrapped]?.focus();
   };
 
-  const handleMenuKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+  const handleMenuKeyDown = (e: ReactKeyboardEvent<HTMLDivElement>) => {
     const focusedIdx = itemRefs.current.findIndex(
       (el) => el === document.activeElement
     );
@@ -134,7 +146,7 @@ export const BoardNavFab: React.FC = () => {
                   loadDashboard(db.id);
                   closePicker();
                 }}
-                className={`w-full flex items-center gap-2 px-3 py-2 text-left text-sm transition-colors focus:outline-none focus:bg-white/15 ${
+                className={`w-full flex items-center gap-2 px-3 py-2 text-left text-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-white/50 ${
                   isActive
                     ? 'bg-brand-blue-primary text-white'
                     : 'text-white/80 hover:bg-white/10'

--- a/components/layout/BoardNavFab.tsx
+++ b/components/layout/BoardNavFab.tsx
@@ -1,4 +1,11 @@
-import React, { useEffect, useMemo, useRef, useState } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import { useTranslation } from 'react-i18next';
 import { ChevronLeft, ChevronRight, MoreVertical, Star } from 'lucide-react';
 import { useDashboard } from '@/context/useDashboard';
@@ -12,22 +19,31 @@ export const BoardNavFab: React.FC = () => {
   const { dashboards, activeDashboard, loadDashboard } = useDashboard();
   const [isPickerOpen, setIsPickerOpen] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const itemRefs = useRef<Array<HTMLButtonElement | null>>([]);
+  const headerId = useId();
 
   const currentIndex = useMemo(() => {
     if (!activeDashboard) return -1;
     return dashboards.findIndex((d) => d.id === activeDashboard.id);
   }, [dashboards, activeDashboard]);
 
-  useClickOutside(containerRef, () => setIsPickerOpen(false));
+  const closePicker = useCallback(
+    (returnFocus = true) => {
+      setIsPickerOpen(false);
+      if (returnFocus) triggerRef.current?.focus();
+    },
+    [setIsPickerOpen]
+  );
 
+  useClickOutside(containerRef, () => closePicker(false));
+
+  // Move focus into the menu when it opens; default to the active board.
   useEffect(() => {
     if (!isPickerOpen) return;
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') setIsPickerOpen(false);
-    };
-    window.addEventListener('keydown', onKey);
-    return () => window.removeEventListener('keydown', onKey);
-  }, [isPickerOpen]);
+    const targetIdx = currentIndex >= 0 ? currentIndex : 0;
+    itemRefs.current[targetIdx]?.focus();
+  }, [isPickerOpen, currentIndex]);
 
   if (dashboards.length <= 1) return null;
 
@@ -43,7 +59,48 @@ export const BoardNavFab: React.FC = () => {
     loadDashboard(dashboards[next].id);
   };
 
+  const focusItem = (idx: number) => {
+    const len = dashboards.length;
+    const wrapped = ((idx % len) + len) % len;
+    itemRefs.current[wrapped]?.focus();
+  };
+
+  const handleMenuKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    const focusedIdx = itemRefs.current.findIndex(
+      (el) => el === document.activeElement
+    );
+    switch (e.key) {
+      case 'Escape':
+        e.preventDefault();
+        closePicker();
+        break;
+      case 'ArrowDown':
+        e.preventDefault();
+        focusItem(focusedIdx < 0 ? 0 : focusedIdx + 1);
+        break;
+      case 'ArrowUp':
+        e.preventDefault();
+        focusItem(focusedIdx < 0 ? dashboards.length - 1 : focusedIdx - 1);
+        break;
+      case 'Home':
+        e.preventDefault();
+        focusItem(0);
+        break;
+      case 'End':
+        e.preventDefault();
+        focusItem(dashboards.length - 1);
+        break;
+      case 'Tab':
+        // Tab takes focus out of the menu — close to keep state consistent.
+        closePicker(false);
+        break;
+    }
+  };
+
   const activeName = activeDashboard?.name ?? '';
+  const boardListLabel = t('boardNav.boardList', {
+    defaultValue: 'All boards',
+  });
 
   return (
     <div
@@ -53,25 +110,31 @@ export const BoardNavFab: React.FC = () => {
     >
       {isPickerOpen && (
         <div
-          role="listbox"
-          aria-label={t('boardNav.boardList', { defaultValue: 'All boards' })}
+          role="menu"
+          aria-labelledby={headerId}
+          onKeyDown={handleMenuKeyDown}
           className="absolute bottom-full left-0 mb-2 w-64 max-h-[60vh] overflow-y-auto rounded-2xl border border-white/20 bg-slate-900/80 backdrop-blur-xl shadow-2xl py-1.5 animate-in fade-in slide-in-from-bottom-2 duration-150"
         >
-          <div className="px-3 py-1.5 text-xxs font-bold uppercase tracking-wider text-white/40">
-            {t('boardNav.boardList', { defaultValue: 'All boards' })}
+          <div
+            id={headerId}
+            className="px-3 py-1.5 text-xxs font-bold uppercase tracking-wider text-white/40"
+          >
+            {boardListLabel}
           </div>
-          {dashboards.map((db) => {
+          {dashboards.map((db, idx) => {
             const isActive = activeDashboard?.id === db.id;
             return (
               <button
                 key={db.id}
-                role="option"
-                aria-selected={isActive}
+                ref={(el) => {
+                  itemRefs.current[idx] = el;
+                }}
+                role="menuitem"
                 onClick={() => {
                   loadDashboard(db.id);
-                  setIsPickerOpen(false);
+                  closePicker();
                 }}
-                className={`w-full flex items-center gap-2 px-3 py-2 text-left text-sm transition-colors ${
+                className={`w-full flex items-center gap-2 px-3 py-2 text-left text-sm transition-colors focus:outline-none focus:bg-white/15 ${
                   isActive
                     ? 'bg-brand-blue-primary text-white'
                     : 'text-white/80 hover:bg-white/10'
@@ -106,12 +169,13 @@ export const BoardNavFab: React.FC = () => {
           <ChevronLeft className="w-4 h-4" />
         </button>
         <button
+          ref={triggerRef}
           type="button"
           onClick={() => setIsPickerOpen((v) => !v)}
           aria-label={t('boardNav.selectBoard', {
             defaultValue: 'Select board',
           })}
-          aria-haspopup="listbox"
+          aria-haspopup="menu"
           aria-expanded={isPickerOpen}
           title={activeName}
           className={FAB_BASE}

--- a/components/layout/BoardNavFab.tsx
+++ b/components/layout/BoardNavFab.tsx
@@ -1,0 +1,133 @@
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { ChevronLeft, ChevronRight, MoreVertical, Star } from 'lucide-react';
+import { useDashboard } from '@/context/useDashboard';
+import { useClickOutside } from '@/hooks/useClickOutside';
+
+const FAB_BASE =
+  'w-8 h-8 rounded-full bg-white/10 hover:bg-white/20 border border-white/20 text-white/60 hover:text-white/90 flex items-center justify-center transition-colors backdrop-blur-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue-primary disabled:opacity-40 disabled:cursor-not-allowed';
+
+export const BoardNavFab: React.FC = () => {
+  const { t } = useTranslation();
+  const { dashboards, activeDashboard, loadDashboard } = useDashboard();
+  const [isPickerOpen, setIsPickerOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const currentIndex = useMemo(() => {
+    if (!activeDashboard) return -1;
+    return dashboards.findIndex((d) => d.id === activeDashboard.id);
+  }, [dashboards, activeDashboard]);
+
+  useClickOutside(containerRef, () => setIsPickerOpen(false));
+
+  useEffect(() => {
+    if (!isPickerOpen) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setIsPickerOpen(false);
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [isPickerOpen]);
+
+  if (dashboards.length <= 1) return null;
+
+  const goPrev = () => {
+    if (currentIndex < 0) return;
+    const next = (currentIndex - 1 + dashboards.length) % dashboards.length;
+    loadDashboard(dashboards[next].id);
+  };
+
+  const goNext = () => {
+    if (currentIndex < 0) return;
+    const next = (currentIndex + 1) % dashboards.length;
+    loadDashboard(dashboards[next].id);
+  };
+
+  const activeName = activeDashboard?.name ?? '';
+
+  return (
+    <div
+      ref={containerRef}
+      data-screenshot="exclude"
+      className="fixed bottom-6 left-4 z-dock"
+    >
+      {isPickerOpen && (
+        <div
+          role="listbox"
+          aria-label={t('boardNav.boardList', { defaultValue: 'All boards' })}
+          className="absolute bottom-full left-0 mb-2 w-64 max-h-[60vh] overflow-y-auto rounded-2xl border border-white/20 bg-slate-900/80 backdrop-blur-xl shadow-2xl py-1.5 animate-in fade-in slide-in-from-bottom-2 duration-150"
+        >
+          <div className="px-3 py-1.5 text-xxs font-bold uppercase tracking-wider text-white/40">
+            {t('boardNav.boardList', { defaultValue: 'All boards' })}
+          </div>
+          {dashboards.map((db) => {
+            const isActive = activeDashboard?.id === db.id;
+            return (
+              <button
+                key={db.id}
+                role="option"
+                aria-selected={isActive}
+                onClick={() => {
+                  loadDashboard(db.id);
+                  setIsPickerOpen(false);
+                }}
+                className={`w-full flex items-center gap-2 px-3 py-2 text-left text-sm transition-colors ${
+                  isActive
+                    ? 'bg-brand-blue-primary text-white'
+                    : 'text-white/80 hover:bg-white/10'
+                }`}
+              >
+                {db.isDefault && (
+                  <Star
+                    className={`w-3.5 h-3.5 flex-shrink-0 ${
+                      isActive
+                        ? 'fill-white text-white'
+                        : 'fill-amber-400 text-amber-400'
+                    }`}
+                  />
+                )}
+                <span className="truncate">{db.name}</span>
+              </button>
+            );
+          })}
+        </div>
+      )}
+
+      <div className="flex items-center gap-1">
+        <button
+          type="button"
+          onClick={goPrev}
+          aria-label={t('boardNav.previous', {
+            defaultValue: 'Previous board',
+          })}
+          title={t('boardNav.previous', { defaultValue: 'Previous board' })}
+          className={FAB_BASE}
+        >
+          <ChevronLeft className="w-4 h-4" />
+        </button>
+        <button
+          type="button"
+          onClick={() => setIsPickerOpen((v) => !v)}
+          aria-label={t('boardNav.selectBoard', {
+            defaultValue: 'Select board',
+          })}
+          aria-haspopup="listbox"
+          aria-expanded={isPickerOpen}
+          title={activeName}
+          className={FAB_BASE}
+        >
+          <MoreVertical className="w-4 h-4" />
+        </button>
+        <button
+          type="button"
+          onClick={goNext}
+          aria-label={t('boardNav.next', { defaultValue: 'Next board' })}
+          title={t('boardNav.next', { defaultValue: 'Next board' })}
+          className={FAB_BASE}
+        >
+          <ChevronRight className="w-4 h-4" />
+        </button>
+      </div>
+    </div>
+  );
+};

--- a/components/layout/DashboardView.tsx
+++ b/components/layout/DashboardView.tsx
@@ -1477,25 +1477,36 @@ export const DashboardView: React.FC = () => {
         </button>
       )}
 
-      {/* Cheat Sheet Help Button */}
-      <button
-        onClick={() => setIsCheatSheetOpen(true)}
-        title={`${t('widgets.cheatSheet.title')} (Ctrl+/)`}
-        className={`fixed z-dock w-8 h-8 rounded-full bg-white/10 hover:bg-white/20 border border-white/20 text-white/60 hover:text-white/90 flex items-center justify-center transition-colors backdrop-blur-sm ${
-          dockPosition === 'right'
-            ? `left-4 ${
-                dashboards.length > 1 && youTubeVideoId
-                  ? 'bottom-[6.5rem]'
-                  : dashboards.length > 1 || youTubeVideoId
-                    ? 'bottom-16'
-                    : 'bottom-6'
-              }`
-            : 'right-4 bottom-6'
-        }`}
-        aria-label={t('widgets.cheatSheet.title')}
-      >
-        <HelpCircle className="w-4 h-4" />
-      </button>
+      {/* Cheat Sheet Help Button.
+          Stacking on the left side (when the dock occupies the right edge):
+          each FAB slot is 32px tall + ~8px gap ≈ 2.5rem. Slot 0 = bottom-6,
+          slot 1 = bottom-16, slot 2 = bottom-[6.5rem]. */}
+      {(() => {
+        const boardNavVisible = dashboards.length > 1;
+        const musicVisible = !!youTubeVideoId;
+        const onLeftSide = dockPosition === 'right';
+        const leftStackSlot =
+          (boardNavVisible ? 1 : 0) + (musicVisible ? 1 : 0);
+        const leftSideBottom =
+          leftStackSlot >= 2
+            ? 'bottom-[6.5rem]'
+            : leftStackSlot === 1
+              ? 'bottom-16'
+              : 'bottom-6';
+        const positionClass = onLeftSide
+          ? `left-4 ${leftSideBottom}`
+          : 'right-4 bottom-6';
+        return (
+          <button
+            onClick={() => setIsCheatSheetOpen(true)}
+            title={`${t('widgets.cheatSheet.title')} (Ctrl+/)`}
+            className={`fixed z-dock w-8 h-8 rounded-full bg-white/10 hover:bg-white/20 border border-white/20 text-white/60 hover:text-white/90 flex items-center justify-center transition-colors backdrop-blur-sm ${positionClass}`}
+            aria-label={t('widgets.cheatSheet.title')}
+          >
+            <HelpCircle className="w-4 h-4" />
+          </button>
+        );
+      })()}
 
       <CheatSheetModal
         isOpen={isCheatSheetOpen}

--- a/components/layout/DashboardView.tsx
+++ b/components/layout/DashboardView.tsx
@@ -18,6 +18,7 @@ import { useStorage, MAX_PDF_SIZE_BYTES } from '@/hooks/useStorage';
 import { Sidebar } from './sidebar/Sidebar';
 import { Dock } from './Dock';
 import { AnnotationOverlay } from './AnnotationOverlay';
+import { BoardNavFab } from './BoardNavFab';
 import { WidgetRenderer } from '@/components/widgets/WidgetRenderer';
 import { GroupBoundingBox } from '@/components/common/GroupBoundingBox';
 import { AnnouncementOverlay } from '@/components/announcements/AnnouncementOverlay';
@@ -1434,6 +1435,9 @@ export const DashboardView: React.FC = () => {
           document.body
         )}
 
+      {/* Board Navigation FAB cluster (bottom-left) */}
+      <BoardNavFab />
+
       {/* Background YouTube Mute Toggle */}
       {youTubeVideoId && (
         <button
@@ -1446,8 +1450,8 @@ export const DashboardView: React.FC = () => {
               ? 'Enable background video sound'
               : 'Mute background video'
           }
-          className={`fixed bottom-6 z-dock w-8 h-8 rounded-full bg-white/10 hover:bg-white/20 border border-white/20 text-white/60 hover:text-white/90 flex items-center justify-center transition-colors backdrop-blur-sm ${
-            dockPosition === 'left' ? 'right-14' : 'left-4'
+          className={`fixed left-4 z-dock w-8 h-8 rounded-full bg-white/10 hover:bg-white/20 border border-white/20 text-white/60 hover:text-white/90 flex items-center justify-center transition-colors backdrop-blur-sm ${
+            dashboards.length > 1 ? 'bottom-16' : 'bottom-6'
           }`}
           aria-label="Toggle background video sound"
         >
@@ -1477,8 +1481,16 @@ export const DashboardView: React.FC = () => {
       <button
         onClick={() => setIsCheatSheetOpen(true)}
         title={`${t('widgets.cheatSheet.title')} (Ctrl+/)`}
-        className={`fixed bottom-6 z-dock w-8 h-8 rounded-full bg-white/10 hover:bg-white/20 border border-white/20 text-white/60 hover:text-white/90 flex items-center justify-center transition-colors backdrop-blur-sm ${
-          dockPosition === 'right' ? 'left-14' : 'right-4'
+        className={`fixed z-dock w-8 h-8 rounded-full bg-white/10 hover:bg-white/20 border border-white/20 text-white/60 hover:text-white/90 flex items-center justify-center transition-colors backdrop-blur-sm ${
+          dockPosition === 'right'
+            ? `left-4 ${
+                dashboards.length > 1 && youTubeVideoId
+                  ? 'bottom-[6.5rem]'
+                  : dashboards.length > 1 || youTubeVideoId
+                    ? 'bottom-16'
+                    : 'bottom-6'
+              }`
+            : 'right-4 bottom-6'
         }`}
         aria-label={t('widgets.cheatSheet.title')}
       >

--- a/components/layout/sidebar/Sidebar.tsx
+++ b/components/layout/sidebar/Sidebar.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useEffect } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDialog } from '@/context/useDialog';
 import {
@@ -10,7 +10,6 @@ import {
   Paintbrush,
   SquareSquare,
   ChevronRight,
-  Star,
   Maximize,
   Minimize,
   ArrowLeft,
@@ -105,7 +104,6 @@ export const Sidebar: React.FC = () => {
     dashboards,
     activeDashboard,
     isSaving,
-    loadDashboard,
     clearAllWidgets,
     setGlobalStyle,
     addToast,
@@ -169,56 +167,11 @@ export const Sidebar: React.FC = () => {
     };
   }, []);
 
-  const [isBoardSwitcherExpanded, setIsBoardSwitcherExpanded] = useState(false);
-  const [canScrollRight, setCanScrollRight] = useState(false);
-  const scrollContainerRef = useRef<HTMLDivElement>(null);
-  const toolbarRef = useRef<HTMLDivElement>(null);
-
-  const checkScroll = () => {
-    if (scrollContainerRef.current) {
-      const { scrollLeft, scrollWidth, clientWidth } =
-        scrollContainerRef.current;
-      setCanScrollRight(scrollLeft + clientWidth < scrollWidth - 5);
-    }
-  };
-
-  useEffect(() => {
-    if (isBoardSwitcherExpanded) {
-      // Small delay to allow transition to finish
-      const timer = setTimeout(checkScroll, 500);
-      return () => {
-        clearTimeout(timer);
-      };
-    }
-    return undefined;
-  }, [isBoardSwitcherExpanded, dashboards]);
-
-  useEffect(() => {
-    const handleClickOutside = (event: MouseEvent | TouchEvent) => {
-      if (
-        isBoardSwitcherExpanded &&
-        toolbarRef.current &&
-        !toolbarRef.current.contains(event.target as Node)
-      ) {
-        setIsBoardSwitcherExpanded(false);
-      }
-    };
-
-    document.addEventListener('mousedown', handleClickOutside);
-    document.addEventListener('touchstart', handleClickOutside);
-
-    return () => {
-      document.removeEventListener('mousedown', handleClickOutside);
-      document.removeEventListener('touchstart', handleClickOutside);
-    };
-  }, [isBoardSwitcherExpanded]);
-
   const [showAdminSettings, setShowAdminSettings] = useState(false);
 
   return (
     <>
       <GlassCard
-        ref={toolbarRef}
         globalStyle={activeDashboard?.globalStyle}
         data-screenshot="exclude"
         className="fixed z-dock flex items-center gap-2 p-2 rounded-full"
@@ -283,73 +236,6 @@ export const Sidebar: React.FC = () => {
           variant="brand-danger-ghost"
           size="md"
         />
-
-        <IconButton
-          onClick={() => setIsBoardSwitcherExpanded(!isBoardSwitcherExpanded)}
-          icon={<ChevronRight className="w-5 h-5" />}
-          label={
-            isBoardSwitcherExpanded
-              ? t('sidebar.header.hideBoards')
-              : t('sidebar.header.switchBoards')
-          }
-          variant={isBoardSwitcherExpanded ? 'primary' : 'brand-ghost'}
-          size="md"
-          className={`[&>svg]:transition-transform [&>svg]:duration-500 ${
-            isBoardSwitcherExpanded ? '[&>svg]:rotate-180' : '[&>svg]:rotate-0'
-          }`}
-        />
-
-        {/* Board Switcher Sliding Toggle Bar */}
-        <div
-          className={`overflow-hidden transition-[max-width,opacity] duration-500 ease-in-out flex items-center gap-1 ${
-            isBoardSwitcherExpanded
-              ? 'max-w-[80vw] ml-2 opacity-100'
-              : 'max-w-0 ml-0 opacity-0'
-          }`}
-        >
-          <div className="h-6 w-px bg-slate-200 mx-1 flex-shrink-0" />
-          <div className="relative flex items-center min-w-0">
-            <div
-              ref={scrollContainerRef}
-              onScroll={checkScroll}
-              className="flex bg-slate-100/80 p-1 rounded-full border border-slate-200/50 backdrop-blur-sm overflow-x-auto no-scrollbar scroll-smooth"
-            >
-              <div className="flex gap-1">
-                {dashboards.map((db) => (
-                  <button
-                    key={db.id}
-                    onClick={() => {
-                      loadDashboard(db.id);
-                    }}
-                    className={`px-4 py-1.5 rounded-full text-xs font-bold uppercase tracking-wider transition-[color,background-color,box-shadow] flex items-center gap-2 whitespace-nowrap ${
-                      activeDashboard?.id === db.id
-                        ? 'bg-brand-blue-primary text-white shadow-md'
-                        : 'text-slate-500 hover:bg-slate-200/50'
-                    }`}
-                  >
-                    {db.isDefault && (
-                      <Star
-                        className={`w-3 h-3 ${
-                          activeDashboard?.id === db.id
-                            ? 'fill-white text-white'
-                            : 'fill-amber-400 text-amber-400'
-                        }`}
-                      />
-                    )}
-                    {db.name}
-                  </button>
-                ))}
-              </div>
-            </div>
-            {canScrollRight && (
-              <div className="absolute right-0 top-0 bottom-0 flex items-center pr-1 pointer-events-none">
-                <div className="bg-gradient-to-l from-slate-100 to-transparent w-8 h-full rounded-r-full flex items-center justify-end">
-                  <ChevronRight className="w-3 h-3 text-slate-400 animate-pulse mr-1" />
-                </div>
-              </div>
-            )}
-          </div>
-        </div>
       </GlassCard>
 
       {showAdminSettings && (

--- a/locales/de.json
+++ b/locales/de.json
@@ -14,6 +14,12 @@
     "upload": "Hochladen",
     "clearAll": "Alles löschen"
   },
+  "boardNav": {
+    "previous": "Vorherige Tafel",
+    "next": "Nächste Tafel",
+    "selectBoard": "Tafel auswählen",
+    "boardList": "Alle Tafeln"
+  },
   "sidebar": {
     "header": {
       "classroomManager": "SpartBoard",
@@ -321,7 +327,7 @@
     },
     "dashboard": {
       "emptyBoardHint": "Ziehen Sie Werkzeuge aus dem Dock unten, um zu beginnen",
-      "switchBoardsHint": "Tafelwechsel über die Tafelauswahl in der oberen Symbolleiste"
+      "switchBoardsHint": "Verwenden Sie die Tafelnavigation unten links, um zwischen Tafeln zu wechseln"
     }
   }
 }

--- a/locales/en.json
+++ b/locales/en.json
@@ -17,6 +17,12 @@
     "error": "Error",
     "clearAll": "Clear All"
   },
+  "boardNav": {
+    "previous": "Previous board",
+    "next": "Next board",
+    "selectBoard": "Select board",
+    "boardList": "All boards"
+  },
   "sidebar": {
     "header": {
       "classroomManager": "SpartBoard",
@@ -562,7 +568,7 @@
     },
     "dashboard": {
       "emptyBoardHint": "Drag tools from the Dock below to start",
-      "switchBoardsHint": "Use the board switcher in the top toolbar to switch boards"
+      "switchBoardsHint": "Use the board navigation controls in the bottom-left to switch boards"
     }
   },
   "admin": {

--- a/locales/es.json
+++ b/locales/es.json
@@ -14,6 +14,12 @@
     "upload": "Subir",
     "clearAll": "Borrar Todo"
   },
+  "boardNav": {
+    "previous": "Tablero anterior",
+    "next": "Tablero siguiente",
+    "selectBoard": "Seleccionar tablero",
+    "boardList": "Todos los tableros"
+  },
   "sidebar": {
     "header": {
       "classroomManager": "SpartBoard",
@@ -440,7 +446,7 @@
     },
     "dashboard": {
       "emptyBoardHint": "Arrastra herramientas desde el Dock para empezar",
-      "switchBoardsHint": "Usa el selector de tableros en la barra de herramientas superior"
+      "switchBoardsHint": "Usa los controles de navegación en la parte inferior izquierda para cambiar de tablero"
     }
   }
 }

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -14,6 +14,12 @@
     "upload": "Télécharger",
     "clearAll": "Tout effacer"
   },
+  "boardNav": {
+    "previous": "Tableau précédent",
+    "next": "Tableau suivant",
+    "selectBoard": "Sélectionner un tableau",
+    "boardList": "Tous les tableaux"
+  },
   "sidebar": {
     "header": {
       "classroomManager": "SpartBoard",
@@ -321,7 +327,7 @@
     },
     "dashboard": {
       "emptyBoardHint": "Faites glisser des outils depuis le Dock ci-dessous pour commencer",
-      "switchBoardsHint": "Utilisez le sélecteur de tableau dans la barre d'outils supérieure"
+      "switchBoardsHint": "Utilisez les commandes de navigation en bas à gauche pour changer de tableau"
     }
   }
 }


### PR DESCRIPTION
## Summary
- Removes the chevron-expanded pill picker from the top floating toolbar
- Adds a 3-button FAB cluster in the bottom-left: `[ ◀ ] [ ⋮ ] [ ▶ ]` styled to match the existing help and background-music FABs
- Prev/next wrap around the dashboard list (matches existing Alt+←/→ behavior)
- The kebab opens a glass-styled popover above the cluster with the full board list — supports keyboard nav (Escape closes), click-outside to dismiss, ⭐ for default board, active row highlighted
- Cluster auto-hides when there is only one board
- Music/help FABs now stack on top of the nav cluster on the left side when they would otherwise overlap (e.g., right-side dock or video background)
- Updates the `switchBoardsHint` empty-state copy in all four locales (en/de/es/fr) and adds new `boardNav.*` keys

## Files
- `components/layout/BoardNavFab.tsx` (new) — cluster + popover
- `components/layout/DashboardView.tsx` — mounts `BoardNavFab`, adjusts music & help FAB stacking
- `components/layout/sidebar/Sidebar.tsx` — removes the chevron + horizontal pill bar and the now-orphaned state/refs/effects (`isBoardSwitcherExpanded`, `scrollContainerRef`, `toolbarRef`, `canScrollRight`, `checkScroll`)
- `locales/{en,de,es,fr}.json` — adds `boardNav.*` keys, updates `switchBoardsHint` copy

## Test plan
- [ ] Multi-board dashboard: click ◀ / ▶ to cycle; verify slide animation triggers in correct direction
- [ ] Cycling wraps at both ends
- [ ] Kebab opens popover above cluster; correct active row highlighted; ⭐ shows for default board
- [ ] Click-outside and Escape both close the popover
- [ ] Single-board dashboard: cluster does not render
- [ ] Default dock (`bottom`): cluster bottom-left, help bottom-right; with video bg, music stacks above cluster
- [ ] Dock `left`: cluster bottom-left (lives below the vertical dock rail), help bottom-right
- [ ] Dock `right`: cluster bottom-left, help on the left stacked above music+cluster
- [ ] Top toolbar no longer shows the chevron / expanded pill picker
- [ ] Existing Alt+←/→ keyboard shortcut and 2-finger swipe still work
- [ ] Empty-board hint copy reads correctly in all 4 locales

https://claude.ai/code/session_015NhosBSSRhEnvYCUD9nT9q

---
_Generated by [Claude Code](https://claude.ai/code/session_015NhosBSSRhEnvYCUD9nT9q)_