### PR TITLE
fix(random): keep jigsaw post-pick footer controls reachable

### DIFF
--- a/components/widgets/random/RandomWidget.test.tsx
+++ b/components/widgets/random/RandomWidget.test.tsx
@@ -229,6 +229,69 @@ describe('RandomWidget', () => {
         screen.queryByRole('button', { name: /Launch Jigsaw/i })
       ).not.toBeInTheDocument();
     });
+
+    it('renders the post-pick footer as two rows with all 5 controls visible (no cutoff)', () => {
+      // Regression guard: when both Launch buttons + both steppers + the
+      // Randomize button shared a single horizontal row, the trailing items
+      // overflowed the widget's right edge and were clipped. The footer is
+      // now a vertical stack of two rows so every control stays reachable.
+      render(<RandomWidget widget={jigsawWidget({ jigsawView: 'home' })} />);
+
+      // Both Launch buttons.
+      expect(
+        screen.getByRole('button', { name: /Launch Jigsaw/i })
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', { name: /Launch Home Group/i })
+      ).toBeInTheDocument();
+
+      // Both steppers (group role + aria-label set on GroupSizeStepper).
+      expect(
+        screen.getByRole('group', { name: /Number of Expert Groups/i })
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole('group', { name: /Home Group Size/i })
+      ).toBeInTheDocument();
+
+      // Randomize button still reachable from this view.
+      expect(
+        screen.getByRole('button', { name: /Randomize|Picking/i })
+      ).toBeInTheDocument();
+
+      // Footer is a flex column whose direct children are the two rows.
+      const footer = screen.getByTestId('footer');
+      const stack = footer.firstElementChild as HTMLElement | null;
+      expect(stack).not.toBeNull();
+      expect(stack?.className).toMatch(/\bflex-col\b/);
+      expect(stack?.children.length).toBe(2);
+
+      // Row 1 must contain the Expert stepper, the Launch Jigsaw button, and
+      // the Randomize button. Row 2 must contain the Home stepper, the Launch
+      // Home Group button, and an aria-hidden spacer for visual alignment.
+      const row1 = stack?.children[0] as HTMLElement;
+      const row2 = stack?.children[1] as HTMLElement;
+      const launchJigsaw = screen.getByRole('button', {
+        name: /Launch Jigsaw/i,
+      });
+      const launchHome = screen.getByRole('button', {
+        name: /Launch Home Group/i,
+      });
+      const randomize = screen.getByRole('button', {
+        name: /^Randomize$|^Picking$/,
+      });
+      const expertStepper = screen.getByRole('group', {
+        name: /Number of Expert Groups/i,
+      });
+      const homeStepper = screen.getByRole('group', {
+        name: /Home Group Size/i,
+      });
+      expect(row1.contains(expertStepper)).toBe(true);
+      expect(row1.contains(launchJigsaw)).toBe(true);
+      expect(row1.contains(randomize)).toBe(true);
+      expect(row2.contains(homeStepper)).toBe(true);
+      expect(row2.contains(launchHome)).toBe(true);
+      expect(row2.querySelector('[aria-hidden="true"]')).not.toBeNull();
+    });
   });
 
   describe('Mode-cycle chip', () => {

--- a/components/widgets/random/RandomWidget.tsx
+++ b/components/widgets/random/RandomWidget.tsx
@@ -1186,15 +1186,18 @@ export const RandomWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
           </div>
         }
         footer={
-          <div
-            className="w-full flex"
-            style={{
-              padding: 'clamp(6px, 1.5cqmin, 14px) clamp(8px, 2cqmin, 16px)',
-              gap: 'clamp(6px, 2cqmin, 14px)',
-            }}
-          >
-            {mode === 'jigsaw' && hasJigsawGroups && (
-              <>
+          mode === 'jigsaw' && hasJigsawGroups ? (
+            <div
+              className="w-full flex flex-col"
+              style={{
+                padding: 'clamp(6px, 1.5cqmin, 14px) clamp(8px, 2cqmin, 16px)',
+                gap: 'clamp(6px, 1.5cqmin, 12px)',
+              }}
+            >
+              <div
+                className="flex w-full items-stretch"
+                style={{ gap: 'clamp(6px, 2cqmin, 14px)' }}
+              >
                 <GroupSizeStepper
                   value={displayNumExpertGroups}
                   onChange={setNumExpertGroups}
@@ -1239,6 +1242,35 @@ export const RandomWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
                     })}
                   </span>
                 </Button>
+                <Button
+                  variant="hero"
+                  size="md"
+                  shape="pill"
+                  onClick={handlePick}
+                  disabled={isSpinning}
+                  className="flex-shrink-0"
+                  style={{
+                    width: 'clamp(40px, 10cqmin, 72px)',
+                    height: 'clamp(40px, 10cqmin, 72px)',
+                    padding: 0,
+                  }}
+                  aria-label={isSpinning ? 'Picking' : 'Randomize'}
+                  title={isSpinning ? 'Picking...' : 'Randomize'}
+                  icon={
+                    <RefreshCw
+                      className={isSpinning ? 'animate-spin' : ''}
+                      style={{
+                        width: 'clamp(20px, 6cqmin, 44px)',
+                        height: 'clamp(20px, 6cqmin, 44px)',
+                      }}
+                    />
+                  }
+                />
+              </div>
+              <div
+                className="flex w-full items-stretch"
+                style={{ gap: 'clamp(6px, 2cqmin, 14px)' }}
+              >
                 <GroupSizeStepper
                   value={groupSize}
                   onChange={setGroupSize}
@@ -1283,111 +1315,113 @@ export const RandomWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
                     })}
                   </span>
                 </Button>
