### PR TITLE
refactor(exports): lift buildResultsSheetData + thread VA grader (PR3b)

### DIFF
--- a/components/widgets/VideoActivityWidget/components/Results.tsx
+++ b/components/widgets/VideoActivityWidget/components/Results.tsx
@@ -161,20 +161,30 @@ export const Results: React.FC<ResultsProps> = ({
       // Pass `byStudentUid` so SSO `studentRole` rows (no PIN) export with
       // their resolved ClassLink names instead of falling back to the
       // generic "Student" label.
-      // TODO(PR3): The Quiz exporter calls Quiz's `gradeAnswer`, which has
-      // no 'MA' case and returns 0 points for VA Multi-Answer questions in
-      // the export. PR3 lifts `buildResultsSheetData` into a generic util
-      // that accepts a custom grader (`utils/assignmentExportShared.ts`)
-      // and at that point the VA call here will pass `gradeVideoActivityAnswer`.
-      // Until then, MA columns in the exported sheet read as "0 / Npt".
-      // MC + FIB questions grade correctly.
+      //
+      // PR3b: pass `gradeFn: gradeVideoActivityAnswer` so the exporter
+      // grades VA's MA / FIB-with-variants questions correctly. Without
+      // this override the Quiz default grader has no `'MA'` case and
+      // returns 0 points for those columns (the TODO PR2a left here).
+      // Cast away the QuizQuestion / QuizResponse / typeof-gradeAnswer
+      // shapes — the lifted `buildResultsSheetData` is generic enough to
+      // accept VA's variants but the public `exportResultsToSheet`
+      // signature is still typed as Quiz-shaped. PR3 documents the cast
+      // boundary; a future refactor that splits the Quiz-specific
+      // question-stats block out into a generic helper would let this
+      // function become generic too and remove the cast.
+      type ExporterOptions = Parameters<typeof drive.exportResultsToSheet>[3];
       const url = await drive.exportResultsToSheet(
         session.assignmentName,
         quizResponses,
         questions as unknown as Parameters<
           typeof drive.exportResultsToSheet
         >[2],
-        { byStudentUid }
+        {
+          byStudentUid,
+          gradeFn:
+            gradeVideoActivityAnswer as unknown as NonNullable<ExporterOptions>['gradeFn'],
+        }
       );
       setExportUrl(url);
     } catch (err) {

--- a/tests/utils/assignmentExportShared.test.ts
+++ b/tests/utils/assignmentExportShared.test.ts
@@ -165,4 +165,16 @@ describe('buildResultsSheetData', () => {
     expect(dataRows[0][3]).toBe('Aiden');
     expect(dataRows[1][3]).toBe('Zara');
   });
+
+  it('handles empty questions and responses without crashing', () => {
+    const empty = buildResultsSheetData([], [], ALWAYS_FULL);
+    expect(empty.headers).toHaveLength(11); // 11 fixed cols + 0 question cols
+    expect(empty.dataRows).toEqual([]);
+
+    // Responses but no questions: maxPoints = 0 must not divide-by-zero;
+    // Score column blanks out via the maxPoints > 0 guard.
+    const noQs = buildResultsSheetData([r()], [], ALWAYS_FULL);
+    expect(noQs.dataRows[0][6]).toBe(''); // Score (%) blank
+    expect(noQs.dataRows[0][8]).toBe('0'); // Max Points = 0
+  });
 });

