### PR TITLE
audit(scheduled-tasks): Tuesday 2026-05-05 — daily clean, 2 new dependency issues

### DIFF
--- a/docs/scheduled-tasks/code-structure.md
+++ b/docs/scheduled-tasks/code-structure.md
@@ -3,7 +3,7 @@
 _Audit model: claude-sonnet-4-6_
 _Action model: claude-opus-4-6_
 _Audit cadence: weekly — Wednesday_
-_Last audited: 2026-04-29_
+_Last audited: 2026-05-06_
 _Last action: never_
 
 ---
@@ -19,14 +19,15 @@ _Nothing currently in progress._
 ### MEDIUM `DashboardContext.tsx` is 3481 lines and growing — at least three extractable responsibilities
 
 - **Detected:** 2026-04-15
-- **Updated:** 2026-04-29 — file grew from 3394 to 3481 lines (+87) since 2026-04-22 audit. Growth rate has slowed but file is still increasing.
+- **Updated:** 2026-05-06 — file grew from 3481 to 3504 lines (+23) since 2026-04-29 audit. Growth rate remains slow but file continues to increase.
 - **File:** context/DashboardContext.tsx
-- **Detail:** The context file is the largest non-test source file at 3481 lines (was 3165 on 2026-04-15). It owns: (1) Firestore CRUD + real-time sync, (2) Google Drive backup/restore orchestration, (3) widget CRUD actions (add/update/delete/reorder), (4) `getAdminBuildingConfig` — a 400-line switch at lines 2127–2540 covering 30+ widget types that maps per-building admin overrides onto widget defaults, (5) `applyDashboardTemplate` and `loadStarterPack`, (6) migration and legacy handling.
+- **Detail:** The context file is the largest non-test source file at 3504 lines (was 3165 on 2026-04-15). It owns: (1) Firestore CRUD + real-time sync, (2) Google Drive backup/restore orchestration, (3) widget CRUD actions (add/update/delete/reorder), (4) `getAdminBuildingConfig` — a 400-line switch at lines 2127–2540 covering 30+ widget types that maps per-building admin overrides onto widget defaults, (5) `applyDashboardTemplate` and `loadStarterPack`, (6) migration and legacy handling.
 - **Fix:** Extract `getAdminBuildingConfig` into `utils/adminBuildingConfig.ts` (pure function: `(type, featurePermissions, selectedBuildings) => Record<string, unknown>`). This removes ~400 lines from the context without touching its public API and makes the validation logic independently testable. Also consider extracting migration logic to `utils/dashboardMigration.ts` (~150 lines).
 
-### MEDIUM `functions/src/index.ts` is 3524 lines — single file for all Cloud Functions (rapidly growing)
+### MEDIUM `functions/src/index.ts` is 3525 lines — single file for all Cloud Functions (growth stalled)
 
 - **Detected:** 2026-04-15
+- **Updated:** 2026-05-06 — file stable at 3525 lines (from 3524, +1) since 2026-04-29 audit. Growth has stalled.
 - **Updated:** 2026-04-29 — file grew from 2488 to 3524 lines (+1036) since 2026-04-22 audit. Four new Cloud Functions were added: `studentLoginV1` (256MiB, public invoker, handles Google + ClassLink SSO for students), `getAssignmentPseudonymV1` (128MiB, student-role only), `getStudentClassDirectoryV1` (256MiB, public invoker), and `getPseudonymsForAssignmentV1` (256MiB, minInstances:1, public invoker). These are all student SSO / pseudonym functions.
 - **File:** functions/src/index.ts
 - **Detail:** 13 Cloud Functions now live in one file. Logical groupings: ClassLink roster integration (getClassLinkRosterV1), AI generation (generateWithAI, generateVideoActivity, transcribeVideoWithGemini, generateGuidedLearning), utility (fetchExternalProxy, archiveActivityWallPhoto, checkUrlCompatibility), admin (adminAnalytics), student SSO/pseudonym (studentLoginV1, getAssignmentPseudonymV1, getStudentClassDirectoryV1, getPseudonymsForAssignmentV1). The file is increasingly difficult to navigate. The `getPseudonymsForAssignmentV1` has `minInstances: 1` — verify this is intentional (cold start cost vs. latency tradeoff).

--- a/docs/scheduled-tasks/css-scaling.md
+++ b/docs/scheduled-tasks/css-scaling.md
@@ -3,7 +3,7 @@
 _Audit model: claude-sonnet-4-6_
 _Action model: claude-opus-4-6_
 _Audit cadence: daily_
-_Last audited: 2026-05-03_
+_Last audited: 2026-05-04_
 _Last action: 2026-04-25_
 
 ---

--- a/docs/scheduled-tasks/css-scaling.md
+++ b/docs/scheduled-tasks/css-scaling.md
@@ -3,7 +3,7 @@
 _Audit model: claude-sonnet-4-6_
 _Action model: claude-opus-4-6_
 _Audit cadence: daily_
-_Last audited: 2026-05-02_
+_Last audited: 2026-05-03_
 _Last action: 2026-04-25_
 
 ---

--- a/docs/scheduled-tasks/css-scaling.md
+++ b/docs/scheduled-tasks/css-scaling.md
@@ -3,7 +3,7 @@
 _Audit model: claude-sonnet-4-6_
 _Action model: claude-opus-4-6_
 _Audit cadence: daily_
-_Last audited: 2026-05-05_
+_Last audited: 2026-05-06_
 _Last action: 2026-04-25_
 
 ---

--- a/docs/scheduled-tasks/css-scaling.md
+++ b/docs/scheduled-tasks/css-scaling.md
@@ -3,7 +3,7 @@
 _Audit model: claude-sonnet-4-6_
 _Action model: claude-opus-4-6_
 _Audit cadence: daily_
-_Last audited: 2026-05-04_
+_Last audited: 2026-05-05_
 _Last action: 2026-04-25_
 
 ---
@@ -22,6 +22,8 @@ _Nothing currently in progress._
 
 ## Open
 
