### PR TITLE
Address PR #1602 reviewer feedback

### DIFF
--- a/components/plc/PlcNewAssignmentSharingSlot.tsx
+++ b/components/plc/PlcNewAssignmentSharingSlot.tsx
@@ -158,7 +158,10 @@ export const PlcNewAssignmentSharingSlot: React.FC<
               type="text"
               value={plcSheetUrl}
               onChange={(e) => onPlcSheetUrlChange(e.target.value)}
-              placeholder="https://docs.google.com/spreadsheets/d/..."
+              placeholder={t(
+                'plcDashboard.newAssignment.sharing.sheetUrlPlaceholder',
+                { defaultValue: 'https://docs.google.com/spreadsheets/d/...' }
+              )}
               className="w-full px-3 py-2 bg-white border border-slate-200 rounded-lg text-slate-800 text-sm focus:outline-none focus:ring-2 focus:ring-brand-blue-primary"
             />
             {plcSheetUrlInvalid && (

--- a/components/plc/PlcNewQuizAssignmentModal.tsx
+++ b/components/plc/PlcNewQuizAssignmentModal.tsx
@@ -78,10 +78,7 @@ import {
   type PlcSharePickerItem,
 } from './PlcSharePickerModal';
 import { PlcNewAssignmentSharingSlot } from './PlcNewAssignmentSharingSlot';
-import {
-  formatRelativeDate,
-  isPlcSheetUrlInvalid,
-} from './newAssignmentHelpers';
+import { formatShortDate, isPlcSheetUrlInvalid } from './newAssignmentHelpers';
 
 interface PlcNewQuizAssignmentModalProps {
   plc: Plc;
@@ -216,7 +213,7 @@ export const PlcNewQuizAssignmentModal: React.FC<
         title: quiz.title,
         metaLine: t('plcDashboard.newAssignment.quiz.metaLine', {
           count: quiz.questionCount ?? 0,
-          date: formatRelativeDate(quiz.updatedAt ?? quiz.createdAt ?? 0),
+          date: formatShortDate(quiz.updatedAt ?? quiz.createdAt ?? 0),
           defaultValue: '{{count}} questions · {{date}}',
         }),
       })),

--- a/components/plc/PlcNewVideoActivityAssignmentModal.tsx
+++ b/components/plc/PlcNewVideoActivityAssignmentModal.tsx
@@ -71,10 +71,7 @@ import {
   type PlcSharePickerItem,
 } from './PlcSharePickerModal';
 import { PlcNewAssignmentSharingSlot } from './PlcNewAssignmentSharingSlot';
-import {
-  formatRelativeDate,
-  isPlcSheetUrlInvalid,
-} from './newAssignmentHelpers';
+import { formatShortDate, isPlcSheetUrlInvalid } from './newAssignmentHelpers';
 
 interface PlcNewVideoActivityAssignmentModalProps {
   plc: Plc;
@@ -174,7 +171,7 @@ export const PlcNewVideoActivityAssignmentModal: React.FC<
         title: a.title,
         metaLine: t('plcDashboard.newAssignment.video.metaLine', {
           count: a.questionCount ?? 0,
-          date: formatRelativeDate(a.updatedAt ?? a.createdAt ?? 0),
+          date: formatShortDate(a.updatedAt ?? a.createdAt ?? 0),
           defaultValue: '{{count}} questions · {{date}}',
         }),
       })),

