### PR TITLE
docs(cloud-functions): audit and refine cost-optimization doc

### DIFF
--- a/docs/CLOUD_FUNCTIONS_COST_OPTIMIZATION.md
+++ b/docs/CLOUD_FUNCTIONS_COST_OPTIMIZATION.md
@@ -1,19 +1,21 @@
 # Cloud Functions Cost Optimization
 
-Audit conducted 2026-05-10. ~$5 spent in the preceding 10 days, almost entirely attributable to Cloud Functions compute.
+Audit conducted 2026-05-10. ~$5 spent in the preceding 10 days, dominated by `adminAnalytics` (Cloud Functions compute plus the Firestore reads it triggers from unbounded collection scans).
 
 ## How Cloud Functions billing works
 
-Billing is primarily **GB-seconds**: memory allocation × wall-clock runtime. Invocation count (first 2 M/month free) and outbound egress ($0.12/GB, first 5 GB free) also contribute but are secondary for this project.
+All callables here are Cloud Functions **2nd gen** (`firebase-functions/v2/https`), which run on Cloud Run and bill **memory (GiB-seconds) and vCPU (vCPU-seconds) separately**, both as a function of wall-clock runtime. Invocation count (first 2 M/month free) and outbound egress ($0.12/GB, first 5 GB free) also contribute but are secondary for this project. Firestore reads triggered from inside a function (especially the unbounded `collectionGroup('dashboards')` and `collection('ai_usage')` scans in `adminAnalytics` — see below) are billed against Firestore, not Cloud Functions, but show up on the same invoice and can be a meaningful share of the total.
 
-| Function                    | Memory  | Max timeout | GB-sec/call | Est. cost/call |
-| --------------------------- | ------- | ----------- | ----------- | -------------- |
-| `adminAnalytics`            | 4 GiB   | 540 s       | 2,160       | ~$0.039        |
-| `generateVideoActivity`     | 1 GiB   | 300 s       | 300         | ~$0.005        |
-| `transcribeVideoWithGemini` | 1 GiB   | 300 s       | 300         | ~$0.005        |
-| `generateWithAI`            | 512 MiB | ~60 s       | ~30         | ~$0.0005       |
-| `archiveActivityWallPhoto`  | 512 MiB | 120 s       | ~60         | ~$0.001        |
-| `fetchExternalProxy`        | 128 MiB | 30 s        | ~3.75       | ~$0.00007      |
+The "GB-sec/call" column below is the **worst case per call** (memory × max timeout). Real per-call cost depends on actual wall-clock runtime; the cost column is the corresponding worst-case ceiling and is the right number for back-of-envelope budgeting on long-running functions like `adminAnalytics`.
+
+| Function                    | Memory  | Max timeout    | GB-sec/call (max) | Est. cost/call (max) |
+| --------------------------- | ------- | -------------- | ----------------- | -------------------- |
+| `adminAnalytics`            | 4 GiB   | 540 s          | 2,160             | ~$0.039              |
+| `generateVideoActivity`     | 1 GiB   | 300 s          | 300               | ~$0.005              |
+| `transcribeVideoWithGemini` | 1 GiB   | 300 s          | 300               | ~$0.005              |
+| `generateWithAI`            | 512 MiB | 60 s (default) | ~30               | ~$0.0005             |
+| `archiveActivityWallPhoto`  | 512 MiB | 120 s          | ~60               | ~$0.001              |
+| `fetchExternalProxy`        | 128 MiB | 30 s           | ~3.75             | ~$0.00007            |
 
 ---
 
@@ -21,46 +23,47 @@ Billing is primarily **GB-seconds**: memory allocation × wall-clock runtime. In
 
 ### 1. `adminAnalytics` — likely the single largest line item
 
-**Memory: 4 GiB. Timeout: 540 s.**
+**Memory: 4 GiB. Timeout: 540 s.** (`functions/src/index.ts` `adminAnalytics`)
 
 On every admin analytics page load, this function:
 
