### PR TITLE
fix(auth): sync dock state and recognize returning users across devices

### DIFF
--- a/context/AuthContext.tsx
+++ b/context/AuthContext.tsx
@@ -16,9 +16,12 @@ import {
 import {
   doc,
   getDoc,
+  getDocs,
   setDoc,
   collection,
   onSnapshot,
+  limit,
+  query,
 } from 'firebase/firestore';
 import {
   auth,
@@ -282,6 +285,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
   // a token refresh later in the session doesn't re-probe and re-write the
   // profile doc. Cleared on sign-out.
   const driveProbedForUidRef = useRef<string | null>(null);
+  const firestoreProbedForUidRef = useRef<string | null>(null);
 
   // Reset role-resolution flags synchronously when `user` changes. Without
   // this, a re-render between users would briefly carry the previous user's
@@ -811,6 +815,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
 
       if (!user) {
         driveProbedForUidRef.current = null;
+        firestoreProbedForUidRef.current = null;
         setSelectedBuildingsState([]);
         setSavedWidgetConfigs({});
         setProfileLoaded(true);
@@ -881,11 +886,25 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
             );
           }
 
-          // Load setupCompleted. The field is only written by the wizard on new
-          // accounts, so its absence from an existing profile doc means the user
-          // pre-dates the wizard — treat them as having completed setup already.
+          // Decide setupCompleted. The wizard writes `setupCompleted: true` on
+          // finish, so any of the following counts as "already set up":
+          //   1. The field is explicitly true.
+          //   2. The field is missing — user pre-dates the wizard.
+          //   3. The user has a non-empty selectedBuildings array. This catches
+          //      legacy users who selected a building via the old Sidebar
+          //      picker (which never wrote setupCompleted) and would otherwise
+          //      see the wizard on every new device.
+          const hasSelectedBuildings =
+            'selectedBuildings' in data &&
+            Array.isArray(
+              (data as { selectedBuildings: unknown }).selectedBuildings
+            ) &&
+            (data as { selectedBuildings: unknown[] }).selectedBuildings
+              .length > 0;
           setSetupCompletedState(
-            !('setupCompleted' in data) || data.setupCompleted === true
+            !('setupCompleted' in data) ||
+              data.setupCompleted === true ||
+              hasSelectedBuildings
           );
 
           // Load account-level preferences
@@ -956,6 +975,81 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
       isCancelled = true;
     };
   }, [user]);
+
+  // Returning-user Firestore probe.
+  //
+  // Runs whenever a user signs in with `setupCompleted=false` but the
+  // profile doc itself was missing or empty (the only path that reaches
+  // here after the in-profile heuristic broadens). Checks two other
+  // signals that the user has used SpartBoard before:
+  //   1. `/users/{uid}` root doc carries a non-empty `buildings` array
+  //      (the legacy analytics mirror written by `setSelectedBuildings`).
+  //   2. `/users/{uid}/dashboards` has at least one document — they
+  //      already created and saved a dashboard previously.
+  // Either signal is enough to skip the setup wizard. Runs before the
+  // Drive probe so users without Google Drive sync are still recognized.
+  useEffect(() => {
+    if (isAuthBypass) return;
+    if (!user || !profileLoaded || setupCompleted) return;
+    if (firestoreProbedForUidRef.current === user.uid) return;
+
+    firestoreProbedForUidRef.current = user.uid;
+    const probeUid = user.uid;
+
+    void (async () => {
+      try {
+        const rootRef = doc(db, 'users', probeUid);
+        const [rootSnap, dashboardsSnap] = await Promise.all([
+          getDoc(rootRef),
+          getDocs(
+            query(collection(db, 'users', probeUid, 'dashboards'), limit(1))
+          ),
+        ]);
+        // If the user has switched since we started, drop the result rather
+        // than scribble on someone else's profile. The ref above is the
+        // authoritative "current probe target".
+        if (firestoreProbedForUidRef.current !== probeUid) return;
+
+        const rootData = rootSnap.exists()
+          ? (rootSnap.data() as Record<string, unknown>)
+          : null;
+        const rootBuildingsRaw =
+          rootData && Array.isArray(rootData.buildings)
+            ? (rootData.buildings as unknown[]).filter(
+                (b): b is string => typeof b === 'string'
+              )
+            : [];
+        const hasRootBuildings = rootBuildingsRaw.length > 0;
+        const hasDashboards = !dashboardsSnap.empty;
+
+        if (!hasRootBuildings && !hasDashboards) return;
+
+        const canonical = hasRootBuildings
+          ? canonicalizeBuildingIds(rootBuildingsRaw)
+          : null;
+
+        const profileUpdate: Record<string, unknown> = {
+          setupCompleted: true,
+        };
+        if (canonical && canonical.length > 0) {
+          profileUpdate.selectedBuildings = canonical;
+        }
+
+        await setDoc(
+          doc(db, 'users', probeUid, 'userProfile', 'profile'),
+          profileUpdate,
+          { merge: true }
+        );
+        if (firestoreProbedForUidRef.current !== probeUid) return;
+        setSetupCompletedState(true);
+        if (canonical && canonical.length > 0) {
+          setSelectedBuildingsState(canonical);
+        }
+      } catch (e) {
+        console.warn('[AuthContext] Returning-user Firestore probe failed:', e);
+      }
+    })();
+  }, [user, profileLoaded, setupCompleted]);
 
   // Returning-user Drive probe.
   //

