### PR TITLE
fix(va-timeline): reset initRetryToken on videoId change (Copilot PR #1561)

### DIFF
--- a/components/widgets/VideoActivityWidget/components/Timeline.tsx
+++ b/components/widgets/VideoActivityWidget/components/Timeline.tsx
@@ -139,6 +139,12 @@ export const Timeline: React.FC<TimelineProps> = ({
     setPlayerReady(false);
     setDuration(0);
     setPlayhead(0);
+    // Reset the init-retry budget so each new video gets a fresh
+    // MAX_PLAYER_INIT_RETRIES window. Without this, a previous video
+    // that maxed out its retries would leave `initRetryToken` at the
+    // cap, and the very first attempt for the new video would bail
+    // immediately — leaving the player stuck on "Loading player…".
+    setInitRetryToken(0);
   }
 
   // (Re)create the player whenever videoId changes.


### PR DESCRIPTION
Addresses Copilot review on PR #1561 (Timeline.tsx:112).

## What

The init-retry budget (`MAX_PLAYER_INIT_RETRIES = 5`) was meant to bound a 50ms retry loop when the YT API resolves before the placeholder div has committed. Bug: `initRetryToken` only increases — it's never reset on `videoId` change.

Failure mode Copilot caught:
1. Video A: unusual mount/DOM race exhausts retries → token pinned at 5.
2. User loads video B → `prevVideoId !== videoId` reset block fires (resets player state) but leaves `initRetryToken` at 5.
3. New init attempt for video B finds the placeholder missing → `initRetryToken >= MAX_PLAYER_INIT_RETRIES` → returns immediately → player stuck on "Loading player…" forever.

## Fix

Add `setInitRetryToken(0)` alongside the existing per-video resets so each video gets a fresh retry window.

## Validation

- `pnpm run type-check` ✓
- `pnpm run lint` ✓
- `pnpm run format:check` ✓

---
_Generated by [Claude Code](https://claude.ai/code/session_016zRd35ZQ48ePR2BWAfpPvG)_