### PR TITLE
refactor(dashboard): extract mergeWidgetConfig + Friday 2026-05-01 audit

### DIFF
--- a/context/DashboardContext.tsx
+++ b/context/DashboardContext.tsx
@@ -25,7 +25,7 @@ import {
   DrawableObject,
 } from '../types';
 import { useAuth } from './useAuth';
-import { stripTransientKeys } from '../utils/widgetConfigPersistence';
+import { mergeWidgetConfig } from '../utils/widgetConfigPersistence';
 import { useFirestore } from '../hooks/useFirestore';
 import { TOOLS } from '../config/tools';
 import { canonicalizeBuildingKeyedRecord } from '@/config/buildings';
@@ -2586,14 +2586,12 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
             version: 1,
             ...defaults,
             ...overrides,
-            // Layer order: widget defaults → admin building defaults → saved global config → explicit overrides
-            config: Object.assign(
-              {},
-              defaults.config ?? {},
+            config: mergeWidgetConfig(
+              defaults.config,
               adminConfig,
-              stripTransientKeys(savedWidgetConfigs?.[type] ?? {}),
-              overrides?.config ?? {}
-            ) as WidgetConfig,
+              savedWidgetConfigs?.[type],
+              overrides?.config
+            ),
           };
           return { ...d, widgets: [...d.widgets, newWidget] };
         })
@@ -2665,14 +2663,12 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
               ? validateGridConfig(item.gridConfig)
               : null;
 
-            // Base config from defaults, admin settings, and global persistence
-            const baseConfig = Object.assign(
-              {},
-              defaults.config ?? {},
+            const baseConfig = mergeWidgetConfig(
+              defaults.config,
               adminConfig,
-              stripTransientKeys(savedWidgetConfigs?.[item.type] ?? {}),
+              savedWidgetConfigs?.[item.type],
               sanitizedInputConfig
-            ) as WidgetConfig;
+            );
 
             const newWidgetId = crypto.randomUUID();
             locallyAddedWidgetIds.current.add(newWidgetId);

--- a/docs/scheduled-tasks/ai-integration.md
+++ b/docs/scheduled-tasks/ai-integration.md
@@ -61,7 +61,7 @@ _Nothing currently in progress._
 - **Detected:** 2026-05-01
 - **File:** functions/src/index.ts (generateWithAI), components/layout/dock/MagicLayoutModal.tsx
 - **Detail:** The `dashboard-layout` generation type has a client-side feature permission gate (`canAccessFeature('magic-layout')` in `MagicLayoutModal.tsx`) but no `specificFeatureId` assignment in the cloud function's rate-limit transaction. This means it shares the global daily `gemini-functions` quota but has no per-feature daily limit or admin-toggleable specific permission. An admin cannot restrict `dashboard-layout` usage independently of the global AI permission. Additionally, if the client-side gate is bypassed (e.g. direct API call), the cloud function will not reject the request based on a `magic-layout` feature check — only the global rate limit applies. This is similar to the existing MEDIUM finding for `instructional-routine`, but lower severity because the client-side gate does exist.
-- **Fix:** Add `if (genType === 'dashboard-layout') specificFeatureId = 'magic-layout';` in the `generateWithAI` cloud function alongside the other `specificFeatureId` assignments. Then add a `magic-layout` entry to `GlobalFeature` in `types.ts` and `GlobalPermissionsManager.tsx` so admins can control it independently.
+- **Fix:** Add `if (genType === 'dashboard-layout') specificFeatureId = 'magic-layout';` in the `generateWithAI` cloud function alongside the other `specificFeatureId` assignments. The `'magic-layout'` feature is already defined in `types.ts` and `components/admin/GlobalPermissionsManager.tsx`, so only the cloud function change is needed to link server-side rate limiting to the existing permission.
 
 ### LOW RevealGrid "Sparkles" button uses AI icon for a paste-import feature
 

--- a/docs/scheduled-tasks/ai-integration.md
+++ b/docs/scheduled-tasks/ai-integration.md
@@ -3,7 +3,7 @@
 _Audit model: claude-sonnet-4-6_
 _Action model: claude-opus-4-6_
 _Audit cadence: weekly — Friday_
