### PR TITLE
🎨 TimeTool: inline control row & reclaim wasted space

### DIFF
--- a/components/widgets/TimeTool/TimeToolWidget.test.tsx
+++ b/components/widgets/TimeTool/TimeToolWidget.test.tsx
@@ -640,6 +640,8 @@ describe('TimeToolWidget', () => {
       renderWidget(widget);
 
       const subBtn = screen.getByLabelText('Subtract time');
+      // Timer is running, so play/pause shows the Pause label.
+      const pauseBtn = screen.getByLabelText('Pause');
       const resetBtn = screen.getByLabelText('Reset');
       const addBtn = screen.getByLabelText('Add time');
 
@@ -648,18 +650,15 @@ describe('TimeToolWidget', () => {
       if (!wrapper) {
         throw new Error('subtract button has no parent wrapper');
       }
+      expect(pauseBtn.parentElement).toBe(wrapper);
       expect(resetBtn.parentElement).toBe(wrapper);
       expect(addBtn.parentElement).toBe(wrapper);
 
-      // DOM order: −, play/pause, reset, +. Play/pause has no accessible
-      // label (its only content is an icon), so identify it positionally
-      // as the wrapper's second child.
+      // DOM order: −, play/pause, reset, +.
       const children = Array.from(wrapper.children);
       expect(children).toHaveLength(4);
       expect(children[0]).toBe(subBtn);
-      expect(children[1].tagName).toBe('BUTTON');
-      expect(children[1]).not.toBe(resetBtn);
-      expect(children[1]).not.toBe(addBtn);
+      expect(children[1]).toBe(pauseBtn);
       expect(children[2]).toBe(resetBtn);
       expect(children[3]).toBe(addBtn);
     });

--- a/components/widgets/TimeTool/TimeToolWidget.test.tsx
+++ b/components/widgets/TimeTool/TimeToolWidget.test.tsx
@@ -589,14 +589,14 @@ describe('TimeToolWidget', () => {
     });
   });
 
