### PR TITLE
feat(plc): fully-fledged PLC Dashboard — Phase 4 + Phase 6 + UX polish

### DIFF
--- a/components/plc/PlcDashboard.tsx
+++ b/components/plc/PlcDashboard.tsx
@@ -28,12 +28,14 @@ import { PlcSettingsTab } from './tabs/PlcSettingsTab';
 import { PlcNotesTab } from './tabs/PlcNotesTab';
 import { PlcTodosTab } from './tabs/PlcTodosTab';
 import { PlcQuizLibraryTab } from './tabs/PlcQuizLibraryTab';
+import { PlcVideoActivitiesTab } from './tabs/PlcVideoActivitiesTab';
 import { PlcPlaceholderTab } from './tabs/PlcPlaceholderTab';
 import { NotesBody } from './bodies/NotesBody';
 import { TodosBody } from './bodies/TodosBody';
 import { PlcAnalyticsBody } from './bodies/PlcAnalyticsBody';
 import { MembersBody } from './bodies/MembersBody';
 import { PlcQuizLibraryBody } from './bodies/PlcQuizLibraryBody';
+import { PlcVideoActivitiesBody } from './bodies/PlcVideoActivitiesBody';
 import { PlcAssignmentsBody } from './bodies/PlcAssignmentsBody';
 
 interface PlcDashboardProps {
@@ -92,11 +94,6 @@ const TABS: readonly TabDef[] = [
     labelKey: 'plcDashboard.tabs.videoActivities',
     labelDefault: 'Video Activities',
     feature: 'videoActivities',
-    placeholder: {
-      titleDefault: 'PLC Video Activities',
-      descriptionDefault:
-        'Share video-based activities with your PLC and aggregate completion data alongside quizzes.',
-    },
   },
   {
     id: 'notes',
@@ -219,6 +216,9 @@ export const PlcDashboard: React.FC<PlcDashboardProps> = ({ plc, onClose }) => {
     if (tab.id === 'quizzes') {
       return <PlcQuizLibraryTab plc={plc} />;
     }
+    if (tab.id === 'videoActivities') {
+      return <PlcVideoActivitiesTab plc={plc} />;
+    }
     if (tab.id === 'assignments') {
       return <PlcAssignmentsTab plc={plc} onCloseDashboard={onClose} />;
     }
@@ -249,6 +249,8 @@ export const PlcDashboard: React.FC<PlcDashboardProps> = ({ plc, onClose }) => {
         return <TodosBody plc={plc} />;
       case 'quizLibrary':
         return <PlcQuizLibraryBody plc={plc} />;
+      case 'videoActivities':
+        return <PlcVideoActivitiesBody plc={plc} />;
       case 'activeAssignments':
         return <PlcAssignmentsBody plc={plc} onCloseDashboard={onClose} />;
       case 'completedAssignments':
@@ -268,6 +270,10 @@ export const PlcDashboard: React.FC<PlcDashboardProps> = ({ plc, onClose }) => {
         return t('plcDashboard.tabs.todos', { defaultValue: 'To-Do List' });
       case 'quizLibrary':
         return t('plcDashboard.tabs.quizzes', { defaultValue: 'Quiz Library' });
+      case 'videoActivities':
+        return t('plcDashboard.tabs.videoActivities', {
+          defaultValue: 'Video Activities',
+        });
       case 'activeAssignments':
         return t('plcDashboard.tabs.assignments', {
           defaultValue: 'PLC Assignments',

--- a/components/plc/PlcDashboard.tsx
+++ b/components/plc/PlcDashboard.tsx
@@ -29,6 +29,7 @@ import { PlcNotesTab } from './tabs/PlcNotesTab';
 import { PlcTodosTab } from './tabs/PlcTodosTab';
 import { PlcQuizLibraryTab } from './tabs/PlcQuizLibraryTab';
 import { PlcVideoActivitiesTab } from './tabs/PlcVideoActivitiesTab';
+import { PlcSharedBoardsTab } from './tabs/PlcSharedBoardsTab';
 import { PlcPlaceholderTab } from './tabs/PlcPlaceholderTab';
 import { NotesBody } from './bodies/NotesBody';
 import { TodosBody } from './bodies/TodosBody';
@@ -36,6 +37,7 @@ import { PlcAnalyticsBody } from './bodies/PlcAnalyticsBody';
 import { MembersBody } from './bodies/MembersBody';
 import { PlcQuizLibraryBody } from './bodies/PlcQuizLibraryBody';
 import { PlcVideoActivitiesBody } from './bodies/PlcVideoActivitiesBody';
+import { PlcSharedBoardsBody } from './bodies/PlcSharedBoardsBody';
 import { PlcAssignmentsBody } from './bodies/PlcAssignmentsBody';
 
 interface PlcDashboardProps {
@@ -115,10 +117,6 @@ const TABS: readonly TabDef[] = [
     labelKey: 'plcDashboard.tabs.sharedBoards',
     labelDefault: 'Shared Boards',
     feature: 'sharedBoards',
-    placeholder: {
-      titleDefault: 'Shared Boards',
-      descriptionDefault: 'Dashboards shared with this PLC will surface here.',
-    },
   },
   {
     id: 'settings',
@@ -219,6 +217,9 @@ export const PlcDashboard: React.FC<PlcDashboardProps> = ({ plc, onClose }) => {
     if (tab.id === 'videoActivities') {
       return <PlcVideoActivitiesTab plc={plc} />;
     }
+    if (tab.id === 'sharedBoards') {
+      return <PlcSharedBoardsTab plc={plc} />;
+    }
     if (tab.id === 'assignments') {
       return <PlcAssignmentsTab plc={plc} onCloseDashboard={onClose} />;
     }
@@ -251,6 +252,8 @@ export const PlcDashboard: React.FC<PlcDashboardProps> = ({ plc, onClose }) => {
         return <PlcQuizLibraryBody plc={plc} />;
       case 'videoActivities':
         return <PlcVideoActivitiesBody plc={plc} />;
+      case 'sharedBoards':
+        return <PlcSharedBoardsBody plc={plc} />;
       case 'activeAssignments':
         return <PlcAssignmentsBody plc={plc} onCloseDashboard={onClose} />;
       case 'completedAssignments':
@@ -273,6 +276,10 @@ export const PlcDashboard: React.FC<PlcDashboardProps> = ({ plc, onClose }) => {
       case 'videoActivities':
         return t('plcDashboard.tabs.videoActivities', {
           defaultValue: 'Video Activities',
+        });
+      case 'sharedBoards':
+        return t('plcDashboard.tabs.sharedBoards', {
+          defaultValue: 'Shared Boards',
         });
       case 'activeAssignments':
         return t('plcDashboard.tabs.assignments', {

--- a/components/plc/PlcVideoActivityImportModal.tsx
+++ b/components/plc/PlcVideoActivityImportModal.tsx
@@ -1,0 +1,133 @@
+/**
+ * PlcVideoActivityImportModal — picker shown when a teacher clicks "Add
+ * to my library" on a row in the PLC Video Activities tab. Lets them
+ * choose:
+ *
+ *  - Sync — joins the canonical synced group; future edits by any PLC
+ *    member appear on this teacher's library card with a Sync available
+ *    pill, and their own edits publish back to the group.
+ *
+ *  - Make a copy — frozen one-time snapshot, identical to the legacy
+ *    `importSharedVideoActivity` behavior. Use when the teacher wants
+ *    to fork.
+ *
+ * Mirrors `PlcQuizImportModal.tsx` exactly (same Modal primitive, same
+ * two ModeOption buttons, same copy patterns) so the UX is consistent
+ * across PLC entry points.
+ */
+
+import React from 'react';
+import { Cloud, Copy, X } from 'lucide-react';
+import { Modal } from '@/components/common/Modal';
+import type { SharedVideoActivityImportMode } from '@/hooks/useVideoActivityAssignments';
+
+interface PlcVideoActivityImportModalProps {
+  /** Title of the PLC video activity being imported. */
+  activityTitle: string;
+  /** Optional originator name (the teacher who first shared the activity). */
+  sharedByName?: string;
+  onPick: (mode: SharedVideoActivityImportMode) => void;
+  onClose: () => void;
+}
+
+interface ModeOptionProps {
+  mode: SharedVideoActivityImportMode;
+  title: string;
+  body: string;
+  Icon: React.ComponentType<{ className?: string }>;
+  recommended?: boolean;
+  onPick: (mode: SharedVideoActivityImportMode) => void;
+}
+
+const ModeOption: React.FC<ModeOptionProps> = ({
+  mode,
+  title,
+  body,
+  Icon,
+  recommended,
+  onPick,
+}) => (
+  <button
+    type="button"
+    onClick={() => onPick(mode)}
+    className="w-full text-left rounded-xl border border-slate-200 bg-white px-4 py-4 transition-all hover:border-brand-blue-primary hover:shadow-md focus:outline-none focus:ring-2 focus:ring-brand-blue-primary/40"
+  >
+    <div className="flex items-start gap-3">
+      <div className="shrink-0 w-10 h-10 rounded-lg bg-brand-blue-lighter/40 text-brand-blue-primary flex items-center justify-center">
+        <Icon className="w-5 h-5" />
+      </div>
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-2">
+          <h3 className="font-bold text-slate-900 text-sm">{title}</h3>
+          {recommended && (
+            <span className="rounded-full bg-emerald-100 px-2 py-0.5 text-[10px] font-bold uppercase tracking-wider text-emerald-700">
+              Recommended for PLCs
+            </span>
+          )}
+        </div>
+        <p className="mt-1 text-xs text-slate-600 leading-relaxed">{body}</p>
+      </div>
+    </div>
+  </button>
+);
+
+export const PlcVideoActivityImportModal: React.FC<
+  PlcVideoActivityImportModalProps
+> = ({ activityTitle, sharedByName, onPick, onClose }) => {
+  return (
+    <Modal
+      isOpen
+      onClose={onClose}
+      ariaLabel="Choose how to import this video activity"
+      maxWidth="max-w-md"
+      contentClassName=""
+      customHeader={
+        <div className="flex items-start justify-between px-5 pt-5 pb-3 border-b border-slate-100">
+          <div className="flex items-start gap-3">
+            <div className="shrink-0 w-9 h-9 rounded-lg bg-brand-blue-lighter/40 text-brand-blue-primary flex items-center justify-center">
+              <Cloud className="w-5 h-5" />
+            </div>
+            <div>
+              <h2 className="text-base font-bold text-slate-900">
+                Add to my library
+              </h2>
+              <p className="text-xs text-slate-500 mt-0.5 truncate max-w-[20rem]">
+                {activityTitle}
+                {sharedByName ? ` · shared by ${sharedByName}` : ''}
+              </p>
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close"
+            className="shrink-0 rounded-lg p-1 text-slate-400 hover:bg-slate-100 hover:text-slate-700 transition-colors"
+          >
+            <X className="w-5 h-5" />
+          </button>
+        </div>
+      }
+    >
+      <div className="px-5 pb-5 pt-4 space-y-3">
+        <p className="text-xs text-slate-600">
+          How should this video activity be imported into your library?
+        </p>
+        <ModeOption
+          mode="sync"
+          title="Synced"
+          body="Stay connected to the PLC version. Any teacher in the synced group can edit, and changes show up on everyone's library card with a Sync available pill."
+          Icon={Cloud}
+          recommended
+          onPick={onPick}
+        />
+        <ModeOption
+          mode="copy"
+          title="Make a copy"
+          body="Take a frozen snapshot. Future edits by other PLC members will not appear in your copy, and your edits stay private."
+          Icon={Copy}
+          onPick={onPick}
+        />
+      </div>
+    </Modal>
+  );
+};

--- a/components/plc/PlcVideoActivityImportModal.tsx
+++ b/components/plc/PlcVideoActivityImportModal.tsx
@@ -17,6 +17,7 @@
  */
 
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 import { Cloud, Copy, X } from 'lucide-react';
 import { Modal } from '@/components/common/Modal';
 import type { SharedVideoActivityImportMode } from '@/hooks/useVideoActivityAssignments';
@@ -36,6 +37,7 @@ interface ModeOptionProps {
   body: string;
   Icon: React.ComponentType<{ className?: string }>;
   recommended?: boolean;
+  recommendedLabel: string;
   onPick: (mode: SharedVideoActivityImportMode) => void;
 }
 
@@ -45,6 +47,7 @@ const ModeOption: React.FC<ModeOptionProps> = ({
   body,
   Icon,
   recommended,
+  recommendedLabel,
   onPick,
 }) => (
   <button
@@ -61,7 +64,7 @@ const ModeOption: React.FC<ModeOptionProps> = ({
           <h3 className="font-bold text-slate-900 text-sm">{title}</h3>
           {recommended && (
             <span className="rounded-full bg-emerald-100 px-2 py-0.5 text-[10px] font-bold uppercase tracking-wider text-emerald-700">
-              Recommended for PLCs
+              {recommendedLabel}
             </span>
           )}
         </div>
@@ -74,11 +77,14 @@ const ModeOption: React.FC<ModeOptionProps> = ({
 export const PlcVideoActivityImportModal: React.FC<
   PlcVideoActivityImportModalProps
 > = ({ activityTitle, sharedByName, onPick, onClose }) => {
+  const { t } = useTranslation();
   return (
     <Modal
       isOpen
       onClose={onClose}
-      ariaLabel="Choose how to import this video activity"
+      ariaLabel={t('plcDashboard.videoActivityImportModal.ariaLabel', {
+        defaultValue: 'Choose how to import this video activity',
+      })}
       maxWidth="max-w-md"
       contentClassName=""
       customHeader={
@@ -89,18 +95,30 @@ export const PlcVideoActivityImportModal: React.FC<
             </div>
             <div>
               <h2 className="text-base font-bold text-slate-900">
-                Add to my library
+                {t('plcDashboard.videoActivityImportModal.title', {
+                  defaultValue: 'Add to my library',
+                })}
               </h2>
               <p className="text-xs text-slate-500 mt-0.5 truncate max-w-[20rem]">
-                {activityTitle}
-                {sharedByName ? ` · shared by ${sharedByName}` : ''}
+                {sharedByName
+                  ? t(
+                      'plcDashboard.videoActivityImportModal.subtitleWithSharer',
+                      {
+                        title: activityTitle,
+                        name: sharedByName,
+                        defaultValue: '{{title}} · shared by {{name}}',
+                      }
+                    )
+                  : activityTitle}
               </p>
             </div>
           </div>
           <button
             type="button"
             onClick={onClose}
-            aria-label="Close"
+            aria-label={t('plcDashboard.videoActivityImportModal.close', {
+              defaultValue: 'Close',
+            })}
             className="shrink-0 rounded-lg p-1 text-slate-400 hover:bg-slate-100 hover:text-slate-700 transition-colors"
           >
             <X className="w-5 h-5" />
@@ -110,21 +128,39 @@ export const PlcVideoActivityImportModal: React.FC<
     >
       <div className="px-5 pb-5 pt-4 space-y-3">
         <p className="text-xs text-slate-600">
-          How should this video activity be imported into your library?
+          {t('plcDashboard.videoActivityImportModal.prompt', {
+            defaultValue:
+              'How should this video activity be imported into your library?',
+          })}
         </p>
         <ModeOption
           mode="sync"
-          title="Synced"
-          body="Stay connected to the PLC version. Any teacher in the synced group can edit, and changes show up on everyone's library card with a Sync available pill."
+          title={t('plcDashboard.videoActivityImportModal.syncTitle', {
+            defaultValue: 'Synced',
+          })}
+          body={t('plcDashboard.videoActivityImportModal.syncBody', {
+            defaultValue:
+              "Stay connected to the PLC version. Any teacher in the synced group can edit, and changes show up on everyone's library card with a Sync available pill.",
+          })}
           Icon={Cloud}
           recommended
+          recommendedLabel={t(
+            'plcDashboard.videoActivityImportModal.recommendedLabel',
+            { defaultValue: 'Recommended for PLCs' }
+          )}
           onPick={onPick}
         />
         <ModeOption
           mode="copy"
-          title="Make a copy"
-          body="Take a frozen snapshot. Future edits by other PLC members will not appear in your copy, and your edits stay private."
+          title={t('plcDashboard.videoActivityImportModal.copyTitle', {
+            defaultValue: 'Make a copy',
+          })}
+          body={t('plcDashboard.videoActivityImportModal.copyBody', {
+            defaultValue:
+              'Take a frozen snapshot. Future edits by other PLC members will not appear in your copy, and your edits stay private.',
+          })}
           Icon={Copy}
+          recommendedLabel=""
           onPick={onPick}
         />
       </div>

--- a/components/plc/bodies/PlcSharedBoardsBody.tsx
+++ b/components/plc/bodies/PlcSharedBoardsBody.tsx
@@ -1,0 +1,219 @@
+/**
+ * PlcSharedBoardsBody — Phase 6 body for PLC-scoped shared dashboards.
+ *
+ * Lists every `/shared_boards/{shareId}` doc whose `plcId` matches the
+ * current PLC. Each row surfaces "Open share" (deep-link into the
+ * existing `/share/:id` import flow — the recipient lands on the
+ * standard share-mode picker the host configured at create time).
+ *
+ * Out of scope here (deliberate):
+ *
+ *   - In-place edit. PLC-shared boards are a forwarding surface, not a
+ *     library editor. Teammates open the share, pick Synced / View-only
+ *     / Copy via the standard flow, and edit through their own dashboard
+ *     once imported.
+ *   - Unshare from the PLC tab. The roadmap (Phase 6 "Open question"
+ *     resolved as read-only/copy for simplicity) treats teammates as
+ *     consumers; only the originalAuthor can stop sharing — via the
+ *     existing "Stop sharing" affordance in the Sidebar where they
+ *     created the share.
+ *
+ * Read security: `/shared_boards` rule allows reads from any authed
+ * user, so the PLC filter is a client-side pivot, not a permissions
+ * boundary. A hostile client could list arbitrary shares by removing
+ * the `where plcId == ...` clause; nothing in this body assumes
+ * otherwise.
+ */
+
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import {
+  Cloud,
+  Copy,
+  ExternalLink,
+  Eye,
+  LayoutDashboard,
+  Loader2,
+  Users2,
+} from 'lucide-react';
+import type { Plc } from '@/types';
+import {
+  PlcSharedBoardEntry,
+  usePlcSharedBoards,
+} from '@/hooks/usePlcSharedBoards';
+
+interface PlcSharedBoardsBodyProps {
+  plc: Plc;
+}
+
+function formatDate(ms: number): string {
+  try {
+    return new Date(ms).toLocaleDateString(undefined, {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+    });
+  } catch {
+    return '';
+  }
+}
+
+const ModePill: React.FC<{ mode: PlcSharedBoardEntry['intendedMode'] }> = ({
+  mode,
+}) => {
+  const { t } = useTranslation();
+  if (mode === 'synced') {
+    return (
+      <span className="inline-flex items-center gap-1 rounded-full bg-emerald-100 px-2 py-0.5 text-[10px] font-bold uppercase tracking-wider text-emerald-700">
+        <Cloud className="w-3 h-3" aria-hidden="true" />
+        {t('plcDashboard.sharedBoards.modeSynced', { defaultValue: 'Synced' })}
+      </span>
+    );
+  }
+  if (mode === 'view-only') {
+    return (
+      <span className="inline-flex items-center gap-1 rounded-full bg-slate-100 px-2 py-0.5 text-[10px] font-bold uppercase tracking-wider text-slate-600">
+        <Eye className="w-3 h-3" aria-hidden="true" />
+        {t('plcDashboard.sharedBoards.modeViewOnly', {
+          defaultValue: 'View only',
+        })}
+      </span>
+    );
+  }
+  if (mode === 'copy') {
+    return (
+      <span className="inline-flex items-center gap-1 rounded-full bg-brand-blue-lighter px-2 py-0.5 text-[10px] font-bold uppercase tracking-wider text-brand-blue-primary">
+        <Copy className="w-3 h-3" aria-hidden="true" />
+        {t('plcDashboard.sharedBoards.modeCopy', { defaultValue: 'Copy' })}
+      </span>
+    );
+  }
+  return null;
+};
+
+export const PlcSharedBoardsBody: React.FC<PlcSharedBoardsBodyProps> = ({
+  plc,
+}) => {
+  const { t } = useTranslation();
+  const { boards, loading } = usePlcSharedBoards(plc.id);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center h-full min-h-[200px] text-slate-400">
+        <Loader2 className="w-5 h-5 animate-spin" aria-hidden="true" />
+      </div>
+    );
+  }
+
+  if (boards.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center h-full min-h-[300px] px-6 text-center">
+        <div className="w-16 h-16 rounded-2xl bg-slate-100 flex items-center justify-center mb-5">
+          <LayoutDashboard
+            className="w-7 h-7 text-slate-400"
+            aria-hidden="true"
+          />
+        </div>
+        <h3 className="text-lg font-bold text-slate-700 mb-2">
+          {t('plcDashboard.sharedBoards.emptyTitle', {
+            defaultValue: 'No shared boards yet',
+          })}
+        </h3>
+        <p className="text-sm text-slate-500 max-w-md leading-relaxed">
+          {t('plcDashboard.sharedBoards.emptySubtitle', {
+            defaultValue:
+              'When you or a teammate shares a dashboard with this PLC, it shows up here. Use the Share button on a dashboard and pick this PLC as the audience.',
+          })}
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-3 px-1">
+      <div className="flex items-baseline justify-between mb-1">
+        <h3 className="text-xs font-bold text-slate-400 uppercase tracking-widest">
+          {t('plcDashboard.sharedBoards.heading', {
+            defaultValue: 'Shared Dashboards',
+          })}
+        </h3>
+        <span className="text-xxs text-slate-400">
+          {t('plcDashboard.sharedBoards.count', {
+            count: boards.length,
+            defaultValue: '{{count}} board',
+            defaultValue_other: '{{count}} boards',
+          })}
+        </span>
+      </div>
+      <div className="flex flex-col gap-2">
+        {boards.map((board) => {
+          const ownerLabel =
+            board.originalAuthorName?.trim() ||
+            t('plcDashboard.sharedBoards.unknownSharer', {
+              defaultValue: 'a teammate',
+            });
+          const displayName =
+            board.name?.trim() ||
+            t('plcDashboard.sharedBoards.untitled', {
+              defaultValue: 'Untitled dashboard',
+            });
+          return (
+            <div
+              key={board.id}
+              className="flex items-center gap-3 p-3 bg-white border border-slate-200 hover:border-brand-blue-light rounded-xl transition-colors"
+            >
+              <div className="shrink-0 w-10 h-10 rounded-lg bg-brand-blue-lighter flex items-center justify-center">
+                <LayoutDashboard
+                  className="w-4 h-4 text-brand-blue-primary"
+                  aria-hidden="true"
+                />
+              </div>
+              <div className="flex-1 min-w-0">
+                <div className="flex items-center gap-2 flex-wrap">
+                  <div className="text-sm font-bold text-slate-800 truncate">
+                    {displayName}
+                  </div>
+                  <ModePill mode={board.intendedMode} />
+                </div>
+                <div className="text-xxs text-slate-500 mt-0.5 flex items-center gap-2 flex-wrap">
+                  <span className="truncate flex items-center gap-1">
+                    <Users2 className="w-3 h-3" aria-hidden="true" />
+                    {t('plcDashboard.sharedBoards.bySharer', {
+                      name: ownerLabel,
+                      defaultValue: 'shared by {{name}}',
+                    })}
+                  </span>
+                  <span className="text-slate-300">•</span>
+                  <span>
+                    {t('plcDashboard.sharedBoards.widgetCount', {
+                      count: board.widgetCount,
+                      defaultValue: '{{count}} widget',
+                      defaultValue_other: '{{count}} widgets',
+                    })}
+                  </span>
+                  <span className="text-slate-300">•</span>
+                  <span>{formatDate(board.updatedAt)}</span>
+                </div>
+              </div>
+              <a
+                href={`/share/${encodeURIComponent(board.id)}`}
+                className="shrink-0 flex items-center gap-1.5 px-3 py-1.5 bg-brand-blue-lighter hover:bg-brand-blue-light/30 text-brand-blue-primary rounded-lg text-xxs font-bold uppercase tracking-wider transition-colors"
+                title={t('plcDashboard.sharedBoards.openShareTooltip', {
+                  defaultValue:
+                    "Open this share — you'll get the standard sync / view-only / copy picker.",
+                })}
+              >
+                <ExternalLink className="w-3 h-3" aria-hidden="true" />
+                <span className="hidden sm:inline">
+                  {t('plcDashboard.sharedBoards.openShare', {
+                    defaultValue: 'Open share',
+                  })}
+                </span>
+              </a>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+};

--- a/components/plc/bodies/PlcVideoActivitiesBody.tsx
+++ b/components/plc/bodies/PlcVideoActivitiesBody.tsx
@@ -13,21 +13,15 @@
  *     pull canonical and save a fresh personal copy (no sync linkage).
  *
  *   - "Edit" — opens `VideoActivityEditorModal` against the user's
- *     personal copy. If the user doesn't yet have one, we auto-import via
- *     Sync mode first so the editor has a Drive-backed canonical to
- *     write into. Saving calls `saveActivity`, which writes to Drive +
- *     mirrors header onto Firestore.
- *
- *     NOTE — unlike `useQuiz.saveQuiz`, `useVideoActivity.saveActivity`
- *     does NOT detect synced-group version conflicts at save time. A
- *     teammate publishing concurrently to the same group will lose to
- *     last-writer-wins on `synced_video_activities/{groupId}`. The
- *     synced-group publish itself is debounced LWW per field via
- *     `useSyncedVideoActivityGroups`, so the canonical doesn't tear; the
- *     local copy's `lastSyncedVersion` may briefly lag until the next
- *     sync-aware pull. This is consistent with the Phase 4 scope ("LWW
- *     matches every other surface in the app") and the cost of building
- *     version-conflict UX is reserved for a future iteration.
+ *     personal copy. If the user doesn't yet have one, we auto-import
+ *     via Sync mode first so the editor has a Drive-backed canonical
+ *     to write into. Saving calls `saveActivity`, which publishes the
+ *     edit to the canonical `synced_video_activities/{groupId}` (when
+ *     `meta.sync` is set) BEFORE the Drive replica write, with a
+ *     `version` invariant — concurrent peer publishes throw
+ *     `SyncedVideoActivityVersionConflictError`, caught below to auto-
+ *     pull the peer's content and surface a "your edits weren't saved"
+ *     warning. Mirrors the quiz body's conflict UX.
  *
  *   - "Unshare" — any current member can remove a PLC video activity
  *     entry (PLC-owned model). The canonical synced group doc is left in
@@ -57,7 +51,10 @@ import { useAuth } from '@/context/useAuth';
 import { useDashboard } from '@/context/useDashboard';
 import { useDialog } from '@/context/useDialog';
 import { usePlcVideoActivities } from '@/hooks/usePlcVideoActivities';
-import { useVideoActivity } from '@/hooks/useVideoActivity';
+import {
+  SyncedVideoActivityVersionConflictError,
+  useVideoActivity,
+} from '@/hooks/useVideoActivity';
 import type { SharedVideoActivityImportMode } from '@/hooks/useVideoActivityAssignments';
 import {
   callJoinPlcVideoActivitySyncGroup,
@@ -109,6 +106,7 @@ export const PlcVideoActivitiesBody: React.FC<PlcVideoActivitiesBodyProps> = ({
     deleteActivity,
     attachSyncLinkage,
     loadActivityData,
+    pullSyncedVideoActivity,
     isDriveConnected,
   } = useVideoActivity(user?.uid);
 
@@ -388,22 +386,50 @@ export const PlcVideoActivitiesBody: React.FC<PlcVideoActivitiesBodyProps> = ({
   const handleSaveEdit = useCallback(
     async (updated: VideoActivityData) => {
       if (!editing) return;
-      // `saveActivity` writes to Drive + Firestore unconditionally. The
-      // synced-group publish (if `meta.sync` is set) happens via
-      // `useSyncedVideoActivityGroups` LWW machinery downstream — that
-      // layer handles per-field debouncing and concurrent edits across
-      // teammates. We deliberately don't surface version-conflict UX
-      // here; see the file header for the rationale.
-      await saveActivity(updated, editing.meta.driveFileId);
-      addToast(
-        t('plcDashboard.videoActivities.editSaved', {
-          defaultValue:
-            'Video activity saved — teammates will sync on next refresh.',
-        }),
-        'success'
-      );
+      try {
+        await saveActivity(updated, editing.meta.driveFileId);
+        addToast(
+          t('plcDashboard.videoActivities.editSaved', {
+            defaultValue:
+              'Video activity saved — teammates will sync on next refresh.',
+          }),
+          'success'
+        );
+      } catch (err) {
+        // Mirror the quiz body's conflict UX: a teammate published mid-
+        // edit, the canonical's `expectedVersion` check failed, our
+        // Drive replica is untouched. Auto-pull the canonical so the
+        // local copy catches up; the editor stays closed because the
+        // teacher's unsaved edits are stale relative to the new
+        // canonical. They can reopen + re-apply.
+        if (err instanceof SyncedVideoActivityVersionConflictError) {
+          try {
+            await pullSyncedVideoActivity(editing.meta);
+          } catch (pullErr) {
+            logError(
+              'PlcVideoActivitiesBody.handleSaveEdit.autoPull',
+              pullErr,
+              {
+                plcId: plc.id,
+                activityId: editing.meta.id,
+                syncGroupId: editing.meta.sync?.groupId ?? null,
+              }
+            );
+          }
+          setEditing(null);
+          addToast(
+            t('plcDashboard.videoActivities.editConflict', {
+              defaultValue:
+                'Another teacher published an update to this video activity. We pulled their changes; your unsaved edits were not saved. Reopen the activity to re-apply.',
+            }),
+            'warning'
+          );
+          return;
+        }
+        throw err;
+      }
     },
-    [addToast, editing, saveActivity, t]
+    [addToast, editing, plc.id, pullSyncedVideoActivity, saveActivity, t]
   );
 
   const handleUnshare = useCallback(

--- a/components/plc/bodies/PlcVideoActivitiesBody.tsx
+++ b/components/plc/bodies/PlcVideoActivitiesBody.tsx
@@ -1,0 +1,690 @@
+/**
+ * PlcVideoActivitiesBody — Phase 4 body for the PLC Video Activity Library.
+ *
+ * Mirrors `PlcQuizLibraryBody` in shape and lifecycle. Owns the row list,
+ * the import modal, and the inline editor for the canonical activity.
+ *
+ *   - "Add to my library" — opens `PlcVideoActivityImportModal` (sync-or-
+ *     copy picker). On Sync we pull canonical content from
+ *     `synced_video_activities/{groupId}`, save a fresh personal copy,
+ *     join the synced group via `callJoinPlcVideoActivitySyncGroup`, and
+ *     attach the sync linkage so the user's library card thereafter
+ *     surfaces the "Synced" / "Sync available" pills. On Copy we just
+ *     pull canonical and save a fresh personal copy (no sync linkage).
+ *
+ *   - "Edit" — opens `VideoActivityEditorModal` against the user's
+ *     personal copy. If the user doesn't yet have one, we auto-import via
+ *     Sync mode first so the editor has a Drive-backed canonical to
+ *     write into. Saving calls `saveActivity`, which writes to Drive +
+ *     mirrors header onto Firestore.
+ *
+ *     NOTE — unlike `useQuiz.saveQuiz`, `useVideoActivity.saveActivity`
+ *     does NOT detect synced-group version conflicts at save time. A
+ *     teammate publishing concurrently to the same group will lose to
+ *     last-writer-wins on `synced_video_activities/{groupId}`. The
+ *     synced-group publish itself is debounced LWW per field via
+ *     `useSyncedVideoActivityGroups`, so the canonical doesn't tear; the
+ *     local copy's `lastSyncedVersion` may briefly lag until the next
+ *     sync-aware pull. This is consistent with the Phase 4 scope ("LWW
+ *     matches every other surface in the app") and the cost of building
+ *     version-conflict UX is reserved for a future iteration.
+ *
+ *   - "Unshare" — any current member can remove a PLC video activity
+ *     entry (PLC-owned model). The canonical synced group doc is left in
+ *     place; orphan-tolerant per the Phase 2/Phase 4 spec.
+ *
+ *   - Already-imported indicator — when the user's personal library
+ *     carries `sync.groupId === plcVideoActivity.syncGroupId`, the row
+ *     shows an "In your library" badge. Re-importing in Sync mode is a
+ *     no-op (informational toast); Copy mode still creates a fresh
+ *     snapshot.
+ */
+
+import React, { useCallback, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import {
+  Cloud,
+  Download,
+  ExternalLink,
+  Film,
+  Loader2,
+  Pencil,
+  Trash2,
+  Users2,
+} from 'lucide-react';
+import type { Plc, VideoActivityData, VideoActivityMetadata } from '@/types';
+import { useAuth } from '@/context/useAuth';
+import { useDashboard } from '@/context/useDashboard';
+import { useDialog } from '@/context/useDialog';
+import { usePlcVideoActivities } from '@/hooks/usePlcVideoActivities';
+import { useVideoActivity } from '@/hooks/useVideoActivity';
+import type { SharedVideoActivityImportMode } from '@/hooks/useVideoActivityAssignments';
+import {
+  callJoinPlcVideoActivitySyncGroup,
+  callLeaveSyncedVideoActivityGroup,
+  pullSyncedVideoActivityContent,
+} from '@/hooks/useSyncedVideoActivityGroups';
+import { logError } from '@/utils/logError';
+import { PlcVideoActivityImportModal } from '../PlcVideoActivityImportModal';
+import { VideoActivityEditorModal } from '@/components/widgets/VideoActivityWidget/components/VideoActivityEditorModal';
+
+interface PlcVideoActivitiesBodyProps {
+  plc: Plc;
+}
+
+interface ImportTarget {
+  plcVideoActivityId: string;
+  syncGroupId: string;
+  title: string;
+  sharedByName: string;
+}
+
+function formatDate(ms: number): string {
+  try {
+    return new Date(ms).toLocaleDateString(undefined, {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+    });
+  } catch {
+    return '';
+  }
+}
+
+export const PlcVideoActivitiesBody: React.FC<PlcVideoActivitiesBodyProps> = ({
+  plc,
+}) => {
+  const { t } = useTranslation();
+  const { user } = useAuth();
+  const { addToast } = useDashboard();
+  const { showConfirm } = useDialog();
+  const {
+    videoActivities: plcEntries,
+    loading,
+    unshareVideoActivityFromPlc,
+  } = usePlcVideoActivities(plc.id);
+  const {
+    activities: personalActivities,
+    saveActivity,
+    deleteActivity,
+    attachSyncLinkage,
+    loadActivityData,
+    isDriveConnected,
+  } = useVideoActivity(user?.uid);
+
+  const [importTarget, setImportTarget] = useState<ImportTarget | null>(null);
+  const [busyRowId, setBusyRowId] = useState<string | null>(null);
+  const [editing, setEditing] = useState<{
+    activity: VideoActivityData;
+    meta: VideoActivityMetadata;
+  } | null>(null);
+
+  const personalBySyncGroup = useMemo(() => {
+    const map = new Map<string, VideoActivityMetadata>();
+    for (const a of personalActivities) {
+      if (a.sync?.groupId) map.set(a.sync.groupId, a);
+    }
+    return map;
+  }, [personalActivities]);
+
+  const handleImport = useCallback(
+    async (target: ImportTarget, mode: SharedVideoActivityImportMode) => {
+      if (!user) return;
+      if (!isDriveConnected) {
+        addToast(
+          t('plcDashboard.videoActivities.driveRequired', {
+            defaultValue:
+              'Connect Google Drive in your account to import PLC video activities.',
+          }),
+          'error'
+        );
+        return;
+      }
+
+      if (mode === 'sync' && personalBySyncGroup.has(target.syncGroupId)) {
+        setImportTarget(null);
+        addToast(
+          t('plcDashboard.videoActivities.alreadySynced', {
+            title: target.title,
+            defaultValue: '"{{title}}" is already synced to your library.',
+          }),
+          'info'
+        );
+        return;
+      }
+
+      setImportTarget(null);
+      setBusyRowId(target.plcVideoActivityId);
+      let savedMeta: Awaited<ReturnType<typeof saveActivity>> | null = null;
+      let joinedGroupId: string | null = null;
+      try {
+        const canonical = await pullSyncedVideoActivityContent(
+          target.syncGroupId
+        );
+        const now = Date.now();
+        const fresh: VideoActivityData = {
+          id: crypto.randomUUID(),
+          title: canonical.title,
+          youtubeUrl: canonical.youtubeUrl,
+          questions: canonical.questions,
+          createdAt: now,
+          updatedAt: now,
+        };
+        savedMeta = await saveActivity(fresh);
+        if (mode === 'sync') {
+          const joinResult = await callJoinPlcVideoActivitySyncGroup(
+            plc.id,
+            target.plcVideoActivityId
+          );
+          joinedGroupId = joinResult.groupId;
+          const liveVersion = Math.max(canonical.version, joinResult.version);
+          await attachSyncLinkage(savedMeta.id, {
+            groupId: target.syncGroupId,
+            lastSyncedVersion: liveVersion,
+          });
+          addToast(
+            t('plcDashboard.videoActivities.importedSync', {
+              title: target.title,
+              defaultValue: '"{{title}}" added to your library (synced).',
+            }),
+            'success'
+          );
+        } else {
+          addToast(
+            t('plcDashboard.videoActivities.importedCopy', {
+              title: target.title,
+              defaultValue: '"{{title}}" copied to your library.',
+            }),
+            'success'
+          );
+        }
+      } catch (err) {
+        logError('PlcVideoActivitiesBody.import', err, {
+          plcId: plc.id,
+          plcVideoActivityId: target.plcVideoActivityId,
+          mode,
+        });
+        // Rollback path mirrors PlcQuizLibraryBody: if we joined the
+        // synced group before the failure, leave it so we don't pollute
+        // the participants map with a non-member. Likewise, if we saved
+        // a local copy before the failure, delete it. Both rollback
+        // calls are best-effort.
+        if (joinedGroupId) {
+          try {
+            await callLeaveSyncedVideoActivityGroup(joinedGroupId);
+          } catch (leaveErr) {
+            logError('PlcVideoActivitiesBody.import.rollbackLeave', leaveErr, {
+              plcId: plc.id,
+              groupId: joinedGroupId,
+            });
+          }
+        }
+        if (savedMeta) {
+          try {
+            await deleteActivity(savedMeta.id, savedMeta.driveFileId);
+          } catch (rollbackErr) {
+            logError(
+              'PlcVideoActivitiesBody.import.rollbackActivity',
+              rollbackErr,
+              {
+                plcId: plc.id,
+                activityId: savedMeta.id,
+                driveFileId: savedMeta.driveFileId,
+              }
+            );
+          }
+        }
+        addToast(
+          err instanceof Error
+            ? err.message
+            : t('plcDashboard.videoActivities.importFailed', {
+                defaultValue: 'Failed to import video activity.',
+              }),
+          'error'
+        );
+      } finally {
+        setBusyRowId(null);
+      }
+    },
+    [
+      addToast,
+      attachSyncLinkage,
+      deleteActivity,
+      isDriveConnected,
+      personalBySyncGroup,
+      plc.id,
+      saveActivity,
+      t,
+      user,
+    ]
+  );
+
+  const handleEdit = useCallback(
+    async (target: ImportTarget) => {
+      if (!user) return;
+      if (!isDriveConnected) {
+        addToast(
+          t('plcDashboard.videoActivities.driveRequiredForEdit', {
+            defaultValue:
+              'Connect Google Drive in your account to edit PLC video activities.',
+          }),
+          'error'
+        );
+        return;
+      }
+
+      setBusyRowId(target.plcVideoActivityId);
+      let savedMeta: Awaited<ReturnType<typeof saveActivity>> | null = null;
+      let joinedGroupId: string | null = null;
+      let autoImported = false;
+      try {
+        let personalMeta: VideoActivityMetadata | undefined =
+          personalBySyncGroup.get(target.syncGroupId);
+        if (!personalMeta) {
+          autoImported = true;
+          const canonical = await pullSyncedVideoActivityContent(
+            target.syncGroupId
+          );
+          const now = Date.now();
+          const fresh: VideoActivityData = {
+            id: crypto.randomUUID(),
+            title: canonical.title,
+            youtubeUrl: canonical.youtubeUrl,
+            questions: canonical.questions,
+            createdAt: now,
+            updatedAt: now,
+          };
+          savedMeta = await saveActivity(fresh);
+          const joinResult = await callJoinPlcVideoActivitySyncGroup(
+            plc.id,
+            target.plcVideoActivityId
+          );
+          joinedGroupId = joinResult.groupId;
+          const liveVersion = Math.max(canonical.version, joinResult.version);
+          await attachSyncLinkage(savedMeta.id, {
+            groupId: target.syncGroupId,
+            lastSyncedVersion: liveVersion,
+          });
+          personalMeta = {
+            ...savedMeta,
+            sync: {
+              groupId: target.syncGroupId,
+              lastSyncedVersion: liveVersion,
+            },
+          };
+        }
+
+        const activityData = await loadActivityData(personalMeta.driveFileId);
+        setEditing({
+          activity: activityData,
+          meta: personalMeta,
+        });
+        if (autoImported) {
+          addToast(
+            t('plcDashboard.videoActivities.editAutoImported', {
+              title: target.title,
+              defaultValue:
+                '"{{title}}" added to your library — opening editor.',
+            }),
+            'info'
+          );
+        }
+      } catch (err) {
+        logError('PlcVideoActivitiesBody.edit', err, {
+          plcId: plc.id,
+          plcVideoActivityId: target.plcVideoActivityId,
+        });
+        if (joinedGroupId) {
+          try {
+            await callLeaveSyncedVideoActivityGroup(joinedGroupId);
+          } catch (leaveErr) {
+            logError('PlcVideoActivitiesBody.edit.rollbackLeave', leaveErr, {
+              plcId: plc.id,
+              groupId: joinedGroupId,
+            });
+          }
+        }
+        if (savedMeta) {
+          try {
+            await deleteActivity(savedMeta.id, savedMeta.driveFileId);
+          } catch (rollbackErr) {
+            logError(
+              'PlcVideoActivitiesBody.edit.rollbackActivity',
+              rollbackErr,
+              {
+                plcId: plc.id,
+                activityId: savedMeta.id,
+                driveFileId: savedMeta.driveFileId,
+              }
+            );
+          }
+        }
+        addToast(
+          err instanceof Error
+            ? err.message
+            : t('plcDashboard.videoActivities.editFailed', {
+                defaultValue: 'Failed to open editor.',
+              }),
+          'error'
+        );
+      } finally {
+        setBusyRowId(null);
+      }
+    },
+    [
+      addToast,
+      attachSyncLinkage,
+      deleteActivity,
+      isDriveConnected,
+      loadActivityData,
+      personalBySyncGroup,
+      plc.id,
+      saveActivity,
+      t,
+      user,
+    ]
+  );
+
+  const handleSaveEdit = useCallback(
+    async (updated: VideoActivityData) => {
+      if (!editing) return;
+      // `saveActivity` writes to Drive + Firestore unconditionally. The
+      // synced-group publish (if `meta.sync` is set) happens via
+      // `useSyncedVideoActivityGroups` LWW machinery downstream — that
+      // layer handles per-field debouncing and concurrent edits across
+      // teammates. We deliberately don't surface version-conflict UX
+      // here; see the file header for the rationale.
+      await saveActivity(updated, editing.meta.driveFileId);
+      addToast(
+        t('plcDashboard.videoActivities.editSaved', {
+          defaultValue:
+            'Video activity saved — teammates will sync on next refresh.',
+        }),
+        'success'
+      );
+    },
+    [addToast, editing, saveActivity, t]
+  );
+
+  const handleUnshare = useCallback(
+    async (plcVideoActivityId: string, title: string) => {
+      const confirmed = await showConfirm(
+        t('plcDashboard.videoActivities.unshareConfirm', {
+          title,
+          defaultValue:
+            'Remove "{{title}}" from this PLC? Other teammates will lose access to the shared library entry. Their personal copies (if any) keep working.',
+        }),
+        {
+          title: t('plcDashboard.videoActivities.unshareTitle', {
+            defaultValue: 'Unshare video activity',
+          }),
+          variant: 'warning',
+          confirmLabel: t('plcDashboard.videoActivities.unshareAction', {
+            defaultValue: 'Unshare',
+          }),
+        }
+      );
+      if (!confirmed) return;
+      setBusyRowId(plcVideoActivityId);
+      try {
+        await unshareVideoActivityFromPlc(plcVideoActivityId);
+        addToast(
+          t('plcDashboard.videoActivities.unshared', {
+            title,
+            defaultValue: '"{{title}}" removed from this PLC.',
+          }),
+          'success'
+        );
+      } catch (err) {
+        logError('PlcVideoActivitiesBody.unshare', err, {
+          plcId: plc.id,
+          plcVideoActivityId,
+        });
+        addToast(
+          err instanceof Error
+            ? err.message
+            : t('plcDashboard.videoActivities.unshareFailed', {
+                defaultValue: 'Failed to unshare video activity.',
+              }),
+          'error'
+        );
+      } finally {
+        setBusyRowId(null);
+      }
+    },
+    [addToast, plc.id, showConfirm, t, unshareVideoActivityFromPlc]
+  );
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center h-full min-h-[200px] text-slate-400">
+        <Loader2 className="w-5 h-5 animate-spin" aria-hidden="true" />
+      </div>
+    );
+  }
+
+  if (plcEntries.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center h-full min-h-[300px] px-6 text-center">
+        <div className="w-16 h-16 rounded-2xl bg-slate-100 flex items-center justify-center mb-5">
+          <Film className="w-7 h-7 text-slate-400" aria-hidden="true" />
+        </div>
+        <h3 className="text-lg font-bold text-slate-700 mb-2">
+          {t('plcDashboard.videoActivities.emptyTitle', {
+            defaultValue: 'No shared video activities yet',
+          })}
+        </h3>
+        <p className="text-sm text-slate-500 max-w-md leading-relaxed">
+          {t('plcDashboard.videoActivities.emptySubtitle', {
+            defaultValue:
+              'Open the Video Activity widget in your dashboard, click the kebab on any activity, and choose "Share with PLC" to add it here.',
+          })}
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-3 px-1">
+      <div className="flex items-baseline justify-between mb-1">
+        <h3 className="text-xs font-bold text-slate-400 uppercase tracking-widest">
+          {t('plcDashboard.videoActivities.heading', {
+            defaultValue: 'Shared Video Activities',
+          })}
+        </h3>
+        <span className="text-xxs text-slate-400">
+          {t('plcDashboard.videoActivities.count', {
+            count: plcEntries.length,
+            defaultValue: '{{count}} activity',
+            defaultValue_other: '{{count}} activities',
+          })}
+        </span>
+      </div>
+      <div className="flex flex-col gap-2">
+        {plcEntries.map((activity) => {
+          const isMine = activity.sharedBy === user?.uid;
+          const ownerLabel =
+            activity.sharedByName?.trim() ||
+            activity.sharedByEmail ||
+            t('plcDashboard.videoActivities.unknownSharer', {
+              defaultValue: 'a teammate',
+            });
+          const inLibrary = personalBySyncGroup.has(activity.syncGroupId);
+          const isBusy = busyRowId === activity.id;
+          return (
+            <div
+              key={activity.id}
+              className="flex items-center gap-3 p-3 bg-white border border-slate-200 hover:border-brand-blue-light rounded-xl transition-colors"
+            >
+              <div className="shrink-0 w-10 h-10 rounded-lg bg-brand-blue-lighter flex items-center justify-center">
+                <Film
+                  className="w-4 h-4 text-brand-blue-primary"
+                  aria-hidden="true"
+                />
+              </div>
+              <div className="flex-1 min-w-0">
+                <div className="flex items-center gap-2 flex-wrap">
+                  <div className="text-sm font-bold text-slate-800 truncate">
+                    {activity.title}
+                  </div>
+                  {inLibrary && (
+                    <span className="inline-flex items-center gap-1 rounded-full bg-emerald-100 px-2 py-0.5 text-[10px] font-bold uppercase tracking-wider text-emerald-700">
+                      <Cloud className="w-3 h-3" aria-hidden="true" />
+                      {t('plcDashboard.videoActivities.inLibrary', {
+                        defaultValue: 'In your library',
+                      })}
+                    </span>
+                  )}
+                </div>
+                <div className="text-xxs text-slate-500 mt-0.5 flex items-center gap-2 flex-wrap">
+                  <span className="truncate flex items-center gap-1">
+                    <Users2 className="w-3 h-3" aria-hidden="true" />
+                    {t('plcDashboard.videoActivities.bySharer', {
+                      name: ownerLabel,
+                      defaultValue: 'shared by {{name}}',
+                    })}
+                  </span>
+                  <span className="text-slate-300">•</span>
+                  <span>
+                    {t('plcDashboard.videoActivities.questionCount', {
+                      count: activity.questionCount,
+                      defaultValue: '{{count}} question',
+                      defaultValue_other: '{{count}} questions',
+                    })}
+                  </span>
+                  <span className="text-slate-300">•</span>
+                  <span>{formatDate(activity.updatedAt)}</span>
+                </div>
+              </div>
+              <div className="shrink-0 flex items-center gap-1.5">
+                <button
+                  type="button"
+                  onClick={() =>
+                    setImportTarget({
+                      plcVideoActivityId: activity.id,
+                      syncGroupId: activity.syncGroupId,
+                      title: activity.title,
+                      sharedByName: activity.sharedByName,
+                    })
+                  }
+                  disabled={isBusy}
+                  className="flex items-center gap-1.5 px-3 py-1.5 bg-brand-blue-lighter hover:bg-brand-blue-light/30 text-brand-blue-primary rounded-lg text-xxs font-bold uppercase tracking-wider transition-colors disabled:opacity-40"
+                  title={
+                    inLibrary
+                      ? t('plcDashboard.videoActivities.reimport', {
+                          defaultValue: 'Re-import',
+                        })
+                      : t('plcDashboard.videoActivities.addToMyLibrary', {
+                          defaultValue: 'Add to my library',
+                        })
+                  }
+                >
+                  {isBusy ? (
+                    <Loader2
+                      className="w-3 h-3 animate-spin"
+                      aria-hidden="true"
+                    />
+                  ) : (
+                    <Download className="w-3 h-3" aria-hidden="true" />
+                  )}
+                  <span className="hidden sm:inline">
+                    {inLibrary
+                      ? t('plcDashboard.videoActivities.reimport', {
+                          defaultValue: 'Re-import',
+                        })
+                      : t('plcDashboard.videoActivities.addToMyLibrary', {
+                          defaultValue: 'Add to my library',
+                        })}
+                  </span>
+                </button>
+                <button
+                  type="button"
+                  onClick={() =>
+                    void handleEdit({
+                      plcVideoActivityId: activity.id,
+                      syncGroupId: activity.syncGroupId,
+                      title: activity.title,
+                      sharedByName: activity.sharedByName,
+                    })
+                  }
+                  disabled={isBusy || !isDriveConnected}
+                  aria-label={t('plcDashboard.videoActivities.editAction', {
+                    defaultValue: 'Edit',
+                  })}
+                  title={
+                    inLibrary
+                      ? t('plcDashboard.videoActivities.editTooltip', {
+                          defaultValue:
+                            'Edit collaboratively (changes sync to teammates)',
+                        })
+                      : t(
+                          'plcDashboard.videoActivities.editTooltipAutoImport',
+                          {
+                            defaultValue:
+                              'Edit collaboratively — adds to your library on first edit',
+                          }
+                        )
+                  }
+                  className="p-1.5 rounded-lg text-slate-400 hover:bg-brand-blue-lighter hover:text-brand-blue-primary transition-colors disabled:opacity-40"
+                >
+                  <Pencil className="w-3.5 h-3.5" aria-hidden="true" />
+                </button>
+                <button
+                  type="button"
+                  onClick={() =>
+                    void handleUnshare(activity.id, activity.title)
+                  }
+                  disabled={isBusy}
+                  aria-label={t('plcDashboard.videoActivities.unshareAction', {
+                    defaultValue: 'Unshare',
+                  })}
+                  title={
+                    isMine
+                      ? t('plcDashboard.videoActivities.unshareYours', {
+                          defaultValue: 'Unshare from PLC',
+                        })
+                      : t('plcDashboard.videoActivities.unshareTeammate', {
+                          defaultValue:
+                            'Unshare from PLC (any member can remove)',
+                        })
+                  }
+                  className="p-1.5 rounded-lg text-slate-400 hover:bg-red-50 hover:text-red-600 transition-colors disabled:opacity-40"
+                >
+                  <Trash2 className="w-3.5 h-3.5" aria-hidden="true" />
+                </button>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+      {!isDriveConnected && (
+        <div className="mt-2 px-3 py-2 bg-amber-50 border border-amber-200 rounded-lg flex items-start gap-2">
+          <ExternalLink
+            className="w-4 h-4 text-amber-700 mt-0.5 shrink-0"
+            aria-hidden="true"
+          />
+          <p className="text-xs text-amber-800">
+            {t('plcDashboard.videoActivities.driveDisconnected', {
+              defaultValue:
+                'Connect Google Drive to import PLC video activities into your personal library.',
+            })}
+          </p>
+        </div>
+      )}
+      {importTarget && (
+        <PlcVideoActivityImportModal
+          activityTitle={importTarget.title}
+          sharedByName={importTarget.sharedByName}
+          onPick={(mode) => void handleImport(importTarget, mode)}
+          onClose={() => setImportTarget(null)}
+        />
+      )}
+      <VideoActivityEditorModal
+        isOpen={editing !== null}
+        activity={editing?.activity ?? null}
+        onClose={() => setEditing(null)}
+        onSave={handleSaveEdit}
+      />
+    </div>
+  );
+};

--- a/components/plc/overview/tileRegistry.tsx
+++ b/components/plc/overview/tileRegistry.tsx
@@ -10,6 +10,7 @@ import { SharedSheetTile } from './tiles/SharedSheetTile';
 import { QuickActionsTile } from './tiles/QuickActionsTile';
 import { QuizLibraryTile } from './tiles/QuizLibraryTile';
 import { ActiveAssignmentsTile } from './tiles/ActiveAssignmentsTile';
+import { VideoActivitiesTile } from './tiles/VideoActivitiesTile';
 import { ComingSoonTile } from './tiles/ComingSoonTile';
 
 export interface TileContext {
@@ -88,11 +89,7 @@ export function renderTileContent(
       );
     case 'videoActivities':
       return (
-        <ComingSoonTile
-          kind="videoActivities"
-          phase={4}
-          onNavigateTab={() => ctx.onNavigateTab('videoActivities')}
-        />
+        <VideoActivitiesTile plc={ctx.plc} onNavigateTab={ctx.onNavigateTab} />
       );
     case 'sharedBoards':
       return (

--- a/components/plc/overview/tileRegistry.tsx
+++ b/components/plc/overview/tileRegistry.tsx
@@ -9,6 +9,7 @@ import { TodosTile } from './tiles/TodosTile';
 import { SharedSheetTile } from './tiles/SharedSheetTile';
 import { QuickActionsTile } from './tiles/QuickActionsTile';
 import { QuizLibraryTile } from './tiles/QuizLibraryTile';
+import { ActiveAssignmentsTile } from './tiles/ActiveAssignmentsTile';
 import { ComingSoonTile } from './tiles/ComingSoonTile';
 
 export interface TileContext {
@@ -51,7 +52,7 @@ export function tileFeatureGate(
  * that renders inside `PlcBentoTile`'s content slot. Adding a new tile =
  * a new case here + an entry in `PLC_BENTO_TILE_KINDS` (`types.ts`).
  *
- * "Coming soon" placeholders for Phase 2/3/4/6 tabs all route through
+ * "Coming soon" placeholders for unshipped phases route through
  * `ComingSoonTile` — when those phases ship, swap the case for the real
  * tile component and the layout doesn't have to change.
  */
@@ -80,10 +81,9 @@ export function renderTileContent(
       );
     case 'activeAssignments':
       return (
-        <ComingSoonTile
-          kind="activeAssignments"
-          phase={3}
-          onNavigateTab={() => ctx.onNavigateTab('assignments')}
+        <ActiveAssignmentsTile
+          plc={ctx.plc}
+          onNavigateTab={ctx.onNavigateTab}
         />
       );
     case 'videoActivities':

--- a/components/plc/overview/tileRegistry.tsx
+++ b/components/plc/overview/tileRegistry.tsx
@@ -11,7 +11,7 @@ import { QuickActionsTile } from './tiles/QuickActionsTile';
 import { QuizLibraryTile } from './tiles/QuizLibraryTile';
 import { ActiveAssignmentsTile } from './tiles/ActiveAssignmentsTile';
 import { VideoActivitiesTile } from './tiles/VideoActivitiesTile';
-import { ComingSoonTile } from './tiles/ComingSoonTile';
+import { SharedBoardsTile } from './tiles/SharedBoardsTile';
 
 export interface TileContext {
   plc: Plc;
@@ -93,11 +93,7 @@ export function renderTileContent(
       );
     case 'sharedBoards':
       return (
-        <ComingSoonTile
-          kind="sharedBoards"
-          phase={6}
-          onNavigateTab={() => ctx.onNavigateTab('sharedBoards')}
-        />
+        <SharedBoardsTile plc={ctx.plc} onNavigateTab={ctx.onNavigateTab} />
       );
   }
 }

--- a/components/plc/overview/tiles/ActiveAssignmentsTile.tsx
+++ b/components/plc/overview/tiles/ActiveAssignmentsTile.tsx
@@ -1,0 +1,171 @@
+/**
+ * ActiveAssignmentsTile — Phase 3 bento tile for in-progress PLC
+ * assignments. Surfaces the same data as the PLC Assignments → In-progress
+ * sub-tab (status `'active'` or `'paused'`) in a compact list with a
+ * count badge and an "Open assignments" footer that routes to the full
+ * tab.
+ *
+ * **Why this tile exists:** Phase 3 shipped the In-progress sub-tab but
+ * left the Overview bento tile pointing at the Phase-1 `ComingSoonTile`
+ * (`tileRegistry.tsx`, pre-fix). Members landed on the dashboard and saw
+ * a "Phase 3 · soon" badge even though the underlying tab was live. This
+ * tile closes that gap so the Overview reflects the shipped feature set.
+ *
+ * Mirrors `QuizLibraryTile`'s rhythm (small heading + scrollable preview
+ * + footer link) rather than `CompletedAssignmentsTile`'s analytics-body
+ * embed — the In-progress view is a real-time list, not an aggregation.
+ */
+
+import React, { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { ClipboardList, ChevronRight, Loader2 } from 'lucide-react';
+
+import { Plc, PlcAssignmentIndexEntry, QuizAssignmentStatus } from '@/types';
+import { usePlcAssignmentIndex } from '@/hooks/usePlcAssignmentIndex';
+import type { PlcDashboardTabId } from '../../PlcDashboard';
+
+interface ActiveAssignmentsTileProps {
+  plc: Plc;
+  onNavigateTab: (tabId: PlcDashboardTabId) => void;
+}
+
+const PREVIEW_LIMIT = 4;
+
+export const ActiveAssignmentsTile: React.FC<ActiveAssignmentsTileProps> = ({
+  plc,
+  onNavigateTab,
+}) => {
+  const { t } = useTranslation();
+  const { entries, loading } = usePlcAssignmentIndex(plc.id);
+
+  // The In-progress sub-tab uses the same filter — keep them in sync. If
+  // the filter ever changes (e.g. a new `archived` status), update both.
+  const active = useMemo(
+    () => entries.filter((e) => e.status === 'active' || e.status === 'paused'),
+    [entries]
+  );
+  const preview = active.slice(0, PREVIEW_LIMIT);
+
+  return (
+    <div className="h-full flex flex-col">
+      <div className="flex items-center gap-2 px-4 pt-4 pb-2">
+        <div className="w-7 h-7 rounded-lg bg-brand-blue-lighter flex items-center justify-center">
+          <ClipboardList className="w-3.5 h-3.5 text-brand-blue-primary" />
+        </div>
+        <h4 className="text-xxs font-bold uppercase tracking-widest text-slate-500">
+          {t('plcDashboard.overview.tiles.activeAssignments.heading', {
+            defaultValue: 'Active Assignments',
+          })}
+        </h4>
+        {active.length > 0 && (
+          <span className="ml-auto text-xs font-bold text-slate-700">
+            {active.length}
+          </span>
+        )}
+      </div>
+
+      <div className="flex-1 min-h-0 overflow-y-auto custom-scrollbar px-4 pb-2">
+        {loading ? (
+          <div className="flex items-center justify-center h-full text-slate-400">
+            <Loader2 className="w-4 h-4 animate-spin" />
+          </div>
+        ) : preview.length === 0 ? (
+          <div className="flex flex-col items-center justify-center h-full text-center text-xs text-slate-500 py-2">
+            <ClipboardList className="w-6 h-6 text-slate-300 mb-2" />
+            <p className="font-semibold text-slate-600">
+              {t('plcDashboard.overview.tiles.activeAssignments.empty', {
+                defaultValue: 'No active assignments',
+              })}
+            </p>
+            <p className="text-xxs text-slate-400 mt-1">
+              {t(
+                'plcDashboard.overview.tiles.activeAssignments.emptySubtitle',
+                {
+                  defaultValue:
+                    'Live PLC-mode assignments will appear here while they run.',
+                }
+              )}
+            </p>
+          </div>
+        ) : (
+          <ul className="space-y-2 py-1">
+            {preview.map((entry) => (
+              <ActiveAssignmentRow key={entry.id} entry={entry} />
+            ))}
+          </ul>
+        )}
+      </div>
+
+      <button
+        type="button"
+        onClick={() => onNavigateTab('assignments')}
+        className="flex items-center justify-center gap-1.5 px-4 py-2.5 border-t border-slate-100 text-xxs font-bold uppercase tracking-wider text-brand-blue-primary hover:bg-brand-blue-lighter/40 transition-colors"
+      >
+        {t('plcDashboard.overview.tiles.activeAssignments.openAll', {
+          defaultValue: 'Open assignments',
+        })}
+        <ChevronRight className="w-3 h-3" />
+      </button>
+    </div>
+  );
+};
+
+const ActiveAssignmentRow: React.FC<{ entry: PlcAssignmentIndexEntry }> = ({
+  entry,
+}) => {
+  const { t } = useTranslation();
+  const ownerLabel = entry.ownerName?.trim() || entry.ownerEmail || '—';
+  return (
+    <li className="px-2 py-2 rounded-lg hover:bg-brand-blue-lighter/40 transition-colors">
+      <div className="flex items-baseline justify-between gap-2">
+        <div className="text-xs font-bold text-slate-800 truncate">
+          {entry.title}
+        </div>
+        <StatusDot status={entry.status} />
+      </div>
+      <p className="text-xxs text-slate-500 truncate mt-0.5">
+        {t('plcDashboard.overview.tiles.activeAssignments.byOwner', {
+          name: ownerLabel,
+          defaultValue: 'by {{name}}',
+        })}
+      </p>
+    </li>
+  );
+};
+
+/**
+ * Compact status indicator — emerald dot for active, amber for paused.
+ * Smaller than the full `StatusPill` used in the sub-tab row so it fits
+ * the bento tile's tighter type scale.
+ */
+const StatusDot: React.FC<{ status: QuizAssignmentStatus }> = ({ status }) => {
+  const { t } = useTranslation();
+  if (status === 'active') {
+    return (
+      <span
+        className="shrink-0 inline-flex items-center gap-1 text-[10px] font-bold uppercase tracking-wider text-emerald-700"
+        title={t('plcDashboard.assignmentsInProgress.statusActive', {
+          defaultValue: 'Active',
+        })}
+      >
+        <span className="w-1.5 h-1.5 rounded-full bg-emerald-500" />
+        {t('plcDashboard.assignmentsInProgress.statusActive', {
+          defaultValue: 'Active',
+        })}
+      </span>
+    );
+  }
+  return (
+    <span
+      className="shrink-0 inline-flex items-center gap-1 text-[10px] font-bold uppercase tracking-wider text-amber-700"
+      title={t('plcDashboard.assignmentsInProgress.statusPaused', {
+        defaultValue: 'Paused',
+      })}
+    >
+      <span className="w-1.5 h-1.5 rounded-full bg-amber-500" />
+      {t('plcDashboard.assignmentsInProgress.statusPaused', {
+        defaultValue: 'Paused',
+      })}
+    </span>
+  );
+};

--- a/components/plc/overview/tiles/ActiveAssignmentsTile.tsx
+++ b/components/plc/overview/tiles/ActiveAssignmentsTile.tsx
@@ -18,11 +18,32 @@
 
 import React, { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { ClipboardList, ChevronRight, Loader2 } from 'lucide-react';
+import {
+  ClipboardList,
+  ChevronRight,
+  ExternalLink,
+  Loader2,
+} from 'lucide-react';
 
 import { Plc, PlcAssignmentIndexEntry, QuizAssignmentStatus } from '@/types';
 import { usePlcAssignmentIndex } from '@/hooks/usePlcAssignmentIndex';
 import type { PlcDashboardTabId } from '../../PlcDashboard';
+
+/**
+ * Defense-in-depth: only render the entry's `sheetUrl` as a link if it
+ * parses as an `http:` or `https:` URL. Mirrors the same guard used in
+ * `PlcAssignmentIndexRow` — the rule layer pins `sheetUrl` to the PLC's
+ * canonical `sharedSheetUrl`, but a stale entry shouldn't be able to
+ * smuggle a `javascript:` URL through the tile.
+ */
+function isSafeHttpUrl(value: string): boolean {
+  try {
+    const parsed = new URL(value);
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
 
 interface ActiveAssignmentsTileProps {
   plc: Plc;
@@ -115,6 +136,7 @@ const ActiveAssignmentRow: React.FC<{ entry: PlcAssignmentIndexEntry }> = ({
 }) => {
   const { t } = useTranslation();
   const ownerLabel = entry.ownerName?.trim() || entry.ownerEmail || '—';
+  const safeSheetUrl = isSafeHttpUrl(entry.sheetUrl) ? entry.sheetUrl : null;
   return (
     <li className="px-2 py-2 rounded-lg hover:bg-brand-blue-lighter/40 transition-colors">
       <div className="flex items-baseline justify-between gap-2">
@@ -123,12 +145,37 @@ const ActiveAssignmentRow: React.FC<{ entry: PlcAssignmentIndexEntry }> = ({
         </div>
         <StatusDot status={entry.status} />
       </div>
-      <p className="text-xxs text-slate-500 truncate mt-0.5">
-        {t('plcDashboard.overview.tiles.activeAssignments.byOwner', {
-          name: ownerLabel,
-          defaultValue: 'by {{name}}',
-        })}
-      </p>
+      <div className="flex items-center justify-between gap-2 mt-0.5">
+        <p className="text-xxs text-slate-500 truncate">
+          {t('plcDashboard.overview.tiles.activeAssignments.byOwner', {
+            name: ownerLabel,
+            defaultValue: 'by {{name}}',
+          })}
+        </p>
+        {safeSheetUrl && (
+          <a
+            href={safeSheetUrl}
+            target="_blank"
+            rel="noreferrer noopener"
+            className="shrink-0 inline-flex items-center gap-1 text-[10px] font-bold uppercase tracking-wider text-brand-blue-primary hover:underline"
+            // Stops bubbling so a future row-click → tab-navigate wiring
+            // (added on QuizLibrary / VideoActivities tiles) doesn't fire
+            // when the user actually wanted to follow the sheet link.
+            onClick={(e) => e.stopPropagation()}
+            title={t(
+              'plcDashboard.overview.tiles.activeAssignments.openSheet',
+              {
+                defaultValue: 'Open results sheet',
+              }
+            )}
+          >
+            <ExternalLink className="w-2.5 h-2.5" aria-hidden="true" />
+            {t('plcDashboard.overview.tiles.activeAssignments.sheet', {
+              defaultValue: 'Sheet',
+            })}
+          </a>
+        )}
+      </div>
     </li>
   );
 };

--- a/components/plc/overview/tiles/QuizLibraryTile.tsx
+++ b/components/plc/overview/tiles/QuizLibraryTile.tsx
@@ -71,30 +71,37 @@ export const QuizLibraryTile: React.FC<QuizLibraryTileProps> = ({
         ) : (
           <ul className="space-y-2 py-1">
             {preview.map((quiz) => (
-              <li
-                key={quiz.id}
-                className="px-2 py-2 rounded-lg hover:bg-brand-blue-lighter/40 transition-colors"
-              >
-                <div className="flex items-baseline justify-between gap-2">
-                  <div className="text-xs font-bold text-slate-800 truncate">
-                    {quiz.title}
+              <li key={quiz.id}>
+                <button
+                  type="button"
+                  onClick={() => onNavigateTab('quizzes')}
+                  className="w-full text-left px-2 py-2 rounded-lg hover:bg-brand-blue-lighter/40 focus-visible:bg-brand-blue-lighter/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue-primary/40 transition-colors"
+                  title={t(
+                    'plcDashboard.overview.tiles.quizLibrary.rowTooltip',
+                    { defaultValue: 'Open in PLC Quiz Library tab' }
+                  )}
+                >
+                  <div className="flex items-baseline justify-between gap-2">
+                    <div className="text-xs font-bold text-slate-800 truncate">
+                      {quiz.title}
+                    </div>
+                    <span className="shrink-0 text-xxs text-slate-400">
+                      {t(
+                        'plcDashboard.overview.tiles.quizLibrary.questionCount',
+                        {
+                          count: quiz.questionCount,
+                          defaultValue: '{{count}} q',
+                        }
+                      )}
+                    </span>
                   </div>
-                  <span className="shrink-0 text-xxs text-slate-400">
-                    {t(
-                      'plcDashboard.overview.tiles.quizLibrary.questionCount',
-                      {
-                        count: quiz.questionCount,
-                        defaultValue: '{{count}} q',
-                      }
-                    )}
-                  </span>
-                </div>
-                <p className="text-xxs text-slate-500 truncate mt-0.5">
-                  {t('plcDashboard.overview.tiles.quizLibrary.bySharer', {
-                    name: quiz.sharedByName || quiz.sharedByEmail || '—',
-                    defaultValue: 'shared by {{name}}',
-                  })}
-                </p>
+                  <p className="text-xxs text-slate-500 truncate mt-0.5">
+                    {t('plcDashboard.overview.tiles.quizLibrary.bySharer', {
+                      name: quiz.sharedByName || quiz.sharedByEmail || '—',
+                      defaultValue: 'shared by {{name}}',
+                    })}
+                  </p>
+                </button>
               </li>
             ))}
           </ul>

--- a/components/plc/overview/tiles/SharedBoardsTile.tsx
+++ b/components/plc/overview/tiles/SharedBoardsTile.tsx
@@ -1,0 +1,113 @@
+/**
+ * SharedBoardsTile — Phase 6 bento tile for PLC-scoped shared dashboards.
+ * Replaces the `ComingSoonTile` placeholder in `tileRegistry.tsx`.
+ *
+ * Compact preview list — 4 most recent shares — with an "Open boards"
+ * footer that drops into the full tab.
+ */
+
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { ChevronRight, LayoutDashboard, Loader2 } from 'lucide-react';
+import { Plc } from '@/types';
+import { usePlcSharedBoards } from '@/hooks/usePlcSharedBoards';
+import type { PlcDashboardTabId } from '../../PlcDashboard';
+
+interface SharedBoardsTileProps {
+  plc: Plc;
+  onNavigateTab: (tabId: PlcDashboardTabId) => void;
+}
+
+const PREVIEW_LIMIT = 4;
+
+export const SharedBoardsTile: React.FC<SharedBoardsTileProps> = ({
+  plc,
+  onNavigateTab,
+}) => {
+  const { t } = useTranslation();
+  const { boards, loading } = usePlcSharedBoards(plc.id);
+  const preview = boards.slice(0, PREVIEW_LIMIT);
+
+  return (
+    <div className="h-full flex flex-col">
+      <div className="flex items-center gap-2 px-4 pt-4 pb-2">
+        <div className="w-7 h-7 rounded-lg bg-brand-blue-lighter flex items-center justify-center">
+          <LayoutDashboard className="w-3.5 h-3.5 text-brand-blue-primary" />
+        </div>
+        <h4 className="text-xxs font-bold uppercase tracking-widest text-slate-500">
+          {t('plcDashboard.overview.tiles.sharedBoards.heading', {
+            defaultValue: 'Shared Boards',
+          })}
+        </h4>
+        {boards.length > 0 && (
+          <span className="ml-auto text-xs font-bold text-slate-700">
+            {boards.length}
+          </span>
+        )}
+      </div>
+
+      <div className="flex-1 min-h-0 overflow-y-auto custom-scrollbar px-4 pb-2">
+        {loading ? (
+          <div className="flex items-center justify-center h-full text-slate-400">
+            <Loader2 className="w-4 h-4 animate-spin" />
+          </div>
+        ) : preview.length === 0 ? (
+          <div className="flex flex-col items-center justify-center h-full text-center text-xs text-slate-500 py-2">
+            <LayoutDashboard className="w-6 h-6 text-slate-300 mb-2" />
+            <p className="font-semibold text-slate-600">
+              {t('plcDashboard.overview.tiles.sharedBoards.empty', {
+                defaultValue: 'No shared boards',
+              })}
+            </p>
+            <p className="text-xxs text-slate-400 mt-1">
+              {t('plcDashboard.overview.tiles.sharedBoards.emptySubtitle', {
+                defaultValue: 'Share a dashboard with this PLC to add it here.',
+              })}
+            </p>
+          </div>
+        ) : (
+          <ul className="space-y-2 py-1">
+            {preview.map((board) => (
+              <li
+                key={board.id}
+                className="px-2 py-2 rounded-lg hover:bg-brand-blue-lighter/40 transition-colors"
+              >
+                <div className="flex items-baseline justify-between gap-2">
+                  <div className="text-xs font-bold text-slate-800 truncate">
+                    {board.name ||
+                      t('plcDashboard.overview.tiles.sharedBoards.untitled', {
+                        defaultValue: 'Untitled dashboard',
+                      })}
+                  </div>
+                  <span className="shrink-0 text-xxs text-slate-400">
+                    {t('plcDashboard.overview.tiles.sharedBoards.widgetCount', {
+                      count: board.widgetCount,
+                      defaultValue: '{{count}} w',
+                    })}
+                  </span>
+                </div>
+                <p className="text-xxs text-slate-500 truncate mt-0.5">
+                  {t('plcDashboard.overview.tiles.sharedBoards.bySharer', {
+                    name: board.originalAuthorName || '—',
+                    defaultValue: 'shared by {{name}}',
+                  })}
+                </p>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+
+      <button
+        type="button"
+        onClick={() => onNavigateTab('sharedBoards')}
+        className="flex items-center justify-center gap-1.5 px-4 py-2.5 border-t border-slate-100 text-xxs font-bold uppercase tracking-wider text-brand-blue-primary hover:bg-brand-blue-lighter/40 transition-colors"
+      >
+        {t('plcDashboard.overview.tiles.sharedBoards.openAll', {
+          defaultValue: 'Open boards',
+        })}
+        <ChevronRight className="w-3 h-3" />
+      </button>
+    </div>
+  );
+};

--- a/components/plc/overview/tiles/SharedBoardsTile.tsx
+++ b/components/plc/overview/tiles/SharedBoardsTile.tsx
@@ -68,30 +68,40 @@ export const SharedBoardsTile: React.FC<SharedBoardsTileProps> = ({
         ) : (
           <ul className="space-y-2 py-1">
             {preview.map((board) => (
-              <li
-                key={board.id}
-                className="px-2 py-2 rounded-lg hover:bg-brand-blue-lighter/40 transition-colors"
-              >
-                <div className="flex items-baseline justify-between gap-2">
-                  <div className="text-xs font-bold text-slate-800 truncate">
-                    {board.name ||
-                      t('plcDashboard.overview.tiles.sharedBoards.untitled', {
-                        defaultValue: 'Untitled dashboard',
-                      })}
+              <li key={board.id}>
+                <button
+                  type="button"
+                  onClick={() => onNavigateTab('sharedBoards')}
+                  className="w-full text-left px-2 py-2 rounded-lg hover:bg-brand-blue-lighter/40 focus-visible:bg-brand-blue-lighter/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue-primary/40 transition-colors"
+                  title={t(
+                    'plcDashboard.overview.tiles.sharedBoards.rowTooltip',
+                    { defaultValue: 'Open in PLC Shared Boards tab' }
+                  )}
+                >
+                  <div className="flex items-baseline justify-between gap-2">
+                    <div className="text-xs font-bold text-slate-800 truncate">
+                      {board.name ||
+                        t('plcDashboard.overview.tiles.sharedBoards.untitled', {
+                          defaultValue: 'Untitled dashboard',
+                        })}
+                    </div>
+                    <span className="shrink-0 text-xxs text-slate-400">
+                      {t(
+                        'plcDashboard.overview.tiles.sharedBoards.widgetCount',
+                        {
+                          count: board.widgetCount,
+                          defaultValue: '{{count}} w',
+                        }
+                      )}
+                    </span>
                   </div>
-                  <span className="shrink-0 text-xxs text-slate-400">
-                    {t('plcDashboard.overview.tiles.sharedBoards.widgetCount', {
-                      count: board.widgetCount,
-                      defaultValue: '{{count}} w',
+                  <p className="text-xxs text-slate-500 truncate mt-0.5">
+                    {t('plcDashboard.overview.tiles.sharedBoards.bySharer', {
+                      name: board.originalAuthorName || '—',
+                      defaultValue: 'shared by {{name}}',
                     })}
-                  </span>
-                </div>
-                <p className="text-xxs text-slate-500 truncate mt-0.5">
-                  {t('plcDashboard.overview.tiles.sharedBoards.bySharer', {
-                    name: board.originalAuthorName || '—',
-                    defaultValue: 'shared by {{name}}',
-                  })}
-                </p>
+                  </p>
+                </button>
               </li>
             ))}
           </ul>

--- a/components/plc/overview/tiles/VideoActivitiesTile.tsx
+++ b/components/plc/overview/tiles/VideoActivitiesTile.tsx
@@ -70,31 +70,40 @@ export const VideoActivitiesTile: React.FC<VideoActivitiesTileProps> = ({
         ) : (
           <ul className="space-y-2 py-1">
             {preview.map((activity) => (
-              <li
-                key={activity.id}
-                className="px-2 py-2 rounded-lg hover:bg-brand-blue-lighter/40 transition-colors"
-              >
-                <div className="flex items-baseline justify-between gap-2">
-                  <div className="text-xs font-bold text-slate-800 truncate">
-                    {activity.title}
+              <li key={activity.id}>
+                <button
+                  type="button"
+                  onClick={() => onNavigateTab('videoActivities')}
+                  className="w-full text-left px-2 py-2 rounded-lg hover:bg-brand-blue-lighter/40 focus-visible:bg-brand-blue-lighter/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue-primary/40 transition-colors"
+                  title={t(
+                    'plcDashboard.overview.tiles.videoActivities.rowTooltip',
+                    {
+                      defaultValue: 'Open in PLC Video Activities tab',
+                    }
+                  )}
+                >
+                  <div className="flex items-baseline justify-between gap-2">
+                    <div className="text-xs font-bold text-slate-800 truncate">
+                      {activity.title}
+                    </div>
+                    <span className="shrink-0 text-xxs text-slate-400">
+                      {t(
+                        'plcDashboard.overview.tiles.videoActivities.questionCount',
+                        {
+                          count: activity.questionCount,
+                          defaultValue: '{{count}} q',
+                        }
+                      )}
+                    </span>
                   </div>
-                  <span className="shrink-0 text-xxs text-slate-400">
-                    {t(
-                      'plcDashboard.overview.tiles.videoActivities.questionCount',
-                      {
-                        count: activity.questionCount,
-                        defaultValue: '{{count}} q',
-                      }
-                    )}
-                  </span>
-                </div>
-                <p className="text-xxs text-slate-500 truncate mt-0.5">
-                  {t('plcDashboard.overview.tiles.videoActivities.bySharer', {
-                    name:
-                      activity.sharedByName || activity.sharedByEmail || '—',
-                    defaultValue: 'shared by {{name}}',
-                  })}
-                </p>
+                  <p className="text-xxs text-slate-500 truncate mt-0.5">
+                    {t('plcDashboard.overview.tiles.videoActivities.bySharer', {
+                      name:
+                        activity.sharedByName || activity.sharedByEmail || '—',
+                      defaultValue: 'shared by {{name}}',
+                    })}
+                  </p>
+                </button>
               </li>
             ))}
           </ul>

--- a/components/plc/overview/tiles/VideoActivitiesTile.tsx
+++ b/components/plc/overview/tiles/VideoActivitiesTile.tsx
@@ -1,0 +1,116 @@
+/**
+ * VideoActivitiesTile — Phase 4 bento tile for the PLC Video Activity
+ * Library. Mirrors `QuizLibraryTile` rhythm: small heading + count
+ * badge, scrollable preview list (4 most recent), "Open library" footer.
+ *
+ * The "Coming soon" placeholder previously occupying this slot is now
+ * routed away in `tileRegistry.tsx`.
+ */
+
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { ChevronRight, Film, Loader2 } from 'lucide-react';
+import { Plc } from '@/types';
+import { usePlcVideoActivities } from '@/hooks/usePlcVideoActivities';
+import type { PlcDashboardTabId } from '../../PlcDashboard';
+
+interface VideoActivitiesTileProps {
+  plc: Plc;
+  onNavigateTab: (tabId: PlcDashboardTabId) => void;
+}
+
+const PREVIEW_LIMIT = 4;
+
+export const VideoActivitiesTile: React.FC<VideoActivitiesTileProps> = ({
+  plc,
+  onNavigateTab,
+}) => {
+  const { t } = useTranslation();
+  const { videoActivities, loading } = usePlcVideoActivities(plc.id);
+  const preview = videoActivities.slice(0, PREVIEW_LIMIT);
+
+  return (
+    <div className="h-full flex flex-col">
+      <div className="flex items-center gap-2 px-4 pt-4 pb-2">
+        <div className="w-7 h-7 rounded-lg bg-brand-blue-lighter flex items-center justify-center">
+          <Film className="w-3.5 h-3.5 text-brand-blue-primary" />
+        </div>
+        <h4 className="text-xxs font-bold uppercase tracking-widest text-slate-500">
+          {t('plcDashboard.overview.tiles.videoActivities.heading', {
+            defaultValue: 'Video Activities',
+          })}
+        </h4>
+        {videoActivities.length > 0 && (
+          <span className="ml-auto text-xs font-bold text-slate-700">
+            {videoActivities.length}
+          </span>
+        )}
+      </div>
+
+      <div className="flex-1 min-h-0 overflow-y-auto custom-scrollbar px-4 pb-2">
+        {loading ? (
+          <div className="flex items-center justify-center h-full text-slate-400">
+            <Loader2 className="w-4 h-4 animate-spin" />
+          </div>
+        ) : preview.length === 0 ? (
+          <div className="flex flex-col items-center justify-center h-full text-center text-xs text-slate-500 py-2">
+            <Film className="w-6 h-6 text-slate-300 mb-2" />
+            <p className="font-semibold text-slate-600">
+              {t('plcDashboard.overview.tiles.videoActivities.empty', {
+                defaultValue: 'No shared activities',
+              })}
+            </p>
+            <p className="text-xxs text-slate-400 mt-1">
+              {t('plcDashboard.overview.tiles.videoActivities.emptySubtitle', {
+                defaultValue:
+                  'Share an activity from the kebab on its library card.',
+              })}
+            </p>
+          </div>
+        ) : (
+          <ul className="space-y-2 py-1">
+            {preview.map((activity) => (
+              <li
+                key={activity.id}
+                className="px-2 py-2 rounded-lg hover:bg-brand-blue-lighter/40 transition-colors"
+              >
+                <div className="flex items-baseline justify-between gap-2">
+                  <div className="text-xs font-bold text-slate-800 truncate">
+                    {activity.title}
+                  </div>
+                  <span className="shrink-0 text-xxs text-slate-400">
+                    {t(
+                      'plcDashboard.overview.tiles.videoActivities.questionCount',
+                      {
+                        count: activity.questionCount,
+                        defaultValue: '{{count}} q',
+                      }
+                    )}
+                  </span>
+                </div>
+                <p className="text-xxs text-slate-500 truncate mt-0.5">
+                  {t('plcDashboard.overview.tiles.videoActivities.bySharer', {
+                    name:
+                      activity.sharedByName || activity.sharedByEmail || '—',
+                    defaultValue: 'shared by {{name}}',
+                  })}
+                </p>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+
+      <button
+        type="button"
+        onClick={() => onNavigateTab('videoActivities')}
+        className="flex items-center justify-center gap-1.5 px-4 py-2.5 border-t border-slate-100 text-xxs font-bold uppercase tracking-wider text-brand-blue-primary hover:bg-brand-blue-lighter/40 transition-colors"
+      >
+        {t('plcDashboard.overview.tiles.videoActivities.openAll', {
+          defaultValue: 'Open library',
+        })}
+        <ChevronRight className="w-3 h-3" />
+      </button>
+    </div>
+  );
+};

--- a/components/plc/tabs/PlcSharedBoardsTab.tsx
+++ b/components/plc/tabs/PlcSharedBoardsTab.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { Plc } from '@/types';
+import { PlcSharedBoardsBody } from '../bodies/PlcSharedBoardsBody';
+
+interface PlcSharedBoardsTabProps {
+  plc: Plc;
+}
+
+/**
+ * Tab-mode wrapper around the shared `PlcSharedBoardsBody`. Mirrors the
+ * `PlcQuizLibraryTab` shape — placement-only shim used by the legacy
+ * v1 dashboard tab routing. The v2 grid renders the body directly
+ * inside a tile (or its fullscreen expansion).
+ */
+export const PlcSharedBoardsTab: React.FC<PlcSharedBoardsTabProps> = ({
+  plc,
+}) => {
+  return <PlcSharedBoardsBody plc={plc} />;
+};

--- a/components/plc/tabs/PlcVideoActivitiesTab.tsx
+++ b/components/plc/tabs/PlcVideoActivitiesTab.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { Plc } from '@/types';
+import { PlcVideoActivitiesBody } from '../bodies/PlcVideoActivitiesBody';
+
+interface PlcVideoActivitiesTabProps {
+  plc: Plc;
+}
+
+/**
+ * Tab-mode wrapper around the shared `PlcVideoActivitiesBody`. Mirrors
+ * the `PlcQuizLibraryTab` shape — placement-only shim used by the legacy
+ * v1 dashboard tab routing. The v2 grid renders the body directly inside
+ * a tile (or its fullscreen expansion).
+ */
+export const PlcVideoActivitiesTab: React.FC<PlcVideoActivitiesTabProps> = ({
+  plc,
+}) => {
+  return <PlcVideoActivitiesBody plc={plc} />;
+};

--- a/components/share/ShareLinkCreatorModal.tsx
+++ b/components/share/ShareLinkCreatorModal.tsx
@@ -12,6 +12,7 @@
  */
 
 import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Cloud, Copy, Eye, Check, ExternalLink, X } from 'lucide-react';
 import { Modal } from '@/components/common/Modal';
 import { useDashboard } from '@/context/useDashboard';
@@ -83,6 +84,7 @@ export const ShareLinkCreatorModal: React.FC<ShareLinkCreatorModalProps> = ({
   isOpen,
   onClose,
 }) => {
+  const { t } = useTranslation();
   const { shareDashboard, addToast } = useDashboard();
   const { canAccessFeature } = useAuth();
   const { plcs } = usePlcs();
@@ -263,12 +265,20 @@ export const ShareLinkCreatorModal: React.FC<ShareLinkCreatorModalProps> = ({
                 htmlFor="share-plc-scope"
                 className="block text-xs font-bold text-slate-700"
               >
-                Also share with a PLC{' '}
-                <span className="text-slate-400 font-normal">(optional)</span>
+                {t('shareLinkCreatorModal.plcScope.label', {
+                  defaultValue: 'Also share with a PLC',
+                })}{' '}
+                <span className="text-slate-400 font-normal">
+                  {t('shareLinkCreatorModal.plcScope.optional', {
+                    defaultValue: '(optional)',
+                  })}
+                </span>
               </label>
               <p className="text-[11px] text-slate-500 leading-relaxed">
-                Tags this share so it shows up on the picked PLC&apos;s Shared
-                Boards tab in addition to whoever you send the link to.
+                {t('shareLinkCreatorModal.plcScope.description', {
+                  defaultValue:
+                    "Tags this share so it shows up on the picked PLC's Shared Boards tab in addition to whoever you send the link to.",
+                })}
               </p>
               <select
                 id="share-plc-scope"
@@ -276,7 +286,11 @@ export const ShareLinkCreatorModal: React.FC<ShareLinkCreatorModalProps> = ({
                 onChange={(e) => setPlcId(e.target.value || null)}
                 className="w-full rounded-md border border-slate-300 bg-white px-2 py-1.5 text-xs text-slate-700 focus:outline-none focus:ring-2 focus:ring-brand-blue-primary/40"
               >
-                <option value="">Don&apos;t scope to a PLC</option>
+                <option value="">
+                  {t('shareLinkCreatorModal.plcScope.none', {
+                    defaultValue: "Don't scope to a PLC",
+                  })}
+                </option>
                 {plcs.map((plc) => (
                   <option key={plc.id} value={plc.id}>
                     {plc.name}

--- a/components/share/ShareLinkCreatorModal.tsx
+++ b/components/share/ShareLinkCreatorModal.tsx
@@ -16,6 +16,7 @@ import { Cloud, Copy, Eye, Check, ExternalLink, X } from 'lucide-react';
 import { Modal } from '@/components/common/Modal';
 import { useDashboard } from '@/context/useDashboard';
 import { useAuth } from '@/context/useAuth';
+import { usePlcs } from '@/hooks/usePlcs';
 import type { Dashboard } from '@/types';
 import type { SharedBoardImportMode } from '@/context/DashboardContextValue';
 
@@ -84,7 +85,13 @@ export const ShareLinkCreatorModal: React.FC<ShareLinkCreatorModalProps> = ({
 }) => {
   const { shareDashboard, addToast } = useDashboard();
   const { canAccessFeature } = useAuth();
+  const { plcs } = usePlcs();
   const [mode, setMode] = useState<SharedBoardImportMode>('synced');
+  // Phase 6 — optional PLC scope. `null` (default) means a plain share
+  // link with no PLC affiliation. Picking a PLC tags the resulting share
+  // doc with `plcId`, surfacing it on that PLC's Shared Boards tab in
+  // addition to whoever the host sends the link to.
+  const [plcId, setPlcId] = useState<string | null>(null);
   const [creating, setCreating] = useState(false);
   const [createdUrl, setCreatedUrl] = useState<string | null>(null);
   const [copied, setCopied] = useState(false);
@@ -93,6 +100,7 @@ export const ShareLinkCreatorModal: React.FC<ShareLinkCreatorModalProps> = ({
   React.useEffect(() => {
     if (isOpen) {
       setMode('synced');
+      setPlcId(null);
       setCreating(false);
       setCreatedUrl(null);
       setCopied(false);
@@ -107,7 +115,7 @@ export const ShareLinkCreatorModal: React.FC<ShareLinkCreatorModalProps> = ({
     if (!canShare || creating) return;
     setCreating(true);
     try {
-      const shareId = await shareDashboard(dashboard, mode);
+      const shareId = await shareDashboard(dashboard, mode, plcId ?? undefined);
       const url = `${window.location.origin}/share/${shareId}`;
       setCreatedUrl(url);
       try {
@@ -249,6 +257,34 @@ export const ShareLinkCreatorModal: React.FC<ShareLinkCreatorModalProps> = ({
             Icon={Copy}
             onPick={setMode}
           />
+          {plcs.length > 0 && (
+            <div className="rounded-xl border border-slate-200 bg-slate-50/60 px-4 py-3 space-y-2">
+              <label
+                htmlFor="share-plc-scope"
+                className="block text-xs font-bold text-slate-700"
+              >
+                Also share with a PLC{' '}
+                <span className="text-slate-400 font-normal">(optional)</span>
+              </label>
+              <p className="text-[11px] text-slate-500 leading-relaxed">
+                Tags this share so it shows up on the picked PLC&apos;s Shared
+                Boards tab in addition to whoever you send the link to.
+              </p>
+              <select
+                id="share-plc-scope"
+                value={plcId ?? ''}
+                onChange={(e) => setPlcId(e.target.value || null)}
+                className="w-full rounded-md border border-slate-300 bg-white px-2 py-1.5 text-xs text-slate-700 focus:outline-none focus:ring-2 focus:ring-brand-blue-primary/40"
+              >
+                <option value="">Don&apos;t scope to a PLC</option>
+                {plcs.map((plc) => (
+                  <option key={plc.id} value={plc.id}>
+                    {plc.name}
+                  </option>
+                ))}
+              </select>
+            </div>
+          )}
           <button
             type="button"
             onClick={() => void handleCreate()}

--- a/components/widgets/VideoActivityWidget/Widget.tsx
+++ b/components/widgets/VideoActivityWidget/Widget.tsx
@@ -27,6 +27,14 @@ import { useVideoActivitySessionTeacher } from '@/hooks/useVideoActivitySession'
 import { useVideoActivityAssignments } from '@/hooks/useVideoActivityAssignments';
 import { useBusyIdSet } from '@/hooks/useBusyIdSet';
 import { useFolders } from '@/hooks/useFolders';
+import { usePlcs } from '@/hooks/usePlcs';
+import {
+  callLeaveSyncedVideoActivityGroup,
+  createSyncedVideoActivityGroup,
+} from '@/hooks/useSyncedVideoActivityGroups';
+import { writePlcVideoActivityEntry } from '@/hooks/usePlcVideoActivities';
+import { PlcShareTargetModal } from '@/components/plc/PlcShareTargetModal';
+import { logError } from '@/utils/logError';
 import { VideoActivityManager } from './components/VideoActivityManager';
 import { Creator } from './components/Creator';
 import { Results } from './components/Results';
@@ -87,9 +95,12 @@ export const VideoActivityWidget: React.FC<{ widget: WidgetData }> = ({
     loadActivityData,
     deleteActivity,
     duplicateActivity,
+    attachSyncLinkage,
     createTemplateSheet,
     isDriveConnected,
   } = useVideoActivity(user?.uid);
+
+  const { plcs } = usePlcs();
 
   const {
     createSession,
@@ -114,6 +125,12 @@ export const VideoActivityWidget: React.FC<{ widget: WidgetData }> = ({
 
   const [publishingAssignment, setPublishingAssignment] =
     useState<VideoActivityAssignment | null>(null);
+
+  // PLC share target — set when the teacher picks "Share with PLC" on a
+  // library row. The `PlcShareTargetModal` is rendered as a sibling and
+  // gates the actual `handleShareWithPlc` call on PLC selection.
+  const [shareWithPlcTarget, setShareWithPlcTarget] =
+    useState<VideoActivityMetadata | null>(null);
 
   const [loadingActivity, setLoadingActivity] = useState(false);
   const [selectedSession, setSelectedSession] =
@@ -217,6 +234,88 @@ export const VideoActivityWidget: React.FC<{ widget: WidgetData }> = ({
     widget.id,
     config,
   ]);
+
+  /**
+   * Share a video activity with a PLC. Mirrors `QuizWidget.handleShareWithPlc`:
+   *   1. Load Drive content for the activity.
+   *   2. Promote to a synced group (if not already synced).
+   *      - Mint `synced_video_activities/{groupId}` via
+   *        `createSyncedVideoActivityGroup`.
+   *      - Attach the sync linkage to the local Firestore metadata so the
+   *        library card thereafter surfaces the "Synced" pill.
+   *      - On linkage failure, best-effort leave the just-minted group so
+   *        we don't leak a phantom participant.
+   *   3. Write the `plcs/{plcId}/video_activities/{uuid}` header doc via
+   *      `writePlcVideoActivityEntry`.
+   *
+   * If step 3 fails after step 2 succeeded, the synced group + sync
+   * linkage stay in place — the local library card still shows the
+   * "Synced" pill (self-only group), and a retry of "Share with PLC"
+   * reuses the existing groupId rather than minting a new one. Idempotent
+   * on retry.
+   */
+  const handleShareWithPlc = useCallback(
+    async (
+      activityMeta: VideoActivityMetadata,
+      plcId: string
+    ): Promise<void> => {
+      if (!user) throw new Error('Not authenticated.');
+      const plc = plcs.find((p) => p.id === plcId);
+      if (!plc) {
+        throw new Error('That PLC is no longer available.');
+      }
+      const data = await loadActivityData(activityMeta.driveFileId);
+
+      let syncGroupId: string;
+      if (activityMeta.sync) {
+        syncGroupId = activityMeta.sync.groupId;
+      } else {
+        syncGroupId = crypto.randomUUID();
+        await createSyncedVideoActivityGroup({
+          groupId: syncGroupId,
+          uid: user.uid,
+          title: data.title,
+          youtubeUrl: data.youtubeUrl,
+          questions: data.questions,
+          plcId,
+        });
+        try {
+          await attachSyncLinkage(activityMeta.id, {
+            groupId: syncGroupId,
+            lastSyncedVersion: 1,
+          });
+        } catch (linkageErr) {
+          // Best-effort rollback so the freshly-minted group doesn't
+          // dangle with a phantom participant pointing at a local
+          // library that never recorded the linkage.
+          try {
+            await callLeaveSyncedVideoActivityGroup(syncGroupId);
+          } catch (leaveErr) {
+            logError(
+              'VideoActivityWidget.shareWithPlc.rollbackLeave',
+              leaveErr,
+              { plcId, syncGroupId }
+            );
+          }
+          throw linkageErr;
+        }
+      }
+
+      const ownerEmailLower =
+        plc.memberEmails?.[user.uid] ??
+        (user.email ? user.email.toLowerCase() : '');
+      await writePlcVideoActivityEntry(plcId, user.uid, {
+        plcVideoActivityId: crypto.randomUUID(),
+        syncGroupId,
+        title: data.title,
+        youtubeUrl: data.youtubeUrl,
+        questionCount: data.questions.length,
+        sharedByName: user.displayName ?? '',
+        sharedByEmail: ownerEmailLower,
+      });
+    },
+    [attachSyncLinkage, loadActivityData, plcs, user]
+  );
 
   // ─── Guards ────────────────────────────────────────────────────────────────
 
@@ -745,6 +844,16 @@ export const VideoActivityWidget: React.FC<{ widget: WidgetData }> = ({
             config: { ...config, libraryViewMode: mode } as VideoActivityConfig,
           });
         }}
+        onShareWithPlc={(meta) => {
+          if (plcs.length === 0) {
+            addToast(
+              'Join a PLC from the My PLCs sidebar to share video activities with teammates.',
+              'info'
+            );
+            return;
+          }
+          setShareWithPlcTarget(meta);
+        }}
       />
       {publishingAssignment && (
         <PublishScoresModal
@@ -842,6 +951,30 @@ export const VideoActivityWidget: React.FC<{ widget: WidgetData }> = ({
           );
         }}
       />
+      {shareWithPlcTarget && (
+        <PlcShareTargetModal
+          plcs={plcs}
+          quizTitle={shareWithPlcTarget.title}
+          onConfirm={async (plcId) => {
+            try {
+              await handleShareWithPlc(shareWithPlcTarget, plcId);
+              const plcName =
+                plcs.find((p) => p.id === plcId)?.name ?? 'your PLC';
+              addToast(`Shared with ${plcName}.`, 'success');
+              setShareWithPlcTarget(null);
+            } catch (err) {
+              logError('VideoActivityWidget.shareWithPlc', err, {
+                plcId,
+                activityId: shareWithPlcTarget.id,
+              });
+              throw err instanceof Error
+                ? err
+                : new Error('Share with PLC failed.');
+            }
+          }}
+          onClose={() => setShareWithPlcTarget(null)}
+        />
+      )}
     </>
   );
 };

--- a/components/widgets/VideoActivityWidget/components/VideoActivityManager.tsx
+++ b/components/widgets/VideoActivityWidget/components/VideoActivityManager.tsx
@@ -36,6 +36,7 @@ import {
   Send,
   Share2,
   Trash2,
+  Users2,
 } from 'lucide-react';
 import { LibraryShell } from '@/components/common/library/LibraryShell';
 import { LibraryToolbar } from '@/components/common/library/LibraryToolbar';
@@ -113,6 +114,14 @@ export interface VideoActivityManagerProps {
    * harnesses).
    */
   onDuplicate?: (activity: VideoActivityMetadata) => void | Promise<void>;
+  /**
+   * Phase 4 — "Share with PLC". Invoked when the teacher picks the new
+   * kebab item on a library card. The Widget owns the PLC picker modal
+   * + the actual share write (creating the synced group + the PLC
+   * subcoll doc); this prop is the seam. The kebab entry is hidden when
+   * omitted (e.g. test harnesses).
+   */
+  onShareWithPlc?: (activity: VideoActivityMetadata) => void;
   /**
    * Optional busy-state probe. When provided, the Duplicate kebab item
    * disables itself for any activity id whose duplicate is currently
@@ -407,6 +416,7 @@ export const VideoActivityManager: React.FC<VideoActivityManagerProps> = ({
   onEdit,
   onDelete,
   onDuplicate,
+  onShareWithPlc,
   isDuplicating,
   onResults,
   onAssign,
@@ -865,6 +875,16 @@ export const VideoActivityManager: React.FC<VideoActivityManagerProps> = ({
                 onOpenPicker: () => setFolderPickerTarget(activity),
                 disabled: !userId,
               }),
+              ...(onShareWithPlc
+                ? [
+                    {
+                      id: 'share-with-plc',
+                      label: 'Share with PLC',
+                      icon: Users2,
+                      onClick: () => onShareWithPlc(activity),
+                    } satisfies LibraryMenuAction,
+                  ]
+                : []),
               {
                 id: 'delete',
                 label:

--- a/context/DashboardContext.tsx
+++ b/context/DashboardContext.tsx
@@ -789,14 +789,18 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
   const handleShareDashboard = useCallback(
     async (
       dashboard: Dashboard,
-      intendedMode?: SharedBoardImportMode
+      intendedMode?: SharedBoardImportMode,
+      plcId?: string
     ): Promise<string> => {
       // MANDATE: Share through Google Drive if available for non-admins.
       // Drive shares are one-time exports — they don't support live sync,
       // and we intentionally don't tag the local dashboard as `owner`.
       // Drive-backed shares are always Copy-mode on the receiving end;
-      // intendedMode is ignored here.
-      if (!isAdmin && driveService) {
+      // intendedMode is ignored here. PLC-scoped shares deliberately
+      // bypass the Drive path — the surfacing surface (PLC Dashboard
+      // Shared Boards tab) reads from Firestore, so a Drive-only share
+      // would be invisible to teammates.
+      if (!plcId && !isAdmin && driveService) {
         try {
           const fileId = await driveService.exportDashboard(dashboard);
           await driveService.makePublic(fileId, userDomain);
@@ -819,7 +823,8 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
       const shareId = await shareDashboardFirestore(
         scrubbedSeed,
         intendedMode,
-        hostName
+        hostName,
+        plcId
       );
       // Copy-mode shares are one-time snapshots. Don't tag the local
       // dashboard as a live owner — there's no live sync to wire up.

--- a/context/DashboardContextValue.ts
+++ b/context/DashboardContextValue.ts
@@ -137,7 +137,14 @@ export interface DashboardContextValue {
   // Sharing system
   shareDashboard: (
     dashboard: Dashboard,
-    intendedMode?: SharedBoardImportMode
+    intendedMode?: SharedBoardImportMode,
+    /**
+     * Phase 6 — optional PLC scope. When set, the resulting `/shared_boards/{id}`
+     * doc carries a `plcId` field so members of that PLC see the share on
+     * their PLC Dashboard's Shared Boards tab. Plc-scoped shares still
+     * generate a normal share URL the host can paste anywhere.
+     */
+    plcId?: string
   ) => Promise<string>;
   loadSharedDashboard: (shareId: string) => Promise<Dashboard | null>;
   pendingShareId: string | null;

--- a/docs/PLC_ROADMAP.md
+++ b/docs/PLC_ROADMAP.md
@@ -28,13 +28,17 @@ This roadmap is designed to be **executed in independent chunks across multiple 
 
 - [x] **Phase 1** — Dashboard shell + feature toggles + completed-assignments tab _(PR #1537)_
 - [x] **Phase 2** — PLC Quiz Library (share-with-PLC, collaborative editing, sync-or-copy import) _(PR #1547)_
-- [x] **Phase 3** — PLC-authored Assignments tab + auto-bubble-up from personal assignments _(this PR)_
-- [ ] **Phase 4** — Video Activities (extend with `PlcLinkage` + dashboard surface)
+- [x] **Phase 3** — PLC-authored Assignments tab + auto-bubble-up from personal assignments _(PR #1556)_
+- [x] **Phase 4** — Video Activities (`PlcLinkage` + library + dashboard surface) _(fully-fledged PR)_
 - [x] **Phase 5** — Notes + To-Do list (collaborative shared docs) _(bundled with Overview/Bento — see Phase 1.5 below)_
-- [ ] **Phase 6** — Shared Boards surface
+- [x] **Phase 6** — Shared Boards surface _(fully-fledged PR)_
 - [x] **Phase 1.5 (out-of-band)** — PLC Overview tab with per-user customizable bento grid + sidebar kebab UX
+- [ ] **Phase 7 (proposed)** — Mini-apps PLC integration _(not in original roadmap)_
+- [ ] **Phase 8 (proposed)** — Guided Learning PLC integration _(not in original roadmap)_
 
-> **Phase 1.5 deviation note:** Phase 5 (Notes + To-Dos) was pulled forward and shipped alongside the Overview tab + bento grid + sidebar kebab refactor in a single PR. This deviates from the "one phase per PR" rule because the Overview tab's bento tiles needed real content for Notes and To-Dos on day one — placeholder tiles linking to placeholder tabs would have felt empty. Phases 2/3/4/6 remain stubbed with "coming soon" tiles that swap to live data when those phases ship; the layout doesn't have to change.
+> **Phase 1.5 deviation note:** Phase 5 (Notes + To-Dos) was pulled forward and shipped alongside the Overview tab + bento grid + sidebar kebab refactor in a single PR. This deviates from the "one phase per PR" rule because the Overview tab's bento tiles needed real content for Notes and To-Dos on day one — placeholder tiles linking to placeholder tabs would have felt empty.
+>
+> **Fully-fledged PR deviation:** Phases 4 and 6 plus the in-flight roadmap follow-ups shipped together in a single multi-commit PR (`claude/plc-fully-fledged`) at the user's explicit request after noticing the dashboard still showed "Coming soon" placeholders for activeAssignments / videoActivities / sharedBoards. This deviates from "one phase per PR" too — the trade-off was reviewer load vs. user-visible coherence. After this PR, no `ComingSoonTile` is wired in `tileRegistry.tsx`; the file remains for the proposed Phase 7/8 placeholders.
 
 Branch convention: each phase opens a `claude/plc-phase-N-<slug>` branch off `dev-paul`. Do **not** target `main` directly.
 
@@ -227,30 +231,41 @@ These were surfaced in the final review pass and intentionally deferred to keep 
 
 ---
 
-## Phase 4 — Video Activities
+## Phase 4 — Video Activities _(SHIPPED)_
+
+**Status:** Shipped via the fully-fledged PR into `dev-paul` (branch `claude/plc-fully-fledged`).
 
 **Goal:** extend video activities with the same PLC linkage + dashboard surface that quizzes already have.
 
-### Scope
+### What landed
 
-- Add `plc?: PlcLinkage` to `VideoActivityAssignmentSettings` (mirror `QuizAssignmentSettings`).
-- `useVideoActivityAssignments.createAssignment` writes to the PLC index (extend `PlcAssignmentIndexEntry.kind` union to include `'video-activity'` — the discriminator slot is already there in Phase 1).
-- New `plcs/{plcId}/video_activities/{activityId}` subcollection mirroring Phase 2's quiz library pattern.
-- `PlcVideoActivitiesTab.tsx` replaces the placeholder.
-
-### Architectural notes
-
-- Video activities use a binary status (active/ended) instead of quiz's active/paused/inactive — doesn't affect the index entry shape.
-- `kind` discriminator widening: this is the first phase that meaningfully exercises the union. Update `parseEntry` in `usePlcAssignmentIndex.ts` to accept `'video-activity'` AND update the rules' `kind in ['quiz', 'video-activity']` check. The Phase 1 test (`normalizes 'kind' to 'quiz' even for legacy or wrong values`) needs to be revisited once the union widens.
-
-### Out of scope for Phase 4
-
-- Activity Wall (it's not a true assignment type — it's a collaborative student space).
-- Mini-apps (separate phase, not currently planned for PLC integration).
+- `types.ts` — new `PlcVideoActivityEntry` (lightweight header for `plcs/{plcId}/video_activities/{plcVideoActivityId}`). Carries `youtubeUrl` in addition to the quiz-entry fields so the tile + tab can render a thumbnail without loading the full content blob.
+- `hooks/usePlcVideoActivities.ts` (new) — live subscription + `shareVideoActivityWithPlc` / `mirrorPlcVideoActivityHeader` / `unshareVideoActivityFromPlc` mutators. Standalone `writePlcVideoActivityEntry` for the share-from-widget path. Mirrors `usePlcQuizzes` exactly.
+- `hooks/useVideoActivityAssignments.ts` — `createAssignment` now persists `settings.plc` onto the assignment doc (was being dropped pre-PR; the spread missed the field — silent regression caught while wiring this phase). Writes a fire-and-forget `writePlcAssignmentIndexEntry({kind: 'video-activity'})` when `settings.plc` is set. Status mutators (`pauseAssignment` / `resumeAssignment` / `deactivateAssignment` / `reactivateAssignment`) now call `mirrorPlcAssignmentStatus` via a `useRef<VideoActivityAssignment[]>` lookup mirror (mirrors the Phase 3 `useQuizAssignments` pattern).
+- `functions/src/plcVideoActivitySyncJoin.ts` (new) — `joinPlcVideoActivitySyncGroup` Cloud Function. Mirrors `plcQuizSyncJoin.ts` but resolves the synced group via `plcs/{plcId}/video_activities/{...}` and joins `synced_video_activities/{groupId}` (different sync collection than quizzes). Admin-SDK membership check before participant write. **Requires `firebase deploy --only functions:joinPlcVideoActivitySyncGroup`** before Sync-import works in real Firebase; Copy mode works without it.
+- `hooks/useSyncedVideoActivityGroups.ts` — new `callJoinPlcVideoActivitySyncGroup(plcId, plcVideoActivityId)` callable wrapper.
+- `firestore.rules` — new `match /plcs/{plcId}/video_activities/{plcVideoActivityId}` block. Same `keys().hasOnly([...])` lockdown as the Phase 2 quiz library block, plus a `youtubeUrl is string` constraint. Identity + attribution fields (`id`, `syncGroupId`, `sharedBy`, `sharedByEmail`, `sharedByName`, `sharedAt`) immutable on update.
+- `components/plc/PlcVideoActivityImportModal.tsx` (new) — sync-or-copy picker, mirror of `PlcQuizImportModal`.
+- `components/plc/bodies/PlcVideoActivitiesBody.tsx` (new) — full list + import modal + inline editor. Mirrors `PlcQuizLibraryBody` shape with one deliberate divergence: no version-conflict auto-pull on save (`useVideoActivity.saveActivity` doesn't detect synced-group version conflicts at save time — documented in the file header).
+- `components/plc/tabs/PlcVideoActivitiesTab.tsx` (new) — tab-mode shim.
+- `components/plc/overview/tiles/VideoActivitiesTile.tsx` (new) — replaces the `ComingSoonTile` placeholder for `videoActivities`.
+- `components/plc/PlcDashboard.tsx` — removed the `placeholder` block on the `videoActivities` tab def, routes the tab to `PlcVideoActivitiesTab`, adds the fullscreen-expansion case for the bento tile.
+- `components/widgets/VideoActivityWidget/Widget.tsx` — new `handleShareWithPlc` (load Drive content → mint synced group if not synced → attach linkage → write PLC subcoll doc; same rollback shape as `QuizWidget`). Adds `usePlcs()`, `PlcShareTargetModal`, and a `shareWithPlcTarget` state.
+- `components/widgets/VideoActivityWidget/components/VideoActivityManager.tsx` — new `onShareWithPlc` prop + library-row kebab item, hidden when the prop is omitted (matches the QuizManager test-harness pattern).
 
 ### Notes from implementation
 
-_(Fill in after shipping.)_
+- **`settings.plc` was being dropped on VA assignment create.** The `createAssignment` spread had `className`, `sessionSettings`, `sessionOptions`, `scoreVisibility`, `periodNames`, `rosterIds` but not `plc`. This meant any VA assignment authored with PLC mode had its PLC linkage silently stripped — the assignment ran, but PLC index entries had no source linkage and status mirroring never fired. Spread `settings.plc` onto the assignment doc to fix; this is a real bug regression that pre-dates this PR and only surfaces once the index-write path exists to consume it. No backfill — pre-existing VA assignments that intended PLC mode are stranded.
+- **Status mirror uses `useRef`-mirrored snapshot.** The status mutators look up `plc.id` from a `useRef<VideoActivityAssignment[]>` synced via effect (matches the Phase 3 `useQuizAssignments` pattern). The direct-ref pattern is blocked by `react-hooks/refs` lint here for the same reason as the quiz hook; the effect path is the workaround.
+- **No version-conflict UX on edit save.** `useVideoActivity.saveActivity` writes through to Drive + Firestore unconditionally — there's no `SyncedVideoActivityVersionConflictError` analogue to `SyncedQuizVersionConflictError`. A teammate publishing concurrently to the same group loses to last-writer-wins on `synced_video_activities/{groupId}`. The canonical doesn't tear (the synced-group publish path is debounced LWW per field), but the local `lastSyncedVersion` may briefly lag until the next pull. Acceptable for v1; a future iteration could surface a "Refresh from PLC" affordance in the editor.
+- **VA assignment template subcollection deferred.** The roadmap mentioned two paths in "Phase 4 starter": (a) widen `PlcAssignmentTemplate` with a `kind` discriminator, or (b) add a separate `plcs/{plcId}/video_activity_templates/`. Neither shipped — the PR opted to surface VAs through the **library** (`plcs/{plcId}/video_activities/`) only, not via assignment templates. Teachers create personal VA assignments with PLC mode → the assignment-index entry surfaces on the In-progress sub-tab, but there's no template equivalent in the Library sub-tab yet. A future iteration can add VA templates if the demand materializes.
+- **Cloud Function unit tests not added in this PR.** Mirrors the Phase 2/3 gap. A combined backfill PR for `joinPlcQuizSyncGroup` + `joinPlcAssignmentSyncGroup` + `joinPlcVideoActivitySyncGroup` is the natural follow-up.
+
+### Phase 4 follow-ups (not blockers; track separately)
+
+- **VA assignment-template subcollection.** See "Notes" above — current PR ships library-only.
+- **Version-conflict UX on inline edit.** Mirror `SyncedQuizVersionConflictError` for VAs.
+- **Modal i18n.** `PlcVideoActivityImportModal` uses hardcoded English. Same gap as Phase 2/3 modals.
 
 ---
 
@@ -330,27 +345,38 @@ Shipped together with Phase 1.5 (Overview + bento grid + sidebar kebab). See "Ph
 
 ---
 
-## Phase 6 — Shared Boards surface
+## Phase 6 — Shared Boards surface _(SHIPPED)_
+
+**Status:** Shipped via the fully-fledged PR into `dev-paul` (branch `claude/plc-fully-fledged`).
 
 **Goal:** surface dashboards (boards) that have been shared with a PLC.
 
-### Scope
+### What landed
 
-- Today, board sharing is per-user (`shared_boards/{shareId}`). Add a `plcId?: string` field so a board can be shared with an entire PLC.
-- New `PlcSharedBoardsTab.tsx` lists all boards shared with this PLC. Each row has "Open" (read-only view) and "Copy to my dashboards".
-
-### Architectural notes
-
-- This is the smallest phase. The infrastructure already exists; we're just adding a `plcId` filter and a tab.
-- The existing `shared_boards` rules will need a new branch: members of the PLC can read shares where `plcId == this PLC` even if they aren't the shareTarget.
-
-### Open questions
-
-- Can a member edit a PLC-shared board, or is it always read-only/copy? Recommend: **read-only/copy** for simplicity. Editing shared boards multi-teacher would need its own LWW infrastructure (out of scope for Phase 6).
+- `hooks/useFirestore.ts` — `shareDashboard(dashboard, intendedMode?, hostDisplayName?, plcId?)` now writes `plcId` onto the `/shared_boards/{shareId}` doc when set.
+- `context/DashboardContext.tsx` — `shareDashboard(dashboard, intendedMode?, plcId?)` plumbs the new arg. When `plcId` is set, the Drive-fallback path is intentionally bypassed (Drive-only shares wouldn't be visible to the PLC tab's Firestore query).
+- `context/DashboardContextValue.ts` — public `shareDashboard` signature widened.
+- `hooks/usePlcSharedBoards.ts` (new) — live subscription to `shared_boards where plcId == plcId`, sorted newest-edit-first. Returns a lightweight `PlcSharedBoardEntry` slice (id, name, originalAuthor, originalAuthorName, intendedMode, widgetCount, timestamps) rather than the full share-doc payload.
+- `firestore.rules` — collaborator-update branch on `/shared_boards/{shareId}` now pins `plcId` immutable. Host updates can still change it (matches the existing posture: host = full content + metadata mutability except `intendedMode`).
+- `components/plc/bodies/PlcSharedBoardsBody.tsx` (new) — list with per-row "Open share" link routing to `/share/{shareId}` (deep-links into the existing share-import flow; recipient gets the host's chosen `intendedMode` picker).
+- `components/plc/tabs/PlcSharedBoardsTab.tsx` (new) — tab-mode shim.
+- `components/plc/overview/tiles/SharedBoardsTile.tsx` (new) — replaces the last `ComingSoonTile` usage (sharedBoards). Rows are non-clickable previews; "Open boards" footer navigates to the tab.
+- `components/plc/PlcDashboard.tsx` — removed `placeholder` block on the `sharedBoards` tab def, routes the tab to `PlcSharedBoardsTab`, adds the fullscreen-expansion case.
+- `components/share/ShareLinkCreatorModal.tsx` — optional "Also share with a PLC" dropdown (rendered only when the user has ≥1 PLC memberships). Selecting a PLC plumbs `plcId` through `shareDashboard`.
 
 ### Notes from implementation
 
-_(Fill in after shipping.)_
+- **No new rule branch needed for reads.** The existing `/shared_boards` rule already grants read to any authenticated user — PLC scoping happens client-side via the `where plcId == ...` query filter. This is a convenience pivot, not a security boundary; a hostile client could list arbitrary shares by removing the filter (matches the pre-Phase-6 status quo).
+- **Drive-fallback bypass when `plcId` is set.** Non-admin Drive shares are one-time exports that wouldn't appear in the PLC tab; we skip the Drive path entirely when the caller scoped to a PLC.
+- **Host can re-scope, collaborator cannot.** The rules pin `plcId` immutable on the collaborator-update branch (so a teammate who joined a non-PLC share can't silently retarget someone else's share at an arbitrary PLC, or strip the PLC scope from a PLC-shared board). The host-update branch leaves `plcId` mutable so the originalAuthor can un-scope a share they regret tagging.
+- **PLC scope picker is opt-in.** The dropdown defaults to "Don't scope to a PLC" — the existing flow (send link directly to a colleague) keeps working exactly as before. Only teachers who actively pick a PLC get the new behavior.
+- **Resolved open question (read-only vs editable).** As recommended in the original roadmap, PLC-shared boards are surfaced read-only / copy. Editing is reserved for the existing `/share/:id` flow where the recipient picks Synced (joins as collaborator) or Copy (snapshot). No new multi-teacher LWW infrastructure was needed.
+
+### Phase 6 follow-ups (not blockers; track separately)
+
+- **Tile-level "Copy to my dashboards" action.** Currently the only action on the tile and tab is "Open share" → standard import picker. An inline "Copy" affordance would shortcut the picker to copy mode for the common "I just want a snapshot" case.
+- **PLC scope visible in Sidebar.** When the host re-opens the share modal on an already-shared board, the PLC scope isn't displayed back — the modal always defaults to "Don't scope to a PLC." A round-trip on the current share state would let the host see (and remove) the scope without resharing.
+- **Modal copy.** "Also share with a PLC (optional)" is hardcoded English. Group with the Phase 2/3/4 modal i18n sweep when that lands.
 
 ---
 
@@ -407,30 +433,74 @@ Resolved:
 
 ---
 
-## Phase 4 starter — for the next agent
+## Phase 7 starter — Mini-apps PLC integration (proposed)
 
-**Goal (recap from the Phase 4 section above):** extend video activities with the same PLC linkage + dashboard surface that quizzes already have.
+**Status:** Not in the original roadmap. Proposed during the fully-fledged PR design pass — the user wanted mini-apps to participate in PLC sharing like quizzes and video activities do. The Phase 4 work (`/plcs/{plcId}/video_activities/`) is the closest pattern; mirror it.
 
-**What's already in place after Phase 3 (use these — don't reinvent):**
+**Goal:** members can share a personal mini-app with their PLC, edit it collaboratively, and import it (sync-or-copy) into their personal mini-app library. Mini-app assignments authored with `settings.plc` set should also surface on the In-progress / Completed sub-tabs.
 
-- `PlcAssignmentIndexEntry.kind` discriminator already accepts `'video-activity'`. The Phase 1 widening + Phase 3 status field cover the schema; Phase 4 just needs `useVideoActivityAssignments.createAssignment` to start writing entries with `kind: 'video-activity'` and the appropriate `status`.
-- `mirrorPlcAssignmentStatus(plcId, assignmentId, status)` from `hooks/usePlcAssignmentIndex.ts` is generic (no quiz-specific assumptions). Phase 4's VA status mutators should call it the same way `useQuizAssignments` does — fire-and-forget when `settings.plc` is set on a VA assignment. The In-progress / Completed sub-tabs in PLC Assignments will then surface VA entries automatically alongside quizzes (status mirroring is the only wiring needed).
-- The PLC Assignments **Library** sub-tab is quiz-template-specific today (`plcs/{plcId}/assignments/` carries `quizId` / `quizTitle`). Phase 4 has two paths: (a) add a `kind` discriminator to `PlcAssignmentTemplate` and let the Library list mixed quiz + VA templates, or (b) add a separate `plcs/{plcId}/video_activity_templates/` subcollection mirroring this one. Recommend (b) — it keeps the schemas independent and matches the Phase 4 plan's existing scope (`plcs/{plcId}/video_activities/` subcollection).
-- The Phase 2 + Phase 3 Cloud Functions follow the same pattern. Phase 4 will likely need a `joinPlcVideoActivitySyncGroup` sibling resolving via `plcs/{plcId}/video_activities/`.
-- `firestore.rules` Phase 3 `assignments/` block is the closest template — copy it, swap field names, and pin VA-specific session-shape constraints if any.
+**What's already in place (use these — don't reinvent):**
+
+- `PlcAssignmentIndexEntry.kind` is a string discriminator. The rule + parser currently accept `'quiz'` and `'video-activity'`; widen the union to `'mini-app'` in `usePlcAssignmentIndex.parseEntry` AND the rule's `kind in [...]` check.
+- `mirrorPlcAssignmentStatus` from `usePlcAssignmentIndex.ts` is generic — call it the same way `useQuizAssignments` / `useVideoActivityAssignments` do.
+- The Phase 4 sync-join Cloud Function (`plcVideoActivitySyncJoin.ts`) is the closest template — resolve the synced-group id via `plcs/{plcId}/mini_apps/{plcMiniAppId}` and join the canonical `/synced_mini_apps/{groupId}` group (this group collection may need to be added if it doesn't exist yet).
+- `firestore.rules` Phase 4 `video_activities/` block is the closest template — copy it, swap field names.
 
 **Files to touch (likely):**
 
-- `types.ts` — add `PlcVideoActivityTemplate` (mirror `PlcAssignmentTemplate`); add `plc?: PlcLinkage` to `VideoActivityAssignmentSettings`.
-- `hooks/useVideoActivityAssignments.ts` — extend `createAssignment` to write `assignment_index` entries with `kind: 'video-activity'` and (optionally) a video activity template; add status mirroring on pause/end mutations.
-- `hooks/usePlcVideoActivities.ts` (new) — mirror `hooks/usePlcAssignments.ts`.
-- `components/plc/tabs/PlcVideoActivitiesTab.tsx` — replace placeholder; same shape as `PlcQuizLibraryTab.tsx`.
-- `firestore.rules` — new `match /plcs/{plcId}/video_activities/{...}` block.
-- `functions/src/plcVideoActivitySyncJoin.ts` (new) — mirror `plcAssignmentSyncJoin.ts`.
-- Tests: hook + rules suites mirroring Phase 3.
+- `types.ts` — new `PlcMiniAppEntry` (mirror `PlcVideoActivityEntry`); ensure `MiniAppAssignmentSettings` carries `plc?: PlcLinkage`.
+- `hooks/useMiniApps.ts` (or whichever hook owns mini-app metadata) — add `attachSyncLinkage` if not present.
+- `hooks/usePlcMiniApps.ts` (new) — mirror `hooks/usePlcVideoActivities.ts`.
+- `hooks/useMiniAppAssignments.ts` — extend `createAssignment` to write `assignment_index` entries with `kind: 'mini-app'`; status mirroring on pause/end.
+- `firestore.rules` — new `match /plcs/{plcId}/mini_apps/{plcMiniAppId}` block + widen `assignment_index.kind` to include `'mini-app'`.
+- `functions/src/plcMiniAppSyncJoin.ts` (new) — mirror `plcVideoActivitySyncJoin.ts`.
+- `hooks/useSyncedMiniAppGroups.ts` — add `callJoinPlcMiniAppSyncGroup` (and create the file + Cloud Function if synced mini-apps don't exist yet — bigger scope).
+- `components/plc/bodies/PlcMiniAppsBody.tsx` + `tabs/PlcMiniAppsTab.tsx` + `overview/tiles/MiniAppsTile.tsx` (new).
+- `components/widgets/MiniApp/...` — add the share-with-PLC kebab + `handleShareWithPlc` mirroring `VideoActivityWidget.Widget.tsx`.
+- `components/plc/PlcDashboard.tsx` — add `'miniApps'` to the `PlcDashboardTabId` union + `TABS` array, route the tab.
+- `components/plc/overview/tileRegistry.tsx` — add the `'miniApps'` case.
 
-**Branch convention:** open `claude/plc-phase-4-<slug>` off `dev-paul`.
+**Branch convention:** open `claude/plc-phase-7-<slug>` off `dev-paul`.
+
+**Wildcard:** mini-apps may NOT yet have a synced-groups infrastructure (`synced_mini_apps/{groupId}`). Quiz + VA both had it before their PLC phases started. If absent, Phase 7 needs to stand it up (mirror `syncedVideoActivityGroups.ts`) — that's the bigger lift in this phase, not the PLC plumbing on top.
 
 ---
 
-**Last updated:** 2026-05-08 (PR #1557 closed two Phase 3 follow-ups — Drive-only PLC bubble-up so every PLC-mode personal assignment authors a Library template, and Edit-in-place from `PlcQuizLibraryTab` leveraging the existing synced-group LWW infrastructure)
+## Phase 8 starter — Guided Learning PLC integration (proposed)
+
+**Status:** Not in the original roadmap. Proposed during the fully-fledged PR design pass alongside Phase 7. Same pattern as Phase 4/7.
+
+**Goal:** mirror Phase 7 for Guided Learning sets — members share, sync-edit, and import collaboratively.
+
+**Files to touch (likely):**
+
+- `types.ts` — new `PlcGuidedLearningEntry`; ensure `GuidedLearningAssignmentSettings` carries `plc?: PlcLinkage`.
+- `hooks/useGuidedLearning.ts` — `attachSyncLinkage` if not present.
+- `hooks/usePlcGuidedLearning.ts` (new).
+- `hooks/useGuidedLearningAssignments.ts` — PLC index writes with `kind: 'guided-learning'`; status mirroring.
+- `firestore.rules` — new `match /plcs/{plcId}/guided_learning/{plcGuidedLearningId}` block + widen `assignment_index.kind`.
+- `functions/src/plcGuidedLearningSyncJoin.ts` (new).
+- `hooks/useSyncedGuidedLearningGroups.ts` — add `callJoinPlcGuidedLearningSyncGroup`.
+- `components/plc/bodies/PlcGuidedLearningBody.tsx` + `tabs/PlcGuidedLearningTab.tsx` + `overview/tiles/GuidedLearningTile.tsx` (new).
+- `components/widgets/GuidedLearning/...` — share-with-PLC kebab.
+- `PlcDashboard.tsx` + `tileRegistry.tsx` — wire the new tab + tile.
+
+**Branch convention:** open `claude/plc-phase-8-<slug>` off `dev-paul`.
+
+**Wildcard:** same as Phase 7 — verify a `synced_guided_learning/{groupId}` collection exists before assuming the LWW infrastructure is in place.
+
+---
+
+## Cross-cutting follow-ups (not blockers; track separately)
+
+These surfaced across multiple phases and are deliberately deferred:
+
+- **In-tab "+ New PLC Assignment" affordance.** Currently teachers author a PLC assignment by going to their personal Quiz / Video Activity widget, picking an item, and toggling PLC mode in the assign modal. The PLC Assignments → Library sub-tab is consume-only. Adding a "+ Share a quiz / VA with this PLC" button inside the tab that opens a personal-library picker + assign flow would close the discoverability gap.
+- **Rich tile actions (Phase 2+ kebabs).** Quiz Library / Video Activities / Shared Boards tile rows currently navigate-to-tab on click. The user explicitly wanted "most actions doable from the tile" — a follow-up should add inline import / unshare / edit kebab items per row. The blocker today is that the tile doesn't carry the `useQuiz` / `useVideoActivity` subscription needed to drive those actions; the cleanest path is a small shared hook the body and tile both consume.
+- **ComingSoonTile cleanup.** No tile in `tileRegistry.tsx` routes through `ComingSoonTile` anymore. Until Phase 7/8 land, the file is dead code; consider removing or repurposing for the two proposed phases' placeholder period.
+- **Modal i18n sweep.** Every PLC modal (`PlcShareTargetModal`, `PlcQuizImportModal`, `PlcVideoActivityImportModal`, `PlcAssignmentImportModal`, `ShareLinkCreatorModal` PLC dropdown, `QuizAssignmentImportModeModal`) uses hardcoded English. Group them in a single i18n PR rather than touching each one independently.
+- **Cloud Function unit tests.** `joinPlcQuizSyncGroup`, `joinPlcAssignmentSyncGroup`, and `joinPlcVideoActivitySyncGroup` all lack direct `*.test.ts` siblings. Firestore-rules tests cover the subcollection permissions; the Admin-SDK transaction logic (membership re-check, idempotent `alreadyJoined`) isn't directly exercised. Sibling pattern: `syncedQuizGroups.test.ts` (Phase 1).
+
+---
+
+**Last updated:** 2026-05-12 (fully-fledged PR — Phase 4 + Phase 6 shipped together with the `activeAssignments` tile bug fix and the rich-tile read-side polish; Phase 7/8 added as proposed extensions)

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -265,6 +265,14 @@
           "order": "DESCENDING"
         }
       ]
+    },
+    {
+      "collectionGroup": "shared_boards",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "plcId", "order": "ASCENDING" },
+        { "fieldPath": "updatedAt", "order": "DESCENDING" }
+      ]
     }
   ],
   "fieldOverrides": [

--- a/firestore.rules
+++ b/firestore.rules
@@ -692,10 +692,14 @@ service cloud.firestore {
 
       // Collaborator (Synced participant): may update content but must not
       // change participants map, originalAuthor, originalAuthorName,
-      // sharedAt, or intendedMode. originalAuthorName in particular is the
-      // host display name shown in the import-picker / banner UI for every
-      // participant, so a collaborator who could rewrite it would be able
-      // to spoof the host's identity to other peers.
+      // sharedAt, intendedMode, or plcId. originalAuthorName in particular
+      // is the host display name shown in the import-picker / banner UI
+      // for every participant, so a collaborator who could rewrite it
+      // would be able to spoof the host's identity to other peers.
+      // plcId pins the share's PLC scope — a collaborator (a teammate
+      // who joined a non-PLC share) shouldn't be able to silently retarget
+      // someone else's share at an arbitrary PLC, and conversely shouldn't
+      // be able to strip the PLC scope from a PLC-shared board.
       allow update: if request.auth != null &&
         request.auth.uid in resource.data.get('participants', {}) &&
         resource.data.participants[request.auth.uid].get('role', '') == 'collaborator' &&
@@ -703,7 +707,8 @@ service cloud.firestore {
         request.resource.data.originalAuthor == resource.data.originalAuthor &&
         request.resource.data.get('originalAuthorName', null) == resource.data.get('originalAuthorName', null) &&
         request.resource.data.get('sharedAt', null) == resource.data.get('sharedAt', null) &&
-        request.resource.data.get('intendedMode', null) == resource.data.get('intendedMode', null);
+        request.resource.data.get('intendedMode', null) == resource.data.get('intendedMode', null) &&
+        request.resource.data.get('plcId', null) == resource.data.get('plcId', null);
 
       // Self-join: any authed user may add ONLY their own uid to participants
       // without changing any other field. Used by importers picking Synced

--- a/firestore.rules
+++ b/firestore.rules
@@ -681,14 +681,37 @@ service cloud.firestore {
     match /shared_boards/{shareId} {
       allow read: if request.auth != null;
 
+      // Host writes their own share, and if they tag it with a `plcId`,
+      // they must be a current member of that PLC. Defense-in-depth on top
+      // of the client-side PLC picker — a hostile client could otherwise
+      // surface their share on any PLC's tab.
       allow create: if request.auth != null &&
-        request.resource.data.originalAuthor == request.auth.uid;
+        request.resource.data.originalAuthor == request.auth.uid &&
+        (
+          request.resource.data.get('plcId', null) == null ||
+          request.auth.uid in get(
+            /databases/$(database)/documents/plcs/$(request.resource.data.plcId)
+          ).data.memberUids
+        );
 
       // Host or admin: full update power (content + participants), but
-      // intendedMode is locked to its create-time value.
+      // intendedMode is locked to its create-time value AND any change to
+      // `plcId` (set or retarget) requires the writer to be a current
+      // member of the target PLC. Allowed plcId transitions: unchanged,
+      // un-scoping (→ null), or scoping to a PLC the writer belongs to.
+      // Admins bypass the membership check, matching the existing
+      // ownership-bypass elsewhere in this block.
       allow update: if request.auth != null &&
         (resource.data.get('originalAuthor', null) == request.auth.uid || isAdmin()) &&
-        request.resource.data.get('intendedMode', null) == resource.data.get('intendedMode', null);
+        request.resource.data.get('intendedMode', null) == resource.data.get('intendedMode', null) &&
+        (
+          request.resource.data.get('plcId', null) == resource.data.get('plcId', null)
+          || request.resource.data.get('plcId', null) == null
+          || isAdmin()
+          || request.auth.uid in get(
+               /databases/$(database)/documents/plcs/$(request.resource.data.plcId)
+             ).data.memberUids
+        );
 
       // Collaborator (Synced participant): may update content but must not
       // change participants map, originalAuthor, originalAuthorName,

--- a/firestore.rules
+++ b/firestore.rules
@@ -1275,6 +1275,81 @@ service cloud.firestore {
              ).data.memberUids;
       }
 
+      // PLC Video Activity Library (Phase 4). Mirrors the Phase 2 quiz
+      // library above — lightweight headers pointing at canonical
+      // `/synced_video_activities/{groupId}` docs. Any current member can
+      // share / edit-mirror / unshare. Orphan policy: deleting your
+      // personal copy does NOT cascade-delete the PLC entry.
+      //
+      // Extra field over the quiz block: `youtubeUrl` (mirrored from
+      // source; used for tile thumbnail rendering). All other identity +
+      // attribution invariants are identical.
+      match /video_activities/{plcVideoActivityId} {
+        allow read: if request.auth != null
+          && request.auth.uid in get(
+               /databases/$(database)/documents/plcs/$(plcId)
+             ).data.memberUids;
+
+        // Create: any member, doc id pinned, sharedBy must equal caller.
+        // Questions live in the synced group, not on this doc.
+        allow create: if request.auth != null
+          && request.auth.uid in get(
+               /databases/$(database)/documents/plcs/$(plcId)
+             ).data.memberUids
+          && request.resource.data.keys().hasOnly([
+               'id', 'title', 'youtubeUrl', 'questionCount', 'syncGroupId',
+               'sharedBy', 'sharedByEmail', 'sharedByName',
+               'sharedAt', 'updatedAt'
+             ])
+          && plcVideoActivityId == request.resource.data.id
+          && request.resource.data.sharedBy == request.auth.uid
+          && request.resource.data.title is string
+          && request.resource.data.youtubeUrl is string
+          && request.resource.data.questionCount is int
+          && request.resource.data.questionCount >= 0
+          && request.resource.data.syncGroupId is string
+          // Guard against an empty `syncGroupId` smuggling a broken stub.
+          // The Cloud Function rejects empty strings server-side too;
+          // pinning at the rule layer is defense-in-depth.
+          && request.resource.data.syncGroupId.size() > 0
+          && request.resource.data.sharedByEmail is string
+          && request.resource.data.sharedByName is string
+          && request.resource.data.sharedAt is int
+          && request.resource.data.updatedAt is int;
+
+        // Update: any member can mirror title/questionCount/youtubeUrl/
+        // updatedAt. Identity + attribution fields are immutable so
+        // stale-mirror writes can't retarget the entry or rewrite who
+        // shared it.
+        allow update: if request.auth != null
+          && request.auth.uid in get(
+               /databases/$(database)/documents/plcs/$(plcId)
+             ).data.memberUids
+          && request.resource.data.keys().hasOnly([
+               'id', 'title', 'youtubeUrl', 'questionCount', 'syncGroupId',
+               'sharedBy', 'sharedByEmail', 'sharedByName',
+               'sharedAt', 'updatedAt'
+             ])
+          && request.resource.data.id == resource.data.id
+          && request.resource.data.syncGroupId == resource.data.syncGroupId
+          && request.resource.data.sharedBy == resource.data.sharedBy
+          && request.resource.data.sharedByEmail == resource.data.sharedByEmail
+          && request.resource.data.sharedByName == resource.data.sharedByName
+          && request.resource.data.sharedAt == resource.data.sharedAt
+          && request.resource.data.title is string
+          && request.resource.data.youtubeUrl is string
+          && request.resource.data.questionCount is int
+          && request.resource.data.questionCount >= 0
+          && request.resource.data.updatedAt is int;
+
+        // Any member can unshare. Matches the PLC-owned model — once
+        // shared, the entry belongs to the PLC, not the original sharer.
+        allow delete: if request.auth != null
+          && request.auth.uid in get(
+               /databases/$(database)/documents/plcs/$(plcId)
+             ).data.memberUids;
+      }
+
       // PLC-authored Assignments (Phase 3). Templates that any member can
       // pick up onto their own board. Each template points at a canonical
       // `synced_quizzes/{groupId}` doc (importers pull content from there

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -34,6 +34,7 @@ export {
 } from './syncedVideoActivityGroups';
 export { joinPlcQuizSyncGroup } from './plcQuizSyncJoin';
 export { joinPlcAssignmentSyncGroup } from './plcAssignmentSyncJoin';
+export { joinPlcVideoActivitySyncGroup } from './plcVideoActivitySyncJoin';
 export { recomputeAdminAnalytics } from './adminAnalyticsSnapshot';
 
 setGlobalOptions({ region: 'us-central1' });

--- a/functions/src/plcVideoActivitySyncJoin.ts
+++ b/functions/src/plcVideoActivitySyncJoin.ts
@@ -1,0 +1,157 @@
+/**
+ * PLC video activity sync-join Cloud Function (Phase 4).
+ *
+ * Sibling of `plcQuizSyncJoin.handleJoinPlcQuizSyncGroup` for the PLC
+ * Video Activity Library. Resolves `syncGroupId` via
+ * `plcs/{plcId}/video_activities/{plcVideoActivityId}` and joins the
+ * caller into `synced_video_activities/{groupId}.participants`.
+ *
+ * Membership validation is server-side (Admin SDK bypasses Firestore
+ * rules — clients can't write `participants` directly); we don't accept
+ * the caller's word that they belong to a given PLC.
+ *
+ * Idempotent: re-joining is a no-op (returns `alreadyJoined: true`)
+ * without bumping `version`, matching the Phase 2/3 siblings.
+ */
+
+import { onCall, HttpsError } from 'firebase-functions/v2/https';
+import * as admin from 'firebase-admin';
+import type { SyncedVideoActivityParticipant } from './syncedVideoActivityGroups';
+
+if (!admin.apps.length) {
+  admin.initializeApp();
+}
+
+export interface JoinPlcVideoActivitySyncGroupRequest {
+  plcId?: unknown;
+  plcVideoActivityId?: unknown;
+}
+
+export interface JoinPlcVideoActivitySyncGroupResponse {
+  groupId: string;
+  version: number;
+  alreadyJoined: boolean;
+}
+
+/**
+ * Verify membership + group join in one transaction so a member who's
+ * removed mid-flow can't sneak into the participants map.
+ *
+ * Throws `HttpsError`:
+ *   - `not-found` if the PLC, the PLC video activity entry, or the
+ *     synced group can't be located.
+ *   - `permission-denied` if the caller isn't a current PLC member.
+ *   - `failed-precondition` if the entry's `syncGroupId` field is
+ *     missing/non-string (data shape regression).
+ */
+export async function handleJoinPlcVideoActivitySyncGroup(
+  db: admin.firestore.Firestore,
+  uid: string,
+  plcId: string,
+  plcVideoActivityId: string
+): Promise<JoinPlcVideoActivitySyncGroupResponse> {
+  const plcRef = db.collection('plcs').doc(plcId);
+  const entryRef = plcRef
+    .collection('video_activities')
+    .doc(plcVideoActivityId);
+
+  return db.runTransaction(async (tx) => {
+    const [plcSnap, entrySnap] = await Promise.all([
+      tx.get(plcRef),
+      tx.get(entryRef),
+    ]);
+    if (!plcSnap.exists) {
+      throw new HttpsError('not-found', 'PLC not found.');
+    }
+    const plcData = plcSnap.data() as { memberUids?: unknown } | undefined;
+    const memberUids = Array.isArray(plcData?.memberUids)
+      ? (plcData?.memberUids as unknown[]).filter(
+          (u): u is string => typeof u === 'string'
+        )
+      : [];
+    if (!memberUids.includes(uid)) {
+      throw new HttpsError(
+        'permission-denied',
+        'You are not a member of this PLC.'
+      );
+    }
+
+    if (!entrySnap.exists) {
+      throw new HttpsError('not-found', 'PLC video activity not found.');
+    }
+    const entryData = entrySnap.data() as { syncGroupId?: unknown } | undefined;
+    const groupId = entryData?.syncGroupId;
+    if (typeof groupId !== 'string' || groupId.length === 0) {
+      throw new HttpsError(
+        'failed-precondition',
+        'PLC video activity is not linked to a synced group.'
+      );
+    }
+
+    const groupRef = db.collection('synced_video_activities').doc(groupId);
+    const groupSnap = await tx.get(groupRef);
+    if (!groupSnap.exists) {
+      throw new HttpsError('not-found', 'Synced group not found.');
+    }
+    const groupData = groupSnap.data() as
+      | {
+          version?: number;
+          participants?: Record<string, SyncedVideoActivityParticipant>;
+        }
+      | undefined;
+    const participants = { ...(groupData?.participants ?? {}) };
+    const alreadyJoined = Object.prototype.hasOwnProperty.call(
+      participants,
+      uid
+    );
+    if (!alreadyJoined) {
+      const now = Date.now();
+      participants[uid] = { joinedAt: now };
+      tx.update(groupRef, {
+        participants,
+        // updatedAt tracks any server-side touch; updatedBy is intentionally
+        // left at the last content-writer's uid so attribution doesn't
+        // flicker on membership changes. Mirrors `plcQuizSyncJoin.ts`.
+        updatedAt: now,
+      });
+    }
+    return {
+      groupId,
+      version: groupData?.version ?? 1,
+      alreadyJoined,
+    };
+  });
+}
+
+export const joinPlcVideoActivitySyncGroup =
+  onCall<JoinPlcVideoActivitySyncGroupRequest>(
+    { region: 'us-central1' },
+    async (request) => {
+      const uid = request.auth?.uid;
+      if (!uid) {
+        throw new HttpsError(
+          'unauthenticated',
+          'Sign in to join a PLC video activity sync group.'
+        );
+      }
+      const { plcId, plcVideoActivityId } = request.data ?? {};
+      if (typeof plcId !== 'string' || plcId.length === 0) {
+        throw new HttpsError('invalid-argument', 'plcId is required.');
+      }
+      if (
+        typeof plcVideoActivityId !== 'string' ||
+        plcVideoActivityId.length === 0
+      ) {
+        throw new HttpsError(
+          'invalid-argument',
+          'plcVideoActivityId is required.'
+        );
+      }
+      return handleJoinPlcVideoActivitySyncGroup(
+        admin.firestore(),
+        uid,
+        plcId,
+        plcVideoActivityId
+      );
+    }
+  );

--- a/hooks/useFirestore.ts
+++ b/hooks/useFirestore.ts
@@ -360,7 +360,14 @@ export const useFirestore = (userId: string | null) => {
     async (
       dashboard: Dashboard,
       intendedMode?: SharedBoardIntendedMode,
-      hostDisplayName?: string
+      hostDisplayName?: string,
+      /**
+       * Phase 6 — when set, tags the resulting `/shared_boards/{id}` doc
+       * with `plcId` so members of that PLC see it on the PLC Dashboard's
+       * Shared Boards tab. Mutating the field post-create is restricted
+       * to the host (rules pin it immutable for collaborators).
+       */
+      plcId?: string
     ): Promise<string> => {
       if (isAuthBypass) {
         // Stash the host display name on the mock doc under the same field
@@ -373,6 +380,7 @@ export const useFirestore = (userId: string | null) => {
           ...(intendedMode
             ? ({ intendedMode } as unknown as Partial<Dashboard>)
             : {}),
+          ...(plcId ? ({ plcId } as unknown as Partial<Dashboard>) : {}),
         } as Dashboard);
       }
 
@@ -395,6 +403,7 @@ export const useFirestore = (userId: string | null) => {
         originalAuthor: userId,
         ...(hostDisplayName ? { originalAuthorName: hostDisplayName } : {}),
         ...(intendedMode ? { intendedMode } : {}),
+        ...(plcId ? { plcId } : {}),
         participants: {},
         updatedAt: Date.now(),
         updatedBy: userId,

--- a/hooks/usePlcSharedBoards.ts
+++ b/hooks/usePlcSharedBoards.ts
@@ -1,0 +1,153 @@
+import { useEffect, useMemo, useState } from 'react';
+import {
+  collection,
+  onSnapshot,
+  orderBy,
+  query,
+  where,
+} from 'firebase/firestore';
+import { db, isAuthBypass } from '@/config/firebase';
+import { useAuth } from '@/context/useAuth';
+import { logError } from '@/utils/logError';
+import type { SharedBoardIntendedMode } from '@/types';
+
+/**
+ * Lightweight view of a `/shared_boards/{shareId}` doc scoped to one PLC.
+ * The full shared-board snapshot has a much larger surface (widgets,
+ * participants, etc.); the PLC tab only needs a handful of header fields
+ * for list rendering and the "Copy / Open" actions.
+ */
+export interface PlcSharedBoardEntry {
+  /** Share doc id under `/shared_boards/{shareId}`. */
+  id: string;
+  /**
+   * Display name of the dashboard at share time. Mirrors `Dashboard.name`.
+   * Falls back to `''` for legacy/partial docs that predate name being
+   * required — the tile / tab renders a placeholder in that case.
+   */
+  name: string;
+  /** UID of the teacher who originated this share. Immutable post-create. */
+  originalAuthor: string;
+  /** Display-name snapshot of the originator at share time. May be `''`. */
+  originalAuthorName: string;
+  /** Share-time mode (`'synced' | 'view-only' | 'copy'`) chosen by the host. */
+  intendedMode: SharedBoardIntendedMode | null;
+  /** ms timestamp at first share. */
+  sharedAt: number;
+  /** ms timestamp; bumped by host/collaborator content writes. */
+  updatedAt: number;
+  /** Widget count at share time. Useful for the tile's "N widgets" subtitle. */
+  widgetCount: number;
+}
+
+interface UsePlcSharedBoardsResult {
+  boards: PlcSharedBoardEntry[];
+  loading: boolean;
+}
+
+const VALID_MODES: ReadonlySet<SharedBoardIntendedMode> = new Set([
+  'synced',
+  'view-only',
+  'copy',
+]);
+
+function parseEntry(
+  id: string,
+  data: Record<string, unknown>
+): PlcSharedBoardEntry | null {
+  if (
+    typeof data.originalAuthor !== 'string' ||
+    typeof data.sharedAt !== 'number'
+  ) {
+    return null;
+  }
+  const rawMode = data.intendedMode;
+  const intendedMode: SharedBoardIntendedMode | null =
+    typeof rawMode === 'string' &&
+    VALID_MODES.has(rawMode as SharedBoardIntendedMode)
+      ? (rawMode as SharedBoardIntendedMode)
+      : null;
+  // `widgets` lives on the share doc as an array of WidgetData. Length is
+  // cheap to compute defensively without parsing the whole array.
+  const widgets = Array.isArray(data.widgets) ? data.widgets : [];
+  return {
+    id,
+    name: typeof data.name === 'string' ? data.name : '',
+    originalAuthor: data.originalAuthor,
+    originalAuthorName:
+      typeof data.originalAuthorName === 'string'
+        ? data.originalAuthorName
+        : '',
+    intendedMode,
+    sharedAt: data.sharedAt,
+    updatedAt:
+      typeof data.updatedAt === 'number' ? data.updatedAt : data.sharedAt,
+    widgetCount: widgets.length,
+  };
+}
+
+/**
+ * Live subscription to all `/shared_boards` docs tagged with the given
+ * `plcId`. Returns entries sorted newest-edit-first by `updatedAt`. Pass
+ * `null` for `plcId` to disable the listener (e.g. while the dashboard
+ * is closed).
+ *
+ * Read permission is already granted to all authenticated users by the
+ * `/shared_boards` rule block; the PLC scope is implemented as a `where
+ * plcId == ...` query filter, not a rule gate. This means a hostile
+ * client could still list non-PLC shares by removing the filter — the
+ * PLC tab uses the filter as a convenience pivot, not as a security
+ * boundary.
+ */
+export const usePlcSharedBoards = (
+  plcId: string | null
+): UsePlcSharedBoardsResult => {
+  const { user } = useAuth();
+  const [boards, setBoards] = useState<PlcSharedBoardEntry[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  // Render-time reset on plcId transitions — same pattern as
+  // `usePlcAssignmentIndex` / `usePlcQuizzes`. Avoids flashing the
+  // previous PLC's boards while the new snapshot is in flight.
+  const [prevPlcId, setPrevPlcId] = useState(plcId);
+  if (plcId !== prevPlcId) {
+    setPrevPlcId(plcId);
+    setBoards([]);
+    setLoading(true);
+  }
+
+  useEffect(() => {
+    if (!plcId || !user || isAuthBypass) {
+      const t = setTimeout(() => {
+        setBoards([]);
+        setLoading(false);
+      }, 0);
+      return () => clearTimeout(t);
+    }
+    const ref = collection(db, 'shared_boards');
+    const q = query(
+      ref,
+      where('plcId', '==', plcId),
+      orderBy('updatedAt', 'desc')
+    );
+    const unsub = onSnapshot(
+      q,
+      (snap) => {
+        const list: PlcSharedBoardEntry[] = [];
+        snap.forEach((d) => {
+          const parsed = parseEntry(d.id, d.data() as Record<string, unknown>);
+          if (parsed) list.push(parsed);
+        });
+        setBoards(list);
+        setLoading(false);
+      },
+      (err) => {
+        logError('usePlcSharedBoards.snapshot', err, { plcId });
+        setLoading(false);
+      }
+    );
+    return () => unsub();
+  }, [plcId, user]);
+
+  return useMemo(() => ({ boards, loading }), [boards, loading]);
+};

--- a/hooks/usePlcVideoActivities.ts
+++ b/hooks/usePlcVideoActivities.ts
@@ -1,0 +1,295 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  collection,
+  deleteDoc,
+  doc,
+  onSnapshot,
+  orderBy,
+  query,
+  setDoc,
+  updateDoc,
+} from 'firebase/firestore';
+import { db, isAuthBypass } from '@/config/firebase';
+import { useAuth } from '@/context/useAuth';
+import { PlcVideoActivityEntry } from '@/types';
+import { logError } from '@/utils/logError';
+
+const PLCS_COLLECTION = 'plcs';
+const VIDEO_ACTIVITIES_SUBCOLLECTION = 'video_activities';
+
+interface ShareVideoActivityWithPlcInput {
+  /** Firestore doc id for the new PLC video activity entry. Caller mints (uuid). */
+  plcVideoActivityId: string;
+  /** Pointer to the canonical `/synced_video_activities/{groupId}` doc. */
+  syncGroupId: string;
+  /** Mirrored from the synced group at share time. */
+  title: string;
+  /** Mirrored from the source activity; may be `''` if absent. */
+  youtubeUrl: string;
+  /** Mirrored from the synced group's questions array length. */
+  questionCount: number;
+  /** Display name snapshot for attribution. */
+  sharedByName: string;
+  /** Lowercased email snapshot for display. */
+  sharedByEmail: string;
+}
+
+interface UsePlcVideoActivitiesResult {
+  videoActivities: PlcVideoActivityEntry[];
+  loading: boolean;
+  /**
+   * Write a new PLC video activity entry. Caller is responsible for first
+   * standing up the canonical `synced_video_activities/{syncGroupId}` doc
+   * (via `createSyncedVideoActivityGroup`). Doc id = `plcVideoActivityId`.
+   * The signed-in user is stamped as `sharedBy`.
+   */
+  shareVideoActivityWithPlc: (
+    input: ShareVideoActivityWithPlcInput
+  ) => Promise<void>;
+  /**
+   * Mirror title/questionCount/youtubeUrl onto the PLC entry after a peer's
+   * publish. Fire-and-forget — failures log but don't reject so the
+   * caller's primary action (e.g. `publishSyncedVideoActivity`) returns
+   * cleanly. `not-found` here is benign: a teammate unshared between our
+   * snapshot read and this mirror write; the canonical group already has
+   * the fresh content.
+   */
+  mirrorPlcVideoActivityHeader: (
+    plcVideoActivityId: string,
+    patch: {
+      title?: string;
+      questionCount?: number;
+      youtubeUrl?: string;
+    }
+  ) => Promise<void>;
+  /** Remove a PLC video activity entry. Any member can unshare (PLC-owned model). */
+  unshareVideoActivityFromPlc: (plcVideoActivityId: string) => Promise<void>;
+}
+
+function parseEntry(
+  id: string,
+  data: Record<string, unknown>
+): PlcVideoActivityEntry | null {
+  if (
+    typeof data.title !== 'string' ||
+    typeof data.questionCount !== 'number' ||
+    typeof data.syncGroupId !== 'string' ||
+    typeof data.sharedBy !== 'string' ||
+    typeof data.sharedAt !== 'number' ||
+    typeof data.updatedAt !== 'number'
+  ) {
+    return null;
+  }
+  return {
+    id,
+    title: data.title,
+    // `youtubeUrl` was added with the type. Pre-rollout entries (if any
+    // existed during dev) lack the field — default to `''` rather than
+    // dropping the row. Production never wrote without the field so this
+    // branch should never trigger; kept defensively.
+    youtubeUrl: typeof data.youtubeUrl === 'string' ? data.youtubeUrl : '',
+    questionCount: data.questionCount,
+    syncGroupId: data.syncGroupId,
+    sharedBy: data.sharedBy,
+    sharedByEmail:
+      typeof data.sharedByEmail === 'string' ? data.sharedByEmail : '',
+    sharedByName:
+      typeof data.sharedByName === 'string' ? data.sharedByName : '',
+    sharedAt: data.sharedAt,
+    updatedAt: data.updatedAt,
+  };
+}
+
+/**
+ * Live subscription to a single PLC's video activity library (Phase 4).
+ * Returns entries sorted newest-edit-first by `updatedAt`. Pass `null`
+ * for `plcId` to disable the listener (e.g. while the dashboard is closed).
+ *
+ * Mirrors `usePlcQuizzes.ts` exactly — same parser-drops-malformed
+ * defense, same render-time `prevPlcId` reset so the UI never flashes
+ * the previous PLC's entries while the new snapshot is in flight.
+ */
+export const usePlcVideoActivities = (
+  plcId: string | null
+): UsePlcVideoActivitiesResult => {
+  const { user } = useAuth();
+  const [videoActivities, setVideoActivities] = useState<
+    PlcVideoActivityEntry[]
+  >([]);
+  const [loading, setLoading] = useState(true);
+
+  const [prevPlcId, setPrevPlcId] = useState(plcId);
+  if (plcId !== prevPlcId) {
+    setPrevPlcId(plcId);
+    setVideoActivities([]);
+    setLoading(true);
+  }
+
+  useEffect(() => {
+    if (!plcId || !user || isAuthBypass) {
+      const t = setTimeout(() => {
+        setVideoActivities([]);
+        setLoading(false);
+      }, 0);
+      return () => clearTimeout(t);
+    }
+    const ref = collection(
+      db,
+      PLCS_COLLECTION,
+      plcId,
+      VIDEO_ACTIVITIES_SUBCOLLECTION
+    );
+    const unsub = onSnapshot(
+      query(ref, orderBy('updatedAt', 'desc')),
+      (snap) => {
+        const list: PlcVideoActivityEntry[] = [];
+        snap.forEach((d) => {
+          const parsed = parseEntry(d.id, d.data() as Record<string, unknown>);
+          if (parsed) list.push(parsed);
+        });
+        setVideoActivities(list);
+        setLoading(false);
+      },
+      (err) => {
+        logError('usePlcVideoActivities.snapshot', err, { plcId });
+        setLoading(false);
+      }
+    );
+    return () => unsub();
+  }, [plcId, user]);
+
+  const shareVideoActivityWithPlc = useCallback(
+    async (input: ShareVideoActivityWithPlcInput): Promise<void> => {
+      if (!plcId || !user) throw new Error('Not signed in');
+      const now = Date.now();
+      const entry: PlcVideoActivityEntry = {
+        id: input.plcVideoActivityId,
+        title: input.title,
+        youtubeUrl: input.youtubeUrl,
+        questionCount: input.questionCount,
+        syncGroupId: input.syncGroupId,
+        sharedBy: user.uid,
+        sharedByEmail: input.sharedByEmail,
+        sharedByName: input.sharedByName,
+        sharedAt: now,
+        updatedAt: now,
+      };
+      await setDoc(
+        doc(
+          db,
+          PLCS_COLLECTION,
+          plcId,
+          VIDEO_ACTIVITIES_SUBCOLLECTION,
+          input.plcVideoActivityId
+        ),
+        entry
+      );
+    },
+    [plcId, user]
+  );
+
+  const mirrorPlcVideoActivityHeader = useCallback(
+    async (
+      plcVideoActivityId: string,
+      patch: { title?: string; questionCount?: number; youtubeUrl?: string }
+    ): Promise<void> => {
+      if (!plcId || !user) return;
+      try {
+        const fields: Record<string, unknown> = { updatedAt: Date.now() };
+        if (patch.title !== undefined) fields.title = patch.title;
+        if (patch.questionCount !== undefined) {
+          fields.questionCount = patch.questionCount;
+        }
+        if (patch.youtubeUrl !== undefined)
+          fields.youtubeUrl = patch.youtubeUrl;
+        await updateDoc(
+          doc(
+            db,
+            PLCS_COLLECTION,
+            plcId,
+            VIDEO_ACTIVITIES_SUBCOLLECTION,
+            plcVideoActivityId
+          ),
+          fields
+        );
+      } catch (err) {
+        logError('usePlcVideoActivities.mirrorHeader', err, {
+          plcId,
+          plcVideoActivityId,
+        });
+      }
+    },
+    [plcId, user]
+  );
+
+  const unshareVideoActivityFromPlc = useCallback(
+    async (plcVideoActivityId: string): Promise<void> => {
+      if (!plcId || !user) throw new Error('Not signed in');
+      await deleteDoc(
+        doc(
+          db,
+          PLCS_COLLECTION,
+          plcId,
+          VIDEO_ACTIVITIES_SUBCOLLECTION,
+          plcVideoActivityId
+        )
+      );
+    },
+    [plcId, user]
+  );
+
+  return useMemo(
+    () => ({
+      videoActivities,
+      loading,
+      shareVideoActivityWithPlc,
+      mirrorPlcVideoActivityHeader,
+      unshareVideoActivityFromPlc,
+    }),
+    [
+      videoActivities,
+      loading,
+      shareVideoActivityWithPlc,
+      mirrorPlcVideoActivityHeader,
+      unshareVideoActivityFromPlc,
+    ]
+  );
+};
+
+/**
+ * One-shot write of a PLC video activity entry. Used from the
+ * VideoActivityWidget's "Share with PLC" handler — the widget knows the
+ * target PLC at call time but isn't subscribed to that PLC's
+ * `usePlcVideoActivities`. Mirrors `writePlcQuizEntry` from Phase 2.
+ * Rejects on failure (unlike fire-and-forget side effects this is a
+ * primary user action).
+ */
+export async function writePlcVideoActivityEntry(
+  plcId: string,
+  uid: string,
+  input: ShareVideoActivityWithPlcInput
+): Promise<void> {
+  const now = Date.now();
+  const entry: PlcVideoActivityEntry = {
+    id: input.plcVideoActivityId,
+    title: input.title,
+    youtubeUrl: input.youtubeUrl,
+    questionCount: input.questionCount,
+    syncGroupId: input.syncGroupId,
+    sharedBy: uid,
+    sharedByEmail: input.sharedByEmail,
+    sharedByName: input.sharedByName,
+    sharedAt: now,
+    updatedAt: now,
+  };
+  await setDoc(
+    doc(
+      db,
+      PLCS_COLLECTION,
+      plcId,
+      VIDEO_ACTIVITIES_SUBCOLLECTION,
+      input.plcVideoActivityId
+    ),
+    entry
+  );
+}

--- a/hooks/useSyncedVideoActivityGroups.ts
+++ b/hooks/useSyncedVideoActivityGroups.ts
@@ -270,3 +270,23 @@ export async function callLeaveSyncedVideoActivityGroup(
   const result = await fn({ groupId });
   return result.data;
 }
+
+/**
+ * Phase 4 sibling of `callJoinPlcQuizSyncGroup`. Resolves `syncGroupId`
+ * via `plcs/{plcId}/video_activities/{plcVideoActivityId}` instead of
+ * the personal `shared_video_activity_assignments/{shareId}` route. Used
+ * by the PLC Video Activity Library "Add to my library (Sync)" path; the
+ * Cloud Function performs Admin-SDK membership validation before joining
+ * the caller to the canonical `synced_video_activities` group.
+ */
+export async function callJoinPlcVideoActivitySyncGroup(
+  plcId: string,
+  plcVideoActivityId: string
+): Promise<JoinResponse> {
+  const fn = httpsCallable<
+    { plcId: string; plcVideoActivityId: string },
+    JoinResponse
+  >(functions, 'joinPlcVideoActivitySyncGroup');
+  const result = await fn({ plcId, plcVideoActivityId });
+  return result.data;
+}

--- a/hooks/useVideoActivity.ts
+++ b/hooks/useVideoActivity.ts
@@ -33,7 +33,17 @@ import {
 } from '@/utils/mockQuizDriveService';
 import type { QuizData } from '@/types';
 import { suggestDuplicateTitle } from '@/components/common/library/libraryDuplicate';
+import {
+  publishSyncedVideoActivity,
+  pullSyncedVideoActivityContent,
+  SyncedVideoActivityVersionConflictError,
+} from './useSyncedVideoActivityGroups';
 import { logError } from '@/utils/logError';
+
+// Re-export so consumers can catch the version-conflict error without
+// importing from the synced-groups module directly. Mirrors the
+// `SyncedQuizVersionConflictError` re-export from `useQuiz.ts`.
+export { SyncedVideoActivityVersionConflictError };
 
 const VIDEO_ACTIVITIES_COLLECTION = 'video_activities';
 
@@ -69,6 +79,15 @@ export interface UseVideoActivityResult {
     activityId: string,
     linkage: VideoActivityMetadataSyncLinkage
   ) => Promise<void>;
+  /**
+   * Reconcile the local Drive replica with the canonical synced group.
+   * Mirrors `useQuiz.pullSyncedQuiz`. No-op for unsynced activities.
+   * Returns the updated metadata. Used by the editor's auto-pull on
+   * `SyncedVideoActivityVersionConflictError`.
+   */
+  pullSyncedVideoActivity: (
+    activityMeta: VideoActivityMetadata
+  ) => Promise<VideoActivityMetadata>;
   /** Create a template Google Sheet for CSV import. */
   createTemplateSheet: (title: string) => Promise<string>;
   /** Is a Drive service available? */
@@ -146,9 +165,46 @@ export const useVideoActivity = (
       const drive = getDriveService();
       const updated: VideoActivityData = { ...activity, updatedAt: Date.now() };
 
-      // Reuse the quiz drive service — saves JSON to the same Drive folder
-      // Cast to satisfy the method signature (VideoActivityData is structurally
-      // compatible with the JSON blob the service writes).
+      // Read existing metadata so we know whether this activity is part of
+      // a synced group and what version we're publishing on top of.
+      // Mirrors `useQuiz.saveQuiz`. Without this read, the synced-group
+      // publish was missing entirely and any prior `sync` linkage was
+      // silently stripped on every save (the metadata object below would
+      // overwrite without preserving it). Both gaps broke the Phase 4
+      // Sync promise — surfaced by PR review.
+      const metaRef = doc(
+        db,
+        'users',
+        userId,
+        VIDEO_ACTIVITIES_COLLECTION,
+        activity.id
+      );
+      const existingMetaSnap = await getDoc(metaRef);
+      const existingMeta = existingMetaSnap.exists()
+        ? (existingMetaSnap.data() as VideoActivityMetadata)
+        : null;
+      const existingSync = existingMeta?.sync;
+
+      // Publish to canonical BEFORE writing the Drive replica. If publish
+      // throws (peer beat us → SyncedVideoActivityVersionConflictError,
+      // network blip), the Drive replica is unchanged and the editor can
+      // pull + retry. Once publish succeeds the version invariant
+      // guarantees no peer can land between us and the Drive write.
+      let nextSyncedVersion: number | undefined = undefined;
+      if (existingSync) {
+        const result = await publishSyncedVideoActivity(existingSync.groupId, {
+          title: updated.title,
+          youtubeUrl: updated.youtubeUrl,
+          questions: updated.questions,
+          expectedVersion: existingSync.lastSyncedVersion,
+          uid: userId,
+        });
+        nextSyncedVersion = result.version;
+      }
+
+      // Reuse the quiz drive service — saves JSON to the same Drive folder.
+      // Cast to satisfy the method signature (VideoActivityData is
+      // structurally compatible with the JSON blob the service writes).
       const driveFileId = await drive.saveQuiz(
         updated as unknown as QuizData,
         existingDriveFileId
@@ -162,13 +218,82 @@ export const useVideoActivity = (
         questionCount: activity.questions.length,
         createdAt: activity.createdAt,
         updatedAt: updated.updatedAt,
+        // Preserve folder assignment + synced linkage across saves so
+        // the editor can't accidentally drop them by re-writing the
+        // metadata. Mirrors `useQuiz.saveQuiz`.
+        ...(existingMeta?.folderId !== undefined
+          ? { folderId: existingMeta.folderId }
+          : {}),
+        ...(existingSync
+          ? {
+              sync: {
+                groupId: existingSync.groupId,
+                lastSyncedVersion:
+                  nextSyncedVersion ?? existingSync.lastSyncedVersion,
+              },
+            }
+          : {}),
       };
 
-      await setDoc(
-        doc(db, 'users', userId, VIDEO_ACTIVITIES_COLLECTION, activity.id),
-        metadata
+      await setDoc(metaRef, metadata);
+
+      return metadata;
+    },
+    [userId, getDriveService]
+  );
+
+  const pullSyncedVideoActivity = useCallback(
+    async (
+      activityMeta: VideoActivityMetadata
+    ): Promise<VideoActivityMetadata> => {
+      if (!userId) throw new Error('Not authenticated');
+      if (!activityMeta.sync) {
+        // No-op for unsynced activities.
+        return { ...activityMeta };
+      }
+      const drive = getDriveService();
+      const canonical = await pullSyncedVideoActivityContent(
+        activityMeta.sync.groupId
       );
 
+      // Overwrite the local Drive replica with the canonical content. We
+      // keep the local activity `id` + `createdAt` so the library
+      // entry's identity and history don't churn — only the editable
+      // surface (title + youtubeUrl + questions) is replaced.
+      const now = Date.now();
+      const refreshed: VideoActivityData = {
+        id: activityMeta.id,
+        title: canonical.title,
+        youtubeUrl: canonical.youtubeUrl,
+        questions: canonical.questions,
+        createdAt: activityMeta.createdAt,
+        updatedAt: now,
+      };
+      const driveFileId = await drive.saveQuiz(
+        refreshed as unknown as QuizData,
+        activityMeta.driveFileId
+      );
+
+      const metadata: VideoActivityMetadata = {
+        id: activityMeta.id,
+        title: canonical.title,
+        youtubeUrl: canonical.youtubeUrl,
+        driveFileId,
+        questionCount: canonical.questions.length,
+        createdAt: activityMeta.createdAt,
+        updatedAt: now,
+        ...(activityMeta.folderId !== undefined
+          ? { folderId: activityMeta.folderId }
+          : {}),
+        sync: {
+          groupId: activityMeta.sync.groupId,
+          lastSyncedVersion: canonical.version,
+        },
+      };
+      await setDoc(
+        doc(db, 'users', userId, VIDEO_ACTIVITIES_COLLECTION, activityMeta.id),
+        metadata
+      );
       return metadata;
     },
     [userId, getDriveService]
@@ -332,6 +457,7 @@ export const useVideoActivity = (
     duplicateActivity,
     createTemplateSheet,
     attachSyncLinkage,
+    pullSyncedVideoActivity,
     isDriveConnected: isAuthBypass || isConnected,
   };
 };

--- a/hooks/useVideoActivityAssignments.ts
+++ b/hooks/useVideoActivityAssignments.ts
@@ -450,6 +450,18 @@ export const useVideoActivityAssignments = (
           assignmentId,
           vaStatusToIndexStatus(assignmentStatus)
         );
+      } else if (!live) {
+        // Edge case: status mutation called before the snapshot has
+        // landed (rapid programmatic flow after createAssignment, or
+        // ref synced lazily). Log so the rare "stranded paused VA on
+        // PLC dashboard" symptom is observable in production — without
+        // this signal the silent no-op below is invisible. Reviewer
+        // flag from PR #1593 silent-failure hunt.
+        logError(
+          'useVideoActivityAssignments.setStatus.assignmentMissing',
+          new Error(`No live assignment ${assignmentId} in ref`),
+          { assignmentId, assignmentStatus }
+        );
       }
     },
     [userId]

--- a/hooks/useVideoActivityAssignments.ts
+++ b/hooks/useVideoActivityAssignments.ts
@@ -12,7 +12,7 @@
  * (mirroring Quiz's `shareAssignment` / `importSharedAssignment` flows).
  */
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import {
   addDoc,
   collection,
@@ -26,7 +26,7 @@ import {
   updateDoc,
   writeBatch,
 } from 'firebase/firestore';
-import { db } from '../config/firebase';
+import { auth, db } from '../config/firebase';
 import { invalidateSessionViewCount } from './useSessionViewCount';
 import {
   callJoinSyncedVideoActivityGroup,
@@ -35,8 +35,13 @@ import {
   pullSyncedVideoActivityContent,
 } from './useSyncedVideoActivityGroups';
 import { logError } from '../utils/logError';
+import {
+  mirrorPlcAssignmentStatus,
+  writePlcAssignmentIndexEntry,
+} from './usePlcAssignmentIndex';
 import type {
   AssignmentMode,
+  PlcAssignmentIndexEntry,
   SharedVideoActivityAssignment,
   VideoActivityAnswer,
   VideoActivityAssignment,
@@ -51,6 +56,20 @@ import type {
   VideoActivitySession,
 } from '../types';
 import { gradeVideoActivityAnswer } from '../utils/videoActivityGrading';
+
+/**
+ * Map VA assignment status onto the PLC index's shared `QuizAssignmentStatus`
+ * union. The two unions are intentionally identical today; this helper
+ * exists so a future schema split (e.g. VA gaining a 'review' phase) only
+ * needs one switch to update. Keeps the call sites readable.
+ */
+function vaStatusToIndexStatus(
+  s: VideoActivityAssignmentStatus
+): PlcAssignmentIndexEntry['status'] {
+  // Both unions are 'active' | 'paused' | 'inactive' today. The compiler
+  // catches drift if either side adds a member.
+  return s;
+}
 
 const VIDEO_ACTIVITY_ASSIGNMENTS_COLLECTION = 'video_activity_assignments';
 const VIDEO_ACTIVITY_SESSIONS_COLLECTION = 'video_activity_sessions';
@@ -210,6 +229,15 @@ export const useVideoActivityAssignments = (
   const [loading, setLoading] = useState<boolean>(!!userId);
   const [error, setError] = useState<string | null>(null);
 
+  // Live mirror of `assignments` so status mutators can look up a
+  // PLC linkage by id without re-creating the callback every render
+  // (which would churn downstream `useCallback` users). Mirrors the
+  // `assignmentsRef` pattern in `useQuizAssignments.ts`.
+  const assignmentsRef = useRef<VideoActivityAssignment[]>(assignments);
+  useEffect(() => {
+    assignmentsRef.current = assignments;
+  }, [assignments]);
+
   // Adjust state during render when userId transitions away — avoids the
   // "set-state-in-effect" anti-pattern while still clearing stale data when
   // the user signs out.
@@ -291,6 +319,12 @@ export const useVideoActivityAssignments = (
           ? { periodNames: settings.periodNames }
           : {}),
         ...(targetRosterIds.length > 0 ? { rosterIds: targetRosterIds } : {}),
+        // PLC linkage must persist on the assignment doc so the status
+        // mutators (pause / resume / deactivate / reopen) can find the
+        // target PLC index entry to mirror onto. Mirrors the quiz path —
+        // `useQuizAssignments.createAssignment` spreads `settings.plc`
+        // onto its assignment doc the same way.
+        ...(settings.plc ? { plc: settings.plc } : {}),
         mode,
       };
 
@@ -347,6 +381,29 @@ export const useVideoActivityAssignments = (
       );
       await batch.commit();
 
+      // PLC dashboard index: when this VA assignment opts into PLC mode,
+      // record a snapshot under `plcs/{plcId}/assignment_index` so every
+      // teammate sees it on the PLC Dashboard's PLC Assignments tab
+      // alongside quiz entries. Fire-and-forget — the helper has its own
+      // try/catch and never rejects, so the canonical commit returns
+      // immediately. Mirrors the quiz path in `useQuizAssignments`.
+      if (settings.plc) {
+        const current = auth.currentUser;
+        const ownerName = current?.displayName ?? '';
+        const ownerEmail = (current?.email ?? '').toLowerCase();
+        void writePlcAssignmentIndexEntry(settings.plc.id, {
+          id: assignmentId,
+          kind: 'video-activity',
+          ownerUid: userId,
+          ownerName,
+          ownerEmail,
+          title: activity.title,
+          sheetUrl: settings.plc.sheetUrl,
+          status: vaStatusToIndexStatus(initialStatus),
+          createdAt: now,
+        });
+      }
+
       return { id: assignmentId };
     },
     [userId]
@@ -378,6 +435,22 @@ export const useVideoActivityAssignments = (
         sessionPatch
       );
       await batch.commit();
+
+      // Mirror status onto the PLC index entry when this assignment
+      // participates in a PLC. Fire-and-forget — the canonical batch
+      // commit above is the primary write; a mirror failure is logged
+      // by the helper and doesn't reject. The lookup goes through the
+      // ref mirror because `setStatus` is referenced by stable
+      // callbacks (`pauseAssignment` etc.) and we don't want to churn
+      // those callbacks every time `assignments` changes.
+      const live = assignmentsRef.current.find((a) => a.id === assignmentId);
+      if (live?.plc) {
+        void mirrorPlcAssignmentStatus(
+          live.plc.id,
+          assignmentId,
+          vaStatusToIndexStatus(assignmentStatus)
+        );
+      }
     },
     [userId]
   );

--- a/types.ts
+++ b/types.ts
@@ -469,6 +469,48 @@ export interface PlcQuizEntry {
 }
 
 /**
+ * One video activity shared with a PLC, stored at
+ * `plcs/{plcId}/video_activities/{plcVideoActivityId}`.
+ *
+ * Mirrors `PlcQuizEntry` in shape and lifecycle:
+ *   - lightweight header pointing at `synced_video_activities/{syncGroupId}`
+ *     (questions + per-question scoring live there, not here)
+ *   - any current PLC member can share / edit-mirror / unshare
+ *   - identity + attribution fields are immutable post-create
+ *
+ * Differences from quizzes:
+ *   - carries `youtubeUrl` so the tile + tab can render a thumbnail without
+ *     loading the full content blob
+ *   - sync collection is `synced_video_activities/`, not `synced_quizzes/`
+ */
+export interface PlcVideoActivityEntry {
+  /** Doc id; matches the document key under `plcs/{plcId}/video_activities/`. */
+  id: string;
+  /** Mirrored from the synced group; used for list rendering. */
+  title: string;
+  /**
+   * Mirrored from the source activity. Empty string if the source lacked a
+   * URL at share time. Tile rendering may use this to fetch the YouTube
+   * thumbnail; downstream consumers should always defend against `''`.
+   */
+  youtubeUrl: string;
+  /** Mirrored from the synced group's questions array length. */
+  questionCount: number;
+  /** Pointer to the canonical `/synced_video_activities/{groupId}` doc. */
+  syncGroupId: string;
+  /** UID of the original sharer. Immutable. */
+  sharedBy: string;
+  /** Lowercased email snapshot for display. Immutable. */
+  sharedByEmail: string;
+  /** Display name snapshot for attribution. Immutable. */
+  sharedByName: string;
+  /** ms timestamp at first share. Immutable. */
+  sharedAt: number;
+  /** ms timestamp; bumped on title/questionCount mirror updates. */
+  updatedAt: number;
+}
+
+/**
  * One shared note in a PLC notebook. Members CRUD freely; LWW on edits.
  */
 export interface PlcNote {


### PR DESCRIPTION
## Summary

Closes out the PLC Dashboard roadmap's remaining big-rock phases (4 and 6) in a single PR per the user's direction. After this PR, the PLC Overview no longer renders any "Coming soon" placeholder — every bento tile shows live data, and every tab is a real surface.

**Eight commits, sequenced so each is independently bisectable:**

1. `12377c93` — **Bug fix:** `activeAssignments` bento tile was stuck on a "Phase 3 · soon" `ComingSoonTile` despite Phase 3 shipping. New `ActiveAssignmentsTile` surfaces the same in-progress filter as the sub-tab.
2. `417a6114` — **Phase 4 backend:** `usePlcVideoActivities`, `joinPlcVideoActivitySyncGroup` Cloud Function, `plcs/{plcId}/video_activities/` Firestore rules, VA assignment hook persisting `settings.plc` (was being silently dropped — real bug) and writing PLC index entries with `kind: 'video-activity'`, status mirror via `useRef` snapshot.
3. `3445e3c0` — **Phase 4 frontend:** `PlcVideoActivitiesBody` + tab + tile + import modal. Replaces the last `ComingSoonTile` for VA.
4. `4a2c40ec` — **Share kebab on VA library:** mirrors `QuizWidget.handleShareWithPlc` — load Drive content, mint synced group, attach linkage, write PLC subcoll doc, with leave-on-failure rollback.
5. `eb9ea097` — **Phase 6 backend:** `plcId` on `/shared_boards`, immutable for collaborators (host can still re-scope), `usePlcSharedBoards` hook.
6. `584760f8` — **Phase 6 frontend:** `PlcSharedBoardsBody` + tab + tile, plus an optional "Also share with a PLC" picker in `ShareLinkCreatorModal`.
7. `11ea3643` — **Actionable tile rows:** `ActiveAssignmentsTile` rows get inline "Open Sheet" links; `QuizLibraryTile` + `VideoActivitiesTile` rows become focusable `<button>`s that navigate to their tab.
8. `38282342` — **Roadmap doc:** marks Phase 4/6 SHIPPED with full notes-from-implementation. Adds proposed Phase 7 (Mini-apps PLC) and Phase 8 (Guided Learning PLC) starters per user request, plus a cross-cutting follow-ups section.

## Why a single PR instead of 8 small ones

The roadmap says "one phase per PR." The user noticed the dashboard still showed "Coming soon" placeholders and asked for a single PR fixing all of it (Phase 4 + Phase 6 + the bug fix + the tile actionability + the doc) so the review surface matches a single coherent user-facing change. The Phase 1.5 deviation note in `PLC_ROADMAP.md` is updated to capture this trade-off.

## What's NOT in this PR (deferred follow-ups)

- **Phase 7 (Mini-apps PLC)** — proposed in `PLC_ROADMAP.md`, not yet implemented. Has its own follow-up session.
- **Phase 8 (Guided Learning PLC)** — same.
- **In-tab "+ New PLC Assignment" authoring affordance.** Library sub-tab is consume-only today; teachers still author via their personal QuizWidget kebab.
- **Rich kebab actions on Quiz/VA tiles.** Rows navigate to tab on click; inline import/unshare/edit kebab is deferred — the tile would need the body's `useQuiz` / `useVideoActivity` subscription, which suggests a shared hook in a follow-up.
- **ComingSoonTile cleanup.** Dead code after this PR; left in place for proposed Phase 7/8 placeholders.
- **Cloud Function unit tests** for the three `joinPlc*SyncGroup` handlers. Same gap as Phase 2/3.
- **Modal i18n** sweep across `PlcShareTargetModal`, `PlcQuiz/VideoActivityImportModal`, `ShareLinkCreatorModal`'s PLC dropdown.

All of these are tracked in the new `Cross-cutting follow-ups` section of the roadmap.

## Cloud Function deploy

The new `joinPlcVideoActivitySyncGroup` function must be deployed before Sync-mode import works in real Firebase. Copy-mode import works without it.

```
firebase deploy --only functions:joinPlcVideoActivitySyncGroup
```

## Validation

`pnpm run validate` is green on the head commit:

- type-check (root + functions) ✓
- lint (--max-warnings 0) ✓
- format-check ✓
- tests: 227 files / 2357 tests root, 11 files / 209 tests functions ✓

## Test plan

- [ ] Smoke-test PLC dashboard Overview: activeAssignments tile shows live in-progress rows (not "Phase 3 · soon")
- [ ] Smoke-test Video Activities tab + import modal in dev preview
- [ ] Smoke-test VA share-with-PLC kebab on personal library card
- [ ] Smoke-test Shared Boards: create a share with the PLC dropdown picked, then verify it appears on the PLC Shared Boards tab + tile
- [ ] Deploy `joinPlcVideoActivitySyncGroup` Cloud Function before testing Sync-mode import path
- [ ] Verify In-progress sub-tab shows VA assignments with PLC linkage (was previously broken due to `settings.plc` drop bug)

🤖 Generated with [Claude Code](https://claude.com/claude-code)