-              </>
-            )}
-            {mode === 'groups' &&
-              Array.isArray(displayResult) &&
-              displayResult.length > 0 &&
-              ((typeof displayResult[0] === 'object' &&
-                displayResult[0] !== null &&
-                'names' in displayResult[0]) ||
-                Array.isArray(displayResult[0])) && (
-                <Button
-                  variant="secondary"
-                  shape="pill"
-                  onClick={handleSendToScoreboard}
-                  aria-label={t('widgets.random.sendToScoreboard')}
+                <div
+                  aria-hidden="true"
+                  className="flex-shrink-0"
                   style={{
                     width: 'clamp(40px, 10cqmin, 72px)',
                     height: 'clamp(40px, 10cqmin, 72px)',
-                    padding: 0,
                   }}
-                  className="flex-shrink-0"
-                  title={t('widgets.random.sendToScoreboard')}
-                  icon={
-                    <Trophy
-                      style={{
-                        width: 'clamp(20px, 5cqmin, 36px)',
-                        height: 'clamp(20px, 5cqmin, 36px)',
-                      }}
-                      className="text-amber-500"
-                    />
-                  }
                 />
-              )}
-            {mode === 'groups' && (
-              <GroupSizeStepper
-                value={groupSize}
-                onChange={setGroupSize}
-                title={t('widgets.random.groupSize', {
-                  defaultValue: 'Group Size',
-                })}
-              />
-            )}
-            {mode === 'jigsaw' && !hasJigsawGroups && (
-              <>
-                <GroupSizeStepper
-                  value={groupSize}
-                  onChange={setGroupSize}
-                  label={t('widgets.random.homeLabelShort', {
-                    defaultValue: 'HOME',
-                  })}
-                  title={t('widgets.random.homeGroupSize', {
-                    defaultValue: 'Home Group Size',
-                  })}
-                />
-                <GroupSizeStepper
-                  value={displayNumExpertGroups}
-                  onChange={setNumExpertGroups}
-                  label={t('widgets.random.expertLabelShort', {
-                    defaultValue: 'EXPERT',
-                  })}
-                  title={t('widgets.random.expertGroupCount', {
-                    defaultValue: 'Number of Expert Groups',
-                  })}
-                />
-              </>
-            )}
-            <Button
-              variant="hero"
-              size="md"
-              shape="pill"
-              onClick={handlePick}
-              disabled={isSpinning}
-              className={
-                mode === 'jigsaw' && hasJigsawGroups
-                  ? 'flex-shrink-0'
-                  : 'flex-1'
-              }
-              style={
-                mode === 'jigsaw' && hasJigsawGroups
-                  ? {
-                      // Jigsaw shows two large Launch buttons already; collapse
-                      // Randomize to a square icon-only button so the footer
-                      // doesn't cram three flex-1 children at narrow widths.
+              </div>
+            </div>
+          ) : (
+            <div
+              className="w-full flex"
+              style={{
+                padding: 'clamp(6px, 1.5cqmin, 14px) clamp(8px, 2cqmin, 16px)',
+                gap: 'clamp(6px, 2cqmin, 14px)',
+              }}
+            >
+              {mode === 'groups' &&
+                Array.isArray(displayResult) &&
+                displayResult.length > 0 &&
+                ((typeof displayResult[0] === 'object' &&
+                  displayResult[0] !== null &&
+                  'names' in displayResult[0]) ||
+                  Array.isArray(displayResult[0])) && (
+                  <Button
+                    variant="secondary"
+                    shape="pill"
+                    onClick={handleSendToScoreboard}
+                    aria-label={t('widgets.random.sendToScoreboard')}
+                    style={{
                       width: 'clamp(40px, 10cqmin, 72px)',
                       height: 'clamp(40px, 10cqmin, 72px)',
                       padding: 0,
+                    }}
+                    className="flex-shrink-0"
+                    title={t('widgets.random.sendToScoreboard')}
+                    icon={
+                      <Trophy
+                        style={{
+                          width: 'clamp(20px, 5cqmin, 36px)',
+                          height: 'clamp(20px, 5cqmin, 36px)',
+                        }}
+                        className="text-amber-500"
+                      />
                     }
-                  : {
-                      height: 'clamp(40px, 10cqmin, 72px)',
-                      paddingLeft: 'clamp(16px, 4cqmin, 40px)',
-                      paddingRight: 'clamp(16px, 4cqmin, 40px)',
-                    }
-              }
-              aria-label={isSpinning ? 'Picking' : 'Randomize'}
-              title={isSpinning ? 'Picking...' : 'Randomize'}
-              icon={
-                <RefreshCw
-                  className={isSpinning ? 'animate-spin' : ''}
-                  style={{
-                    width: 'clamp(20px, 6cqmin, 44px)',
-                    height: 'clamp(20px, 6cqmin, 44px)',
-                  }}
+                  />
+                )}
+              {mode === 'groups' && (
+                <GroupSizeStepper
+                  value={groupSize}
+                  onChange={setGroupSize}
+                  title={t('widgets.random.groupSize', {
+                    defaultValue: 'Group Size',
+                  })}
                 />
-              }
-            />
-          </div>
+              )}
+              {mode === 'jigsaw' && !hasJigsawGroups && (
+                <>
+                  <GroupSizeStepper
+                    value={groupSize}
+                    onChange={setGroupSize}
+                    label={t('widgets.random.homeLabelShort', {
+                      defaultValue: 'HOME',
+                    })}
+                    title={t('widgets.random.homeGroupSize', {
+                      defaultValue: 'Home Group Size',
+                    })}
+                  />
+                  <GroupSizeStepper
+                    value={displayNumExpertGroups}
+                    onChange={setNumExpertGroups}
+                    label={t('widgets.random.expertLabelShort', {
+                      defaultValue: 'EXPERT',
+                    })}
+                    title={t('widgets.random.expertGroupCount', {
+                      defaultValue: 'Number of Expert Groups',
+                    })}
+                  />
+                </>
+              )}
+              <Button
+                variant="hero"
+                size="md"
+                shape="pill"
+                onClick={handlePick}
+                disabled={isSpinning}
+                className="flex-1"
+                style={{
+                  height: 'clamp(40px, 10cqmin, 72px)',
+                  paddingLeft: 'clamp(16px, 4cqmin, 40px)',
+                  paddingRight: 'clamp(16px, 4cqmin, 40px)',
+                }}
+                aria-label={isSpinning ? 'Picking' : 'Randomize'}
+                title={isSpinning ? 'Picking...' : 'Randomize'}
+                icon={
+                  <RefreshCw
+                    className={isSpinning ? 'animate-spin' : ''}
+                    style={{
+                      width: 'clamp(20px, 6cqmin, 44px)',
+                      height: 'clamp(20px, 6cqmin, 44px)',
+                    }}
+                  />
+                }
+              />
+            </div>
+          )
         }
       />
       {absentModal}