+_2026-05-05: New widgets from dev-paul merge audited — BlendingBoard/Widget.tsx and UrlWidget/Widget.tsx both use `cqmin` units throughout; no new scaling violations introduced._
+
 ### LOW EmbedWidget zoom toolbar uses hardcoded sizes — portaled outside container query context
 
 - **Detected:** 2026-04-28
@@ -32,8 +34,8 @@ _Nothing currently in progress._
 ### LOW QuizResults period-filter `<select>` uses hardcoded `text-sm`
 
 - **Detected:** 2026-04-27
-- **File:** components/widgets/QuizWidget/components/QuizResults.tsx:607
-- **Detail:** The period filter `<select>` in the quiz results view uses `text-sm` (hardcoded Tailwind). The QuizWidget has `skipScaling: true`, so this element is inside a CSS container-query context. Introduced by the 2026-04-26 commit `fix(quiz): persist Results export URL on assignment doc (#1419)`.
+- **File:** components/widgets/QuizWidget/components/QuizResults.tsx:968 (line shifted from :607 as of 2026-05-05 merge)
+- **Detail:** The period filter `<select>` in the quiz results view uses `text-sm` (hardcoded Tailwind). The QuizWidget has `skipScaling: true`, so this element is inside a CSS container-query context. Introduced by the 2026-04-26 commit `fix(quiz): persist Results export URL on assignment doc (#1419)`. QuizResults grew significantly in the 2026-05-05 merge (matching/ordering editor addition) — line number has shifted.
 - **Fix:** Replace `text-sm` with an inline style: `style={{ fontSize: 'min(14px, 5.5cqmin)' }}`. The surrounding `px-2 py-1` padding on the same element should also be converted: `style={{ padding: 'min(4px, 1.5cqmin) min(8px, 2.5cqmin)' }}`.
 
 ### LOW RevealGridWidget has additional hardcoded spacing beyond `text-xs` labels

--- a/docs/scheduled-tasks/css-scaling.md
+++ b/docs/scheduled-tasks/css-scaling.md
@@ -3,7 +3,7 @@
 _Audit model: claude-sonnet-4-6_
 _Action model: claude-opus-4-6_
 _Audit cadence: daily_
-_Last audited: 2026-05-04_
+_Last audited: 2026-05-02_
 _Last action: 2026-04-25_
 
 ---

--- a/docs/scheduled-tasks/dependency-audit.md
+++ b/docs/scheduled-tasks/dependency-audit.md
@@ -26,7 +26,7 @@ _Nothing currently in progress._
     The previous upgrade to `1.15.0` (2026-04-14 completed item) patched the three CRITICAL CVEs. These two MODERATE CVEs are distinct advisories with `>=1.15.1` patch requirement. `pnpm outdated` shows latest is `1.16.0`.
 - **Fix:** `pnpm up axios@^1.16.0` in root and `pnpm -C functions up axios@^1.16.0` in functions/. Both advisories are patched in `>=1.15.1`; upgrading to `1.16.0` (latest) addresses both. Verify `pnpm type-check`, `pnpm lint`, and `pnpm test` pass after upgrade.
 
-### MEDIUM `protobufjs` CRITICAL arbitrary code execution via `firebase-functions` path — unresolved
+### HIGH `protobufjs` CRITICAL arbitrary code execution via `firebase-functions` path — unresolved
 
 - **Detected:** 2026-05-05
 - **File:** package.json (via `firebase-functions@7.0.5 > protobufjs`), functions/package.json (same path)

--- a/docs/scheduled-tasks/dependency-audit.md
+++ b/docs/scheduled-tasks/dependency-audit.md
@@ -3,7 +3,7 @@
 _Audit model: claude-sonnet-4-6_
 _Action model: claude-opus-4-6_
 _Audit cadence: weekly — Tuesday_
-_Last audited: 2026-04-28_
+_Last audited: 2026-05-05_
 _Last action: 2026-04-30_
 
 ---
@@ -16,6 +16,23 @@ _Nothing currently in progress._
 
 ## Open
 
+### MEDIUM `axios@1.15.0` still has two MODERATE CVEs — patched in >=1.15.1
+
+- **Detected:** 2026-05-05
+- **File:** package.json (direct devDependency), functions/package.json (direct dependency)
+- **Detail:** Two moderate CVEs appear in `pnpm audit` for both root and functions/ against the current `axios@1.15.0`:
+  - **GHSA-vf2m-468p-8v99** (moderate): HTTP adapter streamed responses bypass `maxContentLength` — allows a malicious server to return a response larger than the configured limit. Patched in `>=1.15.1`.
+  - **GHSA-xx6v-rp6x-q39c** (moderate): XSRF Token Cross-Origin Leakage via Prototype Pollution gadget in `withXSRFToken` Boolean coercion. Patched in `>=1.15.1`.
+    The previous upgrade to `1.15.0` (2026-04-14 completed item) patched the three CRITICAL CVEs. These two MODERATE CVEs are distinct advisories with `>=1.15.1` patch requirement. `pnpm outdated` shows latest is `1.16.0`.
+- **Fix:** `pnpm up axios@^1.16.0` in root and `pnpm -C functions up axios@^1.16.0` in functions/. Both advisories are patched in `>=1.15.1`; upgrading to `1.16.0` (latest) addresses both. Verify `pnpm type-check`, `pnpm lint`, and `pnpm test` pass after upgrade.
+
+### MEDIUM `protobufjs` CRITICAL arbitrary code execution via `firebase-functions` path — unresolved
+
+- **Detected:** 2026-05-05
+- **File:** package.json (via `firebase-functions@7.0.5 > protobufjs`), functions/package.json (same path)
+- **Detail:** `pnpm audit` shows a CRITICAL advisory for `protobufjs <7.5.5` (GHSA-xq3m-2v4x-88gg — arbitrary code execution) with path `.>firebase-functions>protobufjs` in both root and functions/ audits. The 2026-04-30 completed item fixed the `@google/genai > protobufjs` path (now resolved to `protobufjs@7.5.6`), but explicitly noted: "A separate `protobufjs@7.5.4` resolution still exists via `firebase-functions@7.0.5` chain (untouched by this fix)." That secondary CRITICAL path was never followed up with an open item. `pnpm outdated` shows `firebase-functions` at `7.0.5`, latest `7.2.5`. The functions/ package shows `firebase-functions@7.2.3` current, latest `7.2.5`.
+- **Fix:** In root: `pnpm up firebase-functions@^7.2.5`. In functions/: `pnpm -C functions up firebase-functions@^7.2.5`. Verify whether `firebase-functions@7.2.x` upgrades its `protobufjs` transitive dep to `>=7.5.5`. If not, add `"protobufjs": ">=7.5.5"` to `pnpm.overrides` in root `package.json`. Verify `pnpm type-check:all`, `pnpm lint`, `pnpm test`, and `pnpm build:all` pass.
+
 ### MEDIUM `firebase-tools` brings in multiple vulnerable transitive deps
 
 - **Detected:** 2026-04-14
