### PR TITLE
fix(deploy): self-heal stale lazy-chunk failures after redeploy

### DIFF
--- a/components/common/LazyChunkErrorBoundary.tsx
+++ b/components/common/LazyChunkErrorBoundary.tsx
@@ -1,0 +1,88 @@
+import React from 'react';
+import { AlertTriangle, RotateCw } from 'lucide-react';
+import { attemptChunkReload, isChunkLoadError } from '@/utils/chunkLoadError';
+
+interface LazyChunkErrorBoundaryProps {
+  children: React.ReactNode;
+}
+
+interface LazyChunkErrorBoundaryState {
+  error: Error | null;
+}
+
+/**
+ * Catches errors thrown by a Suspended descendant — most importantly, the
+ * dynamic-import failures that occur when a widget chunk no longer exists
+ * after a redeploy. A stale-chunk error triggers a one-shot full-page reload
+ * (guarded by sessionStorage so we never loop). Any other error renders a
+ * scoped "widget failed to render" tile with a Retry button so a single bad
+ * widget can't blank the entire dashboard.
+ */
+export class LazyChunkErrorBoundary extends React.Component<
+  LazyChunkErrorBoundaryProps,
+  LazyChunkErrorBoundaryState
+> {
+  override state: LazyChunkErrorBoundaryState = { error: null };
+
+  static getDerivedStateFromError(error: Error): LazyChunkErrorBoundaryState {
+    return { error };
+  }
+
+  override componentDidCatch(error: Error, info: React.ErrorInfo) {
+    if (isChunkLoadError(error)) {
+      console.warn(
+        '[LazyChunkErrorBoundary] Chunk load failed — attempting reload',
+        error.message
+      );
+      attemptChunkReload();
+      return;
+    }
+    console.error(
+      '[LazyChunkErrorBoundary] Widget render error',
+      error,
+      info.componentStack
+    );
+  }
+
+  handleRetry = () => {
+    this.setState({ error: null });
+  };
+
+  override render() {
+    const { error } = this.state;
+    if (!error) return this.props.children;
+
+    if (isChunkLoadError(error)) {
+      return (
+        <div className="flex h-full w-full items-center justify-center p-4 text-center text-slate-300">
+          <div
+            className="flex flex-col items-center gap-2"
+            style={{ fontSize: 'min(13px, 4cqmin)' }}
+          >
+            <RotateCw className="h-5 w-5 animate-spin text-slate-400" />
+            <span>Updating to the latest version…</span>
+          </div>
+        </div>
+      );
+    }
+
+    return (
+      <div className="flex h-full w-full flex-col items-center justify-center gap-3 p-4 text-center">
+        <AlertTriangle className="h-6 w-6 text-amber-400" />
+        <div
+          className="font-semibold text-slate-200"
+          style={{ fontSize: 'min(14px, 4.5cqmin)' }}
+        >
+          Widget failed to load
+        </div>
+        <button
+          type="button"
+          onClick={this.handleRetry}
+          className="rounded-md bg-slate-700/80 px-3 py-1.5 text-xs font-medium text-white transition hover:bg-slate-600"
+        >
+          Retry
+        </button>
+      </div>
+    );
+  }
+}