-  // Layout coverage for the ±adjust pair. The pair sits in a single absolute
-  // wrapper above the time, mirroring the play/reset pair below
-  // (bottom: 110% in digital style, 120% in visual-ring style). jsdom's
-  // cssstyle parser silently drops CSS `min(...)` values when assigned via
-  // React's el.style[prop] = ... path, so we use renderToStaticMarkup to
-  // inspect the raw inline style strings React emits — the source of truth
-  // for what the browser will actually see.
-  describe('±adjust button placement above the time', () => {
+  // Layout coverage for the unified control row. All four buttons —
+  // `[− adjust] [play/pause] [reset] [+ adjust]` — share a single absolute
+  // wrapper anchored below the time (top: 110% in digital style, 120% in
+  // visual-ring style). jsdom's cssstyle parser silently drops CSS `min(...)`
+  // values when assigned via React's el.style[prop] = ... path, so we use
+  // renderToStaticMarkup to inspect the raw inline style strings React emits —
+  // the source of truth for what the browser will actually see.
+  describe('control row placement below the time', () => {
     const renderHtml = (widget: WidgetData): string =>
       renderToStaticMarkup(<TimeToolWidget widget={widget} />);
 
@@ -610,7 +610,7 @@ describe('TimeToolWidget', () => {
       return wrapper.outerHTML;
     };
 
-    it('renders both buttons inside one absolute wrapper anchored from the bottom', () => {
+    it('renders all four buttons inside one absolute wrapper anchored from the top', () => {
       const widget = createWidget({
         mode: 'timer',
         isRunning: true,
@@ -621,15 +621,16 @@ describe('TimeToolWidget', () => {
       const wrapperHtml = wrapperFor(html, 'Subtract time');
 
       expect(wrapperHtml).toMatch(/class="[^"]*\babsolute\b[^"]*"/);
-      // Anchored above the time via `bottom:`, mirroring play/reset's `top:`.
-      expect(wrapperHtml).toContain('bottom:');
-      // Should not be corner-pinned anymore.
+      // Anchored below the time via `top:`.
+      expect(wrapperHtml).toContain('top:');
+      // Should not be corner-pinned, and should not also be anchored from the
+      // bottom (which would indicate the legacy two-row layout).
+      expect(wrapperHtml).not.toContain('bottom:');
       expect(wrapperHtml).not.toContain('left:');
       expect(wrapperHtml).not.toContain('right:');
-      expect(wrapperHtml).not.toContain('top:');
     });
 
-    it('the − and + buttons share the same wrapper (single centered pair)', () => {
+    it('all four buttons share the same wrapper in [−, play/pause, reset, +] order', () => {
       const widget = createWidget({
         mode: 'timer',
         isRunning: true,
@@ -639,14 +640,32 @@ describe('TimeToolWidget', () => {
       renderWidget(widget);
 
       const subBtn = screen.getByLabelText('Subtract time');
+      const resetBtn = screen.getByLabelText('Reset');
       const addBtn = screen.getByLabelText('Add time');
-      // Buttons are now siblings inside a flex pair; that container also
-      // hosts the gap that separates them.
-      expect(subBtn.parentElement).toBe(addBtn.parentElement);
+
+      // All four siblings inside the same flex row.
+      const wrapper = subBtn.parentElement;
+      if (!wrapper) {
+        throw new Error('subtract button has no parent wrapper');
+      }
+      expect(resetBtn.parentElement).toBe(wrapper);
+      expect(addBtn.parentElement).toBe(wrapper);
+
+      // DOM order: −, play/pause, reset, +. Play/pause has no accessible
+      // label (its only content is an icon), so identify it positionally
+      // as the wrapper's second child.
+      const children = Array.from(wrapper.children);
+      expect(children).toHaveLength(4);
+      expect(children[0]).toBe(subBtn);
+      expect(children[1].tagName).toBe('BUTTON');
+      expect(children[1]).not.toBe(resetBtn);
+      expect(children[1]).not.toBe(addBtn);
+      expect(children[2]).toBe(resetBtn);
+      expect(children[3]).toBe(addBtn);
     });
 
     it.each([['modern'], ['lcd'], ['minimal']] as const)(
-      'uses bottom:110% in digital clockStyle="%s"',
+      'uses top:110% in digital clockStyle="%s"',
       (clockStyle) => {
         const widget = createWidget({
           mode: 'timer',
@@ -658,11 +677,11 @@ describe('TimeToolWidget', () => {
         const html = renderHtml(widget);
         const wrap = wrapperFor(html, 'Subtract time');
 
-        expect(wrap).toContain('bottom:110%');
+        expect(wrap).toContain('top:110%');
       }
     );
 
-    it('uses bottom:120% when visualType="visual" (progress ring on)', () => {
+    it('uses top:120% when visualType="visual" (progress ring on)', () => {
       const widget = createWidget({
         mode: 'timer',
         isRunning: true,
@@ -673,7 +692,33 @@ describe('TimeToolWidget', () => {
       const html = renderHtml(widget);
       const wrap = wrapperFor(html, 'Subtract time');
 
-      expect(wrap).toContain('bottom:120%');
+      expect(wrap).toContain('top:120%');
+    });
+
+    it('hides ± adjust buttons in stopwatch mode (only play/reset render)', () => {
+      const widget = createWidget({
+        mode: 'stopwatch',
+        isRunning: true,
+        elapsedTime: 0,
+      });
+      renderWidget(widget);
+
+      expect(screen.queryByLabelText('Subtract time')).not.toBeInTheDocument();
+      expect(screen.queryByLabelText('Add time')).not.toBeInTheDocument();
+      expect(screen.getByLabelText('Reset')).toBeInTheDocument();
+    });
+
+    it('hides ± adjust buttons in fresh-setup state (timer paused at original duration)', () => {
+      const widget = createWidget({
+        mode: 'timer',
+        isRunning: false,
+        duration: 300,
+        elapsedTime: 300, // untouched from initial duration
+      });
+      renderWidget(widget);
+
+      expect(screen.queryByLabelText('Subtract time')).not.toBeInTheDocument();
+      expect(screen.queryByLabelText('Add time')).not.toBeInTheDocument();
     });
   });
 });

--- a/components/widgets/TimeTool/TimeToolWidget.tsx
+++ b/components/widgets/TimeTool/TimeToolWidget.tsx
@@ -561,7 +561,12 @@ export const TimeToolWidget: React.FC<{ widget: WidgetData }> = ({
                           ? () => handleStop()
                           : () => void handleStart()
                       }
-                      className={`flex items-center justify-center rounded-2xl transition-all active:scale-95 shadow-lg ${
+                      aria-label={t(
+                        isRunning
+                          ? 'widgets.timeTool.pause'
+                          : 'widgets.timeTool.play'
+                      )}
+                      className={`flex items-center justify-center rounded-2xl transition-all select-none active:scale-95 shadow-lg ${
                         isRunning
                           ? 'bg-slate-200/60 text-slate-500'
                           : 'bg-brand-blue-primary text-white shadow-brand-blue-primary/20'
@@ -589,12 +594,12 @@ export const TimeToolWidget: React.FC<{ widget: WidgetData }> = ({
                     </button>
                     <button
                       onClick={handleReset}
-                      className="flex items-center justify-center rounded-2xl bg-slate-200/60 text-slate-400 hover:bg-slate-300/70 hover:text-brand-blue-primary transition-all active:scale-95 shadow-sm"
+                      className="flex items-center justify-center rounded-2xl bg-slate-200/60 text-slate-400 hover:bg-slate-300/70 hover:text-brand-blue-primary transition-all select-none active:scale-95 shadow-sm"
                       style={{
                         width: 'min(56px, 14cqmin)',
                         height: 'min(56px, 14cqmin)',
                       }}
-                      aria-label="Reset"
+                      aria-label={t('widgets.timeTool.reset')}
                     >
                       <RotateCcw style={{ width: '50%', height: '50%' }} />
                     </button>

--- a/components/widgets/TimeTool/TimeToolWidget.tsx
+++ b/components/widgets/TimeTool/TimeToolWidget.tsx
@@ -455,8 +455,8 @@ export const TimeToolWidget: React.FC<{ widget: WidgetData }> = ({
                   <div
                     className="absolute pointer-events-none"
                     style={{
-                      width: 'min(90%, 90cqmin)',
-                      height: 'min(90%, 90cqmin)',
+                      width: 'min(96%, 96cqmin)',
+                      height: 'min(96%, 96cqmin)',
                       top: '50%',
                       left: '50%',
                       transform: 'translate(-50%, -50%)',
@@ -471,30 +471,6 @@ export const TimeToolWidget: React.FC<{ widget: WidgetData }> = ({
 
                 {/* The core centering unit: Time + Absolute Controls */}
                 <div className="relative flex flex-col items-center justify-center">
-                  {/* Adjust controls — mirror of play/reset, above the time */}
-                  {showAdjustControls && (
-                    <div
-                      className="absolute z-10 flex items-center justify-center"
-                      style={{
-                        bottom: isVisual ? '120%' : '110%',
-                        gap: 'min(12px, 3cqmin)',
-                      }}
-                    >
-                      <AdjustButton
-                        sign={-1}
-                        step={effectiveAdjustStep}
-                        disabled={displayTime <= 0}
-                        ariaLabel={t('widgets.timeTool.subtractTime')}
-                        onAdjust={adjustTime}
-                      />
-                      <AdjustButton
-                        sign={1}
-                        step={effectiveAdjustStep}
-                        ariaLabel={t('widgets.timeTool.addTime')}
-                        onAdjust={adjustTime}
-                      />
-                    </div>
-                  )}
                   <button
                     onClick={() => {
                       if (!isRunning && mode === 'timer') setIsEditing(true);
@@ -509,8 +485,8 @@ export const TimeToolWidget: React.FC<{ widget: WidgetData }> = ({
                       fontSize: isVisual
                         ? 'min(22cqmin, 12rem)'
                         : mode === 'stopwatch'
-                          ? 'min(55cqh, 18cqw)'
-                          : 'min(55cqh, 25cqw)',
+                          ? 'min(60cqh, 22cqw)'
+                          : 'min(60cqh, 30cqw)',
                       color: timeColor,
                       textShadow: glow
                         ? `0 0 0.1em ${timeColor}, 0 0 0.25em ${timeColor}66`
@@ -562,7 +538,7 @@ export const TimeToolWidget: React.FC<{ widget: WidgetData }> = ({
                     )}
                   </button>
 
-                  {/* Square Controls - Positioned below the centerline without pushing it */}
+                  {/* Control row - Positioned below the centerline without pushing it */}
                   <div
                     className="absolute z-10 flex items-center justify-center"
                     style={{
@@ -570,24 +546,29 @@ export const TimeToolWidget: React.FC<{ widget: WidgetData }> = ({
                       gap: 'min(12px, 3cqmin)',
                     }}
                   >
+                    {showAdjustControls && (
+                      <AdjustButton
+                        sign={-1}
+                        step={effectiveAdjustStep}
+                        disabled={displayTime <= 0}
+                        ariaLabel={t('widgets.timeTool.subtractTime')}
+                        onAdjust={adjustTime}
+                      />
+                    )}
                     <button
                       onClick={
                         isRunning
                           ? () => handleStop()
                           : () => void handleStart()
                       }
-                      className={`aspect-square flex items-center justify-center rounded-2xl transition-all active:scale-95 shadow-lg ${
+                      className={`flex items-center justify-center rounded-2xl transition-all active:scale-95 shadow-lg ${
                         isRunning
                           ? 'bg-slate-200/60 text-slate-500'
                           : 'bg-brand-blue-primary text-white shadow-brand-blue-primary/20'
                       }`}
                       style={{
-                        width: isVisual
-                          ? 'min(15cqmin, 64px)'
-                          : 'min(15cqh, 12cqw)',
-                        height: isVisual
-                          ? 'min(15cqmin, 64px)'
-                          : 'min(15cqh, 12cqw)',
+                        width: 'min(56px, 14cqmin)',
+                        height: 'min(56px, 14cqmin)',
                       }}
                     >
                       {isRunning ? (
@@ -608,19 +589,23 @@ export const TimeToolWidget: React.FC<{ widget: WidgetData }> = ({
                     </button>
                     <button
                       onClick={handleReset}
-                      className="aspect-square flex items-center justify-center rounded-2xl bg-slate-200/60 text-slate-400 hover:bg-slate-300/70 hover:text-brand-blue-primary transition-all active:scale-95 shadow-sm"
+                      className="flex items-center justify-center rounded-2xl bg-slate-200/60 text-slate-400 hover:bg-slate-300/70 hover:text-brand-blue-primary transition-all active:scale-95 shadow-sm"
                       style={{
-                        width: isVisual
-                          ? 'min(15cqmin, 64px)'
-                          : 'min(15cqh, 12cqw)',
-                        height: isVisual
-                          ? 'min(15cqmin, 64px)'
-                          : 'min(15cqh, 12cqw)',
+                        width: 'min(56px, 14cqmin)',
+                        height: 'min(56px, 14cqmin)',
                       }}
                       aria-label="Reset"
                     >
                       <RotateCcw style={{ width: '50%', height: '50%' }} />
                     </button>
+                    {showAdjustControls && (
+                      <AdjustButton
+                        sign={1}
+                        step={effectiveAdjustStep}
+                        ariaLabel={t('widgets.timeTool.addTime')}
+                        onAdjust={adjustTime}
+                      />
+                    )}
                   </div>
                 </div>
               </div>

--- a/locales/en.json
+++ b/locales/en.json
@@ -441,7 +441,10 @@
       "adjustStepHint": "Tap to add or subtract this much time. Press and hold to add faster.",
       "adjustStepUnit": "seconds",
       "addTime": "Add time",
-      "subtractTime": "Subtract time"
+      "subtractTime": "Subtract time",
+      "play": "Play",
+      "pause": "Pause",
+      "reset": "Reset"
     },
     "weather": {
       "actual": "Actual",


### PR DESCRIPTION
## Summary

- Merges the ± adjust buttons into the same horizontal row as play/pause/reset (`[− step] [play/pause] [reset] [+ step]`), so all four controls read as one deliberate group instead of two competing stacks above and below the time.
- Standardizes all four control buttons to `min(56px, 14cqmin)` (cqmin per CLAUDE.md scaling rules), so play/pause and reset no longer look oversized in visual mode. Play/pause keeps `bg-brand-blue-primary` for primary-action emphasis.
- Reclaims wasted space: progress ring bumps from 90% → 96% of cqmin so it nearly reaches the widget edges, and the digital-mode time font cap grows from `min(55cqh, 25cqw)` → `min(60cqh, 30cqw)` (stopwatch `18cqw` → `22cqw`) so the time fills more of the widget face. Verified in the dev preview the time text grew from ~107px to 125px tall on a default 400×400 widget.

The `showAdjustControls` guard now wraps just the two `AdjustButton` siblings, so stopwatch and fresh-setup states still hide ± while keeping play/reset visible. No changes to `useHoldAccelerate`, `useTimeTool`, settings, or registry — behavior of all four buttons (state, hold-to-accelerate ramp, clamping `adjustStepSeconds` to 5–60) is preserved.

## Test plan

- [x] `pnpm run validate` — type-check, lint (zero warnings), format-check, all tests pass (1966 + 193)
- [x] Rewrote the `±adjust button placement` describe block to assert the new layout: single absolute wrapper anchored from `top:`, all four buttons share the wrapper in `[−, play/pause, reset, +]` DOM order, `top:110%` digital / `top:120%` visual, plus explicit coverage for stopwatch and fresh-setup states hiding ±
- [x] Browser preview verified: 4 buttons rendered in correct order at 56×56 px each, wrapper has `top: 110%; gap: min(12px, 3cqmin)`, time text grew from ~107px → 125.4px tall (computed font-size resolved from `min(60cqh, 30cqw)`)
- [x] Fresh-setup state (timer paused at original duration) — ± hidden until timer is started or off-default
- [ ] Manual sanity check on the preview deploy: switch a timer to Visual mode and confirm the ring nearly fills the widget face
- [ ] Manual sanity check: stopwatch mode renders only play/reset (no ±)
- [ ] Manual sanity check: press-and-hold ramp on `+` still accelerates as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)