### PR TITLE
feat(lunch-count): show meal sides + Nutrislice food images

### DIFF
--- a/components/widgets/LunchCount/Widget.test.tsx
+++ b/components/widgets/LunchCount/Widget.test.tsx
@@ -100,8 +100,9 @@ describe('LunchCountWidget', () => {
         assignments: {},
         // Pre-populate cachedMenu to prevent auto-sync loop in tests
         cachedMenu: {
-          hotLunch: 'Pizza',
-          bentoBox: 'Bento',
+          hotLunch: { name: 'Pizza' },
+          hotLunchSides: [],
+          bentoBox: { name: 'Bento' },
           date: new Date().toISOString(),
         },
         lastSyncDate: new Date().toISOString(),
@@ -146,8 +147,9 @@ describe('LunchCountWidget', () => {
     const widget = createWidget({
       schoolSite: 'orono-middle-school',
       cachedMenu: {
-        hotLunch: 'Pizza',
-        bentoBox: 'Yogurt Parfait',
+        hotLunch: { name: 'Pizza' },
+        hotLunchSides: [],
+        bentoBox: { name: 'Yogurt Parfait' },
         date: new Date().toISOString(),
       },
     });

--- a/components/widgets/LunchCount/Widget.tsx
+++ b/components/widgets/LunchCount/Widget.tsx
@@ -754,7 +754,7 @@ export const LunchCountWidget: React.FC<{ widget: WidgetData }> = ({
                   onPeekItem={peekItem}
                   nameTextClass="text-brand-red-dark"
                   sidesTextClass="text-brand-red-dark"
-                  fallback="Loading menu..."
+                  fallback={t('common.loading')}
                 />
                 <div
                   className="flex-1 flex flex-wrap content-start overflow-y-auto custom-scrollbar"
@@ -817,7 +817,7 @@ export const LunchCountWidget: React.FC<{ widget: WidgetData }> = ({
                   onPeekItem={peekItem}
                   nameTextClass="text-emerald-800"
                   sidesTextClass="text-emerald-800"
-                  fallback="Loading menu..."
+                  fallback={t('common.loading')}
                 />
                 <div
                   className="flex-1 flex flex-wrap content-start overflow-y-auto custom-scrollbar"

--- a/components/widgets/LunchCount/Widget.tsx
+++ b/components/widgets/LunchCount/Widget.tsx
@@ -1,4 +1,10 @@
-import React, { useState, useMemo, useCallback, useEffect } from 'react';
+import React, {
+  useState,
+  useMemo,
+  useCallback,
+  useEffect,
+  useRef,
+} from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   DndContext,
@@ -254,23 +260,57 @@ export const LunchCountWidget: React.FC<{ widget: WidgetData }> = ({
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [activeId, setActiveId] = useState<string | null>(null);
   const [peekedItem, setPeekedItem] = useState<LunchMenuItem | null>(null);
+  const peekTriggerRef = useRef<HTMLElement | null>(null);
+  const peekCloseButtonRef = useRef<HTMLButtonElement | null>(null);
+
+  const closePeek = useCallback(() => {
+    setPeekedItem(null);
+    // Restore focus to the element that opened the peek, on the next frame so
+    // the Modal has unmounted from the portal first.
+    const trigger = peekTriggerRef.current;
+    peekTriggerRef.current = null;
+    if (trigger) {
+      window.requestAnimationFrame(() => trigger.focus());
+    }
+  }, []);
 
   // Auto-dismiss the food-image peek after a short timeout. Outside-click and
   // Esc are handled by the underlying Modal. The peek is local state only —
   // never written to widget.config, so nothing persists in Firestore or Drive.
   useEffect(() => {
     if (!peekedItem) return undefined;
-    const timer = window.setTimeout(
-      () => setPeekedItem(null),
-      PEEK_AUTO_DISMISS_MS
-    );
+    const timer = window.setTimeout(closePeek, PEEK_AUTO_DISMISS_MS);
     return () => window.clearTimeout(timer);
+  }, [peekedItem, closePeek]);
+
+  // When the peek opens, move focus to the close button so keyboard users
+  // land inside the dialog rather than on the (now-covered) trigger.
+  useEffect(() => {
+    if (!peekedItem) return;
+    const id = window.requestAnimationFrame(() => {
+      peekCloseButtonRef.current?.focus();
+    });
+    return () => window.cancelAnimationFrame(id);
   }, [peekedItem]);
 
   const peekItem = useCallback((item: LunchMenuItem | undefined | null) => {
     if (!item?.imageUrl) return;
+    const active = document.activeElement;
+    peekTriggerRef.current = active instanceof HTMLElement ? active : null;
     setPeekedItem(item);
   }, []);
+
+  // Tab-key trap for the peek modal. The modal exposes a single focusable
+  // element (the close button); keep focus on it so Tab/Shift-Tab don't
+  // escape behind the dialog.
+  const handlePeekKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLDivElement>) => {
+      if (event.key !== 'Tab') return;
+      event.preventDefault();
+      peekCloseButtonRef.current?.focus();
+    },
+    []
+  );
 
   const sensors = useSensors(
     useSensor(MouseSensor, {
@@ -994,7 +1034,7 @@ export const LunchCountWidget: React.FC<{ widget: WidgetData }> = ({
       />
       <Modal
         isOpen={!!peekedItem}
-        onClose={() => setPeekedItem(null)}
+        onClose={closePeek}
         variant="bare"
         maxWidth="max-w-[min(60vmin,560px)]"
         ariaLabel={peekedItem ? `Photo of ${peekedItem.name}` : undefined}
@@ -1006,10 +1046,12 @@ export const LunchCountWidget: React.FC<{ widget: WidgetData }> = ({
         <div
           className="relative bg-white shadow-2xl overflow-hidden border border-slate-200 motion-safe:animate-in motion-safe:zoom-in-95 motion-safe:duration-200"
           style={{ borderRadius: 'min(28px, 3vmin)' }}
+          onKeyDown={handlePeekKeyDown}
         >
           <button
+            ref={peekCloseButtonRef}
             type="button"
-            onClick={() => setPeekedItem(null)}
+            onClick={closePeek}
             className="absolute z-10 rounded-full bg-white/80 hover:bg-white text-slate-600 shadow-md focus:outline-none focus:ring-2 focus:ring-brand-blue-primary"
             style={{
               top: 'min(12px, 1.5vmin)',
@@ -1026,10 +1068,14 @@ export const LunchCountWidget: React.FC<{ widget: WidgetData }> = ({
             />
           </button>
           {peekedItem?.imageUrl ? (
+            // alt="" — the surrounding aria-label and visible <p> already
+            // announce the food name; double-announcing is noisy for screen
+            // readers.
             <img
               src={peekedItem.imageUrl}
-              alt={peekedItem.name}
-              className="w-full aspect-square object-cover"
+              alt=""
+              className="w-full bg-slate-100 object-contain"
+              style={{ maxHeight: '60vmin' }}
             />
           ) : null}
           <div className="bg-white" style={{ padding: 'min(20px, 2.5vmin)' }}>

--- a/components/widgets/LunchCount/Widget.tsx
+++ b/components/widgets/LunchCount/Widget.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo, useCallback } from 'react';
+import React, { useState, useMemo, useCallback, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   DndContext,
@@ -19,11 +19,13 @@ import {
   WidgetData,
   LunchCountConfig,
   LunchCountGlobalConfig,
+  LunchMenuItem,
   DEFAULT_GLOBAL_STYLE,
 } from '@/types';
 import { Button } from '@/components/common/Button';
 import { ActiveClassChip } from '@/components/common/ActiveClassChip';
-import { RefreshCw, Undo2, CheckCircle2, Box, Users } from 'lucide-react';
+import { Modal } from '@/components/common/Modal';
+import { RefreshCw, Undo2, CheckCircle2, Box, Users, X } from 'lucide-react';
 import { SubmitReportModal } from './SubmitReportModal';
 import { useNutrislice } from './useNutrislice';
 import { DraggableStudent } from './components/DraggableStudent';
@@ -32,6 +34,8 @@ import { beginWidgetDrag, endWidgetDrag } from '@/utils/widgetDragFlag';
 
 import { WidgetLayout } from '../WidgetLayout';
 import { hexToRgba } from '@/utils/styles';
+
+const PEEK_AUTO_DISMISS_MS = 4000;
 
 /**
  * Format a grade value into the spreadsheet label used in column B.
@@ -122,6 +126,98 @@ function getCentralTimestamp(): string {
   }
 }
 
+interface MenuItemBlockProps {
+  item: LunchMenuItem | undefined | null;
+  sides?: LunchMenuItem[];
+  onPeekItem: (item: LunchMenuItem) => void;
+  nameTextClass: string;
+  sidesTextClass: string;
+  fallback: string;
+}
+
+/**
+ * Renders the food header inside an elementary drop zone: optional thumbnail,
+ * bold main name, and a dot-separated sides line. Each thumbnail and named side
+ * is tappable to open a transient image overlay.
+ */
+const MenuItemBlock: React.FC<MenuItemBlockProps> = ({
+  item,
+  sides = [],
+  onPeekItem,
+  nameTextClass,
+  sidesTextClass,
+  fallback,
+}) => {
+  const name = item?.name ?? fallback;
+  const imageUrl = item?.imageUrl;
+
+  return (
+    <div
+      className="flex items-start"
+      style={{ gap: 'min(8px, 2cqmin)', marginBottom: 'min(10px, 2cqmin)' }}
+    >
+      {imageUrl ? (
+        <button
+          type="button"
+          onClick={() => item && onPeekItem(item)}
+          className="shrink-0 rounded-lg overflow-hidden bg-white/40 border border-white/60 shadow-sm transition-transform hover:scale-105 focus:outline-none focus:ring-2 focus:ring-brand-blue-primary"
+          style={{
+            width: 'min(40px, 14cqmin)',
+            height: 'min(40px, 14cqmin)',
+          }}
+          aria-label={`Show photo of ${name}`}
+        >
+          <img
+            src={imageUrl}
+            alt=""
+            className="w-full h-full object-cover"
+            loading="lazy"
+          />
+        </button>
+      ) : null}
+      <div className="flex-1 min-w-0">
+        <div
+          className={`font-black ${nameTextClass} leading-tight line-clamp-2`}
+          style={{ fontSize: 'min(13px, 4.5cqmin)' }}
+        >
+          {name}
+        </div>
+        {sides.length > 0 ? (
+          <div
+            className={`font-medium ${sidesTextClass} opacity-70 leading-tight line-clamp-2`}
+            style={{
+              fontSize: 'min(10px, 3.5cqmin)',
+              marginTop: 'min(2px, 0.5cqmin)',
+            }}
+          >
+            {sides.map((s, i) => (
+              <React.Fragment key={`${s.name}-${i}`}>
+                {i > 0 ? (
+                  <span aria-hidden="true" style={{ margin: '0 0.4em' }}>
+                    ·
+                  </span>
+                ) : null}
+                {s.imageUrl ? (
+                  <button
+                    type="button"
+                    onClick={() => onPeekItem(s)}
+                    className="hover:underline focus:outline-none focus:underline cursor-pointer"
+                    aria-label={`Show photo of ${s.name}`}
+                  >
+                    {s.name}
+                  </button>
+                ) : (
+                  <span>{s.name}</span>
+                )}
+              </React.Fragment>
+            ))}
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+};
+
 export const LunchCountWidget: React.FC<{ widget: WidgetData }> = ({
   widget,
 }) => {
@@ -157,6 +253,24 @@ export const LunchCountWidget: React.FC<{ widget: WidgetData }> = ({
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [activeId, setActiveId] = useState<string | null>(null);
+  const [peekedItem, setPeekedItem] = useState<LunchMenuItem | null>(null);
+
+  // Auto-dismiss the food-image peek after a short timeout. Outside-click and
+  // Esc are handled by the underlying Modal. The peek is local state only —
+  // never written to widget.config, so nothing persists in Firestore or Drive.
+  useEffect(() => {
+    if (!peekedItem) return undefined;
+    const timer = window.setTimeout(
+      () => setPeekedItem(null),
+      PEEK_AUTO_DISMISS_MS
+    );
+    return () => window.clearTimeout(timer);
+  }, [peekedItem]);
+
+  const peekItem = useCallback((item: LunchMenuItem | undefined | null) => {
+    if (!item?.imageUrl) return;
+    setPeekedItem(item);
+  }, []);
 
   const sensors = useSensors(
     useSensor(MouseSensor, {
@@ -360,7 +474,7 @@ export const LunchCountWidget: React.FC<{ widget: WidgetData }> = ({
   ) {
     const hotLunchItem = config.isManualMode
       ? config.manualHotLunch || t('widgets.lunchCount.noHotLunch')
-      : (cachedMenu?.hotLunch ?? t('common.loading'));
+      : (cachedMenu?.hotLunch?.name ?? t('common.loading'));
 
     const globalStyle = activeDashboard?.globalStyle ?? DEFAULT_GLOBAL_STYLE;
     const fontClass =
@@ -634,15 +748,14 @@ export const LunchCountWidget: React.FC<{ widget: WidgetData }> = ({
                     className="text-brand-red-primary opacity-40 group-hover:scale-110 transition-transform"
                   />
                 </div>
-                <div
-                  style={{
-                    fontSize: 'min(11px, 4cqmin)',
-                    marginBottom: 'min(10px, 2cqmin)',
-                  }}
-                  className="font-bold text-brand-red-dark leading-tight line-clamp-2 italic opacity-60"
-                >
-                  {cachedMenu?.hotLunch ?? 'Loading menu...'}
-                </div>
+                <MenuItemBlock
+                  item={cachedMenu?.hotLunch}
+                  sides={cachedMenu?.hotLunchSides ?? []}
+                  onPeekItem={peekItem}
+                  nameTextClass="text-brand-red-dark"
+                  sidesTextClass="text-brand-red-dark"
+                  fallback="Loading menu..."
+                />
                 <div
                   className="flex-1 flex flex-wrap content-start overflow-y-auto custom-scrollbar"
                   style={{
@@ -699,15 +812,13 @@ export const LunchCountWidget: React.FC<{ widget: WidgetData }> = ({
                     className="text-emerald-400 group-hover:scale-110 transition-transform"
                   />
                 </div>
-                <div
-                  style={{
-                    fontSize: 'min(11px, 4cqmin)',
-                    marginBottom: 'min(10px, 2cqmin)',
-                  }}
-                  className="font-bold text-emerald-800 leading-tight line-clamp-2 italic opacity-60"
-                >
-                  {cachedMenu?.bentoBox ?? 'Loading menu...'}
-                </div>
+                <MenuItemBlock
+                  item={cachedMenu?.bentoBox}
+                  onPeekItem={peekItem}
+                  nameTextClass="text-emerald-800"
+                  sidesTextClass="text-emerald-800"
+                  fallback="Loading menu..."
+                />
                 <div
                   className="flex-1 flex flex-wrap content-start overflow-y-auto custom-scrollbar"
                   style={{
@@ -866,8 +977,8 @@ export const LunchCountWidget: React.FC<{ widget: WidgetData }> = ({
           staffName: formatTeacherName(user?.displayName ?? 'Unknown Staff'),
           hotLunch: stats.hotLunch,
           bentoBox: stats.bentoBox,
-          hotLunchName: cachedMenu?.hotLunch ?? 'Hot Lunch',
-          bentoBoxName: cachedMenu?.bentoBox ?? 'Bento Box',
+          hotLunchName: cachedMenu?.hotLunch?.name ?? 'Hot Lunch',
+          bentoBoxName: cachedMenu?.bentoBox?.name ?? 'Bento Box',
           schoolSite,
           lunchTime: formatLunchTime(lunchTimeHour, lunchTimeMinute),
           gradeLabel: formatGradeLabel(gradeLevel),
@@ -881,6 +992,36 @@ export const LunchCountWidget: React.FC<{ widget: WidgetData }> = ({
         }}
         isSubmitting={isSubmitting}
       />
+      <Modal
+        isOpen={!!peekedItem}
+        onClose={() => setPeekedItem(null)}
+        variant="bare"
+        maxWidth="max-w-sm"
+        ariaLabel={peekedItem ? `Photo of ${peekedItem.name}` : undefined}
+      >
+        <div className="relative bg-white rounded-3xl shadow-2xl overflow-hidden border border-slate-200 motion-safe:animate-in motion-safe:zoom-in-95 motion-safe:duration-200">
+          <button
+            type="button"
+            onClick={() => setPeekedItem(null)}
+            className="absolute top-3 right-3 z-10 p-2 rounded-full bg-white/80 hover:bg-white text-slate-600 shadow-md focus:outline-none focus:ring-2 focus:ring-brand-blue-primary"
+            aria-label="Close photo"
+          >
+            <X className="w-5 h-5" />
+          </button>
+          {peekedItem?.imageUrl ? (
+            <img
+              src={peekedItem.imageUrl}
+              alt={peekedItem.name}
+              className="w-full aspect-square object-cover"
+            />
+          ) : null}
+          <div className="p-4 bg-white">
+            <p className="text-base font-black text-slate-900 text-center leading-tight">
+              {peekedItem?.name}
+            </p>
+          </div>
+        </div>
+      </Modal>
       <DragOverlay
         dropAnimation={dropAnimation}
         modifiers={[snapCenterToCursor]}

--- a/components/widgets/LunchCount/Widget.tsx
+++ b/components/widgets/LunchCount/Widget.tsx
@@ -996,17 +996,34 @@ export const LunchCountWidget: React.FC<{ widget: WidgetData }> = ({
         isOpen={!!peekedItem}
         onClose={() => setPeekedItem(null)}
         variant="bare"
-        maxWidth="max-w-sm"
+        maxWidth="max-w-[min(60vmin,560px)]"
         ariaLabel={peekedItem ? `Photo of ${peekedItem.name}` : undefined}
       >
-        <div className="relative bg-white rounded-3xl shadow-2xl overflow-hidden border border-slate-200 motion-safe:animate-in motion-safe:zoom-in-95 motion-safe:duration-200">
+        {/* The peek overlay renders into document.body via portal, outside any
+            container query context — cqmin would resolve to 0 here. We use
+            vmin instead so the photo scales legibly on classroom projectors
+            while still looking right on a teacher's laptop. */}
+        <div
+          className="relative bg-white shadow-2xl overflow-hidden border border-slate-200 motion-safe:animate-in motion-safe:zoom-in-95 motion-safe:duration-200"
+          style={{ borderRadius: 'min(28px, 3vmin)' }}
+        >
           <button
             type="button"
             onClick={() => setPeekedItem(null)}
-            className="absolute top-3 right-3 z-10 p-2 rounded-full bg-white/80 hover:bg-white text-slate-600 shadow-md focus:outline-none focus:ring-2 focus:ring-brand-blue-primary"
+            className="absolute z-10 rounded-full bg-white/80 hover:bg-white text-slate-600 shadow-md focus:outline-none focus:ring-2 focus:ring-brand-blue-primary"
+            style={{
+              top: 'min(12px, 1.5vmin)',
+              right: 'min(12px, 1.5vmin)',
+              padding: 'min(8px, 1vmin)',
+            }}
             aria-label="Close photo"
           >
-            <X className="w-5 h-5" />
+            <X
+              style={{
+                width: 'min(20px, 2.5vmin)',
+                height: 'min(20px, 2.5vmin)',
+              }}
+            />
           </button>
           {peekedItem?.imageUrl ? (
             <img
@@ -1015,8 +1032,11 @@ export const LunchCountWidget: React.FC<{ widget: WidgetData }> = ({
               className="w-full aspect-square object-cover"
             />
           ) : null}
-          <div className="p-4 bg-white">
-            <p className="text-base font-black text-slate-900 text-center leading-tight">
+          <div className="bg-white" style={{ padding: 'min(20px, 2.5vmin)' }}>
+            <p
+              className="font-black text-slate-900 text-center leading-tight"
+              style={{ fontSize: 'min(24px, 3vmin)' }}
+            >
               {peekedItem?.name}
             </p>
           </div>

--- a/components/widgets/LunchCount/useNutrislice.test.tsx
+++ b/components/widgets/LunchCount/useNutrislice.test.tsx
@@ -251,6 +251,87 @@ describe('useNutrislice', () => {
     });
   });
 
+  it('does not loop when fetch fails on a legacy-shape config', async () => {
+    // P1 regression guard: a legacy cachedMenu plus a failing proxy used to
+    // pin hasLegacyShape=true forever, since the catch block didn't replace
+    // the menu. Each render would re-fire fetchNutrislice. Now the catch
+    // installs a non-legacy stub so the migration check flips to false after
+    // the first attempt.
+    const legacyConfig = {
+      ...mockConfig,
+      cachedMenu: {
+        hotLunch: 'Old Lunch',
+        bentoBox: 'Old Bento',
+        date: new Date().toISOString(),
+      } as unknown as LunchCountConfig['cachedMenu'],
+    };
+
+    const mockProxy = vi.fn().mockRejectedValue(new Error('Fail'));
+    (httpsCallable as Mock).mockReturnValue(mockProxy);
+
+    const consoleErrorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined);
+    const consoleWarnSpy = vi
+      .spyOn(console, 'warn')
+      .mockImplementation(() => undefined);
+
+    render(<TestComponent initialConfig={legacyConfig} />);
+
+    await waitFor(() => {
+      expect(mockProxy).toHaveBeenCalledTimes(1);
+    });
+
+    // Give React several ticks to re-render and re-evaluate the migration
+    // effect. With the bug present, this would queue many more calls.
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    expect(mockProxy).toHaveBeenCalledTimes(1);
+
+    consoleErrorSpy.mockRestore();
+    consoleWarnSpy.mockRestore();
+  });
+
+  it('falls back to first food item when no Entrees/Main section exists', async () => {
+    const noEntreeData = {
+      days: [
+        {
+          date: '2023-10-27',
+          menu_items: [
+            { is_section_title: true, section_name: 'Specials' },
+            {
+              section_name: 'Specials',
+              food: { name: 'Mystery Meat', image_url: 'https://cdn/mm.jpg' },
+            },
+            { section_name: 'Specials', food: { name: 'Mystery Sauce' } },
+          ],
+        },
+      ],
+    };
+
+    const mockProxy = vi.fn().mockResolvedValue({ data: noEntreeData });
+    (httpsCallable as Mock).mockReturnValue(mockProxy);
+
+    render(<TestComponent />);
+
+    await waitFor(() => {
+      expect(mockUpdateWidget).toHaveBeenCalledWith(
+        mockWidgetId,
+        expect.objectContaining({
+          config: expect.objectContaining({
+            cachedMenu: expect.objectContaining({
+              hotLunch: {
+                name: 'Mystery Meat',
+                imageUrl: 'https://cdn/mm.jpg',
+              },
+              hotLunchSides: [{ name: 'Mystery Sauce', imageUrl: undefined }],
+            }) as unknown,
+          }) as unknown,
+        })
+      );
+    });
+  });
+
   it('parses bento via name match across any section', async () => {
     const bentoData = {
       days: [

--- a/components/widgets/LunchCount/useNutrislice.test.tsx
+++ b/components/widgets/LunchCount/useNutrislice.test.tsx
@@ -38,14 +38,39 @@ describe('useNutrislice', () => {
         date: '2023-10-27',
         menu_items: [
           {
+            is_section_title: true,
             section_name: 'Entrees',
-            food: { name: 'Cheese Pizza' },
-            text: 'Cheese Pizza',
+          },
+          {
+            section_name: 'Entrees',
+            food: { name: 'Cheese Pizza', image_url: 'https://cdn/pizza.jpg' },
+          },
+          {
+            is_section_title: true,
+            section_name: 'Sides',
           },
           {
             section_name: 'Sides',
-            food: { name: 'Veggie Bento Box' },
-            text: 'Veggie Bento Box',
+            food: { name: 'Marinara', image_url: 'https://cdn/marinara.jpg' },
+          },
+          {
+            section_name: 'Sides',
+            food: { name: 'Steamed Peas' },
+          },
+          {
+            is_section_title: true,
+            section_name: 'PB Jammin Bento Box',
+          },
+          {
+            section_name: 'PB Jammin Bento Box',
+            food: {
+              name: 'Veggie Bento Box',
+              image_url: 'https://cdn/bento.jpg',
+            },
+          },
+          {
+            section_name: 'PB Jammin Bento Box',
+            food: { name: 'Pretzel' },
           },
         ],
       },
@@ -91,7 +116,7 @@ describe('useNutrislice', () => {
     return null;
   };
 
-  it('should sync menu when data is missing or outdated', async () => {
+  it('parses entree, sides, and bento with image URLs', async () => {
     const mockProxy = vi.fn().mockResolvedValue({ data: mockMenuData });
     (httpsCallable as Mock).mockReturnValue(mockProxy);
 
@@ -114,8 +139,24 @@ describe('useNutrislice', () => {
         expect.objectContaining({
           config: expect.objectContaining({
             cachedMenu: {
-              hotLunch: 'Cheese Pizza',
-              bentoBox: 'Veggie Bento Box',
+              hotLunch: {
+                name: 'Cheese Pizza',
+                imageUrl: 'https://cdn/pizza.jpg',
+              },
+              hotLunchSides: [
+                {
+                  name: 'Marinara',
+                  imageUrl: 'https://cdn/marinara.jpg',
+                },
+                {
+                  name: 'Steamed Peas',
+                  imageUrl: undefined,
+                },
+              ],
+              bentoBox: {
+                name: 'Veggie Bento Box',
+                imageUrl: 'https://cdn/bento.jpg',
+              },
               date: expect.any(String) as string,
             },
             syncError: null,
@@ -130,7 +171,7 @@ describe('useNutrislice', () => {
     );
   });
 
-  it('should handle proxy failure', async () => {
+  it('handles proxy failure', async () => {
     const mockProxy = vi.fn().mockRejectedValue(new Error('Fail'));
     (httpsCallable as Mock).mockReturnValue(mockProxy);
 
@@ -163,13 +204,14 @@ describe('useNutrislice', () => {
     consoleWarnSpy.mockRestore();
   });
 
-  it('should not sync if data is up-to-date', async () => {
+  it('does not sync when current-shape data is up-to-date', async () => {
     const freshConfig: LunchCountConfig = {
       ...mockConfig,
       lastSyncDate: new Date().toISOString(),
       cachedMenu: {
-        hotLunch: 'Old Lunch',
-        bentoBox: 'Old Bento',
+        hotLunch: { name: 'Old Lunch' },
+        hotLunchSides: [],
+        bentoBox: { name: 'Old Bento' },
         date: new Date().toISOString(),
       },
     };
@@ -184,7 +226,32 @@ describe('useNutrislice', () => {
     expect(mockProxy).not.toHaveBeenCalled();
   });
 
-  it('should parse Bento Box correctly', async () => {
+  it('re-fetches when cached menu is in legacy string shape', async () => {
+    // Simulate a config saved before this change: hotLunch/bentoBox are
+    // strings instead of LunchMenuItem objects. Even though it was synced
+    // today, the widget should detect the legacy shape and re-fetch so it
+    // can populate sides + images.
+    const legacyConfig = {
+      ...mockConfig,
+      lastSyncDate: new Date().toISOString(),
+      cachedMenu: {
+        hotLunch: 'Old Lunch',
+        bentoBox: 'Old Bento',
+        date: new Date().toISOString(),
+      } as unknown as LunchCountConfig['cachedMenu'],
+    };
+
+    const mockProxy = vi.fn().mockResolvedValue({ data: mockMenuData });
+    (httpsCallable as Mock).mockReturnValue(mockProxy);
+
+    render(<TestComponent initialConfig={legacyConfig} />);
+
+    await waitFor(() => {
+      expect(mockProxy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('parses bento via name match across any section', async () => {
     const bentoData = {
       days: [
         {
@@ -214,8 +281,9 @@ describe('useNutrislice', () => {
         expect.objectContaining({
           config: expect.objectContaining({
             cachedMenu: {
-              hotLunch: 'Chicken Nuggets',
-              bentoBox: 'Teriyaki Bento',
+              hotLunch: { name: 'Chicken Nuggets', imageUrl: undefined },
+              hotLunchSides: [],
+              bentoBox: { name: 'Teriyaki Bento', imageUrl: undefined },
               date: expect.any(String) as string,
             },
           }) as unknown,

--- a/components/widgets/LunchCount/useNutrislice.ts
+++ b/components/widgets/LunchCount/useNutrislice.ts
@@ -53,7 +53,7 @@ const isAltMealSectionName = (name: string | undefined): boolean => {
 };
 
 const itemDisplayName = (item: NutrisliceMenuItem): string =>
-  item.food?.name ?? item.text ?? '';
+  (item.food?.name ?? item.text ?? '').trim();
 
 const toMenuItem = (
   item: NutrisliceMenuItem,
@@ -66,16 +66,32 @@ const toMenuItem = (
 /**
  * Returns true if a previously cached menu uses the legacy string shape
  * (pre-sides/images). Such configs need to be re-fetched once so the new
- * fields are populated.
+ * fields are populated. Checks both hotLunch and bentoBox so partially
+ * migrated records also get caught.
  */
 const isLegacyCachedMenu = (
   cachedMenu: LunchCountConfig['cachedMenu']
 ): boolean => {
   if (!cachedMenu) return false;
-  const legacyHotLunch = (cachedMenu as unknown as { hotLunch?: unknown })
-    .hotLunch;
-  return typeof legacyHotLunch === 'string';
+  const legacy = cachedMenu as unknown as {
+    hotLunch?: unknown;
+    bentoBox?: unknown;
+  };
+  return (
+    typeof legacy.hotLunch === 'string' || typeof legacy.bentoBox === 'string'
+  );
 };
+
+const buildEmptyMenu = (
+  noHotLunch: string,
+  noBentoBox: string,
+  isoDate: string
+): LunchMenuDay => ({
+  hotLunch: { name: noHotLunch },
+  hotLunchSides: [],
+  bentoBox: { name: noBentoBox },
+  date: isoDate,
+});
 
 export const useNutrislice = ({
   widgetId,
@@ -150,21 +166,23 @@ export const useNutrislice = ({
           // current section without trusting only its own section_name field.
           let currentSection: string | undefined;
           let entreeIndex = -1;
-          let bentoIndex = -1;
+          let bentoIndexBySection = -1;
+          let bentoIndexByName = -1;
+          let sawAltMealSection = false;
           const sectionForIndex: (string | undefined)[] = [];
 
           items.forEach((item, idx) => {
             if (item.is_section_title) {
               currentSection = item.section_name ?? item.text ?? currentSection;
               sectionForIndex[idx] = currentSection;
+              if (isAltMealSectionName(currentSection)) {
+                sawAltMealSection = true;
+              }
               return;
             }
             sectionForIndex[idx] = item.section_name ?? currentSection;
 
-            const sectionName =
-              item.section_name?.toLowerCase() ??
-              currentSection?.toLowerCase() ??
-              '';
+            const sectionName = sectionForIndex[idx]?.toLowerCase() ?? '';
             const itemName = itemDisplayName(item).toLowerCase();
 
             if (
@@ -174,13 +192,31 @@ export const useNutrislice = ({
               entreeIndex = idx;
             }
 
-            if (bentoIndex === -1 && itemName.includes('bento')) {
-              bentoIndex = idx;
+            if (
+              bentoIndexBySection === -1 &&
+              isAltMealSectionName(sectionForIndex[idx])
+            ) {
+              bentoIndexBySection = idx;
+            }
+
+            if (bentoIndexByName === -1 && itemName.includes('bento')) {
+              bentoIndexByName = idx;
             }
           });
 
+          // Prefer section-based bento detection. Only fall back to a name
+          // substring match when no alt-meal section was ever observed —
+          // otherwise a side like "Bento-style Sushi Cup" in a regular Sides
+          // section would be misclassified as the alt meal.
+          const bentoIndex =
+            bentoIndexBySection >= 0
+              ? bentoIndexBySection
+              : sawAltMealSection
+                ? -1
+                : bentoIndexByName;
+
           // Fallback: if no entree section matched, use the first non-title
-          // food item.
+          // food item that has a non-empty display name.
           if (entreeIndex === -1) {
             entreeIndex = items.findIndex(
               (i) => !i.is_section_title && itemDisplayName(i)
@@ -232,12 +268,29 @@ export const useNutrislice = ({
       addToast(t('widgets.lunchCount.syncSuccess'), 'success');
     } catch (err) {
       console.error('Nutrislice Sync Error:', err);
+
+      // If we were trying to migrate a legacy-shape cache and the fetch
+      // failed, install a non-legacy stub so the migration check flips to
+      // false. Otherwise hasLegacyShape stays true and the effect would
+      // re-fire fetchNutrislice on the next render — pegging the proxy
+      // until the network recovers.
+      const wasLegacy = isLegacyCachedMenu(configRef.current.cachedMenu);
+      const stamp = new Date().toISOString();
       updateWidget(widgetId, {
         config: {
           ...configRef.current,
+          ...(wasLegacy
+            ? {
+                cachedMenu: buildEmptyMenu(
+                  t('widgets.lunchCount.noHotLunch'),
+                  t('widgets.lunchCount.noBentoBox'),
+                  stamp
+                ),
+              }
+            : {}),
           syncError: 'E-SYNC-404',
-          // Mark this as a sync attempt so we don't loop endlessly
-          lastSyncDate: new Date().toISOString(),
+          // Mark this as a sync attempt so we don't loop endlessly.
+          lastSyncDate: stamp,
         },
       });
       addToast(t('widgets.lunchCount.syncError'), 'error');

--- a/components/widgets/LunchCount/useNutrislice.ts
+++ b/components/widgets/LunchCount/useNutrislice.ts
@@ -136,7 +136,10 @@ export const useNutrislice = ({
       let bentoBox: LunchMenuItem = { name: noBentoBox };
 
       if (data && data.days) {
-        const todayStr = now.toISOString().split('T')[0];
+        // Match against the same local-time date used to build the request
+        // URL. toISOString() is UTC, which can be a day ahead of the local
+        // date in the evening and would miss the menu entry.
+        const todayStr = `${year}-${month}-${day}`;
         const dayData = data.days.find((d) => d.date === todayStr);
 
         if (dayData && dayData.menu_items) {

--- a/components/widgets/LunchCount/useNutrislice.ts
+++ b/components/widgets/LunchCount/useNutrislice.ts
@@ -1,6 +1,11 @@
 import { useState, useCallback, useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
-import { LunchCountConfig, LunchMenuDay, WidgetData } from '@/types';
+import {
+  LunchCountConfig,
+  LunchMenuDay,
+  LunchMenuItem,
+  WidgetData,
+} from '@/types';
 import { httpsCallable } from 'firebase/functions';
 import { functions } from '@/config/firebase';
 import { toLunchCountSchoolSite } from '@/config/buildings';
@@ -14,6 +19,7 @@ interface UseNutrisliceProps {
 
 interface NutrisliceFood {
   name?: string;
+  image_url?: string;
 }
 
 interface NutrisliceMenuItem {
@@ -31,6 +37,45 @@ interface NutrisliceDay {
 interface NutrisliceWeek {
   days?: NutrisliceDay[];
 }
+
+const ALT_MEAL_SECTION_PATTERNS = [
+  'bento',
+  'alternative',
+  'alt',
+  'pb-jammin',
+  'pb jammin',
+];
+
+const isAltMealSectionName = (name: string | undefined): boolean => {
+  if (!name) return false;
+  const lower = name.toLowerCase();
+  return ALT_MEAL_SECTION_PATTERNS.some((p) => lower.includes(p));
+};
+
+const itemDisplayName = (item: NutrisliceMenuItem): string =>
+  item.food?.name ?? item.text ?? '';
+
+const toMenuItem = (
+  item: NutrisliceMenuItem,
+  fallbackName: string
+): LunchMenuItem => ({
+  name: itemDisplayName(item) || fallbackName,
+  imageUrl: item.food?.image_url,
+});
+
+/**
+ * Returns true if a previously cached menu uses the legacy string shape
+ * (pre-sides/images). Such configs need to be re-fetched once so the new
+ * fields are populated.
+ */
+const isLegacyCachedMenu = (
+  cachedMenu: LunchCountConfig['cachedMenu']
+): boolean => {
+  if (!cachedMenu) return false;
+  const legacyHotLunch = (cachedMenu as unknown as { hotLunch?: unknown })
+    .hotLunch;
+  return typeof legacyHotLunch === 'string';
+};
 
 export const useNutrislice = ({
   widgetId,
@@ -83,8 +128,12 @@ export const useNutrislice = ({
       const apiUrl = `https://orono.api.nutrislice.com/menu/api/weeks/school/${schoolSite}/menu-type/lunch/${year}/${month}/${day}/`;
       const data = await fetchWithFallback(apiUrl);
 
-      let hotLunch = t('widgets.lunchCount.noHotLunch');
-      let bentoBox = t('widgets.lunchCount.noBentoBox');
+      const noHotLunch = t('widgets.lunchCount.noHotLunch');
+      const noBentoBox = t('widgets.lunchCount.noBentoBox');
+
+      let hotLunch: LunchMenuItem = { name: noHotLunch };
+      const hotLunchSides: LunchMenuItem[] = [];
+      let bentoBox: LunchMenuItem = { name: noBentoBox };
 
       if (data && data.days) {
         const todayStr = now.toISOString().split('T')[0];
@@ -93,37 +142,78 @@ export const useNutrislice = ({
         if (dayData && dayData.menu_items) {
           const items = dayData.menu_items;
 
-          // Hot Lunch: Map to the first item in the "Entrees" section
-          const entree = items.find(
-            (i) =>
-              !i.is_section_title &&
-              (i.section_name?.toLowerCase().includes('entree') ??
-                i.section_name?.toLowerCase().includes('main'))
-          );
-          if (entree) hotLunch = entree.food?.name ?? entree.text ?? hotLunch;
+          // Walk items in menu order, tracking the running section name from
+          // is_section_title rows. This lets us classify each food item by its
+          // current section without trusting only its own section_name field.
+          let currentSection: string | undefined;
+          let entreeIndex = -1;
+          let bentoIndex = -1;
+          const sectionForIndex: (string | undefined)[] = [];
 
-          // Bento Box: Map to any item in Entrees or Sides that contains "Bento"
-          const bento = items.find(
-            (i) =>
-              (i.food?.name?.toLowerCase().includes('bento') ??
-                i.text?.toLowerCase().includes('bento')) &&
-              !i.is_section_title
-          );
-          if (bento) bentoBox = bento.food?.name ?? bento.text ?? bentoBox;
+          items.forEach((item, idx) => {
+            if (item.is_section_title) {
+              currentSection = item.section_name ?? item.text ?? currentSection;
+              sectionForIndex[idx] = currentSection;
+              return;
+            }
+            sectionForIndex[idx] = item.section_name ?? currentSection;
 
-          // Fallback for Hot Lunch if no section matched
-          if (hotLunch === 'No Hot Lunch Listed' && items.length > 0) {
-            const firstFood = items.find(
-              (i) => !i.is_section_title && (i.food?.name ?? i.text)
+            const sectionName =
+              item.section_name?.toLowerCase() ??
+              currentSection?.toLowerCase() ??
+              '';
+            const itemName = itemDisplayName(item).toLowerCase();
+
+            if (
+              entreeIndex === -1 &&
+              (sectionName.includes('entree') || sectionName.includes('main'))
+            ) {
+              entreeIndex = idx;
+            }
+
+            if (bentoIndex === -1 && itemName.includes('bento')) {
+              bentoIndex = idx;
+            }
+          });
+
+          // Fallback: if no entree section matched, use the first non-title
+          // food item.
+          if (entreeIndex === -1) {
+            entreeIndex = items.findIndex(
+              (i) => !i.is_section_title && itemDisplayName(i)
             );
-            if (firstFood)
-              hotLunch = firstFood.food?.name ?? firstFood.text ?? hotLunch;
+          }
+
+          if (entreeIndex >= 0) {
+            hotLunch = toMenuItem(items[entreeIndex], noHotLunch);
+
+            // Sides: every non-title item after the entree, in menu order,
+            // until we hit (a) the bento item or (b) an alt-meal section.
+            for (let idx = entreeIndex + 1; idx < items.length; idx++) {
+              const item = items[idx];
+              if (item.is_section_title) {
+                if (isAltMealSectionName(item.section_name ?? item.text)) {
+                  break;
+                }
+                continue;
+              }
+              if (idx === bentoIndex) break;
+              if (isAltMealSectionName(sectionForIndex[idx])) break;
+              const name = itemDisplayName(item);
+              if (!name) continue;
+              hotLunchSides.push(toMenuItem(item, name));
+            }
+          }
+
+          if (bentoIndex >= 0) {
+            bentoBox = toMenuItem(items[bentoIndex], noBentoBox);
           }
         }
       }
 
       const newMenu: LunchMenuDay = {
         hotLunch,
+        hotLunchSides,
         bentoBox,
         date: now.toISOString(),
       };
@@ -153,6 +243,8 @@ export const useNutrislice = ({
     }
   }, [widgetId, updateWidget, addToast, isSyncing, t]);
 
+  const hasLegacyShape = isLegacyCachedMenu(config.cachedMenu);
+
   useEffect(() => {
     if (isSyncing) return;
 
@@ -164,11 +256,12 @@ export const useNutrislice = ({
     const isSyncedToday =
       lastSyncDate && lastSyncDate.toDateString() === today.toDateString();
 
-    // Only try to sync if we haven't already synced (or attempted to) today
-    if (!isSyncedToday) {
+    // Re-fetch if either we haven't synced today, or the cached payload still
+    // uses the pre-images legacy string shape.
+    if (!isSyncedToday || hasLegacyShape) {
       void fetchNutrislice();
     }
-  }, [fetchNutrislice, config.lastSyncDate, isSyncing]);
+  }, [fetchNutrislice, config.lastSyncDate, isSyncing, hasLegacyShape]);
 
   return { isSyncing, fetchNutrislice };
 };

--- a/types.ts
+++ b/types.ts
@@ -1221,9 +1221,17 @@ export interface CalendarConfig {
   cardOpacity?: number;
 }
 
+export interface LunchMenuItem {
+  name: string;
+  /** Nutrislice CDN URL for the food's photo. Undefined when the menu entry has no image. */
+  imageUrl?: string;
+}
+
 export interface LunchMenuDay {
-  hotLunch: string;
-  bentoBox: string;
+  hotLunch: LunchMenuItem;
+  /** Items served alongside the entree, in the order Nutrislice lists them, up to (but excluding) the bento alternative. */
+  hotLunchSides: LunchMenuItem[];
+  bentoBox: LunchMenuItem;
   date: string; // ISO String
 }
 


### PR DESCRIPTION
## Summary

For elementary buildings (Schumann, Intermediate), the lunch count widget now displays the **full meal** — bold main dish with a dot-separated list of sides — instead of just the entree, and surfaces Nutrislice food images as small always-visible thumbnails. Tapping a thumbnail (or a side name that has its own image) opens a transient overlay with the full photo. Helps K–2 students who can't yet read recognize lunch options before assigning.

- **Sides parsing**: walks Nutrislice items in menu order, capturing every non-section item between the entree and the bento (or any alt-meal section header — `bento` / `alternative` / `alt` / `pb-jammin`).
- **Thumbnail + tap-to-enlarge**: small thumb (`min(40px, 14cqmin)`) sits left of the main name; sides whose food has an image are also tappable (sides without images render as plain text). Overlay auto-dismisses after 4s, on backdrop click, on Esc, or via an explicit close button. Peek state is local React state — **never** written to Firestore or Drive.
- **Migration**: `LunchMenuDay` now stores `LunchMenuItem` objects (`{ name, imageUrl? }`) plus a `hotLunchSides[]`. Cached menus saved in the legacy string shape are detected on mount and force-resynced so the new fields populate cleanly.

The architectural follow-up (real admin-side proxy cache so only the admin hits Nutrislice once per day instead of every teacher per day) is intentionally **not** in this PR — flagged for a separate cleanup PR.

## Test plan

- [x] `pnpm run type-check` (every reader of `cachedMenu.hotLunch` updated)
- [x] `pnpm run lint` and `pnpm run format:check`
- [x] `pnpm exec vitest run components/widgets/LunchCount` — 9/9 pass, including new fixtures for sides + image URLs, the up-to-date no-resync gate against the new shape, and the legacy-shape forced re-fetch
- [ ] Open the lunch count widget at Schumann or Intermediate (real Nutrislice fetch). Confirm: (1) thumbnails render, (2) sides appear dot-separated under the bold main, (3) tap thumbnail → overlay shows photo and dismisses correctly, (4) submit-report modal still shows the right names, (5) widget rescales cleanly at small/medium/large sizes
- [ ] **Verify the Nutrislice image field is `food.image_url`** — if Nutrislice uses a different key (e.g. `image`, `images.large.url`), one-line tweak to `NutrisliceFood` in [components/widgets/LunchCount/useNutrislice.ts](components/widgets/LunchCount/useNutrislice.ts)
- [ ] If your menus use alt-meal section names other than the four matched (`bento` / `alternative` / `alt` / `pb-jammin`), add to `ALT_MEAL_SECTION_PATTERNS`

🤖 Generated with [Claude Code](https://claude.com/claude-code)