### PR TITLE
feat(random): independent expert-group control, inline +/- steppers, multi-column shuffle

### DIFF
--- a/components/widgets/random/GroupSizeStepper.tsx
+++ b/components/widgets/random/GroupSizeStepper.tsx
@@ -1,0 +1,95 @@
+import React from 'react';
+import { Minus, Plus } from 'lucide-react';
+
+interface GroupSizeStepperProps {
+  value: number;
+  onChange: (next: number) => void;
+  min?: number;
+  max?: number;
+  /** Short label rendered above the value (e.g. "HOME", "EXPERT", "SIZE"). */
+  label?: string;
+  /** Tooltip + accessible name for the whole control. */
+  title: string;
+}
+
+export const GroupSizeStepper: React.FC<GroupSizeStepperProps> = ({
+  value,
+  onChange,
+  min = 2,
+  max = 20,
+  label,
+  title,
+}) => {
+  const decrement = () => onChange(Math.max(min, value - 1));
+  const increment = () => onChange(Math.min(max, value + 1));
+  const atMin = value <= min;
+  const atMax = value >= max;
+
+  return (
+    <div
+      role="group"
+      aria-label={title}
+      title={title}
+      className="flex items-stretch bg-white/80 border border-slate-200 rounded-full overflow-hidden shadow-sm flex-shrink-0"
+      style={{ height: 'clamp(40px, 10cqmin, 72px)' }}
+    >
+      <button
+        type="button"
+        onClick={decrement}
+        disabled={atMin}
+        className="flex items-center justify-center text-slate-600 hover:bg-slate-100 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+        style={{
+          width: 'clamp(28px, 7cqmin, 44px)',
+        }}
+        aria-label={`Decrease ${title}`}
+      >
+        <Minus
+          style={{
+            width: 'clamp(12px, 3.5cqmin, 22px)',
+            height: 'clamp(12px, 3.5cqmin, 22px)',
+          }}
+        />
+      </button>
+      <div
+        className="flex flex-col items-center justify-center"
+        style={{
+          paddingLeft: 'clamp(2px, 0.5cqmin, 6px)',
+          paddingRight: 'clamp(2px, 0.5cqmin, 6px)',
+          minWidth: 'clamp(24px, 6cqmin, 40px)',
+        }}
+      >
+        {label && (
+          <span
+            className="uppercase tracking-wider text-slate-400 font-bold leading-none"
+            style={{ fontSize: 'clamp(7px, 1.8cqmin, 10px)' }}
+          >
+            {label}
+          </span>
+        )}
+        <span
+          className="font-bold font-mono text-slate-700 tabular-nums leading-tight"
+          style={{ fontSize: 'clamp(13px, 3.5cqmin, 22px)' }}
+        >
+          {value}
+        </span>
+      </div>
+      <button
+        type="button"
+        onClick={increment}
+        disabled={atMax}
+        className="flex items-center justify-center text-slate-600 hover:bg-slate-100 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+        style={{
+          width: 'clamp(28px, 7cqmin, 44px)',
+        }}
+        aria-label={`Increase ${title}`}
+      >
+        <Plus
+          style={{
+            width: 'clamp(12px, 3.5cqmin, 22px)',
+            height: 'clamp(12px, 3.5cqmin, 22px)',
+          }}
+        />
+      </button>
+    </div>
+  );
+};