--- a/components/common/LazyChunkErrorBoundary.tsx
+++ b/components/common/LazyChunkErrorBoundary.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { AlertTriangle, RotateCw } from 'lucide-react';
+import { ScaledEmptyState } from '@/components/common/ScaledEmptyState';
 import { attemptChunkReload, isChunkLoadError } from '@/utils/chunkLoadError';
 
 interface LazyChunkErrorBoundaryProps {
@@ -8,33 +9,54 @@ interface LazyChunkErrorBoundaryProps {
 
 interface LazyChunkErrorBoundaryState {
   error: Error | null;
+  reloadInFlight: boolean;
 }
+
+const RETRY_BUTTON_CLASS =
+  'rounded-md bg-slate-700/80 font-medium text-white transition hover:bg-slate-600';
+const RETRY_BUTTON_STYLE: React.CSSProperties = {
+  fontSize: 'min(12px, 4cqmin)',
+  padding: 'min(6px, 1.5cqmin) min(12px, 3cqmin)',
+};
 
 /**
  * Catches errors thrown by a Suspended descendant — most importantly, the
  * dynamic-import failures that occur when a widget chunk no longer exists
  * after a redeploy. A stale-chunk error triggers a one-shot full-page reload
- * (guarded by sessionStorage so we never loop). Any other error renders a
- * scoped "widget failed to render" tile with a Retry button so a single bad
- * widget can't blank the entire dashboard.
+ * (guarded by sessionStorage so we never loop); when the guard suppresses the
+ * reload (or the error is unrelated), the boundary renders a scoped retry
+ * tile so a single bad widget can't blank the entire dashboard.
  */
 export class LazyChunkErrorBoundary extends React.Component<
   LazyChunkErrorBoundaryProps,
   LazyChunkErrorBoundaryState
 > {
-  override state: LazyChunkErrorBoundaryState = { error: null };
+  override state: LazyChunkErrorBoundaryState = {
+    error: null,
+    reloadInFlight: false,
+  };
 
-  static getDerivedStateFromError(error: Error): LazyChunkErrorBoundaryState {
+  static getDerivedStateFromError(
+    error: Error
+  ): Partial<LazyChunkErrorBoundaryState> {
     return { error };
   }
 
   override componentDidCatch(error: Error, info: React.ErrorInfo) {
     if (isChunkLoadError(error)) {
-      console.warn(
-        '[LazyChunkErrorBoundary] Chunk load failed — attempting reload',
-        error.message
-      );
-      attemptChunkReload();
+      const reloaded = attemptChunkReload();
+      if (reloaded) {
+        console.warn(
+          '[LazyChunkErrorBoundary] Chunk load failed — reloading',
+          error.message
+        );
+        this.setState({ reloadInFlight: true });
+      } else {
+        console.warn(
+          '[LazyChunkErrorBoundary] Chunk load failed and reload already attempted this session — showing retry UI',
+          error.message
+        );
+      }
       return;
     }
     console.error(
@@ -45,44 +67,41 @@ export class LazyChunkErrorBoundary extends React.Component<
   }
 
   handleRetry = () => {
-    this.setState({ error: null });
+    this.setState({ error: null, reloadInFlight: false });
   };
 
   override render() {
-    const { error } = this.state;
+    const { error, reloadInFlight } = this.state;
     if (!error) return this.props.children;
 
-    if (isChunkLoadError(error)) {
+    if (reloadInFlight) {
       return (
-        <div className="flex h-full w-full items-center justify-center p-4 text-center text-slate-300">
-          <div
-            className="flex flex-col items-center gap-2"
-            style={{ fontSize: 'min(13px, 4cqmin)' }}
-          >
-            <RotateCw className="h-5 w-5 animate-spin text-slate-400" />
-            <span>Updating to the latest version…</span>
-          </div>
-        </div>
+        <ScaledEmptyState
+          icon={RotateCw}
+          title="Updating…"
+          subtitle="Loading the latest version."
+          iconClassName="text-slate-400 animate-spin"
+        />
       );
     }
 
     return (
-      <div className="flex h-full w-full flex-col items-center justify-center gap-3 p-4 text-center">
-        <AlertTriangle className="h-6 w-6 text-amber-400" />
-        <div
-          className="font-semibold text-slate-200"
-          style={{ fontSize: 'min(14px, 4.5cqmin)' }}
-        >
-          Widget failed to load
-        </div>
-        <button
-          type="button"
-          onClick={this.handleRetry}
-          className="rounded-md bg-slate-700/80 px-3 py-1.5 text-xs font-medium text-white transition hover:bg-slate-600"
-        >
-          Retry
-        </button>
-      </div>
+      <ScaledEmptyState
+        icon={AlertTriangle}
+        title="Widget failed to load"
+        subtitle="Refresh the page to try again."
+        iconClassName="text-amber-400"
+        action={
+          <button
+            type="button"
+            onClick={this.handleRetry}
+            className={RETRY_BUTTON_CLASS}
+            style={RETRY_BUTTON_STYLE}
+          >
+            Retry
+          </button>
+        }
+      />
     );
   }
 }

--- a/components/widgets/WidgetLayout/WidgetLayoutWrapper.tsx
+++ b/components/widgets/WidgetLayout/WidgetLayoutWrapper.tsx
@@ -1,6 +1,7 @@
 import React, { Suspense } from 'react';
 import { WidgetData, WidgetComponentProps } from '@/types';
 import { WIDGET_COMPONENTS } from '@/components/widgets/WidgetRegistry';
+import { LazyChunkErrorBoundary } from '@/components/common/LazyChunkErrorBoundary';
 
 const LoadingFallback = () => (
   <div className="flex items-center justify-center h-full w-full">
@@ -50,8 +51,10 @@ export const WidgetLayoutWrapper: React.FC<WidgetLayoutWrapperProps> = ({
   };
 
   return (
-    <Suspense fallback={<LoadingFallback />}>
-      <WidgetComponent {...componentProps} />
-    </Suspense>
+    <LazyChunkErrorBoundary>
+      <Suspense fallback={<LoadingFallback />}>
+        <WidgetComponent {...componentProps} />
+      </Suspense>
+    </LazyChunkErrorBoundary>
   );
 };

--- a/components/widgets/WidgetRegistry.ts
+++ b/components/widgets/WidgetRegistry.ts
@@ -13,6 +13,11 @@ import {
   ScalingConfig,
   WidgetComponentProps,
 } from '@/types';
+import {
+  attemptChunkReload,
+  isChunkLoadError,
+  neverResolvingPromise,
+} from '@/utils/chunkLoadError';
 
 // Component type definitions to ensure type safety
 type SettingsComponentProps = {
@@ -26,15 +31,30 @@ type SettingsComponent =
   | React.ComponentType<SettingsComponentProps>
   | React.LazyExoticComponent<React.ComponentType<SettingsComponentProps>>;
 
-// Lazy load helper for named exports
+// Lazy load helper for named exports.
+//
+// If the dynamic import fails because the chunk no longer exists (the classic
+// stale-deploy hazard — see utils/chunkLoadError.ts), trigger a one-shot
+// full-page reload to pick up the new build. If reload was already attempted
+// this session, re-throw so the surrounding LazyChunkErrorBoundary can render
+// a scoped fallback UI.
 const lazyNamed = (
   importFactory: () => Promise<Record<string, unknown>>,
   name: string
 ) => {
   return lazy(() =>
-    importFactory().then((module) => ({
-      default: module[name] as React.ComponentType<unknown>,
-    }))
+    importFactory()
+      .then((module) => ({
+        default: module[name] as React.ComponentType<unknown>,
+      }))
+      .catch((error: unknown) => {
+        if (isChunkLoadError(error) && attemptChunkReload()) {
+          // Reload kicked off; suspend forever so React keeps showing the
+          // Suspense fallback until the reload completes.
+          return neverResolvingPromise();
+        }
+        throw error;
+      })
   );
 };
 

--- a/firebase.json
+++ b/firebase.json
@@ -71,6 +71,15 @@
             "value": "no-cache, no-store, must-revalidate"
           }
         ]
+      },
+      {
+        "source": "/index.html",
+        "headers": [
+          {
+            "key": "Cache-Control",
+            "value": "no-cache, no-store, must-revalidate"
+          }
+        ]
       }
     ]
   }

--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@
       name="viewport"
       content="width=device-width, initial-scale=1.0, viewport-fit=cover"
     />
+    <meta name="mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta
       name="apple-mobile-web-app-status-bar-style"

--- a/index.tsx
+++ b/index.tsx
@@ -3,6 +3,16 @@ import ReactDOM from 'react-dom/client';
 import App from './App';
 import './index.css';
 import './i18n';
+import { attemptChunkReload } from './utils/chunkLoadError';
+
+// Vite v5+ fires `vite:preloadError` when a <link rel="modulepreload"> fails —
+// usually because the chunk no longer exists after a redeploy. Calling
+// preventDefault() lets Vite fall back to a normal import; combined with the
+// one-shot reload below, the page self-heals to the new build.
+window.addEventListener('vite:preloadError', (event) => {
+  event.preventDefault();
+  attemptChunkReload();
+});
 
 const rootElement = document.getElementById('root');
 if (!rootElement) throw new Error('Could not find root element');

--- a/tests/components/LazyChunkErrorBoundary.test.tsx
+++ b/tests/components/LazyChunkErrorBoundary.test.tsx
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { LazyChunkErrorBoundary } from '@/components/common/LazyChunkErrorBoundary';
+
+const Bomb = ({ error }: { error: Error }) => {
+  throw error;
+};
+
+const buildChunkError = () =>
+  new TypeError(
+    'Failed to fetch dynamically imported module: /assets/Widget-abc123.js'
+  );
+
+describe('LazyChunkErrorBoundary', () => {
+  let reloadSpy: ReturnType<typeof vi.fn>;
+  const noop = () => {
+    /* swallow logs in tests */
+  };
+
+  beforeEach(() => {
+    window.sessionStorage.clear();
+    reloadSpy = vi.fn();
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { ...window.location, reload: reloadSpy },
+    });
+    // React logs caught errors to console.error; silence to keep test output readable.
+    vi.spyOn(console, 'warn').mockImplementation(noop);
+    vi.spyOn(console, 'error').mockImplementation(noop);
+  });
+
+  afterEach(() => {
+    window.sessionStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  it('renders children when no error occurs', () => {
+    render(
+      <LazyChunkErrorBoundary>
+        <p>healthy widget</p>
+      </LazyChunkErrorBoundary>
+    );
+    expect(screen.getByText('healthy widget')).toBeInTheDocument();
+  });
+
+  it('triggers a reload and shows the updating spinner on a stale-chunk error', () => {
+    render(
+      <LazyChunkErrorBoundary>
+        <Bomb error={buildChunkError()} />
+      </LazyChunkErrorBoundary>
+    );
+
+    expect(reloadSpy).toHaveBeenCalledTimes(1);
+    expect(screen.getByText('Updating…')).toBeInTheDocument();
+  });
+
+  it('shows the retry tile when chunk reload was already attempted this session', () => {
+    window.sessionStorage.setItem('spartboard:chunk-reload-attempted', '1');
+
+    render(
+      <LazyChunkErrorBoundary>
+        <Bomb error={buildChunkError()} />
+      </LazyChunkErrorBoundary>
+    );
+
+    expect(reloadSpy).not.toHaveBeenCalled();
+    expect(screen.getByText('Widget failed to load')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Retry' })).toBeInTheDocument();
+  });
+
+  it('renders a retry tile for non-chunk render errors and recovers when Retry is clicked', () => {
+    let shouldThrow = true;
+    const Conditional = () => {
+      if (shouldThrow) throw new Error('boom');
+      return <p>recovered</p>;
+    };
+
+    render(
+      <LazyChunkErrorBoundary>
+        <Conditional />
+      </LazyChunkErrorBoundary>
+    );
+
+    expect(reloadSpy).not.toHaveBeenCalled();
+    expect(screen.getByText('Widget failed to load')).toBeInTheDocument();
+
+    shouldThrow = false;
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }));
+
+    expect(screen.getByText('recovered')).toBeInTheDocument();
+  });
+});

