### PR TITLE
feat(video-activity): add live teacher monitor for active assignments

### DIFF
--- a/components/widgets/VideoActivityWidget/Widget.tsx
+++ b/components/widgets/VideoActivityWidget/Widget.tsx
@@ -550,24 +550,23 @@ export const VideoActivityWidget: React.FC<{ widget: WidgetData }> = ({
           });
         }}
         onArchiveMonitor={async (assignment) => {
-          // Same hydrate-then-subscribe pattern as the Results CTA: get the
-          // full session doc up-front so the monitor has the question set
-          // to grade against, and start the live listeners before flipping
-          // the view so we don't render empty between mount and snapshot.
-          subscribeToSession(assignment.id);
+          // Fetch the session doc up-front so we can confirm it exists
+          // before arming the live listeners. Subscribing first would leak
+          // an open Firestore listener on every error / missing-session
+          // path here.
+          let sessionDoc: VideoActivitySession;
           try {
             const snap = await getDoc(
               doc(db, 'video_activity_sessions', assignment.id)
             );
-            if (snap.exists()) {
-              setSelectedSession(snap.data() as VideoActivitySession);
-            } else {
+            if (!snap.exists()) {
               addToast(
                 'Session data no longer available — cannot open monitor.',
                 'error'
               );
               return;
             }
+            sessionDoc = snap.data() as VideoActivitySession;
           } catch (err) {
             addToast(
               err instanceof Error
@@ -577,6 +576,8 @@ export const VideoActivityWidget: React.FC<{ widget: WidgetData }> = ({
             );
             return;
           }
+          setSelectedSession(sessionDoc);
+          subscribeToSession(assignment.id);
           updateWidget(widget.id, {
             config: {
               ...config,

--- a/components/widgets/VideoActivityWidget/Widget.tsx
+++ b/components/widgets/VideoActivityWidget/Widget.tsx
@@ -5,7 +5,7 @@
  * as a sibling of the Manager library view.
  */
 
-import React, { useState, useCallback } from 'react';
+import React, { useState, useCallback, useEffect, useRef } from 'react';
 import { doc, getDoc } from 'firebase/firestore';
 import { db } from '@/config/firebase';
 import {
@@ -105,6 +105,10 @@ export const VideoActivityWidget: React.FC<{ widget: WidgetData }> = ({
   const [loadingActivity, setLoadingActivity] = useState(false);
   const [selectedSession, setSelectedSession] =
     useState<VideoActivitySession | null>(null);
+  // Monotonically increasing token to guard against rapid Monitor/Results
+  // clicks across different assignments — we bail out of any stale fetch
+  // resolution that's no longer the most recent attempt.
+  const sessionLoadAttemptRef = useRef(0);
 
   // Editor modal state — ephemeral, not persisted to Firestore.
   const [editingActivity, setEditingActivity] =
@@ -153,6 +157,50 @@ export const VideoActivityWidget: React.FC<{ widget: WidgetData }> = ({
     },
     [loadActivityData, addToast]
   );
+
+  // ─── Reactive cleanup ──────────────────────────────────────────────────
+  //
+  // Auto-exit the live monitor if the assignment under it goes inactive
+  // (deactivated from another tab) or the session doc is deleted. Without
+  // this the header would silently misrepresent state — pause/end both
+  // write `session.status='ended'`, so the monitor can't tell them apart
+  // from `session` alone, and a deleted session leaves a stale snapshot.
+  // Effect must run before the early-return guards below to keep hook
+  // order stable across renders.
+  const rawViewForGuard = config.view as
+    | VideoActivityView
+    | 'editor'
+    | undefined;
+  const viewForGuard: VideoActivityView =
+    rawViewForGuard === 'editor' || !rawViewForGuard
+      ? 'manager'
+      : rawViewForGuard;
+  useEffect(() => {
+    if (viewForGuard !== 'monitor' || !selectedSession || assignmentsLoading)
+      return;
+    const match = assignments.find((a) => a.id === selectedSession.id);
+    if (match && match.status !== 'inactive') return;
+    unsubscribeFromSession();
+    setSelectedSession(null);
+    addToast('Assignment is no longer active — returning to library.', 'info');
+    updateWidget(widget.id, {
+      config: {
+        ...config,
+        view: 'manager',
+        resultsSessionId: null,
+      } as VideoActivityConfig,
+    });
+  }, [
+    viewForGuard,
+    selectedSession,
+    assignments,
+    assignmentsLoading,
+    unsubscribeFromSession,
+    addToast,
+    updateWidget,
+    widget.id,
+    config,
+  ]);
 
   // ─── Guards ────────────────────────────────────────────────────────────────
 
@@ -234,6 +282,7 @@ export const VideoActivityWidget: React.FC<{ widget: WidgetData }> = ({
   const rawView = config.view as VideoActivityView | 'editor' | undefined;
   const view: VideoActivityView =
     rawView === 'editor' || !rawView ? 'manager' : rawView;
+
   const defaultSessionSettings: VideoActivitySessionSettings = {
     autoPlay: config.autoPlay ?? false,
     requireCorrectAnswer: config.requireCorrectAnswer ?? true,
@@ -553,12 +602,15 @@ export const VideoActivityWidget: React.FC<{ widget: WidgetData }> = ({
           // Fetch the session doc up-front so we can confirm it exists
           // before arming the live listeners. Subscribing first would leak
           // an open Firestore listener on every error / missing-session
-          // path here.
+          // path here. The attempt token guards against a stale resolution
+          // clobbering a newer click for a different assignment.
+          const myAttempt = ++sessionLoadAttemptRef.current;
           let sessionDoc: VideoActivitySession;
           try {
             const snap = await getDoc(
               doc(db, 'video_activity_sessions', assignment.id)
             );
+            if (myAttempt !== sessionLoadAttemptRef.current) return;
             if (!snap.exists()) {
               addToast(
                 'Session data no longer available — cannot open monitor.',
@@ -568,6 +620,7 @@ export const VideoActivityWidget: React.FC<{ widget: WidgetData }> = ({
             }
             sessionDoc = snap.data() as VideoActivitySession;
           } catch (err) {
+            if (myAttempt !== sessionLoadAttemptRef.current) return;
             addToast(
               err instanceof Error
                 ? err.message

--- a/components/widgets/VideoActivityWidget/Widget.tsx
+++ b/components/widgets/VideoActivityWidget/Widget.tsx
@@ -27,6 +27,7 @@ import { useFolders } from '@/hooks/useFolders';
 import { VideoActivityManager } from './components/VideoActivityManager';
 import { Creator } from './components/Creator';
 import { Results } from './components/Results';
+import { VideoActivityLiveMonitor } from './components/VideoActivityLiveMonitor';
 import { VideoActivityEditorModal } from './components/VideoActivityEditorModal';
 import { Loader2, AlertTriangle, LogIn } from 'lucide-react';
 import { deriveSessionTargetsFromRosters } from '@/utils/resolveAssignmentTargets';
@@ -87,6 +88,7 @@ export const VideoActivityWidget: React.FC<{ widget: WidgetData }> = ({
   const {
     createSession,
     responses,
+    liveSession,
     subscribeToSession,
     unsubscribeFromSession,
   } = useVideoActivitySessionTeacher();
@@ -267,6 +269,76 @@ export const VideoActivityWidget: React.FC<{ widget: WidgetData }> = ({
       <Results
         session={selectedSession}
         responses={responses}
+        onBack={() => {
+          unsubscribeFromSession();
+          setSelectedSession(null);
+          updateWidget(widget.id, {
+            config: {
+              ...config,
+              view: 'manager',
+              resultsSessionId: null,
+            } as VideoActivityConfig,
+          });
+        }}
+      />
+    );
+  }
+
+  if (view === 'monitor' && selectedSession) {
+    // Prefer the live snapshot when it's caught up to the assignment we
+    // opened the monitor for; otherwise fall back to the initial fetch so
+    // the view never flashes empty between subscribe and first snapshot.
+    const sessionForMonitor =
+      liveSession && liveSession.id === selectedSession.id
+        ? liveSession
+        : selectedSession;
+    return (
+      <VideoActivityLiveMonitor
+        session={sessionForMonitor}
+        responses={responses}
+        onEnd={async () => {
+          try {
+            await deactivateAssignment(selectedSession.id);
+            addToast('Assignment ended.', 'success');
+          } catch (err) {
+            addToast(
+              err instanceof Error ? err.message : 'Failed to end assignment',
+              'error'
+            );
+            return;
+          }
+          unsubscribeFromSession();
+          setSelectedSession(null);
+          updateWidget(widget.id, {
+            config: {
+              ...config,
+              view: 'manager',
+              resultsSessionId: null,
+            } as VideoActivityConfig,
+          });
+        }}
+        onPause={async () => {
+          try {
+            await pauseAssignment(selectedSession.id);
+            addToast('Assignment paused.', 'success');
+          } catch (err) {
+            addToast(
+              err instanceof Error ? err.message : 'Failed to pause',
+              'error'
+            );
+          }
+        }}
+        onResume={async () => {
+          try {
+            await resumeAssignment(selectedSession.id);
+            addToast('Assignment resumed.', 'success');
+          } catch (err) {
+            addToast(
+              err instanceof Error ? err.message : 'Failed to resume',
+              'error'
+            );
+          }
+        }}
         onBack={() => {
           unsubscribeFromSession();
           setSelectedSession(null);
@@ -471,6 +543,44 @@ export const VideoActivityWidget: React.FC<{ widget: WidgetData }> = ({
             config: {
               ...config,
               view: 'results',
+              selectedActivityId: assignment.activityId,
+              selectedActivityTitle: assignment.activityTitle,
+              resultsSessionId: assignment.id,
+            } as VideoActivityConfig,
+          });
+        }}
+        onArchiveMonitor={async (assignment) => {
+          // Same hydrate-then-subscribe pattern as the Results CTA: get the
+          // full session doc up-front so the monitor has the question set
+          // to grade against, and start the live listeners before flipping
+          // the view so we don't render empty between mount and snapshot.
+          subscribeToSession(assignment.id);
+          try {
+            const snap = await getDoc(
+              doc(db, 'video_activity_sessions', assignment.id)
+            );
+            if (snap.exists()) {
+              setSelectedSession(snap.data() as VideoActivitySession);
+            } else {
+              addToast(
+                'Session data no longer available — cannot open monitor.',
+                'error'
+              );
+              return;
+            }
+          } catch (err) {
+            addToast(
+              err instanceof Error
+                ? err.message
+                : 'Failed to open assignment monitor',
+              'error'
+            );
+            return;
+          }
+          updateWidget(widget.id, {
+            config: {
+              ...config,
+              view: 'monitor',
               selectedActivityId: assignment.activityId,
               selectedActivityTitle: assignment.activityTitle,
               resultsSessionId: assignment.id,

--- a/components/widgets/VideoActivityWidget/components/VideoActivityLiveMonitor.tsx
+++ b/components/widgets/VideoActivityWidget/components/VideoActivityLiveMonitor.tsx
@@ -28,6 +28,7 @@ import {
   VideoActivityQuestion,
 } from '@/types';
 import { useDialog } from '@/context/useDialog';
+import { ScaledEmptyState } from '@/components/common/ScaledEmptyState';
 
 interface VideoActivityLiveMonitorProps {
   session: VideoActivitySession;
@@ -556,30 +557,11 @@ export const VideoActivityLiveMonitor: React.FC<
             </div>
 
             {responses.length === 0 ? (
-              <div
-                className="flex flex-col items-center justify-center text-slate-400 text-center"
-                style={{
-                  gap: 'min(8px, 2cqmin)',
-                  padding: 'min(32px, 8cqmin) min(16px, 4cqmin)',
-                }}
-              >
-                <Users
-                  className="opacity-40"
-                  style={{
-                    width: 'min(28px, 7cqmin)',
-                    height: 'min(28px, 7cqmin)',
-                  }}
-                />
-                <p
-                  className="font-medium text-slate-500"
-                  style={{ fontSize: 'min(12px, 3.5cqmin)' }}
-                >
-                  Waiting for students to join…
-                </p>
-                <p style={{ fontSize: 'min(10px, 3cqmin)' }}>
-                  Share the assignment link from the In Progress tab.
-                </p>
-              </div>
+              <ScaledEmptyState
+                icon={Users}
+                title="Waiting for students"
+                subtitle="Share the assignment link from the In Progress tab."
+              />
             ) : (
               <div
                 className="flex flex-col"

--- a/components/widgets/VideoActivityWidget/components/VideoActivityLiveMonitor.tsx
+++ b/components/widgets/VideoActivityWidget/components/VideoActivityLiveMonitor.tsx
@@ -82,10 +82,13 @@ const StudentRow: React.FC<StudentRowProps> = ({ response, questions }) => {
   }
   const answeredCount = response.answers.length;
   const completed = response.completedAt !== null;
+  // Returns null when there's nothing to grade against — e.g. a fallback
+  // session doc with no questions — so the row renders an em-dash instead
+  // of a misleading red 0%.
   const score =
     questions.length > 0
       ? Math.round((correctCount / questions.length) * 100)
-      : 0;
+      : null;
 
   const formatTime = (ts: number | null): string => {
     if (ts === null) return '—';
@@ -200,15 +203,17 @@ const StudentRow: React.FC<StudentRowProps> = ({ response, questions }) => {
         })}
         <span
           className={`font-black ml-1 ${
-            score >= 70
-              ? 'text-emerald-600'
-              : score >= 40
-                ? 'text-amber-600'
-                : 'text-brand-red-primary'
+            score === null
+              ? 'text-slate-400'
+              : score >= 70
+                ? 'text-emerald-600'
+                : score >= 40
+                  ? 'text-amber-600'
+                  : 'text-brand-red-primary'
           }`}
           style={{ fontSize: 'min(14px, 4.5cqmin)' }}
         >
-          {score}%
+          {score === null ? '—' : `${score}%`}
         </span>
       </div>
     </div>
@@ -386,12 +391,12 @@ export const VideoActivityLiveMonitor: React.FC<
             />
             <div className="flex flex-col min-w-0">
               <div
-                className={`flex items-center gap-1.5 font-black leading-none uppercase tracking-tight ${
+                className={`font-black leading-none uppercase tracking-tight ${
                   isLive ? 'text-brand-red-primary' : 'text-amber-600'
                 }`}
                 style={{ fontSize: 'min(12px, 4cqmin)' }}
               >
-                <span>{isLive ? 'Live' : 'Paused'}</span>
+                {isLive ? 'Live' : 'Paused'}
               </div>
               <span
                 className="text-brand-blue-dark font-bold truncate"

--- a/components/widgets/VideoActivityWidget/components/VideoActivityLiveMonitor.tsx
+++ b/components/widgets/VideoActivityWidget/components/VideoActivityLiveMonitor.tsx
@@ -1,0 +1,602 @@
+/**
+ * VideoActivityLiveMonitor — teacher view during a live video-activity assignment.
+ *
+ * Shows in real time who has joined, which question each student is on, and
+ * whether their submitted answers were correct. Mirrors the QuizLiveMonitor
+ * UX shape (header strip, KPI tiles, scrollable roster) but tailored to the
+ * Video Activity data model: there is no per-question advance, no auto-mode,
+ * and answers are timestamp-pegged to the underlying video. Pause / Resume /
+ * End controls map to the assignment-level pause/resume/deactivate hooks.
+ */
+
+import React, { useCallback, useMemo, useState } from 'react';
+import {
+  ArrowLeft,
+  CheckCircle2,
+  Circle,
+  Clock,
+  Loader2,
+  Pause,
+  Play,
+  Square,
+  Users,
+  XCircle,
+} from 'lucide-react';
+import {
+  VideoActivityResponse,
+  VideoActivitySession,
+  VideoActivityQuestion,
+} from '@/types';
+import { useDialog } from '@/context/useDialog';
+
+interface VideoActivityLiveMonitorProps {
+  session: VideoActivitySession;
+  responses: VideoActivityResponse[];
+  /**
+   * "End assignment" — kills the student URL but preserves all responses.
+   * Wired to `deactivateAssignment(assignmentId)`.
+   */
+  onEnd: () => Promise<void>;
+  /** Pause this assignment — students see a paused screen. */
+  onPause?: () => Promise<void>;
+  /** Resume a paused assignment. */
+  onResume?: () => Promise<void>;
+  /** Navigate back to the manager (In Progress tab) without ending. */
+  onBack?: () => void;
+}
+
+/* ─── Per-row sub-component ──────────────────────────────────────────────── */
+
+interface StudentRowProps {
+  response: VideoActivityResponse;
+  questions: VideoActivityQuestion[];
+}
+
+const StudentRow: React.FC<StudentRowProps> = ({ response, questions }) => {
+  const correctAnswerById = useMemo(() => {
+    const m = new Map<string, string>();
+    for (const q of questions) m.set(q.id, q.correctAnswer);
+    return m;
+  }, [questions]);
+
+  // Last submission timestamp (helps the teacher spot stalled students).
+  const latestAnsweredAt = response.answers.reduce<number | null>(
+    (acc, a) => (acc === null || a.answeredAt > acc ? a.answeredAt : acc),
+    null
+  );
+
+  // Per-question answer index for fast lookup when rendering the strip.
+  const answerByQid = useMemo(() => {
+    const m = new Map<string, string>();
+    for (const a of response.answers) m.set(a.questionId, a.answer);
+    return m;
+  }, [response.answers]);
+
+  let correctCount = 0;
+  for (const q of questions) {
+    const submitted = answerByQid.get(q.id);
+    if (submitted !== undefined && submitted === correctAnswerById.get(q.id)) {
+      correctCount++;
+    }
+  }
+  const answeredCount = response.answers.length;
+  const completed = response.completedAt !== null;
+  const score =
+    questions.length > 0
+      ? Math.round((correctCount / questions.length) * 100)
+      : 0;
+
+  const formatTime = (ts: number | null): string => {
+    if (ts === null) return '—';
+    return new Date(ts).toLocaleTimeString([], {
+      hour: 'numeric',
+      minute: '2-digit',
+    });
+  };
+
+  return (
+    <div
+      className="flex items-center bg-white border border-slate-100 rounded-xl"
+      style={{
+        padding: 'min(10px, 2.5cqmin)',
+        gap: 'min(10px, 2.5cqmin)',
+      }}
+    >
+      <div className="flex-1 min-w-0">
+        <div
+          className="flex items-center"
+          style={{ gap: 'min(6px, 1.5cqmin)' }}
+        >
+          <p
+            className="font-bold text-slate-800 truncate"
+            style={{ fontSize: 'min(13px, 4cqmin)' }}
+          >
+            {response.name || response.pin}
+          </p>
+          {response.classPeriod && (
+            <span
+              className="bg-brand-blue-lighter text-brand-blue-primary font-bold rounded-md shrink-0"
+              style={{
+                fontSize: 'min(9px, 2.5cqmin)',
+                padding: 'min(1px, 0.2cqmin) min(5px, 1.2cqmin)',
+              }}
+            >
+              {response.classPeriod}
+            </span>
+          )}
+          {completed ? (
+            <span
+              className="bg-emerald-50 text-emerald-700 font-bold rounded-md shrink-0"
+              style={{
+                fontSize: 'min(9px, 2.5cqmin)',
+                padding: 'min(1px, 0.2cqmin) min(5px, 1.2cqmin)',
+              }}
+            >
+              Done
+            </span>
+          ) : (
+            <span
+              className="bg-amber-50 text-amber-700 font-bold rounded-md shrink-0"
+              style={{
+                fontSize: 'min(9px, 2.5cqmin)',
+                padding: 'min(1px, 0.2cqmin) min(5px, 1.2cqmin)',
+              }}
+            >
+              In progress
+            </span>
+          )}
+        </div>
+        <p
+          className="text-slate-400"
+          style={{
+            fontSize: 'min(10px, 3cqmin)',
+            marginTop: 'min(2px, 0.5cqmin)',
+          }}
+        >
+          PIN {response.pin} · {answeredCount}/{questions.length} answered ·
+          last {formatTime(latestAnsweredAt)}
+        </p>
+      </div>
+
+      <div
+        className="flex items-center shrink-0 flex-wrap justify-end"
+        style={{ gap: 'min(4px, 1cqmin)', maxWidth: '50%' }}
+      >
+        {questions.map((q) => {
+          const submitted = answerByQid.get(q.id);
+          if (submitted === undefined) {
+            return (
+              <Circle
+                key={q.id}
+                className="text-slate-300"
+                style={{
+                  width: 'min(14px, 3.5cqmin)',
+                  height: 'min(14px, 3.5cqmin)',
+                }}
+              />
+            );
+          }
+          const isCorrect = submitted === correctAnswerById.get(q.id);
+          return isCorrect ? (
+            <CheckCircle2
+              key={q.id}
+              className="text-emerald-500"
+              style={{
+                width: 'min(14px, 3.5cqmin)',
+                height: 'min(14px, 3.5cqmin)',
+              }}
+            />
+          ) : (
+            <XCircle
+              key={q.id}
+              className="text-brand-red-primary"
+              style={{
+                width: 'min(14px, 3.5cqmin)',
+                height: 'min(14px, 3.5cqmin)',
+              }}
+            />
+          );
+        })}
+        <span
+          className={`font-black ml-1 ${
+            score >= 70
+              ? 'text-emerald-600'
+              : score >= 40
+                ? 'text-amber-600'
+                : 'text-brand-red-primary'
+          }`}
+          style={{ fontSize: 'min(14px, 4.5cqmin)' }}
+        >
+          {score}%
+        </span>
+      </div>
+    </div>
+  );
+};
+
+/* ─── KPI tile ──────────────────────────────────────────────────────────── */
+
+interface StatTileProps {
+  label: string;
+  value: number | string;
+  icon: React.ReactNode;
+  color: 'blue' | 'amber' | 'green';
+}
+
+const StatTile: React.FC<StatTileProps> = ({ label, value, icon, color }) => {
+  const colorClasses =
+    color === 'blue'
+      ? 'text-brand-blue-primary'
+      : color === 'amber'
+        ? 'text-amber-600'
+        : 'text-emerald-600';
+  return (
+    <div
+      className="bg-white border border-slate-100 rounded-xl text-center"
+      style={{ padding: 'min(10px, 2.5cqmin)' }}
+    >
+      <div
+        className={`flex items-center justify-center ${colorClasses}`}
+        style={{
+          gap: 'min(4px, 1cqmin)',
+          marginBottom: 'min(4px, 1cqmin)',
+        }}
+      >
+        {icon}
+        <span
+          className="font-bold uppercase tracking-wider"
+          style={{ fontSize: 'min(10px, 3cqmin)' }}
+        >
+          {label}
+        </span>
+      </div>
+      <p
+        className={`font-black ${colorClasses}`}
+        style={{ fontSize: 'min(22px, 7cqmin)' }}
+      >
+        {value}
+      </p>
+    </div>
+  );
+};
+
+/* ─── Main component ────────────────────────────────────────────────────── */
+
+export const VideoActivityLiveMonitor: React.FC<
+  VideoActivityLiveMonitorProps
+> = ({ session, responses, onEnd, onPause, onResume, onBack }) => {
+  const { showConfirm } = useDialog();
+  const questions = session.questions;
+  const [ending, setEnding] = useState(false);
+  const [toggling, setToggling] = useState(false);
+
+  // Derive aggregate counts in a single O(N) pass — mirrors the pattern in
+  // Results.tsx so the two views compute "completed" the same way.
+  const { completed, inProgress, totalAnswers } = useMemo(() => {
+    let _completed = 0;
+    let _inProgress = 0;
+    let _totalAnswers = 0;
+    for (const r of responses) {
+      _totalAnswers += r.answers.length;
+      if (r.completedAt !== null) _completed++;
+      else _inProgress++;
+    }
+    return {
+      completed: _completed,
+      inProgress: _inProgress,
+      totalAnswers: _totalAnswers,
+    };
+  }, [responses]);
+
+  const handleEnd = useCallback(async () => {
+    const ok = await showConfirm(
+      'End this assignment? The student URL will stop working. Responses are preserved and will still be viewable from the Archive.',
+      {
+        title: 'End Assignment',
+        variant: 'warning',
+        confirmLabel: 'End',
+      }
+    );
+    if (!ok) return;
+    setEnding(true);
+    try {
+      await onEnd();
+    } finally {
+      setEnding(false);
+    }
+  }, [showConfirm, onEnd]);
+
+  const handleTogglePause = useCallback(async () => {
+    if (toggling) return;
+    setToggling(true);
+    try {
+      // VA assignment pause maps to session 'ended', so the live indicator
+      // for "paused" reads the assignment status; we drive the toggle
+      // entirely off the parent's onPause/onResume handlers.
+      const isPaused = session.status === 'ended';
+      if (isPaused) {
+        if (onResume) await onResume();
+      } else if (onPause) {
+        await onPause();
+      }
+    } finally {
+      setToggling(false);
+    }
+  }, [toggling, session.status, onPause, onResume]);
+
+  // VA sessions are binary (active | ended). When the assignment is paused
+  // the parent toggles the session to 'ended', so we treat status==='ended'
+  // here as "paused-or-ended" and rely on the parent's pause/resume wiring
+  // to distinguish them. The toggle button is only rendered when the parent
+  // supplies pause/resume callbacks.
+  const isLive = session.status === 'active';
+  const sortedResponses = useMemo(() => {
+    return responses.slice().sort((a, b) => {
+      // Joined-most-recently first within each status bucket; completed
+      // students sink to the bottom so the teacher can focus on stragglers.
+      if ((a.completedAt === null) !== (b.completedAt === null)) {
+        return a.completedAt === null ? -1 : 1;
+      }
+      return b.joinedAt - a.joinedAt;
+    });
+  }, [responses]);
+
+  return (
+    <div className="flex flex-col h-full font-sans bg-brand-blue-lighter/10">
+      {/* ─── Header strip ───────────────────────────────────────────────── */}
+      <div
+        className="border-b border-brand-blue-primary/10 bg-white"
+        style={{ padding: 'min(12px, 2.5cqmin) min(16px, 4cqmin)' }}
+      >
+        <div className="flex items-center justify-between">
+          <div
+            className="flex items-center min-w-0"
+            style={{ gap: 'min(8px, 2cqmin)' }}
+          >
+            {onBack && (
+              <button
+                onClick={onBack}
+                className="flex items-center justify-center rounded-lg text-brand-blue-dark/70 hover:text-brand-blue-dark hover:bg-brand-blue-lighter/30 transition-colors shrink-0"
+                style={{
+                  width: 'min(28px, 7cqmin)',
+                  height: 'min(28px, 7cqmin)',
+                }}
+                title="Back to assignments"
+                aria-label="Back to assignments"
+              >
+                <ArrowLeft
+                  style={{
+                    width: 'min(16px, 4cqmin)',
+                    height: 'min(16px, 4cqmin)',
+                  }}
+                />
+              </button>
+            )}
+            <div
+              className={`rounded-full shrink-0 ${
+                isLive
+                  ? 'bg-brand-red-primary animate-pulse shadow-[0_0_8px_rgba(173,33,34,0.5)]'
+                  : 'bg-amber-500'
+              }`}
+              style={{
+                width: 'min(10px, 2.5cqmin)',
+                height: 'min(10px, 2.5cqmin)',
+              }}
+            />
+            <div className="flex flex-col min-w-0">
+              <div
+                className={`flex items-center gap-1.5 font-black leading-none uppercase tracking-tight ${
+                  isLive ? 'text-brand-red-primary' : 'text-amber-600'
+                }`}
+                style={{ fontSize: 'min(12px, 4cqmin)' }}
+              >
+                <span>{isLive ? 'Live' : 'Paused'}</span>
+              </div>
+              <span
+                className="text-brand-blue-dark font-bold truncate"
+                style={{ fontSize: 'min(11px, 3.5cqmin)' }}
+              >
+                {session.assignmentName}
+              </span>
+            </div>
+          </div>
+          <div
+            className="flex items-center shrink-0"
+            style={{ gap: 'min(6px, 1.5cqmin)' }}
+          >
+            {(onPause ?? onResume) && (
+              <button
+                onClick={() => void handleTogglePause()}
+                disabled={toggling}
+                className="flex items-center bg-amber-500 hover:bg-amber-600 disabled:opacity-50 text-white font-black rounded-xl transition-all shadow-md active:scale-95"
+                style={{
+                  gap: 'min(6px, 1.5cqmin)',
+                  padding: 'min(6px, 1.5cqmin) min(12px, 3cqmin)',
+                  fontSize: 'min(11px, 3.5cqmin)',
+                }}
+                title={
+                  isLive
+                    ? 'Pause — students see a paused screen'
+                    : 'Resume — students can rejoin'
+                }
+              >
+                {toggling ? (
+                  <Loader2
+                    className="animate-spin"
+                    style={{
+                      width: 'min(14px, 3.5cqmin)',
+                      height: 'min(14px, 3.5cqmin)',
+                    }}
+                  />
+                ) : isLive ? (
+                  <Pause
+                    style={{
+                      width: 'min(14px, 3.5cqmin)',
+                      height: 'min(14px, 3.5cqmin)',
+                    }}
+                  />
+                ) : (
+                  <Play
+                    style={{
+                      width: 'min(14px, 3.5cqmin)',
+                      height: 'min(14px, 3.5cqmin)',
+                    }}
+                  />
+                )}
+                {isLive ? 'PAUSE' : 'RESUME'}
+              </button>
+            )}
+            <button
+              onClick={() => void handleEnd()}
+              disabled={ending}
+              className="flex items-center bg-brand-red-primary hover:bg-brand-red-dark disabled:opacity-50 text-white font-black rounded-xl transition-all shadow-md active:scale-95"
+              style={{
+                gap: 'min(6px, 1.5cqmin)',
+                padding: 'min(6px, 1.5cqmin) min(12px, 3cqmin)',
+                fontSize: 'min(11px, 3.5cqmin)',
+              }}
+              title="End the assignment. Responses are preserved."
+            >
+              {ending ? (
+                <Loader2
+                  className="animate-spin"
+                  style={{
+                    width: 'min(14px, 3.5cqmin)',
+                    height: 'min(14px, 3.5cqmin)',
+                  }}
+                />
+              ) : (
+                <Square
+                  style={{
+                    width: 'min(14px, 3.5cqmin)',
+                    height: 'min(14px, 3.5cqmin)',
+                  }}
+                />
+              )}
+              END
+            </button>
+          </div>
+        </div>
+        <p
+          className="text-slate-500 truncate"
+          style={{
+            fontSize: 'min(10px, 3cqmin)',
+            marginTop: 'min(4px, 1cqmin)',
+          }}
+        >
+          {session.activityTitle} · {questions.length} question
+          {questions.length === 1 ? '' : 's'}
+        </p>
+      </div>
+
+      {/* ─── Body ───────────────────────────────────────────────────────── */}
+      <div
+        className="flex-1 overflow-y-auto custom-scrollbar"
+        style={{ padding: 'min(14px, 3.5cqmin)' }}
+      >
+        <div className="flex flex-col" style={{ gap: 'min(12px, 3cqmin)' }}>
+          {/* KPI tiles */}
+          <div className="grid grid-cols-3" style={{ gap: 'min(8px, 2cqmin)' }}>
+            <StatTile
+              label="Joined"
+              value={responses.length}
+              icon={
+                <Users
+                  style={{
+                    width: 'min(12px, 3.5cqmin)',
+                    height: 'min(12px, 3.5cqmin)',
+                  }}
+                />
+              }
+              color="blue"
+            />
+            <StatTile
+              label="Active"
+              value={inProgress}
+              icon={
+                <Clock
+                  style={{
+                    width: 'min(12px, 3.5cqmin)',
+                    height: 'min(12px, 3.5cqmin)',
+                  }}
+                />
+              }
+              color="amber"
+            />
+            <StatTile
+              label="Finished"
+              value={completed}
+              icon={
+                <CheckCircle2
+                  style={{
+                    width: 'min(12px, 3.5cqmin)',
+                    height: 'min(12px, 3.5cqmin)',
+                  }}
+                />
+              }
+              color="green"
+            />
+          </div>
+
+          {/* Roster */}
+          <div className="flex flex-col" style={{ gap: 'min(6px, 1.5cqmin)' }}>
+            <div className="flex items-center justify-between border-b border-brand-blue-primary/10 pb-1">
+              <span
+                className="text-brand-blue-primary/60 font-black uppercase tracking-widest"
+                style={{ fontSize: 'min(10px, 3cqmin)' }}
+              >
+                Roster · {responses.length}
+              </span>
+              <span
+                className="text-slate-400"
+                style={{ fontSize: 'min(9px, 2.5cqmin)' }}
+              >
+                {totalAnswers} total answer{totalAnswers === 1 ? '' : 's'}
+              </span>
+            </div>
+
+            {responses.length === 0 ? (
+              <div
+                className="flex flex-col items-center justify-center text-slate-400 text-center"
+                style={{
+                  gap: 'min(8px, 2cqmin)',
+                  padding: 'min(32px, 8cqmin) min(16px, 4cqmin)',
+                }}
+              >
+                <Users
+                  className="opacity-40"
+                  style={{
+                    width: 'min(28px, 7cqmin)',
+                    height: 'min(28px, 7cqmin)',
+                  }}
+                />
+                <p
+                  className="font-medium text-slate-500"
+                  style={{ fontSize: 'min(12px, 3.5cqmin)' }}
+                >
+                  Waiting for students to join…
+                </p>
+                <p style={{ fontSize: 'min(10px, 3cqmin)' }}>
+                  Share the assignment link from the In Progress tab.
+                </p>
+              </div>
+            ) : (
+              <div
+                className="flex flex-col"
+                style={{ gap: 'min(6px, 1.5cqmin)' }}
+              >
+                {sortedResponses.map((r) => (
+                  <StudentRow
+                    key={r.studentUid}
+                    response={r}
+                    questions={questions}
+                  />
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/components/widgets/VideoActivityWidget/components/VideoActivityManager.tsx
+++ b/components/widgets/VideoActivityWidget/components/VideoActivityManager.tsx
@@ -138,7 +138,9 @@ export interface VideoActivityManagerProps {
    * Open the live teacher monitor for an active assignment. Surfaced as the
    * In Progress tab's primary CTA when wired; mirrors the Quiz manager.
    */
-  onArchiveMonitor?: (assignment: VideoActivityAssignment) => void;
+  onArchiveMonitor?: (
+    assignment: VideoActivityAssignment
+  ) => void | Promise<void>;
 
   /** Persisted library grid/list toggle (from widget config). */
   initialLibraryViewMode?: 'grid' | 'list';
@@ -727,7 +729,7 @@ export const VideoActivityManager: React.FC<VideoActivityManagerProps> = ({
                 onClick: () => {
                   if (mode === 'active') {
                     if (isLiveActive && onArchiveMonitor) {
-                      onArchiveMonitor(assignment);
+                      void onArchiveMonitor(assignment);
                     } else if (onArchiveCopyUrl) {
                       onArchiveCopyUrl(assignment);
                     }

--- a/components/widgets/VideoActivityWidget/components/VideoActivityManager.tsx
+++ b/components/widgets/VideoActivityWidget/components/VideoActivityManager.tsx
@@ -29,6 +29,7 @@ import {
   FileUp,
   Link2,
   Loader2,
+  Monitor,
   PlayCircle,
   Plus,
   Trash2,
@@ -133,6 +134,11 @@ export interface VideoActivityManagerProps {
   onArchiveDeactivate?: (assignment: VideoActivityAssignment) => Promise<void>;
   onArchiveDelete?: (assignment: VideoActivityAssignment) => Promise<void>;
   onArchiveResults?: (assignment: VideoActivityAssignment) => void;
+  /**
+   * Open the live teacher monitor for an active assignment. Surfaced as the
+   * In Progress tab's primary CTA when wired; mirrors the Quiz manager.
+   */
+  onArchiveMonitor?: (assignment: VideoActivityAssignment) => void;
 
   /** Persisted library grid/list toggle (from widget config). */
   initialLibraryViewMode?: 'grid' | 'list';
@@ -234,6 +240,7 @@ export const VideoActivityManager: React.FC<VideoActivityManagerProps> = ({
   onArchiveDeactivate,
   onArchiveDelete,
   onArchiveResults,
+  onArchiveMonitor,
   initialLibraryViewMode,
   onLibraryViewModeChange,
   rosters,
@@ -685,13 +692,18 @@ export const VideoActivityManager: React.FC<VideoActivityManagerProps> = ({
             mode
           );
 
-          // Primary action: for active assignments, the headline CTA copies
-          // the join link (the label matches the handler — previously "Open"
-          // which was misleading since no new view was opened). For archived
-          // assignments, the primary action opens Results.
+          // Primary action: for active (live) assignments the headline CTA
+          // is Monitor when wired — that's the live teacher view of student
+          // progress. Falls back to "Copy link" for paused assignments
+          // (Monitor would show a paused screen) and for callers that don't
+          // wire `onArchiveMonitor`. Archive mode still opens Results.
+          const isLiveActive =
+            mode === 'active' && assignment.status === 'active';
           const primaryAction =
             mode === 'active'
-              ? { label: 'Copy link', icon: Copy }
+              ? isLiveActive && onArchiveMonitor
+                ? { label: 'Monitor', icon: Monitor }
+                : { label: 'Copy link', icon: Copy }
               : { label: 'Results', icon: BarChart3 };
 
           return (
@@ -713,8 +725,12 @@ export const VideoActivityManager: React.FC<VideoActivityManagerProps> = ({
                 label: primaryAction.label,
                 icon: primaryAction.icon,
                 onClick: () => {
-                  if (mode === 'active' && onArchiveCopyUrl) {
-                    onArchiveCopyUrl(assignment);
+                  if (mode === 'active') {
+                    if (isLiveActive && onArchiveMonitor) {
+                      onArchiveMonitor(assignment);
+                    } else if (onArchiveCopyUrl) {
+                      onArchiveCopyUrl(assignment);
+                    }
                   } else if (onArchiveResults) {
                     onArchiveResults(assignment);
                   }

--- a/hooks/useVideoActivitySession.ts
+++ b/hooks/useVideoActivitySession.ts
@@ -271,6 +271,11 @@ export const useVideoActivitySessionTeacher =
         sessionDocUnsubRef.current = null;
       }
 
+      // Clear stale state from any prior subscription so consumers don't
+      // briefly render the previous session's roster / status while the
+      // first snapshot for the new session is in flight.
+      setResponses([]);
+      setLiveSession(null);
       setLoading(true);
       unsubRef.current = onSnapshot(
         collection(db, SESSIONS_COLLECTION, sessionId, RESPONSES_SUBCOLLECTION),

--- a/hooks/useVideoActivitySession.ts
+++ b/hooks/useVideoActivitySession.ts
@@ -117,9 +117,18 @@ export interface UseVideoActivitySessionTeacherResult {
   endSession: (sessionId: string) => Promise<void>;
   /** Real-time responses for a specific session. */
   responses: VideoActivityResponse[];
-  /** Subscribe to a specific session's responses. Cleans up any previous listener. */
+  /**
+   * Real-time snapshot of the session document the responses listener is
+   * scoped to. Populated by `subscribeToSession`. Lets the live monitor
+   * reflect pause/resume state changes without an extra fetch round-trip.
+   */
+  liveSession: VideoActivitySession | null;
+  /**
+   * Subscribe to a specific session's session doc + responses subcollection.
+   * Cleans up any previous listeners.
+   */
   subscribeToSession: (sessionId: string) => void;
-  /** Unsubscribe from the current session listener. */
+  /** Unsubscribe from the current session listeners. */
   unsubscribeFromSession: () => void;
   loading: boolean;
 }
@@ -129,8 +138,12 @@ export const useVideoActivitySessionTeacher =
     const [sessions, setSessions] = useState<VideoActivitySession[]>([]);
     const [sessionsLoading, setSessionsLoading] = useState(false);
     const [responses, setResponses] = useState<VideoActivityResponse[]>([]);
+    const [liveSession, setLiveSession] = useState<VideoActivitySession | null>(
+      null
+    );
     const [loading, setLoading] = useState(false);
     const unsubRef = useRef<Unsubscribe | null>(null);
+    const sessionDocUnsubRef = useRef<Unsubscribe | null>(null);
     const sessionsUnsubRef = useRef<Unsubscribe | null>(null);
 
     const createSession = useCallback(
@@ -248,10 +261,14 @@ export const useVideoActivitySessionTeacher =
     }, []);
 
     const subscribeToSession = useCallback((sessionId: string) => {
-      // Clean up any existing listener before creating a new one
+      // Clean up any existing listeners before creating new ones
       if (unsubRef.current) {
         unsubRef.current();
         unsubRef.current = null;
+      }
+      if (sessionDocUnsubRef.current) {
+        sessionDocUnsubRef.current();
+        sessionDocUnsubRef.current = null;
       }
 
       setLoading(true);
@@ -270,6 +287,30 @@ export const useVideoActivitySessionTeacher =
           setLoading(false);
         }
       );
+
+      // Mirror the session doc so consumers (e.g. the live monitor) reflect
+      // pause/resume state changes in real time.
+      sessionDocUnsubRef.current = onSnapshot(
+        doc(db, SESSIONS_COLLECTION, sessionId),
+        (snap) => {
+          if (snap.exists()) {
+            setLiveSession(
+              normalizeSession(
+                snap.id,
+                snap.data() as Partial<VideoActivitySession>
+              )
+            );
+          } else {
+            setLiveSession(null);
+          }
+        },
+        (err) => {
+          console.error(
+            '[useVideoActivitySessionTeacher] Session doc listener error:',
+            err
+          );
+        }
+      );
     }, []);
 
     const unsubscribeFromSession = useCallback(() => {
@@ -277,7 +318,12 @@ export const useVideoActivitySessionTeacher =
         unsubRef.current();
         unsubRef.current = null;
       }
+      if (sessionDocUnsubRef.current) {
+        sessionDocUnsubRef.current();
+        sessionDocUnsubRef.current = null;
+      }
       setResponses([]);
+      setLiveSession(null);
     }, []);
 
     // Clean up on unmount
@@ -291,6 +337,10 @@ export const useVideoActivitySessionTeacher =
           unsubRef.current();
           unsubRef.current = null;
         }
+        if (sessionDocUnsubRef.current) {
+          sessionDocUnsubRef.current();
+          sessionDocUnsubRef.current = null;
+        }
       };
     }, []);
 
@@ -303,6 +353,7 @@ export const useVideoActivitySessionTeacher =
       renameSession,
       endSession,
       responses,
+      liveSession,
       subscribeToSession,
       unsubscribeFromSession,
       loading,

--- a/types.ts
+++ b/types.ts
@@ -2233,7 +2233,7 @@ export interface VideoActivityMetadata {
   folderId?: string | null;
 }
 
-export type VideoActivityView = 'manager' | 'create' | 'results';
+export type VideoActivityView = 'manager' | 'create' | 'results' | 'monitor';
 
 /** Widget configuration for the video activity widget (teacher side). */
 export interface VideoActivityConfig {


### PR DESCRIPTION
## Summary

Adds a real-time teacher monitor for the Video Activity widget, paralleling
`QuizLiveMonitor`. Teachers can now click **Monitor** on a Live assignment
in the In Progress tab and watch students join, answer, and complete the
activity in real time — replacing the `// runtime will follow in a later
wave` placeholder in the manager.

### What's new

- **`VideoActivityLiveMonitor`** — new component under
  `components/widgets/VideoActivityWidget/components/`. Header strip with
  Live/Paused indicator, three KPI tiles (Joined / Active / Finished), and
  a scrollable roster. Each row shows the student's name, PIN, optional
  classPeriod, last-answer timestamp, completion badge, and a per-question
  status strip (✓ correct / ✗ incorrect / ○ unanswered) plus a colored
  score percent.
- **`useVideoActivitySessionTeacher`** — extended to mirror the session
  document alongside the responses subcollection. New `liveSession` field
  lets the monitor reflect pause/resume state without an extra fetch.
- **`VideoActivityManager`** — gains an `onArchiveMonitor` prop. The
  In Progress tab's primary CTA on Live rows is now Monitor (falls back
  to Copy link on paused rows or when the handler isn't wired).
- **`VideoActivityWidget`** — adds the `'monitor'` view branch with
  Pause / Resume / End controls wired to the existing
  `pauseAssignment` / `resumeAssignment` / `deactivateAssignment` hooks
  from `useVideoActivityAssignments`.
- **`VideoActivityView`** type — adds `'monitor'`.

### Notes / divergences from the prompt

- The prompt mentions a view-only gate keyed on `session.mode ===
  'view-only'`, but `VideoActivitySession` has no `mode` field today
  (the same is true of `QuizSession` — there is no matching block in
  `QuizWidget.tsx`). Per the scope guard "Don't add new Firestore
  fields or change response shapes," this PR does not introduce one.
  When/if Stage 3 of the assignment-modes rollout lands the field, the
  view-only branch can be added with a single `if` ahead of the monitor
  render.
- Kept the monitor focused on the acceptance criteria rather than
  porting QuizLiveMonitor's gamification, leaderboard broadcast, podium,
  period filter, and pseudonym surfaces — none of those have analogues
  on the Video Activity data model today.

## Test plan

- [x] `pnpm run type-check` — clean
- [x] `pnpm run lint` — clean (zero warnings)
- [x] `pnpm run test` — 1697/1697 passing
- [ ] Manual: assign a Video Activity to a roster, click Monitor from the
      In Progress tab, have a student join and answer questions, verify
      the roster row updates live with per-question ✓/✗ indicators
- [ ] Manual: click Pause from the monitor → header flips to "Paused",
      header dot turns amber. Click Resume → flips back to "Live"
- [ ] Manual: click End → confirmation dialog → assignment moves to
      Archive tab; Monitor view returns to manager
- [ ] Manual: refresh while in monitor view → falls back to manager
      gracefully (selectedSession is local state, same pattern as
      Results)

https://claude.ai/code/session_019uSMQe8v9ipLZkQv6ost5c

---
_Generated by [Claude Code](https://claude.ai/code/session_019uSMQe8v9ipLZkQv6ost5c)_