--- a/components/widgets/random/GroupSizeStepper.tsx
+++ b/components/widgets/random/GroupSizeStepper.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Minus, Plus } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 
 interface GroupSizeStepperProps {
   value: number;
@@ -20,6 +21,7 @@ export const GroupSizeStepper: React.FC<GroupSizeStepperProps> = ({
   label,
   title,
 }) => {
+  const { t } = useTranslation();
   const decrement = () => onChange(Math.max(min, value - 1));
   const increment = () => onChange(Math.min(max, value + 1));
   const atMin = value <= min;
@@ -41,7 +43,10 @@ export const GroupSizeStepper: React.FC<GroupSizeStepperProps> = ({
         style={{
           width: 'clamp(28px, 7cqmin, 44px)',
         }}
-        aria-label={`Decrease ${title}`}
+        aria-label={t('widgets.random.stepperDecrease', {
+          name: title,
+          defaultValue: 'Decrease {{name}}',
+        })}
       >
         <Minus
           style={{
@@ -81,7 +86,10 @@ export const GroupSizeStepper: React.FC<GroupSizeStepperProps> = ({
         style={{
           width: 'clamp(28px, 7cqmin, 44px)',
         }}
-        aria-label={`Increase ${title}`}
+        aria-label={t('widgets.random.stepperIncrease', {
+          name: title,
+          defaultValue: 'Increase {{name}}',
+        })}
       >
         <Plus
           style={{

--- a/components/widgets/random/RandomSettings.tsx
+++ b/components/widgets/random/RandomSettings.tsx
@@ -141,9 +141,34 @@ export const RandomSettings: React.FC<{ widget: WidgetData }> = ({
     rosterMode = 'class',
     autoStartTimer = false,
     visualStyle = 'flash',
+    numExpertGroups: configNumExpertGroups,
   } = config;
   // Mirror RandomWidget: jigsaw defaults to 4, others to 3, explicit choice wins.
   const groupSize = configGroupSize ?? (mode === 'jigsaw' ? 4 : 3);
+
+  // Mirror RandomWidget's default — "2 home groups per expert group" —
+  // computed from an estimate of the home group count so the panel
+  // displays what Pick would actually use. Slider clamps to >= 2.
+  const estimatedStudentCount = (() => {
+    if (rosterMode === 'class' && activeRoster) {
+      return activeRoster.students.length;
+    }
+    const firsts = firstNames
+      .split('\n')
+      .map((n) => n.trim())
+      .filter(Boolean).length;
+    const lasts = lastNames
+      .split('\n')
+      .map((n) => n.trim())
+      .filter(Boolean).length;
+    return Math.max(firsts, lasts);
+  })();
+  const estimatedHomeGroups = Math.max(
+    1,
+    Math.ceil(estimatedStudentCount / Math.max(1, groupSize))
+  );
+  const numExpertGroups =
+    configNumExpertGroups ?? Math.max(2, Math.ceil(estimatedHomeGroups / 2));
 
   const [localFirstNames, setLocalFirstNames] = useState(firstNames);
   const [localLastNames, setLocalLastNames] = useState(lastNames);
@@ -415,6 +440,38 @@ export const RandomSettings: React.FC<{ widget: WidgetData }> = ({
             />
             <span className="w-10 text-center font-mono  text-slate-700 text-sm">
               {groupSize}
+            </span>
+          </div>
+        </div>
+      )}
+
+      {mode === 'jigsaw' && (
+        <div className="p-4 bg-white border border-slate-100 rounded-2xl shadow-sm">
+          <label className="text-xxs  text-slate-400 uppercase tracking-widest mb-3 block flex items-center gap-2">
+            <Puzzle className="w-3 h-3" />{' '}
+            {t('widgets.random.expertGroupCount', {
+              defaultValue: 'Number of Expert Groups',
+            })}
+          </label>
+          <div className="flex items-center gap-4">
+            <input
+              type="range"
+              min="2"
+              max="20"
+              step="1"
+              value={numExpertGroups}
+              onChange={(e) =>
+                updateWidget(widget.id, {
+                  config: {
+                    ...config,
+                    numExpertGroups: parseInt(e.target.value),
+                  },
+                })
+              }
+              className="flex-1 accent-brand-blue-primary h-1.5 bg-slate-200 rounded-lg appearance-none cursor-pointer"
+            />
+            <span className="w-10 text-center font-mono  text-slate-700 text-sm">
+              {numExpertGroups}
             </span>
           </div>
         </div>

--- a/components/widgets/random/RandomSettings.tsx
+++ b/components/widgets/random/RandomSettings.tsx
@@ -25,6 +25,7 @@ import {
 } from 'lucide-react';
 import { Button } from '@/components/common/Button';
 import { SettingsLabel } from '@/components/common/SettingsLabel';
+import { getLocalIsoDate } from '@/utils/localDate';
 
 export const RandomSettings: React.FC<{ widget: WidgetData }> = ({
   widget,
@@ -124,14 +125,13 @@ export const RandomSettings: React.FC<{ widget: WidgetData }> = ({
 
     updateWidget(widget.id, {
       config: {
-        ...config,
         firstNames: newFirstNames,
         lastNames: newLastNames,
         lastResult: null,
         remainingStudents: [],
       },
     });
-  }, [activeRoster, config, updateWidget, widget.id]);
+  }, [activeRoster, updateWidget, widget.id]);
   const {
     firstNames = '',
     lastNames = '',
@@ -149,9 +149,16 @@ export const RandomSettings: React.FC<{ widget: WidgetData }> = ({
   // Mirror RandomWidget's default — "2 home groups per expert group" —
   // computed from an estimate of the home group count so the panel
   // displays what Pick would actually use. Slider clamps to >= 2.
+  // Match the widget's absent-student filter in class mode so the panel
+  // doesn't drift from the live stepper on days with absences.
   const estimatedStudentCount = (() => {
     if (rosterMode === 'class' && activeRoster) {
-      return activeRoster.students.length;
+      const today = getLocalIsoDate();
+      const absentCount =
+        activeRoster.absent?.date === today
+          ? activeRoster.absent.studentIds.length
+          : 0;
+      return Math.max(0, activeRoster.students.length - absentCount);
     }
     const firsts = firstNames
       .split('\n')
@@ -205,10 +212,7 @@ export const RandomSettings: React.FC<{ widget: WidgetData }> = ({
     const timer = setTimeout(() => {
       if (localFirstNames !== firstNames) {
         updateWidgetRef.current(widget.id, {
-          config: {
-            ...configRef.current,
-            firstNames: localFirstNames,
-          },
+          config: { firstNames: localFirstNames },
         });
       }
     }, 1000);
@@ -220,10 +224,7 @@ export const RandomSettings: React.FC<{ widget: WidgetData }> = ({
     const timer = setTimeout(() => {
       if (localLastNames !== lastNames) {
         updateWidgetRef.current(widget.id, {
-          config: {
-            ...configRef.current,
-            lastNames: localLastNames,
-          },
+          config: { lastNames: localLastNames },
         });
       }
     }, 1000);
@@ -250,7 +251,7 @@ export const RandomSettings: React.FC<{ widget: WidgetData }> = ({
         rosterMode={rosterMode}
         onModeChange={(mode) =>
           updateWidget(widget.id, {
-            config: { ...config, rosterMode: mode },
+            config: { rosterMode: mode },
           })
         }
       />
@@ -279,7 +280,7 @@ export const RandomSettings: React.FC<{ widget: WidgetData }> = ({
           checked={soundEnabled}
           onChange={() =>
             updateWidget(widget.id, {
-              config: { ...config, soundEnabled: !soundEnabled },
+              config: { soundEnabled: !soundEnabled },
             })
           }
           size="md"
@@ -308,7 +309,7 @@ export const RandomSettings: React.FC<{ widget: WidgetData }> = ({
             checked={autoStartTimer ?? false}
             onChange={() =>
               updateWidget(widget.id, {
-                config: { ...config, autoStartTimer: !autoStartTimer },
+                config: { autoStartTimer: !autoStartTimer },
               })
             }
             size="md"
@@ -348,7 +349,7 @@ export const RandomSettings: React.FC<{ widget: WidgetData }> = ({
       )}
 
       <div>
-        <label className="text-xxs  text-slate-400 uppercase tracking-widest mb-3 block">
+        <label className="text-xxs text-slate-400 uppercase tracking-widest mb-3 block">
           Operation Mode
         </label>
         <div className="grid grid-cols-4 gap-2">
@@ -358,7 +359,6 @@ export const RandomSettings: React.FC<{ widget: WidgetData }> = ({
               onClick={() =>
                 updateWidget(widget.id, {
                   config: {
-                    ...config,
                     mode: m.id,
                     lastResult: null,
                     jigsawHomeGroups: null,
@@ -374,7 +374,7 @@ export const RandomSettings: React.FC<{ widget: WidgetData }> = ({
               }`}
             >
               <m.icon className="w-5 h-5" />
-              <span className="text-xxxs  uppercase">{m.label}</span>
+              <span className="text-xxxs uppercase">{m.label}</span>
             </button>
           ))}
         </div>
@@ -382,7 +382,7 @@ export const RandomSettings: React.FC<{ widget: WidgetData }> = ({
 
       {mode === 'single' && (
         <div>
-          <label className="text-xxs  text-slate-400 uppercase tracking-widest mb-3 block">
+          <label className="text-xxs text-slate-400 uppercase tracking-widest mb-3 block">
             Animation Style
           </label>
           <div className="grid grid-cols-3 gap-2">
@@ -392,7 +392,6 @@ export const RandomSettings: React.FC<{ widget: WidgetData }> = ({
                 onClick={() =>
                   updateWidget(widget.id, {
                     config: {
-                      ...config,
                       visualStyle: s.id as 'flash' | 'slots' | 'wheel',
                     },
                   })
@@ -404,7 +403,7 @@ export const RandomSettings: React.FC<{ widget: WidgetData }> = ({
                 }`}
               >
                 <s.icon className="w-5 h-5" />
-                <span className="text-xxxs  uppercase">{s.label}</span>
+                <span className="text-xxxs uppercase">{s.label}</span>
               </button>
             ))}
           </div>
@@ -413,7 +412,7 @@ export const RandomSettings: React.FC<{ widget: WidgetData }> = ({
 
       {(mode === 'groups' || mode === 'jigsaw') && (
         <div className="p-4 bg-white border border-slate-100 rounded-2xl shadow-sm">
-          <label className="text-xxs  text-slate-400 uppercase tracking-widest mb-3 block flex items-center gap-2">
+          <label className="text-xxs text-slate-400 uppercase tracking-widest mb-3 block flex items-center gap-2">
             <Hash className="w-3 h-3" />{' '}
             {mode === 'jigsaw'
               ? t('widgets.random.homeGroupSize', {
@@ -428,17 +427,16 @@ export const RandomSettings: React.FC<{ widget: WidgetData }> = ({
               max="20"
               step="1"
               value={groupSize}
-              onChange={(e) =>
+              onChange={(e) => {
+                const next = parseInt(e.target.value, 10);
+                if (!Number.isFinite(next)) return;
                 updateWidget(widget.id, {
-                  config: {
-                    ...config,
-                    groupSize: parseInt(e.target.value),
-                  },
-                })
-              }
+                  config: { groupSize: next },
+                });
+              }}
               className="flex-1 accent-brand-blue-primary h-1.5 bg-slate-200 rounded-lg appearance-none cursor-pointer"
             />
-            <span className="w-10 text-center font-mono  text-slate-700 text-sm">
+            <span className="w-10 text-center font-mono text-slate-700 text-sm">
               {groupSize}
             </span>
           </div>
@@ -447,7 +445,7 @@ export const RandomSettings: React.FC<{ widget: WidgetData }> = ({
 
       {mode === 'jigsaw' && (
         <div className="p-4 bg-white border border-slate-100 rounded-2xl shadow-sm">
-          <label className="text-xxs  text-slate-400 uppercase tracking-widest mb-3 block flex items-center gap-2">
+          <label className="text-xxs text-slate-400 uppercase tracking-widest mb-3 block flex items-center gap-2">
             <Puzzle className="w-3 h-3" />{' '}
             {t('widgets.random.expertGroupCount', {
               defaultValue: 'Number of Expert Groups',
@@ -460,16 +458,16 @@ export const RandomSettings: React.FC<{ widget: WidgetData }> = ({
               max="20"
               step="1"
               value={numExpertGroups}
-              onChange={(e) =>
+              onChange={(e) => {
+                const next = parseInt(e.target.value, 10);
+                if (!Number.isFinite(next)) return;
                 updateWidget(widget.id, {
-                  config: {
-                    numExpertGroups: parseInt(e.target.value),
-                  },
-                })
-              }
+                  config: { numExpertGroups: next },
+                });
+              }}
               className="flex-1 accent-brand-blue-primary h-1.5 bg-slate-200 rounded-lg appearance-none cursor-pointer"
             />
-            <span className="w-10 text-center font-mono  text-slate-700 text-sm">
+            <span className="w-10 text-center font-mono text-slate-700 text-sm">
               {numExpertGroups}
             </span>
           </div>
@@ -502,7 +500,7 @@ export const RandomSettings: React.FC<{ widget: WidgetData }> = ({
 
           <div className="grid grid-cols-2 gap-3">
             <div>
-              <label className="text-xxs  text-slate-400 uppercase tracking-widest mb-2 block">
+              <label className="text-xxs text-slate-400 uppercase tracking-widest mb-2 block">
                 First Names
               </label>
               <textarea
@@ -516,10 +514,7 @@ export const RandomSettings: React.FC<{ widget: WidgetData }> = ({
                   }
                   if (localFirstNames !== firstNames) {
                     updateWidgetRef.current(widget.id, {
-                      config: {
-                        ...configRef.current,
-                        firstNames: localFirstNames,
-                      },
+                      config: { firstNames: localFirstNames },
                     });
                   }
                 }}
@@ -528,7 +523,7 @@ export const RandomSettings: React.FC<{ widget: WidgetData }> = ({
               />
             </div>
             <div>
-              <label className="text-xxs  text-slate-400 uppercase tracking-widest mb-2 block">
+              <label className="text-xxs text-slate-400 uppercase tracking-widest mb-2 block">
                 Last Names
               </label>
               <textarea
@@ -542,10 +537,7 @@ export const RandomSettings: React.FC<{ widget: WidgetData }> = ({
                   }
                   if (localLastNames !== lastNames) {
                     updateWidgetRef.current(widget.id, {
-                      config: {
-                        ...configRef.current,
-                        lastNames: localLastNames,
-                      },
+                      config: { lastNames: localLastNames },
                     });
                   }
                 }}
@@ -568,7 +560,6 @@ export const RandomSettings: React.FC<{ widget: WidgetData }> = ({
               if (confirmed) {
                 updateWidget(widget.id, {
                   config: {
-                    ...config,
                     firstNames: '',
                     lastNames: '',
                     lastResult: null,
@@ -577,7 +568,7 @@ export const RandomSettings: React.FC<{ widget: WidgetData }> = ({
                 });
               }
             }}
-            className="w-full py-3 flex items-center justify-center gap-2 text-red-500 text-xxs  uppercase tracking-widest hover:bg-red-50 rounded-xl transition-colors border-2 border-dashed border-red-100"
+            className="w-full py-3 flex items-center justify-center gap-2 text-red-500 text-xxs uppercase tracking-widest hover:bg-red-50 rounded-xl transition-colors border-2 border-dashed border-red-100"
           >
             <Trash2 className="w-4 h-4" /> Clear Custom Names
           </button>

--- a/components/widgets/random/RandomSettings.tsx
+++ b/components/widgets/random/RandomSettings.tsx
@@ -463,7 +463,6 @@ export const RandomSettings: React.FC<{ widget: WidgetData }> = ({
               onChange={(e) =>
                 updateWidget(widget.id, {
                   config: {
-                    ...config,
                     numExpertGroups: parseInt(e.target.value),
                   },
                 })

--- a/components/widgets/random/RandomWidget.tsx
+++ b/components/widgets/random/RandomWidget.tsx
@@ -1118,7 +1118,9 @@ export const RandomWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
                             className="font-bold"
                             style={{ fontSize: 'min(14px, 3.5cqmin)' }}
                           >
-                            Click Randomize to Shuffle
+                            {t('widgets.random.shuffleHint', {
+                              defaultValue: 'Click Randomize to Shuffle',
+                            })}
                           </span>
                         </div>
                       );

--- a/components/widgets/random/RandomWidget.tsx
+++ b/components/widgets/random/RandomWidget.tsx
@@ -280,13 +280,15 @@ export const RandomWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
     Math.max(2, Math.ceil(estimatedHomeGroupCount / 2));
 
   const setGroupSize = (next: number) => {
+    // updateWidget merges partial config into existing state — don't spread
+    // ...config here, since it's a closure-captured snapshot that may be stale.
     updateWidget(widget.id, {
-      config: { ...config, groupSize: next } as WidgetConfig,
+      config: { groupSize: next } as WidgetConfig,
     });
   };
   const setNumExpertGroups = (next: number) => {
     updateWidget(widget.id, {
-      config: { ...config, numExpertGroups: next } as WidgetConfig,
+      config: { numExpertGroups: next } as WidgetConfig,
     });
   };
 

--- a/components/widgets/random/RandomWidget.tsx
+++ b/components/widgets/random/RandomWidget.tsx
@@ -350,7 +350,7 @@ export const RandomWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
   const setJigsawView = (view: 'home' | 'expert') => {
     if (jigsawView === view) return;
     updateWidget(widget.id, {
-      config: { ...config, jigsawView: view },
+      config: { jigsawView: view },
     });
   };
 
@@ -706,6 +706,23 @@ export const RandomWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
             t('widgets.random.jigsawNeedsMultipleGroups', {
               defaultValue:
                 'Jigsaw needs at least 2 home groups — lower the group size or add more students.',
+            }),
+            'warning'
+          );
+        } else if (
+          configNumExpertGroups != null &&
+          expertGroups.length < configNumExpertGroups
+        ) {
+          // The user explicitly set numExpertGroups too high for this class
+          // size — the algorithm filtered empty buckets / merged singletons
+          // and produced fewer groups than requested. Surface this so the
+          // stepper value doesn't silently disagree with the visible result.
+          addToast(
+            t('widgets.random.expertGroupCountReduced', {
+              count: expertGroups.length,
+              requested: configNumExpertGroups,
+              defaultValue:
+                'Only {{count}} expert groups fit this class — lower the Number of Expert Groups setting or add more students.',
             }),
             'warning'
           );
@@ -1111,10 +1128,13 @@ export const RandomWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
                         className="flex-1 overflow-y-auto overflow-x-hidden w-full"
                         style={{
                           // CSS multi-column layout: browser fits as many ~200px
-                          // columns as the container allows. column-fill: balance
-                          // (the default) distributes items evenly across the
-                          // chosen column count, and vertical overflow scrolls.
+                          // columns as the container allows. column-fill: auto
+                          // fills column 1 top-to-bottom, then column 2, etc. —
+                          // the column-first reading order we want for a numbered
+                          // list. Vertical overflow scrolls; breakInside on each
+                          // row keeps cards intact across column boundaries.
                           columnWidth: 'clamp(160px, 36cqmin, 240px)',
+                          columnFill: 'auto',
                           columnGap: 'clamp(6px, 1.5cqmin, 12px)',
                           padding: 'clamp(2px, 1cqmin, 6px) 0',
                         }}

--- a/components/widgets/random/RandomWidget.tsx
+++ b/components/widgets/random/RandomWidget.tsx
@@ -42,6 +42,7 @@ import { RandomWheel } from './RandomWheel';
 import { RandomSlots } from './RandomSlots';
 import { RandomFlash } from './RandomFlash';
 import { RandomGroups } from './RandomGroups';
+import { GroupSizeStepper } from './GroupSizeStepper';
 
 import { WidgetLayout } from '../WidgetLayout';
 
@@ -103,6 +104,7 @@ export const RandomWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
     jigsawHomeGroups,
     jigsawExpertGroups,
     jigsawView = 'home',
+    numExpertGroups: configNumExpertGroups,
   } = config;
   // Classic jigsaw is "4 home groups of 4 → 4 expert groups of 4", so default
   // to 4 in jigsaw mode when the user hasn't explicitly set a size. Other
@@ -265,6 +267,28 @@ export const RandomWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
     }
     return combined;
   }, [firstNames, lastNames, activeRoster, rosterMode, presentClassStudents]);
+
+  // Inline stepper display: mirror the call-site default so the on-widget
+  // controls show what Pick will actually use until the user sets explicit
+  // values. groupSize already has its own default applied above.
+  const estimatedHomeGroupCount = Math.max(
+    1,
+    Math.ceil(students.length / Math.max(1, groupSize))
+  );
+  const displayNumExpertGroups =
+    configNumExpertGroups ??
+    Math.max(2, Math.ceil(estimatedHomeGroupCount / 2));
+
+  const setGroupSize = (next: number) => {
+    updateWidget(widget.id, {
+      config: { ...config, groupSize: next } as WidgetConfig,
+    });
+  };
+  const setNumExpertGroups = (next: number) => {
+    updateWidget(widget.id, {
+      config: { ...config, numExpertGroups: next } as WidgetConfig,
+    });
+  };
 
   const absentCount = useMemo(() => {
     if (rosterMode !== 'class' || !activeRoster) return 0;
@@ -664,7 +688,13 @@ export const RandomWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
         } else {
           homeGroups = makeNameGroups(students, groupSize);
         }
-        const expertGroups = makeJigsawExpertGroups(homeGroups);
+        const numExpertGroups =
+          configNumExpertGroups ??
+          Math.max(2, Math.ceil(homeGroups.length / 2));
+        const expertGroups = makeJigsawExpertGroups(
+          homeGroups,
+          numExpertGroups
+        );
 
         // With < 2 home groups, "expert groups" degenerate into 1-person
         // singletons (each has nobody to compare notes with). Surface a toast
@@ -1042,70 +1072,85 @@ export const RandomWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
                 style={{ padding: '0 min(8px, 2cqmin)' }}
               >
                 {mode === 'shuffle' ? (
-                  <div
-                    className="flex-1 overflow-hidden w-full flex flex-col min-h-0"
-                    style={{
-                      padding: 'min(4px, 1cqmin) 0',
-                      gap: 'min(4px, 1cqmin)',
-                    }}
-                  >
-                    {(Array.isArray(displayResult) &&
-                    (displayResult.length === 0 ||
-                      !Array.isArray(displayResult[0]))
-                      ? (displayResult as string[])
-                      : []
-                    ).map((name: string, i: number) => (
-                      <div
-                        key={i}
-                        className="flex items-center bg-white rounded-xl border border-slate-200 shadow-sm min-h-0 overflow-hidden"
-                        style={{
-                          flex: '1 1 0',
-                          gap: 'min(12px, 4cqmin)',
-                          padding: '0 min(12px, 3cqmin)',
-                          containerType: 'size',
-                        }}
-                      >
-                        <span
-                          className="font-mono font-black text-slate-400 flex-shrink-0"
-                          style={{ fontSize: 'clamp(12px, 25cqmin, 28px)' }}
-                        >
-                          {i + 1}
-                        </span>
-                        <span
-                          className="leading-none font-bold text-slate-700 truncate min-w-0"
-                          style={{ fontSize: 'clamp(16px, 60cqmin, 80px)' }}
-                        >
-                          {name}
-                        </span>
-                      </div>
-                    ))}
-                    {(!displayResult ||
-                      !Array.isArray(displayResult) ||
-                      (displayResult.length > 0 &&
-                        Array.isArray(displayResult[0]))) && (
-                      <div
-                        className="flex-1 flex flex-col items-center justify-center text-slate-300 italic"
-                        style={{
-                          padding: 'min(40px, 8cqmin) 0',
-                          gap: 'min(8px, 2cqmin)',
-                        }}
-                      >
-                        <Layers
-                          className="opacity-20"
+                  (() => {
+                    const shuffleNames =
+                      Array.isArray(displayResult) &&
+                      (displayResult.length === 0 ||
+                        !Array.isArray(displayResult[0]))
+                        ? (displayResult as string[])
+                        : [];
+                    if (shuffleNames.length === 0) {
+                      return (
+                        <div
+                          className="flex-1 flex flex-col items-center justify-center text-slate-300 italic"
                           style={{
-                            width: 'min(32px, 8cqmin)',
-                            height: 'min(32px, 8cqmin)',
+                            padding: 'min(40px, 8cqmin) 0',
+                            gap: 'min(8px, 2cqmin)',
                           }}
-                        />
-                        <span
-                          className="font-bold"
-                          style={{ fontSize: 'min(14px, 3.5cqmin)' }}
                         >
-                          Click Randomize to Shuffle
-                        </span>
+                          <Layers
+                            className="opacity-20"
+                            style={{
+                              width: 'min(32px, 8cqmin)',
+                              height: 'min(32px, 8cqmin)',
+                            }}
+                          />
+                          <span
+                            className="font-bold"
+                            style={{ fontSize: 'min(14px, 3.5cqmin)' }}
+                          >
+                            Click Randomize to Shuffle
+                          </span>
+                        </div>
+                      );
+                    }
+                    return (
+                      <div
+                        className="flex-1 overflow-y-auto overflow-x-hidden w-full"
+                        style={{
+                          // CSS multi-column layout: browser fits as many ~200px
+                          // columns as the container allows. column-fill: balance
+                          // (the default) distributes items evenly across the
+                          // chosen column count, and vertical overflow scrolls.
+                          columnWidth: 'clamp(160px, 36cqmin, 240px)',
+                          columnGap: 'clamp(6px, 1.5cqmin, 12px)',
+                          padding: 'clamp(2px, 1cqmin, 6px) 0',
+                        }}
+                      >
+                        {shuffleNames.map((name: string, i: number) => (
+                          <div
+                            key={i}
+                            className="flex items-center bg-white rounded-xl border border-slate-200 shadow-sm overflow-hidden"
+                            style={{
+                              gap: 'clamp(8px, 2.5cqmin, 14px)',
+                              padding:
+                                'clamp(4px, 1.2cqmin, 10px) clamp(10px, 2.5cqmin, 16px)',
+                              marginBottom: 'clamp(3px, 1cqmin, 8px)',
+                              minHeight: 'clamp(28px, 6cqmin, 48px)',
+                              breakInside: 'avoid',
+                            }}
+                          >
+                            <span
+                              className="font-mono font-black text-slate-400 flex-shrink-0 tabular-nums"
+                              style={{
+                                fontSize: 'clamp(11px, 3.2cqmin, 18px)',
+                              }}
+                            >
+                              {i + 1}
+                            </span>
+                            <span
+                              className="leading-tight font-bold text-slate-700 truncate min-w-0"
+                              style={{
+                                fontSize: 'clamp(13px, 4cqmin, 22px)',
+                              }}
+                            >
+                              {name}
+                            </span>
+                          </div>
+                        ))}
                       </div>
-                    )}
-                  </div>
+                    );
+                  })()
                 ) : (
                   <RandomGroups
                     displayResult={displayResult}
@@ -1126,6 +1171,16 @@ export const RandomWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
           >
             {mode === 'jigsaw' && hasJigsawGroups && (
               <>
+                <GroupSizeStepper
+                  value={displayNumExpertGroups}
+                  onChange={setNumExpertGroups}
+                  label={t('widgets.random.expertLabelShort', {
+                    defaultValue: 'EXPERT',
+                  })}
+                  title={t('widgets.random.expertGroupCount', {
+                    defaultValue: 'Number of Expert Groups',
+                  })}
+                />
                 <Button
                   variant={jigsawView === 'expert' ? 'primary' : 'secondary'}
                   shape="pill"
@@ -1160,6 +1215,16 @@ export const RandomWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
                     })}
                   </span>
                 </Button>
+                <GroupSizeStepper
+                  value={groupSize}
+                  onChange={setGroupSize}
+                  label={t('widgets.random.homeLabelShort', {
+                    defaultValue: 'HOME',
+                  })}
+                  title={t('widgets.random.homeGroupSize', {
+                    defaultValue: 'Home Group Size',
+                  })}
+                />
                 <Button
                   variant={jigsawView === 'home' ? 'primary' : 'secondary'}
                   shape="pill"
@@ -1226,6 +1291,39 @@ export const RandomWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
                   }
                 />
               )}
+            {mode === 'groups' && (
+              <GroupSizeStepper
+                value={groupSize}
+                onChange={setGroupSize}
+                title={t('widgets.random.groupSize', {
+                  defaultValue: 'Group Size',
+                })}
+              />
+            )}
+            {mode === 'jigsaw' && !hasJigsawGroups && (
+              <>
+                <GroupSizeStepper
+                  value={groupSize}
+                  onChange={setGroupSize}
+                  label={t('widgets.random.homeLabelShort', {
+                    defaultValue: 'HOME',
+                  })}
+                  title={t('widgets.random.homeGroupSize', {
+                    defaultValue: 'Home Group Size',
+                  })}
+                />
+                <GroupSizeStepper
+                  value={displayNumExpertGroups}
+                  onChange={setNumExpertGroups}
+                  label={t('widgets.random.expertLabelShort', {
+                    defaultValue: 'EXPERT',
+                  })}
+                  title={t('widgets.random.expertGroupCount', {
+                    defaultValue: 'Number of Expert Groups',
+                  })}
+                />
+              </>
+            )}
             <Button
               variant="hero"
               size="md"

--- a/components/widgets/random/groupMaker.test.ts
+++ b/components/widgets/random/groupMaker.test.ts
@@ -9,10 +9,14 @@ const groupOf = (...names: string[]): RandomGroup => ({
 
 describe('makeJigsawExpertGroups', () => {
   it('returns an empty array when no home groups are supplied', () => {
-    expect(makeJigsawExpertGroups([])).toEqual([]);
+    expect(makeJigsawExpertGroups([], 4)).toEqual([]);
   });
 
-  it('transposes evenly-sized home groups (position N becomes expert N)', () => {
+  it('produces K expert groups from evenly-sized home groups (K = home size)', () => {
+    // 4 home groups of 3 with K=3. The round-robin with rotation still places
+    // exactly one member from each home group into each expert group, which
+    // is the classic jigsaw invariant — even though the per-position mapping
+    // is reshuffled by the offset.
     const home = [
       groupOf('A1', 'A2', 'A3'),
       groupOf('B1', 'B2', 'B3'),
@@ -20,63 +24,82 @@ describe('makeJigsawExpertGroups', () => {
       groupOf('D1', 'D2', 'D3'),
     ];
 
-    const expert = makeJigsawExpertGroups(home);
+    const expert = makeJigsawExpertGroups(home, 3);
 
-    expect(expert.map((g) => g.names)).toEqual([
-      ['A1', 'B1', 'C1', 'D1'],
-      ['A2', 'B2', 'C2', 'D2'],
-      ['A3', 'B3', 'C3', 'D3'],
-    ]);
+    expect(expert.length).toBe(3);
+    // Each expert group should be size 4 and have one student from each home.
+    for (const e of expert) {
+      expect(e.names.length).toBe(4);
+      const prefixes = e.names.map((n) => n[0]).sort();
+      expect(prefixes).toEqual(['A', 'B', 'C', 'D']);
+    }
+    // All 12 students accounted for exactly once.
+    expect(expert.flatMap((g) => g.names).sort()).toEqual(
+      [
+        'A1',
+        'A2',
+        'A3',
+        'B1',
+        'B2',
+        'B3',
+        'C1',
+        'C2',
+        'C3',
+        'D1',
+        'D2',
+        'D3',
+      ].sort()
+    );
   });
 
-  it('skips missing positions when home groups are uneven', () => {
-    // 11 students into home groups of 4 → sizes [4, 4, 3]. Position 4 only
-    // exists in the first two home groups.
+  it('spreads uneven home groups across K expert groups', () => {
+    // 11 students into home groups of 4 → sizes [4, 4, 3]. With K=4 every
+    // student lands in an expert group; the rotation prevents any single
+    // expert from absorbing all the "extra" wrap-around students.
     const home = [
       groupOf('A1', 'A2', 'A3', 'A4'),
       groupOf('B1', 'B2', 'B3', 'B4'),
       groupOf('C1', 'C2', 'C3'),
     ];
 
-    const expert = makeJigsawExpertGroups(home);
+    const expert = makeJigsawExpertGroups(home, 4);
 
-    expect(expert.map((g) => g.names)).toEqual([
-      ['A1', 'B1', 'C1'],
-      ['A2', 'B2', 'C2'],
-      ['A3', 'B3', 'C3'],
-      ['A4', 'B4'],
-    ]);
+    // All 11 students preserved exactly once.
+    expect(expert.flatMap((g) => g.names).sort()).toEqual(
+      ['A1', 'A2', 'A3', 'A4', 'B1', 'B2', 'B3', 'B4', 'C1', 'C2', 'C3'].sort()
+    );
+    // Sizes should be 3 or 2 (no expert group ends up empty or oversized).
+    for (const e of expert) {
+      expect(e.names.length).toBeGreaterThanOrEqual(2);
+      expect(e.names.length).toBeLessThanOrEqual(3);
+    }
   });
 
-  it('drops expert positions that would have zero members', () => {
-    // Empty home groups in the input must not produce empty expert groups.
-    // Here pos 1 only has A2 (singleton) — orphan merging then folds A2 into
-    // the only larger expert group, ['A1', 'C1'].
+  it('drops empty buckets when K exceeds the available students', () => {
+    // Single home group of size 2 with K=2 produces all-singleton experts,
+    // which then collapse via orphan merge into one balanced group.
     const home = [groupOf('A1', 'A2'), groupOf(), groupOf('C1')];
 
-    const expert = makeJigsawExpertGroups(home);
+    const expert = makeJigsawExpertGroups(home, 2);
 
-    expect(expert.map((g) => g.names.sort())).toEqual([
-      ['A1', 'A2', 'C1'].sort(),
-    ]);
+    // All 3 students preserved.
+    expect(expert.flatMap((g) => g.names).sort()).toEqual(
+      ['A1', 'A2', 'C1'].sort()
+    );
+    // No empty groups emitted.
+    expect(expert.every((g) => g.names.length > 0)).toBe(true);
   });
 
   it('merges orphan singletons into the smallest non-singleton expert group', () => {
-    // Home group sizes 4 / 1 / 2 ⇒ raw transpose:
-    //   pos 0: A1, B1, C1   (size 3)
-    //   pos 1: A2, C2       (size 2)
-    //   pos 2: A3           (size 1, orphan)
-    //   pos 3: A4           (size 1, orphan)
-    // After merging each orphan into the smallest non-singleton:
-    //   A3 → smallest = [A2, C2] → [A2, C2, A3] (size 3)
-    //   A4 → smallest now ties at size 3 — picks one of them
+    // Home group sizes 4 / 1 / 2 with K=4. The round-robin will inevitably
+    // create at least one expert group of size 1; orphan merge folds it in.
     const home = [
       groupOf('A1', 'A2', 'A3', 'A4'),
       groupOf('B1'),
       groupOf('C1', 'C2'),
     ];
 
-    const expert = makeJigsawExpertGroups(home);
+    const expert = makeJigsawExpertGroups(home, 4);
 
     // No singletons survive
     expect(expert.every((g) => g.names.length >= 2)).toBe(true);
@@ -87,20 +110,74 @@ describe('makeJigsawExpertGroups', () => {
   });
 
   it('leaves all-singleton expert groups alone (degenerate single-home case)', () => {
-    // Single home group of size N transposes to N singleton expert groups.
-    // There is no larger expert group to fold orphans into, so all stay as
-    // singletons; the caller surfaces a degenerate-jigsaw warning toast
-    // rather than silently merging them all into one big group.
+    // Single home group of size 3 with K=3 produces all-singleton expert
+    // groups; with no larger expert group to fold orphans into, they stay
+    // as singletons. The caller surfaces a degenerate-jigsaw warning toast.
     const home = [groupOf('A', 'B', 'C')];
 
-    const expert = makeJigsawExpertGroups(home);
+    const expert = makeJigsawExpertGroups(home, 3);
 
-    expect(expert.map((g) => g.names)).toEqual([['A'], ['B'], ['C']]);
+    expect(expert.length).toBe(3);
+    expect(expert.every((g) => g.names.length === 1)).toBe(true);
+    expect(expert.flatMap((g) => g.names).sort()).toEqual(['A', 'B', 'C']);
+  });
+
+  it('balances K < max home group size by wrapping with rotation', () => {
+    // 6 home groups of 4 with K=3 — the "default jigsaw" scenario for a
+    // 24-student class. Each expert group should end up the same size (8),
+    // with members drawn from every home group (rotation spreads the
+    // wrap-around evenly so no expert is overloaded).
+    const home = [
+      groupOf('A1', 'A2', 'A3', 'A4'),
+      groupOf('B1', 'B2', 'B3', 'B4'),
+      groupOf('C1', 'C2', 'C3', 'C4'),
+      groupOf('D1', 'D2', 'D3', 'D4'),
+      groupOf('E1', 'E2', 'E3', 'E4'),
+      groupOf('F1', 'F2', 'F3', 'F4'),
+    ];
+
+    const expert = makeJigsawExpertGroups(home, 3);
+
+    expect(expert.length).toBe(3);
+    expect(expert.every((g) => g.names.length === 8)).toBe(true);
+    // Every home group should be represented in every expert group.
+    for (const e of expert) {
+      const prefixes = new Set(e.names.map((n) => n[0]));
+      expect(prefixes).toEqual(new Set(['A', 'B', 'C', 'D', 'E', 'F']));
+    }
+    // All 24 students present exactly once.
+    expect(expert.flatMap((g) => g.names).sort().length).toBe(24);
+  });
+
+  it('handles K > max home group size by spreading contributions', () => {
+    // 2 home groups of 2 with K=4 — more experts than students per home.
+    // Each home group can only fill 2 of the 4 expert positions; rotation
+    // ensures the contributions don't pile up in the same experts.
+    const home = [groupOf('A1', 'A2'), groupOf('B1', 'B2')];
+
+    const expert = makeJigsawExpertGroups(home, 4);
+
+    // 4 students total across at most 4 experts. After orphan merge no
+    // singleton survives, so the count of expert groups drops to <= 2.
+    expect(expert.flatMap((g) => g.names).sort()).toEqual(
+      ['A1', 'A2', 'B1', 'B2'].sort()
+    );
+    expect(expert.every((g) => g.names.length >= 2)).toBe(true);
+  });
+
+  it('clamps numExpertGroups to at least 1', () => {
+    const home = [groupOf('A1', 'A2'), groupOf('B1', 'B2')];
+
+    const expert = makeJigsawExpertGroups(home, 0);
+
+    // K=0 is invalid; algorithm should fall back to 1 expert group.
+    expect(expert.length).toBe(1);
+    expect(expert[0].names.sort()).toEqual(['A1', 'A2', 'B1', 'B2'].sort());
   });
 
   it('assigns a fresh id to each generated expert group', () => {
     const home = [groupOf('A1', 'A2'), groupOf('B1', 'B2')];
-    const expert = makeJigsawExpertGroups(home);
+    const expert = makeJigsawExpertGroups(home, 2);
     const ids = expert.map((g) => g.id);
 
     expect(ids.every((id) => typeof id === 'string' && id.length > 0)).toBe(

--- a/components/widgets/random/groupMaker.test.ts
+++ b/components/widgets/random/groupMaker.test.ts
@@ -175,6 +175,18 @@ describe('makeJigsawExpertGroups', () => {
     expect(expert[0].names.sort()).toEqual(['A1', 'A2', 'B1', 'B2'].sort());
   });
 
+  it('treats NaN numExpertGroups as 1 (no silent empty output)', () => {
+    const home = [groupOf('A1', 'A2'), groupOf('B1', 'B2')];
+
+    const expert = makeJigsawExpertGroups(home, NaN);
+
+    // Without the Number.isFinite guard, Math.max(1, NaN) returns NaN and
+    // Array.from({length: NaN}) returns [] — yielding zero expert groups
+    // silently. Verify we land on the K=1 fallback instead.
+    expect(expert.length).toBe(1);
+    expect(expert[0].names.sort()).toEqual(['A1', 'A2', 'B1', 'B2'].sort());
+  });
+
   it('assigns a fresh id to each generated expert group', () => {
     const home = [groupOf('A1', 'A2'), groupOf('B1', 'B2')];
     const expert = makeJigsawExpertGroups(home, 2);

--- a/components/widgets/random/groupMaker.ts
+++ b/components/widgets/random/groupMaker.ts
@@ -88,7 +88,10 @@ export function makeJigsawExpertGroups(
   numExpertGroups: number
 ): RandomGroup[] {
   if (homeGroups.length === 0) return [];
-  const k = Math.max(1, Math.floor(numExpertGroups));
+  // Math.max(1, NaN) returns NaN, which then makes Array.from({length: NaN})
+  // return [], silently yielding zero expert groups. Guard explicitly.
+  const safeK = Number.isFinite(numExpertGroups) ? numExpertGroups : 1;
+  const k = Math.max(1, Math.floor(safeK));
 
   const buckets: string[][] = Array.from({ length: k }, () => []);
   let offset = 0;

--- a/components/widgets/random/groupMaker.ts
+++ b/components/widgets/random/groupMaker.ts
@@ -60,34 +60,48 @@ export function makeRestrictedGroups(
 }
 
 /**
- * Build expert groups for the Jigsaw cooperative-learning structure: take
- * position N from each home group and combine those students into expert
- * group N. Home groups can be uneven; missing positions are simply skipped.
+ * Build expert groups for the Jigsaw cooperative-learning structure.
  *
- * If the transpose produces a size-1 "expert group" (no peer to compare
- * notes with) AND a larger expert group exists, merge the orphan into the
+ * Distributes each home group's members across `numExpertGroups` buckets
+ * via round-robin assignment with a rotating offset per home group. The
+ * offset rotation prevents any single expert group from consistently
+ * absorbing the "extra" student when numExpertGroups does not evenly
+ * divide the home group size — collisions get spread evenly instead.
+ *
+ * When `numExpertGroups` equals the home group size this reduces to a
+ * straight transpose (position N from each home group → expert N), which
+ * is the classic jigsaw structure. When it is smaller, expert groups grow
+ * by absorbing wrapped positions; when larger, some expert groups receive
+ * fewer members.
+ *
+ * Home groups are shuffled at creation, so positional assignment is
+ * already random — no extra shuffle is needed here.
+ *
+ * If the result contains a size-1 "expert group" (no peer to compare notes
+ * with) AND a larger expert group exists, the orphan is merged into the
  * smallest larger group so every expert has at least one peer. When every
  * expert group is size 1 the caller's degenerate-jigsaw warning toast
  * handles communication; we don't artificially merge in that case.
  */
 export function makeJigsawExpertGroups(
-  homeGroups: RandomGroup[]
+  homeGroups: RandomGroup[],
+  numExpertGroups: number
 ): RandomGroup[] {
   if (homeGroups.length === 0) return [];
-  const maxSize = homeGroups.reduce(
-    (max, g) => Math.max(max, g.names.length),
-    0
-  );
-  const expertGroups: RandomGroup[] = [];
-  for (let pos = 0; pos < maxSize; pos++) {
-    const names: string[] = [];
-    for (const home of homeGroups) {
-      if (pos < home.names.length) names.push(home.names[pos]);
+  const k = Math.max(1, Math.floor(numExpertGroups));
+
+  const buckets: string[][] = Array.from({ length: k }, () => []);
+  let offset = 0;
+  for (const home of homeGroups) {
+    for (let i = 0; i < home.names.length; i++) {
+      buckets[(i + offset) % k].push(home.names[i]);
     }
-    if (names.length > 0) {
-      expertGroups.push({ id: crypto.randomUUID(), names });
-    }
+    offset = (offset + 1) % k;
   }
+
+  const expertGroups: RandomGroup[] = buckets
+    .filter((names) => names.length > 0)
+    .map((names) => ({ id: crypto.randomUUID(), names }));
 
   const balanced = expertGroups.filter((g) => g.names.length > 1);
   const orphans = expertGroups.filter((g) => g.names.length === 1);

--- a/locales/en.json
+++ b/locales/en.json
@@ -644,6 +644,9 @@
       "launchHomeGroupHint": "Return to home groups",
       "groupSize": "Group Size",
       "homeGroupSize": "Home Group Size",
+      "expertGroupCount": "Number of Expert Groups",
+      "homeLabelShort": "HOME",
+      "expertLabelShort": "EXPERT",
       "jigsawNeedsMultipleGroups": "Jigsaw needs at least 2 home groups — lower the group size or add more students.",
       "absent": {
         "buttonLabel": "Mark absent students",

--- a/locales/en.json
+++ b/locales/en.json
@@ -645,6 +645,7 @@
       "groupSize": "Group Size",
       "homeGroupSize": "Home Group Size",
       "expertGroupCount": "Number of Expert Groups",
+      "expertGroupCountReduced": "Only {{count}} expert groups fit this class — lower the Number of Expert Groups setting or add more students.",
       "homeLabelShort": "HOME",
       "expertLabelShort": "EXPERT",
       "jigsawNeedsMultipleGroups": "Jigsaw needs at least 2 home groups — lower the group size or add more students.",

--- a/locales/en.json
+++ b/locales/en.json
@@ -648,6 +648,9 @@
       "expertGroupCountReduced": "Only {{count}} expert groups fit this class — lower the Number of Expert Groups setting or add more students.",
       "homeLabelShort": "HOME",
       "expertLabelShort": "EXPERT",
+      "shuffleHint": "Click Randomize to Shuffle",
+      "stepperDecrease": "Decrease {{name}}",
+      "stepperIncrease": "Increase {{name}}",
       "jigsawNeedsMultipleGroups": "Jigsaw needs at least 2 home groups — lower the group size or add more students.",
       "absent": {
         "buttonLabel": "Mark absent students",

--- a/types.ts
+++ b/types.ts
@@ -830,7 +830,8 @@ export interface RandomConfig {
   /** Jigsaw mode: which view is currently shown on the front face. */
   jigsawView?: 'home' | 'expert';
   /** Jigsaw mode: explicit number of expert groups. When unset, defaults to
-   *  ceil(numHomeGroups / 2) — i.e. "2 home groups per expert group". */
+   *  max(2, ceil(numHomeGroups / 2)) — i.e. "2 home groups per expert group",
+   *  clamped to a minimum of 2 to match the settings/stepper slider range. */
   numExpertGroups?: number;
 }
 

--- a/types.ts
+++ b/types.ts
@@ -824,11 +824,14 @@ export interface RandomConfig {
   externalTrigger?: number;
   /** Jigsaw mode: original home groups (each student's "home base"). */
   jigsawHomeGroups?: RandomGroup[] | null;
-  /** Jigsaw mode: expert groups derived by transposing home groups
-   *  (position N from each home group becomes expert group N). */
+  /** Jigsaw mode: expert groups derived from home groups via round-robin
+   *  assignment with rotating offset across `numExpertGroups` buckets. */
   jigsawExpertGroups?: RandomGroup[] | null;
   /** Jigsaw mode: which view is currently shown on the front face. */
   jigsawView?: 'home' | 'expert';
+  /** Jigsaw mode: explicit number of expert groups. When unset, defaults to
+   *  ceil(numHomeGroups / 2) — i.e. "2 home groups per expert group". */
+  numExpertGroups?: number;
 }
 
 export interface DiceConfig {


### PR DESCRIPTION
## Summary

Three usability fixes for the Randomizer widget's groups / jigsaw / shuffle variations.

### 1. Independent expert-group control for jigsaw
Previously, expert-group count was mathematically locked to home-group size via the transpose algorithm (`groupSize=4` → always 4 expert groups, regardless of class size). Teachers couldn't change one without the other.

- New optional `numExpertGroups` field on `RandomConfig` (defaults to `max(2, ceil(numHomeGroups / 2))` — i.e. "2 home groups per expert group").
- `makeJigsawExpertGroups` rewritten to use **round-robin assignment with rotating offset** across `K` buckets. When `K == max(homeGroupSize)` it produces classic jigsaw structure (one student per home group in each expert group); when `K < homeGroupSize` the offset rotation spreads wrap-around students evenly so no expert group is overloaded.
- New "Number of Expert Groups" slider in the settings panel, gated on jigsaw mode only.

### 2. Inline +/− steppers on the widget face
Teachers no longer have to flip → settings → slider → flip back just to bump group size.

- New `GroupSizeStepper` component: compact `[−] value [+]` control with optional small label, container-query sizing, disabled bounds.
- **Groups mode**: one stepper inline with Randomize.
- **Jigsaw mode** (post-pick): expert stepper paired with "Launch Jigsaw", home stepper paired with "Launch Home Group".
- **Jigsaw mode** (pre-pick): both steppers next to Randomize.
- Settings-panel sliders are retained for precise entry.

### 3. Multi-column shuffle layout
Single-column shuffle became illegible above ~10 students because each row shrank to fit. Now uses CSS multi-columns:

- `column-width: clamp(160px, 36cqmin, 240px)` → browser auto-fits as many columns as the widget allows.
- `column-fill: balance` distributes items evenly column-first (1–N down column 1, then N+1 in column 2, etc.).
- Minimum row height keeps text legible; vertical scroll when even one column overflows.

## Files

- New: `components/widgets/random/GroupSizeStepper.tsx`
- Updated: `RandomWidget.tsx`, `RandomSettings.tsx`, `groupMaker.ts`, `groupMaker.test.ts`, `types.ts`, `locales/en.json`

## Test plan

- [x] `pnpm run type-check` clean
- [x] `pnpm run lint` clean (`--max-warnings 0`)
- [x] `pnpm vitest run components/widgets/random/` → 27/27 pass (groupMaker + RandomWidget + RandomSlots + RandomWheel)
- [x] `pnpm run build` clean
- [ ] Manual: switch a Randomizer to Jigsaw with a ~24-student roster, verify default expert-group count shows **3** in both the on-widget stepper and the settings slider
- [ ] Manual: tap +/− on each stepper, verify value persists across Randomize and page reload
- [ ] Manual: with 6 home groups, slide expert count to 3 then Randomize, verify 3 expert groups of ~8 each — each expert group should contain members from all 6 home groups
- [ ] Manual: switch to Shuffle with a 30+ student roster, resize widget from narrow (1 column, vertical scroll) → wide (multi-column, no scroll if it fits) — confirm numbered count stays beside each name and reads column-first
- [ ] Manual: confirm no visual regressions in single-pick / wheel / slots variants

## Notes

- Memory says `feature → dev-paul` is fine to squash-merge, so this is targeted at `dev-paul` (not `main`) and squash is OK.
- Browser preview verification could not be completed in the sandbox (auth bypass requires a real Firebase backend); the items above marked `[ ]` need a quick eyeballing on a real dev deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)