### PR TITLE
feat(blending-board): admin-managed iframe widget

### DIFF
--- a/components/admin/BlendingBoardConfigurationPanel.tsx
+++ b/components/admin/BlendingBoardConfigurationPanel.tsx
@@ -22,7 +22,8 @@ export const BlendingBoardConfigurationPanel: React.FC<
           id="blending-board-url"
           type="url"
           value={config.url ?? ''}
-          onChange={(e) => onChange({ ...config, url: e.target.value.trim() })}
+          onChange={(e) => onChange({ ...config, url: e.target.value })}
+          onBlur={(e) => onChange({ ...config, url: e.target.value.trim() })}
           placeholder="https://research.dwi.ufl.edu/op.n/file/bca9ju45kvvrvoan/?embed"
           className="w-full px-4 py-2 border border-slate-300 rounded-lg focus:ring-2 focus:ring-violet-500 outline-none text-sm"
         />

--- a/components/admin/BlendingBoardConfigurationPanel.tsx
+++ b/components/admin/BlendingBoardConfigurationPanel.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { BlendingBoardGlobalConfig } from '@/types';
+
+interface BlendingBoardConfigurationPanelProps {
+  config: BlendingBoardGlobalConfig;
+  onChange: (newConfig: BlendingBoardGlobalConfig) => void;
+}
+
+export const BlendingBoardConfigurationPanel: React.FC<
+  BlendingBoardConfigurationPanelProps
+> = ({ config, onChange }) => {
+  return (
+    <div className="space-y-4">
+      <div>
+        <label
+          htmlFor="blending-board-url"
+          className="text-xxs font-bold text-slate-500 uppercase mb-2 block"
+        >
+          Embed URL
+        </label>
+        <input
+          id="blending-board-url"
+          type="url"
+          value={config.url ?? ''}
+          onChange={(e) => onChange({ ...config, url: e.target.value.trim() })}
+          placeholder="https://research.dwi.ufl.edu/op.n/file/bca9ju45kvvrvoan/?embed"
+          className="w-full px-4 py-2 border border-slate-300 rounded-lg focus:ring-2 focus:ring-violet-500 outline-none text-sm"
+        />
+        <p className="text-xxs text-slate-400 mt-1">
+          Enter the URL of the website to embed in the Blending Board widget.
+          Must be served over HTTPS and allow being embedded in an iframe.
+        </p>
+      </div>
+    </div>
+  );
+};

--- a/components/admin/FeatureConfigurationPanel.tsx
+++ b/components/admin/FeatureConfigurationPanel.tsx
@@ -37,6 +37,7 @@ import { MaterialsConfigurationPanel } from './MaterialsConfigurationPanel';
 import { MathToolsConfigurationPanel } from './MathToolsConfigurationPanel';
 import { NextUpConfigurationPanel } from './NextUpConfigurationPanel';
 import { CarRiderConfigurationPanel } from './CarRiderConfigurationPanel';
+import { BlendingBoardConfigurationPanel } from './BlendingBoardConfigurationPanel';
 import { PollConfigurationPanel } from './PollConfigurationPanel';
 import { ActivityWallConfigurationPanel } from './ActivityWallConfigurationPanel';
 import { QRConfigurationPanel } from './QRConfigurationPanel';
