### PR TITLE
fix(quiz): expose Question Randomization on create + reposition class picker on edit

### DIFF
--- a/components/widgets/QuizWidget/components/QuizAssignmentSettingsModal.tsx
+++ b/components/widgets/QuizWidget/components/QuizAssignmentSettingsModal.tsx
@@ -237,89 +237,7 @@ export const QuizAssignmentSettingsModal: React.FC<
       confirmLabel="Save"
       onAssign={handleAssign}
       extraSlot={
-        <AssignmentSettingsToggleGroup
-          modeLocked={modeLocked}
-          options={{
-            tabWarningsEnabled: options.tabWarningsEnabled,
-            showResultToStudent: options.showResultToStudent,
-            showCorrectAnswerToStudent: options.showCorrectAnswerToStudent,
-            showCorrectOnBoard: options.showCorrectOnBoard,
-            shuffleQuestions: options.shuffleQuestions,
-            shuffleAnswerOptions: options.shuffleAnswerOptions,
-          }}
-          onOptionsChange={(next) =>
-            // The primitive's internal `update` always emits the full options
-            // object with one field changed, so spreading `next` over `p`
-            // correctly merges without dropping other state. Avoids the
-            // `?? p.X` pattern that's easy to misread as a falsy bug.
-            setOptions((p) => ({ ...p, ...next }))
-          }
-          attemptLimit={options.attemptLimit}
-          onAttemptLimitChange={(v) =>
-            setOptions((p) => ({ ...p, attemptLimit: v }))
-          }
-          trailingSlot={
-            <CollapsibleSection label="Gamification">
-              <ToggleRow
-                compact
-                label="Speed Bonus Points"
-                checked={options.speedBonusEnabled}
-                onChange={(v) =>
-                  setOptions((p) => ({ ...p, speedBonusEnabled: v }))
-                }
-                hint="Up to 50% bonus for fast answers"
-              />
-              <ToggleRow
-                compact
-                label="Streak Bonuses"
-                checked={options.streakBonusEnabled}
-                onChange={(v) =>
-                  setOptions((p) => ({ ...p, streakBonusEnabled: v }))
-                }
-                hint="Multiplier for consecutive correct answers"
-              />
-              <ToggleRow
-                compact
-                label="Podium Between Questions"
-                checked={options.showPodiumBetweenQuestions}
-                onChange={(v) =>
-                  setOptions((p) => ({ ...p, showPodiumBetweenQuestions: v }))
-                }
-                hint="Show top 3 leaderboard after each question"
-              />
-              <ToggleRow
-                compact
-                label="Sound Effects"
-                checked={options.soundEffectsEnabled}
-                onChange={(v) =>
-                  setOptions((p) => ({ ...p, soundEffectsEnabled: v }))
-                }
-                hint="Chimes, ticks, and fanfares during the quiz"
-              />
-            </CollapsibleSection>
-          }
-        />
-      }
-      plcSlot={
         <>
-          <div className="border-t border-slate-200/70 pt-3 flex items-center justify-between">
-            <div className="flex items-center gap-2">
-              <Share2 className="w-4 h-4 text-brand-blue-primary" />
-              <span className="text-sm font-bold text-brand-blue-dark">
-                Share with PLC
-              </span>
-            </div>
-            <Toggle
-              checked={options.plcMode}
-              onChange={(v) => setOptions((p) => ({ ...p, plcMode: v }))}
-              size="sm"
-              showLabels={true}
-            />
-          </div>
-          <p className="text-xxs text-slate-500 -mt-1">
-            Export results to a shared Google Sheet for your PLC team.
-          </p>
-
           <div>
             <label className="block text-xxs font-bold text-slate-400 uppercase tracking-widest mb-1">
               Class Periods
@@ -376,6 +294,93 @@ export const QuizAssignmentSettingsModal: React.FC<
               their class when joining.
             </p>
           </div>
+
+          <AssignmentSettingsToggleGroup
+            modeLocked={modeLocked}
+            options={{
+              tabWarningsEnabled: options.tabWarningsEnabled,
+              showResultToStudent: options.showResultToStudent,
+              showCorrectAnswerToStudent: options.showCorrectAnswerToStudent,
+              showCorrectOnBoard: options.showCorrectOnBoard,
+              shuffleQuestions: options.shuffleQuestions,
+              shuffleAnswerOptions: options.shuffleAnswerOptions,
+            }}
+            onOptionsChange={(next) =>
+              // The primitive's internal `update` always emits the full options
+              // object with one field changed, so spreading `next` over `p`
+              // correctly merges without dropping other state. Avoids the
+              // `?? p.X` pattern that's easy to misread as a falsy bug.
+              setOptions((p) => ({ ...p, ...next }))
+            }
+            attemptLimit={options.attemptLimit}
+            onAttemptLimitChange={(v) =>
+              setOptions((p) => ({ ...p, attemptLimit: v }))
+            }
+            trailingSlot={
+              <CollapsibleSection label="Gamification">
+                <ToggleRow
+                  compact
+                  label="Speed Bonus Points"
+                  checked={options.speedBonusEnabled}
+                  onChange={(v) =>
+                    setOptions((p) => ({ ...p, speedBonusEnabled: v }))
+                  }
+                  hint="Up to 50% bonus for fast answers"
+                />
+                <ToggleRow
+                  compact
+                  label="Streak Bonuses"
+                  checked={options.streakBonusEnabled}
+                  onChange={(v) =>
+                    setOptions((p) => ({ ...p, streakBonusEnabled: v }))
+                  }
+                  hint="Multiplier for consecutive correct answers"
+                />
+                <ToggleRow
+                  compact
+                  label="Podium Between Questions"
+                  checked={options.showPodiumBetweenQuestions}
+                  onChange={(v) =>
+                    setOptions((p) => ({
+                      ...p,
+                      showPodiumBetweenQuestions: v,
+                    }))
+                  }
+                  hint="Show top 3 leaderboard after each question"
+                />
+                <ToggleRow
+                  compact
+                  label="Sound Effects"
+                  checked={options.soundEffectsEnabled}
+                  onChange={(v) =>
+                    setOptions((p) => ({ ...p, soundEffectsEnabled: v }))
+                  }
+                  hint="Chimes, ticks, and fanfares during the quiz"
+                />
+              </CollapsibleSection>
+            }
+          />
+        </>
+      }
+      plcSlot={
+        <>
+          <div className="border-t border-slate-200/70 pt-3 flex items-center justify-between">
+            <div className="flex items-center gap-2">
+              <Share2 className="w-4 h-4 text-brand-blue-primary" />
+              <span className="text-sm font-bold text-brand-blue-dark">
+                Share with PLC
+              </span>
+            </div>
+            <Toggle
+              checked={options.plcMode}
+              onChange={(v) => setOptions((p) => ({ ...p, plcMode: v }))}
+              size="sm"
+              showLabels={true}
+            />
+          </div>
+          <p className="text-xxs text-slate-500 -mt-1">
+            Export results to a shared Google Sheet for your PLC team.
+          </p>
 
           {options.plcMode && (
             <div className="space-y-3 bg-slate-50 rounded-xl p-3 border border-slate-100">

--- a/components/widgets/QuizWidget/components/QuizAssignmentSettingsModal.tsx
+++ b/components/widgets/QuizWidget/components/QuizAssignmentSettingsModal.tsx
@@ -316,6 +316,10 @@ export const QuizAssignmentSettingsModal: React.FC<
             onAttemptLimitChange={(v) =>
               setOptions((p) => ({ ...p, attemptLimit: v }))
             }
+            // Per-student question shuffle only takes effect in self-paced
+            // mode; disable + hint the toggle otherwise so teachers don't
+            // enable a flag that won't fire.
+            shuffleQuestionsAvailable={sessionMode === 'student'}
             trailingSlot={
               <CollapsibleSection label="Gamification">
                 <ToggleRow

--- a/components/widgets/QuizWidget/components/QuizManager.tsx
+++ b/components/widgets/QuizWidget/components/QuizManager.tsx
@@ -135,6 +135,8 @@ interface QuizAssignOptions {
   streakBonusEnabled: boolean;
   showPodiumBetweenQuestions: boolean;
   soundEffectsEnabled: boolean;
+  shuffleQuestions: boolean;
+  shuffleAnswerOptions: boolean;
   /** Max completed submissions per student. null = unlimited. Default 1. */
   attemptLimit: number | null;
   plcMode: boolean;
@@ -191,6 +193,11 @@ function buildDefaultAssignOptions(
     streakBonusEnabled: false,
     showPodiumBetweenQuestions: false,
     soundEffectsEnabled: false,
+    shuffleQuestions: false,
+    // Pre-toggle sessions had the second client-side shuffle always on; keep
+    // the default ON so behavior matches what teachers had before this
+    // toggle was exposed in the create flow.
+    shuffleAnswerOptions: true,
     // Default: one attempt per student. Teachers can switch to 2/3/Unlimited
     // in the assign modal or later in the assignment settings.
     attemptLimit: 1,
@@ -1151,6 +1158,8 @@ export const QuizManager: React.FC<QuizManagerProps> = ({
       streakBonusEnabled: assignOptions.streakBonusEnabled,
       showPodiumBetweenQuestions: assignOptions.showPodiumBetweenQuestions,
       soundEffectsEnabled: assignOptions.soundEffectsEnabled,
+      shuffleQuestions: assignOptions.shuffleQuestions,
+      shuffleAnswerOptions: assignOptions.shuffleAnswerOptions,
     };
     onAssign(
       assignTarget,
@@ -1956,6 +1965,8 @@ const AssignExtraSlot: React.FC<{
           showResultToStudent: options.showResultToStudent,
           showCorrectAnswerToStudent: options.showCorrectAnswerToStudent,
           showCorrectOnBoard: options.showCorrectOnBoard,
+          shuffleQuestions: options.shuffleQuestions,
+          shuffleAnswerOptions: options.shuffleAnswerOptions,
         }}
         onOptionsChange={(next) =>
           // The primitive's `update` always emits the full options object
@@ -1965,7 +1976,6 @@ const AssignExtraSlot: React.FC<{
         }
         attemptLimit={options.attemptLimit}
         onAttemptLimitChange={(v) => update('attemptLimit', v)}
-        excludeSections={['randomization']}
         trailingSlot={
           <CollapsibleSection label="Gamification">
             <ToggleRow

--- a/components/widgets/QuizWidget/components/QuizManager.tsx
+++ b/components/widgets/QuizWidget/components/QuizManager.tsx
@@ -194,9 +194,10 @@ function buildDefaultAssignOptions(
     showPodiumBetweenQuestions: false,
     soundEffectsEnabled: false,
     shuffleQuestions: false,
-    // Pre-toggle sessions had the second client-side shuffle always on; keep
-    // the default ON so behavior matches what teachers had before this
-    // toggle was exposed in the create flow.
+    // Default ON: matches the legacy always-on answer shuffle that
+    // pre-dated this toggle, and mirrors the edit modal's `?? true`
+    // fallback so a new assignment behaves identically to one created
+    // before the toggle was exposed.
     shuffleAnswerOptions: true,
     // Default: one attempt per student. Teachers can switch to 2/3/Unlimited
     // in the assign modal or later in the assignment settings.
@@ -1512,6 +1513,7 @@ export const QuizManager: React.FC<QuizManagerProps> = ({
               options={assignOptions}
               onChange={setAssignOptions}
               rosters={rosters}
+              selectedMode={selectedMode}
             />
           }
           plcSlot={
@@ -1945,7 +1947,8 @@ const AssignExtraSlot: React.FC<{
   options: QuizAssignOptions;
   onChange: (next: QuizAssignOptions) => void;
   rosters: ClassRoster[];
-}> = ({ options, onChange, rosters }) => {
+  selectedMode: QuizSessionMode | null;
+}> = ({ options, onChange, rosters, selectedMode }) => {
   const update = <K extends keyof QuizAssignOptions>(
     key: K,
     value: QuizAssignOptions[K]
@@ -1976,6 +1979,12 @@ const AssignExtraSlot: React.FC<{
         }
         attemptLimit={options.attemptLimit}
         onAttemptLimitChange={(v) => update('attemptLimit', v)}
+        // Per-student question shuffle only takes effect in self-paced mode
+        // (teacher/auto-paced sessions broadcast a single shared question
+        // sequence). Disable the toggle in non-self-paced modes so teachers
+        // don't enable a flag that won't fire — the primitive renders a hint
+        // explaining the gating.
+        shuffleQuestionsAvailable={selectedMode === 'student'}
         trailingSlot={
           <CollapsibleSection label="Gamification">
             <ToggleRow

--- a/docs/quiz-class-picker-followups.md
+++ b/docs/quiz-class-picker-followups.md
@@ -1,0 +1,34 @@
+# Quiz assignment Class Picker follow-ups
+
+Deferred from the PR #1541 review (dev-paul). Not a correctness bug today; surfaced as a UX/data-model parity gap between the assignment-create modal and the edit-in-progress modal. Worth picking up before the next round of changes to either modal.
+
+## 1. Unify Class Periods control across create + edit modals
+
+**Where:**
+
+- `components/widgets/QuizWidget/components/QuizManager.tsx` — `AssignExtraSlot` renders `<AssignClassPicker rosters={rosters} value={options.picker} onChange={…} />` (unified roster picker, multi-select with Select All / Clear All, ClassLink badges, smart filtering of rosters with `loadError`).
+- `components/widgets/QuizWidget/components/QuizAssignmentSettingsModal.tsx` — `extraSlot` renders an inline checkbox list against `options.selectedPeriodNames` (period-name strings), with a comma-separated text-input fallback when `rosters.length === 0`.
+
+**What:** The two modals look and feel different for the same conceptual task. Teachers switching between create and edit see two different pickers (different visuals, different affordances, different data shape). The edit modal also loses the smart roster filtering and the Select-All affordance that the create flow gets for free.
+
+**Fix sketch:** swap the edit modal's inline checkbox block for `<AssignClassPicker>`. Requires hydrating an `AssignClassPickerValue` (roster IDs) from the assignment's stored period names — see follow-up #2 for the cleanest version.
+
+**Trigger to do it:** next non-trivial change to either modal's class-targeting UX, or whenever follow-up #2 lands.
+
+**Origin:** Reviewer 2 major #1 on PR #1541.
+
+## 2. Migrate quiz assignments from `periodNames[]` to `rosterIds[]`
+
+**Where:**
+
+- `types.ts` — `QuizAssignment.periodName` / `QuizAssignment.periodNames` are the source of truth for class targeting on existing assignments.
+- `components/widgets/QuizWidget/components/QuizAssignmentSettingsModal.tsx` — `initialOptionsFor` reads `a.periodNames`; `handleAssign` writes `periodName` + `periodNames` back into the patch.
+- `hooks/useQuizAssignments.ts` — assignment creation persists from the create-modal's roster IDs via `resolveAssignmentTargets`, which dedups period names. The edit modal does not run that resolver — it round-trips the names verbatim.
+
+**What:** The create modal already operates in roster-ID space (the unified picker emits `rosterIds: string[]`); names are derived at write-time. The edit modal stores and round-trips human-readable period names, so renaming a roster or losing a roster ID leaves the assignment's `periodNames` stale with no automatic recovery, and the inline checkbox list has to do its own ad-hoc roster→name matching to recover the selection on open.
+
+**Fix sketch:** add `rosterIds[]` to the assignment shape (alongside `periodNames[]` for back-compat read-time); have the edit modal hydrate the picker from `rosterIds` and re-derive `periodNames` on save via `resolveAssignmentTargets`. Once everything writes both fields, drop the read-side fallback to `periodNames`.
+
+**Trigger to do it:** next time we touch assignment-targeting logic (e.g. PLC sharing changes, ClassLink resync) — easier to land alongside another targeting change than as a standalone migration. Follow-up #1 wants to depend on this.
+
+**Origin:** Reviewer 2 major #2 on PR #1541.


### PR DESCRIPTION
## Summary

Fixes two discrepancies between the quiz **assignment-create** modal and the **edit-in-progress** modal, on top of the new shared `AssignmentSettingsToggleGroup` primitive landed in `dev-paul` (#1540).

### 1. Question Randomization missing on create
The shared toggle-group already renders a "Question Randomization" section, but the create flow (`QuizManager.tsx → AssignExtraSlot`) was passing `excludeSections={['randomization']}` and not threading the shuffle fields through. Result: teachers had no way to set them at assignment creation, and every new assignment used the hardcoded `Widget.tsx` defaults (`shuffleQuestions: false`, `shuffleAnswerOptions: false`).

This PR:
- Adds `shuffleQuestions` and `shuffleAnswerOptions` to `QuizAssignOptions`.
- `buildDefaultAssignOptions()` defaults `shuffleAnswerOptions` to **`true`** so newly created assignments match the edit-modal default and the legacy "always shuffle answer options" behavior; `shuffleQuestions` defaults to `false`.
- Passes both fields into `AssignmentSettingsToggleGroup.options`.
- Removes `excludeSections={['randomization']}` from `AssignExtraSlot`.
- Threads both fields into `sessionOptions` in `handleAssignConfirm()`. Downstream `useQuizAssignments.ts` already reads and persists them.

### 2. Class picker placement on edit
On create, the Class Periods picker sits at the top of `extraSlot` which is intuitive. On edit it was buried inside `plcSlot` next to PLC sharing — confusing and inconsistent. Moved the Class Periods picker out of `plcSlot` and to the top of `extraSlot` so the layout matches the create flow.

## Test plan
- [ ] Create a new quiz assignment → "Question Randomization" section appears with both toggles, defaults match edit modal (Shuffle Questions OFF, Shuffle Answer Options ON)
- [ ] Toggle Shuffle Questions ON, assign → confirm `sessionOptions.shuffleQuestions === true` on the resulting assignment doc
- [ ] Open edit modal on an in-progress assignment → "Class Periods" picker is now the first section under the mode selector (above Quiz Integrity)
- [ ] PLC toggle still works correctly with Class Periods no longer adjacent to it
- [ ] `pnpm run type-check`, `pnpm run lint`, `pnpm run format:check` all pass

https://claude.ai/code/session_01EP5QuGpM2wcyGtZ7J64DzB