@@ -26,8 +43,8 @@ _Nothing currently in progress._
   - `minimatch` (multiple versions): HIGH ReDoS via repeated wildcards and extglobs
   - `@isaacs/brace-expansion` <=5.0.0: HIGH uncontrolled resource consumption
     All via firebase-tools devDependency chain. These do not affect production runtime.
-    Current: 15.8.0, Latest: 15.15.0 — updating may resolve several transitively.
-- **Fix:** `pnpm up firebase-tools@^15.15.0` in dev dependencies. Check that firebase deploy commands still work after upgrade.
+    Current: 15.8.0, Latest: 15.16.0 — updating may resolve several transitively. (Updated: Latest moved from 15.15.0 → 15.16.0 as of 2026-05-05.)
+- **Fix:** `pnpm up firebase-tools@^15.16.0` in dev dependencies. Check that firebase deploy commands still work after upgrade.
 
 ### MEDIUM `firebase-admin` (root + functions) brings in `fast-xml-parser` and `node-forge` CVEs
 
@@ -76,20 +93,21 @@ _Nothing currently in progress._
 ### LOW Major version updates available — require planned migration
 
 - **Detected:** 2026-04-14
-- **Updated:** 2026-04-28
+- **Updated:** 2026-05-05
 - **File:** package.json
 - **Detail:** Several packages have major version releases available that require migration planning (breaking changes):
-  - `tailwindcss`: 3.4.19 → **4.2.3** (major — config format changed completely)
-  - `vite`: 6.4.2 → **8.x** (2 majors ahead, but focus on patching within v6 first)
-  - `eslint`: 9.39.2 → **10.2.1** (major — verify flat config compatibility)
+  - `tailwindcss`: 3.4.19 → **4.2.4** (major — config format changed completely)
+  - `vite`: 6.4.2 → **8.0.10** (2 majors ahead; focus on patching within v6 first)
+  - `eslint`: 9.39.2 → **10.3.0** (major — verify flat config compatibility)
   - `@eslint/js`: 9.39.2 → **10.0.1** (paired with eslint)
   - `typescript`: 5.9.3 → **6.0.3** (major — strict mode changes)
   - `i18next`: 25.8.13 → **26.0.8** (major — API changes)
-  - `react-i18next`: 16.5.4 → **17.x** (paired with i18next)
-  - `lucide-react`: 0.563.0 → **1.8.0** (first stable major — icon API changes possible)
+  - `react-i18next`: 16.5.4 → **17.0.6** (paired with i18next)
+  - `lucide-react`: 0.563.0 → **1.14.0** (first stable major — icon API changes possible)
   - `@vitejs/plugin-react`: 5.1.2 → **6.0.1** (major)
   - `@types/node`: 24.12.2 → **25.6.0** (major — verify Node 24 compat)
-    Also notable minor updates: `react`/`react-dom` 19.2.4 → 19.2.5, `firebase-tools` 15.8.0 → 15.15.0, `firebase` 12.8.0 → 12.12.1.
+  - `jsdom`: 27.4.0 → **29.1.1** (2 majors ahead — test environment only)
+    Also notable minor updates: `react`/`react-dom` 19.2.4 → 19.2.5, `firebase-tools` 15.8.0 → 15.16.0, `firebase` 12.8.0 → 12.12.1, `firebase-admin` 13.6.0 → 13.8.0.
     These should not be done in a single commit — each needs its own migration PR with testing.
 - **Fix:** Prioritize security patches first. Schedule tailwindcss 4 migration separately (config rewrite required). typescript 6 migration after ensuring all types are clean. Coordinate eslint 9→10 with typescript-eslint team compatibility matrix.
 

--- a/docs/scheduled-tasks/pr-review-log.md
+++ b/docs/scheduled-tasks/pr-review-log.md
@@ -341,3 +341,42 @@ _Automated nightly review by claude-opus-4-6_
   - PR #1485 head SHA `930ba751` — 113 files; CI 14/14 green (Build, Unit Tests, E2E, Code Quality, Firestore Rules, Docker, CodeQL, deploy, Analyze javascript-typescript, Analyze actions, test, lint, type-check, summary)
   - PR #1366 head SHA `da8f0946` — unchanged since 2026-05-01; no new commits in this run
   - Branch-safety: PR #1485 head `dev-paul` matches `dev-*` pattern → no pushes attempted (review-only). The other 2 PRs were eligible for pushes but none required code fixes this run.
