### PR TITLE
fix(draggable): corner-priority zone for resize on inactive widgets

### DIFF
--- a/components/common/DraggableWindow.test.tsx
+++ b/components/common/DraggableWindow.test.tsx
@@ -568,4 +568,129 @@ describe('DraggableWindow', () => {
       expect.objectContaining({ maximized: false })
     );
   });
+
+  describe('Resize handle priority zone', () => {
+    // Widget at x=100, y=100, w=200, h=200 → right=300, bottom=300.
+    // RESIZE_PRIORITY_INSET = 16, so the SE priority zone is
+    // clientX >= 284 AND clientY >= 284.
+    const WIDGET_RECT = {
+      x: 100,
+      y: 100,
+      left: 100,
+      top: 100,
+      right: 300,
+      bottom: 300,
+      width: 200,
+      height: 200,
+      toJSON: () => ({}),
+    } as DOMRect;
+
+    type ElementsFromPoint = (x: number, y: number) => Element[];
+    type DocWithElementsFromPoint = Document & {
+      elementsFromPoint?: ElementsFromPoint;
+    };
+
+    const getSeHandle = (): HTMLElementWithCapture => {
+      const el = document.querySelector('.cursor-se-resize');
+      if (!(el instanceof HTMLElement)) {
+        throw new Error('SE resize handle not found');
+      }
+      const handle = el as HTMLElementWithCapture;
+      handle.setPointerCapture = vi.fn();
+      handle.hasPointerCapture = vi.fn().mockReturnValue(true);
+      handle.releasePointerCapture = vi.fn();
+      return handle;
+    };
+
+    let getBoundingClientRectSpy: MockInstance;
+    let elementsFromPointMock: Mock;
+    let originalElementsFromPoint: ElementsFromPoint | undefined;
+
+    beforeEach(() => {
+      getBoundingClientRectSpy = vi
+        .spyOn(Element.prototype, 'getBoundingClientRect')
+        .mockReturnValue(WIDGET_RECT);
+
+      // jsdom doesn't implement document.elementsFromPoint. Stub it directly
+      // so handleResizeStart's pass-through check has something to call.
+      const stubButton = document.createElement('button');
+      elementsFromPointMock = vi.fn().mockReturnValue([stubButton]);
+      const doc = document as DocWithElementsFromPoint;
+      originalElementsFromPoint = doc.elementsFromPoint;
+      doc.elementsFromPoint =
+        elementsFromPointMock as unknown as ElementsFromPoint;
+
+      document.body.classList.remove('is-dragging-widget');
+    });
+
+    afterEach(() => {
+      getBoundingClientRectSpy.mockRestore();
+      const doc = document as DocWithElementsFromPoint;
+      if (originalElementsFromPoint) {
+        doc.elementsFromPoint = originalElementsFromPoint;
+      } else {
+        Reflect.deleteProperty(doc, 'elementsFromPoint');
+      }
+      document.body.classList.remove('is-dragging-widget');
+    });
+
+    it('starts resize when click is in the corner priority zone, even with a button beneath', () => {
+      renderComponent({}, null, undefined, 'test-widget');
+      const seHandle = getSeHandle();
+
+      // (290, 290) is within 16px of right (300) and bottom (300) → priority zone.
+      fireEvent.pointerDown(seHandle, {
+        clientX: 290,
+        clientY: 290,
+        pointerId: 1,
+      });
+
+      // Resize started: body marker class is added and pointer capture taken.
+      expect(document.body.classList.contains('is-dragging-widget')).toBe(true);
+      expect(seHandle.setPointerCapture).toHaveBeenCalledWith(1);
+      // elementsFromPoint pass-through must be skipped in the priority zone.
+      expect(elementsFromPointMock).not.toHaveBeenCalled();
+
+      fireEvent.pointerUp(window, { pointerId: 1 });
+    });
+
+    it('passes through to interactive element when click is outside priority zone', () => {
+      renderComponent({}, null, undefined, 'test-widget');
+      const seHandle = getSeHandle();
+
+      // (270, 270) is 30px inside right/bottom → NOT in the priority zone,
+      // so the elementsFromPoint pass-through check runs and finds a button.
+      fireEvent.pointerDown(seHandle, {
+        clientX: 270,
+        clientY: 270,
+        pointerId: 1,
+      });
+
+      // Resize did NOT start: no body marker class, no pointer capture.
+      expect(document.body.classList.contains('is-dragging-widget')).toBe(
+        false
+      );
+      expect(seHandle.setPointerCapture).not.toHaveBeenCalled();
+      // Pass-through path was exercised.
+      expect(elementsFromPointMock).toHaveBeenCalledWith(270, 270);
+    });
+
+    it('starts resize from the overhang outside the widget bounds', () => {
+      renderComponent({}, null, undefined, 'test-widget');
+      const seHandle = getSeHandle();
+
+      // (305, 305) is OUTSIDE the widget (right=300, bottom=300) — the
+      // resize handle's 12px overhang. Always treated as priority zone.
+      fireEvent.pointerDown(seHandle, {
+        clientX: 305,
+        clientY: 305,
+        pointerId: 1,
+      });
+
+      expect(document.body.classList.contains('is-dragging-widget')).toBe(true);
+      expect(elementsFromPointMock).not.toHaveBeenCalled();
+
+      fireEvent.pointerUp(window, { pointerId: 1 });
+    });
+  });
 });

