### PR TITLE
Enhance video activity with YouTube search, recommendations, and timeline

### DIFF
--- a/components/common/library/PlcTab.tsx
+++ b/components/common/library/PlcTab.tsx
@@ -1,5 +1,5 @@
 /**
- * PlcTab — cross-teacher aggregate view of a PLC's quiz results.
+ * PlcTab — cross-teacher aggregate view of a PLC's assignment results.
  *
  * Renders only when the active assignment is in PLC mode (Share-with-PLC
  * enabled). The teacher's own class data lives in the Overview / Questions /
@@ -13,6 +13,12 @@
  * and per-period filtering is intentionally NOT exposed here: if a teacher
  * needs that level of detail, they open the sheet itself. This tab keeps
  * the focus on aggregate signal.
+ *
+ * Generic over the assignment kind: works for both Quiz and Video Activity
+ * because both exporters write the same column shape (PR3b lifted
+ * `buildResultsSheetData` into a shared helper). The `questions` prop only
+ * needs `id` + `text`; `QuizQuestion` and `VideoActivityQuestion` both
+ * satisfy `PlcTabQuestion` structurally.
  */
 
 import React, { useEffect, useState, useMemo } from 'react';
@@ -27,13 +33,18 @@ import {
   ExternalLink,
   RefreshCw,
 } from 'lucide-react';
-import type { QuizQuestion } from '@/types';
 import { QuizDriveService, type PlcSheetRow } from '@/utils/quizDriveService';
