### PR TITLE
feat(quiz): add Shuffle Questions / Shuffle Answer Options toggles

### DIFF
--- a/components/quiz/QuizStudentApp.tsx
+++ b/components/quiz/QuizStudentApp.tsx
@@ -516,6 +516,20 @@ const QuizJoinFlow: React.FC<{ isStudentRole: boolean }> = ({
   }
 
   if (session.status === 'active') {
+    // Wait for the student's response doc to load before rendering the
+    // active quiz UI. The per-attempt shuffle seed depends on
+    // `myResponse.completedAttempts`, so rendering before the snapshot
+    // arrives would briefly use `attempt-0` and then visibly reorder once
+    // the real attempt index loaded — confusing on retakes.
+    if (!myResponse) {
+      return (
+        <div className="min-h-screen bg-slate-900 flex flex-col items-center justify-center p-6 text-center">
+          <div className="w-12 h-12 border-2 border-violet-500/30 border-t-violet-400 rounded-full animate-spin mb-4" />
+          <p className="text-slate-400 text-sm">Loading your quiz…</p>
+        </div>
+      );
+    }
+
     const publicQuestions = session.publicQuestions ?? [];
     const currentQ =
       session.currentQuestionIndex >= 0
@@ -534,7 +548,7 @@ const QuizJoinFlow: React.FC<{ isStudentRole: boolean }> = ({
     }
 
     const alreadyAnswered = currentQ
-      ? (myResponse?.answers ?? []).some((a) => a.questionId === currentQ.id)
+      ? myResponse.answers.some((a) => a.questionId === currentQ.id)
       : false;
 
     return (
@@ -707,11 +721,7 @@ const ActiveQuiz: React.FC<{
   // Per-student answer shuffle. The session-level `publicQuestions` was
   // shuffled once teacher-side; we re-shuffle on the client deterministically
   // by student id so neighbours see different orders but a single student's
-  // order stays stable across reload/back-nav. Falls back to the auth uid
-  // when the response doc hasn't loaded yet (first paint of the very first
-  // question), and to a constant when neither is available — that constant
-  // matches the fallback in `seededShuffle`'s caller, so test runs without a
-  // signed-in user are deterministic too.
+  // order stays stable across reload/back-nav.
   //
   // The seed includes `completedAttempts` so retakes get a fresh order: the
   // counter increments on every transition `in-progress → completed`, so a
@@ -719,6 +729,12 @@ const ActiveQuiz: React.FC<{
   // 2 picks up a new seed and walks through a different shuffle. Mid-attempt
   // refreshes / back-nav keep the same seed (the counter only moves on
   // submit) so the order stays stable while the attempt is in flight.
+  //
+  // The parent (QuizStudentAppContent) guards `ActiveQuiz` on myResponse
+  // being non-null, so `completedAttempts` here always reflects the real
+  // value — important for retakes, since otherwise the seed would default
+  // to `attempt-0` before the snapshot arrived and visibly reorder once the
+  // correct value appeared.
   const baseShuffleSeed =
     myResponse?.studentUid ?? auth.currentUser?.uid ?? 'anonymous-student';
   const attemptIndex = myResponse?.completedAttempts ?? 0;

--- a/components/quiz/QuizStudentApp.tsx
+++ b/components/quiz/QuizStudentApp.tsx
@@ -49,7 +49,10 @@ import {
   normalizeAnswer,
   SessionEndedError,
 } from '@/hooks/useQuizSession';
-import { shuffleQuestionForStudent } from '@/utils/quizShuffle';
+import {
+  shufflePublicQuestions,
+  shuffleQuestionForStudent,
+} from '@/utils/quizShuffle';
 import { QuizSession, QuizPublicQuestion } from '@/types';
 import { useDialog } from '@/context/useDialog';
 import { StudentLeaderboard } from './StudentLeaderboard';
@@ -701,10 +704,6 @@ const ActiveQuiz: React.FC<{
     ? localIndex
     : session.currentQuestionIndex;
 
-  const baseQuestion = isStudentPaced
-    ? session.publicQuestions[localIndex]
-    : sessionQuestion;
-
   // Per-student answer shuffle. The session-level `publicQuestions` was
   // shuffled once teacher-side; we re-shuffle on the client deterministically
   // by student id so neighbours see different orders but a single student's
@@ -713,12 +712,46 @@ const ActiveQuiz: React.FC<{
   // question), and to a constant when neither is available — that constant
   // matches the fallback in `seededShuffle`'s caller, so test runs without a
   // signed-in user are deterministic too.
-  const studentShuffleSeed =
+  //
+  // The seed includes `completedAttempts` so retakes get a fresh order: the
+  // counter increments on every transition `in-progress → completed`, so a
+  // student who finishes attempt 1 (counter 0 → 1) and re-joins for attempt
+  // 2 picks up a new seed and walks through a different shuffle. Mid-attempt
+  // refreshes / back-nav keep the same seed (the counter only moves on
+  // submit) so the order stays stable while the attempt is in flight.
+  const baseShuffleSeed =
     myResponse?.studentUid ?? auth.currentUser?.uid ?? 'anonymous-student';
+  const attemptIndex = myResponse?.completedAttempts ?? 0;
+  const studentShuffleSeed = `${baseShuffleSeed}:attempt-${attemptIndex}`;
+
+  // Question-order shuffle. Only meaningful in self-paced mode — in
+  // teacher-paced/auto sessions every student must be on the SAME question
+  // when the teacher advances `currentQuestionIndex`, so reordering per
+  // student would put the projected screen out of sync with student devices.
+  // Legacy/in-flight sessions without the field default to off.
+  const questionOrderShuffleEnabled =
+    isStudentPaced && session.shuffleQuestions === true;
+  const orderedPublicQuestions = useMemo(() => {
+    if (!questionOrderShuffleEnabled) return session.publicQuestions;
+    return shufflePublicQuestions(session.publicQuestions, studentShuffleSeed);
+  }, [
+    questionOrderShuffleEnabled,
+    session.publicQuestions,
+    studentShuffleSeed,
+  ]);
+
+  const baseQuestion = isStudentPaced
+    ? orderedPublicQuestions[localIndex]
+    : sessionQuestion;
+
+  // Answer-option shuffle. Defaults to ON when the field is absent so legacy
+  // sessions that pre-date this toggle keep their always-on behavior.
+  const answerOptionShuffleEnabled = session.shuffleAnswerOptions !== false;
   const currentQuestion = useMemo(() => {
     if (!baseQuestion) return baseQuestion;
+    if (!answerOptionShuffleEnabled) return baseQuestion;
     return shuffleQuestionForStudent(baseQuestion, studentShuffleSeed);
-  }, [baseQuestion, studentShuffleSeed]);
+  }, [baseQuestion, answerOptionShuffleEnabled, studentShuffleSeed]);
 
   const alreadyAnswered = isStudentPaced
     ? (myResponse?.answers ?? []).some(

--- a/components/widgets/QuizWidget/Widget.tsx
+++ b/components/widgets/QuizWidget/Widget.tsx
@@ -73,6 +73,10 @@ const VIEW_ONLY_SESSION_OPTIONS: Required<QuizSessionOptions> = {
   streakBonusEnabled: false,
   showPodiumBetweenQuestions: false,
   soundEffectsEnabled: false,
+  // Shuffles are meaningless for view-only shares (no submissions, so no
+  // student-specific rendering happens).
+  shuffleQuestions: false,
+  shuffleAnswerOptions: false,
 };
 
 export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {

--- a/components/widgets/QuizWidget/components/QuizAssignmentSettingsModal.tsx
+++ b/components/widgets/QuizWidget/components/QuizAssignmentSettingsModal.tsx
@@ -53,6 +53,8 @@ interface SettingsOptions {
   streakBonusEnabled: boolean;
   showPodiumBetweenQuestions: boolean;
   soundEffectsEnabled: boolean;
+  shuffleQuestions: boolean;
+  shuffleAnswerOptions: boolean;
   /** null = unlimited; any positive int = hard cap. */
   attemptLimit: number | null;
   plcMode: boolean;
@@ -76,6 +78,11 @@ function initialOptionsFor(
     streakBonusEnabled: opts.streakBonusEnabled ?? false,
     showPodiumBetweenQuestions: opts.showPodiumBetweenQuestions ?? false,
     soundEffectsEnabled: opts.soundEffectsEnabled ?? false,
+    shuffleQuestions: opts.shuffleQuestions ?? false,
+    // Pre-toggle sessions had the second client-side shuffle always on, so
+    // legacy/absent reads as `true` to keep current assignments behaving
+    // identically after the upgrade.
+    shuffleAnswerOptions: opts.shuffleAnswerOptions ?? true,
     // Legacy assignments have no attemptLimit — preserve "unlimited" for
     // those rather than retroactively capping ongoing sessions.
     attemptLimit: a.attemptLimit ?? null,
@@ -158,6 +165,8 @@ export const QuizAssignmentSettingsModal: React.FC<
       streakBonusEnabled: options.streakBonusEnabled,
       showPodiumBetweenQuestions: options.showPodiumBetweenQuestions,
       soundEffectsEnabled: options.soundEffectsEnabled,
+      shuffleQuestions: options.shuffleQuestions,
+      shuffleAnswerOptions: options.shuffleAnswerOptions,
     };
     // Intentionally pass empty strings (not undefined) so that clearing a
     // field actually writes '' to Firestore. Using `|| undefined` would cause
@@ -251,6 +260,27 @@ export const QuizAssignmentSettingsModal: React.FC<
             }
             hint="Warn students who leave the quiz tab"
           />
+
+          <CollapsibleSection label="Question Randomization">
+            <ToggleRow
+              compact
+              label="Shuffle Questions"
+              checked={options.shuffleQuestions}
+              onChange={(v) =>
+                setOptions((p) => ({ ...p, shuffleQuestions: v }))
+              }
+              hint="Each student gets a fresh question order on every attempt (self-paced mode)"
+            />
+            <ToggleRow
+              compact
+              label="Shuffle Answer Options"
+              checked={options.shuffleAnswerOptions}
+              onChange={(v) =>
+                setOptions((p) => ({ ...p, shuffleAnswerOptions: v }))
+              }
+              hint="Randomize MC choices, matching pairs, and ordering items per student per attempt"
+            />
+          </CollapsibleSection>
 
           <CollapsibleSection label="Answer Feedback">
             <ToggleRow

--- a/hooks/useQuizAssignments.ts
+++ b/hooks/useQuizAssignments.ts
@@ -696,6 +696,11 @@ export const useQuizAssignments = (
         streakBonusEnabled: opts.streakBonusEnabled ?? false,
         showPodiumBetweenQuestions: opts.showPodiumBetweenQuestions ?? true,
         soundEffectsEnabled: opts.soundEffectsEnabled ?? false,
+        // Per-student per-attempt shuffling. `shuffleAnswerOptions` defaults
+        // to true to preserve the always-on behavior that pre-dates this
+        // toggle; `shuffleQuestions` is opt-in.
+        shuffleQuestions: opts.shuffleQuestions ?? false,
+        shuffleAnswerOptions: opts.shuffleAnswerOptions ?? true,
         questionPhase: 'answering',
         periodNames: settings.periodNames,
         // Phase 5A: multi-class ClassLink targeting. Write `classIds` when
@@ -950,6 +955,10 @@ export const useQuizAssignments = (
             o.showPodiumBetweenQuestions;
         if (o.soundEffectsEnabled !== undefined)
           sessionPatch.soundEffectsEnabled = o.soundEffectsEnabled;
+        if (o.shuffleQuestions !== undefined)
+          sessionPatch.shuffleQuestions = o.shuffleQuestions;
+        if (o.shuffleAnswerOptions !== undefined)
+          sessionPatch.shuffleAnswerOptions = o.shuffleAnswerOptions;
       }
       if (Object.keys(sessionPatch).length > 0) {
         batch.update(

--- a/types.ts
+++ b/types.ts
@@ -1834,10 +1834,11 @@ export interface QuizSessionOptions {
   /**
    * Randomize the order of answer options (MC choices, Matching right side,
    * Ordering items) per student per attempt. Independent of the always-on
-   * server-side shuffle in `toPublicQuestion`, which only protects the
-   * Firestore doc; this toggle controls the second client-side shuffle.
-   * Default (when the field is absent on legacy/in-flight sessions) is
-   * treated as ON to preserve pre-toggle behavior.
+   * teacher-client shuffle in `toPublicQuestion` (run once at session-create
+   * time so the answer-key offset isn't deterministic in the Firestore doc);
+   * this toggle controls the second per-student shuffle that runs in the
+   * student client. Default (when the field is absent on legacy/in-flight
+   * sessions) is treated as ON to preserve pre-toggle behavior.
    */
   shuffleAnswerOptions?: boolean;
 }

--- a/types.ts
+++ b/types.ts
@@ -1823,6 +1823,23 @@ export interface QuizSessionOptions {
   streakBonusEnabled?: boolean;
   showPodiumBetweenQuestions?: boolean;
   soundEffectsEnabled?: boolean;
+  /**
+   * Randomize the order of questions per student per attempt. When on, every
+   * student in the class sees questions in their own order, and each retake
+   * by the same student gets a fresh order too. Self-paced mode only —
+   * teacher-paced/auto sessions ignore this toggle (the teacher's
+   * `currentQuestionIndex` is the canonical pointer).
+   */
+  shuffleQuestions?: boolean;
+  /**
+   * Randomize the order of answer options (MC choices, Matching right side,
+   * Ordering items) per student per attempt. Independent of the always-on
+   * server-side shuffle in `toPublicQuestion`, which only protects the
+   * Firestore doc; this toggle controls the second client-side shuffle.
+   * Default (when the field is absent on legacy/in-flight sessions) is
+   * treated as ON to preserve pre-toggle behavior.
+   */
+  shuffleAnswerOptions?: boolean;
 }
 
 /**
@@ -1915,6 +1932,18 @@ export interface QuizSession {
   showPodiumBetweenQuestions?: boolean;
   /** Play sound effects during the quiz (default false) */
   soundEffectsEnabled?: boolean;
+  /**
+   * Per-student per-attempt question-order shuffle (default false / absent).
+   * Mirrored from the assignment's `sessionOptions.shuffleQuestions` so the
+   * student client doesn't need a second fetch.
+   */
+  shuffleQuestions?: boolean;
+  /**
+   * Per-student per-attempt answer-option shuffle. Absent on legacy sessions
+   * — consumers must default to `true` to preserve the pre-toggle behavior
+   * (the second client-side shuffle was always on before this flag landed).
+   */
+  shuffleAnswerOptions?: boolean;
   /** Current phase within a question: 'answering' (default) or 'reviewing' (between-question review) */
   questionPhase?: 'answering' | 'reviewing';
   /** Top-N leaderboard snapshot broadcast by the teacher for student view. */

--- a/types.ts
+++ b/types.ts
@@ -1846,7 +1846,9 @@ export interface QuizSessionOptions {
 /**
  * Student-safe question stored in the session document.
  * Never contains correctAnswer so students cannot cheat by inspecting
- * Firestore/network traffic. Answer choices are pre-shuffled server-side.
+ * Firestore/network traffic. Answer choices are pre-shuffled by the teacher
+ * client at session-create time (in `toPublicQuestion`) before the doc is
+ * written to Firestore.
  */
 export interface QuizPublicQuestion {
   id: string;

--- a/utils/quizShuffle.test.ts
+++ b/utils/quizShuffle.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from 'vitest';
-import { seededShuffle, shuffleQuestionForStudent } from './quizShuffle';
+import {
+  seededShuffle,
+  shufflePublicQuestions,
+  shuffleQuestionForStudent,
+} from './quizShuffle';
 import type { QuizPublicQuestion } from '@/types';
 
 describe('seededShuffle', () => {
@@ -121,5 +125,71 @@ describe('shuffleQuestionForStudent', () => {
     expect(shuffleQuestionForStudent(singleChoice, 'uid-aaa')).toBe(
       singleChoice
     );
+  });
+});
+
+describe('shufflePublicQuestions', () => {
+  const makeQuestions = (n: number): QuizPublicQuestion[] =>
+    Array.from({ length: n }, (_, i) => ({
+      id: `q-${i}`,
+      type: 'FIB' as const,
+      text: `Question ${i}`,
+      timeLimit: 0,
+    }));
+
+  it('produces different orders for different students', () => {
+    const questions = makeQuestions(8);
+    const studentA = shufflePublicQuestions(questions, 'uid-aaa:attempt-0');
+    const studentB = shufflePublicQuestions(questions, 'uid-bbb:attempt-0');
+    expect(studentA.map((q) => q.id)).not.toEqual(studentB.map((q) => q.id));
+  });
+
+  it('produces different orders for different attempts by the same student', () => {
+    const questions = makeQuestions(8);
+    const attempt1 = shufflePublicQuestions(questions, 'uid-same:attempt-0');
+    const attempt2 = shufflePublicQuestions(questions, 'uid-same:attempt-1');
+    expect(attempt1.map((q) => q.id)).not.toEqual(attempt2.map((q) => q.id));
+  });
+
+  it('produces a stable order for the same student + same attempt across calls', () => {
+    const questions = makeQuestions(8);
+    const a = shufflePublicQuestions(questions, 'uid-stable:attempt-2');
+    const b = shufflePublicQuestions(questions, 'uid-stable:attempt-2');
+    expect(a.map((q) => q.id)).toEqual(b.map((q) => q.id));
+  });
+
+  it('preserves the multiset of questions (same set, different order)', () => {
+    const questions = makeQuestions(6);
+    const shuffled = shufflePublicQuestions(questions, 'uid:attempt-0');
+    expect(shuffled.map((q) => q.id).sort()).toEqual(
+      questions.map((q) => q.id).sort()
+    );
+  });
+
+  it('does not mutate the input array', () => {
+    const questions = makeQuestions(5);
+    const snapshot = questions.map((q) => q.id);
+    shufflePublicQuestions(questions, 'uid:attempt-0');
+    expect(questions.map((q) => q.id)).toEqual(snapshot);
+  });
+
+  it('decorrelates from the per-question option shuffle (different domain suffix)', () => {
+    // The same base seed should produce different orders when used as a
+    // question-order seed vs. when used directly by seededShuffle — otherwise
+    // the option shuffle on question 0 would be a deterministic function of
+    // the question-order shuffle, leaking structure.
+    const items = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H'];
+    const optionLikeOrder = seededShuffle(items, 'uid:attempt-0:q-0');
+    const questions = items.map((id) => ({
+      id,
+      type: 'FIB' as const,
+      text: id,
+      timeLimit: 0,
+    }));
+    const questionOrder = shufflePublicQuestions(
+      questions,
+      'uid:attempt-0'
+    ).map((q) => q.id);
+    expect(questionOrder).not.toEqual(optionLikeOrder);
   });
 });

--- a/utils/quizShuffle.ts
+++ b/utils/quizShuffle.ts
@@ -86,11 +86,12 @@ export function shuffleQuestionForStudent(
 /**
  * Re-order the session's public questions per student per attempt. Callers
  * should pass a seed that already encodes both the student identity and the
- * attempt number (e.g. `${studentUid}:${completedAttempts}`) so every retake
- * walks through a fresh ordering. The `:question-order` suffix decorrelates
- * this shuffle from the per-question option shuffle that uses the same base
- * seed — without it, the option order on the first question would be a
- * deterministic function of the question-order shuffle.
+ * attempt number (e.g. `${studentUid}:attempt-${completedAttempts}` — the
+ * format used by `QuizStudentApp`) so every retake walks through a fresh
+ * ordering. The `:question-order` suffix decorrelates this shuffle from the
+ * per-question option shuffle that uses the same base seed — without it,
+ * the option order on the first question would be a deterministic function
+ * of the question-order shuffle.
  */
 export function shufflePublicQuestions(
   questions: readonly QuizPublicQuestion[],

--- a/utils/quizShuffle.ts
+++ b/utils/quizShuffle.ts
@@ -82,3 +82,19 @@ export function shuffleQuestionForStudent(
   }
   return q;
 }
+
+/**
+ * Re-order the session's public questions per student per attempt. Callers
+ * should pass a seed that already encodes both the student identity and the
+ * attempt number (e.g. `${studentUid}:${completedAttempts}`) so every retake
+ * walks through a fresh ordering. The `:question-order` suffix decorrelates
+ * this shuffle from the per-question option shuffle that uses the same base
+ * seed — without it, the option order on the first question would be a
+ * deterministic function of the question-order shuffle.
+ */
+export function shufflePublicQuestions(
+  questions: readonly QuizPublicQuestion[],
+  attemptSeed: string
+): QuizPublicQuestion[] {
+  return seededShuffle(questions, `${attemptSeed}:question-order`);
+}


### PR DESCRIPTION
## Summary

Two new toggles in the Quiz Assignment Settings modal:

- **Shuffle Questions** — randomize question order per student per attempt (self-paced mode).
- **Shuffle Answer Options** — randomize MC choices, matching pairs, and ordering items per student per attempt.

Both shuffles are seeded by `${studentUid}:attempt-${completedAttempts}`, so:

- Different students in the same class get different orders.
- Each retake (under unlimited attempts) gets a fresh shuffle — `completedAttempts` increments on submit, so the seed advances on every new attempt.
- Mid-attempt refreshes / back-nav keep the same order (the counter only moves on submit).

## Verification of pre-existing behavior

The user asked me to verify the existing shuffle works as specified. It did **not** quite:

- ✅ Answer-option shuffle existed and was per-student.
- ❌ It was always-on (no teacher toggle), and the seed was just `studentUid` — so the **same student saw the same option order on every retake**.
- ❌ Question order was never shuffled.

This PR closes those gaps with the per-attempt seed and the two toggles.

## Files

- `types.ts` — add `shuffleQuestions` / `shuffleAnswerOptions` to `QuizSessionOptions` and `QuizSession`.
- `utils/quizShuffle.ts` — new `shufflePublicQuestions` helper (uses a `:question-order` seed suffix to decorrelate from the per-question option shuffle).
- `components/widgets/QuizWidget/components/QuizAssignmentSettingsModal.tsx` — new "Question Randomization" section with the two toggles. `shuffleAnswerOptions` defaults ON for legacy reads to preserve the always-on pre-toggle behavior.
- `hooks/useQuizAssignments.ts` — mirror options on session create + on assignment update.
- `components/quiz/QuizStudentApp.tsx` — derive per-attempt seed, apply both shuffles gated on the toggles. Question-order shuffle is restricted to self-paced mode so teacher-paced sessions stay in lockstep with the projected screen.
- `components/widgets/QuizWidget/Widget.tsx` — `VIEW_ONLY_SESSION_OPTIONS` gets the new fields (`Required<...>` guard).

## Test plan

- [x] `pnpm run test` — 1978 tests pass (including 6 new tests for `shufflePublicQuestions`).
- [x] `pnpm run type-check` — clean.
- [x] `pnpm run lint` — clean (zero warnings).
- [x] `pnpm run format:check` — clean.
- [ ] Manual: create a fresh assignment with both toggles ON, two student devices on the same code → confirm different question orders.
- [ ] Manual: same student finishes attempt 1, re-joins for attempt 2 → confirm a different order.
- [ ] Manual: refresh mid-attempt → confirm order stays stable.
- [ ] Manual: toggle Shuffle Answer Options OFF → confirm options render in their session-doc order.

https://claude.ai/code/session_016XfVwQBNWTEM9nfYiDW6Nw

---
_Generated by [Claude Code](https://claude.ai/code/session_016XfVwQBNWTEM9nfYiDW6Nw)_