### PR TITLE
feat(view-only): minimal Share modal + hide overlay buttons

### DIFF
--- a/components/common/library/AssignmentArchiveCard.tsx
+++ b/components/common/library/AssignmentArchiveCard.tsx
@@ -202,7 +202,7 @@ export function AssignmentArchiveCard<TAssignment>({
   const tone = TONE_STYLES[status.tone];
   const isArchive = mode === 'archive';
 
-  const PrimaryIcon = primaryAction.icon;
+  const PrimaryIcon = primaryAction?.icon;
 
   const cardClass = isArchive
     ? 'bg-white/70 border-slate-200/60 opacity-70'
@@ -258,19 +258,22 @@ export function AssignmentArchiveCard<TAssignment>({
           {status.label}
         </div>
 
-        {/* Primary action */}
-        <button
-          type="button"
-          onClick={primaryAction.onClick}
-          disabled={primaryAction.disabled}
-          title={
-            primaryAction.disabled ? primaryAction.disabledReason : undefined
-          }
-          className="flex items-center gap-1 shrink-0 px-2.5 py-1 bg-brand-blue-primary hover:bg-brand-blue-dark text-white text-xs font-bold rounded-lg transition-all active:scale-95 disabled:opacity-50 disabled:cursor-not-allowed"
-        >
-          {PrimaryIcon && <PrimaryIcon size={12} className="shrink-0" />}
-          <span>{primaryAction.label}</span>
-        </button>
+        {/* Primary action — omitted on archived view-only cards where the
+            link is dead and a Copy button would be misleading. */}
+        {primaryAction && (
+          <button
+            type="button"
+            onClick={primaryAction.onClick}
+            disabled={primaryAction.disabled}
+            title={
+              primaryAction.disabled ? primaryAction.disabledReason : undefined
+            }
+            className="flex items-center gap-1 shrink-0 px-2.5 py-1 bg-brand-blue-primary hover:bg-brand-blue-dark text-white text-xs font-bold rounded-lg transition-all active:scale-95 disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {PrimaryIcon && <PrimaryIcon size={12} className="shrink-0" />}
+            <span>{primaryAction.label}</span>
+          </button>
+        )}
 
         {/* Overflow menu */}
         {secondaryActions && secondaryActions.length > 0 && (

--- a/components/common/library/LibraryItemCard.tsx
+++ b/components/common/library/LibraryItemCard.tsx
@@ -28,6 +28,7 @@ import { LibraryGridLockContext } from './LibraryGridLockContext';
 import type {
   LibraryBadge,
   LibraryBadgeTone,
+  LibraryIconAction,
   LibraryItemCardProps,
   LibraryMenuAction,
 } from './types';
@@ -185,6 +186,43 @@ const OverflowMenu: React.FC<OverflowMenuProps> = ({ actions }) => {
   );
 };
 
+/* ─── Inline icon-only action button ──────────────────────────────────────── */
+
+const IconActionButton: React.FC<{ action: LibraryIconAction }> = ({
+  action,
+}) => {
+  const Icon = action.icon;
+  const isPrimary = action.tone === 'primary';
+  return (
+    <button
+      type="button"
+      onClick={(e) => {
+        e.stopPropagation();
+        if (!action.disabled) action.onClick();
+      }}
+      disabled={action.disabled}
+      title={action.disabled ? action.disabledReason : action.label}
+      aria-label={action.label}
+      className={`inline-flex shrink-0 items-center justify-center rounded-xl shadow-sm transition-all active:scale-95 disabled:cursor-not-allowed disabled:opacity-50 ${
+        isPrimary
+          ? 'bg-brand-blue-primary text-white hover:bg-brand-blue-dark'
+          : 'border border-slate-200 bg-white text-slate-600 hover:border-brand-blue-primary/40 hover:bg-brand-blue-lighter/30 hover:text-brand-blue-dark'
+      }`}
+      style={{
+        width: 'min(34px, 9.5cqmin)',
+        height: 'min(34px, 9.5cqmin)',
+      }}
+    >
+      <Icon
+        style={{
+          width: 'min(16px, 4.5cqmin)',
+          height: 'min(16px, 4.5cqmin)',
+        }}
+      />
+    </button>
+  );
+};
+
 /* ─── Badge chip ──────────────────────────────────────────────────────────── */
 
 const BadgeChip: React.FC<{ badge: LibraryBadge }> = ({ badge }) => {
@@ -218,6 +256,7 @@ function CardBody<TMeta>(props: CardBodyProps<TMeta>) {
     thumbnail,
     badges,
     primaryAction,
+    iconActions,
     secondaryActions,
     onClick,
     viewMode = 'grid',
@@ -229,7 +268,7 @@ function CardBody<TMeta>(props: CardBodyProps<TMeta>) {
     onSelectionToggle,
   } = props;
 
-  const PrimaryIcon = primaryAction.icon;
+  const PrimaryIcon = primaryAction?.icon;
   const isList = viewMode === 'list';
 
   const handleBodyClick = (e: React.MouseEvent<HTMLDivElement>) => {
@@ -259,8 +298,13 @@ function CardBody<TMeta>(props: CardBodyProps<TMeta>) {
         .filter(Boolean)
         .join(' ')}
       style={{
-        gap: isList ? 'min(12px, 3cqmin)' : 'min(12px, 3cqmin)',
-        padding: isList ? 'min(12px, 2.8cqmin)' : 'min(16px, 3.5cqmin)',
+        // List rows are deliberately compact — the row is the click target
+        // and gets read at-a-glance; padding here was previously over-tuned
+        // for grid/card density and felt cavernous in list mode.
+        gap: isList ? 'min(10px, 2.5cqmin)' : 'min(12px, 3cqmin)',
+        padding: isList
+          ? 'min(8px, 2cqmin) min(10px, 2.5cqmin)'
+          : 'min(16px, 3.5cqmin)',
       }}
       aria-hidden={isDragOverlay}
     >
@@ -358,35 +402,40 @@ function CardBody<TMeta>(props: CardBodyProps<TMeta>) {
         className={`flex shrink-0 items-center ${isList ? '' : 'self-end'}`}
         style={{ gap: 'min(6px, 1.5cqmin)' }}
       >
-        <button
-          type="button"
-          onClick={(e) => {
-            e.stopPropagation();
-            if (!primaryAction.disabled) primaryAction.onClick();
-          }}
-          disabled={primaryAction.disabled}
-          title={
-            primaryAction.disabled
-              ? primaryAction.disabledReason
-              : primaryAction.label
-          }
-          className="inline-flex shrink-0 items-center gap-1.5 rounded-xl bg-brand-blue-primary font-bold uppercase tracking-widest text-white shadow-sm transition-all hover:bg-brand-blue-dark active:scale-95 disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:bg-brand-blue-primary"
-          style={{
-            paddingInline: 'min(14px, 3.2cqmin)',
-            paddingBlock: 'min(6px, 1.6cqmin)',
-            fontSize: 'min(12px, 3.8cqmin)',
-          }}
-        >
-          {PrimaryIcon && (
-            <PrimaryIcon
-              style={{
-                width: 'min(14px, 4cqmin)',
-                height: 'min(14px, 4cqmin)',
-              }}
-            />
-          )}
-          {primaryAction.label}
-        </button>
+        {iconActions?.map((action) => (
+          <IconActionButton key={action.id} action={action} />
+        ))}
+        {primaryAction && (
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              if (!primaryAction.disabled) primaryAction.onClick();
+            }}
+            disabled={primaryAction.disabled}
+            title={
+              primaryAction.disabled
+                ? primaryAction.disabledReason
+                : primaryAction.label
+            }
+            className="inline-flex shrink-0 items-center gap-1.5 rounded-xl bg-brand-blue-primary font-bold uppercase tracking-widest text-white shadow-sm transition-all hover:bg-brand-blue-dark active:scale-95 disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:bg-brand-blue-primary"
+            style={{
+              paddingInline: 'min(14px, 3.2cqmin)',
+              paddingBlock: 'min(6px, 1.6cqmin)',
+              fontSize: 'min(12px, 3.8cqmin)',
+            }}
+          >
+            {PrimaryIcon && (
+              <PrimaryIcon
+                style={{
+                  width: 'min(14px, 4cqmin)',
+                  height: 'min(14px, 4cqmin)',
+                }}
+              />
+            )}
+            {primaryAction.label}
+          </button>
+        )}
         {secondaryActions && secondaryActions.length > 0 && (
           <OverflowMenu actions={secondaryActions} />
         )}

--- a/components/common/library/LibraryItemCard.tsx
+++ b/components/common/library/LibraryItemCard.tsx
@@ -203,10 +203,14 @@ const IconActionButton: React.FC<{ action: LibraryIconAction }> = ({
       disabled={action.disabled}
       title={action.disabled ? action.disabledReason : action.label}
       aria-label={action.label}
-      className={`inline-flex shrink-0 items-center justify-center rounded-xl shadow-sm transition-all active:scale-95 disabled:cursor-not-allowed disabled:opacity-50 ${
+      // Hover affordances are only meaningful on an enabled button — gating
+      // them behind `enabled:` keeps the disabled state visually inert
+      // (Tailwind's `enabled:` variant matches `:not(:disabled)`). Without
+      // this, a disabled button still glowed on hover, which is misleading.
+      className={`inline-flex shrink-0 items-center justify-center rounded-xl shadow-sm transition-all enabled:active:scale-95 disabled:cursor-not-allowed disabled:opacity-50 ${
         isPrimary
-          ? 'bg-brand-blue-primary text-white hover:bg-brand-blue-dark'
-          : 'border border-slate-200 bg-white text-slate-600 hover:border-brand-blue-primary/40 hover:bg-brand-blue-lighter/30 hover:text-brand-blue-dark'
+          ? 'bg-brand-blue-primary text-white enabled:hover:bg-brand-blue-dark'
+          : 'border border-slate-200 bg-white text-slate-600 enabled:hover:border-brand-blue-primary/40 enabled:hover:bg-brand-blue-lighter/30 enabled:hover:text-brand-blue-dark'
       }`}
       style={{
         width: 'min(34px, 9.5cqmin)',

--- a/components/common/library/ViewCountBadge.tsx
+++ b/components/common/library/ViewCountBadge.tsx
@@ -29,7 +29,7 @@ export const ViewCountBadge: React.FC<ViewCountBadgeProps> = ({ count }) => {
         className="inline-flex items-center gap-1 text-xs font-medium text-slate-300 select-none"
         style={{ visibility: 'hidden' }}
       >
-        <Eye className="w-3 h-3 shrink-0" />
+        <Eye aria-hidden="true" className="w-3 h-3 shrink-0" />
         <span>0 views</span>
       </span>
     );

--- a/components/common/library/ViewCountBadge.tsx
+++ b/components/common/library/ViewCountBadge.tsx
@@ -1,0 +1,32 @@
+/**
+ * ViewCountBadge — inline metadata chip for view-only assignment cards.
+ *
+ * Shows "👁 N views" next to the title on Shared / Archive rows for
+ * view-only assignments across Quiz / Video Activity / Mini App / Guided
+ * Learning. Render via `AssignmentArchiveCard.meta`.
+ *
+ * `count === null` (loading or unavailable) renders nothing — we'd rather
+ * show no metric at all than flicker a "0 views" placeholder.
+ */
+
+import React from 'react';
+import { Eye } from 'lucide-react';
+
+interface ViewCountBadgeProps {
+  count: number | null;
+}
+
+export const ViewCountBadge: React.FC<ViewCountBadgeProps> = ({ count }) => {
+  if (count === null) return null;
+  return (
+    <span
+      className="inline-flex items-center gap-1 text-xs font-medium text-slate-500"
+      title={count === 1 ? 'Link opened 1 time' : `Link opened ${count} times`}
+    >
+      <Eye className="w-3 h-3 shrink-0" />
+      <span>
+        {count} {count === 1 ? 'view' : 'views'}
+      </span>
+    </span>
+  );
+};

--- a/components/common/library/ViewCountBadge.tsx
+++ b/components/common/library/ViewCountBadge.tsx
@@ -5,8 +5,10 @@
  * view-only assignments across Quiz / Video Activity / Mini App / Guided
  * Learning. Render via `AssignmentArchiveCard.meta`.
  *
- * `count === null` (loading or unavailable) renders nothing — we'd rather
- * show no metric at all than flicker a "0 views" placeholder.
+ * While the count is in flight (`count === null` from `useSessionViewCount`)
+ * we render a width-stable invisible placeholder so the meta line doesn't
+ * jump width when the real count arrives. The placeholder is `aria-hidden`
+ * and unselectable so screen readers don't announce a phantom value.
  */
 
 import React from 'react';
@@ -17,7 +19,21 @@ interface ViewCountBadgeProps {
 }
 
 export const ViewCountBadge: React.FC<ViewCountBadgeProps> = ({ count }) => {
-  if (count === null) return null;
+  if (count === null) {
+    // Width-stable placeholder. Width matches "0 views" — close enough to
+    // the typical resolved width that the layout shift is invisible. Using
+    // `visibility: hidden` (not `display: none`) preserves the box.
+    return (
+      <span
+        aria-hidden="true"
+        className="inline-flex items-center gap-1 text-xs font-medium text-slate-300 select-none"
+        style={{ visibility: 'hidden' }}
+      >
+        <Eye className="w-3 h-3 shrink-0" />
+        <span>0 views</span>
+      </span>
+    );
+  }
   return (
     <span
       className="inline-flex items-center gap-1 text-xs font-medium text-slate-500"

--- a/components/common/library/ViewOnlyShareModal.tsx
+++ b/components/common/library/ViewOnlyShareModal.tsx
@@ -17,9 +17,15 @@
  * Mini App keeps its own custom modal (which doubles as the URL display);
  * this primitive serves the three widgets that route through the shared
  * AssignModal in submissions mode.
+ *
+ * Built on the shared `Modal` primitive — same dialog-role, focus-trap
+ * support (via portal to body), Escape-to-close, body scroll lock, and
+ * backdrop-click-to-close that AssignModal uses. Callers conditionally
+ * render this component (target → mount, no target → unmount); when
+ * mounted the modal is always open, so we pass `isOpen={true}`.
  */
 
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useId, useState } from 'react';
 import {
   Loader2,
   Link2,
@@ -27,8 +33,8 @@ import {
   Copy,
   Check,
   ExternalLink,
-  X,
 } from 'lucide-react';
+import { Modal } from '../Modal';
 
 export interface ViewOnlyShareModalProps {
   /** The thing being shared (quiz title, set title, activity title). */
@@ -54,6 +60,7 @@ export const ViewOnlyShareModal: React.FC<ViewOnlyShareModalProps> = ({
   onClose,
 }) => {
   const [copied, setCopied] = useState(false);
+  const headerLabelId = useId();
 
   // Reset the "Copied!" affordance back to "Copy Link" 2s after a successful
   // copy. Owning the timer in an effect (rather than a bare setTimeout from
@@ -77,112 +84,146 @@ export const ViewOnlyShareModal: React.FC<ViewOnlyShareModalProps> = ({
     }
   }, [createdLink]);
 
-  return (
-    <div className="absolute inset-0 z-overlay bg-brand-blue-dark/60 backdrop-blur-sm flex items-center justify-center p-4">
-      <div className="bg-white rounded-3xl w-full max-w-sm shadow-2xl overflow-hidden animate-in zoom-in-95 duration-200">
-        {/* Header */}
-        <div
-          className={`p-4 flex items-center justify-between ${createdLink ? 'bg-emerald-600' : 'bg-brand-blue-primary'}`}
+  // Custom coloured header (emerald post-creation, brand-blue pre-creation)
+  // — passed to Modal as `customHeader` so the body's rounded-2xl shell
+  // wraps it cleanly. Modal still owns the close affordance via Escape and
+  // backdrop click; the X button below mirrors the original visual.
+  const header = (
+    <div
+      className={`flex items-center justify-between p-4 rounded-t-2xl text-white ${
+        createdLink ? 'bg-emerald-600' : 'bg-brand-blue-primary'
+      }`}
+    >
+      <div className="flex items-center gap-2">
+        {createdLink ? (
+          <CheckCircle2 aria-hidden="true" className="w-5 h-5" />
+        ) : (
+          <Link2 aria-hidden="true" className="w-5 h-5" />
+        )}
+        <h3
+          id={headerLabelId}
+          className="font-black uppercase tracking-tight text-base"
         >
-          <div className="flex items-center gap-2 text-white">
-            {createdLink ? (
-              <CheckCircle2 className="w-5 h-5" />
-            ) : (
-              <Link2 className="w-5 h-5" />
-            )}
-            <span className="font-black uppercase tracking-tight">
-              {createdLink ? 'Share Link Ready' : 'Share'}
-            </span>
-          </div>
-          <button
-            onClick={onClose}
-            className="text-white/60 hover:text-white transition-colors"
-            aria-label="Close"
-          >
-            <X className="w-5 h-5" />
-          </button>
-        </div>
-
-        <div className="p-5 space-y-4">
-          {createdLink ? (
-            /* Post-creation: show link with Copy / Open. */
-            <>
-              <div className="text-center">
-                <p className="font-bold text-brand-blue-dark text-base truncate px-2">
-                  {itemTitle}
-                </p>
-              </div>
-              <p className="text-slate-600 text-sm text-center">
-                Send this link to students. Anyone with the link can view — no
-                submissions are collected.
-              </p>
-              <div className="bg-slate-50 border border-slate-200 rounded-xl p-3 break-all text-xs text-slate-700 font-mono">
-                {createdLink}
-              </div>
-              <div className="grid gap-2">
-                <button
-                  onClick={() => void handleCopy()}
-                  className="w-full flex items-center justify-center gap-2 bg-brand-blue-primary hover:bg-brand-blue-dark text-white font-bold rounded-xl transition-all active:scale-95 shadow-sm py-3 text-sm"
-                >
-                  {copied ? (
-                    <>
-                      <Check className="w-4 h-4" />
-                      Copied!
-                    </>
-                  ) : (
-                    <>
-                      <Copy className="w-4 h-4" />
-                      Copy Link
-                    </>
-                  )}
-                </button>
-                <a
-                  href={createdLink}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="w-full flex items-center justify-center gap-2 bg-slate-100 hover:bg-slate-200 text-slate-700 font-bold rounded-xl transition-colors py-3 text-sm"
-                >
-                  <ExternalLink className="w-4 h-4" />
-                  Open in New Tab
-                </a>
-              </div>
-            </>
-          ) : (
-            /* Pre-creation: zero form fields, single confirm button. */
-            <>
-              <div className="text-center">
-                <p className="font-bold text-brand-blue-dark text-base truncate px-2">
-                  {itemTitle}
-                </p>
-                <p className="text-brand-blue-primary/60 font-black uppercase tracking-widest mt-1 text-xs">
-                  Create Share Link
-                </p>
-              </div>
-              <p className="text-slate-600 text-sm text-center">
-                Anyone with the link can view this. No submissions are collected
-                — view counts appear in the Shared archive.
-              </p>
-              {error && (
-                <p className="text-sm text-brand-red-primary text-center font-medium">
-                  {error}
-                </p>
-              )}
-              <button
-                onClick={onConfirm}
-                disabled={isCreating}
-                className="w-full flex items-center justify-center gap-2 bg-brand-blue-primary hover:bg-brand-blue-dark text-white font-bold rounded-xl transition-all active:scale-95 shadow-sm py-3 text-sm disabled:opacity-60"
-              >
-                {isCreating ? (
-                  <Loader2 className="w-4 h-4 animate-spin" />
-                ) : (
-                  <Link2 className="w-4 h-4" />
-                )}
-                {isCreating ? 'Creating…' : 'Create Share Link'}
-              </button>
-            </>
-          )}
-        </div>
+          {createdLink ? 'Share Link Ready' : 'Share'}
+        </h3>
       </div>
+      <button
+        type="button"
+        onClick={onClose}
+        className="text-white/60 hover:text-white transition-colors"
+        aria-label="Close"
+      >
+        {/* X glyph rendered as a small inline SVG so we don't widen the
+            lucide-react import for a single icon used only in the header. */}
+        <svg
+          aria-hidden="true"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          className="w-5 h-5"
+        >
+          <line x1="18" y1="6" x2="6" y2="18" />
+          <line x1="6" y1="6" x2="18" y2="18" />
+        </svg>
+      </button>
     </div>
+  );
+
+  return (
+    <Modal
+      isOpen
+      onClose={onClose}
+      maxWidth="max-w-sm"
+      customHeader={header}
+      ariaLabelledby={headerLabelId}
+      contentClassName="p-5 space-y-4"
+      // overflow-hidden so the coloured header's corners get clipped by the
+      // shell's rounded-2xl. Modal's default shell has bg-white + rounded
+      // but no overflow clip.
+      className="overflow-hidden"
+    >
+      {createdLink ? (
+        /* Post-creation: show link with Copy / Open. */
+        <>
+          <div className="text-center">
+            <p className="font-bold text-brand-blue-dark text-base truncate px-2">
+              {itemTitle}
+            </p>
+          </div>
+          <p className="text-slate-600 text-sm text-center">
+            Send this link to students. Anyone with the link can view — no
+            submissions are collected.
+          </p>
+          <div className="bg-slate-50 border border-slate-200 rounded-xl p-3 break-all text-xs text-slate-700 font-mono">
+            {createdLink}
+          </div>
+          <div className="grid gap-2">
+            <button
+              type="button"
+              onClick={() => void handleCopy()}
+              className="w-full flex items-center justify-center gap-2 bg-brand-blue-primary hover:bg-brand-blue-dark text-white font-bold rounded-xl transition-all active:scale-95 shadow-sm py-3 text-sm"
+            >
+              {copied ? (
+                <>
+                  <Check aria-hidden="true" className="w-4 h-4" />
+                  Copied!
+                </>
+              ) : (
+                <>
+                  <Copy aria-hidden="true" className="w-4 h-4" />
+                  Copy Link
+                </>
+              )}
+            </button>
+            <a
+              href={createdLink}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="w-full flex items-center justify-center gap-2 bg-slate-100 hover:bg-slate-200 text-slate-700 font-bold rounded-xl transition-colors py-3 text-sm"
+            >
+              <ExternalLink aria-hidden="true" className="w-4 h-4" />
+              Open in New Tab
+            </a>
+          </div>
+        </>
+      ) : (
+        /* Pre-creation: zero form fields, single confirm button. */
+        <>
+          <div className="text-center">
+            <p className="font-bold text-brand-blue-dark text-base truncate px-2">
+              {itemTitle}
+            </p>
+            <p className="text-brand-blue-primary/60 font-black uppercase tracking-widest mt-1 text-xs">
+              Create Share Link
+            </p>
+          </div>
+          <p className="text-slate-600 text-sm text-center">
+            Anyone with the link can view this. No submissions are collected —
+            view counts appear in the Shared archive.
+          </p>
+          {error && (
+            <p className="text-sm text-brand-red-primary text-center font-medium">
+              {error}
+            </p>
+          )}
+          <button
+            type="button"
+            onClick={onConfirm}
+            disabled={isCreating}
+            className="w-full flex items-center justify-center gap-2 bg-brand-blue-primary hover:bg-brand-blue-dark text-white font-bold rounded-xl transition-all active:scale-95 shadow-sm py-3 text-sm disabled:opacity-60"
+          >
+            {isCreating ? (
+              <Loader2 aria-hidden="true" className="w-4 h-4 animate-spin" />
+            ) : (
+              <Link2 aria-hidden="true" className="w-4 h-4" />
+            )}
+            {isCreating ? 'Creating…' : 'Create Share Link'}
+          </button>
+        </>
+      )}
+    </Modal>
   );
 };

--- a/components/common/library/ViewOnlyShareModal.tsx
+++ b/components/common/library/ViewOnlyShareModal.tsx
@@ -1,0 +1,181 @@
+/**
+ * ViewOnlyShareModal — minimal modal for view-only assignment-mode "Share"
+ * flows.
+ *
+ * Used by widgets when the org-wide assignment mode for that widget is set
+ * to `'view-only'`. Drops everything that's pure friction in the view-only
+ * case (assignment name input, class picker, mode picker, PLC, settings)
+ * and offers a single confirmation. After creation, swaps to a link-display
+ * UI with Copy / Open buttons.
+ *
+ * The auto-generated share name still gets persisted on the underlying
+ * session/assignment doc — callers compute it before opening this modal.
+ * Teachers who want to rename can do so from the Shared archive's overflow
+ * menu (already wired for Mini App; Quiz/VA/GL inherit the assignment-doc
+ * `assignmentName` field through the same pattern).
+ *
+ * Mini App keeps its own custom modal (which doubles as the URL display);
+ * this primitive serves the three widgets that route through the shared
+ * AssignModal in submissions mode.
+ */
+
+import React, { useCallback, useState } from 'react';
+import {
+  Loader2,
+  Link2,
+  CheckCircle2,
+  Copy,
+  Check,
+  ExternalLink,
+  X,
+} from 'lucide-react';
+
+export interface ViewOnlyShareModalProps {
+  /** The thing being shared (quiz title, set title, activity title). */
+  itemTitle: string;
+  /** True while the create-session network round trip is in flight. */
+  isCreating: boolean;
+  /** Final student-facing URL once the session is minted. Null pre-creation. */
+  createdLink: string | null;
+  /** Inline error message to surface in the body. Null when no error. */
+  error: string | null;
+  /** Click handler for the confirm button. Should mint the session. */
+  onConfirm: () => void;
+  /** Close the modal — also resets the parent's createdLink state. */
+  onClose: () => void;
+}
+
+export const ViewOnlyShareModal: React.FC<ViewOnlyShareModalProps> = ({
+  itemTitle,
+  isCreating,
+  createdLink,
+  error,
+  onConfirm,
+  onClose,
+}) => {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = useCallback(async () => {
+    if (!createdLink) return;
+    try {
+      await navigator.clipboard.writeText(createdLink);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // Clipboard API can reject in non-secure contexts or when permission
+      // is denied. Swallow — the link is still visible to manually copy.
+    }
+  }, [createdLink]);
+
+  return (
+    <div className="absolute inset-0 z-overlay bg-brand-blue-dark/60 backdrop-blur-sm flex items-center justify-center p-4">
+      <div className="bg-white rounded-3xl w-full max-w-sm shadow-2xl overflow-hidden animate-in zoom-in-95 duration-200">
+        {/* Header */}
+        <div
+          className={`p-4 flex items-center justify-between ${createdLink ? 'bg-emerald-600' : 'bg-brand-blue-primary'}`}
+        >
+          <div className="flex items-center gap-2 text-white">
+            {createdLink ? (
+              <CheckCircle2 className="w-5 h-5" />
+            ) : (
+              <Link2 className="w-5 h-5" />
+            )}
+            <span className="font-black uppercase tracking-tight">
+              {createdLink ? 'Share Link Ready' : 'Share'}
+            </span>
+          </div>
+          <button
+            onClick={onClose}
+            className="text-white/60 hover:text-white transition-colors"
+            aria-label="Close"
+          >
+            <X className="w-5 h-5" />
+          </button>
+        </div>
+
+        <div className="p-5 space-y-4">
+          {createdLink ? (
+            /* Post-creation: show link with Copy / Open. */
+            <>
+              <div className="text-center">
+                <p className="font-bold text-brand-blue-dark text-base truncate px-2">
+                  {itemTitle}
+                </p>
+              </div>
+              <p className="text-slate-600 text-sm text-center">
+                Send this link to students. Anyone with the link can view — no
+                submissions are collected.
+              </p>
+              <div className="bg-slate-50 border border-slate-200 rounded-xl p-3 break-all text-xs text-slate-700 font-mono">
+                {createdLink}
+              </div>
+              <div className="grid gap-2">
+                <button
+                  onClick={() => void handleCopy()}
+                  className="w-full flex items-center justify-center gap-2 bg-brand-blue-primary hover:bg-brand-blue-dark text-white font-bold rounded-xl transition-all active:scale-95 shadow-sm py-3 text-sm"
+                >
+                  {copied ? (
+                    <>
+                      <Check className="w-4 h-4" />
+                      Copied!
+                    </>
+                  ) : (
+                    <>
+                      <Copy className="w-4 h-4" />
+                      Copy Link
+                    </>
+                  )}
+                </button>
+                <a
+                  href={createdLink}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="w-full flex items-center justify-center gap-2 bg-slate-100 hover:bg-slate-200 text-slate-700 font-bold rounded-xl transition-colors py-3 text-sm"
+                >
+                  <ExternalLink className="w-4 h-4" />
+                  Open in New Tab
+                </a>
+              </div>
+            </>
+          ) : (
+            /* Pre-creation: zero form fields, single confirm button. */
+            <>
+              <div className="text-center">
+                <p className="font-bold text-brand-blue-dark text-base truncate px-2">
+                  {itemTitle}
+                </p>
+                <p
+                  className="text-brand-blue-primary/60 font-black uppercase tracking-widest mt-1"
+                  style={{ fontSize: 'clamp(10px, 3cqmin, 12px)' }}
+                >
+                  Create Share Link
+                </p>
+              </div>
+              <p className="text-slate-600 text-sm text-center">
+                Anyone with the link can view this. No submissions are collected
+                — view counts appear in the Shared archive.
+              </p>
+              {error && (
+                <p className="text-sm text-brand-red-primary text-center font-medium">
+                  {error}
+                </p>
+              )}
+              <button
+                onClick={onConfirm}
+                disabled={isCreating}
+                className="w-full flex items-center justify-center gap-2 bg-brand-blue-primary hover:bg-brand-blue-dark text-white font-bold rounded-xl transition-all active:scale-95 shadow-sm py-3 text-sm disabled:opacity-60"
+              >
+                {isCreating ? (
+                  <Loader2 className="w-4 h-4 animate-spin" />
+                ) : (
+                  <Link2 className="w-4 h-4" />
+                )}
+                {isCreating ? 'Creating…' : 'Create Share Link'}
+              </button>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/components/common/library/ViewOnlyShareModal.tsx
+++ b/components/common/library/ViewOnlyShareModal.tsx
@@ -19,7 +19,7 @@
  * AssignModal in submissions mode.
  */
 
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import {
   Loader2,
   Link2,
@@ -55,12 +55,22 @@ export const ViewOnlyShareModal: React.FC<ViewOnlyShareModalProps> = ({
 }) => {
   const [copied, setCopied] = useState(false);
 
+  // Reset the "Copied!" affordance back to "Copy Link" 2s after a successful
+  // copy. Owning the timer in an effect (rather than a bare setTimeout from
+  // inside handleCopy) means React cleans it up if the modal unmounts before
+  // the 2s elapses — no setState-on-unmounted-component warning, no leaked
+  // pending timer.
+  useEffect(() => {
+    if (!copied) return;
+    const id = setTimeout(() => setCopied(false), 2000);
+    return () => clearTimeout(id);
+  }, [copied]);
+
   const handleCopy = useCallback(async () => {
     if (!createdLink) return;
     try {
       await navigator.clipboard.writeText(createdLink);
       setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
     } catch {
       // Clipboard API can reject in non-secure contexts or when permission
       // is denied. Swallow — the link is still visible to manually copy.
@@ -144,10 +154,7 @@ export const ViewOnlyShareModal: React.FC<ViewOnlyShareModalProps> = ({
                 <p className="font-bold text-brand-blue-dark text-base truncate px-2">
                   {itemTitle}
                 </p>
-                <p
-                  className="text-brand-blue-primary/60 font-black uppercase tracking-widest mt-1"
-                  style={{ fontSize: 'clamp(10px, 3cqmin, 12px)' }}
-                >
+                <p className="text-brand-blue-primary/60 font-black uppercase tracking-widest mt-1 text-xs">
                   Create Share Link
                 </p>
               </div>

--- a/components/common/library/index.ts
+++ b/components/common/library/index.ts
@@ -19,6 +19,7 @@ export { ViewOnlyShareModal } from './ViewOnlyShareModal';
 export type { ViewOnlyShareModalProps } from './ViewOnlyShareModal';
 export { CollapsibleSection } from './CollapsibleSection';
 export { AssignmentArchiveCard } from './AssignmentArchiveCard';
+export { ViewCountBadge } from './ViewCountBadge';
 export { PeriodSelector } from './PeriodSelector';
 export { LibraryDndContext } from './LibraryDndContext';
 export {
@@ -64,6 +65,7 @@ export type {
   AssignmentStatus,
   LibraryMenuAction,
   LibraryPrimaryAction,
+  LibraryIconAction,
   LibraryBadge,
   LibrarySortOption,
   LibraryFilter,

--- a/components/common/library/index.ts
+++ b/components/common/library/index.ts
@@ -15,6 +15,8 @@ export { LibraryGridLockContext } from './LibraryGridLockContext';
 export { useLibraryView } from './useLibraryView';
 export { useSortableReorder } from './useSortableReorder';
 export { AssignModal } from './AssignModal';
+export { ViewOnlyShareModal } from './ViewOnlyShareModal';
+export type { ViewOnlyShareModalProps } from './ViewOnlyShareModal';
 export { CollapsibleSection } from './CollapsibleSection';
 export { AssignmentArchiveCard } from './AssignmentArchiveCard';
 export { PeriodSelector } from './PeriodSelector';

--- a/components/common/library/types.ts
+++ b/components/common/library/types.ts
@@ -81,6 +81,30 @@ export interface LibraryPrimaryAction {
   disabledReason?: string;
 }
 
+/**
+ * Compact icon-only action rendered alongside (before) the primary action on
+ * library cards. Used when a card has multiple equal-weight quick actions —
+ * e.g. Mini App's view-only mode where Run and Share both deserve top-level
+ * surface. The `label` doubles as the accessible name and tooltip.
+ */
+export interface LibraryIconAction {
+  id: string;
+  label: string;
+  icon: React.ComponentType<{
+    size?: number;
+    className?: string;
+    style?: React.CSSProperties;
+  }>;
+  onClick: () => void;
+  /**
+   * Visual weight. `'primary'` matches the brand-blue filled primary button;
+   * `'secondary'` is a subtler outline/ghost style. Defaults to `'secondary'`.
+   */
+  tone?: 'primary' | 'secondary';
+  disabled?: boolean;
+  disabledReason?: string;
+}
+
 /** A badge chip shown on library cards. */
 export interface LibraryBadge {
   label: string;
@@ -186,8 +210,18 @@ export interface LibraryItemCardProps<TMeta = unknown> {
   /** Visual preview, usually an <img> or icon. */
   thumbnail?: React.ReactNode;
   badges?: LibraryBadge[];
-  /** e.g. "Assign" — the headline action. Clicked card body defaults to edit. */
-  primaryAction: LibraryPrimaryAction;
+  /**
+   * Headline labelled action (e.g. "Assign"). Optional: cards can rely solely
+   * on `iconActions` when no single label dominates (e.g. view-only Mini App
+   * where Run + Share share equal weight).
+   */
+  primaryAction?: LibraryPrimaryAction;
+  /**
+   * Compact icon-only buttons rendered before `primaryAction`. Used for
+   * equal-weight quick actions where the label would consume too much row
+   * width. Tooltip is each action's `label`.
+   */
+  iconActions?: LibraryIconAction[];
   /** Overflow-menu actions (Edit, Duplicate, Share, Delete...). */
   secondaryActions?: LibraryMenuAction[];
   /** Default click handler for the card body. Typically opens the editor. */
@@ -329,7 +363,12 @@ export interface AssignmentArchiveCardProps<TAssignment> {
   /** Controls styling + available actions. */
   mode: 'active' | 'archive';
   status: AssignmentStatusBadge;
-  primaryAction: LibraryPrimaryAction;
+  /**
+   * Optional headline action (e.g. "Copy link"). Omit on archived view-only
+   * cards where the link is dead and a Copy button would be misleading; the
+   * overflow menu still surfaces remaining actions (Reactivate, Delete).
+   */
+  primaryAction?: LibraryPrimaryAction;
   secondaryActions?: LibraryMenuAction[];
   /** Optional metadata line(s) — e.g. due date, student count, response count. */
   meta?: React.ReactNode;

--- a/components/widgets/GuidedLearning/Widget.tsx
+++ b/components/widgets/GuidedLearning/Widget.tsx
@@ -16,7 +16,7 @@ import { useGuidedLearningSessionTeacher } from '@/hooks/useGuidedLearningSessio
 import { useGuidedLearningAssignments } from '@/hooks/useGuidedLearningAssignments';
 import { useFolders } from '@/hooks/useFolders';
 import { WidgetLayout } from '@/components/widgets/WidgetLayout';
-import { AssignModal } from '@/components/common/library';
+import { AssignModal, ViewOnlyShareModal } from '@/components/common/library';
 import { AssignClassPicker } from '@/components/common/AssignClassPicker';
 import {
   makeEmptyPickerValue,
@@ -245,17 +245,25 @@ export const GuidedLearningWidget: React.FC<{ widget: WidgetData }> = ({
   };
 
   // Actually create the session + matching assignment doc. Shared between
-  // the classic direct-assign path (no ClassLink/rosters) and the picker
-  // dialog confirm path. `classIds` is the selected ClassLink sourcedId
-  // list; `periodNames` is the list of post-PIN period labels (empty when
-  // the teacher targeted nothing).
+  // the classic direct-assign path (no ClassLink/rosters), the picker
+  // dialog confirm path, and the view-only Share confirm path. `classIds`
+  // is the selected ClassLink sourcedId list; `periodNames` is the list of
+  // post-PIN period labels (empty when the teacher targeted nothing).
+  //
+  // When `silent` is true, the function returns the URL without writing to
+  // the clipboard or showing a toast — the caller is responsible for the
+  // post-creation UI (used by the view-only Share modal which displays the
+  // link inline). Throws on failure so callers can surface their own error
+  // path; non-silent callers swallow + toast.
   const performAssign = useCallback(
     async (
       data: GuidedLearningSet,
       source: 'personal' | 'building',
       originSetId: string,
-      rosterIds: string[]
-    ) => {
+      rosterIds: string[],
+      options?: { silent?: boolean }
+    ): Promise<string | null> => {
+      const silent = options?.silent === true;
       try {
         const selectedRosters = rosters.filter((r) => rosterIds.includes(r.id));
         const derived = deriveSessionTargetsFromRosters(selectedRosters);
@@ -299,17 +307,26 @@ export const GuidedLearningWidget: React.FC<{ widget: WidgetData }> = ({
             lastRosterIdsBySetId: nextMap,
           } as GuidedLearningConfig,
         });
-        await navigator.clipboard.writeText(url);
-        addToast(
-          isViewOnly
-            ? 'Share link copied to clipboard!'
-            : 'Assignment link copied to clipboard!',
-          'success'
-        );
+        if (!silent) {
+          await navigator.clipboard.writeText(url);
+          addToast(
+            isViewOnly
+              ? 'Share link copied to clipboard!'
+              : 'Assignment link copied to clipboard!',
+            'success'
+          );
+        }
+        return url;
       } catch (err) {
+        if (silent) {
+          // Re-throw so the view-only modal's own catch path can render
+          // the inline error.
+          throw err;
+        }
         const msg =
           err instanceof Error ? err.message : 'Failed to create session';
         addToast(msg, 'error');
+        return null;
       }
     },
     [
@@ -325,6 +342,22 @@ export const GuidedLearningWidget: React.FC<{ widget: WidgetData }> = ({
     ]
   );
 
+  // ─── View-only Share modal state ────────────────────────────────────────
+  // View-only "shares" deliberately bypass the AssignModal/picker flow
+  // because class targeting has no functional effect on view-only sessions
+  // (Firestore rules don't gate views by class; sessions are filtered out
+  // of /my-assignments anyway). The teacher gets a single confirmation
+  // modal with a description + Create Share Link button.
+  const [viewOnlyShareTarget, setViewOnlyShareTarget] =
+    useState<AssignDialogTarget | null>(null);
+  const [viewOnlyShareLink, setViewOnlyShareLink] = useState<string | null>(
+    null
+  );
+  const [viewOnlyShareError, setViewOnlyShareError] = useState<string | null>(
+    null
+  );
+  const [isCreatingViewOnlyShare, setIsCreatingViewOnlyShare] = useState(false);
+
   const handleAssign = async (
     setId: string,
     driveFileId?: string,
@@ -335,6 +368,14 @@ export const GuidedLearningWidget: React.FC<{ widget: WidgetData }> = ({
     const source: 'personal' | 'building' = buildingSet
       ? 'building'
       : 'personal';
+    // View-only flows skip the picker entirely — open the simplified Share
+    // modal instead.
+    if (isViewOnly) {
+      setViewOnlyShareTarget({ set: data, source, originSetId: setId });
+      setViewOnlyShareLink(null);
+      setViewOnlyShareError(null);
+      return;
+    }
     // If the teacher has no rosters at all, skip the dialog entirely and
     // preserve the classic join-link flow.
     if (rosters.length === 0) {
@@ -343,6 +384,31 @@ export const GuidedLearningWidget: React.FC<{ widget: WidgetData }> = ({
     }
     // Otherwise open the dialog so they can optionally pick rosters.
     setAssignTarget({ set: data, source, originSetId: setId });
+  };
+
+  const handleConfirmViewOnlyShare = async (): Promise<void> => {
+    if (!viewOnlyShareTarget) return;
+    setIsCreatingViewOnlyShare(true);
+    setViewOnlyShareError(null);
+    try {
+      const { set, source, originSetId } = viewOnlyShareTarget;
+      const url = await performAssign(set, source, originSetId, [], {
+        silent: true,
+      });
+      if (url) setViewOnlyShareLink(url);
+    } catch (err) {
+      setViewOnlyShareError(
+        err instanceof Error ? err.message : 'Failed to create share link.'
+      );
+    } finally {
+      setIsCreatingViewOnlyShare(false);
+    }
+  };
+
+  const closeViewOnlyShareModal = () => {
+    setViewOnlyShareTarget(null);
+    setViewOnlyShareLink(null);
+    setViewOnlyShareError(null);
   };
 
   const handleAssignConfirm = async (): Promise<void> => {
@@ -709,7 +775,18 @@ export const GuidedLearningWidget: React.FC<{ widget: WidgetData }> = ({
             />
           }
           onAssign={() => handleAssignConfirm()}
-          confirmLabel={isViewOnly ? 'Share' : 'Assign'}
+          confirmLabel="Assign"
+        />
+      )}
+
+      {viewOnlyShareTarget && (
+        <ViewOnlyShareModal
+          itemTitle={viewOnlyShareTarget.set.title || 'Untitled set'}
+          isCreating={isCreatingViewOnlyShare}
+          createdLink={viewOnlyShareLink}
+          error={viewOnlyShareError}
+          onConfirm={() => void handleConfirmViewOnlyShare()}
+          onClose={closeViewOnlyShareModal}
         />
       )}
     </>

--- a/components/widgets/GuidedLearning/Widget.tsx
+++ b/components/widgets/GuidedLearning/Widget.tsx
@@ -10,6 +10,7 @@ import {
 } from '@/types';
 import { db } from '@/config/firebase';
 import { useDashboard } from '@/context/useDashboard';
+import { useDialog } from '@/context/useDialog';
 import { useAuth } from '@/context/useAuth';
 import { useGuidedLearning } from '@/hooks/useGuidedLearning';
 import { useGuidedLearningSessionTeacher } from '@/hooks/useGuidedLearningSession';
@@ -54,6 +55,7 @@ export const GuidedLearningWidget: React.FC<{ widget: WidgetData }> = ({
   widget,
 }) => {
   const { updateWidget, addToast, rosters } = useDashboard();
+  const { showConfirm } = useDialog();
   const { user, isAdmin, getAssignmentMode } = useAuth();
   const assignmentMode: AssignmentMode = getAssignmentMode('guidedLearning');
   const isViewOnly = assignmentMode === 'view-only';
@@ -484,11 +486,34 @@ export const GuidedLearningWidget: React.FC<{ widget: WidgetData }> = ({
   const handleAssignmentArchive = async (
     assignment: GuidedLearningAssignment
   ) => {
+    // Branch the toast on the assignment's frozen mode — view-only shares
+    // aren't "archived" in the assignment-with-results sense; ending the
+    // share is the user-facing action.
+    const isViewOnlyAssignment = assignment.assignmentMode === 'view-only';
+    const ok = await showConfirm(
+      isViewOnlyAssignment
+        ? `End "${assignment.setTitle}"? The link will stop working.`
+        : `Archive "${assignment.setTitle}"? Students will no longer be able to submit.`,
+      {
+        title: isViewOnlyAssignment ? 'End share' : 'Archive Assignment',
+        variant: 'danger',
+        confirmLabel: isViewOnlyAssignment ? 'End' : 'Archive',
+      }
+    );
+    if (!ok) return;
     try {
       await archiveAssignment(assignment.id);
-      addToast('Assignment archived.', 'success');
+      addToast(
+        isViewOnlyAssignment ? 'Share ended.' : 'Assignment archived.',
+        'success'
+      );
     } catch (err) {
-      const msg = err instanceof Error ? err.message : 'Failed to archive';
+      const msg =
+        err instanceof Error
+          ? err.message
+          : isViewOnlyAssignment
+            ? 'Failed to end share'
+            : 'Failed to archive';
       addToast(msg, 'error');
     }
   };
@@ -496,11 +521,22 @@ export const GuidedLearningWidget: React.FC<{ widget: WidgetData }> = ({
   const handleAssignmentUnarchive = async (
     assignment: GuidedLearningAssignment
   ) => {
+    const isViewOnlyAssignment = assignment.assignmentMode === 'view-only';
     try {
       await unarchiveAssignment(assignment.id);
-      addToast('Moved back to In Progress.', 'success');
+      addToast(
+        isViewOnlyAssignment
+          ? 'Share reactivated.'
+          : 'Moved back to In Progress.',
+        'success'
+      );
     } catch (err) {
-      const msg = err instanceof Error ? err.message : 'Failed to move';
+      const msg =
+        err instanceof Error
+          ? err.message
+          : isViewOnlyAssignment
+            ? 'Failed to reactivate share'
+            : 'Failed to move';
       addToast(msg, 'error');
     }
   };

--- a/components/widgets/GuidedLearning/components/GuidedLearningManager.tsx
+++ b/components/widgets/GuidedLearning/components/GuidedLearningManager.tsx
@@ -46,6 +46,8 @@ import { LibraryShell } from '@/components/common/library/LibraryShell';
 import { LibraryToolbar } from '@/components/common/library/LibraryToolbar';
 import { LibraryGrid } from '@/components/common/library/LibraryGrid';
 import { LibraryItemCard } from '@/components/common/library/LibraryItemCard';
+import { ViewCountBadge } from '@/components/common/library/ViewCountBadge';
+import { useSessionViewCount } from '@/hooks/useSessionViewCount';
 import { FolderSidebar } from '@/components/common/library/FolderSidebar';
 import { FolderPickerPopover } from '@/components/common/library/FolderPickerPopover';
 import { buildMoveToFolderAction } from '@/components/common/library/folderMenuAction';
@@ -270,6 +272,23 @@ const formatDate = (ms: number): string =>
     day: 'numeric',
     year: 'numeric',
   });
+
+/* ─── ViewCountSubtitle ──────────────────────────────────────────────────── */
+
+/**
+ * Per-row hook host so `useSessionViewCount` can run as a top-level hook
+ * (calling it inside the `.map` body of `renderAssignmentTab` would violate
+ * the rules of hooks). Renders the count chip inline as part of the
+ * subtitle line for view-only Shared / Closed cards.
+ */
+const ViewCountSubtitle: React.FC<{ sessionId: string }> = ({ sessionId }) => {
+  const { count } = useSessionViewCount(
+    'guided_learning_sessions',
+    sessionId,
+    true
+  );
+  return <ViewCountBadge count={count} />;
+};
 
 /* ─── Component ───────────────────────────────────────────────────────────── */
 
@@ -724,7 +743,10 @@ export const GuidedLearningManager: React.FC<GuidedLearningManagerProps> = ({
           ]
         : [
             {
-              label: isViewOnly ? 'Ended share' : 'Archived',
+              // Single-word "Closed" reads cleaner and matches the other
+              // assignment widgets' archive labels for view-only shares
+              // (cf. MiniAppManager.statusBadge / QuizManager.resolveStatus).
+              label: isViewOnly ? 'Closed' : 'Archived',
               tone: 'neutral',
             },
           ];
@@ -734,40 +756,51 @@ export const GuidedLearningManager: React.FC<GuidedLearningManagerProps> = ({
     }
 
     const subtitle = (
-      <span>
-        {mode === 'active' ? 'Assigned ' : 'Archived '}
-        {formatDate(
-          mode === 'active' ? a.createdAt : (a.archivedAt ?? a.updatedAt)
-        )}
+      <span className="inline-flex items-center gap-2">
+        <span>
+          {mode === 'active' ? 'Assigned ' : 'Archived '}
+          {formatDate(
+            mode === 'active' ? a.createdAt : (a.archivedAt ?? a.updatedAt)
+          )}
+        </span>
+        {isViewOnly && <ViewCountSubtitle sessionId={a.sessionId} />}
       </span>
     );
 
-    const secondary: LibraryMenuAction[] = [
-      {
+    // For view-only shares the card already exposes Copy link as a primary
+    // action (Shared tab) or surfaces no primary at all (archive tab) — the
+    // duplicate "Copy student link" kebab item is just visual noise. The
+    // "Open student link" affordance stays useful as a quick preview path.
+    const secondary: LibraryMenuAction[] = [];
+    if (!isViewOnly) {
+      secondary.push({
         id: 'copy',
         label: 'Copy student link',
         icon: Copy,
         onClick: () => onAssignmentCopyLink(a),
-      },
-      {
-        id: 'open',
-        label: 'Open student link',
-        icon: ExternalLink,
-        onClick: () => window.open(studentLink, '_blank', 'noopener'),
-      },
-    ];
+      });
+    }
+    secondary.push({
+      id: 'open',
+      label: 'Open student link',
+      icon: ExternalLink,
+      onClick: () => window.open(studentLink, '_blank', 'noopener'),
+    });
 
     if (mode === 'active') {
       secondary.push({
         id: 'archive',
-        label: 'Archive',
+        label: isViewOnly ? 'End share' : 'Archive',
         icon: ArchiveIcon,
         onClick: () => onAssignmentArchive(a),
       });
     } else {
       secondary.push({
         id: 'unarchive',
-        label: 'Move to In Progress',
+        // For view-only shares "Move to In Progress" is the wrong frame —
+        // there's no progress to track; surface as "Reactivate" matching
+        // the other widgets' archive-tab affordance.
+        label: isViewOnly ? 'Reactivate' : 'Move to In Progress',
         icon: RotateCcw,
         onClick: () => onAssignmentUnarchive(a),
       });
@@ -781,10 +814,24 @@ export const GuidedLearningManager: React.FC<GuidedLearningManagerProps> = ({
       onClick: () => onAssignmentDelete(a),
     });
 
-    // Per-assignment mode is frozen at creation. View-only shares have no
-    // results to surface — swap the primary action accordingly. The status
-    // badge above already encodes the mode (Shared / Ended share).
+    // Primary action policy:
+    //   - View-only + active: Copy link (Shared tab — link is the entire UX).
+    //   - View-only + archive: omit (link is dead; Reactivate lives in kebab).
+    //   - Submissions (active or archive): View Results.
     const assignmentIsViewOnly = isViewOnly;
+    const primaryAction = assignmentIsViewOnly
+      ? mode === 'active'
+        ? {
+            label: 'Copy link',
+            icon: Copy,
+            onClick: () => onAssignmentCopyLink(a),
+          }
+        : undefined
+      : {
+          label: 'View Results',
+          icon: BarChart2,
+          onClick: () => onAssignmentOpenResults(a),
+        };
 
     return (
       <LibraryItemCard<GuidedLearningAssignment>
@@ -793,19 +840,7 @@ export const GuidedLearningManager: React.FC<GuidedLearningManagerProps> = ({
         title={a.setTitle}
         subtitle={subtitle}
         badges={badges}
-        primaryAction={
-          assignmentIsViewOnly
-            ? {
-                label: 'Copy link',
-                icon: Copy,
-                onClick: () => onAssignmentCopyLink(a),
-              }
-            : {
-                label: 'View Results',
-                icon: BarChart2,
-                onClick: () => onAssignmentOpenResults(a),
-              }
-        }
+        primaryAction={primaryAction}
         secondaryActions={secondary}
         sortable={false}
         viewMode="list"

--- a/components/widgets/GuidedLearning/components/GuidedLearningManager.tsx
+++ b/components/widgets/GuidedLearning/components/GuidedLearningManager.tsx
@@ -276,9 +276,7 @@ const formatDate = (ms: number): string =>
 /* ─── ViewCountSubtitle ──────────────────────────────────────────────────── */
 
 /**
- * Per-row hook host so `useSessionViewCount` can run as a top-level hook
- * (calling it inside the `.map` body of `renderAssignmentTab` would violate
- * the rules of hooks). Renders the count chip inline as part of the
+ * Per-row hook host that renders the view-count chip inline as part of the
  * subtitle line for view-only Shared / Closed cards.
  */
 const ViewCountSubtitle: React.FC<{ sessionId: string }> = ({ sessionId }) => {

--- a/components/widgets/GuidedLearning/components/GuidedLearningManager.tsx
+++ b/components/widgets/GuidedLearning/components/GuidedLearningManager.tsx
@@ -794,13 +794,13 @@ export const GuidedLearningManager: React.FC<GuidedLearningManagerProps> = ({
         icon: ArchiveIcon,
         onClick: () => onAssignmentArchive(a),
       });
-    } else {
+    } else if (!isViewOnly) {
+      // Submissions archive: keep "Move to In Progress" as a kebab item.
+      // View-only archive surfaces Reactivate as a visible iconAction
+      // instead (see below) — including it in the kebab would duplicate.
       secondary.push({
         id: 'unarchive',
-        // For view-only shares "Move to In Progress" is the wrong frame —
-        // there's no progress to track; surface as "Reactivate" matching
-        // the other widgets' archive-tab affordance.
-        label: isViewOnly ? 'Reactivate' : 'Move to In Progress',
+        label: 'Move to In Progress',
         icon: RotateCcw,
         onClick: () => onAssignmentUnarchive(a),
       });
@@ -816,7 +816,8 @@ export const GuidedLearningManager: React.FC<GuidedLearningManagerProps> = ({
 
     // Primary action policy:
     //   - View-only + active: Copy link (Shared tab — link is the entire UX).
-    //   - View-only + archive: omit (link is dead; Reactivate lives in kebab).
+    //   - View-only + archive: no primary; the visible iconAction is
+    //     "Reactivate" — Copy would be misleading on a dead URL.
     //   - Submissions (active or archive): View Results.
     const assignmentIsViewOnly = isViewOnly;
     const primaryAction = assignmentIsViewOnly
@@ -833,6 +834,23 @@ export const GuidedLearningManager: React.FC<GuidedLearningManagerProps> = ({
           onClick: () => onAssignmentOpenResults(a),
         };
 
+    // Compact icon-only action surfaced left of the (possibly absent)
+    // primary button. Used for the view-only archive Reactivate affordance
+    // so the row has a visible CTA instead of collapsing to the kebab
+    // (the badge is the only other anchor on archived rows).
+    const iconActions =
+      assignmentIsViewOnly && mode === 'archive'
+        ? [
+            {
+              id: 'reactivate',
+              label: 'Reactivate share',
+              icon: RotateCcw,
+              tone: 'primary' as const,
+              onClick: () => onAssignmentUnarchive(a),
+            },
+          ]
+        : undefined;
+
     return (
       <LibraryItemCard<GuidedLearningAssignment>
         key={a.id}
@@ -841,6 +859,7 @@ export const GuidedLearningManager: React.FC<GuidedLearningManagerProps> = ({
         subtitle={subtitle}
         badges={badges}
         primaryAction={primaryAction}
+        iconActions={iconActions}
         secondaryActions={secondary}
         sortable={false}
         viewMode="list"

--- a/components/widgets/MiniApp/Widget.tsx
+++ b/components/widgets/MiniApp/Widget.tsx
@@ -312,6 +312,7 @@ export const MiniAppWidget: React.FC<WidgetComponentProps> = ({
     loading: assignmentsLoading,
     createAssignment,
     endAssignment,
+    reactivateAssignment,
     deleteAssignment,
   } = useMiniAppAssignments(user?.uid);
 
@@ -783,20 +784,51 @@ export const MiniAppWidget: React.FC<WidgetComponentProps> = ({
 
   const handleArchiveEnd = useCallback(
     async (assignment: MiniAppAssignment) => {
+      // Branch all of the user-visible copy on the assignment's frozen mode.
+      // For view-only shares "submit" is the wrong verb (no submissions are
+      // collected) and "Assignment" is the wrong noun (it's a tracked link).
+      const isViewOnlyAssignment = assignment.mode === 'view-only';
       const confirmed = await showConfirm(
-        `End "${assignment.assignmentName}"? Students will no longer be able to submit.`,
-        { title: 'End Assignment', variant: 'danger', confirmLabel: 'End' }
+        isViewOnlyAssignment
+          ? `End "${assignment.assignmentName}"? The link will stop working.`
+          : `End "${assignment.assignmentName}"? Students will no longer be able to submit.`,
+        {
+          title: isViewOnlyAssignment ? 'End share' : 'End Assignment',
+          variant: 'danger',
+          confirmLabel: 'End',
+        }
       );
       if (!confirmed) return;
       try {
         await endAssignment(assignment.id);
-        addToast('Assignment ended', 'info');
+        addToast(
+          isViewOnlyAssignment ? 'Share ended' : 'Assignment ended',
+          'info'
+        );
       } catch (err) {
         console.error(err);
-        addToast('Failed to end assignment', 'error');
+        addToast(
+          isViewOnlyAssignment
+            ? 'Failed to end share'
+            : 'Failed to end assignment',
+          'error'
+        );
       }
     },
     [endAssignment, showConfirm, addToast]
+  );
+
+  const handleArchiveReactivate = useCallback(
+    async (assignment: MiniAppAssignment) => {
+      try {
+        await reactivateAssignment(assignment.id);
+        addToast('Share reactivated', 'success');
+      } catch (err) {
+        console.error(err);
+        addToast('Failed to reactivate share', 'error');
+      }
+    },
+    [reactivateAssignment, addToast]
   );
 
   const handleArchiveDelete = useCallback(
@@ -1120,6 +1152,7 @@ export const MiniAppWidget: React.FC<WidgetComponentProps> = ({
               onExport={handleExport}
               onArchiveCopyUrl={(a) => void handleArchiveCopyUrl(a)}
               onArchiveEnd={(a) => void handleArchiveEnd(a)}
+              onArchiveReactivate={(a) => void handleArchiveReactivate(a)}
               onArchiveDelete={(a) => void handleArchiveDelete(a)}
               initialLibraryViewMode={config.libraryViewMode}
               onLibraryViewModeChange={(mode) =>

--- a/components/widgets/MiniApp/Widget.tsx
+++ b/components/widgets/MiniApp/Widget.tsx
@@ -185,7 +185,7 @@ const MiniAppAssignModal: React.FC<MiniAppAssignModalProps> = ({
               </div>
             </>
           ) : (
-            /* Pre-creation: name input */
+            /* Pre-creation */
             <>
               <div className="text-center">
                 <p className="font-bold text-brand-blue-dark text-base truncate px-2">
@@ -198,39 +198,51 @@ const MiniAppAssignModal: React.FC<MiniAppAssignModalProps> = ({
                   {isViewOnly ? 'Create Share Link' : 'Create Assignment Link'}
                 </p>
               </div>
-              <p className="text-slate-600 text-sm text-center">
-                {isViewOnly
-                  ? 'Name this share, then send the generated link to students. No submissions are collected — view counts appear in the Shared archive.'
-                  : 'Name this assignment, then share the generated link with students.'}
-              </p>
-              <div className="bg-slate-50 border border-slate-200 rounded-xl p-3">
-                <label
-                  htmlFor="miniapp-assignment-name"
-                  className="block text-sm font-bold text-slate-700 mb-1.5"
-                >
-                  {isViewOnly ? 'Share Name' : 'Assignment Name'}
-                </label>
-                <input
-                  id="miniapp-assignment-name"
-                  type="text"
-                  value={assignmentName}
-                  onChange={(e) => onNameChange(e.target.value)}
-                  placeholder="1st period"
-                  className="w-full rounded-xl border border-slate-200 px-3 py-2 text-sm font-medium text-slate-700 outline-none focus:border-brand-blue-primary"
-                />
-              </div>
-              <div className="bg-slate-50 border border-slate-200 rounded-xl p-3">
-                <AssignClassPicker
-                  rosters={rosters}
-                  value={pickerValue}
-                  onChange={onPickerChange}
-                />
-                <p className="text-[11px] text-slate-500 mt-2">
-                  {isViewOnly
-                    ? 'Targeting is optional for view-only shares — used only to organize the Shared archive.'
-                    : 'Enrolled students will see this in their assignments list. Leave unselected to share the link directly.'}
+              {isViewOnly ? (
+                /* View-only: zero form fields. Class targeting has no effect
+                   (rules don't gate views by class; sessions are filtered out
+                   of /my-assignments anyway). The auto-generated share name
+                   is used behind the scenes for the Shared archive — teachers
+                   can rename later from the archive's overflow menu. */
+                <p className="text-slate-600 text-sm text-center">
+                  Anyone with the link can view this app. No submissions are
+                  collected — view counts appear in the Shared archive.
                 </p>
-              </div>
+              ) : (
+                <>
+                  <p className="text-slate-600 text-sm text-center">
+                    Name this assignment, then share the generated link with
+                    students.
+                  </p>
+                  <div className="bg-slate-50 border border-slate-200 rounded-xl p-3">
+                    <label
+                      htmlFor="miniapp-assignment-name"
+                      className="block text-sm font-bold text-slate-700 mb-1.5"
+                    >
+                      Assignment Name
+                    </label>
+                    <input
+                      id="miniapp-assignment-name"
+                      type="text"
+                      value={assignmentName}
+                      onChange={(e) => onNameChange(e.target.value)}
+                      placeholder="1st period"
+                      className="w-full rounded-xl border border-slate-200 px-3 py-2 text-sm font-medium text-slate-700 outline-none focus:border-brand-blue-primary"
+                    />
+                  </div>
+                  <div className="bg-slate-50 border border-slate-200 rounded-xl p-3">
+                    <AssignClassPicker
+                      rosters={rosters}
+                      value={pickerValue}
+                      onChange={onPickerChange}
+                    />
+                    <p className="text-[11px] text-slate-500 mt-2">
+                      Enrolled students will see this in their assignments list.
+                      Leave unselected to share the link directly.
+                    </p>
+                  </div>
+                </>
+              )}
               {error && (
                 <p className="text-sm text-brand-red-primary text-center font-medium">
                   {error}
@@ -238,7 +250,10 @@ const MiniAppAssignModal: React.FC<MiniAppAssignModalProps> = ({
               )}
               <button
                 onClick={onConfirm}
-                disabled={isCreating || assignmentName.trim().length === 0}
+                disabled={
+                  isCreating ||
+                  (!isViewOnly && assignmentName.trim().length === 0)
+                }
                 className="w-full flex items-center justify-center gap-2 bg-brand-blue-primary hover:bg-brand-blue-dark text-white font-bold rounded-xl transition-all active:scale-95 shadow-sm py-3 text-sm disabled:opacity-60"
               >
                 {isCreating ? (
@@ -825,43 +840,49 @@ export const MiniAppWidget: React.FC<WidgetComponentProps> = ({
           <div className="w-full h-full flex flex-col relative overflow-hidden group/miniapp">
             {!isStudentView && (
               <>
-                {/* Left Actions: Assign controls */}
-                <div className="absolute top-2 left-2 z-10 flex items-center gap-2 opacity-0 group-hover/miniapp:opacity-100 transition-opacity duration-200">
-                  <button
-                    onClick={() => handleOpenAssign(activeApp)}
-                    className="bg-indigo-600 hover:bg-indigo-500 text-white flex items-center gap-1.5 font-black uppercase tracking-widest transition-all rounded-lg shadow-sm"
-                    style={{
-                      padding: 'min(4px, 1cqmin) min(8px, 2cqmin)',
-                      fontSize: 'min(10px, 2.5cqmin)',
-                    }}
-                    title="Assign (copy student link)"
-                  >
-                    <Link2
+                {/* Left Actions: Assign controls. Hidden in view-only mode —
+                    "Assign" and "Assignments" both refer to submission-tracking
+                    flows that don't apply when the widget is configured as
+                    view-only by the admin. Teachers create shares from the
+                    library card's Share button instead. */}
+                {assignmentMode !== 'view-only' && (
+                  <div className="absolute top-2 left-2 z-10 flex items-center gap-2 opacity-0 group-hover/miniapp:opacity-100 transition-opacity duration-200">
+                    <button
+                      onClick={() => handleOpenAssign(activeApp)}
+                      className="bg-indigo-600 hover:bg-indigo-500 text-white flex items-center gap-1.5 font-black uppercase tracking-widest transition-all rounded-lg shadow-sm"
                       style={{
-                        width: 'min(12px, 3cqmin)',
-                        height: 'min(12px, 3cqmin)',
+                        padding: 'min(4px, 1cqmin) min(8px, 2cqmin)',
+                        fontSize: 'min(10px, 2.5cqmin)',
                       }}
-                    />
-                    <span className="hidden sm:inline">Assign</span>
-                  </button>
-                  <button
-                    onClick={() => handleOpenAssignments(activeApp)}
-                    className="bg-white/90 hover:bg-white text-slate-700 backdrop-blur-sm flex items-center gap-1.5 font-black uppercase tracking-widest transition-all rounded-lg shadow-sm border border-slate-200/50"
-                    style={{
-                      padding: 'min(4px, 1cqmin) min(8px, 2cqmin)',
-                      fontSize: 'min(10px, 2.5cqmin)',
-                    }}
-                    title="View assignments"
-                  >
-                    <BarChart3
+                      title="Assign (copy student link)"
+                    >
+                      <Link2
+                        style={{
+                          width: 'min(12px, 3cqmin)',
+                          height: 'min(12px, 3cqmin)',
+                        }}
+                      />
+                      <span className="hidden sm:inline">Assign</span>
+                    </button>
+                    <button
+                      onClick={() => handleOpenAssignments(activeApp)}
+                      className="bg-white/90 hover:bg-white text-slate-700 backdrop-blur-sm flex items-center gap-1.5 font-black uppercase tracking-widest transition-all rounded-lg shadow-sm border border-slate-200/50"
                       style={{
-                        width: 'min(12px, 3cqmin)',
-                        height: 'min(12px, 3cqmin)',
+                        padding: 'min(4px, 1cqmin) min(8px, 2cqmin)',
+                        fontSize: 'min(10px, 2.5cqmin)',
                       }}
-                    />
-                    <span className="hidden sm:inline">Assignments</span>
-                  </button>
-                </div>
+                      title="View assignments"
+                    >
+                      <BarChart3
+                        style={{
+                          width: 'min(12px, 3cqmin)',
+                          height: 'min(12px, 3cqmin)',
+                        }}
+                      />
+                      <span className="hidden sm:inline">Assignments</span>
+                    </button>
+                  </div>
+                )}
 
                 {/* Right Actions: App Controls */}
                 <div className="absolute top-2 right-2 z-10 flex items-center gap-1 opacity-0 group-hover/miniapp:opacity-100 transition-opacity duration-200">

--- a/components/widgets/MiniApp/Widget.tsx
+++ b/components/widgets/MiniApp/Widget.tsx
@@ -185,16 +185,14 @@ const MiniAppAssignModal: React.FC<MiniAppAssignModalProps> = ({
               </div>
             </>
           ) : (
-            /* Pre-creation */
+            /* Pre-creation: zero form fields in view-only; name input + class
+               picker in submissions. */
             <>
               <div className="text-center">
                 <p className="font-bold text-brand-blue-dark text-base truncate px-2">
                   {appTitle}
                 </p>
-                <p
-                  className="text-brand-blue-primary/60 font-black uppercase tracking-widest mt-1"
-                  style={{ fontSize: 'clamp(10px, 3cqmin, 12px)' }}
-                >
+                <p className="text-brand-blue-primary/60 font-black uppercase tracking-widest mt-1 text-xs">
                   {isViewOnly ? 'Create Share Link' : 'Create Assignment Link'}
                 </p>
               </div>

--- a/components/widgets/MiniApp/components/MiniAppManager.tsx
+++ b/components/widgets/MiniApp/components/MiniAppManager.tsx
@@ -43,6 +43,7 @@ import {
   ExternalLink,
   Copy,
   CheckSquare,
+  RotateCcw,
 } from 'lucide-react';
 import type {
   AssignmentMode,
@@ -55,6 +56,8 @@ import { LibraryToolbar } from '@/components/common/library/LibraryToolbar';
 import { LibraryGrid } from '@/components/common/library/LibraryGrid';
 import { LibraryItemCard } from '@/components/common/library/LibraryItemCard';
 import { AssignmentArchiveCard } from '@/components/common/library/AssignmentArchiveCard';
+import { ViewCountBadge } from '@/components/common/library/ViewCountBadge';
+import { useSessionViewCount } from '@/hooks/useSessionViewCount';
 import { FolderSidebar } from '@/components/common/library/FolderSidebar';
 import { FolderPickerPopover } from '@/components/common/library/FolderPickerPopover';
 import { buildMoveToFolderAction } from '@/components/common/library/folderMenuAction';
@@ -74,6 +77,7 @@ import type {
   LibraryFilter,
   LibrarySortOption,
   LibraryMenuAction,
+  LibraryPrimaryAction,
   AssignmentStatusBadge,
 } from '@/components/common/library/types';
 
@@ -118,6 +122,12 @@ export interface MiniAppManagerProps {
   /* ── Archive / In Progress callbacks ──────────────────────────────────── */
   onArchiveCopyUrl: (assignment: MiniAppAssignment) => void;
   onArchiveEnd: (assignment: MiniAppAssignment) => void;
+  /**
+   * Re-open a previously ended share (view-only mode only). Flips the
+   * assignment + session status back to active so the URL works again.
+   * Optional so consumers that don't support reactivate can omit it.
+   */
+  onArchiveReactivate?: (assignment: MiniAppAssignment) => void;
   onArchiveDelete: (assignment: MiniAppAssignment) => void;
   /** Optional — open the underlying app in the widget. */
   onArchiveOpenApp?: (assignment: MiniAppAssignment) => void;
@@ -212,6 +222,41 @@ const LIBRARY_FILTER_PREDICATES = {
   source: (row: UnifiedRow, value: string): boolean => row.kind === value,
 };
 
+/* ─── View-only row wrapper (encapsulates per-row view-count fetch) ───────── */
+
+/**
+ * Per-row component so `useSessionViewCount` can run as a top-level hook.
+ * Calling it inside a `.map()` body would violate the rules of hooks; this
+ * wrapper makes the hook call legal and keeps the count colocated with the
+ * card it annotates.
+ */
+const MiniAppArchiveRow: React.FC<{
+  assignment: MiniAppAssignment;
+  mode: 'active' | 'archive';
+  status: AssignmentStatusBadge;
+  primaryAction?: LibraryPrimaryAction;
+  secondaryActions: LibraryMenuAction[];
+}> = ({ assignment, mode, status, primaryAction, secondaryActions }) => {
+  const isViewOnly = assignment.mode === 'view-only';
+  const { count } = useSessionViewCount(
+    'mini_app_sessions',
+    assignment.sessionId,
+    isViewOnly
+  );
+  return (
+    <AssignmentArchiveCard<MiniAppAssignment>
+      assignment={assignment}
+      mode={mode}
+      status={status}
+      title={assignment.assignmentName}
+      subtitle={assignment.appTitle}
+      meta={isViewOnly ? <ViewCountBadge count={count} /> : undefined}
+      primaryAction={primaryAction}
+      secondaryActions={secondaryActions}
+    />
+  );
+};
+
 /* ─── Component ───────────────────────────────────────────────────────────── */
 
 export const MiniAppManager: React.FC<MiniAppManagerProps> = ({
@@ -235,6 +280,7 @@ export const MiniAppManager: React.FC<MiniAppManagerProps> = ({
   onExport,
   onArchiveCopyUrl,
   onArchiveEnd,
+  onArchiveReactivate,
   onArchiveDelete,
   onArchiveOpenApp,
   initialLibraryViewMode,
@@ -490,42 +536,73 @@ export const MiniAppManager: React.FC<MiniAppManagerProps> = ({
 
   function renderPersonalCard(row: UnifiedRow & { kind: 'personal' }) {
     const app = row.item;
-    const secondary: LibraryMenuAction[] = [
-      {
-        id: 'run',
-        label: 'Run app',
-        icon: Play,
-        onClick: () => onRun(app),
-      },
-      {
-        id: 'assignments',
-        label: 'View assignments',
-        icon: BarChart3,
-        onClick: () => onShowAssignments(app),
-      },
-      {
-        id: 'edit',
-        label: 'Edit',
-        icon: Pencil,
-        onClick: () => onEdit(app),
-      },
-      buildMoveToFolderAction({
-        onOpenPicker: () =>
-          setFolderPickerTarget({
-            id: app.id,
-            title: app.title,
-            folderId: app.folderId ?? null,
+    // View-only mode: Run is the dominant action — teachers nearly always
+    // want to *run* a mini-app on the dashboard before they share it. Pair
+    // Run with a compact Share/Link icon and drop "View assignments" from
+    // the overflow menu (the Shared tab is the surface for that).
+    // Submissions mode keeps the existing prominent "Assign" button and the
+    // full kebab so teachers can still jump to the assignments archive.
+    const secondary: LibraryMenuAction[] = isViewOnly
+      ? [
+          {
+            id: 'edit',
+            label: 'Edit',
+            icon: Pencil,
+            onClick: () => onEdit(app),
+          },
+          buildMoveToFolderAction({
+            onOpenPicker: () =>
+              setFolderPickerTarget({
+                id: app.id,
+                title: app.title,
+                folderId: app.folderId ?? null,
+              }),
+            disabled: !userId,
           }),
-        disabled: !userId,
-      }),
-      {
-        id: 'delete',
-        label: 'Delete',
-        icon: Trash2,
-        onClick: () => void onDelete(app),
-        destructive: true,
-      },
-    ];
+          {
+            id: 'delete',
+            label: 'Delete',
+            icon: Trash2,
+            onClick: () => void onDelete(app),
+            destructive: true,
+          },
+        ]
+      : [
+          {
+            id: 'run',
+            label: 'Run app',
+            icon: Play,
+            onClick: () => onRun(app),
+          },
+          {
+            id: 'assignments',
+            label: 'View assignments',
+            icon: BarChart3,
+            onClick: () => onShowAssignments(app),
+          },
+          {
+            id: 'edit',
+            label: 'Edit',
+            icon: Pencil,
+            onClick: () => onEdit(app),
+          },
+          buildMoveToFolderAction({
+            onOpenPicker: () =>
+              setFolderPickerTarget({
+                id: app.id,
+                title: app.title,
+                folderId: app.folderId ?? null,
+              }),
+            disabled: !userId,
+          }),
+          {
+            id: 'delete',
+            label: 'Delete',
+            icon: Trash2,
+            onClick: () => void onDelete(app),
+            destructive: true,
+          },
+        ];
 
     return (
       <LibraryItemCard<MiniAppItem>
@@ -542,11 +619,34 @@ export const MiniAppManager: React.FC<MiniAppManagerProps> = ({
             HTML
           </div>
         }
-        primaryAction={{
-          label: primaryActionLabel,
-          icon: Link2,
-          onClick: () => onAssign(app),
-        }}
+        primaryAction={
+          isViewOnly
+            ? undefined
+            : {
+                label: primaryActionLabel,
+                icon: Link2,
+                onClick: () => onAssign(app),
+              }
+        }
+        iconActions={
+          isViewOnly
+            ? [
+                {
+                  id: 'run',
+                  label: 'Run app',
+                  icon: Play,
+                  tone: 'primary',
+                  onClick: () => onRun(app),
+                },
+                {
+                  id: 'share',
+                  label: 'Share link',
+                  icon: Link2,
+                  onClick: () => onAssign(app),
+                },
+              ]
+            : undefined
+        }
         secondaryActions={secondary}
         onClick={() => onEdit(app)}
         sortable={!selectionMode}
@@ -561,27 +661,37 @@ export const MiniAppManager: React.FC<MiniAppManagerProps> = ({
   function renderGlobalCard(row: UnifiedRow & { kind: 'global' }) {
     const app = row.item;
     const saving = savingGlobalId === app.id;
-    const secondary: LibraryMenuAction[] = [
-      {
-        id: 'run',
-        label: 'Run app',
-        icon: Play,
-        onClick: () => onRun(app),
-      },
-      {
-        id: 'assignments',
-        label: 'View assignments',
-        icon: BarChart3,
-        onClick: () => onShowAssignments(app),
-      },
-      {
-        id: 'save',
-        label: saving ? 'Saving…' : 'Save to my library',
-        icon: saving ? Loader2 : BookDown,
-        onClick: () => onSaveGlobalToLibrary(app),
-        disabled: saving,
-      },
-    ];
+    const secondary: LibraryMenuAction[] = isViewOnly
+      ? [
+          {
+            id: 'save',
+            label: saving ? 'Saving…' : 'Save to my library',
+            icon: saving ? Loader2 : BookDown,
+            onClick: () => onSaveGlobalToLibrary(app),
+            disabled: saving,
+          },
+        ]
+      : [
+          {
+            id: 'run',
+            label: 'Run app',
+            icon: Play,
+            onClick: () => onRun(app),
+          },
+          {
+            id: 'assignments',
+            label: 'View assignments',
+            icon: BarChart3,
+            onClick: () => onShowAssignments(app),
+          },
+          {
+            id: 'save',
+            label: saving ? 'Saving…' : 'Save to my library',
+            icon: saving ? Loader2 : BookDown,
+            onClick: () => onSaveGlobalToLibrary(app),
+            disabled: saving,
+          },
+        ];
 
     return (
       <LibraryItemCard<GlobalMiniAppItem>
@@ -598,11 +708,34 @@ export const MiniAppManager: React.FC<MiniAppManagerProps> = ({
             HTML
           </div>
         }
-        primaryAction={{
-          label: primaryActionLabel,
-          icon: Link2,
-          onClick: () => onAssign(app),
-        }}
+        primaryAction={
+          isViewOnly
+            ? undefined
+            : {
+                label: primaryActionLabel,
+                icon: Link2,
+                onClick: () => onAssign(app),
+              }
+        }
+        iconActions={
+          isViewOnly
+            ? [
+                {
+                  id: 'run',
+                  label: 'Run app',
+                  icon: Play,
+                  tone: 'primary',
+                  onClick: () => onRun(app),
+                },
+                {
+                  id: 'share',
+                  label: 'Share link',
+                  icon: Link2,
+                  onClick: () => onAssign(app),
+                },
+              ]
+            : undefined
+        }
         secondaryActions={secondary}
         // No onClick for global items — they are read-only here; clicking the
         // body would imply "edit", which is admin-only.
@@ -689,7 +822,9 @@ export const MiniAppManager: React.FC<MiniAppManagerProps> = ({
     const isViewOnly = assignment.mode === 'view-only';
     if (mode === 'archive') {
       return {
-        label: isViewOnly ? 'Ended share' : 'Ended',
+        // "Closed" reads cleaner than "Ended share" and matches the
+        // single-word convention used elsewhere for terminal states.
+        label: isViewOnly ? 'Closed' : 'Ended',
         tone: 'neutral',
       };
     }
@@ -706,12 +841,21 @@ export const MiniAppManager: React.FC<MiniAppManagerProps> = ({
   ): LibraryMenuAction[] {
     const isViewOnly = assignment.mode === 'view-only';
     const actions: LibraryMenuAction[] = [];
-    actions.push({
-      id: 'copy-url',
-      label: 'Copy student link',
-      icon: Copy,
-      onClick: () => onArchiveCopyUrl(assignment),
-    });
+
+    // For view-only assignments the Shared-tab card already has a primary
+    // "Copy link" button, and archive view-only cards show "Reactivate" in
+    // place of a primary action — so the kebab Copy entry is redundant
+    // there. Submissions-mode cards keep the kebab entry as a stable
+    // secondary surface.
+    if (!isViewOnly) {
+      actions.push({
+        id: 'copy-url',
+        label: 'Copy student link',
+        icon: Copy,
+        onClick: () => onArchiveCopyUrl(assignment),
+      });
+    }
+
     if (onArchiveOpenApp) {
       actions.push({
         id: 'open',
@@ -728,6 +872,20 @@ export const MiniAppManager: React.FC<MiniAppManagerProps> = ({
         onClick: () => onArchiveEnd(assignment),
       });
     }
+
+    // Reactivate is view-only-only, archive-only — flips status back to
+    // active so the URL works again. Submissions-mode assignments don't get
+    // this affordance: re-collecting submissions on a stale roster is a
+    // bigger UX call than this PR is scoped to make.
+    if (mode === 'archive' && isViewOnly && onArchiveReactivate !== undefined) {
+      actions.push({
+        id: 'reactivate',
+        label: 'Reactivate',
+        icon: RotateCcw,
+        onClick: () => onArchiveReactivate(assignment),
+      });
+    }
+
     actions.push({
       id: 'delete',
       label: 'Delete',
@@ -754,13 +912,11 @@ export const MiniAppManager: React.FC<MiniAppManagerProps> = ({
       tabContent = (
         <div className="flex flex-col gap-2">
           {activeAssignments.map((a) => (
-            <AssignmentArchiveCard<MiniAppAssignment>
+            <MiniAppArchiveRow
               key={a.id}
               assignment={a}
               mode="active"
               status={statusBadge(a, 'active')}
-              title={a.assignmentName}
-              subtitle={a.appTitle}
               primaryAction={{
                 label: 'Copy link',
                 icon: Copy,
@@ -784,22 +940,32 @@ export const MiniAppManager: React.FC<MiniAppManagerProps> = ({
     } else {
       tabContent = (
         <div className="flex flex-col gap-2">
-          {archivedAssignments.map((a) => (
-            <AssignmentArchiveCard<MiniAppAssignment>
-              key={a.id}
-              assignment={a}
-              mode="archive"
-              status={statusBadge(a, 'archive')}
-              title={a.assignmentName}
-              subtitle={a.appTitle}
-              primaryAction={{
-                label: 'Copy link',
-                icon: Copy,
-                onClick: () => onArchiveCopyUrl(a),
-              }}
-              secondaryActions={assignmentSecondary(a, 'archive')}
-            />
-          ))}
+          {archivedAssignments.map((a) => {
+            // Archived view-only shares have a dead URL — Firestore rules
+            // (and the student app guard) reject access once `status ==
+            // 'ended'`. Surfacing a Copy-link button there would mislead
+            // teachers; the kebab's "Reactivate" is the way to bring the
+            // link back if needed.
+            const archiveIsViewOnly = a.mode === 'view-only';
+            return (
+              <MiniAppArchiveRow
+                key={a.id}
+                assignment={a}
+                mode="archive"
+                status={statusBadge(a, 'archive')}
+                primaryAction={
+                  archiveIsViewOnly
+                    ? undefined
+                    : {
+                        label: 'Copy link',
+                        icon: Copy,
+                        onClick: () => onArchiveCopyUrl(a),
+                      }
+                }
+                secondaryActions={assignmentSecondary(a, 'archive')}
+              />
+            );
+          })}
         </div>
       );
     }

--- a/components/widgets/MiniApp/components/MiniAppManager.tsx
+++ b/components/widgets/MiniApp/components/MiniAppManager.tsx
@@ -222,14 +222,8 @@ const LIBRARY_FILTER_PREDICATES = {
   source: (row: UnifiedRow, value: string): boolean => row.kind === value,
 };
 
-/* ─── View-only row wrapper (encapsulates per-row view-count fetch) ───────── */
+/* ─── View-only row wrapper (per-row hook host for view-count fetch) ──────── */
 
-/**
- * Per-row component so `useSessionViewCount` can run as a top-level hook.
- * Calling it inside a `.map()` body would violate the rules of hooks; this
- * wrapper makes the hook call legal and keeps the count colocated with the
- * card it annotates.
- */
 const MiniAppArchiveRow: React.FC<{
   assignment: MiniAppAssignment;
   mode: 'active' | 'archive';

--- a/components/widgets/QuizWidget/Widget.tsx
+++ b/components/widgets/QuizWidget/Widget.tsx
@@ -1067,6 +1067,44 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
             addToast(`Share link: ${url}`, 'info');
           }
         }}
+        onCreateViewOnlyShare={async (meta) => {
+          // View-only Quiz share — bypasses the AssignModal/picker/PLC flow
+          // entirely. Creates a minimal assignment with view-only mode so
+          // students can browse questions but can't submit; returns the
+          // student-facing URL for ViewOnlyShareModal to display.
+          const data = await loadQuiz(meta);
+          if (!data) {
+            throw new Error('Failed to load quiz data');
+          }
+          const { code } = await createAssignment(
+            {
+              id: meta.id,
+              title: meta.title,
+              driveFileId: meta.driveFileId,
+              questions: data.questions,
+            },
+            {
+              sessionMode: 'teacher',
+              sessionOptions: {
+                tabWarningsEnabled: false,
+                showResultToStudent: false,
+                showCorrectAnswerToStudent: false,
+                showCorrectOnBoard: false,
+                speedBonusEnabled: false,
+                streakBonusEnabled: false,
+                showPodiumBetweenQuestions: false,
+                soundEffectsEnabled: false,
+              },
+              attemptLimit: null,
+            },
+            'paused',
+            [],
+            [],
+            {},
+            'view-only'
+          );
+          return `${window.location.origin}/quiz?code=${encodeURIComponent(code)}`;
+        }}
         onDelete={async (meta) => {
           // Block deletion when active/paused assignments reference the quiz,
           // since the monitor + results views need the answer key from the

--- a/components/widgets/QuizWidget/Widget.tsx
+++ b/components/widgets/QuizWidget/Widget.tsx
@@ -1415,26 +1415,46 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
           }
         }}
         onArchiveDeactivate={async (a) => {
+          // Branch the success / failure copy on the assignment's frozen
+          // mode — view-only shares haven't collected anything to "preserve"
+          // and "Assignment" is the wrong noun for a tracked link.
+          const isViewOnlyAssignment = a.mode === 'view-only';
           try {
             await deactivateAssignment(a.id);
-            addToast('Assignment deactivated. Responses preserved.', 'success');
+            addToast(
+              isViewOnlyAssignment
+                ? 'Share ended.'
+                : 'Assignment deactivated. Responses preserved.',
+              'success'
+            );
           } catch (err) {
             addToast(
-              err instanceof Error ? err.message : 'Failed to deactivate',
+              err instanceof Error
+                ? err.message
+                : isViewOnlyAssignment
+                  ? 'Failed to end share'
+                  : 'Failed to deactivate',
               'error'
             );
           }
         }}
         onArchiveReopen={async (a) => {
+          const isViewOnlyAssignment = a.mode === 'view-only';
           try {
             await reopenAssignment(a.id);
             addToast(
-              'Reopened — click Resume to accept submissions.',
+              isViewOnlyAssignment
+                ? 'Share reactivated.'
+                : 'Reopened — click Resume to accept submissions.',
               'success'
             );
           } catch (err) {
             addToast(
-              err instanceof Error ? err.message : 'Failed to reopen',
+              err instanceof Error
+                ? err.message
+                : isViewOnlyAssignment
+                  ? 'Failed to reactivate share'
+                  : 'Failed to reopen',
               'error'
             );
           }

--- a/components/widgets/QuizWidget/Widget.tsx
+++ b/components/widgets/QuizWidget/Widget.tsx
@@ -45,6 +45,27 @@ import { usePlcs } from '@/hooks/usePlcs';
 import { QuizDriveService } from '@/utils/quizDriveService';
 import { getPlcMemberEmails, getPlcTeammateEmails } from '@/utils/plc';
 
+/**
+ * Session-options shape used when minting a view-only Quiz share. Typed as
+ * `Required<QuizSessionOptions>` so adding a new field to QuizSessionOptions
+ * fails type-check here until a deliberate value is chosen — the previous
+ * inline literal silently let new optional fields default to undefined.
+ *
+ * View-only shares disable every per-attempt feature (no leaderboard, no
+ * tab warnings, no bonuses, no result reveal) — none of them have meaning
+ * when there are no submissions to score or compare.
+ */
+const VIEW_ONLY_SESSION_OPTIONS: Required<QuizSessionOptions> = {
+  tabWarningsEnabled: false,
+  showResultToStudent: false,
+  showCorrectAnswerToStudent: false,
+  showCorrectOnBoard: false,
+  speedBonusEnabled: false,
+  streakBonusEnabled: false,
+  showPodiumBetweenQuestions: false,
+  soundEffectsEnabled: false,
+};
+
 export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
   const {
     updateWidget,
@@ -1085,16 +1106,7 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
             },
             {
               sessionMode: 'teacher',
-              sessionOptions: {
-                tabWarningsEnabled: false,
-                showResultToStudent: false,
-                showCorrectAnswerToStudent: false,
-                showCorrectOnBoard: false,
-                speedBonusEnabled: false,
-                streakBonusEnabled: false,
-                showPodiumBetweenQuestions: false,
-                soundEffectsEnabled: false,
-              },
+              sessionOptions: VIEW_ONLY_SESSION_OPTIONS,
               attemptLimit: null,
             },
             'paused',

--- a/components/widgets/QuizWidget/components/QuizManager.tsx
+++ b/components/widgets/QuizWidget/components/QuizManager.tsx
@@ -71,6 +71,7 @@ import {
   LibraryGrid,
   LibraryItemCard,
   AssignModal,
+  ViewOnlyShareModal,
   CollapsibleSection,
   AssignmentArchiveCard,
   FolderSidebar,
@@ -247,6 +248,16 @@ interface QuizManagerProps {
     /** Max completed submissions per student; null = unlimited. */
     attemptLimit: number | null
   ) => void;
+  /**
+   * View-only Share callback — invoked when the org-wide assignment mode
+   * for Quiz is `'view-only'` and the teacher clicks the Share button.
+   * Bypasses the AssignModal entirely (no mode picker, no PLC, no
+   * settings, no class targeting — none of which apply to view-only
+   * shares). Should mint a session/assignment with view-only mode and
+   * return the student-facing URL for the modal to display. Required
+   * when `assignmentMode` is `'view-only'`; otherwise unused.
+   */
+  onCreateViewOnlyShare?: (quiz: QuizMetadata) => Promise<string>;
   onResults: (quiz: QuizMetadata) => void;
   onDelete: (quiz: QuizMetadata) => void | Promise<void>;
   /**
@@ -392,6 +403,7 @@ export const QuizManager: React.FC<QuizManagerProps> = ({
   onLibraryViewModeChange,
   defaultTeacherName,
   assignmentMode = 'submissions',
+  onCreateViewOnlyShare,
 }) => {
   const isViewOnly = assignmentMode === 'view-only';
   const primaryActionLabel = isViewOnly ? 'Share' : 'Assign';
@@ -403,6 +415,54 @@ export const QuizManager: React.FC<QuizManagerProps> = ({
 
   // ─── Assign modal state (2-stage: mode → settings) ────────────────────────
   const [assignTarget, setAssignTarget] = useState<QuizMetadata | null>(null);
+
+  // ─── View-only Share modal state ──────────────────────────────────────────
+  // Bypasses the AssignModal entirely — class targeting, PLC, mode picker,
+  // and per-assignment settings are all meaningless for view-only shares.
+  const [viewOnlyShareTarget, setViewOnlyShareTarget] =
+    useState<QuizMetadata | null>(null);
+  const [viewOnlyShareLink, setViewOnlyShareLink] = useState<string | null>(
+    null
+  );
+  const [viewOnlyShareError, setViewOnlyShareError] = useState<string | null>(
+    null
+  );
+  const [isCreatingViewOnlyShare, setIsCreatingViewOnlyShare] = useState(false);
+
+  const openShareOrAssign = useCallback(
+    (quiz: QuizMetadata) => {
+      if (isViewOnly) {
+        setViewOnlyShareTarget(quiz);
+        setViewOnlyShareLink(null);
+        setViewOnlyShareError(null);
+      } else {
+        setAssignTarget(quiz);
+      }
+    },
+    [isViewOnly]
+  );
+
+  const handleConfirmViewOnlyShare = useCallback(async () => {
+    if (!viewOnlyShareTarget || !onCreateViewOnlyShare) return;
+    setIsCreatingViewOnlyShare(true);
+    setViewOnlyShareError(null);
+    try {
+      const url = await onCreateViewOnlyShare(viewOnlyShareTarget);
+      setViewOnlyShareLink(url);
+    } catch (err) {
+      setViewOnlyShareError(
+        err instanceof Error ? err.message : 'Failed to create share link.'
+      );
+    } finally {
+      setIsCreatingViewOnlyShare(false);
+    }
+  }, [viewOnlyShareTarget, onCreateViewOnlyShare]);
+
+  const closeViewOnlyShareModal = useCallback(() => {
+    setViewOnlyShareTarget(null);
+    setViewOnlyShareLink(null);
+    setViewOnlyShareError(null);
+  }, []);
   const [selectedMode, setSelectedMode] = useState<QuizSessionMode | null>(
     null
   );
@@ -1050,7 +1110,7 @@ export const QuizManager: React.FC<QuizManagerProps> = ({
         primaryAction={{
           label: primaryActionLabel,
           icon: Play,
-          onClick: () => setAssignTarget(quiz),
+          onClick: () => openShareOrAssign(quiz),
         }}
         secondaryActions={buildQuizSecondaryActions(quiz)}
         viewMode="list"
@@ -1082,7 +1142,7 @@ export const QuizManager: React.FC<QuizManagerProps> = ({
         <LibraryTabContent
           error={error}
           orderedItems={reorder.orderedItems}
-          onAssignClick={(q) => setAssignTarget(q)}
+          onAssignClick={(q) => openShareOrAssign(q)}
           buildSecondaryActions={buildQuizSecondaryActions}
           onEdit={onEdit}
           onImport={onImport}
@@ -1164,7 +1224,7 @@ export const QuizManager: React.FC<QuizManagerProps> = ({
         />
       )}
 
-      {assignTarget && (
+      {assignTarget && !isViewOnly && (
         <AssignModal<QuizAssignOptions>
           isOpen={!!assignTarget}
           onClose={() => {
@@ -1200,6 +1260,17 @@ export const QuizManager: React.FC<QuizManagerProps> = ({
           confirmLabel="Assign"
           confirmDisabled={!selectedMode}
           confirmDisabledReason="Choose a session mode first."
+        />
+      )}
+
+      {viewOnlyShareTarget && (
+        <ViewOnlyShareModal
+          itemTitle={viewOnlyShareTarget.title}
+          isCreating={isCreatingViewOnlyShare}
+          createdLink={viewOnlyShareLink}
+          error={viewOnlyShareError}
+          onConfirm={() => void handleConfirmViewOnlyShare()}
+          onClose={closeViewOnlyShareModal}
         />
       )}
     </>

--- a/components/widgets/QuizWidget/components/QuizManager.tsx
+++ b/components/widgets/QuizWidget/components/QuizManager.tsx
@@ -37,6 +37,7 @@ import {
   Pause,
   PowerOff,
   RefreshCw,
+  RotateCcw,
   Calendar,
   Radio,
   Inbox,
@@ -74,6 +75,7 @@ import {
   ViewOnlyShareModal,
   CollapsibleSection,
   AssignmentArchiveCard,
+  ViewCountBadge,
   FolderSidebar,
   FolderPickerPopover,
   LibraryDndContext,
@@ -94,6 +96,7 @@ import {
   filterByFolder,
 } from '@/components/common/library/folderFilters';
 import { useFolders } from '@/hooks/useFolders';
+import { useSessionViewCount } from '@/hooks/useSessionViewCount';
 import { useDialog } from '@/context/useDialog';
 
 export interface PlcOptions {
@@ -308,8 +311,18 @@ interface QuizManagerProps {
 /* ─── Status resolver for archive cards ───────────────────────────────────── */
 
 function resolveStatus(
-  status: QuizAssignment['status']
+  status: QuizAssignment['status'],
+  isViewOnly: boolean
 ): AssignmentStatusBadge {
+  // View-only shares get share-flavored labels so the active/archive UI
+  // doesn't pretend submissions are happening when they aren't. "Closed"
+  // is the cross-widget archive label (cf. MiniAppManager.statusBadge).
+  if (isViewOnly) {
+    if (status === 'inactive') {
+      return { label: 'Closed', tone: 'neutral' };
+    }
+    return { label: 'Shared', tone: 'success', dot: true };
+  }
   if (status === 'active') {
     return { label: 'Live', tone: 'success', dot: true };
   }
@@ -639,7 +652,7 @@ export const QuizManager: React.FC<QuizManagerProps> = ({
       label: string;
       icon: React.ComponentType<{ size?: number; className?: string }>;
       onClick: () => void;
-    };
+    } | null;
     secondaries: LibraryMenuAction[];
   } => {
     const isActive = a.status === 'active';
@@ -651,24 +664,48 @@ export const QuizManager: React.FC<QuizManagerProps> = ({
     const secondaries: LibraryMenuAction[] = [];
 
     if (assignmentIsViewOnly) {
+      // For archived (urlLive === false) view-only shares we keep the
+      // "Reactivate" affordance as a kebab item rather than a primary
+      // action — the card otherwise has no headline action, which matches
+      // the "no Copy on dead link" rule (cf. F2 in the rollout plan).
       const primary = urlLive
         ? {
             label: 'Copy link',
             icon: Link2,
             onClick: () => (onArchiveCopyUrl ?? noop)(a),
           }
-        : {
-            label: 'Reopen',
-            icon: Rocket,
-            onClick: () => void (onArchiveReopen ?? noop)(a),
-          };
+        : null;
       if (urlLive) {
         secondaries.push({
           id: 'deactivate',
           label: 'End share',
           icon: PowerOff,
           destructive: true,
-          onClick: () => void (onArchiveDeactivate ?? noop)(a),
+          // Confirm before tearing down the URL — accidental dismissal
+          // shouldn't kill a tracked link silently. Copy is view-only
+          // flavored (no submissions to preserve, no roster to retire).
+          onClick: async () => {
+            const ok = await showConfirm(
+              `End "${a.quizTitle}"? The link will stop working.`,
+              {
+                title: 'End share',
+                variant: 'danger',
+                confirmLabel: 'End',
+              }
+            );
+            if (ok) await (onArchiveDeactivate ?? noop)(a);
+          },
+        });
+      }
+      // Archived view-only share: surface "Reactivate" as a kebab item
+      // (lifts the URL out of the dead state). Cf. F3 in the rollout plan;
+      // mirrors VideoActivityManager.buildAssignmentSecondaryActions.
+      if (!urlLive && onArchiveReopen) {
+        secondaries.push({
+          id: 'reactivate',
+          label: 'Reactivate',
+          icon: RotateCcw,
+          onClick: () => void onArchiveReopen(a),
         });
       }
       secondaries.push({
@@ -690,7 +727,9 @@ export const QuizManager: React.FC<QuizManagerProps> = ({
       });
       return {
         primary,
-        secondaries: secondaries.filter((m) => m.label !== primary.label),
+        secondaries: primary
+          ? secondaries.filter((m) => m.label !== primary.label)
+          : secondaries,
       };
     }
 
@@ -1434,11 +1473,16 @@ const AssignmentsList: React.FC<{
     a: QuizAssignment,
     mode: 'active' | 'archive'
   ) => {
+    /**
+     * `null` when the card has no headline action — view-only archive cards
+     * surface "Reactivate" via the kebab and intentionally omit the primary
+     * to avoid a Copy-link button on a dead URL (cf. F2 in the rollout plan).
+     */
     primary: {
       label: string;
       icon: React.ComponentType<{ size?: number; className?: string }>;
       onClick: () => void;
-    };
+    } | null;
     secondaries: LibraryMenuAction[];
   };
   emptyTitle: string;
@@ -1466,66 +1510,115 @@ const AssignmentsList: React.FC<{
 
   return (
     <div className="flex flex-col gap-2">
-      {assignments.map((a) => {
-        const { primary, secondaries } = buildActions(a, mode);
-        const status = resolveStatus(a.status);
-        const periods = a.periodNames ?? (a.periodName ? [a.periodName] : []);
-        const urlLive = a.status !== 'inactive';
-        const noPeriods = periods.length === 0 && mode === 'active';
-        const periodLabel =
-          periods.length === 1
-            ? periods[0]
-            : periods.length > 0
-              ? `${periods.length} classes`
-              : null;
+      {assignments.map((a) => (
+        <QuizArchiveRow
+          key={a.id}
+          assignment={a}
+          mode={mode}
+          buildActions={buildActions}
+        />
+      ))}
+    </div>
+  );
+};
 
-        return (
-          <AssignmentArchiveCard<QuizAssignment>
-            key={a.id}
-            assignment={a}
-            mode={mode}
-            status={status}
-            title={a.quizTitle}
-            subtitle={a.className?.trim() ? a.className : undefined}
-            meta={
-              <>
-                <span className="inline-flex items-center gap-0.5">
-                  <Calendar className="w-3 h-3" />
-                  {new Date(a.createdAt).toLocaleDateString(undefined, {
-                    month: 'short',
-                    day: 'numeric',
-                    year: 'numeric',
-                  })}
-                </span>
-                {urlLive && (
-                  <span className="font-mono tracking-wider">{a.code}</span>
-                )}
-                {noPeriods ? (
-                  <span className="font-semibold text-amber-600 truncate max-w-[120px]">
-                    No classes
-                  </span>
-                ) : periodLabel != null ? (
-                  <span className="font-semibold truncate max-w-[120px]">
-                    {periodLabel}
-                  </span>
-                ) : null}
-                {status.tone === 'success' && (
-                  <span className="inline-flex items-center">
-                    <Radio className="w-3 h-3" />
-                  </span>
-                )}
-              </>
-            }
-            primaryAction={{
+/* ─── Archive row wrapper (per-row hooks for view-count fetch) ────────────── */
+
+interface QuizArchiveRowProps {
+  assignment: QuizAssignment;
+  mode: 'active' | 'archive';
+  buildActions: (
+    a: QuizAssignment,
+    mode: 'active' | 'archive'
+  ) => {
+    primary: {
+      label: string;
+      icon: React.ComponentType<{ size?: number; className?: string }>;
+      onClick: () => void;
+    } | null;
+    secondaries: LibraryMenuAction[];
+  };
+}
+
+/**
+ * Per-row component so `useSessionViewCount` can be a top-level hook.
+ * View-only quizzes annotate the meta line with a view count fetched from
+ * the session's `views/` subcollection on mount.
+ */
+const QuizArchiveRow: React.FC<QuizArchiveRowProps> = ({
+  assignment: a,
+  mode,
+  buildActions,
+}) => {
+  const assignmentIsViewOnly = a.mode === 'view-only';
+  const { primary, secondaries } = buildActions(a, mode);
+  const status = resolveStatus(a.status, assignmentIsViewOnly);
+  const periods = a.periodNames ?? (a.periodName ? [a.periodName] : []);
+  const urlLive = a.status !== 'inactive';
+  const noPeriods = periods.length === 0 && mode === 'active';
+  const periodLabel =
+    periods.length === 1
+      ? periods[0]
+      : periods.length > 0
+        ? `${periods.length} classes`
+        : null;
+
+  const { count } = useSessionViewCount(
+    'quiz_sessions',
+    // Quiz assignment id is also the underlying session id (1:1 — see the
+    // QuizAssignment type's "Assignment UUID — also the sessionId" note).
+    a.id,
+    assignmentIsViewOnly
+  );
+
+  return (
+    <AssignmentArchiveCard<QuizAssignment>
+      assignment={a}
+      mode={mode}
+      status={status}
+      title={a.quizTitle}
+      subtitle={a.className?.trim() ? a.className : undefined}
+      meta={
+        <>
+          <span className="inline-flex items-center gap-0.5">
+            <Calendar className="w-3 h-3" />
+            {new Date(a.createdAt).toLocaleDateString(undefined, {
+              month: 'short',
+              day: 'numeric',
+              year: 'numeric',
+            })}
+          </span>
+          {urlLive && !assignmentIsViewOnly && (
+            <span className="font-mono tracking-wider">{a.code}</span>
+          )}
+          {noPeriods && !assignmentIsViewOnly ? (
+            <span className="font-semibold text-amber-600 truncate max-w-[120px]">
+              No classes
+            </span>
+          ) : periodLabel != null && !assignmentIsViewOnly ? (
+            <span className="font-semibold truncate max-w-[120px]">
+              {periodLabel}
+            </span>
+          ) : null}
+          {assignmentIsViewOnly && <ViewCountBadge count={count} />}
+          {status.tone === 'success' && !assignmentIsViewOnly && (
+            <span className="inline-flex items-center">
+              <Radio className="w-3 h-3" />
+            </span>
+          )}
+        </>
+      }
+      primaryAction={
+        primary
+          ? {
               label: primary.label,
               icon: primary.icon,
               onClick: primary.onClick,
-            }}
-            secondaryActions={secondaries}
-          />
-        );
-      })}
-    </div>
+            }
+          : undefined
+      }
+      secondaryActions={secondaries}
+    />
   );
 };
 

--- a/components/widgets/QuizWidget/components/QuizManager.tsx
+++ b/components/widgets/QuizWidget/components/QuizManager.tsx
@@ -1541,9 +1541,8 @@ interface QuizArchiveRowProps {
 }
 
 /**
- * Per-row component so `useSessionViewCount` can be a top-level hook.
- * View-only quizzes annotate the meta line with a view count fetched from
- * the session's `views/` subcollection on mount.
+ * Per-row hook host. View-only quizzes annotate the meta line with a view
+ * count fetched from the session's `views/` subcollection on mount.
  */
 const QuizArchiveRow: React.FC<QuizArchiveRowProps> = ({
   assignment: a,
@@ -1571,6 +1570,51 @@ const QuizArchiveRow: React.FC<QuizArchiveRowProps> = ({
     assignmentIsViewOnly
   );
 
+  // Meta line composes per-mode. View-only shares show date + view count
+  // only — the join code, class targeting, and live-radio dot all relate to
+  // submissions plumbing that doesn't apply. Submissions show the full row.
+  const dateChip = (
+    <span className="inline-flex items-center gap-0.5">
+      <Calendar className="w-3 h-3" />
+      {new Date(a.createdAt).toLocaleDateString(undefined, {
+        month: 'short',
+        day: 'numeric',
+        year: 'numeric',
+      })}
+    </span>
+  );
+
+  let meta: React.ReactNode;
+  if (assignmentIsViewOnly) {
+    meta = (
+      <>
+        {dateChip}
+        <ViewCountBadge count={count} />
+      </>
+    );
+  } else {
+    meta = (
+      <>
+        {dateChip}
+        {urlLive && <span className="font-mono tracking-wider">{a.code}</span>}
+        {noPeriods ? (
+          <span className="font-semibold text-amber-600 truncate max-w-[120px]">
+            No classes
+          </span>
+        ) : periodLabel != null ? (
+          <span className="font-semibold truncate max-w-[120px]">
+            {periodLabel}
+          </span>
+        ) : null}
+        {status.tone === 'success' && (
+          <span className="inline-flex items-center">
+            <Radio className="w-3 h-3" />
+          </span>
+        )}
+      </>
+    );
+  }
+
   return (
     <AssignmentArchiveCard<QuizAssignment>
       assignment={a}
@@ -1578,36 +1622,7 @@ const QuizArchiveRow: React.FC<QuizArchiveRowProps> = ({
       status={status}
       title={a.quizTitle}
       subtitle={a.className?.trim() ? a.className : undefined}
-      meta={
-        <>
-          <span className="inline-flex items-center gap-0.5">
-            <Calendar className="w-3 h-3" />
-            {new Date(a.createdAt).toLocaleDateString(undefined, {
-              month: 'short',
-              day: 'numeric',
-              year: 'numeric',
-            })}
-          </span>
-          {urlLive && !assignmentIsViewOnly && (
-            <span className="font-mono tracking-wider">{a.code}</span>
-          )}
-          {noPeriods && !assignmentIsViewOnly ? (
-            <span className="font-semibold text-amber-600 truncate max-w-[120px]">
-              No classes
-            </span>
-          ) : periodLabel != null && !assignmentIsViewOnly ? (
-            <span className="font-semibold truncate max-w-[120px]">
-              {periodLabel}
-            </span>
-          ) : null}
-          {assignmentIsViewOnly && <ViewCountBadge count={count} />}
-          {status.tone === 'success' && !assignmentIsViewOnly && (
-            <span className="inline-flex items-center">
-              <Radio className="w-3 h-3" />
-            </span>
-          )}
-        </>
-      }
+      meta={meta}
       primaryAction={
         primary
           ? {

--- a/components/widgets/VideoActivityWidget/Widget.tsx
+++ b/components/widgets/VideoActivityWidget/Widget.tsx
@@ -101,6 +101,7 @@ export const VideoActivityWidget: React.FC<{ widget: WidgetData }> = ({
     pauseAssignment,
     resumeAssignment,
     deactivateAssignment,
+    reactivateAssignment,
     deleteAssignment,
   } = useVideoActivityAssignments(user?.uid);
 
@@ -529,12 +530,34 @@ export const VideoActivityWidget: React.FC<{ widget: WidgetData }> = ({
           }
         }}
         onArchiveDeactivate={async (assignment) => {
+          // Branch the success toast on the assignment's frozen mode — for
+          // view-only shares "Assignment" is the wrong noun and "submit" is
+          // the wrong verb (no submissions exist).
+          const isViewOnlyAssignment = assignment.mode === 'view-only';
           try {
             await deactivateAssignment(assignment.id);
-            addToast('Assignment ended.', 'success');
+            addToast(
+              isViewOnlyAssignment ? 'Share ended.' : 'Assignment ended.',
+              'success'
+            );
           } catch (err) {
             addToast(
-              err instanceof Error ? err.message : 'Failed to end assignment',
+              err instanceof Error
+                ? err.message
+                : isViewOnlyAssignment
+                  ? 'Failed to end share'
+                  : 'Failed to end assignment',
+              'error'
+            );
+          }
+        }}
+        onArchiveReactivate={async (assignment) => {
+          try {
+            await reactivateAssignment(assignment.id);
+            addToast('Share reactivated.', 'success');
+          } catch (err) {
+            addToast(
+              err instanceof Error ? err.message : 'Failed to reactivate share',
               'error'
             );
           }

--- a/components/widgets/VideoActivityWidget/components/VideoActivityManager.tsx
+++ b/components/widgets/VideoActivityWidget/components/VideoActivityManager.tsx
@@ -32,6 +32,7 @@ import {
   Monitor,
   PlayCircle,
   Plus,
+  RotateCcw,
   Trash2,
 } from 'lucide-react';
 import { LibraryShell } from '@/components/common/library/LibraryShell';
@@ -41,6 +42,8 @@ import { LibraryItemCard } from '@/components/common/library/LibraryItemCard';
 import { AssignModal } from '@/components/common/library/AssignModal';
 import { ViewOnlyShareModal } from '@/components/common/library/ViewOnlyShareModal';
 import { AssignmentArchiveCard } from '@/components/common/library/AssignmentArchiveCard';
+import { ViewCountBadge } from '@/components/common/library/ViewCountBadge';
+import { useSessionViewCount } from '@/hooks/useSessionViewCount';
 import { FolderSidebar } from '@/components/common/library/FolderSidebar';
 import { FolderPickerPopover } from '@/components/common/library/FolderPickerPopover';
 import { buildMoveToFolderAction } from '@/components/common/library/folderMenuAction';
@@ -134,6 +137,12 @@ export interface VideoActivityManagerProps {
   onArchiveCopyUrl?: (assignment: VideoActivityAssignment) => void;
   onArchivePauseResume?: (assignment: VideoActivityAssignment) => Promise<void>;
   onArchiveDeactivate?: (assignment: VideoActivityAssignment) => Promise<void>;
+  /**
+   * Re-open a previously deactivated view-only share. Required for the
+   * archive-tab "Reactivate" action to render; omit if the parent doesn't
+   * implement reactivation.
+   */
+  onArchiveReactivate?: (assignment: VideoActivityAssignment) => Promise<void>;
   onArchiveDelete?: (assignment: VideoActivityAssignment) => Promise<void>;
   onArchiveResults?: (assignment: VideoActivityAssignment) => void;
   /**
@@ -224,15 +233,115 @@ function statusToBadge(
         dot: true,
       };
     case 'paused':
-      return { label: 'Paused', tone: 'warn', dot: true };
+      // View-only shares don't expose pause/resume — keeping the active
+      // badge label consistent ("Shared") prevents a "Paused" chip from
+      // implying the link is dead.
+      return isViewOnly
+        ? { label: 'Shared', tone: 'success', dot: true }
+        : { label: 'Paused', tone: 'warn', dot: true };
     case 'inactive':
     default:
       return {
-        label: isViewOnly ? 'Ended share' : 'Ended',
+        // Single-word "Closed" reads cleaner and is consistent across
+        // widgets; cf. MiniAppManager.statusBadge / QuizManager.resolveStatus.
+        label: isViewOnly ? 'Closed' : 'Ended',
         tone: 'neutral',
       };
   }
 }
+
+/* ─── Archive row wrapper (per-row hooks for view-count fetch) ────────────── */
+
+interface VideoActivityArchiveRowProps {
+  assignment: VideoActivityAssignment;
+  mode: 'active' | 'archive';
+  secondaryActions: LibraryMenuAction[];
+  onArchiveCopyUrl?: (assignment: VideoActivityAssignment) => void;
+  onArchiveMonitor?: (
+    assignment: VideoActivityAssignment
+  ) => void | Promise<void>;
+  onArchiveResults?: (assignment: VideoActivityAssignment) => void;
+}
+
+/**
+ * Per-row component so `useSessionViewCount` can be called as a top-level
+ * hook (calling it inside `.map()` violates the rules of hooks). Owns the
+ * primary-action selection and the meta-line layout for both Active and
+ * Archive tabs across submissions and view-only modes.
+ */
+const VideoActivityArchiveRow: React.FC<VideoActivityArchiveRowProps> = ({
+  assignment,
+  mode,
+  secondaryActions,
+  onArchiveCopyUrl,
+  onArchiveMonitor,
+  onArchiveResults,
+}) => {
+  const assignmentIsViewOnly = assignment.mode === 'view-only';
+  const status = statusToBadge(assignment.status, assignmentIsViewOnly);
+
+  // Primary action priority:
+  //   - View-only + active: Copy link (the link is the entire UX).
+  //   - View-only + archive: omit — link is dead, Reactivate lives in kebab.
+  //   - Submissions + active+live: Monitor when wired.
+  //   - Submissions + active+paused or no monitor wired: Copy link.
+  //   - Submissions + archive: Results.
+  const isLiveActive = mode === 'active' && assignment.status === 'active';
+  const primaryAction: { label: string; icon: typeof Copy } | null =
+    assignmentIsViewOnly
+      ? mode === 'active'
+        ? { label: 'Copy link', icon: Copy }
+        : null
+      : mode === 'active'
+        ? isLiveActive && onArchiveMonitor
+          ? { label: 'Monitor', icon: Monitor }
+          : { label: 'Copy link', icon: Copy }
+        : { label: 'Results', icon: BarChart3 };
+
+  const { count } = useSessionViewCount(
+    'video_activity_sessions',
+    assignment.id,
+    assignmentIsViewOnly
+  );
+
+  return (
+    <AssignmentArchiveCard<VideoActivityAssignment>
+      assignment={assignment}
+      mode={mode}
+      status={status}
+      title={assignment.className ?? assignment.activityTitle}
+      subtitle={assignment.className ? assignment.activityTitle : undefined}
+      meta={
+        <>
+          <span>{new Date(assignment.updatedAt).toLocaleDateString()}</span>
+          {assignmentIsViewOnly && <ViewCountBadge count={count} />}
+        </>
+      }
+      primaryAction={
+        primaryAction
+          ? {
+              label: primaryAction.label,
+              icon: primaryAction.icon,
+              onClick: () => {
+                if (assignmentIsViewOnly) {
+                  if (onArchiveCopyUrl) onArchiveCopyUrl(assignment);
+                } else if (mode === 'active') {
+                  if (isLiveActive && onArchiveMonitor) {
+                    void onArchiveMonitor(assignment);
+                  } else if (onArchiveCopyUrl) {
+                    onArchiveCopyUrl(assignment);
+                  }
+                } else if (onArchiveResults) {
+                  onArchiveResults(assignment);
+                }
+              },
+            }
+          : undefined
+      }
+      secondaryActions={secondaryActions}
+    />
+  );
+};
 
 /* ─── Main component ──────────────────────────────────────────────────────── */
 
@@ -254,6 +363,7 @@ export const VideoActivityManager: React.FC<VideoActivityManagerProps> = ({
   onArchiveCopyUrl,
   onArchivePauseResume,
   onArchiveDeactivate,
+  onArchiveReactivate,
   onArchiveDelete,
   onArchiveResults,
   onArchiveMonitor,
@@ -762,72 +872,17 @@ export const VideoActivityManager: React.FC<VideoActivityManagerProps> = ({
 
     return (
       <div className="flex flex-col gap-2">
-        {list.map((assignment) => {
-          // Per-assignment mode is frozen at creation. View-only shares have
-          // no responses to surface — relabel the status badge and collapse
-          // the archive primary to "Copy link" instead of "Results".
-          const assignmentIsViewOnly = assignment.mode === 'view-only';
-          const status = statusToBadge(assignment.status, assignmentIsViewOnly);
-          const secondaryActions = buildAssignmentSecondaryActions(
-            assignment,
-            mode
-          );
-
-          // Primary action priority:
-          //   - View-only shares: always Copy link (Monitor would have nothing
-          //     to monitor; Results doesn't exist for view-only).
-          //   - Submissions, active+live: Monitor when wired (the live teacher
-          //     view of student progress).
-          //   - Submissions, active+paused or no monitor wired: Copy link
-          //     (Monitor would show a paused screen).
-          //   - Submissions, archive: Results.
-          const isLiveActive =
-            mode === 'active' && assignment.status === 'active';
-          const primaryAction = assignmentIsViewOnly
-            ? { label: 'Copy link', icon: Copy }
-            : mode === 'active'
-              ? isLiveActive && onArchiveMonitor
-                ? { label: 'Monitor', icon: Monitor }
-                : { label: 'Copy link', icon: Copy }
-              : { label: 'Results', icon: BarChart3 };
-
-          return (
-            <AssignmentArchiveCard<VideoActivityAssignment>
-              key={assignment.id}
-              assignment={assignment}
-              mode={mode}
-              status={status}
-              title={assignment.className ?? assignment.activityTitle}
-              subtitle={
-                assignment.className ? assignment.activityTitle : undefined
-              }
-              meta={
-                <span>
-                  {new Date(assignment.updatedAt).toLocaleDateString()}
-                </span>
-              }
-              primaryAction={{
-                label: primaryAction.label,
-                icon: primaryAction.icon,
-                onClick: () => {
-                  // Mirror the priority used to pick the label above.
-                  if (assignmentIsViewOnly) {
-                    if (onArchiveCopyUrl) onArchiveCopyUrl(assignment);
-                  } else if (mode === 'active') {
-                    if (isLiveActive && onArchiveMonitor) {
-                      void onArchiveMonitor(assignment);
-                    } else if (onArchiveCopyUrl) {
-                      onArchiveCopyUrl(assignment);
-                    }
-                  } else if (onArchiveResults) {
-                    onArchiveResults(assignment);
-                  }
-                },
-              }}
-              secondaryActions={secondaryActions}
-            />
-          );
-        })}
+        {list.map((assignment) => (
+          <VideoActivityArchiveRow
+            key={assignment.id}
+            assignment={assignment}
+            mode={mode}
+            secondaryActions={buildAssignmentSecondaryActions(assignment, mode)}
+            onArchiveCopyUrl={onArchiveCopyUrl}
+            onArchiveMonitor={onArchiveMonitor}
+            onArchiveResults={onArchiveResults}
+          />
+        ))}
       </div>
     );
   };
@@ -846,7 +901,12 @@ export const VideoActivityManager: React.FC<VideoActivityManagerProps> = ({
     const assignmentIsViewOnly = assignment.mode === 'view-only';
 
     if (mode === 'active') {
-      if (onArchiveCopyUrl) {
+      // Submissions cards keep "Copy link" in the kebab as a stable
+      // secondary surface (the primary may be Monitor/Start/Results
+      // depending on state). View-only Shared cards already pin "Copy
+      // link" as the primary action — duplicating it in the kebab is just
+      // visual noise.
+      if (onArchiveCopyUrl && !assignmentIsViewOnly) {
         actions.push({
           id: 'copy-url',
           label: 'Copy link',
@@ -876,6 +936,23 @@ export const VideoActivityManager: React.FC<VideoActivityManagerProps> = ({
           },
         });
       }
+    }
+
+    // Reactivate is view-only-only, archive-only — flips status back to
+    // active so the URL works again. Cf. MiniAppManager.assignmentSecondary.
+    if (
+      mode === 'archive' &&
+      assignmentIsViewOnly &&
+      onArchiveReactivate !== undefined
+    ) {
+      actions.push({
+        id: 'reactivate',
+        label: 'Reactivate',
+        icon: RotateCcw,
+        onClick: () => {
+          void onArchiveReactivate(assignment);
+        },
+      });
     }
 
     // View-only shares have no responses to surface.

--- a/components/widgets/VideoActivityWidget/components/VideoActivityManager.tsx
+++ b/components/widgets/VideoActivityWidget/components/VideoActivityManager.tsx
@@ -39,6 +39,7 @@ import { LibraryToolbar } from '@/components/common/library/LibraryToolbar';
 import { LibraryGrid } from '@/components/common/library/LibraryGrid';
 import { LibraryItemCard } from '@/components/common/library/LibraryItemCard';
 import { AssignModal } from '@/components/common/library/AssignModal';
+import { ViewOnlyShareModal } from '@/components/common/library/ViewOnlyShareModal';
 import { AssignmentArchiveCard } from '@/components/common/library/AssignmentArchiveCard';
 import { FolderSidebar } from '@/components/common/library/FolderSidebar';
 import { FolderPickerPopover } from '@/components/common/library/FolderPickerPopover';
@@ -268,9 +269,23 @@ export const VideoActivityManager: React.FC<VideoActivityManagerProps> = ({
   const primaryActionLabel = isViewOnly ? 'Share' : 'Assign';
   const [tab, setTab] = useState<LibraryTab>('library');
 
-  // Assign modal state
+  // Assign modal state (submissions mode)
   const [assignTarget, setAssignTarget] =
     useState<VideoActivityMetadata | null>(null);
+
+  // View-only Share modal state — bypasses the AssignModal entirely
+  // because class targeting has no functional effect on view-only sessions
+  // (rules don't gate views by class; sessions are filtered out of
+  // /my-assignments anyway).
+  const [viewOnlyShareTarget, setViewOnlyShareTarget] =
+    useState<VideoActivityMetadata | null>(null);
+  const [viewOnlyShareLink, setViewOnlyShareLink] = useState<string | null>(
+    null
+  );
+  const [viewOnlyShareError, setViewOnlyShareError] = useState<string | null>(
+    null
+  );
+  const [isCreatingViewOnlyShare, setIsCreatingViewOnlyShare] = useState(false);
   const [assignOptions, setAssignOptions] =
     useState<VideoActivitySessionSettings>(defaultSessionSettings);
   const [assignmentName, setAssignmentName] = useState<string>('');
@@ -523,6 +538,41 @@ export const VideoActivityManager: React.FC<VideoActivityManagerProps> = ({
     }
   };
 
+  // View-only share confirm: mints the session via the same `onAssign`
+  // callback the parent already wires for submissions, with default settings
+  // and an auto-generated share name. The session/assignment docs carry
+  // the org-wide view-only mode (the parent reads `assignmentMode` via
+  // useAuth), so the rules block submissions and the URL serves as a
+  // read-only share link.
+  const handleConfirmViewOnlyShare = async (): Promise<void> => {
+    if (!viewOnlyShareTarget) return;
+    setIsCreatingViewOnlyShare(true);
+    setViewOnlyShareError(null);
+    try {
+      const sessionId = await onAssign(
+        viewOnlyShareTarget,
+        defaultSessionSettings,
+        buildDefaultAssignmentName(viewOnlyShareTarget.title),
+        []
+      );
+      setViewOnlyShareLink(
+        `${window.location.origin}/activity/${encodeURIComponent(sessionId)}`
+      );
+    } catch (err) {
+      setViewOnlyShareError(
+        err instanceof Error ? err.message : 'Failed to create share link.'
+      );
+    } finally {
+      setIsCreatingViewOnlyShare(false);
+    }
+  };
+
+  const closeViewOnlyShareModal = () => {
+    setViewOnlyShareTarget(null);
+    setViewOnlyShareLink(null);
+    setViewOnlyShareError(null);
+  };
+
   /* ─── Loading state ───────────────────────────────────────────────────── */
 
   if (loading) {
@@ -652,7 +702,16 @@ export const VideoActivityManager: React.FC<VideoActivityManagerProps> = ({
               primaryAction={{
                 label: primaryActionLabel,
                 icon: Link2,
-                onClick: () => setAssignTarget(activity),
+                onClick: () => {
+                  if (isViewOnly) {
+                    // View-only: skip the AssignModal/picker flow entirely.
+                    setViewOnlyShareTarget(activity);
+                    setViewOnlyShareLink(null);
+                    setViewOnlyShareError(null);
+                  } else {
+                    setAssignTarget(activity);
+                  }
+                },
               }}
               secondaryActions={secondaryActions}
               onClick={() => onEdit(activity)}
@@ -1008,7 +1067,7 @@ export const VideoActivityManager: React.FC<VideoActivityManagerProps> = ({
         />
       )}
 
-      {assignTarget && (
+      {assignTarget && !isViewOnly && (
         <AssignModal<VideoActivitySessionSettings>
           isOpen={true}
           onClose={() => setAssignTarget(null)}
@@ -1070,6 +1129,17 @@ export const VideoActivityManager: React.FC<VideoActivityManagerProps> = ({
               </div>
             </div>
           }
+        />
+      )}
+
+      {viewOnlyShareTarget && (
+        <ViewOnlyShareModal
+          itemTitle={viewOnlyShareTarget.title}
+          isCreating={isCreatingViewOnlyShare}
+          createdLink={viewOnlyShareLink}
+          error={viewOnlyShareError}
+          onConfirm={() => void handleConfirmViewOnlyShare()}
+          onClose={closeViewOnlyShareModal}
         />
       )}
     </>

--- a/components/widgets/VideoActivityWidget/components/VideoActivityManager.tsx
+++ b/components/widgets/VideoActivityWidget/components/VideoActivityManager.tsx
@@ -264,10 +264,9 @@ interface VideoActivityArchiveRowProps {
 }
 
 /**
- * Per-row component so `useSessionViewCount` can be called as a top-level
- * hook (calling it inside `.map()` violates the rules of hooks). Owns the
- * primary-action selection and the meta-line layout for both Active and
- * Archive tabs across submissions and view-only modes.
+ * Per-row hook host for view-count fetch. Owns the primary-action selection
+ * and the meta-line layout for both Active and Archive tabs across
+ * submissions and view-only modes.
  */
 const VideoActivityArchiveRow: React.FC<VideoActivityArchiveRowProps> = ({
   assignment,

--- a/hooks/useGuidedLearningAssignments.ts
+++ b/hooks/useGuidedLearningAssignments.ts
@@ -25,6 +25,7 @@ import {
   writeBatch,
 } from 'firebase/firestore';
 import { db } from '@/config/firebase';
+import { invalidateSessionViewCount } from './useSessionViewCount';
 import type {
   AssignmentMode,
   GuidedLearningAssignment,
@@ -176,7 +177,16 @@ export const useGuidedLearningAssignments = (
 
   const unarchiveAssignment = useCallback<
     UseGuidedLearningAssignmentsResult['unarchiveAssignment']
-  >((assignmentId) => setStatus(assignmentId, 'active'), [setStatus]);
+  >(
+    async (assignmentId) => {
+      await setStatus(assignmentId, 'active');
+      // Drop any cached view count so the Shared row re-issues the
+      // aggregation query on next mount; the cache is module-scoped and
+      // would otherwise hold the pre-archive count forever.
+      invalidateSessionViewCount('guided_learning_sessions', assignmentId);
+    },
+    [setStatus]
+  );
 
   const deleteAssignment = useCallback<
     UseGuidedLearningAssignmentsResult['deleteAssignment']

--- a/hooks/useMiniAppAssignments.ts
+++ b/hooks/useMiniAppAssignments.ts
@@ -57,6 +57,13 @@ export interface UseMiniAppAssignmentsResult {
   renameAssignment: (assignmentId: string, name: string) => Promise<void>;
   /** Mark the assignment inactive and end the underlying session. */
   endAssignment: (assignmentId: string) => Promise<void>;
+  /**
+   * Re-open a previously ended share. Symmetric to `endAssignment`: flips the
+   * assignment doc's `status` back to `'active'` and the session doc's
+   * `status` back to `'active'` (clearing `endedAt`). The session URL works
+   * again. Used by the view-only Shared archive's "Reactivate" action.
+   */
+  reactivateAssignment: (assignmentId: string) => Promise<void>;
   /** Permanently remove the archive row (the session doc is left as-is). */
   deleteAssignment: (assignmentId: string) => Promise<void>;
 }
@@ -219,6 +226,39 @@ export const useMiniAppAssignments = (
     [userId, assignments]
   );
 
+  const reactivateAssignment = useCallback<
+    UseMiniAppAssignmentsResult['reactivateAssignment']
+  >(
+    async (assignmentId) => {
+      if (!userId) throw new Error('Not authenticated');
+      const now = Date.now();
+      const assignment = assignments.find((a) => a.id === assignmentId);
+
+      await updateDoc(
+        doc(db, 'users', userId, ASSIGNMENTS_COLLECTION, assignmentId),
+        { status: 'active', updatedAt: now }
+      );
+
+      // Mirror onto the session doc — its `status` is what the student app
+      // checks before rendering. The historical `endedAt` is intentionally
+      // left in place; the student gate keys off `status`, not `endedAt`,
+      // and preserving the timestamp is useful audit history.
+      if (assignment?.sessionId) {
+        try {
+          await updateDoc(doc(db, SESSIONS_COLLECTION, assignment.sessionId), {
+            status: 'active',
+          });
+        } catch (err) {
+          console.warn(
+            '[useMiniAppAssignments] session reactivate mirror failed',
+            err
+          );
+        }
+      }
+    },
+    [userId, assignments]
+  );
+
   const deleteAssignment = useCallback<
     UseMiniAppAssignmentsResult['deleteAssignment']
   >(
@@ -238,6 +278,7 @@ export const useMiniAppAssignments = (
     createAssignment,
     renameAssignment,
     endAssignment,
+    reactivateAssignment,
     deleteAssignment,
   };
 };

--- a/hooks/useMiniAppAssignments.ts
+++ b/hooks/useMiniAppAssignments.ts
@@ -27,6 +27,7 @@ import {
   updateDoc,
 } from 'firebase/firestore';
 import { db } from '@/config/firebase';
+import { invalidateSessionViewCount } from './useSessionViewCount';
 import type { AssignmentMode, MiniAppAssignment, MiniAppItem } from '@/types';
 
 const ASSIGNMENTS_COLLECTION = 'miniapp_assignments';
@@ -254,6 +255,11 @@ export const useMiniAppAssignments = (
             err
           );
         }
+        // Drop any cached view count so the Shared row re-issues the
+        // aggregation query on next mount — students opening the link
+        // post-reactivate will be missed otherwise (the cache is keyed
+        // by sessionId and module-scoped, so it survives unmount).
+        invalidateSessionViewCount('mini_app_sessions', assignment.sessionId);
       }
     },
     [userId, assignments]

--- a/hooks/useQuizAssignments.ts
+++ b/hooks/useQuizAssignments.ts
@@ -27,6 +27,7 @@ import {
   writeBatch,
 } from 'firebase/firestore';
 import { db } from '../config/firebase';
+import { invalidateSessionViewCount } from './useSessionViewCount';
 import type {
   AssignmentMode,
   PlcLinkage,
@@ -650,6 +651,10 @@ export const useQuizAssignments = (
       }
       batch.update(sessionRef, sessionPatch);
       await batch.commit();
+      // Drop any cached view count so the Shared row re-issues the
+      // aggregation query on next mount; submissions-mode reopens get the
+      // call too (no-op against a missing key).
+      invalidateSessionViewCount('quiz_sessions', assignmentId);
     },
     [userId]
   );

--- a/hooks/useSessionViewCount.ts
+++ b/hooks/useSessionViewCount.ts
@@ -1,0 +1,123 @@
+/**
+ * useSessionViewCount — fetches the count of view-tracking docs for a single
+ * view-only session.
+ *
+ * The four assignment widgets (Quiz, Video Activity, Mini App, Guided
+ * Learning) each persist anonymous view events to a `views/` subcollection on
+ * their session doc whenever a student loads a view-only share URL. This
+ * hook exposes that count so the teacher's Shared / Archive surface can
+ * show "viewed N times" without adding a denormalized counter on the
+ * session itself.
+ *
+ * Cost shape: one Firestore aggregation query (`getCountFromServer`) per
+ * mounted card when `enabled === true`, gated behind a module-level cache
+ * keyed by `${collectionName}:${sessionId}`. Re-renders re-use the cached
+ * count; teachers can refresh by re-opening the tab (Library tabs unmount
+ * and remount the cards).
+ *
+ * The hook is intentionally read-once: the user's stated need is "see how
+ * many times the URL was opened" — a snapshot suffices and a live listener
+ * would be a real-time write multiplier across the teacher's archive.
+ */
+
+import { useEffect, useState } from 'react';
+import { collection, getCountFromServer } from 'firebase/firestore';
+import { db } from '@/config/firebase';
+
+export type ViewTrackingCollection =
+  | 'quiz_sessions'
+  | 'video_activity_sessions'
+  | 'mini_app_sessions'
+  | 'guided_learning_sessions';
+
+interface CacheEntry {
+  count: number | null;
+  promise: Promise<number> | null;
+}
+
+// Module-level cache so the same sessionId rendered from multiple cards
+// (or after a list re-render) doesn't fanout to repeat aggregation queries.
+// Cleared on full page reload — sufficient lifetime for a teacher session.
+const cache = new Map<string, CacheEntry>();
+
+function cacheKey(collectionName: ViewTrackingCollection, sessionId: string) {
+  return `${collectionName}:${sessionId}`;
+}
+
+export interface UseSessionViewCountResult {
+  count: number | null;
+  loading: boolean;
+}
+
+/**
+ * @param collectionName Top-level Firestore session collection.
+ * @param sessionId Session doc id whose `views/` subcollection should be counted.
+ *   Pass `undefined` (or `enabled === false`) to skip the read entirely.
+ * @param enabled When false the hook returns `{count: null, loading: false}`
+ *   without issuing any query — used to gate the read on view-only mode.
+ */
+export function useSessionViewCount(
+  collectionName: ViewTrackingCollection,
+  sessionId: string | undefined,
+  enabled: boolean
+): UseSessionViewCountResult {
+  // Resolved key for the current props — null when the hook is disabled.
+  const key = enabled && sessionId ? cacheKey(collectionName, sessionId) : null;
+
+  // The hook reads `count` and `loading` from `cache[key]` during render and
+  // re-renders the consumer when the async fetch resolves via `bumpRevision`.
+  // No synchronous setState lives in the effect body — the disable / key-
+  // change paths just produce a different derived render output, while the
+  // network resolution path bumps the revision counter from inside the
+  // promise's `.then` callback (async, allowed).
+  const [, setRevision] = useState(0);
+
+  useEffect(() => {
+    if (!key) return;
+
+    const cached = cache.get(key);
+    // Cache hit: nothing to do — the component already reads the resolved
+    // count during render.
+    if (cached?.count != null) return;
+
+    let cancelled = false;
+
+    // Coalesce concurrent mounts of the same sessionId onto a single query.
+    const inFlight: Promise<number> =
+      cached?.promise ??
+      getCountFromServer(
+        collection(db, collectionName, sessionId as string, 'views')
+      ).then(
+        (snap) => snap.data().count,
+        (err: unknown) => {
+          // Surface the failure to the caller as `count: 0` rather than
+          // null — a zero-state UI ("0 views") is a fine soft-fail and
+          // avoids broadcasting an empty cell. Logged for debugging.
+          console.warn('[useSessionViewCount] count query failed', err);
+          return 0;
+        }
+      );
+    cache.set(key, { count: cached?.count ?? null, promise: inFlight });
+
+    void inFlight.then((n) => {
+      cache.set(key, { count: n, promise: null });
+      if (!cancelled) {
+        // Bump the revision so this consumer re-renders and reads the
+        // fresh cache entry. Other mounted consumers re-render through
+        // their own effect cleanup; React's render is idempotent.
+        setRevision((r) => r + 1);
+      }
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [collectionName, sessionId, enabled, key]);
+
+  if (!key) return { count: null, loading: false };
+  const cached = cache.get(key);
+  return {
+    count: cached?.count ?? null,
+    loading: cached?.count == null,
+  };
+}

--- a/hooks/useSessionViewCount.ts
+++ b/hooks/useSessionViewCount.ts
@@ -10,10 +10,11 @@
  * session itself.
  *
  * Cost shape: one Firestore aggregation query (`getCountFromServer`) per
- * mounted card when `enabled === true`, gated behind a module-level cache
- * keyed by `${collectionName}:${sessionId}`. Re-renders re-use the cached
- * count; teachers can refresh by re-opening the tab (Library tabs unmount
- * and remount the cards).
+ * `(collection, sessionId)` pair, gated behind a module-level cache.
+ * Subsequent mounts of the same session — including remount-after-unmount —
+ * reuse the cached count. Teachers can force a refetch by calling
+ * `invalidateSessionViewCount` (wired into the reactivate / reopen
+ * callbacks so the count refreshes after a Closed share is brought back).
  *
  * The hook is intentionally read-once: the user's stated need is "see how
  * many times the URL was opened" — a snapshot suffices and a live listener
@@ -42,6 +43,20 @@ const cache = new Map<string, CacheEntry>();
 
 function cacheKey(collectionName: ViewTrackingCollection, sessionId: string) {
   return `${collectionName}:${sessionId}`;
+}
+
+/**
+ * Drop the cached view count for a session so the next mount of
+ * `useSessionViewCount` re-issues the aggregation query. Wire this into
+ * status-change callbacks (Reactivate, Reopen, etc.) where the count is
+ * expected to grow again after the call — without it, teachers would see
+ * the pre-Closed count forever even as new students hit the link.
+ */
+export function invalidateSessionViewCount(
+  collectionName: ViewTrackingCollection,
+  sessionId: string
+): void {
+  cache.delete(cacheKey(collectionName, sessionId));
 }
 
 export interface UseSessionViewCountResult {
@@ -75,38 +90,45 @@ export function useSessionViewCount(
   useEffect(() => {
     if (!key) return;
 
+    // Early-return on EITHER a resolved count OR an in-flight promise. The
+    // promise check is what makes the coalescing actually work under React
+    // 18 StrictMode (and any concurrent mount): without it, two effects
+    // racing through `cache.get(key)` before either has set `promise` would
+    // each call `getCountFromServer`, doubling Firestore reads in dev.
     const cached = cache.get(key);
-    // Cache hit: nothing to do — the component already reads the resolved
-    // count during render.
     if (cached?.count != null) return;
+    if (cached?.promise) {
+      // Coalesce: hitch a ride on the in-flight promise so this consumer
+      // re-renders when it resolves, but don't fire a second query.
+      let cancelled = false;
+      void cached.promise.then(() => {
+        if (!cancelled) setRevision((r) => r + 1);
+      });
+      return () => {
+        cancelled = true;
+      };
+    }
+
+    // Cache miss + no in-flight: claim the slot synchronously by writing
+    // the promise BEFORE awaiting, so a concurrent mount sees it.
+    const inFlight: Promise<number> = getCountFromServer(
+      collection(db, collectionName, sessionId as string, 'views')
+    ).then(
+      (snap) => snap.data().count,
+      (err: unknown) => {
+        // Surface the failure to the caller as `count: 0` rather than
+        // null — a zero-state UI ("0 views") is a fine soft-fail and
+        // avoids broadcasting an empty cell. Logged for debugging.
+        console.warn('[useSessionViewCount] count query failed', err);
+        return 0;
+      }
+    );
+    cache.set(key, { count: null, promise: inFlight });
 
     let cancelled = false;
-
-    // Coalesce concurrent mounts of the same sessionId onto a single query.
-    const inFlight: Promise<number> =
-      cached?.promise ??
-      getCountFromServer(
-        collection(db, collectionName, sessionId as string, 'views')
-      ).then(
-        (snap) => snap.data().count,
-        (err: unknown) => {
-          // Surface the failure to the caller as `count: 0` rather than
-          // null — a zero-state UI ("0 views") is a fine soft-fail and
-          // avoids broadcasting an empty cell. Logged for debugging.
-          console.warn('[useSessionViewCount] count query failed', err);
-          return 0;
-        }
-      );
-    cache.set(key, { count: cached?.count ?? null, promise: inFlight });
-
     void inFlight.then((n) => {
       cache.set(key, { count: n, promise: null });
-      if (!cancelled) {
-        // Bump the revision so this consumer re-renders and reads the
-        // fresh cache entry. Other mounted consumers re-render through
-        // their own effect cleanup; React's render is idempotent.
-        setRevision((r) => r + 1);
-      }
+      if (!cancelled) setRevision((r) => r + 1);
     });
 
     return () => {

--- a/hooks/useVideoActivityAssignments.ts
+++ b/hooks/useVideoActivityAssignments.ts
@@ -81,6 +81,13 @@ export interface UseVideoActivityAssignmentsResult {
   resumeAssignment: (assignmentId: string) => Promise<void>;
   /** Kills the student URL; preserves responses. assignment='inactive', session='ended'. */
   deactivateAssignment: (assignmentId: string) => Promise<void>;
+  /**
+   * Re-open a previously deactivated share (view-only mode only). Symmetric
+   * to `deactivateAssignment`: flips assignment → 'active' and session →
+   * 'active' so the URL works again. Submissions assignments don't expose
+   * this affordance; reopening a stale roster is a different UX call.
+   */
+  reactivateAssignment: (assignmentId: string) => Promise<void>;
   /** Permanently delete assignment + session + all responses. */
   deleteAssignment: (assignmentId: string) => Promise<void>;
   /** Update editable settings (className, session toggles). */
@@ -287,6 +294,15 @@ export const useVideoActivityAssignments = (
     [setStatus]
   );
 
+  const reactivateAssignment = useCallback<
+    UseVideoActivityAssignmentsResult['reactivateAssignment']
+  >(
+    async (assignmentId) => {
+      await setStatus(assignmentId, 'active', 'active');
+    },
+    [setStatus]
+  );
+
   const deleteAssignment = useCallback<
     UseVideoActivityAssignmentsResult['deleteAssignment']
   >(
@@ -366,6 +382,7 @@ export const useVideoActivityAssignments = (
     pauseAssignment,
     resumeAssignment,
     deactivateAssignment,
+    reactivateAssignment,
     deleteAssignment,
     updateAssignmentSettings,
   };

--- a/hooks/useVideoActivityAssignments.ts
+++ b/hooks/useVideoActivityAssignments.ts
@@ -87,6 +87,12 @@ export interface UseVideoActivityAssignmentsResult {
    * to `deactivateAssignment`: flips assignment → 'active' and session →
    * 'active' so the URL works again. Submissions assignments don't expose
    * this affordance; reopening a stale roster is a different UX call.
+   *
+   * Behaviorally equivalent to `resumeAssignment` today (both call
+   * `setStatus(id, 'active', 'active')`). Kept as a separate method so
+   * callers can express *intent* — view-only Reactivate from inactive vs.
+   * Resume from paused — and so the two can diverge later if Resume needs
+   * to preserve, e.g., a paused-at timestamp or pending-question state.
    */
   reactivateAssignment: (assignmentId: string) => Promise<void>;
   /** Permanently delete assignment + session + all responses. */

--- a/hooks/useVideoActivityAssignments.ts
+++ b/hooks/useVideoActivityAssignments.ts
@@ -25,6 +25,7 @@ import {
   writeBatch,
 } from 'firebase/firestore';
 import { db } from '../config/firebase';
+import { invalidateSessionViewCount } from './useSessionViewCount';
 import type {
   AssignmentMode,
   VideoActivityAssignment,
@@ -299,6 +300,10 @@ export const useVideoActivityAssignments = (
   >(
     async (assignmentId) => {
       await setStatus(assignmentId, 'active', 'active');
+      // Drop any cached view count so the Shared row re-issues the
+      // aggregation query on next mount; the cache is module-scoped and
+      // would otherwise hold the pre-Closed count forever.
+      invalidateSessionViewCount('video_activity_sessions', assignmentId);
     },
     [setStatus]
   );

--- a/tests/hooks/useSessionViewCount.test.ts
+++ b/tests/hooks/useSessionViewCount.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Unit tests for `useSessionViewCount`. Mocks Firestore's
+ * `getCountFromServer` so the hook is exercised without hitting the
+ * emulator. Verifies:
+ *   - `enabled === false` short-circuits and does not query.
+ *   - Successful counts surface via `count`.
+ *   - Concurrent mounts of the same sessionId coalesce onto a single query.
+ *   - Failed queries soft-fail to `count: 0` rather than rejecting.
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+
+const getCountFromServerMock = vi.fn();
+
+// Mock the firestore module before importing the hook so the module-level
+// `cache` Map is fresh for every test file run, but shared across tests in
+// this file (the cache is intentional production behavior — see hook docs).
+vi.mock('firebase/firestore', () => ({
+  collection: vi.fn(() => ({})),
+  getCountFromServer: (...args: unknown[]): unknown =>
+    getCountFromServerMock(...args) as unknown,
+}));
+
+vi.mock('@/config/firebase', () => ({
+  db: {},
+}));
+
+import { useSessionViewCount } from '../../hooks/useSessionViewCount';
+
+afterEach(() => {
+  getCountFromServerMock.mockReset();
+});
+
+describe('useSessionViewCount', () => {
+  it('returns null and does not query when disabled', () => {
+    const { result } = renderHook(() =>
+      useSessionViewCount('quiz_sessions', 'session-disabled', false)
+    );
+    expect(result.current).toEqual({ count: null, loading: false });
+    expect(getCountFromServerMock).not.toHaveBeenCalled();
+  });
+
+  it('returns null and does not query when sessionId is undefined', () => {
+    const { result } = renderHook(() =>
+      useSessionViewCount('quiz_sessions', undefined, true)
+    );
+    expect(result.current).toEqual({ count: null, loading: false });
+    expect(getCountFromServerMock).not.toHaveBeenCalled();
+  });
+
+  it('resolves the count after the aggregation query resolves', async () => {
+    getCountFromServerMock.mockResolvedValueOnce({
+      data: () => ({ count: 7 }),
+    });
+    const { result } = renderHook(() =>
+      useSessionViewCount('quiz_sessions', 'session-success', true)
+    );
+    expect(result.current.loading).toBe(true);
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.count).toBe(7);
+  });
+
+  it('coalesces concurrent mounts onto a single query', async () => {
+    getCountFromServerMock.mockResolvedValueOnce({
+      data: () => ({ count: 4 }),
+    });
+    const sessionId = 'session-coalesce';
+    const { result: a } = renderHook(() =>
+      useSessionViewCount('mini_app_sessions', sessionId, true)
+    );
+    const { result: b } = renderHook(() =>
+      useSessionViewCount('mini_app_sessions', sessionId, true)
+    );
+    await waitFor(() => expect(a.current.loading).toBe(false));
+    await waitFor(() => expect(b.current.loading).toBe(false));
+    expect(a.current.count).toBe(4);
+    expect(b.current.count).toBe(4);
+    expect(getCountFromServerMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('soft-fails to 0 when the query rejects', async () => {
+    const warnSpy = vi
+      .spyOn(console, 'warn')
+      .mockImplementation((): void => undefined);
+    getCountFromServerMock.mockRejectedValueOnce(new Error('network'));
+    const { result } = renderHook(() =>
+      useSessionViewCount('guided_learning_sessions', 'session-failure', true)
+    );
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.count).toBe(0);
+    expect(warnSpy).toHaveBeenCalledWith(
+      '[useSessionViewCount] count query failed',
+      expect.any(Error)
+    );
+    warnSpy.mockRestore();
+  });
+});

--- a/tests/hooks/useSessionViewCount.test.ts
+++ b/tests/hooks/useSessionViewCount.test.ts
@@ -5,6 +5,10 @@
  *   - `enabled === false` short-circuits and does not query.
  *   - Successful counts surface via `count`.
  *   - Concurrent mounts of the same sessionId coalesce onto a single query.
+ *   - Subsequent mounts of the same sessionId reuse the cached count.
+ *   - `invalidateSessionViewCount` busts the cache and forces a refetch.
+ *   - Changing sessionId mid-lifecycle issues a fresh query for the new key.
+ *   - Flipping `enabled` false → true mid-lifecycle issues a query.
  *   - Failed queries soft-fail to `count: 0` rather than rejecting.
  */
 import { afterEach, describe, expect, it, vi } from 'vitest';
@@ -25,7 +29,10 @@ vi.mock('@/config/firebase', () => ({
   db: {},
 }));
 
-import { useSessionViewCount } from '../../hooks/useSessionViewCount';
+import {
+  invalidateSessionViewCount,
+  useSessionViewCount,
+} from '../../hooks/useSessionViewCount';
 
 afterEach(() => {
   getCountFromServerMock.mockReset();
@@ -75,6 +82,84 @@ describe('useSessionViewCount', () => {
     await waitFor(() => expect(b.current.loading).toBe(false));
     expect(a.current.count).toBe(4);
     expect(b.current.count).toBe(4);
+    expect(getCountFromServerMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('reuses the cached count on a later mount of the same sessionId', async () => {
+    getCountFromServerMock.mockResolvedValueOnce({
+      data: () => ({ count: 11 }),
+    });
+    const sessionId = 'session-cache-survival';
+    // First mount fetches.
+    const first = renderHook(() =>
+      useSessionViewCount('quiz_sessions', sessionId, true)
+    );
+    await waitFor(() => expect(first.result.current.loading).toBe(false));
+    expect(first.result.current.count).toBe(11);
+    first.unmount();
+
+    // Second mount of the same key should NOT trigger a second query —
+    // the module-level cache survives unmount.
+    const second = renderHook(() =>
+      useSessionViewCount('quiz_sessions', sessionId, true)
+    );
+    expect(second.result.current).toEqual({ count: 11, loading: false });
+    expect(getCountFromServerMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('invalidateSessionViewCount drops the cached count and forces a refetch', async () => {
+    getCountFromServerMock
+      .mockResolvedValueOnce({ data: () => ({ count: 3 }) })
+      .mockResolvedValueOnce({ data: () => ({ count: 5 }) });
+    const sessionId = 'session-invalidate';
+    const first = renderHook(() =>
+      useSessionViewCount('mini_app_sessions', sessionId, true)
+    );
+    await waitFor(() => expect(first.result.current.loading).toBe(false));
+    expect(first.result.current.count).toBe(3);
+    first.unmount();
+
+    invalidateSessionViewCount('mini_app_sessions', sessionId);
+
+    // Next mount should re-fetch and surface the new count.
+    const second = renderHook(() =>
+      useSessionViewCount('mini_app_sessions', sessionId, true)
+    );
+    await waitFor(() => expect(second.result.current.loading).toBe(false));
+    expect(second.result.current.count).toBe(5);
+    expect(getCountFromServerMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('issues a fresh query when sessionId changes mid-lifecycle', async () => {
+    getCountFromServerMock
+      .mockResolvedValueOnce({ data: () => ({ count: 2 }) })
+      .mockResolvedValueOnce({ data: () => ({ count: 8 }) });
+    const { result, rerender } = renderHook(
+      ({ id }: { id: string }) =>
+        useSessionViewCount('quiz_sessions', id, true),
+      { initialProps: { id: 'session-A' } }
+    );
+    await waitFor(() => expect(result.current.count).toBe(2));
+
+    rerender({ id: 'session-B' });
+    await waitFor(() => expect(result.current.count).toBe(8));
+    expect(getCountFromServerMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('issues a query when enabled flips false → true', async () => {
+    getCountFromServerMock.mockResolvedValueOnce({
+      data: () => ({ count: 6 }),
+    });
+    const { result, rerender } = renderHook(
+      ({ enabled }: { enabled: boolean }) =>
+        useSessionViewCount('quiz_sessions', 'session-toggle', enabled),
+      { initialProps: { enabled: false } }
+    );
+    expect(result.current).toEqual({ count: null, loading: false });
+    expect(getCountFromServerMock).not.toHaveBeenCalled();
+
+    rerender({ enabled: true });
+    await waitFor(() => expect(result.current.count).toBe(6));
     expect(getCountFromServerMock).toHaveBeenCalledTimes(1);
   });
 


### PR DESCRIPTION
## Summary

Two follow-up UX cleanups based on user feedback after PR #1473:

1. **Strip the Share modal down for view-only**: hide the "Assign to classes" picker and the "Share Name" input — both are pure friction in view-only mode. Class targeting has no functional effect (rules don't gate views by class; sessions are already filtered out of /my-assignments). The auto-generated share name is sufficient for the Shared archive; teachers can rename later from the archive's overflow menu if they care.

2. **Hide the running Mini App's "Assign" / "Assignments" hover buttons** when the widget is configured view-only — both refer to submission-tracking flows that don't apply.

## Changes

### View-only Share modal
- **Mini App** (existing custom modal): hides the name input and class picker when view-only. Modal becomes title + description + "Create Share Link" button.
- **Quiz / Video Activity / Guided Learning** (route through the shared AssignModal in submissions mode): introduce a shared `ViewOnlyShareModal` primitive at `components/common/library/ViewOnlyShareModal.tsx`. View-only Share clicks open this instead of the AssignModal/picker flow. Pre-creation: single "Create Share Link" button. Post-creation: URL display with Copy / Open buttons.
- **Quiz**: adds `onCreateViewOnlyShare` callback to `QuizManagerProps` so the Widget implements a minimal create path (no PLC, no mode picker, no per-assignment settings) without wedging into the heavy existing `onAssign` chain.
- **VA / GL**: reuse their existing `onAssign` callback or factored helper (GL's `performAssign` gets a `silent` option for the view-only path).

### Running Mini App overlay
- The "Assign" + "Assignments" hover buttons (top-left of the running app) are now wrapped in `assignmentMode !== 'view-only'`. When view-only, the overlay shows only Save as Widget / Library on the right.

## Behavior preview

**Before** (view-only Mini App Share modal): app title + "Create Share Link" header + share-name input + "Assign to classes" picker with checkboxes + Create Share Link button. Two form fields the teacher has to acknowledge for zero functional payoff.

**After** (view-only Mini App Share modal): app title + "Create Share Link" header + 2-line description ("Anyone with the link can view this. No submissions are collected — view counts appear in the Shared archive.") + Create Share Link button. One click → URL displayed with Copy / Open.

Same shape across all four widgets via `ViewOnlyShareModal`. Submissions mode is unchanged.

## Test plan

- [ ] Admin: set Mini App + Quiz + Video Activity + Guided Learning to View only in Global Settings.
- [ ] Mini App: from the library, click Share on an app card — confirm modal shows only description + button. Confirm URL displays after creation with Copy/Open.
- [ ] Mini App: run an app — confirm Assign + Assignments hover buttons are gone (Save as Widget / Library still present).
- [ ] Quiz / VA / GL: from the library, click Share on a card — confirm the new ViewOnlyShareModal renders (single description + button).
- [ ] Switch any widget back to Submissions enabled — confirm the original AssignModal flow is unchanged.

## Verification

- `pnpm run type-check`: clean
- `pnpm run lint`: clean
- `pnpm run test`: 1730/1730 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)