### PR TITLE
feat(ai): surface admin notice when Gemini model config falls back

### DIFF
--- a/components/admin/WidgetBuilder/GeminiPanel.tsx
+++ b/components/admin/WidgetBuilder/GeminiPanel.tsx
@@ -2,6 +2,7 @@ import React, { useState, useCallback } from 'react';
 import { httpsCallable } from 'firebase/functions';
 import { functions } from '@/config/firebase';
 import { Sparkles, Wrench, Plus, HelpCircle, Loader2 } from 'lucide-react';
+import { reportAiModelConfigFallback } from '@/utils/aiModelConfigFallback';
 
 interface GeminiPanelProps {
   onGenerate: (code: string) => void;
@@ -45,9 +46,10 @@ async function callGemini(
 ): Promise<string> {
   const generate = httpsCallable<
     { type: string; prompt: string },
-    { result: string }
+    { result: string; _modelConfigUsedFallback?: boolean }
   >(functions, 'generateWithAI');
   const response = await generate({ type, prompt });
+  reportAiModelConfigFallback(response.data._modelConfigUsedFallback);
   return response.data.result;
 }
 

--- a/components/widgets/InstructionalRoutines/LibraryManager.tsx
+++ b/components/widgets/InstructionalRoutines/LibraryManager.tsx
@@ -20,6 +20,7 @@ import { ALL_GRADE_LEVELS } from '@/config/widgetGradeLevels';
 import { TOOLS } from '@/config/tools';
 import { WidgetType } from '@/types';
 import { httpsCallable } from 'firebase/functions';
+import { reportAiModelConfigFallback } from '@/utils/aiModelConfigFallback';
 
 // Derive widget types from TOOLS registry, excluding catalyst-related widgets and internal tools
 const WIDGET_TYPES: WidgetType[] = TOOLS.filter(
@@ -76,7 +77,10 @@ export const LibraryManager: React.FC<LibraryManagerProps> = ({
         prompt,
       });
 
-      const data = result.data as Partial<InstructionalRoutine>;
+      const data = result.data as Partial<InstructionalRoutine> & {
+        _modelConfigUsedFallback?: boolean;
+      };
+      reportAiModelConfigFallback(data._modelConfigUsedFallback);
 
       // Preserve ID but overwrite other fields
       onChange({

--- a/context/DashboardContext.tsx
+++ b/context/DashboardContext.tsx
@@ -490,7 +490,14 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
         }
       );
     });
