### PR TITLE
refactor(time-tool): pin ±time buttons to widget corners

### DIFF
--- a/components/widgets/TimeTool/TimeToolWidget.tsx
+++ b/components/widgets/TimeTool/TimeToolWidget.tsx
@@ -50,21 +50,29 @@ const AdjustButton: React.FC<{
       onPointerCancel={handlers.onPointerCancel}
       onPointerLeave={handlers.onPointerLeave}
       onKeyDown={handlers.onKeyDown}
-      className={`flex items-center justify-center rounded-2xl bg-slate-200/40 text-slate-500 transition-all select-none touch-none active:scale-95 hover:bg-slate-300/60 hover:text-slate-700 ${
+      className={`flex flex-col items-center justify-center rounded-2xl bg-slate-200/40 text-slate-500 transition-all select-none touch-none active:scale-95 hover:bg-slate-300/60 hover:text-slate-700 ${
         disabled ? 'opacity-30 cursor-not-allowed' : ''
       }`}
       style={{
         width: 'min(56px, 14cqmin)',
         height: 'min(56px, 14cqmin)',
+        padding: 'min(4px, 1cqmin)',
+        gap: 'min(2px, 0.5cqmin)',
       }}
     >
       <Icon
         style={{
-          width: 'min(32px, 9cqmin)',
-          height: 'min(32px, 9cqmin)',
+          width: 'min(28px, 8cqmin)',
+          height: 'min(28px, 8cqmin)',
         }}
         strokeWidth={3}
       />
+      <span
+        className="font-black tabular-nums leading-none"
+        style={{ fontSize: 'min(11px, 3.5cqmin)' }}
+      >
+        {presetLabel(step)}
+      </span>
     </button>
   );
 };

--- a/components/widgets/TimeTool/TimeToolWidget.tsx
+++ b/components/widgets/TimeTool/TimeToolWidget.tsx
@@ -50,29 +50,21 @@ const AdjustButton: React.FC<{
       onPointerCancel={handlers.onPointerCancel}
       onPointerLeave={handlers.onPointerLeave}
       onKeyDown={handlers.onKeyDown}
-      className={`flex flex-col items-center justify-center rounded-2xl bg-slate-200/40 text-slate-500 transition-all select-none touch-none active:scale-95 hover:bg-slate-300/60 hover:text-slate-700 ${
+      className={`flex items-center justify-center rounded-2xl bg-slate-200/40 text-slate-500 transition-all select-none touch-none active:scale-95 hover:bg-slate-300/60 hover:text-slate-700 ${
         disabled ? 'opacity-30 cursor-not-allowed' : ''
       }`}
       style={{
         width: 'min(56px, 14cqmin)',
         height: 'min(56px, 14cqmin)',
-        padding: 'min(4px, 1cqmin)',
-        gap: 'min(2px, 0.5cqmin)',
       }}
     >
       <Icon
         style={{
-          width: 'min(28px, 8cqmin)',
-          height: 'min(28px, 8cqmin)',
+          width: 'min(32px, 9cqmin)',
+          height: 'min(32px, 9cqmin)',
         }}
         strokeWidth={3}
       />
-      <span
-        className="font-black tabular-nums leading-none"
-        style={{ fontSize: 'min(11px, 3.5cqmin)' }}
-      >
-        {presetLabel(step)}
-      </span>
     </button>
   );
 };
@@ -467,96 +459,109 @@ export const TimeToolWidget: React.FC<{ widget: WidgetData }> = ({
                   </div>
                 )}
 
+                {/* Adjust buttons pinned to widget corners (active timer only) */}
+                {showAdjustControls && (
+                  <div
+                    className="absolute z-20"
+                    style={{
+                      top: 'min(10px, 2.5cqmin)',
+                      left: 'min(10px, 2.5cqmin)',
+                    }}
+                  >
+                    <AdjustButton
+                      sign={-1}
+                      step={adjustStepSeconds}
+                      disabled={displayTime <= 0}
+                      ariaLabel={t('widgets.timeTool.subtractTime')}
+                      onAdjust={adjustTime}
+                    />
+                  </div>
+                )}
+                {showAdjustControls && (
+                  <div
+                    className="absolute z-20"
+                    style={{
+                      top: 'min(10px, 2.5cqmin)',
+                      right: 'min(10px, 2.5cqmin)',
+                    }}
+                  >
+                    <AdjustButton
+                      sign={1}
+                      step={adjustStepSeconds}
+                      ariaLabel={t('widgets.timeTool.addTime')}
+                      onAdjust={adjustTime}
+                    />
+                  </div>
+                )}
+
                 {/* The core centering unit: Time + Absolute Controls */}
                 <div className="relative flex flex-col items-center justify-center">
-                  <div
-                    className="flex items-center justify-center"
-                    style={{ gap: 'min(12px, 3cqmin)' }}
+                  <button
+                    onClick={() => {
+                      if (!isRunning && mode === 'timer') setIsEditing(true);
+                    }}
+                    disabled={isRunning || mode !== 'timer'}
+                    className={`relative z-10 flex items-baseline leading-none transition-all ${getFontClass()} ${getStyleClasses()} ${
+                      !isRunning && mode === 'timer'
+                        ? 'cursor-pointer hover:scale-105 active:scale-95'
+                        : 'cursor-default'
+                    }`}
+                    style={{
+                      fontSize: isVisual
+                        ? 'min(22cqmin, 12rem)'
+                        : mode === 'stopwatch'
+                          ? 'min(55cqh, 18cqw)'
+                          : 'min(55cqh, 25cqw)',
+                      color: timeColor,
+                      textShadow: glow
+                        ? `0 0 0.1em ${timeColor}, 0 0 0.25em ${timeColor}66`
+                        : 'none',
+                    }}
                   >
-                    {showAdjustControls && (
-                      <AdjustButton
-                        sign={-1}
-                        step={adjustStepSeconds}
-                        disabled={displayTime <= 0}
-                        ariaLabel={t('widgets.timeTool.subtractTime')}
-                        onAdjust={adjustTime}
-                      />
-                    )}
-                    <button
-                      onClick={() => {
-                        if (!isRunning && mode === 'timer') setIsEditing(true);
-                      }}
-                      disabled={isRunning || mode !== 'timer'}
-                      className={`relative z-10 flex items-baseline leading-none transition-all ${getFontClass()} ${getStyleClasses()} ${
-                        !isRunning && mode === 'timer'
-                          ? 'cursor-pointer hover:scale-105 active:scale-95'
-                          : 'cursor-default'
-                      }`}
-                      style={{
-                        fontSize: isVisual
-                          ? 'min(22cqmin, 12rem)'
-                          : mode === 'stopwatch'
-                            ? 'min(55cqh, 18cqw)'
-                            : 'min(55cqh, 25cqw)',
-                        color: timeColor,
-                        textShadow: glow
-                          ? `0 0 0.1em ${timeColor}, 0 0 0.25em ${timeColor}66`
-                          : 'none',
-                      }}
-                    >
-                      {clockStyle === 'lcd' && !isVisual && (
-                        <div
-                          className="absolute opacity-5 pointer-events-none select-none flex"
-                          aria-hidden="true"
-                          role="presentation"
-                        >
-                          <span>88</span>
-                          <span className="mx-[0.25em]">:</span>
-                          <span>88</span>
-                          {mode === 'stopwatch' && (
-                            <>
-                              <span className="opacity-30 mx-[0.05em]">.</span>
-                              <span>8</span>
-                            </>
-                          )}
-                        </div>
-                      )}
-
-                      {/* Minutes and colon (shared between timer/stopwatch) */}
-                      <span>{timeParts.mins}</span>
-                      <span
-                        className={`${clockStyle === 'minimal' ? '' : 'animate-pulse'} mx-[0.1em] opacity-30`}
+                    {clockStyle === 'lcd' && !isVisual && (
+                      <div
+                        className="absolute opacity-5 pointer-events-none select-none flex"
+                        aria-hidden="true"
+                        role="presentation"
                       >
-                        :
-                      </span>
-                      <span>{timeParts.secs}</span>
-                      {/* Tenths digit (stopwatch only) */}
-                      {mode === 'stopwatch' && (
-                        <>
-                          <span
-                            className="opacity-30 mx-[0.05em]"
-                            style={{ fontSize: '0.5em' }}
-                          >
-                            .
-                          </span>
-                          <span
-                            className="opacity-60"
-                            style={{ fontSize: '0.5em' }}
-                          >
-                            {timeParts.tenths}
-                          </span>
-                        </>
-                      )}
-                    </button>
-                    {showAdjustControls && (
-                      <AdjustButton
-                        sign={1}
-                        step={adjustStepSeconds}
-                        ariaLabel={t('widgets.timeTool.addTime')}
-                        onAdjust={adjustTime}
-                      />
+                        <span>88</span>
+                        <span className="mx-[0.25em]">:</span>
+                        <span>88</span>
+                        {mode === 'stopwatch' && (
+                          <>
+                            <span className="opacity-30 mx-[0.05em]">.</span>
+                            <span>8</span>
+                          </>
+                        )}
+                      </div>
                     )}
-                  </div>
+
+                    {/* Minutes and colon (shared between timer/stopwatch) */}
+                    <span>{timeParts.mins}</span>
+                    <span
+                      className={`${clockStyle === 'minimal' ? '' : 'animate-pulse'} mx-[0.1em] opacity-30`}
+                    >
+                      :
+                    </span>
+                    <span>{timeParts.secs}</span>
+                    {/* Tenths digit (stopwatch only) */}
+                    {mode === 'stopwatch' && (
+                      <>
+                        <span
+                          className="opacity-30 mx-[0.05em]"
+                          style={{ fontSize: '0.5em' }}
+                        >
+                          .
+                        </span>
+                        <span
+                          className="opacity-60"
+                          style={{ fontSize: '0.5em' }}
+                        >
+                          {timeParts.tenths}
+                        </span>
+                      </>
+                    )}
+                  </button>
 
                   {/* Square Controls - Positioned below the centerline without pushing it */}
                   <div

--- a/components/widgets/TimeTool/TimeToolWidget.tsx
+++ b/components/widgets/TimeTool/TimeToolWidget.tsx
@@ -461,37 +461,37 @@ export const TimeToolWidget: React.FC<{ widget: WidgetData }> = ({
 
                 {/* Adjust buttons pinned to widget corners (active timer only) */}
                 {showAdjustControls && (
-                  <div
-                    className="absolute z-20"
-                    style={{
-                      top: 'min(10px, 2.5cqmin)',
-                      left: 'min(10px, 2.5cqmin)',
-                    }}
-                  >
-                    <AdjustButton
-                      sign={-1}
-                      step={adjustStepSeconds}
-                      disabled={displayTime <= 0}
-                      ariaLabel={t('widgets.timeTool.subtractTime')}
-                      onAdjust={adjustTime}
-                    />
-                  </div>
-                )}
-                {showAdjustControls && (
-                  <div
-                    className="absolute z-20"
-                    style={{
-                      top: 'min(10px, 2.5cqmin)',
-                      right: 'min(10px, 2.5cqmin)',
-                    }}
-                  >
-                    <AdjustButton
-                      sign={1}
-                      step={adjustStepSeconds}
-                      ariaLabel={t('widgets.timeTool.addTime')}
-                      onAdjust={adjustTime}
-                    />
-                  </div>
+                  <>
+                    <div
+                      className="absolute z-20"
+                      style={{
+                        top: 'min(10px, 2.5cqmin)',
+                        left: 'min(10px, 2.5cqmin)',
+                      }}
+                    >
+                      <AdjustButton
+                        sign={-1}
+                        step={adjustStepSeconds}
+                        disabled={displayTime <= 0}
+                        ariaLabel={t('widgets.timeTool.subtractTime')}
+                        onAdjust={adjustTime}
+                      />
+                    </div>
+                    <div
+                      className="absolute z-20"
+                      style={{
+                        top: 'min(10px, 2.5cqmin)',
+                        right: 'min(10px, 2.5cqmin)',
+                      }}
+                    >
+                      <AdjustButton
+                        sign={1}
+                        step={adjustStepSeconds}
+                        ariaLabel={t('widgets.timeTool.addTime')}
+                        onAdjust={adjustTime}
+                      />
+                    </div>
+                  </>
                 )}
 
                 {/* The core centering unit: Time + Absolute Controls */}


### PR DESCRIPTION
## Summary

- Moves the increment/decrement buttons out of the same flex row as the time display so the layout no longer shifts as digits change width (e.g. crossing the 60s boundary, where the rendered text width changes by ~12px and used to push the inline buttons around).
- `−` is now pinned to the top-left corner, `+` to the top-right corner, both at `min(10px, 2.5cqmin)` inset. Time returns to a clean, centered block.
- Drops the stacked step-magnitude label (`"1m"` etc.) from inside each button — the icon fills the corner cleanly and the step amount is configured via the settings panel.

No behavioral changes: `useHoldAccelerate` press-and-hold ramp, `adjustTime` math, keyboard handlers, aria labels, and the `showAdjustControls` gating (timer mode + active state) are all preserved.

## Test plan

- [x] `pnpm run type-check`
- [x] `pnpm exec eslint components/widgets/TimeTool/TimeToolWidget.tsx --max-warnings 0`
- [x] Idle / fresh-setup state hides ± buttons (no `data-aria-label="Add time"`)
- [x] Running timer shows ± buttons at top-left and top-right at `(10.94, 10.94)` from each edge on the default 420×400 widget
- [x] `+` increments by 60s; time text width changes from 317.98→306.06px while corner button positions stay locked
- [x] `−` walks `10:00 → 09:00 → ... → 00:00` with no layout disturbance crossing the 60s boundary
- [x] `−` disables (opacity-30, `disabled` attribute) at `00:00`
- [x] At 200×200 widget size, buttons scale to ~28px with ~6px corner inset (`min(56, 14cqmin)` / `min(10, 2.5cqmin)` math holds)
- [x] Stopwatch mode hides ± buttons (gated by `mode === 'timer'`)
- [ ] Manual smoke check on Visual mode (progress ring) and LCD/Minimal clock styles
- [ ] Manual press-and-hold ramp + keyboard (Space/Enter) check

🤖 Generated with [Claude Code](https://claude.com/claude-code)