### PR TITLE
fix(quiz,va): close attempt-cap bypass — defense-in-depth + cross-launch ledger + PIN→SSO unification

### DIFF
--- a/components/quiz/QuizStudentApp.tsx
+++ b/components/quiz/QuizStudentApp.tsx
@@ -504,8 +504,26 @@ const QuizJoinFlow: React.FC<{ isStudentRole: boolean }> = ({
     return <WaitingRoom session={session} pin={pin} />;
   }
 
-  // Active quiz
-  if (session.status === 'active' && myResponse?.status === 'completed') {
+  // Active quiz — already-completed gate.
+  //
+  // Two paths reach the wait screen instead of the question flow:
+  //   1. The student's response is `status: 'completed'` (normal post-submit).
+  //   2. The student is at or past the session's attempt cap, regardless of
+  //      the response's current status. This is defense in depth: if any
+  //      bug ever resets a capped response back to `'joined'` (e.g. a stale
+  //      counter, a partial finalize, a future refactor that changes the
+  //      reset path), the UI still refuses to render the questions. The
+  //      `completeQuiz` transaction blocks a second submit too, but a
+  //      student briefly seeing a question they can't submit would be
+  //      confusing — short-circuiting at the UI is the cleaner UX.
+  const attemptLimit = session.attemptLimit ?? null;
+  const completedCount = myResponse?.completedAttempts ?? 0;
+  const atCap = attemptLimit !== null && completedCount >= attemptLimit;
+  if (
+    session.status === 'active' &&
+    myResponse &&
+    (myResponse.status === 'completed' || atCap)
+  ) {
     return (
       <QuizSubmittedWaitScreen
         session={session}

--- a/components/videoActivity/VideoActivityStudentApp.tsx
+++ b/components/videoActivity/VideoActivityStudentApp.tsx
@@ -512,8 +512,20 @@ const JoinAndPlay: React.FC<JoinAndPlayProps> = ({
   }
 
   // ── Completion screen ─────────────────────────────────────────────────────
-
-  if (videoEnded || myResponse?.completedAt) {
+  //
+  // Defense-in-depth gate: in addition to the existing video-ended /
+  // completedAt triggers, also short-circuit to the completion screen when
+  // the student is at or past the session's attempt cap, regardless of the
+  // response's `completedAt` state. The join hook resets `completedAt: null`
+  // when a student rejoins under the cap, and throws AttemptLimitReached
+  // when at/over it — so this branch is normally redundant. It exists so a
+  // future bug or stale snapshot that leaves a capped response in
+  // `completedAt: null` state can't leak the question UI back to the
+  // student.
+  const attemptLimit = session?.sessionOptions?.attemptLimit ?? null;
+  const completedCount = myResponse?.completedAttempts ?? 0;
+  const atCap = attemptLimit !== null && completedCount >= attemptLimit;
+  if (videoEnded || myResponse?.completedAt || atCap) {
     const answeredCount = myResponse?.answers.length ?? 0;
     const totalQuestions = session?.questions.length ?? 0;
     // Derive correctness via the shared grader so MA / FIB-variants /

--- a/firestore.rules
+++ b/firestore.rules
@@ -1634,7 +1634,17 @@ service cloud.firestore {
     // (atomic with the response delete) — see Phase 2 in the
     // attempt-cap fix branch.
     match /quiz_attempt_ledger/{ledgerId} {
+      // `resource == null` short-circuit lets the student-app join flow
+      // call getDoc() to probe whether a ledger entry exists before
+      // deciding to create it on first completion — without it, the
+      // rules engine throws a Null-value error on
+      // `resource.data.teacherUid` and the read is denied. Mirrors the
+      // response read rule pattern. The student's pseudonym uid is an
+      // opaque HMAC (computed in `studentLoginV1`), so probing another
+      // student's path is not realistically possible without already
+      // knowing that student's uid.
       allow read: if request.auth != null && (
+        resource == null ||
         isAdmin() ||
         request.auth.uid == resource.data.teacherUid ||
         request.auth.uid == resource.data.studentUid
@@ -1685,7 +1695,10 @@ service cloud.firestore {
     // Video Activity Attempt Ledger — same shape as the Quiz ledger.
     // Doc id: `${activityId}__${studentUid}`.
     match /video_activity_attempt_ledger/{ledgerId} {
+      // See `quiz_attempt_ledger` above for the `resource == null`
+      // rationale — same pattern, same threat model.
       allow read: if request.auth != null && (
+        resource == null ||
         isAdmin() ||
         request.auth.uid == resource.data.teacherUid ||
         request.auth.uid == resource.data.studentUid

--- a/firestore.rules
+++ b/firestore.rules
@@ -1604,6 +1604,104 @@ service cloud.firestore {
       }
     }
 
+    // Quiz Attempt Ledger — top-level, cross-launch attempt counter per
+    // (quiz, student). See `QuizAttemptLedger` in types.ts and
+    // `QUIZ_ATTEMPT_LEDGER_COLLECTION` in `useQuizSession.ts` for the
+    // rationale. The doc id is `${quizId}__${studentUid}`; the
+    // `studentUid` field on the doc must equal the student's auth uid
+    // (the rules can't decompose the doc id back into its halves).
+    //
+    // Ledger writes happen only inside the `completeQuiz` transaction
+    // alongside the response status flip, so the rules' append-only
+    // invariant on `completedAttempts` is the last line of defense
+    // against a hostile or buggy client trying to roll the counter
+    // back. The teacher's `removeStudent` action deletes the ledger
+    // (atomic with the response delete) — see Phase 2 in the
+    // attempt-cap fix branch.
+    match /quiz_attempt_ledger/{ledgerId} {
+      allow read: if request.auth != null && (
+        isAdmin() ||
+        request.auth.uid == resource.data.teacherUid ||
+        request.auth.uid == resource.data.studentUid
+      );
+      // Student creates their own ledger entry on first completion.
+      // Constraints mirror the response create rule shape:
+      //   - studentUid field must equal the caller's auth uid
+      //   - completedAttempts must initialize to exactly 1 (not 0 — a
+      //     ledger entry only exists once the first completion has
+      //     occurred, and not >1 — a fresh entry shouldn't be able to
+      //     forge prior history)
+      //   - identity fields must be present and well-typed
+      allow create: if request.auth != null &&
+        request.resource.data.studentUid == request.auth.uid &&
+        request.resource.data.completedAttempts == 1 &&
+        request.resource.data.quizId is string &&
+        request.resource.data.teacherUid is string &&
+        request.resource.data.lastAttemptAt is number;
+      // Update is split into a STUDENT branch (monotonic increment via
+      // their own completeQuiz transaction) and a TEACHER branch (reset
+      // to 0). Identity fields are immutable on both.
+      allow update: if request.auth != null && (
+        // Student branch — increment by exactly 1.
+        (request.auth.uid == resource.data.studentUid &&
+         request.resource.data.studentUid == resource.data.studentUid &&
+         request.resource.data.quizId == resource.data.quizId &&
+         request.resource.data.teacherUid == resource.data.teacherUid &&
+         request.resource.data.completedAttempts == resource.data.completedAttempts + 1 &&
+         request.resource.data.lastAttemptAt is number)
+        ||
+        // Teacher reset branch — set completedAttempts back to 0.
+        (request.auth.uid == resource.data.teacherUid &&
+         request.resource.data.studentUid == resource.data.studentUid &&
+         request.resource.data.quizId == resource.data.quizId &&
+         request.resource.data.teacherUid == resource.data.teacherUid &&
+         request.resource.data.completedAttempts == 0)
+        ||
+        isAdmin()
+      );
+      // Owning teacher (or admin) may delete the entry — used by the
+      // teacher monitor's "Reset student" action. The student cannot
+      // delete (they'd be able to wipe their own cap).
+      allow delete: if request.auth != null && (
+        request.auth.uid == resource.data.teacherUid || isAdmin()
+      );
+    }
+
+    // Video Activity Attempt Ledger — same shape as the Quiz ledger.
+    // Doc id: `${activityId}__${studentUid}`.
+    match /video_activity_attempt_ledger/{ledgerId} {
+      allow read: if request.auth != null && (
+        isAdmin() ||
+        request.auth.uid == resource.data.teacherUid ||
+        request.auth.uid == resource.data.studentUid
+      );
+      allow create: if request.auth != null &&
+        request.resource.data.studentUid == request.auth.uid &&
+        request.resource.data.completedAttempts == 1 &&
+        request.resource.data.activityId is string &&
+        request.resource.data.teacherUid is string &&
+        request.resource.data.lastAttemptAt is number;
+      allow update: if request.auth != null && (
+        (request.auth.uid == resource.data.studentUid &&
+         request.resource.data.studentUid == resource.data.studentUid &&
+         request.resource.data.activityId == resource.data.activityId &&
+         request.resource.data.teacherUid == resource.data.teacherUid &&
+         request.resource.data.completedAttempts == resource.data.completedAttempts + 1 &&
+         request.resource.data.lastAttemptAt is number)
+        ||
+        (request.auth.uid == resource.data.teacherUid &&
+         request.resource.data.studentUid == resource.data.studentUid &&
+         request.resource.data.activityId == resource.data.activityId &&
+         request.resource.data.teacherUid == resource.data.teacherUid &&
+         request.resource.data.completedAttempts == 0)
+        ||
+        isAdmin()
+      );
+      allow delete: if request.auth != null && (
+        request.auth.uid == resource.data.teacherUid || isAdmin()
+      );
+    }
+
     // Announcements - all authenticated users can read, only admins can create/update/delete
     match /announcements/{announcementId} {
       allow read: if request.auth != null;

--- a/firestore.rules
+++ b/firestore.rules
@@ -411,6 +411,21 @@ service cloud.firestore {
     // Rosters - users can only access their own rosters in their subcollection
     match /users/{userId}/rosters/{rosterId} {
       allow read, write: if request.auth != null && request.auth.uid == userId;
+
+      // Phase 3 — non-PII PIN index sidecar. Bridges PIN-joining
+      // students into the SSO uid space via `pinLoginV1`. The cloud
+      // function `commitRosterPinIndexV1` writes these via the admin
+      // SDK (rules-bypass), and `pinLoginV1` reads them via the admin
+      // SDK as well. Clients have NO write path here — the data is
+      // load-bearing for cap enforcement and a hostile teacher-uid
+      // claim would otherwise let them rewrite their own pseudonym
+      // mapping. Admin reads are allowed for support / debugging;
+      // students never touch this collection directly.
+      match /pin_index/{indexKey} {
+        allow read: if request.auth != null &&
+          (request.auth.uid == userId || isAdmin());
+        allow write: if false;
+      }
     }
 
     // PLC Overview layout — per-user customization of the PLC Dashboard

--- a/firestore.rules
+++ b/firestore.rules
@@ -1454,6 +1454,13 @@ service cloud.firestore {
         function sessionMode() {
           return get(/databases/$(database)/documents/quiz_sessions/$(sessionId)).data.get('mode', 'submissions');
         }
+        // Server-side attempt cap. The client also enforces this in the
+        // join + submit transactions; the rule is the last line of defense
+        // against a race, a buggy client, or a hostile caller. Returns
+        // null when the session has no cap (legacy or explicitly unlimited).
+        function sessionAttemptLimit() {
+          return get(/databases/$(database)/documents/quiz_sessions/$(sessionId)).data.get('attemptLimit', null);
+        }
 
         // Student branch allows `resource == null` so the student-app join
         // flow can call getDoc() to probe whether a response already exists
@@ -1553,7 +1560,22 @@ service cloud.firestore {
            (!request.resource.data.diff(resource.data).affectedKeys().hasAny(['tabSwitchWarnings']) ||
             request.resource.data.tabSwitchWarnings >= resource.data.get('tabSwitchWarnings', 0)) &&
            (!request.resource.data.diff(resource.data).affectedKeys().hasAny(['completedAttempts']) ||
-            request.resource.data.get('completedAttempts', 0) >= resource.data.get('completedAttempts', 0)))
+            request.resource.data.get('completedAttempts', 0) >= resource.data.get('completedAttempts', 0)) &&
+           // Attempt-cap enforcement. completedAttempts may not exceed the
+           // session's attemptLimit. attemptLimit == null means unlimited.
+           // Without this rule a hostile client could call completeQuiz N
+           // times and increment the counter past the cap.
+           (sessionAttemptLimit() == null ||
+            request.resource.data.get('completedAttempts', 0) <= sessionAttemptLimit()) &&
+           // Status-transition gate: students cannot re-complete an
+           // already-completed response. Submitting transitions
+           // 'joined'/'in-progress' → 'completed'; rejoining-under-cap
+           // transitions 'completed' → 'joined' (still allowed by this
+           // rule because the new status is not 'completed'). The case
+           // this blocks is 'completed' → 'completed', which only happens
+           // via a race or bug.
+           (resource.data.get('status', '') != 'completed' ||
+            request.resource.data.get('status', '') != 'completed'))
         );
         allow delete: if request.auth != null &&
           (request.auth.uid == sessionTeacherUid() || isAdmin());
@@ -1704,6 +1726,13 @@ service cloud.firestore {
         function vaSessionMode() {
           return get(/databases/$(database)/documents/video_activity_sessions/$(sessionId)).data.get('mode', 'submissions');
         }
+        // Server-side attempt cap. attemptLimit lives nested under
+        // sessionOptions on VideoActivitySession. Pre-PR1 sessions have no
+        // sessionOptions field at all; we tolerate that with the default
+        // empty map. Returns null when the session has no cap.
+        function vaSessionAttemptLimit() {
+          return get(/databases/$(database)/documents/video_activity_sessions/$(sessionId)).data.get('sessionOptions', {}).get('attemptLimit', null);
+        }
 
         // Student branch allows `resource == null` so the student-app join
         // flow can call getDoc() to probe whether a response already exists
@@ -1778,12 +1807,34 @@ service cloud.firestore {
               'classPeriod'
             ]) &&
             request.resource.data.answers is list &&
-            request.resource.data.answers.size() >= resource.data.answers.size() &&
-            request.resource.data.answers.hasAll(resource.data.answers) &&
+            // Append-only on answers, EXCEPT during a rejoin-reset for a
+            // new attempt under the cap. The reset path writes
+            // `completedAt: null` on a doc whose prior `completedAt` was
+            // non-null, signaling a fresh attempt; in that single case
+            // answers may be cleared to []. Otherwise the legacy
+            // append-only invariant holds (prevents a mid-attempt
+            // student from rolling back their answers).
+            ((resource.data.get('completedAt', null) != null &&
+              request.resource.data.get('completedAt', null) == null &&
+              request.resource.data.answers.size() == 0) ||
+             (request.resource.data.answers.size() >= resource.data.answers.size() &&
+              request.resource.data.answers.hasAll(resource.data.answers))) &&
             (!request.resource.data.diff(resource.data).affectedKeys().hasAny(['tabSwitchWarnings']) ||
              request.resource.data.tabSwitchWarnings >= resource.data.get('tabSwitchWarnings', 0)) &&
             (!request.resource.data.diff(resource.data).affectedKeys().hasAny(['completedAttempts']) ||
-             request.resource.data.get('completedAttempts', 0) >= resource.data.get('completedAttempts', 0))
+             request.resource.data.get('completedAttempts', 0) >= resource.data.get('completedAttempts', 0)) &&
+            // Attempt-cap enforcement — last line of defense behind the
+            // client-side join + completeActivity transactions.
+            (vaSessionAttemptLimit() == null ||
+             request.resource.data.get('completedAttempts', 0) <= vaSessionAttemptLimit()) &&
+            // completedAt transition gate: students cannot write a new
+            // non-null completedAt when the prior completedAt was already
+            // non-null. Legit completion goes null → non-null;
+            // rejoin-under-cap goes non-null → null. The case this
+            // blocks is non-null → non-null, which only happens via a
+            // race or bug.
+            (resource.data.get('completedAt', null) == null ||
+             request.resource.data.get('completedAt', null) == null)
           )
         );
         // Owning teacher (or admin) may delete responses when permanently

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -3725,6 +3725,14 @@ export const commitRosterPinIndexV1 = onCall(
       rosterData.classlinkClassId.length > 0
         ? rosterData.classlinkClassId
         : null;
+    // Optional on the roster doc; empty-string default keeps the
+    // pin_index entry shape stable so `pinLoginV1` can read a string
+    // field unconditionally. Stored alongside `classId` so the login
+    // path doesn't need a `collectionGroup` lookup to recover orgId.
+    const classlinkOrgId =
+      typeof rosterData.classlinkOrgId === 'string'
+        ? rosterData.classlinkOrgId
+        : '';
     if (!classlinkClassId) {
       // Local rosters have no ClassLink class id and so can't bridge into
       // the SSO uid space. Returning success (with `wrote: 0`) keeps the
@@ -3744,6 +3752,7 @@ export const commitRosterPinIndexV1 = onCall(
       {
         pseudonym: string;
         classId: string;
+        orgId: string;
         period: string;
         updatedAt: number;
       }
@@ -3755,6 +3764,7 @@ export const commitRosterPinIndexV1 = onCall(
       desired.set(key, {
         pseudonym: computeStudentUid(entry.classlinkSourcedId, hmacSecret),
         classId: classlinkClassId,
+        orgId: classlinkOrgId,
         period: entry.period,
         updatedAt: now,
       });
@@ -3905,32 +3915,50 @@ export const pinLoginV1 = onCall(
 
     const indexKey = pinIndexKey(period, pin);
 
-    // Probe each roster's pin_index for the indexKey. A multi-class
-    // session (multiple rosters) will typically have only one match
-    // because PIN+encoded-period uniquely identifies a student in
-    // practice. If multiple rosters happen to match (PIN collision
-    // across periods with a missing/default period), prefer the first
-    // hit — same behavior the legacy PIN response-key resolution
-    // documents at `quizScoreboard.ts` `resolvePinName`.
-    let matched: { pseudonym: string; classId: string } | null = null;
-    for (const rosterId of rosterIds) {
-      const indexRef = db
+    // Probe each roster's pin_index for the indexKey IN PARALLEL.
+    // PIN-bridged join is on the hot path of every PIN-joining student,
+    // and a multi-class session (multiple rosters) would otherwise
+    // serialize one .get() per roster. Fan-out is bounded by
+    // STUDENT_LOGIN_CLASS_IDS_MAX-style sizing on the client side
+    // (rosterIds is teacher-authored and small in practice).
+    //
+    // A multi-class session will typically have only one match because
+    // PIN + encoded-period uniquely identifies a student. If multiple
+    // rosters happen to match (PIN collision across periods with a
+    // missing/default period), prefer the first hit by rosterIds order
+    // — same behavior the legacy PIN response-key resolution documents
+    // at `quizScoreboard.ts` `resolvePinName`.
+    //
+    // `orgId` lives directly on the index entry (Phase 3 review fix),
+    // so the login path is a single doc read per roster instead of an
+    // additional `collectionGroup('rosters').where('classlinkClassId'…)`
+    // scan to recover org metadata.
+    const indexRefs = rosterIds.map((rosterId) =>
+      db
         .collection('users')
         .doc(teacherUid)
         .collection('rosters')
         .doc(rosterId)
         .collection(PIN_INDEX_SUBCOLLECTION)
-        .doc(indexKey);
-      const indexSnap = await indexRef.get();
-      if (indexSnap.exists) {
-        const entry = indexSnap.data() ?? {};
-        const pseudonym =
-          typeof entry.pseudonym === 'string' ? entry.pseudonym : '';
-        const classId = typeof entry.classId === 'string' ? entry.classId : '';
-        if (pseudonym && classId) {
-          matched = { pseudonym, classId };
-          break;
-        }
+        .doc(indexKey)
+    );
+    const indexSnaps = await Promise.all(indexRefs.map((ref) => ref.get()));
+
+    let matched: {
+      pseudonym: string;
+      classId: string;
+      orgId: string;
+    } | null = null;
+    for (const indexSnap of indexSnaps) {
+      if (!indexSnap.exists) continue;
+      const entry = indexSnap.data() ?? {};
+      const pseudonym =
+        typeof entry.pseudonym === 'string' ? entry.pseudonym : '';
+      const classId = typeof entry.classId === 'string' ? entry.classId : '';
+      const orgId = typeof entry.orgId === 'string' ? entry.orgId : '';
+      if (pseudonym && classId) {
+        matched = { pseudonym, classId, orgId };
+        break;
       }
     }
 
@@ -3938,32 +3966,11 @@ export const pinLoginV1 = onCall(
       return { matched: false, reason: 'no-index-entry' };
     }
 
-    // Recover orgId from the matched roster for the token claim. Best-
-    // effort — the response-rule class gate uses classIds, not orgId,
-    // so an empty orgId is harmless for cap enforcement (only
-    // surfaces in the classlink directory UI).
-    let orgId = '';
-    try {
-      const orgRosterSnap = await db
-        .collectionGroup('rosters')
-        .where('classlinkClassId', '==', matched.classId)
-        .limit(1)
-        .get();
-      if (!orgRosterSnap.empty) {
-        const orgIdMaybe = (
-          orgRosterSnap.docs[0].data() as { classlinkOrgId?: unknown }
-        ).classlinkOrgId;
-        if (typeof orgIdMaybe === 'string') orgId = orgIdMaybe;
-      }
-    } catch (err) {
-      console.warn('[pinLoginV1] orgId lookup failed:', err);
-    }
-
     let customToken: string;
     try {
       customToken = await admin.auth().createCustomToken(matched.pseudonym, {
         studentRole: true,
-        orgId,
+        orgId: matched.orgId,
         classIds: [matched.classId],
       });
     } catch (err) {

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -3567,3 +3567,391 @@ export const getPseudonymsForAssignmentV1 = onCall(
     }
   }
 );
+
+// ─── PIN → SSO identity unification (Phase 3) ────────────────────────────────
+//
+// `pinLoginV1` lets a PIN-joining student authenticate with a custom token
+// whose uid is the same HMAC pseudonym `studentLoginV1` would mint for them
+// if they came in via SSO. Once they sign in with that token, the per-session
+// response doc keys by their `auth.uid` (= the SSO uid), so a student who
+// joins one launch via SSO and another via PIN converges on the same response
+// doc and the per-session attempt cap holds across both auth paths.
+//
+// `commitRosterPinIndexV1` is the teacher-side companion: when a teacher saves
+// a ClassLink-origin roster, the client posts the (period, pin, sourcedId)
+// tuples and this function writes the non-PII pin_index sidecar that
+// pinLoginV1 reads. PII (names, emails) never leaves Drive — the index holds
+// only opaque hashes and ids.
+
+const PIN_INDEX_SUBCOLLECTION = 'pin_index';
+const PIN_INDEX_MAX_ENTRIES = 200;
+
+/**
+ * Mirror of `encodeResponseKeySegment` in `useQuizSession.ts`. Duplicated
+ * server-side rather than imported because the functions package has its own
+ * tsconfig + emit and the client hook lives outside it. The client + server
+ * encoders MUST stay in lockstep — a divergence would produce mismatched
+ * `indexKey`s and silently break the PIN→SSO lookup.
+ */
+function encodeResponseKeySegment(value: string | undefined): string {
+  const trimmed = (value ?? '').trim();
+  if (!trimmed) return 'default';
+  const normalized = trimmed.toLowerCase().replace(/[^a-z0-9]+/g, '_');
+  const stripped = normalized.replace(/^_+|_+$/g, '');
+  return stripped || 'default';
+}
+
+function pinIndexKey(period: string, pin: string): string {
+  return `${encodeResponseKeySegment(period)}__${encodeResponseKeySegment(pin)}`;
+}
+
+interface CommitRosterPinIndexEntry {
+  period: string;
+  pin: string;
+  classlinkSourcedId: string;
+}
+
+/**
+ * commitRosterPinIndexV1
+ *
+ * Input:
+ *   {
+ *     rosterId: string,
+ *     entries: Array<{ period, pin, classlinkSourcedId }>
+ *   }
+ *
+ * The caller MUST be the teacher who owns the roster (the function checks
+ * `users/{auth.uid}/rosters/{rosterId}` exists). The full set of entries
+ * replaces the existing pin_index for the roster — entries dropped from the
+ * input list have their corresponding index docs deleted in the same batch,
+ * so a student removed from the roster automatically loses their
+ * pin_index entry.
+ *
+ * The function reads the roster doc to recover `classlinkClassId` (used as
+ * the index entry's `classId`) and `classlinkOrgId` (used for telemetry —
+ * not written into the index). Only ClassLink-origin rosters with a
+ * `classlinkClassId` produce an index; legacy local rosters skip silently
+ * (no error) so the client's "build the index after every save" hook is
+ * idempotent across both kinds.
+ */
+export const commitRosterPinIndexV1 = onCall(
+  {
+    memory: '256MiB',
+    secrets: [STUDENT_PSEUDONYM_HMAC_SECRET],
+    invoker: 'public',
+  },
+  async (request) => {
+    if (!request.auth) {
+      throw new HttpsError('unauthenticated', 'Sign in required.');
+    }
+    // Students cannot rebuild a teacher's index. The client-side caller is
+    // always the teacher who saved the roster.
+    if (request.auth.token.studentRole === true) {
+      throw new HttpsError('permission-denied', 'Teacher role required.');
+    }
+
+    const rawData = (request.data ?? {}) as {
+      rosterId?: unknown;
+      entries?: unknown;
+    };
+    const rosterId =
+      typeof rawData.rosterId === 'string' ? rawData.rosterId : '';
+    if (!rosterId) {
+      throw new HttpsError('invalid-argument', 'rosterId is required.');
+    }
+    if (!Array.isArray(rawData.entries)) {
+      throw new HttpsError('invalid-argument', 'entries must be an array.');
+    }
+    if (rawData.entries.length > PIN_INDEX_MAX_ENTRIES) {
+      throw new HttpsError(
+        'invalid-argument',
+        `entries exceeds the max of ${PIN_INDEX_MAX_ENTRIES}.`
+      );
+    }
+
+    const entries: CommitRosterPinIndexEntry[] = [];
+    for (const e of rawData.entries) {
+      if (typeof e !== 'object' || e === null) continue;
+      const period = (e as { period?: unknown }).period;
+      const pin = (e as { pin?: unknown }).pin;
+      const sourcedId = (e as { classlinkSourcedId?: unknown })
+        .classlinkSourcedId;
+      if (
+        typeof period !== 'string' ||
+        typeof pin !== 'string' ||
+        typeof sourcedId !== 'string' ||
+        period.length === 0 ||
+        pin.length === 0 ||
+        sourcedId.length === 0
+      ) {
+        // Skip malformed entries; don't fail the whole rebuild.
+        continue;
+      }
+      entries.push({ period, pin, classlinkSourcedId: sourcedId });
+    }
+
+    const hmacSecret = STUDENT_PSEUDONYM_HMAC_SECRET.value();
+    if (!hmacSecret) {
+      throw new HttpsError('internal', 'Server configuration missing.');
+    }
+
+    const db = admin.firestore();
+    const rosterRef = db
+      .collection('users')
+      .doc(request.auth.uid)
+      .collection('rosters')
+      .doc(rosterId);
+    const rosterSnap = await rosterRef.get();
+    if (!rosterSnap.exists) {
+      throw new HttpsError('not-found', 'Roster not found.');
+    }
+    const rosterData = rosterSnap.data() ?? {};
+    const classlinkClassId =
+      typeof rosterData.classlinkClassId === 'string' &&
+      rosterData.classlinkClassId.length > 0
+        ? rosterData.classlinkClassId
+        : null;
+    if (!classlinkClassId) {
+      // Local rosters have no ClassLink class id and so can't bridge into
+      // the SSO uid space. Returning success (with `wrote: 0`) keeps the
+      // client's "save then commit index" hook idempotent across roster
+      // types — it doesn't have to special-case origin.
+      return { wrote: 0, deleted: 0, skippedReason: 'no-classlink-class-id' };
+    }
+
+    // Compute the desired set of (indexKey -> doc payload) tuples.
+    const desired = new Map<
+      string,
+      {
+        pseudonym: string;
+        classId: string;
+        period: string;
+        updatedAt: number;
+      }
+    >();
+    const now = Date.now();
+    for (const entry of entries) {
+      const key = pinIndexKey(entry.period, entry.pin);
+      // Last-write-wins on intra-batch dupes (same encoded period+pin).
+      desired.set(key, {
+        pseudonym: computeStudentUid(entry.classlinkSourcedId, hmacSecret),
+        classId: classlinkClassId,
+        period: entry.period,
+        updatedAt: now,
+      });
+    }
+
+    // Read the current index so we know which docs to delete (entries that
+    // existed before but are not in `desired`). Bounded by
+    // PIN_INDEX_MAX_ENTRIES via `.limit()` — a roster with more entries
+    // would have been rejected on the input side already.
+    const pinIndexCollection = rosterRef.collection(PIN_INDEX_SUBCOLLECTION);
+    const existingSnap = await pinIndexCollection
+      .limit(PIN_INDEX_MAX_ENTRIES + 1)
+      .get();
+
+    const batch = db.batch();
+    let deleted = 0;
+    for (const docSnap of existingSnap.docs) {
+      if (!desired.has(docSnap.id)) {
+        batch.delete(docSnap.ref);
+        deleted++;
+      }
+    }
+
+    let wrote = 0;
+    for (const [key, payload] of desired) {
+      batch.set(pinIndexCollection.doc(key), payload);
+      wrote++;
+    }
+
+    await batch.commit();
+    return { wrote, deleted };
+  }
+);
+
+interface PinLoginRequestData {
+  kind?: unknown;
+  sessionId?: unknown;
+  code?: unknown;
+  pin?: unknown;
+  period?: unknown;
+}
+
+/**
+ * pinLoginV1
+ *
+ * Input:
+ *   {
+ *     kind: 'quiz' | 'video-activity',
+ *     sessionId?: string,    // required for video-activity
+ *     code?: string,         // required for quiz
+ *     pin: string,
+ *     period?: string,       // optional, picks one when the session has
+ *                            // multiple rosters and the pin is ambiguous
+ *   }
+ *
+ * Resolves the (session, period, pin) tuple to a roster-bound student
+ * identity by reading the teacher's pin_index sidecar (built by
+ * `commitRosterPinIndexV1`). On success returns a custom token whose uid
+ * matches the same HMAC pseudonym `studentLoginV1` would mint for that
+ * student over SSO, plus `studentRole: true` and `classIds: [classId]`
+ * so the student passes the response-rule class gate.
+ *
+ * On no-match returns `{ matched: false }` so the client can fall back
+ * to the existing anonymous PIN flow (legacy non-rostered sessions, or
+ * rosters whose index hasn't been built yet).
+ *
+ * No PII logging — only class-of-failure counters.
+ */
+export const pinLoginV1 = onCall(
+  {
+    memory: '256MiB',
+    secrets: [STUDENT_PSEUDONYM_HMAC_SECRET],
+    invoker: 'public',
+  },
+  async (request) => {
+    const data = (request.data ?? {}) as PinLoginRequestData;
+    const kind =
+      data.kind === 'quiz' || data.kind === 'video-activity' ? data.kind : null;
+    const pin = typeof data.pin === 'string' ? data.pin.trim() : '';
+    const period = typeof data.period === 'string' ? data.period : '';
+    if (!kind) {
+      throw new HttpsError('invalid-argument', 'kind is required.');
+    }
+    if (!pin) {
+      throw new HttpsError('invalid-argument', 'pin is required.');
+    }
+
+    const db = admin.firestore();
+
+    // Resolve the session.
+    let sessionRef: admin.firestore.DocumentReference;
+    if (kind === 'quiz') {
+      const code =
+        typeof data.code === 'string'
+          ? data.code
+              .trim()
+              .replace(/[^a-zA-Z0-9]/g, '')
+              .toUpperCase()
+          : '';
+      if (!code) {
+        throw new HttpsError('invalid-argument', 'code is required for quiz.');
+      }
+      const codeMatch = await db
+        .collection('quiz_sessions')
+        .where('code', '==', code)
+        .limit(5)
+        .get();
+      const joinable = codeMatch.docs.find((d) => {
+        const s = (d.data() as { status?: unknown }).status;
+        return s === 'waiting' || s === 'active' || s === 'paused';
+      });
+      if (!joinable) {
+        return { matched: false, reason: 'no-joinable-session' };
+      }
+      sessionRef = joinable.ref;
+    } else {
+      const sessionId =
+        typeof data.sessionId === 'string' ? data.sessionId : '';
+      if (!sessionId) {
+        throw new HttpsError(
+          'invalid-argument',
+          'sessionId is required for video-activity.'
+        );
+      }
+      sessionRef = db.collection('video_activity_sessions').doc(sessionId);
+    }
+
+    const sessionSnap = await sessionRef.get();
+    if (!sessionSnap.exists) {
+      return { matched: false, reason: 'session-not-found' };
+    }
+    const sessionData = sessionSnap.data() ?? {};
+    const teacherUid =
+      typeof sessionData.teacherUid === 'string' ? sessionData.teacherUid : '';
+    if (!teacherUid) {
+      return { matched: false, reason: 'session-missing-teacher' };
+    }
+    const rosterIds = Array.isArray(sessionData.rosterIds)
+      ? sessionData.rosterIds.filter(
+          (r: unknown): r is string => typeof r === 'string' && r.length > 0
+        )
+      : [];
+    if (rosterIds.length === 0) {
+      // No roster on the session — can't bridge. Fall through to the
+      // legacy anonymous PIN flow on the client.
+      return { matched: false, reason: 'no-rosters-on-session' };
+    }
+
+    const indexKey = pinIndexKey(period, pin);
+
+    // Probe each roster's pin_index for the indexKey. A multi-class
+    // session (multiple rosters) will typically have only one match
+    // because PIN+encoded-period uniquely identifies a student in
+    // practice. If multiple rosters happen to match (PIN collision
+    // across periods with a missing/default period), prefer the first
+    // hit — same behavior the legacy PIN response-key resolution
+    // documents at `quizScoreboard.ts` `resolvePinName`.
+    let matched: { pseudonym: string; classId: string } | null = null;
+    for (const rosterId of rosterIds) {
+      const indexRef = db
+        .collection('users')
+        .doc(teacherUid)
+        .collection('rosters')
+        .doc(rosterId)
+        .collection(PIN_INDEX_SUBCOLLECTION)
+        .doc(indexKey);
+      const indexSnap = await indexRef.get();
+      if (indexSnap.exists) {
+        const entry = indexSnap.data() ?? {};
+        const pseudonym =
+          typeof entry.pseudonym === 'string' ? entry.pseudonym : '';
+        const classId = typeof entry.classId === 'string' ? entry.classId : '';
+        if (pseudonym && classId) {
+          matched = { pseudonym, classId };
+          break;
+        }
+      }
+    }
+
+    if (!matched) {
+      return { matched: false, reason: 'no-index-entry' };
+    }
+
+    // Recover orgId from the matched roster for the token claim. Best-
+    // effort — the response-rule class gate uses classIds, not orgId,
+    // so an empty orgId is harmless for cap enforcement (only
+    // surfaces in the classlink directory UI).
+    let orgId = '';
+    try {
+      const orgRosterSnap = await db
+        .collectionGroup('rosters')
+        .where('classlinkClassId', '==', matched.classId)
+        .limit(1)
+        .get();
+      if (!orgRosterSnap.empty) {
+        const orgIdMaybe = (
+          orgRosterSnap.docs[0].data() as { classlinkOrgId?: unknown }
+        ).classlinkOrgId;
+        if (typeof orgIdMaybe === 'string') orgId = orgIdMaybe;
+      }
+    } catch (err) {
+      console.warn('[pinLoginV1] orgId lookup failed:', err);
+    }
+
+    let customToken: string;
+    try {
+      customToken = await admin.auth().createCustomToken(matched.pseudonym, {
+        studentRole: true,
+        orgId,
+        classIds: [matched.classId],
+      });
+    } catch (err) {
+      console.error('[pinLoginV1] createCustomToken failed:', err);
+      throw new HttpsError('internal', 'Failed to mint auth token.');
+    }
+
+    return { matched: true, customToken };
+  }
+);

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -3670,8 +3670,12 @@ export const commitRosterPinIndexV1 = onCall(
     }
 
     const entries: CommitRosterPinIndexEntry[] = [];
+    let skippedMalformed = 0;
     for (const e of rawData.entries) {
-      if (typeof e !== 'object' || e === null) continue;
+      if (typeof e !== 'object' || e === null) {
+        skippedMalformed++;
+        continue;
+      }
       const period = (e as { period?: unknown }).period;
       const pin = (e as { pin?: unknown }).pin;
       const sourcedId = (e as { classlinkSourcedId?: unknown })
@@ -3684,10 +3688,20 @@ export const commitRosterPinIndexV1 = onCall(
         pin.length === 0 ||
         sourcedId.length === 0
       ) {
-        // Skip malformed entries; don't fail the whole rebuild.
+        // Skip malformed entries; don't fail the whole rebuild. Counted
+        // and surfaced in the response so the client can warn the
+        // teacher when one student's row is silently dropped (a typo'd
+        // ClassLink id otherwise produces an unindexed student who
+        // bypasses the cross-launch cap on legacy PIN).
+        skippedMalformed++;
         continue;
       }
       entries.push({ period, pin, classlinkSourcedId: sourcedId });
+    }
+    if (skippedMalformed > 0) {
+      console.warn(
+        `[commitRosterPinIndexV1] Skipped ${skippedMalformed} malformed entries in roster ${rosterId}`
+      );
     }
 
     const hmacSecret = STUDENT_PSEUDONYM_HMAC_SECRET.value();
@@ -3716,7 +3730,12 @@ export const commitRosterPinIndexV1 = onCall(
       // the SSO uid space. Returning success (with `wrote: 0`) keeps the
       // client's "save then commit index" hook idempotent across roster
       // types — it doesn't have to special-case origin.
-      return { wrote: 0, deleted: 0, skippedReason: 'no-classlink-class-id' };
+      return {
+        wrote: 0,
+        deleted: 0,
+        skippedMalformed,
+        skippedReason: 'no-classlink-class-id' as const,
+      };
     }
 
     // Compute the desired set of (indexKey -> doc payload) tuples.
@@ -3766,7 +3785,7 @@ export const commitRosterPinIndexV1 = onCall(
     }
 
     await batch.commit();
-    return { wrote, deleted };
+    return { wrote, deleted, skippedMalformed };
   }
 );
 

--- a/hooks/useQuizSession.ts
+++ b/hooks/useQuizSession.ts
@@ -28,6 +28,7 @@ import {
   writeBatch,
   increment,
   deleteField,
+  runTransaction,
   type DocumentSnapshot,
 } from 'firebase/firestore';
 import { db, auth } from '../config/firebase';
@@ -238,6 +239,21 @@ export class AttemptLimitReachedError extends Error {
       "You've already submitted this quiz. Talk to your teacher if you need another attempt."
     );
     this.name = 'AttemptLimitReachedError';
+  }
+}
+
+/**
+ * Thrown by `completeQuiz` when the response doc is already in the
+ * `completed` state — i.e. the student already submitted (possibly from
+ * another tab or via a rapid double-click). The submit transaction treats
+ * this as a no-op (idempotent), so callers should suppress this in the UI.
+ * Branched on the typed sentinel rather than the message so future copy
+ * changes don't silently break the suppression.
+ */
+export class AlreadySubmittedError extends Error {
+  constructor() {
+    super('This quiz has already been submitted.');
+    this.name = 'AlreadySubmittedError';
   }
 }
 
@@ -564,9 +580,15 @@ export const useQuizSessionTeacher = (
     snap.docs.forEach((d) => {
       const data = d.data() as QuizResponse;
       if (data.status === 'in-progress' || data.status === 'joined') {
+        // Bump `completedAttempts` so the join-side cap check sees this
+        // forced finalize as a real completed attempt. Without the bump,
+        // the doc lands at `status: 'completed', completedAttempts: 0`
+        // and a later rejoin's `completed >= limit` check reads 0,
+        // letting the student through under the cap.
         batch.update(d.ref, {
           status: 'completed',
           submittedAt: Date.now(),
+          completedAttempts: increment(1),
         });
         count++;
       }
@@ -1080,9 +1102,13 @@ export const useQuizSessionStudent = (): UseQuizSessionStudentResult => {
         // Attempt-limit enforcement.
         //   - `attemptLimit == null/undefined` means unlimited (legacy).
         //   - Limit is compared against `completedAttempts` (counter field).
-        //   - Legacy docs with `status === 'completed'` but no counter are
-        //     treated as 1 completed attempt so pre-upgrade submissions still
-        //     count against the cap.
+        //   - Any doc with `status === 'completed'` is treated as having ≥1
+        //     completed attempt even when the counter literally reads 0.
+        //     The literal-0 case happens when `finalizeAllResponses` (or any
+        //     legacy/forced finalize) marked a `joined`/`in-progress` doc as
+        //     completed without bumping the counter — `?? 1` only catches
+        //     `null`/`undefined`, so a stored `0` would otherwise let the
+        //     student rejoin under the cap.
         //   - If the student is under the limit, reset the completed doc to
         //     a fresh 'joined' state so the next join starts a new attempt,
         //     preserving `completedAttempts` to enforce the cap on future
@@ -1091,7 +1117,7 @@ export const useQuizSessionStudent = (): UseQuizSessionStudentResult => {
         if (existingSnap?.exists()) {
           const existing = existingSnap.data() as QuizResponse;
           if (existing.status === 'completed') {
-            const completed = existing.completedAttempts ?? 1;
+            const completed = Math.max(existing.completedAttempts ?? 0, 1);
             if (limit !== null && completed >= limit) {
               throw new AttemptLimitReachedError();
             }
@@ -1391,24 +1417,39 @@ export const useQuizSessionStudent = (): UseQuizSessionStudentResult => {
     const responseKey = responseKeyRef.current;
     if (!sessionId || !responseKey) return;
 
-    // Score is computed from gradeAnswer() by the teacher/results view,
-    // not written by the student, to prevent client-side forgery of the score field.
-    // Increment `completedAttempts` so the attempt-limit check on the next
-    // join can count this submission (and block once the cap is reached).
-    await updateDoc(
-      doc(
-        db,
-        QUIZ_SESSIONS_COLLECTION,
-        sessionId,
-        RESPONSES_COLLECTION,
-        responseKey
-      ),
-      {
+    const responseRef = doc(
+      db,
+      QUIZ_SESSIONS_COLLECTION,
+      sessionId,
+      RESPONSES_COLLECTION,
+      responseKey
+    );
+
+    // Wrap submit in a transaction so the "already-completed?" check and
+    // the status flip are atomic. Without this, two concurrent calls (rapid
+    // double-click, two browser tabs of the same student) both read
+    // `status !== 'completed'`, both write `status: 'completed'`, and the
+    // `completedAttempts: increment(1)` runs twice — bypassing a 1-attempt
+    // cap. The transaction makes the second writer see the first's commit
+    // and short-circuit. Score is computed from gradeAnswer() by the
+    // teacher/results view, not written by the student, to prevent
+    // client-side forgery of the score field.
+    await runTransaction(db, async (tx) => {
+      const snap = await tx.get(responseRef);
+      if (!snap.exists()) return;
+      const existing = snap.data() as QuizResponse;
+      if (existing.status === 'completed') {
+        // Idempotent: the doc was already finalized by an earlier
+        // completeQuiz call (other tab, retry, etc.). Throw a typed
+        // sentinel so the UI can suppress the error toast cleanly.
+        throw new AlreadySubmittedError();
+      }
+      tx.update(responseRef, {
         status: 'completed',
         submittedAt: Date.now(),
         completedAttempts: increment(1),
-      }
-    );
+      });
+    });
   }, []);
 
   const reportTabSwitch = useCallback(async (): Promise<number> => {

--- a/hooks/useQuizSession.ts
+++ b/hooks/useQuizSession.ts
@@ -30,8 +30,9 @@ import {
   runTransaction,
   type DocumentSnapshot,
 } from 'firebase/firestore';
-import { db, auth } from '../config/firebase';
-import { signInAnonymously } from 'firebase/auth';
+import { db, auth, functions } from '../config/firebase';
+import { signInAnonymously, signInWithCustomToken } from 'firebase/auth';
+import { httpsCallable } from 'firebase/functions';
 import {
   QuizSession,
   QuizSessionStatus,
@@ -1066,10 +1067,14 @@ export const useQuizSessionStudent = (): UseQuizSessionStudentResult => {
         if (!auth.currentUser) {
           await signInAnonymously(auth);
         }
-        const currentUser = auth.currentUser;
+        // `let` because the Phase 3 PIN→SSO bridge below may swap the
+        // signed-in user via `signInWithCustomToken`, after which we
+        // re-bind `studentUid` / `isAnonymous` to the new identity.
+        let currentUser = auth.currentUser;
         if (!currentUser)
           throw new Error('Anonymous auth failed — no current user.');
-        const studentUid = currentUser.uid;
+        let studentUid = currentUser.uid;
+        let isAnonymous = currentUser.isAnonymous;
 
         // Contract: PIN is required iff the caller is an anonymous Firebase
         // user. Anonymous joiners arrived via the public `/join` /
@@ -1080,7 +1085,7 @@ export const useQuizSessionStudent = (): UseQuizSessionStudentResult => {
         // response doc by that uid, and Firestore rules are the source of
         // truth for whether the uid is actually allowed to write.
         const sanitizedPin = (pin ?? '').trim().substring(0, 10);
-        if (currentUser.isAnonymous && !sanitizedPin) {
+        if (isAnonymous && !sanitizedPin) {
           throw new Error('PIN is required');
         }
 
@@ -1093,7 +1098,7 @@ export const useQuizSessionStudent = (): UseQuizSessionStudentResult => {
           logQuizJoinFirestoreError('lookup-sessions', err, {
             codeNorm: normCode,
             studentUid,
-            isAnonymous: currentUser.isAnonymous,
+            isAnonymous,
           })
         );
         if (snap.empty) throw new Error('No active quiz found with that code.');
@@ -1120,6 +1125,57 @@ export const useQuizSessionStudent = (): UseQuizSessionStudentResult => {
         const sessionDoc = joinable[0];
         const sessionData = sessionDoc.data() as QuizSession;
 
+        // Phase 3 — PIN→SSO identity bridge. When an anonymous PIN
+        // joiner lands on a rostered session (the typical case for
+        // ClassLink schools), try to upgrade them to a custom-token
+        // sign-in whose uid matches what `studentLoginV1` would mint
+        // for the same physical student over SSO. After this swap the
+        // PIN-side and SSO-side response docs converge on the same key
+        // and the per-session attempt cap holds across both auth paths.
+        //
+        // On any failure (no rosterIds on the session, no pin_index
+        // entry, callable error) we silently fall through to the
+        // legacy anonymous PIN flow. The legacy doc-key path
+        // (pin-{period}-{pin}) still gives per-session enforcement and
+        // the user-visible behavior matches today.
+        const sessionHasRosters =
+          Array.isArray(sessionData.rosterIds) &&
+          sessionData.rosterIds.length > 0;
+        if (isAnonymous && sanitizedPin && sessionHasRosters) {
+          try {
+            const callable = httpsCallable<
+              {
+                kind: 'quiz';
+                code: string;
+                pin: string;
+                period?: string;
+              },
+              { matched: boolean; customToken?: string; reason?: string }
+            >(functions, 'pinLoginV1');
+            const res = await callable({
+              kind: 'quiz',
+              code: normCode,
+              pin: sanitizedPin,
+              period: classPeriod,
+            });
+            if (res.data.matched && res.data.customToken) {
+              await signInWithCustomToken(auth, res.data.customToken);
+              const refreshed = auth.currentUser;
+              if (refreshed) {
+                currentUser = refreshed;
+                studentUid = refreshed.uid;
+                isAnonymous = refreshed.isAnonymous;
+              }
+            }
+          } catch (err) {
+            // Swallow — fall through to anonymous flow. Logging the
+            // class-of-failure is fine; we deliberately don't surface
+            // an error toast because the user-visible behavior is
+            // unchanged from pre-Phase-3 in this fallback path.
+            console.warn('[useQuizSession] pinLoginV1 bridge failed:', err);
+          }
+        }
+
         // Deterministic doc key: stable per-roster-student for PIN auth so
         // the attempt limit can't be bypassed by clearing storage / switching
         // device. studentRole users still key by their auth uid (stable per
@@ -1127,7 +1183,7 @@ export const useQuizSessionStudent = (): UseQuizSessionStudentResult => {
         // for anonymous students rejoining pre-deterministic-keying sessions.
         const deterministicKey = computeResponseKey(
           studentUid,
-          currentUser.isAnonymous,
+          isAnonymous,
           sanitizedPin,
           classPeriod
         );
@@ -1135,7 +1191,7 @@ export const useQuizSessionStudent = (): UseQuizSessionStudentResult => {
           await findExistingResponseDoc(
             sessionDoc.id,
             studentUid,
-            currentUser.isAnonymous,
+            isAnonymous,
             deterministicKey
           );
 
@@ -1171,7 +1227,7 @@ export const useQuizSessionStudent = (): UseQuizSessionStudentResult => {
         // covers PIN joiners.
         let ledgerCompleted = 0;
         if (
-          !currentUser.isAnonymous &&
+          !isAnonymous &&
           typeof sessionData.quizId === 'string' &&
           sessionData.quizId.length > 0
         ) {
@@ -1249,7 +1305,7 @@ export const useQuizSessionStudent = (): UseQuizSessionStudentResult => {
                 responseKey,
                 studentUid,
                 existingStudentUid: existing.studentUid,
-                isAnonymous: currentUser.isAnonymous,
+                isAnonymous,
                 hasPin: !!sanitizedPin,
                 hasClassPeriod: !!classPeriod,
               })
@@ -1265,7 +1321,7 @@ export const useQuizSessionStudent = (): UseQuizSessionStudentResult => {
                   responseKey,
                   studentUid,
                   existingStudentUid: existing.studentUid,
-                  isAnonymous: currentUser.isAnonymous,
+                  isAnonymous,
                 })
             );
           }
@@ -1308,7 +1364,7 @@ export const useQuizSessionStudent = (): UseQuizSessionStudentResult => {
         // map shapes (Firestore type drift); the teacher-side enrichment
         // in QuizResults remains as the legacy fallback.
         let resolvedPeriodName: string | undefined;
-        if (!currentUser.isAnonymous && !classPeriod) {
+        if (!isAnonymous && !classPeriod) {
           try {
             const tokenResult = await currentUser.getIdTokenResult();
             const claimClassIds = tokenResult.claims?.classIds;
@@ -1390,7 +1446,7 @@ export const useQuizSessionStudent = (): UseQuizSessionStudentResult => {
               sessionId: sessionDoc.id,
               responseKey,
               studentUid,
-              isAnonymous: currentUser.isAnonymous,
+              isAnonymous,
               hasPin: !!sanitizedPin,
               hasClassPeriod: !!finalClassPeriod,
               hasResolvedClassId: !!resolvedClassId,
@@ -1432,7 +1488,7 @@ export const useQuizSessionStudent = (): UseQuizSessionStudentResult => {
                 existingClassPeriod: existing.classPeriod,
                 resolvedClassId,
                 resolvedPeriodName,
-                isAnonymous: currentUser.isAnonymous,
+                isAnonymous,
               })
             );
           }

--- a/hooks/useQuizSession.ts
+++ b/hooks/useQuizSession.ts
@@ -30,7 +30,7 @@ import {
   runTransaction,
   type DocumentSnapshot,
 } from 'firebase/firestore';
-import { db, auth, functions } from '../config/firebase';
+import { db, auth, functions } from '@/config/firebase';
 import { signInAnonymously, signInWithCustomToken } from 'firebase/auth';
 import { httpsCallable } from 'firebase/functions';
 import {
@@ -42,8 +42,8 @@ import {
   QuizPublicQuestion,
   QuizAttemptLedger,
   GradeResult,
-} from '../types';
-import { resolvePeriodNames } from '../utils/periodCompat';
+} from '@/types';
+import { resolvePeriodNames } from '@/utils/periodCompat';
 
 // Re-export for backward compatibility with callers that imported
 // QuizSessionOptions from this module before it was moved into types.ts.
@@ -262,21 +262,6 @@ export class AttemptLimitReachedError extends Error {
       "You've already submitted this quiz. Talk to your teacher if you need another attempt."
     );
     this.name = 'AttemptLimitReachedError';
-  }
-}
-
-/**
- * Thrown by `completeQuiz` when the response doc is already in the
- * `completed` state — i.e. the student already submitted (possibly from
- * another tab or via a rapid double-click). The submit transaction treats
- * this as a no-op (idempotent), so callers should suppress this in the UI.
- * Branched on the typed sentinel rather than the message so future copy
- * changes don't silently break the suppression.
- */
-export class AlreadySubmittedError extends Error {
-  constructor() {
-    super('This quiz has already been submitted.');
-    this.name = 'AlreadySubmittedError';
   }
 }
 
@@ -1657,10 +1642,16 @@ export const useQuizSessionStudent = (): UseQuizSessionStudentResult => {
       if (!snap.exists()) return;
       const existing = snap.data() as QuizResponse;
       if (existing.status === 'completed') {
-        // Idempotent: the doc was already finalized by an earlier
-        // completeQuiz call (other tab, retry, etc.). Throw a typed
-        // sentinel so the UI can suppress the error toast cleanly.
-        throw new AlreadySubmittedError();
+        // Idempotent no-op: the doc was already finalized by an earlier
+        // completeQuiz call (other tab, retry, rapid double-click). We
+        // intentionally `return` instead of throwing — callers
+        // (handleSubmitAndAdvance, handleAutoSubmit, the auto-complete
+        // branch in handleAnswer) all `await onComplete()`, sometimes
+        // without a try/catch, so a thrown sentinel would surface as an
+        // unhandled rejection / wrong "submit failed" toast even though
+        // the submit actually succeeded earlier. Returning early
+        // mirrors `completeActivity` in `useVideoActivitySession`.
+        return;
       }
 
       // Read the ledger inside the same transaction so the increment

--- a/hooks/useQuizSession.ts
+++ b/hooks/useQuizSession.ts
@@ -22,7 +22,6 @@ import {
   updateDoc,
   getDocs,
   getDoc,
-  deleteDoc,
   query,
   where,
   writeBatch,
@@ -40,6 +39,7 @@ import {
   QuizResponseAnswer,
   QuizQuestion,
   QuizPublicQuestion,
+  QuizAttemptLedger,
   GradeResult,
 } from '../types';
 import { resolvePeriodNames } from '../utils/periodCompat';
@@ -50,6 +50,28 @@ export type { QuizSessionOptions } from '../types';
 
 export const QUIZ_SESSIONS_COLLECTION = 'quiz_sessions';
 export const RESPONSES_COLLECTION = 'responses';
+/**
+ * Top-level cross-launch attempt ledger. Sits alongside `/quiz_sessions/`
+ * and accumulates a student's completed-attempt count across every session
+ * the teacher creates for the same quiz. Without this collection, the
+ * per-session counter on `responses/{key}` resets every launch and a
+ * teacher's "1 attempt" intent is bypassed by relaunching the quiz.
+ *
+ * Doc id: `${quizId}__${studentUid}` (see `quizLedgerKey`). Schema:
+ * `QuizAttemptLedger` in types.ts.
+ */
+export const QUIZ_ATTEMPT_LEDGER_COLLECTION = 'quiz_attempt_ledger';
+
+/**
+ * Deterministic ledger doc id. Two underscores keep us safe even if a
+ * future quizId or studentUid contains a single underscore (Firestore
+ * doc ids allow underscores). HMAC pseudonyms are hex, current quizIds
+ * are UUIDs, so collisions are not realistic, but the separator is
+ * cheap insurance.
+ */
+export function quizLedgerKey(quizId: string, studentUid: string): string {
+  return `${quizId}__${studentUid}`;
+}
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -601,6 +623,17 @@ export const useQuizSessionTeacher = (
   const removeStudent = useCallback(
     async (responseKey: string) => {
       if (!sessionId) return;
+      // Look up the response in the snapshot-driven `responses` list to
+      // recover the studentUid + quizId we need for the ledger reset
+      // (Phase 2). The teacher's existing UX for `removeStudent` is
+      // "free the student up to retake" — which today only freed the
+      // per-session counter. After Phase 2 the cross-launch ledger
+      // would still cap them, so the reset must clear the ledger entry
+      // too. Falls back to a response-only delete when the response
+      // isn't in the snapshot list (race with a stale UI click).
+      const target = responses.find(
+        (r) => (r._responseKey ?? r.studentUid) === responseKey
+      );
       const responseRef = doc(
         db,
         QUIZ_SESSIONS_COLLECTION,
@@ -608,9 +641,25 @@ export const useQuizSessionTeacher = (
         RESPONSES_COLLECTION,
         responseKey
       );
-      await deleteDoc(responseRef);
+
+      const ledgerRef =
+        target && session?.quizId
+          ? doc(
+              db,
+              QUIZ_ATTEMPT_LEDGER_COLLECTION,
+              quizLedgerKey(session.quizId, target.studentUid)
+            )
+          : null;
+
+      // Delete in a batch so the response and ledger reset are atomic
+      // from a UI perspective (no half-state where the response is
+      // gone but the cap still blocks rejoin).
+      const batch = writeBatch(db);
+      batch.delete(responseRef);
+      if (ledgerRef) batch.delete(ledgerRef);
+      await batch.commit();
     },
-    [sessionId]
+    [sessionId, responses, session?.quizId]
   );
 
   const revealAnswer = useCallback(
@@ -842,6 +891,13 @@ export const useQuizSessionStudent = (): UseQuizSessionStudentResult => {
   // (see computeResponseKey) so an attempt limit survives device/storage
   // resets. Historically named `studentUidRef`.
   const responseKeyRef = useRef<string | null>(null);
+  // Snapshotted at join time for use by `completeQuiz` (writes the ledger
+  // entry inside the same transaction as the response status flip).
+  // Without these refs, completeQuiz would have to re-read the session doc
+  // mid-transaction just to get the quiz/teacher ids — which is correct
+  // but adds a per-submit round-trip.
+  const quizIdRef = useRef<string | null>(null);
+  const teacherUidRef = useRef<string | null>(null);
   // Keep a ref to current answers to avoid stale closure issues
   const myResponseRef = useRef<QuizResponse | null>(null);
   myResponseRef.current = myResponse;
@@ -1085,6 +1141,8 @@ export const useQuizSessionStudent = (): UseQuizSessionStudentResult => {
 
         sessionIdRef.current = sessionDoc.id;
         responseKeyRef.current = responseKey;
+        quizIdRef.current = sessionData.quizId ?? null;
+        teacherUidRef.current = sessionData.teacherUid ?? null;
         // Reset warning count before activating snapshot listeners so a
         // late-arriving snapshot from a previous session can't race with
         // the finally-block reset and leave the counter stuck at 0.
@@ -1099,25 +1157,70 @@ export const useQuizSessionStudent = (): UseQuizSessionStudentResult => {
           responseKey
         );
 
+        // Cross-launch attempt cap (Phase 2).
+        //
+        // Read the per-quiz ledger BEFORE the per-session cap check so a
+        // student who already exhausted their attempts in an earlier
+        // session of the same quiz is rejected here — the per-session
+        // counter on `responseRef` is fresh on every launch and would
+        // otherwise let them through. The ledger is only meaningful for
+        // non-anonymous (SSO/studentRole) joiners today; anonymous PIN
+        // joiners get a rotating uid, so their ledger doc churns and
+        // never accumulates. Phase 3's `pinLoginV1` unifies PIN onto the
+        // same uid space, at which point this same code automatically
+        // covers PIN joiners.
+        let ledgerCompleted = 0;
+        if (
+          !currentUser.isAnonymous &&
+          typeof sessionData.quizId === 'string' &&
+          sessionData.quizId.length > 0
+        ) {
+          const ledgerRef = doc(
+            db,
+            QUIZ_ATTEMPT_LEDGER_COLLECTION,
+            quizLedgerKey(sessionData.quizId, studentUid)
+          );
+          const ledgerSnap = await getDoc(ledgerRef).catch((err: unknown) => {
+            // Ledger reads can fail with permission-denied for legacy
+            // students whose ledger doc predates the rule changes; that
+            // shouldn't block the join. Treat as "no ledger" and rely on
+            // the per-session counter + the (post-deploy) write path to
+            // populate the ledger forward.
+            if (getErrorCode(err) === 'permission-denied') {
+              console.warn(
+                '[useQuizSession] permission-denied reading ledger; treating as 0',
+                { quizId: sessionData.quizId, studentUid, err }
+              );
+              return null;
+            }
+            throw err;
+          });
+          if (ledgerSnap?.exists()) {
+            const ledger = ledgerSnap.data() as QuizAttemptLedger;
+            ledgerCompleted = ledger.completedAttempts ?? 0;
+          }
+        }
+
         // Attempt-limit enforcement.
         //   - `attemptLimit == null/undefined` means unlimited (legacy).
-        //   - Limit is compared against `completedAttempts` (counter field).
-        //   - Any doc with `status === 'completed'` is treated as having ≥1
-        //     completed attempt even when the counter literally reads 0.
-        //     The literal-0 case happens when `finalizeAllResponses` (or any
-        //     legacy/forced finalize) marked a `joined`/`in-progress` doc as
-        //     completed without bumping the counter — `?? 1` only catches
-        //     `null`/`undefined`, so a stored `0` would otherwise let the
-        //     student rejoin under the cap.
+        //   - Limit is compared against the MAX of:
+        //       a) per-session response `completedAttempts`
+        //       b) per-quiz `ledgerCompleted` (Phase 2 cross-launch)
+        //       c) 1, when the per-session response is `status === 'completed'`
+        //          (legacy / finalize-zeroed docs)
         //   - If the student is under the limit, reset the completed doc to
         //     a fresh 'joined' state so the next join starts a new attempt,
-        //     preserving `completedAttempts` to enforce the cap on future
-        //     submissions.
+        //     preserving `completedAttempts` (and the ledger entry) to
+        //     enforce the cap on future submissions.
         const limit = sessionData.attemptLimit ?? null;
         if (existingSnap?.exists()) {
           const existing = existingSnap.data() as QuizResponse;
           if (existing.status === 'completed') {
-            const completed = Math.max(existing.completedAttempts ?? 0, 1);
+            const completed = Math.max(
+              existing.completedAttempts ?? 0,
+              ledgerCompleted,
+              1
+            );
             if (limit !== null && completed >= limit) {
               throw new AttemptLimitReachedError();
             }
@@ -1166,6 +1269,16 @@ export const useQuizSessionStudent = (): UseQuizSessionStudentResult => {
                 })
             );
           }
+        } else if (limit !== null && ledgerCompleted >= limit) {
+          // No response doc yet for this session, but the cross-launch
+          // ledger says the student is already at/past the cap. This is
+          // the SSO student who took an earlier launch of the same quiz,
+          // then opened the new launch from /my-assignments. Without
+          // this branch, the existing fall-through would create a fresh
+          // response for them and the per-session cap would let them
+          // submit once more. The ledger is the only state that survives
+          // the new launch, so we gate on it directly here.
+          throw new AttemptLimitReachedError();
         }
 
         setSessionIdState(sessionDoc.id);
@@ -1415,6 +1528,8 @@ export const useQuizSessionStudent = (): UseQuizSessionStudentResult => {
   const completeQuiz = useCallback(async () => {
     const sessionId = sessionIdRef.current;
     const responseKey = responseKeyRef.current;
+    const quizId = quizIdRef.current;
+    const teacherUid = teacherUidRef.current;
     if (!sessionId || !responseKey) return;
 
     const responseRef = doc(
@@ -1425,15 +1540,37 @@ export const useQuizSessionStudent = (): UseQuizSessionStudentResult => {
       responseKey
     );
 
-    // Wrap submit in a transaction so the "already-completed?" check and
-    // the status flip are atomic. Without this, two concurrent calls (rapid
-    // double-click, two browser tabs of the same student) both read
-    // `status !== 'completed'`, both write `status: 'completed'`, and the
-    // `completedAttempts: increment(1)` runs twice — bypassing a 1-attempt
-    // cap. The transaction makes the second writer see the first's commit
-    // and short-circuit. Score is computed from gradeAnswer() by the
-    // teacher/results view, not written by the student, to prevent
-    // client-side forgery of the score field.
+    // Resolve the cross-launch ledger doc ref (Phase 2). Only meaningful
+    // for non-anonymous (SSO/studentRole) joiners — anonymous PIN
+    // joiners' uids rotate per device, so their ledger entry would be
+    // useless. Phase 3 unifies the PIN flow onto the SSO uid space and
+    // this same code starts covering PIN joiners automatically.
+    const studentUid = auth.currentUser?.uid ?? null;
+    const isAnonymous = auth.currentUser?.isAnonymous ?? true;
+    const writeLedger =
+      !isAnonymous &&
+      typeof studentUid === 'string' &&
+      studentUid.length > 0 &&
+      typeof quizId === 'string' &&
+      quizId.length > 0 &&
+      typeof teacherUid === 'string' &&
+      teacherUid.length > 0;
+    const ledgerRef = writeLedger
+      ? doc(
+          db,
+          QUIZ_ATTEMPT_LEDGER_COLLECTION,
+          quizLedgerKey(quizId, studentUid)
+        )
+      : null;
+
+    // Wrap submit in a transaction so the "already-completed?" check, the
+    // response status flip, and the cross-launch ledger increment are all
+    // atomic. Without the transaction, two concurrent submits (rapid
+    // double-click, two browser tabs) both read `status !== 'completed'`,
+    // both write `status: 'completed'`, and the `increment(1)` runs twice
+    // on both the response and the ledger — bypassing a 1-attempt cap.
+    // Score is computed from gradeAnswer() by the teacher/results view,
+    // not written by the student, to prevent client-side forgery.
     await runTransaction(db, async (tx) => {
       const snap = await tx.get(responseRef);
       if (!snap.exists()) return;
@@ -1444,11 +1581,41 @@ export const useQuizSessionStudent = (): UseQuizSessionStudentResult => {
         // sentinel so the UI can suppress the error toast cleanly.
         throw new AlreadySubmittedError();
       }
+
+      // Read the ledger inside the same transaction so the increment
+      // can't double-write under concurrency. Firestore requires all
+      // reads to precede all writes within a transaction.
+      const ledgerSnap = ledgerRef ? await tx.get(ledgerRef) : null;
+
+      const submittedAt = Date.now();
       tx.update(responseRef, {
         status: 'completed',
-        submittedAt: Date.now(),
+        submittedAt,
         completedAttempts: increment(1),
       });
+
+      if (ledgerRef && ledgerSnap) {
+        if (ledgerSnap.exists()) {
+          tx.update(ledgerRef, {
+            completedAttempts: increment(1),
+            lastAttemptAt: submittedAt,
+            lastSessionId: sessionId,
+          });
+        } else {
+          // First completion for this (quiz, student) pair. The cast
+          // pins the shape so a future ledger-schema drift surfaces as
+          // a TS error here rather than as a silent rule-denied write.
+          const newLedger: QuizAttemptLedger = {
+            quizId: quizId as string,
+            studentUid: studentUid as string,
+            teacherUid: teacherUid as string,
+            completedAttempts: 1,
+            lastAttemptAt: submittedAt,
+            lastSessionId: sessionId,
+          };
+          tx.set(ledgerRef, newLedger);
+        }
+      }
     });
   }, []);
 

--- a/hooks/useQuizSession.ts
+++ b/hooks/useQuizSession.ts
@@ -1168,11 +1168,28 @@ export const useQuizSessionStudent = (): UseQuizSessionStudentResult => {
               }
             }
           } catch (err) {
-            // Swallow — fall through to anonymous flow. Logging the
-            // class-of-failure is fine; we deliberately don't surface
-            // an error toast because the user-visible behavior is
-            // unchanged from pre-Phase-3 in this fallback path.
-            console.warn('[useQuizSession] pinLoginV1 bridge failed:', err);
+            // The bridge is best-effort by design — falling through to
+            // the legacy anonymous PIN flow preserves PIN-only sessions
+            // and rosters whose pin_index hasn't been built yet.
+            // However we still want to LOUDLY surface unexpected
+            // failures so a misconfigured production (rules typo,
+            // function outage) doesn't silently re-open the duplicate-
+            // doc bypass. `not-found` and `unavailable` are the
+            // expected "fall through" codes; everything else gets
+            // logged at error level so it shows up in monitoring.
+            const code = getErrorCode(err);
+            const expected = code === 'not-found' || code === 'unavailable';
+            if (expected) {
+              console.warn('[useQuizSession] pinLoginV1 bridge fell through:', {
+                code,
+                err,
+              });
+            } else {
+              console.error(
+                '[useQuizSession] pinLoginV1 bridge unexpected failure — falling back to anonymous PIN flow:',
+                err
+              );
+            }
           }
         }
 
@@ -1627,6 +1644,14 @@ export const useQuizSessionStudent = (): UseQuizSessionStudentResult => {
     // on both the response and the ledger — bypassing a 1-attempt cap.
     // Score is computed from gradeAnswer() by the teacher/results view,
     // not written by the student, to prevent client-side forgery.
+    //
+    // Ledger atomicity: the ledger write is intentionally NOT best-effort
+    // — if the rules deny the ledger update (e.g. a ledger-rule typo or
+    // schema drift) the entire transaction rolls back and the student's
+    // submit fails with a visible error. That's the right call: a silent
+    // "submit accepted but cap not recorded" would re-open the cross-
+    // launch bypass without any signal. Production rule changes against
+    // this collection MUST be deployed with care.
     await runTransaction(db, async (tx) => {
       const snap = await tx.get(responseRef);
       if (!snap.exists()) return;

--- a/hooks/useRosters.ts
+++ b/hooks/useRosters.ts
@@ -10,11 +10,61 @@ import {
   orderBy,
 } from 'firebase/firestore';
 import { deleteField } from 'firebase/firestore';
+import { httpsCallable } from 'firebase/functions';
 import { User } from 'firebase/auth';
 import { ClassRoster, ClassRosterMeta, Student } from '../types';
-import { db, isAuthBypass } from '../config/firebase';
+import { db, functions, isAuthBypass } from '../config/firebase';
 import { useGoogleDrive } from './useGoogleDrive';
 import { getLocalIsoDate } from '../utils/localDate';
+
+/**
+ * Phase 3 — rebuild the per-roster pin_index sidecar after a roster save.
+ *
+ * Posts every (period, pin, classlinkSourcedId) tuple from the saved
+ * student list to `commitRosterPinIndexV1`, which writes the non-PII
+ * `/users/{uid}/rosters/{rosterId}/pin_index/*` docs that pinLoginV1
+ * later reads to bridge a PIN-joining student into the same uid space
+ * SSO produces. Skips silently for local rosters (no
+ * classLinkSourcedId on any student); the cloud function also short-
+ * circuits there. Best-effort: a failure logs and returns — the roster
+ * save itself has already succeeded, and the next save will retry.
+ */
+async function syncRosterPinIndex(
+  rosterId: string,
+  rosterName: string,
+  students: Student[]
+): Promise<void> {
+  const entries = students
+    .filter(
+      (s) =>
+        typeof s.classLinkSourcedId === 'string' &&
+        s.classLinkSourcedId.length > 0 &&
+        typeof s.pin === 'string' &&
+        s.pin.length > 0
+    )
+    .map((s) => ({
+      period: rosterName,
+      pin: s.pin,
+      classlinkSourcedId: s.classLinkSourcedId as string,
+    }));
+
+  if (entries.length === 0) {
+    // Local rosters — no SSO bridge possible. The function itself
+    // tolerates an empty `entries` and a missing classlinkClassId,
+    // but skipping the round-trip is cheaper.
+    return;
+  }
+
+  try {
+    const callable = httpsCallable<
+      { rosterId: string; entries: typeof entries },
+      { wrote: number; deleted: number; skippedReason?: string }
+    >(functions, 'commitRosterPinIndexV1');
+    await callable({ rosterId, entries });
+  } catch (err) {
+    console.warn('[useRosters] commitRosterPinIndexV1 failed:', err);
+  }
+}
 
 /**
  * Assigns zero-padded sequential PINs to students that don't have one yet.
@@ -575,6 +625,11 @@ export const useRosters = (user: User | null) => {
         studentsCacheRef.current.set(ref.id, withPins);
       }
 
+      // Phase 3 — bridge PIN students into the SSO uid space by writing
+      // the per-roster pin_index sidecar. Best-effort: a failure logs
+      // and continues; the roster is already saved.
+      void syncRosterPinIndex(ref.id, name, withPins);
+
       return ref.id;
     },
     [user, driveService, uploadStudentsToDrive]
@@ -625,6 +680,16 @@ export const useRosters = (user: User | null) => {
               driveFileId,
               studentCount: withPins.length,
             });
+            // Phase 3 — refresh the pin_index sidecar after a successful
+            // Drive write. Uses the post-update name when the caller
+            // renamed the roster, otherwise the existing meta's name.
+            const rosterName =
+              typeof metaUpdates.name === 'string' && metaUpdates.name
+                ? metaUpdates.name
+                : (existingMeta?.name ?? '');
+            if (rosterName) {
+              void syncRosterPinIndex(id, rosterName, withPins);
+            }
           } catch (err) {
             console.error('Failed to upload updated roster to Drive:', err);
             // Revert optimistic updates

--- a/hooks/useRosters.ts
+++ b/hooks/useRosters.ts
@@ -58,9 +58,25 @@ async function syncRosterPinIndex(
   try {
     const callable = httpsCallable<
       { rosterId: string; entries: typeof entries },
-      { wrote: number; deleted: number; skippedReason?: string }
+      {
+        wrote: number;
+        deleted: number;
+        skippedMalformed?: number;
+        skippedReason?: string;
+      }
     >(functions, 'commitRosterPinIndexV1');
-    await callable({ rosterId, entries });
+    const res = await callable({ rosterId, entries });
+    // Server-side input validation may silently drop entries with
+    // malformed shape (typo'd ClassLink id, missing pin). Surface
+    // any such drops to the console so a teacher debugging "why
+    // can't this student SSO-bridge" has a breadcrumb to follow.
+    // Not a toast: the data is still saved, the affected student
+    // just falls back to legacy PIN — same as before Phase 3.
+    if (res.data.skippedMalformed && res.data.skippedMalformed > 0) {
+      console.warn(
+        `[useRosters] commitRosterPinIndexV1 dropped ${res.data.skippedMalformed} malformed entries on roster ${rosterId}`
+      );
+    }
   } catch (err) {
     console.warn('[useRosters] commitRosterPinIndexV1 failed:', err);
   }

--- a/hooks/useRosters.ts
+++ b/hooks/useRosters.ts
@@ -12,10 +12,10 @@ import {
 import { deleteField } from 'firebase/firestore';
 import { httpsCallable } from 'firebase/functions';
 import { User } from 'firebase/auth';
-import { ClassRoster, ClassRosterMeta, Student } from '../types';
-import { db, functions, isAuthBypass } from '../config/firebase';
-import { useGoogleDrive } from './useGoogleDrive';
-import { getLocalIsoDate } from '../utils/localDate';
+import { ClassRoster, ClassRosterMeta, Student } from '@/types';
+import { db, functions, isAuthBypass } from '@/config/firebase';
+import { useGoogleDrive } from '@/hooks/useGoogleDrive';
+import { getLocalIsoDate } from '@/utils/localDate';
 
 /**
  * Phase 3 — rebuild the per-roster pin_index sidecar after a roster save.

--- a/hooks/useVideoActivitySession.ts
+++ b/hooks/useVideoActivitySession.ts
@@ -37,6 +37,7 @@ import {
   AssignmentMode,
   VideoActivitySession,
   VideoActivityResponse,
+  VideoActivityAttemptLedger,
   VideoActivityData,
   VideoActivityAnswer,
   VideoActivitySessionSettings,
@@ -45,6 +46,20 @@ import {
 
 const SESSIONS_COLLECTION = 'video_activity_sessions';
 const RESPONSES_SUBCOLLECTION = 'responses';
+/**
+ * Top-level cross-launch attempt ledger for Video Activity. Mirrors the
+ * Quiz ledger collection — see `QUIZ_ATTEMPT_LEDGER_COLLECTION` in
+ * `useQuizSession.ts` for the rationale and key shape.
+ */
+const VIDEO_ACTIVITY_ATTEMPT_LEDGER_COLLECTION =
+  'video_activity_attempt_ledger';
+
+function videoActivityLedgerKey(
+  activityId: string,
+  studentUid: string
+): string {
+  return `${activityId}__${studentUid}`;
+}
 
 const normalizeSession = (
   sessionId: string,
@@ -658,6 +673,39 @@ export const useVideoActivitySessionStudent =
             }
           }
 
+          // Cross-launch attempt cap (Phase 2). Only meaningful for
+          // non-anonymous (SSO/studentRole) joiners — see the matching
+          // comment in `useQuizSession.joinQuizSession` for the rationale.
+          let ledgerCompleted = 0;
+          if (
+            !isAnonymous &&
+            typeof sessionData.activityId === 'string' &&
+            sessionData.activityId.length > 0
+          ) {
+            const ledgerRef = doc(
+              db,
+              VIDEO_ACTIVITY_ATTEMPT_LEDGER_COLLECTION,
+              videoActivityLedgerKey(sessionData.activityId, currentUser.uid)
+            );
+            const ledgerSnap = await getDoc(ledgerRef).catch((err: unknown) => {
+              logError(
+                'useVideoActivitySessionStudent.ledgerRead',
+                err as Error,
+                {
+                  activityId: sessionData.activityId,
+                  studentUid: currentUser.uid,
+                }
+              );
+              return null;
+            });
+            if (ledgerSnap?.exists()) {
+              const ledger = ledgerSnap.data() as VideoActivityAttemptLedger;
+              ledgerCompleted = ledger.completedAttempts ?? 0;
+            }
+          }
+
+          const limit = sessionData.sessionOptions?.attemptLimit ?? null;
+
           if (existingSnap.exists()) {
             const existing = existingSnap.data() as VideoActivityResponse;
             // Attempt-limit enforcement on rejoin.
@@ -667,15 +715,20 @@ export const useVideoActivitySessionStudent =
             //     ≥1 completed attempt even if the counter literally reads
             //     0 (legacy docs that submitted before the counter was
             //     wired up).
+            //   - The ledger augments this with cross-launch state: a
+            //     student who completed an earlier launch shows up here
+            //     with `ledgerCompleted >= limit` even though the new
+            //     session's response doc is fresh.
             //   - Under the cap, reset the doc to a fresh attempt
             //     (`completedAt: null, answers: []`); preserve
             //     `completedAttempts` so future joins still see the cap.
             if (existing.completedAt != null) {
-              const limit = sessionData.sessionOptions?.attemptLimit ?? null;
-              const completed = Math.max(existing.completedAttempts ?? 0, 1);
+              const completed = Math.max(
+                existing.completedAttempts ?? 0,
+                ledgerCompleted,
+                1
+              );
               if (limit !== null && completed >= limit) {
-                setJoinStatus('error');
-                setError(new AttemptLimitReachedError().message);
                 throw new AttemptLimitReachedError();
               }
               await updateDoc(effectiveResponseRef, {
@@ -686,6 +739,15 @@ export const useVideoActivitySessionStudent =
                   : {}),
               });
             }
+          } else if (limit !== null && ledgerCompleted >= limit) {
+            // No response doc for this session yet, but the ledger says
+            // the student is already at/past the cap. This is the SSO
+            // student who completed an earlier launch and has now opened
+            // a new launch — without this branch the create path below
+            // would give them a fresh response and the per-session
+            // counter would let them submit again. See the Quiz mirror
+            // in `useQuizSession.joinQuizSession`.
+            throw new AttemptLimitReachedError();
           } else {
             // Initialize `completedAttempts` and `tabSwitchWarnings` to 0 so
             // the Firestore rules' monotonic-growth check on update has a
@@ -720,7 +782,15 @@ export const useVideoActivitySessionStudent =
             sessionId: targetSessionId,
           });
           setJoinStatus('error');
-          setError('Failed to join the session. Please try again.');
+          // Preserve the cap-reached message so students know to ask the
+          // teacher rather than seeing the generic "try again" copy.
+          // Branched on the typed sentinel (not the message) so future
+          // copy edits don't silently break the discrimination.
+          if (err instanceof AttemptLimitReachedError) {
+            setError(err.message);
+          } else {
+            setError('Failed to join the session. Please try again.');
+          }
         }
       },
       []
@@ -769,24 +839,72 @@ export const useVideoActivitySessionStudent =
         responseDocId
       );
 
-      // Wrap completion in a transaction so the "already-completed?" check
-      // and the timestamp/counter writes are atomic. Two concurrent
-      // completeActivity calls (rapid double-click, two browser tabs) would
-      // otherwise both write `completedAt` and double-increment
-      // `completedAttempts`, bypassing the cap. If the doc is already
-      // completed, no-op (idempotent — VA student-side has no error toast
-      // for repeated completes, and silently dropping is the right UX).
+      // Resolve the cross-launch ledger ref (Phase 2). Same identity
+      // caveat as the Quiz hook — only meaningful for non-anonymous
+      // joiners until Phase 3 unifies the PIN flow's uid space.
+      const studentUid = auth.currentUser?.uid ?? null;
+      const isAnonymous = auth.currentUser?.isAnonymous ?? true;
+      const activityId = session?.activityId ?? null;
+      const teacherUid = session?.teacherUid ?? null;
+      const writeLedger =
+        !isAnonymous &&
+        typeof studentUid === 'string' &&
+        studentUid.length > 0 &&
+        typeof activityId === 'string' &&
+        activityId.length > 0 &&
+        typeof teacherUid === 'string' &&
+        teacherUid.length > 0;
+      const ledgerRef = writeLedger
+        ? doc(
+            db,
+            VIDEO_ACTIVITY_ATTEMPT_LEDGER_COLLECTION,
+            videoActivityLedgerKey(activityId, studentUid)
+          )
+        : null;
+
+      // Wrap completion in a transaction so the "already-completed?"
+      // check, the response timestamp/counter writes, and the ledger
+      // increment are all atomic. Two concurrent completeActivity calls
+      // (rapid double-click, two browser tabs) would otherwise both write
+      // `completedAt` and double-increment both counters, bypassing the
+      // cap. If the doc is already completed, no-op (idempotent — VA
+      // student-side has no error toast for repeated completes).
       await runTransaction(db, async (tx) => {
         const snap = await tx.get(responseRef);
         if (!snap.exists()) return;
         const existing = snap.data() as VideoActivityResponse;
         if (existing.completedAt != null) return;
+
+        // All reads before all writes (Firestore transaction rule).
+        const ledgerSnap = ledgerRef ? await tx.get(ledgerRef) : null;
+
+        const completedAt = Date.now();
         tx.update(responseRef, {
-          completedAt: Date.now(),
+          completedAt,
           completedAttempts: increment(1),
         });
+
+        if (ledgerRef && ledgerSnap) {
+          if (ledgerSnap.exists()) {
+            tx.update(ledgerRef, {
+              completedAttempts: increment(1),
+              lastAttemptAt: completedAt,
+              lastSessionId: sessionId,
+            });
+          } else {
+            const newLedger: VideoActivityAttemptLedger = {
+              activityId: activityId as string,
+              studentUid: studentUid as string,
+              teacherUid: teacherUid as string,
+              completedAttempts: 1,
+              lastAttemptAt: completedAt,
+              lastSessionId: sessionId,
+            };
+            tx.set(ledgerRef, newLedger);
+          }
+        }
       });
-    }, [sessionId, responseDocId]);
+    }, [sessionId, responseDocId, session?.activityId, session?.teacherUid]);
 
     return {
       session,

--- a/hooks/useVideoActivitySession.ts
+++ b/hooks/useVideoActivitySession.ts
@@ -653,13 +653,39 @@ export const useVideoActivitySessionStudent =
                 }
               }
             } catch (err) {
-              logError(
-                'useVideoActivitySessionStudent.pinLoginBridge',
-                err as Error,
-                {
-                  sessionId: targetSessionId,
-                }
-              );
+              // The bridge is best-effort by design — falling through to
+              // the legacy anonymous PIN flow preserves PIN-only sessions
+              // and rosters whose pin_index hasn't been built yet.
+              // However we still want to LOUDLY surface unexpected
+              // failures so a misconfigured production (rules typo,
+              // function outage) doesn't silently re-open the duplicate-
+              // doc bypass. `not-found` and `unavailable` are the
+              // expected "fall through" codes; everything else gets
+              // logged at error level so it shows up in monitoring.
+              const code =
+                err && typeof err === 'object' && 'code' in err
+                  ? (err as { code?: unknown }).code
+                  : undefined;
+              const expected = code === 'not-found' || code === 'unavailable';
+              const safeErr =
+                err instanceof Error ? err : new Error(String(err));
+              if (expected) {
+                logError(
+                  'useVideoActivitySessionStudent.pinLoginBridge.expected',
+                  safeErr,
+                  { sessionId: targetSessionId, code: String(code) }
+                );
+              } else {
+                console.error(
+                  '[useVideoActivitySessionStudent.pinLoginBridge] unexpected failure — falling back to anonymous PIN flow:',
+                  safeErr
+                );
+                logError(
+                  'useVideoActivitySessionStudent.pinLoginBridge.unexpected',
+                  safeErr,
+                  { sessionId: targetSessionId }
+                );
+              }
             }
           }
 
@@ -926,6 +952,11 @@ export const useVideoActivitySessionStudent =
       // `completedAt` and double-increment both counters, bypassing the
       // cap. If the doc is already completed, no-op (idempotent — VA
       // student-side has no error toast for repeated completes).
+      //
+      // Ledger atomicity: same trade-off as `completeQuiz` — the ledger
+      // write is NOT best-effort. A ledger-rule failure rolls the whole
+      // transaction back so we never accept a submit without recording
+      // the attempt against the cross-launch cap.
       await runTransaction(db, async (tx) => {
         const snap = await tx.get(responseRef);
         if (!snap.exists()) return;

--- a/hooks/useVideoActivitySession.ts
+++ b/hooks/useVideoActivitySession.ts
@@ -25,7 +25,9 @@ import {
   where,
   orderBy,
 } from 'firebase/firestore';
-import { db, auth } from '@/config/firebase';
+import { signInWithCustomToken } from 'firebase/auth';
+import { httpsCallable } from 'firebase/functions';
+import { db, auth, functions } from '@/config/firebase';
 import { logError } from '@/utils/logError';
 import {
   computeResponseKey,
@@ -561,14 +563,18 @@ export const useVideoActivitySessionStudent =
 
           const sessionData = sessionSnap.data() as VideoActivitySession;
 
-          const currentUser = auth.currentUser;
+          // `let` because the Phase 3 PIN→SSO bridge below may swap the
+          // signed-in user via `signInWithCustomToken`, after which we
+          // re-bind `currentUser` and `isAnonymous` to the new identity
+          // before the rest of the function reads them.
+          let currentUser = auth.currentUser;
           if (!currentUser) {
             setJoinStatus('error');
             setError('Authentication required. Please refresh and try again.');
             return;
           }
 
-          const isAnonymous = currentUser.isAnonymous;
+          let isAnonymous = currentUser.isAnonymous;
 
           // Anonymous (PIN) joiners must supply a PIN and pass the allowedPins
           // gate. SSO joiners (studentRole custom-token users) skip both checks
@@ -604,6 +610,57 @@ export const useVideoActivitySessionStudent =
               'This activity has expired. Contact your teacher for a new link.'
             );
             return;
+          }
+
+          // Phase 3 — PIN→SSO identity bridge. Mirrors `useQuizSession`.
+          // When an anonymous PIN joiner lands on a rostered VA session,
+          // upgrade them to a custom-token sign-in whose uid matches the
+          // SSO pseudonym. After the swap, the per-session response key
+          // converges with the SSO key for the same student. Falls
+          // through silently to the legacy anonymous PIN flow on any
+          // miss (no pin_index entry, callable error).
+          const sessionHasRosters =
+            Array.isArray(sessionData.rosterIds) &&
+            sessionData.rosterIds.length > 0;
+          if (
+            isAnonymous &&
+            studentPin &&
+            studentPin.length > 0 &&
+            sessionHasRosters
+          ) {
+            try {
+              const callable = httpsCallable<
+                {
+                  kind: 'video-activity';
+                  sessionId: string;
+                  pin: string;
+                  period?: string;
+                },
+                { matched: boolean; customToken?: string; reason?: string }
+              >(functions, 'pinLoginV1');
+              const res = await callable({
+                kind: 'video-activity',
+                sessionId: targetSessionId,
+                pin: studentPin,
+                period: classPeriod,
+              });
+              if (res.data.matched && res.data.customToken) {
+                await signInWithCustomToken(auth, res.data.customToken);
+                const refreshed = auth.currentUser;
+                if (refreshed) {
+                  currentUser = refreshed;
+                  isAnonymous = refreshed.isAnonymous;
+                }
+              }
+            } catch (err) {
+              logError(
+                'useVideoActivitySessionStudent.pinLoginBridge',
+                err as Error,
+                {
+                  sessionId: targetSessionId,
+                }
+              );
+            }
           }
 
           // Compute the deterministic response-doc key. Anonymous joiners get

--- a/hooks/useVideoActivitySession.ts
+++ b/hooks/useVideoActivitySession.ts
@@ -18,6 +18,7 @@ import {
   onSnapshot,
   updateDoc,
   arrayUnion,
+  increment,
   runTransaction,
   Unsubscribe,
   query,
@@ -29,6 +30,7 @@ import { logError } from '@/utils/logError';
 import {
   computeResponseKey,
   encodeResponseKeySegment,
+  AttemptLimitReachedError,
 } from '@/hooks/useQuizSession';
 import { normalizeVideoActivityQuestions } from '@/utils/videoActivityNormalize';
 import {
@@ -656,7 +658,35 @@ export const useVideoActivitySessionStudent =
             }
           }
 
-          if (!existingSnap.exists()) {
+          if (existingSnap.exists()) {
+            const existing = existingSnap.data() as VideoActivityResponse;
+            // Attempt-limit enforcement on rejoin.
+            //   - `attemptLimit == null/undefined` means unlimited.
+            //   - VA tracks completion via `completedAt != null` (no
+            //     `status` field), so any prior completion is treated as
+            //     ≥1 completed attempt even if the counter literally reads
+            //     0 (legacy docs that submitted before the counter was
+            //     wired up).
+            //   - Under the cap, reset the doc to a fresh attempt
+            //     (`completedAt: null, answers: []`); preserve
+            //     `completedAttempts` so future joins still see the cap.
+            if (existing.completedAt != null) {
+              const limit = sessionData.sessionOptions?.attemptLimit ?? null;
+              const completed = Math.max(existing.completedAttempts ?? 0, 1);
+              if (limit !== null && completed >= limit) {
+                setJoinStatus('error');
+                setError(new AttemptLimitReachedError().message);
+                throw new AttemptLimitReachedError();
+              }
+              await updateDoc(effectiveResponseRef, {
+                completedAt: null,
+                answers: [],
+                ...(classPeriod && existing.classPeriod !== classPeriod
+                  ? { classPeriod }
+                  : {}),
+              });
+            }
+          } else {
             // Initialize `completedAttempts` and `tabSwitchWarnings` to 0 so
             // the Firestore rules' monotonic-growth check on update has a
             // concrete prior value to compare against (otherwise
@@ -739,8 +769,22 @@ export const useVideoActivitySessionStudent =
         responseDocId
       );
 
-      await updateDoc(responseRef, {
-        completedAt: Date.now(),
+      // Wrap completion in a transaction so the "already-completed?" check
+      // and the timestamp/counter writes are atomic. Two concurrent
+      // completeActivity calls (rapid double-click, two browser tabs) would
+      // otherwise both write `completedAt` and double-increment
+      // `completedAttempts`, bypassing the cap. If the doc is already
+      // completed, no-op (idempotent — VA student-side has no error toast
+      // for repeated completes, and silently dropping is the right UX).
+      await runTransaction(db, async (tx) => {
+        const snap = await tx.get(responseRef);
+        if (!snap.exists()) return;
+        const existing = snap.data() as VideoActivityResponse;
+        if (existing.completedAt != null) return;
+        tx.update(responseRef, {
+          completedAt: Date.now(),
+          completedAttempts: increment(1),
+        });
       });
     }, [sessionId, responseDocId]);
 

--- a/tests/hooks/useQuizSession.test.ts
+++ b/tests/hooks/useQuizSession.test.ts
@@ -1499,7 +1499,11 @@ interface TeacherMockEnv {
   /** All `collection(...)` calls in argument-array form (post-db). */
   collectionCalls: unknown[][];
   /** Mock writeBatch instance the hook will use during finalize. */
-  batch: { update: ReturnType<typeof vi.fn>; commit: ReturnType<typeof vi.fn> };
+  batch: {
+    update: ReturnType<typeof vi.fn>;
+    delete: ReturnType<typeof vi.fn>;
+    commit: ReturnType<typeof vi.fn>;
+  };
 }
 
 /**
@@ -1518,6 +1522,7 @@ function setupTeacherMocks(): TeacherMockEnv {
     collectionCalls: [],
     batch: {
       update: vi.fn(),
+      delete: vi.fn(),
       commit: vi.fn().mockResolvedValue(undefined),
     },
   };
@@ -1616,11 +1621,20 @@ describe('useQuizSessionTeacher — removeStudent / revealAnswer / hideAnswer', 
       await result.current.removeStudent('pin-period_1-9999');
     });
 
-    expect(firestore.deleteDoc).toHaveBeenCalledTimes(1);
+    // Phase 2: removeStudent now writes through a batch so the response
+    // delete and the cross-launch ledger delete commit atomically. With
+    // no matching response loaded into the snapshot list (this hook
+    // started without a subscribeToSession call), the ledger ref is
+    // unresolvable — the batch should still issue the response delete
+    // exactly once and commit.
+    expect(env.batch.delete).toHaveBeenCalledTimes(1);
+    expect(env.batch.commit).toHaveBeenCalledTimes(1);
     // Confirm the path segments target the responses subcollection at the
     // PIN-derived key, which is what the teacher monitor passes in.
-    const lastDocCall = env.docCalls.at(-1);
-    expect(lastDocCall).toEqual([
+    const responseRef = env.batch.delete.mock.calls[0][0] as {
+      path: string[];
+    };
+    expect(responseRef.path).toEqual([
       'quiz_sessions',
       'sess-1',
       'responses',
@@ -1635,7 +1649,9 @@ describe('useQuizSessionTeacher — removeStudent / revealAnswer / hideAnswer', 
       await result.current.removeStudent('pin-period_1-9999');
     });
 
-    expect(firestore.deleteDoc).not.toHaveBeenCalled();
+    // No batch should be created when sessionId is null.
+    expect(env.batch.delete).not.toHaveBeenCalled();
+    expect(env.batch.commit).not.toHaveBeenCalled();
   });
 
   it('revealAnswer writes a dotted-path map entry on the session doc', async () => {

--- a/tests/hooks/useQuizSession.test.ts
+++ b/tests/hooks/useQuizSession.test.ts
@@ -1746,7 +1746,14 @@ describe('useQuizSessionTeacher — endQuizSession', () => {
     // finalizeAllResponses must touch only the two non-completed docs.
     expect(env.batch.update).toHaveBeenCalledTimes(2);
     const updateCalls = env.batch.update.mock.calls as Array<
-      [{ path: string[] }, { status: string; submittedAt: unknown }]
+      [
+        { path: string[] },
+        {
+          status: string;
+          submittedAt: unknown;
+          completedAttempts: unknown;
+        },
+      ]
     >;
     const updatedRefs = updateCalls.map((c) => c[0].path[3]);
     expect(updatedRefs).toEqual(
@@ -1756,6 +1763,13 @@ describe('useQuizSessionTeacher — endQuizSession', () => {
     for (const call of updateCalls) {
       expect(call[1]).toMatchObject({ status: 'completed' });
       expect(typeof call[1].submittedAt).toBe('number');
+      // Phase 1 Fix A: every finalized doc must include the
+      // `completedAttempts` field set via `increment(1)` so the join-side
+      // cap check sees the forced finalize as a real completed attempt.
+      // The auto-mock for `increment` returns undefined, so the assertion
+      // checks property presence rather than value (a missing key would
+      // be the actual regression — re-opening the rejoin-bypass).
+      expect(call[1]).toHaveProperty('completedAttempts');
     }
     expect(env.batch.commit).toHaveBeenCalledTimes(1);
   });

--- a/types.ts
+++ b/types.ts
@@ -2417,6 +2417,50 @@ export interface QuizResponse {
   preSyncVersion?: number;
 }
 
+/**
+ * Cross-launch attempt ledger. Stored at the top level
+ * `/quiz_attempt_ledger/{ledgerId}` where `ledgerId = ${quizId}__${studentUid}`.
+ *
+ * Per-session response docs are scoped under the session and reset every time
+ * a teacher launches a new session for the same quiz, so the per-session
+ * `completedAttempts` counter cannot enforce "1 attempt for this quiz, ever"
+ * across re-launches. The ledger sits above sessions and accumulates a
+ * student's attempts on a specific quiz regardless of how many times the
+ * teacher launches it.
+ *
+ * Identity: keyed by the student's auth.uid, which for SSO joiners is the
+ * stable HMAC pseudonym minted by `studentLoginV1`. PIN joiners' anonymous
+ * auth uids rotate per device, so the ledger only enforces meaningfully for
+ * SSO joiners — until Phase 3's `pinLoginV1` unifies the PIN flow onto the
+ * same uid space, at which point the ledger covers PIN joiners too without
+ * any change to this shape.
+ */
+export interface QuizAttemptLedger {
+  /** Matches `QuizSession.quizId`. Half of the deterministic ledger key. */
+  quizId: string;
+  /** Matches `auth.uid`. Other half of the deterministic ledger key. */
+  studentUid: string;
+  /**
+   * UID of the teacher who owns the quiz. Carried so Firestore rules can
+   * authorize the teacher's reset action without a second `get()` to look
+   * up the parent quiz; also supports admin-only repair flows.
+   */
+  teacherUid: string;
+  /**
+   * Monotonic counter — incremented inside the same transaction that flips
+   * a session's response doc to `status: 'completed'`. The teacher reset
+   * path (see `removeStudent`) sets this back to 0.
+   */
+  completedAttempts: number;
+  /** Server-time `Date.now()` of the most recent successful completion. */
+  lastAttemptAt: number;
+  /**
+   * Session id of the most recent successful completion. Diagnostic
+   * breadcrumb only — never read for enforcement.
+   */
+  lastSessionId?: string;
+}
+
 /** Global admin configuration for the Quiz widget */
 export interface QuizGlobalConfig {
   dockDefaults?: Record<string, boolean>;
@@ -3157,6 +3201,27 @@ export interface VideoActivityResponse {
    * publishes scores; mirrors `VideoActivityScoreVisibility`.
    */
   scoreVisibility?: VideoActivityScoreVisibility;
+}
+
+/**
+ * Cross-launch attempt ledger for Video Activity. Mirrors
+ * `QuizAttemptLedger` exactly — see that type's docs for the rationale.
+ * Stored at `/video_activity_attempt_ledger/{ledgerId}` where
+ * `ledgerId = ${activityId}__${studentUid}`.
+ */
+export interface VideoActivityAttemptLedger {
+  /** Matches `VideoActivitySession.activityId`. */
+  activityId: string;
+  /** Matches `auth.uid`. */
+  studentUid: string;
+  /** UID of the teacher who owns the activity. */
+  teacherUid: string;
+  /** Monotonic counter; reset to 0 by the teacher's removeStudent action. */
+  completedAttempts: number;
+  /** Server-time `Date.now()` of the most recent successful completion. */
+  lastAttemptAt: number;
+  /** Diagnostic breadcrumb — most recent session id; not used for enforcement. */
+  lastSessionId?: string;
 }
 
 export interface TalkingToolConfig {

--- a/types.ts
+++ b/types.ts
@@ -2418,6 +2418,46 @@ export interface QuizResponse {
 }
 
 /**
+ * Per-roster, non-PII PIN index. Stored at
+ * `/users/{teacherUid}/rosters/{rosterId}/pin_index/{indexKey}`.
+ *
+ * Bridges PIN-joining students into the same identity space as SSO
+ * (`studentLoginV1`) joiners. The index maps `(period, pin)` → the same
+ * HMAC pseudonym uid `studentLoginV1` would mint for the student, so a
+ * PIN client can sign in via `pinLoginV1` with a custom token whose uid
+ * matches the SSO uid. Result: one student, one response doc per
+ * session, regardless of which auth path they took. Closes the
+ * mixed-auth duplicate path (Hypothesis E in the attempt-cap fix).
+ *
+ * Non-PII by design: the doc holds only opaque hashes and ids. PIN
+ * values are SpartBoard-internal join codes and don't identify a person
+ * without the (private) roster.
+ *
+ * Index key (`indexKey`):
+ *   `${encodeResponseKeySegment(period)}__${encodeResponseKeySegment(pin)}`
+ * — same encoder Quiz response docs use, so the shape is consistent
+ * across PIN-related collections.
+ *
+ * Populated by `commitRosterPinIndexV1` (callable, teacher-only). Read
+ * via `admin SDK` inside `pinLoginV1` (callable, public). Client clients
+ * never read or write these docs directly.
+ */
+export interface RosterPinIndexEntry {
+  /** HMAC(STUDENT_PSEUDONYM_HMAC_SECRET, `sid:${classlinkSourcedId}`). */
+  pseudonym: string;
+  /**
+   * The student's ClassLink class `sourcedId`. Written into the minted
+   * custom token's `classIds` claim so the student passes
+   * `passesStudentClassGate` on the session's responses.
+   */
+  classId: string;
+  /** Raw period name. Diagnostic only — `indexKey` carries the encoded form. */
+  period: string;
+  /** Server-time ms of the most recent index rebuild for this entry. */
+  updatedAt: number;
+}
+
+/**
  * Cross-launch attempt ledger. Stored at the top level
  * `/quiz_attempt_ledger/{ledgerId}` where `ledgerId = ${quizId}__${studentUid}`.
  *

--- a/types.ts
+++ b/types.ts
@@ -2439,8 +2439,8 @@ export interface QuizResponse {
  * across PIN-related collections.
  *
  * Populated by `commitRosterPinIndexV1` (callable, teacher-only). Read
- * via `admin SDK` inside `pinLoginV1` (callable, public). Client clients
- * never read or write these docs directly.
+ * via `admin SDK` inside `pinLoginV1` (callable, public). Clients never
+ * read or write these docs directly.
  */
 export interface RosterPinIndexEntry {
   /** HMAC(STUDENT_PSEUDONYM_HMAC_SECRET, `sid:${classlinkSourcedId}`). */
@@ -2451,6 +2451,16 @@ export interface RosterPinIndexEntry {
    * `passesStudentClassGate` on the session's responses.
    */
   classId: string;
+  /**
+   * ClassLink organization id (from the parent roster's `classlinkOrgId`).
+   * Stored on each pin_index entry so `pinLoginV1` can mint the custom
+   * token with the right `orgId` claim using a single doc read per
+   * roster probe — without it, the function would have to fan out a
+   * `collectionGroup('rosters').where('classlinkClassId'…)` lookup on
+   * every PIN login (a hot path: every PIN-bridged join). Empty string
+   * for rosters whose roster doc is missing the field.
+   */
+  orgId: string;
   /** Raw period name. Diagnostic only — `indexKey` carries the encoded form. */
   period: string;
   /** Server-time ms of the most recent index rebuild for this entry. */


### PR DESCRIPTION
## Why this PR

Closes a quiz attempt-cap bypass reported by Jen Ivers: a teacher set a quiz to 1 attempt, students logged in via the SSO student link and opened the quiz from `/my-assignments`, and at least one student was nevertheless able to complete the quiz more than once.

Diagnosis on the offending production session (`02b3bb3b…`, Week 3 quiz, `attemptLimit: 1`) showed five independently-broken enforcement layers. Each phase below closes one cluster:

| Hypothesis | Phase that closes it |
|---|---|
| A — `finalizeAllResponses` zeros the counter | 1 |
| B — Per-session limit, not per-quiz | 2 |
| C — Two-tab race in `completeQuiz` | 1 |
| D — No server-side cap | 1 |
| E — Mixed-auth duplicate (SSO + PIN both create response docs) | 3 |

**The bug we observed in production was almost certainly E** — the offending session has 18 SSO-keyed response docs alongside 5 PIN-keyed docs, in a session that was supposed to be SSO-only. A and C/D were latent for the same teachers; B is a semantic mismatch that comes up every time a teacher relaunches.

## ⚠️ Merge with **standard merge**, not squash

Three reviewable commits, intentionally separated. Each is its own coherent change with a focused commit message.

```
Phase 3  feat(quiz,va): PIN→SSO identity unification via pin_index
Phase 2  feat(quiz,va): cross-launch attempt ledger
Phase 1  fix(quiz,va):  defense-in-depth attempt-cap enforcement
```

When merging into `dev-paul`, **uncheck "squash"** so the three commits land separately. (Default for this repo is squash; this is the deliberate exception for this PR.)

## Phase 1 — Defense-in-depth within a session

- `finalizeAllResponses` now writes `completedAttempts: increment(1)` so a session-end sweep counts as a real completed attempt instead of leaving a stored 0 that the rejoin check happily steps over.
- Join cap check now uses `Math.max(completedAttempts ?? 0, 1)` for any `status === 'completed'` doc — a literal stored 0 can no longer slip through.
- `completeQuiz` and `completeActivity` are now `runTransaction` calls that read-then-write atomically and short-circuit on already-completed (new typed `AlreadySubmittedError` sentinel). Kills two-tab races and double-clicks.
- `firestore.rules` for `quiz_sessions/responses` and `video_activity_sessions/responses` now read the parent session's `attemptLimit` and deny any student-side update that pushes `completedAttempts` past it. Status / `completedAt` transitions from completed → completed are denied (same race protection at the rule layer).
- `QuizStudentApp` and `VideoActivityStudentApp` short-circuit to the submitted screen whenever `completedAttempts >= attemptLimit`, regardless of `status`. Defense in depth — kicks in only if some future bug leaks state past the hook checks.
- VA's join previously had **no attempt-cap enforcement at all**; this phase adds the same join cap + reset logic Quiz had.

## Phase 2 — Cross-launch attempt ledger

Per-session counters reset on every relaunch. New top-level cross-launch ledger keyed by `(content, student)` accumulates a student's completed attempts regardless of how many times the teacher relaunches.

- `/quiz_attempt_ledger/{quizId__studentUid}` and `/video_activity_attempt_ledger/{activityId__studentUid}`. Schema: `QuizAttemptLedger` / `VideoActivityAttemptLedger`. Stores `completedAttempts` (monotonic), `lastAttemptAt`, `lastSessionId`. Non-PII opaque ids only.
- `joinQuizSession` / VA `joinSession` read the ledger before admitting the student. Cap = `max(per-session counter, ledger counter, 1 if completed)`. New "no response yet but ledger says capped" branch handles the SSO student opening the new launch from `/my-assignments`.
- `completeQuiz` / `completeActivity` write the ledger increment **inside the same `runTransaction`** as the response status flip (reads precede writes per Firestore's rules) so concurrency cannot double-bump.
- `removeStudent` (Quiz) extends to a `writeBatch` that atomically deletes the response doc **and** the ledger entry, preserving the existing "free this student up to retake" UX. (VA has no `removeStudent` hook surface; ledger reset can ship later.)
- New rules for both ledger collections. Student create requires `completedAttempts == 1` exactly; student update requires `== old + 1` exactly (no jumping the counter); teacher reset requires `== 0`. Identity fields immutable.

**Identity caveat (resolved by Phase 3):** the ledger keys on `auth.uid`. SSO/`studentRole` users have a stable HMAC pseudonym, so the ledger enforces meaningfully. PIN joiners get a rotating anonymous uid — the Phase 3 bridge upgrades them to the SSO uid space, at which point this ledger covers them too with no further changes here.

## Phase 3 — PIN→SSO identity unification

Closes Hypothesis E. A student rostered into an SSO class can take a quiz once via `/my-assignments` (SSO doc keyed by HMAC pseudonym uid) AND once via `/quiz?code=…` with their PIN (PIN doc keyed `pin-{period}-{pin}`). Two different doc keys, two independent counters. **Production data on the offending session shows this happening live.**

Architecture is constrained by the existing "no PII in Firestore" policy: PINs and sourcedIds live in a Drive-backed roster file. The PIN-joining client cannot resolve identity locally. So:

- New non-PII Firestore sidecar at `/users/{teacherUid}/rosters/{rosterId}/pin_index/{indexKey}`. Maps `(period, pin) → HMAC pseudonym + classId`. Schema: `RosterPinIndexEntry` in `types.ts`. Holds only opaque hashes and ids.
- New `commitRosterPinIndexV1(rosterId, entries)` cloud function. Teacher-only. Reads the roster doc to recover `classlinkClassId`, computes pseudonyms with the same HMAC formula `studentLoginV1` uses, replaces the roster's pin_index in a single batch (writes desired entries + deletes the rest). Idempotent.
- New `pinLoginV1(kind, sessionId|code, pin, period?)` cloud function. Public. Resolves session → walks `rosterIds` → reads `pin_index/{indexKey}` → on hit mints a custom token whose uid matches what `studentLoginV1` would have minted for that student over SSO, plus `studentRole: true` and `classIds: [classId]`. On miss returns `matched: false` so the client falls through to the legacy anonymous PIN flow.
- `useRosters.ts` calls `commitRosterPinIndexV1` after every successful Drive write (create + update). Best-effort; failures log and continue.
- `useQuizSession.ts` and `useVideoActivitySession.ts` join flows: when joiner is anonymous AND has a PIN AND session has `rosterIds`, call `pinLoginV1` first and `signInWithCustomToken` with the result. After the swap, `studentUid` / `isAnonymous` are reassigned and the rest of the join (deterministic key, ledger lookup, SSO classId resolution) runs against the upgraded identity. The PIN-side and SSO-side response docs converge on the same key.
- `firestore.rules`: `pin_index` is admin-write-only (the cloud functions use admin SDK); read by the owning teacher and admins. Students never touch this collection directly.

**Migration:** new rosters get the index built on first save after deploy. Existing rosters get it built next time the teacher opens / saves the roster. Until then, PIN students of unindexed rosters fall back to the legacy anonymous flow — no regression, just no Phase 3 benefit on those rosters yet.

## Test plan

- [x] `pnpm run validate` passes locally (type-check, lint, format-check, 2166/2166 unit tests).
- [ ] CI passes (rules tests cannot run locally — Java 21+ required; CI has the right JDK).
- [ ] Manual on the dev preview URL:
  - [ ] Teacher launches a quiz with `attemptLimit: 1`, student completes via SSO → second open from `/my-assignments` shows the cap-reached UI.
  - [ ] Teacher ends and re-launches the same quiz (different `quiz_sessions` doc, same `quizId`); student opens new launch → cap-reached UI (Phase 2 ledger).
  - [ ] SSO student completes once; same student tries to join again via PIN at `/quiz?code=…` → cap-reached UI (Phase 3 bridge converges them on one response doc).
  - [ ] Two-tab test: SSO student opens quiz in tabs A and B, submits in A, attempts submit in B → second submission no-ops (Phase 1 transaction).
  - [ ] Teacher uses "Remove student" → student can take it once more, then is capped again (Phase 2 ledger reset).
  - [ ] Non-rostered PIN-only session still works (legacy fallback path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
