### PR TITLE
fix(widgets): make corner resize handles reliably grabbable at min size

### DIFF
--- a/components/common/DraggableWindow.tsx
+++ b/components/common/DraggableWindow.tsx
@@ -76,6 +76,14 @@ const POSITION_AWARE_WIDGETS: WidgetType[] = [
 const INTERACTIVE_ELEMENTS_SELECTOR =
   'button, input, textarea, select, canvas, iframe, label, a, summary, [role="button"], [role="tab"], [role="menuitem"], [role="checkbox"], [role="switch"], .cursor-pointer, [contenteditable="true"]';
 
+// Narrower selector for resize-handle pass-through. Excludes `.cursor-pointer`
+// because many widgets style edge-to-edge tiles/cards with that class, which
+// previously made it nearly impossible to grab corner handles at min widget
+// size. Resize handles take priority over generic clickable surfaces; they
+// only defer to genuine form/role-bearing elements.
+const RESIZE_PASSTHROUGH_SELECTOR =
+  'button, input, textarea, select, a, [role="button"], [role="checkbox"], [role="switch"], [role="tab"], [role="menuitem"]';
+
 const SCROLLABLE_ELEMENTS_SELECTOR =
   '.overflow-y-auto, .overflow-auto, .overflow-x-auto, [data-scrollable="true"], [style*="overflow:auto"], [style*="overflow: auto"], [style*="overflow-y:auto"], [style*="overflow-y: auto"], [style*="overflow-x:auto"], [style*="overflow-x: auto"]';
 
@@ -1007,8 +1015,8 @@ export const DraggableWindow: React.FC<DraggableWindowProps> = ({
         continue;
       if (el instanceof HTMLElement && el.isContentEditable) continue;
       if (
-        el.matches?.(INTERACTIVE_ELEMENTS_SELECTOR) ||
-        el.closest?.(INTERACTIVE_ELEMENTS_SELECTOR)
+        el.matches?.(RESIZE_PASSTHROUGH_SELECTOR) ||
+        el.closest?.(RESIZE_PASSTHROUGH_SELECTOR)
       ) {
         // Temporarily remove pointer-events so the browser dispatches
         // the subsequent click to the interactive element beneath.
@@ -1972,34 +1980,80 @@ export const DraggableWindow: React.FC<DraggableWindowProps> = ({
             </>
           )}
         </div>
+      </div>
 
-        {/* Resize Handles (Corners Only) */}
-        {!isLocked && !isPinned && (
-          <>
+      {/* Resize Handles (Corners Only)
+          Rendered as siblings of `drag-surface` so they aren't clipped by its
+          `overflow: hidden`, allowing each handle to extend ~12px outside the
+          widget bounds for a 36×36 effective hit zone (12 outside + 24 inside).
+          The visible SE corner icon stays anchored at the inner corner. */}
+      {!isLocked && !isPinned && (
+        <>
+          <div
+            onPointerDown={(e) => handleResizeStart(e, 'nw')}
+            className="resize-handle cursor-nw-resize z-widget-resize"
+            style={{
+              position: 'absolute',
+              top: -12,
+              left: -12,
+              width: 36,
+              height: 36,
+              touchAction: 'none',
+            }}
+          />
+          <div
+            onPointerDown={(e) => handleResizeStart(e, 'ne')}
+            className="resize-handle cursor-ne-resize z-widget-resize"
+            style={{
+              position: 'absolute',
+              top: -12,
+              right: -12,
+              width: 36,
+              height: 36,
+              touchAction: 'none',
+            }}
+          />
+          <div
+            onPointerDown={(e) => handleResizeStart(e, 'sw')}
+            className="resize-handle cursor-sw-resize z-widget-resize"
+            style={{
+              position: 'absolute',
+              bottom: -12,
+              left: -12,
+              width: 36,
+              height: 36,
+              touchAction: 'none',
+            }}
+          />
+          <div
+            onPointerDown={(e) => handleResizeStart(e, 'se')}
+            className="resize-handle cursor-se-resize z-widget-resize"
+            style={{
+              position: 'absolute',
+              bottom: -12,
+              right: -12,
+              width: 36,
+              height: 36,
+              touchAction: 'none',
+            }}
+          >
             <div
-              onPointerDown={(e) => handleResizeStart(e, 'nw')}
-              className="resize-handle absolute top-0 left-0 w-6 h-6 cursor-nw-resize z-widget-resize touch-none"
-            />
-            <div
-              onPointerDown={(e) => handleResizeStart(e, 'ne')}
-              className="resize-handle absolute top-0 right-0 w-6 h-6 cursor-ne-resize z-widget-resize touch-none"
-            />
-            <div
-              onPointerDown={(e) => handleResizeStart(e, 'sw')}
-              className="resize-handle absolute bottom-0 left-0 w-6 h-6 cursor-sw-resize z-widget-resize touch-none"
-            />
-            <div
-              onPointerDown={(e) => handleResizeStart(e, 'se')}
-              className="resize-handle absolute bottom-0 right-0 w-6 h-6 cursor-se-resize flex items-end justify-end p-1.5 z-widget-resize touch-none"
+              aria-hidden="true"
+              style={{
+                position: 'absolute',
+                bottom: 13.5,
+                right: 13.5,
+                pointerEvents: 'none',
+              }}
             >
               <ResizeHandleIcon
                 className="text-slate-400"
                 style={{ opacity: isSelected ? 1 : transparency }}
               />
             </div>
-          </>
-        )}
-      </div>
+          </div>
+        </>
+      )}
 
       {/* Invisible edge grab zones — extend INVISIBLE_EDGE_PAD px outside the widget's visual
           bounds so users can reliably grab and drag widgets whose content fills edge-to-edge.

--- a/components/common/DraggableWindow.tsx
+++ b/components/common/DraggableWindow.tsx
@@ -80,9 +80,11 @@ const INTERACTIVE_ELEMENTS_SELECTOR =
 // because many widgets style edge-to-edge tiles/cards with that class, which
 // previously made it nearly impossible to grab corner handles at min widget
 // size. Resize handles take priority over generic clickable surfaces; they
-// only defer to genuine form/role-bearing elements.
+// only defer to genuine form/role-bearing elements. (canvas/iframe/
+// contentEditable are handled separately above the matches() check so the
+// resize handle takes priority over them.)
 const RESIZE_PASSTHROUGH_SELECTOR =
-  'button, input, textarea, select, a, [role="button"], [role="checkbox"], [role="switch"], [role="tab"], [role="menuitem"]';
+  'button, input, textarea, select, a, label, summary, [role="button"], [role="checkbox"], [role="switch"], [role="tab"], [role="menuitem"]';
 
 const SCROLLABLE_ELEMENTS_SELECTOR =
   '.overflow-y-auto, .overflow-auto, .overflow-x-auto, [data-scrollable="true"], [style*="overflow:auto"], [style*="overflow: auto"], [style*="overflow-y:auto"], [style*="overflow-y: auto"], [style*="overflow-x:auto"], [style*="overflow-x: auto"]';
@@ -1986,8 +1988,10 @@ export const DraggableWindow: React.FC<DraggableWindowProps> = ({
           Rendered as siblings of `drag-surface` so they aren't clipped by its
           `overflow: hidden`, allowing each handle to extend ~12px outside the
           widget bounds for a 36×36 effective hit zone (12 outside + 24 inside).
-          The visible SE corner icon stays anchored at the inner corner. */}
-      {!isLocked && !isPinned && (
+          The visible SE corner icon stays anchored at the inner corner.
+          Hidden when maximized or annotating to mirror the outer drag strips
+          and avoid intercepting annotation strokes near the corners. */}
+      {!isLocked && !isPinned && !isMaximized && !isAnnotating && (
         <>
           <div
             onPointerDown={(e) => handleResizeStart(e, 'nw')}


### PR DESCRIPTION
## Summary

Teachers report that widgets resized to the 150x100 floor become impossible to resize back larger — none of the four corner handles respond at default zoom. Fixed by addressing three compounding issues in `components/common/DraggableWindow.tsx`:

- **Lift handles outside `drag-surface`** so they're not clipped by `overflow: hidden`. They're now siblings of `drag-surface` (still inside `GlassCard`), alongside the existing `INVISIBLE_EDGE_PAD` outer drag strips.
- **Enlarge to 36x36 with 12px overhang** outside the widget on each corner (was 24x24, fully inside). Combined with the existing 20px outer drag pad, gives a reliably grabbable hit area at default zoom and on touch (well above WCAG 2.5.8's 44x44 recommendation when overhang + outer pad are considered together).
- **Narrow `elementsFromPoint` pass-through** for resize handles via a new `RESIZE_PASSTHROUGH_SELECTOR` that excludes `.cursor-pointer`. Many widgets (Stations, NeedDoPutThen, MiniApp, etc.) cover their content area edge-to-edge with `.cursor-pointer`, which previously aborted every resize start at min size. Resize handles now defer only to genuine form/role-bearing elements (`button`, `input`, `[role=button]`, etc.). Drag and inner-edge code paths still use `INTERACTIVE_ELEMENTS_SELECTOR` unchanged.

The visible SE corner icon stays anchored near the inner corner via a `pointer-events: none` inner div so the affordance doesn't visually shift.

## Test plan

- [ ] Add a Clock widget, resize to floor (150x100), drag each corner back outward at default zoom — all four respond
- [ ] Repeat with Stations, NeedDoPutThen, MiniApp widgets (which have edge-to-edge `.cursor-pointer` content)
- [ ] Verify zoom-independence at 0.5x, 1.0x, 1.5x, 2.0x, 5.0x board zoom
- [ ] Touch emulation: resize via Chrome devtools touch mode at min size — corners reliably tappable
- [ ] Sanity: place a `<button>` exactly at a corner — clicking the button (not the resize overhang) routes to the button (narrowed selector still passes through real form elements)
- [ ] No drag regression: dragging from widget body / title bar still drags the widget
- [ ] No edge-strip regression: inner edge drag strips still work; 24px corner inset still pairs cleanly
- [x] `pnpm run validate` passes (type-check, lint, format-check, 1771 tests)
- [x] `pnpm run build` succeeds

---
_Generated by [Claude Code](https://claude.ai/code/session_017VtRLA6dPGk2agd5fDTjVw)_