### PR TITLE
✨ Add duplicate button to admin announcements

### DIFF
--- a/components/admin/Announcements/Widget.tsx
+++ b/components/admin/Announcements/Widget.tsx
@@ -12,6 +12,7 @@ import {
   Plus,
   Trash2,
   Edit2,
+  Copy,
   Radio,
   X,
   Clock,
@@ -895,6 +896,29 @@ export const AnnouncementsManager: React.FC = () => {
     }
   };
 
+  const handleDuplicate = async (a: Announcement) => {
+    try {
+      const now = Date.now();
+      const newId = `announcement-${crypto.randomUUID()}`;
+      const { id: _id, ...rest } = a;
+      void _id;
+      const payload: Announcement = {
+        ...rest,
+        id: newId,
+        name: `${a.name} (Copy)`,
+        isActive: false,
+        activatedAt: null,
+        createdAt: now,
+        updatedAt: now,
+        createdBy: user?.email ?? 'admin',
+      };
+      await setDoc(doc(db, 'announcements', newId), payload);
+    } catch (err) {
+      console.error('[AnnouncementsManager] Duplicate error:', err);
+      addToast('Failed to duplicate announcement.', 'error');
+    }
+  };
+
   const handleToggleActive = async (a: Announcement) => {
     const newActive = !a.isActive;
     try {
@@ -1068,6 +1092,13 @@ export const AnnouncementsManager: React.FC = () => {
                       className="p-2 text-slate-500 hover:text-brand-blue-primary hover:bg-blue-50 rounded-lg transition-colors"
                     >
                       <Edit2 className="w-4 h-4" />
+                    </button>
+                    <button
+                      onClick={() => void handleDuplicate(a)}
+                      title="Duplicate announcement"
+                      className="p-2 text-slate-500 hover:text-brand-blue-primary hover:bg-blue-50 rounded-lg transition-colors"
+                    >
+                      <Copy className="w-4 h-4" />
                     </button>
                     {confirmDeleteId === a.id ? (
                       <div className="flex items-center gap-1">

--- a/components/admin/Announcements/Widget.tsx
+++ b/components/admin/Announcements/Widget.tsx
@@ -901,7 +901,6 @@ export const AnnouncementsManager: React.FC = () => {
       const now = Date.now();
       const newId = `announcement-${crypto.randomUUID()}`;
       const { id: _id, ...rest } = a;
-      void _id;
       const payload: Announcement = {
         ...rest,
         id: newId,


### PR DESCRIPTION
## Summary
- Adds a Copy icon button between Edit and Delete in each row of Admin Settings → Announcements.
- Clicking it writes a new Firestore announcement that mirrors the source (widget type/config/size, scheduled times, dismissal settings, target buildings/users) with safety overrides: name suffixed ` (Copy)`, `isActive: false`, `activatedAt: null`, fresh `createdAt`/`updatedAt`/`createdBy`.
- Reuses the existing `setDoc` create pattern; no new types, hooks, or rules touched.

## Test plan
- [ ] `pnpm run type-check` passes
- [ ] `pnpm run lint` passes
- [ ] In the admin panel, click Copy on an existing announcement and confirm a new row appears with `(Copy)` suffix, status Inactive, and matching widget/scheduling/targeting
- [ ] Open the duplicate via Edit and verify all config fields match the original
- [ ] Activate the duplicate and confirm it behaves like the original
- [ ] Delete the duplicate to clean up

🤖 Generated with [Claude Code](https://claude.com/claude-code)