### PR TITLE
feat(sharing): board import picker — Synced / View-Only / Make a Copy

### DIFF
--- a/components/common/DraggableWindow.tsx
+++ b/components/common/DraggableWindow.tsx
@@ -195,6 +195,7 @@ export const DraggableWindow: React.FC<DraggableWindowProps> = ({
     selectedWidgetIds,
     setSelectedWidgetIds,
     zoom,
+    isActiveBoardReadOnly,
   } = useDashboard();
   const { showConfirm: showConfirmDialog } = useDialog();
 
@@ -453,7 +454,10 @@ export const DraggableWindow: React.FC<DraggableWindowProps> = ({
   );
 
   const isMaximized = widget.maximized ?? false;
-  const isLocked = widget.isLocked ?? false;
+  // View-only guests treat every widget as locked. The DashboardContext
+  // mutation guards already block writes — this just surfaces the locked
+  // state to all the existing UI affordances (drag, resize, gear, close).
+  const isLocked = (widget.isLocked ?? false) || isActiveBoardReadOnly;
   const isPinned = widget.isPinned ?? false;
 
   const [pinnedHover, setPinnedHover] = useState(false);

--- a/components/layout/DashboardView.tsx
+++ b/components/layout/DashboardView.tsx
@@ -17,6 +17,8 @@ import {
   type SharedAssignmentImportMode,
 } from '@/hooks/useQuizAssignments';
 import { QuizAssignmentImportModeModal } from '@/components/widgets/QuizWidget/components/QuizAssignmentImportModeModal';
+import { ImportShareModePicker } from '@/components/share/ImportShareModePicker';
+import { ShareStatusBanner } from '@/components/share/ShareStatusBanner';
 import { logError } from '@/utils/logError';
 import { usePlcs } from '@/hooks/usePlcs';
 import { useStorage, MAX_PDF_SIZE_BYTES } from '@/hooks/useStorage';
@@ -168,6 +170,7 @@ export const DashboardView: React.FC = () => {
     setSelectedWidgetIds,
     selectedWidgetId,
     annotationActive,
+    isActiveBoardReadOnly,
   } = useDashboard();
 
   const { importSharedQuiz, saveQuiz, deleteQuiz, attachSyncLinkage } = useQuiz(
@@ -1653,10 +1656,12 @@ export const DashboardView: React.FC = () => {
 
       {/* FIXED UI: Outside the zoom container */}
       <Sidebar />
-      {!annotationActive && <Dock />}
+      {!annotationActive && !isActiveBoardReadOnly && <Dock />}
       <AnnotationOverlay />
       <ToastContainer />
       <AnnouncementOverlay />
+      <ShareStatusBanner />
+      <ImportShareModePicker />
       <BoardActionsFab onOpenCheatSheet={() => setIsCheatSheetOpen(true)} />
 
       {importModePrompt && (

--- a/components/layout/sidebar/SortableDashboardItem.tsx
+++ b/components/layout/sidebar/SortableDashboardItem.tsx
@@ -7,6 +7,10 @@ import {
   Share2,
   Trash2,
   LayoutTemplate,
+  Cloud,
+  Eye,
+  Radio,
+  Unlink,
 } from 'lucide-react';
 import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
@@ -97,6 +101,12 @@ export const SortableDashboardItem = React.memo(
             <div className="absolute top-2 right-2 p-1 bg-amber-500 text-white rounded-full shadow-sm">
               <Star className="w-3 h-3 fill-current" />
             </div>
+          )}
+
+          {/* Live-share status badge — shown for any linked dashboard so
+              teachers can spot synced/view-only/owned boards in their list. */}
+          {db.linkedShareId && (
+            <ShareBadge role={db.linkedShareRole} ended={db.linkedShareEnded} />
           )}
         </div>
 
@@ -236,3 +246,48 @@ export const SortableDashboardItem = React.memo(
 );
 
 SortableDashboardItem.displayName = 'SortableDashboardItem';
+
+const ShareBadge: React.FC<{
+  role: Dashboard['linkedShareRole'];
+  ended?: boolean;
+}> = ({ role, ended }) => {
+  let Icon = Cloud;
+  let title = 'Shared';
+  let className = 'bg-brand-blue-primary text-white';
+
+  if (ended) {
+    Icon = Unlink;
+    title = 'Share ended';
+    className = 'bg-slate-700 text-slate-100';
+  } else if (role === 'owner') {
+    Icon = Radio;
+    title = 'You are sharing this board';
+  } else if (role === 'collaborator') {
+    Icon = Cloud;
+    title = 'Synced board';
+  } else if (role === 'viewer') {
+    Icon = Eye;
+    title = 'View-only — read-only board';
+    className = 'bg-amber-500 text-white';
+  }
+
+  return (
+    <div
+      className={`absolute bottom-2 left-2 inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-bold uppercase tracking-wider shadow-sm ${className}`}
+      title={title}
+    >
+      <Icon className="w-3 h-3" />
+      <span>
+        {ended
+          ? 'Ended'
+          : role === 'owner'
+            ? 'Live'
+            : role === 'collaborator'
+              ? 'Synced'
+              : role === 'viewer'
+                ? 'View-Only'
+                : 'Shared'}
+      </span>
+    </div>
+  );
+};

--- a/components/layout/sidebar/SortableDashboardItem.tsx
+++ b/components/layout/sidebar/SortableDashboardItem.tsx
@@ -254,21 +254,26 @@ const ShareBadge: React.FC<{
   let Icon = Cloud;
   let title = 'Shared';
   let className = 'bg-brand-blue-primary text-white';
+  let label = 'Shared';
 
   if (ended) {
     Icon = Unlink;
     title = 'Share ended';
     className = 'bg-slate-700 text-slate-100';
+    label = 'Ended';
   } else if (role === 'owner') {
     Icon = Radio;
     title = 'You are sharing this board';
+    label = 'Live';
   } else if (role === 'collaborator') {
     Icon = Cloud;
     title = 'Synced board';
+    label = 'Synced';
   } else if (role === 'viewer') {
     Icon = Eye;
     title = 'View-only — read-only board';
     className = 'bg-amber-500 text-white';
+    label = 'View-Only';
   }
 
   return (
@@ -277,17 +282,7 @@ const ShareBadge: React.FC<{
       title={title}
     >
       <Icon className="w-3 h-3" />
-      <span>
-        {ended
-          ? 'Ended'
-          : role === 'owner'
-            ? 'Live'
-            : role === 'collaborator'
-              ? 'Synced'
-              : role === 'viewer'
-                ? 'View-Only'
-                : 'Shared'}
-      </span>
+      <span>{label}</span>
     </div>
   );
 };

--- a/components/share/ImportShareModePicker.tsx
+++ b/components/share/ImportShareModePicker.tsx
@@ -1,0 +1,155 @@
+/**
+ * ImportShareModePicker — modal shown to a teacher who pasted a shared-board
+ * URL. Lets them choose how to import the share:
+ *
+ *  - Synced — bidirectional live link. Both teachers can edit, and edits
+ *    propagate in real time.
+ *  - View-Only — one-way live link. Host's edits appear; the importer
+ *    cannot mutate the board.
+ *  - Make a copy — frozen one-time snapshot, identical to legacy import.
+ *
+ * Drive-backed shares (legacy `drive-` prefix) only support "Make a copy"
+ * because the underlying transport is a Drive export, not a live Firestore
+ * doc. The other options are rendered disabled with an explanatory note in
+ * that case.
+ */
+
+import React from 'react';
+import { Cloud, Copy, Eye, X } from 'lucide-react';
+import { Modal } from '@/components/common/Modal';
+import { useDashboard } from '@/context/useDashboard';
+import type { SharedBoardImportMode } from '@/context/DashboardContextValue';
+
+interface ModeOptionProps {
+  mode: SharedBoardImportMode;
+  title: string;
+  body: string;
+  Icon: React.ComponentType<{ className?: string }>;
+  disabled?: boolean;
+  disabledReason?: string;
+  onPick: (mode: SharedBoardImportMode) => void;
+}
+
+const ModeOption: React.FC<ModeOptionProps> = ({
+  mode,
+  title,
+  body,
+  Icon,
+  disabled,
+  disabledReason,
+  onPick,
+}) => {
+  return (
+    <button
+      type="button"
+      onClick={() => !disabled && onPick(mode)}
+      disabled={disabled}
+      className={`w-full text-left rounded-xl border bg-white px-4 py-4 transition-all focus:outline-none focus:ring-2 focus:ring-brand-blue-primary/40 ${
+        disabled
+          ? 'border-slate-200 opacity-50 cursor-not-allowed'
+          : 'border-slate-200 hover:border-brand-blue-primary hover:shadow-md cursor-pointer'
+      }`}
+    >
+      <div className="flex items-start gap-3">
+        <div className="shrink-0 w-10 h-10 rounded-lg bg-brand-blue-lighter/40 text-brand-blue-primary flex items-center justify-center">
+          <Icon className="w-5 h-5" />
+        </div>
+        <div className="flex-1 min-w-0">
+          <h3 className="font-bold text-slate-900 text-sm">{title}</h3>
+          <p className="mt-1 text-xs text-slate-600 leading-relaxed">{body}</p>
+          {disabled && disabledReason && (
+            <p className="mt-2 text-[11px] italic text-slate-500">
+              {disabledReason}
+            </p>
+          )}
+        </div>
+      </div>
+    </button>
+  );
+};
+
+export const ImportShareModePicker: React.FC = () => {
+  const { pendingShareImport, importSharedBoard, cancelPendingShareImport } =
+    useDashboard();
+
+  if (!pendingShareImport) return null;
+
+  const { preview, driveBacked } = pendingShareImport;
+  const boardName = preview?.name ?? 'Shared board';
+  const hostName = preview?.linkedShareHostName;
+
+  const handlePick = (mode: SharedBoardImportMode) => {
+    void importSharedBoard(mode);
+  };
+
+  const liveDisabledReason = driveBacked
+    ? 'Live sync needs the host to share again from an updated version. Older share links can only be copied.'
+    : undefined;
+
+  return (
+    <Modal
+      isOpen
+      onClose={cancelPendingShareImport}
+      ariaLabel="Choose how to import this shared board"
+      maxWidth="max-w-md"
+      contentClassName=""
+      customHeader={
+        <div className="flex items-start justify-between px-5 pt-5 pb-3 border-b border-slate-100">
+          <div className="flex items-start gap-3">
+            <div className="shrink-0 w-9 h-9 rounded-lg bg-brand-blue-lighter/40 text-brand-blue-primary flex items-center justify-center">
+              <Cloud className="w-5 h-5" />
+            </div>
+            <div>
+              <h2 className="text-base font-bold text-slate-900">
+                Import shared board
+              </h2>
+              <p className="text-xs text-slate-500 mt-0.5 truncate max-w-[20rem]">
+                {boardName}
+                {hostName ? ` · from ${hostName}` : ''}
+              </p>
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={cancelPendingShareImport}
+            aria-label="Close"
+            className="shrink-0 rounded-lg p-1 text-slate-400 hover:bg-slate-100 hover:text-slate-700 transition-colors"
+          >
+            <X className="w-5 h-5" />
+          </button>
+        </div>
+      }
+    >
+      <div className="px-5 pb-5 pt-4 space-y-3">
+        <p className="text-xs text-slate-600">
+          How should this board be imported?
+        </p>
+        <ModeOption
+          mode="synced"
+          title="Synced"
+          body="Both of you stay in sync — anything either teacher changes appears on the other's board in real time."
+          Icon={Cloud}
+          disabled={driveBacked}
+          disabledReason={liveDisabledReason}
+          onPick={handlePick}
+        />
+        <ModeOption
+          mode="view-only"
+          title="View-Only"
+          body="The host's edits appear live on your board, but you can't change anything yourself. Good for sharing a board you're presenting."
+          Icon={Eye}
+          disabled={driveBacked}
+          disabledReason={liveDisabledReason}
+          onPick={handlePick}
+        />
+        <ModeOption
+          mode="copy"
+          title="Make a copy"
+          body="Take a one-time snapshot. Edits by either of you stay private — your boards drift apart immediately."
+          Icon={Copy}
+          onPick={handlePick}
+        />
+      </div>
+    </Modal>
+  );
+};

--- a/components/share/ShareStatusBanner.tsx
+++ b/components/share/ShareStatusBanner.tsx
@@ -1,0 +1,114 @@
+/**
+ * ShareStatusBanner — small persistent banner anchored to the top-center of
+ * the dashboard, surfaced for any board that's part of a live share. Variants:
+ *
+ *  - owner     : "Sharing live" (host) with a Stop sharing action.
+ *  - collaborator (synced) : "Synced with [host]" with a Leave action.
+ *  - viewer (view-only)    : "View-only" indicator + Leave.
+ *  - ended     : surfaced when the host revokes — board becomes read-only-frozen.
+ *
+ * Glassmorphic style matches the rest of the dashboard chrome — sits over
+ * the canvas at low z, dismissable interactions go through DashboardContext.
+ */
+
+import React from 'react';
+import { Cloud, Eye, Radio, Unlink, X } from 'lucide-react';
+import { useDashboard } from '@/context/useDashboard';
+import { useDialog } from '@/context/useDialog';
+
+export const ShareStatusBanner: React.FC = () => {
+  const { activeDashboard, stopSharingDashboard } = useDashboard();
+  const { showConfirm } = useDialog();
+
+  if (!activeDashboard?.linkedShareId) return null;
+
+  const role = activeDashboard.linkedShareRole;
+  const ended = activeDashboard.linkedShareEnded;
+  const hostName = activeDashboard.linkedShareHostName;
+
+  let Icon = Cloud;
+  let label = 'Shared';
+  let detail = '';
+  let tone = 'bg-brand-blue-primary/90 text-white border-brand-blue-light/40';
+  let actionLabel = 'Stop sharing';
+
+  if (ended) {
+    Icon = Unlink;
+    label = 'Share ended';
+    detail = 'The host stopped sharing — this board is no longer in sync.';
+    tone = 'bg-slate-800/90 text-slate-100 border-slate-600/40';
+    actionLabel = 'Detach';
+  } else if (role === 'owner') {
+    Icon = Radio;
+    label = 'Sharing live';
+    detail = 'Anyone with the link can view or join your board.';
+    actionLabel = 'Stop sharing';
+  } else if (role === 'collaborator') {
+    Icon = Cloud;
+    label = 'Synced';
+    detail = hostName
+      ? `Edits sync both ways with ${hostName}.`
+      : 'Edits sync both ways with the host.';
+    actionLabel = 'Leave';
+  } else if (role === 'viewer') {
+    Icon = Eye;
+    label = 'View-only';
+    detail = hostName
+      ? `${hostName} is sharing — you can't edit this board.`
+      : 'The host is sharing — you can’t edit this board.';
+    tone = 'bg-amber-500/95 text-white border-amber-300/50';
+    actionLabel = 'Leave';
+  } else {
+    return null;
+  }
+
+  const onStop = async () => {
+    const confirmed = await showConfirm(
+      ended
+        ? 'Detach this board from the ended share? Your local copy keeps its current contents.'
+        : role === 'owner'
+          ? 'Stop sharing this board? Anyone using your link will be disconnected from your live updates.'
+          : 'Leave this shared board? Your local copy will keep its current contents but won’t receive further updates.',
+      {
+        title: actionLabel,
+        confirmLabel: actionLabel,
+        cancelLabel: 'Cancel',
+        variant: role === 'owner' && !ended ? 'warning' : 'info',
+      }
+    );
+    if (!confirmed) return;
+    await stopSharingDashboard(activeDashboard.id);
+  };
+
+  return (
+    <div
+      className="pointer-events-none fixed top-4 left-1/2 -translate-x-1/2 z-[60] flex justify-center"
+      role="status"
+      aria-live="polite"
+    >
+      <div
+        className={`pointer-events-auto flex items-center gap-3 rounded-full border px-4 py-2 shadow-lg backdrop-blur-md ${tone}`}
+      >
+        <Icon className="w-4 h-4 shrink-0" />
+        <div className="flex items-baseline gap-2 min-w-0">
+          <span className="text-xs font-bold uppercase tracking-wider">
+            {label}
+          </span>
+          {detail && (
+            <span className="text-xs opacity-90 truncate max-w-[28rem]">
+              {detail}
+            </span>
+          )}
+        </div>
+        <button
+          type="button"
+          onClick={() => void onStop()}
+          className="ml-1 inline-flex items-center gap-1 rounded-full bg-black/15 hover:bg-black/25 px-2.5 py-1 text-[11px] font-bold uppercase tracking-wider transition-colors"
+        >
+          <X className="w-3 h-3" />
+          {actionLabel}
+        </button>
+      </div>
+    </div>
+  );
+};

--- a/components/share/ShareStatusBanner.tsx
+++ b/components/share/ShareStatusBanner.tsx
@@ -5,7 +5,10 @@
  *  - owner     : "Sharing live" (host) with a Stop sharing action.
  *  - collaborator (synced) : "Synced with [host]" with a Leave action.
  *  - viewer (view-only)    : "View-only" indicator + Leave.
- *  - ended     : surfaced when the host revokes — board becomes read-only-frozen.
+ *  - ended     : surfaced when the host revokes the share. The local copy
+ *    becomes editable again (read-only mode is intentionally lifted once the
+ *    upstream link is gone — the user "inherits" the last synced state and
+ *    can detach to clear the banner permanently).
  *
  * Glassmorphic style matches the rest of the dashboard chrome — sits over
  * the canvas at low z, dismissable interactions go through DashboardContext.

--- a/components/student/StudentContexts.tsx
+++ b/components/student/StudentContexts.tsx
@@ -259,6 +259,17 @@ const mockDashboard: DashboardContextValue = {
   clearPendingShare: () => {
     // No-op
   },
+  pendingShareImport: null,
+  cancelPendingShareImport: () => {
+    // No-op — student view never imports shared boards.
+  },
+  importSharedBoard: async () => {
+    // No-op
+  },
+  stopSharingDashboard: async () => {
+    // No-op
+  },
+  isActiveBoardReadOnly: false,
   pendingQuizShareId: null,
   clearPendingQuizShare: () => {
     // No-op

--- a/context/DashboardContext.tsx
+++ b/context/DashboardContext.tsx
@@ -1889,7 +1889,6 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
       const dashboardId = d.id;
       const shareId = d.linkedShareId;
       if (!shareId) return () => undefined;
-      const role = d.linkedShareRole;
 
       return subscribeToSharedBoard(shareId, (remote) => {
         if (!remote) {
@@ -1905,21 +1904,25 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
           return;
         }
 
-        // Skip echoes of our own writes.
+        // Skip echoes of our own writes — `updatedBy` is stamped by the
+        // mirror effect with the writer's uid, so this filter applies
+        // symmetrically to owner, collaborator, and viewer roles.
         const remoteWith = remote as Dashboard & {
           updatedBy?: string;
         };
         if (remoteWith.updatedBy === user.uid) return;
 
-        // Apply remote content patch to local dashboard.
+        // Apply remote content patch to the local dashboard. This runs for
+        // every role:
+        //   - owner       receives collaborator edits (Synced bidirectional)
+        //   - collaborator receives owner + peer edits (Synced bidirectional)
+        //   - viewer       receives owner edits (View-Only one-way)
+        // The echo filter above prevents a writer from re-applying its own
+        // mirrored update.
         setDashboards((prev) =>
           prev.map((x) => {
             if (x.id !== dashboardId) return x;
-            // Owners receive participant-only updates from the shared doc
-            // (joins/leaves) — apply those without overwriting their own
-            // canonical local content.
-            if (role === 'owner') return x;
-            return {
+            const next: Dashboard = {
               ...x,
               widgets: remote.widgets ?? x.widgets,
               background: remote.background ?? x.background,
@@ -1927,6 +1930,12 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
               settings: remote.settings ?? x.settings,
               linkedShareEnded: false,
             };
+            // Prime the mirror dedupe so the state change we just made
+            // doesn't trigger an immediate echo write back to the shared
+            // doc. Without this, every remote apply costs an extra
+            // Firestore write of identical content.
+            lastMirroredRef.current.set(shareId, serializeDashboard(next));
+            return next;
           })
         );
       });

--- a/context/DashboardContext.tsx
+++ b/context/DashboardContext.tsx
@@ -43,7 +43,11 @@ import {
 import { useRosters } from '../hooks/useRosters';
 import { useGoogleDrive } from '../hooks/useGoogleDrive';
 import { setDriveAuthErrorHandler } from '../utils/driveAuthErrors';
-import { DashboardContext } from './DashboardContextValue';
+import {
+  DashboardContext,
+  PendingShareImport,
+  SharedBoardImportMode,
+} from './DashboardContextValue';
 import { validateGridConfig, sanitizeAIConfig } from '../utils/ai_security';
 import { getMaterialsCatalog } from '../components/widgets/MaterialsWidget/constants';
 import { AnnotationState } from './DashboardContextValue';
@@ -110,6 +114,11 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
     subscribeToDashboards,
     shareDashboard: shareDashboardFirestore,
     loadSharedDashboard: loadSharedDashboardFirestore,
+    mirrorSharedBoard,
+    subscribeToSharedBoard,
+    joinSharedBoard,
+    leaveSharedBoard,
+    stopSharingBoard,
   } = useFirestore(user?.uid ?? null);
 
   const [dashboards, setDashboards] = useState<Dashboard[]>([]);
@@ -646,7 +655,9 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
 
   const handleShareDashboard = useCallback(
     async (dashboard: Dashboard): Promise<string> => {
-      // MANDATE: Share through Google Drive if available for non-admins
+      // MANDATE: Share through Google Drive if available for non-admins.
+      // Drive shares are one-time exports — they don't support live sync,
+      // and we intentionally don't tag the local dashboard as `owner`.
       if (!isAdmin && driveService) {
         try {
           const fileId = await driveService.exportDashboard(dashboard);
@@ -656,9 +667,39 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
           console.error('Drive sharing failed, falling back to Firestore:', e);
         }
       }
-      return shareDashboardFirestore(dashboard);
+
+      // Firestore-backed share: also tag the local dashboard so subsequent
+      // edits mirror to the shared doc and Synced/View-Only guests stay in
+      // sync with the host.
+      const hostName = user?.displayName ?? user?.email ?? undefined;
+      const shareId = await shareDashboardFirestore(dashboard, hostName);
+      const tagged: Dashboard = {
+        ...dashboard,
+        linkedShareId: shareId,
+        linkedShareRole: 'owner',
+        linkedShareHostName: hostName,
+        linkedShareEnded: false,
+      };
+      // Optimistic local update so the UI reflects the live-share state
+      // immediately. The next save effect will persist this to Firestore.
+      setDashboards((prev) =>
+        prev.map((d) => (d.id === dashboard.id ? tagged : d))
+      );
+      try {
+        await saveDashboardFirestore(tagged);
+      } catch (e) {
+        console.error('Failed to persist share linkage on dashboard:', e);
+      }
+      return shareId;
     },
-    [isAdmin, driveService, shareDashboardFirestore, userDomain]
+    [
+      isAdmin,
+      driveService,
+      shareDashboardFirestore,
+      saveDashboardFirestore,
+      userDomain,
+      user,
+    ]
   );
 
   const handleLoadSharedDashboard = useCallback(
@@ -1607,7 +1648,13 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
   // which can happen if dependencies change during the async load
   const processingRef = useRef<string | null>(null);
 
-  // Handle shared dashboard loading
+  // Pending share-import state. When a recipient opens /share/<id> we fetch
+  // the shared doc and stash a snapshot here; the UI shows a 3-option picker
+  // (Synced / View-Only / Copy) and calls importSharedBoard(mode) to commit.
+  const [pendingShareImport, setPendingShareImport] =
+    useState<PendingShareImport | null>(null);
+
+  // Handle shared dashboard loading — fetches snapshot, then opens the picker.
   useEffect(() => {
     if (!pendingShareId || !user) return;
     if (processingRef.current === pendingShareId) return;
@@ -1619,51 +1666,28 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
     const load = async () => {
       try {
         const sharedDb = await handleLoadSharedDashboard(currentShareId);
-
         if (!mounted) return;
 
-        if (sharedDb) {
-          // Calculate order based on current dashboards state
-          const maxOrder = dashboardsRef.current.reduce(
-            (max, db) => Math.max(max, db.order ?? 0),
-            0
-          );
-
-          // Explicitly construct new dashboard to avoid carrying over
-          // metadata from the shared document (e.g. originalAuthor, sharedAt)
-          const newDb: Dashboard = {
-            id: crypto.randomUUID(),
-            name: `${sharedDb.name} (Copy)`,
-            background: sharedDb.background,
-            widgets: sharedDb.widgets,
-            globalStyle: sharedDb.globalStyle,
-            settings: sharedDb.settings,
-            isDefault: false,
-            createdAt: Date.now(),
-            order: maxOrder + 1,
-          };
-
-          await saveDashboard(newDb);
-
-          if (!mounted) return;
-
-          updateActiveId(newDb.id);
-          addToast('Board imported successfully', 'success');
-          clearPendingShare();
-        } else {
-          if (!mounted) return;
-
+        if (!sharedDb) {
           addToast('Shared board not found', 'error');
           clearPendingShare();
+          return;
         }
+
+        // Drive-backed shares are one-time exports; only Copy mode is
+        // meaningful. Firestore-backed shares unlock all three modes.
+        const driveBacked = currentShareId.startsWith('drive-');
+        setPendingShareImport({
+          shareId: currentShareId,
+          preview: sharedDb,
+          driveBacked,
+        });
       } catch (err) {
         console.error('Failed to load shared dashboard:', err);
         if (!mounted) return;
-
         addToast('Failed to load shared board', 'error');
         clearPendingShare();
       } finally {
-        // Clear processingRef only if it still matches the current share ID
         if (processingRef.current === currentShareId) {
           processingRef.current = null;
         }
@@ -1674,8 +1698,6 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
 
     return () => {
       mounted = false;
-      // Clear processingRef in cleanup if it matches the current share ID
-      // This ensures the effect can re-run after StrictMode's remount cycle
       if (processingRef.current === currentShareId) {
         processingRef.current = null;
       }
@@ -1684,11 +1706,281 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
     pendingShareId,
     user,
     handleLoadSharedDashboard,
-    saveDashboard,
     addToast,
     clearPendingShare,
-    updateActiveId,
   ]);
+
+  const cancelPendingShareImport = useCallback(() => {
+    setPendingShareImport(null);
+    clearPendingShare();
+  }, [clearPendingShare]);
+
+  const importSharedBoard = useCallback(
+    async (mode: SharedBoardImportMode) => {
+      const pending = pendingShareImport;
+      if (!pending || !user) return;
+
+      const { shareId, preview, driveBacked } = pending;
+      if (!preview) return;
+
+      // Drive shares can only ever be a copy — guard against bypass.
+      const effectiveMode: SharedBoardImportMode = driveBacked ? 'copy' : mode;
+
+      const maxOrder = dashboardsRef.current.reduce(
+        (max, db) => Math.max(max, db.order ?? 0),
+        0
+      );
+
+      const baseName = preview.name || 'Shared Board';
+      const nameSuffix =
+        effectiveMode === 'synced'
+          ? ' (Synced)'
+          : effectiveMode === 'view-only'
+            ? ' (View-Only)'
+            : ' (Copy)';
+
+      const newDb: Dashboard = {
+        id: crypto.randomUUID(),
+        name: `${baseName}${nameSuffix}`,
+        background: preview.background,
+        widgets: preview.widgets ?? [],
+        globalStyle: preview.globalStyle,
+        settings: preview.settings,
+        isDefault: false,
+        createdAt: Date.now(),
+        order: maxOrder + 1,
+        ...(effectiveMode !== 'copy'
+          ? {
+              linkedShareId: shareId,
+              linkedShareRole:
+                effectiveMode === 'synced' ? 'collaborator' : 'viewer',
+              linkedShareHostName: preview.linkedShareHostName,
+              linkedShareEnded: false,
+            }
+          : {}),
+      };
+
+      try {
+        await saveDashboard(newDb);
+
+        // Join the shared doc's participants list so the host (and other
+        // peers) can count us. Best-effort — don't block the import if the
+        // join write fails (still useful as a one-way receiver).
+        if (effectiveMode !== 'copy') {
+          try {
+            await joinSharedBoard(
+              shareId,
+              effectiveMode === 'synced' ? 'collaborator' : 'viewer',
+              user.displayName ?? user.email ?? undefined
+            );
+          } catch (joinErr) {
+            console.warn('Failed to join shared board participants:', joinErr);
+          }
+        }
+
+        updateActiveId(newDb.id);
+        const verb =
+          effectiveMode === 'synced'
+            ? 'Synced board imported'
+            : effectiveMode === 'view-only'
+              ? 'View-only board imported'
+              : 'Board imported';
+        addToast(verb, 'success');
+      } catch (err) {
+        console.error('Failed to import shared board:', err);
+        addToast('Failed to import shared board', 'error');
+      } finally {
+        setPendingShareImport(null);
+        clearPendingShare();
+      }
+    },
+    [
+      pendingShareImport,
+      user,
+      saveDashboard,
+      joinSharedBoard,
+      updateActiveId,
+      addToast,
+      clearPendingShare,
+    ]
+  );
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Live-share sync
+  //
+  // For every dashboard that's linked to a shared doc:
+  //   - "owner" / "collaborator" roles MIRROR local changes into the shared
+  //     doc on a debounced cadence.
+  //   - All linked roles SUBSCRIBE to the shared doc so remote edits flow
+  //     back into the local dashboard. We skip echoes by tagging mirror
+  //     writes with our own uid in `updatedBy`.
+  // ─────────────────────────────────────────────────────────────────────────
+
+  /** Last serialized payload we mirrored per shareId — skip duplicate writes. */
+  const lastMirroredRef = useRef<Map<string, string>>(new Map());
+  /** Pending debounced mirror timers per shareId. */
+  const mirrorTimersRef = useRef<Map<string, ReturnType<typeof setTimeout>>>(
+    new Map()
+  );
+
+  // Mirror local edits → shared doc (debounced, 500ms).
+  useEffect(() => {
+    if (!user) return;
+
+    dashboards.forEach((d) => {
+      if (!d.linkedShareId || d.linkedShareEnded) return;
+      if (
+        d.linkedShareRole !== 'owner' &&
+        d.linkedShareRole !== 'collaborator'
+      ) {
+        return;
+      }
+
+      // Cheap dedupe based on the same fields the saveDashboard path uses.
+      const payload = serializeDashboard(d);
+      if (lastMirroredRef.current.get(d.linkedShareId) === payload) return;
+
+      const shareId = d.linkedShareId;
+      const existing = mirrorTimersRef.current.get(shareId);
+      if (existing) clearTimeout(existing);
+
+      const timer = setTimeout(() => {
+        mirrorTimersRef.current.delete(shareId);
+        lastMirroredRef.current.set(shareId, payload);
+        void mirrorSharedBoard(shareId, d).catch((err) => {
+          console.warn('Mirror to shared board failed:', err);
+          // Drop the cached payload so we retry on the next change.
+          lastMirroredRef.current.delete(shareId);
+        });
+      }, 500);
+      mirrorTimersRef.current.set(shareId, timer);
+    });
+  }, [dashboards, user, mirrorSharedBoard]);
+
+  // Cleanup pending mirror timers on unmount so we don't write after teardown.
+  useEffect(() => {
+    const timers = mirrorTimersRef.current;
+    return () => {
+      timers.forEach((t) => clearTimeout(t));
+      timers.clear();
+    };
+  }, []);
+
+  // Subscribe to remote edits on each linked share. We re-subscribe whenever
+  // the set of (dashboardId, shareId) pairs changes; widget content edits do
+  // NOT cause re-subscription because we read the dashboard list via ref.
+  const linkedShareKeys = useMemo(
+    () =>
+      dashboards
+        .filter((d) => d.linkedShareId)
+        .map((d) => `${d.id}:${d.linkedShareId}`)
+        .sort()
+        .join('|'),
+    [dashboards]
+  );
+
+  useEffect(() => {
+    if (!user) return;
+
+    const linked = dashboardsRef.current.filter((d) => d.linkedShareId);
+    if (linked.length === 0) return;
+
+    const unsubs = linked.map((d) => {
+      const dashboardId = d.id;
+      const shareId = d.linkedShareId;
+      if (!shareId) return () => undefined;
+      const role = d.linkedShareRole;
+
+      return subscribeToSharedBoard(shareId, (remote) => {
+        if (!remote) {
+          // Shared doc deleted by the host (revoked) — flag the local copy
+          // as "ended" but preserve the content.
+          setDashboards((prev) =>
+            prev.map((x) =>
+              x.id === dashboardId && !x.linkedShareEnded
+                ? { ...x, linkedShareEnded: true }
+                : x
+            )
+          );
+          return;
+        }
+
+        // Skip echoes of our own writes.
+        const remoteWith = remote as Dashboard & {
+          updatedBy?: string;
+        };
+        if (remoteWith.updatedBy === user.uid) return;
+
+        // Apply remote content patch to local dashboard.
+        setDashboards((prev) =>
+          prev.map((x) => {
+            if (x.id !== dashboardId) return x;
+            // Owners receive participant-only updates from the shared doc
+            // (joins/leaves) — apply those without overwriting their own
+            // canonical local content.
+            if (role === 'owner') return x;
+            return {
+              ...x,
+              widgets: remote.widgets ?? x.widgets,
+              background: remote.background ?? x.background,
+              globalStyle: remote.globalStyle ?? x.globalStyle,
+              settings: remote.settings ?? x.settings,
+              linkedShareEnded: false,
+            };
+          })
+        );
+      });
+    });
+
+    return () => {
+      unsubs.forEach((u) => u());
+    };
+    // linkedShareKeys captures only structural changes (which share/dashboard
+    // pairs exist), not content edits — so we don't re-subscribe on every edit.
+  }, [linkedShareKeys, user, subscribeToSharedBoard]);
+
+  const stopSharingDashboard = useCallback(
+    async (dashboardId: string) => {
+      const target = dashboardsRef.current.find((d) => d.id === dashboardId);
+      if (!target?.linkedShareId) return;
+
+      const shareId = target.linkedShareId;
+      const isOwner = target.linkedShareRole === 'owner';
+
+      try {
+        if (isOwner) {
+          await stopSharingBoard(shareId);
+        } else {
+          // Guest: leave participants list, keep local copy.
+          await leaveSharedBoard(shareId);
+        }
+      } catch (err) {
+        console.error('Failed to tear down share:', err);
+        addToast('Failed to stop sharing', 'error');
+        return;
+      }
+
+      // Clear linkage on the local dashboard so the mirror/subscribe effects
+      // detach. The board's contents stay as a normal local dashboard.
+      const detached: Dashboard = {
+        ...target,
+        linkedShareId: undefined,
+        linkedShareRole: undefined,
+        linkedShareHostName: undefined,
+        linkedShareEnded: undefined,
+      };
+      setDashboards((prev) =>
+        prev.map((d) => (d.id === dashboardId ? detached : d))
+      );
+      try {
+        await saveDashboard(detached);
+      } catch (err) {
+        console.error('Failed to persist detached share state:', err);
+      }
+      addToast(isOwner ? 'Stopped sharing' : 'Left shared board', 'success');
+    },
+    [stopSharingBoard, leaveSharedBoard, saveDashboard, addToast]
+  );
 
   // --- FOLDER ACTIONS ---
   const addFolder = useCallback(
@@ -2145,6 +2437,15 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
 
   const activeDashboard = dashboards.find((d) => d.id === activeId) ?? null;
 
+  // True when the user is viewing a board they joined as a viewer in
+  // View-Only mode. Read-only mutation guards check this via a ref so
+  // memoized action callbacks don't have to invalidate on every change.
+  const isActiveBoardReadOnly =
+    activeDashboard?.linkedShareRole === 'viewer' &&
+    !activeDashboard?.linkedShareEnded;
+  const isActiveBoardReadOnlyRef = useRef(isActiveBoardReadOnly);
+  isActiveBoardReadOnlyRef.current = isActiveBoardReadOnly;
+
   /**
    * Extracts building-level config overrides for a widget type from the admin's
    * feature_permissions config. These are applied between widget defaults and
@@ -2561,6 +2862,7 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
   const addWidget = useCallback(
     (type: WidgetType, overrides?: AddWidgetOverrides) => {
       if (!activeId) return;
+      if (isActiveBoardReadOnlyRef.current) return;
       lastLocalUpdateAt.current = Date.now();
       lastUpdateWasSettingsOnly.current = false;
 
@@ -2609,6 +2911,7 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
       }[]
     ) => {
       if (!activeId) return;
+      if (isActiveBoardReadOnlyRef.current) return;
       lastLocalUpdateAt.current = Date.now();
       lastUpdateWasSettingsOnly.current = false;
 
@@ -2724,6 +3027,7 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
   const removeWidget = useCallback(
     (id: string) => {
       if (!activeId) return;
+      if (isActiveBoardReadOnlyRef.current) return;
       lastLocalUpdateAt.current = Date.now();
       lastUpdateWasSettingsOnly.current = false;
       setDashboards((prev) =>
@@ -2751,6 +3055,7 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
   const duplicateWidget = useCallback(
     (id: string) => {
       if (!activeId) return;
+      if (isActiveBoardReadOnlyRef.current) return;
       lastLocalUpdateAt.current = Date.now();
       lastUpdateWasSettingsOnly.current = false;
       setDashboards((prev) =>
@@ -2780,6 +3085,7 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
   const removeWidgets = useCallback(
     (ids: string[]) => {
       if (!activeId) return;
+      if (isActiveBoardReadOnlyRef.current) return;
       lastLocalUpdateAt.current = Date.now();
       lastUpdateWasSettingsOnly.current = false;
       const idSet = new Set(ids);
@@ -2839,6 +3145,7 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
 
   const clearAllWidgets = useCallback(() => {
     if (!activeId) return;
+    if (isActiveBoardReadOnlyRef.current) return;
     lastLocalUpdateAt.current = Date.now();
     lastUpdateWasSettingsOnly.current = false;
     setDashboards((prev) =>
@@ -2850,6 +3157,7 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
   const updateWidget = useCallback(
     (id: string, updates: Partial<WidgetData>) => {
       if (!activeIdRef.current) return;
+      if (isActiveBoardReadOnlyRef.current) return;
       lastLocalUpdateAt.current = Date.now();
       lastUpdateWasSettingsOnly.current = false;
 
@@ -2920,6 +3228,7 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
       }>
     ) => {
       if (!activeIdRef.current) return;
+      if (isActiveBoardReadOnlyRef.current) return;
       lastLocalUpdateAt.current = Date.now();
       lastUpdateWasSettingsOnly.current = false;
       const updateMap = new Map(updates.map((u) => [u.id, u.changes]));
@@ -2945,6 +3254,7 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
   const groupWidgets = useCallback(
     (widgetIds: string[]) => {
       if (!activeIdRef.current || widgetIds.length < 2) return;
+      if (isActiveBoardReadOnlyRef.current) return;
 
       // Find the active dashboard to check widget states
       const active = dashboardsRef.current.find(
@@ -2995,6 +3305,7 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
 
   const ungroupWidgets = useCallback((groupId: string) => {
     if (!activeIdRef.current) return;
+    if (isActiveBoardReadOnlyRef.current) return;
     lastLocalUpdateAt.current = Date.now();
     lastUpdateWasSettingsOnly.current = false;
     setDashboards((prev) =>
@@ -3069,6 +3380,7 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
   const moveWidgetLayer = useCallback(
     (id: string, direction: 'up' | 'down') => {
       if (!activeIdRef.current) return;
+      if (isActiveBoardReadOnlyRef.current) return;
 
       setDashboards((prev) => {
         const active = prev.find((d) => d.id === activeIdRef.current);
@@ -3121,6 +3433,7 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
 
   const minimizeAllWidgets = useCallback(() => {
     if (!activeId) return;
+    if (isActiveBoardReadOnlyRef.current) return;
     lastLocalUpdateAt.current = Date.now();
     lastUpdateWasSettingsOnly.current = false;
     setDashboards((prev) =>
@@ -3141,6 +3454,7 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
 
   const restoreAllWidgets = useCallback(() => {
     if (!activeId) return;
+    if (isActiveBoardReadOnlyRef.current) return;
     lastLocalUpdateAt.current = Date.now();
     lastUpdateWasSettingsOnly.current = false;
     setDashboards((prev) =>
@@ -3162,6 +3476,7 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
 
   const deleteAllWidgets = useCallback(() => {
     if (!activeId) return;
+    if (isActiveBoardReadOnlyRef.current) return;
     lastLocalUpdateAt.current = Date.now();
     lastUpdateWasSettingsOnly.current = false;
     setDashboards((prev) =>
@@ -3173,6 +3488,7 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
   const resetWidgetSize = useCallback(
     (id: string) => {
       if (!activeId) return;
+      if (isActiveBoardReadOnlyRef.current) return;
       lastLocalUpdateAt.current = Date.now();
       lastUpdateWasSettingsOnly.current = false;
       setDashboards((prev) =>
@@ -3198,6 +3514,7 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
 
   const setBackground = useCallback((bg: string) => {
     if (!activeIdRef.current) return;
+    if (isActiveBoardReadOnlyRef.current) return;
     lastLocalUpdateAt.current = Date.now();
     lastUpdateWasSettingsOnly.current = false;
     setDashboards((prev) =>
@@ -3210,6 +3527,7 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
   const updateDashboardSettings = useCallback(
     (updates: Partial<Dashboard['settings']>) => {
       if (!activeIdRef.current) return;
+      if (isActiveBoardReadOnlyRef.current) return;
       lastLocalUpdateAt.current = Date.now();
       lastUpdateWasSettingsOnly.current = true;
       setDashboards((prev) =>
@@ -3231,6 +3549,15 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
 
   const updateDashboard = useCallback((updates: Partial<Dashboard>) => {
     if (!activeIdRef.current) return;
+    // Allow updates that only change link bookkeeping (so we can mark a
+    // viewer's board as "share ended" or detach a guest) but block any
+    // content edits when the board is read-only.
+    if (isActiveBoardReadOnlyRef.current) {
+      const onlyLinkFields = Object.keys(updates).every((k) =>
+        k.startsWith('linkedShare')
+      );
+      if (!onlyLinkFields) return;
+    }
     lastLocalUpdateAt.current = Date.now();
     lastUpdateWasSettingsOnly.current = false;
     setDashboards((prev) =>
@@ -3240,6 +3567,7 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
 
   const setGlobalStyle = useCallback((style: Partial<GlobalStyle>) => {
     if (!activeIdRef.current) return;
+    if (isActiveBoardReadOnlyRef.current) return;
     lastLocalUpdateAt.current = Date.now();
     lastUpdateWasSettingsOnly.current = false;
     setDashboards((prev) =>
@@ -3381,6 +3709,11 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
       loadSharedDashboard: handleLoadSharedDashboard,
       pendingShareId,
       clearPendingShare,
+      pendingShareImport,
+      cancelPendingShareImport,
+      importSharedBoard,
+      stopSharingDashboard,
+      isActiveBoardReadOnly,
       pendingQuizShareId,
       clearPendingQuizShare,
       setPendingQuizShareId,
@@ -3474,6 +3807,11 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
       handleLoadSharedDashboard,
       pendingShareId,
       clearPendingShare,
+      pendingShareImport,
+      cancelPendingShareImport,
+      importSharedBoard,
+      stopSharingDashboard,
+      isActiveBoardReadOnly,
       pendingQuizShareId,
       clearPendingQuizShare,
       setPendingQuizShareId,

--- a/context/DashboardContext.tsx
+++ b/context/DashboardContext.tsx
@@ -670,9 +670,15 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
 
       // Firestore-backed share: also tag the local dashboard so subsequent
       // edits mirror to the shared doc and Synced/View-Only guests stay in
-      // sync with the host.
+      // sync with the host. Both writes (the shared_boards seed and the
+      // local dashboard with its new linkage) MUST go through PII scrubbing
+      // — Firestore never holds student-name fields, even for the owner's
+      // own dashboards collection. The mirror effect (further down) and the
+      // local saveDashboard() path do this independently; here we scrub the
+      // shared_boards seed up front so the very first write is clean too.
       const hostName = user?.displayName ?? user?.email ?? undefined;
-      const shareId = await shareDashboardFirestore(dashboard, hostName);
+      const scrubbedSeed = scrubDashboardPII(dashboard);
+      const shareId = await shareDashboardFirestore(scrubbedSeed, hostName);
       const tagged: Dashboard = {
         ...dashboard,
         linkedShareId: shareId,
@@ -681,12 +687,16 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
         linkedShareEnded: false,
       };
       // Optimistic local update so the UI reflects the live-share state
-      // immediately. The next save effect will persist this to Firestore.
+      // immediately.
       setDashboards((prev) =>
         prev.map((d) => (d.id === dashboard.id ? tagged : d))
       );
+      // Persist the linkage via the full saveDashboard pipeline, which
+      // handles PII scrub + Drive supplement. Going through
+      // saveDashboardFirestore directly would bypass that and could leak
+      // restored-from-Drive PII to Firestore.
       try {
-        await saveDashboardFirestore(tagged);
+        await saveDashboard(tagged);
       } catch (e) {
         console.error('Failed to persist share linkage on dashboard:', e);
       }
@@ -696,7 +706,7 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
       isAdmin,
       driveService,
       shareDashboardFirestore,
-      saveDashboardFirestore,
+      saveDashboard,
       userDomain,
       user,
     ]
@@ -1827,6 +1837,13 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
   useEffect(() => {
     if (!user) return;
 
+    // Track which shareIds are still actively linked this pass so we can
+    // cancel any pending timers for dashboards that have been detached
+    // (stopSharingDashboard / leaveSharedBoard) before their 500ms debounce
+    // window elapses. Without this, a stale snapshot would land in the
+    // shared doc after the user already stopped sharing.
+    const liveShareIds = new Set<string>();
+
     dashboards.forEach((d) => {
       if (!d.linkedShareId || d.linkedShareEnded) return;
       if (
@@ -1836,18 +1853,26 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
         return;
       }
 
-      // Cheap dedupe based on the same fields the saveDashboard path uses.
-      const payload = serializeDashboard(d);
-      if (lastMirroredRef.current.get(d.linkedShareId) === payload) return;
-
       const shareId = d.linkedShareId;
+      liveShareIds.add(shareId);
+
+      // Scrub student PII before broadcasting. The local dashboard may have
+      // had names merged back in from Drive (mergeDashboardPII); those must
+      // never reach Firestore — least of all the cross-user shared_boards
+      // collection. The mirror sees only scrubbed data.
+      const scrubbed = scrubDashboardPII(d);
+
+      // Cheap dedupe based on the same fields the saveDashboard path uses.
+      const payload = serializeDashboard(scrubbed);
+      if (lastMirroredRef.current.get(shareId) === payload) return;
+
       const existing = mirrorTimersRef.current.get(shareId);
       if (existing) clearTimeout(existing);
 
       const timer = setTimeout(() => {
         mirrorTimersRef.current.delete(shareId);
         lastMirroredRef.current.set(shareId, payload);
-        void mirrorSharedBoard(shareId, d).catch((err) => {
+        void mirrorSharedBoard(shareId, scrubbed).catch((err) => {
           console.warn('Mirror to shared board failed:', err);
           // Drop the cached payload so we retry on the next change.
           lastMirroredRef.current.delete(shareId);
@@ -1855,6 +1880,16 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
       }, 500);
       mirrorTimersRef.current.set(shareId, timer);
     });
+
+    // Cancel pending writes for shareIds that are no longer in the live set —
+    // i.e. boards that were detached/unlinked while a debounce was queued.
+    for (const [shareId, timer] of mirrorTimersRef.current) {
+      if (!liveShareIds.has(shareId)) {
+        clearTimeout(timer);
+        mirrorTimersRef.current.delete(shareId);
+        lastMirroredRef.current.delete(shareId);
+      }
+    }
   }, [dashboards, user, mirrorSharedBoard]);
 
   // Cleanup pending mirror timers on unmount so we don't write after teardown.

--- a/context/DashboardContextValue.ts
+++ b/context/DashboardContextValue.ts
@@ -17,6 +17,20 @@ import {
 } from '../types';
 import type { RosterCreateMeta } from '../hooks/useRosters';
 
+/** Mode chosen by the recipient when pasting a shared-board URL. */
+export type SharedBoardImportMode = 'copy' | 'synced' | 'view-only';
+
+export interface PendingShareImport {
+  shareId: string;
+  /** Snapshot fetched from the shared doc — populated when the picker opens. */
+  preview: Dashboard | null;
+  /**
+   * Drive-backed shares are one-time exports and only support 'copy' mode.
+   * Firestore-backed shares support all three modes.
+   */
+  driveBacked: boolean;
+}
+
 export interface AnnotationState {
   objects: DrawableObject[];
   color: string;
@@ -119,6 +133,16 @@ export interface DashboardContextValue {
   loadSharedDashboard: (shareId: string) => Promise<Dashboard | null>;
   pendingShareId: string | null;
   clearPendingShare: () => void;
+  /** Set after the picker should be displayed — null when no import is pending. */
+  pendingShareImport: PendingShareImport | null;
+  /** Cancel the pending import (close picker without importing). */
+  cancelPendingShareImport: () => void;
+  /** Complete the pending import in the chosen mode. */
+  importSharedBoard: (mode: SharedBoardImportMode) => Promise<void>;
+  /** Host action: tear down the live share for the active dashboard. */
+  stopSharingDashboard: (dashboardId: string) => Promise<void>;
+  /** True when the active dashboard is a view-only guest copy. */
+  isActiveBoardReadOnly: boolean;
   pendingQuizShareId: string | null;
   clearPendingQuizShare: () => void;
   pendingAssignmentShareId: string | null;

--- a/firestore.rules
+++ b/firestore.rules
@@ -601,12 +601,17 @@ service cloud.firestore {
         (resource.data.get('originalAuthor', null) == request.auth.uid || isAdmin());
 
       // Collaborator (Synced participant): may update content but must not
-      // change participants map, originalAuthor, or sharedAt.
+      // change participants map, originalAuthor, originalAuthorName, or
+      // sharedAt. originalAuthorName in particular is the host display
+      // name shown in the import-picker / banner UI for every participant,
+      // so a collaborator who could rewrite it would be able to spoof the
+      // host's identity to other peers.
       allow update: if request.auth != null &&
         request.auth.uid in resource.data.get('participants', {}) &&
         resource.data.participants[request.auth.uid].get('role', '') == 'collaborator' &&
         request.resource.data.get('participants', {}) == resource.data.get('participants', {}) &&
         request.resource.data.originalAuthor == resource.data.originalAuthor &&
+        request.resource.data.get('originalAuthorName', null) == resource.data.get('originalAuthorName', null) &&
         request.resource.data.get('sharedAt', null) == resource.data.get('sharedAt', null);
 
       // Self-join: any authed user may add ONLY their own uid to participants

--- a/firestore.rules
+++ b/firestore.rules
@@ -569,13 +569,66 @@ service cloud.firestore {
       allow write: if isAdmin();
     }
 
-    // Shared boards - Anyone can read, only authenticated users can create. 
-    // Authors and admins can update or delete.
+    // Shared boards — backing store for live-shared dashboards.
+    // Three import modes are layered on top of this collection:
+    //   - "Make a Copy"  : reader pulls a snapshot, no doc-side state changes
+    //   - "View-Only"    : reader joins as { role: 'viewer' }, host pushes updates
+    //   - "Synced"       : reader joins as { role: 'collaborator' }, both push updates
+    //
+    // Field surface:
+    //   originalAuthor: string (uid)         — host, set at create
+    //   sharedAt: number                     — timestamp
+    //   participants: { [uid]: { role, joinedAt, displayName? } }
+    //   updatedAt?: number / updatedBy?: string  — last writer (echo prevention)
+    //   ...plus all Dashboard fields (name, background, widgets, globalStyle, settings)
+    //
+    // Update rules:
+    //   - Host can update anything (content + participants).
+    //   - A participant with role=='collaborator' (Synced) can update content
+    //     fields but cannot rewrite the participants map or transfer ownership.
+    //   - A participant with role=='viewer' cannot update.
+    //   - Any authed user can append themselves to participants (join), but
+    //     cannot mutate other participants' entries or change other fields in
+    //     the same write.
     match /shared_boards/{shareId} {
       allow read: if request.auth != null;
+
       allow create: if request.auth != null &&
         request.resource.data.originalAuthor == request.auth.uid;
-      allow update, delete: if request.auth != null &&
+
+      // Host or admin: full update power (content + participants).
+      allow update: if request.auth != null &&
+        (resource.data.get('originalAuthor', null) == request.auth.uid || isAdmin());
+
+      // Collaborator (Synced participant): may update content but must not
+      // change participants map, originalAuthor, or sharedAt.
+      allow update: if request.auth != null &&
+        request.auth.uid in resource.data.get('participants', {}) &&
+        resource.data.participants[request.auth.uid].get('role', '') == 'collaborator' &&
+        request.resource.data.get('participants', {}) == resource.data.get('participants', {}) &&
+        request.resource.data.originalAuthor == resource.data.originalAuthor &&
+        request.resource.data.get('sharedAt', null) == resource.data.get('sharedAt', null);
+
+      // Self-join: any authed user may add ONLY their own uid to participants
+      // without changing any other field. Used by importers picking Synced
+      // or View-Only mode.
+      allow update: if request.auth != null &&
+        !(request.auth.uid in resource.data.get('participants', {})) &&
+        request.auth.uid in request.resource.data.get('participants', {}) &&
+        request.resource.data.participants.diff(resource.data.get('participants', {}))
+          .affectedKeys().hasOnly([request.auth.uid]) &&
+        request.resource.data.diff(resource.data).affectedKeys().hasOnly(['participants']);
+
+      // Self-leave: any participant may remove ONLY their own uid from
+      // participants without changing any other field.
+      allow update: if request.auth != null &&
+        request.auth.uid in resource.data.get('participants', {}) &&
+        !(request.auth.uid in request.resource.data.get('participants', {})) &&
+        resource.data.participants.diff(request.resource.data.get('participants', {}))
+          .affectedKeys().hasOnly([request.auth.uid]) &&
+        request.resource.data.diff(resource.data).affectedKeys().hasOnly(['participants']);
+
+      allow delete: if request.auth != null &&
         (resource.data.get('originalAuthor', null) == request.auth.uid || isAdmin());
     }
 

--- a/hooks/useFirestore.ts
+++ b/hooks/useFirestore.ts
@@ -7,13 +7,15 @@ import {
   setDoc,
   addDoc,
   deleteDoc,
+  deleteField,
   onSnapshot,
   query,
   orderBy,
+  updateDoc,
   writeBatch,
 } from 'firebase/firestore';
 import { db, isAuthBypass } from '../config/firebase';
-import { Dashboard } from '../types';
+import { Dashboard, SharedBoardParticipant } from '../types';
 
 /**
  * Singleton pattern for mock storage in bypass mode.
@@ -103,6 +105,8 @@ class MockDashboardStore {
 class MockSharedStore {
   private static instance: MockSharedStore;
   private shared: Map<string, Dashboard> = new Map();
+  private listeners: Map<string, Set<(d: Dashboard | null) => void>> =
+    new Map();
 
   private constructor() {
     // Private constructor for singleton
@@ -119,12 +123,27 @@ class MockSharedStore {
     const id = 'share-' + Date.now();
     const data = { ...dashboard, id };
     this.shared.set(id, data);
-    try {
-      sessionStorage.setItem('mock_shared_' + id, JSON.stringify(data));
-    } catch (e) {
-      console.error('Failed to save mock share to storage', e);
-    }
+    this.persist(id, data);
     return id;
+  }
+
+  update(id: string, patch: Partial<Dashboard>): void {
+    const existing = this.get(id);
+    if (!existing) return;
+    const updated = { ...existing, ...patch, id };
+    this.shared.set(id, updated);
+    this.persist(id, updated);
+    this.notify(id, updated);
+  }
+
+  remove(id: string): void {
+    this.shared.delete(id);
+    try {
+      sessionStorage.removeItem('mock_shared_' + id);
+    } catch {
+      /* no-op */
+    }
+    this.notify(id, null);
   }
 
   get(id: string): Dashboard | undefined {
@@ -141,6 +160,31 @@ class MockSharedStore {
       console.error('Failed to load mock share from storage', e);
     }
     return undefined;
+  }
+
+  subscribe(id: string, cb: (d: Dashboard | null) => void): () => void {
+    let bucket = this.listeners.get(id);
+    if (!bucket) {
+      bucket = new Set();
+      this.listeners.set(id, bucket);
+    }
+    bucket.add(cb);
+    cb(this.get(id) ?? null);
+    return () => {
+      this.listeners.get(id)?.delete(cb);
+    };
+  }
+
+  private persist(id: string, data: Dashboard): void {
+    try {
+      sessionStorage.setItem('mock_shared_' + id, JSON.stringify(data));
+    } catch (e) {
+      console.error('Failed to save mock share to storage', e);
+    }
+  }
+
+  private notify(id: string, data: Dashboard | null): void {
+    this.listeners.get(id)?.forEach((cb) => cb(data));
   }
 }
 
@@ -253,23 +297,181 @@ export const useFirestore = (userId: string | null) => {
   );
 
   const shareDashboard = useCallback(
-    async (dashboard: Dashboard): Promise<string> => {
+    async (dashboard: Dashboard, hostDisplayName?: string): Promise<string> => {
       if (isAuthBypass) {
         return mockSharedStore.add(dashboard);
       }
 
       const shareRef = collection(db, 'shared_boards');
-      // We exclude the ID when creating a new shared document
-      const { id: _id, ...data } = dashboard;
+      // Drop link metadata from the snapshot so guests don't inherit the
+      // host's role bookkeeping and so a shared board can never reference
+      // itself as a parent.
+      const {
+        id: _id,
+        linkedShareId: _ls,
+        linkedShareRole: _lsr,
+        linkedShareHostName: _lsh,
+        linkedShareEnded: _lse,
+        ...data
+      } = dashboard;
 
       const docRef = await addDoc(shareRef, {
         ...data,
         sharedAt: Date.now(),
         originalAuthor: userId,
+        ...(hostDisplayName ? { originalAuthorName: hostDisplayName } : {}),
+        participants: {},
+        updatedAt: Date.now(),
+        updatedBy: userId,
       });
       return docRef.id;
     },
     [userId]
+  );
+
+  /**
+   * Push the host or collaborator's local dashboard state into the shared
+   * doc. Strips the doc id and link bookkeeping so they don't leak to the
+   * other side. `updatedBy` is the local user's uid so subscribers can
+   * skip echoes of their own writes.
+   */
+  const mirrorSharedBoard = useCallback(
+    async (shareId: string, dashboard: Dashboard): Promise<void> => {
+      if (isAuthBypass) {
+        const {
+          id: _id,
+          linkedShareId: _ls,
+          linkedShareRole: _lsr,
+          linkedShareHostName: _lsh,
+          linkedShareEnded: _lse,
+          ...patch
+        } = dashboard;
+        mockSharedStore.update(shareId, {
+          ...patch,
+          updatedAt: Date.now(),
+          updatedBy: userId ?? 'mock',
+        } as Partial<Dashboard>);
+        return;
+      }
+
+      if (!userId) return;
+      const docRef = doc(db, 'shared_boards', shareId);
+      const {
+        id: _id,
+        linkedShareId: _ls,
+        linkedShareRole: _lsr,
+        linkedShareHostName: _lsh,
+        linkedShareEnded: _lse,
+        ...patch
+      } = dashboard;
+      // updateDoc preserves participants/originalAuthor/sharedAt so guests
+      // and host bookkeeping survive across mirrors.
+      await updateDoc(docRef, {
+        ...patch,
+        updatedAt: Date.now(),
+        updatedBy: userId,
+      });
+    },
+    [userId]
+  );
+
+  const subscribeToSharedBoard = useCallback(
+    (
+      shareId: string,
+      callback: (dashboard: Dashboard | null) => void
+    ): (() => void) => {
+      if (isAuthBypass) {
+        return mockSharedStore.subscribe(shareId, callback);
+      }
+      const docRef = doc(db, 'shared_boards', shareId);
+      return onSnapshot(
+        docRef,
+        (snap) => {
+          if (!snap.exists()) {
+            callback(null);
+            return;
+          }
+          callback({ ...snap.data(), id: snap.id } as Dashboard);
+        },
+        (err) => {
+          console.error('Failed to subscribe to shared board:', err);
+          callback(null);
+        }
+      );
+    },
+    []
+  );
+
+  const joinSharedBoard = useCallback(
+    async (
+      shareId: string,
+      role: SharedBoardParticipant['role'],
+      displayName?: string
+    ): Promise<void> => {
+      if (!userId) return;
+      const entry: SharedBoardParticipant = {
+        role,
+        joinedAt: Date.now(),
+        ...(displayName ? { displayName } : {}),
+      };
+      if (isAuthBypass) {
+        const existing = mockSharedStore.get(shareId);
+        if (!existing) return;
+        const participants = {
+          ...((existing as unknown as Record<string, unknown>).participants as
+            | Record<string, SharedBoardParticipant>
+            | undefined),
+          [userId]: entry,
+        };
+        mockSharedStore.update(shareId, {
+          ...({ participants } as unknown as Partial<Dashboard>),
+        });
+        return;
+      }
+      const docRef = doc(db, 'shared_boards', shareId);
+      await updateDoc(docRef, {
+        [`participants.${userId}`]: entry,
+      });
+    },
+    [userId]
+  );
+
+  const leaveSharedBoard = useCallback(
+    async (shareId: string): Promise<void> => {
+      if (!userId) return;
+      if (isAuthBypass) {
+        const existing = mockSharedStore.get(shareId);
+        if (!existing) return;
+        const participants = {
+          ...((existing as unknown as Record<string, unknown>).participants as
+            | Record<string, SharedBoardParticipant>
+            | undefined),
+        };
+        delete participants[userId];
+        mockSharedStore.update(shareId, {
+          ...({ participants } as unknown as Partial<Dashboard>),
+        });
+        return;
+      }
+      const docRef = doc(db, 'shared_boards', shareId);
+      await updateDoc(docRef, {
+        [`participants.${userId}`]: deleteField(),
+      });
+    },
+    [userId]
+  );
+
+  /** Host-only: tear down the shared doc so guests detect a "share ended" state. */
+  const stopSharingBoard = useCallback(
+    async (shareId: string): Promise<void> => {
+      if (isAuthBypass) {
+        mockSharedStore.remove(shareId);
+        return;
+      }
+      const docRef = doc(db, 'shared_boards', shareId);
+      await deleteDoc(docRef);
+    },
+    []
   );
 
   const loadSharedDashboard = useCallback(
@@ -297,5 +499,10 @@ export const useFirestore = (userId: string | null) => {
     subscribeToDashboards,
     shareDashboard,
     loadSharedDashboard,
+    mirrorSharedBoard,
+    subscribeToSharedBoard,
+    joinSharedBoard,
+    leaveSharedBoard,
+    stopSharingBoard,
   };
 };

--- a/hooks/useFirestore.ts
+++ b/hooks/useFirestore.ts
@@ -191,6 +191,27 @@ class MockSharedStore {
 const mockStore = MockDashboardStore.getInstance();
 const mockSharedStore = MockSharedStore.getInstance();
 
+/**
+ * Normalize a /shared_boards/{shareId} doc payload into a Dashboard the
+ * client can consume directly. The shared doc stores the host's display
+ * name under `originalAuthorName` (the per-user link bookkeeping field
+ * `linkedShareHostName` is intentionally stripped on write — it's
+ * per-recipient state, not part of the broadcast). Map it back here so
+ * downstream callers see a single canonical field.
+ */
+function mapSharedDocToDashboard(data: unknown, shareId: string): Dashboard {
+  const record = (data ?? {}) as Record<string, unknown>;
+  const originalAuthorName =
+    typeof record.originalAuthorName === 'string'
+      ? record.originalAuthorName
+      : undefined;
+  return {
+    ...(record as unknown as Dashboard),
+    id: shareId,
+    ...(originalAuthorName ? { linkedShareHostName: originalAuthorName } : {}),
+  };
+}
+
 export const useFirestore = (userId: string | null) => {
   const dashboardsRef = useMemo(
     () =>
@@ -299,7 +320,14 @@ export const useFirestore = (userId: string | null) => {
   const shareDashboard = useCallback(
     async (dashboard: Dashboard, hostDisplayName?: string): Promise<string> => {
       if (isAuthBypass) {
-        return mockSharedStore.add(dashboard);
+        // Stash the host display name on the mock doc under the same field
+        // the live path uses so loadSharedDashboard's mapping works in bypass.
+        return mockSharedStore.add({
+          ...dashboard,
+          ...(hostDisplayName
+            ? ({ originalAuthorName: hostDisplayName } as Partial<Dashboard>)
+            : {}),
+        } as Dashboard);
       }
 
       const shareRef = collection(db, 'shared_boards');
@@ -391,7 +419,7 @@ export const useFirestore = (userId: string | null) => {
             callback(null);
             return;
           }
-          callback({ ...snap.data(), id: snap.id } as Dashboard);
+          callback(mapSharedDocToDashboard(snap.data(), snap.id));
         },
         (err) => {
           console.error('Failed to subscribe to shared board:', err);
@@ -477,14 +505,14 @@ export const useFirestore = (userId: string | null) => {
   const loadSharedDashboard = useCallback(
     async (shareId: string): Promise<Dashboard | null> => {
       if (isAuthBypass) {
-        return mockSharedStore.get(shareId) ?? null;
+        const mock = mockSharedStore.get(shareId) ?? null;
+        return mock ? mapSharedDocToDashboard(mock, shareId) : null;
       }
 
       const docRef = doc(db, 'shared_boards', shareId);
       const snap = await getDoc(docRef);
       if (snap.exists()) {
-        const data = snap.data();
-        return { ...data, id: snap.id } as Dashboard;
+        return mapSharedDocToDashboard(snap.data(), snap.id);
       }
       return null;
     },

--- a/tests/DashboardContext_sharing.test.tsx
+++ b/tests/DashboardContext_sharing.test.tsx
@@ -28,15 +28,24 @@ const mockLoadSharedDashboard = vi.fn();
 const mockSaveDashboard = vi.fn().mockResolvedValue(undefined);
 const mockJoinSharedBoard = vi.fn().mockResolvedValue(undefined);
 const mockSubscribeToSharedBoard = vi.fn(() => () => undefined);
+const mockMirrorSharedBoard = vi.fn().mockResolvedValue(undefined);
+const mockStopSharingBoard = vi.fn().mockResolvedValue(undefined);
+const mockLeaveSharedBoard = vi.fn().mockResolvedValue(undefined);
 
 type SubscribeCallback = (
   dashboards: Dashboard[],
   hasPendingWrites: boolean
 ) => void;
 
+// Mutable seed for the initial dashboards-list snapshot. Tests that need
+// the provider to start with a pre-existing linked board override this in
+// their setup before render. Default = empty list so legacy tests are
+// unaffected.
+let initialDashboardsSeed: Dashboard[] = [];
+
 const mockSubscribeToDashboards = vi.fn((cb: SubscribeCallback) => {
-  // Immediate callback with empty list to simulate loaded state
-  cb([], false);
+  // Immediate callback with the seeded list to simulate loaded state
+  cb(initialDashboardsSeed, false);
   return () => {
     // no-op
   };
@@ -50,11 +59,11 @@ vi.mock('../hooks/useFirestore', () => ({
     subscribeToDashboards: mockSubscribeToDashboards,
     shareDashboard: vi.fn(),
     loadSharedDashboard: mockLoadSharedDashboard,
-    mirrorSharedBoard: vi.fn().mockResolvedValue(undefined),
+    mirrorSharedBoard: mockMirrorSharedBoard,
     subscribeToSharedBoard: mockSubscribeToSharedBoard,
     joinSharedBoard: mockJoinSharedBoard,
-    leaveSharedBoard: vi.fn().mockResolvedValue(undefined),
-    stopSharingBoard: vi.fn().mockResolvedValue(undefined),
+    leaveSharedBoard: mockLeaveSharedBoard,
+    stopSharingBoard: mockStopSharingBoard,
     rosters: [],
     addRoster: vi.fn(),
     updateRoster: vi.fn(),
@@ -82,6 +91,7 @@ describe('DashboardContext Sharing Logic', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    initialDashboardsSeed = [];
 
     // Simulate visiting the share URL by updating the history state
     window.history.pushState({}, '', '/share/test-share-id');
@@ -284,5 +294,212 @@ describe('DashboardContext Sharing Logic', () => {
       'viewer',
       expect.any(String)
     );
+  });
+
+  // ───────────────────────────────────────────────────────────────────────
+  // Live-share lifecycle: detach during debounce + host-side stopSharing.
+  //
+  // Both paths share a failure mode: the 500ms mirror debounce can fire
+  // AFTER the user already detached, which would write a stale snapshot
+  // into /shared_boards/{shareId} (or worse, a snapshot for a doc that no
+  // longer exists / a participant that no longer has write access). The
+  // mirror effect is supposed to cancel those pending timers when a
+  // shareId leaves the live linked-set; these tests pin that behavior.
+  // ───────────────────────────────────────────────────────────────────────
+  describe('mirror cancellation on detach', () => {
+    beforeEach(() => {
+      // No share URL for these tests — they exercise the linked-board
+      // lifecycle, not the import flow.
+      window.history.pushState({}, '', '/');
+    });
+
+    it('host stopSharingDashboard cancels a pending mirror write within the 500ms debounce window', async () => {
+      // Seed a Synced board this user owns. The mirror effect is meant
+      // to push edits to /shared_boards/{shareId} on a 500ms debounce.
+      const linkedDashboard: Dashboard = {
+        id: 'local-dash-1',
+        name: 'My Linked Board',
+        background: 'bg-slate-800',
+        widgets: [
+          {
+            id: 'w1',
+            type: 'clock',
+            x: 0,
+            y: 0,
+            w: 100,
+            h: 100,
+            z: 1,
+            flipped: false,
+            config: {},
+          },
+        ],
+        createdAt: 1234567890,
+        linkedShareId: 'test-share-id',
+        linkedShareRole: 'owner',
+      };
+      initialDashboardsSeed = [linkedDashboard];
+
+      type Stop = ReturnType<typeof useDashboard>['stopSharingDashboard'];
+      type Update = ReturnType<typeof useDashboard>['updateWidget'];
+      type Load = ReturnType<typeof useDashboard>['loadDashboard'];
+      let stop: Stop | null = null;
+      let update: Update | null = null;
+      let load: Load | null = null;
+
+      const Probe: React.FC = () => {
+        const { stopSharingDashboard, updateWidget, loadDashboard } =
+          useDashboard();
+        useEffect(() => {
+          stop = stopSharingDashboard;
+          update = updateWidget;
+          load = loadDashboard;
+        }, [stopSharingDashboard, updateWidget, loadDashboard]);
+        return <div>Test App</div>;
+      };
+
+      vi.useFakeTimers();
+      try {
+        render(
+          <DashboardProvider>
+            <Probe />
+          </DashboardProvider>
+        );
+
+        // Wait for the provider to settle and capture handles.
+        await vi.waitFor(() => {
+          expect(stop).not.toBeNull();
+          expect(update).not.toBeNull();
+          expect(load).not.toBeNull();
+        });
+
+        // The seeded board has an initial mirror write queued by the
+        // first effect pass (because lastMirroredRef has no entry yet).
+        // Activate it so updateWidget targets it, then trigger an edit
+        // to refresh the debounce window.
+        act(() => {
+          if (load) load('local-dash-1');
+        });
+        act(() => {
+          if (update) update('w1', { x: 50 });
+        });
+
+        // BEFORE 500ms elapses, the host stops sharing.
+        await act(async () => {
+          if (stop) await stop('local-dash-1');
+        });
+
+        // Now advance past the debounce window. The cancellation logic
+        // should have cleared the pending timer, so no mirror write
+        // fires for the detached share.
+        mockMirrorSharedBoard.mockClear();
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(1000);
+        });
+
+        expect(mockMirrorSharedBoard).not.toHaveBeenCalled();
+        // Host detach also tears down the shared doc.
+        expect(mockStopSharingBoard).toHaveBeenCalledWith('test-share-id');
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('host stopSharingDashboard clears linkedShareId on the local board', async () => {
+      // After stop-sharing, the local copy keeps its content but loses
+      // the live-share link metadata so banner / mirror effects detach.
+      const linkedDashboard: Dashboard = {
+        id: 'local-dash-2',
+        name: 'My Linked Board',
+        background: 'bg-slate-800',
+        widgets: [],
+        createdAt: 1234567890,
+        linkedShareId: 'test-share-id',
+        linkedShareRole: 'owner',
+        linkedShareHostName: 'Test User',
+      };
+      initialDashboardsSeed = [linkedDashboard];
+
+      type Stop = ReturnType<typeof useDashboard>['stopSharingDashboard'];
+      let stop: Stop | null = null;
+      let observed: Dashboard | undefined;
+
+      const Probe: React.FC = () => {
+        const { stopSharingDashboard, dashboards } = useDashboard();
+        useEffect(() => {
+          stop = stopSharingDashboard;
+          observed = dashboards.find((d) => d.id === 'local-dash-2');
+        }, [stopSharingDashboard, dashboards]);
+        return <div>Test App</div>;
+      };
+
+      render(
+        <DashboardProvider>
+          <Probe />
+        </DashboardProvider>
+      );
+
+      await waitFor(() => {
+        expect(stop).not.toBeNull();
+        expect(observed?.linkedShareId).toBe('test-share-id');
+      });
+
+      await act(async () => {
+        if (stop) await stop('local-dash-2');
+      });
+
+      await waitFor(() => {
+        expect(observed?.linkedShareId).toBeUndefined();
+        expect(observed?.linkedShareRole).toBeUndefined();
+      });
+      // The shared doc was deleted on the firestore side.
+      expect(mockStopSharingBoard).toHaveBeenCalledWith('test-share-id');
+      // saveDashboard was called with the detached (cleared-link) snapshot.
+      const detachedSave = (
+        mockSaveDashboard.mock.calls as Array<[Dashboard]>
+      ).find(
+        (c) => c[0].id === 'local-dash-2' && c[0].linkedShareId === undefined
+      );
+      expect(detachedSave).toBeDefined();
+    });
+
+    it('guest stopSharingDashboard calls leaveSharedBoard, not stopSharingBoard', async () => {
+      // Guests can leave but cannot tear down the host's shared doc.
+      const linkedDashboard: Dashboard = {
+        id: 'guest-dash',
+        name: 'Joined Board',
+        background: 'bg-slate-800',
+        widgets: [],
+        createdAt: 1234567890,
+        linkedShareId: 'test-share-id',
+        linkedShareRole: 'collaborator',
+      };
+      initialDashboardsSeed = [linkedDashboard];
+
+      type Stop = ReturnType<typeof useDashboard>['stopSharingDashboard'];
+      let stop: Stop | null = null;
+
+      const Probe: React.FC = () => {
+        const { stopSharingDashboard } = useDashboard();
+        useEffect(() => {
+          stop = stopSharingDashboard;
+        }, [stopSharingDashboard]);
+        return <div>Test App</div>;
+      };
+
+      render(
+        <DashboardProvider>
+          <Probe />
+        </DashboardProvider>
+      );
+
+      await waitFor(() => expect(stop).not.toBeNull());
+
+      await act(async () => {
+        if (stop) await stop('guest-dash');
+      });
+
+      expect(mockLeaveSharedBoard).toHaveBeenCalledWith('test-share-id');
+      expect(mockStopSharingBoard).not.toHaveBeenCalled();
+    });
   });
 });

--- a/tests/DashboardContext_sharing.test.tsx
+++ b/tests/DashboardContext_sharing.test.tsx
@@ -1,7 +1,8 @@
-import React from 'react';
-import { render, waitFor } from '@testing-library/react';
+import React, { useEffect } from 'react';
+import { act, render, waitFor } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { DashboardProvider } from '../context/DashboardContext';
+import { useDashboard } from '../context/useDashboard';
 import { Dashboard } from '../types';
 
 // Mock dependencies
@@ -25,6 +26,8 @@ vi.mock('../context/useAuth', () => ({
 
 const mockLoadSharedDashboard = vi.fn();
 const mockSaveDashboard = vi.fn().mockResolvedValue(undefined);
+const mockJoinSharedBoard = vi.fn().mockResolvedValue(undefined);
+const mockSubscribeToSharedBoard = vi.fn(() => () => undefined);
 
 type SubscribeCallback = (
   dashboards: Dashboard[],
@@ -47,6 +50,11 @@ vi.mock('../hooks/useFirestore', () => ({
     subscribeToDashboards: mockSubscribeToDashboards,
     shareDashboard: vi.fn(),
     loadSharedDashboard: mockLoadSharedDashboard,
+    mirrorSharedBoard: vi.fn().mockResolvedValue(undefined),
+    subscribeToSharedBoard: mockSubscribeToSharedBoard,
+    joinSharedBoard: mockJoinSharedBoard,
+    leaveSharedBoard: vi.fn().mockResolvedValue(undefined),
+    stopSharingBoard: vi.fn().mockResolvedValue(undefined),
     rosters: [],
     addRoster: vi.fn(),
     updateRoster: vi.fn(),
@@ -89,7 +97,7 @@ describe('DashboardContext Sharing Logic', () => {
     window.history.pushState({}, '', originalPathname);
   });
 
-  it('should load shared dashboard and duplicate it when visiting share URL', async () => {
+  it('should fetch shared dashboard and open the import picker (no auto-copy)', async () => {
     const sharedDashboard: Dashboard = {
       id: 'original-id',
       name: 'Shared Board',
@@ -100,9 +108,20 @@ describe('DashboardContext Sharing Logic', () => {
 
     mockLoadSharedDashboard.mockResolvedValue(sharedDashboard);
 
+    type CapturedImport = ReturnType<typeof useDashboard>['pendingShareImport'];
+    let capturedPendingImport: CapturedImport = null;
+
+    const Probe: React.FC = () => {
+      const { pendingShareImport } = useDashboard();
+      useEffect(() => {
+        capturedPendingImport = pendingShareImport;
+      }, [pendingShareImport]);
+      return <div>Test App</div>;
+    };
+
     render(
       <DashboardProvider>
-        <div>Test App</div>
+        <Probe />
       </DashboardProvider>
     );
 
@@ -114,24 +133,156 @@ describe('DashboardContext Sharing Logic', () => {
       { timeout: 2000 }
     );
 
-    // Verify saveDashboard is called (duplication)
+    // The picker should be open (pendingShareImport set with the snapshot).
     await waitFor(() => {
-      expect(mockSaveDashboard).toHaveBeenCalled();
-      // We might have multiple calls to saveDashboard (one for default dashboard, one for shared)
-      // We need to find the one that corresponds to the shared dashboard
-      const calls = mockSaveDashboard.mock.calls as Array<[Dashboard]>;
-      const sharedSave = calls.find(
-        (call) => call[0].name === 'Shared Board (Copy)'
-      );
-      expect(sharedSave).toBeDefined();
-      if (sharedSave) {
-        expect(sharedSave[0].id).not.toBe('original-id');
-      }
+      expect(capturedPendingImport).not.toBeNull();
+      expect(capturedPendingImport?.shareId).toBe('test-share-id');
+      expect(capturedPendingImport?.preview?.name).toBe('Shared Board');
+      // Firestore-style id (no `drive-` prefix) → all 3 modes available.
+      expect(capturedPendingImport?.driveBacked).toBe(false);
     });
 
-    // Verify URL cleanup
+    // No auto-import: saveDashboard is NOT called for a shared board copy.
+    const sharedSave = (
+      mockSaveDashboard.mock.calls as Array<[Dashboard]>
+    ).find((c) => /Shared Board/.test(c[0].name));
+    expect(sharedSave).toBeUndefined();
+  });
+
+  it('importSharedBoard("copy") saves a (Copy) duplicate without join', async () => {
+    const sharedDashboard: Dashboard = {
+      id: 'original-id',
+      name: 'Shared Board',
+      background: 'bg-slate-900',
+      widgets: [],
+      createdAt: 1234567890,
+    };
+    mockLoadSharedDashboard.mockResolvedValue(sharedDashboard);
+
+    type Importer = ReturnType<typeof useDashboard>['importSharedBoard'];
+    let importer: Importer | null = null;
+
+    const Probe: React.FC = () => {
+      const { pendingShareImport, importSharedBoard } = useDashboard();
+      useEffect(() => {
+        if (pendingShareImport) importer = importSharedBoard;
+      }, [pendingShareImport, importSharedBoard]);
+      return <div>Test App</div>;
+    };
+
+    render(
+      <DashboardProvider>
+        <Probe />
+      </DashboardProvider>
+    );
+
+    await waitFor(() => expect(importer).not.toBeNull());
+    await act(async () => {
+      if (importer) await importer('copy');
+    });
+
+    const copySave = (mockSaveDashboard.mock.calls as Array<[Dashboard]>).find(
+      (c) => c[0].name === 'Shared Board (Copy)'
+    );
+    expect(copySave).toBeDefined();
+    expect(copySave?.[0].id).not.toBe('original-id');
+    // Copy mode does NOT establish a live link.
+    expect(copySave?.[0].linkedShareId).toBeUndefined();
+    expect(copySave?.[0].linkedShareRole).toBeUndefined();
+    // Copy mode never joins participants.
+    expect(mockJoinSharedBoard).not.toHaveBeenCalled();
+    // URL cleanup runs.
     await waitFor(() => {
       expect(replaceStateMock).toHaveBeenCalledWith(null, '', '/');
     });
+  });
+
+  it('importSharedBoard("synced") tags the local board as collaborator and joins', async () => {
+    const sharedDashboard: Dashboard = {
+      id: 'original-id',
+      name: 'Shared Board',
+      background: 'bg-slate-900',
+      widgets: [],
+      createdAt: 1234567890,
+    };
+    mockLoadSharedDashboard.mockResolvedValue(sharedDashboard);
+
+    type Importer = ReturnType<typeof useDashboard>['importSharedBoard'];
+    let importer: Importer | null = null;
+
+    const Probe: React.FC = () => {
+      const { pendingShareImport, importSharedBoard } = useDashboard();
+      useEffect(() => {
+        if (pendingShareImport) importer = importSharedBoard;
+      }, [pendingShareImport, importSharedBoard]);
+      return <div>Test App</div>;
+    };
+
+    render(
+      <DashboardProvider>
+        <Probe />
+      </DashboardProvider>
+    );
+
+    await waitFor(() => expect(importer).not.toBeNull());
+    await act(async () => {
+      if (importer) await importer('synced');
+    });
+
+    const syncedSave = (
+      mockSaveDashboard.mock.calls as Array<[Dashboard]>
+    ).find((c) => c[0].name === 'Shared Board (Synced)');
+    expect(syncedSave).toBeDefined();
+    expect(syncedSave?.[0].linkedShareId).toBe('test-share-id');
+    expect(syncedSave?.[0].linkedShareRole).toBe('collaborator');
+    expect(mockJoinSharedBoard).toHaveBeenCalledWith(
+      'test-share-id',
+      'collaborator',
+      expect.any(String)
+    );
+  });
+
+  it('importSharedBoard("view-only") tags the local board as viewer', async () => {
+    const sharedDashboard: Dashboard = {
+      id: 'original-id',
+      name: 'Shared Board',
+      background: 'bg-slate-900',
+      widgets: [],
+      createdAt: 1234567890,
+    };
+    mockLoadSharedDashboard.mockResolvedValue(sharedDashboard);
+
+    type Importer = ReturnType<typeof useDashboard>['importSharedBoard'];
+    let importer: Importer | null = null;
+
+    const Probe: React.FC = () => {
+      const { pendingShareImport, importSharedBoard } = useDashboard();
+      useEffect(() => {
+        if (pendingShareImport) importer = importSharedBoard;
+      }, [pendingShareImport, importSharedBoard]);
+      return <div>Test App</div>;
+    };
+
+    render(
+      <DashboardProvider>
+        <Probe />
+      </DashboardProvider>
+    );
+
+    await waitFor(() => expect(importer).not.toBeNull());
+    await act(async () => {
+      if (importer) await importer('view-only');
+    });
+
+    const viewSave = (mockSaveDashboard.mock.calls as Array<[Dashboard]>).find(
+      (c) => c[0].name === 'Shared Board (View-Only)'
+    );
+    expect(viewSave).toBeDefined();
+    expect(viewSave?.[0].linkedShareRole).toBe('viewer');
+    expect(mockJoinSharedBoard).toHaveBeenCalledWith(
+      'test-share-id',
+      'viewer',
+      expect.any(String)
+    );
   });
 });

--- a/tests/rules/sharedBoards.test.ts
+++ b/tests/rules/sharedBoards.test.ts
@@ -1,0 +1,314 @@
+// Firestore security-rules regression for the `/shared_boards/{shareId}`
+// match block introduced with the live-share board picker. The rules carry
+// four separate update branches (host/admin, collaborator, self-join,
+// self-leave) each with its own immutability invariants. A single CEL edit
+// can silently relax any of them — most dangerously the
+// `originalAuthorName` immutability check that prevents a Synced
+// collaborator from spoofing the host display name shown in everyone's
+// import-picker / banner UI.
+//
+// Requires a running Firestore emulator. Invoke via:
+//   pnpm run test:rules
+
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { afterAll, beforeAll, beforeEach, describe, it } from 'vitest';
+import {
+  initializeTestEnvironment,
+  assertSucceeds,
+  assertFails,
+  type RulesTestEnvironment,
+} from '@firebase/rules-unit-testing';
+import {
+  setDoc,
+  getDoc,
+  updateDoc,
+  deleteDoc,
+  deleteField,
+  doc,
+} from 'firebase/firestore';
+
+const PROJECT_ID = 'spartboard-shared-boards';
+const SHARE_ID = 'share-rules-test';
+const HOST_UID = 'host-uid';
+const COLLAB_UID = 'collaborator-uid';
+const VIEWER_UID = 'viewer-uid';
+const STRANGER_UID = 'stranger-uid';
+
+const RULES_PATH = fileURLToPath(
+  new URL('../../firestore.rules', import.meta.url)
+);
+
+let testEnv: RulesTestEnvironment;
+
+const asHost = () =>
+  testEnv
+    .authenticatedContext(HOST_UID, { email: 'host@example.com' })
+    .firestore();
+
+const asCollab = () =>
+  testEnv
+    .authenticatedContext(COLLAB_UID, { email: 'collab@example.com' })
+    .firestore();
+
+const asViewer = () =>
+  testEnv
+    .authenticatedContext(VIEWER_UID, { email: 'viewer@example.com' })
+    .firestore();
+
+const asStranger = () =>
+  testEnv
+    .authenticatedContext(STRANGER_UID, { email: 'stranger@example.com' })
+    .firestore();
+
+const seededShare = (overrides: Record<string, unknown> = {}) => ({
+  name: 'Shared Board',
+  background: 'bg-slate-800',
+  widgets: [],
+  sharedAt: 1000,
+  originalAuthor: HOST_UID,
+  originalAuthorName: 'Host Display',
+  participants: {
+    [COLLAB_UID]: { role: 'collaborator', joinedAt: 1000 },
+    [VIEWER_UID]: { role: 'viewer', joinedAt: 1000 },
+  },
+  updatedAt: 1000,
+  updatedBy: HOST_UID,
+  ...overrides,
+});
+
+beforeAll(async () => {
+  testEnv = await initializeTestEnvironment({
+    projectId: PROJECT_ID,
+    firestore: {
+      rules: readFileSync(RULES_PATH, 'utf8'),
+      host: process.env.FIRESTORE_EMULATOR_HOST?.split(':')[0] ?? '127.0.0.1',
+      port: Number(
+        process.env.FIRESTORE_EMULATOR_HOST?.split(':')[1] ?? '8080'
+      ),
+    },
+  });
+});
+
+afterAll(async () => {
+  await testEnv?.cleanup();
+});
+
+beforeEach(async () => {
+  await testEnv.clearFirestore();
+  await testEnv.withSecurityRulesDisabled(async (ctx) => {
+    await setDoc(
+      doc(ctx.firestore(), `shared_boards/${SHARE_ID}`),
+      seededShare()
+    );
+  });
+});
+
+describe('shared_boards — read', () => {
+  it('any authenticated user can read a known shareId', async () => {
+    // The shareId is an unguessable Firestore-generated id, so reads are
+    // gated only on auth (matches the existing posture).
+    await assertSucceeds(
+      getDoc(doc(asStranger(), `shared_boards/${SHARE_ID}`))
+    );
+  });
+});
+
+describe('shared_boards — host update', () => {
+  it('host can update content fields', async () => {
+    await assertSucceeds(
+      updateDoc(doc(asHost(), `shared_boards/${SHARE_ID}`), {
+        name: 'Renamed by host',
+        widgets: [{ id: 'w1' }],
+        updatedAt: 2000,
+        updatedBy: HOST_UID,
+      })
+    );
+  });
+
+  it('host can rewrite the participants map (kick/promote)', async () => {
+    await assertSucceeds(
+      updateDoc(doc(asHost(), `shared_boards/${SHARE_ID}`), {
+        [`participants.${COLLAB_UID}`]: {
+          role: 'viewer',
+          joinedAt: 1500,
+        },
+        updatedAt: 2000,
+        updatedBy: HOST_UID,
+      })
+    );
+  });
+
+  it('host can delete the shared doc (revoke)', async () => {
+    await assertSucceeds(deleteDoc(doc(asHost(), `shared_boards/${SHARE_ID}`)));
+  });
+
+  it('non-host cannot delete the shared doc', async () => {
+    await assertFails(deleteDoc(doc(asCollab(), `shared_boards/${SHARE_ID}`)));
+  });
+});
+
+describe('shared_boards — collaborator update', () => {
+  it('collaborator can update content (Synced bidirectional)', async () => {
+    await assertSucceeds(
+      updateDoc(doc(asCollab(), `shared_boards/${SHARE_ID}`), {
+        name: 'Renamed by collab',
+        widgets: [{ id: 'w1' }],
+        updatedAt: 2000,
+        updatedBy: COLLAB_UID,
+      })
+    );
+  });
+
+  it('collaborator CANNOT change originalAuthor (host uid spoof)', async () => {
+    await assertFails(
+      updateDoc(doc(asCollab(), `shared_boards/${SHARE_ID}`), {
+        originalAuthor: COLLAB_UID,
+        updatedAt: 2000,
+        updatedBy: COLLAB_UID,
+      })
+    );
+  });
+
+  it('collaborator CANNOT change originalAuthorName (host display-name spoof)', async () => {
+    // This is the spoofing attack the immutability check at
+    // firestore.rules:611 prevents. Without it, a Synced collaborator
+    // could rewrite the host display name shown in every other
+    // participant's import-picker and ShareStatusBanner UI.
+    await assertFails(
+      updateDoc(doc(asCollab(), `shared_boards/${SHARE_ID}`), {
+        originalAuthorName: 'Imposter',
+        updatedAt: 2000,
+        updatedBy: COLLAB_UID,
+      })
+    );
+  });
+
+  it('collaborator CANNOT mutate the participants map', async () => {
+    await assertFails(
+      updateDoc(doc(asCollab(), `shared_boards/${SHARE_ID}`), {
+        [`participants.${STRANGER_UID}`]: {
+          role: 'collaborator',
+          joinedAt: 9999,
+        },
+        updatedAt: 2000,
+        updatedBy: COLLAB_UID,
+      })
+    );
+  });
+
+  it('collaborator CANNOT change sharedAt', async () => {
+    await assertFails(
+      updateDoc(doc(asCollab(), `shared_boards/${SHARE_ID}`), {
+        sharedAt: 9999,
+        updatedAt: 2000,
+        updatedBy: COLLAB_UID,
+      })
+    );
+  });
+});
+
+describe('shared_boards — viewer (read-only)', () => {
+  it('viewer CANNOT update content', async () => {
+    // View-only mode is one-way by design — the viewer's role check on
+    // the collaborator update branch fails, and no other branch matches.
+    await assertFails(
+      updateDoc(doc(asViewer(), `shared_boards/${SHARE_ID}`), {
+        name: 'Hijacked by viewer',
+        updatedAt: 2000,
+        updatedBy: VIEWER_UID,
+      })
+    );
+  });
+});
+
+describe('shared_boards — self-join', () => {
+  it('stranger can append themselves to participants (Synced join)', async () => {
+    await assertSucceeds(
+      updateDoc(doc(asStranger(), `shared_boards/${SHARE_ID}`), {
+        [`participants.${STRANGER_UID}`]: {
+          role: 'collaborator',
+          joinedAt: 2000,
+        },
+      })
+    );
+  });
+
+  it('stranger can append themselves as viewer (View-Only join)', async () => {
+    await assertSucceeds(
+      updateDoc(doc(asStranger(), `shared_boards/${SHARE_ID}`), {
+        [`participants.${STRANGER_UID}`]: {
+          role: 'viewer',
+          joinedAt: 2000,
+        },
+      })
+    );
+  });
+
+  it('stranger CANNOT add ANOTHER user during self-join', async () => {
+    // The diff().affectedKeys().hasOnly([uid]) clause prevents a caller
+    // from sneaking unrelated participants into the same write.
+    await assertFails(
+      updateDoc(doc(asStranger(), `shared_boards/${SHARE_ID}`), {
+        [`participants.${STRANGER_UID}`]: {
+          role: 'collaborator',
+          joinedAt: 2000,
+        },
+        [`participants.${'another-user'}`]: {
+          role: 'collaborator',
+          joinedAt: 2000,
+        },
+      })
+    );
+  });
+
+  it('stranger CANNOT change other fields during self-join', async () => {
+    // The diff().affectedKeys().hasOnly(['participants']) clause keeps
+    // the join write to a single field — no smuggling content edits.
+    await assertFails(
+      updateDoc(doc(asStranger(), `shared_boards/${SHARE_ID}`), {
+        [`participants.${STRANGER_UID}`]: {
+          role: 'collaborator',
+          joinedAt: 2000,
+        },
+        name: 'Hijacked while joining',
+      })
+    );
+  });
+});
+
+describe('shared_boards — self-leave', () => {
+  it('collaborator can remove their own participants entry', async () => {
+    await assertSucceeds(
+      updateDoc(doc(asCollab(), `shared_boards/${SHARE_ID}`), {
+        [`participants.${COLLAB_UID}`]: deleteField(),
+      })
+    );
+  });
+
+  it('viewer can remove their own participants entry', async () => {
+    await assertSucceeds(
+      updateDoc(doc(asViewer(), `shared_boards/${SHARE_ID}`), {
+        [`participants.${VIEWER_UID}`]: deleteField(),
+      })
+    );
+  });
+
+  it('participant CANNOT remove ANOTHER user during self-leave', async () => {
+    await assertFails(
+      updateDoc(doc(asCollab(), `shared_boards/${SHARE_ID}`), {
+        [`participants.${COLLAB_UID}`]: deleteField(),
+        [`participants.${VIEWER_UID}`]: deleteField(),
+      })
+    );
+  });
+
+  it('participant CANNOT change other fields during self-leave', async () => {
+    await assertFails(
+      updateDoc(doc(asCollab(), `shared_boards/${SHARE_ID}`), {
+        [`participants.${COLLAB_UID}`]: deleteField(),
+        name: 'Hijacked while leaving',
+      })
+    );
+  });
+});

--- a/types.ts
+++ b/types.ts
@@ -3649,6 +3649,14 @@ export interface SpartStickerDropPayload {
   url?: string;
 }
 
+/**
+ * Role this user plays in a live-shared board link.
+ * - `owner`: created the share. Mirrors local edits to /shared_boards/{shareId}.
+ * - `collaborator`: joined a Synced share. Mirrors local edits + receives remote.
+ * - `viewer`: joined a View-Only share. Read-only locally; receives remote.
+ */
+export type DashboardShareRole = 'owner' | 'collaborator' | 'viewer';
+
 export interface Dashboard {
   id: string;
   name: string;
@@ -3668,6 +3676,21 @@ export interface Dashboard {
   viewportWidth?: number;
   /** Viewport height (px) when the dashboard was last saved. Used for proportional layout scaling on load. */
   viewportHeight?: number;
+  /** ID of the /shared_boards/{shareId} doc this dashboard is linked to (live share). */
+  linkedShareId?: string;
+  /** This user's role in the linked share. */
+  linkedShareRole?: DashboardShareRole;
+  /** Cached host display name for the share banner. */
+  linkedShareHostName?: string;
+  /** True after the host has revoked the share — guests see a "share ended" indicator. */
+  linkedShareEnded?: boolean;
+}
+
+/** Per-participant entry on a /shared_boards/{shareId} doc. */
+export interface SharedBoardParticipant {
+  role: 'collaborator' | 'viewer';
+  joinedAt: number;
+  displayName?: string;
 }
 
 export interface Toast {


### PR DESCRIPTION
## Summary

Pasting a shared-board URL now opens a **3-option picker** instead of always making a copy:

- **Synced** — bidirectional live link. Edits made by either teacher appear in real time on the other's board.
- **View-Only** — one-way live link. The host's edits appear on the guest's screen; the guest cannot mutate the board.
- **Make a Copy** — preserves the existing one-time-snapshot behavior.

Both linked modes use the existing `/shared_boards/{shareId}` collection as a live broadcast channel — the host's local board is auto-tagged as the source on Share, and a debounced mirror effect pushes its edits up. Guests subscribe to the same doc and apply remote patches locally; their own writes (Synced only) flow back through the same channel.

## What was added

### Data model (`types.ts`)
- `Dashboard.linkedShareId / linkedShareRole / linkedShareHostName / linkedShareEnded`
- New `SharedBoardParticipant` type for the participants map on shared docs

### Firestore (`firestore.rules`)
- `/shared_boards/{shareId}` rules expanded to allow:
  - host or admin: full update (content + participants)
  - participant with `role: 'collaborator'`: content updates only (cannot rewrite participants/originalAuthor)
  - any authed user: self-join (append only their own uid) and self-leave (remove only their own uid) without touching other fields

### Hook (`hooks/useFirestore.ts`)
- `mirrorSharedBoard`, `subscribeToSharedBoard`, `joinSharedBoard`, `leaveSharedBoard`, `stopSharingBoard`
- `shareDashboard` extended to accept a host display name and seed the `participants` map
- Mock store updated with subscribe/update/remove for auth-bypass mode

### Context (`context/DashboardContext.tsx`)
- New state: `pendingShareImport` (open the picker), `isActiveBoardReadOnly` (gate mutations)
- New actions: `cancelPendingShareImport`, `importSharedBoard(mode)`, `stopSharingDashboard(id)`
- Mirror effect: debounced 500ms write of host/collaborator changes into the shared doc
- Subscribe effect: applies remote patches; flags the local board as `linkedShareEnded` when the host revokes
- Read-only guards added to every widget mutation callback (`addWidget`, `updateWidget`, `removeWidget`, etc.)
- `handleShareDashboard` tags the host's local board with `linkedShareRole: 'owner'` for Firestore-backed shares (Drive-backed shares remain copy-only)

### UI
- **`ImportShareModePicker`** (new): glassmorphic 3-option modal mounted in `DashboardView`. Disables Synced/View-Only with a tooltip when the share is Drive-backed.
- **`ShareStatusBanner`** (new): top-center pill on linked dashboards. Shows role (Sharing live / Synced / View-Only / Share ended), with Stop sharing / Leave actions.
- **Sidebar badge** (`SortableDashboardItem`): small live-share pill on board cards.
- **`DraggableWindow`**: ORs `isActiveBoardReadOnly` into `isLocked` so the existing lock affordances cover view-only guests.
- **`Dock`**: hidden entirely on view-only boards.

### Tests
- Existing sharing test rewritten + 3 new cases covering picker/copy/synced/view-only modes (4/4 passing).

## Notes / known scope limits

- Drive-backed shares (legacy `drive-` prefix) only support Make a Copy — they have no live transport. The picker disables the other two with an explanatory note.
- "Stop sharing" deletes the shared doc; existing guests' local copies stay intact but flip to `linkedShareEnded` (banner offers "Detach" to clear the link).
- Last-write-wins on the shared doc (no version-vector merging). Acceptable since concurrent edits between two teachers are rare and the existing per-user dashboard sync still uses its richer merge logic.

## Test plan

- [ ] User A clicks Share → URL copies → User A's board shows the "Sharing live" banner and the sidebar card shows a "Live" pill.
- [ ] User B pastes the URL → picker opens with Synced / View-Only / Make a Copy.
- [ ] **Synced**: User B picks Synced → both teachers' edits propagate within ~500ms.
- [ ] **View-Only**: User B picks View-Only → host's edits flow to B; B's UI shows "View-only" banner + cannot drag/resize/delete widgets and Dock is hidden.
- [ ] **Make a Copy**: identical to current behavior (no link).
- [ ] User A clicks "Stop sharing" → User B's banner flips to "Share ended" and B can detach to keep a local copy.
- [ ] Pasting a legacy `drive-` share URL → picker shows with Synced / View-Only disabled.
- [ ] Validation: `pnpm run validate` passes (1974 tests).

https://claude.ai/code/session_01LF39GMQjXSTQJbwnga4k7U

---
_Generated by [Claude Code](https://claude.ai/code/session_01LF39GMQjXSTQJbwnga4k7U)_