### PR TITLE
perf(admin-analytics): cache snapshot via daily scheduler

### DIFF
--- a/components/admin/Analytics/AnalyticsManager.tsx
+++ b/components/admin/Analytics/AnalyticsManager.tsx
@@ -25,8 +25,8 @@ import {
   BarChart2,
   ChevronDown,
   ChevronUp,
+  Clock,
   LayoutGrid,
-  RefreshCw,
   School,
   Search,
   Users,
@@ -102,6 +102,15 @@ interface AnalyticsData {
     avgDailyCallsPerUser: number;
     byFeature: Record<string, number>;
   };
+  // Snapshot freshness metadata returned alongside the payload. The server
+  // computes the analytics once a day; these timestamps drive the
+  // "Last updated · Next update at" badge so the admin understands they're
+  // looking at a cached read rather than a live aggregate.
+  meta?: {
+    computedAt: number;
+    nextRecomputeAt: number;
+    computeDurationMs: number;
+  };
 }
 
 type AnalyticsTab = 'overview' | 'widgets' | 'ai' | 'users';
@@ -113,6 +122,57 @@ const WIDGET_LABELS: Record<string, string> = TOOLS.reduce(
   },
   {} as Record<string, string>
 );
+
+/**
+ * "Updated 4h ago · Next update at 5:00 AM" badge that replaces the previous
+ * manual Refresh button. Analytics are now computed once daily by a Cloud
+ * Scheduler job; a client-driven recompute would defeat the cache and reopen
+ * the unbounded-Firestore-reads cost path. The badge makes the cached nature
+ * of the data legible to the admin so they don't wonder why a recent change
+ * isn't reflected yet.
+ *
+ * `meta` is optional because page-load races and the `not-yet-computed` cold
+ * start can both arrive at the badge before the server has any snapshot to
+ * report on. In those cases the badge stays hidden — the surrounding error
+ * banner already carries the "Analytics ready at 5:00 AM Central" copy.
+ */
+const SnapshotFreshnessBadge: React.FC<{
+  meta?: { computedAt: number; nextRecomputeAt: number };
+}> = ({ meta }) => {
+  if (!meta) return null;
+  const updated = formatRelativeTimeAgo(meta.computedAt);
+  const nextAt = new Date(meta.nextRecomputeAt).toLocaleTimeString([], {
+    hour: 'numeric',
+    minute: '2-digit',
+  });
+  return (
+    <div
+      className="inline-flex items-center gap-2 rounded-lg border border-slate-200 bg-slate-50 px-3 py-1.5 text-xs text-slate-600"
+      title={`Computed ${new Date(meta.computedAt).toLocaleString()} · Next refresh ${new Date(meta.nextRecomputeAt).toLocaleString()}`}
+    >
+      <Clock className="w-3.5 h-3.5 text-slate-400" />
+      <span>
+        Updated {updated} · Next update at {nextAt}
+      </span>
+    </div>
+  );
+};
+
+/**
+ * Returns a short relative-time string ("2h ago", "just now", "3d ago").
+ * Uses `Intl.RelativeTimeFormat` so the unit choice is locale-correct.
+ */
+function formatRelativeTimeAgo(timestampMs: number): string {
+  const diffMs = Date.now() - timestampMs;
+  const minutes = Math.round(diffMs / 60_000);
+  const fmt = new Intl.RelativeTimeFormat(undefined, { numeric: 'auto' });
+  if (minutes < 1) return fmt.format(0, 'minute');
+  if (minutes < 60) return fmt.format(-minutes, 'minute');
+  const hours = Math.round(minutes / 60);
+  if (hours < 24) return fmt.format(-hours, 'hour');
+  const days = Math.round(hours / 24);
+  return fmt.format(-days, 'day');
+}
 
 /**
  * Folds a record keyed by raw building IDs into a record keyed by canonical
@@ -1477,6 +1537,11 @@ export const AnalyticsManager: React.FC = () => {
           message?: string;
           error?: string;
         };
+        // 503 + `not-yet-computed` is the server's signal for "this org has
+        // no snapshot yet — wait for the next scheduled refresh." Surface it
+        // verbatim so the admin sees a clear "not ready" state rather than
+        // a generic error banner; the message body already contains the
+        // user-facing copy ("ready at 5:00 AM Central daily").
         const msg = body.message ?? body.error ?? `HTTP ${response.status}`;
         throw new Error(msg);
       }
@@ -1516,6 +1581,7 @@ export const AnalyticsManager: React.FC = () => {
           avgDailyCallsPerUser: raw.api?.avgDailyCallsPerUser ?? 0,
           byFeature: raw.api?.byFeature ?? {},
         },
+        meta: raw.meta,
       };
 
       if (!isMountedRef.current || requestId !== requestSequenceRef.current) {
@@ -1720,15 +1786,7 @@ export const AnalyticsManager: React.FC = () => {
           </select>
         </div>
 
-        <button
-          type="button"
-          disabled={loading}
-          onClick={() => void fetchAnalytics()}
-          className="inline-flex items-center gap-2 rounded-lg border border-slate-200 bg-white px-3 py-1.5 text-sm font-semibold text-slate-700 hover:bg-slate-50 shadow-sm disabled:cursor-not-allowed disabled:opacity-50"
-        >
-          <RefreshCw className={`w-4 h-4 ${loading ? 'animate-spin' : ''}`} />
-          Refresh
-        </button>
+        <SnapshotFreshnessBadge meta={data?.meta} />
       </div>
 
       <div

--- a/components/admin/Analytics/AnalyticsManager.tsx
+++ b/components/admin/Analytics/AnalyticsManager.tsx
@@ -161,16 +161,24 @@ const SnapshotFreshnessBadge: React.FC<{
 /**
  * Returns a short relative-time string ("2h ago", "just now", "3d ago").
  * Uses `Intl.RelativeTimeFormat` so the unit choice is locale-correct.
+ *
+ * Uses `Math.floor` (not `Math.round`) to truncate to the largest unit the
+ * elapsed time has actually crossed. Rounding would promote 59 min to "1
+ * hour ago" and 23.5 hours to "1 day ago" — those displays misrepresent the
+ * freshness of the snapshot in the direction that's worse for the user
+ * (claiming staler data than reality). Truncation always under-states the
+ * elapsed time by less than one unit, which is the right error direction
+ * for a "this data is up to X old" indicator.
  */
 function formatRelativeTimeAgo(timestampMs: number): string {
   const diffMs = Date.now() - timestampMs;
-  const minutes = Math.round(diffMs / 60_000);
+  const minutes = Math.floor(diffMs / 60_000);
   const fmt = new Intl.RelativeTimeFormat(undefined, { numeric: 'auto' });
   if (minutes < 1) return fmt.format(0, 'minute');
   if (minutes < 60) return fmt.format(-minutes, 'minute');
-  const hours = Math.round(minutes / 60);
+  const hours = Math.floor(minutes / 60);
   if (hours < 24) return fmt.format(-hours, 'hour');
-  const days = Math.round(hours / 24);
+  const days = Math.floor(hours / 24);
   return fmt.format(-days, 'day');
 }
 

