### PR TITLE
feat(view-only): refresh view counts on tab focus

### DIFF
--- a/hooks/useSessionViewCount.ts
+++ b/hooks/useSessionViewCount.ts
@@ -12,13 +12,21 @@
  * Cost shape: one Firestore aggregation query (`getCountFromServer`) per
  * `(collection, sessionId)` pair, gated behind a module-level cache.
  * Subsequent mounts of the same session — including remount-after-unmount —
- * reuse the cached count. Teachers can force a refetch by calling
- * `invalidateSessionViewCount` (wired into the reactivate / reopen
- * callbacks so the count refreshes after a Closed share is brought back).
+ * reuse the cached count. Three things bust the cache:
  *
- * The hook is intentionally read-once: the user's stated need is "see how
- * many times the URL was opened" — a snapshot suffices and a live listener
- * would be a real-time write multiplier across the teacher's archive.
+ *   1. Explicit `invalidateSessionViewCount(collection, sessionId)` calls
+ *      (wired into reactivate / reopen / unarchive callbacks so the count
+ *      refreshes after a Closed share is brought back).
+ *   2. Tab-visibility transitions back to `'visible'` (teacher comes back
+ *      to the SpartBoard tab after sending the link out) — throttled to
+ *      one refresh per `VISIBILITY_REFRESH_MIN_MS` so rapid alt-tab
+ *      thrashing doesn't fan out N reads.
+ *   3. Full page reload (cache is module-scoped, dies with the module).
+ *
+ * The hook is intentionally read-once-per-cache-bust: the user's stated
+ * need is "see how many times the URL was opened" — a snapshot per
+ * focus-cycle suffices, and a live `onSnapshot` listener would be a real-
+ * time write multiplier across the teacher's archive.
  */
 
 import { useEffect, useState } from 'react';
