### PR TITLE
feat(dock): add pointer drag-to-scroll for horizontal and vertical dock

### DIFF
--- a/components/layout/Dock.tsx
+++ b/components/layout/Dock.tsx
@@ -11,7 +11,8 @@ import { LayoutGrid, Puzzle, Users, Cast, Square } from 'lucide-react';
 import {
   DndContext,
   closestCenter,
-  PointerSensor,
+  MouseSensor,
+  TouchSensor,
   useSensor,
   useSensors,
   DragEndEvent,
@@ -33,6 +34,7 @@ import { useSavedWidgets } from '@/context/useSavedWidgets';
 import { useDialog } from '@/context/useDialog';
 import { useLiveSession } from '@/hooks/useLiveSession';
 import { useClickOutside } from '@/hooks/useClickOutside';
+import { useDragScroll } from '@/hooks/useDragScroll';
 import {
   WidgetType,
   WidgetData,
@@ -297,6 +299,12 @@ export const Dock: React.FC = () => {
   );
   const [imagePastePending, setImagePastePending] = useState<File | null>(null);
 
+  // Ref for the GlassCard scroll container — used by the drag-scroll hook.
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
+  useDragScroll(scrollContainerRef, isVerticalDock ? 'y' : 'x', {
+    disabled: isEditMode,
+  });
+
   // Drag-to-collapse state — `dragOffset` is the magnitude moved along the
   // collapse axis (down for bottom dock, left/right for side docks).
   const [dragOffset, setDragOffset] = useState(0);
@@ -550,10 +558,13 @@ export const Dock: React.FC = () => {
   const [activeItemId, setActiveItemId] = useState<string | null>(null);
 
   const sensors = useSensors(
-    useSensor(PointerSensor, {
-      activationConstraint: {
-        distance: 15, // Require 15px movement to start drag (better for large touch panels)
-      },
+    useSensor(MouseSensor, {
+      activationConstraint: { distance: 15 },
+    }),
+    useSensor(TouchSensor, {
+      // Require a 250 ms hold before reorder activates on touch, so a quick
+      // horizontal swipe scrolls the dock rather than triggering a drag.
+      activationConstraint: { delay: 250, tolerance: 8 },
     })
   );
 
@@ -962,6 +973,7 @@ export const Dock: React.FC = () => {
 
           {/* Expanded Toolbar with integrated minimize button */}
           <GlassCard
+            ref={scrollContainerRef}
             globalStyle={globalStyle}
             transparency={globalStyle.dockTransparency}
             allowInvisible={true}

--- a/hooks/useDragScroll.ts
+++ b/hooks/useDragScroll.ts
@@ -38,6 +38,8 @@ export function useDragScroll(
     const onPointerDown = (e: PointerEvent) => {
       // Only respond to the primary pointer (left mouse button, first touch)
       if (e.pointerType === 'mouse' && e.button !== 0) return;
+      // Ignore a second pointer while a scroll gesture is already in flight
+      if (activePointerId !== null) return;
 
       state = 'undecided';
       startX = e.clientX;
@@ -62,7 +64,9 @@ export function useDragScroll(
         const primaryDelta = axis === 'x' ? adx : ady;
         const secondaryDelta = axis === 'x' ? ady : adx;
 
-        if (primaryDelta > secondaryDelta) {
+        // Use >= so a perfectly diagonal drag (primaryDelta === secondaryDelta)
+        // commits to scroll rather than falling through to the collapse handler.
+        if (primaryDelta >= secondaryDelta) {
           state = 'scrolling';
           try {
             el.setPointerCapture(e.pointerId);

--- a/hooks/useDragScroll.ts
+++ b/hooks/useDragScroll.ts
@@ -1,0 +1,117 @@
+import { RefObject, useEffect } from 'react';
+
+type ScrollAxis = 'x' | 'y';
+type DragState = 'idle' | 'undecided' | 'scrolling' | 'passthrough';
+
+interface UseDragScrollOptions {
+  disabled?: boolean;
+  /** Pixels of total movement before committing to a direction (default: 8) */
+  minDistance?: number;
+}
+
+/**
+ * Attaches pointer-drag-to-scroll to a scrollable container ref.
+ *
+ * Direction is disambiguated before committing: movement clearly along the
+ * primary axis enters scroll mode (capturing the pointer and stopping
+ * propagation to prevent dnd-kit from activating); movement clearly along the
+ * secondary axis falls through to other handlers (collapse gesture, dnd-kit).
+ */
+export function useDragScroll(
+  ref: RefObject<HTMLElement | null>,
+  axis: ScrollAxis = 'x',
+  options: UseDragScrollOptions = {}
+) {
+  const { disabled = false, minDistance = 8 } = options;
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el || disabled) return;
+
+    let state: DragState = 'idle';
+    let startX = 0;
+    let startY = 0;
+    let startScrollLeft = 0;
+    let startScrollTop = 0;
+    let activePointerId: number | null = null;
+
+    const onPointerDown = (e: PointerEvent) => {
+      // Only respond to the primary pointer (left mouse button, first touch)
+      if (e.pointerType === 'mouse' && e.button !== 0) return;
+
+      state = 'undecided';
+      startX = e.clientX;
+      startY = e.clientY;
+      startScrollLeft = el.scrollLeft;
+      startScrollTop = el.scrollTop;
+      activePointerId = e.pointerId;
+    };
+
+    const onPointerMove = (e: PointerEvent) => {
+      if (state === 'idle' || state === 'passthrough') return;
+      if (e.pointerId !== activePointerId) return;
+
+      const dx = e.clientX - startX;
+      const dy = e.clientY - startY;
+      const adx = Math.abs(dx);
+      const ady = Math.abs(dy);
+
+      if (state === 'undecided') {
+        if (Math.sqrt(dx * dx + dy * dy) < minDistance) return;
+
+        const primaryDelta = axis === 'x' ? adx : ady;
+        const secondaryDelta = axis === 'x' ? ady : adx;
+
+        if (primaryDelta > secondaryDelta) {
+          state = 'scrolling';
+          try {
+            el.setPointerCapture(e.pointerId);
+          } catch (_err) {
+            // Capture may fail on some browsers — scroll still works without it
+          }
+        } else {
+          // Secondary axis dominates — hand off to collapse or dnd-kit
+          state = 'passthrough';
+          return;
+        }
+      }
+
+      if (state === 'scrolling') {
+        // Block dnd-kit (document-level) from seeing this move event
+        e.stopImmediatePropagation();
+        e.preventDefault();
+
+        if (axis === 'x') {
+          el.scrollLeft = startScrollLeft - dx;
+        } else {
+          el.scrollTop = startScrollTop - dy;
+        }
+      }
+    };
+
+    const onPointerUp = (e: PointerEvent) => {
+      if (e.pointerId !== activePointerId) return;
+      if (state === 'scrolling') {
+        try {
+          el.releasePointerCapture(e.pointerId);
+        } catch (_err) {
+          // Ignore — pointer may already be released
+        }
+      }
+      state = 'idle';
+      activePointerId = null;
+    };
+
+    el.addEventListener('pointerdown', onPointerDown);
+    el.addEventListener('pointermove', onPointerMove);
+    el.addEventListener('pointerup', onPointerUp);
+    el.addEventListener('pointercancel', onPointerUp);
+
+    return () => {
+      el.removeEventListener('pointerdown', onPointerDown);
+      el.removeEventListener('pointermove', onPointerMove);
+      el.removeEventListener('pointerup', onPointerUp);
+      el.removeEventListener('pointercancel', onPointerUp);
+    };
+  }, [ref, axis, disabled, minDistance]);
+}


### PR DESCRIPTION
## Summary

- Adds `hooks/useDragScroll.ts` — a direction-disambiguating drag-scroll hook that attaches native pointer listeners to the dock's GlassCard scroll container. Fires before document-level dnd-kit listeners; on the first 8 px of movement it decides: primary axis dominates → scroll mode (captures pointer, stops propagation to block dnd-kit); secondary axis dominates → falls through to the collapse gesture.
- Replaces `PointerSensor` with `MouseSensor` (15 px distance, unchanged) + `TouchSensor` (250 ms hold + 8 px tolerance) so quick touch swipes scroll the dock while a long-press still reorders items.
- Wires `scrollContainerRef` to the `<GlassCard>` scroll container (already uses `forwardRef`) and disables the hook in edit mode so dnd-kit reordering is unobstructed.

## Test plan

- [ ] Open dock with many widget icons (more than fit on screen)
- [ ] **Mouse**: click and drag horizontally on the dock in normal mode — icons should scroll smoothly
- [ ] **Touch / DevTools touch emulation**: quick horizontal swipe → dock scrolls; long press (250 ms) on an item then drag → item reorders
- [ ] **Edit mode**: drag items left/right → reorders (scroll hook inactive)
- [ ] **Collapse gesture**: drag the dock downward → still collapses correctly
- [ ] **Vertical dock**: drag vertically → scrolls; drag horizontally → collapses
- [ ] Lint, type-check, and format all pass (`pnpm run validate`)

https://claude.ai/code/session_01VBaKqRvFRuTEtdx3GZP8Ed

---
_Generated by [Claude Code](https://claude.ai/code/session_01VBaKqRvFRuTEtdx3GZP8Ed)_