### PR TITLE
feat(announcements): date-bounded activation window + YouTube start-at

### DIFF
--- a/components/admin/Announcements/EmbedConfigEditor.tsx
+++ b/components/admin/Announcements/EmbedConfigEditor.tsx
@@ -15,6 +15,7 @@ import { useDashboard } from '@/context/useDashboard';
 import { useGoogleDrive } from '@/hooks/useGoogleDrive';
 import { useScreenRecord } from '@/hooks/useScreenRecord';
 import { convertToEmbedUrl } from '@/utils/urlHelpers';
+import { extractYouTubeId } from '@/utils/youtube';
 import { EmbedTab } from './types';
 
 import { EmbedConfig } from '@/types';
@@ -56,11 +57,47 @@ export const EmbedConfigEditor: React.FC<{
   const embedUrl = convertToEmbedUrl(rawUrl);
   const wasConverted = rawUrl.trim() !== '' && embedUrl !== rawUrl.trim();
   const isDriveUrl = /drive\.google\.com/i.test(rawUrl);
+  const isYouTubeUrl = extractYouTubeId(rawUrl) !== null;
+
+  const startAtSeconds =
+    typeof config.startAtSeconds === 'number' && config.startAtSeconds > 0
+      ? config.startAtSeconds
+      : 0;
+  const startAtMinutes = Math.floor(startAtSeconds / 60);
+  const startAtSecsRemainder = startAtSeconds % 60;
+
+  const updateStartAt = (totalSeconds: number) => {
+    const next: Partial<EmbedConfig> = { ...config };
+    if (totalSeconds > 0) {
+      next.startAtSeconds = totalSeconds;
+    } else {
+      delete next.startAtSeconds;
+    }
+    onChange(next);
+  };
+
+  const handleStartAtMinutesChange = (raw: string) => {
+    const parsed = Number.parseInt(raw, 10);
+    const minutes = Number.isFinite(parsed) && parsed > 0 ? parsed : 0;
+    updateStartAt(minutes * 60 + startAtSecsRemainder);
+  };
+
+  const handleStartAtSecondsChange = (raw: string) => {
+    const parsed = Number.parseInt(raw, 10);
+    let seconds = Number.isFinite(parsed) && parsed > 0 ? parsed : 0;
+    if (seconds > 59) seconds = 59;
+    updateStartAt(startAtMinutes * 60 + seconds);
+  };
 
   const applyUrl = () => {
     const finalUrl = embedUrl || rawUrl.trim();
     if (finalUrl !== config.url) {
-      onChange({ ...config, url: finalUrl });
+      const next: Partial<EmbedConfig> = { ...config, url: finalUrl };
+      // Drop startAtSeconds if the new URL isn't YouTube — only YouTube honors it.
+      if (extractYouTubeId(finalUrl) === null) {
+        delete next.startAtSeconds;
+      }
+      onChange(next);
     }
   };
 
@@ -139,12 +176,20 @@ export const EmbedConfigEditor: React.FC<{
 
     if (finalUrl !== config.url) {
       newConfig.url = finalUrl;
+      if (extractYouTubeId(finalUrl) === null) {
+        delete newConfig.startAtSeconds;
+      }
     }
 
     if (tab === 'url' || tab === 'code') {
       newConfig.mode = tab;
     } else if (tab === 'live' && config.mode !== 'url') {
       newConfig.mode = 'url';
+    }
+
+    // Start-at only applies to URL-tab YouTube embeds.
+    if (tab !== 'url') {
+      delete newConfig.startAtSeconds;
     }
 
     onChange(newConfig);
@@ -227,6 +272,40 @@ export const EmbedConfigEditor: React.FC<{
                 <strong>&quot;Anyone with the link can view&quot;</strong>.
                 Otherwise teachers may see a blank loader due to browser
                 third-party cookie restrictions.
+              </p>
+            </div>
+          )}
+          {isYouTubeUrl && (
+            <div className="space-y-1.5 pt-1">
+              <label className="block text-xs font-semibold text-slate-700">
+                Start at
+              </label>
+              <div className="flex items-center gap-2">
+                <input
+                  type="number"
+                  min={0}
+                  value={startAtMinutes === 0 ? '' : startAtMinutes}
+                  onChange={(e) => handleStartAtMinutesChange(e.target.value)}
+                  placeholder="0"
+                  aria-label="Start at minutes"
+                  className="w-16 px-2 py-1.5 text-sm border border-slate-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-brand-blue-primary"
+                />
+                <span className="text-xs text-slate-500">min</span>
+                <input
+                  type="number"
+                  min={0}
+                  max={59}
+                  value={startAtSecsRemainder === 0 ? '' : startAtSecsRemainder}
+                  onChange={(e) => handleStartAtSecondsChange(e.target.value)}
+                  placeholder="0"
+                  aria-label="Start at seconds"
+                  className="w-16 px-2 py-1.5 text-sm border border-slate-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-brand-blue-primary"
+                />
+                <span className="text-xs text-slate-500">sec</span>
+              </div>
+              <p className="text-xs text-slate-500">
+                The video will begin at this offset. Only YouTube videos support
+                a start time — Drive videos will ignore it.
               </p>
             </div>
           )}

--- a/components/admin/Announcements/Widget.tsx
+++ b/components/admin/Announcements/Widget.tsx
@@ -40,6 +40,7 @@ import { WIDGET_DEFAULTS } from '@/config/widgetDefaults';
 import { Toggle } from '@/components/common/Toggle';
 import { TOOLS } from '@/config/tools';
 import { WIDGET_COMPONENTS } from '@/components/widgets/WidgetRegistry';
+import { getLocalIsoDate } from '@/utils/localDate';
 import { AnnouncementFormData } from './types';
 import { TextConfigEditor } from './TextConfigEditor';
 import { EmbedConfigEditor } from './EmbedConfigEditor';
@@ -130,7 +131,11 @@ function buildDefaultForm(): AnnouncementFormData {
     widgetSize: getDefaultSize('text'),
     maximized: false,
     activationType: 'manual',
+    scheduledActivationDate: getLocalIsoDate(),
     scheduledActivationTime: '08:00',
+    autoDeactivateEnabled: false,
+    scheduledEndDate: getLocalIsoDate(),
+    scheduledEndTime: '15:00',
     dismissalType: 'user',
     scheduledDismissalTime: '15:00',
     dismissalDurationSeconds: 60,
@@ -138,6 +143,68 @@ function buildDefaultForm(): AnnouncementFormData {
     targetBuildings: [],
     targetUsers: [],
   };
+}
+
+/**
+ * Combine a YYYY-MM-DD date and HH:MM time into a millisecond timestamp using
+ * local-time semantics. Returns null when either piece is missing or malformed.
+ *
+ * Wall-clock interpretation matches the admin's intent across timezones —
+ * "May 5, 8:00 AM" means 8:00 AM in the school's local time, not UTC.
+ */
+function combineDateAndTime(
+  date: string | undefined,
+  time: string | undefined
+): number | null {
+  if (!date || !time) return null;
+  const dateMatch = /^(\d{4})-(\d{2})-(\d{2})$/.exec(date);
+  const timeMatch = /^(\d{1,2}):(\d{2})$/.exec(time);
+  if (!dateMatch || !timeMatch) return null;
+  const y = Number(dateMatch[1]);
+  const mo = Number(dateMatch[2]);
+  const d = Number(dateMatch[3]);
+  const h = Number(timeMatch[1]);
+  const mi = Number(timeMatch[2]);
+  if (
+    !Number.isFinite(y) ||
+    !Number.isFinite(mo) ||
+    !Number.isFinite(d) ||
+    !Number.isFinite(h) ||
+    !Number.isFinite(mi)
+  )
+    return null;
+  const ms = new Date(y, mo - 1, d, h, mi, 0, 0).getTime();
+  return Number.isFinite(ms) ? ms : null;
+}
+
+type AnnouncementLiveStatus = 'inactive' | 'scheduled' | 'active' | 'expired';
+
+/**
+ * Derive a live status for an announcement at the given moment, accounting
+ * for the master `isActive` flag plus the optional scheduled start/end window.
+ */
+function getAnnouncementLiveStatus(
+  a: Announcement,
+  nowMs: number
+): AnnouncementLiveStatus {
+  if (!a.isActive) return 'inactive';
+
+  const endMs = combineDateAndTime(a.scheduledEndDate, a.scheduledEndTime);
+  if (endMs != null && nowMs >= endMs) return 'expired';
+
+  if (a.activationType === 'scheduled') {
+    const startMs = combineDateAndTime(
+      a.scheduledActivationDate,
+      a.scheduledActivationTime
+    );
+    if (startMs == null) {
+      // Misconfigured (date/time missing) — keep showing as active so admin notices.
+      return 'active';
+    }
+    if (nowMs < startMs) return 'scheduled';
+  }
+
+  return 'active';
 }
 
 // Inline config editors for common widget types
@@ -348,20 +415,47 @@ function renderConfigEditor(
   }
 }
 
