### PR TITLE
refactor(functions): LRU eviction for admin status cache + BoundedLruMap utility

### DIFF
--- a/functions/src/index.test.ts
+++ b/functions/src/index.test.ts
@@ -2271,11 +2271,12 @@ describe('generateWithAI read caching', () => {
     expect(adminDocGet).toHaveBeenCalledTimes(2);
   });
 
-  it('evicts the oldest entry when the admin cache exceeds its bound', async () => {
+  it('evicts the least-recently-used entry when the admin cache exceeds its bound', async () => {
     // Pins the size-cap contract — a warm instance that sees many distinct
-    // callers must not grow the Map unboundedly. Insertion order is FIFO,
-    // so after filling beyond the cap and probing the very first email
-    // again, that email must be a cache miss (re-reads Firestore).
+    // callers must not grow the Map unboundedly. The cache is LRU, so
+    // after filling beyond the cap the oldest *by recency* entries are
+    // evicted; entries that were never re-touched stay at the front of
+    // the eviction queue.
     const db = admin.firestore();
     // The implementation cap is 500; fill past it with unique emails.
     // Reading 510 distinct emails forces 10 evictions starting from the
@@ -2292,6 +2293,42 @@ describe('generateWithAI read caching', () => {
 
     // bulk-509 (the most recent) is still cached.
     await __getCachedAdminStatus(db, 'bulk-509@school.org');
+    expect(adminDocGet).toHaveBeenCalledTimes(511);
+  });
+
+  it('LRU: a recently-accessed key survives eviction pressure that would drop it under FIFO', async () => {
+    // The regression this guards against: under FIFO, a frequently-hit
+    // key written early gets evicted by one-off lookups. Under LRU, a
+    // hit promotes the key to the tail and it survives.
+    const db = admin.firestore();
+
+    // Insert bulk-0 first, then fill the cache up to (but not over) the
+    // cap with 499 other distinct keys. After this, bulk-0 is the oldest
+    // by insertion order.
+    await __getCachedAdminStatus(db, 'bulk-0@school.org');
+    for (let i = 1; i < 500; i++) {
+      await __getCachedAdminStatus(db, `bulk-${i}@school.org`);
+    }
+    expect(adminDocGet).toHaveBeenCalledTimes(500);
+
+    // Touch bulk-0 again — under LRU this promotes it to most-recently-used.
+    // No Firestore read because it's still cached.
+    await __getCachedAdminStatus(db, 'bulk-0@school.org');
+    expect(adminDocGet).toHaveBeenCalledTimes(500);
+
+    // Now push 10 brand-new entries past the cap. Under FIFO bulk-0 would
+    // be evicted first; under LRU bulk-1 is now the oldest and gets dropped.
+    for (let i = 500; i < 510; i++) {
+      await __getCachedAdminStatus(db, `bulk-${i}@school.org`);
+    }
+    expect(adminDocGet).toHaveBeenCalledTimes(510);
+
+    // bulk-0 must still be cached (the LRU promotion saved it).
+    await __getCachedAdminStatus(db, 'bulk-0@school.org');
+    expect(adminDocGet).toHaveBeenCalledTimes(510);
+
+    // bulk-1 — never re-touched, oldest by recency — should now be evicted.
+    await __getCachedAdminStatus(db, 'bulk-1@school.org');
     expect(adminDocGet).toHaveBeenCalledTimes(511);
   });
 

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -10,6 +10,7 @@ import { randomUUID } from 'node:crypto';
 import { OAuth2Client } from 'google-auth-library';
 import { sanitizePrompt } from './sanitize';
 import { parseGeminiJson } from './parseGeminiJson';
+import { BoundedLruMap } from './utils/boundedLruMap';
 import { readAnalyticsSnapshot } from './adminAnalyticsSnapshot';
 
 // Phase 4 — organization invitations + membership write-through.
@@ -162,17 +163,20 @@ interface AdminStatusCacheEntry {
   isAdmin: boolean;
   cachedAt: number;
 }
-const cachedAdminStatus = new Map<string, AdminStatusCacheEntry>();
 
 // Bound on `cachedAdminStatus` size. A warm Cloud Functions instance that
 // sees many distinct callers across its lifetime would otherwise grow this
 // Map unboundedly. At school-district scale this is firmly in "won't
 // matter" territory (low thousands of admins org-wide), but a hard cap
 // closes the long-tail memory growth path that two independent reviewers
-// flagged on PR #1590. JS Maps preserve insertion order, so deleting the
-// first key is FIFO eviction — close enough to LRU for a small, mostly
-// read-hot cache.
+// flagged on PR #1590. `BoundedLruMap` promotes on read so frequently-hit
+// keys survive eviction pressure from one-off callers — this becomes
+// load-bearing once the same pattern is reused on a higher-cardinality key
+// space (e.g. the student-pseudonym path).
 const ADMIN_STATUS_CACHE_MAX = 500;
+const cachedAdminStatus = new BoundedLruMap<string, AdminStatusCacheEntry>(
+  ADMIN_STATUS_CACHE_MAX
+);
 
 /**
  * Test-only: reset the module-scope read caches so tests can observe a
@@ -259,14 +263,6 @@ async function getCachedAdminStatus(
   }
   const doc = await db.collection('admins').doc(emailLower).get();
   const isAdmin = doc.exists;
-  // Evict the oldest entry if we're at the cap. Map iteration order is
-  // insertion order, so `keys().next().value` gives the oldest key —
-  // FIFO eviction. Sufficient for a cache that's expected to be small
-  // (school district size) and dominated by hot keys.
-  if (cachedAdminStatus.size >= ADMIN_STATUS_CACHE_MAX) {
-    const oldest = cachedAdminStatus.keys().next().value;
-    if (oldest !== undefined) cachedAdminStatus.delete(oldest);
-  }
   cachedAdminStatus.set(emailLower, { isAdmin, cachedAt: now });
   return isAdmin;
 }

--- a/functions/src/utils/boundedLruMap.test.ts
+++ b/functions/src/utils/boundedLruMap.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+import { BoundedLruMap } from './boundedLruMap';
+
+describe('BoundedLruMap', () => {
+  it('rejects non-positive or non-integer maxSize', () => {
+    expect(() => new BoundedLruMap(0)).toThrow();
+    expect(() => new BoundedLruMap(-1)).toThrow();
+    expect(() => new BoundedLruMap(1.5)).toThrow();
+  });
+
+  it('returns undefined for missing keys', () => {
+    const cache = new BoundedLruMap<string, number>(3);
+    expect(cache.get('missing')).toBeUndefined();
+  });
+
+  it('promotes on read so an old entry survives eviction', () => {
+    const cache = new BoundedLruMap<string, number>(3);
+    cache.set('a', 1);
+    cache.set('b', 2);
+    cache.set('c', 3);
+    // Touch 'a' — promotes it to most-recently-used.
+    expect(cache.get('a')).toBe(1);
+    // Adding a fourth key now evicts the new oldest, 'b'.
+    cache.set('d', 4);
+    expect(cache.get('a')).toBe(1);
+    expect(cache.get('b')).toBeUndefined();
+    expect(cache.get('c')).toBe(3);
+    expect(cache.get('d')).toBe(4);
+  });
+
+  it('treats an explicit undefined value as a cache hit and promotes it', () => {
+    // Guards against the FIFO-vs-LRU regression for generic V types: a
+    // `get` for a key whose value is `undefined` must still promote the
+    // entry, not behave as a cache miss.
+    const cache = new BoundedLruMap<string, number | undefined>(3);
+    cache.set('a', undefined);
+    cache.set('b', 2);
+    cache.set('c', 3);
+    // Touch 'a' (value === undefined). Should promote it.
+    expect(cache.get('a')).toBeUndefined();
+    // Adding a fourth key now evicts 'b' (the new oldest) rather than 'a'.
+    cache.set('d', 4);
+    expect(cache.size).toBe(3);
+    expect(cache.get('b')).toBeUndefined();
+    expect(cache.get('c')).toBe(3);
+    expect(cache.get('d')).toBe(4);
+  });
+
+  it('evicts the oldest entry even when its key is undefined', () => {
+    // Guards eviction logic for `K = undefined` legal keys: the previous
+    // implementation skipped the delete branch if `oldest === undefined`,
+    // letting the map grow past `maxSize`.
+    const cache = new BoundedLruMap<string | undefined, number>(2);
+    cache.set(undefined, 1);
+    cache.set('b', 2);
+    cache.set('c', 3); // should evict the `undefined` key
+    expect(cache.size).toBe(2);
+    expect(cache.get(undefined)).toBeUndefined();
+    expect(cache.get('b')).toBe(2);
+    expect(cache.get('c')).toBe(3);
+  });
+
+  it('delete and clear behave as expected', () => {
+    const cache = new BoundedLruMap<string, number>(3);
+    cache.set('a', 1);
+    cache.set('b', 2);
+    expect(cache.delete('a')).toBe(true);
+    expect(cache.delete('a')).toBe(false);
+    expect(cache.size).toBe(1);
+    cache.clear();
+    expect(cache.size).toBe(0);
+  });
+});

--- a/functions/src/utils/boundedLruMap.ts
+++ b/functions/src/utils/boundedLruMap.ts
@@ -22,13 +22,10 @@ export class BoundedLruMap<K, V> {
   }
 
   get(key: K): V | undefined {
-    const value = this.map.get(key);
-    if (value === undefined) {
-      // `has` would be more correct for `V = undefined`, but the extra
-      // lookup isn't worth it for the cache values we actually store
-      // (objects, primitives that callers wrap in objects).
+    if (!this.map.has(key)) {
       return undefined;
     }
+    const value = this.map.get(key) as V;
     // Promote to most-recently-used by re-inserting at the tail.
     this.map.delete(key);
     this.map.set(key, value);
@@ -39,8 +36,11 @@ export class BoundedLruMap<K, V> {
     if (this.map.has(key)) {
       this.map.delete(key);
     } else if (this.map.size >= this.maxSize) {
-      const oldest = this.map.keys().next().value;
-      if (oldest !== undefined) this.map.delete(oldest);
+      // Use the iterator's `done` sentinel rather than checking the key
+      // for `undefined`, so eviction still fires when `K = undefined` is
+      // a legal key in the map.
+      const { value: oldest, done } = this.map.keys().next();
+      if (!done) this.map.delete(oldest);
     }
     this.map.set(key, value);
   }

--- a/functions/src/utils/boundedLruMap.ts
+++ b/functions/src/utils/boundedLruMap.ts
@@ -1,0 +1,59 @@
+/**
+ * Fixed-capacity LRU cache backed by a `Map`.
+ *
+ * `Map` preserves insertion order, so the least-recently-used entry is always
+ * the first key. On a hit, the entry is deleted and re-inserted so it moves
+ * to the most-recently-used position. On insertion at capacity, the first
+ * key (oldest by recency) is evicted.
+ *
+ * Intended for small, mostly read-hot caches inside a single warm Cloud
+ * Functions instance — admin-status lookups, per-instance pseudonym keys,
+ * etc. Not safe for concurrent mutation across async boundaries; callers
+ * that interleave async reads must accept that a stale entry may briefly
+ * coexist with an in-flight refresh.
+ */
+export class BoundedLruMap<K, V> {
+  private readonly map = new Map<K, V>();
+
+  constructor(private readonly maxSize: number) {
+    if (!Number.isInteger(maxSize) || maxSize <= 0) {
+      throw new Error('BoundedLruMap maxSize must be a positive integer');
+    }
+  }
+
+  get(key: K): V | undefined {
+    const value = this.map.get(key);
+    if (value === undefined) {
+      // `has` would be more correct for `V = undefined`, but the extra
+      // lookup isn't worth it for the cache values we actually store
+      // (objects, primitives that callers wrap in objects).
+      return undefined;
+    }
+    // Promote to most-recently-used by re-inserting at the tail.
+    this.map.delete(key);
+    this.map.set(key, value);
+    return value;
+  }
+
+  set(key: K, value: V): void {
+    if (this.map.has(key)) {
+      this.map.delete(key);
+    } else if (this.map.size >= this.maxSize) {
+      const oldest = this.map.keys().next().value;
+      if (oldest !== undefined) this.map.delete(oldest);
+    }
+    this.map.set(key, value);
+  }
+
+  delete(key: K): boolean {
+    return this.map.delete(key);
+  }
+
+  clear(): void {
+    this.map.clear();
+  }
+
+  get size(): number {
+    return this.map.size;
+  }
+}


### PR DESCRIPTION
## Summary

- Switches `cachedAdminStatus` (in `functions/src/index.ts`) from FIFO to LRU eviction, so a frequently-accessed admin written early no longer gets evicted by one-off lookups.
- Extracts the pattern into a small `BoundedLruMap` utility at `functions/src/utils/boundedLruMap.ts` for the next caller (likely the student-pseudonym path, which is higher-cardinality and where FIFO would actively bite).
- Adds a regression test pinning LRU promotion: a key re-touched after the cache fills survives subsequent eviction pressure, while an untouched neighbor gets evicted instead.

Flagged by the pr-review-toolkit:code-reviewer on PR #1597 as LOW priority / acceptable-as-is at current school-district scale (~500 admins). This is the documented "chore when convenient" follow-up.

## Test plan

- [x] `pnpm exec vitest run` in `functions/` — 244/244 pass, including the new LRU promotion test and the updated eviction test.
- [x] `pnpm run validate` at the repo root — type-check (root + functions), lint (0 errors, 0 warnings), format-check, root tests (2370 pass), functions tests (244 pass).
- [ ] No runtime behavior change at current scale — admin cache hit rate is the only thing affected, and it should be marginally better. Verify in dev-preview if desired.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jyi4UKpoZYVJc2BT79igCS)_