### PR TITLE
feat(quiz): structured matching/ordering editor + partial credit

### DIFF
--- a/components/quiz/MatchingResponseInput.tsx
+++ b/components/quiz/MatchingResponseInput.tsx
@@ -1,0 +1,492 @@
+/**
+ * Student-facing matching question input. Shows terms with drop zones on the
+ * left and a shuffled word bank below. Students drag definitions into zones
+ * (or tap-to-place on touch devices), then submit through the parent's
+ * SUBMIT button. Builds the legacy `term:def|term:def` wire format on
+ * every change so grading on the teacher side is unchanged.
+ *
+ * The bank includes both real definitions and any `matchingDistractors`,
+ * shuffled together so the teacher's distractors are indistinguishable from
+ * real answers.
+ */
+
+import React from 'react';
+import {
+  DndContext,
+  PointerSensor,
+  KeyboardSensor,
+  useSensor,
+  useSensors,
+  rectIntersection,
+  useDroppable,
+  useDraggable,
+  type DragEndEvent,
+} from '@dnd-kit/core';
+import { sortableKeyboardCoordinates } from '@dnd-kit/sortable';
+import { RotateCcw } from 'lucide-react';
+import type { QuizPublicQuestion } from '@/types';
+
+interface MatchingResponseInputProps {
+  question: QuizPublicQuestion;
+  savedAnswer: string | null;
+  onChange: (answer: string) => void;
+  disabled?: boolean;
+}
+
+const BANK_ID = '__bank__';
+
+/** Fisher-Yates shuffle (returns a new array). */
+function shuffle<T>(arr: T[]): T[] {
+  const out = [...arr];
+  for (let i = out.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [out[i], out[j]] = [out[j], out[i]];
+  }
+  return out;
+}
+
+interface DraggableChipProps {
+  id: string;
+  label: string;
+  selected: boolean;
+  disabled?: boolean;
+  onTap: () => void;
+  /** Explicit accessible label so screen readers announce the chip's
+   *  relationship (e.g., "Paris, matched to France") instead of just the
+   *  visible text, which loses pairing context when the chip is placed.
+   */
+  ariaLabel?: string;
+}
+
+const DraggableChip: React.FC<DraggableChipProps> = ({
+  id,
+  label,
+  selected,
+  disabled,
+  onTap,
+  ariaLabel,
+}) => {
+  const { attributes, listeners, setNodeRef, transform, isDragging } =
+    useDraggable({ id, disabled });
+  const style: React.CSSProperties = transform
+    ? { transform: `translate3d(${transform.x}px, ${transform.y}px, 0)` }
+    : {};
+  return (
+    <button
+      type="button"
+      ref={setNodeRef}
+      onClick={(e) => {
+        e.preventDefault();
+        if (!disabled) onTap();
+      }}
+      style={style}
+      className={`min-h-[44px] px-3 py-2 rounded-xl text-sm font-bold border-2 select-none touch-none transition-colors ${
+        isDragging
+          ? 'opacity-40'
+          : selected
+            ? 'bg-violet-500 border-violet-400 text-white shadow-lg ring-2 ring-violet-300'
+            : 'bg-slate-700 border-slate-600 text-white hover:bg-slate-600 hover:border-violet-500/60'
+      } ${disabled ? 'cursor-default opacity-60' : 'cursor-grab active:cursor-grabbing'}`}
+      {...listeners}
+      {...attributes}
+      aria-pressed={selected}
+      aria-label={ariaLabel ?? label}
+      title={label}
+    >
+      {label}
+    </button>
+  );
+};
+
+interface DropZoneProps {
+  id: string;
+  filledLabel: string | null;
+  selectedChipId: string | null;
+  onTap: () => void;
+  onChipTap: () => void;
+  disabled?: boolean;
+  /** Term this zone belongs to — used to build the empty-state aria-label
+   *  ("Drop zone for France") so screen readers can identify the target.
+   */
+  termLabel?: string;
+}
+
+const DropZone: React.FC<DropZoneProps> = ({
+  id,
+  filledLabel,
+  selectedChipId,
+  onTap,
+  onChipTap,
+  disabled,
+  termLabel,
+}) => {
+  const { isOver, setNodeRef } = useDroppable({ id, disabled });
+  const ariaLabel = filledLabel
+    ? `${filledLabel}, matched to ${termLabel ?? ''}`.trim()
+    : `Drop zone for ${termLabel ?? 'this term'}`;
+  return (
+    <button
+      type="button"
+      ref={setNodeRef}
+      onClick={(e) => {
+        e.preventDefault();
+        if (disabled) return;
+        if (filledLabel && !selectedChipId) {
+          onChipTap();
+        } else {
+          onTap();
+        }
+      }}
+      aria-label={ariaLabel}
+      className={`flex-1 min-h-[44px] px-3 py-2 rounded-xl text-sm font-bold border-2 border-dashed transition-colors text-left ${
+        isOver
+          ? 'border-violet-400 bg-violet-500/20 text-white'
+          : filledLabel
+            ? 'border-violet-500/40 bg-violet-500/10 text-white border-solid'
+            : 'border-slate-600 bg-slate-800/40 text-slate-500'
+      } ${disabled ? 'cursor-default' : 'cursor-pointer'}`}
+    >
+      {filledLabel ?? 'Drop here'}
+    </button>
+  );
+};
+
+export const MatchingResponseInput: React.FC<MatchingResponseInputProps> = ({
+  question,
+  savedAnswer,
+  onChange,
+  disabled,
+}) => {
+  const terms = React.useMemo<string[]>(
+    () => question.matchingLeft ?? [],
+    [question.matchingLeft]
+  );
+  const allOptions = React.useMemo<string[]>(
+    () => question.matchingRight ?? [],
+    [question.matchingRight]
+  );
+
+  // ─── Initial state ────────────────────────────────────────────────────────
+  // Map term -> placed option index (into allOptions). null = empty zone.
+  // Each option index appears in at most one zone OR in the bank — never
+  // both at once. Bank order is shuffled per attempt (re-shuffles on
+  // remount via QuizStudentApp's `key={question.id}`).
+  const [placements, bankOrder] = React.useMemo(() => {
+    const initialPlacements: Record<string, number | null> = {};
+    terms.forEach((t) => {
+      initialPlacements[t] = null;
+    });
+
+    if (savedAnswer) {
+      // Hydrate placements from savedAnswer ("term:def|term:def"). Match
+      // each pair's right side against allOptions to find the option index.
+      // First-match wins (ties broken by lower index) so the same definition
+      // string appearing in multiple terms still hydrates deterministically.
+      const used = new Set<number>();
+      for (const pair of savedAnswer.split('|')) {
+        const sep = pair.indexOf(':');
+        if (sep < 0) continue;
+        const term = pair.slice(0, sep);
+        const def = pair.slice(sep + 1);
+        if (!(term in initialPlacements)) continue;
+        const idx = allOptions.findIndex(
+          (opt, i) => opt === def && !used.has(i)
+        );
+        if (idx >= 0) {
+          initialPlacements[term] = idx;
+          used.add(idx);
+        }
+      }
+    }
+
+    // Bank starts as every option index NOT placed in a zone, shuffled.
+    const placedIndices = new Set(
+      Object.values(initialPlacements).filter((v): v is number => v !== null)
+    );
+    const remaining: number[] = [];
+    for (let i = 0; i < allOptions.length; i++) {
+      if (!placedIndices.has(i)) remaining.push(i);
+    }
+    return [initialPlacements, shuffle(remaining)];
+  }, [terms, allOptions, savedAnswer]);
+
+  const [zonePlacements, setZonePlacements] = React.useState(placements);
+  const [bankItems, setBankItems] = React.useState<number[]>(bankOrder);
+  const [selectedSource, setSelectedSource] = React.useState<
+    | { kind: 'bank'; optionIndex: number }
+    | { kind: 'zone'; term: string; optionIndex: number }
+    | null
+  >(null);
+
+  // Reset state when the question changes (different question id).
+  const [prevQuestionId, setPrevQuestionId] = React.useState(question.id);
+  if (question.id !== prevQuestionId) {
+    setPrevQuestionId(question.id);
+    setZonePlacements(placements);
+    setBankItems(bankOrder);
+    setSelectedSource(null);
+  }
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 4 } }),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    })
+  );
+
+  // ─── Emit serialized answer on placement changes ─────────────────────────
+  const emit = React.useCallback(
+    (zones: Record<string, number | null>) => {
+      const answer = terms
+        .map((t) => {
+          const idx = zones[t];
+          const def = idx !== null && idx !== undefined ? allOptions[idx] : '';
+          return `${t}:${def}`;
+        })
+        .join('|');
+      onChange(answer);
+    },
+    [terms, allOptions, onChange]
+  );
+
+  // ─── Move helpers ────────────────────────────────────────────────────────
+  /**
+   * Place an option (by index) into a zone. Source can be the bank or
+   * another zone. Anything currently in the target zone is bounced back
+   * to the bank — order preserved for the bank items already there, with
+   * the bounced item appended at the end (most recently freed).
+   *
+   * Computes both `next` placements and `nextBank` from current state in
+   * one synchronous pass, then issues the state setters and `emit()` —
+   * never inside a setState updater (React purity contract; updaters get
+   * invoked twice in StrictMode).
+   */
+  const placeInZone = (
+    optionIndex: number,
+    targetTerm: string,
+    source: 'bank' | { fromTerm: string }
+  ) => {
+    const next = { ...zonePlacements };
+    const displaced = next[targetTerm];
+    next[targetTerm] = optionIndex;
+    if (source !== 'bank') {
+      next[source.fromTerm] = null;
+    }
+    let nextBank = bankItems;
+    if (source === 'bank') {
+      nextBank = nextBank.filter((i) => i !== optionIndex);
+    }
+    if (displaced !== null && displaced !== undefined) {
+      nextBank = [...nextBank, displaced];
+    }
+    setZonePlacements(next);
+    setBankItems(nextBank);
+    setSelectedSource(null);
+    emit(next);
+  };
+
+  /** Return a placed option from a zone back to the bank. */
+  const returnToBank = (term: string) => {
+    const idx = zonePlacements[term];
+    if (idx === null || idx === undefined) return;
+    const next = { ...zonePlacements, [term]: null };
+    const nextBank = [...bankItems, idx];
+    setZonePlacements(next);
+    setBankItems(nextBank);
+    setSelectedSource(null);
+    emit(next);
+  };
+
+  const reset = () => {
+    const blank: Record<string, number | null> = {};
+    terms.forEach((t) => {
+      blank[t] = null;
+    });
+    setZonePlacements(blank);
+    setBankItems(shuffle(allOptions.map((_, i) => i)));
+    setSelectedSource(null);
+    emit(blank);
+  };
+
+  // ─── Drag handlers ────────────────────────────────────────────────────────
+  const handleDragEnd = (e: DragEndEvent) => {
+    if (disabled) return;
+    const { active, over } = e;
+    if (!over) return;
+    const activeId = String(active.id);
+    const overId = String(over.id);
+
+    // Active id encodes source: "bank-<idx>" or "zone-<term>"
+    if (activeId.startsWith('bank-')) {
+      const optionIndex = Number(activeId.slice('bank-'.length));
+      if (overId.startsWith('zone-')) {
+        const term = overId.slice('zone-'.length);
+        placeInZone(optionIndex, term, 'bank');
+      }
+      // Drop on bank (or anywhere else) is a no-op.
+    } else if (activeId.startsWith('zone-')) {
+      const fromTerm = activeId.slice('zone-'.length);
+      const optionIndex = zonePlacements[fromTerm];
+      if (optionIndex === null || optionIndex === undefined) return;
+      if (overId === BANK_ID) {
+        returnToBank(fromTerm);
+      } else if (overId.startsWith('zone-')) {
+        const targetTerm = overId.slice('zone-'.length);
+        if (targetTerm === fromTerm) return;
+        placeInZone(optionIndex, targetTerm, { fromTerm });
+      }
+    }
+  };
+
+  // ─── Tap-to-place handlers ────────────────────────────────────────────────
+  const handleBankChipTap = (optionIndex: number) => {
+    if (disabled) return;
+    if (
+      selectedSource?.kind === 'bank' &&
+      selectedSource.optionIndex === optionIndex
+    ) {
+      setSelectedSource(null);
+      return;
+    }
+    setSelectedSource({ kind: 'bank', optionIndex });
+  };
+
+  const handleZoneTap = (term: string) => {
+    if (disabled || !selectedSource) return;
+    if (selectedSource.kind === 'bank') {
+      placeInZone(selectedSource.optionIndex, term, 'bank');
+    } else if (selectedSource.kind === 'zone') {
+      if (selectedSource.term === term) return;
+      placeInZone(selectedSource.optionIndex, term, {
+        fromTerm: selectedSource.term,
+      });
+    }
+  };
+
+  const handleZoneChipTap = (term: string) => {
+    if (disabled) return;
+    const optionIndex = zonePlacements[term];
+    if (optionIndex === null || optionIndex === undefined) return;
+    // Toggle selection on the placed chip (long-press alternative would be
+    // a drag back to the bank — supported via dnd-kit too).
+    if (selectedSource?.kind === 'zone' && selectedSource.term === term) {
+      // Already selected → tap again to send back to bank.
+      returnToBank(term);
+      return;
+    }
+    setSelectedSource({ kind: 'zone', term, optionIndex });
+  };
+
+  return (
+    <DndContext
+      sensors={sensors}
+      collisionDetection={rectIntersection}
+      onDragEnd={handleDragEnd}
+    >
+      <div className="space-y-4">
+        {/* Term + zone rows */}
+        <div className="space-y-2">
+          {terms.map((term) => {
+            const placedIdx = zonePlacements[term];
+            const placedLabel =
+              placedIdx !== null && placedIdx !== undefined
+                ? allOptions[placedIdx]
+                : null;
+            const placedSelected =
+              selectedSource?.kind === 'zone' && selectedSource.term === term;
+            return (
+              <div key={term} className="flex items-center gap-3">
+                <span
+                  className="text-sm text-slate-200 font-bold w-1/2 break-words"
+                  title={term}
+                >
+                  {term}
+                </span>
+                {placedLabel ? (
+                  <DraggableChip
+                    id={`zone-${term}`}
+                    label={placedLabel}
+                    selected={placedSelected}
+                    disabled={disabled}
+                    onTap={() => handleZoneChipTap(term)}
+                    ariaLabel={`${placedLabel}, matched to ${term}`}
+                  />
+                ) : (
+                  <DropZone
+                    id={`zone-${term}`}
+                    filledLabel={null}
+                    selectedChipId={null}
+                    onTap={() => handleZoneTap(term)}
+                    onChipTap={() => handleZoneChipTap(term)}
+                    disabled={disabled}
+                    termLabel={term}
+                  />
+                )}
+              </div>
+            );
+          })}
+        </div>
+
+        {/* Word bank */}
+        <BankDropZone>
+          <div className="flex items-center justify-between mb-2">
+            <span className="text-xs uppercase tracking-wider text-slate-400 font-bold">
+              Word Bank
+            </span>
+            <button
+              type="button"
+              onClick={reset}
+              disabled={disabled}
+              className="flex items-center gap-1 px-2 py-1 text-xs font-bold text-slate-400 hover:text-white hover:bg-slate-700 rounded-lg transition-colors disabled:opacity-30"
+              aria-label="Reset all placements"
+            >
+              <RotateCcw className="w-3.5 h-3.5" />
+              Reset
+            </button>
+          </div>
+          <div className="flex flex-wrap gap-2 min-h-[48px]">
+            {bankItems.length === 0 && (
+              <span className="text-xs text-slate-500 italic px-2 py-1">
+                All options placed.
+              </span>
+            )}
+            {bankItems.map((optionIndex) => {
+              const selected =
+                selectedSource?.kind === 'bank' &&
+                selectedSource.optionIndex === optionIndex;
+              return (
+                <DraggableChip
+                  key={optionIndex}
+                  id={`bank-${optionIndex}`}
+                  label={allOptions[optionIndex]}
+                  selected={selected}
+                  disabled={disabled}
+                  onTap={() => handleBankChipTap(optionIndex)}
+                  ariaLabel={`${allOptions[optionIndex]}, in word bank`}
+                />
+              );
+            })}
+          </div>
+        </BankDropZone>
+      </div>
+    </DndContext>
+  );
+};
+
+const BankDropZone: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => {
+  const { isOver, setNodeRef } = useDroppable({ id: BANK_ID });
+  return (
+    <div
+      ref={setNodeRef}
+      className={`p-3 rounded-2xl border-2 border-dashed transition-colors ${
+        isOver
+          ? 'border-violet-400 bg-violet-500/10'
+          : 'border-slate-700 bg-slate-900/40'
+      }`}
+    >
+      {children}
+    </div>
+  );
+};

