### PR TITLE
fix(zoom): preserve cursor anchor when ctrl+wheel crosses 100%

### DIFF
--- a/components/layout/BoardActionsFab.tsx
+++ b/components/layout/BoardActionsFab.tsx
@@ -83,12 +83,23 @@ export const BoardActionsFab: FC<BoardActionsFabProps> = ({
     setZoom(sliderToZoom(rawValue));
   };
 
+  // Explicit "go back to canonical view" actions: also reset pan to center.
+  // Listened for in DashboardView, which owns panOffset state. Wheel-zoom
+  // landing on z=1 deliberately does NOT fire this event so the cursor
+  // anchor stays intact when the user zooms back through 100%.
+  const requestCameraReset = () => {
+    window.dispatchEvent(new CustomEvent('camera-reset'));
+  };
+
   const handleReset = () => {
     setZoom(ZOOM_DEFAULT);
+    requestCameraReset();
   };
 
   const handlePresetClick = (value: number) => {
-    setZoom(clampZoom(value));
+    const next = clampZoom(value);
+    setZoom(next);
+    if (next === ZOOM_DEFAULT) requestCameraReset();
   };
 
   const handlePopupKeyDown = (e: ReactKeyboardEvent<HTMLDivElement>) => {

--- a/components/layout/DashboardView.tsx
+++ b/components/layout/DashboardView.tsx
@@ -341,6 +341,16 @@ export const DashboardView: React.FC = () => {
     window.dispatchEvent(new CustomEvent('board-pan'));
   }, [panOffset]);
 
+  // Explicit "reset to canonical view" actions (FAB reset button, 100% preset)
+  // dispatch this event so we snap pan to center alongside their setZoom(1).
+  // Wheel zoom that incidentally crosses through z=1 does NOT fire this — the
+  // cursor anchor must be preserved across the zoom = 1 boundary.
+  React.useEffect(() => {
+    const onCameraReset = () => setPanOffset({ x: 0, y: 0 });
+    window.addEventListener('camera-reset', onCameraReset);
+    return () => window.removeEventListener('camera-reset', onCameraReset);
+  }, []);
+
   // Coalesce pan deltas into one update per animation frame: pointer events
   // can fire faster than the display refresh rate, and applying every delta
   // synchronously triggers React reconciliation per event. We accumulate the

--- a/tests/utils/zoomPanMath.test.ts
+++ b/tests/utils/zoomPanMath.test.ts
@@ -111,10 +111,14 @@ describe('zoomPanMath', () => {
       });
     });
 
-    it('snaps to (0, 0) at zoom = 1 regardless of input', () => {
-      expect(clampPan({ x: 200, y: 200 }, 1, 1000, 600)).toEqual({
-        x: 0,
-        y: 0,
+    it('does NOT snap to center at zoom = 1 — preserves cursor anchor across the boundary', () => {
+      // The FAB-reset-to-center UX is handled at the explicit-reset call
+      // sites (BoardActionsFab dispatches a 'camera-reset' event). clampPan
+      // itself stays pure so a ctrl+wheel zoom landing exactly on z=1
+      // doesn't lose its cursor anchor.
+      expect(clampPan({ x: 200, y: 100 }, 1, 1000, 600)).toEqual({
+        x: 200,
+        y: 100,
       });
     });
   });

--- a/utils/zoomPanMath.ts
+++ b/utils/zoomPanMath.ts
@@ -13,8 +13,9 @@
 //     viewport region inside the world rectangle. Half the slack between
 //     the world-as-rendered (vw × zoom / ZOOM_MIN) and the viewport.
 //     Collapses to zero at zoom = ZOOM_MIN (world fills the viewport) and
-//     grows monotonically with zoom. clampPan additionally snaps to (0, 0)
-//     at zoom = 1 to preserve the FAB-reset-to-center UX.
+//     grows monotonically with zoom. The FAB-reset-to-center UX is handled
+//     at the explicit-reset call sites (not here) so that ctrl+wheel zoom
+//     crossing through zoom = 1 keeps the cursor anchor intact.
 
 import { ZOOM_MIN } from './zoomMapping';
 
@@ -53,10 +54,6 @@ export const clampPan = (
   vw: number,
   vh: number
 ): Point => {
-  // Snap to center at zoom = 1 — the natural [0, vw] × [0, vh] content area
-  // fits the viewport exactly, and the FAB-reset UX expects pan = (0, 0)
-  // when the user returns to 100%.
-  if (zoom === 1) return { x: 0, y: 0 };
   const r = getPanRange(zoom, vw, vh);
   return {
     x: Math.min(r.maxX, Math.max(r.minX, pan.x)),


### PR DESCRIPTION
## Bug

When zoomed out and panned off-center, ctrl+wheel zooming back in toward the cursor *should* keep the wrapper coordinate under the cursor stationary. Today, the moment zoom hits exactly 100%, the camera snaps to center — losing the cursor anchor mid-zoom.

## Root cause

In [#1476](https://github.com/OPS-PIvers/SpartBoard/pull/1476) I put a snap-to-center special case inside \`clampPan\`:

\`\`\`ts
if (zoom === 1) return { x: 0, y: 0 };
\`\`\`

It was meant to preserve the FAB-reset-to-100%-snaps-to-center UX, but it fires for *every* call site — including \`computeCursorAnchoredPan\`, which calls \`clampPan\` on its result. So whenever the wheel handler lands on z=1 (which happens often given the 0.1 step size and 50%→100% sweep), the cursor-anchored pan is overwritten with (0, 0).

## Fix

Move the snap out of pure math and into the explicit-reset call sites.

- [utils/zoomPanMath.ts](utils/zoomPanMath.ts) — \`clampPan\` is now pure: just clamps to the formula range, no z=1 special case.
- [components/layout/BoardActionsFab.tsx](components/layout/BoardActionsFab.tsx) — \`handleReset\` and \`handlePresetClick(value === ZOOM_DEFAULT)\` dispatch a \`'camera-reset'\` window event in addition to \`setZoom(1)\`.
- [components/layout/DashboardView.tsx](components/layout/DashboardView.tsx) — listens for \`'camera-reset'\` and snaps \`panOffset\` to (0, 0).
- [tests/utils/zoomPanMath.test.ts](tests/utils/zoomPanMath.test.ts) — replaces the \"snaps to (0,0) at z=1\" test with one asserting the cursor anchor IS preserved.

## Behavior matrix

| Action | Before | After |
| --- | --- | --- |
| Ctrl+wheel zoom crossing z=1 | Snaps to center (bug) | Cursor anchor preserved |
| Slider drag crossing 100% | Snaps to center | Pan stays (more predictable) |
| Reset FAB clicked | Snaps to center | Snaps to center (unchanged) |
| 100% preset clicked | Snaps to center | Snaps to center (unchanged) |
| Dashboard switch | Resets pan | Resets pan (unchanged — existing logic) |

## Test plan

- [x] \`pnpm vitest run tests/utils/zoomPanMath.test.ts\` — 16/16.
- [x] \`pnpm vitest run\` — 1746/1746.
- [x] Type-check / lint / format clean.
- [ ] **Manual** (worktree has no \`.env.local\`, please verify on local dev):
  - Zoom to 50%, pan off-center, ctrl+wheel zoom in past 100% → camera anchored at cursor the whole way (no snap when crossing 100%).
  - Click reset FAB → snaps to 100% / pan (0, 0).
  - Click 100% preset → same snap.
  - Click 200% preset from a panned 50% view → zoom changes, pan stays clamped to range (no snap).
  - Drag slider through 100% → no snap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)