-    return () => setAiModelConfigFallbackHandler(null);
+    return () => {
+      setAiModelConfigFallbackHandler(null);
+      // Reset the module-level latch on teardown so a re-mounted provider
+      // (e.g. user signs out and a different user signs in without a full
+      // page reload) still surfaces the toast on the next stale-config
+      // attempt. Otherwise the latch would stay sticky across sessions.
+      resetAiModelConfigFallbackLatch();
+    };
   }, [addToast]);
 
   const [gradeFilter, setGradeFilter] = useState<GradeFilter>(() => {

--- a/context/DashboardContext.tsx
+++ b/context/DashboardContext.tsx
@@ -476,7 +476,14 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
   // via `_modelConfigUsedFallback` and consumed in `utils/ai.ts`. We only
   // notify on the most recent attempt — the latch in the helper de-dupes
   // until the user clicks "Reload to retry" (which reloads, re-arming).
+  //
+  // Gated to admins: non-admins can't act on the notice (the override is set
+  // in Admin Settings) and the copy explicitly mentions "admin overrides".
+  // Non-admins still get AI generation — they just don't see the warning.
   useEffect(() => {
+    if (isAdmin !== true) {
+      return;
+    }
     setAiModelConfigFallbackHandler(() => {
       addToast(
         'AI is running with default models (admin overrides unavailable). Reload to retry.',
@@ -498,7 +505,7 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
       // attempt. Otherwise the latch would stay sticky across sessions.
       resetAiModelConfigFallbackLatch();
     };
-  }, [addToast]);
+  }, [addToast, isAdmin]);
 
   const [gradeFilter, setGradeFilter] = useState<GradeFilter>(() => {
     const saved = localStorage.getItem('spartboard_gradeFilter');

--- a/context/DashboardContext.tsx
+++ b/context/DashboardContext.tsx
@@ -56,6 +56,10 @@ import { useRosters } from '../hooks/useRosters';
 import { useGoogleDrive } from '../hooks/useGoogleDrive';
 import { setDriveAuthErrorHandler } from '../utils/driveAuthErrors';
 import {
+  setAiModelConfigFallbackHandler,
+  resetAiModelConfigFallbackLatch,
+} from '../utils/aiModelConfigFallback';
+import {
   DashboardContext,
   PendingShareImport,
   SharedBoardImportMode,
@@ -465,6 +469,29 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
     });
     return () => setDriveAuthErrorHandler(null);
   }, [addToast, refreshGoogleToken]);
+
+  // Surface a one-time notice when an AI Cloud Function couldn't read the
+  // admin-configured Gemini model overrides from Firestore and fell back to
+  // hardcoded defaults. The flag is plumbed through every AI response payload
+  // via `_modelConfigUsedFallback` and consumed in `utils/ai.ts`. We only
+  // notify on the most recent attempt — the latch in the helper de-dupes
+  // until the user clicks "Reload to retry" (which reloads, re-arming).
+  useEffect(() => {
+    setAiModelConfigFallbackHandler(() => {
+      addToast(
+        'AI is running with default models (admin overrides unavailable). Reload to retry.',
+        'warning',
+        {
+          label: 'Reload',
+          onClick: () => {
+            resetAiModelConfigFallbackLatch();
+            window.location.reload();
+          },
+        }
+      );
+    });
+    return () => setAiModelConfigFallbackHandler(null);
+  }, [addToast]);
 
   const [gradeFilter, setGradeFilter] = useState<GradeFilter>(() => {
     const saved = localStorage.getItem('spartboard_gradeFilter');

--- a/functions/src/index.test.ts
+++ b/functions/src/index.test.ts
@@ -2313,6 +2313,7 @@ describe('generateWithAI read caching', () => {
     expect(first).toEqual({
       advancedModel: 'gemini-2.5-pro',
       standardModel: 'gemini-2.5-flash',
+      usedFallback: false,
     });
     expect(second).toEqual(first);
     // The second call must NOT hit Firestore.
@@ -2343,5 +2344,108 @@ describe('generateWithAI read caching', () => {
     expect(first.advancedModel).not.toBe('gemini-2.5-pro');
     expect(second.advancedModel).toBe('gemini-2.5-pro');
     expect(geminiConfigDocGet).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('getGeminiModelConfig usedFallback flag', () => {
+  // Locks in the silent-failure-hunter contract from PR #1597 review: when the
+  // Firestore read for admin model overrides throws (brownout / outage), the
+  // function returns hardcoded defaults AND sets `usedFallback: true` so the
+  // client can surface a one-time admin notice. Without the flag, regressions
+  // in admin-configured AI quality are invisible.
+  //
+  // Uses an isolated `buildDb` rather than the shared scaffolding so the
+  // assertions don't depend on global mock state. Resets the module cache
+  // between cases so a successful read from one case doesn't satisfy the
+  // throw-path read in the next.
+
+  /* eslint-disable @typescript-eslint/no-explicit-any */
+  const buildDb = (
+    geminiDocBehavior: 'success-with-overrides' | 'success-empty' | 'throws'
+  ): any => ({
+    collection: vi.fn((name: string) => {
+      if (name !== 'global_permissions') {
+        throw new Error(`Unexpected collection access: ${name}`);
+      }
+      return {
+        doc: vi.fn((docId: string) => {
+          if (docId !== 'gemini-functions') {
+            throw new Error(`Unexpected doc access: ${docId}`);
+          }
+          return {
+            get: vi.fn(() => {
+              if (geminiDocBehavior === 'throws') {
+                return Promise.reject(
+                  new Error('Firestore unavailable (simulated brownout)')
+                );
+              }
+              if (geminiDocBehavior === 'success-with-overrides') {
+                return Promise.resolve({
+                  data: () => ({
+                    config: {
+                      advancedModel: 'gemini-2.5-pro',
+                      standardModel: 'gemini-2.5-flash',
+                    },
+                  }),
+                });
+              }
+              // success-empty: doc exists but has no config
+              return Promise.resolve({ data: () => ({}) });
+            }),
+          };
+        }),
+      };
+    }),
+  });
+  /* eslint-enable @typescript-eslint/no-explicit-any */
+
+  beforeEach(() => {
+    __resetGenerateWithAICaches();
+  });
+
+  it('sets usedFallback=true and returns defaults when the Firestore read throws', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    /* eslint-disable @typescript-eslint/no-unsafe-argument */
+    const result = await __getGeminiModelConfig(buildDb('throws'));
+    /* eslint-enable @typescript-eslint/no-unsafe-argument */
+
+    expect(result.usedFallback).toBe(true);
+    // Defaults must still be valid (non-empty) model names so generation can
+    // proceed — the whole point of the fallback path is to keep AI working
+    // during a Firestore brownout.
+    expect(typeof result.advancedModel).toBe('string');
+    expect(result.advancedModel.length).toBeGreaterThan(0);
+    expect(typeof result.standardModel).toBe('string');
+    expect(result.standardModel.length).toBeGreaterThan(0);
+
+    // The log-only behavior is preserved alongside the new flag.
+    expect(warnSpy).toHaveBeenCalled();
+
+    warnSpy.mockRestore();
+  });
+
+  it('sets usedFallback=false when admin overrides load successfully', async () => {
+    /* eslint-disable @typescript-eslint/no-unsafe-argument */
+    const result = await __getGeminiModelConfig(
+      buildDb('success-with-overrides')
+    );
+    /* eslint-enable @typescript-eslint/no-unsafe-argument */
+
+    expect(result.usedFallback).toBe(false);
+    expect(result.advancedModel).toBe('gemini-2.5-pro');
+    expect(result.standardModel).toBe('gemini-2.5-flash');
+  });
+
+  it('sets usedFallback=false when the doc exists but carries no overrides', async () => {
+    // No admin has tuned overrides yet — `cfg` is undefined and we fall
+    // through to defaults. This is the steady-state for a fresh install
+    // and must NOT trigger the fallback UI signal (which is reserved for
+    // actual Firestore read failures).
+    /* eslint-disable @typescript-eslint/no-unsafe-argument */
+    const result = await __getGeminiModelConfig(buildDb('success-empty'));
+    /* eslint-enable @typescript-eslint/no-unsafe-argument */
+
+    expect(result.usedFallback).toBe(false);
   });
 });

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -153,7 +153,11 @@ interface GeminiModelConfig {
 const READ_CACHE_TTL_MS = 5 * 60 * 1000;
 
 interface ModelConfigCacheEntry {
-  value: { advancedModel: string; standardModel: string };
+  value: {
+    advancedModel: string;
+    standardModel: string;
+    usedFallback: boolean;
+  };
   cachedAt: number;
 }
 let cachedModelConfig: ModelConfigCacheEntry | null = null;
@@ -188,10 +192,19 @@ export function __resetGenerateWithAICaches(): void {
  * Reads the admin-configured model overrides from the `gemini-functions`
  * global permissions document. Returns validated model names (or defaults).
  * Memoized with a 5-minute TTL — see `READ_CACHE_TTL_MS` above.
+ *
+ * `usedFallback` is `true` when the Firestore read threw — meaning the
+ * caller is running with hardcoded defaults rather than whatever overrides
+ * an admin may have configured. Plumb this back to the client so admins
+ * get a one-time UI signal during Firestore brownouts. Cache hits always
+ * return `usedFallback: false` because the catch path deliberately does
+ * NOT populate the cache.
  */
-async function getGeminiModelConfig(
-  db: admin.firestore.Firestore
-): Promise<{ advancedModel: string; standardModel: string }> {
+async function getGeminiModelConfig(db: admin.firestore.Firestore): Promise<{
+  advancedModel: string;
+  standardModel: string;
+  usedFallback: boolean;
+}> {
   const now = Date.now();
   if (
     cachedModelConfig &&
@@ -210,6 +223,7 @@ async function getGeminiModelConfig(
         normalizeModelName(cfg?.advancedModel) ?? DEFAULT_ADVANCED_MODEL,
       standardModel:
         normalizeModelName(cfg?.standardModel) ?? DEFAULT_STANDARD_MODEL,
+      usedFallback: false,
     };
     cachedModelConfig = { value, cachedAt: now };
     return value;
@@ -223,6 +237,7 @@ async function getGeminiModelConfig(
     return {
       advancedModel: DEFAULT_ADVANCED_MODEL,
       standardModel: DEFAULT_STANDARD_MODEL,
+      usedFallback: true,
     };
   }
 }
@@ -1149,15 +1164,22 @@ Output JSON ONLY in this exact shape:
 
       // blooms-ai returns plain text — wrap in { text } for the generic callAI client
       if (genType === 'blooms-ai') {
-        return { text };
+        return { text, _modelConfigUsedFallback: geminiConfig.usedFallback };
       }
 
       // widget-builder and widget-explainer return plain text — wrap in { result } for the client
       if (genType === 'widget-builder' || genType === 'widget-explainer') {
-        return { result: text };
+        return {
+          result: text,
+          _modelConfigUsedFallback: geminiConfig.usedFallback,
+        };
       }
 
-      return parseGeminiJson<Record<string, unknown>>(text);
+      const parsed = parseGeminiJson<Record<string, unknown>>(text);
+      // Annotate JSON responses with the fallback flag so the client can
+      // surface a one-time admin notice. Underscore-prefixed to make the
+      // marker obvious and avoid colliding with any field Gemini returns.
+      return { ...parsed, _modelConfigUsedFallback: geminiConfig.usedFallback };
     } catch (error: unknown) {
       console.error('AI Generation Error Details:', error);
 
@@ -1533,6 +1555,12 @@ interface GeneratedVideoQuestion {
 interface GeneratedVideoActivity {
   title: string;
   questions: GeneratedVideoQuestion[];
+  /**
+   * Optional: `true` when the Cloud Function couldn't read the admin model
+   * config from Firestore and fell back to hardcoded defaults. Lets the
+   * client surface a one-time admin notice without polluting every call.
+   */
+  _modelConfigUsedFallback?: boolean;
 }
 
 /**
@@ -1724,7 +1752,10 @@ Return JSON in this exact format:
         throw new Error('Invalid response structure from AI');
       }
 
-      return parsed;
+      return {
+        ...parsed,
+        _modelConfigUsedFallback: geminiConfig.usedFallback,
+      };
     } catch (error: unknown) {
       console.error('[generateVideoActivity] Gemini error:', error);
       const detail = error instanceof Error ? error.message : 'unknown error';
@@ -2047,6 +2078,8 @@ interface GeneratedGuidedLearning {
   suggestedTitle: string;
   suggestedMode: string;
   steps: GuidedLearningStep[];
+  /** See `GeneratedVideoActivity._modelConfigUsedFallback`. */
+  _modelConfigUsedFallback?: boolean;
 }
 
 interface GuidedLearningImageInput {
@@ -2259,7 +2292,10 @@ Guidelines:
             : 0,
       }));
 
-      return parsed;
+      return {
+        ...parsed,
+        _modelConfigUsedFallback: geminiConfig.usedFallback,
+      };
     } catch (error: unknown) {
       console.error('[generateGuidedLearning] Gemini error:', error);
       const detail = error instanceof Error ? error.message : 'unknown error';

--- a/tests/utils/ai.test.ts
+++ b/tests/utils/ai.test.ts
@@ -446,17 +446,16 @@ describe('video activity callables', () => {
     // Pins the doc claim that the flag is transport-only and not observable
     // on the resolved value. Without stripping, a caller that spreads the
     // result into a Firestore write would persist the flag.
-    vi.mocked(httpsCallable).mockImplementationOnce(
-      (_functions, _name, _options) => {
-        return async () => ({
-          data: {
-            title: 'Video Activity',
-            questions: [{ text: 'Q1', timestamp: 5 }],
-            _modelConfigUsedFallback: true,
-          },
-        });
-      }
-    );
+    // `httpsCallable` has a complex return type (callable function with a
+    // `.stream()` method); the tests only exercise the call signature so
+    // cast the mock impl through `unknown` to satisfy the type checker.
+    vi.mocked(httpsCallable).mockImplementationOnce((() => async () => ({
+      data: {
+        title: 'Video Activity',
+        questions: [{ text: 'Q1', timestamp: 5 }],
+        _modelConfigUsedFallback: true,
+      },
+    })) as unknown as typeof httpsCallable);
 
     const result = await generateVideoActivity(
       'https://youtube.com/watch?v=fallbackflagstrip',
@@ -467,7 +466,8 @@ describe('video activity callables', () => {
       questions: [{ text: 'Q1', timestamp: 5 }],
     });
     expect(
-      '_modelConfigUsedFallback' in (result as Record<string, unknown>)
+      '_modelConfigUsedFallback' in
+        (result as unknown as Record<string, unknown>)
     ).toBe(false);
   });
 });

--- a/tests/utils/ai.test.ts
+++ b/tests/utils/ai.test.ts
@@ -441,6 +441,35 @@ describe('video activity callables', () => {
       'Video analysis is taking longer than expected. Please try a shorter YouTube video (under ~15 minutes) or try again in a moment.'
     );
   });
+
+  it('strips the _modelConfigUsedFallback transport flag from the returned payload', async () => {
+    // Pins the doc claim that the flag is transport-only and not observable
+    // on the resolved value. Without stripping, a caller that spreads the
+    // result into a Firestore write would persist the flag.
+    vi.mocked(httpsCallable).mockImplementationOnce(
+      (_functions, _name, _options) => {
+        return async () => ({
+          data: {
+            title: 'Video Activity',
+            questions: [{ text: 'Q1', timestamp: 5 }],
+            _modelConfigUsedFallback: true,
+          },
+        });
+      }
+    );
+
+    const result = await generateVideoActivity(
+      'https://youtube.com/watch?v=fallbackflagstrip',
+      1
+    );
+    expect(result).toEqual({
+      title: 'Video Activity',
+      questions: [{ text: 'Q1', timestamp: 5 }],
+    });
+    expect(
+      '_modelConfigUsedFallback' in (result as Record<string, unknown>)
+    ).toBe(false);
+  });
 });
 
 describe('recommendVideoForActivity', () => {

--- a/tests/utils/aiModelConfigFallback.test.ts
+++ b/tests/utils/aiModelConfigFallback.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  __resetAiModelConfigFallbackForTests,
+  reportAiModelConfigFallback,
+  resetAiModelConfigFallbackLatch,
+  setAiModelConfigFallbackHandler,
+} from '@/utils/aiModelConfigFallback';
+
+afterEach(() => {
+  __resetAiModelConfigFallbackForTests();
+});
+
+describe('aiModelConfigFallback', () => {
+  it('fires the handler once per latch lifetime and de-dupes subsequent reports', () => {
+    const handler = vi.fn();
+    setAiModelConfigFallbackHandler(handler);
+
+    expect(reportAiModelConfigFallback(true)).toBe(true);
+    expect(reportAiModelConfigFallback(true)).toBe(false);
+    expect(reportAiModelConfigFallback(true)).toBe(false);
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not fire when the usedFallback flag is falsy', () => {
+    const handler = vi.fn();
+    setAiModelConfigFallbackHandler(handler);
+
+    reportAiModelConfigFallback(false);
+    reportAiModelConfigFallback(undefined);
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('re-arms after resetAiModelConfigFallbackLatch is called', () => {
+    // Guards the DashboardProvider unmount-cleanup contract: a re-mounted
+    // provider (e.g. account switch without page reload) must surface the
+    // toast again on the next stale-config attempt.
+    const handler = vi.fn();
+    setAiModelConfigFallbackHandler(handler);
+
+    reportAiModelConfigFallback(true);
+    expect(handler).toHaveBeenCalledTimes(1);
+
+    resetAiModelConfigFallbackLatch();
+
+    reportAiModelConfigFallback(true);
+    expect(handler).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not fire when no handler is registered', () => {
+    setAiModelConfigFallbackHandler(null);
+    expect(reportAiModelConfigFallback(true)).toBe(false);
+  });
+});

--- a/utils/ai.ts
+++ b/utils/ai.ts
@@ -9,6 +9,7 @@ import {
   GuidedLearningInteractionType,
 } from '@/types';
 import { TOOLS } from '@/config/tools';
+import { reportAiModelConfigFallback } from '@/utils/aiModelConfigFallback';
 
 export interface GeneratedMiniApp {
   /** The generated HTML code for the mini-app, including embedded CSS and JS */
@@ -43,6 +44,13 @@ interface AIResponseData {
   videoId?: string;
   /** `video-activity-recommend`: one-sentence reason this video fits the topic. */
   rationale?: string;
+  /**
+   * `true` when the Cloud Function couldn't read admin-configured Gemini
+   * model overrides from Firestore and fell back to hardcoded defaults.
+   * Reported to the user via `reportAiModelConfigFallback` so admins get a
+   * one-time signal that overrides were silently ignored.
+   */
+  _modelConfigUsedFallback?: boolean;
 }
 
 export type AIGenerationType =
@@ -65,6 +73,12 @@ export interface GeneratedVideoQuestion extends GeneratedQuestion {
 export interface GeneratedVideoActivity {
   title: string;
   questions: GeneratedVideoQuestion[];
+  /**
+   * Optional flag returned by the Cloud Function when admin model overrides
+   * couldn't be loaded from Firestore. Consumed and stripped by callers via
+   * `reportAiModelConfigFallback`.
+   */
+  _modelConfigUsedFallback?: boolean;
 }
 
 const VIDEO_ACTIVITY_CALL_TIMEOUT_MS = 300_000;
@@ -95,6 +109,7 @@ async function callAI(
     >(functions, 'generateWithAI');
 
     const result = await generateWithAI(payload);
+    reportAiModelConfigFallback(result.data?._modelConfigUsedFallback);
     return result.data;
   } catch (error) {
     console.error('AI Generation Error:', error);
@@ -275,6 +290,7 @@ export async function generateVideoActivity(
     });
 
     const result = await fn({ url, questionCount });
+    reportAiModelConfigFallback(result.data._modelConfigUsedFallback);
 
     if (
       !result.data.title ||
@@ -431,6 +447,7 @@ interface AIGuidedLearningResponse {
   suggestedTitle?: string;
   suggestedMode?: string;
   steps?: unknown[];
+  _modelConfigUsedFallback?: boolean;
 }
 
 /** One image to send to Gemini for guided-learning generation. */
@@ -468,6 +485,7 @@ export async function generateGuidedLearning(
 
     const result = await fn({ images, prompt });
     const data = result.data;
+    reportAiModelConfigFallback(data._modelConfigUsedFallback);
 
     if (
       !data.suggestedTitle ||

--- a/utils/ai.ts
+++ b/utils/ai.ts
@@ -45,10 +45,11 @@ interface AIResponseData {
   /** `video-activity-recommend`: one-sentence reason this video fits the topic. */
   rationale?: string;
   /**
-   * `true` when the Cloud Function couldn't read admin-configured Gemini
-   * model overrides from Firestore and fell back to hardcoded defaults.
-   * Reported to the user via `reportAiModelConfigFallback` so admins get a
-   * one-time signal that overrides were silently ignored.
+   * Transport-only flag set by the Cloud Function when admin-configured
+   * Gemini model overrides couldn't be read from Firestore. The shared
+   * `callAI` helper reports it via `reportAiModelConfigFallback` and then
+   * deletes the property before returning, so callers never observe it on
+   * the resolved payload.
    */
   _modelConfigUsedFallback?: boolean;
 }
@@ -74,9 +75,11 @@ export interface GeneratedVideoActivity {
   title: string;
   questions: GeneratedVideoQuestion[];
   /**
-   * Optional flag returned by the Cloud Function when admin model overrides
-   * couldn't be loaded from Firestore. Consumed and stripped by callers via
-   * `reportAiModelConfigFallback`.
+   * Transport-only flag returned by the Cloud Function when admin model
+   * overrides couldn't be loaded from Firestore. `generateVideoActivity`
+   * passes it to `reportAiModelConfigFallback` (which fires a one-time
+   * toast) and then strips the property before returning, so callers
+   * never observe it on the resolved payload.
    */
   _modelConfigUsedFallback?: boolean;
 }
@@ -110,6 +113,12 @@ async function callAI(
 
     const result = await generateWithAI(payload);
     reportAiModelConfigFallback(result.data?._modelConfigUsedFallback);
+    // Strip the transport flag before handing the payload back to callers
+    // so it doesn't get serialized into Firestore by anything that spreads
+    // or persists the response object.
+    if (result.data && '_modelConfigUsedFallback' in result.data) {
+      delete result.data._modelConfigUsedFallback;
+    }
     return result.data;
   } catch (error) {
     console.error('AI Generation Error:', error);
@@ -302,7 +311,12 @@ export async function generateVideoActivity(
       );
     }
 
-    return result.data;
+    // Strip the transport flag so a caller that spreads / persists this
+    // object (the editor saves activities to Firestore) never round-trips
+    // `_modelConfigUsedFallback` into stored content.
+    const { _modelConfigUsedFallback: _omit, ...payload } = result.data;
+    void _omit;
+    return payload;
   } catch (error) {
     console.error('Video Activity Generation Error:', error);
     if (isFunctionsDeadlineExceededError(error)) {

--- a/utils/aiModelConfigFallback.ts
+++ b/utils/aiModelConfigFallback.ts
@@ -1,0 +1,65 @@
+/**
+ * Shared "AI model config used fallback" surface.
+ *
+ * The `generateWithAI` Cloud Function (and its siblings) reads admin-configured
+ * Gemini model overrides from Firestore. When that read throws — Firestore
+ * brownout, transient outage — the function silently falls back to hardcoded
+ * default model names and proceeds with generation. Without a signal, admins
+ * who've tuned overrides have no idea their settings were ignored.
+ *
+ * Every AI callable now returns `_modelConfigUsedFallback: boolean` on its
+ * response. Client-side callers route that flag through `reportAiModelConfigFallback`,
+ * which de-dupes via a module-level latch and dispatches a registered toast
+ * handler — surfacing the notice exactly once until the latch is reset.
+ *
+ * Mirrors the `driveAuthErrors` singleton-dispatch pattern so we don't have to
+ * thread context through every AI-calling component.
+ */
+
+type AiModelConfigFallbackHandler = () => void;
+
+let handler: AiModelConfigFallbackHandler | null = null;
+let latched = false;
+
+/**
+ * Register (or clear) the toast/banner dispatcher. Called once by the auth
+ * provider so the dispatch is available before any AI call fires.
+ */
+export const setAiModelConfigFallbackHandler = (
+  next: AiModelConfigFallbackHandler | null
+): void => {
+  handler = next;
+};
+
+/**
+ * Called by every AI helper with the `_modelConfigUsedFallback` flag from the
+ * Cloud Function response. Fires the toast exactly once per latch lifetime.
+ * Returns `true` iff the toast was actually dispatched on this call.
+ *
+ * If no handler is registered yet, we leave the latch open so the next report
+ * — once a handler exists — still surfaces a toast.
+ */
+export const reportAiModelConfigFallback = (
+  usedFallback: boolean | undefined
+): boolean => {
+  if (!usedFallback) return false;
+  if (latched) return false;
+  if (!handler) return false;
+  handler();
+  latched = true;
+  return true;
+};
+
+/**
+ * Reset the latch so the next fallback report fires the toast again. Intended
+ * to be called from a "Reload to retry" action or on a fresh sign-in.
+ */
+export const resetAiModelConfigFallbackLatch = (): void => {
+  latched = false;
+};
+
+/** Test-only: clear all module-level state. */
+export const __resetAiModelConfigFallbackForTests = (): void => {
+  handler = null;
+  latched = false;
+};


### PR DESCRIPTION
## Summary

Addresses the silent-failure-hunter finding on PR #1597: `getGeminiModelConfig` swallows Firestore read failures, logs `console.warn`, and returns hardcoded defaults — so when an admin's model overrides silently revert during a Firestore brownout, AI quality regressions are invisible.

- `getGeminiModelConfig` now returns `usedFallback: boolean`. `true` only when the Firestore read actually threw — NOT when the doc exists but carries no overrides (steady state for fresh installs).
- `generateWithAI`, `generateVideoActivity`, and `generateGuidedLearning` plumb `_modelConfigUsedFallback` onto every response payload. (`transcribeVideoWithGemini` doesn't use `getGeminiModelConfig`, so it's untouched.)
- New `utils/aiModelConfigFallback.ts` mirrors the `driveAuthErrors` singleton-dispatch + latch pattern. Toast fires exactly once per stale episode; "Reload" action resets the latch and reloads.
- `DashboardProvider` registers the handler alongside the existing Drive auth toast.
- Every client AI caller (`utils/ai.ts` callAI + video-activity + guided-learning, plus `GeminiPanel` and `InstructionalRoutines/LibraryManager`) reports the flag.
- Three new CF tests cover the throws / loaded-overrides / empty-doc paths.

Existing log-only behavior on the cache path is preserved — the toast only fires when the most recent attempt actually used the fallback.

## Test plan

- [x] `pnpm run validate` — 2301 root tests pass, 207 functions tests pass, type-check clean, lint clean, format clean.
- [ ] Manual: simulate a Firestore brownout (e.g. revoke the gemini-functions doc read permission temporarily) and confirm the toast fires once per session and that "Reload" actually reloads.
- [ ] Manual: confirm normal operation (overrides set or empty doc) does NOT surface the toast.

https://claude.ai/code/session_013zvCrVPVsj822JHD6NqLtC

---
_Generated by [Claude Code](https://claude.ai/code/session_013zvCrVPVsj822JHD6NqLtC)_