### PR TITLE
fix(draggable-window): clean up gesture state when pointer capture is silently dropped

### DIFF
--- a/components/common/DraggableWindow.test.tsx
+++ b/components/common/DraggableWindow.test.tsx
@@ -402,6 +402,199 @@ describe('DraggableWindow', () => {
     expect(document.body.classList.contains('is-dragging-widget')).toBe(false);
   });
 
+  // Regression: pointer capture can be silently dropped mid-gesture (browser-
+  // specific — DOM mutations, focus changes, overlapping hit surfaces from a
+  // sibling widget of the same type). When that happens, the user's pointerup
+  // doesn't reach our listener on the capture target. The next pointermove
+  // with buttons=0 must synthesize the teardown so the widget doesn't track
+  // the cursor every time it re-enters the drag-surface.
+  it('synthesizes drag teardown when a mouse pointermove arrives with buttons=0', async () => {
+    renderComponent();
+
+    const dragSurface = screen.getByTestId(
+      'drag-surface'
+    ) as unknown as HTMLElementWithCapture;
+    const windowEl = screen.getByTestId('draggable-window');
+
+    dragSurface.setPointerCapture = vi.fn();
+    dragSurface.hasPointerCapture = vi.fn().mockReturnValue(true);
+    dragSurface.releasePointerCapture = vi.fn();
+
+    fireEvent.pointerDown(dragSurface, {
+      clientX: 110,
+      clientY: 110,
+      pointerId: 1,
+      pointerType: 'mouse',
+      buttons: 1,
+    });
+    expect(document.body.classList.contains('is-dragging-widget')).toBe(true);
+
+    // Normal drag step: pointer moves with button held.
+    fireEvent.pointerMove(dragSurface, {
+      clientX: 160,
+      clientY: 160,
+      pointerId: 1,
+      pointerType: 'mouse',
+      buttons: 1,
+    });
+    await waitFor(() => {
+      expect(windowEl.style.left).toBe('150px');
+    });
+
+    // Pointer button released somewhere we don't see (capture lost), then a
+    // pointermove with buttons=0 arrives on the drag-surface as the cursor
+    // re-enters. Must trigger teardown, not further movement. JSDOM doesn't
+    // reliably propagate `buttons` through PointerEventInit, so patch it onto
+    // the dispatched event explicitly.
+    const dropEvent = new PointerEvent('pointermove', {
+      clientX: 300,
+      clientY: 300,
+      pointerId: 1,
+      pointerType: 'mouse',
+    });
+    Object.defineProperty(dropEvent, 'buttons', { value: 0 });
+    Object.defineProperty(dropEvent, 'pointerType', { value: 'mouse' });
+    fireEvent(dragSurface, dropEvent);
+
+    await waitFor(() => {
+      expect(document.body.classList.contains('is-dragging-widget')).toBe(
+        false
+      );
+    });
+
+    // Subsequent pointermove must NOT move the widget — listener should be
+    // removed by the teardown path.
+    fireEvent.pointerMove(dragSurface, {
+      clientX: 500,
+      clientY: 500,
+      pointerId: 1,
+    });
+    // Position should still reflect the last real drag step, not (500, 500).
+    expect(windowEl.style.left).toBe('150px');
+    expect(windowEl.style.top).toBe('150px');
+  });
+
+  // Regression: a `lostpointercapture` event mid-gesture must run the same
+  // teardown as pointerup so the gesture doesn't get stuck in "follow the
+  // cursor" mode after the browser drops capture.
+  it('runs drag teardown when lostpointercapture fires mid-gesture', async () => {
+    renderComponent();
+
+    const dragSurface = screen.getByTestId(
+      'drag-surface'
+    ) as unknown as HTMLElementWithCapture;
+    const windowEl = screen.getByTestId('draggable-window');
+
+    dragSurface.setPointerCapture = vi.fn();
+    dragSurface.hasPointerCapture = vi.fn().mockReturnValue(false);
+    dragSurface.releasePointerCapture = vi.fn();
+
+    fireEvent.pointerDown(dragSurface, {
+      clientX: 110,
+      clientY: 110,
+      pointerId: 1,
+      pointerType: 'mouse',
+      buttons: 1,
+    });
+    fireEvent.pointerMove(dragSurface, {
+      clientX: 160,
+      clientY: 160,
+      pointerId: 1,
+      pointerType: 'mouse',
+      buttons: 1,
+    });
+    await waitFor(() => {
+      expect(windowEl.style.left).toBe('150px');
+    });
+
+    // Browser drops pointer capture mid-gesture.
+    fireEvent(
+      dragSurface,
+      new PointerEvent('lostpointercapture', { pointerId: 1 })
+    );
+
+    await waitFor(() => {
+      expect(document.body.classList.contains('is-dragging-widget')).toBe(
+        false
+      );
+    });
+
+    // Subsequent pointermove with the same pointerId must not move the widget.
+    fireEvent.pointerMove(dragSurface, {
+      clientX: 500,
+      clientY: 500,
+      pointerId: 1,
+      pointerType: 'mouse',
+      buttons: 1,
+    });
+    expect(windowEl.style.left).toBe('150px');
+    expect(windowEl.style.top).toBe('150px');
+  });
+
+  // Resize gesture parallels the drag gesture's listener wiring. A future
+  // refactor that breaks only the resize teardown wouldn't be caught by the
+  // drag-only regression tests above. Cover the buttons=0 path on a resize
+  // handle to lock both code paths down.
+  it('synthesizes resize teardown when a mouse pointermove arrives with buttons=0', async () => {
+    renderComponent();
+
+    const seHandleEl = document.querySelector('.cursor-se-resize');
+    expect(seHandleEl).not.toBeNull();
+    if (!seHandleEl) return;
+    const seHandle = seHandleEl as unknown as HTMLElementWithCapture;
+    const windowEl = screen.getByTestId('draggable-window');
+
+    seHandle.setPointerCapture = vi.fn();
+    seHandle.hasPointerCapture = vi.fn().mockReturnValue(true);
+    seHandle.releasePointerCapture = vi.fn();
+
+    fireEvent.pointerDown(seHandle, {
+      clientX: 200,
+      clientY: 200,
+      pointerId: 1,
+      pointerType: 'mouse',
+      buttons: 1,
+    });
+    expect(document.body.classList.contains('is-dragging-widget')).toBe(true);
+
+    fireEvent.pointerMove(seHandle, {
+      clientX: 250,
+      clientY: 250,
+      pointerId: 1,
+      pointerType: 'mouse',
+      buttons: 1,
+    });
+    await waitFor(() => {
+      // 200 (initial w from mockWidget) + 50 = 250
+      expect(windowEl.style.width).toBe('250px');
+    });
+
+    // Missed pointerup — capture lost, next move arrives with buttons=0.
+    const dropEvent = new PointerEvent('pointermove', {
+      clientX: 400,
+      clientY: 400,
+      pointerId: 1,
+      pointerType: 'mouse',
+    });
+    Object.defineProperty(dropEvent, 'buttons', { value: 0 });
+    Object.defineProperty(dropEvent, 'pointerType', { value: 'mouse' });
+    fireEvent(seHandle, dropEvent);
+
+    await waitFor(() => {
+      expect(document.body.classList.contains('is-dragging-widget')).toBe(
+        false
+      );
+    });
+
+    // Subsequent pointermove must NOT resize the widget further.
+    fireEvent.pointerMove(seHandle, {
+      clientX: 600,
+      clientY: 600,
+      pointerId: 1,
+    });
+    expect(windowEl.style.width).toBe('250px');
+  });
+
   it('minimizes on Escape key press', () => {
     renderComponent();
     const windowEl = screen.getByTestId('draggable-window');

--- a/components/common/DraggableWindow.tsx
+++ b/components/common/DraggableWindow.tsx
@@ -970,6 +970,16 @@ export const DraggableWindow: React.FC<DraggableWindowProps> = ({
       // Only process the same pointer that started the drag
       if (moveEvent.pointerId !== e.pointerId) return;
 
+      // Defensive: if the mouse button is no longer pressed, the pointerup we
+      // needed was missed (pointer capture silently dropped, event eaten by
+      // another element, etc.). Synthesize the teardown so the widget doesn't
+      // track the cursor every time it re-enters the drag-surface. Touch/pen
+      // don't expose `buttons` reliably and are covered by pointercancel.
+      if (moveEvent.pointerType === 'mouse' && moveEvent.buttons === 0) {
+        onPointerUp(moveEvent);
+        return;
+      }
+
       if (dragAnimationFrame !== null) {
         cancelAnimationFrame(dragAnimationFrame);
       }
@@ -1098,6 +1108,10 @@ export const DraggableWindow: React.FC<DraggableWindowProps> = ({
       targetElement.removeEventListener('pointermove', onPointerMove);
       targetElement.removeEventListener('pointerup', onPointerUp);
       targetElement.removeEventListener('pointercancel', onPointerUp);
+      targetElement.removeEventListener(
+        'lostpointercapture',
+        onLostPointerCapture
+      );
 
       try {
         if (targetElement.hasPointerCapture(e.pointerId)) {
@@ -1168,9 +1182,21 @@ export const DraggableWindow: React.FC<DraggableWindowProps> = ({
       activeGestureCleanupRef.current = null;
     };
 
+    // Defensive: if pointer capture is dropped mid-gesture (browser-specific:
+    // DOM mutations under the captured element, focus changes, OS interrupts,
+    // overlapping hit surfaces from a sibling widget), our pointerup listener
+    // on targetElement may never fire because subsequent pointer events stop
+    // routing here. Treat lost capture as the end of the gesture and run the
+    // same teardown as pointerup.
+    const onLostPointerCapture = (lostEvent: PointerEvent) => {
+      if (lostEvent.pointerId !== e.pointerId) return;
+      onPointerUp(lostEvent);
+    };
+
     targetElement.addEventListener('pointermove', onPointerMove);
     targetElement.addEventListener('pointerup', onPointerUp);
     targetElement.addEventListener('pointercancel', onPointerUp);
+    targetElement.addEventListener('lostpointercapture', onLostPointerCapture);
   };
 
   /** Inner edge drag zones sit on top of widget content. Before starting a drag,
@@ -1309,6 +1335,15 @@ export const DraggableWindow: React.FC<DraggableWindowProps> = ({
     const onPointerMove = (moveEvent: PointerEvent) => {
       if (moveEvent.pointerId !== e.pointerId) return;
 
+      // Defensive: see handleDragStart's onPointerMove. If the mouse button is
+      // no longer pressed, the pointerup we needed was missed; synthesize the
+      // teardown so the widget doesn't resize every time the cursor re-enters
+      // the resize handle.
+      if (moveEvent.pointerType === 'mouse' && moveEvent.buttons === 0) {
+        onPointerUp(moveEvent);
+        return;
+      }
+
       if (resizeAnimationFrame !== null) {
         cancelAnimationFrame(resizeAnimationFrame);
       }
@@ -1406,6 +1441,10 @@ export const DraggableWindow: React.FC<DraggableWindowProps> = ({
       targetElement.removeEventListener('pointermove', onPointerMove);
       targetElement.removeEventListener('pointerup', onPointerUp);
       targetElement.removeEventListener('pointercancel', onPointerUp);
+      targetElement.removeEventListener(
+        'lostpointercapture',
+        onLostPointerCapture
+      );
 
       try {
         if (targetElement.hasPointerCapture(e.pointerId)) {
@@ -1436,9 +1475,18 @@ export const DraggableWindow: React.FC<DraggableWindowProps> = ({
       activeGestureCleanupRef.current = null;
     };
 
+    // Defensive: see handleDragStart for the rationale. If pointer capture is
+    // dropped mid-resize, run the same teardown as pointerup so the widget
+    // doesn't stay in a "follow the cursor" state after the user releases.
+    const onLostPointerCapture = (lostEvent: PointerEvent) => {
+      if (lostEvent.pointerId !== e.pointerId) return;
+      onPointerUp(lostEvent);
+    };
+
     targetElement.addEventListener('pointermove', onPointerMove);
     targetElement.addEventListener('pointerup', onPointerUp);
     targetElement.addEventListener('pointercancel', onPointerUp);
+    targetElement.addEventListener('lostpointercapture', onLostPointerCapture);
   };
 
   // Force 100% opacity when spotlighted so it stands out against the dimming overlay


### PR DESCRIPTION
## Summary

- Adds two defenses against pointer-capture loss mid-gesture in `DraggableWindow`: an early-exit when a mouse `pointermove` arrives with `buttons === 0` (missed pointerup) and a `lostpointercapture` listener that delegates to the same teardown as `pointerup`. Applied to both `handleDragStart` and `handleResizeStart`.
- Closes the regression introduced by #1580 where moving gesture listeners from `window` to the captured element exposed silent capture drops — the user's pointerup would never reach our listener, leaving `isDragging` true and causing the widget to "track" the cursor whenever it re-entered the drag-surface or resize handle.
- Most visible on widgets with live Firestore subscriptions (Activity Wall) and on two same-type widgets opened back-to-back, whose identical default positions stack their hit surfaces directly on top of each other.

## Test plan

- [x] `pnpm run type-check`
- [x] `pnpm run lint`
- [x] `pnpm run format:check`
- [x] `pnpm exec vitest run components/common/DraggableWindow.test.tsx` — 46/46 pass, including three new regression tests (buttons=0 on drag, lostpointercapture on drag, buttons=0 on resize)
- [ ] Manual: open two Activity Wall widgets back-to-back, drag one, release the pointer outside its bounds, move the cursor back over it. Widget should stay put. Repeat with the SE resize handle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)