-1. Issues a `collectionGroup('dashboards')` query that streams **every dashboard document across every user** in the database.
-2. Filters results in-memory by org membership.
-3. Fetches Firebase Auth metadata for all matched users in parallel batches.
+1. Loads the org's member roster from `organizations/{orgId}/members` and resolves Firebase Auth metadata (`auth().getUsers()`) for those members in 100-uid chunks. This is bounded by org size.
+2. Streams **every dashboard document in the database** via `collectionGroup('dashboards').select('widgets', 'updatedAt').stream()` and filters each one against the in-memory member-uid set. The scan is system-wide; only the join is org-scoped.
+3. Streams **every record in the top-level `ai_usage` collection** via `collection('ai_usage').select('count').stream()` and applies the same in-memory member-uid filter. Also unbounded.
+4. Performs additional chunked `users` collection reads (and an Auth fallback) to resolve emails for widget drilldowns and the top 25 AI users.
 
-Even a modestly populated database makes this very slow, and the 4 GiB allocation means each invocation burns up to 2,160 GB-seconds. At ~$0.04 per call, 125 admin page visits over 10 days accounts for ~$5 on its own — matching the observed bill exactly.
+Two unbounded reads-of-everything per admin page load is the root issue. With even a modestly populated database, each invocation burns substantial wall-clock and Firestore read quota; the 4 GiB allocation means each second of runtime costs more than necessary. Worst-case per-call compute alone is ~$0.039 (2,160 GiB-seconds at the 540 s ceiling), and the Firestore reads from steps 2 and 3 add to that on the same invoice. ~125 admin page visits at the worst-case rate would account for ~$5 on its own, which is consistent with the observed 10-day bill — though actual runtime is usually well below the timeout, so the Firestore-read share of the bill is likely meaningful.
 
-**Recommended fix:** Cache computed analytics in a per-org Firestore doc (e.g. `organizations/{orgId}/analytics/cached`) with a `computedAt` timestamp. Scoping the cache per org is important — a shared global doc would leak data between organizations. Serve the cached result immediately on page load. Recompute in the background either on a Cloud Scheduler job (hourly) or when the cache is older than the acceptable staleness window. The 4 GiB memory allocation can also be reduced once the unbounded collection scan is removed.
+**Recommended fix:** Cache computed analytics in a per-org Firestore doc (e.g. `organizations/{orgId}/analytics/cached`) with a `computedAt` timestamp. Scoping the cache per org is important — a shared global doc would leak data between organizations. Serve the cached result immediately on page load. Recompute in the background either on a Cloud Scheduler job (hourly) or when the cache is older than the acceptable staleness window. Once the cached path is in place, both unbounded scans (dashboards + `ai_usage`) only run on the recompute schedule, and the 4 GiB memory allocation can be dropped.
 
-The code itself notes this is a known architectural debt:
+The function header itself flags this as known architectural debt:
 
-> "more scalable (paginated/aggregated) solution [needed]"
+> "Bumps memory and timeout to handle unbounded collection reads while a more scalable (paginated/aggregated) solution is developed."
 
-### 2. `fetchExternalProxy` — potential broken cache
+### 2. `fetchExternalProxy` — bounded by admin tabs, but worth verifying
 
 **Memory: 128 MiB. Cost per call: low but non-trivial at scale.**
 
-This function is called by `AdminWeatherFetcher` (mounted in `App.tsx` only when `isAdmin` is true), not directly by each teacher's Weather widget. The Weather widget reads from `/global_weather/` via Firestore `onSnapshot` — it never calls the proxy itself. So the invocation risk is scoped to admin users only; this is not a high-volume concern unless the cache is broken.
+This function is called by `AdminWeatherFetcher` (lazy-loaded in `App.tsx` only when `isAdmin` is true) and only when the weather feature config has `fetchingStrategy === 'admin_proxy'` and `source === 'earth_networks'` — the OpenWeather path calls the upstream API directly from the browser. Teacher Weather widgets read from `global_weather/current` via Firestore `onSnapshot` and never call the proxy. So invocation volume is scoped to: (admins with the tab open) × (1 / `updateFrequencyMinutes`). With `updateFrequencyMinutes` defaulting to 15 and a floor of 5, an admin keeping the dashboard open for an 8-hour day produces ~32 calls (default) or ~96 calls (floor). Multiple admins multiply linearly.
 