--- a/context/AuthContext.tsx
+++ b/context/AuthContext.tsx
@@ -894,13 +894,17 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
           //      legacy users who selected a building via the old Sidebar
           //      picker (which never wrote setupCompleted) and would otherwise
           //      see the wizard on every new device.
+          // Require at least one non-empty string element so garbage like
+          // [null, ''] doesn't count a user as already-set-up.
+          const rawSelected: unknown =
+            'selectedBuildings' in data
+              ? (data as { selectedBuildings: unknown }).selectedBuildings
+              : null;
           const hasSelectedBuildings =
-            'selectedBuildings' in data &&
-            Array.isArray(
-              (data as { selectedBuildings: unknown }).selectedBuildings
-            ) &&
-            (data as { selectedBuildings: unknown[] }).selectedBuildings
-              .length > 0;
+            Array.isArray(rawSelected) &&
+            rawSelected.some(
+              (id) => typeof id === 'string' && id.trim().length > 0
+            );
           setSetupCompletedState(
             !('setupCompleted' in data) ||
               data.setupCompleted === true ||

--- a/context/DashboardContext.tsx
+++ b/context/DashboardContext.tsx
@@ -425,11 +425,24 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
   const migrationStartedForUidRef = useRef<string | null>(null);
 
   // Cross-device dock sync. `dockItems`, `libraryOrder`, and `isDockInitialized`
-  // are mirrored to `/users/{uid}/userProfile/profile`. `dockHydrated` flips
-  // true once we've read the source-of-truth from Firestore (or determined
-  // there's nothing to read), at which point local mutations may write back.
+  // are mirrored to `/users/{uid}/userProfile/profile`. Hydration tracks two
+  // separate things:
+  //   - `dockHydrated` flips true once we've *attempted* the cloud read, even
+  //     on failure. The local init effect below waits on this so it doesn't
+  //     seed defaults before we know whether a cloud layout exists.
+  //   - `dockHydrationOk` flips true only when the cloud read *succeeded* (doc
+  //     present or confirmed-absent). The persistence effect requires this so
+  //     a transient Firestore error during hydration doesn't let freshly-
+  //     seeded defaults overwrite a real cloud layout that we just couldn't
+  //     reach this session.
   const [dockHydrated, setDockHydrated] = useState(isAuthBypass);
+  const [dockHydrationOk, setDockHydrationOk] = useState(isAuthBypass);
   const dockHydratedForUidRef = useRef<string | null>(null);
+  // Coalesce rapid dock mutations (e.g. drag-reorders) into a single Firestore
+  // write so we don't fire one setDoc per intermediate frame.
+  const dockPersistTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null
+  );
 
   const removeToast = useCallback((id: string) => {
     setToasts((prev) => prev.filter((t) => t.id !== id));
@@ -715,6 +728,7 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
   useEffect(() => {
     if (isAuthBypass) {
       setDockHydrated(true);
+      setDockHydrationOk(true);
       return;
     }
     if (!user || !profileLoaded) return;
@@ -723,6 +737,7 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
 
     let cancelled = false;
     void (async () => {
+      let succeeded = false;
       try {
         const profileRef = doc(db, 'users', user.uid, 'userProfile', 'profile');
         const snap = await getDoc(profileRef);
@@ -781,10 +796,22 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
           setIsDockInitialized(true);
           localStorage.setItem('classroom_dock_initialized', 'true');
         }
+        succeeded = true;
       } catch (err) {
+        // Leave dockHydrationOk false so we don't push defaults over a real
+        // cloud layout we just couldn't reach. The init effect still proceeds
+        // (via dockHydrated) so the user keeps a functional dock from cache
+        // or admin defaults; a future refresh will retry the read.
         console.error('[DashboardContext] Failed to hydrate dock state:', err);
+        // Allow another attempt if the user refreshes — drop the per-uid lock.
+        if (dockHydratedForUidRef.current === user.uid) {
+          dockHydratedForUidRef.current = null;
+        }
       } finally {
-        if (!cancelled) setDockHydrated(true);
+        if (!cancelled) {
+          setDockHydrated(true);
+          if (succeeded) setDockHydrationOk(true);
+        }
       }
     })();
 
@@ -794,28 +821,43 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
   }, [user, profileLoaded]);
 
   // Persist dock state to Firestore whenever it changes locally. Gated on
-  // `dockHydrated` so the initial localStorage-seeded values don't clobber
-  // the cloud doc before we've read it.
+  // `dockHydrationOk` so a transient cloud-read failure doesn't let local
+  // defaults overwrite the user's real layout. The 500ms debounce coalesces
+  // rapid mutations (drag-reorders, multi-toggle bursts) into a single write.
   useEffect(() => {
     if (isAuthBypass) return;
-    if (!user || !dockHydrated) return;
+    if (!user || !dockHydrationOk) return;
     // Only mirror to the cloud once the dock has actually been seeded —
     // otherwise we'd write empty arrays during the brief pre-seed window.
     if (!isDockInitialized) return;
 
-    const profileRef = doc(db, 'users', user.uid, 'userProfile', 'profile');
-    void setDoc(
-      profileRef,
-      {
-        dockItems,
-        libraryOrder,
-        dockInitialized: true,
-      },
-      { merge: true }
-    ).catch((err: unknown) => {
-      console.error('[DashboardContext] Failed to persist dock state:', err);
-    });
-  }, [user, dockHydrated, isDockInitialized, dockItems, libraryOrder]);
+    if (dockPersistTimerRef.current !== null) {
+      clearTimeout(dockPersistTimerRef.current);
+    }
+    const uid = user.uid;
+    dockPersistTimerRef.current = setTimeout(() => {
+      dockPersistTimerRef.current = null;
+      const profileRef = doc(db, 'users', uid, 'userProfile', 'profile');
+      void setDoc(
+        profileRef,
+        {
+          dockItems,
+          libraryOrder,
+          dockInitialized: true,
+        },
+        { merge: true }
+      ).catch((err: unknown) => {
+        console.error('[DashboardContext] Failed to persist dock state:', err);
+      });
+    }, 500);
+
+    return () => {
+      if (dockPersistTimerRef.current !== null) {
+        clearTimeout(dockPersistTimerRef.current);
+        dockPersistTimerRef.current = null;
+      }
+    };
+  }, [user, dockHydrationOk, isDockInitialized, dockItems, libraryOrder]);
 
   // Reset dock-hydration state on sign-out / user switch so the next sign-in
   // re-fetches the cloud doc and the previous user's localStorage cache
