### PR TITLE
feat(video-activity): multi-type questions (MC/FIB/MA) with shared grader

### DIFF
--- a/components/videoActivity/QuestionOverlay.tsx
+++ b/components/videoActivity/QuestionOverlay.tsx
@@ -1,19 +1,51 @@
 /**
  * QuestionOverlay — active question card shown over the video player.
+ *
+ * Supports three question types (PR2a):
+ *   - MC  : single-select option list (default for legacy / pre-PR2a questions)
+ *   - FIB : free-text input; accepts canonical answer + optional variants
+ *   - MA  : multi-select checkbox list; submits `selected.sort().join('|')`
+ *
+ * All correctness checks route through `gradeVideoActivityAnswer` so the
+ * three call-sites (this overlay, the post-completion summary, and the
+ * teacher Results view) stay in lock-step. Bypassing the shared grader
+ * silently breaks gradebook ↔ student-display agreement.
  */
 
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { CheckCircle2, XCircle, Clock } from 'lucide-react';
-import { VideoActivityQuestion } from '@/types';
+import type { VideoActivityQuestion } from '@/types';
+import { gradeVideoActivityAnswer } from '@/utils/videoActivityGrading';
 
 interface QuestionOverlayProps {
   question: VideoActivityQuestion;
-  /** Called with selected answer + correctness once feedback is shown. */
+  /** Called with submitted answer + correctness once feedback is shown. */
   onAnswer: (answer: string, isCorrect: boolean) => void;
   /** 1-based index for display */
   questionIndex: number;
   totalQuestions: number;
   requireCorrectAnswer: boolean;
+}
+
+const formatTimestamp = (seconds: number) => {
+  const m = Math.floor(seconds / 60);
+  const s = Math.floor(seconds % 60);
+  return `${m}:${s.toString().padStart(2, '0')}`;
+};
+
+/** Deterministic Fisher–Yates shuffle keyed by the question id. */
+function shuffleByQuestionId<T>(arr: T[], questionId: string): T[] {
+  const out = [...arr];
+  let seed = questionId.split('').reduce((acc, c) => acc + c.charCodeAt(0), 0);
+  const rand = () => {
+    seed = (seed * 1664525 + 1013904223) & 0xffffffff;
+    return (seed >>> 0) / 0x100000000;
+  };
+  for (let i = out.length - 1; i > 0; i--) {
+    const j = Math.floor(rand() * (i + 1));
+    [out[i], out[j]] = [out[j], out[i]];
+  }
+  return out;
 }
 
 export const QuestionOverlay: React.FC<QuestionOverlayProps> = ({
@@ -23,41 +55,84 @@ export const QuestionOverlay: React.FC<QuestionOverlayProps> = ({
   totalQuestions,
   requireCorrectAnswer,
 }) => {
-  const [selected, setSelected] = useState<string | null>(null);
-  const [submitted, setSubmitted] = useState(false);
+  const type = question.type ?? 'MC';
 
-  // Build the shuffled options array once (stable order per render)
-  const options = React.useMemo(() => {
-    const all = [question.correctAnswer, ...question.incorrectAnswers];
-    // Fisher–Yates shuffle with a deterministic seed based on question id
-    // so options don't re-shuffle on re-render
-    const arr = [...all];
-    let seed = question.id
-      .split('')
-      .reduce((acc, c) => acc + c.charCodeAt(0), 0);
-    const rand = () => {
-      seed = (seed * 1664525 + 1013904223) & 0xffffffff;
-      return (seed >>> 0) / 0x100000000;
-    };
-    for (let i = arr.length - 1; i > 0; i--) {
-      const j = Math.floor(rand() * (i + 1));
-      [arr[i], arr[j]] = [arr[j], arr[i]];
+  // ── MC state: single-selected option ───────────────────────────────────────
+  const [mcSelected, setMcSelected] = useState<string | null>(null);
+  // ── FIB state: free-text answer ────────────────────────────────────────────
+  const [fibAnswer, setFibAnswer] = useState('');
+  // ── MA state: set of selected options ──────────────────────────────────────
+  const [maSelected, setMaSelected] = useState<Set<string>>(new Set());
+
+  // Submission lifecycle is shared across types.
+  const [submitted, setSubmitted] = useState(false);
+  const [submittedIsCorrect, setSubmittedIsCorrect] = useState(false);
+
+  // Correct selections for MA, parsed from the |-encoded correctAnswer.
+  const maCorrectSet = useMemo(() => {
+    if (type !== 'MA') return new Set<string>();
+    return new Set(
+      (question.correctAnswer ?? '')
+        .split('|')
+        .map((s) => s.trim())
+        .filter((s) => s.length > 0)
+    );
+  }, [type, question.correctAnswer]);
+
+  // Shuffled option list for MC + MA (FIB has no options).
+  const options = useMemo(() => {
+    if (type === 'MC') {
+      const all = [
+        question.correctAnswer,
+        ...(question.incorrectAnswers ?? []),
+      ];
+      return shuffleByQuestionId(all, question.id);
     }
-    return arr;
-  }, [question]);
+    if (type === 'MA') {
+      const all = [...maCorrectSet, ...(question.incorrectAnswers ?? [])];
+      // Dedupe in case a malformed save has overlap between the two arrays.
+      return shuffleByQuestionId(Array.from(new Set(all)), question.id);
+    }
+    return [];
+  }, [
+    type,
+    question.id,
+    question.correctAnswer,
+    question.incorrectAnswers,
+    maCorrectSet,
+  ]);
+
+  const canSubmit = (() => {
+    if (submitted) return false;
+    if (type === 'MC') return mcSelected !== null;
+    if (type === 'FIB') return fibAnswer.trim().length > 0;
+    if (type === 'MA') return maSelected.size > 0;
+    return false;
+  })();
 
   const handleSubmit = () => {
-    if (!selected || submitted) return;
+    if (!canSubmit) return;
+    let answer = '';
+    if (type === 'MC') answer = mcSelected ?? '';
+    else if (type === 'FIB') answer = fibAnswer.trim();
+    else if (type === 'MA') answer = Array.from(maSelected).sort().join('|');
+
+    const result = gradeVideoActivityAnswer(question, answer);
+    setSubmittedIsCorrect(result.isCorrect);
     setSubmitted(true);
-    const isCorrect = selected === question.correctAnswer;
-    // Brief delay so student sees feedback before overlay closes
-    setTimeout(() => onAnswer(selected, isCorrect), isCorrect ? 800 : 1200);
+    setTimeout(
+      () => onAnswer(answer, result.isCorrect),
+      result.isCorrect ? 800 : 1200
+    );
   };
 
-  const formatTimestamp = (seconds: number) => {
-    const m = Math.floor(seconds / 60);
-    const s = Math.floor(seconds % 60);
-    return `${m}:${s.toString().padStart(2, '0')}`;
+  const toggleMaOption = (option: string) => {
+    setMaSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(option)) next.delete(option);
+      else next.add(option);
+      return next;
+    });
   };
 
   return (
@@ -80,62 +155,145 @@ export const QuestionOverlay: React.FC<QuestionOverlayProps> = ({
         <p className="text-base font-semibold text-slate-800 leading-snug">
           {question.text}
         </p>
+        {type === 'MA' && (
+          <p className="text-xs text-slate-500 mt-1">Select all that apply.</p>
+        )}
       </div>
 
-      {/* Options */}
-      <div className="px-5 pb-5 grid gap-2.5">
-        {options.map((option, i) => {
-          let style =
-            'border-2 border-slate-200 bg-white hover:border-brand-blue-primary hover:bg-brand-blue-lighter/30 text-slate-700';
-
-          if (submitted) {
-            if (option === question.correctAnswer) {
+      {/* Body — type-specific input */}
+      {type === 'MC' && (
+        <div className="px-5 pb-5 grid gap-2.5">
+          {options.map((option, i) => {
+            let style =
+              'border-2 border-slate-200 bg-white hover:border-brand-blue-primary hover:bg-brand-blue-lighter/30 text-slate-700';
+            if (submitted) {
+              if (option === question.correctAnswer) {
+                style =
+                  'border-2 border-emerald-500 bg-emerald-50 text-emerald-800 font-bold';
+              } else if (
+                option === mcSelected &&
+                option !== question.correctAnswer
+              ) {
+                style =
+                  'border-2 border-brand-red-primary bg-brand-red-lighter/30 text-brand-red-dark';
+              } else {
+                style = 'border-2 border-slate-100 bg-slate-50 text-slate-400';
+              }
+            } else if (mcSelected === option) {
               style =
-                'border-2 border-emerald-500 bg-emerald-50 text-emerald-800 font-bold';
-            } else if (
-              option === selected &&
-              option !== question.correctAnswer
-            ) {
-              style =
-                'border-2 border-brand-red-primary bg-brand-red-lighter/30 text-brand-red-dark';
-            } else {
-              style = 'border-2 border-slate-100 bg-slate-50 text-slate-400';
+                'border-2 border-brand-blue-primary bg-brand-blue-lighter/40 text-brand-blue-dark font-semibold';
             }
-          } else if (selected === option) {
-            style =
-              'border-2 border-brand-blue-primary bg-brand-blue-lighter/40 text-brand-blue-dark font-semibold';
-          }
-
-          return (
-            <button
-              key={`${i}-${option}`}
-              disabled={submitted}
-              onClick={() => setSelected(option)}
-              className={`w-full text-left px-4 py-3 rounded-xl text-sm transition-all ${style} flex items-center gap-3`}
-            >
-              <span className="shrink-0 w-6 h-6 rounded-full border-2 border-current flex items-center justify-center text-xs font-bold">
-                {String.fromCharCode(65 + i)}
-              </span>
-              <span className="flex-1">{option}</span>
-              {submitted && option === question.correctAnswer && (
-                <CheckCircle2 className="w-4 h-4 text-emerald-600 shrink-0" />
-              )}
-              {submitted &&
-                option === selected &&
-                option !== question.correctAnswer && (
-                  <XCircle className="w-4 h-4 text-brand-red-primary shrink-0" />
+            return (
+              <button
+                key={`${i}-${option}`}
+                disabled={submitted}
+                onClick={() => setMcSelected(option)}
+                className={`w-full text-left px-4 py-3 rounded-xl text-sm transition-all ${style} flex items-center gap-3`}
+              >
+                <span className="shrink-0 w-6 h-6 rounded-full border-2 border-current flex items-center justify-center text-xs font-bold">
+                  {String.fromCharCode(65 + i)}
+                </span>
+                <span className="flex-1">{option}</span>
+                {submitted && option === question.correctAnswer && (
+                  <CheckCircle2 className="w-4 h-4 text-emerald-600 shrink-0" />
                 )}
-            </button>
-          );
-        })}
-      </div>
+                {submitted &&
+                  option === mcSelected &&
+                  option !== question.correctAnswer && (
+                    <XCircle className="w-4 h-4 text-brand-red-primary shrink-0" />
+                  )}
+              </button>
+            );
+          })}
+        </div>
+      )}
 
-      {/* Submit */}
+      {type === 'FIB' && (
+        <div className="px-5 pb-5">
+          <input
+            type="text"
+            autoFocus
+            disabled={submitted}
+            value={fibAnswer}
+            onChange={(e) => setFibAnswer(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' && canSubmit) handleSubmit();
+            }}
+            placeholder="Type your answer…"
+            className={`w-full px-4 py-3 text-sm rounded-xl border-2 transition-all focus:outline-none ${
+              submitted
+                ? submittedIsCorrect
+                  ? 'border-emerald-500 bg-emerald-50 text-emerald-800 font-bold'
+                  : 'border-brand-red-primary bg-brand-red-lighter/30 text-brand-red-dark'
+                : 'border-slate-200 focus:border-brand-blue-primary text-slate-700'
+            }`}
+          />
+          {submitted && !submittedIsCorrect && (
+            <p className="text-xs text-slate-500 mt-2">
+              Correct answer:{' '}
+              <span className="font-bold text-emerald-700">
+                {question.correctAnswer}
+              </span>
+            </p>
+          )}
+        </div>
+      )}
+
+      {type === 'MA' && (
+        <div className="px-5 pb-5 grid gap-2.5">
+          {options.map((option, i) => {
+            const isChecked = maSelected.has(option);
+            const isCorrectOption = maCorrectSet.has(option);
+            let style =
+              'border-2 border-slate-200 bg-white hover:border-brand-blue-primary hover:bg-brand-blue-lighter/30 text-slate-700';
+            if (submitted) {
+              if (isCorrectOption && isChecked) {
+                style =
+                  'border-2 border-emerald-500 bg-emerald-50 text-emerald-800 font-bold';
+              } else if (isCorrectOption && !isChecked) {
+                // Missed-correct: highlight subtly so students see what they missed.
+                style =
+                  'border-2 border-emerald-300 bg-emerald-50/60 text-emerald-700';
+              } else if (!isCorrectOption && isChecked) {
+                style =
+                  'border-2 border-brand-red-primary bg-brand-red-lighter/30 text-brand-red-dark';
+              } else {
+                style = 'border-2 border-slate-100 bg-slate-50 text-slate-400';
+              }
+            } else if (isChecked) {
+              style =
+                'border-2 border-brand-blue-primary bg-brand-blue-lighter/40 text-brand-blue-dark font-semibold';
+            }
+            return (
+              <button
+                key={`${i}-${option}`}
+                type="button"
+                disabled={submitted}
+                onClick={() => toggleMaOption(option)}
+                className={`w-full text-left px-4 py-3 rounded-xl text-sm transition-all ${style} flex items-center gap-3`}
+              >
+                <span
+                  className={`shrink-0 w-6 h-6 rounded-md border-2 flex items-center justify-center text-xs font-bold ${
+                    isChecked
+                      ? 'bg-current text-white'
+                      : 'border-current bg-transparent'
+                  }`}
+                >
+                  {isChecked && <CheckCircle2 className="w-3.5 h-3.5" />}
+                </span>
+                <span className="flex-1">{option}</span>
+              </button>
+            );
+          })}
+        </div>
+      )}
+
+      {/* Submit button */}
       {!submitted && (
         <div className="px-5 pb-5">
           <button
             onClick={handleSubmit}
-            disabled={!selected}
+            disabled={!canSubmit}
             className="w-full bg-brand-blue-primary hover:bg-brand-blue-dark disabled:bg-slate-200 disabled:text-slate-400 text-white font-bold rounded-xl py-3 text-sm transition-all active:scale-95 shadow-sm"
           >
             Submit Answer
@@ -147,12 +305,12 @@ export const QuestionOverlay: React.FC<QuestionOverlayProps> = ({
         <div className="px-5 pb-5">
           <div
             className={`text-center text-sm font-bold py-2 rounded-xl ${
-              selected === question.correctAnswer
+              submittedIsCorrect
                 ? 'bg-emerald-100 text-emerald-700'
                 : 'bg-brand-red-lighter/40 text-brand-red-dark'
             }`}
           >
-            {selected === question.correctAnswer
+            {submittedIsCorrect
               ? '✓ Correct! Resuming video…'
               : requireCorrectAnswer
                 ? '✗ Incorrect. Rewinding section…'

--- a/components/videoActivity/VideoActivityStudentApp.tsx
+++ b/components/videoActivity/VideoActivityStudentApp.tsx
@@ -28,6 +28,7 @@ import { auth, db } from '@/config/firebase';
 import { logError } from '@/utils/logError';
 import { useVideoActivitySessionStudent } from '@/hooks/useVideoActivitySession';
 import { VideoActivityQuestion, VideoActivitySession } from '@/types';
+import { gradeVideoActivityAnswer } from '@/utils/videoActivityGrading';
 import { VideoPlayer } from './VideoPlayer';
 import { QuestionOverlay } from './QuestionOverlay';
 
@@ -515,14 +516,14 @@ const JoinAndPlay: React.FC<JoinAndPlayProps> = ({
   if (videoEnded || myResponse?.completedAt) {
     const answeredCount = myResponse?.answers.length ?? 0;
     const totalQuestions = session?.questions.length ?? 0;
-    // Derive correctness from authoritative session data rather than the stored
-    // isCorrect field, which is no longer written by the client.
+    // Derive correctness via the shared grader so MA / FIB-variants /
+    // partial-credit semantics line up with the teacher Results view and
+    // the in-flight QuestionOverlay submit path.
     const correct =
-      session?.questions.filter((q) =>
-        myResponse?.answers.some(
-          (a) => a.questionId === q.id && a.answer === q.correctAnswer
-        )
-      ).length ?? 0;
+      session?.questions.filter((q) => {
+        const a = myResponse?.answers.find((x) => x.questionId === q.id);
+        return a ? gradeVideoActivityAnswer(q, a.answer).isCorrect : false;
+      }).length ?? 0;
 
     return (
       <div className="min-h-screen bg-slate-900 flex flex-col items-center justify-center p-4">

--- a/components/widgets/VideoActivityWidget/components/Results.tsx
+++ b/components/widgets/VideoActivityWidget/components/Results.tsx
@@ -20,6 +20,10 @@ import { VideoActivityResponse, VideoActivitySession } from '@/types';
 import { useAuth } from '@/context/useAuth';
 import { QuizDriveService } from '@/utils/quizDriveService';
 import {
+  gradeVideoActivityAnswer,
+  computeVideoActivityScorePct,
+} from '@/utils/videoActivityGrading';
+import {
   useAssignmentPseudonymsMulti,
   formatStudentName,
 } from '@/hooks/useAssignmentPseudonyms';
@@ -61,30 +65,19 @@ export const Results: React.FC<ResultsProps> = ({
   const questions = session.questions;
   const totalStudents = responses.length;
 
-  /** Compute correctness from the authoritative activity question data. */
+  /**
+   * Compute correctness from the authoritative activity question data.
+   * Routes through the shared `gradeVideoActivityAnswer` so MA / FIB
+   * variants / partial-credit semantics stay aligned with the student
+   * client and the post-completion summary.
+   */
   const isAnswerCorrect = (questionId: string, answer: string): boolean => {
     const q = questions.find((q) => q.id === questionId);
-    return q ? answer === q.correctAnswer : false;
+    return q ? gradeVideoActivityAnswer(q, answer).isCorrect : false;
   };
 
-  const getStudentScore = (r: VideoActivityResponse): number => {
-    if (questions.length === 0) return 0;
-    // Count at most one correct answer per question to prevent inflated scores
-    // from duplicate entries (e.g. if arrayUnion raced and stored multiple answers).
-    let correct = 0;
-    for (const question of questions) {
-      if (
-        r.answers.some(
-          (a) =>
-            a.questionId === question.id &&
-            isAnswerCorrect(a.questionId, a.answer)
-        )
-      ) {
-        correct += 1;
-      }
-    }
-    return Math.round((correct / questions.length) * 100);
-  };
+  const getStudentScore = (r: VideoActivityResponse): number =>
+    computeVideoActivityScorePct(questions, r.answers);
 
   // ⚡ Bolt: Consolidate multiple O(N) array passes inside render
   // Calculate completed count and average score in a single loop
@@ -93,31 +86,13 @@ export const Results: React.FC<ResultsProps> = ({
       return { completed: 0, avgScore: 0 };
     }
 
-    const correctAnswersMap = new Map<string, string>();
-    for (const q of questions) {
-      correctAnswersMap.set(q.id, q.correctAnswer);
-    }
-
     let completedCount = 0;
     let scoreSum = 0;
 
     for (const r of responses) {
       if (r.completedAt !== null) {
         completedCount++;
-
-        const correctAnswersForStudent = new Set<string>();
-        for (const answer of r.answers) {
-          if (answer.answer === correctAnswersMap.get(answer.questionId)) {
-            correctAnswersForStudent.add(answer.questionId);
-          }
-        }
-        const score =
-          questions.length > 0
-            ? Math.round(
-                (correctAnswersForStudent.size / questions.length) * 100
-              )
-            : 0;
-        scoreSum += score;
+        scoreSum += computeVideoActivityScorePct(questions, r.answers);
       }
     }
 
@@ -186,10 +161,19 @@ export const Results: React.FC<ResultsProps> = ({
       // Pass `byStudentUid` so SSO `studentRole` rows (no PIN) export with
       // their resolved ClassLink names instead of falling back to the
       // generic "Student" label.
+      // TODO(PR3): The Quiz exporter calls Quiz's `gradeAnswer`, which has
+      // no 'MA' case and returns 0 points for VA Multi-Answer questions in
+      // the export. PR3 lifts `buildResultsSheetData` into a generic util
+      // that accepts a custom grader (`utils/assignmentExportShared.ts`)
+      // and at that point the VA call here will pass `gradeVideoActivityAnswer`.
+      // Until then, MA columns in the exported sheet read as "0 / Npt".
+      // MC + FIB questions grade correctly.
       const url = await drive.exportResultsToSheet(
         session.assignmentName,
         quizResponses,
-        questions,
+        questions as unknown as Parameters<
+          typeof drive.exportResultsToSheet
+        >[2],
         { byStudentUid }
       );
       setExportUrl(url);

--- a/components/widgets/VideoActivityWidget/components/VideoActivityEditorModal.tsx
+++ b/components/widgets/VideoActivityWidget/components/VideoActivityEditorModal.tsx
@@ -72,7 +72,18 @@ const blankQuestion = (): VideoActivityQuestion => ({
   correctAnswer: '',
   incorrectAnswers: ['', '', ''],
   timestamp: 0,
+  points: 1,
 });
+
+const arrEq = (a?: string[], b?: string[]): boolean => {
+  const aa = a ?? [];
+  const bb = b ?? [];
+  if (aa.length !== bb.length) return false;
+  for (let i = 0; i < aa.length; i++) {
+    if (aa[i] !== bb[i]) return false;
+  }
+  return true;
+};
 
 const questionsEqual = (
   a: VideoActivityQuestion[],
@@ -88,12 +99,13 @@ const questionsEqual = (
       qa.correctAnswer !== qb.correctAnswer ||
       qa.timeLimit !== qb.timeLimit ||
       qa.timestamp !== qb.timestamp ||
-      qa.incorrectAnswers.length !== qb.incorrectAnswers.length
+      qa.type !== qb.type ||
+      (qa.points ?? 1) !== (qb.points ?? 1) ||
+      (qa.allowPartialCredit ?? false) !== (qb.allowPartialCredit ?? false) ||
+      !arrEq(qa.incorrectAnswers, qb.incorrectAnswers) ||
+      !arrEq(qa.acceptableVariants, qb.acceptableVariants)
     ) {
       return false;
-    }
-    for (let j = 0; j < qa.incorrectAnswers.length; j++) {
-      if (qa.incorrectAnswers[j] !== qb.incorrectAnswers[j]) return false;
     }
   }
   return true;
@@ -311,8 +323,18 @@ export const VideoActivityEditorModal: React.FC<
     if (questions.length === 0) errors.push('Add at least one question');
     questions.forEach((q, i) => {
       if (!q.text.trim()) errors.push(`Question ${i + 1}: text is required`);
-      if (!q.correctAnswer.trim())
+      const type = q.type ?? 'MC';
+      if (type === 'MA') {
+        const correctCount = q.correctAnswer
+          .split('|')
+          .map((s) => s.trim())
+          .filter((s) => s.length > 0).length;
+        if (correctCount === 0) {
+          errors.push(`Question ${i + 1}: select at least one correct option`);
+        }
+      } else if (!q.correctAnswer.trim()) {
         errors.push(`Question ${i + 1}: correct answer is required`);
+      }
     });
 
     // Timestamps must be strictly increasing to keep cue-point playback
@@ -357,7 +379,11 @@ export const VideoActivityEditorModal: React.FC<
       title={title.trim() || (originalTitle ? 'Edit Activity' : 'New Activity')}
       subtitle={
         <span>
-          {questions.length} {questions.length === 1 ? 'question' : 'questions'}
+          {questions.length} {questions.length === 1 ? 'question' : 'questions'}{' '}
+          • {questions.reduce((sum, q) => sum + (q.points ?? 1), 0)}{' '}
+          {questions.reduce((sum, q) => sum + (q.points ?? 1), 0) === 1
+            ? 'point'
+            : 'points'}
         </span>
       }
       isDirty={isDirty}
@@ -504,7 +530,7 @@ export const VideoActivityEditorModal: React.FC<
 
               {expandedId === q.id && (
                 <div className="px-4 pb-4 space-y-4 border-t border-brand-blue-primary/5 pt-4 bg-brand-blue-lighter/10">
-                  <div className="grid grid-cols-2 gap-3">
+                  <div className="grid grid-cols-3 gap-3">
                     <div>
                       <label className="block font-bold text-brand-blue-dark mb-1 text-xs">
                         Trigger Timestamp (MM:SS)
@@ -549,6 +575,70 @@ export const VideoActivityEditorModal: React.FC<
                         </span>
                       </div>
                     </div>
+                    <div>
+                      <label className="block font-bold text-brand-blue-dark mb-1 text-xs">
+                        Points
+                      </label>
+                      <input
+                        type="number"
+                        min={1}
+                        step={1}
+                        value={q.points ?? 1}
+                        onChange={(e) => {
+                          const next = Math.floor(Number(e.target.value));
+                          const safe =
+                            Number.isFinite(next) && next >= 1 ? next : 1;
+                          updateQuestion(q.id, { points: safe });
+                        }}
+                        className="w-full px-3 py-2 bg-white border border-brand-blue-primary/20 rounded-xl text-brand-blue-dark font-bold focus:outline-none focus:border-brand-blue-primary shadow-sm text-sm"
+                      />
+                    </div>
+                  </div>
+
+                  <div>
+                    <label className="block font-bold text-brand-blue-dark mb-1 text-xs">
+                      Question Type
+                    </label>
+                    <div className="inline-flex rounded-xl border border-brand-blue-primary/20 bg-white overflow-hidden">
+                      {(
+                        [
+                          { value: 'MC', label: 'Multiple Choice' },
+                          { value: 'FIB', label: 'Fill in the Blank' },
+                          { value: 'MA', label: 'Multi-Answer' },
+                        ] as const
+                      ).map((opt) => {
+                        const active = (q.type ?? 'MC') === opt.value;
+                        return (
+                          <button
+                            key={opt.value}
+                            type="button"
+                            aria-pressed={active}
+                            onClick={() => {
+                              // When type changes, reset format-specific fields
+                              // so we don't carry stale MA pipe-encodings into
+                              // a fresh MC question, etc.
+                              if (opt.value === q.type) return;
+                              updateQuestion(q.id, {
+                                type: opt.value,
+                                correctAnswer: '',
+                                incorrectAnswers:
+                                  opt.value === 'FIB' ? [] : ['', '', ''],
+                                acceptableVariants: undefined,
+                                allowPartialCredit: false,
+                              });
+                            }}
+                            className={
+                              'px-3 py-1.5 text-xs font-bold transition ' +
+                              (active
+                                ? 'bg-brand-blue-primary text-white'
+                                : 'text-brand-blue-dark hover:bg-brand-blue-lighter/40')
+                            }
+                          >
+                            {opt.label}
+                          </button>
+                        );
+                      })}
+                    </div>
                   </div>
 
                   <div>
@@ -566,43 +656,35 @@ export const VideoActivityEditorModal: React.FC<
                     />
                   </div>
 
-                  <div>
-                    <label className="block font-bold text-emerald-700 mb-1 text-xs">
-                      Correct Answer
-                    </label>
-                    <input
-                      type="text"
-                      value={q.correctAnswer}
-                      onChange={(e) =>
-                        updateQuestion(q.id, { correctAnswer: e.target.value })
+                  {/* Type-specific sub-form */}
+                  {(q.type ?? 'MC') === 'MC' && (
+                    <McSubForm
+                      question={q}
+                      onChangeCorrect={(v) =>
+                        updateQuestion(q.id, { correctAnswer: v })
                       }
-                      className="w-full px-3 py-2 bg-white border-2 border-emerald-500/20 rounded-xl text-emerald-800 font-bold focus:outline-none focus:border-emerald-500 shadow-sm text-sm"
-                      placeholder="Enter the correct answer"
+                      onChangeIncorrect={(idx, v) =>
+                        updateIncorrect(q.id, idx, v)
+                      }
                     />
-                  </div>
-
-                  <div className="space-y-2">
-                    <label className="block font-bold text-brand-red-primary mb-1 text-xs">
-                      Distractors (Incorrect Options)
-                    </label>
-                    <div className="grid gap-2">
-                      {(q.incorrectAnswers.length === 0
-                        ? ['', '', '']
-                        : q.incorrectAnswers
-                      ).map((ans, idx) => (
-                        <input
-                          key={idx}
-                          type="text"
-                          value={ans}
-                          onChange={(e) =>
-                            updateIncorrect(q.id, idx, e.target.value)
-                          }
-                          placeholder={`Distractor ${idx + 1}`}
-                          className="flex-1 px-3 py-1.5 bg-white border border-brand-red-primary/10 rounded-xl text-brand-blue-dark font-medium focus:outline-none focus:border-brand-red-primary shadow-sm text-sm"
-                        />
-                      ))}
-                    </div>
-                  </div>
+                  )}
+                  {q.type === 'FIB' && (
+                    <FibSubForm
+                      question={q}
+                      onChangeCorrect={(v) =>
+                        updateQuestion(q.id, { correctAnswer: v })
+                      }
+                      onChangeVariants={(variants) =>
+                        updateQuestion(q.id, { acceptableVariants: variants })
+                      }
+                    />
+                  )}
+                  {q.type === 'MA' && (
+                    <MaSubForm
+                      question={q}
+                      onUpdate={(patch) => updateQuestion(q.id, patch)}
+                    />
+                  )}
                 </div>
               )}
             </div>
@@ -684,5 +766,224 @@ export const VideoActivityEditorModal: React.FC<
         </div>
       )}
     </EditorModalShell>
+  );
+};
+
+/* ─── Type-specific sub-forms ─────────────────────────────────────────────── */
+
+interface McSubFormProps {
+  question: VideoActivityQuestion;
+  onChangeCorrect: (v: string) => void;
+  onChangeIncorrect: (idx: number, v: string) => void;
+}
+
+const McSubForm: React.FC<McSubFormProps> = ({
+  question,
+  onChangeCorrect,
+  onChangeIncorrect,
+}) => (
+  <>
+    <div>
+      <label className="block font-bold text-emerald-700 mb-1 text-xs">
+        Correct Answer
+      </label>
+      <input
+        type="text"
+        value={question.correctAnswer}
+        onChange={(e) => onChangeCorrect(e.target.value)}
+        className="w-full px-3 py-2 bg-white border-2 border-emerald-500/20 rounded-xl text-emerald-800 font-bold focus:outline-none focus:border-emerald-500 shadow-sm text-sm"
+        placeholder="Enter the correct answer"
+      />
+    </div>
+
+    <div className="space-y-2">
+      <label className="block font-bold text-brand-red-primary mb-1 text-xs">
+        Distractors (Incorrect Options)
+      </label>
+      <div className="grid gap-2">
+        {(question.incorrectAnswers.length === 0
+          ? ['', '', '']
+          : question.incorrectAnswers
+        ).map((ans, idx) => (
+          <input
+            key={idx}
+            type="text"
+            value={ans}
+            onChange={(e) => onChangeIncorrect(idx, e.target.value)}
+            placeholder={`Distractor ${idx + 1}`}
+            className="flex-1 px-3 py-1.5 bg-white border border-brand-red-primary/10 rounded-xl text-brand-blue-dark font-medium focus:outline-none focus:border-brand-red-primary shadow-sm text-sm"
+          />
+        ))}
+      </div>
+    </div>
+  </>
+);
+
+interface FibSubFormProps {
+  question: VideoActivityQuestion;
+  onChangeCorrect: (v: string) => void;
+  onChangeVariants: (variants: string[] | undefined) => void;
+}
+
+const FibSubForm: React.FC<FibSubFormProps> = ({
+  question,
+  onChangeCorrect,
+  onChangeVariants,
+}) => {
+  const variantsText = (question.acceptableVariants ?? []).join('\n');
+  return (
+    <>
+      <div>
+        <label className="block font-bold text-emerald-700 mb-1 text-xs">
+          Canonical Answer
+        </label>
+        <input
+          type="text"
+          value={question.correctAnswer}
+          onChange={(e) => onChangeCorrect(e.target.value)}
+          className="w-full px-3 py-2 bg-white border-2 border-emerald-500/20 rounded-xl text-emerald-800 font-bold focus:outline-none focus:border-emerald-500 shadow-sm text-sm"
+          placeholder="The expected answer"
+        />
+      </div>
+      <div>
+        <label className="block font-bold text-brand-blue-dark mb-1 text-xs">
+          Acceptable Variants{' '}
+          <span className="font-normal text-brand-blue-primary/50">
+            (one per line, optional)
+          </span>
+        </label>
+        <textarea
+          value={variantsText}
+          onChange={(e) => {
+            const lines = e.target.value
+              .split('\n')
+              .map((s) => s.trim())
+              .filter((s) => s.length > 0);
+            onChangeVariants(lines.length > 0 ? lines : undefined);
+          }}
+          rows={3}
+          placeholder={'color\ncolour'}
+          className="w-full px-3 py-2 bg-white border border-brand-blue-primary/20 rounded-xl text-brand-blue-dark font-medium resize-none focus:outline-none focus:border-brand-blue-primary shadow-sm text-sm"
+        />
+        <p className="text-xxs text-slate-500 mt-1">
+          Whitespace + case are ignored automatically. Add variants for spelling
+          differences, synonyms, or alternate phrasings.
+        </p>
+      </div>
+    </>
+  );
+};
+
+interface MaSubFormProps {
+  question: VideoActivityQuestion;
+  onUpdate: (patch: Partial<VideoActivityQuestion>) => void;
+}
+
+/**
+ * MA editor: a single combined "options" list where the teacher checks
+ * each correct option. We persist the correct selections into
+ * `correctAnswer` as `'opt1|opt2|opt3'` and the unchecked options into
+ * `incorrectAnswers`. This keeps the wire format aligned with the
+ * existing Matching/Ordering convention and works with the shared
+ * grader's set-compare logic.
+ */
+const MaSubForm: React.FC<MaSubFormProps> = ({ question, onUpdate }) => {
+  const correctSelections = (question.correctAnswer ?? '')
+    .split('|')
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+  const allOptions = [
+    ...correctSelections,
+    ...(question.incorrectAnswers ?? []),
+  ];
+  // Pad to at least 4 rows so the teacher always has a place to type.
+  while (allOptions.length < 4) allOptions.push('');
+
+  const setOptionAt = (idx: number, value: string) => {
+    const next = [...allOptions];
+    next[idx] = value;
+    persist(next, isCheckedAt);
+  };
+
+  const isCheckedAt = (idx: number): boolean => idx < correctSelections.length;
+
+  const toggleAt = (idx: number) => {
+    persist(allOptions, (i) => (i === idx ? !isCheckedAt(i) : isCheckedAt(i)));
+  };
+
+  function persist(rows: string[], isCorrect: (idx: number) => boolean) {
+    const correct: string[] = [];
+    const incorrect: string[] = [];
+    rows.forEach((r, idx) => {
+      const trimmed = r.trim();
+      if (trimmed.length === 0) return;
+      if (isCorrect(idx)) correct.push(trimmed);
+      else incorrect.push(trimmed);
+    });
+    onUpdate({
+      correctAnswer: correct.join('|'),
+      incorrectAnswers: incorrect,
+    });
+  }
+
+  return (
+    <>
+      <div className="space-y-2">
+        <label className="block font-bold text-brand-blue-dark mb-1 text-xs">
+          Options{' '}
+          <span className="font-normal text-brand-blue-primary/50">
+            (check each correct selection)
+          </span>
+        </label>
+        <div className="grid gap-2">
+          {allOptions.map((opt, idx) => {
+            const checked = isCheckedAt(idx);
+            return (
+              <div key={idx} className="flex items-center gap-2">
+                <button
+                  type="button"
+                  onClick={() => toggleAt(idx)}
+                  aria-pressed={checked}
+                  aria-label={`Mark option ${idx + 1} ${checked ? 'incorrect' : 'correct'}`}
+                  className={`shrink-0 w-7 h-7 rounded-md border-2 flex items-center justify-center transition-colors ${
+                    checked
+                      ? 'border-emerald-500 bg-emerald-500 text-white'
+                      : 'border-slate-300 bg-white text-slate-400 hover:border-emerald-400'
+                  }`}
+                >
+                  {checked ? '✓' : ''}
+                </button>
+                <input
+                  type="text"
+                  value={opt}
+                  onChange={(e) => setOptionAt(idx, e.target.value)}
+                  placeholder={`Option ${idx + 1}`}
+                  className={`flex-1 px-3 py-1.5 bg-white border rounded-xl font-medium focus:outline-none shadow-sm text-sm ${
+                    checked
+                      ? 'border-emerald-500/30 text-emerald-800 focus:border-emerald-500'
+                      : 'border-brand-red-primary/10 text-brand-blue-dark focus:border-brand-red-primary'
+                  }`}
+                />
+              </div>
+            );
+          })}
+        </div>
+      </div>
+
+      <label className="flex items-center gap-2 cursor-pointer">
+        <input
+          type="checkbox"
+          checked={question.allowPartialCredit ?? false}
+          onChange={(e) => onUpdate({ allowPartialCredit: e.target.checked })}
+          className="rounded border-slate-300 text-brand-blue-primary focus:ring-brand-blue-primary"
+        />
+        <span className="text-sm font-bold text-brand-blue-dark">
+          Allow partial credit
+        </span>
+        <span className="text-xxs text-slate-500">
+          (proportional to correct ∩ given)
+        </span>
+      </label>
+    </>
   );
 };

--- a/components/widgets/VideoActivityWidget/components/VideoActivityEditorModal.tsx
+++ b/components/widgets/VideoActivityWidget/components/VideoActivityEditorModal.tsx
@@ -215,6 +215,11 @@ export const VideoActivityEditorModal: React.FC<
     ]
   );
 
+  const totalPoints = useMemo(
+    () => questions.reduce((sum, q) => sum + (q.points ?? 1), 0),
+    [questions]
+  );
+
   const updateQuestion = (
     id: string,
     updates: Partial<VideoActivityQuestion>
@@ -329,8 +334,24 @@ export const VideoActivityEditorModal: React.FC<
           .split('|')
           .map((s) => s.trim())
           .filter((s) => s.length > 0).length;
-        if (correctCount === 0) {
+        const incorrectCount = (q.incorrectAnswers ?? []).filter(
+          (s) => s.trim().length > 0
+        ).length;
+        if (correctCount + incorrectCount === 0) {
+          errors.push(`Question ${i + 1}: add at least one option`);
+        } else if (correctCount === 0) {
           errors.push(`Question ${i + 1}: select at least one correct option`);
+        }
+        // Defense-in-depth: a `|` in option text would corrupt the
+        // pipe-encoded `correctAnswer` wire format silently.
+        const hasPipe = [
+          ...q.correctAnswer.split('|'),
+          ...(q.incorrectAnswers ?? []),
+        ].some((s) => s.includes('|'));
+        if (hasPipe) {
+          errors.push(
+            `Question ${i + 1}: option text cannot contain the | character`
+          );
         }
       } else if (!q.correctAnswer.trim()) {
         errors.push(`Question ${i + 1}: correct answer is required`);
@@ -380,10 +401,7 @@ export const VideoActivityEditorModal: React.FC<
       subtitle={
         <span>
           {questions.length} {questions.length === 1 ? 'question' : 'questions'}{' '}
-          • {questions.reduce((sum, q) => sum + (q.points ?? 1), 0)}{' '}
-          {questions.reduce((sum, q) => sum + (q.points ?? 1), 0) === 1
-            ? 'point'
-            : 'points'}
+          • {totalPoints} {totalPoints === 1 ? 'point' : 'points'}
         </span>
       }
       isDirty={isDirty}
@@ -614,15 +632,28 @@ export const VideoActivityEditorModal: React.FC<
                             type="button"
                             aria-pressed={active}
                             onClick={() => {
-                              // When type changes, reset format-specific fields
-                              // so we don't carry stale MA pipe-encodings into
-                              // a fresh MC question, etc.
                               if (opt.value === q.type) return;
+                              // Preserve non-empty distractor rows across
+                              // type changes so a teacher who's already typed
+                              // a few options doesn't lose their work. Reset
+                              // format-specific encodings (MA pipe-encoding,
+                              // FIB variants, partial-credit flag) so they
+                              // don't bleed into the new type's semantics.
+                              const preservedDistractors = (
+                                q.incorrectAnswers ?? []
+                              ).filter((s) => s.trim().length > 0);
+                              const padTo = (arr: string[], n: number) => {
+                                const out = [...arr];
+                                while (out.length < n) out.push('');
+                                return out;
+                              };
                               updateQuestion(q.id, {
                                 type: opt.value,
                                 correctAnswer: '',
                                 incorrectAnswers:
-                                  opt.value === 'FIB' ? [] : ['', '', ''],
+                                  opt.value === 'FIB'
+                                    ? []
+                                    : padTo(preservedDistractors, 3),
                                 acceptableVariants: undefined,
                                 allowPartialCredit: false,
                               });
@@ -879,52 +910,99 @@ interface MaSubFormProps {
   onUpdate: (patch: Partial<VideoActivityQuestion>) => void;
 }
 
+interface MaRow {
+  text: string;
+  isCorrect: boolean;
+}
+
 /**
- * MA editor: a single combined "options" list where the teacher checks
- * each correct option. We persist the correct selections into
- * `correctAnswer` as `'opt1|opt2|opt3'` and the unchecked options into
- * `incorrectAnswers`. This keeps the wire format aligned with the
- * existing Matching/Ordering convention and works with the shared
- * grader's set-compare logic.
+ * Build the local row state from the wire format. The wire format
+ * (`correctAnswer` + `incorrectAnswers`) is disjoint, so we render
+ * correct rows first, then incorrect, then pad. This is the ONLY
+ * place we read the wire format directly — every subsequent edit
+ * mutates the local row state and re-derives the wire format.
  */
-const MaSubForm: React.FC<MaSubFormProps> = ({ question, onUpdate }) => {
-  const correctSelections = (question.correctAnswer ?? '')
+function rowsFromQuestion(question: VideoActivityQuestion): MaRow[] {
+  const correct = (question.correctAnswer ?? '')
     .split('|')
     .map((s) => s.trim())
     .filter((s) => s.length > 0);
-  const allOptions = [
-    ...correctSelections,
-    ...(question.incorrectAnswers ?? []),
+  const incorrect = (question.incorrectAnswers ?? []).filter(
+    (s) => s.trim().length > 0
+  );
+  const rows: MaRow[] = [
+    ...correct.map((text) => ({ text, isCorrect: true })),
+    ...incorrect.map((text) => ({ text, isCorrect: false })),
   ];
   // Pad to at least 4 rows so the teacher always has a place to type.
-  while (allOptions.length < 4) allOptions.push('');
+  while (rows.length < 4) rows.push({ text: '', isCorrect: false });
+  return rows;
+}
 
-  const setOptionAt = (idx: number, value: string) => {
-    const next = [...allOptions];
-    next[idx] = value;
-    persist(next, isCheckedAt);
-  };
+/**
+ * MA editor: a single combined "options" list where the teacher checks
+ * each correct option. Persists the correct selections into
+ * `correctAnswer` as `'opt1|opt2|opt3'` and the unchecked options into
+ * `incorrectAnswers` — wire format aligned with Matching/Ordering and the
+ * shared grader's set-compare.
+ *
+ * **Why local state for rows?** Using `correctAnswer.split('|')` directly
+ * for rendering meant every toggle re-partitioned the visible row order
+ * (because `correctSelections.length` changed), causing rows to visibly
+ * jump positions. We hold the row order in component state, decoupled
+ * from persistence, so toggling only flips `isCorrect` without reordering.
+ */
+const MaSubForm: React.FC<MaSubFormProps> = ({ question, onUpdate }) => {
+  const [rows, setRows] = useState<MaRow[]>(() => rowsFromQuestion(question));
 
-  const isCheckedAt = (idx: number): boolean => idx < correctSelections.length;
+  // If the question identity changes (different question expanded), reset
+  // the local row state. Adjusting state during render — same pattern used
+  // elsewhere in this file for editor-prop changes.
+  const [prevQuestionId, setPrevQuestionId] = useState(question.id);
+  if (prevQuestionId !== question.id) {
+    setPrevQuestionId(question.id);
+    setRows(rowsFromQuestion(question));
+  }
 
-  const toggleAt = (idx: number) => {
-    persist(allOptions, (i) => (i === idx ? !isCheckedAt(i) : isCheckedAt(i)));
-  };
-
-  function persist(rows: string[], isCorrect: (idx: number) => boolean) {
+  const persist = (next: MaRow[]): void => {
     const correct: string[] = [];
     const incorrect: string[] = [];
-    rows.forEach((r, idx) => {
-      const trimmed = r.trim();
+    next.forEach((r) => {
+      const trimmed = r.text.trim();
       if (trimmed.length === 0) return;
-      if (isCorrect(idx)) correct.push(trimmed);
+      if (r.isCorrect) correct.push(trimmed);
       else incorrect.push(trimmed);
     });
     onUpdate({
       correctAnswer: correct.join('|'),
       incorrectAnswers: incorrect,
     });
-  }
+  };
+
+  const setRowsAndPersist = (next: MaRow[]) => {
+    setRows(next);
+    persist(next);
+  };
+
+  const setOptionAt = (idx: number, value: string) => {
+    setRowsAndPersist(
+      rows.map((r, i) => (i === idx ? { ...r, text: value } : r))
+    );
+  };
+
+  const isCheckedAt = (idx: number): boolean => rows[idx]?.isCorrect ?? false;
+
+  const toggleAt = (idx: number) => {
+    setRowsAndPersist(
+      rows.map((r, i) => (i === idx ? { ...r, isCorrect: !r.isCorrect } : r))
+    );
+  };
+
+  // Detect a teacher typing a `|` into an option text — the wire format
+  // would silently corrupt because `correctAnswer.split('|')` would treat
+  // it as a separator. Render an inline warning rather than a toast so the
+  // teacher sees it next to the offending input.
+  const hasPipeInOption = rows.some((r) => r.text.includes('|'));
 
   return (
     <>
@@ -936,7 +1014,7 @@ const MaSubForm: React.FC<MaSubFormProps> = ({ question, onUpdate }) => {
           </span>
         </label>
         <div className="grid gap-2">
-          {allOptions.map((opt, idx) => {
+          {rows.map((row, idx) => {
             const checked = isCheckedAt(idx);
             return (
               <div key={idx} className="flex items-center gap-2">
@@ -955,7 +1033,7 @@ const MaSubForm: React.FC<MaSubFormProps> = ({ question, onUpdate }) => {
                 </button>
                 <input
                   type="text"
-                  value={opt}
+                  value={row.text}
                   onChange={(e) => setOptionAt(idx, e.target.value)}
                   placeholder={`Option ${idx + 1}`}
                   className={`flex-1 px-3 py-1.5 bg-white border rounded-xl font-medium focus:outline-none shadow-sm text-sm ${
@@ -968,6 +1046,14 @@ const MaSubForm: React.FC<MaSubFormProps> = ({ question, onUpdate }) => {
             );
           })}
         </div>
+        {hasPipeInOption && (
+          <p className="text-xxs text-amber-600 font-medium pl-9">
+            Option text contains a pipe (<code>|</code>) character, which is
+            reserved as the wire format separator. Replace it with another
+            character before saving — otherwise the question will grade
+            incorrectly.
+          </p>
+        )}
       </div>
 
       <label className="flex items-center gap-2 cursor-pointer">

--- a/hooks/useVideoActivity.ts
+++ b/hooks/useVideoActivity.ts
@@ -18,6 +18,7 @@ import {
 import { db, isAuthBypass } from '@/config/firebase';
 import { useAuth } from '@/context/useAuth';
 import { useGoogleDrive } from './useGoogleDrive';
+import { normalizeVideoActivityQuestions } from '@/utils/videoActivityNormalize';
 import { VideoActivityData, VideoActivityMetadata } from '@/types';
 import { QuizDriveService } from '@/utils/quizDriveService';
 import {
@@ -144,8 +145,15 @@ export const useVideoActivity = (
     async (driveFileId: string): Promise<VideoActivityData> => {
       const drive = getDriveService();
       // loadQuiz returns the raw JSON blob we stored — it is a VideoActivityData
-      const raw = await drive.loadQuiz(driveFileId);
-      return raw as unknown as VideoActivityData;
+      const raw = (await drive.loadQuiz(
+        driveFileId
+      )) as unknown as VideoActivityData;
+      // Normalize legacy V1 questions (no `type`, no `points`) up to the
+      // PR2a shape so consumers can rely on the fields being present.
+      return {
+        ...raw,
+        questions: normalizeVideoActivityQuestions(raw.questions),
+      };
     },
     [getDriveService]
   );

--- a/hooks/useVideoActivitySession.ts
+++ b/hooks/useVideoActivitySession.ts
@@ -30,6 +30,7 @@ import {
   computeResponseKey,
   encodeResponseKeySegment,
 } from '@/hooks/useQuizSession';
+import { normalizeVideoActivityQuestions } from '@/utils/videoActivityNormalize';
 import {
   AssignmentMode,
   VideoActivitySession,
@@ -60,7 +61,7 @@ const normalizeSession = (
         : `${activityTitle} ${new Date(createdAt).toLocaleString()}`,
     teacherUid: data.teacherUid ?? '',
     youtubeUrl: data.youtubeUrl ?? '',
-    questions: data.questions ?? [],
+    questions: normalizeVideoActivityQuestions(data.questions),
     settings: {
       autoPlay: data.settings?.autoPlay ?? false,
       requireCorrectAnswer: data.settings?.requireCorrectAnswer ?? true,

--- a/tests/utils/videoActivityGrading.test.ts
+++ b/tests/utils/videoActivityGrading.test.ts
@@ -188,6 +188,36 @@ describe('gradeVideoActivityAnswer — MA', () => {
   });
 });
 
+describe('gradeVideoActivityAnswer — Unicode normalization (VA-specific)', () => {
+  it('treats accented and unaccented as equivalent (FIB)', () => {
+    const result = gradeVideoActivityAnswer(
+      q({ type: 'FIB', correctAnswer: 'café' }),
+      'cafe'
+    );
+    expect(result.isCorrect).toBe(true);
+  });
+
+  it('reverse direction also works — accented student, unaccented canonical', () => {
+    const result = gradeVideoActivityAnswer(
+      q({ type: 'FIB', correctAnswer: 'naive' }),
+      'naïve'
+    );
+    expect(result.isCorrect).toBe(true);
+  });
+
+  it('strips combining marks across MA option compare', () => {
+    const result = gradeVideoActivityAnswer(
+      q({
+        type: 'MA',
+        correctAnswer: 'résumé|élève',
+        incorrectAnswers: ['école'],
+      }),
+      'resume|eleve'
+    );
+    expect(result.isCorrect).toBe(true);
+  });
+});
+
 describe('gradeVideoActivityAnswer — defensive defaults', () => {
   it('treats missing type as MC', () => {
     const result = gradeVideoActivityAnswer(
@@ -206,6 +236,16 @@ describe('gradeVideoActivityAnswer — defensive defaults', () => {
     );
     expect(result.pointsMax).toBe(1);
     expect(result.pointsEarned).toBe(1);
+  });
+
+  it('points: 0 produces zero pointsEarned and pointsMax', () => {
+    const result = gradeVideoActivityAnswer(
+      q({ type: 'MC', correctAnswer: 'X', points: 0 }),
+      'X'
+    );
+    expect(result.isCorrect).toBe(true);
+    expect(result.pointsEarned).toBe(0);
+    expect(result.pointsMax).toBe(0);
   });
 
   it('unknown type fails closed', () => {

--- a/tests/utils/videoActivityGrading.test.ts
+++ b/tests/utils/videoActivityGrading.test.ts
@@ -1,0 +1,283 @@
+import { describe, it, expect } from 'vitest';
+import {
+  gradeVideoActivityAnswer,
+  computeVideoActivityScorePct,
+} from '@/utils/videoActivityGrading';
+import type { VideoActivityQuestion } from '@/types';
+
+function q(
+  overrides: Partial<VideoActivityQuestion> = {}
+): VideoActivityQuestion {
+  return {
+    id: 'q1',
+    text: 'What?',
+    timestamp: 30,
+    timeLimit: 30,
+    type: 'MC',
+    correctAnswer: '',
+    incorrectAnswers: [],
+    points: 1,
+    ...overrides,
+  };
+}
+
+describe('gradeVideoActivityAnswer — MC', () => {
+  it('full credit on exact match', () => {
+    const result = gradeVideoActivityAnswer(
+      q({ type: 'MC', correctAnswer: 'Saturn', points: 2 }),
+      'Saturn'
+    );
+    expect(result).toEqual({ isCorrect: true, pointsEarned: 2, pointsMax: 2 });
+  });
+
+  it('case- and whitespace-insensitive', () => {
+    const result = gradeVideoActivityAnswer(
+      q({ type: 'MC', correctAnswer: 'Saturn' }),
+      '  saturn  '
+    );
+    expect(result.isCorrect).toBe(true);
+  });
+
+  it('zero credit on miss', () => {
+    const result = gradeVideoActivityAnswer(
+      q({ type: 'MC', correctAnswer: 'Saturn', points: 5 }),
+      'Mars'
+    );
+    expect(result).toEqual({ isCorrect: false, pointsEarned: 0, pointsMax: 5 });
+  });
+});
+
+describe('gradeVideoActivityAnswer — FIB', () => {
+  it('canonical answer matches', () => {
+    const result = gradeVideoActivityAnswer(
+      q({ type: 'FIB', correctAnswer: 'mitochondria' }),
+      'Mitochondria'
+    );
+    expect(result.isCorrect).toBe(true);
+  });
+
+  it('accepts variants', () => {
+    const result = gradeVideoActivityAnswer(
+      q({
+        type: 'FIB',
+        correctAnswer: 'color',
+        acceptableVariants: ['colour'],
+      }),
+      'Colour'
+    );
+    expect(result.isCorrect).toBe(true);
+  });
+
+  it('rejects answers that are neither canonical nor variant', () => {
+    const result = gradeVideoActivityAnswer(
+      q({
+        type: 'FIB',
+        correctAnswer: 'color',
+        acceptableVariants: ['colour'],
+      }),
+      'shade'
+    );
+    expect(result.isCorrect).toBe(false);
+  });
+
+  it('treats missing variants as empty list (canonical only)', () => {
+    const result = gradeVideoActivityAnswer(
+      q({ type: 'FIB', correctAnswer: 'photosynthesis' }),
+      'photosynthesis'
+    );
+    expect(result.isCorrect).toBe(true);
+  });
+});
+
+describe('gradeVideoActivityAnswer — MA', () => {
+  it('full credit on exact set match', () => {
+    const result = gradeVideoActivityAnswer(
+      q({
+        type: 'MA',
+        correctAnswer: 'a|b|c',
+        incorrectAnswers: ['d', 'e'],
+        points: 3,
+      }),
+      'b|a|c'
+    );
+    expect(result).toEqual({ isCorrect: true, pointsEarned: 3, pointsMax: 3 });
+  });
+
+  it('zero credit when missing one correct selection (no partial credit)', () => {
+    const result = gradeVideoActivityAnswer(
+      q({
+        type: 'MA',
+        correctAnswer: 'a|b|c',
+        incorrectAnswers: ['d'],
+        points: 3,
+      }),
+      'a|b'
+    );
+    expect(result.isCorrect).toBe(false);
+    expect(result.pointsEarned).toBe(0);
+  });
+
+  it('zero credit when over-selecting (includes a wrong option)', () => {
+    const result = gradeVideoActivityAnswer(
+      q({
+        type: 'MA',
+        correctAnswer: 'a|b',
+        incorrectAnswers: ['c', 'd'],
+      }),
+      'a|b|c'
+    );
+    expect(result.isCorrect).toBe(false);
+  });
+
+  it('partial credit awards proportional points', () => {
+    const result = gradeVideoActivityAnswer(
+      q({
+        type: 'MA',
+        correctAnswer: 'a|b|c|d',
+        incorrectAnswers: ['e'],
+        allowPartialCredit: true,
+        points: 4,
+      }),
+      'a|b'
+    );
+    // 2 correct picks, 0 wrong picks, 4 needed -> 2/4 * 4 = 2
+    expect(result.isCorrect).toBe(false);
+    expect(result.pointsEarned).toBe(2);
+  });
+
+  it('partial credit penalizes wrong picks', () => {
+    const result = gradeVideoActivityAnswer(
+      q({
+        type: 'MA',
+        correctAnswer: 'a|b|c|d',
+        incorrectAnswers: ['e', 'f'],
+        allowPartialCredit: true,
+        points: 4,
+      }),
+      'a|b|e|f'
+    );
+    // 2 correct, 2 wrong, 4 needed -> (2-2)/4 * 4 = 0
+    expect(result.pointsEarned).toBe(0);
+  });
+
+  it('partial credit floors at zero', () => {
+    const result = gradeVideoActivityAnswer(
+      q({
+        type: 'MA',
+        correctAnswer: 'a|b',
+        incorrectAnswers: ['c', 'd', 'e', 'f'],
+        allowPartialCredit: true,
+        points: 4,
+      }),
+      'c|d|e|f'
+    );
+    // 0 correct, 4 wrong, 2 needed -> max(0, (0-4)/2) * 4 = 0
+    expect(result.pointsEarned).toBe(0);
+  });
+
+  it('case- and whitespace-insensitive on MA selections', () => {
+    const result = gradeVideoActivityAnswer(
+      q({
+        type: 'MA',
+        correctAnswer: 'Apple|Banana',
+        incorrectAnswers: ['Cherry'],
+      }),
+      'banana | APPLE'
+    );
+    expect(result.isCorrect).toBe(true);
+  });
+});
+
+describe('gradeVideoActivityAnswer — defensive defaults', () => {
+  it('treats missing type as MC', () => {
+    const result = gradeVideoActivityAnswer(
+      // type left out — pre-PR2a Drive blob shape
+      // @ts-expect-error intentional missing field
+      { ...q({ correctAnswer: 'Earth' }), type: undefined },
+      'Earth'
+    );
+    expect(result.isCorrect).toBe(true);
+  });
+
+  it('defaults points to 1 when missing', () => {
+    const result = gradeVideoActivityAnswer(
+      q({ type: 'MC', correctAnswer: 'X', points: undefined }),
+      'X'
+    );
+    expect(result.pointsMax).toBe(1);
+    expect(result.pointsEarned).toBe(1);
+  });
+
+  it('unknown type fails closed', () => {
+    const result = gradeVideoActivityAnswer(
+      // Cast through unknown so the test can simulate a corrupt save.
+      {
+        ...q(),
+        type: 'BOGUS' as unknown as VideoActivityQuestion['type'],
+      },
+      'anything'
+    );
+    expect(result.isCorrect).toBe(false);
+    expect(result.pointsEarned).toBe(0);
+  });
+});
+
+describe('computeVideoActivityScorePct', () => {
+  const questions = [
+    q({ id: 'q1', type: 'MC', correctAnswer: 'a', points: 1 }),
+    q({
+      id: 'q2',
+      type: 'MA',
+      correctAnswer: 'x|y',
+      incorrectAnswers: ['z'],
+      points: 4,
+    }),
+    q({ id: 'q3', type: 'FIB', correctAnswer: 'photosynthesis', points: 2 }),
+  ];
+
+  it('returns 0 when no questions', () => {
+    expect(computeVideoActivityScorePct([], [])).toBe(0);
+  });
+
+  it('returns 0 when no answers', () => {
+    expect(computeVideoActivityScorePct(questions, [])).toBe(0);
+  });
+
+  it('computes points-weighted percentage', () => {
+    const score = computeVideoActivityScorePct(questions, [
+      { questionId: 'q1', answer: 'a' }, // 1/1
+      { questionId: 'q2', answer: 'x|y' }, // 4/4
+      { questionId: 'q3', answer: 'photosynthesis' }, // 2/2
+    ]);
+    expect(score).toBe(100); // 7/7
+  });
+
+  it('partial-credit MA contributes fractional points', () => {
+    const partialQuestions = [
+      q({
+        id: 'q1',
+        type: 'MA',
+        correctAnswer: 'a|b|c|d',
+        incorrectAnswers: [],
+        allowPartialCredit: true,
+        points: 4,
+      }),
+    ];
+    const score = computeVideoActivityScorePct(partialQuestions, [
+      { questionId: 'q1', answer: 'a|b' },
+    ]);
+    expect(score).toBe(50); // 2/4 = 50%
+  });
+
+  it('credits at most one answer per question', () => {
+    const score = computeVideoActivityScorePct(
+      [q({ id: 'q1', type: 'MC', correctAnswer: 'a', points: 1 })],
+      [
+        { questionId: 'q1', answer: 'a' },
+        { questionId: 'q1', answer: 'b' }, // would be 0 if counted
+      ]
+    );
+    // First answer wins, no inflation from arrayUnion races
+    expect(score).toBe(100);
+  });
+});

--- a/tests/utils/videoActivityNormalize.test.ts
+++ b/tests/utils/videoActivityNormalize.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from 'vitest';
+import {
+  normalizeVideoActivityQuestion,
+  normalizeVideoActivityQuestions,
+} from '@/utils/videoActivityNormalize';
+import type { VideoActivityQuestion } from '@/types';
+
+describe('normalizeVideoActivityQuestion', () => {
+  it('defaults missing type to MC', () => {
+    const result = normalizeVideoActivityQuestion({
+      id: 'q1',
+      text: 'pre-PR2a question',
+      timestamp: 5,
+      timeLimit: 30,
+      // type intentionally omitted — pre-PR2a shape
+      correctAnswer: 'Mars',
+      incorrectAnswers: ['Earth', 'Jupiter'],
+    } as unknown as VideoActivityQuestion);
+    expect(result.type).toBe('MC');
+  });
+
+  it('defaults missing points to 1', () => {
+    const result = normalizeVideoActivityQuestion({
+      id: 'q1',
+      text: '',
+      timestamp: 0,
+      timeLimit: 30,
+      type: 'MC',
+      correctAnswer: 'a',
+      incorrectAnswers: [],
+      // points intentionally omitted
+    } as VideoActivityQuestion);
+    expect(result.points).toBe(1);
+  });
+
+  it('preserves PR2a-shape questions unchanged', () => {
+    const original: VideoActivityQuestion = {
+      id: 'q1',
+      text: 'multi answer',
+      timestamp: 10,
+      timeLimit: 60,
+      type: 'MA',
+      correctAnswer: 'a|b',
+      incorrectAnswers: ['c'],
+      points: 3,
+      allowPartialCredit: true,
+    };
+    const result = normalizeVideoActivityQuestion(original);
+    expect(result).toEqual(original);
+  });
+
+  it('idempotent', () => {
+    const once = normalizeVideoActivityQuestion({
+      id: 'q1',
+      text: '',
+      timestamp: 0,
+      timeLimit: 30,
+      correctAnswer: '',
+      incorrectAnswers: [],
+    } as unknown as VideoActivityQuestion);
+    const twice = normalizeVideoActivityQuestion(once);
+    expect(twice).toEqual(once);
+  });
+});
+
+describe('normalizeVideoActivityQuestions', () => {
+  it('handles undefined input', () => {
+    expect(normalizeVideoActivityQuestions(undefined)).toEqual([]);
+  });
+
+  it('normalizes every question in the array', () => {
+    const result = normalizeVideoActivityQuestions([
+      {
+        id: 'q1',
+        text: 'a',
+        timestamp: 0,
+        timeLimit: 30,
+        correctAnswer: 'x',
+        incorrectAnswers: [],
+      },
+      {
+        id: 'q2',
+        text: 'b',
+        timestamp: 5,
+        timeLimit: 30,
+        type: 'FIB',
+        correctAnswer: 'y',
+        incorrectAnswers: [],
+        points: 5,
+      },
+    ] as unknown as VideoActivityQuestion[]);
+    expect(result[0].type).toBe('MC');
+    expect(result[0].points).toBe(1);
+    expect(result[1].type).toBe('FIB');
+    expect(result[1].points).toBe(5);
+  });
+});

--- a/types.ts
+++ b/types.ts
@@ -2543,13 +2543,46 @@ export interface SharedQuizAssignment {
 // --- VIDEO ACTIVITY TYPES ---
 
 /**
- * A quiz question that is tied to a specific timestamp in a YouTube video.
- * Only MC question type is supported in V1.
+ * Question types supported by the Video Activity widget. Distinct from
+ * `QuizQuestionType` — VA introduces `'MA'` (multi-answer / "select all
+ * that apply") and does not surface Matching or Ordering, which don't
+ * map cleanly to a video-cue-point pause.
  */
-export interface VideoActivityQuestion extends QuizQuestion {
+export type VideoActivityQuestionType = 'MC' | 'FIB' | 'MA';
+
+/**
+ * A question tied to a specific timestamp in a YouTube video.
+ *
+ * Storage shape per `type`:
+ *   - `MC`:  `correctAnswer` is the correct option text;
+ *            `incorrectAnswers` are distractors.
+ *   - `FIB`: `correctAnswer` is the canonical accepted answer;
+ *            `acceptableVariants` (optional) is a list of additional
+ *            accepted forms (e.g. ["color", "colour"]).
+ *   - `MA`:  `correctAnswer` is `|`-encoded correct selections
+ *            ("opt1|opt2|opt3"); `incorrectAnswers` are the distractor
+ *            options shown alongside. Mirrors the Matching/Ordering
+ *            convention so the wire format stays uniform.
+ *
+ * Inherits `points?` and `allowPartialCredit?` from `QuizQuestion`. MA
+ * uses `allowPartialCredit` to score (|correct ∩ given| − |given − correct|)
+ * / |correct| × points; without partial credit the question is all-or-nothing.
+ */
+export type VideoActivityQuestion = Omit<
+  QuizQuestion,
+  'type' | 'matchingDistractors'
+> & {
+  type: VideoActivityQuestionType;
   /** Seconds into the video when this question should trigger. */
   timestamp: number;
-}
+  /**
+   * FIB only — additional accepted answers beyond `correctAnswer`. Each
+   * variant is normalized (whitespace + case collapsed) before comparison
+   * via `normalizeAnswer`. Empty/missing = the canonical answer is the
+   * only accepted form.
+   */
+  acceptableVariants?: string[];
+};
 
 /** Full video activity data stored in Google Drive as JSON. */
 export interface VideoActivityData {

--- a/utils/videoActivityGrading.ts
+++ b/utils/videoActivityGrading.ts
@@ -1,0 +1,123 @@
+/**
+ * Single shared grader for Video Activity questions. All three call-sites
+ * (student-side QuestionOverlay, post-completion summary in
+ * VideoActivityStudentApp, teacher Results) MUST route correctness checks
+ * through this module. Bypassing it via raw `answer === correctAnswer`
+ * comparison silently drifts pre-PR2a logic and creates student/gradebook
+ * discrepancies — see PR1b/PR2 alignment plan for the regression history.
+ *
+ * Wire format per question type:
+ *   - MC  : correctAnswer = "the right option text"
+ *   - FIB : correctAnswer = "canonical answer"; acceptableVariants?: string[]
+ *   - MA  : correctAnswer = "opt1|opt2|opt3"  (correct selections, |-encoded)
+ *
+ * For MA, the student client packages selections as `selected.sort().join('|')`
+ * before submission so the grader's set-compare is deterministic against any
+ * checkbox order.
+ */
+
+import type { GradeResult, VideoActivityQuestion } from '@/types';
+import { normalizeAnswer } from '@/hooks/useQuizSession';
+
+/**
+ * Grade a single Video Activity answer.
+ *
+ * Returns full-credit (`isCorrect: true`, `pointsEarned = pointsMax`) when
+ * the answer matches exactly. For MA with `allowPartialCredit` set, may
+ * return a fractional `pointsEarned` even when `isCorrect` is `false`.
+ *
+ * Defensive against missing/legacy fields:
+ *   - missing `type`     → treated as 'MC'
+ *   - missing `points`   → 1
+ *   - missing `correctAnswer` → empty string (always wrong unless given
+ *     is also empty, which is a no-op)
+ */
+export function gradeVideoActivityAnswer(
+  question: VideoActivityQuestion,
+  studentAnswer: string
+): GradeResult {
+  const max = question.points ?? 1;
+  const type = question.type ?? 'MC';
+  const correct = question.correctAnswer ?? '';
+
+  if (type === 'MC') {
+    const isCorrect =
+      normalizeAnswer(correct) === normalizeAnswer(studentAnswer);
+    return { isCorrect, pointsEarned: isCorrect ? max : 0, pointsMax: max };
+  }
+
+  if (type === 'FIB') {
+    const givenNorm = normalizeAnswer(studentAnswer);
+    const accepted = [correct, ...(question.acceptableVariants ?? [])];
+    const isCorrect = accepted.some((a) => normalizeAnswer(a) === givenNorm);
+    return { isCorrect, pointsEarned: isCorrect ? max : 0, pointsMax: max };
+  }
+
+  if (type === 'MA') {
+    const correctSet = new Set(
+      correct
+        .split('|')
+        .map(normalizeAnswer)
+        .filter((s) => s.length > 0)
+    );
+    const givenSet = new Set(
+      studentAnswer
+        .split('|')
+        .map(normalizeAnswer)
+        .filter((s) => s.length > 0)
+    );
+    let intersection = 0;
+    for (const s of givenSet) {
+      if (correctSet.has(s)) intersection++;
+    }
+    const wrongSelections = givenSet.size - intersection;
+    const isCorrect =
+      correctSet.size > 0 &&
+      intersection === correctSet.size &&
+      wrongSelections === 0;
+
+    if (!question.allowPartialCredit) {
+      return { isCorrect, pointsEarned: isCorrect ? max : 0, pointsMax: max };
+    }
+    if (correctSet.size === 0) {
+      return { isCorrect: false, pointsEarned: 0, pointsMax: max };
+    }
+    // Partial credit: reward correct picks, penalize wrong picks. Floor at 0
+    // so a student who picked nothing right but every wrong option doesn't
+    // go negative. Cap at max for the all-correct case.
+    const raw = (intersection - wrongSelections) / correctSet.size;
+    const pointsEarned = Math.max(0, Math.min(1, raw)) * max;
+    return { isCorrect, pointsEarned, pointsMax: max };
+  }
+
+  // Unknown type — fail closed.
+  return { isCorrect: false, pointsEarned: 0, pointsMax: max };
+}
+
+/**
+ * Convenience: compute a student's percentage score across all questions.
+ * Uses points-aware totals so a 5-point MA question counts more than a
+ * 1-point MC. Returns 0 when there are no questions.
+ *
+ * `answers` may contain duplicates per question (e.g. arrayUnion races);
+ * we credit only the first answer per question id to avoid inflation.
+ */
+export function computeVideoActivityScorePct(
+  questions: VideoActivityQuestion[],
+  answers: { questionId: string; answer: string }[]
+): number {
+  if (questions.length === 0) return 0;
+  const seen = new Set<string>();
+  let earned = 0;
+  let max = 0;
+  for (const q of questions) {
+    max += q.points ?? 1;
+    if (seen.has(q.id)) continue;
+    const a = answers.find((x) => x.questionId === q.id);
+    if (!a) continue;
+    seen.add(q.id);
+    earned += gradeVideoActivityAnswer(q, a.answer).pointsEarned;
+  }
+  if (max === 0) return 0;
+  return Math.round((earned / max) * 100);
+}

--- a/utils/videoActivityGrading.ts
+++ b/utils/videoActivityGrading.ts
@@ -17,7 +17,21 @@
  */
 
 import type { GradeResult, VideoActivityQuestion } from '@/types';
-import { normalizeAnswer } from '@/hooks/useQuizSession';
+import { normalizeAnswer as quizNormalizeAnswer } from '@/hooks/useQuizSession';
+
+/**
+ * VA-specific answer normalization. Applies Quiz's whitespace + case pass
+ * AND additionally strips combining diacritical marks (NFD + remove
+ * `̀-ͯ`), so that `café` and `cafe`, `naïve` and `naive`, or
+ * `résumé` and `resume` all compare as equivalent. This is a deliberate
+ * VA-only forgiveness — Quiz's own grading stays strict to keep Matching
+ * pair-equality behavior unchanged.
+ */
+function normalizeAnswer(s: string): string {
+  return quizNormalizeAnswer(s)
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '');
+}
 
 /**
  * Grade a single Video Activity answer.

--- a/utils/videoActivityNormalize.ts
+++ b/utils/videoActivityNormalize.ts
@@ -1,0 +1,29 @@
+/**
+ * Read-side normalization for Video Activity question payloads.
+ *
+ * Pre-PR2a Drive blobs / session docs may have questions with a missing
+ * `type` (always treated as MC by the V1 editor) and missing `points`.
+ * Routing all reads through `normalizeQuestion` lets the rest of the
+ * pipeline assume the post-PR2a shape — every call site can rely on
+ * `q.type` and `q.points` being present.
+ *
+ * Pure function; safe to call repeatedly.
+ */
+
+import type { VideoActivityQuestion } from '@/types';
+
+export function normalizeVideoActivityQuestion(
+  q: VideoActivityQuestion
+): VideoActivityQuestion {
+  return {
+    ...q,
+    type: q.type ?? 'MC',
+    points: q.points ?? 1,
+  };
+}
+
+export function normalizeVideoActivityQuestions(
+  qs: VideoActivityQuestion[] | undefined
+): VideoActivityQuestion[] {
+  return (qs ?? []).map(normalizeVideoActivityQuestion);
+}


### PR DESCRIPTION
## Summary

Phase 2 of the VA-Quiz alignment effort, **part 1 of 2**. This PR adds Fill-in-the-Blank (with optional `acceptableVariants[]`) and Multi-Answer (single- or partial-credit) question types to Video Activity, plus per-question point values surfaced in the editor. Part 2 (PR2b — discovery + Timeline UI) will follow once this is in production a few days.

## Why a single shared grader matters

Pre-PR2a, three independent call-sites computed correctness via raw `answer === q.correctAnswer` equality:
- `QuestionOverlay.tsx:52` (student-side submit)
- `VideoActivityStudentApp.tsx:523` (post-completion summary)
- `Results.tsx:67` (teacher results)

If PR2a missed any one, students and gradebook would silently disagree on MA questions. All three now route through `gradeVideoActivityAnswer` in `utils/videoActivityGrading.ts`. The plan agent flagged this as the single biggest blast-radius risk — addressed.

## What changed

- **`types.ts`** — `VideoActivityQuestion` is now `Omit<QuizQuestion, 'type' | 'matchingDistractors'> & { type: 'MC' | 'FIB' | 'MA'; ... }`. Avoids polluting `QuizQuestionType` with VA's MA literal.
- **`utils/videoActivityGrading.ts`** (new) — `gradeVideoActivityAnswer` + `computeVideoActivityScorePct`.
- **`utils/videoActivityNormalize.ts`** (new) — defaults missing `type` to 'MC' and missing `points` to 1; wired into `useVideoActivity.loadActivityData` (Drive read) and `useVideoActivitySession.normalizeSession` (Firestore session read).
- **`VideoActivityEditorModal.tsx`** — type segmented control + points input, conditional sub-forms (`McSubForm`/`FibSubForm`/`MaSubForm`), MA validation requires ≥1 correct selection, subtitle shows "N questions • M points".
- **`QuestionOverlay.tsx`** — branches on type: MC buttons, FIB text input, MA checkbox list. All correctness checks via shared grader.
- **`Results.tsx`** + **`VideoActivityStudentApp.tsx`** — grading consolidated through shared grader.

## MA wire format

Selections are `|`-encoded into existing `correctAnswer: string` (e.g. `"opt1|opt2|opt3"`). Mirrors Matching/Ordering convention; pre-PR2a clients render the encoded string as a single MC option (unanswerable but no crash). Student submits as `selected.sort().join('|')` for order-independent set-compare.

## Known follow-up (PR3)

`Results.tsx` export still calls Quiz's `gradeAnswer` for VA questions, which has no 'MA' case and grades MA columns as 0/Npt in the exported sheet. PR3 lifts `buildResultsSheetData` into `utils/assignmentExportShared.ts` accepting a custom grader; the cast at the call-site disappears then. MC + FIB grade correctly in export today.

## Test plan
- [x] `pnpm run type-check` clean
- [x] `pnpm exec eslint --ignore-pattern remotion/` clean (zero warnings)
- [x] All 2081 unit tests pass (was 2053; +28 new for grader/normalizer)
- [x] New tests cover: MC exact/case/whitespace, FIB canonical+variants, MA full/partial-credit/over-select, defensive defaults (missing type/points), normalizer round-trip + idempotency, points-weighted percentage
- [x] VA widget mounts cleanly in preview (verified via eval — render errors would have surfaced)
- [ ] **Manual cross-version test** — pre-PR2a Drive blob opens correctly with normalizer applying defaults (verify on preview URL when available)
- [ ] **Manual create-each-type** — author one MC, one FIB (with variants), one MA (with partial credit), save, reload, run as student
- [ ] **Manual grading** — confirm Results % matches student's post-completion %

🤖 Generated with [Claude Code](https://claude.com/claude-code)