### PR TITLE
feat(activity-wall): view-only gallery share link with comments + likes

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -60,6 +60,13 @@ const ActivityWallStudentApp = lazy(() =>
     default: module.ActivityWallStudentApp,
   }))
 );
+const ActivityWallGalleryView = lazy(() =>
+  import('./components/activityWall/ActivityWallGalleryView').then(
+    (module) => ({
+      default: module.ActivityWallGalleryView,
+    })
+  )
+);
 const MiniAppStudentApp = lazy(() =>
   import('./components/miniApp/MiniAppStudentApp').then((module) => ({
     default: module.MiniAppStudentApp,
@@ -323,11 +330,22 @@ const App: React.FC = () => {
   }
 
   if (isActivityWallRoute) {
+    // `/activity-wall/gallery/{shareId}` is a view-only "art gallery"
+    // page for an Activity Wall's submissions — distinct from the
+    // student submission flow that owns every other path under
+    // `/activity-wall/...`. Both are unauthenticated entries.
+    const isActivityWallGalleryRoute = pathname.startsWith(
+      '/activity-wall/gallery/'
+    );
     return (
       <DialogProvider>
         <StudentIdleTimeoutGuard />
         <Suspense fallback={<FullPageLoader />}>
-          <ActivityWallStudentApp />
+          {isActivityWallGalleryRoute ? (
+            <ActivityWallGalleryView />
+          ) : (
+            <ActivityWallStudentApp />
+          )}
         </Suspense>
         <DialogContainer />
       </DialogProvider>

--- a/components/activityWall/ActivityWallGalleryView.tsx
+++ b/components/activityWall/ActivityWallGalleryView.tsx
@@ -10,7 +10,7 @@
  * people's work only.
  */
 
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import {
   CornerDownRight,
   Heart,
@@ -125,6 +125,11 @@ export const ActivityWallGalleryView: React.FC = () => {
   const [submissions, setSubmissions] = useState<ActivityWallSubmission[]>([]);
   const [submissionsReady, setSubmissionsReady] = useState(false);
   const [photoUrls, setPhotoUrls] = useState<Record<string, string>>({});
+  // Tracks storage paths we've already kicked off a download for, so the
+  // resolver effect can stay off the `photoUrls` dependency (which it
+  // also writes to). On a fetch failure we drop the entry so the path is
+  // eligible for retry when the next submissions snapshot arrives.
+  const inFlightPhotoPathsRef = useRef<Set<string>>(new Set());
   const [likes, setLikes] = useState<ActivityWallLike[]>([]);
   const [comments, setComments] = useState<ActivityWallComment[]>([]);
 
@@ -282,10 +287,12 @@ export const ActivityWallGalleryView: React.FC = () => {
   useEffect(() => {
     if (state.kind !== 'ready' || state.share.mode !== 'photo') return;
     let cancelled = false;
+    const inFlight = inFlightPhotoPathsRef.current;
     const missing = submissions
-      .filter((s) => s.storagePath && !photoUrls[s.storagePath])
+      .filter((s) => s.storagePath && !inFlight.has(s.storagePath))
       .map((s) => s.storagePath as string);
     if (missing.length === 0) return;
+    missing.forEach((path) => inFlight.add(path));
     void (async () => {
       const resolved: Record<string, string> = {};
       await Promise.all(
@@ -299,6 +306,9 @@ export const ActivityWallGalleryView: React.FC = () => {
               path,
               err
             );
+            // Allow a retry on the next submissions tick — keeping the
+            // path in the in-flight set would silently drop the photo.
+            inFlight.delete(path);
           }
         })
       );
@@ -308,7 +318,7 @@ export const ActivityWallGalleryView: React.FC = () => {
     return () => {
       cancelled = true;
     };
-  }, [submissions, state, photoUrls]);
+  }, [submissions, state]);
 
   if (!shareId || state.kind === 'not-found') {
     return (

--- a/components/activityWall/ActivityWallGalleryView.tsx
+++ b/components/activityWall/ActivityWallGalleryView.tsx
@@ -1,0 +1,811 @@
+/**
+ * Read-only "gallery" view for an Activity Wall session's submissions.
+ * Mounted at `/activity-wall/gallery/{shareId}`.
+ *
+ * The viewer is unauthenticated by design — we sign them in
+ * anonymously via Firebase Auth so Firestore reads work, then load the
+ * `shared_activity_walls/{shareId}` doc to discover which session to
+ * read from plus which interactions (likes / comments / replies) the
+ * teacher enabled. No submission UI is rendered; viewers see other
+ * people's work only.
+ */
+
+import React, { useEffect, useMemo, useState } from 'react';
+import {
+  CornerDownRight,
+  Heart,
+  Loader2,
+  MessageSquare,
+  Send,
+} from 'lucide-react';
+import { signInAnonymously, type User } from 'firebase/auth';
+import {
+  collection,
+  doc,
+  deleteDoc,
+  getDoc,
+  onSnapshot,
+  query,
+  setDoc,
+} from 'firebase/firestore';
+import { getDownloadURL, ref as storageRef } from 'firebase/storage';
+import { auth, db, storage } from '@/config/firebase';
+import type {
+  ActivityWallComment,
+  ActivityWallIdentificationMode,
+  ActivityWallLike,
+  ActivityWallSubmission,
+  SharedActivityWall,
+} from '@/types';
+
+type LoadState =
+  | { kind: 'loading' }
+  | { kind: 'expired' }
+  | { kind: 'revoked' }
+  | { kind: 'not-found' }
+  | { kind: 'ready'; share: SharedActivityWall };
+
+const isShareDoc = (raw: unknown): raw is SharedActivityWall => {
+  if (typeof raw !== 'object' || raw === null) return false;
+  const r = raw as Record<string, unknown>;
+  return (
+    typeof r.id === 'string' &&
+    typeof r.sessionId === 'string' &&
+    typeof r.originalAuthor === 'string' &&
+    typeof r.title === 'string' &&
+    typeof r.prompt === 'string' &&
+    (r.mode === 'text' || r.mode === 'photo') &&
+    (r.identificationMode === 'anonymous' ||
+      r.identificationMode === 'name' ||
+      r.identificationMode === 'pin' ||
+      r.identificationMode === 'name-pin') &&
+    typeof r.allowComments === 'boolean' &&
+    typeof r.allowCommentResponses === 'boolean' &&
+    typeof r.allowLikes === 'boolean' &&
+    typeof r.createdAt === 'number' &&
+    (r.expiresAt === null || typeof r.expiresAt === 'number')
+  );
+};
+
+const isSafeHttpUrl = (url: string): boolean => {
+  try {
+    const parsed = new URL(url);
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:';
+  } catch {
+    return false;
+  }
+};
+
+const buildParticipantLabel = (
+  identificationMode: ActivityWallIdentificationMode,
+  name: string,
+  pin: string
+): string => {
+  if (identificationMode === 'name') return name.trim() || 'Visitor';
+  if (identificationMode === 'pin') return `PIN: ${pin.trim()}`;
+  if (identificationMode === 'name-pin')
+    return `${name.trim()} (${pin.trim()})`;
+  return 'Anonymous';
+};
+
+const useAnonymousFirebaseUser = (): User | null => {
+  const [user, setUser] = useState<User | null>(auth.currentUser);
+  useEffect(() => {
+    let cancelled = false;
+    if (!auth.currentUser) {
+      void signInAnonymously(auth).catch((err) => {
+        console.error('[ActivityWallGallery] Anonymous sign-in failed:', err);
+      });
+    }
+    const unsubscribe = auth.onAuthStateChanged((next) => {
+      if (cancelled) return;
+      setUser(next);
+    });
+    return () => {
+      cancelled = true;
+      unsubscribe();
+    };
+  }, []);
+  return user;
+};
+
+const getShareIdFromPath = (): string | null => {
+  const match = window.location.pathname.match(
+    /^\/activity-wall\/gallery\/([^/?#]+)/
+  );
+  return match ? decodeURIComponent(match[1] ?? '') : null;
+};
+
+export const ActivityWallGalleryView: React.FC = () => {
+  const shareId = useMemo(() => getShareIdFromPath(), []);
+  const viewer = useAnonymousFirebaseUser();
+  const [state, setState] = useState<LoadState>(
+    shareId ? { kind: 'loading' } : { kind: 'not-found' }
+  );
+  const [submissions, setSubmissions] = useState<ActivityWallSubmission[]>([]);
+  const [submissionsReady, setSubmissionsReady] = useState(false);
+  const [photoUrls, setPhotoUrls] = useState<Record<string, string>>({});
+  const [likes, setLikes] = useState<ActivityWallLike[]>([]);
+  const [comments, setComments] = useState<ActivityWallComment[]>([]);
+
+  // Load the share doc once. We don't subscribe — the share toggles are
+  // effectively immutable (teachers re-share rather than edit), and
+  // every additional snapshot multiplies traffic across the gallery's
+  // viewers.
+  useEffect(() => {
+    if (!shareId || !viewer) return;
+    let cancelled = false;
+    void (async () => {
+      try {
+        const snap = await getDoc(doc(db, 'shared_activity_walls', shareId));
+        if (cancelled) return;
+        if (!snap.exists()) {
+          setState({ kind: 'not-found' });
+          return;
+        }
+        const raw = snap.data();
+        if (!isShareDoc(raw)) {
+          setState({ kind: 'not-found' });
+          return;
+        }
+        if (raw.revoked === true) {
+          setState({ kind: 'revoked' });
+          return;
+        }
+        if (raw.expiresAt !== null && raw.expiresAt <= Date.now()) {
+          setState({ kind: 'expired' });
+          return;
+        }
+        setState({ kind: 'ready', share: raw });
+      } catch (err) {
+        console.error('[ActivityWallGallery] Failed to load share doc:', err);
+        if (cancelled) return;
+        setState({ kind: 'not-found' });
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [shareId, viewer]);
+
+  // Subscribe to the underlying session's submissions. Firestore rules
+  // unlock this read path because the parent session has
+  // `publiclyShared: true`.
+  useEffect(() => {
+    if (state.kind !== 'ready' || !viewer) return;
+    const { sessionId } = state.share;
+    const submissionsRef = collection(
+      db,
+      'activity_wall_sessions',
+      sessionId,
+      'submissions'
+    );
+    const unsubscribe = onSnapshot(
+      submissionsRef,
+      (snap) => {
+        const next: ActivityWallSubmission[] = snap.docs.map((d) => {
+          const data = d.data() as Record<string, unknown>;
+          return {
+            id: typeof data.id === 'string' ? data.id : d.id,
+            content: typeof data.content === 'string' ? data.content : '',
+            submittedAt:
+              typeof data.submittedAt === 'number' ? data.submittedAt : 0,
+            status:
+              data.status === 'approved' || data.status === 'pending'
+                ? data.status
+                : 'approved',
+            participantLabel:
+              typeof data.participantLabel === 'string'
+                ? data.participantLabel
+                : undefined,
+            storagePath:
+              typeof data.storagePath === 'string'
+                ? data.storagePath
+                : undefined,
+          };
+        });
+        setSubmissions(next);
+        setSubmissionsReady(true);
+      },
+      (err) => {
+        console.error('[ActivityWallGallery] Submissions snapshot error:', err);
+        setSubmissionsReady(true);
+      }
+    );
+    return unsubscribe;
+  }, [state, viewer]);
+
+  // Subscribe to likes + comments. These live under the share doc itself
+  // so they're scoped to this gallery instance (a teacher resharing the
+  // same session gets a fresh interaction set).
+  useEffect(() => {
+    if (state.kind !== 'ready' || !viewer) return;
+    const shareDocRef = doc(db, 'shared_activity_walls', state.share.id);
+    const unsubLikes = onSnapshot(
+      query(collection(shareDocRef, 'likes')),
+      (snap) => {
+        setLikes(
+          snap.docs.map((d) => {
+            const data = d.data() as Record<string, unknown>;
+            return {
+              id: d.id,
+              submissionId:
+                typeof data.submissionId === 'string' ? data.submissionId : '',
+              authorUid:
+                typeof data.authorUid === 'string' ? data.authorUid : '',
+              createdAt:
+                typeof data.createdAt === 'number' ? data.createdAt : 0,
+            };
+          })
+        );
+      }
+    );
+    const unsubComments = onSnapshot(
+      query(collection(shareDocRef, 'comments')),
+      (snap) => {
+        setComments(
+          snap.docs
+            .map((d) => {
+              const data = d.data() as Record<string, unknown>;
+              return {
+                id: typeof data.id === 'string' ? data.id : d.id,
+                submissionId:
+                  typeof data.submissionId === 'string'
+                    ? data.submissionId
+                    : '',
+                parentCommentId:
+                  typeof data.parentCommentId === 'string'
+                    ? data.parentCommentId
+                    : null,
+                content: typeof data.content === 'string' ? data.content : '',
+                participantLabel:
+                  typeof data.participantLabel === 'string'
+                    ? data.participantLabel
+                    : 'Anonymous',
+                authorUid:
+                  typeof data.authorUid === 'string' ? data.authorUid : '',
+                createdAt:
+                  typeof data.createdAt === 'number' ? data.createdAt : 0,
+              };
+            })
+            .sort((a, b) => a.createdAt - b.createdAt)
+        );
+      }
+    );
+    return () => {
+      unsubLikes();
+      unsubComments();
+    };
+  }, [state, viewer]);
+
+  // Resolve Firebase Storage download URLs for photo submissions.
+  useEffect(() => {
+    if (state.kind !== 'ready' || state.share.mode !== 'photo') return;
+    let cancelled = false;
+    const missing = submissions
+      .filter((s) => s.storagePath && !photoUrls[s.storagePath])
+      .map((s) => s.storagePath as string);
+    if (missing.length === 0) return;
+    void (async () => {
+      const resolved: Record<string, string> = {};
+      await Promise.all(
+        missing.map(async (path) => {
+          try {
+            const url = await getDownloadURL(storageRef(storage, path));
+            resolved[path] = url;
+          } catch (err) {
+            console.warn(
+              '[ActivityWallGallery] Failed to resolve photo URL:',
+              path,
+              err
+            );
+          }
+        })
+      );
+      if (cancelled || Object.keys(resolved).length === 0) return;
+      setPhotoUrls((prev) => ({ ...prev, ...resolved }));
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [submissions, state, photoUrls]);
+
+  if (!shareId || state.kind === 'not-found') {
+    return (
+      <div className="min-h-screen bg-slate-900 text-white flex items-center justify-center p-6 text-center">
+        This gallery isn&apos;t available. The link may be incorrect or has been
+        removed.
+      </div>
+    );
+  }
+
+  if (state.kind === 'expired') {
+    return (
+      <div className="min-h-screen bg-slate-900 text-white flex items-center justify-center p-6 text-center">
+        This gallery link has expired.
+      </div>
+    );
+  }
+
+  if (state.kind === 'revoked') {
+    return (
+      <div className="min-h-screen bg-slate-900 text-white flex items-center justify-center p-6 text-center">
+        This gallery link has been turned off by the teacher.
+      </div>
+    );
+  }
+
+  if (state.kind === 'loading' || !viewer) {
+    return (
+      <div className="min-h-screen bg-slate-100 flex items-center justify-center p-6 text-center text-slate-600">
+        <Loader2 className="w-5 h-5 animate-spin mr-2" />
+        Loading gallery…
+      </div>
+    );
+  }
+
+  return (
+    <GalleryReady
+      share={state.share}
+      viewer={viewer}
+      submissions={submissions.filter((s) => s.status !== 'pending')}
+      submissionsReady={submissionsReady}
+      photoUrls={photoUrls}
+      likes={likes}
+      comments={comments}
+    />
+  );
+};
+
+interface GalleryReadyProps {
+  share: SharedActivityWall;
+  viewer: User;
+  submissions: ActivityWallSubmission[];
+  submissionsReady: boolean;
+  photoUrls: Record<string, string>;
+  likes: ActivityWallLike[];
+  comments: ActivityWallComment[];
+}
+
+const GalleryReady: React.FC<GalleryReadyProps> = ({
+  share,
+  viewer,
+  submissions,
+  submissionsReady,
+  photoUrls,
+  likes,
+  comments,
+}) => {
+  const sortedSubmissions = useMemo(
+    () => [...submissions].sort((a, b) => b.submittedAt - a.submittedAt),
+    [submissions]
+  );
+
+  const likeIndex = useMemo(() => {
+    const map = new Map<string, { count: number; viewerLiked: boolean }>();
+    likes.forEach((like) => {
+      const entry = map.get(like.submissionId) ?? {
+        count: 0,
+        viewerLiked: false,
+      };
+      entry.count += 1;
+      if (like.authorUid === viewer.uid) entry.viewerLiked = true;
+      map.set(like.submissionId, entry);
+    });
+    return map;
+  }, [likes, viewer.uid]);
+
+  const commentsBySubmission = useMemo(() => {
+    const map = new Map<string, ActivityWallComment[]>();
+    comments.forEach((comment) => {
+      const list = map.get(comment.submissionId) ?? [];
+      list.push(comment);
+      map.set(comment.submissionId, list);
+    });
+    return map;
+  }, [comments]);
+
+  return (
+    <div className="min-h-screen bg-slate-100">
+      <header className="bg-brand-blue-primary text-white">
+        <div className="max-w-5xl mx-auto px-5 py-6">
+          <p className="text-xs uppercase tracking-widest font-bold opacity-90">
+            Gallery
+          </p>
+          <h1 className="text-2xl font-black mt-1">{share.title}</h1>
+          {share.prompt && (
+            <p className="mt-2 text-sm opacity-90 max-w-2xl">{share.prompt}</p>
+          )}
+          {share.expiresAt && (
+            <p className="mt-3 text-[11px] uppercase tracking-wider opacity-75">
+              Available until {new Date(share.expiresAt).toLocaleString()}
+            </p>
+          )}
+        </div>
+      </header>
+
+      <main className="max-w-5xl mx-auto px-5 py-6">
+        {!submissionsReady ? (
+          <div className="flex items-center justify-center text-slate-500 py-12">
+            <Loader2 className="w-5 h-5 animate-spin mr-2" />
+            Loading submissions…
+          </div>
+        ) : sortedSubmissions.length === 0 ? (
+          <div className="rounded-2xl border border-dashed border-slate-300 bg-white px-6 py-12 text-center text-slate-500">
+            No submissions yet — check back soon!
+          </div>
+        ) : (
+          <div
+            className={
+              share.mode === 'photo'
+                ? 'grid gap-4 sm:grid-cols-2 lg:grid-cols-3'
+                : 'space-y-4'
+            }
+          >
+            {sortedSubmissions.map((submission) => (
+              <SubmissionCard
+                key={submission.id}
+                share={share}
+                viewer={viewer}
+                submission={submission}
+                photoUrl={
+                  submission.storagePath
+                    ? (photoUrls[submission.storagePath] ?? null)
+                    : isSafeHttpUrl(submission.content)
+                      ? submission.content
+                      : null
+                }
+                likeInfo={
+                  likeIndex.get(submission.id) ?? {
+                    count: 0,
+                    viewerLiked: false,
+                  }
+                }
+                comments={commentsBySubmission.get(submission.id) ?? []}
+              />
+            ))}
+          </div>
+        )}
+      </main>
+    </div>
+  );
+};
+
+interface SubmissionCardProps {
+  share: SharedActivityWall;
+  viewer: User;
+  submission: ActivityWallSubmission;
+  photoUrl: string | null;
+  likeInfo: { count: number; viewerLiked: boolean };
+  comments: ActivityWallComment[];
+}
+
+const SubmissionCard: React.FC<SubmissionCardProps> = ({
+  share,
+  viewer,
+  submission,
+  photoUrl,
+  likeInfo,
+  comments,
+}) => {
+  const topLevel = comments.filter((c) => c.parentCommentId === null);
+  const repliesByParent = useMemo(() => {
+    const map = new Map<string, ActivityWallComment[]>();
+    comments
+      .filter((c) => c.parentCommentId !== null)
+      .forEach((c) => {
+        const list = map.get(c.parentCommentId as string) ?? [];
+        list.push(c);
+        map.set(c.parentCommentId as string, list);
+      });
+    return map;
+  }, [comments]);
+
+  const [likeBusy, setLikeBusy] = useState(false);
+
+  const toggleLike = async () => {
+    if (!share.allowLikes || likeBusy) return;
+    setLikeBusy(true);
+    try {
+      const likeDocId = `${submission.id}__${viewer.uid}`;
+      const likeRef = doc(
+        db,
+        'shared_activity_walls',
+        share.id,
+        'likes',
+        likeDocId
+      );
+      if (likeInfo.viewerLiked) {
+        await deleteDoc(likeRef);
+      } else {
+        await setDoc(likeRef, {
+          id: likeDocId,
+          submissionId: submission.id,
+          authorUid: viewer.uid,
+          createdAt: Date.now(),
+        });
+      }
+    } catch (err) {
+      console.error('[ActivityWallGallery] Like toggle failed:', err);
+    } finally {
+      setLikeBusy(false);
+    }
+  };
+
+  return (
+    <article className="bg-white rounded-2xl shadow-sm border border-slate-200 overflow-hidden flex flex-col">
+      {share.mode === 'photo' && photoUrl ? (
+        <img
+          src={photoUrl}
+          alt={submission.participantLabel ?? 'Submission'}
+          className="w-full aspect-square object-cover bg-slate-100"
+        />
+      ) : share.mode === 'photo' ? (
+        <div className="w-full aspect-square bg-slate-100 flex items-center justify-center text-slate-400 text-sm">
+          Photo unavailable
+        </div>
+      ) : (
+        <div className="p-5 whitespace-pre-wrap text-slate-800 leading-relaxed">
+          {submission.content}
+        </div>
+      )}
+      <div className="p-4 flex items-center justify-between gap-3 border-t border-slate-100">
+        <div className="min-w-0 flex-1">
+          <p className="text-xs font-bold text-slate-700 truncate">
+            {submission.participantLabel ?? 'Anonymous'}
+          </p>
+          <p className="text-[11px] text-slate-400">
+            {new Date(submission.submittedAt).toLocaleString()}
+          </p>
+        </div>
+        {share.allowLikes && (
+          <button
+            type="button"
+            onClick={() => void toggleLike()}
+            disabled={likeBusy}
+            className={`inline-flex items-center gap-1 rounded-full px-3 py-1 text-xs font-bold transition-colors disabled:opacity-50 ${
+              likeInfo.viewerLiked
+                ? 'bg-rose-100 text-rose-600 hover:bg-rose-200'
+                : 'bg-slate-100 text-slate-600 hover:bg-slate-200'
+            }`}
+            aria-pressed={likeInfo.viewerLiked}
+            aria-label={likeInfo.viewerLiked ? 'Unlike' : 'Like'}
+          >
+            <Heart
+              className={`w-4 h-4 ${likeInfo.viewerLiked ? 'fill-rose-500' : ''}`}
+            />
+            {likeInfo.count}
+          </button>
+        )}
+      </div>
+
+      {share.allowComments && (
+        <div className="border-t border-slate-100 bg-slate-50/60 p-4 space-y-3">
+          <div className="flex items-center gap-2 text-xs font-bold text-slate-600 uppercase tracking-wider">
+            <MessageSquare className="w-3.5 h-3.5" />
+            {topLevel.length === 0
+              ? 'No comments yet'
+              : `${topLevel.length} comment${topLevel.length === 1 ? '' : 's'}`}
+          </div>
+          {topLevel.length > 0 && (
+            <ul className="space-y-2">
+              {topLevel.map((comment) => (
+                <CommentNode
+                  key={comment.id}
+                  share={share}
+                  viewer={viewer}
+                  submissionId={submission.id}
+                  comment={comment}
+                  replies={repliesByParent.get(comment.id) ?? []}
+                />
+              ))}
+            </ul>
+          )}
+          <CommentComposer
+            share={share}
+            viewer={viewer}
+            submissionId={submission.id}
+            parentCommentId={null}
+          />
+        </div>
+      )}
+    </article>
+  );
+};
+
+interface CommentNodeProps {
+  share: SharedActivityWall;
+  viewer: User;
+  submissionId: string;
+  comment: ActivityWallComment;
+  replies: ActivityWallComment[];
+}
+
+const CommentNode: React.FC<CommentNodeProps> = ({
+  share,
+  viewer,
+  submissionId,
+  comment,
+  replies,
+}) => {
+  const [replyOpen, setReplyOpen] = useState(false);
+  return (
+    <li className="rounded-lg bg-white border border-slate-200 px-3 py-2">
+      <div className="flex items-baseline justify-between gap-2">
+        <p className="text-xs font-bold text-slate-700 truncate">
+          {comment.participantLabel}
+        </p>
+        <span className="text-[10px] text-slate-400 shrink-0">
+          {new Date(comment.createdAt).toLocaleString()}
+        </span>
+      </div>
+      <p className="mt-1 text-sm text-slate-700 whitespace-pre-wrap">
+        {comment.content}
+      </p>
+      {share.allowCommentResponses && (
+        <button
+          type="button"
+          onClick={() => setReplyOpen((p) => !p)}
+          className="mt-1 inline-flex items-center gap-1 text-[11px] font-semibold text-brand-blue-primary hover:text-brand-blue-dark"
+        >
+          <CornerDownRight className="w-3 h-3" />
+          {replyOpen ? 'Cancel' : 'Reply'}
+        </button>
+      )}
+      {replies.length > 0 && (
+        <ul className="mt-2 ml-4 space-y-2 border-l border-slate-200 pl-3">
+          {replies.map((reply) => (
+            <li key={reply.id} className="text-sm">
+              <div className="flex items-baseline justify-between gap-2">
+                <p className="text-xs font-bold text-slate-700 truncate">
+                  {reply.participantLabel}
+                </p>
+                <span className="text-[10px] text-slate-400 shrink-0">
+                  {new Date(reply.createdAt).toLocaleString()}
+                </span>
+              </div>
+              <p className="mt-0.5 text-slate-700 whitespace-pre-wrap">
+                {reply.content}
+              </p>
+            </li>
+          ))}
+        </ul>
+      )}
+      {replyOpen && share.allowCommentResponses && (
+        <div className="mt-2">
+          <CommentComposer
+            share={share}
+            viewer={viewer}
+            submissionId={submissionId}
+            parentCommentId={comment.id}
+            onDone={() => setReplyOpen(false)}
+            compact
+          />
+        </div>
+      )}
+    </li>
+  );
+};
+
+interface CommentComposerProps {
+  share: SharedActivityWall;
+  viewer: User;
+  submissionId: string;
+  parentCommentId: string | null;
+  compact?: boolean;
+  onDone?: () => void;
+}
+
+const CommentComposer: React.FC<CommentComposerProps> = ({
+  share,
+  viewer,
+  submissionId,
+  parentCommentId,
+  compact = false,
+  onDone,
+}) => {
+  const requiresName =
+    share.identificationMode === 'name' ||
+    share.identificationMode === 'name-pin';
+  const requiresPin =
+    share.identificationMode === 'pin' ||
+    share.identificationMode === 'name-pin';
+
+  const [name, setName] = useState('');
+  const [pin, setPin] = useState('');
+  const [content, setContent] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const onSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    if (submitting) return;
+    if (!content.trim()) return;
+    if (requiresName && !name.trim()) {
+      setError('Please enter your name.');
+      return;
+    }
+    if (requiresPin && !pin.trim()) {
+      setError('Please enter the PIN.');
+      return;
+    }
+    setSubmitting(true);
+    setError(null);
+    try {
+      const commentId = crypto.randomUUID();
+      await setDoc(
+        doc(db, 'shared_activity_walls', share.id, 'comments', commentId),
+        {
+          id: commentId,
+          submissionId,
+          parentCommentId,
+          content: content.trim().slice(0, 2000),
+          participantLabel: buildParticipantLabel(
+            share.identificationMode,
+            name,
+            pin
+          ),
+          authorUid: viewer.uid,
+          createdAt: Date.now(),
+        }
+      );
+      setContent('');
+      setName('');
+      setPin('');
+      onDone?.();
+    } catch (err) {
+      console.error('[ActivityWallGallery] Comment submit failed:', err);
+      setError('Could not post your comment. Please try again.');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <form onSubmit={onSubmit} className={compact ? 'space-y-2' : 'space-y-2'}>
+      {(requiresName || requiresPin) && (
+        <div className="grid grid-cols-2 gap-2">
+          {requiresName && (
+            <input
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="Your name"
+              className="w-full px-2 py-1 border border-slate-300 rounded-md text-xs"
+            />
+          )}
+          {requiresPin && (
+            <input
+              value={pin}
+              onChange={(e) => setPin(e.target.value)}
+              placeholder="PIN"
+              className="w-full px-2 py-1 border border-slate-300 rounded-md text-xs"
+            />
+          )}
+        </div>
+      )}
+      <div className="flex items-end gap-2">
+        <textarea
+          value={content}
+          onChange={(e) => setContent(e.target.value)}
+          rows={compact ? 2 : 2}
+          maxLength={2000}
+          placeholder={parentCommentId ? 'Write a reply…' : 'Leave a comment…'}
+          className="flex-1 px-2 py-1 border border-slate-300 rounded-md text-sm resize-none focus:outline-none focus:ring-2 focus:ring-brand-blue-primary/40"
+        />
+        <button
+          type="submit"
+          disabled={submitting || !content.trim()}
+          className="shrink-0 inline-flex items-center gap-1 rounded-md bg-brand-blue-primary px-3 py-2 text-xs font-bold text-white hover:bg-brand-blue-dark transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          {submitting ? (
+            <Loader2 className="w-3.5 h-3.5 animate-spin" />
+          ) : (
+            <Send className="w-3.5 h-3.5" />
+          )}
+          Post
+        </button>
+      </div>
+      {error && <p className="text-[11px] text-red-600">{error}</p>}
+    </form>
+  );
+};

--- a/components/widgets/ActivityWall/ShareModal.tsx
+++ b/components/widgets/ActivityWall/ShareModal.tsx
@@ -1,0 +1,437 @@
+/**
+ * Teacher-facing modal that publishes an Activity Wall session as a
+ * view-only gallery. The teacher picks which gallery interactions to
+ * enable (comments, replies, likes) and an optional expiration date.
+ *
+ * On submit we:
+ *   1. Flip `publiclyShared: true` onto `activity_wall_sessions/{sessionId}`
+ *      so the read-side Firestore + Storage rules unlock for anonymous
+ *      gallery viewers.
+ *   2. Write a `shared_activity_walls/{shareId}` doc carrying the gallery
+ *      toggles + snapshot of title/prompt/identificationMode.
+ *   3. Surface the resulting URL with a copy-to-clipboard button — matches
+ *      the ShareLinkCreatorModal UX so the experience feels consistent.
+ *
+ * View-only philosophy: the gallery never lets viewers submit new
+ * activity entries; new posts only happen through the original student
+ * URL. Comments + likes are layered on top via subcollections under the
+ * share doc so deleting the share also cleans them up.
+ */
+
+import React, { useEffect, useState } from 'react';
+import {
+  Check,
+  Copy,
+  ExternalLink,
+  MessageCircle,
+  MessageSquare,
+  Heart,
+  CalendarClock,
+  X,
+} from 'lucide-react';
+import { doc, setDoc, updateDoc } from 'firebase/firestore';
+import { Modal } from '@/components/common/Modal';
+import { useDashboard } from '@/context/useDashboard';
+import { db } from '@/config/firebase';
+import type {
+  ActivityWallActivity,
+  ActivityWallIdentificationMode,
+  SharedActivityWall,
+} from '@/types';
+
+interface ActivityWallShareModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  activity: ActivityWallActivity | null;
+  sessionId: string | null;
+  teacherUid: string | null;
+}
+
+interface ToggleRowProps {
+  id: string;
+  Icon: React.ComponentType<{ className?: string }>;
+  title: string;
+  body: string;
+  checked: boolean;
+  disabled?: boolean;
+  onChange: (next: boolean) => void;
+}
+
+const ToggleRow: React.FC<ToggleRowProps> = ({
+  id,
+  Icon,
+  title,
+  body,
+  checked,
+  disabled = false,
+  onChange,
+}) => {
+  return (
+    <label
+      htmlFor={id}
+      className={`flex items-start gap-3 rounded-xl border px-4 py-3 transition-all ${
+        disabled
+          ? 'opacity-50 cursor-not-allowed border-slate-200 bg-slate-50/60'
+          : checked
+            ? 'border-brand-blue-primary bg-brand-blue-lighter/20 cursor-pointer'
+            : 'border-slate-200 bg-white hover:border-brand-blue-primary cursor-pointer'
+      }`}
+    >
+      <div
+        className={`shrink-0 w-9 h-9 rounded-lg flex items-center justify-center ${
+          checked
+            ? 'bg-brand-blue-primary text-white'
+            : 'bg-slate-100 text-slate-500'
+        }`}
+      >
+        <Icon className="w-4 h-4" />
+      </div>
+      <div className="flex-1 min-w-0">
+        <h3 className="font-bold text-slate-900 text-sm">{title}</h3>
+        <p className="mt-0.5 text-xs text-slate-600 leading-relaxed">{body}</p>
+      </div>
+      <input
+        id={id}
+        type="checkbox"
+        className="mt-1 h-4 w-4 accent-brand-blue-primary cursor-pointer disabled:cursor-not-allowed"
+        checked={checked}
+        disabled={disabled}
+        onChange={(e) => onChange(e.target.checked)}
+      />
+    </label>
+  );
+};
+
+const identificationModeBlurb = (
+  mode: ActivityWallIdentificationMode
+): string => {
+  switch (mode) {
+    case 'anonymous':
+      return 'Viewers can comment anonymously — same as how students submitted.';
+    case 'name':
+      return 'Viewers will be asked for their name before posting a comment.';
+    case 'pin':
+      return 'Viewers will be asked for a PIN before posting a comment.';
+    case 'name-pin':
+      return 'Viewers will be asked for their name and PIN before posting a comment.';
+  }
+};
+
+export const ActivityWallShareModal: React.FC<ActivityWallShareModalProps> = ({
+  isOpen,
+  onClose,
+  activity,
+  sessionId,
+  teacherUid,
+}) => {
+  const { addToast } = useDashboard();
+  const [allowComments, setAllowComments] = useState(true);
+  const [allowCommentResponses, setAllowCommentResponses] = useState(true);
+  const [allowLikes, setAllowLikes] = useState(true);
+  const [enableExpiration, setEnableExpiration] = useState(false);
+  const [expiresAtInput, setExpiresAtInput] = useState('');
+  const [creating, setCreating] = useState(false);
+  const [createdUrl, setCreatedUrl] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    setAllowComments(true);
+    setAllowCommentResponses(true);
+    setAllowLikes(true);
+    setEnableExpiration(false);
+    setExpiresAtInput('');
+    setCreating(false);
+    setCreatedUrl(null);
+    setCopied(false);
+    setError(null);
+  }, [isOpen, activity?.id]);
+
+  if (!isOpen) return null;
+
+  const handleCreate = async () => {
+    if (creating) return;
+    if (!activity || !sessionId || !teacherUid) {
+      setError(
+        'Start the activity first — there are no submissions to share yet.'
+      );
+      return;
+    }
+
+    let expiresAt: number | null = null;
+    if (enableExpiration) {
+      if (!expiresAtInput) {
+        setError('Pick an expiration date or turn off expiration.');
+        return;
+      }
+      const parsed = new Date(expiresAtInput).getTime();
+      if (Number.isNaN(parsed)) {
+        setError("That expiration date doesn't look right.");
+        return;
+      }
+      if (parsed <= Date.now()) {
+        setError('Expiration must be in the future.');
+        return;
+      }
+      expiresAt = parsed;
+    }
+
+    setCreating(true);
+    setError(null);
+
+    try {
+      const shareId = crypto.randomUUID();
+      const sharedDoc: SharedActivityWall = {
+        id: shareId,
+        sessionId,
+        originalAuthor: teacherUid,
+        title: activity.title,
+        prompt: activity.prompt,
+        mode: activity.mode,
+        identificationMode: activity.identificationMode,
+        allowComments,
+        allowCommentResponses: allowComments && allowCommentResponses,
+        allowLikes,
+        expiresAt,
+        createdAt: Date.now(),
+      };
+
+      // Unlock viewer reads first — if this fails we don't write the share
+      // doc, which would otherwise produce a working link that returns
+      // permission-denied on every photo/submission read.
+      await updateDoc(doc(db, 'activity_wall_sessions', sessionId), {
+        publiclyShared: true,
+      });
+
+      await setDoc(
+        doc(db, 'shared_activity_walls', shareId),
+        sharedDoc as unknown as Record<string, unknown>
+      );
+
+      const url = `${window.location.origin}/activity-wall/gallery/${shareId}`;
+      setCreatedUrl(url);
+      try {
+        await navigator.clipboard.writeText(url);
+        setCopied(true);
+      } catch {
+        // Clipboard may be blocked — user can still copy manually below.
+      }
+    } catch (err) {
+      console.error('[ActivityWallShareModal] Failed to create share:', err);
+      setError('Could not create the gallery link. Please try again.');
+      addToast('Failed to create gallery link.', 'error');
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  const handleCopy = async () => {
+    if (!createdUrl) return;
+    try {
+      await navigator.clipboard.writeText(createdUrl);
+      setCopied(true);
+      addToast('Gallery link copied!', 'success');
+    } catch {
+      addToast(
+        'Could not copy automatically — select the link to copy manually.',
+        'error'
+      );
+    }
+  };
+
+  // <input type="datetime-local"> wants a value in the form 'YYYY-MM-DDTHH:mm';
+  // surface today as the floor so teachers don't accidentally pick a
+  // past timestamp.
+  const minExpirationInput = (() => {
+    const now = new Date();
+    const tzOffsetMs = now.getTimezoneOffset() * 60_000;
+    return new Date(now.getTime() - tzOffsetMs).toISOString().slice(0, 16);
+  })();
+
+  return (
+    <Modal
+      isOpen
+      onClose={onClose}
+      ariaLabel="Create gallery share link"
+      maxWidth="max-w-md"
+      contentClassName=""
+      customHeader={
+        <div className="flex items-start justify-between px-5 pt-5 pb-3 border-b border-slate-100">
+          <div className="flex items-start gap-3">
+            <div className="shrink-0 w-9 h-9 rounded-lg bg-brand-blue-lighter/40 text-brand-blue-primary flex items-center justify-center">
+              <ExternalLink className="w-5 h-5" />
+            </div>
+            <div>
+              <h2 className="text-base font-bold text-slate-900">
+                {createdUrl
+                  ? 'Gallery link ready'
+                  : 'Share submissions gallery'}
+              </h2>
+              <p className="text-xs text-slate-500 mt-0.5 truncate max-w-[20rem]">
+                {activity?.title ?? 'Activity Wall'}
+              </p>
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close"
+            className="shrink-0 rounded-lg p-1 text-slate-400 hover:bg-slate-100 hover:text-slate-700 transition-colors cursor-pointer"
+          >
+            <X className="w-5 h-5" />
+          </button>
+        </div>
+      }
+    >
+      {createdUrl ? (
+        <div className="px-5 pb-5 pt-4 space-y-4">
+          <p className="text-xs text-slate-600">
+            Anyone with this link can view the submissions gallery — no sign-in
+            required.
+          </p>
+          <div className="flex items-center gap-2 rounded-lg border border-slate-200 bg-slate-50 px-3 py-2">
+            <input
+              type="text"
+              readOnly
+              value={createdUrl}
+              onFocus={(e) => e.currentTarget.select()}
+              className="flex-1 bg-transparent text-xs text-slate-700 truncate focus:outline-none"
+              aria-label="Share link URL"
+            />
+            <button
+              type="button"
+              onClick={() => void handleCopy()}
+              className={`shrink-0 inline-flex items-center gap-1 rounded-md px-2.5 py-1 text-xs font-bold transition-colors cursor-pointer ${
+                copied
+                  ? 'bg-emerald-100 text-emerald-700'
+                  : 'bg-brand-blue-primary text-white hover:bg-brand-blue-dark'
+              }`}
+            >
+              {copied ? (
+                <>
+                  <Check className="w-3.5 h-3.5" />
+                  Copied
+                </>
+              ) : (
+                <>
+                  <Copy className="w-3.5 h-3.5" />
+                  Copy
+                </>
+              )}
+            </button>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="w-full rounded-lg bg-slate-100 hover:bg-slate-200 text-slate-700 font-bold text-sm py-2 transition-colors cursor-pointer"
+          >
+            Done
+          </button>
+        </div>
+      ) : (
+        <div className="px-5 pb-5 pt-4 space-y-3">
+          <p className="text-xs text-slate-600">
+            Anyone with the link can view this activity&apos;s submissions
+            gallery. Pick what gallery viewers can do.
+          </p>
+
+          <ToggleRow
+            id="aw-share-allow-likes"
+            Icon={Heart}
+            title="Allow likes"
+            body="Viewers can give each submission a heart."
+            checked={allowLikes}
+            onChange={setAllowLikes}
+          />
+
+          <ToggleRow
+            id="aw-share-allow-comments"
+            Icon={MessageSquare}
+            title="Allow comments"
+            body={
+              activity
+                ? identificationModeBlurb(activity.identificationMode)
+                : 'Viewers can leave a comment on each submission.'
+            }
+            checked={allowComments}
+            onChange={(next) => {
+              setAllowComments(next);
+              if (!next) setAllowCommentResponses(false);
+            }}
+          />
+
+          <ToggleRow
+            id="aw-share-allow-replies"
+            Icon={MessageCircle}
+            title="Allow comment replies"
+            body="Viewers can reply to other people's comments."
+            checked={allowComments && allowCommentResponses}
+            disabled={!allowComments}
+            onChange={setAllowCommentResponses}
+          />
+
+          <div
+            className={`rounded-xl border bg-white px-4 py-3 transition-colors ${
+              enableExpiration
+                ? 'border-brand-blue-primary'
+                : 'border-slate-200'
+            }`}
+          >
+            <label
+              htmlFor="aw-share-enable-expiration"
+              className="flex items-start gap-3 cursor-pointer"
+            >
+              <div
+                className={`shrink-0 w-9 h-9 rounded-lg flex items-center justify-center ${
+                  enableExpiration
+                    ? 'bg-brand-blue-primary text-white'
+                    : 'bg-slate-100 text-slate-500'
+                }`}
+              >
+                <CalendarClock className="w-4 h-4" />
+              </div>
+              <div className="flex-1 min-w-0">
+                <h3 className="font-bold text-slate-900 text-sm">
+                  Set link expiration
+                </h3>
+                <p className="mt-0.5 text-xs text-slate-600 leading-relaxed">
+                  The link stops working after this date.
+                </p>
+              </div>
+              <input
+                id="aw-share-enable-expiration"
+                type="checkbox"
+                className="mt-1 h-4 w-4 accent-brand-blue-primary cursor-pointer"
+                checked={enableExpiration}
+                onChange={(e) => setEnableExpiration(e.target.checked)}
+              />
+            </label>
+            {enableExpiration && (
+              <div className="mt-3 pl-12">
+                <input
+                  type="datetime-local"
+                  value={expiresAtInput}
+                  min={minExpirationInput}
+                  onChange={(e) => setExpiresAtInput(e.target.value)}
+                  className="w-full rounded-md border border-slate-300 bg-white px-2 py-1.5 text-xs text-slate-700 focus:outline-none focus:ring-2 focus:ring-brand-blue-primary/40"
+                />
+              </div>
+            )}
+          </div>
+
+          {error && <p className="text-xs text-red-600 font-medium">{error}</p>}
+
+          <button
+            type="button"
+            onClick={() => void handleCreate()}
+            disabled={creating || !activity || !sessionId || !teacherUid}
+            className="w-full rounded-lg bg-brand-blue-primary hover:bg-brand-blue-dark text-white font-bold text-sm py-2 transition-colors disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer"
+          >
+            {creating ? 'Creating link…' : 'Create gallery link'}
+          </button>
+        </div>
+      )}
+    </Modal>
+  );
+};

--- a/components/widgets/ActivityWall/Widget.tsx
+++ b/components/widgets/ActivityWall/Widget.tsx
@@ -13,6 +13,7 @@ import {
   Pencil,
   Plus,
   QrCode,
+  Share2,
   Trash2,
   Users,
 } from 'lucide-react';
@@ -51,6 +52,7 @@ import {
 import { useGoogleDrive } from '@/hooks/useGoogleDrive';
 import { useActivityWallLibrary } from '@/hooks/useActivityWallLibrary';
 import { Modal } from '@/components/common/Modal';
+import { ActivityWallShareModal } from './ShareModal';
 
 const encodeActivityData = (
   activity: ActivityWallActivity,
@@ -318,6 +320,7 @@ export const ActivityWallWidget: React.FC<{ widget: WidgetData }> = ({
     null
   );
   const [showLiveView, setShowLiveView] = useState(false);
+  const [isShareModalOpen, setIsShareModalOpen] = useState(false);
 
   // ─── ClassLink target-class fetch (Phase 3D) ────────────────────────────
   // Teacher's ClassLink classes (if provisioned). Fetched once per widget
@@ -1734,7 +1737,7 @@ export const ActivityWallWidget: React.FC<{ widget: WidgetData }> = ({
             )}
 
             <div
-              className="grid grid-cols-2"
+              className="grid grid-cols-3"
               style={{ gap: 'min(6px, 1.8cqmin)' }}
             >
               <button
@@ -1772,6 +1775,26 @@ export const ActivityWallWidget: React.FC<{ widget: WidgetData }> = ({
                   }}
                 />
                 Pop-out QR
+              </button>
+              <button
+                type="button"
+                onClick={() => setIsShareModalOpen(true)}
+                disabled={!activeActivity || !activeSessionId || !user}
+                className="rounded-xl bg-violet-600 text-white font-bold flex items-center justify-center disabled:opacity-50"
+                style={{
+                  gap: 'min(6px, 1.8cqmin)',
+                  padding: 'min(8px, 2cqmin)',
+                  fontSize: 'min(11px, 3.8cqmin)',
+                }}
+                title="Share a view-only gallery of submissions"
+              >
+                <Share2
+                  style={{
+                    width: 'min(14px, 4cqmin)',
+                    height: 'min(14px, 4cqmin)',
+                  }}
+                />
+                Share gallery
               </button>
             </div>
 
@@ -2070,6 +2093,13 @@ export const ActivityWallWidget: React.FC<{ widget: WidgetData }> = ({
           </div>
         )}
       </Modal>
+      <ActivityWallShareModal
+        isOpen={isShareModalOpen}
+        onClose={() => setIsShareModalOpen(false)}
+        activity={activeActivity}
+        sessionId={activeSessionId}
+        teacherUid={user?.uid ?? null}
+      />
     </>
   );
 };

--- a/components/widgets/ActivityWall/Widget.tsx
+++ b/components/widgets/ActivityWall/Widget.tsx
@@ -52,7 +52,7 @@ import {
 import { useGoogleDrive } from '@/hooks/useGoogleDrive';
 import { useActivityWallLibrary } from '@/hooks/useActivityWallLibrary';
 import { Modal } from '@/components/common/Modal';
-import { ActivityWallShareModal } from './ShareModal';
+import { ActivityWallShareModal } from '@/components/widgets/ActivityWall/ShareModal';
 
 const encodeActivityData = (
   activity: ActivityWallActivity,

--- a/firestore.rules
+++ b/firestore.rules
@@ -784,6 +784,92 @@ service cloud.firestore {
         (resource.data.get('originalAuthor', null) == request.auth.uid || isAdmin());
     }
 
+    // Shared Activity Wall galleries — view-only published copy of an
+    // Activity Wall session's submissions. The teacher creates the share
+    // doc; viewers land at /activity-wall/gallery/{shareId} and read the
+    // doc to discover the underlying sessionId + gallery toggles
+    // (allowComments / allowCommentResponses / allowLikes). Reads are
+    // permitted for any signed-in caller (including anonymous gallery
+    // viewers) so an unauthenticated student can open the link.
+    match /shared_activity_walls/{shareId} {
+      allow read: if request.auth != null;
+
+      allow create: if request.auth != null &&
+        request.auth.token.firebase.sign_in_provider != 'anonymous' &&
+        request.resource.data.originalAuthor == request.auth.uid &&
+        request.resource.data.id is string &&
+        request.resource.data.sessionId is string &&
+        request.resource.data.title is string &&
+        request.resource.data.prompt is string &&
+        request.resource.data.mode in ['text', 'photo'] &&
+        request.resource.data.identificationMode in ['anonymous', 'name', 'pin', 'name-pin'] &&
+        request.resource.data.allowComments is bool &&
+        request.resource.data.allowCommentResponses is bool &&
+        request.resource.data.allowLikes is bool &&
+        request.resource.data.createdAt is int &&
+        (request.resource.data.expiresAt == null || request.resource.data.expiresAt is int);
+
+      allow update, delete: if request.auth != null &&
+        (resource.data.get('originalAuthor', null) == request.auth.uid || isAdmin());
+
+      // Comments — any authenticated viewer (incl. anonymous) can create.
+      // Parent share must allow comments; replies (parentCommentId != null)
+      // additionally require allowCommentResponses == true.
+      match /comments/{commentId} {
+        function parentShare() {
+          return get(/databases/$(database)/documents/shared_activity_walls/$(shareId)).data;
+        }
+        allow read: if request.auth != null;
+        allow create: if request.auth != null &&
+          parentShare().get('revoked', false) == false &&
+          parentShare().get('allowComments', false) == true &&
+          (
+            request.resource.data.get('parentCommentId', null) == null ||
+            parentShare().get('allowCommentResponses', false) == true
+          ) &&
+          request.resource.data.id is string &&
+          request.resource.data.submissionId is string &&
+          request.resource.data.content is string &&
+          request.resource.data.content.size() > 0 &&
+          request.resource.data.content.size() <= 2000 &&
+          request.resource.data.participantLabel is string &&
+          request.resource.data.authorUid == request.auth.uid &&
+          request.resource.data.createdAt is int;
+        // Commenter can delete their own comment; share owner / admin can
+        // moderate any comment.
+        allow delete: if request.auth != null &&
+          (
+            resource.data.get('authorUid', null) == request.auth.uid ||
+            parentShare().get('originalAuthor', null) == request.auth.uid ||
+            isAdmin()
+          );
+        allow update: if false;
+      }
+
+      // Likes — deterministic doc id (`{submissionId}__{authorUid}`) caps
+      // each viewer to one like per submission. Toggling off is a delete.
+      match /likes/{likeId} {
+        function parentShare() {
+          return get(/databases/$(database)/documents/shared_activity_walls/$(shareId)).data;
+        }
+        allow read: if request.auth != null;
+        allow create: if request.auth != null &&
+          parentShare().get('revoked', false) == false &&
+          parentShare().get('allowLikes', false) == true &&
+          request.resource.data.submissionId is string &&
+          request.resource.data.authorUid == request.auth.uid &&
+          request.resource.data.createdAt is int &&
+          likeId == request.resource.data.submissionId + '__' + request.auth.uid;
+        allow delete: if request.auth != null &&
+          (
+            resource.data.get('authorUid', null) == request.auth.uid ||
+            parentShare().get('originalAuthor', null) == request.auth.uid ||
+            isAdmin()
+          );
+        allow update: if false;
+      }
+    }
+
     // Synced quiz groups — canonical, mutable record of a quiz shared
     // across PLC peers. The group id is an unguessable v4 UUID, so reads
     // are gated only on auth (matches the `shared_assignments` posture).
@@ -2515,8 +2601,16 @@ service cloud.firestore {
           !('driveFileId' in request.resource.data) &&
           !('archiveError' in request.resource.data) &&
           !('archivedAt' in request.resource.data);
-        // Only teacher and admins can read or delete submissions.
-        allow read, delete: if request.auth != null &&
+        // Only teacher and admins can read or delete submissions —
+        // EXCEPT when the parent session has been published as a view-only
+        // gallery (`publiclyShared == true`), in which case any
+        // authenticated caller (including anonymous gallery viewers) can
+        // read the approved submissions. Delete remains teacher/admin-only.
+        allow read: if request.auth != null &&
+                            (isAdmin() ||
+                             sessionId.matches(request.auth.uid + '_.*') ||
+                             get(/databases/$(database)/documents/activity_wall_sessions/$(sessionId)).data.get('publiclyShared', false) == true);
+        allow delete: if request.auth != null &&
                             (isAdmin() || sessionId.matches(request.auth.uid + '_.*'));
         allow update: if request.auth != null &&
                             (isAdmin() || sessionId.matches(request.auth.uid + '_.*')) &&

--- a/storage.rules
+++ b/storage.rules
@@ -115,10 +115,19 @@ service firebase.storage {
     // these rules, so <img> display works without SDK read permission.
     // SDK-level read/list is limited to the owning teacher and admins.
     match /activity_wall_photos/{sessionId}/{fileName} {
-      // Only the teacher who owns the session (sessionId prefix = their uid) or an admin
-      // can list/download via the SDK.
+      // Owning teacher / admin can list/download via the SDK. Additionally,
+      // when the session has been published as a view-only gallery
+      // (`publiclyShared == true` on the parent session doc), any
+      // authenticated caller — including anonymous gallery viewers — can
+      // download a photo so the gallery page can render it.
       allow read: if request.auth != null &&
-        (isAdmin() || sessionId.matches(request.auth.uid + '_.*'));
+        (
+          isAdmin() ||
+          sessionId.matches(request.auth.uid + '_.*') ||
+          firestore.get(
+            /databases/(default)/documents/activity_wall_sessions/$(sessionId)
+          ).data.get('publiclyShared', false) == true
+        );
       // Any authenticated user (including anonymous students) may upload a new image,
       // but only if the target session exists in Firestore (guards against DoS uploads
       // to guessed sessionIds).

--- a/types.ts
+++ b/types.ts
@@ -1267,6 +1267,86 @@ export interface ActivityWallSession {
   updatedAt: number;
   /** See `ActivityWallActivity.classId` — omitted for code/PIN-only launches. */
   classId?: string;
+  /**
+   * When `true`, a `shared_activity_walls/{shareId}` doc references this
+   * session as a view-only gallery. The Firestore rules use this flag to
+   * unlock anonymous read access on submissions so gallery viewers can see
+   * the work without joining the live session.
+   */
+  publiclyShared?: boolean;
+}
+
+/**
+ * Firestore document shape for `shared_activity_walls/{shareId}`.
+ *
+ * Created by the teacher when they want to publish a view-only gallery
+ * link to the submissions of an existing Activity Wall session. The
+ * gallery viewer is unauthenticated (uses anonymous Firebase Auth) so the
+ * doc carries everything the viewer needs to render the page without
+ * touching the owning user's `/users/{uid}/...` collections.
+ */
+export interface SharedActivityWall {
+  id: string;
+  /** Activity wall session id (`${teacherUid}_${activityId}`). */
+  sessionId: string;
+  /** Teacher uid — used to gate update/delete. */
+  originalAuthor: string;
+  /** Snapshot of the activity's title at share time. */
+  title: string;
+  /** Snapshot of the activity's prompt at share time. */
+  prompt: string;
+  mode: ActivityWallMode;
+  /**
+   * Inherited from the parent activity. Gallery commenters identify
+   * themselves the same way the original submitters did.
+   */
+  identificationMode: ActivityWallIdentificationMode;
+  allowComments: boolean;
+  allowCommentResponses: boolean;
+  allowLikes: boolean;
+  /** Millis epoch — `null` means the link never expires. */
+  expiresAt: number | null;
+  createdAt: number;
+  /**
+   * Teacher can revoke a link without deleting the doc, which keeps
+   * existing comments/likes intact in case they want to re-enable later.
+   */
+  revoked?: boolean;
+}
+
+/**
+ * Comment posted by a gallery viewer on a specific submission.
+ * Lives at `shared_activity_walls/{shareId}/comments/{commentId}`.
+ */
+export interface ActivityWallComment {
+  id: string;
+  /** Submission this comment is attached to. */
+  submissionId: string;
+  /**
+   * Parent comment id when this is a reply, or `null` for a top-level
+   * comment. Replies are only allowed when the share has
+   * `allowCommentResponses === true`.
+   */
+  parentCommentId: string | null;
+  content: string;
+  /** Display label built from the share's `identificationMode`. */
+  participantLabel: string;
+  /** Firebase auth uid of the commenter (anonymous uid for viewers). */
+  authorUid: string;
+  createdAt: number;
+}
+
+/**
+ * Like on a submission within a shared gallery. Lives at
+ * `shared_activity_walls/{shareId}/likes/{submissionId}__{authorUid}` —
+ * the deterministic doc id enforces one-like-per-viewer-per-submission
+ * without a separate counter document.
+ */
+export interface ActivityWallLike {
+  id: string;
+  submissionId: string;
+  authorUid: string;
+  createdAt: number;
 }
 
 export interface WebcamConfig {


### PR DESCRIPTION
## Summary

Adds a teacher-controlled, view-only "gallery" share link for an Activity Wall session's submissions so students (and parents) can browse each other's work without joining the live session. When the teacher creates the link they pick which gallery interactions to enable, and the resulting URL works for anyone — no sign-in required.

## What's new

**Share modal** (new `Share gallery` button on the Activity Wall widget, sits beside the existing Copy link / Pop-out QR buttons):

- **Allow Likes** — viewers can heart each submission (one like per viewer per submission, deterministic doc id enforces it).
- **Allow Comments** — viewers can leave a comment on each submission. Identification matches the activity's existing `identificationMode` (anonymous / name / PIN / name+PIN).
- **Allow Comment Replies** — gated on Allow Comments; when on, viewers can reply to top-level comments.
- **Set Link Expiration** — optional `datetime-local` picker. Past that point the gallery refuses to render.

**Gallery view** at `/activity-wall/gallery/{shareId}`:

- Unauthenticated entry — viewers are signed in anonymously, same pattern as the existing student app.
- Photo activities render as a responsive grid; text activities render as a stacked feed.
- Each card surfaces the submitter label, like count, and a comment thread (with reply nesting when enabled).
- Honors `expiresAt`, a `revoked` flag, and missing/invalid share docs with friendly empty states.

## Architecture

- **New Firestore collection** `shared_activity_walls/{shareId}` carries the toggles plus a snapshot of `title`, `prompt`, `mode`, and `identificationMode`. Comments live at `.../comments/{commentId}` and likes at `.../likes/{submissionId}__{authorUid}` so deleting the share doc cleans up its interactions.
- **`publiclyShared: true` flag** on `activity_wall_sessions/{sessionId}` unlocks read access to the session's submissions + Storage photos for any authenticated caller (incl. anonymous gallery viewers). Submission writes/deletes remain teacher-only.
- **Rules** validate every field on share / comment / like creates, gate comment replies on `allowCommentResponses`, and let the share owner moderate any comment or like.

## Files

- `types.ts` — `SharedActivityWall`, `ActivityWallComment`, `ActivityWallLike`, `publiclyShared` on `ActivityWallSession`.
- `firestore.rules` — `shared_activity_walls/**` block + `publiclyShared` branch on the existing submissions read rule.
- `storage.rules` — gallery viewers can download `activity_wall_photos/{sessionId}/**` when the session is publicly shared.
- `components/widgets/ActivityWall/ShareModal.tsx` — new modal, follows the `ShareLinkCreatorModal` UX pattern.
- `components/widgets/ActivityWall/Widget.tsx` — `Share gallery` button + modal wiring.
- `components/activityWall/ActivityWallGalleryView.tsx` — new view-only gallery page.
- `App.tsx` — `/activity-wall/gallery/{shareId}` route under the existing Activity Wall router.

## Test plan

- [ ] Deploy updated Firestore + Storage rules to the dev project.
- [ ] Teacher: start an Activity Wall session, submit a couple of text + photo entries, click **Share gallery**, toggle each option, create a link.
- [ ] Open the link in a private window — confirm photos render, text submissions render, no submit UI is shown.
- [ ] Toggle likes off → confirm heart button is absent. Toggle comments off → confirm thread + composer absent. Toggle replies off but comments on → confirm "Reply" buttons hidden.
- [ ] Set an expiration 1 min in the future → wait → confirm gallery shows the expired state.
- [ ] As a viewer with `identificationMode: 'name-pin'`, confirm name + PIN are required before posting a comment.
- [ ] Like a submission, refresh, confirm the heart persists and count is correct. Click again to unlike.
- [ ] Confirm anonymous viewers cannot read submissions of a session that isn't `publiclyShared` (regression check).
- [ ] Run `pnpm run validate` — type-check + lint + format-check + tests all clean (verified locally, 2394 tests pass).

https://claude.ai/code/session_015ScCN9sf7c5EPKrFxvg4S3

---
_Generated by [Claude Code](https://claude.ai/code/session_015ScCN9sf7c5EPKrFxvg4S3)_