### PR DESCRIPTION
## Summary

When the Randomizer widget is in **Jigsaw** mode and groups have been generated, the bottom toolbar packs five horizontal controls (Expert stepper, Launch Jigsaw button, Home stepper, Launch Home Group button, Randomize button) into a single row. At typical widget widths the row overflows the widget's right edge and the trailing **Launch Home Group** + **Randomize** buttons get clipped — effectively unreachable from this view. This regressed in PR #1573.

This PR splits the post-pick footer into **two stacked rows**, pairing each stepper with its companion Launch button:

```
Row 1:  [Expert stepper]  [Launch Jigsaw   (flex-1)]  [Randomize ◯]
Row 2:  [Home stepper  ]  [Launch Home Grp (flex-1)]  [   spacer  ]
```

The aria-hidden spacer in Row 2 matches the Randomize button's width so both Launch buttons share the same right edge.

Other footer variants (`mode === 'groups'`, `mode === 'jigsaw'` pre-pick, `single`, `shuffle`) are unchanged — they already fit at any size and weren't the source of the cutoff.

- Touches only the ` + "`footer={...}`" + ` JSX inside the WidgetLayout call in [components/widgets/random/RandomWidget.tsx](https://github.com/OPS-PIvers/SpartBoard/blob/claude/wizardly-gauss-b68c62/components/widgets/random/RandomWidget.tsx)
- All shared building blocks (` + "`GroupSizeStepper`, `Button`, `Sparkles`/`Home`/`RefreshCw`" + ` icons) reused as-is — no new components

## Test plan

- [x] ` + "`pnpm run validate`" + ` — full pipeline (type-check + lint + format + 2270 root tests + 204 functions tests) green
- [x] New regression test in [components/widgets/random/RandomWidget.test.tsx](https://github.com/OPS-PIvers/SpartBoard/blob/claude/wizardly-gauss-b68c62/components/widgets/random/RandomWidget.test.tsx) asserts the two-row footer structure and pins which row each of the 5 controls belongs to
- [x] Existing 11 RandomWidget tests still pass (Launch button toggle behavior, ` + "`aria-pressed`/`disabled`" + ` state on the active view, pre-pick steppers, scoreboard hand-off, mode cycle)
- [ ] Manual smoke check after merge: open Group Maker, switch to Jigsaw, click Randomize, resize widget from default (~300×320) up through large sizes — confirm every footer control stays visible and clickable; toggle Launch Jigsaw / Launch Home Group; click +/- on each stepper independently

🤖 Generated with [Claude Code](https://claude.com/claude-code)