### PR TITLE
fix(quiz-monitor): guard concurrent score-reveal prompts

### DIFF
--- a/components/widgets/QuizWidget/components/QuizLiveMonitor.tsx
+++ b/components/widgets/QuizWidget/components/QuizLiveMonitor.tsx
@@ -448,25 +448,42 @@ export const QuizLiveMonitor: React.FC<QuizLiveMonitorProps> = ({
   const sessionIdRef = useRef(session.id);
   sessionIdRef.current = session.id;
 
-  const requestScoreReveal = useCallback(async () => {
-    if (scoreRevealApproved) return true;
+  // Share the in-flight reveal prompt across concurrent callers. Both
+  // `handleToggleColors` and `handleCycleScoreDisplay` can call
+  // `requestScoreReveal`, and rapid clicks would otherwise stack two
+  // confirm dialogs for the same approval. Returning the same Promise
+  // keeps the UX to a single dialog while letting both call sites await
+  // the answer.
+  const revealRequestRef = useRef<Promise<boolean> | null>(null);
+
+  const requestScoreReveal = useCallback((): Promise<boolean> => {
+    if (scoreRevealApproved) return Promise.resolve(true);
+    if (revealRequestRef.current) return revealRequestRef.current;
     // Capture the session this prompt belongs to. If the active session
     // changes mid-await, the resolution must NOT apply approval to the
     // fresh session — that would silently bypass the gate on a session
     // the teacher never agreed to reveal.
     const sessionAtRequest = sessionIdRef.current;
-    const ok = await showConfirm(
-      "Heads up — this monitor may be projected to the class. Confirm only if it's appropriate to display student performance on the current screen.",
-      {
-        title: 'Reveal student results?',
-        variant: 'warning',
-        confirmLabel: 'Yes, reveal',
-        cancelLabel: 'Keep hidden',
+    const inFlight = (async () => {
+      try {
+        const ok = await showConfirm(
+          "Heads up — this monitor may be projected to the class. Confirm only if it's appropriate to display student performance on the current screen.",
+          {
+            title: 'Reveal student results?',
+            variant: 'warning',
+            confirmLabel: 'Yes, reveal',
+            cancelLabel: 'Keep hidden',
+          }
+        );
+        if (sessionIdRef.current !== sessionAtRequest) return false;
+        if (ok) setScoreRevealApproved(true);
+        return ok;
+      } finally {
+        revealRequestRef.current = null;
       }
-    );
-    if (sessionIdRef.current !== sessionAtRequest) return false;
-    if (ok) setScoreRevealApproved(true);
-    return ok;
+    })();
+    revealRequestRef.current = inFlight;
+    return inFlight;
   }, [scoreRevealApproved, showConfirm]);
 
   // Single seam for the "preference write failed" pattern. Routes the error
@@ -569,6 +586,7 @@ export const QuizLiveMonitor: React.FC<QuizLiveMonitorProps> = ({
     setPrevSessionId(session.id);
     lastLeaderboardFingerprintRef.current = null;
     hasClearedLeaderboardRef.current = false;
+    revealRequestRef.current = null;
     setScoreRevealApproved(false);
   }
 

--- a/components/widgets/VideoActivityWidget/components/useVideoActivityEditorState.ts
+++ b/components/widgets/VideoActivityWidget/components/useVideoActivityEditorState.ts
@@ -265,7 +265,22 @@ export function useVideoActivityEditorState({
    */
   const reorderQuestions = useCallback(
     (next: VideoActivityQuestion[]) => {
-      setQuestions(() => {
+      // Identify the moved question by largest absolute index delta.
+      // Tiebreakers (e.g. swap-of-two) resolve to the item whose new index
+      // moved later in the list, which matches the typical drag intent.
+      let movedId = '';
+      setQuestions((prev) => {
+        let maxDelta = -1;
+        for (let i = 0; i < next.length; i++) {
+          const oldIndex = prev.findIndex((q) => q.id === next[i].id);
+          if (oldIndex < 0) continue;
+          const delta = Math.abs(oldIndex - i);
+          if (delta > maxDelta) {
+            maxDelta = delta;
+            movedId = next[i].id;
+          }
+        }
+
         const adjusted: VideoActivityQuestion[] = [];
         for (let i = 0; i < next.length; i++) {
           const q = next[i];
@@ -284,9 +299,24 @@ export function useVideoActivityEditorState({
           }
           adjusted.push({ ...q, timestamp: ts });
         }
+        // Final monotonicity pass: when neighbors leave no integer room
+        // (e.g. prev=5, following=6) the +1 fallback above can equal
+        // followingTs, producing a duplicate. Bump any non-strictly-
+        // increasing timestamp by 1 — the cascade always resolves
+        // because Firestore `orderBy('timestamp')` requires unique-ish
+        // values for stable ordering, and the array's last item has no
+        // hard upper bound.
+        for (let i = 1; i < adjusted.length; i++) {
+          if (adjusted[i].timestamp <= adjusted[i - 1].timestamp) {
+            adjusted[i] = {
+              ...adjusted[i],
+              timestamp: adjusted[i - 1].timestamp + 1,
+            };
+          }
+        }
         // Sync the visible MM:SS inputs.
-        setTimestampInputs((prev) => {
-          const out = { ...prev };
+        setTimestampInputs((tsPrev) => {
+          const out = { ...tsPrev };
           adjusted.forEach((q) => {
             out[q.id] = secondsToMmSs(q.timestamp);
           });
@@ -294,7 +324,7 @@ export function useVideoActivityEditorState({
         });
         return adjusted;
       });
-      flashReorderHint(next[next.length - 1]?.id ?? '');
+      flashReorderHint(movedId || next[next.length - 1]?.id || '');
     },
     [flashReorderHint]
   );


### PR DESCRIPTION
Addresses one remaining PR #1561 review comment (gemini-code-assist):
the score-reveal confirm dialog could stack if a teacher rapidly
toggled both the Colors and Score Display controls while the first
dialog was still awaiting input. Both call sites now share a single
in-flight `Promise<boolean>` via a `useRef`, so concurrent callers
get the same dialog and same answer. The ref is also reset whenever
the session id changes (alongside the existing `scoreRevealApproved`
reset), so a teacher's confirm in one quiz can't leak into the next.

The other fix on this branch (reorder hint + duplicate-timestamp
guard in `useVideoActivityEditorState`) is already on `dev-paul`
via commit f3bd71f, so this PR will be a no-op for that file.

Merging into `dev-paul` so PR #1561 picks up both fixes.

https://claude.ai/code/session_01Y2hEqXhyMKGukKrq7fDtDx

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y2hEqXhyMKGukKrq7fDtDx)_