### PR TITLE
Fix FAB positioning: zoom/help always bottom-right, board switcher always bottom-left

### DIFF
--- a/components/layout/BoardActionsFab.tsx
+++ b/components/layout/BoardActionsFab.tsx
@@ -10,7 +10,6 @@ import {
 import { useTranslation } from 'react-i18next';
 import { HelpCircle, RotateCcw, Search, ZoomIn, ZoomOut } from 'lucide-react';
 import { useDashboard } from '@/context/useDashboard';
-import { useAuth } from '@/context/useAuth';
 import { useClickOutside } from '@/hooks/useClickOutside';
 import { FAB_BASE } from './fabClasses';
 import {
@@ -36,7 +35,6 @@ export const BoardActionsFab: FC<BoardActionsFabProps> = ({
 }) => {
   const { t } = useTranslation();
   const { zoom, setZoom } = useDashboard();
-  const { dockPosition } = useAuth();
 
   const [isSliderOpen, setIsSliderOpen] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -67,17 +65,6 @@ export const BoardActionsFab: FC<BoardActionsFabProps> = ({
 
   const isZoomed = zoom !== ZOOM_DEFAULT;
   const percentage = Math.round(zoom * 100);
-
-  // Mirror BoardNavFab's left/right anchoring: when the dock occupies the
-  // right edge, the cluster must move to the left so they don't overlap.
-  const onLeftSide = dockPosition === 'right';
-  const positionClass = onLeftSide ? 'left-14' : 'right-4';
-  // The popup card itself anchors to the same edge as the cluster.
-  const popupEdge = onLeftSide ? 'left-0' : 'right-0';
-  // The reset FAB animates in from whichever direction the cluster grows.
-  const resetSlideClass = onLeftSide
-    ? 'slide-in-from-left-2'
-    : 'slide-in-from-right-2';
 
   const handleSliderChange = (rawValue: number) => {
     setZoom(sliderToZoom(rawValue));
@@ -122,7 +109,7 @@ export const BoardActionsFab: FC<BoardActionsFabProps> = ({
     <div
       ref={containerRef}
       data-screenshot="exclude"
-      className={`fixed bottom-6 ${positionClass} z-dock`}
+      className="fixed bottom-6 right-4 z-dock"
     >
       {isSliderOpen && (
         <div
@@ -130,7 +117,7 @@ export const BoardActionsFab: FC<BoardActionsFabProps> = ({
           role="dialog"
           aria-labelledby={headerId}
           onKeyDown={handlePopupKeyDown}
-          className={`absolute bottom-full ${popupEdge} mb-2 w-64 rounded-2xl border border-white/20 bg-slate-900/80 backdrop-blur-xl shadow-2xl px-3.5 py-3 animate-in fade-in slide-in-from-bottom-2 duration-150`}
+          className="absolute bottom-full right-0 mb-2 w-64 rounded-2xl border border-white/20 bg-slate-900/80 backdrop-blur-xl shadow-2xl px-3.5 py-3 animate-in fade-in slide-in-from-bottom-2 duration-150"
         >
           <div className="flex items-center justify-between mb-2">
             <span
@@ -204,7 +191,7 @@ export const BoardActionsFab: FC<BoardActionsFabProps> = ({
             onClick={handleReset}
             aria-label={t('boardZoom.reset', { defaultValue: 'Reset to 100%' })}
             title={t('boardZoom.reset', { defaultValue: 'Reset to 100%' })}
-            className={`${FAB_BASE} animate-in fade-in ${resetSlideClass} duration-200`}
+            className={`${FAB_BASE} animate-in fade-in slide-in-from-right-2 duration-200`}
           >
             <RotateCcw className="w-4 h-4" />
           </button>

--- a/tests/components/layout/BoardActionsFab.test.tsx
+++ b/tests/components/layout/BoardActionsFab.test.tsx
@@ -6,10 +6,6 @@ vi.mock('@/context/useDashboard', () => ({
   useDashboard: vi.fn(),
 }));
 
-vi.mock('@/context/useAuth', () => ({
-  useAuth: vi.fn(),
-}));
-
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
     t: (key: string, options?: { defaultValue?: string }) =>
@@ -18,10 +14,8 @@ vi.mock('react-i18next', () => ({
 }));
 
 import { useDashboard } from '@/context/useDashboard';
-import { useAuth } from '@/context/useAuth';
 
 const mockedUseDashboard = vi.mocked(useDashboard);
-const mockedUseAuth = vi.mocked(useAuth);
 
 const noop = () => undefined;
 
@@ -31,9 +25,6 @@ const setupContexts = (zoom: number) => {
     zoom,
     setZoom,
   } as unknown as ReturnType<typeof useDashboard>);
-  mockedUseAuth.mockReturnValue({
-    dockPosition: 'left',
-  } as unknown as ReturnType<typeof useAuth>);
   return { setZoom };
 };
 
@@ -97,17 +88,11 @@ describe('BoardActionsFab', () => {
     expect(setZoom).toHaveBeenCalledWith(2);
   });
 
-  it('switches anchoring to the left when the dock is on the right', () => {
-    mockedUseDashboard.mockReturnValue({
-      zoom: 1,
-      setZoom: vi.fn(),
-    } as unknown as ReturnType<typeof useDashboard>);
-    mockedUseAuth.mockReturnValue({
-      dockPosition: 'right',
-    } as unknown as ReturnType<typeof useAuth>);
+  it('always anchors to bottom-right regardless of dock position', () => {
+    setupContexts(1);
     const { container } = render(<BoardActionsFab onOpenCheatSheet={noop} />);
     const root = container.querySelector('[data-screenshot="exclude"]');
-    expect(root?.className).toContain('left-14');
-    expect(root?.className).not.toContain('right-4');
+    expect(root?.className).toContain('right-4');
+    expect(root?.className).not.toContain('left-14');
   });
 });


### PR DESCRIPTION
## Summary

- Removes the dock-position-dependent repositioning logic from `BoardActionsFab`. When the dock was on the right side, the zoom/help FABs incorrectly jumped to `left-14`, colliding with the board-switcher FABs pinned at `left-4`.
- The right dock sits at `top-1/2` (vertically centered on the right edge), so it never overlaps with bottom-corner FABs — the avoidance logic was both unnecessary and harmful.
- Both FAB clusters now stay pinned to their fixed corners regardless of dock position: **zoom/help → bottom-right**, **board switcher → bottom-left**.
- Updates the corresponding test to assert the new invariant (always `right-4`, never `left-14`).

## Test plan

- [ ] Set dock to **right** — zoom/help FABs stay bottom-right, board-switcher FABs stay bottom-left, no overlap
- [ ] Set dock to **left** — both FAB clusters remain in their respective corners
- [ ] Set dock to **bottom** (default) — no change in behavior
- [ ] Unit tests pass (`pnpm run test`)
- [ ] Lint and type-check pass (`pnpm run lint && pnpm run type-check`)

https://claude.ai/code/session_01Hr7CmfUTxZG92bvLxA21qJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hr7CmfUTxZG92bvLxA21qJ)_