### PR TITLE
🧪 test: add error path test for invalid URL parse in urlHelpers.ts

### DIFF
--- a/utils/urlHelpers.test.ts
+++ b/utils/urlHelpers.test.ts
@@ -249,5 +249,9 @@ describe('urlHelpers', () => {
       const url = 'https://example.com';
       expect(convertToEmbedUrl(url)).toBe(url);
     });
+    it('returns original URL if URL parsing fails for Google Docs-like strings', () => {
+      const invalidUrl = 'https://docs.google.com:999999/%%';
+      expect(convertToEmbedUrl(invalidUrl)).toBe(invalidUrl);
+    });
   });
 });


### PR DESCRIPTION
### 🎯 What: The testing gap addressed
Missing test coverage for the error-handling catch block in `convertToEmbedUrl` when processing malformed Google Docs-like URLs.

### 📊 Coverage: What scenarios are now tested
A new test case was added to `utils/urlHelpers.test.ts` that passes a malformed URL with an invalid port (e.g., `https://docs.google.com:999999/%%`) to `convertToEmbedUrl`.

### ✨ Result: The improvement in test coverage
The `catch` block in `utils/urlHelpers.ts` is now explicitly exercised, ensuring that the function robustly falls back to returning the original trimmed URL when `new URL()` fails, rather than crashing.

---
*PR created automatically by Jules for task [12176278758115479385](https://jules.google.com/task/12176278758115479385) started by @OPS-PIvers*