--- a/tests/utils/assignmentExportShared.test.ts
+++ b/tests/utils/assignmentExportShared.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildResultsSheetData,
+  formatExportPoints,
+  type ExportableQuestion,
+  type ExportableResponse,
+} from '@/utils/assignmentExportShared';
+import type { GradeResult } from '@/types';
+
+describe('formatExportPoints', () => {
+  it('renders integers without decimals', () => {
+    expect(formatExportPoints(0)).toBe('0');
+    expect(formatExportPoints(5)).toBe('5');
+    expect(formatExportPoints(100)).toBe('100');
+  });
+
+  it('renders fractional values with up to 2 decimals', () => {
+    expect(formatExportPoints(0.5)).toBe('0.5');
+    expect(formatExportPoints(1.25)).toBe('1.25');
+  });
+
+  it('strips trailing zeros from rounded fractionals', () => {
+    expect(formatExportPoints(1.1)).toBe('1.1');
+  });
+});
+
+describe('buildResultsSheetData', () => {
+  const ALWAYS_FULL: (q: { points?: number }) => GradeResult = (q) => ({
+    isCorrect: true,
+    pointsEarned: q.points ?? 1,
+    pointsMax: q.points ?? 1,
+  });
+  const ALWAYS_ZERO: () => GradeResult = () => ({
+    isCorrect: false,
+    pointsEarned: 0,
+    pointsMax: 1,
+  });
+
+  function q(overrides: Partial<ExportableQuestion> = {}): ExportableQuestion {
+    return {
+      id: 'q1',
+      text: 'What?',
+      points: 1,
+      ...overrides,
+    };
+  }
+
+  function r(overrides: Partial<ExportableResponse> = {}): ExportableResponse {
+    return {
+      pin: '01',
+      studentUid: 'student-1',
+      classPeriod: 'Period 1',
+      answers: [{ questionId: 'q1', answer: 'a' }],
+      status: 'completed',
+      submittedAt: 1700000000000,
+      tabSwitchWarnings: 0,
+      ...overrides,
+    };
+  }
+
+  it('emits the canonical column header layout', () => {
+    const { headers } = buildResultsSheetData(
+      [r()],
+      [q({ id: 'q1', text: 'Question 1', points: 2 })],
+      ALWAYS_FULL
+    );
+    expect(headers).toEqual([
+      'Timestamp',
+      'Teacher',
+      'Class Period',
+      'Student',
+      'PIN',
+      'Status',
+      'Score (%)',
+      'Points Earned',
+      'Max Points',
+      'Warnings',
+      'Submitted At',
+      'Q1 (2pt): Question 1',
+    ]);
+  });
+
+  it('routes correctness through the injected grader (full credit)', () => {
+    const { dataRows } = buildResultsSheetData(
+      [r()],
+      [q({ points: 3 })],
+      ALWAYS_FULL
+    );
+    expect(dataRows).toHaveLength(1);
+    // Score column is index 6 (after Timestamp, Teacher, Class, Student, PIN, Status)
+    expect(dataRows[0][6]).toBe('100%');
+    // Points Earned at index 7
+    expect(dataRows[0][7]).toBe('3');
+  });
+
+  it('routes correctness through the injected grader (zero credit)', () => {
+    const { dataRows } = buildResultsSheetData(
+      [r()],
+      [q({ points: 3 })],
+      ALWAYS_ZERO
+    );
+    // Even though the response is "completed", earned is 0 so score is 0%
+    expect(dataRows[0][6]).toBe('0%');
+    expect(dataRows[0][7]).toBe('0');
+  });
+
+  it('hides score column for in-progress responses', () => {
+    const { dataRows } = buildResultsSheetData(
+      [r({ status: 'in-progress', submittedAt: null })],
+      [q()],
+      ALWAYS_FULL
+    );
+    // Score column blank for non-completed
+    expect(dataRows[0][6]).toBe('');
+  });
+
+  it('resolves SSO students by studentUid first, falling back to PIN', () => {
+    const ssoMap = new Map([
+      ['sso-1', { givenName: 'Alex', familyName: 'Lee' }],
+    ]);
+    // Period-scoped pinToName uses the canonical `${period}${pin}` key
+    // shape produced by `buildPinToNameMap`.
+    const PIN_KEY_SEP = String.fromCharCode(0x01);
+    const { dataRows } = buildResultsSheetData(
+      [
+        r({ studentUid: 'sso-1', pin: undefined }),
+        r({ studentUid: 'pin-1', pin: '02' }),
+      ],
+      [q()],
+      ALWAYS_FULL,
+      {
+        byStudentUid: ssoMap,
+        pinToName: { [`Period 1${PIN_KEY_SEP}02`]: 'Maya' },
+      }
+    );
+    // Student column at index 3; rows are sorted by name so verify both
+    const names = dataRows.map((row) => row[3]);
+    expect(names).toContain('Alex Lee');
+    expect(names).toContain('Maya');
+  });
+
+  it('passes question.points to the grader call (max points sums correctly)', () => {
+    const { dataRows } = buildResultsSheetData(
+      [r({ answers: [{ questionId: 'q1', answer: 'x' }] })],
+      [q({ id: 'q1', points: 5 })],
+      ALWAYS_FULL
+    );
+    // Max Points column at index 8
+    expect(dataRows[0][8]).toBe('5');
+  });
+
+  it('sorts rows by student name', () => {
+    const PIN_KEY_SEP = String.fromCharCode(0x01);
+    const { dataRows } = buildResultsSheetData(
+      [r({ studentUid: 'a', pin: '03' }), r({ studentUid: 'b', pin: '01' })],
+      [q()],
+      ALWAYS_FULL,
+      {
+        pinToName: {
+          [`Period 1${PIN_KEY_SEP}01`]: 'Aiden',
+          [`Period 1${PIN_KEY_SEP}03`]: 'Zara',
+        },
+      }
+    );
+    expect(dataRows[0][3]).toBe('Aiden');
+    expect(dataRows[1][3]).toBe('Zara');
+  });
+});

