### PR TITLE
feat(video-activity): SSO bypass + drop name field; mirror Quiz response keying

### DIFF
--- a/components/videoActivity/VideoActivityStudentApp.tsx
+++ b/components/videoActivity/VideoActivityStudentApp.tsx
@@ -33,23 +33,28 @@ import { QuestionOverlay } from './QuestionOverlay';
 
 /**
  * Resolve the SSO student's class period from the session's
- * `classPeriodByClassId` map. Falls back to the first declared period name
- * when the map is missing (best-effort — the session-create flow populates
- * the map for new assignments). Returns undefined when no period can be
- * resolved; callers default the response doc's `classPeriod` accordingly.
+ * `classPeriodByClassId` map. Mirrors the Quiz semantics: only resolves
+ * when the intersection of the student's claimed `classIds` with the
+ * session's targeted `classIds` is unambiguously a single class. When the
+ * intersection is empty (claim doesn't overlap the session) or multiple
+ * (the student is in 2+ targeted classes), returns `undefined` and lets
+ * the response doc carry no period — wrong-but-confident attribution to
+ * `periodNames[0]` is worse than no attribution because it silently
+ * corrupts results filtering and the export sheet's class-period column.
  */
 function resolveSsoClassPeriod(
   session: VideoActivitySession,
   classIdsClaim: string[]
 ): string | undefined {
   const map = session.classPeriodByClassId;
-  if (map) {
-    for (const classId of classIdsClaim) {
-      const period = map[classId];
-      if (period) return period;
-    }
-  }
-  return session.periodNames?.[0];
+  if (!map) return undefined;
+  const sessionClassIds = new Set(session.classIds ?? []);
+  const matches = classIdsClaim
+    .filter((id) => sessionClassIds.size === 0 || sessionClassIds.has(id))
+    .map((id) => map[id])
+    .filter((period): period is string => typeof period === 'string');
+  if (matches.length !== 1) return undefined;
+  return matches[0];
 }
 
 // ─── Root ──────────────────────────────────────────────────────────────────────
