### PR TITLE
feat(video-activity): PR3c — Publish scores + Results PLC tab + share routing

### DIFF
--- a/components/common/library/PlcTab.tsx
+++ b/components/common/library/PlcTab.tsx
@@ -1,5 +1,5 @@
 /**
- * PlcTab — cross-teacher aggregate view of a PLC's quiz results.
+ * PlcTab — cross-teacher aggregate view of a PLC's assignment results.
  *
  * Renders only when the active assignment is in PLC mode (Share-with-PLC
  * enabled). The teacher's own class data lives in the Overview / Questions /
@@ -13,6 +13,12 @@
  * and per-period filtering is intentionally NOT exposed here: if a teacher
  * needs that level of detail, they open the sheet itself. This tab keeps
  * the focus on aggregate signal.
+ *
+ * Generic over the assignment kind: works for both Quiz and Video Activity
+ * because both exporters write the same column shape (PR3b lifted
+ * `buildResultsSheetData` into a shared helper). The `questions` prop only
+ * needs `id` + `text`; `QuizQuestion` and `VideoActivityQuestion` both
+ * satisfy `PlcTabQuestion` structurally.
  */
 
 import React, { useEffect, useState, useMemo } from 'react';
@@ -27,13 +33,18 @@ import {
   ExternalLink,
   RefreshCw,
 } from 'lucide-react';
-import type { QuizQuestion } from '@/types';
 import { QuizDriveService, type PlcSheetRow } from '@/utils/quizDriveService';
