### PR TITLE
feat(quiz-monitor): default roster open, gate score reveal, period chips

### DIFF
--- a/components/widgets/QuizWidget/components/QuizLiveMonitor.tsx
+++ b/components/widgets/QuizWidget/components/QuizLiveMonitor.tsx
@@ -350,7 +350,9 @@ export const QuizLiveMonitor: React.FC<QuizLiveMonitorProps> = ({
   // monitor. Defaults to false so a fresh open never shows scores or
   // score-band tinting on what may be a projected screen, regardless of
   // the teacher's persisted preference. Toggling Colors or Score Display
-  // requires confirming a privacy-aware reveal once per session.
+  // requires confirming a privacy-aware reveal, and the flag resets when
+  // the session id changes (see the session-change block below) so each
+  // quiz starts hidden again.
   const [scoreRevealApproved, setScoreRevealApproved] = useState(false);
 
   // Periods this assignment was launched against, deduped while preserving
@@ -547,15 +549,18 @@ export const QuizLiveMonitor: React.FC<QuizLiveMonitorProps> = ({
   const lastLeaderboardFingerprintRef = useRef<string | null>(null);
   const hasClearedLeaderboardRef = useRef(false);
 
-  // Reset leaderboard tracking refs when the session id changes. Done during
+  // Reset session-scoped tracking when the session id changes. Done during
   // render via the "adjusting state while rendering" pattern (see React docs)
   // instead of an effect — useEffect is reserved for syncing with external
-  // systems, and ref assignment is purely local.
+  // systems, and ref assignment is purely local. Includes the score-reveal
+  // approval flag so a teacher's confirm in one quiz doesn't silently leak
+  // scores when the same QuizLiveMonitor instance hosts a new session.
   const [prevSessionId, setPrevSessionId] = useState(session.id);
   if (prevSessionId !== session.id) {
     setPrevSessionId(session.id);
     lastLeaderboardFingerprintRef.current = null;
     hasClearedLeaderboardRef.current = false;
+    setScoreRevealApproved(false);
   }
 
   // Broadcast student-safe live leaderboard snapshot for gamified sessions.

--- a/components/widgets/QuizWidget/components/QuizLiveMonitor.tsx
+++ b/components/widgets/QuizWidget/components/QuizLiveMonitor.tsx
@@ -424,13 +424,30 @@ export const QuizLiveMonitor: React.FC<QuizLiveMonitorProps> = ({
   // override the persisted preference until the teacher confirms it's
   // safe to display student performance on this screen — a projector
   // could otherwise leak grades the moment the monitor opens.
+  // Effective values gated by the session-local reveal approval. We
+  // override the persisted preference until the teacher confirms it's
+  // safe to display student performance on this screen — a projector
+  // could otherwise leak grades the moment the monitor opens.
   const effectiveColorsEnabled =
     scoreRevealApproved && quizMonitorColorsEnabled;
   const effectiveScoreDisplay: 'percent' | 'count' | 'hidden' =
     scoreRevealApproved ? quizMonitorScoreDisplay : 'hidden';
 
+  // Live session-id tracker. The `requestScoreReveal` callback can stay
+  // mounted while a teacher's confirm dialog awaits, and Firestore can
+  // swap `session.id` underneath. `useCallback` would close over a stale
+  // `session.id` from its capturing render, so we read the current id
+  // through a ref that's updated every render.
+  const sessionIdRef = useRef(session.id);
+  sessionIdRef.current = session.id;
+
   const requestScoreReveal = useCallback(async () => {
     if (scoreRevealApproved) return true;
+    // Capture the session this prompt belongs to. If the active session
+    // changes mid-await, the resolution must NOT apply approval to the
+    // fresh session — that would silently bypass the gate on a session
+    // the teacher never agreed to reveal.
+    const sessionAtRequest = sessionIdRef.current;
     const ok = await showConfirm(
       "Heads up — this monitor may be projected to the class. Confirm only if it's appropriate to display student performance on the current screen.",
       {
@@ -440,6 +457,7 @@ export const QuizLiveMonitor: React.FC<QuizLiveMonitorProps> = ({
         cancelLabel: 'Keep hidden',
       }
     );
+    if (sessionIdRef.current !== sessionAtRequest) return false;
     if (ok) setScoreRevealApproved(true);
     return ok;
   }, [scoreRevealApproved, showConfirm]);
@@ -2540,7 +2558,7 @@ const StudentRow: React.FC<{
 
   return (
     <div
-      className={`flex items-center rounded-xl border transition-all group/row ${rowBg}`}
+      className={`flex items-center rounded-xl border transition-all ${rowBg}`}
       style={{
         gap: 'min(8px, 2cqmin)',
         padding: 'min(8px, 2cqmin)',

--- a/components/widgets/QuizWidget/components/QuizLiveMonitor.tsx
+++ b/components/widgets/QuizWidget/components/QuizLiveMonitor.tsx
@@ -71,6 +71,7 @@ import {
   playPodiumFanfare,
   playQuizCompleteCelebration,
 } from '@/utils/quizAudio';
+import { logError } from '@/utils/logError';
 
 interface QuizLiveMonitorProps {
   session: QuizSession;
@@ -407,23 +408,29 @@ export const QuizLiveMonitor: React.FC<QuizLiveMonitorProps> = ({
   // Apply the class-period filter to the response stream that drives the
   // monitor's KPIs and roster. Leaderboard broadcasts intentionally use the
   // unfiltered `responses` so the student-facing leaderboard stays global.
+  // SSO joiners write `classPeriod` directly when their classIds claim
+  // resolves cleanly, but multi-class students or claim failures can leave
+  // a row with only `classId`. Resolve those through
+  // `session.classPeriodByClassId` before filtering so SSO students don't
+  // silently disappear from a narrowed view.
   const filteredResponses = useMemo(() => {
     if (!filterActive) return responses;
     const allow = new Set(selectedPeriodNames);
-    // Drop SSO/legacy rows that have no `classPeriod`: when the teacher
-    // narrows to a specific period they expect a clean view, and a row
-    // with no period claim should not silently leak through.
-    return responses.filter((r) =>
-      r.classPeriod ? allow.has(r.classPeriod) : false
-    );
-  }, [responses, selectedPeriodNames, filterActive]);
+    const classIdToPeriod = session.classPeriodByClassId ?? {};
+    return responses.filter((r) => {
+      const period =
+        r.classPeriod ?? (r.classId ? classIdToPeriod[r.classId] : undefined);
+      return period ? allow.has(period) : false;
+    });
+  }, [
+    responses,
+    selectedPeriodNames,
+    filterActive,
+    session.classPeriodByClassId,
+  ]);
 
   const { addToast } = useDashboard();
 
-  // Effective values gated by the session-local reveal approval. We
-  // override the persisted preference until the teacher confirms it's
-  // safe to display student performance on this screen — a projector
-  // could otherwise leak grades the moment the monitor opens.
   // Effective values gated by the session-local reveal approval. We
   // override the persisted preference until the teacher confirms it's
   // safe to display student performance on this screen — a projector
@@ -462,6 +469,23 @@ export const QuizLiveMonitor: React.FC<QuizLiveMonitorProps> = ({
     return ok;
   }, [scoreRevealApproved, showConfirm]);
 
+  // Single seam for the "preference write failed" pattern. Routes the error
+  // through the structured `logError` helper (so future Sentry/Bugsnag
+  // wiring picks these up) and surfaces a toast with a label-specific
+  // message. Returned as a `.catch` handler factory so each call site
+  // stays a one-liner.
+  const persistPreferenceFailed = useCallback(
+    (scope: string, label: string) =>
+      (err: unknown): void => {
+        logError(`QuizLiveMonitor.${scope}`, err);
+        addToast(
+          `Could not save the ${label} preference — try again or check your connection.`,
+          'error'
+        );
+      },
+    [addToast]
+  );
+
   const handleToggleColors = useCallback(() => {
     void (async () => {
       // Turning ON requires confirmation while results are still gated.
@@ -469,30 +493,15 @@ export const QuizLiveMonitor: React.FC<QuizLiveMonitorProps> = ({
         const ok = await requestScoreReveal();
         if (!ok) return;
         if (!quizMonitorColorsEnabled) {
-          updateAccountPreferences({ quizMonitorColorsEnabled: true }).catch(
-            (err: unknown) => {
-              console.error(
-                '[QuizLiveMonitor] persist colors toggle failed:',
-                err
-              );
-              addToast(
-                'Could not save the Colors preference — try again or check your connection.',
-                'error'
-              );
-            }
-          );
+          updateAccountPreferences({
+            quizMonitorColorsEnabled: true,
+          }).catch(persistPreferenceFailed('persistColorsToggle', 'Colors'));
         }
         return;
       }
       // Turning OFF — no confirmation needed.
       updateAccountPreferences({ quizMonitorColorsEnabled: false }).catch(
-        (err: unknown) => {
-          console.error('[QuizLiveMonitor] persist colors toggle failed:', err);
-          addToast(
-            'Could not save the Colors preference — try again or check your connection.',
-            'error'
-          );
-        }
+        persistPreferenceFailed('persistColorsToggle', 'Colors')
       );
     })();
   }, [
@@ -500,7 +509,7 @@ export const QuizLiveMonitor: React.FC<QuizLiveMonitorProps> = ({
     quizMonitorColorsEnabled,
     requestScoreReveal,
     updateAccountPreferences,
-    addToast,
+    persistPreferenceFailed,
   ]);
 
   const handleCycleScoreDisplay = useCallback(() => {
@@ -516,16 +525,7 @@ export const QuizLiveMonitor: React.FC<QuizLiveMonitorProps> = ({
             : quizMonitorScoreDisplay;
         if (next !== quizMonitorScoreDisplay) {
           updateAccountPreferences({ quizMonitorScoreDisplay: next }).catch(
-            (err: unknown) => {
-              console.error(
-                '[QuizLiveMonitor] persist score-display cycle failed:',
-                err
-              );
-              addToast(
-                'Could not save the score display preference — try again or check your connection.',
-                'error'
-              );
-            }
+            persistPreferenceFailed('persistScoreDisplayCycle', 'score display')
           );
         }
         return;
@@ -537,16 +537,7 @@ export const QuizLiveMonitor: React.FC<QuizLiveMonitorProps> = ({
             ? 'hidden'
             : 'percent';
       updateAccountPreferences({ quizMonitorScoreDisplay: next }).catch(
-        (err: unknown) => {
-          console.error(
-            '[QuizLiveMonitor] persist score-display cycle failed:',
-            err
-          );
-          addToast(
-            'Could not save the score display preference — try again or check your connection.',
-            'error'
-          );
-        }
+        persistPreferenceFailed('persistScoreDisplayCycle', 'score display')
       );
     })();
   }, [
@@ -554,7 +545,7 @@ export const QuizLiveMonitor: React.FC<QuizLiveMonitorProps> = ({
     quizMonitorScoreDisplay,
     requestScoreReveal,
     updateAccountPreferences,
-    addToast,
+    persistPreferenceFailed,
   ]);
   const [confirmRemove, setConfirmRemove] = useState<ResponseDocKey | null>(
     null

--- a/components/widgets/QuizWidget/components/QuizLiveMonitor.tsx
+++ b/components/widgets/QuizWidget/components/QuizLiveMonitor.tsx
@@ -33,7 +33,6 @@ import {
   VolumeX,
   Palette,
   Percent,
-  Filter,
   Medal,
   Pause,
   Play,
@@ -72,7 +71,6 @@ import {
   playPodiumFanfare,
   playQuizCompleteCelebration,
 } from '@/utils/quizAudio';
-import { PeriodSelector } from '@/components/common/library/PeriodSelector';
 
 interface QuizLiveMonitorProps {
   session: QuizSession;
@@ -318,7 +316,10 @@ export const QuizLiveMonitor: React.FC<QuizLiveMonitorProps> = ({
   const [showStats, setShowStats] = useState(false);
   const [advancing, setAdvancing] = useState(false);
   const [ending, setEnding] = useState(false);
-  const [showRoster, setShowRoster] = useState(false);
+  // Roster is visible by default — teachers monitoring a live session
+  // expect the student list immediately; gating it behind a click hurt
+  // discoverability, especially on touch devices.
+  const [showRoster, setShowRoster] = useState(true);
   const [autoCountdown, setAutoCountdown] = useState<number | null>(null);
   const [showLiveScoreboardSetup, setShowLiveScoreboardSetup] = useState(false);
   const [liveScoreboardMode, setLiveScoreboardMode] = useState<'pin' | 'name'>(
@@ -340,9 +341,17 @@ export const QuizLiveMonitor: React.FC<QuizLiveMonitorProps> = ({
     Boolean(session.showPodiumBetweenQuestions);
   const showScoreboardControl = isGamifiedSession || isLiveScoreboardActive;
 
-  // New state for Phase 1 & 2 features
-  const [showTabWarnings, setShowTabWarnings] = useState(true);
-  const [showPeriodFilter, setShowPeriodFilter] = useState(false);
+  // Tab-switch warnings are hidden by default — they're noise during
+  // normal monitoring and only meaningful for assessments. Teachers can
+  // surface them on demand from the roster toolbar.
+  const [showTabWarnings, setShowTabWarnings] = useState(false);
+
+  // Session-local approval gate for revealing student performance on the
+  // monitor. Defaults to false so a fresh open never shows scores or
+  // score-band tinting on what may be a projected screen, regardless of
+  // the teacher's persisted preference. Toggling Colors or Score Display
+  // requires confirming a privacy-aware reveal once per session.
+  const [scoreRevealApproved, setScoreRevealApproved] = useState(false);
 
   // Periods this assignment was launched against, deduped while preserving
   // order. Drives the class-period filter UI: hidden when there's only a
@@ -352,12 +361,16 @@ export const QuizLiveMonitor: React.FC<QuizLiveMonitorProps> = ({
     return Array.from(new Set(list.filter((p) => typeof p === 'string' && p)));
   }, [session.periodNames]);
 
-  // Selected periods for the live monitor view. Default = all targeted periods
-  // so a fresh open shows the same data the teacher is used to. Local state —
-  // resets between sessions, which is the right default for a transient
-  // monitor filter (teachers usually want to start with everyone visible).
+  // Selected periods for the live monitor view. Teachers run live
+  // sessions one period at a time, so the default narrows to the first
+  // targeted period rather than dumping every period into the same KPI
+  // counts and roster (which obscured "who's in this room right now").
+  // When the assignment only targets one period this is a no-op.
   const [selectedPeriodNames, setSelectedPeriodNames] = useState<string[]>(
-    () => sessionPeriodNames
+    () =>
+      sessionPeriodNames.length > 1
+        ? [sessionPeriodNames[0]]
+        : sessionPeriodNames
   );
   // If the assignment's targeted periods change (e.g. teacher edits the
   // assignment in another tab), reset the selection rather than letting it go
@@ -375,7 +388,11 @@ export const QuizLiveMonitor: React.FC<QuizLiveMonitorProps> = ({
     prevPeriods.some((p, i) => p !== sessionPeriodNames[i]);
   if (periodsChanged && sessionPeriodNames.length > 0) {
     lastSessionPeriodsRef.current = sessionPeriodNames;
-    setSelectedPeriodNames(sessionPeriodNames);
+    setSelectedPeriodNames(
+      sessionPeriodNames.length > 1
+        ? [sessionPeriodNames[0]]
+        : sessionPeriodNames
+    );
   }
 
   // True when the user has narrowed the session's targeted periods. Used
@@ -401,39 +418,124 @@ export const QuizLiveMonitor: React.FC<QuizLiveMonitorProps> = ({
 
   const { addToast } = useDashboard();
 
-  const handleToggleColors = useCallback(() => {
-    const next = !quizMonitorColorsEnabled;
-    updateAccountPreferences({ quizMonitorColorsEnabled: next }).catch(
-      (err: unknown) => {
-        console.error('[QuizLiveMonitor] persist colors toggle failed:', err);
-        addToast(
-          'Could not save the Colors preference — try again or check your connection.',
-          'error'
-        );
+  // Effective values gated by the session-local reveal approval. We
+  // override the persisted preference until the teacher confirms it's
+  // safe to display student performance on this screen — a projector
+  // could otherwise leak grades the moment the monitor opens.
+  const effectiveColorsEnabled =
+    scoreRevealApproved && quizMonitorColorsEnabled;
+  const effectiveScoreDisplay: 'percent' | 'count' | 'hidden' =
+    scoreRevealApproved ? quizMonitorScoreDisplay : 'hidden';
+
+  const requestScoreReveal = useCallback(async () => {
+    if (scoreRevealApproved) return true;
+    const ok = await showConfirm(
+      "Heads up — this monitor may be projected to the class. Confirm only if it's appropriate to display student performance on the current screen.",
+      {
+        title: 'Reveal student results?',
+        variant: 'warning',
+        confirmLabel: 'Yes, reveal',
+        cancelLabel: 'Keep hidden',
       }
     );
-  }, [quizMonitorColorsEnabled, updateAccountPreferences, addToast]);
+    if (ok) setScoreRevealApproved(true);
+    return ok;
+  }, [scoreRevealApproved, showConfirm]);
+
+  const handleToggleColors = useCallback(() => {
+    void (async () => {
+      // Turning ON requires confirmation while results are still gated.
+      if (!effectiveColorsEnabled) {
+        const ok = await requestScoreReveal();
+        if (!ok) return;
+        if (!quizMonitorColorsEnabled) {
+          updateAccountPreferences({ quizMonitorColorsEnabled: true }).catch(
+            (err: unknown) => {
+              console.error(
+                '[QuizLiveMonitor] persist colors toggle failed:',
+                err
+              );
+              addToast(
+                'Could not save the Colors preference — try again or check your connection.',
+                'error'
+              );
+            }
+          );
+        }
+        return;
+      }
+      // Turning OFF — no confirmation needed.
+      updateAccountPreferences({ quizMonitorColorsEnabled: false }).catch(
+        (err: unknown) => {
+          console.error('[QuizLiveMonitor] persist colors toggle failed:', err);
+          addToast(
+            'Could not save the Colors preference — try again or check your connection.',
+            'error'
+          );
+        }
+      );
+    })();
+  }, [
+    effectiveColorsEnabled,
+    quizMonitorColorsEnabled,
+    requestScoreReveal,
+    updateAccountPreferences,
+    addToast,
+  ]);
 
   const handleCycleScoreDisplay = useCallback(() => {
-    const next: 'percent' | 'count' | 'hidden' =
-      quizMonitorScoreDisplay === 'percent'
-        ? 'count'
-        : quizMonitorScoreDisplay === 'count'
-          ? 'hidden'
-          : 'percent';
-    updateAccountPreferences({ quizMonitorScoreDisplay: next }).catch(
-      (err: unknown) => {
-        console.error(
-          '[QuizLiveMonitor] persist score-display cycle failed:',
-          err
-        );
-        addToast(
-          'Could not save the score display preference — try again or check your connection.',
-          'error'
-        );
+    void (async () => {
+      // Cycling away from "hidden" reveals scores — gate it behind the
+      // same approval prompt as the Colors toggle.
+      if (effectiveScoreDisplay === 'hidden') {
+        const ok = await requestScoreReveal();
+        if (!ok) return;
+        const next =
+          quizMonitorScoreDisplay === 'hidden'
+            ? 'percent'
+            : quizMonitorScoreDisplay;
+        if (next !== quizMonitorScoreDisplay) {
+          updateAccountPreferences({ quizMonitorScoreDisplay: next }).catch(
+            (err: unknown) => {
+              console.error(
+                '[QuizLiveMonitor] persist score-display cycle failed:',
+                err
+              );
+              addToast(
+                'Could not save the score display preference — try again or check your connection.',
+                'error'
+              );
+            }
+          );
+        }
+        return;
       }
-    );
-  }, [quizMonitorScoreDisplay, updateAccountPreferences, addToast]);
+      const next: 'percent' | 'count' | 'hidden' =
+        quizMonitorScoreDisplay === 'percent'
+          ? 'count'
+          : quizMonitorScoreDisplay === 'count'
+            ? 'hidden'
+            : 'percent';
+      updateAccountPreferences({ quizMonitorScoreDisplay: next }).catch(
+        (err: unknown) => {
+          console.error(
+            '[QuizLiveMonitor] persist score-display cycle failed:',
+            err
+          );
+          addToast(
+            'Could not save the score display preference — try again or check your connection.',
+            'error'
+          );
+        }
+      );
+    })();
+  }, [
+    effectiveScoreDisplay,
+    quizMonitorScoreDisplay,
+    requestScoreReveal,
+    updateAccountPreferences,
+    addToast,
+  ]);
   const [confirmRemove, setConfirmRemove] = useState<ResponseDocKey | null>(
     null
   );
@@ -1137,6 +1239,18 @@ export const QuizLiveMonitor: React.FC<QuizLiveMonitorProps> = ({
                 />
               )}
 
+              {/* 2a. CLASS-PERIOD CHIPS — visible at the top of the
+                     KPI cluster so teachers see immediately which
+                     period is driving the counts and roster below.
+                     Defaults to a single period (set in state init);
+                     the All chip widens back out. */}
+              <PeriodChipFilter
+                sessionPeriodNames={sessionPeriodNames}
+                selectedPeriodNames={selectedPeriodNames}
+                onSelectPeriod={(name) => setSelectedPeriodNames([name])}
+                onSelectAll={() => setSelectedPeriodNames(sessionPeriodNames)}
+              />
+
               {/* 2. INTERACTIVE STAT BOXES — tappable to show students */}
               <div
                 className="grid grid-cols-3"
@@ -1385,18 +1499,9 @@ export const QuizLiveMonitor: React.FC<QuizLiveMonitorProps> = ({
                     </button>
                     {showRoster && (
                       <RosterToolbar
-                        rosters={rosters}
-                        sessionPeriodNames={sessionPeriodNames}
-                        selectedPeriodNames={selectedPeriodNames}
-                        onChangeSelectedPeriods={setSelectedPeriodNames}
-                        showPeriodFilter={showPeriodFilter}
-                        onTogglePeriodFilter={() =>
-                          setShowPeriodFilter(!showPeriodFilter)
-                        }
-                        onClosePeriodFilter={() => setShowPeriodFilter(false)}
-                        colorsEnabled={quizMonitorColorsEnabled}
+                        colorsEnabled={effectiveColorsEnabled}
                         onToggleColors={handleToggleColors}
-                        scoreDisplay={quizMonitorScoreDisplay}
+                        scoreDisplay={effectiveScoreDisplay}
                         onCycleScoreDisplay={handleCycleScoreDisplay}
                         tabWarningsAllowed={
                           session.tabWarningsEnabled !== false
@@ -1452,8 +1557,8 @@ export const QuizLiveMonitor: React.FC<QuizLiveMonitorProps> = ({
                               totalQuestions={session.totalQuestions}
                               questions={quizData.questions}
                               scoringConfig={scoringConfig}
-                              colorsEnabled={quizMonitorColorsEnabled}
-                              scoreDisplay={quizMonitorScoreDisplay}
+                              colorsEnabled={effectiveColorsEnabled}
+                              scoreDisplay={effectiveScoreDisplay}
                               showTabWarnings={
                                 showTabWarnings &&
                                 session.tabWarningsEnabled !== false
@@ -1630,6 +1735,16 @@ export const QuizLiveMonitor: React.FC<QuizLiveMonitorProps> = ({
                 </div>
               )}
 
+              {/* Period chips above stat boxes — same pattern as the
+                  active layout so teachers can preview / review one
+                  period at a time before starting or after ending. */}
+              <PeriodChipFilter
+                sessionPeriodNames={sessionPeriodNames}
+                selectedPeriodNames={selectedPeriodNames}
+                onSelectPeriod={(name) => setSelectedPeriodNames([name])}
+                onSelectAll={() => setSelectedPeriodNames(sessionPeriodNames)}
+              />
+
               {/* Stat boxes (non-interactive for waiting/ended) */}
               <div
                 className="grid grid-cols-3"
@@ -1769,18 +1884,9 @@ export const QuizLiveMonitor: React.FC<QuizLiveMonitorProps> = ({
                     </button>
                     {showRoster && (
                       <RosterToolbar
-                        rosters={rosters}
-                        sessionPeriodNames={sessionPeriodNames}
-                        selectedPeriodNames={selectedPeriodNames}
-                        onChangeSelectedPeriods={setSelectedPeriodNames}
-                        showPeriodFilter={showPeriodFilter}
-                        onTogglePeriodFilter={() =>
-                          setShowPeriodFilter(!showPeriodFilter)
-                        }
-                        onClosePeriodFilter={() => setShowPeriodFilter(false)}
-                        colorsEnabled={quizMonitorColorsEnabled}
+                        colorsEnabled={effectiveColorsEnabled}
                         onToggleColors={handleToggleColors}
-                        scoreDisplay={quizMonitorScoreDisplay}
+                        scoreDisplay={effectiveScoreDisplay}
                         onCycleScoreDisplay={handleCycleScoreDisplay}
                         tabWarningsAllowed={
                           session.tabWarningsEnabled !== false
@@ -1836,8 +1942,8 @@ export const QuizLiveMonitor: React.FC<QuizLiveMonitorProps> = ({
                               totalQuestions={session.totalQuestions}
                               questions={quizData.questions}
                               scoringConfig={scoringConfig}
-                              colorsEnabled={quizMonitorColorsEnabled}
-                              scoreDisplay={quizMonitorScoreDisplay}
+                              colorsEnabled={effectiveColorsEnabled}
+                              scoreDisplay={effectiveScoreDisplay}
                               showTabWarnings={
                                 showTabWarnings &&
                                 session.tabWarningsEnabled !== false
@@ -2065,20 +2171,100 @@ const InteractiveStatBox: React.FC<{
 };
 
 /**
- * Right-side controls in the roster header: period filter, Colors toggle,
- * score-display cycle, and tab-warnings toggle. Extracted because the same
- * cluster is rendered in two layouts (active in-question view and
- * waiting/ended view) and the previous inline duplication was already
- * starting to drift across edits.
+ * PeriodChipFilter — touch-friendly chip strip for switching the
+ * monitor between class periods. One chip per targeted period plus an
+ * "All" chip. Single-select on individual periods (the common teacher
+ * workflow is "show me period 3 right now"); the All chip widens back
+ * out for end-of-day overviews. Hidden when the assignment only
+ * targets one period.
  */
-const RosterToolbar: React.FC<{
-  rosters: ClassRoster[];
+const PeriodChipFilter: React.FC<{
   sessionPeriodNames: string[];
   selectedPeriodNames: string[];
-  onChangeSelectedPeriods: (names: string[]) => void;
-  showPeriodFilter: boolean;
-  onTogglePeriodFilter: () => void;
-  onClosePeriodFilter: () => void;
+  onSelectPeriod: (name: string) => void;
+  onSelectAll: () => void;
+}> = ({
+  sessionPeriodNames,
+  selectedPeriodNames,
+  onSelectPeriod,
+  onSelectAll,
+}) => {
+  if (sessionPeriodNames.length <= 1) return null;
+  const allSelected =
+    selectedPeriodNames.length === sessionPeriodNames.length &&
+    sessionPeriodNames.every((p) => selectedPeriodNames.includes(p));
+  const isActive = (name: string) =>
+    !allSelected &&
+    selectedPeriodNames.length === 1 &&
+    selectedPeriodNames[0] === name;
+  return (
+    <div
+      className="flex items-center flex-wrap"
+      role="group"
+      aria-label="Filter monitor by class period"
+      style={{ gap: 'min(6px, 1.5cqmin)' }}
+    >
+      <span
+        className="text-brand-blue-primary/60 font-black uppercase tracking-widest shrink-0"
+        style={{ fontSize: 'min(10px, 3cqmin)' }}
+      >
+        Period
+      </span>
+      {sessionPeriodNames.map((name) => {
+        const active = isActive(name);
+        return (
+          <button
+            key={name}
+            type="button"
+            onClick={() => onSelectPeriod(name)}
+            aria-pressed={active}
+            className={`font-bold rounded-full border transition-all active:scale-95 ${
+              active
+                ? 'bg-brand-blue-primary text-white border-brand-blue-primary shadow-sm'
+                : 'bg-white text-brand-blue-dark border-brand-blue-primary/20 hover:bg-brand-blue-lighter/40'
+            }`}
+            style={{
+              fontSize: 'min(12px, 3.2cqmin)',
+              padding: 'min(6px, 1.5cqmin) min(12px, 3cqmin)',
+              minHeight: 'min(32px, 8cqmin)',
+            }}
+          >
+            {name}
+          </button>
+        );
+      })}
+      <button
+        type="button"
+        onClick={onSelectAll}
+        aria-pressed={allSelected}
+        className={`font-bold rounded-full border transition-all active:scale-95 ${
+          allSelected
+            ? 'bg-brand-blue-primary text-white border-brand-blue-primary shadow-sm'
+            : 'bg-white text-brand-blue-dark/70 border-brand-blue-primary/15 hover:bg-brand-blue-lighter/30'
+        }`}
+        style={{
+          fontSize: 'min(12px, 3.2cqmin)',
+          padding: 'min(6px, 1.5cqmin) min(12px, 3cqmin)',
+          minHeight: 'min(32px, 8cqmin)',
+        }}
+        title="Show every targeted period at once"
+      >
+        All
+      </button>
+    </div>
+  );
+};
+
+/**
+ * Right-side controls in the roster header: Colors toggle, score-display
+ * cycle, and tab-warnings toggle. Extracted because the same cluster is
+ * rendered in two layouts (active in-question view and waiting/ended
+ * view) and the previous inline duplication was already starting to
+ * drift across edits. The class-period filter lives in a separate chip
+ * row above the KPI cards so teachers can swap periods at a glance
+ * instead of digging into a dropdown.
+ */
+const RosterToolbar: React.FC<{
   colorsEnabled: boolean;
   onToggleColors: () => void;
   scoreDisplay: 'percent' | 'count' | 'hidden';
@@ -2087,13 +2273,6 @@ const RosterToolbar: React.FC<{
   showTabWarnings: boolean;
   onToggleTabWarnings: () => void;
 }> = ({
-  rosters,
-  sessionPeriodNames,
-  selectedPeriodNames,
-  onChangeSelectedPeriods,
-  showPeriodFilter,
-  onTogglePeriodFilter,
-  onClosePeriodFilter,
   colorsEnabled,
   onToggleColors,
   scoreDisplay,
@@ -2102,9 +2281,6 @@ const RosterToolbar: React.FC<{
   showTabWarnings,
   onToggleTabWarnings,
 }) => {
-  const filterActive =
-    sessionPeriodNames.length > 1 &&
-    selectedPeriodNames.length < sessionPeriodNames.length;
   const scoreDisplayLabels = {
     percent: 'showing percent',
     count: 'showing answered / total',
@@ -2112,46 +2288,6 @@ const RosterToolbar: React.FC<{
   } as const;
   return (
     <div className="flex items-center gap-2">
-      {sessionPeriodNames.length > 1 && (
-        <div className="relative">
-          <button
-            onClick={onTogglePeriodFilter}
-            className={`flex items-center gap-1 font-bold rounded-md transition-all ${
-              filterActive
-                ? 'text-brand-blue-primary bg-brand-blue-lighter/50'
-                : 'text-brand-blue-primary/40 hover:text-brand-blue-primary/60'
-            }`}
-            style={{
-              fontSize: 'min(9px, 2.5cqmin)',
-              padding: 'min(3px, 0.7cqmin) min(6px, 1.5cqmin)',
-            }}
-            title="Filter monitor by class period"
-            aria-label="Filter by class period"
-            aria-haspopup="dialog"
-            aria-expanded={showPeriodFilter}
-          >
-            <Filter
-              style={{
-                width: 'min(12px, 3cqmin)',
-                height: 'min(12px, 3cqmin)',
-              }}
-            />
-            {filterActive
-              ? `${selectedPeriodNames.length}/${sessionPeriodNames.length}`
-              : 'All Periods'}
-          </button>
-          {showPeriodFilter && (
-            <PeriodSelector
-              rosters={rosters.filter((r) =>
-                sessionPeriodNames.includes(r.name)
-              )}
-              selectedPeriodNames={selectedPeriodNames}
-              onSave={onChangeSelectedPeriods}
-              onClose={onClosePeriodFilter}
-            />
-          )}
-        </div>
-      )}
       <button
         onClick={onToggleColors}
         className={`flex items-center gap-1 font-bold rounded-md transition-all ${
@@ -2460,16 +2596,20 @@ const StudentRow: React.FC<{
           {pillText}
         </span>
       )}
-      {/* Remove button */}
+      {/* Remove button — always visible. Hover-only discoverability
+          failed on touch devices and made the action effectively
+          invisible. The icon stays muted so it doesn't compete with
+          the row content. */}
       {onRemove && (
         <button
           onClick={onConfirmRemoveToggle}
-          className="opacity-0 group-hover/row:opacity-100 text-red-400 hover:text-red-600 transition-all shrink-0"
+          className="text-slate-300 hover:text-red-600 hover:bg-red-50 rounded-md transition-colors shrink-0 flex items-center justify-center"
           style={{
-            width: 'min(16px, 4cqmin)',
-            height: 'min(16px, 4cqmin)',
+            width: 'min(20px, 5cqmin)',
+            height: 'min(20px, 5cqmin)',
           }}
           title="Remove student"
+          aria-label="Remove student"
         >
           <X
             style={{

--- a/tests/components/widgets/QuizLiveMonitor.test.tsx
+++ b/tests/components/widgets/QuizLiveMonitor.test.tsx
@@ -328,6 +328,48 @@ describe('QuizLiveMonitor', () => {
     );
   });
 
+  it('resolves SSO joiners through session.classPeriodByClassId so they are not filtered out when only classId is set', () => {
+    // SSO student: response has `classId` but no `classPeriod` (multi-class
+    // claim, claim-resolution race, or legacy doc). The chip filter must
+    // resolve via the session map before deciding to drop the row.
+    renderMonitor({
+      session: {
+        periodNames: ['P1', 'P2'],
+        classPeriodByClassId: { 'class-A': 'P1', 'class-B': 'P2' },
+      },
+      responses: [
+        makeResponse({ pin: '1111', classPeriod: 'P1', status: 'completed' }),
+        // SSO row: classId only, no classPeriod
+        {
+          studentUid: 'uid-sso-A',
+          joinedAt: 1,
+          status: 'completed',
+          answers: [{ questionId: 'q1', answer: 'a', answeredAt: 100 }],
+          score: null,
+          submittedAt: 200,
+          tabSwitchWarnings: 0,
+          classId: 'class-A',
+        } as unknown as QuizResponse,
+        // SSO row that belongs to P2 — must NOT show under default P1.
+        {
+          studentUid: 'uid-sso-B',
+          joinedAt: 1,
+          status: 'completed',
+          answers: [{ questionId: 'q1', answer: 'a', answeredAt: 100 }],
+          score: null,
+          submittedAt: 200,
+          tabSwitchWarnings: 0,
+          classId: 'class-B',
+        } as unknown as QuizResponse,
+      ],
+    });
+    // Default narrows to P1: PIN row (P1) + SSO row resolved via class-A → P1.
+    expect(screen.getByText(/^Roster · /)).toHaveTextContent('Roster · 2');
+    fireEvent.click(screen.getByRole('button', { name: 'P2' }));
+    // P2: only the class-B SSO row qualifies.
+    expect(screen.getByText(/^Roster · /)).toHaveTextContent('Roster · 1');
+  });
+
   it('cycles the score-display preference percent → count → hidden → percent after the privacy gate is approved', async () => {
     const { rerenderSame } = renderMonitor({
       session: { periodNames: ['P1'] },

--- a/tests/components/widgets/QuizLiveMonitor.test.tsx
+++ b/tests/components/widgets/QuizLiveMonitor.test.tsx
@@ -1,14 +1,12 @@
 /**
- * Smoke-level coverage for QuizLiveMonitor — the file is ~2400 lines after
- * PR #1449 and previously had zero tests. Focus is the structural pieces
- * the diff introduces: the `RosterToolbar` cluster (period filter / Colors /
- * score-display cycle), the `filteredResponses` narrowing that drives the
- * roster + KPIs, and the leaderboard-broadcast invariant that the filter
- * must NOT touch the student-facing leaderboard.
+ * Smoke-level coverage for QuizLiveMonitor — focuses on the privacy
+ * gate around score reveal, the chip-style class-period filter, and
+ * the leaderboard-broadcast invariant that filtering must NOT touch
+ * the student-facing leaderboard.
  *
- * Heavy mocking style mirrors `QuizResults.regenerate.test.tsx`: every hook
- * the component reaches into is stubbed at module-scope so the test stays
- * self-contained.
+ * Heavy mocking style mirrors `QuizResults.regenerate.test.tsx`: every
+ * hook the component reaches into is stubbed at module-scope so the
+ * test stays self-contained.
  */
 import React from 'react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
@@ -192,10 +190,6 @@ function buildTree(opts: RenderOpts) {
     periodNames: session.periodNames,
     ...opts.config,
   });
-  // PeriodSelector inside the toolbar filters its checkbox list to rosters
-  // whose `name` matches one of the session's targeted periods. Default to
-  // a roster per period so the selector is exercisable in tests that open
-  // it.
   const rosters: ClassRoster[] =
     opts.rosters ?? (session.periodNames ?? []).map(makeRoster);
   return (
@@ -222,12 +216,24 @@ function renderMonitor(opts: RenderOpts = {}) {
   return Object.assign(result, { rerenderSame });
 }
 
-// Open the roster (so the toolbar with the period filter / Colors / score
-// buttons is mounted) and return the matching toolbar buttons.
-function openRoster() {
-  const rosterToggle = screen.getByText(/^Roster · /).closest('button');
-  if (!rosterToggle) throw new Error('Roster toggle not found');
-  fireEvent.click(rosterToggle);
+// Approve the privacy gate that hides scores/colors by default. After
+// approval, the persisted account preference takes effect. Helpers below
+// click a toggle once with the confirm dialog auto-resolving true, then
+// reset mocks so the test only sees calls from the action under test.
+async function approveScoreReveal() {
+  showConfirm.mockResolvedValueOnce(true);
+  // Click the Colors button: turning ON triggers the confirm. With stored
+  // colors=true, no preference write happens — the click only flips the
+  // session-local approval flag.
+  fireEvent.click(screen.getByRole('button', { name: /Colors/i }));
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+  vi.clearAllMocks();
+  // Restore the default-deny showConfirm so subsequent prompts (e.g. END)
+  // don't accidentally fire in tests that don't expect a dialog.
+  showConfirm.mockResolvedValue(false);
 }
 
 describe('QuizLiveMonitor', () => {
@@ -257,77 +263,77 @@ describe('QuizLiveMonitor', () => {
     );
   });
 
-  it('hides the period-filter button when the assignment targets a single period', () => {
+  it('hides the period chip filter when the assignment targets a single period', () => {
     renderMonitor({
       session: { periodNames: ['Period 1'] },
       responses: [makeResponse({ pin: '1111', classPeriod: 'Period 1' })],
     });
-    openRoster();
     expect(
-      screen.queryByRole('button', { name: /Filter by class period/i })
+      screen.queryByRole('group', { name: /Filter monitor by class period/i })
     ).not.toBeInTheDocument();
   });
 
-  it('renders the period-filter button labeled "All Periods" when 2+ periods are targeted', () => {
+  it('renders one chip per period plus an "All" chip when 2+ periods are targeted, defaulting to the first period', () => {
     renderMonitor({
       session: { periodNames: ['P1', 'P2', 'P3'] },
-      responses: [makeResponse({ pin: '1111', classPeriod: 'P1' })],
+      responses: [
+        makeResponse({ pin: '1111', classPeriod: 'P1' }),
+        makeResponse({ pin: '2222', classPeriod: 'P2' }),
+        makeResponse({ pin: '3333', classPeriod: 'P3' }),
+      ],
     });
-    openRoster();
-    const filterBtn = screen.getByRole('button', {
-      name: /Filter by class period/i,
-    });
-    expect(filterBtn).toBeInTheDocument();
-    expect(filterBtn).toHaveTextContent('All Periods');
+    expect(
+      screen.getByRole('group', { name: /Filter monitor by class period/i })
+    ).toBeInTheDocument();
+    const p1 = screen.getByRole('button', { name: 'P1' });
+    const p2 = screen.getByRole('button', { name: 'P2' });
+    const p3 = screen.getByRole('button', { name: 'P3' });
+    const all = screen.getByRole('button', { name: 'All' });
+    // Default selection narrows to the first targeted period.
+    expect(p1).toHaveAttribute('aria-pressed', 'true');
+    expect(p2).toHaveAttribute('aria-pressed', 'false');
+    expect(p3).toHaveAttribute('aria-pressed', 'false');
+    expect(all).toHaveAttribute('aria-pressed', 'false');
+    // KPI roster reflects the narrowed default — only P1's response shows.
+    expect(screen.getByText(/^Roster · /)).toHaveTextContent('Roster · 1');
   });
 
-  it('toggling a period off narrows the KPI counts and roster, and updates the filter label', () => {
+  it('clicking a period chip narrows the KPI counts and roster exclusively to that period', () => {
     renderMonitor({
       session: { periodNames: ['P1', 'P2'] },
       responses: [
-        makeResponse({
-          pin: '1111',
-          classPeriod: 'P1',
-          status: 'completed',
-        }),
-        makeResponse({
-          pin: '2222',
-          classPeriod: 'P2',
-          status: 'completed',
-        }),
+        makeResponse({ pin: '1111', classPeriod: 'P1', status: 'completed' }),
+        makeResponse({ pin: '2222', classPeriod: 'P2', status: 'completed' }),
       ],
     });
-    openRoster();
-    expect(screen.getByText(/^Roster · /)).toHaveTextContent('Roster · 2');
-
-    fireEvent.click(
-      screen.getByRole('button', { name: /Filter by class period/i })
-    );
-    // Selector dialog renders one checkbox per period. Untick P2 (it starts
-    // selected because the default mirrors the session's targeted periods).
-    const checkboxes = screen.getAllByRole('checkbox');
-    const p2Box = checkboxes.find((b) =>
-      (b as HTMLInputElement).parentElement?.textContent?.includes('P2')
-    );
-    if (!p2Box) throw new Error('P2 checkbox not found');
-    fireEvent.click(p2Box);
-
-    fireEvent.click(screen.getByRole('button', { name: /Save/i }));
-
-    // Roster row count drops to 1.
+    // Default narrows to P1 only.
     expect(screen.getByText(/^Roster · /)).toHaveTextContent('Roster · 1');
-    // Filter button label flips to "selected/total".
-    expect(
-      screen.getByRole('button', { name: /Filter by class period/i })
-    ).toHaveTextContent('1/2');
+    // Switch to P2 — exclusive selection.
+    fireEvent.click(screen.getByRole('button', { name: 'P2' }));
+    expect(screen.getByText(/^Roster · /)).toHaveTextContent('Roster · 1');
+    expect(screen.getByRole('button', { name: 'P2' })).toHaveAttribute(
+      'aria-pressed',
+      'true'
+    );
+    expect(screen.getByRole('button', { name: 'P1' })).toHaveAttribute(
+      'aria-pressed',
+      'false'
+    );
+    // All widens back out.
+    fireEvent.click(screen.getByRole('button', { name: 'All' }));
+    expect(screen.getByText(/^Roster · /)).toHaveTextContent('Roster · 2');
+    expect(screen.getByRole('button', { name: 'All' })).toHaveAttribute(
+      'aria-pressed',
+      'true'
+    );
   });
 
-  it('cycles the score-display preference percent → count → hidden → percent', async () => {
+  it('cycles the score-display preference percent → count → hidden → percent after the privacy gate is approved', async () => {
     const { rerenderSame } = renderMonitor({
       session: { periodNames: ['P1'] },
       responses: [makeResponse({ pin: '1111', classPeriod: 'P1' })],
     });
-    openRoster();
+    await approveScoreReveal();
     const cycleBtn = () =>
       screen.getByRole('button', { name: /Cycle score display/i });
 
@@ -343,7 +349,8 @@ describe('QuizLiveMonitor', () => {
       await Promise.resolve();
     });
     rerenderSame();
-    // Click 3: hidden → percent
+    // Click 3: hidden → percent (back through the gate, which is already
+    // approved for this session so no second confirm dialog appears)
     fireEvent.click(cycleBtn());
     await act(async () => {
       await Promise.resolve();
@@ -361,19 +368,42 @@ describe('QuizLiveMonitor', () => {
     });
   });
 
-  it('Colors toggle persists the inverted value via updateAccountPreferences', () => {
+  it('Colors toggle requires the privacy gate before persisting a flip', async () => {
+    // Start with stored colors OFF so a click after approval produces a
+    // visible "turn ON → persist true" call.
+    authState.quizMonitorColorsEnabled = false;
     renderMonitor({
       session: { periodNames: ['P1'] },
       responses: [makeResponse({ pin: '1111', classPeriod: 'P1' })],
     });
-    openRoster();
 
+    // First click: triggers the privacy confirm. With showConfirm → true,
+    // approval is granted and the stored preference flips on.
+    showConfirm.mockResolvedValueOnce(true);
     fireEvent.click(screen.getByRole('button', { name: /Colors/i }));
-
-    expect(updateAccountPreferences).toHaveBeenCalledTimes(1);
-    expect(updateAccountPreferences).toHaveBeenCalledWith({
-      quizMonitorColorsEnabled: false,
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
     });
+    expect(showConfirm).toHaveBeenCalledTimes(1);
+    expect(updateAccountPreferences).toHaveBeenCalledWith({
+      quizMonitorColorsEnabled: true,
+    });
+  });
+
+  it('cancelling the privacy gate keeps scores hidden and writes nothing', async () => {
+    renderMonitor({
+      session: { periodNames: ['P1'] },
+      responses: [makeResponse({ pin: '1111', classPeriod: 'P1' })],
+    });
+    showConfirm.mockResolvedValueOnce(false);
+    fireEvent.click(screen.getByRole('button', { name: /Colors/i }));
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(showConfirm).toHaveBeenCalledTimes(1);
+    expect(updateAccountPreferences).not.toHaveBeenCalled();
   });
 
   it('shows the empty-state and Clear filter button when the active filter narrows to zero rows', () => {
@@ -381,21 +411,9 @@ describe('QuizLiveMonitor', () => {
       session: { periodNames: ['P1', 'P2'] },
       responses: [makeResponse({ pin: '1111', classPeriod: 'P1' })],
     });
-    openRoster();
-
-    fireEvent.click(
-      screen.getByRole('button', { name: /Filter by class period/i })
-    );
-    // The selector starts with both ['P1','P2'] selected. Untick P1 so only
-    // P2 remains — the lone response is in P1, so filteredResponses → [].
-    const checkboxes = screen.getAllByRole('checkbox');
-    const p1Box = checkboxes.find((b) =>
-      (b as HTMLInputElement).parentElement?.textContent?.includes('P1')
-    );
-    if (!p1Box) throw new Error('P1 checkbox not found');
-    fireEvent.click(p1Box);
-    fireEvent.click(screen.getByRole('button', { name: /Save/i }));
-
+    // Default selects P1; switching to P2 (which has no responses) yields
+    // the empty state. The Clear filter button widens back out.
+    fireEvent.click(screen.getByRole('button', { name: 'P2' }));
     expect(
       screen.getByText(/No students match the active class-period filter\./i)
     ).toBeInTheDocument();
@@ -433,7 +451,9 @@ describe('QuizLiveMonitor', () => {
         ],
       });
 
-      // Initial broadcast — debounced 300ms.
+      // Initial broadcast — debounced 300ms. The chip filter defaults to
+      // P1 only on the monitor side; the leaderboard MUST still see both
+      // responses.
       act(() => {
         vi.advanceTimersByTime(400);
       });
@@ -451,34 +471,20 @@ describe('QuizLiveMonitor', () => {
       expect(Array.isArray(initialEntries)).toBe(true);
       expect(initialEntries).toHaveLength(2);
 
-      // Now narrow the filter via the UI. Switch to real timers briefly so
-      // jsdom event handlers can fire the way fireEvent expects.
+      // Sanity: the visible roster on the monitor is narrowed to 1 row by
+      // the chip-filter default while the leaderboard above stayed at 2.
       vi.useRealTimers();
-      openRoster();
-      fireEvent.click(
-        screen.getByRole('button', { name: /Filter by class period/i })
-      );
-      const checkboxes = screen.getAllByRole('checkbox');
-      const p2Box = checkboxes.find((b) =>
-        (b as HTMLInputElement).parentElement?.textContent?.includes('P2')
-      );
-      if (!p2Box) throw new Error('P2 checkbox not found');
-      fireEvent.click(p2Box);
-      fireEvent.click(screen.getByRole('button', { name: /Save/i }));
-
-      // Sanity: the visible roster narrowed to 1 row.
       expect(screen.getByText(/^Roster · /)).toHaveTextContent('Roster · 1');
 
-      // Re-arm fake timers to drive the (potentially) re-fired broadcast.
+      // Switch the chip to P2 and re-arm the broadcast — same invariant.
+      fireEvent.click(screen.getByRole('button', { name: 'P2' }));
+      expect(screen.getByText(/^Roster · /)).toHaveTextContent('Roster · 1');
+
       vi.useFakeTimers();
       act(() => {
         vi.advanceTimersByTime(400);
       });
 
-      // Every leaderboard payload — initial OR post-filter — must contain
-      // BOTH responses. The diff explicitly comments on this invariant
-      // (filter narrows roster/KPIs only; the student-facing leaderboard
-      // stays on the unfiltered `responses`).
       const leaderboardCalls = updateDocMock.mock.calls.filter(
         (c) =>
           typeof c[1] === 'object' &&
@@ -497,6 +503,9 @@ describe('QuizLiveMonitor', () => {
   });
 
   it('surfaces a toast when updateAccountPreferences rejects on the Colors toggle', async () => {
+    // Start with stored colors OFF so the post-approval branch will issue
+    // an updateAccountPreferences write that we can reject.
+    authState.quizMonitorColorsEnabled = false;
     // The handler logs the error before toasting; silence it here so the
     // expected rejection doesn't pollute test output.
     const errorSpy = vi
@@ -507,13 +516,14 @@ describe('QuizLiveMonitor', () => {
       session: { periodNames: ['P1'] },
       responses: [makeResponse({ pin: '1111', classPeriod: 'P1' })],
     });
-    openRoster();
 
+    showConfirm.mockResolvedValueOnce(true);
     fireEvent.click(screen.getByRole('button', { name: /Colors/i }));
 
     // The catch handler is async — flush microtasks so the rejection
     // settles before we assert.
     await act(async () => {
+      await Promise.resolve();
       await Promise.resolve();
       await Promise.resolve();
     });

--- a/tests/components/widgets/QuizLiveMonitor.test.tsx
+++ b/tests/components/widgets/QuizLiveMonitor.test.tsx
@@ -406,6 +406,54 @@ describe('QuizLiveMonitor', () => {
     expect(updateAccountPreferences).not.toHaveBeenCalled();
   });
 
+  it('resets the score-reveal approval when the session id changes so a new quiz starts with scores hidden', async () => {
+    const result = render(
+      buildTree({
+        session: { id: 'sess-A', periodNames: ['P1'] },
+        responses: [makeResponse({ pin: '1111', classPeriod: 'P1' })],
+      })
+    );
+    // Approve the privacy gate in the first session.
+    showConfirm.mockResolvedValueOnce(true);
+    fireEvent.click(screen.getByRole('button', { name: /Colors/i }));
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    // Sanity: subsequent toggles in the same session no longer prompt.
+    showConfirm.mockClear();
+    fireEvent.click(screen.getByRole('button', { name: /Colors/i }));
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(showConfirm).not.toHaveBeenCalled();
+
+    // Now swap to a fresh session id on the same component instance — the
+    // approval should reset, so the next reveal click prompts again.
+    const session2 = makeSession({ id: 'sess-B', periodNames: ['P1'] });
+    const config2 = makeConfig({ periodNames: session2.periodNames });
+    result.rerender(
+      <QuizLiveMonitor
+        session={session2}
+        responses={[makeResponse({ pin: '1111', classPeriod: 'P1' })]}
+        quizData={makeQuizData()}
+        onAdvance={noopAsync}
+        onEnd={noopAsync}
+        config={config2}
+        rosters={[makeRoster('P1')]}
+        onUpdateConfig={vi.fn()}
+      />
+    );
+    showConfirm.mockClear();
+    showConfirm.mockResolvedValueOnce(false);
+    fireEvent.click(screen.getByRole('button', { name: /Colors/i }));
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(showConfirm).toHaveBeenCalledTimes(1);
+  });
+
   it('shows the empty-state and Clear filter button when the active filter narrows to zero rows', () => {
     renderMonitor({
       session: { periodNames: ['P1', 'P2'] },

--- a/tests/components/widgets/QuizLiveMonitor.test.tsx
+++ b/tests/components/widgets/QuizLiveMonitor.test.tsx
@@ -454,6 +454,59 @@ describe('QuizLiveMonitor', () => {
     expect(showConfirm).toHaveBeenCalledTimes(1);
   });
 
+  it('does not apply approval to a fresh session if session.id changes while the confirm dialog is awaiting', async () => {
+    // Hold the confirm promise open so we can swap session.id under it.
+    let resolveConfirm: (value: boolean) => void = () => undefined;
+    showConfirm.mockImplementationOnce(
+      () =>
+        new Promise<boolean>((resolve) => {
+          resolveConfirm = resolve;
+        })
+    );
+    const result = render(
+      buildTree({
+        session: { id: 'sess-A', periodNames: ['P1'] },
+        responses: [makeResponse({ pin: '1111', classPeriod: 'P1' })],
+      })
+    );
+    fireEvent.click(screen.getByRole('button', { name: /Colors/i }));
+
+    // Swap the active session before the dialog resolves. The session-id
+    // change block clears any prior approval — but the in-flight confirm
+    // must NOT race ahead and re-set scoreRevealApproved on the new session.
+    const session2 = makeSession({ id: 'sess-B', periodNames: ['P1'] });
+    const config2 = makeConfig({ periodNames: session2.periodNames });
+    result.rerender(
+      <QuizLiveMonitor
+        session={session2}
+        responses={[makeResponse({ pin: '1111', classPeriod: 'P1' })]}
+        quizData={makeQuizData()}
+        onAdvance={noopAsync}
+        onEnd={noopAsync}
+        config={config2}
+        rosters={[makeRoster('P1')]}
+        onUpdateConfig={vi.fn()}
+      />
+    );
+
+    // Now resolve the original confirm with `true` — the new session must
+    // stay un-approved, so the next reveal click on session B prompts again.
+    await act(async () => {
+      resolveConfirm(true);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    showConfirm.mockClear();
+    showConfirm.mockResolvedValueOnce(false);
+    fireEvent.click(screen.getByRole('button', { name: /Colors/i }));
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(showConfirm).toHaveBeenCalledTimes(1);
+  });
+
   it('shows the empty-state and Clear filter button when the active filter narrows to zero rows', () => {
     renderMonitor({
       session: { periodNames: ['P1', 'P2'] },


### PR DESCRIPTION
## Summary

Touch-first refresh of the live quiz assignment monitor. The previous UI buried the most-used controls behind hover or popover targets that were invisible on tablets and projected screens.

- **Roster visible by default** — was hidden behind the eye-toggle. Teachers expected the student list immediately.
- **Tab-switch warnings hidden by default** — they're noise for normal monitoring; surface on demand from the toolbar.
- **Privacy gate around score reveal** — a fresh open always shows scores hidden and color bands off, regardless of the teacher's persisted preference. Toggling **Colors** or cycling **Score Display** prompts a confirm dialog ("this monitor may be projected — confirm only if it's appropriate to display student performance"). Once confirmed, the persisted preference takes effect for the rest of the session.
- **X remove button always visible** — no more hover-only discoverability. Renders muted (`text-slate-300 → red on hover`) so it doesn't compete with row content.
- **Class-period chip filter** — replaces the popover dropdown with a chip strip above the KPI cluster. One chip per targeted period plus an "All" chip. Defaults to the **first targeted period** so KPIs and roster reflect the room the teacher is actually running. The popover-style `PeriodSelector` and unused `Filter` import were removed.
- **Live leaderboard broadcast invariant preserved** — chip filter only narrows the monitor's KPIs and roster. The student-facing scoreboard stays on the unfiltered response set.

## Files changed

- `components/widgets/QuizWidget/components/QuizLiveMonitor.tsx`
- `tests/components/widgets/QuizLiveMonitor.test.tsx`

## Test plan

- [x] `pnpm type-check` clean
- [x] `pnpm lint` clean (max-warnings 0)
- [x] `pnpm format:check` clean
- [x] `pnpm test -- tests/components/widgets/QuizLiveMonitor.test.tsx --run` — 8/8 pass (covers single-period hide, chip default selection, exclusive chip selection + All widen, score cycle through privacy gate, Colors toggle through privacy gate, cancel-keeps-hidden, empty-state, leaderboard invariant, error toast)
- [x] Full test suite green (213 files / 2197 tests)
- [ ] Manual smoke on dev preview: open monitor with multi-period assignment → confirm chips render + default narrows to first period; toggle Colors → confirm dialog appears; remove a student → X visible without hover

https://claude.ai/code/session_013xqKyRftDWUagHw8vWxtub

---
_Generated by [Claude Code](https://claude.ai/code/session_013xqKyRftDWUagHw8vWxtub)_