-_Last audited: 2026-04-24_
+_Last audited: 2026-05-01_
 _Last action: never_
 
 ---
@@ -55,6 +55,13 @@ _Nothing currently in progress._
 - **File:** functions/src/index.ts:1714 (line number shifts with function additions)
 - **Detail:** The `generateVideoActivity` function selects a model with `perm.config?.model ?? 'gemini-3.1-flash-lite-preview'`. This duplicates the literal string defined by the `DEFAULT_STANDARD_MODEL` constant at line 97. If the default model is updated, this line will not automatically follow.
 - **Fix:** Replace the hardcoded string with `DEFAULT_STANDARD_MODEL`: `perm.config?.model ?? DEFAULT_STANDARD_MODEL`.
+
+### LOW `dashboard-layout` has no server-side per-feature rate limit or specific permission ID
+
+- **Detected:** 2026-05-01
+- **File:** functions/src/index.ts (generateWithAI), components/layout/dock/MagicLayoutModal.tsx
+- **Detail:** The `dashboard-layout` generation type has a client-side feature permission gate (`canAccessFeature('magic-layout')` in `MagicLayoutModal.tsx`) but no `specificFeatureId` assignment in the cloud function's rate-limit transaction. This means it shares the global daily `gemini-functions` quota but has no per-feature daily limit or admin-toggleable specific permission. An admin cannot restrict `dashboard-layout` usage independently of the global AI permission. Additionally, if the client-side gate is bypassed (e.g. direct API call), the cloud function will not reject the request based on a `magic-layout` feature check — only the global rate limit applies. This is similar to the existing MEDIUM finding for `instructional-routine`, but lower severity because the client-side gate does exist.
+- **Fix:** Add `if (genType === 'dashboard-layout') specificFeatureId = 'magic-layout';` in the `generateWithAI` cloud function alongside the other `specificFeatureId` assignments. Then add a `magic-layout` entry to `GlobalFeature` in `types.ts` and `GlobalPermissionsManager.tsx` so admins can control it independently.
 
 ### LOW RevealGrid "Sparkles" button uses AI icon for a paste-import feature
 

--- a/docs/scheduled-tasks/css-scaling.md
+++ b/docs/scheduled-tasks/css-scaling.md
@@ -3,7 +3,7 @@
 _Audit model: claude-sonnet-4-6_
 _Action model: claude-opus-4-6_
 _Audit cadence: daily_
-_Last audited: 2026-04-30_
+_Last audited: 2026-05-01_
 _Last action: 2026-04-25_
 
 ---

--- a/docs/scheduled-tasks/pr-review-log.md
+++ b/docs/scheduled-tasks/pr-review-log.md
@@ -294,3 +294,29 @@ _Automated nightly review by claude-opus-4-6_
   - PR #1414 head SHA `693ebf39` — unchanged since 2026-04-25; 4 files
   - PR #1366 head SHA `af5c4043` — unchanged since 2026-04-28; 1 file (doc-only)
   - Branch-safety: PR #1445 head `dev-paul` matches `dev-*` pattern → no pushes attempted; reply-only on its 2 unresolved comments. The other 3 PRs were eligible for pushes but none required code fixes this run.