--- a/components/common/DraggableWindow.tsx
+++ b/components/common/DraggableWindow.tsx
@@ -114,6 +114,11 @@ const DRAG_CLICK_THRESHOLD_PX = 25;
 const INVISIBLE_EDGE_PAD = 20; // px of invisible grab zone extending outside widget bounds
 const INNER_EDGE_PAD = 16; // px of invisible drag zone inside widget bounds
 const INNER_EDGE_CORNER_INSET = 24; // px inset at corners to avoid resize handle overlap
+// Resize handles always win within this many px of the widget's outer edge in
+// the handle's direction, regardless of what's beneath. Prevents widgets that
+// place buttons / links flush to the corner (e.g. URL widget tiles) from
+// stealing the resize gesture via the elementsFromPoint pass-through check.
+const RESIZE_PRIORITY_INSET = 16;
 
 interface DraggableWindowProps {
   widget: WidgetData;
@@ -1019,27 +1024,50 @@ export const DraggableWindow: React.FC<DraggableWindowProps> = ({
 
     // Check if an interactive element exists beneath this resize overlay.
     // If so, let the event pass through to the interactive element instead of resizing.
+    // Skipped when the click is in the near-corner priority zone (overhang +
+    // RESIZE_PRIORITY_INSET inside on the relevant edges), so widgets that
+    // place buttons flush to the edge can't steal the resize gesture.
     const resizeEl = e.currentTarget as HTMLElement;
-    const elementsAtPoint = document.elementsFromPoint(e.clientX, e.clientY);
-    for (const el of elementsAtPoint) {
-      if (el === resizeEl) continue;
-      // Iframes, canvases, and contentEditable elements (e.g. embed, drawing,
-      // or text widgets) often fill the entire container — the resize handle
-      // must take priority over them.
-      if (el instanceof HTMLIFrameElement || el instanceof HTMLCanvasElement)
-        continue;
-      if (el instanceof HTMLElement && el.isContentEditable) continue;
-      if (
-        el.matches?.(RESIZE_PASSTHROUGH_SELECTOR) ||
-        el.closest?.(RESIZE_PASSTHROUGH_SELECTOR)
-      ) {
-        // Temporarily remove pointer-events so the browser dispatches
-        // the subsequent click to the interactive element beneath.
-        resizeEl.style.pointerEvents = 'none';
-        requestAnimationFrame(() => {
-          resizeEl.style.pointerEvents = '';
-        });
-        return;
+    const windowEl = windowRef.current;
+    let inPriorityZone = false;
+    if (windowEl) {
+      const rect = windowEl.getBoundingClientRect();
+      const eastOk =
+        !direction.includes('e') ||
+        e.clientX >= rect.right - RESIZE_PRIORITY_INSET;
+      const westOk =
+        !direction.includes('w') ||
+        e.clientX <= rect.left + RESIZE_PRIORITY_INSET;
+      const southOk =
+        !direction.includes('s') ||
+        e.clientY >= rect.bottom - RESIZE_PRIORITY_INSET;
+      const northOk =
+        !direction.includes('n') ||
+        e.clientY <= rect.top + RESIZE_PRIORITY_INSET;
+      inPriorityZone = eastOk && westOk && southOk && northOk;
+    }
+    if (!inPriorityZone) {
+      const elementsAtPoint = document.elementsFromPoint(e.clientX, e.clientY);
+      for (const el of elementsAtPoint) {
+        if (el === resizeEl) continue;
+        // Iframes, canvases, and contentEditable elements (e.g. embed, drawing,
+        // or text widgets) often fill the entire container — the resize handle
+        // must take priority over them.
+        if (el instanceof HTMLIFrameElement || el instanceof HTMLCanvasElement)
+          continue;
+        if (el instanceof HTMLElement && el.isContentEditable) continue;
+        if (
+          el.matches?.(RESIZE_PASSTHROUGH_SELECTOR) ||
+          el.closest?.(RESIZE_PASSTHROUGH_SELECTOR)
+        ) {
+          // Temporarily remove pointer-events so the browser dispatches
+          // the subsequent click to the interactive element beneath.
+          resizeEl.style.pointerEvents = 'none';
+          requestAnimationFrame(() => {
+            resizeEl.style.pointerEvents = '';
+          });
+          return;
+        }
       }
     }
 

--- a/components/widgets/UrlWidget/Widget.tsx
+++ b/components/widgets/UrlWidget/Widget.tsx
@@ -41,7 +41,10 @@ export const UrlWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
     <WidgetLayout
       padding="p-0"
       content={
-        <div className="h-full w-full flex flex-col overflow-hidden">
+        <div
+          className="h-full w-full flex flex-col overflow-hidden"
+          style={{ padding: 'min(4px, 1cqmin)' }}
+        >
           <div className="flex-1 min-h-0">
             <div
               className="grid h-full w-full"


### PR DESCRIPTION
## Summary

- Fixes a regression where the URL widget required first clicking to "activate" before its corner could be grabbed for resize. Other widgets allow grab-corner-and-drag immediately; the URL widget did not.
- Adds a defensive corner-priority zone in `DraggableWindow` so the same class of bug can't recur for any future widget that places interactive elements flush to the edge.

## Why this happened

PR [#1496](https://github.com/OPS-PIvers/SpartBoard/pull/1496) (`feat(url-widget): overhaul UI`) removed the URL widget's inner padding and introduced an edge-to-edge `<button class="absolute inset-0">` per tile, plus a per-widget min-size override letting the widget shrink to 80×80. The resize handles in `DraggableWindow` are 36×36 corner overlays that overhang 12 px outside the widget and reach 24 px inside. `handleResizeStart` did an `elementsFromPoint` pass-through check, and `RESIZE_PASSTHROUGH_SELECTOR` includes `'button'` — so a click on the corner found the tile button beneath, set the handle to `pointer-events: none` for one frame, and skipped the resize. The click bubbled up to focus the widget. Subsequent drags hit fast enough (and in slightly different layout once selected-state UI rendered) for resize to work, giving the appearance of a "click first, then resize" requirement.

This is the same class of issue addressed by `2ba87563` (which excluded `.cursor-pointer` from the pass-through selector). That fix held until widgets started rendering real `<button>` elements at their corners.

## Changes

- **components/common/DraggableWindow.tsx** — new `RESIZE_PRIORITY_INSET = 16` constant. `handleResizeStart` now skips the pass-through check entirely when the click lands within 16 px of the widget's outer edge in the handle's direction (combined with the existing 12 px overhang, this gives a ~28 px always-resize band per corner edge). Pass-through still runs for clicks deeper inside the widget body, so canvas/iframe/contentEditable widgets keep their existing exclusions away from corners.
- **components/widgets/UrlWidget/Widget.tsx** — restore a minimal `min(4px, 1cqmin)` outer padding so tile buttons don't kiss the absolute corner. Belt-and-suspenders alongside the DraggableWindow change; preserves PR #1496's "tighter sizing" intent (was 12 px before #1496 removed it; 4 px now).

## Test plan

- [x] `pnpm run type-check` — clean
- [x] `pnpm run lint` — clean (zero errors / zero warnings)
- [x] `pnpm run test` — 1802 / 1802 pass
- [ ] **Manual UI verification needed** (resize-handle pointer-capture gestures don't reproduce reliably via synthetic DOM events):
  - [ ] Add a URL widget with 1–2 links. Click somewhere outside it so it's inactive. Drag each corner (NW/NE/SW/SE) directly — resize should start immediately, no "click first" dance.
  - [ ] Shrink the URL widget to its 80×80 minimum and confirm corner resize still works there.
  - [ ] Confirm clicking the *body* of a tile (well inside, not near a corner) still opens the link in a new tab.
  - [ ] Smoke-test: Clock / Weather (static), Schedule or LunchCount (interactive but not edge-to-edge), Drawing (canvas pass-through). All corners should still resize; deeper-body clicks should still hit interactive elements / draw on canvas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)