### PR TITLE
🧪 Add tests for resolveCategory in backgroundCategories.ts

### DIFF
--- a/utils/backgroundCategories.test.ts
+++ b/utils/backgroundCategories.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from 'vitest';
+import { resolveCategory } from './backgroundCategories';
+
+describe('backgroundCategories', () => {
+  describe('resolveCategory', () => {
+    describe('admin override', () => {
+      it('returns canonical category when adminCategory matches exactly', () => {
+        expect(resolveCategory('Any Label', 'Nature')).toBe('Nature');
+      });
+
+      it('normalises casing when adminCategory matches a known category case-insensitively', () => {
+        expect(resolveCategory('Any Label', 'nature')).toBe('Nature');
+        expect(resolveCategory('Any Label', 'SPACE')).toBe('Space');
+      });
+
+      it('trims whitespace from adminCategory', () => {
+        expect(resolveCategory('Any Label', '  Nature  ')).toBe('Nature');
+      });
+
+      it('returns adminCategory as-is if it is not a known category', () => {
+        expect(resolveCategory('Any Label', 'Custom Category')).toBe(
+          'Custom Category'
+        );
+      });
+    });
+
+    describe('keyword matching', () => {
+      it('matches Classroom keywords', () => {
+        expect(resolveCategory('chalkboard background')).toBe('Classroom');
+        expect(resolveCategory('school room')).toBe('Classroom');
+        expect(resolveCategory('blackboard style')).toBe('Classroom');
+      });
+
+      it('matches Landmarks keywords', () => {
+        expect(resolveCategory('the eiffel tower')).toBe('Landmarks');
+        expect(resolveCategory('pyramid of giza')).toBe('Landmarks');
+        expect(resolveCategory('machu picchu')).toBe('Landmarks');
+        expect(resolveCategory('chichén itzá')).toBe('Landmarks');
+        expect(resolveCategory('chichen itza')).toBe('Landmarks');
+      });
+
+      it('matches Nature keywords', () => {
+        expect(resolveCategory('beautiful forest')).toBe('Nature');
+        expect(resolveCategory('sunny beach')).toBe('Nature');
+        expect(resolveCategory('mountain range')).toBe('Nature');
+      });
+
+      it('matches Space keywords', () => {
+        expect(resolveCategory('deep space')).toBe('Space');
+        expect(resolveCategory('galaxy nebula')).toBe('Space');
+        expect(resolveCategory('planet earth')).toBe('Space');
+      });
+
+      it('matches Abstract keywords', () => {
+        expect(resolveCategory('abstract pattern')).toBe('Abstract');
+        expect(resolveCategory('geometric shapes')).toBe('Abstract');
+        expect(resolveCategory('minimal texture')).toBe('Abstract');
+      });
+
+      it('matches Seasonal keywords', () => {
+        expect(resolveCategory('winter snow')).toBe('Seasonal');
+        expect(resolveCategory('autumn leaves')).toBe('Seasonal');
+        expect(resolveCategory('christmas tree')).toBe('Seasonal');
+      });
+
+      it('is case-insensitive for keywords', () => {
+        expect(resolveCategory('FOREST')).toBe('Nature');
+        expect(resolveCategory('Eiffel')).toBe('Landmarks');
+      });
+    });
+
+    describe('fallback', () => {
+      it('returns "General" if no keywords match and no admin override is provided', () => {
+        expect(resolveCategory('some random label')).toBe('General');
+      });
+
+      it('returns "General" for empty label', () => {
+        expect(resolveCategory('')).toBe('General');
+      });
+    });
+  });
+});

--- a/utils/backgroundCategories.test.ts
+++ b/utils/backgroundCategories.test.ts
@@ -13,14 +13,22 @@ describe('backgroundCategories', () => {
         expect(resolveCategory('Any Label', 'SPACE')).toBe('Space');
       });
 
-      it('trims whitespace from adminCategory', () => {
+      it('trims whitespace from adminCategory and trims custom categories', () => {
         expect(resolveCategory('Any Label', '  Nature  ')).toBe('Nature');
+        expect(resolveCategory('Any Label', '  Custom Category  ')).toBe(
+          'Custom Category'
+        );
       });
 
       it('returns adminCategory as-is if it is not a known category', () => {
         expect(resolveCategory('Any Label', 'Custom Category')).toBe(
           'Custom Category'
         );
+      });
+
+      it('falls back to keyword matching when adminCategory is empty or whitespace', () => {
+        expect(resolveCategory('beautiful forest', '')).toBe('Nature');
+        expect(resolveCategory('beautiful forest', '   ')).toBe('Nature');
       });
     });
 
@@ -67,6 +75,13 @@ describe('backgroundCategories', () => {
         expect(resolveCategory('FOREST')).toBe('Nature');
         expect(resolveCategory('Eiffel')).toBe('Landmarks');
       });
+
+      it('respects category priority when multiple keywords match', () => {
+        // Classroom (higher priority) vs Space (lower priority)
+        expect(resolveCategory('classroom in space')).toBe('Classroom');
+        // Nature (higher priority) vs Seasonal (lower priority)
+        expect(resolveCategory('winter forest')).toBe('Nature');
+      });
     });
 
     describe('fallback', () => {
@@ -74,8 +89,9 @@ describe('backgroundCategories', () => {
         expect(resolveCategory('some random label')).toBe('General');
       });
 
-      it('returns "General" for empty label', () => {
+      it('returns "General" for empty or whitespace-only label', () => {
         expect(resolveCategory('')).toBe('General');
+        expect(resolveCategory('   ')).toBe('General');
       });
     });
   });


### PR DESCRIPTION
🎯 **What:** The testing gap addressed: Missing tests for the \`resolveCategory\` function in \`utils/backgroundCategories.ts\`.
📊 **Coverage:** What scenarios are now tested:
- Admin overrides (exact match, normalization, unknown categories, whitespace trimming).
- Keyword matching for all categories (Classroom, Landmarks, Nature, Space, Abstract, Seasonal).
- Case-insensitivity for keyword matching.
- "General" fallback for unmatched labels and empty inputs.
✨ **Result:** The improvement in test coverage: Increased reliability and coverage for background category resolution logic.

---
*PR created automatically by Jules for task [13027691926138345191](https://jules.google.com/task/13027691926138345191) started by @OPS-PIvers*