+
+## 2026-05-01
+
+- PRs reviewed:
+  - #1470 — refactor(dashboard): extract mergeWidgetConfig + Friday 2026-05-01 audit (head `scheduled-tasks`, base `dev-paul`, DRAFT)
+  - #1469 — feat(navigation): replace top-toolbar board picker with bottom-left FAB cluster (head `claude/redesign-board-navigation-gCWoW`, base `dev-paul`)
+  - #1468 — chore(pr1466-cleanup): refactor effect-based ref reset, setState deferral, and Drive error classification (head `feature/pr1466-cleanup`, base `dev-paul`)
+  - #1366 — docs: plan for repo-wide line-ending normalization (head `docs/line-endings-normalization-plan`, base `main`)
+- Comments processed: 9 total — 4 fixed (PR #1366 doc improvements bundled into one commit), 5 explained
+  - PR #1470: 1 outdated inline thread (gemini-code-assist on `ai-integration.md` wording for the `magic-layout` fix description) — reply-explained, no code change (wording suggestion, comment is outdated, the actual implementation when this finding is acted on will be a single-line `functions/src/index.ts` change)
+  - PR #1469: 10 inline threads — most outdated and addressed in subsequent commits on the branch (role=menu instead of listbox, focus management on open/close, full keyboard handler, useCallback wrapping of click-outside handler, focus-visible rings on menu items, length-truncation cleanup of itemRefs); 2 still-open threads reply-explained pointing at the addressing lines; 1 (gemini high-priority on music FAB opposite-side placement) declined by author with prior rationale, no further action
+  - PR #1468: 2 unresolved inline threads (copilot suggesting `useRef` over `useState` for `prevUid` / `prevSessionId`) — both reply-explained: the `useState`-based "adjusting state while rendering" pattern is React's documented approach (per `CLAUDE.md`) and the synchronous re-render is intentional to avoid one-frame stale-data flashes
+  - PR #1366: 4 issue-level comments from prior review rounds (Step 3 grep case-sensitivity, Steps 3/4 ordering, Step 5 missing `git add` / `git rebase --continue`, Step 4 `--ignore-all-space` over-broad) — all 4 fixed in a single commit on the branch
+- Fixes pushed:
+  - PR #1366 → `docs/line-endings-normalization-plan` branch: commit `da8f094` `docs(pr-1366): apply 4 review fixes to line-endings normalization plan` — Steps 3/4 swapped (verification now precedes squash-hash PR step), `SQUASH_HASH` lookup uses `grep -i` plus an explicit empty-hash hard-fail guard, verify-diff drops `--ignore-all-space` in favor of `--ignore-cr-at-eol` alone, rebase-conflict remediation adds the previously-missing `git add <file>` and `git rebase --continue` calls; format:check clean
+- Reviews posted: 4
+  - PR #1470: Ready — clean extract-method refactor of duplicated four-layer config merge into `mergeWidgetConfig` helper in `utils/widgetConfigPersistence.ts`; both `addWidget` and `addWidgets` delegate to it; 3 new unit tests cover layer ordering, transient-key stripping, all-undefined inputs; touches `DashboardContext.tsx` (regression-risk file) but layer order is preserved byte-for-byte; manual smoke of add-widget + AI-paste flows still unchecked in PR test plan
+  - PR #1469: Ready with minor notes — 209-line new `BoardNavFab.tsx` with strong accessibility (role=menu, aria-labelledby, full keyboard nav, focus management, focus-visible rings), help-FAB stacking refactored from nested ternary to named-variable IIFE, dead board-switcher state/refs/effects removed from `Sidebar.tsx`; missing test coverage for the new component flagged as non-blocking follow-up; deliberate "all FABs on one edge" design choice noted (author already declined the music-FAB-opposite-side alternative)
+  - PR #1468: Ready — three pattern-compliance refactors per `CLAUDE.md`: `prevSessionId`/`prevUid` "adjusting state while rendering" replaces `useEffect`-only-resets-refs, `shouldSubscribe` boolean replaces `setTimeout(..., 0)` deferral, `DriveAuthError` marker class enables `instanceof`-first classification with message-matching fallback preserved; backwards-compatible; 1678 tests pass per PR description
+  - PR #1366: Ready — doc-only, all 4 earlier issue-level comments now addressed in `da8f094`; plan in better shape than at any prior review (operator-friendly step ordering, hard-fail squash-hash capture, accurate verify-diff, complete rebase remediation); execution still gated on "no open PRs" precondition (4 open today, including this PR)
+- Notes:
+  - PR #1470 head SHA `ac945ca1` — 7 files (4 audit docs + `DashboardContext.tsx` + `widgetConfigPersistence.ts` + test file); CI status pending at review time per github status API
+  - PR #1469 head SHA `ad85e87f` — 7 files (1 new component + `DashboardView.tsx` + `Sidebar.tsx` + 4 locales)
+  - PR #1468 head SHA `0cf76282` — 4 files (`QuizLiveMonitor.tsx` + `SavedWidgetsContext.tsx` + `driveAuthErrors.ts` + test file)
+  - PR #1366 head SHA `da8f0946` (was `af5c4043` before this run) — added one commit in this run
+  - Branch-safety: no head branches match `main` or `dev-*`; all 4 PRs eligible for pushes; only PR #1366 received a push this run

--- a/docs/scheduled-tasks/simplification.md
+++ b/docs/scheduled-tasks/simplification.md
@@ -4,7 +4,7 @@ _Audit model: claude-sonnet-4-6_
 _Action model: claude-opus-4-6_
 _Audit cadence: weekly — Friday_
 _Last audited: 2026-05-01_
-_Last action: never_
+_Last action: 2026-05-01_
 
 ---
 
@@ -15,13 +15,6 @@ _Nothing currently in progress._
 ---
 
 ## Open
-
-### MEDIUM Duplicated config layer-merge pattern in DashboardContext — extraction candidate
-
-- **Detected:** 2026-04-17
-- **File:** context/DashboardContext.tsx:2482, :2561 (line numbers shift with each context addition)
-- **Detail:** Two `Object.assign` call sites (one for the widget-open path at line 2464, one for the add-widget path at line 2543) implement an identical four-layer config merge: `defaults.config → adminConfig → savedWidgetConfigs → overrides`. The pattern and argument list are visually identical; only variable names differ. Any change to the merge order or the inclusion of a new layer (e.g. user preferences) must be made in two places.
-- **Fix:** Extract a helper function such as `mergeWidgetConfig(defaults, adminConfig, saved, overrides)` that performs the `Object.assign` and documents the layer order. Call it from both sites. The function is a pure utility — no hook dependencies — and belongs in utils/ or as a module-level function in DashboardContext.tsx.
 
 ### LOW `as unknown as BuildingConfigPanel` repeated throughout FeatureConfigurationPanel
 
@@ -48,4 +41,10 @@ _Nothing currently in progress._
 
 ## Completed
 
-_No completed items yet._
+### MEDIUM Duplicated config layer-merge pattern in DashboardContext — extraction candidate
+
+- **Detected:** 2026-04-17
+- **Completed:** 2026-05-01
+- **File:** context/DashboardContext.tsx (addWidget + addWidgets paths), utils/widgetConfigPersistence.ts
+- **Detail:** Two `Object.assign` call sites (one in `addWidget` for single-widget adds, one in `addWidgets` for batch/AI/paste adds) implemented an identical four-layer config merge: `defaults.config → adminConfig → savedWidgetConfigs → overrides`.
+- **Resolution:** Extracted `mergeWidgetConfig(defaults, adminConfig, saved, overrides)` as a pure helper in `utils/widgetConfigPersistence.ts` next to `stripTransientKeys`. The helper documents the layer order in JSDoc, calls `stripTransientKeys` internally on the saved layer, and tolerates `undefined` for any layer. Both call sites in `DashboardContext.tsx` now delegate to it; the now-redundant `stripTransientKeys` import there was removed (still imported by `AuthContext.tsx` for save-side filtering, which is unchanged). Added three unit tests covering layer ordering, transient-key stripping, and all-undefined inputs. `pnpm type-check`, `pnpm lint --max-warnings 0`, and `pnpm format:check` clean; all 1680 tests pass.

--- a/docs/scheduled-tasks/simplification.md
+++ b/docs/scheduled-tasks/simplification.md
@@ -3,7 +3,7 @@
 _Audit model: claude-sonnet-4-6_
 _Action model: claude-opus-4-6_
 _Audit cadence: weekly — Friday_
-_Last audited: 2026-04-24_
+_Last audited: 2026-05-01_
 _Last action: never_
 
 ---

--- a/docs/scheduled-tasks/typescript-eslint.md
+++ b/docs/scheduled-tasks/typescript-eslint.md
@@ -3,7 +3,7 @@
 _Audit model: claude-sonnet-4-6_
 _Action model: claude-opus-4-6_
 _Audit cadence: daily_
-_Last audited: 2026-04-30_
+_Last audited: 2026-05-01_
 _Last action: never_
 
 ---

--- a/docs/scheduled-tasks/widget-registry.md
+++ b/docs/scheduled-tasks/widget-registry.md
@@ -3,7 +3,7 @@
 _Audit model: claude-sonnet-4-6_
 _Action model: claude-opus-4-6_
 _Audit cadence: daily_
-_Last audited: 2026-04-30_
+_Last audited: 2026-05-01_
 _Last action: 2026-04-26_
 
 ---
@@ -36,6 +36,13 @@ _Nothing currently in progress._
 - **File:** components/widgets/WidgetRegistry.ts
 - **Detail:** `stickers` (StickerBook) has entries in `WIDGET_COMPONENTS`, `WIDGET_APPEARANCE_COMPONENTS`, `WIDGET_SCALING_CONFIG`, `widgetDefaults.ts`, `widgetGradeLevels.ts`, and `tools.ts`, but is absent from `WIDGET_SETTINGS_COMPONENTS`. `stickers/StickerBookSettings.tsx` exports `StickerBookAppearanceSettings` (wired into appearance panel), but there is no flip-panel settings component registered. As a result flipping the stickers widget shows no settings tab — only the appearance tab. May be intentional if stickers has no non-appearance settings, but is undocumented.
 - **Fix:** Either (a) confirm this is intentional and add a JSDoc comment in `WIDGET_SETTINGS_COMPONENTS` noting stickers has appearance-only settings, or (b) create a `StickerBookSettings` component and register it if any non-appearance settings (e.g. lock/reset) are desired.
+
+### LOW `blooms-detail` absent from `config/tools.ts`
+
+- **Detected:** 2026-05-01
+- **File:** config/tools.ts, types.ts
+- **Detail:** `blooms-detail` is in the WidgetType union, registered in `WIDGET_COMPONENTS`, `WIDGET_SCALING_CONFIG`, `widgetDefaults.ts`, and `widgetGradeLevels.ts`, but is absent from `config/tools.ts`. As a programmatically-spawned companion widget (opened by the `blooms-taxonomy` widget), this is likely intentional — but it is not documented anywhere in the file. The two existing LOW items about `catalyst-instruction`/`catalyst-visual` and `mathTool`/`onboarding`/`custom-widget` propose a comment block documenting intentionally excluded types; `blooms-detail` should be included in that block.
+- **Fix:** When addressing the "Add a comment block documenting which WidgetTypes are intentionally excluded" fix in the items above, also add `blooms-detail` to the list with the note that it is a read-only companion widget spawned by `blooms-taxonomy`.
 
 ### LOW `blooms-detail` missing from `WIDGET_SETTINGS_COMPONENTS`
 

--- a/tests/utils/widgetConfigPersistence.test.ts
+++ b/tests/utils/widgetConfigPersistence.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect } from 'vitest';
-import { stripTransientKeys } from '@/utils/widgetConfigPersistence';
+import {
+  mergeWidgetConfig,
+  stripTransientKeys,
+} from '@/utils/widgetConfigPersistence';
 import type { WidgetConfig } from '@/types';
 
 describe('stripTransientKeys', () => {
@@ -126,5 +129,58 @@ describe('stripTransientKeys', () => {
     expect(result).not.toHaveProperty('roster');
     expect(result).not.toHaveProperty('completedNames');
     expect(result).not.toHaveProperty('remainingStudents');
+  });
+});
+
+describe('mergeWidgetConfig', () => {
+  it('layers defaults < admin < saved < overrides (later wins)', () => {
+    const defaults = {
+      fontFamily: 'sans',
+      fontColor: '#000',
+      cardOpacity: 0.5,
+    } as Partial<WidgetConfig>;
+    const adminConfig = { fontColor: '#111', cardColor: '#fff' } as Record<
+      string,
+      unknown
+    >;
+    const saved = { cardOpacity: 0.8 } as Partial<WidgetConfig>;
+    const overrides = { fontColor: '#222' } as Partial<WidgetConfig>;
+
+    const result = mergeWidgetConfig(defaults, adminConfig, saved, overrides);
+
+    expect(result).toEqual({
+      fontFamily: 'sans',
+      fontColor: '#222',
+      cardColor: '#fff',
+      cardOpacity: 0.8,
+    });
+  });
+
+  it('strips transient keys from the saved layer only', () => {
+    const defaults = { isRunning: true } as Partial<WidgetConfig>;
+    const saved = {
+      isRunning: false,
+      content: 'leftover',
+      fontFamily: 'mono',
+    } as Partial<WidgetConfig>;
+    const overrides = { content: 'fresh' } as Partial<WidgetConfig>;
+
+    const result = mergeWidgetConfig(defaults, undefined, saved, overrides);
+
+    expect(result).toEqual({
+      isRunning: true,
+      fontFamily: 'mono',
+      content: 'fresh',
+    });
+  });
+
+  it('treats undefined layers as empty', () => {
+    const result = mergeWidgetConfig(
+      undefined,
+      undefined,
+      undefined,
+      undefined
+    );
+    expect(result).toEqual({});
   });
 });