@@ -824,6 +866,11 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
     if (!user) {
       dockHydratedForUidRef.current = null;
       setDockHydrated(isAuthBypass);
+      setDockHydrationOk(isAuthBypass);
+      if (dockPersistTimerRef.current !== null) {
+        clearTimeout(dockPersistTimerRef.current);
+        dockPersistTimerRef.current = null;
+      }
       if (!isAuthBypass) {
         localStorage.removeItem('classroom_dock_items');
         localStorage.removeItem('classroom_visible_tools');

--- a/context/DashboardContext.tsx
+++ b/context/DashboardContext.tsx
@@ -21,6 +21,7 @@ import {
   GridPosition,
   FeaturePermission,
   DrawableObject,
+  UserProfile,
 } from '../types';
 import { doc, getDoc, setDoc } from 'firebase/firestore';
 import { db, isAuthBypass } from '../config/firebase';
@@ -354,7 +355,23 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
     setAnnotationActive(false);
   }, []);
 
+  // Same-device cache invalidation across user accounts. The dock cache in
+  // localStorage is keyed by the uid that last wrote it; on mount we only
+  // trust the cache when its uid matches the currently signed-in user.
+  // Mismatch → return defaults, so user B doesn't briefly see user A's
+  // layout while waiting for Firestore hydration. DashboardProvider is only
+  // mounted when `user` is truthy (see App.tsx), so a sign-out → sign-in as
+  // a different user remounts this component with a fresh user value.
+  const dockCacheUidRaw =
+    typeof window !== 'undefined'
+      ? localStorage.getItem('classroom_dock_cache_uid')
+      : null;
+  const dockCacheMatchesUser = user
+    ? dockCacheUidRaw === user.uid
+    : dockCacheUidRaw === null;
+
   const [isDockInitialized, setIsDockInitialized] = useState<boolean>(() => {
+    if (!dockCacheMatchesUser) return false;
     return localStorage.getItem('classroom_dock_initialized') === 'true';
   });
   // Keep a ref in sync so timeout callbacks can read the latest value without