--- a/components/plc/bodies/PlcAssignmentsBody.tsx
+++ b/components/plc/bodies/PlcAssignmentsBody.tsx
@@ -20,7 +20,7 @@
  *                     Read-only history.
  */
 
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useId, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   ClipboardList,
@@ -95,6 +95,13 @@ export const PlcAssignmentsBody: React.FC<PlcAssignmentsBodyProps> = ({
   // other so we don't fight Modal's focus-trap.
   const [newQuizOpen, setNewQuizOpen] = useState(false);
   const [newVideoOpen, setNewVideoOpen] = useState(false);
+  // Stable ids so the screen-reader-only disabled-reason text can be
+  // associated with each CTA via `aria-describedby`. Native `disabled`
+  // strips a button from the tab order, so keyboard / AT users never
+  // surface the `title` hint — we use `aria-disabled` + a click guard
+  // instead so the control stays focusable and announces its reason.
+  const quizCtaReasonId = useId();
+  const videoCtaReasonId = useId();
 
   // Library counts + Drive-connect status feed the CTA disabled state.
   // Matches the `shareCta` pattern from `PlcQuizLibraryBody` (PR #1595):
@@ -198,8 +205,15 @@ export const PlcAssignmentsBody: React.FC<PlcAssignmentsBodyProps> = ({
           <div className="flex items-center gap-2">
             <button
               type="button"
-              onClick={openQuizWizard}
-              disabled={quizCtaDisabledReason !== undefined}
+              onClick={
+                quizCtaDisabledReason !== undefined ? undefined : openQuizWizard
+              }
+              aria-disabled={quizCtaDisabledReason !== undefined}
+              aria-describedby={
+                quizCtaDisabledReason !== undefined
+                  ? quizCtaReasonId
+                  : undefined
+              }
               title={
                 quizCtaDisabledReason ??
                 t('plcDashboard.newAssignment.quiz.ctaTooltip', {
@@ -207,17 +221,31 @@ export const PlcAssignmentsBody: React.FC<PlcAssignmentsBodyProps> = ({
                     'Create a PLC quiz assignment from your personal library.',
                 })
               }
-              className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-brand-blue-primary text-white text-xs font-bold hover:bg-brand-blue-dark transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+              className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-brand-blue-primary text-white text-xs font-bold hover:bg-brand-blue-dark transition-colors aria-disabled:opacity-40 aria-disabled:cursor-not-allowed aria-disabled:hover:bg-brand-blue-primary"
             >
               <Plus className="w-3.5 h-3.5" aria-hidden="true" />
               {t('plcDashboard.newAssignment.quiz.ctaLabel', {
                 defaultValue: 'Assign Quiz',
               })}
             </button>
+            {quizCtaDisabledReason !== undefined && (
+              <span id={quizCtaReasonId} className="sr-only">
+                {quizCtaDisabledReason}
+              </span>
+            )}
             <button
               type="button"
-              onClick={openVideoWizard}
-              disabled={videoCtaDisabledReason !== undefined}
+              onClick={
+                videoCtaDisabledReason !== undefined
+                  ? undefined
+                  : openVideoWizard
+              }
+              aria-disabled={videoCtaDisabledReason !== undefined}
+              aria-describedby={
+                videoCtaDisabledReason !== undefined
+                  ? videoCtaReasonId
+                  : undefined
+              }
               title={
                 videoCtaDisabledReason ??
                 t('plcDashboard.newAssignment.video.ctaTooltip', {
@@ -225,13 +253,18 @@ export const PlcAssignmentsBody: React.FC<PlcAssignmentsBodyProps> = ({
                     'Create a PLC video activity assignment from your personal library.',
                 })
               }
-              className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-brand-blue-primary text-white text-xs font-bold hover:bg-brand-blue-dark transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+              className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-brand-blue-primary text-white text-xs font-bold hover:bg-brand-blue-dark transition-colors aria-disabled:opacity-40 aria-disabled:cursor-not-allowed aria-disabled:hover:bg-brand-blue-primary"
             >
               <PlayCircle className="w-3.5 h-3.5" aria-hidden="true" />
               {t('plcDashboard.newAssignment.video.ctaLabel', {
                 defaultValue: 'Assign Video',
               })}
             </button>
+            {videoCtaDisabledReason !== undefined && (
+              <span id={videoCtaReasonId} className="sr-only">
+                {videoCtaDisabledReason}
+              </span>
+            )}
           </div>
         )}
       </div>

--- a/components/plc/newAssignmentHelpers.ts
+++ b/components/plc/newAssignmentHelpers.ts
@@ -7,7 +7,7 @@
  */
 
 /** Locale-aware short date for the picker `metaLine`. Returns `''` on bad input. */
-export function formatRelativeDate(ms: number): string {
+export function formatShortDate(ms: number): string {
   try {
     return new Date(ms).toLocaleDateString(undefined, {
       year: 'numeric',

--- a/components/plc/tabs/PlcAssignmentsLibrarySubTab.tsx
+++ b/components/plc/tabs/PlcAssignmentsLibrarySubTab.tsx
@@ -25,7 +25,7 @@
  *     boards keep running (orphan-tolerant per Phase 3 spec).
  */
 
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useId, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   ClipboardList,
@@ -58,6 +58,7 @@ import {
 import type { SharedAssignmentImportMode } from '@/hooks/useQuizAssignments';
 import { logError } from '@/utils/logError';
 import { PlcAssignmentImportModal } from '../PlcAssignmentImportModal';
+import { formatShortDate } from '../newAssignmentHelpers';
 import { QuizAssignmentImportSetupModal } from '@/components/quiz/QuizAssignmentImportSetupModal';
 
 interface PlcAssignmentsLibrarySubTabProps {
@@ -80,13 +81,16 @@ interface PlcAssignmentsLibrarySubTabProps {
   /** Mirror of `onNewQuizAssignment` for the video-activity wizard. */
   onNewVideoActivityAssignment?: () => void;
   /**
-   * If present, the corresponding empty-state CTA renders disabled and
-   * uses this string as its `title` (hover tooltip + screen-reader
-   * accessible-name fallback that ATs read on the focused disabled
-   * button). Mirrors the body-level CTA pattern so the empty-state and
-   * populated-state CTAs stay in lockstep — Drive disconnected on
-   * both, library empty on both. When undefined, the CTA is enabled
-   * and uses the default ctaTooltip string.
+   * If present, the corresponding empty-state CTA renders in an
+   * `aria-disabled` state (still focusable, click guarded) and exposes
+   * this string both as the hover tooltip (`title`) and as
+   * screen-reader-only text wired up via `aria-describedby` — native
+   * `disabled` strips the button from the tab order, so keyboard / AT
+   * users would never surface a `title`-only hint. Mirrors the
+   * body-level CTA pattern so the empty-state and populated-state CTAs
+   * stay in lockstep — Drive disconnected on both, library empty on
+   * both. When undefined, the CTA is enabled and uses the default
+   * ctaTooltip string.
    */
   newQuizDisabledReason?: string;
   newVideoActivityDisabledReason?: string;
@@ -102,18 +106,6 @@ interface ImportTarget {
   attemptLimit: number | null;
 }
 
-function formatDate(ms: number): string {
-  try {
-    return new Date(ms).toLocaleDateString(undefined, {
-      year: 'numeric',
-      month: 'short',
-      day: 'numeric',
-    });
-  } catch {
-    return '';
-  }
-}
-
 export const PlcAssignmentsLibrarySubTab: React.FC<
   PlcAssignmentsLibrarySubTabProps
 > = ({
@@ -125,6 +117,8 @@ export const PlcAssignmentsLibrarySubTab: React.FC<
   newVideoActivityDisabledReason,
 }) => {
   const { t } = useTranslation();
+  const newQuizReasonId = useId();
+  const newVideoReasonId = useId();
   const { user } = useAuth();
   const { addToast, rosters, setPendingAssignmentEdit } = useDashboard();
   const { showConfirm } = useDialog();
@@ -396,44 +390,76 @@ export const PlcAssignmentsLibrarySubTab: React.FC<
         {(onNewQuizAssignment ?? onNewVideoActivityAssignment) && (
           <div className="flex flex-wrap items-center justify-center gap-2">
             {onNewQuizAssignment && (
-              <button
-                type="button"
-                onClick={onNewQuizAssignment}
-                disabled={newQuizDisabledReason !== undefined}
-                title={
-                  newQuizDisabledReason ??
-                  t('plcDashboard.newAssignment.quiz.ctaTooltip', {
-                    defaultValue:
-                      'Create a PLC quiz assignment from your personal library.',
-                  })
-                }
-                className="inline-flex items-center gap-1.5 px-4 py-2 rounded-lg bg-brand-blue-primary text-white text-xs font-bold hover:bg-brand-blue-dark transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
-              >
-                <Plus className="w-3.5 h-3.5" aria-hidden="true" />
-                {t('plcDashboard.newAssignment.quiz.ctaLabel', {
-                  defaultValue: 'Assign Quiz',
-                })}
-              </button>
+              <>
+                <button
+                  type="button"
+                  onClick={
+                    newQuizDisabledReason !== undefined
+                      ? undefined
+                      : onNewQuizAssignment
+                  }
+                  aria-disabled={newQuizDisabledReason !== undefined}
+                  aria-describedby={
+                    newQuizDisabledReason !== undefined
+                      ? newQuizReasonId
+                      : undefined
+                  }
+                  title={
+                    newQuizDisabledReason ??
+                    t('plcDashboard.newAssignment.quiz.ctaTooltip', {
+                      defaultValue:
+                        'Create a PLC quiz assignment from your personal library.',
+                    })
+                  }
+                  className="inline-flex items-center gap-1.5 px-4 py-2 rounded-lg bg-brand-blue-primary text-white text-xs font-bold hover:bg-brand-blue-dark transition-colors aria-disabled:opacity-40 aria-disabled:cursor-not-allowed aria-disabled:hover:bg-brand-blue-primary"
+                >
+                  <Plus className="w-3.5 h-3.5" aria-hidden="true" />
+                  {t('plcDashboard.newAssignment.quiz.ctaLabel', {
+                    defaultValue: 'Assign Quiz',
+                  })}
+                </button>
+                {newQuizDisabledReason !== undefined && (
+                  <span id={newQuizReasonId} className="sr-only">
+                    {newQuizDisabledReason}
+                  </span>
+                )}
+              </>
             )}
             {onNewVideoActivityAssignment && (
-              <button
-                type="button"
-                onClick={onNewVideoActivityAssignment}
-                disabled={newVideoActivityDisabledReason !== undefined}
-                title={
-                  newVideoActivityDisabledReason ??
-                  t('plcDashboard.newAssignment.video.ctaTooltip', {
-                    defaultValue:
-                      'Create a PLC video activity assignment from your personal library.',
-                  })
-                }
-                className="inline-flex items-center gap-1.5 px-4 py-2 rounded-lg bg-brand-blue-primary text-white text-xs font-bold hover:bg-brand-blue-dark transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
-              >
-                <PlayCircle className="w-3.5 h-3.5" aria-hidden="true" />
-                {t('plcDashboard.newAssignment.video.ctaLabel', {
-                  defaultValue: 'Assign Video',
-                })}
-              </button>
+              <>
+                <button
+                  type="button"
+                  onClick={
+                    newVideoActivityDisabledReason !== undefined
+                      ? undefined
+                      : onNewVideoActivityAssignment
+                  }
+                  aria-disabled={newVideoActivityDisabledReason !== undefined}
+                  aria-describedby={
+                    newVideoActivityDisabledReason !== undefined
+                      ? newVideoReasonId
+                      : undefined
+                  }
+                  title={
+                    newVideoActivityDisabledReason ??
+                    t('plcDashboard.newAssignment.video.ctaTooltip', {
+                      defaultValue:
+                        'Create a PLC video activity assignment from your personal library.',
+                    })
+                  }
+                  className="inline-flex items-center gap-1.5 px-4 py-2 rounded-lg bg-brand-blue-primary text-white text-xs font-bold hover:bg-brand-blue-dark transition-colors aria-disabled:opacity-40 aria-disabled:cursor-not-allowed aria-disabled:hover:bg-brand-blue-primary"
+                >
+                  <PlayCircle className="w-3.5 h-3.5" aria-hidden="true" />
+                  {t('plcDashboard.newAssignment.video.ctaLabel', {
+                    defaultValue: 'Assign Video',
+                  })}
+                </button>
+                {newVideoActivityDisabledReason !== undefined && (
+                  <span id={newVideoReasonId} className="sr-only">
+                    {newVideoActivityDisabledReason}
+                  </span>
+                )}
+              </>
             )}
           </div>
         )}
@@ -498,7 +524,7 @@ export const PlcAssignmentsLibrarySubTab: React.FC<
                     {template.sessionMode}
                   </span>
                   <span className="text-slate-300">•</span>
-                  <span>{formatDate(template.updatedAt)}</span>
+                  <span>{formatShortDate(template.updatedAt)}</span>
                 </div>
               </div>
               <div className="shrink-0 flex items-center gap-1.5">


### PR DESCRIPTION
Fast-forward fixes for the Copilot and Gemini comments on #1602 so `dev-paul` is merge-ready into `main`.

## Summary
- Replace `disabled` + `title` with `aria-disabled` + click guard + `aria-describedby` on the "+ Assign Quiz" / "+ Assign Video" CTAs in both `PlcAssignmentsBody` (header) and `PlcAssignmentsLibrarySubTab` (empty state) so the disabled reason is reachable by keyboard/screen-reader users — native `disabled` buttons aren't focusable.
- Rename `formatRelativeDate` → `formatShortDate` in `newAssignmentHelpers.ts` (and both wizard importers); the helper returns an absolute locale short date, not a relative string.
- Remove the duplicated local `formatDate` in `PlcAssignmentsLibrarySubTab.tsx` and use the shared helper.
- Wrap the hardcoded Google Sheet URL placeholder in `PlcNewAssignmentSharingSlot.tsx` in `t(...)` for i18n parity with the rest of the slot.
- Update the `newQuizDisabledReason` / `newVideoActivityDisabledReason` prop docs to match the new `aria-disabled` semantics.

## Test plan
- [x] `pnpm run type-check`
- [x] `pnpm run lint`
- [x] `pnpm run format:check`
- [x] `pnpm vitest run tests/components/plc/PlcAssignmentsLibrarySubTab.test.tsx` (4/4 pass)
- [ ] Manual: keyboard-focus the CTAs with Drive disconnected / empty library and confirm the reason text is announced via `aria-describedby`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BCLs8PCQjmTbSvb4C25kHC)_