### PR TITLE
fix(url-widget): customize link on paste + improve tile scaling

### DIFF
--- a/components/layout/Dock.tsx
+++ b/components/layout/Dock.tsx
@@ -933,15 +933,25 @@ export const Dock: React.FC = () => {
           url={urlPastePending}
           globalStyle={globalStyle}
           onClose={() => setUrlPastePending(null)}
-          onSelect={(type) => {
+          onSelect={(selection) => {
             const url = urlPastePending;
             setUrlPastePending(null);
-            if (type === 'qr') {
+            if (selection.type === 'qr') {
               addWidget('qr', { config: { url } });
               addToast('Added QR Code widget!', 'success');
             } else {
               addWidget('url', {
-                config: { urls: [{ id: crypto.randomUUID(), url }] },
+                config: {
+                  urls: [
+                    {
+                      id: crypto.randomUUID(),
+                      url,
+                      title: selection.title,
+                      icon: selection.icon,
+                      color: selection.color,
+                    },
+                  ],
+                },
               });
               addToast('Added Links widget!', 'success');
             }

--- a/components/layout/dock/UrlPickerModal.tsx
+++ b/components/layout/dock/UrlPickerModal.tsx
@@ -8,6 +8,7 @@ import {
   URL_COLORS,
   DEFAULT_URL_ICON_ID,
   DEFAULT_URL_COLOR,
+  getUrlIcon,
 } from '@/components/widgets/UrlWidget/icons';
 
 export type UrlPickerSelection =
@@ -148,9 +149,7 @@ export const UrlPickerModal: React.FC<UrlPickerModalProps> = ({
                 style={{ backgroundColor: color }}
               >
                 {(() => {
-                  const Picked =
-                    URL_ICONS.find((i) => i.id === iconId)?.icon ??
-                    URL_ICONS[0].icon;
+                  const Picked = getUrlIcon(iconId);
                   return (
                     <Picked className="w-8 h-8 text-white drop-shadow-sm" />
                   );

--- a/components/layout/dock/UrlPickerModal.tsx
+++ b/components/layout/dock/UrlPickerModal.tsx
@@ -1,12 +1,27 @@
-import React from 'react';
-import { Link, QrCode, X } from 'lucide-react';
+import React, { useState } from 'react';
+import { Link, QrCode, X, ArrowLeft, Check } from 'lucide-react';
 import { GlassCard } from '@/components/common/GlassCard';
 import { Modal } from '@/components/common/Modal';
 import { GlobalStyle } from '@/types';
+import {
+  URL_ICONS,
+  URL_COLORS,
+  DEFAULT_URL_ICON_ID,
+  DEFAULT_URL_COLOR,
+} from '@/components/widgets/UrlWidget/icons';
+
+export type UrlPickerSelection =
+  | { type: 'qr' }
+  | {
+      type: 'url';
+      title?: string;
+      icon: string;
+      color: string;
+    };
 
 interface UrlPickerModalProps {
   url: string;
-  onSelect: (type: 'url' | 'qr') => void;
+  onSelect: (selection: UrlPickerSelection) => void;
   onClose: () => void;
   globalStyle?: GlobalStyle;
 }
@@ -19,10 +34,24 @@ export const UrlPickerModal: React.FC<UrlPickerModalProps> = ({
   onClose,
   globalStyle,
 }) => {
+  const [stage, setStage] = useState<'choose' | 'customize'>('choose');
+  const [title, setTitle] = useState('');
+  const [iconId, setIconId] = useState(DEFAULT_URL_ICON_ID);
+  const [color, setColor] = useState(DEFAULT_URL_COLOR);
+
   const preview =
     url.length > PREVIEW_MAX_LENGTH
       ? url.slice(0, PREVIEW_MAX_LENGTH).trimEnd() + '…'
       : url;
+
+  const handleConfirm = () => {
+    onSelect({
+      type: 'url',
+      title: title.trim() || undefined,
+      icon: iconId,
+      color,
+    });
+  };
 
   return (
     <Modal isOpen={true} onClose={onClose} variant="bare" zIndex="z-critical">
@@ -32,13 +61,28 @@ export const UrlPickerModal: React.FC<UrlPickerModalProps> = ({
       >
         {/* Header */}
         <div className="flex items-center justify-between px-6 pt-6 pb-4">
-          <div>
-            <h3 className="text-sm font-black uppercase tracking-widest text-slate-800">
-              How should this link be displayed?
-            </h3>
-            <p className="text-xs text-slate-500 mt-0.5 font-bold">
-              Pick a widget type for this link
-            </p>
+          <div className="flex items-center gap-2">
+            {stage === 'customize' && (
+              <button
+                onClick={() => setStage('choose')}
+                className="p-1.5 rounded-lg hover:bg-slate-100 text-slate-400 hover:text-slate-600 transition-colors"
+                aria-label="Back"
+              >
+                <ArrowLeft className="w-4 h-4" />
+              </button>
+            )}
+            <div>
+              <h3 className="text-sm font-black uppercase tracking-widest text-slate-800">
+                {stage === 'choose'
+                  ? 'How should this link be displayed?'
+                  : 'Customize your link'}
+              </h3>
+              <p className="text-xs text-slate-500 mt-0.5 font-bold">
+                {stage === 'choose'
+                  ? 'Pick a widget type for this link'
+                  : 'Set a title, icon, and color'}
+              </p>
+            </div>
           </div>
           <button
             onClick={onClose}
@@ -49,7 +93,7 @@ export const UrlPickerModal: React.FC<UrlPickerModalProps> = ({
           </button>
         </div>
 
-        {/* Text preview — React renders {preview} as a text node, so no XSS risk */}
+        {/* URL preview — React renders {preview} as a text node, so no XSS risk */}
         <div className="mx-6 mb-5 px-4 py-3 bg-slate-50 border border-slate-200 rounded-xl">
           <p className="text-xs text-slate-500 font-black uppercase tracking-widest mb-1.5">
             Pasted link
@@ -59,42 +103,143 @@ export const UrlPickerModal: React.FC<UrlPickerModalProps> = ({
           </p>
         </div>
 
-        {/* Choice buttons */}
-        <div className="px-6 pb-6 grid grid-cols-2 gap-3">
-          <button
-            onClick={() => onSelect('url')}
-            className="group flex flex-col items-center gap-3 p-5 bg-blue-50 hover:bg-blue-100 border-2 border-blue-200 hover:border-blue-400 rounded-2xl transition-all active:scale-95 text-left"
-          >
-            <div className="w-11 h-11 rounded-xl bg-blue-500 flex items-center justify-center shadow-md shadow-blue-400/40 group-hover:scale-110 transition-transform">
-              <Link className="w-5 h-5 text-white" />
-            </div>
-            <div>
-              <p className="text-xs font-black uppercase tracking-widest text-blue-800">
-                Links Widget
-              </p>
-              <p className="text-xxs text-blue-600 font-bold mt-0.5 leading-tight">
-                Clickable button on the board
-              </p>
-            </div>
-          </button>
+        {stage === 'choose' ? (
+          <div className="px-6 pb-6 grid grid-cols-2 gap-3">
+            <button
+              onClick={() => setStage('customize')}
+              className="group flex flex-col items-center gap-3 p-5 bg-blue-50 hover:bg-blue-100 border-2 border-blue-200 hover:border-blue-400 rounded-2xl transition-all active:scale-95 text-left"
+            >
+              <div className="w-11 h-11 rounded-xl bg-blue-500 flex items-center justify-center shadow-md shadow-blue-400/40 group-hover:scale-110 transition-transform">
+                <Link className="w-5 h-5 text-white" />
+              </div>
+              <div>
+                <p className="text-xs font-black uppercase tracking-widest text-blue-800">
+                  Links Widget
+                </p>
+                <p className="text-xxs text-blue-600 font-bold mt-0.5 leading-tight">
+                  Clickable button on the board
+                </p>
+              </div>
+            </button>
 
-          <button
-            onClick={() => onSelect('qr')}
-            className="group flex flex-col items-center gap-3 p-5 bg-brand-blue-lighter hover:bg-brand-blue-lighter/80 border-2 border-brand-blue-lighter hover:border-brand-blue-light rounded-2xl transition-all active:scale-95 text-left"
-          >
-            <div className="w-11 h-11 rounded-xl bg-brand-blue-primary flex items-center justify-center shadow-md shadow-brand-blue-primary/40 group-hover:scale-110 transition-transform">
-              <QrCode className="w-5 h-5 text-white" />
+            <button
+              onClick={() => onSelect({ type: 'qr' })}
+              className="group flex flex-col items-center gap-3 p-5 bg-brand-blue-lighter hover:bg-brand-blue-lighter/80 border-2 border-brand-blue-lighter hover:border-brand-blue-light rounded-2xl transition-all active:scale-95 text-left"
+            >
+              <div className="w-11 h-11 rounded-xl bg-brand-blue-primary flex items-center justify-center shadow-md shadow-brand-blue-primary/40 group-hover:scale-110 transition-transform">
+                <QrCode className="w-5 h-5 text-white" />
+              </div>
+              <div>
+                <p className="text-xs font-black uppercase tracking-widest text-brand-blue-dark">
+                  QR Code
+                </p>
+                <p className="text-xxs text-brand-blue-primary font-bold mt-0.5 leading-tight">
+                  Scannable by student devices
+                </p>
+              </div>
+            </button>
+          </div>
+        ) : (
+          <div className="px-6 pb-6 space-y-5">
+            {/* Live preview */}
+            <div className="flex items-center justify-center">
+              <div
+                className="flex flex-col items-center justify-center w-32 h-24 rounded-2xl border border-white/30 shadow-md"
+                style={{ backgroundColor: color }}
+              >
+                {(() => {
+                  const Picked =
+                    URL_ICONS.find((i) => i.id === iconId)?.icon ??
+                    URL_ICONS[0].icon;
+                  return (
+                    <Picked className="w-8 h-8 text-white drop-shadow-sm" />
+                  );
+                })()}
+                <span className="font-black text-white text-sm mt-1 drop-shadow-md break-words text-center px-2 line-clamp-2">
+                  {title.trim() || 'Sample'}
+                </span>
+              </div>
             </div>
+
+            {/* Title input */}
             <div>
-              <p className="text-xs font-black uppercase tracking-widest text-brand-blue-dark">
-                QR Code
-              </p>
-              <p className="text-xxs text-brand-blue-primary font-bold mt-0.5 leading-tight">
-                Scannable by student devices
-              </p>
+              <label className="block text-xs font-black text-slate-700 mb-1.5 uppercase tracking-widest">
+                Title (Optional)
+              </label>
+              <input
+                type="text"
+                value={title}
+                onChange={(e) => setTitle(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') handleConfirm();
+                }}
+                autoFocus
+                placeholder="e.g. Class Website"
+                className="w-full px-3 py-2 border border-slate-200 rounded-xl text-sm font-semibold focus:ring-2 focus:ring-brand-blue-primary focus:outline-none"
+              />
             </div>
-          </button>
-        </div>
+
+            {/* Icon picker */}
+            <div>
+              <label className="block text-xs font-black text-slate-700 mb-1.5 uppercase tracking-widest">
+                Icon
+              </label>
+              <div className="grid grid-cols-10 gap-1.5 max-h-32 overflow-y-auto p-1">
+                {URL_ICONS.map(({ id, label, icon: Icon }) => (
+                  <button
+                    key={id}
+                    type="button"
+                    onClick={() => setIconId(id)}
+                    title={label}
+                    aria-label={label}
+                    aria-pressed={iconId === id}
+                    className={`flex items-center justify-center w-8 h-8 rounded-lg border-2 transition-all ${
+                      iconId === id
+                        ? 'border-slate-800 bg-slate-800 text-white scale-105'
+                        : 'border-transparent bg-slate-100 text-slate-600 hover:bg-slate-200'
+                    }`}
+                  >
+                    <Icon className="w-4 h-4" />
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            {/* Color picker */}
+            <div>
+              <label className="block text-xs font-black text-slate-700 mb-1.5 uppercase tracking-widest">
+                Color
+              </label>
+              <div className="flex flex-wrap gap-2">
+                {URL_COLORS.map((c) => (
+                  <button
+                    key={c}
+                    type="button"
+                    onClick={() => setColor(c)}
+                    aria-label={`Color ${c}`}
+                    aria-pressed={color === c}
+                    className={`w-8 h-8 rounded-full border-2 transition-all ${
+                      color === c
+                        ? 'border-slate-800 scale-110 shadow-sm'
+                        : 'border-transparent hover:scale-105'
+                    }`}
+                    style={{ backgroundColor: c }}
+                  />
+                ))}
+              </div>
+            </div>
+
+            {/* Confirm button */}
+            <button
+              type="button"
+              onClick={handleConfirm}
+              className="w-full flex items-center justify-center gap-2 bg-slate-800 hover:bg-slate-700 text-white px-4 py-2.5 rounded-xl font-black uppercase tracking-widest text-xs transition-colors"
+            >
+              <Check className="w-4 h-4" />
+              Add Link
+            </button>
+          </div>
+        )}
       </GlassCard>
     </Modal>
   );

--- a/components/widgets/UrlWidget/Settings.tsx
+++ b/components/widgets/UrlWidget/Settings.tsx
@@ -2,20 +2,13 @@ import React, { useState } from 'react';
 import { WidgetData, UrlWidgetConfig } from '@/types';
 import { useDashboard } from '@/context/useDashboard';
 import { Plus, Trash2 } from 'lucide-react';
-
-const COLORS = [
-  '#ef4444',
-  '#f97316',
-  '#f59e0b',
-  '#84cc16',
-  '#10b981',
-  '#06b6d4',
-  '#3b82f6',
-  '#6366f1',
-  '#8b5cf6',
-  '#d946ef',
-  '#f43f5e',
-];
+import {
+  URL_ICONS,
+  URL_COLORS,
+  DEFAULT_URL_ICON_ID,
+  DEFAULT_URL_COLOR,
+  getUrlIcon,
+} from './icons';
 
 export const UrlWidgetSettings: React.FC<{ widget: WidgetData }> = ({
   widget,
@@ -27,7 +20,8 @@ export const UrlWidgetSettings: React.FC<{ widget: WidgetData }> = ({
   // local state for the form inputs
   const [newUrl, setNewUrl] = useState('');
   const [newTitle, setNewTitle] = useState('');
-  const [newColor, setNewColor] = useState(COLORS[4]);
+  const [newColor, setNewColor] = useState(DEFAULT_URL_COLOR);
+  const [newIcon, setNewIcon] = useState(DEFAULT_URL_ICON_ID);
 
   const update = (updates: Partial<UrlWidgetConfig>) => {
     updateWidget(widget.id, { config: { ...config, ...updates } });
@@ -52,12 +46,13 @@ export const UrlWidgetSettings: React.FC<{ widget: WidgetData }> = ({
       url: formattedUrl,
       title: newTitle.trim() || undefined,
       color: newColor,
+      icon: newIcon,
     };
 
     update({ urls: [...urls, newItem] });
     setNewUrl('');
     setNewTitle('');
-    // Optionally keep the color or change it
+    // Optionally keep the color/icon or reset them
   };
 
   const removeUrl = (id: string) => {
@@ -98,10 +93,35 @@ export const UrlWidgetSettings: React.FC<{ widget: WidgetData }> = ({
 
         <div>
           <label className="block text-xs font-bold text-slate-600 mb-2 uppercase tracking-wider">
+            Icon
+          </label>
+          <div className="grid grid-cols-10 gap-1.5 max-h-32 overflow-y-auto p-1">
+            {URL_ICONS.map(({ id, label, icon: Icon }) => (
+              <button
+                key={id}
+                type="button"
+                onClick={() => setNewIcon(id)}
+                title={label}
+                aria-label={label}
+                aria-pressed={newIcon === id}
+                className={`flex items-center justify-center w-8 h-8 rounded-lg border-2 transition-all ${
+                  newIcon === id
+                    ? 'border-slate-800 bg-slate-800 text-white scale-105'
+                    : 'border-transparent bg-slate-100 text-slate-600 hover:bg-slate-200'
+                }`}
+              >
+                <Icon className="w-4 h-4" />
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <div>
+          <label className="block text-xs font-bold text-slate-600 mb-2 uppercase tracking-wider">
             Button Color
           </label>
           <div className="flex flex-wrap gap-2">
-            {COLORS.map((c) => (
+            {URL_COLORS.map((c) => (
               <button
                 key={c}
                 type="button"
@@ -133,35 +153,40 @@ export const UrlWidgetSettings: React.FC<{ widget: WidgetData }> = ({
         <div className="space-y-3">
           <h3 className="text-sm font-bold text-slate-700">Active Links</h3>
           <div className="space-y-2">
-            {urls.map((u) => (
-              <div
-                key={u.id}
-                className="flex items-center justify-between bg-white p-3 rounded-xl border border-slate-200 shadow-sm"
-              >
-                <div className="flex items-center gap-3 overflow-hidden">
-                  <div
-                    className="w-4 h-4 rounded-full flex-shrink-0"
-                    style={{ backgroundColor: u.color ?? '#10b981' }}
-                  />
-                  <div className="flex flex-col overflow-hidden">
-                    <span className="font-bold text-sm text-slate-800 truncate">
-                      {getDisplayLabel(u.title, u.url)}
-                    </span>
-                    <span className="text-xs text-slate-500 truncate">
-                      {u.url}
-                    </span>
-                  </div>
-                </div>
-                <button
-                  type="button"
-                  onClick={() => removeUrl(u.id)}
-                  className="p-2 text-slate-400 hover:text-red-500 hover:bg-red-50 rounded-lg transition-colors"
-                  title="Remove Link"
+            {urls.map((u) => {
+              const Icon = getUrlIcon(u.icon);
+              return (
+                <div
+                  key={u.id}
+                  className="flex items-center justify-between bg-white p-3 rounded-xl border border-slate-200 shadow-sm"
                 >
-                  <Trash2 size={16} />
-                </button>
-              </div>
-            ))}
+                  <div className="flex items-center gap-3 overflow-hidden">
+                    <div
+                      className="w-8 h-8 rounded-lg flex items-center justify-center flex-shrink-0"
+                      style={{ backgroundColor: u.color ?? DEFAULT_URL_COLOR }}
+                    >
+                      <Icon className="w-4 h-4 text-white" />
+                    </div>
+                    <div className="flex flex-col overflow-hidden">
+                      <span className="font-bold text-sm text-slate-800 truncate">
+                        {getDisplayLabel(u.title, u.url)}
+                      </span>
+                      <span className="text-xs text-slate-500 truncate">
+                        {u.url}
+                      </span>
+                    </div>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() => removeUrl(u.id)}
+                    className="p-2 text-slate-400 hover:text-red-500 hover:bg-red-50 rounded-lg transition-colors"
+                    title="Remove Link"
+                  >
+                    <Trash2 size={16} />
+                  </button>
+                </div>
+              );
+            })}
           </div>
         </div>
       )}

--- a/components/widgets/UrlWidget/Settings.tsx
+++ b/components/widgets/UrlWidget/Settings.tsx
@@ -52,7 +52,6 @@ export const UrlWidgetSettings: React.FC<{ widget: WidgetData }> = ({
     update({ urls: [...urls, newItem] });
     setNewUrl('');
     setNewTitle('');
-    // Optionally keep the color/icon or reset them
   };
 
   const removeUrl = (id: string) => {

--- a/components/widgets/UrlWidget/Widget.tsx
+++ b/components/widgets/UrlWidget/Widget.tsx
@@ -2,8 +2,9 @@ import React, { useMemo } from 'react';
 import { WidgetData, UrlWidgetConfig } from '@/types';
 import { WidgetLayout } from '@/components/widgets/WidgetLayout';
 import { ScaledEmptyState } from '@/components/common/ScaledEmptyState';
-import { Globe, ExternalLink, QrCode } from 'lucide-react';
+import { Globe, QrCode } from 'lucide-react';
 import { useDashboard } from '@/context/useDashboard';
+import { getUrlIcon, DEFAULT_URL_COLOR } from './icons';
 
 export const UrlWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
   const { addWidget } = useDashboard();
@@ -54,68 +55,79 @@ export const UrlWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
                 gap: 'min(10px, 2cqmin)',
               }}
             >
-              {urls.map((urlItem) => (
-                <div
-                  role="button"
-                  tabIndex={0}
-                  key={urlItem.id}
-                  className="relative overflow-hidden rounded-[min(16px,3cqmin)] flex flex-col items-center justify-center transition-all active:scale-95 group shadow-sm hover:shadow-md border border-white/20 hover:brightness-110 cursor-pointer text-left"
-                  style={{ backgroundColor: urlItem.color ?? '#10b981' }}
-                  onClick={() =>
-                    window.open(urlItem.url, '_blank', 'noopener,noreferrer')
-                  }
-                  onKeyDown={(e) => {
-                    if (e.key === 'Enter' || e.key === ' ') {
-                      e.preventDefault();
-                      window.open(urlItem.url, '_blank', 'noopener,noreferrer');
-                    }
-                  }}
-                >
-                  <div className="absolute inset-0 bg-black/0 group-hover:bg-black/5 group-active:bg-black/10 transition-colors" />
-
-                  <button
-                    type="button"
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      addWidget('qr', { config: { url: urlItem.url } });
-                    }}
-                    className="absolute z-20 rounded-full bg-black/20 text-white opacity-70 transition-all outline-none hover:bg-black/40 group-hover:opacity-100 focus:opacity-100 focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-black/40"
+              {urls.map((urlItem) => {
+                const Icon = getUrlIcon(urlItem.icon);
+                const label = getDisplayLabel(urlItem.title, urlItem.url);
+                return (
+                  <div
+                    role="button"
+                    tabIndex={0}
+                    key={urlItem.id}
+                    className="relative overflow-hidden rounded-[min(16px,3cqmin)] flex flex-col items-center justify-center transition-all active:scale-95 group shadow-sm hover:shadow-md border border-white/20 hover:brightness-110 cursor-pointer text-left"
                     style={{
-                      top: 'min(8px, 2cqmin)',
-                      right: 'min(8px, 2cqmin)',
-                      padding: 'min(6px, 1.5cqmin)',
+                      backgroundColor: urlItem.color ?? DEFAULT_URL_COLOR,
+                      containerType: 'size',
                     }}
-                    title="Create QR Code"
-                    aria-label="Create QR Code"
+                    onClick={() =>
+                      window.open(urlItem.url, '_blank', 'noopener,noreferrer')
+                    }
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter' || e.key === ' ') {
+                        e.preventDefault();
+                        window.open(
+                          urlItem.url,
+                          '_blank',
+                          'noopener,noreferrer'
+                        );
+                      }
+                    }}
                   >
-                    <QrCode
+                    <div className="absolute inset-0 bg-black/0 group-hover:bg-black/5 group-active:bg-black/10 transition-colors" />
+
+                    <button
+                      type="button"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        addWidget('qr', { config: { url: urlItem.url } });
+                      }}
+                      className="absolute z-20 rounded-full bg-black/20 text-white opacity-70 transition-all outline-none hover:bg-black/40 group-hover:opacity-100 focus:opacity-100 focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-black/40"
                       style={{
-                        width: 'min(20px, 6cqmin)',
-                        height: 'min(20px, 6cqmin)',
+                        top: 'min(8px, 2cqmin)',
+                        right: 'min(8px, 2cqmin)',
+                        padding: 'min(6px, 1.5cqmin)',
+                      }}
+                      title="Create QR Code"
+                      aria-label="Create QR Code"
+                    >
+                      <QrCode
+                        style={{
+                          width: 'min(20px, 10cqmin)',
+                          height: 'min(20px, 10cqmin)',
+                        }}
+                      />
+                    </button>
+
+                    <Icon
+                      className="text-white drop-shadow-sm z-10"
+                      style={{
+                        width: 'min(96px, 32cqmin)',
+                        height: 'min(96px, 32cqmin)',
+                        marginBottom: 'min(8px, 2.5cqmin)',
                       }}
                     />
-                  </button>
 
-                  <ExternalLink
-                    className="text-white drop-shadow-sm z-10"
-                    style={{
-                      width: 'min(48px, 15cqmin)',
-                      height: 'min(48px, 15cqmin)',
-                      marginBottom: 'min(6px, 1.5cqmin)',
-                    }}
-                  />
-
-                  <span
-                    className="font-black text-white text-center leading-tight drop-shadow-md break-words max-w-full z-10"
-                    style={{
-                      fontSize: 'min(18px, 6cqmin)',
-                      padding: '0 min(8px, 1.5cqmin)',
-                    }}
-                  >
-                    {getDisplayLabel(urlItem.title, urlItem.url)}
-                  </span>
-                </div>
-              ))}
+                    <span
+                      className="font-black text-white text-center leading-tight drop-shadow-md break-words max-w-full z-10 line-clamp-2"
+                      style={{
+                        fontSize: 'min(36px, 14cqmin)',
+                        padding: '0 min(8px, 1.5cqmin)',
+                      }}
+                    >
+                      {label}
+                    </span>
+                  </div>
+                );
+              })}
             </div>
           </div>
         </div>

--- a/components/widgets/UrlWidget/icons.ts
+++ b/components/widgets/UrlWidget/icons.ts
@@ -1,0 +1,69 @@
+import {
+  ExternalLink,
+  Globe,
+  Link as LinkIcon,
+  BookOpen,
+  Video,
+  Image as ImageIcon,
+  FileText,
+  Music,
+  Gamepad2,
+  GraduationCap,
+  Calendar,
+  Mail,
+  Newspaper,
+  Star,
+  Heart,
+  PenTool,
+  Calculator,
+  Microscope,
+  Map,
+  Camera,
+  type LucideIcon,
+} from 'lucide-react';
+
+export const URL_ICONS: { id: string; label: string; icon: LucideIcon }[] = [
+  { id: 'external-link', label: 'External Link', icon: ExternalLink },
+  { id: 'globe', label: 'Globe', icon: Globe },
+  { id: 'link', label: 'Link', icon: LinkIcon },
+  { id: 'book', label: 'Book', icon: BookOpen },
+  { id: 'video', label: 'Video', icon: Video },
+  { id: 'image', label: 'Image', icon: ImageIcon },
+  { id: 'file', label: 'File', icon: FileText },
+  { id: 'music', label: 'Music', icon: Music },
+  { id: 'game', label: 'Game', icon: Gamepad2 },
+  { id: 'school', label: 'School', icon: GraduationCap },
+  { id: 'calendar', label: 'Calendar', icon: Calendar },
+  { id: 'mail', label: 'Mail', icon: Mail },
+  { id: 'news', label: 'News', icon: Newspaper },
+  { id: 'star', label: 'Star', icon: Star },
+  { id: 'heart', label: 'Heart', icon: Heart },
+  { id: 'pen', label: 'Draw', icon: PenTool },
+  { id: 'calc', label: 'Calculator', icon: Calculator },
+  { id: 'science', label: 'Science', icon: Microscope },
+  { id: 'map', label: 'Map', icon: Map },
+  { id: 'camera', label: 'Camera', icon: Camera },
+];
+
+export const DEFAULT_URL_ICON_ID = 'external-link';
+
+export const getUrlIcon = (id?: string): LucideIcon => {
+  const found = URL_ICONS.find((i) => i.id === id);
+  return found?.icon ?? ExternalLink;
+};
+
+export const URL_COLORS = [
+  '#ef4444',
+  '#f97316',
+  '#f59e0b',
+  '#84cc16',
+  '#10b981',
+  '#06b6d4',
+  '#3b82f6',
+  '#6366f1',
+  '#8b5cf6',
+  '#d946ef',
+  '#f43f5e',
+];
+
+export const DEFAULT_URL_COLOR = '#10b981';

--- a/types.ts
+++ b/types.ts
@@ -475,6 +475,7 @@ export interface UrlWidgetConfig {
     url: string;
     title?: string;
     color?: string;
+    icon?: string;
   }[];
 }
 


### PR DESCRIPTION
## Summary

Fixes two UX issues with the URL/Link widget:

**1. Smart paste URL picker now lets the user customize the link.**
When pasting a URL the picker opens with the existing Link vs. QR choice. Selecting **Link** now opens a second stage where the teacher can enter a title, pick an icon, and choose a color before the widget is created. Previously every pasted link defaulted to green because no metadata was wired through the paste handler — that "color isn't sticking" bug is now fixed.

- Added `icon?: string` to `UrlWidgetConfig.urls`.
- New shared icon set in `components/widgets/UrlWidget/icons.ts` (20 lucide icons + 11 colors).
- `UrlPickerModal` is now two-stage with a live preview of the resulting tile.
- Settings panel grew an icon picker so existing links can be customized.

**2. URL tiles now fill the container properly.**
Each tile is its own CSS size container, so `cqmin` units inside the tile reference the tile rather than the whole widget. Combined with bumped icon/text sizing (32cqmin icon, 14cqmin label), tiles look full at every grid layout (1×1 through 5×N).

## Test plan

- [ ] Paste a URL → choose **Link** → set title/icon/color → confirm tile renders with correct color & icon
- [ ] Paste a URL → choose **QR Code** → confirm QR widget is added
- [ ] Flip an existing URL widget → add another link via Settings → icon picker works
- [ ] Resize URL widget; verify icon and label scale to fill tiles in 1, 2, 4, 9, and 16-tile layouts
- [ ] `pnpm run validate` (type-check, lint, format, tests) — all pass locally

https://claude.ai/code/session_01Ed6drxknSnC6sodp8wbHcb

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ed6drxknSnC6sodp8wbHcb)_