### PR TITLE
feat(admin): add link shortener with /r/:code resolver

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -30,6 +30,11 @@ const MobileRemoteApp = lazy(() =>
     default: module.MobileRemoteView,
   }))
 );
+const ShortLinkRedirect = lazy(() =>
+  import('./components/common/ShortLinkRedirect').then((module) => ({
+    default: module.ShortLinkRedirect,
+  }))
+);
 const StudentApp = lazy(() =>
   import('./components/student/StudentApp').then((module) => ({
     default: module.StudentApp,
@@ -256,6 +261,7 @@ const App: React.FC = () => {
   // Simple routing for Student View
   const pathname = window.location.pathname;
   const isMiniAppRoute = pathname.startsWith('/miniapp/');
+  const isShortLinkRoute = pathname.startsWith('/r/') && pathname.length > 3;
   const isStudentRoute = pathname === '/join' || pathname.startsWith('/join/');
   const isQuizRoute = pathname === '/quiz' || pathname.startsWith('/quiz/');
   const isNextUpRoute =
@@ -272,6 +278,18 @@ const App: React.FC = () => {
     pathname === '/student/login' || pathname.startsWith('/student/login/');
   const isMyAssignmentsRoute =
     pathname === '/my-assignments' || pathname.startsWith('/my-assignments/');
+
+  // Short-link resolver. Runs outside every provider so anonymous visitors
+  // can follow admin-created /r/:code links without triggering Firebase
+  // Auth, dashboard listeners, or any other heavy setup. The resolver does
+  // a single Firestore lookup + client-side redirect.
+  if (isShortLinkRoute) {
+    return (
+      <Suspense fallback={<FullPageLoader />}>
+        <ShortLinkRedirect />
+      </Suspense>
+    );
+  }
 
   // MiniApp student route — anonymous entry, no teacher auth needed.
   // StudentIdleTimeoutGuard is a no-op unless a studentRole (ClassLink-via-

--- a/App.tsx
+++ b/App.tsx
@@ -261,7 +261,9 @@ const App: React.FC = () => {
   // Simple routing for Student View
   const pathname = window.location.pathname;
   const isMiniAppRoute = pathname.startsWith('/miniapp/');
-  const isShortLinkRoute = pathname.startsWith('/r/') && pathname.length > 3;
+  // Catch `/r`, `/r/`, and `/r/:code` so typos hit the resolver's
+  // not-found UI instead of mounting the full teacher app + providers.
+  const isShortLinkRoute = pathname === '/r' || pathname.startsWith('/r/');
   const isStudentRoute = pathname === '/join' || pathname.startsWith('/join/');
   const isQuizRoute = pathname === '/quiz' || pathname.startsWith('/quiz/');
   const isNextUpRoute =

--- a/components/admin/AdminSettings.tsx
+++ b/components/admin/AdminSettings.tsx
@@ -10,6 +10,7 @@ import {
   Building2,
   BarChart,
   LayoutTemplate,
+  Link2,
 } from 'lucide-react';
 
 import { useAuth } from '@/context/useAuth';
@@ -20,6 +21,7 @@ import { AnnouncementsManager } from './Announcements';
 import { OrganizationPanel } from './Organization/OrganizationPanel';
 import { AnalyticsManager } from './Analytics/AnalyticsManager';
 import { DashboardTemplatesManager } from './DashboardTemplatesManager';
+import { LinkShortenerManager } from './LinkShortenerManager';
 
 interface AdminSettingsProps {
   onClose: () => void;
@@ -67,6 +69,12 @@ const TABS = [
     label: 'Templates',
     icon: LayoutTemplate,
     component: DashboardTemplatesManager,
+  },
+  {
+    id: 'links',
+    label: 'Links',
+    icon: Link2,
+    component: LinkShortenerManager,
   },
 ] as const;
 

--- a/components/admin/LinkShortenerManager.tsx
+++ b/components/admin/LinkShortenerManager.tsx
@@ -1,0 +1,576 @@
+import React, { useMemo, useState } from 'react';
+import {
+  Link2,
+  Plus,
+  Copy,
+  Check,
+  Trash2,
+  Pencil,
+  ExternalLink,
+  Save,
+  X,
+  Loader2,
+  Search,
+} from 'lucide-react';
+
+import { useShortLinks } from '@/hooks/useShortLinks';
+import { useDialog } from '@/context/useDialog';
+import { Toast } from '@/components/common/Toast';
+import { SHORT_LINK_PREFIX } from '@/utils/shortLinkValidation';
+import { ShortLink } from '@/types';
+
+const buildShortUrl = (code: string): string => {
+  if (typeof window === 'undefined') return SHORT_LINK_PREFIX + code;
+  return `${window.location.origin}${SHORT_LINK_PREFIX}${code}`;
+};
+
+const formatDate = (epoch: number | null | undefined): string => {
+  if (!epoch) return '—';
+  return new Date(epoch).toLocaleDateString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  });
+};
+
+const formatRelative = (epoch: number | null | undefined): string => {
+  if (!epoch) return 'Never';
+  const diff = Date.now() - epoch;
+  const minute = 60 * 1000;
+  const hour = 60 * minute;
+  const day = 24 * hour;
+  if (diff < minute) return 'Just now';
+  if (diff < hour) return `${Math.floor(diff / minute)}m ago`;
+  if (diff < day) return `${Math.floor(diff / hour)}h ago`;
+  if (diff < 7 * day) return `${Math.floor(diff / day)}d ago`;
+  return formatDate(epoch);
+};
+
+interface CreateFormProps {
+  onSuccess?: (link: ShortLink) => void;
+  /** When true, hides the heading + uses tighter spacing (for Sidebar modal). */
+  compact?: boolean;
+}
+
+/**
+ * Standalone create form, exported so the Sidebar quick-action can reuse it
+ * inside a lightweight modal without pulling in the full manager UI.
+ */
+export const ShortLinkCreateForm: React.FC<CreateFormProps> = ({
+  onSuccess,
+  compact = false,
+}) => {
+  const { createShortLink } = useShortLinks();
+  const [destination, setDestination] = useState('');
+  const [slug, setSlug] = useState('');
+  const [label, setLabel] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [created, setCreated] = useState<ShortLink | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    setError(null);
+    setSubmitting(true);
+    try {
+      const result = await createShortLink({
+        destination,
+        slug: slug || undefined,
+        label: label || undefined,
+      });
+      if (!result.ok) {
+        setError(result.reason);
+        return;
+      }
+      setCreated(result.link);
+      setDestination('');
+      setSlug('');
+      setLabel('');
+      onSuccess?.(result.link);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleCopy = async (url: string) => {
+    try {
+      await navigator.clipboard.writeText(url);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1500);
+    } catch (err) {
+      console.warn('[ShortLinkCreateForm] clipboard failed:', err);
+    }
+  };
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className={
+        compact
+          ? 'flex flex-col gap-3'
+          : 'flex flex-col gap-4 bg-white rounded-xl border border-slate-200 p-5 shadow-sm'
+      }
+    >
+      {!compact && (
+        <div className="flex items-center gap-2">
+          <div className="bg-brand-blue-lighter text-brand-blue-primary p-2 rounded-lg">
+            <Plus className="w-4 h-4" />
+          </div>
+          <h3 className="font-bold text-slate-800">Create short link</h3>
+        </div>
+      )}
+
+      <div className="flex flex-col gap-1">
+        <label className="text-xs font-semibold text-slate-600 uppercase tracking-wide">
+          Destination URL
+        </label>
+        <input
+          type="url"
+          value={destination}
+          onChange={(event) => setDestination(event.target.value)}
+          placeholder="https://docs.google.com/document/d/…"
+          required
+          className="px-3 py-2 rounded-lg border border-slate-300 text-sm focus:outline-none focus:ring-2 focus:ring-brand-blue-primary"
+        />
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+        <div className="flex flex-col gap-1">
+          <label className="text-xs font-semibold text-slate-600 uppercase tracking-wide">
+            Custom slug{' '}
+            <span className="font-normal normal-case text-slate-400">
+              (optional)
+            </span>
+          </label>
+          <div className="flex items-stretch rounded-lg border border-slate-300 focus-within:ring-2 focus-within:ring-brand-blue-primary overflow-hidden">
+            <span className="px-2 py-2 bg-slate-100 text-slate-500 text-sm font-mono whitespace-nowrap">
+              /r/
+            </span>
+            <input
+              type="text"
+              value={slug}
+              onChange={(event) => setSlug(event.target.value)}
+              placeholder="auto-generated"
+              className="flex-1 px-2 py-2 text-sm focus:outline-none"
+            />
+          </div>
+        </div>
+
+        <div className="flex flex-col gap-1">
+          <label className="text-xs font-semibold text-slate-600 uppercase tracking-wide">
+            Label{' '}
+            <span className="font-normal normal-case text-slate-400">
+              (optional)
+            </span>
+          </label>
+          <input
+            type="text"
+            value={label}
+            onChange={(event) => setLabel(event.target.value)}
+            placeholder="Lesson 1 video"
+            className="px-3 py-2 rounded-lg border border-slate-300 text-sm focus:outline-none focus:ring-2 focus:ring-brand-blue-primary"
+          />
+        </div>
+      </div>
+
+      {error && (
+        <div className="rounded-lg bg-red-50 border border-red-200 text-red-700 text-sm px-3 py-2">
+          {error}
+        </div>
+      )}
+
+      <button
+        type="submit"
+        disabled={submitting}
+        className="self-start inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-brand-blue-primary text-white text-sm font-semibold hover:bg-brand-blue-dark disabled:opacity-60 disabled:cursor-not-allowed transition-colors"
+      >
+        {submitting ? (
+          <Loader2 className="w-4 h-4 animate-spin" />
+        ) : (
+          <Plus className="w-4 h-4" />
+        )}
+        Create short link
+      </button>
+
+      {created && (
+        <div className="rounded-lg bg-emerald-50 border border-emerald-200 px-3 py-3 flex items-center gap-2">
+          <Check className="w-4 h-4 text-emerald-600 shrink-0" />
+          <code className="flex-1 text-sm font-mono text-emerald-800 truncate">
+            {buildShortUrl(created.code)}
+          </code>
+          <button
+            type="button"
+            onClick={() => handleCopy(buildShortUrl(created.code))}
+            className="inline-flex items-center gap-1 px-2 py-1 rounded-md bg-white border border-emerald-200 text-emerald-700 text-xs font-semibold hover:bg-emerald-100 transition-colors"
+          >
+            {copied ? (
+              <Check className="w-3.5 h-3.5" />
+            ) : (
+              <Copy className="w-3.5 h-3.5" />
+            )}
+            {copied ? 'Copied' : 'Copy'}
+          </button>
+        </div>
+      )}
+    </form>
+  );
+};
+
+interface EditModalProps {
+  link: ShortLink;
+  onClose: () => void;
+  onSaved: (text: string) => void;
+}
+
+const EditModal: React.FC<EditModalProps> = ({ link, onClose, onSaved }) => {
+  const { updateShortLink } = useShortLinks();
+  const [destination, setDestination] = useState(link.destination);
+  const [label, setLabel] = useState(link.label ?? '');
+  const [error, setError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  const handleSave = async (event: React.FormEvent) => {
+    event.preventDefault();
+    setError(null);
+    setSaving(true);
+    try {
+      const result = await updateShortLink(link.code, { destination, label });
+      if (!result.ok) {
+        setError(result.reason);
+        return;
+      }
+      onSaved('Short link updated');
+      onClose();
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-modal-nested bg-black/50 flex items-center justify-center p-4"
+      role="dialog"
+      aria-modal="true"
+    >
+      <form
+        onSubmit={handleSave}
+        className="bg-white rounded-2xl shadow-xl w-full max-w-lg p-6 flex flex-col gap-4"
+      >
+        <div className="flex items-start justify-between">
+          <div>
+            <h3 className="text-lg font-bold text-slate-800">
+              Edit short link
+            </h3>
+            <p className="text-sm text-slate-500 font-mono mt-1">
+              {buildShortUrl(link.code)}
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close"
+            className="p-1.5 rounded-lg hover:bg-slate-100 text-slate-500"
+          >
+            <X className="w-5 h-5" />
+          </button>
+        </div>
+
+        <div className="flex flex-col gap-1">
+          <label className="text-xs font-semibold text-slate-600 uppercase tracking-wide">
+            Destination URL
+          </label>
+          <input
+            type="url"
+            value={destination}
+            onChange={(event) => setDestination(event.target.value)}
+            required
+            className="px-3 py-2 rounded-lg border border-slate-300 text-sm focus:outline-none focus:ring-2 focus:ring-brand-blue-primary"
+          />
+        </div>
+
+        <div className="flex flex-col gap-1">
+          <label className="text-xs font-semibold text-slate-600 uppercase tracking-wide">
+            Label
+          </label>
+          <input
+            type="text"
+            value={label}
+            onChange={(event) => setLabel(event.target.value)}
+            placeholder="Optional"
+            className="px-3 py-2 rounded-lg border border-slate-300 text-sm focus:outline-none focus:ring-2 focus:ring-brand-blue-primary"
+          />
+        </div>
+
+        <p className="text-xs text-slate-500">
+          The slug <code className="font-mono">{link.code}</code> can&apos;t be
+          changed — editing it would break any URL already shared.
+        </p>
+
+        {error && (
+          <div className="rounded-lg bg-red-50 border border-red-200 text-red-700 text-sm px-3 py-2">
+            {error}
+          </div>
+        )}
+
+        <div className="flex items-center justify-end gap-2 pt-2">
+          <button
+            type="button"
+            onClick={onClose}
+            className="px-3 py-2 rounded-lg text-sm font-semibold text-slate-600 hover:bg-slate-100"
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            disabled={saving}
+            className="inline-flex items-center gap-2 px-3 py-2 rounded-lg bg-brand-blue-primary text-white text-sm font-semibold hover:bg-brand-blue-dark disabled:opacity-60"
+          >
+            {saving ? (
+              <Loader2 className="w-4 h-4 animate-spin" />
+            ) : (
+              <Save className="w-4 h-4" />
+            )}
+            Save
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+};
+
+export const LinkShortenerManager: React.FC = () => {
+  const { links, loading, error, deleteShortLink } = useShortLinks();
+  const { showConfirm } = useDialog();
+  const [search, setSearch] = useState('');
+  const [editing, setEditing] = useState<ShortLink | null>(null);
+  const [copiedCode, setCopiedCode] = useState<string | null>(null);
+  const [toast, setToast] = useState<{
+    type: 'success' | 'error';
+    text: string;
+  } | null>(null);
+
+  const filtered = useMemo(() => {
+    const query = search.trim().toLowerCase();
+    if (!query) return links;
+    return links.filter((link) => {
+      return (
+        link.code.toLowerCase().includes(query) ||
+        link.destination.toLowerCase().includes(query) ||
+        (link.label?.toLowerCase().includes(query) ?? false) ||
+        link.createdByEmail.toLowerCase().includes(query)
+      );
+    });
+  }, [links, search]);
+
+  const showToast = (type: 'success' | 'error', text: string) => {
+    setToast({ type, text });
+    window.setTimeout(() => setToast(null), 3000);
+  };
+
+  const handleCopy = async (code: string) => {
+    try {
+      await navigator.clipboard.writeText(buildShortUrl(code));
+      setCopiedCode(code);
+      window.setTimeout(() => setCopiedCode(null), 1500);
+    } catch (err) {
+      console.warn('[LinkShortenerManager] clipboard failed:', err);
+      showToast('error', 'Could not copy to clipboard');
+    }
+  };
+
+  const handleDelete = async (link: ShortLink) => {
+    const confirmed = await showConfirm(
+      `Delete /r/${link.code}? Anyone visiting this short link will see a "Link not found" page.`,
+      {
+        title: 'Delete short link',
+        variant: 'danger',
+        confirmLabel: 'Delete',
+      }
+    );
+    if (!confirmed) return;
+    try {
+      await deleteShortLink(link.code);
+      showToast('success', 'Short link deleted');
+    } catch (err) {
+      console.error('[LinkShortenerManager] delete error:', err);
+      showToast('error', 'Failed to delete short link');
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-6 max-w-5xl">
+      <div>
+        <div className="flex items-center gap-2 mb-1">
+          <div className="bg-brand-blue-lighter text-brand-blue-primary p-2 rounded-lg">
+            <Link2 className="w-4 h-4" />
+          </div>
+          <h2 className="text-lg font-bold text-slate-800">Link Shortener</h2>
+        </div>
+        <p className="text-sm text-slate-600">
+          Paste a long URL to get a short, copyable link on this domain. Edit
+          the destination later without changing the short URL.
+        </p>
+      </div>
+
+      <ShortLinkCreateForm
+        onSuccess={() => showToast('success', 'Short link created')}
+      />
+
+      <div className="bg-white rounded-xl border border-slate-200 shadow-sm overflow-hidden">
+        <div className="px-5 py-4 border-b border-slate-200 flex items-center justify-between gap-4">
+          <div>
+            <h3 className="font-bold text-slate-800">All short links</h3>
+            <p className="text-xs text-slate-500">
+              {links.length} {links.length === 1 ? 'link' : 'links'} total
+            </p>
+          </div>
+          <div className="relative">
+            <Search className="w-4 h-4 absolute left-3 top-1/2 -translate-y-1/2 text-slate-400" />
+            <input
+              type="text"
+              value={search}
+              onChange={(event) => setSearch(event.target.value)}
+              placeholder="Search…"
+              className="pl-9 pr-3 py-2 rounded-lg border border-slate-300 text-sm focus:outline-none focus:ring-2 focus:ring-brand-blue-primary w-64"
+            />
+          </div>
+        </div>
+
+        {loading ? (
+          <div className="px-5 py-10 flex items-center justify-center text-slate-500">
+            <Loader2 className="w-5 h-5 animate-spin mr-2" /> Loading short
+            links…
+          </div>
+        ) : error ? (
+          <div className="px-5 py-6 text-sm text-red-600">{error}</div>
+        ) : filtered.length === 0 ? (
+          <div className="px-5 py-10 text-center text-sm text-slate-500">
+            {links.length === 0
+              ? 'No short links yet. Create your first one above.'
+              : 'No links match your search.'}
+          </div>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead className="bg-slate-50 text-xs uppercase tracking-wide text-slate-500">
+                <tr>
+                  <th className="text-left px-4 py-2 font-semibold">
+                    Short URL
+                  </th>
+                  <th className="text-left px-4 py-2 font-semibold">
+                    Destination
+                  </th>
+                  <th className="text-left px-4 py-2 font-semibold">Clicks</th>
+                  <th className="text-left px-4 py-2 font-semibold">Created</th>
+                  <th className="text-right px-4 py-2 font-semibold">
+                    Actions
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {filtered.map((link) => (
+                  <tr
+                    key={link.code}
+                    className="border-t border-slate-100 hover:bg-slate-50/50"
+                  >
+                    <td className="px-4 py-3 align-top">
+                      <div className="flex items-center gap-2">
+                        <code className="font-mono text-slate-800 text-sm">
+                          /r/{link.code}
+                        </code>
+                        <button
+                          type="button"
+                          onClick={() => handleCopy(link.code)}
+                          aria-label="Copy short URL"
+                          className="p-1 rounded hover:bg-slate-200 text-slate-500"
+                        >
+                          {copiedCode === link.code ? (
+                            <Check className="w-3.5 h-3.5 text-emerald-600" />
+                          ) : (
+                            <Copy className="w-3.5 h-3.5" />
+                          )}
+                        </button>
+                      </div>
+                      {link.label && (
+                        <div className="text-xs text-slate-500 mt-0.5">
+                          {link.label}
+                        </div>
+                      )}
+                    </td>
+                    <td className="px-4 py-3 align-top max-w-md">
+                      <a
+                        href={link.destination}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="inline-flex items-center gap-1 text-slate-700 hover:text-brand-blue-primary truncate max-w-full"
+                        title={link.destination}
+                      >
+                        <span className="truncate">{link.destination}</span>
+                        <ExternalLink className="w-3 h-3 shrink-0" />
+                      </a>
+                    </td>
+                    <td className="px-4 py-3 align-top">
+                      <div className="font-semibold text-slate-800">
+                        {link.clicks}
+                      </div>
+                      <div className="text-xs text-slate-500">
+                        {formatRelative(link.lastClickedAt)}
+                      </div>
+                    </td>
+                    <td className="px-4 py-3 align-top">
+                      <div className="text-slate-700">
+                        {formatDate(link.createdAt)}
+                      </div>
+                      <div className="text-xs text-slate-500 truncate max-w-[12rem]">
+                        {link.createdByEmail}
+                      </div>
+                    </td>
+                    <td className="px-4 py-3 align-top text-right">
+                      <div className="inline-flex items-center gap-1">
+                        <button
+                          type="button"
+                          onClick={() => setEditing(link)}
+                          aria-label="Edit link"
+                          className="p-1.5 rounded-md hover:bg-slate-200 text-slate-600"
+                        >
+                          <Pencil className="w-4 h-4" />
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => handleDelete(link)}
+                          aria-label="Delete link"
+                          className="p-1.5 rounded-md hover:bg-red-100 text-red-600"
+                        >
+                          <Trash2 className="w-4 h-4" />
+                        </button>
+                      </div>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+
+      {editing && (
+        <EditModal
+          link={editing}
+          onClose={() => setEditing(null)}
+          onSaved={(message) => showToast('success', message)}
+        />
+      )}
+
+      {toast && (
+        <div className="fixed bottom-4 right-4 z-toast">
+          <Toast
+            message={toast.text}
+            type={toast.type}
+            onClose={() => setToast(null)}
+          />
+        </div>
+      )}
+    </div>
+  );
+};

--- a/components/admin/ShortLinkQuickCreate.tsx
+++ b/components/admin/ShortLinkQuickCreate.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { X, Link2 } from 'lucide-react';
+
+import { ShortLinkCreateForm } from './LinkShortenerManager';
+
+interface ShortLinkQuickCreateProps {
+  onClose: () => void;
+}
+
+/**
+ * Lightweight modal opened from the Sidebar admin quick-action. Reuses the
+ * create form from `LinkShortenerManager` so the field set, validation, and
+ * Firestore write all stay in one place.
+ */
+export const ShortLinkQuickCreate: React.FC<ShortLinkQuickCreateProps> = ({
+  onClose,
+}) => {
+  React.useEffect(() => {
+    const handleEscape = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') onClose();
+    };
+    document.addEventListener('keydown', handleEscape);
+    return () => document.removeEventListener('keydown', handleEscape);
+  }, [onClose]);
+
+  return (
+    <div
+      className="fixed inset-0 z-modal bg-black/50 flex items-center justify-center p-4"
+      role="dialog"
+      aria-modal="true"
+      onClick={(event) => {
+        if (event.target === event.currentTarget) onClose();
+      }}
+    >
+      <div className="bg-white rounded-2xl shadow-xl w-full max-w-lg p-6 flex flex-col gap-4">
+        <div className="flex items-start justify-between">
+          <div className="flex items-center gap-2">
+            <div className="bg-brand-blue-lighter text-brand-blue-primary p-2 rounded-lg">
+              <Link2 className="w-4 h-4" />
+            </div>
+            <h3 className="text-lg font-bold text-slate-800">Shorten a URL</h3>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close"
+            className="p-1.5 rounded-lg hover:bg-slate-100 text-slate-500"
+          >
+            <X className="w-5 h-5" />
+          </button>
+        </div>
+
+        <ShortLinkCreateForm compact />
+      </div>
+    </div>
+  );
+};

--- a/components/common/ShortLinkRedirect.tsx
+++ b/components/common/ShortLinkRedirect.tsx
@@ -5,7 +5,6 @@ import React, { useEffect, useState } from 'react';
 import { Loader2, LinkIcon } from 'lucide-react';
 
 import { recordShortLinkClick, resolveShortLink } from '@/hooks/useShortLinks';
-import { SHORT_LINK_PREFIX } from '@/utils/shortLinkValidation';
 
 type ResolveState =
   | { status: 'resolving' }
@@ -15,8 +14,11 @@ type ResolveState =
 
 export const ShortLinkRedirect: React.FC = () => {
   // Parse the code once during render; an empty path segment goes straight
-  // to the not-found UI without ever scheduling an effect.
-  const code = window.location.pathname.slice(SHORT_LINK_PREFIX.length);
+  // to the not-found UI without ever scheduling an effect. Splitting on
+  // `/` is robust against trailing slashes (`/r/code/`) and stray
+  // sub-segments (`/r/code/extra`) — we always take the first segment
+  // after `/r/`.
+  const code = window.location.pathname.split('/')[2] ?? '';
   const [state, setState] = useState<ResolveState>(() =>
     code ? { status: 'resolving' } : { status: 'not-found' }
   );

--- a/components/common/ShortLinkRedirect.tsx
+++ b/components/common/ShortLinkRedirect.tsx
@@ -1,0 +1,95 @@
+// Public resolver for /r/:code short links. Renders outside any auth
+// provider so anonymous users can click admin-created links.
+
+import React, { useEffect, useState } from 'react';
+import { Loader2, LinkIcon } from 'lucide-react';
+
+import { recordShortLinkClick, resolveShortLink } from '@/hooks/useShortLinks';
+import { SHORT_LINK_PREFIX } from '@/utils/shortLinkValidation';
+
+type ResolveState =
+  | { status: 'resolving' }
+  | { status: 'redirecting'; destination: string }
+  | { status: 'not-found' }
+  | { status: 'error'; message: string };
+
+export const ShortLinkRedirect: React.FC = () => {
+  // Parse the code once during render; an empty path segment goes straight
+  // to the not-found UI without ever scheduling an effect.
+  const code = window.location.pathname.slice(SHORT_LINK_PREFIX.length);
+  const [state, setState] = useState<ResolveState>(() =>
+    code ? { status: 'resolving' } : { status: 'not-found' }
+  );
+
+  useEffect(() => {
+    if (!code) return;
+    let cancelled = false;
+
+    void (async () => {
+      try {
+        const link = await resolveShortLink(code);
+        if (cancelled) return;
+        if (!link) {
+          setState({ status: 'not-found' });
+          return;
+        }
+        setState({ status: 'redirecting', destination: link.destination });
+        // Fire-and-forget — never block the redirect on the counter write.
+        // The security rule explicitly permits this update from anonymous
+        // sessions.
+        recordShortLinkClick(code).catch((err) => {
+          console.warn('[ShortLinkRedirect] click counter failed:', err);
+        });
+        window.location.replace(link.destination);
+      } catch (err) {
+        if (cancelled) return;
+        console.error('[ShortLinkRedirect] resolve error:', err);
+        setState({
+          status: 'error',
+          message: 'Could not resolve this link. Try again later.',
+        });
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [code]);
+
+  if (state.status === 'resolving' || state.status === 'redirecting') {
+    return (
+      <div className="h-screen w-screen flex items-center justify-center bg-slate-50">
+        <div className="flex flex-col items-center gap-3 text-slate-600">
+          <Loader2 className="w-8 h-8 animate-spin text-brand-blue-primary" />
+          <p className="text-sm">Redirecting…</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="h-screen w-screen flex items-center justify-center bg-slate-50 p-4">
+      <div className="max-w-sm w-full bg-white rounded-2xl shadow-md p-8 text-center">
+        <div className="mx-auto mb-4 w-12 h-12 rounded-full bg-slate-100 flex items-center justify-center">
+          <LinkIcon className="w-6 h-6 text-slate-500" />
+        </div>
+        <h1 className="text-lg font-bold text-slate-800 mb-2">
+          {state.status === 'not-found'
+            ? 'Link not found'
+            : 'Something went wrong'}
+        </h1>
+        <p className="text-sm text-slate-600 mb-6">
+          {state.status === 'not-found'
+            ? 'This short link is no longer active or never existed.'
+            : state.message}
+        </p>
+        <a
+          href="/"
+          className="inline-block px-4 py-2 rounded-lg bg-brand-blue-primary text-white text-sm font-semibold hover:bg-brand-blue-dark transition-colors"
+        >
+          Back to SpartBoard
+        </a>
+      </div>
+    </div>
+  );
+};

--- a/components/common/ShortLinkRedirect.tsx
+++ b/components/common/ShortLinkRedirect.tsx
@@ -4,7 +4,7 @@
 import React, { useEffect, useState } from 'react';
 import { Loader2, LinkIcon } from 'lucide-react';
 
-import { recordShortLinkClick, resolveShortLink } from '@/hooks/useShortLinks';
+import { recordShortLinkClick, resolveShortLink } from '@/utils/shortLinksApi';
 
 type ResolveState =
   | { status: 'resolving' }

--- a/components/layout/sidebar/Sidebar.tsx
+++ b/components/layout/sidebar/Sidebar.tsx
@@ -25,12 +25,14 @@ import {
   SlidersHorizontal,
   Users,
   Users2,
+  Link2,
 } from 'lucide-react';
 import { GoogleDriveIcon } from '@/components/common/GoogleDriveIcon';
 import { useGoogleDrive } from '@/hooks/useGoogleDrive';
 import { useDashboard } from '@/context/useDashboard';
 import { useAuth } from '@/context/useAuth';
 import { AdminSettings } from '@/components/admin/AdminSettings';
+import { ShortLinkQuickCreate } from '@/components/admin/ShortLinkQuickCreate';
 import { GlassCard } from '@/components/common/GlassCard';
 import { IconButton } from '@/components/common/IconButton';
 import { Z_INDEX } from '@/config/zIndex';
@@ -182,6 +184,8 @@ export const Sidebar: React.FC = () => {
   }, []);
 
   const [showAdminSettings, setShowAdminSettings] = useState(false);
+  const [showShortLinkQuickCreate, setShowShortLinkQuickCreate] =
+    useState(false);
 
   // The currently-open PLC dashboard tracks against the live `plcs` array so
   // a feature toggle by another member shows up immediately. If the PLC
@@ -233,6 +237,16 @@ export const Sidebar: React.FC = () => {
             onClick={() => setShowAdminSettings(true)}
             icon={<Settings className="w-5 h-5" />}
             label={t('sidebar.header.adminSettings')}
+            variant="brand-ghost"
+            size="md"
+          />
+        )}
+
+        {isAdmin && (
+          <IconButton
+            onClick={() => setShowShortLinkQuickCreate(true)}
+            icon={<Link2 className="w-5 h-5" />}
+            label="Shorten URL"
             variant="brand-ghost"
             size="md"
           />
@@ -302,6 +316,12 @@ export const Sidebar: React.FC = () => {
 
       {showAdminSettings && (
         <AdminSettings onClose={() => setShowAdminSettings(false)} />
+      )}
+
+      {showShortLinkQuickCreate && (
+        <ShortLinkQuickCreate
+          onClose={() => setShowShortLinkQuickCreate(false)}
+        />
       )}
 
       {openPlcDashboardPlc && (

--- a/docs/link-shortener-phase-2.md
+++ b/docs/link-shortener-phase-2.md
@@ -1,0 +1,211 @@
+# Link Shortener — Phase 2 Roadmap
+
+## Context
+
+Phase 1 of the admin link shortener shipped in [PR #1570](https://github.com/OPS-PIvers/SpartBoard/pull/1570). It delivers:
+
+- Admin-only creation, editing, deletion of `short_links/{code}` docs via an Admin Settings tab (`components/admin/LinkShortenerManager.tsx`) and a Sidebar quick-action (`components/admin/ShortLinkQuickCreate.tsx`).
+- A public `/r/:code` resolver (`components/common/ShortLinkRedirect.tsx`) that performs a client-side Firestore lookup, atomically increments a per-link `clicks` counter, and redirects via `window.location.replace()`.
+- Custom slug + random fallback code generation with reserved-word guard (`utils/shortLinkValidation.ts`).
+- Firestore rules that allow public reads, admin-only writes, and a narrow anonymous click-counter update (`firestore.rules` — `/short_links/{code}`).
+- 100-link cap on the admin listing query (`hooks/useShortLinks.ts`).
+
+**Net infra cost of phase 1: $0/month** (existing domain, existing SPA fallback, no Cloud Function added).
+
+Phase 2 builds on that foundation in three independent slices — each can ship on its own without blocking the others. None of them require a new domain or new infrastructure surface area; the dominant cost remains dev time.
+
+---
+
+## Phase 2 PRs (roadmap snapshot)
+
+| PR  | Title                                                     | Status   |
+| --- | --------------------------------------------------------- | -------- |
+| 1   | Analytics tab in `AnalyticsManager` (Links panel)         | Planned  |
+| 2   | Per-click event log + richer metrics                      | Planned  |
+| 3   | "Shorten this URL" integration in widgets + Announcements | Planned  |
+| 4   | Bulk import/export                                        | Sketch   |
+| 5   | Vanity short domain                                       | Deferred |
+
+---
+
+## PR 1 — Analytics: "Links" panel in `AnalyticsManager`
+
+### Goal
+
+Surface the click data phase 1 already collects. No new writes — just read what's there and render it inside the existing analytics chrome so admins can spot which shared resources teachers actually use.
+
+### Key design decisions
+
+1. **Reuse the existing tab pattern in `AnalyticsManager.tsx`** (the `tabs` array around line 1641). Add `{ id: 'links', label: 'Links', icon: <Link2 /> }` and a `LinksPanel` component conditionally rendered alongside the other panels.
+
+2. **Pull data with the same `useShortLinks()` hook** from phase 1 (`hooks/useShortLinks.ts`). The 100-link cap there is already appropriate for analytics — districts with more than that should hit a pagination/search story before they hit an analytics story.
+
+3. **Reuse `KpiCard` + `PanelCard`** wrappers from `AnalyticsManager.tsx:232-286` so the visual language matches every other analytics panel. Charts use Recharts (already a dependency).
+
+4. **Three sections, top to bottom:**
+   - **KPIs row:** total links, total clicks (sum of `link.clicks`), links created in the last 7 days, links with zero clicks (dead-link cleanup candidates).
+   - **Top links table:** ordered by `clicks` desc, top 10. Columns mirror the `LinkShortenerManager` table but no edit/delete (this is analytics, not management — link to the Links tab for actions).
+   - **Recent activity:** links sorted by `lastClickedAt` desc, top 10. Shows what's currently in rotation.
+
+5. **No chart in PR 1.** A clicks-over-time chart needs the event log from PR 2; without it, all we have is "total clicks since creation" which doesn't bucket by date. Adding a fake aggregation here would be misleading.
+
+### Files
+
+**New:**
+
+- `components/admin/Analytics/LinksPanel.tsx`
+
+**Modified:**
+
+- `components/admin/Analytics/AnalyticsManager.tsx` — register the tab.
+
+### Cost
+
+$0 — same Firestore data phase 1 already reads.
+
+### Verification
+
+1. As admin: Admin Settings → Analytics → confirm "Links" tab appears with `Link2` icon.
+2. KPIs show non-zero numbers after creating a few links and clicking them in another browser/incognito.
+3. Top-links table sorts by clicks descending.
+4. Recent-activity table updates after clicking a link (allow snapshot to fire).
+5. Empty state (`links.length === 0`) renders gracefully.
+
+---
+
+## PR 2 — Per-click event log + richer metrics
+
+### Goal
+
+Move from a counter-only model to per-click events so analytics can show clicks over time, device class, and referrer. This is the prerequisite for any time-series chart.
+
+### Key design decisions
+
+1. **New collection: `/short_link_events/{eventId}`**, one doc per click. Auto-ID. Schema:
+
+   ```ts
+   interface ShortLinkEvent {
+     code: string; // FK to short_links/{code}
+     timestamp: number; // Date.now() at click
+     referrer: string | null; // document.referrer, truncated to 256 chars
+     deviceClass: 'desktop' | 'tablet' | 'mobile' | 'unknown';
+     // Deliberately NO IP, NO user agent string, NO uid — FERPA-aware.
+   }
+   ```
+
+2. **Resolver writes both** — counter (today) **and** event doc. Both writes are fire-and-forget. The event write happens in `recordShortLinkClick()` in `hooks/useShortLinks.ts`.
+
+3. **Security rule:** anonymous create allowed when payload matches schema; nobody but admins can read or update. Read aggregation happens through a scheduled Cloud Function (next decision), not direct queries.
+
+4. **Scheduled rollup function** — a Cloud Function that runs nightly and writes per-day aggregates to `short_links/{code}/daily_clicks/{yyyy-mm-dd}` with `{ clicks, byDevice }`. This is what `LinksPanel` actually queries for time-series — never the raw events. Keeps client read costs flat regardless of click volume.
+
+5. **TTL on raw events: 30 days.** Firestore TTL policy on `/short_link_events/{*}` so storage stays bounded. After 30 days only the daily aggregates remain.
+
+6. **Cost framing:** this is the one phase 2 PR that actually adds infra surface area — a scheduled Cloud Function and an additional write per click. Both stay well within free tier for a single-district audience (free tier covers 125k function invocations/month; one nightly function is ~30/month). Net expected spend: still **$0/month**.
+
+### Files
+
+**New:**
+
+- `functions/src/rollupShortLinkClicks.ts` — scheduled function.
+- `tests/utils/deviceClass.test.ts` (optional) — covers UA-string → deviceClass mapping.
+
+**Modified:**
+
+- `hooks/useShortLinks.ts` — `recordShortLinkClick()` also writes an event doc.
+- `types.ts` — `ShortLinkEvent` interface.
+- `firestore.rules` — `/short_link_events/{eventId}` rules; admin-only read.
+- `functions/src/index.ts` — export the scheduled function.
+- `components/admin/Analytics/LinksPanel.tsx` — read `daily_clicks` rollups and render a clicks-over-time chart.
+
+### Verification
+
+1. Click a short link → confirm a new `short_link_events` doc appears in Firestore.
+2. Manually invoke the rollup (`firebase functions:shell`) → confirm `daily_clicks/{date}` subdocs are created.
+3. Analytics panel shows a 7-day bar chart that matches the event-log totals.
+4. Sign out → click a link → event doc is still created (anonymous create rule).
+5. As non-admin: attempting to query `/short_link_events` returns permission-denied.
+
+---
+
+## PR 3 — Inline "Shorten this URL" integration
+
+### Goal
+
+Make the shortener useful from where URLs actually get entered, without an auto-shortening sweep. Admin pastes a long URL into a widget setting or an announcement → optional button next to the field converts it to a `/r/:code` link, returning the short URL to the field.
+
+### Key design decisions
+
+1. **New shared component: `<ShortenUrlButton url onShortened>`** in `components/admin/ShortenUrlButton.tsx`. Renders a small button next to URL inputs. Click → calls `createShortLink()` from `useShortLinks` → on success, calls `onShortened(shortUrl)` so the parent component can replace the field value.
+
+2. **Admin-gated.** Component returns `null` when `!isAdmin`. Non-admins keep entering raw URLs as today.
+
+3. **Opt-in placement.** Do NOT auto-replace URLs. The button is a hint, not magic. Three planned integration points:
+   - `components/admin/Announcements/EmbedConfigEditor.tsx` — alongside the URL input.
+   - Widget settings panels for `iframe`, `embed`, `url`, `video-activity` — wherever a long external URL is stored. Audit which widgets actually accept external URLs via `grep` for `<input type="url"` and `placeholder="https://`.
+   - `components/admin/WidgetBuilder/*` — when an admin pastes a resource URL into a generated widget.
+
+4. **No auto-detection.** Don't try to recognize "this looks like a Google Doc, shorten it." Teachers should choose. This avoids surprising rewrites and keeps the audit trail clean.
+
+5. **The link inherits a label** from the surrounding context where possible. The announcement editor passes the announcement title as the label; widget integrations pass the widget label. Defaults to blank if no good source.
+
+### Files
+
+**New:**
+
+- `components/admin/ShortenUrlButton.tsx`
+
+**Modified:** (one entry per integration point — pick the highest-value ones first)
+
+- `components/admin/Announcements/EmbedConfigEditor.tsx`
+- Widget settings panels for URL-bearing widgets (audit pending — list once the integration PR opens).
+
+### Verification
+
+1. As admin in the Announcements editor: paste a long URL → button appears → click → field replaced with `spartboard.web.app/r/<code>` → confirm new entry in `LinkShortenerManager`.
+2. As non-admin: button hidden everywhere.
+3. Widget settings with URL fields show the same button next to the URL input.
+4. Created link has the contextual label populated (announcement title / widget label).
+
+---
+
+## PR 4 — Bulk import/export (Sketch)
+
+CSV in / CSV out for the Links tab. Useful for district-wide migrations and offline editing. Skeleton:
+
+- Export: download `short_links` as CSV (`code, destination, label, clicks, createdAt`).
+- Import: parse a CSV, validate each row through `validateDestination` + `validateSlug`, dry-run preview, then batch `setDoc` writes.
+- UX lives behind a small "More" menu in the Links tab header so the primary CRUD surface stays uncluttered.
+
+Defer until there's a real district-migration scenario asking for it.
+
+---
+
+## PR 5 — Vanity short domain (Deferred)
+
+The shortest possible URL on `spartboard.web.app/r/abc` is ~28 characters. A custom `.app`/`.link`/`.io` short domain could drop that to ~12. The implementation work is trivial (Firebase Hosting supports multiple custom domains; just add a domain that rewrites the same `/r/:code` path).
+
+**Out of zero-cost scope** because a usable short domain typically runs $15–50/yr. Revisit only if there's a documented user complaint about URL length.
+
+---
+
+## Cross-cutting notes
+
+### Privacy / FERPA
+
+- Never log IPs, user agent strings, full referrer query strings, or anything that could identify a student.
+- Truncate `document.referrer` to its origin (or 256 chars) before storing.
+- Device class only — not user agent.
+- TTL on raw events keeps the privacy surface area small.
+
+### Backwards compatibility
+
+- Phase 1 docs (`short_links/{code}`) don't gain any required fields in phase 2. `daily_clicks` is a subcollection, optional. Old links keep working.
+- The `clicks` counter on the parent doc stays authoritative as a quick-read fallback if the rollup hasn't run yet.
+
+### Out-of-scope across all phase 2 PRs
+
+- QR code generation for short links (separate feature; widgets like `qr` already generate QR codes).
+- Password-protected or expiring links (no use case yet; the dock + analytics gives admins the same control via delete).
+- Per-user short links (admin-only is a deliberate scope choice; broadening it changes the security-rule model).
+- Server-side `301` redirects (would require a Cloud Function rewrite; client redirect is fine for our latency budget).

--- a/firestore.rules
+++ b/firestore.rules
@@ -549,14 +549,18 @@ service cloud.firestore {
     }
 
     // Admin-created short links resolved by the client at /r/:code.
-    // - Public read: anyone (incl. anonymous) can follow a shortlink.
+    // - Public `get`: anyone (incl. anonymous) can follow a known shortlink.
+    // - Admin-only `list`: prevents anonymous enumeration of every short
+    //   code + destination, which `allow read: if true` would otherwise
+    //   permit via a collection-level scan.
     // - Admin-only create/edit/delete: only admins manage links.
     // - Narrow anonymous update: the resolver bumps `clicks` by exactly 1
     //   and stamps `lastClickedAt`. Restricting the diff prevents resetting
     //   or inflating the counter — without these clauses an attacker could
     //   set `clicks` to any value while still passing `affectedKeys`.
     match /short_links/{code} {
-      allow read: if true;
+      allow get: if true;
+      allow list: if isAdmin();
       allow create: if isAdmin();
       allow update: if isAdmin()
         || (request.resource.data.diff(resource.data).affectedKeys()

--- a/firestore.rules
+++ b/firestore.rules
@@ -548,6 +548,21 @@ service cloud.firestore {
       allow write: if isAdmin();
     }
 
+    // Admin-created short links resolved by the client at /r/:code.
+    // - Public read: anyone (incl. anonymous) can follow a shortlink.
+    // - Admin-only create/edit/delete: only admins manage links.
+    // - Narrow anonymous update: the resolver bumps `clicks` + `lastClickedAt`
+    //   without an auth session, so we explicitly allow updates that touch
+    //   ONLY those two fields. Any other field change requires admin auth.
+    match /short_links/{code} {
+      allow read: if true;
+      allow create: if isAdmin();
+      allow update: if isAdmin()
+        || request.resource.data.diff(resource.data).affectedKeys()
+             .hasOnly(['clicks', 'lastClickedAt']);
+      allow delete: if isAdmin();
+    }
+
     // Global permissions - all authenticated users can read, only admins can write
     match /global_permissions/{featureId=**} {
       allow read: if request.auth != null;

--- a/firestore.rules
+++ b/firestore.rules
@@ -551,15 +551,18 @@ service cloud.firestore {
     // Admin-created short links resolved by the client at /r/:code.
     // - Public read: anyone (incl. anonymous) can follow a shortlink.
     // - Admin-only create/edit/delete: only admins manage links.
-    // - Narrow anonymous update: the resolver bumps `clicks` + `lastClickedAt`
-    //   without an auth session, so we explicitly allow updates that touch
-    //   ONLY those two fields. Any other field change requires admin auth.
+    // - Narrow anonymous update: the resolver bumps `clicks` by exactly 1
+    //   and stamps `lastClickedAt`. Restricting the diff prevents resetting
+    //   or inflating the counter — without these clauses an attacker could
+    //   set `clicks` to any value while still passing `affectedKeys`.
     match /short_links/{code} {
       allow read: if true;
       allow create: if isAdmin();
       allow update: if isAdmin()
-        || request.resource.data.diff(resource.data).affectedKeys()
-             .hasOnly(['clicks', 'lastClickedAt']);
+        || (request.resource.data.diff(resource.data).affectedKeys()
+              .hasOnly(['clicks', 'lastClickedAt'])
+            && request.resource.data.clicks == resource.data.get('clicks', 0) + 1
+            && request.resource.data.lastClickedAt is int);
       allow delete: if isAdmin();
     }
 

--- a/hooks/useShortLinks.ts
+++ b/hooks/useShortLinks.ts
@@ -1,0 +1,279 @@
+// CRUD + resolve helpers for the admin link-shortener feature.
+//
+// Reads/writes go to the top-level `short_links` Firestore collection. Doc
+// ids are the public short codes. Security rules (`firestore.rules`)
+// constrain creates/edits/deletes to admins and allow public reads + a
+// narrow anonymous click-counter update.
+
+import { useCallback, useEffect, useState } from 'react';
+import {
+  collection,
+  deleteDoc,
+  doc,
+  getDoc,
+  getDocs,
+  increment,
+  onSnapshot,
+  orderBy,
+  query,
+  setDoc,
+  updateDoc,
+} from 'firebase/firestore';
+
+import { db } from '@/config/firebase';
+import { useAuth } from '@/context/useAuth';
+import { ShortLink } from '@/types';
+import {
+  generateRandomCode,
+  validateDestination,
+  validateSlug,
+} from '@/utils/shortLinkValidation';
+
+const COLLECTION = 'short_links';
+const MAX_CODE_GENERATION_RETRIES = 5;
+
+interface CreateShortLinkInput {
+  destination: string;
+  slug?: string;
+  label?: string;
+}
+
+interface UpdateShortLinkInput {
+  destination?: string;
+  label?: string;
+}
+
+export type CreateResult =
+  | { ok: true; link: ShortLink }
+  | { ok: false; reason: string };
+
+export type UpdateResult =
+  | { ok: true; link: ShortLink }
+  | { ok: false; reason: string };
+
+/**
+ * Look up a short link by code. Public read — no auth required. Used by the
+ * resolver, so it deliberately avoids any cached/listened state.
+ */
+export const resolveShortLink = async (
+  code: string
+): Promise<ShortLink | null> => {
+  const ref = doc(db, COLLECTION, code);
+  const snap = await getDoc(ref);
+  if (!snap.exists()) return null;
+  return snap.data() as ShortLink;
+};
+
+/**
+ * Atomic counter bump used by the resolver. Allowed for anonymous users by
+ * the security rule because it touches only `clicks` and `lastClickedAt`.
+ * Failure here is swallowed at the call site so a counter glitch never
+ * blocks the redirect itself.
+ */
+export const recordShortLinkClick = async (code: string): Promise<void> => {
+  const ref = doc(db, COLLECTION, code);
+  await updateDoc(ref, {
+    clicks: increment(1),
+    lastClickedAt: Date.now(),
+  });
+};
+
+interface UseShortLinksResult {
+  links: ShortLink[];
+  loading: boolean;
+  error: string | null;
+  createShortLink: (input: CreateShortLinkInput) => Promise<CreateResult>;
+  updateShortLink: (
+    code: string,
+    patch: UpdateShortLinkInput
+  ) => Promise<UpdateResult>;
+  deleteShortLink: (code: string) => Promise<void>;
+  refresh: () => Promise<void>;
+}
+
+/**
+ * Admin-side hook. Subscribes to all short links (small collection,
+ * admin-only audience) and exposes create/update/delete helpers.
+ */
+export const useShortLinks = (): UseShortLinksResult => {
+  const { user, isAdmin } = useAuth();
+  const [links, setLinks] = useState<ShortLink[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!isAdmin) {
+      setLinks([]);
+      setLoading(false);
+      return;
+    }
+
+    setLoading(true);
+    const q = query(collection(db, COLLECTION), orderBy('createdAt', 'desc'));
+    const unsubscribe = onSnapshot(
+      q,
+      (snapshot) => {
+        const next: ShortLink[] = [];
+        snapshot.forEach((docSnap) => {
+          next.push(docSnap.data() as ShortLink);
+        });
+        setLinks(next);
+        setLoading(false);
+        setError(null);
+      },
+      (err) => {
+        console.error('[useShortLinks] snapshot error:', err);
+        setError('Failed to load short links.');
+        setLoading(false);
+      }
+    );
+
+    return () => unsubscribe();
+  }, [isAdmin]);
+
+  const refresh = useCallback(async () => {
+    if (!isAdmin) return;
+    try {
+      setLoading(true);
+      const snapshot = await getDocs(
+        query(collection(db, COLLECTION), orderBy('createdAt', 'desc'))
+      );
+      const next: ShortLink[] = [];
+      snapshot.forEach((docSnap) => next.push(docSnap.data() as ShortLink));
+      setLinks(next);
+      setError(null);
+    } catch (err) {
+      console.error('[useShortLinks] refresh error:', err);
+      setError('Failed to load short links.');
+    } finally {
+      setLoading(false);
+    }
+  }, [isAdmin]);
+
+  const codeIsTaken = useCallback(async (code: string): Promise<boolean> => {
+    const existing = await getDoc(doc(db, COLLECTION, code));
+    return existing.exists();
+  }, []);
+
+  const createShortLink = useCallback(
+    async (input: CreateShortLinkInput): Promise<CreateResult> => {
+      if (!user) {
+        return { ok: false, reason: 'You must be signed in.' };
+      }
+
+      const destinationResult = validateDestination(input.destination);
+      if (!destinationResult.ok) {
+        return { ok: false, reason: destinationResult.reason };
+      }
+
+      let code: string;
+      if (input.slug && input.slug.trim()) {
+        const slugResult = validateSlug(input.slug);
+        if (!slugResult.ok) {
+          return { ok: false, reason: slugResult.reason };
+        }
+        if (await codeIsTaken(slugResult.slug)) {
+          return {
+            ok: false,
+            reason: `"${slugResult.slug}" is already taken.`,
+          };
+        }
+        code = slugResult.slug;
+      } else {
+        // Random code — retry on the (very unlikely) collision.
+        let candidate = '';
+        for (
+          let attempt = 0;
+          attempt < MAX_CODE_GENERATION_RETRIES;
+          attempt++
+        ) {
+          candidate = generateRandomCode();
+          if (!(await codeIsTaken(candidate))) break;
+          candidate = '';
+        }
+        if (!candidate) {
+          return {
+            ok: false,
+            reason: 'Could not generate a unique code. Try again.',
+          };
+        }
+        code = candidate;
+      }
+
+      const now = Date.now();
+      const label = input.label?.trim();
+      const link: ShortLink = {
+        code,
+        destination: destinationResult.url,
+        createdBy: user.uid,
+        createdByEmail: user.email ?? '',
+        createdAt: now,
+        updatedAt: now,
+        clicks: 0,
+        lastClickedAt: null,
+        ...(label ? { label } : {}),
+      };
+
+      try {
+        await setDoc(doc(db, COLLECTION, code), link);
+        return { ok: true, link };
+      } catch (err) {
+        console.error('[useShortLinks] create error:', err);
+        return { ok: false, reason: 'Failed to save short link.' };
+      }
+    },
+    [user, codeIsTaken]
+  );
+
+  const updateShortLink = useCallback(
+    async (
+      code: string,
+      patch: UpdateShortLinkInput
+    ): Promise<UpdateResult> => {
+      const ref = doc(db, COLLECTION, code);
+      const snap = await getDoc(ref);
+      if (!snap.exists()) {
+        return { ok: false, reason: 'Short link no longer exists.' };
+      }
+      const existing = snap.data() as ShortLink;
+
+      const updates: Partial<ShortLink> = { updatedAt: Date.now() };
+
+      if (patch.destination !== undefined) {
+        const result = validateDestination(patch.destination);
+        if (!result.ok) {
+          return { ok: false, reason: result.reason };
+        }
+        updates.destination = result.url;
+      }
+
+      if (patch.label !== undefined) {
+        const trimmed = patch.label.trim();
+        updates.label = trimmed || '';
+      }
+
+      try {
+        await updateDoc(ref, updates);
+        return { ok: true, link: { ...existing, ...updates } as ShortLink };
+      } catch (err) {
+        console.error('[useShortLinks] update error:', err);
+        return { ok: false, reason: 'Failed to save changes.' };
+      }
+    },
+    []
+  );
+
+  const deleteShortLink = useCallback(async (code: string): Promise<void> => {
+    await deleteDoc(doc(db, COLLECTION, code));
+  }, []);
+
+  return {
+    links,
+    loading,
+    error,
+    createShortLink,
+    updateShortLink,
+    deleteShortLink,
+    refresh,
+  };
+};

--- a/hooks/useShortLinks.ts
+++ b/hooks/useShortLinks.ts
@@ -13,6 +13,7 @@ import {
   getDoc,
   getDocs,
   increment,
+  limit,
   onSnapshot,
   orderBy,
   query,
@@ -31,6 +32,10 @@ import {
 
 const COLLECTION = 'short_links';
 const MAX_CODE_GENERATION_RETRIES = 5;
+// Cap admin listings — keeps the read quota predictable and the table
+// responsive once a district has hundreds of links. Pagination/search UI
+// for larger sets is a phase 2 concern.
+const ADMIN_LIST_LIMIT = 100;
 
 interface CreateShortLinkInput {
   destination: string;
@@ -109,7 +114,11 @@ export const useShortLinks = (): UseShortLinksResult => {
     }
 
     setLoading(true);
-    const q = query(collection(db, COLLECTION), orderBy('createdAt', 'desc'));
+    const q = query(
+      collection(db, COLLECTION),
+      orderBy('createdAt', 'desc'),
+      limit(ADMIN_LIST_LIMIT)
+    );
     const unsubscribe = onSnapshot(
       q,
       (snapshot) => {
@@ -136,7 +145,11 @@ export const useShortLinks = (): UseShortLinksResult => {
     try {
       setLoading(true);
       const snapshot = await getDocs(
-        query(collection(db, COLLECTION), orderBy('createdAt', 'desc'))
+        query(
+          collection(db, COLLECTION),
+          orderBy('createdAt', 'desc'),
+          limit(ADMIN_LIST_LIMIT)
+        )
       );
       const next: ShortLink[] = [];
       snapshot.forEach((docSnap) => next.push(docSnap.data() as ShortLink));

--- a/hooks/useShortLinks.ts
+++ b/hooks/useShortLinks.ts
@@ -1,9 +1,8 @@
-// CRUD + resolve helpers for the admin link-shortener feature.
+// Admin-side CRUD hook for short links.
 //
-// Reads/writes go to the top-level `short_links` Firestore collection. Doc
-// ids are the public short codes. Security rules (`firestore.rules`)
-// constrain creates/edits/deletes to admins and allow public reads + a
-// narrow anonymous click-counter update.
+// The public resolve/click helpers live in `utils/shortLinksApi.ts` so the
+// `/r/:code` resolver doesn't have to import `useAuth` or any React hook
+// machinery. This file is React-only — admin management surface.
 
 import { useCallback, useEffect, useState } from 'react';
 import {
@@ -12,30 +11,47 @@ import {
   doc,
   getDoc,
   getDocs,
-  increment,
   limit,
   onSnapshot,
   orderBy,
   query,
-  setDoc,
+  runTransaction,
   updateDoc,
 } from 'firebase/firestore';
 
 import { db } from '@/config/firebase';
 import { useAuth } from '@/context/useAuth';
 import { ShortLink } from '@/types';
+import { SHORT_LINKS_COLLECTION } from '@/utils/shortLinksApi';
 import {
   generateRandomCode,
   validateDestination,
   validateSlug,
 } from '@/utils/shortLinkValidation';
 
-const COLLECTION = 'short_links';
+// Re-export the public helpers so existing call sites keep working. The
+// implementations live in the non-React module to keep the resolver bundle
+// lean.
+export { resolveShortLink, recordShortLinkClick } from '@/utils/shortLinksApi';
+
+const COLLECTION = SHORT_LINKS_COLLECTION;
 const MAX_CODE_GENERATION_RETRIES = 5;
 // Cap admin listings — keeps the read quota predictable and the table
 // responsive once a district has hundreds of links. Pagination/search UI
 // for larger sets is a phase 2 concern.
 const ADMIN_LIST_LIMIT = 100;
+
+/**
+ * Thrown inside the create transaction when the target slug already
+ * exists. Using a typed Error (rather than a sentinel symbol) keeps the
+ * lint rule against non-Error throws happy.
+ */
+class CodeTakenError extends Error {
+  constructor() {
+    super('CODE_TAKEN');
+    this.name = 'CodeTakenError';
+  }
+}
 
 interface CreateShortLinkInput {
   destination: string;
@@ -56,33 +72,6 @@ export type UpdateResult =
   | { ok: true; link: ShortLink }
   | { ok: false; reason: string };
 
-/**
- * Look up a short link by code. Public read — no auth required. Used by the
- * resolver, so it deliberately avoids any cached/listened state.
- */
-export const resolveShortLink = async (
-  code: string
-): Promise<ShortLink | null> => {
-  const ref = doc(db, COLLECTION, code);
-  const snap = await getDoc(ref);
-  if (!snap.exists()) return null;
-  return snap.data() as ShortLink;
-};
-
-/**
- * Atomic counter bump used by the resolver. Allowed for anonymous users by
- * the security rule because it touches only `clicks` and `lastClickedAt`.
- * Failure here is swallowed at the call site so a counter glitch never
- * blocks the redirect itself.
- */
-export const recordShortLinkClick = async (code: string): Promise<void> => {
-  const ref = doc(db, COLLECTION, code);
-  await updateDoc(ref, {
-    clicks: increment(1),
-    lastClickedAt: Date.now(),
-  });
-};
-
 interface UseShortLinksResult {
   links: ShortLink[];
   loading: boolean;
@@ -95,6 +84,33 @@ interface UseShortLinksResult {
   deleteShortLink: (code: string) => Promise<void>;
   refresh: () => Promise<void>;
 }
+
+/**
+ * Atomic "claim this code" write. Inside the transaction we read the doc
+ * and bail (via a sentinel) if it already exists, so concurrent admins
+ * creating the same slug can't clobber each other's links.
+ */
+const createShortLinkAtomic = async (
+  code: string,
+  link: ShortLink
+): Promise<{ ok: true } | { ok: false; reason: 'taken' }> => {
+  try {
+    await runTransaction(db, async (transaction) => {
+      const ref = doc(db, COLLECTION, code);
+      const existing = await transaction.get(ref);
+      if (existing.exists()) {
+        throw new CodeTakenError();
+      }
+      transaction.set(ref, link);
+    });
+    return { ok: true };
+  } catch (err) {
+    if (err instanceof CodeTakenError) {
+      return { ok: false, reason: 'taken' };
+    }
+    throw err;
+  }
+};
 
 /**
  * Admin-side hook. Subscribes to all short links (small collection,
@@ -163,11 +179,6 @@ export const useShortLinks = (): UseShortLinksResult => {
     }
   }, [isAdmin]);
 
-  const codeIsTaken = useCallback(async (code: string): Promise<boolean> => {
-    const existing = await getDoc(doc(db, COLLECTION, code));
-    return existing.exists();
-  }, []);
-
   const createShortLink = useCallback(
     async (input: CreateShortLinkInput): Promise<CreateResult> => {
       if (!user) {
@@ -179,43 +190,9 @@ export const useShortLinks = (): UseShortLinksResult => {
         return { ok: false, reason: destinationResult.reason };
       }
 
-      let code: string;
-      if (input.slug && input.slug.trim()) {
-        const slugResult = validateSlug(input.slug);
-        if (!slugResult.ok) {
-          return { ok: false, reason: slugResult.reason };
-        }
-        if (await codeIsTaken(slugResult.slug)) {
-          return {
-            ok: false,
-            reason: `"${slugResult.slug}" is already taken.`,
-          };
-        }
-        code = slugResult.slug;
-      } else {
-        // Random code — retry on the (very unlikely) collision.
-        let candidate = '';
-        for (
-          let attempt = 0;
-          attempt < MAX_CODE_GENERATION_RETRIES;
-          attempt++
-        ) {
-          candidate = generateRandomCode();
-          if (!(await codeIsTaken(candidate))) break;
-          candidate = '';
-        }
-        if (!candidate) {
-          return {
-            ok: false,
-            reason: 'Could not generate a unique code. Try again.',
-          };
-        }
-        code = candidate;
-      }
-
       const now = Date.now();
       const label = input.label?.trim();
-      const link: ShortLink = {
+      const buildLink = (code: string): ShortLink => ({
         code,
         destination: destinationResult.url,
         createdBy: user.uid,
@@ -225,17 +202,64 @@ export const useShortLinks = (): UseShortLinksResult => {
         clicks: 0,
         lastClickedAt: null,
         ...(label ? { label } : {}),
-      };
+      });
 
       try {
-        await setDoc(doc(db, COLLECTION, code), link);
-        return { ok: true, link };
+        // Custom slug: validate once, then try to claim atomically. A
+        // collision means another admin grabbed the slug between us
+        // validating and writing — surface the error so they pick again.
+        if (input.slug && input.slug.trim()) {
+          const slugResult = validateSlug(input.slug);
+          if (!slugResult.ok) {
+            return { ok: false, reason: slugResult.reason };
+          }
+          const result = await createShortLinkAtomic(
+            slugResult.slug,
+            buildLink(slugResult.slug)
+          );
+          if (!result.ok) {
+            return {
+              ok: false,
+              reason: `"${slugResult.slug}" is already taken.`,
+            };
+          }
+          return { ok: true, link: buildLink(slugResult.slug) };
+        }
+
+        // Random code: spin up to N candidates and try each transactionally.
+        // A "taken" outcome means we lost the race; just regenerate and
+        // try again until we either succeed or exhaust retries.
+        for (
+          let attempt = 0;
+          attempt < MAX_CODE_GENERATION_RETRIES;
+          attempt++
+        ) {
+          const candidate = generateRandomCode();
+          const result = await createShortLinkAtomic(
+            candidate,
+            buildLink(candidate)
+          );
+          if (result.ok) {
+            return { ok: true, link: buildLink(candidate) };
+          }
+        }
+        return {
+          ok: false,
+          reason: 'Could not generate a unique code. Try again.',
+        };
       } catch (err) {
+        // Anything else (network, permission, quota) lands here so the
+        // form sees a clean `{ ok: false, reason }` instead of an
+        // unhandled rejection.
         console.error('[useShortLinks] create error:', err);
-        return { ok: false, reason: 'Failed to save short link.' };
+        return {
+          ok: false,
+          reason:
+            'Failed to save short link. Check your connection and try again.',
+        };
       }
     },
-    [user, codeIsTaken]
+    [user]
   );
 
   const updateShortLink = useCallback(
@@ -243,34 +267,38 @@ export const useShortLinks = (): UseShortLinksResult => {
       code: string,
       patch: UpdateShortLinkInput
     ): Promise<UpdateResult> => {
-      const ref = doc(db, COLLECTION, code);
-      const snap = await getDoc(ref);
-      if (!snap.exists()) {
-        return { ok: false, reason: 'Short link no longer exists.' };
-      }
-      const existing = snap.data() as ShortLink;
-
-      const updates: Partial<ShortLink> = { updatedAt: Date.now() };
-
-      if (patch.destination !== undefined) {
-        const result = validateDestination(patch.destination);
-        if (!result.ok) {
-          return { ok: false, reason: result.reason };
-        }
-        updates.destination = result.url;
-      }
-
-      if (patch.label !== undefined) {
-        const trimmed = patch.label.trim();
-        updates.label = trimmed || '';
-      }
-
       try {
+        const ref = doc(db, COLLECTION, code);
+        const snap = await getDoc(ref);
+        if (!snap.exists()) {
+          return { ok: false, reason: 'Short link no longer exists.' };
+        }
+        const existing = snap.data() as ShortLink;
+
+        const updates: Partial<ShortLink> = { updatedAt: Date.now() };
+
+        if (patch.destination !== undefined) {
+          const result = validateDestination(patch.destination);
+          if (!result.ok) {
+            return { ok: false, reason: result.reason };
+          }
+          updates.destination = result.url;
+        }
+
+        if (patch.label !== undefined) {
+          const trimmed = patch.label.trim();
+          updates.label = trimmed || '';
+        }
+
         await updateDoc(ref, updates);
         return { ok: true, link: { ...existing, ...updates } as ShortLink };
       } catch (err) {
         console.error('[useShortLinks] update error:', err);
-        return { ok: false, reason: 'Failed to save changes.' };
+        return {
+          ok: false,
+          reason:
+            'Failed to save changes. Check your connection and try again.',
+        };
       }
     },
     []

--- a/types.ts
+++ b/types.ts
@@ -5454,3 +5454,30 @@ export interface LibraryFolder {
   /** Epoch ms at last rename / move / reorder. Optional on legacy records. */
   updatedAt?: number;
 }
+
+/**
+ * Admin-created short link, stored at `/short_links/{code}`. The doc id is
+ * the public-facing code (e.g. `lesson-1`); the URL `${origin}/r/${code}`
+ * resolves client-side via `ShortLinkRedirect` and bumps the `clicks`
+ * counter atomically before redirecting the browser to `destination`.
+ */
+export interface ShortLink {
+  /** Doc id and URL path segment. Lowercased, slug-safe, unique. */
+  code: string;
+  /** Absolute http(s) URL to redirect to. */
+  destination: string;
+  /** Creator uid (for table display + audit). */
+  createdBy: string;
+  /** Creator email at create time (snapshot — not kept in sync). */
+  createdByEmail: string;
+  /** Epoch ms at create. */
+  createdAt: number;
+  /** Epoch ms at last edit. */
+  updatedAt: number;
+  /** Total resolved clicks. Incremented atomically by the resolver. */
+  clicks: number;
+  /** Epoch ms of the most recent click, or null if never clicked. */
+  lastClickedAt: number | null;
+  /** Optional human-readable name shown in the admin table. */
+  label?: string;
+}

--- a/utils/shortLinkValidation.ts
+++ b/utils/shortLinkValidation.ts
@@ -128,14 +128,31 @@ export const validateDestination = (
 };
 
 /**
- * Generate a random short code. Uses crypto.randomUUID (already used
- * throughout the codebase) sliced to a manageable length. The dash from
- * the UUID is stripped so the resulting code is alphanumeric.
+ * Generate a random short code from cryptographically strong randomness.
+ * Uses `crypto.randomUUID()` when available and falls back to
+ * `crypto.getRandomValues()` — never `Math.random()`, which is predictable
+ * and unsuitable for code generation in a security-sensitive context
+ * (short codes are public URLs that map to admin-curated destinations).
  */
 export const generateRandomCode = (
   length: number = RANDOM_CODE_LENGTH
 ): string => {
-  const uuid =
-    globalThis.crypto?.randomUUID?.() ?? `${Date.now()}-${Math.random()}`;
-  return uuid.replace(/-/g, '').slice(0, length).toLowerCase();
+  const cryptoObj = globalThis.crypto;
+  if (cryptoObj?.randomUUID) {
+    return cryptoObj
+      .randomUUID()
+      .replace(/-/g, '')
+      .slice(0, length)
+      .toLowerCase();
+  }
+  if (cryptoObj?.getRandomValues) {
+    const bytes = new Uint8Array(Math.ceil(length / 2));
+    cryptoObj.getRandomValues(bytes);
+    return Array.from(bytes, (b) => b.toString(16).padStart(2, '0'))
+      .join('')
+      .slice(0, length);
+  }
+  throw new Error(
+    'No secure random source available — Web Crypto API is required to generate short codes.'
+  );
 };

--- a/utils/shortLinkValidation.ts
+++ b/utils/shortLinkValidation.ts
@@ -1,0 +1,141 @@
+// Validation helpers for the admin link-shortener feature.
+//
+// Short links live at /r/:code on the existing domain, so the set of legal
+// codes must be (a) URL-path-safe, (b) disjoint from existing app routes,
+// and (c) bounded in length to keep Firestore doc ids sane.
+
+import { slugify } from './slug';
+
+export const SHORT_LINK_PREFIX = '/r/';
+export const MIN_SLUG_LENGTH = 2;
+export const MAX_SLUG_LENGTH = 32;
+export const MAX_DESTINATION_LENGTH = 2048;
+export const RANDOM_CODE_LENGTH = 8;
+
+// Codes that would collide with existing top-level SPA routes (or are
+// otherwise reserved for future routes). The shortener resolver lives at
+// `/r/:code`, but a typo like `/r` or `/r/admin` should never be silently
+// reachable, and shortlinks themselves should never alias real product paths.
+export const RESERVED_SLUGS: readonly string[] = [
+  'r',
+  'admin',
+  'api',
+  'join',
+  'quiz',
+  'activity',
+  'activity-wall',
+  'guided-learning',
+  'miniapp',
+  'nextup',
+  'remote',
+  'invite',
+  'plc-invite',
+  'student',
+  'my-assignments',
+];
+
+export type SlugValidationResult =
+  | { ok: true; slug: string }
+  | { ok: false; reason: string };
+
+export type DestinationValidationResult =
+  | { ok: true; url: string }
+  | { ok: false; reason: string };
+
+/**
+ * Normalize and validate a user-supplied slug. Returns the canonical form
+ * (lowercased, dash-separated) when valid, otherwise a human-readable reason.
+ *
+ * Note: this does NOT check Firestore uniqueness — callers must do that
+ * with a `getDoc` against `short_links/{slug}` after normalization.
+ */
+export const validateSlug = (raw: string): SlugValidationResult => {
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    return { ok: false, reason: 'Slug cannot be empty.' };
+  }
+
+  const normalized = slugify(trimmed);
+  if (!normalized) {
+    return {
+      ok: false,
+      reason: 'Slug must contain at least one letter or number.',
+    };
+  }
+
+  if (normalized.length < MIN_SLUG_LENGTH) {
+    return {
+      ok: false,
+      reason: `Slug must be at least ${MIN_SLUG_LENGTH} characters.`,
+    };
+  }
+
+  if (normalized.length > MAX_SLUG_LENGTH) {
+    return {
+      ok: false,
+      reason: `Slug must be at most ${MAX_SLUG_LENGTH} characters.`,
+    };
+  }
+
+  if (RESERVED_SLUGS.includes(normalized)) {
+    return {
+      ok: false,
+      reason: `"${normalized}" is reserved. Pick a different slug.`,
+    };
+  }
+
+  return { ok: true, slug: normalized };
+};
+
+/**
+ * Validate a destination URL. Requires an absolute http(s) URL — relative
+ * paths and `javascript:` / `data:` / `file:` schemes are rejected so the
+ * resolver can hand the value straight to `window.location.replace()`.
+ */
+export const validateDestination = (
+  raw: string
+): DestinationValidationResult => {
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    return { ok: false, reason: 'Destination URL is required.' };
+  }
+
+  if (trimmed.length > MAX_DESTINATION_LENGTH) {
+    return {
+      ok: false,
+      reason: `URL is too long (max ${MAX_DESTINATION_LENGTH} characters).`,
+    };
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(trimmed);
+  } catch {
+    return {
+      ok: false,
+      reason: 'Enter a complete URL including https://',
+    };
+  }
+
+  if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') {
+    return {
+      ok: false,
+      reason: 'Only http and https URLs are allowed.',
+    };
+  }
+
+  return { ok: true, url: parsed.toString() };
+};
+
+/**
+ * Generate a random short code. Uses crypto.randomUUID (already used
+ * throughout the codebase) sliced to a manageable length. The dash from
+ * the UUID is stripped so the resulting code is alphanumeric.
+ */
+export const generateRandomCode = (
+  length: number = RANDOM_CODE_LENGTH
+): string => {
+  const uuid =
+    globalThis.crypto?.randomUUID?.() ?? `${Date.now()}-${Math.random()}`;
+  return uuid.replace(/-/g, '').slice(0, length).toLowerCase();
+};

--- a/utils/shortLinksApi.ts
+++ b/utils/shortLinksApi.ts
@@ -1,0 +1,39 @@
+// Public, non-React helpers for the short-link feature.
+//
+// Lives outside the `hooks/` tree so the public `/r/:code` resolver can
+// import it without pulling in `useAuth` or any React hook machinery that
+// only exists for the admin management surface.
+
+import { doc, getDoc, increment, updateDoc } from 'firebase/firestore';
+
+import { db } from '@/config/firebase';
+import { ShortLink } from '@/types';
+
+export const SHORT_LINKS_COLLECTION = 'short_links';
+
+/**
+ * Look up a short link by code. Public read — no auth required. Used by
+ * the resolver, so it deliberately avoids any cached/listened state.
+ */
+export const resolveShortLink = async (
+  code: string
+): Promise<ShortLink | null> => {
+  const ref = doc(db, SHORT_LINKS_COLLECTION, code);
+  const snap = await getDoc(ref);
+  if (!snap.exists()) return null;
+  return snap.data() as ShortLink;
+};
+
+/**
+ * Atomic counter bump used by the resolver. Allowed for anonymous users
+ * by the security rule because it touches only `clicks` (strictly +1) and
+ * `lastClickedAt`. Failure here is swallowed at the call site so a
+ * counter glitch never blocks the redirect itself.
+ */
+export const recordShortLinkClick = async (code: string): Promise<void> => {
+  const ref = doc(db, SHORT_LINKS_COLLECTION, code);
+  await updateDoc(ref, {
+    clicks: increment(1),
+    lastClickedAt: Date.now(),
+  });
+};


### PR DESCRIPTION
## Summary

Phase 1 of the admin link shortener. Admins can paste a long URL and get a short, copyable link on the existing domain (`spartboard.web.app/r/:code`) — no new domain, no Cloud Function, no new hosting rewrite. **Net infra cost: $0.**

- New **Links** tab in Admin Settings with create form, search, edit (destination + label), delete, and click counts
- New **Shorten URL** quick action in the Sidebar (admin-only) for fast one-off creates
- Public `/r/:code` resolver renders outside every provider so anonymous students/parents can follow links without triggering Firebase Auth or dashboard listeners
- Custom slugs (with validation + reserved-word list) + random fallback (8-char from `crypto.randomUUID`)
- Editable destinations (preserves the short URL once shared); slug is immutable to avoid breaking already-shared links
- Atomic click counter via Firestore `increment(1)` — narrow security-rule exception lets anonymous resolves bump `clicks` + `lastClickedAt` only

## Architecture

- **Data**: `/short_links/{code}` — doc id is the public short code. See `ShortLink` interface in `types.ts`.
- **Resolution**: `components/common/ShortLinkRedirect.tsx` reads the code from `window.location.pathname`, looks up Firestore, fires-and-forgets the counter bump, and `window.location.replace()`s to the destination.
- **Security rules**: public read; admin-only create/edit/delete; narrow anonymous update restricted to `clicks`/`lastClickedAt` via `.diff(...).affectedKeys().hasOnly(...)`.
- **Reuse**: leans on `utils/slug.ts:slugify`, `useDialog().showConfirm`, the AdminSettings TABS pattern, and the existing toast component.

## Files

**New**
- `utils/shortLinkValidation.ts` — slug + URL validation, reserved-word list, random code generator
- `hooks/useShortLinks.ts` — CRUD + resolve helpers (`resolveShortLink`, `recordShortLinkClick`, `useShortLinks`)
- `components/common/ShortLinkRedirect.tsx` — public resolver
- `components/admin/LinkShortenerManager.tsx` — admin tab UI (also exports `ShortLinkCreateForm`)
- `components/admin/ShortLinkQuickCreate.tsx` — sidebar quick-action modal

**Modified**
- `App.tsx` — `/r/:code` route detection + lazy import
- `components/admin/AdminSettings.tsx` — register the new tab
- `components/layout/sidebar/Sidebar.tsx` — admin-only "Shorten URL" icon button
- `firestore.rules` — `short_links` collection rules
- `types.ts` — `ShortLink` interface

## Cost

- Domain: **$0** (existing `spartboard.web.app`)
- Cloud Functions: **none added**
- Firestore: 1 read + 1 write per redirect — free tier covers 50k/20k per day, single-district usage will not approach this
- Storage: ~200 bytes per link doc

## Test plan

- [x] `pnpm run type-check && pnpm run lint && pnpm run format:check && pnpm run build` all clean ✅ (verified locally)
- [ ] As admin: open Admin Settings → confirm **Links** tab appears with Link2 icon
- [ ] Create link with custom slug `lesson-1` → copyable `/r/lesson-1` URL displayed
- [ ] Create link with blank slug → 8-char random code generated
- [ ] Slug validation rejects reserved (`r`, `admin`, `join`, etc.), invalid chars, duplicates
- [ ] Open `/r/lesson-1` in a fresh tab → redirects without flashing the dashboard
- [ ] Click counter increments on each visit, `lastClickedAt` updates
- [ ] Edit destination → revisiting short URL goes to new destination
- [ ] Delete → confirm dialog → `/r/<code>` shows "Link not found"
- [ ] Sidebar **Shorten URL** button opens lightweight modal; created link appears in the manager table
- [ ] Non-admin: tab + sidebar button hidden, direct Firestore writes rejected by rules
- [ ] Signed-out user can still follow `/r/<code>` and the counter still increments

## Out of scope (phase 2)

- Analytics dashboard tab (click trends, top links, dead-link cleanup)
- Per-click event log with referrer + device class
- "Shorten this URL" buttons in widget settings + AnnouncementsManager
- Bulk import/export

https://claude.ai/code/session_01D6R26MbCGbkegUs9Ez4s9e

---
_Generated by [Claude Code](https://claude.ai/code/session_01D6R26MbCGbkegUs9Ez4s9e)_