--- a/components/quiz/OrderingResponseInput.tsx
+++ b/components/quiz/OrderingResponseInput.tsx
@@ -1,0 +1,482 @@
+/**
+ * Student-facing ordering question input. Numbered drop zones (1, 2, 3, …)
+ * stack vertically; below them a word bank holds unplaced items in a
+ * per-attempt unique shuffle. Students drag (or tap-to-place) items into
+ * the slots, rearrange between zones, or send items back to the bank.
+ *
+ * Builds the legacy pipe-joined wire format on every change so the
+ * teacher's `gradeAnswer()` continues to work.
+ */
+
+import React from 'react';
+import {
+  DndContext,
+  PointerSensor,
+  KeyboardSensor,
+  useSensor,
+  useSensors,
+  rectIntersection,
+  useDroppable,
+  useDraggable,
+  type DragEndEvent,
+} from '@dnd-kit/core';
+import { sortableKeyboardCoordinates } from '@dnd-kit/sortable';
+import { RotateCcw } from 'lucide-react';
+import type { QuizPublicQuestion } from '@/types';
+
+interface OrderingResponseInputProps {
+  question: QuizPublicQuestion;
+  savedAnswer: string | null;
+  onChange: (answer: string) => void;
+  disabled?: boolean;
+}
+
+const BANK_ID = '__bank__';
+
+function shuffle<T>(arr: T[]): T[] {
+  const out = [...arr];
+  for (let i = out.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [out[i], out[j]] = [out[j], out[i]];
+  }
+  return out;
+}
+
+const DraggableChip: React.FC<{
+  id: string;
+  label: string;
+  selected: boolean;
+  disabled?: boolean;
+  onTap: () => void;
+  ariaLabel?: string;
+}> = ({ id, label, selected, disabled, onTap, ariaLabel }) => {
+  const { attributes, listeners, setNodeRef, transform, isDragging } =
+    useDraggable({ id, disabled });
+  const style: React.CSSProperties = transform
+    ? { transform: `translate3d(${transform.x}px, ${transform.y}px, 0)` }
+    : {};
+  return (
+    <button
+      type="button"
+      ref={setNodeRef}
+      onClick={(e) => {
+        e.preventDefault();
+        if (!disabled) onTap();
+      }}
+      style={style}
+      className={`min-h-[44px] px-3 py-2 rounded-xl text-sm font-bold border-2 select-none touch-none transition-colors ${
+        isDragging
+          ? 'opacity-40'
+          : selected
+            ? 'bg-violet-500 border-violet-400 text-white shadow-lg ring-2 ring-violet-300'
+            : 'bg-slate-700 border-slate-600 text-white hover:bg-slate-600 hover:border-violet-500/60'
+      } ${disabled ? 'cursor-default opacity-60' : 'cursor-grab active:cursor-grabbing'}`}
+      {...listeners}
+      {...attributes}
+      aria-pressed={selected}
+      aria-label={ariaLabel ?? label}
+      title={label}
+    >
+      {label}
+    </button>
+  );
+};
+
+const Slot: React.FC<{
+  id: string;
+  index: number;
+  filledLabel: string | null;
+  selectedHere: boolean;
+  onTapEmpty: () => void;
+  onChipTap: () => void;
+  onMove: (dir: 'up' | 'down') => void;
+  upDisabled: boolean;
+  downDisabled: boolean;
+  disabled?: boolean;
+}> = ({
+  id,
+  index,
+  filledLabel,
+  selectedHere,
+  onTapEmpty,
+  onChipTap,
+  onMove,
+  upDisabled,
+  downDisabled,
+  disabled,
+}) => {
+  const { isOver, setNodeRef } = useDroppable({ id, disabled });
+  const {
+    attributes,
+    listeners,
+    setNodeRef: setDragRef,
+    transform,
+    isDragging,
+  } = useDraggable({
+    id: `slot-${index}`,
+    disabled: (disabled ?? false) || filledLabel === null,
+  });
+  const dragStyle: React.CSSProperties = transform
+    ? { transform: `translate3d(${transform.x}px, ${transform.y}px, 0)` }
+    : {};
+  const slotPosition = `position ${index + 1}`;
+  return (
+    <div ref={setNodeRef} className="flex items-center gap-2">
+      <span className="text-violet-400 font-black text-sm w-6 shrink-0 text-center">
+        {index + 1}.
+      </span>
+      {filledLabel ? (
+        <button
+          type="button"
+          ref={setDragRef}
+          onClick={(e) => {
+            e.preventDefault();
+            if (!disabled) onChipTap();
+          }}
+          style={dragStyle}
+          title={filledLabel}
+          className={`flex-1 min-h-[44px] px-3 py-2 rounded-xl text-sm font-bold border-2 transition-colors text-left select-none touch-none ${
+            isDragging
+              ? 'opacity-40'
+              : selectedHere
+                ? 'bg-violet-500 border-violet-400 text-white shadow-lg ring-2 ring-violet-300'
+                : 'bg-slate-700 border-slate-600 text-white hover:bg-slate-600 hover:border-violet-500/60'
+          } ${disabled ? 'cursor-default' : 'cursor-grab active:cursor-grabbing'}`}
+          {...listeners}
+          {...attributes}
+          aria-label={`${filledLabel}, ${slotPosition}`}
+          aria-pressed={selectedHere}
+        >
+          {filledLabel}
+        </button>
+      ) : (
+        <button
+          type="button"
+          onClick={(e) => {
+            e.preventDefault();
+            if (!disabled) onTapEmpty();
+          }}
+          aria-label={`Empty drop zone, ${slotPosition}`}
+          className={`flex-1 min-h-[44px] px-3 py-2 rounded-xl text-sm font-bold border-2 border-dashed transition-colors text-left ${
+            isOver
+              ? 'border-violet-400 bg-violet-500/20 text-white'
+              : 'border-slate-600 bg-slate-800/40 text-slate-500'
+          } ${disabled ? 'cursor-default' : 'cursor-pointer'}`}
+        >
+          Drop here
+        </button>
+      )}
+      <div className="flex flex-col">
+        <button
+          type="button"
+          onClick={() => onMove('up')}
+          disabled={(disabled ?? false) || upDisabled || !filledLabel}
+          className="min-w-[32px] min-h-[22px] p-1 text-slate-400 hover:text-white disabled:opacity-20 transition-colors"
+          aria-label={`Move ${slotPosition} up`}
+        >
+          ▲
+        </button>
+        <button
+          type="button"
+          onClick={() => onMove('down')}
+          disabled={(disabled ?? false) || downDisabled || !filledLabel}
+          className="min-w-[32px] min-h-[22px] p-1 text-slate-400 hover:text-white disabled:opacity-20 transition-colors"
+          aria-label={`Move ${slotPosition} down`}
+        >
+          ▼
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export const OrderingResponseInput: React.FC<OrderingResponseInputProps> = ({
+  question,
+  savedAnswer,
+  onChange,
+  disabled,
+}) => {
+  const items = React.useMemo<string[]>(
+    () => question.orderingItems ?? [],
+    [question.orderingItems]
+  );
+
+  // Slot state: each slot holds either an item index (into `items`) or null.
+  // Bank holds the rest, in shuffled order. Per-attempt re-shuffle on
+  // remount via `key={question.id}` in QuizStudentApp.
+  const [initialSlots, initialBank] = React.useMemo(() => {
+    const slots: (number | null)[] = items.map(() => null);
+    const used = new Set<number>();
+    if (savedAnswer) {
+      const parts = savedAnswer.split('|');
+      for (let i = 0; i < parts.length && i < items.length; i++) {
+        const idx = items.findIndex(
+          (item, j) => item === parts[i] && !used.has(j)
+        );
+        if (idx >= 0) {
+          slots[i] = idx;
+          used.add(idx);
+        }
+      }
+    }
+    const bank: number[] = [];
+    for (let i = 0; i < items.length; i++) {
+      if (!used.has(i)) bank.push(i);
+    }
+    return [slots, shuffle(bank)];
+  }, [items, savedAnswer]);
+
+  const [slots, setSlots] = React.useState<(number | null)[]>(initialSlots);
+  const [bankItems, setBankItems] = React.useState<number[]>(initialBank);
+  const [selectedSource, setSelectedSource] = React.useState<
+    | { kind: 'bank'; itemIndex: number }
+    | { kind: 'slot'; slotIndex: number; itemIndex: number }
+    | null
+  >(null);
+
+  const [prevQuestionId, setPrevQuestionId] = React.useState(question.id);
+  if (question.id !== prevQuestionId) {
+    setPrevQuestionId(question.id);
+    setSlots(initialSlots);
+    setBankItems(initialBank);
+    setSelectedSource(null);
+  }
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 4 } }),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    })
+  );
+
+  const emit = React.useCallback(
+    (next: (number | null)[]) => {
+      const answer = next
+        .map((idx) => (idx !== null && idx !== undefined ? items[idx] : ''))
+        .join('|');
+      onChange(answer);
+    },
+    [items, onChange]
+  );
+
+  // ─── Mutation helpers ─────────────────────────────────────────────────────
+  /** Place an item into a slot. Source = bank or another slot. */
+  // Compute next state outside the setState updater (React purity) so
+  // emit/onChange isn't invoked twice in StrictMode.
+  const placeInSlot = (
+    itemIndex: number,
+    targetSlot: number,
+    source: 'bank' | { fromSlot: number }
+  ) => {
+    const next = [...slots];
+    const displaced = next[targetSlot];
+    next[targetSlot] = itemIndex;
+    if (source !== 'bank') {
+      next[source.fromSlot] = null;
+    }
+    let nextBank = bankItems;
+    if (source === 'bank') {
+      nextBank = nextBank.filter((i) => i !== itemIndex);
+    }
+    if (displaced !== null && displaced !== undefined) {
+      nextBank = [...nextBank, displaced];
+    }
+    setSlots(next);
+    setBankItems(nextBank);
+    setSelectedSource(null);
+    emit(next);
+  };
+
+  const returnToBank = (slotIndex: number) => {
+    const idx = slots[slotIndex];
+    if (idx === null || idx === undefined) return;
+    const next = [...slots];
+    next[slotIndex] = null;
+    setSlots(next);
+    setBankItems([...bankItems, idx]);
+    setSelectedSource(null);
+    emit(next);
+  };
+
+  const swapSlots = (slotIndex: number, dir: 'up' | 'down') => {
+    const target = dir === 'up' ? slotIndex - 1 : slotIndex + 1;
+    if (target < 0 || target >= slots.length) return;
+    const next = [...slots];
+    [next[slotIndex], next[target]] = [next[target], next[slotIndex]];
+    setSlots(next);
+    setSelectedSource(null);
+    emit(next);
+  };
+
+  const reset = () => {
+    const blank = items.map(() => null);
+    setSlots(blank);
+    setBankItems(shuffle(items.map((_, i) => i)));
+    setSelectedSource(null);
+    emit(blank);
+  };
+
+  // ─── Drag handlers ────────────────────────────────────────────────────────
+  const handleDragEnd = (e: DragEndEvent) => {
+    if (disabled) return;
+    const { active, over } = e;
+    if (!over) return;
+    const activeId = String(active.id);
+    const overId = String(over.id);
+
+    if (activeId.startsWith('bank-')) {
+      const itemIndex = Number(activeId.slice('bank-'.length));
+      if (overId.startsWith('slot-')) {
+        const target = Number(overId.slice('slot-'.length));
+        // Only allow drop on an empty target — slots that are full route
+        // through their chip handle and are handled by the slot-drag branch.
+        // If the target is full, swap the items: bank in, displaced to bank.
+        placeInSlot(itemIndex, target, 'bank');
+      }
+    } else if (activeId.startsWith('slot-')) {
+      const fromSlot = Number(activeId.slice('slot-'.length));
+      const itemIndex = slots[fromSlot];
+      if (itemIndex === null || itemIndex === undefined) return;
+      if (overId === BANK_ID) {
+        returnToBank(fromSlot);
+      } else if (overId.startsWith('slot-')) {
+        const targetSlot = Number(overId.slice('slot-'.length));
+        if (targetSlot === fromSlot) return;
+        placeInSlot(itemIndex, targetSlot, { fromSlot });
+      }
+    }
+  };
+
+  // ─── Tap-to-place handlers ────────────────────────────────────────────────
+  const handleBankChipTap = (itemIndex: number) => {
+    if (disabled) return;
+    if (
+      selectedSource?.kind === 'bank' &&
+      selectedSource.itemIndex === itemIndex
+    ) {
+      setSelectedSource(null);
+      return;
+    }
+    setSelectedSource({ kind: 'bank', itemIndex });
+  };
+
+  const handleEmptySlotTap = (slotIndex: number) => {
+    if (disabled || !selectedSource) return;
+    if (selectedSource.kind === 'bank') {
+      placeInSlot(selectedSource.itemIndex, slotIndex, 'bank');
+    } else {
+      if (selectedSource.slotIndex === slotIndex) return;
+      placeInSlot(selectedSource.itemIndex, slotIndex, {
+        fromSlot: selectedSource.slotIndex,
+      });
+    }
+  };
+
+  const handleSlotChipTap = (slotIndex: number) => {
+    if (disabled) return;
+    const itemIndex = slots[slotIndex];
+    if (itemIndex === null || itemIndex === undefined) return;
+    if (
+      selectedSource?.kind === 'slot' &&
+      selectedSource.slotIndex === slotIndex
+    ) {
+      // Tap a selected slot chip again → return to bank.
+      returnToBank(slotIndex);
+      return;
+    }
+    setSelectedSource({ kind: 'slot', slotIndex, itemIndex });
+  };
+
+  return (
+    <DndContext
+      sensors={sensors}
+      collisionDetection={rectIntersection}
+      onDragEnd={handleDragEnd}
+    >
+      <div className="space-y-4">
+        <div className="space-y-2">
+          {slots.map((slot, i) => {
+            const label =
+              slot !== null && slot !== undefined ? items[slot] : null;
+            const selectedHere =
+              selectedSource?.kind === 'slot' && selectedSource.slotIndex === i;
+            return (
+              <Slot
+                key={i}
+                id={`slot-${i}`}
+                index={i}
+                filledLabel={label}
+                selectedHere={selectedHere}
+                onTapEmpty={() => handleEmptySlotTap(i)}
+                onChipTap={() => handleSlotChipTap(i)}
+                onMove={(dir) => swapSlots(i, dir)}
+                upDisabled={i === 0}
+                downDisabled={i === slots.length - 1}
+                disabled={disabled}
+              />
+            );
+          })}
+        </div>
+
+        <BankDropZone>
+          <div className="flex items-center justify-between mb-2">
+            <span className="text-xs uppercase tracking-wider text-slate-400 font-bold">
+              Word Bank
+            </span>
+            <button
+              type="button"
+              onClick={reset}
+              disabled={disabled}
+              className="flex items-center gap-1 px-2 py-1 text-xs font-bold text-slate-400 hover:text-white hover:bg-slate-700 rounded-lg transition-colors disabled:opacity-30"
+              aria-label="Reset all placements"
+            >
+              <RotateCcw className="w-3.5 h-3.5" />
+              Reset
+            </button>
+          </div>
+          <div className="flex flex-wrap gap-2 min-h-[48px]">
+            {bankItems.length === 0 && (
+              <span className="text-xs text-slate-500 italic px-2 py-1">
+                All items placed.
+              </span>
+            )}
+            {bankItems.map((itemIndex) => {
+              const selected =
+                selectedSource?.kind === 'bank' &&
+                selectedSource.itemIndex === itemIndex;
+              return (
+                <DraggableChip
+                  key={itemIndex}
+                  id={`bank-${itemIndex}`}
+                  label={items[itemIndex]}
+                  selected={selected}
+                  disabled={disabled}
+                  onTap={() => handleBankChipTap(itemIndex)}
+                  ariaLabel={`${items[itemIndex]}, in word bank`}
+                />
+              );
+            })}
+          </div>
+        </BankDropZone>
+      </div>
+    </DndContext>
+  );
+};
+
+const BankDropZone: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => {
+  const { isOver, setNodeRef } = useDroppable({ id: BANK_ID });
+  return (
+    <div
+      ref={setNodeRef}
+      className={`p-3 rounded-2xl border-2 border-dashed transition-colors ${
+        isOver
+          ? 'border-violet-400 bg-violet-500/10'
+          : 'border-slate-700 bg-slate-900/40'
+      }`}
+    >
+      {children}
+    </div>
+  );
+};