--- a/utils/widgetConfigPersistence.ts
+++ b/utils/widgetConfigPersistence.ts
@@ -77,3 +77,28 @@ export function stripTransientKeys(
     Object.entries(config).filter(([key]) => !TRANSIENT_CONFIG_KEYS.has(key))
   ) as Partial<WidgetConfig>;
 }
+
+/**
+ * Merges the four widget config layers used when adding a widget to a dashboard.
+ * Later layers override earlier ones (Object.assign semantics).
+ *
+ * Layer order:
+ *   1. defaults     — from WIDGET_DEFAULTS[type].config (baseline)
+ *   2. adminConfig  — from getAdminBuildingConfig (per-building admin defaults)
+ *   3. saved        — from user's savedWidgetConfigs (transient keys are stripped here)
+ *   4. overrides    — explicit per-add overrides (e.g. AI-provided config, paste import)
+ */
+export function mergeWidgetConfig(
+  defaults: Partial<WidgetConfig> | undefined,
+  adminConfig: Record<string, unknown> | Partial<WidgetConfig> | undefined,
+  saved: Partial<WidgetConfig> | undefined,
+  overrides: Partial<WidgetConfig> | undefined
+): WidgetConfig {
+  return Object.assign(
+    {},
+    defaults ?? {},
+    adminConfig ?? {},
+    stripTransientKeys(saved ?? {}),
+    overrides ?? {}
+  ) as WidgetConfig;
+}


