### PR TITLE
feat(student): teacher Preview button for student URLs (?preview=1)

### DIFF
--- a/components/quiz/QuizStudentApp.tsx
+++ b/components/quiz/QuizStudentApp.tsx
@@ -75,13 +75,7 @@ import {
 // ─── Root component ───────────────────────────────────────────────────────────
 
 export const QuizStudentApp: React.FC = () => {
-  // `?preview=1` — teachers verifying the student URL from QuizLiveMonitor's
-  // Preview button. Render a non-functional lobby preview and skip auth init
-  // so the teacher's signed-in session in other tabs isn't replaced by
-  // `signInAnonymously` (which would cascade through cross-tab broadcast and
-  // a `studentRole: true` token contaminating the SSO auto-join below). The
-  // hook also strips the flag from the URL bar so a teacher copying the URL
-  // from the address bar gets the real student URL.
+  // preview mode — see hooks/usePreviewMode
   const previewMode = usePreviewMode();
 
   const [authReady, setAuthReady] = useState(false);
@@ -149,10 +143,10 @@ export const QuizStudentApp: React.FC = () => {
  * verify what students will see without their Firebase Auth session being
  * touched by `signInAnonymously` or the SSO auto-join path. */
 const QuizPreviewLobby: React.FC = () => {
-  const urlCode = useMemo(() => {
-    if (typeof window === 'undefined') return '';
-    return new URLSearchParams(window.location.search).get('code') ?? '';
-  }, []);
+  const urlCode =
+    typeof window === 'undefined'
+      ? ''
+      : (new URLSearchParams(window.location.search).get('code') ?? '');
 
   return (
     <div className="min-h-screen bg-slate-900 flex flex-col">

--- a/components/quiz/QuizStudentApp.tsx
+++ b/components/quiz/QuizStudentApp.tsx
@@ -167,23 +167,26 @@ const QuizPreviewLobby: React.FC = () => {
             Enter the code and your PIN from your teacher.
           </p>
 
-          <div className="space-y-4">
+          <div className="space-y-4" aria-hidden="true">
             <input
               type="text"
               value={urlCode}
               readOnly
+              tabIndex={-1}
               placeholder="Quiz Code (XXXXXX)"
               className="w-full px-4 py-4 bg-slate-800 border border-slate-700 rounded-xl text-white text-xl font-black font-mono tracking-widest text-center uppercase placeholder-slate-600 focus:outline-none cursor-default"
             />
             <input
               type="text"
               readOnly
+              tabIndex={-1}
               placeholder="Your PIN"
               className="w-full px-4 py-4 bg-slate-800 border border-slate-700 rounded-xl text-white text-xl font-black font-mono tracking-widest text-center placeholder-slate-600 focus:outline-none cursor-default"
             />
             <button
               type="button"
               disabled
+              tabIndex={-1}
               className="w-full py-4 bg-violet-600 disabled:opacity-50 text-white font-bold text-lg rounded-xl flex items-center justify-center gap-2 cursor-not-allowed"
             >
               Join <ArrowRight className="w-5 h-5" />

--- a/components/quiz/QuizStudentApp.tsx
+++ b/components/quiz/QuizStudentApp.tsx
@@ -59,6 +59,8 @@ import { StudentLeaderboard } from './StudentLeaderboard';
 import { QuizPausedPlaceholder } from './QuizPausedPlaceholder';
 import { MatchingResponseInput } from './MatchingResponseInput';
 import { OrderingResponseInput } from './OrderingResponseInput';
+import { TeacherPreviewBanner } from '@/components/student/TeacherPreviewBanner';
+import { usePreviewMode } from '@/hooks/usePreviewMode';
 import {
   getScoreSuffix,
   isGamificationActive,
@@ -73,6 +75,15 @@ import {
 // ─── Root component ───────────────────────────────────────────────────────────
 
 export const QuizStudentApp: React.FC = () => {
+  // `?preview=1` — teachers verifying the student URL from QuizLiveMonitor's
+  // Preview button. Render a non-functional lobby preview and skip auth init
+  // so the teacher's signed-in session in other tabs isn't replaced by
+  // `signInAnonymously` (which would cascade through cross-tab broadcast and
+  // a `studentRole: true` token contaminating the SSO auto-join below). The
+  // hook also strips the flag from the URL bar so a teacher copying the URL
+  // from the address bar gets the real student URL.
+  const previewMode = usePreviewMode();
+
   const [authReady, setAuthReady] = useState(false);
   const [authFailed, setAuthFailed] = useState(false);
   // True iff `auth.currentUser` carries the `studentRole: true` custom claim
@@ -85,6 +96,7 @@ export const QuizStudentApp: React.FC = () => {
   // user we must keep. This satisfies Firestore security rules
   // (`request.auth != null`) for direct `/quiz?code=…` visitors.
   useEffect(() => {
+    if (previewMode) return;
     const init = async () => {
       try {
         if (!auth.currentUser) {
@@ -106,7 +118,11 @@ export const QuizStudentApp: React.FC = () => {
       }
     };
     void init();
-  }, []);
+  }, [previewMode]);
+
+  if (previewMode) {
+    return <QuizPreviewLobby />;
+  }
 
   if (!authReady) {
     return <FullPageLoader message="Loading…" />;
@@ -124,6 +140,65 @@ export const QuizStudentApp: React.FC = () => {
   }
 
   return <QuizJoinFlow isStudentRole={isStudentRole} />;
+};
+
+// ─── Preview lobby ────────────────────────────────────────────────────────────
+
+/** Static read-only preview of the quiz join form — no hooks, no auth, no
+ * submission. Mounted when the URL carries `?preview=1` so a teacher can
+ * verify what students will see without their Firebase Auth session being
+ * touched by `signInAnonymously` or the SSO auto-join path. */
+const QuizPreviewLobby: React.FC = () => {
+  const urlCode = useMemo(() => {
+    if (typeof window === 'undefined') return '';
+    return new URLSearchParams(window.location.search).get('code') ?? '';
+  }, []);
+
+  return (
+    <div className="min-h-screen bg-slate-900 flex flex-col">
+      <TeacherPreviewBanner />
+      <div className="flex-1 flex flex-col items-center justify-center p-6">
+        <div className="w-full max-w-sm">
+          <div className="flex items-center justify-center mb-8">
+            <ClipboardList className="w-5 h-5 text-violet-400 mr-2" />
+            <span className="text-sm text-slate-300 font-semibold">
+              Student Quiz
+            </span>
+          </div>
+
+          <h1 className="text-2xl font-black text-white mb-2 text-center">
+            Join Quiz
+          </h1>
+          <p className="text-slate-400 text-sm text-center mb-6">
+            Enter the code and your PIN from your teacher.
+          </p>
+
+          <div className="space-y-4">
+            <input
+              type="text"
+              value={urlCode}
+              readOnly
+              placeholder="Quiz Code (XXXXXX)"
+              className="w-full px-4 py-4 bg-slate-800 border border-slate-700 rounded-xl text-white text-xl font-black font-mono tracking-widest text-center uppercase placeholder-slate-600 focus:outline-none cursor-default"
+            />
+            <input
+              type="text"
+              readOnly
+              placeholder="Your PIN"
+              className="w-full px-4 py-4 bg-slate-800 border border-slate-700 rounded-xl text-white text-xl font-black font-mono tracking-widest text-center placeholder-slate-600 focus:outline-none cursor-default"
+            />
+            <button
+              type="button"
+              disabled
+              className="w-full py-4 bg-violet-600 disabled:opacity-50 text-white font-bold text-lg rounded-xl flex items-center justify-center gap-2 cursor-not-allowed"
+            >
+              Join <ArrowRight className="w-5 h-5" />
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
 };
 
 // ─── Join flow ────────────────────────────────────────────────────────────────

--- a/components/student/StudentApp.tsx
+++ b/components/student/StudentApp.tsx
@@ -49,22 +49,25 @@ const StudentPreviewLobby: React.FC = () => (
       <p className="text-slate-400 text-sm mb-8">
         Join your teacher&apos;s session
       </p>
-      <div className="w-full max-w-sm space-y-4">
+      <div className="w-full max-w-sm space-y-4" aria-hidden="true">
         <input
           type="text"
           readOnly
+          tabIndex={-1}
           placeholder="Teacher ID / Room Code"
           className="w-full px-4 py-3 bg-slate-800 border border-slate-700 rounded-xl text-white placeholder-slate-500 focus:outline-none font-mono text-center tracking-widest uppercase cursor-default"
         />
         <input
           type="text"
           readOnly
+          tabIndex={-1}
           placeholder="Your PIN"
           className="w-full px-4 py-3 bg-slate-800 border border-slate-700 rounded-xl text-white placeholder-slate-500 focus:outline-none text-center font-mono tracking-widest cursor-default"
         />
         <button
           type="button"
           disabled
+          tabIndex={-1}
           className="w-full py-4 bg-indigo-600 text-white rounded-xl font-bold text-lg shadow-lg shadow-indigo-900/50 disabled:opacity-50 cursor-not-allowed mt-4"
         >
           Join Session

--- a/components/student/StudentApp.tsx
+++ b/components/student/StudentApp.tsx
@@ -3,10 +3,12 @@ import { signInAnonymously, signOut } from 'firebase/auth';
 import { auth } from '@/config/firebase';
 import { useLiveSession } from '@/hooks/useLiveSession';
 import { StudentLobby } from './StudentLobby';
+import { TeacherPreviewBanner } from './TeacherPreviewBanner';
 import { WidgetRenderer } from '../widgets/WidgetRenderer';
 import { Snowflake, Radio } from 'lucide-react';
 import { WidgetData, DEFAULT_GLOBAL_STYLE, LiveSession } from '@/types';
 import { getDefaultWidgetConfig } from '@/utils/widgetHelpers';
+import { usePreviewMode } from '@/hooks/usePreviewMode';
 
 const noop = () => undefined;
 const asyncNoop = async () => {
@@ -24,6 +26,28 @@ const asyncNoopSession = (): Promise<LiveSession> =>
   });
 
 export const StudentApp = () => {
+  // `?preview=1` — teachers verifying the student URL. Render a static
+  // lobby preview and skip `signInAnonymously` so the teacher's signed-in
+  // session in other tabs isn't replaced via the cross-tab BroadcastChannel.
+  // The hook also strips the flag from the URL bar so the teacher's
+  // address-bar copy is the real student URL.
+  const previewMode = usePreviewMode();
+
+  if (previewMode) {
+    return (
+      <div className="min-h-screen bg-slate-900 flex flex-col">
+        <TeacherPreviewBanner />
+        <div className="flex-1">
+          <StudentLobby onJoin={() => undefined} isLoading={false} />
+        </div>
+      </div>
+    );
+  }
+
+  return <StudentAppInner />;
+};
+
+const StudentAppInner: React.FC = () => {
   const [joinedCode, setJoinedCode] = useState<string | null>(null);
   const [authInitialized, setAuthInitialized] = useState(false);
   const [error, setError] = useState<string | null>(null);

--- a/components/student/StudentApp.tsx
+++ b/components/student/StudentApp.tsx
@@ -5,7 +5,7 @@ import { useLiveSession } from '@/hooks/useLiveSession';
 import { StudentLobby } from './StudentLobby';
 import { TeacherPreviewBanner } from './TeacherPreviewBanner';
 import { WidgetRenderer } from '../widgets/WidgetRenderer';
-import { Snowflake, Radio } from 'lucide-react';
+import { Cast, Snowflake, Radio } from 'lucide-react';
 import { WidgetData, DEFAULT_GLOBAL_STYLE, LiveSession } from '@/types';
 import { getDefaultWidgetConfig } from '@/utils/widgetHelpers';
 import { usePreviewMode } from '@/hooks/usePreviewMode';
@@ -26,26 +26,53 @@ const asyncNoopSession = (): Promise<LiveSession> =>
   });
 
 export const StudentApp = () => {
-  // `?preview=1` — teachers verifying the student URL. Render a static
-  // lobby preview and skip `signInAnonymously` so the teacher's signed-in
-  // session in other tabs isn't replaced via the cross-tab BroadcastChannel.
-  // The hook also strips the flag from the URL bar so the teacher's
-  // address-bar copy is the real student URL.
+  // preview mode — see hooks/usePreviewMode
   const previewMode = usePreviewMode();
-
-  if (previewMode) {
-    return (
-      <div className="min-h-screen bg-slate-900 flex flex-col">
-        <TeacherPreviewBanner />
-        <div className="flex-1">
-          <StudentLobby onJoin={() => undefined} isLoading={false} />
-        </div>
-      </div>
-    );
-  }
-
+  if (previewMode) return <StudentPreviewLobby />;
   return <StudentAppInner />;
 };
+
+/** Static read-only preview of the live-session join lobby for teachers.
+ * Mirrors the visual structure of `StudentLobby` but with inert inputs and
+ * a disabled button so a curious user can't enter a code/PIN that silently
+ * goes nowhere. */
+const StudentPreviewLobby: React.FC = () => (
+  <div className="min-h-screen bg-slate-900 flex flex-col">
+    <TeacherPreviewBanner />
+    <div className="flex-1 flex flex-col items-center justify-center p-6 text-center text-slate-200">
+      <div className="w-16 h-16 bg-slate-800 rounded-2xl flex items-center justify-center mb-6 shadow-xl ring-1 ring-slate-700">
+        <Cast className="text-indigo-500 w-8 h-8" />
+      </div>
+      <h1 className="text-3xl font-black text-white mb-2 tracking-tight">
+        Classroom Live
+      </h1>
+      <p className="text-slate-400 text-sm mb-8">
+        Join your teacher&apos;s session
+      </p>
+      <div className="w-full max-w-sm space-y-4">
+        <input
+          type="text"
+          readOnly
+          placeholder="Teacher ID / Room Code"
+          className="w-full px-4 py-3 bg-slate-800 border border-slate-700 rounded-xl text-white placeholder-slate-500 focus:outline-none font-mono text-center tracking-widest uppercase cursor-default"
+        />
+        <input
+          type="text"
+          readOnly
+          placeholder="Your PIN"
+          className="w-full px-4 py-3 bg-slate-800 border border-slate-700 rounded-xl text-white placeholder-slate-500 focus:outline-none text-center font-mono tracking-widest cursor-default"
+        />
+        <button
+          type="button"
+          disabled
+          className="w-full py-4 bg-indigo-600 text-white rounded-xl font-bold text-lg shadow-lg shadow-indigo-900/50 disabled:opacity-50 cursor-not-allowed mt-4"
+        >
+          Join Session
+        </button>
+      </div>
+    </div>
+  </div>
+);
 
 const StudentAppInner: React.FC = () => {
   const [joinedCode, setJoinedCode] = useState<string | null>(null);

--- a/components/student/TeacherPreviewBanner.tsx
+++ b/components/student/TeacherPreviewBanner.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { Eye } from 'lucide-react';
+
+/**
+ * Banner shown atop student route lobbies when the URL carries `?preview=1`.
+ * Lets a teacher verify what students will see without their teacher Firebase
+ * session being replaced by `signInAnonymously` or contaminating a session
+ * via the SSO auto-join path. Pure visual — reads no auth state.
+ */
+export const TeacherPreviewBanner: React.FC = () => (
+  <div className="w-full bg-indigo-500/15 border-b border-indigo-400/30 px-4 py-3 flex items-center justify-center gap-2 text-indigo-200 text-sm font-semibold backdrop-blur-sm">
+    <Eye className="w-4 h-4 shrink-0" />
+    <span>Teacher preview — students will see this exact screen.</span>
+  </div>
+);

--- a/components/student/TeacherPreviewBanner.tsx
+++ b/components/student/TeacherPreviewBanner.tsx
@@ -8,8 +8,11 @@ import { Eye } from 'lucide-react';
  * via the SSO auto-join path. Pure visual — reads no auth state.
  */
 export const TeacherPreviewBanner: React.FC = () => (
-  <div className="w-full bg-indigo-500/15 border-b border-indigo-400/30 px-4 py-3 flex items-center justify-center gap-2 text-indigo-200 text-sm font-semibold backdrop-blur-sm">
-    <Eye className="w-4 h-4 shrink-0" />
+  <div
+    role="status"
+    className="w-full bg-indigo-500/15 border-b border-indigo-400/30 px-4 py-3 flex items-center justify-center gap-2 text-indigo-200 text-sm font-semibold backdrop-blur-sm"
+  >
+    <Eye className="w-4 h-4 shrink-0" aria-hidden="true" />
     <span>Teacher preview — students will see this exact screen.</span>
   </div>
 );

--- a/components/videoActivity/VideoActivityStudentApp.tsx
+++ b/components/videoActivity/VideoActivityStudentApp.tsx
@@ -31,6 +31,8 @@ import { VideoActivityQuestion, VideoActivitySession } from '@/types';
 import { gradeVideoActivityAnswer } from '@/utils/videoActivityGrading';
 import { VideoPlayer } from './VideoPlayer';
 import { QuestionOverlay } from './QuestionOverlay';
+import { TeacherPreviewBanner } from '@/components/student/TeacherPreviewBanner';
+import { usePreviewMode } from '@/hooks/usePreviewMode';
 
 /**
  * Resolve the SSO student's class period from the session's
@@ -65,6 +67,13 @@ function resolveSsoClassPeriod(
 // ─── Root ──────────────────────────────────────────────────────────────────────
 
 export const VideoActivityStudentApp: React.FC = () => {
+  // `?preview=1` — teachers verifying the student URL. Render a static lobby
+  // preview and skip auth init so the teacher's signed-in session isn't
+  // replaced by `signInAnonymously` and the SSO auto-join doesn't fire with
+  // a stale `studentRole: true` token. The hook also strips the flag from
+  // the URL bar so the teacher's address-bar copy is the real student URL.
+  const previewMode = usePreviewMode();
+
   const [authReady, setAuthReady] = useState(false);
   const [authFailed, setAuthFailed] = useState(false);
   // True iff `auth.currentUser` carries the `studentRole: true` custom claim
@@ -76,6 +85,7 @@ export const VideoActivityStudentApp: React.FC = () => {
   const [ssoClassIds, setSsoClassIds] = useState<string[]>([]);
 
   useEffect(() => {
+    if (previewMode) return;
     const init = async () => {
       try {
         // Sign in anonymously only when nobody is signed in — SSO students
@@ -109,7 +119,11 @@ export const VideoActivityStudentApp: React.FC = () => {
       }
     };
     void init();
-  }, []);
+  }, [previewMode]);
+
+  if (previewMode) {
+    return <VideoActivityPreviewLobby />;
+  }
 
   if (!authReady) {
     return <FullPageLoader message="Loading…" />;
@@ -125,6 +139,49 @@ export const VideoActivityStudentApp: React.FC = () => {
     <JoinAndPlay isStudentRole={isStudentRole} ssoClassIds={ssoClassIds} />
   );
 };
+
+// ─── Preview lobby ────────────────────────────────────────────────────────────
+
+/** Static read-only preview of the activity join form for teachers. Renders
+ * the lobby UI without mounting any hooks that would touch Firebase Auth or
+ * Firestore — pasting the `?preview=1` URL into a tab is safe regardless of
+ * what auth state that browser profile already carries. */
+const VideoActivityPreviewLobby: React.FC = () => (
+  <div className="min-h-screen bg-slate-900 flex flex-col">
+    <TeacherPreviewBanner />
+    <div className="flex-1 flex flex-col items-center justify-center p-6">
+      <div className="w-full max-w-sm">
+        <div className="flex items-center justify-center mb-8">
+          <PlayCircle className="w-5 h-5 text-violet-400 mr-2" />
+          <span className="text-sm text-slate-300 font-semibold">
+            Video Activity
+          </span>
+        </div>
+        <h1 className="text-2xl font-black text-white mb-2 text-center">
+          Join Activity
+        </h1>
+        <p className="text-slate-400 text-sm text-center mb-6">
+          Enter your PIN from your teacher.
+        </p>
+        <div className="space-y-4">
+          <input
+            type="text"
+            readOnly
+            placeholder="Your PIN"
+            className="w-full px-4 py-4 bg-slate-800 border border-slate-700 rounded-xl text-white text-xl font-black font-mono tracking-widest text-center placeholder-slate-600 focus:outline-none cursor-default"
+          />
+          <button
+            type="button"
+            disabled
+            className="w-full py-4 bg-violet-600 disabled:opacity-50 text-white font-bold text-lg rounded-xl flex items-center justify-center gap-2 cursor-not-allowed"
+          >
+            Join <ArrowRight className="w-5 h-5" />
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+);
 
 // ─── Join + Play ───────────────────────────────────────────────────────────────
 

--- a/components/videoActivity/VideoActivityStudentApp.tsx
+++ b/components/videoActivity/VideoActivityStudentApp.tsx
@@ -67,11 +67,7 @@ function resolveSsoClassPeriod(
 // ─── Root ──────────────────────────────────────────────────────────────────────
 
 export const VideoActivityStudentApp: React.FC = () => {
-  // `?preview=1` — teachers verifying the student URL. Render a static lobby
-  // preview and skip auth init so the teacher's signed-in session isn't
-  // replaced by `signInAnonymously` and the SSO auto-join doesn't fire with
-  // a stale `studentRole: true` token. The hook also strips the flag from
-  // the URL bar so the teacher's address-bar copy is the real student URL.
+  // preview mode — see hooks/usePreviewMode
   const previewMode = usePreviewMode();
 
   const [authReady, setAuthReady] = useState(false);

--- a/components/videoActivity/VideoActivityStudentApp.tsx
+++ b/components/videoActivity/VideoActivityStudentApp.tsx
@@ -159,16 +159,18 @@ const VideoActivityPreviewLobby: React.FC = () => (
         <p className="text-slate-400 text-sm text-center mb-6">
           Enter your PIN from your teacher.
         </p>
-        <div className="space-y-4">
+        <div className="space-y-4" aria-hidden="true">
           <input
             type="text"
             readOnly
+            tabIndex={-1}
             placeholder="Your PIN"
             className="w-full px-4 py-4 bg-slate-800 border border-slate-700 rounded-xl text-white text-xl font-black font-mono tracking-widest text-center placeholder-slate-600 focus:outline-none cursor-default"
           />
           <button
             type="button"
             disabled
+            tabIndex={-1}
             className="w-full py-4 bg-violet-600 disabled:opacity-50 text-white font-bold text-lg rounded-xl flex items-center justify-center gap-2 cursor-not-allowed"
           >
             Join <ArrowRight className="w-5 h-5" />

--- a/components/widgets/LiveControl.tsx
+++ b/components/widgets/LiveControl.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { createPortal } from 'react-dom';
-import { Cast, Snowflake, X, Trash2 } from 'lucide-react';
+import { Cast, Snowflake, X, Trash2, Eye } from 'lucide-react';
 import { LiveStudent } from '@/types';
 import { useClickOutside } from '@/hooks/useClickOutside';
 import { Z_INDEX } from '@/config/zIndex';
@@ -204,6 +204,17 @@ export const LiveControl: React.FC<LiveControlProps> = ({
               <div className="text-xxs text-indigo-400">
                 {joinUrl?.replace(/^https?:\/\//, '')}
               </div>
+              {joinUrl && (
+                <a
+                  href={`${joinUrl}?preview=1`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="mt-2 inline-flex items-center gap-1.5 px-2.5 py-1 bg-white text-indigo-600 border border-indigo-200 rounded-md text-xxs font-bold uppercase tracking-wider hover:bg-indigo-100 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400 focus-visible:ring-offset-1 focus-visible:ring-offset-indigo-50"
+                  title="Preview the student view without touching your teacher session"
+                >
+                  <Eye size={12} /> Preview
+                </a>
+              )}
             </div>
           )}
 

--- a/components/widgets/LiveControl.tsx
+++ b/components/widgets/LiveControl.tsx
@@ -4,6 +4,7 @@ import { Cast, Snowflake, X, Trash2, Eye } from 'lucide-react';
 import { LiveStudent } from '@/types';
 import { useClickOutside } from '@/hooks/useClickOutside';
 import { Z_INDEX } from '@/config/zIndex';
+import { withPreviewFlag } from '@/utils/urlHelpers';
 
 interface LiveControlProps {
   isLive: boolean;
@@ -206,7 +207,7 @@ export const LiveControl: React.FC<LiveControlProps> = ({
               </div>
               {joinUrl && (
                 <a
-                  href={`${joinUrl}?preview=1`}
+                  href={withPreviewFlag(joinUrl)}
                   target="_blank"
                   rel="noopener noreferrer"
                   className="mt-2 inline-flex items-center gap-1.5 px-2.5 py-1 bg-white text-indigo-600 border border-indigo-200 rounded-md text-xxs font-bold uppercase tracking-wider hover:bg-indigo-100 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400 focus-visible:ring-offset-1 focus-visible:ring-offset-indigo-50"

--- a/components/widgets/QuizWidget/components/QuizLiveMonitor.tsx
+++ b/components/widgets/QuizWidget/components/QuizLiveMonitor.tsx
@@ -727,6 +727,10 @@ export const QuizLiveMonitor: React.FC<QuizLiveMonitorProps> = ({
 
   const isActive = session.status === 'active';
   const joinUrl = `${window.location.origin}/quiz?code=${session.code}`;
+  // `?preview=1` variant for the "Preview" button — opens the student lobby
+  // in a static read-only form so a teacher can verify the URL without
+  // their teacher Firebase Auth session being touched.
+  const previewUrl = `${joinUrl}&preview=1`;
 
   const handleCopy = () => {
     void navigator.clipboard.writeText(joinUrl).then(() => {
@@ -1415,6 +1419,26 @@ export const QuizLiveMonitor: React.FC<QuizLiveMonitorProps> = ({
                   />
                   OPEN
                 </a>
+                <a
+                  href={previewUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="flex items-center bg-slate-200 hover:bg-slate-300 text-slate-700 font-bold rounded-lg transition-all shadow-sm active:scale-95"
+                  style={{
+                    gap: 'min(3px, 0.7cqmin)',
+                    padding: 'min(4px, 1cqmin) min(8px, 2cqmin)',
+                    fontSize: 'min(9px, 2.5cqmin)',
+                  }}
+                  title="Preview the student view without touching your teacher session"
+                >
+                  <Eye
+                    style={{
+                      width: 'min(12px, 3cqmin)',
+                      height: 'min(12px, 3cqmin)',
+                    }}
+                  />
+                  PREVIEW
+                </a>
                 {/* Sound mute toggle */}
                 {session.soundEffectsEnabled && (
                   <button
@@ -1689,6 +1713,26 @@ export const QuizLiveMonitor: React.FC<QuizLiveMonitorProps> = ({
                     }}
                   />
                   OPEN
+                </a>
+                <a
+                  href={previewUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="flex items-center bg-slate-200 hover:bg-slate-300 text-slate-700 font-bold rounded-lg transition-all shadow-sm active:scale-95"
+                  style={{
+                    gap: 'min(4px, 1cqmin)',
+                    padding: 'min(6px, 1.5cqmin) min(10px, 2.5cqmin)',
+                    fontSize: 'min(10px, 3cqmin)',
+                  }}
+                  title="Preview the student view without touching your teacher session"
+                >
+                  <Eye
+                    style={{
+                      width: 'min(14px, 3.5cqmin)',
+                      height: 'min(14px, 3.5cqmin)',
+                    }}
+                  />
+                  PREVIEW
                 </a>
                 {session.soundEffectsEnabled && (
                   <button

--- a/components/widgets/QuizWidget/components/QuizLiveMonitor.tsx
+++ b/components/widgets/QuizWidget/components/QuizLiveMonitor.tsx
@@ -72,6 +72,7 @@ import {
   playQuizCompleteCelebration,
 } from '@/utils/quizAudio';
 import { logError } from '@/utils/logError';
+import { withPreviewFlag } from '@/utils/urlHelpers';
 
 interface QuizLiveMonitorProps {
   session: QuizSession;
@@ -726,11 +727,16 @@ export const QuizLiveMonitor: React.FC<QuizLiveMonitorProps> = ({
   }, [session.status, session.soundEffectsEnabled, soundMuted]);
 
   const isActive = session.status === 'active';
-  const joinUrl = `${window.location.origin}/quiz?code=${session.code}`;
-  // `?preview=1` variant for the "Preview" button — opens the student lobby
-  // in a static read-only form so a teacher can verify the URL without
-  // their teacher Firebase Auth session being touched.
-  const previewUrl = `${joinUrl}&preview=1`;
+  // Don't construct URLs until the session has a code — otherwise the
+  // OPEN / PREVIEW links point at `?code=` (empty), which renders a broken
+  // lobby. `hasCode` gates rendering of both buttons below.
+  const hasCode = Boolean(session.code);
+  const joinUrl = hasCode
+    ? `${window.location.origin}/quiz?code=${session.code}`
+    : '';
+  // Built via `withPreviewFlag` so it stays well-formed if `joinUrl` ever
+  // gains additional query parameters.
+  const previewUrl = hasCode ? withPreviewFlag(joinUrl) : '';
 
   const handleCopy = () => {
     void navigator.clipboard.writeText(joinUrl).then(() => {
@@ -1400,45 +1406,49 @@ export const QuizLiveMonitor: React.FC<QuizLiveMonitorProps> = ({
                   )}
                   {copied ? 'COPIED' : 'COPY'}
                 </button>
-                <a
-                  href={joinUrl}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="flex items-center bg-brand-blue-primary hover:bg-brand-blue-dark text-white font-bold rounded-lg transition-all shadow-sm active:scale-95"
-                  style={{
-                    gap: 'min(3px, 0.7cqmin)',
-                    padding: 'min(4px, 1cqmin) min(8px, 2cqmin)',
-                    fontSize: 'min(9px, 2.5cqmin)',
-                  }}
-                >
-                  <ExternalLink
-                    style={{
-                      width: 'min(12px, 3cqmin)',
-                      height: 'min(12px, 3cqmin)',
-                    }}
-                  />
-                  OPEN
-                </a>
-                <a
-                  href={previewUrl}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="flex items-center bg-slate-200 hover:bg-slate-300 text-slate-700 font-bold rounded-lg transition-all shadow-sm active:scale-95"
-                  style={{
-                    gap: 'min(3px, 0.7cqmin)',
-                    padding: 'min(4px, 1cqmin) min(8px, 2cqmin)',
-                    fontSize: 'min(9px, 2.5cqmin)',
-                  }}
-                  title="Preview the student view without touching your teacher session"
-                >
-                  <Eye
-                    style={{
-                      width: 'min(12px, 3cqmin)',
-                      height: 'min(12px, 3cqmin)',
-                    }}
-                  />
-                  PREVIEW
-                </a>
+                {hasCode && (
+                  <>
+                    <a
+                      href={joinUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="flex items-center bg-brand-blue-primary hover:bg-brand-blue-dark text-white font-bold rounded-lg transition-all shadow-sm active:scale-95"
+                      style={{
+                        gap: 'min(3px, 0.7cqmin)',
+                        padding: 'min(4px, 1cqmin) min(8px, 2cqmin)',
+                        fontSize: 'min(9px, 2.5cqmin)',
+                      }}
+                    >
+                      <ExternalLink
+                        style={{
+                          width: 'min(12px, 3cqmin)',
+                          height: 'min(12px, 3cqmin)',
+                        }}
+                      />
+                      OPEN
+                    </a>
+                    <a
+                      href={previewUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="flex items-center bg-slate-200 hover:bg-slate-300 text-slate-700 font-bold rounded-lg transition-all shadow-sm active:scale-95"
+                      style={{
+                        gap: 'min(3px, 0.7cqmin)',
+                        padding: 'min(4px, 1cqmin) min(8px, 2cqmin)',
+                        fontSize: 'min(9px, 2.5cqmin)',
+                      }}
+                      title="Preview the student view without touching your teacher session"
+                    >
+                      <Eye
+                        style={{
+                          width: 'min(12px, 3cqmin)',
+                          height: 'min(12px, 3cqmin)',
+                        }}
+                      />
+                      PREVIEW
+                    </a>
+                  </>
+                )}
                 {/* Sound mute toggle */}
                 {session.soundEffectsEnabled && (
                   <button
@@ -1695,45 +1705,49 @@ export const QuizLiveMonitor: React.FC<QuizLiveMonitorProps> = ({
                   )}
                   {copied ? 'COPIED' : 'COPY'}
                 </button>
-                <a
-                  href={joinUrl}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="flex items-center bg-brand-blue-primary hover:bg-brand-blue-dark text-white font-bold rounded-lg transition-all shadow-sm active:scale-95"
-                  style={{
-                    gap: 'min(4px, 1cqmin)',
-                    padding: 'min(6px, 1.5cqmin) min(10px, 2.5cqmin)',
-                    fontSize: 'min(10px, 3cqmin)',
-                  }}
-                >
-                  <ExternalLink
-                    style={{
-                      width: 'min(14px, 3.5cqmin)',
-                      height: 'min(14px, 3.5cqmin)',
-                    }}
-                  />
-                  OPEN
-                </a>
-                <a
-                  href={previewUrl}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="flex items-center bg-slate-200 hover:bg-slate-300 text-slate-700 font-bold rounded-lg transition-all shadow-sm active:scale-95"
-                  style={{
-                    gap: 'min(4px, 1cqmin)',
-                    padding: 'min(6px, 1.5cqmin) min(10px, 2.5cqmin)',
-                    fontSize: 'min(10px, 3cqmin)',
-                  }}
-                  title="Preview the student view without touching your teacher session"
-                >
-                  <Eye
-                    style={{
-                      width: 'min(14px, 3.5cqmin)',
-                      height: 'min(14px, 3.5cqmin)',
-                    }}
-                  />
-                  PREVIEW
-                </a>
+                {hasCode && (
+                  <>
+                    <a
+                      href={joinUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="flex items-center bg-brand-blue-primary hover:bg-brand-blue-dark text-white font-bold rounded-lg transition-all shadow-sm active:scale-95"
+                      style={{
+                        gap: 'min(4px, 1cqmin)',
+                        padding: 'min(6px, 1.5cqmin) min(10px, 2.5cqmin)',
+                        fontSize: 'min(10px, 3cqmin)',
+                      }}
+                    >
+                      <ExternalLink
+                        style={{
+                          width: 'min(14px, 3.5cqmin)',
+                          height: 'min(14px, 3.5cqmin)',
+                        }}
+                      />
+                      OPEN
+                    </a>
+                    <a
+                      href={previewUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="flex items-center bg-slate-200 hover:bg-slate-300 text-slate-700 font-bold rounded-lg transition-all shadow-sm active:scale-95"
+                      style={{
+                        gap: 'min(4px, 1cqmin)',
+                        padding: 'min(6px, 1.5cqmin) min(10px, 2.5cqmin)',
+                        fontSize: 'min(10px, 3cqmin)',
+                      }}
+                      title="Preview the student view without touching your teacher session"
+                    >
+                      <Eye
+                        style={{
+                          width: 'min(14px, 3.5cqmin)',
+                          height: 'min(14px, 3.5cqmin)',
+                        }}
+                      />
+                      PREVIEW
+                    </a>
+                  </>
+                )}
                 {session.soundEffectsEnabled && (
                   <button
                     onClick={() => setSoundMuted((m) => !m)}

--- a/hooks/usePreviewMode.ts
+++ b/hooks/usePreviewMode.ts
@@ -1,28 +1,28 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { isPreviewMode } from '@/utils/previewMode';
 
 /**
  * Read `?preview=1` on mount and immediately strip it from the URL bar so a
- * teacher copying the URL from the address bar gets the clean student URL,
- * not the preview URL. The component stays in preview mode for its lifetime
- * because the value is captured in state at first render. A page refresh
- * exits preview mode — acceptable because the preview tab's purpose is "look
- * at it, then close it," not "refresh it."
+ * teacher copying the URL from the address bar gets the clean student URL.
+ * Strip runs synchronously inside the state initializer — before the first
+ * paint — so the address bar never momentarily shows `preview=1` after the
+ * component mounts. A page refresh exits preview mode (the flag is gone);
+ * the preview tab is meant to be looked at and closed, not refreshed.
  */
 export const usePreviewMode = (): boolean => {
-  const [previewMode] = useState(() => isPreviewMode());
-
-  useEffect(() => {
-    if (!previewMode || typeof window === 'undefined') return;
-    const params = new URLSearchParams(window.location.search);
-    params.delete('preview');
-    const search = params.toString();
-    const cleanedUrl =
-      window.location.pathname +
-      (search ? `?${search}` : '') +
-      window.location.hash;
-    window.history.replaceState(null, '', cleanedUrl);
-  }, [previewMode]);
-
+  const [previewMode] = useState(() => {
+    const active = isPreviewMode();
+    if (active && typeof window !== 'undefined') {
+      const params = new URLSearchParams(window.location.search);
+      params.delete('preview');
+      const search = params.toString();
+      const cleanedUrl =
+        window.location.pathname +
+        (search ? `?${search}` : '') +
+        window.location.hash;
+      window.history.replaceState(null, '', cleanedUrl);
+    }
+    return active;
+  });
   return previewMode;
 };

--- a/hooks/usePreviewMode.ts
+++ b/hooks/usePreviewMode.ts
@@ -1,0 +1,28 @@
+import { useEffect, useState } from 'react';
+import { isPreviewMode } from '@/utils/previewMode';
+
+/**
+ * Read `?preview=1` on mount and immediately strip it from the URL bar so a
+ * teacher copying the URL from the address bar gets the clean student URL,
+ * not the preview URL. The component stays in preview mode for its lifetime
+ * because the value is captured in state at first render. A page refresh
+ * exits preview mode — acceptable because the preview tab's purpose is "look
+ * at it, then close it," not "refresh it."
+ */
+export const usePreviewMode = (): boolean => {
+  const [previewMode] = useState(() => isPreviewMode());
+
+  useEffect(() => {
+    if (!previewMode || typeof window === 'undefined') return;
+    const params = new URLSearchParams(window.location.search);
+    params.delete('preview');
+    const search = params.toString();
+    const cleanedUrl =
+      window.location.pathname +
+      (search ? `?${search}` : '') +
+      window.location.hash;
+    window.history.replaceState(null, '', cleanedUrl);
+  }, [previewMode]);
+
+  return previewMode;
+};

--- a/hooks/usePreviewMode.ts
+++ b/hooks/usePreviewMode.ts
@@ -1,28 +1,38 @@
-import { useState } from 'react';
+import { useLayoutEffect, useState } from 'react';
 import { isPreviewMode } from '@/utils/previewMode';
 
 /**
- * Read `?preview=1` on mount and immediately strip it from the URL bar so a
- * teacher copying the URL from the address bar gets the clean student URL.
- * Strip runs synchronously inside the state initializer — before the first
- * paint — so the address bar never momentarily shows `preview=1` after the
- * component mounts. A page refresh exits preview mode (the flag is gone);
- * the preview tab is meant to be looked at and closed, not refreshed.
+ * Read `?preview=1` on mount and strip it from the URL bar so a teacher
+ * copying the URL from the address bar gets the clean student URL.
+ *
+ * The flag is captured in a pure `useState` initializer (StrictMode
+ * double-invokes initializers in dev to verify purity; an impure
+ * initializer that mutates `window.location` would return different
+ * values on the two calls). The URL strip lives in `useLayoutEffect`
+ * instead — same UX guarantee (fires synchronously after commit, before
+ * the browser paints, so the address bar never momentarily shows
+ * `preview=1`), but the mutation is properly contained in an effect.
+ *
+ * A page refresh exits preview mode; the preview tab is meant to be
+ * looked at and closed, not refreshed.
  */
 export const usePreviewMode = (): boolean => {
-  const [previewMode] = useState(() => {
-    const active = isPreviewMode();
-    if (active && typeof window !== 'undefined') {
-      const params = new URLSearchParams(window.location.search);
-      params.delete('preview');
-      const search = params.toString();
-      const cleanedUrl =
-        window.location.pathname +
-        (search ? `?${search}` : '') +
-        window.location.hash;
-      window.history.replaceState(null, '', cleanedUrl);
-    }
-    return active;
-  });
+  const [previewMode] = useState(() => isPreviewMode());
+
+  useLayoutEffect(() => {
+    if (!previewMode || typeof window === 'undefined') return;
+    const params = new URLSearchParams(window.location.search);
+    params.delete('preview');
+    const search = params.toString();
+    const cleanedUrl =
+      window.location.pathname +
+      (search ? `?${search}` : '') +
+      window.location.hash;
+    window.history.replaceState(null, '', cleanedUrl);
+    // `previewMode` is captured at mount and never changes; stripping
+    // already-stripped URL is a no-op idempotent operation, so a
+    // StrictMode re-fire is safe.
+  }, [previewMode]);
+
   return previewMode;
 };

--- a/tests/components/quiz/QuizStudentApp.ssoAutoJoin.test.tsx
+++ b/tests/components/quiz/QuizStudentApp.ssoAutoJoin.test.tsx
@@ -22,6 +22,7 @@ import React, { StrictMode } from 'react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom/vitest';
+import { signInAnonymously } from 'firebase/auth';
 
 // vi.mock is hoisted above imports, so any external references inside the
 // factory must be declared via vi.hoisted (otherwise we hit the classic
@@ -269,6 +270,34 @@ describe('QuizStudentApp — SSO studentRole auto-join', () => {
 
     // And we should not be stuck on the "Joining quiz…" loader.
     expect(screen.queryByText(/Joining quiz…/i)).not.toBeInTheDocument();
+  });
+
+  it('preview-mode short-circuits to a static lobby — no signInAnonymously, no auto-join, banner visible', async () => {
+    // A teacher arrives at /quiz?code=ABC&preview=1 via the Preview button.
+    // Even with a non-anonymous (teacher) session already present and a code
+    // in the URL, the auth-init effect and the SSO auto-join effect must
+    // both no-op so the teacher's session isn't replaced or contaminated.
+    mockAuth.currentUser = mintUser({
+      uid: 'teacher-uid-preview',
+      isAnonymous: false,
+      studentRole: false,
+    });
+    setSearch('?code=ABC123&preview=1');
+
+    render(<QuizStudentApp />);
+
+    expect(await screen.findByText(/Teacher preview/i)).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { name: /Join Quiz/i })
+    ).toBeInTheDocument();
+
+    expect(vi.mocked(signInAnonymously)).not.toHaveBeenCalled();
+    expect(mockJoinQuizSession).not.toHaveBeenCalled();
+    expect(mockLookupSession).not.toHaveBeenCalled();
+
+    // `usePreviewMode` strips the flag on mount so a teacher copying the URL
+    // from the address bar gets the real student URL.
+    expect(window.location.search).toBe('?code=ABC123');
   });
 
   it('uses a generic fallback message when the rejected value is not an Error', async () => {

--- a/tests/components/widgets/LiveControl.test.tsx
+++ b/tests/components/widgets/LiveControl.test.tsx
@@ -154,4 +154,27 @@ describe('LiveControl', () => {
 
     expect(screen.queryByText('Classroom (2)')).not.toBeInTheDocument();
   });
+
+  it('renders Preview link with preview=1 appended when joinUrl is present', () => {
+    renderLiveControl();
+    fireEvent.click(screen.getByLabelText(/connected students/));
+
+    const previewLink = screen.getByRole('link', { name: /preview/i });
+    expect(previewLink).toBeInTheDocument();
+    expect(previewLink).toHaveAttribute(
+      'href',
+      'https://app.school.com/join?preview=1'
+    );
+    // Plain joinUrl text is shown unchanged elsewhere in the menu.
+    expect(screen.getByText('app.school.com/join')).toBeInTheDocument();
+  });
+
+  it('does not render the Preview link when joinUrl is absent', () => {
+    renderLiveControl({ joinUrl: undefined });
+    fireEvent.click(screen.getByLabelText(/connected students/));
+
+    expect(
+      screen.queryByRole('link', { name: /preview/i })
+    ).not.toBeInTheDocument();
+  });
 });

--- a/tests/components/widgets/QuizLiveMonitor.test.tsx
+++ b/tests/components/widgets/QuizLiveMonitor.test.tsx
@@ -674,6 +674,56 @@ describe('QuizLiveMonitor', () => {
     }
   });
 
+  it('renders an OPEN and a PREVIEW link in every join-code bar when session.code is set', () => {
+    // The component renders the join-code bar in two layout variants (compact
+    // and full); both should expose an OPEN link to the bare student URL and
+    // a PREVIEW link with `preview=1` appended. Mocking `window.location.origin`
+    // makes the assertions independent of where the test happens to run.
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      writable: true,
+      value: { origin: 'https://app.school.com' },
+    });
+    renderMonitor({
+      session: { code: 'ABC123', periodNames: ['P1'] },
+      responses: [makeResponse({ pin: '1111', classPeriod: 'P1' })],
+    });
+
+    const openLinks = screen.getAllByRole('link', { name: /^OPEN$/ });
+    const previewLinks = screen.getAllByRole('link', { name: /PREVIEW/ });
+
+    // Two layout variants each render the pair, so we expect ≥ 1 of each
+    // and the same count.
+    expect(openLinks.length).toBeGreaterThan(0);
+    expect(openLinks.length).toBe(previewLinks.length);
+
+    openLinks.forEach((a) => {
+      expect(a).toHaveAttribute(
+        'href',
+        'https://app.school.com/quiz?code=ABC123'
+      );
+    });
+    previewLinks.forEach((a) => {
+      expect(a).toHaveAttribute(
+        'href',
+        'https://app.school.com/quiz?code=ABC123&preview=1'
+      );
+    });
+  });
+
+  it('omits the OPEN and PREVIEW links entirely when session.code is empty', () => {
+    renderMonitor({
+      session: { code: '', periodNames: ['P1'] },
+      responses: [makeResponse({ pin: '1111', classPeriod: 'P1' })],
+    });
+    expect(
+      screen.queryByRole('link', { name: /^OPEN$/ })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('link', { name: /PREVIEW/ })
+    ).not.toBeInTheDocument();
+  });
+
   it('surfaces a toast when updateAccountPreferences rejects on the Colors toggle', async () => {
     // Start with stored colors OFF so the post-approval branch will issue
     // an updateAccountPreferences write that we can reject.

--- a/tests/hooks/usePreviewMode.test.ts
+++ b/tests/hooks/usePreviewMode.test.ts
@@ -1,3 +1,4 @@
+import React, { StrictMode } from 'react';
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { renderHook } from '@testing-library/react';
 import { usePreviewMode } from '@/hooks/usePreviewMode';
@@ -85,5 +86,25 @@ describe('usePreviewMode', () => {
     setLocation('');
     rerender();
     expect(result.current).toBe(true);
+  });
+
+  it('returns true and strips the URL under React.StrictMode (initializer purity)', () => {
+    // StrictMode double-invokes useState initializers in dev to surface
+    // accidental impurities. The hook's initializer is pure (a plain read);
+    // the side effect lives in useLayoutEffect, which is idempotent under
+    // re-fire. Both invariants must hold for the production behavior to
+    // survive StrictMode dev tooling.
+    setLocation('?code=ABC&preview=1');
+    const { result } = renderHook(() => usePreviewMode(), {
+      wrapper: ({ children }: { children: React.ReactNode }) =>
+        React.createElement(StrictMode, null, children),
+    });
+    expect(result.current).toBe(true);
+    expect(replaceStateSpy).toHaveBeenCalled();
+    expect(replaceStateSpy).toHaveBeenLastCalledWith(
+      null,
+      '',
+      '/quiz?code=ABC'
+    );
   });
 });

--- a/tests/hooks/usePreviewMode.test.ts
+++ b/tests/hooks/usePreviewMode.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { usePreviewMode } from '@/hooks/usePreviewMode';
+
+const setLocation = (search: string, hash = '', pathname = '/quiz') => {
+  // Override the read-only `window.location` for the duration of the test.
+  Object.defineProperty(window, 'location', {
+    configurable: true,
+    writable: true,
+    value: {
+      pathname,
+      search,
+      hash,
+      origin: 'https://example.com',
+      href: `https://example.com${pathname}${search}${hash}`,
+    },
+  });
+};
+
+describe('usePreviewMode', () => {
+  const replaceStateSpy = vi.fn<typeof window.history.replaceState>();
+
+  beforeEach(() => {
+    replaceStateSpy.mockReset();
+    window.history.replaceState = replaceStateSpy;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns true when ?preview=1 is present in the URL', () => {
+    setLocation('?preview=1');
+    const { result } = renderHook(() => usePreviewMode());
+    expect(result.current).toBe(true);
+  });
+
+  it('returns false when preview flag is absent', () => {
+    setLocation('?code=ABC');
+    const { result } = renderHook(() => usePreviewMode());
+    expect(result.current).toBe(false);
+  });
+
+  it('returns false on an empty query string', () => {
+    setLocation('');
+    const { result } = renderHook(() => usePreviewMode());
+    expect(result.current).toBe(false);
+  });
+
+  it('strips preview=1 from the URL synchronously on mount', () => {
+    setLocation('?code=ABC&preview=1');
+    renderHook(() => usePreviewMode());
+    expect(replaceStateSpy).toHaveBeenCalledTimes(1);
+    expect(replaceStateSpy).toHaveBeenCalledWith(null, '', '/quiz?code=ABC');
+  });
+
+  it('produces a clean path when preview=1 is the only query param', () => {
+    setLocation('?preview=1', '', '/join');
+    renderHook(() => usePreviewMode());
+    expect(replaceStateSpy).toHaveBeenCalledWith(null, '', '/join');
+  });
+
+  it('preserves hash and other query params when stripping preview', () => {
+    setLocation('?code=ABC&preview=1', '#section');
+    renderHook(() => usePreviewMode());
+    expect(replaceStateSpy).toHaveBeenCalledWith(
+      null,
+      '',
+      '/quiz?code=ABC#section'
+    );
+  });
+
+  it('does not call replaceState when preview flag is absent', () => {
+    setLocation('?code=ABC');
+    renderHook(() => usePreviewMode());
+    expect(replaceStateSpy).not.toHaveBeenCalled();
+  });
+
+  it('captures preview state on first render — value is stable across rerenders', () => {
+    setLocation('?preview=1');
+    const { result, rerender } = renderHook(() => usePreviewMode());
+    expect(result.current).toBe(true);
+    // Simulate the URL changing after mount (e.g., the very strip we just
+    // performed). The captured value should not flip back to false.
+    setLocation('');
+    rerender();
+    expect(result.current).toBe(true);
+  });
+});

--- a/utils/previewMode.ts
+++ b/utils/previewMode.ts
@@ -1,0 +1,12 @@
+/**
+ * Read the `?preview=1` query flag teachers use to verify the student
+ * URL without burning their Firebase Auth session. When set, the student
+ * routes (`StudentApp`, `QuizStudentApp`, `VideoActivityStudentApp`) skip
+ * `signInAnonymously`, skip SSO auto-join, and render a non-functional
+ * lobby preview behind the `TeacherPreviewBanner`.
+ */
+export const isPreviewMode = (): boolean => {
+  if (typeof window === 'undefined') return false;
+  const params = new URLSearchParams(window.location.search);
+  return params.get('preview') === '1';
+};

--- a/utils/urlHelpers.test.ts
+++ b/utils/urlHelpers.test.ts
@@ -4,6 +4,7 @@ import {
   getJoinUrl,
   convertToEmbedUrl,
   extractGoogleFileId,
+  withPreviewFlag,
 } from './urlHelpers';
 
 describe('urlHelpers', () => {
@@ -97,6 +98,32 @@ describe('urlHelpers', () => {
       delete global.window;
 
       expect(getJoinUrl()).toBe('/join');
+    });
+  });
+
+  describe('withPreviewFlag', () => {
+    it('appends ?preview=1 to a URL with no existing query', () => {
+      expect(withPreviewFlag('https://myschool.com/join')).toBe(
+        'https://myschool.com/join?preview=1'
+      );
+    });
+
+    it('uses & when the URL already carries query params', () => {
+      expect(withPreviewFlag('https://myschool.com/quiz?code=ABC')).toBe(
+        'https://myschool.com/quiz?code=ABC&preview=1'
+      );
+    });
+
+    it('preserves a fragment', () => {
+      expect(withPreviewFlag('https://myschool.com/quiz?code=ABC#frag')).toBe(
+        'https://myschool.com/quiz?code=ABC&preview=1#frag'
+      );
+    });
+
+    it('overwrites an existing preview=0 to preview=1', () => {
+      expect(withPreviewFlag('https://myschool.com/quiz?preview=0')).toBe(
+        'https://myschool.com/quiz?preview=1'
+      );
     });
   });
 

--- a/utils/urlHelpers.ts
+++ b/utils/urlHelpers.ts
@@ -34,6 +34,19 @@ export const getJoinUrl = (): string => {
 };
 
 /**
+ * Append `?preview=1` to a student-facing URL using URLSearchParams so the
+ * result is well-formed regardless of whether `baseUrl` already carries
+ * query parameters. Used by the live-monitor widgets' Preview buttons.
+ */
+export const withPreviewFlag = (baseUrl: string): string => {
+  const fallbackOrigin =
+    typeof window !== 'undefined' ? window.location.origin : 'http://localhost';
+  const url = new URL(baseUrl, fallbackOrigin);
+  url.searchParams.set('preview', '1');
+  return url.toString();
+};
+
+/**
  * Ensures a URL string has a protocol prefix (http:// or https://).
  * Defaults to https:// if missing.
  * @param url The original URL to check


### PR DESCRIPTION
## Summary

- Teachers reported that pasting `/quiz?code=…` into a new tab in the same browser profile redirects them off to the main app, leaving them unsure whether the URL they're about to share with students is even correct.
- Root cause: the PIN→SSO unification in #1555 stopped `QuizStudentApp` / `VideoActivityStudentApp` from replacing the teacher's Firebase session with an anonymous one, so a stale `studentRole: true` token (from prior `/student/login` testing or a `pinLoginV1` bridge) triggers the SSO auto-join under the teacher's UID, and the `AppContent` `isStudentRole` redirect from #1443 then bounces the teacher tab off `/` to `/my-assignments`.
- Adds a `?preview=1` flag + Preview button so teachers can verify the student URL without their session being touched. The flag is also stripped from the URL bar on mount so a teacher copying the URL from the address bar gets the real student URL — not the preview URL.

## What changed

- New utility [utils/previewMode.ts](https://github.com/OPS-PIvers/SpartBoard/blob/claude/exciting-stonebraker-735b98/utils/previewMode.ts) reads `?preview=1`.
- New hook [hooks/usePreviewMode.ts](https://github.com/OPS-PIvers/SpartBoard/blob/claude/exciting-stonebraker-735b98/hooks/usePreviewMode.ts) captures the flag in state on mount, then `history.replaceState`s `preview=1` out of the URL bar.
- New component [components/student/TeacherPreviewBanner.tsx](https://github.com/OPS-PIvers/SpartBoard/blob/claude/exciting-stonebraker-735b98/components/student/TeacherPreviewBanner.tsx) — small `Teacher preview — students will see this exact screen` banner.
- [StudentApp](https://github.com/OPS-PIvers/SpartBoard/blob/claude/exciting-stonebraker-735b98/components/student/StudentApp.tsx), [QuizStudentApp](https://github.com/OPS-PIvers/SpartBoard/blob/claude/exciting-stonebraker-735b98/components/quiz/QuizStudentApp.tsx), and [VideoActivityStudentApp](https://github.com/OPS-PIvers/SpartBoard/blob/claude/exciting-stonebraker-735b98/components/videoActivity/VideoActivityStudentApp.tsx) short-circuit to a static read-only lobby when preview mode is on: no `signInAnonymously`, no claims probe, no SSO auto-join, no Firestore subscriptions.
- [QuizLiveMonitor](https://github.com/OPS-PIvers/SpartBoard/blob/claude/exciting-stonebraker-735b98/components/widgets/QuizWidget/components/QuizLiveMonitor.tsx) gains a `Preview` button next to each `OPEN` button (both copy-URL blocks).
- [LiveControl](https://github.com/OPS-PIvers/SpartBoard/blob/claude/exciting-stonebraker-735b98/components/widgets/LiveControl.tsx) gains a `Preview` button in the session-info menu.

The non-preview path is byte-identical to before — existing SSO auto-join, anon PIN entry, `/student/login`, `/my-assignments`, and the `AppContent` `isStudentRole` redirect all work as they did.

## Test plan

- [ ] Sign in as a teacher, start a quiz session, click the new `PREVIEW` button on `QuizLiveMonitor`. Confirm the new tab's address bar shows `/quiz?code=…` (no `&preview=1`) and the page shows the `Teacher preview` banner + static lobby.
- [ ] Confirm the teacher's main tab stays on `/` unaffected.
- [ ] Repeat for the `LiveControl` widget's session menu — confirm the `Preview` link does the same for `/join`.
- [ ] Repeat by pasting `https://spartboard.web.app/quiz?code=ABC&preview=1`, `https://spartboard.web.app/join?preview=1`, and `https://spartboard.web.app/activity/SESSION_ID?preview=1` manually — confirm the URL bar strips `preview=1` and the lobby renders.
- [ ] As an SSO student via `/student/login`, confirm pasting a URL **without** `?preview=1` still SSO-auto-joins as before.
- [ ] In a fresh incognito window, confirm pasting `?preview=1` still renders the lobby (no auth needed).
- [ ] Confirm `pnpm run test` still passes 2219/2219 (incl. `QuizStudentApp.ssoAutoJoin` and `LiveControl` tests). Type-check, lint, format clean.

## Out of scope

- Cleaning up stale `studentRole: true` tokens on teacher devices (server-side claim revocation + client-side forced refresh). The preview flag avoids the symptom; full token hygiene is a bigger change.
- A fully isolated `'preview'` Firebase app with `inMemoryPersistence`. The current approach is 90% as good at 10% the cost — preview mode doesn't *isolate* auth, it just renders the lobby UI without mounting hooks that touch auth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)