+
+## 2026-05-05
+
+- PRs reviewed:
+  - #1502 — Add tests for `getLocalIsoDate` in `localDate.ts` (head `fix/local-date-tests-…`, base `main`, DRAFT)
+  - #1503 — Add comprehensive tests for first5 utilities (head `testing/first5-utils-…`, base `main`, DRAFT)
+  - #1504 — Add comprehensive tests for `isCustomBackground` (head `testing-is-custom-background-…`, base `main`, DRAFT)
+  - #1505 — Add unit tests for `blobToBase64` (head `test-file-encoding-…`, base `main`, DRAFT)
+  - #1506 — Add error path tests for smartPaste URL parsers (head `testing/smart-paste-error-paths-…`, base `main`, DRAFT)
+  - #1507 — audit(scheduled-tasks): Tuesday 2026-05-05 (head `scheduled-tasks`, base `dev-paul`, DRAFT)
+  - #1366 — docs: plan for repo-wide line-ending normalization (head `docs/line-endings-normalization-plan`, base `main`)
+- Comments processed: 5 actionable inline threads — 4 fixed, 1 (#1366 cluster) skipped as already-addressed
+  - PR #1507: 2 gemini-code-assist threads — both fixed in `de81795`
+    - dependency-audit.md line 29 — relabel protobufjs CRITICAL entry from MEDIUM → HIGH to match prior precedent
+    - skill-freshness.md — refresh post-merge line numbers (FeaturePermissionsManager 919–933 → 941–953; FeatureConfigurationPanel 682–694 → 688–700), verified against current source
+  - PR #1502: 1 gemini-code-assist thread — fixed in `40931d8`
+    - utils/localDate.test.ts:2 — `import { getLocalIsoDate } from './localDate'` → `'@/utils/localDate'` per repo style guide
+  - PR #1503: 1 gemini-code-assist thread — fixed in `df33da3`
+    - utils/first5.test.ts — added 8 new boundary tests covering 5:59 vs 6:00 AM rollover, same-day pre-rollover returning `activeDayNumber - 1`, and weekend stick-to-Friday transitions through Monday 6 AM
+  - PR #1366: 6 inline threads — all `is_outdated: true` with prior OPS-PIvers replies; no further action this run
+- Fixes pushed: 3
+  - PR #1507 → `scheduled-tasks` `de81795` — fix(pr-1507): relabel protobufjs to HIGH and refresh post-merge line numbers (markdown only; prettier check passed)
+  - PR #1502 → `fix/local-date-tests-…` `40931d8` — fix(pr-1502): use @/ path alias for internal import (type-check ✓ lint ✓ 6/6 tests pass)
+  - PR #1503 → `testing/first5-utils-…` `df33da3` — fix(pr-1503): expand computeCurrentDayNumber boundary tests (lint ✓ 20/20 tests pass)
+- Reviews posted: 7
+  - PR #1502: Ready — small focused test addition; only DST-boundary case noted as optional follow-up
+  - PR #1503: Ready — 20/20 pass after boundary additions; DST optional follow-up noted
+  - PR #1504: Ready — focused 4-test addition pinning `startsWith` semantics; adequate coverage
+  - PR #1505: Ready — solid coverage including null-error branch; minor convention nit on `tests/utils/` vs co-located placement
+  - PR #1506: Ready with minor notes — new error-path tests are valuable; flagged minor coverage regressions in fixture edits (`/view → /edit` Google Docs branch and Drive `?usp=sharing` stripping no longer covered)
+  - PR #1507: Ready — both gemini comments now fixed; flagged that the new dependency-audit items (axios MEDIUM, protobufjs HIGH via firebase-functions) should be triaged into upgrade PRs before next Tuesday cycle
+  - PR #1366: Ready — seventh review with no content change; all 6 prior threads still addressed
+- Notes:
+  - PR #1507 head SHA `de81795` (was `ac05d3a`) — 1 fix commit added this run; 2 markdown files changed
+  - PR #1502 head SHA `40931d8` (was `8401713`) — 1 fix commit added this run; 1 file changed
+  - PR #1503 head SHA `df33da3` (was `12ce825`) — 1 fix commit added this run; 1 file changed (+59 lines)
+  - PR #1504, #1505, #1506 had no inline review threads at audit time — review-only this run
+  - PR #1366 head SHA `da8f0946` — unchanged since 2026-05-01; no new commits this run
+  - Branch-safety: all 7 PRs had non-`main` / non-`dev-*` head branches → eligible for pushes; pushes only made where comments required a code/doc fix

--- a/docs/scheduled-tasks/pr-review-log.md
+++ b/docs/scheduled-tasks/pr-review-log.md
@@ -380,3 +380,51 @@ _Automated nightly review by claude-opus-4-6_
   - PR #1504, #1505, #1506 had no inline review threads at audit time — review-only this run
   - PR #1366 head SHA `da8f0946` — unchanged since 2026-05-01; no new commits this run
   - Branch-safety: all 7 PRs had non-`main` / non-`dev-*` head branches → eligible for pushes; pushes only made where comments required a code/doc fix
+
+## 2026-05-06
+
+- PRs reviewed: 23 open PRs
+  - #1502 — Add tests for `getLocalIsoDate` (base `dev-paul`)
+  - #1503 — Add tests for first5 utilities (base `dev-paul`)
+  - #1504 — Add tests for `isCustomBackground` (base `dev-paul`)
+  - #1505 — Add tests for `blobToBase64` (base `dev-paul`)
+  - #1506 — Add error path tests for smartPaste URL parsers (base `dev-paul`)
+  - #1507 — audit(scheduled-tasks): Tuesday 2026-05-05 (base `dev-paul`)
+  - #1508 — slugify trailing-dash fix + tests (base `dev-paul`)
+  - #1509 — widgetDragFlag tests (base `dev-paul`)
+  - #1510 — styles utilities tests (base `dev-paul`)
+  - #1511 — DraggableWindow commented-code cleanup (base `dev-paul`)
+  - #1512 — Cloud Functions parallel email lookup (base `dev-paul`)
+  - #1513 — PLC tests + memberUids source-of-truth fix (base `dev-paul`)
+  - #1514 — DraggableWindow commented-code cleanup (base `dev-paul`, non-draft)
+  - #1515 — testClassAccess tests + whitespace orgId fix (base `dev-paul`)
+  - #1516 — backgrounds tests + getCustomBackgroundStyle refactor (base `dev-paul`)
+  - #1517 — PLC tests + memberEmails safety check (base `main`)
+  - #1518 — urlHelpers error path test (base `main`)
+  - #1519 — Cloud Functions concurrent getUsers (base `main`)
+  - #1520 — resolveCategory tests (base `main`)
+  - #1521 — DOMPurify XSS sanitizer replacement (base `main`)
+  - #1522 — DraggableWindow commented-code cleanup (base `main`)
+  - #1523 — DraggableWindow commented-code cleanup (base `main`)
+  - #1366 — docs: line-endings normalization plan (base `main`)
+- Comments processed: 0 actionable — every unresolved thread across all 23 PRs already had author "Fixed in [commit]" replies from prior cycles. No new code fixes required this run.
+- Fixes pushed: 0
+- Reviews posted: 23
+  - PR #1521 DOMPurify: Ready with minor notes — flagged adding back the SVG regression test and a `data:text/html` URI test to lock in the new `ALLOWED_TAGS`/URI behavior
+  - PR #1519 perf (concurrent getUsers): Ready with minor notes — optional concurrency-cap follow-up for very large orgs (Firebase Auth quota: 1000 ops/sec)
+  - PR #1512 perf (parallel email lookup): Ready
+  - PR #1508 slugify: Ready with minor notes — `slugOrFallback` now returns variable lengths (≤24); verify no caller asserts `length === 24`
+  - PR #1517 vs #1513 PLC tests: flagged as overlapping; recommended merging #1513 (stronger `memberUids` source-of-truth fix + caller-email-alias suppression) and closing #1517
+  - PR #1516 backgrounds: Ready
+  - PR #1515 testClassAccess: Ready
+  - PR #1507 audit: Ready — flagged the two new dependency-audit items (axios MEDIUM `>=1.15.1`, firebase-functions `>=7.2.5` to resolve the protobufjs HIGH path) for follow-up upgrade PRs before next Tuesday cycle
+  - PR #1502, #1503, #1504, #1505, #1506, #1509, #1510, #1518, #1520: Ready (focused test additions)
+  - PR #1511, #1514, #1522, #1523: all four delete the same commented-out `MIN_GESTURE_SWIPE_DISTANCE` constant; flagged duplicate; recommended merging one (#1511 preferred — non-draft, base `dev-paul`) and closing the other three
+  - PR #1366: Ready — eighth review with no content change since `da8f0946` (2026-05-01); all 6 prior threads addressed
+- Notes:
+  - Every open PR's unresolved review threads were already addressed by author "Fixed in [commit]" replies in prior runs (many marked `is_outdated:true` on GitHub but not `is_resolved:true`). No code/doc fixes pushed this run.
+  - Coordination call-outs raised in reviews:
+    - #1511 / #1514 / #1522 / #1523 — duplicate DraggableWindow cleanup PRs; merge one, close three
+    - #1513 / #1517 — overlapping PLC tests; recommend #1513
+    - #1504 / #1516 — overlapping `isCustomBackground` test additions on `dev-paul`; coordinate to avoid test-file conflicts
+  - Branch-safety: PR #1507 head `scheduled-tasks` is the current branch (review-only). All other open PRs have non-`main` / non-`dev-*` head branches; no pushes were required this run.

--- a/docs/scheduled-tasks/skill-freshness.md
+++ b/docs/scheduled-tasks/skill-freshness.md
@@ -3,7 +3,7 @@
 _Audit model: claude-sonnet-4-6_
 _Action model: claude-opus-4-6_
 _Audit cadence: weekly — Tuesday_
-_Last audited: 2026-04-28_
+_Last audited: 2026-05-05_
 _Last action: never_
 
 ---
@@ -15,6 +15,8 @@ _Nothing currently in progress._
 ---
 
 ## Open
+
+_2026-05-05: Skill files not accessible at `/mnt/skills/user/` in this audit environment. Codebase-side verifications performed: `SpecialistSchedule/SpecialistScheduleWidget.tsx` still exists (Widget.tsx does not); `FeaturePermissionsManager.tsx` exclusion list still omits the 7 types noted in the LOW item below; `FeatureConfigurationPanel.tsx` secondary exclusion gate still undocumented in skill. `blending-board` was added to `BUILDING_CONFIG_PANELS` in `FeatureConfigurationPanel.tsx` this week — the exclusion-list LOW item is now more stale. All four open items remain valid._
 
 ### MEDIUM `spart-new-widget` references non-existent `SpecialistSchedule/Widget.tsx`
 

--- a/docs/scheduled-tasks/skill-freshness.md
+++ b/docs/scheduled-tasks/skill-freshness.md
@@ -40,14 +40,14 @@ _2026-05-05: Skill files not accessible at `/mnt/skills/user/` in this audit env
   ```
   !['instructionalRoutines', 'stickers', 'calendar', 'specialist-schedule', 'miniApp', 'starter-pack', 'your-widget-type']
   ```
-  The actual array in `components/admin/FeaturePermissionsManager.tsx` (lines 919–933) is significantly longer and includes 7 additional types added since the skill was written: `blooms-taxonomy`, `catalyst`, `graphic-organizer`, `music`, `pdf`, `video-activity`, `work-symbols`. A developer following the example literally would insert their widget type into an outdated list and potentially misunderstand the full scope of widgets with dedicated config modals.
+  The actual array in `components/admin/FeaturePermissionsManager.tsx` (lines 941–953) is significantly longer and includes 7 additional types added since the skill was written: `blooms-taxonomy`, `catalyst`, `graphic-organizer`, `music`, `pdf`, `video-activity`, `work-symbols`. A developer following the example literally would insert their widget type into an outdated list and potentially misunderstand the full scope of widgets with dedicated config modals.
 - **Fix:** Update the skill's code example to match the current exclusion array, or replace the hardcoded list in the example with a comment like `// ...existing widget types with dedicated modals...` so the example is not tied to a specific snapshot.
 
 ### LOW `spart-widget-admin-config` does not document hardcoded exclusion list in `FeatureConfigurationPanel.tsx`
 
 - **Detected:** 2026-04-14
 - **File:** `.claude/skills/admin-widget-config/SKILL.md` — Path B description
-- **Detail:** `components/admin/FeatureConfigurationPanel.tsx` (lines 682–694) contains a hardcoded widget-type exclusion list: `['calendar', 'expectations', 'guided-learning', 'instructionalRoutines', 'miniApp', 'quiz', 'stickers', 'talking-tool', 'weather', 'webcam', ...Object.keys(BUILDING_CONFIG_PANELS)]`. These widgets show custom panels or full-screen modals within `GenericConfigurationModal`. The skill describes Path B but does not mention this secondary exclusion gate. For most new widgets the `BUILDING_CONFIG_PANELS` registration handles exclusion automatically, but if a developer needs to know why certain widgets disappear from the generic modal, this list is the missing context.
+- **Detail:** `components/admin/FeatureConfigurationPanel.tsx` (lines 688–700) contains a hardcoded widget-type exclusion list: `['calendar', 'expectations', 'guided-learning', 'instructionalRoutines', 'miniApp', 'quiz', 'stickers', 'talking-tool', 'weather', 'webcam', ...Object.keys(BUILDING_CONFIG_PANELS)]`. These widgets show custom panels or full-screen modals within `GenericConfigurationModal`. The skill describes Path B but does not mention this secondary exclusion gate. For most new widgets the `BUILDING_CONFIG_PANELS` registration handles exclusion automatically, but if a developer needs to know why certain widgets disappear from the generic modal, this list is the missing context.
 - **Fix:** Add a note in the skill's Path B section explaining this secondary exclusion list and its purpose.
 
 ---

--- a/docs/scheduled-tasks/typescript-eslint.md
+++ b/docs/scheduled-tasks/typescript-eslint.md
@@ -3,7 +3,7 @@
 _Audit model: claude-sonnet-4-6_
 _Action model: claude-opus-4-6_
 _Audit cadence: daily_
-_Last audited: 2026-05-04_
+_Last audited: 2026-05-02_
 _Last action: never_
 
 ---
@@ -16,7 +16,7 @@ _Nothing currently in progress._
 
 ## Open
 
-_No open items. Both `pnpm type-check` and `pnpm lint` pass cleanly as of 2026-05-04. TypeScript: 0 errors. ESLint: 0 errors, 0 warnings (`--max-warnings 0`). Test suite: 185 files / 1771 tests all passing._
+_No open items. Both `pnpm type-check` and `pnpm lint` pass cleanly as of 2026-05-02. TypeScript: 0 errors. ESLint: 0 errors, 0 warnings (`--max-warnings 0`)._
 
 ---
 

--- a/docs/scheduled-tasks/typescript-eslint.md
+++ b/docs/scheduled-tasks/typescript-eslint.md
@@ -3,7 +3,7 @@
 _Audit model: claude-sonnet-4-6_
 _Action model: claude-opus-4-6_
 _Audit cadence: daily_
-_Last audited: 2026-05-05_
+_Last audited: 2026-05-06_
 _Last action: never_
 
 ---
@@ -16,7 +16,7 @@ _Nothing currently in progress._
 
 ## Open
 
-_No open items. Both `pnpm type-check` and `pnpm lint` pass cleanly as of 2026-05-05. TypeScript: 0 errors. ESLint: 0 errors, 0 warnings (`--max-warnings 0`). Codebase absorbed the dev-paul merge (BlendingBoard widget, MatchingResponseInput, OrderingResponseInput, useResetOnChange, UrlWidget refactor — 48 files changed) without introducing any type errors or lint violations._
+_No open items. Both `pnpm type-check` and `pnpm lint` pass cleanly as of 2026-05-06. TypeScript: 0 errors. ESLint: 0 errors, 0 warnings (`--max-warnings 0`). Codebase absorbed the dev-paul merge (feat/announcements date-bounded activation, TimeTool ±time buttons, URL widget overhaul, structured matching/ordering quiz editor — multiple commits) without introducing any type errors or lint violations._
 
 ---
 

--- a/docs/scheduled-tasks/typescript-eslint.md
+++ b/docs/scheduled-tasks/typescript-eslint.md
@@ -3,7 +3,7 @@
 _Audit model: claude-sonnet-4-6_
 _Action model: claude-opus-4-6_
 _Audit cadence: daily_
-_Last audited: 2026-05-04_
+_Last audited: 2026-05-05_
 _Last action: never_
 
 ---
@@ -16,7 +16,7 @@ _Nothing currently in progress._
 
 ## Open
 
-_No open items. Both `pnpm type-check` and `pnpm lint` pass cleanly as of 2026-05-04. TypeScript: 0 errors. ESLint: 0 errors, 0 warnings (`--max-warnings 0`). Test suite: 185 files / 1771 tests all passing._
+_No open items. Both `pnpm type-check` and `pnpm lint` pass cleanly as of 2026-05-05. TypeScript: 0 errors. ESLint: 0 errors, 0 warnings (`--max-warnings 0`). Codebase absorbed the dev-paul merge (BlendingBoard widget, MatchingResponseInput, OrderingResponseInput, useResetOnChange, UrlWidget refactor — 48 files changed) without introducing any type errors or lint violations._
 
 ---
 

--- a/docs/scheduled-tasks/typescript-eslint.md
+++ b/docs/scheduled-tasks/typescript-eslint.md
@@ -3,7 +3,7 @@
 _Audit model: claude-sonnet-4-6_
 _Action model: claude-opus-4-6_
 _Audit cadence: daily_
-_Last audited: 2026-05-03_
+_Last audited: 2026-05-04_
 _Last action: never_
 
 ---
@@ -16,7 +16,7 @@ _Nothing currently in progress._
 
 ## Open
 
-_No open items. Both `pnpm type-check` and `pnpm lint` pass cleanly as of 2026-05-03. TypeScript: 0 errors. ESLint: 0 errors, 0 warnings (`--max-warnings 0`)._
+_No open items. Both `pnpm type-check` and `pnpm lint` pass cleanly as of 2026-05-04. TypeScript: 0 errors. ESLint: 0 errors, 0 warnings (`--max-warnings 0`). Test suite: 185 files / 1771 tests all passing._
 
 ---
 

--- a/docs/scheduled-tasks/typescript-eslint.md
+++ b/docs/scheduled-tasks/typescript-eslint.md
@@ -3,7 +3,7 @@
 _Audit model: claude-sonnet-4-6_
 _Action model: claude-opus-4-6_
 _Audit cadence: daily_
-_Last audited: 2026-05-02_
+_Last audited: 2026-05-03_
 _Last action: never_
 
 ---
@@ -16,7 +16,7 @@ _Nothing currently in progress._
 
 ## Open
 
-_No open items. Both `pnpm type-check` and `pnpm lint` pass cleanly as of 2026-05-02. TypeScript: 0 errors. ESLint: 0 errors, 0 warnings (`--max-warnings 0`)._
+_No open items. Both `pnpm type-check` and `pnpm lint` pass cleanly as of 2026-05-03. TypeScript: 0 errors. ESLint: 0 errors, 0 warnings (`--max-warnings 0`)._
 
 ---
 

--- a/docs/scheduled-tasks/ui-unification.md
+++ b/docs/scheduled-tasks/ui-unification.md
@@ -3,7 +3,7 @@
 _Audit model: claude-sonnet-4-6_
 _Action model: claude-opus-4-6_
 _Audit cadence: weekly — Wednesday_
-_Last audited: 2026-04-29_
+_Last audited: 2026-05-06_
 _Last action: never_
 
 ---
@@ -57,6 +57,13 @@ _Nothing currently in progress._
 - **File:** components/admin/FeatureConfigurationPanel.tsx
 - **Detail:** The file is the largest admin config panel at 706 lines and contains per-widget building-default forms inline. Many fields it renders (string inputs, number inputs, color pickers, selects, booleans) follow the same pattern that `SchemaDrivenConfigurationPanel` was designed to handle. Only `MagicConfigurationPanel.tsx` and `RecordConfigurationPanel.tsx` currently use `SchemaDrivenConfigurationPanel`. The 18 remaining config panels that don't use it include `FeatureConfigurationPanel`, `SoundboardConfigurationPanel` (593 lines), `ScheduleConfigurationPanel` (538 lines), and `MaterialsConfigurationPanel` (523 lines).
 - **Fix:** Audit `FeatureConfigurationPanel` for schema-driven extraction candidates. For panels whose entire form can be expressed as a field schema (input type + label + key + validation), migrate to `SchemaDrivenConfigurationPanel`. Panels with complex custom UIs (materials catalog, seating-chart layout, specialist schedule) should remain manual. Start with the simplest panels (DiceConfigurationPanel, TrafficLightConfigurationPanel, DrawingConfigurationPanel) as proof-of-concept before tackling the large ones.
+
+### LOW `InstructionalRoutinesWidget` uses hardcoded brand blue hex for numbered step badge
+
+- **Detected:** 2026-05-06
+- **File:** components/widgets/InstructionalRoutines/Widget.tsx:217
+- **Detail:** The numbered step badge on list/step-view routines uses `style={{ backgroundColor: '#2d3f89' }}`. `--spart-primary` is set by the admin's global style configuration in `DashboardView.tsx` specifically so that widget chrome can use `var(--spart-primary)` instead of hardcoded brand blue. Using a hardcoded hex means this badge will not update when the admin changes the primary color.
+- **Fix:** Replace `backgroundColor: '#2d3f89'` with `backgroundColor: 'var(--spart-primary, #2d3f89)'` to respect the theme while keeping the brand blue as the fallback.
 
 ### LOW `TextConfig` has `fontFamily`, `fontColor`, `textSizePreset` but no appearance panel or settings UI
 

--- a/docs/scheduled-tasks/widget-registry.md
+++ b/docs/scheduled-tasks/widget-registry.md
@@ -3,7 +3,7 @@
 _Audit model: claude-sonnet-4-6_
 _Action model: claude-opus-4-6_
 _Audit cadence: daily_
-_Last audited: 2026-05-02_
+_Last audited: 2026-05-03_
 _Last action: 2026-05-02_
 
 ---

--- a/docs/scheduled-tasks/widget-registry.md
+++ b/docs/scheduled-tasks/widget-registry.md
@@ -3,7 +3,7 @@
 _Audit model: claude-sonnet-4-6_
 _Action model: claude-opus-4-6_
 _Audit cadence: daily_
-_Last audited: 2026-05-05_
+_Last audited: 2026-05-06_
 _Last action: 2026-05-02_
 
 ---
@@ -15,6 +15,8 @@ _Nothing currently in progress._
 ---
 
 ## Open
+
+_2026-05-06: All WidgetType values verified against WIDGET_COMPONENTS, WIDGET_SETTINGS_COMPONENTS, WIDGET_SCALING_CONFIG, widgetDefaults.ts, tools.ts, and widgetGradeLevels.ts. No new gaps found. TimeTool ±button additions, URL widget overhaul, and BlendingBoard expansion all correctly registered. `stations`, `need-do-put-then`, `blooms-detail`, `blooms-taxonomy` — all confirmed._
 
 _2026-05-05: `blending-board` (added in dev-paul merge) verified fully registered in all locations; export names match source files. No new registry gaps from the merge._
 

--- a/docs/scheduled-tasks/widget-registry.md
+++ b/docs/scheduled-tasks/widget-registry.md
@@ -4,7 +4,7 @@ _Audit model: claude-sonnet-4-6_
 _Action model: claude-opus-4-6_
 _Audit cadence: daily_
 _Last audited: 2026-05-02_
-_Last action: 2026-04-26_
+_Last action: 2026-05-02_
 
 ---
 

--- a/docs/scheduled-tasks/widget-registry.md
+++ b/docs/scheduled-tasks/widget-registry.md
@@ -3,7 +3,7 @@
 _Audit model: claude-sonnet-4-6_
 _Action model: claude-opus-4-6_
 _Audit cadence: daily_
-_Last audited: 2026-05-04_
+_Last audited: 2026-05-05_
 _Last action: 2026-05-02_
 
 ---
@@ -15,6 +15,8 @@ _Nothing currently in progress._
 ---
 
 ## Open
+
+_2026-05-05: `blending-board` (added in dev-paul merge) verified fully registered in all locations; export names match source files. No new registry gaps from the merge._
 
 ### LOW `stickers` missing from `WIDGET_SETTINGS_COMPONENTS`
 

--- a/docs/scheduled-tasks/widget-registry.md
+++ b/docs/scheduled-tasks/widget-registry.md
@@ -3,7 +3,7 @@
 _Audit model: claude-sonnet-4-6_
 _Action model: claude-opus-4-6_
 _Audit cadence: daily_
-_Last audited: 2026-05-03_
+_Last audited: 2026-05-04_
 _Last action: 2026-05-02_
 
 ---

--- a/docs/scheduled-tasks/widget-registry.md
+++ b/docs/scheduled-tasks/widget-registry.md
@@ -3,8 +3,8 @@
 _Audit model: claude-sonnet-4-6_
 _Action model: claude-opus-4-6_
 _Audit cadence: daily_
-_Last audited: 2026-05-04_
-_Last action: 2026-05-02_
+_Last audited: 2026-05-02_
+_Last action: 2026-04-26_
 
 ---
 

--- a/hooks/useClickOutside.ts
+++ b/hooks/useClickOutside.ts
@@ -3,10 +3,9 @@ import { useEffect, useLayoutEffect, useRef, RefObject } from 'react';
 type Handler = (event: MouseEvent | TouchEvent) => void;
 
 // Module-level constant so callers that omit `ignoreRefs` get the SAME
-// empty-array reference every render. A `[]` literal default would create
-// a fresh array each call, which — combined with `ignoreRefs` being in the
-// effect dep list — tears down and re-adds the document listeners on every
-// render of the consuming component.
+// empty-array reference every render — kept as a defensive default even
+// though the listener now reads `ignoreRefs` via a ref rather than from
+// the effect deps.
 const EMPTY_REFS: ReadonlyArray<RefObject<HTMLElement | null>> = [];
 
 export const useClickOutside = <T extends HTMLElement = HTMLElement>(

--- a/hooks/useClickOutside.ts
+++ b/hooks/useClickOutside.ts
@@ -3,9 +3,10 @@ import { useEffect, useLayoutEffect, useRef, RefObject } from 'react';
 type Handler = (event: MouseEvent | TouchEvent) => void;
 
 // Module-level constant so callers that omit `ignoreRefs` get the SAME
-// empty-array reference every render — kept as a defensive default even
-// though the listener now reads `ignoreRefs` via a ref rather than from
-// the effect deps.
+// empty-array reference every render. A `[]` literal default would create
+// a fresh array each call, which — combined with `ignoreRefs` being in the
+// effect dep list — tears down and re-adds the document listeners on every
+// render of the consuming component.
 const EMPTY_REFS: ReadonlyArray<RefObject<HTMLElement | null>> = [];
 
 export const useClickOutside = <T extends HTMLElement = HTMLElement>(


### PR DESCRIPTION
## Summary

Automated audit run for Tuesday 2026-05-05. Merged latest `dev-paul` branch (BlendingBoard widget, MatchingResponseInput/OrderingResponseInput, UrlWidget refactor, useResetOnChange hook — 48 files), then ran all daily audits and Tuesday's weekly audits.

**Daily audits — all clean:**
- **Widget Registry:** `blending-board` fully registered in all 7 locations; export names verified. No new gaps.
- **CSS Scaling:** No new violations in the merged widgets (BlendingBoard and UrlWidget both use `cqmin` correctly). QuizResults issue line shifted to :968 due to file growth.
- **TypeScript & ESLint:** 0 type errors, 0 lint errors/warnings after absorbing the large dev-paul merge.

**Tuesday weekly audits — 2 new issues:**

- **Skill Freshness (B1):** Skill files not accessible at `/mnt/skills/user/` in this environment. Codebase-side checks confirm all 4 open items remain valid. `blending-board` added to `BUILDING_CONFIG_PANELS` makes the exclusion-list LOW item more stale.

- **Dependency Audit (B2) — 2 new MEDIUM items:**
  1. `axios@1.15.0` has 2 moderate CVEs (GHSA-vf2m-468p-8v99 maxContentLength bypass, GHSA-xx6v-rp6x-q39c XSRF token leakage) — patched in `>=1.15.1`. Fix: `pnpm up axios@^1.16.0` in root and functions/.
  2. `protobufjs` CRITICAL (GHSA-xq3m-2v4x-88gg) via `firebase-functions@7.0.5` path — this was acknowledged in the 2026-04-30 completion note but never opened as a separate tracking item. Fix: upgrade `firebase-functions` to `^7.2.5` in both root and functions/, or add `protobufjs: ">=7.5.5"` override.

  Also updated: firebase-tools latest now 15.16.0, vite latest 8.0.10, lucide-react latest 1.14.0, added jsdom 2-major-version gap.

## Test plan

- [ ] Review 2 new dependency audit MEDIUM items in `docs/scheduled-tasks/dependency-audit.md`
- [ ] Action team to upgrade `axios` to `^1.16.0` in root + functions
- [ ] Action team to upgrade `firebase-functions` to `^7.2.5` or add protobufjs override

https://claude.ai/code/session_0153cBEwY99otwRnsVBCNpTU

---
_Generated by [Claude Code](https://claude.ai/code/session_0153cBEwY99otwRnsVBCNpTU)_