@@ -85,7 +90,7 @@ export const VideoActivityStudentApp: React.FC = () => {
             if (Array.isArray(claimedClassIds)) {
               setSsoClassIds(
                 claimedClassIds.filter(
-                  (id): id is string => typeof id === 'string'
+                  (id): id is string => typeof id === 'string' && id.length > 0
                 )
               );
             }
@@ -194,17 +199,30 @@ const JoinAndPlay: React.FC<JoinAndPlayProps> = ({
   const [lookingUp, setLookingUp] = useState(false);
 
   // SSO auto-join. Mirrors QuizStudentApp's pattern: a single ref guards
-  // against StrictMode double-invoke; on success the student is taken
-  // straight to the player. Local error state because `lookupSession` can
-  // throw before the hook's `joinSession` runs.
+  // against StrictMode double-invoke. The ref is reset whenever
+  // `joinStatus` flips to `'error'` so a transient Firestore hiccup
+  // doesn't strand the student on a permanent loader — the next render
+  // (e.g. a refresh, network recovery) re-arms the effect for another
+  // attempt. Local `ssoAutoJoinError` covers the lookup-failure leg
+  // (`lookupSession` swallows errors and returns `null`); the hook's own
+  // `error`/`joinStatus` carry post-lookup failures.
   const ssoAutoJoinStartedRef = useRef(false);
   const [ssoAutoJoinError, setSsoAutoJoinError] = useState<string | null>(null);
+
+  // Re-arm the started ref when the hook reports an error so a recoverable
+  // failure (e.g. transient network) can retry on the next effect pass.
+  // Done as adjust-state-during-render rather than an effect to avoid an
+  // extra render cycle (per CLAUDE.md "useEffect is an escape hatch").
+  if (joinStatus === 'error' && ssoAutoJoinStartedRef.current) {
+    ssoAutoJoinStartedRef.current = false;
+  }
 
   useEffect(() => {
     if (!isStudentRole || !sessionId) return;
     if (ssoAutoJoinStartedRef.current) return;
     if (joinStatus === 'joined' || joinStatus === 'loading') return;
     ssoAutoJoinStartedRef.current = true;
+    setSsoAutoJoinError(null);
     void (async () => {
       try {
         const sessionInfo = await lookupSession(sessionId);
@@ -223,14 +241,12 @@ const JoinAndPlay: React.FC<JoinAndPlayProps> = ({
         );
       }
     })();
-  }, [
-    isStudentRole,
-    sessionId,
-    ssoClassIds,
-    lookupSession,
-    joinSession,
-    joinStatus,
-  ]);
+    // `joinStatus` is intentionally omitted from deps. The ref guard above
+    // and the early-return on 'joined'/'loading' make a status-driven
+    // re-fire redundant; including it would just trigger a no-op re-render
+    // on every status transition.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isStudentRole, sessionId, ssoClassIds, lookupSession, joinSession]);
 
   // Track answered question IDs for anti-skip enforcement in VideoPlayer
   const answeredQuestionIds = React.useMemo(
@@ -249,15 +265,15 @@ const JoinAndPlay: React.FC<JoinAndPlayProps> = ({
     try {
       const sessionInfo = await lookupSession(sessionId);
       const periodNames = sessionInfo?.periodNames ?? [];
-      // Anon (PIN) joiners always disambiguate by period when the assignment
-      // declares any — `pin-{period}-{pin}` is what keys the response doc.
-      // Show the picker even when there's only one period to keep the doc
-      // key deterministic across re-joins.
-      if (periodNames.length > 0) {
+      // Anon (PIN) joiners disambiguate by period when the assignment
+      // declares more than one — `pin-{period}-{pin}` is what keys the
+      // response doc. With a single period there's nothing for the
+      // student to choose, so auto-pick to skip a friction tap.
+      if (periodNames.length > 1) {
         setPeriodStep(periodNames);
         return;
       }
-      await joinSession(sessionId, pin.trim(), undefined);
+      await joinSession(sessionId, pin.trim(), periodNames[0]);
     } finally {
       setLookingUp(false);
     }
@@ -406,7 +422,10 @@ const JoinAndPlay: React.FC<JoinAndPlayProps> = ({
     // PIN form. Anonymous joiners fall through to the PIN form below.
     if (isStudentRole) {
       if (ssoAutoJoinError || error) {
-        return <ErrorScreen message={ssoAutoJoinError ?? error ?? ''} />;
+        // Prefer the hook's specific error (e.g. "session ended", "PIN
+        // rejected") over the generic auto-join wrapper message. Mirrors
+        // the QuizStudentApp precedence.
+        return <ErrorScreen message={error ?? ssoAutoJoinError ?? ''} />;
       }
       return <FullPageLoader message="Joining activity…" />;
     }

--- a/components/videoActivity/VideoActivityStudentApp.tsx
+++ b/components/videoActivity/VideoActivityStudentApp.tsx
@@ -2,11 +2,14 @@
  * VideoActivityStudentApp — student-facing video activity experience.
  * Accessible at /activity/:sessionId (no Google auth required).
  *
- * Flow:
- *  1. Anonymous Firebase auth (satisfies Firestore security rules)
- *  2. Student enters name + PIN to join
- *  3. Video plays with embedded questions at timestamps
- *  4. Completion / score screen when all questions answered and video ends
+ * Flow (mirrors QuizStudentApp):
+ *  - SSO `studentRole` joiners (custom-token users from /my-assignments):
+ *    auto-join on mount. No PIN, no class-period picker, no name input.
+ *    Their auth UID identifies them; class period is resolved from the
+ *    session's `classPeriodByClassId` map when available.
+ *  - Anonymous (PIN) joiners: enter PIN, then pick a class period if the
+ *    session declares any. No name is collected — Results UI uses
+ *    `useAssignmentPseudonyms` for display.
  */
 
 import React, { useState, useCallback, useEffect, useRef } from 'react';
@@ -24,27 +27,76 @@ import { addDoc, collection, serverTimestamp } from 'firebase/firestore';
 import { auth, db } from '@/config/firebase';
 import { logError } from '@/utils/logError';
 import { useVideoActivitySessionStudent } from '@/hooks/useVideoActivitySession';
-import { VideoActivityQuestion } from '@/types';
+import { VideoActivityQuestion, VideoActivitySession } from '@/types';
 import { VideoPlayer } from './VideoPlayer';
 import { QuestionOverlay } from './QuestionOverlay';
+
+/**
+ * Resolve the SSO student's class period from the session's
+ * `classPeriodByClassId` map. Falls back to the first declared period name
+ * when the map is missing (best-effort — the session-create flow populates
+ * the map for new assignments). Returns undefined when no period can be
+ * resolved; callers default the response doc's `classPeriod` accordingly.
+ */
+function resolveSsoClassPeriod(
+  session: VideoActivitySession,
+  classIdsClaim: string[]
+): string | undefined {
+  const map = session.classPeriodByClassId;
+  if (map) {
+    for (const classId of classIdsClaim) {
+      const period = map[classId];
+      if (period) return period;
+    }
+  }
+  return session.periodNames?.[0];
+}
 
 // ─── Root ──────────────────────────────────────────────────────────────────────
 
 export const VideoActivityStudentApp: React.FC = () => {
   const [authReady, setAuthReady] = useState(false);
   const [authFailed, setAuthFailed] = useState(false);
+  // True iff `auth.currentUser` carries the `studentRole: true` custom claim
+  // minted by `studentLoginV1`. Resolved at mount; drives the auto-join
+  // branch in `JoinAndPlay`. Anonymous joiners stay `false`.
+  const [isStudentRole, setIsStudentRole] = useState(false);
+  // ClassLink class-id list from the SSO custom claim. Used to resolve the
+  // joining student's period via `session.classPeriodByClassId`.
+  const [ssoClassIds, setSsoClassIds] = useState<string[]>([]);
 
   useEffect(() => {
     const init = async () => {
-      if (!auth.currentUser) {
-        try {
+      try {
+        // Sign in anonymously only when nobody is signed in — SSO students
+        // arrive with a custom-token user we must keep.
+        if (!auth.currentUser) {
           await signInAnonymously(auth);
-        } catch (err) {
-          console.warn('[VideoActivityStudentApp] Anonymous auth failed:', err);
-          setAuthFailed(true);
         }
+        const user = auth.currentUser;
+        if (user && !user.isAnonymous) {
+          // Probe custom claims once. We don't refresh — `studentLoginV1`
+          // minted these and a stale token is fine for read-only identity;
+          // Firestore rules re-validate on every write.
+          const tokenResult = await user.getIdTokenResult();
+          if (tokenResult.claims?.studentRole === true) {
+            setIsStudentRole(true);
+            const claimedClassIds = tokenResult.claims.classIds;
+            if (Array.isArray(claimedClassIds)) {
+              setSsoClassIds(
+                claimedClassIds.filter(
+                  (id): id is string => typeof id === 'string'
+                )
+              );
+            }
+          }
+        }
+      } catch (err) {
+        console.warn('[VideoActivityStudentApp] Auth init failed:', err);
+        setAuthFailed(true);
+      } finally {
+        setAuthReady(true);
       }
-      setAuthReady(true);
     };
     void init();
   }, []);
@@ -53,22 +105,31 @@ export const VideoActivityStudentApp: React.FC = () => {
     return <FullPageLoader message="Loading…" />;
   }
 
-  if (authFailed) {
+  if (authFailed || !auth.currentUser) {
     return (
       <ErrorScreen message="Unable to connect. Please refresh and try again." />
     );
   }
 
-  return <JoinAndPlay />;
+  return (
+    <JoinAndPlay isStudentRole={isStudentRole} ssoClassIds={ssoClassIds} />
+  );
 };
 
 // ─── Join + Play ───────────────────────────────────────────────────────────────
 
-const JoinAndPlay: React.FC = () => {
+interface JoinAndPlayProps {
+  isStudentRole: boolean;
+  ssoClassIds: string[];
+}
+
+const JoinAndPlay: React.FC<JoinAndPlayProps> = ({
+  isStudentRole,
+  ssoClassIds,
+}) => {
   // Extract sessionId from /activity/:sessionId
   const sessionId = window.location.pathname.replace(/^\/activity\/?/, '');
 
-  const [name, setName] = useState('');
   const [pin, setPin] = useState('');
   const [activeQuestion, setActiveQuestion] =
     useState<VideoActivityQuestion | null>(null);
@@ -121,8 +182,9 @@ const JoinAndPlay: React.FC = () => {
   }, [isViewOnly, session?.id, authedUid]);
 
   // Multi-period selection step — shown when the session has more than one
-  // class-period name configured, so students pick their period before the
-  // response doc is created (mirrors the Quiz pattern).
+  // class-period name configured, so anon students pick their period before
+  // the response doc is created (mirrors the Quiz pattern). SSO joiners
+  // skip this step entirely.
   const [periodStep, setPeriodStep] = useState<string[] | null>(null);
   const [selectedPeriod, setSelectedPeriod] = useState<string | null>(null);
   // Local guard for the async `lookupSession` leg of `handleJoin` — the
@@ -130,6 +192,45 @@ const JoinAndPlay: React.FC = () => {
   // so without this the button would stay clickable during the lookup and
   // a double-tap could fan out parallel requests.
   const [lookingUp, setLookingUp] = useState(false);
+
+  // SSO auto-join. Mirrors QuizStudentApp's pattern: a single ref guards
+  // against StrictMode double-invoke; on success the student is taken
+  // straight to the player. Local error state because `lookupSession` can
+  // throw before the hook's `joinSession` runs.
+  const ssoAutoJoinStartedRef = useRef(false);
+  const [ssoAutoJoinError, setSsoAutoJoinError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!isStudentRole || !sessionId) return;
+    if (ssoAutoJoinStartedRef.current) return;
+    if (joinStatus === 'joined' || joinStatus === 'loading') return;
+    ssoAutoJoinStartedRef.current = true;
+    void (async () => {
+      try {
+        const sessionInfo = await lookupSession(sessionId);
+        if (!sessionInfo) {
+          setSsoAutoJoinError(
+            'This activity session was not found. Check the link and try again.'
+          );
+          return;
+        }
+        const autoClassPeriod = resolveSsoClassPeriod(sessionInfo, ssoClassIds);
+        await joinSession(sessionId, undefined, autoClassPeriod);
+      } catch (err) {
+        console.error('[VideoActivityStudentApp] SSO auto-join failed:', err);
+        setSsoAutoJoinError(
+          'Something went wrong joining this activity. Please refresh and try again.'
+        );
+      }
+    })();
+  }, [
+    isStudentRole,
+    sessionId,
+    ssoClassIds,
+    lookupSession,
+    joinSession,
+    joinStatus,
+  ]);
 
   // Track answered question IDs for anti-skip enforcement in VideoPlayer
   const answeredQuestionIds = React.useMemo(
@@ -142,18 +243,21 @@ const JoinAndPlay: React.FC = () => {
 
   const handleJoin = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (!name.trim() || !pin.trim() || !sessionId) return;
+    if (!pin.trim() || !sessionId) return;
     if (lookingUp || joinStatus === 'loading') return;
     setLookingUp(true);
     try {
       const sessionInfo = await lookupSession(sessionId);
       const periodNames = sessionInfo?.periodNames ?? [];
-      if (periodNames.length > 1) {
+      // Anon (PIN) joiners always disambiguate by period when the assignment
+      // declares any — `pin-{period}-{pin}` is what keys the response doc.
+      // Show the picker even when there's only one period to keep the doc
+      // key deterministic across re-joins.
+      if (periodNames.length > 0) {
         setPeriodStep(periodNames);
         return;
       }
-      const autoClassPeriod = periodNames[0];
-      await joinSession(sessionId, pin.trim(), name.trim(), autoClassPeriod);
+      await joinSession(sessionId, pin.trim(), undefined);
     } finally {
       setLookingUp(false);
     }
@@ -161,8 +265,8 @@ const JoinAndPlay: React.FC = () => {
 
   const handlePeriodConfirm = useCallback(async () => {
     if (!selectedPeriod || !sessionId) return;
-    await joinSession(sessionId, pin.trim(), name.trim(), selectedPeriod);
-  }, [joinSession, sessionId, pin, name, selectedPeriod]);
+    await joinSession(sessionId, pin.trim(), selectedPeriod);
+  }, [joinSession, sessionId, pin, selectedPeriod]);
 
   const handleQuestionTrigger = useCallback(
     (question: VideoActivityQuestion) => {
@@ -297,6 +401,16 @@ const JoinAndPlay: React.FC = () => {
   // ── Not joined yet ────────────────────────────────────────────────────────
 
   if (joinStatus !== 'joined') {
+    // SSO students are auto-joining via the effect above — show the loader
+    // (or any error surfaced from the auto-join attempt) instead of the
+    // PIN form. Anonymous joiners fall through to the PIN form below.
+    if (isStudentRole) {
+      if (ssoAutoJoinError || error) {
+        return <ErrorScreen message={ssoAutoJoinError ?? error ?? ''} />;
+      }
+      return <FullPageLoader message="Joining activity…" />;
+    }
+
     return (
       <div className="min-h-screen bg-slate-900 flex flex-col items-center justify-center p-4">
         <div className="w-full max-w-sm">
@@ -325,21 +439,6 @@ const JoinAndPlay: React.FC = () => {
             <form onSubmit={handleJoin} className="p-5 flex flex-col gap-4">
               <div>
                 <label className="block text-xs font-bold text-slate-500 uppercase tracking-wider mb-1.5">
-                  Your Name
-                </label>
-                <input
-                  type="text"
-                  value={name}
-                  onChange={(e) => setName(e.target.value)}
-                  placeholder="First name"
-                  autoComplete="given-name"
-                  className="w-full border-2 border-slate-200 focus:border-brand-blue-primary rounded-xl px-3 py-2.5 text-sm font-medium outline-none transition-colors"
-                  required
-                />
-              </div>
-
-              <div>
-                <label className="block text-xs font-bold text-slate-500 uppercase tracking-wider mb-1.5">
                   Roster PIN
                 </label>
                 <input
@@ -348,6 +447,7 @@ const JoinAndPlay: React.FC = () => {
                   onChange={(e) => setPin(e.target.value)}
                   placeholder="Ask your teacher"
                   inputMode="numeric"
+                  autoFocus
                   className="w-full border-2 border-slate-200 focus:border-brand-blue-primary rounded-xl px-3 py-2.5 text-sm font-medium outline-none transition-colors"
                   required
                 />
@@ -362,12 +462,7 @@ const JoinAndPlay: React.FC = () => {
 
               <button
                 type="submit"
-                disabled={
-                  joinStatus === 'loading' ||
-                  lookingUp ||
-                  !name.trim() ||
-                  !pin.trim()
-                }
+                disabled={joinStatus === 'loading' || lookingUp || !pin.trim()}
                 className="w-full bg-brand-blue-primary hover:bg-brand-blue-dark disabled:bg-slate-200 disabled:text-slate-400 text-white font-bold rounded-xl py-3 text-sm transition-all active:scale-95 flex items-center justify-center gap-2"
               >
                 {joinStatus === 'loading' || lookingUp ? (
@@ -415,13 +510,7 @@ const JoinAndPlay: React.FC = () => {
             </div>
 
             <div className="p-6 flex flex-col gap-4">
-              <p className="text-slate-600 font-medium">
-                Great work,{' '}
-                <span className="text-brand-blue-dark font-bold">
-                  {myResponse?.name}
-                </span>
-                !
-              </p>
+              <p className="text-slate-600 font-medium">Great work!</p>
 
               {totalQuestions > 0 && (
                 <div className="bg-brand-blue-lighter/30 rounded-2xl p-5">

--- a/components/videoActivity/VideoActivityStudentApp.tsx
+++ b/components/videoActivity/VideoActivityStudentApp.tsx
@@ -53,7 +53,11 @@ function resolveSsoClassPeriod(
     .filter((id) => sessionClassIds.size === 0 || sessionClassIds.has(id))
     .map((id) => map[id])
     .filter((period): period is string => typeof period === 'string');
-  if (matches.length !== 1) return undefined;
+  // Dedupe so a student enrolled in multiple targeted classes that share
+  // the same period name (e.g. teacher labelled both "Period 1") still
+  // resolves cleanly. Only `Set.size !== 1` is genuinely ambiguous.
+  const unique = new Set(matches);
+  if (unique.size !== 1) return undefined;
   return matches[0];
 }
 
@@ -199,20 +203,21 @@ const JoinAndPlay: React.FC<JoinAndPlayProps> = ({
   const [lookingUp, setLookingUp] = useState(false);
 
   // SSO auto-join. Mirrors QuizStudentApp's pattern: a single ref guards
-  // against StrictMode double-invoke. The ref is reset whenever
-  // `joinStatus` flips to `'error'` so a transient Firestore hiccup
-  // doesn't strand the student on a permanent loader — the next render
-  // (e.g. a refresh, network recovery) re-arms the effect for another
-  // attempt. Local `ssoAutoJoinError` covers the lookup-failure leg
-  // (`lookupSession` swallows errors and returns `null`); the hook's own
-  // `error`/`joinStatus` carry post-lookup failures.
+  // against StrictMode double-invoke. When `joinStatus` flips to `'error'`,
+  // the render-time reset below clears the ref AND `joinStatus` is in the
+  // effect deps, so the effect re-fires once on the next render — letting
+  // a transient Firestore failure recover without a page refresh. Local
+  // `ssoAutoJoinError` covers the lookup-failure leg (`lookupSession`
+  // swallows errors and returns `null`); the hook's own `error`/
+  // `joinStatus` carry post-lookup failures.
   const ssoAutoJoinStartedRef = useRef(false);
   const [ssoAutoJoinError, setSsoAutoJoinError] = useState<string | null>(null);
 
-  // Re-arm the started ref when the hook reports an error so a recoverable
-  // failure (e.g. transient network) can retry on the next effect pass.
-  // Done as adjust-state-during-render rather than an effect to avoid an
-  // extra render cycle (per CLAUDE.md "useEffect is an escape hatch").
+  // Re-arm the started ref when the hook reports an error so the effect
+  // pass below can retry. Done as adjust-state-during-render rather than
+  // an effect to avoid an extra render cycle (per CLAUDE.md "useEffect is
+  // an escape hatch"). Pairs with `joinStatus` in the effect deps —
+  // without that dep, the reset would have nothing to trigger the rerun.
   if (joinStatus === 'error' && ssoAutoJoinStartedRef.current) {
     ssoAutoJoinStartedRef.current = false;
   }
@@ -241,12 +246,14 @@ const JoinAndPlay: React.FC<JoinAndPlayProps> = ({
         );
       }
     })();
-    // `joinStatus` is intentionally omitted from deps. The ref guard above
-    // and the early-return on 'joined'/'loading' make a status-driven
-    // re-fire redundant; including it would just trigger a no-op re-render
-    // on every status transition.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isStudentRole, sessionId, ssoClassIds, lookupSession, joinSession]);
+  }, [
+    isStudentRole,
+    sessionId,
+    ssoClassIds,
+    lookupSession,
+    joinSession,
+    joinStatus,
+  ]);
 
   // Track answered question IDs for anti-skip enforcement in VideoPlayer
   const answeredQuestionIds = React.useMemo(

--- a/components/videoActivity/VideoActivityStudentApp.tsx
+++ b/components/videoActivity/VideoActivityStudentApp.tsx
@@ -92,7 +92,7 @@ export const VideoActivityStudentApp: React.FC = () => {
           }
         }
       } catch (err) {
-        console.warn('[VideoActivityStudentApp] Auth init failed:', err);
+        logError('VideoActivityStudentApp.authInit', err);
         setAuthFailed(true);
       } finally {
         setAuthReady(true);
@@ -217,7 +217,7 @@ const JoinAndPlay: React.FC<JoinAndPlayProps> = ({
         const autoClassPeriod = resolveSsoClassPeriod(sessionInfo, ssoClassIds);
         await joinSession(sessionId, undefined, autoClassPeriod);
       } catch (err) {
-        console.error('[VideoActivityStudentApp] SSO auto-join failed:', err);
+        logError('VideoActivityStudentApp.ssoAutoJoin', err, { sessionId });
         setSsoAutoJoinError(
           'Something went wrong joining this activity. Please refresh and try again.'
         );

--- a/components/widgets/VideoActivityWidget/Widget.tsx
+++ b/components/widgets/VideoActivityWidget/Widget.tsx
@@ -457,7 +457,8 @@ export const VideoActivityWidget: React.FC<{ widget: WidgetData }> = ({
             derived.classIds,
             derived.periodNames,
             derived.rosterIds,
-            vaAssignmentMode
+            vaAssignmentMode,
+            derived.classPeriodByClassId
           );
 
           // Persist per-activity memory of the last roster selection so

--- a/components/widgets/VideoActivityWidget/components/Results.tsx
+++ b/components/widgets/VideoActivityWidget/components/Results.tsx
@@ -173,10 +173,14 @@ export const Results: React.FC<ResultsProps> = ({
         tabSwitchWarnings: r.tabSwitchWarnings ?? 0,
       }));
 
+      // Pass `byStudentUid` so SSO `studentRole` rows (no PIN) export with
+      // their resolved ClassLink names instead of falling back to the
+      // generic "Student" label.
       const url = await drive.exportResultsToSheet(
         session.assignmentName,
         quizResponses,
-        questions
+        questions,
+        { byStudentUid }
       );
       setExportUrl(url);
     } catch (err) {

--- a/components/widgets/VideoActivityWidget/components/Results.tsx
+++ b/components/widgets/VideoActivityWidget/components/Results.tsx
@@ -153,8 +153,10 @@ export const Results: React.FC<ResultsProps> = ({
 
       // Map VideoActivityResponses to QuizResponse shape for reuse
       const quizResponses = responses.map((r) => ({
-        studentUid: r.pin,
-        pin: r.pin,
+        studentUid: r.studentUid,
+        // Anon responses always carry a PIN; SSO responses don't. Fall back
+        // to empty string so the export shape stays string-typed.
+        pin: r.pin ?? '',
         joinedAt: r.joinedAt,
         status: (r.completedAt ? 'completed' : 'in-progress') as
           | 'completed'
@@ -168,7 +170,7 @@ export const Results: React.FC<ResultsProps> = ({
         })),
         score: r.score,
         submittedAt: r.completedAt,
-        tabSwitchWarnings: 0,
+        tabSwitchWarnings: r.tabSwitchWarnings ?? 0,
       }));
 
       const url = await drive.exportResultsToSheet(

--- a/components/widgets/VideoActivityWidget/components/Results.tsx
+++ b/components/widgets/VideoActivityWidget/components/Results.tsx
@@ -508,9 +508,12 @@ export const Results: React.FC<ResultsProps> = ({
                           className="font-bold text-slate-800 truncate"
                           style={{ fontSize: 'min(13px, 4cqmin)' }}
                         >
-                          {formatStudentName(byStudentUid.get(r.studentUid)) ||
-                            r.name ||
-                            r.pin}
+                          {/* `formatStudentName` returns '' on roster miss and legacy rows may carry '' for `r.name`; pick the first non-empty string so the falsy-fallthrough intent is explicit (no `||` chain that ESLint would flag). */}
+                          {[
+                            formatStudentName(byStudentUid.get(r.studentUid)),
+                            r.name,
+                            r.pin,
+                          ].find((s) => typeof s === 'string' && s.length > 0)}
                         </p>
                         <p
                           className="text-slate-400"

--- a/components/widgets/VideoActivityWidget/components/Results.tsx
+++ b/components/widgets/VideoActivityWidget/components/Results.tsx
@@ -3,7 +3,7 @@
  * Adapted from QuizResults. Shows per-student scores and per-question accuracy.
  */
 
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import {
   ArrowLeft,
   Download,
@@ -20,7 +20,7 @@ import { VideoActivityResponse, VideoActivitySession } from '@/types';
 import { useAuth } from '@/context/useAuth';
 import { QuizDriveService } from '@/utils/quizDriveService';
 import {
-  useAssignmentPseudonyms,
+  useAssignmentPseudonymsMulti,
   formatStudentName,
 } from '@/hooks/useAssignmentPseudonyms';
 
@@ -36,9 +36,19 @@ export const Results: React.FC<ResultsProps> = ({
   onBack,
 }) => {
   const { googleAccessToken, orgId } = useAuth();
-  const { byStudentUid } = useAssignmentPseudonyms(
+  // Use the multi-class variant — `session.classId` is a transitional
+  // mirror of `classIds[0]` only, so the single-class hook would miss
+  // SSO students from `classIds[1+]` on multi-class assignments and
+  // their export rows would fall back to the generic "Student" label.
+  // Mirrors the QuizLiveMonitor pattern.
+  const sessionClassIds = useMemo(() => {
+    if (session.classIds && session.classIds.length > 0)
+      return session.classIds;
+    return session.classId ? [session.classId] : [];
+  }, [session.classIds, session.classId]);
+  const { byStudentUid } = useAssignmentPseudonymsMulti(
     session.id,
-    session.classId ?? null,
+    sessionClassIds,
     orgId
   );
   const [exporting, setExporting] = useState(false);

--- a/components/widgets/VideoActivityWidget/components/VideoActivityLiveMonitor.tsx
+++ b/components/widgets/VideoActivityWidget/components/VideoActivityLiveMonitor.tsx
@@ -30,7 +30,7 @@ import {
 import { useDialog } from '@/context/useDialog';
 import { useAuth } from '@/context/useAuth';
 import {
-  useAssignmentPseudonyms,
+  useAssignmentPseudonymsMulti,
   formatStudentName,
 } from '@/hooks/useAssignmentPseudonyms';
 import { ScaledEmptyState } from '@/components/common/ScaledEmptyState';
@@ -313,9 +313,18 @@ export const VideoActivityLiveMonitor: React.FC<
   const { orgId } = useAuth();
   // SSO `studentRole` responses carry no PIN or self-typed name; resolve
   // their roster identities here so the monitor row labels stay populated.
-  const { byStudentUid } = useAssignmentPseudonyms(
+  // Use the multi-class variant — `session.classId` is a transitional
+  // mirror of `classIds[0]` only, so the single-class hook would miss
+  // SSO students from `classIds[1+]` entirely on multi-class assignments.
+  // Mirrors the QuizLiveMonitor pattern.
+  const sessionClassIds = useMemo(() => {
+    if (session.classIds && session.classIds.length > 0)
+      return session.classIds;
+    return session.classId ? [session.classId] : [];
+  }, [session.classIds, session.classId]);
+  const { byStudentUid } = useAssignmentPseudonymsMulti(
     session.id,
-    session.classId ?? null,
+    sessionClassIds,
     orgId
   );
   const questions = session.questions;

--- a/components/widgets/VideoActivityWidget/components/VideoActivityLiveMonitor.tsx
+++ b/components/widgets/VideoActivityWidget/components/VideoActivityLiveMonitor.tsx
@@ -115,7 +115,10 @@ const StudentRow: React.FC<StudentRowProps> = ({ response, questions }) => {
             className="font-bold text-slate-800 truncate"
             style={{ fontSize: 'min(13px, 4cqmin)' }}
           >
-            {response.name || response.pin}
+            {/* Legacy rows may carry '' for `response.name`; fall through to PIN when name is empty. */}
+            {response.name && response.name.length > 0
+              ? response.name
+              : response.pin}
           </p>
           {response.classPeriod && (
             <span

--- a/components/widgets/VideoActivityWidget/components/VideoActivityLiveMonitor.tsx
+++ b/components/widgets/VideoActivityWidget/components/VideoActivityLiveMonitor.tsx
@@ -28,6 +28,11 @@ import {
   VideoActivityQuestion,
 } from '@/types';
 import { useDialog } from '@/context/useDialog';
+import { useAuth } from '@/context/useAuth';
+import {
+  useAssignmentPseudonyms,
+  formatStudentName,
+} from '@/hooks/useAssignmentPseudonyms';
 import { ScaledEmptyState } from '@/components/common/ScaledEmptyState';
 
 interface VideoActivityLiveMonitorProps {
@@ -51,9 +56,41 @@ interface VideoActivityLiveMonitorProps {
 interface StudentRowProps {
   response: VideoActivityResponse;
   questions: VideoActivityQuestion[];
+  /**
+   * Roster name lookup keyed by `response.studentUid`. Used to label SSO
+   * `studentRole` joiners (who carry no `pin` or `name` field) with their
+   * real ClassLink name. Empty map = legacy / non-SSO sessions; rows fall
+   * back through `response.name` and finally `response.pin`.
+   */
+  byStudentUid: Map<string, { givenName: string; familyName: string }>;
 }
 
-const StudentRow: React.FC<StudentRowProps> = ({ response, questions }) => {
+/**
+ * Pick the first non-empty display label from
+ *   1. The roster name resolved via `byStudentUid` (SSO students)
+ *   2. The self-typed `response.name` (legacy pre-PR1 anon rows)
+ *   3. The PIN itself (PR1+ anon rows)
+ *
+ * Returns `undefined` if all three are empty/missing — caller renders an
+ * em-dash so the UI never goes blank.
+ */
+function pickDisplayLabel(
+  response: VideoActivityResponse,
+  byStudentUid: Map<string, { givenName: string; familyName: string }>
+): string | undefined {
+  const candidates = [
+    formatStudentName(byStudentUid.get(response.studentUid)),
+    response.name,
+    response.pin,
+  ];
+  return candidates.find((s) => typeof s === 'string' && s.length > 0);
+}
+
+const StudentRow: React.FC<StudentRowProps> = ({
+  response,
+  questions,
+  byStudentUid,
+}) => {
   const correctAnswerById = useMemo(() => {
     const m = new Map<string, string>();
     for (const q of questions) m.set(q.id, q.correctAnswer);
@@ -115,10 +152,7 @@ const StudentRow: React.FC<StudentRowProps> = ({ response, questions }) => {
             className="font-bold text-slate-800 truncate"
             style={{ fontSize: 'min(13px, 4cqmin)' }}
           >
-            {/* Legacy rows may carry '' for `response.name`; fall through to PIN when name is empty. */}
-            {response.name && response.name.length > 0
-              ? response.name
-              : response.pin}
+            {pickDisplayLabel(response, byStudentUid) ?? '—'}
           </p>
           {response.classPeriod && (
             <span
@@ -160,8 +194,9 @@ const StudentRow: React.FC<StudentRowProps> = ({ response, questions }) => {
             marginTop: 'min(2px, 0.5cqmin)',
           }}
         >
-          PIN {response.pin} · {answeredCount}/{questions.length} answered ·
-          last {formatTime(latestAnsweredAt)}
+          {response.pin ? `PIN ${response.pin} · ` : null}
+          {answeredCount}/{questions.length} answered · last{' '}
+          {formatTime(latestAnsweredAt)}
         </p>
       </div>
 
@@ -275,6 +310,14 @@ export const VideoActivityLiveMonitor: React.FC<
   VideoActivityLiveMonitorProps
 > = ({ session, responses, onEnd, onPause, onResume, onBack }) => {
   const { showConfirm } = useDialog();
+  const { orgId } = useAuth();
+  // SSO `studentRole` responses carry no PIN or self-typed name; resolve
+  // their roster identities here so the monitor row labels stay populated.
+  const { byStudentUid } = useAssignmentPseudonyms(
+    session.id,
+    session.classId ?? null,
+    orgId
+  );
   const questions = session.questions;
   const [ending, setEnding] = useState(false);
   const [toggling, setToggling] = useState(false);
@@ -580,6 +623,7 @@ export const VideoActivityLiveMonitor: React.FC<
                     key={r.studentUid}
                     response={r}
                     questions={questions}
+                    byStudentUid={byStudentUid}
                   />
                 ))}
               </div>

--- a/firestore.rules
+++ b/firestore.rules
@@ -1338,7 +1338,12 @@ service cloud.firestore {
       allow delete: if request.auth != null &&
         (resource.data.teacherUid == request.auth.uid || isAdmin());
 
-      match /responses/{studentUid} {
+      // Doc id (`responseDocId`) is one of:
+      //   - `auth.uid`             (SSO `studentRole` joiners — stable per user)
+      //   - `pin-{period}-{pin}`   (anonymous PIN joiners — period-scoped)
+      // The variable name predates PR1; the runtime helper below decides
+      // whether the caller is the legitimate owner of the doc.
+      match /responses/{responseDocId} {
         function vaSessionClassId() {
           return get(/databases/$(database)/documents/video_activity_sessions/$(sessionId)).data.get('classId', '');
         }
@@ -1349,39 +1354,63 @@ service cloud.firestore {
         function vaSessionMode() {
           return get(/databases/$(database)/documents/video_activity_sessions/$(sessionId)).data.get('mode', 'submissions');
         }
+        // True iff the doc id is either the caller's auth.uid (SSO) or a
+        // `pin-…` anonymous response key. Anonymous students are scoped by
+        // the `studentUid` field on the doc; that field is always required
+        // to equal `request.auth.uid` so the same physical caller cannot
+        // claim two anon docs at once.
+        function callerOwnsResponse() {
+          return responseDocId == request.auth.uid ||
+            responseDocId.matches('^pin-.+');
+        }
 
-        // Teacher can read all responses; students can only read their own (doc ID == auth UID)
+        // Teacher can read all responses; students can only read their own.
+        // SSO joiners' doc id equals auth.uid; anon joiners' doc carries
+        // their auth uid in the `studentUid` field.
         allow read: if request.auth != null && (
           isAdmin() ||
           get(/databases/$(database)/documents/video_activity_sessions/$(sessionId)).data.teacherUid == request.auth.uid ||
-          (studentUid == request.auth.uid && passesStudentClassGateCompat(vaSessionClassIds(), vaSessionClassId()))
+          ((responseDocId == request.auth.uid || resource.data.studentUid == request.auth.uid) &&
+            passesStudentClassGateCompat(vaSessionClassIds(), vaSessionClassId()))
         );
-        // Students create their own response; document ID and studentUid field must match their auth UID.
-        // studentRole users must also be enrolled in the session's class.
+        // Students create their own response. The `studentUid` field must
+        // equal the caller's auth uid (prevents impersonation); the doc id
+        // must follow either the `pin-…` anon scheme or be the caller's
+        // auth uid (SSO). studentRole users must also be enrolled in the
+        // session's class.
         allow create: if request.auth != null &&
-          studentUid == request.auth.uid &&
+          callerOwnsResponse() &&
           request.resource.data.studentUid == request.auth.uid &&
           request.resource.data.score == null &&
           request.resource.data.completedAt == null &&
           passesStudentClassGateCompat(vaSessionClassIds(), vaSessionClassId()) &&
           // Block submissions on view-only sessions (mode is frozen at creation)
           vaSessionMode() == 'submissions';
-        // Students can update only their own response to add answers or set completedAt;
-        // identity fields and score are immutable from the client; answers array may only grow
+        // Students update their own response to add answers, set
+        // completedAt, log tab switches, log attempts, or set their class
+        // period after the post-PIN picker. Identity fields and
+        // teacher-controlled fields (score, isCorrect, scoreVisibility)
+        // remain immutable from the client; answers array may only grow.
         allow update: if request.auth != null &&
-          studentUid == request.auth.uid &&
+          callerOwnsResponse() &&
+          resource.data.studentUid == request.auth.uid &&
           passesStudentClassGateCompat(vaSessionClassIds(), vaSessionClassId()) &&
           request.resource.data.studentUid == resource.data.studentUid &&
-          // Same fragility class as the quiz_sessions/responses rule: SSO
-          // studentRole responses may omit `pin` and `name` entirely, so
+          // SSO studentRole responses omit `pin` and `name` entirely, so
           // direct dot-access would throw and deny the write. The
-          // `affectedKeys().hasOnly(['answers', 'completedAt'])` clause
-          // below still prevents a student from adding/changing them.
+          // `affectedKeys().hasOnly(...)` clause below still prevents a
+          // student from changing them.
           request.resource.data.get('pin', null) == resource.data.get('pin', null) &&
           request.resource.data.get('name', null) == resource.data.get('name', null) &&
           request.resource.data.get('joinedAt', null) == resource.data.get('joinedAt', null) &&
           request.resource.data.score == resource.data.score &&
-          request.resource.data.diff(resource.data).affectedKeys().hasOnly(['answers', 'completedAt']) &&
+          request.resource.data.diff(resource.data).affectedKeys().hasOnly([
+            'answers',
+            'completedAt',
+            'tabSwitchWarnings',
+            'completedAttempts',
+            'classPeriod'
+          ]) &&
           request.resource.data.answers.size() >= resource.data.answers.size() &&
           request.resource.data.answers.hasAll(resource.data.answers);
         // Owning teacher (or admin) may delete responses when permanently

--- a/firestore.rules
+++ b/firestore.rules
@@ -1154,7 +1154,7 @@ service cloud.firestore {
           sessionMode() == 'submissions' &&
           (isStudentRoleUser()
             ? responseKey == request.auth.uid
-            : responseKey.matches('^pin-[a-z0-9_]+-[a-z0-9_]+$'));
+            : responseKey.matches('^pin-[a-z0-9_]{1,64}-[a-z0-9_]{1,64}$'));
         allow update: if request.auth != null && (
           // Teacher and admins can update any field
           request.auth.uid == sessionTeacherUid() || isAdmin() ||
@@ -1375,7 +1375,8 @@ service cloud.firestore {
         // shape is enforced split-by-auth-mode:
         //   - SSO (studentRole)  → responseDocId must equal auth.uid
         //   - Anonymous (PIN)    → responseDocId must match
-        //                          ^pin-[a-z0-9_]+-[a-z0-9_]+$ (mirrors
+        //                          ^pin-[a-z0-9_]{1,64}-[a-z0-9_]{1,64}$
+        //                          (mirrors
         //                          `encodeResponseKeySegment` on the
         //                          client). This closes the cross-auth
         //                          path where any authenticated caller
@@ -1394,7 +1395,7 @@ service cloud.firestore {
           vaSessionMode() == 'submissions' &&
           (isStudentRoleUser()
             ? responseDocId == request.auth.uid
-            : responseDocId.matches('^pin-[a-z0-9_]+-[a-z0-9_]+$'));
+            : responseDocId.matches('^pin-[a-z0-9_]{1,64}-[a-z0-9_]{1,64}$'));
         // Students update their own response to add answers, set
         // completedAt, log tab switches, increment the attempt counter, or
         // set their class period after the post-PIN picker. Ownership is
@@ -1407,17 +1408,22 @@ service cloud.firestore {
         //     `attemptLimit` cap).
         //   - `answers` may only grow (size monotonic, all prior elements
         //     preserved).
-        //   - Identity fields (`pin`, `name`, `joinedAt`, `studentUid`)
-        //     and teacher-controlled fields (`score`, `isCorrect`,
+        //   - Identity fields (`pin`, `name`, `joinedAt`) and
+        //     teacher-controlled fields (`score`, `isCorrect`,
         //     `scoreVisibility`) are immutable from the client.
+        //     `studentUid` is checked separately as the ownership anchor
+        //     (the line right above this block).
         allow update: if request.auth != null &&
           resource.data.studentUid == request.auth.uid &&
           passesStudentClassGateCompat(vaSessionClassIds(), vaSessionClassId()) &&
           request.resource.data.studentUid == resource.data.studentUid &&
-          // SSO studentRole responses omit `pin` and `name` entirely, so
-          // direct dot-access would throw and deny the write. The
-          // `changedKeys().hasOnly(...)` clause below still prevents a
-          // student from adding/changing them.
+          // Defense-in-depth: redundant with the `changedKeys().hasOnly([...])`
+          // allowlist below (which would already reject a `pin`/`name`/
+          // `joinedAt` change), but kept explicit so a future allowlist
+          // expansion can't silently allow these to mutate. SSO
+          // `studentRole` responses omit `pin` and `name` entirely, so the
+          // checks use `.get(_, null)` to tolerate the field being absent
+          // on both sides instead of throwing a Null-value error.
           request.resource.data.get('pin', null) == resource.data.get('pin', null) &&
           request.resource.data.get('name', null) == resource.data.get('name', null) &&
           request.resource.data.get('joinedAt', null) == resource.data.get('joinedAt', null) &&

--- a/firestore.rules
+++ b/firestore.rules
@@ -1339,10 +1339,10 @@ service cloud.firestore {
         (resource.data.teacherUid == request.auth.uid || isAdmin());
 
       // Doc id (`responseDocId`) is one of:
-      //   - `auth.uid`             (SSO `studentRole` joiners — stable per user)
-      //   - `pin-{period}-{pin}`   (anonymous PIN joiners — period-scoped)
-      // The variable name predates PR1; the runtime helper below decides
-      // whether the caller is the legitimate owner of the doc.
+      //   - `auth.uid`                   (SSO `studentRole` joiners — stable per user)
+      //   - `pin-{period}-{pin}`         (anonymous PIN joiners — period-scoped)
+      // Mirrors the Quiz response keying contract; see `computeResponseKey`
+      // and `encodeResponseKeySegment` in `useQuizSession.ts`.
       match /responses/{responseDocId} {
         function vaSessionClassId() {
           return get(/databases/$(database)/documents/video_activity_sessions/$(sessionId)).data.get('classId', '');
@@ -1350,74 +1350,96 @@ service cloud.firestore {
         function vaSessionClassIds() {
           return get(/databases/$(database)/documents/video_activity_sessions/$(sessionId)).data.get('classIds', []);
         }
+        function vaSessionTeacherUid() {
+          return get(/databases/$(database)/documents/video_activity_sessions/$(sessionId)).data.teacherUid;
+        }
         // Defense in depth — block response writes on view-only sessions.
         function vaSessionMode() {
           return get(/databases/$(database)/documents/video_activity_sessions/$(sessionId)).data.get('mode', 'submissions');
         }
-        // True iff the doc id is either the caller's auth.uid (SSO) or a
-        // `pin-…` anonymous response key. Anonymous students are scoped by
-        // the `studentUid` field on the doc; that field is always required
-        // to equal `request.auth.uid` so the same physical caller cannot
-        // claim two anon docs at once.
-        function callerOwnsResponse() {
-          return responseDocId == request.auth.uid ||
-            responseDocId.matches('^pin-.+');
-        }
 
-        // Teacher can read all responses; students can only read their own.
-        // SSO joiners' doc id equals auth.uid; anon joiners' doc carries
-        // their auth uid in the `studentUid` field.
+        // Student branch allows `resource == null` so the student-app join
+        // flow can call getDoc() to probe whether a response already exists
+        // before deciding to create. Without this guard, a read of a
+        // non-existent `pin-*` doc would throw a Null-value error on
+        // `resource.data.studentUid` and deny the write. Mirrors the Quiz
+        // response read rule.
         allow read: if request.auth != null && (
           isAdmin() ||
-          get(/databases/$(database)/documents/video_activity_sessions/$(sessionId)).data.teacherUid == request.auth.uid ||
-          ((responseDocId == request.auth.uid || resource.data.studentUid == request.auth.uid) &&
-            passesStudentClassGateCompat(vaSessionClassIds(), vaSessionClassId()))
+          request.auth.uid == vaSessionTeacherUid() ||
+          (passesStudentClassGateCompat(vaSessionClassIds(), vaSessionClassId()) &&
+           (resource == null || request.auth.uid == resource.data.studentUid))
         );
         // Students create their own response. The `studentUid` field must
-        // equal the caller's auth uid (prevents impersonation); the doc id
-        // must follow either the `pin-…` anon scheme or be the caller's
-        // auth uid (SSO). studentRole users must also be enrolled in the
-        // session's class.
+        // equal the caller's auth uid (prevents impersonation). Doc-id
+        // shape is enforced split-by-auth-mode:
+        //   - SSO (studentRole)  → responseDocId must equal auth.uid
+        //   - Anonymous (PIN)    → responseDocId must match
+        //                          ^pin-[a-z0-9_]+-[a-z0-9_]+$ (mirrors
+        //                          `encodeResponseKeySegment` on the
+        //                          client). This closes the cross-auth
+        //                          path where any authenticated caller
+        //                          could grief-create arbitrary `pin-*`
+        //                          docs.
+        // studentRole users must also be enrolled in the session's class.
         allow create: if request.auth != null &&
-          callerOwnsResponse() &&
           request.resource.data.studentUid == request.auth.uid &&
           request.resource.data.score == null &&
           request.resource.data.completedAt == null &&
+          // Students cannot forge prior completions — initialize to 0.
+          request.resource.data.get('completedAttempts', 0) == 0 &&
+          request.resource.data.get('tabSwitchWarnings', 0) == 0 &&
           passesStudentClassGateCompat(vaSessionClassIds(), vaSessionClassId()) &&
           // Block submissions on view-only sessions (mode is frozen at creation)
-          vaSessionMode() == 'submissions';
+          vaSessionMode() == 'submissions' &&
+          (isStudentRoleUser()
+            ? responseDocId == request.auth.uid
+            : responseDocId.matches('^pin-[a-z0-9_]+-[a-z0-9_]+$'));
         // Students update their own response to add answers, set
-        // completedAt, log tab switches, log attempts, or set their class
-        // period after the post-PIN picker. Identity fields and
-        // teacher-controlled fields (score, isCorrect, scoreVisibility)
-        // remain immutable from the client; answers array may only grow.
+        // completedAt, log tab switches, increment the attempt counter, or
+        // set their class period after the post-PIN picker. Ownership is
+        // enforced against the `studentUid` field, not the doc key (which
+        // is pin-derived for anonymous joiners). Mutable-field allowlist
+        // and monotonic-growth checks mirror Quiz response rules:
+        //   - `tabSwitchWarnings` and `completedAttempts` may only stay
+        //     the same or increase (prevents rollback tampering, e.g. a
+        //     student resetting their attempt counter to bypass the
+        //     `attemptLimit` cap).
+        //   - `answers` may only grow (size monotonic, all prior elements
+        //     preserved).
+        //   - Identity fields (`pin`, `name`, `joinedAt`, `studentUid`)
+        //     and teacher-controlled fields (`score`, `isCorrect`,
+        //     `scoreVisibility`) are immutable from the client.
         allow update: if request.auth != null &&
-          callerOwnsResponse() &&
           resource.data.studentUid == request.auth.uid &&
           passesStudentClassGateCompat(vaSessionClassIds(), vaSessionClassId()) &&
           request.resource.data.studentUid == resource.data.studentUid &&
           // SSO studentRole responses omit `pin` and `name` entirely, so
           // direct dot-access would throw and deny the write. The
-          // `affectedKeys().hasOnly(...)` clause below still prevents a
-          // student from changing them.
+          // `changedKeys().hasOnly(...)` clause below still prevents a
+          // student from adding/changing them.
           request.resource.data.get('pin', null) == resource.data.get('pin', null) &&
           request.resource.data.get('name', null) == resource.data.get('name', null) &&
           request.resource.data.get('joinedAt', null) == resource.data.get('joinedAt', null) &&
           request.resource.data.score == resource.data.score &&
-          request.resource.data.diff(resource.data).affectedKeys().hasOnly([
+          request.resource.data.diff(resource.data).changedKeys().hasOnly([
             'answers',
             'completedAt',
             'tabSwitchWarnings',
             'completedAttempts',
             'classPeriod'
           ]) &&
+          request.resource.data.answers is list &&
           request.resource.data.answers.size() >= resource.data.answers.size() &&
-          request.resource.data.answers.hasAll(resource.data.answers);
+          request.resource.data.answers.hasAll(resource.data.answers) &&
+          (!request.resource.data.diff(resource.data).affectedKeys().hasAny(['tabSwitchWarnings']) ||
+           request.resource.data.tabSwitchWarnings >= resource.data.get('tabSwitchWarnings', 0)) &&
+          (!request.resource.data.diff(resource.data).affectedKeys().hasAny(['completedAttempts']) ||
+           request.resource.data.get('completedAttempts', 0) >= resource.data.get('completedAttempts', 0));
         // Owning teacher (or admin) may delete responses when permanently
         // deleting the assignment (matches GL responses).
         allow delete: if request.auth != null && (
-          get(/databases/$(database)/documents/video_activity_sessions/$(sessionId)).data.teacherUid == request.auth.uid ||
-          isAdmin()
+          request.auth.uid == vaSessionTeacherUid() || isAdmin()
         );
       }
 

--- a/hooks/useVideoActivitySession.ts
+++ b/hooks/useVideoActivitySession.ts
@@ -435,7 +435,10 @@ export const useVideoActivitySessionStudent =
     const [joinStatus, setJoinStatus] = useState<StudentJoinStatus>('idle');
     const [error, setError] = useState<string | null>(null);
     const [sessionId, setSessionId] = useState<string | null>(null);
-    // responseDocId is the student's Firebase auth UID (used as the Firestore document ID)
+    // responseDocId is the deterministic Firestore doc id for the student's
+    // response — `auth.uid` for SSO `studentRole` joiners, or
+    // `pin-{period}-{pin}` for anonymous PIN joiners. Computed at join time
+    // via `computeResponseKey`; see `useQuizSession.ts`.
     const [responseDocId, setResponseDocId] = useState<string | null>(null);
 
     // Listen to session document
@@ -450,10 +453,9 @@ export const useVideoActivitySessionStudent =
           }
         },
         (err) => {
-          console.error(
-            '[useVideoActivitySessionStudent] Session listener error:',
-            err
-          );
+          logError('useVideoActivitySessionStudent.sessionListener', err, {
+            sessionId,
+          });
         }
       );
 
@@ -478,10 +480,10 @@ export const useVideoActivitySessionStudent =
           }
         },
         (err) => {
-          console.error(
-            '[useVideoActivitySessionStudent] Response listener error:',
-            err
-          );
+          logError('useVideoActivitySessionStudent.responseListener', err, {
+            sessionId,
+            responseDocId,
+          });
         }
       );
 
@@ -497,10 +499,9 @@ export const useVideoActivitySessionStudent =
           if (!snap.exists()) return null;
           return snap.data() as VideoActivitySession;
         } catch (err) {
-          console.error(
-            '[useVideoActivitySessionStudent] lookupSession error:',
-            err
-          );
+          logError('useVideoActivitySessionStudent.lookupSession', err, {
+            sessionId: targetSessionId,
+          });
           return null;
         }
       },
@@ -589,6 +590,26 @@ export const useVideoActivitySessionStudent =
             classPeriod
           );
 
+          // Defense against the encoder's `'default'` fallback — when the
+          // PIN and period are both all-special-chars or empty, both
+          // segments collapse to `'default'` and unrelated students collide
+          // on the same doc. Surface a user-facing error instead.
+          if (isAnonymous && responseDocKey === 'pin-default-default') {
+            setJoinStatus('error');
+            setError(
+              'Your PIN is in an unsupported format. Please check the PIN your teacher gave you.'
+            );
+            return;
+          }
+
+          // Probe the deterministic key first. If nothing's there AND the
+          // caller is anonymous, also probe a legacy `auth.uid`-keyed doc
+          // (the pre-PR1 keying scheme) so an in-flight student rejoining
+          // after deploy resumes their existing response instead of starting
+          // a fresh one. SSO joiners are unaffected — their `auth.uid` is
+          // both the new key and the legacy key. The legacy probe is
+          // skipped when we already found the new doc, so the steady-state
+          // path stays one read.
           const responseRef = doc(
             db,
             SESSIONS_COLLECTION,
@@ -596,7 +617,27 @@ export const useVideoActivitySessionStudent =
             RESPONSES_SUBCOLLECTION,
             responseDocKey
           );
-          const existingSnap = await getDoc(responseRef);
+          let effectiveResponseRef = responseRef;
+          let existingSnap = await getDoc(responseRef);
+
+          if (
+            !existingSnap.exists() &&
+            isAnonymous &&
+            responseDocKey !== currentUser.uid
+          ) {
+            const legacyRef = doc(
+              db,
+              SESSIONS_COLLECTION,
+              targetSessionId,
+              RESPONSES_SUBCOLLECTION,
+              currentUser.uid
+            );
+            const legacySnap = await getDoc(legacyRef);
+            if (legacySnap.exists()) {
+              effectiveResponseRef = legacyRef;
+              existingSnap = legacySnap;
+            }
+          }
 
           if (!existingSnap.exists()) {
             // Initialize `completedAttempts` and `tabSwitchWarnings` to 0 so
@@ -616,11 +657,15 @@ export const useVideoActivitySessionStudent =
               ...(studentPin ? { pin: studentPin } : {}),
               ...(classPeriod ? { classPeriod } : {}),
             };
-            await setDoc(responseRef, newResponse);
+            await setDoc(effectiveResponseRef, newResponse);
           }
 
           setSessionId(targetSessionId);
-          setResponseDocId(responseDocKey);
+          // When a legacy doc was found we resume against its id (the
+          // student's auth.uid) rather than the deterministic key — the
+          // listener path keeps tracking the doc that actually has their
+          // answers. New writes always go to `effectiveResponseRef`.
+          setResponseDocId(effectiveResponseRef.id);
           setSession(sessionData);
           setJoinStatus('joined');
         } catch (err) {

--- a/hooks/useVideoActivitySession.ts
+++ b/hooks/useVideoActivitySession.ts
@@ -26,7 +26,10 @@ import {
 } from 'firebase/firestore';
 import { db, auth } from '@/config/firebase';
 import { logError } from '@/utils/logError';
-import { computeResponseKey } from '@/hooks/useQuizSession';
+import {
+  computeResponseKey,
+  encodeResponseKeySegment,
+} from '@/hooks/useQuizSession';
 import {
   AssignmentMode,
   VideoActivitySession,
@@ -590,11 +593,17 @@ export const useVideoActivitySessionStudent =
             classPeriod
           );
 
-          // Defense against the encoder's `'default'` fallback — when the
-          // PIN and period are both all-special-chars or empty, both
-          // segments collapse to `'default'` and unrelated students collide
-          // on the same doc. Surface a user-facing error instead.
-          if (isAnonymous && responseDocKey === 'pin-default-default') {
+          // Defense against the encoder's `'default'` fallback. The PIN
+          // segment is the per-student field, so any all-special-character
+          // input collapses to `'default'` and two such students in the
+          // same period collide on the same doc — a much more reachable
+          // shape than both-segments-default. Surface a user-facing error
+          // instead. (Period defaulting alone is harmless because there's
+          // only one period bucket per session.)
+          if (
+            isAnonymous &&
+            encodeResponseKeySegment(studentPin) === 'default'
+          ) {
             setJoinStatus('error');
             setError(
               'Your PIN is in an unsupported format. Please check the PIN your teacher gave you.'

--- a/hooks/useVideoActivitySession.ts
+++ b/hooks/useVideoActivitySession.ts
@@ -26,6 +26,7 @@ import {
 } from 'firebase/firestore';
 import { db, auth } from '@/config/firebase';
 import { logError } from '@/utils/logError';
+import { computeResponseKey } from '@/hooks/useQuizSession';
 import {
   AssignmentMode,
   VideoActivitySession,
@@ -107,7 +108,11 @@ export interface UseVideoActivitySessionTeacherResult {
     rosterIds?: string[],
     /** Org-wide assignment mode frozen onto the session. Defaults to
      *  `'submissions'`. */
-    mode?: AssignmentMode
+    mode?: AssignmentMode,
+    /** Map of ClassLink classId -> period name. Lets the SSO student-app
+     *  auto-join path resolve the joining student's period without a
+     *  picker. Optional; falls back to `periodNames[0]` when absent. */
+    classPeriodByClassId?: Record<string, string>
   ) => Promise<string>;
   /** Sessions created by the current teacher for the selected activity. */
   sessions: VideoActivitySession[];
@@ -161,7 +166,8 @@ export const useVideoActivitySessionTeacher =
         classIds: string[] = [],
         periodNames: string[] = [],
         rosterIds: string[] = [],
-        mode: AssignmentMode = 'submissions'
+        mode: AssignmentMode = 'submissions',
+        classPeriodByClassId?: Record<string, string>
       ): Promise<string> => {
         const sessionId = crypto.randomUUID();
         const trimmedAssignmentName = assignmentName?.trim();
@@ -193,6 +199,10 @@ export const useVideoActivitySessionTeacher =
           ...(classIds.length > 0 ? { classIds, classId: classIds[0] } : {}),
           ...(periodNames.length > 0 ? { periodNames } : {}),
           ...(rosterIds.length > 0 ? { rosterIds } : {}),
+          ...(classPeriodByClassId &&
+          Object.keys(classPeriodByClassId).length > 0
+            ? { classPeriodByClassId }
+            : {}),
           mode,
         };
 
@@ -393,10 +403,23 @@ export interface UseVideoActivitySessionStudentResult {
    * picker before committing the join.
    */
   lookupSession: (sessionId: string) => Promise<VideoActivitySession | null>;
+  /**
+   * Join a session and create the response document.
+   *
+   * Calling conventions mirror `useQuizSession.joinQuizSession`:
+   *   - Anonymous PIN students:  pass `pin` and `classPeriod`. Response
+   *     doc is keyed `pin-{period}-{pin}` so the same PIN in different
+   *     periods doesn't collide and attempt limits survive device resets.
+   *   - SSO `studentRole` joiners: pass `pin = undefined`. The hook reads
+   *     the auth UID and keys the response doc by it. `classPeriod` is
+   *     derived from `session.classPeriodByClassId` if available.
+   *
+   * The student's name is no longer collected — Results UI uses
+   * `useAssignmentPseudonyms` for display.
+   */
   joinSession: (
     sessionId: string,
-    pin: string,
-    name: string,
+    pin: string | undefined,
     classPeriod?: string
   ) => Promise<void>;
   submitAnswer: (questionId: string, answer: string) => Promise<void>;
@@ -487,8 +510,7 @@ export const useVideoActivitySessionStudent =
     const joinSession = useCallback(
       async (
         targetSessionId: string,
-        studentPin: string,
-        studentName: string,
+        studentPin: string | undefined,
         classPeriod?: string
       ): Promise<void> => {
         setJoinStatus('loading');
@@ -510,14 +532,32 @@ export const useVideoActivitySessionStudent =
 
           const sessionData = sessionSnap.data() as VideoActivitySession;
 
-          // Validate PIN against allowed list (empty list = open to any PIN)
-          if (
-            sessionData.allowedPins.length > 0 &&
-            !sessionData.allowedPins.includes(studentPin)
-          ) {
-            setJoinStatus('pin-rejected');
-            setError('Incorrect PIN. Please check with your teacher.');
+          const currentUser = auth.currentUser;
+          if (!currentUser) {
+            setJoinStatus('error');
+            setError('Authentication required. Please refresh and try again.');
             return;
+          }
+
+          const isAnonymous = currentUser.isAnonymous;
+
+          // Anonymous (PIN) joiners must supply a PIN and pass the allowedPins
+          // gate. SSO joiners (studentRole custom-token users) skip both checks
+          // — they're identified by their auth UID, not by a roster PIN.
+          if (isAnonymous) {
+            if (!studentPin || studentPin.trim().length === 0) {
+              setJoinStatus('error');
+              setError('A roster PIN is required to join this activity.');
+              return;
+            }
+            if (
+              sessionData.allowedPins.length > 0 &&
+              !sessionData.allowedPins.includes(studentPin)
+            ) {
+              setJoinStatus('pin-rejected');
+              setError('Incorrect PIN. Please check with your teacher.');
+              return;
+            }
           }
 
           if (sessionData.status === 'ended') {
@@ -537,39 +577,42 @@ export const useVideoActivitySessionStudent =
             return;
           }
 
-          const studentUid = auth.currentUser?.uid;
-          if (!studentUid) {
-            setJoinStatus('error');
-            setError('Authentication required. Please refresh and try again.');
-            return;
-          }
+          // Compute the deterministic response-doc key. Anonymous joiners get
+          // `pin-{period}-{pin}` so the same PIN in different periods stays
+          // distinct and attempt limits survive a device wipe; SSO joiners
+          // get `auth.uid`. `computeResponseKey` is the canonical helper —
+          // shared with the Quiz student app.
+          const responseDocKey = computeResponseKey(
+            currentUser.uid,
+            isAnonymous,
+            studentPin ?? '',
+            classPeriod
+          );
 
-          // Response document ID is the student's auth UID (prevents PIN-claiming attacks)
           const responseRef = doc(
             db,
             SESSIONS_COLLECTION,
             targetSessionId,
             RESPONSES_SUBCOLLECTION,
-            studentUid
+            responseDocKey
           );
           const existingSnap = await getDoc(responseRef);
 
           if (!existingSnap.exists()) {
             const newResponse: VideoActivityResponse = {
-              pin: studentPin,
-              name: studentName,
-              studentUid,
+              studentUid: currentUser.uid,
               joinedAt: Date.now(),
               answers: [],
               completedAt: null,
               score: null,
+              ...(studentPin ? { pin: studentPin } : {}),
               ...(classPeriod ? { classPeriod } : {}),
             };
             await setDoc(responseRef, newResponse);
           }
 
           setSessionId(targetSessionId);
-          setResponseDocId(studentUid);
+          setResponseDocId(responseDocKey);
           setSession(sessionData);
           setJoinStatus('joined');
         } catch (err) {

--- a/hooks/useVideoActivitySession.ts
+++ b/hooks/useVideoActivitySession.ts
@@ -599,12 +599,20 @@ export const useVideoActivitySessionStudent =
           const existingSnap = await getDoc(responseRef);
 
           if (!existingSnap.exists()) {
+            // Initialize `completedAttempts` and `tabSwitchWarnings` to 0 so
+            // the Firestore rules' monotonic-growth check on update has a
+            // concrete prior value to compare against (otherwise
+            // `resource.data.completedAttempts` is missing on first write
+            // and `.size()`/comparison would throw). Mirrors the Quiz
+            // create-time initialization.
             const newResponse: VideoActivityResponse = {
               studentUid: currentUser.uid,
               joinedAt: Date.now(),
               answers: [],
               completedAt: null,
               score: null,
+              completedAttempts: 0,
+              tabSwitchWarnings: 0,
               ...(studentPin ? { pin: studentPin } : {}),
               ...(classPeriod ? { classPeriod } : {}),
             };
@@ -616,10 +624,9 @@ export const useVideoActivitySessionStudent =
           setSession(sessionData);
           setJoinStatus('joined');
         } catch (err) {
-          console.error(
-            '[useVideoActivitySessionStudent] joinSession error:',
-            err
-          );
+          logError('useVideoActivitySessionStudent.joinSession', err, {
+            sessionId: targetSessionId,
+          });
           setJoinStatus('error');
           setError('Failed to join the session. Please try again.');
         }

--- a/tests/e2e/sharing.spec.ts
+++ b/tests/e2e/sharing.spec.ts
@@ -2,7 +2,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-call */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
-/* eslint-disable @typescript-eslint/require-await */
+
 import { test, expect } from '@playwright/test';
 
 test.describe('Board Sharing', () => {
@@ -72,20 +72,41 @@ test.describe('Board Sharing', () => {
     // Force click to ensure it registers even if there are layout shifts
     await shareButton.click({ force: true });
 
-    await expect(page.getByText(/Link copied/i)).toBeVisible({
+    // Share now opens `ShareLinkCreatorModal` (host picks a mode, then
+    // clicks "Create link"). Wait for the modal then click through.
+    await expect(
+      page.getByRole('heading', { name: 'Share board' })
+    ).toBeVisible({
       timeout: 15000,
     });
+    // The default "Synced" mode is fine for this test — no need to click a
+    // mode option first.
+    await page.getByRole('button', { name: /create link/i }).click();
 
-    // If clipboard text is still empty, fall back to assuming success if toast appeared
+    // The result panel shows the URL in an input (aria-label "Share link
+    // URL"). Wait for it to appear — this is the success signal that
+    // replaces the legacy "Link copied" toast.
+    const shareUrlInput = page.getByLabel('Share link URL');
+    await expect(shareUrlInput).toBeVisible({ timeout: 15000 });
+
+    // The modal auto-copies on Create; if the clipboard mock didn't catch
+    // it, fall back to reading the URL straight out of the input. Either
+    // way the toast-based assertion is gone — the visible URL panel is
+    // proof of success.
+    if (!clipboardText) {
+      const inputValue = await shareUrlInput.inputValue();
+      if (inputValue.includes('/share/')) {
+        clipboardText = inputValue;
+      }
+    }
+
     if (!clipboardText) {
       // eslint-disable-next-line no-console
       console.log(
-        'Clipboard mock empty, skipping specific URL check but verify toast appeared.'
+        'Clipboard mock empty and URL input empty — skipping specific URL check.'
       );
     } else {
-      await expect(async () => {
-        expect(clipboardText).toContain('/share/');
-      }).toPass({ timeout: 15000 });
+      expect(clipboardText).toContain('/share/');
     }
 
     // If we have a URL, test visiting it. If not (clipboard mock fail), skip the visit part to avoid failing the whole suite on a flake

--- a/tests/e2e/sharing.spec.ts
+++ b/tests/e2e/sharing.spec.ts
@@ -100,38 +100,44 @@ test.describe('Board Sharing', () => {
     }
     expect(clipboardText).toContain('/share/');
 
-    // If we have a URL, test visiting it. If not (clipboard mock fail), skip the visit part to avoid failing the whole suite on a flake
-    if (clipboardText && clipboardText.includes('/share/')) {
-      const shareUrl = clipboardText;
-      // eslint-disable-next-line no-console
-      console.log('Share URL:', shareUrl);
+    // Visit the share URL. The recipient flow is the new
+    // `ImportShareModePicker` in confirmation mode (the host already
+    // chose "synced" by default in `ShareLinkCreatorModal`), so the
+    // dialog shows heading "Import shared board" and a single primary
+    // action button labelled "Import synced board" — not the legacy
+    // 3-option picker.
+    const shareUrl = clipboardText;
+    // eslint-disable-next-line no-console
+    console.log('Share URL:', shareUrl);
 
-      await page.goto(shareUrl);
+    await page.goto(shareUrl);
 
-      await expect(page.getByText('Import Board')).toBeVisible();
-      await expect(page.getByText('Loading shared board...')).not.toBeVisible();
+    const importHeading = page.getByRole('heading', {
+      name: 'Import shared board',
+    });
+    await expect(importHeading).toBeVisible({ timeout: 15000 });
 
-      await page.getByRole('button', { name: 'Add Board' }).click();
+    // Default host mode is "synced" → button text is "Import synced board".
+    await page.getByRole('button', { name: /import synced board/i }).click();
 
-      await expect(page.getByText('Import Board')).not.toBeVisible();
+    // Modal dismisses on import success.
+    await expect(importHeading).not.toBeVisible();
 
-      await page.getByTitle('Open Menu').click();
-      // Use a specific locator for the Sidebar Boards button
-      await page
-        .locator('nav button')
-        .filter({ hasText: /Boards/i })
-        .click();
+    await page.getByTitle('Open Menu').click();
+    await page
+      .locator('nav button')
+      .filter({ hasText: /Boards/i })
+      .click();
 
-      // Use a more generic locator for the imported board if specific text fails
-      await expect(
-        page
-          .locator('.group.relative')
-          .filter({ hasText: /Imported:/ })
-          .first()
-      ).toBeVisible();
-    } else {
-      // eslint-disable-next-line no-console
-      console.log('Skipping import test steps due to missing clipboard URL.');
-    }
+    // The imported board's name carries a " (Synced)" suffix (see
+    // `importSharedBoard` in DashboardContext.tsx). Use the suffix as
+    // the locator so the assertion doesn't depend on the source board's
+    // name.
+    await expect(
+      page
+        .locator('.group.relative')
+        .filter({ hasText: /\(Synced\)/ })
+        .first()
+    ).toBeVisible({ timeout: 15000 });
   });
 });

--- a/tests/e2e/sharing.spec.ts
+++ b/tests/e2e/sharing.spec.ts
@@ -84,30 +84,21 @@ test.describe('Board Sharing', () => {
     await page.getByRole('button', { name: /create link/i }).click();
 
     // The result panel shows the URL in an input (aria-label "Share link
-    // URL"). Wait for it to appear — this is the success signal that
-    // replaces the legacy "Link copied" toast.
+    // URL"). Wait for it to appear AND validate the URL shape directly on
+    // the input — the input's value is the source of truth and works even
+    // when the clipboard mock fails to capture the auto-copy. This
+    // replaces the legacy "Link copied" toast assertion.
     const shareUrlInput = page.getByLabel('Share link URL');
     await expect(shareUrlInput).toBeVisible({ timeout: 15000 });
+    await expect(shareUrlInput).toHaveValue(/\/share\//, { timeout: 15000 });
 
-    // The modal auto-copies on Create; if the clipboard mock didn't catch
-    // it, fall back to reading the URL straight out of the input. Either
-    // way the toast-based assertion is gone — the visible URL panel is
-    // proof of success.
+    // Prefer the clipboard-mock value when present (covers the auto-copy
+    // path); fall back to reading the input directly so the import
+    // roundtrip below always has a URL to navigate to.
     if (!clipboardText) {
-      const inputValue = await shareUrlInput.inputValue();
-      if (inputValue.includes('/share/')) {
-        clipboardText = inputValue;
-      }
+      clipboardText = await shareUrlInput.inputValue();
     }
-
-    if (!clipboardText) {
-      // eslint-disable-next-line no-console
-      console.log(
-        'Clipboard mock empty and URL input empty — skipping specific URL check.'
-      );
-    } else {
-      expect(clipboardText).toContain('/share/');
-    }
+    expect(clipboardText).toContain('/share/');
 
     // If we have a URL, test visiting it. If not (clipboard mock fail), skip the visit part to avoid failing the whole suite on a flake
     if (clipboardText && clipboardText.includes('/share/')) {

--- a/tests/rules/assignmentModes.test.ts
+++ b/tests/rules/assignmentModes.test.ts
@@ -250,15 +250,25 @@ describe('Video Activity responses — view-only mode blocks submissions', () =>
     });
   });
 
-  it("denies response create when mode === 'view-only'", async () => {
-    const path = `video_activity_sessions/${sessionId}/responses/${STUDENT_UID}`;
+  it("denies anonymous PIN response create when mode === 'view-only'", async () => {
+    // Mirrors the Quiz pattern: anon joiners write under
+    // `pin-{period}-{pin}` keys. Using STUDENT_UID directly would now be
+    // denied by the doc-id-shape regex before the view-only gate fires;
+    // we want to prove the view-only mode gate is what blocks the write,
+    // so the key is well-formed.
+    const responseKey = `pin-period_1-01`;
+    const path = `video_activity_sessions/${sessionId}/responses/${responseKey}`;
     await assertFails(
       setDoc(doc(asStudent(), path), {
         studentUid: STUDENT_UID,
+        pin: '01',
+        classPeriod: 'period_1',
         score: null,
         completedAt: null,
         answers: [],
         joinedAt: 1000,
+        completedAttempts: 0,
+        tabSwitchWarnings: 0,
       })
     );
   });

--- a/tests/rules/studentRoleClassGate.test.ts
+++ b/tests/rules/studentRoleClassGate.test.ts
@@ -610,18 +610,27 @@ describe('video_activity_sessions/responses — student-role gate', () => {
     );
   });
 
-  it('anonymous PIN student can create response without studentRole restriction', async () => {
+  it('anonymous PIN student can create response under pin-{period}-{pin} key', async () => {
+    // Anonymous joiners write under deterministic `pin-{period}-{pin}` keys
+    // (mirrors `computeResponseKey` / `encodeResponseKeySegment` on the
+    // client). The rules require this exact shape via regex; using
+    // `auth.uid` as the doc key would now be denied for anon callers.
+    const period = 'period_1';
+    const pin = '5678';
+    const responseKey = `pin-${period}-${pin}`;
     await assertSucceeds(
       setDoc(
-        doc(asAnonStudent(), `${col}/${SESSION_A}/responses/${ANON_UID}`),
+        doc(asAnonStudent(), `${col}/${SESSION_A}/responses/${responseKey}`),
         {
           studentUid: ANON_UID,
-          pin: '5678',
-          name: 'Anon',
+          pin,
+          classPeriod: period,
           joinedAt: 2000,
           score: null,
           completedAt: null,
           answers: [],
+          completedAttempts: 0,
+          tabSwitchWarnings: 0,
         }
       )
     );

--- a/tests/rules/studentRoleClassGate.test.ts
+++ b/tests/rules/studentRoleClassGate.test.ts
@@ -32,6 +32,7 @@ import {
   addDoc,
   collection,
   deleteDoc,
+  updateDoc,
   doc,
   query,
   where,
@@ -633,6 +634,101 @@ describe('video_activity_sessions/responses — student-role gate', () => {
           tabSwitchWarnings: 0,
         }
       )
+    );
+  });
+
+  it('anonymous PIN student cannot create response under arbitrary key shape', async () => {
+    // Locks in the doc-id-shape regex: anonymous joiners must use the
+    // `^pin-[a-z0-9_]{1,64}-[a-z0-9_]{1,64}$` scheme. Writing under a
+    // bare uid (the pre-PR1 keying) or any other arbitrary id is denied
+    // even when the studentUid field is correct — closes the cross-auth
+    // grief-create vector.
+    await assertFails(
+      setDoc(
+        doc(asAnonStudent(), `${col}/${SESSION_A}/responses/${ANON_UID}`),
+        {
+          studentUid: ANON_UID,
+          pin: '5678',
+          classPeriod: 'period_1',
+          joinedAt: 2000,
+          score: null,
+          completedAt: null,
+          answers: [],
+          completedAttempts: 0,
+          tabSwitchWarnings: 0,
+        }
+      )
+    );
+  });
+
+  it('studentRole user cannot create response under pin-scheme key', async () => {
+    // SSO `studentRole` joiners must write under their auth.uid (the
+    // stable identity). Routing through a `pin-*` key is denied even
+    // when the studentUid field matches — same cross-auth defense.
+    const responseKey = 'pin-period_1-9999';
+    await assertFails(
+      setDoc(
+        doc(asStudentA(), `${col}/${SESSION_A}/responses/${responseKey}`),
+        {
+          studentUid: STUDENT_A_UID,
+          pin: '9999',
+          classPeriod: 'period_1',
+          joinedAt: 2000,
+          score: null,
+          completedAt: null,
+          answers: [],
+          completedAttempts: 0,
+          tabSwitchWarnings: 0,
+        }
+      )
+    );
+  });
+
+  it('student cannot decrement completedAttempts on update', async () => {
+    // Locks in the monotonic-growth check on `completedAttempts`.
+    // Without it, a student could reset their attempt counter to 0 and
+    // bypass the assignment's `attemptLimit` cap.
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      await setDoc(doc(ctx.firestore(), respPath(SESSION_A)), {
+        studentUid: STUDENT_A_UID,
+        pin: '9999',
+        name: 'Student A',
+        joinedAt: 1000,
+        score: null,
+        completedAt: null,
+        answers: [],
+        completedAttempts: 2,
+        tabSwitchWarnings: 0,
+      });
+    });
+    await assertFails(
+      updateDoc(doc(asStudentA(), respPath(SESSION_A)), {
+        completedAttempts: 1,
+      })
+    );
+  });
+
+  it('student cannot decrement tabSwitchWarnings on update', async () => {
+    // Locks in the monotonic-growth check on `tabSwitchWarnings`.
+    // Without it, a student could clear their tab-switch history before
+    // the teacher reviews results.
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      await setDoc(doc(ctx.firestore(), respPath(SESSION_A)), {
+        studentUid: STUDENT_A_UID,
+        pin: '9999',
+        name: 'Student A',
+        joinedAt: 1000,
+        score: null,
+        completedAt: null,
+        answers: [],
+        completedAttempts: 0,
+        tabSwitchWarnings: 3,
+      });
+    });
+    await assertFails(
+      updateDoc(doc(asStudentA(), respPath(SESSION_A)), {
+        tabSwitchWarnings: 1,
+      })
     );
   });
 });

--- a/types.ts
+++ b/types.ts
@@ -1893,34 +1893,42 @@ export interface QuizMetadata {
 export type QuizSessionStatus = 'waiting' | 'active' | 'paused' | 'ended';
 export type QuizSessionMode = 'teacher' | 'auto' | 'student';
 
-/** Options passed from the assignment modal to configure session toggles. */
-export interface QuizSessionOptions {
+/**
+ * Common session-level toggles applicable to any assignment widget that
+ * mirrors the Quiz pattern (Quiz, Video Activity, future GuidedLearning).
+ * Keep this surface small — only fields with the same semantics across
+ * widgets belong here. Widget-specific knobs go on the per-widget
+ * extension type.
+ */
+export interface BaseSessionOptions {
   tabWarningsEnabled?: boolean;
   showResultToStudent?: boolean;
   showCorrectAnswerToStudent?: boolean;
   showCorrectOnBoard?: boolean;
-  speedBonusEnabled?: boolean;
-  streakBonusEnabled?: boolean;
-  showPodiumBetweenQuestions?: boolean;
-  soundEffectsEnabled?: boolean;
   /**
    * Randomize the order of questions per student per attempt. When on, every
    * student in the class sees questions in their own order, and each retake
-   * by the same student gets a fresh order too. Self-paced mode only —
-   * teacher-paced/auto sessions ignore this toggle (the teacher's
-   * `currentQuestionIndex` is the canonical pointer).
+   * by the same student gets a fresh order too. (Self-paced quiz only —
+   * teacher-paced/auto sessions ignore this toggle.)
    */
   shuffleQuestions?: boolean;
   /**
    * Randomize the order of answer options (MC choices, Matching right side,
    * Ordering items) per student per attempt. Independent of the always-on
-   * teacher-client shuffle in `toPublicQuestion` (run once at session-create
-   * time so the answer-key offset isn't deterministic in the Firestore doc);
-   * this toggle controls the second per-student shuffle that runs in the
-   * student client. Default (when the field is absent on legacy/in-flight
-   * sessions) is treated as ON to preserve pre-toggle behavior.
+   * teacher-client shuffle in `toPublicQuestion`; this toggle controls the
+   * second per-student shuffle that runs in the student client. Default
+   * (when the field is absent on legacy/in-flight sessions) is treated as
+   * ON to preserve pre-toggle behavior.
    */
   shuffleAnswerOptions?: boolean;
+}
+
+/** Options passed from the quiz assignment modal to configure session toggles. */
+export interface QuizSessionOptions extends BaseSessionOptions {
+  speedBonusEnabled?: boolean;
+  streakBonusEnabled?: boolean;
+  showPodiumBetweenQuestions?: boolean;
+  soundEffectsEnabled?: boolean;
 }
 
 /**
@@ -2603,10 +2611,51 @@ export interface VideoActivityConfig {
   lastRosterIdsByActivityId?: Record<string, string[]>;
 }
 
+/**
+ * Player-behavior controls that the student-side VideoPlayer reads directly.
+ * Captured at assignment-create time and mirrored onto the session doc so the
+ * student client can enforce them without a teacher round-trip.
+ */
 export interface VideoActivitySessionSettings {
   autoPlay: boolean;
+  /**
+   * Legacy "rewind to section start on incorrect answer" flag. New code
+   * prefers `VideoActivitySessionOptions.rewindOnIncorrectSeconds`. When that
+   * field is absent, `requireCorrectAnswer === true` is interpreted as
+   * "rewind to the previous question's timestamp" (the historical behavior).
+   */
   requireCorrectAnswer: boolean;
   allowSkipping: boolean;
+}
+
+/**
+ * Score-visibility levels mirroring `QuizAssignment.scoreVisibility`. Controls
+ * what the student sees on the post-completion screen.
+ */
+export type VideoActivityScoreVisibility =
+  | 'none'
+  | 'score_only'
+  | 'score_and_responses'
+  | 'score_responses_and_answers';
+
+/**
+ * Assignment-policy options for a Video Activity session. Distinct from
+ * `VideoActivitySessionSettings` (player behavior) — these are the
+ * security/feedback/scoring knobs that mirror the Quiz toggle group.
+ */
+export interface VideoActivitySessionOptions extends BaseSessionOptions {
+  /** Hard cap on the number of attempts per question. null/undefined = unlimited. */
+  attemptLimit?: number | null;
+  /**
+   * Seconds to rewind on a wrong submission. 0 / undefined = no rewind. When
+   * set and > 0, supersedes the legacy `requireCorrectAnswer` rewind-to-
+   * section-start behavior.
+   */
+  rewindOnIncorrectSeconds?: number;
+  /** Points to deduct per incorrect submission. 0 / undefined = no penalty. */
+  pointPenaltyOnIncorrect?: number;
+  /** Controls how much of the result the student sees post-completion. */
+  scoreVisibility?: VideoActivityScoreVisibility;
 }
 
 export interface GlobalVideoActivity extends VideoActivityMetadata {
@@ -2632,8 +2681,13 @@ export interface VideoActivitySession {
   youtubeUrl: string;
   /** Full questions including correctAnswer — used server-side for grading. */
   questions: VideoActivityQuestion[];
-  /** Session-level behavior controls configured at assignment time. */
+  /** Session-level player-behavior controls configured at assignment time. */
   settings?: VideoActivitySessionSettings;
+  /**
+   * Assignment-policy options (security, feedback, attempt limits, scoring).
+   * Mirrors QuizSession.sessionOptions. Absent on pre-PR1 sessions.
+   */
+  sessionOptions?: VideoActivitySessionOptions;
   status: 'active' | 'ended';
   /**
    * Roster PINs allowed to join. Teacher sets this when assigning to a class.
@@ -2671,6 +2725,12 @@ export interface VideoActivitySession {
    */
   rosterIds?: string[];
   /**
+   * Optional map of ClassLink `classId` → period name. Lets the SSO join
+   * path resolve the joining student's period without prompting them.
+   * Mirrors `QuizSession.classPeriodByClassId`.
+   */
+  classPeriodByClassId?: Record<string, string>;
+  /**
    * Frozen at creation from the org-wide `assignment-modes` admin setting.
    * Determines whether students see a tracked Share link (`'view-only'`) or
    * the full assignment experience (`'submissions'`). Absent on pre-feature
@@ -2691,12 +2751,27 @@ export interface VideoActivityAnswer {
 
 /**
  * Per-student response document in Firestore.
- * Stored at /video_activity_sessions/{sessionId}/responses/{studentUid}
- * The document ID is the student's Firebase auth UID (prevents PIN-claiming attacks).
+ *
+ * Document ID format mirrors the Quiz pattern:
+ *   - SSO students:         {auth.uid}            (stable identity)
+ *   - Anonymous PIN joiners: pin-{period}-{pin}    (deterministic, period-scoped)
+ *
+ * The deterministic anon key prevents two students with the same PIN in
+ * different periods from colliding, and lets the response doc be addressed
+ * server-side without prior knowledge of the auth UID.
+ *
+ * Stored at /video_activity_sessions/{sessionId}/responses/{responseKey}
  */
 export interface VideoActivityResponse {
-  pin: string;
-  name: string;
+  /** Roster PIN — present for anonymous joiners, absent on SSO joiners. */
+  pin?: string;
+  /**
+   * Self-typed name. Optional from PR1 onward — the student app no longer
+   * collects a name. Pre-PR1 archived responses still carry one; the Results
+   * UI prefers `useAssignmentPseudonyms` for display so legacy values remain
+   * harmless.
+   */
+  name?: string;
   /** Firebase auth UID of the student who created this response. Used for Firestore ownership rules. */
   studentUid: string;
   joinedAt: number;
@@ -2705,6 +2780,21 @@ export interface VideoActivityResponse {
   score: number | null;
   /** Which class period the student selected when joining (multi-class support). */
   classPeriod?: string;
+  /** Count of tab/focus losses while the activity is in progress. */
+  tabSwitchWarnings?: number;
+  /**
+   * Timestamps of completed attempts on each question. Used to enforce
+   * `VideoActivitySessionOptions.attemptLimit`. The array is appended to on
+   * every submission (correct or incorrect).
+   */
+  completedAttempts?: number[];
+  /** Final correctness flag, set when scores are published. */
+  isCorrect?: boolean;
+  /**
+   * Server-published score visibility for the response. Set when the teacher
+   * publishes scores; mirrors `VideoActivityScoreVisibility`.
+   */
+  scoreVisibility?: VideoActivityScoreVisibility;
 }
 
 export interface TalkingToolConfig {
@@ -4601,8 +4691,27 @@ export type VideoActivityAssignmentStatus = 'active' | 'paused' | 'inactive';
 export interface VideoActivityAssignmentSettings {
   /** Free-text label shown in the archive (e.g. "Period 2"). */
   className?: string;
-  /** Session behavior captured at assign time. */
+  /** Player-behavior toggles captured at assign time (autoPlay, etc.). */
   sessionSettings: VideoActivitySessionSettings;
+  /**
+   * Assignment-policy options (security, feedback, scoring). Mirrors
+   * `QuizAssignmentSettings.sessionOptions`. Optional so legacy assignments
+   * persist without these knobs; consumers default missing fields safely.
+   */
+  sessionOptions?: VideoActivitySessionOptions;
+  /**
+   * Score visibility level chosen by the teacher. Authoritative for what the
+   * student sees on the post-completion screen.
+   */
+  scoreVisibility?: VideoActivityScoreVisibility;
+  /** Server-set timestamp for when scores were published (publishScoresModal). */
+  scorePublishedAt?: number;
+  /**
+   * Per-roster period name(s) the assignment targets. Mirrors
+   * `QuizAssignment.periodNames` — populated at create time from the
+   * roster picker so the student-app post-PIN picker has stable labels.
+   */
+  periodNames?: string[];
 }
 
 /**

--- a/types.ts
+++ b/types.ts
@@ -1895,10 +1895,11 @@ export type QuizSessionMode = 'teacher' | 'auto' | 'student';
 
 /**
  * Common session-level toggles applicable to any assignment widget that
- * mirrors the Quiz pattern (Quiz, Video Activity, future GuidedLearning).
- * Keep this surface small — only fields with the same semantics across
- * widgets belong here. Widget-specific knobs go on the per-widget
- * extension type.
+ * mirrors the Quiz pattern. Currently extended by `QuizSessionOptions`
+ * and `VideoActivitySessionOptions`; other widgets may opt in by
+ * extending too. Keep this surface small — only fields with the same
+ * semantics across widgets belong here; widget-specific knobs go on the
+ * per-widget extension type.
  */
 export interface BaseSessionOptions {
   tabWarningsEnabled?: boolean;
@@ -2644,7 +2645,12 @@ export type VideoActivityScoreVisibility =
  * security/feedback/scoring knobs that mirror the Quiz toggle group.
  */
 export interface VideoActivitySessionOptions extends BaseSessionOptions {
-  /** Hard cap on the number of attempts per question. null/undefined = unlimited. */
+  /**
+   * Hard cap on the number of times the student may attempt the activity
+   * (one increment per `completedAttempts` bump). null/undefined = unlimited.
+   * Compared against `VideoActivityResponse.completedAttempts`, which is a
+   * single counter — not per-question.
+   */
   attemptLimit?: number | null;
   /**
    * Seconds to rewind on a wrong submission. 0 / undefined = no rewind. When
@@ -2790,7 +2796,14 @@ export interface VideoActivityResponse {
    * `QuizResponse.completedAttempts`.
    */
   completedAttempts?: number;
-  /** Final correctness flag, set when scores are published. */
+  /**
+   * Per-attempt correctness flag, set by the teacher-side score-publish
+   * flow. **Semantics for VA are intentionally left to the publisher in
+   * PR1b** — the publish UI will choose between "all questions correct"
+   * vs "score >= threshold" and write the resulting boolean here. Until
+   * then this field is always absent on VA responses; UI consumers must
+   * tolerate `undefined`. Mirrors `QuizResponse.isCorrect`.
+   */
   isCorrect?: boolean;
   /**
    * Server-published score visibility for the response. Set when the teacher

--- a/types.ts
+++ b/types.ts
@@ -2780,14 +2780,16 @@ export interface VideoActivityResponse {
   score: number | null;
   /** Which class period the student selected when joining (multi-class support). */
   classPeriod?: string;
-  /** Count of tab/focus losses while the activity is in progress. */
+  /** Count of tab/focus losses while the activity is in progress. Append-only at the rules layer. */
   tabSwitchWarnings?: number;
   /**
-   * Timestamps of completed attempts on each question. Used to enforce
-   * `VideoActivitySessionOptions.attemptLimit`. The array is appended to on
-   * every submission (correct or incorrect).
+   * Number of completed activity attempts. Used to enforce
+   * `VideoActivitySessionOptions.attemptLimit`. Initialized to 0 at create
+   * time and incremented on each completion. Append-only at the rules layer
+   * (a student can only write a value `>=` the existing one). Mirrors
+   * `QuizResponse.completedAttempts`.
    */
-  completedAttempts?: number[];
+  completedAttempts?: number;
   /** Final correctness flag, set when scores are published. */
   isCorrect?: boolean;
   /**


### PR DESCRIPTION
## Summary

Bring Video Activity student-experience to parity with the Quiz widget.

- **SSO students** auto-join with no PIN, no period picker, no name input — identified by their `studentRole` custom-token UID, period resolved from `session.classPeriodByClassId`.
- **Anonymous students** enter PIN + period only (the name field is gone). Response docs are now keyed `pin-{period}-{pin}` so the same PIN in different periods stays distinct and attempt limits will survive a device wipe.
- **Foundation for the assignment-options follow-up (PR1b):** `BaseSessionOptions` is extracted from `QuizSessionOptions`, and a new `VideoActivitySessionOptions` shape carries the VA-specific knobs (`rewindOnIncorrectSeconds`, `pointPenaltyOnIncorrect`, `attemptLimit`, `scoreVisibility`). All additions are optional and not yet consumed by UI.

## Why this PR is split from the original PR1 plan

The approved plan called for one PR1 covering both student-experience parity AND the full assignment-options UI surface. After exploring the surface area, I split it: this PR1a is the student-experience half (security-critical, touches Firestore rules + response keying); PR1b will land the new `AssignmentSettingsToggleGroup` shared primitive, the VA `extraSlot` rewrite, and `useVideoActivityAssignments` extension. The type additions in this PR sit dormant until PR1b consumes them.

## Migration note

In-flight VA sessions at deploy time lose progress on first student visit (the new key won't match the old `studentUid`-keyed doc). Assignment + session docs survive. Pre-PR1 archived responses retain their `name` field; Results UI already uses `useAssignmentPseudonyms` for display, so the orphaned field is harmless.

After merge to `main`, `firebase deploy --only firestore:rules` ships the new response-doc rules.

## Test plan

- [x] `pnpm run type-check` clean
- [x] `pnpm run lint` — zero new errors/warnings (pre-existing `remotion/` errors and 2 pre-existing nullish-coalescing warnings in `Results.tsx:512` + `VideoActivityLiveMonitor.tsx:118` unchanged)
- [x] `pnpm run format:check` — only pre-existing untracked `remotion/` files flagged
- [x] `pnpm run test` — all 2046 unit tests pass (regression-free)
- [ ] Manual: SSO student opens an `/activity/:sessionId` link → auto-joins without prompts
- [ ] Manual: anonymous student → enters PIN, picks period from list, joins (no name prompt)
- [ ] Manual: same PIN in two periods → two distinct response docs
- [ ] Manual: existing Quiz flow unchanged (Quiz `joinQuizSession` and `QuizStudentApp` untouched)

## Follow-up — PR1b

- Build new `components/common/library/AssignmentSettingsToggleGroup.tsx` (shared primitive)
- Replace VA `AssignModal` extraSlot with the toggle group + VA-specific block (rewind, penalty, attempt limit, score visibility)
- Extend `useVideoActivityAssignments.createAssignment` to persist new options on assignment + session docs
- Add tests for new options round-trip

🤖 Generated with [Claude Code](https://claude.com/claude-code)