### PR TITLE
fix(functions): bump fetchExternalProxy memory + add CORS allowlist to callables

### DIFF
--- a/components/widgets/LunchCount/useNutrislice.ts
+++ b/components/widgets/LunchCount/useNutrislice.ts
@@ -270,13 +270,34 @@ export const useNutrislice = ({
     } catch (err) {
       logError('useNutrislice.fetchNutrislice', err, { widgetId });
 
+      const stamp = new Date().toISOString();
+      const errCode = (err as { code?: string } | null)?.code;
+
+      // Upstream returned 404 (no menu published for this date). Treat as a
+      // benign "no menu today" — install an empty menu and skip the toast so
+      // users on non-instructional days aren't spammed with errors.
+      if (errCode === 'functions/not-found') {
+        updateWidget(widgetId, {
+          config: {
+            ...configRef.current,
+            cachedMenu: buildEmptyMenu(
+              t('widgets.lunchCount.noHotLunch'),
+              t('widgets.lunchCount.noBentoBox'),
+              stamp
+            ),
+            syncError: null,
+            lastSyncDate: stamp,
+          },
+        });
+        return;
+      }
+
       // If we were trying to migrate a legacy-shape cache and the fetch
       // failed, install a non-legacy stub so the migration check flips to
       // false. Otherwise hasLegacyShape stays true and the effect would
       // re-fire fetchNutrislice on the next render — pegging the proxy
       // until the network recovers.
       const wasLegacy = isLegacyCachedMenu(configRef.current.cachedMenu);
-      const stamp = new Date().toISOString();
       updateWidget(widgetId, {
         config: {
           ...configRef.current,

--- a/functions/src/index.test.ts
+++ b/functions/src/index.test.ts
@@ -373,7 +373,8 @@ describe('fetchExternalProxy', () => {
     );
 
     expect(mockGet).toHaveBeenCalledWith(
-      'https://api.openweathermap.org/data/2.5/weather?q=London'
+      'https://api.openweathermap.org/data/2.5/weather?q=London',
+      { maxRedirects: 0 }
     );
     expect(result).toEqual({ temp: 72 });
   });
@@ -394,7 +395,8 @@ describe('fetchExternalProxy', () => {
     );
 
     expect(mockGet).toHaveBeenCalledWith(
-      'https://owc.enterprise.earthnetworks.com/Data/GetData.ashx?si=BLLST'
+      'https://owc.enterprise.earthnetworks.com/Data/GetData.ashx?si=BLLST',
+      { maxRedirects: 0 }
     );
     expect(result).toEqual({ o: { t: 72, ic: 0 } });
   });

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -339,6 +339,7 @@ export const getClassLinkRosterV1 = onCall(
       CLASSLINK_TENANT_URL,
     ],
     invoker: 'public',
+    cors: ALLOWED_ORIGINS,
   },
   async (request) => {
     if (!request.auth) {
@@ -459,6 +460,7 @@ export const generateWithAI = onCall(
   {
     memory: '512MiB',
     secrets: [GEMINI_API_KEY],
+    cors: ALLOWED_ORIGINS,
   },
   async (request) => {
     const data = request.data as AIData;
@@ -1037,8 +1039,9 @@ Output JSON ONLY in this exact shape:
 
 export const fetchExternalProxy = onCall(
   {
-    memory: '128MiB',
+    memory: '256MiB',
     timeoutSeconds: 30,
+    cors: ALLOWED_ORIGINS,
   },
   async (request) => {
     const data = request.data as { url: string };
@@ -1070,10 +1073,28 @@ export const fetchExternalProxy = onCall(
       const response = await axios.get<unknown>(data.url);
       return response.data;
     } catch (error: unknown) {
-      console.error('External Proxy Error:', error);
-      const msg =
-        error instanceof Error ? error.message : 'External fetch failed';
-      throw new HttpsError('internal', msg);
+      const axiosError = error as {
+        response?: { status?: number; data?: unknown };
+        message?: string;
+      };
+      const status = axiosError.response?.status;
+      console.error('External Proxy Error:', {
+        url: data.url,
+        status,
+        message: axiosError.message,
+        responseBody: axiosError.response?.data,
+      });
+      if (status === 404) {
+        throw new HttpsError(
+          'not-found',
+          `Upstream returned 404 for ${data.url}`
+        );
+      }
+      const msg = axiosError.message ?? 'External fetch failed';
+      throw new HttpsError(
+        'internal',
+        `Upstream ${status ?? 'unknown'}: ${msg}`
+      );
     }
   }
 );
@@ -1082,6 +1103,7 @@ export const archiveActivityWallPhoto = onCall(
   {
     memory: '512MiB',
     timeoutSeconds: 120,
+    cors: ALLOWED_ORIGINS,
   },
   async (request) => {
     const data = request.data as ArchiveActivityWallPhotoData;
@@ -1214,8 +1236,9 @@ export const archiveActivityWallPhoto = onCall(
 
 export const checkUrlCompatibility = onCall(
   {
-    memory: '128MiB',
+    memory: '256MiB',
     timeoutSeconds: 20,
+    cors: ALLOWED_ORIGINS,
   },
   async (request) => {
     const data = request.data as { url: string };
@@ -1341,6 +1364,7 @@ export const generateVideoActivity = onCall(
     memory: '1GiB',
     timeoutSeconds: 300,
     secrets: [GEMINI_API_KEY],
+    cors: ALLOWED_ORIGINS,
   },
   async (request): Promise<GeneratedVideoActivity> => {
     const data = request.data as VideoActivityRequestData;
@@ -1571,6 +1595,7 @@ export const transcribeVideoWithGemini = onCall(
     memory: '1GiB',
     timeoutSeconds: 300,
     secrets: [GEMINI_API_KEY],
+    cors: ALLOWED_ORIGINS,
   },
   async (request): Promise<GeneratedVideoActivity> => {
     const data = request.data as AudioTranscriptionRequestData;
@@ -1855,6 +1880,7 @@ export const generateGuidedLearning = onCall(
     memory: '512MiB',
     timeoutSeconds: 120,
     secrets: [GEMINI_API_KEY],
+    cors: ALLOWED_ORIGINS,
   },
   async (request) => {
     const data = request.data as {
@@ -2558,7 +2584,7 @@ export const studentLoginV1 = onCall(
  */
 export const getAssignmentPseudonymV1 = onCall(
   {
-    memory: '128MiB',
+    memory: '256MiB',
     secrets: [STUDENT_PSEUDONYM_HMAC_SECRET],
     invoker: 'public',
   },

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -1077,43 +1077,52 @@ export const fetchExternalProxy = onCall(
       const response = await axios.get<unknown>(data.url, { maxRedirects: 0 });
       return response.data;
     } catch (error: unknown) {
-      const axiosError = error as {
-        response?: { status?: number; data?: unknown };
-        message?: string;
-      };
-      const status = axiosError.response?.status;
-      // Summarise the response body instead of dumping it: upstream HTML
-      // error pages can be large and may contain sensitive content.
-      const rawBody = axiosError.response?.data;
-      const bodyPreview =
-        rawBody === undefined
-          ? undefined
-          : ((): { type: string; size: number; preview: string } => {
-              const str =
-                typeof rawBody === 'string' ? rawBody : JSON.stringify(rawBody);
-              return {
-                type: typeof rawBody,
-                size: str.length,
-                preview: str.slice(0, 200),
-              };
-            })();
-      console.error('External Proxy Error:', {
-        url: data.url,
-        status,
-        message: axiosError.message,
-        body: bodyPreview,
-      });
-      if (status === 404) {
+      if (axios.isAxiosError(error)) {
+        const status = error.response?.status;
+        // Summarise the response body instead of dumping it: upstream HTML
+        // error pages can be large and may contain sensitive content.
+        // AxiosResponse.data is typed `any`; narrow to `unknown` before use.
+        const rawBody: unknown = error.response?.data;
+        const bodyPreview =
+          rawBody === undefined
+            ? undefined
+            : ((): { type: string; size: number; preview: string } => {
+                const str =
+                  typeof rawBody === 'string'
+                    ? rawBody
+                    : JSON.stringify(rawBody);
+                return {
+                  type: typeof rawBody,
+                  size: str.length,
+                  preview: str.slice(0, 200),
+                };
+              })();
+        console.error('External Proxy Error:', {
+          url: data.url,
+          status,
+          message: error.message,
+          body: bodyPreview,
+        });
+        if (status === 404) {
+          throw new HttpsError(
+            'not-found',
+            `Upstream returned 404 for ${data.url}`
+          );
+        }
         throw new HttpsError(
-          'not-found',
-          `Upstream returned 404 for ${data.url}`
+          'internal',
+          `Upstream ${status ?? 'unknown'}: ${error.message}`
         );
       }
-      const msg = axiosError.message ?? 'External fetch failed';
-      throw new HttpsError(
-        'internal',
-        `Upstream ${status ?? 'unknown'}: ${msg}`
-      );
+
+      // Non-axios path: e.g. invalid response coercion, code defect, or
+      // anything thrown before/after the request itself.
+      const msg = error instanceof Error ? error.message : String(error);
+      console.error('External Proxy Error (non-axios):', {
+        url: data.url,
+        message: msg,
+      });
+      throw new HttpsError('internal', `Proxy failed: ${msg}`);
     }
   }
 );

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -1070,7 +1070,11 @@ export const fetchExternalProxy = onCall(
     }
 
     try {
-      const response = await axios.get<unknown>(data.url);
+      // Disable redirects entirely: the URL allowlist check above only
+      // validates the initial host, so a 3xx Location pointing off-allowlist
+      // would otherwise let us fetch arbitrary URLs. None of our three
+      // upstream APIs need redirects in practice.
+      const response = await axios.get<unknown>(data.url, { maxRedirects: 0 });
       return response.data;
     } catch (error: unknown) {
       const axiosError = error as {
@@ -1078,11 +1082,26 @@ export const fetchExternalProxy = onCall(
         message?: string;
       };
       const status = axiosError.response?.status;
+      // Summarise the response body instead of dumping it: upstream HTML
+      // error pages can be large and may contain sensitive content.
+      const rawBody = axiosError.response?.data;
+      const bodyPreview =
+        rawBody === undefined
+          ? undefined
+          : ((): { type: string; size: number; preview: string } => {
+              const str =
+                typeof rawBody === 'string' ? rawBody : JSON.stringify(rawBody);
+              return {
+                type: typeof rawBody,
+                size: str.length,
+                preview: str.slice(0, 200),
+              };
+            })();
       console.error('External Proxy Error:', {
         url: data.url,
         status,
         message: axiosError.message,
-        responseBody: axiosError.response?.data,
+        body: bodyPreview,
       });
       if (status === 404) {
         throw new HttpsError(
@@ -2364,6 +2383,7 @@ export const studentLoginV1 = onCall(
   {
     memory: '256MiB',
     minInstances: 1,
+    cors: ALLOWED_ORIGINS,
     secrets: [
       CLASSLINK_CLIENT_ID,
       CLASSLINK_CLIENT_SECRET,
@@ -2587,6 +2607,7 @@ export const getAssignmentPseudonymV1 = onCall(
     memory: '256MiB',
     secrets: [STUDENT_PSEUDONYM_HMAC_SECRET],
     invoker: 'public',
+    cors: ALLOWED_ORIGINS,
   },
   (request) => {
     if (!request.auth) {
@@ -2648,6 +2669,7 @@ export const getStudentClassDirectoryV1 = onCall(
   {
     memory: '256MiB',
     invoker: 'public',
+    cors: ALLOWED_ORIGINS,
   },
   async (request) => {
     if (!request.auth) {
@@ -2863,6 +2885,7 @@ export const getPseudonymsForAssignmentV1 = onCall(
   {
     memory: '256MiB',
     minInstances: 1,
+    cors: ALLOWED_ORIGINS,
     secrets: [
       CLASSLINK_CLIENT_ID,
       CLASSLINK_CLIENT_SECRET,
@@ -3196,6 +3219,7 @@ export const commitRosterPinIndexV1 = onCall(
     memory: '256MiB',
     secrets: [STUDENT_PSEUDONYM_HMAC_SECRET],
     invoker: 'public',
+    cors: ALLOWED_ORIGINS,
   },
   async (request) => {
     if (!request.auth) {
@@ -3395,6 +3419,7 @@ export const pinLoginV1 = onCall(
     memory: '256MiB',
     secrets: [STUDENT_PSEUDONYM_HMAC_SECRET],
     invoker: 'public',
+    cors: ALLOWED_ORIGINS,
   },
   async (request) => {
     const data = (request.data ?? {}) as PinLoginRequestData;


### PR DESCRIPTION
## Summary

- **Bumps `fetchExternalProxy` from 128MiB → 256MiB** to fix cold-start OOMs surfacing as "Failed to sync" toasts on the Lunch Count widget. Cloud Run logs confirmed `Memory limit of 128 MiB exceeded with 142 MiB used` after the May 12 `firebase-functions` 7.0.5 → 7.2.5 bump — the container never reached its startup probe, so requests failed before the handler ran (surfacing as a generic `FirebaseError: internal` plus a preflight CORS error that's actually downstream of the OOM).
- **Wires `ALLOWED_ORIGINS` into every user-facing `onCall`** so Firebase Hosting preview-channel origins (`spartboard--<branch>-*.web.app`) can reach them. This was a separate latent bug — under `firebase-functions@^7.2.5`, v2 callables don't auto-allow preview hostnames.
- **Improves `fetchExternalProxy`'s axios catch** to log URL/status/body and map upstream `404 → HttpsError('not-found')` so the client can distinguish "no menu today" from genuine outages.
- **Quiets the Lunch Count toast on `functions/not-found`** — write `buildEmptyMenu`, clear `syncError`, and skip the toast so users on non-instructional days aren't spammed.

Also bumps the only other 128 MiB user-facing callables (`checkUrlCompatibility`, `getAssignmentPseudonymV1`) to 256 MiB so they don't bite us next.

## Root cause investigation

Confirmed from Cloud Logging (`firebase functions:log --only fetchExternalProxy`):

```
'Memory limit of 128 MiB exceeded with 142 MiB used. Consider increasing the memory limit'
Default STARTUP TCP probe failed 1 time consecutively for container "worker" on port 8080.
  The instance was not started. Connection failed with status CANCELLED.
The request failed because the instance could not start successfully.
```

Cross-checked against the reporting user (megan.ringsred@orono.k12.mn.us): building assignment, school-site slug, and Firebase Auth state were all correct, and yesterday's `cachedMenu` (2026-05-11) proved the function worked before the deploy. Generic `GET https://orono.api.nutrislice.com/.../2026/05/12/` returned HTTP 200 from public internet — Nutrislice was fine; only the Cloud Function was dead.

## Test plan

- [x] `pnpm run type-check:all` — clean (root + functions)
- [x] `pnpm run test` — 225 files / 2349 tests pass
- [x] `pnpm -C functions run test` — 11 files / 209 tests pass
- [ ] After squash-merge to `dev-paul`, watch `firebase functions:log --only fetchExternalProxy --lines 100 --project spartboard` and confirm no more `Memory limit ... exceeded` or `Default STARTUP TCP probe failed` lines
- [ ] On `https://spartboard--dev-paul-*.web.app`: add a Lunch Count widget → menu renders, no error toast; check Network → `fetchExternalProxy` returns 200 with `Access-Control-Allow-Origin` matching origin
- [ ] Weather Settings → "Refresh Station" in Earth Networks mode works
- [ ] `[AdminWeatherFetcher] Cloud Proxy failed` is gone from the console
- [ ] After regular-merge to `main` (per dev-paul → main convention): refresh `https://spartboard.web.app`, confirm Megan's `syncError` clears on next sync and `cachedMenu` updates to today's date

🤖 Generated with [Claude Code](https://claude.com/claude-code)