-// Status badge
-function StatusBadge({ isActive }: { isActive: boolean }) {
+const LIVE_STATUS_STYLES: Record<
+  AnnouncementLiveStatus,
+  { label: string; classes: string; dot: string; pulse: boolean }
+> = {
+  active: {
+    label: 'Active now',
+    classes: 'bg-green-100 text-green-700 border border-green-300',
+    dot: 'bg-green-500',
+    pulse: true,
+  },
+  scheduled: {
+    label: 'Scheduled',
+    classes: 'bg-blue-100 text-blue-700 border border-blue-300',
+    dot: 'bg-blue-500',
+    pulse: false,
+  },
+  expired: {
+    label: 'Expired',
+    classes: 'bg-amber-100 text-amber-700 border border-amber-300',
+    dot: 'bg-amber-500',
+    pulse: false,
+  },
+  inactive: {
+    label: 'Inactive',
+    classes: 'bg-slate-100 text-slate-500 border border-slate-300',
+    dot: 'bg-slate-400',
+    pulse: false,
+  },
+};
+
+// Live status badge — derived from isActive plus the optional schedule window
+function StatusBadge({ status }: { status: AnnouncementLiveStatus }) {
+  const style = LIVE_STATUS_STYLES[status];
   return (
     <span
-      className={`inline-flex items-center gap-1 px-2 py-0.5 text-xs font-semibold rounded-full ${
-        isActive
-          ? 'bg-green-100 text-green-700 border border-green-300'
-          : 'bg-slate-100 text-slate-500 border border-slate-300'
-      }`}
+      className={`inline-flex items-center gap-1 px-2 py-0.5 text-xs font-semibold rounded-full ${style.classes}`}
     >
       <span
-        className={`w-1.5 h-1.5 rounded-full ${isActive ? 'bg-green-500 animate-pulse' : 'bg-slate-400'}`}
+        className={`w-1.5 h-1.5 rounded-full ${style.dot}${style.pulse ? ' animate-pulse' : ''}`}
       />
-      {isActive ? 'Active' : 'Inactive'}
+      {style.label}
     </span>
   );
 }
@@ -593,6 +687,13 @@ export const AnnouncementsManager: React.FC = () => {
     null
   );
   const [form, setForm] = useState<AnnouncementFormData>(buildDefaultForm);
+  // Tick every 30 s so the derived live-status badge transitions
+  // (Scheduled → Active now → Expired) without requiring a manual refresh.
+  const [nowMs, setNowMs] = useState<number>(() => Date.now());
+  useEffect(() => {
+    const interval = setInterval(() => setNowMs(Date.now()), 30_000);
+    return () => clearInterval(interval);
+  }, []);
 
   // Subscribe to announcements collection
   useEffect(() => {
@@ -626,6 +727,8 @@ export const AnnouncementsManager: React.FC = () => {
   const openEdit = useCallback((a: Announcement) => {
     const durationSec = a.dismissalDurationSeconds ?? 60;
     const isMinutes = durationSec >= 60 && durationSec % 60 === 0;
+    const today = getLocalIsoDate();
+    const hasEndWindow = !!(a.scheduledEndDate && a.scheduledEndTime);
     setForm({
       name: a.name,
       widgetType: a.widgetType,
@@ -633,7 +736,11 @@ export const AnnouncementsManager: React.FC = () => {
       widgetSize: a.widgetSize,
       maximized: a.maximized,
       activationType: a.activationType,
+      scheduledActivationDate: a.scheduledActivationDate ?? today,
       scheduledActivationTime: a.scheduledActivationTime ?? '08:00',
+      autoDeactivateEnabled: hasEndWindow,
+      scheduledEndDate: a.scheduledEndDate ?? today,
+      scheduledEndTime: a.scheduledEndTime ?? '15:00',
       dismissalType: a.dismissalType,
       scheduledDismissalTime: a.scheduledDismissalTime ?? '15:00',
       dismissalDurationSeconds: isMinutes ? durationSec / 60 : durationSec,
@@ -697,6 +804,38 @@ export const AnnouncementsManager: React.FC = () => {
       addToast('Please enter an announcement name.', 'error');
       return;
     }
+    if (form.activationType === 'scheduled') {
+      if (!form.scheduledActivationDate || !form.scheduledActivationTime) {
+        addToast(
+          'Please set a start date and start time for scheduled announcements.',
+          'error'
+        );
+        return;
+      }
+    }
+    if (form.autoDeactivateEnabled) {
+      if (!form.scheduledEndDate || !form.scheduledEndTime) {
+        addToast(
+          'Please set both an end date and end time, or turn off auto-deactivate.',
+          'error'
+        );
+        return;
+      }
+      if (form.activationType === 'scheduled') {
+        const startMs = combineDateAndTime(
+          form.scheduledActivationDate,
+          form.scheduledActivationTime
+        );
+        const endMs = combineDateAndTime(
+          form.scheduledEndDate,
+          form.scheduledEndTime
+        );
+        if (startMs != null && endMs != null && endMs <= startMs) {
+          addToast('End date/time must be after the start date/time.', 'error');
+          return;
+        }
+      }
+    }
     setSaving(true);
     try {
       const durationSeconds =
@@ -720,6 +859,16 @@ export const AnnouncementsManager: React.FC = () => {
           form.activationType === 'scheduled'
             ? form.scheduledActivationTime
             : undefined,
+        scheduledActivationDate:
+          form.activationType === 'scheduled'
+            ? form.scheduledActivationDate
+            : undefined,
+        scheduledEndDate: form.autoDeactivateEnabled
+          ? form.scheduledEndDate
+          : undefined,
+        scheduledEndTime: form.autoDeactivateEnabled
+          ? form.scheduledEndTime
+          : undefined,
         // Scheduled announcements are enabled ("active") as soon as they're created —
         // the overlay itself gates visibility by the clock time. Manual announcements
         // start inactive until the admin explicitly clicks Activate.
@@ -840,6 +989,17 @@ export const AnnouncementsManager: React.FC = () => {
           {announcements.map((a) => {
             const allBuildings = a.targetBuildings.length === 0;
             const userCount = a.targetUsers?.length ?? 0;
+            const liveStatus = getAnnouncementLiveStatus(a, nowMs);
+            const startLabel =
+              a.activationType === 'scheduled'
+                ? a.scheduledActivationDate
+                  ? `Activates ${a.scheduledActivationDate} at ${a.scheduledActivationTime ?? ''}`
+                  : `Activates at ${a.scheduledActivationTime ?? ''}`
+                : 'Manual activation';
+            const endLabel =
+              a.scheduledEndDate && a.scheduledEndTime
+                ? `Auto-deactivates ${a.scheduledEndDate} at ${a.scheduledEndTime}`
+                : null;
             return (
               <div
                 key={a.id}
@@ -851,7 +1011,7 @@ export const AnnouncementsManager: React.FC = () => {
                       <h4 className="font-semibold text-slate-800 truncate">
                         {a.name}
                       </h4>
-                      <StatusBadge isActive={a.isActive} />
+                      <StatusBadge status={liveStatus} />
                     </div>
                     <div className="mt-1.5 flex flex-wrap gap-x-4 gap-y-1 text-xs text-slate-500">
                       <span className="flex items-center gap-1">
@@ -860,10 +1020,14 @@ export const AnnouncementsManager: React.FC = () => {
                       </span>
                       <span className="flex items-center gap-1">
                         <Clock className="w-3 h-3" />
-                        {a.activationType === 'manual'
-                          ? 'Manual activation'
-                          : `Activates at ${a.scheduledActivationTime}`}
+                        {startLabel}
                       </span>
+                      {endLabel && (
+                        <span className="flex items-center gap-1">
+                          <Square className="w-3 h-3" />
+                          {endLabel}
+                        </span>
+                      )}
                       <span className="flex items-center gap-1">
                         <Building2 className="w-3 h-3" />
                         {allBuildings
@@ -1128,23 +1292,97 @@ export const AnnouncementsManager: React.FC = () => {
                 ))}
               </div>
               {form.activationType === 'scheduled' && (
-                <div>
-                  <label className="block text-xs font-semibold text-slate-700 mb-1">
-                    Activation Time
-                  </label>
-                  <input
-                    type="time"
-                    value={form.scheduledActivationTime}
-                    onChange={(e) =>
-                      setForm((f) => ({
-                        ...f,
-                        scheduledActivationTime: e.target.value,
-                      }))
-                    }
-                    className="w-full px-3 py-1.5 text-sm border border-slate-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-brand-blue-primary"
-                  />
+                <div className="grid grid-cols-2 gap-2">
+                  <div>
+                    <label className="block text-xs font-semibold text-slate-700 mb-1">
+                      Start Date
+                    </label>
+                    <input
+                      type="date"
+                      value={form.scheduledActivationDate}
+                      onChange={(e) =>
+                        setForm((f) => ({
+                          ...f,
+                          scheduledActivationDate: e.target.value,
+                        }))
+                      }
+                      className="w-full px-3 py-1.5 text-sm border border-slate-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-brand-blue-primary"
+                    />
+                  </div>
+                  <div>
+                    <label className="block text-xs font-semibold text-slate-700 mb-1">
+                      Start Time
+                    </label>
+                    <input
+                      type="time"
+                      value={form.scheduledActivationTime}
+                      onChange={(e) =>
+                        setForm((f) => ({
+                          ...f,
+                          scheduledActivationTime: e.target.value,
+                        }))
+                      }
+                      className="w-full px-3 py-1.5 text-sm border border-slate-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-brand-blue-primary"
+                    />
+                  </div>
                 </div>
               )}
+              {/* Auto-deactivate end window — applies to both manual and scheduled */}
+              <div className="pt-3 border-t border-slate-100">
+                <div className="flex items-center gap-3">
+                  <Toggle
+                    checked={form.autoDeactivateEnabled}
+                    onChange={(v) =>
+                      setForm((f) => ({ ...f, autoDeactivateEnabled: v }))
+                    }
+                  />
+                  <div>
+                    <div className="text-sm font-medium text-slate-700">
+                      Auto-deactivate at end date/time
+                    </div>
+                    <div className="text-xs text-slate-500">
+                      The announcement automatically goes inactive after this
+                      moment — no need to remember to turn it off.
+                    </div>
+                  </div>
+                </div>
+                {form.autoDeactivateEnabled && (
+                  <div className="grid grid-cols-2 gap-2 mt-3">
+                    <div>
+                      <label className="block text-xs font-semibold text-slate-700 mb-1">
+                        End Date
+                      </label>
+                      <input
+                        type="date"
+                        value={form.scheduledEndDate}
+                        onChange={(e) =>
+                          setForm((f) => ({
+                            ...f,
+                            scheduledEndDate: e.target.value,
+                          }))
+                        }
+                        className="w-full px-3 py-1.5 text-sm border border-slate-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-brand-blue-primary"
+                      />
+                    </div>
+                    <div>
+                      <label className="block text-xs font-semibold text-slate-700 mb-1">
+                        End Time
+                      </label>
+                      <input
+                        type="time"
+                        value={form.scheduledEndTime}
+                        onChange={(e) =>
+                          setForm((f) => ({
+                            ...f,
+                            scheduledEndTime: e.target.value,
+                          }))
+                        }
+                        className="w-full px-3 py-1.5 text-sm border border-slate-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-brand-blue-primary"
+                      />
+                    </div>
+                  </div>
+                )}
+              </div>
             </FormSection>
 
             {/* Dismissal */}

--- a/components/admin/Announcements/Widget.tsx
+++ b/components/admin/Announcements/Widget.tsx
@@ -40,7 +40,7 @@ import { WIDGET_DEFAULTS } from '@/config/widgetDefaults';
 import { Toggle } from '@/components/common/Toggle';
 import { TOOLS } from '@/config/tools';
 import { WIDGET_COMPONENTS } from '@/components/widgets/WidgetRegistry';
-import { getLocalIsoDate } from '@/utils/localDate';
+import { getLocalIsoDate, combineDateAndTime } from '@/utils/localDate';
 import { AnnouncementFormData } from './types';
 import { TextConfigEditor } from './TextConfigEditor';
 import { EmbedConfigEditor } from './EmbedConfigEditor';
@@ -143,38 +143,6 @@ function buildDefaultForm(): AnnouncementFormData {
     targetBuildings: [],
     targetUsers: [],
   };
-}
-
-/**
- * Combine a YYYY-MM-DD date and HH:MM time into a millisecond timestamp using
- * local-time semantics. Returns null when either piece is missing or malformed.
- *
- * Wall-clock interpretation matches the admin's intent across timezones —
- * "May 5, 8:00 AM" means 8:00 AM in the school's local time, not UTC.
- */
-function combineDateAndTime(
-  date: string | undefined,
-  time: string | undefined
-): number | null {
-  if (!date || !time) return null;
-  const dateMatch = /^(\d{4})-(\d{2})-(\d{2})$/.exec(date);
-  const timeMatch = /^(\d{1,2}):(\d{2})$/.exec(time);
-  if (!dateMatch || !timeMatch) return null;
-  const y = Number(dateMatch[1]);
-  const mo = Number(dateMatch[2]);
-  const d = Number(dateMatch[3]);
-  const h = Number(timeMatch[1]);
-  const mi = Number(timeMatch[2]);
-  if (
-    !Number.isFinite(y) ||
-    !Number.isFinite(mo) ||
-    !Number.isFinite(d) ||
-    !Number.isFinite(h) ||
-    !Number.isFinite(mi)
-  )
-    return null;
-  const ms = new Date(y, mo - 1, d, h, mi, 0, 0).getTime();
-  return Number.isFinite(ms) ? ms : null;
 }
 
 type AnnouncementLiveStatus = 'inactive' | 'scheduled' | 'active' | 'expired';
@@ -736,7 +704,11 @@ export const AnnouncementsManager: React.FC = () => {
       widgetSize: a.widgetSize,
       maximized: a.maximized,
       activationType: a.activationType,
-      scheduledActivationDate: a.scheduledActivationDate ?? today,
+      // Preserve legacy time-only schedules: leave the date empty when the
+      // announcement was created before the date field existed. The overlay
+      // falls back to a daily-recurring HH:MM compare in that case. Defaulting
+      // here would silently convert the legacy schedule to a one-shot.
+      scheduledActivationDate: a.scheduledActivationDate ?? '',
       scheduledActivationTime: a.scheduledActivationTime ?? '08:00',
       autoDeactivateEnabled: hasEndWindow,
       scheduledEndDate: a.scheduledEndDate ?? today,
@@ -805,13 +777,15 @@ export const AnnouncementsManager: React.FC = () => {
       return;
     }
     if (form.activationType === 'scheduled') {
-      if (!form.scheduledActivationDate || !form.scheduledActivationTime) {
+      if (!form.scheduledActivationTime) {
         addToast(
-          'Please set a start date and start time for scheduled announcements.',
+          'Please set a start time for scheduled announcements.',
           'error'
         );
         return;
       }
+      // Start date is optional — empty preserves the legacy time-only
+      // daily-recurring behavior. The overlay falls back accordingly.
     }
     if (form.autoDeactivateEnabled) {
       if (!form.scheduledEndDate || !form.scheduledEndTime) {
@@ -860,7 +834,7 @@ export const AnnouncementsManager: React.FC = () => {
             ? form.scheduledActivationTime
             : undefined,
         scheduledActivationDate:
-          form.activationType === 'scheduled'
+          form.activationType === 'scheduled' && form.scheduledActivationDate
             ? form.scheduledActivationDate
             : undefined,
         scheduledEndDate: form.autoDeactivateEnabled
@@ -1292,40 +1266,49 @@ export const AnnouncementsManager: React.FC = () => {
                 ))}
               </div>
               {form.activationType === 'scheduled' && (
-                <div className="grid grid-cols-2 gap-2">
-                  <div>
-                    <label className="block text-xs font-semibold text-slate-700 mb-1">
-                      Start Date
-                    </label>
-                    <input
-                      type="date"
-                      value={form.scheduledActivationDate}
-                      onChange={(e) =>
-                        setForm((f) => ({
-                          ...f,
-                          scheduledActivationDate: e.target.value,
-                        }))
-                      }
-                      className="w-full px-3 py-1.5 text-sm border border-slate-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-brand-blue-primary"
-                    />
+                <>
+                  <div className="grid grid-cols-2 gap-2">
+                    <div>
+                      <label className="block text-xs font-semibold text-slate-700 mb-1">
+                        Start Date
+                      </label>
+                      <input
+                        type="date"
+                        value={form.scheduledActivationDate}
+                        onChange={(e) =>
+                          setForm((f) => ({
+                            ...f,
+                            scheduledActivationDate: e.target.value,
+                          }))
+                        }
+                        className="w-full px-3 py-1.5 text-sm border border-slate-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-brand-blue-primary"
+                      />
+                    </div>
+                    <div>
+                      <label className="block text-xs font-semibold text-slate-700 mb-1">
+                        Start Time
+                      </label>
+                      <input
+                        type="time"
+                        value={form.scheduledActivationTime}
+                        onChange={(e) =>
+                          setForm((f) => ({
+                            ...f,
+                            scheduledActivationTime: e.target.value,
+                          }))
+                        }
+                        className="w-full px-3 py-1.5 text-sm border border-slate-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-brand-blue-primary"
+                      />
+                    </div>
                   </div>
-                  <div>
-                    <label className="block text-xs font-semibold text-slate-700 mb-1">
-                      Start Time
-                    </label>
-                    <input
-                      type="time"
-                      value={form.scheduledActivationTime}
-                      onChange={(e) =>
-                        setForm((f) => ({
-                          ...f,
-                          scheduledActivationTime: e.target.value,
-                        }))
-                      }
-                      className="w-full px-3 py-1.5 text-sm border border-slate-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-brand-blue-primary"
-                    />
-                  </div>
-                </div>
+                  {!form.scheduledActivationDate && (
+                    <p className="text-xs text-amber-700">
+                      No start date set — the announcement recurs daily at the
+                      time above (legacy behavior). Pick a date to convert it to
+                      a one-shot schedule.
+                    </p>
+                  )}
+                </>
               )}
               {/* Auto-deactivate end window — applies to both manual and scheduled */}
               <div className="pt-3 border-t border-slate-100">

--- a/components/admin/Announcements/types.ts
+++ b/components/admin/Announcements/types.ts
@@ -11,7 +11,12 @@ export interface AnnouncementFormData {
   widgetSize: { w: number; h: number };
   maximized: boolean;
   activationType: AnnouncementActivationType;
+  scheduledActivationDate: string;
   scheduledActivationTime: string;
+  /** When true, the form's end date+time auto-deactivate the announcement */
+  autoDeactivateEnabled: boolean;
+  scheduledEndDate: string;
+  scheduledEndTime: string;
   dismissalType: AnnouncementDismissalType;
   scheduledDismissalTime: string;
   dismissalDurationSeconds: number;

--- a/components/announcements/AnnouncementOverlay.tsx
+++ b/components/announcements/AnnouncementOverlay.tsx
@@ -82,17 +82,64 @@ function currentMinutes(): number {
 }
 
 /**
- * Returns true when the announcement should currently be visible.
- * @param nowMins - current wall-clock time in minutes (hours * 60 + minutes),
- *                  passed explicitly so callers can include it in useMemo deps.
+ * Combine a YYYY-MM-DD date and HH:MM time into a millisecond timestamp using
+ * local-time semantics. Returns null when either piece is missing or malformed.
  */
-function isScheduledTimeReached(a: Announcement, nowMins: number): boolean {
+function combineDateAndTime(
+  date: string | undefined,
+  time: string | undefined
+): number | null {
+  if (!date || !time) return null;
+  const dateMatch = /^(\d{4})-(\d{2})-(\d{2})$/.exec(date);
+  const timeMatch = /^(\d{1,2}):(\d{2})$/.exec(time);
+  if (!dateMatch || !timeMatch) return null;
+  const y = Number(dateMatch[1]);
+  const mo = Number(dateMatch[2]);
+  const d = Number(dateMatch[3]);
+  const h = Number(timeMatch[1]);
+  const mi = Number(timeMatch[2]);
+  if (
+    !Number.isFinite(y) ||
+    !Number.isFinite(mo) ||
+    !Number.isFinite(d) ||
+    !Number.isFinite(h) ||
+    !Number.isFinite(mi)
+  )
+    return null;
+  const ms = new Date(y, mo - 1, d, h, mi, 0, 0).getTime();
+  return Number.isFinite(ms) ? ms : null;
+}
+
+/**
+ * Returns true when the announcement is currently inside its active window.
+ * @param nowMs - current wall-clock time in ms, passed explicitly so callers
+ *                can include it in useMemo deps.
+ */
+function isWithinActiveWindow(a: Announcement, nowMs: number): boolean {
   // isActive acts as a master enable flag for all activation types.
   if (!a.isActive) return false;
-  // Non-scheduled announcements are visible whenever they are active.
+
+  // Optional auto-deactivate end window — applies regardless of activation type.
+  const endMs = combineDateAndTime(a.scheduledEndDate, a.scheduledEndTime);
+  if (endMs != null && nowMs >= endMs) return false;
+
   if (a.activationType !== 'scheduled') return true;
-  // Scheduled announcements become visible once the wall clock passes the configured activation time.
+
+  // Scheduled activation: gated by start date+time when present, falling back
+  // to time-only comparison for legacy announcements created before the
+  // date field existed (so old announcements still work).
+  if (a.scheduledActivationDate && a.scheduledActivationTime) {
+    const startMs = combineDateAndTime(
+      a.scheduledActivationDate,
+      a.scheduledActivationTime
+    );
+    if (startMs == null) return false;
+    return nowMs >= startMs;
+  }
   if (!a.scheduledActivationTime) return false;
+  // Legacy: HH:MM-only — visible when wall-clock minutes meet/exceed start time.
+  const now = new Date(nowMs);
+  const nowMins = now.getHours() * 60 + now.getMinutes();
   return nowMins >= timeToMinutes(a.scheduledActivationTime);
 }
 
@@ -341,9 +388,10 @@ export const AnnouncementOverlay: React.FC = () => {
     const rec = getDismissals();
     return new Set(Object.keys(rec));
   });
-  // Current wall-clock time in minutes, updated every SCHEDULE_CHECK_INTERVAL_MS
-  // so scheduled activation/dismissal logic in useMemo re-runs automatically.
-  const [nowMinutes, setNowMinutes] = useState(currentMinutes);
+  // Current wall-clock time (ms), updated every SCHEDULE_CHECK_INTERVAL_MS so
+  // scheduled activation/dismissal logic in useMemo re-runs automatically and
+  // date-window transitions (start/end across midnight) trigger correctly.
+  const [nowMs, setNowMs] = useState<number>(() => Date.now());
 
   // Subscribe to the announcements collection (only active announcements)
   useEffect(() => {
@@ -371,7 +419,7 @@ export const AnnouncementOverlay: React.FC = () => {
   // Periodic clock update for scheduled activation/dismissal checks
   useEffect(() => {
     const interval = setInterval(
-      () => setNowMinutes(currentMinutes()),
+      () => setNowMs(Date.now()),
       SCHEDULE_CHECK_INTERVAL_MS
     );
     return () => clearInterval(interval);
@@ -387,14 +435,14 @@ export const AnnouncementOverlay: React.FC = () => {
   );
 
   // Determine which announcements are visible to this user.
-  // nowMinutes is the current wall-clock time (minutes since midnight) and
-  // is updated every SCHEDULE_CHECK_INTERVAL_MS so scheduled announcements
-  // appear/disappear without a full re-subscribe.
+  // nowMs is the current wall-clock time (ms) and is updated every
+  // SCHEDULE_CHECK_INTERVAL_MS so scheduled announcements appear/disappear
+  // and the auto-deactivate end window fires without a full re-subscribe.
   const visible = useMemo(
     () =>
       announcements.filter((a) => {
-        // Must pass scheduled/manual activation check
-        if (!isScheduledTimeReached(a, nowMinutes)) return false;
+        // Must pass scheduled/manual activation check + auto-deactivate window
+        if (!isWithinActiveWindow(a, nowMs)) return false;
 
         // Must not have been dismissed by this user in this push epoch
         const epochKey = `${a.id}_${a.activatedAt}`;
@@ -430,7 +478,7 @@ export const AnnouncementOverlay: React.FC = () => {
 
         return true;
       }),
-    [announcements, dismissed, selectedBuildings, nowMinutes, user?.email]
+    [announcements, dismissed, selectedBuildings, nowMs, user?.email]
   );
 
   if (visible.length === 0) return null;

--- a/components/announcements/AnnouncementOverlay.tsx
+++ b/components/announcements/AnnouncementOverlay.tsx
@@ -37,6 +37,7 @@ import { Announcement, WidgetData, WidgetConfig } from '@/types';
 import { WIDGET_COMPONENTS } from '@/components/widgets/WidgetRegistry';
 import { useWindowSize } from '@/hooks/useWindowSize';
 import { Z_INDEX } from '@/config/zIndex';
+import { combineDateAndTime } from '@/utils/localDate';
 
 const DISMISSALS_KEY = 'spart_announcement_dismissals';
 const SCHEDULE_CHECK_INTERVAL_MS = 30_000;
@@ -79,35 +80,6 @@ function timeToMinutes(hhmm: string): number {
 function currentMinutes(): number {
   const now = new Date();
   return now.getHours() * 60 + now.getMinutes();
-}
-
-/**
- * Combine a YYYY-MM-DD date and HH:MM time into a millisecond timestamp using
- * local-time semantics. Returns null when either piece is missing or malformed.
- */
-function combineDateAndTime(
-  date: string | undefined,
-  time: string | undefined
-): number | null {
-  if (!date || !time) return null;
-  const dateMatch = /^(\d{4})-(\d{2})-(\d{2})$/.exec(date);
-  const timeMatch = /^(\d{1,2}):(\d{2})$/.exec(time);
-  if (!dateMatch || !timeMatch) return null;
-  const y = Number(dateMatch[1]);
-  const mo = Number(dateMatch[2]);
-  const d = Number(dateMatch[3]);
-  const h = Number(timeMatch[1]);
-  const mi = Number(timeMatch[2]);
-  if (
-    !Number.isFinite(y) ||
-    !Number.isFinite(mo) ||
-    !Number.isFinite(d) ||
-    !Number.isFinite(h) ||
-    !Number.isFinite(mi)
-  )
-    return null;
-  const ms = new Date(y, mo - 1, d, h, mi, 0, 0).getTime();
-  return Number.isFinite(ms) ? ms : null;
 }
 
 /**

--- a/components/widgets/Embed/Widget.tsx
+++ b/components/widgets/Embed/Widget.tsx
@@ -28,6 +28,7 @@ import { useWidgetBuildingId } from '@/hooks/useWidgetBuildingId';
 import { Z_INDEX } from '@/config/zIndex';
 
 import { applyAutoplay } from './applyAutoplay';
+import { applyStartAt } from './applyStartAt';
 
 const NEW_WIDGET_SPACING = 20;
 const TOOLBAR_GAP = 6;
@@ -50,6 +51,7 @@ export const EmbedWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
     blockedReason = '',
     zoom = 1,
     autoplay = false,
+    startAtSeconds,
   } = config;
 
   const ZOOM_STEPS = [
@@ -208,9 +210,10 @@ export const EmbedWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
   const embedUrl = convertToEmbedUrl(sanitizedUrl);
 
   // When autoplay is enabled, append ?autoplay=1 for supported hosts
+  // and apply the YouTube start-at offset (no-op for non-YouTube hosts).
   const finalEmbedUrl = React.useMemo(
-    () => applyAutoplay(embedUrl, autoplay),
-    [embedUrl, autoplay]
+    () => applyStartAt(applyAutoplay(embedUrl, autoplay), startAtSeconds),
+    [embedUrl, autoplay, startAtSeconds]
   );
 
   const [refreshKey, setRefreshKey] = useState(0);

--- a/components/widgets/Embed/applyStartAt.test.ts
+++ b/components/widgets/Embed/applyStartAt.test.ts
@@ -62,6 +62,20 @@ describe('applyStartAt', () => {
     expect(applyStartAt(url, 30)).toBe(url);
   });
 
+  // youtu.be short links are normalized to youtube.com/embed/... by
+  // convertToEmbedUrl before this helper runs, and `?start=N` is only honored
+  // by the embed player anyway (short links use `?t=N`). Asserting the
+  // pass-through here makes the input contract explicit.
+  it('does not modify youtu.be short links (caller is expected to normalize first)', () => {
+    const url = 'https://youtu.be/abc123';
+    expect(applyStartAt(url, 30)).toBe(url);
+  });
+
+  it('does not modify youtube.com/watch URLs (caller is expected to normalize first)', () => {
+    const url = 'https://www.youtube.com/watch?v=abc123';
+    expect(applyStartAt(url, 30)).toBe(url);
+  });
+
   it('preserves existing query parameters', () => {
     const url = 'https://www.youtube.com/embed/abc123?autoplay=1&mute=1';
     const result = applyStartAt(url, 45);

--- a/components/widgets/Embed/applyStartAt.test.ts
+++ b/components/widgets/Embed/applyStartAt.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest';
+import { applyStartAt } from './applyStartAt';
+
+describe('applyStartAt', () => {
+  it('returns the original URL when startAtSeconds is undefined', () => {
+    const url = 'https://www.youtube.com/embed/abc123';
+    expect(applyStartAt(url, undefined)).toBe(url);
+  });
+
+  it('returns the original URL when startAtSeconds is 0', () => {
+    const url = 'https://www.youtube.com/embed/abc123';
+    expect(applyStartAt(url, 0)).toBe(url);
+  });
+
+  it('returns the original URL when startAtSeconds is negative', () => {
+    const url = 'https://www.youtube.com/embed/abc123';
+    expect(applyStartAt(url, -5)).toBe(url);
+  });
+
+  it('returns the original URL when it is empty', () => {
+    expect(applyStartAt('', 30)).toBe('');
+  });
+
+  it('appends start=30 for YouTube embed URLs', () => {
+    const url = 'https://www.youtube.com/embed/abc123';
+    expect(applyStartAt(url, 30)).toBe(
+      'https://www.youtube.com/embed/abc123?start=30'
+    );
+  });
+
+  it('appends start=N for bare youtube.com', () => {
+    const url = 'https://youtube.com/embed/xyz';
+    expect(applyStartAt(url, 90)).toBe(
+      'https://youtube.com/embed/xyz?start=90'
+    );
+  });
+
+  it('floors fractional seconds', () => {
+    const url = 'https://www.youtube.com/embed/abc';
+    expect(applyStartAt(url, 12.7)).toBe(
+      'https://www.youtube.com/embed/abc?start=12'
+    );
+  });
+
+  it('does not modify Google Drive preview URLs', () => {
+    const url = 'https://drive.google.com/file/d/fileId123/preview';
+    expect(applyStartAt(url, 30)).toBe(url);
+  });
+
+  it('does not modify Google Vids preview URLs', () => {
+    const url = 'https://vids.google.com/vids/vidId456/preview';
+    expect(applyStartAt(url, 30)).toBe(url);
+  });
+
+  it('does not modify unsupported hosts', () => {
+    const url = 'https://example.com/video';
+    expect(applyStartAt(url, 30)).toBe(url);
+  });
+
+  it('does not match lookalike domains like notyoutube.com', () => {
+    const url = 'https://notyoutube.com/embed/abc';
+    expect(applyStartAt(url, 30)).toBe(url);
+  });
+
+  it('preserves existing query parameters', () => {
+    const url = 'https://www.youtube.com/embed/abc123?autoplay=1&mute=1';
+    const result = applyStartAt(url, 45);
+    expect(result).toContain('autoplay=1');
+    expect(result).toContain('mute=1');
+    expect(result).toContain('start=45');
+  });
+
+  it('overwrites an existing start parameter', () => {
+    const url = 'https://www.youtube.com/embed/abc?start=10';
+    expect(applyStartAt(url, 60)).toBe(
+      'https://www.youtube.com/embed/abc?start=60'
+    );
+  });
+
+  it('returns the original string for malformed URLs', () => {
+    const url = 'not-a-valid-url';
+    expect(applyStartAt(url, 30)).toBe(url);
+  });
+});

--- a/components/widgets/Embed/applyStartAt.ts
+++ b/components/widgets/Embed/applyStartAt.ts
@@ -1,0 +1,26 @@
+/**
+ * Appends `&start=N` to YouTube embed URLs so the player begins at the given
+ * offset (seconds). Returns the original URL unchanged otherwise.
+ *
+ * Drive and Vids are intentionally excluded — same rationale as applyAutoplay.
+ * Their `/preview` iframes don't honor any documented seek parameter, so the
+ * value would silently be ignored. Hiding the field in the admin editor for
+ * non-YouTube hosts keeps the UI honest; this guard is a defense-in-depth
+ * fallback in case stale config flows in.
+ */
+export function applyStartAt(
+  embedUrl: string,
+  startAtSeconds?: number
+): string {
+  if (!startAtSeconds || startAtSeconds <= 0 || !embedUrl) return embedUrl;
+  try {
+    const u = new URL(embedUrl);
+    const host = u.hostname.toLowerCase();
+    const isYouTube = host === 'youtube.com' || host.endsWith('.youtube.com');
+    if (!isYouTube) return embedUrl;
+    u.searchParams.set('start', String(Math.floor(startAtSeconds)));
+    return u.toString();
+  } catch {
+    return embedUrl;
+  }
+}

--- a/components/widgets/Embed/applyStartAt.ts
+++ b/components/widgets/Embed/applyStartAt.ts
@@ -2,11 +2,18 @@
  * Appends `&start=N` to YouTube embed URLs so the player begins at the given
  * offset (seconds). Returns the original URL unchanged otherwise.
  *
+ * **Input contract:** the caller is expected to pass a URL that has already
+ * been normalized through `convertToEmbedUrl()` — i.e. in
+ * `https://www.youtube.com/embed/{id}` form. `youtu.be` short links and
+ * `youtube.com/watch?v=` URLs are intentionally NOT matched here because:
+ *   1. They never reach this helper in production — `convertToEmbedUrl`
+ *      rewrites them to the `/embed/` form first (see Embed/Widget.tsx).
+ *   2. The `?start=N` parameter is only honored by the embed player. Short
+ *      links and the watch player use `?t=N` instead, so naively appending
+ *      `?start=N` to those would produce a non-functional URL.
+ *
  * Drive and Vids are intentionally excluded — same rationale as applyAutoplay.
- * Their `/preview` iframes don't honor any documented seek parameter, so the
- * value would silently be ignored. Hiding the field in the admin editor for
- * non-YouTube hosts keeps the UI honest; this guard is a defense-in-depth
- * fallback in case stale config flows in.
+ * Their `/preview` iframes don't honor any documented seek parameter.
  */
 export function applyStartAt(
   embedUrl: string,
@@ -16,8 +23,13 @@ export function applyStartAt(
   try {
     const u = new URL(embedUrl);
     const host = u.hostname.toLowerCase();
-    const isYouTube = host === 'youtube.com' || host.endsWith('.youtube.com');
-    if (!isYouTube) return embedUrl;
+    const isYouTubeHost =
+      host === 'youtube.com' || host.endsWith('.youtube.com');
+    // Require the embed path explicitly: the `start` query param is only
+    // honored by `/embed/` URLs. Watch URLs and short links (`youtu.be`)
+    // would silently ignore it, so we leave them unchanged rather than
+    // producing a URL that looks valid but doesn't seek.
+    if (!isYouTubeHost || !u.pathname.startsWith('/embed/')) return embedUrl;
     u.searchParams.set('start', String(Math.floor(startAtSeconds)));
     return u.toString();
   } catch {

--- a/tests/components/announcements/AnnouncementOverlay.test.tsx
+++ b/tests/components/announcements/AnnouncementOverlay.test.tsx
@@ -233,6 +233,157 @@ describe('AnnouncementOverlay', () => {
   });
 
   // -------------------------------------------------------------------------
+  // Date-bounded activation window
+  // -------------------------------------------------------------------------
+
+  describe('date window (auto-deactivate)', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('hides a scheduled announcement before its start date+time', () => {
+      // Clock: May 5, 7:30 AM. Window starts May 5, 8:00 AM.
+      vi.setSystemTime(new Date(2026, 4, 5, 7, 30));
+      render(<AnnouncementOverlay />);
+      emitAnnouncements([
+        {
+          ...BASE_ANNOUNCEMENT,
+          activationType: 'scheduled',
+          scheduledActivationDate: '2026-05-05',
+          scheduledActivationTime: '08:00',
+          isActive: true,
+        },
+      ]);
+      expect(screen.queryByText('Test Announcement')).not.toBeInTheDocument();
+    });
+
+    it('shows a scheduled announcement during its window', () => {
+      // Clock: May 5, 9:00 AM. Window: May 5 08:00 → May 5 17:00.
+      vi.setSystemTime(new Date(2026, 4, 5, 9, 0));
+      render(<AnnouncementOverlay />);
+      emitAnnouncements([
+        {
+          ...BASE_ANNOUNCEMENT,
+          activationType: 'scheduled',
+          scheduledActivationDate: '2026-05-05',
+          scheduledActivationTime: '08:00',
+          scheduledEndDate: '2026-05-05',
+          scheduledEndTime: '17:00',
+          isActive: true,
+        },
+      ]);
+      expect(screen.getByText('Test Announcement')).toBeInTheDocument();
+    });
+
+    it('hides a scheduled announcement after its end date+time', () => {
+      // Clock: May 5, 18:00. Window ended at 17:00.
+      vi.setSystemTime(new Date(2026, 4, 5, 18, 0));
+      render(<AnnouncementOverlay />);
+      emitAnnouncements([
+        {
+          ...BASE_ANNOUNCEMENT,
+          activationType: 'scheduled',
+          scheduledActivationDate: '2026-05-05',
+          scheduledActivationTime: '08:00',
+          scheduledEndDate: '2026-05-05',
+          scheduledEndTime: '17:00',
+          isActive: true,
+        },
+      ]);
+      expect(screen.queryByText('Test Announcement')).not.toBeInTheDocument();
+    });
+
+    it('shows a manual announcement with end window before the end moment', () => {
+      // Clock: May 5, 14:00. Manual + end May 5 17:00.
+      vi.setSystemTime(new Date(2026, 4, 5, 14, 0));
+      render(<AnnouncementOverlay />);
+      emitAnnouncements([
+        {
+          ...BASE_ANNOUNCEMENT,
+          activationType: 'manual',
+          scheduledEndDate: '2026-05-05',
+          scheduledEndTime: '17:00',
+          isActive: true,
+        },
+      ]);
+      expect(screen.getByText('Test Announcement')).toBeInTheDocument();
+    });
+
+    it('hides a manual announcement after its end window', () => {
+      // Clock: May 5, 18:00. Manual + end May 5 17:00.
+      vi.setSystemTime(new Date(2026, 4, 5, 18, 0));
+      render(<AnnouncementOverlay />);
+      emitAnnouncements([
+        {
+          ...BASE_ANNOUNCEMENT,
+          activationType: 'manual',
+          scheduledEndDate: '2026-05-05',
+          scheduledEndTime: '17:00',
+          isActive: true,
+        },
+      ]);
+      expect(screen.queryByText('Test Announcement')).not.toBeInTheDocument();
+    });
+
+    it('shows a multi-day windowed announcement after midnight crossing', () => {
+      // Clock: May 6, 02:00 (crossed midnight from May 5).
+      // Window: May 5 14:00 → May 6 08:00. 02:00 < 08:00 so still within window.
+      vi.setSystemTime(new Date(2026, 4, 6, 2, 0));
+      render(<AnnouncementOverlay />);
+      emitAnnouncements([
+        {
+          ...BASE_ANNOUNCEMENT,
+          activationType: 'scheduled',
+          scheduledActivationDate: '2026-05-05',
+          scheduledActivationTime: '14:00',
+          scheduledEndDate: '2026-05-06',
+          scheduledEndTime: '08:00',
+          isActive: true,
+        },
+      ]);
+      expect(screen.getByText('Test Announcement')).toBeInTheDocument();
+    });
+
+    it('hides a multi-day windowed announcement after the next morning end', () => {
+      // Clock: May 6, 09:00. Window ended at May 6 08:00.
+      vi.setSystemTime(new Date(2026, 4, 6, 9, 0));
+      render(<AnnouncementOverlay />);
+      emitAnnouncements([
+        {
+          ...BASE_ANNOUNCEMENT,
+          activationType: 'scheduled',
+          scheduledActivationDate: '2026-05-05',
+          scheduledActivationTime: '14:00',
+          scheduledEndDate: '2026-05-06',
+          scheduledEndTime: '08:00',
+          isActive: true,
+        },
+      ]);
+      expect(screen.queryByText('Test Announcement')).not.toBeInTheDocument();
+    });
+
+    it('falls back to time-only comparison for legacy announcements without a start date', () => {
+      // Clock: 10:00. Legacy schedule: time only at 09:00, no date set.
+      vi.setSystemTime(new Date(2026, 4, 5, 10, 0));
+      render(<AnnouncementOverlay />);
+      emitAnnouncements([
+        {
+          ...BASE_ANNOUNCEMENT,
+          activationType: 'scheduled',
+          scheduledActivationTime: '09:00',
+          // no scheduledActivationDate — legacy data
+          isActive: true,
+        },
+      ]);
+      expect(screen.getByText('Test Announcement')).toBeInTheDocument();
+    });
+  });
+
+  // -------------------------------------------------------------------------
   // Building targeting
   // -------------------------------------------------------------------------
 

--- a/types.ts
+++ b/types.ts
@@ -622,6 +622,8 @@ export interface EmbedConfig {
   blockedReason?: string;
   zoom?: number;
   autoplay?: boolean;
+  /** Start playback at this offset (seconds). YouTube only — Drive's /preview iframe ignores it. */
+  startAtSeconds?: number;
 }
 
 export interface BuildingPollDefaults {
@@ -3939,6 +3941,12 @@ export interface Announcement {
   activationType: AnnouncementActivationType;
   /** HH:MM in 24h format — used when activationType is 'scheduled' */
   scheduledActivationTime?: string;
+  /** YYYY-MM-DD local date — used when activationType is 'scheduled' */
+  scheduledActivationDate?: string;
+  /** YYYY-MM-DD local date — optional auto-deactivate end date (paired with scheduledEndTime) */
+  scheduledEndDate?: string;
+  /** HH:MM in 24h format — optional auto-deactivate end time (paired with scheduledEndDate) */
+  scheduledEndTime?: string;
   /** Whether the announcement is currently active (visible to targeted users) */
   isActive: boolean;
   /**

--- a/utils/localDate.test.ts
+++ b/utils/localDate.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { getLocalIsoDate, combineDateAndTime } from './localDate';
+
+describe('getLocalIsoDate', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('returns YYYY-MM-DD for the given date', () => {
+    expect(getLocalIsoDate(new Date(2026, 4, 5, 14, 30))).toBe('2026-05-05');
+  });
+
+  it('zero-pads single-digit months and days', () => {
+    expect(getLocalIsoDate(new Date(2026, 0, 3, 0, 0))).toBe('2026-01-03');
+  });
+
+  it('uses the current date when no argument is provided', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 11, 25, 9, 0));
+    expect(getLocalIsoDate()).toBe('2026-12-25');
+  });
+});
+
+describe('combineDateAndTime', () => {
+  it('returns null when date is missing', () => {
+    expect(combineDateAndTime(undefined, '08:00')).toBeNull();
+    expect(combineDateAndTime('', '08:00')).toBeNull();
+  });
+
+  it('returns null when time is missing', () => {
+    expect(combineDateAndTime('2026-05-05', undefined)).toBeNull();
+    expect(combineDateAndTime('2026-05-05', '')).toBeNull();
+  });
+
+  it('returns null for malformed date strings', () => {
+    expect(combineDateAndTime('2026/05/05', '08:00')).toBeNull();
+    expect(combineDateAndTime('not-a-date', '08:00')).toBeNull();
+    expect(combineDateAndTime('2026-5-5', '08:00')).toBeNull(); // not zero-padded
+  });
+
+  it('returns null for malformed time strings', () => {
+    expect(combineDateAndTime('2026-05-05', '8am')).toBeNull();
+    expect(combineDateAndTime('2026-05-05', '08')).toBeNull();
+  });
+
+  it('returns a millisecond timestamp for valid input', () => {
+    const ms = combineDateAndTime('2026-05-05', '14:30');
+    expect(ms).not.toBeNull();
+    const dt = new Date(ms as number);
+    expect(dt.getFullYear()).toBe(2026);
+    expect(dt.getMonth()).toBe(4); // May, 0-indexed
+    expect(dt.getDate()).toBe(5);
+    expect(dt.getHours()).toBe(14);
+    expect(dt.getMinutes()).toBe(30);
+  });
+
+  it('rejects month 0 and month 13 (out of range)', () => {
+    expect(combineDateAndTime('2026-00-05', '08:00')).toBeNull();
+    expect(combineDateAndTime('2026-13-05', '08:00')).toBeNull();
+  });
+
+  it('rejects day 0 and day 32 (out of range)', () => {
+    expect(combineDateAndTime('2026-05-00', '08:00')).toBeNull();
+    expect(combineDateAndTime('2026-05-32', '08:00')).toBeNull();
+  });
+
+  it('rejects Feb 31 (would silently roll to Mar 3 without round-trip check)', () => {
+    expect(combineDateAndTime('2026-02-31', '08:00')).toBeNull();
+  });
+
+  it('rejects Feb 30 in a non-leap year', () => {
+    expect(combineDateAndTime('2026-02-30', '08:00')).toBeNull();
+  });
+
+  it('accepts Feb 29 in a leap year', () => {
+    const ms = combineDateAndTime('2024-02-29', '08:00');
+    expect(ms).not.toBeNull();
+    const dt = new Date(ms as number);
+    expect(dt.getMonth()).toBe(1); // February
+    expect(dt.getDate()).toBe(29);
+  });
+
+  it('rejects Feb 29 in a non-leap year', () => {
+    expect(combineDateAndTime('2026-02-29', '08:00')).toBeNull();
+  });
+
+  it('rejects hour 24 and hour -1', () => {
+    expect(combineDateAndTime('2026-05-05', '24:00')).toBeNull();
+  });
+
+  it('rejects minute 60', () => {
+    expect(combineDateAndTime('2026-05-05', '08:60')).toBeNull();
+  });
+
+  it('accepts boundary values 00:00 and 23:59', () => {
+    expect(combineDateAndTime('2026-05-05', '00:00')).not.toBeNull();
+    expect(combineDateAndTime('2026-05-05', '23:59')).not.toBeNull();
+  });
+});

--- a/utils/localDate.ts
+++ b/utils/localDate.ts
@@ -11,3 +11,56 @@ export function getLocalIsoDate(now: Date = new Date()): string {
   const d = String(now.getDate()).padStart(2, '0');
   return `${y}-${m}-${d}`;
 }
+
+/**
+ * Combine a `YYYY-MM-DD` date and `HH:MM` time into a millisecond timestamp
+ * using local-time semantics. Returns null when either piece is missing,
+ * malformed, or out of range.
+ *
+ * Wall-clock interpretation matches the admin's intent across timezones —
+ * "May 5, 8:00 AM" means 8:00 AM in the school's local time, not UTC.
+ *
+ * Strict range + round-trip validation: rejects out-of-range components
+ * (Feb 31, 25:00, etc.) instead of silently letting JS `Date` normalize
+ * them (Feb 31 → Mar 3) and producing a misleading timestamp.
+ */
+export function combineDateAndTime(
+  date: string | undefined,
+  time: string | undefined
+): number | null {
+  if (!date || !time) return null;
+  const dateMatch = /^(\d{4})-(\d{2})-(\d{2})$/.exec(date);
+  const timeMatch = /^(\d{1,2}):(\d{2})$/.exec(time);
+  if (!dateMatch || !timeMatch) return null;
+  const y = Number(dateMatch[1]);
+  const mo = Number(dateMatch[2]);
+  const d = Number(dateMatch[3]);
+  const h = Number(timeMatch[1]);
+  const mi = Number(timeMatch[2]);
+  if (
+    !Number.isFinite(y) ||
+    !Number.isFinite(mo) ||
+    !Number.isFinite(d) ||
+    !Number.isFinite(h) ||
+    !Number.isFinite(mi)
+  ) {
+    return null;
+  }
+  if (mo < 1 || mo > 12) return null;
+  if (d < 1 || d > 31) return null;
+  if (h < 0 || h > 23) return null;
+  if (mi < 0 || mi > 59) return null;
+  const dt = new Date(y, mo - 1, d, h, mi, 0, 0);
+  // Round-trip check: catches Feb 31 → Mar 3 normalization, year overflow, etc.
+  if (
+    dt.getFullYear() !== y ||
+    dt.getMonth() !== mo - 1 ||
+    dt.getDate() !== d ||
+    dt.getHours() !== h ||
+    dt.getMinutes() !== mi
+  ) {
+    return null;
+  }
+  const ms = dt.getTime();
+  return Number.isFinite(ms) ? ms : null;
+}


### PR DESCRIPTION
## Summary
- Optional **Start Date** / **End Date + Time** on scheduled announcements with auto-deactivate, so admins don't have to remember to flip `isActive` off after the event.
- Live admin status badge: **Active now** / **Scheduled** / **Expired** / **Inactive** — derived from the schedule window, ticks every 30 s.
- Embed config gains a **Start at** (min + sec) field for YouTube announcements; new `applyStartAt` URL helper appends `&start=N`. Drive is intentionally excluded (its `/preview` iframe ignores seek params — same rationale as the existing `applyAutoplay` exclusion).

Schema additions are purely additive (`scheduledActivationDate`, `scheduledEndDate`, `scheduledEndTime`, `EmbedConfig.startAtSeconds`); legacy time-only announcements keep working via a fallback path in `isWithinActiveWindow`.

## Test plan
- [x] `pnpm run type-check` — clean
- [x] `pnpm run lint` — 0 warnings (CI enforces `--max-warnings 0`)
- [x] `pnpm run format:check` — clean
- [x] `pnpm run test` — all 1845 tests pass; new `applyStartAt.test.ts` (14 cases) and 8 new date-window cases in `AnnouncementOverlay.test.tsx`
- [x] Live preview: scheduled radio reveals Start Date + Start Time; Auto-deactivate toggle reveals End Date + End Time; end-before-start save attempt fires `End date/time must be after the start date/time.` validation toast; Embed editor shows Start-at min+sec only for YouTube URLs (Drive URL hides them); runtime call confirms `&start=N` is appended to YouTube embed URLs and Drive URLs are untouched.

## Out of scope (v2 follow-ups)
- **Drive video start-at** — would require swapping Drive embeds from iframe-`/preview` to native HTML5 `<video>` against the canonical `videoplayback` URL. Tradeoffs around public sharing, Drive player chrome, CORS — separate effort.
- **Multiple discrete dates** ("active May 5, May 8, May 12 only"). Single contiguous window covers the most common use case.
- **Replacing `dismissalType: 'scheduled'`** — kept for backwards compat; the per-user recurring auto-dismiss and the new global auto-deactivate coexist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)