### PR TITLE
feat(annotation): move screen-annotation entry to floating sidebar toolbar

### DIFF
--- a/components/layout/Dock.tsx
+++ b/components/layout/Dock.tsx
@@ -7,15 +7,7 @@ import React, {
 } from 'react';
 import { createPortal } from 'react-dom';
 import { useTranslation } from 'react-i18next';
-import {
-  LayoutGrid,
-  Puzzle,
-  Users,
-  Cast,
-  Square,
-  Pencil,
-  Maximize,
-} from 'lucide-react';
+import { LayoutGrid, Puzzle, Users, Cast, Square } from 'lucide-react';
 import {
   DndContext,
   closestCenter,
@@ -107,9 +99,6 @@ export const Dock: React.FC = () => {
     moveItemOutOfFolder,
     reorderFolderItems,
     addToast,
-    annotationActive,
-    openAnnotation,
-    closeAnnotation,
     setPendingQuizShareId,
     setPendingAssignmentShareId,
   } = useDashboard();
@@ -485,12 +474,6 @@ export const Dock: React.FC = () => {
   const classesButtonRef = useRef<HTMLButtonElement>(null);
   const remoteButtonRef = useRef<HTMLButtonElement>(null);
   const catalystButtonRef = useRef<HTMLButtonElement>(null);
-  const drawingButtonRef = useRef<HTMLButtonElement>(null);
-  const drawingPopoverRef = useRef<HTMLDivElement>(null);
-  const [showDrawingMenu, setShowDrawingMenu] = useState(false);
-  const [drawingAnchorRect, setDrawingAnchorRect] = useState<DOMRect | null>(
-    null
-  );
   const [showCatalystPicker, setShowCatalystPicker] = useState(false);
   const [catalystAnchorRect, setCatalystAnchorRect] = useState<DOMRect | null>(
     null
@@ -558,30 +541,6 @@ export const Dock: React.FC = () => {
     }
     setShowCatalystPicker((prev) => !prev);
   }, [showCatalystPicker]);
-
-  /**
-   * Draw tool click:
-   *  - If an annotation is already active, clicking Draw is a shortcut to
-   *    close it (toggle-off) without showing the picker.
-   *  - Otherwise, show a small popover so the teacher can explicitly choose
-   *    between full-screen annotation and a windowed whiteboard widget.
-   */
-  const handleToggleDrawingMenu = useCallback(() => {
-    if (annotationActive) {
-      closeAnnotation();
-      setShowDrawingMenu(false);
-      return;
-    }
-    if (!showDrawingMenu && drawingButtonRef.current) {
-      setDrawingAnchorRect(drawingButtonRef.current.getBoundingClientRect());
-    }
-    setShowDrawingMenu((prev) => !prev);
-  }, [annotationActive, closeAnnotation, showDrawingMenu]);
-
-  // Close drawing popover when clicking outside
-  useClickOutside(drawingPopoverRef, () => {
-    if (showDrawingMenu) setShowDrawingMenu(false);
-  }, [drawingButtonRef]);
 
   const handleLongPress = useCallback(() => {
     setIsEditMode(true);
@@ -797,91 +756,6 @@ export const Dock: React.FC = () => {
           onClose={() => setShowCatalystPicker(false)}
         />
       )}
-
-      {showDrawingMenu &&
-        drawingAnchorRect &&
-        createPortal(
-          <GlassCard
-            globalStyle={globalStyle}
-            ref={drawingPopoverRef}
-            style={{
-              position: 'fixed',
-              zIndex: Z_INDEX.popover,
-              ...(dockPosition === 'left'
-                ? {
-                    left: drawingAnchorRect.right + 10,
-                    top: drawingAnchorRect.top + drawingAnchorRect.height / 2,
-                    transform: 'translateY(-50%)',
-                  }
-                : dockPosition === 'right'
-                  ? {
-                      right: window.innerWidth - drawingAnchorRect.left + 10,
-                      top: drawingAnchorRect.top + drawingAnchorRect.height / 2,
-                      transform: 'translateY(-50%)',
-                    }
-                  : {
-                      left:
-                        drawingAnchorRect.left + drawingAnchorRect.width / 2,
-                      bottom: window.innerHeight - drawingAnchorRect.top + 10,
-                      transform: 'translateX(-50%)',
-                    }),
-            }}
-            className={`w-64 overflow-hidden animate-in duration-200 ${
-              dockPosition === 'left'
-                ? 'slide-in-from-left-2'
-                : dockPosition === 'right'
-                  ? 'slide-in-from-right-2'
-                  : 'slide-in-from-bottom-2'
-            }`}
-          >
-            <div className="bg-white/50 px-3 py-2 border-b border-white/30">
-              <span className="text-xxs font-black uppercase text-slate-600 tracking-wider">
-                Draw mode
-              </span>
-            </div>
-            <div className="p-2 space-y-1">
-              <button
-                onClick={() => {
-                  setShowDrawingMenu(false);
-                  openAnnotation();
-                }}
-                className="w-full flex items-start gap-3 p-2.5 hover:bg-white/60 rounded-lg transition-colors text-left"
-              >
-                <div className="shrink-0 w-9 h-9 rounded-lg bg-brand-blue-primary/10 text-brand-blue-primary flex items-center justify-center">
-                  <Maximize className="w-5 h-5" />
-                </div>
-                <div className="min-w-0">
-                  <div className="text-sm font-bold text-slate-800">
-                    Annotate screen
-                  </div>
-                  <div className="text-xxs text-slate-500 leading-tight">
-                    Draw over everything. Ephemeral — closes cleanly.
-                  </div>
-                </div>
-              </button>
-              <button
-                onClick={() => {
-                  setShowDrawingMenu(false);
-                  addWidget('drawing');
-                }}
-                className="w-full flex items-start gap-3 p-2.5 hover:bg-white/60 rounded-lg transition-colors text-left"
-              >
-                <div className="shrink-0 w-9 h-9 rounded-lg bg-cyan-500/10 text-cyan-600 flex items-center justify-center">
-                  <Pencil className="w-5 h-5" />
-                </div>
-                <div className="min-w-0">
-                  <div className="text-sm font-bold text-slate-800">
-                    Open whiteboard
-                  </div>
-                  <div className="text-xxs text-slate-500 leading-tight">
-                    Add a windowed whiteboard widget to your board.
-                  </div>
-                </div>
-              </button>
-            </div>
-          </GlassCard>,
-          document.body
-        )}
 
       {imagePastePending !== null && (
         <ImagePastePickerModal
@@ -1248,42 +1122,6 @@ export const Dock: React.FC = () => {
                                   : undefined
                               }
                               buttonRef={catalystButtonRef}
-                              dockPosition={dockPosition}
-                            />
-                          );
-                        }
-
-                        // Handle "drawing" with a mode-picker popover
-                        // (Annotate screen vs Open whiteboard)
-                        if (item.toolType === 'drawing') {
-                          const minimizedDrawing =
-                            minimizedWidgetsByType['drawing'] ?? [];
-                          return (
-                            <ToolDockItem
-                              key={tool.type}
-                              tool={tool}
-                              minimizedWidgets={minimizedDrawing}
-                              onAdd={handleToggleDrawingMenu}
-                              onRestore={(id) =>
-                                updateWidget(id, { minimized: false })
-                              }
-                              onDelete={(id) => removeWidget(id)}
-                              onDeleteAll={() =>
-                                removeWidgets(minimizedDrawing.map((w) => w.id))
-                              }
-                              onRemoveFromDock={() =>
-                                toggleToolVisibility(tool.type)
-                              }
-                              isEditMode={isEditMode}
-                              onLongPress={handleLongPress}
-                              globalStyle={globalStyle}
-                              customLabel={getToolLabel(tool.type)}
-                              onClickOverride={
-                                minimizedDrawing.length === 0
-                                  ? handleToggleDrawingMenu
-                                  : undefined
-                              }
-                              buttonRef={drawingButtonRef}
                               dockPosition={dockPosition}
                             />
                           );

--- a/components/layout/sidebar/Sidebar.tsx
+++ b/components/layout/sidebar/Sidebar.tsx
@@ -14,6 +14,7 @@ import {
   Minimize,
   ArrowLeft,
   Palette,
+  Pencil,
   Trash2,
   Cloud,
   CloudCheck,
@@ -108,6 +109,9 @@ export const Sidebar: React.FC = () => {
     setGlobalStyle,
     addToast,
     rosters,
+    annotationActive,
+    openAnnotation,
+    closeAnnotation,
   } = useDashboard();
 
   // Mount the PLC listeners once at the Sidebar level and drill the data into
@@ -217,6 +221,25 @@ export const Sidebar: React.FC = () => {
           }
           variant="brand-ghost"
           size="md"
+        />
+
+        <IconButton
+          onClick={() =>
+            annotationActive ? closeAnnotation() : openAnnotation()
+          }
+          icon={<Pencil className="w-5 h-5" />}
+          label={
+            annotationActive
+              ? t('sidebar.header.stopAnnotating')
+              : t('sidebar.header.annotateScreen')
+          }
+          variant="brand-ghost"
+          size="md"
+          className={
+            annotationActive
+              ? '!bg-brand-blue-lighter !text-brand-blue-primary'
+              : ''
+          }
         />
 
         <IconButton

--- a/components/layout/sidebar/Sidebar.tsx
+++ b/components/layout/sidebar/Sidebar.tsx
@@ -33,6 +33,7 @@ import { useAuth } from '@/context/useAuth';
 import { AdminSettings } from '@/components/admin/AdminSettings';
 import { GlassCard } from '@/components/common/GlassCard';
 import { IconButton } from '@/components/common/IconButton';
+import { Z_INDEX } from '@/config/zIndex';
 import { StylePanel } from './StylePanel';
 import { SidebarBoards } from './SidebarBoards';
 import { SidebarBackgrounds } from './SidebarBackgrounds';
@@ -178,10 +179,16 @@ export const Sidebar: React.FC = () => {
       <GlassCard
         globalStyle={activeDashboard?.globalStyle}
         data-screenshot="exclude"
-        className="fixed z-dock flex items-center gap-2 p-2 rounded-full"
+        className="fixed flex items-center gap-2 p-2 rounded-full"
         style={{
           top: 'calc(1.5rem + env(safe-area-inset-top, 0px))',
           left: 'calc(1.5rem + env(safe-area-inset-left, 0px))',
+          // While annotation is active, the AnnotationOverlay's full-viewport
+          // canvas sits at Z_INDEX.overlay with pointer-events-auto, which
+          // would otherwise swallow clicks on this toolbar (specifically the
+          // pencil toggle that's supposed to close annotation). Lift the
+          // toolbar above the overlay so the toggle remains reachable.
+          zIndex: annotationActive ? Z_INDEX.confirmOverlay : Z_INDEX.dock,
         }}
       >
         <IconButton

--- a/components/widgets/DrawingWidget/Settings.tsx
+++ b/components/widgets/DrawingWidget/Settings.tsx
@@ -74,9 +74,9 @@ export const DrawingSettings: React.FC<{ widget: WidgetData }> = ({
 
       <div className="p-4 bg-indigo-50 rounded-2xl border border-indigo-100">
         <p className="text-xxs text-indigo-600 leading-relaxed">
-          <b>Tip:</b> To annotate over your whole dashboard, click the Draw icon
-          in the Dock and choose <b>Annotate screen</b>. The whiteboard widget
-          here is best for persistent sketches and notes.
+          <b>Tip:</b> To annotate over your whole dashboard, click the{' '}
+          <b>pencil</b> in the floating toolbar at the top-left of your board.
+          The whiteboard widget here is best for persistent sketches and notes.
         </p>
       </div>
     </div>

--- a/locales/de.json
+++ b/locales/de.json
@@ -41,6 +41,8 @@
       "adminSettings": "Admin-Einstellungen",
       "enterFullscreen": "Vollbild",
       "exitFullscreen": "Vollbild beenden",
+      "annotateScreen": "Bildschirm annotieren",
+      "stopAnnotating": "Annotation beenden",
       "clearAllWindows": "Alle Fenster schließen",
       "switchBoards": "Tafeln wechseln",
       "hideBoards": "Tafeln ausblenden",

--- a/locales/en.json
+++ b/locales/en.json
@@ -44,6 +44,8 @@
       "adminSettings": "Admin Settings",
       "enterFullscreen": "Enter Fullscreen",
       "exitFullscreen": "Exit Fullscreen",
+      "annotateScreen": "Annotate Screen",
+      "stopAnnotating": "Stop Annotating",
       "clearAllWindows": "Clear All Windows",
       "switchBoards": "Switch Boards",
       "hideBoards": "Hide Boards",

--- a/locales/es.json
+++ b/locales/es.json
@@ -41,6 +41,8 @@
       "adminSettings": "Configuración Admin",
       "enterFullscreen": "Pantalla Completa",
       "exitFullscreen": "Salir de Pantalla Completa",
+      "annotateScreen": "Anotar Pantalla",
+      "stopAnnotating": "Detener Anotación",
       "clearAllWindows": "Cerrar Todas las Ventanas",
       "switchBoards": "Cambiar Tableros",
       "hideBoards": "Ocultar Tableros",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -41,6 +41,8 @@
       "adminSettings": "Paramètres admin",
       "enterFullscreen": "Plein écran",
       "exitFullscreen": "Quitter le plein écran",
+      "annotateScreen": "Annoter l'écran",
+      "stopAnnotating": "Arrêter l'annotation",
       "clearAllWindows": "Fermer toutes les fenêtres",
       "switchBoards": "Changer de tableau",
       "hideBoards": "Masquer les tableaux",


### PR DESCRIPTION
## Summary

Replaces the Dock's two-card "Annotate screen / Open whiteboard" popover with a dedicated Pencil button on the floating sidebar control toolbar (next to the existing Menu / Settings / Fullscreen / Trash cluster).

The Drawing icon in the dock now does what every other tool does: spawn its widget. The folder-bypass bug goes with it. Annotation overlay state on `DashboardContext` (introduced in #1284) is untouched — only the entry point moves.

## Why

- **The popover was a forced two-step on every click**, even when teachers already knew which mode they wanted.
- **It was bypassed entirely from dock folders.** `Dock.tsx`'s `FolderItem.onAdd` had no special-case for `'drawing'` and fell straight through to `addWidget(...)`, so any teacher whose Drawing icon lived inside a folder never saw the picker.
- **The floating sidebar toolbar is the right conceptual home** — its existing icons (menu / fullscreen / clear-all) are dashboard-level actions, and the annotation overlay is also dashboard-level (ephemeral, not a widget). One Pencil there keeps it at four buttons total — still tight, glanceable from any dock layout.
- **Keeps #1284's data-model decoupling.** Drawing widget stays a single-purpose windowed whiteboard. Annotation overlay stays an ephemeral, board-local mode.

## Changes

- `components/layout/sidebar/Sidebar.tsx` — new `Pencil` `IconButton` between Fullscreen and Trash. Toggles `openAnnotation()` / `closeAnnotation()`. Active treatment lifted verbatim from the per-widget annotate active state in `DraggableWindow.tsx:2273-2277`.
- `components/layout/Dock.tsx` — removed `drawingButtonRef`, `drawingPopoverRef`, `showDrawingMenu`, `drawingAnchorRect`, `handleToggleDrawingMenu`, the `useClickOutside` for it, the portal'd popover JSX, and the `if (item.toolType === 'drawing')` special branch. Drawing now uses the default `ToolDockItem` path.
- `locales/{en,de,es,fr}.json` — new `sidebar.header.annotateScreen` / `stopAnnotating` keys.

## Test plan

- [x] `pnpm run type-check`
- [x] `pnpm run lint` (zero warnings)
- [x] `pnpm run format:check`
- [x] `pnpm run test` (1771/1771 passing)
- [ ] Manual: click Pencil in sidebar toolbar → full-screen `AnnotationOverlay` opens, Dock hides, button shows brand-blue active state. Click again → overlay closes, button returns to ghost.
- [ ] Manual: click Drawing icon in dock root → spawns whiteboard widget, no popover.
- [ ] Manual: move Drawing into a dock folder, click it from the folder → also spawns whiteboard directly (folder-bypass bug is now moot).
- [ ] Manual: per-widget Highlighter button (Alt+D) on other widgets still works — separate code path in `DraggableWindow.tsx:2263-2278`.
- [ ] Manual: switch dashboards while annotating — `DashboardContext.tsx:205` auto-clears annotation; verify the toolbar button reflects that (returns to inactive).

## Out of scope

- Admin permission gate for the annotation overlay (no `feature_permissions` row, no `GLOBAL_FEATURES` entry). Discussed but deferred — independent decision about whether admins should be able to disable it.
- Restoring the in-widget "Annotate" button on the DrawingWidget toolbar. The sidebar entry covers the same need without re-coupling the data model.
- The "init error on the main URL when switching to annotation overlay" the user mentioned. Overlay code is defensive (`FALLBACK_ANNOTATION_STATE`, optional chaining); the crash is likely from a downstream call (Drive auth, Gemini OCR, Firestore listener) and surfaces in the overlay incidentally. Needs the actual stack trace before it can be fixed.
- Global keyboard shortcut for `openAnnotation` (e.g., `Alt+A`). Worth adding, but separate.

https://claude.ai/code/session_01SEULV1gc5HmZW6Ww6peMY2

---
_Generated by [Claude Code](https://claude.ai/code/session_01SEULV1gc5HmZW6Ww6peMY2)_