@@ -109,6 +110,8 @@ const BUILDING_CONFIG_PANELS: Partial<Record<string, BuildingConfigPanel>> = {
   mathTools: MathToolsConfigurationPanel as unknown as BuildingConfigPanel,
   nextUp: NextUpConfigurationPanel as unknown as BuildingConfigPanel,
   'car-rider-pro': CarRiderConfigurationPanel as unknown as BuildingConfigPanel,
+  'blending-board':
+    BlendingBoardConfigurationPanel as unknown as BuildingConfigPanel,
   poll: PollConfigurationPanel as unknown as BuildingConfigPanel,
   'activity-wall':
     ActivityWallConfigurationPanel as unknown as BuildingConfigPanel,

--- a/components/widgets/BlendingBoard/Settings.tsx
+++ b/components/widgets/BlendingBoard/Settings.tsx
@@ -2,16 +2,27 @@ import React from 'react';
 import { WidgetData } from '@/types';
 import { Speech } from 'lucide-react';
 
+const CentrallyManagedNotice: React.FC = () => (
+  <div className="p-4 bg-slate-50 border border-slate-100 rounded-xl text-center flex flex-col items-center gap-3">
+    <Speech className="w-6 h-6 text-slate-400" />
+    <p className="text-sm text-slate-600 leading-relaxed">
+      This widget is centrally managed. Your district administrator configures
+      the embedded URL for all classrooms.
+    </p>
+  </div>
+);
+
 export const BlendingBoardSettings: React.FC<{ widget: WidgetData }> = ({
   widget: _widget,
 }) => {
-  return (
-    <div className="p-4 bg-slate-50 border border-slate-100 rounded-xl text-center flex flex-col items-center gap-3">
-      <Speech className="w-6 h-6 text-slate-400" />
-      <p className="text-sm text-slate-600 leading-relaxed">
-        This widget is centrally managed. Your district administrator configures
-        the embedded URL for all classrooms.
-      </p>
-    </div>
-  );
+  return <CentrallyManagedNotice />;
+};
+
+// Suppress the default UniversalStyleSettings fallback in the Style tab —
+// Blending Board has no per-widget styling because the iframe is opaque
+// and the URL is admin-controlled. Show the same read-only notice.
+export const BlendingBoardAppearanceSettings: React.FC<{
+  widget: WidgetData;
+}> = ({ widget: _widget }) => {
+  return <CentrallyManagedNotice />;
 };

--- a/components/widgets/BlendingBoard/Settings.tsx
+++ b/components/widgets/BlendingBoard/Settings.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { WidgetData } from '@/types';
+import { Speech } from 'lucide-react';
+
+export const BlendingBoardSettings: React.FC<{ widget: WidgetData }> = ({
+  widget: _widget,
+}) => {
+  return (
+    <div className="p-4 bg-slate-50 border border-slate-100 rounded-xl text-center flex flex-col items-center gap-3">
+      <Speech className="w-6 h-6 text-slate-400" />
+      <p className="text-sm text-slate-600 leading-relaxed">
+        This widget is centrally managed. Your district administrator configures
+        the embedded URL for all classrooms.
+      </p>
+    </div>
+  );
+};

--- a/components/widgets/BlendingBoard/Widget.tsx
+++ b/components/widgets/BlendingBoard/Widget.tsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import { WidgetData } from '@/types';
+import { Speech, ExternalLink, Loader2 } from 'lucide-react';
+import { ScaledEmptyState } from '@/components/common/ScaledEmptyState';
+import { WidgetLayout } from '@/components/widgets/WidgetLayout';
+import { useBlendingBoardConfig } from '@/components/widgets/BlendingBoard/hooks/useBlendingBoardConfig';
+
+export const BlendingBoardWidget: React.FC<{ widget: WidgetData }> = ({
+  widget: _widget,
+}) => {
+  const { url, isLoading } = useBlendingBoardConfig();
+
+  if (isLoading) {
+    return (
+      <WidgetLayout
+        padding="p-0"
+        content={
+          <div className="w-full h-full flex items-center justify-center bg-slate-50">
+            <Loader2
+              className="animate-spin text-slate-300"
+              style={{
+                width: 'min(32px, 8cqmin)',
+                height: 'min(32px, 8cqmin)',
+              }}
+            />
+          </div>
+        }
+      />
+    );
+  }
+
+  const isValidUrl = url.startsWith('https://');
+
+  if (!url || !isValidUrl) {
+    return (
+      <WidgetLayout
+        padding="p-0"
+        content={
+          <ScaledEmptyState
+            icon={Speech}
+            title="Blending Board Disabled"
+            subtitle={
+              !url
+                ? 'Your district administrator has not configured the embed URL yet.'
+                : 'The configured embed URL is invalid or insecure.'
+            }
+          />
+        }
+      />
+    );
+  }
+
+  return (
+    <WidgetLayout
+      padding="p-0"
+      content={
+        <div className="w-full h-full relative group/blending-content">
+          <a
+            href={url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="absolute top-2 right-2 z-10 bg-white/80 backdrop-blur-sm hover:bg-white text-slate-500 hover:text-violet-500 shadow-sm border border-slate-200/50 rounded-lg p-1.5 transition-colors"
+            title="Open in new tab"
+            onPointerDown={(e) => e.stopPropagation()}
+          >
+            <ExternalLink
+              style={{
+                width: 'min(12px, 2.5cqmin)',
+                height: 'min(12px, 2.5cqmin)',
+              }}
+            />
+          </a>
+          <iframe
+            title="Blending Board"
+            src={url}
+            className="w-full h-full border-none"
+            sandbox="allow-scripts allow-forms allow-popups allow-same-origin"
+          />
+        </div>
+      }
+    />
+  );
+};

--- a/components/widgets/BlendingBoard/Widget.tsx
+++ b/components/widgets/BlendingBoard/Widget.tsx
@@ -29,7 +29,7 @@ export const BlendingBoardWidget: React.FC<{ widget: WidgetData }> = ({
     );
   }
 
-  const isValidUrl = url.startsWith('https://');
+  const isValidUrl = url.toLowerCase().startsWith('https://');
 
   if (!url || !isValidUrl) {
     return (

--- a/components/widgets/BlendingBoard/Widget.tsx
+++ b/components/widgets/BlendingBoard/Widget.tsx
@@ -59,7 +59,13 @@ export const BlendingBoardWidget: React.FC<{ widget: WidgetData }> = ({
             href={url}
             target="_blank"
             rel="noopener noreferrer"
-            className="absolute top-2 right-2 z-10 bg-white/80 backdrop-blur-sm hover:bg-white text-slate-500 hover:text-violet-500 shadow-sm border border-slate-200/50 rounded-lg p-1.5 transition-colors"
+            className="absolute z-10 bg-white/80 backdrop-blur-sm hover:bg-white text-slate-500 hover:text-violet-500 shadow-sm border border-slate-200/50 transition-colors"
+            style={{
+              top: 'min(8px, 2cqmin)',
+              right: 'min(8px, 2cqmin)',
+              padding: 'min(6px, 1.5cqmin)',
+              borderRadius: 'min(8px, 2cqmin)',
+            }}
             title="Open in new tab"
             onPointerDown={(e) => e.stopPropagation()}
           >

--- a/components/widgets/BlendingBoard/hooks/useBlendingBoardConfig.ts
+++ b/components/widgets/BlendingBoard/hooks/useBlendingBoardConfig.ts
@@ -1,0 +1,40 @@
+import { useState, useEffect } from 'react';
+import { doc, onSnapshot } from 'firebase/firestore';
+import { db } from '@/config/firebase';
+import { BlendingBoardGlobalConfig } from '@/types';
+
+export const useBlendingBoardConfig = () => {
+  const [url, setUrl] = useState('');
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    const unsubscribe = onSnapshot(
+      doc(db, 'feature_permissions', 'blending-board'),
+      (docSnap) => {
+        if (docSnap.exists()) {
+          const data = docSnap.data() as {
+            config?: BlendingBoardGlobalConfig;
+            url?: string;
+          };
+          // Prefer config.url (new shape); fall back to top-level url (legacy shape)
+          const resolved = (data.config?.url ?? data.url ?? '').trim();
+          setUrl(resolved);
+        } else {
+          setUrl('');
+        }
+        setIsLoading(false);
+      },
+      (error) => {
+        console.error(
+          'Failed to listen for Blending Board config changes:',
+          error
+        );
+        setIsLoading(false);
+        setUrl('');
+      }
+    );
+    return () => unsubscribe();
+  }, []);
+
+  return { url, isLoading };
+};

--- a/components/widgets/BlendingBoard/index.ts
+++ b/components/widgets/BlendingBoard/index.ts
@@ -1,0 +1,2 @@
+export { BlendingBoardWidget } from './Widget';
+export { BlendingBoardSettings } from './Settings';

--- a/components/widgets/WidgetRegistry.ts
+++ b/components/widgets/WidgetRegistry.ts
@@ -169,6 +169,10 @@ export const WIDGET_COMPONENTS: Partial<Record<WidgetType, WidgetComponent>> = {
     () => import('./CarRiderPro/Widget'),
     'CarRiderProWidget'
   ),
+  'blending-board': lazyNamed(
+    () => import('./BlendingBoard/Widget'),
+    'BlendingBoardWidget'
+  ),
   'first-5': lazyNamed(() => import('./First5/Widget'), 'First5Widget'),
   'specialist-schedule': lazyNamed(
     () => import('./SpecialistSchedule'),
@@ -319,6 +323,10 @@ export const WIDGET_SETTINGS_COMPONENTS: Partial<
   'car-rider-pro': lazyNamed(
     () => import('./CarRiderPro/Settings'),
     'CarRiderProSettings'
+  ),
+  'blending-board': lazyNamed(
+    () => import('./BlendingBoard/Settings'),
+    'BlendingBoardSettings'
   ),
   'first-5': lazyNamed(() => import('./First5/Settings'), 'First5Settings'),
   'specialist-schedule': lazyNamed(
@@ -815,6 +823,13 @@ export const WIDGET_SCALING_CONFIG: Record<WidgetType, ScalingConfig> = {
     padding: 0,
   },
   'car-rider-pro': {
+    baseWidth: 450,
+    baseHeight: 600,
+    canSpread: true,
+    skipScaling: true,
+    padding: 0,
+  },
+  'blending-board': {
     baseWidth: 450,
     baseHeight: 600,
     canSpread: true,

--- a/components/widgets/WidgetRegistry.ts
+++ b/components/widgets/WidgetRegistry.ts
@@ -397,6 +397,10 @@ export const WIDGET_APPEARANCE_COMPONENTS: Partial<
   Record<WidgetType, SettingsComponent>
 > = {
   // Populated per-widget in components/widgets/*/Settings.tsx
+  'blending-board': lazyNamed(
+    () => import('./BlendingBoard/Settings'),
+    'BlendingBoardAppearanceSettings'
+  ),
   clock: lazyNamed(
     () => import('./ClockWidget/Settings'),
     'ClockAppearanceSettings'

--- a/config/tools.ts
+++ b/config/tools.ts
@@ -36,6 +36,7 @@ import {
   ListOrdered,
   Music,
   CarFront,
+  Speech,
   Smartphone,
   Layers,
   MapPin,
@@ -152,6 +153,12 @@ export const TOOLS: ToolMetadata[] = [
     icon: CarFront,
     label: 'Car Rider',
     color: 'bg-blue-500',
+  },
+  {
+    type: 'blending-board',
+    icon: Speech,
+    label: 'Blending Board',
+    color: 'bg-violet-500',
   },
   {
     type: 'first-5',

--- a/config/widgetDefaults.ts
+++ b/config/widgetDefaults.ts
@@ -352,6 +352,11 @@ export const WIDGET_DEFAULTS: Record<WidgetType, Partial<WidgetData>> = {
     h: 600,
     config: {},
   },
+  'blending-board': {
+    w: 450,
+    h: 600,
+    config: {},
+  },
   'first-5': {
     w: 450,
     h: 600,

--- a/config/widgetGradeLevels.ts
+++ b/config/widgetGradeLevels.ts
@@ -91,6 +91,7 @@ export const WIDGET_GRADE_LEVELS: Record<
   countdown: ALL_GRADE_LEVELS,
   music: ALL_GRADE_LEVELS,
   'car-rider-pro': ALL_GRADE_LEVELS,
+  'blending-board': ALL_GRADE_LEVELS,
   'first-5': ALL_GRADE_LEVELS,
   'specialist-schedule': ['k-2', '3-5', '6-8'],
   'graphic-organizer': ['k-2', '3-5', '6-8'],

--- a/types.ts
+++ b/types.ts
@@ -2834,11 +2834,7 @@ export interface CarRiderProConfig {
   cardOpacity?: number;
 }
 
-export interface BlendingBoardConfig {
-  iframeUrl?: string;
-  cardColor?: string;
-  cardOpacity?: number;
-}
+export type BlendingBoardConfig = Record<string, never>;
 
 export interface RevealCard {
   id: string;

--- a/types.ts
+++ b/types.ts
@@ -3342,6 +3342,7 @@ export type WidgetConfig =
   | OnboardingConfig
   | CountdownConfig
   | CarRiderProConfig
+  | BlendingBoardConfig
   | MusicConfig
   | SpecialistScheduleConfig
   | GraphicOrganizerConfig

--- a/types.ts
+++ b/types.ts
@@ -40,6 +40,7 @@ export type WidgetType =
   | 'onboarding'
   | 'countdown'
   | 'car-rider-pro'
+  | 'blending-board'
   | 'music'
   | 'specialist-schedule'
   | 'graphic-organizer'
@@ -2833,6 +2834,12 @@ export interface CarRiderProConfig {
   cardOpacity?: number;
 }
 
+export interface BlendingBoardConfig {
+  iframeUrl?: string;
+  cardColor?: string;
+  cardOpacity?: number;
+}
+
 export interface RevealCard {
   id: string;
   frontContent: string;
@@ -3446,43 +3453,45 @@ export type ConfigForWidget<T extends WidgetType> = T extends 'url'
                                                                                     ? CountdownConfig
                                                                                     : T extends 'car-rider-pro'
                                                                                       ? CarRiderProConfig
-                                                                                      : T extends 'music'
-                                                                                        ? MusicConfig
-                                                                                        : T extends 'specialist-schedule'
-                                                                                          ? SpecialistScheduleConfig
-                                                                                          : T extends 'graphic-organizer'
-                                                                                            ? GraphicOrganizerConfig
-                                                                                            : T extends 'concept-web'
-                                                                                              ? ConceptWebConfig
-                                                                                              : T extends 'reveal-grid'
-                                                                                                ? RevealGridConfig
-                                                                                                : T extends 'numberLine'
-                                                                                                  ? NumberLineConfig
-                                                                                                  : T extends 'syntax-framer'
-                                                                                                    ? SyntaxFramerConfig
-                                                                                                    : T extends 'hotspot-image'
-                                                                                                      ? HotspotImageConfig
-                                                                                                      : T extends 'starter-pack'
-                                                                                                        ? StarterPackConfig
-                                                                                                        : T extends 'video-activity'
-                                                                                                          ? VideoActivityConfig
-                                                                                                          : T extends 'guided-learning'
-                                                                                                            ? GuidedLearningConfig
-                                                                                                            : T extends 'custom-widget'
-                                                                                                              ? CustomWidgetConfig
-                                                                                                              : T extends 'activity-wall'
-                                                                                                                ? ActivityWallConfig
-                                                                                                                : T extends 'work-symbols'
-                                                                                                                  ? WorkSymbolsConfig
-                                                                                                                  : T extends 'blooms-taxonomy'
-                                                                                                                    ? BloomsTaxonomyConfig
-                                                                                                                    : T extends 'blooms-detail'
-                                                                                                                      ? BloomsDetailConfig
-                                                                                                                      : T extends 'need-do-put-then'
-                                                                                                                        ? NeedDoPutThenConfig
-                                                                                                                        : T extends 'stations'
-                                                                                                                          ? StationsConfig
-                                                                                                                          : never;
+                                                                                      : T extends 'blending-board'
+                                                                                        ? BlendingBoardConfig
+                                                                                        : T extends 'music'
+                                                                                          ? MusicConfig
+                                                                                          : T extends 'specialist-schedule'
+                                                                                            ? SpecialistScheduleConfig
+                                                                                            : T extends 'graphic-organizer'
+                                                                                              ? GraphicOrganizerConfig
+                                                                                              : T extends 'concept-web'
+                                                                                                ? ConceptWebConfig
+                                                                                                : T extends 'reveal-grid'
+                                                                                                  ? RevealGridConfig
+                                                                                                  : T extends 'numberLine'
+                                                                                                    ? NumberLineConfig
+                                                                                                    : T extends 'syntax-framer'
+                                                                                                      ? SyntaxFramerConfig
+                                                                                                      : T extends 'hotspot-image'
+                                                                                                        ? HotspotImageConfig
+                                                                                                        : T extends 'starter-pack'
+                                                                                                          ? StarterPackConfig
+                                                                                                          : T extends 'video-activity'
+                                                                                                            ? VideoActivityConfig
+                                                                                                            : T extends 'guided-learning'
+                                                                                                              ? GuidedLearningConfig
+                                                                                                              : T extends 'custom-widget'
+                                                                                                                ? CustomWidgetConfig
+                                                                                                                : T extends 'activity-wall'
+                                                                                                                  ? ActivityWallConfig
+                                                                                                                  : T extends 'work-symbols'
+                                                                                                                    ? WorkSymbolsConfig
+                                                                                                                    : T extends 'blooms-taxonomy'
+                                                                                                                      ? BloomsTaxonomyConfig
+                                                                                                                      : T extends 'blooms-detail'
+                                                                                                                        ? BloomsDetailConfig
+                                                                                                                        : T extends 'need-do-put-then'
+                                                                                                                          ? NeedDoPutThenConfig
+                                                                                                                          : T extends 'stations'
+                                                                                                                            ? StationsConfig
+                                                                                                                            : never;
 
 export interface WidgetComponentProps {
   widget: WidgetData;
@@ -3802,6 +3811,11 @@ export interface FeaturePermission {
 
 export interface CarRiderProGlobalConfig {
   /** District portal login URL for the Car Rider Pro dismissal widget */
+  url?: string;
+}
+
+export interface BlendingBoardGlobalConfig {
+  /** Embedded research/blending board URL configured by district admin */
   url?: string;
 }
 


### PR DESCRIPTION
## Summary

- New **Blending Board** widget modeled exactly on Car Rider Pro — sandboxed iframe whose URL is centrally managed by district admins via `feature_permissions/blending-board` in Firestore.
- Settings panel is the read-only "centrally managed" notice; admin URL is configured in Admin Settings → Feature Permissions → Blending Board (config gear).
- URL is trimmed on both store (admin panel) and read (Firestore listener) so whitespace-padded paste doesn't silently produce a blank iframe.

## Implementation notes

- 8-step new-widget checklist covered: type union + config interfaces + `ConfigForWidget` branch, `TOOLS` entry (Speech icon, `bg-violet-500`), `WidgetRegistry` (component + settings + scaling), `widgetDefaults` (450×600), `widgetGradeLevels` (`ALL_GRADE_LEVELS`), admin config panel + `FeatureConfigurationPanel` wiring.
- No appearance tab (matches Car Rider Pro).
- Default URL placeholder in admin panel: `https://research.dwi.ufl.edu/op.n/file/bca9ju45kvvrvoan/?embed`.

## Test plan

- [ ] `pnpm run validate` passes locally (type-check, lint, format-check, tests)
- [ ] As an admin, open Admin Settings → Feature Permissions → Blending Board config gear; paste/save the embed URL; confirm Firestore writes to `feature_permissions/blending-board`
- [ ] Add Blending Board from the Dock; confirm iframe loads (or visible third-party host error if X-Frame-Options blocks)
- [ ] "Open in new tab" affordance works and doesn't hijack drag
- [ ] Flip widget; confirm Settings shows the read-only "centrally managed" notice
- [ ] Clear the admin URL; confirm widget shows the `ScaledEmptyState` "Blending Board Disabled"
- [ ] Verify the widget appears for non-admin teachers (default public access)

🤖 Generated with [Claude Code](https://claude.com/claude-code)