-**Check invocation counts first.** If `fetchExternalProxy` shows only a few dozen calls per day in Firebase Console → Functions → Usage, the cache is working and this is a low priority. If it shows thousands, the cache TTL or cache key is mismatched and every admin page load is hitting the external API.
+**Check invocation counts first** in Firebase Console → Functions → Usage. A few hundred calls per day across the admin pool is the expected order of magnitude. Thousands per day means too many admin tabs are open with too short a refresh interval, or the strategy is misconfigured.
 
-**Recommended fix (if cache is broken):** Audit the weather caching logic end-to-end. Ensure `AdminWeatherFetcher` reads from `/global_weather/` first and only calls the proxy when the cached entry is stale (10–15 minutes is appropriate for weather data). Verify the cache key used when writing matches the key the fetcher uses when deciding whether to refresh.
+**Recommended fix (if volume is unexpectedly high):** Audit `AdminWeatherFetcher` (`components/admin/AdminWeatherFetcher.tsx`) — confirm the `setInterval` honors `updateFrequencyMinutes` (currently `Math.max(5, …)`), and consider gating on tab visibility (`document.visibilityState === 'visible'`) so background tabs don't fire calls every interval. Server-side, a small in-memory or Firestore-backed cache keyed by upstream URL with a 10–15 min TTL would deduplicate concurrent admin calls.
 
 ### 3. `generateWithAI` — unnecessary Firestore reads on every AI call
 
-**Memory: 512 MiB.**
+**Memory: 512 MiB.** (default 60 s timeout; no `timeoutSeconds` specified)
 
 Every AI generation call performs 4–6 Firestore reads before the Gemini API call even begins:
 
-- Admin status check (`admins/{email}`)
-- Model config fetch (`geminiConfig`)
-- Global permissions doc per feature
-- Usage counter read (transactional)
+- `admins/{email}` (1 read, outside the transaction).
+- Inside `runTransaction`: the per-day overall usage counter (`ai_usage/{uid}_{today}`) and, for the 7 typed flows, the per-feature counter (`ai_usage/{uid}_{featureId}_{today}`) — 1–2 reads.
+- Inside the same transaction, for non-admin callers only: `global_permissions/gemini-functions` and (if a typed feature) `global_permissions/{featureId}` — 0–2 reads.
+- After the transaction: `getGeminiModelConfig()` re-reads `global_permissions/gemini-functions` to pick the model name — 1 read every call.
 
-These docs change rarely. Reading them fresh on every invocation wastes both latency and Firestore read quota.
+The usage counters genuinely change per invocation, but `admins/{email}` and the `global_permissions/*` docs change rarely. The model-config read post-transaction is a duplicate of one already performed in the transaction (for non-admins).
 
-**Recommended fix:** Store `global_permissions` and model config in module-level variables with a short TTL (e.g. 5 minutes). Cloud Functions instances are reused across warm invocations, so a module-level cache is effective and requires no external infrastructure. The pattern is: store the value and a `cachedAt` timestamp; at the top of each invocation check `Date.now() - cachedAt > TTL` and refresh only when stale.
+**Recommended fix:** Cache the long-lived reads in module scope with a short TTL (e.g. 5 minutes). Cloud Functions 2nd-gen instances are reused across warm invocations, so a module-level `{ value, cachedAt }` cache is effective with no external infrastructure. The straightforward wins are (a) memoize `getGeminiModelConfig()` so warm calls skip the post-transaction read entirely, and (b) memoize the admin check by email. Caching `global_permissions/*` reads inside the transaction is also possible, but note those reads currently gate rate-limit enforcement — moving the threshold lookup outside the transaction (only the usage counter read needs to stay transactional) is the cleanest restructuring.
 
 ---
 
@@ -88,8 +91,8 @@ The proxy function streams external API responses back to the caller with no siz
 
 ## Recommended action order
 