--- a/docs/CLOUD_FUNCTIONS_COST_OPTIMIZATION.md
+++ b/docs/CLOUD_FUNCTIONS_COST_OPTIMIZATION.md
@@ -10,12 +10,15 @@ The "GB-sec/call" column below is the **worst case per call** (memory × max tim
 
 | Function                    | Memory  | Max timeout    | GB-sec/call (max) | Est. cost/call (max) |
 | --------------------------- | ------- | -------------- | ----------------- | -------------------- |
-| `adminAnalytics`            | 4 GiB   | 540 s          | 2,160             | ~$0.039              |
+| `adminAnalytics` (hot path) | 1 GiB   | 30 s           | 30                | ~$0.0005             |
+| `recomputeAdminAnalytics`   | 4 GiB   | 540 s (1/day)  | 2,160             | ~$0.039              |
 | `generateVideoActivity`     | 1 GiB   | 300 s          | 300               | ~$0.005              |
 | `transcribeVideoWithGemini` | 1 GiB   | 300 s          | 300               | ~$0.005              |
 | `generateWithAI`            | 512 MiB | 60 s (default) | ~30               | ~$0.0005             |
 | `archiveActivityWallPhoto`  | 512 MiB | 120 s          | ~60               | ~$0.001              |
 | `fetchExternalProxy`        | 128 MiB | 30 s           | ~3.75             | ~$0.00007            |
+
+The `adminAnalytics` row now reflects the post-2026-05-11 snapshot-read implementation. The 4 GiB / 540 s ceiling moved to the once-a-day scheduled `recomputeAdminAnalytics` job, so the per-call cost of admin page loads dropped by ~98% even before counting the Firestore reads that were eliminated.
 
 ---
 
@@ -91,12 +94,11 @@ The proxy function streams external API responses back to the caller with no siz
 
 ## Recommended action order
 
-1. **Cache `adminAnalytics` output per org** — highest ROI; eliminates both unbounded Firestore scans on the hot path and is what's likely driving the bulk of the bill.
+1. ~~**Cache `adminAnalytics` output per org**~~ — **Done** (2026-05-11). Replaced with a once-daily scheduled recompute (`recomputeAdminAnalytics`, 5 AM Central) that writes `/organizations/{orgId}/analytics/snapshot`. The hot-path HTTP handler now reads that snapshot doc and returns it; the two unbounded streams (`collectionGroup('dashboards')` + `collection('ai_usage')`) are gone from the per-call path entirely. Hot-path memory dropped from 4 GiB to 1 GiB, timeout from 540 s to 30 s. UI shows a "Updated Xh ago · Next update at 5:00 AM" badge instead of a Refresh button — analytics are explicitly a luxury daily read, and a manual recompute button would just reintroduce the cost path that this change amortizes. Compute helper extracted to `functions/src/adminAnalyticsCompute.ts`; the scheduled job and snapshot reader live in `functions/src/adminAnalyticsSnapshot.ts`. Per-org failures in the recompute don't abort the batch.
 2. **Verify `fetchExternalProxy` invocation counts** in Firebase Console → Functions → Usage. A few hundred/day across the admin pool is expected; thousands/day means too many admin tabs or a misconfigured refresh interval.
 3. **Add module-level caching to `generateWithAI`** — easy win, saves Firestore reads with no behavioral change.
-4. **Reduce `adminAnalytics` memory** — after caching is in place, drop from 4 GiB to 512 MiB.
-5. **Add file size guard to `archiveActivityWallPhoto`**.
-6. **Batch ClassLink roster fetches**.
+4. **Add file size guard to `archiveActivityWallPhoto`**.
+5. **Batch ClassLink roster fetches**.
 
 ## How to monitor going forward
 

--- a/firestore.rules
+++ b/firestore.rules
@@ -384,6 +384,22 @@ service cloud.firestore {
       match /testClasses/{classId} {
         allow read, write: if isSuperAdmin() || isDomainAdmin(orgId);
       }
+
+      // Cached analytics snapshot, written nightly by the
+      // `recomputeAdminAnalytics` scheduled function (Admin SDK, bypasses
+      // rules) and read by the `adminAnalytics` HTTP function. Surfaced here
+      // so the client can read it directly in future iterations without going
+      // through the HTTP handler; today the HTTP handler is still the only
+      // reader, but a client-direct read path would be a strict cost win.
+      // Read is gated to org admins (any tier) since the snapshot carries
+      // per-member emails and engagement data. All writes are blocked — no
+      // client should ever write here; the scheduler is the sole writer.
+      match /analytics/{document} {
+        allow read: if isSuperAdmin() ||
+                    isDomainAdmin(orgId) ||
+                    isBuildingAdmin(orgId);
+        allow write: if false;
+      }
     }
 
     // Admins collection

--- a/functions/src/adminAnalyticsCompute.ts
+++ b/functions/src/adminAnalyticsCompute.ts
@@ -1,18 +1,17 @@
 /**
  * Org-scoped analytics computation.
  *
- * Extracted from the inline body of `adminAnalytics` so the same logic can run
- * from two callers without duplicating it:
- *   - the read-only `adminAnalytics` HTTP callable falls back to it only on a
- *     cold-miss for a newly-created org (one-time per org);
- *   - the scheduled `recomputeAdminAnalytics` job calls it once per active org
- *     at 5 AM Central daily and stores the result at
- *     `/organizations/{orgId}/analytics/snapshot`.
+ * Extracted from the inline body of `adminAnalytics` and now driven only by
+ * the scheduled `recomputeAdminAnalytics` job in `adminAnalyticsSnapshot.ts`,
+ * which calls this once per active org at 5 AM Central daily and stores the
+ * result at `/organizations/{orgId}/analytics/snapshot`. The HTTP handler
+ * reads that snapshot and returns 503 on a cold-miss — it intentionally does
+ * NOT fall back to this helper, because doing so would reintroduce the
+ * unbounded-Firestore-reads cost path the snapshot cache exists to amortize.
  *
  * The function performs two unbounded reads — `collectionGroup('dashboards')`
  * and `collection('ai_usage')` — joined against the org's member roster
- * in-memory. That cost is the reason the snapshot cache exists; the hot path
- * is expected to read the snapshot doc, not call this helper.
+ * in-memory. That cost is the reason the snapshot cache exists.
  */
 
 import * as admin from 'firebase-admin';

--- a/functions/src/adminAnalyticsCompute.ts
+++ b/functions/src/adminAnalyticsCompute.ts
@@ -1,0 +1,558 @@
+/**
+ * Org-scoped analytics computation.
+ *
+ * Extracted from the inline body of `adminAnalytics` so the same logic can run
+ * from two callers without duplicating it:
+ *   - the read-only `adminAnalytics` HTTP callable falls back to it only on a
+ *     cold-miss for a newly-created org (one-time per org);
+ *   - the scheduled `recomputeAdminAnalytics` job calls it once per active org
+ *     at 5 AM Central daily and stores the result at
+ *     `/organizations/{orgId}/analytics/snapshot`.
+ *
+ * The function performs two unbounded reads — `collectionGroup('dashboards')`
+ * and `collection('ai_usage')` — joined against the org's member roster
+ * in-memory. That cost is the reason the snapshot cache exists; the hot path
+ * is expected to read the snapshot doc, not call this helper.
+ */
+
+import * as admin from 'firebase-admin';
+
+export interface AdminAnalyticsPayload {
+  users: {
+    total: number;
+    registered: number;
+    registeredIsFallback: boolean;
+    monthly: number;
+    daily: number;
+    withDashboards: number;
+    domains: Record<string, EngagementCounts>;
+    buildings: Record<string, EngagementCounts>;
+    domainBuilding: Record<string, Record<string, EngagementCounts>>;
+    userList: AnalyticsUserRow[];
+  };
+  widgets: {
+    totalInstances: Record<string, number>;
+    activeInstances: Record<string, number>;
+    usersByType: Record<string, { count: number; emails: string[] }>;
+  };
+  dashboards: {
+    total: number;
+    avgWidgetsPerDashboard: number;
+  };
+  api: {
+    totalCalls: number;
+    activeUsers: number;
+    topUsers: { uid: string; count: number; email: string }[];
+    avgDailyCalls: number;
+    avgDailyCallsPerUser: number;
+    byFeature: Record<string, number>;
+  };
+}
+
+interface EngagementCounts {
+  total: number;
+  monthly: number;
+  daily: number;
+}
+
+interface AnalyticsUserRow {
+  email: string;
+  buildings: string[];
+  lastSignInMs: number;
+  lastEditMs: number;
+  hasDashboard: boolean;
+  isMonthlyActive: boolean;
+  isDailyActive: boolean;
+}
+
+interface DashboardData {
+  updatedAt?: number;
+  widgets?: { type: string }[];
+}
+
+interface MemberLite {
+  email: string;
+  uid: string | null;
+  buildingIds: string[];
+}
+
+/**
+ * Compute the full analytics payload for one org. Pure(ish) — only side
+ * effects are Firestore reads and `auth().getUsers()` lookups. Caller is
+ * expected to have already verified authorization for `orgId`.
+ *
+ * `logContext` is threaded into the same `[getAdminAnalytics]` log lines the
+ * inline implementation used, so existing Cloud Logging filters keep working.
+ */
+export async function computeAnalyticsForOrg(
+  orgId: string,
+  logContext: { requestId?: string; scheduled?: boolean } = {}
+): Promise<AdminAnalyticsPayload> {
+  const db = admin.firestore();
+  const now = Date.now();
+
+  // 1. Load the org's members as the authoritative user roster. Members
+  // without a `uid` (invited but never signed in) still count toward totals
+  // but have zero engagement.
+  const members: MemberLite[] = [];
+  const membersSnap = await db
+    .collection(`organizations/${orgId}/members`)
+    .get();
+  for (const doc of membersSnap.docs) {
+    const data = doc.data() as {
+      email?: unknown;
+      uid?: unknown;
+      buildingIds?: unknown;
+    };
+    const memberEmail =
+      typeof data.email === 'string' ? data.email.toLowerCase() : doc.id;
+    const uid = typeof data.uid === 'string' && data.uid ? data.uid : null;
+    const buildingIds = Array.isArray(data.buildingIds)
+      ? data.buildingIds.filter(
+          (id): id is string => typeof id === 'string' && id.length > 0
+        )
+      : [];
+    members.push({ email: memberEmail, uid, buildingIds });
+  }
+
+  // Resolve Firebase Auth metadata for members with a linked uid. `getUsers`
+  // tolerates up to 100 identifiers per call and silently drops uids that no
+  // longer exist in Auth, which is the right behavior for a member doc whose
+  // uid was revoked.
+  const authUsersMap = new Map<
+    string,
+    { email: string; lastSignInMs: number }
+  >();
+  const uidsToResolve = members
+    .map((m) => m.uid)
+    .filter((uid): uid is string => uid !== null);
+  const chunks: { uid: string }[][] = [];
+  for (let i = 0; i < uidsToResolve.length; i += 100) {
+    chunks.push(uidsToResolve.slice(i, i + 100).map((uid) => ({ uid })));
+  }
+
+  await Promise.all(
+    chunks.map(async (chunk) => {
+      try {
+        const result = await admin.auth().getUsers(chunk);
+        for (const u of result.users) {
+          const lastSignIn = u.metadata.lastSignInTime
+            ? new Date(u.metadata.lastSignInTime).getTime()
+            : 0;
+          authUsersMap.set(u.uid, {
+            email: u.email ?? '',
+            lastSignInMs: lastSignIn,
+          });
+        }
+      } catch (err) {
+        console.warn('[getAdminAnalytics] auth().getUsers() chunk failed', {
+          ...logContext,
+          orgId,
+          chunkSize: chunk.length,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    })
+  );
+
+  // Build uid → member lookup so downstream dashboard/AI filters can scope to
+  // org members without being gated on a successful `auth().getUsers()`
+  // round-trip. An auth lookup failure must not silently drop a real member's
+  // dashboards or AI usage from the totals.
+  const memberUids = new Set<string>();
+  for (const m of members) {
+    if (m.uid) memberUids.add(m.uid);
+  }
+
+  // 2. Time constants & helpers (engagement computed after dashboard stream
+  // so we can use last-edit timestamps instead of last-login).
+  const thirtyDaysMs = 30 * 24 * 60 * 60 * 1000;
+  const oneDayMs = 24 * 60 * 60 * 1000;
+
+  const increment = (
+    bucket: Record<string, EngagementCounts>,
+    key: string,
+    isMonthlyActive: boolean,
+    isDailyActive: boolean
+  ) => {
+    if (!bucket[key]) {
+      bucket[key] = { total: 0, monthly: 0, daily: 0 };
+    }
+    bucket[key].total += 1;
+    if (isMonthlyActive) bucket[key].monthly += 1;
+    if (isDailyActive) bucket[key].daily += 1;
+  };
+
+  // 3. Stream every dashboard doc in the database and join against the
+  // member-uid set in memory. This is one of the two unbounded reads the
+  // snapshot cache exists to amortize.
+  let totalDashboards = 0;
+  const totalWidgetCounts: Record<string, number> = {};
+  const activeWidgetCounts: Record<string, number> = {};
+  const allDashboardOwnerUids = new Set<string>();
+  let totalWidgetInstances = 0;
+  // Bounded at MAX_WIDGET_USER_TRACK UIDs per type: memory is
+  // O(widget_types × limit) instead of O(widget_types × all_users).
+  // count = Set.size is exact up to the cap; above the cap it means "≥ cap".
+  const MAX_WIDGET_USER_TRACK = 100;
+  const widgetToUserUids: Record<string, Set<string>> = {};
+  const activeThreshold = now - 30 * 24 * 60 * 60 * 1000;
+  const lastEditByUser = new Map<string, number>();
+
+  const dashboardsStream = db
+    .collectionGroup('dashboards')
+    .select('widgets', 'updatedAt')
+    .stream() as unknown as AsyncIterable<admin.firestore.QueryDocumentSnapshot>;
+
+  for await (const dashDoc of dashboardsStream) {
+    if (!dashDoc.exists) continue;
+    const dashData = dashDoc.data() as DashboardData;
+    const updatedAt =
+      typeof dashData.updatedAt === 'number' ? dashData.updatedAt : 0;
+    const isActive = updatedAt > activeThreshold;
+
+    // Extract owner UID from path: users/{uid}/dashboards/{dashId}
+    const ownerUid: string | null = dashDoc.ref.parent.parent?.id ?? null;
+
+    if (!ownerUid || !memberUids.has(ownerUid)) continue;
+
+    totalDashboards++;
+    allDashboardOwnerUids.add(ownerUid);
+
+    const prevEdit = lastEditByUser.get(ownerUid) ?? 0;
+    if (updatedAt > prevEdit) {
+      lastEditByUser.set(ownerUid, updatedAt);
+    }
+
+    const widgetCount = Array.isArray(dashData.widgets)
+      ? dashData.widgets.length
+      : 0;
+    totalWidgetInstances += widgetCount;
+
+    if (dashData.widgets && Array.isArray(dashData.widgets)) {
+      dashData.widgets.forEach((w: { type: string }) => {
+        if (w && w.type) {
+          totalWidgetCounts[w.type] = (totalWidgetCounts[w.type] || 0) + 1;
+          if (isActive) {
+            activeWidgetCounts[w.type] = (activeWidgetCounts[w.type] || 0) + 1;
+          }
+          if (ownerUid) {
+            if (!widgetToUserUids[w.type]) {
+              widgetToUserUids[w.type] = new Set<string>();
+            }
+            const uidSet = widgetToUserUids[w.type];
+            if (uidSet.size < MAX_WIDGET_USER_TRACK || uidSet.has(ownerUid)) {
+              uidSet.add(ownerUid);
+            }
+          }
+        }
+      });
+    }
+  }
+
+  // 4. Compute engagement from last-edit timestamps. Iterate the org member
+  // roster (not just the auth-resolved subset) so invited-but-never-signed-in
+  // members count toward totals with zero engagement.
+  const usersByDomain: Record<string, EngagementCounts> = {};
+  const usersByBuilding: Record<string, EngagementCounts> = {};
+  const usersByDomainAndBuilding: Record<
+    string,
+    Record<string, EngagementCounts>
+  > = {};
+  const totalEngagement: EngagementCounts = {
+    total: 0,
+    monthly: 0,
+    daily: 0,
+  };
+
+  for (const member of members) {
+    const userEmail = member.email;
+    const domain = userEmail.includes('@')
+      ? userEmail.split('@')[1]
+      : 'unknown';
+    const lastEditMs = member.uid ? (lastEditByUser.get(member.uid) ?? 0) : 0;
+    const isMonthlyActive = lastEditMs > 0 && now - lastEditMs <= thirtyDaysMs;
+    const isDailyActive = lastEditMs > 0 && now - lastEditMs <= oneDayMs;
+
+    totalEngagement.total += 1;
+    if (isMonthlyActive) totalEngagement.monthly += 1;
+    if (isDailyActive) totalEngagement.daily += 1;
+
+    increment(usersByDomain, domain, isMonthlyActive, isDailyActive);
+
+    const buildings = member.buildingIds;
+    if (buildings.length === 0) {
+      increment(usersByBuilding, 'none', isMonthlyActive, isDailyActive);
+      if (!usersByDomainAndBuilding[domain]) {
+        usersByDomainAndBuilding[domain] = {};
+      }
+      increment(
+        usersByDomainAndBuilding[domain],
+        'none',
+        isMonthlyActive,
+        isDailyActive
+      );
+    } else {
+      for (const building of buildings) {
+        increment(usersByBuilding, building, isMonthlyActive, isDailyActive);
+        if (!usersByDomainAndBuilding[domain]) {
+          usersByDomainAndBuilding[domain] = {};
+        }
+        increment(
+          usersByDomainAndBuilding[domain],
+          building,
+          isMonthlyActive,
+          isDailyActive
+        );
+      }
+    }
+  }
+
+  const userList: AnalyticsUserRow[] = members.map((member) => {
+    const authInfo = member.uid ? authUsersMap.get(member.uid) : undefined;
+    const lastSignInMs = authInfo?.lastSignInMs ?? 0;
+    const lastEditMs = member.uid ? (lastEditByUser.get(member.uid) ?? 0) : 0;
+    return {
+      email: member.email,
+      buildings: member.buildingIds,
+      lastSignInMs,
+      lastEditMs,
+      hasDashboard: member.uid ? allDashboardOwnerUids.has(member.uid) : false,
+      isMonthlyActive: lastEditMs > 0 && now - lastEditMs <= thirtyDaysMs,
+      isDailyActive: lastEditMs > 0 && now - lastEditMs <= oneDayMs,
+    };
+  });
+
+  const totalRegisteredUsers = authUsersMap.size;
+
+  // Resolve widget UIDs to emails (cap at 200 unique UIDs total).
+  const allWidgetUids = new Set<string>();
+  outer: for (const uids of Object.values(widgetToUserUids)) {
+    for (const uid of uids) {
+      if (allWidgetUids.size >= 200) break outer;
+      allWidgetUids.add(uid);
+    }
+  }
+
+  const widgetUserEmails: Record<string, string> = {};
+  const resolveUserEmailsViaAuthFallback = async (
+    uids: string[],
+    targetMap: Record<string, string>,
+    warningContext: string
+  ): Promise<void> => {
+    const identifiers = uids.map((uid) => ({ uid }));
+    const chunks: { uid: string }[][] = [];
+    for (let i = 0; i < identifiers.length; i += 100) {
+      chunks.push(identifiers.slice(i, i + 100));
+    }
+
+    await Promise.all(
+      chunks.map(async (chunk, chunkIdx) => {
+        try {
+          const result = await admin.auth().getUsers(chunk);
+          result.users.forEach((u) => {
+            if (u.email) {
+              targetMap[u.uid] = u.email;
+            }
+          });
+        } catch (error) {
+          console.warn(
+            `[getAdminAnalytics] Failed to resolve user emails via auth fallback for ${warningContext}`,
+            {
+              ...logContext,
+              orgId,
+              chunkSize: chunk.length,
+              chunkStart: chunkIdx * 100,
+              totalIdentifiers: identifiers.length,
+              totalUids: uids.length,
+              error: error instanceof Error ? error.message : String(error),
+            }
+          );
+        }
+      })
+    );
+  };
+
+  const allWidgetUidArray = Array.from(allWidgetUids);
+  for (let i = 0; i < allWidgetUidArray.length; i += 30) {
+    const uidChunk = allWidgetUidArray.slice(i, i + 30);
+    if (uidChunk.length === 0) continue;
+    const snapshot = await db
+      .collection('users')
+      .where(admin.firestore.FieldPath.documentId(), 'in', uidChunk)
+      .select('email')
+      .get();
+    snapshot.docs.forEach((d) => {
+      const userData = d.data();
+      if (
+        typeof userData['email'] === 'string' &&
+        userData['email'].length > 0
+      ) {
+        widgetUserEmails[d.id] = userData['email'];
+      }
+    });
+  }
+  const unresolvedWidgetUids = allWidgetUidArray.filter(
+    (uid) => !widgetUserEmails[uid]
+  );
+  if (unresolvedWidgetUids.length > 0) {
+    await resolveUserEmailsViaAuthFallback(
+      unresolvedWidgetUids,
+      widgetUserEmails,
+      'widget drilldowns'
+    );
+  }
+
+  const usersByType: Record<string, { count: number; emails: string[] }> = {};
+  for (const [widgetType, uidSet] of Object.entries(widgetToUserUids)) {
+    usersByType[widgetType] = {
+      count: uidSet.size,
+      emails: Array.from(uidSet)
+        .slice(0, 20)
+        .map((uid) => widgetUserEmails[uid] ?? `Unknown (${uid})`)
+        .sort(),
+    };
+  }
+
+  // 5. Stream every ai_usage doc and filter by member uid. Second unbounded
+  // read; same amortization story as dashboards.
+  let totalAiCalls = 0;
+  const callsPerUser: Record<string, number> = {};
+  const dailyCallCounts: Record<string, number> = {};
+  const aiCallsByFeature: Record<string, number> = {};
+
+  const GEMINI_SPECIFIC_FEATURES = [
+    'smart-poll',
+    'embed-mini-app',
+    'video-activity-audio-transcription',
+    'quiz',
+    'ocr',
+    'guided-learning',
+  ];
+
+  const aiUsageStream = db
+    .collection('ai_usage')
+    .select('count')
+    .stream() as unknown as AsyncIterable<admin.firestore.QueryDocumentSnapshot>;
+
+  for await (const usageDoc of aiUsageStream) {
+    if (!usageDoc.exists) continue;
+    const idParts = usageDoc.id.split('_');
+    if (idParts.length < 2) continue;
+
+    const datePart = idParts[idParts.length - 1];
+    const secondToLast = idParts[idParts.length - 2];
+    const isSpecificFeature = GEMINI_SPECIFIC_FEATURES.includes(secondToLast);
+
+    const uidParts = idParts.slice(0, isSpecificFeature ? -2 : -1);
+    const uid = uidParts.join('_');
+
+    if (!uid || !datePart) continue;
+
+    if (!memberUids.has(uid)) continue;
+
+    const usageData = usageDoc.data();
+    const count = typeof usageData.count === 'number' ? usageData.count : 0;
+
+    if (isSpecificFeature) {
+      aiCallsByFeature[secondToLast] =
+        (aiCallsByFeature[secondToLast] ?? 0) + count;
+    }
+
+    // ONLY count "overall" records for total analytics to avoid double counting
+    // (per-feature records are for rate-limit enforcement, overall tracks all).
+    if (!isSpecificFeature) {
+      totalAiCalls += count;
+      callsPerUser[uid] = (callsPerUser[uid] ?? 0) + count;
+      dailyCallCounts[datePart] = (dailyCallCounts[datePart] ?? 0) + count;
+    }
+  }
+
+  const uniqueDays = Object.keys(dailyCallCounts).length || 1;
+  const avgDailyCalls = Math.round(totalAiCalls / uniqueDays);
+  const activeAiUsers = Object.keys(callsPerUser).length || 1;
+  const avgDailyCallsPerUser =
+    Math.round((avgDailyCalls / activeAiUsers) * 10) / 10;
+  const topUserUids = Object.entries(callsPerUser)
+    .sort(([, a], [, b]) => b - a)
+    .slice(0, 25)
+    .map(([uid]) => uid);
+  const topUserEmails: Record<string, string> = {};
+
+  const uidChunks: string[][] = [];
+  for (let i = 0; i < topUserUids.length; i += 10) {
+    uidChunks.push(topUserUids.slice(i, i + 10));
+  }
+
+  await Promise.all(
+    uidChunks.map(async (uidChunk) => {
+      if (uidChunk.length === 0) return;
+      const usersSnapshot = await db
+        .collection('users')
+        .where(admin.firestore.FieldPath.documentId(), 'in', uidChunk)
+        .select('email')
+        .get();
+
+      usersSnapshot.docs.forEach((doc) => {
+        const userData = doc.data();
+        if (typeof userData.email === 'string' && userData.email.length > 0) {
+          topUserEmails[doc.id] = userData.email;
+        }
+      });
+    })
+  );
+  const unresolvedTopUserUids = topUserUids.filter(
+    (uid) => !topUserEmails[uid]
+  );
+  if (unresolvedTopUserUids.length > 0) {
+    await resolveUserEmailsViaAuthFallback(
+      unresolvedTopUserUids,
+      topUserEmails,
+      'AI top users'
+    );
+  }
+
+  const topUsers = Object.entries(callsPerUser)
+    .sort(([, a], [, b]) => b - a)
+    .slice(0, 25)
+    .map(([uid, count]) => ({
+      uid,
+      count,
+      email: topUserEmails[uid] ?? `Unknown (${uid})`,
+    }));
+
+  return {
+    users: {
+      total: totalEngagement.total,
+      registered: totalRegisteredUsers,
+      registeredIsFallback: false,
+      monthly: totalEngagement.monthly,
+      daily: totalEngagement.daily,
+      withDashboards: allDashboardOwnerUids.size,
+      domains: usersByDomain,
+      buildings: usersByBuilding,
+      domainBuilding: usersByDomainAndBuilding,
+      userList,
+    },
+    widgets: {
+      totalInstances: totalWidgetCounts,
+      activeInstances: activeWidgetCounts,
+      usersByType,
+    },
+    dashboards: {
+      total: totalDashboards,
+      avgWidgetsPerDashboard:
+        totalDashboards > 0
+          ? Math.round((totalWidgetInstances / totalDashboards) * 10) / 10
+          : 0,
+    },
+    api: {
+      totalCalls: totalAiCalls,
+      activeUsers: Object.keys(callsPerUser).length,
+      topUsers,
+      avgDailyCalls,
+      avgDailyCallsPerUser,
+      byFeature: aiCallsByFeature,
+    },
+  };
+}

--- a/functions/src/adminAnalyticsSnapshot.ts
+++ b/functions/src/adminAnalyticsSnapshot.ts
@@ -92,10 +92,25 @@ export const recomputeAdminAnalytics = onSchedule(
     // the org count and risk OOM on the 4 GiB instance.
     for (const orgId of targetOrgs) {
       const orgStartedAt = Date.now();
+      let payload;
       try {
-        const payload = await computeAnalyticsForOrg(orgId, {
-          scheduled: true,
+        payload = await computeAnalyticsForOrg(orgId, { scheduled: true });
+      } catch (err) {
+        failed += 1;
+        // Per-org failures must not abort the batch — a single misconfigured
+        // org shouldn't starve the rest of the fleet of fresh analytics.
+        // `phase` is split from the write branch below so log-based alerts
+        // can distinguish "compute logic is broken" from "Firestore is
+        // flaky on the write path" without parsing error messages.
+        console.error('[recomputeAdminAnalytics] org failed', {
+          orgId,
+          phase: 'compute',
+          error: err instanceof Error ? err.message : String(err),
         });
+        continue;
+      }
+
+      try {
         const computedAt = Date.now();
         const snapshot: AnalyticsSnapshotDoc = {
           schemaVersion: SNAPSHOT_SCHEMA_VERSION,
@@ -108,38 +123,78 @@ export const recomputeAdminAnalytics = onSchedule(
         succeeded += 1;
       } catch (err) {
         failed += 1;
-        // Per-org failures must not abort the batch — a single misconfigured
-        // org shouldn't starve the rest of the fleet of fresh analytics.
         console.error('[recomputeAdminAnalytics] org failed', {
           orgId,
+          phase: 'write',
           error: err instanceof Error ? err.message : String(err),
         });
       }
     }
 
+    // If every org failed there's no point letting Scheduler treat the run
+    // as healthy — throw so the run is marked failed and the next-run alert
+    // fires. Mixed results stay at info-level so a single bad org doesn't
+    // spam alerts when the rest succeeded; the per-org error lines above are
+    // the right hook for "investigate this specific org" log alerts.
+    const totalDurationMs = Date.now() - startedAt;
+    if (failed > 0 && succeeded === 0 && targetOrgs.length > 0) {
+      console.error('[recomputeAdminAnalytics] all orgs failed', {
+        failed,
+        totalDurationMs,
+      });
+      throw new Error(
+        `recomputeAdminAnalytics: all ${failed} org(s) failed; see prior log lines for per-org error details`
+      );
+    }
+
     console.log('[recomputeAdminAnalytics] done', {
       succeeded,
       failed,
-      totalDurationMs: Date.now() - startedAt,
+      totalDurationMs,
     });
   }
 );
 
 /**
- * Read a single org's analytics snapshot. Returns `null` when no snapshot
- * exists yet (new org pre-first-scheduled-run) or when the stored
- * `schemaVersion` doesn't match — both treated as "not yet computed" so the
- * hot path returns a deterministic 503 rather than serving stale or
- * mis-shaped data.
+ * Read a single org's analytics snapshot. Returns `null` when no usable
+ * snapshot exists for any of three reasons. All three collapse into a 503
+ * `not-yet-computed` at the HTTP handler because the user-facing remedy is
+ * the same (wait for the next scheduled refresh), but they log at distinct
+ * severities so Cloud Logging triage can tell them apart:
+ *
+ *   - `missing`          — doc doesn't exist (new org pre-first-run). Quiet
+ *                          path; logged at debug only since this is the
+ *                          expected cold-start state and would otherwise
+ *                          spam logs every page load until the next 5 AM.
+ *   - `stale-schema`     — `schemaVersion` mismatch. Expected for ~24h
+ *                          after a snapshot-shape bump; logs at warn so a
+ *                          spike post-deploy is visible but not alarming.
+ *   - `malformed`        — required fields missing/wrong-typed. Unexpected
+ *                          (the scheduler always writes a valid shape), so
+ *                          logged at error and worth investigating.
  */
 export async function readAnalyticsSnapshot(
   orgId: string
 ): Promise<AnalyticsSnapshotDoc | null> {
   const db = admin.firestore();
   const snap = await db.doc(`organizations/${orgId}/analytics/snapshot`).get();
-  if (!snap.exists) return null;
+  if (!snap.exists) {
+    console.debug('[readAnalyticsSnapshot] missing', { orgId });
+    return null;
+  }
   const data = snap.data() as Partial<AnalyticsSnapshotDoc> | undefined;
-  if (!data || data.schemaVersion !== SNAPSHOT_SCHEMA_VERSION) {
+  if (!data) {
+    console.error('[readAnalyticsSnapshot] malformed: empty doc data', {
+      orgId,
+    });
+    return null;
+  }
+  if (data.schemaVersion !== SNAPSHOT_SCHEMA_VERSION) {
+    console.warn('[readAnalyticsSnapshot] stale-schema', {
+      orgId,
+      observedSchemaVersion: data.schemaVersion,
+      expectedSchemaVersion: SNAPSHOT_SCHEMA_VERSION,
+    });
     return null;
   }
   if (
@@ -148,6 +203,13 @@ export async function readAnalyticsSnapshot(
     typeof data.computeDurationMs !== 'number' ||
     !data.payload
   ) {
+    console.error('[readAnalyticsSnapshot] malformed: required fields', {
+      orgId,
+      hasComputedAt: typeof data.computedAt === 'number',
+      hasNextRecomputeAt: typeof data.nextRecomputeAt === 'number',
+      hasComputeDurationMs: typeof data.computeDurationMs === 'number',
+      hasPayload: !!data.payload,
+    });
     return null;
   }
   return data as AnalyticsSnapshotDoc;

--- a/functions/src/adminAnalyticsSnapshot.ts
+++ b/functions/src/adminAnalyticsSnapshot.ts
@@ -1,0 +1,154 @@
+/**
+ * Scheduled analytics recompute + snapshot read helper.
+ *
+ * The previous `adminAnalytics` HTTP function did two unbounded Firestore
+ * reads (`collectionGroup('dashboards').stream()` and
+ * `collection('ai_usage').stream()`) on every admin page load. Once the user
+ * base grew past a handful of teachers, that path dominated the Cloud
+ * Functions + Firestore bill (see `docs/CLOUD_FUNCTIONS_COST_OPTIMIZATION.md`).
+ *
+ * The cache architecture:
+ *   - `recomputeAdminAnalytics` runs once a day at 5 AM Central, iterates
+ *     every non-archived org, and writes the computed payload to
+ *     `/organizations/{orgId}/analytics/snapshot` with `computedAt` and
+ *     `nextRecomputeAt` timestamps.
+ *   - `adminAnalytics` (hot path, lives in `index.ts`) reads the snapshot and
+ *     returns it verbatim. Total reads per admin page load: 3 (admin gate,
+ *     member doc, snapshot). No streaming reads.
+ *   - First-ever load for a newly created org returns a 503 so the UI shows
+ *     "Analytics will be ready after the next scheduled refresh" until the
+ *     scheduler runs once.
+ *
+ * The Refresh button in the UI is gone — analytics are a luxury read,
+ * once-daily refresh is acceptable, and any client-initiated recompute would
+ * just reintroduce the cost path we're amortizing.
+ */
+
+import { onSchedule } from 'firebase-functions/v2/scheduler';
+import * as admin from 'firebase-admin';
+import {
+  computeAnalyticsForOrg,
+  type AdminAnalyticsPayload,
+} from './adminAnalyticsCompute';
+
+// Skip archived orgs. Active + trial both get recomputed.
+const ACTIVE_ORG_STATUSES = new Set(['active', 'trial']);
+
+/**
+ * Bumped if the snapshot shape ever changes incompatibly. The reader at the
+ * hot path will reject mismatched versions and fall through to the
+ * "not-yet-computed" branch, forcing the next scheduled run to overwrite the
+ * stale doc with a current-shape payload.
+ */
+export const SNAPSHOT_SCHEMA_VERSION = 1;
+
+const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+
+export interface AnalyticsSnapshotDoc {
+  schemaVersion: number;
+  computedAt: number;
+  nextRecomputeAt: number;
+  computeDurationMs: number;
+  payload: AdminAnalyticsPayload;
+}
+
+/**
+ * Scheduled daily recompute. 5 AM America/Chicago — off-peak for US-Central
+ * teachers, well clear of the morning login wave. 4 GiB / 540 s ceilings
+ * mirror the previous HTTP handler since the compute work itself is
+ * unchanged; only its trigger surface moved.
+ */
+export const recomputeAdminAnalytics = onSchedule(
+  {
+    schedule: '0 5 * * *',
+    timeZone: 'America/Chicago',
+    memory: '4GiB',
+    timeoutSeconds: 540,
+  },
+  async () => {
+    const startedAt = Date.now();
+    const db = admin.firestore();
+
+    const orgsSnap = await db.collection('organizations').get();
+    const targetOrgs: string[] = [];
+    for (const doc of orgsSnap.docs) {
+      const data = doc.data() as { status?: unknown };
+      const status = typeof data.status === 'string' ? data.status : 'active';
+      if (ACTIVE_ORG_STATUSES.has(status)) {
+        targetOrgs.push(doc.id);
+      }
+    }
+
+    console.log('[recomputeAdminAnalytics] starting', {
+      orgCount: targetOrgs.length,
+      orgIds: targetOrgs,
+    });
+
+    let succeeded = 0;
+    let failed = 0;
+
+    // Sequential, not parallel: each org's compute streams two unbounded
+    // collections. Running them concurrently would multiply peak memory by
+    // the org count and risk OOM on the 4 GiB instance.
+    for (const orgId of targetOrgs) {
+      const orgStartedAt = Date.now();
+      try {
+        const payload = await computeAnalyticsForOrg(orgId, {
+          scheduled: true,
+        });
+        const computedAt = Date.now();
+        const snapshot: AnalyticsSnapshotDoc = {
+          schemaVersion: SNAPSHOT_SCHEMA_VERSION,
+          computedAt,
+          nextRecomputeAt: computedAt + ONE_DAY_MS,
+          computeDurationMs: computedAt - orgStartedAt,
+          payload,
+        };
+        await db.doc(`organizations/${orgId}/analytics/snapshot`).set(snapshot);
+        succeeded += 1;
+      } catch (err) {
+        failed += 1;
+        // Per-org failures must not abort the batch — a single misconfigured
+        // org shouldn't starve the rest of the fleet of fresh analytics.
+        console.error('[recomputeAdminAnalytics] org failed', {
+          orgId,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+
+    console.log('[recomputeAdminAnalytics] done', {
+      succeeded,
+      failed,
+      totalDurationMs: Date.now() - startedAt,
+    });
+  }
+);
+
+/**
+ * Read a single org's analytics snapshot. Returns `null` when no snapshot
+ * exists yet (new org pre-first-scheduled-run) or when the stored
+ * `schemaVersion` doesn't match — both treated as "not yet computed" so the
+ * hot path returns a deterministic 503 rather than serving stale or
+ * mis-shaped data.
+ */
+export async function readAnalyticsSnapshot(
+  orgId: string
+): Promise<AnalyticsSnapshotDoc | null> {
+  const db = admin.firestore();
+  const snap = await db.doc(`organizations/${orgId}/analytics/snapshot`).get();
+  if (!snap.exists) return null;
+  const data = snap.data() as Partial<AnalyticsSnapshotDoc> | undefined;
+  if (!data || data.schemaVersion !== SNAPSHOT_SCHEMA_VERSION) {
+    return null;
+  }
+  if (
+    typeof data.computedAt !== 'number' ||
+    typeof data.nextRecomputeAt !== 'number' ||
+    typeof data.computeDurationMs !== 'number' ||
+    !data.payload
+  ) {
+    return null;
+  }
+  return data as AnalyticsSnapshotDoc;
+}

--- a/functions/src/index.test.ts
+++ b/functions/src/index.test.ts
@@ -32,6 +32,17 @@ const mockFirestoreState = {
   users: [] as MockDocInput[],
   dashboards: [] as MockDocInput[],
   aiUsage: [] as MockDocInput[],
+  // Map of path → doc data for `db.doc(path).get()` mocks. Used by the
+  // adminAnalytics snapshot read tests (path:
+  // `organizations/{orgId}/analytics/snapshot`) and any future test that
+  // needs a deterministic doc fetch. Unset paths return `{ exists: false }`
+  // via the default `mockFirestore.doc` fallback.
+  docs: new Map<string, Record<string, unknown>>(),
+  // Org records for the scheduled `recomputeAdminAnalytics` job. Each entry
+  // is treated as a doc under `/organizations/{id}` with the given `status`.
+  // The scheduler iterates this collection and only recomputes for orgs
+  // with status in {active, trial}.
+  organizations: [] as { id: string; status: string }[],
 };
 
 const toDocSnapshot = (doc: MockDocInput) => ({
@@ -61,7 +72,17 @@ interface MockDocRef {
 const mockFirestore = {
   doc: vi.fn((path: string) => ({
     path,
-    get: vi.fn(() => Promise.resolve({ exists: false })),
+    get: vi.fn(() => {
+      const stashed = mockFirestoreState.docs.get(path);
+      if (stashed) {
+        return Promise.resolve({ exists: true, data: () => stashed });
+      }
+      return Promise.resolve({ exists: false });
+    }),
+    set: vi.fn((data: Record<string, unknown>) => {
+      mockFirestoreState.docs.set(path, data);
+      return Promise.resolve();
+    }),
   })),
   getAll: vi.fn((...refs: MockDocRef[]) => {
     return Promise.resolve(
@@ -134,6 +155,21 @@ const mockFirestore = {
         select: vi.fn(() => ({
           stream: vi.fn(() => toAsyncStream(mockFirestoreState.aiUsage)),
         })),
+      };
+    }
+
+    // Top-level `organizations` collection — used by the scheduled
+    // `recomputeAdminAnalytics` job to iterate every non-archived org.
+    if (name === 'organizations') {
+      return {
+        get: vi.fn(() =>
+          Promise.resolve({
+            docs: mockFirestoreState.organizations.map((o) => ({
+              id: o.id,
+              data: () => ({ status: o.status }),
+            })),
+          })
+        ),
       };
     }
 
@@ -245,6 +281,13 @@ vi.mock('firebase-functions/v2', () => ({
   setGlobalOptions: vi.fn(),
 }));
 
+// Mock firebase-functions/v2/scheduler — `onSchedule` returns the handler
+// directly so tests can invoke the recompute job by calling
+// `recomputeAdminAnalytics()` like a plain async function.
+vi.mock('firebase-functions/v2/scheduler', () => ({
+  onSchedule: (_options: unknown, handler: () => Promise<void>) => handler,
+}));
+
 // Mock firebase-functions/params (defineSecret)
 vi.mock('firebase-functions/params', () => ({
   defineSecret: (name: string) => ({
@@ -263,6 +306,12 @@ import {
   adminAnalytics,
   getPseudonymsForAssignmentV1,
 } from './index';
+import { computeAnalyticsForOrg } from './adminAnalyticsCompute';
+import {
+  SNAPSHOT_SCHEMA_VERSION,
+  recomputeAdminAnalytics,
+  type AnalyticsSnapshotDoc,
+} from './adminAnalyticsSnapshot';
 
 describe('fetchExternalProxy', () => {
   beforeEach(() => {
@@ -497,6 +546,7 @@ describe('adminAnalytics', () => {
     mockFirestoreState.users = [];
     mockFirestoreState.dashboards = [];
     mockFirestoreState.aiUsage = [];
+    mockFirestoreState.docs = new Map();
   });
 
   it('aggregates users by domain and building, including no-building users', async () => {
@@ -546,32 +596,7 @@ describe('adminAnalytics', () => {
       { id: 'uid2_smart-poll_2026-03-30', data: { count: 99 } },
     ];
 
-    const handler = adminAnalytics;
-
-    /* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-call */
-    const resPromise = new Promise<any>((resolve) => {
-      const mockRes = {
-        status: vi.fn().mockReturnThis(),
-        json: vi.fn().mockImplementation((data) => {
-          resolve(data);
-          return data;
-        }),
-        setHeader: vi.fn().mockReturnThis(),
-        getHeader: vi.fn().mockReturnValue(''),
-      };
-
-      const mockReq = {
-        headers: {
-          origin: 'http://localhost',
-          authorization: 'Bearer mock-token',
-        },
-        body: { orgId: 'orono' },
-      };
-
-      (handler as any)(mockReq, mockRes);
-    });
-
-    const capturedData = await resPromise;
+    const capturedData = await computeAnalyticsForOrg('orono');
 
     expect(capturedData.users.total).toBe(3);
     expect(capturedData.users.monthly).toBe(2);
@@ -597,7 +622,6 @@ describe('adminAnalytics', () => {
       daily: 0,
     });
     expect(capturedData.api.totalCalls).toBe(10);
-    /* eslint-enable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-return */
   });
 
   it('returns topUsers with resolved email and unknown fallback', async () => {
@@ -624,32 +648,7 @@ describe('adminAnalytics', () => {
       { id: 'uid_b_2026-03-30', data: { count: 3 } },
     ];
 
-    const handler = adminAnalytics;
-
-    /* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-call */
-    const resPromise = new Promise<any>((resolve) => {
-      const mockRes = {
-        status: vi.fn().mockReturnThis(),
-        json: vi.fn().mockImplementation((data) => {
-          resolve(data);
-          return data;
-        }),
-        setHeader: vi.fn().mockReturnThis(),
-        getHeader: vi.fn().mockReturnValue(''),
-      };
-
-      const mockReq = {
-        headers: {
-          origin: 'http://localhost',
-          authorization: 'Bearer mock-token',
-        },
-        body: { orgId: 'orono' },
-      };
-
-      (handler as any)(mockReq, mockRes);
-    });
-
-    const capturedData = await resPromise;
+    const capturedData = await computeAnalyticsForOrg('orono');
 
     expect(capturedData.api.topUsers[0]).toEqual({
       uid: 'uid_a',
@@ -661,7 +660,6 @@ describe('adminAnalytics', () => {
       count: 3,
       email: 'Unknown (uid_b)',
     });
-    /* eslint-enable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-return */
   });
 
   it('returns usersByType with correct count and resolved emails', async () => {
@@ -712,28 +710,7 @@ describe('adminAnalytics', () => {
       },
     ];
 
-    /* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-call */
-    const resPromise = new Promise<any>((resolve) => {
-      const mockRes = {
-        status: vi.fn().mockReturnThis(),
-        json: vi.fn().mockImplementation((data) => {
-          resolve(data);
-          return data;
-        }),
-        setHeader: vi.fn().mockReturnThis(),
-        getHeader: vi.fn().mockReturnValue(''),
-      };
-      const mockReq = {
-        headers: {
-          origin: 'http://localhost',
-          authorization: 'Bearer mock-token',
-        },
-        body: { orgId: 'orono' },
-      };
-      (adminAnalytics as any)(mockReq, mockRes);
-    });
-
-    const capturedData = await resPromise;
+    const capturedData = await computeAnalyticsForOrg('orono');
 
     // clock: 2 distinct users (alice counted once despite 2 dashboards)
     expect(capturedData.widgets.usersByType.clock.count).toBe(2);
@@ -750,7 +727,6 @@ describe('adminAnalytics', () => {
     expect(capturedData.widgets.usersByType.timer.emails).toEqual([
       'alice@district.org',
     ]);
-    /* eslint-enable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-return */
   });
 
   it('caps usersByType emails at 20 and reports accurate count up to 100', async () => {
@@ -770,34 +746,12 @@ describe('adminAnalytics', () => {
       data: { updatedAt: Date.now(), widgets: [{ type: 'clock' }] },
     }));
 
-    /* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-call */
-    const resPromise = new Promise<any>((resolve) => {
-      const mockRes = {
-        status: vi.fn().mockReturnThis(),
-        json: vi.fn().mockImplementation((data) => {
-          resolve(data);
-          return data;
-        }),
-        setHeader: vi.fn().mockReturnThis(),
-        getHeader: vi.fn().mockReturnValue(''),
-      };
-      const mockReq = {
-        headers: {
-          origin: 'http://localhost',
-          authorization: 'Bearer mock-token',
-        },
-        body: { orgId: 'orono' },
-      };
-      (adminAnalytics as any)(mockReq, mockRes);
-    });
-
-    const capturedData = await resPromise;
+    const capturedData = await computeAnalyticsForOrg('orono');
 
     // All 25 distinct users tracked (well within the 100-cap)
     expect(capturedData.widgets.usersByType.clock.count).toBe(25);
     // Emails preview capped at 20
     expect(capturedData.widgets.usersByType.clock.emails).toHaveLength(20);
-    /* eslint-enable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-return */
   });
 
   it('excludes anonymous auth users from all analytics metrics', async () => {
@@ -853,28 +807,7 @@ describe('adminAnalytics', () => {
       { id: 'uid_anon1_2026-03-30', data: { count: 10 } },
     ];
 
-    /* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-call */
-    const resPromise = new Promise<any>((resolve) => {
-      const mockRes = {
-        status: vi.fn().mockReturnThis(),
-        json: vi.fn().mockImplementation((data) => {
-          resolve(data);
-          return data;
-        }),
-        setHeader: vi.fn().mockReturnThis(),
-        getHeader: vi.fn().mockReturnValue(''),
-      };
-      const mockReq = {
-        headers: {
-          origin: 'http://localhost',
-          authorization: 'Bearer mock-token',
-        },
-        body: { orgId: 'orono' },
-      };
-      (adminAnalytics as any)(mockReq, mockRes);
-    });
-
-    const capturedData = await resPromise;
+    const capturedData = await computeAnalyticsForOrg('orono');
 
     // Only the teacher should be counted — anonymous users excluded
     expect(capturedData.users.total).toBe(1);
@@ -896,7 +829,6 @@ describe('adminAnalytics', () => {
 
     // Only teacher's AI usage counted
     expect(capturedData.api.totalCalls).toBe(5);
-    /* eslint-enable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-call */
   });
 
   it('excludes signed-in auth users who are not members of the requested org', async () => {
@@ -977,28 +909,7 @@ describe('adminAnalytics', () => {
       { id: 'uid_uninvited_same_domain_2026-03-30', data: { count: 42 } },
     ];
 
-    /* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-call */
-    const resPromise = new Promise<any>((resolve) => {
-      const mockRes = {
-        status: vi.fn().mockReturnThis(),
-        json: vi.fn().mockImplementation((data) => {
-          resolve(data);
-          return data;
-        }),
-        setHeader: vi.fn().mockReturnThis(),
-        getHeader: vi.fn().mockReturnValue(''),
-      };
-      const mockReq = {
-        headers: {
-          origin: 'http://localhost',
-          authorization: 'Bearer mock-token',
-        },
-        body: { orgId: 'orono' },
-      };
-      (adminAnalytics as any)(mockReq, mockRes);
-    });
-
-    const capturedData = await resPromise;
+    const capturedData = await computeAnalyticsForOrg('orono');
 
     // Only the invited member counts toward totals.
     expect(capturedData.users.total).toBe(1);
@@ -1034,7 +945,6 @@ describe('adminAnalytics', () => {
       (u: { email: string }) => u.email === 'uninvited@school.org'
     );
     expect(uninvitedRow).toBeUndefined();
-    /* eslint-enable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-call */
   });
 
   it('counts invited-but-never-signed-in members toward totals with zero engagement', async () => {
@@ -1072,28 +982,7 @@ describe('adminAnalytics', () => {
       },
     ];
 
-    /* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-call */
-    const resPromise = new Promise<any>((resolve) => {
-      const mockRes = {
-        status: vi.fn().mockReturnThis(),
-        json: vi.fn().mockImplementation((data) => {
-          resolve(data);
-          return data;
-        }),
-        setHeader: vi.fn().mockReturnThis(),
-        getHeader: vi.fn().mockReturnValue(''),
-      };
-      const mockReq = {
-        headers: {
-          origin: 'http://localhost',
-          authorization: 'Bearer mock-token',
-        },
-        body: { orgId: 'orono' },
-      };
-      (adminAnalytics as any)(mockReq, mockRes);
-    });
-
-    const capturedData = await resPromise;
+    const capturedData = await computeAnalyticsForOrg('orono');
 
     // Totals include the invited member.
     expect(capturedData.users.total).toBe(2);
@@ -1117,9 +1006,10 @@ describe('adminAnalytics', () => {
 
     // Per-user drilldown: the invited member is present with zero engagement.
     const invitedRow = capturedData.users.userList.find(
-      (u: { email: string }) => u.email === 'invited@district.org'
+      (u) => u.email === 'invited@district.org'
     );
     expect(invitedRow).toBeDefined();
+    if (!invitedRow) throw new Error('unreachable');
     expect(invitedRow.lastSignInMs).toBe(0);
     expect(invitedRow.lastEditMs).toBe(0);
     expect(invitedRow.hasDashboard).toBe(false);
@@ -1129,7 +1019,6 @@ describe('adminAnalytics', () => {
     // Only the active member owns a dashboard.
     expect(capturedData.users.withDashboards).toBe(1);
     expect(capturedData.dashboards.total).toBe(1);
-    /* eslint-enable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-call */
   });
 
   it('returns 400 when orgId is missing from the request body', async () => {
@@ -1336,6 +1225,274 @@ describe('adminAnalytics', () => {
       collectionSpy.mockRestore();
     }
     /* eslint-enable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment */
+  });
+
+  it('returns 503 when no analytics snapshot exists yet for the org', async () => {
+    // Cold-start contract: a brand-new org has no entry at
+    // `organizations/{orgId}/analytics/snapshot` until the scheduled
+    // `recomputeAdminAnalytics` job has run at least once. The HTTP handler
+    // must return a deterministic 503 with `error: 'not-yet-computed'` so
+    // the UI can show "Analytics ready after the next scheduled refresh"
+    // rather than spinning forever or surfacing a generic error.
+    /* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-call */
+    const statusSpy = vi.fn().mockReturnThis();
+    const jsonSpy = vi.fn().mockReturnThis();
+    const setHeaderSpy = vi.fn().mockReturnThis();
+    const mockRes = {
+      status: statusSpy,
+      json: jsonSpy,
+      setHeader: setHeaderSpy,
+      getHeader: vi.fn().mockReturnValue(''),
+    };
+
+    const mockReq = {
+      headers: {
+        origin: 'http://localhost',
+        authorization: 'Bearer mock-token',
+      },
+      body: { orgId: 'orono' },
+    };
+
+    await (adminAnalytics as any)(mockReq, mockRes);
+
+    expect(statusSpy).toHaveBeenCalledWith(503);
+    const jsonCall = jsonSpy.mock.calls[0]?.[0] as
+      | { error?: string; message?: string }
+      | undefined;
+    expect(jsonCall?.error).toBe('not-yet-computed');
+    expect(jsonCall?.message ?? '').toMatch(/scheduled refresh/i);
+
+    // Crucially: the snapshot-only hot path must not have hit either of the
+    // unbounded streaming reads that the old inline-compute implementation
+    // did. Verifies the cost-saving invariant — if a regression reintroduces
+    // the streams, this assertion catches it.
+    expect(mockFirestore.collectionGroup).not.toHaveBeenCalled();
+    /* eslint-enable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-call */
+  });
+
+  it('returns the cached snapshot payload + meta when one exists', async () => {
+    // Seed a snapshot doc at the canonical path. The hot path should read
+    // this verbatim and round-trip the payload to the caller alongside the
+    // freshness metadata the UI badge consumes.
+    const computedAt = Date.now() - 60 * 60 * 1000; // 1 hour ago
+    const nextRecomputeAt = computedAt + 24 * 60 * 60 * 1000;
+    const seedSnapshot: AnalyticsSnapshotDoc = {
+      schemaVersion: SNAPSHOT_SCHEMA_VERSION,
+      computedAt,
+      nextRecomputeAt,
+      computeDurationMs: 42_000,
+      payload: {
+        users: {
+          total: 7,
+          registered: 7,
+          registeredIsFallback: false,
+          monthly: 5,
+          daily: 2,
+          withDashboards: 6,
+          domains: { 'district.org': { total: 7, monthly: 5, daily: 2 } },
+          buildings: { north: { total: 7, monthly: 5, daily: 2 } },
+          domainBuilding: {},
+          userList: [],
+        },
+        widgets: { totalInstances: {}, activeInstances: {}, usersByType: {} },
+        dashboards: { total: 6, avgWidgetsPerDashboard: 3.5 },
+        api: {
+          totalCalls: 123,
+          activeUsers: 4,
+          topUsers: [],
+          avgDailyCalls: 41,
+          avgDailyCallsPerUser: 10.25,
+          byFeature: {},
+        },
+      },
+    };
+    mockFirestoreState.docs.set(
+      'organizations/orono/analytics/snapshot',
+      seedSnapshot as unknown as Record<string, unknown>
+    );
+
+    /* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-call */
+    let captured: unknown;
+    const statusSpy = vi.fn().mockReturnThis();
+    const jsonSpy = vi.fn().mockImplementation((data: unknown) => {
+      captured = data;
+      return data;
+    });
+    const mockRes = {
+      status: statusSpy,
+      json: jsonSpy,
+      setHeader: vi.fn().mockReturnThis(),
+      getHeader: vi.fn().mockReturnValue(''),
+    };
+
+    const mockReq = {
+      headers: {
+        origin: 'http://localhost',
+        authorization: 'Bearer mock-token',
+      },
+      body: { orgId: 'orono' },
+    };
+
+    await (adminAnalytics as any)(mockReq, mockRes);
+    /* eslint-enable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-call */
+
+    // 200 (no explicit status call — Express defaults to 200 when only
+    // `res.json` is invoked).
+    expect(statusSpy).not.toHaveBeenCalledWith(503);
+    expect(statusSpy).not.toHaveBeenCalledWith(500);
+
+    const body = captured as {
+      users?: { total?: number };
+      dashboards?: { total?: number };
+      meta?: { computedAt?: number; nextRecomputeAt?: number };
+    };
+    expect(body.users?.total).toBe(7);
+    expect(body.dashboards?.total).toBe(6);
+    expect(body.meta?.computedAt).toBe(computedAt);
+    expect(body.meta?.nextRecomputeAt).toBe(nextRecomputeAt);
+
+    // No streaming reads on the cached path.
+    expect(mockFirestore.collectionGroup).not.toHaveBeenCalled();
+  });
+});
+
+describe('recomputeAdminAnalytics (scheduled)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFirestoreState.admins = new Set<string>();
+    mockFirestoreState.users = [];
+    mockFirestoreState.dashboards = [];
+    mockFirestoreState.aiUsage = [];
+    mockFirestoreState.docs = new Map();
+    mockFirestoreState.organizations = [];
+  });
+
+  it('writes a snapshot doc only for orgs with status active or trial; skips archived', async () => {
+    // Mix of statuses across three orgs. The scheduler must recompute for
+    // the active + trial ones and explicitly skip the archived org so a
+    // legacy/deactivated tenant doesn't waste compute on every run.
+    mockFirestoreState.organizations = [
+      { id: 'orono', status: 'active' },
+      { id: 'demo-school', status: 'trial' },
+      { id: 'legacy-school', status: 'archived' },
+    ];
+
+    // Seed a single member so `computeAnalyticsForOrg` has a roster to iterate.
+    // Reused across orgs since `mockFirestoreState.users` is global to the
+    // mock; the per-org `members` collection lookup returns the same list,
+    // which is fine for the org-filtering assertion this test is about.
+    mockFirestoreState.users = [
+      {
+        id: 'uid-1',
+        data: {
+          email: 'teacher@orono.k12.mn.us',
+          lastLogin: Date.now(),
+          buildings: [],
+        },
+      },
+    ];
+
+    // The test mock for `firebase-functions/v2/scheduler` returns the inner
+    // handler directly, so the type-system view (a `ScheduleFunction` taking
+    // event + context) doesn't match the actual runtime shape (a thunk).
+    // Cast to a no-arg async function for the call.
+    await (recomputeAdminAnalytics as unknown as () => Promise<void>)();
+
+    // The two active/trial orgs each got a snapshot written; the archived
+    // org did not. Verifies the `ACTIVE_ORG_STATUSES` filter at the top of
+    // the scheduler — a regression that recomputes archived orgs would
+    // immediately get caught here.
+    expect(
+      mockFirestoreState.docs.get('organizations/orono/analytics/snapshot')
+    ).toBeDefined();
+    expect(
+      mockFirestoreState.docs.get(
+        'organizations/demo-school/analytics/snapshot'
+      )
+    ).toBeDefined();
+    expect(
+      mockFirestoreState.docs.get(
+        'organizations/legacy-school/analytics/snapshot'
+      )
+    ).toBeUndefined();
+
+    // Snapshot shape: schemaVersion + computedAt + nextRecomputeAt (24h
+    // delta) + payload. Lock in the contract the reader at
+    // `readAnalyticsSnapshot` enforces.
+    const written = mockFirestoreState.docs.get(
+      'organizations/orono/analytics/snapshot'
+    ) as unknown as AnalyticsSnapshotDoc;
+    expect(written.schemaVersion).toBe(SNAPSHOT_SCHEMA_VERSION);
+    expect(typeof written.computedAt).toBe('number');
+    expect(written.nextRecomputeAt).toBe(
+      written.computedAt + 24 * 60 * 60 * 1000
+    );
+    expect(written.payload.users.total).toBe(1);
+  });
+
+  it('survives a per-org compute failure and continues to the next org', async () => {
+    // Pin the failure: the first org's member-roster read rejects, while
+    // the second org's read succeeds. The scheduler must log the failure,
+    // skip writing a snapshot for the failing org, and still complete the
+    // recompute for the healthy one. Without this resilience, a single
+    // misconfigured org would starve every other tenant of fresh analytics.
+    mockFirestoreState.organizations = [
+      { id: 'broken-org', status: 'active' },
+      { id: 'healthy-org', status: 'active' },
+    ];
+    mockFirestoreState.users = [
+      {
+        id: 'uid-2',
+        data: {
+          email: 'teacher@healthy.org',
+          lastLogin: Date.now(),
+          buildings: [],
+        },
+      },
+    ];
+
+    // Force the first call to `collection('organizations/broken-org/members')`
+    // to reject. Subsequent calls (healthy-org) use the normal mock path.
+    //
+    // Direct property replacement rather than `vi.spyOn` because spying on a
+    // property that's already a `vi.fn()` collapses identities — the captured
+    // "original" reference ends up being the spy itself, and a delegating
+    // impl that calls `original(name)` infinite-loops. Swapping the property
+    // with a fresh wrapper and calling the saved original breaks the cycle.
+    const originalCollection = mockFirestore.collection;
+    const wrappedCollection = vi.fn((name: string) => {
+      if (name === 'organizations/broken-org/members') {
+        return {
+          get: vi.fn(() =>
+            Promise.reject(new Error('synthetic failure: roster read'))
+          ),
+        } as unknown as ReturnType<typeof originalCollection>;
+      }
+      return originalCollection(name);
+    });
+    mockFirestore.collection =
+      wrappedCollection as unknown as typeof originalCollection;
+
+    try {
+      // The test mock for `firebase-functions/v2/scheduler` returns the inner
+      // handler directly, so the type-system view (a `ScheduleFunction` taking
+      // event + context) doesn't match the actual runtime shape (a thunk).
+      // Cast to a no-arg async function for the call.
+      await (recomputeAdminAnalytics as unknown as () => Promise<void>)();
+
+      expect(
+        mockFirestoreState.docs.get(
+          'organizations/broken-org/analytics/snapshot'
+        )
+      ).toBeUndefined();
+      expect(
+        mockFirestoreState.docs.get(
+          'organizations/healthy-org/analytics/snapshot'
+        )
+      ).toBeDefined();
+    } finally {
+      mockFirestore.collection = originalCollection;
+    }
   });
 });
 

--- a/functions/src/index.test.ts
+++ b/functions/src/index.test.ts
@@ -1494,6 +1494,43 @@ describe('recomputeAdminAnalytics (scheduled)', () => {
       mockFirestore.collection = originalCollection;
     }
   });
+
+  it('throws when every active org fails so Cloud Scheduler marks the run failed', async () => {
+    // Mixed-results path is silent so a single misconfigured org doesn't spam
+    // alerts (covered by the test above). But if every active org fails,
+    // there's nothing to log-alert on per-org and the scheduler run looks
+    // healthy by default — the throw is what tells Cloud Scheduler to mark
+    // the run failed so the next-run-failure alarm fires.
+    mockFirestoreState.organizations = [
+      { id: 'broken-org-1', status: 'active' },
+      { id: 'broken-org-2', status: 'active' },
+    ];
+
+    const originalCollection = mockFirestore.collection;
+    const wrappedCollection = vi.fn((name: string) => {
+      if (
+        name === 'organizations/broken-org-1/members' ||
+        name === 'organizations/broken-org-2/members'
+      ) {
+        return {
+          get: vi.fn(() =>
+            Promise.reject(new Error('synthetic failure: roster read'))
+          ),
+        } as unknown as ReturnType<typeof originalCollection>;
+      }
+      return originalCollection(name);
+    });
+    mockFirestore.collection =
+      wrappedCollection as unknown as typeof originalCollection;
+
+    try {
+      await expect(
+        (recomputeAdminAnalytics as unknown as () => Promise<void>)()
+      ).rejects.toThrow(/all 2 org\(s\) failed/);
+    } finally {
+      mockFirestore.collection = originalCollection;
+    }
+  });
 });
 
 describe('getPseudonymsForAssignmentV1', () => {

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -10,6 +10,7 @@ import { randomUUID } from 'node:crypto';
 import { OAuth2Client } from 'google-auth-library';
 import { sanitizePrompt } from './sanitize';
 import { parseGeminiJson } from './parseGeminiJson';
+import { readAnalyticsSnapshot } from './adminAnalyticsSnapshot';
 
 // Phase 4 — organization invitations + membership write-through.
 // These modules initialize their own `admin.initializeApp()` guarded by
@@ -33,6 +34,7 @@ export {
 } from './syncedVideoActivityGroups';
 export { joinPlcQuizSyncGroup } from './plcQuizSyncJoin';
 export { joinPlcAssignmentSyncGroup } from './plcAssignmentSyncJoin';
+export { recomputeAdminAnalytics } from './adminAnalyticsSnapshot';
 
 setGlobalOptions({ region: 'us-central1' });
 
@@ -2061,30 +2063,27 @@ Guidelines:
   }
 );
 
-interface DashboardData {
-  updatedAt?: number;
-  widgets?: { type: string }[];
-}
-
-interface EngagementCounts {
-  total: number;
-  monthly: number;
-  daily: number;
-}
-
-// registeredUsersCache removed – Auth data is now collected in a single
-// listUsers pass that also provides MAU/DAU, so a separate cache is unnecessary.
-
 /**
  * Cloud Function to fetch administrative analytics.
- * Uses onRequest with explicit CORS to avoid preflight issues with onCall.
- * Bumps memory and timeout to handle unbounded collection reads
- * while a more scalable (paginated/aggregated) solution is developed.
+ *
+ * Read-only hot path: returns the snapshot at
+ * `/organizations/{orgId}/analytics/snapshot` (written nightly by
+ * `recomputeAdminAnalytics`). The previous implementation computed the
+ * payload inline on every call, doing two unbounded reads
+ * (`collectionGroup('dashboards').stream()` + `collection('ai_usage').stream()`)
+ * that dominated the bill once user counts grew. The compute helper itself
+ * still lives in `adminAnalyticsCompute.ts`; it now runs once a day from the
+ * scheduled job in `adminAnalyticsSnapshot.ts` instead of on every page load.
+ *
+ * Memory is held at 1 GiB rather than the legacy 4 GiB because no streaming
+ * reads happen here anymore — only the snapshot doc read plus the auth/authz
+ * doc reads. Could probably drop further; leaving headroom for the JSON
+ * serialization of large snapshots.
  */
 export const adminAnalytics = onRequest(
   {
-    memory: '4GiB',
-    timeoutSeconds: 540,
+    memory: '1GiB',
+    timeoutSeconds: 30,
     cors: ALLOWED_ORIGINS,
     invoker: 'public',
   },
@@ -2172,514 +2171,46 @@ export const adminAnalytics = onRequest(
     }
 
     try {
-      const now = Date.now();
-      // 3a. Load the org's members as the authoritative user roster. This
-      // replaces the previous global `listUsers()` scan, which pulled in every
-      // Firebase Auth account regardless of org and caused foreign-domain
-      // users to show up in a different org's analytics.
+      // Hot path is now snapshot-only. The compute logic that used to live
+      // here (~500 LOC) has moved to `adminAnalyticsCompute.ts` and runs
+      // once a day from the scheduled job in `adminAnalyticsSnapshot.ts`.
       //
-      // For each member we need auth metadata (lastSignInTime) to compute
-      // engagement. Members without a `uid` (invited but never signed in)
-      // still count toward totals but have zero engagement.
-      interface MemberLite {
-        email: string;
-        uid: string | null;
-        buildingIds: string[];
-      }
-      const members: MemberLite[] = [];
-      const membersSnap = await db
-        .collection(`organizations/${orgId}/members`)
-        .get();
-      for (const doc of membersSnap.docs) {
-        const data = doc.data() as {
-          email?: unknown;
-          uid?: unknown;
-          buildingIds?: unknown;
-        };
-        const memberEmail =
-          typeof data.email === 'string' ? data.email.toLowerCase() : doc.id;
-        const uid = typeof data.uid === 'string' && data.uid ? data.uid : null;
-        const buildingIds = Array.isArray(data.buildingIds)
-          ? data.buildingIds.filter(
-              (id): id is string => typeof id === 'string' && id.length > 0
-            )
-          : [];
-        members.push({ email: memberEmail, uid, buildingIds });
-      }
-
-      // Resolve Firebase Auth metadata for members that have a linked uid.
-      // `getUsers()` tolerates up to 100 identifiers per call and silently
-      // drops uids that no longer exist in Auth, which is the right behavior
-      // for a member doc whose uid was revoked.
-      const authUsersMap = new Map<
-        string,
-        { email: string; lastSignInMs: number }
-      >();
-      const uidsToResolve = members
-        .map((m) => m.uid)
-        .filter((uid): uid is string => uid !== null);
-      const chunks: { uid: string }[][] = [];
-      for (let i = 0; i < uidsToResolve.length; i += 100) {
-        chunks.push(uidsToResolve.slice(i, i + 100).map((uid) => ({ uid })));
-      }
-
-      await Promise.all(
-        chunks.map(async (chunk) => {
-          try {
-            const result = await admin.auth().getUsers(chunk);
-            for (const u of result.users) {
-              const lastSignIn = u.metadata.lastSignInTime
-                ? new Date(u.metadata.lastSignInTime).getTime()
-                : 0;
-              authUsersMap.set(u.uid, {
-                email: u.email ?? '',
-                lastSignInMs: lastSignIn,
-              });
-            }
-          } catch (err) {
-            console.warn('[getAdminAnalytics] auth().getUsers() chunk failed', {
-              requestId,
-              orgId,
-              chunkSize: chunk.length,
-              error: err instanceof Error ? err.message : String(err),
-            });
-          }
-        })
-      );
-
-      // 3b. Build a uid → member lookup so downstream dashboard/AI filters can
-      // scope to org members without being gated on a successful
-      // `auth().getUsers()` round-trip. `authUsersMap` is only used to join
-      // lastSignIn metadata; an auth lookup failure must not silently drop a
-      // real member's dashboards or AI usage from the totals.
-      const memberUids = new Set<string>();
-      for (const m of members) {
-        if (m.uid) memberUids.add(m.uid);
-      }
-
-      // 3c. Time constants & helpers (engagement computed after dashboard
-      //     stream so we can use last-edit timestamps instead of last-login)
-      const thirtyDaysMs = 30 * 24 * 60 * 60 * 1000;
-      const oneDayMs = 24 * 60 * 60 * 1000;
-
-      const increment = (
-        bucket: Record<string, EngagementCounts>,
-        key: string,
-        isMonthlyActive: boolean,
-        isDailyActive: boolean
-      ) => {
-        if (!bucket[key]) {
-          bucket[key] = { total: 0, monthly: 0, daily: 0 };
-        }
-        bucket[key].total += 1;
-        if (isMonthlyActive) bucket[key].monthly += 1;
-        if (isDailyActive) bucket[key].daily += 1;
-      };
-      // 4. Fetch Dashboards for Widget Stats
-      let totalDashboards = 0;
-      const totalWidgetCounts: Record<string, number> = {};
-      const activeWidgetCounts: Record<string, number> = {};
-      const allDashboardOwnerUids = new Set<string>();
-      let totalWidgetInstances = 0;
-      // Bounded at MAX_WIDGET_USER_TRACK UIDs per type: memory is
-      // O(widget_types × limit) instead of O(widget_types × all_users).
-      // count = Set.size is exact up to the cap; above the cap it means "≥ cap".
-      const MAX_WIDGET_USER_TRACK = 100;
-      const widgetToUserUids: Record<string, Set<string>> = {};
-      const activeThreshold = now - 30 * 24 * 60 * 60 * 1000; // 30 days
-      // Track most recent dashboard edit per user for edit-based DAU/MAU
-      const lastEditByUser = new Map<string, number>();
-
-      const dashboardsStream = db
-        .collectionGroup('dashboards')
-        .select('widgets', 'updatedAt')
-        .stream() as unknown as AsyncIterable<admin.firestore.QueryDocumentSnapshot>;
-
-      for await (const dashDoc of dashboardsStream) {
-        if (!dashDoc.exists) continue;
-        const dashData = dashDoc.data() as DashboardData;
-        const updatedAt =
-          typeof dashData.updatedAt === 'number' ? dashData.updatedAt : 0;
-        const isActive = updatedAt > activeThreshold;
-
-        // Extract owner UID from path: users/{uid}/dashboards/{dashId}
-        const ownerUid: string | null = dashDoc.ref.parent.parent?.id ?? null;
-
-        // Skip dashboards not owned by a member of this org. Use the member
-        // roster (not `authUsersMap`) so a transient `auth().getUsers()`
-        // failure doesn't silently drop real members' dashboards from totals.
-        if (!ownerUid || !memberUids.has(ownerUid)) continue;
-
-        totalDashboards++;
-        allDashboardOwnerUids.add(ownerUid);
-
-        // Track the most recent edit across all of this user's dashboards
-        const prevEdit = lastEditByUser.get(ownerUid) ?? 0;
-        if (updatedAt > prevEdit) {
-          lastEditByUser.set(ownerUid, updatedAt);
-        }
-
-        const widgetCount = Array.isArray(dashData.widgets)
-          ? dashData.widgets.length
-          : 0;
-        totalWidgetInstances += widgetCount;
-
-        if (dashData.widgets && Array.isArray(dashData.widgets)) {
-          dashData.widgets.forEach((w: { type: string }) => {
-            if (w && w.type) {
-              totalWidgetCounts[w.type] = (totalWidgetCounts[w.type] || 0) + 1;
-              if (isActive) {
-                activeWidgetCounts[w.type] =
-                  (activeWidgetCounts[w.type] || 0) + 1;
-              }
-              if (ownerUid) {
-                if (!widgetToUserUids[w.type]) {
-                  widgetToUserUids[w.type] = new Set<string>();
-                }
-                const uidSet = widgetToUserUids[w.type];
-                // Only grow the Set while under the cap (or if already present)
-                if (
-                  uidSet.size < MAX_WIDGET_USER_TRACK ||
-                  uidSet.has(ownerUid)
-                ) {
-                  uidSet.add(ownerUid);
-                }
-              }
-            }
-          });
-        }
-      }
-
-      // 4b. Compute engagement using last-edit timestamps (not last-login)
-      //     A user is "active" if they edited a dashboard within the window.
-      const usersByDomain: Record<string, EngagementCounts> = {};
-      const usersByBuilding: Record<string, EngagementCounts> = {};
-      const usersByDomainAndBuilding: Record<
-        string,
-        Record<string, EngagementCounts>
-      > = {};
-      const totalEngagement: EngagementCounts = {
-        total: 0,
-        monthly: 0,
-        daily: 0,
-      };
-
-      // Iterate the org member roster (not just the auth-resolved subset) so
-      // invited-but-never-signed-in members count toward totals/domain/building
-      // buckets with zero engagement, matching the "totals come from the
-      // member roster; engagement is joined from Auth when available" contract.
-      for (const member of members) {
-        const userEmail = member.email;
-        const domain = userEmail.includes('@')
-          ? userEmail.split('@')[1]
-          : 'unknown';
-        const lastEditMs = member.uid
-          ? (lastEditByUser.get(member.uid) ?? 0)
-          : 0;
-        const isMonthlyActive =
-          lastEditMs > 0 && now - lastEditMs <= thirtyDaysMs;
-        const isDailyActive = lastEditMs > 0 && now - lastEditMs <= oneDayMs;
-
-        totalEngagement.total += 1;
-        if (isMonthlyActive) totalEngagement.monthly += 1;
-        if (isDailyActive) totalEngagement.daily += 1;
-
-        increment(usersByDomain, domain, isMonthlyActive, isDailyActive);
-
-        const buildings = member.buildingIds;
-        if (buildings.length === 0) {
-          increment(usersByBuilding, 'none', isMonthlyActive, isDailyActive);
-          if (!usersByDomainAndBuilding[domain]) {
-            usersByDomainAndBuilding[domain] = {};
-          }
-          increment(
-            usersByDomainAndBuilding[domain],
-            'none',
-            isMonthlyActive,
-            isDailyActive
-          );
-        } else {
-          for (const building of buildings) {
-            increment(
-              usersByBuilding,
-              building,
-              isMonthlyActive,
-              isDailyActive
-            );
-            if (!usersByDomainAndBuilding[domain]) {
-              usersByDomainAndBuilding[domain] = {};
-            }
-            increment(
-              usersByDomainAndBuilding[domain],
-              building,
-              isMonthlyActive,
-              isDailyActive
-            );
-          }
-        }
-      }
-
-      // 4c. Build per-user detail list for KPI drilldowns. Same rule: iterate
-      // the member roster, join Auth metadata when a uid is present.
-      const userList = members.map((member) => {
-        const authInfo = member.uid ? authUsersMap.get(member.uid) : undefined;
-        const lastSignInMs = authInfo?.lastSignInMs ?? 0;
-        const lastEditMs = member.uid
-          ? (lastEditByUser.get(member.uid) ?? 0)
-          : 0;
-        return {
-          email: member.email,
-          buildings: member.buildingIds,
-          lastSignInMs,
-          lastEditMs,
-          hasDashboard: member.uid
-            ? allDashboardOwnerUids.has(member.uid)
-            : false,
-          isMonthlyActive: lastEditMs > 0 && now - lastEditMs <= thirtyDaysMs,
-          isDailyActive: lastEditMs > 0 && now - lastEditMs <= oneDayMs,
-        };
-      });
-
-      // Auth data was already collected in step 3a – no separate scan needed
-      const totalRegisteredUsers = authUsersMap.size;
-      const registeredIsFallback = false;
-
-      // Resolve widget UIDs to emails (cap at 200 unique UIDs total)
-      const allWidgetUids = new Set<string>();
-      outer: for (const uids of Object.values(widgetToUserUids)) {
-        for (const uid of uids) {
-          if (allWidgetUids.size >= 200) break outer;
-          allWidgetUids.add(uid);
-        }
-      }
-
-      const widgetUserEmails: Record<string, string> = {};
-      const resolveUserEmailsViaAuthFallback = async (
-        uids: string[],
-        targetMap: Record<string, string>,
-        warningContext: string
-      ): Promise<void> => {
-        const identifiers = uids.map((uid) => ({ uid }));
-        const chunks: { uid: string }[][] = [];
-        for (let i = 0; i < identifiers.length; i += 100) {
-          chunks.push(identifiers.slice(i, i + 100));
-        }
-
-        await Promise.all(
-          chunks.map(async (chunk, chunkIdx) => {
-            try {
-              const result = await admin.auth().getUsers(chunk);
-              result.users.forEach((u) => {
-                if (u.email) {
-                  targetMap[u.uid] = u.email;
-                }
-              });
-            } catch (error) {
-              console.warn(
-                `[getAdminAnalytics] Failed to resolve user emails via auth fallback for ${warningContext}`,
-                {
-                  requestId,
-                  chunkSize: chunk.length,
-                  chunkStart: chunkIdx * 100,
-                  totalIdentifiers: identifiers.length,
-                  totalUids: uids.length,
-                  error: error instanceof Error ? error.message : String(error),
-                }
-              );
-            }
-          })
-        );
-      };
-      const allWidgetUidArray = Array.from(allWidgetUids);
-      for (let i = 0; i < allWidgetUidArray.length; i += 30) {
-        const uidChunk = allWidgetUidArray.slice(i, i + 30);
-        if (uidChunk.length === 0) continue;
-        const snapshot = await db
-          .collection('users')
-          .where(admin.firestore.FieldPath.documentId(), 'in', uidChunk)
-          .select('email')
-          .get();
-        snapshot.docs.forEach((d) => {
-          const userData = d.data();
-          if (
-            typeof userData['email'] === 'string' &&
-            userData['email'].length > 0
-          ) {
-            widgetUserEmails[d.id] = userData['email'];
-          }
+      // Three reads total at this point: admin doc, member doc (both fetched
+      // above for the authz gate), and the snapshot doc. Compared to the
+      // pre-cache implementation this skips a `collectionGroup('dashboards')`
+      // stream over every dashboard in the database plus an `ai_usage`
+      // stream over every per-user counter — the two reads that were
+      // dominating the bill.
+      const snapshot = await readAnalyticsSnapshot(orgId);
+      if (!snapshot) {
+        // No snapshot yet — either a brand-new org pre-first-scheduled-run,
+        // or the snapshot was written under an older schemaVersion that the
+        // reader rejects. Either way, surface a 503 with a deterministic
+        // payload shape so the UI can show "Analytics will be ready after
+        // the next scheduled refresh" rather than spinning forever.
+        console.log('[getAdminAnalytics] no snapshot available', {
+          requestId,
+          orgId,
         });
-      }
-      const unresolvedWidgetUids = allWidgetUidArray.filter(
-        (uid) => !widgetUserEmails[uid]
-      );
-      if (unresolvedWidgetUids.length > 0) {
-        await resolveUserEmailsViaAuthFallback(
-          unresolvedWidgetUids,
-          widgetUserEmails,
-          'widget drilldowns'
-        );
+        res.status(503).json({
+          error: 'not-yet-computed',
+          message:
+            'Analytics for this organization have not been computed yet. The next scheduled refresh runs at 5:00 AM Central daily.',
+          requestId,
+        });
+        return;
       }
 
-      const usersByType: Record<string, { count: number; emails: string[] }> =
-        {};
-      for (const [widgetType, uidSet] of Object.entries(widgetToUserUids)) {
-        usersByType[widgetType] = {
-          count: uidSet.size,
-          emails: Array.from(uidSet)
-            .slice(0, 20)
-            .map((uid) => widgetUserEmails[uid] ?? `Unknown (${uid})`)
-            .sort(),
-        };
-      }
-      // 5. Fetch AI Usage
-      let totalAiCalls = 0;
-      const callsPerUser: Record<string, number> = {};
-      const dailyCallCounts: Record<string, number> = {};
-      const aiCallsByFeature: Record<string, number> = {};
-
-      const GEMINI_SPECIFIC_FEATURES = [
-        'smart-poll',
-        'embed-mini-app',
-        'video-activity-audio-transcription',
-        'quiz',
-        'ocr',
-        'guided-learning',
-      ];
-
-      const aiUsageStream = db
-        .collection('ai_usage')
-        .select('count')
-        .stream() as unknown as AsyncIterable<admin.firestore.QueryDocumentSnapshot>;
-
-      for await (const usageDoc of aiUsageStream) {
-        if (!usageDoc.exists) continue;
-        const idParts = usageDoc.id.split('_');
-        if (idParts.length < 2) continue;
-
-        const datePart = idParts[idParts.length - 1];
-        const secondToLast = idParts[idParts.length - 2];
-        const isSpecificFeature =
-          GEMINI_SPECIFIC_FEATURES.includes(secondToLast);
-
-        // Exclude the feature ID and date to get the original UID
-        const uidParts = idParts.slice(0, isSpecificFeature ? -2 : -1);
-        const uid = uidParts.join('_');
-
-        if (!uid || !datePart) continue;
-
-        // Skip AI usage not attributed to a member of this org. Scope by the
-        // member roster rather than `authUsersMap` so auth lookup failures
-        // don't silently drop members' AI calls from the totals.
-        if (!memberUids.has(uid)) continue;
-
-        const usageData = usageDoc.data();
-        const count = typeof usageData.count === 'number' ? usageData.count : 0;
-
-        if (isSpecificFeature) {
-          aiCallsByFeature[secondToLast] =
-            (aiCallsByFeature[secondToLast] ?? 0) + count;
-        }
-
-        // ONLY count the "overall" records for total analytics to avoid double counting
-        // (Specific feature records are for enforcement, overall records track everything)
-        if (!isSpecificFeature) {
-          totalAiCalls += count;
-          callsPerUser[uid] = (callsPerUser[uid] ?? 0) + count;
-          dailyCallCounts[datePart] = (dailyCallCounts[datePart] ?? 0) + count;
-        }
-      }
-
-      const uniqueDays = Object.keys(dailyCallCounts).length || 1;
-      const avgDailyCalls = Math.round(totalAiCalls / uniqueDays);
-      const activeAiUsers = Object.keys(callsPerUser).length || 1;
-      const avgDailyCallsPerUser =
-        Math.round((avgDailyCalls / activeAiUsers) * 10) / 10;
-      const topUserUids = Object.entries(callsPerUser)
-        .sort(([, a], [, b]) => b - a)
-        .slice(0, 25)
-        .map(([uid]) => uid);
-      const topUserEmails: Record<string, string> = {};
-
-      const uidChunks: string[][] = [];
-      for (let i = 0; i < topUserUids.length; i += 10) {
-        uidChunks.push(topUserUids.slice(i, i + 10));
-      }
-
-      await Promise.all(
-        uidChunks.map(async (uidChunk) => {
-          if (uidChunk.length === 0) return;
-          const usersSnapshot = await db
-            .collection('users')
-            .where(admin.firestore.FieldPath.documentId(), 'in', uidChunk)
-            .select('email')
-            .get();
-
-          usersSnapshot.docs.forEach((doc) => {
-            const userData = doc.data();
-            if (
-              typeof userData.email === 'string' &&
-              userData.email.length > 0
-            ) {
-              topUserEmails[doc.id] = userData.email;
-            }
-          });
-        })
-      );
-      const unresolvedTopUserUids = topUserUids.filter(
-        (uid) => !topUserEmails[uid]
-      );
-      if (unresolvedTopUserUids.length > 0) {
-        await resolveUserEmailsViaAuthFallback(
-          unresolvedTopUserUids,
-          topUserEmails,
-          'AI top users'
-        );
-      }
-
-      const topUsers = Object.entries(callsPerUser)
-        .sort(([, a], [, b]) => b - a)
-        .slice(0, 25)
-        .map(([uid, count]) => ({
-          uid,
-          count,
-          email: topUserEmails[uid] ?? `Unknown (${uid})`,
-        }));
       res.json({
-        users: {
-          total: totalEngagement.total,
-          registered: totalRegisteredUsers,
-          registeredIsFallback,
-          monthly: totalEngagement.monthly,
-          daily: totalEngagement.daily,
-          withDashboards: allDashboardOwnerUids.size,
-          domains: usersByDomain,
-          buildings: usersByBuilding,
-          domainBuilding: usersByDomainAndBuilding,
-          userList,
-        },
-        widgets: {
-          totalInstances: totalWidgetCounts,
-          activeInstances: activeWidgetCounts,
-          usersByType,
-        },
-        dashboards: {
-          total: totalDashboards,
-          avgWidgetsPerDashboard:
-            totalDashboards > 0
-              ? Math.round((totalWidgetInstances / totalDashboards) * 10) / 10
-              : 0,
-        },
-        api: {
-          totalCalls: totalAiCalls,
-          activeUsers: Object.keys(callsPerUser).length,
-          topUsers,
-          avgDailyCalls,
-          avgDailyCallsPerUser,
-          byFeature: aiCallsByFeature,
+        ...snapshot.payload,
+        meta: {
+          computedAt: snapshot.computedAt,
+          nextRecomputeAt: snapshot.nextRecomputeAt,
+          computeDurationMs: snapshot.computeDurationMs,
         },
       });
     } catch (err: unknown) {
-      console.error('[getAdminAnalytics] Error fetching analytics', {
+      console.error('[getAdminAnalytics] Error reading snapshot', {
         requestId,
         orgId,
         error: err instanceof Error ? err.message : String(err),
@@ -2687,7 +2218,7 @@ export const adminAnalytics = onRequest(
       const errorMessage =
         err instanceof Error
           ? err.message
-          : 'An internal error occurred fetching analytics.';
+          : 'An internal error occurred reading analytics.';
       res
         .status(500)
         .json({ error: 'internal', message: errorMessage, requestId });


### PR DESCRIPTION
## Summary

- **Cost win**: `adminAnalytics` was the largest line on the Cloud Functions invoice (~$5/10 days). The two unbounded streaming reads (`collectionGroup('dashboards')` + `collection('ai_usage')`) are gone from the per-call path entirely. Hot-path memory drops from 4 GiB → 1 GiB, timeout from 540 s → 30 s.
- **New architecture**: A scheduled job (`recomputeAdminAnalytics`, 5 AM America/Chicago daily) runs the unbounded compute once per non-archived org and writes the payload to `/organizations/{orgId}/analytics/snapshot`. The HTTP handler reads that doc and returns it verbatim — total reads per admin page load: 3 (admin gate, member doc, snapshot).
- **UI**: Refresh button is gone. Replaced with a `Updated 4h ago · Next update at 5:00 AM` badge that surfaces the cached nature of the data. Per discussion: analytics are explicitly a luxury daily read; a manual recompute button would just defeat the cache.

## Layout

- `functions/src/adminAnalyticsCompute.ts` — pure compute helper, owns the unbounded reads.
- `functions/src/adminAnalyticsSnapshot.ts` — `onSchedule` recompute + `readAnalyticsSnapshot()`. Per-org failures don't abort the batch.
- `functions/src/index.ts` — `adminAnalytics` handler is now ~50 LOC (auth/authz + snapshot read), down from ~580 LOC inline.
- `firestore.rules` — new `match /organizations/{orgId}/analytics/{document}` block. Read: org admins. Write: nobody (Admin SDK bypasses).
- `components/admin/Analytics/AnalyticsManager.tsx` — propagates `meta` on the response, renders the freshness badge.
- `docs/CLOUD_FUNCTIONS_COST_OPTIMIZATION.md` — action item #1 marked done with date + summary.

## Cold-start contract

Brand-new orgs with no snapshot yet return **503 `not-yet-computed`** with a user-facing message ("Analytics will be ready after the next scheduled refresh at 5:00 AM Central"). The UI surfaces that message in the existing error banner.

## Deploy note

The first scheduler run fires at 5 AM Central the day after deploy. Until then, admins will see the cold-start message. To populate snapshots immediately after deploy, manually trigger \`recomputeAdminAnalytics\` from the GCP console (Cloud Scheduler → Run now).

## Test plan

- [x] \`pnpm run validate\` green (2301 root tests + 208 functions tests, lint, format, type-check all pass)
- [x] New unit tests in \`functions/src/index.test.ts\`:
  - \`adminAnalytics\` returns 503 on cold start (no snapshot)
  - \`adminAnalytics\` returns 200 + meta on cache hit; asserts no streaming reads happen
  - \`recomputeAdminAnalytics\` filters by status (skips \`archived\`, writes for \`active\` + \`trial\`)
  - \`recomputeAdminAnalytics\` survives a per-org compute failure and continues
- [x] Existing compute tests migrated to call \`computeAnalyticsForOrg\` directly — same assertions, no HTTP boilerplate.
- [ ] After deploy: manually trigger \`recomputeAdminAnalytics\` from GCP console; verify \`/organizations/orono/analytics/snapshot\` is written; reload admin analytics page and confirm the "Updated · Next update" badge renders with sensible times.

🤖 Generated with [Claude Code](https://claude.com/claude-code)