### PR TITLE
refactor(video-activity): move question list into right-pane pill navigator

### DIFF
--- a/components/common/SortableList.tsx
+++ b/components/common/SortableList.tsx
@@ -12,7 +12,9 @@ import { restrictToParentElement } from '@dnd-kit/modifiers';
 import {
   arrayMove,
   SortableContext,
+  SortingStrategy,
   sortableKeyboardCoordinates,
+  rectSortingStrategy,
   verticalListSortingStrategy,
   useSortable,
 } from '@dnd-kit/sortable';
@@ -52,7 +54,18 @@ interface SortableListProps<T> {
   ) => React.ReactNode;
   /** Optional className for the outer list container. */
   className?: string;
+  /**
+   * Layout strategy passed to dnd-kit's `SortableContext`. Defaults to
+   * `'vertical'`. Use `'grid'` for wrap-flow / pill-strip layouts so
+   * hit-testing computes neighbor zones in 2D instead of along the Y axis.
+   */
+  layout?: 'vertical' | 'grid';
 }
+
+const STRATEGY_BY_LAYOUT: Record<'vertical' | 'grid', SortingStrategy> = {
+  vertical: verticalListSortingStrategy,
+  grid: rectSortingStrategy,
+};
 
 interface SortableRowProps {
   id: string;
@@ -108,6 +121,7 @@ export function SortableList<T>({
   onReorder,
   renderItem,
   className,
+  layout = 'vertical',
 }: SortableListProps<T>): React.ReactElement {
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
@@ -132,7 +146,7 @@ export function SortableList<T>({
       modifiers={[restrictToParentElement]}
       onDragEnd={handleDragEnd}
     >
-      <SortableContext items={ids} strategy={verticalListSortingStrategy}>
+      <SortableContext items={ids} strategy={STRATEGY_BY_LAYOUT[layout]}>
         <div className={className}>
           {items.map((item) => {
             const id = getId(item);

--- a/components/widgets/VideoActivityWidget/components/VideoActivityEditor.tsx
+++ b/components/widgets/VideoActivityWidget/components/VideoActivityEditor.tsx
@@ -27,7 +27,9 @@ import {
   type VideoActivityEditorController,
 } from './useVideoActivityEditorState';
 
-const TYPE_BADGE: Record<string, { label: string; className: string }> = {
+type QuestionType = NonNullable<VideoActivityQuestion['type']>;
+
+const TYPE_BADGE: Record<QuestionType, { label: string; className: string }> = {
   MC: { label: 'MC', className: 'bg-blue-100 text-blue-700' },
   FIB: { label: 'FIB', className: 'bg-amber-100 text-amber-800' },
   MA: { label: 'MA', className: 'bg-emerald-100 text-emerald-700' },
@@ -158,82 +160,94 @@ const QuestionNavigator: React.FC<QuestionNavigatorProps> = ({
           Drag to reorder · click to edit
         </span>
       </div>
-      <SortableList
-        items={questions}
-        getId={(q) => q.id}
-        onReorder={onReorder}
-        renderItem={(q, handle) => {
-          const idx = questions.findIndex((x) => x.id === q.id);
-          const isSelected = q.id === selectedId;
-          const showReorderHint = q.id === reorderHintFor;
-          const type = q.type ?? 'MC';
-          const badge = TYPE_BADGE[type];
-          return (
-            <div
-              {...handle.attributes}
-              onPointerDown={
-                handle.listeners?.onPointerDown as
-                  | React.PointerEventHandler<HTMLDivElement>
-                  | undefined
-              }
-              onClick={() => onSelect(q.id)}
-              role="button"
-              tabIndex={0}
-              aria-pressed={isSelected}
-              aria-label={`Question ${idx + 1} at ${secondsToMmSs(q.timestamp)}${q.text ? `: ${q.text}` : ''}`}
-              title={q.text?.trim() ? q.text : `Question ${idx + 1}`}
-              className={`group shrink-0 cursor-grab active:cursor-grabbing touch-none flex items-center gap-1.5 pl-2 pr-1 py-1 rounded-md text-xs font-bold border transition-colors ${
-                isSelected
-                  ? 'bg-brand-blue-primary text-white border-brand-blue-primary'
-                  : 'bg-white border-slate-300 text-slate-700 hover:border-slate-400'
-              }`}
-            >
-              <span className="font-mono">{idx + 1}</span>
-              <span
-                className={`flex items-center gap-0.5 font-mono rounded px-1 py-0.5 text-xxs ${
+      <div className="max-h-[7.5rem] overflow-y-auto custom-scrollbar -mx-1 px-1">
+        <SortableList
+          items={questions}
+          getId={(q) => q.id}
+          onReorder={onReorder}
+          layout="grid"
+          renderItem={(q, handle) => {
+            const idx = questions.findIndex((x) => x.id === q.id);
+            const isSelected = q.id === selectedId;
+            const showReorderHint = q.id === reorderHintFor;
+            const type = (q.type ?? 'MC') as QuestionType;
+            const badge = TYPE_BADGE[type];
+            return (
+              <div
+                className={`group inline-flex shrink-0 items-stretch rounded-md border transition-colors ${
                   isSelected
-                    ? 'bg-brand-blue-dark text-white/90'
-                    : 'bg-slate-100 text-slate-600'
+                    ? 'bg-brand-blue-primary border-brand-blue-primary'
+                    : 'bg-white border-slate-300 hover:border-slate-400'
                 }`}
               >
-                <Clock className="w-3 h-3" />
-                {secondsToMmSs(q.timestamp)}
-              </span>
-              <span
-                className={`px-1 py-0.5 rounded text-xxs uppercase tracking-wider ${
-                  isSelected
-                    ? 'bg-brand-blue-dark text-white/90'
-                    : badge.className
-                }`}
-              >
-                {badge.label}
-              </span>
-              {showReorderHint && (
-                <span className="text-xxs font-bold text-amber-700 bg-amber-50 border border-amber-200 rounded px-1 py-0.5 animate-in fade-in duration-200">
-                  Reordered
-                </span>
-              )}
-              <button
-                type="button"
-                onPointerDown={(e) => e.stopPropagation()}
-                onClick={(e) => {
-                  e.stopPropagation();
-                  onDelete(q.id);
-                }}
-                aria-label={`Delete question ${idx + 1}`}
-                className={`rounded p-0.5 transition-colors ${
-                  isSelected
-                    ? 'text-white/70 hover:text-white hover:bg-white/15'
-                    : 'text-slate-300 hover:text-red-500 hover:bg-red-50 opacity-0 group-hover:opacity-100'
-                }`}
-              >
-                <X className="w-3.5 h-3.5" />
-              </button>
-            </div>
-          );
-        }}
-        className="flex flex-wrap gap-1.5"
-      />
+                <button
+                  type="button"
+                  {...handle.attributes}
+                  onPointerDown={
+                    handle.listeners?.onPointerDown as
+                      | React.PointerEventHandler<HTMLButtonElement>
+                      | undefined
+                  }
+                  onClick={() => onSelect(q.id)}
+                  aria-current={isSelected ? 'true' : undefined}
+                  aria-label={`Question ${idx + 1} at ${secondsToMmSs(q.timestamp)}${q.text ? `: ${q.text}` : ''}`}
+                  title={q.text?.trim() ? q.text : `Question ${idx + 1}`}
+                  className={`cursor-grab active:cursor-grabbing touch-none flex items-center gap-1.5 pl-2 pr-1.5 py-1 rounded-l-md text-xs font-bold focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-1 focus-visible:ring-brand-blue-primary ${
+                    isSelected ? 'text-white' : 'text-slate-700'
+                  }`}
+                >
+                  <span className="font-mono min-w-[1.25ch] text-center">
+                    {idx + 1}
+                  </span>
+                  <span
+                    className={`flex items-center gap-0.5 font-mono rounded px-1 py-0.5 text-xxs ${
+                      isSelected
+                        ? 'bg-brand-blue-dark text-white/90'
+                        : 'bg-slate-100 text-slate-600'
+                    }`}
+                  >
+                    <Clock className="w-3 h-3" />
+                    {secondsToMmSs(q.timestamp)}
+                  </span>
+                  <span
+                    className={`px-1 py-0.5 rounded text-xxs uppercase tracking-wider ${
+                      isSelected
+                        ? 'bg-brand-blue-dark text-white/90'
+                        : badge.className
+                    }`}
+                  >
+                    {badge.label}
+                  </span>
+                  {showReorderHint && (
+                    <span
+                      className={`text-xxs font-bold rounded px-1 py-0.5 animate-in fade-in duration-200 ${
+                        isSelected
+                          ? 'bg-amber-300 text-amber-900'
+                          : 'bg-amber-50 border border-amber-200 text-amber-700'
+                      }`}
+                    >
+                      Reordered
+                    </span>
+                  )}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => onDelete(q.id)}
+                  aria-label={`Delete question ${idx + 1}`}
+                  className={`flex items-center rounded-r-md pl-1 pr-1.5 transition-opacity focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-1 focus-visible:ring-brand-red-primary ${
+                    isSelected
+                      ? 'text-white/70 hover:text-white hover:bg-white/15'
+                      : 'text-slate-300 hover:text-red-500 hover:bg-red-50 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 [@media(hover:none)]:opacity-100'
+                  }`}
+                >
+                  <X className="w-3.5 h-3.5" />
+                </button>
+              </div>
+            );
+          }}
+          className="flex flex-wrap gap-1.5"
+        />
+      </div>
     </div>
   );
 };
@@ -286,7 +300,7 @@ export const VideoActivityEditorDetailPane: React.FC<PaneProps> = ({
           </h4>
           <p className="text-sm max-w-xs">
             {questions.length === 0
-              ? 'Use "+ Add at [time]" below the timeline to drop a question at the current playhead.'
+              ? 'Click "Add at MM:SS" under the timeline to drop a question at the current playhead — or use Draft with AI in the footer to generate a set.'
               : 'Click a pill above (or a green marker on the timeline) to edit it here.'}
           </p>
         </div>

--- a/components/widgets/VideoActivityWidget/components/VideoActivityEditor.tsx
+++ b/components/widgets/VideoActivityWidget/components/VideoActivityEditor.tsx
@@ -11,11 +11,8 @@ import React, { useState } from 'react';
 import {
   AlertCircle,
   Clock,
-  GripVertical,
   MousePointerClick,
-  Plus,
-  Sparkles,
-  Trash2,
+  X,
   Youtube,
 } from 'lucide-react';
 import { LibraryFolder, VideoActivityQuestion } from '@/types';
@@ -30,10 +27,14 @@ import {
   type VideoActivityEditorController,
 } from './useVideoActivityEditorState';
 
+const TYPE_BADGE: Record<string, { label: string; className: string }> = {
+  MC: { label: 'MC', className: 'bg-blue-100 text-blue-700' },
+  FIB: { label: 'FIB', className: 'bg-amber-100 text-amber-800' },
+  MA: { label: 'MA', className: 'bg-emerald-100 text-emerald-700' },
+};
+
 interface PaneProps {
   state: VideoActivityEditorController;
-  /** YouTube widget-level AI toggle (admin override applies elsewhere). */
-  canUseAi: boolean;
   folders?: LibraryFolder[];
   folderId?: string | null;
   onFolderChange?: (folderId: string | null) => void;
@@ -43,7 +44,6 @@ interface PaneProps {
 
 export const VideoActivityEditorContextPane: React.FC<PaneProps> = ({
   state,
-  canUseAi,
   folders,
   folderId,
   onFolderChange,
@@ -57,14 +57,8 @@ export const VideoActivityEditorContextPane: React.FC<PaneProps> = ({
     selectedId,
     setSelectedId,
     addQuestionAtTime,
-    addQuestion,
-    deleteQuestion,
-    reorderQuestions,
-    reorderHintFor,
     updateQuestion,
     error,
-    showAiPrompt,
-    setShowAiPrompt,
   } = state;
 
   // Memo via inline parse — Timeline only rebuilds when the resolved id changes.
@@ -108,8 +102,8 @@ export const VideoActivityEditorContextPane: React.FC<PaneProps> = ({
         )}
       </div>
 
-      {/* Timeline */}
-      <div className="px-5 pt-4 shrink-0 bg-slate-50">
+      {/* Timeline — fills remaining space, never scrolls */}
+      <div className="flex-1 min-h-0 px-5 py-4 bg-slate-50">
         {videoIdForTimeline ? (
           <Timeline
             videoId={videoIdForTimeline}
@@ -131,157 +125,115 @@ export const VideoActivityEditorContextPane: React.FC<PaneProps> = ({
           </div>
         )}
       </div>
-
-      {/* Question list */}
-      <div className="flex-1 min-h-0 overflow-y-auto custom-scrollbar bg-slate-50 px-5 pb-5 pt-4">
-        <div className="flex items-center justify-between mb-2">
-          <h4 className="text-xs font-bold uppercase tracking-wider text-slate-500">
-            Questions ({questions.length})
-          </h4>
-          <div className="flex items-center gap-2">
-            {canUseAi && (
-              <button
-                onClick={() => setShowAiPrompt(!showAiPrompt)}
-                disabled={!youtubeUrl.trim()}
-                className="flex items-center gap-1 px-2.5 py-1 bg-white hover:bg-slate-100 border border-slate-300 disabled:opacity-50 disabled:cursor-not-allowed text-slate-700 rounded-lg text-xs font-bold transition-colors"
-                title={
-                  youtubeUrl.trim()
-                    ? 'Generate questions with AI'
-                    : 'Paste a YouTube URL first'
-                }
-              >
-                <Sparkles className="w-3.5 h-3.5 text-indigo-500" />
-                Draft with AI
-              </button>
-            )}
-            <button
-              onClick={addQuestion}
-              className="flex items-center gap-1 px-2.5 py-1 bg-brand-blue-primary hover:bg-brand-blue-dark text-white rounded-lg text-xs font-bold transition-colors"
-            >
-              <Plus className="w-3.5 h-3.5" />
-              Add
-            </button>
-          </div>
-        </div>
-
-        {questions.length === 0 ? (
-          <div className="text-center text-slate-500 text-sm py-8 border-2 border-dashed border-slate-300 rounded-lg bg-white">
-            No questions yet. Click <strong>Add</strong> or use the timeline
-            above.
-          </div>
-        ) : (
-          <SortableList
-            items={questions}
-            getId={(q) => q.id}
-            onReorder={reorderQuestions}
-            renderItem={(q, handle) => (
-              <QuestionRow
-                question={q}
-                index={questions.findIndex((x) => x.id === q.id)}
-                isSelected={q.id === selectedId}
-                showReorderHint={q.id === reorderHintFor}
-                onSelect={() => setSelectedId(q.id)}
-                onDelete={() => deleteQuestion(q.id)}
-                dragHandleAttributes={handle.attributes}
-                dragHandleListeners={handle.listeners}
-              />
-            )}
-            className="space-y-1.5"
-          />
-        )}
-      </div>
     </div>
   );
 };
 
-// ─── Question row (inside SortableList) ──────────────────────────────────────
+// ─── Question navigator (sortable pill strip) ────────────────────────────────
 
-interface QuestionRowProps {
-  question: VideoActivityQuestion;
-  index: number;
-  isSelected: boolean;
-  showReorderHint: boolean;
-  onSelect: () => void;
-  onDelete: () => void;
-  dragHandleAttributes: React.HTMLAttributes<HTMLElement>;
-  dragHandleListeners: Record<string, (event: Event) => void> | undefined;
+interface QuestionNavigatorProps {
+  questions: VideoActivityQuestion[];
+  selectedId: string | null;
+  reorderHintFor: string | null;
+  onSelect: (id: string) => void;
+  onReorder: (next: VideoActivityQuestion[]) => void;
+  onDelete: (id: string) => void;
 }
 
-const TYPE_BADGE: Record<string, { label: string; className: string }> = {
-  MC: { label: 'MC', className: 'bg-blue-100 text-blue-700' },
-  FIB: { label: 'FIB', className: 'bg-amber-100 text-amber-800' },
-  MA: { label: 'MA', className: 'bg-emerald-100 text-emerald-700' },
-};
-
-const QuestionRow: React.FC<QuestionRowProps> = ({
-  question,
-  index,
-  isSelected,
-  showReorderHint,
+const QuestionNavigator: React.FC<QuestionNavigatorProps> = ({
+  questions,
+  selectedId,
+  reorderHintFor,
   onSelect,
+  onReorder,
   onDelete,
-  dragHandleAttributes,
-  dragHandleListeners,
 }) => {
-  const type = question.type ?? 'MC';
-  const badge = TYPE_BADGE[type];
-
   return (
-    <div
-      onClick={onSelect}
-      className={`group flex items-center gap-2 px-2.5 py-2 rounded-lg border bg-white cursor-pointer transition-all ${
-        isSelected
-          ? 'border-brand-blue-primary ring-2 ring-brand-blue-primary/15'
-          : 'border-slate-200 hover:border-slate-300'
-      }`}
-    >
-      <button
-        type="button"
-        {...dragHandleAttributes}
-        onPointerDown={
-          dragHandleListeners?.onPointerDown as
-            | React.PointerEventHandler<HTMLButtonElement>
-            | undefined
-        }
-        onClick={(e) => e.stopPropagation()}
-        aria-label="Drag to reorder"
-        className="text-slate-300 hover:text-slate-500 cursor-grab active:cursor-grabbing touch-none p-0.5"
-      >
-        <GripVertical className="w-4 h-4" />
-      </button>
-      <span className="text-slate-400 font-mono font-bold text-xs w-5 shrink-0 text-center">
-        {index + 1}
-      </span>
-      <span className="flex items-center gap-1 bg-slate-100 text-slate-600 font-bold rounded-md shrink-0 px-1.5 py-0.5 text-xxs uppercase tracking-wider">
-        <Clock className="w-3 h-3" />
-        {secondsToMmSs(question.timestamp)}
-      </span>
-      <span
-        className={`shrink-0 px-1.5 py-0.5 rounded text-xxs font-bold uppercase tracking-wider ${badge.className}`}
-      >
-        {badge.label}
-      </span>
-      <span className="flex-1 text-sm text-slate-700 truncate">
-        {question.text || (
-          <span className="italic text-slate-400">Untitled question</span>
-        )}
-      </span>
-      {showReorderHint && (
-        <span className="shrink-0 text-xxs font-bold text-amber-700 bg-amber-50 border border-amber-200 rounded px-1.5 py-0.5 animate-in fade-in duration-200">
-          Reordered
+    <div className="px-4 py-2.5 border-b border-slate-200 bg-white shrink-0">
+      <div className="flex items-center justify-between mb-1.5">
+        <span className="text-xxs font-bold uppercase tracking-wider text-slate-500">
+          Questions ({questions.length})
         </span>
-      )}
-      <button
-        type="button"
-        onClick={(e) => {
-          e.stopPropagation();
-          onDelete();
+        <span className="text-xxs text-slate-400">
+          Drag to reorder · click to edit
+        </span>
+      </div>
+      <SortableList
+        items={questions}
+        getId={(q) => q.id}
+        onReorder={onReorder}
+        renderItem={(q, handle) => {
+          const idx = questions.findIndex((x) => x.id === q.id);
+          const isSelected = q.id === selectedId;
+          const showReorderHint = q.id === reorderHintFor;
+          const type = q.type ?? 'MC';
+          const badge = TYPE_BADGE[type];
+          return (
+            <div
+              {...handle.attributes}
+              onPointerDown={
+                handle.listeners?.onPointerDown as
+                  | React.PointerEventHandler<HTMLDivElement>
+                  | undefined
+              }
+              onClick={() => onSelect(q.id)}
+              role="button"
+              tabIndex={0}
+              aria-pressed={isSelected}
+              aria-label={`Question ${idx + 1} at ${secondsToMmSs(q.timestamp)}${q.text ? `: ${q.text}` : ''}`}
+              title={q.text?.trim() ? q.text : `Question ${idx + 1}`}
+              className={`group shrink-0 cursor-grab active:cursor-grabbing touch-none flex items-center gap-1.5 pl-2 pr-1 py-1 rounded-md text-xs font-bold border transition-colors ${
+                isSelected
+                  ? 'bg-brand-blue-primary text-white border-brand-blue-primary'
+                  : 'bg-white border-slate-300 text-slate-700 hover:border-slate-400'
+              }`}
+            >
+              <span className="font-mono">{idx + 1}</span>
+              <span
+                className={`flex items-center gap-0.5 font-mono rounded px-1 py-0.5 text-xxs ${
+                  isSelected
+                    ? 'bg-brand-blue-dark text-white/90'
+                    : 'bg-slate-100 text-slate-600'
+                }`}
+              >
+                <Clock className="w-3 h-3" />
+                {secondsToMmSs(q.timestamp)}
+              </span>
+              <span
+                className={`px-1 py-0.5 rounded text-xxs uppercase tracking-wider ${
+                  isSelected
+                    ? 'bg-brand-blue-dark text-white/90'
+                    : badge.className
+                }`}
+              >
+                {badge.label}
+              </span>
+              {showReorderHint && (
+                <span className="text-xxs font-bold text-amber-700 bg-amber-50 border border-amber-200 rounded px-1 py-0.5 animate-in fade-in duration-200">
+                  Reordered
+                </span>
+              )}
+              <button
+                type="button"
+                onPointerDown={(e) => e.stopPropagation()}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onDelete(q.id);
+                }}
+                aria-label={`Delete question ${idx + 1}`}
+                className={`rounded p-0.5 transition-colors ${
+                  isSelected
+                    ? 'text-white/70 hover:text-white hover:bg-white/15'
+                    : 'text-slate-300 hover:text-red-500 hover:bg-red-50 opacity-0 group-hover:opacity-100'
+                }`}
+              >
+                <X className="w-3.5 h-3.5" />
+              </button>
+            </div>
+          );
         }}
-        aria-label="Delete question"
-        className="text-slate-300 hover:text-red-500 hover:bg-red-50 rounded p-1 transition-colors opacity-0 group-hover:opacity-100"
-      >
-        <Trash2 className="w-3.5 h-3.5" />
-      </button>
+        className="flex flex-wrap gap-1.5"
+      />
     </div>
   );
 };
@@ -300,24 +252,44 @@ export const VideoActivityEditorDetailPane: React.FC<PaneProps> = ({
     selectedQuestion,
     selectedIndex,
     questions,
+    selectedId,
+    setSelectedId,
+    reorderQuestions,
+    reorderHintFor,
+    deleteQuestion,
     timestampInputs,
     setTimestampInput,
     updateQuestion,
     updateIncorrect,
   } = state;
 
+  const navigator =
+    questions.length > 0 ? (
+      <QuestionNavigator
+        questions={questions}
+        selectedId={selectedId}
+        reorderHintFor={reorderHintFor}
+        onSelect={setSelectedId}
+        onReorder={reorderQuestions}
+        onDelete={deleteQuestion}
+      />
+    ) : null;
+
   if (!selectedQuestion) {
     return (
-      <div className="flex flex-col h-full items-center justify-center text-center px-8 py-12 text-slate-500">
-        <MousePointerClick className="w-10 h-10 mb-3 text-slate-400" />
-        <h4 className="text-base font-bold text-slate-700 mb-1">
-          {questions.length === 0 ? 'No questions yet' : 'Pick a question'}
-        </h4>
-        <p className="text-sm max-w-xs">
-          {questions.length === 0
-            ? 'Add a question from the timeline or the questions list to start editing.'
-            : 'Click a row in the questions list (or a green marker on the timeline) to edit it here.'}
-        </p>
+      <div className="flex flex-col h-full">
+        {navigator}
+        <div className="flex-1 flex flex-col items-center justify-center text-center px-8 py-12 text-slate-500">
+          <MousePointerClick className="w-10 h-10 mb-3 text-slate-400" />
+          <h4 className="text-base font-bold text-slate-700 mb-1">
+            {questions.length === 0 ? 'No questions yet' : 'Pick a question'}
+          </h4>
+          <p className="text-sm max-w-xs">
+            {questions.length === 0
+              ? 'Use "+ Add at [time]" below the timeline to drop a question at the current playhead.'
+              : 'Click a pill above (or a green marker on the timeline) to edit it here.'}
+          </p>
+        </div>
       </div>
     );
   }
@@ -328,7 +300,8 @@ export const VideoActivityEditorDetailPane: React.FC<PaneProps> = ({
 
   return (
     <div className="flex flex-col h-full">
-      <div className="px-5 py-4 border-b border-slate-200 bg-white sticky top-0 z-10">
+      {navigator}
+      <div className="px-5 py-4 border-b border-slate-200 bg-white shrink-0">
         <div className="text-xs uppercase tracking-wider text-slate-500 font-bold">
           Question {selectedIndex + 1} of {questions.length}
           <span className="mx-1.5">·</span>

--- a/components/widgets/VideoActivityWidget/components/VideoActivityEditorModal.tsx
+++ b/components/widgets/VideoActivityWidget/components/VideoActivityEditorModal.tsx
@@ -226,7 +226,7 @@ export const VideoActivityEditorModal: React.FC<
         ) : null
       }
       contextRatio={56}
-      contextPaneClassName="bg-slate-50 border-r border-slate-200 overflow-hidden"
+      contextPaneClassName="bg-slate-50 border-r border-slate-200 !overflow-hidden"
       contextPane={
         <VideoActivityEditorContextPane
           state={editorState}

--- a/components/widgets/VideoActivityWidget/components/VideoActivityEditorModal.tsx
+++ b/components/widgets/VideoActivityWidget/components/VideoActivityEditorModal.tsx
@@ -226,21 +226,16 @@ export const VideoActivityEditorModal: React.FC<
         ) : null
       }
       contextRatio={56}
+      contextPaneClassName="bg-slate-50 border-r border-slate-200 overflow-hidden"
       contextPane={
         <VideoActivityEditorContextPane
           state={editorState}
-          canUseAi={canUseAi}
           folders={folders}
           folderId={folderId}
           onFolderChange={onFolderChange}
         />
       }
-      detailPane={
-        <VideoActivityEditorDetailPane
-          state={editorState}
-          canUseAi={canUseAi}
-        />
-      }
+      detailPane={<VideoActivityEditorDetailPane state={editorState} />}
       overlay={<VideoActivityAiOverlay state={editorState} />}
     />
   );

--- a/tests/components/common/SortableList.test.tsx
+++ b/tests/components/common/SortableList.test.tsx
@@ -38,6 +38,7 @@ vi.mock('@dnd-kit/sortable', () => ({
   ),
   sortableKeyboardCoordinates: vi.fn(),
   verticalListSortingStrategy: vi.fn(),
+  rectSortingStrategy: vi.fn(),
   arrayMove: vi.fn(<T,>(arr: T[], from: number, to: number) => {
     const result = [...arr];
     result.splice(to, 0, result.splice(from, 1)[0]);


### PR DESCRIPTION
## Summary

- Removes the redundant Questions section from the bottom of the Video Activity editor's left pane (its "Draft with AI" duplicated the footer button and its "+ Add" duplicated the timeline's "+ Add at [time]").
- Anchors the video + timeline so they never scroll: the left pane is now `overflow-hidden` and the Timeline fills remaining space.
- Moves question selection / reordering / deletion into a sortable pill navigator at the top of the right (detail) pane — mirroring the GuidedLearning `StepNavigator` pattern. Each pill shows index, timestamp chip, type badge, and a delete ×.
- Keeps "Draft with AI" as the single footer entry point; the timeline's "+ Add at [time]" stays as the single add affordance.

## Test plan

- [ ] Open the Video Activity editor and confirm the left pane shows only title / URL / folder / video + timeline (no list section below).
- [ ] Confirm the left pane does not scroll — video + timeline stay anchored regardless of optional fields.
- [ ] Paste a YouTube URL, click "+ Add at [MM:SS]" several times → pills appear at the top of the right pane.
- [ ] Click a pill → detail editor loads that question; matching timeline marker highlights.
- [ ] Drag pills to reorder → timestamps re-sort as expected; "Reordered" hint flashes briefly.
- [ ] Hover/select a pill → delete × appears; click it removes the question and its timeline marker.
- [ ] Click "Draft with AI" in the footer → AI overlay opens.
- [ ] `pnpm run type-check`, `pnpm run lint`, `pnpm run format:check`, and component tests all pass.

https://claude.ai/code/session_01DQmWjrFQG8iB4AuVo4sj1Q

---
_Generated by [Claude Code](https://claude.ai/code/session_01DQmWjrFQG8iB4AuVo4sj1Q)_