### PR TITLE
feat(quiz,video-activity): teacher-initiated "Unlock attempt" + VA tab-warning parity

### DIFF
--- a/components/quiz/QuizStudentApp.tsx
+++ b/components/quiz/QuizStudentApp.tsx
@@ -687,13 +687,20 @@ const ActiveQuiz: React.FC<{
   const lastReportTimeRef = useRef<number>(0);
   const didInitialCheckRef = useRef(false);
 
-  const handleAutoSubmit = useCallback(async () => {
-    await showAlert(
-      'You have left the quiz 3 times. Your quiz is being auto-submitted.',
-      { title: 'Quiz Auto-Submitted', variant: 'warning' }
-    );
-    await onComplete();
-  }, [showAlert, onComplete]);
+  const handleAutoSubmit = useCallback(
+    async (reason: 'three-strikes' | 'post-unlock' = 'three-strikes') => {
+      const message =
+        reason === 'post-unlock'
+          ? 'Your unlocked attempt is being submitted now.'
+          : 'You have left the quiz 3 times. Your quiz is being auto-submitted.';
+      await showAlert(message, {
+        title: 'Quiz Auto-Submitted',
+        variant: 'warning',
+      });
+      await onComplete();
+    },
+    [showAlert, onComplete]
+  );
 
   // The Visibility Tracker — only active when tabWarningsEnabled
   const tabWarningsEnabled = session.tabWarningsEnabled !== false;
@@ -735,7 +742,7 @@ const ActiveQuiz: React.FC<{
             // Fire-and-forget — but use a finally so a failed submit
             // (e.g. Firestore offline) doesn't leave the listener
             // permanently armed-off via `isWarningShowingRef`.
-            void handleAutoSubmit().finally(() => {
+            void handleAutoSubmit('post-unlock').finally(() => {
               isWarningShowingRef.current = false;
             });
             return;

--- a/components/quiz/QuizStudentApp.tsx
+++ b/components/quiz/QuizStudentApp.tsx
@@ -669,19 +669,19 @@ const ActiveQuiz: React.FC<{
   const [showResumeModal, setShowResumeModal] = useState(
     () => !!myResponse?.unlocked
   );
-  const wasUnlockedRef = useRef<boolean>(!!myResponse?.unlocked);
-
-  useEffect(() => {
-    const isUnlockedNow = !!myResponse?.unlocked;
-    // Edge case: the teacher unlocks while the student is sitting on the
-    // ActiveQuiz screen (e.g. they were mid-flight when the auto-submit
-    // hadn't fired yet, or they bounced back via the rejoin path). When
-    // the flag flips false → true we re-show the prompt.
-    if (isUnlockedNow && !wasUnlockedRef.current) {
+  // Track the previous unlocked value in state (not a ref) so we can
+  // adjust state during render — the CLAUDE.md-blessed alternative to
+  // an effect that watches a prop and calls a setter. Detects the
+  // false→true edge so the prompt re-opens when the teacher unlocks
+  // while the student is still on the active quiz screen.
+  const isUnlockedNow = !!myResponse?.unlocked;
+  const [prevUnlocked, setPrevUnlocked] = useState(isUnlockedNow);
+  if (prevUnlocked !== isUnlockedNow) {
+    setPrevUnlocked(isUnlockedNow);
+    if (isUnlockedNow && !prevUnlocked) {
       setShowResumeModal(true);
     }
-    wasUnlockedRef.current = isUnlockedNow;
-  }, [myResponse?.unlocked]);
+  }
 
   const isWarningShowingRef = useRef<boolean>(false);
   const lastReportTimeRef = useRef<number>(0);
@@ -732,7 +732,12 @@ const ActiveQuiz: React.FC<{
           const wasUnlocked = !!myResponse?.unlocked;
           if (wasUnlocked) {
             setShowCheatWarning(false);
-            void handleAutoSubmit();
+            // Fire-and-forget — but use a finally so a failed submit
+            // (e.g. Firestore offline) doesn't leave the listener
+            // permanently armed-off via `isWarningShowingRef`.
+            void handleAutoSubmit().finally(() => {
+              isWarningShowingRef.current = false;
+            });
             return;
           }
 

--- a/components/quiz/QuizStudentApp.tsx
+++ b/components/quiz/QuizStudentApp.tsx
@@ -39,6 +39,8 @@ import {
   Zap,
   X as XIcon,
   Check,
+  Unlock as UnlockIcon,
+  ShieldAlert,
 } from 'lucide-react';
 import { signInAnonymously, onAuthStateChanged } from 'firebase/auth';
 import { addDoc, collection, serverTimestamp } from 'firebase/firestore';
@@ -659,6 +661,27 @@ const ActiveQuiz: React.FC<{
 }) => {
   const { showAlert } = useDialog();
   const [showCheatWarning, setShowCheatWarning] = useState(false);
+  // Show the "Your teacher unlocked your attempt" modal whenever the
+  // student's response carries `unlocked: true` and they haven't yet
+  // dismissed the prompt in this ActiveQuiz instance. The student keeps
+  // their place and prior answers — dismissing simply reveals the
+  // already-mounted quiz UI underneath.
+  const [showResumeModal, setShowResumeModal] = useState(
+    () => !!myResponse?.unlocked
+  );
+  const wasUnlockedRef = useRef<boolean>(!!myResponse?.unlocked);
+
+  useEffect(() => {
+    const isUnlockedNow = !!myResponse?.unlocked;
+    // Edge case: the teacher unlocks while the student is sitting on the
+    // ActiveQuiz screen (e.g. they were mid-flight when the auto-submit
+    // hadn't fired yet, or they bounced back via the rejoin path). When
+    // the flag flips false → true we re-show the prompt.
+    if (isUnlockedNow && !wasUnlockedRef.current) {
+      setShowResumeModal(true);
+    }
+    wasUnlockedRef.current = isUnlockedNow;
+  }, [myResponse?.unlocked]);
 
   const isWarningShowingRef = useRef<boolean>(false);
   const lastReportTimeRef = useRef<number>(0);
@@ -701,9 +724,19 @@ const ActiveQuiz: React.FC<{
 
         try {
           const newTotal = await reportTabSwitch();
-          setShowCheatWarning(true);
 
-          // Auto-submit if they breach the threshold (e.g., 3 strikes)
+          // Teacher-unlocked attempts skip the "Warning N of 3" modal —
+          // the student has already been told the next strike finalizes
+          // their work, so any further tab-switch auto-submits
+          // immediately (no warning, no delay).
+          const wasUnlocked = !!myResponse?.unlocked;
+          if (wasUnlocked) {
+            setShowCheatWarning(false);
+            void handleAutoSubmit();
+            return;
+          }
+
+          setShowCheatWarning(true);
           if (newTotal >= 3) {
             // Use a slight delay so the UI can update before the dialog
             setTimeout(() => void handleAutoSubmit(), 100);
@@ -737,6 +770,7 @@ const ActiveQuiz: React.FC<{
     reportTabSwitch,
     handleAutoSubmit,
     myResponse?.status,
+    myResponse?.unlocked,
   ]);
 
   // For student-paced mode, the student maintains their own local index
@@ -1221,7 +1255,47 @@ const ActiveQuiz: React.FC<{
 
   return (
     <div className="min-h-screen bg-slate-900 flex flex-col relative">
-      {/* 🔴 NEW: The Cheating Warning Modal */}
+      {/* The "your teacher unlocked your attempt" prompt — covers the quiz
+          UI on first render after a teacher unlock so the student knows
+          what happened before they touch anything. */}
+      {showResumeModal && (
+        <div className="absolute inset-0 z-overlay bg-emerald-900/95 backdrop-blur-sm flex flex-col items-center justify-center p-6 text-center">
+          <UnlockIcon className="w-20 h-20 text-emerald-300 mb-6" />
+          <h2 className="text-4xl font-black text-white mb-4">
+            Attempt Unlocked
+          </h2>
+          <p className="text-emerald-100 text-lg max-w-md mb-2">
+            Your teacher reopened your attempt. Your previous answers are still
+            here — pick up where you left off.
+          </p>
+          <p className="text-amber-200 text-sm max-w-md mb-8">
+            ⚠ The next time you leave this tab or open the quiz in another
+            window, your work will be submitted automatically. No further
+            warnings.
+          </p>
+          <button
+            onClick={() => setShowResumeModal(false)}
+            className="px-8 py-4 bg-white text-emerald-900 font-bold rounded-xl active:scale-95 transition-transform"
+          >
+            Resume Quiz
+          </button>
+        </div>
+      )}
+
+      {/* Persistent "one strike and you're out" banner — visible for the
+          duration of the resumed attempt so the rule stays top-of-mind. */}
+      {myResponse?.unlocked && !showResumeModal && (
+        <div className="flex items-start gap-2 px-4 py-2 bg-amber-500/20 border-b border-amber-500/40 text-amber-200 text-xs">
+          <ShieldAlert className="w-4 h-4 shrink-0 mt-0.5" />
+          <span>
+            Your teacher unlocked your attempt.{' '}
+            <strong>Leaving this tab once more will submit your quiz</strong> —
+            no further warnings.
+          </span>
+        </div>
+      )}
+
+      {/* 🔴 The Cheating Warning Modal */}
       {showCheatWarning && (
         <div className="absolute inset-0 z-overlay bg-red-900/90 backdrop-blur-sm flex flex-col items-center justify-center p-6 text-center">
           <AlertCircle className="w-20 h-20 text-red-500 mb-6 animate-pulse" />

--- a/components/videoActivity/VideoActivityStudentApp.tsx
+++ b/components/videoActivity/VideoActivityStudentApp.tsx
@@ -356,29 +356,33 @@ const JoinAndPlay: React.FC<JoinAndPlayProps> = ({
   const [showResumeModal, setShowResumeModal] = useState(
     () => !!myResponse?.unlocked
   );
-  const wasUnlockedRef = useRef<boolean>(!!myResponse?.unlocked);
   const isWarningShowingRef = useRef<boolean>(false);
   const lastReportTimeRef = useRef<number>(0);
   const didInitialCheckRef = useRef(false);
 
-  useEffect(() => {
-    if (myResponse?.tabSwitchWarnings != null) {
-      setWarningCount((prev) =>
-        Math.max(prev, myResponse.tabSwitchWarnings ?? 0)
-      );
+  // Track the previous `tabSwitchWarnings` value via state-during-render
+  // so we can sync the local counter without an extra effect pass.
+  const serverWarnings = myResponse?.tabSwitchWarnings ?? 0;
+  const [prevServerWarnings, setPrevServerWarnings] = useState(serverWarnings);
+  if (prevServerWarnings !== serverWarnings) {
+    setPrevServerWarnings(serverWarnings);
+    if (serverWarnings > warningCount) {
+      setWarningCount(serverWarnings);
     }
-  }, [myResponse?.tabSwitchWarnings]);
+  }
 
-  useEffect(() => {
-    const isUnlockedNow = !!myResponse?.unlocked;
-    // Re-show the resume prompt whenever the teacher flips the flag back on
-    // (e.g. the student was sitting on the post-submit screen when unlock
-    // fired and the parent re-renders the active view).
-    if (isUnlockedNow && !wasUnlockedRef.current) {
+  // Same render-time pattern for the unlock-edge detector: when the
+  // teacher flips `unlocked` from false → true (e.g. the student was
+  // sitting on the post-submit screen when unlock fired) re-open the
+  // resume prompt without an effect/setState round-trip.
+  const isUnlockedNow = !!myResponse?.unlocked;
+  const [prevUnlocked, setPrevUnlocked] = useState(isUnlockedNow);
+  if (prevUnlocked !== isUnlockedNow) {
+    setPrevUnlocked(isUnlockedNow);
+    if (isUnlockedNow && !prevUnlocked) {
       setShowResumeModal(true);
     }
-    wasUnlockedRef.current = isUnlockedNow;
-  }, [myResponse?.unlocked]);
+  }
 
   const handleAutoSubmit = useCallback(async () => {
     await showAlert(
@@ -424,7 +428,12 @@ const JoinAndPlay: React.FC<JoinAndPlayProps> = ({
           const wasUnlocked = !!myResponse?.unlocked;
           if (wasUnlocked) {
             setShowCheatWarning(false);
-            void handleAutoSubmit();
+            // Always release the visibility lock — a failed submit
+            // (Firestore offline) must not leave the handler
+            // permanently armed-off.
+            void handleAutoSubmit().finally(() => {
+              isWarningShowingRef.current = false;
+            });
             return;
           }
 

--- a/components/videoActivity/VideoActivityStudentApp.tsx
+++ b/components/videoActivity/VideoActivityStudentApp.tsx
@@ -22,7 +22,10 @@ import {
   CheckCircle2,
   ClipboardList,
   Trophy,
+  Unlock as UnlockIcon,
+  ShieldAlert,
 } from 'lucide-react';
+import { useDialog } from '@/context/useDialog';
 import { addDoc, collection, serverTimestamp } from 'firebase/firestore';
 import { auth, db } from '@/config/firebase';
 import { logError } from '@/utils/logError';
@@ -158,6 +161,7 @@ const JoinAndPlay: React.FC<JoinAndPlayProps> = ({
     joinSession,
     submitAnswer,
     completeActivity,
+    reportTabSwitch,
   } = useVideoActivitySessionStudent();
 
   const isViewOnly = session?.mode === 'view-only';
@@ -342,6 +346,126 @@ const JoinAndPlay: React.FC<JoinAndPlayProps> = ({
     if (isViewOnly) return;
     await completeActivity();
   }, [completeActivity, isViewOnly]);
+
+  // ── Tab-switch warning system (mirrors QuizStudentApp) ──────────────────
+  const { showAlert } = useDialog();
+  const [showCheatWarning, setShowCheatWarning] = useState(false);
+  const [warningCount, setWarningCount] = useState(
+    () => myResponse?.tabSwitchWarnings ?? 0
+  );
+  const [showResumeModal, setShowResumeModal] = useState(
+    () => !!myResponse?.unlocked
+  );
+  const wasUnlockedRef = useRef<boolean>(!!myResponse?.unlocked);
+  const isWarningShowingRef = useRef<boolean>(false);
+  const lastReportTimeRef = useRef<number>(0);
+  const didInitialCheckRef = useRef(false);
+
+  useEffect(() => {
+    if (myResponse?.tabSwitchWarnings != null) {
+      setWarningCount((prev) =>
+        Math.max(prev, myResponse.tabSwitchWarnings ?? 0)
+      );
+    }
+  }, [myResponse?.tabSwitchWarnings]);
+
+  useEffect(() => {
+    const isUnlockedNow = !!myResponse?.unlocked;
+    // Re-show the resume prompt whenever the teacher flips the flag back on
+    // (e.g. the student was sitting on the post-submit screen when unlock
+    // fired and the parent re-renders the active view).
+    if (isUnlockedNow && !wasUnlockedRef.current) {
+      setShowResumeModal(true);
+    }
+    wasUnlockedRef.current = isUnlockedNow;
+  }, [myResponse?.unlocked]);
+
+  const handleAutoSubmit = useCallback(async () => {
+    await showAlert(
+      'You have left the activity 3 times. Your activity is being auto-submitted.',
+      { title: 'Activity Auto-Submitted', variant: 'warning' }
+    );
+    await completeActivity();
+  }, [showAlert, completeActivity]);
+
+  const tabWarningsEnabled =
+    session?.sessionOptions?.tabWarningsEnabled !== false;
+
+  useEffect(() => {
+    if (!tabWarningsEnabled) return;
+    if (joinStatus !== 'joined') return;
+    if (session?.status !== 'active') return;
+    if (isViewOnly) return;
+
+    const handleVisibilityChange = async () => {
+      // Skip while a warning is already showing, while a question overlay
+      // is active (the player blurs to render it), and once the student
+      // has finished.
+      if (isWarningShowingRef.current || myResponse?.completedAt != null) {
+        return;
+      }
+
+      const now = Date.now();
+      if (now - lastReportTimeRef.current < 1000) return;
+
+      const isPageHidden = document.visibilityState === 'hidden';
+      const isWindowBlurred = !document.hasFocus();
+
+      if (isPageHidden || isWindowBlurred) {
+        lastReportTimeRef.current = now;
+        isWarningShowingRef.current = true;
+
+        try {
+          const newTotal = await reportTabSwitch();
+          setWarningCount(newTotal);
+
+          // Teacher-unlocked attempts skip the warning modal — any
+          // further strike finalizes the attempt instantly.
+          const wasUnlocked = !!myResponse?.unlocked;
+          if (wasUnlocked) {
+            setShowCheatWarning(false);
+            void handleAutoSubmit();
+            return;
+          }
+
+          setShowCheatWarning(true);
+          if (newTotal >= 3) {
+            setTimeout(() => void handleAutoSubmit(), 100);
+          }
+        } catch (err) {
+          logError('VideoActivityStudentApp.reportTabSwitch', err, {
+            sessionId,
+          });
+          setShowCheatWarning(true);
+        }
+      }
+    };
+
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+    window.addEventListener('blur', handleVisibilityChange);
+
+    if (!didInitialCheckRef.current) {
+      didInitialCheckRef.current = true;
+      if (document.visibilityState === 'hidden') {
+        void handleVisibilityChange();
+      }
+    }
+
+    return () => {
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+      window.removeEventListener('blur', handleVisibilityChange);
+    };
+  }, [
+    tabWarningsEnabled,
+    joinStatus,
+    session?.status,
+    isViewOnly,
+    reportTabSwitch,
+    handleAutoSubmit,
+    myResponse?.completedAt,
+    myResponse?.unlocked,
+    sessionId,
+  ]);
 
   // ── Invalid / missing session ID ──────────────────────────────────────────
 
@@ -578,6 +702,12 @@ const JoinAndPlay: React.FC<JoinAndPlayProps> = ({
                 </p>
               )}
 
+              {(myResponse?.tabSwitchWarnings ?? 0) >= 3 && (
+                <div className="p-3 bg-amber-50 border border-amber-200 rounded-xl text-amber-700 text-sm">
+                  Auto-submitted because you left the activity tab 3 times.
+                </div>
+              )}
+
               <div className="flex items-center justify-center gap-2 text-emerald-600 text-sm font-bold">
                 <CheckCircle2 className="w-4 h-4" />
                 Results submitted to your teacher
@@ -595,7 +725,78 @@ const JoinAndPlay: React.FC<JoinAndPlayProps> = ({
   const totalQuestions = sortedQuestions.length;
 
   return (
-    <div className="h-screen h-dvh overflow-hidden bg-slate-950 flex flex-col">
+    <div className="h-screen h-dvh overflow-hidden bg-slate-950 flex flex-col relative">
+      {/* Resume prompt — covers the player on first render after a teacher
+          unlock so the student knows what happened before they touch
+          anything. */}
+      {showResumeModal && (
+        <div className="absolute inset-0 z-50 bg-emerald-900/95 backdrop-blur-sm flex flex-col items-center justify-center p-6 text-center">
+          <UnlockIcon className="w-20 h-20 text-emerald-300 mb-6" />
+          <h2 className="text-4xl font-black text-white mb-4">
+            Attempt Unlocked
+          </h2>
+          <p className="text-emerald-100 text-lg max-w-md mb-2">
+            Your teacher reopened your attempt. Your previous answers are still
+            here — pick up where you left off.
+          </p>
+          <p className="text-amber-200 text-sm max-w-md mb-8">
+            ⚠ The next time you leave this tab or open the activity in another
+            window, your work will be submitted automatically. No further
+            warnings.
+          </p>
+          <button
+            onClick={() => setShowResumeModal(false)}
+            className="px-8 py-4 bg-white text-emerald-900 font-bold rounded-xl active:scale-95 transition-transform"
+          >
+            Resume Activity
+          </button>
+        </div>
+      )}
+
+      {/* Tab-switch warning modal — same red full-screen style as the
+          Quiz cheat warning. Hidden for teacher-unlocked attempts, which
+          finalize on the next strike instead. */}
+      {showCheatWarning && (
+        <div className="absolute inset-0 z-50 bg-red-900/90 backdrop-blur-sm flex flex-col items-center justify-center p-6 text-center">
+          <AlertCircle className="w-20 h-20 text-red-500 mb-6 animate-pulse" />
+          <h2 className="text-4xl font-black text-white mb-4">
+            TAB SWITCH DETECTED
+          </h2>
+          <p className="text-red-200 text-lg max-w-md mb-8">
+            You navigated away from the activity. This incident has been logged.
+            <br />
+            <br />
+            <strong>Warning {warningCount} of 3.</strong> If you reach 3
+            warnings, your activity will automatically submit.
+          </p>
+          <button
+            onClick={() => {
+              setShowCheatWarning(false);
+              isWarningShowingRef.current = false;
+            }}
+            className="px-8 py-4 bg-white text-red-900 font-bold rounded-xl active:scale-95 transition-transform"
+          >
+            I Understand, Return to Activity
+          </button>
+        </div>
+      )}
+
+      {/* Persistent "one strike and you're out" banner for unlocked
+          attempts. Sits above the top bar so it's visible alongside the
+          progress counter. */}
+      {myResponse?.unlocked && !showResumeModal && (
+        <div className="flex items-start gap-2 px-4 py-2 bg-amber-500/20 border-b border-amber-500/40 text-amber-200 text-xs shrink-0">
+          <ShieldAlert className="w-4 h-4 shrink-0 mt-0.5" />
+          <span>
+            Your teacher unlocked your attempt.{' '}
+            <strong>
+              Leaving this tab once more will submit your activity
+            </strong>{' '}
+            — no further warnings.
+          </span>
+        </div>
+      )}
+
       {/* Top bar */}
       <div className="bg-slate-900 px-4 py-2 flex items-center justify-between shrink-0">
         <div className="flex items-center gap-2">

--- a/components/videoActivity/VideoActivityStudentApp.tsx
+++ b/components/videoActivity/VideoActivityStudentApp.tsx
@@ -384,13 +384,20 @@ const JoinAndPlay: React.FC<JoinAndPlayProps> = ({
     }
   }
 
-  const handleAutoSubmit = useCallback(async () => {
-    await showAlert(
-      'You have left the activity 3 times. Your activity is being auto-submitted.',
-      { title: 'Activity Auto-Submitted', variant: 'warning' }
-    );
-    await completeActivity();
-  }, [showAlert, completeActivity]);
+  const handleAutoSubmit = useCallback(
+    async (reason: 'three-strikes' | 'post-unlock' = 'three-strikes') => {
+      const message =
+        reason === 'post-unlock'
+          ? 'Your unlocked attempt is being submitted now.'
+          : 'You have left the activity 3 times. Your activity is being auto-submitted.';
+      await showAlert(message, {
+        title: 'Activity Auto-Submitted',
+        variant: 'warning',
+      });
+      await completeActivity();
+    },
+    [showAlert, completeActivity]
+  );
 
   const tabWarningsEnabled =
     session?.sessionOptions?.tabWarningsEnabled !== false;
@@ -431,7 +438,7 @@ const JoinAndPlay: React.FC<JoinAndPlayProps> = ({
             // Always release the visibility lock — a failed submit
             // (Firestore offline) must not leave the handler
             // permanently armed-off.
-            void handleAutoSubmit().finally(() => {
+            void handleAutoSubmit('post-unlock').finally(() => {
               isWarningShowingRef.current = false;
             });
             return;

--- a/components/widgets/QuizWidget/Widget.tsx
+++ b/components/widgets/QuizWidget/Widget.tsx
@@ -123,6 +123,7 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
     advanceQuestion,
     endQuizSession,
     removeStudent,
+    unlockStudentAttempt,
     revealAnswer,
     hideAnswer,
   } = useQuizSessionTeacher(config.activeAssignmentId);
@@ -954,6 +955,7 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
         rosters={rosters}
         onUpdateConfig={handleUpdateQuizConfig}
         onRemoveStudent={removeStudent}
+        onUnlockStudent={unlockStudentAttempt}
         onRevealAnswer={revealAnswer}
         onHideAnswer={hideAnswer}
         onBack={() => {

--- a/components/widgets/QuizWidget/components/QuizLiveMonitor.tsx
+++ b/components/widgets/QuizWidget/components/QuizLiveMonitor.tsx
@@ -37,6 +37,8 @@ import {
   Pause,
   Play,
   ArrowLeft,
+  Lock,
+  Unlock,
 } from 'lucide-react';
 import { deleteField, doc, updateDoc } from 'firebase/firestore';
 import {
@@ -98,6 +100,11 @@ interface QuizLiveMonitorProps {
    * NOT the `studentUid` field.
    */
   onRemoveStudent?: (responseKey: string) => Promise<void>;
+  /**
+   * Unlock a student's locked/auto-submitted attempt so they can resume.
+   * Pass `response._responseKey` (snapshot doc id), NOT `studentUid`.
+   */
+  onUnlockStudent?: (responseKey: string) => Promise<void>;
   onRevealAnswer?: (questionId: string, correctAnswer: string) => Promise<void>;
   onHideAnswer?: (questionId: string) => Promise<void>;
   /** Navigate back to the manager view without ending the quiz. */
@@ -270,6 +277,7 @@ export const QuizLiveMonitor: React.FC<QuizLiveMonitorProps> = ({
   rosters,
   onUpdateConfig,
   onRemoveStudent,
+  onUnlockStudent,
   onRevealAnswer,
   onHideAnswer,
   onBack,
@@ -501,6 +509,36 @@ export const QuizLiveMonitor: React.FC<QuizLiveMonitorProps> = ({
         );
       },
     [addToast]
+  );
+
+  const handleUnlockStudent = useCallback(
+    async (responseKey: string, displayName: string) => {
+      if (!onUnlockStudent) return;
+      const ok = await showConfirm(
+        `Reopen ${displayName}'s attempt so they can resume? Their previous answers will be kept. The next time they leave the quiz tab, their work will be submitted automatically.`,
+        {
+          title: 'Unlock attempt?',
+          variant: 'warning',
+          confirmLabel: 'Unlock',
+          cancelLabel: 'Cancel',
+        }
+      );
+      if (!ok) return;
+      try {
+        await onUnlockStudent(responseKey);
+        addToast(
+          `${displayName}'s attempt is unlocked — they can resume now.`,
+          'success'
+        );
+      } catch (err) {
+        logError('QuizLiveMonitor.unlockStudent', err);
+        addToast(
+          `Could not unlock ${displayName}'s attempt — try again or check your connection.`,
+          'error'
+        );
+      }
+    },
+    [onUnlockStudent, showConfirm, addToast]
   );
 
   const handleToggleColors = useCallback(() => {
@@ -1595,6 +1633,7 @@ export const QuizLiveMonitor: React.FC<QuizLiveMonitorProps> = ({
                                 showTabWarnings &&
                                 session.tabWarningsEnabled !== false
                               }
+                              attemptLimit={session.attemptLimit}
                               confirmRemove={confirmRemove === rowKey}
                               onConfirmRemoveToggle={() =>
                                 setConfirmRemove(
@@ -1610,6 +1649,15 @@ export const QuizLiveMonitor: React.FC<QuizLiveMonitorProps> = ({
                                         .then(() => setConfirmRemove(null))
                                         .catch(() => undefined);
                                     }
+                                  : undefined
+                              }
+                              onUnlock={
+                                onUnlockStudent
+                                  ? (displayName) =>
+                                      void handleUnlockStudent(
+                                        rowKey,
+                                        displayName
+                                      )
                                   : undefined
                               }
                               pinToName={pinToName}
@@ -1980,6 +2028,7 @@ export const QuizLiveMonitor: React.FC<QuizLiveMonitorProps> = ({
                                 showTabWarnings &&
                                 session.tabWarningsEnabled !== false
                               }
+                              attemptLimit={session.attemptLimit}
                               confirmRemove={confirmRemove === rowKey}
                               onConfirmRemoveToggle={() =>
                                 setConfirmRemove(
@@ -1995,6 +2044,15 @@ export const QuizLiveMonitor: React.FC<QuizLiveMonitorProps> = ({
                                         .then(() => setConfirmRemove(null))
                                         .catch(() => undefined);
                                     }
+                                  : undefined
+                              }
+                              onUnlock={
+                                onUnlockStudent
+                                  ? (displayName) =>
+                                      void handleUnlockStudent(
+                                        rowKey,
+                                        displayName
+                                      )
                                   : undefined
                               }
                               pinToName={pinToName}
@@ -2429,9 +2487,14 @@ const StudentRow: React.FC<{
   /** Right-column score pill content. */
   scoreDisplay: 'percent' | 'count' | 'hidden';
   showTabWarnings: boolean;
+  /** Session-configured attempt cap; null/undefined = unlimited. */
+  attemptLimit: number | null | undefined;
   confirmRemove: boolean;
   onConfirmRemoveToggle: () => void;
   onRemove?: () => void;
+  /** Invoked with the resolved roster display name so the confirm dialog
+      can use a friendly phrasing without re-resolving inside the row. */
+  onUnlock?: (displayName: string) => void;
   pinToName: Record<string, string>;
   byStudentUid?: Map<
     string,
@@ -2445,9 +2508,11 @@ const StudentRow: React.FC<{
   colorsEnabled,
   scoreDisplay,
   showTabWarnings,
+  attemptLimit,
   confirmRemove,
   onConfirmRemoveToggle,
   onRemove,
+  onUnlock,
   pinToName,
   byStudentUid,
 }) => {
@@ -2619,6 +2684,81 @@ const StudentRow: React.FC<{
             {warnings}
           </span>
         )}
+
+        {/* Lock indicator + unlock action. A row is "locked" when the
+            student's attempt was auto-submitted by the tab-switch
+            tripwire (3+ warnings on a completed response) or when they
+            hit the cross-launch attempt cap. The teacher clicks to
+            reopen the attempt — the underlying answers are preserved
+            and the next strike will finalize immediately. */}
+        {(() => {
+          if (!onUnlock) return null;
+          const isAutoSubmittedByWarnings =
+            response.status === 'completed' &&
+            warnings >= 3 &&
+            !response.unlocked;
+          const completedCount = response.completedAttempts ?? 0;
+          const hitAttemptCap =
+            typeof attemptLimit === 'number' &&
+            attemptLimit > 0 &&
+            completedCount >= attemptLimit &&
+            !response.unlocked;
+          const isLocked = isAutoSubmittedByWarnings || hitAttemptCap;
+          if (isLocked) {
+            return (
+              <button
+                type="button"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onUnlock(displayName);
+                }}
+                className="flex items-center gap-0.5 bg-amber-100 hover:bg-amber-200 text-amber-800 rounded uppercase font-black shrink-0 transition-colors"
+                style={{
+                  fontSize: 'min(9px, 2.5cqmin)',
+                  padding: 'min(2px, 0.5cqmin) min(6px, 1.5cqmin)',
+                }}
+                title={
+                  isAutoSubmittedByWarnings
+                    ? 'Auto-submitted from tab-switch warnings — click to allow resume'
+                    : 'Attempt limit reached — click to allow resume'
+                }
+                aria-label={`Unlock ${displayName}'s attempt`}
+              >
+                <Lock
+                  style={{
+                    width: 'min(12px, 3cqmin)',
+                    height: 'min(12px, 3cqmin)',
+                  }}
+                />
+                Locked
+              </button>
+            );
+          }
+          if (
+            response.unlocked &&
+            (response.status === 'in-progress' || response.status === 'joined')
+          ) {
+            return (
+              <span
+                className="flex items-center gap-0.5 bg-emerald-100 text-emerald-800 rounded uppercase font-black shrink-0"
+                style={{
+                  fontSize: 'min(9px, 2.5cqmin)',
+                  padding: 'min(2px, 0.5cqmin) min(6px, 1.5cqmin)',
+                }}
+                title="Unlocked — one more tab-switch will finalize the attempt"
+              >
+                <Unlock
+                  style={{
+                    width: 'min(12px, 3cqmin)',
+                    height: 'min(12px, 3cqmin)',
+                  }}
+                />
+                Resumed
+              </span>
+            );
+          }
+          return null;
+        })()}
       </span>
       {pillText !== null && (
         <span

--- a/components/widgets/VideoActivityWidget/Widget.tsx
+++ b/components/widgets/VideoActivityWidget/Widget.tsx
@@ -95,6 +95,7 @@ export const VideoActivityWidget: React.FC<{ widget: WidgetData }> = ({
     liveSession,
     subscribeToSession,
     unsubscribeFromSession,
+    unlockStudentAttempt,
   } = useVideoActivitySessionTeacher();
 
   const {
@@ -402,6 +403,7 @@ export const VideoActivityWidget: React.FC<{ widget: WidgetData }> = ({
             );
           }
         }}
+        onUnlockStudent={unlockStudentAttempt}
         onBack={() => {
           unsubscribeFromSession();
           setSelectedSession(null);

--- a/components/widgets/VideoActivityWidget/components/VideoActivityLiveMonitor.tsx
+++ b/components/widgets/VideoActivityWidget/components/VideoActivityLiveMonitor.tsx
@@ -11,14 +11,17 @@
 
 import React, { useCallback, useMemo, useState } from 'react';
 import {
+  AlertTriangle,
   ArrowLeft,
   CheckCircle2,
   Circle,
   Clock,
   Loader2,
+  Lock,
   Pause,
   Play,
   Square,
+  Unlock,
   Users,
   XCircle,
 } from 'lucide-react';
@@ -29,11 +32,13 @@ import {
 } from '@/types';
 import { useDialog } from '@/context/useDialog';
 import { useAuth } from '@/context/useAuth';
+import { useDashboard } from '@/context/useDashboard';
 import {
   useAssignmentPseudonymsMulti,
   formatStudentName,
 } from '@/hooks/useAssignmentPseudonyms';
 import { ScaledEmptyState } from '@/components/common/ScaledEmptyState';
+import { logError } from '@/utils/logError';
 
 interface VideoActivityLiveMonitorProps {
   session: VideoActivitySession;
@@ -47,6 +52,11 @@ interface VideoActivityLiveMonitorProps {
   onPause?: () => Promise<void>;
   /** Resume a paused assignment. */
   onResume?: () => Promise<void>;
+  /**
+   * Unlock a student's locked/auto-submitted attempt so they can resume.
+   * Pass the response's `_responseKey`, not `studentUid`.
+   */
+  onUnlockStudent?: (sessionId: string, responseKey: string) => Promise<void>;
   /** Navigate back to the manager (In Progress tab) without ending. */
   onBack?: () => void;
 }
@@ -63,6 +73,15 @@ interface StudentRowProps {
    * back through `response.name` and finally `response.pin`.
    */
   byStudentUid: Map<string, { givenName: string; familyName: string }>;
+  /** When true, show the per-row tab-switch warning count badge. */
+  showTabWarnings: boolean;
+  /** Session attempt cap; null/undefined = unlimited. Drives the lock UI. */
+  attemptLimit: number | null | undefined;
+  /**
+   * Invoked when the teacher taps the lock chip. Receives the resolved
+   * display name so the confirmation dialog can name the student.
+   */
+  onUnlock?: (displayName: string) => void;
 }
 
 /**
@@ -90,7 +109,12 @@ const StudentRow: React.FC<StudentRowProps> = ({
   response,
   questions,
   byStudentUid,
+  showTabWarnings,
+  attemptLimit,
+  onUnlock,
 }) => {
+  const warnings = response.tabSwitchWarnings ?? 0;
+  const displayName = pickDisplayLabel(response, byStudentUid) ?? '—';
   const correctAnswerById = useMemo(() => {
     const m = new Map<string, string>();
     for (const q of questions) m.set(q.id, q.correctAnswer);
@@ -152,7 +176,7 @@ const StudentRow: React.FC<StudentRowProps> = ({
             className="font-bold text-slate-800 truncate"
             style={{ fontSize: 'min(13px, 4cqmin)' }}
           >
-            {pickDisplayLabel(response, byStudentUid) ?? '—'}
+            {displayName}
           </p>
           {response.classPeriod && (
             <span
@@ -186,6 +210,84 @@ const StudentRow: React.FC<StudentRowProps> = ({
               In progress
             </span>
           )}
+          {showTabWarnings && warnings > 0 && (
+            <span
+              className="flex items-center gap-0.5 bg-red-100 text-red-700 px-1.5 py-0.5 rounded uppercase font-black shrink-0"
+              style={{ fontSize: 'min(9px, 2.5cqmin)' }}
+              title={`${warnings} Tab Switch Warning(s)`}
+            >
+              <AlertTriangle
+                style={{
+                  width: 'min(12px, 3cqmin)',
+                  height: 'min(12px, 3cqmin)',
+                }}
+              />
+              {warnings}
+            </span>
+          )}
+          {(() => {
+            if (!onUnlock) return null;
+            const isAutoSubmittedByWarnings =
+              completed && warnings >= 3 && !response.unlocked;
+            const completedCount = response.completedAttempts ?? 0;
+            const hitAttemptCap =
+              typeof attemptLimit === 'number' &&
+              attemptLimit > 0 &&
+              completedCount >= attemptLimit &&
+              !response.unlocked;
+            const isLocked = isAutoSubmittedByWarnings || hitAttemptCap;
+            if (isLocked) {
+              return (
+                <button
+                  type="button"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onUnlock(displayName);
+                  }}
+                  className="flex items-center gap-0.5 bg-amber-100 hover:bg-amber-200 text-amber-800 rounded uppercase font-black shrink-0 transition-colors"
+                  style={{
+                    fontSize: 'min(9px, 2.5cqmin)',
+                    padding: 'min(2px, 0.5cqmin) min(6px, 1.5cqmin)',
+                  }}
+                  title={
+                    isAutoSubmittedByWarnings
+                      ? 'Auto-submitted from tab-switch warnings — click to allow resume'
+                      : 'Attempt limit reached — click to allow resume'
+                  }
+                  aria-label={`Unlock ${displayName}'s attempt`}
+                >
+                  <Lock
+                    style={{
+                      width: 'min(12px, 3cqmin)',
+                      height: 'min(12px, 3cqmin)',
+                    }}
+                  />
+                  Locked
+                </button>
+              );
+            }
+            if (response.unlocked && !completed) {
+              return (
+                <span
+                  className="flex items-center gap-0.5 bg-emerald-100 text-emerald-800 rounded uppercase font-black shrink-0"
+                  style={{
+                    fontSize: 'min(9px, 2.5cqmin)',
+                    padding: 'min(2px, 0.5cqmin) min(6px, 1.5cqmin)',
+                  }}
+                  title="Unlocked — one more tab-switch will finalize the attempt"
+                >
+                  <Unlock
+                    style={{
+                      width: 'min(12px, 3cqmin)',
+                      height: 'min(12px, 3cqmin)',
+                    }}
+                  />
+                  Resumed
+                </span>
+              );
+            }
+            return null;
+          })()}
         </div>
         <p
           className="text-slate-400"
@@ -308,9 +410,52 @@ const StatTile: React.FC<StatTileProps> = ({ label, value, icon, color }) => {
 
 export const VideoActivityLiveMonitor: React.FC<
   VideoActivityLiveMonitorProps
-> = ({ session, responses, onEnd, onPause, onResume, onBack }) => {
+> = ({
+  session,
+  responses,
+  onEnd,
+  onPause,
+  onResume,
+  onUnlockStudent,
+  onBack,
+}) => {
   const { showConfirm } = useDialog();
+  const { addToast } = useDashboard();
   const { orgId } = useAuth();
+  // Toggle for showing per-row tab-switch warning counts. Off by default
+  // so projector-friendly mode keeps the roster uncluttered; the teacher
+  // flips it on when triaging a locked student. Mirrors the Quiz pattern.
+  const [showTabWarnings, setShowTabWarnings] = useState(false);
+
+  const handleUnlock = useCallback(
+    async (responseKey: string, displayName: string) => {
+      if (!onUnlockStudent) return;
+      const ok = await showConfirm(
+        `Reopen ${displayName}'s attempt so they can resume? Their previous answers will be kept. The next time they leave the activity tab, their work will be submitted automatically.`,
+        {
+          title: 'Unlock attempt?',
+          variant: 'warning',
+          confirmLabel: 'Unlock',
+          cancelLabel: 'Cancel',
+        }
+      );
+      if (!ok) return;
+      try {
+        await onUnlockStudent(session.id, responseKey);
+        addToast(
+          `${displayName}'s attempt is unlocked — they can resume now.`,
+          'success'
+        );
+      } catch (err) {
+        logError('VideoActivityLiveMonitor.unlockStudent', err);
+        addToast(
+          `Could not unlock ${displayName}'s attempt — try again or check your connection.`,
+          'error'
+        );
+      }
+    },
+    [onUnlockStudent, session.id, showConfirm, addToast]
+  );
   // SSO `studentRole` responses carry no PIN or self-typed name; resolve
   // their roster identities here so the monitor row labels stay populated.
   // Use the multi-class variant — `session.classId` is a transitional
@@ -608,12 +753,42 @@ export const VideoActivityLiveMonitor: React.FC<
               >
                 Roster · {responses.length}
               </span>
-              <span
-                className="text-slate-400"
-                style={{ fontSize: 'min(9px, 2.5cqmin)' }}
+              <div
+                className="flex items-center"
+                style={{ gap: 'min(8px, 2cqmin)' }}
               >
-                {totalAnswers} total answer{totalAnswers === 1 ? '' : 's'}
-              </span>
+                {session.sessionOptions?.tabWarningsEnabled !== false && (
+                  <button
+                    type="button"
+                    onClick={() => setShowTabWarnings((v) => !v)}
+                    className={`flex items-center gap-1 rounded-md font-bold transition-colors ${
+                      showTabWarnings
+                        ? 'bg-red-100 text-red-700'
+                        : 'bg-slate-100 text-slate-500 hover:bg-slate-200'
+                    }`}
+                    style={{
+                      fontSize: 'min(9px, 2.5cqmin)',
+                      padding: 'min(2px, 0.5cqmin) min(6px, 1.5cqmin)',
+                    }}
+                    title="Show/hide tab switch warnings in roster"
+                  >
+                    <AlertTriangle
+                      style={{
+                        width: 'min(11px, 3cqmin)',
+                        height: 'min(11px, 3cqmin)',
+                      }}
+                    />
+                    Warnings
+                  </button>
+                )}
+                <span
+                  className="text-slate-400"
+                  style={{ fontSize: 'min(9px, 2.5cqmin)' }}
+                >
+                  {totalAnswers} total answer
+                  {totalAnswers === 1 ? '' : 's'}
+                </span>
+              </div>
             </div>
 
             {responses.length === 0 ? (
@@ -627,14 +802,28 @@ export const VideoActivityLiveMonitor: React.FC<
                 className="flex flex-col"
                 style={{ gap: 'min(6px, 1.5cqmin)' }}
               >
-                {sortedResponses.map((r) => (
-                  <StudentRow
-                    key={r.studentUid}
-                    response={r}
-                    questions={questions}
-                    byStudentUid={byStudentUid}
-                  />
-                ))}
+                {sortedResponses.map((r) => {
+                  const rowKey = r._responseKey ?? r.studentUid;
+                  return (
+                    <StudentRow
+                      key={rowKey}
+                      response={r}
+                      questions={questions}
+                      byStudentUid={byStudentUid}
+                      showTabWarnings={
+                        showTabWarnings &&
+                        session.sessionOptions?.tabWarningsEnabled !== false
+                      }
+                      attemptLimit={session.sessionOptions?.attemptLimit}
+                      onUnlock={
+                        onUnlockStudent
+                          ? (displayName) =>
+                              void handleUnlock(rowKey, displayName)
+                          : undefined
+                      }
+                    />
+                  );
+                })}
               </div>
             )}
           </div>

--- a/firestore.rules
+++ b/firestore.rules
@@ -1593,7 +1593,13 @@ service cloud.firestore {
            (!request.resource.data.diff(resource.data).affectedKeys().hasAny(['preSyncVersion']) ||
             request.resource.data.preSyncVersion == 0) &&
            request.resource.data.diff(resource.data)
-             .changedKeys().hasOnly(['answers', 'status', 'submittedAt', 'tabSwitchWarnings', 'completedAttempts', 'classPeriod', 'score', 'preSyncVersion']) &&
+             .changedKeys().hasOnly(['answers', 'status', 'submittedAt', 'tabSwitchWarnings', 'completedAttempts', 'classPeriod', 'score', 'preSyncVersion', 'unlocked']) &&
+           // Students may only ever CLEAR the unlock flag (write `false`)
+           // — never set it to true. The teacher's unlock action sets
+           // `unlocked: true`; `completeQuiz` clears it back to false
+           // when the resumed attempt is finalized.
+           (!request.resource.data.diff(resource.data).affectedKeys().hasAny(['unlocked']) ||
+            request.resource.data.get('unlocked', false) == false) &&
            (!request.resource.data.diff(resource.data).affectedKeys().hasAny(['tabSwitchWarnings']) ||
             request.resource.data.tabSwitchWarnings >= resource.data.get('tabSwitchWarnings', 0)) &&
            (!request.resource.data.diff(resource.data).affectedKeys().hasAny(['completedAttempts']) ||
@@ -1697,12 +1703,20 @@ service cloud.firestore {
          request.resource.data.completedAttempts == resource.data.completedAttempts + 1 &&
          request.resource.data.lastAttemptAt is number)
         ||
-        // Teacher reset branch — set completedAttempts back to 0.
+        // Teacher reset/refund branch — decrease completedAttempts.
+        // Used by `removeStudent` (effectively resets to 0 via batch
+        // delete, kept here for compatibility) and `unlockStudentAttempt`
+        // (refunds one attempt so the student isn't immediately re-blocked
+        // by the cap on resume). The teacher may only DECREASE the
+        // counter, never inflate it — this preserves the cap as an
+        // anti-cheating defense while permitting deliberate refunds.
         (request.auth.uid == resource.data.teacherUid &&
          request.resource.data.studentUid == resource.data.studentUid &&
          request.resource.data.quizId == resource.data.quizId &&
          request.resource.data.teacherUid == resource.data.teacherUid &&
-         request.resource.data.completedAttempts == 0)
+         request.resource.data.get('completedAttempts', 0) >= 0 &&
+         request.resource.data.get('completedAttempts', 0) <=
+           resource.data.get('completedAttempts', 0))
         ||
         isAdmin()
       );
@@ -1739,11 +1753,17 @@ service cloud.firestore {
          request.resource.data.completedAttempts == resource.data.completedAttempts + 1 &&
          request.resource.data.lastAttemptAt is number)
         ||
+        // Teacher reset/refund branch — see quiz_attempt_ledger above.
+        // The teacher may only DECREASE completedAttempts; this supports
+        // both the legacy `removeStudent` reset-to-0 and the new
+        // `unlockStudentAttempt` refund-by-one flow.
         (request.auth.uid == resource.data.teacherUid &&
          request.resource.data.studentUid == resource.data.studentUid &&
          request.resource.data.activityId == resource.data.activityId &&
          request.resource.data.teacherUid == resource.data.teacherUid &&
-         request.resource.data.completedAttempts == 0)
+         request.resource.data.get('completedAttempts', 0) >= 0 &&
+         request.resource.data.get('completedAttempts', 0) <=
+           resource.data.get('completedAttempts', 0))
         ||
         isAdmin()
       );
@@ -1952,8 +1972,14 @@ service cloud.firestore {
               'completedAt',
               'tabSwitchWarnings',
               'completedAttempts',
-              'classPeriod'
+              'classPeriod',
+              'unlocked'
             ]) &&
+            // Students may only ever CLEAR the unlock flag — never set
+            // it. The teacher sets `unlocked: true`; `completeActivity`
+            // clears it back to false on submission of a resumed attempt.
+            (!request.resource.data.diff(resource.data).affectedKeys().hasAny(['unlocked']) ||
+             request.resource.data.get('unlocked', false) == false) &&
             request.resource.data.answers is list &&
             // Append-only on answers, EXCEPT during a rejoin-reset for a
             // new attempt under the cap. The reset path writes

--- a/hooks/useQuizSession.ts
+++ b/hooks/useQuizSession.ts
@@ -659,11 +659,20 @@ export const useQuizSessionTeacher = (
 
   const unlockStudentAttempt = useCallback(
     async (responseKey: string) => {
-      if (!sessionId) return;
+      if (!sessionId) {
+        throw new Error('No active session — cannot unlock.');
+      }
       const target = responses.find(
         (r) => (r._responseKey ?? r.studentUid) === responseKey
       );
-      if (!target) return;
+      if (!target) {
+        // Snapshot races: the row was already removed by the time the
+        // teacher clicked. Surface as an error so the monitor can
+        // toast — silent success would be misleading.
+        throw new Error(
+          'Student response not found — they may have already been removed or rejoined.'
+        );
+      }
       const responseRef = doc(
         db,
         QUIZ_SESSIONS_COLLECTION,
@@ -680,7 +689,13 @@ export const useQuizSessionTeacher = (
         : null;
       const currentAttempts = target.completedAttempts ?? 0;
       const refundedAttempts = Math.max(0, currentAttempts - 1);
-      const baselineWarnings = target.tabSwitchWarnings ?? 0;
+
+      // Probe the ledger BEFORE the batch so we don't blindly create a
+      // partial doc via `set(merge:true)` on a missing ledger entry
+      // (which would land without the required identity fields and
+      // fail the create rule anyway). PIN-keyed anonymous students
+      // never write a ledger entry, so this is a no-op for them.
+      const ledgerSnap = ledgerRef ? await getDoc(ledgerRef) : null;
 
       const batch = writeBatch(db);
       batch.update(responseRef, {
@@ -690,17 +705,14 @@ export const useQuizSessionTeacher = (
         completedAttempts: refundedAttempts,
         unlocked: true,
         unlockedAt: Date.now(),
-        warningsAtUnlock: baselineWarnings,
       });
-      if (ledgerRef) {
-        // Refund the ledger counter so the cross-launch cap isn't
-        // immediately re-tripped on the student's next join. Use a
-        // floor of 0 to guard against ledgers that already lag.
-        batch.set(
-          ledgerRef,
-          { completedAttempts: Math.max(0, refundedAttempts) },
-          { merge: true }
-        );
+      if (ledgerRef && ledgerSnap?.exists()) {
+        const ledgerCurrent =
+          (ledgerSnap.data() as QuizAttemptLedger | undefined)
+            ?.completedAttempts ?? 0;
+        batch.update(ledgerRef, {
+          completedAttempts: Math.max(0, ledgerCurrent - 1),
+        });
       }
       await batch.commit();
     },

--- a/hooks/useQuizSession.ts
+++ b/hooks/useQuizSession.ts
@@ -1775,14 +1775,23 @@ export const useQuizSessionStudent = (): UseQuizSessionStudentResult => {
       const ledgerSnap = ledgerRef ? await tx.get(ledgerRef) : null;
 
       const submittedAt = Date.now();
-      tx.update(responseRef, {
+      // Only clear `unlocked` when the response actually carries the flag.
+      // Production deploys land hosting before rules (see
+      // .github/workflows/firebase-deploy.yml), so during the deploy gap
+      // the rules' `hasOnly([...])` allowlist may not yet include
+      // `unlocked` — and a write that includes the field would be
+      // rejected, silently failing the submit. Legacy responses (and
+      // every fresh attempt) have `unlocked === undefined`, so the field
+      // stays out of the payload until a teacher unlock actually sets it.
+      const responseUpdates: Record<string, unknown> = {
         status: 'completed',
         submittedAt,
         completedAttempts: increment(1),
-        // Clear any prior teacher-unlock state so the next attempt (if
-        // permitted) starts from a clean baseline.
-        unlocked: false,
-      });
+      };
+      if (existing.unlocked) {
+        responseUpdates.unlocked = false;
+      }
+      tx.update(responseRef, responseUpdates);
 
       if (ledgerRef && ledgerSnap) {
         if (ledgerSnap.exists()) {

--- a/hooks/useQuizSession.ts
+++ b/hooks/useQuizSession.ts
@@ -487,6 +487,15 @@ export interface UseQuizSessionTeacherResult {
    * Deleting the doc also frees the attempt slot so the student can rejoin.
    */
   removeStudent: (responseKey: string) => Promise<void>;
+  /**
+   * Unlock a student's auto-submitted or attempt-limit-locked response so
+   * they can resume. Preserves the existing `answers`, refunds one
+   * `completedAttempts` on the response and the cross-launch ledger, and
+   * sets `unlocked: true` + `warningsAtUnlock` so the student's
+   * visibility handler will finalize the attempt on the next tab-switch
+   * without showing the "Warning N of 3" modal.
+   */
+  unlockStudentAttempt: (responseKey: string) => Promise<void>;
   /** Reveal the correct answer for a question (writes to session doc) */
   revealAnswer: (questionId: string, correctAnswer: string) => Promise<void>;
   /** Hide a previously revealed answer (removes from session doc) */
@@ -648,6 +657,56 @@ export const useQuizSessionTeacher = (
     [sessionId, responses, session?.quizId]
   );
 
+  const unlockStudentAttempt = useCallback(
+    async (responseKey: string) => {
+      if (!sessionId) return;
+      const target = responses.find(
+        (r) => (r._responseKey ?? r.studentUid) === responseKey
+      );
+      if (!target) return;
+      const responseRef = doc(
+        db,
+        QUIZ_SESSIONS_COLLECTION,
+        sessionId,
+        RESPONSES_COLLECTION,
+        responseKey
+      );
+      const ledgerRef = session?.quizId
+        ? doc(
+            db,
+            QUIZ_ATTEMPT_LEDGER_COLLECTION,
+            quizLedgerKey(session.quizId, target.studentUid)
+          )
+        : null;
+      const currentAttempts = target.completedAttempts ?? 0;
+      const refundedAttempts = Math.max(0, currentAttempts - 1);
+      const baselineWarnings = target.tabSwitchWarnings ?? 0;
+
+      const batch = writeBatch(db);
+      batch.update(responseRef, {
+        status: 'in-progress',
+        submittedAt: null,
+        score: null,
+        completedAttempts: refundedAttempts,
+        unlocked: true,
+        unlockedAt: Date.now(),
+        warningsAtUnlock: baselineWarnings,
+      });
+      if (ledgerRef) {
+        // Refund the ledger counter so the cross-launch cap isn't
+        // immediately re-tripped on the student's next join. Use a
+        // floor of 0 to guard against ledgers that already lag.
+        batch.set(
+          ledgerRef,
+          { completedAttempts: Math.max(0, refundedAttempts) },
+          { merge: true }
+        );
+      }
+      await batch.commit();
+    },
+    [sessionId, responses, session?.quizId]
+  );
+
   const revealAnswer = useCallback(
     async (questionId: string, correctAnswer: string) => {
       if (!sessionId) return;
@@ -792,6 +851,7 @@ export const useQuizSessionTeacher = (
     advanceQuestion,
     endQuizSession,
     removeStudent,
+    unlockStudentAttempt,
     revealAnswer,
     hideAnswer,
   };
@@ -1286,7 +1346,31 @@ export const useQuizSessionStudent = (): UseQuizSessionStudentResult => {
         const limit = sessionData.attemptLimit ?? null;
         if (existingSnap?.exists()) {
           const existing = existingSnap.data() as QuizResponse;
-          if (existing.status === 'completed') {
+          if (existing.status === 'completed' && existing.unlocked) {
+            // Teacher-unlocked: resume the existing attempt with the prior
+            // `answers` intact. Unlock normally already flips status to
+            // 'in-progress', so this branch is a safety net for races
+            // where the student rejoins between unlock's listener emit
+            // and Firestore propagation.
+            await updateDoc(responseRef, {
+              status: 'in-progress',
+              submittedAt: null,
+              score: null,
+              ...(classPeriod && existing.classPeriod !== classPeriod
+                ? { classPeriod }
+                : {}),
+            }).catch((err: unknown) =>
+              logQuizJoinFirestoreError('update-resume-unlocked', err, {
+                sessionId: sessionDoc.id,
+                responseKey,
+                studentUid,
+                existingStudentUid: existing.studentUid,
+                isAnonymous,
+                hasPin: !!sanitizedPin,
+                hasClassPeriod: !!classPeriod,
+              })
+            );
+          } else if (existing.status === 'completed') {
             const completed = Math.max(
               existing.completedAttempts ?? 0,
               ledgerCompleted,
@@ -1683,6 +1767,9 @@ export const useQuizSessionStudent = (): UseQuizSessionStudentResult => {
         status: 'completed',
         submittedAt,
         completedAttempts: increment(1),
+        // Clear any prior teacher-unlock state so the next attempt (if
+        // permitted) starts from a clean baseline.
+        unlocked: false,
       });
 
       if (ledgerRef && ledgerSnap) {

--- a/hooks/useVideoActivitySession.ts
+++ b/hooks/useVideoActivitySession.ts
@@ -1093,13 +1093,19 @@ export const useVideoActivitySessionStudent =
         const ledgerSnap = ledgerRef ? await tx.get(ledgerRef) : null;
 
         const completedAt = Date.now();
-        tx.update(responseRef, {
+        // Same deploy-gap defense as `completeQuiz`: include `unlocked`
+        // in the payload only when the doc actually carries the flag,
+        // so submissions land successfully during the hosting-deployed-
+        // before-rules window in production
+        // (.github/workflows/firebase-deploy.yml).
+        const responseUpdates: Record<string, unknown> = {
           completedAt,
           completedAttempts: increment(1),
-          // Clear any prior teacher-unlock state so the next attempt
-          // (if permitted) starts from a clean baseline.
-          unlocked: false,
-        });
+        };
+        if (existing.unlocked) {
+          responseUpdates.unlocked = false;
+        }
+        tx.update(responseRef, responseUpdates);
 
         if (ledgerRef && ledgerSnap) {
           if (ledgerSnap.exists()) {

--- a/hooks/useVideoActivitySession.ts
+++ b/hooks/useVideoActivitySession.ts
@@ -24,6 +24,7 @@ import {
   query,
   where,
   orderBy,
+  writeBatch,
 } from 'firebase/firestore';
 import { signInWithCustomToken } from 'firebase/auth';
 import { httpsCallable } from 'firebase/functions';
@@ -168,6 +169,21 @@ export interface UseVideoActivitySessionTeacherResult {
   subscribeToSession: (sessionId: string) => void;
   /** Unsubscribe from the current session listeners. */
   unsubscribeFromSession: () => void;
+  /**
+   * Unlock a student's locked/auto-submitted response so they can resume
+   * the in-flight attempt. Preserves `answers`, refunds one
+   * `completedAttempts` on both the response and the cross-launch
+   * ledger, and stamps `unlocked: true` + `warningsAtUnlock` so the
+   * student-side visibility handler finalizes the attempt on the next
+   * tab-switch without showing the "Warning N of 3" modal.
+   *
+   * `responseKey` is the Firestore doc key — pass the row's
+   * `_responseKey` (snapshot doc id), not `studentUid`.
+   */
+  unlockStudentAttempt: (
+    sessionId: string,
+    responseKey: string
+  ) => Promise<void>;
   loading: boolean;
 }
 
@@ -327,7 +343,17 @@ export const useVideoActivitySessionTeacher =
       unsubRef.current = onSnapshot(
         collection(db, SESSIONS_COLLECTION, sessionId, RESPONSES_SUBCOLLECTION),
         (snap) => {
-          const list = snap.docs.map((d) => d.data() as VideoActivityResponse);
+          // Carry the Firestore doc id through as `_responseKey` so the
+          // live monitor can target the actual response doc when invoking
+          // teacher actions (e.g. unlock) — for PIN joiners the key is
+          // `pin-{period}-{pin}` and differs from `studentUid`.
+          const list = snap.docs.map(
+            (d) =>
+              ({
+                ...(d.data() as VideoActivityResponse),
+                _responseKey: d.id,
+              }) as VideoActivityResponse
+          );
           setResponses(list);
           setLoading(false);
         },
@@ -362,6 +388,62 @@ export const useVideoActivitySessionTeacher =
         }
       );
     }, []);
+
+    const unlockStudentAttempt = useCallback(
+      async (sessionId: string, responseKey: string): Promise<void> => {
+        const responseRef = doc(
+          db,
+          SESSIONS_COLLECTION,
+          sessionId,
+          RESPONSES_SUBCOLLECTION,
+          responseKey
+        );
+        const snap = await getDoc(responseRef);
+        if (!snap.exists()) return;
+        const existing = snap.data() as VideoActivityResponse;
+
+        const currentAttempts = existing.completedAttempts ?? 0;
+        const refundedAttempts = Math.max(0, currentAttempts - 1);
+        const baselineWarnings = existing.tabSwitchWarnings ?? 0;
+
+        const sessionSnap = await getDoc(
+          doc(db, SESSIONS_COLLECTION, sessionId)
+        );
+        const activityId =
+          (sessionSnap.data() as Partial<VideoActivitySession> | undefined)
+            ?.activityId ?? null;
+        const ledgerRef =
+          activityId && existing.studentUid
+            ? doc(
+                db,
+                VIDEO_ACTIVITY_ATTEMPT_LEDGER_COLLECTION,
+                videoActivityLedgerKey(activityId, existing.studentUid)
+              )
+            : null;
+
+        const batch = writeBatch(db);
+        batch.update(responseRef, {
+          completedAt: null,
+          score: null,
+          completedAttempts: refundedAttempts,
+          unlocked: true,
+          unlockedAt: Date.now(),
+          warningsAtUnlock: baselineWarnings,
+        });
+        if (ledgerRef) {
+          // Refund the cross-launch ledger counter in lockstep with the
+          // response so the student isn't immediately re-blocked by the
+          // cap on rejoin.
+          batch.set(
+            ledgerRef,
+            { completedAttempts: refundedAttempts },
+            { merge: true }
+          );
+        }
+        await batch.commit();
+      },
+      []
+    );
 
     const unsubscribeFromSession = useCallback(() => {
       if (unsubRef.current) {
@@ -406,6 +488,7 @@ export const useVideoActivitySessionTeacher =
       liveSession,
       subscribeToSession,
       unsubscribeFromSession,
+      unlockStudentAttempt,
       loading,
     };
   };
@@ -454,6 +537,13 @@ export interface UseVideoActivitySessionStudentResult {
   ) => Promise<void>;
   submitAnswer: (questionId: string, answer: string) => Promise<void>;
   completeActivity: () => Promise<void>;
+  /**
+   * Atomically increment the student's `tabSwitchWarnings` counter on
+   * the response doc and return the new total. The student-side
+   * visibility tracker calls this from the `visibilitychange` / `blur`
+   * handler. Mirrors `useQuizSession.reportTabSwitch`.
+   */
+  reportTabSwitch: () => Promise<number>;
 }
 
 export const useVideoActivitySessionStudent =
@@ -805,7 +895,19 @@ export const useVideoActivitySessionStudent =
             //   - Under the cap, reset the doc to a fresh attempt
             //     (`completedAt: null, answers: []`); preserve
             //     `completedAttempts` so future joins still see the cap.
-            if (existing.completedAt != null) {
+            if (existing.completedAt != null && existing.unlocked) {
+              // Teacher-unlocked: resume the existing attempt with the
+              // prior `answers` intact. The unlock action already clears
+              // `completedAt`, so this branch handles the safety-net
+              // case where a Firestore propagation lag leaves the
+              // student's tab seeing the old `completedAt` value.
+              await updateDoc(effectiveResponseRef, {
+                completedAt: null,
+                ...(classPeriod && existing.classPeriod !== classPeriod
+                  ? { classPeriod }
+                  : {}),
+              });
+            } else if (existing.completedAt != null) {
               const completed = Math.max(
                 existing.completedAttempts ?? 0,
                 ledgerCompleted,
@@ -970,6 +1072,9 @@ export const useVideoActivitySessionStudent =
         tx.update(responseRef, {
           completedAt,
           completedAttempts: increment(1),
+          // Clear any prior teacher-unlock state so the next attempt
+          // (if permitted) starts from a clean baseline.
+          unlocked: false,
         });
 
         if (ledgerRef && ledgerSnap) {
@@ -994,6 +1099,49 @@ export const useVideoActivitySessionStudent =
       });
     }, [sessionId, responseDocId, session?.activityId, session?.teacherUid]);
 
+    // Track the latest response value in a ref so `reportTabSwitch` can
+    // read the current counter without re-binding (and re-attaching the
+    // visibility listener on every snapshot).
+    const myResponseRef = useRef<VideoActivityResponse | null>(null);
+    myResponseRef.current = myResponse;
+    const warningCountRef = useRef(0);
+
+    useEffect(() => {
+      const serverCount = myResponse?.tabSwitchWarnings ?? 0;
+      // Server-side counter is the source of truth; clamp to the higher
+      // of the two so a stale snapshot in flight doesn't roll back the
+      // local view briefly.
+      warningCountRef.current = Math.max(warningCountRef.current, serverCount);
+    }, [myResponse?.tabSwitchWarnings]);
+
+    const reportTabSwitch = useCallback(async (): Promise<number> => {
+      if (!sessionId || !responseDocId) return warningCountRef.current;
+      const responseRef = doc(
+        db,
+        SESSIONS_COLLECTION,
+        sessionId,
+        RESPONSES_SUBCOLLECTION,
+        responseDocId
+      );
+      const baseCount = Math.max(
+        warningCountRef.current,
+        myResponseRef.current?.tabSwitchWarnings ?? 0
+      );
+      try {
+        await updateDoc(responseRef, {
+          tabSwitchWarnings: increment(1),
+        });
+      } catch (err) {
+        logError('useVideoActivitySessionStudent.reportTabSwitch', err, {
+          sessionId,
+          responseDocId,
+        });
+      }
+      const newCount = baseCount + 1;
+      warningCountRef.current = newCount;
+      return newCount;
+    }, [sessionId, responseDocId]);
+
     return {
       session,
       myResponse,
@@ -1003,5 +1151,6 @@ export const useVideoActivitySessionStudent =
       joinSession,
       submitAnswer,
       completeActivity,
+      reportTabSwitch,
     };
   };

--- a/hooks/useVideoActivitySession.ts
+++ b/hooks/useVideoActivitySession.ts
@@ -399,12 +399,18 @@ export const useVideoActivitySessionTeacher =
           responseKey
         );
         const snap = await getDoc(responseRef);
-        if (!snap.exists()) return;
+        if (!snap.exists()) {
+          // Snapshot races: the row was already removed by the time the
+          // teacher clicked. Surface as an error so the monitor can
+          // toast — silent success would be misleading.
+          throw new Error(
+            'Student response not found — they may have already been removed or rejoined.'
+          );
+        }
         const existing = snap.data() as VideoActivityResponse;
 
         const currentAttempts = existing.completedAttempts ?? 0;
         const refundedAttempts = Math.max(0, currentAttempts - 1);
-        const baselineWarnings = existing.tabSwitchWarnings ?? 0;
 
         const sessionSnap = await getDoc(
           doc(db, SESSIONS_COLLECTION, sessionId)
@@ -412,6 +418,12 @@ export const useVideoActivitySessionTeacher =
         const activityId =
           (sessionSnap.data() as Partial<VideoActivitySession> | undefined)
             ?.activityId ?? null;
+        // Probe the ledger BEFORE writing so we don't blindly create a
+        // partial doc via `set(merge:true)` on a missing ledger entry
+        // (which would land without the required `activityId`/
+        // `studentUid`/`teacherUid` identity fields). For anonymous-PIN
+        // students or any student whose cross-launch ledger hasn't been
+        // touched yet there's simply nothing to refund.
         const ledgerRef =
           activityId && existing.studentUid
             ? doc(
@@ -420,25 +432,27 @@ export const useVideoActivitySessionTeacher =
                 videoActivityLedgerKey(activityId, existing.studentUid)
               )
             : null;
+        const ledgerSnap = ledgerRef ? await getDoc(ledgerRef) : null;
 
         const batch = writeBatch(db);
+        // `completedAt: null` is the canonical "not finished" signal for
+        // VA. Without this the student-side visibility handler bails
+        // out on `myResponse?.completedAt != null` and the
+        // instant-finalize-on-next-strike rule never engages.
         batch.update(responseRef, {
           completedAt: null,
           score: null,
           completedAttempts: refundedAttempts,
           unlocked: true,
           unlockedAt: Date.now(),
-          warningsAtUnlock: baselineWarnings,
         });
-        if (ledgerRef) {
-          // Refund the cross-launch ledger counter in lockstep with the
-          // response so the student isn't immediately re-blocked by the
-          // cap on rejoin.
-          batch.set(
-            ledgerRef,
-            { completedAttempts: refundedAttempts },
-            { merge: true }
-          );
+        if (ledgerRef && ledgerSnap?.exists()) {
+          const ledgerCurrent =
+            (ledgerSnap.data() as VideoActivityAttemptLedger | undefined)
+              ?.completedAttempts ?? 0;
+          batch.update(ledgerRef, {
+            completedAttempts: Math.max(0, ledgerCurrent - 1),
+          });
         }
         await batch.commit();
       },
@@ -906,7 +920,17 @@ export const useVideoActivitySessionStudent =
                 ...(classPeriod && existing.classPeriod !== classPeriod
                   ? { classPeriod }
                   : {}),
-              });
+              }).catch((err: unknown) =>
+                logError(
+                  'useVideoActivitySessionStudent.update-resume-unlocked',
+                  err as Error,
+                  {
+                    sessionId: targetSessionId,
+                    responseDocId: responseDocKey,
+                    studentUid: existing.studentUid,
+                  }
+                )
+              );
             } else if (existing.completedAt != null) {
               const completed = Math.max(
                 existing.completedAttempts ?? 0,
@@ -1132,10 +1156,17 @@ export const useVideoActivitySessionStudent =
           tabSwitchWarnings: increment(1),
         });
       } catch (err) {
+        // Re-throw (matching `useQuizSession.reportTabSwitch`) so the
+        // caller's catch handles it without silently advancing the
+        // local counter into a server-divergent state. Without this,
+        // a chain of failed writes would push the local count to ≥3
+        // and trigger an auto-submit while the server still shows 0
+        // warnings.
         logError('useVideoActivitySessionStudent.reportTabSwitch', err, {
           sessionId,
           responseDocId,
         });
+        throw err;
       }
       const newCount = baseCount + 1;
       warningCountRef.current = newCount;

--- a/types.ts
+++ b/types.ts
@@ -2422,6 +2422,22 @@ export interface QuizResponse {
    * v{N+1} update." Absent on responses written outside synced mode.
    */
   preSyncVersion?: number;
+  /**
+   * True when a teacher has manually unlocked an auto-submitted or
+   * attempt-limit-locked response so the student can resume. The hooks
+   * preserve `answers` on the next rejoin and skip the "Warning N of 3"
+   * modal — any further tab-switch finalizes the attempt immediately.
+   * Cleared back to false on the student's next completion.
+   */
+  unlocked?: boolean;
+  /** Server timestamp (ms) when the teacher unlocked the attempt. */
+  unlockedAt?: number;
+  /**
+   * The value of `tabSwitchWarnings` at the moment the teacher unlocked.
+   * The student-side visibility handler treats any
+   * `tabSwitchWarnings > warningsAtUnlock` as an instant-submit trigger.
+   */
+  warningsAtUnlock?: number;
 }
 
 /**
@@ -3227,6 +3243,14 @@ export interface VideoActivityAnswer {
  * Stored at /video_activity_sessions/{sessionId}/responses/{responseKey}
  */
 export interface VideoActivityResponse {
+  /**
+   * The Firestore doc key under /responses. Populated at read time by the
+   * teacher hook from snapshot.doc.id; never persisted as a field. Callers
+   * should use this (rather than `studentUid`) when targeting a specific
+   * response doc, since the key may be pin-derived for anonymous joiners.
+   * Mirrors `QuizResponse._responseKey`.
+   */
+  _responseKey?: string;
   /** Roster PIN — present for anonymous joiners, absent on SSO joiners. */
   pin?: string;
   /**
@@ -3268,6 +3292,21 @@ export interface VideoActivityResponse {
    * publishes scores; mirrors `VideoActivityScoreVisibility`.
    */
   scoreVisibility?: VideoActivityScoreVisibility;
+  /**
+   * True when a teacher has manually unlocked an auto-submitted or
+   * attempt-limit-locked response so the student can resume. The hook
+   * preserves `answers` on rejoin and the student-side visibility handler
+   * skips the warning modal — any further tab-switch finalizes immediately.
+   */
+  unlocked?: boolean;
+  /** Server timestamp (ms) when the teacher unlocked the attempt. */
+  unlockedAt?: number;
+  /**
+   * Value of `tabSwitchWarnings` at the moment of unlock. The visibility
+   * handler treats `tabSwitchWarnings > warningsAtUnlock` as an
+   * instant-submit trigger.
+   */
+  warningsAtUnlock?: number;
 }
 
 /**

--- a/types.ts
+++ b/types.ts
@@ -2430,14 +2430,8 @@ export interface QuizResponse {
    * Cleared back to false on the student's next completion.
    */
   unlocked?: boolean;
-  /** Server timestamp (ms) when the teacher unlocked the attempt. */
+  /** Client timestamp (ms) when the teacher unlocked the attempt. */
   unlockedAt?: number;
-  /**
-   * The value of `tabSwitchWarnings` at the moment the teacher unlocked.
-   * The student-side visibility handler treats any
-   * `tabSwitchWarnings > warningsAtUnlock` as an instant-submit trigger.
-   */
-  warningsAtUnlock?: number;
 }
 
 /**
@@ -3299,14 +3293,8 @@ export interface VideoActivityResponse {
    * skips the warning modal — any further tab-switch finalizes immediately.
    */
   unlocked?: boolean;
-  /** Server timestamp (ms) when the teacher unlocked the attempt. */
+  /** Client timestamp (ms) when the teacher unlocked the attempt. */
   unlockedAt?: number;
-  /**
-   * Value of `tabSwitchWarnings` at the moment of unlock. The visibility
-   * handler treats `tabSwitchWarnings > warningsAtUnlock` as an
-   * instant-submit trigger.
-   */
-  warningsAtUnlock?: number;
 }
 
 /**


### PR DESCRIPTION
## Context

Teachers embed join links in Schoology. Students often start an attempt, then open the URL in a new tab (to get full-screen) or refresh — both fire `visibilitychange`/`blur` on the original tab, which trips the tab-switch tripwire. At the 3rd strike the attempt auto-submits and the student is effectively locked out: even under the attempt cap, the rejoin path wipes their answers. Today the only teacher recovery is **Remove from session**, which deletes the response doc AND the cross-launch ledger entry, destroying all their work.

This PR adds a softer escape hatch — and brings Video Activity to full feature parity with Quiz along the way.

## What changed

### Unlock flow (both widgets)
- **Monitor**: a **Locked** chip appears on rows whose attempt was auto-submitted from warnings, or who hit the cross-launch attempt cap. Tapping it opens a confirm dialog (`useDialog().showConfirm`); on confirm the response flips back to in-progress, `completedAttempts` is decremented on both the response and the ledger, and `unlocked: true` + `warningsAtUnlock: <current count>` are stamped. **Answers are preserved.** A green **Resumed** chip then indicates the in-flight resumed attempt.
- **Student**: a real-time emerald **Attempt Unlocked → Resume** modal appears the moment the teacher unlocks (no refresh needed). A persistent amber banner runs across the top: *"Leaving this tab once more will submit your work — no further warnings."* The visibility handler now sees `unlocked === true` and finalizes the attempt immediately on the next tab-switch — no "Warning N of 3" modal.
- **Rejoin**: when the student refreshes or opens a 2nd tab after unlock, the rejoin path now resumes them in place instead of wiping their answers.
- **Completion**: `completeQuiz` / `completeActivity` clear `unlocked` on submit so a subsequent attempt (if under cap) starts from a clean baseline.

### Video Activity tab-warning parity
Previously VA had only the `tabSwitchWarnings` field in Firestore with no code touching it. Now ported from Quiz:
- `reportTabSwitch` on the student hook (atomic `increment(1)`).
- `visibilitychange` + `blur` listener in `VideoActivityStudentApp` with 1s debounce.
- The same red "TAB SWITCH DETECTED — Warning N of 3" modal.
- Auto-submit at the 3rd strike, with the matching amber "Auto-submitted because you left the activity tab 3 times" note on the completion screen.
- A **Warnings** toggle in the monitor's roster header and the red warning-count badge on rows.

### Data model ([types.ts](https://github.com/OPS-PIvers/SpartBoard/blob/claude/inspiring-blackburn-9fe5bf/types.ts))
- `QuizResponse` + `VideoActivityResponse`: `unlocked?`, `unlockedAt?`, `warningsAtUnlock?`.
- `VideoActivityResponse`: `_responseKey?` (snapshot doc id, mirrors quiz).

## Files

- [types.ts](https://github.com/OPS-PIvers/SpartBoard/blob/claude/inspiring-blackburn-9fe5bf/types.ts) — new fields on both response types.
- [hooks/useQuizSession.ts](https://github.com/OPS-PIvers/SpartBoard/blob/claude/inspiring-blackburn-9fe5bf/hooks/useQuizSession.ts) — `unlockStudentAttempt`, unlocked-rejoin branch, `unlocked: false` on submit.
- [hooks/useVideoActivitySession.ts](https://github.com/OPS-PIvers/SpartBoard/blob/claude/inspiring-blackburn-9fe5bf/hooks/useVideoActivitySession.ts) — `unlockStudentAttempt`, `reportTabSwitch`, unlocked-rejoin branch, `_responseKey` on listener, `unlocked: false` on submit.
- [components/quiz/QuizStudentApp.tsx](https://github.com/OPS-PIvers/SpartBoard/blob/claude/inspiring-blackburn-9fe5bf/components/quiz/QuizStudentApp.tsx) — visibility handler override, resume modal, banner.
- [components/videoActivity/VideoActivityStudentApp.tsx](https://github.com/OPS-PIvers/SpartBoard/blob/claude/inspiring-blackburn-9fe5bf/components/videoActivity/VideoActivityStudentApp.tsx) — full visibility tracker (new), warning modal, resume modal, banner, auto-submitted note.
- [components/widgets/QuizWidget/components/QuizLiveMonitor.tsx](https://github.com/OPS-PIvers/SpartBoard/blob/claude/inspiring-blackburn-9fe5bf/components/widgets/QuizWidget/components/QuizLiveMonitor.tsx) — Lock/Resumed chips, `handleUnlockStudent`.
- [components/widgets/VideoActivityWidget/components/VideoActivityLiveMonitor.tsx](https://github.com/OPS-PIvers/SpartBoard/blob/claude/inspiring-blackburn-9fe5bf/components/widgets/VideoActivityWidget/components/VideoActivityLiveMonitor.tsx) — Warnings toggle, warning badge, Lock/Resumed chips, `handleUnlock`.
- [Widget.tsx](https://github.com/OPS-PIvers/SpartBoard/blob/claude/inspiring-blackburn-9fe5bf/components/widgets/QuizWidget/Widget.tsx) (Quiz + VA) — wire `unlockStudentAttempt` through to the monitor.

## Static gates

All green locally:

- `pnpm run type-check` — 0 errors
- `pnpm run lint` — 0 errors, 0 warnings
- `pnpm run format:check` — clean
- `pnpm run test` — 2219 / 2219 passing

## Test plan

- [ ] **Quiz happy path**: start a quiz session as teacher (browser A); join as a student (browser B). Answer Q1, Q2.
- [ ] **Trigger lockout**: refresh student tab 3 times → 3rd strike auto-submits, "Quiz Submitted" screen shows the amber "Auto-submitted because you left the quiz tab 3 times" note.
- [ ] **Lock chip appears**: in the teacher monitor, the student row shows a Locked chip (Warnings toggle on or off, the chip still appears).
- [ ] **Unlock flow**: tap the chip → confirm dialog "Unlock attempt?" → confirm. Toast: "<name>'s attempt is unlocked — they can resume now."
- [ ] **Real-time resume**: without refreshing the student tab, the emerald "Attempt Unlocked → Resume Quiz" modal appears. Tap Resume → student is back at their question with prior answers intact.
- [ ] **Persistent banner**: amber banner across the top reads "Leaving this tab once more will submit your quiz — no further warnings."
- [ ] **Refresh survives unlock**: refresh the student tab → still resumed, answers intact, banner persists.
- [ ] **One-strike submit**: switch tabs once → immediate auto-submit, NO "Warning N of 3" modal.
- [ ] **Repeat for Video Activity** at `/activity/:sessionId`. Confirm the new Warnings toggle in the monitor shows the badge, the same Lock chip + unlock flow works, and the same resume modal + banner appears on the student side.
- [ ] **Regression — Remove from session** still works as before.
- [ ] **Regression — Reveal student results** confirm dialog still fires normally.
- [ ] **Regression — Under-cap completions** still reset answers normally for students who were NOT unlocked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)