+
+/** Minimal question shape this tab renders. */
+export interface PlcTabQuestion {
+  id: string;
+  text: string;
+}
 
 interface PlcTabProps {
   plcSheetUrl: string;
   googleAccessToken: string | null;
-  questions: QuizQuestion[];
+  questions: PlcTabQuestion[];
 }
 
 interface PlcAggregate {
@@ -83,7 +94,7 @@ const SCORE_BUCKETS = [
 
 function aggregate(
   rows: PlcSheetRow[],
-  questions: QuizQuestion[]
+  questions: PlcTabQuestion[]
 ): PlcAggregate {
   const completed = rows.filter((r) => r.status === 'completed');
   const teachers = new Set<string>();

--- a/components/common/library/PublishScoresModal.tsx
+++ b/components/common/library/PublishScoresModal.tsx
@@ -4,7 +4,8 @@
  * given assignment.
  *
  * Reached from the archive tab's per-assignment kebab → "Publish Scores".
- * The four levels map to `QuizScoreVisibility`:
+ * The four levels map to the assignment's score-visibility union (Quiz
+ * and Video Activity define structurally identical unions):
  *
  *   - none: scores are hidden from students (default / unpublish path).
  *   - score-only: students see their final percentage score.
@@ -16,7 +17,7 @@
  * The modal is purely a level-picker — the actual publish work
  * (computing scores, writing per-response `isCorrect`, populating
  * `session.revealedAnswers`, mirroring the visibility flag) is done by
- * `useQuizAssignments.publishAssignmentScores`.
+ * the caller's `publishAssignmentScores` hook.
  */
 
 import React, { useState } from 'react';
@@ -30,19 +31,30 @@ import {
   X,
 } from 'lucide-react';
 import { Modal } from '@/components/common/Modal';
-import type { QuizScoreVisibility } from '@/types';
+import type {
+  QuizScoreVisibility,
+  VideoActivityScoreVisibility,
+} from '@/types';
+
+/**
+ * Score-visibility level. Quiz and VA both define the same string-literal
+ * union; either resolves to the same shape at the call site.
+ */
+export type PublishScoresVisibility =
+  | QuizScoreVisibility
+  | VideoActivityScoreVisibility;
 
 interface PublishScoresModalProps {
-  /** Quiz title — shown as a sub-line so the teacher knows which assignment they're publishing. */
-  quizTitle: string;
+  /** Assignment title — sub-line so the teacher knows which assignment they're publishing. */
+  assignmentTitle: string;
   /** Currently-published level (or 'none' / undefined when nothing is published yet). */
-  currentVisibility: QuizScoreVisibility | undefined;
+  currentVisibility: PublishScoresVisibility | undefined;
   onClose: () => void;
-  onConfirm: (visibility: QuizScoreVisibility) => Promise<void> | void;
+  onConfirm: (visibility: PublishScoresVisibility) => Promise<void> | void;
 }
 
 interface VisibilityOption {
-  id: QuizScoreVisibility;
+  id: PublishScoresVisibility;
   title: string;
   body: string;
   Icon: React.ComponentType<{ className?: string }>;
@@ -70,24 +82,24 @@ const OPTIONS: VisibilityOption[] = [
 ];
 
 export const PublishScoresModal: React.FC<PublishScoresModalProps> = ({
-  quizTitle,
+  assignmentTitle,
   currentVisibility,
   onClose,
   onConfirm,
 }) => {
   // Default the picker to whatever the assignment is currently set to (or
   // 'score-only' on first publish — the calmest non-empty choice).
-  const initial: QuizScoreVisibility =
+  const initial: PublishScoresVisibility =
     currentVisibility && currentVisibility !== 'none'
       ? currentVisibility
       : 'score-only';
-  const [selected, setSelected] = useState<QuizScoreVisibility>(initial);
+  const [selected, setSelected] = useState<PublishScoresVisibility>(initial);
   const [submitting, setSubmitting] = useState(false);
 
   const isPublished =
     currentVisibility !== undefined && currentVisibility !== 'none';
 
-  const handleConfirm = async (visibility: QuizScoreVisibility) => {
+  const handleConfirm = async (visibility: PublishScoresVisibility) => {
     if (submitting) return;
     setSubmitting(true);
     try {
@@ -115,7 +127,7 @@ export const PublishScoresModal: React.FC<PublishScoresModalProps> = ({
                 Publish scores
               </h2>
               <p className="text-xs text-slate-500 mt-0.5 truncate max-w-[20rem]">
-                {quizTitle}
+                {assignmentTitle}
               </p>
             </div>
           </div>

--- a/components/layout/DashboardView.tsx
+++ b/components/layout/DashboardView.tsx
@@ -16,6 +16,8 @@ import {
   useQuizAssignments,
   type SharedAssignmentImportMode,
 } from '@/hooks/useQuizAssignments';
+import { useVideoActivity } from '@/hooks/useVideoActivity';
+import { useVideoActivityAssignments } from '@/hooks/useVideoActivityAssignments';
 import { QuizAssignmentImportModeModal } from '@/components/widgets/QuizWidget/components/QuizAssignmentImportModeModal';
 import { ImportShareModePicker } from '@/components/share/ImportShareModePicker';
 import { ShareStatusBanner } from '@/components/share/ShareStatusBanner';
@@ -160,6 +162,8 @@ export const DashboardView: React.FC = () => {
     clearPendingQuizShare,
     pendingAssignmentShareId,
     clearPendingAssignmentShare,
+    pendingVideoActivityShareId,
+    clearPendingVideoActivityShare,
     setPendingAssignmentSetup,
     // Widget grouping
     groupWidgets,
@@ -178,6 +182,13 @@ export const DashboardView: React.FC = () => {
   const { importSharedAssignment, peekSharedAssignment } = useQuizAssignments(
     user?.uid
   );
+  const {
+    saveActivity: saveVideoActivity,
+    deleteActivity: deleteVideoActivity,
+    attachSyncLinkage: attachVideoActivitySyncLinkage,
+  } = useVideoActivity(user?.uid);
+  const { importSharedAssignment: importSharedVideoActivityAssignment } =
+    useVideoActivityAssignments(user?.uid);
   const { plcs, loading: plcsLoading } = usePlcs();
 
   // Mode picker state — populated when a synced share is detected; null
@@ -212,6 +223,32 @@ export const DashboardView: React.FC = () => {
         bringToFront(quizWidget.id);
       } else {
         addWidget('quiz', {
+          config: { view: 'manager', managerTab: tab },
+        });
+      }
+    },
+    [activeDashboard, updateWidget, addWidget, bringToFront]
+  );
+
+  const openVideoActivityWidgetToTab = React.useCallback(
+    (tab: 'library' | 'active' | 'archive') => {
+      const vaWidget = activeDashboard?.widgets.find(
+        (w) => w.type === 'video-activity'
+      );
+      if (vaWidget) {
+        if (vaWidget.minimized) {
+          updateWidget(vaWidget.id, { minimized: false });
+        }
+        updateWidget(vaWidget.id, {
+          config: {
+            ...vaWidget.config,
+            view: 'manager',
+            managerTab: tab,
+          },
+        });
+        bringToFront(vaWidget.id);
+      } else {
+        addWidget('video-activity', {
           config: { view: 'manager', managerTab: tab },
         });
       }
@@ -449,6 +486,59 @@ export const DashboardView: React.FC = () => {
     peekAndDispatchImport,
     clearPendingAssignmentShare,
     plcsLoading,
+  ]);
+
+  // PR3c — pending video-activity-assignment share import. Mirrors the
+  // quiz-assignment effect above. Default to 'copy' mode for now: VA's
+  // sync-mode picker UI hasn't been ported, and a synced share will simply
+  // import as a copy (peers can re-share if they want sync). Errors
+  // surface a Retry-capable toast like the Quiz path.
+  useEffect(() => {
+    if (!pendingVideoActivityShareId || !user) return;
+    if (plcsLoading) return;
+    const shareId = pendingVideoActivityShareId;
+    clearPendingVideoActivityShare();
+    void importSharedVideoActivityAssignment(shareId, {
+      mode: 'copy',
+      saveActivity: saveVideoActivity,
+      attachSyncLinkage: attachVideoActivitySyncLinkage,
+    })
+      .then(() => {
+        addToast('Shared video activity imported!', 'success');
+        openVideoActivityWidgetToTab('active');
+      })
+      .catch((err: unknown) => {
+        logError('DashboardView.importSharedVideoActivity', err, { shareId });
+        // No half-state to roll back: the VA import hook handles its own
+        // rollback (Drive copy + sync-group leave) on failure paths.
+        // `deleteVideoActivity` stays referenced via the dep array so a
+        // future expansion can hook a rollback path here without a
+        // ref-stale closure.
+        void deleteVideoActivity;
+        const msg =
+          err instanceof Error
+            ? err.message
+            : typeof err === 'string'
+              ? err
+              : '';
+        addToast(
+          msg
+            ? `Failed to import shared video activity: ${msg}`
+            : 'Failed to import shared video activity.',
+          'error'
+        );
+      });
+  }, [
+    pendingVideoActivityShareId,
+    user,
+    plcsLoading,
+    clearPendingVideoActivityShare,
+    importSharedVideoActivityAssignment,
+    saveVideoActivity,
+    attachVideoActivitySyncLinkage,
+    addToast,
+    openVideoActivityWidgetToTab,
+    deleteVideoActivity,
   ]);
 
   const [panOffset, setPanOffset] = React.useState({ x: 0, y: 0 });

--- a/components/layout/DashboardView.tsx
+++ b/components/layout/DashboardView.tsx
@@ -184,7 +184,6 @@ export const DashboardView: React.FC = () => {
   );
   const {
     saveActivity: saveVideoActivity,
-    deleteActivity: deleteVideoActivity,
     attachSyncLinkage: attachVideoActivitySyncLinkage,
   } = useVideoActivity(user?.uid);
   const { importSharedAssignment: importSharedVideoActivityAssignment } =
@@ -488,57 +487,74 @@ export const DashboardView: React.FC = () => {
     plcsLoading,
   ]);
 
+  // Stable dispatcher for VA share imports — extracted so the failure
+  // toast's Retry action can re-invoke it without re-running the
+  // pending-id effect (which clears the id synchronously to avoid the
+  // triple-import race documented on the Quiz path above). Mirrors
+  // `peekAndDispatchImport` for the Quiz flow but skips the peek + mode
+  // picker — VA's sync-mode picker UI hasn't been ported and a synced
+  // share simply imports as a copy.
+  const runVideoActivityImport = React.useCallback(
+    (shareId: string) => {
+      void importSharedVideoActivityAssignment(shareId, {
+        mode: 'copy',
+        saveActivity: saveVideoActivity,
+        attachSyncLinkage: attachVideoActivitySyncLinkage,
+      })
+        .then(() => {
+          addToast('Shared video activity imported!', 'success');
+          openVideoActivityWidgetToTab('active');
+        })
+        .catch((err: unknown) => {
+          logError('DashboardView.importSharedVideoActivity', err, {
+            shareId,
+          });
+          // The VA import hook handles its own rollback (Drive copy +
+          // sync-group leave) on failure paths, so the catch block is
+          // surface-only — no manual cleanup needed.
+          const msg =
+            err instanceof Error
+              ? err.message
+              : typeof err === 'string'
+                ? err
+                : '';
+          addToast(
+            msg
+              ? `Failed to import shared video activity: ${msg}`
+              : 'Failed to import shared video activity.',
+            'error',
+            {
+              label: 'Retry',
+              onClick: () => runVideoActivityImport(shareId),
+            }
+          );
+        });
+    },
+    [
+      importSharedVideoActivityAssignment,
+      saveVideoActivity,
+      attachVideoActivitySyncLinkage,
+      addToast,
+      openVideoActivityWidgetToTab,
+    ]
+  );
+
   // PR3c — pending video-activity-assignment share import. Mirrors the
-  // quiz-assignment effect above. Default to 'copy' mode for now: VA's
-  // sync-mode picker UI hasn't been ported, and a synced share will simply
-  // import as a copy (peers can re-share if they want sync). Errors
-  // surface a Retry-capable toast like the Quiz path.
+  // quiz-assignment effect above: clears the pending id synchronously
+  // before dispatching to avoid the triple-import race; the dispatcher's
+  // failure toast carries Retry as the recovery path.
   useEffect(() => {
     if (!pendingVideoActivityShareId || !user) return;
     if (plcsLoading) return;
     const shareId = pendingVideoActivityShareId;
     clearPendingVideoActivityShare();
-    void importSharedVideoActivityAssignment(shareId, {
-      mode: 'copy',
-      saveActivity: saveVideoActivity,
-      attachSyncLinkage: attachVideoActivitySyncLinkage,
-    })
-      .then(() => {
-        addToast('Shared video activity imported!', 'success');
-        openVideoActivityWidgetToTab('active');
-      })
-      .catch((err: unknown) => {
-        logError('DashboardView.importSharedVideoActivity', err, { shareId });
-        // No half-state to roll back: the VA import hook handles its own
-        // rollback (Drive copy + sync-group leave) on failure paths.
-        // `deleteVideoActivity` stays referenced via the dep array so a
-        // future expansion can hook a rollback path here without a
-        // ref-stale closure.
-        void deleteVideoActivity;
-        const msg =
-          err instanceof Error
-            ? err.message
-            : typeof err === 'string'
-              ? err
-              : '';
-        addToast(
-          msg
-            ? `Failed to import shared video activity: ${msg}`
-            : 'Failed to import shared video activity.',
-          'error'
-        );
-      });
+    runVideoActivityImport(shareId);
   }, [
     pendingVideoActivityShareId,
     user,
     plcsLoading,
     clearPendingVideoActivityShare,
-    importSharedVideoActivityAssignment,
-    saveVideoActivity,
-    attachVideoActivitySyncLinkage,
-    addToast,
-    openVideoActivityWidgetToTab,
-    deleteVideoActivity,
+    runVideoActivityImport,
   ]);
 
   const [panOffset, setPanOffset] = React.useState({ x: 0, y: 0 });

--- a/components/student/StudentContexts.tsx
+++ b/components/student/StudentContexts.tsx
@@ -284,6 +284,13 @@ const mockDashboard: DashboardContextValue = {
   clearPendingAssignmentShare: () => {
     // No-op
   },
+  pendingVideoActivityShareId: null,
+  setPendingVideoActivityShareId: () => {
+    // No-op
+  },
+  clearPendingVideoActivityShare: () => {
+    // No-op
+  },
   pendingAssignmentSetupId: null,
   setPendingAssignmentSetup: () => {
     // No-op — student view never imports assignments.

--- a/components/widgets/QuizWidget/Widget.tsx
+++ b/components/widgets/QuizWidget/Widget.tsx
@@ -38,7 +38,7 @@ import { QuizPreview } from './components/QuizPreview';
 import { QuizResults } from './components/QuizResults';
 import { QuizAssignmentSettingsModal } from './components/QuizAssignmentSettingsModal';
 import { QuizAssignmentImportSetupModal } from './components/QuizAssignmentImportSetupModal';
-import { PublishScoresModal } from './components/PublishScoresModal';
+import { PublishScoresModal } from '@/components/common/library/PublishScoresModal';
 import type { QuizAssignment } from '@/types';
 import {
   buildPinToNameMap,
@@ -1784,7 +1784,7 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
       )}
       {publishingAssignment && (
         <PublishScoresModal
-          quizTitle={publishingAssignment.quizTitle}
+          assignmentTitle={publishingAssignment.quizTitle}
           currentVisibility={publishingAssignment.scoreVisibility}
           onClose={() => setPublishingAssignment(null)}
           onConfirm={async (visibility) => {

--- a/components/widgets/QuizWidget/components/QuizResults.tsx
+++ b/components/widgets/QuizWidget/components/QuizResults.tsx
@@ -57,7 +57,7 @@ import {
 import { resolveResponseDisplayName } from '../utils/resolveDisplayName';
 import { useClickOutside } from '@/hooks/useClickOutside';
 import { useAssignmentPseudonyms } from '@/hooks/useAssignmentPseudonyms';
-import { PlcTab } from './PlcTab';
+import { PlcTab } from '@/components/common/library/PlcTab';
 
 interface QuizResultsProps {
   quiz: QuizData;

--- a/components/widgets/VideoActivityWidget/Widget.tsx
+++ b/components/widgets/VideoActivityWidget/Widget.tsx
@@ -12,12 +12,14 @@ import {
   WidgetData,
   VideoActivityConfig,
   VideoActivityView,
+  VideoActivityAssignment,
   VideoActivityMetadata,
   VideoActivityData,
   VideoActivitySessionSettings,
   VideoActivityGlobalConfig,
   VideoActivitySession,
 } from '@/types';
+import { PublishScoresModal } from '@/components/common/library/PublishScoresModal';
 import { useDashboard } from '@/context/useDashboard';
 import { useAuth } from '@/context/useAuth';
 import { useVideoActivity } from '@/hooks/useVideoActivity';
@@ -104,7 +106,11 @@ export const VideoActivityWidget: React.FC<{ widget: WidgetData }> = ({
     reactivateAssignment,
     deleteAssignment,
     shareAssignment,
+    publishAssignmentScores,
   } = useVideoActivityAssignments(user?.uid);
+
+  const [publishingAssignment, setPublishingAssignment] =
+    useState<VideoActivityAssignment | null>(null);
 
   const [loadingActivity, setLoadingActivity] = useState(false);
   const [selectedSession, setSelectedSession] =
@@ -318,10 +324,14 @@ export const VideoActivityWidget: React.FC<{ widget: WidgetData }> = ({
   }
 
   if (view === 'results' && selectedSession) {
+    const resultsAssignment = assignments.find(
+      (a) => a.id === selectedSession.id
+    );
     return (
       <Results
         session={selectedSession}
         responses={responses}
+        plc={resultsAssignment?.plc}
         onBack={() => {
           unsubscribeFromSession();
           setSelectedSession(null);
@@ -705,6 +715,9 @@ export const VideoActivityWidget: React.FC<{ widget: WidgetData }> = ({
             } as VideoActivityConfig,
           });
         }}
+        onArchivePublishScores={(assignment) =>
+          setPublishingAssignment(assignment)
+        }
         initialLibraryViewMode={config.libraryViewMode}
         onLibraryViewModeChange={(mode) => {
           updateWidget(widget.id, {
@@ -712,6 +725,65 @@ export const VideoActivityWidget: React.FC<{ widget: WidgetData }> = ({
           });
         }}
       />
+      {publishingAssignment && (
+        <PublishScoresModal
+          assignmentTitle={
+            publishingAssignment.className ?? publishingAssignment.activityTitle
+          }
+          currentVisibility={publishingAssignment.scoreVisibility}
+          onClose={() => setPublishingAssignment(null)}
+          onConfirm={async (visibility) => {
+            const target = publishingAssignment;
+            try {
+              if (visibility === 'none') {
+                await publishAssignmentScores(
+                  target.id,
+                  // Empty placeholder VideoActivityData — the 'none' branch
+                  // never reads it. Cheaper than re-loading from Drive for
+                  // a flag flip.
+                  {
+                    id: target.activityId,
+                    title: target.activityTitle,
+                    youtubeUrl: '',
+                    questions: [],
+                    createdAt: 0,
+                    updatedAt: 0,
+                  },
+                  visibility
+                );
+                addToast('Scores unpublished.', 'success');
+                setPublishingAssignment(null);
+                return;
+              }
+              const data = await loadActivityData(target.activityDriveFileId);
+              if (!data) {
+                addToast(
+                  'Activity content unavailable — cannot publish scores.',
+                  'error'
+                );
+                return;
+              }
+              const result = await publishAssignmentScores(
+                target.id,
+                data,
+                visibility
+              );
+              addToast(
+                result.responsesUpdated > 0
+                  ? `Scores published to ${result.responsesUpdated} student${result.responsesUpdated === 1 ? '' : 's'}.`
+                  : 'Scores published. Students will see results once they submit.',
+                'success'
+              );
+              setPublishingAssignment(null);
+            } catch (err) {
+              addToast(
+                err instanceof Error ? err.message : 'Failed to publish scores',
+                'error'
+              );
+            }
+          }}
+        />
+      )}
       <VideoActivityEditorModal
         isOpen={!!editingActivity}
         activity={editingActivity}

--- a/components/widgets/VideoActivityWidget/components/Results.tsx
+++ b/components/widgets/VideoActivityWidget/components/Results.tsx
@@ -161,20 +161,30 @@ export const Results: React.FC<ResultsProps> = ({
       // Pass `byStudentUid` so SSO `studentRole` rows (no PIN) export with
       // their resolved ClassLink names instead of falling back to the
       // generic "Student" label.
-      // TODO(PR3): The Quiz exporter calls Quiz's `gradeAnswer`, which has
-      // no 'MA' case and returns 0 points for VA Multi-Answer questions in
-      // the export. PR3 lifts `buildResultsSheetData` into a generic util
-      // that accepts a custom grader (`utils/assignmentExportShared.ts`)
-      // and at that point the VA call here will pass `gradeVideoActivityAnswer`.
-      // Until then, MA columns in the exported sheet read as "0 / Npt".
-      // MC + FIB questions grade correctly.
+      //
+      // PR3b: pass `gradeFn: gradeVideoActivityAnswer` so the exporter
+      // grades VA's MA / FIB-with-variants questions correctly. Without
+      // this override the Quiz default grader has no `'MA'` case and
+      // returns 0 points for those columns (the TODO PR2a left here).
+      // Cast away the QuizQuestion / QuizResponse / typeof-gradeAnswer
+      // shapes — the lifted `buildResultsSheetData` is generic enough to
+      // accept VA's variants but the public `exportResultsToSheet`
+      // signature is still typed as Quiz-shaped. PR3 documents the cast
+      // boundary; a future refactor that splits the Quiz-specific
+      // question-stats block out into a generic helper would let this
+      // function become generic too and remove the cast.
+      type ExporterOptions = Parameters<typeof drive.exportResultsToSheet>[3];
       const url = await drive.exportResultsToSheet(
         session.assignmentName,
         quizResponses,
         questions as unknown as Parameters<
           typeof drive.exportResultsToSheet
         >[2],
-        { byStudentUid }
+        {
+          byStudentUid,
+          gradeFn:
+            gradeVideoActivityAnswer as unknown as NonNullable<ExporterOptions>['gradeFn'],
+        }
       );
       setExportUrl(url);
     } catch (err) {

--- a/components/widgets/VideoActivityWidget/components/Results.tsx
+++ b/components/widgets/VideoActivityWidget/components/Results.tsx
@@ -15,8 +15,13 @@ import {
   Users,
   CheckCircle2,
   XCircle,
+  Share2,
 } from 'lucide-react';
-import { VideoActivityResponse, VideoActivitySession } from '@/types';
+import {
+  PlcLinkage,
+  VideoActivityResponse,
+  VideoActivitySession,
+} from '@/types';
 import { useAuth } from '@/context/useAuth';
 import { QuizDriveService } from '@/utils/quizDriveService';
 import {
@@ -27,17 +32,25 @@ import {
   useAssignmentPseudonymsMulti,
   formatStudentName,
 } from '@/hooks/useAssignmentPseudonyms';
+import { PlcTab } from '@/components/common/library/PlcTab';
 
 interface ResultsProps {
   session: VideoActivitySession;
   responses: VideoActivityResponse[];
   onBack: () => void;
+  /**
+   * PLC linkage for this assignment, if any. Set → render the 4th tab
+   * ("PLC") that aggregates across every PLC peer's exports against the
+   * shared sheet. Absent → tab is hidden.
+   */
+  plc?: PlcLinkage;
 }
 
 export const Results: React.FC<ResultsProps> = ({
   session,
   responses,
   onBack,
+  plc,
 }) => {
   const { googleAccessToken, orgId } = useAuth();
   // Use the multi-class variant — `session.classId` is a transitional
@@ -59,7 +72,7 @@ export const Results: React.FC<ResultsProps> = ({
   const [exportUrl, setExportUrl] = useState<string | null>(null);
   const [exportError, setExportError] = useState<string | null>(null);
   const [activeTab, setActiveTab] = useState<
-    'overview' | 'questions' | 'students'
+    'overview' | 'questions' | 'students' | 'plc'
   >('overview');
 
   const questions = session.questions;
@@ -317,6 +330,9 @@ export const Results: React.FC<ResultsProps> = ({
             { id: 'overview', icon: <BarChart3 />, label: 'Overview' },
             { id: 'questions', icon: <Clock />, label: 'Questions' },
             { id: 'students', icon: <Users />, label: 'Students' },
+            ...(plc?.sheetUrl
+              ? [{ id: 'plc' as const, icon: <Share2 />, label: 'PLC' }]
+              : []),
           ] as const
         ).map((tab) => (
           <button
@@ -568,6 +584,14 @@ export const Results: React.FC<ResultsProps> = ({
                 })
             )}
           </div>
+        )}
+
+        {activeTab === 'plc' && plc?.sheetUrl && (
+          <PlcTab
+            plcSheetUrl={plc.sheetUrl}
+            googleAccessToken={googleAccessToken}
+            questions={questions}
+          />
         )}
       </div>
     </div>

--- a/components/widgets/VideoActivityWidget/components/VideoActivityManager.tsx
+++ b/components/widgets/VideoActivityWidget/components/VideoActivityManager.tsx
@@ -33,6 +33,7 @@ import {
   PlayCircle,
   Plus,
   RotateCcw,
+  Send,
   Share2,
   Trash2,
 } from 'lucide-react';
@@ -175,6 +176,13 @@ export interface VideoActivityManagerProps {
   onArchiveMonitor?: (
     assignment: VideoActivityAssignment
   ) => void | Promise<void>;
+  /**
+   * PR3c — open the publish-scores modal for this assignment. Set ⇒ the
+   * archive kebab gains a "Publish scores" / "Update published scores"
+   * entry that calls back through to `Widget.tsx`'s
+   * `useVideoActivityAssignments.publishAssignmentScores` hook.
+   */
+  onArchivePublishScores?: (assignment: VideoActivityAssignment) => void;
 
   /** Persisted library grid/list toggle (from widget config). */
   initialLibraryViewMode?: 'grid' | 'list';
@@ -397,6 +405,7 @@ export const VideoActivityManager: React.FC<VideoActivityManagerProps> = ({
   onArchiveResults,
   onArchiveShare,
   onArchiveMonitor,
+  onArchivePublishScores,
   initialLibraryViewMode,
   onLibraryViewModeChange,
   rosters,
@@ -1014,6 +1023,22 @@ export const VideoActivityManager: React.FC<VideoActivityManagerProps> = ({
         label: 'Results',
         icon: BarChart3,
         onClick: () => onArchiveResults(assignment),
+      });
+    }
+
+    // PR3c — surface "Publish scores" on the archive kebab when the
+    // assignment carries submissions. Label flips to "Update published
+    // scores" once a level is set so the teacher sees that re-opening
+    // the modal will replace, not stack.
+    if (onArchivePublishScores && !assignmentIsViewOnly) {
+      const isPublished =
+        assignment.scoreVisibility !== undefined &&
+        assignment.scoreVisibility !== 'none';
+      actions.push({
+        id: 'publish-scores',
+        label: isPublished ? 'Update published scores' : 'Publish scores',
+        icon: Send,
+        onClick: () => onArchivePublishScores(assignment),
       });
     }
 

--- a/context/DashboardContext.tsx
+++ b/context/DashboardContext.tsx
@@ -225,9 +225,11 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
   const [pendingShareId, setPendingShareId] = useState<string | null>(() => {
     if (typeof window === 'undefined') return null;
     const path = window.location.pathname;
-    // Skip quiz and assignment share URLs — those are handled separately
+    // Skip quiz, assignment, and video-activity share URLs — those are
+    // handled separately by their dedicated `pending*ShareId` states.
     if (path.startsWith('/share/quiz/')) return null;
     if (path.startsWith('/share/assignment/')) return null;
+    if (path.startsWith('/share/video-activity/')) return null;
     if (path.startsWith('/share/')) {
       return path.split('/share/')[1] || null;
     }
@@ -256,6 +258,16 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
     return null;
   });
 
+  const [pendingVideoActivityShareId, setPendingVideoActivityShareId] =
+    useState<string | null>(() => {
+      if (typeof window === 'undefined') return null;
+      const path = window.location.pathname;
+      if (path.startsWith('/share/video-activity/')) {
+        return path.split('/share/video-activity/')[1] || null;
+      }
+      return null;
+    });
+
   const clearPendingShare = useCallback(() => {
     setPendingShareId(null);
     window.history.replaceState(null, '', '/');
@@ -268,6 +280,11 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
 
   const clearPendingAssignmentShare = useCallback(() => {
     setPendingAssignmentShareId(null);
+    window.history.replaceState(null, '', '/');
+  }, []);
+
+  const clearPendingVideoActivityShare = useCallback(() => {
+    setPendingVideoActivityShareId(null);
     window.history.replaceState(null, '', '/');
   }, []);
 
@@ -4232,6 +4249,9 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
       pendingAssignmentShareId,
       setPendingAssignmentShareId,
       clearPendingAssignmentShare,
+      pendingVideoActivityShareId,
+      setPendingVideoActivityShareId,
+      clearPendingVideoActivityShare,
       pendingAssignmentSetupId,
       setPendingAssignmentSetup,
       clearPendingAssignmentSetup,
@@ -4330,6 +4350,9 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
       pendingAssignmentShareId,
       setPendingAssignmentShareId,
       clearPendingAssignmentShare,
+      pendingVideoActivityShareId,
+      setPendingVideoActivityShareId,
+      clearPendingVideoActivityShare,
       pendingAssignmentSetupId,
       setPendingAssignmentSetup,
       clearPendingAssignmentSetup,

--- a/context/DashboardContextValue.ts
+++ b/context/DashboardContextValue.ts
@@ -157,6 +157,14 @@ export interface DashboardContextValue {
   pendingAssignmentShareId: string | null;
   setPendingAssignmentShareId: (shareId: string | null) => void;
   clearPendingAssignmentShare: () => void;
+  /**
+   * Pending video-activity-assignment share id, parsed from
+   * `/share/video-activity/{shareId}`. Mirrors `pendingAssignmentShareId`;
+   * the VideoActivityWidget's URL-paste flow drives off this state.
+   */
+  pendingVideoActivityShareId: string | null;
+  setPendingVideoActivityShareId: (shareId: string | null) => void;
+  clearPendingVideoActivityShare: () => void;
   setPendingQuizShareId: (shareId: string | null) => void;
   /**
    * Set after a successful `importSharedAssignment` to signal the QuizWidget

--- a/hooks/useVideoActivity.ts
+++ b/hooks/useVideoActivity.ts
@@ -9,6 +9,7 @@ import { useState, useEffect, useCallback } from 'react';
 import {
   collection,
   doc,
+  getDoc,
   onSnapshot,
   setDoc,
   deleteDoc,
@@ -19,7 +20,11 @@ import { db, isAuthBypass } from '@/config/firebase';
 import { useAuth } from '@/context/useAuth';
 import { useGoogleDrive } from './useGoogleDrive';
 import { normalizeVideoActivityQuestions } from '@/utils/videoActivityNormalize';
-import { VideoActivityData, VideoActivityMetadata } from '@/types';
+import {
+  VideoActivityData,
+  VideoActivityMetadata,
+  VideoActivityMetadataSyncLinkage,
+} from '@/types';
 import { QuizDriveService } from '@/utils/quizDriveService';
 import {
   MockQuizDriveService,
@@ -42,6 +47,16 @@ export interface UseVideoActivityResult {
   loadActivityData: (driveFileId: string) => Promise<VideoActivityData>;
   /** Delete an activity from Drive and Firestore. */
   deleteActivity: (activityId: string, driveFileId: string) => Promise<void>;
+  /**
+   * Patch the synced-group linkage onto an activity's Firestore metadata.
+   * Mirrors `useQuiz.attachSyncLinkage`: used by the shared-assignment import
+   * flow to mark a freshly-imported activity as participating in a synced
+   * group, so future edits publish to the canonical doc.
+   */
+  attachSyncLinkage: (
+    activityId: string,
+    linkage: VideoActivityMetadataSyncLinkage
+  ) => Promise<void>;
   /** Create a template Google Sheet for CSV import. */
   createTemplateSheet: (title: string) => Promise<string>;
   /** Is a Drive service available? */
@@ -183,6 +198,47 @@ export const useVideoActivity = (
     [getDriveService]
   );
 
+  const attachSyncLinkage = useCallback(
+    async (
+      activityId: string,
+      linkage: VideoActivityMetadataSyncLinkage
+    ): Promise<void> => {
+      if (!userId) throw new Error('Not authenticated');
+      const metaRef = doc(
+        db,
+        'users',
+        userId,
+        VIDEO_ACTIVITIES_COLLECTION,
+        activityId
+      );
+      const snap = await getDoc(metaRef);
+      if (!snap.exists()) {
+        throw new Error(
+          `Cannot attach sync linkage: activity ${activityId} not in library.`
+        );
+      }
+      const existing = snap.data() as VideoActivityMetadata;
+      if (
+        existing.sync?.groupId === linkage.groupId &&
+        existing.sync?.lastSyncedVersion === linkage.lastSyncedVersion
+      ) {
+        return;
+      }
+      await setDoc(
+        metaRef,
+        {
+          ...existing,
+          sync: {
+            groupId: linkage.groupId,
+            lastSyncedVersion: linkage.lastSyncedVersion,
+          },
+        } satisfies VideoActivityMetadata,
+        { merge: false }
+      );
+    },
+    [userId]
+  );
+
   return {
     activities,
     loading,
@@ -191,6 +247,7 @@ export const useVideoActivity = (
     loadActivityData,
     deleteActivity,
     createTemplateSheet,
+    attachSyncLinkage,
     isDriveConnected: isAuthBypass || isConnected,
   };
 };

--- a/hooks/useVideoActivityAssignments.ts
+++ b/hooks/useVideoActivityAssignments.ts
@@ -16,6 +16,7 @@ import { useState, useEffect, useCallback } from 'react';
 import {
   addDoc,
   collection,
+  deleteField,
   doc,
   getDoc,
   onSnapshot,
@@ -37,6 +38,7 @@ import { logError } from '../utils/logError';
 import type {
   AssignmentMode,
   SharedVideoActivityAssignment,
+  VideoActivityAnswer,
   VideoActivityAssignment,
   VideoActivityAssignmentSettings,
   VideoActivityAssignmentSyncLinkage,
@@ -44,8 +46,11 @@ import type {
   VideoActivityData,
   VideoActivityMetadata,
   VideoActivityMetadataSyncLinkage,
+  VideoActivityResponse,
+  VideoActivityScoreVisibility,
   VideoActivitySession,
 } from '../types';
+import { gradeVideoActivityAnswer } from '../utils/videoActivityGrading';
 
 const VIDEO_ACTIVITY_ASSIGNMENTS_COLLECTION = 'video_activity_assignments';
 const VIDEO_ACTIVITY_SESSIONS_COLLECTION = 'video_activity_sessions';
@@ -152,6 +157,31 @@ export interface UseVideoActivityAssignmentsResult {
     shareId: string,
     options: ImportSharedAssignmentOptions
   ) => Promise<{ assignmentId: string; activityId: string }>;
+  /**
+   * Publish (or unpublish) per-student scores for an assignment. Mirrors
+   * `useQuizAssignments.publishAssignmentScores`. Grades every response
+   * via `gradeVideoActivityAnswer` (handles MA / FIB-with-variants — the
+   * Quiz grader's `'MA'` blind spot is irrelevant here), writes the
+   * computed `score` + per-answer `isCorrect` flags onto each response,
+   * and mirrors the visibility flag onto the assignment + session docs.
+   *
+   * `'none'` is the unpublish path: clears `scoreVisibility` on assignment
+   * + session and wipes `revealedAnswers`. Already-written `score` /
+   * `isCorrect` are left in place — the reader gates on `scoreVisibility`,
+   * so this is harmless and avoids a multi-batch wipe on a gesture the
+   * teacher may immediately undo.
+   *
+   * `'score-responses-and-answers'` populates `session.revealedAnswers`
+   * (id → correctAnswer) so the student review screen can show the
+   * canonical correct answer for each question — VA's session strips
+   * correct answers from `publicQuestions` for the in-progress flow,
+   * mirroring Quiz's student-safety pattern.
+   */
+  publishAssignmentScores: (
+    assignmentId: string,
+    activityData: VideoActivityData,
+    visibility: VideoActivityScoreVisibility
+  ) => Promise<{ responsesUpdated: number }>;
 }
 
 export interface ImportSharedAssignmentOptions {
@@ -766,6 +796,146 @@ export const useVideoActivityAssignments = (
     [userId, peekSharedAssignment, createAssignment]
   );
 
+  const publishAssignmentScores = useCallback<
+    UseVideoActivityAssignmentsResult['publishAssignmentScores']
+  >(
+    async (assignmentId, activityData, visibility) => {
+      if (!userId) throw new Error('Not authenticated');
+
+      const now = Date.now();
+      const assignmentRef = doc(
+        db,
+        'users',
+        userId,
+        VIDEO_ACTIVITY_ASSIGNMENTS_COLLECTION,
+        assignmentId
+      );
+      const sessionRef = doc(
+        db,
+        VIDEO_ACTIVITY_SESSIONS_COLLECTION,
+        assignmentId
+      );
+
+      if (visibility === 'none') {
+        const batch = writeBatch(db);
+        batch.update(assignmentRef, {
+          scoreVisibility: 'none',
+          scorePublishedAt: deleteField(),
+          updatedAt: now,
+        });
+        batch.update(sessionRef, {
+          scoreVisibility: 'none',
+          revealedAnswers: deleteField(),
+        });
+        await batch.commit();
+        return { responsesUpdated: 0 };
+      }
+
+      const questionsById = new Map(
+        activityData.questions.map((q) => [q.id, q])
+      );
+
+      const responsesSnap = await getDocs(
+        collection(
+          db,
+          VIDEO_ACTIVITY_SESSIONS_COLLECTION,
+          assignmentId,
+          RESPONSES_COLLECTION
+        )
+      );
+
+      interface ResponseUpdate {
+        ref: ReturnType<typeof doc>;
+        patch: { score: number; answers: VideoActivityAnswer[] };
+      }
+      const updates: ResponseUpdate[] = [];
+      for (const d of responsesSnap.docs) {
+        const data = d.data() as VideoActivityResponse;
+        const answers = Array.isArray(data.answers) ? data.answers : [];
+        let pointsEarned = 0;
+        let pointsMax = 0;
+        const gradedAnswers: VideoActivityAnswer[] = answers.map((a) => {
+          const q = questionsById.get(a.questionId);
+          if (!q) {
+            // Question deleted between submission and publish — drop any
+            // stale `isCorrect` from a prior publish so the response
+            // doesn't carry a value the canonical activity no longer
+            // supports. Mirrors the Quiz pattern.
+            const { isCorrect: _stale, ...rest } = a;
+            void _stale;
+            return rest;
+          }
+          const result = gradeVideoActivityAnswer(q, a.answer);
+          pointsEarned += result.pointsEarned;
+          pointsMax += result.pointsMax;
+          return { ...a, isCorrect: result.isCorrect };
+        });
+        // Count unanswered questions toward the denominator so a blank
+        // response scores 0%, not undefined. O(Q) Set lookup vs the
+        // O(Q*A) `.some` pattern matters on PLC-shared assignments.
+        const answeredQuestionIds = new Set<string>();
+        for (const a of answers) answeredQuestionIds.add(a.questionId);
+        for (const q of activityData.questions) {
+          if (!answeredQuestionIds.has(q.id)) {
+            pointsMax += q.points ?? 1;
+          }
+        }
+        const score =
+          pointsMax === 0 ? 0 : Math.round((pointsEarned / pointsMax) * 100);
+        updates.push({
+          ref: d.ref,
+          patch: { score, answers: gradedAnswers },
+        });
+      }
+
+      const MAX_BATCH_WRITES = 400;
+      const firstBatch = writeBatch(db);
+      firstBatch.update(assignmentRef, {
+        scoreVisibility: visibility,
+        scorePublishedAt: now,
+        updatedAt: now,
+      });
+      const sessionPatch: Record<string, unknown> = {
+        scoreVisibility: visibility,
+      };
+      if (visibility === 'score-responses-and-answers') {
+        const revealedAnswers: Record<string, string> = {};
+        for (const q of activityData.questions) {
+          revealedAnswers[q.id] = q.correctAnswer;
+        }
+        sessionPatch.revealedAnswers = revealedAnswers;
+      } else {
+        sessionPatch.revealedAnswers = deleteField();
+      }
+      firstBatch.update(sessionRef, sessionPatch);
+
+      // 2 writes already consumed (assignment + session); fill the rest
+      // of the first batch with response updates so the visibility flip
+      // is atomic with at least the first chunk of grades.
+      const firstChunkSize = Math.min(updates.length, MAX_BATCH_WRITES - 2);
+      for (let i = 0; i < firstChunkSize; i++) {
+        firstBatch.update(updates[i].ref, updates[i].patch);
+      }
+      await firstBatch.commit();
+
+      for (
+        let cursor = firstChunkSize;
+        cursor < updates.length;
+        cursor += MAX_BATCH_WRITES
+      ) {
+        const chunk = updates.slice(cursor, cursor + MAX_BATCH_WRITES);
+        const chunkBatch = writeBatch(db);
+        for (const u of chunk) {
+          chunkBatch.update(u.ref, u.patch);
+        }
+        await chunkBatch.commit();
+      }
+
+      return { responsesUpdated: updates.length };
+    },
+    [userId]
+  );
+
   return {
     assignments,
     loading,
@@ -780,5 +950,6 @@ export const useVideoActivityAssignments = (
     shareAssignment,
     peekSharedAssignment,
     importSharedAssignment,
+    publishAssignmentScores,
   };
 };

--- a/tests/components/layout/DashboardView.test.tsx
+++ b/tests/components/layout/DashboardView.test.tsx
@@ -56,6 +56,28 @@ vi.mock('@/hooks/useQuizAssignments', () => ({
   }),
 }));
 
+vi.mock('@/hooks/useVideoActivity', () => ({
+  useVideoActivity: vi.fn().mockReturnValue({
+    activities: [],
+    loading: false,
+    error: null,
+    saveActivity: vi.fn().mockResolvedValue({ id: 'va1', driveFileId: 'd-1' }),
+    deleteActivity: vi.fn().mockResolvedValue(undefined),
+    attachSyncLinkage: vi.fn().mockResolvedValue(undefined),
+  }),
+}));
+
+vi.mock('@/hooks/useVideoActivityAssignments', () => ({
+  useVideoActivityAssignments: vi.fn().mockReturnValue({
+    assignments: [],
+    loading: false,
+    error: null,
+    importSharedAssignment: vi
+      .fn()
+      .mockResolvedValue({ assignmentId: 'a1', activityId: 'va1' }),
+  }),
+}));
+
 vi.mock('@/hooks/usePlcs', () => ({
   usePlcs: vi.fn().mockReturnValue({
     plcs: [],

--- a/tests/escapeInteraction.test.tsx
+++ b/tests/escapeInteraction.test.tsx
@@ -85,6 +85,26 @@ vi.mock('../hooks/useQuizAssignments', () => ({
     importSharedAssignment: vi.fn().mockResolvedValue('a1'),
   }),
 }));
+vi.mock('../hooks/useVideoActivity', () => ({
+  useVideoActivity: () => ({
+    activities: [],
+    loading: false,
+    error: null,
+    saveActivity: vi.fn().mockResolvedValue({ id: 'va1', driveFileId: 'd-1' }),
+    deleteActivity: vi.fn().mockResolvedValue(undefined),
+    attachSyncLinkage: vi.fn().mockResolvedValue(undefined),
+  }),
+}));
+vi.mock('../hooks/useVideoActivityAssignments', () => ({
+  useVideoActivityAssignments: () => ({
+    assignments: [],
+    loading: false,
+    error: null,
+    importSharedAssignment: vi
+      .fn()
+      .mockResolvedValue({ assignmentId: 'a1', activityId: 'va1' }),
+  }),
+}));
 vi.mock('../hooks/usePlcs', () => ({
   usePlcs: () => ({
     plcs: [],

--- a/tests/utils/assignmentExportShared.test.ts
+++ b/tests/utils/assignmentExportShared.test.ts
@@ -165,4 +165,16 @@ describe('buildResultsSheetData', () => {
     expect(dataRows[0][3]).toBe('Aiden');
     expect(dataRows[1][3]).toBe('Zara');
   });
+
+  it('handles empty questions and responses without crashing', () => {
+    const empty = buildResultsSheetData([], [], ALWAYS_FULL);
+    expect(empty.headers).toHaveLength(11); // 11 fixed cols + 0 question cols
+    expect(empty.dataRows).toEqual([]);
+
+    // Responses but no questions: maxPoints = 0 must not divide-by-zero;
+    // Score column blanks out via the maxPoints > 0 guard.
+    const noQs = buildResultsSheetData([r()], [], ALWAYS_FULL);
+    expect(noQs.dataRows[0][6]).toBe(''); // Score (%) blank
+    expect(noQs.dataRows[0][8]).toBe('0'); // Max Points = 0
+  });
 });

--- a/tests/utils/assignmentExportShared.test.ts
+++ b/tests/utils/assignmentExportShared.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildResultsSheetData,
+  formatExportPoints,
+  type ExportableQuestion,
+  type ExportableResponse,
+} from '@/utils/assignmentExportShared';
+import type { GradeResult } from '@/types';
+
+describe('formatExportPoints', () => {
+  it('renders integers without decimals', () => {
+    expect(formatExportPoints(0)).toBe('0');
+    expect(formatExportPoints(5)).toBe('5');
+    expect(formatExportPoints(100)).toBe('100');
+  });
+
+  it('renders fractional values with up to 2 decimals', () => {
+    expect(formatExportPoints(0.5)).toBe('0.5');
+    expect(formatExportPoints(1.25)).toBe('1.25');
+  });
+
+  it('strips trailing zeros from rounded fractionals', () => {
+    expect(formatExportPoints(1.1)).toBe('1.1');
+  });
+});
+
+describe('buildResultsSheetData', () => {
+  const ALWAYS_FULL: (q: { points?: number }) => GradeResult = (q) => ({
+    isCorrect: true,
+    pointsEarned: q.points ?? 1,
+    pointsMax: q.points ?? 1,
+  });
+  const ALWAYS_ZERO: () => GradeResult = () => ({
+    isCorrect: false,
+    pointsEarned: 0,
+    pointsMax: 1,
+  });
+
+  function q(overrides: Partial<ExportableQuestion> = {}): ExportableQuestion {
+    return {
+      id: 'q1',
+      text: 'What?',
+      points: 1,
+      ...overrides,
+    };
+  }
+
+  function r(overrides: Partial<ExportableResponse> = {}): ExportableResponse {
+    return {
+      pin: '01',
+      studentUid: 'student-1',
+      classPeriod: 'Period 1',
+      answers: [{ questionId: 'q1', answer: 'a' }],
+      status: 'completed',
+      submittedAt: 1700000000000,
+      tabSwitchWarnings: 0,
+      ...overrides,
+    };
+  }
+
+  it('emits the canonical column header layout', () => {
+    const { headers } = buildResultsSheetData(
+      [r()],
+      [q({ id: 'q1', text: 'Question 1', points: 2 })],
+      ALWAYS_FULL
+    );
+    expect(headers).toEqual([
+      'Timestamp',
+      'Teacher',
+      'Class Period',
+      'Student',
+      'PIN',
+      'Status',
+      'Score (%)',
+      'Points Earned',
+      'Max Points',
+      'Warnings',
+      'Submitted At',
+      'Q1 (2pt): Question 1',
+    ]);
+  });
+
+  it('routes correctness through the injected grader (full credit)', () => {
+    const { dataRows } = buildResultsSheetData(
+      [r()],
+      [q({ points: 3 })],
+      ALWAYS_FULL
+    );
+    expect(dataRows).toHaveLength(1);
+    // Score column is index 6 (after Timestamp, Teacher, Class, Student, PIN, Status)
+    expect(dataRows[0][6]).toBe('100%');
+    // Points Earned at index 7
+    expect(dataRows[0][7]).toBe('3');
+  });
+
+  it('routes correctness through the injected grader (zero credit)', () => {
+    const { dataRows } = buildResultsSheetData(
+      [r()],
+      [q({ points: 3 })],
+      ALWAYS_ZERO
+    );
+    // Even though the response is "completed", earned is 0 so score is 0%
+    expect(dataRows[0][6]).toBe('0%');
+    expect(dataRows[0][7]).toBe('0');
+  });
+
+  it('hides score column for in-progress responses', () => {
+    const { dataRows } = buildResultsSheetData(
+      [r({ status: 'in-progress', submittedAt: null })],
+      [q()],
+      ALWAYS_FULL
+    );
+    // Score column blank for non-completed
+    expect(dataRows[0][6]).toBe('');
+  });
+
+  it('resolves SSO students by studentUid first, falling back to PIN', () => {
+    const ssoMap = new Map([
+      ['sso-1', { givenName: 'Alex', familyName: 'Lee' }],
+    ]);
+    // Period-scoped pinToName uses the canonical `${period}${pin}` key
+    // shape produced by `buildPinToNameMap`.
+    const PIN_KEY_SEP = String.fromCharCode(0x01);
+    const { dataRows } = buildResultsSheetData(
+      [
+        r({ studentUid: 'sso-1', pin: undefined }),
+        r({ studentUid: 'pin-1', pin: '02' }),
+      ],
+      [q()],
+      ALWAYS_FULL,
+      {
+        byStudentUid: ssoMap,
+        pinToName: { [`Period 1${PIN_KEY_SEP}02`]: 'Maya' },
+      }
+    );
+    // Student column at index 3; rows are sorted by name so verify both
+    const names = dataRows.map((row) => row[3]);
+    expect(names).toContain('Alex Lee');
+    expect(names).toContain('Maya');
+  });
+
+  it('passes question.points to the grader call (max points sums correctly)', () => {
+    const { dataRows } = buildResultsSheetData(
+      [r({ answers: [{ questionId: 'q1', answer: 'x' }] })],
+      [q({ id: 'q1', points: 5 })],
+      ALWAYS_FULL
+    );
+    // Max Points column at index 8
+    expect(dataRows[0][8]).toBe('5');
+  });
+
+  it('sorts rows by student name', () => {
+    const PIN_KEY_SEP = String.fromCharCode(0x01);
+    const { dataRows } = buildResultsSheetData(
+      [r({ studentUid: 'a', pin: '03' }), r({ studentUid: 'b', pin: '01' })],
+      [q()],
+      ALWAYS_FULL,
+      {
+        pinToName: {
+          [`Period 1${PIN_KEY_SEP}01`]: 'Aiden',
+          [`Period 1${PIN_KEY_SEP}03`]: 'Zara',
+        },
+      }
+    );
+    expect(dataRows[0][3]).toBe('Aiden');
+    expect(dataRows[1][3]).toBe('Zara');
+  });
+});

--- a/tests/utils/videoActivityDriveService.test.ts
+++ b/tests/utils/videoActivityDriveService.test.ts
@@ -93,6 +93,17 @@ describe('buildVideoActivityResultsSheetData', () => {
     expect(dataRows[0][6]).toBe(''); // score blank for in-progress
   });
 
+  it('treats completedAt: 0 as completed (explicit null check)', () => {
+    // The type allows `number | null`; a truthiness check would misclassify
+    // `0` (Jan 1 1970 timestamp) as in-progress.
+    const r = vaResponse({ completedAt: 0 });
+    const { dataRows } = buildVideoActivityResultsSheetData(
+      [r],
+      [vaQuestion()]
+    );
+    expect(dataRows[0][5]).toBe('completed');
+  });
+
   it('preserves the canonical 12-column shape', () => {
     const { headers } = buildVideoActivityResultsSheetData(
       [vaResponse()],

--- a/tests/utils/videoActivityDriveService.test.ts
+++ b/tests/utils/videoActivityDriveService.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from 'vitest';
+import { buildVideoActivityResultsSheetData } from '@/utils/videoActivityDriveService';
+import type { VideoActivityQuestion, VideoActivityResponse } from '@/types';
+
+function vaQuestion(
+  overrides: Partial<VideoActivityQuestion> = {}
+): VideoActivityQuestion {
+  return {
+    id: 'q1',
+    text: 'What organelle?',
+    timestamp: 30,
+    timeLimit: 30,
+    type: 'MC',
+    correctAnswer: 'mitochondria',
+    incorrectAnswers: [],
+    points: 1,
+    ...overrides,
+  };
+}
+
+function vaResponse(
+  overrides: Partial<VideoActivityResponse> = {}
+): VideoActivityResponse {
+  return {
+    pin: '01',
+    studentUid: 'student-1',
+    classPeriod: 'Period 1',
+    joinedAt: 1700000000000,
+    answers: [
+      { questionId: 'q1', answer: 'mitochondria', answeredAt: 1700000000500 },
+    ],
+    score: null,
+    completedAt: 1700000001000,
+    tabSwitchWarnings: 0,
+    ...overrides,
+  };
+}
+
+describe('buildVideoActivityResultsSheetData', () => {
+  it('grades MA questions correctly (PR2a TODO fix)', () => {
+    // The Quiz grader has no 'MA' case and would award 0 points.
+    // VA's grader (gradeVideoActivityAnswer) handles set-equality, so a
+    // student who picked exactly the correct selections gets full points.
+    const ma = vaQuestion({
+      id: 'q-ma',
+      type: 'MA',
+      correctAnswer: 'a|b|c',
+      incorrectAnswers: ['d'],
+      points: 3,
+    });
+    const r = vaResponse({
+      answers: [
+        { questionId: 'q-ma', answer: 'a|b|c', answeredAt: 1700000000500 },
+      ],
+    });
+    const { dataRows } = buildVideoActivityResultsSheetData([r], [ma]);
+    // Points Earned at index 7 — 3 points awarded, NOT 0
+    expect(dataRows[0][7]).toBe('3');
+    // Score column at index 6
+    expect(dataRows[0][6]).toBe('100%');
+  });
+
+  it('grades FIB with acceptableVariants', () => {
+    const fib = vaQuestion({
+      type: 'FIB',
+      correctAnswer: 'colour',
+      acceptableVariants: ['color'],
+    });
+    const r = vaResponse({
+      answers: [{ questionId: 'q1', answer: 'color', answeredAt: 1 }],
+    });
+    const { dataRows } = buildVideoActivityResultsSheetData([r], [fib]);
+    expect(dataRows[0][7]).toBe('1');
+  });
+
+  it('maps completedAt → status column "completed"', () => {
+    const r = vaResponse({ completedAt: 1700000001000 });
+    const { dataRows } = buildVideoActivityResultsSheetData(
+      [r],
+      [vaQuestion()]
+    );
+    // Status column at index 5
+    expect(dataRows[0][5]).toBe('completed');
+  });
+
+  it('maps null completedAt → status "in-progress" with empty score', () => {
+    const r = vaResponse({ completedAt: null });
+    const { dataRows } = buildVideoActivityResultsSheetData(
+      [r],
+      [vaQuestion()]
+    );
+    expect(dataRows[0][5]).toBe('in-progress');
+    expect(dataRows[0][6]).toBe(''); // score blank for in-progress
+  });
+
+  it('preserves the canonical 12-column shape', () => {
+    const { headers } = buildVideoActivityResultsSheetData(
+      [vaResponse()],
+      [vaQuestion({ id: 'q1', text: 'Q1', points: 1 })]
+    );
+    expect(headers).toHaveLength(12); // 11 fixed + 1 question column
+    expect(headers[0]).toBe('Timestamp');
+    expect(headers[10]).toBe('Submitted At');
+  });
+});

--- a/utils/assignmentExportShared.ts
+++ b/utils/assignmentExportShared.ts
@@ -1,0 +1,154 @@
+/**
+ * Shared results-sheet export primitives.
+ *
+ * Originally lived as `private buildResultsSheetData` on `QuizDriveService`.
+ * PR3b lifts it here so Video Activity (and any future Quiz-style widget)
+ * can produce the same column shape without duplicating the loop. The
+ * grader is injected as a callback so each widget passes its own —
+ * Quiz uses `gradeAnswer`, VA uses `gradeVideoActivityAnswer` (which
+ * handles MA/FIB-variants that the Quiz grader has no case for).
+ *
+ * The shape is intentionally minimal: just the fields the column layout
+ * reads. Quiz passes its `QuizResponse` / `QuizQuestion` directly (they
+ * fit). VA wraps its `VideoActivityResponse` to map `completedAt` →
+ * `submittedAt` + derive a `status` string.
+ */
+
+import type { GradeResult } from '@/types';
+import { resolvePinName } from '@/components/widgets/QuizWidget/utils/quizScoreboard';
+
+/**
+ * Format a points value for export. Whole numbers stay as integers;
+ * fractional partial-credit values render with up to 2 decimals.
+ */
+export function formatExportPoints(points: number): string {
+  if (Number.isInteger(points)) return String(points);
+  return (Math.round(points * 100) / 100).toString();
+}
+
+/** Minimum response shape the export reads. */
+export interface ExportableResponse {
+  pin?: string;
+  studentUid: string;
+  classPeriod?: string;
+  answers: { questionId: string; answer: string }[];
+  /** 'completed' | 'in-progress' | other widget-specific status string. */
+  status: string;
+  /**
+   * When the response was finalized. VA's `completedAt` and Quiz's
+   * `submittedAt` both fit; the export displays it verbatim.
+   */
+  submittedAt: number | null;
+  tabSwitchWarnings?: number;
+}
+
+/** Minimum question shape the export reads. */
+export interface ExportableQuestion {
+  id: string;
+  text: string;
+  points?: number;
+}
+
+export interface BuildResultsSheetDataOptions {
+  /** PIN → roster student name lookup. Per-period when keyed. */
+  pinToName?: Record<string, string>;
+  /** SSO uid → resolved ClassLink name. Wins over `pinToName` when present. */
+  byStudentUid?: Map<string, { givenName: string; familyName: string }>;
+  /** Teacher display name for the "Teacher" column. */
+  teacherName?: string;
+}
+
+/**
+ * Build headers + data rows for a results sheet export. Side-effect free.
+ * The grader callback is widget-specific so MA/FIB-variant grading works
+ * for VA, and Matching/Ordering partial credit works for Quiz.
+ */
+export function buildResultsSheetData<
+  Q extends ExportableQuestion,
+  R extends ExportableResponse,
+>(
+  responses: R[],
+  questions: Q[],
+  gradeFn: (question: Q, studentAnswer: string) => GradeResult,
+  options?: BuildResultsSheetDataOptions
+): { headers: string[]; dataRows: string[][] } {
+  const pinToName = options?.pinToName ?? {};
+  const byStudentUid = options?.byStudentUid;
+  const teacherName =
+    (options?.teacherName?.trim() ? options.teacherName.trim() : null) ??
+    'Unknown Teacher';
+  const timestamp = new Date().toISOString();
+
+  const resolveStudent = (r: R): string => {
+    const sso = byStudentUid?.get(r.studentUid);
+    if (sso) {
+      const full = `${sso.givenName ?? ''} ${sso.familyName ?? ''}`.trim();
+      if (full) return full;
+    }
+    if (r.pin) {
+      const name = resolvePinName(pinToName, r.classPeriod, r.pin);
+      return name ?? `Student (PIN: ${r.pin})`;
+    }
+    return 'Student';
+  };
+
+  const maxPoints = questions.reduce((sum, q) => sum + (q.points ?? 1), 0);
+  const headers = [
+    'Timestamp',
+    'Teacher',
+    'Class Period',
+    'Student',
+    'PIN',
+    'Status',
+    'Score (%)',
+    'Points Earned',
+    'Max Points',
+    'Warnings',
+    'Submitted At',
+    ...questions.map(
+      (q, i) => `Q${i + 1} (${q.points ?? 1}pt): ${q.text.substring(0, 40)}`
+    ),
+  ];
+
+  const dataRows = responses.map((r) => {
+    const submitted = r.submittedAt
+      ? new Date(r.submittedAt).toLocaleString()
+      : '';
+    const warnings = r.tabSwitchWarnings?.toString() ?? '0';
+    const answerMap = new Map(r.answers.map((a) => [a.questionId, a]));
+    const answerCols = questions.map((q) => {
+      const ans = answerMap.get(q.id);
+      if (!ans) return '';
+      const grade = gradeFn(q, ans.answer);
+      return formatExportPoints(grade.pointsEarned);
+    });
+    const earnedPoints = questions.reduce((sum, q) => {
+      const ans = answerMap.get(q.id);
+      if (!ans) return sum;
+      return sum + gradeFn(q, ans.answer).pointsEarned;
+    }, 0);
+    const scoreDisplay =
+      r.status === 'completed' && maxPoints > 0
+        ? `${Math.round((earnedPoints / maxPoints) * 100)}%`
+        : '';
+    return [
+      timestamp,
+      teacherName,
+      r.classPeriod ?? '',
+      resolveStudent(r),
+      r.pin ?? '',
+      r.status,
+      scoreDisplay,
+      formatExportPoints(earnedPoints),
+      String(maxPoints),
+      warnings,
+      submitted,
+      ...answerCols,
+    ];
+  });
+
+  // Stable sort by student name so the export reads naturally even when
+  // responses arrive in arbitrary join order.
+  dataRows.sort((a, b) => a[3].localeCompare(b[3]));
+  return { headers, dataRows };
+}

--- a/utils/quizDriveService.ts
+++ b/utils/quizDriveService.ts
@@ -18,7 +18,7 @@ import {
 import { gradeAnswer } from '../hooks/useQuizSession';
 import { APP_NAME } from '../config/constants';
 import { authError } from './driveAuthErrors';
-import { buildResultsSheetData as buildResultsSheetDataShared } from './assignmentExportShared';
+import { buildResultsSheetData as buildResultsSheetDataShared } from '@/utils/assignmentExportShared';
 
 const DRIVE_API_URL = 'https://www.googleapis.com/drive/v3';
 const UPLOAD_API_URL = 'https://www.googleapis.com/upload/drive/v3';

--- a/utils/quizDriveService.ts
+++ b/utils/quizDriveService.ts
@@ -18,7 +18,7 @@ import {
 import { gradeAnswer } from '../hooks/useQuizSession';
 import { APP_NAME } from '../config/constants';
 import { authError } from './driveAuthErrors';
-import { resolvePinName } from '../components/widgets/QuizWidget/utils/quizScoreboard';
+import { buildResultsSheetData as buildResultsSheetDataShared } from './assignmentExportShared';
 
 const DRIVE_API_URL = 'https://www.googleapis.com/drive/v3';
 const UPLOAD_API_URL = 'https://www.googleapis.com/upload/drive/v3';
@@ -37,16 +37,6 @@ const QUIZ_FOLDER_NAME = 'Quizzes';
 /** Escape single quotes in Drive API q-string values (single-quote is the delimiter). */
 function driveQueryEscape(s: string): string {
   return s.replace(/\\/g, '\\\\').replace(/'/g, "\\'");
-}
-
-/**
- * Format a points value for export to a Google Sheet cell. Whole numbers
- * stay as integers; fractional partial-credit values render with up to
- * 2 decimals (trailing zeros stripped).
- */
-function formatExportPoints(points: number): string {
-  if (Number.isInteger(points)) return String(points);
-  return (Math.round(points * 100) / 100).toString();
 }
 
 /**
@@ -511,9 +501,10 @@ export class QuizDriveService {
 
   /**
    * Build the headers + data rows for the results sheet WITHOUT touching
-   * the network. Shared between `exportResultsToSheet` (initial export +
-   * append) and `regeneratePlcSheet` (clear-then-rewrite) so the column
-   * shape stays in lock-step across all three flows. Side-effect-free.
+   * the network. Delegates to the shared `buildResultsSheetData` helper.
+   * Used internally by `regeneratePlcSheet`; `exportResultsToSheet` calls
+   * the shared helper directly so it can thread the grader through.
+   * Side-effect-free.
    */
   private buildResultsSheetData(
     responses: QuizResponse[],
@@ -524,83 +515,12 @@ export class QuizDriveService {
       teacherName?: string;
     }
   ): { headers: string[]; dataRows: string[][] } {
-    const pinToName = options?.pinToName ?? {};
-    const byStudentUid = options?.byStudentUid;
-    const teacherName =
-      (options?.teacherName?.trim() ? options.teacherName.trim() : null) ??
-      'Unknown Teacher';
-    const timestamp = new Date().toISOString();
-
-    const resolveStudent = (r: QuizResponse): string => {
-      const sso = byStudentUid?.get(r.studentUid);
-      if (sso) {
-        const full = `${sso.givenName ?? ''} ${sso.familyName ?? ''}`.trim();
-        if (full) return full;
-      }
-      if (r.pin) {
-        const name = resolvePinName(pinToName, r.classPeriod, r.pin);
-        return name ?? `Student (PIN: ${r.pin})`;
-      }
-      return 'Student';
-    };
-
-    const maxPoints = questions.reduce((sum, q) => sum + (q.points ?? 1), 0);
-    const headers = [
-      'Timestamp',
-      'Teacher',
-      'Class Period',
-      'Student',
-      'PIN',
-      'Status',
-      'Score (%)',
-      'Points Earned',
-      'Max Points',
-      'Warnings',
-      'Submitted At',
-      ...questions.map(
-        (q, i) => `Q${i + 1} (${q.points ?? 1}pt): ${q.text.substring(0, 40)}`
-      ),
-    ];
-
-    const dataRows = responses.map((r) => {
-      const submitted = r.submittedAt
-        ? new Date(r.submittedAt).toLocaleString()
-        : '';
-      const warnings = r.tabSwitchWarnings?.toString() ?? '0';
-      const answerMap = new Map(r.answers.map((a) => [a.questionId, a]));
-      const answerCols = questions.map((q) => {
-        const ans = answerMap.get(q.id);
-        if (!ans) return '';
-        const grade = gradeAnswer(q, ans.answer);
-        return formatExportPoints(grade.pointsEarned);
-      });
-      const earnedPoints = questions.reduce((sum, q) => {
-        const ans = answerMap.get(q.id);
-        if (!ans) return sum;
-        return sum + gradeAnswer(q, ans.answer).pointsEarned;
-      }, 0);
-      const scoreDisplay =
-        r.status === 'completed' && maxPoints > 0
-          ? `${Math.round((earnedPoints / maxPoints) * 100)}%`
-          : '';
-      return [
-        timestamp,
-        teacherName,
-        r.classPeriod ?? '',
-        resolveStudent(r),
-        r.pin ?? '',
-        r.status,
-        scoreDisplay,
-        formatExportPoints(earnedPoints),
-        String(maxPoints),
-        warnings,
-        submitted,
-        ...answerCols,
-      ];
-    });
-
-    dataRows.sort((a, b) => a[3].localeCompare(b[3]));
-    return { headers, dataRows };
+    return buildResultsSheetDataShared<QuizQuestion, QuizResponse>(
+      responses,
+      questions,
+      gradeAnswer,
+      options
+    );
   }
 
   /**
@@ -701,13 +621,21 @@ export class QuizDriveService {
       teacherName?: string;
       plcMode?: boolean;
       plcSheetUrl?: string;
+      /**
+       * Optional grader override. Defaults to Quiz's `gradeAnswer`. Video
+       * Activity passes `gradeVideoActivityAnswer` so MA / FIB-with-variants
+       * grade correctly in the export — Quiz's grader has no `'MA'` case
+       * and otherwise returns 0 points for those columns. Fixes the TODO
+       * PR2a left at `Results.tsx:170`.
+       */
+      gradeFn?: typeof gradeAnswer;
     }
   ): Promise<string> {
-    const { headers, dataRows } = this.buildResultsSheetData(
-      responses,
-      questions,
-      options
-    );
+    const gradeFn = options?.gradeFn ?? gradeAnswer;
+    const { headers, dataRows } = buildResultsSheetDataShared<
+      QuizQuestion,
+      QuizResponse
+    >(responses, questions, gradeFn, options);
 
     // PLC mode: append to existing shared sheet
     if (options?.plcMode) {
@@ -752,7 +680,7 @@ export class QuizDriveService {
         if (!q) continue;
 
         answeredSet.add(a.questionId);
-        if (gradeAnswer(q, a.answer).isCorrect) {
+        if (gradeFn(q, a.answer).isCorrect) {
           correctSet.add(a.questionId);
         }
       }

--- a/utils/videoActivityDriveService.ts
+++ b/utils/videoActivityDriveService.ts
@@ -1,0 +1,72 @@
+/**
+ * Video Activity Drive Service.
+ *
+ * Wraps the shared `buildResultsSheetData` helper from
+ * `assignmentExportShared.ts` with VA's grader (`gradeVideoActivityAnswer`)
+ * so MA / FIB-with-variants grade correctly in the export — Quiz's grader
+ * has no `'MA'` case and was returning 0 points for those columns (the
+ * TODO PR2a left at `Results.tsx:170`).
+ *
+ * Also handles the small response-shape adapter: VA tracks completion via
+ * `completedAt: number | null` (no separate `status` field), but the
+ * shared exporter expects `submittedAt` + `status`. We derive both from
+ * `completedAt` at the call site so consumers don't have to.
+ */
+
+import type { VideoActivityQuestion, VideoActivityResponse } from '@/types';
+import { gradeVideoActivityAnswer } from './videoActivityGrading';
+import {
+  buildResultsSheetData,
+  formatExportPoints,
+  type BuildResultsSheetDataOptions,
+  type ExportableResponse,
+} from './assignmentExportShared';
+
+/**
+ * Re-export so consumers don't have to know which file the helper lives
+ * in. PR3b lifted it into a shared module; the call sites just want
+ * "format export points" without caring where it comes from.
+ */
+export { formatExportPoints };
+
+/**
+ * Adapt a `VideoActivityResponse` to the `ExportableResponse` shape the
+ * shared exporter consumes. The mapping is:
+ *   completedAt: number → status: 'completed', submittedAt: completedAt
+ *   completedAt: null   → status: 'in-progress', submittedAt: null
+ *
+ * Pure function; safe to call inside .map().
+ */
+function toExportable(r: VideoActivityResponse): ExportableResponse {
+  return {
+    pin: r.pin,
+    studentUid: r.studentUid,
+    classPeriod: r.classPeriod,
+    answers: r.answers.map((a) => ({
+      questionId: a.questionId,
+      answer: a.answer,
+    })),
+    status: r.completedAt ? 'completed' : 'in-progress',
+    submittedAt: r.completedAt ?? null,
+    tabSwitchWarnings: r.tabSwitchWarnings,
+  };
+}
+
+/**
+ * Build the headers + data rows for a Video Activity results sheet.
+ * Mirrors `QuizDriveService.buildResultsSheetData` semantics — same
+ * column layout, same options shape — but uses VA's grader so MA and
+ * FIB-with-variants score correctly. Side-effect-free.
+ */
+export function buildVideoActivityResultsSheetData(
+  responses: VideoActivityResponse[],
+  questions: VideoActivityQuestion[],
+  options?: BuildResultsSheetDataOptions
+): { headers: string[]; dataRows: string[][] } {
+  return buildResultsSheetData<VideoActivityQuestion, ExportableResponse>(
+    responses.map(toExportable),
+    questions,
+    gradeVideoActivityAnswer,
+    options
+  );
+}

--- a/utils/videoActivityDriveService.ts
+++ b/utils/videoActivityDriveService.ts
@@ -35,9 +35,14 @@ export { formatExportPoints };
  *   completedAt: number → status: 'completed', submittedAt: completedAt
  *   completedAt: null   → status: 'in-progress', submittedAt: null
  *
+ * Uses an explicit `!== null` check rather than truthiness so a
+ * `completedAt: 0` (theoretical Jan 1 1970 timestamp; the type allows it)
+ * still maps to `'completed'`.
+ *
  * Pure function; safe to call inside .map().
  */
 function toExportable(r: VideoActivityResponse): ExportableResponse {
+  const completed = r.completedAt !== null;
   return {
     pin: r.pin,
     studentUid: r.studentUid,
@@ -46,8 +51,8 @@ function toExportable(r: VideoActivityResponse): ExportableResponse {
       questionId: a.questionId,
       answer: a.answer,
     })),
-    status: r.completedAt ? 'completed' : 'in-progress',
-    submittedAt: r.completedAt ?? null,
+    status: completed ? 'completed' : 'in-progress',
+    submittedAt: completed ? r.completedAt : null,
     tabSwitchWarnings: r.tabSwitchWarnings,
   };
 }

--- a/utils/videoActivityDriveService.ts
+++ b/utils/videoActivityDriveService.ts
@@ -14,13 +14,13 @@
  */
 
 import type { VideoActivityQuestion, VideoActivityResponse } from '@/types';
-import { gradeVideoActivityAnswer } from './videoActivityGrading';
+import { gradeVideoActivityAnswer } from '@/utils/videoActivityGrading';
 import {
   buildResultsSheetData,
   formatExportPoints,
   type BuildResultsSheetDataOptions,
   type ExportableResponse,
-} from './assignmentExportShared';
+} from '@/utils/assignmentExportShared';
 
 /**
  * Re-export so consumers don't have to know which file the helper lives


### PR DESCRIPTION
## Summary

Final PR in the Video Activity ↔ Quiz alignment series. After PR3c, VA reaches feature parity with Quiz across assignment options, student experience, creator UX, PLC sharing, exports, score publishing, and PLC results.

**Series recap (all merged before this):** PR1a/b (assignment-options + student-experience parity), PR2a/b (creator overhaul), PR3a (PLC sharing + sync-group foundation), PR3b (export refactor with `gradeFn` override).

## What's in PR3c

1. **Lift `PublishScoresModal`** → `components/common/library/PublishScoresModal.tsx`. Quiz Widget now imports from the shared location; the old QuizWidget copy is deleted. Visibility prop typed as the union of Quiz + VA visibility unions (structurally identical strings).

2. **Lift `PlcTab`** → `components/common/library/PlcTab.tsx`. Generalized the `questions` prop to a minimal `{ id; text }` shape so both Quiz and VA questions satisfy it. Both exporters write the same per-question cell convention (PR3b lifted `buildResultsSheetData`), so the aggregation logic works unchanged for VA.

3. **`useVideoActivityAssignments.publishAssignmentScores`** — mirrors `useQuizAssignments.publishAssignmentScores`. Grades every response via `gradeVideoActivityAnswer` (so MA / FIB-with-variants score correctly), writes `score` + per-answer `isCorrect`, and mirrors `scoreVisibility` + `scorePublishedAt` onto the assignment + session. The 'none' branch clears flags + wipes `revealedAnswers`; 'score-responses-and-answers' populates `revealedAnswers` so the student review screen can show canonical correct answers. Chunks across the 400-write batch limit.

4. **VA UI wiring** — Manager kebab gets "Publish scores" / "Update published scores" entry, Widget threads `publishingAssignment` state and the modal, Results gets a 4th tab "PLC" gated on `assignment.plc?.sheetUrl`.

5. **`useVideoActivity.attachSyncLinkage`** — mirrors `useQuiz.attachSyncLinkage`. Needed so the share-import flow can mark a freshly-imported VA as participating in a synced group. Idempotent.

6. **`/share/video-activity/{shareId}` URL routing** — `DashboardContext` parses the path into `pendingVideoActivityShareId`, `DashboardView` consumes it and dispatches `importSharedVideoActivityAssignment` in copy mode, then opens the VA widget to Active. Sync-mode picker UI deferred (peers can re-share if they want sync — the share doc carries the sync linkage either way).

## Out of scope (deferred)

- Sync-mode picker for VA shares (Quiz has `QuizAssignmentImportModeModal`; VA always copies for now, peers can re-share to sync).

## Test plan

- [x] `pnpm exec vitest run` — 2166/2166 passing (added VA mocks to `DashboardView.test.tsx` + `escapeInteraction.test.tsx`)
- [x] `pnpm run type-check` — clean
- [x] `pnpm exec eslint . --ignore-pattern remotion/ --max-warnings 0` — clean
- [ ] Manual: Open VA Manager kebab on an assignment with completed responses → "Publish scores" → modal opens with 3 levels → confirm → toast count matches response count → re-open kebab → label is now "Update published scores".
- [ ] Manual: Create a VA in PLC mode, run a few responses, view Results → 4th tab "PLC" appears → loads aggregate (avg, distribution, per-question accuracy) from the shared sheet.
- [ ] Manual: Share a VA assignment → copy URL → paste in another browser as a different teacher → toast "Shared video activity imported!" → VA widget opens to Active tab with paused assignment.
- [ ] Manual: Quiz publish flow + Quiz Results PLC tab still work (regression check on the lifts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)