### PR TITLE
feat(plc): PLC Dashboard shell + feature toggles + completed assignments (Phase 1)

### DIFF
--- a/components/layout/sidebar/Sidebar.tsx
+++ b/components/layout/sidebar/Sidebar.tsx
@@ -46,6 +46,7 @@ import { SidebarClasses } from './SidebarClasses';
 import { SidebarPlcs } from './SidebarPlcs';
 import { usePlcs } from '@/hooks/usePlcs';
 import { usePlcInvitations } from '@/hooks/usePlcInvitations';
+import { PlcDashboard } from '@/components/plc/PlcDashboard';
 
 type MenuSection =
   | 'main'
@@ -122,12 +123,19 @@ export const Sidebar: React.FC = () => {
   // Firestore `onSnapshot` subscriptions (1 from usePlcs, 2 from
   // usePlcInvitations) for data that's semantically a singleton per session.
   //
-  // `enabled: isOpen` keeps the subscriptions paused while the drawer is
-  // closed — the consumers (`PlcsMenuButton`, `SidebarPlcs`) only render
-  // inside `{isOpen && (...)}`, so paying for those listeners while the
-  // sidebar is hidden buys nothing. `Sidebar` itself is always mounted by
-  // `DashboardView`, so we can't rely on unmounting alone to release them.
-  const plcsHook = usePlcs({ enabled: isOpen });
+  // `enabled: isOpen || dashboardOpen` keeps the subscriptions paused while
+  // both the drawer AND the PLC dashboard overlay are closed — the
+  // dashboard render keys off the live `plcs` array so the subscription
+  // must remain active while it's mounted (e.g. so a feature toggle from
+  // another member is reflected immediately). `Sidebar` itself is always
+  // mounted by `DashboardView`, so we can't rely on unmounting alone to
+  // release the listeners.
+  const [openPlcDashboardId, setOpenPlcDashboardId] = useState<string | null>(
+    null
+  );
+  const plcsHook = usePlcs({
+    enabled: isOpen || openPlcDashboardId !== null,
+  });
   const plcInvitationsHook = usePlcInvitations({ enabled: isOpen });
 
   const { isConnected: isDriveConnected } = useGoogleDrive();
@@ -173,6 +181,23 @@ export const Sidebar: React.FC = () => {
   }, []);
 
   const [showAdminSettings, setShowAdminSettings] = useState(false);
