### PR TITLE
feat(quiz): publish scores with per-assignment visibility levels

### DIFF
--- a/components/quiz/QuizStudentApp.tsx
+++ b/components/quiz/QuizStudentApp.tsx
@@ -44,7 +44,11 @@ import { signInAnonymously, onAuthStateChanged } from 'firebase/auth';
 import { addDoc, collection, serverTimestamp } from 'firebase/firestore';
 import { auth, db } from '@/config/firebase';
 import { logError } from '@/utils/logError';
-import { useQuizSessionStudent, normalizeAnswer } from '@/hooks/useQuizSession';
+import {
+  useQuizSessionStudent,
+  normalizeAnswer,
+  SessionEndedError,
+} from '@/hooks/useQuizSession';
 import { shuffleQuestionForStudent } from '@/utils/quizShuffle';
 import { QuizSession, QuizPublicQuestion } from '@/types';
 import { useDialog } from '@/context/useDialog';
@@ -211,13 +215,12 @@ const QuizJoinFlow: React.FC<{ isStudentRole: boolean }> = ({
       } catch (err) {
         // If the session has already ended, fall back to read-only review
         // mode so the student can see their published score / responses /
-        // answers from the `/my-assignments` Completed list. Other join
+        // answers from the `/my-assignments` Completed list. Branch on the
+        // typed sentinel rather than the error message — the latter would
+        // silently break the fallback if the copy ever changes. Other join
         // failures (no such code, network error, etc.) bubble up to the
         // existing error UI.
-        const isEnded =
-          err instanceof Error &&
-          err.message === 'This quiz session has already ended.';
-        if (isEnded) {
+        if (err instanceof SessionEndedError) {
           try {
             await subscribeForReview(urlCode);
             setJoined(true);
@@ -2006,7 +2009,7 @@ const PublishedScoreReview: React.FC<{
                           }`}
                         >
                           {studentAnswer
-                            ? formatAnswerForDisplay(studentAnswer)
+                            ? formatAnswerForDisplay(studentAnswer, q.type)
                             : '— no response'}
                         </span>
                       </p>
@@ -2014,7 +2017,7 @@ const PublishedScoreReview: React.FC<{
                         <p className="text-xs text-slate-400">
                           Correct answer:{' '}
                           <span className="font-mono text-emerald-300">
-                            {formatAnswerForDisplay(correctAnswer)}
+                            {formatAnswerForDisplay(correctAnswer, q.type)}
                           </span>
                         </p>
                       )}
@@ -2040,11 +2043,16 @@ const PublishedScoreReview: React.FC<{
 /**
  * Format pipe-encoded matching/ordering answers for human display. MC/FIB
  * answers come through as plain strings and pass through untouched.
+ *
+ * Branch on `type` rather than sniffing the string for `:` — Ordering
+ * items can legitimately contain colons (e.g. "9:00 AM", "H:O ratio")
+ * that would otherwise be reformatted as "left → right" pairs.
  */
-function formatAnswerForDisplay(raw: string): string {
-  if (!raw.includes('|') && !raw.includes(':')) return raw;
-  // Matching pairs: "left:right|left:right" → "left → right, left → right"
-  if (raw.includes(':')) {
+function formatAnswerForDisplay(
+  raw: string,
+  type: QuizPublicQuestion['type']
+): string {
+  if (type === 'Matching') {
     return raw
       .split('|')
       .map((pair) => {
@@ -2054,8 +2062,10 @@ function formatAnswerForDisplay(raw: string): string {
       })
       .join(', ');
   }
-  // Ordering: "a|b|c" → "a, b, c"
-  return raw.split('|').join(', ');
+  if (type === 'Ordering') {
+    return raw.split('|').join(', ');
+  }
+  return raw;
 }
 
 const QuizSubmittedWaitScreen: React.FC<{

--- a/components/quiz/QuizStudentApp.tsx
+++ b/components/quiz/QuizStudentApp.tsx
@@ -1948,8 +1948,15 @@ const PublishedScoreReview: React.FC<{
               <p className="text-5xl font-black text-white sm:text-6xl">
                 {scorePercent}%
               </p>
+              {/* Per-question tally counts only fully-correct answers, so it
+                  can lag the percentage on quizzes that award partial credit
+                  (Matching/Ordering with `allowPartialCredit`) or use non-1
+                  point values. The "fully correct" qualifier makes the
+                  potential gap between this line and the percentage above
+                  legible to the student rather than appearing to contradict
+                  it. */}
               <p className="mt-2 text-sm text-slate-400">
-                {correctCount} of {total} correct
+                {correctCount} of {total} fully correct
               </p>
             </>
           ) : (

--- a/components/quiz/QuizStudentApp.tsx
+++ b/components/quiz/QuizStudentApp.tsx
@@ -154,6 +154,7 @@ const QuizJoinFlow: React.FC<{ isStudentRole: boolean }> = ({
     error,
     lookupSession,
     joinQuizSession,
+    subscribeForReview,
     submitAnswer,
     completeQuiz,
     reportTabSwitch,
@@ -208,6 +209,26 @@ const QuizJoinFlow: React.FC<{ isStudentRole: boolean }> = ({
         await joinQuizSession(urlCode, undefined, undefined);
         setJoined(true);
       } catch (err) {
+        // If the session has already ended, fall back to read-only review
+        // mode so the student can see their published score / responses /
+        // answers from the `/my-assignments` Completed list. Other join
+        // failures (no such code, network error, etc.) bubble up to the
+        // existing error UI.
+        const isEnded =
+          err instanceof Error &&
+          err.message === 'This quiz session has already ended.';
+        if (isEnded) {
+          try {
+            await subscribeForReview(urlCode);
+            setJoined(true);
+            return;
+          } catch (reviewErr) {
+            console.warn(
+              '[QuizStudentApp] subscribeForReview fallback failed:',
+              reviewErr
+            );
+          }
+        }
         console.warn('[QuizStudentApp] SSO auto-join failed:', err);
         // Surface the failure to the UI. The hook's own `error` state will
         // also be populated, and the render branch below prefers that more
@@ -222,7 +243,7 @@ const QuizJoinFlow: React.FC<{ isStudentRole: boolean }> = ({
       }
     };
     void run();
-  }, [isStudentRole, urlCode, joined, joinQuizSession]);
+  }, [isStudentRole, urlCode, joined, joinQuizSession, subscribeForReview]);
 
   const isViewOnly = session?.mode === 'view-only';
 
@@ -528,6 +549,7 @@ const QuizJoinFlow: React.FC<{ isStudentRole: boolean }> = ({
   return (
     <ResultsScreen
       session={session}
+      myResponse={myResponse}
       answeredCount={(myResponse?.answers ?? []).length}
       totalQuestions={session.totalQuestions}
       pin={pin}
@@ -1783,49 +1805,258 @@ const ReviewPhase: React.FC<{
 
 const ResultsScreen: React.FC<{
   session: QuizSession;
+  myResponse: ReturnType<typeof useQuizSessionStudent>['myResponse'];
   answeredCount: number;
   totalQuestions: number;
   pin: string;
   /** Auth uid — used by `StudentLeaderboard` to highlight the SSO student's row. */
   myStudentUid?: string;
-}> = ({ session, answeredCount, totalQuestions, pin, myStudentUid }) => (
-  <div className="min-h-screen bg-slate-900 flex flex-col items-center justify-center p-6 text-center">
-    <Trophy className="w-16 h-16 text-amber-400 mb-6" />
-    <h1 className="text-3xl font-black text-white mb-2">Quiz Complete!</h1>
-    <p className="text-slate-400 text-sm mb-8">
-      {pin ? (
-        <>
-          Great job, PIN{' '}
-          <span className="font-mono font-bold text-white">{pin}</span>!
-        </>
-      ) : (
-        'Great job!'
-      )}
-    </p>
+}> = ({
+  session,
+  myResponse,
+  answeredCount,
+  totalQuestions,
+  pin,
+  myStudentUid,
+}) => {
+  const visibility = session.scoreVisibility ?? 'none';
+  const showReview = visibility !== 'none' && !!myResponse;
 
-    <div className="mb-8 p-6 bg-slate-800 rounded-2xl">
-      <p className="text-5xl font-black text-white mb-2">{answeredCount}</p>
-      <p className="text-slate-400 text-sm">
-        of {totalQuestions} questions answered
+  if (showReview) {
+    return (
+      <PublishedScoreReview
+        session={session}
+        myResponse={myResponse}
+        visibility={visibility}
+        pin={pin}
+      />
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-slate-900 flex flex-col items-center justify-center p-6 text-center">
+      <Trophy className="w-16 h-16 text-amber-400 mb-6" />
+      <h1 className="text-3xl font-black text-white mb-2">Quiz Complete!</h1>
+      <p className="text-slate-400 text-sm mb-8">
+        {pin ? (
+          <>
+            Great job, PIN{' '}
+            <span className="font-mono font-bold text-white">{pin}</span>!
+          </>
+        ) : (
+          'Great job!'
+        )}
       </p>
-    </div>
 
-    <p className="text-slate-500 text-sm max-w-xs">
-      Your answers have been submitted. Ask your teacher to see your results.
-    </p>
-
-    {isGamificationActive(session) && session.liveLeaderboard && (
-      <div className="mt-8 w-full flex justify-center">
-        <StudentLeaderboard
-          entries={session.liveLeaderboard}
-          myPin={pin}
-          myStudentUid={myStudentUid}
-          scoreSuffix={getScoreSuffix(session)}
-        />
+      <div className="mb-8 p-6 bg-slate-800 rounded-2xl">
+        <p className="text-5xl font-black text-white mb-2">{answeredCount}</p>
+        <p className="text-slate-400 text-sm">
+          of {totalQuestions} questions answered
+        </p>
       </div>
-    )}
-  </div>
-);
+
+      <p className="text-slate-500 text-sm max-w-xs">
+        Your answers have been submitted. Ask your teacher to see your results.
+      </p>
+
+      {isGamificationActive(session) && session.liveLeaderboard && (
+        <div className="mt-8 w-full flex justify-center">
+          <StudentLeaderboard
+            entries={session.liveLeaderboard}
+            myPin={pin}
+            myStudentUid={myStudentUid}
+            scoreSuffix={getScoreSuffix(session)}
+          />
+        </div>
+      )}
+    </div>
+  );
+};
+
+// ─── Published-score review ──────────────────────────────────────────────────
+//
+// Rendered on the post-end results screen when the teacher has flipped
+// `scoreVisibility` on the session via the archive's "Publish Scores" kebab
+// action. The three modes are progressive disclosure:
+//
+//   - score-only: top card with the percentage + correct/total tally.
+//   - score-and-responses: above + per-question rows showing each of the
+//     student's answers tagged correct (green) or incorrect (red), but
+//     never the canonical correct answer.
+//   - score-responses-and-answers: above + the canonical correct answer
+//     under each row, sourced from `session.revealedAnswers` (populated
+//     atomically by `publishAssignmentScores`).
+//
+// All data the screen needs already lives on `myResponse` (score + each
+// answer's `isCorrect`) and `session` (publicQuestions, revealedAnswers).
+// We deliberately don't recompute correctness client-side — the teacher's
+// publish step is the only writer for those fields, so a stale-cache
+// student device can't manufacture a "correct" badge that isn't on the
+// authoritative response doc.
+
+const PublishedScoreReview: React.FC<{
+  session: QuizSession;
+  myResponse: NonNullable<
+    ReturnType<typeof useQuizSessionStudent>['myResponse']
+  >;
+  visibility: NonNullable<QuizSession['scoreVisibility']>;
+  pin: string;
+}> = ({ session, myResponse, visibility, pin }) => {
+  const showResponses =
+    visibility === 'score-and-responses' ||
+    visibility === 'score-responses-and-answers';
+  const showAnswers = visibility === 'score-responses-and-answers';
+
+  const scorePercent =
+    typeof myResponse.score === 'number' ? myResponse.score : null;
+  // Per-question correctness counts come straight off the authoritative
+  // response — no client-side grading. Defensive default: a published
+  // assignment with all-undefined `isCorrect` reads as 0 correct rather
+  // than crashing.
+  const answerById = new Map<string, (typeof myResponse.answers)[number]>();
+  for (const a of myResponse.answers) {
+    answerById.set(a.questionId, a);
+  }
+  const correctCount = myResponse.answers.filter(
+    (a) => a.isCorrect === true
+  ).length;
+  const total = session.totalQuestions;
+
+  return (
+    <div className="min-h-screen bg-slate-900 px-4 py-8 sm:px-6 sm:py-12">
+      <div className="mx-auto w-full max-w-2xl">
+        <header className="mb-6 flex flex-col items-center text-center">
+          <Trophy className="mb-4 h-12 w-12 text-amber-400" />
+          <h1 className="text-2xl font-black text-white sm:text-3xl">
+            Your Results
+          </h1>
+          <p className="mt-1 text-sm text-slate-400">{session.quizTitle}</p>
+          {pin && (
+            <p className="mt-1 text-xs text-slate-500">
+              PIN <span className="font-mono text-slate-300">{pin}</span>
+            </p>
+          )}
+        </header>
+
+        {/* Score card — present at every visibility level. */}
+        <section className="mb-6 rounded-2xl border border-slate-700 bg-slate-800 p-6 text-center">
+          {scorePercent !== null ? (
+            <>
+              <p className="text-5xl font-black text-white sm:text-6xl">
+                {scorePercent}%
+              </p>
+              <p className="mt-2 text-sm text-slate-400">
+                {correctCount} of {total} correct
+              </p>
+            </>
+          ) : (
+            <p className="text-sm text-slate-300">
+              Your score is being prepared. Check back soon.
+            </p>
+          )}
+        </section>
+
+        {showResponses && (
+          <section>
+            <h2 className="mb-3 text-xs font-bold uppercase tracking-[0.14em] text-slate-400">
+              Your Answers
+            </h2>
+            <div className="flex flex-col gap-3">
+              {(session.publicQuestions ?? []).map((q, idx) => {
+                const ans = answerById.get(q.id);
+                const studentAnswer = ans?.answer ?? '';
+                const isCorrect = ans?.isCorrect === true;
+                const isIncorrect = ans?.isCorrect === false;
+                const correctAnswer = session.revealedAnswers?.[q.id];
+                return (
+                  <article
+                    key={q.id}
+                    className={`rounded-xl border bg-slate-800/60 p-4 ${
+                      isCorrect
+                        ? 'border-emerald-500/40'
+                        : isIncorrect
+                          ? 'border-red-500/40'
+                          : 'border-slate-700'
+                    }`}
+                  >
+                    <header className="mb-2 flex items-start gap-2">
+                      <span className="mt-0.5 inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-slate-700 font-mono text-[11px] font-bold text-slate-200">
+                        {idx + 1}
+                      </span>
+                      <p className="flex-1 text-sm font-semibold text-slate-100">
+                        {q.text}
+                      </p>
+                      {ans?.isCorrect === true && (
+                        <Check className="h-5 w-5 shrink-0 text-emerald-400" />
+                      )}
+                      {ans?.isCorrect === false && (
+                        <XIcon className="h-5 w-5 shrink-0 text-red-400" />
+                      )}
+                    </header>
+                    <div className="ml-7 space-y-1.5">
+                      <p className="text-xs text-slate-400">
+                        Your answer:{' '}
+                        <span
+                          className={`font-mono ${
+                            isCorrect
+                              ? 'text-emerald-300'
+                              : isIncorrect
+                                ? 'text-red-300'
+                                : 'text-slate-200'
+                          }`}
+                        >
+                          {studentAnswer
+                            ? formatAnswerForDisplay(studentAnswer)
+                            : '— no response'}
+                        </span>
+                      </p>
+                      {showAnswers && correctAnswer && (
+                        <p className="text-xs text-slate-400">
+                          Correct answer:{' '}
+                          <span className="font-mono text-emerald-300">
+                            {formatAnswerForDisplay(correctAnswer)}
+                          </span>
+                        </p>
+                      )}
+                    </div>
+                  </article>
+                );
+              })}
+            </div>
+          </section>
+        )}
+
+        {!showResponses && (
+          <p className="text-center text-xs text-slate-500">
+            Your teacher published your score. Detailed responses aren&apos;t
+            shared for this assignment.
+          </p>
+        )}
+      </div>
+    </div>
+  );
+};
+
+/**
+ * Format pipe-encoded matching/ordering answers for human display. MC/FIB
+ * answers come through as plain strings and pass through untouched.
+ */
+function formatAnswerForDisplay(raw: string): string {
+  if (!raw.includes('|') && !raw.includes(':')) return raw;
+  // Matching pairs: "left:right|left:right" → "left → right, left → right"
+  if (raw.includes(':')) {
+    return raw
+      .split('|')
+      .map((pair) => {
+        const sep = pair.indexOf(':');
+        if (sep < 0) return pair;
+        return `${pair.slice(0, sep)} → ${pair.slice(sep + 1)}`;
+      })
+      .join(', ');
+  }
+  // Ordering: "a|b|c" → "a, b, c"
+  return raw.split('|').join(', ');
+}
 
 const QuizSubmittedWaitScreen: React.FC<{
   session: QuizSession;

--- a/components/widgets/QuizWidget/Widget.tsx
+++ b/components/widgets/QuizWidget/Widget.tsx
@@ -32,6 +32,7 @@ import { QuizPreview } from './components/QuizPreview';
 import { QuizResults } from './components/QuizResults';
 import { QuizAssignmentSettingsModal } from './components/QuizAssignmentSettingsModal';
 import { QuizAssignmentImportSetupModal } from './components/QuizAssignmentImportSetupModal';
+import { PublishScoresModal } from './components/PublishScoresModal';
 import type { QuizAssignment } from '@/types';
 import {
   buildPinToNameMap,
@@ -131,6 +132,7 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
     setAssignmentExportUrl,
     setAssignmentExportedResponseIds,
     shareAssignment,
+    publishAssignmentScores,
     syncAssignmentToLatest,
   } = useQuizAssignments(user?.uid);
 
@@ -167,6 +169,9 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
 
   // Ephemeral modal state for per-assignment settings editing.
   const [editingAssignment, setEditingAssignment] =
+    useState<QuizAssignment | null>(null);
+  // Ephemeral modal state for the per-assignment "Publish Scores" picker.
+  const [publishingAssignment, setPublishingAssignment] =
     useState<QuizAssignment | null>(null);
 
   // Local state for views that need loaded data
@@ -1437,6 +1442,9 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
             );
           }
         }}
+        onArchivePublishScores={(a) => {
+          setPublishingAssignment(a);
+        }}
         onArchivePauseResume={async (a) => {
           try {
             if (a.status === 'paused') {
@@ -1663,6 +1671,69 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
               // user's edits intact so they can retry. Without this,
               // toast appears, modal disappears, edits are lost.
               throw err;
+            }
+          }}
+        />
+      )}
+      {publishingAssignment && (
+        <PublishScoresModal
+          quizTitle={publishingAssignment.quizTitle}
+          currentVisibility={publishingAssignment.scoreVisibility}
+          onClose={() => setPublishingAssignment(null)}
+          onConfirm={async (visibility) => {
+            // Resolve the canonical quiz from Drive so the score
+            // computation has access to every question's correctAnswer
+            // (the session's `publicQuestions` strips them for student
+            // safety). When unpublishing the quiz lookup is skipped —
+            // the hook's `'none'` path doesn't read questions.
+            const target = publishingAssignment;
+            try {
+              if (visibility === 'none') {
+                await publishAssignmentScores(
+                  target.id,
+                  // Empty placeholder QuizData — the 'none' branch never
+                  // reads it. Cheaper than re-loading the quiz from Drive
+                  // for a flag-flip.
+                  {
+                    id: target.quizId,
+                    title: target.quizTitle,
+                    questions: [],
+                    createdAt: 0,
+                    updatedAt: 0,
+                  },
+                  visibility
+                );
+                addToast('Scores unpublished.', 'success');
+                setPublishingAssignment(null);
+                return;
+              }
+              const meta = quizzes.find((q) => q.id === target.quizId);
+              if (!meta) {
+                addToast(
+                  'Quiz is no longer in your library — cannot publish scores.',
+                  'error'
+                );
+                return;
+              }
+              const data = await loadQuiz(meta);
+              if (!data) return;
+              const result = await publishAssignmentScores(
+                target.id,
+                data,
+                visibility
+              );
+              addToast(
+                result.responsesUpdated > 0
+                  ? `Scores published to ${result.responsesUpdated} student${result.responsesUpdated === 1 ? '' : 's'}.`
+                  : 'Scores published. Students will see results once they submit.',
+                'success'
+              );
+              setPublishingAssignment(null);
+            } catch (err) {
+              addToast(
+                err instanceof Error ? err.message : 'Failed to publish scores',
+                'error'
+              );
             }
           }}
         />

--- a/components/widgets/QuizWidget/components/PublishScoresModal.tsx
+++ b/components/widgets/QuizWidget/components/PublishScoresModal.tsx
@@ -1,0 +1,221 @@
+/**
+ * PublishScoresModal — teacher-facing modal that controls what each
+ * student sees on the `/my-assignments` Completed review screen for a
+ * given assignment.
+ *
+ * Reached from the archive tab's per-assignment kebab → "Publish Scores".
+ * The four levels map to `QuizScoreVisibility`:
+ *
+ *   - none: scores are hidden from students (default / unpublish path).
+ *   - score-only: students see their final percentage score.
+ *   - score-and-responses: above + each of their answers tagged
+ *     correct / incorrect.
+ *   - score-responses-and-answers: above + the canonical correct answer
+ *     for every question.
+ *
+ * The modal is purely a level-picker — the actual publish work
+ * (computing scores, writing per-response `isCorrect`, populating
+ * `session.revealedAnswers`, mirroring the visibility flag) is done by
+ * `useQuizAssignments.publishAssignmentScores`.
+ */
+
+import React, { useState } from 'react';
+import {
+  CheckCircle2,
+  EyeOff,
+  Gauge,
+  ListChecks,
+  Loader2,
+  Trophy,
+  X,
+} from 'lucide-react';
+import { Modal } from '@/components/common/Modal';
+import type { QuizScoreVisibility } from '@/types';
+
+interface PublishScoresModalProps {
+  /** Quiz title — shown as a sub-line so the teacher knows which assignment they're publishing. */
+  quizTitle: string;
+  /** Currently-published level (or 'none' / undefined when nothing is published yet). */
+  currentVisibility: QuizScoreVisibility | undefined;
+  onClose: () => void;
+  onConfirm: (visibility: QuizScoreVisibility) => Promise<void> | void;
+}
+
+interface VisibilityOption {
+  id: QuizScoreVisibility;
+  title: string;
+  body: string;
+  Icon: React.ComponentType<{ className?: string }>;
+}
+
+const OPTIONS: VisibilityOption[] = [
+  {
+    id: 'score-only',
+    title: 'Score only',
+    body: 'Students see just their final score.',
+    Icon: Trophy,
+  },
+  {
+    id: 'score-and-responses',
+    title: 'Score & Responses',
+    body: 'Students see their score and which of their answers were correct or incorrect.',
+    Icon: ListChecks,
+  },
+  {
+    id: 'score-responses-and-answers',
+    title: 'Score, Responses, & Answers',
+    body: 'Students see their score, their answers marked correct or incorrect, and the correct answer for each question.',
+    Icon: CheckCircle2,
+  },
+];
+
+export const PublishScoresModal: React.FC<PublishScoresModalProps> = ({
+  quizTitle,
+  currentVisibility,
+  onClose,
+  onConfirm,
+}) => {
+  // Default the picker to whatever the assignment is currently set to (or
+  // 'score-only' on first publish — the calmest non-empty choice).
+  const initial: QuizScoreVisibility =
+    currentVisibility && currentVisibility !== 'none'
+      ? currentVisibility
+      : 'score-only';
+  const [selected, setSelected] = useState<QuizScoreVisibility>(initial);
+  const [submitting, setSubmitting] = useState(false);
+
+  const isPublished =
+    currentVisibility !== undefined && currentVisibility !== 'none';
+
+  const handleConfirm = async (visibility: QuizScoreVisibility) => {
+    if (submitting) return;
+    setSubmitting(true);
+    try {
+      await onConfirm(visibility);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Modal
+      isOpen
+      onClose={submitting ? () => undefined : onClose}
+      ariaLabel="Publish scores to students"
+      maxWidth="max-w-md"
+      contentClassName=""
+      customHeader={
+        <div className="flex items-start justify-between px-5 pt-5 pb-3 border-b border-slate-100">
+          <div className="flex items-start gap-3">
+            <div className="shrink-0 w-9 h-9 rounded-lg bg-brand-blue-lighter/40 text-brand-blue-primary flex items-center justify-center">
+              <Gauge className="w-5 h-5" />
+            </div>
+            <div>
+              <h2 className="text-base font-bold text-slate-900">
+                Publish scores
+              </h2>
+              <p className="text-xs text-slate-500 mt-0.5 truncate max-w-[20rem]">
+                {quizTitle}
+              </p>
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={submitting}
+            aria-label="Close"
+            className="shrink-0 rounded-lg p-1 text-slate-400 hover:bg-slate-100 hover:text-slate-700 transition-colors disabled:opacity-50"
+          >
+            <X className="w-5 h-5" />
+          </button>
+        </div>
+      }
+    >
+      <div className="px-5 pb-5 pt-4 space-y-3">
+        <p className="text-xs text-slate-600">
+          Choose what students will see on their Completed list:
+        </p>
+        <div
+          role="radiogroup"
+          aria-label="Score visibility"
+          className="space-y-2"
+        >
+          {OPTIONS.map((opt) => {
+            const isActive = selected === opt.id;
+            const Icon = opt.Icon;
+            return (
+              <button
+                key={opt.id}
+                type="button"
+                role="radio"
+                aria-checked={isActive}
+                onClick={() => setSelected(opt.id)}
+                disabled={submitting}
+                className={`w-full text-left rounded-xl border px-4 py-3 transition-all focus:outline-none focus:ring-2 focus:ring-brand-blue-primary/40 disabled:opacity-50 ${
+                  isActive
+                    ? 'border-brand-blue-primary bg-brand-blue-lighter/30 shadow-sm'
+                    : 'border-slate-200 bg-white hover:border-slate-300'
+                }`}
+              >
+                <div className="flex items-start gap-3">
+                  <div
+                    className={`shrink-0 w-9 h-9 rounded-lg flex items-center justify-center ${
+                      isActive
+                        ? 'bg-brand-blue-primary text-white'
+                        : 'bg-slate-100 text-slate-500'
+                    }`}
+                  >
+                    <Icon className="w-5 h-5" />
+                  </div>
+                  <div className="flex-1 min-w-0">
+                    <h3 className="font-bold text-slate-900 text-sm">
+                      {opt.title}
+                    </h3>
+                    <p className="mt-1 text-xs text-slate-600 leading-relaxed">
+                      {opt.body}
+                    </p>
+                  </div>
+                </div>
+              </button>
+            );
+          })}
+        </div>
+
+        <div className="pt-2 flex flex-col-reverse sm:flex-row gap-2 sm:justify-between">
+          {isPublished ? (
+            <button
+              type="button"
+              onClick={() => void handleConfirm('none')}
+              disabled={submitting}
+              className="inline-flex items-center justify-center gap-1.5 rounded-lg border border-slate-200 px-3 py-2 text-xs font-semibold text-slate-700 hover:bg-slate-50 transition-colors disabled:opacity-50"
+            >
+              <EyeOff className="w-4 h-4" />
+              Unpublish
+            </button>
+          ) : (
+            <span />
+          )}
+          <div className="flex gap-2 sm:justify-end">
+            <button
+              type="button"
+              onClick={onClose}
+              disabled={submitting}
+              className="rounded-lg border border-slate-200 px-4 py-2 text-sm font-semibold text-slate-700 hover:bg-slate-50 transition-colors disabled:opacity-50"
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              onClick={() => void handleConfirm(selected)}
+              disabled={submitting}
+              className="inline-flex items-center gap-1.5 rounded-lg bg-brand-blue-primary px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-brand-blue-dark transition-colors disabled:opacity-60"
+            >
+              {submitting && <Loader2 className="w-4 h-4 animate-spin" />}
+              {isPublished ? 'Update' : 'Publish'}
+            </button>
+          </div>
+        </div>
+      </div>
+    </Modal>
+  );
+};

--- a/components/widgets/QuizWidget/components/QuizManager.tsx
+++ b/components/widgets/QuizWidget/components/QuizManager.tsx
@@ -38,6 +38,7 @@ import {
   PowerOff,
   RefreshCw,
   RotateCcw,
+  Send,
   Calendar,
   Radio,
   Inbox,
@@ -292,6 +293,13 @@ interface QuizManagerProps {
   onArchiveResults?: (assignment: QuizAssignment) => void | Promise<void>;
   onArchiveEditSettings?: (assignment: QuizAssignment) => void;
   onArchiveShare?: (assignment: QuizAssignment) => void | Promise<void>;
+  /**
+   * Publish (or unpublish) student-facing score visibility for an
+   * assignment. The widget owns the picker modal and the
+   * `publishAssignmentScores` call; the manager just surfaces the
+   * kebab affordance.
+   */
+  onArchivePublishScores?: (assignment: QuizAssignment) => void | Promise<void>;
   onArchivePauseResume?: (assignment: QuizAssignment) => void | Promise<void>;
   onArchiveDeactivate?: (assignment: QuizAssignment) => void | Promise<void>;
   /** Reopen an ended assignment back to a paused state. */
@@ -450,6 +458,7 @@ export const QuizManager: React.FC<QuizManagerProps> = ({
   onArchiveResults,
   onArchiveEditSettings,
   onArchiveShare,
+  onArchivePublishScores,
   onArchivePauseResume,
   onArchiveDeactivate,
   onArchiveReopen,
@@ -1049,6 +1058,19 @@ export const QuizManager: React.FC<QuizManagerProps> = ({
       icon: Share2,
       onClick: () => void (onArchiveShare ?? noop)(a),
     });
+    if (onArchivePublishScores) {
+      // Surface the same affordance regardless of current visibility — the
+      // modal handles both first-publish and unpublish/re-publish flows.
+      secondaries.push({
+        id: 'publish-scores',
+        label:
+          a.scoreVisibility && a.scoreVisibility !== 'none'
+            ? 'Update published scores'
+            : 'Publish scores',
+        icon: Send,
+        onClick: () => void onArchivePublishScores(a),
+      });
+    }
     secondaries.push({
       id: 'reopen',
       label: 'Reopen',

--- a/hooks/useQuizAssignments.ts
+++ b/hooks/useQuizAssignments.ts
@@ -1683,21 +1683,29 @@ export const useQuizAssignments = (
         const gradedAnswers: QuizResponseAnswer[] = answers.map((a) => {
           const q = questionsById.get(a.questionId);
           if (!q) {
-            // Question deleted between submission and publish — leave the
-            // answer untouched (no `isCorrect` we can claim) and skip it
-            // from the score denominator so the percentage isn't punished
-            // for a missing question.
-            return a;
+            // Question deleted between submission and publish — we can't
+            // claim correctness any more. Strip any stale `isCorrect`
+            // from a prior publish so the response doesn't carry a
+            // value the canonical quiz no longer supports.
+            const { isCorrect: _stale, ...rest } = a;
+            void _stale;
+            return rest;
           }
           const result = gradeAnswer(q, a.answer);
           pointsEarned += result.pointsEarned;
           pointsMax += result.pointsMax;
           return { ...a, isCorrect: result.isCorrect };
         });
-        // Also count questions the student didn't answer at all toward the
-        // denominator so a blank response scores 0%, not undefined.
+        // Count questions the student didn't answer toward the denominator
+        // so a blank response scores 0%, not undefined. Use a Set lookup
+        // (O(Q) total) rather than `answers.some(...)` per question (O(Q*A))
+        // — the inner `.some` would otherwise become a noticeable stall on
+        // PLC-shared assignments with hundreds of submissions × dozens of
+        // questions.
+        const answeredQuestionIds = new Set<string>();
+        for (const a of answers) answeredQuestionIds.add(a.questionId);
         for (const q of quizData.questions) {
-          if (!answers.some((a) => a.questionId === q.id)) {
+          if (!answeredQuestionIds.has(q.id)) {
             pointsMax += q.points ?? 1;
           }
         }

--- a/hooks/useQuizAssignments.ts
+++ b/hooks/useQuizAssignments.ts
@@ -38,6 +38,9 @@ import type {
   QuizData,
   QuizMetadataSyncLinkage,
   QuizQuestion,
+  QuizResponse,
+  QuizResponseAnswer,
+  QuizScoreVisibility,
   QuizSession,
   SharedQuizAssignment,
 } from '../types';
@@ -45,6 +48,7 @@ import type { SessionTargets } from '../utils/resolveAssignmentTargets';
 import {
   QUIZ_SESSIONS_COLLECTION,
   RESPONSES_COLLECTION,
+  gradeAnswer,
   toPublicQuestion,
   type ResponseDocKey,
 } from './useQuizSession';
@@ -305,6 +309,34 @@ export interface UseQuizAssignmentsResult {
     /** How many existing responses were tagged with `preSyncVersion`. */
     taggedResponseCount: number;
   }>;
+  /**
+   * Publish (or unpublish) score visibility for an archived assignment.
+   *
+   * For visibility levels other than `'none'`, this:
+   *   1. Computes each student's percentage score from the live response
+   *      docs using `gradeAnswer` against the canonical `quizData`, and
+   *      writes the resulting `score` + per-answer `isCorrect` flags onto
+   *      every response doc under `/quiz_sessions/{id}/responses/`.
+   *   2. Mirrors `scoreVisibility` onto both the assignment doc and the
+   *      session doc so the `/my-assignments` student view can read it
+   *      without a teacher-scoped fetch.
+   *   3. When `'score-responses-and-answers'`, populates
+   *      `session.revealedAnswers` with every question's canonical answer
+   *      so the student review screen can render the correct answer text.
+   *
+   * Passing `'none'` clears the visibility flags (and `revealedAnswers`)
+   * so a teacher who published in error can roll back without deleting
+   * the assignment. Already-written `score` / `isCorrect` fields on
+   * responses are left in place — re-publishing simply overwrites them.
+   *
+   * Returns the number of responses whose score was (re)computed; `0`
+   * when `'none'`.
+   */
+  publishAssignmentScores: (
+    assignmentId: string,
+    quizData: QuizData,
+    visibility: QuizScoreVisibility
+  ) => Promise<{ responsesUpdated: number }>;
 }
 
 /**
@@ -1579,6 +1611,161 @@ export const useQuizAssignments = (
     [userId]
   );
 
+  const publishAssignmentScores = useCallback<
+    UseQuizAssignmentsResult['publishAssignmentScores']
+  >(
+    async (assignmentId, quizData, visibility) => {
+      if (!userId) throw new Error('Not authenticated');
+
+      const now = Date.now();
+      const assignmentRef = doc(
+        db,
+        'users',
+        userId,
+        QUIZ_ASSIGNMENTS_COLLECTION,
+        assignmentId
+      );
+      const sessionRef = doc(db, QUIZ_SESSIONS_COLLECTION, assignmentId);
+
+      // Unpublish path — clear the visibility flags on assignment + session
+      // and wipe the revealed-answers map so the student review screen
+      // falls back to "scores not yet published". Already-written `score`
+      // and per-answer `isCorrect` fields on response docs are left in
+      // place: the reader gates on `scoreVisibility`, so leaving the
+      // numbers behind is harmless and avoids a multi-batch wipe on a
+      // gesture the teacher may immediately undo.
+      if (visibility === 'none') {
+        const batch = writeBatch(db);
+        batch.update(assignmentRef, {
+          scoreVisibility: 'none',
+          scorePublishedAt: deleteField(),
+          updatedAt: now,
+        });
+        batch.update(sessionRef, {
+          scoreVisibility: 'none',
+          revealedAnswers: deleteField(),
+        });
+        await batch.commit();
+        return { responsesUpdated: 0 };
+      }
+
+      // Index questions by id for O(1) grading lookups. Use the canonical
+      // `quizData.questions` (loaded from Drive on the teacher side) so
+      // grading sees the full `correctAnswer` text — `session.publicQuestions`
+      // strips it for student-safety.
+      const questionsById = new Map<string, QuizQuestion>();
+      for (const q of quizData.questions) {
+        questionsById.set(q.id, q);
+      }
+
+      const responsesSnap = await getDocs(
+        collection(
+          db,
+          QUIZ_SESSIONS_COLLECTION,
+          assignmentId,
+          RESPONSES_COLLECTION
+        )
+      );
+
+      // Compute the score + per-answer correctness for every response. Per-
+      // response payload is built up front so the batch loop below stays
+      // straightforward and we can slice it across the 500-write cap.
+      interface ResponseUpdate {
+        ref: ReturnType<typeof doc>;
+        patch: { score: number; answers: QuizResponseAnswer[] };
+      }
+      const updates: ResponseUpdate[] = [];
+      for (const d of responsesSnap.docs) {
+        const data = d.data() as QuizResponse;
+        const answers = Array.isArray(data.answers) ? data.answers : [];
+        let pointsEarned = 0;
+        let pointsMax = 0;
+        const gradedAnswers: QuizResponseAnswer[] = answers.map((a) => {
+          const q = questionsById.get(a.questionId);
+          if (!q) {
+            // Question deleted between submission and publish — leave the
+            // answer untouched (no `isCorrect` we can claim) and skip it
+            // from the score denominator so the percentage isn't punished
+            // for a missing question.
+            return a;
+          }
+          const result = gradeAnswer(q, a.answer);
+          pointsEarned += result.pointsEarned;
+          pointsMax += result.pointsMax;
+          return { ...a, isCorrect: result.isCorrect };
+        });
+        // Also count questions the student didn't answer at all toward the
+        // denominator so a blank response scores 0%, not undefined.
+        for (const q of quizData.questions) {
+          if (!answers.some((a) => a.questionId === q.id)) {
+            pointsMax += q.points ?? 1;
+          }
+        }
+        const score =
+          pointsMax === 0 ? 0 : Math.round((pointsEarned / pointsMax) * 100);
+        updates.push({
+          ref: d.ref,
+          patch: { score, answers: gradedAnswers },
+        });
+      }
+
+      // First batch carries the assignment + session writes so the
+      // visibility flag flips atomically with at least the first chunk
+      // of response updates. If subsequent chunks fail, a re-publish
+      // safely overwrites — the operation is idempotent.
+      const MAX_BATCH_WRITES = 400;
+      const firstBatch = writeBatch(db);
+      firstBatch.update(assignmentRef, {
+        scoreVisibility: visibility,
+        scorePublishedAt: now,
+        updatedAt: now,
+      });
+      const sessionPatch: Record<string, unknown> = {
+        scoreVisibility: visibility,
+      };
+      // Populate `revealedAnswers` only when the teacher chose to share
+      // correct-answer text. The other two visibility levels deliberately
+      // leave it untouched (or wiped on unpublish) so the student review
+      // screen can't surface answers the teacher hasn't opted in to.
+      if (visibility === 'score-responses-and-answers') {
+        const revealedAnswers: Record<string, string> = {};
+        for (const q of quizData.questions) {
+          revealedAnswers[q.id] = q.correctAnswer;
+        }
+        sessionPatch.revealedAnswers = revealedAnswers;
+      } else {
+        sessionPatch.revealedAnswers = deleteField();
+      }
+      firstBatch.update(sessionRef, sessionPatch);
+
+      // 2 writes already consumed (assignment + session); fill the rest
+      // of the first batch with response updates.
+      const firstChunkSize = Math.min(updates.length, MAX_BATCH_WRITES - 2);
+      for (let i = 0; i < firstChunkSize; i++) {
+        firstBatch.update(updates[i].ref, updates[i].patch);
+      }
+      await firstBatch.commit();
+
+      // Remaining responses in subsequent batches (assignments with > ~398
+      // submissions across a PLC). Each batch is independently committed.
+      for (
+        let cursor = firstChunkSize;
+        cursor < updates.length;
+        cursor += MAX_BATCH_WRITES
+      ) {
+        const chunk = updates.slice(cursor, cursor + MAX_BATCH_WRITES);
+        const chunkBatch = writeBatch(db);
+        for (const u of chunk) {
+          chunkBatch.update(u.ref, u.patch);
+        }
+        await chunkBatch.commit();
+      }
+
+      return { responsesUpdated: updates.length };
+    },
+    [userId]
+  );
+
   return {
     assignments,
     loading,
@@ -1597,5 +1784,6 @@ export const useQuizAssignments = (
     peekSharedAssignment,
     importSharedAssignment,
     syncAssignmentToLatest,
+    publishAssignmentScores,
   };
 };

--- a/hooks/useQuizSession.ts
+++ b/hooks/useQuizSession.ts
@@ -760,6 +760,28 @@ export interface UseQuizSessionStudentResult {
     pin?: string,
     classPeriod?: string
   ) => Promise<string>;
+  /**
+   * Subscribe to an already-ended session for a read-only review of the
+   * student's previous submission. Used by the `/my-assignments` Completed
+   * list when the teacher has published scores via the archive's "Publish
+   * Scores" action.
+   *
+   * Unlike `joinQuizSession`, this never creates or mutates a response
+   * doc — it just resolves the session by code, picks the most recent
+   * matching doc (preferring published-score sessions over plain ended
+   * ones), and wires up the snapshot listeners so `session` and
+   * `myResponse` flow through to the consumer.
+   *
+   * Only meaningful for non-anonymous (SSO `studentRole`) callers because
+   * the response doc is keyed by `auth.uid` for them; anonymous PIN
+   * joiners would still need the PIN to compute their response key, so
+   * that path is rejected.
+   *
+   * Throws when no session matches, when the caller is anonymous, or
+   * when no response doc exists under the resolved key (e.g., the
+   * student never submitted before the session ended).
+   */
+  subscribeForReview: (code: string) => Promise<void>;
   submitAnswer: (
     questionId: string,
     answer: string,
@@ -1423,6 +1445,76 @@ export const useQuizSessionStudent = (): UseQuizSessionStudentResult => {
     return newCount;
   }, []);
 
+  const subscribeForReview = useCallback(
+    async (code: string): Promise<void> => {
+      setLoading(true);
+      setError(null);
+      try {
+        const normCode = code
+          .trim()
+          .replace(/[^a-zA-Z0-9]/g, '')
+          .toUpperCase();
+        if (!normCode) throw new Error('Invalid code');
+
+        const currentUser = auth.currentUser;
+        if (!currentUser) {
+          throw new Error('Not signed in.');
+        }
+        if (currentUser.isAnonymous) {
+          // Anonymous PIN students don't have a stable identity to look up
+          // their old response without re-supplying the PIN. Reject so the
+          // caller can fall back to the PIN form.
+          throw new Error(
+            'Sign in to review this quiz — anonymous review is not supported.'
+          );
+        }
+        const studentUid = currentUser.uid;
+
+        const snap = await getDocs(
+          query(
+            collection(db, QUIZ_SESSIONS_COLLECTION),
+            where('code', '==', normCode)
+          )
+        );
+        if (snap.empty) {
+          throw new Error('No quiz found with that code.');
+        }
+        // Prefer sessions where the teacher has published scores; among
+        // ties, fall back to the most-recent session by `endedAt` /
+        // `startedAt`. A code can recur across multiple sessions over a
+        // school year, and the student-facing review should land on the
+        // assignment that's actually been published.
+        const docs = snap.docs.slice().sort((a, b) => {
+          const ad = a.data() as QuizSession;
+          const bd = b.data() as QuizSession;
+          const aPublished = (ad.scoreVisibility ?? 'none') !== 'none' ? 1 : 0;
+          const bPublished = (bd.scoreVisibility ?? 'none') !== 'none' ? 1 : 0;
+          if (aPublished !== bPublished) return bPublished - aPublished;
+          const at = ad.endedAt ?? ad.startedAt ?? 0;
+          const bt = bd.endedAt ?? bd.startedAt ?? 0;
+          return bt - at;
+        });
+        const sessionDoc = docs[0];
+        sessionIdRef.current = sessionDoc.id;
+        // SSO students key their response doc by auth.uid (see
+        // `computeResponseKey` for the contract).
+        responseKeyRef.current = studentUid;
+        setSessionIdState(sessionDoc.id);
+        setResponseKeyState(studentUid);
+      } catch (err) {
+        const msg =
+          err instanceof Error
+            ? err.message
+            : 'Could not load this quiz for review.';
+        setError(msg);
+        throw err;
+      } finally {
+        setLoading(false);
+      }
+    },
+    []
+  );
+
   return {
     session,
     myResponse,
@@ -1431,6 +1523,7 @@ export const useQuizSessionStudent = (): UseQuizSessionStudentResult => {
     sessionIdRef,
     lookupSession,
     joinQuizSession,
+    subscribeForReview,
     submitAnswer,
     completeQuiz,
     reportTabSwitch,

--- a/hooks/useQuizSession.ts
+++ b/hooks/useQuizSession.ts
@@ -242,6 +242,19 @@ export class AttemptLimitReachedError extends Error {
 }
 
 /**
+ * Thrown by `joinQuizSession` when the resolved code maps only to ended
+ * sessions. Callers (notably the SSO auto-join in `QuizStudentApp`) use
+ * this as a sentinel to fall back to read-only review mode via
+ * `subscribeForReview`, rather than string-matching the error message.
+ */
+export class SessionEndedError extends Error {
+  constructor() {
+    super('This quiz session has already ended.');
+    this.name = 'SessionEndedError';
+  }
+}
+
+/**
  * Normalize a string for use as a segment inside a Firestore response doc id.
  *
  * Roster period names and pins are teacher-defined free text and can contain
@@ -1018,7 +1031,7 @@ export const useQuizSessionStudent = (): UseQuizSessionStudentResult => {
           return s === 'waiting' || s === 'active' || s === 'paused';
         });
         if (joinable.length === 0) {
-          throw new Error('This quiz session has already ended.');
+          throw new SessionEndedError();
         }
         // Prefer the most recently created joinable doc.
         joinable.sort((a, b) => {
@@ -1495,6 +1508,26 @@ export const useQuizSessionStudent = (): UseQuizSessionStudentResult => {
           return bt - at;
         });
         const sessionDoc = docs[0];
+        // Verify the student's response doc exists before flipping the
+        // listeners on. Without this, the response snapshot would just
+        // emit `null` and the caller would think review mode loaded
+        // successfully (matches the docstring contract: throw on
+        // missing response so the UI can show a targeted error rather
+        // than a misleading empty-review screen).
+        const responseSnap = await getDoc(
+          doc(
+            db,
+            QUIZ_SESSIONS_COLLECTION,
+            sessionDoc.id,
+            RESPONSES_COLLECTION,
+            studentUid
+          )
+        );
+        if (!responseSnap.exists()) {
+          throw new Error(
+            'No submission found for this quiz — you may not have completed it.'
+          );
+        }
         sessionIdRef.current = sessionDoc.id;
         // SSO students key their response doc by auth.uid (see
         // `computeResponseKey` for the contract).

--- a/tests/components/quiz/QuizStudentApp.ssoAutoJoin.test.tsx
+++ b/tests/components/quiz/QuizStudentApp.ssoAutoJoin.test.tsx
@@ -68,23 +68,37 @@ vi.mock('firebase/auth', () => ({
 
 // Stub the hook so we can observe the call args and control rejections.
 // `normalizeAnswer` is also imported but only fires post-join, so a
-// pass-through identity is fine.
-vi.mock('@/hooks/useQuizSession', () => ({
-  useQuizSessionStudent: () => ({
-    session: null,
-    myResponse: null,
-    loading: false,
-    error: null,
-    sessionIdRef: { current: null },
-    lookupSession: mockLookupSession,
-    joinQuizSession: mockJoinQuizSession,
-    submitAnswer: vi.fn(),
-    completeQuiz: vi.fn(),
-    reportTabSwitch: vi.fn(),
-    warningCount: 0,
-  }),
-  normalizeAnswer: (s: string) => s,
-}));
+// pass-through identity is fine. `SessionEndedError` is re-exported as a
+// real subclass so the component's `err instanceof SessionEndedError`
+// branch inside the SSO auto-join catch resolves correctly under the
+// mock — without it the `instanceof` would target `undefined` and throw,
+// which would break the "rejection surfaces in the UI" tests below.
+vi.mock('@/hooks/useQuizSession', () => {
+  class MockSessionEndedError extends Error {
+    constructor() {
+      super('This quiz session has already ended.');
+      this.name = 'SessionEndedError';
+    }
+  }
+  return {
+    useQuizSessionStudent: () => ({
+      session: null,
+      myResponse: null,
+      loading: false,
+      error: null,
+      sessionIdRef: { current: null },
+      lookupSession: mockLookupSession,
+      joinQuizSession: mockJoinQuizSession,
+      subscribeForReview: vi.fn(),
+      submitAnswer: vi.fn(),
+      completeQuiz: vi.fn(),
+      reportTabSwitch: vi.fn(),
+      warningCount: 0,
+    }),
+    normalizeAnswer: (s: string) => s,
+    SessionEndedError: MockSessionEndedError,
+  };
+});
 
 // Imported AFTER the mocks above so the component picks up the stubs.
 import { QuizStudentApp } from '@/components/quiz/QuizStudentApp';

--- a/tests/hooks/useQuizAssignments.test.ts
+++ b/tests/hooks/useQuizAssignments.test.ts
@@ -1007,3 +1007,237 @@ describe('useQuizAssignments - syncAssignmentToLatest', () => {
     expect(updatedRefs).toContain(refFresh);
   });
 });
+
+describe('useQuizAssignments - publishAssignmentScores', () => {
+  const batchUpdate = vi.fn();
+  const batchCommit = vi.fn();
+  const mockGetDocs = getDocs as Mock;
+
+  // A small canonical quiz used across the publish tests. Two MC questions,
+  // 1 point each, so the published-score arithmetic is easy to assert.
+  const quizData = {
+    id: 'quiz-1',
+    title: 'Test Quiz',
+    questions: [
+      {
+        id: 'q0',
+        text: 'Q0',
+        type: 'MC' as const,
+        correctAnswer: 'a',
+        incorrectAnswers: ['b', 'c', 'd'],
+        timeLimit: 30,
+        points: 1,
+      },
+      {
+        id: 'q1',
+        text: 'Q1',
+        type: 'MC' as const,
+        correctAnswer: 'b',
+        incorrectAnswers: ['a', 'c', 'd'],
+        timeLimit: 30,
+        points: 1,
+      },
+    ],
+    createdAt: 0,
+    updatedAt: 0,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDoc.mockImplementation((_db: unknown, ...segs: string[]) =>
+      segs.join('/')
+    );
+    mockCollection.mockImplementation((_db: unknown, ...segs: string[]) =>
+      segs.join('/')
+    );
+    mockOnSnapshot.mockReturnValue(() => undefined);
+    batchUpdate.mockReset();
+    batchCommit.mockReset().mockResolvedValue(undefined);
+    mockWriteBatch.mockReturnValue({
+      update: batchUpdate,
+      commit: batchCommit,
+    });
+  });
+
+  it("clears flags and skips response writes when visibility is 'none'", async () => {
+    const { result } = renderHook(() => useQuizAssignments(TEACHER_UID));
+    await act(async () => {
+      const outcome = await result.current.publishAssignmentScores(
+        ASSIGNMENT_ID,
+        quizData,
+        'none'
+      );
+      expect(outcome).toEqual({ responsesUpdated: 0 });
+    });
+
+    // Exactly one batch (assignment + session) — no response queries.
+    expect(mockGetDocs).not.toHaveBeenCalled();
+    expect(batchCommit).toHaveBeenCalledTimes(1);
+
+    const assignmentCall = batchUpdate.mock.calls.find(
+      ([ref]) =>
+        typeof ref === 'string' &&
+        ref.startsWith(`users/${TEACHER_UID}/quiz_assignments/`)
+    );
+    if (!assignmentCall) {
+      throw new Error('expected batch.update on assignment doc');
+    }
+    expect(assignmentCall[1]).toMatchObject({
+      scoreVisibility: 'none',
+      scorePublishedAt: DELETE_FIELD_SENTINEL,
+    });
+
+    const sessionCall = batchUpdate.mock.calls.find(
+      ([ref]) => typeof ref === 'string' && ref.startsWith('quiz_sessions/')
+    );
+    if (!sessionCall) {
+      throw new Error('expected batch.update on session doc');
+    }
+    expect(sessionCall[1]).toMatchObject({
+      scoreVisibility: 'none',
+      revealedAnswers: DELETE_FIELD_SENTINEL,
+    });
+  });
+
+  it('grades responses and writes per-answer isCorrect on score-only publish', async () => {
+    // Two responses: a perfect 2/2 and a partial 1/2. Score is the percentage.
+    const refPerfect = { id: 'r-perfect' };
+    const refPartial = { id: 'r-partial' };
+    const refBlank = { id: 'r-blank' };
+    mockGetDocs.mockResolvedValueOnce({
+      docs: [
+        {
+          ref: refPerfect,
+          data: () => ({
+            studentUid: 's1',
+            answers: [
+              { questionId: 'q0', answer: 'a', answeredAt: 1 },
+              { questionId: 'q1', answer: 'b', answeredAt: 2 },
+            ],
+          }),
+        },
+        {
+          ref: refPartial,
+          data: () => ({
+            studentUid: 's2',
+            answers: [
+              { questionId: 'q0', answer: 'a', answeredAt: 1 },
+              { questionId: 'q1', answer: 'wrong', answeredAt: 2 },
+            ],
+          }),
+        },
+        // Student who joined but never answered — both questions count
+        // toward the denominator so the score is 0 / 2 = 0%.
+        {
+          ref: refBlank,
+          data: () => ({
+            studentUid: 's3',
+            answers: [],
+          }),
+        },
+      ],
+    });
+
+    const { result } = renderHook(() => useQuizAssignments(TEACHER_UID));
+    await act(async () => {
+      const outcome = await result.current.publishAssignmentScores(
+        ASSIGNMENT_ID,
+        quizData,
+        'score-only'
+      );
+      expect(outcome).toEqual({ responsesUpdated: 3 });
+    });
+
+    expect(batchCommit).toHaveBeenCalledTimes(1);
+
+    // Session should NOT carry revealedAnswers on score-only — the
+    // implementation deleteField()s it for any visibility level below
+    // the highest one.
+    const sessionCall = batchUpdate.mock.calls.find(
+      ([ref]) => typeof ref === 'string' && ref.startsWith('quiz_sessions/')
+    );
+    if (!sessionCall) throw new Error('expected session update');
+    expect(sessionCall[1]).toMatchObject({
+      scoreVisibility: 'score-only',
+      revealedAnswers: DELETE_FIELD_SENTINEL,
+    });
+
+    // Per-response patches carry the computed score plus answers with
+    // isCorrect tagged. Locate by ref so the order in mock.calls
+    // doesn't matter.
+    const perfectCall = batchUpdate.mock.calls.find(
+      ([ref]) => ref === refPerfect
+    );
+    const partialCall = batchUpdate.mock.calls.find(
+      ([ref]) => ref === refPartial
+    );
+    const blankCall = batchUpdate.mock.calls.find(([ref]) => ref === refBlank);
+    if (!perfectCall || !partialCall || !blankCall) {
+      throw new Error('expected updates on all three response refs');
+    }
+    expect(perfectCall[1]).toMatchObject({ score: 100 });
+    expect(
+      (perfectCall[1] as { answers: { isCorrect: boolean }[] }).answers
+    ).toEqual([
+      expect.objectContaining({ questionId: 'q0', isCorrect: true }),
+      expect.objectContaining({ questionId: 'q1', isCorrect: true }),
+    ]);
+    expect(partialCall[1]).toMatchObject({ score: 50 });
+    expect(
+      (partialCall[1] as { answers: { isCorrect: boolean }[] }).answers
+    ).toEqual([
+      expect.objectContaining({ questionId: 'q0', isCorrect: true }),
+      expect.objectContaining({ questionId: 'q1', isCorrect: false }),
+    ]);
+    expect(blankCall[1]).toMatchObject({ score: 0, answers: [] });
+  });
+
+  it('populates session.revealedAnswers on score-responses-and-answers publish', async () => {
+    mockGetDocs.mockResolvedValueOnce({ docs: [] });
+
+    const { result } = renderHook(() => useQuizAssignments(TEACHER_UID));
+    await act(async () => {
+      await result.current.publishAssignmentScores(
+        ASSIGNMENT_ID,
+        quizData,
+        'score-responses-and-answers'
+      );
+    });
+
+    const sessionCall = batchUpdate.mock.calls.find(
+      ([ref]) => typeof ref === 'string' && ref.startsWith('quiz_sessions/')
+    );
+    if (!sessionCall) throw new Error('expected session update');
+    expect(sessionCall[1]).toMatchObject({
+      scoreVisibility: 'score-responses-and-answers',
+      revealedAnswers: { q0: 'a', q1: 'b' },
+    });
+  });
+
+  it('chunks response writes across multiple batches when there are more than 398 responses', async () => {
+    // 500 responses — exceeds the 400-write batch budget after the
+    // assignment + session writes consume 2 slots, so the remaining
+    // 102 spill into a second batch.
+    const responseDocs = Array.from({ length: 500 }, (_, i) => ({
+      ref: { id: `r${i}` },
+      data: () => ({
+        studentUid: `s${i}`,
+        answers: [{ questionId: 'q0', answer: 'a', answeredAt: 1 }],
+      }),
+    }));
+    mockGetDocs.mockResolvedValueOnce({ docs: responseDocs });
+
+    const { result } = renderHook(() => useQuizAssignments(TEACHER_UID));
+    await act(async () => {
+      const outcome = await result.current.publishAssignmentScores(
+        ASSIGNMENT_ID,
+        quizData,
+        'score-only'
+      );
+      expect(outcome).toEqual({ responsesUpdated: 500 });
+    });
+
+    // First batch + at least one continuation batch.
+    expect(batchCommit.mock.calls.length).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/tests/hooks/useQuizSession.test.ts
+++ b/tests/hooks/useQuizSession.test.ts
@@ -2022,3 +2022,118 @@ describe('useQuizSessionTeacher — advanceQuestion', () => {
     expect(env.batch.commit).toHaveBeenCalledTimes(1);
   });
 });
+
+describe('useQuizSessionStudent — subscribeForReview', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (auth as unknown as { currentUser: unknown }).currentUser = {
+      uid: 'sso-uid-1',
+      isAnonymous: false,
+    };
+    (firestore.doc as unknown as ReturnType<typeof vi.fn>).mockReturnValue({});
+    (
+      firestore.collection as unknown as ReturnType<typeof vi.fn>
+    ).mockReturnValue({});
+    (firestore.query as unknown as ReturnType<typeof vi.fn>).mockReturnValue(
+      {}
+    );
+    (firestore.where as unknown as ReturnType<typeof vi.fn>).mockReturnValue(
+      {}
+    );
+    (
+      firestore.onSnapshot as unknown as ReturnType<typeof vi.fn>
+    ).mockImplementation(() => vi.fn());
+  });
+
+  it('rejects anonymous callers — review needs a stable identity', async () => {
+    (auth as unknown as { currentUser: unknown }).currentUser = {
+      uid: 'anon-uid',
+      isAnonymous: true,
+    };
+    const { result } = renderHook(() => useQuizSessionStudent());
+    await act(async () => {
+      await expect(result.current.subscribeForReview('ABC123')).rejects.toThrow(
+        /anonymous review is not supported/i
+      );
+    });
+  });
+
+  it('throws when no session matches the code', async () => {
+    (
+      firestore.getDocs as unknown as ReturnType<typeof vi.fn>
+    ).mockResolvedValueOnce({ empty: true, docs: [] });
+
+    const { result } = renderHook(() => useQuizSessionStudent());
+    await act(async () => {
+      await expect(result.current.subscribeForReview('NOPE12')).rejects.toThrow(
+        /no quiz found with that code/i
+      );
+    });
+  });
+
+  it('throws when the student has no response doc on the resolved session', async () => {
+    (
+      firestore.getDocs as unknown as ReturnType<typeof vi.fn>
+    ).mockResolvedValueOnce({
+      empty: false,
+      docs: [
+        buildSessionDoc('s1', {
+          status: 'ended',
+          scoreVisibility: 'score-only',
+        }),
+      ],
+    });
+    (
+      firestore.getDoc as unknown as ReturnType<typeof vi.fn>
+    ).mockResolvedValueOnce({ exists: () => false });
+
+    const { result } = renderHook(() => useQuizSessionStudent());
+    await act(async () => {
+      await expect(result.current.subscribeForReview('ABC123')).rejects.toThrow(
+        /no submission found/i
+      );
+    });
+  });
+
+  it('prefers a published-score session over a plain ended one when both share the code', async () => {
+    // Two ended sessions with the same code; only `published` carries
+    // scoreVisibility so it must win the tie-break ahead of `recent`.
+    const recentDoc = buildSessionDoc('recent', {
+      status: 'ended',
+      endedAt: 9999,
+    });
+    const publishedDoc = buildSessionDoc('published', {
+      status: 'ended',
+      endedAt: 1,
+      scoreVisibility: 'score-only',
+    });
+    (
+      firestore.getDocs as unknown as ReturnType<typeof vi.fn>
+    ).mockResolvedValueOnce({
+      empty: false,
+      docs: [recentDoc, publishedDoc],
+    });
+    (
+      firestore.getDoc as unknown as ReturnType<typeof vi.fn>
+    ).mockResolvedValueOnce({ exists: () => true });
+
+    const docMock = firestore.doc as unknown as ReturnType<typeof vi.fn>;
+    docMock.mockClear();
+
+    const { result } = renderHook(() => useQuizSessionStudent());
+    await act(async () => {
+      await result.current.subscribeForReview('ABC123');
+    });
+
+    // The response-existence probe should target the PUBLISHED session,
+    // not the more-recent unpublished one.
+    const responseProbeCall = docMock.mock.calls.find((args: unknown[]) =>
+      args.includes('published')
+    );
+    expect(responseProbeCall).toBeDefined();
+    const recentProbeCall = docMock.mock.calls.find((args: unknown[]) =>
+      args.includes('recent')
+    );
+    expect(recentProbeCall).toBeUndefined();
+  });
+});

--- a/types.ts
+++ b/types.ts
@@ -1972,6 +1972,18 @@ export interface QuizSession {
    * sessions; consumers must default to `'submissions'`.
    */
   mode?: AssignmentMode;
+  /**
+   * Mirror of `QuizAssignment.scoreVisibility`. Absent / `'none'` means
+   * scores have not been published to students yet. Read by the student
+   * `/my-assignments` Completed review screen to decide which fields
+   * (score / per-answer correctness / correct-answer text) to surface.
+   *
+   * `revealedAnswers` (above) is the source of truth for correct-answer
+   * text when `scoreVisibility === 'score-responses-and-answers'` —
+   * `publishAssignmentScores` populates it with every question's
+   * canonical answer in one batch.
+   */
+  scoreVisibility?: QuizScoreVisibility;
 }
 
 export interface QuizResponseAnswer {
@@ -2148,6 +2160,29 @@ export interface QuizConfig {
 export type QuizAssignmentStatus = 'active' | 'paused' | 'inactive';
 
 /**
+ * Score-publication visibility level for a quiz assignment.
+ *
+ * Set by the teacher's "Publish Scores" action on an archived assignment.
+ * Controls what each student sees on the `/my-assignments` Completed
+ * review screen.
+ *
+ * - `none`: scores not published. Students see only "submitted".
+ * - `score-only`: students see their numeric score (out of total).
+ * - `score-and-responses`: students see score + each of their answers
+ *   marked correct/incorrect, but not the correct answer.
+ * - `score-responses-and-answers`: students see score, their answers
+ *   marked correct/incorrect, AND the correct answer for each question.
+ *
+ * Mirrored to the matching `QuizSession` doc so students can read the
+ * level without needing access to the teacher's assignment doc.
+ */
+export type QuizScoreVisibility =
+  | 'none'
+  | 'score-only'
+  | 'score-and-responses'
+  | 'score-responses-and-answers';
+
+/**
  * PLC linkage for a quiz assignment. Present iff the assignment is in PLC
  * mode (the originator opted into "Share with PLC" at create time, or the
  * importer is a member of the originator's PLC). The presence of this
@@ -2287,6 +2322,18 @@ export interface QuizAssignment extends QuizAssignmentSettings {
   /** Frozen at creation from the org-wide `assignment-modes` admin setting.
    *  Mirrors QuizSession.mode. Absent on pre-feature assignments. */
   mode?: AssignmentMode;
+  /**
+   * Score-publication visibility level. Absent / `'none'` means scores
+   * have not been published to students yet. Mirrored to the matching
+   * `QuizSession` doc by `publishAssignmentScores`.
+   */
+  scoreVisibility?: QuizScoreVisibility;
+  /**
+   * Timestamp of the most recent `publishAssignmentScores` call. Used by
+   * the archive UI to surface "Published <date>" text on cards whose
+   * scores have been shared with students.
+   */
+  scorePublishedAt?: number;
 }
 
 /** See `QuizAssignment.sync`. */


### PR DESCRIPTION
## Summary

Adds a teacher-side "Publish Scores" affordance and a matching student-side review screen so completed quizzes on `/my-assignments` can surface scores, responses, and (optionally) correct answers.

### Teacher side
- New kebab option **Publish scores** on each card in the archived-quiz tab (and the existing-active tab as well, where applicable on archived shapes). Surfaces an "Update published scores" label when an assignment is already published.
- New `PublishScoresModal` with three visibility levels:
  1. **Score only** — student sees just their final percentage.
  2. **Score & Responses** — adds per-answer correct/incorrect chips on the student's submission.
  3. **Score, Responses, & Answers** — adds the canonical correct answer for every question.
  - Includes an **Unpublish** affordance for accidental publishes.
- New `useQuizAssignments.publishAssignmentScores(assignmentId, quizData, visibility)` does the heavy lifting:
  - Loads every response under the session, grades each via the existing `gradeAnswer` against the canonical Drive `quizData`, and writes `score` + per-answer `isCorrect` onto every response doc.
  - Mirrors `scoreVisibility` onto both the assignment and the session.
  - For the highest level, populates `session.revealedAnswers` with every question's canonical answer in one batch.
  - Chunks across the 500-write batch limit so PLC-shared assignments with hundreds of submissions don't blow the cap.
  - Idempotent — re-publishing safely overwrites; "Unpublish" clears the flag and revealed answers without wiping the per-response score data (cheap to re-publish).

### Student side
- Existing `/my-assignments` Completed tab and `Review` button already handle navigation — the row now lands on a real review screen instead of the placeholder "Quiz Complete!" card.
- `QuizStudentApp`'s SSO auto-join now falls back to a new `useQuizSessionStudent.subscribeForReview(code)` when the session has already ended. That subscribes read-only to the existing response doc keyed by `auth.uid` (no join, no mutate).
- `ResultsScreen` now branches on `session.scoreVisibility`. When published, it renders the new `PublishedScoreReview`:
  - Big score card (percentage + correct/total).
  - Per-question rows tagged correct (green) / incorrect (red) for the response-and-answer levels.
  - Correct-answer line under each row when the teacher chose the highest visibility level.

### Data model & rules
- New `QuizScoreVisibility` union added to `types.ts`; new `scoreVisibility` and `scorePublishedAt` on `QuizAssignment`, mirrored `scoreVisibility` on `QuizSession`.
- No Firestore rule changes required — the teacher already has full update rights on response docs and the session, and students already read their own response + the session metadata.

## Test plan

- [ ] Teacher: open the Quiz widget → archive tab → kebab on an ended assignment → "Publish scores" → choose each level. Toast confirms responses count.
- [ ] Teacher: re-open the modal — current selection should match what was published; toggle to a new level and confirm "Update".
- [ ] Teacher: choose "Unpublish" — confirm scores disappear from the student review.
- [ ] Student (SSO via `/my-assignments`): open a Completed quiz that's been published at each level — verify only the right fields show.
- [ ] Student: try opening a Completed quiz that hasn't been published — should fall back to the existing "Ask your teacher" placeholder.
- [ ] Verify lint, type-check, and the full unit-test suite still pass.

https://claude.ai/code/session_01FsSSsa7GmvAEYTm6mBnX4b

---
_Generated by [Claude Code](https://claude.ai/code/session_01FsSSsa7GmvAEYTm6mBnX4b)_