### PR TITLE
feat(admin-analytics): cold-start vs fatal UI, partial-data signal, logError

### DIFF
--- a/components/admin/Analytics/AnalyticsManager.tsx
+++ b/components/admin/Analytics/AnalyticsManager.tsx
@@ -19,6 +19,7 @@ import {
 import { auth } from '@/config/firebase';
 import {
   AlertCircle,
+  AlertTriangle,
   ArrowDownUp,
   ArrowUp,
   ArrowDown,
@@ -26,6 +27,7 @@ import {
   ChevronDown,
   ChevronUp,
   Clock,
+  Info,
   LayoutGrid,
   School,
   Search,
@@ -33,6 +35,7 @@ import {
   WandSparkles,
   Zap,
 } from 'lucide-react';
+import { logError } from '@/utils/logError';
 import { Modal } from '@/components/common/Modal';
 import { useAdminBuildings } from '@/hooks/useAdminBuildings';
 import { useAuth } from '@/context/useAuth';
@@ -106,12 +109,28 @@ interface AnalyticsData {
   // computes the analytics once a day; these timestamps drive the
   // "Last updated · Next update at" badge so the admin understands they're
   // looking at a cached read rather than a live aggregate.
+  //
+  // `partial` is set when one or more chunks of `auth().getUsers()` failed
+  // during compute; the counts that depend on email/uid resolution will be
+  // lower than reality. Admins need to see this signal before drawing
+  // conclusions from a daily snapshot.
   meta?: {
     computedAt: number;
     nextRecomputeAt: number;
     computeDurationMs: number;
+    partial?: boolean;
   };
 }
+
+/**
+ * Failure shape returned by the `/api/admin-analytics` endpoint. The
+ * `cold-start` kind is a benign state (the daily scheduler hasn't run for
+ * this org yet) and renders as a calm informational notice; `fatal` is a
+ * real error and renders as a red banner.
+ */
+type AnalyticsErrorState =
+  | { kind: 'cold-start'; message: string }
+  | { kind: 'fatal'; message: string };
 
 type AnalyticsTab = 'overview' | 'widgets' | 'ai' | 'users';
 
@@ -1483,7 +1502,7 @@ export const AnalyticsManager: React.FC = () => {
   const { orgId } = useAuth();
   const [loading, setLoading] = useState(true);
   const [data, setData] = useState<AnalyticsData | null>(null);
-  const [error, setError] = useState<string | null>(null);
+  const [error, setError] = useState<AnalyticsErrorState | null>(null);
   const [selectedTab, setSelectedTab] = useState<AnalyticsTab>('overview');
   const [selectedDomain, setSelectedDomain] = useState('all');
   const [selectedBuilding, setSelectedBuilding] = useState('all');
@@ -1514,9 +1533,11 @@ export const AnalyticsManager: React.FC = () => {
       if (isMountedRef.current) {
         setLoading(false);
         setData(null);
-        setError(
-          'No organization selected. Analytics require an active organization.'
-        );
+        setError({
+          kind: 'fatal',
+          message:
+            'No organization selected. Analytics require an active organization.',
+        });
       }
       return;
     }
@@ -1546,11 +1567,20 @@ export const AnalyticsManager: React.FC = () => {
           error?: string;
         };
         // 503 + `not-yet-computed` is the server's signal for "this org has
-        // no snapshot yet — wait for the next scheduled refresh." Surface it
-        // verbatim so the admin sees a clear "not ready" state rather than
-        // a generic error banner; the message body already contains the
-        // user-facing copy ("ready at 5:00 AM Central daily").
+        // no snapshot yet — wait for the next scheduled refresh." This is a
+        // benign state for a freshly-onboarded org; render a calm "scheduled
+        // refresh is on its way" notice instead of the red error banner.
         const msg = body.message ?? body.error ?? `HTTP ${response.status}`;
+        if (response.status === 503 && body.error === 'not-yet-computed') {
+          if (
+            isMountedRef.current &&
+            requestId === requestSequenceRef.current
+          ) {
+            setData(null);
+            setError({ kind: 'cold-start', message: msg });
+          }
+          return;
+        }
         throw new Error(msg);
       }
 
@@ -1597,15 +1627,17 @@ export const AnalyticsManager: React.FC = () => {
       }
       setData(normalized);
     } catch (err: unknown) {
-      console.error('Failed to load analytics', err);
+      logError('AnalyticsManager.fetch', err, { orgId });
       if (!isMountedRef.current || requestId !== requestSequenceRef.current) {
         return;
       }
-      setError(
-        err instanceof Error
-          ? err.message
-          : 'An error occurred loading analytics data'
-      );
+      setError({
+        kind: 'fatal',
+        message:
+          err instanceof Error
+            ? err.message
+            : 'An error occurred loading analytics data',
+      });
     } finally {
       if (isMountedRef.current && requestId === requestSequenceRef.current) {
         setLoading(false);
@@ -1746,12 +1778,29 @@ export const AnalyticsManager: React.FC = () => {
   }
 
   if (error) {
+    if (error.kind === 'cold-start') {
+      // Benign state — the daily scheduler hasn't computed a snapshot for
+      // this org yet. The server's message already contains the user-facing
+      // copy ("ready at 5:00 AM Central daily"); render it in a calm slate
+      // surface, not red.
+      return (
+        <div className="bg-slate-50 border border-slate-200 text-slate-700 p-6 rounded-2xl flex items-start gap-3">
+          <Info className="w-6 h-6 shrink-0 mt-0.5 text-slate-400" />
+          <div>
+            <h3 className="font-bold mb-1 text-slate-900">
+              Analytics not ready yet
+            </h3>
+            <p className="text-sm">{error.message}</p>
+          </div>
+        </div>
+      );
+    }
     return (
       <div className="bg-red-50 border border-red-200 text-red-800 p-6 rounded-2xl flex items-start gap-3">
         <AlertCircle className="w-6 h-6 shrink-0 mt-0.5" />
         <div>
           <h3 className="font-bold mb-1">Failed to Load Analytics</h3>
-          <p className="text-sm">{error}</p>
+          <p className="text-sm">{error.message}</p>
         </div>
       </div>
     );
@@ -1761,6 +1810,27 @@ export const AnalyticsManager: React.FC = () => {
 
   return (
     <div className="space-y-5 pb-12">
+      {data.meta?.partial && (
+        // Amber banner — counts are real but the compute hit one or more
+        // chunks where `auth().getUsers()` failed, so engagement totals
+        // are under-counted. Admins need to know this before drawing
+        // conclusions from the snapshot. The next scheduled refresh will
+        // re-run the auth lookups and (hopefully) clear the flag.
+        <div
+          role="status"
+          className="bg-amber-50 border border-amber-200 text-amber-900 p-4 rounded-2xl flex items-start gap-3"
+        >
+          <AlertTriangle className="w-5 h-5 shrink-0 mt-0.5 text-amber-600" />
+          <div>
+            <h3 className="font-semibold mb-0.5">Partial data</h3>
+            <p className="text-sm">
+              Some user data couldn&apos;t be loaded during the last compute.
+              Counts may be lower than actual. The next scheduled refresh should
+              clear this.
+            </p>
+          </div>
+        </div>
+      )}
       <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-3">
         <div className="flex flex-wrap gap-2">
           <select

--- a/functions/src/adminAnalyticsCompute.ts
+++ b/functions/src/adminAnalyticsCompute.ts
@@ -46,6 +46,14 @@ export interface AdminAnalyticsPayload {
     avgDailyCallsPerUser: number;
     byFeature: Record<string, number>;
   };
+  // Compute-time signals. `partial` is set when one or more
+  // `auth().getUsers()` chunks failed during compute — the engagement
+  // counts that depend on email/uid resolution will be lower than reality.
+  // The HTTP handler merges this into the response meta so the UI can
+  // surface a "some counts may be lower than actual" banner.
+  meta?: {
+    partial?: boolean;
+  };
 }
 
 interface EngagementCounts {
@@ -89,6 +97,12 @@ export async function computeAnalyticsForOrg(
 ): Promise<AdminAnalyticsPayload> {
   const db = admin.firestore();
   const now = Date.now();
+
+  // Tracks whether any `auth().getUsers()` chunk silently failed. The
+  // compute continues so a single bad chunk doesn't drop a fresh snapshot,
+  // but the response carries this flag so admins know the totals may be
+  // under-counted.
+  let partial = false;
 
   // 1. Load the org's members as the authoritative user roster. Members
   // without a `uid` (invited but never signed in) still count toward totals
@@ -144,6 +158,7 @@ export async function computeAnalyticsForOrg(
           });
         }
       } catch (err) {
+        partial = true;
         console.warn('[getAdminAnalytics] auth().getUsers() chunk failed', {
           ...logContext,
           orgId,
@@ -355,6 +370,7 @@ export async function computeAnalyticsForOrg(
             }
           });
         } catch (error) {
+          partial = true;
           console.warn(
             `[getAdminAnalytics] Failed to resolve user emails via auth fallback for ${warningContext}`,
             {
@@ -553,5 +569,9 @@ export async function computeAnalyticsForOrg(
       avgDailyCallsPerUser,
       byFeature: aiCallsByFeature,
     },
+    // Only emit `meta` when something noteworthy happened during compute —
+    // keeps the snapshot payload identical to the previous shape for the
+    // common all-chunks-succeeded path.
+    ...(partial ? { meta: { partial: true } } : {}),
   };
 }

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -2201,9 +2201,11 @@ export const adminAnalytics = onRequest(
         return;
       }
 
+      const { meta: payloadMeta, ...payloadWithoutMeta } = snapshot.payload;
       res.json({
-        ...snapshot.payload,
+        ...payloadWithoutMeta,
         meta: {
+          ...(payloadMeta ?? {}),
           computedAt: snapshot.computedAt,
           nextRecomputeAt: snapshot.nextRecomputeAt,
           computeDurationMs: snapshot.computeDurationMs,


### PR DESCRIPTION
## Summary

Three deferred polish items from PR #1583's review feedback.

- **Cold-start vs fatal**: AnalyticsManager now treats 503 with `error: 'not-yet-computed'` as a benign state (the daily scheduler hasn't run for this org yet) and renders a calm "Analytics not ready yet" notice instead of the red error banner. The server message already explains the 5 AM Central cadence.
- **Partial-data signal**: `computeAnalyticsForOrg` already swallowed per-chunk `auth().getUsers()` failures silently. Now it tracks a `partial: true` flag, plumbed through the snapshot payload's `meta` into the HTTP response meta, and rendered as an amber banner above the KPIs so admins know totals may be under-counted before drawing conclusions.
- **logError migration**: `console.error('Failed to load analytics', err)` → `logError('AnalyticsManager.fetch', err, { orgId })` to match the convention used in `PlcQuizLibraryBody.tsx`.

The `error` state type is now a discriminated union (`{ kind: 'cold-start' | 'fatal'; message: string } | null`) so the render path can branch cleanly.

## Test plan

- [x] `pnpm run validate` passes (227/2357 root, 11/209 functions — baseline unchanged)
- [ ] Manual: visit admin analytics on a freshly-onboarded org (or stub the fetch to return 503 + `not-yet-computed`) — confirm the calm slate notice renders instead of the red banner
- [ ] Manual: simulate a `meta.partial: true` response and confirm the amber banner appears above the KPIs
- [ ] After merge to `dev-paul`: visit the dev preview URL and verify nothing regressed for the normal happy path

🤖 Generated with [Claude Code](https://claude.com/claude-code)