### PR TITLE
feat(plc): Overview tab + bento grid + Notes/To-Dos + sidebar kebab

### DIFF
--- a/components/layout/sidebar/SidebarPlcs.tsx
+++ b/components/layout/sidebar/SidebarPlcs.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   Users2,
@@ -67,6 +67,23 @@ const PlcRow: React.FC<PlcRowProps> = ({
   const kebabRef = useRef<HTMLButtonElement>(null);
 
   useClickOutside(menuRef, () => setMenuOpen(false), [kebabRef]);
+
+  // Escape closes the menu and restores focus to the kebab button.
+  // `aria-haspopup="menu"` on the kebab implies this contract per WAI-ARIA
+  // menu-button practices. Mounted only while the menu is open to avoid a
+  // global listener tax for every PLC row in the sidebar.
+  useEffect(() => {
+    if (!menuOpen) return;
+    const handler = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.stopPropagation();
+        setMenuOpen(false);
+        kebabRef.current?.focus();
+      }
+    };
+    document.addEventListener('keydown', handler);
+    return () => document.removeEventListener('keydown', handler);
+  }, [menuOpen]);
 
   const handleMenuClick = (e: React.MouseEvent, action: () => void) => {
     e.stopPropagation();

--- a/components/layout/sidebar/SidebarPlcs.tsx
+++ b/components/layout/sidebar/SidebarPlcs.tsx
@@ -1,9 +1,19 @@
-import React, { useState } from 'react';
+import React, { useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Users2, Plus, Pencil, LogOut, Trash2, Mail } from 'lucide-react';
+import {
+  Users2,
+  Plus,
+  Pencil,
+  LogOut,
+  Trash2,
+  Mail,
+  ChevronRight,
+  MoreVertical,
+} from 'lucide-react';
 
 import { useAuth } from '@/context/useAuth';
 import { useDialog } from '@/context/useDialog';
+import { useClickOutside } from '@/hooks/useClickOutside';
 import { Plc, PlcInvitation } from '@/types';
 import { PlcEditModal } from './PlcEditModal';
 import { PlcInvitesModal } from './PlcInvitesModal';
@@ -22,11 +32,167 @@ interface SidebarPlcsProps {
   onOpenDashboard: (plcId: string) => void;
 }
 
+interface PlcRowProps {
+  plc: Plc;
+  isLead: boolean;
+  onOpen: () => void;
+  onEdit: () => void;
+  onDelete: () => void;
+  onLeave: () => void;
+}
+
+/**
+ * One PLC card in the sidebar list.
+ *
+ * Click-affordance design: the entire card is a single click target that
+ * opens the PLC Dashboard. Secondary actions (edit/view, delete/leave)
+ * collapse into a kebab popover. Implemented as an absolute-positioned
+ * backdrop `<button>` (the row click) with the visible content + kebab
+ * layered above. `pointer-events-none` on the static visual content lets
+ * clicks fall through to the backdrop; `pointer-events-auto` on the kebab
+ * captures its own clicks. This avoids the invalid nested-button HTML
+ * the previous split-row layout was working around.
+ */
+const PlcRow: React.FC<PlcRowProps> = ({
+  plc,
+  isLead,
+  onOpen,
+  onEdit,
+  onDelete,
+  onLeave,
+}) => {
+  const { t } = useTranslation();
+  const [menuOpen, setMenuOpen] = useState(false);
+  const menuRef = useRef<HTMLDivElement>(null);
+  const kebabRef = useRef<HTMLButtonElement>(null);
+
+  useClickOutside(menuRef, () => setMenuOpen(false), [kebabRef]);
+
+  const handleMenuClick = (e: React.MouseEvent, action: () => void) => {
+    e.stopPropagation();
+    setMenuOpen(false);
+    action();
+  };
+
+  return (
+    <div className="group relative flex items-center gap-2 p-2.5 bg-white border border-slate-200 hover:border-brand-blue-primary/40 hover:bg-brand-blue-lighter/20 rounded-xl transition-all">
+      {/* Backdrop click target — covers the full card so clicking anywhere
+          (except the kebab) opens the dashboard. */}
+      <button
+        type="button"
+        onClick={onOpen}
+        className="absolute inset-0 rounded-xl focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue-primary"
+        aria-label={t('sidebar.plcs.openDashboard', {
+          defaultValue: 'Open {{name}} dashboard',
+          name: plc.name,
+        })}
+      />
+
+      {/* Visible content. `pointer-events-none` so clicks pass through to
+          the backdrop button. */}
+      <div className="relative flex items-center gap-2 flex-1 min-w-0 pointer-events-none">
+        <div className="shrink-0 w-8 h-8 rounded-lg bg-brand-blue-lighter flex items-center justify-center">
+          <Users2 className="w-4 h-4 text-brand-blue-primary" />
+        </div>
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-1.5 min-w-0">
+            <div className="text-sm font-bold text-slate-800 truncate">
+              {plc.name}
+            </div>
+            {isLead && (
+              <span className="text-xxs font-bold text-brand-blue-primary bg-brand-blue-lighter px-1.5 py-0.5 rounded uppercase tracking-wider">
+                {t('sidebar.plcs.leadBadge', { defaultValue: 'Lead' })}
+              </span>
+            )}
+          </div>
+          <div className="text-xxs font-semibold text-slate-400 uppercase tracking-widest">
+            {t('sidebar.plcs.memberCount', {
+              count: plc.memberUids.length,
+              defaultValue: '{{count}} Member',
+              defaultValue_other: '{{count}} Members',
+            })}
+          </div>
+        </div>
+      </div>
+
+      {/* Right-side cluster: chevron affordance + kebab. `pointer-events-auto`
+          re-enables clicks here so the kebab fires its own handler. */}
+      <div className="relative flex items-center gap-0.5 shrink-0 pointer-events-auto">
+        <ChevronRight
+          className="w-4 h-4 text-slate-300 group-hover:text-brand-blue-primary transition-colors"
+          aria-hidden="true"
+        />
+        <button
+          ref={kebabRef}
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation();
+            setMenuOpen((prev) => !prev);
+          }}
+          className="p-1.5 text-slate-400 hover:text-brand-blue-primary hover:bg-brand-blue-lighter rounded-lg transition-colors"
+          aria-haspopup="menu"
+          aria-expanded={menuOpen}
+          aria-label={t('sidebar.plcs.actionsMenu', {
+            defaultValue: 'PLC actions',
+          })}
+          title={t('sidebar.plcs.actionsMenu', {
+            defaultValue: 'PLC actions',
+          })}
+        >
+          <MoreVertical className="w-4 h-4" />
+        </button>
+
+        {menuOpen && (
+          <div
+            ref={menuRef}
+            role="menu"
+            className="absolute right-0 top-full mt-1 z-20 min-w-[160px] bg-white border border-slate-200 rounded-lg shadow-lg overflow-hidden animate-in fade-in slide-in-from-top-1 duration-150"
+            data-click-outside-ignore="true"
+          >
+            <button
+              type="button"
+              role="menuitem"
+              onClick={(e) => handleMenuClick(e, onEdit)}
+              className="w-full flex items-center gap-2.5 px-3 py-2 text-xs font-semibold text-slate-700 hover:bg-slate-100 transition-colors text-left"
+            >
+              <Pencil className="w-3.5 h-3.5 text-slate-500" />
+              {isLead
+                ? t('sidebar.plcs.editPlc', { defaultValue: 'Edit PLC' })
+                : t('sidebar.plcs.viewPlc', { defaultValue: 'View PLC' })}
+            </button>
+            {isLead ? (
+              <button
+                type="button"
+                role="menuitem"
+                onClick={(e) => handleMenuClick(e, onDelete)}
+                className="w-full flex items-center gap-2.5 px-3 py-2 text-xs font-semibold text-red-600 hover:bg-red-50 transition-colors text-left border-t border-slate-100"
+              >
+                <Trash2 className="w-3.5 h-3.5" />
+                {t('sidebar.plcs.deletePlc', { defaultValue: 'Delete PLC' })}
+              </button>
+            ) : (
+              <button
+                type="button"
+                role="menuitem"
+                onClick={(e) => handleMenuClick(e, onLeave)}
+                className="w-full flex items-center gap-2.5 px-3 py-2 text-xs font-semibold text-red-600 hover:bg-red-50 transition-colors text-left border-t border-slate-100"
+              >
+                <LogOut className="w-3.5 h-3.5" />
+                {t('sidebar.plcs.leavePlc', { defaultValue: 'Leave PLC' })}
+              </button>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
 /**
  * "My PLCs" sidebar page.
  *
- * Mirrors `SidebarClasses` — flat list of the user's PLCs with inline edit /
- * leave / delete actions and modals for create+edit + pending invites.
+ * Mirrors `SidebarClasses` — flat list of the user's PLCs with a kebab
+ * action menu and modals for create+edit + pending invites.
  */
 export const SidebarPlcs: React.FC<SidebarPlcsProps> = ({
   isVisible,
@@ -207,102 +373,15 @@ export const SidebarPlcs: React.FC<SidebarPlcsProps> = ({
                   {plcs.map((plc) => {
                     const isLead = plc.leadUid === user?.uid;
                     return (
-                      <div
+                      <PlcRow
                         key={plc.id}
-                        className="flex items-center gap-2 p-2.5 bg-white border border-slate-200 hover:border-slate-300 rounded-xl transition-all"
-                      >
-                        {/* Left side: clickable area opens the PLC dashboard.
-                            Implemented as a button so keyboard + screen-reader
-                            navigation work. The right-side action icons sit
-                            outside this button so nested-button HTML is avoided. */}
-                        <button
-                          type="button"
-                          onClick={() => onOpenDashboard(plc.id)}
-                          className="flex items-center gap-2 flex-1 min-w-0 text-left rounded-lg hover:bg-brand-blue-lighter/30 transition-colors -m-1 p-1"
-                          aria-label={t('sidebar.plcs.openDashboard', {
-                            defaultValue: 'Open {{name}} dashboard',
-                            name: plc.name,
-                          })}
-                        >
-                          <div className="shrink-0 w-8 h-8 rounded-lg bg-brand-blue-lighter flex items-center justify-center">
-                            <Users2 className="w-4 h-4 text-brand-blue-primary" />
-                          </div>
-                          <div className="flex-1 min-w-0">
-                            <div className="flex items-center gap-1.5 min-w-0">
-                              <div className="text-sm font-bold text-slate-800 truncate">
-                                {plc.name}
-                              </div>
-                              {isLead && (
-                                <span className="text-xxs font-bold text-brand-blue-primary bg-brand-blue-lighter px-1.5 py-0.5 rounded uppercase tracking-wider">
-                                  {t('sidebar.plcs.leadBadge', {
-                                    defaultValue: 'Lead',
-                                  })}
-                                </span>
-                              )}
-                            </div>
-                            <div className="text-xxs font-semibold text-slate-400 uppercase tracking-widest">
-                              {t('sidebar.plcs.memberCount', {
-                                count: plc.memberUids.length,
-                                defaultValue: '{{count}} Member',
-                                defaultValue_other: '{{count}} Members',
-                              })}
-                            </div>
-                          </div>
-                        </button>
-                        <div className="flex items-center gap-0.5 shrink-0">
-                          <button
-                            onClick={() => setEditingPlcId(plc.id)}
-                            className="p-1.5 text-slate-400 hover:text-brand-blue-primary hover:bg-brand-blue-lighter rounded-lg transition-colors"
-                            title={
-                              isLead
-                                ? t('sidebar.plcs.editPlc', {
-                                    defaultValue: 'Edit PLC',
-                                  })
-                                : t('sidebar.plcs.viewPlc', {
-                                    defaultValue: 'View PLC',
-                                  })
-                            }
-                            aria-label={
-                              isLead
-                                ? t('sidebar.plcs.editPlc', {
-                                    defaultValue: 'Edit PLC',
-                                  })
-                                : t('sidebar.plcs.viewPlc', {
-                                    defaultValue: 'View PLC',
-                                  })
-                            }
-                          >
-                            <Pencil className="w-3.5 h-3.5" />
-                          </button>
-                          {isLead ? (
-                            <button
-                              onClick={() => void handleDelete(plc)}
-                              className="p-1.5 text-slate-400 hover:text-red-500 hover:bg-red-50 rounded-lg transition-colors"
-                              title={t('sidebar.plcs.deletePlc', {
-                                defaultValue: 'Delete PLC',
-                              })}
-                              aria-label={t('sidebar.plcs.deletePlc', {
-                                defaultValue: 'Delete PLC',
-                              })}
-                            >
-                              <Trash2 className="w-3.5 h-3.5" />
-                            </button>
-                          ) : (
-                            <button
-                              onClick={() => void handleLeave(plc)}
-                              className="p-1.5 text-slate-400 hover:text-red-500 hover:bg-red-50 rounded-lg transition-colors"
-                              title={t('sidebar.plcs.leavePlc', {
-                                defaultValue: 'Leave PLC',
-                              })}
-                              aria-label={t('sidebar.plcs.leavePlc', {
-                                defaultValue: 'Leave PLC',
-                              })}
-                            >
-                              <LogOut className="w-3.5 h-3.5" />
-                            </button>
-                          )}
-                        </div>
-                      </div>
+                        plc={plc}
+                        isLead={isLead}
+                        onOpen={() => onOpenDashboard(plc.id)}
+                        onEdit={() => setEditingPlcId(plc.id)}
+                        onDelete={() => void handleDelete(plc)}
+                        onLeave={() => void handleLeave(plc)}
+                      />
                     );
                   })}
                 </div>

--- a/components/plc/PlcDashboard.tsx
+++ b/components/plc/PlcDashboard.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   BookOpen,
@@ -6,6 +6,7 @@ import {
   ChevronRight,
   ClipboardList,
   Film,
+  LayoutDashboard,
   ListChecks,
   Settings as SettingsIcon,
   SquareSquare,
@@ -16,8 +17,11 @@ import {
 
 import { Plc, PlcFeatureSettings, getPlcFeatures } from '@/types';
 import { useAuth } from '@/context/useAuth';
+import { PlcOverviewTab } from './tabs/PlcOverviewTab';
 import { PlcCompletedAssignmentsTab } from './tabs/PlcCompletedAssignmentsTab';
 import { PlcSettingsTab } from './tabs/PlcSettingsTab';
+import { PlcNotesTab } from './tabs/PlcNotesTab';
+import { PlcTodosTab } from './tabs/PlcTodosTab';
 import { PlcPlaceholderTab } from './tabs/PlcPlaceholderTab';
 
 interface PlcDashboardProps {
@@ -25,7 +29,8 @@ interface PlcDashboardProps {
   onClose: () => void;
 }
 
-type TabId =
+export type PlcDashboardTabId =
+  | 'overview'
   | 'completed'
   | 'quizzes'
   | 'assignments'
@@ -36,13 +41,13 @@ type TabId =
   | 'settings';
 
 interface TabDef {
-  id: TabId;
+  id: PlcDashboardTabId;
   icon: LucideIcon;
   labelKey: string;
   labelDefault: string;
   /**
    * Feature flag key gating this tab; absent means the tab is always
-   * visible (Completed Assignments + Settings).
+   * visible (Overview, Completed Assignments, Settings).
    */
   feature?: keyof PlcFeatureSettings;
   /** Phase 1 placeholder copy for tabs not yet implemented. */
@@ -50,6 +55,12 @@ interface TabDef {
 }
 
 const TABS: readonly TabDef[] = [
+  {
+    id: 'overview',
+    icon: LayoutDashboard,
+    labelKey: 'plcDashboard.tabs.overview',
+    labelDefault: 'Overview',
+  },
   {
     id: 'completed',
     icon: ClipboardList,
@@ -98,10 +109,6 @@ const TABS: readonly TabDef[] = [
     labelKey: 'plcDashboard.tabs.notes',
     labelDefault: 'Notes',
     feature: 'notes',
-    placeholder: {
-      titleDefault: 'PLC Notes',
-      descriptionDefault: 'A shared notebook for the PLC.',
-    },
   },
   {
     id: 'todos',
@@ -109,11 +116,6 @@ const TABS: readonly TabDef[] = [
     labelKey: 'plcDashboard.tabs.todos',
     labelDefault: 'To-Do List',
     feature: 'todos',
-    placeholder: {
-      titleDefault: 'PLC To-Do List',
-      descriptionDefault:
-        'Track action items the PLC has agreed to follow up on.',
-    },
   },
   {
     id: 'sharedBoards',
@@ -143,7 +145,7 @@ const TABS: readonly TabDef[] = [
 export const PlcDashboard: React.FC<PlcDashboardProps> = ({ plc, onClose }) => {
   const { t } = useTranslation();
   const { user } = useAuth();
-  const [activeTab, setActiveTab] = useState<TabId>('completed');
+  const [activeTab, setActiveTab] = useState<PlcDashboardTabId>('overview');
   const [showMobileMenu, setShowMobileMenu] = useState(true);
 
   // Close on Escape — same UX contract as AdminSettings.
@@ -162,11 +164,11 @@ export const PlcDashboard: React.FC<PlcDashboardProps> = ({ plc, onClose }) => {
   );
 
   // If the active tab gets hidden via a settings toggle by another member,
-  // fall back to "Completed Assignments" — which is always visible. Adjust
-  // state during render rather than via an effect to avoid an extra render
-  // pass; the setter is a no-op when the value is already 'completed'.
+  // fall back to "Overview" — which is always visible. Adjust state during
+  // render rather than via an effect to avoid an extra render pass; the
+  // setter is a no-op when the value is already 'overview'.
   if (!visibleTabs.find((tab) => tab.id === activeTab)) {
-    setActiveTab('completed');
+    setActiveTab('overview');
   }
 
   const activeTabDef = visibleTabs.find((tab) => tab.id === activeTab);
@@ -180,9 +182,27 @@ export const PlcDashboard: React.FC<PlcDashboardProps> = ({ plc, onClose }) => {
     }
   };
 
+  // Tile click handler — overview tiles call this to drill into a tab.
+  // On mobile the drawer is currently open (because the user just
+  // navigated from the menu); auto-collapse it so the tab content
+  // becomes visible without an extra tap.
+  const handleNavigateTab = useCallback((tabId: PlcDashboardTabId) => {
+    setActiveTab(tabId);
+    setShowMobileMenu(false);
+  }, []);
+
   const renderTabContent = (tab: TabDef) => {
+    if (tab.id === 'overview') {
+      return <PlcOverviewTab plc={plc} onNavigateTab={handleNavigateTab} />;
+    }
     if (tab.id === 'completed') {
       return <PlcCompletedAssignmentsTab plc={plc} />;
+    }
+    if (tab.id === 'notes') {
+      return <PlcNotesTab plc={plc} />;
+    }
+    if (tab.id === 'todos') {
+      return <PlcTodosTab plc={plc} />;
     }
     if (tab.id === 'settings') {
       return <PlcSettingsTab plc={plc} />;

--- a/components/plc/overview/PlcBentoGrid.tsx
+++ b/components/plc/overview/PlcBentoGrid.tsx
@@ -1,0 +1,221 @@
+import React, { useCallback, useMemo, useState } from 'react';
+import {
+  DndContext,
+  DragOverlay,
+  KeyboardSensor,
+  PointerSensor,
+  closestCenter,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+  type DragStartEvent,
+} from '@dnd-kit/core';
+import {
+  SortableContext,
+  rectSortingStrategy,
+  sortableKeyboardCoordinates,
+} from '@dnd-kit/sortable';
+import { snapCenterToCursor } from '@dnd-kit/modifiers';
+import { useTranslation } from 'react-i18next';
+import { EyeOff } from 'lucide-react';
+import {
+  Plc,
+  PlcBentoTileKind,
+  PlcOverviewLayout,
+  getPlcFeatures,
+} from '@/types';
+import { renderTileContent, tileFeatureGate } from './tileRegistry';
+import { nextSize } from './bentoSizes';
+import { PlcBentoTile } from './PlcBentoTile';
+import type { PlcDashboardTabId } from '../PlcDashboard';
+
+interface PlcBentoGridProps {
+  plc: Plc;
+  layout: PlcOverviewLayout;
+  editMode: boolean;
+  onLayoutChange: (next: PlcOverviewLayout) => void;
+  onNavigateTab: (tabId: PlcDashboardTabId) => void;
+}
+
+/**
+ * The PLC Overview bento grid. Renders visible tiles in a 4-column CSS
+ * grid (1-column on mobile) with dnd-kit sortable wiring for reorder and
+ * resize. Hidden tiles surface in a tray below the grid in edit mode so
+ * the user can restore them.
+ *
+ * Drag pattern mirrors `components/common/library/LibraryGrid.tsx`:
+ * `closestCenter` collision detection, `rectSortingStrategy`,
+ * `PointerSensor { distance: 5 }` (so click-to-resize doesn't fire as a
+ * drag), and a `DragOverlay` snapped to the cursor (heterogeneous spans
+ * look broken when the source tile is transformed in place).
+ */
+export const PlcBentoGrid: React.FC<PlcBentoGridProps> = ({
+  plc,
+  layout,
+  editMode,
+  onLayoutChange,
+  onNavigateTab,
+}) => {
+  const { t } = useTranslation();
+  const [activeKind, setActiveKind] = useState<PlcBentoTileKind | null>(null);
+  const features = useMemo(() => getPlcFeatures(plc), [plc]);
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    })
+  );
+
+  // Filter tiles whose feature is disabled by the PLC's `features` map.
+  // The Settings toggle has the final say — if the PLC has notes off,
+  // the bento grid hides the Notes tile too (matches the tab gate).
+  const featureFilteredTiles = useMemo(
+    () =>
+      layout.tiles.filter((tile) => {
+        const gate = tileFeatureGate(tile.kind);
+        if (gate && !features[gate]) return false;
+        return true;
+      }),
+    [layout.tiles, features]
+  );
+
+  const visibleTiles = featureFilteredTiles.filter((t) => !t.hidden);
+  const hiddenTiles = featureFilteredTiles.filter((t) => t.hidden);
+  const visibleKinds = useMemo(
+    () => visibleTiles.map((t) => t.kind),
+    [visibleTiles]
+  );
+  const activeTile = useMemo(
+    () =>
+      activeKind == null
+        ? null
+        : (visibleTiles.find((t) => t.kind === activeKind) ?? null),
+    [activeKind, visibleTiles]
+  );
+
+  const handleDragStart = useCallback((event: DragStartEvent) => {
+    setActiveKind(event.active.id as PlcBentoTileKind);
+  }, []);
+
+  const handleDragCancel = useCallback(() => {
+    setActiveKind(null);
+  }, []);
+
+  const handleDragEnd = useCallback(
+    (event: DragEndEvent) => {
+      setActiveKind(null);
+      const { active, over } = event;
+      if (!over || active.id === over.id) return;
+
+      const activeIdx = layout.tiles.findIndex((t) => t.kind === active.id);
+      const overIdx = layout.tiles.findIndex((t) => t.kind === over.id);
+      if (activeIdx === -1 || overIdx === -1) return;
+
+      const next = [...layout.tiles];
+      const [moved] = next.splice(activeIdx, 1);
+      if (!moved) return;
+      next.splice(overIdx, 0, moved);
+
+      onLayoutChange({ tiles: next, updatedAt: Date.now() });
+    },
+    [layout, onLayoutChange]
+  );
+
+  const handleResize = useCallback(
+    (kind: PlcBentoTileKind) => {
+      const next = layout.tiles.map((tile) =>
+        tile.kind === kind ? { ...tile, size: nextSize(tile.size) } : tile
+      );
+      onLayoutChange({ tiles: next, updatedAt: Date.now() });
+    },
+    [layout, onLayoutChange]
+  );
+
+  const handleToggleHide = useCallback(
+    (kind: PlcBentoTileKind) => {
+      const next = layout.tiles.map((tile) =>
+        tile.kind === kind ? { ...tile, hidden: !tile.hidden } : tile
+      );
+      onLayoutChange({ tiles: next, updatedAt: Date.now() });
+    },
+    [layout, onLayoutChange]
+  );
+
+  return (
+    <div className="space-y-6">
+      <DndContext
+        sensors={sensors}
+        collisionDetection={closestCenter}
+        onDragStart={handleDragStart}
+        onDragEnd={handleDragEnd}
+        onDragCancel={handleDragCancel}
+      >
+        <SortableContext items={visibleKinds} strategy={rectSortingStrategy}>
+          {/* Mobile: single column flow, sizes ignored (each tile natural-height).
+              Desktop (md+): 4-column CSS grid with row spans driven by tile.size. */}
+          <div
+            className="
+              grid grid-cols-1 gap-4
+              md:grid-cols-4 md:auto-rows-[minmax(180px,auto)]
+            "
+            data-testid="plc-bento-grid"
+          >
+            {visibleTiles.map((tile) => (
+              <PlcBentoTile
+                key={tile.kind}
+                tile={tile}
+                editMode={editMode}
+                onResize={handleResize}
+                onToggleHide={handleToggleHide}
+              >
+                {renderTileContent(tile.kind, { plc, onNavigateTab })}
+              </PlcBentoTile>
+            ))}
+          </div>
+        </SortableContext>
+
+        <DragOverlay modifiers={[snapCenterToCursor]}>
+          {activeTile ? (
+            <PlcBentoTile tile={activeTile} editMode={false}>
+              {renderTileContent(activeTile.kind, { plc, onNavigateTab })}
+            </PlcBentoTile>
+          ) : null}
+        </DragOverlay>
+      </DndContext>
+
+      {/* Hidden tiles tray — only shown in edit mode + when there's anything
+          to restore. */}
+      {editMode && hiddenTiles.length > 0 && (
+        <div className="bg-slate-50 border border-dashed border-slate-300 rounded-2xl p-4">
+          <div className="flex items-center gap-2 mb-3">
+            <EyeOff className="w-4 h-4 text-slate-400" />
+            <h4 className="text-xxs font-bold uppercase tracking-widest text-slate-500">
+              {t('plcDashboard.overview.hiddenTiles', {
+                defaultValue: 'Hidden tiles',
+              })}
+            </h4>
+            <span className="text-xxs text-slate-400">
+              {t('plcDashboard.overview.hiddenTilesHint', {
+                defaultValue: 'click to restore',
+              })}
+            </span>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            {hiddenTiles.map((tile) => (
+              <PlcBentoTile
+                key={tile.kind}
+                tile={tile}
+                editMode={false}
+                inTray
+                onToggleHide={handleToggleHide}
+              >
+                {null}
+              </PlcBentoTile>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/components/plc/overview/PlcBentoTile.tsx
+++ b/components/plc/overview/PlcBentoTile.tsx
@@ -1,0 +1,162 @@
+import React from 'react';
+import { useSortable } from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import { useTranslation } from 'react-i18next';
+import { Eye, EyeOff, GripVertical, Maximize2 } from 'lucide-react';
+import type { PlcBentoTile as PlcBentoTileData } from '@/types';
+import { TILE_GRID_SPANS } from './bentoSizes';
+
+interface PlcBentoTileProps {
+  tile: PlcBentoTileData;
+  editMode: boolean;
+  /** Hidden tray rendering: drag/sort wiring is suppressed and grid spans collapse. */
+  inTray?: boolean;
+  onResize?: (kind: PlcBentoTileData['kind']) => void;
+  onToggleHide?: (kind: PlcBentoTileData['kind']) => void;
+  children: React.ReactNode;
+}
+
+/**
+ * Sortable bento tile wrapper. Owns:
+ *   - the dnd-kit `useSortable` binding (drag handle scoped to the grip icon)
+ *   - the CSS-grid `grid-column` / `grid-row` spans for the tile size
+ *   - edit-mode chrome (grip, resize, hide buttons)
+ *   - the tile content slot
+ *
+ * Tile content is rendered in a wrapper that gets `pointer-events-none` while
+ * `editMode` is true, so the user's clicks fall through to the chrome
+ * controls instead of triggering the live tile interactions (e.g. opening
+ * a note while trying to drag the tile).
+ *
+ * `inTray` mode is for the "Hidden tiles" tray: the tile renders as a
+ * compact restore-button without the resize/grip controls.
+ */
+export const PlcBentoTile: React.FC<PlcBentoTileProps> = ({
+  tile,
+  editMode,
+  inTray = false,
+  onResize,
+  onToggleHide,
+  children,
+}) => {
+  const { t } = useTranslation();
+  const sortable = useSortable({
+    id: tile.kind,
+    disabled: !editMode || inTray,
+  });
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = sortable;
+
+  const span = TILE_GRID_SPANS[tile.size];
+
+  const baseStyle: React.CSSProperties = {
+    transform: CSS.Translate.toString(transform),
+    transition,
+    opacity: isDragging ? 0 : 1,
+  };
+
+  const gridStyle: React.CSSProperties = inTray
+    ? {}
+    : {
+        gridColumn: `span ${span.col} / span ${span.col}`,
+        gridRow: `span ${span.row} / span ${span.row}`,
+      };
+
+  if (inTray) {
+    return (
+      <button
+        type="button"
+        onClick={() => onToggleHide?.(tile.kind)}
+        className="flex items-center gap-2 px-3 py-2 bg-white border border-dashed border-slate-300 hover:border-brand-blue-primary rounded-lg text-xs font-semibold text-slate-600 hover:text-brand-blue-primary transition-colors"
+        aria-label={t('plcDashboard.overview.unhideTile', {
+          defaultValue: 'Restore {{kind}} tile',
+          kind: tile.kind,
+        })}
+      >
+        <Eye className="w-3.5 h-3.5" />
+        <span className="capitalize">{tile.kind}</span>
+      </button>
+    );
+  }
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={{ ...baseStyle, ...gridStyle }}
+      className={`relative bg-white rounded-2xl border border-slate-200 shadow-sm overflow-hidden flex flex-col transition-shadow ${
+        editMode ? 'ring-1 ring-brand-blue-primary/20' : 'hover:shadow-md'
+      }`}
+      data-tile-kind={tile.kind}
+      data-tile-size={tile.size}
+    >
+      {/* Edit-mode chrome */}
+      {editMode && (
+        <>
+          {/* Drag handle (grip icon, top-left) — listeners scoped here so
+              tile content stays interactive when not dragging. */}
+          <button
+            type="button"
+            {...listeners}
+            {...attributes}
+            className="absolute top-2 left-2 z-10 p-1.5 bg-white/95 hover:bg-brand-blue-lighter rounded-md text-slate-400 hover:text-brand-blue-primary cursor-grab active:cursor-grabbing transition-colors shadow-sm border border-slate-200"
+            aria-label={t('plcDashboard.overview.dragHandle', {
+              defaultValue: 'Drag to reorder',
+            })}
+            title={t('plcDashboard.overview.dragHandle', {
+              defaultValue: 'Drag to reorder',
+            })}
+          >
+            <GripVertical className="w-3.5 h-3.5" />
+          </button>
+
+          {/* Hide button (top-right) */}
+          <button
+            type="button"
+            onClick={() => onToggleHide?.(tile.kind)}
+            className="absolute top-2 right-2 z-10 p-1.5 bg-white/95 hover:bg-red-50 rounded-md text-slate-400 hover:text-red-500 transition-colors shadow-sm border border-slate-200"
+            aria-label={t('plcDashboard.overview.hideTile', {
+              defaultValue: 'Hide tile',
+            })}
+            title={t('plcDashboard.overview.hideTile', {
+              defaultValue: 'Hide tile',
+            })}
+          >
+            <EyeOff className="w-3.5 h-3.5" />
+          </button>
+
+          {/* Resize button (bottom-right) — cycles size variants */}
+          <button
+            type="button"
+            onClick={() => onResize?.(tile.kind)}
+            className="absolute bottom-2 right-2 z-10 p-1.5 bg-white/95 hover:bg-brand-blue-lighter rounded-md text-slate-400 hover:text-brand-blue-primary transition-colors shadow-sm border border-slate-200"
+            aria-label={t('plcDashboard.overview.resizeTile', {
+              defaultValue: 'Resize tile (current: {{size}})',
+              size: tile.size,
+            })}
+            title={t('plcDashboard.overview.resizeTile', {
+              defaultValue: 'Resize tile (current: {{size}})',
+              size: tile.size,
+            })}
+          >
+            <Maximize2 className="w-3.5 h-3.5" />
+          </button>
+        </>
+      )}
+
+      {/* Tile content. While editing, suppress interaction so clicks land on
+          the chrome buttons, not on whatever interactive content the tile
+          renders (e.g. a note's open-link). */}
+      <div
+        className={`flex-1 min-h-0 ${editMode ? 'pointer-events-none select-none' : ''}`}
+      >
+        {children}
+      </div>
+    </div>
+  );
+};

--- a/components/plc/overview/bentoSizes.ts
+++ b/components/plc/overview/bentoSizes.ts
@@ -1,0 +1,36 @@
+import type { PlcBentoTileSize } from '@/types';
+
+/**
+ * CSS-grid span values for each tile size variant. Keyed by `PlcBentoTileSize`
+ * so adding a new size = one entry here + a new union member in `types.ts`.
+ *
+ * The grid container is `grid-cols-4` (4 columns of equal width) with
+ * `auto-rows-[180px]` (each row 180px tall, plus 16px gap). On viewport
+ * `< 768px` the grid collapses to 1 column and these spans are ignored
+ * — every tile becomes natural-height, ordered by user preference.
+ */
+export const TILE_GRID_SPANS: Record<
+  PlcBentoTileSize,
+  { col: number; row: number }
+> = {
+  sm: { col: 1, row: 1 },
+  'md-wide': { col: 2, row: 1 },
+  'md-tall': { col: 1, row: 2 },
+  lg: { col: 2, row: 2 },
+};
+
+/**
+ * Cycle order for the resize button. Click cycles through these in order.
+ */
+export const SIZE_CYCLE: readonly PlcBentoTileSize[] = [
+  'sm',
+  'md-wide',
+  'md-tall',
+  'lg',
+] as const;
+
+export function nextSize(current: PlcBentoTileSize): PlcBentoTileSize {
+  const idx = SIZE_CYCLE.indexOf(current);
+  if (idx === -1) return 'sm';
+  return SIZE_CYCLE[(idx + 1) % SIZE_CYCLE.length] ?? 'sm';
+}

--- a/components/plc/overview/tileRegistry.tsx
+++ b/components/plc/overview/tileRegistry.tsx
@@ -1,0 +1,114 @@
+import React from 'react';
+import { Plc, PlcBentoTileKind, PlcFeatureSettings } from '@/types';
+import type { PlcDashboardTabId } from '../PlcDashboard';
+import { MembersTile } from './tiles/MembersTile';
+import { PlcInfoTile } from './tiles/PlcInfoTile';
+import { CompletedAssignmentsTile } from './tiles/CompletedAssignmentsTile';
+import { NotesTile } from './tiles/NotesTile';
+import { TodosTile } from './tiles/TodosTile';
+import { SharedSheetTile } from './tiles/SharedSheetTile';
+import { QuickActionsTile } from './tiles/QuickActionsTile';
+import { ComingSoonTile } from './tiles/ComingSoonTile';
+
+export interface TileContext {
+  plc: Plc;
+  onNavigateTab: (tabId: PlcDashboardTabId) => void;
+}
+
+/**
+ * Some tile kinds gate on a `PlcFeatureSettings` flag — when the feature is
+ * off (toggled in the Settings tab), the tile is hidden from the grid AND
+ * its corresponding tab. Returning `null` means "always visible."
+ */
+export function tileFeatureGate(
+  kind: PlcBentoTileKind
+): keyof PlcFeatureSettings | null {
+  switch (kind) {
+    case 'notes':
+      return 'notes';
+    case 'todos':
+      return 'todos';
+    case 'quizLibrary':
+      return 'quizzes';
+    case 'activeAssignments':
+      return 'assignments';
+    case 'videoActivities':
+      return 'videoActivities';
+    case 'sharedBoards':
+      return 'sharedBoards';
+    case 'plcInfo':
+    case 'members':
+    case 'completedAssignments':
+    case 'sharedSheet':
+    case 'quickActions':
+      return null;
+  }
+}
+
+/**
+ * Switchboard for tile content. Each tile kind maps to a small component
+ * that renders inside `PlcBentoTile`'s content slot. Adding a new tile =
+ * a new case here + an entry in `PLC_BENTO_TILE_KINDS` (`types.ts`).
+ *
+ * "Coming soon" placeholders for Phase 2/3/4/6 tabs all route through
+ * `ComingSoonTile` — when those phases ship, swap the case for the real
+ * tile component and the layout doesn't have to change.
+ */
+export function renderTileContent(
+  kind: PlcBentoTileKind,
+  ctx: TileContext
+): React.ReactNode {
+  switch (kind) {
+    case 'plcInfo':
+      return <PlcInfoTile plc={ctx.plc} onNavigateTab={ctx.onNavigateTab} />;
+    case 'members':
+      return <MembersTile plc={ctx.plc} />;
+    case 'completedAssignments':
+      return (
+        <CompletedAssignmentsTile
+          plc={ctx.plc}
+          onNavigateTab={ctx.onNavigateTab}
+        />
+      );
+    case 'notes':
+      return <NotesTile plc={ctx.plc} onNavigateTab={ctx.onNavigateTab} />;
+    case 'todos':
+      return <TodosTile plc={ctx.plc} onNavigateTab={ctx.onNavigateTab} />;
+    case 'sharedSheet':
+      return <SharedSheetTile plc={ctx.plc} />;
+    case 'quickActions':
+      return <QuickActionsTile onNavigateTab={ctx.onNavigateTab} />;
+    case 'quizLibrary':
+      return (
+        <ComingSoonTile
+          kind="quizLibrary"
+          phase={2}
+          onNavigateTab={() => ctx.onNavigateTab('quizzes')}
+        />
+      );
+    case 'activeAssignments':
+      return (
+        <ComingSoonTile
+          kind="activeAssignments"
+          phase={3}
+          onNavigateTab={() => ctx.onNavigateTab('assignments')}
+        />
+      );
+    case 'videoActivities':
+      return (
+        <ComingSoonTile
+          kind="videoActivities"
+          phase={4}
+          onNavigateTab={() => ctx.onNavigateTab('videoActivities')}
+        />
+      );
+    case 'sharedBoards':
+      return (
+        <ComingSoonTile
+          kind="sharedBoards"
+          phase={6}
+          onNavigateTab={() => ctx.onNavigateTab('sharedBoards')}
+        />
+      );
+  }
+}

--- a/components/plc/overview/tiles/ComingSoonTile.tsx
+++ b/components/plc/overview/tiles/ComingSoonTile.tsx
@@ -21,33 +21,48 @@ interface ComingSoonTileProps {
   onNavigateTab: () => void;
 }
 
+// `titleKey` and `teaserKey` are sibling leaves in the locale tree
+// (e.g. `quizLibrary.title` + `quizLibrary.teaser`). They must be tracked
+// as separate strings — `${titleKey}.teaser` would yield `…title.teaser`,
+// which doesn't exist in the locale JSON and would only render the
+// defaultValue.
 const META: Record<
   ComingSoonKind,
-  { icon: LucideIcon; titleKey: string; titleDefault: string; teaser: string }
+  {
+    icon: LucideIcon;
+    titleKey: string;
+    titleDefault: string;
+    teaserKey: string;
+    teaserDefault: string;
+  }
 > = {
   quizLibrary: {
     icon: BookOpen,
     titleKey: 'plcDashboard.overview.tiles.quizLibrary.title',
     titleDefault: 'Quiz library',
-    teaser: 'Share quizzes with your PLC.',
+    teaserKey: 'plcDashboard.overview.tiles.quizLibrary.teaser',
+    teaserDefault: 'Share quizzes with your PLC.',
   },
   activeAssignments: {
     icon: ClipboardList,
     titleKey: 'plcDashboard.overview.tiles.activeAssignments.title',
     titleDefault: 'Active assignments',
-    teaser: 'PLC-authored assignments awaiting pickup.',
+    teaserKey: 'plcDashboard.overview.tiles.activeAssignments.teaser',
+    teaserDefault: 'PLC-authored assignments awaiting pickup.',
   },
   videoActivities: {
     icon: Film,
     titleKey: 'plcDashboard.overview.tiles.videoActivities.title',
     titleDefault: 'Video activities',
-    teaser: 'Share video activities with the PLC.',
+    teaserKey: 'plcDashboard.overview.tiles.videoActivities.teaser',
+    teaserDefault: 'Share video activities with the PLC.',
   },
   sharedBoards: {
     icon: SquareSquare,
     titleKey: 'plcDashboard.overview.tiles.sharedBoards.title',
     titleDefault: 'Shared boards',
-    teaser: 'Boards shared with this PLC.',
+    teaserKey: 'plcDashboard.overview.tiles.sharedBoards.teaser',
+    teaserDefault: 'Boards shared with this PLC.',
   },
 };
 
@@ -75,7 +90,7 @@ export const ComingSoonTile: React.FC<ComingSoonTileProps> = ({
         </h4>
       </div>
       <p className="text-xxs text-slate-500 leading-snug flex-1">
-        {t(`${meta.titleKey}.teaser`, { defaultValue: meta.teaser })}
+        {t(meta.teaserKey, { defaultValue: meta.teaserDefault })}
       </p>
       <span className="mt-2 inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-slate-100 text-xxs font-bold uppercase tracking-widest text-slate-400">
         {t('plcDashboard.overview.tiles.comingSoon', {

--- a/components/plc/overview/tiles/ComingSoonTile.tsx
+++ b/components/plc/overview/tiles/ComingSoonTile.tsx
@@ -1,0 +1,88 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import {
+  BookOpen,
+  ClipboardList,
+  Film,
+  SquareSquare,
+  type LucideIcon,
+} from 'lucide-react';
+import type { PlcBentoTileKind } from '@/types';
+
+type ComingSoonKind = Extract<
+  PlcBentoTileKind,
+  'quizLibrary' | 'activeAssignments' | 'videoActivities' | 'sharedBoards'
+>;
+
+interface ComingSoonTileProps {
+  kind: ComingSoonKind;
+  /** Roadmap phase number — surfaces as a small "Phase N" badge. */
+  phase: number;
+  onNavigateTab: () => void;
+}
+
+const META: Record<
+  ComingSoonKind,
+  { icon: LucideIcon; titleKey: string; titleDefault: string; teaser: string }
+> = {
+  quizLibrary: {
+    icon: BookOpen,
+    titleKey: 'plcDashboard.overview.tiles.quizLibrary.title',
+    titleDefault: 'Quiz library',
+    teaser: 'Share quizzes with your PLC.',
+  },
+  activeAssignments: {
+    icon: ClipboardList,
+    titleKey: 'plcDashboard.overview.tiles.activeAssignments.title',
+    titleDefault: 'Active assignments',
+    teaser: 'PLC-authored assignments awaiting pickup.',
+  },
+  videoActivities: {
+    icon: Film,
+    titleKey: 'plcDashboard.overview.tiles.videoActivities.title',
+    titleDefault: 'Video activities',
+    teaser: 'Share video activities with the PLC.',
+  },
+  sharedBoards: {
+    icon: SquareSquare,
+    titleKey: 'plcDashboard.overview.tiles.sharedBoards.title',
+    titleDefault: 'Shared boards',
+    teaser: 'Boards shared with this PLC.',
+  },
+};
+
+export const ComingSoonTile: React.FC<ComingSoonTileProps> = ({
+  kind,
+  phase,
+  onNavigateTab,
+}) => {
+  const { t } = useTranslation();
+  const meta = META[kind];
+  const Icon = meta.icon;
+
+  return (
+    <button
+      type="button"
+      onClick={onNavigateTab}
+      className="h-full w-full p-4 flex flex-col items-start text-left hover:bg-slate-50 transition-colors"
+    >
+      <div className="flex items-center gap-2 mb-2">
+        <div className="w-7 h-7 rounded-lg bg-slate-100 flex items-center justify-center">
+          <Icon className="w-3.5 h-3.5 text-slate-500" />
+        </div>
+        <h4 className="text-xxs font-bold uppercase tracking-widest text-slate-500">
+          {t(meta.titleKey, { defaultValue: meta.titleDefault })}
+        </h4>
+      </div>
+      <p className="text-xxs text-slate-500 leading-snug flex-1">
+        {t(`${meta.titleKey}.teaser`, { defaultValue: meta.teaser })}
+      </p>
+      <span className="mt-2 inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-slate-100 text-xxs font-bold uppercase tracking-widest text-slate-400">
+        {t('plcDashboard.overview.tiles.comingSoon', {
+          defaultValue: 'Phase {{phase}} · soon',
+          phase,
+        })}
+      </span>
+    </button>
+  );
+};

--- a/components/plc/overview/tiles/CompletedAssignmentsTile.tsx
+++ b/components/plc/overview/tiles/CompletedAssignmentsTile.tsx
@@ -1,0 +1,109 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { ChevronRight, ClipboardList, Loader2 } from 'lucide-react';
+import { Plc } from '@/types';
+import { usePlcAssignmentIndex } from '@/hooks/usePlcAssignmentIndex';
+import type { PlcDashboardTabId } from '../../PlcDashboard';
+
+interface CompletedAssignmentsTileProps {
+  plc: Plc;
+  onNavigateTab: (tabId: PlcDashboardTabId) => void;
+}
+
+const PREVIEW_LIMIT = 4;
+
+function formatDate(ms: number): string {
+  if (!ms) return '';
+  try {
+    return new Date(ms).toLocaleDateString(undefined, {
+      month: 'short',
+      day: 'numeric',
+    });
+  } catch {
+    return '';
+  }
+}
+
+export const CompletedAssignmentsTile: React.FC<
+  CompletedAssignmentsTileProps
+> = ({ plc, onNavigateTab }) => {
+  const { t } = useTranslation();
+  const { entries, loading } = usePlcAssignmentIndex(plc.id);
+  const preview = entries.slice(0, PREVIEW_LIMIT);
+
+  return (
+    <div className="h-full flex flex-col">
+      <div className="flex items-center gap-2 px-4 pt-4 pb-2">
+        <div className="w-7 h-7 rounded-lg bg-emerald-100 flex items-center justify-center">
+          <ClipboardList className="w-3.5 h-3.5 text-emerald-600" />
+        </div>
+        <h4 className="text-xxs font-bold uppercase tracking-widest text-slate-500">
+          {t('plcDashboard.overview.tiles.completedAssignments.heading', {
+            defaultValue: 'Recent results',
+          })}
+        </h4>
+        {entries.length > 0 && (
+          <span className="ml-auto text-xs font-bold text-slate-700">
+            {entries.length}
+          </span>
+        )}
+      </div>
+
+      <div className="flex-1 min-h-0 overflow-y-auto custom-scrollbar px-4">
+        {loading ? (
+          <div className="flex items-center justify-center h-full text-slate-400">
+            <Loader2 className="w-4 h-4 animate-spin" />
+          </div>
+        ) : preview.length === 0 ? (
+          <div className="flex flex-col items-center justify-center h-full text-center text-xs text-slate-500 py-4">
+            <ClipboardList className="w-6 h-6 text-slate-300 mb-2" />
+            <p className="font-semibold text-slate-600">
+              {t('plcDashboard.overview.tiles.completedAssignments.empty', {
+                defaultValue: 'No assignments run yet',
+              })}
+            </p>
+            <p className="text-xxs text-slate-400 mt-1">
+              {t(
+                'plcDashboard.overview.tiles.completedAssignments.emptySubtitle',
+                {
+                  defaultValue: 'Quizzes you run with PLC mode appear here.',
+                }
+              )}
+            </p>
+          </div>
+        ) : (
+          <ul className="space-y-1.5 py-1">
+            {preview.map((entry) => (
+              <li
+                key={entry.id}
+                className="flex items-center gap-2 px-2 py-1.5 rounded-lg hover:bg-slate-50 transition-colors"
+              >
+                <div className="flex-1 min-w-0">
+                  <div className="text-xs font-bold text-slate-800 truncate">
+                    {entry.title}
+                  </div>
+                  <div className="text-xxs text-slate-500 truncate">
+                    {entry.ownerName?.trim() || entry.ownerEmail || '—'}
+                    {' • '}
+                    {formatDate(entry.createdAt)}
+                  </div>
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+
+      <button
+        type="button"
+        onClick={() => onNavigateTab('completed')}
+        className="flex items-center justify-center gap-1.5 px-4 py-2.5 border-t border-slate-100 text-xxs font-bold uppercase tracking-wider text-brand-blue-primary hover:bg-brand-blue-lighter/30 transition-colors"
+      >
+        {t('plcDashboard.overview.tiles.completedAssignments.viewAll', {
+          defaultValue: 'View all',
+        })}
+        <ChevronRight className="w-3 h-3" />
+      </button>
+    </div>
+  );
+};

--- a/components/plc/overview/tiles/MembersTile.tsx
+++ b/components/plc/overview/tiles/MembersTile.tsx
@@ -1,0 +1,74 @@
+import React, { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Users2 } from 'lucide-react';
+import { Plc } from '@/types';
+import { useAuth } from '@/context/useAuth';
+
+interface MembersTileProps {
+  plc: Plc;
+}
+
+function initialsFromEmail(email: string): string {
+  if (!email) return '?';
+  const local = email.split('@')[0] ?? '';
+  const parts = local.split(/[._-]+/).filter(Boolean);
+  if (parts.length === 0) return email.charAt(0).toUpperCase();
+  if (parts.length === 1)
+    return (parts[0]?.charAt(0) ?? '').toUpperCase() || '?';
+  return (
+    (parts[0]?.charAt(0) ?? '') + (parts[1]?.charAt(0) ?? '')
+  ).toUpperCase();
+}
+
+export const MembersTile: React.FC<MembersTileProps> = ({ plc }) => {
+  const { t } = useTranslation();
+  const { user } = useAuth();
+
+  const members = useMemo(
+    () =>
+      plc.memberUids.map((uid) => ({
+        uid,
+        email: plc.memberEmails[uid] ?? '',
+        isLead: uid === plc.leadUid,
+        isYou: uid === user?.uid,
+      })),
+    [plc, user]
+  );
+
+  return (
+    <div className="h-full p-4 flex flex-col">
+      <div className="flex items-center gap-2 mb-3">
+        <div className="w-7 h-7 rounded-lg bg-brand-blue-lighter flex items-center justify-center">
+          <Users2 className="w-3.5 h-3.5 text-brand-blue-primary" />
+        </div>
+        <h4 className="text-xxs font-bold uppercase tracking-widest text-slate-500">
+          {t('plcDashboard.overview.tiles.members.heading', {
+            defaultValue: 'Members',
+            count: members.length,
+          })}
+        </h4>
+        <span className="ml-auto text-xs font-bold text-slate-700">
+          {members.length}
+        </span>
+      </div>
+      <div className="flex flex-wrap gap-1.5 overflow-y-auto custom-scrollbar -m-0.5 p-0.5">
+        {members.map((m) => (
+          <div
+            key={m.uid}
+            className={`relative flex items-center justify-center w-9 h-9 rounded-full text-xxs font-bold shadow-sm border ${
+              m.isYou
+                ? 'bg-brand-blue-primary text-white border-brand-blue-dark'
+                : 'bg-white text-slate-600 border-slate-200'
+            }`}
+            title={`${m.email}${m.isLead ? ' (lead)' : ''}${m.isYou ? ' (you)' : ''}`}
+          >
+            {initialsFromEmail(m.email)}
+            {m.isLead && (
+              <span className="absolute -top-0.5 -right-0.5 w-2.5 h-2.5 rounded-full bg-brand-red-primary border border-white" />
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};

--- a/components/plc/overview/tiles/NotesTile.tsx
+++ b/components/plc/overview/tiles/NotesTile.tsx
@@ -1,0 +1,137 @@
+import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { ChevronRight, Loader2, StickyNote } from 'lucide-react';
+import { Plc } from '@/types';
+import { usePlcNotes } from '@/hooks/usePlcNotes';
+import type { PlcDashboardTabId } from '../../PlcDashboard';
+
+interface NotesTileProps {
+  plc: Plc;
+  onNavigateTab: (tabId: PlcDashboardTabId) => void;
+}
+
+const PREVIEW_LIMIT = 3;
+const BODY_TRUNCATE_AT = 90;
+
+function truncate(text: string, max: number): string {
+  if (text.length <= max) return text;
+  return text.slice(0, max - 1).trimEnd() + '…';
+}
+
+export const NotesTile: React.FC<NotesTileProps> = ({ plc, onNavigateTab }) => {
+  const { t } = useTranslation();
+  const { notes, loading } = usePlcNotes(plc.id);
+  const preview = notes.slice(0, PREVIEW_LIMIT);
+
+  // Capture "now" once at mount. Frozen across re-renders is fine for
+  // a preview tile — exact relative-time accuracy isn't critical, and
+  // the lint rule forbids calling Date.now() inside render.
+  const [now] = useState(() => Date.now());
+  const relativeTime = (ms: number): string => {
+    if (!ms) return '';
+    const diff = Math.max(0, now - ms);
+    const min = 60 * 1000;
+    const hr = 60 * min;
+    const day = 24 * hr;
+    if (diff < min)
+      return t('plcDashboard.overview.tiles.notes.justNow', {
+        defaultValue: 'just now',
+      });
+    if (diff < hr)
+      return t('plcDashboard.overview.tiles.notes.minutesAgo', {
+        defaultValue: '{{count}}m ago',
+        count: Math.floor(diff / min),
+      });
+    if (diff < day)
+      return t('plcDashboard.overview.tiles.notes.hoursAgo', {
+        defaultValue: '{{count}}h ago',
+        count: Math.floor(diff / hr),
+      });
+    return t('plcDashboard.overview.tiles.notes.daysAgo', {
+      defaultValue: '{{count}}d ago',
+      count: Math.floor(diff / day),
+    });
+  };
+
+  return (
+    <div className="h-full flex flex-col">
+      <div className="flex items-center gap-2 px-4 pt-4 pb-2">
+        <div className="w-7 h-7 rounded-lg bg-amber-100 flex items-center justify-center">
+          <StickyNote className="w-3.5 h-3.5 text-amber-600" />
+        </div>
+        <h4 className="text-xxs font-bold uppercase tracking-widest text-slate-500">
+          {t('plcDashboard.overview.tiles.notes.heading', {
+            defaultValue: 'Notes',
+          })}
+        </h4>
+        {notes.length > 0 && (
+          <span className="ml-auto text-xs font-bold text-slate-700">
+            {notes.length}
+          </span>
+        )}
+      </div>
+
+      <div className="flex-1 min-h-0 overflow-y-auto custom-scrollbar px-4 pb-2">
+        {loading ? (
+          <div className="flex items-center justify-center h-full text-slate-400">
+            <Loader2 className="w-4 h-4 animate-spin" />
+          </div>
+        ) : preview.length === 0 ? (
+          <div className="flex flex-col items-center justify-center h-full text-center text-xs text-slate-500 py-2">
+            <StickyNote className="w-6 h-6 text-slate-300 mb-2" />
+            <p className="font-semibold text-slate-600">
+              {t('plcDashboard.overview.tiles.notes.empty', {
+                defaultValue: 'No notes yet',
+              })}
+            </p>
+            <p className="text-xxs text-slate-400 mt-1">
+              {t('plcDashboard.overview.tiles.notes.emptySubtitle', {
+                defaultValue: 'Capture meeting notes, decisions, ideas.',
+              })}
+            </p>
+          </div>
+        ) : (
+          <ul className="space-y-2 py-1">
+            {preview.map((note) => (
+              <li
+                key={note.id}
+                className="px-2 py-2 rounded-lg hover:bg-amber-50/60 transition-colors"
+              >
+                <div className="flex items-baseline justify-between gap-2">
+                  <div className="text-xs font-bold text-slate-800 truncate">
+                    {note.title || (
+                      <span className="italic text-slate-400">
+                        {t('plcDashboard.overview.tiles.notes.untitled', {
+                          defaultValue: 'Untitled',
+                        })}
+                      </span>
+                    )}
+                  </div>
+                  <span className="shrink-0 text-xxs text-slate-400">
+                    {relativeTime(note.lastEditedAt)}
+                  </span>
+                </div>
+                {note.body && (
+                  <p className="text-xxs text-slate-500 line-clamp-2 mt-0.5">
+                    {truncate(note.body, BODY_TRUNCATE_AT)}
+                  </p>
+                )}
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+
+      <button
+        type="button"
+        onClick={() => onNavigateTab('notes')}
+        className="flex items-center justify-center gap-1.5 px-4 py-2.5 border-t border-slate-100 text-xxs font-bold uppercase tracking-wider text-amber-700 hover:bg-amber-50/60 transition-colors"
+      >
+        {t('plcDashboard.overview.tiles.notes.openAll', {
+          defaultValue: 'Open notes',
+        })}
+        <ChevronRight className="w-3 h-3" />
+      </button>
+    </div>
+  );
+};

--- a/components/plc/overview/tiles/PlcInfoTile.tsx
+++ b/components/plc/overview/tiles/PlcInfoTile.tsx
@@ -1,0 +1,102 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { Settings as SettingsIcon, Users2 } from 'lucide-react';
+import { Plc } from '@/types';
+import { useAuth } from '@/context/useAuth';
+import type { PlcDashboardTabId } from '../../PlcDashboard';
+
+interface PlcInfoTileProps {
+  plc: Plc;
+  onNavigateTab: (tabId: PlcDashboardTabId) => void;
+}
+
+export const PlcInfoTile: React.FC<PlcInfoTileProps> = ({
+  plc,
+  onNavigateTab,
+}) => {
+  const { t } = useTranslation();
+  const { user } = useAuth();
+  const isLead = plc.leadUid === user?.uid;
+  const leadEmail = plc.memberEmails[plc.leadUid] ?? '';
+
+  const formatDate = (ms: number) => {
+    if (!ms) return '';
+    try {
+      return new Date(ms).toLocaleDateString(undefined, {
+        year: 'numeric',
+        month: 'short',
+        day: 'numeric',
+      });
+    } catch {
+      return '';
+    }
+  };
+
+  return (
+    <div className="h-full p-5 flex flex-col">
+      <div className="flex items-start gap-3">
+        <div className="shrink-0 w-10 h-10 rounded-xl bg-brand-blue-lighter flex items-center justify-center">
+          <Users2 className="w-5 h-5 text-brand-blue-primary" />
+        </div>
+        <div className="flex-1 min-w-0">
+          <h4 className="text-base font-bold text-slate-900 truncate">
+            {plc.name}
+          </h4>
+          <p className="text-xxs text-slate-400 uppercase tracking-widest font-bold mt-0.5">
+            {t('plcDashboard.overview.tiles.plcInfo.label', {
+              defaultValue: 'Professional Learning Community',
+            })}
+          </p>
+        </div>
+      </div>
+
+      <dl className="mt-4 space-y-2 text-xs flex-1">
+        <div className="flex items-center justify-between">
+          <dt className="text-slate-500">
+            {t('plcDashboard.overview.tiles.plcInfo.members', {
+              defaultValue: 'Members',
+            })}
+          </dt>
+          <dd className="font-bold text-slate-800">{plc.memberUids.length}</dd>
+        </div>
+        <div className="flex items-center justify-between">
+          <dt className="text-slate-500">
+            {t('plcDashboard.overview.tiles.plcInfo.lead', {
+              defaultValue: 'Lead',
+            })}
+          </dt>
+          <dd className="font-semibold text-slate-700 truncate ml-2">
+            {isLead
+              ? t('plcDashboard.overview.tiles.plcInfo.you', {
+                  defaultValue: 'You',
+                })
+              : leadEmail || '—'}
+          </dd>
+        </div>
+        {plc.createdAt > 0 && (
+          <div className="flex items-center justify-between">
+            <dt className="text-slate-500">
+              {t('plcDashboard.overview.tiles.plcInfo.created', {
+                defaultValue: 'Created',
+              })}
+            </dt>
+            <dd className="font-semibold text-slate-700">
+              {formatDate(plc.createdAt)}
+            </dd>
+          </div>
+        )}
+      </dl>
+
+      <button
+        type="button"
+        onClick={() => onNavigateTab('settings')}
+        className="mt-3 inline-flex items-center gap-1.5 px-3 py-1.5 bg-slate-100 hover:bg-brand-blue-lighter hover:text-brand-blue-primary text-slate-600 text-xxs font-bold uppercase tracking-wider rounded-lg transition-colors self-start"
+      >
+        <SettingsIcon className="w-3.5 h-3.5" />
+        {t('plcDashboard.overview.tiles.plcInfo.openSettings', {
+          defaultValue: 'Open settings',
+        })}
+      </button>
+    </div>
+  );
+};

--- a/components/plc/overview/tiles/QuickActionsTile.tsx
+++ b/components/plc/overview/tiles/QuickActionsTile.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { ListChecks, Sparkles, StickyNote } from 'lucide-react';
+import type { PlcDashboardTabId } from '../../PlcDashboard';
+
+interface QuickActionsTileProps {
+  onNavigateTab: (tabId: PlcDashboardTabId) => void;
+}
+
+export const QuickActionsTile: React.FC<QuickActionsTileProps> = ({
+  onNavigateTab,
+}) => {
+  const { t } = useTranslation();
+
+  const actions: Array<{
+    label: string;
+    icon: React.ComponentType<{ className?: string }>;
+    color: string;
+    onClick: () => void;
+  }> = [
+    {
+      label: t('plcDashboard.overview.tiles.quickActions.addNote', {
+        defaultValue: 'Add note',
+      }),
+      icon: StickyNote,
+      color: 'bg-amber-50 text-amber-700 hover:bg-amber-100',
+      onClick: () => onNavigateTab('notes'),
+    },
+    {
+      label: t('plcDashboard.overview.tiles.quickActions.addTodo', {
+        defaultValue: 'Add to-do',
+      }),
+      icon: ListChecks,
+      color: 'bg-violet-50 text-violet-700 hover:bg-violet-100',
+      onClick: () => onNavigateTab('todos'),
+    },
+  ];
+
+  return (
+    <div className="h-full p-4 flex flex-col">
+      <div className="flex items-center gap-2 mb-3">
+        <div className="w-7 h-7 rounded-lg bg-fuchsia-100 flex items-center justify-center">
+          <Sparkles className="w-3.5 h-3.5 text-fuchsia-600" />
+        </div>
+        <h4 className="text-xxs font-bold uppercase tracking-widest text-slate-500">
+          {t('plcDashboard.overview.tiles.quickActions.heading', {
+            defaultValue: 'Quick actions',
+          })}
+        </h4>
+      </div>
+      <div className="flex flex-col gap-2 flex-1">
+        {actions.map((action) => (
+          <button
+            key={action.label}
+            type="button"
+            onClick={action.onClick}
+            className={`flex items-center gap-2.5 px-3 py-2 rounded-lg text-xs font-semibold transition-colors text-left ${action.color}`}
+          >
+            <action.icon className="w-4 h-4 shrink-0" />
+            <span className="truncate">{action.label}</span>
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+};

--- a/components/plc/overview/tiles/SharedSheetTile.tsx
+++ b/components/plc/overview/tiles/SharedSheetTile.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { ExternalLink, FileSpreadsheet } from 'lucide-react';
+import { Plc } from '@/types';
+
+interface SharedSheetTileProps {
+  plc: Plc;
+}
+
+/** Defense-in-depth — only render the sheet URL as a link if it's http/https. */
+function isSafeHttpUrl(value: string): boolean {
+  try {
+    const parsed = new URL(value);
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
+export const SharedSheetTile: React.FC<SharedSheetTileProps> = ({ plc }) => {
+  const { t } = useTranslation();
+  const url = plc.sharedSheetUrl ?? null;
+  const safeUrl = url && isSafeHttpUrl(url) ? url : null;
+
+  return (
+    <div className="h-full p-4 flex flex-col">
+      <div className="flex items-center gap-2 mb-3">
+        <div className="w-7 h-7 rounded-lg bg-green-100 flex items-center justify-center">
+          <FileSpreadsheet className="w-3.5 h-3.5 text-green-600" />
+        </div>
+        <h4 className="text-xxs font-bold uppercase tracking-widest text-slate-500">
+          {t('plcDashboard.overview.tiles.sharedSheet.heading', {
+            defaultValue: 'Shared sheet',
+          })}
+        </h4>
+      </div>
+
+      {safeUrl ? (
+        <div className="flex flex-col gap-2 flex-1 justify-between">
+          <p className="text-xxs text-slate-500 leading-relaxed">
+            {t('plcDashboard.overview.tiles.sharedSheet.connectedHint', {
+              defaultValue:
+                'Aggregated PLC results land in this Google Sheet. All members can open it.',
+            })}
+          </p>
+          <a
+            href={safeUrl}
+            target="_blank"
+            rel="noreferrer noopener"
+            className="inline-flex items-center justify-center gap-1.5 px-3 py-2 bg-green-50 hover:bg-green-100 text-green-700 text-xxs font-bold uppercase tracking-wider rounded-lg transition-colors"
+          >
+            <ExternalLink className="w-3.5 h-3.5" />
+            {t('plcDashboard.overview.tiles.sharedSheet.open', {
+              defaultValue: 'Open sheet',
+            })}
+          </a>
+        </div>
+      ) : (
+        <div className="flex flex-col gap-2 flex-1 justify-between">
+          <p className="text-xxs text-slate-500 leading-relaxed">
+            {t('plcDashboard.overview.tiles.sharedSheet.unsetHint', {
+              defaultValue:
+                'No shared sheet yet — it will be created automatically when the first PLC quiz is run.',
+            })}
+          </p>
+          <span className="inline-flex items-center justify-center gap-1.5 px-3 py-2 bg-slate-50 text-slate-400 text-xxs font-bold uppercase tracking-wider rounded-lg cursor-not-allowed">
+            {t('plcDashboard.overview.tiles.sharedSheet.notReady', {
+              defaultValue: 'Not yet created',
+            })}
+          </span>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/components/plc/overview/tiles/TodosTile.tsx
+++ b/components/plc/overview/tiles/TodosTile.tsx
@@ -1,0 +1,107 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { ChevronRight, ListChecks, Loader2 } from 'lucide-react';
+import { Plc } from '@/types';
+import { usePlcTodos } from '@/hooks/usePlcTodos';
+import type { PlcDashboardTabId } from '../../PlcDashboard';
+
+interface TodosTileProps {
+  plc: Plc;
+  onNavigateTab: (tabId: PlcDashboardTabId) => void;
+}
+
+const PREVIEW_LIMIT = 6;
+
+export const TodosTile: React.FC<TodosTileProps> = ({ plc, onNavigateTab }) => {
+  const { t } = useTranslation();
+  const { todos, loading, toggleDone } = usePlcTodos(plc.id);
+  const incomplete = todos.filter((todo) => !todo.done);
+  const preview = incomplete.slice(0, PREVIEW_LIMIT);
+  const remaining = Math.max(0, incomplete.length - preview.length);
+
+  return (
+    <div className="h-full flex flex-col">
+      <div className="flex items-center gap-2 px-4 pt-4 pb-2">
+        <div className="w-7 h-7 rounded-lg bg-violet-100 flex items-center justify-center">
+          <ListChecks className="w-3.5 h-3.5 text-violet-600" />
+        </div>
+        <h4 className="text-xxs font-bold uppercase tracking-widest text-slate-500">
+          {t('plcDashboard.overview.tiles.todos.heading', {
+            defaultValue: 'To-do list',
+          })}
+        </h4>
+        {incomplete.length > 0 && (
+          <span className="ml-auto text-xs font-bold text-slate-700">
+            {incomplete.length}
+          </span>
+        )}
+      </div>
+
+      <div className="flex-1 min-h-0 overflow-y-auto custom-scrollbar px-4 pb-2">
+        {loading ? (
+          <div className="flex items-center justify-center h-full text-slate-400">
+            <Loader2 className="w-4 h-4 animate-spin" />
+          </div>
+        ) : preview.length === 0 ? (
+          <div className="flex flex-col items-center justify-center h-full text-center text-xs text-slate-500 py-2">
+            <ListChecks className="w-6 h-6 text-slate-300 mb-2" />
+            <p className="font-semibold text-slate-600">
+              {t('plcDashboard.overview.tiles.todos.empty', {
+                defaultValue: 'Nothing to do',
+              })}
+            </p>
+            <p className="text-xxs text-slate-400 mt-1">
+              {t('plcDashboard.overview.tiles.todos.emptySubtitle', {
+                defaultValue: 'Add action items in the To-Do tab.',
+              })}
+            </p>
+          </div>
+        ) : (
+          <ul className="space-y-1 py-1">
+            {preview.map((todo) => (
+              <li
+                key={todo.id}
+                className="flex items-start gap-2 px-1.5 py-1.5 rounded-lg hover:bg-slate-50 transition-colors"
+              >
+                <input
+                  type="checkbox"
+                  checked={todo.done}
+                  onChange={(e) => {
+                    void toggleDone(todo.id, e.target.checked);
+                  }}
+                  className="mt-0.5 w-4 h-4 rounded border-slate-300 text-violet-600 focus:ring-violet-500 focus:ring-offset-0 cursor-pointer"
+                  aria-label={t('plcDashboard.overview.tiles.todos.toggle', {
+                    defaultValue: 'Mark "{{text}}" complete',
+                    text: todo.text,
+                  })}
+                />
+                <span className="flex-1 text-xs text-slate-700 leading-snug">
+                  {todo.text}
+                </span>
+              </li>
+            ))}
+            {remaining > 0 && (
+              <li className="px-1.5 pt-1 text-xxs text-slate-400 italic">
+                {t('plcDashboard.overview.tiles.todos.moreCount', {
+                  defaultValue: '+{{count}} more',
+                  count: remaining,
+                })}
+              </li>
+            )}
+          </ul>
+        )}
+      </div>
+
+      <button
+        type="button"
+        onClick={() => onNavigateTab('todos')}
+        className="flex items-center justify-center gap-1.5 px-4 py-2.5 border-t border-slate-100 text-xxs font-bold uppercase tracking-wider text-violet-700 hover:bg-violet-50/60 transition-colors"
+      >
+        {t('plcDashboard.overview.tiles.todos.openAll', {
+          defaultValue: 'Open list',
+        })}
+        <ChevronRight className="w-3 h-3" />
+      </button>
+    </div>
+  );
+};

--- a/components/plc/overview/tiles/TodosTile.tsx
+++ b/components/plc/overview/tiles/TodosTile.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { ChevronRight, ListChecks, Loader2 } from 'lucide-react';
 import { Plc } from '@/types';
 import { usePlcTodos } from '@/hooks/usePlcTodos';
+import { logError } from '@/utils/logError';
 import type { PlcDashboardTabId } from '../../PlcDashboard';
 
 interface TodosTileProps {
@@ -67,7 +68,14 @@ export const TodosTile: React.FC<TodosTileProps> = ({ plc, onNavigateTab }) => {
                   type="checkbox"
                   checked={todo.done}
                   onChange={(e) => {
-                    void toggleDone(todo.id, e.target.checked);
+                    void toggleDone(todo.id, e.target.checked).catch(
+                      (err: unknown) => {
+                        logError('TodosTile.toggleDone', err, {
+                          plcId: plc.id,
+                          todoId: todo.id,
+                        });
+                      }
+                    );
                   }}
                   className="mt-0.5 w-4 h-4 rounded border-slate-300 text-violet-600 focus:ring-violet-500 focus:ring-offset-0 cursor-pointer"
                   aria-label={t('plcDashboard.overview.tiles.todos.toggle', {

--- a/components/plc/tabs/PlcNotesTab.tsx
+++ b/components/plc/tabs/PlcNotesTab.tsx
@@ -45,6 +45,11 @@ export const PlcNotesTab: React.FC<PlcNotesTabProps> = ({ plc }) => {
   const [draftTitle, setDraftTitle] = useState('');
   const [draftBody, setDraftBody] = useState('');
   const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Accumulates patches from rapid edits across fields so a same-window
+  // title→body sequence doesn't drop the title patch. Reset on flush /
+  // cancel.
+  const pendingPatchRef = useRef<{ title?: string; body?: string }>({});
+  const pendingNoteIdRef = useRef<string | null>(null);
 
   // Auto-select the most-recent note once data lands. Same "adjust state
   // during render" pattern used elsewhere in the repo.
@@ -93,27 +98,55 @@ export const PlcNotesTab: React.FC<PlcNotesTabProps> = ({ plc }) => {
     setDraftBody(selectedNote.body);
   }
 
+  const flushPendingSave = () => {
+    if (debounceTimerRef.current) {
+      clearTimeout(debounceTimerRef.current);
+      debounceTimerRef.current = null;
+    }
+    const id = pendingNoteIdRef.current;
+    const toSave = pendingPatchRef.current;
+    pendingPatchRef.current = {};
+    pendingNoteIdRef.current = null;
+    if (!id || (toSave.title === undefined && toSave.body === undefined)) {
+      return;
+    }
+    void updateNote(id, toSave).catch((err: unknown) => {
+      logError('PlcNotesTab.updateNote', err, { plcId: plc.id, noteId: id });
+    });
+  };
+
+  const cancelPendingSave = () => {
+    if (debounceTimerRef.current) {
+      clearTimeout(debounceTimerRef.current);
+      debounceTimerRef.current = null;
+    }
+    pendingPatchRef.current = {};
+    pendingNoteIdRef.current = null;
+  };
+
   // Flush pending debounced writes on unmount so a fast tab close doesn't
   // drop the user's last edit.
   useEffect(() => {
-    const timerRef = debounceTimerRef;
     return () => {
-      if (timerRef.current) {
-        clearTimeout(timerRef.current);
-      }
+      flushPendingSave();
     };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const scheduleSave = (
     id: string,
     patch: { title?: string; body?: string }
   ) => {
+    // If a write is queued for a different note, flush it first so we
+    // don't merge title/body across notes.
+    if (pendingNoteIdRef.current && pendingNoteIdRef.current !== id) {
+      flushPendingSave();
+    }
+    pendingNoteIdRef.current = id;
+    pendingPatchRef.current = { ...pendingPatchRef.current, ...patch };
     if (debounceTimerRef.current) clearTimeout(debounceTimerRef.current);
     debounceTimerRef.current = setTimeout(() => {
-      debounceTimerRef.current = null;
-      void updateNote(id, patch).catch((err: unknown) => {
-        logError('PlcNotesTab.updateNote', err, { plcId: plc.id, noteId: id });
-      });
+      flushPendingSave();
     }, SAVE_DEBOUNCE_MS);
   };
 
@@ -142,9 +175,10 @@ export const PlcNotesTab: React.FC<PlcNotesTabProps> = ({ plc }) => {
       }
     );
     if (!confirmed) return;
-    if (debounceTimerRef.current) {
-      clearTimeout(debounceTimerRef.current);
-      debounceTimerRef.current = null;
+    // Drop any queued write — the doc is being deleted, no point flushing
+    // (and the rule on `notes/{id}` would reject a write to a missing doc).
+    if (pendingNoteIdRef.current === note.id) {
+      cancelPendingSave();
     }
     try {
       await deleteNote(note.id);
@@ -162,10 +196,9 @@ export const PlcNotesTab: React.FC<PlcNotesTabProps> = ({ plc }) => {
   };
 
   const handleSelect = (id: string) => {
-    if (debounceTimerRef.current) {
-      clearTimeout(debounceTimerRef.current);
-      debounceTimerRef.current = null;
-    }
+    // Flush any queued write for the previously-selected note so switching
+    // notes mid-debounce doesn't drop the user's last edit.
+    flushPendingSave();
     const note = notes.find((n) => n.id === id);
     if (!note) return;
     setSelectedId(id);

--- a/components/plc/tabs/PlcNotesTab.tsx
+++ b/components/plc/tabs/PlcNotesTab.tsx
@@ -1,0 +1,330 @@
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Loader2, Plus, StickyNote, Trash2 } from 'lucide-react';
+import { Plc, PlcNote } from '@/types';
+import { useDialog } from '@/context/useDialog';
+import { usePlcNotes } from '@/hooks/usePlcNotes';
+import { logError } from '@/utils/logError';
+
+interface PlcNotesTabProps {
+  plc: Plc;
+}
+
+const SAVE_DEBOUNCE_MS = 500;
+
+function formatDate(ms: number): string {
+  if (!ms) return '';
+  try {
+    return new Date(ms).toLocaleDateString(undefined, {
+      month: 'short',
+      day: 'numeric',
+      hour: 'numeric',
+      minute: '2-digit',
+    });
+  } catch {
+    return '';
+  }
+}
+
+/**
+ * Two-pane shared notebook for the PLC. Left rail lists notes ordered by
+ * `lastEditedAt desc`; right pane edits the selected note's title + body.
+ *
+ * Editor writes are debounced (~500ms) and last-write-wins per field —
+ * matches the rest of the app's collaborative model. The hook stamps
+ * `lastEditedBy` to the current user on every write.
+ */
+export const PlcNotesTab: React.FC<PlcNotesTabProps> = ({ plc }) => {
+  const { t } = useTranslation();
+  const { showConfirm } = useDialog();
+  const { notes, loading, createNote, updateNote, deleteNote } = usePlcNotes(
+    plc.id
+  );
+
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [draftTitle, setDraftTitle] = useState('');
+  const [draftBody, setDraftBody] = useState('');
+  const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Auto-select the most-recent note once data lands. Same "adjust state
+  // during render" pattern used elsewhere in the repo.
+  const [seededFromList, setSeededFromList] = useState(false);
+  if (!seededFromList && !loading && notes.length > 0 && selectedId === null) {
+    setSeededFromList(true);
+    const first = notes[0];
+    if (first) {
+      setSelectedId(first.id);
+      setDraftTitle(first.title);
+      setDraftBody(first.body);
+    }
+  }
+
+  const selectedNote = useMemo<PlcNote | null>(
+    () => notes.find((n) => n.id === selectedId) ?? null,
+    [notes, selectedId]
+  );
+
+  // When the selection changes (different note picked OR teammate edited
+  // the active one), seed the draft fields from the canonical note.
+  // `lastSyncedAt` keeps the same note's remote updates from clobbering
+  // the user's in-flight typing — once they start editing locally, only
+  // a fresher remote `lastEditedAt` re-syncs.
+  const [syncedSnapshot, setSyncedSnapshot] = useState<{
+    id: string;
+    lastEditedAt: number;
+  } | null>(null);
+  if (selectedNote && selectedNote.id !== syncedSnapshot?.id) {
+    setSyncedSnapshot({
+      id: selectedNote.id,
+      lastEditedAt: selectedNote.lastEditedAt,
+    });
+    setDraftTitle(selectedNote.title);
+    setDraftBody(selectedNote.body);
+  } else if (
+    selectedNote &&
+    syncedSnapshot &&
+    selectedNote.lastEditedAt > syncedSnapshot.lastEditedAt
+  ) {
+    setSyncedSnapshot({
+      id: selectedNote.id,
+      lastEditedAt: selectedNote.lastEditedAt,
+    });
+    setDraftTitle(selectedNote.title);
+    setDraftBody(selectedNote.body);
+  }
+
+  // Flush pending debounced writes on unmount so a fast tab close doesn't
+  // drop the user's last edit.
+  useEffect(() => {
+    const timerRef = debounceTimerRef;
+    return () => {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+      }
+    };
+  }, []);
+
+  const scheduleSave = (
+    id: string,
+    patch: { title?: string; body?: string }
+  ) => {
+    if (debounceTimerRef.current) clearTimeout(debounceTimerRef.current);
+    debounceTimerRef.current = setTimeout(() => {
+      debounceTimerRef.current = null;
+      void updateNote(id, patch).catch((err: unknown) => {
+        logError('PlcNotesTab.updateNote', err, { plcId: plc.id, noteId: id });
+      });
+    }, SAVE_DEBOUNCE_MS);
+  };
+
+  const handleCreate = async () => {
+    try {
+      const id = await createNote({ title: '', body: '' });
+      setSelectedId(id);
+      setDraftTitle('');
+      setDraftBody('');
+    } catch (err) {
+      logError('PlcNotesTab.createNote', err, { plcId: plc.id });
+    }
+  };
+
+  const handleDelete = async (note: PlcNote) => {
+    const confirmed = await showConfirm(
+      t('plcDashboard.notes.confirmDelete', {
+        defaultValue: 'Delete this note? This cannot be undone.',
+      }),
+      {
+        title: t('plcDashboard.notes.confirmDeleteTitle', {
+          defaultValue: 'Delete note',
+        }),
+        variant: 'danger',
+        confirmLabel: t('common.delete', { defaultValue: 'Delete' }),
+      }
+    );
+    if (!confirmed) return;
+    if (debounceTimerRef.current) {
+      clearTimeout(debounceTimerRef.current);
+      debounceTimerRef.current = null;
+    }
+    try {
+      await deleteNote(note.id);
+      if (selectedId === note.id) {
+        setSelectedId(null);
+        setDraftTitle('');
+        setDraftBody('');
+      }
+    } catch (err) {
+      logError('PlcNotesTab.deleteNote', err, {
+        plcId: plc.id,
+        noteId: note.id,
+      });
+    }
+  };
+
+  const handleSelect = (id: string) => {
+    if (debounceTimerRef.current) {
+      clearTimeout(debounceTimerRef.current);
+      debounceTimerRef.current = null;
+    }
+    const note = notes.find((n) => n.id === id);
+    if (!note) return;
+    setSelectedId(id);
+    setDraftTitle(note.title);
+    setDraftBody(note.body);
+    setSyncedSnapshot({ id, lastEditedAt: note.lastEditedAt });
+  };
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center h-full min-h-[300px] text-slate-400">
+        <Loader2 className="w-5 h-5 animate-spin" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-[260px_1fr] gap-4 h-full min-h-[400px]">
+      {/* Notes list */}
+      <aside className="bg-white border border-slate-200 rounded-2xl flex flex-col overflow-hidden">
+        <div className="flex items-center justify-between px-3 py-2.5 border-b border-slate-100">
+          <h3 className="text-xxs font-bold uppercase tracking-widest text-slate-500">
+            {t('plcDashboard.notes.heading', { defaultValue: 'Notes' })}
+          </h3>
+          <button
+            type="button"
+            onClick={() => void handleCreate()}
+            className="inline-flex items-center gap-1 px-2 py-1 bg-brand-blue-primary hover:bg-brand-blue-dark text-white text-xxs font-bold uppercase tracking-wider rounded-md transition-colors"
+          >
+            <Plus className="w-3 h-3" />
+            {t('plcDashboard.notes.newNote', { defaultValue: 'New' })}
+          </button>
+        </div>
+        <div className="flex-1 overflow-y-auto custom-scrollbar">
+          {notes.length === 0 ? (
+            <div className="flex flex-col items-center justify-center text-center text-xs text-slate-500 py-10 px-4">
+              <StickyNote className="w-7 h-7 text-slate-300 mb-2" />
+              <p className="font-semibold text-slate-600">
+                {t('plcDashboard.notes.emptyTitle', {
+                  defaultValue: 'No notes yet',
+                })}
+              </p>
+              <p className="text-xxs text-slate-400 mt-1">
+                {t('plcDashboard.notes.emptySubtitle', {
+                  defaultValue: 'Create the first one to get started.',
+                })}
+              </p>
+            </div>
+          ) : (
+            <ul>
+              {notes.map((note) => {
+                const isActive = selectedId === note.id;
+                return (
+                  <li key={note.id}>
+                    <button
+                      type="button"
+                      onClick={() => handleSelect(note.id)}
+                      className={`w-full text-left px-3 py-2.5 border-b border-slate-100 transition-colors ${
+                        isActive
+                          ? 'bg-brand-blue-lighter/50'
+                          : 'hover:bg-slate-50'
+                      }`}
+                    >
+                      <div className="text-xs font-bold text-slate-800 truncate">
+                        {note.title || (
+                          <span className="italic text-slate-400">
+                            {t('plcDashboard.notes.untitled', {
+                              defaultValue: 'Untitled',
+                            })}
+                          </span>
+                        )}
+                      </div>
+                      <div className="text-xxs text-slate-500 truncate mt-0.5">
+                        {note.body
+                          ? note.body.slice(0, 60)
+                          : t('plcDashboard.notes.empty', {
+                              defaultValue: 'Empty note',
+                            })}
+                      </div>
+                      <div className="text-xxs text-slate-400 mt-1">
+                        {formatDate(note.lastEditedAt)}
+                      </div>
+                    </button>
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+        </div>
+      </aside>
+
+      {/* Editor */}
+      <main className="bg-white border border-slate-200 rounded-2xl flex flex-col overflow-hidden">
+        {selectedNote ? (
+          <>
+            <div className="flex items-center gap-2 px-4 py-3 border-b border-slate-100">
+              <input
+                type="text"
+                value={draftTitle}
+                onChange={(e) => {
+                  setDraftTitle(e.target.value);
+                  scheduleSave(selectedNote.id, { title: e.target.value });
+                }}
+                placeholder={t('plcDashboard.notes.titlePlaceholder', {
+                  defaultValue: 'Note title',
+                })}
+                className="flex-1 bg-transparent border-0 focus:ring-0 focus:outline-none text-base font-bold text-slate-900 placeholder:text-slate-300"
+              />
+              <button
+                type="button"
+                onClick={() => void handleDelete(selectedNote)}
+                className="p-2 text-slate-400 hover:text-red-500 hover:bg-red-50 rounded-lg transition-colors"
+                aria-label={t('plcDashboard.notes.deleteNote', {
+                  defaultValue: 'Delete note',
+                })}
+                title={t('plcDashboard.notes.deleteNote', {
+                  defaultValue: 'Delete note',
+                })}
+              >
+                <Trash2 className="w-4 h-4" />
+              </button>
+            </div>
+            <textarea
+              value={draftBody}
+              onChange={(e) => {
+                setDraftBody(e.target.value);
+                scheduleSave(selectedNote.id, { body: e.target.value });
+              }}
+              placeholder={t('plcDashboard.notes.bodyPlaceholder', {
+                defaultValue: 'Write your notes…',
+              })}
+              className="flex-1 w-full p-4 bg-transparent border-0 resize-none focus:ring-0 focus:outline-none text-sm text-slate-700 leading-relaxed"
+            />
+            <div className="px-4 py-2 border-t border-slate-100 text-xxs text-slate-400">
+              {t('plcDashboard.notes.lastEdited', {
+                defaultValue: 'Last edited {{when}}',
+                when: formatDate(selectedNote.lastEditedAt),
+              })}
+            </div>
+          </>
+        ) : (
+          <div className="flex flex-col items-center justify-center h-full text-center text-slate-500 p-8">
+            <StickyNote className="w-10 h-10 text-slate-300 mb-3" />
+            <p className="text-sm font-bold text-slate-700 mb-1">
+              {t('plcDashboard.notes.pickOrCreate', {
+                defaultValue: 'Select a note to edit, or create a new one.',
+              })}
+            </p>
+            <button
+              type="button"
+              onClick={() => void handleCreate()}
+              className="mt-3 inline-flex items-center gap-1.5 px-3 py-1.5 bg-brand-blue-primary hover:bg-brand-blue-dark text-white text-xxs font-bold uppercase tracking-wider rounded-lg transition-colors"
+            >
+              <Plus className="w-3.5 h-3.5" />
+              {t('plcDashboard.notes.newNote', { defaultValue: 'New note' })}
+            </button>
+          </div>
+        )}
+      </main>
+    </div>
+  );
+};

--- a/components/plc/tabs/PlcNotesTab.tsx
+++ b/components/plc/tabs/PlcNotesTab.tsx
@@ -1,4 +1,10 @@
-import React, { useEffect, useMemo, useRef, useState } from 'react';
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import { useTranslation } from 'react-i18next';
 import { Loader2, Plus, StickyNote, Trash2 } from 'lucide-react';
 import { Plc, PlcNote } from '@/types';
@@ -110,7 +116,11 @@ export const PlcNotesTab: React.FC<PlcNotesTabProps> = ({ plc }) => {
     setDraftBody(selectedNote.body);
   }
 
-  const flushPendingSave = () => {
+  // Stable across renders so the unmount cleanup effect can depend on it
+  // without re-running each render. Re-binds only when `updateNote` or
+  // `plc.id` changes — both effectively constant for the component's
+  // lifetime, since `PlcDashboard` unmounts on PLC switch.
+  const flushPendingSave = useCallback(() => {
     if (debounceTimerRef.current) {
       clearTimeout(debounceTimerRef.current);
       debounceTimerRef.current = null;
@@ -126,9 +136,9 @@ export const PlcNotesTab: React.FC<PlcNotesTabProps> = ({ plc }) => {
     void updateNote(id, toSave).catch((err: unknown) => {
       logError('PlcNotesTab.updateNote', err, { plcId: plc.id, noteId: id });
     });
-  };
+  }, [updateNote, plc.id]);
 
-  const cancelPendingSave = () => {
+  const cancelPendingSave = useCallback(() => {
     if (debounceTimerRef.current) {
       clearTimeout(debounceTimerRef.current);
       debounceTimerRef.current = null;
@@ -136,7 +146,7 @@ export const PlcNotesTab: React.FC<PlcNotesTabProps> = ({ plc }) => {
     pendingPatchRef.current = {};
     pendingNoteIdRef.current = null;
     setPendingNoteId(null);
-  };
+  }, []);
 
   // Flush pending debounced writes on unmount so a fast tab close doesn't
   // drop the user's last edit.
@@ -144,26 +154,25 @@ export const PlcNotesTab: React.FC<PlcNotesTabProps> = ({ plc }) => {
     return () => {
       flushPendingSave();
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [flushPendingSave]);
 
-  const scheduleSave = (
-    id: string,
-    patch: { title?: string; body?: string }
-  ) => {
-    // If a write is queued for a different note, flush it first so we
-    // don't merge title/body across notes.
-    if (pendingNoteIdRef.current && pendingNoteIdRef.current !== id) {
-      flushPendingSave();
-    }
-    pendingNoteIdRef.current = id;
-    setPendingNoteId(id);
-    pendingPatchRef.current = { ...pendingPatchRef.current, ...patch };
-    if (debounceTimerRef.current) clearTimeout(debounceTimerRef.current);
-    debounceTimerRef.current = setTimeout(() => {
-      flushPendingSave();
-    }, SAVE_DEBOUNCE_MS);
-  };
+  const scheduleSave = useCallback(
+    (id: string, patch: { title?: string; body?: string }) => {
+      // If a write is queued for a different note, flush it first so we
+      // don't merge title/body across notes.
+      if (pendingNoteIdRef.current && pendingNoteIdRef.current !== id) {
+        flushPendingSave();
+      }
+      pendingNoteIdRef.current = id;
+      setPendingNoteId(id);
+      pendingPatchRef.current = { ...pendingPatchRef.current, ...patch };
+      if (debounceTimerRef.current) clearTimeout(debounceTimerRef.current);
+      debounceTimerRef.current = setTimeout(() => {
+        flushPendingSave();
+      }, SAVE_DEBOUNCE_MS);
+    },
+    [flushPendingSave]
+  );
 
   const handleCreate = async () => {
     try {

--- a/components/plc/tabs/PlcNotesTab.tsx
+++ b/components/plc/tabs/PlcNotesTab.tsx
@@ -50,6 +50,12 @@ export const PlcNotesTab: React.FC<PlcNotesTabProps> = ({ plc }) => {
   // cancel.
   const pendingPatchRef = useRef<{ title?: string; body?: string }>({});
   const pendingNoteIdRef = useRef<string | null>(null);
+  // State mirror of `pendingNoteIdRef` for render-time consumption. Refs
+  // can't be read during render (react-hooks/refs lint rule), but the
+  // remote-edit re-sync below needs to know if the active note has unsaved
+  // local edits — otherwise a teammate's snapshot would clobber the user's
+  // in-flight typing.
+  const [pendingNoteId, setPendingNoteId] = useState<string | null>(null);
 
   // Auto-select the most-recent note once data lands. Same "adjust state
   // during render" pattern used elsewhere in the repo.
@@ -88,8 +94,14 @@ export const PlcNotesTab: React.FC<PlcNotesTabProps> = ({ plc }) => {
   } else if (
     selectedNote &&
     syncedSnapshot &&
-    selectedNote.lastEditedAt > syncedSnapshot.lastEditedAt
+    selectedNote.lastEditedAt > syncedSnapshot.lastEditedAt &&
+    pendingNoteId !== selectedNote.id
   ) {
+    // Remote edit landed on the active note AND we have no unsaved local
+    // edits for it — accept the remote update. When `pendingNoteId` matches
+    // the selection, the user is mid-typing; their drafts win until the
+    // debounce flushes (at which point `lastEditedAt` will catch up and
+    // this branch becomes a no-op).
     setSyncedSnapshot({
       id: selectedNote.id,
       lastEditedAt: selectedNote.lastEditedAt,
@@ -107,6 +119,7 @@ export const PlcNotesTab: React.FC<PlcNotesTabProps> = ({ plc }) => {
     const toSave = pendingPatchRef.current;
     pendingPatchRef.current = {};
     pendingNoteIdRef.current = null;
+    setPendingNoteId(null);
     if (!id || (toSave.title === undefined && toSave.body === undefined)) {
       return;
     }
@@ -122,6 +135,7 @@ export const PlcNotesTab: React.FC<PlcNotesTabProps> = ({ plc }) => {
     }
     pendingPatchRef.current = {};
     pendingNoteIdRef.current = null;
+    setPendingNoteId(null);
   };
 
   // Flush pending debounced writes on unmount so a fast tab close doesn't
@@ -143,6 +157,7 @@ export const PlcNotesTab: React.FC<PlcNotesTabProps> = ({ plc }) => {
       flushPendingSave();
     }
     pendingNoteIdRef.current = id;
+    setPendingNoteId(id);
     pendingPatchRef.current = { ...pendingPatchRef.current, ...patch };
     if (debounceTimerRef.current) clearTimeout(debounceTimerRef.current);
     debounceTimerRef.current = setTimeout(() => {

--- a/components/plc/tabs/PlcOverviewTab.tsx
+++ b/components/plc/tabs/PlcOverviewTab.tsx
@@ -1,0 +1,130 @@
+import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Loader2, Pencil, RotateCcw, Check } from 'lucide-react';
+import { Plc } from '@/types';
+import { useDialog } from '@/context/useDialog';
+import { usePlcOverviewLayout } from '@/hooks/usePlcOverviewLayout';
+import { PlcBentoGrid } from '../overview/PlcBentoGrid';
+import type { PlcDashboardTabId } from '../PlcDashboard';
+
+interface PlcOverviewTabProps {
+  plc: Plc;
+  onNavigateTab: (tabId: PlcDashboardTabId) => void;
+}
+
+/**
+ * Wraps the PLC Overview bento grid with the edit-mode toggle + reset
+ * controls. Layout state owned by `usePlcOverviewLayout` and persisted
+ * per-user.
+ */
+export const PlcOverviewTab: React.FC<PlcOverviewTabProps> = ({
+  plc,
+  onNavigateTab,
+}) => {
+  const { t } = useTranslation();
+  const { showConfirm } = useDialog();
+  const { layout, loading, updateLayout, resetLayout } = usePlcOverviewLayout(
+    plc.id
+  );
+  const [editMode, setEditMode] = useState(false);
+
+  const handleReset = async () => {
+    const confirmed = await showConfirm(
+      t('plcDashboard.overview.confirmReset', {
+        defaultValue:
+          'Reset your bento layout to the default arrangement? Tile sizes and order will be restored.',
+      }),
+      {
+        title: t('plcDashboard.overview.confirmResetTitle', {
+          defaultValue: 'Reset layout',
+        }),
+        confirmLabel: t('plcDashboard.overview.reset', {
+          defaultValue: 'Reset',
+        }),
+      }
+    );
+    if (!confirmed) return;
+    try {
+      await resetLayout();
+    } catch {
+      // logError already fired inside the hook; the snapshot will recover
+      // the on-disk state if Firestore eventually rejected.
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center h-full min-h-[300px] text-slate-400">
+        <Loader2 className="w-5 h-5 animate-spin" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between flex-wrap gap-2">
+        <div>
+          <h3 className="text-xs font-bold text-slate-400 uppercase tracking-widest">
+            {t('plcDashboard.overview.heading', {
+              defaultValue: 'Overview',
+            })}
+          </h3>
+          {editMode && (
+            <p className="text-xxs text-slate-500 mt-1">
+              {t('plcDashboard.overview.editHint', {
+                defaultValue:
+                  'Drag tiles by the grip, click the corner to resize, click the eye to hide.',
+              })}
+            </p>
+          )}
+        </div>
+        <div className="flex items-center gap-2">
+          {editMode && (
+            <button
+              type="button"
+              onClick={() => void handleReset()}
+              className="inline-flex items-center gap-1.5 px-3 py-1.5 bg-white border border-slate-200 hover:border-slate-300 text-slate-700 text-xxs font-bold uppercase tracking-wider rounded-lg transition-colors"
+            >
+              <RotateCcw className="w-3.5 h-3.5" />
+              {t('plcDashboard.overview.reset', { defaultValue: 'Reset' })}
+            </button>
+          )}
+          <button
+            type="button"
+            onClick={() => setEditMode((prev) => !prev)}
+            className={`inline-flex items-center gap-1.5 px-3 py-1.5 text-xxs font-bold uppercase tracking-wider rounded-lg transition-colors ${
+              editMode
+                ? 'bg-brand-blue-primary text-white hover:bg-brand-blue-dark'
+                : 'bg-white border border-slate-200 hover:border-brand-blue-primary text-slate-700 hover:text-brand-blue-primary'
+            }`}
+            aria-pressed={editMode}
+          >
+            {editMode ? (
+              <>
+                <Check className="w-3.5 h-3.5" />
+                {t('plcDashboard.overview.doneEditing', {
+                  defaultValue: 'Done',
+                })}
+              </>
+            ) : (
+              <>
+                <Pencil className="w-3.5 h-3.5" />
+                {t('plcDashboard.overview.editLayout', {
+                  defaultValue: 'Edit layout',
+                })}
+              </>
+            )}
+          </button>
+        </div>
+      </div>
+
+      <PlcBentoGrid
+        plc={plc}
+        layout={layout}
+        editMode={editMode}
+        onLayoutChange={updateLayout}
+        onNavigateTab={onNavigateTab}
+      />
+    </div>
+  );
+};

--- a/components/plc/tabs/PlcTodosTab.tsx
+++ b/components/plc/tabs/PlcTodosTab.tsx
@@ -1,0 +1,224 @@
+import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { ListChecks, Loader2, Plus, Trash2 } from 'lucide-react';
+import { Plc, PlcTodo } from '@/types';
+import { useDialog } from '@/context/useDialog';
+import { usePlcTodos } from '@/hooks/usePlcTodos';
+import { logError } from '@/utils/logError';
+
+interface PlcTodosTabProps {
+  plc: Plc;
+}
+
+export const PlcTodosTab: React.FC<PlcTodosTabProps> = ({ plc }) => {
+  const { t } = useTranslation();
+  const { showConfirm } = useDialog();
+  const { todos, loading, createTodo, toggleDone, updateText, deleteTodo } =
+    usePlcTodos(plc.id);
+
+  const [draft, setDraft] = useState('');
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editingText, setEditingText] = useState('');
+
+  const incomplete = todos.filter((t) => !t.done);
+  const complete = todos.filter((t) => t.done);
+
+  const handleAdd = async () => {
+    const trimmed = draft.trim();
+    if (!trimmed) return;
+    setDraft('');
+    try {
+      await createTodo(trimmed);
+    } catch (err) {
+      logError('PlcTodosTab.createTodo', err, { plcId: plc.id });
+      // Restore the draft so the user doesn't lose what they typed.
+      setDraft(trimmed);
+    }
+  };
+
+  const handleSubmitEdit = async (todo: PlcTodo) => {
+    const trimmed = editingText.trim();
+    setEditingId(null);
+    if (!trimmed || trimmed === todo.text) return;
+    try {
+      await updateText(todo.id, trimmed);
+    } catch (err) {
+      logError('PlcTodosTab.updateText', err, {
+        plcId: plc.id,
+        todoId: todo.id,
+      });
+    }
+  };
+
+  const handleDelete = async (todo: PlcTodo) => {
+    const confirmed = await showConfirm(
+      t('plcDashboard.todos.confirmDelete', {
+        defaultValue: 'Delete this to-do?',
+      }),
+      {
+        title: t('plcDashboard.todos.confirmDeleteTitle', {
+          defaultValue: 'Delete to-do',
+        }),
+        variant: 'danger',
+        confirmLabel: t('common.delete', { defaultValue: 'Delete' }),
+      }
+    );
+    if (!confirmed) return;
+    try {
+      await deleteTodo(todo.id);
+    } catch (err) {
+      logError('PlcTodosTab.deleteTodo', err, {
+        plcId: plc.id,
+        todoId: todo.id,
+      });
+    }
+  };
+
+  const renderRow = (todo: PlcTodo) => {
+    const isEditing = editingId === todo.id;
+    return (
+      <li
+        key={todo.id}
+        className="group flex items-start gap-3 px-3 py-2.5 bg-white border border-slate-200 hover:border-brand-blue-primary/30 rounded-xl transition-colors"
+      >
+        <input
+          type="checkbox"
+          checked={todo.done}
+          onChange={(e) => {
+            void toggleDone(todo.id, e.target.checked).catch((err: unknown) => {
+              logError('PlcTodosTab.toggleDone', err, {
+                plcId: plc.id,
+                todoId: todo.id,
+              });
+            });
+          }}
+          className="mt-0.5 w-4 h-4 rounded border-slate-300 text-brand-blue-primary focus:ring-brand-blue-primary cursor-pointer"
+          aria-label={t('plcDashboard.todos.toggle', {
+            defaultValue: 'Mark "{{text}}" complete',
+            text: todo.text,
+          })}
+        />
+        {isEditing ? (
+          <input
+            type="text"
+            value={editingText}
+            onChange={(e) => setEditingText(e.target.value)}
+            onBlur={() => void handleSubmitEdit(todo)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                e.preventDefault();
+                void handleSubmitEdit(todo);
+              } else if (e.key === 'Escape') {
+                setEditingId(null);
+              }
+            }}
+            autoFocus
+            className="flex-1 bg-transparent border-0 focus:ring-0 focus:outline-none text-sm text-slate-700"
+          />
+        ) : (
+          <button
+            type="button"
+            onClick={() => {
+              setEditingId(todo.id);
+              setEditingText(todo.text);
+            }}
+            className={`flex-1 text-left text-sm leading-snug ${
+              todo.done ? 'text-slate-400 line-through' : 'text-slate-700'
+            }`}
+          >
+            {todo.text}
+          </button>
+        )}
+        <button
+          type="button"
+          onClick={() => void handleDelete(todo)}
+          className="opacity-0 group-hover:opacity-100 focus:opacity-100 p-1 text-slate-400 hover:text-red-500 hover:bg-red-50 rounded transition-all"
+          aria-label={t('plcDashboard.todos.deleteTodo', {
+            defaultValue: 'Delete to-do',
+          })}
+          title={t('plcDashboard.todos.deleteTodo', {
+            defaultValue: 'Delete to-do',
+          })}
+        >
+          <Trash2 className="w-3.5 h-3.5" />
+        </button>
+      </li>
+    );
+  };
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center h-full min-h-[300px] text-slate-400">
+        <Loader2 className="w-5 h-5 animate-spin" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-2xl mx-auto space-y-4">
+      {/* Add new */}
+      <div className="flex gap-2">
+        <input
+          type="text"
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') {
+              e.preventDefault();
+              void handleAdd();
+            }
+          }}
+          placeholder={t('plcDashboard.todos.addPlaceholder', {
+            defaultValue: 'Add a to-do for the PLC…',
+          })}
+          className="flex-1 px-3 py-2 bg-white border border-slate-200 focus:border-brand-blue-primary focus:ring-2 focus:ring-brand-blue-primary/20 rounded-lg text-sm text-slate-700 transition-colors"
+        />
+        <button
+          type="button"
+          onClick={() => void handleAdd()}
+          disabled={!draft.trim()}
+          className="inline-flex items-center gap-1.5 px-3 py-2 bg-brand-blue-primary hover:bg-brand-blue-dark disabled:bg-slate-300 disabled:cursor-not-allowed text-white text-xxs font-bold uppercase tracking-wider rounded-lg transition-colors"
+        >
+          <Plus className="w-3.5 h-3.5" />
+          {t('plcDashboard.todos.add', { defaultValue: 'Add' })}
+        </button>
+      </div>
+
+      {/* Open */}
+      <section>
+        <h3 className="text-xxs font-bold uppercase tracking-widest text-slate-400 px-1 mb-2">
+          {t('plcDashboard.todos.openHeading', {
+            defaultValue: 'To do',
+            count: incomplete.length,
+          })}
+          {incomplete.length > 0 && (
+            <span className="ml-2 text-slate-500">{incomplete.length}</span>
+          )}
+        </h3>
+        {incomplete.length === 0 ? (
+          <div className="flex flex-col items-center justify-center text-center text-xs text-slate-500 py-8 bg-white rounded-2xl border border-dashed border-slate-200">
+            <ListChecks className="w-6 h-6 text-slate-300 mb-2" />
+            <p className="font-semibold text-slate-600">
+              {t('plcDashboard.todos.allDone', {
+                defaultValue: 'Nothing on the list',
+              })}
+            </p>
+          </div>
+        ) : (
+          <ul className="space-y-2">{incomplete.map(renderRow)}</ul>
+        )}
+      </section>
+
+      {/* Done */}
+      {complete.length > 0 && (
+        <section>
+          <h3 className="text-xxs font-bold uppercase tracking-widest text-slate-400 px-1 mb-2">
+            {t('plcDashboard.todos.doneHeading', { defaultValue: 'Done' })}
+            <span className="ml-2 text-slate-500">{complete.length}</span>
+          </h3>
+          <ul className="space-y-2 opacity-80">{complete.map(renderRow)}</ul>
+        </section>
+      )}
+    </div>
+  );
+};

--- a/docs/PLC_ROADMAP.md
+++ b/docs/PLC_ROADMAP.md
@@ -30,8 +30,11 @@ This roadmap is designed to be **executed in independent chunks across multiple 
 - [ ] **Phase 2** — PLC Quiz Library (share-with-PLC, collaborative editing, sync-or-copy import)
 - [ ] **Phase 3** — PLC-authored Assignments tab + auto-bubble-up from personal assignments
 - [ ] **Phase 4** — Video Activities (extend with `PlcLinkage` + dashboard surface)
-- [ ] **Phase 5** — Notes + To-Do list (collaborative shared docs)
+- [x] **Phase 5** — Notes + To-Do list (collaborative shared docs) _(bundled with Overview/Bento — see Phase 1.5 below)_
 - [ ] **Phase 6** — Shared Boards surface
+- [x] **Phase 1.5 (out-of-band)** — PLC Overview tab with per-user customizable bento grid + sidebar kebab UX
+
+> **Phase 1.5 deviation note:** Phase 5 (Notes + To-Dos) was pulled forward and shipped alongside the Overview tab + bento grid + sidebar kebab refactor in a single PR. This deviates from the "one phase per PR" rule because the Overview tab's bento tiles needed real content for Notes and To-Dos on day one — placeholder tiles linking to placeholder tabs would have felt empty. Phases 2/3/4/6 remain stubbed with "coming soon" tiles that swap to live data when those phases ship; the layout doesn't have to change.
 
 Branch convention: each phase opens a `claude/plc-phase-N-<slug>` branch off `dev-paul`. Do **not** target `main` directly.
 
@@ -221,7 +224,57 @@ _(Fill in after shipping.)_
 
 ### Notes from implementation
 
-_(Fill in after shipping.)_
+Shipped together with Phase 1.5 (Overview + bento grid + sidebar kebab). See "Phase 1.5" below for the details that affect future phases.
+
+---
+
+## Phase 1.5 — Overview tab + bento grid + sidebar kebab _(SHIPPED)_
+
+**Status:** Shipped together with Phase 5 (Notes + To-Dos).
+
+### What landed
+
+- `components/plc/tabs/PlcOverviewTab.tsx` — new default landing tab. Wraps the bento grid with an Edit Layout / Reset toggle.
+- `components/plc/overview/PlcBentoGrid.tsx` — dnd-kit `SortableContext` + `DragOverlay` + closest-center collision detection. Mirrors `components/common/library/LibraryGrid.tsx` exactly (the canonical sortable pattern in this codebase — do not invent a new shape).
+- `components/plc/overview/PlcBentoTile.tsx` — sortable tile wrapper. Drag handle scoped to a grip icon (so tile content stays interactive when not dragging). Resize button cycles `sm → md-wide → md-tall → lg`. Hide button moves the tile into a "Hidden tiles" tray below the grid.
+- `components/plc/overview/tileRegistry.tsx` — central switchboard for tile content, keyed by `PlcBentoTileKind`. Adding a new tile = a new case here + a new union member in `types.ts`. The "coming soon" tiles for Phases 2/3/4/6 route through `ComingSoonTile`; swap the case for the real component when each phase ships.
+- `components/plc/overview/tiles/*` — live tile content for Members, PlcInfo, CompletedAssignments, Notes, Todos, SharedSheet, QuickActions, plus `ComingSoonTile` for the four still-stubbed phases.
+- `hooks/usePlcOverviewLayout.ts` — per-user layout persistence at `users/{uid}/plc_layouts/{plcId}`. Optimistic local state with debounced (~500ms) writes; `lastWrittenAt` guard so an in-flight snapshot doesn't clobber a fresher local rearrangement; pending write flushes on unmount.
+- `firestore.rules` — new `match /users/{userId}/plc_layouts/{plcId}` block (owner-only, schema lock-down via `keys().hasOnly([...])`).
+- `components/layout/sidebar/SidebarPlcs.tsx` — refactored. Each PLC card is now a single click target (backdrop button + layered visible content with `pointer-events-none`); secondary actions (edit/view, delete/leave) live in a kebab popover. Whole-card hover state and chevron-right affordance.
+
+### Notes from implementation
+
+- **dnd-kit usage in this codebase:** the canonical sortable pattern lives in `components/common/library/LibraryGrid.tsx` + `useSortableReorder.ts`. Mirror its sensor activation (`PointerSensor { distance: 5 }`), collision detection (`closestCenter`), strategy (`rectSortingStrategy`), and overlay (`DragOverlay` with `snapCenterToCursor`). An earlier exploration that "found" zero dnd-kit usage was wrong — when in doubt, search for `useSortable` and `SortableContext` imports.
+- **Heterogeneous tile sizes:** the bento grid mixes 1×1, 2×1, 1×2, and 2×2 tiles inside a CSS grid. `closestCenter` is forgiving enough for the current ~10-tile size; if jitter shows up at scale the documented mitigation is to collapse non-active tiles to 1×1 during drag (`activeId != null` ⇒ render-time span override) so the sort math sees uniform rects.
+- **Resize via cycle button:** the alternative — drag-resize against a CSS-grid container — would require quantizing pointer deltas to grid cells and is a notable rabbit hole. The 4-state cycle button (sm→md-wide→md-tall→lg→sm) is much cheaper and is well-discoverable with a tooltip.
+- **Per-tile drag handle is mandatory:** without binding `{...listeners}` to a specific grip icon (instead of the whole tile), tile content (e.g. note row click handlers) becomes inert. The bento tile additionally suppresses content interaction with `pointer-events-none` while `editMode` is on.
+- **Sidebar click affordance:** the previous split-row layout (left button + right icons) was already two real `<button>`s side-by-side, but the affordance was unclear. The new layout uses an absolute-positioned backdrop `<button>` covering the whole card with `pointer-events-none` on the visible content — clicks pass through to the backdrop unless they hit the kebab. This avoids the invalid nested-button HTML the previous design was working around.
+
+---
+
+## Phase 5 — Notes + To-Do list _(SHIPPED)_
+
+**Status:** Shipped together with Phase 1.5 (see above for the bundling rationale).
+
+### What landed
+
+- `plcs/{plcId}/notes/{noteId}` subcollection — `{ id, title, body, createdBy, createdAt, lastEditedBy, lastEditedAt }`. Any member CRUD; `createdBy`/`createdAt`/`id` immutable on update; `lastEditedBy` must equal `request.auth.uid` on every update. Members can also delete (PLC-owned model — notes are shared, not creator-owned).
+- `plcs/{plcId}/todos/{todoId}` subcollection — `{ id, text, done, createdBy, createdAt }`. Any member CRUD; `createdBy`/`createdAt`/`id` immutable. One doc per todo (not an array on a parent doc) so concurrent toggles don't serialize against the whole list.
+- `hooks/usePlcNotes.ts`, `hooks/usePlcTodos.ts` — live subscriptions + CRUD mutators. The hook pattern mirrors `usePlcAssignmentIndex.ts` (parser drops malformed entries, listener disabled with `null` plcId, no useEffect for state-on-prop-change).
+- `components/plc/tabs/PlcNotesTab.tsx` — two-pane (list + editor). Plain textarea body editing; debounced (~500ms) writes via `updateNote`. Snapshot updates apply to the editor only when there's no pending local write.
+- `components/plc/tabs/PlcTodosTab.tsx` — single list. Add input + click-to-edit-inline + completed section.
+
+### Open questions resolved
+
+- **Multi-note vs. single notepad:** Multi-note model. Subcollection-per-note matches the rest of the app's collaborative pattern.
+- **Optional `assignedTo` on todos:** Deferred. Not in this PR. Add later as a non-breaking schema extension (the rules' `keys().hasOnly([...])` would need to widen).
+
+### Out of scope (still)
+
+- Rich text in notes (we ship plain textarea — Markdown is fine via convention; no rendering yet).
+- Per-todo `assignedTo` field.
+- Notification when a teammate changes shared content.
 
 ---
 
@@ -298,4 +351,4 @@ _(Add new ones here as they come up. Resolve before starting the affected phase.
 
 ---
 
-**Last updated:** 2026-05-07 (Phase 1 shipped — PR #1537)
+**Last updated:** 2026-05-07 (Phase 1.5 + Phase 5 shipped — Overview tab + bento grid + sidebar kebab + Notes/To-Dos)

--- a/firestore.rules
+++ b/firestore.rules
@@ -413,6 +413,20 @@ service cloud.firestore {
       allow read, write: if request.auth != null && request.auth.uid == userId;
     }
 
+    // PLC Overview layout — per-user customization of the PLC Dashboard
+    // bento grid. Pure view preferences, so no PLC membership check is
+    // needed (a non-member's layout doc here would be inert because the
+    // tiles can't read PLC content without passing the PLC rule gates).
+    // Schema lock-down keeps the doc shape closed for future readers.
+    match /users/{userId}/plc_layouts/{plcId} {
+      allow read, delete: if request.auth != null && request.auth.uid == userId;
+      allow write: if request.auth != null
+                   && request.auth.uid == userId
+                   && request.resource.data.keys().hasOnly(['tiles', 'updatedAt'])
+                   && request.resource.data.tiles is list
+                   && request.resource.data.updatedAt is int;
+    }
+
     // Mini Apps - users can only access their own mini apps in their subcollection
     match /users/{userId}/miniapps/{appId} {
       allow read, write: if request.auth != null && request.auth.uid == userId;
@@ -963,6 +977,107 @@ service cloud.firestore {
         // sweep stale entries can ask the owner.
         allow delete: if request.auth != null
           && request.auth.uid == resource.data.ownerUid;
+      }
+
+      // PLC shared notes (Phase 5). Lightweight collaborative notebook —
+      // any current member can CRUD any note. LWW on edits via the
+      // `lastEditedBy` / `lastEditedAt` snapshot on each write. Schema
+      // is locked so future readers can rely on the field set.
+      match /notes/{noteId} {
+        allow read: if request.auth != null
+          && request.auth.uid in get(
+               /databases/$(database)/documents/plcs/$(plcId)
+             ).data.memberUids;
+
+        allow create: if request.auth != null
+          && request.auth.uid in get(
+               /databases/$(database)/documents/plcs/$(plcId)
+             ).data.memberUids
+          && request.resource.data.keys().hasOnly([
+               'id', 'title', 'body',
+               'createdBy', 'createdAt',
+               'lastEditedBy', 'lastEditedAt'
+             ])
+          && request.resource.data.id == noteId
+          && request.resource.data.createdBy == request.auth.uid
+          && request.resource.data.lastEditedBy == request.auth.uid
+          && request.resource.data.title is string
+          && request.resource.data.body is string
+          && request.resource.data.createdAt is int
+          && request.resource.data.lastEditedAt is int;
+
+        // Update: any current member can edit any note. createdBy /
+        // createdAt / id are immutable — they describe who first authored
+        // the note and shouldn't be rewritten by later editors. The
+        // editor must stamp themselves into `lastEditedBy` so the audit
+        // trail is honest.
+        allow update: if request.auth != null
+          && request.auth.uid in get(
+               /databases/$(database)/documents/plcs/$(plcId)
+             ).data.memberUids
+          && request.resource.data.keys().hasOnly([
+               'id', 'title', 'body',
+               'createdBy', 'createdAt',
+               'lastEditedBy', 'lastEditedAt'
+             ])
+          && request.resource.data.id == resource.data.id
+          && request.resource.data.createdBy == resource.data.createdBy
+          && request.resource.data.createdAt == resource.data.createdAt
+          && request.resource.data.lastEditedBy == request.auth.uid
+          && request.resource.data.lastEditedAt is int
+          && request.resource.data.title is string
+          && request.resource.data.body is string;
+
+        // Any member can delete (matches the "shared notebook" model —
+        // notes are PLC-owned, not creator-owned).
+        allow delete: if request.auth != null
+          && request.auth.uid in get(
+               /databases/$(database)/documents/plcs/$(plcId)
+             ).data.memberUids;
+      }
+
+      // PLC shared to-do list (Phase 5). One doc per todo so concurrent
+      // toggles don't serialize on a single parent doc. Any current
+      // member can CRUD any todo.
+      match /todos/{todoId} {
+        allow read: if request.auth != null
+          && request.auth.uid in get(
+               /databases/$(database)/documents/plcs/$(plcId)
+             ).data.memberUids;
+
+        allow create: if request.auth != null
+          && request.auth.uid in get(
+               /databases/$(database)/documents/plcs/$(plcId)
+             ).data.memberUids
+          && request.resource.data.keys().hasOnly([
+               'id', 'text', 'done', 'createdBy', 'createdAt'
+             ])
+          && request.resource.data.id == todoId
+          && request.resource.data.createdBy == request.auth.uid
+          && request.resource.data.text is string
+          && request.resource.data.done is bool
+          && request.resource.data.createdAt is int;
+
+        // Update: createdBy / createdAt / id are immutable. `done` and
+        // `text` are mutable so any teammate can mark a todo complete or
+        // tweak the wording.
+        allow update: if request.auth != null
+          && request.auth.uid in get(
+               /databases/$(database)/documents/plcs/$(plcId)
+             ).data.memberUids
+          && request.resource.data.keys().hasOnly([
+               'id', 'text', 'done', 'createdBy', 'createdAt'
+             ])
+          && request.resource.data.id == resource.data.id
+          && request.resource.data.createdBy == resource.data.createdBy
+          && request.resource.data.createdAt == resource.data.createdAt
+          && request.resource.data.text is string
+          && request.resource.data.done is bool;
+
+        allow delete: if request.auth != null
+          && request.auth.uid in get(
+               /databases/$(database)/documents/plcs/$(plcId)
+             ).data.memberUids;
       }
     }
 

--- a/firestore.rules
+++ b/firestore.rules
@@ -418,12 +418,21 @@ service cloud.firestore {
     // needed (a non-member's layout doc here would be inert because the
     // tiles can't read PLC content without passing the PLC rule gates).
     // Schema lock-down keeps the doc shape closed for future readers.
+    //
+    // Per-tile interior validation (kind / size enums) is intentionally
+    // delegated to the client parser in `usePlcOverviewLayout.ts` rather
+    // than CEL: Firestore rules don't expose `.every()` over lists, and
+    // the blast radius of garbage tile entries is bounded to the user's
+    // own dashboard (the rule scope is owner-only). The tiles-list size
+    // cap below prevents a single doc from being weaponized as unbounded
+    // storage.
     match /users/{userId}/plc_layouts/{plcId} {
       allow read, delete: if request.auth != null && request.auth.uid == userId;
       allow write: if request.auth != null
                    && request.auth.uid == userId
                    && request.resource.data.keys().hasOnly(['tiles', 'updatedAt'])
                    && request.resource.data.tiles is list
+                   && request.resource.data.tiles.size() <= 50
                    && request.resource.data.updatedAt is int;
     }
 

--- a/hooks/usePlcNotes.ts
+++ b/hooks/usePlcNotes.ts
@@ -7,6 +7,7 @@ import {
   orderBy,
   query,
   setDoc,
+  updateDoc,
 } from 'firebase/firestore';
 import { db, isAuthBypass } from '@/config/firebase';
 import { useAuth } from '@/context/useAuth';
@@ -124,26 +125,27 @@ export const usePlcNotes = (plcId: string | null): UsePlcNotesResult => {
       patch: { title?: string; body?: string }
     ): Promise<void> => {
       if (!plcId || !user) throw new Error('Not signed in');
-      // Find the existing note in local state so we can re-write the full
-      // doc — the rule requires `keys().hasOnly(...)`, so a partial merge
-      // would fail if the local state ever drifts from the server.
-      const existing = notes.find((n) => n.id === noteId);
-      if (!existing) {
-        throw new Error('Note not found');
-      }
-      const updated: PlcNote = {
-        ...existing,
-        title: patch.title ?? existing.title,
-        body: patch.body ?? existing.body,
+      // Patch-only updates so a teammate's concurrent edit on the *other*
+      // field isn't reverted by our stale local snapshot. The rule's
+      // `keys.hasOnly(...)` check applies to the post-merge doc, so a
+      // partial `updateDoc` passes — `id`/`createdBy`/`createdAt` stay
+      // immutable because they're untouched.
+      //
+      // `lastEditedBy` + `lastEditedAt` must be in the patch on every
+      // edit: the rule requires `lastEditedBy == request.auth.uid` and
+      // `lastEditedAt is int` on update.
+      const fields: Record<string, unknown> = {
         lastEditedBy: user.uid,
         lastEditedAt: Date.now(),
       };
-      await setDoc(
+      if (patch.title !== undefined) fields.title = patch.title;
+      if (patch.body !== undefined) fields.body = patch.body;
+      await updateDoc(
         doc(db, PLCS_COLLECTION, plcId, NOTES_SUBCOLLECTION, noteId),
-        updated
+        fields
       );
     },
-    [plcId, user, notes]
+    [plcId, user]
   );
 
   const deleteNote = useCallback(

--- a/hooks/usePlcNotes.ts
+++ b/hooks/usePlcNotes.ts
@@ -1,0 +1,163 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  collection,
+  deleteDoc,
+  doc,
+  onSnapshot,
+  orderBy,
+  query,
+  setDoc,
+} from 'firebase/firestore';
+import { db, isAuthBypass } from '@/config/firebase';
+import { useAuth } from '@/context/useAuth';
+import { PlcNote } from '@/types';
+import { logError } from '@/utils/logError';
+
+const PLCS_COLLECTION = 'plcs';
+const NOTES_SUBCOLLECTION = 'notes';
+
+interface UsePlcNotesResult {
+  notes: PlcNote[];
+  loading: boolean;
+  /** Create a new note. Returns the new doc id. */
+  createNote: (input: { title: string; body: string }) => Promise<string>;
+  /** Patch an existing note's title/body. Stamps `lastEditedBy/At` to the current user. */
+  updateNote: (
+    noteId: string,
+    patch: { title?: string; body?: string }
+  ) => Promise<void>;
+  deleteNote: (noteId: string) => Promise<void>;
+}
+
+function parseNote(id: string, data: Record<string, unknown>): PlcNote | null {
+  if (
+    typeof data.title !== 'string' ||
+    typeof data.body !== 'string' ||
+    typeof data.createdBy !== 'string' ||
+    typeof data.createdAt !== 'number' ||
+    typeof data.lastEditedBy !== 'string' ||
+    typeof data.lastEditedAt !== 'number'
+  ) {
+    return null;
+  }
+  return {
+    id,
+    title: data.title,
+    body: data.body,
+    createdBy: data.createdBy,
+    createdAt: data.createdAt,
+    lastEditedBy: data.lastEditedBy,
+    lastEditedAt: data.lastEditedAt,
+  };
+}
+
+/**
+ * Live subscription to a PLC's shared notes. Returns notes ordered
+ * newest-first by `lastEditedAt`. Pass `null` for `plcId` to skip the
+ * listener (e.g. while the dashboard is closed).
+ */
+export const usePlcNotes = (plcId: string | null): UsePlcNotesResult => {
+  const { user } = useAuth();
+  const [notes, setNotes] = useState<PlcNote[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const [prevPlcId, setPrevPlcId] = useState(plcId);
+  if (plcId !== prevPlcId) {
+    setPrevPlcId(plcId);
+    setNotes([]);
+    setLoading(true);
+  }
+
+  useEffect(() => {
+    if (!plcId || !user || isAuthBypass) {
+      const t = setTimeout(() => {
+        setNotes([]);
+        setLoading(false);
+      }, 0);
+      return () => clearTimeout(t);
+    }
+    const ref = collection(db, PLCS_COLLECTION, plcId, NOTES_SUBCOLLECTION);
+    const unsub = onSnapshot(
+      query(ref, orderBy('lastEditedAt', 'desc')),
+      (snap) => {
+        const list: PlcNote[] = [];
+        snap.forEach((d) => {
+          const parsed = parseNote(d.id, d.data() as Record<string, unknown>);
+          if (parsed) list.push(parsed);
+        });
+        setNotes(list);
+        setLoading(false);
+      },
+      (err) => {
+        logError('usePlcNotes.snapshot', err, { plcId });
+        setLoading(false);
+      }
+    );
+    return () => unsub();
+  }, [plcId, user]);
+
+  const createNote = useCallback(
+    async (input: { title: string; body: string }): Promise<string> => {
+      if (!plcId || !user) throw new Error('Not signed in');
+      const ref = doc(
+        collection(db, PLCS_COLLECTION, plcId, NOTES_SUBCOLLECTION)
+      );
+      const now = Date.now();
+      const note: PlcNote = {
+        id: ref.id,
+        title: input.title,
+        body: input.body,
+        createdBy: user.uid,
+        createdAt: now,
+        lastEditedBy: user.uid,
+        lastEditedAt: now,
+      };
+      await setDoc(ref, note);
+      return ref.id;
+    },
+    [plcId, user]
+  );
+
+  const updateNote = useCallback(
+    async (
+      noteId: string,
+      patch: { title?: string; body?: string }
+    ): Promise<void> => {
+      if (!plcId || !user) throw new Error('Not signed in');
+      // Find the existing note in local state so we can re-write the full
+      // doc — the rule requires `keys().hasOnly(...)`, so a partial merge
+      // would fail if the local state ever drifts from the server.
+      const existing = notes.find((n) => n.id === noteId);
+      if (!existing) {
+        throw new Error('Note not found');
+      }
+      const updated: PlcNote = {
+        ...existing,
+        title: patch.title ?? existing.title,
+        body: patch.body ?? existing.body,
+        lastEditedBy: user.uid,
+        lastEditedAt: Date.now(),
+      };
+      await setDoc(
+        doc(db, PLCS_COLLECTION, plcId, NOTES_SUBCOLLECTION, noteId),
+        updated
+      );
+    },
+    [plcId, user, notes]
+  );
+
+  const deleteNote = useCallback(
+    async (noteId: string): Promise<void> => {
+      if (!plcId || !user) throw new Error('Not signed in');
+      await deleteDoc(
+        doc(db, PLCS_COLLECTION, plcId, NOTES_SUBCOLLECTION, noteId)
+      );
+    },
+    [plcId, user]
+  );
+
+  return useMemo(
+    () => ({ notes, loading, createNote, updateNote, deleteNote }),
+    [notes, loading, createNote, updateNote, deleteNote]
+  );
+};

--- a/hooks/usePlcOverviewLayout.ts
+++ b/hooks/usePlcOverviewLayout.ts
@@ -1,0 +1,254 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { doc, onSnapshot, setDoc } from 'firebase/firestore';
+import { db, isAuthBypass } from '@/config/firebase';
+import { useAuth } from '@/context/useAuth';
+import {
+  DEFAULT_PLC_OVERVIEW_LAYOUT,
+  PLC_BENTO_TILE_KINDS,
+  PLC_BENTO_TILE_SIZES,
+  PlcBentoTile,
+  PlcBentoTileKind,
+  PlcBentoTileSize,
+  PlcOverviewLayout,
+} from '@/types';
+import { logError } from '@/utils/logError';
+
+const USERS_COLLECTION = 'users';
+const LAYOUTS_SUBCOLLECTION = 'plc_layouts';
+
+const DEBOUNCE_MS = 500;
+
+interface UsePlcOverviewLayoutResult {
+  /** The merged layout — defaults overlaid with any persisted user customization. */
+  layout: PlcOverviewLayout;
+  loading: boolean;
+  /** Replace the full layout. Debounced (~500ms) — successive calls coalesce. */
+  updateLayout: (next: PlcOverviewLayout) => void;
+  /** Reset to defaults. Writes immediately, no debounce. */
+  resetLayout: () => Promise<void>;
+}
+
+function parseTile(raw: unknown): PlcBentoTile | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const obj = raw as Record<string, unknown>;
+  const kind = obj.kind;
+  const size = obj.size;
+  if (typeof kind !== 'string' || typeof size !== 'string') return null;
+  if (!PLC_BENTO_TILE_KINDS.includes(kind as PlcBentoTileKind)) return null;
+  if (!PLC_BENTO_TILE_SIZES.includes(size as PlcBentoTileSize)) return null;
+  const tile: PlcBentoTile = {
+    kind: kind as PlcBentoTileKind,
+    size: size as PlcBentoTileSize,
+  };
+  if (typeof obj.hidden === 'boolean') tile.hidden = obj.hidden;
+  return tile;
+}
+
+/**
+ * Merge a (possibly partial) persisted layout against the default tile set
+ * so newly added tile kinds appear automatically without forcing a layout
+ * reset. Persisted entries are kept in their stored order; any unseen
+ * default tiles are appended at the end.
+ */
+function mergeLayout(persisted: PlcBentoTile[]): PlcBentoTile[] {
+  const seen = new Set<PlcBentoTileKind>();
+  const merged: PlcBentoTile[] = [];
+  for (const tile of persisted) {
+    if (seen.has(tile.kind)) continue;
+    seen.add(tile.kind);
+    merged.push(tile);
+  }
+  for (const fallback of DEFAULT_PLC_OVERVIEW_LAYOUT.tiles) {
+    if (seen.has(fallback.kind)) continue;
+    merged.push({ ...fallback });
+    seen.add(fallback.kind);
+  }
+  return merged;
+}
+
+function parseLayout(data: Record<string, unknown>): PlcOverviewLayout {
+  const tilesRaw = Array.isArray(data.tiles) ? data.tiles : [];
+  const tiles: PlcBentoTile[] = [];
+  for (const entry of tilesRaw) {
+    const parsed = parseTile(entry);
+    if (parsed) tiles.push(parsed);
+  }
+  const updatedAt = typeof data.updatedAt === 'number' ? data.updatedAt : 0;
+  return {
+    tiles: mergeLayout(tiles),
+    updatedAt,
+  };
+}
+
+/**
+ * Per-user PLC dashboard bento-grid layout. Reads `users/{uid}/plc_layouts/{plcId}`
+ * via `onSnapshot`; falls back to `DEFAULT_PLC_OVERVIEW_LAYOUT` when no doc
+ * exists. Writes are debounced (~500ms) — sequential drag/resize
+ * interactions coalesce into one Firestore write. `resetLayout` writes
+ * immediately because it's an explicit user action.
+ *
+ * Pass `null` for `plcId` to skip the listener (e.g. while the dashboard
+ * is closed). Mirrors the `enabled`/`null` gating pattern in
+ * `usePlcs.ts` / `usePlcAssignmentIndex.ts`.
+ */
+export const usePlcOverviewLayout = (
+  plcId: string | null
+): UsePlcOverviewLayoutResult => {
+  const { user } = useAuth();
+  const [layout, setLayout] = useState<PlcOverviewLayout>(
+    DEFAULT_PLC_OVERVIEW_LAYOUT
+  );
+  const [loading, setLoading] = useState(true);
+
+  // Track local writes so an in-flight snapshot doesn't clobber a tile
+  // the user just rearranged. We compare timestamps before accepting a
+  // remote snapshot — only newer (or equal+different content) wins.
+  const lastLocalWriteRef = useRef<number>(0);
+
+  // Debounce timer for `updateLayout`. Ref-held so a re-render doesn't
+  // restart the clock unintentionally; cleared on unmount or PLC change.
+  const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const pendingWriteRef = useRef<PlcOverviewLayout | null>(null);
+
+  // Reset on plcId change so we don't render the previous PLC's layout
+  // while the new snapshot is in flight. Same "adjust state during render"
+  // pattern as usePlcAssignmentIndex. Ref-side cleanup happens in the
+  // listener-effect's cleanup below (the lint rule forbids mutating refs
+  // during render).
+  const [prevPlcId, setPrevPlcId] = useState(plcId);
+  if (plcId !== prevPlcId) {
+    setPrevPlcId(plcId);
+    setLayout(DEFAULT_PLC_OVERVIEW_LAYOUT);
+    setLoading(true);
+  }
+
+  useEffect(() => {
+    if (!plcId || !user || isAuthBypass) {
+      const t = setTimeout(() => {
+        setLayout(DEFAULT_PLC_OVERVIEW_LAYOUT);
+        setLoading(false);
+      }, 0);
+      return () => clearTimeout(t);
+    }
+    const ref = doc(
+      db,
+      USERS_COLLECTION,
+      user.uid,
+      LAYOUTS_SUBCOLLECTION,
+      plcId
+    );
+    const unsub = onSnapshot(
+      ref,
+      (snap) => {
+        if (!snap.exists()) {
+          setLayout(DEFAULT_PLC_OVERVIEW_LAYOUT);
+          setLoading(false);
+          return;
+        }
+        const parsed = parseLayout(snap.data() as Record<string, unknown>);
+        // Don't clobber a fresher local write that hasn't flushed yet.
+        if (parsed.updatedAt < lastLocalWriteRef.current) {
+          setLoading(false);
+          return;
+        }
+        setLayout(parsed);
+        setLoading(false);
+      },
+      (err) => {
+        logError('usePlcOverviewLayout.snapshot', err, { plcId });
+        setLoading(false);
+      }
+    );
+    // Cleanup on unmount OR plcId/user change: tear down the listener AND
+    // flush any pending debounced write so a fast tab-close (or PLC swap)
+    // doesn't drop the user's last rearrangement. Also resets local-write
+    // tracking so the next PLC's snapshot isn't shadowed by the old
+    // PLC's `lastLocalWriteRef`.
+    return () => {
+      unsub();
+      if (debounceTimerRef.current) {
+        clearTimeout(debounceTimerRef.current);
+        debounceTimerRef.current = null;
+      }
+      const pending = pendingWriteRef.current;
+      if (pending && !isAuthBypass) {
+        // Fire-and-forget — cleanup can't await. The `void` is intentional.
+        void setDoc(ref, pending).catch((err: unknown) => {
+          logError('usePlcOverviewLayout.flush', err, { plcId });
+        });
+      }
+      pendingWriteRef.current = null;
+      lastLocalWriteRef.current = 0;
+    };
+  }, [plcId, user]);
+
+  const updateLayout = useCallback(
+    (next: PlcOverviewLayout) => {
+      const stamped: PlcOverviewLayout = {
+        tiles: next.tiles,
+        updatedAt: Date.now(),
+      };
+      lastLocalWriteRef.current = stamped.updatedAt;
+      setLayout(stamped);
+      pendingWriteRef.current = stamped;
+
+      if (!plcId || !user || isAuthBypass) return;
+      if (debounceTimerRef.current) {
+        clearTimeout(debounceTimerRef.current);
+      }
+      debounceTimerRef.current = setTimeout(() => {
+        const pending = pendingWriteRef.current;
+        debounceTimerRef.current = null;
+        if (!pending) return;
+        pendingWriteRef.current = null;
+        const ref = doc(
+          db,
+          USERS_COLLECTION,
+          user.uid,
+          LAYOUTS_SUBCOLLECTION,
+          plcId
+        );
+        void setDoc(ref, pending).catch((err: unknown) => {
+          logError('usePlcOverviewLayout.write', err, { plcId });
+        });
+      }, DEBOUNCE_MS);
+    },
+    [plcId, user]
+  );
+
+  const resetLayout = useCallback(async () => {
+    if (!plcId || !user || isAuthBypass) {
+      setLayout(DEFAULT_PLC_OVERVIEW_LAYOUT);
+      return;
+    }
+    if (debounceTimerRef.current) {
+      clearTimeout(debounceTimerRef.current);
+      debounceTimerRef.current = null;
+    }
+    pendingWriteRef.current = null;
+    const stamped: PlcOverviewLayout = {
+      tiles: DEFAULT_PLC_OVERVIEW_LAYOUT.tiles.map((t) => ({ ...t })),
+      updatedAt: Date.now(),
+    };
+    lastLocalWriteRef.current = stamped.updatedAt;
+    setLayout(stamped);
+    const ref = doc(
+      db,
+      USERS_COLLECTION,
+      user.uid,
+      LAYOUTS_SUBCOLLECTION,
+      plcId
+    );
+    try {
+      await setDoc(ref, stamped);
+    } catch (err) {
+      logError('usePlcOverviewLayout.reset', err, { plcId });
+      throw err;
+    }
+  }, [plcId, user]);
+
+  return useMemo(
+    () => ({ layout, loading, updateLayout, resetLayout }),
+    [layout, loading, updateLayout, resetLayout]
+  );
+};

--- a/hooks/usePlcTodos.ts
+++ b/hooks/usePlcTodos.ts
@@ -7,6 +7,7 @@ import {
   orderBy,
   query,
   setDoc,
+  updateDoc,
 } from 'firebase/firestore';
 import { db, isAuthBypass } from '@/config/firebase';
 import { useAuth } from '@/context/useAuth';
@@ -117,17 +118,20 @@ export const usePlcTodos = (plcId: string | null): UsePlcTodosResult => {
     [plcId, user]
   );
 
+  // Patch-only updates so a teammate's concurrent edit on a different
+  // field isn't reverted by a stale local copy of the todo. The rule's
+  // `keys.hasOnly([...])` check applies to the post-merge doc, so a
+  // partial `updateDoc` patch passes — id/createdBy/createdAt remain
+  // immutable because they're untouched.
   const toggleDone = useCallback(
     async (todoId: string, done: boolean): Promise<void> => {
       if (!plcId || !user) throw new Error('Not signed in');
-      const existing = todos.find((t) => t.id === todoId);
-      if (!existing) throw new Error('Todo not found');
-      await setDoc(
+      await updateDoc(
         doc(db, PLCS_COLLECTION, plcId, TODOS_SUBCOLLECTION, todoId),
-        { ...existing, done }
+        { done }
       );
     },
-    [plcId, user, todos]
+    [plcId, user]
   );
 
   const updateText = useCallback(
@@ -135,14 +139,12 @@ export const usePlcTodos = (plcId: string | null): UsePlcTodosResult => {
       if (!plcId || !user) throw new Error('Not signed in');
       const trimmed = text.trim();
       if (!trimmed) throw new Error('Todo text required');
-      const existing = todos.find((t) => t.id === todoId);
-      if (!existing) throw new Error('Todo not found');
-      await setDoc(
+      await updateDoc(
         doc(db, PLCS_COLLECTION, plcId, TODOS_SUBCOLLECTION, todoId),
-        { ...existing, text: trimmed }
+        { text: trimmed }
       );
     },
-    [plcId, user, todos]
+    [plcId, user]
   );
 
   const deleteTodo = useCallback(

--- a/hooks/usePlcTodos.ts
+++ b/hooks/usePlcTodos.ts
@@ -1,0 +1,162 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  collection,
+  deleteDoc,
+  doc,
+  onSnapshot,
+  orderBy,
+  query,
+  setDoc,
+} from 'firebase/firestore';
+import { db, isAuthBypass } from '@/config/firebase';
+import { useAuth } from '@/context/useAuth';
+import { PlcTodo } from '@/types';
+import { logError } from '@/utils/logError';
+
+const PLCS_COLLECTION = 'plcs';
+const TODOS_SUBCOLLECTION = 'todos';
+
+interface UsePlcTodosResult {
+  todos: PlcTodo[];
+  loading: boolean;
+  createTodo: (text: string) => Promise<string>;
+  toggleDone: (todoId: string, done: boolean) => Promise<void>;
+  updateText: (todoId: string, text: string) => Promise<void>;
+  deleteTodo: (todoId: string) => Promise<void>;
+}
+
+function parseTodo(id: string, data: Record<string, unknown>): PlcTodo | null {
+  if (
+    typeof data.text !== 'string' ||
+    typeof data.done !== 'boolean' ||
+    typeof data.createdBy !== 'string' ||
+    typeof data.createdAt !== 'number'
+  ) {
+    return null;
+  }
+  return {
+    id,
+    text: data.text,
+    done: data.done,
+    createdBy: data.createdBy,
+    createdAt: data.createdAt,
+  };
+}
+
+/**
+ * Live subscription to a PLC's shared to-do list. Server-orders by
+ * `createdAt` ascending; the UI sorts incomplete-first locally because
+ * Firestore can't compose multiple orderBy clauses without a composite
+ * index for boolean+number, and a single index pin doesn't justify the
+ * Firestore deploy cost for a feature this small.
+ */
+export const usePlcTodos = (plcId: string | null): UsePlcTodosResult => {
+  const { user } = useAuth();
+  const [todos, setTodos] = useState<PlcTodo[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const [prevPlcId, setPrevPlcId] = useState(plcId);
+  if (plcId !== prevPlcId) {
+    setPrevPlcId(plcId);
+    setTodos([]);
+    setLoading(true);
+  }
+
+  useEffect(() => {
+    if (!plcId || !user || isAuthBypass) {
+      const t = setTimeout(() => {
+        setTodos([]);
+        setLoading(false);
+      }, 0);
+      return () => clearTimeout(t);
+    }
+    const ref = collection(db, PLCS_COLLECTION, plcId, TODOS_SUBCOLLECTION);
+    const unsub = onSnapshot(
+      query(ref, orderBy('createdAt', 'asc')),
+      (snap) => {
+        const list: PlcTodo[] = [];
+        snap.forEach((d) => {
+          const parsed = parseTodo(d.id, d.data() as Record<string, unknown>);
+          if (parsed) list.push(parsed);
+        });
+        // Incomplete first, then completed — within each group preserve
+        // server order (insertion order).
+        list.sort((a, b) => {
+          if (a.done === b.done) return 0;
+          return a.done ? 1 : -1;
+        });
+        setTodos(list);
+        setLoading(false);
+      },
+      (err) => {
+        logError('usePlcTodos.snapshot', err, { plcId });
+        setLoading(false);
+      }
+    );
+    return () => unsub();
+  }, [plcId, user]);
+
+  const createTodo = useCallback(
+    async (text: string): Promise<string> => {
+      if (!plcId || !user) throw new Error('Not signed in');
+      const trimmed = text.trim();
+      if (!trimmed) throw new Error('Todo text required');
+      const ref = doc(
+        collection(db, PLCS_COLLECTION, plcId, TODOS_SUBCOLLECTION)
+      );
+      const todo: PlcTodo = {
+        id: ref.id,
+        text: trimmed,
+        done: false,
+        createdBy: user.uid,
+        createdAt: Date.now(),
+      };
+      await setDoc(ref, todo);
+      return ref.id;
+    },
+    [plcId, user]
+  );
+
+  const toggleDone = useCallback(
+    async (todoId: string, done: boolean): Promise<void> => {
+      if (!plcId || !user) throw new Error('Not signed in');
+      const existing = todos.find((t) => t.id === todoId);
+      if (!existing) throw new Error('Todo not found');
+      await setDoc(
+        doc(db, PLCS_COLLECTION, plcId, TODOS_SUBCOLLECTION, todoId),
+        { ...existing, done }
+      );
+    },
+    [plcId, user, todos]
+  );
+
+  const updateText = useCallback(
+    async (todoId: string, text: string): Promise<void> => {
+      if (!plcId || !user) throw new Error('Not signed in');
+      const trimmed = text.trim();
+      if (!trimmed) throw new Error('Todo text required');
+      const existing = todos.find((t) => t.id === todoId);
+      if (!existing) throw new Error('Todo not found');
+      await setDoc(
+        doc(db, PLCS_COLLECTION, plcId, TODOS_SUBCOLLECTION, todoId),
+        { ...existing, text: trimmed }
+      );
+    },
+    [plcId, user, todos]
+  );
+
+  const deleteTodo = useCallback(
+    async (todoId: string): Promise<void> => {
+      if (!plcId || !user) throw new Error('Not signed in');
+      await deleteDoc(
+        doc(db, PLCS_COLLECTION, plcId, TODOS_SUBCOLLECTION, todoId)
+      );
+    },
+    [plcId, user]
+  );
+
+  return useMemo(
+    () => ({ todos, loading, createTodo, toggleDone, updateText, deleteTodo }),
+    [todos, loading, createTodo, toggleDone, updateText, deleteTodo]
+  );
+};

--- a/locales/en.json
+++ b/locales/en.json
@@ -178,6 +178,8 @@
       "viewPlcTitle": "PLC Details",
       "deletePlc": "Delete PLC",
       "leavePlc": "Leave PLC",
+      "actionsMenu": "PLC actions",
+      "openDashboard": "Open {{name}} dashboard",
       "yourPlcs": "Your PLCs",
       "leadBadge": "Lead",
       "memberCount_one": "{{count}} Member",
@@ -257,6 +259,7 @@
     "backToMenu": "Back",
     "close": "Close",
     "tabs": {
+      "overview": "Overview",
       "completed": "Completed Assignments",
       "quizzes": "Quiz Library",
       "assignments": "PLC Assignments",
@@ -312,6 +315,118 @@
         "title": "Shared Boards",
         "description": "Surface dashboards shared with this PLC."
       }
+    },
+    "overview": {
+      "heading": "Overview",
+      "editLayout": "Edit layout",
+      "doneEditing": "Done",
+      "reset": "Reset",
+      "editHint": "Drag tiles by the grip, click the corner to resize, click the eye to hide.",
+      "confirmReset": "Reset your bento layout to the default arrangement? Tile sizes and order will be restored.",
+      "confirmResetTitle": "Reset layout",
+      "dragHandle": "Drag to reorder",
+      "hideTile": "Hide tile",
+      "unhideTile": "Restore {{kind}} tile",
+      "resizeTile": "Resize tile (current: {{size}})",
+      "hiddenTiles": "Hidden tiles",
+      "hiddenTilesHint": "click to restore",
+      "tiles": {
+        "comingSoon": "Phase {{phase}} · soon",
+        "plcInfo": {
+          "label": "Professional Learning Community",
+          "members": "Members",
+          "lead": "Lead",
+          "you": "You",
+          "created": "Created",
+          "openSettings": "Open settings"
+        },
+        "members": {
+          "heading": "Members"
+        },
+        "completedAssignments": {
+          "heading": "Recent results",
+          "empty": "No assignments run yet",
+          "emptySubtitle": "Quizzes you run with PLC mode appear here.",
+          "viewAll": "View all"
+        },
+        "notes": {
+          "heading": "Notes",
+          "empty": "No notes yet",
+          "emptySubtitle": "Capture meeting notes, decisions, ideas.",
+          "untitled": "Untitled",
+          "openAll": "Open notes",
+          "justNow": "just now",
+          "minutesAgo_one": "{{count}}m ago",
+          "minutesAgo_other": "{{count}}m ago",
+          "hoursAgo_one": "{{count}}h ago",
+          "hoursAgo_other": "{{count}}h ago",
+          "daysAgo_one": "{{count}}d ago",
+          "daysAgo_other": "{{count}}d ago"
+        },
+        "todos": {
+          "heading": "To-do list",
+          "empty": "Nothing to do",
+          "emptySubtitle": "Add action items in the To-Do tab.",
+          "openAll": "Open list",
+          "toggle": "Mark \"{{text}}\" complete",
+          "moreCount_one": "+{{count}} more",
+          "moreCount_other": "+{{count}} more"
+        },
+        "sharedSheet": {
+          "heading": "Shared sheet",
+          "connectedHint": "Aggregated PLC results land in this Google Sheet. All members can open it.",
+          "unsetHint": "No shared sheet yet — it will be created automatically when the first PLC quiz is run.",
+          "open": "Open sheet",
+          "notReady": "Not yet created"
+        },
+        "quickActions": {
+          "heading": "Quick actions",
+          "addNote": "Add note",
+          "addTodo": "Add to-do"
+        },
+        "quizLibrary": {
+          "title": "Quiz library",
+          "teaser": "Share quizzes with your PLC."
+        },
+        "activeAssignments": {
+          "title": "Active assignments",
+          "teaser": "PLC-authored assignments awaiting pickup."
+        },
+        "videoActivities": {
+          "title": "Video activities",
+          "teaser": "Share video activities with the PLC."
+        },
+        "sharedBoards": {
+          "title": "Shared boards",
+          "teaser": "Boards shared with this PLC."
+        }
+      }
+    },
+    "notes": {
+      "heading": "Notes",
+      "newNote": "New",
+      "untitled": "Untitled",
+      "empty": "Empty note",
+      "emptyTitle": "No notes yet",
+      "emptySubtitle": "Create the first one to get started.",
+      "titlePlaceholder": "Note title",
+      "bodyPlaceholder": "Write your notes…",
+      "deleteNote": "Delete note",
+      "confirmDelete": "Delete this note? This cannot be undone.",
+      "confirmDeleteTitle": "Delete note",
+      "lastEdited": "Last edited {{when}}",
+      "pickOrCreate": "Select a note to edit, or create a new one."
+    },
+    "todos": {
+      "addPlaceholder": "Add a to-do for the PLC…",
+      "add": "Add",
+      "openHeading": "To do",
+      "doneHeading": "Done",
+      "allDone": "Nothing on the list",
+      "toggle": "Mark \"{{text}}\" complete",
+      "deleteTodo": "Delete to-do",
+      "confirmDelete": "Delete this to-do?",
+      "confirmDeleteTitle": "Delete to-do"
     }
   },
   "widgetWindow": {

--- a/tests/hooks/usePlcNotes.test.ts
+++ b/tests/hooks/usePlcNotes.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+import {
+  collection,
+  deleteDoc,
+  doc,
+  onSnapshot,
+  orderBy,
+  setDoc,
+} from 'firebase/firestore';
+import { usePlcNotes } from '@/hooks/usePlcNotes';
+
+vi.mock('firebase/firestore', () => ({
+  collection: vi.fn(),
+  deleteDoc: vi.fn(),
+  doc: vi.fn(),
+  onSnapshot: vi.fn(),
+  orderBy: vi.fn((field: string, dir: 'asc' | 'desc') => ({
+    __orderBy: { field, dir },
+  })),
+  query: vi.fn((_ref, ...constraints) => ({ __query: constraints })),
+  setDoc: vi.fn(),
+}));
+
+vi.mock('@/config/firebase', () => ({
+  db: { __mock: 'db' },
+  isAuthBypass: false,
+}));
+
+const useAuthMock = vi.fn<() => { user: { uid: string } | null }>();
+vi.mock('@/context/useAuth', () => ({
+  useAuth: () => useAuthMock(),
+}));
+
+vi.mock('@/utils/logError', () => ({ logError: vi.fn() }));
+
+const mockCollection = collection as Mock;
+const mockDoc = doc as Mock;
+const mockOnSnapshot = onSnapshot as Mock;
+const mockSetDoc = setDoc as Mock;
+const mockDeleteDoc = deleteDoc as Mock;
+const mockOrderBy = orderBy as Mock;
+
+const USER_UID = 'user-1';
+const PLC_ID = 'plc-1';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // doc() with no `path` (i.e. doc(collection)) returns an object with an
+  // `.id` so the create-note helper has something to seed `id` from.
+  mockDoc.mockImplementation((collectionRef: unknown, ...segs: string[]) => {
+    if (segs.length === 0) {
+      return { id: 'generated-id', __collection: collectionRef };
+    }
+    return segs.join('/');
+  });
+  mockCollection.mockImplementation((_db: unknown, ...segs: string[]) =>
+    segs.join('/')
+  );
+  mockSetDoc.mockResolvedValue(undefined);
+  mockDeleteDoc.mockResolvedValue(undefined);
+  useAuthMock.mockReturnValue({ user: { uid: USER_UID } });
+});
+
+describe('usePlcNotes — listener wiring', () => {
+  it('orders by lastEditedAt desc', () => {
+    mockOnSnapshot.mockReturnValue(() => undefined);
+    renderHook(() => usePlcNotes(PLC_ID));
+    expect(mockOrderBy).toHaveBeenCalledWith('lastEditedAt', 'desc');
+  });
+
+  it('skips the listener when plcId is null', () => {
+    renderHook(() => usePlcNotes(null));
+    expect(mockOnSnapshot).not.toHaveBeenCalled();
+  });
+});
+
+describe('usePlcNotes — defensive parse', () => {
+  it('drops notes missing required string/number fields', () => {
+    let cb: (snap: unknown) => void = () => undefined;
+    mockOnSnapshot.mockImplementation((_q, onNext) => {
+      cb = onNext;
+      return () => undefined;
+    });
+    const { result } = renderHook(() => usePlcNotes(PLC_ID));
+
+    const fakeSnap = (
+      docs: Array<{ id: string; data: Record<string, unknown> }>
+    ) => ({
+      forEach: (fn: (d: { id: string; data: () => unknown }) => void) => {
+        for (const d of docs) fn({ id: d.id, data: () => d.data });
+      },
+    });
+
+    act(() => {
+      cb(
+        fakeSnap([
+          {
+            id: 'a',
+            data: {
+              title: 'Valid',
+              body: 'body',
+              createdBy: 'u1',
+              createdAt: 1,
+              lastEditedBy: 'u1',
+              lastEditedAt: 2,
+            },
+          },
+          {
+            // body missing — drop
+            id: 'b',
+            data: {
+              title: 'No body',
+              createdBy: 'u1',
+              createdAt: 1,
+              lastEditedBy: 'u1',
+              lastEditedAt: 2,
+            },
+          },
+          {
+            // lastEditedAt not a number — drop
+            id: 'c',
+            data: {
+              title: 'Bad',
+              body: 'b',
+              createdBy: 'u1',
+              createdAt: 1,
+              lastEditedBy: 'u1',
+              lastEditedAt: 'recent',
+            },
+          },
+        ])
+      );
+    });
+
+    expect(result.current.notes).toHaveLength(1);
+    expect(result.current.notes[0]?.id).toBe('a');
+  });
+});
+
+describe('usePlcNotes — createNote', () => {
+  it('writes a fully-formed note with createdBy + lastEditedBy stamped to the current user', async () => {
+    mockOnSnapshot.mockReturnValue(() => undefined);
+    const { result } = renderHook(() => usePlcNotes(PLC_ID));
+
+    await act(async () => {
+      const id = await result.current.createNote({
+        title: 'T',
+        body: 'B',
+      });
+      expect(id).toBe('generated-id');
+    });
+
+    expect(mockSetDoc).toHaveBeenCalledTimes(1);
+    const written = mockSetDoc.mock.calls[0]?.[1] as Record<string, unknown>;
+    expect(written.title).toBe('T');
+    expect(written.body).toBe('B');
+    expect(written.createdBy).toBe(USER_UID);
+    expect(written.lastEditedBy).toBe(USER_UID);
+    expect(typeof written.createdAt).toBe('number');
+    expect(typeof written.lastEditedAt).toBe('number');
+  });
+});

--- a/tests/hooks/usePlcNotes.test.ts
+++ b/tests/hooks/usePlcNotes.test.ts
@@ -7,6 +7,7 @@ import {
   onSnapshot,
   orderBy,
   setDoc,
+  updateDoc,
 } from 'firebase/firestore';
 import { usePlcNotes } from '@/hooks/usePlcNotes';
 
@@ -20,6 +21,7 @@ vi.mock('firebase/firestore', () => ({
   })),
   query: vi.fn((_ref, ...constraints) => ({ __query: constraints })),
   setDoc: vi.fn(),
+  updateDoc: vi.fn(),
 }));
 
 vi.mock('@/config/firebase', () => ({
@@ -38,6 +40,7 @@ const mockCollection = collection as Mock;
 const mockDoc = doc as Mock;
 const mockOnSnapshot = onSnapshot as Mock;
 const mockSetDoc = setDoc as Mock;
+const mockUpdateDoc = updateDoc as Mock;
 const mockDeleteDoc = deleteDoc as Mock;
 const mockOrderBy = orderBy as Mock;
 
@@ -58,6 +61,7 @@ beforeEach(() => {
     segs.join('/')
   );
   mockSetDoc.mockResolvedValue(undefined);
+  mockUpdateDoc.mockResolvedValue(undefined);
   mockDeleteDoc.mockResolvedValue(undefined);
   useAuthMock.mockReturnValue({ user: { uid: USER_UID } });
 });
@@ -159,5 +163,50 @@ describe('usePlcNotes — createNote', () => {
     expect(written.lastEditedBy).toBe(USER_UID);
     expect(typeof written.createdAt).toBe('number');
     expect(typeof written.lastEditedAt).toBe('number');
+  });
+});
+
+// updateDoc patches — verify only the changed field travels in the wire
+// payload (plus the always-stamped lastEditedBy / lastEditedAt). The
+// previous setDoc-based implementation rewrote the full doc from local
+// state, which could revert a teammate's concurrent edit on the *other*
+// field.
+describe('usePlcNotes — patch-only updateNote', () => {
+  it('sends only the patched field plus lastEditedBy/At via updateDoc', async () => {
+    mockOnSnapshot.mockReturnValue(() => undefined);
+    const { result } = renderHook(() => usePlcNotes(PLC_ID));
+
+    await act(async () => {
+      await result.current.updateNote('note-1', { body: 'new body' });
+    });
+
+    expect(mockSetDoc).not.toHaveBeenCalled();
+    expect(mockUpdateDoc).toHaveBeenCalledTimes(1);
+    const [path, patch] = mockUpdateDoc.mock.calls[0] ?? [];
+    expect(path).toBe(`plcs/${PLC_ID}/notes/note-1`);
+    const fields = patch as Record<string, unknown>;
+    // Only `body` is patched, plus the rule-required `lastEditedBy` and
+    // `lastEditedAt`. `title` must NOT appear — that's the whole point
+    // of the patch-only contract (a teammate's concurrent title edit
+    // would otherwise be reverted by stale local state).
+    expect(fields.body).toBe('new body');
+    expect(fields.title).toBeUndefined();
+    expect(fields.lastEditedBy).toBe(USER_UID);
+    expect(typeof fields.lastEditedAt).toBe('number');
+  });
+
+  it('omits both title and body when patch contains neither (still stamps lastEditedBy)', async () => {
+    mockOnSnapshot.mockReturnValue(() => undefined);
+    const { result } = renderHook(() => usePlcNotes(PLC_ID));
+
+    await act(async () => {
+      await result.current.updateNote('note-1', {});
+    });
+
+    expect(mockUpdateDoc).toHaveBeenCalledTimes(1);
+    const fields = mockUpdateDoc.mock.calls[0]?.[1] as Record<string, unknown>;
+    expect(fields.title).toBeUndefined();
+    expect(fields.body).toBeUndefined();
+    expect(fields.lastEditedBy).toBe(USER_UID);
   });
 });

--- a/tests/hooks/usePlcOverviewLayout.test.ts
+++ b/tests/hooks/usePlcOverviewLayout.test.ts
@@ -1,0 +1,191 @@
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeEach,
+  afterEach,
+  type Mock,
+} from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+import { doc, onSnapshot, setDoc } from 'firebase/firestore';
+import { usePlcOverviewLayout } from '@/hooks/usePlcOverviewLayout';
+import { DEFAULT_PLC_OVERVIEW_LAYOUT } from '@/types';
+
+vi.mock('firebase/firestore', () => ({
+  doc: vi.fn(),
+  onSnapshot: vi.fn(),
+  setDoc: vi.fn(),
+}));
+
+vi.mock('@/config/firebase', () => ({
+  db: { __mock: 'db' },
+  isAuthBypass: false,
+}));
+
+const useAuthMock = vi.fn<() => { user: { uid: string } | null }>();
+vi.mock('@/context/useAuth', () => ({
+  useAuth: () => useAuthMock(),
+}));
+
+vi.mock('@/utils/logError', () => ({ logError: vi.fn() }));
+
+const mockDoc = doc as Mock;
+const mockOnSnapshot = onSnapshot as Mock;
+const mockSetDoc = setDoc as Mock;
+
+const USER_UID = 'user-1';
+const PLC_ID = 'plc-1';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockDoc.mockImplementation((_db: unknown, ...segs: string[]) =>
+    segs.join('/')
+  );
+  mockSetDoc.mockResolvedValue(undefined);
+  useAuthMock.mockReturnValue({ user: { uid: USER_UID } });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('usePlcOverviewLayout — listener wiring', () => {
+  it('listens at users/{uid}/plc_layouts/{plcId}', () => {
+    mockOnSnapshot.mockReturnValue(() => undefined);
+    renderHook(() => usePlcOverviewLayout(PLC_ID));
+    expect(mockOnSnapshot).toHaveBeenCalledTimes(1);
+    expect(mockOnSnapshot.mock.calls[0]?.[0]).toBe(
+      `users/${USER_UID}/plc_layouts/${PLC_ID}`
+    );
+  });
+
+  it('skips the listener when plcId is null', () => {
+    renderHook(() => usePlcOverviewLayout(null));
+    expect(mockOnSnapshot).not.toHaveBeenCalled();
+  });
+
+  it('skips the listener when the user is signed out', () => {
+    useAuthMock.mockReturnValue({ user: null });
+    renderHook(() => usePlcOverviewLayout(PLC_ID));
+    expect(mockOnSnapshot).not.toHaveBeenCalled();
+  });
+});
+
+describe('usePlcOverviewLayout — default layout when no doc exists', () => {
+  it('returns the default layout when the snapshot reports the doc does not exist', () => {
+    let snapCb: (snap: unknown) => void = () => undefined;
+    mockOnSnapshot.mockImplementation((_ref, onNext) => {
+      snapCb = onNext;
+      return () => undefined;
+    });
+
+    const { result } = renderHook(() => usePlcOverviewLayout(PLC_ID));
+
+    act(() => {
+      snapCb({ exists: () => false, data: () => undefined });
+    });
+
+    expect(result.current.layout.tiles).toEqual(
+      DEFAULT_PLC_OVERVIEW_LAYOUT.tiles
+    );
+    expect(result.current.loading).toBe(false);
+  });
+});
+
+describe('usePlcOverviewLayout — parse + merge', () => {
+  it('drops malformed tile entries and appends missing default tiles', () => {
+    let snapCb: (snap: unknown) => void = () => undefined;
+    mockOnSnapshot.mockImplementation((_ref, onNext) => {
+      snapCb = onNext;
+      return () => undefined;
+    });
+
+    const { result } = renderHook(() => usePlcOverviewLayout(PLC_ID));
+
+    act(() => {
+      snapCb({
+        exists: () => true,
+        data: () => ({
+          tiles: [
+            // Valid persisted tile — kept.
+            { kind: 'todos', size: 'lg' },
+            // Malformed (bad size) — dropped.
+            { kind: 'notes', size: 'huge' },
+            // Malformed (unknown kind) — dropped.
+            { kind: 'mystery', size: 'sm' },
+          ],
+          updatedAt: 100,
+        }),
+      });
+    });
+
+    const kinds = result.current.layout.tiles.map((t) => t.kind);
+    // The persisted `todos` tile is preserved at the front; the rest of
+    // the default tiles are appended in default order.
+    expect(kinds[0]).toBe('todos');
+    // Every default tile kind should still be represented (merge appends
+    // anything missing). This is the "newly added tile auto-appears"
+    // contract — without it, adding a tile kind in code would require a
+    // forced layout reset for every existing user.
+    for (const fallback of DEFAULT_PLC_OVERVIEW_LAYOUT.tiles) {
+      expect(kinds).toContain(fallback.kind);
+    }
+  });
+});
+
+describe('usePlcOverviewLayout — debounced write', () => {
+  it('debounces consecutive updateLayout calls into a single setDoc', () => {
+    vi.useFakeTimers();
+    mockOnSnapshot.mockReturnValue(() => undefined);
+
+    const { result } = renderHook(() => usePlcOverviewLayout(PLC_ID));
+
+    act(() => {
+      result.current.updateLayout({
+        tiles: [{ kind: 'todos', size: 'sm' }],
+        updatedAt: 1,
+      });
+      result.current.updateLayout({
+        tiles: [{ kind: 'todos', size: 'md-wide' }],
+        updatedAt: 2,
+      });
+      result.current.updateLayout({
+        tiles: [{ kind: 'todos', size: 'lg' }],
+        updatedAt: 3,
+      });
+    });
+
+    // Only the last call should fire after the debounce window.
+    expect(mockSetDoc).not.toHaveBeenCalled();
+    act(() => {
+      vi.advanceTimersByTime(600);
+    });
+
+    expect(mockSetDoc).toHaveBeenCalledTimes(1);
+    const writtenLayout = mockSetDoc.mock.calls[0]?.[1] as {
+      tiles: Array<{ size: string }>;
+    };
+    expect(writtenLayout.tiles[0]?.size).toBe('lg');
+  });
+});
+
+describe('usePlcOverviewLayout — reset', () => {
+  it('resetLayout writes the default layout immediately (no debounce)', async () => {
+    mockOnSnapshot.mockReturnValue(() => undefined);
+
+    const { result } = renderHook(() => usePlcOverviewLayout(PLC_ID));
+
+    await act(async () => {
+      await result.current.resetLayout();
+    });
+
+    expect(mockSetDoc).toHaveBeenCalledTimes(1);
+    const written = mockSetDoc.mock.calls[0]?.[1] as {
+      tiles: Array<{ kind: string }>;
+    };
+    expect(written.tiles.map((t) => t.kind)).toEqual(
+      DEFAULT_PLC_OVERVIEW_LAYOUT.tiles.map((t) => t.kind)
+    );
+  });
+});

--- a/tests/hooks/usePlcTodos.test.ts
+++ b/tests/hooks/usePlcTodos.test.ts
@@ -7,6 +7,7 @@ import {
   onSnapshot,
   orderBy,
   setDoc,
+  updateDoc,
 } from 'firebase/firestore';
 import { usePlcTodos } from '@/hooks/usePlcTodos';
 
@@ -20,6 +21,7 @@ vi.mock('firebase/firestore', () => ({
   })),
   query: vi.fn((_ref, ...constraints) => ({ __query: constraints })),
   setDoc: vi.fn(),
+  updateDoc: vi.fn(),
 }));
 
 vi.mock('@/config/firebase', () => ({
@@ -38,6 +40,7 @@ const mockCollection = collection as Mock;
 const mockDoc = doc as Mock;
 const mockOnSnapshot = onSnapshot as Mock;
 const mockSetDoc = setDoc as Mock;
+const mockUpdateDoc = updateDoc as Mock;
 const mockDeleteDoc = deleteDoc as Mock;
 const mockOrderBy = orderBy as Mock;
 
@@ -56,6 +59,7 @@ beforeEach(() => {
     segs.join('/')
   );
   mockSetDoc.mockResolvedValue(undefined);
+  mockUpdateDoc.mockResolvedValue(undefined);
   mockDeleteDoc.mockResolvedValue(undefined);
   useAuthMock.mockReturnValue({ user: { uid: USER_UID } });
 });
@@ -136,5 +140,41 @@ describe('usePlcTodos — createTodo', () => {
     expect(written.text).toBe('meet on Tuesday');
     expect(written.done).toBe(false);
     expect(written.createdBy).toBe(USER_UID);
+  });
+});
+
+// updateDoc patches — verify only the changed field travels in the wire
+// payload. The previous setDoc-based implementation rewrote the full doc
+// from local state, which could revert a teammate's concurrent edit on
+// the *other* field. These tests pin the patch-only contract.
+describe('usePlcTodos — patch-only updates', () => {
+  it('toggleDone sends only { done } via updateDoc (no full-doc rewrite)', async () => {
+    mockOnSnapshot.mockReturnValue(() => undefined);
+    const { result } = renderHook(() => usePlcTodos(PLC_ID));
+
+    await act(async () => {
+      await result.current.toggleDone('todo-1', true);
+    });
+
+    expect(mockSetDoc).not.toHaveBeenCalled();
+    expect(mockUpdateDoc).toHaveBeenCalledTimes(1);
+    const [path, patch] = mockUpdateDoc.mock.calls[0] ?? [];
+    expect(path).toBe(`plcs/${PLC_ID}/todos/todo-1`);
+    expect(patch).toEqual({ done: true });
+  });
+
+  it('updateText sends only { text } trimmed via updateDoc', async () => {
+    mockOnSnapshot.mockReturnValue(() => undefined);
+    const { result } = renderHook(() => usePlcTodos(PLC_ID));
+
+    await act(async () => {
+      await result.current.updateText('todo-1', '  call parents  ');
+    });
+
+    expect(mockSetDoc).not.toHaveBeenCalled();
+    expect(mockUpdateDoc).toHaveBeenCalledTimes(1);
+    const [path, patch] = mockUpdateDoc.mock.calls[0] ?? [];
+    expect(path).toBe(`plcs/${PLC_ID}/todos/todo-1`);
+    expect(patch).toEqual({ text: 'call parents' });
   });
 });

--- a/tests/hooks/usePlcTodos.test.ts
+++ b/tests/hooks/usePlcTodos.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+import {
+  collection,
+  deleteDoc,
+  doc,
+  onSnapshot,
+  orderBy,
+  setDoc,
+} from 'firebase/firestore';
+import { usePlcTodos } from '@/hooks/usePlcTodos';
+
+vi.mock('firebase/firestore', () => ({
+  collection: vi.fn(),
+  deleteDoc: vi.fn(),
+  doc: vi.fn(),
+  onSnapshot: vi.fn(),
+  orderBy: vi.fn((field: string, dir: 'asc' | 'desc') => ({
+    __orderBy: { field, dir },
+  })),
+  query: vi.fn((_ref, ...constraints) => ({ __query: constraints })),
+  setDoc: vi.fn(),
+}));
+
+vi.mock('@/config/firebase', () => ({
+  db: { __mock: 'db' },
+  isAuthBypass: false,
+}));
+
+const useAuthMock = vi.fn<() => { user: { uid: string } | null }>();
+vi.mock('@/context/useAuth', () => ({
+  useAuth: () => useAuthMock(),
+}));
+
+vi.mock('@/utils/logError', () => ({ logError: vi.fn() }));
+
+const mockCollection = collection as Mock;
+const mockDoc = doc as Mock;
+const mockOnSnapshot = onSnapshot as Mock;
+const mockSetDoc = setDoc as Mock;
+const mockDeleteDoc = deleteDoc as Mock;
+const mockOrderBy = orderBy as Mock;
+
+const USER_UID = 'user-1';
+const PLC_ID = 'plc-1';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockDoc.mockImplementation((collectionRef: unknown, ...segs: string[]) => {
+    if (segs.length === 0) {
+      return { id: 'generated-id', __collection: collectionRef };
+    }
+    return segs.join('/');
+  });
+  mockCollection.mockImplementation((_db: unknown, ...segs: string[]) =>
+    segs.join('/')
+  );
+  mockSetDoc.mockResolvedValue(undefined);
+  mockDeleteDoc.mockResolvedValue(undefined);
+  useAuthMock.mockReturnValue({ user: { uid: USER_UID } });
+});
+
+describe('usePlcTodos — listener wiring', () => {
+  it('orders by createdAt asc (UI sorts incomplete-first locally)', () => {
+    mockOnSnapshot.mockReturnValue(() => undefined);
+    renderHook(() => usePlcTodos(PLC_ID));
+    expect(mockOrderBy).toHaveBeenCalledWith('createdAt', 'asc');
+  });
+});
+
+describe('usePlcTodos — sort: incomplete first then complete', () => {
+  it('local sort puts done todos at the bottom', () => {
+    let cb: (snap: unknown) => void = () => undefined;
+    mockOnSnapshot.mockImplementation((_q, onNext) => {
+      cb = onNext;
+      return () => undefined;
+    });
+    const { result } = renderHook(() => usePlcTodos(PLC_ID));
+
+    const fakeSnap = (
+      docs: Array<{ id: string; data: Record<string, unknown> }>
+    ) => ({
+      forEach: (fn: (d: { id: string; data: () => unknown }) => void) => {
+        for (const d of docs) fn({ id: d.id, data: () => d.data });
+      },
+    });
+
+    act(() => {
+      cb(
+        fakeSnap([
+          {
+            id: 'a',
+            data: { text: 'A', done: true, createdBy: 'u', createdAt: 1 },
+          },
+          {
+            id: 'b',
+            data: { text: 'B', done: false, createdBy: 'u', createdAt: 2 },
+          },
+          {
+            id: 'c',
+            data: { text: 'C', done: false, createdBy: 'u', createdAt: 3 },
+          },
+        ])
+      );
+    });
+
+    const ids = result.current.todos.map((t) => t.id);
+    // Incomplete (b, c) before complete (a). Within each group, server
+    // order (createdAt asc) is preserved.
+    expect(ids).toEqual(['b', 'c', 'a']);
+  });
+});
+
+describe('usePlcTodos — createTodo', () => {
+  it('rejects empty/whitespace-only text without writing', async () => {
+    mockOnSnapshot.mockReturnValue(() => undefined);
+    const { result } = renderHook(() => usePlcTodos(PLC_ID));
+
+    await act(async () => {
+      await expect(result.current.createTodo('   ')).rejects.toThrow();
+    });
+
+    expect(mockSetDoc).not.toHaveBeenCalled();
+  });
+
+  it('writes a trimmed-text todo stamped with createdBy', async () => {
+    mockOnSnapshot.mockReturnValue(() => undefined);
+    const { result } = renderHook(() => usePlcTodos(PLC_ID));
+
+    await act(async () => {
+      await result.current.createTodo('  meet on Tuesday  ');
+    });
+
+    expect(mockSetDoc).toHaveBeenCalledTimes(1);
+    const written = mockSetDoc.mock.calls[0]?.[1] as Record<string, unknown>;
+    expect(written.text).toBe('meet on Tuesday');
+    expect(written.done).toBe(false);
+    expect(written.createdBy).toBe(USER_UID);
+  });
+});

--- a/tests/rules/plcOverviewAndContent.test.ts
+++ b/tests/rules/plcOverviewAndContent.test.ts
@@ -1,0 +1,388 @@
+// Firestore rules regression coverage for the new PLC Overview /
+// Notes / To-Dos surfaces shipped alongside Phase 5 of the PLC Dashboard
+// roadmap. Pins the security invariants the dashboard depends on:
+//   - `users/{uid}/plc_layouts/{plcId}` is owner-only with a closed schema
+//     so a malicious extension can't smuggle extra fields.
+//   - `plcs/{plcId}/notes` and `plcs/{plcId}/todos` are membership-gated
+//     for both reads and writes — non-members must not be able to peek
+//     into a community's shared documents.
+//   - Notes' `createdBy` / `createdAt` / `id` are immutable on update so
+//     a later editor can't rewrite authorship.
+//   - On every note update the caller must stamp themselves into
+//     `lastEditedBy` so the audit trail stays honest.
+//
+// Requires a running Firestore emulator — invoke via `pnpm run test:rules`.
+
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { afterAll, beforeAll, beforeEach, describe, it } from 'vitest';
+import {
+  initializeTestEnvironment,
+  assertSucceeds,
+  assertFails,
+  type RulesTestEnvironment,
+} from '@firebase/rules-unit-testing';
+import { setDoc, getDoc, updateDoc, deleteDoc, doc } from 'firebase/firestore';
+
+const PROJECT_ID = 'spartboard-plc-overview-and-content';
+const PLC_ID = 'plc-rules-test';
+const NOTE_ID = 'note-rules-test';
+const TODO_ID = 'todo-rules-test';
+
+const MEMBER_A_UID = 'member-a-uid';
+const MEMBER_B_UID = 'member-b-uid';
+const NON_MEMBER_UID = 'non-member-uid';
+
+const RULES_PATH = fileURLToPath(
+  new URL('../../firestore.rules', import.meta.url)
+);
+
+let testEnv: RulesTestEnvironment;
+
+const asMemberA = () =>
+  testEnv
+    .authenticatedContext(MEMBER_A_UID, { email: 'member-a@example.com' })
+    .firestore();
+const asMemberB = () =>
+  testEnv
+    .authenticatedContext(MEMBER_B_UID, { email: 'member-b@example.com' })
+    .firestore();
+const asNonMember = () =>
+  testEnv
+    .authenticatedContext(NON_MEMBER_UID, { email: 'random@example.com' })
+    .firestore();
+
+beforeAll(async () => {
+  testEnv = await initializeTestEnvironment({
+    projectId: PROJECT_ID,
+    firestore: {
+      rules: readFileSync(RULES_PATH, 'utf8'),
+      host: process.env.FIRESTORE_EMULATOR_HOST?.split(':')[0] ?? '127.0.0.1',
+      port: Number(
+        process.env.FIRESTORE_EMULATOR_HOST?.split(':')[1] ?? '8080'
+      ),
+    },
+  });
+});
+
+afterAll(async () => {
+  await testEnv?.cleanup();
+});
+
+beforeEach(async () => {
+  await testEnv.clearFirestore();
+  await testEnv.withSecurityRulesDisabled(async (ctx) => {
+    await setDoc(doc(ctx.firestore(), `plcs/${PLC_ID}`), {
+      name: 'Test PLC',
+      leadUid: MEMBER_A_UID,
+      memberUids: [MEMBER_A_UID, MEMBER_B_UID],
+      memberEmails: {
+        [MEMBER_A_UID]: 'member-a@example.com',
+        [MEMBER_B_UID]: 'member-b@example.com',
+      },
+      createdAt: 1,
+      updatedAt: 1,
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// users/{uid}/plc_layouts/{plcId}
+// ---------------------------------------------------------------------------
+
+describe('users/{uid}/plc_layouts — owner-only', () => {
+  const validLayout = (overrides: Record<string, unknown> = {}) => ({
+    tiles: [{ kind: 'todos', size: 'lg' }],
+    updatedAt: 100,
+    ...overrides,
+  });
+
+  it('owner can write their own layout doc', async () => {
+    await assertSucceeds(
+      setDoc(
+        doc(asMemberA(), `users/${MEMBER_A_UID}/plc_layouts/${PLC_ID}`),
+        validLayout()
+      )
+    );
+  });
+
+  it('owner can read their own layout doc', async () => {
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      await setDoc(
+        doc(ctx.firestore(), `users/${MEMBER_A_UID}/plc_layouts/${PLC_ID}`),
+        validLayout()
+      );
+    });
+    await assertSucceeds(
+      getDoc(doc(asMemberA(), `users/${MEMBER_A_UID}/plc_layouts/${PLC_ID}`))
+    );
+  });
+
+  it("a different user cannot read or write someone else's layout", async () => {
+    // Even fellow PLC members can't see each other's layout — this is
+    // strictly view preferences, scoped by uid.
+    await assertFails(
+      setDoc(
+        doc(asMemberB(), `users/${MEMBER_A_UID}/plc_layouts/${PLC_ID}`),
+        validLayout()
+      )
+    );
+    await assertFails(
+      getDoc(doc(asMemberB(), `users/${MEMBER_A_UID}/plc_layouts/${PLC_ID}`))
+    );
+  });
+
+  it('rejects an extra field (schema lock-down via keys().hasOnly)', async () => {
+    await assertFails(
+      setDoc(doc(asMemberA(), `users/${MEMBER_A_UID}/plc_layouts/${PLC_ID}`), {
+        ...validLayout(),
+        unexpected: 'extra-field',
+      })
+    );
+  });
+
+  it('rejects when tiles is not a list', async () => {
+    await assertFails(
+      setDoc(doc(asMemberA(), `users/${MEMBER_A_UID}/plc_layouts/${PLC_ID}`), {
+        tiles: 'not-a-list',
+        updatedAt: 1,
+      })
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// plcs/{plcId}/notes
+// ---------------------------------------------------------------------------
+
+describe('plcs/{plcId}/notes — read', () => {
+  beforeEach(async () => {
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      await setDoc(doc(ctx.firestore(), `plcs/${PLC_ID}/notes/${NOTE_ID}`), {
+        id: NOTE_ID,
+        title: 'Hello',
+        body: 'World',
+        createdBy: MEMBER_A_UID,
+        createdAt: 1,
+        lastEditedBy: MEMBER_A_UID,
+        lastEditedAt: 1,
+      });
+    });
+  });
+
+  it('a PLC member can read notes', async () => {
+    await assertSucceeds(
+      getDoc(doc(asMemberB(), `plcs/${PLC_ID}/notes/${NOTE_ID}`))
+    );
+  });
+
+  it('a non-member cannot read notes (membership gate)', async () => {
+    await assertFails(
+      getDoc(doc(asNonMember(), `plcs/${PLC_ID}/notes/${NOTE_ID}`))
+    );
+  });
+});
+
+describe('plcs/{plcId}/notes — write', () => {
+  const validNote = (overrides: Record<string, unknown> = {}) => ({
+    id: NOTE_ID,
+    title: 'Title',
+    body: 'Body',
+    createdBy: MEMBER_A_UID,
+    createdAt: 1,
+    lastEditedBy: MEMBER_A_UID,
+    lastEditedAt: 1,
+    ...overrides,
+  });
+
+  it('any current member can create a note', async () => {
+    await assertSucceeds(
+      setDoc(doc(asMemberA(), `plcs/${PLC_ID}/notes/${NOTE_ID}`), validNote())
+    );
+  });
+
+  it('rejects creation by a non-member', async () => {
+    await assertFails(
+      setDoc(
+        doc(asNonMember(), `plcs/${PLC_ID}/notes/${NOTE_ID}`),
+        validNote({ createdBy: NON_MEMBER_UID, lastEditedBy: NON_MEMBER_UID })
+      )
+    );
+  });
+
+  it('rejects extra unknown fields (schema lock-down)', async () => {
+    await assertFails(
+      setDoc(doc(asMemberA(), `plcs/${PLC_ID}/notes/${NOTE_ID}`), {
+        ...validNote(),
+        unexpected: 'extra-field',
+      })
+    );
+  });
+
+  it('rejects when path id != payload id', async () => {
+    await assertFails(
+      setDoc(
+        doc(asMemberA(), `plcs/${PLC_ID}/notes/different-id`),
+        validNote({ id: NOTE_ID })
+      )
+    );
+  });
+
+  describe('update', () => {
+    beforeEach(async () => {
+      await testEnv.withSecurityRulesDisabled(async (ctx) => {
+        await setDoc(
+          doc(ctx.firestore(), `plcs/${PLC_ID}/notes/${NOTE_ID}`),
+          validNote()
+        );
+      });
+    });
+
+    it('a different member can edit (any-member-edits model)', async () => {
+      await assertSucceeds(
+        updateDoc(doc(asMemberB(), `plcs/${PLC_ID}/notes/${NOTE_ID}`), {
+          body: 'edited by B',
+          lastEditedBy: MEMBER_B_UID,
+          lastEditedAt: 2,
+        })
+      );
+    });
+
+    it('rejects when lastEditedBy != caller (no impersonation)', async () => {
+      await assertFails(
+        updateDoc(doc(asMemberB(), `plcs/${PLC_ID}/notes/${NOTE_ID}`), {
+          body: 'edited',
+          lastEditedBy: MEMBER_A_UID, // pretending to be A
+          lastEditedAt: 2,
+        })
+      );
+    });
+
+    it('rejects createdBy mutation (immutability)', async () => {
+      await assertFails(
+        updateDoc(doc(asMemberB(), `plcs/${PLC_ID}/notes/${NOTE_ID}`), {
+          createdBy: MEMBER_B_UID,
+          lastEditedBy: MEMBER_B_UID,
+          lastEditedAt: 2,
+        })
+      );
+    });
+
+    it('rejects createdAt mutation (immutability)', async () => {
+      await assertFails(
+        updateDoc(doc(asMemberB(), `plcs/${PLC_ID}/notes/${NOTE_ID}`), {
+          createdAt: 9999,
+          lastEditedBy: MEMBER_B_UID,
+          lastEditedAt: 2,
+        })
+      );
+    });
+
+    it('a non-member cannot edit', async () => {
+      await assertFails(
+        updateDoc(doc(asNonMember(), `plcs/${PLC_ID}/notes/${NOTE_ID}`), {
+          body: 'leaked',
+          lastEditedBy: NON_MEMBER_UID,
+          lastEditedAt: 2,
+        })
+      );
+    });
+  });
+
+  describe('delete', () => {
+    beforeEach(async () => {
+      await testEnv.withSecurityRulesDisabled(async (ctx) => {
+        await setDoc(
+          doc(ctx.firestore(), `plcs/${PLC_ID}/notes/${NOTE_ID}`),
+          validNote()
+        );
+      });
+    });
+
+    it('any member can delete (PLC-owned note model)', async () => {
+      await assertSucceeds(
+        deleteDoc(doc(asMemberB(), `plcs/${PLC_ID}/notes/${NOTE_ID}`))
+      );
+    });
+
+    it('a non-member cannot delete', async () => {
+      await assertFails(
+        deleteDoc(doc(asNonMember(), `plcs/${PLC_ID}/notes/${NOTE_ID}`))
+      );
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// plcs/{plcId}/todos
+// ---------------------------------------------------------------------------
+
+describe('plcs/{plcId}/todos — write', () => {
+  const validTodo = (overrides: Record<string, unknown> = {}) => ({
+    id: TODO_ID,
+    text: 'Do the thing',
+    done: false,
+    createdBy: MEMBER_A_UID,
+    createdAt: 1,
+    ...overrides,
+  });
+
+  it('any current member can create a todo', async () => {
+    await assertSucceeds(
+      setDoc(doc(asMemberA(), `plcs/${PLC_ID}/todos/${TODO_ID}`), validTodo())
+    );
+  });
+
+  it('rejects creation by a non-member', async () => {
+    await assertFails(
+      setDoc(
+        doc(asNonMember(), `plcs/${PLC_ID}/todos/${TODO_ID}`),
+        validTodo({ createdBy: NON_MEMBER_UID })
+      )
+    );
+  });
+
+  it('rejects extra unknown fields (schema lock-down)', async () => {
+    await assertFails(
+      setDoc(doc(asMemberA(), `plcs/${PLC_ID}/todos/${TODO_ID}`), {
+        ...validTodo(),
+        assignedTo: 'someone',
+      })
+    );
+  });
+
+  describe('update', () => {
+    beforeEach(async () => {
+      await testEnv.withSecurityRulesDisabled(async (ctx) => {
+        await setDoc(
+          doc(ctx.firestore(), `plcs/${PLC_ID}/todos/${TODO_ID}`),
+          validTodo()
+        );
+      });
+    });
+
+    it("a different member can mark a teammate's todo done", async () => {
+      await assertSucceeds(
+        updateDoc(doc(asMemberB(), `plcs/${PLC_ID}/todos/${TODO_ID}`), {
+          done: true,
+        })
+      );
+    });
+
+    it('rejects createdBy mutation', async () => {
+      await assertFails(
+        updateDoc(doc(asMemberB(), `plcs/${PLC_ID}/todos/${TODO_ID}`), {
+          createdBy: MEMBER_B_UID,
+        })
+      );
+    });
+
+    it('a non-member cannot edit', async () => {
+      await assertFails(
+        updateDoc(doc(asNonMember(), `plcs/${PLC_ID}/todos/${TODO_ID}`), {
+          done: true,
+        })
+      );
+    });
+  });
+});

--- a/tests/rules/plcOverviewAndContent.test.ts
+++ b/tests/rules/plcOverviewAndContent.test.ts
@@ -149,6 +149,23 @@ describe('users/{uid}/plc_layouts — owner-only', () => {
       })
     );
   });
+
+  it('rejects an oversized tiles list (> 50 entries)', async () => {
+    // Defense-in-depth size cap. Per-tile interior validation is delegated
+    // to the client parser, but the rule must still bound the doc size so
+    // a malicious extension can't weaponize the layout doc as unbounded
+    // storage on the user's own quota.
+    const oversized = Array.from({ length: 51 }, () => ({
+      kind: 'todos',
+      size: 'sm',
+    }));
+    await assertFails(
+      setDoc(doc(asMemberA(), `users/${MEMBER_A_UID}/plc_layouts/${PLC_ID}`), {
+        tiles: oversized,
+        updatedAt: 1,
+      })
+    );
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/types.ts
+++ b/types.ts
@@ -289,6 +289,111 @@ export interface PlcAssignmentIndexEntry {
 }
 
 /**
+ * One shared note in a PLC notebook. Members CRUD freely; LWW on edits.
+ */
+export interface PlcNote {
+  id: string;
+  title: string;
+  body: string;
+  createdBy: string;
+  createdAt: number;
+  lastEditedBy: string;
+  lastEditedAt: number;
+}
+
+/**
+ * One PLC to-do. Stored as one doc per todo (not an array on a parent doc)
+ * so concurrent edits don't serialize against the whole list.
+ */
+export interface PlcTodo {
+  id: string;
+  text: string;
+  done: boolean;
+  createdBy: string;
+  createdAt: number;
+}
+
+/**
+ * Bento-grid layout types for the PLC Overview tab. Per-user layout —
+ * persisted at `users/{uid}/plc_layouts/{plcId}` so each member arranges
+ * their own dashboard without affecting teammates.
+ */
+export type PlcBentoTileSize = 'sm' | 'md-wide' | 'md-tall' | 'lg';
+
+/**
+ * Stable identifier for each tile renderer. Doubles as the doc-key in the
+ * persisted layout (one tile per kind). Adding a new tile = appending the
+ * kind here + extending the rules' `kind in […]` allow-list.
+ */
+export type PlcBentoTileKind =
+  | 'plcInfo'
+  | 'members'
+  | 'completedAssignments'
+  | 'notes'
+  | 'todos'
+  | 'sharedSheet'
+  | 'quickActions'
+  | 'quizLibrary'
+  | 'activeAssignments'
+  | 'videoActivities'
+  | 'sharedBoards';
+
+export interface PlcBentoTile {
+  kind: PlcBentoTileKind;
+  size: PlcBentoTileSize;
+  /** When true the tile sits in the "Hidden tiles" tray instead of the grid. */
+  hidden?: boolean;
+}
+
+export interface PlcOverviewLayout {
+  tiles: PlcBentoTile[];
+  updatedAt: number;
+}
+
+export const PLC_BENTO_TILE_SIZES: readonly PlcBentoTileSize[] = [
+  'sm',
+  'md-wide',
+  'md-tall',
+  'lg',
+] as const;
+
+export const PLC_BENTO_TILE_KINDS: readonly PlcBentoTileKind[] = [
+  'plcInfo',
+  'members',
+  'completedAssignments',
+  'notes',
+  'todos',
+  'sharedSheet',
+  'quickActions',
+  'quizLibrary',
+  'activeAssignments',
+  'videoActivities',
+  'sharedBoards',
+] as const;
+
+/**
+ * Default tile order + sizes for a brand-new PLC overview. Used when a
+ * member opens the dashboard for the first time and no `plc_layouts` doc
+ * exists yet. Live-data tiles come first; "coming soon" placeholders trail.
+ */
+export const DEFAULT_PLC_OVERVIEW_LAYOUT: PlcOverviewLayout = {
+  tiles: [
+    { kind: 'plcInfo', size: 'md-wide' },
+    { kind: 'quickActions', size: 'md-wide' },
+    { kind: 'members', size: 'sm' },
+    { kind: 'sharedSheet', size: 'sm' },
+    { kind: 'todos', size: 'md-tall' },
+    { kind: 'notes', size: 'md-wide' },
+    { kind: 'completedAssignments', size: 'lg' },
+    { kind: 'quizLibrary', size: 'sm' },
+    { kind: 'activeAssignments', size: 'sm' },
+    { kind: 'videoActivities', size: 'sm' },
+    { kind: 'sharedBoards', size: 'sm' },
+  ],
+  updatedAt: 0,
+};
+
+/**
  * An outstanding invitation for a teacher to join a PLC. Top-level so the
  * invitee can read pending invites by email without being a member of the
  * target PLC yet. The doc id is *deterministic* — `<plcId>_<emailLower>`


### PR DESCRIPTION
## Summary

- **Overview tab is now the default landing** for the PLC Dashboard, replacing the read-only "Completed Assignments" view. Tiles preview members, recent results, notes, to-dos, the shared sheet, and quick actions; "coming soon" tiles for Phases 2/3/4/6 link through to their (still-stubbed) tabs.
- **Per-user customizable bento grid** — drag tiles by the grip, click the corner to cycle size variants (`sm` / `md-wide` / `md-tall` / `lg`), click the eye to hide. Layout persists at `users/{uid}/plc_layouts/{plcId}` with debounced (~500ms) writes.
- **Phase 5 (Notes + To-Dos) bundled in** so the bento has real content on day one. New `plcs/{plcId}/notes` and `/todos` subcollections with split create/update rules, schema lock-down, and `lastEditedBy = request.auth.uid` enforcement on every note edit. Two-pane Notes editor + flat To-Do list with click-to-edit + completed section.
- **Sidebar PLC card affordance fixed** — full-row click via absolute backdrop button, secondary actions (edit/view, delete/leave) collapse into a kebab menu. Chevron-right hint signals the row is interactive.

dnd-kit wiring mirrors [LibraryGrid](components/common/library/LibraryGrid.tsx) exactly: `closestCenter` + `rectSortingStrategy` + `PointerSensor {distance:5}` + `DragOverlay` with `snapCenterToCursor`. Tile drag handle is scoped to the grip icon so non-edit-mode tile content stays interactive.

See [docs/PLC_ROADMAP.md](docs/PLC_ROADMAP.md) for the Phase 1.5 + Phase 5 implementation notes (including the explicit bundling rationale that deviates from the "one phase per PR" rule).

## Test plan

- [x] `pnpm run type-check` — clean
- [x] `pnpm run lint` — clean (0 errors / 0 warnings)
- [x] `pnpm run format:check` — clean
- [x] `pnpm run test` — 2061/2061 passing including 15 new tests (`usePlcOverviewLayout`, `usePlcNotes`, `usePlcTodos`)
- [ ] `pnpm run test:rules` (firebase emulator) — covers `users/{uid}/plc_layouts` owner-only + `plcs/{plcId}/notes` and `/todos` membership-gating, schema lock-down, immutability, and `lastEditedBy` impersonation guard
- [ ] Manual UX in dev preview:
  - [ ] Sidebar: hover PLC card highlights the whole row; click anywhere except kebab opens dashboard; kebab menu shows Edit/Delete (or Edit/Leave for non-leads)
  - [ ] Dashboard: "Overview" is the active tab on first open
  - [ ] Edit Layout: drag tiles to reorder (persists across reload), corner button cycles tile size, eye button moves tile to "Hidden tiles" tray
  - [ ] Reset Layout returns to default
  - [ ] Notes tile shows recent notes; clicking footer opens Notes tab; create/edit/delete works
  - [ ] To-Dos tile checkbox marks complete inline; full list available in To-Dos tab
  - [ ] Toggle a feature off in Settings (e.g. notes) → corresponding bento tile auto-hides; toggling back on restores it
  - [ ] Mobile (< 768px): grid collapses to single column, drag still works, sizes ignored
- [ ] Multi-user smoke: second member sees independent layout, but shares the same notes + todos

🤖 Generated with [Claude Code](https://claude.com/claude-code)