### PR TITLE
refactor(hooks): fix effect cleanup leaks via adjusting-state-while-rendering pattern

### DIFF
--- a/hooks/useGuidedLearning.ts
+++ b/hooks/useGuidedLearning.ts
@@ -58,19 +58,25 @@ export const useGuidedLearning = (
   const { isConnected } = useGoogleDrive();
   const [sets, setSets] = useState<GuidedLearningSetMetadata[]>([]);
   const [buildingSets, setBuildingSets] = useState<GuidedLearningSet[]>([]);
-  const [loading, setLoading] = useState(true);
+  const [loading, setLoading] = useState(!!userId);
   const [buildingLoading, setBuildingLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [prevUserId, setPrevUserId] = useState(userId);
+
+  // Adjusting-state-while-rendering: synchronously reset on userId transitions.
+  if (prevUserId !== userId) {
+    setPrevUserId(userId);
+    if (!userId) {
+      setSets([]);
+      setLoading(false);
+    } else {
+      setLoading(true);
+    }
+  }
 
   // Real-time listener for personal set metadata
   useEffect(() => {
-    if (!userId) {
-      const tid = setTimeout(() => {
-        setSets([]);
-        setLoading(false);
-      }, 0);
-      return () => clearTimeout(tid);
-    }
+    if (!userId) return;
 
     const q = query(
       collection(db, 'users', userId, GL_COLLECTION),

--- a/hooks/useGuidedLearning.ts
+++ b/hooks/useGuidedLearning.ts
@@ -65,11 +65,11 @@ export const useGuidedLearning = (
   // Real-time listener for personal set metadata
   useEffect(() => {
     if (!userId) {
-      setTimeout(() => {
+      const tid = setTimeout(() => {
         setSets([]);
         setLoading(false);
       }, 0);
-      return;
+      return () => clearTimeout(tid);
     }
 
     const q = query(

--- a/hooks/useQuiz.ts
+++ b/hooks/useQuiz.ts
@@ -112,18 +112,24 @@ export const useQuiz = (userId: string | undefined): UseQuizResult => {
   const { googleAccessToken } = useAuth();
   const { isConnected } = useGoogleDrive();
   const [quizzes, setQuizzes] = useState<QuizMetadata[]>([]);
-  const [loading, setLoading] = useState(true);
+  const [loading, setLoading] = useState(!!userId);
   const [error, setError] = useState<string | null>(null);
+  const [prevUserId, setPrevUserId] = useState(userId);
+
+  // Adjusting-state-while-rendering: synchronously reset on userId transitions.
+  if (prevUserId !== userId) {
+    setPrevUserId(userId);
+    if (!userId) {
+      setQuizzes([]);
+      setLoading(false);
+    } else {
+      setLoading(true);
+    }
+  }
 
   // Real-time listener for quiz metadata from Firestore
   useEffect(() => {
-    if (!userId) {
-      const tid = setTimeout(() => {
-        setQuizzes([]);
-        setLoading(false);
-      }, 0);
-      return () => clearTimeout(tid);
-    }
+    if (!userId) return;
 
     const q = query(
       collection(db, 'users', userId, QUIZZES_COLLECTION),

--- a/hooks/useQuiz.ts
+++ b/hooks/useQuiz.ts
@@ -118,11 +118,11 @@ export const useQuiz = (userId: string | undefined): UseQuizResult => {
   // Real-time listener for quiz metadata from Firestore
   useEffect(() => {
     if (!userId) {
-      setTimeout(() => {
+      const tid = setTimeout(() => {
         setQuizzes([]);
         setLoading(false);
       }, 0);
-      return;
+      return () => clearTimeout(tid);
     }
 
     const q = query(

--- a/hooks/useStarterPacks.ts
+++ b/hooks/useStarterPacks.ts
@@ -11,19 +11,21 @@ const appId =
 export function useStarterPacks(userId?: string | null) {
   const [publicPacks, setPublicPacks] = useState<StarterPack[]>([]);
   const [userPacks, setUserPacks] = useState<StarterPack[]>([]);
-  const [loading, setLoading] = useState(true);
+  const [loading, setLoading] = useState(!isAuthBypass);
+  const [prevUserId, setPrevUserId] = useState(userId);
+
+  // Adjusting-state-while-rendering: synchronously reset on userId transitions
+  // (skipped in bypass mode — no subscription, state stays at initial values).
+  if (!isAuthBypass && prevUserId !== userId) {
+    setPrevUserId(userId);
+    setLoading(true);
+    if (!userId) {
+      setUserPacks([]);
+    }
+  }
 
   useEffect(() => {
-    if (isAuthBypass) {
-      const tid = setTimeout(() => {
-        setPublicPacks([]);
-        setUserPacks([]);
-        setLoading(false);
-      }, 0);
-      return () => clearTimeout(tid);
-    }
-
-    const loadingTid = setTimeout(() => setLoading(true), 0);
+    if (isAuthBypass) return;
 
     let isPublicLoaded = false;
     let isUserLoaded = !userId;
@@ -91,14 +93,7 @@ export function useStarterPacks(userId?: string | null) {
       );
     }
 
-    let userPacksTid: ReturnType<typeof setTimeout> | undefined;
-    if (!userId) {
-      userPacksTid = setTimeout(() => setUserPacks([]), 0);
-    }
-
     return () => {
-      clearTimeout(loadingTid);
-      if (userPacksTid !== undefined) clearTimeout(userPacksTid);
       unsubPublic();
       if (unsubUser) unsubUser();
     };

--- a/hooks/useStarterPacks.ts
+++ b/hooks/useStarterPacks.ts
@@ -15,15 +15,15 @@ export function useStarterPacks(userId?: string | null) {
 
   useEffect(() => {
     if (isAuthBypass) {
-      setTimeout(() => {
+      const tid = setTimeout(() => {
         setPublicPacks([]);
         setUserPacks([]);
         setLoading(false);
       }, 0);
-      return;
+      return () => clearTimeout(tid);
     }
 
-    setTimeout(() => setLoading(true), 0);
+    const loadingTid = setTimeout(() => setLoading(true), 0);
 
     let isPublicLoaded = false;
     let isUserLoaded = !userId;
@@ -89,11 +89,16 @@ export function useStarterPacks(userId?: string | null) {
           checkLoading();
         }
       );
-    } else {
-      setTimeout(() => setUserPacks([]), 0);
+    }
+
+    let userPacksTid: ReturnType<typeof setTimeout> | undefined;
+    if (!userId) {
+      userPacksTid = setTimeout(() => setUserPacks([]), 0);
     }
 
     return () => {
+      clearTimeout(loadingTid);
+      if (userPacksTid !== undefined) clearTimeout(userPacksTid);
       unsubPublic();
       if (unsubUser) unsubUser();
     };

--- a/hooks/useVideoActivity.ts
+++ b/hooks/useVideoActivity.ts
@@ -75,11 +75,11 @@ export const useVideoActivity = (
   // Real-time listener for activity metadata from Firestore
   useEffect(() => {
     if (!userId) {
-      setTimeout(() => {
+      const tid = setTimeout(() => {
         setActivities([]);
         setLoading(false);
       }, 0);
-      return;
+      return () => clearTimeout(tid);
     }
 
     const q = query(

--- a/hooks/useVideoActivity.ts
+++ b/hooks/useVideoActivity.ts
@@ -69,18 +69,24 @@ export const useVideoActivity = (
   const { googleAccessToken } = useAuth();
   const { isConnected } = useGoogleDrive();
   const [activities, setActivities] = useState<VideoActivityMetadata[]>([]);
-  const [loading, setLoading] = useState(true);
+  const [loading, setLoading] = useState(!!userId);
   const [error, setError] = useState<string | null>(null);
+  const [prevUserId, setPrevUserId] = useState(userId);
+
+  // Adjusting-state-while-rendering: synchronously reset on userId transitions.
+  if (prevUserId !== userId) {
+    setPrevUserId(userId);
+    if (!userId) {
+      setActivities([]);
+      setLoading(false);
+    } else {
+      setLoading(true);
+    }
+  }
 
   // Real-time listener for activity metadata from Firestore
   useEffect(() => {
-    if (!userId) {
-      const tid = setTimeout(() => {
-        setActivities([]);
-        setLoading(false);
-      }, 0);
-      return () => clearTimeout(tid);
-    }
+    if (!userId) return;
 
     const q = query(
       collection(db, 'users', userId, VIDEO_ACTIVITIES_COLLECTION),


### PR DESCRIPTION
## Summary

Fixes the four ERROR-severity `effect-needs-cleanup` findings surfaced by `npx react-doctor`. The original code deferred state writes via `setTimeout(fn, 0)` in `useEffect` early-return branches (when `userId` is undefined) but never released the timers — leaked `setState` calls could fire after a later effect run or after unmount.

The fix applies the **"adjusting state while rendering"** pattern ([React docs](https://react.dev/reference/react/useState#storing-information-from-previous-renders)): a `prevUserId` value is stored in state; during render, if `prevUserId !== userId` the setters are called immediately and React discards the in-progress render, re-rendering with the new state. The guard condition fails on the second pass, so no re-render loop occurs. The `useEffect` bodies now only manage Firestore `onSnapshot` subscriptions and their unsubscribe cleanup.

This approach is used (not avoided) because the project's own `react-hooks/set-state-in-effect` ESLint rule (enforced at `--max-warnings 0`) explicitly rejects calling `setState` synchronously inside a `useEffect` body. Moving the reset to the render phase satisfies both the lint rule and avoids the cleanup leak.

**Files changed:**
- `hooks/useGuidedLearning.ts`
- `hooks/useQuiz.ts`
- `hooks/useVideoActivity.ts`
- `hooks/useStarterPacks.ts`

The fifth flagged site (`context/DashboardContext.tsx:2024`) is a verified false positive — per-shareId debounced timers are managed in a ref-tracked `Map` with explicit cleanup on every re-run and a dedicated unmount effect at line 2083. Intentionally left unchanged.

## Why this scope only

The other react-doctor categories were audited and skipped:

- **`rerender-state-only-in-handlers` (100 hits)** — sampled cases (`StudentApp.authInitialized`, `NextUpStudentApp.authInitialized`) ARE read in render. False positives.
- **`async-await-in-loop` (43 hits)** — sampled cases are Firestore `batch.commit()` chains and chunked `'in'` queries that must run sequentially.
- **`no-cascading-set-state` (100 hits)** — `useEffect` → `useReducer` rewrites of working state machines are high-risk.
- **Architecture warnings (7,744)** — palette / size-shorthand / heading-weight changes are stylistic; some affect brand identity.
- **Knip "unused files" (56)** — high false-positive rate (lazy imports, barrel re-exports, CLI scripts).

## Test plan

- [x] `pnpm run type-check` passes
- [x] `pnpm run lint` passes (`--max-warnings 0`)
- [x] `pnpm run format:check` passes
- [x] `pnpm run test` — unit tests pass
- [ ] Manual smoke: sign out / sign in repeatedly; confirm guided learning, quiz, video activity, and starter packs lists populate correctly each time
- [ ] Manual smoke: `VITE_AUTH_BYPASS=true` — starter packs list shows empty state without console warnings
- [ ] Re-run `npx react-doctor` and confirm `effect-needs-cleanup` count drops from 5 → 1

https://claude.ai/code/session_01KPtZBzFzb1y53eKLvguZiw