### PR TITLE
feat(randomizer): add Jigsaw operation mode + front-face mode-cycle chip

### DIFF
--- a/components/widgets/random/RandomGroups.tsx
+++ b/components/widgets/random/RandomGroups.tsx
@@ -5,6 +5,8 @@ import { RandomGroup, SharedGroup } from '@/types';
 interface RandomGroupsProps {
   displayResult: string | string[] | string[][] | RandomGroup[] | null;
   sharedGroups?: SharedGroup[];
+  /** Default group name prefix when a group has no shared-groups entry. */
+  groupNamePrefix?: string;
 }
 
 const computeColumnCount = (
@@ -46,6 +48,7 @@ const computeColumnCount = (
 export const RandomGroups: React.FC<RandomGroupsProps> = ({
   displayResult,
   sharedGroups,
+  groupNamePrefix = 'Group',
 }) => {
   const groups = useMemo(() => {
     if (
@@ -115,7 +118,7 @@ export const RandomGroups: React.FC<RandomGroupsProps> = ({
         const groupId =
           !Array.isArray(groupItem) && 'id' in groupItem ? groupItem.id : null;
 
-        let groupName = `Group ${i + 1}`;
+        let groupName = `${groupNamePrefix} ${i + 1}`;
         if (groupId && sharedGroups) {
           const shared = sharedGroups.find((g) => g.id === groupId);
           if (shared) groupName = shared.name;

--- a/components/widgets/random/RandomSettings.tsx
+++ b/components/widgets/random/RandomSettings.tsx
@@ -20,6 +20,7 @@ import {
   Clock,
   RefreshCw,
   Send,
+  Puzzle,
 } from 'lucide-react';
 import { Button } from '@/components/common/Button';
 import { SettingsLabel } from '@/components/common/SettingsLabel';
@@ -205,6 +206,7 @@ export const RandomSettings: React.FC<{ widget: WidgetData }> = ({
     { id: 'single', label: 'Pick One', icon: UserPlus },
     { id: 'shuffle', label: 'Shuffle', icon: Layers },
     { id: 'groups', label: 'Groups', icon: Users },
+    { id: 'jigsaw', label: 'Jigsaw', icon: Puzzle },
   ];
 
   const styles = [
@@ -320,13 +322,20 @@ export const RandomSettings: React.FC<{ widget: WidgetData }> = ({
         <label className="text-xxs  text-slate-400 uppercase tracking-widest mb-3 block">
           Operation Mode
         </label>
-        <div className="grid grid-cols-3 gap-2">
+        <div className="grid grid-cols-4 gap-2">
           {modes.map((m) => (
             <button
               key={m.id}
               onClick={() =>
                 updateWidget(widget.id, {
-                  config: { ...config, mode: m.id, lastResult: null },
+                  config: {
+                    ...config,
+                    mode: m.id,
+                    lastResult: null,
+                    jigsawHomeGroups: null,
+                    jigsawExpertGroups: null,
+                    jigsawView: 'home',
+                  },
                 })
               }
               className={`flex flex-col items-center gap-1.5 p-3 rounded-2xl border-2 transition-all ${
@@ -373,10 +382,11 @@ export const RandomSettings: React.FC<{ widget: WidgetData }> = ({
         </div>
       )}
 
-      {mode === 'groups' && (
+      {(mode === 'groups' || mode === 'jigsaw') && (
         <div className="p-4 bg-white border border-slate-100 rounded-2xl shadow-sm">
           <label className="text-xxs  text-slate-400 uppercase tracking-widest mb-3 block flex items-center gap-2">
-            <Hash className="w-3 h-3" /> Group Size
+            <Hash className="w-3 h-3" />{' '}
+            {mode === 'jigsaw' ? 'Home Group Size' : 'Group Size'}
           </label>
           <div className="flex items-center gap-4">
             <input

--- a/components/widgets/random/RandomSettings.tsx
+++ b/components/widgets/random/RandomSettings.tsx
@@ -136,12 +136,14 @@ export const RandomSettings: React.FC<{ widget: WidgetData }> = ({
     firstNames = '',
     lastNames = '',
     mode = 'single',
-    groupSize = 3,
+    groupSize: configGroupSize,
     soundEnabled = true,
     rosterMode = 'class',
     autoStartTimer = false,
     visualStyle = 'flash',
   } = config;
+  // Mirror RandomWidget: jigsaw defaults to 4, others to 3, explicit choice wins.
+  const groupSize = configGroupSize ?? (mode === 'jigsaw' ? 4 : 3);
 
   const [localFirstNames, setLocalFirstNames] = useState(firstNames);
   const [localLastNames, setLocalLastNames] = useState(lastNames);

--- a/components/widgets/random/RandomSettings.tsx
+++ b/components/widgets/random/RandomSettings.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useRef, useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useDashboard } from '@/context/useDashboard';
 import { useDialog } from '@/context/useDialog';
 import { WidgetData, RandomConfig, RandomGroup, StationsConfig } from '@/types';
@@ -28,6 +29,7 @@ import { SettingsLabel } from '@/components/common/SettingsLabel';
 export const RandomSettings: React.FC<{ widget: WidgetData }> = ({
   widget,
 }) => {
+  const { t } = useTranslation();
   const { updateWidget, activeDashboard, rosters, activeRosterId, addToast } =
     useDashboard();
   const { showConfirm } = useDialog();
@@ -386,7 +388,11 @@ export const RandomSettings: React.FC<{ widget: WidgetData }> = ({
         <div className="p-4 bg-white border border-slate-100 rounded-2xl shadow-sm">
           <label className="text-xxs  text-slate-400 uppercase tracking-widest mb-3 block flex items-center gap-2">
             <Hash className="w-3 h-3" />{' '}
-            {mode === 'jigsaw' ? 'Home Group Size' : 'Group Size'}
+            {mode === 'jigsaw'
+              ? t('widgets.random.homeGroupSize', {
+                  defaultValue: 'Home Group Size',
+                })
+              : t('widgets.random.groupSize', { defaultValue: 'Group Size' })}
           </label>
           <div className="flex items-center gap-4">
             <input

--- a/components/widgets/random/RandomWidget.test.tsx
+++ b/components/widgets/random/RandomWidget.test.tsx
@@ -23,16 +23,19 @@ vi.mock('./audioUtils', () => ({
   playWinner: vi.fn(),
 }));
 
-// Mock WidgetLayout to render content and footer
+// Mock WidgetLayout to render header, content, and footer
 vi.mock('../WidgetLayout', () => ({
   WidgetLayout: ({
+    header,
     content,
     footer,
   }: {
+    header?: React.ReactNode;
     content: React.ReactNode;
     footer: React.ReactNode;
   }) => (
     <div data-testid="widget-layout">
+      {header && <div data-testid="header">{header}</div>}
       <div data-testid="content">{content}</div>
       <div data-testid="footer">{footer}</div>
     </div>
@@ -113,6 +116,149 @@ describe('RandomWidget', () => {
     // Default group names
     expect(screen.getByText('Group 1')).toBeInTheDocument();
     expect(screen.getByText('Group 2')).toBeInTheDocument();
+  });
+
+  describe('Jigsaw mode', () => {
+    const jigsawWidget = (
+      override: Partial<RandomConfig> = {}
+    ): WidgetData => ({
+      id: 'test-id',
+      type: 'random',
+      config: {
+        firstNames: 'A\nB\nC\nD\nE\nF',
+        mode: 'jigsaw',
+        rosterMode: 'custom',
+        groupSize: 2,
+        jigsawHomeGroups: [
+          { id: 'h1', names: ['A', 'B'] },
+          { id: 'h2', names: ['C', 'D'] },
+          { id: 'h3', names: ['E', 'F'] },
+        ],
+        jigsawExpertGroups: [
+          { id: 'e1', names: ['A', 'C', 'E'] },
+          { id: 'e2', names: ['B', 'D', 'F'] },
+        ],
+        jigsawView: 'home',
+        ...override,
+      } as RandomConfig,
+      x: 0,
+      y: 0,
+      w: 100,
+      h: 100,
+      z: 1,
+      flipped: false,
+    });
+
+    it('renders home groups when jigsawView is "home"', () => {
+      render(<RandomWidget widget={jigsawWidget({ jigsawView: 'home' })} />);
+      expect(screen.getByText('A')).toBeInTheDocument();
+      expect(screen.getByText('Group 1')).toBeInTheDocument();
+      // Footer launch buttons present
+      expect(
+        screen.getByRole('button', { name: /Launch Jigsaw/i })
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', { name: /Launch Home Group/i })
+      ).toBeInTheDocument();
+    });
+
+    it('renders expert groups when jigsawView is "expert"', () => {
+      render(<RandomWidget widget={jigsawWidget({ jigsawView: 'expert' })} />);
+      // Expert group 1 has [A, C, E] together (one student per home group at
+      // position 0). Asserting on the expert-specific composition rules out
+      // that we accidentally rendered the home view.
+      expect(screen.getByText('A')).toBeInTheDocument();
+      expect(screen.getByText('C')).toBeInTheDocument();
+      expect(screen.getByText('E')).toBeInTheDocument();
+    });
+
+    it('toggles jigsawView when Launch Jigsaw is clicked', () => {
+      render(<RandomWidget widget={jigsawWidget({ jigsawView: 'home' })} />);
+      fireEvent.click(screen.getByRole('button', { name: /Launch Jigsaw/i }));
+
+      expect(mockUpdateWidget).toHaveBeenCalledWith(
+        'test-id',
+        expect.objectContaining({
+          config: expect.objectContaining({
+            jigsawView: 'expert',
+          }) as unknown,
+        })
+      );
+    });
+
+    it('toggles jigsawView when Launch Home Group is clicked', () => {
+      render(<RandomWidget widget={jigsawWidget({ jigsawView: 'expert' })} />);
+      fireEvent.click(
+        screen.getByRole('button', { name: /Launch Home Group/i })
+      );
+
+      expect(mockUpdateWidget).toHaveBeenCalledWith(
+        'test-id',
+        expect.objectContaining({
+          config: expect.objectContaining({
+            jigsawView: 'home',
+          }) as unknown,
+        })
+      );
+    });
+
+    it('does not show Launch buttons before any pick has happened', () => {
+      render(
+        <RandomWidget
+          widget={jigsawWidget({
+            jigsawHomeGroups: null,
+            jigsawExpertGroups: null,
+          })}
+        />
+      );
+      expect(
+        screen.queryByRole('button', { name: /Launch Jigsaw/i })
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Mode-cycle chip', () => {
+    const widgetWithMode = (mode: string): WidgetData => ({
+      id: 'test-id',
+      type: 'random',
+      config: {
+        firstNames: 'Alice\nBob',
+        mode,
+        rosterMode: 'custom',
+      } as RandomConfig,
+      x: 0,
+      y: 0,
+      w: 100,
+      h: 100,
+      z: 1,
+      flipped: false,
+    });
+
+    it('cycles single → shuffle when tapped', () => {
+      render(<RandomWidget widget={widgetWithMode('single')} />);
+      fireEvent.click(
+        screen.getByRole('button', { name: /Operation mode: Pick One/i })
+      );
+      expect(mockUpdateWidget).toHaveBeenCalledWith(
+        'test-id',
+        expect.objectContaining({
+          config: expect.objectContaining({ mode: 'shuffle' }) as unknown,
+        })
+      );
+    });
+
+    it('wraps from jigsaw back to single', () => {
+      render(<RandomWidget widget={widgetWithMode('jigsaw')} />);
+      fireEvent.click(
+        screen.getByRole('button', { name: /Operation mode: Jigsaw/i })
+      );
+      expect(mockUpdateWidget).toHaveBeenCalledWith(
+        'test-id',
+        expect.objectContaining({
+          config: expect.objectContaining({ mode: 'single' }) as unknown,
+        })
+      );
+    });
   });
 
   it('sends groups to scoreboard when button is clicked (New Connection)', () => {

--- a/components/widgets/random/RandomWidget.test.tsx
+++ b/components/widgets/random/RandomWidget.test.tsx
@@ -152,8 +152,8 @@ describe('RandomWidget', () => {
     it('renders home groups when jigsawView is "home"', () => {
       render(<RandomWidget widget={jigsawWidget({ jigsawView: 'home' })} />);
       expect(screen.getByText('A')).toBeInTheDocument();
-      expect(screen.getByText('Group 1')).toBeInTheDocument();
-      // Footer launch buttons present
+      expect(screen.getByText('Home Group 1')).toBeInTheDocument();
+      // Footer launch buttons present (active one is disabled)
       expect(
         screen.getByRole('button', { name: /Launch Jigsaw/i })
       ).toBeInTheDocument();
@@ -162,14 +162,28 @@ describe('RandomWidget', () => {
       ).toBeInTheDocument();
     });
 
-    it('renders expert groups when jigsawView is "expert"', () => {
+    it('renders all expert groups when jigsawView is "expert"', () => {
       render(<RandomWidget widget={jigsawWidget({ jigsawView: 'expert' })} />);
-      // Expert group 1 has [A, C, E] together (one student per home group at
-      // position 0). Asserting on the expert-specific composition rules out
-      // that we accidentally rendered the home view.
-      expect(screen.getByText('A')).toBeInTheDocument();
-      expect(screen.getByText('C')).toBeInTheDocument();
-      expect(screen.getByText('E')).toBeInTheDocument();
+      // Expert group 1 has [A, C, E] (position 0 from each home group);
+      // expert group 2 has [B, D, F] (position 1). Asserting on both rules
+      // out a regression where only the first expert group renders.
+      expect(screen.getByText('Expert Group 1')).toBeInTheDocument();
+      expect(screen.getByText('Expert Group 2')).toBeInTheDocument();
+      for (const name of ['A', 'B', 'C', 'D', 'E', 'F']) {
+        expect(screen.getByText(name)).toBeInTheDocument();
+      }
+    });
+
+    it('disables the active jigsaw view button (clear current state)', () => {
+      render(<RandomWidget widget={jigsawWidget({ jigsawView: 'home' })} />);
+      // jigsawView === 'home' → Launch Home Group is the current view, so it
+      // should be disabled to make the active state visually unambiguous.
+      expect(
+        screen.getByRole('button', { name: /Launch Home Group/i })
+      ).toBeDisabled();
+      expect(
+        screen.getByRole('button', { name: /Launch Jigsaw/i })
+      ).not.toBeDisabled();
     });
 
     it('toggles jigsawView when Launch Jigsaw is clicked', () => {

--- a/components/widgets/random/RandomWidget.tsx
+++ b/components/widgets/random/RandomWidget.tsx
@@ -29,6 +29,7 @@ import {
 } from 'lucide-react';
 import { getAudioCtx, playTick, playWinner } from './audioUtils';
 import { getLocalIsoDate } from '@/utils/localDate';
+import { logError } from '@/utils/logError';
 import {
   makeJigsawExpertGroups,
   makeNameGroups,
@@ -548,7 +549,7 @@ export const RandomWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
             } as unknown as WidgetConfig,
           });
         } catch (err) {
-          console.error('Randomizer Jigsaw Sync Error:', err);
+          logError('RandomWidget.jigsawSync', err, { widgetId: widget.id });
         }
       }, 500);
     } else {

--- a/components/widgets/random/RandomWidget.tsx
+++ b/components/widgets/random/RandomWidget.tsx
@@ -99,11 +99,16 @@ export const RandomWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
     rosterMode = 'class',
     autoStartTimer = false,
     visualStyle = 'flash',
-    groupSize = 3,
+    groupSize: configGroupSize,
     jigsawHomeGroups,
     jigsawExpertGroups,
     jigsawView = 'home',
   } = config;
+  // Classic jigsaw is "4 home groups of 4 → 4 expert groups of 4", so default
+  // to 4 in jigsaw mode when the user hasn't explicitly set a size. Other
+  // modes keep the historical default of 3. An explicit user choice always
+  // wins (slider writes config.groupSize, which short-circuits the fallback).
+  const groupSize = configGroupSize ?? (mode === 'jigsaw' ? 4 : 3);
 
   const remainingStudents = Array.isArray(config.remainingStudents)
     ? config.remainingStudents
@@ -170,15 +175,14 @@ export const RandomWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
         (config.jigsawExpertGroups?.length ?? 0) > 0;
       if (hasTransientState) {
         spinGenRef.current += 1;
-        updateWidget(widget.id, {
-          config: {
-            lastResult: null,
-            remainingStudents: [],
-            jigsawHomeGroups: null,
-            jigsawExpertGroups: null,
-            jigsawView: 'home',
-          } as unknown as WidgetConfig,
-        });
+        const update: Partial<RandomConfig> = {
+          lastResult: null,
+          remainingStudents: [],
+          jigsawHomeGroups: null,
+          jigsawExpertGroups: null,
+          jigsawView: 'home',
+        };
+        updateWidget(widget.id, { config: update as WidgetConfig });
       }
     }
   }, [activeRosterId, widget.id, updateWidget, config, rosterMode]);
@@ -248,15 +252,14 @@ export const RandomWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
 
   const handleReset = () => {
     spinGenRef.current += 1;
-    updateWidget(widget.id, {
-      config: {
-        remainingStudents: [],
-        lastResult: null,
-        jigsawHomeGroups: null,
-        jigsawExpertGroups: null,
-        jigsawView: 'home',
-      } as unknown as WidgetConfig,
-    });
+    const update: Partial<RandomConfig> = {
+      remainingStudents: [],
+      lastResult: null,
+      jigsawHomeGroups: null,
+      jigsawExpertGroups: null,
+      jigsawView: 'home',
+    };
+    updateWidget(widget.id, { config: update as WidgetConfig });
     setDisplayResult('');
     setRotation(0);
   };
@@ -272,15 +275,14 @@ export const RandomWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
     const idx = MODE_CYCLE.findIndex((m) => m.id === mode);
     const next = MODE_CYCLE[(idx + 1) % MODE_CYCLE.length];
     spinGenRef.current += 1;
-    updateWidget(widget.id, {
-      config: {
-        mode: next.id,
-        lastResult: null,
-        jigsawHomeGroups: null,
-        jigsawExpertGroups: null,
-        jigsawView: 'home',
-      } as unknown as WidgetConfig,
-    });
+    const update: Partial<RandomConfig> = {
+      mode: next.id,
+      lastResult: null,
+      jigsawHomeGroups: null,
+      jigsawExpertGroups: null,
+      jigsawView: 'home',
+    };
+    updateWidget(widget.id, { config: update as WidgetConfig });
   };
 
   const setJigsawView = (view: 'home' | 'expert') => {
@@ -472,9 +474,7 @@ export const RandomWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
           updates.remainingStudents = remaining;
         }
 
-        updateWidget(widget.id, {
-          config: updates as unknown as WidgetConfig,
-        });
+        updateWidget(widget.id, { config: updates as WidgetConfig });
 
         // Nexus: Auto-Start Timer Logic
         if (autoStartTimer && activeDashboard && mode === 'single') {
@@ -651,14 +651,13 @@ export const RandomWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
             updateDashboard({ sharedGroups: [...filtered, ...uniqueNew] });
           }
 
-          updateWidget(widget.id, {
-            config: {
-              jigsawHomeGroups: homeGroups,
-              jigsawExpertGroups: expertGroups,
-              jigsawView: 'home',
-              lastResult: homeGroups,
-            } as unknown as WidgetConfig,
-          });
+          const update: Partial<RandomConfig> = {
+            jigsawHomeGroups: homeGroups,
+            jigsawExpertGroups: expertGroups,
+            jigsawView: 'home',
+            lastResult: homeGroups,
+          };
+          updateWidget(widget.id, { config: update as WidgetConfig });
         } catch (err) {
           logError('RandomWidget.jigsawSync', err, { widgetId: widget.id });
         }

--- a/components/widgets/random/RandomWidget.tsx
+++ b/components/widgets/random/RandomWidget.tsx
@@ -378,7 +378,7 @@ export const RandomWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
       try {
         await ctx.resume();
       } catch (e) {
-        console.error('Audio resume failed', e);
+        logError('RandomWidget.audioResume', e, { widgetId: widget.id });
       }
     }
 
@@ -463,7 +463,7 @@ export const RandomWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
           }
         }
       } catch (err) {
-        console.error('Randomizer Sync Error:', err);
+        logError('RandomWidget.pickSync', err, { widgetId: widget.id });
       }
     };
 
@@ -578,6 +578,19 @@ export const RandomWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
           homeGroups = makeNameGroups(students, groupSize);
         }
         const expertGroups = makeJigsawExpertGroups(homeGroups);
+
+        // With < 2 home groups, "expert groups" degenerate into 1-person
+        // singletons (each has nobody to compare notes with). Surface a toast
+        // so the teacher knows to lower the group size.
+        if (homeGroups.length < 2) {
+          addToast(
+            t('widgets.random.jigsawNeedsMultipleGroups', {
+              defaultValue:
+                'Jigsaw needs at least 2 home groups — lower the group size or add more students.',
+            }),
+            'warning'
+          );
+        }
 
         setDisplayResult(homeGroups);
         if (soundEnabled) playWinner();

--- a/components/widgets/random/RandomWidget.tsx
+++ b/components/widgets/random/RandomWidget.tsx
@@ -369,6 +369,36 @@ export const RandomWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
     }
   };
 
+  // Collect this widget's prior-pick RandomGroup IDs so we can drop them
+  // from dashboard.sharedGroups before adding the new ones — otherwise the
+  // collection grows unboundedly across re-picks. Downstream consumers
+  // (e.g. ScoreboardTeam.linkedGroupId) keep their own name field, so
+  // dropping the link gracefully degrades to "name only" rather than
+  // erroring.
+  const collectPriorGroupIds = (): Set<string> => {
+    const ids = new Set<string>();
+    const fields: unknown[] = [
+      config.lastResult,
+      config.jigsawHomeGroups,
+      config.jigsawExpertGroups,
+    ];
+    for (const field of fields) {
+      if (!Array.isArray(field)) continue;
+      for (const item of field) {
+        if (
+          item &&
+          typeof item === 'object' &&
+          'id' in item &&
+          typeof (item as RandomGroup).id === 'string' &&
+          (item as RandomGroup).id
+        ) {
+          ids.add((item as RandomGroup).id as string);
+        }
+      }
+    }
+    return ids;
+  };
+
   const handlePick = async () => {
     if (students.length === 0) return;
 
@@ -420,12 +450,16 @@ export const RandomWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
           }));
 
           const existing = activeDashboard?.sharedGroups ?? [];
+          const dropIds = collectPriorGroupIds();
+          const filtered = dropIds.size
+            ? existing.filter((g) => !dropIds.has(g.id))
+            : existing;
           const uniqueNew = newSharedGroups.filter(
-            (n) => !existing.some((e) => e.id === n.id)
+            (n) => n.id && !filtered.some((e) => e.id === n.id)
           );
 
-          if (uniqueNew.length > 0) {
-            updateDashboard({ sharedGroups: [...existing, ...uniqueNew] });
+          if (uniqueNew.length > 0 || filtered.length !== existing.length) {
+            updateDashboard({ sharedGroups: [...filtered, ...uniqueNew] });
           }
         }
 
@@ -606,11 +640,15 @@ export const RandomWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
             name: `Expert Group ${i + 1}`,
           }));
           const existing = activeDashboard?.sharedGroups ?? [];
+          const dropIds = collectPriorGroupIds();
+          const filtered = dropIds.size
+            ? existing.filter((g) => !dropIds.has(g.id))
+            : existing;
           const uniqueNew = [...newHomeShared, ...newExpertShared].filter(
-            (n) => n.id && !existing.some((e) => e.id === n.id)
+            (n) => n.id && !filtered.some((e) => e.id === n.id)
           );
-          if (uniqueNew.length > 0) {
-            updateDashboard({ sharedGroups: [...existing, ...uniqueNew] });
+          if (uniqueNew.length > 0 || filtered.length !== existing.length) {
+            updateDashboard({ sharedGroups: [...filtered, ...uniqueNew] });
           }
 
           updateWidget(widget.id, {
@@ -1141,12 +1179,27 @@ export const RandomWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
               shape="pill"
               onClick={handlePick}
               disabled={isSpinning}
-              className="flex-1"
-              style={{
-                height: 'clamp(40px, 10cqmin, 72px)',
-                paddingLeft: 'clamp(16px, 4cqmin, 40px)',
-                paddingRight: 'clamp(16px, 4cqmin, 40px)',
-              }}
+              className={
+                mode === 'jigsaw' && hasJigsawGroups
+                  ? 'flex-shrink-0'
+                  : 'flex-1'
+              }
+              style={
+                mode === 'jigsaw' && hasJigsawGroups
+                  ? {
+                      // Jigsaw shows two large Launch buttons already; collapse
+                      // Randomize to a square icon-only button so the footer
+                      // doesn't cram three flex-1 children at narrow widths.
+                      width: 'clamp(40px, 10cqmin, 72px)',
+                      height: 'clamp(40px, 10cqmin, 72px)',
+                      padding: 0,
+                    }
+                  : {
+                      height: 'clamp(40px, 10cqmin, 72px)',
+                      paddingLeft: 'clamp(16px, 4cqmin, 40px)',
+                      paddingRight: 'clamp(16px, 4cqmin, 40px)',
+                    }
+              }
               aria-label={isSpinning ? 'Picking' : 'Randomize'}
               title={isSpinning ? 'Picking...' : 'Randomize'}
               icon={

--- a/components/widgets/random/RandomWidget.tsx
+++ b/components/widgets/random/RandomWidget.tsx
@@ -27,6 +27,7 @@ import {
   Home,
   Sparkles,
 } from 'lucide-react';
+import type { LucideIcon } from 'lucide-react';
 import { getAudioCtx, playTick, playWinner } from './audioUtils';
 import { getLocalIsoDate } from '@/utils/localDate';
 import { logError } from '@/utils/logError';
@@ -43,6 +44,40 @@ import { RandomFlash } from './RandomFlash';
 import { RandomGroups } from './RandomGroups';
 
 import { WidgetLayout } from '../WidgetLayout';
+
+interface ModeCycleEntry {
+  id: string;
+  labelKey: string;
+  defaultLabel: string;
+  icon: LucideIcon;
+}
+
+const MODE_CYCLE: readonly ModeCycleEntry[] = [
+  {
+    id: 'single',
+    labelKey: 'widgets.random.modes.single',
+    defaultLabel: 'Pick One',
+    icon: UserPlus,
+  },
+  {
+    id: 'shuffle',
+    labelKey: 'widgets.random.modes.shuffle',
+    defaultLabel: 'Shuffle',
+    icon: Layers,
+  },
+  {
+    id: 'groups',
+    labelKey: 'widgets.random.modes.groups',
+    defaultLabel: 'Groups',
+    icon: Users,
+  },
+  {
+    id: 'jigsaw',
+    labelKey: 'widgets.random.modes.jigsaw',
+    defaultLabel: 'Jigsaw',
+    icon: Puzzle,
+  },
+];
 
 export const RandomWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
   const { t } = useTranslation();
@@ -95,6 +130,12 @@ export const RandomWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
   >(() => normalizeLastResult(config.lastResult));
   const [rotation, setRotation] = useState(0);
 
+  // Monotonic generation counter for in-flight picks. Bumped whenever the
+  // user resets, cycles modes, or the active roster changes mid-spin so the
+  // deferred jigsaw/groups setTimeout can detect that its result is stale
+  // and bail before clobbering the new state.
+  const spinGenRef = useRef(0);
+
   // Sync displayResult when config.lastResult changes (e.g. mode switch clears
   // it) using the "adjusting state while rendering" pattern. Doing this in a
   // useEffect would leave displayResult stale for one render, which crashed
@@ -120,16 +161,25 @@ export const RandomWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
 
     if (changed) {
       lastRosterRef.current = { id: activeRosterId, mode: rosterMode };
-      updateWidget(widget.id, {
-        config: {
-          ...config,
-          lastResult: null,
-          remainingStudents: [],
-          jigsawHomeGroups: null,
-          jigsawExpertGroups: null,
-          jigsawView: 'home',
-        },
-      });
+      // Only write when there is actually transient state to clear —
+      // otherwise every roster swap costs a Firestore round-trip.
+      const hasTransientState =
+        config.lastResult != null ||
+        (config.remainingStudents?.length ?? 0) > 0 ||
+        (config.jigsawHomeGroups?.length ?? 0) > 0 ||
+        (config.jigsawExpertGroups?.length ?? 0) > 0;
+      if (hasTransientState) {
+        spinGenRef.current += 1;
+        updateWidget(widget.id, {
+          config: {
+            lastResult: null,
+            remainingStudents: [],
+            jigsawHomeGroups: null,
+            jigsawExpertGroups: null,
+            jigsawView: 'home',
+          } as unknown as WidgetConfig,
+        });
+      }
     }
   }, [activeRosterId, widget.id, updateWidget, config, rosterMode]);
 
@@ -197,6 +247,7 @@ export const RandomWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
   };
 
   const handleReset = () => {
+    spinGenRef.current += 1;
     updateWidget(widget.id, {
       config: {
         remainingStudents: [],
@@ -210,28 +261,25 @@ export const RandomWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
     setRotation(0);
   };
 
-  const MODE_CYCLE: { id: string; label: string; icon: typeof UserPlus }[] = [
-    { id: 'single', label: 'Pick One', icon: UserPlus },
-    { id: 'shuffle', label: 'Shuffle', icon: Layers },
-    { id: 'groups', label: 'Groups', icon: Users },
-    { id: 'jigsaw', label: 'Jigsaw', icon: Puzzle },
-  ];
   const currentModeMeta =
     MODE_CYCLE.find((m) => m.id === mode) ?? MODE_CYCLE[0];
+  const currentModeLabel = t(currentModeMeta.labelKey, {
+    defaultValue: currentModeMeta.defaultLabel,
+  });
   const ModeIcon = currentModeMeta.icon;
 
   const cycleMode = () => {
     const idx = MODE_CYCLE.findIndex((m) => m.id === mode);
     const next = MODE_CYCLE[(idx + 1) % MODE_CYCLE.length];
+    spinGenRef.current += 1;
     updateWidget(widget.id, {
       config: {
-        ...config,
         mode: next.id,
         lastResult: null,
         jigsawHomeGroups: null,
         jigsawExpertGroups: null,
         jigsawView: 'home',
-      },
+      } as unknown as WidgetConfig,
     });
   };
 
@@ -501,7 +549,15 @@ export const RandomWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
         }, 100);
       }
     } else if (mode === 'jigsaw') {
+      const myGen = ++spinGenRef.current;
       setTimeout(() => {
+        // Bail if the user reset / cycled mode / changed class while the
+        // 500 ms timeout was pending — otherwise we'd write home/expert
+        // groups for a mode the user already moved away from.
+        if (myGen !== spinGenRef.current) {
+          setIsSpinning(false);
+          return;
+        }
         let homeGroups: RandomGroup[];
         if (rosterMode === 'class' && activeRoster) {
           const { groups, unsatisfied } = makeRestrictedGroups(
@@ -528,12 +584,16 @@ export const RandomWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
         setIsSpinning(false);
 
         try {
-          const newSharedGroups: SharedGroup[] = homeGroups.map((g, i) => ({
+          const newHomeShared: SharedGroup[] = homeGroups.map((g, i) => ({
             id: g.id ?? '',
             name: `Home Group ${i + 1}`,
           }));
+          const newExpertShared: SharedGroup[] = expertGroups.map((g, i) => ({
+            id: g.id ?? '',
+            name: `Expert Group ${i + 1}`,
+          }));
           const existing = activeDashboard?.sharedGroups ?? [];
-          const uniqueNew = newSharedGroups.filter(
+          const uniqueNew = [...newHomeShared, ...newExpertShared].filter(
             (n) => n.id && !existing.some((e) => e.id === n.id)
           );
           if (uniqueNew.length > 0) {
@@ -553,7 +613,12 @@ export const RandomWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
         }
       }, 500);
     } else {
+      const myGen = ++spinGenRef.current;
       setTimeout(() => {
+        if (myGen !== spinGenRef.current) {
+          setIsSpinning(false);
+          return;
+        }
         let result: string[] | RandomGroup[];
         if (mode === 'shuffle') {
           result = shuffle(students);
@@ -764,27 +829,34 @@ export const RandomWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
                 type="button"
                 onClick={cycleMode}
                 disabled={isSpinning}
-                className="flex items-center rounded-xl bg-white border border-slate-200 hover:bg-slate-50 transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+                className="flex items-center rounded-xl bg-white border border-slate-200 hover:bg-slate-50 transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed focus-visible:outline-2 focus-visible:outline-brand-blue-primary focus-visible:outline-offset-2"
                 style={{
                   gap: 'min(6px, 1.5cqmin)',
-                  padding: 'min(6px, 1.5cqmin) min(10px, 2.5cqmin)',
-                  height: 'min(32px, 8cqmin)',
+                  padding:
+                    'clamp(6px, 1.5cqmin, 10px) clamp(10px, 2.5cqmin, 18px)',
+                  minHeight: 'clamp(32px, 8cqmin, 48px)',
                 }}
-                aria-label={`Operation mode: ${currentModeMeta.label}. Tap to change.`}
-                title={`Mode: ${currentModeMeta.label} — tap to cycle`}
+                aria-label={t('widgets.random.modeChipAria', {
+                  mode: currentModeLabel,
+                  defaultValue: 'Operation mode: {{mode}}',
+                })}
+                title={t('widgets.random.modeChipTitle', {
+                  mode: currentModeLabel,
+                  defaultValue: 'Mode: {{mode}} — click to cycle',
+                })}
               >
                 <ModeIcon
                   className="text-brand-blue-primary shrink-0"
                   style={{
-                    width: 'min(14px, 4cqmin)',
-                    height: 'min(14px, 4cqmin)',
+                    width: 'clamp(14px, 4cqmin, 22px)',
+                    height: 'clamp(14px, 4cqmin, 22px)',
                   }}
                 />
                 <span
                   className="font-black uppercase text-brand-blue-primary truncate min-w-0 tracking-widest"
-                  style={{ fontSize: 'min(11px, 3.5cqmin)' }}
+                  style={{ fontSize: 'clamp(11px, 3.5cqmin, 18px)' }}
                 >
-                  {currentModeMeta.label}
+                  {currentModeLabel}
                 </span>
               </button>
               {mode === 'single' && (
@@ -855,6 +927,9 @@ export const RandomWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
                       : (jigsawHomeGroups ?? null)
                   }
                   sharedGroups={activeDashboard?.sharedGroups}
+                  groupNamePrefix={
+                    jigsawView === 'expert' ? 'Expert Group' : 'Home Group'
+                  }
                 />
               </div>
             ) : (
@@ -952,15 +1027,14 @@ export const RandomWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
                   shape="pill"
                   size="md"
                   onClick={() => setJigsawView('expert')}
+                  disabled={jigsawView === 'expert'}
+                  aria-pressed={jigsawView === 'expert'}
                   className="flex-1"
                   style={{
                     height: 'clamp(40px, 10cqmin, 72px)',
                     paddingLeft: 'clamp(10px, 3cqmin, 24px)',
                     paddingRight: 'clamp(10px, 3cqmin, 24px)',
                   }}
-                  aria-label={t('widgets.random.launchJigsaw', {
-                    defaultValue: 'Launch Jigsaw',
-                  })}
                   title={t('widgets.random.launchJigsawHint', {
                     defaultValue: 'Show expert groups',
                   })}
@@ -987,15 +1061,14 @@ export const RandomWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
                   shape="pill"
                   size="md"
                   onClick={() => setJigsawView('home')}
+                  disabled={jigsawView === 'home'}
+                  aria-pressed={jigsawView === 'home'}
                   className="flex-1"
                   style={{
                     height: 'clamp(40px, 10cqmin, 72px)',
                     paddingLeft: 'clamp(10px, 3cqmin, 24px)',
                     paddingRight: 'clamp(10px, 3cqmin, 24px)',
                   }}
-                  aria-label={t('widgets.random.launchHomeGroup', {
-                    defaultValue: 'Launch Home Group',
-                  })}
                   title={t('widgets.random.launchHomeGroupHint', {
                     defaultValue: 'Return to home groups',
                   })}

--- a/components/widgets/random/RandomWidget.tsx
+++ b/components/widgets/random/RandomWidget.tsx
@@ -152,6 +152,39 @@ export const RandomWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
     setDisplayResult(normalizeLastResult(config.lastResult));
   }
 
+  // Local jigsaw groups state: render falls back to this when config hasn't
+  // round-tripped yet (the gap between setIsSpinning(false) and the Firestore
+  // listener replay) or when updateWidget is a no-op (e.g. view-only board).
+  // Without it the UI stays empty after a Pick on view-only boards because
+  // the jigsaw render reads exclusively from config.
+  const [localJigsaw, setLocalJigsaw] = useState<{
+    home: RandomGroup[];
+    expert: RandomGroup[];
+  } | null>(() => {
+    const h = config.jigsawHomeGroups;
+    const e = config.jigsawExpertGroups;
+    if (Array.isArray(h) && h.length > 0) {
+      return { home: h, expert: Array.isArray(e) ? e : [] };
+    }
+    return null;
+  });
+
+  // Adjust localJigsaw when the config-side jigsaw groups change (mode swap,
+  // roster swap, manual reset). Reference equality is sufficient because
+  // updateWidget rewrites the array on every change.
+  const [prevJigsawHome, setPrevJigsawHome] = useState(jigsawHomeGroups);
+  if (jigsawHomeGroups !== prevJigsawHome) {
+    setPrevJigsawHome(jigsawHomeGroups);
+    if (Array.isArray(jigsawHomeGroups) && jigsawHomeGroups.length > 0) {
+      setLocalJigsaw({
+        home: jigsawHomeGroups,
+        expert: Array.isArray(jigsawExpertGroups) ? jigsawExpertGroups : [],
+      });
+    } else {
+      setLocalJigsaw(null);
+    }
+  }
+
   // Track active roster to only clear when it actually changes
   const lastRosterRef = useRef<{ id: string | null; mode: string }>({
     id: activeRosterId,
@@ -183,6 +216,7 @@ export const RandomWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
           jigsawView: 'home',
         };
         updateWidget(widget.id, { config: update as WidgetConfig });
+        setLocalJigsaw(null);
       }
     }
   }, [activeRosterId, widget.id, updateWidget, config, rosterMode]);
@@ -260,6 +294,7 @@ export const RandomWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
       jigsawView: 'home',
     };
     updateWidget(widget.id, { config: update as WidgetConfig });
+    setLocalJigsaw(null);
     setDisplayResult('');
     setRotation(0);
   };
@@ -283,6 +318,7 @@ export const RandomWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
       jigsawView: 'home',
     };
     updateWidget(widget.id, { config: update as WidgetConfig });
+    setLocalJigsaw(null);
   };
 
   const setJigsawView = (view: 'home' | 'expert') => {
@@ -292,8 +328,25 @@ export const RandomWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
     });
   };
 
+  // Render-side jigsaw groups: prefer config (the source of truth that
+  // survives reload) but fall back to localJigsaw so the UI never goes blank
+  // between a Pick and the Firestore round-trip — and so view-only boards
+  // (where updateWidget is a no-op) still show the picked groups locally.
+  const renderedHomeGroups: RandomGroup[] | null =
+    (Array.isArray(jigsawHomeGroups) && jigsawHomeGroups.length > 0
+      ? jigsawHomeGroups
+      : null) ??
+    localJigsaw?.home ??
+    null;
+  const renderedExpertGroups: RandomGroup[] | null =
+    (Array.isArray(jigsawExpertGroups) && jigsawExpertGroups.length > 0
+      ? jigsawExpertGroups
+      : null) ??
+    localJigsaw?.expert ??
+    null;
   const hasJigsawGroups =
-    Array.isArray(jigsawHomeGroups) && jigsawHomeGroups.length > 0;
+    (renderedHomeGroups?.length ?? 0) > 0 ||
+    (renderedExpertGroups?.length ?? 0) > 0;
 
   const handleSendToScoreboard = () => {
     // 1. Normalize current groups from displayResult
@@ -626,6 +679,7 @@ export const RandomWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
           );
         }
 
+        setLocalJigsaw({ home: homeGroups, expert: expertGroups });
         setDisplayResult(homeGroups);
         if (soundEnabled) playWinner();
         setIsSpinning(false);
@@ -973,8 +1027,8 @@ export const RandomWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
                 <RandomGroups
                   displayResult={
                     jigsawView === 'expert'
-                      ? (jigsawExpertGroups ?? null)
-                      : (jigsawHomeGroups ?? null)
+                      ? renderedExpertGroups
+                      : renderedHomeGroups
                   }
                   sharedGroups={activeDashboard?.sharedGroups}
                   groupNamePrefix={

--- a/components/widgets/random/RandomWidget.tsx
+++ b/components/widgets/random/RandomWidget.tsx
@@ -22,10 +22,18 @@ import {
   RotateCcw,
   Trophy,
   UserX,
+  UserPlus,
+  Puzzle,
+  Home,
+  Sparkles,
 } from 'lucide-react';
 import { getAudioCtx, playTick, playWinner } from './audioUtils';
 import { getLocalIsoDate } from '@/utils/localDate';
-import { makeNameGroups, makeRestrictedGroups } from './groupMaker';
+import {
+  makeJigsawExpertGroups,
+  makeNameGroups,
+  makeRestrictedGroups,
+} from './groupMaker';
 
 import { SCOREBOARD_COLORS as TEAM_COLORS } from '@/config/scoreboard';
 import { RandomWheel } from './RandomWheel';
@@ -56,6 +64,9 @@ export const RandomWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
     autoStartTimer = false,
     visualStyle = 'flash',
     groupSize = 3,
+    jigsawHomeGroups,
+    jigsawExpertGroups,
+    jigsawView = 'home',
   } = config;
 
   const remainingStudents = Array.isArray(config.remainingStudents)
@@ -113,6 +124,9 @@ export const RandomWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
           ...config,
           lastResult: null,
           remainingStudents: [],
+          jigsawHomeGroups: null,
+          jigsawExpertGroups: null,
+          jigsawView: 'home',
         },
       });
     }
@@ -186,11 +200,49 @@ export const RandomWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
       config: {
         remainingStudents: [],
         lastResult: null,
+        jigsawHomeGroups: null,
+        jigsawExpertGroups: null,
+        jigsawView: 'home',
       } as unknown as WidgetConfig,
     });
     setDisplayResult('');
     setRotation(0);
   };
+
+  const MODE_CYCLE: { id: string; label: string; icon: typeof UserPlus }[] = [
+    { id: 'single', label: 'Pick One', icon: UserPlus },
+    { id: 'shuffle', label: 'Shuffle', icon: Layers },
+    { id: 'groups', label: 'Groups', icon: Users },
+    { id: 'jigsaw', label: 'Jigsaw', icon: Puzzle },
+  ];
+  const currentModeMeta =
+    MODE_CYCLE.find((m) => m.id === mode) ?? MODE_CYCLE[0];
+  const ModeIcon = currentModeMeta.icon;
+
+  const cycleMode = () => {
+    const idx = MODE_CYCLE.findIndex((m) => m.id === mode);
+    const next = MODE_CYCLE[(idx + 1) % MODE_CYCLE.length];
+    updateWidget(widget.id, {
+      config: {
+        ...config,
+        mode: next.id,
+        lastResult: null,
+        jigsawHomeGroups: null,
+        jigsawExpertGroups: null,
+        jigsawView: 'home',
+      },
+    });
+  };
+
+  const setJigsawView = (view: 'home' | 'expert') => {
+    if (jigsawView === view) return;
+    updateWidget(widget.id, {
+      config: { ...config, jigsawView: view },
+    });
+  };
+
+  const hasJigsawGroups =
+    Array.isArray(jigsawHomeGroups) && jigsawHomeGroups.length > 0;
 
   const handleSendToScoreboard = () => {
     // 1. Normalize current groups from displayResult
@@ -447,6 +499,58 @@ export const RandomWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
           }
         }, 100);
       }
+    } else if (mode === 'jigsaw') {
+      setTimeout(() => {
+        let homeGroups: RandomGroup[];
+        if (rosterMode === 'class' && activeRoster) {
+          const { groups, unsatisfied } = makeRestrictedGroups(
+            presentClassStudents,
+            groupSize
+          );
+          homeGroups = groups;
+          if (unsatisfied > 0) {
+            addToast(
+              t('widgets.random.restrictionsUnsatisfied', {
+                defaultValue:
+                  "Couldn't satisfy all restrictions — try again or adjust group size.",
+              }),
+              'warning'
+            );
+          }
+        } else {
+          homeGroups = makeNameGroups(students, groupSize);
+        }
+        const expertGroups = makeJigsawExpertGroups(homeGroups);
+
+        setDisplayResult(homeGroups);
+        if (soundEnabled) playWinner();
+        setIsSpinning(false);
+
+        try {
+          const newSharedGroups: SharedGroup[] = homeGroups.map((g, i) => ({
+            id: g.id ?? '',
+            name: `Home Group ${i + 1}`,
+          }));
+          const existing = activeDashboard?.sharedGroups ?? [];
+          const uniqueNew = newSharedGroups.filter(
+            (n) => n.id && !existing.some((e) => e.id === n.id)
+          );
+          if (uniqueNew.length > 0) {
+            updateDashboard({ sharedGroups: [...existing, ...uniqueNew] });
+          }
+
+          updateWidget(widget.id, {
+            config: {
+              jigsawHomeGroups: homeGroups,
+              jigsawExpertGroups: expertGroups,
+              jigsawView: 'home',
+              lastResult: homeGroups,
+            } as unknown as WidgetConfig,
+          });
+        } catch (err) {
+          console.error('Randomizer Jigsaw Sync Error:', err);
+        }
+      }, 500);
     } else {
       setTimeout(() => {
         let result: string[] | RandomGroup[];
@@ -655,6 +759,33 @@ export const RandomWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
               className="flex items-center"
               style={{ gap: 'clamp(6px, 2cqmin, 14px)' }}
             >
+              <button
+                type="button"
+                onClick={cycleMode}
+                disabled={isSpinning}
+                className="flex items-center rounded-xl bg-white border border-slate-200 hover:bg-slate-50 transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+                style={{
+                  gap: 'min(6px, 1.5cqmin)',
+                  padding: 'min(6px, 1.5cqmin) min(10px, 2.5cqmin)',
+                  height: 'min(32px, 8cqmin)',
+                }}
+                aria-label={`Operation mode: ${currentModeMeta.label}. Tap to change.`}
+                title={`Mode: ${currentModeMeta.label} — tap to cycle`}
+              >
+                <ModeIcon
+                  className="text-brand-blue-primary shrink-0"
+                  style={{
+                    width: 'min(14px, 4cqmin)',
+                    height: 'min(14px, 4cqmin)',
+                  }}
+                />
+                <span
+                  className="font-black uppercase text-brand-blue-primary truncate min-w-0 tracking-widest"
+                  style={{ fontSize: 'min(11px, 3.5cqmin)' }}
+                >
+                  {currentModeMeta.label}
+                </span>
+              </button>
               {mode === 'single' && (
                 <>
                   <button
@@ -711,6 +842,20 @@ export const RandomWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
           >
             {mode === 'single' ? (
               renderSinglePick()
+            ) : mode === 'jigsaw' ? (
+              <div
+                className="w-full flex-1 min-h-0 flex flex-col"
+                style={{ padding: '0 min(8px, 2cqmin)' }}
+              >
+                <RandomGroups
+                  displayResult={
+                    jigsawView === 'expert'
+                      ? (jigsawExpertGroups ?? null)
+                      : (jigsawHomeGroups ?? null)
+                  }
+                  sharedGroups={activeDashboard?.sharedGroups}
+                />
+              </div>
             ) : (
               <div
                 className="w-full flex-1 min-h-0 flex flex-col"
@@ -799,6 +944,80 @@ export const RandomWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
               gap: 'clamp(6px, 2cqmin, 14px)',
             }}
           >
+            {mode === 'jigsaw' && hasJigsawGroups && (
+              <>
+                <Button
+                  variant={jigsawView === 'expert' ? 'primary' : 'secondary'}
+                  shape="pill"
+                  size="md"
+                  onClick={() => setJigsawView('expert')}
+                  className="flex-1"
+                  style={{
+                    height: 'clamp(40px, 10cqmin, 72px)',
+                    paddingLeft: 'clamp(10px, 3cqmin, 24px)',
+                    paddingRight: 'clamp(10px, 3cqmin, 24px)',
+                  }}
+                  aria-label={t('widgets.random.launchJigsaw', {
+                    defaultValue: 'Launch Jigsaw',
+                  })}
+                  title={t('widgets.random.launchJigsawHint', {
+                    defaultValue: 'Show expert groups',
+                  })}
+                  icon={
+                    <Sparkles
+                      style={{
+                        width: 'clamp(16px, 4.5cqmin, 32px)',
+                        height: 'clamp(16px, 4.5cqmin, 32px)',
+                      }}
+                    />
+                  }
+                >
+                  <span
+                    className="font-black uppercase tracking-wider truncate"
+                    style={{ fontSize: 'clamp(11px, 3cqmin, 18px)' }}
+                  >
+                    {t('widgets.random.launchJigsaw', {
+                      defaultValue: 'Launch Jigsaw',
+                    })}
+                  </span>
+                </Button>
+                <Button
+                  variant={jigsawView === 'home' ? 'primary' : 'secondary'}
+                  shape="pill"
+                  size="md"
+                  onClick={() => setJigsawView('home')}
+                  className="flex-1"
+                  style={{
+                    height: 'clamp(40px, 10cqmin, 72px)',
+                    paddingLeft: 'clamp(10px, 3cqmin, 24px)',
+                    paddingRight: 'clamp(10px, 3cqmin, 24px)',
+                  }}
+                  aria-label={t('widgets.random.launchHomeGroup', {
+                    defaultValue: 'Launch Home Group',
+                  })}
+                  title={t('widgets.random.launchHomeGroupHint', {
+                    defaultValue: 'Return to home groups',
+                  })}
+                  icon={
+                    <Home
+                      style={{
+                        width: 'clamp(16px, 4.5cqmin, 32px)',
+                        height: 'clamp(16px, 4.5cqmin, 32px)',
+                      }}
+                    />
+                  }
+                >
+                  <span
+                    className="font-black uppercase tracking-wider truncate"
+                    style={{ fontSize: 'clamp(11px, 3cqmin, 18px)' }}
+                  >
+                    {t('widgets.random.launchHomeGroup', {
+                      defaultValue: 'Launch Home Group',
+                    })}
+                  </span>
+                </Button>
+              </>
+            )}
             {mode === 'groups' &&
               Array.isArray(displayResult) &&
               displayResult.length > 0 &&

--- a/components/widgets/random/groupMaker.test.ts
+++ b/components/widgets/random/groupMaker.test.ts
@@ -50,11 +50,52 @@ describe('makeJigsawExpertGroups', () => {
 
   it('drops expert positions that would have zero members', () => {
     // Empty home groups in the input must not produce empty expert groups.
+    // Here pos 1 only has A2 (singleton) — orphan merging then folds A2 into
+    // the only larger expert group, ['A1', 'C1'].
     const home = [groupOf('A1', 'A2'), groupOf(), groupOf('C1')];
 
     const expert = makeJigsawExpertGroups(home);
 
-    expect(expert.map((g) => g.names)).toEqual([['A1', 'C1'], ['A2']]);
+    expect(expert.map((g) => g.names.sort())).toEqual([
+      ['A1', 'A2', 'C1'].sort(),
+    ]);
+  });
+
+  it('merges orphan singletons into the smallest non-singleton expert group', () => {
+    // Home group sizes 4 / 1 / 2 ⇒ raw transpose:
+    //   pos 0: A1, B1, C1   (size 3)
+    //   pos 1: A2, C2       (size 2)
+    //   pos 2: A3           (size 1, orphan)
+    //   pos 3: A4           (size 1, orphan)
+    // After merging each orphan into the smallest non-singleton:
+    //   A3 → smallest = [A2, C2] → [A2, C2, A3] (size 3)
+    //   A4 → smallest now ties at size 3 — picks one of them
+    const home = [
+      groupOf('A1', 'A2', 'A3', 'A4'),
+      groupOf('B1'),
+      groupOf('C1', 'C2'),
+    ];
+
+    const expert = makeJigsawExpertGroups(home);
+
+    // No singletons survive
+    expect(expert.every((g) => g.names.length >= 2)).toBe(true);
+    // Total student count is preserved
+    expect(expert.flatMap((g) => g.names).sort()).toEqual(
+      ['A1', 'A2', 'A3', 'A4', 'B1', 'C1', 'C2'].sort()
+    );
+  });
+
+  it('leaves all-singleton expert groups alone (degenerate single-home case)', () => {
+    // Single home group of size N transposes to N singleton expert groups.
+    // There is no larger expert group to fold orphans into, so all stay as
+    // singletons; the caller surfaces a degenerate-jigsaw warning toast
+    // rather than silently merging them all into one big group.
+    const home = [groupOf('A', 'B', 'C')];
+
+    const expert = makeJigsawExpertGroups(home);
+
+    expect(expert.map((g) => g.names)).toEqual([['A'], ['B'], ['C']]);
   });
 
   it('assigns a fresh id to each generated expert group', () => {

--- a/components/widgets/random/groupMaker.test.ts
+++ b/components/widgets/random/groupMaker.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest';
+import { RandomGroup } from '@/types';
+import { makeJigsawExpertGroups, makeNameGroups } from './groupMaker';
+
+const groupOf = (...names: string[]): RandomGroup => ({
+  id: crypto.randomUUID(),
+  names,
+});
+
+describe('makeJigsawExpertGroups', () => {
+  it('returns an empty array when no home groups are supplied', () => {
+    expect(makeJigsawExpertGroups([])).toEqual([]);
+  });
+
+  it('transposes evenly-sized home groups (position N becomes expert N)', () => {
+    const home = [
+      groupOf('A1', 'A2', 'A3'),
+      groupOf('B1', 'B2', 'B3'),
+      groupOf('C1', 'C2', 'C3'),
+      groupOf('D1', 'D2', 'D3'),
+    ];
+
+    const expert = makeJigsawExpertGroups(home);
+
+    expect(expert.map((g) => g.names)).toEqual([
+      ['A1', 'B1', 'C1', 'D1'],
+      ['A2', 'B2', 'C2', 'D2'],
+      ['A3', 'B3', 'C3', 'D3'],
+    ]);
+  });
+
+  it('skips missing positions when home groups are uneven', () => {
+    // 11 students into home groups of 4 → sizes [4, 4, 3]. Position 4 only
+    // exists in the first two home groups.
+    const home = [
+      groupOf('A1', 'A2', 'A3', 'A4'),
+      groupOf('B1', 'B2', 'B3', 'B4'),
+      groupOf('C1', 'C2', 'C3'),
+    ];
+
+    const expert = makeJigsawExpertGroups(home);
+
+    expect(expert.map((g) => g.names)).toEqual([
+      ['A1', 'B1', 'C1'],
+      ['A2', 'B2', 'C2'],
+      ['A3', 'B3', 'C3'],
+      ['A4', 'B4'],
+    ]);
+  });
+
+  it('drops expert positions that would have zero members', () => {
+    // Empty home groups in the input must not produce empty expert groups.
+    const home = [groupOf('A1', 'A2'), groupOf(), groupOf('C1')];
+
+    const expert = makeJigsawExpertGroups(home);
+
+    expect(expert.map((g) => g.names)).toEqual([['A1', 'C1'], ['A2']]);
+  });
+
+  it('assigns a fresh id to each generated expert group', () => {
+    const home = [groupOf('A1', 'A2'), groupOf('B1', 'B2')];
+    const expert = makeJigsawExpertGroups(home);
+    const ids = expert.map((g) => g.id);
+
+    expect(ids.every((id) => typeof id === 'string' && id.length > 0)).toBe(
+      true
+    );
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+});
+
+describe('makeNameGroups (regression — used by Jigsaw home-group fallback)', () => {
+  it('chunks names into the requested group size', () => {
+    const groups = makeNameGroups(['a', 'b', 'c', 'd', 'e'], 2);
+    expect(groups.length).toBe(3);
+    expect(groups[0].names.length).toBe(2);
+    expect(groups[2].names.length).toBe(1);
+  });
+});

--- a/components/widgets/random/groupMaker.ts
+++ b/components/widgets/random/groupMaker.ts
@@ -60,6 +60,32 @@ export function makeRestrictedGroups(
 }
 
 /**
+ * Build expert groups for the Jigsaw cooperative-learning structure: take
+ * position N from each home group and combine those students into expert
+ * group N. Home groups can be uneven; missing positions are simply skipped.
+ */
+export function makeJigsawExpertGroups(
+  homeGroups: RandomGroup[]
+): RandomGroup[] {
+  if (homeGroups.length === 0) return [];
+  const maxSize = homeGroups.reduce(
+    (max, g) => Math.max(max, g.names.length),
+    0
+  );
+  const expertGroups: RandomGroup[] = [];
+  for (let pos = 0; pos < maxSize; pos++) {
+    const names: string[] = [];
+    for (const home of homeGroups) {
+      if (pos < home.names.length) names.push(home.names[pos]);
+    }
+    if (names.length > 0) {
+      expertGroups.push({ id: crypto.randomUUID(), names });
+    }
+  }
+  return expertGroups;
+}
+
+/**
  * Plain chunking used for custom-names mode, where we have strings only
  * (no IDs, so no restriction lookup). Matches the pre-existing behavior.
  */

--- a/components/widgets/random/groupMaker.ts
+++ b/components/widgets/random/groupMaker.ts
@@ -63,6 +63,12 @@ export function makeRestrictedGroups(
  * Build expert groups for the Jigsaw cooperative-learning structure: take
  * position N from each home group and combine those students into expert
  * group N. Home groups can be uneven; missing positions are simply skipped.
+ *
+ * If the transpose produces a size-1 "expert group" (no peer to compare
+ * notes with) AND a larger expert group exists, merge the orphan into the
+ * smallest larger group so every expert has at least one peer. When every
+ * expert group is size 1 the caller's degenerate-jigsaw warning toast
+ * handles communication; we don't artificially merge in that case.
  */
 export function makeJigsawExpertGroups(
   homeGroups: RandomGroup[]
@@ -82,7 +88,16 @@ export function makeJigsawExpertGroups(
       expertGroups.push({ id: crypto.randomUUID(), names });
     }
   }
-  return expertGroups;
+
+  const balanced = expertGroups.filter((g) => g.names.length > 1);
+  const orphans = expertGroups.filter((g) => g.names.length === 1);
+  if (balanced.length === 0 || orphans.length === 0) return expertGroups;
+
+  for (const orphan of orphans) {
+    balanced.sort((a, b) => a.names.length - b.names.length);
+    balanced[0].names.push(...orphan.names);
+  }
+  return balanced;
 }
 
 /**

--- a/locales/en.json
+++ b/locales/en.json
@@ -630,6 +630,18 @@
       "sendToScoreboard": "Send to Scoreboard",
       "scoreboardUpdated": "Updated scoreboard with {{count}} teams!",
       "scoreboardCreated": "Created scoreboard with {{count}} teams!",
+      "modes": {
+        "single": "Pick One",
+        "shuffle": "Shuffle",
+        "groups": "Groups",
+        "jigsaw": "Jigsaw"
+      },
+      "modeChipAria": "Operation mode: {{mode}}",
+      "modeChipTitle": "Mode: {{mode}} — click to cycle",
+      "launchJigsaw": "Launch Jigsaw",
+      "launchJigsawHint": "Show expert groups",
+      "launchHomeGroup": "Launch Home Group",
+      "launchHomeGroupHint": "Return to home groups",
       "absent": {
         "buttonLabel": "Mark absent students",
         "ariaLabel": "Open attendance — {{count}} marked absent today",

--- a/locales/en.json
+++ b/locales/en.json
@@ -642,6 +642,9 @@
       "launchJigsawHint": "Show expert groups",
       "launchHomeGroup": "Launch Home Group",
       "launchHomeGroupHint": "Return to home groups",
+      "groupSize": "Group Size",
+      "homeGroupSize": "Home Group Size",
+      "jigsawNeedsMultipleGroups": "Jigsaw needs at least 2 home groups — lower the group size or add more students.",
       "absent": {
         "buttonLabel": "Mark absent students",
         "ariaLabel": "Open attendance — {{count}} marked absent today",

--- a/types.ts
+++ b/types.ts
@@ -822,6 +822,13 @@ export interface RandomConfig {
   autoStartTimer?: boolean;
   visualStyle?: 'flash' | 'slots' | 'wheel';
   externalTrigger?: number;
+  /** Jigsaw mode: original home groups (each student's "home base"). */
+  jigsawHomeGroups?: RandomGroup[];
+  /** Jigsaw mode: expert groups derived by transposing home groups
+   *  (position N from each home group becomes expert group N). */
+  jigsawExpertGroups?: RandomGroup[];
+  /** Jigsaw mode: which view is currently shown on the front face. */
+  jigsawView?: 'home' | 'expert';
 }
 
 export interface DiceConfig {

--- a/types.ts
+++ b/types.ts
@@ -823,10 +823,10 @@ export interface RandomConfig {
   visualStyle?: 'flash' | 'slots' | 'wheel';
   externalTrigger?: number;
   /** Jigsaw mode: original home groups (each student's "home base"). */
-  jigsawHomeGroups?: RandomGroup[];
+  jigsawHomeGroups?: RandomGroup[] | null;
   /** Jigsaw mode: expert groups derived by transposing home groups
    *  (position N from each home group becomes expert group N). */
-  jigsawExpertGroups?: RandomGroup[];
+  jigsawExpertGroups?: RandomGroup[] | null;
   /** Jigsaw mode: which view is currently shown on the front face. */
   jigsawView?: 'home' | 'expert';
 }

--- a/utils/widgetConfigPersistence.ts
+++ b/utils/widgetConfigPersistence.ts
@@ -56,6 +56,13 @@ const TRANSIENT_CONFIG_KEYS = new Set<string>([
   'activeNotebookId',
   'lastResult',
 
+  // Randomizer Jigsaw mode: per-pick group state (jigsaw*Groups also contain
+  // student names in custom-roster mode, so they must never be saved as a
+  // global default).
+  'jigsawHomeGroups',
+  'jigsawExpertGroups',
+  'jigsawView',
+
   // Large instance data / per-session game state
   'paths',
   'furniture',


### PR DESCRIPTION
## Summary

- Adds a **Jigsaw** operation mode to the Random widget (the 4th option alongside Pick One / Shuffle / Groups). On Pick, it generates **home groups** sized by `groupSize`, then derives **expert groups** by transposing position N from each home group into expert group N.
- Adds two footer buttons in jigsaw mode: **Launch Jigsaw** (show expert groups) and **Launch Home Group** (return to home groups). The active view is highlighted as `primary`; the other is `secondary`.
- Adds a compact **mode-cycle chip** to the front-face header. Tap to cycle Pick One → Shuffle → Groups → Jigsaw → Pick One without flipping to settings. Styled to match the existing Stations-style header chip (white shell, slate border, brand-blue label/icon) for visual consistency.
- Also: Jigsaw mode now reuses the Group Size slider in settings (relabeled "Home Group Size"), and the mode buttons in `RandomSettings` move to a 4-column grid to fit the new option.

## Implementation notes

- New `RandomConfig` fields: `jigsawHomeGroups`, `jigsawExpertGroups`, `jigsawView` (`'home' | 'expert'`).
- New helper `makeJigsawExpertGroups(homeGroups)` in `groupMaker.ts`.
- Mode switches and reset/roster-change clear all jigsaw fields, mirroring how `lastResult` / `remainingStudents` are cleared today.
- Home groups are still added to `dashboard.sharedGroups` so a later "Send to Scoreboard" or Stations sync still works on the home grouping.

## Test plan

- [ ] In Pick One / Shuffle / Groups, the new chip appears, shows the current label, and cycling through it lands on the right view each time.
- [ ] In Groups mode, behavior is unchanged (regression check).
- [ ] In Jigsaw mode with a class roster, clicking Pick generates home groups; Launch Jigsaw shows expert groups (one student per home group, length = home-group size); Launch Home Group returns.
- [ ] Resetting the widget or switching the active class clears jigsaw state.
- [ ] Group Size slider also drives jigsaw home-group size with the relabeled "Home Group Size" copy.
- [ ] Restriction-aware grouping still works for jigsaw home groups (uses `makeRestrictedGroups`).


---
_Generated by [Claude Code](https://claude.ai/code/session_01Ur7gVg5QXzDporEYNmnxWj)_