--- a/components/quiz/QuizStudentApp.tsx
+++ b/components/quiz/QuizStudentApp.tsx
@@ -50,6 +50,8 @@ import { QuizSession, QuizPublicQuestion } from '@/types';
 import { useDialog } from '@/context/useDialog';
 import { StudentLeaderboard } from './StudentLeaderboard';
 import { QuizPausedPlaceholder } from './QuizPausedPlaceholder';
+import { MatchingResponseInput } from './MatchingResponseInput';
+import { OrderingResponseInput } from './OrderingResponseInput';
 import {
   getScoreSuffix,
   isGamificationActive,
@@ -827,6 +829,10 @@ const ActiveQuiz: React.FC<{
   const fibAnswerRef = useRef(fibAnswer);
   const draftMcAnswerRef = useRef(draftMcAnswer);
   const onAnswerRef = useRef(onAnswer);
+  // Live serialized answer for Matching/Ordering, written by the child
+  // StructuredQuestionInput on every drag/tap so timer auto-submit can
+  // capture partial placements instead of submitting the empty string.
+  const structuredAnswerRef = useRef<string>('');
 
   useEffect(() => {
     currentQuestionRef.current = currentQuestion;
@@ -835,6 +841,16 @@ const ActiveQuiz: React.FC<{
     draftMcAnswerRef.current = draftMcAnswer;
     onAnswerRef.current = onAnswer;
   }, [currentQuestion, selectedAnswer, fibAnswer, draftMcAnswer, onAnswer]);
+
+  // Reset the structured answer ref when the question changes so a stale
+  // answer from a previous question can't leak into auto-submit.
+  const [prevStructuredQuestionId, setPrevStructuredQuestionId] = useState(
+    currentQuestion?.id ?? null
+  );
+  if ((currentQuestion?.id ?? null) !== prevStructuredQuestionId) {
+    setPrevStructuredQuestionId(currentQuestion?.id ?? null);
+    structuredAnswerRef.current = '';
+  }
 
   // Countdown — only runs the interval; auto-submit is handled above.
   useEffect(() => {
@@ -863,13 +879,20 @@ const ActiveQuiz: React.FC<{
     if (!autoSubmitTriggeredFor) return;
     const question = currentQuestionRef.current;
     if (!question || question.id !== autoSubmitTriggeredFor) return;
+    // Pull from the type-appropriate live ref so a half-completed
+    // matching/ordering answer is preserved on timeout instead of
+    // submitting the empty string.
+    const answer =
+      question.type === 'Matching' || question.type === 'Ordering'
+        ? structuredAnswerRef.current
+        : (selectedAnswerRef.current ??
+          draftMcAnswerRef.current ??
+          fibAnswerRef.current ??
+          '');
     void onAnswerRef
       .current(
         autoSubmitTriggeredFor,
-        selectedAnswerRef.current ??
-          draftMcAnswerRef.current ??
-          fibAnswerRef.current ??
-          '',
+        answer,
         0 // Speed bonus is 0 when timer expires
       )
       .catch((err: unknown) => {
@@ -1412,6 +1435,9 @@ const ActiveQuiz: React.FC<{
             savedAnswer={savedAnswerForCurrent}
             onSubmit={(answer) => void handleSubmit(answer)}
             onSubmitAndAdvance={(answer) => void handleSubmitAndAdvance(answer)}
+            onAnswerChange={(answer) => {
+              structuredAnswerRef.current = answer;
+            }}
             submitting={submitting}
             isStudentPaced={isStudentPaced}
             isLastQuestion={currentIndex >= session.totalQuestions - 1}
@@ -1433,6 +1459,12 @@ const StructuredQuestionInput: React.FC<{
   savedAnswer: string | null;
   onSubmit: (answer: string) => void;
   onSubmitAndAdvance: (answer: string) => void;
+  /**
+   * Forwarded to the parent so it can keep a ref to the live partial answer.
+   * Timer auto-submit reads from this ref to preserve the student's work
+   * when the clock runs out mid-placement.
+   */
+  onAnswerChange?: (answer: string) => void;
   submitting: boolean;
   isStudentPaced: boolean;
   isLastQuestion: boolean;
@@ -1445,6 +1477,7 @@ const StructuredQuestionInput: React.FC<{
   savedAnswer,
   onSubmit,
   onSubmitAndAdvance,
+  onAnswerChange,
   submitting,
   isStudentPaced,
   isLastQuestion,
@@ -1458,80 +1491,52 @@ const StructuredQuestionInput: React.FC<{
     ? (question.matchingLeft ?? [])
     : (question.orderingItems ?? []);
 
-  const rightItemsShuffled: string[] = isMatching
-    ? (question.matchingRight ?? [])
-    : [];
+  // Live serialized answer driven by the structured input components below.
+  // `canSubmit` derives from this string: every term/slot must be filled
+  // (the structured inputs emit blank segments — `term:` or `||` — when a
+  // zone is empty, so we check for any blank token).
+  const [currentAnswer, setCurrentAnswer] = useState<string>(savedAnswer ?? '');
 
-  // Hydrate from a saved answer on mount (back-navigation in self-paced
-  // mode). The component remounts per question via `key={question.id}` so
-  // initial state is recomputed each visit.
-  const [matchings, setMatchings] = useState<Record<string, string>>(() => {
-    const base: Record<string, string> = Object.fromEntries(
-      leftItems.map((l: string) => [l, ''])
-    );
-    if (isMatching && savedAnswer) {
-      for (const pair of savedAnswer.split('|')) {
-        const sep = pair.indexOf(':');
-        if (sep < 0) continue;
-        const l = pair.slice(0, sep);
-        const r = pair.slice(sep + 1);
-        if (l in base) base[l] = r;
-      }
-    }
-    return base;
-  });
-  const [order, setOrder] = useState<string[]>(() => {
-    if (!isMatching && savedAnswer) {
-      const parsed = savedAnswer.split('|');
-      // Only adopt the saved order if it matches the current item set,
-      // otherwise fall back to the question's default ordering.
-      if (
-        parsed.length === leftItems.length &&
-        parsed.every((p) => leftItems.includes(p))
-      ) {
-        return parsed;
-      }
-    }
-    return [...leftItems];
-  });
-
-  const canSubmit = isMatching
-    ? Object.values(matchings).every((v: string) => !!v)
-    : order.length > 0 && order.length === leftItems.length;
-
-  const buildAnswer = (): string => {
-    if (isMatching) {
-      return leftItems
-        .map((l: string) => `${l}:${matchings[l] || ''}`)
-        .join('|');
-    }
-    return order.join('|');
+  // Mirror every change up to the parent ref so timer auto-submit can
+  // capture partial placements. We can't use the inline setter (the parent
+  // stores the value in a useRef, not state) so an explicit propagation
+  // call is required.
+  const handleAnswerChange = (answer: string) => {
+    setCurrentAnswer(answer);
+    onAnswerChange?.(answer);
   };
+
+  // Seed the parent ref with the hydrated savedAnswer on mount so timer
+  // auto-submit on a never-touched revisit still preserves the saved work.
+  useEffect(() => {
+    if (savedAnswer) onAnswerChange?.(savedAnswer);
+    // Intentionally only on mount — the child component's onChange covers
+    // every subsequent update.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const canSubmit = useMemo(() => {
+    if (!currentAnswer) return false;
+    const segments = currentAnswer.split('|');
+    if (isMatching) {
+      if (segments.length !== leftItems.length) return false;
+      return segments.every((s) => {
+        const sep = s.indexOf(':');
+        return sep >= 0 && s.slice(sep + 1).length > 0;
+      });
+    }
+    return (
+      segments.length === leftItems.length &&
+      segments.every((s) => s.length > 0)
+    );
+  }, [currentAnswer, isMatching, leftItems.length]);
 
   const handleSubmitStructured = () => {
     if (isStudentPaced) {
-      onSubmitAndAdvance(buildAnswer());
+      onSubmitAndAdvance(currentAnswer);
     } else {
-      onSubmit(buildAnswer());
+      onSubmit(currentAnswer);
     }
-  };
-
-  // ─── Drag and Drop Handlers ────────────────────────────────────────────────
-  const [draggedIndex, setDraggedIndex] = useState<number | null>(null);
-
-  const handleDragStart = (index: number) => {
-    setDraggedIndex(index);
-  };
-
-  const handleDragOver = (e: React.DragEvent, index: number) => {
-    e.preventDefault();
-    if (draggedIndex === null || draggedIndex === index) return;
-
-    const newOrder = [...order];
-    const item = newOrder.splice(draggedIndex, 1)[0];
-    newOrder.splice(index, 0, item);
-    setOrder(newOrder);
-    setDraggedIndex(index);
   };
 
   // Self-paced revisits stay editable. We only switch out of the form for
@@ -1547,84 +1552,19 @@ const StructuredQuestionInput: React.FC<{
       {showEditableForm ? (
         <>
           {isMatching ? (
-            <div className="space-y-3">
-              {leftItems.map((left: string) => (
-                <div key={left} className="flex items-center gap-3">
-                  <span className="text-sm text-slate-300 w-1/2">{left}</span>
-                  <select
-                    value={matchings[left]}
-                    onChange={(e) =>
-                      setMatchings((m) => ({ ...m, [left]: e.target.value }))
-                    }
-                    className="flex-1 px-3 py-2 bg-slate-800 border border-slate-700 rounded-xl text-white text-sm focus:outline-none focus:ring-1 focus:ring-violet-500"
-                  >
-                    <option value="">Select…</option>
-                    {rightItemsShuffled.map((r: string) => (
-                      <option key={r} value={r}>
-                        {r}
-                      </option>
-                    ))}
-                  </select>
-                </div>
-              ))}
-            </div>
+            <MatchingResponseInput
+              question={question}
+              savedAnswer={savedAnswer}
+              onChange={handleAnswerChange}
+              disabled={submitting}
+            />
           ) : (
-            <div className="space-y-2">
-              <p className="text-xs text-slate-500 mb-2">
-                Drag or use arrows to set the correct order:
-              </p>
-              {order.map((item: string, i: number) => (
-                <div
-                  key={item}
-                  draggable
-                  onDragStart={() => handleDragStart(i)}
-                  onDragOver={(e) => handleDragOver(e, i)}
-                  onDragEnd={() => setDraggedIndex(null)}
-                  className={`flex items-center gap-2 bg-slate-800 border rounded-xl px-4 py-3 cursor-grab active:cursor-grabbing transition-colors ${draggedIndex === i ? 'border-violet-500 bg-violet-500/10' : 'border-slate-700'}`}
-                >
-                  <span className="text-violet-400 font-bold text-sm w-5">
-                    {i + 1}.
-                  </span>
-                  <span className="flex-1 text-sm text-white select-none">
-                    {item}
-                  </span>
-                  <div className="flex gap-1">
-                    <button
-                      onClick={() => {
-                        if (i > 0) {
-                          const newOrder = [...order];
-                          [newOrder[i - 1], newOrder[i]] = [
-                            newOrder[i],
-                            newOrder[i - 1],
-                          ];
-                          setOrder(newOrder);
-                        }
-                      }}
-                      disabled={i === 0}
-                      className="p-1 text-slate-500 hover:text-white disabled:opacity-30 transition-colors"
-                    >
-                      ▲
-                    </button>
-                    <button
-                      onClick={() => {
-                        if (i < order.length - 1) {
-                          const newOrder = [...order];
-                          [newOrder[i], newOrder[i + 1]] = [
-                            newOrder[i + 1],
-                            newOrder[i],
-                          ];
-                          setOrder(newOrder);
-                        }
-                      }}
-                      disabled={i === order.length - 1}
-                      className="p-1 text-slate-500 hover:text-white disabled:opacity-30 transition-colors"
-                    >
-                      ▼
-                    </button>
-                  </div>
-                </div>
-              ))}
-            </div>
+            <OrderingResponseInput
+              question={question}
+              savedAnswer={savedAnswer}
+              onChange={handleAnswerChange}
+              disabled={submitting}
+            />
           )}
 
           {isStudentPaced && saveError && (

--- a/components/widgets/QuizWidget/components/MatchingOrderingEditor.tsx
+++ b/components/widgets/QuizWidget/components/MatchingOrderingEditor.tsx
@@ -1,0 +1,559 @@
+/**
+ * Structured row editors for Matching and Ordering quiz answer keys.
+ *
+ * Replaces the legacy single-text-input that asked teachers to type
+ * `term:def|term:def` or `item|item|item` strings. Both editors serialize
+ * back to the same wire format so old quizzes continue to grade and new
+ * quizzes stay on the same Drive schema.
+ */
+
+import React from 'react';
+import { GripVertical, Plus, Trash2 } from 'lucide-react';
+import {
+  DndContext,
+  PointerSensor,
+  KeyboardSensor,
+  closestCenter,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from '@dnd-kit/core';
+import {
+  SortableContext,
+  arrayMove,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+interface PairRow {
+  id: string;
+  term: string;
+  definition: string;
+}
+
+interface OrderRow {
+  id: string;
+  text: string;
+}
+
+const newId = () =>
+  typeof crypto !== 'undefined' && 'randomUUID' in crypto
+    ? crypto.randomUUID()
+    : `row-${Math.random().toString(36).slice(2)}`;
+
+/**
+ * Strip wire-format delimiters from a teacher-typed field. The
+ * `correctAnswer` schema is `term:def|term:def`, so any literal `|` or
+ * (in a term) `:` would split a single field into two and corrupt grading.
+ * Replaced silently with the closest unicode lookalike on each keystroke.
+ */
+const sanitizeTerm = (value: string): string =>
+  value.replace(/\|/g, '｜').replace(/:/g, '：');
+const sanitizeDefinition = (value: string): string =>
+  value.replace(/\|/g, '｜');
+const sanitizeOrderingItem = (value: string): string =>
+  value.replace(/\|/g, '｜');
+
+/**
+ * Parse a matching `correctAnswer` string (`term1:def1|term2:def2`) into
+ * editable rows. Empty / malformed input falls back to two blank rows so
+ * the editor always has something to render.
+ */
+function parsePairs(correctAnswer: string): PairRow[] {
+  if (!correctAnswer.trim()) {
+    return [
+      { id: newId(), term: '', definition: '' },
+      { id: newId(), term: '', definition: '' },
+    ];
+  }
+  const rows = correctAnswer.split('|').map((p) => {
+    const sep = p.indexOf(':');
+    if (sep < 0) return { id: newId(), term: p, definition: '' };
+    return {
+      id: newId(),
+      term: p.slice(0, sep),
+      definition: p.slice(sep + 1),
+    };
+  });
+  while (rows.length < 2) rows.push({ id: newId(), term: '', definition: '' });
+  return rows;
+}
+
+function serializePairs(rows: PairRow[]): string {
+  return rows
+    .filter((r) => r.term.trim() || r.definition.trim())
+    .map((r) => `${r.term}:${r.definition}`)
+    .join('|');
+}
+
+function parseOrderItems(correctAnswer: string): OrderRow[] {
+  if (!correctAnswer.trim()) {
+    return [
+      { id: newId(), text: '' },
+      { id: newId(), text: '' },
+      { id: newId(), text: '' },
+    ];
+  }
+  const rows = correctAnswer.split('|').map((text) => ({ id: newId(), text }));
+  while (rows.length < 2) rows.push({ id: newId(), text: '' });
+  return rows;
+}
+
+function serializeOrderItems(rows: OrderRow[]): string {
+  return rows
+    .filter((r) => r.text.trim())
+    .map((r) => r.text)
+    .join('|');
+}
+
+// ─── Sortable row primitive ─────────────────────────────────────────────────
+
+interface SortableRowProps {
+  id: string;
+  children: (handle: {
+    listeners: ReturnType<typeof useSortable>['listeners'];
+    attributes: ReturnType<typeof useSortable>['attributes'];
+  }) => React.ReactNode;
+}
+
+/** Skip dnd-kit's reorder animation when the user has requested reduced motion. */
+function usePrefersReducedMotion(): boolean {
+  const [reduced, setReduced] = React.useState(false);
+  React.useEffect(() => {
+    if (typeof window === 'undefined' || !window.matchMedia) return;
+    const mq = window.matchMedia('(prefers-reduced-motion: reduce)');
+    const update = () => setReduced(mq.matches);
+    update();
+    mq.addEventListener('change', update);
+    return () => mq.removeEventListener('change', update);
+  }, []);
+  return reduced;
+}
+
+const SortableRow: React.FC<SortableRowProps> = ({ id, children }) => {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id });
+  const reducedMotion = usePrefersReducedMotion();
+  const style: React.CSSProperties = {
+    transform: CSS.Transform.toString(transform),
+    transition: reducedMotion ? undefined : transition,
+    opacity: isDragging ? 0.6 : 1,
+  };
+  return (
+    <div ref={setNodeRef} style={style}>
+      {children({ listeners, attributes })}
+    </div>
+  );
+};
+
+// ─── Matching editor ────────────────────────────────────────────────────────
+
+export interface MatchingAnswerEditorProps {
+  correctAnswer: string;
+  matchingDistractors: string[];
+  onChange: (next: {
+    correctAnswer: string;
+    matchingDistractors: string[];
+  }) => void;
+}
+
+export const MatchingAnswerEditor: React.FC<MatchingAnswerEditorProps> = ({
+  correctAnswer,
+  matchingDistractors,
+  onChange,
+}) => {
+  // Local row state owns ids/blank rows; the canonical wire form lives in
+  // the parent's `correctAnswer`. We re-parse only when the parent value
+  // changes from the outside (e.g., AI-generated questions, quiz reload).
+  const [rows, setRows] = React.useState<PairRow[]>(() =>
+    parsePairs(correctAnswer)
+  );
+  const [distractors, setDistractors] = React.useState<string[]>(() =>
+    matchingDistractors.length > 0 ? [...matchingDistractors] : []
+  );
+  const [prevCorrectAnswer, setPrevCorrectAnswer] =
+    React.useState(correctAnswer);
+  const [prevDistractors, setPrevDistractors] =
+    React.useState<string[]>(matchingDistractors);
+  if (correctAnswer !== prevCorrectAnswer) {
+    setPrevCorrectAnswer(correctAnswer);
+    if (serializePairs(rows) !== correctAnswer) {
+      setRows(parsePairs(correctAnswer));
+    }
+  }
+  if (matchingDistractors !== prevDistractors) {
+    setPrevDistractors(matchingDistractors);
+    if (
+      distractors.length !== matchingDistractors.length ||
+      distractors.some((d, i) => d !== matchingDistractors[i])
+    ) {
+      setDistractors([...matchingDistractors]);
+    }
+  }
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 4 } }),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    })
+  );
+
+  const emit = (nextRows: PairRow[], nextDistractors: string[]) => {
+    onChange({
+      correctAnswer: serializePairs(nextRows),
+      matchingDistractors: nextDistractors.filter((d) => d.trim().length > 0),
+    });
+  };
+
+  const updateRow = (id: string, patch: Partial<Omit<PairRow, 'id'>>) => {
+    const next = rows.map((r) => (r.id === id ? { ...r, ...patch } : r));
+    setRows(next);
+    emit(next, distractors);
+  };
+
+  const addRow = () => {
+    const next = [...rows, { id: newId(), term: '', definition: '' }];
+    setRows(next);
+    emit(next, distractors);
+  };
+
+  const removeRow = (id: string) => {
+    if (rows.length <= 2) return;
+    const next = rows.filter((r) => r.id !== id);
+    setRows(next);
+    emit(next, distractors);
+  };
+
+  const handleDragEnd = (e: DragEndEvent) => {
+    const { active, over } = e;
+    if (!over || active.id === over.id) return;
+    const oldIndex = rows.findIndex((r) => r.id === active.id);
+    const newIndex = rows.findIndex((r) => r.id === over.id);
+    if (oldIndex < 0 || newIndex < 0) return;
+    const next = arrayMove(rows, oldIndex, newIndex);
+    setRows(next);
+    emit(next, distractors);
+  };
+
+  const updateDistractor = (index: number, value: string) => {
+    const next = [...distractors];
+    next[index] = value;
+    setDistractors(next);
+    emit(rows, next);
+  };
+
+  const addDistractor = () => {
+    const next = [...distractors, ''];
+    setDistractors(next);
+    // Don't emit yet — empty distractor would be filtered out anyway.
+  };
+
+  const removeDistractor = (index: number) => {
+    const next = distractors.filter((_, i) => i !== index);
+    setDistractors(next);
+    emit(rows, next);
+  };
+
+  return (
+    <div className="space-y-3">
+      <div>
+        <label className="block font-bold text-emerald-700 mb-1 text-xs">
+          Matching Pairs
+        </label>
+        <div className="grid grid-cols-[24px_1fr_1fr_32px] gap-2 items-center mb-1 px-1">
+          <span></span>
+          <span className="text-xxs font-black uppercase tracking-wider text-brand-blue-primary/60">
+            Term
+          </span>
+          <span className="text-xxs font-black uppercase tracking-wider text-brand-blue-primary/60">
+            Match
+          </span>
+          <span></span>
+        </div>
+        <DndContext
+          sensors={sensors}
+          collisionDetection={closestCenter}
+          onDragEnd={handleDragEnd}
+        >
+          <SortableContext
+            items={rows.map((r) => r.id)}
+            strategy={verticalListSortingStrategy}
+          >
+            <div className="space-y-1.5">
+              {rows.map((row) => (
+                <SortableRow key={row.id} id={row.id}>
+                  {({ listeners, attributes }) => (
+                    <div className="grid grid-cols-[24px_1fr_1fr_32px] gap-2 items-center">
+                      <button
+                        type="button"
+                        className="flex items-center justify-center text-brand-blue-primary/30 hover:text-brand-blue-primary cursor-grab active:cursor-grabbing touch-none"
+                        aria-label="Drag to reorder"
+                        {...listeners}
+                        {...attributes}
+                      >
+                        <GripVertical className="w-4 h-4" />
+                      </button>
+                      <input
+                        type="text"
+                        value={row.term}
+                        onChange={(e) =>
+                          updateRow(row.id, {
+                            term: sanitizeTerm(e.target.value),
+                          })
+                        }
+                        placeholder="Term"
+                        className="px-3 py-2 bg-white border-2 border-emerald-500/20 rounded-xl text-emerald-800 font-bold focus:outline-none focus:border-emerald-500 shadow-sm text-sm"
+                      />
+                      <input
+                        type="text"
+                        value={row.definition}
+                        onChange={(e) =>
+                          updateRow(row.id, {
+                            definition: sanitizeDefinition(e.target.value),
+                          })
+                        }
+                        placeholder="Match"
+                        className="px-3 py-2 bg-white border-2 border-emerald-500/20 rounded-xl text-emerald-800 font-bold focus:outline-none focus:border-emerald-500 shadow-sm text-sm"
+                      />
+                      <button
+                        type="button"
+                        onClick={() => removeRow(row.id)}
+                        disabled={rows.length <= 2}
+                        className="flex items-center justify-center p-1.5 text-brand-red-primary hover:bg-brand-red-lighter rounded-lg transition-colors disabled:opacity-20 disabled:hover:bg-transparent"
+                        aria-label="Remove pair"
+                      >
+                        <Trash2 className="w-4 h-4" />
+                      </button>
+                    </div>
+                  )}
+                </SortableRow>
+              ))}
+            </div>
+          </SortableContext>
+        </DndContext>
+        <button
+          type="button"
+          onClick={addRow}
+          className="mt-2 flex items-center gap-1.5 px-3 py-1.5 text-xs font-bold text-emerald-700 hover:bg-emerald-50 rounded-lg transition-colors"
+        >
+          <Plus className="w-3.5 h-3.5" />
+          Add Pair
+        </button>
+      </div>
+
+      <details className="bg-white/50 border border-brand-blue-primary/10 rounded-xl px-3 py-2">
+        <summary className="cursor-pointer font-bold text-brand-blue-dark text-xs">
+          Extra distractor definitions{' '}
+          <span className="font-normal text-brand-blue-primary/60">
+            (optional — increase difficulty)
+          </span>
+        </summary>
+        <div className="mt-2 space-y-1.5">
+          {distractors.length === 0 && (
+            <p className="text-xxs text-brand-blue-primary/50 italic">
+              Add unmatched options that appear in the student&apos;s word bank
+              but don&apos;t match any term.
+            </p>
+          )}
+          {distractors.map((d, i) => (
+            <div key={i} className="flex items-center gap-2">
+              <input
+                type="text"
+                value={d}
+                onChange={(e) =>
+                  updateDistractor(i, sanitizeDefinition(e.target.value))
+                }
+                placeholder={`Distractor ${i + 1}`}
+                className="flex-1 px-3 py-1.5 bg-white border border-brand-red-primary/20 rounded-xl text-brand-blue-dark font-medium focus:outline-none focus:border-brand-red-primary shadow-sm text-sm"
+              />
+              <button
+                type="button"
+                onClick={() => removeDistractor(i)}
+                className="p-1.5 text-brand-red-primary hover:bg-brand-red-lighter rounded-lg transition-colors"
+                aria-label={`Remove distractor ${i + 1}`}
+              >
+                <Trash2 className="w-4 h-4" />
+              </button>
+            </div>
+          ))}
+          <button
+            type="button"
+            onClick={addDistractor}
+            className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-bold text-brand-blue-dark hover:bg-brand-blue-lighter rounded-lg transition-colors"
+          >
+            <Plus className="w-3.5 h-3.5" />
+            Add Distractor
+          </button>
+        </div>
+      </details>
+    </div>
+  );
+};
+
+// ─── Ordering editor ────────────────────────────────────────────────────────
+
+export interface OrderingAnswerEditorProps {
+  correctAnswer: string;
+  onChange: (correctAnswer: string) => void;
+}
+
+export const OrderingAnswerEditor: React.FC<OrderingAnswerEditorProps> = ({
+  correctAnswer,
+  onChange,
+}) => {
+  const [rows, setRows] = React.useState<OrderRow[]>(() =>
+    parseOrderItems(correctAnswer)
+  );
+  const [prevCorrectAnswer, setPrevCorrectAnswer] =
+    React.useState(correctAnswer);
+  if (correctAnswer !== prevCorrectAnswer) {
+    setPrevCorrectAnswer(correctAnswer);
+    if (serializeOrderItems(rows) !== correctAnswer) {
+      setRows(parseOrderItems(correctAnswer));
+    }
+  }
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 4 } }),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    })
+  );
+
+  const emit = (next: OrderRow[]) => onChange(serializeOrderItems(next));
+
+  const updateRow = (id: string, text: string) => {
+    const next = rows.map((r) => (r.id === id ? { ...r, text } : r));
+    setRows(next);
+    emit(next);
+  };
+
+  const addRow = () => {
+    const next = [...rows, { id: newId(), text: '' }];
+    setRows(next);
+    emit(next);
+  };
+
+  const removeRow = (id: string) => {
+    if (rows.length <= 2) return;
+    const next = rows.filter((r) => r.id !== id);
+    setRows(next);
+    emit(next);
+  };
+
+  const swap = (index: number, dir: 'up' | 'down') => {
+    const target = dir === 'up' ? index - 1 : index + 1;
+    if (target < 0 || target >= rows.length) return;
+    const next = arrayMove(rows, index, target);
+    setRows(next);
+    emit(next);
+  };
+
+  const handleDragEnd = (e: DragEndEvent) => {
+    const { active, over } = e;
+    if (!over || active.id === over.id) return;
+    const oldIndex = rows.findIndex((r) => r.id === active.id);
+    const newIndex = rows.findIndex((r) => r.id === over.id);
+    if (oldIndex < 0 || newIndex < 0) return;
+    const next = arrayMove(rows, oldIndex, newIndex);
+    setRows(next);
+    emit(next);
+  };
+
+  return (
+    <div>
+      <label className="block font-bold text-emerald-700 mb-1 text-xs">
+        Items in Correct Order
+      </label>
+      <DndContext
+        sensors={sensors}
+        collisionDetection={closestCenter}
+        onDragEnd={handleDragEnd}
+      >
+        <SortableContext
+          items={rows.map((r) => r.id)}
+          strategy={verticalListSortingStrategy}
+        >
+          <div className="space-y-1.5">
+            {rows.map((row, i) => (
+              <SortableRow key={row.id} id={row.id}>
+                {({ listeners, attributes }) => (
+                  <div className="flex items-center gap-2">
+                    <button
+                      type="button"
+                      className="flex items-center justify-center text-brand-blue-primary/30 hover:text-brand-blue-primary cursor-grab active:cursor-grabbing touch-none"
+                      aria-label="Drag to reorder"
+                      {...listeners}
+                      {...attributes}
+                    >
+                      <GripVertical className="w-4 h-4" />
+                    </button>
+                    <span className="font-black text-emerald-700 w-6 text-center text-sm shrink-0">
+                      {i + 1}.
+                    </span>
+                    <input
+                      type="text"
+                      value={row.text}
+                      onChange={(e) =>
+                        updateRow(row.id, sanitizeOrderingItem(e.target.value))
+                      }
+                      placeholder={`Item ${i + 1}`}
+                      className="flex-1 px-3 py-2 bg-white border-2 border-emerald-500/20 rounded-xl text-emerald-800 font-bold focus:outline-none focus:border-emerald-500 shadow-sm text-sm"
+                    />
+                    <div className="flex items-center">
+                      <button
+                        type="button"
+                        onClick={() => swap(i, 'up')}
+                        disabled={i === 0}
+                        className="p-1 text-brand-blue-primary hover:bg-brand-blue-lighter rounded transition-colors disabled:opacity-20"
+                        aria-label="Move up"
+                      >
+                        ▲
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => swap(i, 'down')}
+                        disabled={i === rows.length - 1}
+                        className="p-1 text-brand-blue-primary hover:bg-brand-blue-lighter rounded transition-colors disabled:opacity-20"
+                        aria-label="Move down"
+                      >
+                        ▼
+                      </button>
+                    </div>
+                    <button
+                      type="button"
+                      onClick={() => removeRow(row.id)}
+                      disabled={rows.length <= 2}
+                      className="flex items-center justify-center p-1.5 text-brand-red-primary hover:bg-brand-red-lighter rounded-lg transition-colors disabled:opacity-20 disabled:hover:bg-transparent"
+                      aria-label="Remove item"
+                    >
+                      <Trash2 className="w-4 h-4" />
+                    </button>
+                  </div>
+                )}
+              </SortableRow>
+            ))}
+          </div>
+        </SortableContext>
+      </DndContext>
+      <button
+        type="button"
+        onClick={addRow}
+        className="mt-2 flex items-center gap-1.5 px-3 py-1.5 text-xs font-bold text-emerald-700 hover:bg-emerald-50 rounded-lg transition-colors"
+      >
+        <Plus className="w-3.5 h-3.5" />
+        Add Row
+      </button>
+    </div>
+  );
+};

--- a/components/widgets/QuizWidget/components/QuizEditorModal.tsx
+++ b/components/widgets/QuizWidget/components/QuizEditorModal.tsx
@@ -32,6 +32,10 @@ import {
   generateQuiz,
 } from '@/utils/ai';
 import { DriveFileAttachment } from '@/components/common/DriveFileAttachment';
+import {
+  MatchingAnswerEditor,
+  OrderingAnswerEditor,
+} from './MatchingOrderingEditor';
 
 interface QuizEditorModalProps {
   isOpen: boolean;
@@ -49,6 +53,11 @@ interface QuizEditorModalProps {
    */
   onFolderChange?: (folderId: string | null) => void;
 }
+
+/** Stable empty array reused as the `matchingDistractors` fallback so the
+ *  child editor's "did the prop change" check doesn't fire on every parent
+ *  render when the field is undefined. */
+const EMPTY_DISTRACTORS: readonly string[] = Object.freeze([]);
 
 const QUESTION_TYPES: {
   value: QuizQuestionType;
@@ -68,12 +77,12 @@ const QUESTION_TYPES: {
   {
     value: 'Matching',
     label: 'Matching',
-    hint: 'Format: term1:definition1|term2:definition2',
+    hint: 'Pair terms with their matching definitions. Add extra distractors to increase difficulty.',
   },
   {
     value: 'Ordering',
     label: 'Ordering',
-    hint: 'Format: item1|item2|item3 in the correct sequence.',
+    hint: 'List items in the correct sequence. Drag rows or use arrows to reorder.',
   },
 ];
 
@@ -98,12 +107,19 @@ const questionsEqual = (a: QuizQuestion[], b: QuizQuestion[]): boolean => {
       qa.correctAnswer !== qb.correctAnswer ||
       qa.timeLimit !== qb.timeLimit ||
       (qa.points ?? 1) !== (qb.points ?? 1) ||
+      (qa.allowPartialCredit === true) !== (qb.allowPartialCredit === true) ||
       qa.incorrectAnswers.length !== qb.incorrectAnswers.length
     ) {
       return false;
     }
     for (let j = 0; j < qa.incorrectAnswers.length; j++) {
       if (qa.incorrectAnswers[j] !== qb.incorrectAnswers[j]) return false;
+    }
+    const aDistractors = qa.matchingDistractors ?? [];
+    const bDistractors = qb.matchingDistractors ?? [];
+    if (aDistractors.length !== bDistractors.length) return false;
+    for (let j = 0; j < aDistractors.length; j++) {
+      if (aDistractors[j] !== bDistractors[j]) return false;
     }
   }
   return true;
@@ -538,11 +554,35 @@ export const QuizEditorModal: React.FC<QuizEditorModalProps> = ({
                 </div>
 
                 {(q.type === 'Matching' || q.type === 'Ordering') && (
-                  <div className="flex gap-2 p-2.5 bg-brand-blue-primary text-white rounded-xl shadow-sm">
-                    <AlertCircle className="w-4 h-4 shrink-0" />
-                    <p className="font-medium text-xs">
-                      {QUESTION_TYPES.find((t) => t.value === q.type)?.hint}
-                    </p>
+                  <div className="flex items-center gap-2">
+                    <div className="flex gap-2 p-2.5 bg-brand-blue-primary text-white rounded-xl shadow-sm flex-1">
+                      <AlertCircle className="w-4 h-4 shrink-0" />
+                      <p className="font-medium text-xs">
+                        {QUESTION_TYPES.find((t) => t.value === q.type)?.hint}
+                      </p>
+                    </div>
+                    <label
+                      className="flex items-center gap-2 px-3 py-2 bg-white border border-brand-blue-primary/20 rounded-xl shadow-sm cursor-pointer select-none"
+                      title={
+                        q.type === 'Matching'
+                          ? 'Award partial points based on the number of correct pairs.'
+                          : 'Award partial points based on the longest correctly-ordered sequence.'
+                      }
+                    >
+                      <input
+                        type="checkbox"
+                        checked={q.allowPartialCredit === true}
+                        onChange={(e) =>
+                          updateQuestion(q.id, {
+                            allowPartialCredit: e.target.checked,
+                          })
+                        }
+                        className="w-4 h-4 accent-brand-blue-primary"
+                      />
+                      <span className="font-bold text-xs text-brand-blue-dark whitespace-nowrap">
+                        Allow partial credit
+                      </span>
+                    </label>
                   </div>
                 )}
 
@@ -561,26 +601,42 @@ export const QuizEditorModal: React.FC<QuizEditorModalProps> = ({
                   />
                 </div>
 
-                <div>
-                  <label className="block font-bold text-emerald-700 mb-1 text-xs">
-                    Correct Answer
-                  </label>
-                  <input
-                    type="text"
-                    value={q.correctAnswer}
-                    onChange={(e) =>
-                      updateQuestion(q.id, { correctAnswer: e.target.value })
+                {q.type === 'Matching' ? (
+                  <MatchingAnswerEditor
+                    correctAnswer={q.correctAnswer}
+                    matchingDistractors={
+                      q.matchingDistractors ?? (EMPTY_DISTRACTORS as string[])
                     }
-                    className="w-full px-3 py-2 bg-white border-2 border-emerald-500/20 rounded-xl text-emerald-800 font-bold focus:outline-none focus:border-emerald-500 shadow-sm text-sm"
-                    placeholder={
-                      q.type === 'Matching'
-                        ? 'term1:def1|term2:def2'
-                        : q.type === 'Ordering'
-                          ? 'item1|item2|item3'
-                          : 'Enter the definitive answer'
+                    onChange={({ correctAnswer, matchingDistractors }) =>
+                      updateQuestion(q.id, {
+                        correctAnswer,
+                        matchingDistractors,
+                      })
                     }
                   />
-                </div>
+                ) : q.type === 'Ordering' ? (
+                  <OrderingAnswerEditor
+                    correctAnswer={q.correctAnswer}
+                    onChange={(correctAnswer) =>
+                      updateQuestion(q.id, { correctAnswer })
+                    }
+                  />
+                ) : (
+                  <div>
+                    <label className="block font-bold text-emerald-700 mb-1 text-xs">
+                      Correct Answer
+                    </label>
+                    <input
+                      type="text"
+                      value={q.correctAnswer}
+                      onChange={(e) =>
+                        updateQuestion(q.id, { correctAnswer: e.target.value })
+                      }
+                      className="w-full px-3 py-2 bg-white border-2 border-emerald-500/20 rounded-xl text-emerald-800 font-bold focus:outline-none focus:border-emerald-500 shadow-sm text-sm"
+                      placeholder="Enter the definitive answer"
+                    />
+                  </div>
+                )}
 
                 {q.type === 'MC' && (
                   <div className="space-y-2">

--- a/components/widgets/QuizWidget/components/QuizLiveMonitor.tsx
+++ b/components/widgets/QuizWidget/components/QuizLiveMonitor.tsx
@@ -2642,7 +2642,7 @@ const MCDistribution: React.FC<{
         const count = distribution[opt] || 0;
         const pct =
           totalAnswered > 0 ? Math.round((count / totalAnswered) * 100) : 0;
-        const isCorrect = gradeAnswer(question, opt);
+        const isCorrect = gradeAnswer(question, opt).isCorrect;
 
         return (
           <div key={opt}>

--- a/components/widgets/QuizWidget/components/QuizPreview.tsx
+++ b/components/widgets/QuizWidget/components/QuizPreview.tsx
@@ -340,7 +340,7 @@ const MCAnswerArea: React.FC<{
   <div className="flex flex-col" style={{ gap: 'min(10px, 2.5cqmin)' }}>
     {options.map((opt) => {
       const isSelected = selectedAnswer === opt;
-      const isCorrect = gradeAnswer(question, opt);
+      const isCorrect = gradeAnswer(question, opt).isCorrect;
 
       let variantClasses =
         'bg-brand-gray-lightest/50 border-brand-blue-primary/10 text-brand-blue-dark hover:bg-brand-blue-lighter/50 hover:border-brand-blue-primary/30';
@@ -474,6 +474,42 @@ const StructuredAnswerArea: React.FC<{
           </div>
         ))}
       </div>
+      {question.type === 'Matching' &&
+        question.matchingDistractors &&
+        question.matchingDistractors.length > 0 &&
+        showAnswer && (
+          <div
+            className="bg-brand-red-lighter/30 border border-brand-red-primary/10 rounded-2xl"
+            style={{ padding: 'min(10px, 2.5cqmin)' }}
+          >
+            <p
+              className="text-brand-red-dark font-black uppercase tracking-wider"
+              style={{
+                fontSize: 'min(10px, 3cqmin)',
+                marginBottom: 'min(4px, 1cqmin)',
+              }}
+            >
+              Distractors (in word bank)
+            </p>
+            <div
+              className="flex flex-wrap"
+              style={{ gap: 'min(6px, 1.5cqmin)' }}
+            >
+              {question.matchingDistractors.map((d, i) => (
+                <span
+                  key={i}
+                  className="bg-brand-red-lighter/50 border border-brand-red-primary/20 text-brand-red-dark font-bold rounded-lg"
+                  style={{
+                    padding: 'min(4px, 1cqmin) min(8px, 2cqmin)',
+                    fontSize: 'min(12px, 3.5cqmin)',
+                  }}
+                >
+                  {d}
+                </span>
+              ))}
+            </div>
+          </div>
+        )}
       {!showAnswer && (
         <button
           onClick={onReveal}

--- a/components/widgets/QuizWidget/components/QuizResults.tsx
+++ b/components/widgets/QuizWidget/components/QuizResults.tsx
@@ -1224,7 +1224,7 @@ const QuestionsTab: React.FC<{
 
         if (qStats && q) {
           qStats.answered++;
-          if (gradeAnswer(q, a.answer)) {
+          if (gradeAnswer(q, a.answer).isCorrect) {
             qStats.correct++;
           }
         }

--- a/components/widgets/QuizWidget/utils/quizScoreboard.test.ts
+++ b/components/widgets/QuizWidget/utils/quizScoreboard.test.ts
@@ -3,11 +3,17 @@ import { describe, it, expect, vi } from 'vitest';
 vi.mock('@/hooks/useQuizSession', () => ({
   gradeAnswer: vi.fn(
     (
-      question: { correctAnswer: string; type: string },
+      question: { correctAnswer: string; type: string; points?: number },
       answer: string
-    ): boolean => {
+    ): { isCorrect: boolean; pointsEarned: number; pointsMax: number } => {
       const norm = (s: string) => s.trim().toLowerCase().replace(/\s+/g, ' ');
-      return norm(question.correctAnswer) === norm(answer);
+      const isCorrect = norm(question.correctAnswer) === norm(answer);
+      const max = question.points ?? 1;
+      return {
+        isCorrect,
+        pointsEarned: isCorrect ? max : 0,
+        pointsMax: max,
+      };
     }
   ),
 }));
@@ -21,6 +27,7 @@ vi.mock('@/config/scoreboard', () => ({
   ],
 }));
 
+import { gradeAnswer } from '@/hooks/useQuizSession';
 import {
   getEarnedPoints,
   getResponseScore,
@@ -212,6 +219,56 @@ describe('quizScoreboard', () => {
           { questionId: 'q2', answer: 'B', answeredAt: 200 },
         ]);
         expect(getEarnedPoints(response, questions, session)).toBe(2);
+      });
+
+      it('partial credit holds the streak — neither extends nor resets it', () => {
+        // Override gradeAnswer for this test so q2 returns the
+        // partial-credit branch (`isCorrect: false, pointsEarned > 0`)
+        // that the default correct-vs-zero mock can't reach. Uses
+        // mockImplementationOnce per call so the default mock takes
+        // over again for subsequent tests in the file.
+        const mocked = vi.mocked(gradeAnswer);
+        mocked.mockImplementationOnce(
+          (q: { points?: number }) =>
+            ({
+              isCorrect: true,
+              pointsEarned: q.points ?? 1,
+              pointsMax: q.points ?? 1,
+            }) as ReturnType<typeof gradeAnswer>
+        );
+        mocked.mockImplementationOnce(
+          (q: { points?: number }) =>
+            ({
+              isCorrect: false,
+              pointsEarned: (q.points ?? 1) / 2,
+              pointsMax: q.points ?? 1,
+            }) as ReturnType<typeof gradeAnswer>
+        );
+        mocked.mockImplementationOnce(
+          (q: { points?: number }) =>
+            ({
+              isCorrect: true,
+              pointsEarned: q.points ?? 1,
+              pointsMax: q.points ?? 1,
+            }) as ReturnType<typeof gradeAnswer>
+        );
+
+        const questions = [
+          makeQuestion('q1', 'A'),
+          makeQuestion('q2', 'B'), // partial — holds streak
+          makeQuestion('q3', 'C'),
+        ];
+        const session = makeSession({ streakBonusEnabled: true });
+        const response = makeResponse('01', [
+          { questionId: 'q1', answer: 'A', answeredAt: 100 },
+          { questionId: 'q2', answer: 'partial', answeredAt: 200 },
+          { questionId: 'q3', answer: 'C', answeredAt: 300 },
+        ]);
+        // q1: 1pt × 1.0 = 1 (streak=1)
+        // q2: 0.5pt × 1.0 = 0.5 (streak HELD at 1, partial doesn't extend)
+        // q3: 1pt × 1.5 = 1.5 (streak advances to 2; multiplier = 1.5)
+        // total = 3.0 → Math.round → 3
+        expect(getEarnedPoints(response, questions, session)).toBe(3);
       });
     });
 

--- a/components/widgets/QuizWidget/utils/quizScoreboard.ts
+++ b/components/widgets/QuizWidget/utils/quizScoreboard.ts
@@ -62,17 +62,22 @@ export function getEarnedPoints(
     const q = qMap.get(ans.questionId);
     if (!q) continue;
 
-    const basePts = q.points ?? 1;
-    const isCorrect = gradeAnswer(q, ans.answer);
+    const grade = gradeAnswer(q, ans.answer);
 
-    if (!isCorrect) {
+    if (grade.pointsEarned <= 0) {
       streak = 0;
       continue;
     }
 
-    streak++;
+    // Streak only advances on full credit. Partial credit holds the streak
+    // (neither extends nor resets) — the student earned some credit, so
+    // they shouldn't lose their multiplier; but a partly-wrong answer also
+    // shouldn't compound the multiplier on a half-right answer.
+    if (grade.isCorrect) {
+      streak++;
+    }
 
-    let pts = basePts;
+    let pts = grade.pointsEarned;
 
     // Speed bonus: up to 50% extra for fast answers (clamp untrusted client data)
     if (speedEnabled && q.timeLimit > 0 && ans.speedBonus) {

--- a/hooks/useQuizSession.ts
+++ b/hooks/useQuizSession.ts
@@ -39,6 +39,7 @@ import {
   QuizResponseAnswer,
   QuizQuestion,
   QuizPublicQuestion,
+  GradeResult,
 } from '../types';
 import { resolvePeriodNames } from '../utils/periodCompat';
 
@@ -79,12 +80,23 @@ export function toPublicQuestion(q: QuizQuestion): QuizPublicQuestion {
       ...q.incorrectAnswers.filter(Boolean),
     ]);
   } else if (q.type === 'Matching') {
+    // Use indexOf+slice (not split(':')) so a definition that itself contains
+    // a colon (e.g. "9:00 AM", "H:O") survives intact. Only the FIRST colon
+    // separates term from definition; everything after stays in `right`.
     const pairs = q.correctAnswer.split('|').map((p) => {
-      const [left, right] = p.split(':');
-      return { left: left ?? '', right: right ?? '' };
+      const sep = p.indexOf(':');
+      if (sep < 0) return { left: p, right: '' };
+      return { left: p.slice(0, sep), right: p.slice(sep + 1) };
     });
+    const distractors = (q.matchingDistractors ?? []).filter(Boolean);
     base.matchingLeft = pairs.map((p) => p.left);
-    base.matchingRight = fisherYatesShuffle(pairs.map((p) => p.right));
+    base.matchingRight = fisherYatesShuffle([
+      ...pairs.map((p) => p.right),
+      ...distractors,
+    ]);
+    if (distractors.length > 0) {
+      base.matchingDistractors = distractors;
+    }
   } else if (q.type === 'Ordering') {
     base.orderingItems = fisherYatesShuffle(q.correctAnswer.split('|'));
   }
@@ -97,28 +109,100 @@ export function toPublicQuestion(q: QuizQuestion): QuizPublicQuestion {
 export const normalizeAnswer = (s: string) =>
   s.trim().toLowerCase().replace(/\s+/g, ' ');
 
+/**
+ * Length of the longest subsequence of `given` whose items appear in
+ * `correct` in correct relative order. Used for Ordering partial credit:
+ * rewards a student who has items in the right order even if shifted.
+ *
+ * Items in `given` not present in `correct` are skipped (don't break
+ * runs). Comparison is whitespace/case-insensitive (`normalizeAnswer`).
+ *
+ * Duplicate items in `correct` are handled positionally: each occurrence
+ * is consumed at most once, in left-to-right order, so a perfect student
+ * answer to `[A,B,A]` produces seq `[0,1,2]` (LIS = 3) rather than
+ * `[2,1,2]` (LIS = 2) which a value→index map would produce.
+ *
+ * O(n × m) for the pairing pass plus O(n log n) for the patience-sort
+ * tails — n is small enough (≤ 50 ordering items in practice) that the
+ * constant matters more than asymptotics.
+ */
+function longestOrderedSubsequenceLength(
+  correct: string[],
+  given: string[]
+): number {
+  const correctNorm = correct.map(normalizeAnswer);
+  const used = new Array<boolean>(correct.length).fill(false);
+  const seq: number[] = [];
+  for (const g of given) {
+    const target = normalizeAnswer(g);
+    // Pick the leftmost unused occurrence — left-to-right consumption is
+    // what produces the intuitive "perfect answer scores full credit"
+    // behavior on inputs with duplicates.
+    let chosen = -1;
+    for (let i = 0; i < correctNorm.length; i++) {
+      if (!used[i] && correctNorm[i] === target) {
+        chosen = i;
+        break;
+      }
+    }
+    if (chosen >= 0) {
+      used[chosen] = true;
+      seq.push(chosen);
+    }
+  }
+  const tails: number[] = [];
+  for (const x of seq) {
+    let lo = 0;
+    let hi = tails.length;
+    while (lo < hi) {
+      const mid = (lo + hi) >> 1;
+      if (tails[mid] < x) lo = mid + 1;
+      else hi = mid;
+    }
+    tails[lo] = x;
+  }
+  return tails.length;
+}
+
 export function gradeAnswer(
   question: QuizQuestion,
   studentAnswer: string
-): boolean {
+): GradeResult {
+  const max = question.points ?? 1;
+  const partial = question.allowPartialCredit === true;
   const correct = normalizeAnswer(question.correctAnswer);
   const given = normalizeAnswer(studentAnswer);
 
   if (question.type === 'MC' || question.type === 'FIB') {
-    return correct === given;
+    const isCorrect = correct === given;
+    return { isCorrect, pointsEarned: isCorrect ? max : 0, pointsMax: max };
   }
   if (question.type === 'Matching') {
-    const correctSet = new Set(correct.split('|').map(normalizeAnswer));
-    const givenParts = given.split('|').map(normalizeAnswer);
-    return (
-      givenParts.length === correctSet.size &&
-      givenParts.every((p) => correctSet.has(p))
-    );
+    const correctPairs = correct.split('|').map(normalizeAnswer);
+    const givenPairs = given.split('|').map(normalizeAnswer);
+    const correctSet = new Set(correctPairs);
+    const matched = givenPairs.filter((p) => correctSet.has(p)).length;
+    const total = correctPairs.length;
+    const isCorrect = matched === total && givenPairs.length === total;
+    if (!partial) {
+      return { isCorrect, pointsEarned: isCorrect ? max : 0, pointsMax: max };
+    }
+    const pointsEarned = total === 0 ? 0 : (matched / total) * max;
+    return { isCorrect, pointsEarned, pointsMax: max };
   }
   if (question.type === 'Ordering') {
-    return correct === given;
+    const isCorrect = correct === given;
+    if (!partial) {
+      return { isCorrect, pointsEarned: isCorrect ? max : 0, pointsMax: max };
+    }
+    const correctItems = question.correctAnswer.split('|');
+    const givenItems = studentAnswer.split('|');
+    const lis = longestOrderedSubsequenceLength(correctItems, givenItems);
+    const pointsEarned =
+      correctItems.length === 0 ? 0 : (lis / correctItems.length) * max;
+    return { isCorrect, pointsEarned, pointsMax: max };
   }
-  return false;
+  return { isCorrect: false, pointsEarned: 0, pointsMax: max };
 }
 
 /**

--- a/tests/components/quiz/MatchingResponseInput.test.tsx
+++ b/tests/components/quiz/MatchingResponseInput.test.tsx
@@ -1,0 +1,140 @@
+/**
+ * Standalone unit tests for MatchingResponseInput. The component is a pure
+ * UI shell over a stable wire format — no Firebase, no router. Tests cover
+ * the tap-to-place flow, hydration from saved answers, distractor presence
+ * in the bank, reset, and the all-options-placed terminal state.
+ */
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom/vitest';
+import { MatchingResponseInput } from '@/components/quiz/MatchingResponseInput';
+import type { QuizPublicQuestion } from '@/types';
+
+function makeQuestion(
+  matchingLeft: string[],
+  matchingRight: string[],
+  matchingDistractors?: string[]
+): QuizPublicQuestion {
+  return {
+    id: 'q1',
+    type: 'Matching',
+    text: 'Match the items',
+    timeLimit: 0,
+    matchingLeft,
+    matchingRight,
+    matchingDistractors,
+  };
+}
+
+describe('MatchingResponseInput', () => {
+  it('renders all definitions from matchingRight as selectable bank chips', () => {
+    const onChange = vi.fn();
+    render(
+      <MatchingResponseInput
+        question={makeQuestion(
+          ['France', 'Germany'],
+          ['Paris', 'Berlin', 'quack', 'oink']
+        )}
+        savedAnswer={null}
+        onChange={onChange}
+      />
+    );
+    // All four options appear as buttons (the merged shuffled bank
+    // includes real definitions + distractors with no visual distinction).
+    expect(screen.getByRole('button', { name: /Paris/ })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Berlin/ })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /quack/ })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /oink/ })).toBeInTheDocument();
+  });
+
+  it('serializes term:def pairs in matchingLeft order on tap-to-place', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <MatchingResponseInput
+        question={makeQuestion(['France', 'Germany'], ['Paris', 'Berlin'])}
+        savedAnswer={null}
+        onChange={onChange}
+      />
+    );
+    // Tap chip → tap empty zone (works without dragging on touch devices).
+    await user.click(
+      screen.getByRole('button', { name: /Paris, in word bank/ })
+    );
+    await user.click(
+      screen.getByRole('button', { name: /Drop zone for France/ })
+    );
+    expect(onChange).toHaveBeenLastCalledWith('France:Paris|Germany:');
+
+    await user.click(
+      screen.getByRole('button', { name: /Berlin, in word bank/ })
+    );
+    await user.click(
+      screen.getByRole('button', { name: /Drop zone for Germany/ })
+    );
+    expect(onChange).toHaveBeenLastCalledWith('France:Paris|Germany:Berlin');
+  });
+
+  it('hydrates from a saved answer so placed chips render in their zones', () => {
+    const onChange = vi.fn();
+    render(
+      <MatchingResponseInput
+        question={makeQuestion(['France', 'Germany'], ['Paris', 'Berlin'])}
+        savedAnswer="France:Paris|Germany:Berlin"
+        onChange={onChange}
+      />
+    );
+    // Both placed chips advertise their pairing through aria-label so the
+    // round-trip from savedAnswer → render is visible to screen readers.
+    expect(
+      screen.getByRole('button', { name: /Paris, matched to France/ })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /Berlin, matched to Germany/ })
+    ).toBeInTheDocument();
+  });
+
+  it('reset returns every placed chip to the bank and emits empty pairs', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <MatchingResponseInput
+        question={makeQuestion(['France', 'Germany'], ['Paris', 'Berlin'])}
+        savedAnswer="France:Paris|Germany:Berlin"
+        onChange={onChange}
+      />
+    );
+    await user.click(screen.getByRole('button', { name: /Reset/ }));
+    expect(onChange).toHaveBeenLastCalledWith('France:|Germany:');
+    // Both chips back in the bank → empty drop zones rendered for both terms.
+    expect(
+      screen.getByRole('button', { name: /Drop zone for France/ })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /Drop zone for Germany/ })
+    ).toBeInTheDocument();
+  });
+
+  it('preserves a colon inside a definition through the place + serialize round-trip', async () => {
+    // Regression for the toPublicQuestion fix: the student-side wire format
+    // must not split on inner colons either. "9:00 AM" stays intact.
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <MatchingResponseInput
+        question={makeQuestion(['breakfast'], ['9:00 AM'])}
+        savedAnswer={null}
+        onChange={onChange}
+      />
+    );
+    await user.click(
+      screen.getByRole('button', { name: /9:00 AM, in word bank/ })
+    );
+    await user.click(
+      screen.getByRole('button', { name: /Drop zone for breakfast/ })
+    );
+    expect(onChange).toHaveBeenLastCalledWith('breakfast:9:00 AM');
+  });
+});

--- a/tests/components/quiz/OrderingResponseInput.test.tsx
+++ b/tests/components/quiz/OrderingResponseInput.test.tsx
@@ -1,0 +1,146 @@
+/**
+ * Standalone unit tests for OrderingResponseInput. Covers the tap-to-place
+ * flow, hydration from saved answers, slot-to-slot moves via the up/down
+ * arrows, and reset.
+ */
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom/vitest';
+import { OrderingResponseInput } from '@/components/quiz/OrderingResponseInput';
+import type { QuizPublicQuestion } from '@/types';
+
+function makeQuestion(orderingItems: string[]): QuizPublicQuestion {
+  return {
+    id: 'qo',
+    type: 'Ordering',
+    text: 'Put these in order',
+    timeLimit: 0,
+    orderingItems,
+  };
+}
+
+describe('OrderingResponseInput', () => {
+  it('renders all items as bank chips and empty slots', () => {
+    const onChange = vi.fn();
+    render(
+      <OrderingResponseInput
+        question={makeQuestion(['First', 'Second', 'Third'])}
+        savedAnswer={null}
+        onChange={onChange}
+      />
+    );
+    // Three bank chips render as draggable buttons.
+    expect(
+      screen.getByRole('button', { name: /First, in word bank/ })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /Second, in word bank/ })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /Third, in word bank/ })
+    ).toBeInTheDocument();
+    // Three empty slot drop zones render with their position aria-labels.
+    expect(
+      screen.getByRole('button', { name: /Empty drop zone, position 1/ })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /Empty drop zone, position 2/ })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /Empty drop zone, position 3/ })
+    ).toBeInTheDocument();
+  });
+
+  it('serializes pipe-joined items in slot order on tap-to-place', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <OrderingResponseInput
+        question={makeQuestion(['A', 'B', 'C'])}
+        savedAnswer={null}
+        onChange={onChange}
+      />
+    );
+    await user.click(screen.getByRole('button', { name: /A, in word bank/ }));
+    await user.click(
+      screen.getByRole('button', { name: /Empty drop zone, position 1/ })
+    );
+    expect(onChange).toHaveBeenLastCalledWith('A||');
+
+    await user.click(screen.getByRole('button', { name: /B, in word bank/ }));
+    await user.click(
+      screen.getByRole('button', { name: /Empty drop zone, position 2/ })
+    );
+    expect(onChange).toHaveBeenLastCalledWith('A|B|');
+
+    await user.click(screen.getByRole('button', { name: /C, in word bank/ }));
+    await user.click(
+      screen.getByRole('button', { name: /Empty drop zone, position 3/ })
+    );
+    expect(onChange).toHaveBeenLastCalledWith('A|B|C');
+  });
+
+  it('hydrates from a saved answer so placed chips render in their slots', () => {
+    const onChange = vi.fn();
+    render(
+      <OrderingResponseInput
+        question={makeQuestion(['A', 'B', 'C'])}
+        savedAnswer="C|A|B"
+        onChange={onChange}
+      />
+    );
+    expect(
+      screen.getByRole('button', { name: /C, position 1/ })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /A, position 2/ })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /B, position 3/ })
+    ).toBeInTheDocument();
+  });
+
+  it('the up arrow swaps a slot with the one above and emits the new order', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <OrderingResponseInput
+        question={makeQuestion(['A', 'B', 'C'])}
+        savedAnswer="A|B|C"
+        onChange={onChange}
+      />
+    );
+    // Move position-2 (B) up → expected order A,C,B... no wait, A,B,C with
+    // B moved up = B,A,C. Confirm:
+    await user.click(
+      screen.getByRole('button', { name: /Move position 2 up/ })
+    );
+    expect(onChange).toHaveBeenLastCalledWith('B|A|C');
+  });
+
+  it('reset returns every placed item to the bank and emits all-empty', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <OrderingResponseInput
+        question={makeQuestion(['A', 'B', 'C'])}
+        savedAnswer="A|B|C"
+        onChange={onChange}
+      />
+    );
+    await user.click(screen.getByRole('button', { name: /Reset/ }));
+    expect(onChange).toHaveBeenLastCalledWith('||');
+    // All three items are back in the bank.
+    expect(
+      screen.getByRole('button', { name: /A, in word bank/ })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /B, in word bank/ })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /C, in word bank/ })
+    ).toBeInTheDocument();
+  });
+});