+
+  // The currently-open PLC dashboard tracks against the live `plcs` array so
+  // a feature toggle by another member shows up immediately. If the PLC
+  // disappears from the user's list (e.g. removed by the lead, or they left
+  // elsewhere), close the dashboard. Adjusting state during render avoids
+  // the extra round-trip an effect would cost.
+  const openPlcDashboardPlc =
+    openPlcDashboardId !== null
+      ? (plcsHook.plcs.find((p) => p.id === openPlcDashboardId) ?? null)
+      : null;
+  if (
+    openPlcDashboardId !== null &&
+    !openPlcDashboardPlc &&
+    !plcsHook.loading
+  ) {
+    setOpenPlcDashboardId(null);
+  }
 
   return (
     <>
@@ -270,6 +295,13 @@ export const Sidebar: React.FC = () => {
 
       {showAdminSettings && (
         <AdminSettings onClose={() => setShowAdminSettings(false)} />
+      )}
+
+      {openPlcDashboardPlc && (
+        <PlcDashboard
+          plc={openPlcDashboardPlc}
+          onClose={() => setOpenPlcDashboardId(null)}
+        />
       )}
 
       {isOpen && (
@@ -531,6 +563,11 @@ export const Sidebar: React.FC = () => {
                 leavePlc={plcsHook.leavePlc}
                 deletePlc={plcsHook.deletePlc}
                 pendingInvites={plcInvitationsHook.pendingInvites}
+                onOpenDashboard={(plcId) => {
+                  setOpenPlcDashboardId(plcId);
+                  setIsOpen(false);
+                  setActiveSection('main');
+                }}
               />
 
               {/* STYLE SECTION */}

--- a/components/layout/sidebar/SidebarPlcs.tsx
+++ b/components/layout/sidebar/SidebarPlcs.tsx
@@ -18,6 +18,8 @@ interface SidebarPlcsProps {
   deletePlc: (plcId: string) => Promise<void>;
   /** Pending invites, lifted alongside `plcs` for the same reason. */
   pendingInvites: PlcInvitation[];
+  /** Open the full PLC Dashboard for the selected PLC. */
+  onOpenDashboard: (plcId: string) => void;
 }
 
 /**
@@ -34,6 +36,7 @@ export const SidebarPlcs: React.FC<SidebarPlcsProps> = ({
   leavePlc,
   deletePlc,
   pendingInvites,
+  onOpenDashboard,
 }) => {
   const { t } = useTranslation();
   const { user } = useAuth();
@@ -208,30 +211,44 @@ export const SidebarPlcs: React.FC<SidebarPlcsProps> = ({
                         key={plc.id}
                         className="flex items-center gap-2 p-2.5 bg-white border border-slate-200 hover:border-slate-300 rounded-xl transition-all"
                       >
-                        <div className="shrink-0 w-8 h-8 rounded-lg bg-brand-blue-lighter flex items-center justify-center">
-                          <Users2 className="w-4 h-4 text-brand-blue-primary" />
-                        </div>
-                        <div className="flex-1 min-w-0">
-                          <div className="flex items-center gap-1.5 min-w-0">
-                            <div className="text-sm font-bold text-slate-800 truncate">
-                              {plc.name}
+                        {/* Left side: clickable area opens the PLC dashboard.
+                            Implemented as a button so keyboard + screen-reader
+                            navigation work. The right-side action icons sit
+                            outside this button so nested-button HTML is avoided. */}
+                        <button
+                          type="button"
+                          onClick={() => onOpenDashboard(plc.id)}
+                          className="flex items-center gap-2 flex-1 min-w-0 text-left rounded-lg hover:bg-brand-blue-lighter/30 transition-colors -m-1 p-1"
+                          aria-label={t('sidebar.plcs.openDashboard', {
+                            defaultValue: 'Open {{name}} dashboard',
+                            name: plc.name,
+                          })}
+                        >
+                          <div className="shrink-0 w-8 h-8 rounded-lg bg-brand-blue-lighter flex items-center justify-center">
+                            <Users2 className="w-4 h-4 text-brand-blue-primary" />
+                          </div>
+                          <div className="flex-1 min-w-0">
+                            <div className="flex items-center gap-1.5 min-w-0">
+                              <div className="text-sm font-bold text-slate-800 truncate">
+                                {plc.name}
+                              </div>
+                              {isLead && (
+                                <span className="text-xxs font-bold text-brand-blue-primary bg-brand-blue-lighter px-1.5 py-0.5 rounded uppercase tracking-wider">
+                                  {t('sidebar.plcs.leadBadge', {
+                                    defaultValue: 'Lead',
+                                  })}
+                                </span>
+                              )}
                             </div>
-                            {isLead && (
-                              <span className="text-xxs font-bold text-brand-blue-primary bg-brand-blue-lighter px-1.5 py-0.5 rounded uppercase tracking-wider">
-                                {t('sidebar.plcs.leadBadge', {
-                                  defaultValue: 'Lead',
-                                })}
-                              </span>
-                            )}
+                            <div className="text-xxs font-semibold text-slate-400 uppercase tracking-widest">
+                              {t('sidebar.plcs.memberCount', {
+                                count: plc.memberUids.length,
+                                defaultValue: '{{count}} Member',
+                                defaultValue_other: '{{count}} Members',
+                              })}
+                            </div>
                           </div>
-                          <div className="text-xxs font-semibold text-slate-400 uppercase tracking-widest">
-                            {t('sidebar.plcs.memberCount', {
-                              count: plc.memberUids.length,
-                              defaultValue: '{{count}} Member',
-                              defaultValue_other: '{{count}} Members',
-                            })}
-                          </div>
-                        </div>
+                        </button>
                         <div className="flex items-center gap-0.5 shrink-0">
                           <button
                             onClick={() => setEditingPlcId(plc.id)}

--- a/components/plc/PlcDashboard.tsx
+++ b/components/plc/PlcDashboard.tsx
@@ -1,0 +1,351 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import {
+  BookOpen,
+  ChevronLeft,
+  ChevronRight,
+  ClipboardList,
+  Film,
+  ListChecks,
+  Settings as SettingsIcon,
+  SquareSquare,
+  StickyNote,
+  Users2,
+  type LucideIcon,
+} from 'lucide-react';
+
+import { Plc, PlcFeatureSettings, getPlcFeatures } from '@/types';
+import { useAuth } from '@/context/useAuth';
+import { PlcCompletedAssignmentsTab } from './tabs/PlcCompletedAssignmentsTab';
+import { PlcSettingsTab } from './tabs/PlcSettingsTab';
+import { PlcPlaceholderTab } from './tabs/PlcPlaceholderTab';
+
+interface PlcDashboardProps {
+  plc: Plc;
+  onClose: () => void;
+}
+
+type TabId =
+  | 'completed'
+  | 'quizzes'
+  | 'assignments'
+  | 'videoActivities'
+  | 'notes'
+  | 'todos'
+  | 'sharedBoards'
+  | 'settings';
+
+interface TabDef {
+  id: TabId;
+  icon: LucideIcon;
+  labelKey: string;
+  labelDefault: string;
+  /**
+   * Feature flag key gating this tab; absent means the tab is always
+   * visible (Completed Assignments + Settings).
+   */
+  feature?: keyof PlcFeatureSettings;
+  /** Phase 1 placeholder copy for tabs not yet implemented. */
+  placeholder?: { titleDefault: string; descriptionDefault: string };
+}
+
+const TABS: readonly TabDef[] = [
+  {
+    id: 'completed',
+    icon: ClipboardList,
+    labelKey: 'plcDashboard.tabs.completed',
+    labelDefault: 'Completed Assignments',
+  },
+  {
+    id: 'quizzes',
+    icon: BookOpen,
+    labelKey: 'plcDashboard.tabs.quizzes',
+    labelDefault: 'Quiz Library',
+    feature: 'quizzes',
+    placeholder: {
+      titleDefault: 'PLC Quiz Library',
+      descriptionDefault:
+        'Share quizzes with the PLC, edit collaboratively, and let teammates sync or copy them into their own libraries.',
+    },
+  },
+  {
+    id: 'assignments',
+    icon: ClipboardList,
+    labelKey: 'plcDashboard.tabs.assignments',
+    labelDefault: 'PLC Assignments',
+    feature: 'assignments',
+    placeholder: {
+      titleDefault: 'PLC Assignments',
+      descriptionDefault:
+        'Author PLC-level assignments here so teammates can pick them up on their own boards.',
+    },
+  },
+  {
+    id: 'videoActivities',
+    icon: Film,
+    labelKey: 'plcDashboard.tabs.videoActivities',
+    labelDefault: 'Video Activities',
+    feature: 'videoActivities',
+    placeholder: {
+      titleDefault: 'PLC Video Activities',
+      descriptionDefault:
+        'Share video-based activities with your PLC and aggregate completion data alongside quizzes.',
+    },
+  },
+  {
+    id: 'notes',
+    icon: StickyNote,
+    labelKey: 'plcDashboard.tabs.notes',
+    labelDefault: 'Notes',
+    feature: 'notes',
+    placeholder: {
+      titleDefault: 'PLC Notes',
+      descriptionDefault: 'A shared notebook for the PLC.',
+    },
+  },
+  {
+    id: 'todos',
+    icon: ListChecks,
+    labelKey: 'plcDashboard.tabs.todos',
+    labelDefault: 'To-Do List',
+    feature: 'todos',
+    placeholder: {
+      titleDefault: 'PLC To-Do List',
+      descriptionDefault:
+        'Track action items the PLC has agreed to follow up on.',
+    },
+  },
+  {
+    id: 'sharedBoards',
+    icon: SquareSquare,
+    labelKey: 'plcDashboard.tabs.sharedBoards',
+    labelDefault: 'Shared Boards',
+    feature: 'sharedBoards',
+    placeholder: {
+      titleDefault: 'Shared Boards',
+      descriptionDefault: 'Dashboards shared with this PLC will surface here.',
+    },
+  },
+  {
+    id: 'settings',
+    icon: SettingsIcon,
+    labelKey: 'plcDashboard.tabs.settings',
+    labelDefault: 'Settings',
+  },
+] as const;
+
+/**
+ * Full-screen PLC Dashboard view. Opens when a member clicks a PLC in the
+ * sidebar list. Mirrors `AdminSettings`'s overlay pattern — a fixed-position
+ * dialog that takes the full viewport, with a desktop tab rail and a
+ * mobile drawer.
+ */
+export const PlcDashboard: React.FC<PlcDashboardProps> = ({ plc, onClose }) => {
+  const { t } = useTranslation();
+  const { user } = useAuth();
+  const [activeTab, setActiveTab] = useState<TabId>('completed');
+  const [showMobileMenu, setShowMobileMenu] = useState(true);
+
+  // Close on Escape — same UX contract as AdminSettings.
+  useEffect(() => {
+    const handler = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') onClose();
+    };
+    document.addEventListener('keydown', handler);
+    return () => document.removeEventListener('keydown', handler);
+  }, [onClose]);
+
+  const features = useMemo(() => getPlcFeatures(plc), [plc]);
+  const visibleTabs = useMemo(
+    () => TABS.filter((tab) => !tab.feature || features[tab.feature]),
+    [features]
+  );
+
+  // If the active tab gets hidden via a settings toggle by another member,
+  // fall back to "Completed Assignments" — which is always visible. Adjust
+  // state during render rather than via an effect to avoid an extra render
+  // pass; the setter is a no-op when the value is already 'completed'.
+  if (!visibleTabs.find((tab) => tab.id === activeTab)) {
+    setActiveTab('completed');
+  }
+
+  const activeTabDef = visibleTabs.find((tab) => tab.id === activeTab);
+  const isLead = plc.leadUid === user?.uid;
+
+  const handleBackOrClose = () => {
+    if (!showMobileMenu) {
+      setShowMobileMenu(true);
+    } else {
+      onClose();
+    }
+  };
+
+  const renderTabContent = (tab: TabDef) => {
+    if (tab.id === 'completed') {
+      return <PlcCompletedAssignmentsTab plc={plc} />;
+    }
+    if (tab.id === 'settings') {
+      return <PlcSettingsTab plc={plc} />;
+    }
+    if (tab.placeholder) {
+      return (
+        <PlcPlaceholderTab
+          icon={tab.icon}
+          title={t(`${tab.labelKey}.placeholderTitle`, {
+            defaultValue: tab.placeholder.titleDefault,
+          })}
+          description={t(`${tab.labelKey}.placeholderDescription`, {
+            defaultValue: tab.placeholder.descriptionDefault,
+          })}
+        />
+      );
+    }
+    return null;
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-modal bg-slate-50 flex flex-col overscroll-none"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="plc-dashboard-title"
+    >
+      <div className="bg-white w-full h-full overflow-hidden flex flex-col">
+        {/* Header */}
+        <div className="bg-gradient-to-r from-brand-blue-primary to-brand-blue-dark text-white h-14 md:h-16 px-4 flex items-center justify-between shadow-sm shrink-0">
+          <div className="flex items-center gap-2 overflow-hidden w-full md:w-auto">
+            <button
+              onClick={handleBackOrClose}
+              className="p-2 md:p-1.5 hover:bg-white/20 rounded-lg transition-colors shrink-0 -ml-2 md:ml-0"
+              aria-label={
+                !showMobileMenu
+                  ? t('plcDashboard.backToMenu', { defaultValue: 'Back' })
+                  : t('plcDashboard.close', { defaultValue: 'Close' })
+              }
+            >
+              <ChevronLeft className="w-6 h-6 md:w-5 md:h-5" />
+            </button>
+            <div className="flex items-center gap-2 min-w-0 flex-1">
+              <Users2 className="w-5 h-5 md:w-4 md:h-4 text-white/70 shrink-0 hidden md:block" />
+              <div className="flex flex-col md:flex-row md:items-baseline md:gap-2 min-w-0">
+                <h2
+                  id="plc-dashboard-title"
+                  className="text-base md:text-lg font-bold truncate"
+                >
+                  {plc.name}
+                </h2>
+                <span className="hidden md:inline text-xxs uppercase tracking-widest text-white/60">
+                  {t('plcDashboard.subtitle', {
+                    defaultValue: 'PLC Dashboard',
+                  })}
+                </span>
+              </div>
+            </div>
+          </div>
+
+          {/* Right: Tab pills (desktop only) + meta */}
+          <div className="hidden md:flex items-center gap-3 ml-4">
+            <div className="flex gap-1" role="tablist">
+              {visibleTabs.map((tab) => (
+                <button
+                  key={tab.id}
+                  role="tab"
+                  aria-selected={activeTab === tab.id}
+                  onClick={() => setActiveTab(tab.id)}
+                  className={`px-3 py-1.5 rounded-full font-bold text-xxs uppercase tracking-wide flex items-center gap-2 transition-colors whitespace-nowrap ${
+                    activeTab === tab.id
+                      ? 'bg-white text-brand-blue-dark shadow-sm'
+                      : 'text-white/80 hover:bg-white/20 hover:text-white'
+                  }`}
+                  title={t(tab.labelKey, { defaultValue: tab.labelDefault })}
+                >
+                  <tab.icon className="w-3.5 h-3.5" />
+                  <span className="hidden xl:inline">
+                    {t(tab.labelKey, { defaultValue: tab.labelDefault })}
+                  </span>
+                </button>
+              ))}
+            </div>
+          </div>
+        </div>
+
+        {/* Sub-header: PLC meta */}
+        <div className="bg-white border-b border-slate-200 px-4 md:px-6 py-2.5 flex items-center gap-3 text-xxs text-slate-500 shrink-0">
+          <span className="font-semibold uppercase tracking-widest">
+            {t('plcDashboard.meta.members', {
+              count: plc.memberUids.length,
+              defaultValue: '{{count}} Member',
+              defaultValue_other: '{{count}} Members',
+            })}
+          </span>
+          {isLead && (
+            <>
+              <span className="text-slate-300">•</span>
+              <span className="font-semibold uppercase tracking-widest text-brand-blue-primary">
+                {t('plcDashboard.meta.youLead', {
+                  defaultValue: 'You lead this PLC',
+                })}
+              </span>
+            </>
+          )}
+          {!showMobileMenu && activeTabDef && (
+            <>
+              <span className="text-slate-300 md:hidden">•</span>
+              <span className="md:hidden font-semibold text-slate-700 truncate">
+                {t(activeTabDef.labelKey, {
+                  defaultValue: activeTabDef.labelDefault,
+                })}
+              </span>
+            </>
+          )}
+        </div>
+
+        {/* Content */}
+        <div className="flex-1 overflow-y-auto overscroll-none touch-pan-y bg-slate-50">
+          {/* Mobile menu */}
+          <div className={`md:hidden ${showMobileMenu ? 'block' : 'hidden'}`}>
+            <div className="flex flex-col py-2">
+              {visibleTabs.map((tab) => (
+                <button
+                  key={tab.id}
+                  onClick={() => {
+                    setActiveTab(tab.id);
+                    setShowMobileMenu(false);
+                  }}
+                  className="flex items-center justify-between p-4 min-h-[60px] hover:bg-slate-100 active:bg-slate-200 transition-colors border-b border-slate-100 last:border-b-0 w-full text-left"
+                >
+                  <div className="flex items-center gap-4">
+                    <div className="bg-slate-100 p-2.5 rounded-xl text-slate-600">
+                      <tab.icon className="w-5 h-5" />
+                    </div>
+                    <span className="font-semibold text-slate-700 text-base">
+                      {t(tab.labelKey, { defaultValue: tab.labelDefault })}
+                    </span>
+                  </div>
+                  <ChevronRight className="w-5 h-5 text-slate-400" />
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {/* Active panel */}
+          <div
+            className={`${
+              !showMobileMenu ? 'block' : 'hidden md:block'
+            } p-4 md:p-6 h-full`}
+          >
+            {activeTabDef && (
+              <div
+                key={activeTabDef.id}
+                role="tabpanel"
+                className="animate-in fade-in slide-in-from-bottom-2 duration-300 h-full"
+              >
+                {renderTabContent(activeTabDef)}
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/components/plc/tabs/PlcCompletedAssignmentsTab.tsx
+++ b/components/plc/tabs/PlcCompletedAssignmentsTab.tsx
@@ -1,0 +1,127 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { ClipboardList, ExternalLink, Loader2 } from 'lucide-react';
+import { usePlcAssignmentIndex } from '@/hooks/usePlcAssignmentIndex';
+import { Plc } from '@/types';
+
+interface PlcCompletedAssignmentsTabProps {
+  plc: Plc;
+}
+
+/**
+ * Read-only list of every PLC-mode assignment any member has run. Each
+ * row links out to the shared Google Sheet that aggregates results.
+ *
+ * Phase 1 only renders the index — opening the sheet is the path to
+ * detailed data. Later phases can inline aggregated stats here using
+ * the same `readPlcSheet` machinery as `QuizWidget/PlcTab.tsx`.
+ */
+export const PlcCompletedAssignmentsTab: React.FC<
+  PlcCompletedAssignmentsTabProps
+> = ({ plc }) => {
+  const { t } = useTranslation();
+  const { entries, loading } = usePlcAssignmentIndex(plc.id);
+
+  // Format a `createdAt` ms timestamp into a short locale date. Done inline
+  // (no useMemo) since the list is small and the cost is trivial.
+  const formatDate = (ms: number) => {
+    try {
+      return new Date(ms).toLocaleDateString(undefined, {
+        year: 'numeric',
+        month: 'short',
+        day: 'numeric',
+      });
+    } catch {
+      return '';
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center h-full min-h-[200px] text-slate-400">
+        <Loader2 className="w-5 h-5 animate-spin" />
+      </div>
+    );
+  }
+
+  if (entries.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center h-full min-h-[300px] px-6 text-center">
+        <div className="w-16 h-16 rounded-2xl bg-slate-100 flex items-center justify-center mb-5">
+          <ClipboardList className="w-7 h-7 text-slate-400" />
+        </div>
+        <h3 className="text-lg font-bold text-slate-700 mb-2">
+          {t('plcDashboard.completedAssignments.emptyTitle', {
+            defaultValue: 'No PLC assignments yet',
+          })}
+        </h3>
+        <p className="text-sm text-slate-500 max-w-md leading-relaxed">
+          {t('plcDashboard.completedAssignments.emptySubtitle', {
+            defaultValue:
+              "When you or a teammate runs a quiz with PLC mode on, it'll show up here with a link to the shared results sheet.",
+          })}
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-3 px-1">
+      <div className="flex items-baseline justify-between mb-1">
+        <h3 className="text-xs font-bold text-slate-400 uppercase tracking-widest">
+          {t('plcDashboard.completedAssignments.heading', {
+            defaultValue: 'Shared Results',
+          })}
+        </h3>
+        <span className="text-xxs text-slate-400">
+          {t('plcDashboard.completedAssignments.count', {
+            count: entries.length,
+            defaultValue: '{{count}} assignment',
+            defaultValue_other: '{{count}} assignments',
+          })}
+        </span>
+      </div>
+      <div className="flex flex-col gap-2">
+        {entries.map((entry) => {
+          const ownerLabel = entry.ownerName?.trim() || entry.ownerEmail || '—';
+          return (
+            <div
+              key={entry.id}
+              className="flex items-center gap-3 p-3 bg-white border border-slate-200 hover:border-brand-blue-light rounded-xl transition-colors"
+            >
+              <div className="shrink-0 w-10 h-10 rounded-lg bg-brand-blue-lighter flex items-center justify-center">
+                <ClipboardList className="w-4 h-4 text-brand-blue-primary" />
+              </div>
+              <div className="flex-1 min-w-0">
+                <div className="text-sm font-bold text-slate-800 truncate">
+                  {entry.title}
+                </div>
+                <div className="text-xxs text-slate-500 mt-0.5 flex items-center gap-2 flex-wrap">
+                  <span className="truncate">
+                    {t('plcDashboard.completedAssignments.byOwner', {
+                      name: ownerLabel,
+                      defaultValue: 'by {{name}}',
+                    })}
+                  </span>
+                  <span className="text-slate-300">•</span>
+                  <span>{formatDate(entry.createdAt)}</span>
+                </div>
+              </div>
+              <a
+                href={entry.sheetUrl}
+                target="_blank"
+                rel="noreferrer noopener"
+                className="shrink-0 flex items-center gap-1.5 px-3 py-1.5 bg-brand-blue-lighter hover:bg-brand-blue-light/30 text-brand-blue-primary rounded-lg text-xxs font-bold uppercase tracking-wider transition-colors"
+              >
+                <ExternalLink className="w-3 h-3" />
+                {t('plcDashboard.completedAssignments.openSheet', {
+                  defaultValue: 'Open Sheet',
+                })}
+              </a>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+};

--- a/components/plc/tabs/PlcCompletedAssignmentsTab.tsx
+++ b/components/plc/tabs/PlcCompletedAssignmentsTab.tsx
@@ -9,6 +9,22 @@ interface PlcCompletedAssignmentsTabProps {
 }
 
 /**
+ * Defense-in-depth: only render the entry's `sheetUrl` as a link if it
+ * parses as an `http:` or `https:` URL. The Firestore rule already pins
+ * `sheetUrl` to the PLC's canonical `sharedSheetUrl`, but a stale entry
+ * (or future schema change) shouldn't be able to smuggle a `javascript:`
+ * URL through the dashboard.
+ */
+function isSafeHttpUrl(value: string): boolean {
+  try {
+    const parsed = new URL(value);
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Read-only list of every PLC-mode assignment any member has run. Each
  * row links out to the shared Google Sheet that aggregates results.
  *
@@ -84,6 +100,9 @@ export const PlcCompletedAssignmentsTab: React.FC<
       <div className="flex flex-col gap-2">
         {entries.map((entry) => {
           const ownerLabel = entry.ownerName?.trim() || entry.ownerEmail || '—';
+          const safeSheetUrl = isSafeHttpUrl(entry.sheetUrl)
+            ? entry.sheetUrl
+            : null;
           return (
             <div
               key={entry.id}
@@ -107,17 +126,30 @@ export const PlcCompletedAssignmentsTab: React.FC<
                   <span>{formatDate(entry.createdAt)}</span>
                 </div>
               </div>
-              <a
-                href={entry.sheetUrl}
-                target="_blank"
-                rel="noreferrer noopener"
-                className="shrink-0 flex items-center gap-1.5 px-3 py-1.5 bg-brand-blue-lighter hover:bg-brand-blue-light/30 text-brand-blue-primary rounded-lg text-xxs font-bold uppercase tracking-wider transition-colors"
-              >
-                <ExternalLink className="w-3 h-3" />
-                {t('plcDashboard.completedAssignments.openSheet', {
-                  defaultValue: 'Open Sheet',
-                })}
-              </a>
+              {safeSheetUrl ? (
+                <a
+                  href={safeSheetUrl}
+                  target="_blank"
+                  rel="noreferrer noopener"
+                  className="shrink-0 flex items-center gap-1.5 px-3 py-1.5 bg-brand-blue-lighter hover:bg-brand-blue-light/30 text-brand-blue-primary rounded-lg text-xxs font-bold uppercase tracking-wider transition-colors"
+                >
+                  <ExternalLink className="w-3 h-3" />
+                  {t('plcDashboard.completedAssignments.openSheet', {
+                    defaultValue: 'Open Sheet',
+                  })}
+                </a>
+              ) : (
+                <span
+                  className="shrink-0 flex items-center gap-1.5 px-3 py-1.5 bg-slate-100 text-slate-400 rounded-lg text-xxs font-bold uppercase tracking-wider"
+                  title={t('plcDashboard.completedAssignments.unsafeSheet', {
+                    defaultValue: 'Sheet link unavailable',
+                  })}
+                >
+                  {t('plcDashboard.completedAssignments.unsafeSheet', {
+                    defaultValue: 'No link',
+                  })}
+                </span>
+              )}
             </div>
           );
         })}

--- a/components/plc/tabs/PlcPlaceholderTab.tsx
+++ b/components/plc/tabs/PlcPlaceholderTab.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 import { LucideIcon } from 'lucide-react';
 
 interface PlcPlaceholderTabProps {
@@ -17,6 +18,7 @@ export const PlcPlaceholderTab: React.FC<PlcPlaceholderTabProps> = ({
   title,
   description,
 }) => {
+  const { t } = useTranslation();
   return (
     <div className="flex flex-col items-center justify-center h-full min-h-[300px] px-6 text-center">
       <div className="w-16 h-16 rounded-2xl bg-brand-blue-lighter flex items-center justify-center mb-5">
@@ -27,7 +29,9 @@ export const PlcPlaceholderTab: React.FC<PlcPlaceholderTabProps> = ({
         {description}
       </p>
       <span className="mt-5 text-xxs font-bold uppercase tracking-widest text-brand-blue-primary bg-brand-blue-lighter px-3 py-1 rounded-full">
-        Coming soon
+        {t('plcDashboard.placeholder.comingSoon', {
+          defaultValue: 'Coming soon',
+        })}
       </span>
     </div>
   );

--- a/components/plc/tabs/PlcPlaceholderTab.tsx
+++ b/components/plc/tabs/PlcPlaceholderTab.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { LucideIcon } from 'lucide-react';
+
+interface PlcPlaceholderTabProps {
+  icon: LucideIcon;
+  title: string;
+  description: string;
+}
+
+/**
+ * Inert placeholder for PLC Dashboard tabs that aren't built yet.
+ * Phase 1 ships the shell with the navigation already in place; later
+ * phases swap each placeholder for the real implementation.
+ */
+export const PlcPlaceholderTab: React.FC<PlcPlaceholderTabProps> = ({
+  icon: Icon,
+  title,
+  description,
+}) => {
+  return (
+    <div className="flex flex-col items-center justify-center h-full min-h-[300px] px-6 text-center">
+      <div className="w-16 h-16 rounded-2xl bg-brand-blue-lighter flex items-center justify-center mb-5">
+        <Icon className="w-7 h-7 text-brand-blue-primary" />
+      </div>
+      <h3 className="text-lg font-bold text-slate-800 mb-2">{title}</h3>
+      <p className="text-sm text-slate-500 max-w-md leading-relaxed">
+        {description}
+      </p>
+      <span className="mt-5 text-xxs font-bold uppercase tracking-widest text-brand-blue-primary bg-brand-blue-lighter px-3 py-1 rounded-full">
+        Coming soon
+      </span>
+    </div>
+  );
+};

--- a/components/plc/tabs/PlcSettingsTab.tsx
+++ b/components/plc/tabs/PlcSettingsTab.tsx
@@ -140,16 +140,21 @@ export const PlcSettingsTab: React.FC<PlcSettingsTabProps> = ({ plc }) => {
           const Icon = row.icon;
           const enabled = features[row.key];
           const isBusy = busyKey === row.key;
+          // While any toggle is in-flight, lock out every row so the UI
+          // visibly matches the in-handler `if (busyKey) return` guard.
+          // Otherwise an unrelated row would look interactive but silently
+          // ignore clicks.
+          const anyBusy = busyKey !== null;
           return (
             <button
               key={row.key}
               onClick={() => void handleToggle(row.key)}
-              disabled={isBusy}
+              disabled={anyBusy}
               className={`flex items-start gap-3 p-3 bg-white border rounded-xl text-left transition-colors ${
                 enabled
                   ? 'border-brand-blue-light/60 hover:border-brand-blue-primary'
                   : 'border-slate-200 hover:border-slate-300'
-              } ${isBusy ? 'opacity-60 cursor-wait' : ''}`}
+              } ${isBusy ? 'opacity-60 cursor-wait' : anyBusy ? 'opacity-70' : ''}`}
             >
               <div
                 className={`shrink-0 w-10 h-10 rounded-lg flex items-center justify-center transition-colors ${

--- a/components/plc/tabs/PlcSettingsTab.tsx
+++ b/components/plc/tabs/PlcSettingsTab.tsx
@@ -1,0 +1,192 @@
+import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import {
+  BookOpen,
+  ClipboardList,
+  Film,
+  ListChecks,
+  StickyNote,
+  SquareSquare,
+} from 'lucide-react';
+import {
+  DEFAULT_PLC_FEATURE_SETTINGS,
+  Plc,
+  PlcFeatureSettings,
+  getPlcFeatures,
+} from '@/types';
+import { usePlcs } from '@/hooks/usePlcs';
+import { useDashboard } from '@/context/useDashboard';
+
+interface PlcSettingsTabProps {
+  plc: Plc;
+}
+
+interface FeatureRow {
+  key: keyof PlcFeatureSettings;
+  icon: typeof BookOpen;
+  titleKey: string;
+  titleDefault: string;
+  descriptionKey: string;
+  descriptionDefault: string;
+}
+
+const FEATURE_ROWS: readonly FeatureRow[] = [
+  {
+    key: 'quizzes',
+    icon: BookOpen,
+    titleKey: 'plcDashboard.settings.quizzes.title',
+    titleDefault: 'Quiz Library',
+    descriptionKey: 'plcDashboard.settings.quizzes.description',
+    descriptionDefault:
+      'Share quizzes with the PLC. Members can sync edits or copy a quiz into their own library.',
+  },
+  {
+    key: 'assignments',
+    icon: ClipboardList,
+    titleKey: 'plcDashboard.settings.assignments.title',
+    titleDefault: 'PLC Assignments',
+    descriptionKey: 'plcDashboard.settings.assignments.description',
+    descriptionDefault:
+      'Author PLC-level assignments that members can pick up on their own boards.',
+  },
+  {
+    key: 'videoActivities',
+    icon: Film,
+    titleKey: 'plcDashboard.settings.videoActivities.title',
+    titleDefault: 'Video Activities',
+    descriptionKey: 'plcDashboard.settings.videoActivities.description',
+    descriptionDefault:
+      'Share video-based activities and aggregate completion data with the PLC.',
+  },
+  {
+    key: 'notes',
+    icon: StickyNote,
+    titleKey: 'plcDashboard.settings.notes.title',
+    titleDefault: 'Notes',
+    descriptionKey: 'plcDashboard.settings.notes.description',
+    descriptionDefault: 'A shared notebook for the PLC.',
+  },
+  {
+    key: 'todos',
+    icon: ListChecks,
+    titleKey: 'plcDashboard.settings.todos.title',
+    titleDefault: 'To-Do List',
+    descriptionKey: 'plcDashboard.settings.todos.description',
+    descriptionDefault: 'A shared checklist so the PLC can track action items.',
+  },
+  {
+    key: 'sharedBoards',
+    icon: SquareSquare,
+    titleKey: 'plcDashboard.settings.sharedBoards.title',
+    titleDefault: 'Shared Boards',
+    descriptionKey: 'plcDashboard.settings.sharedBoards.description',
+    descriptionDefault: 'Surface dashboards shared with the PLC.',
+  },
+] as const;
+
+/**
+ * Per-PLC dashboard feature toggles. Per spec, every PLC member can flip
+ * these — they're shared configuration, not lead-only. Failures roll the
+ * UI back to the previous value and surface a toast.
+ */
+export const PlcSettingsTab: React.FC<PlcSettingsTabProps> = ({ plc }) => {
+  const { t } = useTranslation();
+  const { updatePlcFeatures } = usePlcs({ enabled: false });
+  const { addToast } = useDashboard();
+  const features = getPlcFeatures(plc);
+  const [busyKey, setBusyKey] = useState<keyof PlcFeatureSettings | null>(null);
+
+  const handleToggle = async (key: keyof PlcFeatureSettings) => {
+    if (busyKey) return;
+    setBusyKey(key);
+    const next: PlcFeatureSettings = {
+      ...DEFAULT_PLC_FEATURE_SETTINGS,
+      ...features,
+      [key]: !features[key],
+    };
+    try {
+      await updatePlcFeatures(plc.id, next);
+    } catch (err) {
+      addToast(
+        err instanceof Error
+          ? err.message
+          : t('plcDashboard.settings.saveFailed', {
+              defaultValue: 'Failed to save settings',
+            }),
+        'error'
+      );
+    } finally {
+      setBusyKey(null);
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div>
+        <h3 className="text-sm font-bold text-slate-800">
+          {t('plcDashboard.settings.heading', {
+            defaultValue: 'Dashboard Sections',
+          })}
+        </h3>
+        <p className="text-xs text-slate-500 mt-1 leading-relaxed">
+          {t('plcDashboard.settings.description', {
+            defaultValue:
+              "Choose which sections appear in this PLC's dashboard. Any PLC member can update these.",
+          })}
+        </p>
+      </div>
+      <div className="flex flex-col gap-2">
+        {FEATURE_ROWS.map((row) => {
+          const Icon = row.icon;
+          const enabled = features[row.key];
+          const isBusy = busyKey === row.key;
+          return (
+            <button
+              key={row.key}
+              onClick={() => void handleToggle(row.key)}
+              disabled={isBusy}
+              className={`flex items-start gap-3 p-3 bg-white border rounded-xl text-left transition-colors ${
+                enabled
+                  ? 'border-brand-blue-light/60 hover:border-brand-blue-primary'
+                  : 'border-slate-200 hover:border-slate-300'
+              } ${isBusy ? 'opacity-60 cursor-wait' : ''}`}
+            >
+              <div
+                className={`shrink-0 w-10 h-10 rounded-lg flex items-center justify-center transition-colors ${
+                  enabled
+                    ? 'bg-brand-blue-lighter text-brand-blue-primary'
+                    : 'bg-slate-100 text-slate-400'
+                }`}
+              >
+                <Icon className="w-4 h-4" />
+              </div>
+              <div className="flex-1 min-w-0">
+                <div className="text-sm font-bold text-slate-800">
+                  {t(row.titleKey, { defaultValue: row.titleDefault })}
+                </div>
+                <div className="text-xxs text-slate-500 leading-relaxed mt-0.5">
+                  {t(row.descriptionKey, {
+                    defaultValue: row.descriptionDefault,
+                  })}
+                </div>
+              </div>
+              <div
+                role="switch"
+                aria-checked={enabled}
+                className={`shrink-0 relative w-10 h-5 rounded-full transition-colors ${
+                  enabled ? 'bg-brand-blue-primary' : 'bg-slate-300'
+                }`}
+              >
+                <span
+                  className={`absolute top-0.5 w-4 h-4 rounded-full bg-white shadow-sm transition-all ${
+                    enabled ? 'left-[22px]' : 'left-0.5'
+                  }`}
+                />
+              </div>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+};

--- a/docs/PLC_ROADMAP.md
+++ b/docs/PLC_ROADMAP.md
@@ -1,0 +1,301 @@
+# PLC Dashboard Expansion — Roadmap
+
+Multi-phase plan to grow the **My PLCs** sidebar entry from "list + invites" into a full Professional Learning Community workspace: shared quiz library, PLC-authored assignments, video activities, notes, to-dos, and shared boards.
+
+Phase 1 has shipped (PR #1537, into `dev-paul`). This doc captures what landed, what's next, and the architectural decisions that bind future phases.
+
+---
+
+## How to use this doc
+
+This roadmap is designed to be **executed in independent chunks across multiple sessions**. An agent (or human) can pick up any unshipped phase without re-deriving context.
+
+### Rules for agents working this roadmap
+
+1. **Always read this doc top-to-bottom before starting a phase.** Decisions in later phases may have shifted based on notes from earlier phases.
+2. **Work one phase at a time.** Each phase is a shippable PR. Do not interleave phases.
+3. **After completing each phase:**
+   - Check the phase box in the Status list.
+   - Fill in the phase's "Notes from implementation" block with: files actually changed (if different from the plan), surprises encountered, decisions made mid-phase, and anything the next phase needs to know.
+   - If the work diverged from the plan, update the affected later-phase sections to reflect reality.
+4. **Open questions.** If you hit a decision that isn't answered in "Locked decisions" below, add it to the **Open questions** list at the bottom and ask the user before proceeding — don't guess.
+5. **Scope discipline.** Each phase has an explicit "Out of scope" list. Resist the urge to bundle later-phase work — small PRs ship; big PRs stall.
+6. **Don't delete this section.** The next agent needs it.
+
+---
+
+## Status
+
+- [x] **Phase 1** — Dashboard shell + feature toggles + completed-assignments tab _(PR #1537)_
+- [ ] **Phase 2** — PLC Quiz Library (share-with-PLC, collaborative editing, sync-or-copy import)
+- [ ] **Phase 3** — PLC-authored Assignments tab + auto-bubble-up from personal assignments
+- [ ] **Phase 4** — Video Activities (extend with `PlcLinkage` + dashboard surface)
+- [ ] **Phase 5** — Notes + To-Do list (collaborative shared docs)
+- [ ] **Phase 6** — Shared Boards surface
+
+Branch convention: each phase opens a `claude/plc-phase-N-<slug>` branch off `dev-paul`. Do **not** target `main` directly.
+
+---
+
+## Locked decisions (do not re-open without user approval)
+
+| Decision                                   | Value                                                                                                                                                                                                                                                                                                       |
+| ------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| PLC-owned content storage                  | **Subcollections under `plcs/{plcId}/...`** (not top-level collections with a `plcId` field). One precedent already exists: `plcs/{plcId}/assignment_index/{assignmentId}` from Phase 1. Same pattern applies to `quizzes/`, `video_activities/`, `notes/`, `todos/`, `assignments/` in later phases.       |
+| Sync-vs-copy import model                  | When a member adds PLC content to their own board/library, they pick **Sync** (live-edit follows the PLC version) or **Copy** (one-time snapshot). Reuse the existing `QuizAssignmentImportModeModal` pattern (`components/widgets/QuizWidget/components/QuizAssignmentImportModeModal.tsx`).               |
+| Collaborative edit infrastructure          | Lean on existing `synced_quizzes/{groupId}` machinery (last-writer-wins per field, debounced). Phase 2 wires PLC quizzes to a sync group so member edits propagate near-real-time. **Do not invest in CRDT/op-based editing** — LWW matches every other surface in the app.                                 |
+| Settings toggles                           | Per-PLC `features` map on the PLC doc, editable by **any member** (not lead-only). Always merged through `getPlcFeatures(plc)` so legacy PLCs and partial maps default to enabled.                                                                                                                          |
+| `completedAssignments` is not a flag       | The completed-assignments index is always visible; it's the read-only history view that anchors the dashboard. Don't add a toggle for it.                                                                                                                                                                   |
+| Assignment index writes                    | **Fire-and-forget** from `useQuizAssignments.createAssignment` via `void writePlcAssignmentIndexEntry(...)`. The helper has its own try/catch and never rejects — the assign action returns immediately after the canonical batch commits. Failures are logged via `logError` and surface at next snapshot. |
+| Anti-phish on `sheetUrl`                   | The Firestore rule pins `assignment_index.sheetUrl` to the parent PLC's `sharedSheetUrl`. Defense-in-depth: client also validates `http:` / `https:` before rendering as a link. **Both layers must stay** — neither is sufficient alone.                                                                   |
+| Shared sheet URL race                      | Set-if-empty transactional write at the rules layer (`isSettingPlcSharedSheetUrl`) plus client transaction in `setPlcSharedSheetUrl`. A race-loser's freshly-created sheet may be orphaned in their Drive — accepted trade-off for rare concurrent first-PLC-assignment collisions.                         |
+| Migration to subcollections from top-level | None expected — every Phase 2-6 collection is **new**. Do not move the existing top-level `quizzes/`, `video_activities/`, etc. — those stay user-scoped under `users/{uid}/...`. PLC content is a separate, additive store.                                                                                |
+
+---
+
+## Reference files (read before starting any phase)
+
+Open these in the first session so you understand the pivot points:
+
+- `types.ts` — `Plc`, `PlcFeatureSettings`, `PlcLinkage`, `PlcAssignmentIndexEntry`, `QuizAssignmentSettings`. The `PlcLinkage` sub-object is the canonical "this assignment opts into PLC mode" predicate.
+- `firestore.rules` lines 676–902 — PLC + invite + assignment_index rules. Read the helper functions (`isAcceptingPlcInvite`, `isLeavingPlc`, `isSettingPlcSharedSheetUrl`, `isUpdatingPlcFeatures`) before adding new rule branches.
+- `hooks/usePlcs.ts` — live PLC list, mutators, `updatePlcFeatures`, transactional sheet-URL write.
+- `hooks/usePlcAssignmentIndex.ts` — Phase 1 example of a PLC subcollection hook + writer pattern. Mirror this for later phases.
+- `hooks/useQuizAssignments.ts` lines ~568–720 — `createAssignment` body. The PLC index write side effect lives here.
+- `components/plc/PlcDashboard.tsx` — full-screen dashboard shell. Tab routing is feature-flag-gated via `getPlcFeatures(plc)`.
+- `components/plc/tabs/*` — Phase 1 tab implementations + placeholder pattern (`PlcPlaceholderTab.tsx`).
+- `components/widgets/QuizWidget/components/QuizAssignmentImportModeModal.tsx` — the canonical sync-or-copy picker UX. Phase 2/3/4 pickers should mirror it.
+- `hooks/useSyncedQuizGroups.ts` + `synced_quizzes/{groupId}` rules in `firestore.rules` — the LWW collaborative-edit infrastructure Phase 2 will lean on.
+
+---
+
+## Phase 1 — Dashboard shell + feature toggles + completed assignments _(SHIPPED)_
+
+**Status:** Merged via PR #1537 into `dev-paul`.
+
+### What landed
+
+- `components/plc/PlcDashboard.tsx` — full-screen overlay (mirrors `AdminSettings` pattern). Desktop tab pills, mobile drawer, Escape-to-close.
+- `components/plc/tabs/PlcCompletedAssignmentsTab.tsx` — read-only list of every PLC-mode assignment any member has run. Backed by `plcs/{plcId}/assignment_index`. Each row links out to the shared Google Sheet (with `isSafeHttpUrl` defense-in-depth).
+- `components/plc/tabs/PlcSettingsTab.tsx` — per-PLC feature toggles. Any member can flip. Disables all rows while one toggle write is in flight.
+- `components/plc/tabs/PlcPlaceholderTab.tsx` — placeholder pattern for unshipped phases.
+- `hooks/usePlcAssignmentIndex.ts` — live subscription + best-effort writer for the assignment index.
+- `hooks/usePlcs.ts` extended with `updatePlcFeatures(plcId, features)` and a `features` field parser that merges against `DEFAULT_PLC_FEATURE_SETTINGS`.
+- `hooks/useQuizAssignments.ts` — `createAssignment` now fires a best-effort `void writePlcAssignmentIndexEntry(...)` whenever `settings.plc` is set (covers `importSharedAssignment` for PLC members too).
+- `firestore.rules` — new `isUpdatingPlcFeatures()` helper for the PLC-level features map; `plcs/{plcId}/assignment_index/{assignmentId}` rules with split create/update branches, schema lock-down via `keys().hasOnly([...])`, `kind == 'quiz'` constraint, and `sheetUrl == parent.sharedSheetUrl` anti-phish pin.
+- `tests/hooks/usePlcAssignmentIndex.test.ts` (new), `tests/rules/plcAssignmentIndex.test.ts` (new), `tests/hooks/useQuizAssignments.test.ts` (extended with PLC index side-effect coverage).
+
+### Notes from implementation
+
+- The original `allow create, update` rule for the assignment index had a takeover bypass (member B could overwrite member A's entry by setting `ownerUid` to themselves). Caught in Copilot review — fixed by splitting into separate `create` and `update` branches and pinning `id`/`ownerUid`/`createdAt` immutable on update.
+- The `PlcSettingsTab` initially only disabled the active row while a toggle write was in flight, but other rows kept the busy guard silently. Fixed to disable all rows whenever `busyKey !== null`.
+- Listener mounting: `Sidebar.tsx` keeps `usePlcs` subscription active while either the drawer OR the dashboard overlay is open (`enabled: isOpen || openPlcDashboardId !== null`). Don't drop this — closing the drawer while the dashboard is open would otherwise stop refreshing the live PLC list.
+
+---
+
+## Phase 2 — PLC Quiz Library
+
+**Goal:** members can share a quiz with their PLC, edit it collaboratively in near-real-time, and import it into their personal library via sync-or-copy.
+
+### Scope
+
+- New `plcs/{plcId}/quizzes/{quizId}` subcollection. Each entry mirrors the shape of a personal quiz (`QuizData`) plus a small PLC-snapshot header (sharedAt, sharedBy, syncGroupId).
+- New "Share with PLC" item in the Quiz Library kebab menu. Click → pick PLC → write to subcollection AND join the source quiz to a `synced_quizzes/{groupId}` group.
+- `PlcQuizLibraryTab.tsx` (replaces the placeholder). Lists the PLC's shared quizzes. Each row supports edit-in-place (the editor opens the synced version, debounced LWW writes via existing `useSyncedQuizGroups`).
+- "Add to my library" action on each row. Opens a sync-or-copy picker (mirror `QuizAssignmentImportModeModal`):
+  - **Sync** — adds the quiz to the user's personal library AND joins the sync group, so subsequent PLC edits flow into their copy.
+  - **Copy** — one-time snapshot.
+
+### Architectural notes
+
+- The synced-quizzes infrastructure is the load-bearing piece. Don't re-implement LWW. The `participants` map on the sync group already supports multi-teacher edits.
+- Add `plcId?: string` to the synced quiz group doc so it can be filtered to "this PLC's shared quizzes" without a cross-collection join.
+- The kebab "Share with PLC" should reject if the user isn't a member of any PLC (not just hide — show a toast pointing at the My PLCs sidebar).
+
+### Files (expected)
+
+- `types.ts` — add `PlcQuizSnapshot` (or extend `QuizData` with optional `plc?: { plcId, sharedAt, sharedBy }` header).
+- `firestore.rules` — new `match /plcs/{plcId}/quizzes/{quizId}` block. Reads gated by membership; writes gated by membership + sync-group ownership.
+- `hooks/usePlcQuizzes.ts` (new) — live list + share/unshare mutators.
+- `components/widgets/QuizWidget/QuizManager.tsx` (or wherever the kebab is) — add "Share with PLC" item + PLC picker.
+- `components/plc/tabs/PlcQuizLibraryTab.tsx` — replaces placeholder.
+- `components/plc/PlcQuizImportModal.tsx` (new) — sync-or-copy picker, mirrors `QuizAssignmentImportModeModal`.
+- Tests: hook + rules suites for the new subcollection, mirror of existing `plcAssignmentIndex.test.ts`.
+
+### Out of scope for Phase 2
+
+- Video activities (Phase 4).
+- PLC-authored assignments (Phase 3) — sharing a quiz does not auto-create an assignment; the assignment is created by the importer's existing flow.
+- Permissions beyond "any member can edit / any member can copy". No editor-vs-viewer split.
+
+### Open question
+
+- When the original sharer **deletes** their personal copy of a quiz that's been synced to a PLC, does the PLC copy stay (orphan-tolerant) or get pulled? Recommend: **stays.** PLC copy lives in its own subcollection; deleting your personal version doesn't affect the PLC's shared version. Confirm with user before implementing.
+
+### Notes from implementation
+
+_(Fill in after shipping.)_
+
+---
+
+## Phase 3 — PLC-authored Assignments tab
+
+**Goal:** members can author assignments at the PLC level (so all teammates pick them up), AND any personal assignment that opts into PLC mode auto-bubbles up to the PLC dashboard.
+
+### Scope
+
+- New `plcs/{plcId}/assignments/{assignmentId}` subcollection. PLC-level assignments differ from the personal `quiz_assignments` collection: they're created without a teacher's class targeting, and members opt in by importing them onto their own board.
+- New `PlcAssignmentsTab.tsx` (replaces the placeholder, distinct from `PlcCompletedAssignmentsTab`):
+  - **Top half:** PLC-authored assignments awaiting member pickup. Each row has "Add to my board" (sync-or-copy picker).
+  - **Bottom half:** the existing completed-assignments index (or move it into a sub-tab here — TBD).
+- The reverse path: when a member toggles "PLC" inside the personal `QuizAssignmentSettingsModal`, the assignment auto-creates a corresponding PLC-level entry too. (Phase 1 already writes to `assignment_index` for the completed view; Phase 3 extends this with a "live assignment" entry for the authoring tab.)
+
+### Architectural notes
+
+- A PLC-level assignment is essentially a parameterized template: quiz reference, session options, attempt limit, `sessionMode`. It does NOT carry `classIds` / `rosterIds` (those are per-importer).
+- The "Add to my board" action calls the existing `createAssignment` with the PLC template's settings, then either joins the synced group (sync) or creates a fresh sync group (copy).
+- The reverse-bubble-up should write to BOTH the existing `assignment_index` (already done in Phase 1) AND the new `assignments` subcollection. Document the difference: `assignment_index` is the read-only history; `assignments` is the live "available for pickup" template list.
+
+### Out of scope for Phase 3
+
+- Per-member completion tracking (already covered by the assignment_index + Google Sheet aggregation).
+- Notifications when a PLC-level assignment is added.
+
+### Open questions
+
+- Does the "PLC option" in the personal assignment modal create a brand-new PLC-level assignment, or surface the personal one with a `forkable: true` flag? Recommend: **brand-new PLC-level assignment** (cleaner separation; personal assignment stays personal). Confirm.
+- If a PLC member deletes the PLC-level assignment, what happens to any in-flight imports on members' boards? Recommend: **imports keep running** (they're independent assignment+session docs after import). Confirm.
+
+### Notes from implementation
+
+_(Fill in after shipping.)_
+
+---
+
+## Phase 4 — Video Activities
+
+**Goal:** extend video activities with the same PLC linkage + dashboard surface that quizzes already have.
+
+### Scope
+
+- Add `plc?: PlcLinkage` to `VideoActivityAssignmentSettings` (mirror `QuizAssignmentSettings`).
+- `useVideoActivityAssignments.createAssignment` writes to the PLC index (extend `PlcAssignmentIndexEntry.kind` union to include `'video-activity'` — the discriminator slot is already there in Phase 1).
+- New `plcs/{plcId}/video_activities/{activityId}` subcollection mirroring Phase 2's quiz library pattern.
+- `PlcVideoActivitiesTab.tsx` replaces the placeholder.
+
+### Architectural notes
+
+- Video activities use a binary status (active/ended) instead of quiz's active/paused/inactive — doesn't affect the index entry shape.
+- `kind` discriminator widening: this is the first phase that meaningfully exercises the union. Update `parseEntry` in `usePlcAssignmentIndex.ts` to accept `'video-activity'` AND update the rules' `kind in ['quiz', 'video-activity']` check. The Phase 1 test (`normalizes 'kind' to 'quiz' even for legacy or wrong values`) needs to be revisited once the union widens.
+
+### Out of scope for Phase 4
+
+- Activity Wall (it's not a true assignment type — it's a collaborative student space).
+- Mini-apps (separate phase, not currently planned for PLC integration).
+
+### Notes from implementation
+
+_(Fill in after shipping.)_
+
+---
+
+## Phase 5 — Notes + To-Do list
+
+**Goal:** lightweight collaborative shared docs at the PLC level.
+
+### Scope
+
+- `plcs/{plcId}/notes/{noteId}` subcollection — shared rich-text notes. Each note has `title`, `body` (markdown or simple HTML), `lastEditedBy`, `lastEditedAt`. Any member can create/edit/delete.
+- `plcs/{plcId}/todos/{todoId}` subcollection — shared task list. Each todo has `text`, `done: boolean`, `createdBy`, `createdAt`, optionally `assignedTo: uid`.
+- `PlcNotesTab.tsx` and `PlcTodosTab.tsx` replace placeholders.
+
+### Architectural notes
+
+- Notes editing: same LWW pattern as synced quizzes (debounced field writes). For Phase 5 we don't need version monotonicity (notes are a single doc, not a structured quiz tree) — last write wins on the whole `body` field is acceptable.
+- For todos, prefer a subcollection (one doc per todo) over a single doc with an array — array writes serialize the whole list and don't scale to dozens of items with concurrent edits.
+
+### Open questions
+
+- Should notes support multiple notes per PLC (e.g. "meeting notes from May 7") or a single shared notepad? Recommend: **multiple notes** (matches the subcollection model). Confirm.
+- Are todos owned by the PLC or per-member? Recommend: **PLC-owned with optional `assignedTo`** so any member can mark any todo complete. Confirm.
+
+### Notes from implementation
+
+_(Fill in after shipping.)_
+
+---
+
+## Phase 6 — Shared Boards surface
+
+**Goal:** surface dashboards (boards) that have been shared with a PLC.
+
+### Scope
+
+- Today, board sharing is per-user (`shared_boards/{shareId}`). Add a `plcId?: string` field so a board can be shared with an entire PLC.
+- New `PlcSharedBoardsTab.tsx` lists all boards shared with this PLC. Each row has "Open" (read-only view) and "Copy to my dashboards".
+
+### Architectural notes
+
+- This is the smallest phase. The infrastructure already exists; we're just adding a `plcId` filter and a tab.
+- The existing `shared_boards` rules will need a new branch: members of the PLC can read shares where `plcId == this PLC` even if they aren't the shareTarget.
+
+### Open questions
+
+- Can a member edit a PLC-shared board, or is it always read-only/copy? Recommend: **read-only/copy** for simplicity. Editing shared boards multi-teacher would need its own LWW infrastructure (out of scope for Phase 6).
+
+### Notes from implementation
+
+_(Fill in after shipping.)_
+
+---
+
+## Cross-cutting concerns
+
+### i18n
+
+Each phase adds strings under `locales/en.json` `plcDashboard.*`. The other locales (`de.json`, `es.json`, `fr.json`) pick them up automatically via `defaultValue` fallbacks in `t()` calls — explicit translations can be backfilled later.
+
+### Telemetry
+
+Errors in best-effort writes (assignment index, sync group joins) go through `logError(scope, err, context)`. Use stable `scope` strings so log queries don't break across releases. Pattern:
+
+```ts
+logError('usePlcAssignmentIndex.snapshot', err, { plcId });
+logError('writePlcAssignmentIndexEntry.write', err, { plcId, entryId });
+```
+
+### Testing
+
+- **Hooks:** unit tests with mocked Firestore SDK, mirror `tests/hooks/usePlcAssignmentIndex.test.ts`.
+- **Rules:** emulator-backed tests, mirror `tests/rules/plcAssignmentIndex.test.ts`. CI's "Firestore Rules Tests" job runs them automatically.
+- **Integration:** every new `createX` call site must have at least one test that asserts the side-effect (e.g. "PLC index entry is written when settings.plc is set").
+
+### Performance
+
+- Don't load PLC content while the dashboard is closed. Hooks accept an `enabled` option (see `usePlcs.ts`). Mirror this pattern.
+- Don't add new top-level collections — every PLC subcollection is automatically gated by the parent PLC's membership check. A top-level `plc_quizzes` collection would need a `plcId` field on every doc and a rule that does an extra `get()`, doubling the read cost.
+
+### Security
+
+- Every PLC subcollection rule must:
+  1. Gate reads on PLC membership (`request.auth.uid in get(plcDoc).data.memberUids`).
+  2. Lock writes to the canonical schema via `keys().hasOnly([...])`.
+  3. Pin any user-controlled URL field to a known canonical source (anti-phish pattern from Phase 1's `sheetUrl`).
+  4. Split create vs update so update can also check the **existing** `resource.data` for ownership/immutability.
+
+---
+
+## Open questions
+
+_(Add new ones here as they come up. Resolve before starting the affected phase.)_
+
+- **Phase 2:** orphan behavior when sharer deletes their personal copy of a synced PLC quiz.
+- **Phase 3:** does the personal "PLC option" toggle create a brand-new PLC-level assignment template, or fork from the personal one?
+- **Phase 3:** what happens to in-flight imports if the PLC-level template is deleted?
+- **Phase 5:** single shared notepad vs. multiple notes per PLC.
+- **Phase 5:** are todos PLC-owned or per-member?
+- **Phase 6:** read-only vs. editable for PLC-shared boards.
+
+---
+
+**Last updated:** 2026-05-07 (Phase 1 shipped — PR #1537)

--- a/firestore.rules
+++ b/firestore.rules
@@ -893,12 +893,31 @@ service cloud.firestore {
         // author must be a current PLC member — non-members can't fabricate
         // entries pointing at someone else's assignment. Status mirroring
         // (later phases) goes through the same `update` branch.
+        //
+        // Schema lock-down (`keys().hasOnly([...])`) keeps the doc shape
+        // closed so future readers can rely on the field set without
+        // defensive parsing of unexpected payloads.
+        //
+        // `sheetUrl` is pinned to the parent PLC's `sharedSheetUrl` — the
+        // dashboard renders this as a clickable link, so an unconstrained
+        // string would let a malicious member point teammates at a
+        // phishing URL through the dashboard. Two separate `get()`s on
+        // the parent PLC are de-duped by the rules engine within a single
+        // evaluation, so this doesn't cost an extra read.
         allow create, update: if request.auth != null
           && request.auth.uid == request.resource.data.ownerUid
           && request.auth.uid in get(
                /databases/$(database)/documents/plcs/$(plcId)
              ).data.memberUids
-          && assignmentId == request.resource.data.id;
+          && assignmentId == request.resource.data.id
+          && request.resource.data.keys().hasOnly([
+               'id', 'kind', 'ownerUid', 'ownerName', 'ownerEmail',
+               'title', 'sheetUrl', 'createdAt'
+             ])
+          && request.resource.data.kind == 'quiz'
+          && request.resource.data.sheetUrl == get(
+               /databases/$(database)/documents/plcs/$(plcId)
+             ).data.get('sharedSheetUrl', '');
 
         // Authors can clean up their own entries (e.g. if they delete the
         // source assignment). No lead-override here — leads who want to

--- a/firestore.rules
+++ b/firestore.rules
@@ -901,14 +901,46 @@ service cloud.firestore {
         // `sheetUrl` is pinned to the parent PLC's `sharedSheetUrl` — the
         // dashboard renders this as a clickable link, so an unconstrained
         // string would let a malicious member point teammates at a
-        // phishing URL through the dashboard. Two separate `get()`s on
-        // the parent PLC are de-duped by the rules engine within a single
+        // phishing URL through the dashboard. The two `get()`s on the
+        // parent PLC are de-duped by the rules engine within a single
         // evaluation, so this doesn't cost an extra read.
-        allow create, update: if request.auth != null
+        //
+        // Create and update are split because the `update` branch must
+        // also check the *existing* `resource.data.ownerUid`. Without that
+        // extra check, a different PLC member could overwrite someone
+        // else's entry by simply setting `request.resource.data.ownerUid`
+        // to their own UID. The split also lets `update` enforce
+        // immutability on `id`, `ownerUid`, and `createdAt` so future
+        // status-mirroring writes (later phases) can't quietly retarget
+        // an entry to a different assignment or rewrite history.
+        allow create: if request.auth != null
           && request.auth.uid == request.resource.data.ownerUid
           && request.auth.uid in get(
                /databases/$(database)/documents/plcs/$(plcId)
              ).data.memberUids
+          && assignmentId == request.resource.data.id
+          && request.resource.data.keys().hasOnly([
+               'id', 'kind', 'ownerUid', 'ownerName', 'ownerEmail',
+               'title', 'sheetUrl', 'createdAt'
+             ])
+          && request.resource.data.kind == 'quiz'
+          && request.resource.data.sheetUrl == get(
+               /databases/$(database)/documents/plcs/$(plcId)
+             ).data.get('sharedSheetUrl', '');
+
+        allow update: if request.auth != null
+          // Caller must be the *existing* owner — prevents takeover by a
+          // different member rewriting `ownerUid` to themselves.
+          && request.auth.uid == resource.data.ownerUid
+          && request.auth.uid in get(
+               /databases/$(database)/documents/plcs/$(plcId)
+             ).data.memberUids
+          // Identity fields are immutable across the lifetime of the
+          // entry. Mutable fields (e.g. status mirroring later) must
+          // still keep the doc shape closed via `keys().hasOnly([...])`.
+          && request.resource.data.id == resource.data.id
+          && request.resource.data.ownerUid == resource.data.ownerUid
+          && request.resource.data.createdAt == resource.data.createdAt
           && assignmentId == request.resource.data.id
           && request.resource.data.keys().hasOnly([
                'id', 'kind', 'ownerUid', 'ownerName', 'ownerEmail',

--- a/firestore.rules
+++ b/firestore.rules
@@ -807,6 +807,21 @@ service cloud.firestore {
            );
     }
 
+    // True iff the pending update is any current member toggling the
+    // dashboard `features` map (and nothing else). Per spec, every PLC
+    // member can toggle which optional sections render in the PLC Dashboard
+    // — this is shared configuration, not lead-only. Constrained to the
+    // `features` field plus the customary `updatedAt` bump so this branch
+    // can't be used to smuggle membership/leadership/sheet-URL changes.
+    function isUpdatingPlcFeatures() {
+      return (request.auth.uid in resource.data.memberUids)
+        && request.resource.data.diff(resource.data).affectedKeys()
+             .hasOnly(['features', 'updatedAt'])
+        && request.resource.data.diff(resource.data).affectedKeys()
+             .hasAny(['features'])
+        && request.resource.data.features is map;
+    }
+
     // True iff the pending update is the caller self-removing from
     // memberUids (i.e. leaving the PLC). The lead can't use this path —
     // they must transfer leadership first or delete the PLC outright.
@@ -853,11 +868,44 @@ service cloud.firestore {
         || isAcceptingPlcInvite(plcId)
         || isLeavingPlc()
         || isSettingPlcSharedSheetUrl()
+        || isUpdatingPlcFeatures()
       );
 
       // Only the lead can dissolve the PLC.
       allow delete: if request.auth != null
         && request.auth.uid == resource.data.leadUid;
+
+      // Index of PLC-mode assignments authored by any member. Each row is
+      // a small snapshot (title, ownerUid, sheetUrl, createdAt) written by
+      // the author when their personal `quiz_assignments` doc opts into
+      // PLC mode. Subcollection rather than a top-level collection so
+      // membership-gated reads are a one-line rule.
+      match /assignment_index/{assignmentId} {
+        // Any current member can read the index — the dashboard renders
+        // the same list for everyone in the PLC.
+        allow read: if request.auth != null
+          && request.auth.uid in get(
+               /databases/$(database)/documents/plcs/$(plcId)
+             ).data.memberUids;
+
+        // Only the assignment author writes their own entries; doc id is
+        // forced to the source assignment id for easy join-back. The
+        // author must be a current PLC member — non-members can't fabricate
+        // entries pointing at someone else's assignment. Status mirroring
+        // (later phases) goes through the same `update` branch.
+        allow create, update: if request.auth != null
+          && request.auth.uid == request.resource.data.ownerUid
+          && request.auth.uid in get(
+               /databases/$(database)/documents/plcs/$(plcId)
+             ).data.memberUids
+          && assignmentId == request.resource.data.id;
+
+        // Authors can clean up their own entries (e.g. if they delete the
+        // source assignment). No lead-override here — leads who want to
+        // sweep stale entries can ask the owner.
+        allow delete: if request.auth != null
+          && request.auth.uid == resource.data.ownerUid;
+      }
     }
 
     match /plc_invitations/{inviteId} {

--- a/hooks/usePlcAssignmentIndex.ts
+++ b/hooks/usePlcAssignmentIndex.ts
@@ -1,8 +1,16 @@
 import { useEffect, useMemo, useState } from 'react';
-import { collection, doc, onSnapshot, query, setDoc } from 'firebase/firestore';
+import {
+  collection,
+  doc,
+  onSnapshot,
+  orderBy,
+  query,
+  setDoc,
+} from 'firebase/firestore';
 import { db, isAuthBypass } from '@/config/firebase';
 import { useAuth } from '@/context/useAuth';
 import { PlcAssignmentIndexEntry } from '@/types';
+import { logError } from '@/utils/logError';
 
 const PLCS_COLLECTION = 'plcs';
 const ASSIGNMENT_INDEX_SUBCOLLECTION = 'assignment_index';
@@ -24,13 +32,12 @@ function parseEntry(
   ) {
     return null;
   }
-  // `kind` is a discriminator for future video-activity entries; default to
-  // 'quiz' for legacy or partially-written rows so the dashboard doesn't
-  // drop them.
-  const kind = data.kind === 'quiz' ? 'quiz' : 'quiz';
+  // `kind` is a discriminator slot for future video-activity entries.
+  // Today there's only one valid value; later phases will widen the union
+  // and switch on the raw `data.kind` here.
   return {
     id,
-    kind,
+    kind: 'quiz',
     ownerUid: data.ownerUid,
     ownerName: typeof data.ownerName === 'string' ? data.ownerName : '',
     ownerEmail: typeof data.ownerEmail === 'string' ? data.ownerEmail : '',
@@ -52,6 +59,18 @@ export const usePlcAssignmentIndex = (
   const [entries, setEntries] = useState<PlcAssignmentIndexEntry[]>([]);
   const [loading, setLoading] = useState(true);
 
+  // Reset state when the target PLC changes so the UI never flashes the
+  // previous PLC's entries while the new snapshot is in flight. This is the
+  // "adjusting state while rendering" pattern used elsewhere in the repo
+  // (see `useQuizAssignments.ts` lines 523-526) — preferred over an effect
+  // because it avoids an extra render pass.
+  const [prevPlcId, setPrevPlcId] = useState(plcId);
+  if (plcId !== prevPlcId) {
+    setPrevPlcId(plcId);
+    setEntries([]);
+    setLoading(true);
+  }
+
   useEffect(() => {
     if (!plcId || !user || isAuthBypass) {
       const t = setTimeout(() => {
@@ -60,10 +79,8 @@ export const usePlcAssignmentIndex = (
       }, 0);
       return () => clearTimeout(t);
     }
-    // No `setLoading(true)` here: the initial useState value is already
-    // true, and the snapshot callback flips it to false on first emit
-    // (success or error). Switching `plcId` mid-mount isn't a supported
-    // path — the dashboard remounts when the user picks a different PLC.
+    // Server-side ordering by `createdAt desc` so the snapshot already
+    // arrives newest-first — no client-side `.sort()` pass needed.
     const ref = collection(
       db,
       PLCS_COLLECTION,
@@ -71,19 +88,18 @@ export const usePlcAssignmentIndex = (
       ASSIGNMENT_INDEX_SUBCOLLECTION
     );
     const unsub = onSnapshot(
-      query(ref),
+      query(ref, orderBy('createdAt', 'desc')),
       (snap) => {
         const list: PlcAssignmentIndexEntry[] = [];
         snap.forEach((d) => {
           const parsed = parseEntry(d.id, d.data() as Record<string, unknown>);
           if (parsed) list.push(parsed);
         });
-        list.sort((a, b) => b.createdAt - a.createdAt);
         setEntries(list);
         setLoading(false);
       },
       (err) => {
-        console.error('[usePlcAssignmentIndex] snapshot error:', err);
+        logError('usePlcAssignmentIndex.snapshot', err, { plcId });
         setLoading(false);
       }
     );
@@ -110,6 +126,9 @@ export async function writePlcAssignmentIndexEntry(
       entry
     );
   } catch (err) {
-    console.error('[writePlcAssignmentIndexEntry] write failed:', err);
+    logError('writePlcAssignmentIndexEntry.write', err, {
+      plcId,
+      entryId: entry.id,
+    });
   }
 }

--- a/hooks/usePlcAssignmentIndex.ts
+++ b/hooks/usePlcAssignmentIndex.ts
@@ -1,0 +1,115 @@
+import { useEffect, useMemo, useState } from 'react';
+import { collection, doc, onSnapshot, query, setDoc } from 'firebase/firestore';
+import { db, isAuthBypass } from '@/config/firebase';
+import { useAuth } from '@/context/useAuth';
+import { PlcAssignmentIndexEntry } from '@/types';
+
+const PLCS_COLLECTION = 'plcs';
+const ASSIGNMENT_INDEX_SUBCOLLECTION = 'assignment_index';
+
+interface UsePlcAssignmentIndexResult {
+  entries: PlcAssignmentIndexEntry[];
+  loading: boolean;
+}
+
+function parseEntry(
+  id: string,
+  data: Record<string, unknown>
+): PlcAssignmentIndexEntry | null {
+  if (
+    typeof data.ownerUid !== 'string' ||
+    typeof data.title !== 'string' ||
+    typeof data.sheetUrl !== 'string' ||
+    typeof data.createdAt !== 'number'
+  ) {
+    return null;
+  }
+  // `kind` is a discriminator for future video-activity entries; default to
+  // 'quiz' for legacy or partially-written rows so the dashboard doesn't
+  // drop them.
+  const kind = data.kind === 'quiz' ? 'quiz' : 'quiz';
+  return {
+    id,
+    kind,
+    ownerUid: data.ownerUid,
+    ownerName: typeof data.ownerName === 'string' ? data.ownerName : '',
+    ownerEmail: typeof data.ownerEmail === 'string' ? data.ownerEmail : '',
+    title: data.title,
+    sheetUrl: data.sheetUrl,
+    createdAt: data.createdAt,
+  };
+}
+
+/**
+ * Live subscription to a single PLC's assignment index. Returns entries
+ * sorted newest-first. Pass `null` for `plcId` to disable the listener
+ * (e.g. while the dashboard is closed).
+ */
+export const usePlcAssignmentIndex = (
+  plcId: string | null
+): UsePlcAssignmentIndexResult => {
+  const { user } = useAuth();
+  const [entries, setEntries] = useState<PlcAssignmentIndexEntry[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!plcId || !user || isAuthBypass) {
+      const t = setTimeout(() => {
+        setEntries([]);
+        setLoading(false);
+      }, 0);
+      return () => clearTimeout(t);
+    }
+    // No `setLoading(true)` here: the initial useState value is already
+    // true, and the snapshot callback flips it to false on first emit
+    // (success or error). Switching `plcId` mid-mount isn't a supported
+    // path — the dashboard remounts when the user picks a different PLC.
+    const ref = collection(
+      db,
+      PLCS_COLLECTION,
+      plcId,
+      ASSIGNMENT_INDEX_SUBCOLLECTION
+    );
+    const unsub = onSnapshot(
+      query(ref),
+      (snap) => {
+        const list: PlcAssignmentIndexEntry[] = [];
+        snap.forEach((d) => {
+          const parsed = parseEntry(d.id, d.data() as Record<string, unknown>);
+          if (parsed) list.push(parsed);
+        });
+        list.sort((a, b) => b.createdAt - a.createdAt);
+        setEntries(list);
+        setLoading(false);
+      },
+      (err) => {
+        console.error('[usePlcAssignmentIndex] snapshot error:', err);
+        setLoading(false);
+      }
+    );
+    return () => unsub();
+  }, [plcId, user]);
+
+  return useMemo(() => ({ entries, loading }), [entries, loading]);
+};
+
+/**
+ * One-shot write of an index entry. Called from the quiz assignment
+ * creation flow when the new assignment opts into PLC mode. Failures are
+ * non-fatal — the assignment itself has already committed; the dashboard
+ * can recover via a manual reindex later. We log + swallow so a transient
+ * Firestore hiccup doesn't break the user's "Assign" action.
+ */
+export async function writePlcAssignmentIndexEntry(
+  plcId: string,
+  entry: PlcAssignmentIndexEntry
+): Promise<void> {
+  try {
+    await setDoc(
+      doc(db, PLCS_COLLECTION, plcId, ASSIGNMENT_INDEX_SUBCOLLECTION, entry.id),
+      entry
+    );
+  } catch (err) {
+    console.error('[writePlcAssignmentIndexEntry] write failed:', err);
+  }
+}

--- a/hooks/usePlcs.ts
+++ b/hooks/usePlcs.ts
@@ -13,7 +13,7 @@ import {
 } from 'firebase/firestore';
 import { db, isAuthBypass } from '@/config/firebase';
 import { useAuth } from '@/context/useAuth';
-import { Plc } from '@/types';
+import { DEFAULT_PLC_FEATURE_SETTINGS, Plc, PlcFeatureSettings } from '@/types';
 
 const PLCS_COLLECTION = 'plcs';
 // Mirrors the constant in `usePlcInvitations` — kept here so `deletePlc` can
@@ -60,6 +60,16 @@ interface UsePlcsResult {
    * for the "already created?" check to avoid racing two teachers).
    */
   getPlcSharedSheetUrl: (plcId: string) => Promise<string | null>;
+  /**
+   * Any member: toggle the PLC dashboard `features` map. Always writes the
+   * full canonical map (defaults merged in) so partial historical writes
+   * can't leave dangling fields. Rejected by rules if the caller is not a
+   * current member of the PLC.
+   */
+  updatePlcFeatures: (
+    plcId: string,
+    features: PlcFeatureSettings
+  ) => Promise<void>;
 }
 
 function parsePlc(id: string, data: Record<string, unknown>): Plc | null {
@@ -83,6 +93,40 @@ function parsePlc(id: string, data: Record<string, unknown>): Plc | null {
   if (typeof data.sharedSheetUrl === 'string') {
     sharedSheetUrl = data.sharedSheetUrl;
   }
+  // features: optional map of dashboard section toggles. Read consumers
+  // should always merge against DEFAULT_PLC_FEATURE_SETTINGS via
+  // `getPlcFeatures()` rather than reading this field directly, so an
+  // absent field (legacy PLCs) and partial maps both default to enabled.
+  let features: PlcFeatureSettings | undefined;
+  if (data.features && typeof data.features === 'object') {
+    const raw = data.features as Record<string, unknown>;
+    features = {
+      quizzes:
+        typeof raw.quizzes === 'boolean'
+          ? raw.quizzes
+          : DEFAULT_PLC_FEATURE_SETTINGS.quizzes,
+      videoActivities:
+        typeof raw.videoActivities === 'boolean'
+          ? raw.videoActivities
+          : DEFAULT_PLC_FEATURE_SETTINGS.videoActivities,
+      assignments:
+        typeof raw.assignments === 'boolean'
+          ? raw.assignments
+          : DEFAULT_PLC_FEATURE_SETTINGS.assignments,
+      notes:
+        typeof raw.notes === 'boolean'
+          ? raw.notes
+          : DEFAULT_PLC_FEATURE_SETTINGS.notes,
+      todos:
+        typeof raw.todos === 'boolean'
+          ? raw.todos
+          : DEFAULT_PLC_FEATURE_SETTINGS.todos,
+      sharedBoards:
+        typeof raw.sharedBoards === 'boolean'
+          ? raw.sharedBoards
+          : DEFAULT_PLC_FEATURE_SETTINGS.sharedBoards,
+    };
+  }
   return {
     id,
     name: data.name,
@@ -90,6 +134,7 @@ function parsePlc(id: string, data: Record<string, unknown>): Plc | null {
     memberUids: data.memberUids,
     memberEmails,
     sharedSheetUrl,
+    ...(features ? { features } : {}),
     createdAt: typeof data.createdAt === 'number' ? data.createdAt : 0,
     updatedAt: typeof data.updatedAt === 'number' ? data.updatedAt : 0,
   };
@@ -361,6 +406,28 @@ export const usePlcs = (options?: UsePlcsOptions): UsePlcsResult => {
     []
   );
 
+  // Any current member: write the canonical features map. We always send
+  // the full merged shape (defaults overlaid with the partial caller map)
+  // so partial writes can't leave dangling fields, and so the rule's
+  // `is map` check always sees a complete object. The `isUpdatingPlcFeatures`
+  // rule branch guards the field-set so this can't be used to smuggle
+  // membership/leadership/sheet-URL changes.
+  const updatePlcFeatures = useCallback(
+    async (plcId: string, features: PlcFeatureSettings) => {
+      if (!user) throw new Error('Not signed in');
+      const merged: PlcFeatureSettings = {
+        ...DEFAULT_PLC_FEATURE_SETTINGS,
+        ...features,
+      };
+      await setDoc(
+        doc(db, PLCS_COLLECTION, plcId),
+        { features: merged, updatedAt: Date.now() },
+        { merge: true }
+      );
+    },
+    [user]
+  );
+
   return useMemo(
     () => ({
       plcs,
@@ -373,6 +440,7 @@ export const usePlcs = (options?: UsePlcsOptions): UsePlcsResult => {
       setPlcSharedSheetUrl,
       clearPlcSharedSheetUrl,
       getPlcSharedSheetUrl,
+      updatePlcFeatures,
     }),
     [
       plcs,
@@ -385,6 +453,7 @@ export const usePlcs = (options?: UsePlcsOptions): UsePlcsResult => {
       setPlcSharedSheetUrl,
       clearPlcSharedSheetUrl,
       getPlcSharedSheetUrl,
+      updatePlcFeatures,
     ]
   );
 };

--- a/hooks/useQuizAssignments.ts
+++ b/hooks/useQuizAssignments.ts
@@ -26,7 +26,7 @@ import {
   updateDoc,
   writeBatch,
 } from 'firebase/firestore';
-import { auth, db } from '../config/firebase';
+import { auth, db } from '@/config/firebase';
 import { invalidateSessionViewCount } from './useSessionViewCount';
 import { writePlcAssignmentIndexEntry } from './usePlcAssignmentIndex';
 import type {

--- a/hooks/useQuizAssignments.ts
+++ b/hooks/useQuizAssignments.ts
@@ -733,13 +733,15 @@ export const useQuizAssignments = (
       // PLC dashboard index: when this assignment opts into PLC mode,
       // record a snapshot under `plcs/{plcId}/assignment_index` so every
       // teammate sees it on the PLC Dashboard's Completed Assignments tab.
-      // Fire-and-forget: the helper logs and swallows errors so a transient
-      // index-write failure doesn't take down the assignment-create action.
-      // Covers every flow that goes through `createAssignment`, including
+      // Fire-and-forget — we deliberately don't `await` so the assign
+      // action returns as soon as the canonical assignment + session
+      // batch has committed. The helper has its own try/catch and never
+      // rejects, so there's no unhandled-promise concern. Covers every
+      // flow that goes through `createAssignment`, including
       // `importSharedAssignment` when the importer is a PLC member.
       if (settings.plc) {
         const current = auth.currentUser;
-        await writePlcAssignmentIndexEntry(settings.plc.id, {
+        void writePlcAssignmentIndexEntry(settings.plc.id, {
           id: assignmentId,
           kind: 'quiz',
           ownerUid: userId,

--- a/hooks/useQuizAssignments.ts
+++ b/hooks/useQuizAssignments.ts
@@ -26,8 +26,9 @@ import {
   updateDoc,
   writeBatch,
 } from 'firebase/firestore';
-import { db } from '../config/firebase';
+import { auth, db } from '../config/firebase';
 import { invalidateSessionViewCount } from './useSessionViewCount';
+import { writePlcAssignmentIndexEntry } from './usePlcAssignmentIndex';
 import type {
   AssignmentMode,
   PlcLinkage,
@@ -728,6 +729,27 @@ export const useQuizAssignments = (
       );
       batch.set(doc(db, QUIZ_SESSIONS_COLLECTION, assignmentId), session);
       await batch.commit();
+
+      // PLC dashboard index: when this assignment opts into PLC mode,
+      // record a snapshot under `plcs/{plcId}/assignment_index` so every
+      // teammate sees it on the PLC Dashboard's Completed Assignments tab.
+      // Fire-and-forget: the helper logs and swallows errors so a transient
+      // index-write failure doesn't take down the assignment-create action.
+      // Covers every flow that goes through `createAssignment`, including
+      // `importSharedAssignment` when the importer is a PLC member.
+      if (settings.plc) {
+        const current = auth.currentUser;
+        await writePlcAssignmentIndexEntry(settings.plc.id, {
+          id: assignmentId,
+          kind: 'quiz',
+          ownerUid: userId,
+          ownerName: current?.displayName ?? '',
+          ownerEmail: (current?.email ?? '').toLowerCase(),
+          title: quiz.title,
+          sheetUrl: settings.plc.sheetUrl,
+          createdAt: now,
+        });
+      }
 
       return { id: assignmentId, code };
     },

--- a/locales/en.json
+++ b/locales/en.json
@@ -216,7 +216,8 @@
       "removeFailed": "Failed to remove member",
       "revokeFailed": "Failed to revoke invitation",
       "acceptFailed": "Failed to accept invitation",
-      "declineFailed": "Failed to decline invitation"
+      "declineFailed": "Failed to decline invitation",
+      "openDashboard": "Open {{name}} dashboard"
     },
     "widgets": {
       "gradeFilter": "Grade Filter",
@@ -250,6 +251,64 @@
       "saveAllChanges": "Save all changes"
     },
     "confirmClearBoard": "Are you sure you want to close ALL widget windows?"
+  },
+  "plcDashboard": {
+    "subtitle": "PLC Dashboard",
+    "backToMenu": "Back",
+    "close": "Close",
+    "tabs": {
+      "completed": "Completed Assignments",
+      "quizzes": "Quiz Library",
+      "assignments": "PLC Assignments",
+      "videoActivities": "Video Activities",
+      "notes": "Notes",
+      "todos": "To-Do List",
+      "sharedBoards": "Shared Boards",
+      "settings": "Settings"
+    },
+    "meta": {
+      "members_one": "{{count}} Member",
+      "members_other": "{{count}} Members",
+      "youLead": "You lead this PLC"
+    },
+    "completedAssignments": {
+      "heading": "Shared Results",
+      "count_one": "{{count}} assignment",
+      "count_other": "{{count}} assignments",
+      "byOwner": "by {{name}}",
+      "openSheet": "Open Sheet",
+      "emptyTitle": "No PLC assignments yet",
+      "emptySubtitle": "When you or a teammate runs a quiz with PLC mode on, it'll show up here with a link to the shared results sheet."
+    },
+    "settings": {
+      "heading": "Dashboard Sections",
+      "description": "Choose which sections appear in this PLC's dashboard. Any PLC member can update these.",
+      "saveFailed": "Failed to save settings",
+      "quizzes": {
+        "title": "Quiz Library",
+        "description": "Share quizzes with the PLC. Members can sync edits or copy a quiz into their own library."
+      },
+      "assignments": {
+        "title": "PLC Assignments",
+        "description": "Author PLC-level assignments that members can pick up on their own boards."
+      },
+      "videoActivities": {
+        "title": "Video Activities",
+        "description": "Share video-based activities and aggregate completion data with the PLC."
+      },
+      "notes": {
+        "title": "Notes",
+        "description": "A shared notebook for the PLC."
+      },
+      "todos": {
+        "title": "To-Do List",
+        "description": "A shared checklist so the PLC can track action items."
+      },
+      "sharedBoards": {
+        "title": "Shared Boards",
+        "description": "Surface dashboards shared with this PLC."
+      }
+    }
   },
   "widgetWindow": {
     "closeWidget": "Close widget? Data will be lost.",

--- a/locales/en.json
+++ b/locales/en.json
@@ -277,8 +277,12 @@
       "count_other": "{{count}} assignments",
       "byOwner": "by {{name}}",
       "openSheet": "Open Sheet",
+      "unsafeSheet": "No link",
       "emptyTitle": "No PLC assignments yet",
       "emptySubtitle": "When you or a teammate runs a quiz with PLC mode on, it'll show up here with a link to the shared results sheet."
+    },
+    "placeholder": {
+      "comingSoon": "Coming soon"
     },
     "settings": {
       "heading": "Dashboard Sections",

--- a/tests/hooks/usePlcAssignmentIndex.test.ts
+++ b/tests/hooks/usePlcAssignmentIndex.test.ts
@@ -1,0 +1,391 @@
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeEach,
+  afterEach,
+  type Mock,
+} from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+import {
+  collection,
+  doc,
+  onSnapshot,
+  orderBy,
+  query,
+  setDoc,
+} from 'firebase/firestore';
+import {
+  usePlcAssignmentIndex,
+  writePlcAssignmentIndexEntry,
+} from '@/hooks/usePlcAssignmentIndex';
+import { logError } from '@/utils/logError';
+import type { PlcAssignmentIndexEntry } from '@/types';
+
+vi.mock('firebase/firestore', () => ({
+  collection: vi.fn(),
+  doc: vi.fn(),
+  onSnapshot: vi.fn(),
+  orderBy: vi.fn((field: string, dir: 'asc' | 'desc') => ({
+    __orderBy: { field, dir },
+  })),
+  query: vi.fn((_ref, ...constraints) => ({ __query: constraints })),
+  setDoc: vi.fn(),
+}));
+
+vi.mock('@/config/firebase', () => ({
+  db: { __mock: 'db' },
+  isAuthBypass: false,
+}));
+
+const useAuthMock = vi.fn<() => { user: { uid: string } | null }>();
+vi.mock('@/context/useAuth', () => ({
+  useAuth: () => useAuthMock(),
+}));
+
+vi.mock('@/utils/logError', () => ({
+  logError: vi.fn(),
+}));
+
+const mockCollection = collection as Mock;
+const mockDoc = doc as Mock;
+const mockOnSnapshot = onSnapshot as Mock;
+const mockOrderBy = orderBy as Mock;
+const mockQuery = query as Mock;
+const mockSetDoc = setDoc as Mock;
+const mockLogError = logError as unknown as Mock;
+
+const TEACHER_UID = 'teacher-1';
+const PLC_ID = 'plc-1';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // Resolve doc/collection refs to addressable strings so assertions can
+  // verify which path the listener attached to. Pattern lifted from
+  // useQuizAssignments.test.ts.
+  mockDoc.mockImplementation((_db: unknown, ...segs: string[]) =>
+    segs.join('/')
+  );
+  mockCollection.mockImplementation((_db: unknown, ...segs: string[]) =>
+    segs.join('/')
+  );
+  mockSetDoc.mockResolvedValue(undefined);
+  useAuthMock.mockReturnValue({ user: { uid: TEACHER_UID } });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+// ---------------------------------------------------------------------------
+// usePlcAssignmentIndex hook
+// ---------------------------------------------------------------------------
+
+describe('usePlcAssignmentIndex - subscription wiring', () => {
+  it('uses server-side orderBy(createdAt, desc) — no client-side sort needed', () => {
+    mockOnSnapshot.mockReturnValue(() => undefined);
+
+    renderHook(() => usePlcAssignmentIndex(PLC_ID));
+
+    // The orderBy clause must be passed into `query()` so Firestore returns
+    // newest-first. Without this the dashboard would render in arbitrary
+    // doc order.
+    expect(mockOrderBy).toHaveBeenCalledWith('createdAt', 'desc');
+    expect(mockQuery).toHaveBeenCalledWith(`plcs/${PLC_ID}/assignment_index`, {
+      __orderBy: { field: 'createdAt', dir: 'desc' },
+    });
+  });
+
+  it('skips the listener when plcId is null', () => {
+    mockOnSnapshot.mockReturnValue(() => undefined);
+
+    renderHook(() => usePlcAssignmentIndex(null));
+
+    // No subscription should mount when there's no PLC selected — the
+    // dashboard passes null while it's closed, and we shouldn't pay for
+    // the Firestore connection then.
+    expect(mockOnSnapshot).not.toHaveBeenCalled();
+  });
+
+  it('skips the listener when the user is signed out', () => {
+    useAuthMock.mockReturnValue({ user: null });
+    mockOnSnapshot.mockReturnValue(() => undefined);
+
+    renderHook(() => usePlcAssignmentIndex(PLC_ID));
+
+    expect(mockOnSnapshot).not.toHaveBeenCalled();
+  });
+});
+
+describe('usePlcAssignmentIndex - parseEntry (via snapshot)', () => {
+  // The parser itself isn't exported — exercise it through the snapshot
+  // callback so we test the public surface and pin the contract that
+  // listeners observe.
+  function fakeSnap(
+    docs: Array<{ id: string; data: Record<string, unknown> }>
+  ) {
+    return {
+      forEach: (fn: (d: { id: string; data: () => unknown }) => void) => {
+        for (const d of docs) {
+          fn({ id: d.id, data: () => d.data });
+        }
+      },
+    };
+  }
+
+  it('drops entries missing required fields (defensive parse)', () => {
+    let cb: (snap: unknown) => void = () => {
+      throw new Error('snapshot callback not captured');
+    };
+    mockOnSnapshot.mockImplementation((_q, onNext) => {
+      cb = onNext;
+      return () => undefined;
+    });
+    const { result } = renderHook(() => usePlcAssignmentIndex(PLC_ID));
+
+    act(() => {
+      cb(
+        fakeSnap([
+          {
+            // Valid — must survive
+            id: 'a',
+            data: {
+              ownerUid: 'u1',
+              ownerName: 'Alice',
+              ownerEmail: 'a@x.com',
+              title: 'A Quiz',
+              sheetUrl: 'https://example.com/a',
+              createdAt: 1000,
+            },
+          },
+          {
+            // Missing title — must be dropped
+            id: 'b',
+            data: {
+              ownerUid: 'u2',
+              sheetUrl: 'https://example.com/b',
+              createdAt: 2000,
+            },
+          },
+          {
+            // ownerUid not a string — must be dropped
+            id: 'c',
+            data: {
+              ownerUid: 42,
+              title: 'C Quiz',
+              sheetUrl: 'https://example.com/c',
+              createdAt: 3000,
+            },
+          },
+          {
+            // createdAt not a number — must be dropped
+            id: 'd',
+            data: {
+              ownerUid: 'u4',
+              title: 'D Quiz',
+              sheetUrl: 'https://example.com/d',
+              createdAt: 'not-a-number',
+            },
+          },
+        ])
+      );
+    });
+
+    // Only the valid entry survives. Dropping malformed rows on read keeps
+    // the dashboard stable against partial-write or schema-drift bugs that
+    // the firestore.rules schema lock-down should normally prevent.
+    expect(result.current.entries).toHaveLength(1);
+    expect(result.current.entries[0].id).toBe('a');
+  });
+
+  it('coerces optional ownerName/ownerEmail to empty string when missing', () => {
+    let cb: (snap: unknown) => void = () => {
+      throw new Error('snapshot callback not captured');
+    };
+    mockOnSnapshot.mockImplementation((_q, onNext) => {
+      cb = onNext;
+      return () => undefined;
+    });
+    const { result } = renderHook(() => usePlcAssignmentIndex(PLC_ID));
+
+    act(() => {
+      cb(
+        fakeSnap([
+          {
+            id: 'a',
+            data: {
+              ownerUid: 'u1',
+              title: 'A',
+              sheetUrl: 'https://example.com/a',
+              createdAt: 1000,
+              // ownerName + ownerEmail intentionally absent
+            },
+          },
+        ])
+      );
+    });
+
+    expect(result.current.entries).toHaveLength(1);
+    expect(result.current.entries[0]).toEqual({
+      id: 'a',
+      kind: 'quiz',
+      ownerUid: 'u1',
+      ownerName: '',
+      ownerEmail: '',
+      title: 'A',
+      sheetUrl: 'https://example.com/a',
+      createdAt: 1000,
+    });
+    expect(result.current.loading).toBe(false);
+  });
+
+  it("normalizes `kind` to 'quiz' even for legacy or wrong values", () => {
+    // Today the parser hardcodes `kind: 'quiz'`; this test pins that
+    // behaviour so a future widening of the union has to update both the
+    // parser AND this test consciously.
+    let cb: (snap: unknown) => void = () => {
+      throw new Error('snapshot callback not captured');
+    };
+    mockOnSnapshot.mockImplementation((_q, onNext) => {
+      cb = onNext;
+      return () => undefined;
+    });
+    const { result } = renderHook(() => usePlcAssignmentIndex(PLC_ID));
+
+    act(() => {
+      cb(
+        fakeSnap([
+          {
+            id: 'a',
+            data: {
+              kind: 'video-activity', // future widening, ignored today
+              ownerUid: 'u1',
+              title: 'A',
+              sheetUrl: 'https://example.com/a',
+              createdAt: 1000,
+            },
+          },
+        ])
+      );
+    });
+
+    expect(result.current.entries[0].kind).toBe('quiz');
+  });
+});
+
+describe('usePlcAssignmentIndex - state reset on plcId change', () => {
+  it('resets entries + loading synchronously when plcId changes (no stale-PLC flash)', () => {
+    let cb: (snap: unknown) => void = () => {
+      throw new Error('snapshot callback not captured');
+    };
+    mockOnSnapshot.mockImplementation((_q, onNext) => {
+      cb = onNext;
+      return () => undefined;
+    });
+    const { result, rerender } = renderHook(
+      ({ id }: { id: string }) => usePlcAssignmentIndex(id),
+      { initialProps: { id: 'plc-A' } }
+    );
+
+    // Seed entries for PLC A.
+    act(() => {
+      cb({
+        forEach: (fn: (d: { id: string; data: () => unknown }) => void) => {
+          fn({
+            id: 'asn-A',
+            data: () => ({
+              ownerUid: 'u1',
+              title: 'PLC A Quiz',
+              sheetUrl: 'https://example.com/A',
+              createdAt: 1000,
+            }),
+          });
+        },
+      });
+    });
+    expect(result.current.entries).toHaveLength(1);
+    expect(result.current.loading).toBe(false);
+
+    // Switch PLCs — the dashboard would do this when the user picks a
+    // different PLC without unmounting the hook. Without the reset, the
+    // UI would briefly show PLC A's entries with `loading=false` while
+    // PLC B's snapshot is in flight.
+    rerender({ id: 'plc-B' });
+
+    expect(result.current.entries).toEqual([]);
+    expect(result.current.loading).toBe(true);
+  });
+});
+
+describe('usePlcAssignmentIndex - error path', () => {
+  it('routes snapshot errors through logError with the plcId scope', () => {
+    let errorCb: (err: unknown) => void = () => {
+      throw new Error('error callback not captured');
+    };
+    mockOnSnapshot.mockImplementation((_q, _onNext, onError) => {
+      errorCb = onError;
+      return () => undefined;
+    });
+    renderHook(() => usePlcAssignmentIndex(PLC_ID));
+
+    const err = new Error('permission-denied');
+    act(() => {
+      errorCb(err);
+    });
+
+    // Tests that the error path (a) uses the structured logger (not
+    // console.error) and (b) carries the plcId so triage can scope to
+    // the affected community.
+    expect(mockLogError).toHaveBeenCalledWith(
+      'usePlcAssignmentIndex.snapshot',
+      err,
+      { plcId: PLC_ID }
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// writePlcAssignmentIndexEntry
+// ---------------------------------------------------------------------------
+
+describe('writePlcAssignmentIndexEntry', () => {
+  const ENTRY: PlcAssignmentIndexEntry = {
+    id: 'asn-1',
+    kind: 'quiz',
+    ownerUid: TEACHER_UID,
+    ownerName: 'Alice',
+    ownerEmail: 'alice@example.com',
+    title: 'My Quiz',
+    sheetUrl: 'https://docs.google.com/spreadsheets/d/abc',
+    createdAt: 12345,
+  };
+
+  it('writes the entry to plcs/{plcId}/assignment_index/{entry.id} with the canonical payload', async () => {
+    await writePlcAssignmentIndexEntry(PLC_ID, ENTRY);
+
+    expect(mockSetDoc).toHaveBeenCalledTimes(1);
+    expect(mockSetDoc).toHaveBeenCalledWith(
+      `plcs/${PLC_ID}/assignment_index/${ENTRY.id}`,
+      ENTRY
+    );
+  });
+
+  it('swallows errors via logError (assignment-create stays fast even if the index write fails)', async () => {
+    const err = new Error('quota-exceeded');
+    mockSetDoc.mockRejectedValueOnce(err);
+
+    // Must NOT reject — the canonical fire-and-forget contract from
+    // useQuizAssignments.createAssignment relies on this. If this
+    // assertion ever fails, the assign action would block on the index
+    // write and slow down the user's "Assign" tap.
+    await expect(
+      writePlcAssignmentIndexEntry(PLC_ID, ENTRY)
+    ).resolves.toBeUndefined();
+    expect(mockLogError).toHaveBeenCalledWith(
+      'writePlcAssignmentIndexEntry.write',
+      err,
+      { plcId: PLC_ID, entryId: ENTRY.id }
+    );
+  });
+});

--- a/tests/hooks/useQuizAssignments.test.ts
+++ b/tests/hooks/useQuizAssignments.test.ts
@@ -53,14 +53,35 @@ vi.mock('@/hooks/useSyncedQuizGroups', () => ({
   SyncedQuizVersionConflictError: class extends Error {},
 }));
 
+// `useQuizAssignments.createAssignment` reads `auth.currentUser` to
+// snapshot the owner's display name + email into the PLC assignment
+// index when the new assignment opts into PLC mode. Hold the user object
+// in a mutable cell so individual PLC-side-effect tests can swap it.
+const authMock: {
+  currentUser: { displayName?: string; email?: string } | null;
+} = {
+  currentUser: null,
+};
 vi.mock('@/config/firebase', () => ({
   db: {},
-  // `useQuizAssignments.createAssignment` reads `auth.currentUser` to
-  // snapshot the owner's display name + email into the PLC assignment
-  // index when the new assignment opts into PLC mode. Tests don't exercise
-  // that branch end-to-end, but importing `auth` would crash without this
-  // stub since `vi.mock` replaces the whole module.
-  auth: { currentUser: null },
+  get auth() {
+    return authMock;
+  },
+}));
+
+// PLC dashboard index — `createAssignment` calls this best-effort when
+// `settings.plc` is set. Mocked so tests can assert the canonical payload
+// (assignmentId, ownerUid/Name/Email, title, sheetUrl, createdAt) lands
+// without exercising the helper's own setDoc path. Resolves to a Promise
+// so the production code's `void` discard is safe.
+const writePlcAssignmentIndexEntryMock = vi
+  .fn<(plcId: string, entry: Record<string, unknown>) => Promise<void>>()
+  .mockResolvedValue(undefined);
+vi.mock('@/hooks/usePlcAssignmentIndex', () => ({
+  writePlcAssignmentIndexEntry: (
+    plcId: string,
+    entry: Record<string, unknown>
+  ) => writePlcAssignmentIndexEntryMock(plcId, entry),
 }));
 
 const mockCollection = collection as Mock;
@@ -1245,5 +1266,148 @@ describe('useQuizAssignments - publishAssignmentScores', () => {
 
     // First batch + at least one continuation batch.
     expect(batchCommit.mock.calls.length).toBeGreaterThanOrEqual(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createAssignment — PLC dashboard index side effect
+// ---------------------------------------------------------------------------
+//
+// When the new assignment opts into PLC mode (`settings.plc` is present),
+// `createAssignment` writes a snapshot under `plcs/{plcId}/assignment_index`
+// so every PLC member sees the assignment on the PLC Dashboard's
+// Completed Assignments tab. These tests pin the contract:
+//
+//   - The write fires only when `settings.plc` is set (no PLC linkage =
+//     no index churn for solo assignments).
+//   - The payload carries the assignment id (matches the source doc),
+//     the canonical PLC sheet URL (so security rules match against the
+//     parent PLC's sharedSheetUrl), and a snapshot of the owner's
+//     identity from `auth.currentUser`.
+//
+// We mock `writePlcAssignmentIndexEntry` rather than hitting Firestore
+// so the assertions describe the integration boundary, not the helper's
+// internals. The helper itself is tested separately in
+// `tests/hooks/usePlcAssignmentIndex.test.ts`.
+describe('useQuizAssignments - createAssignment (PLC index side effect)', () => {
+  const batchSet = vi.fn();
+  const batchCommit = vi.fn();
+  const mockGetDocs = getDocs as Mock;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDoc.mockImplementation((_db: unknown, ...segs: string[]) =>
+      segs.join('/')
+    );
+    mockCollection.mockReturnValue('coll-ref');
+    mockOnSnapshot.mockReturnValue(() => undefined);
+    // allocateJoinCode probes for code collisions; return empty so the
+    // first generated code wins.
+    mockGetDocs.mockResolvedValue({ docs: [], empty: true });
+    batchSet.mockReset();
+    batchCommit.mockReset().mockResolvedValue(undefined);
+    mockWriteBatch.mockReturnValue({
+      set: batchSet,
+      update: vi.fn(),
+      commit: batchCommit,
+    });
+    writePlcAssignmentIndexEntryMock.mockReset().mockResolvedValue(undefined);
+    authMock.currentUser = {
+      displayName: 'Alice Owner',
+      email: 'Alice@Example.com',
+    };
+  });
+
+  const QUIZ = {
+    id: 'quiz-1',
+    title: 'Fractions Quick Check',
+    driveFileId: 'drive-1',
+    questions: [],
+  };
+
+  function plcSettings() {
+    return {
+      sessionMode: 'teacher' as const,
+      sessionOptions: {},
+      plc: {
+        id: 'plc-42',
+        name: 'Math PLC',
+        sheetUrl: 'https://docs.google.com/spreadsheets/d/plc-42-sheet',
+        memberEmails: ['a@x.com', 'b@x.com'],
+      },
+    };
+  }
+
+  it('writes an index entry to the PLC subcollection when settings.plc is set', async () => {
+    const { result } = renderHook(() => useQuizAssignments(TEACHER_UID));
+    let returnedId = '';
+    await act(async () => {
+      const created = await result.current.createAssignment(
+        QUIZ,
+        plcSettings()
+      );
+      returnedId = created.id;
+    });
+
+    // Exactly one index write per assignment-create.
+    expect(writePlcAssignmentIndexEntryMock).toHaveBeenCalledTimes(1);
+    const [plcId, entry] = writePlcAssignmentIndexEntryMock.mock.calls[0];
+
+    // Targets the PLC the assignment is linked to.
+    expect(plcId).toBe('plc-42');
+
+    // Pins the canonical payload shape. Each field matters:
+    //   - `id` matches the source assignment so the dashboard can
+    //     join back if it ever needs to.
+    //   - `kind: 'quiz'` is the discriminator slot for future video-
+    //     activity entries.
+    //   - `ownerUid` matches the teacher running the assignment.
+    //   - `ownerEmail` is lowercased so it matches across surfaces.
+    //   - `sheetUrl` mirrors `settings.plc.sheetUrl` so the firestore
+    //     rule's `sheetUrl == parentPlc.sharedSheetUrl` check holds.
+    //   - `createdAt` is a number (the same `now` the assignment doc
+    //     uses).
+    expect(entry).toMatchObject({
+      id: returnedId,
+      kind: 'quiz',
+      ownerUid: TEACHER_UID,
+      ownerName: 'Alice Owner',
+      ownerEmail: 'alice@example.com',
+      title: 'Fractions Quick Check',
+      sheetUrl: 'https://docs.google.com/spreadsheets/d/plc-42-sheet',
+    });
+    expect(typeof entry.createdAt).toBe('number');
+  });
+
+  it('does NOT write an index entry when settings.plc is absent (solo assignment)', async () => {
+    const { result } = renderHook(() => useQuizAssignments(TEACHER_UID));
+    await act(async () => {
+      await result.current.createAssignment(QUIZ, {
+        sessionMode: 'teacher',
+        sessionOptions: {},
+        // No `plc` field — solo assignment, no PLC dashboard surfacing.
+      });
+    });
+
+    // No PLC linkage = no churn on any PLC's assignment_index.
+    // Without this guard, every solo assignment would either crash (no
+    // plcId) or write to a phantom PLC.
+    expect(writePlcAssignmentIndexEntryMock).not.toHaveBeenCalled();
+  });
+
+  it('falls back to empty strings when auth.currentUser has no displayName / email', async () => {
+    authMock.currentUser = { displayName: undefined, email: undefined };
+
+    const { result } = renderHook(() => useQuizAssignments(TEACHER_UID));
+    await act(async () => {
+      await result.current.createAssignment(QUIZ, plcSettings());
+    });
+
+    const [, entry] = writePlcAssignmentIndexEntryMock.mock.calls[0];
+    // The Firestore schema lock requires both fields to be strings, so
+    // the snapshot must coerce missing identity to '' rather than
+    // omitting the keys (which would fail `keys().hasOnly([...])`).
+    expect(entry.ownerName).toBe('');
+    expect(entry.ownerEmail).toBe('');
   });
 });

--- a/tests/hooks/useQuizAssignments.test.ts
+++ b/tests/hooks/useQuizAssignments.test.ts
@@ -55,6 +55,12 @@ vi.mock('@/hooks/useSyncedQuizGroups', () => ({
 
 vi.mock('@/config/firebase', () => ({
   db: {},
+  // `useQuizAssignments.createAssignment` reads `auth.currentUser` to
+  // snapshot the owner's display name + email into the PLC assignment
+  // index when the new assignment opts into PLC mode. Tests don't exercise
+  // that branch end-to-end, but importing `auth` would crash without this
+  // stub since `vi.mock` replaces the whole module.
+  auth: { currentUser: null },
 }));
 
 const mockCollection = collection as Mock;

--- a/tests/rules/plcAssignmentIndex.test.ts
+++ b/tests/rules/plcAssignmentIndex.test.ts
@@ -1,0 +1,400 @@
+// Firestore security-rules regression for the
+// `/plcs/{plcId}/assignment_index/{assignmentId}` match block introduced
+// with Phase 1 of the PLC Dashboard. The rules carry several subtle
+// invariants that the dashboard's security model depends on:
+//   - membership-gated reads
+//   - author-only writes
+//   - schema lock-down (`keys().hasOnly([...])`) so future readers don't
+//     have to defensively parse unexpected payloads
+//   - `sheetUrl` pinned to the parent PLC's `sharedSheetUrl` (anti-phish)
+//   - update rule blocks owner takeover by a different PLC member
+//   - immutability of `id`, `ownerUid`, `createdAt` on update
+//
+// A single CEL edit can silently break any of these. This file pins each
+// one. Requires a running Firestore emulator — invoke via
+// `pnpm run test:rules` (see vitest.rules.config.ts).
+
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { afterAll, beforeAll, beforeEach, describe, it } from 'vitest';
+import {
+  initializeTestEnvironment,
+  assertSucceeds,
+  assertFails,
+  type RulesTestEnvironment,
+} from '@firebase/rules-unit-testing';
+import { setDoc, getDoc, updateDoc, deleteDoc, doc } from 'firebase/firestore';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const PROJECT_ID = 'spartboard-plc-assignment-index';
+const PLC_ID = 'plc-rules-test';
+const ASSIGNMENT_ID = 'asn-rules-test';
+
+const MEMBER_A_UID = 'member-a-uid';
+const MEMBER_B_UID = 'member-b-uid';
+const NON_MEMBER_UID = 'non-member-uid';
+
+const SHEET_URL = 'https://docs.google.com/spreadsheets/d/canonical-sheet-id';
+const PHISH_URL = 'https://evil.example.com/phish';
+
+const RULES_PATH = fileURLToPath(
+  new URL('../../firestore.rules', import.meta.url)
+);
+
+let testEnv: RulesTestEnvironment;
+
+const asMemberA = () =>
+  testEnv
+    .authenticatedContext(MEMBER_A_UID, { email: 'member-a@example.com' })
+    .firestore();
+
+const asMemberB = () =>
+  testEnv
+    .authenticatedContext(MEMBER_B_UID, { email: 'member-b@example.com' })
+    .firestore();
+
+const asNonMember = () =>
+  testEnv
+    .authenticatedContext(NON_MEMBER_UID, { email: 'random@example.com' })
+    .firestore();
+
+// Canonical valid entry payload. Tests start from this and mutate fields
+// to exercise individual invariants — keeping the "happy path" template
+// in one place avoids drift across cases.
+const validEntry = (overrides: Record<string, unknown> = {}) => ({
+  id: ASSIGNMENT_ID,
+  kind: 'quiz',
+  ownerUid: MEMBER_A_UID,
+  ownerName: 'Member A',
+  ownerEmail: 'member-a@example.com',
+  title: 'My Quiz',
+  sheetUrl: SHEET_URL,
+  createdAt: 1000,
+  ...overrides,
+});
+
+beforeAll(async () => {
+  testEnv = await initializeTestEnvironment({
+    projectId: PROJECT_ID,
+    firestore: {
+      rules: readFileSync(RULES_PATH, 'utf8'),
+      host: process.env.FIRESTORE_EMULATOR_HOST?.split(':')[0] ?? '127.0.0.1',
+      port: Number(
+        process.env.FIRESTORE_EMULATOR_HOST?.split(':')[1] ?? '8080'
+      ),
+    },
+  });
+});
+
+afterAll(async () => {
+  await testEnv?.cleanup();
+});
+
+beforeEach(async () => {
+  await testEnv.clearFirestore();
+  // Seed a PLC with two members and a canonical sharedSheetUrl. Use the
+  // privileged context so we don't have to satisfy the rule's create
+  // branch in test setup.
+  await testEnv.withSecurityRulesDisabled(async (ctx) => {
+    await setDoc(doc(ctx.firestore(), `plcs/${PLC_ID}`), {
+      name: 'Test PLC',
+      leadUid: MEMBER_A_UID,
+      memberUids: [MEMBER_A_UID, MEMBER_B_UID],
+      memberEmails: {
+        [MEMBER_A_UID]: 'member-a@example.com',
+        [MEMBER_B_UID]: 'member-b@example.com',
+      },
+      sharedSheetUrl: SHEET_URL,
+      createdAt: 1,
+      updatedAt: 1,
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// read
+// ---------------------------------------------------------------------------
+
+describe('plcs/{plcId}/assignment_index — read', () => {
+  beforeEach(async () => {
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      await setDoc(
+        doc(
+          ctx.firestore(),
+          `plcs/${PLC_ID}/assignment_index/${ASSIGNMENT_ID}`
+        ),
+        validEntry()
+      );
+    });
+  });
+
+  it('a PLC member can read entries', async () => {
+    await assertSucceeds(
+      getDoc(
+        doc(asMemberB(), `plcs/${PLC_ID}/assignment_index/${ASSIGNMENT_ID}`)
+      )
+    );
+  });
+
+  it('a non-member cannot read entries (membership gate)', async () => {
+    // The dashboard renders the same list for every member; non-members
+    // must not see the index at all. Without this gate, anyone with the
+    // PLC id could enumerate every PLC-mode assignment a community has
+    // run.
+    await assertFails(
+      getDoc(
+        doc(asNonMember(), `plcs/${PLC_ID}/assignment_index/${ASSIGNMENT_ID}`)
+      )
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// create
+// ---------------------------------------------------------------------------
+
+describe('plcs/{plcId}/assignment_index — create', () => {
+  it('PLC member can create their own entry with a valid payload', async () => {
+    await assertSucceeds(
+      setDoc(
+        doc(asMemberA(), `plcs/${PLC_ID}/assignment_index/${ASSIGNMENT_ID}`),
+        validEntry()
+      )
+    );
+  });
+
+  it('rejects creation by a non-member (member-only authorship)', async () => {
+    // Even with a valid-looking payload, a non-member cannot fabricate
+    // an entry. This blocks the "I just learned this PLC's id" attack
+    // surface.
+    await assertFails(
+      setDoc(
+        doc(asNonMember(), `plcs/${PLC_ID}/assignment_index/${ASSIGNMENT_ID}`),
+        validEntry({ ownerUid: NON_MEMBER_UID })
+      )
+    );
+  });
+
+  it('rejects when ownerUid != caller (no impersonation)', async () => {
+    // Member A cannot author an entry "as" member B — the dashboard
+    // displays `ownerName` from this snapshot, so an impersonation
+    // would mislead other members about who ran the assignment.
+    await assertFails(
+      setDoc(
+        doc(asMemberA(), `plcs/${PLC_ID}/assignment_index/${ASSIGNMENT_ID}`),
+        validEntry({ ownerUid: MEMBER_B_UID })
+      )
+    );
+  });
+
+  it('rejects when assignmentId path segment != entry.id (path/payload mismatch)', async () => {
+    // The doc id must equal the source assignment id so the dashboard
+    // can join back. Without this, members could write entries at
+    // arbitrary paths and confuse the join logic.
+    await assertFails(
+      setDoc(
+        doc(asMemberA(), `plcs/${PLC_ID}/assignment_index/different-id`),
+        validEntry({ id: ASSIGNMENT_ID })
+      )
+    );
+  });
+
+  it('rejects when sheetUrl != parent PLC sharedSheetUrl (anti-phish pin)', async () => {
+    // The dashboard renders `sheetUrl` as a clickable `<a href>`. If the
+    // rule allowed an arbitrary string here, any member could turn the
+    // PLC dashboard into a phishing redirect for every teammate. The
+    // rule pins it to the PLC's canonical `sharedSheetUrl`.
+    await assertFails(
+      setDoc(
+        doc(asMemberA(), `plcs/${PLC_ID}/assignment_index/${ASSIGNMENT_ID}`),
+        validEntry({ sheetUrl: PHISH_URL })
+      )
+    );
+  });
+
+  it('rejects extra unknown fields (schema lock-down via keys().hasOnly)', async () => {
+    // Closed schema — future readers can rely on the field set without
+    // defensive parsing. A drift here would also hide payload bloat
+    // that the rule should reject.
+    await assertFails(
+      setDoc(
+        doc(asMemberA(), `plcs/${PLC_ID}/assignment_index/${ASSIGNMENT_ID}`),
+        { ...validEntry(), unexpected: 'extra-field' }
+      )
+    );
+  });
+
+  it("rejects kind != 'quiz' (constrained discriminator)", async () => {
+    // `kind` is reserved for future video-activity entries but currently
+    // only `'quiz'` is valid. Rejecting other values keeps the dashboard
+    // from rendering rows it doesn't know how to display.
+    await assertFails(
+      setDoc(
+        doc(asMemberA(), `plcs/${PLC_ID}/assignment_index/${ASSIGNMENT_ID}`),
+        validEntry({ kind: 'video-activity' })
+      )
+    );
+  });
+
+  it('rejects when the parent PLC has no sharedSheetUrl', async () => {
+    // Race: a PLC whose first assignment hasn't created the shared sheet
+    // yet has `sharedSheetUrl == null`. The rule's `get('sharedSheetUrl',
+    // '')` defaults to `''`, so an entry with sheetUrl `''` would
+    // technically match — but the production code never writes an
+    // empty sheetUrl (the assignment-create flow requires the sheet to
+    // exist first). Pin this so a future regression that wrote `sheetUrl
+    // = ''` for a sheet-less PLC would still match against `''` — i.e.
+    // verify that a NON-empty mismatched URL is still rejected.
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      await updateDoc(doc(ctx.firestore(), `plcs/${PLC_ID}`), {
+        sharedSheetUrl: null,
+      });
+    });
+    await assertFails(
+      setDoc(
+        doc(asMemberA(), `plcs/${PLC_ID}/assignment_index/${ASSIGNMENT_ID}`),
+        validEntry({ sheetUrl: SHEET_URL })
+      )
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// update — owner takeover & immutability
+// ---------------------------------------------------------------------------
+
+describe('plcs/{plcId}/assignment_index — update', () => {
+  beforeEach(async () => {
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      await setDoc(
+        doc(
+          ctx.firestore(),
+          `plcs/${PLC_ID}/assignment_index/${ASSIGNMENT_ID}`
+        ),
+        validEntry()
+      );
+    });
+  });
+
+  it('original owner can update their own entry (e.g. retitle)', async () => {
+    await assertSucceeds(
+      updateDoc(
+        doc(asMemberA(), `plcs/${PLC_ID}/assignment_index/${ASSIGNMENT_ID}`),
+        { title: 'Renamed Quiz' }
+      )
+    );
+  });
+
+  it('a different PLC member CANNOT take over an entry by claiming ownerUid (the bypass we closed)', async () => {
+    // This is the security flaw Copilot caught: the original combined
+    // `allow create, update` rule only checked
+    // `request.resource.data.ownerUid == request.auth.uid`, not the
+    // *existing* `resource.data.ownerUid`. Member B could overwrite
+    // member A's entry simply by setting `ownerUid` to themselves. If
+    // this assertion ever flips to `assertSucceeds`, the takeover is
+    // back.
+    await assertFails(
+      updateDoc(
+        doc(asMemberB(), `plcs/${PLC_ID}/assignment_index/${ASSIGNMENT_ID}`),
+        {
+          ownerUid: MEMBER_B_UID,
+          ownerName: 'Member B',
+          ownerEmail: 'member-b@example.com',
+        }
+      )
+    );
+  });
+
+  it('rejects an attempt by the existing owner to change ownerUid (immutability)', async () => {
+    // Even the rightful owner can't transfer ownership via update —
+    // this would let a leaving member dump entries on a teammate.
+    await assertFails(
+      updateDoc(
+        doc(asMemberA(), `plcs/${PLC_ID}/assignment_index/${ASSIGNMENT_ID}`),
+        { ownerUid: MEMBER_B_UID }
+      )
+    );
+  });
+
+  it('rejects an attempt to mutate id (immutability)', async () => {
+    // `id` is a copy of the source assignment id — changing it on the
+    // entry would silently break the dashboard's join-back path.
+    await assertFails(
+      updateDoc(
+        doc(asMemberA(), `plcs/${PLC_ID}/assignment_index/${ASSIGNMENT_ID}`),
+        { id: 'different-id' }
+      )
+    );
+  });
+
+  it('rejects an attempt to mutate createdAt (immutability)', async () => {
+    // `createdAt` orders the dashboard list — rewriting it would let an
+    // owner re-pin their old entries to the top.
+    await assertFails(
+      updateDoc(
+        doc(asMemberA(), `plcs/${PLC_ID}/assignment_index/${ASSIGNMENT_ID}`),
+        { createdAt: 9999999 }
+      )
+    );
+  });
+
+  it('rejects an update that introduces an extra field (schema lock-down still applies)', async () => {
+    await assertFails(
+      updateDoc(
+        doc(asMemberA(), `plcs/${PLC_ID}/assignment_index/${ASSIGNMENT_ID}`),
+        { unexpected: 'extra-field' }
+      )
+    );
+  });
+
+  it('rejects sheetUrl drift to an arbitrary URL on update', async () => {
+    // Same anti-phish guard as create — once an entry is in place, the
+    // owner can't later swap the link to point at a different sheet.
+    await assertFails(
+      updateDoc(
+        doc(asMemberA(), `plcs/${PLC_ID}/assignment_index/${ASSIGNMENT_ID}`),
+        { sheetUrl: PHISH_URL }
+      )
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// delete
+// ---------------------------------------------------------------------------
+
+describe('plcs/{plcId}/assignment_index — delete', () => {
+  beforeEach(async () => {
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      await setDoc(
+        doc(
+          ctx.firestore(),
+          `plcs/${PLC_ID}/assignment_index/${ASSIGNMENT_ID}`
+        ),
+        validEntry()
+      );
+    });
+  });
+
+  it('owner can delete their own entry', async () => {
+    await assertSucceeds(
+      deleteDoc(
+        doc(asMemberA(), `plcs/${PLC_ID}/assignment_index/${ASSIGNMENT_ID}`)
+      )
+    );
+  });
+
+  it('a different PLC member cannot delete', async () => {
+    // No lead-override on delete — leads who want to sweep stale entries
+    // ask the owner. Pinning this prevents an accidental rule edit from
+    // adding a permissive lead branch.
+    await assertFails(
+      deleteDoc(
+        doc(asMemberB(), `plcs/${PLC_ID}/assignment_index/${ASSIGNMENT_ID}`)
+      )
+    );
+  });
+});

--- a/types.ts
+++ b/types.ts
@@ -206,8 +206,86 @@ export interface Plc {
    * next assignment regenerates transparently.
    */
   sharedSheetUrl?: string | null;
+  /**
+   * PLC dashboard section toggles. Any member can flip these — they govern
+   * which optional sections render in the PLC Dashboard view. Absent or
+   * partial maps are merged against `DEFAULT_PLC_FEATURE_SETTINGS` so legacy
+   * PLCs (and any newly added flags) default to enabled. Always read via
+   * `getPlcFeatures(plc)` rather than `plc.features` directly.
+   */
+  features?: PlcFeatureSettings;
   createdAt: number;
   updatedAt: number;
+}
+
+/**
+ * Per-PLC dashboard section toggles. Any member can flip these. Use
+ * `getPlcFeatures(plc)` when reading so legacy PLCs (no `features` field)
+ * and partial maps merge against `DEFAULT_PLC_FEATURE_SETTINGS`.
+ *
+ * `completedAssignments` is intentionally NOT a flag — the index of finished
+ * PLC assignments is always visible since it's the read-only history view
+ * that anchors the dashboard.
+ */
+export interface PlcFeatureSettings {
+  /** PLC Quiz Library tab (Phase 2). */
+  quizzes: boolean;
+  /** PLC Video Activities tab (Phase 4). */
+  videoActivities: boolean;
+  /** PLC-authored Assignments tab (Phase 3). */
+  assignments: boolean;
+  /** PLC Notes tab (Phase 5). */
+  notes: boolean;
+  /** PLC To-Do list tab (Phase 5). */
+  todos: boolean;
+  /** PLC Shared Boards tab (Phase 6). */
+  sharedBoards: boolean;
+}
+
+export const DEFAULT_PLC_FEATURE_SETTINGS: PlcFeatureSettings = {
+  quizzes: true,
+  videoActivities: true,
+  assignments: true,
+  notes: true,
+  todos: true,
+  sharedBoards: true,
+};
+
+/**
+ * Merge a (possibly absent or partial) `Plc.features` map against
+ * `DEFAULT_PLC_FEATURE_SETTINGS`. Use this everywhere the dashboard reads
+ * feature flags so legacy PLCs and newly added flags default to enabled.
+ */
+export function getPlcFeatures(plc: Plc): PlcFeatureSettings {
+  return { ...DEFAULT_PLC_FEATURE_SETTINGS, ...(plc.features ?? {}) };
+}
+
+/**
+ * One row in `plcs/{plcId}/assignment_index/{assignmentId}`. Written by the
+ * assignment author at create time when their assignment opts into PLC
+ * mode (i.e. `QuizAssignmentSettings.plc` is set). Lets every PLC member
+ * read a unified list of "PLC assignments my teammates have run" without
+ * cross-user collection-group queries on each teacher's `quiz_assignments`.
+ *
+ * Snapshot fields (title, ownerName, sheetUrl) are taken at create time;
+ * Phase 1 does not mirror later edits. The doc id matches the source
+ * assignment's id for easy join-back.
+ */
+export interface PlcAssignmentIndexEntry {
+  id: string;
+  /** Discriminator for future video-activity support. */
+  kind: 'quiz';
+  /** UID of the teacher who created the assignment. Always a PLC member. */
+  ownerUid: string;
+  /** Display name snapshot — avoids a `/users` lookup per row. */
+  ownerName: string;
+  /** Lowercased email snapshot — used for member matching in the UI. */
+  ownerEmail: string;
+  /** Quiz title at create time. */
+  title: string;
+  /** Shared PLC Google Sheet URL (mirrored from `Plc.sharedSheetUrl`). */
+  sheetUrl: string;
+  createdAt: number;
 }
 
 /**


### PR DESCRIPTION
## Summary

Phase 1 of the **My PLCs** expansion. Lays the foundation for all later phases (Quiz Library, PLC Assignments, Video Activities, Notes, To-Dos, Shared Boards) by introducing the dashboard shell, navigation, settings model, and the read-only "Completed Assignments" view.

Selecting a PLC from `Sidebar > My PLCs` now opens a full-screen dashboard. The PLC pencil/leave/delete actions still work — clicking the row body opens the dashboard, action icons stay scoped to themselves.

### What ships

- **PLC Dashboard shell** (`components/plc/PlcDashboard.tsx`) — full-screen overlay mirroring the `AdminSettings` UX (header gradient, desktop tab pills, mobile drawer, Escape-to-close, sub-header with member count + lead badge).
- **Completed Assignments tab** — lists every PLC-mode assignment any member has run. Backed by a new `plcs/{plcId}/assignment_index` subcollection that the quiz assignment creation flow now writes into when `settings.plc` is set. Each row shows title, owner, date, and an "Open Sheet" link out to the shared Google Sheet. Auto-covers `importSharedAssignment` for PLC members.
- **Settings tab** — per-PLC `features` map (`quizzes`, `assignments`, `videoActivities`, `notes`, `todos`, `sharedBoards`). Any member can toggle. Defaults to all-enabled; legacy PLCs merge through `getPlcFeatures()` so absent fields stay enabled.
- **Placeholder tabs** for the six upcoming sections, gated by their feature flag, so navigation is wired now.

### Architecture decisions

- **Storage**: PLC-owned content goes under `plcs/{plcId}/...` subcollections (your earlier sign-off). The assignment index is the first one.
- **Index writes**: handled inside `useQuizAssignments.createAssignment` so every call site (Widget assign, view-only share won't trigger because no PLC, importSharedAssignment for PLC members) is covered without per-call-site duplication. Owner profile is snapshotted from `auth.currentUser` at write time.
- **Failure mode**: index writes are best-effort — `writePlcAssignmentIndexEntry` logs and swallows errors so a transient Firestore hiccup can't take down the user's "Assign" action.

### Firestore rule changes

- New `isUpdatingPlcFeatures()` helper: any current member can patch `features` (constrained to that field + `updatedAt` so it can't be used to smuggle membership/leadership/sheet-URL changes).
- New `plcs/{plcId}/assignment_index/{assignmentId}` subcollection rules: members can read; assignment authors can write/update/delete their own entries; doc id forced to match the source assignment id.

### What's NOT in this PR (later phases)

- Quiz Library / collaborative editing (Phase 2)
- PLC-authored Assignments tab (Phase 3)
- Video Activities (Phase 4)
- Notes / To-Dos (Phase 5)
- Shared Boards surface (Phase 6)

Each placeholder tab shows a "Coming soon" empty state when its feature flag is on.

## Test plan

- [ ] Sign in, open Sidebar > My PLCs, click a PLC → dashboard opens
- [ ] Verify pencil / leave / delete icons still work without opening the dashboard
- [ ] Toggle each feature flag in Settings tab → corresponding tab hides/shows immediately
- [ ] Create a quiz assignment with PLC mode on → entry appears in Completed Assignments tab for all members
- [ ] Click "Open Sheet" → shared Google Sheet opens in new tab
- [ ] Test on mobile: tab drawer appears, back button collapses to drawer first then closes
- [ ] Verify another member's settings toggle reflects live in your dashboard
- [ ] Test that `importSharedAssignment` (sync mode) for a PLC-member importer also writes the index entry

## Verification done locally

- `pnpm run type-check` ✅
- `pnpm run lint` ✅ (zero errors / zero warnings)
- `pnpm run format:check` ✅
- `pnpm run test` ✅ (1971 / 1971 passing — added `auth` stub to the existing `useQuizAssignments` Firebase mock)

https://claude.ai/code/session_019KAFwyhikUKpFThgY3bBQS

---
_Generated by [Claude Code](https://claude.ai/code/session_019KAFwyhikUKpFThgY3bBQS)_