### PR TITLE
feat(url-widget): overhaul UI — shape, image background, tighter sizing

### DIFF
--- a/components/common/DraggableWindow.tsx
+++ b/components/common/DraggableWindow.tsx
@@ -73,6 +73,19 @@ const POSITION_AWARE_WIDGETS: WidgetType[] = [
   'catalyst-visual',
 ];
 
+// Default min size all widgets shrink to during resize.
+const DEFAULT_MIN_W = 150;
+const DEFAULT_MIN_H = 100;
+
+// Per-widget overrides — used for widget types that intentionally need to
+// shrink smaller than the default floor (e.g. URL bookmarks meant to feel
+// like a floating icon on the board).
+const WIDGET_MIN_SIZE_OVERRIDES: Partial<
+  Record<WidgetType, { w: number; h: number }>
+> = {
+  url: { w: 80, h: 80 },
+};
+
 const INTERACTIVE_ELEMENTS_SELECTOR =
   'button, input, textarea, select, canvas, iframe, label, a, summary, [role="button"], [role="tab"], [role="menuitem"], [role="checkbox"], [role="switch"], .cursor-pointer, [contenteditable="true"]';
 
@@ -1055,6 +1068,8 @@ export const DraggableWindow: React.FC<DraggableWindowProps> = ({
     const startY = e.clientY;
     const startPosX = widget.x;
     const startPosY = widget.y;
+    const minW = WIDGET_MIN_SIZE_OVERRIDES[widget.type]?.w ?? DEFAULT_MIN_W;
+    const minH = WIDGET_MIN_SIZE_OVERRIDES[widget.type]?.h ?? DEFAULT_MIN_H;
 
     const targetElement = e.currentTarget as HTMLElement;
     try {
@@ -1082,21 +1097,21 @@ export const DraggableWindow: React.FC<DraggableWindowProps> = ({
         let newY = startPosY;
 
         if (direction.includes('e')) {
-          newW = Math.max(150, startW + dx);
+          newW = Math.max(minW, startW + dx);
         }
         if (direction.includes('w')) {
           const potentialW = startW - dx;
-          if (potentialW >= 150) {
+          if (potentialW >= minW) {
             newW = potentialW;
             newX = startPosX + dx;
           }
         }
         if (direction.includes('s')) {
-          newH = Math.max(100, startH + dy);
+          newH = Math.max(minH, startH + dy);
         }
         if (direction.includes('n')) {
           const potentialH = startH - dy;
-          if (potentialH >= 100) {
+          if (potentialH >= minH) {
             newH = potentialH;
             newY = startPosY + dy;
           }
@@ -1124,8 +1139,8 @@ export const DraggableWindow: React.FC<DraggableWindowProps> = ({
         const wb = getWorldBounds(vw, vh);
         const availableW = Math.max(0, wb.maxX - newX);
         const availableH = Math.max(0, wb.maxY - newY);
-        newW = Math.max(Math.min(150, availableW), Math.min(newW, availableW));
-        newH = Math.max(Math.min(100, availableH), Math.min(newH, availableH));
+        newW = Math.max(Math.min(minW, availableW), Math.min(newW, availableW));
+        newH = Math.max(Math.min(minH, availableH), Math.min(newH, availableH));
 
         // OPTIMIZATION: If widget is not position-aware, update DOM directly and skip React render cycle
         if (

--- a/components/layout/Dock.tsx
+++ b/components/layout/Dock.tsx
@@ -823,6 +823,8 @@ export const Dock: React.FC = () => {
                       title: selection.title,
                       icon: selection.icon,
                       color: selection.color,
+                      shape: selection.shape,
+                      imageUrl: selection.imageUrl,
                     },
                   ],
                 },

--- a/components/layout/dock/UrlPickerModal.tsx
+++ b/components/layout/dock/UrlPickerModal.tsx
@@ -3,13 +3,18 @@ import { Link, QrCode, X, ArrowLeft, Check } from 'lucide-react';
 import { GlassCard } from '@/components/common/GlassCard';
 import { Modal } from '@/components/common/Modal';
 import { GlobalStyle } from '@/types';
+import { isSafeIconUrl } from '@/components/widgets/Catalyst/catalystHelpers';
 import {
   URL_ICONS,
-  URL_COLORS,
   DEFAULT_URL_ICON_ID,
   DEFAULT_URL_COLOR,
   getUrlIcon,
 } from '@/components/widgets/UrlWidget/icons';
+import { LinkBackgroundInput } from '@/components/widgets/UrlWidget/LinkBackgroundInput';
+import {
+  LinkShapePicker,
+  type LinkShape,
+} from '@/components/widgets/UrlWidget/LinkShapePicker';
 
 export type UrlPickerSelection =
   | { type: 'qr' }
@@ -18,6 +23,8 @@ export type UrlPickerSelection =
       title?: string;
       icon: string;
       color: string;
+      shape: LinkShape;
+      imageUrl?: string;
     };
 
 interface UrlPickerModalProps {
@@ -39,6 +46,8 @@ export const UrlPickerModal: React.FC<UrlPickerModalProps> = ({
   const [title, setTitle] = useState('');
   const [iconId, setIconId] = useState(DEFAULT_URL_ICON_ID);
   const [color, setColor] = useState(DEFAULT_URL_COLOR);
+  const [shape, setShape] = useState<LinkShape>('rectangle');
+  const [imageUrl, setImageUrl] = useState<string | undefined>(undefined);
 
   const preview =
     url.length > PREVIEW_MAX_LENGTH
@@ -51,8 +60,13 @@ export const UrlPickerModal: React.FC<UrlPickerModalProps> = ({
       title: title.trim() || undefined,
       icon: iconId,
       color,
+      shape,
+      imageUrl,
     });
   };
+
+  const hasSafeImage = imageUrl ? isSafeIconUrl(imageUrl) : false;
+  const isCircle = shape === 'circle';
 
   return (
     <Modal isOpen={true} onClose={onClose} variant="bare" zIndex="z-critical">
@@ -81,7 +95,7 @@ export const UrlPickerModal: React.FC<UrlPickerModalProps> = ({
               <p className="text-xs text-slate-500 mt-0.5 font-bold">
                 {stage === 'choose'
                   ? 'Pick a widget type for this link'
-                  : 'Set a title, icon, and color'}
+                  : 'Set a title, shape, icon, and background'}
               </p>
             </div>
           </div>
@@ -145,18 +159,46 @@ export const UrlPickerModal: React.FC<UrlPickerModalProps> = ({
             {/* Live preview */}
             <div className="flex items-center justify-center">
               <div
-                className="flex flex-col items-center justify-center w-32 h-24 rounded-2xl border border-white/30 shadow-md"
-                style={{ backgroundColor: color }}
+                className={`relative overflow-hidden flex flex-col items-center justify-center border border-white/30 shadow-md ${
+                  isCircle ? 'w-24 h-24 rounded-full' : 'w-32 h-24 rounded-2xl'
+                }`}
+                style={{
+                  backgroundColor: hasSafeImage ? '#1e293b' : color,
+                }}
               >
-                {(() => {
-                  const Picked = getUrlIcon(iconId);
-                  return (
-                    <Picked className="w-8 h-8 text-white drop-shadow-sm" />
-                  );
-                })()}
-                <span className="font-black text-white text-sm mt-1 drop-shadow-md break-words text-center px-2 line-clamp-2">
-                  {title.trim() || 'Sample'}
-                </span>
+                {hasSafeImage && (
+                  <img
+                    src={imageUrl}
+                    alt=""
+                    referrerPolicy="no-referrer"
+                    aria-hidden="true"
+                    className="absolute inset-0 w-full h-full object-cover pointer-events-none"
+                  />
+                )}
+                {hasSafeImage ? (
+                  <span
+                    className="absolute left-0 right-0 bottom-0 z-10 font-black text-white text-xs text-center leading-tight px-2 py-1.5"
+                    style={{
+                      backgroundColor: 'rgba(15, 23, 42, 0.42)',
+                      backdropFilter: 'blur(4px)',
+                      WebkitBackdropFilter: 'blur(4px)',
+                    }}
+                  >
+                    {title.trim() || 'Sample'}
+                  </span>
+                ) : (
+                  (() => {
+                    const Picked = getUrlIcon(iconId);
+                    return (
+                      <>
+                        <Picked className="w-8 h-8 text-white drop-shadow-sm" />
+                        <span className="font-black text-white text-sm mt-1 drop-shadow-md break-words text-center px-2 line-clamp-2">
+                          {title.trim() || 'Sample'}
+                        </span>
+                      </>
+                    );
+                  })()
+                )}
               </div>
             </div>
 
@@ -176,6 +218,14 @@ export const UrlPickerModal: React.FC<UrlPickerModalProps> = ({
                 placeholder="e.g. Class Website"
                 className="w-full px-3 py-2 border border-slate-200 rounded-xl text-sm font-semibold focus:ring-2 focus:ring-brand-blue-primary focus:outline-none"
               />
+            </div>
+
+            {/* Shape picker */}
+            <div>
+              <label className="block text-xs font-black text-slate-700 mb-1.5 uppercase tracking-widest">
+                Shape
+              </label>
+              <LinkShapePicker shape={shape} onChange={setShape} />
             </div>
 
             {/* Icon picker */}
@@ -204,28 +254,19 @@ export const UrlPickerModal: React.FC<UrlPickerModalProps> = ({
               </div>
             </div>
 
-            {/* Color picker */}
+            {/* Background — color or image */}
             <div>
               <label className="block text-xs font-black text-slate-700 mb-1.5 uppercase tracking-widest">
-                Color
+                Background
               </label>
-              <div className="flex flex-wrap gap-2">
-                {URL_COLORS.map((c) => (
-                  <button
-                    key={c}
-                    type="button"
-                    onClick={() => setColor(c)}
-                    aria-label={`Color ${c}`}
-                    aria-pressed={color === c}
-                    className={`w-8 h-8 rounded-full border-2 transition-all ${
-                      color === c
-                        ? 'border-slate-800 scale-110 shadow-sm'
-                        : 'border-transparent hover:scale-105'
-                    }`}
-                    style={{ backgroundColor: c }}
-                  />
-                ))}
-              </div>
+              <LinkBackgroundInput
+                color={color}
+                imageUrl={imageUrl}
+                onChange={({ color: nextColor, imageUrl: nextImage }) => {
+                  if (nextColor !== undefined) setColor(nextColor);
+                  setImageUrl(nextImage);
+                }}
+              />
             </div>
 
             {/* Confirm button */}

--- a/components/widgets/UrlWidget/LinkBackgroundInput.tsx
+++ b/components/widgets/UrlWidget/LinkBackgroundInput.tsx
@@ -1,0 +1,265 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  Image as ImageIcon,
+  Upload,
+  Loader2,
+  Trash2,
+  Palette,
+} from 'lucide-react';
+import { useStorage } from '@/hooks/useStorage';
+import { useAuth } from '@/context/useAuth';
+import { useDashboard } from '@/context/useDashboard';
+import { URL_COLORS } from './icons';
+
+const MAX_BYTES = 5 * 1024 * 1024;
+
+interface LinkBackgroundInputProps {
+  color?: string;
+  imageUrl?: string;
+  onChange: (next: { color?: string; imageUrl?: string }) => void;
+}
+
+export const LinkBackgroundInput: React.FC<LinkBackgroundInputProps> = ({
+  color,
+  imageUrl,
+  onChange,
+}) => {
+  const [tab, setTab] = useState<'color' | 'image'>(
+    imageUrl ? 'image' : 'color'
+  );
+  const [uploading, setUploading] = useState(false);
+  const inFlightRef = useRef(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const { user } = useAuth();
+  const { addToast } = useDashboard();
+  const { uploadSticker, deleteFile } = useStorage();
+
+  const handleUpload = useCallback(
+    async (file: File) => {
+      if (inFlightRef.current) {
+        addToast('An upload is already in progress.', 'info');
+        return;
+      }
+      if (!user) {
+        addToast('Sign in to upload images.', 'error');
+        return;
+      }
+      if (!file.type.startsWith('image/')) {
+        addToast('Please choose an image file.', 'error');
+        return;
+      }
+      if (file.size > MAX_BYTES) {
+        addToast('Image too large. 5 MB maximum.', 'error');
+        return;
+      }
+      const previousUrl = imageUrl;
+      inFlightRef.current = true;
+      setUploading(true);
+      try {
+        const url = await uploadSticker(user.uid, file);
+        // Commit the new URL FIRST so a failed delete cannot orphan us with no image.
+        onChange({ color, imageUrl: url });
+        if (previousUrl) {
+          try {
+            await deleteFile(previousUrl);
+          } catch (deleteErr) {
+            console.warn(
+              '[LinkBackgroundInput] Failed to delete previous image; the file may now be orphaned in Drive/Storage.',
+              deleteErr
+            );
+          }
+        }
+        addToast('Image uploaded.', 'success');
+      } catch (err) {
+        console.error('[LinkBackgroundInput] Upload failed', err);
+        addToast('Failed to upload image.', 'error');
+      } finally {
+        inFlightRef.current = false;
+        setUploading(false);
+        if (fileInputRef.current) fileInputRef.current.value = '';
+      }
+    },
+    [user, addToast, uploadSticker, deleteFile, onChange, imageUrl, color]
+  );
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) void handleUpload(file);
+  };
+
+  const handlePickColor = async (next: string) => {
+    const previousImage = imageUrl;
+    onChange({ color: next, imageUrl: undefined });
+    if (previousImage) {
+      try {
+        await deleteFile(previousImage);
+      } catch (deleteErr) {
+        console.warn(
+          '[LinkBackgroundInput] Failed to delete previous image when switching to color.',
+          deleteErr
+        );
+      }
+    }
+  };
+
+  const handleClearImage = async () => {
+    const previousImage = imageUrl;
+    onChange({ color, imageUrl: undefined });
+    if (previousImage) {
+      try {
+        await deleteFile(previousImage);
+      } catch (deleteErr) {
+        console.warn(
+          '[LinkBackgroundInput] Failed to delete cleared image.',
+          deleteErr
+        );
+      }
+    }
+  };
+
+  // Paste support — only while the inline image panel is mounted.
+  useEffect(() => {
+    if (tab !== 'image') return;
+    const onPaste = (e: ClipboardEvent) => {
+      const target = e.target as HTMLElement | null;
+      if (!containerRef.current?.contains(target)) return;
+      const items = e.clipboardData?.items;
+      if (!items) return;
+      for (const item of Array.from(items)) {
+        if (item.type.startsWith('image/')) {
+          const file = item.getAsFile();
+          if (file) {
+            e.preventDefault();
+            void handleUpload(file);
+            break;
+          }
+        }
+      }
+    };
+    document.addEventListener('paste', onPaste);
+    return () => document.removeEventListener('paste', onPaste);
+  }, [tab, handleUpload]);
+
+  return (
+    <div ref={containerRef} className="space-y-2">
+      <div className="grid grid-cols-2 gap-2">
+        <button
+          type="button"
+          onClick={() => setTab('color')}
+          className={`flex items-center justify-center gap-1.5 py-1.5 rounded-lg text-xxs font-black uppercase tracking-widest transition-all border-2 ${
+            tab === 'color'
+              ? 'bg-blue-600 border-blue-600 text-white shadow-sm'
+              : 'bg-white border-slate-200 text-slate-600'
+          }`}
+        >
+          <Palette size={12} />
+          Color
+        </button>
+        <button
+          type="button"
+          onClick={() => setTab('image')}
+          className={`flex items-center justify-center gap-1.5 py-1.5 rounded-lg text-xxs font-black uppercase tracking-widest transition-all border-2 ${
+            tab === 'image'
+              ? 'bg-blue-600 border-blue-600 text-white shadow-sm'
+              : 'bg-white border-slate-200 text-slate-600'
+          }`}
+        >
+          <ImageIcon size={12} />
+          Image
+        </button>
+      </div>
+
+      {tab === 'color' && (
+        <div className="flex flex-wrap gap-2">
+          {URL_COLORS.map((c) => (
+            <button
+              key={c}
+              type="button"
+              onClick={() => void handlePickColor(c)}
+              className={`w-8 h-8 rounded-full border-2 transition-all ${
+                color === c && !imageUrl
+                  ? 'border-slate-800 scale-110 shadow-sm'
+                  : 'border-transparent hover:scale-105'
+              }`}
+              style={{ backgroundColor: c }}
+              aria-label={`Pick ${c}`}
+              aria-pressed={color === c && !imageUrl}
+            />
+          ))}
+        </div>
+      )}
+
+      {tab === 'image' && (
+        <div className="space-y-2">
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept="image/*"
+            className="hidden"
+            onChange={handleFileChange}
+          />
+          {imageUrl ? (
+            <div className="flex items-center gap-3 p-3 border border-slate-200 rounded-lg bg-white">
+              <img
+                src={imageUrl}
+                alt=""
+                referrerPolicy="no-referrer"
+                className="w-12 h-12 rounded-md object-cover"
+              />
+              <div className="flex-1 min-w-0">
+                <div className="text-xs font-bold text-slate-700 truncate">
+                  Custom image
+                </div>
+                <div className="text-xxs text-slate-400 truncate">
+                  Saved to your Google Drive
+                </div>
+              </div>
+              <button
+                type="button"
+                onClick={() => fileInputRef.current?.click()}
+                disabled={uploading}
+                className="p-1.5 rounded-md text-slate-400 hover:text-brand-blue-primary hover:bg-blue-50 transition-colors"
+                title="Replace image"
+              >
+                {uploading ? (
+                  <Loader2 size={14} className="animate-spin" />
+                ) : (
+                  <Upload size={14} />
+                )}
+              </button>
+              <button
+                type="button"
+                onClick={() => void handleClearImage()}
+                disabled={uploading}
+                className="p-1.5 rounded-md text-slate-400 hover:text-brand-red-primary hover:bg-red-50 transition-colors"
+                title="Remove image"
+              >
+                <Trash2 size={14} />
+              </button>
+            </div>
+          ) : (
+            <button
+              type="button"
+              onClick={() => fileInputRef.current?.click()}
+              disabled={uploading}
+              className="w-full p-4 rounded-lg border-2 border-dashed border-slate-200 text-slate-500 hover:border-brand-blue-primary hover:bg-blue-50 transition-all flex flex-col items-center gap-2"
+            >
+              {uploading ? (
+                <Loader2 size={20} className="animate-spin" />
+              ) : (
+                <Upload size={20} />
+              )}
+              <div className="text-xs font-bold text-slate-600">
+                {uploading ? 'Uploading...' : 'Upload or paste image'}
+              </div>
+              <div className="text-xxs text-slate-400">
+                Click to browse, or Cmd/Ctrl-V to paste
+              </div>
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/components/widgets/UrlWidget/LinkBackgroundInput.tsx
+++ b/components/widgets/UrlWidget/LinkBackgroundInput.tsx
@@ -9,6 +9,7 @@ import {
 import { useStorage } from '@/hooks/useStorage';
 import { useAuth } from '@/context/useAuth';
 import { useDashboard } from '@/context/useDashboard';
+import { isSafeIconUrl } from '@/components/widgets/Catalyst/catalystHelpers';
 import { URL_COLORS } from './icons';
 
 const MAX_BYTES = 5 * 1024 * 1024;
@@ -200,44 +201,61 @@ export const LinkBackgroundInput: React.FC<LinkBackgroundInputProps> = ({
             onChange={handleFileChange}
           />
           {imageUrl ? (
-            <div className="flex items-center gap-3 p-3 border border-slate-200 rounded-lg bg-white">
-              <img
-                src={imageUrl}
-                alt=""
-                referrerPolicy="no-referrer"
-                className="w-12 h-12 rounded-md object-cover"
-              />
-              <div className="flex-1 min-w-0">
-                <div className="text-xs font-bold text-slate-700 truncate">
-                  Custom image
+            (() => {
+              const safe = isSafeIconUrl(imageUrl);
+              return (
+                <div className="flex items-center gap-3 p-3 border border-slate-200 rounded-lg bg-white">
+                  {safe ? (
+                    <img
+                      src={imageUrl}
+                      alt=""
+                      referrerPolicy="no-referrer"
+                      className="w-12 h-12 rounded-md object-cover"
+                    />
+                  ) : (
+                    <div
+                      aria-hidden
+                      className="w-12 h-12 rounded-md bg-red-50 border border-red-200 flex items-center justify-center text-red-500"
+                      title="Image URL is not safe to load"
+                    >
+                      <ImageIcon size={18} />
+                    </div>
+                  )}
+                  <div className="flex-1 min-w-0">
+                    <div className="text-xs font-bold text-slate-700 truncate">
+                      {safe ? 'Custom image' : 'Unsafe image URL'}
+                    </div>
+                    <div className="text-xxs text-slate-400 truncate">
+                      {safe
+                        ? 'Saved to your Google Drive'
+                        : 'Remove and re-upload to fix.'}
+                    </div>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() => fileInputRef.current?.click()}
+                    disabled={uploading}
+                    className="p-1.5 rounded-md text-slate-400 hover:text-brand-blue-primary hover:bg-blue-50 transition-colors"
+                    title="Replace image"
+                  >
+                    {uploading ? (
+                      <Loader2 size={14} className="animate-spin" />
+                    ) : (
+                      <Upload size={14} />
+                    )}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => void handleClearImage()}
+                    disabled={uploading}
+                    className="p-1.5 rounded-md text-slate-400 hover:text-brand-red-primary hover:bg-red-50 transition-colors"
+                    title="Remove image"
+                  >
+                    <Trash2 size={14} />
+                  </button>
                 </div>
-                <div className="text-xxs text-slate-400 truncate">
-                  Saved to your Google Drive
-                </div>
-              </div>
-              <button
-                type="button"
-                onClick={() => fileInputRef.current?.click()}
-                disabled={uploading}
-                className="p-1.5 rounded-md text-slate-400 hover:text-brand-blue-primary hover:bg-blue-50 transition-colors"
-                title="Replace image"
-              >
-                {uploading ? (
-                  <Loader2 size={14} className="animate-spin" />
-                ) : (
-                  <Upload size={14} />
-                )}
-              </button>
-              <button
-                type="button"
-                onClick={() => void handleClearImage()}
-                disabled={uploading}
-                className="p-1.5 rounded-md text-slate-400 hover:text-brand-red-primary hover:bg-red-50 transition-colors"
-                title="Remove image"
-              >
-                <Trash2 size={14} />
-              </button>
-            </div>
+              );
+            })()
           ) : (
             <button
               type="button"

--- a/components/widgets/UrlWidget/LinkShapePicker.tsx
+++ b/components/widgets/UrlWidget/LinkShapePicker.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { Square, Circle } from 'lucide-react';
+
+export type LinkShape = 'rectangle' | 'circle';
+
+interface LinkShapePickerProps {
+  shape: LinkShape;
+  onChange: (next: LinkShape) => void;
+}
+
+export const LinkShapePicker: React.FC<LinkShapePickerProps> = ({
+  shape,
+  onChange,
+}) => (
+  <div className="grid grid-cols-2 gap-2">
+    <button
+      type="button"
+      onClick={() => onChange('rectangle')}
+      aria-pressed={shape === 'rectangle'}
+      className={`flex items-center justify-center gap-1.5 py-1.5 rounded-lg text-xxs font-black uppercase tracking-widest transition-all border-2 ${
+        shape === 'rectangle'
+          ? 'bg-blue-600 border-blue-600 text-white shadow-sm'
+          : 'bg-white border-slate-200 text-slate-600'
+      }`}
+    >
+      <Square size={12} />
+      Rectangle
+    </button>
+    <button
+      type="button"
+      onClick={() => onChange('circle')}
+      aria-pressed={shape === 'circle'}
+      className={`flex items-center justify-center gap-1.5 py-1.5 rounded-lg text-xxs font-black uppercase tracking-widest transition-all border-2 ${
+        shape === 'circle'
+          ? 'bg-blue-600 border-blue-600 text-white shadow-sm'
+          : 'bg-white border-slate-200 text-slate-600'
+      }`}
+    >
+      <Circle size={12} />
+      Circle
+    </button>
+  </div>
+);

--- a/components/widgets/UrlWidget/Settings.tsx
+++ b/components/widgets/UrlWidget/Settings.tsx
@@ -1,14 +1,40 @@
 import React, { useState } from 'react';
 import { WidgetData, UrlWidgetConfig } from '@/types';
 import { useDashboard } from '@/context/useDashboard';
-import { Plus, Trash2 } from 'lucide-react';
+import { Plus, Trash2, ChevronDown, ChevronUp } from 'lucide-react';
 import {
   URL_ICONS,
-  URL_COLORS,
   DEFAULT_URL_ICON_ID,
   DEFAULT_URL_COLOR,
   getUrlIcon,
 } from './icons';
+import { LinkBackgroundInput } from './LinkBackgroundInput';
+import { LinkShapePicker, type LinkShape } from './LinkShapePicker';
+
+const IconPicker: React.FC<{
+  iconId: string;
+  onChange: (next: string) => void;
+}> = ({ iconId, onChange }) => (
+  <div className="grid grid-cols-10 gap-1.5 max-h-32 overflow-y-auto p-1">
+    {URL_ICONS.map(({ id, label, icon: Icon }) => (
+      <button
+        key={id}
+        type="button"
+        onClick={() => onChange(id)}
+        title={label}
+        aria-label={label}
+        aria-pressed={iconId === id}
+        className={`flex items-center justify-center w-8 h-8 rounded-lg border-2 transition-all ${
+          iconId === id
+            ? 'border-slate-800 bg-slate-800 text-white scale-105'
+            : 'border-transparent bg-slate-100 text-slate-600 hover:bg-slate-200'
+        }`}
+      >
+        <Icon className="w-4 h-4" />
+      </button>
+    ))}
+  </div>
+);
 
 export const UrlWidgetSettings: React.FC<{ widget: WidgetData }> = ({
   widget,
@@ -17,11 +43,13 @@ export const UrlWidgetSettings: React.FC<{ widget: WidgetData }> = ({
   const config = widget.config as UrlWidgetConfig;
   const urls = config.urls ?? [];
 
-  // local state for the form inputs
   const [newUrl, setNewUrl] = useState('');
   const [newTitle, setNewTitle] = useState('');
-  const [newColor, setNewColor] = useState(DEFAULT_URL_COLOR);
+  const [newColor, setNewColor] = useState<string>(DEFAULT_URL_COLOR);
+  const [newImageUrl, setNewImageUrl] = useState<string | undefined>(undefined);
   const [newIcon, setNewIcon] = useState(DEFAULT_URL_ICON_ID);
+  const [newShape, setNewShape] = useState<LinkShape>('rectangle');
+  const [expandedId, setExpandedId] = useState<string | null>(null);
 
   const update = (updates: Partial<UrlWidgetConfig>) => {
     updateWidget(widget.id, { config: { ...config, ...updates } });
@@ -35,7 +63,6 @@ export const UrlWidgetSettings: React.FC<{ widget: WidgetData }> = ({
   const addUrl = () => {
     if (!newUrl.trim()) return;
 
-    // basic url formatting if missing protocol
     let formattedUrl = newUrl.trim();
     if (!/^https?:\/\//i.test(formattedUrl)) {
       formattedUrl = 'https://' + formattedUrl;
@@ -47,15 +74,28 @@ export const UrlWidgetSettings: React.FC<{ widget: WidgetData }> = ({
       title: newTitle.trim() || undefined,
       color: newColor,
       icon: newIcon,
+      shape: newShape,
+      imageUrl: newImageUrl,
     };
 
     update({ urls: [...urls, newItem] });
     setNewUrl('');
     setNewTitle('');
+    setNewImageUrl(undefined);
   };
 
   const removeUrl = (id: string) => {
     update({ urls: urls.filter((u) => u.id !== id) });
+    if (expandedId === id) setExpandedId(null);
+  };
+
+  const patchUrl = (
+    id: string,
+    patch: Partial<UrlWidgetConfig['urls'][number]>
+  ) => {
+    update({
+      urls: urls.map((u) => (u.id === id ? { ...u, ...patch } : u)),
+    });
   };
 
   return (
@@ -92,48 +132,30 @@ export const UrlWidgetSettings: React.FC<{ widget: WidgetData }> = ({
 
         <div>
           <label className="block text-xs font-bold text-slate-600 mb-2 uppercase tracking-wider">
-            Icon
+            Shape
           </label>
-          <div className="grid grid-cols-10 gap-1.5 max-h-32 overflow-y-auto p-1">
-            {URL_ICONS.map(({ id, label, icon: Icon }) => (
-              <button
-                key={id}
-                type="button"
-                onClick={() => setNewIcon(id)}
-                title={label}
-                aria-label={label}
-                aria-pressed={newIcon === id}
-                className={`flex items-center justify-center w-8 h-8 rounded-lg border-2 transition-all ${
-                  newIcon === id
-                    ? 'border-slate-800 bg-slate-800 text-white scale-105'
-                    : 'border-transparent bg-slate-100 text-slate-600 hover:bg-slate-200'
-                }`}
-              >
-                <Icon className="w-4 h-4" />
-              </button>
-            ))}
-          </div>
+          <LinkShapePicker shape={newShape} onChange={setNewShape} />
         </div>
 
         <div>
           <label className="block text-xs font-bold text-slate-600 mb-2 uppercase tracking-wider">
-            Button Color
+            Icon
           </label>
-          <div className="flex flex-wrap gap-2">
-            {URL_COLORS.map((c) => (
-              <button
-                key={c}
-                type="button"
-                onClick={() => setNewColor(c)}
-                className={`w-8 h-8 rounded-full border-2 transition-all ${
-                  newColor === c
-                    ? 'border-slate-800 scale-110 shadow-sm'
-                    : 'border-transparent hover:scale-105'
-                }`}
-                style={{ backgroundColor: c }}
-              />
-            ))}
-          </div>
+          <IconPicker iconId={newIcon} onChange={setNewIcon} />
+        </div>
+
+        <div>
+          <label className="block text-xs font-bold text-slate-600 mb-2 uppercase tracking-wider">
+            Background
+          </label>
+          <LinkBackgroundInput
+            color={newColor}
+            imageUrl={newImageUrl}
+            onChange={({ color, imageUrl }) => {
+              if (color !== undefined) setNewColor(color);
+              setNewImageUrl(imageUrl);
+            }}
+          />
         </div>
 
         <button
@@ -154,35 +176,119 @@ export const UrlWidgetSettings: React.FC<{ widget: WidgetData }> = ({
           <div className="space-y-2">
             {urls.map((u) => {
               const Icon = getUrlIcon(u.icon);
+              const isExpanded = expandedId === u.id;
+              const shape: LinkShape = u.shape ?? 'rectangle';
+              const previewBg = u.imageUrl
+                ? undefined
+                : (u.color ?? DEFAULT_URL_COLOR);
               return (
                 <div
                   key={u.id}
-                  className="flex items-center justify-between bg-white p-3 rounded-xl border border-slate-200 shadow-sm"
+                  className="bg-white rounded-xl border border-slate-200 shadow-sm overflow-hidden"
                 >
-                  <div className="flex items-center gap-3 overflow-hidden">
-                    <div
-                      className="w-8 h-8 rounded-lg flex items-center justify-center flex-shrink-0"
-                      style={{ backgroundColor: u.color ?? DEFAULT_URL_COLOR }}
+                  <div className="flex items-center justify-between p-3 gap-2">
+                    <div className="flex items-center gap-3 overflow-hidden flex-1 min-w-0">
+                      <div
+                        className={`w-8 h-8 ${shape === 'circle' ? 'rounded-full' : 'rounded-lg'} flex items-center justify-center flex-shrink-0 overflow-hidden`}
+                        style={
+                          previewBg ? { backgroundColor: previewBg } : undefined
+                        }
+                      >
+                        {u.imageUrl ? (
+                          <img
+                            src={u.imageUrl}
+                            alt=""
+                            referrerPolicy="no-referrer"
+                            className="w-full h-full object-cover"
+                          />
+                        ) : (
+                          <Icon className="w-4 h-4 text-white" />
+                        )}
+                      </div>
+                      <div className="flex flex-col overflow-hidden">
+                        <span className="font-bold text-sm text-slate-800 truncate">
+                          {getDisplayLabel(u.title, u.url)}
+                        </span>
+                        <span className="text-xs text-slate-500 truncate">
+                          {u.url}
+                        </span>
+                      </div>
+                    </div>
+                    <button
+                      type="button"
+                      onClick={() => setExpandedId(isExpanded ? null : u.id)}
+                      className="p-2 text-slate-400 hover:text-brand-blue-primary hover:bg-blue-50 rounded-lg transition-colors"
+                      title={isExpanded ? 'Collapse' : 'Edit'}
+                      aria-expanded={isExpanded}
                     >
-                      <Icon className="w-4 h-4 text-white" />
-                    </div>
-                    <div className="flex flex-col overflow-hidden">
-                      <span className="font-bold text-sm text-slate-800 truncate">
-                        {getDisplayLabel(u.title, u.url)}
-                      </span>
-                      <span className="text-xs text-slate-500 truncate">
-                        {u.url}
-                      </span>
-                    </div>
+                      {isExpanded ? (
+                        <ChevronUp size={16} />
+                      ) : (
+                        <ChevronDown size={16} />
+                      )}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => removeUrl(u.id)}
+                      className="p-2 text-slate-400 hover:text-red-500 hover:bg-red-50 rounded-lg transition-colors"
+                      title="Remove Link"
+                    >
+                      <Trash2 size={16} />
+                    </button>
                   </div>
-                  <button
-                    type="button"
-                    onClick={() => removeUrl(u.id)}
-                    className="p-2 text-slate-400 hover:text-red-500 hover:bg-red-50 rounded-lg transition-colors"
-                    title="Remove Link"
-                  >
-                    <Trash2 size={16} />
-                  </button>
+                  {isExpanded && (
+                    <div className="border-t border-slate-100 p-3 space-y-4 bg-slate-50">
+                      <div>
+                        <label className="block text-xs font-bold text-slate-600 mb-1 uppercase tracking-wider">
+                          Title
+                        </label>
+                        <input
+                          type="text"
+                          value={u.title ?? ''}
+                          onChange={(e) =>
+                            patchUrl(u.id, {
+                              title: e.target.value || undefined,
+                            })
+                          }
+                          className="w-full px-3 py-2 border border-slate-200 rounded-xl text-sm focus:ring-2 focus:ring-brand-blue-primary focus:outline-none"
+                          placeholder="Link title"
+                        />
+                      </div>
+                      <div>
+                        <label className="block text-xs font-bold text-slate-600 mb-2 uppercase tracking-wider">
+                          Shape
+                        </label>
+                        <LinkShapePicker
+                          shape={shape}
+                          onChange={(next) => patchUrl(u.id, { shape: next })}
+                        />
+                      </div>
+                      <div>
+                        <label className="block text-xs font-bold text-slate-600 mb-2 uppercase tracking-wider">
+                          Icon
+                        </label>
+                        <IconPicker
+                          iconId={u.icon ?? DEFAULT_URL_ICON_ID}
+                          onChange={(id) => patchUrl(u.id, { icon: id })}
+                        />
+                      </div>
+                      <div>
+                        <label className="block text-xs font-bold text-slate-600 mb-2 uppercase tracking-wider">
+                          Background
+                        </label>
+                        <LinkBackgroundInput
+                          color={u.color}
+                          imageUrl={u.imageUrl}
+                          onChange={({ color, imageUrl }) =>
+                            patchUrl(u.id, {
+                              color: color ?? u.color,
+                              imageUrl,
+                            })
+                          }
+                        />
+                      </div>
+                    </div>
+                  )}
                 </div>
               );
             })}

--- a/components/widgets/UrlWidget/Settings.tsx
+++ b/components/widgets/UrlWidget/Settings.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { WidgetData, UrlWidgetConfig } from '@/types';
 import { useDashboard } from '@/context/useDashboard';
 import { Plus, Trash2, ChevronDown, ChevronUp } from 'lucide-react';
+import { isSafeIconUrl } from '@/components/widgets/Catalyst/catalystHelpers';
 import {
   URL_ICONS,
   DEFAULT_URL_ICON_ID,
@@ -178,7 +179,11 @@ export const UrlWidgetSettings: React.FC<{ widget: WidgetData }> = ({
               const Icon = getUrlIcon(u.icon);
               const isExpanded = expandedId === u.id;
               const shape: LinkShape = u.shape ?? 'rectangle';
-              const previewBg = u.imageUrl
+              const safeImage =
+                u.imageUrl && isSafeIconUrl(u.imageUrl)
+                  ? u.imageUrl
+                  : undefined;
+              const previewBg = safeImage
                 ? undefined
                 : (u.color ?? DEFAULT_URL_COLOR);
               return (
@@ -194,9 +199,9 @@ export const UrlWidgetSettings: React.FC<{ widget: WidgetData }> = ({
                           previewBg ? { backgroundColor: previewBg } : undefined
                         }
                       >
-                        {u.imageUrl ? (
+                        {safeImage ? (
                           <img
-                            src={u.imageUrl}
+                            src={safeImage}
                             alt=""
                             referrerPolicy="no-referrer"
                             className="w-full h-full object-cover"

--- a/components/widgets/UrlWidget/Widget.test.tsx
+++ b/components/widgets/UrlWidget/Widget.test.tsx
@@ -1,15 +1,8 @@
 import { render, screen, fireEvent } from '@testing-library/react';
-import { vi, describe, it, expect, beforeEach, afterEach, Mock } from 'vitest';
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { UrlWidget } from './Widget';
 import { WidgetData, UrlWidgetConfig } from '@/types';
-import { useDashboard } from '@/context/useDashboard';
 
-// Mock the context
-vi.mock('@/context/useDashboard', () => ({
-  useDashboard: vi.fn(),
-}));
-
-const mockAddWidget = vi.fn();
 let mockOpen: ReturnType<typeof vi.spyOn>;
 
 const createMockWidget = (
@@ -39,10 +32,6 @@ const createMockWidget = (
 describe('UrlWidget', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    (useDashboard as Mock).mockReturnValue({
-      addWidget: mockAddWidget,
-    });
-    // Mock window.open
     mockOpen = vi.spyOn(window, 'open').mockImplementation(() => null);
   });
 
@@ -70,16 +59,68 @@ describe('UrlWidget', () => {
     );
   });
 
-  it('spawns a QR widget when QrCode button is clicked', () => {
+  it('does not render a corner Create QR Code button (paste flow handles QR choice)', () => {
     const widget = createMockWidget();
     render(<UrlWidget widget={widget} />);
 
-    // Find the create QR code button
-    const qrCodeButton = screen.getByTitle('Create QR Code');
-    fireEvent.click(qrCodeButton);
+    expect(screen.queryByTitle('Create QR Code')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Create QR Code')).not.toBeInTheDocument();
+  });
 
-    expect(mockAddWidget).toHaveBeenCalledWith('qr', {
-      config: { url: 'https://example.com' },
+  it('renders an image-background tile (with bottom text plate) when imageUrl is set', () => {
+    const widget = createMockWidget({
+      urls: [
+        {
+          id: 'url-img',
+          url: 'https://example.com',
+          title: 'With Image',
+          imageUrl: 'https://images.example.com/photo.jpg',
+        },
+      ],
     });
+    const { container } = render(<UrlWidget widget={widget} />);
+
+    const img = container.querySelector(
+      'img[src="https://images.example.com/photo.jpg"]'
+    );
+    expect(img).not.toBeNull();
+    expect(screen.getByText('With Image')).toBeInTheDocument();
+  });
+
+  it('does NOT render an image when imageUrl uses an unsafe (non-https) protocol', () => {
+    const widget = createMockWidget({
+      urls: [
+        {
+          id: 'url-bad',
+          url: 'https://example.com',
+          title: 'Unsafe',
+          imageUrl: 'http://insecure.example.com/photo.jpg',
+        },
+      ],
+    });
+    const { container } = render(<UrlWidget widget={widget} />);
+
+    const img = container.querySelector(
+      'img[src^="http://insecure.example.com"]'
+    );
+    expect(img).toBeNull();
+  });
+
+  it('applies a circular shape when shape is "circle"', () => {
+    const widget = createMockWidget({
+      urls: [
+        {
+          id: 'url-circle',
+          url: 'https://example.com',
+          title: 'Round',
+          color: '#ef4444',
+          shape: 'circle',
+        },
+      ],
+    });
+    const { container } = render(<UrlWidget widget={widget} />);
+
+    const circle = container.querySelector('.rounded-full.aspect-square');
+    expect(circle).not.toBeNull();
   });
 });

--- a/components/widgets/UrlWidget/Widget.tsx
+++ b/components/widgets/UrlWidget/Widget.tsx
@@ -2,20 +2,19 @@ import React, { useMemo } from 'react';
 import { WidgetData, UrlWidgetConfig } from '@/types';
 import { WidgetLayout } from '@/components/widgets/WidgetLayout';
 import { ScaledEmptyState } from '@/components/common/ScaledEmptyState';
-import { Globe, QrCode } from 'lucide-react';
-import { useDashboard } from '@/context/useDashboard';
+import { Globe } from 'lucide-react';
+import { isSafeIconUrl } from '@/components/widgets/Catalyst/catalystHelpers';
 import { getUrlIcon, DEFAULT_URL_COLOR } from './icons';
 
+const getDisplayLabel = (title?: string, url?: string) => {
+  const trimmedTitle = title?.trim();
+  return trimmedTitle && trimmedTitle.length > 0 ? trimmedTitle : url;
+};
+
 export const UrlWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
-  const { addWidget } = useDashboard();
   const config = widget.config as UrlWidgetConfig;
   const urls = config.urls ?? [];
-  const getDisplayLabel = (title?: string, url?: string) => {
-    const trimmedTitle = title?.trim();
-    return trimmedTitle && trimmedTitle.length > 0 ? trimmedTitle : url;
-  };
 
-  // Calculate grid layout based on number of active URLs
   const { cols, rows } = useMemo(() => {
     const count = urls.length;
     if (count === 0) return { cols: 1, rows: 1 };
@@ -42,89 +41,116 @@ export const UrlWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
     <WidgetLayout
       padding="p-0"
       content={
-        <div
-          className="h-full w-full flex flex-col overflow-hidden"
-          style={{ padding: 'min(12px, 2.5cqmin)' }}
-        >
+        <div className="h-full w-full flex flex-col overflow-hidden">
           <div className="flex-1 min-h-0">
             <div
               className="grid h-full w-full"
               style={{
                 gridTemplateColumns: `repeat(${cols}, minmax(0, 1fr))`,
                 gridTemplateRows: `repeat(${rows}, minmax(0, 1fr))`,
-                gap: 'min(10px, 2cqmin)',
+                gap: 'min(6px, 1.5cqmin)',
               }}
             >
               {urls.map((urlItem) => {
                 const Icon = getUrlIcon(urlItem.icon);
                 const label = getDisplayLabel(urlItem.title, urlItem.url);
+                const isCircle = urlItem.shape === 'circle';
+                const trimmedImage = urlItem.imageUrl?.trim();
+                const hasImage = trimmedImage
+                  ? isSafeIconUrl(trimmedImage)
+                  : false;
+                const radiusClass = isCircle
+                  ? 'rounded-full'
+                  : 'rounded-[min(16px,3cqmin)]';
+                // Wrap the tile in a centering cell so a circle (which forces
+                // aspect-square) sits centered inside its grid cell rather
+                // than collapsing to one edge.
                 return (
                   <div
                     key={urlItem.id}
-                    className="relative overflow-hidden rounded-[min(16px,3cqmin)] transition-all group shadow-sm hover:shadow-md border border-white/20 hover:brightness-110"
-                    style={{
-                      backgroundColor: urlItem.color ?? DEFAULT_URL_COLOR,
-                      containerType: 'size',
-                    }}
+                    className="relative flex items-center justify-center min-w-0 min-h-0"
                   >
-                    <button
-                      type="button"
-                      onClick={() =>
-                        window.open(
-                          urlItem.url,
-                          '_blank',
-                          'noopener,noreferrer'
-                        )
-                      }
-                      aria-label={`Open ${label}`}
-                      className="absolute inset-0 flex flex-col items-center justify-center cursor-pointer text-left transition-all active:scale-95 outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-inset"
-                    >
-                      <span
-                        aria-hidden="true"
-                        className="absolute inset-0 bg-black/0 group-hover:bg-black/5 group-active:bg-black/10 transition-colors pointer-events-none"
-                      />
-
-                      <Icon
-                        className="text-white drop-shadow-sm z-10"
-                        style={{
-                          width: 'min(96px, 32cqmin)',
-                          height: 'min(96px, 32cqmin)',
-                          marginBottom: 'min(8px, 2.5cqmin)',
-                        }}
-                      />
-
-                      <span
-                        className="font-black text-white text-center leading-tight drop-shadow-md break-words max-w-full z-10 line-clamp-2"
-                        style={{
-                          fontSize: 'min(24px, 8cqmin)',
-                          padding: '0 min(8px, 1.5cqmin)',
-                        }}
-                      >
-                        {label}
-                      </span>
-                    </button>
-
-                    <button
-                      type="button"
-                      onClick={() =>
-                        addWidget('qr', { config: { url: urlItem.url } })
-                      }
-                      className="absolute z-20 rounded-full bg-black/20 text-white opacity-70 transition-all outline-none hover:bg-black/40 group-hover:opacity-100 focus:opacity-100 focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-black/40"
+                    <div
+                      className={`relative overflow-hidden transition-all group shadow-sm hover:shadow-md border border-white/20 hover:brightness-110 ${radiusClass} ${
+                        isCircle
+                          ? 'aspect-square max-w-full max-h-full'
+                          : 'h-full w-full'
+                      }`}
                       style={{
-                        top: 'min(8px, 2cqmin)',
-                        right: 'min(8px, 2cqmin)',
-                        padding: 'min(6px, 1.5cqmin)',
+                        ...(isCircle
+                          ? { height: '100%', width: 'auto' }
+                          : null),
+                        backgroundColor: hasImage
+                          ? '#1e293b'
+                          : (urlItem.color ?? DEFAULT_URL_COLOR),
+                        containerType: 'size',
                       }}
-                      title="Create QR Code"
-                      aria-label="Create QR Code"
                     >
-                      <QrCode
-                        style={{
-                          width: 'min(20px, 10cqmin)',
-                          height: 'min(20px, 10cqmin)',
-                        }}
-                      />
-                    </button>
+                      {hasImage && (
+                        <img
+                          src={trimmedImage}
+                          alt=""
+                          referrerPolicy="no-referrer"
+                          loading="lazy"
+                          aria-hidden="true"
+                          className="absolute inset-0 w-full h-full object-cover pointer-events-none"
+                        />
+                      )}
+                      <button
+                        type="button"
+                        onClick={() =>
+                          window.open(
+                            urlItem.url,
+                            '_blank',
+                            'noopener,noreferrer'
+                          )
+                        }
+                        aria-label={`Open ${label}`}
+                        className="absolute inset-0 flex flex-col items-center justify-center cursor-pointer text-left transition-all active:scale-95 outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-inset"
+                      >
+                        <span
+                          aria-hidden="true"
+                          className={`absolute inset-0 bg-black/0 group-hover:bg-black/5 group-active:bg-black/10 transition-colors pointer-events-none ${radiusClass}`}
+                        />
+
+                        {hasImage ? (
+                          // Image mode: bottom text plate, no icon (image IS the visual).
+                          <span
+                            className="absolute left-0 right-0 bottom-0 z-10 font-black text-white text-center leading-tight break-words px-1.5"
+                            style={{
+                              fontSize: 'clamp(11px, 9cqmin, 28px)',
+                              padding: 'min(8px, 4cqmin) min(10px, 5cqmin)',
+                              backgroundColor: 'rgba(15, 23, 42, 0.42)',
+                              backdropFilter: 'blur(min(4px, 2cqmin))',
+                              WebkitBackdropFilter: 'blur(min(4px, 2cqmin))',
+                            }}
+                          >
+                            {label}
+                          </span>
+                        ) : (
+                          // Color mode: large icon + label centered.
+                          <>
+                            <Icon
+                              className="text-white drop-shadow-sm z-10"
+                              style={{
+                                width: 'min(120px, 38cqmin)',
+                                height: 'min(120px, 38cqmin)',
+                                marginBottom: 'min(4px, 1.5cqmin)',
+                              }}
+                            />
+                            <span
+                              className="font-black text-white text-center leading-tight drop-shadow-md break-words max-w-full z-10"
+                              style={{
+                                fontSize: 'clamp(11px, 9cqmin, 28px)',
+                                padding: '0 min(6px, 1.5cqmin)',
+                              }}
+                            >
+                              {label}
+                            </span>
+                          </>
+                        )}
+                      </button>
+                    </div>
                   </div>
                 );
               })}

--- a/config/widgetDefaults.ts
+++ b/config/widgetDefaults.ts
@@ -21,8 +21,8 @@ import {
 
 export const WIDGET_DEFAULTS: Record<WidgetType, Partial<WidgetData>> = {
   url: {
-    w: 320,
-    h: 280,
+    w: 220,
+    h: 180,
     config: {
       urls: [],
     } satisfies import('@/types').UrlWidgetConfig,

--- a/types.ts
+++ b/types.ts
@@ -476,6 +476,8 @@ export interface UrlWidgetConfig {
     title?: string;
     color?: string;
     icon?: string;
+    shape?: 'rectangle' | 'circle';
+    imageUrl?: string;
   }[];
 }
 


### PR DESCRIPTION
## Summary

Overhauls the URL/Link widget addressing six issues raised in review:

- **Padding & label sizing** — link tile now fills the widget edge-to-edge; label uses `clamp(11px, 9cqmin, 28px)` so it stays readable when the widget is small.
- **Removed corner QR badge** — it was redundant (the paste flow's `UrlPickerModal` already lets you choose URL vs QR before the widget is created) and hard to tap once the widget shrank. Regression test asserts it's gone.
- **Per-widget min size** — URL widgets can shrink to `80×80` (other widgets keep the existing `150×100` floor) via a small `WIDGET_MIN_SIZE_OVERRIDES` lookup in `DraggableWindow`.
- **Per-link Shape** (`Rectangle | Circle`) — circle uses `rounded-full` + `aspect-square` so it stays a true circle inside any cell.
- **Per-link Background** (`Color | Image`) — image mode shows a full-bleed photo with a translucent text plate pinned to the bottom (mirrors the Stations widget pattern). Uploads save to the user's Drive via `useStorage().uploadSticker`, with old-image cleanup.
- **Default size tightened** to `220×180` so a single-link widget feels like a floating bookmark out of the gate.

Shape + Background controls live in **both** the paste-time customize step (`UrlPickerModal`) and the widget settings panel — `LinkShapePicker` and `LinkBackgroundInput` are shared.

## Test plan

- [x] `pnpm validate` passes (type-check, lint, format-check, 1774 unit tests)
- [x] Pasting a URL shows the picker → choosing **Links Widget** opens the customize step with **Shape** and **Background** controls
- [x] Selecting **Circle** in the customize step renders a circular tile on the board
- [x] Image-background tile renders full-bleed image with bottom text plate
- [ ] Drive-backed image upload persists across reload (needs real Firebase auth — verify in deploy preview)
- [x] Corner QR badge no longer appears on URL widgets
- [x] URL widget can be resized smaller than 150×100; other widget types still floor at 150×100

🤖 Generated with [Claude Code](https://claude.com/claude-code)