--- a/tests/components/quiz/QuizStudentApp.selfPaced.test.tsx
+++ b/tests/components/quiz/QuizStudentApp.selfPaced.test.tsx
@@ -409,6 +409,113 @@ describe('QuizStudentApp — self-paced flow', () => {
     }
   });
 
+  it('preserves partial Matching placements when the timer auto-submits', async () => {
+    // Regression: before the structuredAnswerRef wiring, the timer-expiry
+    // auto-submit path read selectedAnswerRef ?? draftMcAnswerRef ??
+    // fibAnswerRef ?? '' — none of which capture the live wire string from
+    // the matching/ordering child component, so timeouts always submitted
+    // ''. This test holds that path: place one chip, let the clock run
+    // out, and assert the partial placement reaches submitAnswer.
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    try {
+      const user = userEvent.setup({
+        advanceTimers: vi.advanceTimersByTime,
+      });
+      const matching: QuizPublicQuestion = {
+        id: 'qm-timer',
+        type: 'Matching',
+        text: 'Match the capitals',
+        timeLimit: 5,
+        matchingLeft: ['France', 'Germany'],
+        matchingRight: ['Paris', 'Berlin'],
+      };
+      hookState.session = buildSession({
+        publicQuestions: [matching, QUESTIONS[1]],
+        totalQuestions: 2,
+      });
+
+      render(<QuizStudentApp />);
+      expect(
+        await screen.findByText(/Match the capitals/i)
+      ).toBeInTheDocument();
+
+      // Tap-to-place: select Paris from the bank, then drop into France.
+      await user.click(
+        screen.getByRole('button', { name: /Paris, in word bank/ })
+      );
+      await user.click(
+        screen.getByRole('button', { name: /Drop zone for France/ })
+      );
+
+      // Run out the clock. The countdown effect ticks once per second, so
+      // 6s is enough to trigger auto-submit.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(6000);
+      });
+
+      // The auto-submit must have called submitAnswer with the partial
+      // placement, not the empty string.
+      expect(mockSubmitAnswer).toHaveBeenCalledWith(
+        'qm-timer',
+        'France:Paris|Germany:',
+        0
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('preserves partial Ordering placements when the timer auto-submits', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    try {
+      const user = userEvent.setup({
+        advanceTimers: vi.advanceTimersByTime,
+      });
+      const ordering: QuizPublicQuestion = {
+        id: 'qo-timer',
+        type: 'Ordering',
+        text: 'Put these in order',
+        timeLimit: 5,
+        orderingItems: ['First', 'Second', 'Third'],
+      };
+      hookState.session = buildSession({
+        publicQuestions: [ordering, QUESTIONS[1]],
+        totalQuestions: 2,
+      });
+
+      render(<QuizStudentApp />);
+      expect(
+        await screen.findByText(/Put these in order/i)
+      ).toBeInTheDocument();
+
+      // Place First and Second; leave Third in the bank.
+      await user.click(
+        screen.getByRole('button', { name: /First, in word bank/ })
+      );
+      await user.click(
+        screen.getByRole('button', { name: /Empty drop zone, position 1/ })
+      );
+      await user.click(
+        screen.getByRole('button', { name: /Second, in word bank/ })
+      );
+      await user.click(
+        screen.getByRole('button', { name: /Empty drop zone, position 2/ })
+      );
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(6000);
+      });
+
+      expect(mockSubmitAnswer).toHaveBeenCalledWith(
+        'qo-timer',
+        'First|Second|',
+        0
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('renders MC choices in a per-student order so neighbours diverge', async () => {
     // Use 6 choices so the chance of two random orders matching by accident
     // is small enough that this test won't flake (1/6! ≈ 0.14%).
@@ -493,7 +600,7 @@ describe('QuizStudentApp — self-paced flow', () => {
     expect(afterOrder).toEqual(beforeOrder);
   });
 
-  it('hydrates Matching dropdowns from a saved answer on revisit', async () => {
+  it('hydrates Matching placements from a saved answer on revisit', async () => {
     const user = userEvent.setup();
     const matching: QuizPublicQuestion = {
       id: 'qm',
@@ -508,26 +615,21 @@ describe('QuizStudentApp — self-paced flow', () => {
       totalQuestions: 2,
     });
 
+    // Seed a saved answer so the placements hydrate from Firestore on mount.
+    appendAnswer('qm', 'France:Paris|Germany:Berlin|Spain:Madrid');
+
     render(<QuizStudentApp />);
     expect(await screen.findByText(/Match the capitals/i)).toBeInTheDocument();
 
-    // Pick correct pairings.
-    const selects = screen.getAllByRole('combobox');
-    await user.selectOptions(selects[0], 'Paris');
-    await user.selectOptions(selects[1], 'Berlin');
-    await user.selectOptions(selects[2], 'Madrid');
+    // Each term has its definition placed (chips render with aria-pressed,
+    // bank items in remaining bank). NEXT submits the hydrated answer
+    // directly without further interaction.
     await user.click(screen.getByRole('button', { name: /^NEXT/i }));
-    expect(await screen.findByText(/Capital of France/i)).toBeInTheDocument();
-
-    // Back-nav: each <select> should re-show its prior value.
-    await user.click(
-      screen.getByRole('button', { name: /Previous question/i })
+    expect(mockSubmitAnswer).toHaveBeenLastCalledWith(
+      'qm',
+      'France:Paris|Germany:Berlin|Spain:Madrid',
+      undefined
     );
-    expect(await screen.findByText(/Match the capitals/i)).toBeInTheDocument();
-    const revisitSelects = screen.getAllByRole<HTMLSelectElement>('combobox');
-    expect(revisitSelects[0].value).toBe('Paris');
-    expect(revisitSelects[1].value).toBe('Berlin');
-    expect(revisitSelects[2].value).toBe('Madrid');
   });
 
   it('hydrates Ordering arrangement from a saved answer on revisit', async () => {
@@ -551,14 +653,18 @@ describe('QuizStudentApp — self-paced flow', () => {
     render(<QuizStudentApp />);
     expect(await screen.findByText(/Put these in order/i)).toBeInTheDocument();
 
-    // The list items should appear in the saved order, not the default
-    // `[...orderingItems]` order.
-    const listed = screen
-      .getAllByText(/^(First|Second|Third|Fourth)$/, { selector: 'span' })
-      .map((s) => s.textContent);
-    expect(listed).toEqual(['Fourth', 'Third', 'Second', 'First']);
+    // The four slot chips should appear in the saved order. We scope the
+    // search to button elements since the bank shows chips too — but with
+    // all items hydrated into slots, the bank is empty.
+    const slotChips = screen
+      .getAllByRole('button')
+      .filter((b) =>
+        ['First', 'Second', 'Third', 'Fourth'].includes(b.textContent ?? '')
+      )
+      .map((b) => b.textContent);
+    expect(slotChips).toEqual(['Fourth', 'Third', 'Second', 'First']);
 
-    // And NEXT submits the existing arrangement on a single tap.
+    // NEXT submits the existing arrangement on a single tap.
     await user.click(screen.getByRole('button', { name: /^NEXT/i }));
     expect(mockSubmitAnswer).toHaveBeenLastCalledWith(
       'qo',

--- a/tests/hooks/useQuizSession.test.ts
+++ b/tests/hooks/useQuizSession.test.ts
@@ -48,9 +48,9 @@ describe('gradeAnswer', () => {
   };
 
   it('grades MC case-insensitively and ignores surrounding whitespace', () => {
-    expect(gradeAnswer(mcQuestion, 'paris')).toBe(true);
-    expect(gradeAnswer(mcQuestion, '  PARIS  ')).toBe(true);
-    expect(gradeAnswer(mcQuestion, 'London')).toBe(false);
+    expect(gradeAnswer(mcQuestion, 'paris').isCorrect).toBe(true);
+    expect(gradeAnswer(mcQuestion, '  PARIS  ').isCorrect).toBe(true);
+    expect(gradeAnswer(mcQuestion, 'London').isCorrect).toBe(false);
   });
 
   it('grades FIB with whitespace normalization', () => {
@@ -62,8 +62,8 @@ describe('gradeAnswer', () => {
       correctAnswer: 'four',
       incorrectAnswers: [],
     };
-    expect(gradeAnswer(fib, '  Four  ')).toBe(true);
-    expect(gradeAnswer(fib, 'five')).toBe(false);
+    expect(gradeAnswer(fib, '  Four  ').isCorrect).toBe(true);
+    expect(gradeAnswer(fib, 'five').isCorrect).toBe(false);
   });
 
   it('grades Matching regardless of pair order', () => {
@@ -75,8 +75,12 @@ describe('gradeAnswer', () => {
       correctAnswer: 'dog:bark|cat:meow|cow:moo',
       incorrectAnswers: [],
     };
-    expect(gradeAnswer(matching, 'cat:meow|dog:bark|cow:moo')).toBe(true);
-    expect(gradeAnswer(matching, 'dog:bark|cat:meow|cow:moo')).toBe(true);
+    expect(gradeAnswer(matching, 'cat:meow|dog:bark|cow:moo').isCorrect).toBe(
+      true
+    );
+    expect(gradeAnswer(matching, 'dog:bark|cat:meow|cow:moo').isCorrect).toBe(
+      true
+    );
   });
 
   it('rejects Matching when a pair is wrong or missing', () => {
@@ -88,8 +92,8 @@ describe('gradeAnswer', () => {
       correctAnswer: 'dog:bark|cat:meow',
       incorrectAnswers: [],
     };
-    expect(gradeAnswer(matching, 'dog:meow|cat:bark')).toBe(false);
-    expect(gradeAnswer(matching, 'dog:bark')).toBe(false);
+    expect(gradeAnswer(matching, 'dog:meow|cat:bark').isCorrect).toBe(false);
+    expect(gradeAnswer(matching, 'dog:bark').isCorrect).toBe(false);
   });
 
   it('grades Ordering strictly by sequence', () => {
@@ -101,9 +105,220 @@ describe('gradeAnswer', () => {
       correctAnswer: 'first|second|third',
       incorrectAnswers: [],
     };
-    expect(gradeAnswer(ordering, 'first|second|third')).toBe(true);
-    expect(gradeAnswer(ordering, 'FIRST|Second|THIRD')).toBe(true);
-    expect(gradeAnswer(ordering, 'first|third|second')).toBe(false);
+    expect(gradeAnswer(ordering, 'first|second|third').isCorrect).toBe(true);
+    expect(gradeAnswer(ordering, 'FIRST|Second|THIRD').isCorrect).toBe(true);
+    expect(gradeAnswer(ordering, 'first|third|second').isCorrect).toBe(false);
+  });
+
+  it('returns full points for correct answers and zero for wrong', () => {
+    const q: QuizQuestion = {
+      id: 'p1',
+      timeLimit: 0,
+      text: 'Order',
+      type: 'Ordering',
+      correctAnswer: 'a|b|c|d',
+      incorrectAnswers: [],
+      points: 4,
+    };
+    const correct = gradeAnswer(q, 'a|b|c|d');
+    expect(correct).toEqual({ isCorrect: true, pointsEarned: 4, pointsMax: 4 });
+    const wrong = gradeAnswer(q, 'd|c|b|a');
+    expect(wrong).toEqual({ isCorrect: false, pointsEarned: 0, pointsMax: 4 });
+  });
+
+  it('defaults to 1 point when points is unset', () => {
+    const q: QuizQuestion = {
+      id: 'p2',
+      timeLimit: 0,
+      text: '?',
+      type: 'MC',
+      correctAnswer: 'yes',
+      incorrectAnswers: ['no'],
+    };
+    expect(gradeAnswer(q, 'yes').pointsEarned).toBe(1);
+    expect(gradeAnswer(q, 'no').pointsEarned).toBe(0);
+  });
+
+  describe('partial credit', () => {
+    it('Matching: awards (correctPairs / total) * points when allowPartialCredit', () => {
+      const q: QuizQuestion = {
+        id: 'pm1',
+        timeLimit: 0,
+        text: 'Match',
+        type: 'Matching',
+        correctAnswer: 'dog:bark|cat:meow|cow:moo',
+        incorrectAnswers: [],
+        points: 6,
+        allowPartialCredit: true,
+      };
+      // 2 of 3 pairs correct → 4/6 points.
+      const partial = gradeAnswer(q, 'dog:bark|cat:meow|cow:wrong');
+      expect(partial.isCorrect).toBe(false);
+      expect(partial.pointsMax).toBe(6);
+      expect(partial.pointsEarned).toBeCloseTo(4, 5);
+    });
+
+    it('Matching: distractors picked as a "match" grade as wrong, do not crash grading', () => {
+      const q: QuizQuestion = {
+        id: 'pm2',
+        timeLimit: 0,
+        text: 'Match',
+        type: 'Matching',
+        correctAnswer: 'dog:bark|cat:meow',
+        incorrectAnswers: [],
+        matchingDistractors: ['quack', 'oink'],
+        points: 4,
+        allowPartialCredit: true,
+      };
+      // Student picked one real pair and a distractor for the other → 1/2.
+      const grade = gradeAnswer(q, 'dog:bark|cat:quack');
+      expect(grade.isCorrect).toBe(false);
+      expect(grade.pointsEarned).toBeCloseTo(2, 5);
+    });
+
+    it('Matching: full-credit bonus path still produces isCorrect=true with partial enabled', () => {
+      const q: QuizQuestion = {
+        id: 'pm3',
+        timeLimit: 0,
+        text: 'Match',
+        type: 'Matching',
+        correctAnswer: 'a:1|b:2',
+        incorrectAnswers: [],
+        points: 2,
+        allowPartialCredit: true,
+      };
+      const grade = gradeAnswer(q, 'a:1|b:2');
+      expect(grade.isCorrect).toBe(true);
+      expect(grade.pointsEarned).toBe(2);
+    });
+
+    it('Ordering: shifted-but-correct-order subsequence earns LIS-based partial credit', () => {
+      const q: QuizQuestion = {
+        id: 'po1',
+        timeLimit: 0,
+        text: 'Order',
+        type: 'Ordering',
+        correctAnswer: 'A|B|C|D',
+        incorrectAnswers: [],
+        points: 4,
+        allowPartialCredit: true,
+      };
+      // correct=A,B,C,D ; given=B,C,D,A → LIS through B,C,D = 3 → 3/4 points.
+      const grade = gradeAnswer(q, 'B|C|D|A');
+      expect(grade.isCorrect).toBe(false);
+      expect(grade.pointsEarned).toBeCloseTo(3, 5);
+    });
+
+    it('Ordering: full reverse on a 4-item list awards 1/4 (longest run is 1)', () => {
+      const q: QuizQuestion = {
+        id: 'po2',
+        timeLimit: 0,
+        text: 'Order',
+        type: 'Ordering',
+        correctAnswer: 'A|B|C|D',
+        incorrectAnswers: [],
+        points: 4,
+        allowPartialCredit: true,
+      };
+      const grade = gradeAnswer(q, 'D|C|B|A');
+      expect(grade.pointsEarned).toBeCloseTo(1, 5);
+    });
+
+    it('Ordering: full reverse on a 2-item list awards 1/2', () => {
+      const q: QuizQuestion = {
+        id: 'po3',
+        timeLimit: 0,
+        text: 'Order',
+        type: 'Ordering',
+        correctAnswer: 'A|B',
+        incorrectAnswers: [],
+        points: 2,
+        allowPartialCredit: true,
+      };
+      const grade = gradeAnswer(q, 'B|A');
+      expect(grade.pointsEarned).toBeCloseTo(1, 5);
+    });
+
+    it('Ordering: full match earns full points with partial enabled', () => {
+      const q: QuizQuestion = {
+        id: 'po4',
+        timeLimit: 0,
+        text: 'Order',
+        type: 'Ordering',
+        correctAnswer: 'A|B|C',
+        incorrectAnswers: [],
+        points: 3,
+        allowPartialCredit: true,
+      };
+      const grade = gradeAnswer(q, 'A|B|C');
+      expect(grade.isCorrect).toBe(true);
+      expect(grade.pointsEarned).toBe(3);
+    });
+
+    it('Ordering: handles duplicate items in correctAnswer positionally so a perfect answer scores full credit', () => {
+      // Regression: a value→index map (last-write-wins) made a perfect
+      // answer to "A|B|A" score 2/3. Positional pairing fixes it.
+      const q: QuizQuestion = {
+        id: 'po-dup',
+        timeLimit: 0,
+        text: 'Order',
+        type: 'Ordering',
+        correctAnswer: 'A|B|A',
+        incorrectAnswers: [],
+        points: 3,
+        allowPartialCredit: true,
+      };
+      const grade = gradeAnswer(q, 'A|B|A');
+      expect(grade.isCorrect).toBe(true);
+      expect(grade.pointsEarned).toBe(3);
+    });
+
+    it('Matching: empty student answer earns zero points and is not flagged correct', () => {
+      const q: QuizQuestion = {
+        id: 'pm-empty',
+        timeLimit: 0,
+        text: 'Match',
+        type: 'Matching',
+        correctAnswer: 'a:1|b:2',
+        incorrectAnswers: [],
+        points: 4,
+        allowPartialCredit: true,
+      };
+      const grade = gradeAnswer(q, '');
+      expect(grade.isCorrect).toBe(false);
+      expect(grade.pointsEarned).toBe(0);
+    });
+
+    it('Ordering: empty student answer earns zero points and is not flagged correct', () => {
+      const q: QuizQuestion = {
+        id: 'po-empty',
+        timeLimit: 0,
+        text: 'Order',
+        type: 'Ordering',
+        correctAnswer: 'A|B|C',
+        incorrectAnswers: [],
+        points: 3,
+        allowPartialCredit: true,
+      };
+      const grade = gradeAnswer(q, '');
+      expect(grade.isCorrect).toBe(false);
+      expect(grade.pointsEarned).toBe(0);
+    });
+
+    it('partial credit is ignored when allowPartialCredit is undefined', () => {
+      const q: QuizQuestion = {
+        id: 'po5',
+        timeLimit: 0,
+        text: 'Order',
+        type: 'Ordering',
+        correctAnswer: 'A|B|C',
+        incorrectAnswers: [],
+        points: 3,
+      };
+      const grade = gradeAnswer(q, 'A|C|B');
+      expect(grade.isCorrect).toBe(false);
+      expect(grade.pointsEarned).toBe(0);
+    });
   });
 });
 
@@ -146,6 +361,50 @@ describe('toPublicQuestion', () => {
       expect.arrayContaining(['bark', 'meow', 'moo'])
     );
     expect(pub).not.toHaveProperty('correctAnswer');
+    expect(pub).not.toHaveProperty('matchingDistractors');
+  });
+
+  it('preserves a colon inside a matching definition end-to-end', () => {
+    // Regression: split(':') destructuring truncated definitions like "9:00 AM"
+    // to "9". indexOf(':') + slice keeps the rest intact.
+    const q: QuizQuestion = {
+      id: 'q-colon',
+      timeLimit: 0,
+      text: 'Match',
+      type: 'Matching',
+      correctAnswer: 'breakfast:9:00 AM|lunch:12:30 PM',
+      incorrectAnswers: [],
+    };
+    const pub = toPublicQuestion(q);
+    expect(pub.matchingLeft).toEqual(['breakfast', 'lunch']);
+    expect(pub.matchingRight).toEqual(
+      expect.arrayContaining(['9:00 AM', '12:30 PM'])
+    );
+
+    // gradeAnswer also has to round-trip the same wire format correctly.
+    const grade = gradeAnswer(q, 'breakfast:9:00 AM|lunch:12:30 PM');
+    expect(grade.isCorrect).toBe(true);
+  });
+
+  it('merges matchingDistractors into the shuffled right bank for Matching', () => {
+    const q: QuizQuestion = {
+      id: 'q2b',
+      timeLimit: 0,
+      text: 'Match',
+      type: 'Matching',
+      correctAnswer: 'dog:bark|cat:meow',
+      incorrectAnswers: [],
+      matchingDistractors: ['quack', 'oink'],
+    };
+    const pub = toPublicQuestion(q);
+    expect(pub.matchingLeft).toEqual(['dog', 'cat']);
+    // Bank contains real definitions + distractors merged together.
+    expect(pub.matchingRight).toHaveLength(4);
+    expect(pub.matchingRight).toEqual(
+      expect.arrayContaining(['bark', 'meow', 'quack', 'oink'])
+    );
+    // Distractor list copied through verbatim (for transparency / preview).
+    expect(pub.matchingDistractors).toEqual(['quack', 'oink']);
   });
 
   it('splits Ordering into items without preserving order or correctAnswer', () => {

--- a/types.ts
+++ b/types.ts
@@ -1729,6 +1729,32 @@ export interface QuizQuestion {
   incorrectAnswers: string[];
   /** Point value for this question. Defaults to 1 if not set. */
   points?: number;
+  /**
+   * Matching only. Extra incorrect definitions added to the student's
+   * word bank to increase difficulty (e.g., 3 terms but 6 definitions).
+   * Empty/undefined = no distractors. Stored separately so they can never
+   * be mistakenly read as correct pairs.
+   */
+  matchingDistractors?: string[];
+  /**
+   * Per-question opt-in for partial credit on Matching/Ordering. Ignored
+   * for MC/FIB. Defaults to false.
+   */
+  allowPartialCredit?: boolean;
+}
+
+/**
+ * Result of grading a student's answer to a single quiz question.
+ * Replaces the legacy boolean return so partial credit (Matching / Ordering)
+ * can be expressed without changing wire formats.
+ */
+export interface GradeResult {
+  /** True iff the answer earned full credit. */
+  isCorrect: boolean;
+  /** Points actually awarded (fractional ok). */
+  pointsEarned: number;
+  /** Max points for this question (= q.points ?? 1). */
+  pointsMax: number;
 }
 
 /** Full quiz data stored in Google Drive as JSON */
@@ -1811,6 +1837,13 @@ export interface QuizPublicQuestion {
   matchingLeft?: string[];
   /** Matching only: right-side definitions, pre-shuffled */
   matchingRight?: string[];
+  /**
+   * Matching only: extra distractor definitions, pre-shuffled together with
+   * `matchingRight` server-side and copied here for transparency. Students
+   * receive the merged shuffled bank; the boundary between real definitions
+   * and distractors is invisible at render time.
+   */
+  matchingDistractors?: string[];
   /** Ordering only: items to sequence, pre-shuffled */
   orderingItems?: string[];
 }

--- a/utils/quizDriveService.ts
+++ b/utils/quizDriveService.ts
@@ -40,6 +40,16 @@ function driveQueryEscape(s: string): string {
 }
 
 /**
+ * Format a points value for export to a Google Sheet cell. Whole numbers
+ * stay as integers; fractional partial-credit values render with up to
+ * 2 decimals (trailing zeros stripped).
+ */
+function formatExportPoints(points: number): string {
+  if (Number.isInteger(points)) return String(points);
+  return (Math.round(points * 100) / 100).toString();
+}
+
+/**
  * Sanitize a title for use as a Drive file name.
  * Drive disallows `/` and some OS-reserved characters; replace them with underscores.
  */
@@ -561,13 +571,13 @@ export class QuizDriveService {
       const answerCols = questions.map((q) => {
         const ans = answerMap.get(q.id);
         if (!ans) return '';
-        const isCorrect = gradeAnswer(q, ans.answer);
-        return isCorrect ? String(q.points ?? 1) : '0';
+        const grade = gradeAnswer(q, ans.answer);
+        return formatExportPoints(grade.pointsEarned);
       });
       const earnedPoints = questions.reduce((sum, q) => {
         const ans = answerMap.get(q.id);
         if (!ans) return sum;
-        return sum + (gradeAnswer(q, ans.answer) ? (q.points ?? 1) : 0);
+        return sum + gradeAnswer(q, ans.answer).pointsEarned;
       }, 0);
       const scoreDisplay =
         r.status === 'completed' && maxPoints > 0
@@ -581,7 +591,7 @@ export class QuizDriveService {
         r.pin ?? '',
         r.status,
         scoreDisplay,
-        String(earnedPoints),
+        formatExportPoints(earnedPoints),
         String(maxPoints),
         warnings,
         submitted,
@@ -742,7 +752,7 @@ export class QuizDriveService {
         if (!q) continue;
 
         answeredSet.add(a.questionId);
-        if (gradeAnswer(q, a.answer)) {
+        if (gradeAnswer(q, a.answer).isCorrect) {
           correctSet.add(a.questionId);
         }
       }


### PR DESCRIPTION
## Summary

- Replaces the legacy `term:def|term:def` / `item|item` text-input editor for Matching and Ordering questions with structured row editors (dnd-kit drag handles, per-row Term/Match inputs for matching, numbered rows for ordering, Add/Remove controls, optional distractors collapsible).
- New student-facing word-bank + drop-zone UIs with drag, tap-to-place, Reset, per-attempt unique shuffle, full keyboard support, 44px touch targets, and screen-reader labels.
- Adds optional per-question **partial credit** with an "Allow partial credit" checkbox in the editor:
  - Matching: `(correctPairs / total) × points` — also supports extra distractor definitions in the word bank.
  - Ordering: longest correctly-ordered subsequence (LIS) × points / total — a shifted-but-ordered sequence still earns partial credit, matches duplicate items positionally so a perfect answer always scores full credit.
- Streak multiplier holds (neither extends nor resets) on partial-credit answers.
- `gradeAnswer` return type changes from `boolean` to `{ isCorrect, pointsEarned, pointsMax }`; all 8 call sites migrated.
- Wire format unchanged — old `quiz_assignments` and live `quiz_sessions` continue to grade correctly.
- Editor inputs sanitize `|` (and `:` in terms) on every keystroke to unicode lookalikes so teachers can't accidentally corrupt the wire format.
- `prefers-reduced-motion` honored by the editor's dnd-kit reorder transition.

## Test plan

- [x] `pnpm run validate` — type-check, lint, prettier all clean.
- [x] **1,802 root tests + 193 functions tests pass** (16 new: partial-credit grading, LIS with duplicates, empty-answer grading, colon-in-definition round-trip, distractor merging, timer auto-submit preserves partial placements, streak holds on partial credit, plus full standalone unit tests for `MatchingResponseInput` and `OrderingResponseInput`).
- [x] Browser-verified: editor renders correctly, `|` in term sanitized live to `｜`, structured rows drag/reorder, partial-credit checkbox toggles.
- [ ] On a real Firebase env: assign a Matching quiz with distractors + partial credit, complete from a student device, verify points display fractionally on QuizResults and the export Sheet.
- [ ] Verify backward compat: open an existing quiz authored before this change and confirm the editor parses + saves it round-trip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)