### PR TITLE
🎨 TimeTool: relocate adjust buttons & clean up step range

### DIFF
--- a/components/widgets/TimeTool/Settings.tsx
+++ b/components/widgets/TimeTool/Settings.tsx
@@ -16,8 +16,8 @@ import {
   PlusSquare,
 } from 'lucide-react';
 
-const ADJUST_STEP_MIN = 1;
-const ADJUST_STEP_MAX = 600;
+const ADJUST_STEP_MIN = 5;
+const ADJUST_STEP_MAX = 60;
 const ADJUST_STEP_DEFAULT = 60;
 
 const clampAdjustStep = (n: number) =>
@@ -176,6 +176,7 @@ export const TimeToolSettings: React.FC<{ widget: WidgetData }> = ({
               type="number"
               min={ADJUST_STEP_MIN}
               max={ADJUST_STEP_MAX}
+              step={5}
               value={config.adjustStepSeconds ?? ADJUST_STEP_DEFAULT}
               onChange={(e) => {
                 const parsed = parseInt(e.target.value, 10);

--- a/components/widgets/TimeTool/TimeToolWidget.test.tsx
+++ b/components/widgets/TimeTool/TimeToolWidget.test.tsx
@@ -329,6 +329,68 @@ describe('TimeToolWidget', () => {
       expect(updatedConfig.startTime).not.toBe(startTime);
     });
 
+    it('clamps a legacy out-of-range adjustStepSeconds (>60) down to 60 on tap', () => {
+      const widget = createWidget({
+        mode: 'timer',
+        isRunning: false,
+        duration: 600,
+        elapsedTime: 300,
+        adjustStepSeconds: 80, // legacy value above the new max
+      });
+      renderWidget(widget);
+
+      fireEvent.pointerDown(screen.getByLabelText('Add time'));
+      fireEvent.pointerUp(screen.getByLabelText('Add time'));
+
+      // Should bump by the clamped 60s (300 + 60 = 360), not the stored 80s.
+      expect(mockUpdateWidget).toHaveBeenCalledWith(
+        'timetool-1',
+        expect.objectContaining({
+          config: expect.objectContaining({
+            elapsedTime: 360,
+          }) as unknown,
+        })
+      );
+    });
+
+    it('clamps a legacy out-of-range adjustStepSeconds (<5) up to 5 on tap', () => {
+      const widget = createWidget({
+        mode: 'timer',
+        isRunning: false,
+        duration: 600,
+        elapsedTime: 300,
+        adjustStepSeconds: 1, // legacy value below the new min
+      });
+      renderWidget(widget);
+
+      fireEvent.pointerDown(screen.getByLabelText('Subtract time'));
+      fireEvent.pointerUp(screen.getByLabelText('Subtract time'));
+
+      // Should drop by the clamped 5s (300 - 5 = 295), not the stored 1s.
+      expect(mockUpdateWidget).toHaveBeenCalledWith(
+        'timetool-1',
+        expect.objectContaining({
+          config: expect.objectContaining({
+            elapsedTime: 295,
+          }) as unknown,
+        })
+      );
+    });
+
+    it('renders the clamped step label, not the legacy stored value', () => {
+      const widget = createWidget({
+        mode: 'timer',
+        isRunning: true,
+        duration: 600,
+        elapsedTime: 300,
+        adjustStepSeconds: 80, // would render as "1.333…m" without the clamp
+      });
+      renderWidget(widget);
+
+      expect(screen.getByLabelText('Add time')).toHaveTextContent('1m');
+      expect(screen.getByLabelText('Subtract time')).toHaveTextContent('1m');
+    });
+
     it('adjusting + past original duration bumps duration to match', () => {
       const widget = createWidget({
         mode: 'timer',

--- a/components/widgets/TimeTool/TimeToolWidget.test.tsx
+++ b/components/widgets/TimeTool/TimeToolWidget.test.tsx
@@ -335,7 +335,7 @@ describe('TimeToolWidget', () => {
         isRunning: false,
         duration: 60,
         elapsedTime: 30,
-        adjustStepSeconds: 120,
+        adjustStepSeconds: 60,
       });
       renderWidget(widget);
 
@@ -346,8 +346,8 @@ describe('TimeToolWidget', () => {
         'timetool-1',
         expect.objectContaining({
           config: expect.objectContaining({
-            elapsedTime: 150,
-            duration: 150,
+            elapsedTime: 90,
+            duration: 90,
           }) as unknown,
         })
       );
@@ -527,20 +527,18 @@ describe('TimeToolWidget', () => {
     });
   });
 
-  // Corner-pinning regression coverage for PR #1526. jsdom's cssstyle parser
-  // silently drops CSS `min(...)` values when assigned via React's
-  // el.style[prop] = ... path, so we use renderToStaticMarkup to inspect the
-  // raw inline style strings React emits — which is the source of truth for
-  // what the browser will actually see.
-  describe('±adjust button corner positioning (PR #1526)', () => {
+  // Layout coverage for the ±adjust pair. The pair sits in a single absolute
+  // wrapper above the time, mirroring the play/reset pair below
+  // (bottom: 110% in digital style, 120% in visual-ring style). jsdom's
+  // cssstyle parser silently drops CSS `min(...)` values when assigned via
+  // React's el.style[prop] = ... path, so we use renderToStaticMarkup to
+  // inspect the raw inline style strings React emits — the source of truth
+  // for what the browser will actually see.
+  describe('±adjust button placement above the time', () => {
     const renderHtml = (widget: WidgetData): string =>
       renderToStaticMarkup(<TimeToolWidget widget={widget} />);
 
-    // Pulls the immediately-enclosing wrapper <div> for a given aria-labeled
-    // button out of the static markup. The wrapper is the element that owns
-    // the `position: absolute` + corner-inset inline styles.
     const wrapperFor = (html: string, ariaLabel: string): string => {
-      // Walk the markup so we can find the *parent* of the matching button.
       const dom = new DOMParser().parseFromString(html, 'text/html');
       const btn = dom.querySelector(`button[aria-label="${ariaLabel}"]`);
       const wrapper = btn?.parentElement;
@@ -550,7 +548,7 @@ describe('TimeToolWidget', () => {
       return wrapper.outerHTML;
     };
 
-    it('renders the − button inside an absolute wrapper pinned to top-left', () => {
+    it('renders both buttons inside one absolute wrapper anchored from the bottom', () => {
       const widget = createWidget({
         mode: 'timer',
         isRunning: true,
@@ -560,31 +558,16 @@ describe('TimeToolWidget', () => {
       const html = renderHtml(widget);
       const wrapperHtml = wrapperFor(html, 'Subtract time');
 
-      // Tailwind class applies position:absolute via CSS; verify it's wired
       expect(wrapperHtml).toMatch(/class="[^"]*\babsolute\b[^"]*"/);
-      // Inline style fields verify corner pinning
-      expect(wrapperHtml).toContain('top:');
-      expect(wrapperHtml).toContain('left:');
-      expect(wrapperHtml).not.toContain('right:');
-    });
-
-    it('renders the + button inside an absolute wrapper pinned to top-right', () => {
-      const widget = createWidget({
-        mode: 'timer',
-        isRunning: true,
-        duration: 300,
-        elapsedTime: 240,
-      });
-      const html = renderHtml(widget);
-      const wrapperHtml = wrapperFor(html, 'Add time');
-
-      expect(wrapperHtml).toMatch(/class="[^"]*\babsolute\b[^"]*"/);
-      expect(wrapperHtml).toContain('top:');
-      expect(wrapperHtml).toContain('right:');
+      // Anchored above the time via `bottom:`, mirroring play/reset's `top:`.
+      expect(wrapperHtml).toContain('bottom:');
+      // Should not be corner-pinned anymore.
       expect(wrapperHtml).not.toContain('left:');
+      expect(wrapperHtml).not.toContain('right:');
+      expect(wrapperHtml).not.toContain('top:');
     });
 
-    it('the − and + buttons live in distinct wrappers (not a shared row)', () => {
+    it('the − and + buttons share the same wrapper (single centered pair)', () => {
       const widget = createWidget({
         mode: 'timer',
         isRunning: true,
@@ -595,13 +578,13 @@ describe('TimeToolWidget', () => {
 
       const subBtn = screen.getByLabelText('Subtract time');
       const addBtn = screen.getByLabelText('Add time');
-      // PR #1526 explicitly moves them out of a shared flex container so
-      // changing time text width can't shift either button.
-      expect(subBtn.parentElement).not.toBe(addBtn.parentElement);
+      // Buttons are now siblings inside a flex pair; that container also
+      // hosts the gap that separates them.
+      expect(subBtn.parentElement).toBe(addBtn.parentElement);
     });
 
     it.each([['modern'], ['lcd'], ['minimal']] as const)(
-      'pins both corners in clockStyle="%s"',
+      'uses bottom:110% in digital clockStyle="%s"',
       (clockStyle) => {
         const widget = createWidget({
           mode: 'timer',
@@ -611,18 +594,13 @@ describe('TimeToolWidget', () => {
           clockStyle,
         });
         const html = renderHtml(widget);
+        const wrap = wrapperFor(html, 'Subtract time');
 
-        const subWrap = wrapperFor(html, 'Subtract time');
-        expect(subWrap).toContain('top:');
-        expect(subWrap).toContain('left:');
-
-        const addWrap = wrapperFor(html, 'Add time');
-        expect(addWrap).toContain('top:');
-        expect(addWrap).toContain('right:');
+        expect(wrap).toContain('bottom:110%');
       }
     );
 
-    it('pins both corners when visualType="visual" (progress ring on)', () => {
+    it('uses bottom:120% when visualType="visual" (progress ring on)', () => {
       const widget = createWidget({
         mode: 'timer',
         isRunning: true,
@@ -631,14 +609,9 @@ describe('TimeToolWidget', () => {
         visualType: 'visual',
       });
       const html = renderHtml(widget);
+      const wrap = wrapperFor(html, 'Subtract time');
 
-      const subWrap = wrapperFor(html, 'Subtract time');
-      expect(subWrap).toContain('top:');
-      expect(subWrap).toContain('left:');
-
-      const addWrap = wrapperFor(html, 'Add time');
-      expect(addWrap).toContain('top:');
-      expect(addWrap).toContain('right:');
+      expect(wrap).toContain('bottom:120%');
     });
   });
 });

--- a/components/widgets/TimeTool/TimeToolWidget.tsx
+++ b/components/widgets/TimeTool/TimeToolWidget.tsx
@@ -361,6 +361,8 @@ export const TimeToolWidget: React.FC<{ widget: WidgetData }> = ({
     adjustStepSeconds = DEFAULT_ADJUST_STEP_SECONDS,
   } = config;
 
+  const effectiveAdjustStep = Math.max(5, Math.min(60, adjustStepSeconds));
+
   // Show ±buttons once a timer has started or been adjusted off its initial duration.
   // Hides during the fresh-setup state (where the keypad handles input) and in stopwatch mode.
   const showAdjustControls =
@@ -467,43 +469,32 @@ export const TimeToolWidget: React.FC<{ widget: WidgetData }> = ({
                   </div>
                 )}
 
-                {/* Adjust buttons pinned to widget corners (active timer only) */}
-                {showAdjustControls && (
-                  <>
+                {/* The core centering unit: Time + Absolute Controls */}
+                <div className="relative flex flex-col items-center justify-center">
+                  {/* Adjust controls — mirror of play/reset, above the time */}
+                  {showAdjustControls && (
                     <div
-                      className="absolute z-20"
+                      className="absolute z-10 flex items-center justify-center"
                       style={{
-                        top: 'min(10px, 2.5cqmin)',
-                        left: 'min(10px, 2.5cqmin)',
+                        bottom: isVisual ? '120%' : '110%',
+                        gap: 'min(12px, 3cqmin)',
                       }}
                     >
                       <AdjustButton
                         sign={-1}
-                        step={adjustStepSeconds}
+                        step={effectiveAdjustStep}
                         disabled={displayTime <= 0}
                         ariaLabel={t('widgets.timeTool.subtractTime')}
                         onAdjust={adjustTime}
                       />
-                    </div>
-                    <div
-                      className="absolute z-20"
-                      style={{
-                        top: 'min(10px, 2.5cqmin)',
-                        right: 'min(10px, 2.5cqmin)',
-                      }}
-                    >
                       <AdjustButton
                         sign={1}
-                        step={adjustStepSeconds}
+                        step={effectiveAdjustStep}
                         ariaLabel={t('widgets.timeTool.addTime')}
                         onAdjust={adjustTime}
                       />
                     </div>
-                  </>
-                )}
-
-                {/* The core centering unit: Time + Absolute Controls */}
-                <div className="relative flex flex-col items-center justify-center">
+                  )}
                   <button
                     onClick={() => {
                       if (!isRunning && mode === 'timer') setIsEditing(true);


### PR DESCRIPTION
## Summary

- **Relocate the on-face +/- buttons.** The corner-pinned `+`/`−` adjust buttons made the Time Tool feel cluttered, forced extra horizontal padding around the time, and sat awkwardly *outside* the ring on the visual-ring style. They now live in a single centered pair **above the time**, mirroring the play/reset pair below — symmetric, balanced, and inside the ring.
- **Clean up the Adjust Step setting.** Range was 1–600s in 1s increments, which produced ugly decimal-minute labels for non-multiples of 60 (e.g. `80s` → `"1.333333…m"`). Now constrained to **5–60s in 5s increments** (default unchanged at 60). Anything bigger is better expressed by quick taps on the on-face buttons.
- **Defensive render-time clamp** on `adjustStepSeconds` so any legacy dashboards with stored values outside the new range still display cleanly (`80` → `"1m"`, `1` → `"5s"`).

## Test plan

- [ ] Add a Time Tool widget — confirm `+`/`−` are hidden in the idle state, time display is uncluttered.
- [ ] Start the timer (or adjust off duration) — `+`/`−` appear above, play/reset below, visually symmetric.
- [ ] Switch to the visual-ring clock style — both pairs sit *inside* the ring at matching offsets.
- [ ] Resize the widget small/large — buttons scale via container queries, never overflow the ring.
- [ ] Open settings → Adjust Step — spinner steps by 5, refuses values <5 or >60.
- [ ] Force a stale stored value (`adjustStepSeconds: 80`) — on-face label reads `"1m"`, not `"1.333…m"`.
- [ ] `pnpm run lint` and `pnpm run type-check` clean (verified locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)