### PR TITLE
fix(miniapp): hide running-mode toolbar when widget unselected

### DIFF
--- a/components/widgets/MiniApp/Widget.tsx
+++ b/components/widgets/MiniApp/Widget.tsx
@@ -281,7 +281,8 @@ export const MiniAppWidget: React.FC<WidgetComponentProps> = ({
   widget,
   isStudentView,
 }) => {
-  const { updateWidget, addToast, rosters, addWidget } = useDashboard();
+  const { updateWidget, addToast, rosters, addWidget, selectedWidgetId } =
+    useDashboard();
   const { user, getAssignmentMode } = useAuth();
   const assignmentMode: AssignmentMode = getAssignmentMode('miniApp');
   const { showConfirm } = useDialog();
@@ -995,6 +996,10 @@ export const MiniAppWidget: React.FC<WidgetComponentProps> = ({
               widgetRect &&
               !widget.minimized &&
               !widget.flipped &&
+              // Mirror the DraggableWindow chrome: only show the floating
+              // toolbar while this widget is the selected one. Avoids leaving
+              // an orphaned action bar floating below an unfocused widget.
+              selectedWidgetId === widget.id &&
               // The toolbar lives at Z_INDEX.popover (11000), which is above
               // the running-mode modals (z-overlay = 9910). Hide it whenever
               // one of those modals is open so it doesn't float on top of the


### PR DESCRIPTION
## Summary
- The MiniApp running-mode floating toolbar (Assign / QR Share / Save as Widget / Library) was rendering below the widget regardless of selection state, leaving an orphaned action bar floating beneath unfocused widgets.
- Mirror the `DraggableWindow` chrome's selection gating: pull `selectedWidgetId` from `DashboardContext` and add `selectedWidgetId === widget.id` to the existing portal render conditional.

## Test plan
- [x] `pnpm run type-check` clean
- [x] `pnpm exec eslint components/widgets/MiniApp/Widget.tsx --max-warnings 0` clean
- [x] `pnpm exec prettier --check components/widgets/MiniApp/Widget.tsx` clean
- [x] Verified in dev preview: toolbar visible when MiniApp widget is selected, removed when dashboard background clicked, returns when widget reselected

🤖 Generated with [Claude Code](https://claude.com/claude-code)