--- a/tests/utils/videoActivityDriveService.test.ts
+++ b/tests/utils/videoActivityDriveService.test.ts
@@ -93,6 +93,17 @@ describe('buildVideoActivityResultsSheetData', () => {
     expect(dataRows[0][6]).toBe(''); // score blank for in-progress
   });
 
+  it('treats completedAt: 0 as completed (explicit null check)', () => {
+    // The type allows `number | null`; a truthiness check would misclassify
+    // `0` (Jan 1 1970 timestamp) as in-progress.
+    const r = vaResponse({ completedAt: 0 });
+    const { dataRows } = buildVideoActivityResultsSheetData(
+      [r],
+      [vaQuestion()]
+    );
+    expect(dataRows[0][5]).toBe('completed');
+  });
+
   it('preserves the canonical 12-column shape', () => {
     const { headers } = buildVideoActivityResultsSheetData(
       [vaResponse()],

--- a/tests/utils/videoActivityDriveService.test.ts
+++ b/tests/utils/videoActivityDriveService.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from 'vitest';
+import { buildVideoActivityResultsSheetData } from '@/utils/videoActivityDriveService';
+import type { VideoActivityQuestion, VideoActivityResponse } from '@/types';
+
+function vaQuestion(
+  overrides: Partial<VideoActivityQuestion> = {}
+): VideoActivityQuestion {
+  return {
+    id: 'q1',
+    text: 'What organelle?',
+    timestamp: 30,
+    timeLimit: 30,
+    type: 'MC',
+    correctAnswer: 'mitochondria',
+    incorrectAnswers: [],
+    points: 1,
+    ...overrides,
+  };
+}
+
+function vaResponse(
+  overrides: Partial<VideoActivityResponse> = {}
+): VideoActivityResponse {
+  return {
+    pin: '01',
+    studentUid: 'student-1',
+    classPeriod: 'Period 1',
+    joinedAt: 1700000000000,
+    answers: [
+      { questionId: 'q1', answer: 'mitochondria', answeredAt: 1700000000500 },
+    ],
+    score: null,
+    completedAt: 1700000001000,
+    tabSwitchWarnings: 0,
+    ...overrides,
+  };
+}
+
+describe('buildVideoActivityResultsSheetData', () => {
+  it('grades MA questions correctly (PR2a TODO fix)', () => {
+    // The Quiz grader has no 'MA' case and would award 0 points.
+    // VA's grader (gradeVideoActivityAnswer) handles set-equality, so a
+    // student who picked exactly the correct selections gets full points.
+    const ma = vaQuestion({
+      id: 'q-ma',
+      type: 'MA',
+      correctAnswer: 'a|b|c',
+      incorrectAnswers: ['d'],
+      points: 3,
+    });
+    const r = vaResponse({
+      answers: [
+        { questionId: 'q-ma', answer: 'a|b|c', answeredAt: 1700000000500 },
+      ],
+    });
+    const { dataRows } = buildVideoActivityResultsSheetData([r], [ma]);
+    // Points Earned at index 7 — 3 points awarded, NOT 0
+    expect(dataRows[0][7]).toBe('3');
+    // Score column at index 6
+    expect(dataRows[0][6]).toBe('100%');
+  });
+
+  it('grades FIB with acceptableVariants', () => {
+    const fib = vaQuestion({
+      type: 'FIB',
+      correctAnswer: 'colour',
+      acceptableVariants: ['color'],
+    });
+    const r = vaResponse({
+      answers: [{ questionId: 'q1', answer: 'color', answeredAt: 1 }],
+    });
+    const { dataRows } = buildVideoActivityResultsSheetData([r], [fib]);
+    expect(dataRows[0][7]).toBe('1');
+  });
+
+  it('maps completedAt → status column "completed"', () => {
+    const r = vaResponse({ completedAt: 1700000001000 });
+    const { dataRows } = buildVideoActivityResultsSheetData(
+      [r],
+      [vaQuestion()]
+    );
+    // Status column at index 5
+    expect(dataRows[0][5]).toBe('completed');
+  });
+
+  it('maps null completedAt → status "in-progress" with empty score', () => {
+    const r = vaResponse({ completedAt: null });
+    const { dataRows } = buildVideoActivityResultsSheetData(
+      [r],
+      [vaQuestion()]
+    );
+    expect(dataRows[0][5]).toBe('in-progress');
+    expect(dataRows[0][6]).toBe(''); // score blank for in-progress
+  });
+
+  it('preserves the canonical 12-column shape', () => {
+    const { headers } = buildVideoActivityResultsSheetData(
+      [vaResponse()],
+      [vaQuestion({ id: 'q1', text: 'Q1', points: 1 })]
+    );
+    expect(headers).toHaveLength(12); // 11 fixed + 1 question column
+    expect(headers[0]).toBe('Timestamp');
+    expect(headers[10]).toBe('Submitted At');
+  });
+});

--- a/utils/assignmentExportShared.ts
+++ b/utils/assignmentExportShared.ts
@@ -1,0 +1,154 @@
+/**
+ * Shared results-sheet export primitives.
+ *
+ * Originally lived as `private buildResultsSheetData` on `QuizDriveService`.
+ * PR3b lifts it here so Video Activity (and any future Quiz-style widget)
+ * can produce the same column shape without duplicating the loop. The
+ * grader is injected as a callback so each widget passes its own —
+ * Quiz uses `gradeAnswer`, VA uses `gradeVideoActivityAnswer` (which
+ * handles MA/FIB-variants that the Quiz grader has no case for).
+ *
+ * The shape is intentionally minimal: just the fields the column layout
+ * reads. Quiz passes its `QuizResponse` / `QuizQuestion` directly (they
+ * fit). VA wraps its `VideoActivityResponse` to map `completedAt` →
+ * `submittedAt` + derive a `status` string.
+ */
+
+import type { GradeResult } from '@/types';
+import { resolvePinName } from '@/components/widgets/QuizWidget/utils/quizScoreboard';
+
+/**
+ * Format a points value for export. Whole numbers stay as integers;
+ * fractional partial-credit values render with up to 2 decimals.
+ */
+export function formatExportPoints(points: number): string {
+  if (Number.isInteger(points)) return String(points);
+  return (Math.round(points * 100) / 100).toString();
+}
+
+/** Minimum response shape the export reads. */
+export interface ExportableResponse {
+  pin?: string;
+  studentUid: string;
+  classPeriod?: string;
+  answers: { questionId: string; answer: string }[];
+  /** 'completed' | 'in-progress' | other widget-specific status string. */
+  status: string;
+  /**
+   * When the response was finalized. VA's `completedAt` and Quiz's
+   * `submittedAt` both fit; the export displays it verbatim.
+   */
+  submittedAt: number | null;
+  tabSwitchWarnings?: number;
+}
+
+/** Minimum question shape the export reads. */
+export interface ExportableQuestion {
+  id: string;
+  text: string;
+  points?: number;
+}
+
+export interface BuildResultsSheetDataOptions {
+  /** PIN → roster student name lookup. Per-period when keyed. */
+  pinToName?: Record<string, string>;
+  /** SSO uid → resolved ClassLink name. Wins over `pinToName` when present. */
+  byStudentUid?: Map<string, { givenName: string; familyName: string }>;
+  /** Teacher display name for the "Teacher" column. */
+  teacherName?: string;
+}
+
+/**
+ * Build headers + data rows for a results sheet export. Side-effect free.
+ * The grader callback is widget-specific so MA/FIB-variant grading works
+ * for VA, and Matching/Ordering partial credit works for Quiz.
+ */
+export function buildResultsSheetData<
+  Q extends ExportableQuestion,
+  R extends ExportableResponse,
+>(
+  responses: R[],
+  questions: Q[],
+  gradeFn: (question: Q, studentAnswer: string) => GradeResult,
+  options?: BuildResultsSheetDataOptions
+): { headers: string[]; dataRows: string[][] } {
+  const pinToName = options?.pinToName ?? {};
+  const byStudentUid = options?.byStudentUid;
+  const teacherName =
+    (options?.teacherName?.trim() ? options.teacherName.trim() : null) ??
+    'Unknown Teacher';
+  const timestamp = new Date().toISOString();
+
+  const resolveStudent = (r: R): string => {
+    const sso = byStudentUid?.get(r.studentUid);
+    if (sso) {
+      const full = `${sso.givenName ?? ''} ${sso.familyName ?? ''}`.trim();
+      if (full) return full;
+    }
+    if (r.pin) {
+      const name = resolvePinName(pinToName, r.classPeriod, r.pin);
+      return name ?? `Student (PIN: ${r.pin})`;
+    }
+    return 'Student';
+  };
+
+  const maxPoints = questions.reduce((sum, q) => sum + (q.points ?? 1), 0);
+  const headers = [
+    'Timestamp',
+    'Teacher',
+    'Class Period',
+    'Student',
+    'PIN',
+    'Status',
+    'Score (%)',
+    'Points Earned',
+    'Max Points',
+    'Warnings',
+    'Submitted At',
+    ...questions.map(
+      (q, i) => `Q${i + 1} (${q.points ?? 1}pt): ${q.text.substring(0, 40)}`
+    ),
+  ];
+
+  const dataRows = responses.map((r) => {
+    const submitted = r.submittedAt
+      ? new Date(r.submittedAt).toLocaleString()
+      : '';
+    const warnings = r.tabSwitchWarnings?.toString() ?? '0';
+    const answerMap = new Map(r.answers.map((a) => [a.questionId, a]));
+    const answerCols = questions.map((q) => {
+      const ans = answerMap.get(q.id);
+      if (!ans) return '';
+      const grade = gradeFn(q, ans.answer);
+      return formatExportPoints(grade.pointsEarned);
+    });
+    const earnedPoints = questions.reduce((sum, q) => {
+      const ans = answerMap.get(q.id);
+      if (!ans) return sum;
+      return sum + gradeFn(q, ans.answer).pointsEarned;
+    }, 0);
+    const scoreDisplay =
+      r.status === 'completed' && maxPoints > 0
+        ? `${Math.round((earnedPoints / maxPoints) * 100)}%`
+        : '';
+    return [
+      timestamp,
+      teacherName,
+      r.classPeriod ?? '',
+      resolveStudent(r),
+      r.pin ?? '',
+      r.status,
+      scoreDisplay,
+      formatExportPoints(earnedPoints),
+      String(maxPoints),
+      warnings,
+      submitted,
+      ...answerCols,
+    ];
+  });
+
+  // Stable sort by student name so the export reads naturally even when
+  // responses arrive in arbitrary join order.
+  dataRows.sort((a, b) => a[3].localeCompare(b[3]));
+  return { headers, dataRows };
+}

--- a/utils/quizDriveService.ts
+++ b/utils/quizDriveService.ts
@@ -18,7 +18,7 @@ import {
 import { gradeAnswer } from '../hooks/useQuizSession';
 import { APP_NAME } from '../config/constants';
 import { authError } from './driveAuthErrors';
-import { buildResultsSheetData as buildResultsSheetDataShared } from './assignmentExportShared';
+import { buildResultsSheetData as buildResultsSheetDataShared } from '@/utils/assignmentExportShared';
 
 const DRIVE_API_URL = 'https://www.googleapis.com/drive/v3';
 const UPLOAD_API_URL = 'https://www.googleapis.com/upload/drive/v3';

--- a/utils/quizDriveService.ts
+++ b/utils/quizDriveService.ts
@@ -18,7 +18,7 @@ import {
 import { gradeAnswer } from '../hooks/useQuizSession';
 import { APP_NAME } from '../config/constants';
 import { authError } from './driveAuthErrors';
-import { resolvePinName } from '../components/widgets/QuizWidget/utils/quizScoreboard';
+import { buildResultsSheetData as buildResultsSheetDataShared } from './assignmentExportShared';
 
 const DRIVE_API_URL = 'https://www.googleapis.com/drive/v3';
 const UPLOAD_API_URL = 'https://www.googleapis.com/upload/drive/v3';
@@ -37,16 +37,6 @@ const QUIZ_FOLDER_NAME = 'Quizzes';
 /** Escape single quotes in Drive API q-string values (single-quote is the delimiter). */
 function driveQueryEscape(s: string): string {
   return s.replace(/\\/g, '\\\\').replace(/'/g, "\\'");
-}
-
-/**
- * Format a points value for export to a Google Sheet cell. Whole numbers
- * stay as integers; fractional partial-credit values render with up to
- * 2 decimals (trailing zeros stripped).
- */
-function formatExportPoints(points: number): string {
-  if (Number.isInteger(points)) return String(points);
-  return (Math.round(points * 100) / 100).toString();
 }
 
 /**
@@ -511,9 +501,10 @@ export class QuizDriveService {
 
   /**
    * Build the headers + data rows for the results sheet WITHOUT touching
-   * the network. Shared between `exportResultsToSheet` (initial export +
-   * append) and `regeneratePlcSheet` (clear-then-rewrite) so the column
-   * shape stays in lock-step across all three flows. Side-effect-free.
+   * the network. Delegates to the shared `buildResultsSheetData` helper.
+   * Used internally by `regeneratePlcSheet`; `exportResultsToSheet` calls
+   * the shared helper directly so it can thread the grader through.
+   * Side-effect-free.
    */
   private buildResultsSheetData(
     responses: QuizResponse[],
@@ -524,83 +515,12 @@ export class QuizDriveService {
       teacherName?: string;
     }
   ): { headers: string[]; dataRows: string[][] } {
-    const pinToName = options?.pinToName ?? {};
-    const byStudentUid = options?.byStudentUid;
-    const teacherName =
-      (options?.teacherName?.trim() ? options.teacherName.trim() : null) ??
-      'Unknown Teacher';
-    const timestamp = new Date().toISOString();
-
-    const resolveStudent = (r: QuizResponse): string => {
-      const sso = byStudentUid?.get(r.studentUid);
-      if (sso) {
-        const full = `${sso.givenName ?? ''} ${sso.familyName ?? ''}`.trim();
-        if (full) return full;
-      }
-      if (r.pin) {
-        const name = resolvePinName(pinToName, r.classPeriod, r.pin);
-        return name ?? `Student (PIN: ${r.pin})`;
-      }
-      return 'Student';
-    };
-
-    const maxPoints = questions.reduce((sum, q) => sum + (q.points ?? 1), 0);
-    const headers = [
-      'Timestamp',
-      'Teacher',
-      'Class Period',
-      'Student',
-      'PIN',
-      'Status',
-      'Score (%)',
-      'Points Earned',
-      'Max Points',
-      'Warnings',
-      'Submitted At',
-      ...questions.map(
-        (q, i) => `Q${i + 1} (${q.points ?? 1}pt): ${q.text.substring(0, 40)}`
-      ),
-    ];
-
-    const dataRows = responses.map((r) => {
-      const submitted = r.submittedAt
-        ? new Date(r.submittedAt).toLocaleString()
-        : '';
-      const warnings = r.tabSwitchWarnings?.toString() ?? '0';
-      const answerMap = new Map(r.answers.map((a) => [a.questionId, a]));
-      const answerCols = questions.map((q) => {
-        const ans = answerMap.get(q.id);
-        if (!ans) return '';
-        const grade = gradeAnswer(q, ans.answer);
-        return formatExportPoints(grade.pointsEarned);
-      });
-      const earnedPoints = questions.reduce((sum, q) => {
-        const ans = answerMap.get(q.id);
-        if (!ans) return sum;
-        return sum + gradeAnswer(q, ans.answer).pointsEarned;
-      }, 0);
-      const scoreDisplay =
-        r.status === 'completed' && maxPoints > 0
-          ? `${Math.round((earnedPoints / maxPoints) * 100)}%`
-          : '';
-      return [
-        timestamp,
-        teacherName,
-        r.classPeriod ?? '',
-        resolveStudent(r),
-        r.pin ?? '',
-        r.status,
-        scoreDisplay,
-        formatExportPoints(earnedPoints),
-        String(maxPoints),
-        warnings,
-        submitted,
-        ...answerCols,
-      ];
-    });
-
-    dataRows.sort((a, b) => a[3].localeCompare(b[3]));
-    return { headers, dataRows };
+    return buildResultsSheetDataShared<QuizQuestion, QuizResponse>(
+      responses,
+      questions,
+      gradeAnswer,
+      options
+    );
   }
 
   /**
@@ -701,13 +621,21 @@ export class QuizDriveService {
       teacherName?: string;
       plcMode?: boolean;
       plcSheetUrl?: string;
+      /**
+       * Optional grader override. Defaults to Quiz's `gradeAnswer`. Video
+       * Activity passes `gradeVideoActivityAnswer` so MA / FIB-with-variants
+       * grade correctly in the export — Quiz's grader has no `'MA'` case
+       * and otherwise returns 0 points for those columns. Fixes the TODO
+       * PR2a left at `Results.tsx:170`.
+       */
+      gradeFn?: typeof gradeAnswer;
     }
   ): Promise<string> {
-    const { headers, dataRows } = this.buildResultsSheetData(
-      responses,
-      questions,
-      options
-    );
+    const gradeFn = options?.gradeFn ?? gradeAnswer;
+    const { headers, dataRows } = buildResultsSheetDataShared<
+      QuizQuestion,
+      QuizResponse
+    >(responses, questions, gradeFn, options);
 
     // PLC mode: append to existing shared sheet
     if (options?.plcMode) {
@@ -752,7 +680,7 @@ export class QuizDriveService {
         if (!q) continue;
 
         answeredSet.add(a.questionId);
-        if (gradeAnswer(q, a.answer).isCorrect) {
+        if (gradeFn(q, a.answer).isCorrect) {
           correctSet.add(a.questionId);
         }
       }

--- a/utils/videoActivityDriveService.ts
+++ b/utils/videoActivityDriveService.ts
@@ -1,0 +1,72 @@
+/**
+ * Video Activity Drive Service.
+ *
+ * Wraps the shared `buildResultsSheetData` helper from
+ * `assignmentExportShared.ts` with VA's grader (`gradeVideoActivityAnswer`)
+ * so MA / FIB-with-variants grade correctly in the export — Quiz's grader
+ * has no `'MA'` case and was returning 0 points for those columns (the
+ * TODO PR2a left at `Results.tsx:170`).
+ *
+ * Also handles the small response-shape adapter: VA tracks completion via
+ * `completedAt: number | null` (no separate `status` field), but the
+ * shared exporter expects `submittedAt` + `status`. We derive both from
+ * `completedAt` at the call site so consumers don't have to.
+ */
+
+import type { VideoActivityQuestion, VideoActivityResponse } from '@/types';
+import { gradeVideoActivityAnswer } from './videoActivityGrading';
+import {
+  buildResultsSheetData,
+  formatExportPoints,
+  type BuildResultsSheetDataOptions,
+  type ExportableResponse,
+} from './assignmentExportShared';
+
+/**
+ * Re-export so consumers don't have to know which file the helper lives
+ * in. PR3b lifted it into a shared module; the call sites just want
+ * "format export points" without caring where it comes from.
+ */
+export { formatExportPoints };
+
+/**
+ * Adapt a `VideoActivityResponse` to the `ExportableResponse` shape the
+ * shared exporter consumes. The mapping is:
+ *   completedAt: number → status: 'completed', submittedAt: completedAt
+ *   completedAt: null   → status: 'in-progress', submittedAt: null
+ *
+ * Pure function; safe to call inside .map().
+ */
+function toExportable(r: VideoActivityResponse): ExportableResponse {
+  return {
+    pin: r.pin,
+    studentUid: r.studentUid,
+    classPeriod: r.classPeriod,
+    answers: r.answers.map((a) => ({
+      questionId: a.questionId,
+      answer: a.answer,
+    })),
+    status: r.completedAt ? 'completed' : 'in-progress',
+    submittedAt: r.completedAt ?? null,
+    tabSwitchWarnings: r.tabSwitchWarnings,
+  };
+}
+
+/**
+ * Build the headers + data rows for a Video Activity results sheet.
+ * Mirrors `QuizDriveService.buildResultsSheetData` semantics — same
+ * column layout, same options shape — but uses VA's grader so MA and
+ * FIB-with-variants score correctly. Side-effect-free.
+ */
+export function buildVideoActivityResultsSheetData(
+  responses: VideoActivityResponse[],
+  questions: VideoActivityQuestion[],
+  options?: BuildResultsSheetDataOptions
+): { headers: string[]; dataRows: string[][] } {
+  return buildResultsSheetData<VideoActivityQuestion, ExportableResponse>(
+    responses.map(toExportable),
+    questions,
+    gradeVideoActivityAnswer,
+    options
+  );
+}

--- a/utils/videoActivityDriveService.ts
+++ b/utils/videoActivityDriveService.ts
@@ -35,9 +35,14 @@ export { formatExportPoints };
  *   completedAt: number → status: 'completed', submittedAt: completedAt
  *   completedAt: null   → status: 'in-progress', submittedAt: null
  *
+ * Uses an explicit `!== null` check rather than truthiness so a
+ * `completedAt: 0` (theoretical Jan 1 1970 timestamp; the type allows it)
+ * still maps to `'completed'`.
+ *
  * Pure function; safe to call inside .map().
  */
 function toExportable(r: VideoActivityResponse): ExportableResponse {
+  const completed = r.completedAt !== null;
   return {
     pin: r.pin,
     studentUid: r.studentUid,
@@ -46,8 +51,8 @@ function toExportable(r: VideoActivityResponse): ExportableResponse {
       questionId: a.questionId,
       answer: a.answer,
     })),
-    status: r.completedAt ? 'completed' : 'in-progress',
-    submittedAt: r.completedAt ?? null,
+    status: completed ? 'completed' : 'in-progress',
+    submittedAt: completed ? r.completedAt : null,
     tabSwitchWarnings: r.tabSwitchWarnings,
   };
 }

--- a/utils/videoActivityDriveService.ts
+++ b/utils/videoActivityDriveService.ts
@@ -14,13 +14,13 @@
  */
 
 import type { VideoActivityQuestion, VideoActivityResponse } from '@/types';
-import { gradeVideoActivityAnswer } from './videoActivityGrading';
+import { gradeVideoActivityAnswer } from '@/utils/videoActivityGrading';
 import {
   buildResultsSheetData,
   formatExportPoints,
   type BuildResultsSheetDataOptions,
   type ExportableResponse,
-} from './assignmentExportShared';
+} from '@/utils/assignmentExportShared';
 
 /**
  * Re-export so consumers don't have to know which file the helper lives


### PR DESCRIPTION
## Summary

PR3b of the Video Activity ↔ Quiz alignment series. Closes the export-side gap left by PR2a:

- Lifts `buildResultsSheetData` out of QuizDriveService into a shared `utils/assignmentExportShared.ts` parameterized on a grader callback.
- VA's new `videoActivityDriveService.ts` wraps the shared helper with `gradeVideoActivityAnswer`, so MA / FIB-with-variants questions grade correctly in the exported sheet (was returning 0 points because Quiz's `gradeAnswer` has no `'MA'` case — that's the TODO PR2a left at `Results.tsx:170`).
- Quiz path unchanged: `exportResultsToSheet` defaults `gradeFn` to `gradeAnswer`, and the private builder method delegates to the shared helper.
- Column shape stays identical between Quiz and VA exports → a PLC sheet can hold both kinds of assignment without schema drift.

The shared helper imports the canonical `resolvePinName` from `quizScoreboard.ts` so period-scoped / zero-padded / legacy-suffix-scan resolution stays in lock-step.

## Why a cast at the boundary in Results.tsx

The public `exportResultsToSheet` signature is still typed Quiz-shaped (it does Drive/Sheets glue + a Quiz-specific question-stats block after the row build). VA passes its own grader through `gradeFn` and casts the parameter at the call site. A follow-up that splits the question-stats block out into a generic helper would let the whole method go generic and drop the cast — flagged inline.

## Out of scope (deferred)

The original PR3 plan also covered: generalize `PublishScoresModal`, widen `PlcTab` to accept a kind discriminator, add a VA Results PLC tab, add `publishVideoActivityScores`, add `/share/video-activity/{shareId}` URL routing. Those land as PR3c.

## Test plan

- [x] `pnpm exec vitest run` — 2164/2164 passing
- [x] `pnpm run type-check` — clean
- [x] `pnpm exec eslint . --ignore-pattern 'remotion/**' --max-warnings 0` — clean
- [x] New tests:
  - `tests/utils/assignmentExportShared.test.ts` (10 cases) — column layout, grader threading, in-progress blanking, SSO-vs-PIN resolution, max-points sum, name sort.
  - `tests/utils/videoActivityDriveService.test.ts` (5 cases) — MA grading fix, FIB-variant grading, completedAt → status adapter in both directions, 12-column shape.
- [ ] Manual: export VA assignment with mixed MC/FIB/MA questions and verify MA columns now show earned points instead of 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)