@@ -38,7 +46,6 @@ interface CacheEntry {
 
 // Module-level cache so the same sessionId rendered from multiple cards
 // (or after a list re-render) doesn't fanout to repeat aggregation queries.
-// Cleared on full page reload — sufficient lifetime for a teacher session.
 const cache = new Map<string, CacheEntry>();
 
 function cacheKey(collectionName: ViewTrackingCollection, sessionId: string) {
@@ -58,6 +65,46 @@ export function invalidateSessionViewCount(
 ): void {
   cache.delete(cacheKey(collectionName, sessionId));
 }
+
+/* ─── Visibility-driven cross-hook refresh ────────────────────────────────── */
+
+/** Minimum gap between visibility-driven cache flushes. Prevents rapid
+ *  alt-tab cycling from thrashing Firestore reads — each return to the
+ *  SpartBoard tab inside this window is a no-op. Tuned for "teacher came
+ *  back to check the dashboard": longer is fine, shorter is wasteful. */
+const VISIBILITY_REFRESH_MIN_MS = 5000;
+
+const subscribers = new Set<() => void>();
+let lastVisibilityRefreshAt = 0;
+
+/**
+ * Internal: invoked by the visibility listener (and by tests) to clear the
+ * cache and notify every mounted hook to re-run its fetch effect. Throttled
+ * via `lastVisibilityRefreshAt` so rapid focus changes don't multiply reads.
+ *
+ * Exported only for tests — production code should never call this
+ * directly; the `'visibilitychange'` listener registered at module load is
+ * the sole production trigger.
+ */
+export function _testVisibilityRefresh(now: number = Date.now()): boolean {
+  if (now - lastVisibilityRefreshAt < VISIBILITY_REFRESH_MIN_MS) return false;
+  lastVisibilityRefreshAt = now;
+  cache.clear();
+  subscribers.forEach((cb) => cb());
+  return true;
+}
+
+if (typeof document !== 'undefined') {
+  document.addEventListener('visibilitychange', () => {
+    // Only act on hidden → visible transitions. The reverse triggers no
+    // user-facing work (the dashboard is hidden) and would just shorten
+    // the throttle window for the next legitimate refresh.
+    if (document.visibilityState !== 'visible') return;
+    _testVisibilityRefresh();
+  });
+}
+
+/* ─── Hook ────────────────────────────────────────────────────────────────── */
 
 export interface UseSessionViewCountResult {
   count: number | null;
@@ -80,12 +127,24 @@ export function useSessionViewCount(
   const key = enabled && sessionId ? cacheKey(collectionName, sessionId) : null;
 
   // The hook reads `count` and `loading` from `cache[key]` during render and
-  // re-renders the consumer when the async fetch resolves via `bumpRevision`.
-  // No synchronous setState lives in the effect body — the disable / key-
-  // change paths just produce a different derived render output, while the
-  // network resolution path bumps the revision counter from inside the
-  // promise's `.then` callback (async, allowed).
-  const [, setRevision] = useState(0);
+  // re-renders the consumer when the async fetch resolves (via the promise
+  // `.then` bumping `revision`) or when a global cache flush fires (via the
+  // visibility-subscriber callback bumping `revision`). No synchronous
+  // setState lives in the effect body — the disable / key-change paths just
+  // produce a different derived render output.
+  const [revision, setRevision] = useState(0);
+
+  // Subscribe to global cache flushes (currently driven only by the tab
+  // visibility listener at module scope). Bumping `revision` re-runs the
+  // fetch effect; with the cache now cleared, that effect issues a fresh
+  // aggregation query.
+  useEffect(() => {
+    const cb = () => setRevision((r) => r + 1);
+    subscribers.add(cb);
+    return () => {
+      subscribers.delete(cb);
+    };
+  }, []);
 
   useEffect(() => {
     if (!key) return;
@@ -134,7 +193,9 @@ export function useSessionViewCount(
     return () => {
       cancelled = true;
     };
-  }, [collectionName, sessionId, enabled, key]);
+    // `revision` participates so a global cache flush (visibility refresh,
+    // or any future trigger) re-runs this effect against the empty cache.
+  }, [collectionName, sessionId, enabled, key, revision]);
 
   if (!key) return { count: null, loading: false };
   const cached = cache.get(key);

--- a/tests/hooks/useSessionViewCount.test.ts
+++ b/tests/hooks/useSessionViewCount.test.ts
@@ -7,12 +7,14 @@
  *   - Concurrent mounts of the same sessionId coalesce onto a single query.
  *   - Subsequent mounts of the same sessionId reuse the cached count.
  *   - `invalidateSessionViewCount` busts the cache and forces a refetch.
+ *   - Visibility-driven refresh flushes the cache and re-queries mounted
+ *     hooks; the throttle prevents rapid-fire refreshes.
  *   - Changing sessionId mid-lifecycle issues a fresh query for the new key.
  *   - Flipping `enabled` false → true mid-lifecycle issues a query.
  *   - Failed queries soft-fail to `count: 0` rather than rejecting.
  */
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { renderHook, waitFor } from '@testing-library/react';
+import { act, renderHook, waitFor } from '@testing-library/react';
 
 const getCountFromServerMock = vi.fn();
 
@@ -30,6 +32,7 @@ vi.mock('@/config/firebase', () => ({
 }));
 
 import {
+  _testVisibilityRefresh,
   invalidateSessionViewCount,
   useSessionViewCount,
 } from '../../hooks/useSessionViewCount';
@@ -128,6 +131,62 @@ describe('useSessionViewCount', () => {
     await waitFor(() => expect(second.result.current.loading).toBe(false));
     expect(second.result.current.count).toBe(5);
     expect(getCountFromServerMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('refetches mounted hooks on a visibility refresh and reflects the new count', async () => {
+    getCountFromServerMock
+      .mockResolvedValueOnce({ data: () => ({ count: 1 }) })
+      .mockResolvedValueOnce({ data: () => ({ count: 4 }) });
+    const sessionId = 'session-visibility';
+    const { result } = renderHook(() =>
+      useSessionViewCount('quiz_sessions', sessionId, true)
+    );
+    await waitFor(() => expect(result.current.count).toBe(1));
+
+    // Simulate "teacher returns to the SpartBoard tab" — fire a visibility
+    // refresh well past the throttle window. The mounted hook should
+    // observe the new count without remount. `act` wraps the synchronous
+    // setRevision bumps the refresh triggers across subscribed hooks.
+    let fired = false;
+    act(() => {
+      fired = _testVisibilityRefresh(Date.now() + 10_000);
+    });
+    expect(fired).toBe(true);
+
+    await waitFor(() => expect(result.current.count).toBe(4));
+    expect(getCountFromServerMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('throttles back-to-back visibility refreshes', async () => {
+    // The first fired refresh clears the cache and forces a refetch — so
+    // we mock two responses (initial mount + first refresh's refetch).
+    // The second refresh's no-op behaviour is what we're asserting.
+    getCountFromServerMock
+      .mockResolvedValueOnce({ data: () => ({ count: 9 }) })
+      .mockResolvedValueOnce({ data: () => ({ count: 9 }) });
+    const sessionId = 'session-throttle';
+    const { result } = renderHook(() =>
+      useSessionViewCount('quiz_sessions', sessionId, true)
+    );
+    await waitFor(() => expect(result.current.count).toBe(9));
+
+    // Two rapid refreshes inside the 5s throttle window: first wins,
+    // second is a no-op.
+    const t0 = Date.now() + 20_000;
+    let firstFired = false;
+    let secondFired = false;
+    act(() => {
+      firstFired = _testVisibilityRefresh(t0);
+      secondFired = _testVisibilityRefresh(t0 + 100);
+    });
+
+    expect(firstFired).toBe(true);
+    expect(secondFired).toBe(false);
+    // Total Firestore reads: initial mount + the first (un-throttled)
+    // visibility refresh. The throttled second refresh adds nothing.
+    await waitFor(() =>
+      expect(getCountFromServerMock).toHaveBeenCalledTimes(2)
+    );
   });
 
   it('issues a fresh query when sessionId changes mid-lifecycle', async () => {


### PR DESCRIPTION
## Summary

- View-count cards now refetch automatically when the teacher returns to the SpartBoard tab.
- Throttled to one refresh / 5s so rapid alt-tab cycles don't fan out N reads.
- Adds 2 tests; existing 9 hook tests still pass.

## Why

Follow-up to PR #1477. Reported in review: after sending a view-only share link out, teachers saw "0 views" indefinitely — the module-scoped cache held the original count and only busted on explicit Reactivate or full page reload. A live \`onSnapshot\` listener would solve it but adds real-time write-multipliers across the archive; visibility-driven refresh is the cheaper option that matches the actual workflow ("send link → switch tabs → come back to check").

## How

\`useSessionViewCount\` hooks now register a callback in a module-level subscriber set. A \`'visibilitychange'\` listener (registered once at module load) clears the cache and notifies subscribers when \`document.visibilityState\` returns to \`'visible'\`. Each notified hook bumps its revision counter; the fetch effect re-runs against the empty cache and issues a fresh aggregation query.

The \`_testVisibilityRefresh(now?)\` export drives the listener at deterministic timestamps in unit tests; production code never calls it.

## Test plan

- [x] \`pnpm run type-check\`
- [x] \`pnpm run lint\`
- [x] \`pnpm run test\` — 1760/1760 pass (added 2 hook tests for refresh-on-visibility + throttle)
- [ ] Manual: open a view-only share, hit the URL from another browser, switch back to the dashboard tab → count updates within ~one second
- [ ] Manual: rapid alt-tab cycle within 5s → only one refetch fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)