+
+/** Minimal question shape this tab renders. */
+export interface PlcTabQuestion {
+  id: string;
+  text: string;
+}
 
 interface PlcTabProps {
   plcSheetUrl: string;
   googleAccessToken: string | null;
-  questions: QuizQuestion[];
+  questions: PlcTabQuestion[];
 }
 
 interface PlcAggregate {
@@ -83,7 +94,7 @@ const SCORE_BUCKETS = [
 
 function aggregate(
   rows: PlcSheetRow[],
-  questions: QuizQuestion[]
+  questions: PlcTabQuestion[]
 ): PlcAggregate {
   const completed = rows.filter((r) => r.status === 'completed');
   const teachers = new Set<string>();

--- a/components/common/library/PublishScoresModal.tsx
+++ b/components/common/library/PublishScoresModal.tsx
@@ -4,7 +4,8 @@
  * given assignment.
  *
  * Reached from the archive tab's per-assignment kebab → "Publish Scores".
- * The four levels map to `QuizScoreVisibility`:
+ * The four levels map to the assignment's score-visibility union (Quiz
+ * and Video Activity define structurally identical unions):
  *
  *   - none: scores are hidden from students (default / unpublish path).
  *   - score-only: students see their final percentage score.
@@ -16,7 +17,7 @@
  * The modal is purely a level-picker — the actual publish work
  * (computing scores, writing per-response `isCorrect`, populating
  * `session.revealedAnswers`, mirroring the visibility flag) is done by
- * `useQuizAssignments.publishAssignmentScores`.
+ * the caller's `publishAssignmentScores` hook.
  */
 
 import React, { useState } from 'react';
@@ -30,19 +31,30 @@ import {
   X,
 } from 'lucide-react';
 import { Modal } from '@/components/common/Modal';
-import type { QuizScoreVisibility } from '@/types';
+import type {
+  QuizScoreVisibility,
+  VideoActivityScoreVisibility,
+} from '@/types';
+
+/**
+ * Score-visibility level. Quiz and VA both define the same string-literal
+ * union; either resolves to the same shape at the call site.
+ */
+export type PublishScoresVisibility =
+  | QuizScoreVisibility
+  | VideoActivityScoreVisibility;
 
 interface PublishScoresModalProps {
-  /** Quiz title — shown as a sub-line so the teacher knows which assignment they're publishing. */
-  quizTitle: string;
+  /** Assignment title — sub-line so the teacher knows which assignment they're publishing. */
+  assignmentTitle: string;
   /** Currently-published level (or 'none' / undefined when nothing is published yet). */
-  currentVisibility: QuizScoreVisibility | undefined;
+  currentVisibility: PublishScoresVisibility | undefined;
   onClose: () => void;
-  onConfirm: (visibility: QuizScoreVisibility) => Promise<void> | void;
+  onConfirm: (visibility: PublishScoresVisibility) => Promise<void> | void;
 }
 
 interface VisibilityOption {
-  id: QuizScoreVisibility;
+  id: PublishScoresVisibility;
   title: string;
   body: string;
   Icon: React.ComponentType<{ className?: string }>;
@@ -70,24 +82,24 @@ const OPTIONS: VisibilityOption[] = [
 ];
 
 export const PublishScoresModal: React.FC<PublishScoresModalProps> = ({
-  quizTitle,
+  assignmentTitle,
   currentVisibility,
   onClose,
   onConfirm,
 }) => {
   // Default the picker to whatever the assignment is currently set to (or
   // 'score-only' on first publish — the calmest non-empty choice).
-  const initial: QuizScoreVisibility =
+  const initial: PublishScoresVisibility =
     currentVisibility && currentVisibility !== 'none'
       ? currentVisibility
       : 'score-only';
-  const [selected, setSelected] = useState<QuizScoreVisibility>(initial);
+  const [selected, setSelected] = useState<PublishScoresVisibility>(initial);
   const [submitting, setSubmitting] = useState(false);
 
   const isPublished =
     currentVisibility !== undefined && currentVisibility !== 'none';
 
-  const handleConfirm = async (visibility: QuizScoreVisibility) => {
+  const handleConfirm = async (visibility: PublishScoresVisibility) => {
     if (submitting) return;
     setSubmitting(true);
     try {
@@ -115,7 +127,7 @@ export const PublishScoresModal: React.FC<PublishScoresModalProps> = ({
                 Publish scores
               </h2>
               <p className="text-xs text-slate-500 mt-0.5 truncate max-w-[20rem]">
-                {quizTitle}
+                {assignmentTitle}
               </p>
             </div>
           </div>

--- a/components/layout/DashboardView.tsx
+++ b/components/layout/DashboardView.tsx
@@ -16,6 +16,8 @@ import {
   useQuizAssignments,
   type SharedAssignmentImportMode,
 } from '@/hooks/useQuizAssignments';
+import { useVideoActivity } from '@/hooks/useVideoActivity';
+import { useVideoActivityAssignments } from '@/hooks/useVideoActivityAssignments';
 import { QuizAssignmentImportModeModal } from '@/components/widgets/QuizWidget/components/QuizAssignmentImportModeModal';
 import { ImportShareModePicker } from '@/components/share/ImportShareModePicker';
 import { ShareStatusBanner } from '@/components/share/ShareStatusBanner';
@@ -160,6 +162,8 @@ export const DashboardView: React.FC = () => {
     clearPendingQuizShare,
     pendingAssignmentShareId,
     clearPendingAssignmentShare,
+    pendingVideoActivityShareId,
+    clearPendingVideoActivityShare,
     setPendingAssignmentSetup,
     // Widget grouping
     groupWidgets,
@@ -178,6 +182,12 @@ export const DashboardView: React.FC = () => {
   const { importSharedAssignment, peekSharedAssignment } = useQuizAssignments(
     user?.uid
   );
+  const {
+    saveActivity: saveVideoActivity,
+    attachSyncLinkage: attachVideoActivitySyncLinkage,
+  } = useVideoActivity(user?.uid);
+  const { importSharedAssignment: importSharedVideoActivityAssignment } =
+    useVideoActivityAssignments(user?.uid);
   const { plcs, loading: plcsLoading } = usePlcs();
 
   // Mode picker state — populated when a synced share is detected; null
@@ -212,6 +222,32 @@ export const DashboardView: React.FC = () => {
         bringToFront(quizWidget.id);
       } else {
         addWidget('quiz', {
+          config: { view: 'manager', managerTab: tab },
+        });
+      }
+    },
+    [activeDashboard, updateWidget, addWidget, bringToFront]
+  );
+
+  const openVideoActivityWidgetToTab = React.useCallback(
+    (tab: 'library' | 'active' | 'archive') => {
+      const vaWidget = activeDashboard?.widgets.find(
+        (w) => w.type === 'video-activity'
+      );
+      if (vaWidget) {
+        if (vaWidget.minimized) {
+          updateWidget(vaWidget.id, { minimized: false });
+        }
+        updateWidget(vaWidget.id, {
+          config: {
+            ...vaWidget.config,
+            view: 'manager',
+            managerTab: tab,
+          },
+        });
+        bringToFront(vaWidget.id);
+      } else {
+        addWidget('video-activity', {
           config: { view: 'manager', managerTab: tab },
         });
       }
@@ -449,6 +485,76 @@ export const DashboardView: React.FC = () => {
     peekAndDispatchImport,
     clearPendingAssignmentShare,
     plcsLoading,
+  ]);
+
+  // Stable dispatcher for VA share imports — extracted so the failure
+  // toast's Retry action can re-invoke it without re-running the
+  // pending-id effect (which clears the id synchronously to avoid the
+  // triple-import race documented on the Quiz path above). Mirrors
+  // `peekAndDispatchImport` for the Quiz flow but skips the peek + mode
+  // picker — VA's sync-mode picker UI hasn't been ported and a synced
+  // share simply imports as a copy.
+  const runVideoActivityImport = React.useCallback(
+    (shareId: string) => {
+      void importSharedVideoActivityAssignment(shareId, {
+        mode: 'copy',
+        saveActivity: saveVideoActivity,
+        attachSyncLinkage: attachVideoActivitySyncLinkage,
+      })
+        .then(() => {
+          addToast('Shared video activity imported!', 'success');
+          openVideoActivityWidgetToTab('active');
+        })
+        .catch((err: unknown) => {
+          logError('DashboardView.importSharedVideoActivity', err, {
+            shareId,
+          });
+          // The VA import hook handles its own rollback (Drive copy +
+          // sync-group leave) on failure paths, so the catch block is
+          // surface-only — no manual cleanup needed.
+          const msg =
+            err instanceof Error
+              ? err.message
+              : typeof err === 'string'
+                ? err
+                : '';
+          addToast(
+            msg
+              ? `Failed to import shared video activity: ${msg}`
+              : 'Failed to import shared video activity.',
+            'error',
+            {
+              label: 'Retry',
+              onClick: () => runVideoActivityImport(shareId),
+            }
+          );
+        });
+    },
+    [
+      importSharedVideoActivityAssignment,
+      saveVideoActivity,
+      attachVideoActivitySyncLinkage,
+      addToast,
+      openVideoActivityWidgetToTab,
+    ]
+  );
+
+  // PR3c — pending video-activity-assignment share import. Mirrors the
+  // quiz-assignment effect above: clears the pending id synchronously
+  // before dispatching to avoid the triple-import race; the dispatcher's
+  // failure toast carries Retry as the recovery path.
+  useEffect(() => {
+    if (!pendingVideoActivityShareId || !user) return;
+    if (plcsLoading) return;
+    const shareId = pendingVideoActivityShareId;
+    clearPendingVideoActivityShare();
+    runVideoActivityImport(shareId);
+  }, [
+    pendingVideoActivityShareId,
+    user,
+    plcsLoading,
+    clearPendingVideoActivityShare,
+    runVideoActivityImport,
   ]);
 
   const [panOffset, setPanOffset] = React.useState({ x: 0, y: 0 });

--- a/components/plc/PlcDashboard.tsx
+++ b/components/plc/PlcDashboard.tsx
@@ -22,6 +22,7 @@ import { PlcCompletedAssignmentsTab } from './tabs/PlcCompletedAssignmentsTab';
 import { PlcSettingsTab } from './tabs/PlcSettingsTab';
 import { PlcNotesTab } from './tabs/PlcNotesTab';
 import { PlcTodosTab } from './tabs/PlcTodosTab';
+import { PlcQuizLibraryTab } from './tabs/PlcQuizLibraryTab';
 import { PlcPlaceholderTab } from './tabs/PlcPlaceholderTab';
 
 interface PlcDashboardProps {
@@ -73,11 +74,6 @@ const TABS: readonly TabDef[] = [
     labelKey: 'plcDashboard.tabs.quizzes',
     labelDefault: 'Quiz Library',
     feature: 'quizzes',
-    placeholder: {
-      titleDefault: 'PLC Quiz Library',
-      descriptionDefault:
-        'Share quizzes with the PLC, edit collaboratively, and let teammates sync or copy them into their own libraries.',
-    },
   },
   {
     id: 'assignments',
@@ -203,6 +199,9 @@ export const PlcDashboard: React.FC<PlcDashboardProps> = ({ plc, onClose }) => {
     }
     if (tab.id === 'todos') {
       return <PlcTodosTab plc={plc} />;
+    }
+    if (tab.id === 'quizzes') {
+      return <PlcQuizLibraryTab plc={plc} />;
     }
     if (tab.id === 'settings') {
       return <PlcSettingsTab plc={plc} />;

--- a/components/plc/PlcQuizImportModal.tsx
+++ b/components/plc/PlcQuizImportModal.tsx
@@ -1,0 +1,134 @@
+/**
+ * PlcQuizImportModal — picker shown when a teacher clicks "Add to my
+ * library" on a row in the PLC Quiz Library tab. Lets them choose:
+ *
+ *  - Sync — joins the canonical synced group; future edits by any PLC
+ *    member appear on this teacher's library card with a Sync available
+ *    pill, and their own edits publish back to the group.
+ *
+ *  - Make a copy — frozen one-time snapshot, identical to the legacy
+ *    `importSharedQuiz` behavior. Use when the teacher wants to fork.
+ *
+ * Mirrors `QuizAssignmentImportModeModal.tsx` exactly (same Modal
+ * primitive, same two ModeOption buttons, same copy patterns) so the
+ * UX is consistent across PLC entry points.
+ */
+
+import React from 'react';
+import { Cloud, Copy, X } from 'lucide-react';
+import { Modal } from '@/components/common/Modal';
+import type { SharedAssignmentImportMode } from '@/hooks/useQuizAssignments';
+
+interface PlcQuizImportModalProps {
+  /** Title of the PLC quiz being imported, displayed under the modal header. */
+  quizTitle: string;
+  /** Optional originator name (the teacher who first shared the quiz). */
+  sharedByName?: string;
+  onPick: (mode: SharedAssignmentImportMode) => void;
+  onClose: () => void;
+}
+
+interface ModeOptionProps {
+  mode: SharedAssignmentImportMode;
+  title: string;
+  body: string;
+  Icon: React.ComponentType<{ className?: string }>;
+  recommended?: boolean;
+  onPick: (mode: SharedAssignmentImportMode) => void;
+}
+
+const ModeOption: React.FC<ModeOptionProps> = ({
+  mode,
+  title,
+  body,
+  Icon,
+  recommended,
+  onPick,
+}) => (
+  <button
+    type="button"
+    onClick={() => onPick(mode)}
+    className="w-full text-left rounded-xl border border-slate-200 bg-white px-4 py-4 transition-all hover:border-brand-blue-primary hover:shadow-md focus:outline-none focus:ring-2 focus:ring-brand-blue-primary/40"
+  >
+    <div className="flex items-start gap-3">
+      <div className="shrink-0 w-10 h-10 rounded-lg bg-brand-blue-lighter/40 text-brand-blue-primary flex items-center justify-center">
+        <Icon className="w-5 h-5" />
+      </div>
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-2">
+          <h3 className="font-bold text-slate-900 text-sm">{title}</h3>
+          {recommended && (
+            <span className="rounded-full bg-emerald-100 px-2 py-0.5 text-[10px] font-bold uppercase tracking-wider text-emerald-700">
+              Recommended for PLCs
+            </span>
+          )}
+        </div>
+        <p className="mt-1 text-xs text-slate-600 leading-relaxed">{body}</p>
+      </div>
+    </div>
+  </button>
+);
+
+export const PlcQuizImportModal: React.FC<PlcQuizImportModalProps> = ({
+  quizTitle,
+  sharedByName,
+  onPick,
+  onClose,
+}) => {
+  return (
+    <Modal
+      isOpen
+      onClose={onClose}
+      ariaLabel="Choose how to import this quiz"
+      maxWidth="max-w-md"
+      contentClassName=""
+      customHeader={
+        <div className="flex items-start justify-between px-5 pt-5 pb-3 border-b border-slate-100">
+          <div className="flex items-start gap-3">
+            <div className="shrink-0 w-9 h-9 rounded-lg bg-brand-blue-lighter/40 text-brand-blue-primary flex items-center justify-center">
+              <Cloud className="w-5 h-5" />
+            </div>
+            <div>
+              <h2 className="text-base font-bold text-slate-900">
+                Add to my library
+              </h2>
+              <p className="text-xs text-slate-500 mt-0.5 truncate max-w-[20rem]">
+                {quizTitle}
+                {sharedByName ? ` · shared by ${sharedByName}` : ''}
+              </p>
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close"
+            className="shrink-0 rounded-lg p-1 text-slate-400 hover:bg-slate-100 hover:text-slate-700 transition-colors"
+          >
+            <X className="w-5 h-5" />
+          </button>
+        </div>
+      }
+    >
+      <div className="px-5 pb-5 pt-4 space-y-3">
+        <p className="text-xs text-slate-600">
+          How should this quiz be imported into your library?
+        </p>
+        <ModeOption
+          mode="sync"
+          title="Synced"
+          body="Stay connected to the PLC version. Any teacher in the synced group can edit, and changes show up on everyone's library card with a Sync available pill."
+          Icon={Cloud}
+          recommended
+          onPick={onPick}
+        />
+        <ModeOption
+          mode="copy"
+          title="Make a copy"
+          body="Take a frozen snapshot. Future edits by other PLC members will not appear in your copy, and your edits stay private."
+          Icon={Copy}
+          onPick={onPick}
+        />
+      </div>
+    </Modal>
+  );
+};

--- a/components/plc/PlcShareTargetModal.tsx
+++ b/components/plc/PlcShareTargetModal.tsx
@@ -1,0 +1,152 @@
+/**
+ * PlcShareTargetModal — picker shown to a teacher who clicks "Share with
+ * PLC" on a quiz from their library. Lets them choose which of their PLCs
+ * to share with. If they only belong to one PLC, the form preselects it
+ * and the user just confirms.
+ *
+ * The actual share write (creating the synced group + the PLC subcoll
+ * doc) is done by the caller via the `onConfirm(plcId)` callback — this
+ * component is a pure picker.
+ */
+
+import React, { useState } from 'react';
+import { Loader2, Users2, X } from 'lucide-react';
+import { Modal } from '@/components/common/Modal';
+import { Plc } from '@/types';
+
+interface PlcShareTargetModalProps {
+  /** PLCs the user is a current member of. Caller filters; modal renders as-is. */
+  plcs: Plc[];
+  /** Title of the quiz being shared, displayed under the modal header. */
+  quizTitle: string;
+  onConfirm: (plcId: string) => void | Promise<void>;
+  onClose: () => void;
+}
+
+export const PlcShareTargetModal: React.FC<PlcShareTargetModalProps> = ({
+  plcs,
+  quizTitle,
+  onConfirm,
+  onClose,
+}) => {
+  const initialSelected = plcs.length === 1 ? plcs[0].id : '';
+  const [selectedId, setSelectedId] = useState<string>(initialSelected);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const canSubmit = !!selectedId && !submitting;
+
+  const handleSubmit = async () => {
+    if (!canSubmit) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      await onConfirm(selectedId);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Share failed.');
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Modal
+      isOpen
+      onClose={submitting ? () => undefined : onClose}
+      ariaLabel="Pick a PLC to share with"
+      maxWidth="max-w-md"
+      contentClassName=""
+      customHeader={
+        <div className="flex items-start justify-between px-5 pt-5 pb-3 border-b border-slate-100">
+          <div className="flex items-start gap-3">
+            <div className="shrink-0 w-9 h-9 rounded-lg bg-brand-blue-lighter/40 text-brand-blue-primary flex items-center justify-center">
+              <Users2 className="w-5 h-5" />
+            </div>
+            <div>
+              <h2 className="text-base font-bold text-slate-900">
+                Share with PLC
+              </h2>
+              <p className="text-xs text-slate-500 mt-0.5 truncate max-w-[20rem]">
+                {quizTitle}
+              </p>
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={submitting}
+            aria-label="Close"
+            className="shrink-0 rounded-lg p-1 text-slate-400 hover:bg-slate-100 hover:text-slate-700 transition-colors disabled:opacity-40"
+          >
+            <X className="w-5 h-5" />
+          </button>
+        </div>
+      }
+    >
+      <div className="px-5 pb-5 pt-4 space-y-4">
+        <p className="text-xs text-slate-600">
+          Pick which PLC should receive this quiz. Teammates can sync or copy it
+          into their own libraries.
+        </p>
+
+        <div className="space-y-2 max-h-72 overflow-y-auto custom-scrollbar -mx-1 px-1">
+          {plcs.map((plc) => (
+            <label
+              key={plc.id}
+              className={`flex items-center gap-3 rounded-xl border px-3 py-2.5 cursor-pointer transition-colors ${
+                selectedId === plc.id
+                  ? 'border-brand-blue-primary bg-brand-blue-lighter/30'
+                  : 'border-slate-200 hover:border-slate-300'
+              }`}
+            >
+              <input
+                type="radio"
+                name="plc-share-target"
+                value={plc.id}
+                checked={selectedId === plc.id}
+                onChange={() => setSelectedId(plc.id)}
+                className="h-4 w-4 accent-brand-blue-primary"
+                disabled={submitting}
+                aria-label={plc.name}
+              />
+              <div className="flex-1 min-w-0">
+                <div className="text-sm font-bold text-slate-800 truncate">
+                  {plc.name}
+                </div>
+                <div className="text-xxs text-slate-500">
+                  {plc.memberUids.length}{' '}
+                  {plc.memberUids.length === 1 ? 'member' : 'members'}
+                </div>
+              </div>
+            </label>
+          ))}
+        </div>
+
+        {error && (
+          <div className="text-xs font-bold text-red-600 bg-red-50 border border-red-200 rounded-lg px-3 py-2">
+            {error}
+          </div>
+        )}
+
+        <div className="flex items-center justify-end gap-2 pt-1">
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={submitting}
+            className="px-3 py-2 text-xs font-bold text-slate-600 hover:bg-slate-100 rounded-lg transition-colors disabled:opacity-40"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={() => void handleSubmit()}
+            disabled={!canSubmit}
+            className="px-4 py-2 text-xs font-bold text-white bg-brand-blue-primary hover:bg-brand-blue-dark disabled:opacity-40 disabled:cursor-not-allowed rounded-lg transition-colors flex items-center gap-2"
+          >
+            {submitting && <Loader2 className="w-3.5 h-3.5 animate-spin" />}
+            Share
+          </button>
+        </div>
+      </div>
+    </Modal>
+  );
+};

--- a/components/plc/overview/tileRegistry.tsx
+++ b/components/plc/overview/tileRegistry.tsx
@@ -8,6 +8,7 @@ import { NotesTile } from './tiles/NotesTile';
 import { TodosTile } from './tiles/TodosTile';
 import { SharedSheetTile } from './tiles/SharedSheetTile';
 import { QuickActionsTile } from './tiles/QuickActionsTile';
+import { QuizLibraryTile } from './tiles/QuizLibraryTile';
 import { ComingSoonTile } from './tiles/ComingSoonTile';
 
 export interface TileContext {
@@ -80,11 +81,7 @@ export function renderTileContent(
       return <QuickActionsTile onNavigateTab={ctx.onNavigateTab} />;
     case 'quizLibrary':
       return (
-        <ComingSoonTile
-          kind="quizLibrary"
-          phase={2}
-          onNavigateTab={() => ctx.onNavigateTab('quizzes')}
-        />
+        <QuizLibraryTile plc={ctx.plc} onNavigateTab={ctx.onNavigateTab} />
       );
     case 'activeAssignments':
       return (

--- a/components/plc/overview/tiles/QuizLibraryTile.tsx
+++ b/components/plc/overview/tiles/QuizLibraryTile.tsx
@@ -1,0 +1,116 @@
+/**
+ * QuizLibraryTile — Phase 2 bento tile for the PLC Quiz Library.
+ *
+ * Mirrors the visual rhythm of `NotesTile`: small heading, scrollable
+ * preview list, single-tap link into the full tab. Renders the most
+ * recent N PLC-shared quizzes (newest-edit first) with an attribution
+ * line and question count. Empty state nudges teammates to share their
+ * first quiz from the QuizWidget kebab.
+ */
+
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { BookOpen, ChevronRight, Loader2 } from 'lucide-react';
+import { Plc } from '@/types';
+import { usePlcQuizzes } from '@/hooks/usePlcQuizzes';
+import type { PlcDashboardTabId } from '../../PlcDashboard';
+
+interface QuizLibraryTileProps {
+  plc: Plc;
+  onNavigateTab: (tabId: PlcDashboardTabId) => void;
+}
+
+const PREVIEW_LIMIT = 4;
+
+export const QuizLibraryTile: React.FC<QuizLibraryTileProps> = ({
+  plc,
+  onNavigateTab,
+}) => {
+  const { t } = useTranslation();
+  const { quizzes, loading } = usePlcQuizzes(plc.id);
+  const preview = quizzes.slice(0, PREVIEW_LIMIT);
+
+  return (
+    <div className="h-full flex flex-col">
+      <div className="flex items-center gap-2 px-4 pt-4 pb-2">
+        <div className="w-7 h-7 rounded-lg bg-brand-blue-lighter flex items-center justify-center">
+          <BookOpen className="w-3.5 h-3.5 text-brand-blue-primary" />
+        </div>
+        <h4 className="text-xxs font-bold uppercase tracking-widest text-slate-500">
+          {t('plcDashboard.overview.tiles.quizLibrary.heading', {
+            defaultValue: 'Quiz Library',
+          })}
+        </h4>
+        {quizzes.length > 0 && (
+          <span className="ml-auto text-xs font-bold text-slate-700">
+            {quizzes.length}
+          </span>
+        )}
+      </div>
+
+      <div className="flex-1 min-h-0 overflow-y-auto custom-scrollbar px-4 pb-2">
+        {loading ? (
+          <div className="flex items-center justify-center h-full text-slate-400">
+            <Loader2 className="w-4 h-4 animate-spin" />
+          </div>
+        ) : preview.length === 0 ? (
+          <div className="flex flex-col items-center justify-center h-full text-center text-xs text-slate-500 py-2">
+            <BookOpen className="w-6 h-6 text-slate-300 mb-2" />
+            <p className="font-semibold text-slate-600">
+              {t('plcDashboard.overview.tiles.quizLibrary.empty', {
+                defaultValue: 'No shared quizzes',
+              })}
+            </p>
+            <p className="text-xxs text-slate-400 mt-1">
+              {t('plcDashboard.overview.tiles.quizLibrary.emptySubtitle', {
+                defaultValue:
+                  'Share a quiz from the kebab on its library card.',
+              })}
+            </p>
+          </div>
+        ) : (
+          <ul className="space-y-2 py-1">
+            {preview.map((quiz) => (
+              <li
+                key={quiz.id}
+                className="px-2 py-2 rounded-lg hover:bg-brand-blue-lighter/40 transition-colors"
+              >
+                <div className="flex items-baseline justify-between gap-2">
+                  <div className="text-xs font-bold text-slate-800 truncate">
+                    {quiz.title}
+                  </div>
+                  <span className="shrink-0 text-xxs text-slate-400">
+                    {t(
+                      'plcDashboard.overview.tiles.quizLibrary.questionCount',
+                      {
+                        count: quiz.questionCount,
+                        defaultValue: '{{count}} q',
+                      }
+                    )}
+                  </span>
+                </div>
+                <p className="text-xxs text-slate-500 truncate mt-0.5">
+                  {t('plcDashboard.overview.tiles.quizLibrary.bySharer', {
+                    name: quiz.sharedByName || quiz.sharedByEmail || '—',
+                    defaultValue: 'shared by {{name}}',
+                  })}
+                </p>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+
+      <button
+        type="button"
+        onClick={() => onNavigateTab('quizzes')}
+        className="flex items-center justify-center gap-1.5 px-4 py-2.5 border-t border-slate-100 text-xxs font-bold uppercase tracking-wider text-brand-blue-primary hover:bg-brand-blue-lighter/40 transition-colors"
+      >
+        {t('plcDashboard.overview.tiles.quizLibrary.openAll', {
+          defaultValue: 'Open library',
+        })}
+        <ChevronRight className="w-3 h-3" />
+      </button>
+    </div>
+  );
+};

--- a/components/plc/tabs/PlcQuizLibraryTab.tsx
+++ b/components/plc/tabs/PlcQuizLibraryTab.tsx
@@ -1,0 +1,479 @@
+/**
+ * PlcQuizLibraryTab — Phase 2.
+ *
+ * Lists every quiz that any PLC member has shared with this PLC. Each
+ * row supports:
+ *
+ *   - "Add to my library" — opens `PlcQuizImportModal` (sync-or-copy
+ *     picker). On Sync we pull the canonical content, save a fresh
+ *     personal copy, join the synced group via Cloud Function, and
+ *     attach the sync linkage so the user's library card thereafter
+ *     surfaces the "Synced" / "Sync available" pills. On Copy we just
+ *     pull canonical and save a fresh personal copy (no sync linkage).
+ *
+ *   - "Unshare" — any current member can remove a PLC quiz entry
+ *     (PLC-owned model — quizzes shared with the PLC belong to the PLC,
+ *     not the original sharer). The canonical `synced_quizzes/{groupId}`
+ *     doc is intentionally left in place; orphan-tolerant per the
+ *     Phase 2 spec.
+ *
+ *   - Already-imported indicator — when the user's personal library
+ *     already carries a `sync.groupId === plcQuiz.syncGroupId`, the row
+ *     shows an "In your library" badge. Re-importing in Sync mode is a
+ *     no-op (informational toast — duplicating a synced linkage would
+ *     just create two personal copies pointing at the same group); Copy
+ *     mode still creates a fresh snapshot.
+ */
+
+import React, { useCallback, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import {
+  BookOpen,
+  Cloud,
+  Download,
+  ExternalLink,
+  Loader2,
+  Trash2,
+  Users2,
+} from 'lucide-react';
+import type { Plc, QuizData } from '@/types';
+import { useAuth } from '@/context/useAuth';
+import { useDashboard } from '@/context/useDashboard';
+import { useDialog } from '@/context/useDialog';
+import { usePlcQuizzes } from '@/hooks/usePlcQuizzes';
+import { useQuiz } from '@/hooks/useQuiz';
+import {
+  callJoinPlcQuizSyncGroup,
+  callLeaveSyncedQuizGroup,
+  pullSyncedQuizContent,
+} from '@/hooks/useSyncedQuizGroups';
+import type { SharedAssignmentImportMode } from '@/hooks/useQuizAssignments';
+import { logError } from '@/utils/logError';
+import { PlcQuizImportModal } from '../PlcQuizImportModal';
+
+interface PlcQuizLibraryTabProps {
+  plc: Plc;
+}
+
+interface ImportTarget {
+  plcQuizId: string;
+  syncGroupId: string;
+  title: string;
+  sharedByName: string;
+}
+
+function formatDate(ms: number): string {
+  try {
+    return new Date(ms).toLocaleDateString(undefined, {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+    });
+  } catch {
+    return '';
+  }
+}
+
+export const PlcQuizLibraryTab: React.FC<PlcQuizLibraryTabProps> = ({
+  plc,
+}) => {
+  const { t } = useTranslation();
+  const { user } = useAuth();
+  const { addToast } = useDashboard();
+  const { showConfirm } = useDialog();
+  const {
+    quizzes: plcQuizzes,
+    loading,
+    unshareQuizFromPlc,
+  } = usePlcQuizzes(plc.id);
+  const {
+    quizzes: personalQuizzes,
+    saveQuiz,
+    deleteQuiz,
+    attachSyncLinkage,
+    isDriveConnected,
+  } = useQuiz(user?.uid);
+
+  const [importTarget, setImportTarget] = useState<ImportTarget | null>(null);
+  const [busyRowId, setBusyRowId] = useState<string | null>(null);
+
+  // Map of syncGroupId → personal quiz that already carries this linkage.
+  // Used to render the "In your library" badge and to skip a redundant
+  // re-import.
+  const personalBySyncGroup = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const q of personalQuizzes) {
+      if (q.sync?.groupId) map.set(q.sync.groupId, q.id);
+    }
+    return map;
+  }, [personalQuizzes]);
+
+  const handleImport = useCallback(
+    async (target: ImportTarget, mode: SharedAssignmentImportMode) => {
+      if (!user) return;
+      if (!isDriveConnected) {
+        addToast(
+          t('plcDashboard.quizLibrary.driveRequired', {
+            defaultValue:
+              'Connect Google Drive in your account to import PLC quizzes.',
+          }),
+          'error'
+        );
+        return;
+      }
+
+      // Short-circuit a redundant Sync re-import: a personal quiz is
+      // already linked to this synced group, so writing a fresh copy
+      // would just duplicate it. (Copy mode is allowed to fall through —
+      // the user explicitly asked for a snapshot.)
+      if (mode === 'sync' && personalBySyncGroup.has(target.syncGroupId)) {
+        setImportTarget(null);
+        addToast(
+          t('plcDashboard.quizLibrary.alreadySynced', {
+            title: target.title,
+            defaultValue: '"{{title}}" is already synced to your library.',
+          }),
+          'info'
+        );
+        return;
+      }
+
+      setImportTarget(null);
+      setBusyRowId(target.plcQuizId);
+      let savedMeta: Awaited<ReturnType<typeof saveQuiz>> | null = null;
+      let joinedGroupId: string | null = null;
+      try {
+        const canonical = await pullSyncedQuizContent(target.syncGroupId);
+        const now = Date.now();
+        const fresh: QuizData = {
+          id: crypto.randomUUID(),
+          title: canonical.title,
+          questions: canonical.questions,
+          createdAt: now,
+          updatedAt: now,
+        };
+        savedMeta = await saveQuiz(fresh);
+        if (mode === 'sync') {
+          // Server-side participant write must precede the client-side
+          // attachSyncLinkage so a later editor save doesn't try to
+          // publish from a non-participant context.
+          const joinResult = await callJoinPlcQuizSyncGroup(
+            plc.id,
+            target.plcQuizId
+          );
+          joinedGroupId = joinResult.groupId;
+          // Prefer the higher of canonical.version (read at pull time)
+          // and joinResult.version (read inside the join transaction).
+          // If a peer published between those two reads, joinResult.version
+          // is fresher — using only canonical.version would tag the new
+          // local copy as already-stale and surface a false "Sync available"
+          // prompt right after import.
+          const liveVersion = Math.max(canonical.version, joinResult.version);
+          await attachSyncLinkage(savedMeta.id, {
+            groupId: target.syncGroupId,
+            lastSyncedVersion: liveVersion,
+          });
+          addToast(
+            t('plcDashboard.quizLibrary.importedSync', {
+              title: target.title,
+              defaultValue: '"{{title}}" added to your library (synced).',
+            }),
+            'success'
+          );
+        } else {
+          addToast(
+            t('plcDashboard.quizLibrary.importedCopy', {
+              title: target.title,
+              defaultValue: '"{{title}}" copied to your library.',
+            }),
+            'success'
+          );
+        }
+      } catch (err) {
+        logError('PlcQuizLibraryTab.import', err, {
+          plcId: plc.id,
+          plcQuizId: target.plcQuizId,
+          mode,
+        });
+        // Best-effort rollback so a partial failure (join or attach)
+        // doesn't leave an orphan personal quiz / phantom participant
+        // entry behind. Mirrors the shared-assignment importer's shape.
+        if (joinedGroupId) {
+          try {
+            await callLeaveSyncedQuizGroup(joinedGroupId);
+          } catch (leaveErr) {
+            logError('PlcQuizLibraryTab.import.rollbackLeave', leaveErr, {
+              plcId: plc.id,
+              groupId: joinedGroupId,
+            });
+          }
+        }
+        if (savedMeta) {
+          try {
+            await deleteQuiz(savedMeta.id, savedMeta.driveFileId);
+          } catch (rollbackErr) {
+            logError('PlcQuizLibraryTab.import.rollbackQuiz', rollbackErr, {
+              plcId: plc.id,
+              quizId: savedMeta.id,
+              driveFileId: savedMeta.driveFileId,
+            });
+          }
+        }
+        addToast(
+          err instanceof Error
+            ? err.message
+            : t('plcDashboard.quizLibrary.importFailed', {
+                defaultValue: 'Failed to import quiz.',
+              }),
+          'error'
+        );
+      } finally {
+        setBusyRowId(null);
+      }
+    },
+    [
+      addToast,
+      attachSyncLinkage,
+      deleteQuiz,
+      isDriveConnected,
+      personalBySyncGroup,
+      plc.id,
+      saveQuiz,
+      t,
+      user,
+    ]
+  );
+
+  const handleUnshare = useCallback(
+    async (plcQuizId: string, title: string) => {
+      const confirmed = await showConfirm(
+        t('plcDashboard.quizLibrary.unshareConfirm', {
+          title,
+          defaultValue:
+            'Remove "{{title}}" from this PLC? Other teammates will lose access to the shared library entry. Their personal copies (if any) keep working.',
+        }),
+        {
+          title: t('plcDashboard.quizLibrary.unshareTitle', {
+            defaultValue: 'Unshare quiz',
+          }),
+          variant: 'warning',
+          confirmLabel: t('plcDashboard.quizLibrary.unshareAction', {
+            defaultValue: 'Unshare',
+          }),
+        }
+      );
+      if (!confirmed) return;
+      setBusyRowId(plcQuizId);
+      try {
+        await unshareQuizFromPlc(plcQuizId);
+        addToast(
+          t('plcDashboard.quizLibrary.unshared', {
+            title,
+            defaultValue: '"{{title}}" removed from this PLC.',
+          }),
+          'success'
+        );
+      } catch (err) {
+        logError('PlcQuizLibraryTab.unshare', err, {
+          plcId: plc.id,
+          plcQuizId,
+        });
+        addToast(
+          err instanceof Error
+            ? err.message
+            : t('plcDashboard.quizLibrary.unshareFailed', {
+                defaultValue: 'Failed to unshare quiz.',
+              }),
+          'error'
+        );
+      } finally {
+        setBusyRowId(null);
+      }
+    },
+    [addToast, plc.id, showConfirm, t, unshareQuizFromPlc]
+  );
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center h-full min-h-[200px] text-slate-400">
+        <Loader2 className="w-5 h-5 animate-spin" />
+      </div>
+    );
+  }
+
+  if (plcQuizzes.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center h-full min-h-[300px] px-6 text-center">
+        <div className="w-16 h-16 rounded-2xl bg-slate-100 flex items-center justify-center mb-5">
+          <BookOpen className="w-7 h-7 text-slate-400" />
+        </div>
+        <h3 className="text-lg font-bold text-slate-700 mb-2">
+          {t('plcDashboard.quizLibrary.emptyTitle', {
+            defaultValue: 'No shared quizzes yet',
+          })}
+        </h3>
+        <p className="text-sm text-slate-500 max-w-md leading-relaxed">
+          {t('plcDashboard.quizLibrary.emptySubtitle', {
+            defaultValue:
+              'Open the Quiz widget in your dashboard, click the kebab on any quiz, and choose "Share with PLC" to add it here.',
+          })}
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-3 px-1">
+      <div className="flex items-baseline justify-between mb-1">
+        <h3 className="text-xs font-bold text-slate-400 uppercase tracking-widest">
+          {t('plcDashboard.quizLibrary.heading', {
+            defaultValue: 'Shared Quizzes',
+          })}
+        </h3>
+        <span className="text-xxs text-slate-400">
+          {t('plcDashboard.quizLibrary.count', {
+            count: plcQuizzes.length,
+            defaultValue: '{{count}} quiz',
+            defaultValue_other: '{{count}} quizzes',
+          })}
+        </span>
+      </div>
+      <div className="flex flex-col gap-2">
+        {plcQuizzes.map((quiz) => {
+          const isMine = quiz.sharedBy === user?.uid;
+          const ownerLabel =
+            quiz.sharedByName?.trim() ||
+            quiz.sharedByEmail ||
+            t('plcDashboard.quizLibrary.unknownSharer', {
+              defaultValue: 'a teammate',
+            });
+          const inLibrary = personalBySyncGroup.has(quiz.syncGroupId);
+          const isBusy = busyRowId === quiz.id;
+          return (
+            <div
+              key={quiz.id}
+              className="flex items-center gap-3 p-3 bg-white border border-slate-200 hover:border-brand-blue-light rounded-xl transition-colors"
+            >
+              <div className="shrink-0 w-10 h-10 rounded-lg bg-brand-blue-lighter flex items-center justify-center">
+                <BookOpen className="w-4 h-4 text-brand-blue-primary" />
+              </div>
+              <div className="flex-1 min-w-0">
+                <div className="flex items-center gap-2 flex-wrap">
+                  <div className="text-sm font-bold text-slate-800 truncate">
+                    {quiz.title}
+                  </div>
+                  {inLibrary && (
+                    <span className="inline-flex items-center gap-1 rounded-full bg-emerald-100 px-2 py-0.5 text-[10px] font-bold uppercase tracking-wider text-emerald-700">
+                      <Cloud className="w-3 h-3" />
+                      {t('plcDashboard.quizLibrary.inLibrary', {
+                        defaultValue: 'In your library',
+                      })}
+                    </span>
+                  )}
+                </div>
+                <div className="text-xxs text-slate-500 mt-0.5 flex items-center gap-2 flex-wrap">
+                  <span className="truncate flex items-center gap-1">
+                    <Users2 className="w-3 h-3" />
+                    {t('plcDashboard.quizLibrary.bySharer', {
+                      name: ownerLabel,
+                      defaultValue: 'shared by {{name}}',
+                    })}
+                  </span>
+                  <span className="text-slate-300">•</span>
+                  <span>
+                    {t('plcDashboard.quizLibrary.questionCount', {
+                      count: quiz.questionCount,
+                      defaultValue: '{{count}} question',
+                      defaultValue_other: '{{count}} questions',
+                    })}
+                  </span>
+                  <span className="text-slate-300">•</span>
+                  <span>{formatDate(quiz.updatedAt)}</span>
+                </div>
+              </div>
+              <div className="shrink-0 flex items-center gap-1.5">
+                <button
+                  type="button"
+                  onClick={() =>
+                    setImportTarget({
+                      plcQuizId: quiz.id,
+                      syncGroupId: quiz.syncGroupId,
+                      title: quiz.title,
+                      sharedByName: quiz.sharedByName,
+                    })
+                  }
+                  disabled={isBusy}
+                  className="flex items-center gap-1.5 px-3 py-1.5 bg-brand-blue-lighter hover:bg-brand-blue-light/30 text-brand-blue-primary rounded-lg text-xxs font-bold uppercase tracking-wider transition-colors disabled:opacity-40"
+                  title={
+                    inLibrary
+                      ? t('plcDashboard.quizLibrary.reimport', {
+                          defaultValue: 'Re-import',
+                        })
+                      : t('plcDashboard.quizLibrary.addToMyLibrary', {
+                          defaultValue: 'Add to my library',
+                        })
+                  }
+                >
+                  {isBusy ? (
+                    <Loader2 className="w-3 h-3 animate-spin" />
+                  ) : (
+                    <Download className="w-3 h-3" />
+                  )}
+                  <span className="hidden sm:inline">
+                    {inLibrary
+                      ? t('plcDashboard.quizLibrary.reimport', {
+                          defaultValue: 'Re-import',
+                        })
+                      : t('plcDashboard.quizLibrary.addToMyLibrary', {
+                          defaultValue: 'Add to my library',
+                        })}
+                  </span>
+                </button>
+                <button
+                  type="button"
+                  onClick={() => void handleUnshare(quiz.id, quiz.title)}
+                  disabled={isBusy}
+                  aria-label={t('plcDashboard.quizLibrary.unshareAction', {
+                    defaultValue: 'Unshare',
+                  })}
+                  title={
+                    isMine
+                      ? t('plcDashboard.quizLibrary.unshareYours', {
+                          defaultValue: 'Unshare from PLC',
+                        })
+                      : t('plcDashboard.quizLibrary.unshareTeammate', {
+                          defaultValue:
+                            'Unshare from PLC (any member can remove)',
+                        })
+                  }
+                  className="p-1.5 rounded-lg text-slate-400 hover:bg-red-50 hover:text-red-600 transition-colors disabled:opacity-40"
+                >
+                  <Trash2 className="w-3.5 h-3.5" />
+                </button>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+      {!isDriveConnected && (
+        <div className="mt-2 px-3 py-2 bg-amber-50 border border-amber-200 rounded-lg flex items-start gap-2">
+          <ExternalLink className="w-4 h-4 text-amber-700 mt-0.5 shrink-0" />
+          <p className="text-xs text-amber-800">
+            {t('plcDashboard.quizLibrary.driveDisconnected', {
+              defaultValue:
+                'Connect Google Drive to import PLC quizzes into your personal library.',
+            })}
+          </p>
+        </div>
+      )}
+      {importTarget && (
+        <PlcQuizImportModal
+          quizTitle={importTarget.title}
+          sharedByName={importTarget.sharedByName}
+          onPick={(mode) => void handleImport(importTarget, mode)}
+          onClose={() => setImportTarget(null)}
+        />
+      )}
+    </div>
+  );
+};

--- a/components/student/StudentContexts.tsx
+++ b/components/student/StudentContexts.tsx
@@ -284,6 +284,13 @@ const mockDashboard: DashboardContextValue = {
   clearPendingAssignmentShare: () => {
     // No-op
   },
+  pendingVideoActivityShareId: null,
+  setPendingVideoActivityShareId: () => {
+    // No-op
+  },
+  clearPendingVideoActivityShare: () => {
+    // No-op
+  },
   pendingAssignmentSetupId: null,
   setPendingAssignmentSetup: () => {
     // No-op — student view never imports assignments.

--- a/components/widgets/QuizWidget/Widget.tsx
+++ b/components/widgets/QuizWidget/Widget.tsx
@@ -38,7 +38,7 @@ import { QuizPreview } from './components/QuizPreview';
 import { QuizResults } from './components/QuizResults';
 import { QuizAssignmentSettingsModal } from './components/QuizAssignmentSettingsModal';
 import { QuizAssignmentImportSetupModal } from './components/QuizAssignmentImportSetupModal';
-import { PublishScoresModal } from './components/PublishScoresModal';
+import { PublishScoresModal } from '@/components/common/library/PublishScoresModal';
 import type { QuizAssignment } from '@/types';
 import {
   buildPinToNameMap,
@@ -1784,7 +1784,7 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
       )}
       {publishingAssignment && (
         <PublishScoresModal
-          quizTitle={publishingAssignment.quizTitle}
+          assignmentTitle={publishingAssignment.quizTitle}
           currentVisibility={publishingAssignment.scoreVisibility}
           onClose={() => setPublishingAssignment(null)}
           onConfirm={async (visibility) => {

--- a/components/widgets/QuizWidget/Widget.tsx
+++ b/components/widgets/QuizWidget/Widget.tsx
@@ -23,7 +23,13 @@ import {
 } from '@/hooks/useQuizSession';
 import { useQuizAssignments } from '@/hooks/useQuizAssignments';
 import { useFolders } from '@/hooks/useFolders';
-import { useSyncedQuizGroupsByIds } from '@/hooks/useSyncedQuizGroups';
+import {
+  callLeaveSyncedQuizGroup,
+  createSyncedQuizGroup,
+  useSyncedQuizGroupsByIds,
+} from '@/hooks/useSyncedQuizGroups';
+import { writePlcQuizEntry } from '@/hooks/usePlcQuizzes';
+import { PlcShareTargetModal } from '@/components/plc/PlcShareTargetModal';
 import { QuizManager, PlcOptions } from './components/QuizManager';
 import { ImportWizard } from '@/components/common/library/importer';
 import { createQuizImportAdapter } from './adapters/quizImportAdapter';
@@ -107,6 +113,7 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
     shareQuiz,
     pullSyncedQuiz,
     detachSyncedQuiz,
+    attachSyncLinkage,
     isDriveConnected,
   } = useQuiz(user?.uid);
 
@@ -200,6 +207,11 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
   const [editingQuiz, setEditingQuiz] = useState<QuizData | null>(null);
   const [editingMeta, setEditingMeta] = useState<QuizMetadata | null>(null);
 
+  // "Share with PLC" target — when set, the PlcShareTargetModal is open
+  // for this quiz. Phase 2.
+  const [shareWithPlcTarget, setShareWithPlcTarget] =
+    useState<QuizMetadata | null>(null);
+
   const setView = useCallback(
     (view: QuizConfig['view']) => {
       updateWidget(widget.id, { config: { ...config, view } as QuizConfig });
@@ -225,6 +237,87 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
       }
     },
     [loadQuizData, addToast]
+  );
+
+  /**
+   * Phase 2 — share an existing personal quiz with a chosen PLC.
+   *
+   * Order of operations:
+   *   1. Load the quiz content from Drive (needed to seed the canonical
+   *      synced group on first share).
+   *   2. If the quiz isn't yet part of a synced group, mint a fresh group
+   *      with `plcId` set, then attach the linkage to the local
+   *      `quiz_metadata` so subsequent edits publish (LWW) for every
+   *      member who imports. If `attachSyncLinkage` fails, leave the
+   *      freshly-minted group via `callLeaveSyncedQuizGroup` so we don't
+   *      leave a phantom participant entry — the empty group itself
+   *      stays (synced_quizzes rules intentionally don't delete empty
+   *      groups; future paste of the same id should still resolve).
+   *   3. Write the `plcs/{plcId}/quizzes/{plcQuizId}` header. Doc id is a
+   *      fresh uuid so the same quiz can be shared with multiple PLCs
+   *      without doc-id collisions.
+   *
+   * If step 3 fails after step 2 succeeded, the synced group + sync
+   * linkage stay in place — the canonical doc is reachable from the
+   * user's library card as the "Synced" pill (self-only group), and a
+   * retry of "Share with PLC" reuses the existing groupId rather than
+   * minting a new one. Idempotent on retry.
+   */
+  const handleShareWithPlc = useCallback(
+    async (quizMeta: QuizMetadata, plcId: string): Promise<void> => {
+      if (!user) throw new Error('Not authenticated.');
+      const plc = plcs.find((p) => p.id === plcId);
+      if (!plc) {
+        throw new Error('That PLC is no longer available.');
+      }
+      const data = await loadQuizData(quizMeta.driveFileId);
+
+      let syncGroupId: string;
+      if (quizMeta.sync) {
+        syncGroupId = quizMeta.sync.groupId;
+      } else {
+        syncGroupId = crypto.randomUUID();
+        await createSyncedQuizGroup({
+          groupId: syncGroupId,
+          uid: user.uid,
+          title: data.title,
+          questions: data.questions,
+          plcId,
+        });
+        try {
+          await attachSyncLinkage(quizMeta.id, {
+            groupId: syncGroupId,
+            lastSyncedVersion: 1,
+          });
+        } catch (linkageErr) {
+          // Best-effort: drop our self-participant entry on the
+          // freshly-minted group so we don't leave a phantom participant
+          // pointing at a sync group the local library never knew about.
+          try {
+            await callLeaveSyncedQuizGroup(syncGroupId);
+          } catch (leaveErr) {
+            logError('QuizWidget.shareWithPlc.rollbackLeave', leaveErr, {
+              plcId,
+              syncGroupId,
+            });
+          }
+          throw linkageErr;
+        }
+      }
+
+      const ownerEmailLower =
+        plc.memberEmails?.[user.uid] ??
+        (user.email ? user.email.toLowerCase() : '');
+      await writePlcQuizEntry(plcId, user.uid, {
+        plcQuizId: crypto.randomUUID(),
+        syncGroupId,
+        title: data.title,
+        questionCount: data.questions.length,
+        sharedByName: user.displayName ?? '',
+        sharedByEmail: ownerEmailLower,
+      });
+    },
+    [attachSyncLinkage, loadQuizData, plcs, user]
   );
 
   // Drop any pending import-setup prompt when the QuizWidget unmounts.
@@ -1128,6 +1221,16 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
             addToast(`Share link: ${url}`, 'info');
           }
         }}
+        onShareWithPlc={(meta) => {
+          if (plcs.length === 0) {
+            addToast(
+              'Join a PLC from the My PLCs sidebar to share quizzes with teammates.',
+              'info'
+            );
+            return;
+          }
+          setShareWithPlcTarget(meta);
+        }}
         onCreateViewOnlyShare={async (meta) => {
           // View-only Quiz share — bypasses the AssignModal/picker/PLC flow
           // entirely. Creates a minimal assignment with view-only mode so
@@ -1786,6 +1889,30 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
             />
           );
         })()}
+      {shareWithPlcTarget && (
+        <PlcShareTargetModal
+          plcs={plcs}
+          quizTitle={shareWithPlcTarget.title}
+          onConfirm={async (plcId) => {
+            try {
+              await handleShareWithPlc(shareWithPlcTarget, plcId);
+              const plcName =
+                plcs.find((p) => p.id === plcId)?.name ?? 'your PLC';
+              addToast(`Shared with ${plcName}.`, 'success');
+              setShareWithPlcTarget(null);
+            } catch (err) {
+              logError('QuizWidget.shareWithPlc', err, {
+                plcId,
+                quizId: shareWithPlcTarget.id,
+              });
+              throw err instanceof Error
+                ? err
+                : new Error('Share with PLC failed.');
+            }
+          }}
+          onClose={() => setShareWithPlcTarget(null)}
+        />
+      )}
     </>
   );
 };

--- a/components/widgets/QuizWidget/components/QuizManager.tsx
+++ b/components/widgets/QuizWidget/components/QuizManager.tsx
@@ -47,6 +47,7 @@ import {
   CheckSquare,
   Cloud,
   CloudOff,
+  Users2,
 } from 'lucide-react';
 import {
   AssignmentMode,
@@ -288,6 +289,14 @@ interface QuizManagerProps {
    */
   onBulkDelete?: (quizzes: QuizMetadata[]) => Promise<boolean>;
   onShare: (quiz: QuizMetadata) => void;
+  /**
+   * Phase 2 — "Share with PLC". Invoked when the teacher picks the new
+   * kebab item on a library card. The Widget owns the modal + the actual
+   * share write (creating the synced group + the PLC subcoll doc); this
+   * surface only triggers it. Kebab item is hidden when this prop is
+   * omitted (e.g. test harnesses).
+   */
+  onShareWithPlc?: (quiz: QuizMetadata) => void;
   rosters: ClassRoster[];
   config: QuizConfig;
 
@@ -455,6 +464,7 @@ export const QuizManager: React.FC<QuizManagerProps> = ({
   onDelete,
   onBulkDelete,
   onShare,
+  onShareWithPlc,
   rosters,
   config,
   managerTab = 'library',
@@ -754,6 +764,14 @@ export const QuizManager: React.FC<QuizManagerProps> = ({
         disabled: !userId,
       })
     );
+    if (onShareWithPlc) {
+      actions.push({
+        id: 'share-with-plc',
+        label: 'Share with PLC',
+        icon: Users2,
+        onClick: () => onShareWithPlc(quiz),
+      });
+    }
     actions.push({
       id: 'delete',
       label: 'Delete',

--- a/components/widgets/QuizWidget/components/QuizResults.tsx
+++ b/components/widgets/QuizWidget/components/QuizResults.tsx
@@ -57,7 +57,7 @@ import {
 import { resolveResponseDisplayName } from '../utils/resolveDisplayName';
 import { useClickOutside } from '@/hooks/useClickOutside';
 import { useAssignmentPseudonyms } from '@/hooks/useAssignmentPseudonyms';
-import { PlcTab } from './PlcTab';
+import { PlcTab } from '@/components/common/library/PlcTab';
 
 interface QuizResultsProps {
   quiz: QuizData;

--- a/components/widgets/VideoActivityWidget/Widget.tsx
+++ b/components/widgets/VideoActivityWidget/Widget.tsx
@@ -12,12 +12,14 @@ import {
   WidgetData,
   VideoActivityConfig,
   VideoActivityView,
+  VideoActivityAssignment,
   VideoActivityMetadata,
   VideoActivityData,
   VideoActivitySessionSettings,
   VideoActivityGlobalConfig,
   VideoActivitySession,
 } from '@/types';
+import { PublishScoresModal } from '@/components/common/library/PublishScoresModal';
 import { useDashboard } from '@/context/useDashboard';
 import { useAuth } from '@/context/useAuth';
 import { useVideoActivity } from '@/hooks/useVideoActivity';
@@ -104,7 +106,11 @@ export const VideoActivityWidget: React.FC<{ widget: WidgetData }> = ({
     reactivateAssignment,
     deleteAssignment,
     shareAssignment,
+    publishAssignmentScores,
   } = useVideoActivityAssignments(user?.uid);
+
+  const [publishingAssignment, setPublishingAssignment] =
+    useState<VideoActivityAssignment | null>(null);
 
   const [loadingActivity, setLoadingActivity] = useState(false);
   const [selectedSession, setSelectedSession] =
@@ -318,10 +324,14 @@ export const VideoActivityWidget: React.FC<{ widget: WidgetData }> = ({
   }
 
   if (view === 'results' && selectedSession) {
+    const resultsAssignment = assignments.find(
+      (a) => a.id === selectedSession.id
+    );
     return (
       <Results
         session={selectedSession}
         responses={responses}
+        plc={resultsAssignment?.plc}
         onBack={() => {
           unsubscribeFromSession();
           setSelectedSession(null);
@@ -705,6 +715,9 @@ export const VideoActivityWidget: React.FC<{ widget: WidgetData }> = ({
             } as VideoActivityConfig,
           });
         }}
+        onArchivePublishScores={(assignment) =>
+          setPublishingAssignment(assignment)
+        }
         initialLibraryViewMode={config.libraryViewMode}
         onLibraryViewModeChange={(mode) => {
           updateWidget(widget.id, {
@@ -712,6 +725,65 @@ export const VideoActivityWidget: React.FC<{ widget: WidgetData }> = ({
           });
         }}
       />
+      {publishingAssignment && (
+        <PublishScoresModal
+          assignmentTitle={
+            publishingAssignment.className ?? publishingAssignment.activityTitle
+          }
+          currentVisibility={publishingAssignment.scoreVisibility}
+          onClose={() => setPublishingAssignment(null)}
+          onConfirm={async (visibility) => {
+            const target = publishingAssignment;
+            try {
+              if (visibility === 'none') {
+                await publishAssignmentScores(
+                  target.id,
+                  // Empty placeholder VideoActivityData — the 'none' branch
+                  // never reads it. Cheaper than re-loading from Drive for
+                  // a flag flip.
+                  {
+                    id: target.activityId,
+                    title: target.activityTitle,
+                    youtubeUrl: '',
+                    questions: [],
+                    createdAt: 0,
+                    updatedAt: 0,
+                  },
+                  visibility
+                );
+                addToast('Scores unpublished.', 'success');
+                setPublishingAssignment(null);
+                return;
+              }
+              const data = await loadActivityData(target.activityDriveFileId);
+              if (!data) {
+                addToast(
+                  'Activity content unavailable — cannot publish scores.',
+                  'error'
+                );
+                return;
+              }
+              const result = await publishAssignmentScores(
+                target.id,
+                data,
+                visibility
+              );
+              addToast(
+                result.responsesUpdated > 0
+                  ? `Scores published to ${result.responsesUpdated} student${result.responsesUpdated === 1 ? '' : 's'}.`
+                  : 'Scores published. Students will see results once they submit.',
+                'success'
+              );
+              setPublishingAssignment(null);
+            } catch (err) {
+              addToast(
+                err instanceof Error ? err.message : 'Failed to publish scores',
+                'error'
+              );
+            }
+          }}
+        />
+      )}
       <VideoActivityEditorModal
         isOpen={!!editingActivity}
         activity={editingActivity}

--- a/components/widgets/VideoActivityWidget/Widget.tsx
+++ b/components/widgets/VideoActivityWidget/Widget.tsx
@@ -103,6 +103,7 @@ export const VideoActivityWidget: React.FC<{ widget: WidgetData }> = ({
     deactivateAssignment,
     reactivateAssignment,
     deleteAssignment,
+    shareAssignment,
   } = useVideoActivityAssignments(user?.uid);
 
   const [loadingActivity, setLoadingActivity] = useState(false);
@@ -577,6 +578,29 @@ export const VideoActivityWidget: React.FC<{ widget: WidgetData }> = ({
           } catch (err) {
             addToast(
               err instanceof Error ? err.message : 'Delete failed',
+              'error'
+            );
+          }
+        }}
+        onArchiveShare={async (assignment) => {
+          // Hydrate the activity from Drive (Manager doesn't keep full
+          // question content) so shareAssignment can inline the questions
+          // into the share doc + canonical synced group.
+          try {
+            const data = await loadActivityData(assignment.activityDriveFileId);
+            if (!data) {
+              addToast('Could not load activity content for sharing.', 'error');
+              return;
+            }
+            const url = await shareAssignment(assignment.id, data);
+            await copyUrlToClipboard(url, addToast, {
+              successMessage: 'Share link copied! Send it to a peer teacher.',
+              errorMessage:
+                'Share link created, but it could not be copied. Visit the assignment to grab the link.',
+            });
+          } catch (err) {
+            addToast(
+              err instanceof Error ? err.message : 'Share failed',
               'error'
             );
           }

--- a/components/widgets/VideoActivityWidget/components/Creator.tsx
+++ b/components/widgets/VideoActivityWidget/components/Creator.tsx
@@ -1,6 +1,15 @@
 /**
  * Creator — Video Activity creation orchestrator.
- * Supports Manual creation, CSV/Sheets Import, and AI Generation (admin-gated).
+ *
+ * Three discovery paths in the `info` step:
+ *   - **Search**: type a query, hit Enter/Search button, pick from
+ *     YouTube Data API v3 results. (Search button only — no debounce-on-
+ *     keystroke — to keep daily quota under the 10k unit cap.)
+ *   - **Paste URL**: classic flow, paste a YouTube URL.
+ *   - **Recommend**: describe a topic/objective, Gemini suggests a video.
+ *
+ * After a video is chosen the rest of the flow (manual / import / AI
+ * draft) is unchanged from PR2a.
  */
 
 import React, { useState } from 'react';
@@ -9,12 +18,23 @@ import {
   Youtube,
   FileSpreadsheet,
   PlusCircle,
+  Search as SearchIcon,
   Sparkles,
   Loader2,
   AlertCircle,
+  Wand2,
+  Check,
 } from 'lucide-react';
 import { VideoActivityData } from '@/types';
-import { generateVideoActivity } from '@/utils/ai';
+import { generateVideoActivity, recommendVideoForActivity } from '@/utils/ai';
+import {
+  searchYouTube,
+  formatDuration,
+  YouTubeKeyMissingError,
+  YouTubeQuotaError,
+  type YouTubeSearchResult,
+} from '@/utils/youtubeSearch';
+import { extractYouTubeId } from '@/utils/youtube';
 import { ImportWizard } from '@/components/common/library/importer';
 import { createVideoActivityImportAdapter } from '../adapters/videoActivityImportAdapter';
 
@@ -28,6 +48,7 @@ interface CreatorProps {
 }
 
 type Step = 'info' | 'source' | 'ai' | 'import';
+type DiscoverTab = 'search' | 'paste' | 'recommend';
 
 export const Creator: React.FC<CreatorProps> = ({
   onBack,
@@ -37,11 +58,29 @@ export const Creator: React.FC<CreatorProps> = ({
   createTemplateSheet,
 }) => {
   const [step, setStep] = useState<Step>('info');
+  const [discoverTab, setDiscoverTab] = useState<DiscoverTab>('paste');
   const [url, setUrl] = useState('');
   const [title, setTitle] = useState('');
   const [questionCount, setQuestionCount] = useState(5);
   const [isGenerating, setIsGenerating] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  // Search-tab state
+  const [searchQuery, setSearchQuery] = useState('');
+  const [searchResults, setSearchResults] = useState<YouTubeSearchResult[]>([]);
+  const [searching, setSearching] = useState(false);
+  const [searchError, setSearchError] = useState<string | null>(null);
+  const [hasSearched, setHasSearched] = useState(false);
+
+  // Recommend-tab state
+  const [recommendTopic, setRecommendTopic] = useState('');
+  const [recommending, setRecommending] = useState(false);
+  const [recommendError, setRecommendError] = useState<string | null>(null);
+  const [recommendation, setRecommendation] = useState<{
+    videoId: string;
+    title: string;
+    rationale: string;
+  } | null>(null);
 
   // Allow AI if explicitly enabled OR if user is admin
   const canUseAI = aiEnabled || isAdmin;
@@ -51,8 +90,80 @@ export const Creator: React.FC<CreatorProps> = ({
       setError('Title and YouTube URL are required.');
       return;
     }
+    if (!extractYouTubeId(url.trim())) {
+      setError(
+        'That doesn’t look like a YouTube URL. Paste a youtube.com or youtu.be link.'
+      );
+      return;
+    }
     setError(null);
     setStep('source');
+  };
+
+  const handleSearch = async () => {
+    const q = searchQuery.trim();
+    if (q.length === 0) return;
+    setSearching(true);
+    setSearchError(null);
+    setHasSearched(true);
+    try {
+      const results = await searchYouTube(q, 10);
+      setSearchResults(results);
+    } catch (err) {
+      if (err instanceof YouTubeKeyMissingError) {
+        setSearchError(
+          'YouTube search isn’t configured. Paste a URL or ask Gemini to recommend one instead.'
+        );
+      } else if (err instanceof YouTubeQuotaError) {
+        setSearchError(
+          'YouTube search quota is exhausted for today. Paste a URL or use the recommend tab.'
+        );
+      } else {
+        setSearchError(
+          err instanceof Error ? err.message : 'YouTube search failed.'
+        );
+      }
+      setSearchResults([]);
+    } finally {
+      setSearching(false);
+    }
+  };
+
+  const pickResult = (result: YouTubeSearchResult) => {
+    setUrl(`https://www.youtube.com/watch?v=${result.videoId}`);
+    if (!title.trim()) setTitle(result.title);
+    setDiscoverTab('paste');
+  };
+
+  const handleRecommend = async () => {
+    const topic = recommendTopic.trim();
+    if (topic.length === 0) return;
+    setRecommending(true);
+    setRecommendError(null);
+    setRecommendation(null);
+    try {
+      const result = await recommendVideoForActivity(topic);
+      if (!result || result.videoId.length === 0) {
+        setRecommendError(
+          'Gemini couldn’t confidently recommend a video for that topic. Try rephrasing or describing a grade level.'
+        );
+      } else {
+        setRecommendation(result);
+      }
+    } catch (err) {
+      setRecommendError(
+        err instanceof Error ? err.message : 'Recommendation failed. Try again.'
+      );
+    } finally {
+      setRecommending(false);
+    }
+  };
+
+  const acceptRecommendation = () => {
+    if (!recommendation) return;
+    setUrl(`https://www.youtube.com/watch?v=${recommendation.videoId}`);
+    if (!title.trim() && recommendation.title) setTitle(recommendation.title);
+    setDiscoverTab('paste');
   };
 
   const handleManualCreate = async () => {
@@ -163,19 +274,101 @@ export const Creator: React.FC<CreatorProps> = ({
 
                 <div>
                   <label className="block text-xxs font-bold text-slate-400 uppercase tracking-widest mb-1.5 ml-1">
-                    YouTube URL
+                    YouTube Video
                   </label>
-                  <div className="relative">
-                    <Youtube className="absolute left-4 top-1/2 -translate-y-1/2 w-5 h-5 text-red-500" />
-                    <input
-                      type="url"
-                      value={url}
-                      onChange={(e) => setUrl(e.target.value)}
-                      placeholder="https://www.youtube.com/watch?v=..."
-                      className="w-full pl-12 pr-4 py-3 bg-white border-2 border-slate-200 rounded-2xl text-slate-800 font-medium focus:outline-none focus:border-brand-blue-primary transition-all shadow-sm"
-                      style={{ fontSize: 'min(13px, 3.5cqmin)' }}
-                    />
+                  {/* Discover-tab selector */}
+                  <div
+                    role="tablist"
+                    aria-label="Find a video"
+                    className="inline-flex w-full rounded-xl border border-slate-200 bg-white overflow-hidden mb-3"
+                  >
+                    {[
+                      {
+                        id: 'search' as const,
+                        label: 'Search',
+                        Icon: SearchIcon,
+                      },
+                      {
+                        id: 'paste' as const,
+                        label: 'Paste URL',
+                        Icon: Youtube,
+                      },
+                      {
+                        id: 'recommend' as const,
+                        label: 'Recommend',
+                        Icon: Wand2,
+                      },
+                    ].map(({ id, label, Icon }) => {
+                      const active = discoverTab === id;
+                      return (
+                        <button
+                          key={id}
+                          role="tab"
+                          aria-selected={active}
+                          onClick={() => setDiscoverTab(id)}
+                          className={
+                            'flex-1 font-bold transition-colors flex items-center justify-center gap-1.5 ' +
+                            (active
+                              ? 'bg-brand-blue-primary text-white'
+                              : 'text-slate-600 hover:bg-slate-50')
+                          }
+                          style={{
+                            padding: 'min(8px, 2cqmin) min(12px, 2.5cqmin)',
+                            fontSize: 'min(12px, 3.5cqmin)',
+                          }}
+                        >
+                          <Icon
+                            style={{
+                              width: 'min(14px, 4cqmin)',
+                              height: 'min(14px, 4cqmin)',
+                            }}
+                          />
+                          {label}
+                        </button>
+                      );
+                    })}
                   </div>
+
+                  {discoverTab === 'paste' && (
+                    <div className="relative">
+                      <Youtube className="absolute left-4 top-1/2 -translate-y-1/2 w-5 h-5 text-red-500" />
+                      <input
+                        type="url"
+                        value={url}
+                        onChange={(e) => setUrl(e.target.value)}
+                        placeholder="https://www.youtube.com/watch?v=..."
+                        className="w-full pl-12 pr-4 py-3 bg-white border-2 border-slate-200 rounded-2xl text-slate-800 font-medium focus:outline-none focus:border-brand-blue-primary transition-all shadow-sm"
+                        style={{ fontSize: 'min(13px, 3.5cqmin)' }}
+                      />
+                    </div>
+                  )}
+
+                  {discoverTab === 'search' && (
+                    <SearchTab
+                      query={searchQuery}
+                      onQueryChange={setSearchQuery}
+                      onSubmit={handleSearch}
+                      results={searchResults}
+                      searching={searching}
+                      hasSearched={hasSearched}
+                      error={searchError}
+                      onPick={pickResult}
+                      pickedUrl={url}
+                    />
+                  )}
+
+                  {discoverTab === 'recommend' && (
+                    <RecommendTab
+                      topic={recommendTopic}
+                      onTopicChange={setRecommendTopic}
+                      onSubmit={handleRecommend}
+                      recommending={recommending}
+                      error={recommendError}
+                      recommendation={recommendation}
+                      onAccept={acceptRecommendation}
+                      pickedUrl={url}
+                    />
+                  )}
                 </div>
               </div>
 
@@ -202,7 +395,6 @@ export const Creator: React.FC<CreatorProps> = ({
                 How would you like to add questions to this video?
               </p>
 
-              {/* AI Option */}
               {canUseAI && (
                 <button
                   onClick={() => setStep('ai')}
@@ -228,7 +420,6 @@ export const Creator: React.FC<CreatorProps> = ({
                 </button>
               )}
 
-              {/* Import Option */}
               <button
                 onClick={() => setStep('import')}
                 className="group relative p-5 bg-white border-2 border-slate-200 hover:border-emerald-500 hover:shadow-md rounded-2xl text-left transition-all overflow-hidden"
@@ -251,7 +442,6 @@ export const Creator: React.FC<CreatorProps> = ({
                 </div>
               </button>
 
-              {/* Manual Option */}
               <button
                 onClick={handleManualCreate}
                 className="group relative p-5 bg-white border-2 border-slate-200 hover:border-brand-blue-primary hover:shadow-md rounded-2xl text-left transition-all overflow-hidden"
@@ -334,6 +524,214 @@ export const Creator: React.FC<CreatorProps> = ({
           )}
         </div>
       </div>
+    </div>
+  );
+};
+
+/* ─── SearchTab ─────────────────────────────────────────────────────────── */
+
+interface SearchTabProps {
+  query: string;
+  onQueryChange: (v: string) => void;
+  onSubmit: () => void;
+  results: YouTubeSearchResult[];
+  searching: boolean;
+  hasSearched: boolean;
+  error: string | null;
+  onPick: (result: YouTubeSearchResult) => void;
+  pickedUrl: string;
+}
+
+const SearchTab: React.FC<SearchTabProps> = ({
+  query,
+  onQueryChange,
+  onSubmit,
+  results,
+  searching,
+  hasSearched,
+  error,
+  onPick,
+  pickedUrl,
+}) => (
+  <div className="space-y-3">
+    <div className="flex gap-2">
+      <div className="relative flex-1">
+        <SearchIcon className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-400" />
+        <input
+          type="text"
+          value={query}
+          onChange={(e) => onQueryChange(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') onSubmit();
+          }}
+          placeholder="e.g. photosynthesis crash course"
+          className="w-full pl-9 pr-3 py-2.5 bg-white border-2 border-slate-200 rounded-xl text-slate-800 font-medium focus:outline-none focus:border-brand-blue-primary shadow-sm"
+          style={{ fontSize: 'min(13px, 3.5cqmin)' }}
+        />
+      </div>
+      <button
+        type="button"
+        onClick={onSubmit}
+        disabled={query.trim().length === 0 || searching}
+        className="px-4 py-2.5 bg-brand-blue-primary text-white rounded-xl font-bold uppercase tracking-wider disabled:opacity-50 hover:bg-brand-blue-dark transition-colors shadow-sm"
+        style={{ fontSize: 'min(12px, 3.5cqmin)' }}
+      >
+        {searching ? <Loader2 className="w-4 h-4 animate-spin" /> : 'Search'}
+      </button>
+    </div>
+
+    {error && (
+      <div className="flex items-start gap-2 p-3 bg-amber-50 border border-amber-100 rounded-xl text-amber-700 text-xs font-medium">
+        <AlertCircle className="w-4 h-4 shrink-0 mt-0.5" />
+        <span>{error}</span>
+      </div>
+    )}
+
+    {!error && hasSearched && !searching && results.length === 0 && (
+      <p className="text-xs text-slate-500 text-center py-4">
+        No results. Try different keywords.
+      </p>
+    )}
+
+    {results.length > 0 && (
+      <div className="grid gap-2 max-h-72 overflow-y-auto custom-scrollbar">
+        {results.map((r) => {
+          const picked = pickedUrl.includes(r.videoId);
+          return (
+            <button
+              key={r.videoId}
+              type="button"
+              onClick={() => onPick(r)}
+              className={`flex gap-3 p-2 bg-white border-2 rounded-xl text-left transition-all active:scale-[0.99] ${
+                picked
+                  ? 'border-emerald-500 ring-2 ring-emerald-100'
+                  : 'border-slate-200 hover:border-brand-blue-primary'
+              }`}
+            >
+              <img
+                src={r.thumbnailUrl}
+                alt=""
+                className="w-32 h-18 rounded-md object-cover bg-slate-100 shrink-0"
+                style={{ aspectRatio: '16 / 9' }}
+              />
+              <div className="flex-1 min-w-0 py-1">
+                <p className="font-bold text-slate-800 text-sm leading-snug line-clamp-2">
+                  {r.title}
+                </p>
+                <p className="text-xs text-slate-500 mt-1 truncate">
+                  {r.channelTitle}
+                </p>
+                {r.durationSeconds > 0 && (
+                  <p className="text-xxs text-slate-400 font-mono mt-1">
+                    {formatDuration(r.durationSeconds)}
+                  </p>
+                )}
+              </div>
+              {picked && (
+                <Check className="w-5 h-5 text-emerald-600 shrink-0 self-center" />
+              )}
+            </button>
+          );
+        })}
+      </div>
+    )}
+  </div>
+);
+
+/* ─── RecommendTab ──────────────────────────────────────────────────────── */
+
+interface RecommendTabProps {
+  topic: string;
+  onTopicChange: (v: string) => void;
+  onSubmit: () => void;
+  recommending: boolean;
+  error: string | null;
+  recommendation: { videoId: string; title: string; rationale: string } | null;
+  onAccept: () => void;
+  pickedUrl: string;
+}
+
+const RecommendTab: React.FC<RecommendTabProps> = ({
+  topic,
+  onTopicChange,
+  onSubmit,
+  recommending,
+  error,
+  recommendation,
+  onAccept,
+  pickedUrl,
+}) => {
+  const accepted =
+    !!recommendation && pickedUrl.includes(recommendation.videoId);
+  return (
+    <div className="space-y-3">
+      <textarea
+        value={topic}
+        onChange={(e) => onTopicChange(e.target.value)}
+        rows={3}
+        placeholder="e.g. 6th grade lesson on photosynthesis — focus on chloroplasts and the role of sunlight"
+        className="w-full px-3 py-2 bg-white border-2 border-slate-200 rounded-xl text-slate-800 font-medium focus:outline-none focus:border-brand-blue-primary shadow-sm resize-none"
+        style={{ fontSize: 'min(13px, 3.5cqmin)' }}
+      />
+      <button
+        type="button"
+        onClick={onSubmit}
+        disabled={topic.trim().length === 0 || recommending}
+        className="w-full py-2.5 bg-indigo-600 hover:bg-indigo-700 disabled:opacity-50 text-white rounded-xl font-bold uppercase tracking-wider transition-colors flex items-center justify-center gap-2 shadow-sm"
+        style={{ fontSize: 'min(12px, 3.5cqmin)' }}
+      >
+        {recommending ? (
+          <>
+            <Loader2 className="w-4 h-4 animate-spin" /> Asking Gemini…
+          </>
+        ) : (
+          <>
+            <Wand2 className="w-4 h-4" /> Suggest a video
+          </>
+        )}
+      </button>
+
+      {error && (
+        <div className="flex items-start gap-2 p-3 bg-amber-50 border border-amber-100 rounded-xl text-amber-700 text-xs font-medium">
+          <AlertCircle className="w-4 h-4 shrink-0 mt-0.5" />
+          <span>{error}</span>
+        </div>
+      )}
+
+      {recommendation && (
+        <div
+          className={`p-3 bg-white border-2 rounded-xl transition-all ${
+            accepted
+              ? 'border-emerald-500 ring-2 ring-emerald-100'
+              : 'border-indigo-200'
+          }`}
+        >
+          <div className="flex gap-3">
+            <img
+              src={`https://img.youtube.com/vi/${recommendation.videoId}/mqdefault.jpg`}
+              alt=""
+              className="w-32 h-18 rounded-md object-cover bg-slate-100 shrink-0"
+              style={{ aspectRatio: '16 / 9' }}
+            />
+            <div className="flex-1 min-w-0">
+              <p className="font-bold text-slate-800 text-sm leading-snug">
+                {recommendation.title || 'Recommended video'}
+              </p>
+              <p className="text-xs text-slate-500 mt-1 italic line-clamp-3">
+                {recommendation.rationale}
+              </p>
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={onAccept}
+            disabled={accepted}
+            className="w-full mt-3 py-2 bg-emerald-600 hover:bg-emerald-700 disabled:bg-emerald-300 text-white rounded-lg font-bold text-xs uppercase tracking-wider transition-colors"
+          >
+            {accepted ? '✓ Selected' : 'Use this video'}
+          </button>
+        </div>
+      )}
     </div>
   );
 };

--- a/components/widgets/VideoActivityWidget/components/Results.tsx
+++ b/components/widgets/VideoActivityWidget/components/Results.tsx
@@ -161,20 +161,30 @@ export const Results: React.FC<ResultsProps> = ({
       // Pass `byStudentUid` so SSO `studentRole` rows (no PIN) export with
       // their resolved ClassLink names instead of falling back to the
       // generic "Student" label.
-      // TODO(PR3): The Quiz exporter calls Quiz's `gradeAnswer`, which has
-      // no 'MA' case and returns 0 points for VA Multi-Answer questions in
-      // the export. PR3 lifts `buildResultsSheetData` into a generic util
-      // that accepts a custom grader (`utils/assignmentExportShared.ts`)
-      // and at that point the VA call here will pass `gradeVideoActivityAnswer`.
-      // Until then, MA columns in the exported sheet read as "0 / Npt".
-      // MC + FIB questions grade correctly.
+      //
+      // PR3b: pass `gradeFn: gradeVideoActivityAnswer` so the exporter
+      // grades VA's MA / FIB-with-variants questions correctly. Without
+      // this override the Quiz default grader has no `'MA'` case and
+      // returns 0 points for those columns (the TODO PR2a left here).
+      // Cast away the QuizQuestion / QuizResponse / typeof-gradeAnswer
+      // shapes — the lifted `buildResultsSheetData` is generic enough to
+      // accept VA's variants but the public `exportResultsToSheet`
+      // signature is still typed as Quiz-shaped. PR3 documents the cast
+      // boundary; a future refactor that splits the Quiz-specific
+      // question-stats block out into a generic helper would let this
+      // function become generic too and remove the cast.
+      type ExporterOptions = Parameters<typeof drive.exportResultsToSheet>[3];
       const url = await drive.exportResultsToSheet(
         session.assignmentName,
         quizResponses,
         questions as unknown as Parameters<
           typeof drive.exportResultsToSheet
         >[2],
-        { byStudentUid }
+        {
+          byStudentUid,
+          gradeFn:
+            gradeVideoActivityAnswer as unknown as NonNullable<ExporterOptions>['gradeFn'],
+        }
       );
       setExportUrl(url);
     } catch (err) {

--- a/components/widgets/VideoActivityWidget/components/Results.tsx
+++ b/components/widgets/VideoActivityWidget/components/Results.tsx
@@ -15,8 +15,13 @@ import {
   Users,
   CheckCircle2,
   XCircle,
+  Share2,
 } from 'lucide-react';
-import { VideoActivityResponse, VideoActivitySession } from '@/types';
+import {
+  PlcLinkage,
+  VideoActivityResponse,
+  VideoActivitySession,
+} from '@/types';
 import { useAuth } from '@/context/useAuth';
 import { QuizDriveService } from '@/utils/quizDriveService';
 import {
@@ -27,17 +32,25 @@ import {
   useAssignmentPseudonymsMulti,
   formatStudentName,
 } from '@/hooks/useAssignmentPseudonyms';
+import { PlcTab } from '@/components/common/library/PlcTab';
 
 interface ResultsProps {
   session: VideoActivitySession;
   responses: VideoActivityResponse[];
   onBack: () => void;
+  /**
+   * PLC linkage for this assignment, if any. Set → render the 4th tab
+   * ("PLC") that aggregates across every PLC peer's exports against the
+   * shared sheet. Absent → tab is hidden.
+   */
+  plc?: PlcLinkage;
 }
 
 export const Results: React.FC<ResultsProps> = ({
   session,
   responses,
   onBack,
+  plc,
 }) => {
   const { googleAccessToken, orgId } = useAuth();
   // Use the multi-class variant — `session.classId` is a transitional
@@ -59,7 +72,7 @@ export const Results: React.FC<ResultsProps> = ({
   const [exportUrl, setExportUrl] = useState<string | null>(null);
   const [exportError, setExportError] = useState<string | null>(null);
   const [activeTab, setActiveTab] = useState<
-    'overview' | 'questions' | 'students'
+    'overview' | 'questions' | 'students' | 'plc'
   >('overview');
 
   const questions = session.questions;
@@ -317,6 +330,9 @@ export const Results: React.FC<ResultsProps> = ({
             { id: 'overview', icon: <BarChart3 />, label: 'Overview' },
             { id: 'questions', icon: <Clock />, label: 'Questions' },
             { id: 'students', icon: <Users />, label: 'Students' },
+            ...(plc?.sheetUrl
+              ? [{ id: 'plc' as const, icon: <Share2 />, label: 'PLC' }]
+              : []),
           ] as const
         ).map((tab) => (
           <button
@@ -568,6 +584,14 @@ export const Results: React.FC<ResultsProps> = ({
                 })
             )}
           </div>
+        )}
+
+        {activeTab === 'plc' && plc?.sheetUrl && (
+          <PlcTab
+            plcSheetUrl={plc.sheetUrl}
+            googleAccessToken={googleAccessToken}
+            questions={questions}
+          />
         )}
       </div>
     </div>

--- a/components/widgets/VideoActivityWidget/components/Timeline.tsx
+++ b/components/widgets/VideoActivityWidget/components/Timeline.tsx
@@ -1,0 +1,337 @@
+/**
+ * Timeline — YouTube IFrame player + custom scrubber for the Video Activity
+ * editor.
+ *
+ * Renders the player at the top, then a horizontal track underneath that
+ * shows:
+ *   - Existing question markers at each `question.timestamp`
+ *   - The current playhead position
+ *   - A "+" pill at the playhead the teacher clicks to add a question at
+ *     that exact second
+ *
+ * The scrubber sits in its own DOM row below the iframe — it does NOT
+ * overlay the player — so YouTube's own controls remain reachable and the
+ * iframe never fights us for pointer events. Clicking anywhere on the
+ * track seeks the player.
+ *
+ * Player lifecycle is owned here. The component re-instantiates the
+ * `YT.Player` whenever `videoId` changes, polls `getCurrentTime()` on a
+ * 250ms interval while the player is in PLAYING state, and tears down on
+ * unmount. Reuses the shared `loadYouTubeApi` singleton from utils so we
+ * don't double-load the IFrame script when MusicWidget is also mounted.
+ */
+
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { Plus } from 'lucide-react';
+import {
+  loadYouTubeApi,
+  YT_PLAYER_STATE,
+  type YTPlayer,
+} from '@/utils/youtube';
+import type { VideoActivityQuestion } from '@/types';
+
+export interface TimelineProps {
+  /** 11-character YouTube video id. Use `extractYouTubeId(url)` to derive. */
+  videoId: string;
+  /** Existing questions to render as markers on the track. */
+  questions: VideoActivityQuestion[];
+  /**
+   * Called when the teacher clicks the "+" pill at the playhead. Receives
+   * the current playhead time in seconds, snapped to integer.
+   */
+  onAddAtTime: (seconds: number) => void;
+  /**
+   * Called when the teacher clicks an existing question marker.
+   * Receives the question id so the parent can scroll/expand the
+   * matching question editor below.
+   */
+  onSelectQuestion?: (questionId: string) => void;
+  /** Optional id of a question the parent considers "active" (rendered larger). */
+  activeQuestionId?: string;
+}
+
+/** Format seconds as M:SS or H:MM:SS for the playhead label. */
+function formatHms(seconds: number): string {
+  const safe = Math.max(0, Math.floor(seconds));
+  const h = Math.floor(safe / 3600);
+  const m = Math.floor((safe % 3600) / 60);
+  const s = safe % 60;
+  const ss = String(s).padStart(2, '0');
+  if (h > 0) return `${h}:${String(m).padStart(2, '0')}:${ss}`;
+  return `${m}:${ss}`;
+}
+
+export const Timeline: React.FC<TimelineProps> = ({
+  videoId,
+  questions,
+  onAddAtTime,
+  onSelectQuestion,
+  activeQuestionId,
+}) => {
+  const playerContainerRef = useRef<HTMLDivElement | null>(null);
+  const playerRef = useRef<YTPlayer | null>(null);
+  const pollIntervalRef = useRef<number | null>(null);
+  const [duration, setDuration] = useState(0);
+  const [playhead, setPlayhead] = useState(0);
+  const [playerReady, setPlayerReady] = useState(false);
+  // Each player instance gets a unique DOM id. React's StrictMode mounts
+  // effects twice in dev; reusing the same id collides because IFrame API
+  // takes ownership of the element by id. Lazy-initialized state (not a
+  // ref) so the id is read during render without triggering the
+  // refs-during-render lint.
+  const [playerElementId] = useState(
+    () => `va-timeline-player-${crypto.randomUUID().slice(0, 8)}`
+  );
+
+  const stopPolling = useCallback(() => {
+    if (pollIntervalRef.current != null) {
+      window.clearInterval(pollIntervalRef.current);
+      pollIntervalRef.current = null;
+    }
+  }, []);
+
+  const startPolling = useCallback(() => {
+    stopPolling();
+    pollIntervalRef.current = window.setInterval(() => {
+      if (playerRef.current) {
+        try {
+          setPlayhead(playerRef.current.getCurrentTime());
+        } catch {
+          /* iframe gone — next render handles cleanup */
+        }
+      }
+    }, 250);
+  }, [stopPolling]);
+
+  // Reset transient player state when videoId changes — done at render
+  // time via the adjust-state-while-rendering pattern to avoid the
+  // setState-in-effect anti-pattern.
+  const [prevVideoId, setPrevVideoId] = useState(videoId);
+  if (prevVideoId !== videoId) {
+    setPrevVideoId(videoId);
+    setPlayerReady(false);
+    setDuration(0);
+    setPlayhead(0);
+  }
+
+  // (Re)create the player whenever videoId changes.
+  useEffect(() => {
+    if (!videoId) return;
+    let cancelled = false;
+
+    const teardown = () => {
+      stopPolling();
+      if (playerRef.current) {
+        try {
+          playerRef.current.destroy();
+        } catch {
+          /* ignore */
+        }
+        playerRef.current = null;
+      }
+    };
+
+    loadYouTubeApi(() => {
+      if (cancelled || !playerContainerRef.current || !window.YT?.Player) {
+        return;
+      }
+      // Replace any previous instance bound to this container.
+      teardown();
+      // The target div is rendered in JSX with id=playerElementId; YT.Player
+      // takes ownership of it by id and replaces it with an iframe. We don't
+      // re-create it here — leaving DOM ownership to React first, then YT —
+      // because manual createElement() can race React's reconciliation when
+      // the component re-renders.
+      if (!document.getElementById(playerElementId)) {
+        // JSX hasn't flushed yet on this render; bail and let the next
+        // videoId-effect tick recreate the player.
+        return;
+      }
+      playerRef.current = new window.YT.Player(playerElementId, {
+        height: '100%',
+        width: '100%',
+        videoId,
+        playerVars: {
+          rel: 0,
+          modestbranding: 1,
+          playsinline: 1,
+        },
+        events: {
+          onReady: () => {
+            if (cancelled || !playerRef.current) return;
+            try {
+              setDuration(playerRef.current.getDuration());
+              setPlayhead(playerRef.current.getCurrentTime());
+              setPlayerReady(true);
+            } catch {
+              /* ignore */
+            }
+          },
+          onStateChange: ({ data }: { data: number }) => {
+            if (data === YT_PLAYER_STATE.PLAYING) {
+              startPolling();
+            } else {
+              stopPolling();
+              // One last sample so the playhead reflects the pause point.
+              if (playerRef.current) {
+                try {
+                  setPlayhead(playerRef.current.getCurrentTime());
+                  // Duration may not be known until first play on some videos.
+                  const d = playerRef.current.getDuration();
+                  if (d > 0) setDuration(d);
+                } catch {
+                  /* ignore */
+                }
+              }
+            }
+          },
+        },
+      });
+    });
+
+    return () => {
+      cancelled = true;
+      teardown();
+    };
+  }, [videoId, playerElementId, startPolling, stopPolling]);
+
+  // Render markers and playhead.
+  const safeDuration = duration > 0 ? duration : 1;
+  const playheadPct = Math.max(
+    0,
+    Math.min(100, (playhead / safeDuration) * 100)
+  );
+
+  const handleTrackClick = (e: React.MouseEvent<HTMLDivElement>) => {
+    if (!playerRef.current || duration <= 0) return;
+    const rect = e.currentTarget.getBoundingClientRect();
+    const ratio = (e.clientX - rect.left) / rect.width;
+    const target = Math.max(0, Math.min(duration, ratio * duration));
+    try {
+      playerRef.current.seekTo(target, true);
+      setPlayhead(target);
+    } catch {
+      /* ignore */
+    }
+  };
+
+  return (
+    <div className="space-y-2">
+      <div
+        ref={playerContainerRef}
+        className="relative w-full overflow-hidden rounded-xl border border-slate-200 bg-black"
+        style={{ aspectRatio: '16 / 9' }}
+      >
+        <div id={playerElementId} className="w-full h-full" />
+        {!playerReady && (
+          <div className="absolute inset-0 flex items-center justify-center text-slate-400 text-sm">
+            Loading player…
+          </div>
+        )}
+      </div>
+
+      {/* Custom scrubber + question markers + add-at-playhead pill */}
+      <div className="space-y-1.5">
+        <div className="flex items-center justify-between text-xxs font-bold text-brand-blue-primary/60 uppercase tracking-widest">
+          <span>Timeline</span>
+          <span>
+            {formatHms(playhead)} / {formatHms(duration)}
+          </span>
+        </div>
+        <div
+          role="slider"
+          aria-label="Video timeline"
+          aria-orientation="horizontal"
+          aria-valuemin={0}
+          aria-valuemax={Math.floor(duration)}
+          aria-valuenow={Math.floor(playhead)}
+          aria-valuetext={`${formatHms(playhead)} of ${formatHms(duration)}`}
+          tabIndex={0}
+          onClick={handleTrackClick}
+          onKeyDown={(e) => {
+            if (!playerRef.current || duration <= 0) return;
+            const step = 5; // 5-second nudge per arrow press
+            const bigStep = Math.max(15, Math.floor(duration / 10));
+            const seek = (next: number) => {
+              const clamped = Math.max(0, Math.min(duration, next));
+              playerRef.current?.seekTo(clamped, true);
+              setPlayhead(clamped);
+              e.preventDefault();
+            };
+            if (e.key === 'ArrowLeft') seek(playhead - step);
+            else if (e.key === 'ArrowRight') seek(playhead + step);
+            else if (e.key === 'PageUp') seek(playhead - bigStep);
+            else if (e.key === 'PageDown') seek(playhead + bigStep);
+            else if (e.key === 'Home') seek(0);
+            else if (e.key === 'End') seek(duration);
+          }}
+          className="relative h-8 rounded-lg bg-slate-200 cursor-pointer focus:outline-none focus:ring-2 focus:ring-brand-blue-primary focus:ring-offset-2"
+        >
+          {/* Played-progress fill */}
+          <div
+            className="absolute inset-y-0 left-0 bg-brand-blue-primary/30 rounded-lg pointer-events-none"
+            style={{ width: `${playheadPct}%` }}
+          />
+
+          {/* Question markers */}
+          {questions.map((q) => {
+            const pct = (q.timestamp / safeDuration) * 100;
+            if (pct < 0 || pct > 100) return null;
+            const isActive = q.id === activeQuestionId;
+            return (
+              <button
+                key={q.id}
+                type="button"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  // Seek the player so the teacher sees the video context
+                  // alongside the question they just selected.
+                  if (playerRef.current && duration > 0) {
+                    try {
+                      playerRef.current.seekTo(q.timestamp, true);
+                      setPlayhead(q.timestamp);
+                    } catch {
+                      /* ignore — player may have torn down */
+                    }
+                  }
+                  onSelectQuestion?.(q.id);
+                }}
+                aria-label={`Question at ${formatHms(q.timestamp)}: ${q.text || 'untitled'}`}
+                title={`${formatHms(q.timestamp)} — ${q.text || 'Untitled question'}`}
+                className={`absolute top-1/2 -translate-y-1/2 -translate-x-1/2 rounded-full transition-all ${
+                  isActive
+                    ? 'w-4 h-4 bg-emerald-500 ring-2 ring-emerald-200'
+                    : 'w-3 h-3 bg-emerald-500 hover:w-4 hover:h-4'
+                }`}
+                style={{ left: `${pct}%` }}
+              />
+            );
+          })}
+
+          {/* Playhead indicator */}
+          <div
+            className="absolute top-0 bottom-0 w-0.5 bg-brand-blue-primary pointer-events-none"
+            style={{ left: `${playheadPct}%` }}
+          />
+        </div>
+
+        {/* Add-at-playhead button */}
+        <div className="flex items-center justify-between gap-3">
+          <p className="text-xxs text-slate-500">
+            Click the timeline to seek. Click a green marker to jump to an
+            existing question.
+          </p>
+          <button
+            type="button"
+            disabled={!playerReady}
+            onClick={() => onAddAtTime(Math.floor(playhead))}
+            className="inline-flex items-center gap-1.5 rounded-lg bg-brand-blue-primary text-white font-bold px-3 py-1.5 text-xs hover:bg-brand-blue-dark disabled:opacity-50 disabled:cursor-not-allowed transition-colors active:scale-95 shadow-sm"
+          >
+            <Plus className="w-3.5 h-3.5" />
+            Add at {formatHms(playhead)}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/components/widgets/VideoActivityWidget/components/VideoActivityEditorModal.tsx
+++ b/components/widgets/VideoActivityWidget/components/VideoActivityEditorModal.tsx
@@ -31,6 +31,8 @@ import { EditorModalShell } from '@/components/common/EditorModalShell';
 import { FolderSelectField } from '@/components/common/library/FolderSelectField';
 import { useAuth } from '@/context/useAuth';
 import { generateVideoActivity } from '@/utils/ai';
+import { extractYouTubeId } from '@/utils/youtube';
+import { Timeline } from './Timeline';
 
 interface VideoActivityEditorModalProps {
   isOpen: boolean;
@@ -220,6 +222,16 @@ export const VideoActivityEditorModal: React.FC<
     [questions]
   );
 
+  /**
+   * Memoize the parsed videoId so Timeline.tsx doesn't restart its YT
+   * player on every keystroke into the URL field — the player only
+   * rebuilds when the resolved id actually changes.
+   */
+  const videoIdForTimeline = useMemo(
+    () => (youtubeUrl.trim() ? extractYouTubeId(youtubeUrl.trim()) : null),
+    [youtubeUrl]
+  );
+
   const updateQuestion = (
     id: string,
     updates: Partial<VideoActivityQuestion>
@@ -263,6 +275,45 @@ export const VideoActivityEditorModal: React.FC<
     setQuestions((prev) => [...prev, q]);
     setTimestampInputs((prev) => ({ ...prev, [q.id]: secondsToMmSs(0) }));
     setExpandedId(q.id);
+  };
+
+  /**
+   * Add a question at the Timeline's current playhead. Mirrors `addQuestion`
+   * but seeds the timestamp from the seconds the teacher chose. Inserts in
+   * timestamp order so the strictly-increasing-timestamp save validation
+   * doesn't fail when the user adds out-of-order. Tied timestamps get a
+   * +1s nudge rather than a save error so the teacher can still hit Save.
+   */
+  const addQuestionAtTime = (seconds: number) => {
+    setQuestions((prev) => {
+      const used = new Set(prev.map((q) => q.timestamp));
+      let target = Math.max(0, Math.floor(seconds));
+      while (used.has(target)) target += 1;
+      const fresh: VideoActivityQuestion = {
+        ...blankQuestion(),
+        timestamp: target,
+      };
+      const next = [...prev, fresh].sort((a, b) => a.timestamp - b.timestamp);
+      setTimestampInputs((tsPrev) => ({
+        ...tsPrev,
+        [fresh.id]: secondsToMmSs(target),
+      }));
+      setExpandedId(fresh.id);
+      return next;
+    });
+  };
+
+  /** Marker click — scroll the question into view and expand it. */
+  const focusQuestion = (id: string) => {
+    setExpandedId(id);
+    if (typeof document !== 'undefined') {
+      // The question card has `id={`q-card-${id}`}`. Scroll only when the
+      // element is present (it always should be for in-list questions).
+      const el = document.getElementById(`q-card-${id}`);
+      if (el?.scrollIntoView) {
+        el.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+      }
+    }
   };
 
   const handleAiGenerate = async () => {
@@ -481,11 +532,23 @@ export const VideoActivityEditorModal: React.FC<
           </div>
         )}
 
+        {/* Timeline: only renders when we have a parseable YouTube URL. */}
+        {videoIdForTimeline && (
+          <Timeline
+            videoId={videoIdForTimeline}
+            questions={questions}
+            onAddAtTime={addQuestionAtTime}
+            onSelectQuestion={focusQuestion}
+            activeQuestionId={expandedId ?? undefined}
+          />
+        )}
+
         {questions.map((q, i) => {
           const tsValue = timestampInputs[q.id] ?? secondsToMmSs(q.timestamp);
           return (
             <div
               key={q.id}
+              id={`q-card-${q.id}`}
               className={`bg-white border rounded-2xl overflow-hidden transition-all shadow-sm ${
                 expandedId === q.id
                   ? 'border-brand-blue-primary/30 ring-2 ring-brand-blue-primary/5 shadow-md'

--- a/components/widgets/VideoActivityWidget/components/VideoActivityManager.tsx
+++ b/components/widgets/VideoActivityWidget/components/VideoActivityManager.tsx
@@ -33,6 +33,7 @@ import {
   PlayCircle,
   Plus,
   RotateCcw,
+  Send,
   Share2,
   Trash2,
 } from 'lucide-react';
@@ -175,6 +176,13 @@ export interface VideoActivityManagerProps {
   onArchiveMonitor?: (
     assignment: VideoActivityAssignment
   ) => void | Promise<void>;
+  /**
+   * PR3c — open the publish-scores modal for this assignment. Set ⇒ the
+   * archive kebab gains a "Publish scores" / "Update published scores"
+   * entry that calls back through to `Widget.tsx`'s
+   * `useVideoActivityAssignments.publishAssignmentScores` hook.
+   */
+  onArchivePublishScores?: (assignment: VideoActivityAssignment) => void;
 
   /** Persisted library grid/list toggle (from widget config). */
   initialLibraryViewMode?: 'grid' | 'list';
@@ -397,6 +405,7 @@ export const VideoActivityManager: React.FC<VideoActivityManagerProps> = ({
   onArchiveResults,
   onArchiveShare,
   onArchiveMonitor,
+  onArchivePublishScores,
   initialLibraryViewMode,
   onLibraryViewModeChange,
   rosters,
@@ -1014,6 +1023,22 @@ export const VideoActivityManager: React.FC<VideoActivityManagerProps> = ({
         label: 'Results',
         icon: BarChart3,
         onClick: () => onArchiveResults(assignment),
+      });
+    }
+
+    // PR3c — surface "Publish scores" on the archive kebab when the
+    // assignment carries submissions. Label flips to "Update published
+    // scores" once a level is set so the teacher sees that re-opening
+    // the modal will replace, not stack.
+    if (onArchivePublishScores && !assignmentIsViewOnly) {
+      const isPublished =
+        assignment.scoreVisibility !== undefined &&
+        assignment.scoreVisibility !== 'none';
+      actions.push({
+        id: 'publish-scores',
+        label: isPublished ? 'Update published scores' : 'Publish scores',
+        icon: Send,
+        onClick: () => onArchivePublishScores(assignment),
       });
     }
 

--- a/components/widgets/VideoActivityWidget/components/VideoActivityManager.tsx
+++ b/components/widgets/VideoActivityWidget/components/VideoActivityManager.tsx
@@ -33,6 +33,7 @@ import {
   PlayCircle,
   Plus,
   RotateCcw,
+  Share2,
   Trash2,
 } from 'lucide-react';
 import { LibraryShell } from '@/components/common/library/LibraryShell';
@@ -159,6 +160,14 @@ export interface VideoActivityManagerProps {
   onArchiveReactivate?: (assignment: VideoActivityAssignment) => Promise<void>;
   onArchiveDelete?: (assignment: VideoActivityAssignment) => Promise<void>;
   onArchiveResults?: (assignment: VideoActivityAssignment) => void;
+  /**
+   * PR3 PLC sharing — invoked when the teacher picks "Share with PLC" on an
+   * assignment's kebab menu. Implementation lives in `Widget.tsx` and calls
+   * `useVideoActivityAssignments.shareAssignment` after hydrating the
+   * activity from Drive. The handler is responsible for copying the
+   * resulting share URL to the clipboard and surfacing toasts.
+   */
+  onArchiveShare?: (assignment: VideoActivityAssignment) => Promise<void>;
   /**
    * Open the live teacher monitor for an active assignment. Surfaced as the
    * In Progress tab's primary CTA when wired; mirrors the Quiz manager.
@@ -386,6 +395,7 @@ export const VideoActivityManager: React.FC<VideoActivityManagerProps> = ({
   onArchiveReactivate,
   onArchiveDelete,
   onArchiveResults,
+  onArchiveShare,
   onArchiveMonitor,
   initialLibraryViewMode,
   onLibraryViewModeChange,
@@ -963,6 +973,21 @@ export const VideoActivityManager: React.FC<VideoActivityManagerProps> = ({
           },
         });
       }
+      // PR3 cross-teacher sharing — works for any submission assignment
+      // (PLC linkage is optional in PR3a; the share doc carries the
+      // teacher's settings either way and peers can import it). Label
+      // says "peers" rather than "PLC" because the button isn't gated
+      // on `assignment.plc` — it's a generic peer-handoff affordance.
+      if (onArchiveShare && !assignmentIsViewOnly) {
+        actions.push({
+          id: 'share-with-peers',
+          label: 'Share with peers',
+          icon: Share2,
+          onClick: () => {
+            void onArchiveShare(assignment);
+          },
+        });
+      }
     }
 
     // Reactivate is view-only-only, archive-only — flips status back to
@@ -1302,7 +1327,7 @@ function buildDefaultPolicyOptions(): VideoActivitySessionOptions {
     attemptLimit: 1,
     rewindOnIncorrectSeconds: 0,
     pointPenaltyOnIncorrect: 0,
-    scoreVisibility: 'score_only',
+    scoreVisibility: 'score-only',
   };
 }
 
@@ -1326,17 +1351,17 @@ const SCORE_VISIBILITY_OPTIONS: {
     hint: "Students see 'Submitted' only — no score.",
   },
   {
-    value: 'score_only',
+    value: 'score-only',
     label: 'Score',
     hint: 'Students see their final score, no per-question detail.',
   },
   {
-    value: 'score_and_responses',
+    value: 'score-and-responses',
     label: 'Score + responses',
     hint: 'Students see their score and which questions they got right/wrong.',
   },
   {
-    value: 'score_responses_and_answers',
+    value: 'score-responses-and-answers',
     label: 'Full review',
     hint: 'Students see their score, right/wrong, and the correct answers.',
   },
@@ -1358,8 +1383,15 @@ const VideoActivityScoringBlock: React.FC<VideoActivityScoringBlockProps> = ({
 }) => {
   const rewind = options.rewindOnIncorrectSeconds ?? 0;
   const penalty = options.pointPenaltyOnIncorrect ?? 0;
+  // Backward compat for pre-PR3a snake_case scoreVisibility values that
+  // may already be persisted in Firestore. Without the normalize step the
+  // <select> falls through to the default 'score-only' silently, hiding
+  // the teacher's actual choice.
+  const rawVisibility = options.scoreVisibility;
   const visibility: VideoActivityScoreVisibility =
-    options.scoreVisibility ?? 'score_only';
+    rawVisibility === undefined
+      ? 'score-only'
+      : (rawVisibility.replace(/_/g, '-') as VideoActivityScoreVisibility);
 
   return (
     <div className="space-y-3 pt-1">

--- a/context/DashboardContext.tsx
+++ b/context/DashboardContext.tsx
@@ -225,9 +225,11 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
   const [pendingShareId, setPendingShareId] = useState<string | null>(() => {
     if (typeof window === 'undefined') return null;
     const path = window.location.pathname;
-    // Skip quiz and assignment share URLs — those are handled separately
+    // Skip quiz, assignment, and video-activity share URLs — those are
+    // handled separately by their dedicated `pending*ShareId` states.
     if (path.startsWith('/share/quiz/')) return null;
     if (path.startsWith('/share/assignment/')) return null;
+    if (path.startsWith('/share/video-activity/')) return null;
     if (path.startsWith('/share/')) {
       return path.split('/share/')[1] || null;
     }
@@ -256,6 +258,16 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
     return null;
   });
 
+  const [pendingVideoActivityShareId, setPendingVideoActivityShareId] =
+    useState<string | null>(() => {
+      if (typeof window === 'undefined') return null;
+      const path = window.location.pathname;
+      if (path.startsWith('/share/video-activity/')) {
+        return path.split('/share/video-activity/')[1] || null;
+      }
+      return null;
+    });
+
   const clearPendingShare = useCallback(() => {
     setPendingShareId(null);
     window.history.replaceState(null, '', '/');
@@ -268,6 +280,11 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
 
   const clearPendingAssignmentShare = useCallback(() => {
     setPendingAssignmentShareId(null);
+    window.history.replaceState(null, '', '/');
+  }, []);
+
+  const clearPendingVideoActivityShare = useCallback(() => {
+    setPendingVideoActivityShareId(null);
     window.history.replaceState(null, '', '/');
   }, []);
 
@@ -4232,6 +4249,9 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
       pendingAssignmentShareId,
       setPendingAssignmentShareId,
       clearPendingAssignmentShare,
+      pendingVideoActivityShareId,
+      setPendingVideoActivityShareId,
+      clearPendingVideoActivityShare,
       pendingAssignmentSetupId,
       setPendingAssignmentSetup,
       clearPendingAssignmentSetup,
@@ -4330,6 +4350,9 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
       pendingAssignmentShareId,
       setPendingAssignmentShareId,
       clearPendingAssignmentShare,
+      pendingVideoActivityShareId,
+      setPendingVideoActivityShareId,
+      clearPendingVideoActivityShare,
       pendingAssignmentSetupId,
       setPendingAssignmentSetup,
       clearPendingAssignmentSetup,

--- a/context/DashboardContextValue.ts
+++ b/context/DashboardContextValue.ts
@@ -157,6 +157,14 @@ export interface DashboardContextValue {
   pendingAssignmentShareId: string | null;
   setPendingAssignmentShareId: (shareId: string | null) => void;
   clearPendingAssignmentShare: () => void;
+  /**
+   * Pending video-activity-assignment share id, parsed from
+   * `/share/video-activity/{shareId}`. Mirrors `pendingAssignmentShareId`;
+   * the VideoActivityWidget's URL-paste flow drives off this state.
+   */
+  pendingVideoActivityShareId: string | null;
+  setPendingVideoActivityShareId: (shareId: string | null) => void;
+  clearPendingVideoActivityShare: () => void;
   setPendingQuizShareId: (shareId: string | null) => void;
   /**
    * Set after a successful `importSharedAssignment` to signal the QuizWidget

--- a/docs/PLC_ROADMAP.md
+++ b/docs/PLC_ROADMAP.md
@@ -27,7 +27,7 @@ This roadmap is designed to be **executed in independent chunks across multiple 
 ## Status
 
 - [x] **Phase 1** — Dashboard shell + feature toggles + completed-assignments tab _(PR #1537)_
-- [ ] **Phase 2** — PLC Quiz Library (share-with-PLC, collaborative editing, sync-or-copy import)
+- [x] **Phase 2** — PLC Quiz Library (share-with-PLC, collaborative editing, sync-or-copy import) _(this PR)_
 - [ ] **Phase 3** — PLC-authored Assignments tab + auto-bubble-up from personal assignments
 - [ ] **Phase 4** — Video Activities (extend with `PlcLinkage` + dashboard surface)
 - [x] **Phase 5** — Notes + To-Do list (collaborative shared docs) _(bundled with Overview/Bento — see Phase 1.5 below)_
@@ -131,13 +131,31 @@ Open these in the first session so you understand the pivot points:
 - PLC-authored assignments (Phase 3) — sharing a quiz does not auto-create an assignment; the assignment is created by the importer's existing flow.
 - Permissions beyond "any member can edit / any member can copy". No editor-vs-viewer split.
 
-### Open question
+### Open question — RESOLVED
 
-- When the original sharer **deletes** their personal copy of a quiz that's been synced to a PLC, does the PLC copy stay (orphan-tolerant) or get pulled? Recommend: **stays.** PLC copy lives in its own subcollection; deleting your personal version doesn't affect the PLC's shared version. Confirm with user before implementing.
+- When the original sharer **deletes** their personal copy of a quiz that's been synced to a PLC, the PLC copy **stays** (orphan-tolerant). The PLC subcoll doc lives independently of the sharer's `quiz_metadata`; the canonical `synced_quizzes/{groupId}` doc also stays in place (its rule already declines client deletes). No cascade.
 
 ### Notes from implementation
 
-_(Fill in after shipping.)_
+- **Subcollection shape:** `plcs/{plcId}/quizzes/{plcQuizId}` is a lightweight header (`title`, `questionCount`, `syncGroupId`, `sharedBy*`, `sharedAt`, `updatedAt`) — questions live only in `synced_quizzes/{groupId}`. List rendering thus avoids an N+1 read against the sync collection. After every successful peer publish, `mirrorPlcQuizHeader` patches title/questionCount onto the PLC doc fire-and-forget — failures log via `logError('usePlcQuizzes.mirrorHeader', …)` and never reject so the publish path stays fast.
+- **Doc ids:** the PLC doc id is a fresh v4 UUID minted at share time (NOT the source quiz id). This lets the same source quiz be shared with multiple PLCs without doc-id collisions, and lets the sharer remove a PLC entry without affecting their personal library.
+- **Sharing flow** (`Widget.tsx → handleShareWithPlc`): load drive content → mint `synced_quizzes/{groupId}` (with `plcId` set) if the quiz wasn't already synced → attach sync linkage to local `quiz_metadata` → write the PLC subcoll doc. If the PLC subcoll write fails after the synced group is minted, the synced group + sync linkage are intentionally NOT rolled back — the canonical doc still appears as a "Synced" pill on the user's library card, which is still useful, and a retry just re-uses the existing groupId.
+- **Importing flow** (`PlcQuizLibraryTab → handleImport`):
+  - **Sync** — `pullSyncedQuizContent(syncGroupId)` → `saveQuiz(fresh)` → `callJoinPlcQuizSyncGroup(plcId, plcQuizId)` (Cloud Function) → `attachSyncLinkage`. Server-side participant write precedes the local linkage attach so a later editor save publishes from a participant context.
+  - **Copy** — pull canonical → `saveQuiz(fresh)`. No sync linkage; future PLC edits do NOT propagate.
+- **New Cloud Function** `joinPlcQuizSyncGroup({plcId, plcQuizId})` (`functions/src/plcQuizSyncJoin.ts`). Mirrors the existing `joinSyncedQuizGroup` shape but resolves `syncGroupId` via `plcs/{plcId}/quizzes/{plcQuizId}` instead of `shared_assignments/{shareId}` — and adds an explicit Admin-SDK membership check so the caller can't sneak into a sync group by knowing the PLC quiz id alone. **Requires `firebase deploy --only functions:joinPlcQuizSyncGroup`** before the Sync import path will work in the staging or production environment; until then, Copy mode still works without the Cloud Function.
+- **Permissions:** any current member can share / edit (via the synced group, after import) / unshare. The unshare action in the PLC tab is therefore visible on every row, not just rows the current user shared — this matches the Phase 5 notes/todos PLC-owned posture. The rules pin identity + attribution fields (`id`, `syncGroupId`, `sharedBy`, `sharedByEmail`, `sharedByName`, `sharedAt`) immutable on update so a teammate can't quietly retarget an entry or rewrite authorship while patching the title mirror.
+- **Edit-in-place from the PLC tab is not in this PR.** The existing `QuizEditorModal` reads/writes Drive, which only works for quizzes already in the user's personal library. Members sync the quiz first ("Add to my library → Sync"), then edit from their library card; published edits propagate back to all teammates via the existing LWW infrastructure. Direct in-tab editing on the synced doc would need a Drive-less editor surface — explicitly out of scope here.
+- **dev-paul branch convention:** Phase 2 was committed to `claude/shared-plc-implementation-TB67Z` and PR'd into `dev-paul`. The auth bypass was not exercised; manual smoke tests were not run because this environment lacks Firebase project access — verification falls to the dev preview URL and the human reviewer.
+
+### Phase 2 follow-ups (not blockers; track separately)
+
+These were surfaced in the final review pass and intentionally deferred to keep this PR focused. None block merge:
+
+- **Modal i18n.** `PlcShareTargetModal` and `PlcQuizImportModal` use hardcoded English. Consistent with the sibling `QuizAssignmentImportModeModal.tsx` pattern — every share/import picker in this codebase is currently English-only. A separate localization sweep should bring all three modals plus the QuizManager kebab labels under `t()` together.
+- **Rollback path tests.** `PlcQuizLibraryTab.handleImport` has a 3-stage rollback (leave sync group + delete personal quiz on partial failure) but no integration test exercising it. The shared-assignment importer's analogous path also has unit-only coverage today; adding this would be additive parity.
+- **Cloud Function unit tests.** `joinPlcQuizSyncGroup` (`functions/src/plcQuizSyncJoin.ts`) has no `*.test.ts` sibling. The Firestore rules suite covers the subcollection's permissions, but the Admin-SDK transaction logic itself (membership re-check, idempotent `alreadyJoined`, version-bump invariants) isn't directly exercised. Sibling pattern: `syncedQuizGroups.test.ts` (Phase 1).
+- **Modal title polish.** When the user clicks "Re-import" on an already-synced quiz, the `PlcQuizImportModal` header still reads "Add to my library". Minor UX nit — the import button label updates correctly, but the modal title doesn't acknowledge the re-import context.
 
 ---
 
@@ -342,13 +360,16 @@ logError('writePlcAssignmentIndexEntry.write', err, { plcId, entryId });
 
 _(Add new ones here as they come up. Resolve before starting the affected phase.)_
 
-- **Phase 2:** orphan behavior when sharer deletes their personal copy of a synced PLC quiz.
 - **Phase 3:** does the personal "PLC option" toggle create a brand-new PLC-level assignment template, or fork from the personal one?
 - **Phase 3:** what happens to in-flight imports if the PLC-level template is deleted?
-- **Phase 5:** single shared notepad vs. multiple notes per PLC.
-- **Phase 5:** are todos PLC-owned or per-member?
 - **Phase 6:** read-only vs. editable for PLC-shared boards.
+
+Resolved:
+
+- ~~**Phase 2:** orphan behavior when sharer deletes their personal copy of a synced PLC quiz.~~ → PLC copy stays (orphan-tolerant). See Phase 2 "Notes from implementation".
+- ~~**Phase 5:** single shared notepad vs. multiple notes per PLC.~~ → Multi-note. Shipped.
+- ~~**Phase 5:** are todos PLC-owned or per-member?~~ → PLC-owned, optional `assignedTo` deferred. Shipped.
 
 ---
 
-**Last updated:** 2026-05-07 (Phase 1.5 + Phase 5 shipped — Overview tab + bento grid + sidebar kebab + Notes/To-Dos)
+**Last updated:** 2026-05-08 (Phase 2 shipped — PLC Quiz Library: share-with-PLC, sync-or-copy import, collaborative edits via synced_quizzes)

--- a/firestore.rules
+++ b/firestore.rules
@@ -761,6 +761,67 @@ service cloud.firestore {
       allow delete: if false;
     }
 
+    // ---- Shared / Synced VIDEO ACTIVITY parallel collections (PR3) ----
+    //
+    // Mirrors the quiz `/shared_assignments` and `/synced_quizzes` rule blocks
+    // exactly, scoped to Video Activity. Kept as parallel collections (rather
+    // than mixing into the quiz collections behind a `kind` discriminator) so
+    // existing quiz-only rules don't have to migrate, and so VA's content
+    // schema can drift independently (it carries `youtubeUrl` and a different
+    // question shape).
+
+    match /shared_video_activity_assignments/{shareId} {
+      allow get: if request.auth != null;
+      allow create: if request.auth != null &&
+        request.resource.data.originalAuthor == request.auth.uid;
+      allow update, delete: if request.auth != null &&
+        (resource.data.get('originalAuthor', null) == request.auth.uid || isAdmin());
+    }
+
+    match /synced_video_activities/{groupId} {
+      allow get: if request.auth != null;
+      // Listing is closed for the same reason as `synced_quizzes`: any
+      // authenticated user knowing only the collection name could otherwise
+      // enumerate every synced activity (questions included). Clients always
+      // know the specific groupId via either their own
+      // `video_activity_metadata` or a pasted share URL.
+      allow list: if false;
+
+      allow create: if request.auth != null
+        && request.resource.data.keys().hasOnly([
+             'id', 'version', 'title', 'youtubeUrl', 'questions',
+             'participants', 'plcId', 'createdAt',
+             'updatedAt', 'updatedBy'
+           ])
+        && request.resource.data.id == groupId
+        && request.resource.data.version is int
+        && request.resource.data.version == 1
+        && request.resource.data.updatedBy == request.auth.uid
+        && request.resource.data.participants.keys().hasOnly([request.auth.uid])
+        && request.resource.data.participants[request.auth.uid].joinedAt is int
+        && request.resource.data.participants[request.auth.uid].joinedAt >= 0
+        && (!('plcId' in request.resource.data) || request.resource.data.plcId is string);
+
+      // Content updates: caller must be a participant; participants map and
+      // doc id are immutable from the client; version must strictly increase
+      // by 1. Loser of a concurrent transaction retries with the new base
+      // version. Mirrors `synced_quizzes` line-for-line.
+      allow update: if request.auth != null
+        && request.auth.uid in resource.data.participants
+        && request.resource.data.keys().hasOnly([
+             'id', 'version', 'title', 'youtubeUrl', 'questions',
+             'participants', 'plcId', 'createdAt',
+             'updatedAt', 'updatedBy'
+           ])
+        && request.resource.data.id == resource.data.id
+        && request.resource.data.participants == resource.data.participants
+        && request.resource.data.version == resource.data.version + 1
+        && request.resource.data.updatedBy == request.auth.uid
+        && request.resource.data.get('plcId', null) == resource.data.get('plcId', null);
+
+      allow delete: if false;
+    }
+
     // ---- PLC (Professional Learning Community) helpers + rules ----
     //
     // PLCs are top-level so cross-teacher reads work — every member needs to
@@ -953,7 +1014,7 @@ service cloud.firestore {
                'id', 'kind', 'ownerUid', 'ownerName', 'ownerEmail',
                'title', 'sheetUrl', 'createdAt'
              ])
-          && request.resource.data.kind == 'quiz'
+          && request.resource.data.kind in ['quiz', 'video-activity']
           && request.resource.data.sheetUrl == get(
                /databases/$(database)/documents/plcs/$(plcId)
              ).data.get('sharedSheetUrl', '');
@@ -976,7 +1037,7 @@ service cloud.firestore {
                'id', 'kind', 'ownerUid', 'ownerName', 'ownerEmail',
                'title', 'sheetUrl', 'createdAt'
              ])
-          && request.resource.data.kind == 'quiz'
+          && request.resource.data.kind in ['quiz', 'video-activity']
           && request.resource.data.sheetUrl == get(
                /databases/$(database)/documents/plcs/$(plcId)
              ).data.get('sharedSheetUrl', '');
@@ -1514,25 +1575,20 @@ service cloud.firestore {
       allow read: if request.auth != null;
       // Only authenticated (non-anonymous) users can create sessions (teachers)
       allow create: if request.auth != null && request.auth.token.firebase.sign_in_provider != 'anonymous';
-      // Teacher owners may rename or end sessions, but not mutate session content.
+      // Teacher owners may update their own session — including renames,
+      // status changes, sync-pull content updates, PLC linkage attach, score-
+      // publish field writes, and PR3 sharing fields. Identity fields stay
+      // immutable. The looser allowlist matches the Quiz session pattern:
+      // simple ownership check + immutable identity, no per-field hasOnly
+      // (sync, PLC, publish flows would otherwise need ever-growing
+      // allowlists). The student-side response rule below remains tight.
       allow update: if request.auth != null &&
         request.auth.token.firebase.sign_in_provider != 'anonymous' &&
         resource.data.teacherUid == request.auth.uid &&
         request.resource.data.id == resource.data.id &&
         request.resource.data.activityId == resource.data.activityId &&
-        request.resource.data.activityTitle == resource.data.activityTitle &&
         request.resource.data.teacherUid == resource.data.teacherUid &&
-        request.resource.data.youtubeUrl == resource.data.youtubeUrl &&
-        request.resource.data.questions == resource.data.questions &&
-        request.resource.data.settings == resource.data.settings &&
-        request.resource.data.allowedPins == resource.data.allowedPins &&
-        request.resource.data.createdAt == resource.data.createdAt &&
-        request.resource.data.diff(resource.data).affectedKeys().hasOnly(['assignmentName', 'status', 'endedAt', 'expiresAt']) &&
-        request.resource.data.assignmentName is string &&
-        request.resource.data.assignmentName.size() > 0 &&
-        request.resource.data.status in ['active', 'ended'] &&
-        (!('endedAt' in request.resource.data) || request.resource.data.endedAt is int) &&
-        (!('expiresAt' in request.resource.data) || request.resource.data.expiresAt is int);
+        request.resource.data.createdAt == resource.data.createdAt;
       // Owning teacher (or admin) may delete — used by the Video Activity
       // "Delete permanently" action in the Assignment archive to clean up the
       // session along with the per-teacher assignment doc. Mirrors GL sessions.
@@ -1597,52 +1653,49 @@ service cloud.firestore {
           (isStudentRoleUser()
             ? responseDocId == request.auth.uid
             : responseDocId.matches('^pin-[a-z0-9_]{1,64}-[a-z0-9_]{1,64}$'));
-        // Students update their own response to add answers, set
-        // completedAt, log tab switches, increment the attempt counter, or
-        // set their class period after the post-PIN picker. Ownership is
-        // enforced against the `studentUid` field, not the doc key (which
-        // is pin-derived for anonymous joiners). Mutable-field allowlist
-        // and monotonic-growth checks mirror Quiz response rules:
-        //   - `tabSwitchWarnings` and `completedAttempts` may only stay
-        //     the same or increase (prevents rollback tampering, e.g. a
-        //     student resetting their attempt counter to bypass the
-        //     `attemptLimit` cap).
-        //   - `answers` may only grow (size monotonic, all prior elements
-        //     preserved).
-        //   - Identity fields (`pin`, `name`, `joinedAt`) and
-        //     teacher-controlled fields (`score`, `isCorrect`,
-        //     `scoreVisibility`) are immutable from the client.
-        //     `studentUid` is checked separately as the ownership anchor
-        //     (the line right above this block).
-        allow update: if request.auth != null &&
-          resource.data.studentUid == request.auth.uid &&
-          passesStudentClassGateCompat(vaSessionClassIds(), vaSessionClassId()) &&
-          request.resource.data.studentUid == resource.data.studentUid &&
-          // Defense-in-depth: redundant with the `changedKeys().hasOnly([...])`
-          // allowlist below (which would already reject a `pin`/`name`/
-          // `joinedAt` change), but kept explicit so a future allowlist
-          // expansion can't silently allow these to mutate. SSO
-          // `studentRole` responses omit `pin` and `name` entirely, so the
-          // checks use `.get(_, null)` to tolerate the field being absent
-          // on both sides instead of throwing a Null-value error.
-          request.resource.data.get('pin', null) == resource.data.get('pin', null) &&
-          request.resource.data.get('name', null) == resource.data.get('name', null) &&
-          request.resource.data.get('joinedAt', null) == resource.data.get('joinedAt', null) &&
-          request.resource.data.score == resource.data.score &&
-          request.resource.data.diff(resource.data).changedKeys().hasOnly([
-            'answers',
-            'completedAt',
-            'tabSwitchWarnings',
-            'completedAttempts',
-            'classPeriod'
-          ]) &&
-          request.resource.data.answers is list &&
-          request.resource.data.answers.size() >= resource.data.answers.size() &&
-          request.resource.data.answers.hasAll(resource.data.answers) &&
-          (!request.resource.data.diff(resource.data).affectedKeys().hasAny(['tabSwitchWarnings']) ||
-           request.resource.data.tabSwitchWarnings >= resource.data.get('tabSwitchWarnings', 0)) &&
-          (!request.resource.data.diff(resource.data).affectedKeys().hasAny(['completedAttempts']) ||
-           request.resource.data.get('completedAttempts', 0) >= resource.data.get('completedAttempts', 0));
+        // Update is split into a TEACHER branch (PR3 publish-scores writes
+        // `score`/`isCorrect`/`scoreVisibility` onto each response) and a
+        // STUDENT branch (the existing answer-submit path). The teacher
+        // branch is permissive — the parent session's `teacherUid` gate
+        // is sufficient ownership; admins also pass for the
+        // `delete-assignment` and emergency repair flows. Mirrors the
+        // Quiz response update pattern.
+        //
+        // Branch mutual exclusivity is by intent, not accident: the teacher
+        // branch only checks `request.auth.uid == vaSessionTeacherUid()`,
+        // never `resource.data`, so a student calling update() will fail
+        // the teacher disjunct (their uid won't match the session's
+        // teacherUid) and fall through to the student branch's full
+        // append-only invariants. If `vaSessionTeacherUid()` ever needs to
+        // dereference the response itself (it shouldn't), revisit.
+        allow update: if request.auth != null && (
+          // Teacher branch.
+          (request.auth.uid == vaSessionTeacherUid() || isAdmin()) ||
+          // Student branch — same invariants as before PR3.
+          (
+            resource.data.studentUid == request.auth.uid &&
+            passesStudentClassGateCompat(vaSessionClassIds(), vaSessionClassId()) &&
+            request.resource.data.studentUid == resource.data.studentUid &&
+            request.resource.data.get('pin', null) == resource.data.get('pin', null) &&
+            request.resource.data.get('name', null) == resource.data.get('name', null) &&
+            request.resource.data.get('joinedAt', null) == resource.data.get('joinedAt', null) &&
+            request.resource.data.score == resource.data.score &&
+            request.resource.data.diff(resource.data).changedKeys().hasOnly([
+              'answers',
+              'completedAt',
+              'tabSwitchWarnings',
+              'completedAttempts',
+              'classPeriod'
+            ]) &&
+            request.resource.data.answers is list &&
+            request.resource.data.answers.size() >= resource.data.answers.size() &&
+            request.resource.data.answers.hasAll(resource.data.answers) &&
+            (!request.resource.data.diff(resource.data).affectedKeys().hasAny(['tabSwitchWarnings']) ||
+             request.resource.data.tabSwitchWarnings >= resource.data.get('tabSwitchWarnings', 0)) &&
+            (!request.resource.data.diff(resource.data).affectedKeys().hasAny(['completedAttempts']) ||
+             request.resource.data.get('completedAttempts', 0) >= resource.data.get('completedAttempts', 0))
+          )
+        );
         // Owning teacher (or admin) may delete responses when permanently
         // deleting the assignment (matches GL responses).
         allow delete: if request.auth != null && (

--- a/firestore.rules
+++ b/firestore.rules
@@ -988,6 +988,83 @@ service cloud.firestore {
           && request.auth.uid == resource.data.ownerUid;
       }
 
+      // PLC Quiz Library (Phase 2). Lightweight headers pointing at
+      // canonical `/synced_quizzes/{groupId}` docs — questions live there,
+      // not here. Any current PLC member can share a new quiz, edit any
+      // shared quiz's mirrored header (title/questionCount), or unshare.
+      // The orphan policy is "PLC copy stays" — deleting your personal
+      // copy of the source quiz does NOT cascade-delete the PLC entry.
+      //
+      // Schema lock-down (`keys().hasOnly([...])`) keeps the doc shape
+      // closed. Identity fields (`id`, `syncGroupId`, `sharedBy`,
+      // `sharedByEmail`, `sharedByName`, `sharedAt`) are immutable post-
+      // create so a different member can't quietly retarget the entry to
+      // a different sync group or rewrite attribution.
+      match /quizzes/{plcQuizId} {
+        allow read: if request.auth != null
+          && request.auth.uid in get(
+               /databases/$(database)/documents/plcs/$(plcId)
+             ).data.memberUids;
+
+        // Create: any member, doc id pinned, sharedBy must equal caller.
+        // No content (questions) on this doc — those live in the synced
+        // group, which has its own rule layer.
+        allow create: if request.auth != null
+          && request.auth.uid in get(
+               /databases/$(database)/documents/plcs/$(plcId)
+             ).data.memberUids
+          && request.resource.data.keys().hasOnly([
+               'id', 'title', 'questionCount', 'syncGroupId',
+               'sharedBy', 'sharedByEmail', 'sharedByName',
+               'sharedAt', 'updatedAt'
+             ])
+          && plcQuizId == request.resource.data.id
+          && request.resource.data.sharedBy == request.auth.uid
+          && request.resource.data.title is string
+          && request.resource.data.questionCount is int
+          && request.resource.data.questionCount >= 0
+          && request.resource.data.syncGroupId is string
+          // Guard against an empty `syncGroupId` smuggling a broken stub
+          // entry past the rule. The Cloud Function rejects empty strings
+          // server-side too; pinning at the rule layer is defense-in-depth.
+          && request.resource.data.syncGroupId.size() > 0
+          && request.resource.data.sharedByEmail is string
+          && request.resource.data.sharedByName is string
+          && request.resource.data.sharedAt is int
+          && request.resource.data.updatedAt is int;
+
+        // Update: any member can mirror title/questionCount/updatedAt
+        // (e.g. after a peer publishes an edit). Identity + attribution
+        // fields are immutable so stale-mirror writes can't quietly
+        // retarget the entry or rewrite who shared it.
+        allow update: if request.auth != null
+          && request.auth.uid in get(
+               /databases/$(database)/documents/plcs/$(plcId)
+             ).data.memberUids
+          && request.resource.data.keys().hasOnly([
+               'id', 'title', 'questionCount', 'syncGroupId',
+               'sharedBy', 'sharedByEmail', 'sharedByName',
+               'sharedAt', 'updatedAt'
+             ])
+          && request.resource.data.id == resource.data.id
+          && request.resource.data.syncGroupId == resource.data.syncGroupId
+          && request.resource.data.sharedBy == resource.data.sharedBy
+          && request.resource.data.sharedByEmail == resource.data.sharedByEmail
+          && request.resource.data.sharedByName == resource.data.sharedByName
+          && request.resource.data.sharedAt == resource.data.sharedAt
+          && request.resource.data.title is string
+          && request.resource.data.questionCount is int
+          && request.resource.data.questionCount >= 0
+          && request.resource.data.updatedAt is int;
+
+        // Any member can unshare. Matches the "PLC-owned" model — a quiz
+        // shared with the PLC belongs to the PLC, not the original sharer.
+        allow delete: if request.auth != null
+          && request.auth.uid in get(
+               /databases/$(database)/documents/plcs/$(plcId)
+             ).data.memberUids;
+      }
+
       // PLC shared notes (Phase 5). Lightweight collaborative notebook —
       // any current member can CRUD any note. LWW on edits via the
       // `lastEditedBy` / `lastEditedAt` snapshot on each write. Schema

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -27,6 +27,10 @@ export { resetOrganizationUserPassword } from './organizationResetPassword';
 export { getOrgUserActivity } from './organizationUserActivity';
 export { plcInvitationEmail } from './plcInviteEmails';
 export { joinSyncedQuizGroup, leaveSyncedQuizGroup } from './syncedQuizGroups';
+export {
+  joinSyncedVideoActivityGroup,
+  leaveSyncedVideoActivityGroup,
+} from './syncedVideoActivityGroups';
 export { joinPlcQuizSyncGroup } from './plcQuizSyncJoin';
 
 setGlobalOptions({ region: 'us-central1' });

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -905,6 +905,26 @@ Worked example (flashcards app with a "Done" button):
           `,
           userPrompt: sanitizedUserInput,
         }),
+        'video-activity-recommend': () => ({
+          systemPrompt: `
+You are an expert classroom instructional designer recommending YouTube videos for K-12 teachers building Video Activity assignments. The teacher will provide a topic, learning objective, or grade-level description in the <topic> tags. Recommend a SINGLE high-quality, classroom-appropriate YouTube video that fits the topic.
+
+Hard constraints:
+1. The video MUST be on YouTube (not Vimeo, TED.com, etc.) and have a stable 11-character video id.
+2. Prefer videos under 15 minutes — shorter is better for in-class video activities.
+3. Prefer educator-aligned channels (Crash Course, SciShow Kids, Khan Academy, TED-Ed, National Geographic, etc.) over random uploads.
+4. Reject anything with mature content, ads-heavy intros, or low production quality.
+5. If you cannot confidently recommend a real, currently-live YouTube video that fits the topic, return { "videoId": "", "title": "", "rationale": "..." } with an empty videoId — do NOT hallucinate ids.
+
+Output JSON ONLY in this exact shape:
+{
+  "videoId": "11_char_id",
+  "title": "Video title as you remember it",
+  "rationale": "One sentence explaining why this fits the topic and grade level."
+}
+          `,
+          userPrompt: `Topic: <topic>${sanitizedUserInput}</topic>`,
+        }),
       };
 
       const promptDataFn = promptMap[genType];

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -27,6 +27,7 @@ export { resetOrganizationUserPassword } from './organizationResetPassword';
 export { getOrgUserActivity } from './organizationUserActivity';
 export { plcInvitationEmail } from './plcInviteEmails';
 export { joinSyncedQuizGroup, leaveSyncedQuizGroup } from './syncedQuizGroups';
+export { joinPlcQuizSyncGroup } from './plcQuizSyncJoin';
 
 setGlobalOptions({ region: 'us-central1' });
 

--- a/functions/src/plcQuizSyncJoin.ts
+++ b/functions/src/plcQuizSyncJoin.ts
@@ -1,0 +1,147 @@
+/**
+ * PLC quiz sync-join Cloud Function (Phase 2).
+ *
+ * Sibling of `syncedQuizGroups.handleJoinSyncedQuizGroup` for the PLC
+ * Quiz Library entry point. Where the existing handler uses a
+ * `shared_assignments/{shareId}` doc to resolve `syncGroupId`, this one
+ * uses `plcs/{plcId}/quizzes/{plcQuizId}` and additionally verifies that
+ * the caller is a current member of the parent PLC.
+ *
+ * Membership validation is server-side (Admin SDK bypasses Firestore
+ * rules — clients can't write `participants` directly); we don't accept
+ * the caller's word that they belong to a given PLC.
+ *
+ * Idempotent: re-joining is a no-op (returns `alreadyJoined: true`)
+ * without bumping `version`, matching the share-id sibling.
+ */
+
+import { onCall, HttpsError } from 'firebase-functions/v2/https';
+import * as admin from 'firebase-admin';
+import type { SyncedParticipant } from './syncedQuizGroups';
+
+if (!admin.apps.length) {
+  admin.initializeApp();
+}
+
+export interface JoinPlcQuizSyncGroupRequest {
+  plcId?: unknown;
+  plcQuizId?: unknown;
+}
+
+export interface JoinPlcQuizSyncGroupResponse {
+  groupId: string;
+  version: number;
+  alreadyJoined: boolean;
+}
+
+/**
+ * Verify membership + group join in one transaction so a member who's
+ * removed mid-flow can't sneak into the participants map.
+ *
+ * Throws `HttpsError`:
+ *   - `not-found` if the PLC, the PLC quiz entry, or the synced group
+ *     can't be located.
+ *   - `permission-denied` if the caller isn't a current PLC member.
+ *   - `failed-precondition` if the PLC quiz entry's `syncGroupId` field
+ *     is missing/non-string (data shape regression).
+ */
+export async function handleJoinPlcQuizSyncGroup(
+  db: admin.firestore.Firestore,
+  uid: string,
+  plcId: string,
+  plcQuizId: string
+): Promise<JoinPlcQuizSyncGroupResponse> {
+  const plcRef = db.collection('plcs').doc(plcId);
+  const plcQuizRef = plcRef.collection('quizzes').doc(plcQuizId);
+
+  return db.runTransaction(async (tx) => {
+    // Read membership + plc quiz inside the transaction so a member who
+    // is removed from `memberUids` mid-flow can't sneak into the synced
+    // group's `participants` map (the membership read becomes a
+    // contention point that forces a retry on concurrent change).
+    const [plcSnap, plcQuizSnap] = await Promise.all([
+      tx.get(plcRef),
+      tx.get(plcQuizRef),
+    ]);
+    if (!plcSnap.exists) {
+      throw new HttpsError('not-found', 'PLC not found.');
+    }
+    const plcData = plcSnap.data() as { memberUids?: unknown } | undefined;
+    const memberUids = Array.isArray(plcData?.memberUids)
+      ? (plcData?.memberUids as unknown[]).filter(
+          (u): u is string => typeof u === 'string'
+        )
+      : [];
+    if (!memberUids.includes(uid)) {
+      throw new HttpsError(
+        'permission-denied',
+        'You are not a member of this PLC.'
+      );
+    }
+
+    if (!plcQuizSnap.exists) {
+      throw new HttpsError('not-found', 'PLC quiz not found.');
+    }
+    const plcQuizData = plcQuizSnap.data() as
+      | { syncGroupId?: unknown }
+      | undefined;
+    const groupId = plcQuizData?.syncGroupId;
+    if (typeof groupId !== 'string' || groupId.length === 0) {
+      throw new HttpsError(
+        'failed-precondition',
+        'PLC quiz is not linked to a synced group.'
+      );
+    }
+
+    const groupRef = db.collection('synced_quizzes').doc(groupId);
+    const groupSnap = await tx.get(groupRef);
+    if (!groupSnap.exists) {
+      throw new HttpsError('not-found', 'Synced group not found.');
+    }
+    const groupData = groupSnap.data() as
+      | {
+          version?: number;
+          participants?: Record<string, SyncedParticipant>;
+        }
+      | undefined;
+    const participants = { ...(groupData?.participants ?? {}) };
+    const alreadyJoined = Object.prototype.hasOwnProperty.call(
+      participants,
+      uid
+    );
+    if (!alreadyJoined) {
+      const now = Date.now();
+      participants[uid] = { joinedAt: now };
+      tx.update(groupRef, {
+        participants,
+        updatedAt: now,
+      });
+    }
+    return {
+      groupId,
+      version: groupData?.version ?? 1,
+      alreadyJoined,
+    };
+  });
+}
+
+export const joinPlcQuizSyncGroup = onCall<JoinPlcQuizSyncGroupRequest>(
+  { region: 'us-central1' },
+  async (request) => {
+    const uid = request.auth?.uid;
+    if (!uid) {
+      throw new HttpsError(
+        'unauthenticated',
+        'Sign in to join a PLC quiz sync group.'
+      );
+    }
+    const { plcId, plcQuizId } = request.data ?? {};
+    if (typeof plcId !== 'string' || plcId.length === 0) {
+      throw new HttpsError('invalid-argument', 'plcId is required.');
+    }
+    if (typeof plcQuizId !== 'string' || plcQuizId.length === 0) {
+      throw new HttpsError('invalid-argument', 'plcQuizId is required.');
+    }
+    return handleJoinPlcQuizSyncGroup(admin.firestore(), uid, plcId, plcQuizId);
+  }
+);

--- a/functions/src/syncedVideoActivityGroups.ts
+++ b/functions/src/syncedVideoActivityGroups.ts
@@ -1,0 +1,189 @@
+/**
+ * Synced Video Activity group membership Cloud Functions. Counterpart to
+ * `syncedQuizGroups.ts`, scoped to Video Activity's parallel collections:
+ *
+ *  - `/shared_video_activity_assignments/{shareId}` — pasted share doc
+ *  - `/synced_video_activities/{groupId}` — canonical synced content
+ *
+ * Two v2 onCall functions back the synced-mode share flow:
+ *
+ *  - joinSyncedVideoActivityGroup: invoked when a teacher pastes a synced
+ *    share URL and picks "Synced" in the import-mode picker. Validates that
+ *    the presented `shareId` resolves to a doc carrying a `syncGroupId`,
+ *    then adds the caller's uid to that group's `participants` map. Admin
+ *    SDK bypasses Firestore rules — clients can't write to `participants`
+ *    directly.
+ *
+ *  - leaveSyncedVideoActivityGroup: invoked when a teacher chooses "Stop
+ *    syncing" on a synced activity card. Removes the caller from
+ *    `participants`. Empty groups are left intact so future paste of the
+ *    same share URL still resolves a bootstrap snapshot.
+ *
+ * Business logic is exposed via thin handlers that take an Admin SDK
+ * Firestore reference plus the validated request fields, so unit tests can
+ * drive them with the firebase-admin emulator without rebuilding the onCall
+ * wrapper. Mirrors syncedQuizGroups.ts pattern.
+ */
+
+import { onCall, HttpsError } from 'firebase-functions/v2/https';
+import * as admin from 'firebase-admin';
+
+if (!admin.apps.length) {
+  admin.initializeApp();
+}
+
+const SHARED_COLLECTION = 'shared_video_activity_assignments';
+const SYNCED_COLLECTION = 'synced_video_activities';
+
+export interface SyncedVideoActivityParticipant {
+  joinedAt: number;
+}
+
+export interface JoinSyncedVideoActivityGroupRequest {
+  shareId?: unknown;
+}
+
+export interface JoinSyncedVideoActivityGroupResponse {
+  groupId: string;
+  version: number;
+  alreadyJoined: boolean;
+}
+
+export interface LeaveSyncedVideoActivityGroupRequest {
+  groupId?: unknown;
+}
+
+export interface LeaveSyncedVideoActivityGroupResponse {
+  remainingParticipants: number;
+}
+
+export async function handleJoinSyncedVideoActivityGroup(
+  db: admin.firestore.Firestore,
+  uid: string,
+  shareId: string
+): Promise<JoinSyncedVideoActivityGroupResponse> {
+  const shareRef = db.collection(SHARED_COLLECTION).doc(shareId);
+  const shareSnap = await shareRef.get();
+  if (!shareSnap.exists) {
+    throw new HttpsError('not-found', 'Shared video activity not found.');
+  }
+  const shareData = shareSnap.data() as { syncGroupId?: string } | undefined;
+  const groupId = shareData?.syncGroupId;
+  if (!groupId || typeof groupId !== 'string') {
+    throw new HttpsError(
+      'failed-precondition',
+      'This share is not enabled for sync.'
+    );
+  }
+
+  const groupRef = db.collection(SYNCED_COLLECTION).doc(groupId);
+
+  return db.runTransaction(async (tx) => {
+    const groupSnap = await tx.get(groupRef);
+    if (!groupSnap.exists) {
+      throw new HttpsError(
+        'not-found',
+        'Synced video activity group not found.'
+      );
+    }
+    const groupData = groupSnap.data() as
+      | {
+          version: number;
+          participants?: Record<string, SyncedVideoActivityParticipant>;
+        }
+      | undefined;
+    const participants = { ...(groupData?.participants ?? {}) };
+    const alreadyJoined = Object.prototype.hasOwnProperty.call(
+      participants,
+      uid
+    );
+    if (!alreadyJoined) {
+      const now = Date.now();
+      participants[uid] = { joinedAt: now };
+      tx.update(groupRef, {
+        participants,
+        updatedAt: now,
+      });
+    }
+    return {
+      groupId,
+      version: groupData?.version ?? 1,
+      alreadyJoined,
+    };
+  });
+}
+
+export async function handleLeaveSyncedVideoActivityGroup(
+  db: admin.firestore.Firestore,
+  uid: string,
+  groupId: string
+): Promise<LeaveSyncedVideoActivityGroupResponse> {
+  const groupRef = db.collection(SYNCED_COLLECTION).doc(groupId);
+  return db.runTransaction(async (tx) => {
+    const groupSnap = await tx.get(groupRef);
+    if (!groupSnap.exists) {
+      throw new HttpsError(
+        'not-found',
+        'Synced video activity group not found.'
+      );
+    }
+    const groupData = groupSnap.data() as
+      | { participants?: Record<string, SyncedVideoActivityParticipant> }
+      | undefined;
+    const participants = { ...(groupData?.participants ?? {}) };
+    if (Object.prototype.hasOwnProperty.call(participants, uid)) {
+      delete participants[uid];
+      tx.update(groupRef, {
+        participants,
+        updatedAt: Date.now(),
+      });
+    }
+    return { remainingParticipants: Object.keys(participants).length };
+  });
+}
+
+export const joinSyncedVideoActivityGroup =
+  onCall<JoinSyncedVideoActivityGroupRequest>(
+    { region: 'us-central1' },
+    async (request) => {
+      const uid = request.auth?.uid;
+      if (!uid) {
+        throw new HttpsError(
+          'unauthenticated',
+          'Sign in to join a synced video activity.'
+        );
+      }
+      const shareId = request.data?.shareId;
+      if (typeof shareId !== 'string' || shareId.length === 0) {
+        throw new HttpsError('invalid-argument', 'shareId is required.');
+      }
+      return handleJoinSyncedVideoActivityGroup(
+        admin.firestore(),
+        uid,
+        shareId
+      );
+    }
+  );
+
+export const leaveSyncedVideoActivityGroup =
+  onCall<LeaveSyncedVideoActivityGroupRequest>(
+    { region: 'us-central1' },
+    async (request) => {
+      const uid = request.auth?.uid;
+      if (!uid) {
+        throw new HttpsError(
+          'unauthenticated',
+          'Sign in to leave a synced video activity.'
+        );
+      }
+      const groupId = request.data?.groupId;
+      if (typeof groupId !== 'string' || groupId.length === 0) {
+        throw new HttpsError('invalid-argument', 'groupId is required.');
+      }
+      return handleLeaveSyncedVideoActivityGroup(
+        admin.firestore(),
+        uid,
+        groupId
+      );
+    }
+  );

--- a/hooks/usePlcAssignmentIndex.ts
+++ b/hooks/usePlcAssignmentIndex.ts
@@ -32,12 +32,15 @@ function parseEntry(
   ) {
     return null;
   }
-  // `kind` is a discriminator slot for future video-activity entries.
-  // Today there's only one valid value; later phases will widen the union
-  // and switch on the raw `data.kind` here.
+  // PR3a widened the type union to include 'video-activity'. Pre-PR3a
+  // entries lack the `kind` field; default to 'quiz' for backward compat.
+  // VA index writes (PR3b) will set `kind: 'video-activity'` explicitly.
+  const rawKind = data.kind;
+  const kind: PlcAssignmentIndexEntry['kind'] =
+    rawKind === 'video-activity' ? 'video-activity' : 'quiz';
   return {
     id,
-    kind: 'quiz',
+    kind,
     ownerUid: data.ownerUid,
     ownerName: typeof data.ownerName === 'string' ? data.ownerName : '',
     ownerEmail: typeof data.ownerEmail === 'string' ? data.ownerEmail : '',

--- a/hooks/usePlcQuizzes.ts
+++ b/hooks/usePlcQuizzes.ts
@@ -1,0 +1,246 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  collection,
+  deleteDoc,
+  doc,
+  onSnapshot,
+  orderBy,
+  query,
+  setDoc,
+  updateDoc,
+} from 'firebase/firestore';
+import { db, isAuthBypass } from '@/config/firebase';
+import { useAuth } from '@/context/useAuth';
+import { PlcQuizEntry } from '@/types';
+import { logError } from '@/utils/logError';
+
+const PLCS_COLLECTION = 'plcs';
+const QUIZZES_SUBCOLLECTION = 'quizzes';
+
+interface ShareQuizWithPlcInput {
+  /** Firestore doc id for the new PLC quiz entry. Caller mints (uuid). */
+  plcQuizId: string;
+  /** Pointer to the canonical `/synced_quizzes/{groupId}` doc. */
+  syncGroupId: string;
+  /** Mirrored from the synced group at share time. */
+  title: string;
+  /** Mirrored from the synced group's questions array length. */
+  questionCount: number;
+  /** Display name snapshot for attribution. */
+  sharedByName: string;
+  /** Lowercased email snapshot for display. */
+  sharedByEmail: string;
+}
+
+interface UsePlcQuizzesResult {
+  quizzes: PlcQuizEntry[];
+  loading: boolean;
+  /**
+   * Write a new PLC quiz entry. Caller is responsible for first standing
+   * up the canonical `synced_quizzes/{syncGroupId}` doc (via
+   * `createSyncedQuizGroup`). Doc id = `plcQuizId`. The signed-in user is
+   * stamped as `sharedBy`.
+   */
+  shareQuizWithPlc: (input: ShareQuizWithPlcInput) => Promise<void>;
+  /**
+   * Mirror title/questionCount onto the PLC quiz doc after a peer's
+   * publish. Fire-and-forget — failures log but don't reject so the
+   * caller's primary action (e.g. `publishSyncedQuiz`) returns cleanly.
+   */
+  mirrorPlcQuizHeader: (
+    plcQuizId: string,
+    patch: { title?: string; questionCount?: number }
+  ) => Promise<void>;
+  /** Remove a PLC quiz entry. Any member can unshare (PLC-owned model). */
+  unshareQuizFromPlc: (plcQuizId: string) => Promise<void>;
+}
+
+function parseEntry(
+  id: string,
+  data: Record<string, unknown>
+): PlcQuizEntry | null {
+  if (
+    typeof data.title !== 'string' ||
+    typeof data.questionCount !== 'number' ||
+    typeof data.syncGroupId !== 'string' ||
+    typeof data.sharedBy !== 'string' ||
+    typeof data.sharedAt !== 'number' ||
+    typeof data.updatedAt !== 'number'
+  ) {
+    return null;
+  }
+  return {
+    id,
+    title: data.title,
+    questionCount: data.questionCount,
+    syncGroupId: data.syncGroupId,
+    sharedBy: data.sharedBy,
+    sharedByEmail:
+      typeof data.sharedByEmail === 'string' ? data.sharedByEmail : '',
+    sharedByName:
+      typeof data.sharedByName === 'string' ? data.sharedByName : '',
+    sharedAt: data.sharedAt,
+    updatedAt: data.updatedAt,
+  };
+}
+
+/**
+ * Live subscription to a single PLC's quiz library. Returns entries
+ * sorted newest-edit-first by `updatedAt`. Pass `null` for `plcId` to
+ * disable the listener (e.g. while the dashboard is closed).
+ *
+ * Mirrors `usePlcAssignmentIndex.ts` — same parser-drops-malformed
+ * defense, same render-time `prevPlcId` reset so the UI never flashes
+ * the previous PLC's entries while the new snapshot is in flight.
+ */
+export const usePlcQuizzes = (plcId: string | null): UsePlcQuizzesResult => {
+  const { user } = useAuth();
+  const [quizzes, setQuizzes] = useState<PlcQuizEntry[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const [prevPlcId, setPrevPlcId] = useState(plcId);
+  if (plcId !== prevPlcId) {
+    setPrevPlcId(plcId);
+    setQuizzes([]);
+    setLoading(true);
+  }
+
+  useEffect(() => {
+    if (!plcId || !user || isAuthBypass) {
+      const t = setTimeout(() => {
+        setQuizzes([]);
+        setLoading(false);
+      }, 0);
+      return () => clearTimeout(t);
+    }
+    const ref = collection(db, PLCS_COLLECTION, plcId, QUIZZES_SUBCOLLECTION);
+    const unsub = onSnapshot(
+      query(ref, orderBy('updatedAt', 'desc')),
+      (snap) => {
+        const list: PlcQuizEntry[] = [];
+        snap.forEach((d) => {
+          const parsed = parseEntry(d.id, d.data() as Record<string, unknown>);
+          if (parsed) list.push(parsed);
+        });
+        setQuizzes(list);
+        setLoading(false);
+      },
+      (err) => {
+        logError('usePlcQuizzes.snapshot', err, { plcId });
+        setLoading(false);
+      }
+    );
+    return () => unsub();
+  }, [plcId, user]);
+
+  const shareQuizWithPlc = useCallback(
+    async (input: ShareQuizWithPlcInput): Promise<void> => {
+      if (!plcId || !user) throw new Error('Not signed in');
+      const now = Date.now();
+      const entry: PlcQuizEntry = {
+        id: input.plcQuizId,
+        title: input.title,
+        questionCount: input.questionCount,
+        syncGroupId: input.syncGroupId,
+        sharedBy: user.uid,
+        sharedByEmail: input.sharedByEmail,
+        sharedByName: input.sharedByName,
+        sharedAt: now,
+        updatedAt: now,
+      };
+      await setDoc(
+        doc(db, PLCS_COLLECTION, plcId, QUIZZES_SUBCOLLECTION, input.plcQuizId),
+        entry
+      );
+    },
+    [plcId, user]
+  );
+
+  const mirrorPlcQuizHeader = useCallback(
+    async (
+      plcQuizId: string,
+      patch: { title?: string; questionCount?: number }
+    ): Promise<void> => {
+      if (!plcId || !user) return;
+      try {
+        const fields: Record<string, unknown> = { updatedAt: Date.now() };
+        if (patch.title !== undefined) fields.title = patch.title;
+        if (patch.questionCount !== undefined) {
+          fields.questionCount = patch.questionCount;
+        }
+        await updateDoc(
+          doc(db, PLCS_COLLECTION, plcId, QUIZZES_SUBCOLLECTION, plcQuizId),
+          fields
+        );
+      } catch (err) {
+        // Mirror writes are best-effort — never reject so callers' primary
+        // action (e.g. `publishSyncedQuiz`) returns cleanly. A
+        // `not-found` from `updateDoc` here means a teammate unshared the
+        // PLC entry between our snapshot read and this mirror write —
+        // the entry is already gone, the canonical sync group still has
+        // the new content, and the next snapshot tick will reflect both.
+        // No remediation needed; logging is sufficient.
+        logError('usePlcQuizzes.mirrorHeader', err, { plcId, plcQuizId });
+      }
+    },
+    [plcId, user]
+  );
+
+  const unshareQuizFromPlc = useCallback(
+    async (plcQuizId: string): Promise<void> => {
+      if (!plcId || !user) throw new Error('Not signed in');
+      await deleteDoc(
+        doc(db, PLCS_COLLECTION, plcId, QUIZZES_SUBCOLLECTION, plcQuizId)
+      );
+    },
+    [plcId, user]
+  );
+
+  return useMemo(
+    () => ({
+      quizzes,
+      loading,
+      shareQuizWithPlc,
+      mirrorPlcQuizHeader,
+      unshareQuizFromPlc,
+    }),
+    [
+      quizzes,
+      loading,
+      shareQuizWithPlc,
+      mirrorPlcQuizHeader,
+      unshareQuizFromPlc,
+    ]
+  );
+};
+
+/**
+ * One-shot write of a PLC quiz entry. Used from the QuizWidget's
+ * "Share with PLC" handler — the widget knows the target PLC at call
+ * time but isn't subscribed to that PLC's `usePlcQuizzes`. Mirrors the
+ * `writePlcAssignmentIndexEntry` shape from Phase 1, but rejects on
+ * failure (unlike the index writer this is a primary user action, not a
+ * fire-and-forget side effect).
+ */
+export async function writePlcQuizEntry(
+  plcId: string,
+  uid: string,
+  input: ShareQuizWithPlcInput
+): Promise<void> {
+  const now = Date.now();
+  const entry: PlcQuizEntry = {
+    id: input.plcQuizId,
+    title: input.title,
+    questionCount: input.questionCount,
+    syncGroupId: input.syncGroupId,
+    sharedBy: uid,
+    sharedByEmail: input.sharedByEmail,
+    sharedByName: input.sharedByName,
+    sharedAt: now,
+    updatedAt: now,
+  };
+  await setDoc(
+    doc(db, PLCS_COLLECTION, plcId, QUIZZES_SUBCOLLECTION, input.plcQuizId),
+    entry
+  );
+}

--- a/hooks/useSyncedQuizGroups.ts
+++ b/hooks/useSyncedQuizGroups.ts
@@ -334,3 +334,21 @@ export async function callLeaveSyncedQuizGroup(
   const result = await fn({ groupId });
   return result.data;
 }
+
+/**
+ * PLC variant of `callJoinSyncedQuizGroup` (Phase 2). Adds the caller to
+ * the synced group referenced by `plcs/{plcId}/quizzes/{plcQuizId}` after
+ * the Cloud Function verifies the caller is a current PLC member. Used by
+ * the PLC Quiz Library tab's "Add to my library (Sync)" path.
+ */
+export async function callJoinPlcQuizSyncGroup(
+  plcId: string,
+  plcQuizId: string
+): Promise<JoinResponse> {
+  const fn = httpsCallable<{ plcId: string; plcQuizId: string }, JoinResponse>(
+    functions,
+    'joinPlcQuizSyncGroup'
+  );
+  const result = await fn({ plcId, plcQuizId });
+  return result.data;
+}

--- a/hooks/useSyncedVideoActivityGroups.ts
+++ b/hooks/useSyncedVideoActivityGroups.ts
@@ -1,0 +1,272 @@
+/**
+ * useSyncedVideoActivityGroups — counterpart to `useSyncedQuizGroups` for
+ * Video Activity. Bridges the canonical docs at
+ * `/synced_video_activities/{groupId}` and the teacher's UI.
+ *
+ * Architectural decisions mirror the Quiz hook:
+ *   - Per-doc `onSnapshot` listeners (vs. an `in`-query) so list changes
+ *     diff naturally and we don't hit the 30-id `in` cap.
+ *   - Adjust-state-while-rendering when the id set changes — prunes the
+ *     map of stale entries before the effect re-runs.
+ *   - Transactional publish that asserts `expectedVersion` and bumps by
+ *     exactly one. The Firestore rule mirrors the +1 invariant; concurrent
+ *     losers retry against the new base version.
+ */
+
+import { useEffect, useState } from 'react';
+import {
+  doc,
+  getDoc,
+  onSnapshot,
+  runTransaction,
+  setDoc,
+} from 'firebase/firestore';
+import { httpsCallable } from 'firebase/functions';
+import { db, functions } from '../config/firebase';
+import { logError } from '../utils/logError';
+import type { SyncedVideoActivityGroup, VideoActivityQuestion } from '../types';
+
+const SYNCED_COLLECTION = 'synced_video_activities';
+
+export interface PublishSyncedVideoActivityInput {
+  title: string;
+  youtubeUrl: string;
+  questions: VideoActivityQuestion[];
+  expectedVersion: number;
+  uid: string;
+}
+
+export interface PublishSyncedVideoActivityResult {
+  version: number;
+}
+
+export class SyncedVideoActivityVersionConflictError extends Error {
+  readonly currentVersion: number;
+  readonly expectedVersion: number;
+  constructor(expectedVersion: number, currentVersion: number) {
+    super(
+      `Synced video activity canonical version is ${currentVersion} but caller expected ${expectedVersion}.`
+    );
+    this.name = 'SyncedVideoActivityVersionConflictError';
+    this.expectedVersion = expectedVersion;
+    this.currentVersion = currentVersion;
+  }
+}
+
+export function useSyncedVideoActivityGroupsByIds(
+  syncGroupIds: readonly string[] | undefined
+): {
+  groups: Map<string, SyncedVideoActivityGroup>;
+  loading: boolean;
+} {
+  const [groups, setGroups] = useState<Map<string, SyncedVideoActivityGroup>>(
+    () => new Map()
+  );
+  const [loading, setLoading] = useState<boolean>(
+    () => (syncGroupIds?.length ?? 0) > 0
+  );
+
+  // Dedupe before sorting so `total` in the effect's `markResolved`
+  // counter matches the number of unique listeners we'll actually
+  // create. Otherwise a duplicate id would inflate `total` and the
+  // hook's `loading` flag would hang at `true` forever.
+  const idsKey = Array.from(new Set(syncGroupIds ?? []))
+    .sort()
+    .join(',');
+
+  const [prevIdsKey, setPrevIdsKey] = useState(idsKey);
+  if (prevIdsKey !== idsKey) {
+    setPrevIdsKey(idsKey);
+    if (idsKey === '') {
+      setGroups((prev) => (prev.size === 0 ? prev : new Map()));
+      setLoading(false);
+    } else {
+      const liveIds = new Set(idsKey.split(','));
+      setGroups((prev) => {
+        let mutated = false;
+        const next = new Map<string, SyncedVideoActivityGroup>();
+        for (const [groupId, group] of prev) {
+          if (liveIds.has(groupId)) {
+            next.set(groupId, group);
+          } else {
+            mutated = true;
+          }
+        }
+        if (!mutated && next.size === prev.size) return prev;
+        return next;
+      });
+      setLoading(true);
+    }
+  }
+
+  useEffect(() => {
+    if (idsKey === '') return;
+    const ids = idsKey.split(',');
+    const resolved = new Set<string>();
+    const total = ids.length;
+    const markResolved = (groupId: string) => {
+      if (resolved.has(groupId)) return;
+      resolved.add(groupId);
+      if (resolved.size === total) setLoading(false);
+    };
+    const unsubs: Array<() => void> = ids.map((groupId) =>
+      onSnapshot(
+        doc(db, SYNCED_COLLECTION, groupId),
+        (snap) => {
+          setGroups((prev) => {
+            const next = new Map(prev);
+            if (snap.exists()) {
+              next.set(groupId, {
+                id: groupId,
+                ...(snap.data() as Omit<SyncedVideoActivityGroup, 'id'>),
+              });
+            } else {
+              next.delete(groupId);
+            }
+            return next;
+          });
+          markResolved(groupId);
+        },
+        (err) => {
+          logError('useSyncedVideoActivityGroups.subscribe', err, { groupId });
+          markResolved(groupId);
+        }
+      )
+    );
+    return () => {
+      unsubs.forEach((u) => u());
+    };
+  }, [idsKey]);
+
+  return { groups, loading };
+}
+
+/**
+ * Read the latest canonical content for a single synced group. Used by the
+ * "Sync available" pull path on activity library cards.
+ */
+export async function pullSyncedVideoActivityContent(groupId: string): Promise<{
+  title: string;
+  youtubeUrl: string;
+  questions: VideoActivityQuestion[];
+  version: number;
+}> {
+  const snap = await getDoc(doc(db, SYNCED_COLLECTION, groupId));
+  if (!snap.exists()) {
+    throw new Error('Synced video activity group not found.');
+  }
+  const data = snap.data() as Pick<
+    SyncedVideoActivityGroup,
+    'title' | 'youtubeUrl' | 'questions' | 'version'
+  >;
+  return {
+    title: data.title,
+    youtubeUrl: data.youtubeUrl ?? '',
+    questions: data.questions ?? [],
+    version: data.version ?? 1,
+  };
+}
+
+/**
+ * Create the canonical doc for a brand-new synced group. Used by
+ * `shareAssignment` when the source activity has no `syncGroupId` yet —
+ * the sharer is the sole initial participant.
+ */
+export async function createSyncedVideoActivityGroup(input: {
+  groupId: string;
+  uid: string;
+  title: string;
+  youtubeUrl: string;
+  questions: VideoActivityQuestion[];
+  plcId?: string;
+}): Promise<void> {
+  const now = Date.now();
+  const payload: SyncedVideoActivityGroup = {
+    id: input.groupId,
+    version: 1,
+    title: input.title,
+    youtubeUrl: input.youtubeUrl,
+    questions: input.questions,
+    participants: { [input.uid]: { joinedAt: now } },
+    ...(input.plcId ? { plcId: input.plcId } : {}),
+    createdAt: now,
+    updatedAt: now,
+    updatedBy: input.uid,
+  };
+  await setDoc(doc(db, SYNCED_COLLECTION, input.groupId), payload);
+}
+
+/**
+ * Transactionally publish a content edit to a synced group. Asserts the
+ * caller's `expectedVersion` is still the canonical doc's `version`,
+ * increments by 1, and stamps `updatedBy`.
+ */
+export async function publishSyncedVideoActivity(
+  groupId: string,
+  input: PublishSyncedVideoActivityInput
+): Promise<PublishSyncedVideoActivityResult> {
+  const ref = doc(db, SYNCED_COLLECTION, groupId);
+  return runTransaction(db, async (tx) => {
+    const snap = await tx.get(ref);
+    if (!snap.exists()) {
+      throw new Error('Synced video activity group not found.');
+    }
+    const current = snap.data() as SyncedVideoActivityGroup;
+    if (current.version !== input.expectedVersion) {
+      throw new SyncedVideoActivityVersionConflictError(
+        input.expectedVersion,
+        current.version
+      );
+    }
+    if (
+      !current.participants ||
+      !Object.prototype.hasOwnProperty.call(current.participants, input.uid)
+    ) {
+      throw new Error(
+        'You are not a participant of this synced video activity group.'
+      );
+    }
+    const nextVersion = current.version + 1;
+    const now = Date.now();
+    tx.update(ref, {
+      version: nextVersion,
+      title: input.title,
+      youtubeUrl: input.youtubeUrl,
+      questions: input.questions,
+      updatedAt: now,
+      updatedBy: input.uid,
+    });
+    return { version: nextVersion };
+  });
+}
+
+interface JoinResponse {
+  groupId: string;
+  version: number;
+  alreadyJoined: boolean;
+}
+interface LeaveResponse {
+  remainingParticipants: number;
+}
+
+export async function callJoinSyncedVideoActivityGroup(
+  shareId: string
+): Promise<JoinResponse> {
+  const fn = httpsCallable<{ shareId: string }, JoinResponse>(
+    functions,
+    'joinSyncedVideoActivityGroup'
+  );
+  const result = await fn({ shareId });
+  return result.data;
+}
+
+export async function callLeaveSyncedVideoActivityGroup(
+  groupId: string
+): Promise<LeaveResponse> {
+  const fn = httpsCallable<{ groupId: string }, LeaveResponse>(
+    functions,
+    'leaveSyncedVideoActivityGroup'
+  );
+  const result = await fn({ groupId });
+  return result.data;
+}

--- a/hooks/useVideoActivity.ts
+++ b/hooks/useVideoActivity.ts
@@ -9,6 +9,7 @@ import { useState, useEffect, useCallback } from 'react';
 import {
   collection,
   doc,
+  getDoc,
   onSnapshot,
   setDoc,
   deleteDoc,
@@ -19,7 +20,11 @@ import { db, isAuthBypass } from '@/config/firebase';
 import { useAuth } from '@/context/useAuth';
 import { useGoogleDrive } from './useGoogleDrive';
 import { normalizeVideoActivityQuestions } from '@/utils/videoActivityNormalize';
-import { VideoActivityData, VideoActivityMetadata } from '@/types';
+import {
+  VideoActivityData,
+  VideoActivityMetadata,
+  VideoActivityMetadataSyncLinkage,
+} from '@/types';
 import { QuizDriveService } from '@/utils/quizDriveService';
 import {
   MockQuizDriveService,
@@ -42,6 +47,16 @@ export interface UseVideoActivityResult {
   loadActivityData: (driveFileId: string) => Promise<VideoActivityData>;
   /** Delete an activity from Drive and Firestore. */
   deleteActivity: (activityId: string, driveFileId: string) => Promise<void>;
+  /**
+   * Patch the synced-group linkage onto an activity's Firestore metadata.
+   * Mirrors `useQuiz.attachSyncLinkage`: used by the shared-assignment import
+   * flow to mark a freshly-imported activity as participating in a synced
+   * group, so future edits publish to the canonical doc.
+   */
+  attachSyncLinkage: (
+    activityId: string,
+    linkage: VideoActivityMetadataSyncLinkage
+  ) => Promise<void>;
   /** Create a template Google Sheet for CSV import. */
   createTemplateSheet: (title: string) => Promise<string>;
   /** Is a Drive service available? */
@@ -183,6 +198,47 @@ export const useVideoActivity = (
     [getDriveService]
   );
 
+  const attachSyncLinkage = useCallback(
+    async (
+      activityId: string,
+      linkage: VideoActivityMetadataSyncLinkage
+    ): Promise<void> => {
+      if (!userId) throw new Error('Not authenticated');
+      const metaRef = doc(
+        db,
+        'users',
+        userId,
+        VIDEO_ACTIVITIES_COLLECTION,
+        activityId
+      );
+      const snap = await getDoc(metaRef);
+      if (!snap.exists()) {
+        throw new Error(
+          `Cannot attach sync linkage: activity ${activityId} not in library.`
+        );
+      }
+      const existing = snap.data() as VideoActivityMetadata;
+      if (
+        existing.sync?.groupId === linkage.groupId &&
+        existing.sync?.lastSyncedVersion === linkage.lastSyncedVersion
+      ) {
+        return;
+      }
+      await setDoc(
+        metaRef,
+        {
+          ...existing,
+          sync: {
+            groupId: linkage.groupId,
+            lastSyncedVersion: linkage.lastSyncedVersion,
+          },
+        } satisfies VideoActivityMetadata,
+        { merge: false }
+      );
+    },
+    [userId]
+  );
+
   return {
     activities,
     loading,
@@ -191,6 +247,7 @@ export const useVideoActivity = (
     loadActivityData,
     deleteActivity,
     createTemplateSheet,
+    attachSyncLinkage,
     isDriveConnected: isAuthBypass || isConnected,
   };
 };

--- a/hooks/useVideoActivityAssignments.ts
+++ b/hooks/useVideoActivityAssignments.ts
@@ -16,6 +16,7 @@ import { useState, useEffect, useCallback } from 'react';
 import {
   addDoc,
   collection,
+  deleteField,
   doc,
   getDoc,
   onSnapshot,
@@ -37,6 +38,7 @@ import { logError } from '../utils/logError';
 import type {
   AssignmentMode,
   SharedVideoActivityAssignment,
+  VideoActivityAnswer,
   VideoActivityAssignment,
   VideoActivityAssignmentSettings,
   VideoActivityAssignmentSyncLinkage,
@@ -44,8 +46,11 @@ import type {
   VideoActivityData,
   VideoActivityMetadata,
   VideoActivityMetadataSyncLinkage,
+  VideoActivityResponse,
+  VideoActivityScoreVisibility,
   VideoActivitySession,
 } from '../types';
+import { gradeVideoActivityAnswer } from '../utils/videoActivityGrading';
 
 const VIDEO_ACTIVITY_ASSIGNMENTS_COLLECTION = 'video_activity_assignments';
 const VIDEO_ACTIVITY_SESSIONS_COLLECTION = 'video_activity_sessions';
@@ -152,6 +157,31 @@ export interface UseVideoActivityAssignmentsResult {
     shareId: string,
     options: ImportSharedAssignmentOptions
   ) => Promise<{ assignmentId: string; activityId: string }>;
+  /**
+   * Publish (or unpublish) per-student scores for an assignment. Mirrors
+   * `useQuizAssignments.publishAssignmentScores`. Grades every response
+   * via `gradeVideoActivityAnswer` (handles MA / FIB-with-variants — the
+   * Quiz grader's `'MA'` blind spot is irrelevant here), writes the
+   * computed `score` + per-answer `isCorrect` flags onto each response,
+   * and mirrors the visibility flag onto the assignment + session docs.
+   *
+   * `'none'` is the unpublish path: clears `scoreVisibility` on assignment
+   * + session and wipes `revealedAnswers`. Already-written `score` /
+   * `isCorrect` are left in place — the reader gates on `scoreVisibility`,
+   * so this is harmless and avoids a multi-batch wipe on a gesture the
+   * teacher may immediately undo.
+   *
+   * `'score-responses-and-answers'` populates `session.revealedAnswers`
+   * (id → correctAnswer) so the student review screen can show the
+   * canonical correct answer for each question — VA's session strips
+   * correct answers from `publicQuestions` for the in-progress flow,
+   * mirroring Quiz's student-safety pattern.
+   */
+  publishAssignmentScores: (
+    assignmentId: string,
+    activityData: VideoActivityData,
+    visibility: VideoActivityScoreVisibility
+  ) => Promise<{ responsesUpdated: number }>;
 }
 
 export interface ImportSharedAssignmentOptions {
@@ -766,6 +796,146 @@ export const useVideoActivityAssignments = (
     [userId, peekSharedAssignment, createAssignment]
   );
 
+  const publishAssignmentScores = useCallback<
+    UseVideoActivityAssignmentsResult['publishAssignmentScores']
+  >(
+    async (assignmentId, activityData, visibility) => {
+      if (!userId) throw new Error('Not authenticated');
+
+      const now = Date.now();
+      const assignmentRef = doc(
+        db,
+        'users',
+        userId,
+        VIDEO_ACTIVITY_ASSIGNMENTS_COLLECTION,
+        assignmentId
+      );
+      const sessionRef = doc(
+        db,
+        VIDEO_ACTIVITY_SESSIONS_COLLECTION,
+        assignmentId
+      );
+
+      if (visibility === 'none') {
+        const batch = writeBatch(db);
+        batch.update(assignmentRef, {
+          scoreVisibility: 'none',
+          scorePublishedAt: deleteField(),
+          updatedAt: now,
+        });
+        batch.update(sessionRef, {
+          scoreVisibility: 'none',
+          revealedAnswers: deleteField(),
+        });
+        await batch.commit();
+        return { responsesUpdated: 0 };
+      }
+
+      const questionsById = new Map(
+        activityData.questions.map((q) => [q.id, q])
+      );
+
+      const responsesSnap = await getDocs(
+        collection(
+          db,
+          VIDEO_ACTIVITY_SESSIONS_COLLECTION,
+          assignmentId,
+          RESPONSES_COLLECTION
+        )
+      );
+
+      interface ResponseUpdate {
+        ref: ReturnType<typeof doc>;
+        patch: { score: number; answers: VideoActivityAnswer[] };
+      }
+      const updates: ResponseUpdate[] = [];
+      for (const d of responsesSnap.docs) {
+        const data = d.data() as VideoActivityResponse;
+        const answers = Array.isArray(data.answers) ? data.answers : [];
+        let pointsEarned = 0;
+        let pointsMax = 0;
+        const gradedAnswers: VideoActivityAnswer[] = answers.map((a) => {
+          const q = questionsById.get(a.questionId);
+          if (!q) {
+            // Question deleted between submission and publish — drop any
+            // stale `isCorrect` from a prior publish so the response
+            // doesn't carry a value the canonical activity no longer
+            // supports. Mirrors the Quiz pattern.
+            const { isCorrect: _stale, ...rest } = a;
+            void _stale;
+            return rest;
+          }
+          const result = gradeVideoActivityAnswer(q, a.answer);
+          pointsEarned += result.pointsEarned;
+          pointsMax += result.pointsMax;
+          return { ...a, isCorrect: result.isCorrect };
+        });
+        // Count unanswered questions toward the denominator so a blank
+        // response scores 0%, not undefined. O(Q) Set lookup vs the
+        // O(Q*A) `.some` pattern matters on PLC-shared assignments.
+        const answeredQuestionIds = new Set<string>();
+        for (const a of answers) answeredQuestionIds.add(a.questionId);
+        for (const q of activityData.questions) {
+          if (!answeredQuestionIds.has(q.id)) {
+            pointsMax += q.points ?? 1;
+          }
+        }
+        const score =
+          pointsMax === 0 ? 0 : Math.round((pointsEarned / pointsMax) * 100);
+        updates.push({
+          ref: d.ref,
+          patch: { score, answers: gradedAnswers },
+        });
+      }
+
+      const MAX_BATCH_WRITES = 400;
+      const firstBatch = writeBatch(db);
+      firstBatch.update(assignmentRef, {
+        scoreVisibility: visibility,
+        scorePublishedAt: now,
+        updatedAt: now,
+      });
+      const sessionPatch: Record<string, unknown> = {
+        scoreVisibility: visibility,
+      };
+      if (visibility === 'score-responses-and-answers') {
+        const revealedAnswers: Record<string, string> = {};
+        for (const q of activityData.questions) {
+          revealedAnswers[q.id] = q.correctAnswer;
+        }
+        sessionPatch.revealedAnswers = revealedAnswers;
+      } else {
+        sessionPatch.revealedAnswers = deleteField();
+      }
+      firstBatch.update(sessionRef, sessionPatch);
+
+      // 2 writes already consumed (assignment + session); fill the rest
+      // of the first batch with response updates so the visibility flip
+      // is atomic with at least the first chunk of grades.
+      const firstChunkSize = Math.min(updates.length, MAX_BATCH_WRITES - 2);
+      for (let i = 0; i < firstChunkSize; i++) {
+        firstBatch.update(updates[i].ref, updates[i].patch);
+      }
+      await firstBatch.commit();
+
+      for (
+        let cursor = firstChunkSize;
+        cursor < updates.length;
+        cursor += MAX_BATCH_WRITES
+      ) {
+        const chunk = updates.slice(cursor, cursor + MAX_BATCH_WRITES);
+        const chunkBatch = writeBatch(db);
+        for (const u of chunk) {
+          chunkBatch.update(u.ref, u.patch);
+        }
+        await chunkBatch.commit();
+      }
+
+      return { responsesUpdated: updates.length };
+    },
+    [userId]
+  );
+
   return {
     assignments,
     loading,
@@ -780,5 +950,6 @@ export const useVideoActivityAssignments = (
     shareAssignment,
     peekSharedAssignment,
     importSharedAssignment,
+    publishAssignmentScores,
   };
 };

--- a/hooks/useVideoActivityAssignments.ts
+++ b/hooks/useVideoActivityAssignments.ts
@@ -8,36 +8,53 @@
  * document (under /video_activity_sessions/{sessionId}) 1:1.
  *
  * Mirrors the shape of useQuizAssignments but simplified: Video Activities
- * have no join code, no session-mode variants, no PLC sharing, and session
- * status is binary (active | ended). Assignment statuses still distinguish
- * active/paused/inactive so the In Progress tab can surface paused sessions
- * the teacher may want to resume.
+ * have no join code and no session-mode variants. PR3 adds PLC sharing
+ * (mirroring Quiz's `shareAssignment` / `importSharedAssignment` flows).
  */
 
 import { useState, useEffect, useCallback } from 'react';
 import {
+  addDoc,
   collection,
   doc,
+  getDoc,
   onSnapshot,
   getDocs,
   query,
   orderBy,
+  updateDoc,
   writeBatch,
 } from 'firebase/firestore';
 import { db } from '../config/firebase';
 import { invalidateSessionViewCount } from './useSessionViewCount';
+import {
+  callJoinSyncedVideoActivityGroup,
+  callLeaveSyncedVideoActivityGroup,
+  createSyncedVideoActivityGroup,
+  pullSyncedVideoActivityContent,
+} from './useSyncedVideoActivityGroups';
+import { logError } from '../utils/logError';
 import type {
   AssignmentMode,
+  SharedVideoActivityAssignment,
   VideoActivityAssignment,
   VideoActivityAssignmentSettings,
+  VideoActivityAssignmentSyncLinkage,
   VideoActivityAssignmentStatus,
   VideoActivityData,
+  VideoActivityMetadata,
+  VideoActivityMetadataSyncLinkage,
   VideoActivitySession,
 } from '../types';
 
 const VIDEO_ACTIVITY_ASSIGNMENTS_COLLECTION = 'video_activity_assignments';
 const VIDEO_ACTIVITY_SESSIONS_COLLECTION = 'video_activity_sessions';
+const VIDEO_ACTIVITY_METADATA_COLLECTION = 'video_activities';
+const SHARED_VA_ASSIGNMENTS_COLLECTION = 'shared_video_activity_assignments';
 const RESPONSES_COLLECTION = 'responses';
+
+/** Import-mode picker result for shared-VA-assignment paste flows. */
+export type SharedVideoActivityImportMode = 'sync' | 'copy';
 
 /**
  * Minimal activity data needed to stand up an assignment. The driveFileId lets
@@ -101,6 +118,58 @@ export interface UseVideoActivityAssignmentsResult {
   updateAssignmentSettings: (
     assignmentId: string,
     patch: Partial<VideoActivityAssignmentSettings>
+  ) => Promise<void>;
+  /**
+   * Publish a shared-VA-assignment doc to `/shared_video_activity_assignments/`
+   * and (if the source activity has no synced linkage yet) auto-create a
+   * canonical group at `/synced_video_activities/{groupId}` so peer importers
+   * can pick "Synced" mode. Returns the share URL the teacher copies.
+   */
+  shareAssignment: (
+    assignmentId: string,
+    activityData: VideoActivityData
+  ) => Promise<string>;
+  /**
+   * Read-only fetch for a shared-assignment doc. Used by the importer's URL-
+   * paste flow to preview the share before committing to copy/sync mode.
+   */
+  peekSharedAssignment: (
+    shareId: string
+  ) => Promise<SharedVideoActivityAssignment | null>;
+  /**
+   * Import a shared-assignment doc into the teacher's library. Mirrors
+   * `useQuizAssignments.importSharedAssignment` — runs a copy of the
+   * activity into the teacher's Drive, creates a paused local assignment,
+   * and (in 'sync' mode) joins the synced group via the Cloud Function.
+   *
+   * The caller provides:
+   *   - `saveActivity`: writes the inlined activity content into Drive
+   *     and Firestore metadata (returns the created VideoActivityMetadata).
+   *   - `attachSyncLinkage` (sync-mode only): patches the local activity's
+   *     metadata with the synced-group linkage so future edits publish.
+   */
+  importSharedAssignment: (
+    shareId: string,
+    options: ImportSharedAssignmentOptions
+  ) => Promise<{ assignmentId: string; activityId: string }>;
+}
+
+export interface ImportSharedAssignmentOptions {
+  mode: SharedVideoActivityImportMode;
+  /**
+   * Persist a fresh copy of the activity content to the importer's Drive +
+   * Firestore metadata. Returns the new VideoActivityMetadata so the
+   * import flow can attach a sync linkage and create the local assignment.
+   */
+  saveActivity: (activity: VideoActivityData) => Promise<VideoActivityMetadata>;
+  /**
+   * Sync-mode only: write `sync.{ groupId, lastSyncedVersion }` onto the
+   * importer's local `video_activities/{activityId}` metadata so the editor's
+   * save path will publish future edits to the canonical group.
+   */
+  attachSyncLinkage?: (
+    activityId: string,
+    linkage: VideoActivityMetadataSyncLinkage
   ) => Promise<void>;
 }
 
@@ -414,6 +483,289 @@ export const useVideoActivityAssignments = (
     [userId]
   );
 
+  /**
+   * Publish a shared-VA-assignment doc + auto-create a synced group if the
+   * source activity has none yet. Mirrors `useQuizAssignments.shareAssignment`
+   * but scoped to VA's parallel collections. The local activity metadata gets
+   * its `sync` field patched in place so the editor's save path can publish
+   * future edits to peers.
+   */
+  const shareAssignment = useCallback<
+    UseVideoActivityAssignmentsResult['shareAssignment']
+  >(
+    async (assignmentId, activityData) => {
+      if (!userId) throw new Error('Not authenticated');
+      const assignmentRef = doc(
+        db,
+        'users',
+        userId,
+        VIDEO_ACTIVITY_ASSIGNMENTS_COLLECTION,
+        assignmentId
+      );
+      const snap = await getDoc(assignmentRef);
+      if (!snap.exists()) throw new Error('Assignment not found');
+      const assignment = snap.data() as VideoActivityAssignment;
+
+      const metaRef = doc(
+        db,
+        'users',
+        userId,
+        VIDEO_ACTIVITY_METADATA_COLLECTION,
+        assignment.activityId
+      );
+      const metaSnap = await getDoc(metaRef);
+      if (!metaSnap.exists()) {
+        throw new Error(
+          'Source activity is missing from your library — cannot share.'
+        );
+      }
+      const meta = metaSnap.data() as VideoActivityMetadata;
+
+      // Sync-mode plumbing: every share carries a `syncGroupId` so the
+      // importer's mode picker can offer Synced. If the source is already
+      // part of a group, reuse it; otherwise mint a fresh group with the
+      // sharer as the sole participant.
+      let syncGroupId = meta.sync?.groupId;
+      // Track whether we just minted the linkage so the rollback path knows
+      // whether to clear it. If the source already had a `sync.groupId` we
+      // leave it alone on rollback — that linkage predates this share call.
+      let mintedLinkage = false;
+      if (!syncGroupId) {
+        syncGroupId = crypto.randomUUID();
+        await createSyncedVideoActivityGroup({
+          groupId: syncGroupId,
+          uid: userId,
+          title: activityData.title,
+          youtubeUrl: activityData.youtubeUrl,
+          questions: activityData.questions,
+          ...(assignment.plc?.id ? { plcId: assignment.plc.id } : {}),
+        });
+        await updateDoc(metaRef, {
+          sync: { groupId: syncGroupId, lastSyncedVersion: 1 },
+        });
+        mintedLinkage = true;
+      }
+
+      const payload: Omit<SharedVideoActivityAssignment, 'id'> = {
+        title: activityData.title,
+        youtubeUrl: activityData.youtubeUrl,
+        questions: activityData.questions,
+        createdAt: activityData.createdAt,
+        updatedAt: activityData.updatedAt,
+        assignmentSettings: {
+          className: assignment.className,
+          sessionSettings: assignment.sessionSettings,
+          ...(assignment.sessionOptions
+            ? { sessionOptions: assignment.sessionOptions }
+            : {}),
+          ...(assignment.scoreVisibility
+            ? { scoreVisibility: assignment.scoreVisibility }
+            : {}),
+          ...(assignment.periodNames && assignment.periodNames.length > 0
+            ? { periodNames: assignment.periodNames }
+            : {}),
+          ...(assignment.periodName
+            ? { periodName: assignment.periodName }
+            : {}),
+          ...(assignment.teacherName
+            ? { teacherName: assignment.teacherName }
+            : {}),
+          ...(assignment.plc ? { plc: assignment.plc } : {}),
+        },
+        originalAuthor: userId,
+        sharedAt: Date.now(),
+        syncGroupId,
+      };
+      // Best-effort rollback: if `addDoc` fails AFTER we've minted the
+      // synced-group linkage, clear the local metadata patch so the
+      // teacher's library doesn't carry a sync linkage to a group with no
+      // matching share doc. Non-rollback (rethrow original) on cleanup
+      // failure — we can't do better than logging.
+      let ref;
+      try {
+        ref = await addDoc(
+          collection(db, SHARED_VA_ASSIGNMENTS_COLLECTION),
+          payload
+        );
+      } catch (err) {
+        if (mintedLinkage) {
+          try {
+            await updateDoc(metaRef, { sync: null });
+          } catch (rollbackErr) {
+            logError(
+              'useVideoActivityAssignments.shareAssignment.rollback',
+              rollbackErr,
+              { assignmentId, syncGroupId }
+            );
+          }
+        }
+        throw err;
+      }
+      return `${window.location.origin}/share/video-activity/${ref.id}`;
+    },
+    [userId]
+  );
+
+  /** Read-only peek for the importer's URL-paste preview. */
+  const peekSharedAssignment = useCallback<
+    UseVideoActivityAssignmentsResult['peekSharedAssignment']
+  >(async (shareId) => {
+    const snap = await getDoc(
+      doc(db, SHARED_VA_ASSIGNMENTS_COLLECTION, shareId)
+    );
+    if (!snap.exists()) return null;
+    return {
+      id: shareId,
+      ...(snap.data() as Omit<SharedVideoActivityAssignment, 'id'>),
+    };
+  }, []);
+
+  /**
+   * Import a shared-VA-assignment into the local library. Forks the read-side
+   * of `useQuizAssignments.importSharedAssignment`. The flow:
+   *   1. Fetch the share doc.
+   *   2. Save a fresh copy of the activity into the importer's Drive +
+   *      Firestore metadata (caller-supplied `saveActivity`).
+   *   3. (sync mode) Join the synced group via the Cloud Function and patch
+   *      local metadata with the linkage.
+   *   4. Create a paused local assignment seeded from the shared settings —
+   *      with originator-only fields cleared (teacherName, periodName) so
+   *      the importer doesn't masquerade as the original author.
+   */
+  const importSharedAssignment = useCallback<
+    UseVideoActivityAssignmentsResult['importSharedAssignment']
+  >(
+    async (shareId, options) => {
+      if (!userId) throw new Error('Not authenticated');
+      const sharedDoc = await peekSharedAssignment(shareId);
+      if (!sharedDoc) {
+        throw new Error('Shared video activity not found.');
+      }
+
+      // 1) Sync mode FIRST — join the synced group and pull the canonical
+      // content BEFORE we save the activity. This guarantees the local
+      // replica matches the live group at join time; the share doc's
+      // inlined content can be stale relative to the canonical (peers
+      // edit the canonical via the publish transaction; the share doc is
+      // a snapshot from the moment the originator clicked Share).
+      let syncedFromLinkage: VideoActivityAssignmentSyncLinkage | undefined;
+      let canonicalContent: {
+        title: string;
+        youtubeUrl: string;
+        questions: typeof sharedDoc.questions;
+      } | null = null;
+      if (options.mode === 'sync' && sharedDoc.syncGroupId) {
+        try {
+          const joinResult = await callJoinSyncedVideoActivityGroup(shareId);
+          const canonical = await pullSyncedVideoActivityContent(
+            joinResult.groupId
+          );
+          canonicalContent = {
+            title: canonical.title,
+            youtubeUrl: canonical.youtubeUrl,
+            questions: canonical.questions,
+          };
+          syncedFromLinkage = {
+            groupId: joinResult.groupId,
+            syncedVersion: canonical.version,
+          };
+        } catch (err) {
+          // Best-effort leave: if the join itself failed there's nothing
+          // to leave; if it succeeded but the pull failed, leave so the
+          // importer doesn't accumulate orphan participation. Either way,
+          // rethrow so the caller knows the import didn't run.
+          if (sharedDoc.syncGroupId) {
+            await callLeaveSyncedVideoActivityGroup(
+              sharedDoc.syncGroupId
+            ).catch((leaveErr) =>
+              logError(
+                'useVideoActivityAssignments.importSharedAssignment.rollbackJoin',
+                leaveErr,
+                { shareId }
+              )
+            );
+          }
+          throw err;
+        }
+      }
+
+      // 2) Save activity content into the importer's library — using the
+      // canonical content when sync mode succeeded, otherwise the share
+      // doc's inline snapshot for copy mode.
+      const importedActivity: VideoActivityData = {
+        id: crypto.randomUUID(),
+        title: canonicalContent?.title ?? sharedDoc.title,
+        youtubeUrl: canonicalContent?.youtubeUrl ?? sharedDoc.youtubeUrl,
+        questions: canonicalContent?.questions ?? sharedDoc.questions,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      };
+
+      // From here onward, every failure must roll back the synced-group
+      // join (if any) so the importer doesn't end up as a participant in
+      // a group with no corresponding local assignment. Single try block
+      // wrapping save → attach → create covers all three failure points.
+      const rollbackLeave = async (rollbackErrCtx: string): Promise<void> => {
+        if (!syncedFromLinkage) return;
+        await callLeaveSyncedVideoActivityGroup(
+          syncedFromLinkage.groupId
+        ).catch((leaveErr) => logError(rollbackErrCtx, leaveErr, { shareId }));
+      };
+
+      try {
+        const savedMeta = await options.saveActivity(importedActivity);
+
+        if (syncedFromLinkage && options.attachSyncLinkage) {
+          await options.attachSyncLinkage(savedMeta.id, {
+            groupId: syncedFromLinkage.groupId,
+            lastSyncedVersion: syncedFromLinkage.syncedVersion,
+          });
+        }
+
+        // 3) Create the local assignment, paused. Originator-only fields
+        // cleared: teacherName + periodName (which encode the original
+        // author's identity / single-class targeting). PLC linkage is
+        // preserved so the importer's results flow through the same
+        // sheet for PLC peers.
+        const sourceSettings = sharedDoc.assignmentSettings;
+        const importedSettings: VideoActivityAssignmentSettings = {
+          className: sourceSettings.className,
+          sessionSettings: sourceSettings.sessionSettings,
+          ...(sourceSettings.sessionOptions
+            ? { sessionOptions: sourceSettings.sessionOptions }
+            : {}),
+          ...(sourceSettings.scoreVisibility
+            ? { scoreVisibility: sourceSettings.scoreVisibility }
+            : {}),
+          ...(sourceSettings.periodNames &&
+          sourceSettings.periodNames.length > 0
+            ? { periodNames: sourceSettings.periodNames }
+            : {}),
+          ...(sourceSettings.plc ? { plc: sourceSettings.plc } : {}),
+          ...(syncedFromLinkage ? { sync: syncedFromLinkage } : {}),
+        };
+        const created = await createAssignment(
+          {
+            id: savedMeta.id,
+            title: savedMeta.title,
+            driveFileId: savedMeta.driveFileId,
+            youtubeUrl: savedMeta.youtubeUrl,
+            questions: importedActivity.questions,
+          },
+          importedSettings,
+          'paused'
+        );
+        return { assignmentId: created.id, activityId: savedMeta.id };
+      } catch (err) {
+        await rollbackLeave(
+          'useVideoActivityAssignments.importSharedAssignment.rollbackSaveOrCreate'
+        );
+        throw err;
+      }
+    },
+    [userId, peekSharedAssignment, createAssignment]
+  );
+
   return {
     assignments,
     loading,
@@ -425,5 +777,8 @@ export const useVideoActivityAssignments = (
     reactivateAssignment,
     deleteAssignment,
     updateAssignmentSettings,
+    shareAssignment,
+    peekSharedAssignment,
+    importSharedAssignment,
   };
 };

--- a/locales/en.json
+++ b/locales/en.json
@@ -386,7 +386,14 @@
         },
         "quizLibrary": {
           "title": "Quiz library",
-          "teaser": "Share quizzes with your PLC."
+          "teaser": "Share quizzes with your PLC.",
+          "heading": "Quiz Library",
+          "empty": "No shared quizzes",
+          "emptySubtitle": "Share a quiz from the kebab on its library card.",
+          "questionCount_one": "{{count}} q",
+          "questionCount_other": "{{count}} q",
+          "bySharer": "shared by {{name}}",
+          "openAll": "Open library"
         },
         "activeAssignments": {
           "title": "Active assignments",
@@ -427,6 +434,33 @@
       "deleteTodo": "Delete to-do",
       "confirmDelete": "Delete this to-do?",
       "confirmDeleteTitle": "Delete to-do"
+    },
+    "quizLibrary": {
+      "heading": "Shared Quizzes",
+      "count_one": "{{count}} quiz",
+      "count_other": "{{count}} quizzes",
+      "emptyTitle": "No shared quizzes yet",
+      "emptySubtitle": "Open the Quiz widget in your dashboard, click the kebab on any quiz, and choose \"Share with PLC\" to add it here.",
+      "bySharer": "shared by {{name}}",
+      "unknownSharer": "a teammate",
+      "questionCount_one": "{{count}} question",
+      "questionCount_other": "{{count}} questions",
+      "addToMyLibrary": "Add to my library",
+      "reimport": "Re-import",
+      "inLibrary": "In your library",
+      "alreadySynced": "\"{{title}}\" is already synced to your library.",
+      "unshareAction": "Unshare",
+      "unshareYours": "Unshare from PLC",
+      "unshareTeammate": "Unshare from PLC (any member can remove)",
+      "unshareTitle": "Unshare quiz",
+      "unshareConfirm": "Remove \"{{title}}\" from this PLC? Other teammates will lose access to the shared library entry. Their personal copies (if any) keep working.",
+      "unshared": "\"{{title}}\" removed from this PLC.",
+      "unshareFailed": "Failed to unshare quiz.",
+      "importedSync": "\"{{title}}\" added to your library (synced).",
+      "importedCopy": "\"{{title}}\" copied to your library.",
+      "importFailed": "Failed to import quiz.",
+      "driveRequired": "Connect Google Drive in your account to import PLC quizzes.",
+      "driveDisconnected": "Connect Google Drive to import PLC quizzes into your personal library."
     }
   },
   "widgetWindow": {

--- a/tests/components/layout/DashboardView.test.tsx
+++ b/tests/components/layout/DashboardView.test.tsx
@@ -56,6 +56,28 @@ vi.mock('@/hooks/useQuizAssignments', () => ({
   }),
 }));
 
+vi.mock('@/hooks/useVideoActivity', () => ({
+  useVideoActivity: vi.fn().mockReturnValue({
+    activities: [],
+    loading: false,
+    error: null,
+    saveActivity: vi.fn().mockResolvedValue({ id: 'va1', driveFileId: 'd-1' }),
+    deleteActivity: vi.fn().mockResolvedValue(undefined),
+    attachSyncLinkage: vi.fn().mockResolvedValue(undefined),
+  }),
+}));
+
+vi.mock('@/hooks/useVideoActivityAssignments', () => ({
+  useVideoActivityAssignments: vi.fn().mockReturnValue({
+    assignments: [],
+    loading: false,
+    error: null,
+    importSharedAssignment: vi
+      .fn()
+      .mockResolvedValue({ assignmentId: 'a1', activityId: 'va1' }),
+  }),
+}));
+
 vi.mock('@/hooks/usePlcs', () => ({
   usePlcs: vi.fn().mockReturnValue({
     plcs: [],

--- a/tests/escapeInteraction.test.tsx
+++ b/tests/escapeInteraction.test.tsx
@@ -85,6 +85,26 @@ vi.mock('../hooks/useQuizAssignments', () => ({
     importSharedAssignment: vi.fn().mockResolvedValue('a1'),
   }),
 }));
+vi.mock('../hooks/useVideoActivity', () => ({
+  useVideoActivity: () => ({
+    activities: [],
+    loading: false,
+    error: null,
+    saveActivity: vi.fn().mockResolvedValue({ id: 'va1', driveFileId: 'd-1' }),
+    deleteActivity: vi.fn().mockResolvedValue(undefined),
+    attachSyncLinkage: vi.fn().mockResolvedValue(undefined),
+  }),
+}));
+vi.mock('../hooks/useVideoActivityAssignments', () => ({
+  useVideoActivityAssignments: () => ({
+    assignments: [],
+    loading: false,
+    error: null,
+    importSharedAssignment: vi
+      .fn()
+      .mockResolvedValue({ assignmentId: 'a1', activityId: 'va1' }),
+  }),
+}));
 vi.mock('../hooks/usePlcs', () => ({
   usePlcs: () => ({
     plcs: [],

--- a/tests/hooks/usePlcAssignmentIndex.test.ts
+++ b/tests/hooks/usePlcAssignmentIndex.test.ts
@@ -240,10 +240,12 @@ describe('usePlcAssignmentIndex - parseEntry (via snapshot)', () => {
     expect(result.current.loading).toBe(false);
   });
 
-  it("normalizes `kind` to 'quiz' even for legacy or wrong values", () => {
-    // Today the parser hardcodes `kind: 'quiz'`; this test pins that
-    // behaviour so a future widening of the union has to update both the
-    // parser AND this test consciously.
+  it("reads kind: 'video-activity' through the parser (PR3a widening)", () => {
+    // PR3a widened `PlcAssignmentIndexEntry.kind` from `'quiz'` to
+    // `'quiz' | 'video-activity'` and updated the parser to read the raw
+    // `data.kind` field. PR3b's `useVideoActivityAssignments` will start
+    // writing VA index entries; this test pins that the parser passes the
+    // discriminator through faithfully.
     let cb: (snap: unknown) => void = () => {
       throw new Error('snapshot callback not captured');
     };
@@ -259,7 +261,38 @@ describe('usePlcAssignmentIndex - parseEntry (via snapshot)', () => {
           {
             id: 'a',
             data: {
-              kind: 'video-activity', // future widening, ignored today
+              kind: 'video-activity',
+              ownerUid: 'u1',
+              title: 'A',
+              sheetUrl: 'https://example.com/a',
+              createdAt: 1000,
+            },
+          },
+        ])
+      );
+    });
+
+    expect(result.current.entries[0].kind).toBe('video-activity');
+  });
+
+  it("defaults missing `kind` to 'quiz' for backward compat with pre-PR3a entries", () => {
+    let cb: (snap: unknown) => void = () => {
+      throw new Error('snapshot callback not captured');
+    };
+    mockOnSnapshot.mockImplementation((_q, onNext) => {
+      cb = onNext;
+      return () => undefined;
+    });
+    const { result } = renderHook(() => usePlcAssignmentIndex(PLC_ID));
+
+    act(() => {
+      cb(
+        fakeSnap([
+          {
+            id: 'a',
+            data: {
+              // No `kind` field — pre-PR3a entries written before the
+              // discriminator existed.
               ownerUid: 'u1',
               title: 'A',
               sheetUrl: 'https://example.com/a',

--- a/tests/hooks/usePlcQuizzes.test.ts
+++ b/tests/hooks/usePlcQuizzes.test.ts
@@ -1,0 +1,432 @@
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeEach,
+  afterEach,
+  type Mock,
+} from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+import {
+  collection,
+  deleteDoc,
+  doc,
+  onSnapshot,
+  orderBy,
+  query,
+  setDoc,
+  updateDoc,
+} from 'firebase/firestore';
+import { usePlcQuizzes, writePlcQuizEntry } from '@/hooks/usePlcQuizzes';
+import { logError } from '@/utils/logError';
+
+vi.mock('firebase/firestore', () => ({
+  collection: vi.fn(),
+  deleteDoc: vi.fn(),
+  doc: vi.fn(),
+  onSnapshot: vi.fn(),
+  orderBy: vi.fn((field: string, dir: 'asc' | 'desc') => ({
+    __orderBy: { field, dir },
+  })),
+  query: vi.fn((_ref, ...constraints) => ({ __query: constraints })),
+  setDoc: vi.fn(),
+  updateDoc: vi.fn(),
+}));
+
+vi.mock('@/config/firebase', () => ({
+  db: { __mock: 'db' },
+  isAuthBypass: false,
+}));
+
+const useAuthMock = vi.fn<() => { user: { uid: string } | null }>();
+vi.mock('@/context/useAuth', () => ({
+  useAuth: () => useAuthMock(),
+}));
+
+vi.mock('@/utils/logError', () => ({
+  logError: vi.fn(),
+}));
+
+const mockCollection = collection as Mock;
+const mockDeleteDoc = deleteDoc as Mock;
+const mockDoc = doc as Mock;
+const mockOnSnapshot = onSnapshot as Mock;
+const mockOrderBy = orderBy as Mock;
+const mockQuery = query as Mock;
+const mockSetDoc = setDoc as Mock;
+const mockUpdateDoc = updateDoc as Mock;
+const mockLogError = logError as unknown as Mock;
+
+const TEACHER_UID = 'teacher-1';
+const PLC_ID = 'plc-1';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // Resolve doc/collection refs to addressable strings so assertions can
+  // verify which path the listener attached to.
+  mockDoc.mockImplementation((_db: unknown, ...segs: string[]) =>
+    segs.join('/')
+  );
+  mockCollection.mockImplementation((_db: unknown, ...segs: string[]) =>
+    segs.join('/')
+  );
+  mockSetDoc.mockResolvedValue(undefined);
+  mockUpdateDoc.mockResolvedValue(undefined);
+  mockDeleteDoc.mockResolvedValue(undefined);
+  useAuthMock.mockReturnValue({ user: { uid: TEACHER_UID } });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+// ---------------------------------------------------------------------------
+// usePlcQuizzes - subscription wiring
+// ---------------------------------------------------------------------------
+
+describe('usePlcQuizzes - subscription wiring', () => {
+  it('uses server-side orderBy(updatedAt, desc) so latest edits surface first', () => {
+    mockOnSnapshot.mockReturnValue(() => undefined);
+
+    renderHook(() => usePlcQuizzes(PLC_ID));
+
+    expect(mockOrderBy).toHaveBeenCalledWith('updatedAt', 'desc');
+    expect(mockQuery).toHaveBeenCalledWith(`plcs/${PLC_ID}/quizzes`, {
+      __orderBy: { field: 'updatedAt', dir: 'desc' },
+    });
+  });
+
+  it('skips the listener when plcId is null (dashboard closed)', () => {
+    mockOnSnapshot.mockReturnValue(() => undefined);
+
+    renderHook(() => usePlcQuizzes(null));
+
+    expect(mockOnSnapshot).not.toHaveBeenCalled();
+  });
+
+  it('skips the listener when the user is signed out', () => {
+    useAuthMock.mockReturnValue({ user: null });
+    mockOnSnapshot.mockReturnValue(() => undefined);
+
+    renderHook(() => usePlcQuizzes(PLC_ID));
+
+    expect(mockOnSnapshot).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// usePlcQuizzes - parser (via snapshot)
+// ---------------------------------------------------------------------------
+
+function fakeSnap(docs: Array<{ id: string; data: Record<string, unknown> }>) {
+  return {
+    forEach: (fn: (d: { id: string; data: () => unknown }) => void) => {
+      for (const d of docs) {
+        fn({ id: d.id, data: () => d.data });
+      }
+    },
+  };
+}
+
+describe('usePlcQuizzes - parseEntry (via snapshot)', () => {
+  it('drops entries missing required fields (defensive parse)', () => {
+    let cb: (snap: unknown) => void = () => {
+      throw new Error('snapshot callback not captured');
+    };
+    mockOnSnapshot.mockImplementation((_q, onNext) => {
+      cb = onNext;
+      return () => undefined;
+    });
+    const { result } = renderHook(() => usePlcQuizzes(PLC_ID));
+
+    act(() => {
+      cb(
+        fakeSnap([
+          {
+            // Valid — must survive
+            id: 'a',
+            data: {
+              title: 'A Quiz',
+              questionCount: 5,
+              syncGroupId: 'group-A',
+              sharedBy: 'u1',
+              sharedByEmail: 'a@x.com',
+              sharedByName: 'Alice',
+              sharedAt: 1000,
+              updatedAt: 1500,
+            },
+          },
+          {
+            // Missing title — must be dropped
+            id: 'b',
+            data: {
+              questionCount: 3,
+              syncGroupId: 'group-B',
+              sharedBy: 'u2',
+              sharedAt: 2000,
+              updatedAt: 2000,
+            },
+          },
+          {
+            // questionCount not a number — must be dropped
+            id: 'c',
+            data: {
+              title: 'C Quiz',
+              questionCount: 'three',
+              syncGroupId: 'group-C',
+              sharedBy: 'u1',
+              sharedAt: 3000,
+              updatedAt: 3000,
+            },
+          },
+          {
+            // syncGroupId not a string — must be dropped (the doc would be
+            // unable to participate in collaborative editing)
+            id: 'd',
+            data: {
+              title: 'D Quiz',
+              questionCount: 4,
+              syncGroupId: 42,
+              sharedBy: 'u1',
+              sharedAt: 4000,
+              updatedAt: 4000,
+            },
+          },
+        ])
+      );
+    });
+
+    expect(result.current.quizzes).toHaveLength(1);
+    expect(result.current.quizzes[0].id).toBe('a');
+  });
+
+  it('coerces optional sharedByName/sharedByEmail to empty strings when missing', () => {
+    let cb: (snap: unknown) => void = () => {
+      throw new Error('snapshot callback not captured');
+    };
+    mockOnSnapshot.mockImplementation((_q, onNext) => {
+      cb = onNext;
+      return () => undefined;
+    });
+    const { result } = renderHook(() => usePlcQuizzes(PLC_ID));
+
+    act(() => {
+      cb(
+        fakeSnap([
+          {
+            id: 'a',
+            data: {
+              title: 'A',
+              questionCount: 0,
+              syncGroupId: 'group-A',
+              sharedBy: 'u1',
+              sharedAt: 1000,
+              updatedAt: 1000,
+              // sharedByName + sharedByEmail intentionally absent
+            },
+          },
+        ])
+      );
+    });
+
+    expect(result.current.quizzes).toHaveLength(1);
+    expect(result.current.quizzes[0]).toEqual({
+      id: 'a',
+      title: 'A',
+      questionCount: 0,
+      syncGroupId: 'group-A',
+      sharedBy: 'u1',
+      sharedByEmail: '',
+      sharedByName: '',
+      sharedAt: 1000,
+      updatedAt: 1000,
+    });
+    expect(result.current.loading).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// usePlcQuizzes - state reset on plcId change
+// ---------------------------------------------------------------------------
+
+describe('usePlcQuizzes - state reset on plcId change', () => {
+  it('resets quizzes + loading synchronously when plcId changes (no stale-PLC flash)', () => {
+    let cb: (snap: unknown) => void = () => {
+      throw new Error('snapshot callback not captured');
+    };
+    mockOnSnapshot.mockImplementation((_q, onNext) => {
+      cb = onNext;
+      return () => undefined;
+    });
+    const { result, rerender } = renderHook(
+      ({ id }: { id: string }) => usePlcQuizzes(id),
+      { initialProps: { id: 'plc-A' } }
+    );
+
+    act(() => {
+      cb(
+        fakeSnap([
+          {
+            id: 'q-A',
+            data: {
+              title: 'PLC A Quiz',
+              questionCount: 1,
+              syncGroupId: 'group-A',
+              sharedBy: 'u1',
+              sharedAt: 1000,
+              updatedAt: 1000,
+            },
+          },
+        ])
+      );
+    });
+    expect(result.current.quizzes).toHaveLength(1);
+    expect(result.current.loading).toBe(false);
+
+    rerender({ id: 'plc-B' });
+
+    expect(result.current.quizzes).toEqual([]);
+    expect(result.current.loading).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// usePlcQuizzes - mutators
+// ---------------------------------------------------------------------------
+
+describe('usePlcQuizzes - mutators', () => {
+  it('shareQuizWithPlc writes the canonical payload to plcs/{plcId}/quizzes/{plcQuizId}', async () => {
+    mockOnSnapshot.mockReturnValue(() => undefined);
+    const { result } = renderHook(() => usePlcQuizzes(PLC_ID));
+
+    await result.current.shareQuizWithPlc({
+      plcQuizId: 'pq-1',
+      syncGroupId: 'group-1',
+      title: 'My Quiz',
+      questionCount: 7,
+      sharedByName: 'Alice',
+      sharedByEmail: 'alice@example.com',
+    });
+
+    expect(mockSetDoc).toHaveBeenCalledTimes(1);
+    const [path, payload] = mockSetDoc.mock.calls[0] as [
+      string,
+      Record<string, unknown>,
+    ];
+    expect(path).toBe(`plcs/${PLC_ID}/quizzes/pq-1`);
+    expect(payload).toMatchObject({
+      id: 'pq-1',
+      title: 'My Quiz',
+      questionCount: 7,
+      syncGroupId: 'group-1',
+      sharedBy: TEACHER_UID,
+      sharedByEmail: 'alice@example.com',
+      sharedByName: 'Alice',
+    });
+    expect(payload.sharedAt).toBe(payload.updatedAt);
+  });
+
+  it('mirrorPlcQuizHeader patches title/questionCount/updatedAt only', async () => {
+    mockOnSnapshot.mockReturnValue(() => undefined);
+    const { result } = renderHook(() => usePlcQuizzes(PLC_ID));
+
+    await result.current.mirrorPlcQuizHeader('pq-1', {
+      title: 'Updated',
+      questionCount: 9,
+    });
+
+    expect(mockUpdateDoc).toHaveBeenCalledTimes(1);
+    const [path, fields] = mockUpdateDoc.mock.calls[0] as [
+      string,
+      Record<string, unknown>,
+    ];
+    expect(path).toBe(`plcs/${PLC_ID}/quizzes/pq-1`);
+    expect(fields.title).toBe('Updated');
+    expect(fields.questionCount).toBe(9);
+    expect(typeof fields.updatedAt).toBe('number');
+    // Identity / attribution fields must NOT appear in the patch — the
+    // rules pin them immutable, and the parser is the only thing that
+    // ever surfaces them locally.
+    expect(fields).not.toHaveProperty('id');
+    expect(fields).not.toHaveProperty('syncGroupId');
+    expect(fields).not.toHaveProperty('sharedBy');
+  });
+
+  it('mirrorPlcQuizHeader swallows errors via logError (caller never rejects)', async () => {
+    mockOnSnapshot.mockReturnValue(() => undefined);
+    const err = new Error('permission-denied');
+    mockUpdateDoc.mockRejectedValueOnce(err);
+
+    const { result } = renderHook(() => usePlcQuizzes(PLC_ID));
+
+    await expect(
+      result.current.mirrorPlcQuizHeader('pq-1', { title: 'X' })
+    ).resolves.toBeUndefined();
+
+    expect(mockLogError).toHaveBeenCalledWith(
+      'usePlcQuizzes.mirrorHeader',
+      err,
+      { plcId: PLC_ID, plcQuizId: 'pq-1' }
+    );
+  });
+
+  it('unshareQuizFromPlc deletes the canonical doc id', async () => {
+    mockOnSnapshot.mockReturnValue(() => undefined);
+    const { result } = renderHook(() => usePlcQuizzes(PLC_ID));
+
+    await result.current.unshareQuizFromPlc('pq-1');
+
+    expect(mockDeleteDoc).toHaveBeenCalledTimes(1);
+    expect(mockDeleteDoc).toHaveBeenCalledWith(`plcs/${PLC_ID}/quizzes/pq-1`);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// writePlcQuizEntry — top-level helper (used by Widget.tsx for one-shot writes)
+// ---------------------------------------------------------------------------
+
+describe('writePlcQuizEntry', () => {
+  it('writes the canonical payload to plcs/{plcId}/quizzes/{plcQuizId}', async () => {
+    await writePlcQuizEntry(PLC_ID, TEACHER_UID, {
+      plcQuizId: 'pq-1',
+      syncGroupId: 'group-1',
+      title: 'My Quiz',
+      questionCount: 7,
+      sharedByName: 'Alice',
+      sharedByEmail: 'alice@example.com',
+    });
+
+    expect(mockSetDoc).toHaveBeenCalledTimes(1);
+    const [path, payload] = mockSetDoc.mock.calls[0] as [
+      string,
+      Record<string, unknown>,
+    ];
+    expect(path).toBe(`plcs/${PLC_ID}/quizzes/pq-1`);
+    expect(payload).toMatchObject({
+      id: 'pq-1',
+      title: 'My Quiz',
+      questionCount: 7,
+      syncGroupId: 'group-1',
+      sharedBy: TEACHER_UID,
+      sharedByEmail: 'alice@example.com',
+      sharedByName: 'Alice',
+    });
+  });
+
+  it('rejects on failure (unlike Phase 1 fire-and-forget index writer)', async () => {
+    const err = new Error('quota-exceeded');
+    mockSetDoc.mockRejectedValueOnce(err);
+
+    await expect(
+      writePlcQuizEntry(PLC_ID, TEACHER_UID, {
+        plcQuizId: 'pq-1',
+        syncGroupId: 'group-1',
+        title: 'My Quiz',
+        questionCount: 7,
+        sharedByName: 'Alice',
+        sharedByEmail: 'alice@example.com',
+      })
+    ).rejects.toBe(err);
+  });
+});

--- a/tests/hooks/useVideoActivityAssignments.test.ts
+++ b/tests/hooks/useVideoActivityAssignments.test.ts
@@ -1,27 +1,35 @@
 import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
 import { act, renderHook } from '@testing-library/react';
 import {
+  addDoc,
   collection,
   doc,
+  getDoc,
   getDocs,
   onSnapshot,
+  updateDoc,
   writeBatch,
 } from 'firebase/firestore';
 import { useVideoActivityAssignments } from '@/hooks/useVideoActivityAssignments';
 import type {
+  SharedVideoActivityAssignment,
   VideoActivityAssignmentSettings,
+  VideoActivityMetadata,
   VideoActivitySession,
   VideoActivitySessionOptions,
 } from '@/types';
 
 vi.mock('firebase/firestore', () => ({
+  addDoc: vi.fn(),
   collection: vi.fn(),
   doc: vi.fn(),
+  getDoc: vi.fn(),
   getDocs: vi.fn(),
   onSnapshot: vi.fn(),
   query: vi.fn(),
   where: vi.fn(),
   orderBy: vi.fn(),
+  updateDoc: vi.fn(),
   writeBatch: vi.fn(),
 }));
 
@@ -29,18 +37,34 @@ vi.mock('@/config/firebase', () => ({
   db: {},
 }));
 
-// Hook imports from `./useSessionViewCount` (relative to hooks/), so we
-// mock the same absolute alias path the hook resolves to. This guards the
-// reactivate-assignment code path; current tests don't hit it, but
-// preserves the mock if a future test adds reactivate coverage.
 vi.mock('@/hooks/useSessionViewCount', () => ({
   invalidateSessionViewCount: vi.fn(),
 }));
 
+// Sync-group cloud function shims — mocked so `shareAssignment` / `import…`
+// don't try to write to a real Firestore or fire an httpsCallable.
+const mockCallJoin = vi.fn();
+const mockCallLeave = vi.fn();
+const mockCreateGroup = vi.fn();
+const mockPullContent = vi.fn();
+vi.mock('@/hooks/useSyncedVideoActivityGroups', () => ({
+  callJoinSyncedVideoActivityGroup: (shareId: string): unknown =>
+    mockCallJoin(shareId) as unknown,
+  callLeaveSyncedVideoActivityGroup: (groupId: string): unknown =>
+    mockCallLeave(groupId) as unknown,
+  createSyncedVideoActivityGroup: (input: unknown): unknown =>
+    mockCreateGroup(input) as unknown,
+  pullSyncedVideoActivityContent: (groupId: string): unknown =>
+    mockPullContent(groupId) as unknown,
+}));
+
+const mockAddDoc = addDoc as Mock;
 const mockCollection = collection as Mock;
 const mockDoc = doc as Mock;
+const mockGetDoc = getDoc as Mock;
 const mockGetDocs = getDocs as Mock;
 const mockOnSnapshot = onSnapshot as Mock;
+const mockUpdateDoc = updateDoc as Mock;
 const mockWriteBatch = writeBatch as Mock;
 
 const TEACHER_UID = 'teacher-1';
@@ -66,7 +90,7 @@ function makeSessionOptions(
     attemptLimit: 2,
     rewindOnIncorrectSeconds: 30,
     pointPenaltyOnIncorrect: 1,
-    scoreVisibility: 'score_and_responses',
+    scoreVisibility: 'score-and-responses',
     ...overrides,
   };
 }
@@ -157,7 +181,7 @@ describe('useVideoActivityAssignments — createAssignment persists sessionOptio
       useVideoActivityAssignments(TEACHER_UID)
     );
     const settings = makeSettings({
-      scoreVisibility: 'score_responses_and_answers',
+      scoreVisibility: 'score-responses-and-answers',
       periodNames: ['Period 1', 'Period 2'],
     });
 
@@ -170,7 +194,7 @@ describe('useVideoActivityAssignments — createAssignment persists sessionOptio
       unknown
     >;
     expect(assignmentPayload.scoreVisibility).toBe(
-      'score_responses_and_answers'
+      'score-responses-and-answers'
     );
     expect(assignmentPayload.periodNames).toEqual(['Period 1', 'Period 2']);
   });
@@ -276,11 +300,465 @@ describe('useVideoActivityAssignments — updateAssignmentSettings mirrors polic
       // they live on the assignment archive doc but never need to flow to
       // the session doc, so the session-update branch should stay quiet.
       await result.current.updateAssignmentSettings('assignment-1', {
-        scoreVisibility: 'score_only',
+        scoreVisibility: 'score-only',
         scorePublishedAt: 1700000000000,
       });
     });
 
     expect(batchUpdate).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('useVideoActivityAssignments — shareAssignment + import', () => {
+  const batchSet = vi.fn();
+  const batchCommit = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDoc.mockImplementation((_db: unknown, ...segs: string[]) =>
+      segs.join('/')
+    );
+    mockCollection.mockImplementation((_db: unknown, name: string) => name);
+    mockOnSnapshot.mockReturnValue(() => undefined);
+    batchSet.mockReset();
+    batchCommit.mockReset().mockResolvedValue(undefined);
+    mockWriteBatch.mockReturnValue({
+      set: batchSet,
+      update: vi.fn(),
+      commit: batchCommit,
+    });
+    mockAddDoc.mockReset();
+    mockUpdateDoc.mockReset().mockResolvedValue(undefined);
+    mockCreateGroup.mockReset().mockResolvedValue(undefined);
+    mockCallJoin.mockReset();
+    mockCallLeave.mockReset().mockResolvedValue({ remainingParticipants: 0 });
+    mockPullContent.mockReset();
+  });
+
+  const ACTIVITY_DATA = {
+    id: 'activity-1',
+    title: 'Photosynthesis',
+    youtubeUrl: 'https://youtube.com/watch?v=abc',
+    questions: [],
+    createdAt: 100,
+    updatedAt: 200,
+  };
+
+  function seedAssignmentSnap(overrides: Record<string, unknown> = {}): {
+    exists: () => boolean;
+    data: () => Record<string, unknown>;
+  } {
+    return {
+      exists: () => true,
+      data: () => ({
+        id: 'assign-1',
+        activityId: 'activity-1',
+        teacherUid: TEACHER_UID,
+        sessionSettings: {
+          autoPlay: false,
+          requireCorrectAnswer: true,
+          allowSkipping: false,
+        },
+        ...overrides,
+      }),
+    };
+  }
+
+  function seedMetadataSnap(overrides: Record<string, unknown> = {}): {
+    exists: () => boolean;
+    data: () => Record<string, unknown>;
+  } {
+    return {
+      exists: () => true,
+      data: () => ({
+        id: 'activity-1',
+        title: 'Photosynthesis',
+        youtubeUrl: 'https://youtube.com/watch?v=abc',
+        driveFileId: 'drive-1',
+        questionCount: 0,
+        createdAt: 100,
+        updatedAt: 100,
+        ...overrides,
+      }),
+    };
+  }
+
+  it('shareAssignment auto-creates a synced group when source has none', async () => {
+    mockGetDoc
+      .mockResolvedValueOnce(seedAssignmentSnap())
+      .mockResolvedValueOnce(seedMetadataSnap());
+    mockAddDoc.mockResolvedValue({ id: 'share-abc' });
+
+    const { result } = renderHook(() =>
+      useVideoActivityAssignments(TEACHER_UID)
+    );
+    let url = '';
+    await act(async () => {
+      url = await result.current.shareAssignment('assign-1', ACTIVITY_DATA);
+    });
+
+    // 1) Synced group was minted with the sharer as sole participant.
+    expect(mockCreateGroup).toHaveBeenCalledTimes(1);
+    const groupArg = mockCreateGroup.mock.calls[0][0] as Record<
+      string,
+      unknown
+    >;
+    expect(groupArg.uid).toBe(TEACHER_UID);
+    expect(groupArg.title).toBe('Photosynthesis');
+    expect(typeof groupArg.groupId).toBe('string');
+
+    // 2) Local metadata patched with the new linkage.
+    expect(mockUpdateDoc).toHaveBeenCalledTimes(1);
+    const linkagePatch = mockUpdateDoc.mock.calls[0][1] as Record<
+      string,
+      unknown
+    >;
+    const sync = linkagePatch.sync as {
+      groupId: string;
+      lastSyncedVersion: number;
+    };
+    expect(sync.groupId).toBe(groupArg.groupId);
+    expect(sync.lastSyncedVersion).toBe(1);
+
+    // 3) Share doc carries the syncGroupId so importers can pick Synced.
+    expect(mockAddDoc).toHaveBeenCalledTimes(1);
+    const sharePayload = mockAddDoc.mock.calls[0][1] as Record<string, unknown>;
+    expect(sharePayload.originalAuthor).toBe(TEACHER_UID);
+    expect(sharePayload.syncGroupId).toBe(groupArg.groupId);
+    expect(url).toContain('/share/video-activity/share-abc');
+  });
+
+  it('shareAssignment reuses an existing syncGroupId when source already has one', async () => {
+    mockGetDoc
+      .mockResolvedValueOnce(seedAssignmentSnap())
+      .mockResolvedValueOnce(
+        seedMetadataSnap({
+          sync: { groupId: 'existing-group', lastSyncedVersion: 3 },
+        })
+      );
+    mockAddDoc.mockResolvedValue({ id: 'share-xyz' });
+
+    const { result } = renderHook(() =>
+      useVideoActivityAssignments(TEACHER_UID)
+    );
+    await act(async () => {
+      await result.current.shareAssignment('assign-1', ACTIVITY_DATA);
+    });
+
+    // Existing group reused — no new createSyncedGroup, no metadata patch.
+    expect(mockCreateGroup).not.toHaveBeenCalled();
+    expect(mockUpdateDoc).not.toHaveBeenCalled();
+    const sharePayload = mockAddDoc.mock.calls[0][1] as Record<string, unknown>;
+    expect(sharePayload.syncGroupId).toBe('existing-group');
+  });
+
+  it('shareAssignment throws when source activity is missing from local library', async () => {
+    mockGetDoc
+      .mockResolvedValueOnce(seedAssignmentSnap())
+      .mockResolvedValueOnce({ exists: () => false, data: () => ({}) });
+
+    const { result } = renderHook(() =>
+      useVideoActivityAssignments(TEACHER_UID)
+    );
+    await expect(
+      result.current.shareAssignment('assign-1', ACTIVITY_DATA)
+    ).rejects.toThrow(/Source activity is missing/);
+  });
+
+  it('shareAssignment rolls back the metadata sync linkage when addDoc fails', async () => {
+    // Source activity has no synced linkage — so we mint one, then addDoc fails.
+    mockGetDoc
+      .mockResolvedValueOnce(seedAssignmentSnap())
+      .mockResolvedValueOnce(seedMetadataSnap());
+    mockAddDoc.mockRejectedValue(new Error('share write denied'));
+
+    const { result } = renderHook(() =>
+      useVideoActivityAssignments(TEACHER_UID)
+    );
+    await expect(
+      result.current.shareAssignment('assign-1', ACTIVITY_DATA)
+    ).rejects.toThrow(/share write denied/);
+
+    // updateDoc was called twice: once to attach the freshly-minted linkage,
+    // once to roll it back to null after addDoc failed. Without the rollback
+    // the local meta would carry a `sync.groupId` pointing at a group with
+    // no matching share doc — same race the Quiz hook has documented.
+    expect(mockUpdateDoc).toHaveBeenCalledTimes(2);
+    const rollbackPatch = mockUpdateDoc.mock.calls[1][1] as Record<
+      string,
+      unknown
+    >;
+    expect(rollbackPatch.sync).toBeNull();
+  });
+
+  it('shareAssignment does NOT roll back metadata when source already had a syncGroupId', async () => {
+    // Pre-existing linkage means we never minted one, so a downstream
+    // addDoc failure shouldn't clear what predates this share call.
+    mockGetDoc
+      .mockResolvedValueOnce(seedAssignmentSnap())
+      .mockResolvedValueOnce(
+        seedMetadataSnap({
+          sync: { groupId: 'pre-existing', lastSyncedVersion: 5 },
+        })
+      );
+    mockAddDoc.mockRejectedValue(new Error('share write denied'));
+
+    const { result } = renderHook(() =>
+      useVideoActivityAssignments(TEACHER_UID)
+    );
+    await expect(
+      result.current.shareAssignment('assign-1', ACTIVITY_DATA)
+    ).rejects.toThrow(/share write denied/);
+
+    expect(mockUpdateDoc).not.toHaveBeenCalled();
+  });
+
+  it('peekSharedAssignment returns null for missing shareId', async () => {
+    mockGetDoc.mockResolvedValueOnce({
+      exists: () => false,
+      data: () => ({}),
+    });
+    const { result } = renderHook(() =>
+      useVideoActivityAssignments(TEACHER_UID)
+    );
+    const out = await result.current.peekSharedAssignment('nope');
+    expect(out).toBeNull();
+  });
+
+  it('importSharedAssignment in copy mode does not call sync-group join', async () => {
+    const sharedDoc: SharedVideoActivityAssignment = {
+      id: 'share-1',
+      title: 'Shared Activity',
+      youtubeUrl: 'https://youtube.com/watch?v=def',
+      questions: [],
+      createdAt: 100,
+      updatedAt: 200,
+      assignmentSettings: {
+        sessionSettings: {
+          autoPlay: false,
+          requireCorrectAnswer: true,
+          allowSkipping: false,
+        },
+      },
+      originalAuthor: 'teacher-A',
+      sharedAt: 300,
+      syncGroupId: 'group-x',
+    };
+    mockGetDoc.mockResolvedValueOnce({
+      exists: () => true,
+      data: () => sharedDoc,
+    });
+
+    const newMeta: VideoActivityMetadata = {
+      id: 'imported-activity',
+      title: 'Shared Activity',
+      youtubeUrl: 'https://youtube.com/watch?v=def',
+      driveFileId: 'imported-drive',
+      questionCount: 0,
+      createdAt: 1,
+      updatedAt: 1,
+    };
+    const saveActivity = vi.fn().mockResolvedValue(newMeta);
+
+    const { result } = renderHook(() =>
+      useVideoActivityAssignments(TEACHER_UID)
+    );
+    await act(async () => {
+      await result.current.importSharedAssignment('share-1', {
+        mode: 'copy',
+        saveActivity,
+      });
+    });
+    expect(saveActivity).toHaveBeenCalledTimes(1);
+    expect(mockCallJoin).not.toHaveBeenCalled();
+    expect(mockPullContent).not.toHaveBeenCalled();
+  });
+
+  it('importSharedAssignment in sync mode joins the group and attaches linkage', async () => {
+    const sharedDoc: SharedVideoActivityAssignment = {
+      id: 'share-2',
+      title: 'Synced Activity',
+      youtubeUrl: 'https://youtube.com/watch?v=ghi',
+      questions: [],
+      createdAt: 100,
+      updatedAt: 200,
+      assignmentSettings: {
+        sessionSettings: {
+          autoPlay: false,
+          requireCorrectAnswer: true,
+          allowSkipping: false,
+        },
+      },
+      originalAuthor: 'teacher-A',
+      sharedAt: 300,
+      syncGroupId: 'group-sync',
+    };
+    mockGetDoc.mockResolvedValueOnce({
+      exists: () => true,
+      data: () => sharedDoc,
+    });
+    mockCallJoin.mockResolvedValue({
+      groupId: 'group-sync',
+      version: 7,
+      alreadyJoined: false,
+    });
+    mockPullContent.mockResolvedValue({
+      title: 'Synced Activity',
+      youtubeUrl: 'https://youtube.com/watch?v=ghi',
+      questions: [],
+      version: 7,
+    });
+
+    const newMeta: VideoActivityMetadata = {
+      id: 'imported-2',
+      title: 'Synced Activity',
+      youtubeUrl: 'https://youtube.com/watch?v=ghi',
+      driveFileId: 'imported-drive-2',
+      questionCount: 0,
+      createdAt: 1,
+      updatedAt: 1,
+    };
+    const saveActivity = vi.fn().mockResolvedValue(newMeta);
+    const attachSyncLinkage = vi.fn().mockResolvedValue(undefined);
+
+    const { result } = renderHook(() =>
+      useVideoActivityAssignments(TEACHER_UID)
+    );
+    await act(async () => {
+      await result.current.importSharedAssignment('share-2', {
+        mode: 'sync',
+        saveActivity,
+        attachSyncLinkage,
+      });
+    });
+
+    expect(mockCallJoin).toHaveBeenCalledWith('share-2');
+    expect(mockPullContent).toHaveBeenCalledWith('group-sync');
+    expect(attachSyncLinkage).toHaveBeenCalledWith('imported-2', {
+      groupId: 'group-sync',
+      lastSyncedVersion: 7,
+    });
+  });
+
+  it('importSharedAssignment rolls back the synced-group join when downstream save fails', async () => {
+    const sharedDoc: SharedVideoActivityAssignment = {
+      id: 'share-3',
+      title: 'Failing import',
+      youtubeUrl: 'https://youtube.com/watch?v=jkl',
+      questions: [],
+      createdAt: 100,
+      updatedAt: 200,
+      assignmentSettings: {
+        sessionSettings: {
+          autoPlay: false,
+          requireCorrectAnswer: true,
+          allowSkipping: false,
+        },
+      },
+      originalAuthor: 'teacher-A',
+      sharedAt: 300,
+      syncGroupId: 'group-fail',
+    };
+    mockGetDoc.mockResolvedValueOnce({
+      exists: () => true,
+      data: () => sharedDoc,
+    });
+    mockCallJoin.mockResolvedValue({
+      groupId: 'group-fail',
+      version: 1,
+      alreadyJoined: false,
+    });
+    mockPullContent.mockRejectedValue(new Error('canonical fetch failed'));
+
+    const { result } = renderHook(() =>
+      useVideoActivityAssignments(TEACHER_UID)
+    );
+    await expect(
+      result.current.importSharedAssignment('share-3', {
+        mode: 'sync',
+        saveActivity: vi
+          .fn<
+            (
+              activity: import('@/types').VideoActivityData
+            ) => Promise<VideoActivityMetadata>
+          >()
+          .mockResolvedValue({
+            id: 'imported-3',
+            title: 'Failing import',
+            youtubeUrl: 'https://youtube.com/watch?v=jkl',
+            driveFileId: 'd',
+            questionCount: 0,
+            createdAt: 1,
+            updatedAt: 1,
+          }),
+      })
+    ).rejects.toThrow(/canonical fetch failed/);
+    // Rollback fired so the importer doesn't accumulate orphan participation.
+    expect(mockCallLeave).toHaveBeenCalledWith('group-fail');
+  });
+
+  it('importSharedAssignment rolls back the synced-group join when attachSyncLinkage fails', async () => {
+    const sharedDoc: SharedVideoActivityAssignment = {
+      id: 'share-4',
+      title: 'Linkage-attach failure',
+      youtubeUrl: 'https://youtube.com/watch?v=mno',
+      questions: [],
+      createdAt: 100,
+      updatedAt: 200,
+      assignmentSettings: {
+        sessionSettings: {
+          autoPlay: false,
+          requireCorrectAnswer: true,
+          allowSkipping: false,
+        },
+      },
+      originalAuthor: 'teacher-A',
+      sharedAt: 300,
+      syncGroupId: 'group-attach-fail',
+    };
+    mockGetDoc.mockResolvedValueOnce({
+      exists: () => true,
+      data: () => sharedDoc,
+    });
+    mockCallJoin.mockResolvedValue({
+      groupId: 'group-attach-fail',
+      version: 4,
+      alreadyJoined: false,
+    });
+    mockPullContent.mockResolvedValue({
+      title: 'Linkage-attach failure',
+      youtubeUrl: 'https://youtube.com/watch?v=mno',
+      questions: [],
+      version: 4,
+    });
+
+    const { result } = renderHook(() =>
+      useVideoActivityAssignments(TEACHER_UID)
+    );
+    await expect(
+      result.current.importSharedAssignment('share-4', {
+        mode: 'sync',
+        saveActivity: vi
+          .fn<
+            (
+              activity: import('@/types').VideoActivityData
+            ) => Promise<VideoActivityMetadata>
+          >()
+          .mockResolvedValue({
+            id: 'imported-4',
+            title: 'Linkage-attach failure',
+            youtubeUrl: 'https://youtube.com/watch?v=mno',
+            driveFileId: 'd',
+            questionCount: 0,
+            createdAt: 1,
+            updatedAt: 1,
+          }),
+        // Simulate the metadata patch failing AFTER join + pull succeed.
+        attachSyncLinkage: vi
+          .fn()
+          .mockRejectedValue(new Error('metadata patch denied')),
+      })
+    ).rejects.toThrow(/metadata patch denied/);
+    expect(mockCallLeave).toHaveBeenCalledWith('group-attach-fail');
   });
 });

--- a/tests/rules/plcAssignmentIndex.test.ts
+++ b/tests/rules/plcAssignmentIndex.test.ts
@@ -227,14 +227,27 @@ describe('plcs/{plcId}/assignment_index — create', () => {
     );
   });
 
-  it("rejects kind != 'quiz' (constrained discriminator)", async () => {
-    // `kind` is reserved for future video-activity entries but currently
-    // only `'quiz'` is valid. Rejecting other values keeps the dashboard
-    // from rendering rows it doesn't know how to display.
-    await assertFails(
+  it("accepts kind: 'video-activity' (PR3a widening)", async () => {
+    // PR3a widened the rules constraint from `kind == 'quiz'` to
+    // `kind in ['quiz', 'video-activity']` so VA's PR3b assignment-share
+    // flow can write its own index entries. This test pins the new
+    // allow-list and prevents a future narrowing regression.
+    await assertSucceeds(
       setDoc(
         doc(asMemberA(), `plcs/${PLC_ID}/assignment_index/${ASSIGNMENT_ID}`),
         validEntry({ kind: 'video-activity' })
+      )
+    );
+  });
+
+  it("rejects kind outside ['quiz', 'video-activity']", async () => {
+    // The rule's `kind in [...]` is still a closed allowlist; arbitrary
+    // values must still be rejected so the dashboard doesn't render rows
+    // it doesn't know how to display.
+    await assertFails(
+      setDoc(
+        doc(asMemberA(), `plcs/${PLC_ID}/assignment_index/${ASSIGNMENT_ID}`),
+        validEntry({ kind: 'mini-app' })
       )
     );
   });

--- a/tests/rules/plcQuizzes.test.ts
+++ b/tests/rules/plcQuizzes.test.ts
@@ -1,0 +1,327 @@
+// Firestore security-rules regression for the
+// `/plcs/{plcId}/quizzes/{plcQuizId}` match block introduced with Phase 2
+// of the PLC Dashboard (PLC Quiz Library). The rules carry the same
+// invariants as Phase 1's assignment_index plus a few PLC-Library-specific
+// ones:
+//   - membership-gated reads
+//   - ANY member can create / update / delete (PLC-owned model — quizzes
+//     shared with the PLC belong to the PLC, not the original sharer)
+//   - schema lock-down (`keys().hasOnly([...])`)
+//   - identity + attribution fields immutable on update (`id`,
+//     `syncGroupId`, `sharedBy`, `sharedByEmail`, `sharedByName`,
+//     `sharedAt`)
+//   - `sharedBy` must equal the caller on create (no impersonation)
+//
+// Requires a running Firestore emulator — invoke via
+// `pnpm run test:rules` (see vitest.rules.config.ts).
+
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { afterAll, beforeAll, beforeEach, describe, it } from 'vitest';
+import {
+  initializeTestEnvironment,
+  assertSucceeds,
+  assertFails,
+  type RulesTestEnvironment,
+} from '@firebase/rules-unit-testing';
+import { setDoc, getDoc, updateDoc, deleteDoc, doc } from 'firebase/firestore';
+
+const PROJECT_ID = 'spartboard-plc-quizzes';
+const PLC_ID = 'plc-rules-test';
+const PLC_QUIZ_ID = 'plc-quiz-rules-test';
+const SYNC_GROUP_ID = 'group-rules-test';
+
+const MEMBER_A_UID = 'member-a-uid';
+const MEMBER_B_UID = 'member-b-uid';
+const NON_MEMBER_UID = 'non-member-uid';
+
+const RULES_PATH = fileURLToPath(
+  new URL('../../firestore.rules', import.meta.url)
+);
+
+let testEnv: RulesTestEnvironment;
+
+const asMemberA = () =>
+  testEnv
+    .authenticatedContext(MEMBER_A_UID, { email: 'member-a@example.com' })
+    .firestore();
+
+const asMemberB = () =>
+  testEnv
+    .authenticatedContext(MEMBER_B_UID, { email: 'member-b@example.com' })
+    .firestore();
+
+const asNonMember = () =>
+  testEnv
+    .authenticatedContext(NON_MEMBER_UID, { email: 'random@example.com' })
+    .firestore();
+
+const validEntry = (overrides: Record<string, unknown> = {}) => ({
+  id: PLC_QUIZ_ID,
+  title: 'My PLC Quiz',
+  questionCount: 5,
+  syncGroupId: SYNC_GROUP_ID,
+  sharedBy: MEMBER_A_UID,
+  sharedByEmail: 'member-a@example.com',
+  sharedByName: 'Member A',
+  sharedAt: 1000,
+  updatedAt: 1000,
+  ...overrides,
+});
+
+beforeAll(async () => {
+  testEnv = await initializeTestEnvironment({
+    projectId: PROJECT_ID,
+    firestore: {
+      rules: readFileSync(RULES_PATH, 'utf8'),
+      host: process.env.FIRESTORE_EMULATOR_HOST?.split(':')[0] ?? '127.0.0.1',
+      port: Number(
+        process.env.FIRESTORE_EMULATOR_HOST?.split(':')[1] ?? '8080'
+      ),
+    },
+  });
+});
+
+afterAll(async () => {
+  await testEnv?.cleanup();
+});
+
+beforeEach(async () => {
+  await testEnv.clearFirestore();
+  await testEnv.withSecurityRulesDisabled(async (ctx) => {
+    await setDoc(doc(ctx.firestore(), `plcs/${PLC_ID}`), {
+      name: 'Test PLC',
+      leadUid: MEMBER_A_UID,
+      memberUids: [MEMBER_A_UID, MEMBER_B_UID],
+      memberEmails: {
+        [MEMBER_A_UID]: 'member-a@example.com',
+        [MEMBER_B_UID]: 'member-b@example.com',
+      },
+      createdAt: 1,
+      updatedAt: 1,
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// read
+// ---------------------------------------------------------------------------
+
+describe('plcs/{plcId}/quizzes — read', () => {
+  beforeEach(async () => {
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      await setDoc(
+        doc(ctx.firestore(), `plcs/${PLC_ID}/quizzes/${PLC_QUIZ_ID}`),
+        validEntry()
+      );
+    });
+  });
+
+  it('a PLC member can read entries', async () => {
+    await assertSucceeds(
+      getDoc(doc(asMemberB(), `plcs/${PLC_ID}/quizzes/${PLC_QUIZ_ID}`))
+    );
+  });
+
+  it('a non-member cannot read entries (membership gate)', async () => {
+    await assertFails(
+      getDoc(doc(asNonMember(), `plcs/${PLC_ID}/quizzes/${PLC_QUIZ_ID}`))
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// create
+// ---------------------------------------------------------------------------
+
+describe('plcs/{plcId}/quizzes — create', () => {
+  it('any PLC member can create a valid entry', async () => {
+    await assertSucceeds(
+      setDoc(
+        doc(asMemberA(), `plcs/${PLC_ID}/quizzes/${PLC_QUIZ_ID}`),
+        validEntry()
+      )
+    );
+  });
+
+  it('a non-member cannot fabricate an entry', async () => {
+    await assertFails(
+      setDoc(
+        doc(asNonMember(), `plcs/${PLC_ID}/quizzes/${PLC_QUIZ_ID}`),
+        validEntry({ sharedBy: NON_MEMBER_UID })
+      )
+    );
+  });
+
+  it('rejects when sharedBy != caller (no impersonation)', async () => {
+    // The PLC tab displays sharedByName/Email from this snapshot — an
+    // impersonation would mislead other members about who shared the
+    // quiz, undermining the audit trail.
+    await assertFails(
+      setDoc(
+        doc(asMemberA(), `plcs/${PLC_ID}/quizzes/${PLC_QUIZ_ID}`),
+        validEntry({ sharedBy: MEMBER_B_UID })
+      )
+    );
+  });
+
+  it('rejects when path id != entry.id (path/payload mismatch)', async () => {
+    await assertFails(
+      setDoc(
+        doc(asMemberA(), `plcs/${PLC_ID}/quizzes/different-id`),
+        validEntry({ id: PLC_QUIZ_ID })
+      )
+    );
+  });
+
+  it('rejects extra unknown fields (schema lock-down)', async () => {
+    // Closed schema — future readers shouldn't have to defensively parse
+    // unexpected payloads. Drift here would also smuggle bloat past the
+    // rule that should reject it.
+    await assertFails(
+      setDoc(doc(asMemberA(), `plcs/${PLC_ID}/quizzes/${PLC_QUIZ_ID}`), {
+        ...validEntry(),
+        unexpected: 'extra',
+      })
+    );
+  });
+
+  it('rejects when questionCount is negative', async () => {
+    await assertFails(
+      setDoc(
+        doc(asMemberA(), `plcs/${PLC_ID}/quizzes/${PLC_QUIZ_ID}`),
+        validEntry({ questionCount: -1 })
+      )
+    );
+  });
+
+  it('rejects when syncGroupId is missing/non-string', async () => {
+    // Without syncGroupId the entry can't participate in collaborative
+    // editing — the PLC tab would render an unactionable row.
+    await assertFails(
+      setDoc(
+        doc(asMemberA(), `plcs/${PLC_ID}/quizzes/${PLC_QUIZ_ID}`),
+        validEntry({ syncGroupId: 42 })
+      )
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// update — immutability of identity + attribution fields
+// ---------------------------------------------------------------------------
+
+describe('plcs/{plcId}/quizzes — update', () => {
+  beforeEach(async () => {
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      await setDoc(
+        doc(ctx.firestore(), `plcs/${PLC_ID}/quizzes/${PLC_QUIZ_ID}`),
+        validEntry()
+      );
+    });
+  });
+
+  it('any member can mirror title/questionCount/updatedAt (collaborative-edit posture)', async () => {
+    // Phase 5 notes/todos gives any member edit rights. Phase 2 quizzes
+    // mirror that — title and questionCount are bumped after each peer
+    // publishes a content edit, so any current member must be able to
+    // patch them. If this assertion ever flips, the LWW mirror would
+    // start failing for non-sharer peers.
+    await assertSucceeds(
+      updateDoc(doc(asMemberB(), `plcs/${PLC_ID}/quizzes/${PLC_QUIZ_ID}`), {
+        title: 'Renamed',
+        questionCount: 9,
+        updatedAt: 2000,
+      })
+    );
+  });
+
+  it('rejects an attempt to change syncGroupId (immutability)', async () => {
+    // The syncGroupId pins this PLC entry to a specific canonical
+    // synced_quizzes doc. Letting a member retarget the linkage would
+    // silently swap one quiz for another behind teammates' backs.
+    await assertFails(
+      updateDoc(doc(asMemberB(), `plcs/${PLC_ID}/quizzes/${PLC_QUIZ_ID}`), {
+        syncGroupId: 'different-group',
+      })
+    );
+  });
+
+  it('rejects an attempt to change sharedBy (attribution immutability)', async () => {
+    // The PLC tab renders "shared by {sharedByName}" — rewriting this
+    // would let a teammate steal authorship of someone else's share.
+    await assertFails(
+      updateDoc(doc(asMemberB(), `plcs/${PLC_ID}/quizzes/${PLC_QUIZ_ID}`), {
+        sharedBy: MEMBER_B_UID,
+      })
+    );
+  });
+
+  it('rejects an attempt to mutate id (immutability)', async () => {
+    await assertFails(
+      updateDoc(doc(asMemberA(), `plcs/${PLC_ID}/quizzes/${PLC_QUIZ_ID}`), {
+        id: 'different-id',
+      })
+    );
+  });
+
+  it('rejects an attempt to mutate sharedAt (immutability)', async () => {
+    await assertFails(
+      updateDoc(doc(asMemberA(), `plcs/${PLC_ID}/quizzes/${PLC_QUIZ_ID}`), {
+        sharedAt: 9999999,
+      })
+    );
+  });
+
+  it('rejects an update that introduces an extra field (schema lock-down)', async () => {
+    await assertFails(
+      updateDoc(doc(asMemberA(), `plcs/${PLC_ID}/quizzes/${PLC_QUIZ_ID}`), {
+        unexpected: 'extra-field',
+      })
+    );
+  });
+
+  it('a non-member cannot update an entry', async () => {
+    await assertFails(
+      updateDoc(doc(asNonMember(), `plcs/${PLC_ID}/quizzes/${PLC_QUIZ_ID}`), {
+        title: 'Hijacked',
+      })
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// delete — orphan-tolerant, any-member
+// ---------------------------------------------------------------------------
+
+describe('plcs/{plcId}/quizzes — delete', () => {
+  beforeEach(async () => {
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      await setDoc(
+        doc(ctx.firestore(), `plcs/${PLC_ID}/quizzes/${PLC_QUIZ_ID}`),
+        validEntry()
+      );
+    });
+  });
+
+  it('the original sharer can unshare', async () => {
+    await assertSucceeds(
+      deleteDoc(doc(asMemberA(), `plcs/${PLC_ID}/quizzes/${PLC_QUIZ_ID}`))
+    );
+  });
+
+  it('any teammate (not just the sharer) can unshare (PLC-owned model)', async () => {
+    // Phase 2 spec: quizzes shared with the PLC belong to the PLC, not
+    // the original sharer. If this flips to assertFails, the unshare
+    // affordance must hide for non-sharer rows in PlcQuizLibraryTab.
+    await assertSucceeds(
+      deleteDoc(doc(asMemberB(), `plcs/${PLC_ID}/quizzes/${PLC_QUIZ_ID}`))
+    );
+  });
+
+  it('a non-member cannot delete', async () => {
+    await assertFails(
+      deleteDoc(doc(asNonMember(), `plcs/${PLC_ID}/quizzes/${PLC_QUIZ_ID}`))
+    );
+  });
+});

--- a/tests/utils/ai.test.ts
+++ b/tests/utils/ai.test.ts
@@ -14,6 +14,7 @@ import {
   generateVideoActivity,
   transcribeVideoWithGemini,
   generateGuidedLearning,
+  recommendVideoForActivity,
 } from '@/utils/ai';
 
 // Mock Firebase Functions
@@ -162,6 +163,32 @@ vi.mock('firebase/functions', () => {
                   incorrectAnswers: ['B', 'C'],
                 },
               ],
+            },
+          };
+        }
+
+        if (data.type === 'video-activity-recommend') {
+          if (data.prompt.includes('refuse')) {
+            // Gemini refuses with empty videoId
+            return {
+              data: { videoId: '', title: '', rationale: 'Topic too vague.' },
+            };
+          }
+          if (data.prompt.includes('hallucinate')) {
+            // Bad videoId shape (only 5 chars) — wrapper rejects
+            return {
+              data: { videoId: 'short', title: 'Bad', rationale: 'x' },
+            };
+          }
+          if (data.prompt.includes('garbage')) {
+            // Missing fields entirely
+            return { data: {} };
+          }
+          return {
+            data: {
+              videoId: 'abcDEF12345',
+              title: 'Photosynthesis Crash Course',
+              rationale: 'Aligned with 6th-grade life science standards.',
             },
           };
         }
@@ -413,5 +440,43 @@ describe('video activity callables', () => {
     ).rejects.toThrow(
       'Video analysis is taking longer than expected. Please try a shorter YouTube video (under ~15 minutes) or try again in a moment.'
     );
+  });
+});
+
+describe('recommendVideoForActivity', () => {
+  it('returns a parsed recommendation on a valid response', async () => {
+    const result = await recommendVideoForActivity('photosynthesis 6th grade');
+    expect(result).toEqual({
+      videoId: 'abcDEF12345',
+      title: 'Photosynthesis Crash Course',
+      rationale: 'Aligned with 6th-grade life science standards.',
+    });
+  });
+
+  it('returns null when Gemini refuses with empty videoId', async () => {
+    const result = await recommendVideoForActivity('refuse this topic');
+    expect(result).toBeNull();
+  });
+
+  it('returns null when Gemini hallucinates an invalid id shape', async () => {
+    // 5 chars — must be exactly 11 alphanumerics/hyphens/underscores
+    const result = await recommendVideoForActivity('hallucinate test');
+    expect(result).toBeNull();
+  });
+
+  it('returns null on garbled response (missing fields)', async () => {
+    const result = await recommendVideoForActivity('garbage in');
+    expect(result).toBeNull();
+  });
+
+  it('throws when topic is empty', async () => {
+    await expect(recommendVideoForActivity('   ')).rejects.toThrow(
+      'A topic or objective is required.'
+    );
+  });
+
+  it('routes through the generic generateWithAI function', async () => {
+    await recommendVideoForActivity('photosynthesis 6th grade');
+    expect(vi.mocked(httpsCallable)).toHaveBeenCalledWith({}, 'generateWithAI');
   });
 });

--- a/tests/utils/assignmentExportShared.test.ts
+++ b/tests/utils/assignmentExportShared.test.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildResultsSheetData,
+  formatExportPoints,
+  type ExportableQuestion,
+  type ExportableResponse,
+} from '@/utils/assignmentExportShared';
+import type { GradeResult } from '@/types';
+
+describe('formatExportPoints', () => {
+  it('renders integers without decimals', () => {
+    expect(formatExportPoints(0)).toBe('0');
+    expect(formatExportPoints(5)).toBe('5');
+    expect(formatExportPoints(100)).toBe('100');
+  });
+
+  it('renders fractional values with up to 2 decimals', () => {
+    expect(formatExportPoints(0.5)).toBe('0.5');
+    expect(formatExportPoints(1.25)).toBe('1.25');
+  });
+
+  it('strips trailing zeros from rounded fractionals', () => {
+    expect(formatExportPoints(1.1)).toBe('1.1');
+  });
+});
+
+describe('buildResultsSheetData', () => {
+  const ALWAYS_FULL: (q: { points?: number }) => GradeResult = (q) => ({
+    isCorrect: true,
+    pointsEarned: q.points ?? 1,
+    pointsMax: q.points ?? 1,
+  });
+  const ALWAYS_ZERO: () => GradeResult = () => ({
+    isCorrect: false,
+    pointsEarned: 0,
+    pointsMax: 1,
+  });
+
+  function q(overrides: Partial<ExportableQuestion> = {}): ExportableQuestion {
+    return {
+      id: 'q1',
+      text: 'What?',
+      points: 1,
+      ...overrides,
+    };
+  }
+
+  function r(overrides: Partial<ExportableResponse> = {}): ExportableResponse {
+    return {
+      pin: '01',
+      studentUid: 'student-1',
+      classPeriod: 'Period 1',
+      answers: [{ questionId: 'q1', answer: 'a' }],
+      status: 'completed',
+      submittedAt: 1700000000000,
+      tabSwitchWarnings: 0,
+      ...overrides,
+    };
+  }
+
+  it('emits the canonical column header layout', () => {
+    const { headers } = buildResultsSheetData(
+      [r()],
+      [q({ id: 'q1', text: 'Question 1', points: 2 })],
+      ALWAYS_FULL
+    );
+    expect(headers).toEqual([
+      'Timestamp',
+      'Teacher',
+      'Class Period',
+      'Student',
+      'PIN',
+      'Status',
+      'Score (%)',
+      'Points Earned',
+      'Max Points',
+      'Warnings',
+      'Submitted At',
+      'Q1 (2pt): Question 1',
+    ]);
+  });
+
+  it('routes correctness through the injected grader (full credit)', () => {
+    const { dataRows } = buildResultsSheetData(
+      [r()],
+      [q({ points: 3 })],
+      ALWAYS_FULL
+    );
+    expect(dataRows).toHaveLength(1);
+    // Score column is index 6 (after Timestamp, Teacher, Class, Student, PIN, Status)
+    expect(dataRows[0][6]).toBe('100%');
+    // Points Earned at index 7
+    expect(dataRows[0][7]).toBe('3');
+  });
+
+  it('routes correctness through the injected grader (zero credit)', () => {
+    const { dataRows } = buildResultsSheetData(
+      [r()],
+      [q({ points: 3 })],
+      ALWAYS_ZERO
+    );
+    // Even though the response is "completed", earned is 0 so score is 0%
+    expect(dataRows[0][6]).toBe('0%');
+    expect(dataRows[0][7]).toBe('0');
+  });
+
+  it('hides score column for in-progress responses', () => {
+    const { dataRows } = buildResultsSheetData(
+      [r({ status: 'in-progress', submittedAt: null })],
+      [q()],
+      ALWAYS_FULL
+    );
+    // Score column blank for non-completed
+    expect(dataRows[0][6]).toBe('');
+  });
+
+  it('resolves SSO students by studentUid first, falling back to PIN', () => {
+    const ssoMap = new Map([
+      ['sso-1', { givenName: 'Alex', familyName: 'Lee' }],
+    ]);
+    // Period-scoped pinToName uses the canonical `${period}${pin}` key
+    // shape produced by `buildPinToNameMap`.
+    const PIN_KEY_SEP = String.fromCharCode(0x01);
+    const { dataRows } = buildResultsSheetData(
+      [
+        r({ studentUid: 'sso-1', pin: undefined }),
+        r({ studentUid: 'pin-1', pin: '02' }),
+      ],
+      [q()],
+      ALWAYS_FULL,
+      {
+        byStudentUid: ssoMap,
+        pinToName: { [`Period 1${PIN_KEY_SEP}02`]: 'Maya' },
+      }
+    );
+    // Student column at index 3; rows are sorted by name so verify both
+    const names = dataRows.map((row) => row[3]);
+    expect(names).toContain('Alex Lee');
+    expect(names).toContain('Maya');
+  });
+
+  it('passes question.points to the grader call (max points sums correctly)', () => {
+    const { dataRows } = buildResultsSheetData(
+      [r({ answers: [{ questionId: 'q1', answer: 'x' }] })],
+      [q({ id: 'q1', points: 5 })],
+      ALWAYS_FULL
+    );
+    // Max Points column at index 8
+    expect(dataRows[0][8]).toBe('5');
+  });
+
+  it('sorts rows by student name', () => {
+    const PIN_KEY_SEP = String.fromCharCode(0x01);
+    const { dataRows } = buildResultsSheetData(
+      [r({ studentUid: 'a', pin: '03' }), r({ studentUid: 'b', pin: '01' })],
+      [q()],
+      ALWAYS_FULL,
+      {
+        pinToName: {
+          [`Period 1${PIN_KEY_SEP}01`]: 'Aiden',
+          [`Period 1${PIN_KEY_SEP}03`]: 'Zara',
+        },
+      }
+    );
+    expect(dataRows[0][3]).toBe('Aiden');
+    expect(dataRows[1][3]).toBe('Zara');
+  });
+
+  it('handles empty questions and responses without crashing', () => {
+    const empty = buildResultsSheetData([], [], ALWAYS_FULL);
+    expect(empty.headers).toHaveLength(11); // 11 fixed cols + 0 question cols
+    expect(empty.dataRows).toEqual([]);
+
+    // Responses but no questions: maxPoints = 0 must not divide-by-zero;
+    // Score column blanks out via the maxPoints > 0 guard.
+    const noQs = buildResultsSheetData([r()], [], ALWAYS_FULL);
+    expect(noQs.dataRows[0][6]).toBe(''); // Score (%) blank
+    expect(noQs.dataRows[0][8]).toBe('0'); // Max Points = 0
+  });
+});

--- a/tests/utils/videoActivityDriveService.test.ts
+++ b/tests/utils/videoActivityDriveService.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect } from 'vitest';
+import { buildVideoActivityResultsSheetData } from '@/utils/videoActivityDriveService';
+import type { VideoActivityQuestion, VideoActivityResponse } from '@/types';
+
+function vaQuestion(
+  overrides: Partial<VideoActivityQuestion> = {}
+): VideoActivityQuestion {
+  return {
+    id: 'q1',
+    text: 'What organelle?',
+    timestamp: 30,
+    timeLimit: 30,
+    type: 'MC',
+    correctAnswer: 'mitochondria',
+    incorrectAnswers: [],
+    points: 1,
+    ...overrides,
+  };
+}
+
+function vaResponse(
+  overrides: Partial<VideoActivityResponse> = {}
+): VideoActivityResponse {
+  return {
+    pin: '01',
+    studentUid: 'student-1',
+    classPeriod: 'Period 1',
+    joinedAt: 1700000000000,
+    answers: [
+      { questionId: 'q1', answer: 'mitochondria', answeredAt: 1700000000500 },
+    ],
+    score: null,
+    completedAt: 1700000001000,
+    tabSwitchWarnings: 0,
+    ...overrides,
+  };
+}
+
+describe('buildVideoActivityResultsSheetData', () => {
+  it('grades MA questions correctly (PR2a TODO fix)', () => {
+    // The Quiz grader has no 'MA' case and would award 0 points.
+    // VA's grader (gradeVideoActivityAnswer) handles set-equality, so a
+    // student who picked exactly the correct selections gets full points.
+    const ma = vaQuestion({
+      id: 'q-ma',
+      type: 'MA',
+      correctAnswer: 'a|b|c',
+      incorrectAnswers: ['d'],
+      points: 3,
+    });
+    const r = vaResponse({
+      answers: [
+        { questionId: 'q-ma', answer: 'a|b|c', answeredAt: 1700000000500 },
+      ],
+    });
+    const { dataRows } = buildVideoActivityResultsSheetData([r], [ma]);
+    // Points Earned at index 7 — 3 points awarded, NOT 0
+    expect(dataRows[0][7]).toBe('3');
+    // Score column at index 6
+    expect(dataRows[0][6]).toBe('100%');
+  });
+
+  it('grades FIB with acceptableVariants', () => {
+    const fib = vaQuestion({
+      type: 'FIB',
+      correctAnswer: 'colour',
+      acceptableVariants: ['color'],
+    });
+    const r = vaResponse({
+      answers: [{ questionId: 'q1', answer: 'color', answeredAt: 1 }],
+    });
+    const { dataRows } = buildVideoActivityResultsSheetData([r], [fib]);
+    expect(dataRows[0][7]).toBe('1');
+  });
+
+  it('maps completedAt → status column "completed"', () => {
+    const r = vaResponse({ completedAt: 1700000001000 });
+    const { dataRows } = buildVideoActivityResultsSheetData(
+      [r],
+      [vaQuestion()]
+    );
+    // Status column at index 5
+    expect(dataRows[0][5]).toBe('completed');
+  });
+
+  it('maps null completedAt → status "in-progress" with empty score', () => {
+    const r = vaResponse({ completedAt: null });
+    const { dataRows } = buildVideoActivityResultsSheetData(
+      [r],
+      [vaQuestion()]
+    );
+    expect(dataRows[0][5]).toBe('in-progress');
+    expect(dataRows[0][6]).toBe(''); // score blank for in-progress
+  });
+
+  it('treats completedAt: 0 as completed (explicit null check)', () => {
+    // The type allows `number | null`; a truthiness check would misclassify
+    // `0` (Jan 1 1970 timestamp) as in-progress.
+    const r = vaResponse({ completedAt: 0 });
+    const { dataRows } = buildVideoActivityResultsSheetData(
+      [r],
+      [vaQuestion()]
+    );
+    expect(dataRows[0][5]).toBe('completed');
+  });
+
+  it('preserves the canonical 12-column shape', () => {
+    const { headers } = buildVideoActivityResultsSheetData(
+      [vaResponse()],
+      [vaQuestion({ id: 'q1', text: 'Q1', points: 1 })]
+    );
+    expect(headers).toHaveLength(12); // 11 fixed + 1 question column
+    expect(headers[0]).toBe('Timestamp');
+    expect(headers[10]).toBe('Submitted At');
+  });
+});

--- a/tests/utils/youtubeSearch.test.ts
+++ b/tests/utils/youtubeSearch.test.ts
@@ -1,0 +1,248 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  searchYouTube,
+  parseIsoDuration,
+  formatDuration,
+  YouTubeKeyMissingError,
+  YouTubeQuotaError,
+  YouTubeSearchError,
+} from '@/utils/youtubeSearch';
+
+describe('parseIsoDuration', () => {
+  it('parses minute+second', () => {
+    expect(parseIsoDuration('PT4M13S')).toBe(253);
+  });
+
+  it('parses hours+minutes', () => {
+    expect(parseIsoDuration('PT1H2M')).toBe(3720);
+  });
+
+  it('parses seconds only', () => {
+    expect(parseIsoDuration('PT45S')).toBe(45);
+  });
+
+  it('returns 0 for unparseable input', () => {
+    expect(parseIsoDuration('garbage')).toBe(0);
+    expect(parseIsoDuration('')).toBe(0);
+  });
+});
+
+describe('formatDuration', () => {
+  it('formats sub-hour as M:SS', () => {
+    expect(formatDuration(125)).toBe('2:05');
+    expect(formatDuration(45)).toBe('0:45');
+  });
+
+  it('formats >= 1h as H:MM:SS', () => {
+    expect(formatDuration(3725)).toBe('1:02:05');
+  });
+
+  it('handles zero', () => {
+    expect(formatDuration(0)).toBe('0:00');
+  });
+});
+
+describe('searchYouTube', () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    vi.stubEnv('VITE_YOUTUBE_API_KEY', 'test-key');
+    vi.stubGlobal('fetch', fetchMock);
+    fetchMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+  });
+
+  it('returns empty array for empty/whitespace query', async () => {
+    expect(await searchYouTube('')).toEqual([]);
+    expect(await searchYouTube('   ')).toEqual([]);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('throws YouTubeKeyMissingError when env var is empty', async () => {
+    vi.stubEnv('VITE_YOUTUBE_API_KEY', '');
+    await expect(searchYouTube('photosynthesis')).rejects.toBeInstanceOf(
+      YouTubeKeyMissingError
+    );
+  });
+
+  it('returns parsed results with durations from videos.list', async () => {
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () =>
+          Promise.resolve({
+            items: [
+              {
+                id: { videoId: 'abc12345678' },
+                snippet: {
+                  title: 'Photosynthesis',
+                  channelTitle: 'Crash Course',
+                  thumbnails: {
+                    medium: {
+                      url: 'https://i.ytimg.com/vi/abc12345678/mqdefault.jpg',
+                    },
+                  },
+                },
+              },
+            ],
+          }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () =>
+          Promise.resolve({
+            items: [
+              {
+                id: 'abc12345678',
+                contentDetails: { duration: 'PT11M30S' },
+              },
+            ],
+          }),
+      });
+
+    const results = await searchYouTube('photosynthesis');
+    expect(results).toEqual([
+      {
+        videoId: 'abc12345678',
+        title: 'Photosynthesis',
+        channelTitle: 'Crash Course',
+        thumbnailUrl: 'https://i.ytimg.com/vi/abc12345678/mqdefault.jpg',
+        durationSeconds: 690,
+      },
+    ]);
+  });
+
+  it('falls back to default thumbnail when medium is absent', async () => {
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () =>
+          Promise.resolve({
+            items: [
+              {
+                id: { videoId: 'abc12345678' },
+                snippet: {
+                  title: 't',
+                  channelTitle: 'c',
+                  thumbnails: { default: { url: 'https://example.com/t.jpg' } },
+                },
+              },
+            ],
+          }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ items: [] }),
+      });
+
+    const results = await searchYouTube('q');
+    expect(results[0].thumbnailUrl).toBe('https://example.com/t.jpg');
+    expect(results[0].durationSeconds).toBe(0);
+  });
+
+  it('throws YouTubeQuotaError on 403 quotaExceeded', async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: false,
+      status: 403,
+      json: () =>
+        Promise.resolve({
+          error: {
+            code: 403,
+            errors: [{ reason: 'quotaExceeded' }],
+            message: 'quotaExceeded',
+          },
+        }),
+    });
+    await expect(searchYouTube('photosynthesis')).rejects.toBeInstanceOf(
+      YouTubeQuotaError
+    );
+  });
+
+  it('throws YouTubeSearchError on other failures', async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: false,
+      status: 400,
+      json: () => Promise.resolve({ error: { message: 'Bad request' } }),
+    });
+    await expect(searchYouTube('q')).rejects.toBeInstanceOf(YouTubeSearchError);
+  });
+
+  it('skips items without a videoId', async () => {
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () =>
+          Promise.resolve({
+            items: [
+              {
+                id: {},
+                snippet: { title: 'no id', channelTitle: 'x' },
+              },
+              {
+                id: { videoId: 'abc12345678' },
+                snippet: { title: 'good', channelTitle: 'x' },
+              },
+            ],
+          }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ items: [] }),
+      });
+    const results = await searchYouTube('q');
+    expect(results).toHaveLength(1);
+    expect(results[0].videoId).toBe('abc12345678');
+  });
+
+  it('clamps maxResults to 1..25', async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ items: [] }),
+    });
+    await searchYouTube('q', 1000);
+    const firstCall = fetchMock.mock.calls[0][0] as string;
+    expect(firstCall).toContain('maxResults=25');
+    fetchMock.mockClear();
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ items: [] }),
+    });
+    await searchYouTube('q', -5);
+    const nextCall = fetchMock.mock.calls[0][0] as string;
+    expect(nextCall).toContain('maxResults=1');
+  });
+
+  it('does not block search on duration-fetch failure', async () => {
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () =>
+          Promise.resolve({
+            items: [
+              {
+                id: { videoId: 'abc12345678' },
+                snippet: { title: 't', channelTitle: 'c' },
+              },
+            ],
+          }),
+      })
+      .mockRejectedValueOnce(new Error('network'));
+
+    const results = await searchYouTube('q');
+    expect(results).toHaveLength(1);
+    expect(results[0].durationSeconds).toBe(0);
+  });
+});

--- a/types.ts
+++ b/types.ts
@@ -273,8 +273,12 @@ export function getPlcFeatures(plc: Plc): PlcFeatureSettings {
  */
 export interface PlcAssignmentIndexEntry {
   id: string;
-  /** Discriminator for future video-activity support. */
-  kind: 'quiz';
+  /**
+   * Discriminator for the source assignment widget. PR3a widens this to
+   * accept `'video-activity'` (rules updated alongside); PR3b will start
+   * writing VA index entries via `useVideoActivityAssignments`.
+   */
+  kind: 'quiz' | 'video-activity';
   /** UID of the teacher who created the assignment. Always a PLC member. */
   ownerUid: string;
   /** Display name snapshot — avoids a `/users` lookup per row. */
@@ -2681,6 +2685,75 @@ export interface SharedQuizAssignment {
   syncGroupId?: string;
 }
 
+/**
+ * Synchronized canonical Video Activity shared by multiple PLC peers, stored
+ * at `/synced_video_activities/{groupId}`. Counterpart to `SyncedQuizGroup`.
+ *
+ * Each peer's local `video_activity_metadata` carries `sync.groupId`
+ * referencing this doc; the Drive-resident JSON acts as an editing canvas +
+ * cached replica. Edits run inside a Firestore transaction that increments
+ * `version`, writes the new `questions`/`title`/`youtubeUrl`, and stamps
+ * `updatedBy`. Other peers' `onSnapshot` listeners surface a "Sync available"
+ * pill on the library card.
+ *
+ * Last-write-wins on content; the monotonic `version` increment serializes
+ * concurrent saves. Participants are added/removed via the
+ * `joinSyncedVideoActivityGroup` / `leaveSyncedVideoActivityGroup` Cloud
+ * Functions so Firestore rules can keep client writes scoped to existing
+ * participants.
+ */
+export interface SyncedVideoActivityGroup {
+  /** Group id (Firestore doc id). */
+  id: string;
+  /**
+   * Monotonically increasing version. Bumped inside a Firestore transaction
+   * on every content write. Initial value is `1` at create time.
+   */
+  version: number;
+  title: string;
+  youtubeUrl: string;
+  questions: VideoActivityQuestion[];
+  /**
+   * Roster of participating teachers. Keyed by Firebase Auth uid → metadata.
+   * Modified only by the Cloud Function paths so the rules-side write check
+   * can be a simple `auth.uid in resource.data.participants` predicate.
+   */
+  participants: Record<string, { joinedAt: number }>;
+  /** Optional PLC linkage for downstream notification routing. */
+  plcId?: string;
+  createdAt: number;
+  updatedAt: number;
+  /** Auth uid of whoever last published an edit. */
+  updatedBy: string;
+}
+
+/**
+ * Shared-assignment document stored at
+ * `/shared_video_activity_assignments/{shareId}`. Counterpart to
+ * `SharedQuizAssignment` — kept in a parallel collection rather than mixed
+ * into `/shared_assignments` so the existing quiz-only `originalAuthor`-
+ * gated rules don't need a `kind` discriminator.
+ */
+export interface SharedVideoActivityAssignment {
+  /** Shared-doc id (Firestore auto-id). */
+  id: string;
+  /** Inlined activity data so the importer can copy it into their own library. */
+  title: string;
+  youtubeUrl: string;
+  questions: VideoActivityQuestion[];
+  createdAt: number;
+  updatedAt: number;
+  assignmentSettings: VideoActivityAssignmentSettings;
+  /** Original author's UID. */
+  originalAuthor: string;
+  sharedAt: number;
+  /**
+   * If present, this share offers a "Sync" import option that joins the
+   * importer to the named synced group. Absent on copy-only shares.
+   */
+  syncGroupId?: string;
+}
+
 // --- VIDEO ACTIVITY TYPES ---
 
 /**
@@ -2737,6 +2810,23 @@ export interface VideoActivityData {
   updatedAt: number;
 }
 
+/**
+ * See `VideoActivityMetadata.sync`. Mirrors `QuizMetadataSyncLinkage`:
+ * present iff the activity participates in a `/synced_video_activities/{groupId}`
+ * group. Both fields are required or neither is present so the type forbids
+ * partial states.
+ */
+export interface VideoActivityMetadataSyncLinkage {
+  /** Doc id under `/synced_video_activities/{groupId}`. */
+  groupId: string;
+  /**
+   * The `version` of the canonical group doc this local Drive replica was
+   * last reconciled with. Used as a stale-detector against the canonical's
+   * live `version`.
+   */
+  lastSyncedVersion: number;
+}
+
 /** Lightweight metadata stored in Firestore (avoids Drive API on every list). */
 export interface VideoActivityMetadata {
   id: string;
@@ -2753,6 +2843,11 @@ export interface VideoActivityMetadata {
    * Refers to a folder id in `/users/{userId}/video_activity_folders/{folderId}`.
    */
   folderId?: string | null;
+  /**
+   * Optional sync-group linkage for PR3 PLC sharing. Present iff this
+   * activity participates in a synced group. Mirrors `QuizMetadata.sync`.
+   */
+  sync?: VideoActivityMetadataSyncLinkage;
 }
 
 export type VideoActivityView = 'manager' | 'create' | 'results' | 'monitor';
@@ -2809,9 +2904,9 @@ export interface VideoActivitySessionSettings {
  */
 export type VideoActivityScoreVisibility =
   | 'none'
-  | 'score_only'
-  | 'score_and_responses'
-  | 'score_responses_and_answers';
+  | 'score-only'
+  | 'score-and-responses'
+  | 'score-responses-and-answers';
 
 /**
  * Assignment-policy options for a Video Activity session. Distinct from
@@ -2917,6 +3012,26 @@ export interface VideoActivitySession {
    * sessions; consumers must default to `'submissions'`.
    */
   mode?: AssignmentMode;
+  /**
+   * Map of question id → revealed correct answer string. Populated by the
+   * teacher's Publish Scores flow (PR3) when the chosen `scoreVisibility`
+   * level reveals correct answers to students. Absent until publish runs.
+   * Mirrors `QuizSession.revealedAnswers`.
+   */
+  revealedAnswers?: Record<string, string>;
+  /**
+   * Optional sync-group linkage. Mirrors `QuizSession.sync`. Set when the
+   * assignment was created from (or imported as) a synced share so peer
+   * edits to the canonical group flow through to this session on next
+   * teacher sync-pull.
+   */
+  sync?: VideoActivitySessionSyncLinkage;
+}
+
+/** Per-session sync linkage to `/synced_video_activities/{groupId}`. */
+export interface VideoActivitySessionSyncLinkage {
+  groupId: string;
+  syncedVersion: number;
 }
 
 /** A single answer submitted by a student for a video activity question. */
@@ -4876,6 +4991,12 @@ export interface RemoteGlobalConfig {
 
 export type VideoActivityAssignmentStatus = 'active' | 'paused' | 'inactive';
 
+/** See `VideoActivityAssignment.sync`. Mirrors `QuizAssignmentSyncLinkage`. */
+export interface VideoActivityAssignmentSyncLinkage {
+  groupId: string;
+  syncedVersion: number;
+}
+
 /** Persisted settings for a Video Activity assignment (session behavior flags). */
 export interface VideoActivityAssignmentSettings {
   /** Free-text label shown in the archive (e.g. "Period 2"). */
@@ -4901,6 +5022,31 @@ export interface VideoActivityAssignmentSettings {
    * roster picker so the student-app post-PIN picker has stable labels.
    */
   periodNames?: string[];
+  /**
+   * Single period name for legacy compatibility. Set to `periodNames[0]` at
+   * write time so pre-multiclass clients can still read a single label.
+   * Mirrors `QuizAssignment.periodName`.
+   */
+  periodName?: string;
+  /**
+   * Display name of the teacher who owns this assignment. Surfaces in the
+   * exported PLC sheet's "Teacher" column. Mirrors `QuizAssignment.teacherName`.
+   */
+  teacherName?: string;
+  /**
+   * PLC linkage. Set when the teacher opts into PLC mode at assign time. The
+   * `sheetUrl` on this sub-object is the canonical export target — when
+   * absent, PR3 auto-creates the sheet on first export. Mirrors
+   * `QuizAssignment.plc`.
+   */
+  plc?: PlcLinkage;
+  /**
+   * Sync-group linkage. Present iff this assignment was created from (or
+   * imported as) a synced share. Drives the per-assignment "Sync" button
+   * which detects divergence against `/synced_video_activities/{groupId}`
+   * and offers to pull the canonical's latest content.
+   */
+  sync?: VideoActivityAssignmentSyncLinkage;
 }
 
 /**

--- a/types.ts
+++ b/types.ts
@@ -289,6 +289,42 @@ export interface PlcAssignmentIndexEntry {
 }
 
 /**
+ * One quiz shared with a PLC, stored at `plcs/{plcId}/quizzes/{plcQuizId}`.
+ *
+ * The doc is a lightweight header that points at the canonical
+ * `synced_quizzes/{syncGroupId}` doc — questions live there, not here, so
+ * list rendering avoids an N+1 read against the sync collection. `title`
+ * and `questionCount` are best-effort mirrors of the canonical doc; they
+ * get bumped fire-and-forget after a successful publish, but the source
+ * of truth for content is always the synced group.
+ *
+ * Any PLC member can share, edit (via the synced group), or unshare a
+ * quiz — same posture as Phase 5 notes/todos. The `sharedBy` snapshot is
+ * for attribution only; deleting your personal copy does NOT cascade-
+ * delete the PLC entry (orphan-tolerant per Phase 2 spec).
+ */
+export interface PlcQuizEntry {
+  /** Doc id; matches the document key under `plcs/{plcId}/quizzes/`. */
+  id: string;
+  /** Mirrored from the synced group; used for list rendering. */
+  title: string;
+  /** Mirrored from the synced group's questions array length. */
+  questionCount: number;
+  /** Pointer to the canonical `/synced_quizzes/{groupId}` doc. */
+  syncGroupId: string;
+  /** UID of the original sharer. Immutable. */
+  sharedBy: string;
+  /** Lowercased email snapshot for display. Immutable. */
+  sharedByEmail: string;
+  /** Display name snapshot for attribution. Immutable. */
+  sharedByName: string;
+  /** ms timestamp at first share. Immutable. */
+  sharedAt: number;
+  /** ms timestamp; bumped on title/questionCount mirror updates. */
+  updatedAt: number;
+}
+
+/**
  * One shared note in a PLC notebook. Members CRUD freely; LWW on edits.
  */
 export interface PlcNote {

--- a/utils/ai.ts
+++ b/utils/ai.ts
@@ -39,6 +39,10 @@ interface AIResponseData {
   options?: string[];
   widgets?: GeneratedWidget[];
   text?: string;
+  /** `video-activity-recommend`: 11-character YouTube video id Gemini recommends. */
+  videoId?: string;
+  /** `video-activity-recommend`: one-sentence reason this video fits the topic. */
+  rationale?: string;
 }
 
 export type AIGenerationType =
@@ -49,6 +53,7 @@ export type AIGenerationType =
   | 'ocr'
   | 'quiz'
   | 'video-activity'
+  | 'video-activity-recommend'
   | 'guided-learning'
   | 'blooms-ai';
 
@@ -295,6 +300,54 @@ export async function generateVideoActivity(
       'Failed to generate video activity. Please try again with a different video.'
     );
   }
+}
+
+/**
+ * Result from `recommendVideoForActivity`. The Cloud Function asks Gemini
+ * to suggest a single YouTube video matching the teacher's topic/objective
+ * and respond with the videoId plus a one-sentence rationale. Returns
+ * `null` when Gemini declines (e.g. topic too vague or unsafe).
+ */
+export interface VideoActivityRecommendation {
+  videoId: string;
+  /** Title Gemini believes the video has — display while we don't load the video API. */
+  title: string;
+  /** One-sentence reason this video fits the topic. Shown to the teacher. */
+  rationale: string;
+}
+
+/**
+ * Ask Gemini to recommend a YouTube video for a Video Activity given a
+ * topic, objective, or grade-level description. Routes through the same
+ * `generateWithAI` Cloud Function as the rest of our AI integrations —
+ * no client-side Gemini SDK or VITE-prefixed Gemini key.
+ */
+export async function recommendVideoForActivity(
+  topic: string
+): Promise<VideoActivityRecommendation | null> {
+  const trimmed = topic.trim();
+  if (trimmed.length === 0) {
+    throw new Error('A topic or objective is required.');
+  }
+  const data = await callAI(
+    { type: 'video-activity-recommend', prompt: trimmed },
+    'Failed to recommend a video. Please try again with a different topic.'
+  );
+  // The Cloud Function parses Gemini's JSON server-side and spreads its
+  // fields into AIResponseData, so videoId/title/rationale arrive as
+  // top-level fields. Defensive: bad shapes (Gemini refused, hallucinated
+  // an invalid id) return null and the caller shows a generic error.
+  if (
+    typeof data.videoId !== 'string' ||
+    !/^[A-Za-z0-9_-]{11}$/.test(data.videoId)
+  ) {
+    return null;
+  }
+  return {
+    videoId: data.videoId,
+    title: typeof data.title === 'string' ? data.title : '',
+    rationale: typeof data.rationale === 'string' ? data.rationale : '',
+  };
 }
 
 /**

--- a/utils/assignmentExportShared.ts
+++ b/utils/assignmentExportShared.ts
@@ -1,0 +1,154 @@
+/**
+ * Shared results-sheet export primitives.
+ *
+ * Originally lived as `private buildResultsSheetData` on `QuizDriveService`.
+ * PR3b lifts it here so Video Activity (and any future Quiz-style widget)
+ * can produce the same column shape without duplicating the loop. The
+ * grader is injected as a callback so each widget passes its own —
+ * Quiz uses `gradeAnswer`, VA uses `gradeVideoActivityAnswer` (which
+ * handles MA/FIB-variants that the Quiz grader has no case for).
+ *
+ * The shape is intentionally minimal: just the fields the column layout
+ * reads. Quiz passes its `QuizResponse` / `QuizQuestion` directly (they
+ * fit). VA wraps its `VideoActivityResponse` to map `completedAt` →
+ * `submittedAt` + derive a `status` string.
+ */
+
+import type { GradeResult } from '@/types';
+import { resolvePinName } from '@/components/widgets/QuizWidget/utils/quizScoreboard';
+
+/**
+ * Format a points value for export. Whole numbers stay as integers;
+ * fractional partial-credit values render with up to 2 decimals.
+ */
+export function formatExportPoints(points: number): string {
+  if (Number.isInteger(points)) return String(points);
+  return (Math.round(points * 100) / 100).toString();
+}
+
+/** Minimum response shape the export reads. */
+export interface ExportableResponse {
+  pin?: string;
+  studentUid: string;
+  classPeriod?: string;
+  answers: { questionId: string; answer: string }[];
+  /** 'completed' | 'in-progress' | other widget-specific status string. */
+  status: string;
+  /**
+   * When the response was finalized. VA's `completedAt` and Quiz's
+   * `submittedAt` both fit; the export displays it verbatim.
+   */
+  submittedAt: number | null;
+  tabSwitchWarnings?: number;
+}
+
+/** Minimum question shape the export reads. */
+export interface ExportableQuestion {
+  id: string;
+  text: string;
+  points?: number;
+}
+
+export interface BuildResultsSheetDataOptions {
+  /** PIN → roster student name lookup. Per-period when keyed. */
+  pinToName?: Record<string, string>;
+  /** SSO uid → resolved ClassLink name. Wins over `pinToName` when present. */
+  byStudentUid?: Map<string, { givenName: string; familyName: string }>;
+  /** Teacher display name for the "Teacher" column. */
+  teacherName?: string;
+}
+
+/**
+ * Build headers + data rows for a results sheet export. Side-effect free.
+ * The grader callback is widget-specific so MA/FIB-variant grading works
+ * for VA, and Matching/Ordering partial credit works for Quiz.
+ */
+export function buildResultsSheetData<
+  Q extends ExportableQuestion,
+  R extends ExportableResponse,
+>(
+  responses: R[],
+  questions: Q[],
+  gradeFn: (question: Q, studentAnswer: string) => GradeResult,
+  options?: BuildResultsSheetDataOptions
+): { headers: string[]; dataRows: string[][] } {
+  const pinToName = options?.pinToName ?? {};
+  const byStudentUid = options?.byStudentUid;
+  const teacherName =
+    (options?.teacherName?.trim() ? options.teacherName.trim() : null) ??
+    'Unknown Teacher';
+  const timestamp = new Date().toISOString();
+
+  const resolveStudent = (r: R): string => {
+    const sso = byStudentUid?.get(r.studentUid);
+    if (sso) {
+      const full = `${sso.givenName ?? ''} ${sso.familyName ?? ''}`.trim();
+      if (full) return full;
+    }
+    if (r.pin) {
+      const name = resolvePinName(pinToName, r.classPeriod, r.pin);
+      return name ?? `Student (PIN: ${r.pin})`;
+    }
+    return 'Student';
+  };
+
+  const maxPoints = questions.reduce((sum, q) => sum + (q.points ?? 1), 0);
+  const headers = [
+    'Timestamp',
+    'Teacher',
+    'Class Period',
+    'Student',
+    'PIN',
+    'Status',
+    'Score (%)',
+    'Points Earned',
+    'Max Points',
+    'Warnings',
+    'Submitted At',
+    ...questions.map(
+      (q, i) => `Q${i + 1} (${q.points ?? 1}pt): ${q.text.substring(0, 40)}`
+    ),
+  ];
+
+  const dataRows = responses.map((r) => {
+    const submitted = r.submittedAt
+      ? new Date(r.submittedAt).toLocaleString()
+      : '';
+    const warnings = r.tabSwitchWarnings?.toString() ?? '0';
+    const answerMap = new Map(r.answers.map((a) => [a.questionId, a]));
+    const answerCols = questions.map((q) => {
+      const ans = answerMap.get(q.id);
+      if (!ans) return '';
+      const grade = gradeFn(q, ans.answer);
+      return formatExportPoints(grade.pointsEarned);
+    });
+    const earnedPoints = questions.reduce((sum, q) => {
+      const ans = answerMap.get(q.id);
+      if (!ans) return sum;
+      return sum + gradeFn(q, ans.answer).pointsEarned;
+    }, 0);
+    const scoreDisplay =
+      r.status === 'completed' && maxPoints > 0
+        ? `${Math.round((earnedPoints / maxPoints) * 100)}%`
+        : '';
+    return [
+      timestamp,
+      teacherName,
+      r.classPeriod ?? '',
+      resolveStudent(r),
+      r.pin ?? '',
+      r.status,
+      scoreDisplay,
+      formatExportPoints(earnedPoints),
+      String(maxPoints),
+      warnings,
+      submitted,
+      ...answerCols,
+    ];
+  });
+
+  // Stable sort by student name so the export reads naturally even when
+  // responses arrive in arbitrary join order.
+  dataRows.sort((a, b) => a[3].localeCompare(b[3]));
+  return { headers, dataRows };
+}

--- a/utils/quizDriveService.ts
+++ b/utils/quizDriveService.ts
@@ -18,7 +18,7 @@ import {
 import { gradeAnswer } from '../hooks/useQuizSession';
 import { APP_NAME } from '../config/constants';
 import { authError } from './driveAuthErrors';
-import { resolvePinName } from '../components/widgets/QuizWidget/utils/quizScoreboard';
+import { buildResultsSheetData as buildResultsSheetDataShared } from '@/utils/assignmentExportShared';
 
 const DRIVE_API_URL = 'https://www.googleapis.com/drive/v3';
 const UPLOAD_API_URL = 'https://www.googleapis.com/upload/drive/v3';
@@ -37,16 +37,6 @@ const QUIZ_FOLDER_NAME = 'Quizzes';
 /** Escape single quotes in Drive API q-string values (single-quote is the delimiter). */
 function driveQueryEscape(s: string): string {
   return s.replace(/\\/g, '\\\\').replace(/'/g, "\\'");
-}
-
-/**
- * Format a points value for export to a Google Sheet cell. Whole numbers
- * stay as integers; fractional partial-credit values render with up to
- * 2 decimals (trailing zeros stripped).
- */
-function formatExportPoints(points: number): string {
-  if (Number.isInteger(points)) return String(points);
-  return (Math.round(points * 100) / 100).toString();
 }
 
 /**
@@ -511,9 +501,10 @@ export class QuizDriveService {
 
   /**
    * Build the headers + data rows for the results sheet WITHOUT touching
-   * the network. Shared between `exportResultsToSheet` (initial export +
-   * append) and `regeneratePlcSheet` (clear-then-rewrite) so the column
-   * shape stays in lock-step across all three flows. Side-effect-free.
+   * the network. Delegates to the shared `buildResultsSheetData` helper.
+   * Used internally by `regeneratePlcSheet`; `exportResultsToSheet` calls
+   * the shared helper directly so it can thread the grader through.
+   * Side-effect-free.
    */
   private buildResultsSheetData(
     responses: QuizResponse[],
@@ -524,83 +515,12 @@ export class QuizDriveService {
       teacherName?: string;
     }
   ): { headers: string[]; dataRows: string[][] } {
-    const pinToName = options?.pinToName ?? {};
-    const byStudentUid = options?.byStudentUid;
-    const teacherName =
-      (options?.teacherName?.trim() ? options.teacherName.trim() : null) ??
-      'Unknown Teacher';
-    const timestamp = new Date().toISOString();
-
-    const resolveStudent = (r: QuizResponse): string => {
-      const sso = byStudentUid?.get(r.studentUid);
-      if (sso) {
-        const full = `${sso.givenName ?? ''} ${sso.familyName ?? ''}`.trim();
-        if (full) return full;
-      }
-      if (r.pin) {
-        const name = resolvePinName(pinToName, r.classPeriod, r.pin);
-        return name ?? `Student (PIN: ${r.pin})`;
-      }
-      return 'Student';
-    };
-
-    const maxPoints = questions.reduce((sum, q) => sum + (q.points ?? 1), 0);
-    const headers = [
-      'Timestamp',
-      'Teacher',
-      'Class Period',
-      'Student',
-      'PIN',
-      'Status',
-      'Score (%)',
-      'Points Earned',
-      'Max Points',
-      'Warnings',
-      'Submitted At',
-      ...questions.map(
-        (q, i) => `Q${i + 1} (${q.points ?? 1}pt): ${q.text.substring(0, 40)}`
-      ),
-    ];
-
-    const dataRows = responses.map((r) => {
-      const submitted = r.submittedAt
-        ? new Date(r.submittedAt).toLocaleString()
-        : '';
-      const warnings = r.tabSwitchWarnings?.toString() ?? '0';
-      const answerMap = new Map(r.answers.map((a) => [a.questionId, a]));
-      const answerCols = questions.map((q) => {
-        const ans = answerMap.get(q.id);
-        if (!ans) return '';
-        const grade = gradeAnswer(q, ans.answer);
-        return formatExportPoints(grade.pointsEarned);
-      });
-      const earnedPoints = questions.reduce((sum, q) => {
-        const ans = answerMap.get(q.id);
-        if (!ans) return sum;
-        return sum + gradeAnswer(q, ans.answer).pointsEarned;
-      }, 0);
-      const scoreDisplay =
-        r.status === 'completed' && maxPoints > 0
-          ? `${Math.round((earnedPoints / maxPoints) * 100)}%`
-          : '';
-      return [
-        timestamp,
-        teacherName,
-        r.classPeriod ?? '',
-        resolveStudent(r),
-        r.pin ?? '',
-        r.status,
-        scoreDisplay,
-        formatExportPoints(earnedPoints),
-        String(maxPoints),
-        warnings,
-        submitted,
-        ...answerCols,
-      ];
-    });
-
-    dataRows.sort((a, b) => a[3].localeCompare(b[3]));
-    return { headers, dataRows };
+    return buildResultsSheetDataShared<QuizQuestion, QuizResponse>(
+      responses,
+      questions,
+      gradeAnswer,
+      options
+    );
   }
 
   /**
@@ -701,13 +621,21 @@ export class QuizDriveService {
       teacherName?: string;
       plcMode?: boolean;
       plcSheetUrl?: string;
+      /**
+       * Optional grader override. Defaults to Quiz's `gradeAnswer`. Video
+       * Activity passes `gradeVideoActivityAnswer` so MA / FIB-with-variants
+       * grade correctly in the export — Quiz's grader has no `'MA'` case
+       * and otherwise returns 0 points for those columns. Fixes the TODO
+       * PR2a left at `Results.tsx:170`.
+       */
+      gradeFn?: typeof gradeAnswer;
     }
   ): Promise<string> {
-    const { headers, dataRows } = this.buildResultsSheetData(
-      responses,
-      questions,
-      options
-    );
+    const gradeFn = options?.gradeFn ?? gradeAnswer;
+    const { headers, dataRows } = buildResultsSheetDataShared<
+      QuizQuestion,
+      QuizResponse
+    >(responses, questions, gradeFn, options);
 
     // PLC mode: append to existing shared sheet
     if (options?.plcMode) {
@@ -752,7 +680,7 @@ export class QuizDriveService {
         if (!q) continue;
 
         answeredSet.add(a.questionId);
-        if (gradeAnswer(q, a.answer).isCorrect) {
+        if (gradeFn(q, a.answer).isCorrect) {
           correctSet.add(a.questionId);
         }
       }

--- a/utils/videoActivityDriveService.ts
+++ b/utils/videoActivityDriveService.ts
@@ -1,0 +1,77 @@
+/**
+ * Video Activity Drive Service.
+ *
+ * Wraps the shared `buildResultsSheetData` helper from
+ * `assignmentExportShared.ts` with VA's grader (`gradeVideoActivityAnswer`)
+ * so MA / FIB-with-variants grade correctly in the export — Quiz's grader
+ * has no `'MA'` case and was returning 0 points for those columns (the
+ * TODO PR2a left at `Results.tsx:170`).
+ *
+ * Also handles the small response-shape adapter: VA tracks completion via
+ * `completedAt: number | null` (no separate `status` field), but the
+ * shared exporter expects `submittedAt` + `status`. We derive both from
+ * `completedAt` at the call site so consumers don't have to.
+ */
+
+import type { VideoActivityQuestion, VideoActivityResponse } from '@/types';
+import { gradeVideoActivityAnswer } from '@/utils/videoActivityGrading';
+import {
+  buildResultsSheetData,
+  formatExportPoints,
+  type BuildResultsSheetDataOptions,
+  type ExportableResponse,
+} from '@/utils/assignmentExportShared';
+
+/**
+ * Re-export so consumers don't have to know which file the helper lives
+ * in. PR3b lifted it into a shared module; the call sites just want
+ * "format export points" without caring where it comes from.
+ */
+export { formatExportPoints };
+
+/**
+ * Adapt a `VideoActivityResponse` to the `ExportableResponse` shape the
+ * shared exporter consumes. The mapping is:
+ *   completedAt: number → status: 'completed', submittedAt: completedAt
+ *   completedAt: null   → status: 'in-progress', submittedAt: null
+ *
+ * Uses an explicit `!== null` check rather than truthiness so a
+ * `completedAt: 0` (theoretical Jan 1 1970 timestamp; the type allows it)
+ * still maps to `'completed'`.
+ *
+ * Pure function; safe to call inside .map().
+ */
+function toExportable(r: VideoActivityResponse): ExportableResponse {
+  const completed = r.completedAt !== null;
+  return {
+    pin: r.pin,
+    studentUid: r.studentUid,
+    classPeriod: r.classPeriod,
+    answers: r.answers.map((a) => ({
+      questionId: a.questionId,
+      answer: a.answer,
+    })),
+    status: completed ? 'completed' : 'in-progress',
+    submittedAt: completed ? r.completedAt : null,
+    tabSwitchWarnings: r.tabSwitchWarnings,
+  };
+}
+
+/**
+ * Build the headers + data rows for a Video Activity results sheet.
+ * Mirrors `QuizDriveService.buildResultsSheetData` semantics — same
+ * column layout, same options shape — but uses VA's grader so MA and
+ * FIB-with-variants score correctly. Side-effect-free.
+ */
+export function buildVideoActivityResultsSheetData(
+  responses: VideoActivityResponse[],
+  questions: VideoActivityQuestion[],
+  options?: BuildResultsSheetDataOptions
+): { headers: string[]; dataRows: string[][] } {
+  return buildResultsSheetData<VideoActivityQuestion, ExportableResponse>(
+    responses.map(toExportable),
+    questions,
+    gradeVideoActivityAnswer,
+    options
+  );
+}

--- a/utils/youtubeSearch.ts
+++ b/utils/youtubeSearch.ts
@@ -1,0 +1,222 @@
+/**
+ * YouTube Data API v3 search wrapper.
+ *
+ * Used by the Video Activity Creator's "discover" step to let teachers
+ * search for videos by keyword and pick one. Search-on-Enter only — no
+ * keystroke debounce — because each `search.list` call costs 100 quota
+ * units and the default daily cap is 10k = 100 queries/day district-wide.
+ * One unit per intentional query keeps a busy day under quota.
+ *
+ * The API key (`VITE_YOUTUBE_API_KEY`) MUST be referrer-restricted in the
+ * Google Cloud Console to the production + preview origins. Without that
+ * restriction, a leaked key is an open quota tap.
+ */
+
+export interface YouTubeSearchResult {
+  videoId: string;
+  title: string;
+  channelTitle: string;
+  /** URL of a medium-resolution (320x180) thumbnail. */
+  thumbnailUrl: string;
+  /** Duration in seconds, parsed from the videos.list contentDetails. */
+  durationSeconds: number;
+}
+
+export class YouTubeKeyMissingError extends Error {
+  constructor() {
+    super(
+      'YouTube search is not configured. The VITE_YOUTUBE_API_KEY environment variable is missing.'
+    );
+    this.name = 'YouTubeKeyMissingError';
+  }
+}
+
+export class YouTubeQuotaError extends Error {
+  constructor() {
+    super(
+      'YouTube search quota exceeded for the day. Try again tomorrow, or paste a video URL directly.'
+    );
+    this.name = 'YouTubeQuotaError';
+  }
+}
+
+export class YouTubeSearchError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'YouTubeSearchError';
+  }
+}
+
+/**
+ * Parse an ISO 8601 duration (e.g. `PT4M13S`, `PT1H2M`) to total seconds.
+ * Returns 0 for unparseable input.
+ */
+export function parseIsoDuration(iso: string): number {
+  const match = iso.match(/^PT(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?$/);
+  if (!match) return 0;
+  const [, h, m, s] = match;
+  return (
+    (h ? parseInt(h, 10) * 3600 : 0) +
+    (m ? parseInt(m, 10) * 60 : 0) +
+    (s ? parseInt(s, 10) : 0)
+  );
+}
+
+/**
+ * Format a duration in seconds as `M:SS` (or `H:MM:SS` for ≥ 1h).
+ * Used by the search-result card to show a runtime badge.
+ */
+export function formatDuration(seconds: number): string {
+  const h = Math.floor(seconds / 3600);
+  const m = Math.floor((seconds % 3600) / 60);
+  const s = Math.floor(seconds % 60);
+  const ss = String(s).padStart(2, '0');
+  if (h > 0) return `${h}:${String(m).padStart(2, '0')}:${ss}`;
+  return `${m}:${ss}`;
+}
+
+interface RawSearchItem {
+  id?: { videoId?: string };
+  snippet?: {
+    title?: string;
+    channelTitle?: string;
+    thumbnails?: {
+      medium?: { url?: string };
+      default?: { url?: string };
+    };
+  };
+}
+
+interface RawVideoItem {
+  id?: string;
+  contentDetails?: { duration?: string };
+}
+
+interface RawSearchResponse {
+  items?: RawSearchItem[];
+  error?: { code?: number; errors?: { reason?: string }[]; message?: string };
+}
+
+interface RawVideosResponse {
+  items?: RawVideoItem[];
+  error?: { code?: number; errors?: { reason?: string }[]; message?: string };
+}
+
+const SEARCH_ENDPOINT = 'https://www.googleapis.com/youtube/v3/search';
+const VIDEOS_ENDPOINT = 'https://www.googleapis.com/youtube/v3/videos';
+
+/**
+ * Search YouTube for videos matching `query`. Returns up to `maxResults`
+ * results (clamped 1–25; default 10). Two API calls total: search.list
+ * for snippets, then videos.list for durations.
+ */
+export async function searchYouTube(
+  query: string,
+  maxResults: number = 10
+): Promise<YouTubeSearchResult[]> {
+  const trimmed = query.trim();
+  if (trimmed.length === 0) return [];
+
+  const apiKey = String(
+    (import.meta.env as Record<string, string | undefined>)
+      .VITE_YOUTUBE_API_KEY ?? ''
+  ).trim();
+  if (apiKey.length === 0) {
+    throw new YouTubeKeyMissingError();
+  }
+
+  const safeMax = Math.max(1, Math.min(25, Math.floor(maxResults)));
+
+  // 1) Snippet search.
+  const searchParams = new URLSearchParams({
+    part: 'snippet',
+    q: trimmed,
+    type: 'video',
+    maxResults: String(safeMax),
+    key: apiKey,
+    // Educational filter: prefer videos that are embeddable so they
+    // actually load in our IFrame player.
+    videoEmbeddable: 'true',
+    safeSearch: 'strict',
+  });
+
+  let searchData: RawSearchResponse;
+  try {
+    const resp = await fetch(`${SEARCH_ENDPOINT}?${searchParams.toString()}`);
+    searchData = (await (resp.json() as Promise<unknown>)) as RawSearchResponse;
+    if (!resp.ok) {
+      const reason = searchData.error?.errors?.[0]?.reason;
+      if (resp.status === 403 && reason === 'quotaExceeded') {
+        throw new YouTubeQuotaError();
+      }
+      throw new YouTubeSearchError(
+        searchData.error?.message ?? `YouTube search failed (${resp.status})`
+      );
+    }
+  } catch (err) {
+    if (
+      err instanceof YouTubeQuotaError ||
+      err instanceof YouTubeSearchError ||
+      err instanceof YouTubeKeyMissingError
+    ) {
+      throw err;
+    }
+    throw new YouTubeSearchError(
+      err instanceof Error ? err.message : 'YouTube search request failed.'
+    );
+  }
+
+  const ids: string[] = (searchData.items ?? [])
+    .map((it) => it.id?.videoId)
+    .filter((id): id is string => typeof id === 'string' && id.length > 0);
+
+  if (ids.length === 0) return [];
+
+  // 2) Batch durations. Single call for all ids — costs 1 quota unit.
+  const videosParams = new URLSearchParams({
+    part: 'contentDetails',
+    id: ids.join(','),
+    key: apiKey,
+  });
+  let videosData: RawVideosResponse;
+  try {
+    const resp = await fetch(`${VIDEOS_ENDPOINT}?${videosParams.toString()}`);
+    videosData = (await (resp.json() as Promise<unknown>)) as RawVideosResponse;
+    if (!resp.ok) {
+      const reason = videosData.error?.errors?.[0]?.reason;
+      if (resp.status === 403 && reason === 'quotaExceeded') {
+        throw new YouTubeQuotaError();
+      }
+      // Don't fail the whole search if duration lookup partially fails —
+      // fall through with empty durations rather than blocking the picker.
+      videosData = { items: [] };
+    }
+  } catch {
+    videosData = { items: [] };
+  }
+
+  const durationById = new Map<string, number>();
+  for (const item of videosData.items ?? []) {
+    if (item.id && item.contentDetails?.duration) {
+      durationById.set(item.id, parseIsoDuration(item.contentDetails.duration));
+    }
+  }
+
+  return (searchData.items ?? [])
+    .map((it): YouTubeSearchResult | null => {
+      const videoId = it.id?.videoId;
+      if (!videoId) return null;
+      const snippet = it.snippet ?? {};
+      return {
+        videoId,
+        title: snippet.title ?? '',
+        channelTitle: snippet.channelTitle ?? '',
+        thumbnailUrl:
+          snippet.thumbnails?.medium?.url ??
+          snippet.thumbnails?.default?.url ??
+          '',
+        durationSeconds: durationById.get(videoId) ?? 0,
+      };
+    })
+    .filter((r): r is YouTubeSearchResult => r !== null);
+}


### PR DESCRIPTION
This pull request implements the Phase 2 PLC Quiz Library feature, enabling teachers to share quizzes with their PLC (Professional Learning Community), view shared quizzes in a new dashboard tab and overview tile, and import quizzes from the PLC library into their own library with options for syncing or copying. The changes introduce new modal components for sharing and importing, update the dashboard and overview UI, and add the full share workflow to the `QuizWidget`.

**Key changes include:**

### PLC Quiz Library UI and Functionality

- Added a new `PlcQuizLibraryTab` to the PLC dashboard, replacing the placeholder and wiring up the tab to show the shared quiz library. (`PlcDashboard.tsx`) [[1]](diffhunk://#diff-00a8d3158e862274b4e134263eb85ae35698c9d389f8f3ee5c4f4c6f6928f8eaR25) [[2]](diffhunk://#diff-00a8d3158e862274b4e134263eb85ae35698c9d389f8f3ee5c4f4c6f6928f8eaL76-L80) [[3]](diffhunk://#diff-00a8d3158e862274b4e134263eb85ae35698c9d389f8f3ee5c4f4c6f6928f8eaR203-R205)
- Introduced `QuizLibraryTile` to the PLC overview, displaying a preview of recently shared quizzes and providing a link to the full library tab. (`QuizLibraryTile.tsx`, `tileRegistry.tsx`) [[1]](diffhunk://#diff-3ccbc212753b5f67a3507266abd984586818d1a1721d8d92f783158c3db8ad23R1-R116) [[2]](diffhunk://#diff-c63677e2ef8a7966a549059bcf9aa9023100d9e5f08c4037c4b0b5aa68e09b6dR11) [[3]](diffhunk://#diff-c63677e2ef8a7966a549059bcf9aa9023100d9e5f08c4037c4b0b5aa68e09b6dL83-R84)

### Sharing and Import Modals

- Added `PlcShareTargetModal`, a picker shown when a teacher chooses to share a quiz with a PLC, allowing selection of the target PLC. (`PlcShareTargetModal.tsx`)
- Added `PlcQuizImportModal`, a picker shown when importing a quiz from the PLC library, letting the user choose between syncing with the group or making a copy. (`PlcQuizImportModal.tsx`)

### Quiz Sharing Workflow

- Implemented the full workflow for sharing a quiz with a PLC in `QuizWidget`, including creating a synced group if needed, linking the quiz, and writing the PLC quiz entry. Handles errors and ensures idempotency. (`Widget.tsx`) [[1]](diffhunk://#diff-048aa6c14a798f8886ece64742b2a60f8239f92c1b1b71231e928468bea17b81L26-R32) [[2]](diffhunk://#diff-048aa6c14a798f8886ece64742b2a60f8239f92c1b1b71231e928468bea17b81R116) [[3]](diffhunk://#diff-048aa6c14a798f8886ece64742b2a60f8239f92c1b1b71231e928468bea17b81R210-R214) [[4]](diffhunk://#diff-048aa6c14a798f8886ece64742b2a60f8239f92c1b1b71231e928468bea17b81R242-R322)

These changes collectively deliver the core user experience for collaborative quiz sharing and management within PLCs.

**References:**  
[[1]](diffhunk://#diff-00a8d3158e862274b4e134263eb85ae35698c9d389f8f3ee5c4f4c6f6928f8eaR25) [[2]](diffhunk://#diff-00a8d3158e862274b4e134263eb85ae35698c9d389f8f3ee5c4f4c6f6928f8eaL76-L80) [[3]](diffhunk://#diff-00a8d3158e862274b4e134263eb85ae35698c9d389f8f3ee5c4f4c6f6928f8eaR203-R205) [[4]](diffhunk://#diff-0957b5db960a1d649e83e7c81193005806d5a8e3457bcbe246beea2c271cc2f2R1-R134) [[5]](diffhunk://#diff-c14773b87de125d9889ce05abc17dfef23663e5df9c16752a99f5b703a78060cR1-R152) [[6]](diffhunk://#diff-c63677e2ef8a7966a549059bcf9aa9023100d9e5f08c4037c4b0b5aa68e09b6dR11) [[7]](diffhunk://#diff-c63677e2ef8a7966a549059bcf9aa9023100d9e5f08c4037c4b0b5aa68e09b6dL83-R84) [[8]](diffhunk://#diff-3ccbc212753b5f67a3507266abd984586818d1a1721d8d92f783158c3db8ad23R1-R116) [[9]](diffhunk://#diff-048aa6c14a798f8886ece64742b2a60f8239f92c1b1b71231e928468bea17b81L26-R32) [[10]](diffhunk://#diff-048aa6c14a798f8886ece64742b2a60f8239f92c1b1b71231e928468bea17b81R116) [[11]](diffhunk://#diff-048aa6c14a798f8886ece64742b2a60f8239f92c1b1b71231e928468bea17b81R210-R214) [[12]](diffhunk://#diff-048aa6c14a798f8886ece64742b2a60f8239f92c1b1b71231e928468bea17b81R242-R322)