--- a/utils/chunkLoadError.test.ts
+++ b/utils/chunkLoadError.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
+import {
+  attemptChunkReload,
+  isChunkLoadError,
+  neverResolvingPromise,
+} from './chunkLoadError';
+
+describe('chunkLoadError', () => {
+  describe('isChunkLoadError', () => {
+    it('matches errors named ChunkLoadError', () => {
+      const err = new Error('whatever');
+      err.name = 'ChunkLoadError';
+      expect(isChunkLoadError(err)).toBe(true);
+    });
+
+    it('matches Vite dynamic-import failure messages', () => {
+      const err = new TypeError(
+        'Failed to fetch dynamically imported module: https://example.com/assets/Widget-abc123.js'
+      );
+      expect(isChunkLoadError(err)).toBe(true);
+    });
+
+    it('matches the lowercase Vite error variant', () => {
+      const err = new Error(
+        'error loading dynamically imported module: /assets/Widget-abc123.js'
+      );
+      expect(isChunkLoadError(err)).toBe(true);
+    });
+
+    it('matches the Safari-style import failure', () => {
+      const err = new Error('Importing a module script failed.');
+      expect(isChunkLoadError(err)).toBe(true);
+    });
+
+    it('matches the MIME-type / text/html surface that Firebase SPA rewrites produce', () => {
+      const err = new Error(
+        'Failed to load module script: Expected a JavaScript-or-Wasm module script but the server responded with a MIME type of "text/html".'
+      );
+      expect(isChunkLoadError(err)).toBe(true);
+    });
+
+    it('matches webpack-style "Loading chunk N failed"', () => {
+      const err = new Error('Loading chunk 42 failed.');
+      expect(isChunkLoadError(err)).toBe(true);
+    });
+
+    it('matches CSS chunk failures', () => {
+      const err = new Error('Loading CSS chunk 3 failed.');
+      expect(isChunkLoadError(err)).toBe(true);
+    });
+
+    it('does not match unrelated errors', () => {
+      expect(isChunkLoadError(new Error('Network request failed'))).toBe(false);
+      expect(isChunkLoadError(new TypeError('foo is not a function'))).toBe(
+        false
+      );
+      expect(isChunkLoadError(new RangeError('Invalid index'))).toBe(false);
+    });
+
+    it('returns false for non-error values', () => {
+      expect(isChunkLoadError(null)).toBe(false);
+      expect(isChunkLoadError(undefined)).toBe(false);
+      expect(isChunkLoadError('a string')).toBe(false);
+      expect(isChunkLoadError(42)).toBe(false);
+      expect(isChunkLoadError({})).toBe(false);
+    });
+  });
+
+  describe('attemptChunkReload', () => {
+    let reloadSpy: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+      window.sessionStorage.clear();
+      reloadSpy = vi.fn();
+      // jsdom's location.reload is non-configurable; replace the whole object.
+      Object.defineProperty(window, 'location', {
+        configurable: true,
+        value: { ...window.location, reload: reloadSpy },
+      });
+    });
+
+    afterEach(() => {
+      window.sessionStorage.clear();
+    });
+
+    it('reloads the page on first call and returns true', () => {
+      expect(attemptChunkReload()).toBe(true);
+      expect(reloadSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not reload twice in the same session', () => {
+      attemptChunkReload();
+      reloadSpy.mockClear();
+
+      expect(attemptChunkReload()).toBe(false);
+      expect(reloadSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('neverResolvingPromise', () => {
+    it('returns a promise that never settles', async () => {
+      const p = neverResolvingPromise<number>();
+      const settled = await Promise.race([
+        p.then(() => 'resolved').catch(() => 'rejected'),
+        new Promise((resolve) => setTimeout(() => resolve('timeout'), 20)),
+      ]);
+      expect(settled).toBe('timeout');
+    });
+  });
+});

--- a/utils/chunkLoadError.ts
+++ b/utils/chunkLoadError.ts
@@ -1,0 +1,77 @@
+/**
+ * Detects and recovers from "stale chunk" failures that occur when an open tab
+ * tries to lazy-load a JS chunk that no longer exists after a redeploy.
+ *
+ * Why: Vite emits hashed chunk filenames per build. After a deploy, the old
+ * tab's `index.html` references chunks that 404 — and Firebase Hosting's SPA
+ * rewrite (`** -> /index.html`) returns HTML for those URLs, so the browser
+ * fails the import with a MIME-type error. Without recovery, the React tree
+ * crashes to a blank screen.
+ *
+ * Recovery: on the first matching error in a session, force-reload the page
+ * once. A sessionStorage flag prevents reload loops if the failure is real
+ * (e.g. the chunk genuinely is broken on the server).
+ */
+
+const RELOAD_GUARD_KEY = 'spartboard:chunk-reload-attempted';
+
+/**
+ * Returns true if the error looks like a stale-chunk / failed dynamic-import
+ * failure. Covers Vite, webpack, and the MIME-mismatch surface that Firebase's
+ * SPA rewrite produces.
+ */
+export function isChunkLoadError(error: unknown): boolean {
+  if (!error) return false;
+  const err = error as { name?: string; message?: string };
+  if (err.name === 'ChunkLoadError') return true;
+
+  const message = typeof err.message === 'string' ? err.message : '';
+  if (!message) return false;
+
+  if (message.includes('Failed to fetch dynamically imported module'))
+    return true;
+  if (message.includes('error loading dynamically imported module'))
+    return true;
+  if (message.includes('Importing a module script failed')) return true;
+  if (message.includes('Loading chunk') && message.includes('failed'))
+    return true;
+  if (message.includes('Loading CSS chunk')) return true;
+  if (message.includes('MIME type') && message.includes('text/html'))
+    return true;
+
+  return false;
+}
+
+/**
+ * Returns a Promise that never resolves or rejects. Used after kicking off a
+ * page reload so React keeps showing the Suspense fallback (rather than
+ * surfacing the original chunk error) for the brief moment before the reload
+ * tears the page down.
+ */
+export function neverResolvingPromise<T = never>(): Promise<T> {
+  return new Promise<T>(() => {
+    /* intentionally never settles — page is reloading */
+  });
+}
+
+/**
+ * Triggers a one-shot full-page reload to pull in the new build. If we've
+ * already attempted a reload this session, returns false so the caller can
+ * fall back to an error UI instead of looping.
+ */
+export function attemptChunkReload(): boolean {
+  if (typeof window === 'undefined') return false;
+
+  try {
+    if (window.sessionStorage.getItem(RELOAD_GUARD_KEY) === '1') {
+      return false;
+    }
+    window.sessionStorage.setItem(RELOAD_GUARD_KEY, '1');
+  } catch {
+    // sessionStorage can throw in privacy modes; if it does, allow the
+    // reload anyway — looping is unlikely without storage to track state.
+  }
+
+  window.location.reload();
+  return true;
+}


### PR DESCRIPTION
## Summary

Open tabs that miss a redeploy were hitting a blank screen when they tried to lazy-load a widget chunk that no longer exists — Firebase's SPA rewrite serves `/index.html` for missing `/assets/*.js`, the browser refuses to execute HTML as a module (`"Expected a JavaScript-or-Wasm module script but the server responded with a MIME type of \"text/html\""`), and with no error boundary the whole React tree unmounts.

The Stations widget surfaced the bug because it's lazy-loaded — but the failure mode applies to every widget chunk after a deploy.

This adds layered recovery so the page self-heals to the new build instead of blanking, and isolates any future widget render error to a single tile.

- **`utils/chunkLoadError.ts`** — `isChunkLoadError` matcher (covers Vite, webpack, Safari, and the Firebase MIME surface) + `attemptChunkReload` with `sessionStorage` one-shot guard so we never loop
- **`components/widgets/WidgetRegistry.ts`** — `lazyNamed` now `.catch`es chunk failures, reloads once, otherwise rethrows
- **`components/common/LazyChunkErrorBoundary.tsx`** — new boundary wrapping each widget's Suspense; auto-reloads on stale-chunk errors, renders a scoped Retry tile for any other widget render error
- **`index.tsx`** — listens for `vite:preloadError` (Vite v5+ emits this for failed `<link rel="modulepreload">`) and triggers the same one-shot reload
- **`firebase.json`** — explicit `Cache-Control: no-cache, no-store, must-revalidate` for `/index.html` so reloads always fetch a fresh document
- **`index.html`** — adds modern `<meta name="mobile-web-app-capable">` next to the apple variant (silences the deprecation warning the user hit)

## Test plan

- [x] `pnpm run type-check` clean
- [x] ESLint + Prettier clean on all changed files
- [x] Full unit suite passes (1677 existing + 12 new in `utils/chunkLoadError.test.ts`)
- [x] Dev server (`pnpm run dev`) loads with no MIME / chunk-load errors
- [x] Stations chunk lazy-loads in ~150ms via the same path the registry uses
- [x] `vite:preloadError` listener verified in browser: calls `preventDefault()` and respects the sessionStorage reload guard
- [x] `isChunkLoadError` verified against all 5 stale-chunk error variants and rejects unrelated errors

## Manual verification (post-deploy preview)

1. Open the dev-paul preview URL in a tab.
2. Push another commit so a new build deploys (chunk hashes change).
3. Without refreshing, open the Stations widget (or any other lazy-loaded widget).
4. **Expected:** the page auto-reloads once and shows the working widget — no blank screen, no console MIME errors.
5. With DevTools "Block request URL" on a Stations chunk, repeat — the boundary's Retry tile appears (scoped to that one widget) without blanking the dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)