-1. **Cache `adminAnalytics` output** — highest ROI, likely eliminates the majority of the bill.
-2. **Audit weather caching** — check `fetchExternalProxy` invocation counts in Firebase Console → Functions → Usage. Dozens/day is expected (admin users only); hundreds/day suggests the Firestore cache is not working.
+1. **Cache `adminAnalytics` output per org** — highest ROI; eliminates both unbounded Firestore scans on the hot path and is what's likely driving the bulk of the bill.
+2. **Verify `fetchExternalProxy` invocation counts** in Firebase Console → Functions → Usage. A few hundred/day across the admin pool is expected; thousands/day means too many admin tabs or a misconfigured refresh interval.
 3. **Add module-level caching to `generateWithAI`** — easy win, saves Firestore reads with no behavioral change.
 4. **Reduce `adminAnalytics` memory** — after caching is in place, drop from 4 GiB to 512 MiB.
 5. **Add file size guard to `archiveActivityWallPhoto`**.


### PR DESCRIPTION
## Summary

Audited `docs/CLOUD_FUNCTIONS_COST_OPTIMIZATION.md` against the actual code in `functions/src/index.ts` (and the weather wiring in `App.tsx` / `components/admin/AdminWeatherFetcher.tsx`) and tightened the parts that didn't match reality. The structure, recommendations, and action order are preserved; the changes are accuracy fixes, not a rewrite.

### What was wrong (and is now fixed)

- **Billing description was incomplete** — said billing is "primarily GB-seconds." All callables are 2nd gen and run on Cloud Run, which bills **memory and vCPU separately**. Also clarified that Firestore reads triggered by `adminAnalytics`'s unbounded scans land on the same invoice.
- **Cost table didn't disclose it was worst-case** — re-labelled the "GB-sec/call" and "Est. cost/call" columns as the worst-case ceiling (memory × max timeout) so the numbers aren't read as typical-case.
- **`adminAnalytics` was missing a second unbounded scan** — added the `db.collection('ai_usage').select('count').stream()` (line 2549 in `functions/src/index.ts`) to the list. Also reordered the steps: auth metadata is fetched up-front for the bounded org member roster (lines 2218–2248), not for matched dashboard owners as the doc previously implied.
- **`fetchExternalProxy` framing was off** — the function isn't gated by a "cache that might be broken." It's only invoked when `fetchingStrategy === 'admin_proxy' && source === 'earth_networks'`, by `AdminWeatherFetcher`'s `setInterval` (`Math.max(5, updateFrequencyMinutes ?? 15) * 60 * 1000`). Replaced the broken-cache narrative with the actual per-admin-tab invocation rate and a tab-visibility / server-side dedupe recommendation.
- **`generateWithAI` bullet list misnamed a doc** — there's no `geminiConfig` collection. Replaced with the actual Firestore paths (`admins/{email}`, `ai_usage/{uid}_{today}`, `ai_usage/{uid}_{featureId}_{today}`, `global_permissions/gemini-functions`, `global_permissions/{featureId}`, plus the duplicate `getGeminiModelConfig()` post-transaction read). Scoped the caching recommendation so it doesn't suggest caching reads that gate the rate-limit transaction.

### What was already correct (verified against code)

- Memory + max timeout values for every function in the table.
- `archiveActivityWallPhoto` lacks any size/metadata pre-check before `file.download()`.
- `getClassLinkRosterV1` uses unbounded `Promise.all` over per-class student lookups.
- `fetchExternalProxy` uses plain `axios.get` and would buffer the full response before headers can be inspected.
- The teacher Weather widget reads `global_weather/current` via `onSnapshot` and never calls the proxy.

## Test plan

- [ ] Re-read the updated doc end-to-end and confirm each claim still matches `functions/src/index.ts` on `dev-paul`.
- [ ] Confirm prettier passes (`pnpm exec prettier --check docs/CLOUD_FUNCTIONS_COST_OPTIMIZATION.md`) — already verified locally.
- [ ] Spot-check the `AdminWeatherFetcher` invocation-rate math (admins × 8h tab uptime ÷ `updateFrequencyMinutes`) against actual Firebase Console → Functions → Usage numbers.

https://claude.ai/code/session_012TSSNxV7wNai2JghfLh98t

---
_Generated by [Claude Code](https://claude.ai/code/session_012TSSNxV7wNai2JghfLh98t)_