@@ -365,6 +382,7 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
   const [visibleTools, setVisibleTools] = useState<
     (WidgetType | InternalToolType)[]
   >(() => {
+    if (!dockCacheMatchesUser) return [];
     const saved = localStorage.getItem('classroom_visible_tools');
     if (saved) {
       try {
@@ -379,6 +397,7 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
   const [libraryOrder, setLibraryOrder] = useState<
     (WidgetType | InternalToolType)[]
   >(() => {
+    if (!dockCacheMatchesUser) return TOOLS.map((t) => t.type);
     const saved = localStorage.getItem('spartboard_library_order');
     if (saved) {
       try {
@@ -391,6 +410,7 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
   });
 
   const [dockItems, setDockItems] = useState<DockItem[]>(() => {
+    if (!dockCacheMatchesUser) return [];
     const saved = localStorage.getItem('classroom_dock_items');
     if (saved) {
       try {
@@ -743,17 +763,13 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
         const snap = await getDoc(profileRef);
         if (cancelled) return;
         const data = snap.exists()
-          ? (snap.data() as Record<string, unknown>)
+          ? (snap.data() as Partial<UserProfile>)
           : null;
 
         const cloudDock =
-          data && Array.isArray(data.dockItems)
-            ? (data.dockItems as DockItem[])
-            : null;
+          data && Array.isArray(data.dockItems) ? data.dockItems : null;
         const cloudLibrary =
-          data && Array.isArray(data.libraryOrder)
-            ? (data.libraryOrder as (WidgetType | InternalToolType)[])
-            : null;
+          data && Array.isArray(data.libraryOrder) ? data.libraryOrder : null;
         const cloudInitialized =
           data && typeof data.dockInitialized === 'boolean'
             ? data.dockInitialized
@@ -769,16 +785,9 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
 
           // Derive visibleTools from cloud dockItems so the two stores stay
           // in sync. Folder items count as visible too.
-          const derivedVisible: (WidgetType | InternalToolType)[] = [];
-          for (const item of cloudDock) {
-            if (item.type === 'tool') {
-              derivedVisible.push(item.toolType);
-            } else {
-              for (const inner of item.folder.items) {
-                derivedVisible.push(inner);
-              }
-            }
-          }
+          const derivedVisible = cloudDock.flatMap((item) =>
+            item.type === 'tool' ? item.toolType : item.folder.items
+          );
           setVisibleTools(derivedVisible);
           localStorage.setItem(
             'classroom_visible_tools',
@@ -796,6 +805,10 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
           setIsDockInitialized(true);
           localStorage.setItem('classroom_dock_initialized', 'true');
         }
+        // Claim the cache for this user so subsequent reloads on the same
+        // device trust the localStorage cache and skip straight to the
+        // cloud-synced state.
+        localStorage.setItem('classroom_dock_cache_uid', user.uid);
         succeeded = true;
       } catch (err) {
         // Leave dockHydrationOk false so we don't push defaults over a real
@@ -859,29 +872,31 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
     };
   }, [user, dockHydrationOk, isDockInitialized, dockItems, libraryOrder]);
 
-  // Reset dock-hydration state on sign-out / user switch so the next sign-in
-  // re-fetches the cloud doc and the previous user's localStorage cache
-  // doesn't leak across accounts on a shared device.
+  // Drop any stale dock localStorage entries left behind by a previous user
+  // on this device. We can't do this in the useState initializers because
+  // they shouldn't have side effects, so this runs once on mount when the
+  // cache uid sentinel doesn't match. Cache invalidation across accounts is
+  // primarily handled by the uid-gated useState initializers above; this
+  // just keeps localStorage tidy. A second user-switch in the same tab
+  // session is impossible because DashboardProvider is conditionally
+  // mounted on `user` (App.tsx) and remounts on each sign-in.
   useEffect(() => {
-    if (!user) {
-      dockHydratedForUidRef.current = null;
-      setDockHydrated(isAuthBypass);
-      setDockHydrationOk(isAuthBypass);
-      if (dockPersistTimerRef.current !== null) {
-        clearTimeout(dockPersistTimerRef.current);
-        dockPersistTimerRef.current = null;
-      }
-      if (!isAuthBypass) {
-        localStorage.removeItem('classroom_dock_items');
-        localStorage.removeItem('classroom_visible_tools');
-        localStorage.removeItem('classroom_dock_initialized');
-        localStorage.removeItem('spartboard_library_order');
-        setDockItems([]);
-        setVisibleTools([]);
-        setIsDockInitialized(false);
-      }
+    if (isAuthBypass) return;
+    if (dockCacheMatchesUser) return;
+    localStorage.removeItem('classroom_dock_items');
+    localStorage.removeItem('classroom_visible_tools');
+    localStorage.removeItem('classroom_dock_initialized');
+    localStorage.removeItem('spartboard_library_order');
+    // Persist the new owner so subsequent reloads from cache succeed. The
+    // hydration/persistence effects below also keep this in sync on every
+    // write — this is just the initial claim.
+    if (user) {
+      localStorage.setItem('classroom_dock_cache_uid', user.uid);
+    } else {
+      localStorage.removeItem('classroom_dock_cache_uid');
     }
-  }, [user]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   // --- ROSTER LOGIC ---
   const {

--- a/context/DashboardContext.tsx
+++ b/context/DashboardContext.tsx
@@ -22,6 +22,8 @@ import {
   FeaturePermission,
   DrawableObject,
 } from '../types';
+import { doc, getDoc, setDoc } from 'firebase/firestore';
+import { db, isAuthBypass } from '../config/firebase';
 import { useAuth } from './useAuth';
 import { mergeWidgetConfig } from '../utils/widgetConfigPersistence';
 import { useFirestore, type SharedBoardSnapshot } from '../hooks/useFirestore';
@@ -206,6 +208,7 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
     selectedBuildings,
     savedWidgetConfigs,
     saveWidgetConfig,
+    profileLoaded,
     remoteControlEnabled: accountRemoteControlEnabled,
   } = useAuth();
   const { driveService, userDomain } = useGoogleDrive();
@@ -421,6 +424,13 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
   // Scoped per-uid so a sign-out → sign-in as a different user re-arms it.
   const migrationStartedForUidRef = useRef<string | null>(null);
 
+  // Cross-device dock sync. `dockItems`, `libraryOrder`, and `isDockInitialized`
+  // are mirrored to `/users/{uid}/userProfile/profile`. `dockHydrated` flips
+  // true once we've read the source-of-truth from Firestore (or determined
+  // there's nothing to read), at which point local mutations may write back.
+  const [dockHydrated, setDockHydrated] = useState(isAuthBypass);
+  const dockHydratedForUidRef = useRef<string | null>(null);
+
   const removeToast = useCallback((id: string) => {
     setToasts((prev) => prev.filter((t) => t.id !== id));
   }, []);
@@ -602,6 +612,9 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
 
   useEffect(() => {
     if (isDockInitialized) return;
+    // Wait for the Firestore hydration to finish so we don't seed default
+    // building tools on top of a cloud-synced dock layout from another device.
+    if (!dockHydrated) return;
 
     // If the user already has a saved dock layout/tool visibility in
     // localStorage, preserve it and mark init complete instead of overwriting
@@ -686,10 +699,142 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
     return () => clearTimeout(initTimer);
   }, [
     isDockInitialized,
+    dockHydrated,
     featurePermissions,
     selectedBuildings,
     getDefaultDockTools,
   ]);
+
+  // Hydrate dock state from Firestore on sign-in. The userProfile doc is the
+  // cross-device source of truth; localStorage is a cache that gives instant
+  // initial paint and survives offline launches. Order of precedence:
+  //   1. Firestore userProfile.dockItems (cloud, authoritative).
+  //   2. localStorage (this device's last-known layout).
+  //   3. Default building seeding via the effect above (truly new users).
+  // Runs once per uid; resets on sign-out / user switch via the cleanup effect below.
+  useEffect(() => {
+    if (isAuthBypass) {
+      setDockHydrated(true);
+      return;
+    }
+    if (!user || !profileLoaded) return;
+    if (dockHydratedForUidRef.current === user.uid) return;
+    dockHydratedForUidRef.current = user.uid;
+
+    let cancelled = false;
+    void (async () => {
+      try {
+        const profileRef = doc(db, 'users', user.uid, 'userProfile', 'profile');
+        const snap = await getDoc(profileRef);
+        if (cancelled) return;
+        const data = snap.exists()
+          ? (snap.data() as Record<string, unknown>)
+          : null;
+
+        const cloudDock =
+          data && Array.isArray(data.dockItems)
+            ? (data.dockItems as DockItem[])
+            : null;
+        const cloudLibrary =
+          data && Array.isArray(data.libraryOrder)
+            ? (data.libraryOrder as (WidgetType | InternalToolType)[])
+            : null;
+        const cloudInitialized =
+          data && typeof data.dockInitialized === 'boolean'
+            ? data.dockInitialized
+            : null;
+
+        if (cloudDock !== null) {
+          // Cloud has authoritative state — overwrite local state and cache.
+          setDockItems(cloudDock);
+          localStorage.setItem(
+            'classroom_dock_items',
+            JSON.stringify(cloudDock)
+          );
+
+          // Derive visibleTools from cloud dockItems so the two stores stay
+          // in sync. Folder items count as visible too.
+          const derivedVisible: (WidgetType | InternalToolType)[] = [];
+          for (const item of cloudDock) {
+            if (item.type === 'tool') {
+              derivedVisible.push(item.toolType);
+            } else {
+              for (const inner of item.folder.items) {
+                derivedVisible.push(inner);
+              }
+            }
+          }
+          setVisibleTools(derivedVisible);
+          localStorage.setItem(
+            'classroom_visible_tools',
+            JSON.stringify(derivedVisible)
+          );
+        }
+        if (cloudLibrary !== null) {
+          setLibraryOrder(cloudLibrary);
+          localStorage.setItem(
+            'spartboard_library_order',
+            JSON.stringify(cloudLibrary)
+          );
+        }
+        if (cloudInitialized === true) {
+          setIsDockInitialized(true);
+          localStorage.setItem('classroom_dock_initialized', 'true');
+        }
+      } catch (err) {
+        console.error('[DashboardContext] Failed to hydrate dock state:', err);
+      } finally {
+        if (!cancelled) setDockHydrated(true);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [user, profileLoaded]);
+
+  // Persist dock state to Firestore whenever it changes locally. Gated on
+  // `dockHydrated` so the initial localStorage-seeded values don't clobber
+  // the cloud doc before we've read it.
+  useEffect(() => {
+    if (isAuthBypass) return;
+    if (!user || !dockHydrated) return;
+    // Only mirror to the cloud once the dock has actually been seeded —
+    // otherwise we'd write empty arrays during the brief pre-seed window.
+    if (!isDockInitialized) return;
+
+    const profileRef = doc(db, 'users', user.uid, 'userProfile', 'profile');
+    void setDoc(
+      profileRef,
+      {
+        dockItems,
+        libraryOrder,
+        dockInitialized: true,
+      },
+      { merge: true }
+    ).catch((err: unknown) => {
+      console.error('[DashboardContext] Failed to persist dock state:', err);
+    });
+  }, [user, dockHydrated, isDockInitialized, dockItems, libraryOrder]);
+
+  // Reset dock-hydration state on sign-out / user switch so the next sign-in
+  // re-fetches the cloud doc and the previous user's localStorage cache
+  // doesn't leak across accounts on a shared device.
+  useEffect(() => {
+    if (!user) {
+      dockHydratedForUidRef.current = null;
+      setDockHydrated(isAuthBypass);
+      if (!isAuthBypass) {
+        localStorage.removeItem('classroom_dock_items');
+        localStorage.removeItem('classroom_visible_tools');
+        localStorage.removeItem('classroom_dock_initialized');
+        localStorage.removeItem('spartboard_library_order');
+        setDockItems([]);
+        setVisibleTools([]);
+        setIsDockInitialized(false);
+      }
+    }
+  }, [user]);
 
   // --- ROSTER LOGIC ---
   const {

--- a/tests/context/AuthContext.setupCompleted.test.tsx
+++ b/tests/context/AuthContext.setupCompleted.test.tsx
@@ -1,0 +1,288 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, act, waitFor } from '@testing-library/react';
+import * as firebaseAuth from 'firebase/auth';
+import * as firestore from 'firebase/firestore';
+import type { User } from 'firebase/auth';
+import { auth } from '@/config/firebase';
+import { AuthProvider } from '@/context/AuthContext';
+import { useAuth } from '@/context/useAuth';
+import type { AuthContextType } from '@/context/AuthContextValue';
+
+/**
+ * Tests for the `setupCompleted` resolution logic that gates the new-user
+ * setup wizard. Covers the in-profile heuristic and the Firestore-based
+ * returning-user probe added to handle legacy users whose profile doc is
+ * missing or pre-dates the wizard.
+ */
+
+vi.mock('firebase/auth', async () => {
+  const actual =
+    await vi.importActual<typeof import('firebase/auth')>('firebase/auth');
+  return {
+    ...actual,
+    onAuthStateChanged: vi.fn(),
+    signInWithPopup: vi.fn(),
+    signInAnonymously: vi.fn(),
+    signOut: vi.fn().mockResolvedValue(undefined),
+  };
+});
+
+vi.mock('firebase/firestore', () => ({
+  doc: vi.fn((_db: unknown, ...segments: string[]) => ({
+    __path: segments.join('/'),
+  })),
+  collection: vi.fn((_db: unknown, ...segments: string[]) => ({
+    __path: segments.join('/'),
+  })),
+  query: vi.fn((collectionRef: unknown) => collectionRef),
+  limit: vi.fn(() => ({})),
+  getDoc: vi.fn(),
+  getDocs: vi.fn(),
+  setDoc: vi.fn().mockResolvedValue(undefined),
+  onSnapshot: vi.fn(() => () => undefined),
+}));
+
+interface DocRef {
+  __path: string;
+}
+
+const ctxHolder: { current: AuthContextType | null } = { current: null };
+
+const Probe: React.FC = () => {
+  const ctx = useAuth();
+  React.useEffect(() => {
+    ctxHolder.current = ctx;
+  });
+  return null;
+};
+
+function getCtx(): AuthContextType {
+  if (!ctxHolder.current) {
+    throw new Error('AuthContext was never captured by the Probe');
+  }
+  return ctxHolder.current;
+}
+
+function buildFakeUser(uid = 'test-uid', email = 'teacher@example.com'): User {
+  return {
+    uid,
+    email,
+    displayName: 'Teacher',
+    photoURL: null,
+    emailVerified: true,
+    isAnonymous: false,
+    providerData: [],
+    refreshToken: '',
+    metadata: {} as User['metadata'],
+    providerId: 'firebase',
+    tenantId: null,
+    delete: vi.fn(),
+    getIdToken: vi.fn().mockResolvedValue('mock-id-token'),
+    getIdTokenResult: vi.fn().mockResolvedValue({
+      claims: {},
+      authTime: '',
+      issuedAtTime: '',
+      expirationTime: '',
+      signInProvider: '',
+      signInSecondFactor: null,
+      token: 'mock-id-token',
+    }),
+    reload: vi.fn(),
+    toJSON: () => ({}),
+    phoneNumber: null,
+  } as unknown as User;
+}
+
+type DocSnap = Awaited<ReturnType<typeof firestore.getDoc>>;
+type QuerySnap = Awaited<ReturnType<typeof firestore.getDocs>>;
+
+interface FakeData {
+  profile: Record<string, unknown> | null;
+  rootUser: Record<string, unknown> | null;
+  hasDashboard: boolean;
+}
+
+function installFirestoreFakes(data: FakeData): void {
+  vi.mocked(firestore.getDoc).mockImplementation((ref) => {
+    const path = (ref as unknown as DocRef).__path ?? '';
+    if (path.endsWith('userProfile/profile')) {
+      if (data.profile === null) {
+        return Promise.resolve({
+          exists: () => false,
+          data: () => undefined,
+        } as unknown as DocSnap);
+      }
+      const captured = data.profile;
+      return Promise.resolve({
+        exists: () => true,
+        data: () => captured,
+      } as unknown as DocSnap);
+    }
+    if (/^users\/[^/]+$/.test(path)) {
+      if (data.rootUser === null) {
+        return Promise.resolve({
+          exists: () => false,
+          data: () => undefined,
+        } as unknown as DocSnap);
+      }
+      const captured = data.rootUser;
+      return Promise.resolve({
+        exists: () => true,
+        data: () => captured,
+      } as unknown as DocSnap);
+    }
+    return Promise.resolve({
+      exists: () => false,
+      data: () => undefined,
+    } as unknown as DocSnap);
+  });
+
+  vi.mocked(firestore.getDocs).mockImplementation(() => {
+    return Promise.resolve({
+      empty: !data.hasDashboard,
+      size: data.hasDashboard ? 1 : 0,
+    } as unknown as QuerySnap);
+  });
+}
+
+async function mountWithFakes(data: FakeData): Promise<void> {
+  ctxHolder.current = null;
+  installFirestoreFakes(data);
+
+  vi.mocked(firestore.onSnapshot).mockImplementation(() => () => undefined);
+
+  const onAuthMock = vi.mocked(firebaseAuth.onAuthStateChanged);
+  onAuthMock.mockImplementation(() => () => undefined);
+
+  render(
+    <AuthProvider>
+      <Probe />
+    </AuthProvider>
+  );
+
+  const lastCall = onAuthMock.mock.calls[onAuthMock.mock.calls.length - 1];
+  if (!lastCall) {
+    throw new Error(
+      'onAuthStateChanged was never called — provider failed to mount'
+    );
+  }
+  const listener = lastCall[1] as (u: User | null) => void;
+  const user = buildFakeUser();
+
+  Object.defineProperty(auth, 'currentUser', {
+    configurable: true,
+    writable: true,
+    value: user,
+  });
+
+  act(() => {
+    listener(user);
+  });
+
+  await waitFor(() => {
+    expect(ctxHolder.current?.profileLoaded).toBe(true);
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  ctxHolder.current = null;
+  window.localStorage.clear();
+  vi.mocked(firestore.setDoc).mockResolvedValue(undefined);
+});
+
+describe('AuthContext — setupCompleted resolution', () => {
+  describe('in-profile heuristic', () => {
+    it('treats explicit setupCompleted: true as completed', async () => {
+      await mountWithFakes({
+        profile: { setupCompleted: true, selectedBuildings: ['high'] },
+        rootUser: null,
+        hasDashboard: false,
+      });
+      expect(getCtx().setupCompleted).toBe(true);
+    });
+
+    it('treats a profile doc missing the setupCompleted field as completed', async () => {
+      await mountWithFakes({
+        profile: { selectedBuildings: ['high'] },
+        rootUser: null,
+        hasDashboard: false,
+      });
+      expect(getCtx().setupCompleted).toBe(true);
+    });
+
+    it('treats setupCompleted: false as completed when selectedBuildings is non-empty (legacy-building broaden)', async () => {
+      await mountWithFakes({
+        profile: {
+          setupCompleted: false,
+          selectedBuildings: ['orono-high-school'],
+        },
+        rootUser: null,
+        hasDashboard: false,
+      });
+      expect(getCtx().setupCompleted).toBe(true);
+    });
+
+    it('keeps setupCompleted: false when profile has it false and no buildings', async () => {
+      await mountWithFakes({
+        profile: { setupCompleted: false, selectedBuildings: [] },
+        rootUser: null,
+        hasDashboard: false,
+      });
+      expect(getCtx().setupCompleted).toBe(false);
+    });
+  });
+
+  describe('Firestore returning-user probe (profile doc missing)', () => {
+    it('marks setupCompleted=true when the root users doc has buildings', async () => {
+      await mountWithFakes({
+        profile: null,
+        rootUser: { buildings: ['orono-high-school'] },
+        hasDashboard: false,
+      });
+      await waitFor(() => {
+        expect(getCtx().setupCompleted).toBe(true);
+      });
+      const writes = vi
+        .mocked(firestore.setDoc)
+        .mock.calls.map((c) => [(c[0] as unknown as DocRef).__path, c[1]]);
+      const profileWrite = writes.find(
+        ([path]) =>
+          typeof path === 'string' && path.endsWith('userProfile/profile')
+      );
+      expect(profileWrite).toBeDefined();
+      const payload = profileWrite?.[1] as Record<string, unknown>;
+      expect(payload.setupCompleted).toBe(true);
+      expect(payload.selectedBuildings).toEqual(['high']);
+    });
+
+    it('marks setupCompleted=true when the user has at least one dashboard', async () => {
+      await mountWithFakes({
+        profile: null,
+        rootUser: null,
+        hasDashboard: true,
+      });
+      await waitFor(() => {
+        expect(getCtx().setupCompleted).toBe(true);
+      });
+    });
+
+    it('leaves setupCompleted=false when there is no prior data anywhere', async () => {
+      await mountWithFakes({
+        profile: null,
+        rootUser: null,
+        hasDashboard: false,
+      });
+      // Give the probe a tick to run and fail to find anything.
+      await waitFor(() => {
+        expect(getCtx().profileLoaded).toBe(true);
+      });
+      // Wait for any pending microtasks from the probe to settle.
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      });
+      expect(getCtx().setupCompleted).toBe(false);
+    });
+  });
+});

--- a/tests/context/AuthContext.setupCompleted.test.tsx
+++ b/tests/context/AuthContext.setupCompleted.test.tsx
@@ -224,6 +224,19 @@ describe('AuthContext — setupCompleted resolution', () => {
       expect(getCtx().setupCompleted).toBe(true);
     });
 
+    it('ignores garbage selectedBuildings entries (null / empty strings) for the broaden heuristic', async () => {
+      await mountWithFakes({
+        profile: {
+          setupCompleted: false,
+          // Mixed garbage — no entry is a non-empty string.
+          selectedBuildings: [null, '', 42],
+        },
+        rootUser: null,
+        hasDashboard: false,
+      });
+      expect(getCtx().setupCompleted).toBe(false);
+    });
+
     it('keeps setupCompleted: false when profile has it false and no buildings', async () => {
       await mountWithFakes({
         profile: { setupCompleted: false, selectedBuildings: [] },

--- a/types.ts
+++ b/types.ts
@@ -4689,6 +4689,22 @@ export interface UserProfile {
    * Per-teacher account-level preference.
    */
   quizMonitorScoreDisplay?: 'percent' | 'count' | 'hidden';
+  /**
+   * The user's dock layout (tools + folders, ordered). Synced across devices.
+   * When absent, the dock is seeded from building-level admin defaults.
+   */
+  dockItems?: DockItem[];
+  /**
+   * Ordered list of all widget/tool types as the user arranged them in the
+   * "More" library. Synced across devices.
+   */
+  libraryOrder?: (WidgetType | InternalToolType)[];
+  /**
+   * True once the dock has been seeded for this user (either via admin
+   * defaults on first sign-in or via wizard completion). Prevents the dock
+   * from being re-seeded on subsequent logins.
+   */
+  dockInitialized?: boolean;
 }
 
 export interface SharedGroup {


### PR DESCRIPTION
## Summary

Fixes two desktop-login UX bugs:

1. **Dock reset on every new device** — every widget icon appeared on the dock instead of the user's curated layout from another device. Dock state (`dockItems`, `libraryOrder`, `dockInitialized`) was stored only in `localStorage` and never mirrored to Firestore.
2. **Setup wizard re-triggered for legacy-building users** — users whose building was selected via the old Sidebar picker (which never wrote `setupCompleted`) or whose data lived only on the root `/users/{uid}` doc were forced through the full 3-step wizard again on a new device.

## What changed

- **Dock sync to Firestore** (`context/DashboardContext.tsx`): new hydrate-on-sign-in and persist-on-change effects that mirror `dockItems`, `libraryOrder`, and `dockInitialized` to `/users/{uid}/userProfile/profile`. `localStorage` stays as a cache for instant cold starts. Cache is cleared on sign-out so it doesn't leak across accounts on a shared device.
- **Schema extension** (`types.ts`): added `dockItems`, `libraryOrder`, `dockInitialized` fields to `UserProfile`.
- **Broadened `setupCompleted` heuristic** (`context/AuthContext.tsx`): a non-empty `selectedBuildings` array now counts as "already set up" — catches legacy users whose buildings predate the wizard.
- **Firestore-based returning-user probe** (`context/AuthContext.tsx`): runs alongside the existing Drive probe. When the profile doc is missing/empty, checks the root `/users/{uid}` doc for `buildings` and `/users/{uid}/dashboards` for any existing dashboard. Either signal flips `setupCompleted=true` (canonicalizing legacy building IDs along the way) and skips the wizard.
- **Tests** (`tests/context/AuthContext.setupCompleted.test.tsx`): new Vitest suite covering all `setupCompleted` resolution paths (in-profile heuristic, returning-user probe, true new user).

Only an account with truly no prior data anywhere (no profile doc, no root buildings, no dashboards, no Drive folder) now sees the setup wizard.

## Test plan

- [ ] **Dock sync, two devices:** sign in on Device A, customize the dock (remove tools, add a folder, reorder), sign out. Sign in on Device B (fresh browser/different machine). Dock matches Device A exactly. Change dock on Device A → refresh Device B → dock updates.
- [ ] **Legacy-building user, profile-doc-exists path:** in Firestore, set a test user's `/users/{uid}/userProfile/profile` to `selectedBuildings: ['orono-high-school']` with `setupCompleted` removed or `false`. Sign in on a fresh browser → wizard does NOT appear, lands on dashboard.
- [ ] **Legacy-building user, profile-doc-missing path:** delete the `userProfile/profile` subdoc, leave `/users/{uid}` with `buildings: ['orono-high-school']` and at least one dashboard. Sign in on a fresh browser → wizard does NOT appear, profile doc is created with `setupCompleted: true` and canonicalized buildings.
- [ ] **True new user:** sign in with a brand-new Google account (no profile, no root buildings, no dashboards, no Drive folder). Wizard SHOULD appear (no regression).
- [ ] **Sign-out hygiene:** on a shared device, user A signs in (custom dock) → signs out → user B signs in → user B does NOT see user A's dock cached locally.
- [ ] `pnpm run validate` passes.

https://claude.ai/code/session_014fZ3ZKZHMJLh2WMCTV48yd

---
_Generated by [Claude Code](https://claude.ai/code/session_014fZ3ZKZHMJLh2WMCTV48yd)_