### PR TITLE
feat(library): preview pane + Duplicate polish (deferred from #1587)

### DIFF
--- a/components/common/library/LibraryItemCard.tsx
+++ b/components/common/library/LibraryItemCard.tsx
@@ -17,7 +17,13 @@
  * hint as the drag-handle tooltip at reduced opacity.
  */
 
-import React, { useContext, useLayoutEffect, useRef, useState } from 'react';
+import React, {
+  useContext,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from 'react';
 import { createPortal } from 'react-dom';
 import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
@@ -338,6 +344,7 @@ function CardBody<TMeta>(props: CardBodyProps<TMeta>) {
     iconActions,
     secondaryActions,
     onClick,
+    onDoubleClick,
     viewMode = 'grid',
     dragHandle,
     isDragOverlay,
@@ -351,6 +358,20 @@ function CardBody<TMeta>(props: CardBodyProps<TMeta>) {
   const SecondaryPrimaryIcon = secondaryPrimaryAction?.icon;
   const isList = viewMode === 'list';
 
+  // Single-click vs double-click coordination. The browser fires
+  // `onClick` AND `onDoubleClick` on a real dblclick; without a delay
+  // the preview pane would flash open before the editor lands. Standard
+  // pattern: start a 250ms timer on the first click and cancel it if a
+  // second click arrives within the window. Refs avoid the render
+  // churn of useState while still surviving across re-renders of the
+  // memoized card.
+  const clickTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(() => {
+    return () => {
+      if (clickTimerRef.current) clearTimeout(clickTimerRef.current);
+    };
+  }, []);
+
   const handleBodyClick = (e: React.MouseEvent<HTMLDivElement>) => {
     // Ignore bubbled events from buttons / links / menus inside the card.
     if ((e.target as HTMLElement).closest('button, a, [role="menu"]')) return;
@@ -358,12 +379,32 @@ function CardBody<TMeta>(props: CardBodyProps<TMeta>) {
       onSelectionToggle?.();
       return;
     }
-    onClick?.();
+    if (!onDoubleClick) {
+      // Legacy path — no double-click distinction wanted by the host.
+      onClick?.();
+      return;
+    }
+    if (clickTimerRef.current) {
+      // Second click arrived inside the detection window. Cancel the
+      // pending single-click and treat as a dblclick.
+      clearTimeout(clickTimerRef.current);
+      clickTimerRef.current = null;
+      onDoubleClick();
+      return;
+    }
+    clickTimerRef.current = setTimeout(() => {
+      clickTimerRef.current = null;
+      onClick?.();
+    }, 250);
   };
 
   return (
     <div
-      onClick={(onClick ?? selectionMode) ? handleBodyClick : undefined}
+      onClick={
+        (onClick ?? onDoubleClick ?? selectionMode)
+          ? handleBodyClick
+          : undefined
+      }
       className={[
         // `@container` makes the card itself the query target so the action
         // buttons can collapse their text labels at narrow widths via
@@ -373,7 +414,7 @@ function CardBody<TMeta>(props: CardBodyProps<TMeta>) {
           ? 'border-brand-blue-primary/60 bg-brand-blue-lighter/30 hover:bg-brand-blue-lighter/40 ring-2 ring-brand-blue-primary/30'
           : 'border-slate-200/80 bg-white/70 hover:bg-white/85',
         isList ? 'flex-row items-center' : 'flex-col',
-        (onClick ?? selectionMode) && 'cursor-pointer',
+        (onClick ?? onDoubleClick ?? selectionMode) && 'cursor-pointer',
         isDragging && 'opacity-50',
         isDragOverlay &&
           'pointer-events-none ring-2 ring-brand-blue-primary/30',

--- a/components/common/library/types.ts
+++ b/components/common/library/types.ts
@@ -268,8 +268,21 @@ export interface LibraryItemCardProps<TMeta = unknown> {
   iconActions?: LibraryIconAction[];
   /** Overflow-menu actions (Edit, Duplicate, Share, Delete...). */
   secondaryActions?: LibraryMenuAction[];
-  /** Default click handler for the card body. Typically opens the editor. */
+  /**
+   * Default click handler for the card body. Typically opens preview or
+   * editor depending on the host's `onDoubleClick` wiring (see below).
+   */
   onClick?: () => void;
+  /**
+   * Phase 5 follow-up — when provided, the card distinguishes single
+   * vs double click on the body via a 250ms delay-and-cancel timer:
+   * a double-click fires `onDoubleClick` immediately and suppresses
+   * the pending single-click. Use this when single-click should open
+   * a preview pane and double-click should open the editor. Omitting
+   * it preserves the legacy "single-click runs onClick immediately"
+   * behavior.
+   */
+  onDoubleClick?: () => void;
   /** Default true. Disabled via `LibraryGrid.dragDisabled` for read-only views. */
   sortable?: boolean;
   /** Passthrough for consumer — typed via the generic. */

--- a/components/widgets/GuidedLearning/Widget.tsx
+++ b/components/widgets/GuidedLearning/Widget.tsx
@@ -81,6 +81,7 @@ export const GuidedLearningWidget: React.FC<{ widget: WidgetData }> = ({
     duplicateSet,
     saveBuildingSet,
     deleteBuildingSet,
+    duplicateBuildingSet,
   } = useGuidedLearning(user?.uid);
 
   const { createSession } = useGuidedLearningSessionTeacher(user?.uid);
@@ -108,6 +109,10 @@ export const GuidedLearningWidget: React.FC<{ widget: WidgetData }> = ({
   const [showAIGen, setShowAIGen] = useState(false);
   // In-flight Duplicate kebab guard — see QuizWidget for the rationale.
   const [duplicatingSetIds, setDuplicatingSetIds] = useState<
+    ReadonlySet<string>
+  >(() => new Set());
+  // Same guard for building-set duplicates (admin-only).
+  const [duplicatingBuildingSetIds, setDuplicatingBuildingSetIds] = useState<
     ReadonlySet<string>
   >(() => new Set());
   const [recentSessionIds, setRecentSessionIds] = useState<
@@ -674,6 +679,38 @@ export const GuidedLearningWidget: React.FC<{ widget: WidgetData }> = ({
                   }
                 }}
                 isDuplicatingPersonal={(setId) => duplicatingSetIds.has(setId)}
+                onDuplicateBuilding={async (setId) => {
+                  if (duplicatingBuildingSetIds.has(setId)) return;
+                  const source = buildingSets.find((s) => s.id === setId);
+                  if (!source) return;
+                  setDuplicatingBuildingSetIds((prev) => {
+                    const next = new Set(prev);
+                    next.add(setId);
+                    return next;
+                  });
+                  try {
+                    const copy = await duplicateBuildingSet(source);
+                    addToast(
+                      `Duplicated building set as "${copy.title}".`,
+                      'success'
+                    );
+                  } catch (err) {
+                    addToast(
+                      err instanceof Error ? err.message : 'Duplicate failed',
+                      'error'
+                    );
+                  } finally {
+                    setDuplicatingBuildingSetIds((prev) => {
+                      if (!prev.has(setId)) return prev;
+                      const next = new Set(prev);
+                      next.delete(setId);
+                      return next;
+                    });
+                  }
+                }}
+                isDuplicatingBuilding={(setId) =>
+                  duplicatingBuildingSetIds.has(setId)
+                }
                 onDeleteBuilding={(setId) => {
                   void handleDeleteBuilding(setId);
                 }}

--- a/components/widgets/GuidedLearning/Widget.tsx
+++ b/components/widgets/GuidedLearning/Widget.tsx
@@ -106,6 +106,10 @@ export const GuidedLearningWidget: React.FC<{ widget: WidgetData }> = ({
     'guided_learning'
   );
   const [showAIGen, setShowAIGen] = useState(false);
+  // In-flight Duplicate kebab guard — see QuizWidget for the rationale.
+  const [duplicatingSetIds, setDuplicatingSetIds] = useState<
+    ReadonlySet<string>
+  >(() => new Set());
   const [recentSessionIds, setRecentSessionIds] = useState<
     Record<string, string>
   >({});
@@ -644,8 +648,14 @@ export const GuidedLearningWidget: React.FC<{ widget: WidgetData }> = ({
                   // (mirrors onDeletePersonal) but we don't need it —
                   // `duplicateSet` reads driveFileId off the resolved
                   // source metadata.
+                  if (duplicatingSetIds.has(setId)) return;
                   const source = sets.find((s) => s.id === setId);
                   if (!source) return;
+                  setDuplicatingSetIds((prev) => {
+                    const next = new Set(prev);
+                    next.add(setId);
+                    return next;
+                  });
                   try {
                     const copy = await duplicateSet(source);
                     addToast(`Duplicated as "${copy.title}".`, 'success');
@@ -654,8 +664,16 @@ export const GuidedLearningWidget: React.FC<{ widget: WidgetData }> = ({
                       err instanceof Error ? err.message : 'Duplicate failed',
                       'error'
                     );
+                  } finally {
+                    setDuplicatingSetIds((prev) => {
+                      if (!prev.has(setId)) return prev;
+                      const next = new Set(prev);
+                      next.delete(setId);
+                      return next;
+                    });
                   }
                 }}
+                isDuplicatingPersonal={(setId) => duplicatingSetIds.has(setId)}
                 onDeleteBuilding={(setId) => {
                   void handleDeleteBuilding(setId);
                 }}

--- a/components/widgets/GuidedLearning/Widget.tsx
+++ b/components/widgets/GuidedLearning/Widget.tsx
@@ -16,6 +16,7 @@ import { useGuidedLearning } from '@/hooks/useGuidedLearning';
 import { useGuidedLearningSessionTeacher } from '@/hooks/useGuidedLearningSession';
 import { useGuidedLearningAssignments } from '@/hooks/useGuidedLearningAssignments';
 import { useFolders } from '@/hooks/useFolders';
+import { useBusyIdSet } from '@/hooks/useBusyIdSet';
 import { WidgetLayout } from '@/components/widgets/WidgetLayout';
 import { AssignModal, ViewOnlyShareModal } from '@/components/common/library';
 import { AssignClassPicker } from '@/components/common/AssignClassPicker';
@@ -107,14 +108,10 @@ export const GuidedLearningWidget: React.FC<{ widget: WidgetData }> = ({
     'guided_learning'
   );
   const [showAIGen, setShowAIGen] = useState(false);
-  // In-flight Duplicate kebab guard — see QuizWidget for the rationale.
-  const [duplicatingSetIds, setDuplicatingSetIds] = useState<
-    ReadonlySet<string>
-  >(() => new Set());
-  // Same guard for building-set duplicates (admin-only).
-  const [duplicatingBuildingSetIds, setDuplicatingBuildingSetIds] = useState<
-    ReadonlySet<string>
-  >(() => new Set());
+  // Shared rapid-click guards (personal sets + admin building sets).
+  // See `hooks/useBusyIdSet.ts`.
+  const personalDuplicateBusy = useBusyIdSet();
+  const buildingDuplicateBusy = useBusyIdSet();
   const [recentSessionIds, setRecentSessionIds] = useState<
     Record<string, string>
   >({});
@@ -648,69 +645,45 @@ export const GuidedLearningWidget: React.FC<{ widget: WidgetData }> = ({
                 onDeletePersonal={(setId, driveFileId) => {
                   void handleDelete(setId, driveFileId);
                 }}
-                onDuplicatePersonal={async (setId, _driveFileId) => {
+                onDuplicatePersonal={(setId, _driveFileId) => {
                   // `_driveFileId` is part of the manager's signature
                   // (mirrors onDeletePersonal) but we don't need it —
                   // `duplicateSet` reads driveFileId off the resolved
                   // source metadata.
-                  if (duplicatingSetIds.has(setId)) return;
                   const source = sets.find((s) => s.id === setId);
                   if (!source) return;
-                  setDuplicatingSetIds((prev) => {
-                    const next = new Set(prev);
-                    next.add(setId);
-                    return next;
+                  void personalDuplicateBusy.run(setId, async () => {
+                    try {
+                      const copy = await duplicateSet(source);
+                      addToast(`Duplicated as "${copy.title}".`, 'success');
+                    } catch (err) {
+                      addToast(
+                        err instanceof Error ? err.message : 'Duplicate failed',
+                        'error'
+                      );
+                    }
                   });
-                  try {
-                    const copy = await duplicateSet(source);
-                    addToast(`Duplicated as "${copy.title}".`, 'success');
-                  } catch (err) {
-                    addToast(
-                      err instanceof Error ? err.message : 'Duplicate failed',
-                      'error'
-                    );
-                  } finally {
-                    setDuplicatingSetIds((prev) => {
-                      if (!prev.has(setId)) return prev;
-                      const next = new Set(prev);
-                      next.delete(setId);
-                      return next;
-                    });
-                  }
                 }}
-                isDuplicatingPersonal={(setId) => duplicatingSetIds.has(setId)}
-                onDuplicateBuilding={async (setId) => {
-                  if (duplicatingBuildingSetIds.has(setId)) return;
+                isDuplicatingPersonal={personalDuplicateBusy.isBusy}
+                onDuplicateBuilding={(setId) => {
                   const source = buildingSets.find((s) => s.id === setId);
                   if (!source) return;
-                  setDuplicatingBuildingSetIds((prev) => {
-                    const next = new Set(prev);
-                    next.add(setId);
-                    return next;
+                  void buildingDuplicateBusy.run(setId, async () => {
+                    try {
+                      const copy = await duplicateBuildingSet(source);
+                      addToast(
+                        `Duplicated building set as "${copy.title}".`,
+                        'success'
+                      );
+                    } catch (err) {
+                      addToast(
+                        err instanceof Error ? err.message : 'Duplicate failed',
+                        'error'
+                      );
+                    }
                   });
-                  try {
-                    const copy = await duplicateBuildingSet(source);
-                    addToast(
-                      `Duplicated building set as "${copy.title}".`,
-                      'success'
-                    );
-                  } catch (err) {
-                    addToast(
-                      err instanceof Error ? err.message : 'Duplicate failed',
-                      'error'
-                    );
-                  } finally {
-                    setDuplicatingBuildingSetIds((prev) => {
-                      if (!prev.has(setId)) return prev;
-                      const next = new Set(prev);
-                      next.delete(setId);
-                      return next;
-                    });
-                  }
                 }}
-                isDuplicatingBuilding={(setId) =>
-                  duplicatingBuildingSetIds.has(setId)
-                }
+                isDuplicatingBuilding={buildingDuplicateBusy.isBusy}
                 onDeleteBuilding={(setId) => {
                   void handleDeleteBuilding(setId);
                 }}

--- a/components/widgets/GuidedLearning/components/GuidedLearningManager.tsx
+++ b/components/widgets/GuidedLearning/components/GuidedLearningManager.tsx
@@ -153,6 +153,16 @@ export interface GuidedLearningManagerProps {
    * whose duplicate is currently in-flight.
    */
   isDuplicatingPersonal?: (setId: string) => boolean;
+  /**
+   * Phase 5 follow-up — admin-only Duplicate kebab item on building
+   * sets. Sibling of `onDuplicatePersonal`. Building sets live in the
+   * `building_guided_learning` collection; the hook's
+   * `duplicateBuildingSet` owns the actual write. When omitted (or
+   * when the current user is not admin), the entry is hidden.
+   */
+  onDuplicateBuilding?: (setId: string) => void | Promise<void>;
+  /** Busy-state probe for the building-set Duplicate kebab. */
+  isDuplicatingBuilding?: (setId: string) => boolean;
   onDeleteBuilding: (setId: string) => void | Promise<void>;
   onCreateNewPersonal: () => void;
   onCreateNewBuilding: () => void;
@@ -332,6 +342,8 @@ export const GuidedLearningManager: React.FC<GuidedLearningManagerProps> = ({
   onDeletePersonal,
   onDuplicatePersonal,
   isDuplicatingPersonal,
+  onDuplicateBuilding,
+  isDuplicatingBuilding,
   onDeleteBuilding,
   onCreateNewPersonal,
   onCreateNewBuilding,
@@ -652,10 +664,8 @@ export const GuidedLearningManager: React.FC<GuidedLearningManagerProps> = ({
     }
 
     if (entry.source === 'personal') {
-      // Phase 5 — Duplicate only for personal sets (building sets are
-      // admin-authored and not part of the teacher library duplicate
-      // flow). Stacked between Edit/Results and Move/Delete so the
-      // destructive action stays last.
+      // Phase 5 — Duplicate. Stacked between Edit/Results and Move/Delete
+      // so the destructive action stays last.
       if (onDuplicatePersonal && entry.driveFileId) {
         const fileId = entry.driveFileId;
         secondary.push(
@@ -679,6 +689,20 @@ export const GuidedLearningManager: React.FC<GuidedLearningManagerProps> = ({
             }),
           disabled: !userId,
         })
+      );
+    } else if (entry.source === 'building' && isAdmin && onDuplicateBuilding) {
+      // Admin-only Duplicate for building sets. Mirrors the personal
+      // entry's Duplicate; building sets have no folder concept so the
+      // Move-to-folder action is skipped.
+      secondary.push(
+        buildDuplicateAction(
+          { id: rawId, title: entry.title },
+          () => void onDuplicateBuilding(rawId),
+          {
+            disabled: isDuplicatingBuilding?.(rawId),
+            disabledReason: 'Duplicating…',
+          }
+        )
       );
     }
 

--- a/components/widgets/GuidedLearning/components/GuidedLearningManager.tsx
+++ b/components/widgets/GuidedLearning/components/GuidedLearningManager.tsx
@@ -369,8 +369,12 @@ export const GuidedLearningManager: React.FC<GuidedLearningManagerProps> = ({
   const selection = useLibrarySelection();
   const [selectionMode, setSelectionMode] = React.useState(false);
   const [bulkBusy, setBulkBusy] = React.useState(false);
-  // Phase 5 follow-up — preview pane state (see QuizManager).
-  const [previewEntry, setPreviewEntry] = React.useState<LibraryEntry | null>(
+  // Phase 5 follow-up — preview pane state. Stores the entry's
+  // composite id (`personal:abc` / `building:xyz`); the live entry is
+  // derived from `reorder.orderedItems` at render time so the pane
+  // tracks Firestore updates and auto-closes on deletion (subagent
+  // review flag on PR #1588).
+  const [previewEntryId, setPreviewEntryId] = React.useState<string | null>(
     null
   );
   const [prevTab, setPrevTab] = React.useState(tab);
@@ -771,7 +775,7 @@ export const GuidedLearningManager: React.FC<GuidedLearningManagerProps> = ({
         // click opens the editor (when the user can edit; for read-only
         // building cards seen by non-admins, single-click still opens
         // preview but double-click is a no-op).
-        onClick={() => setPreviewEntry(entry)}
+        onClick={() => setPreviewEntryId(entry.id)}
         onDoubleClick={
           canEdit
             ? () => onEdit(rawId, entry.driveFileId, entry.buildingSet)
@@ -1006,22 +1010,29 @@ export const GuidedLearningManager: React.FC<GuidedLearningManagerProps> = ({
             }
           />
         </div>
-        {previewEntry && (
-          <GuidedLearningPreviewPane
-            entry={previewEntry}
-            onClose={() => setPreviewEntry(null)}
-            onEdit={(e) => {
-              const target = e;
-              setPreviewEntry(null);
-              const id =
-                target.source === 'personal'
-                  ? target.id.slice('personal:'.length)
-                  : target.id.slice('building:'.length);
-              onEdit(id, target.driveFileId, target.buildingSet);
-            }}
-            canEdit={previewEntry.source === 'building' ? isAdmin : true}
-          />
-        )}
+        {(() => {
+          const livePreviewEntry = previewEntryId
+            ? (reorder.orderedItems.find((e) => e.id === previewEntryId) ??
+              null)
+            : null;
+          if (!livePreviewEntry) return null;
+          return (
+            <GuidedLearningPreviewPane
+              entry={livePreviewEntry}
+              onClose={() => setPreviewEntryId(null)}
+              onEdit={(e) => {
+                const target = e;
+                setPreviewEntryId(null);
+                const id =
+                  target.source === 'personal'
+                    ? target.id.slice('personal:'.length)
+                    : target.id.slice('building:'.length);
+                onEdit(id, target.driveFileId, target.buildingSet);
+              }}
+              canEdit={livePreviewEntry.source === 'building' ? isAdmin : true}
+            />
+          );
+        })()}
       </div>
     );
   };

--- a/components/widgets/GuidedLearning/components/GuidedLearningManager.tsx
+++ b/components/widgets/GuidedLearning/components/GuidedLearningManager.tsx
@@ -57,6 +57,7 @@ import { useLibraryView } from '@/components/common/library/useLibraryView';
 import { useLibrarySelection } from '@/components/common/library/useLibrarySelection';
 import { useSortableReorder } from '@/components/common/library/useSortableReorder';
 import { BulkActionBar } from '@/components/common/library/BulkActionBar';
+import { LibraryPreviewPane } from '@/components/common/library/LibraryPreviewPane';
 import {
   countItemsByFolder,
   filterSourcedEntriesByFolder,
@@ -368,6 +369,10 @@ export const GuidedLearningManager: React.FC<GuidedLearningManagerProps> = ({
   const selection = useLibrarySelection();
   const [selectionMode, setSelectionMode] = React.useState(false);
   const [bulkBusy, setBulkBusy] = React.useState(false);
+  // Phase 5 follow-up — preview pane state (see QuizManager).
+  const [previewEntry, setPreviewEntry] = React.useState<LibraryEntry | null>(
+    null
+  );
   const [prevTab, setPrevTab] = React.useState(tab);
   if (prevTab !== tab) {
     setPrevTab(tab);
@@ -762,7 +767,12 @@ export const GuidedLearningManager: React.FC<GuidedLearningManagerProps> = ({
           onClick: () => onAssign(rawId, entry.driveFileId, entry.buildingSet),
         }}
         secondaryActions={secondary}
-        onClick={
+        // Phase 5 follow-up — single-click opens preview pane, double-
+        // click opens the editor (when the user can edit; for read-only
+        // building cards seen by non-admins, single-click still opens
+        // preview but double-click is a no-op).
+        onClick={() => setPreviewEntry(entry)}
+        onDoubleClick={
           canEdit
             ? () => onEdit(rawId, entry.driveFileId, entry.buildingSet)
             : undefined
@@ -943,57 +953,76 @@ export const GuidedLearningManager: React.FC<GuidedLearningManagerProps> = ({
     }
 
     return (
-      <>
-        {showDriveBanner && (
-          <div className="mb-3 rounded-xl border border-amber-200 bg-amber-50 px-3 py-2 text-xs font-medium text-amber-800">
-            Your personal sets are saved to Google Drive. Sign out and sign back
-            in to grant Drive access. Building sets are still available below.
-          </div>
-        )}
+      <div className="flex h-full min-h-0 gap-3">
+        <div className="flex-1 min-w-0 flex flex-col">
+          {showDriveBanner && (
+            <div className="mb-3 rounded-xl border border-amber-200 bg-amber-50 px-3 py-2 text-xs font-medium text-amber-800">
+              Your personal sets are saved to Google Drive. Sign out and sign
+              back in to grant Drive access. Building sets are still available
+              below.
+            </div>
+          )}
 
-        {selectionMode && selection.count > 0 && (
-          <div className="mb-3">
-            <BulkActionBar
-              count={selection.count}
-              onClear={() => {
-                selection.clear();
-                setSelectionMode(false);
-              }}
-              folders={folderState.folders}
-              onMove={handleBulkMove}
-              onDelete={handleBulkDelete}
-              busy={bulkBusy}
-            />
-          </div>
-        )}
+          {selectionMode && selection.count > 0 && (
+            <div className="mb-3">
+              <BulkActionBar
+                count={selection.count}
+                onClear={() => {
+                  selection.clear();
+                  setSelectionMode(false);
+                }}
+                folders={folderState.folders}
+                onMove={handleBulkMove}
+                onDelete={handleBulkDelete}
+                busy={bulkBusy}
+              />
+            </div>
+          )}
 
-        <LibraryGrid<LibraryEntry>
-          items={reorder.orderedItems}
-          getId={(e) => e.id}
-          renderCard={renderLibraryCard}
-          onReorder={handleReorderDrop}
-          dragDisabled={!enableCardDrag}
-          reorderLocked={reorderDragActive ? view.reorderLocked : false}
-          reorderLockedReason={
-            reorderDragActive ? view.reorderLockedReason : undefined
-          }
-          layout={view.state.viewMode}
-          useExternalDndContext={Boolean(userId)}
-          emptyState={
-            <ScaledEmptyState
-              icon={BookOpen}
-              title="No sets yet"
-              subtitle={
-                isBuildingFiltered
-                  ? isAdmin
-                    ? 'Use "New Building Set" or "AI" to add a building-level experience.'
-                    : 'No building sets have been created yet.'
-                  : 'Click "New Set" to create your first guided experience.'
-              }
-            />
-          }
-        />
-      </>
+          <LibraryGrid<LibraryEntry>
+            items={reorder.orderedItems}
+            getId={(e) => e.id}
+            renderCard={renderLibraryCard}
+            onReorder={handleReorderDrop}
+            dragDisabled={!enableCardDrag}
+            reorderLocked={reorderDragActive ? view.reorderLocked : false}
+            reorderLockedReason={
+              reorderDragActive ? view.reorderLockedReason : undefined
+            }
+            layout={view.state.viewMode}
+            useExternalDndContext={Boolean(userId)}
+            emptyState={
+              <ScaledEmptyState
+                icon={BookOpen}
+                title="No sets yet"
+                subtitle={
+                  isBuildingFiltered
+                    ? isAdmin
+                      ? 'Use "New Building Set" or "AI" to add a building-level experience.'
+                      : 'No building sets have been created yet.'
+                    : 'Click "New Set" to create your first guided experience.'
+                }
+              />
+            }
+          />
+        </div>
+        {previewEntry && (
+          <GuidedLearningPreviewPane
+            entry={previewEntry}
+            onClose={() => setPreviewEntry(null)}
+            onEdit={(e) => {
+              const target = e;
+              setPreviewEntry(null);
+              const id =
+                target.source === 'personal'
+                  ? target.id.slice('personal:'.length)
+                  : target.id.slice('building:'.length);
+              onEdit(id, target.driveFileId, target.buildingSet);
+            }}
+            canEdit={previewEntry.source === 'building' ? isAdmin : true}
+          />
+        )}
+      </div>
     );
   };
 
@@ -1192,5 +1221,66 @@ export const GuidedLearningManager: React.FC<GuidedLearningManagerProps> = ({
       {shell}
       {folderPickerDialog}
     </>
+  );
+};
+
+/**
+ * Preview pane content for the GuidedLearningManager. Renders the
+ * first image (when present) and a step-count summary — matches the
+ * spec's "first image + step hotspots" intent at a lightweight level
+ * without requiring a full Drive load of the set's steps.
+ */
+const GuidedLearningPreviewPane: React.FC<{
+  entry: LibraryEntry;
+  onClose: () => void;
+  onEdit: (entry: LibraryEntry) => void;
+  canEdit: boolean;
+}> = ({ entry, onClose, onEdit, canEdit }) => {
+  return (
+    <LibraryPreviewPane
+      isOpen={true}
+      onClose={onClose}
+      title={entry.title}
+      subtitle={
+        <>
+          {entry.stepCount} {entry.stepCount === 1 ? 'step' : 'steps'}
+          {' · '}
+          {entry.source === 'personal' ? 'Personal' : 'Building'}
+        </>
+      }
+      primaryAction={
+        canEdit
+          ? {
+              label: 'Open editor',
+              icon: Pencil,
+              onClick: () => onEdit(entry),
+            }
+          : undefined
+      }
+    >
+      <div className="flex flex-col gap-3 text-sm text-slate-700">
+        {entry.imageUrl ? (
+          <img
+            src={entry.imageUrl}
+            alt=""
+            className="w-full rounded-lg border border-slate-200 bg-slate-100 object-cover"
+            loading="lazy"
+          />
+        ) : (
+          <div className="flex aspect-video items-center justify-center rounded-lg border border-dashed border-slate-300 bg-slate-50 text-xs text-slate-400">
+            No preview image
+          </div>
+        )}
+        {entry.description && (
+          <p className="text-xs leading-relaxed text-slate-600">
+            {entry.description}
+          </p>
+        )}
+        <div className="text-xxs text-slate-500">
+          Mode:{' '}
+          <span className="font-semibold text-slate-700">{entry.mode}</span>
+        </div>
+      </div>
+    </LibraryPreviewPane>
   );
 };

--- a/components/widgets/GuidedLearning/components/GuidedLearningManager.tsx
+++ b/components/widgets/GuidedLearning/components/GuidedLearningManager.tsx
@@ -147,6 +147,12 @@ export interface GuidedLearningManagerProps {
     setId: string,
     driveFileId: string
   ) => void | Promise<void>;
+  /**
+   * Optional busy-state probe for the Duplicate kebab. Mirrors the
+   * Quiz/VA/MiniApp managers — disables the kebab item for any set id
+   * whose duplicate is currently in-flight.
+   */
+  isDuplicatingPersonal?: (setId: string) => boolean;
   onDeleteBuilding: (setId: string) => void | Promise<void>;
   onCreateNewPersonal: () => void;
   onCreateNewBuilding: () => void;
@@ -325,6 +331,7 @@ export const GuidedLearningManager: React.FC<GuidedLearningManagerProps> = ({
   onAssign,
   onDeletePersonal,
   onDuplicatePersonal,
+  isDuplicatingPersonal,
   onDeleteBuilding,
   onCreateNewPersonal,
   onCreateNewBuilding,
@@ -654,7 +661,11 @@ export const GuidedLearningManager: React.FC<GuidedLearningManagerProps> = ({
         secondary.push(
           buildDuplicateAction(
             { id: rawId, title: entry.title },
-            () => void onDuplicatePersonal(rawId, fileId)
+            () => void onDuplicatePersonal(rawId, fileId),
+            {
+              disabled: isDuplicatingPersonal?.(rawId),
+              disabledReason: 'Duplicating…',
+            }
           )
         );
       }

--- a/components/widgets/MiniApp/Widget.tsx
+++ b/components/widgets/MiniApp/Widget.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useRef, useEffect, useCallback } from 'react';
 import { createPortal } from 'react-dom';
 import { useDashboard } from '@/context/useDashboard';
+import { useBusyIdSet } from '@/hooks/useBusyIdSet';
 import {
   AssignmentMode,
   MiniAppItem,
@@ -308,10 +309,8 @@ export const MiniAppWidget: React.FC<WidgetComponentProps> = ({
   const [managerTab, setManagerTab] = useState<LibraryTab>('library');
   const [savingGlobalId, setSavingGlobalId] = useState<string | null>(null);
   const [showImportWizard, setShowImportWizard] = useState(false);
-  // In-flight Duplicate kebab guard — see QuizWidget for the rationale.
-  const [duplicatingAppIds, setDuplicatingAppIds] = useState<
-    ReadonlySet<string>
-  >(() => new Set());
+  // Shared rapid-click guard. See `hooks/useBusyIdSet.ts`.
+  const duplicateBusy = useBusyIdSet();
 
   // Per-teacher MiniApp assignment archive — populates the In Progress /
   // Archive tabs. Lives in `/users/{uid}/miniapp_assignments/`.
@@ -762,45 +761,34 @@ export const MiniAppWidget: React.FC<WidgetComponentProps> = ({
    * `handleCreate` uses, so the duplicate appears at the top of the
    * personal library where the teacher just acted.
    */
-  const handleDuplicate = async (app: MiniAppItem) => {
+  const handleDuplicate = (app: MiniAppItem) => {
     if (!user) return;
-    if (duplicatingAppIds.has(app.id)) return;
-    setDuplicatingAppIds((prev) => {
-      const next = new Set(prev);
-      next.add(app.id);
-      return next;
+    void duplicateBusy.run(app.id, async () => {
+      try {
+        const copy: MiniAppItem = {
+          ...app,
+          id: crypto.randomUUID(),
+          title: suggestDuplicateTitle(app.title),
+          createdAt: Date.now(),
+          order:
+            library.length > 0
+              ? library.reduce((min, a) => Math.min(min, a.order ?? 0), 0) - 1
+              : 0,
+        };
+        const appsRef = collection(db, 'users', user.uid, 'miniapps');
+        await setDoc(doc(appsRef, copy.id), copy);
+        addToast(`Duplicated as "${copy.title}".`, 'success');
+      } catch (err) {
+        logError('MiniAppWidget.handleDuplicate', err, {
+          userId: user.uid,
+          sourceAppId: app.id,
+        });
+        addToast(
+          err instanceof Error ? err.message : 'Duplicate failed',
+          'error'
+        );
+      }
     });
-    try {
-      const copy: MiniAppItem = {
-        ...app,
-        id: crypto.randomUUID(),
-        title: suggestDuplicateTitle(app.title),
-        createdAt: Date.now(),
-        order:
-          library.length > 0
-            ? library.reduce((min, a) => Math.min(min, a.order ?? 0), 0) - 1
-            : 0,
-      };
-      const appsRef = collection(db, 'users', user.uid, 'miniapps');
-      await setDoc(doc(appsRef, copy.id), copy);
-      addToast(`Duplicated as "${copy.title}".`, 'success');
-    } catch (err) {
-      logError('MiniAppWidget.handleDuplicate', err, {
-        userId: user.uid,
-        sourceAppId: app.id,
-      });
-      addToast(
-        err instanceof Error ? err.message : 'Duplicate failed',
-        'error'
-      );
-    } finally {
-      setDuplicatingAppIds((prev) => {
-        if (!prev.has(app.id)) return prev;
-        const next = new Set(prev);
-        next.delete(app.id);
-        return next;
-      });
-    }
   };
 
   const saveMiniApp = async (updated: MiniAppItem) => {
@@ -1340,7 +1328,7 @@ export const MiniAppWidget: React.FC<WidgetComponentProps> = ({
               onEdit={handleEdit}
               onDelete={(app) => void handleDelete(app.id)}
               onDuplicate={(app) => void handleDuplicate(app)}
-              isDuplicating={(appId) => duplicatingAppIds.has(appId)}
+              isDuplicating={duplicateBusy.isBusy}
               onRun={handleRun}
               onAssign={handleOpenAssign}
               onShowAssignments={handleOpenAssignments}

--- a/components/widgets/MiniApp/Widget.tsx
+++ b/components/widgets/MiniApp/Widget.tsx
@@ -308,6 +308,10 @@ export const MiniAppWidget: React.FC<WidgetComponentProps> = ({
   const [managerTab, setManagerTab] = useState<LibraryTab>('library');
   const [savingGlobalId, setSavingGlobalId] = useState<string | null>(null);
   const [showImportWizard, setShowImportWizard] = useState(false);
+  // In-flight Duplicate kebab guard — see QuizWidget for the rationale.
+  const [duplicatingAppIds, setDuplicatingAppIds] = useState<
+    ReadonlySet<string>
+  >(() => new Set());
 
   // Per-teacher MiniApp assignment archive — populates the In Progress /
   // Archive tabs. Lives in `/users/{uid}/miniapp_assignments/`.
@@ -760,6 +764,12 @@ export const MiniAppWidget: React.FC<WidgetComponentProps> = ({
    */
   const handleDuplicate = async (app: MiniAppItem) => {
     if (!user) return;
+    if (duplicatingAppIds.has(app.id)) return;
+    setDuplicatingAppIds((prev) => {
+      const next = new Set(prev);
+      next.add(app.id);
+      return next;
+    });
     try {
       const copy: MiniAppItem = {
         ...app,
@@ -783,6 +793,13 @@ export const MiniAppWidget: React.FC<WidgetComponentProps> = ({
         err instanceof Error ? err.message : 'Duplicate failed',
         'error'
       );
+    } finally {
+      setDuplicatingAppIds((prev) => {
+        if (!prev.has(app.id)) return prev;
+        const next = new Set(prev);
+        next.delete(app.id);
+        return next;
+      });
     }
   };
 
@@ -1323,6 +1340,7 @@ export const MiniAppWidget: React.FC<WidgetComponentProps> = ({
               onEdit={handleEdit}
               onDelete={(app) => void handleDelete(app.id)}
               onDuplicate={(app) => void handleDuplicate(app)}
+              isDuplicating={(appId) => duplicatingAppIds.has(appId)}
               onRun={handleRun}
               onAssign={handleOpenAssign}
               onShowAssignments={handleOpenAssignments}

--- a/components/widgets/MiniApp/components/MiniAppManager.tsx
+++ b/components/widgets/MiniApp/components/MiniAppManager.tsx
@@ -323,10 +323,15 @@ export const MiniAppManager: React.FC<MiniAppManagerProps> = ({
   const selection = useLibrarySelection();
   const [selectionMode, setSelectionMode] = useState(false);
   const [bulkBusy, setBulkBusy] = useState(false);
-  // Phase 5 follow-up — preview pane state (see QuizManager).
-  // Holds the row, not just the item, so the pane can render different
-  // chrome for personal vs global apps.
-  const [previewRow, setPreviewRow] = useState<UnifiedRow | null>(null);
+  // Phase 5 follow-up — preview pane state. Stores the row's composite
+  // id (e.g. `personal:abc`/`global:xyz`); deriving the live row from
+  // the current `view.visibleItems` on every render means the pane
+  // always shows the latest Firestore snapshot and auto-closes when an
+  // admin republishes a global app or a teacher's library shifts the
+  // row away (subagent review flag on PR #1588: the previous
+  // object-pinned state could have routed "Save to my library" against
+  // the stale HTML of a republished global app).
+  const [previewRowId, setPreviewRowId] = useState<string | null>(null);
   const [prevTab, setPrevTab] = useState(tab);
   if (prevTab !== tab) {
     setPrevTab(tab);
@@ -693,7 +698,7 @@ export const MiniAppManager: React.FC<MiniAppManagerProps> = ({
         secondaryActions={secondary}
         // Phase 5 follow-up — single-click opens preview pane,
         // double-click opens editor.
-        onClick={() => setPreviewRow(row)}
+        onClick={() => setPreviewRowId(getRowId(row))}
         onDoubleClick={() => onEdit(app)}
         sortable={!selectionMode}
         viewMode={view.state.viewMode}
@@ -788,7 +793,7 @@ export const MiniAppManager: React.FC<MiniAppManagerProps> = ({
         // before clicking "Save to my library"); no double-click for
         // editor because there is no editor for global apps from this
         // surface.
-        onClick={() => setPreviewRow(row)}
+        onClick={() => setPreviewRowId(getRowId(row))}
         sortable={false}
         viewMode={view.state.viewMode}
       />
@@ -1068,16 +1073,23 @@ export const MiniAppManager: React.FC<MiniAppManagerProps> = ({
             emptyState={empty}
           />
         </div>
-        {previewRow && (
-          <MiniAppPreviewPane
-            row={previewRow}
-            onClose={() => setPreviewRow(null)}
-            onEdit={onEdit}
-            onSaveGlobalToLibrary={onSaveGlobalToLibrary}
-            savingGlobalId={savingGlobalId}
-            isViewOnly={isViewOnly}
-          />
-        )}
+        {(() => {
+          const livePreviewRow = previewRowId
+            ? (view.visibleItems.find((r) => getRowId(r) === previewRowId) ??
+              null)
+            : null;
+          if (!livePreviewRow) return null;
+          return (
+            <MiniAppPreviewPane
+              row={livePreviewRow}
+              onClose={() => setPreviewRowId(null)}
+              onEdit={onEdit}
+              onSaveGlobalToLibrary={onSaveGlobalToLibrary}
+              savingGlobalId={savingGlobalId}
+              isViewOnly={isViewOnly}
+            />
+          );
+        })()}
       </div>
     );
   }
@@ -1228,11 +1240,24 @@ export const MiniAppManager: React.FC<MiniAppManagerProps> = ({
 /**
  * Preview pane content for the MiniAppManager. Renders the app's HTML
  * inside a sandboxed iframe so the teacher can see what the app looks
- * like before opening the editor. The iframe `sandbox` attribute
- * isolates the app from the host (no parent access, no top-level
- * navigation), and `allow-scripts` is the only capability granted —
- * matches the runtime player's sandbox shape so the preview is a
- * faithful glance at what students will see.
+ * like before opening the editor.
+ *
+ * Security note — the preview sandbox is DELIBERATELY tighter than the
+ * runtime player's:
+ *
+ *   preview:  sandbox="allow-scripts"
+ *   runtime:  sandbox="allow-scripts allow-forms allow-popups allow-modals
+ *                      allow-same-origin"
+ *
+ * The runtime grants `allow-same-origin` so apps can use localStorage /
+ * postMessage origin checks. In preview we keep the iframe at a null
+ * origin so a teacher inspecting a malicious global app (review path)
+ * can't have it reach `parent.window` and read the host DOM. That makes
+ * the preview a strict subset of what students will see: apps that rely
+ * on `allow-same-origin`, forms POST, `window.open`, or
+ * `alert/confirm/prompt` will look broken in preview yet work at
+ * runtime. The trade-off favors safety on the inspection surface; the
+ * runtime is the source of truth.
  */
 const MiniAppPreviewPane: React.FC<{
   row: UnifiedRow;
@@ -1287,11 +1312,8 @@ const MiniAppPreviewPane: React.FC<{
       }
     >
       {/*
-        Sandbox notes: `allow-scripts` is required for almost every mini-
-        app (no scripts = nothing happens). We deliberately do NOT grant
-        `allow-same-origin`, which keeps the iframe in a null origin and
-        prevents reading the parent's cookies/storage/DOM. `srcDoc`
-        avoids needing a real URL — the HTML is inlined directly.
+        See the component header for the sandbox security trade-off.
+        `srcDoc` inlines the HTML directly so no real URL is needed.
       */}
       <iframe
         title={`Preview of ${app.title}`}

--- a/components/widgets/MiniApp/components/MiniAppManager.tsx
+++ b/components/widgets/MiniApp/components/MiniAppManager.tsx
@@ -67,6 +67,7 @@ import { useLibraryView } from '@/components/common/library/useLibraryView';
 import { useLibrarySelection } from '@/components/common/library/useLibrarySelection';
 import { useSortableReorder } from '@/components/common/library/useSortableReorder';
 import { BulkActionBar } from '@/components/common/library/BulkActionBar';
+import { LibraryPreviewPane } from '@/components/common/library/LibraryPreviewPane';
 import {
   countItemsByFolder,
   filterByFolder,
@@ -322,6 +323,10 @@ export const MiniAppManager: React.FC<MiniAppManagerProps> = ({
   const selection = useLibrarySelection();
   const [selectionMode, setSelectionMode] = useState(false);
   const [bulkBusy, setBulkBusy] = useState(false);
+  // Phase 5 follow-up — preview pane state (see QuizManager).
+  // Holds the row, not just the item, so the pane can render different
+  // chrome for personal vs global apps.
+  const [previewRow, setPreviewRow] = useState<UnifiedRow | null>(null);
   const [prevTab, setPrevTab] = useState(tab);
   if (prevTab !== tab) {
     setPrevTab(tab);
@@ -686,7 +691,10 @@ export const MiniAppManager: React.FC<MiniAppManagerProps> = ({
             : undefined
         }
         secondaryActions={secondary}
-        onClick={() => onEdit(app)}
+        // Phase 5 follow-up — single-click opens preview pane,
+        // double-click opens editor.
+        onClick={() => setPreviewRow(row)}
+        onDoubleClick={() => onEdit(app)}
         sortable={!selectionMode}
         viewMode={view.state.viewMode}
         selectionMode={selectionMode}
@@ -775,8 +783,12 @@ export const MiniAppManager: React.FC<MiniAppManagerProps> = ({
             : undefined
         }
         secondaryActions={secondary}
-        // No onClick for global items — they are read-only here; clicking the
-        // body would imply "edit", which is admin-only.
+        // Global apps are read-only here. Single-click still opens the
+        // preview pane (so teachers can inspect what they'd be saving
+        // before clicking "Save to my library"); no double-click for
+        // editor because there is no editor for global apps from this
+        // surface.
+        onClick={() => setPreviewRow(row)}
         sortable={false}
         viewMode={view.state.viewMode}
       />
@@ -1020,41 +1032,53 @@ export const MiniAppManager: React.FC<MiniAppManagerProps> = ({
     // the shared `LibraryDndContext` below), so a non-manual sort won't persist
     // a new order.
     tabContent = (
-      <>
-        {selectionMode && selection.count > 0 && (
-          <div className="mb-3">
-            <BulkActionBar
-              count={selection.count}
-              onClear={() => {
-                selection.clear();
-                setSelectionMode(false);
-              }}
-              folders={folderState.folders}
-              onMove={handleBulkMove}
-              onDelete={handleBulkDelete}
-              busy={bulkBusy}
-            />
-          </div>
+      <div className="flex h-full min-h-0 gap-3">
+        <div className="flex-1 min-w-0 flex flex-col">
+          {selectionMode && selection.count > 0 && (
+            <div className="mb-3">
+              <BulkActionBar
+                count={selection.count}
+                onClear={() => {
+                  selection.clear();
+                  setSelectionMode(false);
+                }}
+                folders={folderState.folders}
+                onMove={handleBulkMove}
+                onDelete={handleBulkDelete}
+                busy={bulkBusy}
+              />
+            </div>
+          )}
+          <LibraryGrid<UnifiedRow>
+            items={view.visibleItems}
+            getId={getRowId}
+            renderCard={renderCard}
+            onReorder={
+              isGlobalView ? undefined : (ids) => reorderHook.handleReorder(ids)
+            }
+            dragDisabled={isGlobalView || selectionMode}
+            reorderLocked={
+              enableCardDrag ? false : !isGlobalView && view.reorderLocked
+            }
+            reorderLockedReason={
+              enableCardDrag ? undefined : view.reorderLockedReason
+            }
+            layout={view.state.viewMode}
+            useExternalDndContext={enableCardDrag}
+            emptyState={empty}
+          />
+        </div>
+        {previewRow && (
+          <MiniAppPreviewPane
+            row={previewRow}
+            onClose={() => setPreviewRow(null)}
+            onEdit={onEdit}
+            onSaveGlobalToLibrary={onSaveGlobalToLibrary}
+            savingGlobalId={savingGlobalId}
+            isViewOnly={isViewOnly}
+          />
         )}
-        <LibraryGrid<UnifiedRow>
-          items={view.visibleItems}
-          getId={getRowId}
-          renderCard={renderCard}
-          onReorder={
-            isGlobalView ? undefined : (ids) => reorderHook.handleReorder(ids)
-          }
-          dragDisabled={isGlobalView || selectionMode}
-          reorderLocked={
-            enableCardDrag ? false : !isGlobalView && view.reorderLocked
-          }
-          reorderLockedReason={
-            enableCardDrag ? undefined : view.reorderLockedReason
-          }
-          layout={view.state.viewMode}
-          useExternalDndContext={enableCardDrag}
-          emptyState={empty}
-        />
-      </>
+      </div>
     );
   }
 
@@ -1198,5 +1222,84 @@ export const MiniAppManager: React.FC<MiniAppManagerProps> = ({
       {shell}
       {folderPickerDialog}
     </>
+  );
+};
+
+/**
+ * Preview pane content for the MiniAppManager. Renders the app's HTML
+ * inside a sandboxed iframe so the teacher can see what the app looks
+ * like before opening the editor. The iframe `sandbox` attribute
+ * isolates the app from the host (no parent access, no top-level
+ * navigation), and `allow-scripts` is the only capability granted —
+ * matches the runtime player's sandbox shape so the preview is a
+ * faithful glance at what students will see.
+ */
+const MiniAppPreviewPane: React.FC<{
+  row: UnifiedRow;
+  onClose: () => void;
+  onEdit: (app: MiniAppItem) => void;
+  onSaveGlobalToLibrary: (app: GlobalMiniAppItem) => void;
+  savingGlobalId: string | null;
+  isViewOnly: boolean;
+}> = ({
+  row,
+  onClose,
+  onEdit,
+  onSaveGlobalToLibrary,
+  savingGlobalId,
+  isViewOnly,
+}) => {
+  const app = row.item;
+  const isPersonal = row.kind === 'personal';
+  const saving = !isPersonal && savingGlobalId === app.id;
+  return (
+    <LibraryPreviewPane
+      isOpen={true}
+      onClose={onClose}
+      title={app.title}
+      subtitle={
+        <span className="font-mono">
+          {(app.html.length / 1024).toFixed(1)} KB
+        </span>
+      }
+      primaryAction={
+        isPersonal && !isViewOnly
+          ? {
+              label: 'Open editor',
+              icon: Pencil,
+              onClick: () => {
+                const a = app;
+                onClose();
+                onEdit(a as MiniAppItem);
+              },
+            }
+          : !isPersonal
+            ? {
+                label: saving ? 'Saving…' : 'Save to my library',
+                icon: Pencil,
+                disabled: saving,
+                onClick: () => {
+                  const a = app as GlobalMiniAppItem;
+                  onSaveGlobalToLibrary(a);
+                },
+              }
+            : undefined
+      }
+    >
+      {/*
+        Sandbox notes: `allow-scripts` is required for almost every mini-
+        app (no scripts = nothing happens). We deliberately do NOT grant
+        `allow-same-origin`, which keeps the iframe in a null origin and
+        prevents reading the parent's cookies/storage/DOM. `srcDoc`
+        avoids needing a real URL — the HTML is inlined directly.
+      */}
+      <iframe
+        title={`Preview of ${app.title}`}
+        srcDoc={app.html}
+        sandbox="allow-scripts"
+        className="w-full aspect-[4/3] rounded-lg border border-slate-200 bg-white"
+        loading="lazy"
+      />
+    </LibraryPreviewPane>
   );
 };

--- a/components/widgets/MiniApp/components/MiniAppManager.tsx
+++ b/components/widgets/MiniApp/components/MiniAppManager.tsx
@@ -112,6 +112,12 @@ export interface MiniAppManagerProps {
    * already has Firestore access). Optional so test harnesses can omit.
    */
   onDuplicate?: (app: MiniAppItem) => void | Promise<void>;
+  /**
+   * Optional busy-state probe. When provided, the Duplicate kebab item
+   * disables itself for any app id whose duplicate is currently
+   * in-flight. Prevents rapid double-click → two identical copies.
+   */
+  isDuplicating?: (appId: string) => boolean;
   onRun: (app: MiniAppItem) => void;
   onAssign: (app: MiniAppItem) => void;
   onShowAssignments: (app: MiniAppItem) => void;
@@ -282,6 +288,7 @@ export const MiniAppManager: React.FC<MiniAppManagerProps> = ({
   onEdit,
   onDelete,
   onDuplicate,
+  isDuplicating,
   onRun,
   onAssign,
   onShowAssignments,
@@ -566,7 +573,12 @@ export const MiniAppManager: React.FC<MiniAppManagerProps> = ({
           // submissions modes; mini-apps are personal HTML blobs and the
           // duplicate semantics don't depend on assignment shape.
           ...(onDuplicate
-            ? [buildDuplicateAction(app, () => void onDuplicate(app))]
+            ? [
+                buildDuplicateAction(app, () => void onDuplicate(app), {
+                  disabled: isDuplicating?.(app.id),
+                  disabledReason: 'Duplicating…',
+                }),
+              ]
             : []),
           buildMoveToFolderAction({
             onOpenPicker: () =>
@@ -605,7 +617,12 @@ export const MiniAppManager: React.FC<MiniAppManagerProps> = ({
             onClick: () => onEdit(app),
           },
           ...(onDuplicate
-            ? [buildDuplicateAction(app, () => void onDuplicate(app))]
+            ? [
+                buildDuplicateAction(app, () => void onDuplicate(app), {
+                  disabled: isDuplicating?.(app.id),
+                  disabledReason: 'Duplicating…',
+                }),
+              ]
             : []),
           buildMoveToFolderAction({
             onOpenPicker: () =>

--- a/components/widgets/QuizWidget/Widget.tsx
+++ b/components/widgets/QuizWidget/Widget.tsx
@@ -22,6 +22,7 @@ import {
   type QuizSessionOptions,
 } from '@/hooks/useQuizSession';
 import { useQuizAssignments } from '@/hooks/useQuizAssignments';
+import { useBusyIdSet } from '@/hooks/useBusyIdSet';
 import { useFolders } from '@/hooks/useFolders';
 import {
   callLeaveSyncedQuizGroup,
@@ -194,13 +195,10 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
   const [loadingQuizData, setLoadingQuizData] = useState(false);
   const [dataError, setDataError] = useState<string | null>(null);
 
-  // Tracks quiz ids whose duplicate is currently in-flight. Used to
-  // disable the Duplicate kebab on a per-row basis so a rapid
-  // double-click doesn't create two identical-titled copies + burn 2x
-  // Drive API calls. Empty set → no in-flight duplicates.
-  const [duplicatingQuizIds, setDuplicatingQuizIds] = useState<
-    ReadonlySet<string>
-  >(() => new Set());
+  // Rapid-double-click guard for the Duplicate kebab. The shared hook
+  // owns the set, the `run()` wrapper, and the no-op-on-busy semantics
+  // so the four library widgets stay in lockstep.
+  const duplicateBusy = useBusyIdSet();
 
   // Bump a token whenever the user navigates INTO the results view so the
   // QuizResults consumer remounts with fresh memos over the current live
@@ -1391,35 +1389,20 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
             );
           }
         }}
-        onDuplicate={async (meta) => {
-          // Guard against rapid double-clicks: the kebab also disables
-          // itself via `isDuplicating`, but the manager renders the
-          // disabled-state on the NEXT React commit so a 60-fps user can
-          // still squeeze through two clicks before the disable lands.
-          if (duplicatingQuizIds.has(meta.id)) return;
-          setDuplicatingQuizIds((prev) => {
-            const next = new Set(prev);
-            next.add(meta.id);
-            return next;
-          });
-          try {
-            const copy = await duplicateQuiz(meta);
-            addToast(`Duplicated as "${copy.title}".`, 'success');
-          } catch (err) {
-            addToast(
-              err instanceof Error ? err.message : 'Duplicate failed',
-              'error'
-            );
-          } finally {
-            setDuplicatingQuizIds((prev) => {
-              if (!prev.has(meta.id)) return prev;
-              const next = new Set(prev);
-              next.delete(meta.id);
-              return next;
-            });
-          }
-        }}
-        isDuplicating={(quizId) => duplicatingQuizIds.has(quizId)}
+        onDuplicate={(meta) =>
+          void duplicateBusy.run(meta.id, async () => {
+            try {
+              const copy = await duplicateQuiz(meta);
+              addToast(`Duplicated as "${copy.title}".`, 'success');
+            } catch (err) {
+              addToast(
+                err instanceof Error ? err.message : 'Duplicate failed',
+                'error'
+              );
+            }
+          })
+        }
+        isDuplicating={duplicateBusy.isBusy}
         onBulkDelete={async (metas): Promise<boolean> => {
           // Aggregated variant of the single-quiz onDelete handler above.
           // Partitions targets into:

--- a/components/widgets/QuizWidget/Widget.tsx
+++ b/components/widgets/QuizWidget/Widget.tsx
@@ -194,6 +194,14 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
   const [loadingQuizData, setLoadingQuizData] = useState(false);
   const [dataError, setDataError] = useState<string | null>(null);
 
+  // Tracks quiz ids whose duplicate is currently in-flight. Used to
+  // disable the Duplicate kebab on a per-row basis so a rapid
+  // double-click doesn't create two identical-titled copies + burn 2x
+  // Drive API calls. Empty set → no in-flight duplicates.
+  const [duplicatingQuizIds, setDuplicatingQuizIds] = useState<
+    ReadonlySet<string>
+  >(() => new Set());
+
   // Bump a token whenever the user navigates INTO the results view so the
   // QuizResults consumer remounts with fresh memos over the current live
   // `responses` — guarantees aggregate stats recompute after a mid-view
@@ -1384,6 +1392,16 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
           }
         }}
         onDuplicate={async (meta) => {
+          // Guard against rapid double-clicks: the kebab also disables
+          // itself via `isDuplicating`, but the manager renders the
+          // disabled-state on the NEXT React commit so a 60-fps user can
+          // still squeeze through two clicks before the disable lands.
+          if (duplicatingQuizIds.has(meta.id)) return;
+          setDuplicatingQuizIds((prev) => {
+            const next = new Set(prev);
+            next.add(meta.id);
+            return next;
+          });
           try {
             const copy = await duplicateQuiz(meta);
             addToast(`Duplicated as "${copy.title}".`, 'success');
@@ -1392,8 +1410,16 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
               err instanceof Error ? err.message : 'Duplicate failed',
               'error'
             );
+          } finally {
+            setDuplicatingQuizIds((prev) => {
+              if (!prev.has(meta.id)) return prev;
+              const next = new Set(prev);
+              next.delete(meta.id);
+              return next;
+            });
           }
         }}
+        isDuplicating={(quizId) => duplicatingQuizIds.has(quizId)}
         onBulkDelete={async (metas): Promise<boolean> => {
           // Aggregated variant of the single-quiz onDelete handler above.
           // Partitions targets into:

--- a/components/widgets/QuizWidget/components/QuizManager.tsx
+++ b/components/widgets/QuizWidget/components/QuizManager.tsx
@@ -642,10 +642,12 @@ export const QuizManager: React.FC<QuizManagerProps> = ({
   const selection = useLibrarySelection();
   const [selectionMode, setSelectionMode] = useState(false);
   const [bulkBusy, setBulkBusy] = useState(false);
-  // Phase 5 follow-up — preview pane state. Single-click on a card sets
-  // this; double-click bypasses to the editor directly. The pane lives
-  // beside the grid in a flex-row layout when set.
-  const [previewQuiz, setPreviewQuiz] = useState<QuizMetadata | null>(null);
+  // Phase 5 follow-up — preview pane state. We store the id (not the
+  // metadata object) so the pane always reflects the latest Firestore
+  // snapshot for the previewed quiz. Storing the object pinned the pane
+  // to a stale copy and routed the "Open editor" primary action to a
+  // possibly-deleted quiz id (subagent review flag on PR #1588).
+  const [previewQuizId, setPreviewQuizId] = useState<string | null>(null);
   // Exit selection mode if the user leaves the library tab
   const [prevManagerTab, setPrevManagerTab] = useState(managerTab);
   if (prevManagerTab !== managerTab) {
@@ -1481,8 +1483,16 @@ export const QuizManager: React.FC<QuizManagerProps> = ({
           onBulkMove={handleBulkMove}
           onBulkDelete={handleBulkDelete}
           primaryActionLabel={primaryActionLabel}
-          previewQuiz={previewQuiz}
-          onPreviewQuiz={setPreviewQuiz}
+          // Derive the live snapshot from `quizzes` so Firestore updates
+          // (rename / question edit / sync push) flow through the pane.
+          // When the previewed quiz is deleted upstream, `find` returns
+          // undefined and the pane unmounts.
+          previewQuiz={
+            previewQuizId
+              ? (quizzes.find((q) => q.id === previewQuizId) ?? null)
+              : null
+          }
+          onPreviewQuiz={(quiz) => setPreviewQuizId(quiz ? quiz.id : null)}
           onOpenFullPreview={onPreview}
         />
       )}

--- a/components/widgets/QuizWidget/components/QuizManager.tsx
+++ b/components/widgets/QuizWidget/components/QuizManager.tsx
@@ -75,6 +75,7 @@ import {
   LibraryToolbar,
   LibraryGrid,
   LibraryItemCard,
+  LibraryPreviewPane,
   AssignModal,
   AssignmentSettingsToggleGroup,
   ToggleRow,
@@ -641,6 +642,10 @@ export const QuizManager: React.FC<QuizManagerProps> = ({
   const selection = useLibrarySelection();
   const [selectionMode, setSelectionMode] = useState(false);
   const [bulkBusy, setBulkBusy] = useState(false);
+  // Phase 5 follow-up — preview pane state. Single-click on a card sets
+  // this; double-click bypasses to the editor directly. The pane lives
+  // beside the grid in a flex-row layout when set.
+  const [previewQuiz, setPreviewQuiz] = useState<QuizMetadata | null>(null);
   // Exit selection mode if the user leaves the library tab
   const [prevManagerTab, setPrevManagerTab] = useState(managerTab);
   if (prevManagerTab !== managerTab) {
@@ -1476,6 +1481,9 @@ export const QuizManager: React.FC<QuizManagerProps> = ({
           onBulkMove={handleBulkMove}
           onBulkDelete={handleBulkDelete}
           primaryActionLabel={primaryActionLabel}
+          previewQuiz={previewQuiz}
+          onPreviewQuiz={setPreviewQuiz}
+          onOpenFullPreview={onPreview}
         />
       )}
 
@@ -1631,6 +1639,20 @@ const LibraryTabContent: React.FC<{
   onBulkMove: (folderId: string | null) => Promise<void>;
   onBulkDelete: () => void | Promise<void>;
   primaryActionLabel: string;
+  /**
+   * Phase 5 follow-up — preview pane state. `previewQuiz` is the
+   * currently-shown item (or null); single-click on a card sets it,
+   * double-click on a card opens the editor directly. When set, a
+   * `LibraryPreviewPane` renders as a right-side sibling of the grid.
+   */
+  previewQuiz: QuizMetadata | null;
+  onPreviewQuiz: (quiz: QuizMetadata | null) => void;
+  /**
+   * Heavyweight full-screen QuizPreview entry point — the same callback
+   * the kebab's `Preview` item already uses. Surfaced from the pane as
+   * a secondary "Full preview" action.
+   */
+  onOpenFullPreview: (quiz: QuizMetadata) => void;
 }> = ({
   error,
   orderedItems,
@@ -1651,6 +1673,9 @@ const LibraryTabContent: React.FC<{
   onBulkMove,
   onBulkDelete,
   primaryActionLabel,
+  previewQuiz,
+  onPreviewQuiz,
+  onOpenFullPreview,
 }) => {
   const emptyState =
     totalCount === 0 ? (
@@ -1682,77 +1707,161 @@ const LibraryTabContent: React.FC<{
     );
 
   return (
-    <>
-      {error && (
-        <div className="mb-4 flex items-center gap-2 bg-brand-red-lighter/40 border border-brand-red-primary/30 rounded-xl text-brand-red-dark px-3 py-2 text-sm font-medium">
-          <AlertCircle className="w-4 h-4 shrink-0" />
-          {error}
-        </div>
-      )}
-
-      {selectionMode && selection.count > 0 && (
-        <div className="mb-3">
-          <BulkActionBar
-            count={selection.count}
-            onClear={() => selection.clear()}
-            folders={folders}
-            onMove={onBulkMove}
-            onDelete={onBulkDelete}
-            busy={bulkBusy}
-          />
-        </div>
-      )}
-
-      <LibraryGrid<QuizMetadata>
-        items={orderedItems}
-        getId={(q) => q.id}
-        dragDisabled={!enableCardDrag}
-        // Quiz has no manual reorder, so reorderLocked is noise; only surface
-        // it when drag is fully disabled so the existing lock tooltip still
-        // works on grids without folder drag.
-        reorderLocked={enableCardDrag ? false : reorderLocked}
-        reorderLockedReason={enableCardDrag ? undefined : reorderLockedReason}
-        layout={viewMode}
-        emptyState={emptyState}
-        useExternalDndContext={enableCardDrag}
-        renderCard={(quiz) => (
-          <LibraryItemCard<QuizMetadata>
-            key={quiz.id}
-            id={quiz.id}
-            title={quiz.title}
-            subtitle={
-              <span className="flex items-center gap-2">
-                <span className="bg-brand-blue-lighter text-brand-blue-primary font-bold rounded px-1.5 text-[10px] uppercase">
-                  {quiz.questionCount} Qs
-                </span>
-                <span>
-                  Updated{' '}
-                  {new Date(
-                    quiz.updatedAt || quiz.createdAt
-                  ).toLocaleDateString()}
-                </span>
-              </span>
-            }
-            primaryAction={{
-              label: primaryActionLabel,
-              icon: Play,
-              onClick: () => onAssignClick(quiz),
-            }}
-            secondaryActions={buildSecondaryActions(quiz)}
-            badges={buildBadges?.(quiz)}
-            onClick={() => onEdit(quiz)}
-            viewMode={viewMode}
-            sortable={enableCardDrag}
-            meta={quiz}
-            selectionMode={selectionMode}
-            selected={selection.isSelected(quiz.id)}
-            onSelectionToggle={() => selection.toggle(quiz.id)}
-          />
+    <div className="flex h-full min-h-0 gap-3">
+      <div className="flex-1 min-w-0 flex flex-col">
+        {error && (
+          <div className="mb-4 flex items-center gap-2 bg-brand-red-lighter/40 border border-brand-red-primary/30 rounded-xl text-brand-red-dark px-3 py-2 text-sm font-medium">
+            <AlertCircle className="w-4 h-4 shrink-0" aria-hidden="true" />
+            {error}
+          </div>
         )}
-      />
-    </>
+
+        {selectionMode && selection.count > 0 && (
+          <div className="mb-3">
+            <BulkActionBar
+              count={selection.count}
+              onClear={() => selection.clear()}
+              folders={folders}
+              onMove={onBulkMove}
+              onDelete={onBulkDelete}
+              busy={bulkBusy}
+            />
+          </div>
+        )}
+
+        <LibraryGrid<QuizMetadata>
+          items={orderedItems}
+          getId={(q) => q.id}
+          dragDisabled={!enableCardDrag}
+          // Quiz has no manual reorder, so reorderLocked is noise; only surface
+          // it when drag is fully disabled so the existing lock tooltip still
+          // works on grids without folder drag.
+          reorderLocked={enableCardDrag ? false : reorderLocked}
+          reorderLockedReason={enableCardDrag ? undefined : reorderLockedReason}
+          layout={viewMode}
+          emptyState={emptyState}
+          useExternalDndContext={enableCardDrag}
+          renderCard={(quiz) => (
+            <LibraryItemCard<QuizMetadata>
+              key={quiz.id}
+              id={quiz.id}
+              title={quiz.title}
+              subtitle={
+                <span className="flex items-center gap-2">
+                  <span className="bg-brand-blue-lighter text-brand-blue-primary font-bold rounded px-1.5 text-[10px] uppercase">
+                    {quiz.questionCount} Qs
+                  </span>
+                  <span>
+                    Updated{' '}
+                    {new Date(
+                      quiz.updatedAt || quiz.createdAt
+                    ).toLocaleDateString()}
+                  </span>
+                </span>
+              }
+              primaryAction={{
+                label: primaryActionLabel,
+                icon: Play,
+                onClick: () => onAssignClick(quiz),
+              }}
+              secondaryActions={buildSecondaryActions(quiz)}
+              badges={buildBadges?.(quiz)}
+              // Phase 5 follow-up — single-click opens the preview pane,
+              // double-click opens the editor directly. The 250ms
+              // delay-and-cancel coordination is owned by
+              // `LibraryItemCard`.
+              onClick={() => onPreviewQuiz(quiz)}
+              onDoubleClick={() => onEdit(quiz)}
+              viewMode={viewMode}
+              sortable={enableCardDrag}
+              meta={quiz}
+              selectionMode={selectionMode}
+              selected={selection.isSelected(quiz.id)}
+              onSelectionToggle={() => selection.toggle(quiz.id)}
+            />
+          )}
+        />
+      </div>
+      {previewQuiz && (
+        <LibraryPreviewPane
+          isOpen={true}
+          onClose={() => onPreviewQuiz(null)}
+          title={previewQuiz.title}
+          subtitle={
+            <>
+              {previewQuiz.questionCount}{' '}
+              {previewQuiz.questionCount === 1 ? 'question' : 'questions'}
+              {previewQuiz.updatedAt
+                ? ` · Updated ${new Date(previewQuiz.updatedAt).toLocaleDateString()}`
+                : ''}
+            </>
+          }
+          primaryAction={{
+            label: 'Open editor',
+            icon: Edit2,
+            onClick: () => {
+              const q = previewQuiz;
+              onPreviewQuiz(null);
+              onEdit(q);
+            },
+          }}
+          secondaryActions={[
+            {
+              label: 'Full preview',
+              icon: Eye,
+              onClick: () => {
+                const q = previewQuiz;
+                onPreviewQuiz(null);
+                onOpenFullPreview(q);
+              },
+            },
+          ]}
+        >
+          <QuizPreviewPaneContent quiz={previewQuiz} />
+        </LibraryPreviewPane>
+      )}
+    </div>
   );
 };
+
+/**
+ * Lightweight preview pane content for the QuizManager. Renders only
+ * metadata that's already on the `QuizMetadata` doc — no Drive load,
+ * so the pane is responsive on click. For interactive question-by-
+ * question preview, the pane's secondary action routes to the existing
+ * heavyweight `onOpenFullPreview` flow.
+ */
+const QuizPreviewPaneContent: React.FC<{ quiz: QuizMetadata }> = ({ quiz }) => {
+  const created = quiz.createdAt
+    ? new Date(quiz.createdAt).toLocaleDateString()
+    : null;
+  const updated = quiz.updatedAt
+    ? new Date(quiz.updatedAt).toLocaleDateString()
+    : null;
+  return (
+    <div className="flex flex-col gap-3 text-sm text-slate-700">
+      <div className="grid grid-cols-2 gap-3">
+        <Stat label="Questions" value={String(quiz.questionCount)} />
+        {created && <Stat label="Created" value={created} />}
+        {updated && <Stat label="Last updated" value={updated} />}
+        {quiz.sync && <Stat label="Sync group" value="Active" />}
+      </div>
+      <p className="text-xxs text-slate-500 leading-relaxed mt-1">
+        Open the editor to see questions, or use “Full preview” to walk through
+        this quiz the way students will.
+      </p>
+    </div>
+  );
+};
+
+const Stat: React.FC<{ label: string; value: string }> = ({ label, value }) => (
+  <div className="rounded-lg border border-slate-200 bg-white px-3 py-2">
+    <div className="text-xxs font-bold uppercase tracking-wider text-slate-400">
+      {label}
+    </div>
+    <div className="text-sm font-semibold text-slate-800 mt-0.5">{value}</div>
+  </div>
+);
 
 /* ─── AssignmentsList (for active + archive tabs) ────────────────────────── */
 

--- a/components/widgets/QuizWidget/components/QuizManager.tsx
+++ b/components/widgets/QuizWidget/components/QuizManager.tsx
@@ -287,6 +287,15 @@ interface QuizManagerProps {
    */
   onDuplicate?: (quiz: QuizMetadata) => void | Promise<void>;
   /**
+   * Optional busy-state probe. When provided, the Duplicate kebab item
+   * disables itself for any quiz id whose duplicate is currently
+   * in-flight. Prevents the rapid double-click pattern that previously
+   * fired the duplicate twice — both attempts computed the same
+   * `suggestDuplicateTitle()` output and burned 2x Drive API quota for
+   * one teacher intent.
+   */
+  isDuplicating?: (quizId: string) => boolean;
+  /**
    * Optional batch delete that bypasses the per-quiz confirmation/toasts
    * fired by `onDelete` (see QuizWidget's `onDelete` wiring, which prompts
    * per-quiz when archived assignments exist). Receives every selected
@@ -471,6 +480,7 @@ export const QuizManager: React.FC<QuizManagerProps> = ({
   onResults,
   onDelete,
   onDuplicate,
+  isDuplicating,
   onBulkDelete,
   onShare,
   onShareWithPlc,
@@ -731,7 +741,12 @@ export const QuizManager: React.FC<QuizManagerProps> = ({
       // the menu. Hidden when no `onDuplicate` is wired (view-only and
       // test harnesses).
       ...(onDuplicate
-        ? [buildDuplicateAction(quiz, () => void onDuplicate(quiz))]
+        ? [
+            buildDuplicateAction(quiz, () => void onDuplicate(quiz), {
+              disabled: isDuplicating?.(quiz.id),
+              disabledReason: 'Duplicating…',
+            }),
+          ]
         : []),
       {
         id: 'stats',

--- a/components/widgets/VideoActivityWidget/Widget.tsx
+++ b/components/widgets/VideoActivityWidget/Widget.tsx
@@ -25,6 +25,7 @@ import { useAuth } from '@/context/useAuth';
 import { useVideoActivity } from '@/hooks/useVideoActivity';
 import { useVideoActivitySessionTeacher } from '@/hooks/useVideoActivitySession';
 import { useVideoActivityAssignments } from '@/hooks/useVideoActivityAssignments';
+import { useBusyIdSet } from '@/hooks/useBusyIdSet';
 import { useFolders } from '@/hooks/useFolders';
 import { VideoActivityManager } from './components/VideoActivityManager';
 import { Creator } from './components/Creator';
@@ -129,10 +130,8 @@ export const VideoActivityWidget: React.FC<{ widget: WidgetData }> = ({
     null
   );
 
-  // In-flight Duplicate kebab guard — see QuizWidget for the rationale.
-  const [duplicatingActivityIds, setDuplicatingActivityIds] = useState<
-    ReadonlySet<string>
-  >(() => new Set());
+  // Shared rapid-click guard. See `hooks/useBusyIdSet.ts`.
+  const duplicateBusy = useBusyIdSet();
 
   const { folders: videoActivityFolders, moveItem: moveVideoActivityItem } =
     useFolders(user?.uid, 'video_activity');
@@ -531,31 +530,20 @@ export const VideoActivityWidget: React.FC<{ widget: WidgetData }> = ({
             );
           }
         }}
-        onDuplicate={async (meta) => {
-          if (duplicatingActivityIds.has(meta.id)) return;
-          setDuplicatingActivityIds((prev) => {
-            const next = new Set(prev);
-            next.add(meta.id);
-            return next;
-          });
-          try {
-            const copy = await duplicateActivity(meta);
-            addToast(`Duplicated as "${copy.title}".`, 'success');
-          } catch (err) {
-            addToast(
-              err instanceof Error ? err.message : 'Duplicate failed',
-              'error'
-            );
-          } finally {
-            setDuplicatingActivityIds((prev) => {
-              if (!prev.has(meta.id)) return prev;
-              const next = new Set(prev);
-              next.delete(meta.id);
-              return next;
-            });
-          }
-        }}
-        isDuplicating={(activityId) => duplicatingActivityIds.has(activityId)}
+        onDuplicate={(meta) =>
+          void duplicateBusy.run(meta.id, async () => {
+            try {
+              const copy = await duplicateActivity(meta);
+              addToast(`Duplicated as "${copy.title}".`, 'success');
+            } catch (err) {
+              addToast(
+                err instanceof Error ? err.message : 'Duplicate failed',
+                'error'
+              );
+            }
+          })
+        }
+        isDuplicating={duplicateBusy.isBusy}
         assignments={assignments}
         assignmentsLoading={assignmentsLoading}
         onArchiveCopyUrl={(assignment) => {

--- a/components/widgets/VideoActivityWidget/Widget.tsx
+++ b/components/widgets/VideoActivityWidget/Widget.tsx
@@ -129,6 +129,11 @@ export const VideoActivityWidget: React.FC<{ widget: WidgetData }> = ({
     null
   );
 
+  // In-flight Duplicate kebab guard — see QuizWidget for the rationale.
+  const [duplicatingActivityIds, setDuplicatingActivityIds] = useState<
+    ReadonlySet<string>
+  >(() => new Set());
+
   const { folders: videoActivityFolders, moveItem: moveVideoActivityItem } =
     useFolders(user?.uid, 'video_activity');
 
@@ -527,6 +532,12 @@ export const VideoActivityWidget: React.FC<{ widget: WidgetData }> = ({
           }
         }}
         onDuplicate={async (meta) => {
+          if (duplicatingActivityIds.has(meta.id)) return;
+          setDuplicatingActivityIds((prev) => {
+            const next = new Set(prev);
+            next.add(meta.id);
+            return next;
+          });
           try {
             const copy = await duplicateActivity(meta);
             addToast(`Duplicated as "${copy.title}".`, 'success');
@@ -535,8 +546,16 @@ export const VideoActivityWidget: React.FC<{ widget: WidgetData }> = ({
               err instanceof Error ? err.message : 'Duplicate failed',
               'error'
             );
+          } finally {
+            setDuplicatingActivityIds((prev) => {
+              if (!prev.has(meta.id)) return prev;
+              const next = new Set(prev);
+              next.delete(meta.id);
+              return next;
+            });
           }
         }}
+        isDuplicating={(activityId) => duplicatingActivityIds.has(activityId)}
         assignments={assignments}
         assignmentsLoading={assignmentsLoading}
         onArchiveCopyUrl={(assignment) => {

--- a/components/widgets/VideoActivityWidget/components/VideoActivityManager.tsx
+++ b/components/widgets/VideoActivityWidget/components/VideoActivityManager.tsx
@@ -60,6 +60,7 @@ import { useLibraryView } from '@/components/common/library/useLibraryView';
 import { useLibrarySelection } from '@/components/common/library/useLibrarySelection';
 import { useSortableReorder } from '@/components/common/library/useSortableReorder';
 import { BulkActionBar } from '@/components/common/library/BulkActionBar';
+import { LibraryPreviewPane } from '@/components/common/library/LibraryPreviewPane';
 import {
   countItemsByFolder,
   filterByFolder,
@@ -516,6 +517,9 @@ export const VideoActivityManager: React.FC<VideoActivityManagerProps> = ({
   const selection = useLibrarySelection();
   const [selectionMode, setSelectionMode] = useState(false);
   const [bulkBusy, setBulkBusy] = useState(false);
+  // Phase 5 follow-up — preview pane state (see QuizManager).
+  const [previewActivity, setPreviewActivity] =
+    useState<VideoActivityMetadata | null>(null);
   const [prevManagerTab, setPrevManagerTab] = useState(tab);
   if (prevManagerTab !== tab) {
     setPrevManagerTab(tab);
@@ -783,133 +787,165 @@ export const VideoActivityManager: React.FC<VideoActivityManagerProps> = ({
     (useExternalDnd || Boolean(onReorderActivities)) && !selectionMode;
 
   const renderLibraryTab = (): React.ReactElement => (
-    <>
-      {error && (
-        <div className="mb-3 flex items-center gap-2 rounded-xl border border-brand-red-primary/30 bg-brand-red-lighter/40 px-3 py-2 text-sm font-medium text-brand-red-dark">
-          <AlertCircle className="h-4 w-4 shrink-0" />
-          {error}
-        </div>
-      )}
+    <div className="flex h-full min-h-0 gap-3">
+      <div className="flex-1 min-w-0 flex flex-col">
+        {error && (
+          <div className="mb-3 flex items-center gap-2 rounded-xl border border-brand-red-primary/30 bg-brand-red-lighter/40 px-3 py-2 text-sm font-medium text-brand-red-dark">
+            <AlertCircle className="h-4 w-4 shrink-0" aria-hidden="true" />
+            {error}
+          </div>
+        )}
 
-      {selectionMode && selection.count > 0 && (
-        <div className="mb-3">
-          <BulkActionBar
-            count={selection.count}
-            onClear={() => selection.clear()}
-            folders={folderState.folders}
-            onMove={handleBulkMove}
-            onDelete={handleBulkDelete}
-            busy={bulkBusy}
-          />
-        </div>
-      )}
+        {selectionMode && selection.count > 0 && (
+          <div className="mb-3">
+            <BulkActionBar
+              count={selection.count}
+              onClear={() => selection.clear()}
+              folders={folderState.folders}
+              onMove={handleBulkMove}
+              onDelete={handleBulkDelete}
+              busy={bulkBusy}
+            />
+          </div>
+        )}
 
-      <LibraryGrid<VideoActivityMetadata>
-        items={reorder.orderedItems}
-        getId={(a) => a.id}
-        onReorder={reorder.handleReorder}
-        dragDisabled={!cardDragEnabled}
-        reorderLocked={useExternalDnd ? false : libraryView.reorderLocked}
-        reorderLockedReason={
-          useExternalDnd ? undefined : libraryView.reorderLockedReason
-        }
-        layout={libraryView.state.viewMode}
-        emptyState={libraryEmptyState}
-        useExternalDndContext={useExternalDnd}
-        renderCard={(activity) => {
-          const secondaryActions: LibraryMenuAction[] = [
-            {
-              id: 'edit',
-              label: 'Edit',
-              icon: Edit2,
-              onClick: () => onEdit(activity),
-            },
-            ...(onResults
-              ? [
-                  {
-                    id: 'results',
-                    label: 'Results',
-                    icon: BarChart3,
-                    onClick: () => onResults(activity),
-                  } satisfies LibraryMenuAction,
-                ]
-              : []),
-            // Phase 5 — Duplicate. Stacked below Edit (and Results when
-            // wired) so the destructive Delete remains the last entry.
-            ...(onDuplicate
-              ? [
-                  buildDuplicateAction(
-                    activity,
-                    () => void onDuplicate(activity),
-                    {
-                      disabled: isDuplicating?.(activity.id),
-                      disabledReason: 'Duplicating…',
-                    }
-                  ),
-                ]
-              : []),
-            buildMoveToFolderAction({
-              onOpenPicker: () => setFolderPickerTarget(activity),
-              disabled: !userId,
-            }),
-            {
-              id: 'delete',
-              label:
-                confirmDeleteActivityId === activity.id
-                  ? 'Confirm delete'
-                  : 'Delete',
-              icon: Trash2,
-              destructive: true,
-              onClick: () => {
-                if (confirmDeleteActivityId === activity.id) {
-                  setConfirmDeleteActivityId(null);
-                  void onDelete(activity);
-                } else {
-                  setConfirmDeleteActivityId(activity.id);
-                }
+        <LibraryGrid<VideoActivityMetadata>
+          items={reorder.orderedItems}
+          getId={(a) => a.id}
+          onReorder={reorder.handleReorder}
+          dragDisabled={!cardDragEnabled}
+          reorderLocked={useExternalDnd ? false : libraryView.reorderLocked}
+          reorderLockedReason={
+            useExternalDnd ? undefined : libraryView.reorderLockedReason
+          }
+          layout={libraryView.state.viewMode}
+          emptyState={libraryEmptyState}
+          useExternalDndContext={useExternalDnd}
+          renderCard={(activity) => {
+            const secondaryActions: LibraryMenuAction[] = [
+              {
+                id: 'edit',
+                label: 'Edit',
+                icon: Edit2,
+                onClick: () => onEdit(activity),
               },
-            },
-          ];
-          return (
-            <LibraryItemCard<VideoActivityMetadata>
-              key={activity.id}
-              id={activity.id}
-              title={activity.title}
-              subtitle={
-                <span className="truncate">
-                  Updated{' '}
-                  {new Date(
-                    activity.updatedAt || activity.createdAt
-                  ).toLocaleDateString()}
-                </span>
-              }
-              badges={activityBadges(activity)}
-              primaryAction={{
-                label: primaryActionLabel,
-                icon: Link2,
+              ...(onResults
+                ? [
+                    {
+                      id: 'results',
+                      label: 'Results',
+                      icon: BarChart3,
+                      onClick: () => onResults(activity),
+                    } satisfies LibraryMenuAction,
+                  ]
+                : []),
+              // Phase 5 — Duplicate. Stacked below Edit (and Results when
+              // wired) so the destructive Delete remains the last entry.
+              ...(onDuplicate
+                ? [
+                    buildDuplicateAction(
+                      activity,
+                      () => void onDuplicate(activity),
+                      {
+                        disabled: isDuplicating?.(activity.id),
+                        disabledReason: 'Duplicating…',
+                      }
+                    ),
+                  ]
+                : []),
+              buildMoveToFolderAction({
+                onOpenPicker: () => setFolderPickerTarget(activity),
+                disabled: !userId,
+              }),
+              {
+                id: 'delete',
+                label:
+                  confirmDeleteActivityId === activity.id
+                    ? 'Confirm delete'
+                    : 'Delete',
+                icon: Trash2,
+                destructive: true,
                 onClick: () => {
-                  if (isViewOnly) {
-                    // View-only: skip the AssignModal/picker flow entirely.
-                    setViewOnlyShareTarget(activity);
-                    setViewOnlyShareLink(null);
-                    setViewOnlyShareError(null);
+                  if (confirmDeleteActivityId === activity.id) {
+                    setConfirmDeleteActivityId(null);
+                    void onDelete(activity);
                   } else {
-                    setAssignTarget(activity);
+                    setConfirmDeleteActivityId(activity.id);
                   }
                 },
-              }}
-              secondaryActions={secondaryActions}
-              onClick={() => onEdit(activity)}
-              viewMode={libraryView.state.viewMode}
-              meta={activity}
-              selectionMode={selectionMode}
-              selected={selection.isSelected(activity.id)}
-              onSelectionToggle={() => selection.toggle(activity.id)}
-            />
-          );
-        }}
-      />
-    </>
+              },
+            ];
+            return (
+              <LibraryItemCard<VideoActivityMetadata>
+                key={activity.id}
+                id={activity.id}
+                title={activity.title}
+                subtitle={
+                  <span className="truncate">
+                    Updated{' '}
+                    {new Date(
+                      activity.updatedAt || activity.createdAt
+                    ).toLocaleDateString()}
+                  </span>
+                }
+                badges={activityBadges(activity)}
+                primaryAction={{
+                  label: primaryActionLabel,
+                  icon: Link2,
+                  onClick: () => {
+                    if (isViewOnly) {
+                      // View-only: skip the AssignModal/picker flow entirely.
+                      setViewOnlyShareTarget(activity);
+                      setViewOnlyShareLink(null);
+                      setViewOnlyShareError(null);
+                    } else {
+                      setAssignTarget(activity);
+                    }
+                  },
+                }}
+                secondaryActions={secondaryActions}
+                // Phase 5 follow-up — single-click opens preview pane,
+                // double-click opens editor. See QuizManager for rationale.
+                onClick={() => setPreviewActivity(activity)}
+                onDoubleClick={() => onEdit(activity)}
+                viewMode={libraryView.state.viewMode}
+                meta={activity}
+                selectionMode={selectionMode}
+                selected={selection.isSelected(activity.id)}
+                onSelectionToggle={() => selection.toggle(activity.id)}
+              />
+            );
+          }}
+        />
+      </div>
+      {previewActivity && (
+        <LibraryPreviewPane
+          isOpen={true}
+          onClose={() => setPreviewActivity(null)}
+          title={previewActivity.title}
+          subtitle={
+            <>
+              {previewActivity.questionCount}{' '}
+              {previewActivity.questionCount === 1 ? 'question' : 'questions'}
+              {previewActivity.updatedAt
+                ? ` · Updated ${new Date(previewActivity.updatedAt).toLocaleDateString()}`
+                : ''}
+            </>
+          }
+          primaryAction={{
+            label: 'Open editor',
+            icon: Edit2,
+            onClick: () => {
+              const a = previewActivity;
+              setPreviewActivity(null);
+              onEdit(a);
+            },
+          }}
+        >
+          <VideoActivityPreviewPaneContent activity={previewActivity} />
+        </LibraryPreviewPane>
+      )}
+    </div>
   );
 
   /* ─── In Progress / Archive tab content ──────────────────────────────── */
@@ -1551,3 +1587,72 @@ const VideoActivityScoringBlock: React.FC<VideoActivityScoringBlockProps> = ({
     </div>
   );
 };
+
+/**
+ * Lightweight preview pane content for the VideoActivityManager.
+ * Renders metadata + an embedded YouTube thumbnail. Activity authoring
+ * uses Google Drive for the full question data, which would require a
+ * Drive load to render here — keeping the pane to metadata-only keeps
+ * it responsive on click.
+ */
+const VideoActivityPreviewPaneContent: React.FC<{
+  activity: VideoActivityMetadata;
+}> = ({ activity }) => {
+  const created = activity.createdAt
+    ? new Date(activity.createdAt).toLocaleDateString()
+    : null;
+  const updated = activity.updatedAt
+    ? new Date(activity.updatedAt).toLocaleDateString()
+    : null;
+  // Extract the YouTube video id from common URL shapes (watch?v=…, youtu.be/…)
+  // so we can show the standard thumbnail. Returns null on anything we
+  // don't recognise — pane falls back to a neutral placeholder.
+  const youtubeId = extractYouTubeId(activity.youtubeUrl);
+  return (
+    <div className="flex flex-col gap-3 text-sm text-slate-700">
+      {youtubeId ? (
+        <img
+          src={`https://img.youtube.com/vi/${youtubeId}/hqdefault.jpg`}
+          alt=""
+          className="w-full rounded-lg border border-slate-200 bg-slate-100"
+          loading="lazy"
+        />
+      ) : (
+        <div className="flex aspect-video items-center justify-center rounded-lg border border-dashed border-slate-300 bg-slate-50 text-xs text-slate-400">
+          No video preview
+        </div>
+      )}
+      <div className="grid grid-cols-2 gap-3">
+        <VAStat label="Questions" value={String(activity.questionCount)} />
+        {created && <VAStat label="Created" value={created} />}
+        {updated && <VAStat label="Last updated" value={updated} />}
+      </div>
+    </div>
+  );
+};
+
+function extractYouTubeId(url: string | undefined): string | null {
+  if (!url) return null;
+  try {
+    const u = new URL(url);
+    if (u.hostname === 'youtu.be') return u.pathname.slice(1) || null;
+    if (u.hostname.endsWith('youtube.com')) {
+      return u.searchParams.get('v');
+    }
+  } catch {
+    return null;
+  }
+  return null;
+}
+
+const VAStat: React.FC<{ label: string; value: string }> = ({
+  label,
+  value,
+}) => (
+  <div className="rounded-lg border border-slate-200 bg-white px-3 py-2">
+    <div className="text-xxs font-bold uppercase tracking-wider text-slate-400">
+      {label}
+    </div>
+    <div className="text-sm font-semibold text-slate-800 mt-0.5">{value}</div>
+  </div>
+);

--- a/components/widgets/VideoActivityWidget/components/VideoActivityManager.tsx
+++ b/components/widgets/VideoActivityWidget/components/VideoActivityManager.tsx
@@ -92,6 +92,7 @@ import {
   type AssignClassPickerValue,
 } from '@/components/common/AssignClassPicker.helpers';
 import { mapLegacyClassIdsToRosterIds } from '@/utils/resolveAssignmentTargets';
+import { extractYouTubeId } from '@/utils/youtube';
 
 /* ─── Props ───────────────────────────────────────────────────────────────── */
 
@@ -517,9 +518,16 @@ export const VideoActivityManager: React.FC<VideoActivityManagerProps> = ({
   const selection = useLibrarySelection();
   const [selectionMode, setSelectionMode] = useState(false);
   const [bulkBusy, setBulkBusy] = useState(false);
-  // Phase 5 follow-up — preview pane state (see QuizManager).
-  const [previewActivity, setPreviewActivity] =
-    useState<VideoActivityMetadata | null>(null);
+  // Phase 5 follow-up — preview pane state. Stores id only so the pane
+  // always reflects the latest snapshot in `activities` (subagent
+  // review flag on PR #1588).
+  const [previewActivityId, setPreviewActivityId] = useState<string | null>(
+    null
+  );
+  const previewActivity =
+    previewActivityId != null
+      ? (activities.find((a) => a.id === previewActivityId) ?? null)
+      : null;
   const [prevManagerTab, setPrevManagerTab] = useState(tab);
   if (prevManagerTab !== tab) {
     setPrevManagerTab(tab);
@@ -906,7 +914,7 @@ export const VideoActivityManager: React.FC<VideoActivityManagerProps> = ({
                 secondaryActions={secondaryActions}
                 // Phase 5 follow-up — single-click opens preview pane,
                 // double-click opens editor. See QuizManager for rationale.
-                onClick={() => setPreviewActivity(activity)}
+                onClick={() => setPreviewActivityId(activity.id)}
                 onDoubleClick={() => onEdit(activity)}
                 viewMode={libraryView.state.viewMode}
                 meta={activity}
@@ -921,7 +929,7 @@ export const VideoActivityManager: React.FC<VideoActivityManagerProps> = ({
       {previewActivity && (
         <LibraryPreviewPane
           isOpen={true}
-          onClose={() => setPreviewActivity(null)}
+          onClose={() => setPreviewActivityId(null)}
           title={previewActivity.title}
           subtitle={
             <>
@@ -937,7 +945,7 @@ export const VideoActivityManager: React.FC<VideoActivityManagerProps> = ({
             icon: Edit2,
             onClick: () => {
               const a = previewActivity;
-              setPreviewActivity(null);
+              setPreviewActivityId(null);
               onEdit(a);
             },
           }}
@@ -1604,10 +1612,13 @@ const VideoActivityPreviewPaneContent: React.FC<{
   const updated = activity.updatedAt
     ? new Date(activity.updatedAt).toLocaleDateString()
     : null;
-  // Extract the YouTube video id from common URL shapes (watch?v=…, youtu.be/…)
-  // so we can show the standard thumbnail. Returns null on anything we
-  // don't recognise — pane falls back to a neutral placeholder.
-  const youtubeId = extractYouTubeId(activity.youtubeUrl);
+  // Reuse the canonical YouTube-URL helper so the pane recognises the
+  // full URL set the Creator path accepts (watch?v=, youtu.be/, embed/,
+  // v/, shorts/, watch?…&v=). Returns null on anything else — pane
+  // falls back to a neutral placeholder.
+  const youtubeId = activity.youtubeUrl
+    ? extractYouTubeId(activity.youtubeUrl)
+    : null;
   return (
     <div className="flex flex-col gap-3 text-sm text-slate-700">
       {youtubeId ? (
@@ -1630,20 +1641,6 @@ const VideoActivityPreviewPaneContent: React.FC<{
     </div>
   );
 };
-
-function extractYouTubeId(url: string | undefined): string | null {
-  if (!url) return null;
-  try {
-    const u = new URL(url);
-    if (u.hostname === 'youtu.be') return u.pathname.slice(1) || null;
-    if (u.hostname.endsWith('youtube.com')) {
-      return u.searchParams.get('v');
-    }
-  } catch {
-    return null;
-  }
-  return null;
-}
 
 const VAStat: React.FC<{ label: string; value: string }> = ({
   label,

--- a/components/widgets/VideoActivityWidget/components/VideoActivityManager.tsx
+++ b/components/widgets/VideoActivityWidget/components/VideoActivityManager.tsx
@@ -112,6 +112,12 @@ export interface VideoActivityManagerProps {
    */
   onDuplicate?: (activity: VideoActivityMetadata) => void | Promise<void>;
   /**
+   * Optional busy-state probe. When provided, the Duplicate kebab item
+   * disables itself for any activity id whose duplicate is currently
+   * in-flight. Prevents rapid double-click → two identical copies.
+   */
+  isDuplicating?: (activityId: string) => boolean;
+  /**
    * Optional per-activity results view. New work prefers the assignment-
    * archive tab; kept for backwards-compatibility while the legacy Widget
    * still wires a per-activity session history modal.
@@ -399,6 +405,7 @@ export const VideoActivityManager: React.FC<VideoActivityManagerProps> = ({
   onEdit,
   onDelete,
   onDuplicate,
+  isDuplicating,
   onResults,
   onAssign,
   onReorderActivities,
@@ -833,7 +840,11 @@ export const VideoActivityManager: React.FC<VideoActivityManagerProps> = ({
               ? [
                   buildDuplicateAction(
                     activity,
-                    () => void onDuplicate(activity)
+                    () => void onDuplicate(activity),
+                    {
+                      disabled: isDuplicating?.(activity.id),
+                      disabledReason: 'Duplicating…',
+                    }
                   ),
                 ]
               : []),

--- a/hooks/useBusyIdSet.ts
+++ b/hooks/useBusyIdSet.ts
@@ -49,9 +49,12 @@ export function useBusyIdSet(): UseBusyIdSetResult {
   const [, forceSnapshot] = useState<ReadonlySet<string>>(busyRef.current);
 
   const commit = useCallback(() => {
-    // Replace the ref with a new Set instance so `isBusy` getter (which
-    // closes over the current snapshot) sees a fresh reference; React's
-    // re-render commits the state mirror.
+    // Replace the ref with a NEW Set instance before calling
+    // `forceSnapshot`. `useState` short-circuits on `Object.is` equality —
+    // passing the same Set reference wouldn't trigger the re-render that
+    // we need so consumers' `isBusy(id)` calls return the updated value.
+    // The clone is purely a re-render trigger; `isBusy` itself reads
+    // `busyRef.current` directly and doesn't depend on the snapshot.
     busyRef.current = new Set(busyRef.current);
     forceSnapshot(busyRef.current);
   }, []);

--- a/hooks/useBusyIdSet.ts
+++ b/hooks/useBusyIdSet.ts
@@ -1,0 +1,81 @@
+/**
+ * useBusyIdSet — small reusable busy-state tracker keyed by id.
+ *
+ * Originally extracted from the Phase 5 duplicate-kebab plumbing in the
+ * four library managers (Quiz / VideoActivity / MiniApp / Guided
+ * Learning), where the same shape was repeated 5 times: a Set<string>
+ * of in-flight ids, an `isBusy(id)` probe for disabling UI affordances,
+ * and an async wrapper that adds the id on entry and removes it in a
+ * `finally` arm.
+ *
+ * Contract:
+ *   - `isBusy(id)` is true while a `run(id, …)` call is in-flight.
+ *   - Calling `run(id, op)` while the same id is already in-flight is
+ *     a no-op (returns `undefined`, does NOT invoke `op`). This is the
+ *     rapid-double-click guard.
+ *   - `op` runs to completion (resolution OR rejection). The id is
+ *     ALWAYS removed in `finally`, even on rejection. The rejection
+ *     propagates to the caller so existing try/catch sites keep their
+ *     toasts/log paths.
+ *
+ * Implementation note: we keep TWO copies of the busy set — a ref that
+ * mutates synchronously (for the no-op-on-busy guard inside `run`) and
+ * a React state snapshot that drives re-renders (so `isBusy(id)` flips
+ * the disabled state on the kebab item). The ref check is synchronous
+ * so a rapid second `run(id)` call sees the in-flight id even before
+ * React commits the state update from the first call.
+ */
+
+import { useCallback, useRef, useState } from 'react';
+
+export interface UseBusyIdSetResult {
+  /** True iff the id is currently in-flight via `run`. */
+  isBusy: (id: string) => boolean;
+  /**
+   * Wrap an async operation. Adds `id` to the busy set before invoking
+   * `op`; removes it in `finally`. If the id is already in-flight,
+   * returns `undefined` without invoking `op` (rapid-click guard).
+   *
+   * Returns the result of `op` (or `undefined` for the guard path).
+   */
+  run: <T>(id: string, op: () => Promise<T>) => Promise<T | undefined>;
+}
+
+export function useBusyIdSet(): UseBusyIdSetResult {
+  // The ref is the source of truth for the no-op-on-busy check —
+  // synchronous reads and writes. The state mirror exists only so
+  // components re-render when busy-state changes.
+  const busyRef = useRef<Set<string>>(new Set());
+  const [, forceSnapshot] = useState<ReadonlySet<string>>(busyRef.current);
+
+  const commit = useCallback(() => {
+    // Replace the ref with a new Set instance so `isBusy` getter (which
+    // closes over the current snapshot) sees a fresh reference; React's
+    // re-render commits the state mirror.
+    busyRef.current = new Set(busyRef.current);
+    forceSnapshot(busyRef.current);
+  }, []);
+
+  const isBusy = useCallback((id: string) => busyRef.current.has(id), []);
+
+  const run = useCallback(
+    async <T>(id: string, op: () => Promise<T>): Promise<T | undefined> => {
+      // Synchronous read of the live set. React's `setState` updater
+      // doesn't run eagerly — checking `busyRef.current.has(id)` here
+      // is what prevents a rapid second call from sliding through
+      // before the first's state update commits.
+      if (busyRef.current.has(id)) return undefined;
+      busyRef.current.add(id);
+      commit();
+      try {
+        return await op();
+      } finally {
+        busyRef.current.delete(id);
+        commit();
+      }
+    },
+    [commit]
+  );
+
+  return { isBusy, run };
+}

--- a/hooks/useGuidedLearning.ts
+++ b/hooks/useGuidedLearning.ts
@@ -303,23 +303,33 @@ export const useGuidedLearning = (
    * Building-set duplicate. Firestore-only — no Drive rollback path
    * needed because the failure mode is a single `setDoc` rejection
    * with no orphan to clean up.
+   *
+   * Re-attributes `authorUid` to the current admin. The spread of
+   * `...source` would otherwise carry the original author's uid into
+   * the copy, which mis-attributes the audit trail and (since the
+   * project's user-deletion sweep checks authorUid) makes the copy
+   * appear as content owned by a possibly-since-deleted author.
+   * Storage image refs are shared with the source — matches the
+   * personal-set policy in `duplicateSet`.
    */
   const duplicateBuildingSet = useCallback(
     async (source: GuidedLearningSet): Promise<GuidedLearningSet> => {
       if (!isAdmin) throw new Error('Admin access required');
+      if (!userId) throw new Error('Not authenticated');
       const now = Date.now();
       const fresh: GuidedLearningSet = normalizeGuidedLearningSet({
         ...source,
         id: crypto.randomUUID(),
         title: suggestDuplicateTitle(source.title),
         isBuilding: true,
+        authorUid: userId,
         createdAt: now,
         updatedAt: now,
       });
       await setDoc(doc(db, BUILDING_GL_COLLECTION, fresh.id), fresh);
       return fresh;
     },
-    [isAdmin]
+    [isAdmin, userId]
   );
 
   const deleteBuildingSet = useCallback(

--- a/hooks/useGuidedLearning.ts
+++ b/hooks/useGuidedLearning.ts
@@ -62,6 +62,17 @@ export interface UseGuidedLearningResult {
   saveBuildingSet: (set: GuidedLearningSet) => Promise<void>;
   /** Delete an admin building set from Firestore */
   deleteBuildingSet: (setId: string) => Promise<void>;
+  /**
+   * Duplicate an admin building set. Mirrors `duplicateSet` for the
+   * Firestore-only building-set collection: clones the source's
+   * `GuidedLearningSet` directly into a new doc with a fresh id and a
+   * suggested title. No Drive involvement (building sets store full
+   * data inline in Firestore). Storage image refs are shared with the
+   * source — matches `duplicateSet`'s personal-set policy.
+   */
+  duplicateBuildingSet: (
+    source: GuidedLearningSet
+  ) => Promise<GuidedLearningSet>;
 }
 
 export const useGuidedLearning = (
@@ -288,6 +299,29 @@ export const useGuidedLearning = (
     [isAdmin]
   );
 
+  /**
+   * Building-set duplicate. Firestore-only — no Drive rollback path
+   * needed because the failure mode is a single `setDoc` rejection
+   * with no orphan to clean up.
+   */
+  const duplicateBuildingSet = useCallback(
+    async (source: GuidedLearningSet): Promise<GuidedLearningSet> => {
+      if (!isAdmin) throw new Error('Admin access required');
+      const now = Date.now();
+      const fresh: GuidedLearningSet = normalizeGuidedLearningSet({
+        ...source,
+        id: crypto.randomUUID(),
+        title: suggestDuplicateTitle(source.title),
+        isBuilding: true,
+        createdAt: now,
+        updatedAt: now,
+      });
+      await setDoc(doc(db, BUILDING_GL_COLLECTION, fresh.id), fresh);
+      return fresh;
+    },
+    [isAdmin]
+  );
+
   const deleteBuildingSet = useCallback(
     async (setId: string): Promise<void> => {
       if (!isAdmin) throw new Error('Admin access required');
@@ -307,6 +341,7 @@ export const useGuidedLearning = (
     loadSetData,
     deleteSet,
     duplicateSet,
+    duplicateBuildingSet,
     saveBuildingSet,
     deleteBuildingSet,
   };

--- a/hooks/useGuidedLearning.ts
+++ b/hooks/useGuidedLearning.ts
@@ -248,6 +248,10 @@ export const useGuidedLearning = (
           driveFileId: createdDriveFileId,
           createdAt: fresh.createdAt,
           updatedAt: fresh.updatedAt,
+          // Preserve folder placement on duplicate.
+          ...(source.folderId !== undefined
+            ? { folderId: source.folderId }
+            : {}),
         };
         await setDoc(
           doc(db, 'users', userId, GL_COLLECTION, fresh.id),

--- a/hooks/useQuiz.ts
+++ b/hooks/useQuiz.ts
@@ -456,10 +456,11 @@ export const useQuiz = (userId: string | undefined): UseQuizResult => {
   /**
    * Duplicate a quiz. Loads canonical content from the source's Drive
    * file, then writes a fresh quiz (new id, new Drive file, new title
-   * suffix). Does NOT inherit `folderId` or `sync` linkage — duplicates
-   * land at the library root as a standalone copy. Callers can pass the
-   * returned metadata to a follow-up `moveQuizToFolder` if they want to
-   * preserve folder placement.
+   * suffix). Preserves `folderId` when the source carries one — so a
+   * teacher who duplicates a quiz inside a folder sees the copy land
+   * in the same folder, matching their mental model. Does NOT inherit
+   * `sync` linkage (duplicates are private forks; PLC sharing is a
+   * separate explicit step).
    *
    * The write is hand-rolled (not via `saveQuiz`) so we can observe the
    * freshly-created `driveFileId` and roll it back if the Firestore
@@ -492,6 +493,12 @@ export const useQuiz = (userId: string | undefined): UseQuizResult => {
           questionCount: fresh.questions.length,
           createdAt: fresh.createdAt,
           updatedAt: fresh.updatedAt,
+          // Preserve folder placement. Setting folderId to undefined on
+          // a freshly-created doc is harmless (Firestore drops the
+          // field); reading it back yields the same shape.
+          ...(sourceMeta.folderId !== undefined
+            ? { folderId: sourceMeta.folderId }
+            : {}),
         };
         await setDoc(
           doc(db, 'users', userId, QUIZZES_COLLECTION, fresh.id),

--- a/hooks/useVideoActivity.ts
+++ b/hooks/useVideoActivity.ts
@@ -241,6 +241,10 @@ export const useVideoActivity = (
           questionCount: fresh.questions.length,
           createdAt: fresh.createdAt,
           updatedAt: fresh.updatedAt,
+          // Preserve folder placement on duplicate.
+          ...(source.folderId !== undefined
+            ? { folderId: source.folderId }
+            : {}),
         };
         await setDoc(
           doc(db, 'users', userId, VIDEO_ACTIVITIES_COLLECTION, fresh.id),

--- a/tests/components/LibraryItemCard.doubleClick.test.tsx
+++ b/tests/components/LibraryItemCard.doubleClick.test.tsx
@@ -17,7 +17,15 @@
  */
 
 import React from 'react';
-import { describe, it, expect, vi, beforeAll, afterEach } from 'vitest';
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeAll,
+  afterAll,
+  afterEach,
+} from 'vitest';
 import { render, screen, fireEvent, act } from '@testing-library/react';
 import { DndContext } from '@dnd-kit/core';
 import { SortableContext } from '@dnd-kit/sortable';
@@ -28,6 +36,14 @@ beforeAll(() => {
   // The card uses real timers via setTimeout; vitest's fake timers let
   // us assert the 250ms boundary without flaky `await new Promise`.
   vi.useFakeTimers();
+});
+
+afterAll(() => {
+  // Defensive — Vitest defaults to per-file isolation today so the
+  // beforeAll fake-timer install is automatically torn down between
+  // files, but if isolation is ever disabled for performance this
+  // explicit reset prevents fake timers from leaking into other suites.
+  vi.useRealTimers();
 });
 
 afterEach(() => {

--- a/tests/components/LibraryItemCard.doubleClick.test.tsx
+++ b/tests/components/LibraryItemCard.doubleClick.test.tsx
@@ -1,0 +1,133 @@
+/**
+ * Focused unit tests for `LibraryItemCard`'s Phase 5 follow-up
+ * `onDoubleClick` handling.
+ *
+ * The card uses a 250ms delay-and-cancel timer to disambiguate
+ * single-click (→ preview) from double-click (→ editor). A real
+ * dblclick fires onClick *and* onDoubleClick in sequence; without the
+ * delay the preview pane would flash open before the editor lands.
+ *
+ * Contract pinned here:
+ *   - Single click runs `onClick` after the 250ms window expires.
+ *   - Two clicks inside the window cancel the pending `onClick` and
+ *     fire `onDoubleClick` immediately.
+ *   - When `onDoubleClick` is omitted, `onClick` still runs
+ *     immediately (legacy callers unaffected).
+ *   - Clicks on nested buttons / links never reach the body handler.
+ */
+
+import React from 'react';
+import { describe, it, expect, vi, beforeAll, afterEach } from 'vitest';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import { DndContext } from '@dnd-kit/core';
+import { SortableContext } from '@dnd-kit/sortable';
+
+import { LibraryItemCard } from '@/components/common/library/LibraryItemCard';
+
+beforeAll(() => {
+  // The card uses real timers via setTimeout; vitest's fake timers let
+  // us assert the 250ms boundary without flaky `await new Promise`.
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.clearAllTimers();
+});
+
+function renderCard(opts: {
+  onClick?: () => void;
+  onDoubleClick?: () => void;
+}) {
+  const { onClick, onDoubleClick } = opts;
+  render(
+    <DndContext>
+      <SortableContext items={['card-1']}>
+        <LibraryItemCard
+          id="card-1"
+          title="Test card"
+          onClick={onClick}
+          onDoubleClick={onDoubleClick}
+          sortable={false}
+        />
+      </SortableContext>
+    </DndContext>
+  );
+}
+
+function clickBody() {
+  // The card body is the parent div that owns the click handler. We
+  // target the title text and bubble up — the card's handler is on the
+  // wrapping div, so any inner click reaches it via React's synthetic
+  // event delegation.
+  const title = screen.getByText('Test card');
+  fireEvent.click(title);
+}
+
+describe('LibraryItemCard onDoubleClick delay-and-cancel', () => {
+  it('fires single onClick after the 250ms window', () => {
+    const onClick = vi.fn();
+    const onDoubleClick = vi.fn();
+    renderCard({ onClick, onDoubleClick });
+
+    clickBody();
+    expect(onClick).not.toHaveBeenCalled(); // Pending the timer.
+
+    act(() => {
+      vi.advanceTimersByTime(249);
+    });
+    expect(onClick).not.toHaveBeenCalled();
+
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(onClick).toHaveBeenCalledOnce();
+    expect(onDoubleClick).not.toHaveBeenCalled();
+  });
+
+  it('cancels the pending onClick and fires onDoubleClick on a second click within 250ms', () => {
+    const onClick = vi.fn();
+    const onDoubleClick = vi.fn();
+    renderCard({ onClick, onDoubleClick });
+
+    clickBody();
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+    clickBody();
+
+    expect(onDoubleClick).toHaveBeenCalledOnce();
+    expect(onClick).not.toHaveBeenCalled();
+
+    // Advance past the original window — onClick should remain unfired.
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
+  it('runs onClick immediately (no delay) when onDoubleClick is omitted', () => {
+    const onClick = vi.fn();
+    renderCard({ onClick });
+
+    clickBody();
+    expect(onClick).toHaveBeenCalledOnce();
+  });
+
+  it('treats three rapid clicks as (double, single) — the third arms a new window', () => {
+    const onClick = vi.fn();
+    const onDoubleClick = vi.fn();
+    renderCard({ onClick, onDoubleClick });
+
+    clickBody();
+    clickBody(); // → dblclick fires; window cleared
+    clickBody(); // → new window opens
+
+    expect(onDoubleClick).toHaveBeenCalledOnce();
+    expect(onClick).not.toHaveBeenCalled();
+
+    act(() => {
+      vi.advanceTimersByTime(250);
+    });
+    expect(onClick).toHaveBeenCalledOnce();
+  });
+});

--- a/tests/hooks/useBusyIdSet.test.tsx
+++ b/tests/hooks/useBusyIdSet.test.tsx
@@ -42,7 +42,7 @@ describe('useBusyIdSet', () => {
     expect(result.current.isBusy('a')).toBe(false);
   });
 
-  it('rejects a concurrent run(id) call as a no-op (returns undefined, skips op)', async () => {
+  it('treats a concurrent run(id) call as a no-op — returns undefined without invoking op (does NOT reject)', async () => {
     const { result } = renderHook(() => useBusyIdSet());
     let resolveFirst!: () => void;
     const first = vi.fn(

--- a/tests/hooks/useBusyIdSet.test.tsx
+++ b/tests/hooks/useBusyIdSet.test.tsx
@@ -1,0 +1,130 @@
+/**
+ * `useBusyIdSet` — contract tests for the shared rapid-click guard
+ * extracted from the Phase 5 follow-up duplicate-kebab plumbing.
+ *
+ * What's pinned:
+ *   - `isBusy(id)` is true between `run()` invocation and resolution.
+ *   - A second `run(id, …)` while the first is in-flight is a no-op
+ *     (returns undefined, does NOT invoke `op`).
+ *   - The id is removed in `finally` even when `op` rejects.
+ *   - Rejections propagate to the caller of `run`.
+ *   - Different ids run independently (no global busy state).
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+
+import { useBusyIdSet } from '@/hooks/useBusyIdSet';
+
+describe('useBusyIdSet', () => {
+  it('flips isBusy(id) to true while op is in-flight and back to false on resolution', async () => {
+    const { result } = renderHook(() => useBusyIdSet());
+    let resolveOp!: () => void;
+    const op = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveOp = resolve;
+        })
+    );
+
+    let runPromise: Promise<unknown> | undefined;
+    act(() => {
+      runPromise = result.current.run('a', op);
+    });
+    expect(op).toHaveBeenCalledOnce();
+    expect(result.current.isBusy('a')).toBe(true);
+    expect(result.current.isBusy('other')).toBe(false);
+
+    await act(async () => {
+      resolveOp();
+      await runPromise;
+    });
+    expect(result.current.isBusy('a')).toBe(false);
+  });
+
+  it('rejects a concurrent run(id) call as a no-op (returns undefined, skips op)', async () => {
+    const { result } = renderHook(() => useBusyIdSet());
+    let resolveFirst!: () => void;
+    const first = vi.fn(
+      () =>
+        new Promise<string>((resolve) => {
+          resolveFirst = () => resolve('done-1');
+        })
+    );
+    const second = vi.fn().mockResolvedValue('done-2');
+
+    let firstPromise: Promise<unknown> | undefined;
+    act(() => {
+      firstPromise = result.current.run('a', first);
+    });
+    expect(first).toHaveBeenCalledOnce();
+
+    // Second call while first is in-flight should be a no-op.
+    let secondResult: unknown;
+    await act(async () => {
+      secondResult = await result.current.run('a', second);
+    });
+    expect(second).not.toHaveBeenCalled();
+    expect(secondResult).toBeUndefined();
+
+    // Drain the first so the test doesn't leak the promise.
+    await act(async () => {
+      resolveFirst();
+      await firstPromise;
+    });
+    expect(result.current.isBusy('a')).toBe(false);
+  });
+
+  it('clears the busy state in finally when op rejects, and rethrows', async () => {
+    const { result } = renderHook(() => useBusyIdSet());
+    const boom = new Error('boom');
+    const op = vi.fn().mockRejectedValue(boom);
+
+    let rejection: unknown;
+    await act(async () => {
+      try {
+        await result.current.run('a', op);
+      } catch (err) {
+        rejection = err;
+      }
+    });
+    expect(rejection).toBe(boom);
+    expect(result.current.isBusy('a')).toBe(false);
+  });
+
+  it('tracks different ids independently', async () => {
+    const { result } = renderHook(() => useBusyIdSet());
+    let resolveA!: () => void;
+    let resolveB!: () => void;
+    const opA = () =>
+      new Promise<void>((resolve) => {
+        resolveA = resolve;
+      });
+    const opB = () =>
+      new Promise<void>((resolve) => {
+        resolveB = resolve;
+      });
+
+    let pA: Promise<unknown> | undefined;
+    let pB: Promise<unknown> | undefined;
+    act(() => {
+      pA = result.current.run('a', opA);
+      pB = result.current.run('b', opB);
+    });
+    expect(result.current.isBusy('a')).toBe(true);
+    expect(result.current.isBusy('b')).toBe(true);
+
+    await act(async () => {
+      resolveA();
+      await pA;
+    });
+    expect(result.current.isBusy('a')).toBe(false);
+    expect(result.current.isBusy('b')).toBe(true);
+
+    await act(async () => {
+      resolveB();
+      await pB;
+    });
+    expect(result.current.isBusy('b')).toBe(false);
+  });
+});


### PR DESCRIPTION
Follow-up to #1587 — finishes all four items the previous PR explicitly deferred. Targets `dev-paul`. Each block is its own commit so reviewers can take them independently.

## Blocks shipped

### H — Busy guard on the Duplicate kebab
`feat(library): Duplicate busy guard + folderId preservation (Blocks H, I)`

Subagent silent-failure-hunter flagged that the 4 widget managers' Duplicate action had no in-flight protection: a rapid double-click fired the duplicate twice, both attempts computed the same `suggestDuplicateTitle()` output and burned 2× Drive API calls (Quiz/VA/GL) or 2× Firestore writes (MiniApp) for one teacher intent.

Plumbed an optional `isDuplicating: (id) => boolean` (`isDuplicatingPersonal` for GL) probe through each manager. Each host Widget tracks a `duplicatingIds: ReadonlySet<string>` state, adds the id on duplicate start, removes it in the finally arm. `buildDuplicateAction` already accepted `disabled` / `disabledReason` — the manager passes the busy state through, kebab renders the entry as disabled with a "Duplicating…" tooltip. The host's `onDuplicate` handler also guards an early-return on busy-id so a 60-fps user can't squeeze a second click through before React commits the disabled state.

### I — folderId preservation across the four duplicate paths
*(same commit as H)*

Code-reviewer subagent flagged that the four paths were inconsistent: Quiz/VA/GL coincidentally dropped `folderId` via `saveX()`'s metadata enumeration, while MiniApp's `...app` spread already preserved it. Aligned on "preserve folderId" — matches the MiniApp behavior, matches the user's mental model (duplicate-in-folder lands in the same folder). Doc comments on the hooks updated to reflect the new behavior.

### J — Admin Duplicate for GL building sets
`feat(guided-learning): admin Duplicate for building sets (Block J)`

Adds `duplicateBuildingSet(source)` to `useGuidedLearning`. Firestore-only (building sets store full data inline) so no Drive rollback needed. GuidedLearningManager gains an admin-gated Duplicate kebab item on building entries.

### F — Preview pane wiring + dblclick-to-edit across the four managers
`feat(library): preview pane wiring + dblclick-to-edit across 4 managers (Block F)`

The biggest piece. Each of the four library managers (Quiz / VA / MiniApp / GL) now opens a right-side `LibraryPreviewPane` on single-click of a card; double-click on the card bypasses the pane and opens the editor directly.

**Shared infra:** `LibraryItemCardProps` gains `onDoubleClick?: () => void`. `LibraryItemCard.handleBodyClick` now uses the standard 250ms delay-and-cancel pattern when both `onClick` and `onDoubleClick` are provided — a refs-based timer cleared on dblclick / unmount. Falls through to legacy "single-click runs immediately" when `onDoubleClick` is omitted, so every existing caller keeps its old behavior.

**Per-manager preview content:**

- **QuizManager**: stats-only pane (questions, created/updated, sync state). Secondary "Full preview" action routes to the existing heavyweight `onPreview` flow.
- **VideoActivityManager**: YouTube thumbnail extracted from `activity.youtubeUrl` + question count + dates. Neutral placeholder when the URL isn't a recognised YouTube shape.
- **MiniAppManager**: read-only sandboxed iframe (`sandbox="allow-scripts"`, no `allow-same-origin`) running the app's `srcDoc` HTML. Faithful glance at what students will see. Personal apps get an "Open editor" CTA; global apps get "Save to my library".
- **GuidedLearningManager**: first image thumbnail + step count + description + mode. Building-set rows show the pane for any user, but the "Open editor" CTA is gated on `isAdmin`.

Layout: each manager wraps its existing grid in a `flex-row` so the pane sits as a `shrink-0` sibling on the right and the grid stays `flex-1`. The pane's existing close button + Esc handling (from #1582) unmounts it.

### Tests
`test(library): pin the LibraryItemCard onDoubleClick delay-and-cancel contract`

4 cases with vitest fake timers asserting the 249ms / 250ms boundary precisely:
- single click → `onClick` fires after 250ms
- two clicks in <250ms → `onDoubleClick` fires, pending `onClick` cancelled
- no `onDoubleClick` prop → `onClick` runs immediately (legacy path)
- three rapid clicks → (dblclick, then a fresh single-click window)

## Validation gates

- `pnpm run validate` — clean ✅ (typecheck root + functions, lint `--max-warnings 0`, format:check, **226 root test files / 2353 tests**, 11 functions test files / 209 tests).

## Manual test plan

- [ ] In each of the four library managers, single-click a card → preview pane slides in from the right; the grid stays interactive. Click "Open editor" in the pane → editor opens.
- [ ] In each of the four library managers, double-click a card → editor opens directly with no pane flash.
- [ ] In Quiz, kebab → Preview (the existing entry) still routes to the full QuizPreview page.
- [ ] In MiniApp, single-click a personal app → pane shows the app rendered inside a sandbox iframe.
- [ ] In MiniApp, single-click a global app → pane shows the sandboxed runner and a "Save to my library" CTA instead of "Open editor".
- [ ] In Guided Learning, single-click a personal set → pane shows the first image + step count. As admin, single-click a building set → pane shows the same with the "Open editor" CTA. As non-admin, single-click a building set → pane shows but no edit CTA.
- [ ] In any manager, kebab → Duplicate → "Duplicating…" disabled state briefly visible. Rapid double-click on the kebab item does not produce two copies.
- [ ] Duplicate a card that's inside a folder → the copy lands in the same folder (Quiz/VA/GL/MiniApp).
- [ ] As admin in Guided Learning, kebab → Duplicate on a building set → a new building-set row appears with the bumped title.

## Out of scope (not deferred — explicitly out of scope here)

- `BulkActionBar` legacy → new `actions[]` API conversion: the legacy `onMove`/`onDelete` props don't have a like-for-like replacement in the new `actions[]` API (no popover support), so converting requires moving the folder-picker rendering into each manager. Not worth the diff size for zero functional gain — the legacy API is permanently supported in `BulkActionBar`.
- Stale-source duplicate when a synced quiz's canonical is ahead of the local Drive replica: edge case worth a separate decision (current behavior: duplicate captures local-state content).
- Touch resize manual smoke gate from #1587: physical-device check, not unit-testable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)