### PR TITLE
Synced PLC quiz: show "Syncing…" pill while pull is in flight

### DIFF
--- a/components/common/library/LibraryItemCard.tsx
+++ b/components/common/library/LibraryItemCard.tsx
@@ -280,19 +280,32 @@ const BadgeChip: React.FC<{ badge: LibraryBadge }> = ({ badge }) => {
     </>
   );
 
-  if (badge.onClick) {
+  // Render as a <button> when there's an action attached OR when the badge
+  // is explicitly disabled (transient inert state like "Syncing…"). The
+  // disabled-button path matters: browsers swallow user clicks on disabled
+  // buttons, so the click doesn't bubble to the card body's onClick — a
+  // plain <span> would, and would open the editor mid-sync.
+  if (badge.onClick || badge.disabled) {
     const handler = badge.onClick;
     const accessibleLabel = badge.actionLabel ?? badge.label;
+    const interactiveClasses = badge.disabled
+      ? 'cursor-default'
+      : `${tone.hoverBg} cursor-pointer transition-colors active:scale-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-current focus-visible:ring-offset-1`;
     return (
       <button
         type="button"
-        onClick={(e) => {
-          e.stopPropagation();
-          handler();
-        }}
+        disabled={badge.disabled}
+        onClick={
+          handler
+            ? (e) => {
+                e.stopPropagation();
+                handler();
+              }
+            : undefined
+        }
         title={accessibleLabel}
         aria-label={accessibleLabel}
-        className={`${baseClasses} ${tone.hoverBg} cursor-pointer transition-colors active:scale-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-current focus-visible:ring-offset-1`}
+        className={`${baseClasses} ${interactiveClasses}`}
         style={baseStyle}
       >
         {inner}

--- a/components/common/library/types.ts
+++ b/components/common/library/types.ts
@@ -130,6 +130,15 @@ export interface LibraryBadge {
     className?: string;
     style?: React.CSSProperties;
   }>;
+  /**
+   * When true, renders as a disabled <button> (no hover state, no cursor
+   * change, browser-suppresses user clicks). Useful for transient
+   * non-actionable states (e.g., "Syncing…") that displace an actionable
+   * badge — a plain <span> would bubble up to the card body's onClick
+   * (which only short-circuits on button/a/[role=menu]) and open the
+   * editor.
+   */
+  disabled?: boolean;
 }
 
 /** A sort option surfaced in the toolbar sort dropdown. */

--- a/components/widgets/QuizWidget/components/QuizManager.tsx
+++ b/components/widgets/QuizWidget/components/QuizManager.tsx
@@ -495,7 +495,7 @@ export const QuizManager: React.FC<QuizManagerProps> = ({
   // truth for read-back in the handler; the state copy drives re-renders.
   const inFlightSyncRef = useRef<Set<string>>(new Set());
   const [syncingQuizIds, setSyncingQuizIds] = useState<ReadonlySet<string>>(
-    () => new Set()
+    new Set()
   );
 
   const handlePullSync = useCallback(
@@ -765,15 +765,18 @@ export const QuizManager: React.FC<QuizManagerProps> = ({
   const buildQuizBadges = (quiz: QuizMetadata) => {
     if (!quiz.sync) return [];
 
-    // While a pull is in flight, show a non-clickable "Syncing…" pill with
-    // a spinning icon. Wins over the "Sync available" pill so the user
-    // can't double-tap, and gives instant feedback that the click landed.
+    // While a pull is in flight, show a disabled "Syncing…" pill with a
+    // spinning icon. `disabled: true` makes BadgeChip render as a
+    // <button disabled> — the browser swallows user clicks so the event
+    // doesn't bubble to the card body and accidentally open the editor
+    // (which a plain <span> would let happen).
     if (syncingQuizIds.has(quiz.id)) {
       return [
         {
           label: 'Syncing…',
           tone: 'info' as const,
           icon: SpinningRefreshIcon,
+          disabled: true,
         },
       ];
     }

--- a/components/widgets/QuizWidget/components/QuizManager.tsx
+++ b/components/widgets/QuizWidget/components/QuizManager.tsx
@@ -16,7 +16,7 @@
  * only, not functionality.
  */
 
-import React, { useCallback, useMemo, useState } from 'react';
+import React, { useCallback, useMemo, useRef, useState } from 'react';
 import {
   Plus,
   FileUp,
@@ -409,6 +409,19 @@ const SORT_COMPARATORS: Record<
   },
 };
 
+/**
+ * RefreshCw with `animate-spin` baked in. Used as the badge icon while a
+ * synced-quiz pull is in flight so the user gets immediate visual feedback
+ * even before the Firestore listener delivers the bumped version.
+ */
+const SpinningRefreshIcon: React.ComponentType<{
+  size?: number;
+  className?: string;
+  style?: React.CSSProperties;
+}> = ({ className, ...rest }) => (
+  <RefreshCw {...rest} className={`${className ?? ''} animate-spin`.trim()} />
+);
+
 /* ─── Main component ──────────────────────────────────────────────────────── */
 
 export const QuizManager: React.FC<QuizManagerProps> = ({
@@ -473,6 +486,33 @@ export const QuizManager: React.FC<QuizManagerProps> = ({
     null
   );
   const [isCreatingViewOnlyShare, setIsCreatingViewOnlyShare] = useState(false);
+
+  // ─── Synced-quiz pull in-flight tracking ──────────────────────────────────
+  // The "Sync available" pill flips to a "Syncing…" pill the instant a pull
+  // starts so the user gets immediate feedback before the Firestore listener
+  // delivers the bumped version (which can lag a beat on slow connections,
+  // making the click feel like nothing happened). The ref is the source of
+  // truth for read-back in the handler; the state copy drives re-renders.
+  const inFlightSyncRef = useRef<Set<string>>(new Set());
+  const [syncingQuizIds, setSyncingQuizIds] = useState<ReadonlySet<string>>(
+    () => new Set()
+  );
+
+  const handlePullSync = useCallback(
+    async (quiz: QuizMetadata) => {
+      if (!onPullSyncedQuiz) return;
+      if (inFlightSyncRef.current.has(quiz.id)) return;
+      inFlightSyncRef.current.add(quiz.id);
+      setSyncingQuizIds(new Set(inFlightSyncRef.current));
+      try {
+        await onPullSyncedQuiz(quiz);
+      } finally {
+        inFlightSyncRef.current.delete(quiz.id);
+        setSyncingQuizIds(new Set(inFlightSyncRef.current));
+      }
+    },
+    [onPullSyncedQuiz]
+  );
 
   const openShareOrAssign = useCallback(
     (quiz: QuizMetadata) => {
@@ -663,11 +703,13 @@ export const QuizManager: React.FC<QuizManagerProps> = ({
       },
     ];
     if (isStale && onPullSyncedQuiz) {
+      const isSyncing = syncingQuizIds.has(quiz.id);
       actions.push({
         id: 'sync-now',
-        label: 'Sync available',
-        icon: RefreshCw,
-        onClick: () => void onPullSyncedQuiz(quiz),
+        label: isSyncing ? 'Syncing…' : 'Sync available',
+        icon: isSyncing ? SpinningRefreshIcon : RefreshCw,
+        disabled: isSyncing,
+        onClick: () => void handlePullSync(quiz),
       });
     }
     if (quiz.sync && onDetachSyncedQuiz) {
@@ -722,6 +764,20 @@ export const QuizManager: React.FC<QuizManagerProps> = ({
    */
   const buildQuizBadges = (quiz: QuizMetadata) => {
     if (!quiz.sync) return [];
+
+    // While a pull is in flight, show a non-clickable "Syncing…" pill with
+    // a spinning icon. Wins over the "Sync available" pill so the user
+    // can't double-tap, and gives instant feedback that the click landed.
+    if (syncingQuizIds.has(quiz.id)) {
+      return [
+        {
+          label: 'Syncing…',
+          tone: 'info' as const,
+          icon: SpinningRefreshIcon,
+        },
+      ];
+    }
+
     const group = syncedGroups?.get(quiz.sync.groupId);
     if (group && group.version > quiz.sync.lastSyncedVersion) {
       // Actionable badge: click pulls the canonical content into the local
@@ -735,7 +791,7 @@ export const QuizManager: React.FC<QuizManagerProps> = ({
           icon: RefreshCw,
           actionLabel: 'Sync now',
           ...(onPullSyncedQuiz
-            ? { onClick: () => void onPullSyncedQuiz(quiz) }
+            ? { onClick: () => void handlePullSync(quiz) }
             : {}),
         },
       ];


### PR DESCRIPTION
## Summary

Follow-up to [#1494](https://github.com/OPS-PIvers/SpartBoard/pull/1494). The amber \"Sync available\" pill now flips to a non-clickable \"Syncing…\" pill with a spinning icon the instant a pull starts, so the user gets immediate feedback even if the Firestore listener takes a beat to deliver the bumped version. Prevents double-tap and removes the \"did anything happen?\" feeling on slow connections.

The kebab \"Sync available\" item gets the same treatment — labeled \"Syncing…\", icon switched to spinning, and disabled while in flight.

## Implementation notes

- A `useRef<Set<string>>` is the source of truth for in-flight ids (synchronous read-back in the handler avoids stale-closure pitfalls).
- A `useState` copy of that set drives re-renders.
- State clears in a `finally` block, so a thrown pull doesn't strand the badge in \"Syncing…\" forever.
- `SpinningRefreshIcon` is defined at module scope (not recreated per render); it's just `RefreshCw` with `animate-spin` baked in.

## Test plan

- [ ] On a stale synced PLC quiz, click the amber \"Sync available\" pill — confirm it immediately flips to a blue \"Syncing…\" pill with a spinning refresh icon, and the click-during-flight does nothing (pill is non-clickable).
- [ ] After the pull resolves, confirm the pill transitions to the inert \"Synced\" state (no spinner).
- [ ] Repeat from the kebab menu — confirm the menu item is labeled \"Syncing…\" and disabled while in flight.
- [ ] Force a failure (e.g., toggle network off mid-pull) — confirm the badge returns to \"Sync available\" and is clickable again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)