### PR DESCRIPTION
## Summary

Combines yesterday's Friday 2026-05-01 scheduled-task audit with today's action item (the MEDIUM `simplification.md` finding from 2026-04-17 about the duplicated config layer-merge in `DashboardContext`).

### Action: extract `mergeWidgetConfig`

Both `addWidget` and `addWidgets` had an identical four-layer `Object.assign` (`defaults → admin → saved → overrides`). Extracted into `mergeWidgetConfig` in `utils/widgetConfigPersistence.ts`, sitting next to `stripTransientKeys` (which now runs inside the helper on the saved layer). Layer order is documented in JSDoc; both call sites delegate to the helper. The redundant `stripTransientKeys` import in `DashboardContext.tsx` was removed (it remains imported by `AuthContext.tsx` for save-side filtering, unchanged). Three new unit tests cover layer ordering, transient stripping in the saved layer, and all-undefined inputs.

### Audits (Friday 2026-05-01)

**Daily:**
- **Widget Registry** — 1 new LOW: `blooms-detail` absent from `config/tools.ts` (programmatic sub-widget)
- **CSS Scaling** — 0 new; 6 existing open
- **TypeScript/ESLint** — CLEAN

**Weekly:**
- **Simplification** — MEDIUM `mergeWidgetConfig` extraction now resolved (this PR); 3 LOW carry forward
- **AI Integration** — 1 new LOW: `dashboard-layout` has no server-side `specificFeatureId`

## Test plan

- [x] `pnpm type-check` — 0 errors
- [x] `pnpm lint --max-warnings 0` — clean
- [x] `pnpm format:check` — clean
- [x] `pnpm test` — 1680 passed (175 files)
- [ ] Verify add-widget + AI-paste flows still apply admin building defaults and saved global config layers as before

https://claude.ai/code/session_01597tQzW5F3bQ8hBqwhnrmJ