### PR TITLE
docs(tools): document intentionally-excluded WidgetTypes in config/tools.ts

### DIFF
--- a/config/tools.ts
+++ b/config/tools.ts
@@ -51,6 +51,31 @@ import { ToolMetadata } from '../types';
 import { RecordIcon } from '../components/layout/dock/RecordIcon';
 import { First5Icon } from '../components/widgets/First5/First5Icon';
 
+/**
+ * TOOLS is the Dock-facing catalog of user-selectable widgets. It is
+ * intentionally NOT exhaustive over the `WidgetType` union — several
+ * `WidgetType`s are registered in `WIDGET_COMPONENTS`, `widgetDefaults.ts`,
+ * etc., but are deliberately excluded here because they cannot be added
+ * directly from the Dock:
+ *
+ *   - `catalyst-instruction`, `catalyst-visual` — companion sub-widgets
+ *     spawned programmatically by the `catalyst` widget.
+ *   - `blooms-detail` — read-only companion widget spawned by the
+ *     `blooms-taxonomy` widget.
+ *   - `mathTool` — individual math-tool instance spawned by the
+ *     `mathTools` palette (the palette itself IS in the Dock).
+ *   - `custom-widget` — created via the Custom Widget system, surfaced in
+ *     the Dock through `CustomWidgetsContext`, not through this catalog.
+ *   - `onboarding` — one-time system widget that is added automatically
+ *     for new users; never user-selectable.
+ *   - `sticker` — handled via a hard-coded branch in
+ *     `WidgetRenderer.tsx`; spawned by the `stickers` (StickerBook) widget.
+ *
+ * If you add a new `WidgetType` that is meant to be user-selectable, add an
+ * entry below. If it is programmatically spawned, add it to the list above
+ * instead of this array so future maintainers know it was an intentional
+ * omission.
+ */
 export const TOOLS: ToolMetadata[] = [
   {
     type: 'url',

--- a/docs/scheduled-tasks/css-scaling.md
+++ b/docs/scheduled-tasks/css-scaling.md
@@ -3,7 +3,7 @@
 _Audit model: claude-sonnet-4-6_
 _Action model: claude-opus-4-6_
 _Audit cadence: daily_
-_Last audited: 2026-05-01_
+_Last audited: 2026-05-02_
 _Last action: 2026-04-25_
 
 ---

--- a/docs/scheduled-tasks/typescript-eslint.md
+++ b/docs/scheduled-tasks/typescript-eslint.md
@@ -3,7 +3,7 @@
 _Audit model: claude-sonnet-4-6_
 _Action model: claude-opus-4-6_
 _Audit cadence: daily_
-_Last audited: 2026-05-01_
+_Last audited: 2026-05-02_
 _Last action: never_
 
 ---
@@ -16,7 +16,7 @@ _Nothing currently in progress._
 
 ## Open
 
-_No open items. Both `pnpm type-check` and `pnpm lint` pass cleanly as of 2026-04-30. TypeScript: 0 errors. ESLint: 0 errors, 0 warnings (`--max-warnings 0`)._
+_No open items. Both `pnpm type-check` and `pnpm lint` pass cleanly as of 2026-05-02. TypeScript: 0 errors. ESLint: 0 errors, 0 warnings (`--max-warnings 0`)._
 
 ---
 

--- a/docs/scheduled-tasks/widget-registry.md
+++ b/docs/scheduled-tasks/widget-registry.md
@@ -3,7 +3,7 @@
 _Audit model: claude-sonnet-4-6_
 _Action model: claude-opus-4-6_
 _Audit cadence: daily_
-_Last audited: 2026-05-01_
+_Last audited: 2026-05-02_
 _Last action: 2026-04-26_
 
 ---

--- a/docs/scheduled-tasks/widget-registry.md
+++ b/docs/scheduled-tasks/widget-registry.md
@@ -4,7 +4,7 @@ _Audit model: claude-sonnet-4-6_
 _Action model: claude-opus-4-6_
 _Audit cadence: daily_
 _Last audited: 2026-05-02_
-_Last action: 2026-04-26_
+_Last action: 2026-05-02_
 
 ---
 
@@ -16,33 +16,12 @@ _Nothing currently in progress._
 
 ## Open
 
-### LOW `catalyst-instruction`, `catalyst-visual` absent from config/tools.ts
-
-- **Detected:** 2026-04-12
-- **File:** config/tools.ts, types.ts
-- **Detail:** Both sub-types are in the WidgetType union, are registered in WIDGET_COMPONENTS and WIDGET_SETTINGS_COMPONENTS, and have entries in widgetDefaults.ts. They are intentionally absent from config/tools.ts because they are programmatically spawned by the Catalyst widget, not user-selectable from the Dock. However, this is undocumented — a developer adding a new sub-widget type could mistakenly conclude they need a tools.ts entry.
-- **Fix:** Add a comment in config/tools.ts near the catalyst entry noting that `catalyst-instruction` and `catalyst-visual` are intentionally omitted because they are spawned programmatically.
-
-### LOW `mathTool`, `onboarding`, `custom-widget` absent from config/tools.ts
-
-- **Detected:** 2026-04-12
-- **File:** config/tools.ts, types.ts
-- **Detail:** These three WidgetTypes are fully registered in all other locations (WIDGET_COMPONENTS, widgetDefaults.ts, widgetGradeLevels.ts) but are absent from config/tools.ts because they cannot be directly added from the Dock. `mathTool` is spawned by mathTools, `onboarding` is a one-time system widget, `custom-widget` is created via the Custom Widget system. This is intentional but undocumented.
-- **Fix:** Add a comment block in config/tools.ts documenting which WidgetTypes are intentionally excluded from the dock and why.
-
 ### LOW `stickers` missing from `WIDGET_SETTINGS_COMPONENTS`
 
 - **Detected:** 2026-04-14
 - **File:** components/widgets/WidgetRegistry.ts
 - **Detail:** `stickers` (StickerBook) has entries in `WIDGET_COMPONENTS`, `WIDGET_APPEARANCE_COMPONENTS`, `WIDGET_SCALING_CONFIG`, `widgetDefaults.ts`, `widgetGradeLevels.ts`, and `tools.ts`, but is absent from `WIDGET_SETTINGS_COMPONENTS`. `stickers/StickerBookSettings.tsx` exports `StickerBookAppearanceSettings` (wired into appearance panel), but there is no flip-panel settings component registered. As a result flipping the stickers widget shows no settings tab — only the appearance tab. May be intentional if stickers has no non-appearance settings, but is undocumented.
 - **Fix:** Either (a) confirm this is intentional and add a JSDoc comment in `WIDGET_SETTINGS_COMPONENTS` noting stickers has appearance-only settings, or (b) create a `StickerBookSettings` component and register it if any non-appearance settings (e.g. lock/reset) are desired.
-
-### LOW `blooms-detail` absent from `config/tools.ts`
-
-- **Detected:** 2026-05-01
-- **File:** config/tools.ts, types.ts
-- **Detail:** `blooms-detail` is in the WidgetType union, registered in `WIDGET_COMPONENTS`, `WIDGET_SCALING_CONFIG`, `widgetDefaults.ts`, and `widgetGradeLevels.ts`, but is absent from `config/tools.ts`. As a programmatically-spawned companion widget (opened by the `blooms-taxonomy` widget), this is likely intentional — but it is not documented anywhere in the file. The two existing LOW items about `catalyst-instruction`/`catalyst-visual` and `mathTool`/`onboarding`/`custom-widget` propose a comment block documenting intentionally excluded types; `blooms-detail` should be included in that block.
-- **Fix:** When addressing the "Add a comment block documenting which WidgetTypes are intentionally excluded" fix in the items above, also add `blooms-detail` to the list with the note that it is a read-only companion widget spawned by `blooms-taxonomy`.
 
 ### LOW `blooms-detail` missing from `WIDGET_SETTINGS_COMPONENTS`
 
@@ -54,6 +33,14 @@ _Nothing currently in progress._
 ---
 
 ## Completed
+
+### LOW `config/tools.ts` lacks documentation of intentionally-excluded `WidgetType`s
+
+- **Detected:** 2026-04-12 (catalyst sub-types), 2026-04-12 (mathTool/onboarding/custom-widget), 2026-05-01 (blooms-detail)
+- **Completed:** 2026-05-02
+- **File:** config/tools.ts
+- **Detail:** Six `WidgetType`s are fully registered elsewhere (WIDGET_COMPONENTS, widgetDefaults.ts, widgetGradeLevels.ts) but intentionally absent from `config/tools.ts` because they are not user-selectable from the Dock: `catalyst-instruction` and `catalyst-visual` (spawned by `catalyst`), `blooms-detail` (spawned by `blooms-taxonomy`), `mathTool` (spawned by the `mathTools` palette), `custom-widget` (created via Custom Widget system), and `onboarding` (one-time system widget). Each omission was deliberate but undocumented — a developer adding a new sub-widget could mistakenly conclude they needed a tools.ts entry.
+- **Resolution:** Added a JSDoc block above the `TOOLS` export in `config/tools.ts` explaining that the catalog is intentionally not exhaustive over `WidgetType` and listing each excluded type with the reason it is excluded. Also referenced `sticker`, which is handled via the `WidgetRenderer` special-case branch (already documented in the prior `WIDGET_COMPONENTS` comment, surfaced here for completeness). Documentation-only change — no behavioral impact. `pnpm type-check`, `pnpm exec eslint config/tools.ts --max-warnings 0`, and `pnpm exec prettier --check config/tools.ts` all clean.
 
 ### LOW `sticker` widget bypasses WIDGET_COMPONENTS via WidgetRenderer special-case
 


### PR DESCRIPTION
## Summary

- Adds a JSDoc block above the `TOOLS` export in `config/tools.ts` explaining that the catalog is intentionally not exhaustive over `WidgetType`.
- Documents the seven types deliberately omitted from the Dock catalog (`catalyst-instruction`, `catalyst-visual`, `blooms-detail`, `mathTool`, `custom-widget`, `onboarding`, `sticker`) and why each is excluded.
- Closes three related LOW items in `docs/scheduled-tasks/widget-registry.md` (collapsed into a single Completed entry).

Documentation-only change — no behavioral impact.

## Test plan

- [x] `pnpm type-check` clean
- [x] `pnpm exec eslint config/tools.ts --max-warnings 0` clean
- [x] `pnpm exec prettier --check config/tools.ts docs/scheduled-tasks/widget-registry.md` clean

https://claude.ai/code/session_01Q9qmn2WranuxbmxJzGuhRf

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q9qmn2WranuxbmxJzGuhRf)_