### PR TITLE
Synced PLC quiz: clickable Sync badge + silence admin listener errors

### DIFF
--- a/components/common/library/LibraryItemCard.tsx
+++ b/components/common/library/LibraryItemCard.tsx
@@ -37,24 +37,37 @@ import type {
 
 const BADGE_TONE_STYLES: Record<
   LibraryBadgeTone,
-  { bg: string; fg: string; dot: string }
+  { bg: string; fg: string; dot: string; hoverBg: string }
 > = {
-  neutral: { bg: 'bg-slate-100', fg: 'text-slate-600', dot: 'bg-slate-400' },
+  neutral: {
+    bg: 'bg-slate-100',
+    fg: 'text-slate-600',
+    dot: 'bg-slate-400',
+    hoverBg: 'hover:bg-slate-200',
+  },
   info: {
     bg: 'bg-brand-blue-lighter/40',
     fg: 'text-brand-blue-dark',
     dot: 'bg-brand-blue-primary',
+    hoverBg: 'hover:bg-brand-blue-lighter/60',
   },
-  warn: { bg: 'bg-amber-100', fg: 'text-amber-700', dot: 'bg-amber-500' },
+  warn: {
+    bg: 'bg-amber-100',
+    fg: 'text-amber-700',
+    dot: 'bg-amber-500',
+    hoverBg: 'hover:bg-amber-200',
+  },
   success: {
     bg: 'bg-emerald-100',
     fg: 'text-emerald-700',
     dot: 'bg-emerald-500',
+    hoverBg: 'hover:bg-emerald-200',
   },
   danger: {
     bg: 'bg-brand-red-lighter/40',
     fg: 'text-brand-red-dark',
     dot: 'bg-brand-red-primary',
+    hoverBg: 'hover:bg-brand-red-lighter/60',
   },
 };
 
@@ -231,19 +244,41 @@ const IconActionButton: React.FC<{ action: LibraryIconAction }> = ({
 
 const BadgeChip: React.FC<{ badge: LibraryBadge }> = ({ badge }) => {
   const tone = BADGE_TONE_STYLES[badge.tone];
-  return (
-    <span
-      className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[11px] font-bold uppercase tracking-wider ${tone.bg} ${tone.fg}`}
-    >
+  const Icon = badge.icon;
+  const baseClasses = `inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[11px] font-bold uppercase tracking-wider ${tone.bg} ${tone.fg}`;
+  const inner = (
+    <>
       {badge.dot && (
         <span
           className={`h-1.5 w-1.5 shrink-0 rounded-full ${tone.dot}`}
           aria-hidden="true"
         />
       )}
+      {Icon && <Icon size={12} className="shrink-0" />}
       {badge.label}
-    </span>
+    </>
   );
+
+  if (badge.onClick) {
+    const handler = badge.onClick;
+    const accessibleLabel = badge.actionLabel ?? badge.label;
+    return (
+      <button
+        type="button"
+        onClick={(e) => {
+          e.stopPropagation();
+          handler();
+        }}
+        title={accessibleLabel}
+        aria-label={accessibleLabel}
+        className={`${baseClasses} ${tone.hoverBg} cursor-pointer transition-colors active:scale-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-current focus-visible:ring-offset-1`}
+      >
+        {inner}
+      </button>
+    );
+  }
+
+  return <span className={baseClasses}>{inner}</span>;
 };
 
 /* ─── Inner card body (presentation only — no dnd-kit coupling) ───────────── */

--- a/components/common/library/LibraryItemCard.tsx
+++ b/components/common/library/LibraryItemCard.tsx
@@ -245,16 +245,37 @@ const IconActionButton: React.FC<{ action: LibraryIconAction }> = ({
 const BadgeChip: React.FC<{ badge: LibraryBadge }> = ({ badge }) => {
   const tone = BADGE_TONE_STYLES[badge.tone];
   const Icon = badge.icon;
-  const baseClasses = `inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[11px] font-bold uppercase tracking-wider ${tone.bg} ${tone.fg}`;
+  // Container-query units cap at the original pixel sizes so badges look
+  // identical on default-size widgets but scale down with the rest of the
+  // card chrome (kebab button, icon-action buttons) on smaller widgets.
+  const baseClasses = `inline-flex items-center rounded-full font-bold uppercase tracking-wider ${tone.bg} ${tone.fg}`;
+  const baseStyle: React.CSSProperties = {
+    fontSize: 'min(11px, 4cqmin)',
+    paddingInline: 'min(8px, 2.5cqmin)',
+    paddingBlock: 'min(2px, 0.6cqmin)',
+    gap: 'min(4px, 1.2cqmin)',
+  };
   const inner = (
     <>
       {badge.dot && (
         <span
-          className={`h-1.5 w-1.5 shrink-0 rounded-full ${tone.dot}`}
+          className={`shrink-0 rounded-full ${tone.dot}`}
+          style={{
+            width: 'min(6px, 1.8cqmin)',
+            height: 'min(6px, 1.8cqmin)',
+          }}
           aria-hidden="true"
         />
       )}
-      {Icon && <Icon size={12} className="shrink-0" />}
+      {Icon && (
+        <Icon
+          className="shrink-0"
+          style={{
+            width: 'min(12px, 4cqmin)',
+            height: 'min(12px, 4cqmin)',
+          }}
+        />
+      )}
       {badge.label}
     </>
   );
@@ -272,13 +293,18 @@ const BadgeChip: React.FC<{ badge: LibraryBadge }> = ({ badge }) => {
         title={accessibleLabel}
         aria-label={accessibleLabel}
         className={`${baseClasses} ${tone.hoverBg} cursor-pointer transition-colors active:scale-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-current focus-visible:ring-offset-1`}
+        style={baseStyle}
       >
         {inner}
       </button>
     );
   }
 
-  return <span className={baseClasses}>{inner}</span>;
+  return (
+    <span className={baseClasses} style={baseStyle}>
+      {inner}
+    </span>
+  );
 };
 
 /* ─── Inner card body (presentation only — no dnd-kit coupling) ───────────── */

--- a/components/common/library/types.ts
+++ b/components/common/library/types.ts
@@ -111,6 +111,25 @@ export interface LibraryBadge {
   tone: LibraryBadgeTone;
   /** Optional dot indicator (used for live/paused pulses on archive cards). */
   dot?: boolean;
+  /**
+   * When set, the badge renders as an interactive button (with hover/focus
+   * states and ARIA) that triggers this on click. Click propagation is
+   * stopped so the card body's `onClick` doesn't also fire. Omit for
+   * purely informational badges (the default).
+   */
+  onClick?: () => void;
+  /**
+   * Accessible name + tooltip when the badge is actionable. Required when
+   * `onClick` is set so screen readers get a verb-phrase ("Sync now")
+   * rather than the status label ("Sync available").
+   */
+  actionLabel?: string;
+  /** Optional leading icon (e.g. RefreshCw for "Sync available"). */
+  icon?: React.ComponentType<{
+    size?: number;
+    className?: string;
+    style?: React.CSSProperties;
+  }>;
 }
 
 /** A sort option surfaced in the toolbar sort dropdown. */

--- a/components/widgets/QuizWidget/components/QuizManager.tsx
+++ b/components/widgets/QuizWidget/components/QuizManager.tsx
@@ -724,7 +724,21 @@ export const QuizManager: React.FC<QuizManagerProps> = ({
     if (!quiz.sync) return [];
     const group = syncedGroups?.get(quiz.sync.groupId);
     if (group && group.version > quiz.sync.lastSyncedVersion) {
-      return [{ label: 'Sync available', tone: 'warn' as const, dot: true }];
+      // Actionable badge: click pulls the canonical content into the local
+      // Drive replica. The kebab menu still surfaces a redundant "Sync
+      // available" item so keyboard / power users have a familiar path.
+      return [
+        {
+          label: 'Sync available',
+          tone: 'warn' as const,
+          dot: true,
+          icon: RefreshCw,
+          actionLabel: 'Sync now',
+          ...(onPullSyncedQuiz
+            ? { onClick: () => void onPullSyncedQuiz(quiz) }
+            : {}),
+        },
+      ];
     }
     return [{ label: 'Synced', tone: 'info' as const }];
   };

--- a/context/AuthContext.tsx
+++ b/context/AuthContext.tsx
@@ -529,11 +529,19 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
     }
   }, [googleAccessToken]);
 
-  // Listen to user roles
+  // Listen to user roles + app settings.
+  //
+  // Both docs live under `/admin_settings/*`, which Firestore rules restrict
+  // to admins (firestore.rules: `match /admin_settings/{document=**}` requires
+  // isAdmin()). Subscribing for non-admins fired permission-denied errors on
+  // every page load. Gate on `isAdmin === true` so the listeners only attach
+  // once admin status has resolved positively; for `null` (loading) and
+  // `false` (non-admin) we clear any stale config and stay quiet.
   useEffect(() => {
     if (isAuthBypass) return;
-    if (!user) {
+    if (!user || isAdmin !== true) {
       setUserRoles(null);
+      setAppSettings(null);
       return;
     }
 
@@ -569,7 +577,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
       unsubscribe();
       appSettingsUnsubscribe();
     };
-  }, [user]);
+  }, [user, isAdmin]);
 
   // Check if user is admin
   useEffect(() => {

--- a/context/AuthContext.tsx
+++ b/context/AuthContext.tsx
@@ -583,11 +583,14 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
   useEffect(() => {
     if (isAuthBypass) return;
 
+    // Reset to the loading state immediately when the user changes so the
+    // settings listener effect (gated on isAdmin === true) doesn't act on
+    // stale admin status from a previous user during a sign-out → sign-in
+    // transition while AuthContext stays mounted.
+    setIsAdmin(null);
+
     const checkAdminStatus = async () => {
-      if (!user?.email) {
-        setIsAdmin(null);
-        return;
-      }
+      if (!user?.email) return;
 
       try {
         const adminDoc = await getDoc(


### PR DESCRIPTION
## Summary

Two issues from testing the synced PLC quiz workflow:

- **\"Sync available\" badge looked like a button but wasn't.** Clicking it opened the editor (the row's onClick); the actual sync action was buried in the kebab menu. Now the amber pill is the button — one tap syncs. Hover/focus states, RefreshCw icon, ARIA, stopPropagation. Kebab item kept as a redundant path.
- **Two console errors on every page load** for non-admins: `Error loading user roles` / `Error loading app settings`. AuthContext was attaching `onSnapshot` listeners to `/admin_settings/*` for any signed-in user, but firestore.rules restricts those docs to admins. Gated the effect on `isAdmin === true`.

The two changes are in separate commits so they can be reverted independently if needed.

## Test plan

- [ ] On a stale synced PLC quiz, click the amber \"Sync available\" pill — confirm it syncs (toast appears) and does NOT open the editor.
- [ ] Hover the pill — confirm darker amber bg and cursor change.
- [ ] Tab to the pill — confirm visible focus ring; press Enter/Space — confirm it syncs.
- [ ] Click anywhere else on the row — confirm editor still opens.
- [ ] Open the kebab menu — confirm \"Sync available\" item still works as a redundant path.
- [ ] Sign in as a non-admin (or with an account not in `/admins/{email}`) — confirm \"Error loading user roles\" / \"Error loading app settings\" are gone from the console.
- [ ] Sign in as an admin — confirm any admin UI that consumes `userRoles` / `appSettings` still populates correctly (Global Permissions Manager, Organization panel).
- [ ] Regression: confirm the inert `Synced` (info) pill, archive status pills (`Live`, `Paused`, `Closed`, `Shared`) still render as plain `<span>` with no hover/focus/cursor change.

## Notes

The originally-reported \"quiz library doesn't update until refresh after sync\" issue was not addressed in code here — without a stale synced quiz to repro in preview, my best hypothesis is normal Firestore write→listener latency masquerading as \"didn't update\". Try the new badge button on your end; if the badge still feels stuck after the toast appears, I'll add an optimistic \"Syncing…\" state in a follow-up.

Two Haiku reviewer agents reviewed both changes — green light, 0 blockers, 0 high. Two minor forward-looking suggestions (per-tone explicit focus rings if we ever add clickable info/danger badges, `user?.uid` instead of `user` in deps) were not acted on; both are micro-optimizations and the current code is functionally correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)