### PR TITLE
fix(dock): preserve legacy localStorage on Firestore-sync migration

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -60,6 +60,13 @@ const ActivityWallStudentApp = lazy(() =>
     default: module.ActivityWallStudentApp,
   }))
 );
+const ActivityWallGalleryView = lazy(() =>
+  import('./components/activityWall/ActivityWallGalleryView').then(
+    (module) => ({
+      default: module.ActivityWallGalleryView,
+    })
+  )
+);
 const MiniAppStudentApp = lazy(() =>
   import('./components/miniApp/MiniAppStudentApp').then((module) => ({
     default: module.MiniAppStudentApp,
@@ -323,11 +330,22 @@ const App: React.FC = () => {
   }
 
   if (isActivityWallRoute) {
+    // `/activity-wall/gallery/{shareId}` is a view-only "art gallery"
+    // page for an Activity Wall's submissions — distinct from the
+    // student submission flow that owns every other path under
+    // `/activity-wall/...`. Both are unauthenticated entries.
+    const isActivityWallGalleryRoute = pathname.startsWith(
+      '/activity-wall/gallery/'
+    );
     return (
       <DialogProvider>
         <StudentIdleTimeoutGuard />
         <Suspense fallback={<FullPageLoader />}>
-          <ActivityWallStudentApp />
+          {isActivityWallGalleryRoute ? (
+            <ActivityWallGalleryView />
+          ) : (
+            <ActivityWallStudentApp />
+          )}
         </Suspense>
         <DialogContainer />
       </DialogProvider>

--- a/components/activityWall/ActivityWallGalleryView.tsx
+++ b/components/activityWall/ActivityWallGalleryView.tsx
@@ -10,7 +10,7 @@
  * people's work only.
  */
 
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import {
   CornerDownRight,
   Heart,
@@ -125,6 +125,11 @@ export const ActivityWallGalleryView: React.FC = () => {
   const [submissions, setSubmissions] = useState<ActivityWallSubmission[]>([]);
   const [submissionsReady, setSubmissionsReady] = useState(false);
   const [photoUrls, setPhotoUrls] = useState<Record<string, string>>({});
+  // Tracks storage paths we've already kicked off a download for, so the
+  // resolver effect can stay off the `photoUrls` dependency (which it
+  // also writes to). On a fetch failure we drop the entry so the path is
+  // eligible for retry when the next submissions snapshot arrives.
+  const inFlightPhotoPathsRef = useRef<Set<string>>(new Set());
   const [likes, setLikes] = useState<ActivityWallLike[]>([]);
   const [comments, setComments] = useState<ActivityWallComment[]>([]);
 
@@ -282,10 +287,12 @@ export const ActivityWallGalleryView: React.FC = () => {
   useEffect(() => {
     if (state.kind !== 'ready' || state.share.mode !== 'photo') return;
     let cancelled = false;
+    const inFlight = inFlightPhotoPathsRef.current;
     const missing = submissions
-      .filter((s) => s.storagePath && !photoUrls[s.storagePath])
+      .filter((s) => s.storagePath && !inFlight.has(s.storagePath))
       .map((s) => s.storagePath as string);
     if (missing.length === 0) return;
+    missing.forEach((path) => inFlight.add(path));
     void (async () => {
       const resolved: Record<string, string> = {};
       await Promise.all(
@@ -299,6 +306,9 @@ export const ActivityWallGalleryView: React.FC = () => {
               path,
               err
             );
+            // Allow a retry on the next submissions tick — keeping the
+            // path in the in-flight set would silently drop the photo.
+            inFlight.delete(path);
           }
         })
       );
@@ -308,7 +318,7 @@ export const ActivityWallGalleryView: React.FC = () => {
     return () => {
       cancelled = true;
     };
-  }, [submissions, state, photoUrls]);
+  }, [submissions, state]);
 
   if (!shareId || state.kind === 'not-found') {
     return (

--- a/components/activityWall/ActivityWallGalleryView.tsx
+++ b/components/activityWall/ActivityWallGalleryView.tsx
@@ -1,0 +1,811 @@
+/**
+ * Read-only "gallery" view for an Activity Wall session's submissions.
+ * Mounted at `/activity-wall/gallery/{shareId}`.
+ *
+ * The viewer is unauthenticated by design — we sign them in
+ * anonymously via Firebase Auth so Firestore reads work, then load the
+ * `shared_activity_walls/{shareId}` doc to discover which session to
+ * read from plus which interactions (likes / comments / replies) the
+ * teacher enabled. No submission UI is rendered; viewers see other
+ * people's work only.
+ */
+
+import React, { useEffect, useMemo, useState } from 'react';
+import {
+  CornerDownRight,
+  Heart,
+  Loader2,
+  MessageSquare,
+  Send,
+} from 'lucide-react';
+import { signInAnonymously, type User } from 'firebase/auth';
+import {
+  collection,
+  doc,
+  deleteDoc,
+  getDoc,
+  onSnapshot,
+  query,
+  setDoc,
+} from 'firebase/firestore';
+import { getDownloadURL, ref as storageRef } from 'firebase/storage';
+import { auth, db, storage } from '@/config/firebase';
+import type {
+  ActivityWallComment,
+  ActivityWallIdentificationMode,
+  ActivityWallLike,
+  ActivityWallSubmission,
+  SharedActivityWall,
+} from '@/types';
+
+type LoadState =
+  | { kind: 'loading' }
+  | { kind: 'expired' }
+  | { kind: 'revoked' }
+  | { kind: 'not-found' }
+  | { kind: 'ready'; share: SharedActivityWall };
+
+const isShareDoc = (raw: unknown): raw is SharedActivityWall => {
+  if (typeof raw !== 'object' || raw === null) return false;
+  const r = raw as Record<string, unknown>;
+  return (
+    typeof r.id === 'string' &&
+    typeof r.sessionId === 'string' &&
+    typeof r.originalAuthor === 'string' &&
+    typeof r.title === 'string' &&
+    typeof r.prompt === 'string' &&
+    (r.mode === 'text' || r.mode === 'photo') &&
+    (r.identificationMode === 'anonymous' ||
+      r.identificationMode === 'name' ||
+      r.identificationMode === 'pin' ||
+      r.identificationMode === 'name-pin') &&
+    typeof r.allowComments === 'boolean' &&
+    typeof r.allowCommentResponses === 'boolean' &&
+    typeof r.allowLikes === 'boolean' &&
+    typeof r.createdAt === 'number' &&
+    (r.expiresAt === null || typeof r.expiresAt === 'number')
+  );
+};
+
+const isSafeHttpUrl = (url: string): boolean => {
+  try {
+    const parsed = new URL(url);
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:';
+  } catch {
+    return false;
+  }
+};
+
+const buildParticipantLabel = (
+  identificationMode: ActivityWallIdentificationMode,
+  name: string,
+  pin: string
+): string => {
+  if (identificationMode === 'name') return name.trim() || 'Visitor';
+  if (identificationMode === 'pin') return `PIN: ${pin.trim()}`;
+  if (identificationMode === 'name-pin')
+    return `${name.trim()} (${pin.trim()})`;
+  return 'Anonymous';
+};
+
+const useAnonymousFirebaseUser = (): User | null => {
+  const [user, setUser] = useState<User | null>(auth.currentUser);
+  useEffect(() => {
+    let cancelled = false;
+    if (!auth.currentUser) {
+      void signInAnonymously(auth).catch((err) => {
+        console.error('[ActivityWallGallery] Anonymous sign-in failed:', err);
+      });
+    }
+    const unsubscribe = auth.onAuthStateChanged((next) => {
+      if (cancelled) return;
+      setUser(next);
+    });
+    return () => {
+      cancelled = true;
+      unsubscribe();
+    };
+  }, []);
+  return user;
+};
+
+const getShareIdFromPath = (): string | null => {
+  const match = window.location.pathname.match(
+    /^\/activity-wall\/gallery\/([^/?#]+)/
+  );
+  return match ? decodeURIComponent(match[1] ?? '') : null;
+};
+
+export const ActivityWallGalleryView: React.FC = () => {
+  const shareId = useMemo(() => getShareIdFromPath(), []);
+  const viewer = useAnonymousFirebaseUser();
+  const [state, setState] = useState<LoadState>(
+    shareId ? { kind: 'loading' } : { kind: 'not-found' }
+  );
+  const [submissions, setSubmissions] = useState<ActivityWallSubmission[]>([]);
+  const [submissionsReady, setSubmissionsReady] = useState(false);
+  const [photoUrls, setPhotoUrls] = useState<Record<string, string>>({});
+  const [likes, setLikes] = useState<ActivityWallLike[]>([]);
+  const [comments, setComments] = useState<ActivityWallComment[]>([]);
+
+  // Load the share doc once. We don't subscribe — the share toggles are
+  // effectively immutable (teachers re-share rather than edit), and
+  // every additional snapshot multiplies traffic across the gallery's
+  // viewers.
+  useEffect(() => {
+    if (!shareId || !viewer) return;
+    let cancelled = false;
+    void (async () => {
+      try {
+        const snap = await getDoc(doc(db, 'shared_activity_walls', shareId));
+        if (cancelled) return;
+        if (!snap.exists()) {
+          setState({ kind: 'not-found' });
+          return;
+        }
+        const raw = snap.data();
+        if (!isShareDoc(raw)) {
+          setState({ kind: 'not-found' });
+          return;
+        }
+        if (raw.revoked === true) {
+          setState({ kind: 'revoked' });
+          return;
+        }
+        if (raw.expiresAt !== null && raw.expiresAt <= Date.now()) {
+          setState({ kind: 'expired' });
+          return;
+        }
+        setState({ kind: 'ready', share: raw });
+      } catch (err) {
+        console.error('[ActivityWallGallery] Failed to load share doc:', err);
+        if (cancelled) return;
+        setState({ kind: 'not-found' });
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [shareId, viewer]);
+
+  // Subscribe to the underlying session's submissions. Firestore rules
+  // unlock this read path because the parent session has
+  // `publiclyShared: true`.
+  useEffect(() => {
+    if (state.kind !== 'ready' || !viewer) return;
+    const { sessionId } = state.share;
+    const submissionsRef = collection(
+      db,
+      'activity_wall_sessions',
+      sessionId,
+      'submissions'
+    );
+    const unsubscribe = onSnapshot(
+      submissionsRef,
+      (snap) => {
+        const next: ActivityWallSubmission[] = snap.docs.map((d) => {
+          const data = d.data() as Record<string, unknown>;
+          return {
+            id: typeof data.id === 'string' ? data.id : d.id,
+            content: typeof data.content === 'string' ? data.content : '',
+            submittedAt:
+              typeof data.submittedAt === 'number' ? data.submittedAt : 0,
+            status:
+              data.status === 'approved' || data.status === 'pending'
+                ? data.status
+                : 'approved',
+            participantLabel:
+              typeof data.participantLabel === 'string'
+                ? data.participantLabel
+                : undefined,
+            storagePath:
+              typeof data.storagePath === 'string'
+                ? data.storagePath
+                : undefined,
+          };
+        });
+        setSubmissions(next);
+        setSubmissionsReady(true);
+      },
+      (err) => {
+        console.error('[ActivityWallGallery] Submissions snapshot error:', err);
+        setSubmissionsReady(true);
+      }
+    );
+    return unsubscribe;
+  }, [state, viewer]);
+
+  // Subscribe to likes + comments. These live under the share doc itself
+  // so they're scoped to this gallery instance (a teacher resharing the
+  // same session gets a fresh interaction set).
+  useEffect(() => {
+    if (state.kind !== 'ready' || !viewer) return;
+    const shareDocRef = doc(db, 'shared_activity_walls', state.share.id);
+    const unsubLikes = onSnapshot(
+      query(collection(shareDocRef, 'likes')),
+      (snap) => {
+        setLikes(
+          snap.docs.map((d) => {
+            const data = d.data() as Record<string, unknown>;
+            return {
+              id: d.id,
+              submissionId:
+                typeof data.submissionId === 'string' ? data.submissionId : '',
+              authorUid:
+                typeof data.authorUid === 'string' ? data.authorUid : '',
+              createdAt:
+                typeof data.createdAt === 'number' ? data.createdAt : 0,
+            };
+          })
+        );
+      }
+    );
+    const unsubComments = onSnapshot(
+      query(collection(shareDocRef, 'comments')),
+      (snap) => {
+        setComments(
+          snap.docs
+            .map((d) => {
+              const data = d.data() as Record<string, unknown>;
+              return {
+                id: typeof data.id === 'string' ? data.id : d.id,
+                submissionId:
+                  typeof data.submissionId === 'string'
+                    ? data.submissionId
+                    : '',
+                parentCommentId:
+                  typeof data.parentCommentId === 'string'
+                    ? data.parentCommentId
+                    : null,
+                content: typeof data.content === 'string' ? data.content : '',
+                participantLabel:
+                  typeof data.participantLabel === 'string'
+                    ? data.participantLabel
+                    : 'Anonymous',
+                authorUid:
+                  typeof data.authorUid === 'string' ? data.authorUid : '',
+                createdAt:
+                  typeof data.createdAt === 'number' ? data.createdAt : 0,
+              };
+            })
+            .sort((a, b) => a.createdAt - b.createdAt)
+        );
+      }
+    );
+    return () => {
+      unsubLikes();
+      unsubComments();
+    };
+  }, [state, viewer]);
+
+  // Resolve Firebase Storage download URLs for photo submissions.
+  useEffect(() => {
+    if (state.kind !== 'ready' || state.share.mode !== 'photo') return;
+    let cancelled = false;
+    const missing = submissions
+      .filter((s) => s.storagePath && !photoUrls[s.storagePath])
+      .map((s) => s.storagePath as string);
+    if (missing.length === 0) return;
+    void (async () => {
+      const resolved: Record<string, string> = {};
+      await Promise.all(
+        missing.map(async (path) => {
+          try {
+            const url = await getDownloadURL(storageRef(storage, path));
+            resolved[path] = url;
+          } catch (err) {
+            console.warn(
+              '[ActivityWallGallery] Failed to resolve photo URL:',
+              path,
+              err
+            );
+          }
+        })
+      );
+      if (cancelled || Object.keys(resolved).length === 0) return;
+      setPhotoUrls((prev) => ({ ...prev, ...resolved }));
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [submissions, state, photoUrls]);
+
+  if (!shareId || state.kind === 'not-found') {
+    return (
+      <div className="min-h-screen bg-slate-900 text-white flex items-center justify-center p-6 text-center">
+        This gallery isn&apos;t available. The link may be incorrect or has been
+        removed.
+      </div>
+    );
+  }
+
+  if (state.kind === 'expired') {
+    return (
+      <div className="min-h-screen bg-slate-900 text-white flex items-center justify-center p-6 text-center">
+        This gallery link has expired.
+      </div>
+    );
+  }
+
+  if (state.kind === 'revoked') {
+    return (
+      <div className="min-h-screen bg-slate-900 text-white flex items-center justify-center p-6 text-center">
+        This gallery link has been turned off by the teacher.
+      </div>
+    );
+  }
+
+  if (state.kind === 'loading' || !viewer) {
+    return (
+      <div className="min-h-screen bg-slate-100 flex items-center justify-center p-6 text-center text-slate-600">
+        <Loader2 className="w-5 h-5 animate-spin mr-2" />
+        Loading gallery…
+      </div>
+    );
+  }
+
+  return (
+    <GalleryReady
+      share={state.share}
+      viewer={viewer}
+      submissions={submissions.filter((s) => s.status !== 'pending')}
+      submissionsReady={submissionsReady}
+      photoUrls={photoUrls}
+      likes={likes}
+      comments={comments}
+    />
+  );
+};
+
+interface GalleryReadyProps {
+  share: SharedActivityWall;
+  viewer: User;
+  submissions: ActivityWallSubmission[];
+  submissionsReady: boolean;
+  photoUrls: Record<string, string>;
+  likes: ActivityWallLike[];
+  comments: ActivityWallComment[];
+}
+
+const GalleryReady: React.FC<GalleryReadyProps> = ({
+  share,
+  viewer,
+  submissions,
+  submissionsReady,
+  photoUrls,
+  likes,
+  comments,
+}) => {
+  const sortedSubmissions = useMemo(
+    () => [...submissions].sort((a, b) => b.submittedAt - a.submittedAt),
+    [submissions]
+  );
+
+  const likeIndex = useMemo(() => {
+    const map = new Map<string, { count: number; viewerLiked: boolean }>();
+    likes.forEach((like) => {
+      const entry = map.get(like.submissionId) ?? {
+        count: 0,
+        viewerLiked: false,
+      };
+      entry.count += 1;
+      if (like.authorUid === viewer.uid) entry.viewerLiked = true;
+      map.set(like.submissionId, entry);
+    });
+    return map;
+  }, [likes, viewer.uid]);
+
+  const commentsBySubmission = useMemo(() => {
+    const map = new Map<string, ActivityWallComment[]>();
+    comments.forEach((comment) => {
+      const list = map.get(comment.submissionId) ?? [];
+      list.push(comment);
+      map.set(comment.submissionId, list);
+    });
+    return map;
+  }, [comments]);
+
+  return (
+    <div className="min-h-screen bg-slate-100">
+      <header className="bg-brand-blue-primary text-white">
+        <div className="max-w-5xl mx-auto px-5 py-6">
+          <p className="text-xs uppercase tracking-widest font-bold opacity-90">
+            Gallery
+          </p>
+          <h1 className="text-2xl font-black mt-1">{share.title}</h1>
+          {share.prompt && (
+            <p className="mt-2 text-sm opacity-90 max-w-2xl">{share.prompt}</p>
+          )}
+          {share.expiresAt && (
+            <p className="mt-3 text-[11px] uppercase tracking-wider opacity-75">
+              Available until {new Date(share.expiresAt).toLocaleString()}
+            </p>
+          )}
+        </div>
+      </header>
+
+      <main className="max-w-5xl mx-auto px-5 py-6">
+        {!submissionsReady ? (
+          <div className="flex items-center justify-center text-slate-500 py-12">
+            <Loader2 className="w-5 h-5 animate-spin mr-2" />
+            Loading submissions…
+          </div>
+        ) : sortedSubmissions.length === 0 ? (
+          <div className="rounded-2xl border border-dashed border-slate-300 bg-white px-6 py-12 text-center text-slate-500">
+            No submissions yet — check back soon!
+          </div>
+        ) : (
+          <div
+            className={
+              share.mode === 'photo'
+                ? 'grid gap-4 sm:grid-cols-2 lg:grid-cols-3'
+                : 'space-y-4'
+            }
+          >
+            {sortedSubmissions.map((submission) => (
+              <SubmissionCard
+                key={submission.id}
+                share={share}
+                viewer={viewer}
+                submission={submission}
+                photoUrl={
+                  submission.storagePath
+                    ? (photoUrls[submission.storagePath] ?? null)
+                    : isSafeHttpUrl(submission.content)
+                      ? submission.content
+                      : null
+                }
+                likeInfo={
+                  likeIndex.get(submission.id) ?? {
+                    count: 0,
+                    viewerLiked: false,
+                  }
+                }
+                comments={commentsBySubmission.get(submission.id) ?? []}
+              />
+            ))}
+          </div>
+        )}
+      </main>
+    </div>
+  );
+};
+
+interface SubmissionCardProps {
+  share: SharedActivityWall;
+  viewer: User;
+  submission: ActivityWallSubmission;
+  photoUrl: string | null;
+  likeInfo: { count: number; viewerLiked: boolean };
+  comments: ActivityWallComment[];
+}
+
+const SubmissionCard: React.FC<SubmissionCardProps> = ({
+  share,
+  viewer,
+  submission,
+  photoUrl,
+  likeInfo,
+  comments,
+}) => {
+  const topLevel = comments.filter((c) => c.parentCommentId === null);
+  const repliesByParent = useMemo(() => {
+    const map = new Map<string, ActivityWallComment[]>();
+    comments
+      .filter((c) => c.parentCommentId !== null)
+      .forEach((c) => {
+        const list = map.get(c.parentCommentId as string) ?? [];
+        list.push(c);
+        map.set(c.parentCommentId as string, list);
+      });
+    return map;
+  }, [comments]);
+
+  const [likeBusy, setLikeBusy] = useState(false);
+
+  const toggleLike = async () => {
+    if (!share.allowLikes || likeBusy) return;
+    setLikeBusy(true);
+    try {
+      const likeDocId = `${submission.id}__${viewer.uid}`;
+      const likeRef = doc(
+        db,
+        'shared_activity_walls',
+        share.id,
+        'likes',
+        likeDocId
+      );
+      if (likeInfo.viewerLiked) {
+        await deleteDoc(likeRef);
+      } else {
+        await setDoc(likeRef, {
+          id: likeDocId,
+          submissionId: submission.id,
+          authorUid: viewer.uid,
+          createdAt: Date.now(),
+        });
+      }
+    } catch (err) {
+      console.error('[ActivityWallGallery] Like toggle failed:', err);
+    } finally {
+      setLikeBusy(false);
+    }
+  };
+
+  return (
+    <article className="bg-white rounded-2xl shadow-sm border border-slate-200 overflow-hidden flex flex-col">
+      {share.mode === 'photo' && photoUrl ? (
+        <img
+          src={photoUrl}
+          alt={submission.participantLabel ?? 'Submission'}
+          className="w-full aspect-square object-cover bg-slate-100"
+        />
+      ) : share.mode === 'photo' ? (
+        <div className="w-full aspect-square bg-slate-100 flex items-center justify-center text-slate-400 text-sm">
+          Photo unavailable
+        </div>
+      ) : (
+        <div className="p-5 whitespace-pre-wrap text-slate-800 leading-relaxed">
+          {submission.content}
+        </div>
+      )}
+      <div className="p-4 flex items-center justify-between gap-3 border-t border-slate-100">
+        <div className="min-w-0 flex-1">
+          <p className="text-xs font-bold text-slate-700 truncate">
+            {submission.participantLabel ?? 'Anonymous'}
+          </p>
+          <p className="text-[11px] text-slate-400">
+            {new Date(submission.submittedAt).toLocaleString()}
+          </p>
+        </div>
+        {share.allowLikes && (
+          <button
+            type="button"
+            onClick={() => void toggleLike()}
+            disabled={likeBusy}
+            className={`inline-flex items-center gap-1 rounded-full px-3 py-1 text-xs font-bold transition-colors disabled:opacity-50 ${
+              likeInfo.viewerLiked
+                ? 'bg-rose-100 text-rose-600 hover:bg-rose-200'
+                : 'bg-slate-100 text-slate-600 hover:bg-slate-200'
+            }`}
+            aria-pressed={likeInfo.viewerLiked}
+            aria-label={likeInfo.viewerLiked ? 'Unlike' : 'Like'}
+          >
+            <Heart
+              className={`w-4 h-4 ${likeInfo.viewerLiked ? 'fill-rose-500' : ''}`}
+            />
+            {likeInfo.count}
+          </button>
+        )}
+      </div>
+
+      {share.allowComments && (
+        <div className="border-t border-slate-100 bg-slate-50/60 p-4 space-y-3">
+          <div className="flex items-center gap-2 text-xs font-bold text-slate-600 uppercase tracking-wider">
+            <MessageSquare className="w-3.5 h-3.5" />
+            {topLevel.length === 0
+              ? 'No comments yet'
+              : `${topLevel.length} comment${topLevel.length === 1 ? '' : 's'}`}
+          </div>
+          {topLevel.length > 0 && (
+            <ul className="space-y-2">
+              {topLevel.map((comment) => (
+                <CommentNode
+                  key={comment.id}
+                  share={share}
+                  viewer={viewer}
+                  submissionId={submission.id}
+                  comment={comment}
+                  replies={repliesByParent.get(comment.id) ?? []}
+                />
+              ))}
+            </ul>
+          )}
+          <CommentComposer
+            share={share}
+            viewer={viewer}
+            submissionId={submission.id}
+            parentCommentId={null}
+          />
+        </div>
+      )}
+    </article>
+  );
+};
+
+interface CommentNodeProps {
+  share: SharedActivityWall;
+  viewer: User;
+  submissionId: string;
+  comment: ActivityWallComment;
+  replies: ActivityWallComment[];
+}
+
+const CommentNode: React.FC<CommentNodeProps> = ({
+  share,
+  viewer,
+  submissionId,
+  comment,
+  replies,
+}) => {
+  const [replyOpen, setReplyOpen] = useState(false);
+  return (
+    <li className="rounded-lg bg-white border border-slate-200 px-3 py-2">
+      <div className="flex items-baseline justify-between gap-2">
+        <p className="text-xs font-bold text-slate-700 truncate">
+          {comment.participantLabel}
+        </p>
+        <span className="text-[10px] text-slate-400 shrink-0">
+          {new Date(comment.createdAt).toLocaleString()}
+        </span>
+      </div>
+      <p className="mt-1 text-sm text-slate-700 whitespace-pre-wrap">
+        {comment.content}
+      </p>
+      {share.allowCommentResponses && (
+        <button
+          type="button"
+          onClick={() => setReplyOpen((p) => !p)}
+          className="mt-1 inline-flex items-center gap-1 text-[11px] font-semibold text-brand-blue-primary hover:text-brand-blue-dark"
+        >
+          <CornerDownRight className="w-3 h-3" />
+          {replyOpen ? 'Cancel' : 'Reply'}
+        </button>
+      )}
+      {replies.length > 0 && (
+        <ul className="mt-2 ml-4 space-y-2 border-l border-slate-200 pl-3">
+          {replies.map((reply) => (
+            <li key={reply.id} className="text-sm">
+              <div className="flex items-baseline justify-between gap-2">
+                <p className="text-xs font-bold text-slate-700 truncate">
+                  {reply.participantLabel}
+                </p>
+                <span className="text-[10px] text-slate-400 shrink-0">
+                  {new Date(reply.createdAt).toLocaleString()}
+                </span>
+              </div>
+              <p className="mt-0.5 text-slate-700 whitespace-pre-wrap">
+                {reply.content}
+              </p>
+            </li>
+          ))}
+        </ul>
+      )}
+      {replyOpen && share.allowCommentResponses && (
+        <div className="mt-2">
+          <CommentComposer
+            share={share}
+            viewer={viewer}
+            submissionId={submissionId}
+            parentCommentId={comment.id}
+            onDone={() => setReplyOpen(false)}
+            compact
+          />
+        </div>
+      )}
+    </li>
+  );
+};
+
+interface CommentComposerProps {
+  share: SharedActivityWall;
+  viewer: User;
+  submissionId: string;
+  parentCommentId: string | null;
+  compact?: boolean;
+  onDone?: () => void;
+}
+
+const CommentComposer: React.FC<CommentComposerProps> = ({
+  share,
+  viewer,
+  submissionId,
+  parentCommentId,
+  compact = false,
+  onDone,
+}) => {
+  const requiresName =
+    share.identificationMode === 'name' ||
+    share.identificationMode === 'name-pin';
+  const requiresPin =
+    share.identificationMode === 'pin' ||
+    share.identificationMode === 'name-pin';
+
+  const [name, setName] = useState('');
+  const [pin, setPin] = useState('');
+  const [content, setContent] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const onSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    if (submitting) return;
+    if (!content.trim()) return;
+    if (requiresName && !name.trim()) {
+      setError('Please enter your name.');
+      return;
+    }
+    if (requiresPin && !pin.trim()) {
+      setError('Please enter the PIN.');
+      return;
+    }
+    setSubmitting(true);
+    setError(null);
+    try {
+      const commentId = crypto.randomUUID();
+      await setDoc(
+        doc(db, 'shared_activity_walls', share.id, 'comments', commentId),
+        {
+          id: commentId,
+          submissionId,
+          parentCommentId,
+          content: content.trim().slice(0, 2000),
+          participantLabel: buildParticipantLabel(
+            share.identificationMode,
+            name,
+            pin
+          ),
+          authorUid: viewer.uid,
+          createdAt: Date.now(),
+        }
+      );
+      setContent('');
+      setName('');
+      setPin('');
+      onDone?.();
+    } catch (err) {
+      console.error('[ActivityWallGallery] Comment submit failed:', err);
+      setError('Could not post your comment. Please try again.');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <form onSubmit={onSubmit} className={compact ? 'space-y-2' : 'space-y-2'}>
+      {(requiresName || requiresPin) && (
+        <div className="grid grid-cols-2 gap-2">
+          {requiresName && (
+            <input
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="Your name"
+              className="w-full px-2 py-1 border border-slate-300 rounded-md text-xs"
+            />
+          )}
+          {requiresPin && (
+            <input
+              value={pin}
+              onChange={(e) => setPin(e.target.value)}
+              placeholder="PIN"
+              className="w-full px-2 py-1 border border-slate-300 rounded-md text-xs"
+            />
+          )}
+        </div>
+      )}
+      <div className="flex items-end gap-2">
+        <textarea
+          value={content}
+          onChange={(e) => setContent(e.target.value)}
+          rows={compact ? 2 : 2}
+          maxLength={2000}
+          placeholder={parentCommentId ? 'Write a reply…' : 'Leave a comment…'}
+          className="flex-1 px-2 py-1 border border-slate-300 rounded-md text-sm resize-none focus:outline-none focus:ring-2 focus:ring-brand-blue-primary/40"
+        />
+        <button
+          type="submit"
+          disabled={submitting || !content.trim()}
+          className="shrink-0 inline-flex items-center gap-1 rounded-md bg-brand-blue-primary px-3 py-2 text-xs font-bold text-white hover:bg-brand-blue-dark transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          {submitting ? (
+            <Loader2 className="w-3.5 h-3.5 animate-spin" />
+          ) : (
+            <Send className="w-3.5 h-3.5" />
+          )}
+          Post
+        </button>
+      </div>
+      {error && <p className="text-[11px] text-red-600">{error}</p>}
+    </form>
+  );
+};

--- a/components/layout/Dock.tsx
+++ b/components/layout/Dock.tsx
@@ -990,7 +990,12 @@ export const Dock: React.FC = () => {
                 : 'max-w-[95vw] overflow-x-auto'
             }`}
           >
-            {dockItems.length > 0 ? (
+            {dockItems.length === 0 && (
+              <div className="px-3 py-2 text-xxs font-black uppercase text-slate-400 italic flex-shrink-0">
+                {t('dock.noAppsSelected')}
+              </div>
+            )}
+            {dockItems.length > 0 && (
               <>
                 <DndContext
                   sensors={sensors}
@@ -1415,38 +1420,39 @@ export const Dock: React.FC = () => {
                     ))}
                   </>
                 )}
-
-                {/* Separator and More Button */}
-                <div
-                  className={`bg-slate-200 flex-shrink-0 ${
-                    isVerticalDock
-                      ? 'h-px w-8 my-1 md:my-2'
-                      : 'w-px h-8 mx-1 md:mx-2'
-                  }`}
-                />
-
-                <button
-                  ref={moreButtonRef}
-                  onClick={() => setShowMoreMenu(!showMoreMenu)}
-                  className="group flex flex-col items-center gap-1 min-w-[50px] transition-transform active:scale-90 touch-pan-x flex-shrink-0"
-                  title={t('sidebar.header.moreWidgets')}
-                >
-                  <DockIcon
-                    color="bg-brand-blue-primary shadow-lg shadow-brand-blue-primary/20"
-                    className="flex items-center justify-center text-white group-hover:scale-110 group-hover:bg-brand-blue-dark transition"
-                  >
-                    <LayoutGrid className="w-5 h-5 md:w-6 md:h-6" />
-                  </DockIcon>
-                  <DockLabel className="text-slate-600 font-bold">
-                    {t('sidebar.header.more')}
-                  </DockLabel>
-                </button>
               </>
-            ) : (
-              <div className="px-6 py-2 text-xxs font-black uppercase text-slate-400 italic">
-                {t('dock.noAppsSelected')}
-              </div>
             )}
+
+            {/* Separator + "More" button — always accessible so users can
+                add widgets even when the dock is empty. Previously the
+                More button was rendered only inside the dockItems>0 branch,
+                which left users with an empty dock stuck with no UI to
+                recover from. */}
+            {dockItems.length > 0 && (
+              <div
+                className={`bg-slate-200 flex-shrink-0 ${
+                  isVerticalDock
+                    ? 'h-px w-8 my-1 md:my-2'
+                    : 'w-px h-8 mx-1 md:mx-2'
+                }`}
+              />
+            )}
+            <button
+              ref={moreButtonRef}
+              onClick={() => setShowMoreMenu(!showMoreMenu)}
+              className="group flex flex-col items-center gap-1 min-w-[50px] transition-transform active:scale-90 touch-pan-x flex-shrink-0"
+              title={t('sidebar.header.moreWidgets')}
+            >
+              <DockIcon
+                color="bg-brand-blue-primary shadow-lg shadow-brand-blue-primary/20"
+                className="flex items-center justify-center text-white group-hover:scale-110 group-hover:bg-brand-blue-dark transition"
+              >
+                <LayoutGrid className="w-5 h-5 md:w-6 md:h-6" />
+              </DockIcon>
+              <DockLabel className="text-slate-600 font-bold">
+                {t('sidebar.header.more')}
+              </DockLabel>
+            </button>
           </GlassCard>
 
           {showMagicLayout && (

--- a/components/quiz/QuizStudentApp.tsx
+++ b/components/quiz/QuizStudentApp.tsx
@@ -61,14 +61,6 @@ import { StudentLeaderboard } from './StudentLeaderboard';
 import { QuizPausedPlaceholder } from './QuizPausedPlaceholder';
 import { MatchingResponseInput } from './MatchingResponseInput';
 import { OrderingResponseInput } from './OrderingResponseInput';
-// Lazy-load the rich-text editor so the bundle for legacy quiz types isn't
-// pulled into the initial student-app payload. Loaded on first render of a
-// short/essay question.
-const WrittenResponseEditor = React.lazy(() =>
-  import('./WrittenResponseEditor').then((m) => ({
-    default: m.WrittenResponseEditor,
-  }))
-);
 import { TeacherPreviewBanner } from '@/components/student/TeacherPreviewBanner';
 import { usePreviewMode } from '@/hooks/usePreviewMode';
 import {
@@ -81,6 +73,15 @@ import {
   playCountdownTick,
   playStreakSound,
 } from '@/utils/quizAudio';
+
+// Lazy-load the rich-text editor so the bundle for legacy quiz types isn't
+// pulled into the initial student-app payload. Loaded on first render of a
+// short/essay question.
+const WrittenResponseEditor = React.lazy(() =>
+  import('./WrittenResponseEditor').then((m) => ({
+    default: m.WrittenResponseEditor,
+  }))
+);
 
 // ─── Root component ───────────────────────────────────────────────────────────
 
@@ -773,6 +774,13 @@ const ActiveQuiz: React.FC<{
         reason === 'post-unlock'
           ? 'Your unlocked attempt is being submitted now.'
           : 'You have left the quiz 3 times. Your quiz is being auto-submitted.';
+      // Ask the inner question view to flush any pending written-response
+      // autosave before we mark the response complete. Listened for in
+      // `StudentQuestionView`'s flush handler. Without this, a strike-3
+      // auto-submit fired within 500 ms of the student's last keystroke
+      // could finalize the response with the previous (already-written)
+      // draft and silently drop the most recent edits.
+      document.dispatchEvent(new CustomEvent('spartboard:quiz:flush-written'));
       await showAlert(message, {
         title: 'Quiz Auto-Submitted',
         variant: 'warning',
@@ -943,6 +951,15 @@ const ActiveQuiz: React.FC<{
   const writtenAutosaveTimer = useRef<ReturnType<typeof setTimeout> | null>(
     null
   );
+  // Which question id the current `writtenAnswer` belongs to. Used by the
+  // autosave effect to refuse writes during the single render between
+  // `currentQuestion.id` advancing (student-paced submit-and-advance) and
+  // the hydration branch replacing `writtenAnswer` with the new
+  // question's saved value. Without this guard, the diff
+  // `writtenAnswer !== savedAnswerForCurrent` is briefly true on the new
+  // question and would persist the *previous* question's draft against
+  // the new question's id 500 ms later.
+  const writtenAnswerQuestionIdRef = useRef<string | undefined>(undefined);
 
   const [submitted, setSubmitted] = useState(alreadyAnswered);
   const [timeLeft, setTimeLeft] = useState<number | null>(
@@ -1007,12 +1024,16 @@ const ActiveQuiz: React.FC<{
     // Always seed the written-answer slot from any saved response so
     // pause/resume across class periods rehydrates the editor at the
     // exact text the student left behind. Other types get an empty
-    // string here, which the editor branches never read.
+    // string here, which the editor branches never read. The
+    // question-id ref is updated in lockstep so the autosave effect
+    // refuses to write the new question with a draft that's still about
+    // to be replaced (see the autosave effect comment).
     const isWritten =
       currentQuestion?.type === 'short' || currentQuestion?.type === 'essay';
     const next = isWritten ? (savedAnswerForCurrent ?? '') : '';
     setWrittenAnswer(next);
     writtenAnswerRef.current = next;
+    writtenAnswerQuestionIdRef.current = currentQuestion?.id;
   };
 
   // Derived state: full reset on question change, narrow update on alreadyAnswered flips.
@@ -1168,6 +1189,14 @@ const ActiveQuiz: React.FC<{
     if (!isWritten || !qid) return;
     if (submitted) return;
 
+    // Race guard: if `currentQuestion.id` has advanced (student-paced
+    // submit-and-advance) but `hydrateAnswerControls` hasn't yet replaced
+    // `writtenAnswer` with the new question's saved value, the draft we
+    // see here is still from the previous question. Refuse to write —
+    // the next render after hydration will re-evaluate this effect with
+    // the correct draft.
+    if (writtenAnswerQuestionIdRef.current !== qid) return;
+
     // Skip the initial-hydration call: if the editor's seeded value
     // matches the saved response, there's nothing to write.
     if (writtenAnswer === (savedAnswerForCurrent ?? '')) return;
@@ -1178,7 +1207,9 @@ const ActiveQuiz: React.FC<{
     const draft = writtenAnswer;
     writtenAutosaveTimer.current = setTimeout(() => {
       void onAnswerRef.current(qid, draft).catch((err: unknown) => {
-        console.error('[QuizStudentApp] written autosave failed:', err);
+        logError('QuizStudentApp.writtenAutosave', err, {
+          questionId: qid,
+        });
       });
     }, 500);
 
@@ -1213,16 +1244,23 @@ const ActiveQuiz: React.FC<{
         writtenAutosaveTimer.current = null;
       }
       void onAnswerRef.current(qid, draft).catch((err: unknown) => {
-        console.error('[QuizStudentApp] written autosave flush failed:', err);
+        logError('QuizStudentApp.writtenAutosaveFlush', err, {
+          questionId: qid,
+        });
       });
     };
     const onVisibilityChange = () => {
       if (document.visibilityState === 'hidden') flush();
     };
+    // Custom event from `ActiveQuiz.handleAutoSubmit` so a strike-3
+    // auto-submit lands the latest essay draft before completing the
+    // response. Internal-only event name; not part of any public API.
     document.addEventListener('visibilitychange', onVisibilityChange);
+    document.addEventListener('spartboard:quiz:flush-written', flush);
     window.addEventListener('beforeunload', flush);
     return () => {
       document.removeEventListener('visibilitychange', onVisibilityChange);
+      document.removeEventListener('spartboard:quiz:flush-written', flush);
       window.removeEventListener('beforeunload', flush);
       flush();
     };
@@ -1845,6 +1883,9 @@ const ActiveQuiz: React.FC<{
                 onChange={(html) => {
                   setWrittenAnswer(html);
                   writtenAnswerRef.current = html;
+                  // Mark the draft as belonging to this question so the
+                  // autosave race guard lets it through.
+                  writtenAnswerQuestionIdRef.current = currentQuestion.id;
                 }}
                 placeholder={currentQuestion.placeholder}
                 maxWords={currentQuestion.maxWords}

--- a/components/quiz/QuizStudentApp.tsx
+++ b/components/quiz/QuizStudentApp.tsx
@@ -61,6 +61,14 @@ import { StudentLeaderboard } from './StudentLeaderboard';
 import { QuizPausedPlaceholder } from './QuizPausedPlaceholder';
 import { MatchingResponseInput } from './MatchingResponseInput';
 import { OrderingResponseInput } from './OrderingResponseInput';
+// Lazy-load the rich-text editor so the bundle for legacy quiz types isn't
+// pulled into the initial student-app payload. Loaded on first render of a
+// short/essay question.
+const WrittenResponseEditor = React.lazy(() =>
+  import('./WrittenResponseEditor').then((m) => ({
+    default: m.WrittenResponseEditor,
+  }))
+);
 import { TeacherPreviewBanner } from '@/components/student/TeacherPreviewBanner';
 import { usePreviewMode } from '@/hooks/usePreviewMode';
 import {
@@ -927,6 +935,14 @@ const ActiveQuiz: React.FC<{
   const [submitting, setSubmitting] = useState(false);
   const [fibAnswer, setFibAnswer] = useState('');
   const [draftMcAnswer, setDraftMcAnswer] = useState<string | null>(null);
+  // Written-response live draft (sanitized HTML). Hydrated on question
+  // change from any saved response so pause/resume next class period
+  // picks up exactly where the student left off.
+  const [writtenAnswer, setWrittenAnswer] = useState<string>('');
+  const writtenAnswerRef = useRef<string>('');
+  const writtenAutosaveTimer = useRef<ReturnType<typeof setTimeout> | null>(
+    null
+  );
 
   const [submitted, setSubmitted] = useState(alreadyAnswered);
   const [timeLeft, setTimeLeft] = useState<number | null>(
@@ -988,6 +1004,15 @@ const ActiveQuiz: React.FC<{
       setDraftMcAnswer(null);
       setFibAnswer('');
     }
+    // Always seed the written-answer slot from any saved response so
+    // pause/resume across class periods rehydrates the editor at the
+    // exact text the student left behind. Other types get an empty
+    // string here, which the editor branches never read.
+    const isWritten =
+      currentQuestion?.type === 'short' || currentQuestion?.type === 'essay';
+    const next = isWritten ? (savedAnswerForCurrent ?? '') : '';
+    setWrittenAnswer(next);
+    writtenAnswerRef.current = next;
   };
 
   // Derived state: full reset on question change, narrow update on alreadyAnswered flips.
@@ -1061,7 +1086,15 @@ const ActiveQuiz: React.FC<{
     fibAnswerRef.current = fibAnswer;
     draftMcAnswerRef.current = draftMcAnswer;
     onAnswerRef.current = onAnswer;
-  }, [currentQuestion, selectedAnswer, fibAnswer, draftMcAnswer, onAnswer]);
+    writtenAnswerRef.current = writtenAnswer;
+  }, [
+    currentQuestion,
+    selectedAnswer,
+    fibAnswer,
+    draftMcAnswer,
+    onAnswer,
+    writtenAnswer,
+  ]);
 
   // Reset the structured answer ref when the question changes so a stale
   // answer from a previous question can't leak into auto-submit.
@@ -1106,10 +1139,12 @@ const ActiveQuiz: React.FC<{
     const answer =
       question.type === 'Matching' || question.type === 'Ordering'
         ? structuredAnswerRef.current
-        : (selectedAnswerRef.current ??
-          draftMcAnswerRef.current ??
-          fibAnswerRef.current ??
-          '');
+        : question.type === 'short' || question.type === 'essay'
+          ? writtenAnswerRef.current
+          : (selectedAnswerRef.current ??
+            draftMcAnswerRef.current ??
+            fibAnswerRef.current ??
+            '');
     void onAnswerRef
       .current(
         autoSubmitTriggeredFor,
@@ -1121,6 +1156,82 @@ const ActiveQuiz: React.FC<{
       });
   }, [autoSubmitTriggeredFor]);
 
+  // Written-response autosave. Debounced 500ms to mirror the PLC notes
+  // editor pattern; flushed synchronously on unmount, visibility-hidden,
+  // and when the teacher pauses the session so a student can resume on
+  // a new day without losing typing. Submit/advance also persists the
+  // final state, so the debounce is purely a write-rate optimization.
+  useEffect(() => {
+    const qid = currentQuestion?.id;
+    const isWritten =
+      currentQuestion?.type === 'short' || currentQuestion?.type === 'essay';
+    if (!isWritten || !qid) return;
+    if (submitted) return;
+
+    // Skip the initial-hydration call: if the editor's seeded value
+    // matches the saved response, there's nothing to write.
+    if (writtenAnswer === (savedAnswerForCurrent ?? '')) return;
+
+    if (writtenAutosaveTimer.current) {
+      clearTimeout(writtenAutosaveTimer.current);
+    }
+    const draft = writtenAnswer;
+    writtenAutosaveTimer.current = setTimeout(() => {
+      void onAnswerRef.current(qid, draft).catch((err: unknown) => {
+        console.error('[QuizStudentApp] written autosave failed:', err);
+      });
+    }, 500);
+
+    return () => {
+      if (writtenAutosaveTimer.current) {
+        clearTimeout(writtenAutosaveTimer.current);
+      }
+    };
+  }, [
+    writtenAnswer,
+    currentQuestion?.id,
+    currentQuestion?.type,
+    submitted,
+    savedAnswerForCurrent,
+  ]);
+
+  // Flush pending written-response autosave on unmount and on the
+  // visibility-hidden / pause transitions so a closed tab or a teacher
+  // pause never loses in-flight typing. The synchronous Firestore write
+  // can't be awaited inside a unload handler, but kicking it off before
+  // the page tears down is the best-effort flush we can do.
+  useEffect(() => {
+    const flush = () => {
+      const qid = currentQuestionRef.current?.id;
+      const type = currentQuestionRef.current?.type;
+      if (type !== 'short' && type !== 'essay') return;
+      if (!qid) return;
+      const draft = writtenAnswerRef.current;
+      if (draft === (savedAnswerForCurrent ?? '')) return;
+      if (writtenAutosaveTimer.current) {
+        clearTimeout(writtenAutosaveTimer.current);
+        writtenAutosaveTimer.current = null;
+      }
+      void onAnswerRef.current(qid, draft).catch((err: unknown) => {
+        console.error('[QuizStudentApp] written autosave flush failed:', err);
+      });
+    };
+    const onVisibilityChange = () => {
+      if (document.visibilityState === 'hidden') flush();
+    };
+    document.addEventListener('visibilitychange', onVisibilityChange);
+    window.addEventListener('beforeunload', flush);
+    return () => {
+      document.removeEventListener('visibilitychange', onVisibilityChange);
+      window.removeEventListener('beforeunload', flush);
+      flush();
+    };
+    // savedAnswerForCurrent is intentionally not a dep — we flush against
+    // whatever the current saved value is at flush time, not on every
+    // change of saved state.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   // Watch for teacher revealing answers after student already submitted.
   // Uses "adjusting state during render" pattern to avoid setState-in-effect.
   const currentRevealed = currentQuestion
@@ -1130,9 +1241,14 @@ const ActiveQuiz: React.FC<{
 
   if (currentRevealed !== prevRevealed) {
     setPrevRevealed(currentRevealed);
+    // Written question types have no canonical correct answer — they are
+    // manually graded. Skip the reveal/feedback path entirely.
+    const isWritten =
+      currentQuestion?.type === 'short' || currentQuestion?.type === 'essay';
     if (
       currentRevealed &&
       submitted &&
+      !isWritten &&
       session.showResultToStudent &&
       answerFeedback === null
     ) {
@@ -1449,7 +1565,9 @@ const ActiveQuiz: React.FC<{
                   ? 'bg-amber-500/20 text-amber-400'
                   : currentQuestion.type === 'Matching'
                     ? 'bg-purple-500/20 text-purple-400'
-                    : 'bg-teal-500/20 text-teal-400'
+                    : currentQuestion.type === 'Ordering'
+                      ? 'bg-teal-500/20 text-teal-400'
+                      : 'bg-rose-500/20 text-rose-400'
             }`}
           >
             {currentQuestion.type === 'MC'
@@ -1458,7 +1576,11 @@ const ActiveQuiz: React.FC<{
                 ? 'Fill in the Blank'
                 : currentQuestion.type === 'Matching'
                   ? 'Matching'
-                  : 'Ordering'}
+                  : currentQuestion.type === 'Ordering'
+                    ? 'Ordering'
+                    : currentQuestion.type === 'short'
+                      ? 'Short Answer'
+                      : 'Essay'}
           </span>
         </div>
 
@@ -1705,6 +1827,89 @@ const ActiveQuiz: React.FC<{
             onNext={handleNext}
             saveError={saveError}
           />
+        )}
+
+        {(currentQuestion.type === 'short' ||
+          currentQuestion.type === 'essay') && (
+          <div className="space-y-4 flex-1">
+            <React.Suspense
+              fallback={
+                <div className="h-48 bg-slate-800 border border-slate-700 rounded-2xl flex items-center justify-center">
+                  <Loader2 className="w-5 h-5 animate-spin text-slate-500" />
+                </div>
+              }
+            >
+              <WrittenResponseEditor
+                questionKey={currentQuestion.id}
+                value={writtenAnswer}
+                onChange={(html) => {
+                  setWrittenAnswer(html);
+                  writtenAnswerRef.current = html;
+                }}
+                placeholder={currentQuestion.placeholder}
+                maxWords={currentQuestion.maxWords}
+                disabled={submitted && !isStudentPaced}
+                isEssay={currentQuestion.type === 'essay'}
+              />
+            </React.Suspense>
+
+            <div className="animate-in fade-in slide-in-from-bottom-2 space-y-3">
+              {isStudentPaced ? (
+                submitted && currentIndex >= session.totalQuestions - 1 ? (
+                  <div className="p-4 bg-emerald-500/15 border border-emerald-500/30 rounded-2xl flex items-center justify-center gap-3">
+                    <CheckCircle2 className="w-5 h-5 text-emerald-400 shrink-0" />
+                    <p className="text-emerald-300 text-sm font-bold">
+                      Quiz complete!
+                    </p>
+                  </div>
+                ) : (
+                  <>
+                    {saveError && <SaveErrorBanner message={saveError} />}
+                    <button
+                      onClick={() => void handleSubmitAndAdvance(writtenAnswer)}
+                      disabled={submitting}
+                      className="w-full py-4 bg-emerald-600 hover:bg-emerald-500 disabled:opacity-50 disabled:cursor-not-allowed text-white font-black rounded-2xl flex items-center justify-center gap-2 transition-all shadow-lg active:scale-95"
+                    >
+                      {submitting ? (
+                        <Loader2 className="w-5 h-5 animate-spin" />
+                      ) : currentIndex >= session.totalQuestions - 1 ? (
+                        <>
+                          {saveError ? 'Retry Submit' : 'SUBMIT'}{' '}
+                          <CheckCircle2 className="w-5 h-5" />
+                        </>
+                      ) : (
+                        <>
+                          {saveError ? 'Retry' : 'NEXT'}{' '}
+                          <ArrowRight className="w-5 h-5" />
+                        </>
+                      )}
+                    </button>
+                  </>
+                )
+              ) : !submitted ? (
+                <button
+                  onClick={() => void handleSubmit(writtenAnswer)}
+                  disabled={submitting}
+                  className="w-full py-4 bg-violet-600 hover:bg-violet-500 disabled:opacity-50 text-white font-bold rounded-2xl flex items-center justify-center gap-2 transition-colors"
+                >
+                  {submitting ? (
+                    <Loader2 className="w-5 h-5 animate-spin" />
+                  ) : (
+                    'Submit Response'
+                  )}
+                </button>
+              ) : (
+                <div className="p-4 bg-emerald-500/15 border border-emerald-500/30 rounded-2xl flex items-center justify-center gap-3">
+                  <CheckCircle2 className="w-5 h-5 text-emerald-400 shrink-0" />
+                  <p className="text-emerald-300 text-sm font-bold">
+                    {currentIndex < session.totalQuestions - 1
+                      ? 'Waiting for teacher…'
+                      : 'Response submitted — your teacher will grade this.'}
+                  </p>
+                </div>
+              )}
+            </div>
+          </div>
         )}
       </div>
     </div>

--- a/components/quiz/WrittenResponseEditor.tsx
+++ b/components/quiz/WrittenResponseEditor.tsx
@@ -1,0 +1,239 @@
+/**
+ * Student-facing rich-text editor for `short` and `essay` quiz questions.
+ *
+ * Phase 1 keeps the editor intentionally minimal — a `contenteditable`
+ * surface plus a small formatting toolbar — so we don't pay the bundle
+ * cost of TipTap/ProseMirror until annotations actually need them
+ * (Phase 2). All HTML in and out of the editor passes through the shared
+ * `sanitizeHtml` util to keep things safe.
+ *
+ * The editor is intentionally uncontrolled internally: writing to
+ * `innerHTML` on every keystroke would blow away the caret. Instead, the
+ * caller-provided `value` is used to seed the DOM only when the question
+ * identity (`questionKey`) changes — pause/resume rehydration uses the
+ * key prop to force a fresh editor instance.
+ */
+
+import React, { useEffect, useRef, useState } from 'react';
+import { Bold, Italic, List, ListOrdered, Underline } from 'lucide-react';
+import { sanitizeHtml } from '@/utils/security';
+
+interface WrittenResponseEditorProps {
+  /** Initial HTML content. Sanitized on render. */
+  value: string;
+  /** Called with sanitized HTML on every edit. */
+  onChange: (html: string) => void;
+  /** Optional placeholder displayed when the editor is empty. */
+  placeholder?: string;
+  /** Optional soft word cap shown in the counter. 0/undefined = no cap. */
+  maxWords?: number;
+  /** Disable editing (e.g. when the quiz is paused or submitted). */
+  disabled?: boolean;
+  /**
+   * When true, the toolbar exposes list controls and the editor grows to a
+   * multi-paragraph height. Short-answer questions stay single-paragraph.
+   */
+  isEssay?: boolean;
+  /**
+   * Stable identity for the current question. Changing this remounts the
+   * inner editor so a fresh `value` is loaded — used for cross-question
+   * navigation and pause/resume rehydration without manually managing the
+   * caret/selection.
+   */
+  questionKey: string;
+}
+
+const countWords = (html: string): number => {
+  if (!html) return 0;
+  // Strip tags, normalize whitespace, count word-ish runs.
+  const text = html
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/&nbsp;/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+  if (!text) return 0;
+  return text.split(' ').length;
+};
+
+const WrittenResponseEditorInner: React.FC<
+  Omit<WrittenResponseEditorProps, 'questionKey'>
+> = ({ value, onChange, placeholder, maxWords, disabled, isEssay }) => {
+  const editorRef = useRef<HTMLDivElement | null>(null);
+  const [wordCount, setWordCount] = useState(() => countWords(value));
+  const [isEmpty, setIsEmpty] = useState(() => !value.trim());
+
+  // Seed innerHTML once on mount. Subsequent edits are driven by the
+  // contenteditable element itself — re-writing innerHTML on every value
+  // change would reset the caret on every keystroke.
+  useEffect(() => {
+    if (!editorRef.current) return;
+    const initial = sanitizeHtml(value);
+    editorRef.current.innerHTML = initial;
+    setWordCount(countWords(initial));
+    setIsEmpty(!editorRef.current.textContent?.trim());
+    // We intentionally don't depend on `value` — the `questionKey`-driven
+    // remount in the parent handles "load a different student's response."
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const handleInput = () => {
+    if (!editorRef.current) return;
+    const raw = editorRef.current.innerHTML;
+    const clean = sanitizeHtml(raw);
+    setWordCount(countWords(clean));
+    setIsEmpty(!editorRef.current.textContent?.trim());
+    onChange(clean);
+  };
+
+  // Strip formatting from pasted content so students can't inject styled
+  // HTML by copy/pasting from rich sources. We only allow plain text on
+  // paste; the toolbar buttons are the only path to formatting.
+  const handlePaste = (e: React.ClipboardEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    const text = e.clipboardData.getData('text/plain');
+    if (!text) return;
+    // Insert as plain text at the current selection.
+    document.execCommand('insertText', false, text);
+  };
+
+  const exec = (command: string) => {
+    if (disabled) return;
+    editorRef.current?.focus();
+    document.execCommand(command);
+    handleInput();
+  };
+
+  const overCap = !!maxWords && maxWords > 0 && wordCount > maxWords;
+
+  return (
+    <div className="flex flex-col gap-2 w-full">
+      <div className="flex items-center gap-1 px-2 py-1.5 bg-slate-800 border border-slate-700 rounded-t-2xl">
+        <ToolbarButton
+          label="Bold"
+          onClick={() => exec('bold')}
+          disabled={disabled}
+        >
+          <Bold className="w-4 h-4" />
+        </ToolbarButton>
+        <ToolbarButton
+          label="Italic"
+          onClick={() => exec('italic')}
+          disabled={disabled}
+        >
+          <Italic className="w-4 h-4" />
+        </ToolbarButton>
+        <ToolbarButton
+          label="Underline"
+          onClick={() => exec('underline')}
+          disabled={disabled}
+        >
+          <Underline className="w-4 h-4" />
+        </ToolbarButton>
+        {isEssay && (
+          <>
+            <div className="w-px h-5 bg-slate-700 mx-1" />
+            <ToolbarButton
+              label="Bulleted list"
+              onClick={() => exec('insertUnorderedList')}
+              disabled={disabled}
+            >
+              <List className="w-4 h-4" />
+            </ToolbarButton>
+            <ToolbarButton
+              label="Numbered list"
+              onClick={() => exec('insertOrderedList')}
+              disabled={disabled}
+            >
+              <ListOrdered className="w-4 h-4" />
+            </ToolbarButton>
+          </>
+        )}
+        <div className="flex-1" />
+        <span
+          className={`text-xs font-mono px-2 py-0.5 rounded ${
+            overCap ? 'bg-amber-500/20 text-amber-300' : 'text-slate-500'
+          }`}
+          aria-live="polite"
+        >
+          {wordCount}
+          {maxWords && maxWords > 0 ? ` / ${maxWords}` : ''}{' '}
+          {wordCount === 1 ? 'word' : 'words'}
+        </span>
+      </div>
+
+      <div className="relative">
+        <div
+          ref={editorRef}
+          role="textbox"
+          aria-multiline="true"
+          aria-label="Your response"
+          aria-disabled={disabled ?? undefined}
+          contentEditable={!disabled}
+          suppressContentEditableWarning
+          onInput={handleInput}
+          onPaste={handlePaste}
+          spellCheck
+          className={`w-full px-5 py-4 bg-slate-800 border-2 border-t-0 ${
+            disabled
+              ? 'border-slate-700 text-slate-400 cursor-not-allowed'
+              : 'border-slate-700 text-white focus:outline-none focus:border-violet-500'
+          } rounded-b-2xl text-sm leading-relaxed overflow-y-auto ${
+            isEssay ? 'min-h-[18rem]' : 'min-h-[6rem]'
+          }`}
+          style={{ wordBreak: 'break-word' }}
+        />
+        {isEmpty && placeholder && (
+          <div
+            className="absolute inset-0 px-5 py-4 text-slate-500 text-sm pointer-events-none select-none"
+            aria-hidden
+          >
+            {placeholder}
+          </div>
+        )}
+      </div>
+
+      {overCap && (
+        <p className="text-xs text-amber-400 italic">
+          You&apos;re past the suggested word cap. Your teacher may take this
+          into account when grading.
+        </p>
+      )}
+    </div>
+  );
+};
+
+const ToolbarButton: React.FC<{
+  label: string;
+  onClick: () => void;
+  disabled?: boolean;
+  children: React.ReactNode;
+}> = ({ label, onClick, disabled, children }) => (
+  <button
+    type="button"
+    aria-label={label}
+    title={label}
+    disabled={disabled}
+    onMouseDown={(e) => {
+      // Prevent the contenteditable from losing focus when the user clicks
+      // a toolbar button — execCommand operates on the active selection.
+      e.preventDefault();
+    }}
+    onClick={onClick}
+    className="p-1.5 rounded text-slate-300 hover:bg-slate-700 hover:text-white disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+  >
+    {children}
+  </button>
+);
+
+/**
+ * Public wrapper that remounts the inner editor whenever `questionKey`
+ * changes — gives us cheap "load a different value" behavior without
+ * having to imperatively reset the contenteditable.
+ */
+export const WrittenResponseEditor: React.FC<WrittenResponseEditorProps> = (
+  props
+) => {
+  return <WrittenResponseEditorInner key={props.questionKey} {...props} />;
+};
+
+export default WrittenResponseEditor;

--- a/components/quiz/WrittenResponseEditor.tsx
+++ b/components/quiz/WrittenResponseEditor.tsx
@@ -5,7 +5,8 @@
  * surface plus a small formatting toolbar — so we don't pay the bundle
  * cost of TipTap/ProseMirror until annotations actually need them
  * (Phase 2). All HTML in and out of the editor passes through the shared
- * `sanitizeHtml` util to keep things safe.
+ * `sanitizeQuizResponse` util to keep things safe and consistent with the
+ * teacher's grading view (which uses the same profile).
  *
  * The editor is intentionally uncontrolled internally: writing to
  * `innerHTML` on every keystroke would blow away the caret. Instead, the
@@ -16,7 +17,7 @@
 
 import React, { useEffect, useRef, useState } from 'react';
 import { Bold, Italic, List, ListOrdered, Underline } from 'lucide-react';
-import { sanitizeHtml } from '@/utils/security';
+import { sanitizeQuizResponse } from '@/utils/security';
 
 interface WrittenResponseEditorProps {
   /** Initial HTML content. Sanitized on render. */
@@ -46,6 +47,17 @@ interface WrittenResponseEditorProps {
 const countWords = (html: string): number => {
   if (!html) return 0;
   // Strip tags, normalize whitespace, count word-ish runs.
+  //
+  // Known limitation (Phase 1): this is a whitespace-delimited token
+  // count. CJK scripts (Chinese / Japanese / Korean) without inter-word
+  // spaces will under-count (a 400-character Mandarin response counts
+  // as 1 "word"), and HTML entities like `&amp;` survive the tag-strip
+  // and inflate the count by one. The word cap is described to teachers
+  // as a "soft suggestion" so the imprecision is acceptable for now —
+  // Phase 2 can swap to `Intl.Segmenter(locale, { granularity: 'word' })`
+  // operating on `editorRef.current.textContent` for proper Unicode
+  // segmentation if non-Latin classrooms surface this as a real
+  // problem.
   const text = html
     .replace(/<[^>]+>/g, ' ')
     .replace(/&nbsp;/g, ' ')
@@ -67,7 +79,7 @@ const WrittenResponseEditorInner: React.FC<
   // change would reset the caret on every keystroke.
   useEffect(() => {
     if (!editorRef.current) return;
-    const initial = sanitizeHtml(value);
+    const initial = sanitizeQuizResponse(value);
     editorRef.current.innerHTML = initial;
     setWordCount(countWords(initial));
     setIsEmpty(!editorRef.current.textContent?.trim());
@@ -79,7 +91,7 @@ const WrittenResponseEditorInner: React.FC<
   const handleInput = () => {
     if (!editorRef.current) return;
     const raw = editorRef.current.innerHTML;
-    const clean = sanitizeHtml(raw);
+    const clean = sanitizeQuizResponse(raw);
     setWordCount(countWords(clean));
     setIsEmpty(!editorRef.current.textContent?.trim());
     onChange(clean);
@@ -167,7 +179,12 @@ const WrittenResponseEditorInner: React.FC<
           role="textbox"
           aria-multiline="true"
           aria-label="Your response"
-          aria-disabled={disabled ?? undefined}
+          aria-placeholder={placeholder}
+          aria-disabled={disabled ? 'true' : 'false'}
+          // contenteditable is not naturally in the tab order; opt in so
+          // keyboard-only users can reach the editor after navigating
+          // past the toolbar buttons.
+          tabIndex={disabled ? -1 : 0}
           contentEditable={!disabled}
           suppressContentEditableWarning
           onInput={handleInput}
@@ -176,7 +193,7 @@ const WrittenResponseEditorInner: React.FC<
           className={`w-full px-5 py-4 bg-slate-800 border-2 border-t-0 ${
             disabled
               ? 'border-slate-700 text-slate-400 cursor-not-allowed'
-              : 'border-slate-700 text-white focus:outline-none focus:border-violet-500'
+              : 'border-slate-700 text-white focus:outline-none focus:border-violet-500 focus-visible:ring-2 focus-visible:ring-violet-400'
           } rounded-b-2xl text-sm leading-relaxed overflow-y-auto ${
             isEssay ? 'min-h-[18rem]' : 'min-h-[6rem]'
           }`}
@@ -219,7 +236,7 @@ const ToolbarButton: React.FC<{
       e.preventDefault();
     }}
     onClick={onClick}
-    className="p-1.5 rounded text-slate-300 hover:bg-slate-700 hover:text-white disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+    className="p-1.5 rounded text-slate-300 hover:bg-slate-700 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-violet-400 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
   >
     {children}
   </button>

--- a/components/widgets/ActivityWall/ShareModal.tsx
+++ b/components/widgets/ActivityWall/ShareModal.tsx
@@ -1,0 +1,437 @@
+/**
+ * Teacher-facing modal that publishes an Activity Wall session as a
+ * view-only gallery. The teacher picks which gallery interactions to
+ * enable (comments, replies, likes) and an optional expiration date.
+ *
+ * On submit we:
+ *   1. Flip `publiclyShared: true` onto `activity_wall_sessions/{sessionId}`
+ *      so the read-side Firestore + Storage rules unlock for anonymous
+ *      gallery viewers.
+ *   2. Write a `shared_activity_walls/{shareId}` doc carrying the gallery
+ *      toggles + snapshot of title/prompt/identificationMode.
+ *   3. Surface the resulting URL with a copy-to-clipboard button — matches
+ *      the ShareLinkCreatorModal UX so the experience feels consistent.
+ *
+ * View-only philosophy: the gallery never lets viewers submit new
+ * activity entries; new posts only happen through the original student
+ * URL. Comments + likes are layered on top via subcollections under the
+ * share doc so deleting the share also cleans them up.
+ */
+
+import React, { useEffect, useState } from 'react';
+import {
+  Check,
+  Copy,
+  ExternalLink,
+  MessageCircle,
+  MessageSquare,
+  Heart,
+  CalendarClock,
+  X,
+} from 'lucide-react';
+import { doc, setDoc, updateDoc } from 'firebase/firestore';
+import { Modal } from '@/components/common/Modal';
+import { useDashboard } from '@/context/useDashboard';
+import { db } from '@/config/firebase';
+import type {
+  ActivityWallActivity,
+  ActivityWallIdentificationMode,
+  SharedActivityWall,
+} from '@/types';
+
+interface ActivityWallShareModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  activity: ActivityWallActivity | null;
+  sessionId: string | null;
+  teacherUid: string | null;
+}
+
+interface ToggleRowProps {
+  id: string;
+  Icon: React.ComponentType<{ className?: string }>;
+  title: string;
+  body: string;
+  checked: boolean;
+  disabled?: boolean;
+  onChange: (next: boolean) => void;
+}
+
+const ToggleRow: React.FC<ToggleRowProps> = ({
+  id,
+  Icon,
+  title,
+  body,
+  checked,
+  disabled = false,
+  onChange,
+}) => {
+  return (
+    <label
+      htmlFor={id}
+      className={`flex items-start gap-3 rounded-xl border px-4 py-3 transition-all ${
+        disabled
+          ? 'opacity-50 cursor-not-allowed border-slate-200 bg-slate-50/60'
+          : checked
+            ? 'border-brand-blue-primary bg-brand-blue-lighter/20 cursor-pointer'
+            : 'border-slate-200 bg-white hover:border-brand-blue-primary cursor-pointer'
+      }`}
+    >
+      <div
+        className={`shrink-0 w-9 h-9 rounded-lg flex items-center justify-center ${
+          checked
+            ? 'bg-brand-blue-primary text-white'
+            : 'bg-slate-100 text-slate-500'
+        }`}
+      >
+        <Icon className="w-4 h-4" />
+      </div>
+      <div className="flex-1 min-w-0">
+        <h3 className="font-bold text-slate-900 text-sm">{title}</h3>
+        <p className="mt-0.5 text-xs text-slate-600 leading-relaxed">{body}</p>
+      </div>
+      <input
+        id={id}
+        type="checkbox"
+        className="mt-1 h-4 w-4 accent-brand-blue-primary cursor-pointer disabled:cursor-not-allowed"
+        checked={checked}
+        disabled={disabled}
+        onChange={(e) => onChange(e.target.checked)}
+      />
+    </label>
+  );
+};
+
+const identificationModeBlurb = (
+  mode: ActivityWallIdentificationMode
+): string => {
+  switch (mode) {
+    case 'anonymous':
+      return 'Viewers can comment anonymously — same as how students submitted.';
+    case 'name':
+      return 'Viewers will be asked for their name before posting a comment.';
+    case 'pin':
+      return 'Viewers will be asked for a PIN before posting a comment.';
+    case 'name-pin':
+      return 'Viewers will be asked for their name and PIN before posting a comment.';
+  }
+};
+
+export const ActivityWallShareModal: React.FC<ActivityWallShareModalProps> = ({
+  isOpen,
+  onClose,
+  activity,
+  sessionId,
+  teacherUid,
+}) => {
+  const { addToast } = useDashboard();
+  const [allowComments, setAllowComments] = useState(true);
+  const [allowCommentResponses, setAllowCommentResponses] = useState(true);
+  const [allowLikes, setAllowLikes] = useState(true);
+  const [enableExpiration, setEnableExpiration] = useState(false);
+  const [expiresAtInput, setExpiresAtInput] = useState('');
+  const [creating, setCreating] = useState(false);
+  const [createdUrl, setCreatedUrl] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    setAllowComments(true);
+    setAllowCommentResponses(true);
+    setAllowLikes(true);
+    setEnableExpiration(false);
+    setExpiresAtInput('');
+    setCreating(false);
+    setCreatedUrl(null);
+    setCopied(false);
+    setError(null);
+  }, [isOpen, activity?.id]);
+
+  if (!isOpen) return null;
+
+  const handleCreate = async () => {
+    if (creating) return;
+    if (!activity || !sessionId || !teacherUid) {
+      setError(
+        'Start the activity first — there are no submissions to share yet.'
+      );
+      return;
+    }
+
+    let expiresAt: number | null = null;
+    if (enableExpiration) {
+      if (!expiresAtInput) {
+        setError('Pick an expiration date or turn off expiration.');
+        return;
+      }
+      const parsed = new Date(expiresAtInput).getTime();
+      if (Number.isNaN(parsed)) {
+        setError("That expiration date doesn't look right.");
+        return;
+      }
+      if (parsed <= Date.now()) {
+        setError('Expiration must be in the future.');
+        return;
+      }
+      expiresAt = parsed;
+    }
+
+    setCreating(true);
+    setError(null);
+
+    try {
+      const shareId = crypto.randomUUID();
+      const sharedDoc: SharedActivityWall = {
+        id: shareId,
+        sessionId,
+        originalAuthor: teacherUid,
+        title: activity.title,
+        prompt: activity.prompt,
+        mode: activity.mode,
+        identificationMode: activity.identificationMode,
+        allowComments,
+        allowCommentResponses: allowComments && allowCommentResponses,
+        allowLikes,
+        expiresAt,
+        createdAt: Date.now(),
+      };
+
+      // Unlock viewer reads first — if this fails we don't write the share
+      // doc, which would otherwise produce a working link that returns
+      // permission-denied on every photo/submission read.
+      await updateDoc(doc(db, 'activity_wall_sessions', sessionId), {
+        publiclyShared: true,
+      });
+
+      await setDoc(
+        doc(db, 'shared_activity_walls', shareId),
+        sharedDoc as unknown as Record<string, unknown>
+      );
+
+      const url = `${window.location.origin}/activity-wall/gallery/${shareId}`;
+      setCreatedUrl(url);
+      try {
+        await navigator.clipboard.writeText(url);
+        setCopied(true);
+      } catch {
+        // Clipboard may be blocked — user can still copy manually below.
+      }
+    } catch (err) {
+      console.error('[ActivityWallShareModal] Failed to create share:', err);
+      setError('Could not create the gallery link. Please try again.');
+      addToast('Failed to create gallery link.', 'error');
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  const handleCopy = async () => {
+    if (!createdUrl) return;
+    try {
+      await navigator.clipboard.writeText(createdUrl);
+      setCopied(true);
+      addToast('Gallery link copied!', 'success');
+    } catch {
+      addToast(
+        'Could not copy automatically — select the link to copy manually.',
+        'error'
+      );
+    }
+  };
+
+  // <input type="datetime-local"> wants a value in the form 'YYYY-MM-DDTHH:mm';
+  // surface today as the floor so teachers don't accidentally pick a
+  // past timestamp.
+  const minExpirationInput = (() => {
+    const now = new Date();
+    const tzOffsetMs = now.getTimezoneOffset() * 60_000;
+    return new Date(now.getTime() - tzOffsetMs).toISOString().slice(0, 16);
+  })();
+
+  return (
+    <Modal
+      isOpen
+      onClose={onClose}
+      ariaLabel="Create gallery share link"
+      maxWidth="max-w-md"
+      contentClassName=""
+      customHeader={
+        <div className="flex items-start justify-between px-5 pt-5 pb-3 border-b border-slate-100">
+          <div className="flex items-start gap-3">
+            <div className="shrink-0 w-9 h-9 rounded-lg bg-brand-blue-lighter/40 text-brand-blue-primary flex items-center justify-center">
+              <ExternalLink className="w-5 h-5" />
+            </div>
+            <div>
+              <h2 className="text-base font-bold text-slate-900">
+                {createdUrl
+                  ? 'Gallery link ready'
+                  : 'Share submissions gallery'}
+              </h2>
+              <p className="text-xs text-slate-500 mt-0.5 truncate max-w-[20rem]">
+                {activity?.title ?? 'Activity Wall'}
+              </p>
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close"
+            className="shrink-0 rounded-lg p-1 text-slate-400 hover:bg-slate-100 hover:text-slate-700 transition-colors cursor-pointer"
+          >
+            <X className="w-5 h-5" />
+          </button>
+        </div>
+      }
+    >
+      {createdUrl ? (
+        <div className="px-5 pb-5 pt-4 space-y-4">
+          <p className="text-xs text-slate-600">
+            Anyone with this link can view the submissions gallery — no sign-in
+            required.
+          </p>
+          <div className="flex items-center gap-2 rounded-lg border border-slate-200 bg-slate-50 px-3 py-2">
+            <input
+              type="text"
+              readOnly
+              value={createdUrl}
+              onFocus={(e) => e.currentTarget.select()}
+              className="flex-1 bg-transparent text-xs text-slate-700 truncate focus:outline-none"
+              aria-label="Share link URL"
+            />
+            <button
+              type="button"
+              onClick={() => void handleCopy()}
+              className={`shrink-0 inline-flex items-center gap-1 rounded-md px-2.5 py-1 text-xs font-bold transition-colors cursor-pointer ${
+                copied
+                  ? 'bg-emerald-100 text-emerald-700'
+                  : 'bg-brand-blue-primary text-white hover:bg-brand-blue-dark'
+              }`}
+            >
+              {copied ? (
+                <>
+                  <Check className="w-3.5 h-3.5" />
+                  Copied
+                </>
+              ) : (
+                <>
+                  <Copy className="w-3.5 h-3.5" />
+                  Copy
+                </>
+              )}
+            </button>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="w-full rounded-lg bg-slate-100 hover:bg-slate-200 text-slate-700 font-bold text-sm py-2 transition-colors cursor-pointer"
+          >
+            Done
+          </button>
+        </div>
+      ) : (
+        <div className="px-5 pb-5 pt-4 space-y-3">
+          <p className="text-xs text-slate-600">
+            Anyone with the link can view this activity&apos;s submissions
+            gallery. Pick what gallery viewers can do.
+          </p>
+
+          <ToggleRow
+            id="aw-share-allow-likes"
+            Icon={Heart}
+            title="Allow likes"
+            body="Viewers can give each submission a heart."
+            checked={allowLikes}
+            onChange={setAllowLikes}
+          />
+
+          <ToggleRow
+            id="aw-share-allow-comments"
+            Icon={MessageSquare}
+            title="Allow comments"
+            body={
+              activity
+                ? identificationModeBlurb(activity.identificationMode)
+                : 'Viewers can leave a comment on each submission.'
+            }
+            checked={allowComments}
+            onChange={(next) => {
+              setAllowComments(next);
+              if (!next) setAllowCommentResponses(false);
+            }}
+          />
+
+          <ToggleRow
+            id="aw-share-allow-replies"
+            Icon={MessageCircle}
+            title="Allow comment replies"
+            body="Viewers can reply to other people's comments."
+            checked={allowComments && allowCommentResponses}
+            disabled={!allowComments}
+            onChange={setAllowCommentResponses}
+          />
+
+          <div
+            className={`rounded-xl border bg-white px-4 py-3 transition-colors ${
+              enableExpiration
+                ? 'border-brand-blue-primary'
+                : 'border-slate-200'
+            }`}
+          >
+            <label
+              htmlFor="aw-share-enable-expiration"
+              className="flex items-start gap-3 cursor-pointer"
+            >
+              <div
+                className={`shrink-0 w-9 h-9 rounded-lg flex items-center justify-center ${
+                  enableExpiration
+                    ? 'bg-brand-blue-primary text-white'
+                    : 'bg-slate-100 text-slate-500'
+                }`}
+              >
+                <CalendarClock className="w-4 h-4" />
+              </div>
+              <div className="flex-1 min-w-0">
+                <h3 className="font-bold text-slate-900 text-sm">
+                  Set link expiration
+                </h3>
+                <p className="mt-0.5 text-xs text-slate-600 leading-relaxed">
+                  The link stops working after this date.
+                </p>
+              </div>
+              <input
+                id="aw-share-enable-expiration"
+                type="checkbox"
+                className="mt-1 h-4 w-4 accent-brand-blue-primary cursor-pointer"
+                checked={enableExpiration}
+                onChange={(e) => setEnableExpiration(e.target.checked)}
+              />
+            </label>
+            {enableExpiration && (
+              <div className="mt-3 pl-12">
+                <input
+                  type="datetime-local"
+                  value={expiresAtInput}
+                  min={minExpirationInput}
+                  onChange={(e) => setExpiresAtInput(e.target.value)}
+                  className="w-full rounded-md border border-slate-300 bg-white px-2 py-1.5 text-xs text-slate-700 focus:outline-none focus:ring-2 focus:ring-brand-blue-primary/40"
+                />
+              </div>
+            )}
+          </div>
+
+          {error && <p className="text-xs text-red-600 font-medium">{error}</p>}
+
+          <button
+            type="button"
+            onClick={() => void handleCreate()}
+            disabled={creating || !activity || !sessionId || !teacherUid}
+            className="w-full rounded-lg bg-brand-blue-primary hover:bg-brand-blue-dark text-white font-bold text-sm py-2 transition-colors disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer"
+          >
+            {creating ? 'Creating link…' : 'Create gallery link'}
+          </button>
+        </div>
+      )}
+    </Modal>
+  );
+};

--- a/components/widgets/ActivityWall/Widget.tsx
+++ b/components/widgets/ActivityWall/Widget.tsx
@@ -13,6 +13,7 @@ import {
   Pencil,
   Plus,
   QrCode,
+  Share2,
   Trash2,
   Users,
 } from 'lucide-react';
@@ -51,6 +52,7 @@ import {
 import { useGoogleDrive } from '@/hooks/useGoogleDrive';
 import { useActivityWallLibrary } from '@/hooks/useActivityWallLibrary';
 import { Modal } from '@/components/common/Modal';
+import { ActivityWallShareModal } from './ShareModal';
 
 const encodeActivityData = (
   activity: ActivityWallActivity,
@@ -318,6 +320,7 @@ export const ActivityWallWidget: React.FC<{ widget: WidgetData }> = ({
     null
   );
   const [showLiveView, setShowLiveView] = useState(false);
+  const [isShareModalOpen, setIsShareModalOpen] = useState(false);
 
   // ─── ClassLink target-class fetch (Phase 3D) ────────────────────────────
   // Teacher's ClassLink classes (if provisioned). Fetched once per widget
@@ -1734,7 +1737,7 @@ export const ActivityWallWidget: React.FC<{ widget: WidgetData }> = ({
             )}
 
             <div
-              className="grid grid-cols-2"
+              className="grid grid-cols-3"
               style={{ gap: 'min(6px, 1.8cqmin)' }}
             >
               <button
@@ -1772,6 +1775,26 @@ export const ActivityWallWidget: React.FC<{ widget: WidgetData }> = ({
                   }}
                 />
                 Pop-out QR
+              </button>
+              <button
+                type="button"
+                onClick={() => setIsShareModalOpen(true)}
+                disabled={!activeActivity || !activeSessionId || !user}
+                className="rounded-xl bg-violet-600 text-white font-bold flex items-center justify-center disabled:opacity-50"
+                style={{
+                  gap: 'min(6px, 1.8cqmin)',
+                  padding: 'min(8px, 2cqmin)',
+                  fontSize: 'min(11px, 3.8cqmin)',
+                }}
+                title="Share a view-only gallery of submissions"
+              >
+                <Share2
+                  style={{
+                    width: 'min(14px, 4cqmin)',
+                    height: 'min(14px, 4cqmin)',
+                  }}
+                />
+                Share gallery
               </button>
             </div>
 
@@ -2070,6 +2093,13 @@ export const ActivityWallWidget: React.FC<{ widget: WidgetData }> = ({
           </div>
         )}
       </Modal>
+      <ActivityWallShareModal
+        isOpen={isShareModalOpen}
+        onClose={() => setIsShareModalOpen(false)}
+        activity={activeActivity}
+        sessionId={activeSessionId}
+        teacherUid={user?.uid ?? null}
+      />
     </>
   );
 };

--- a/components/widgets/ActivityWall/Widget.tsx
+++ b/components/widgets/ActivityWall/Widget.tsx
@@ -52,7 +52,7 @@ import {
 import { useGoogleDrive } from '@/hooks/useGoogleDrive';
 import { useActivityWallLibrary } from '@/hooks/useActivityWallLibrary';
 import { Modal } from '@/components/common/Modal';
-import { ActivityWallShareModal } from './ShareModal';
+import { ActivityWallShareModal } from '@/components/widgets/ActivityWall/ShareModal';
 
 const encodeActivityData = (
   activity: ActivityWallActivity,

--- a/components/widgets/QuizWidget/components/QuizEditor.tsx
+++ b/components/widgets/QuizWidget/components/QuizEditor.tsx
@@ -60,6 +60,16 @@ const QUESTION_TYPES: {
     label: 'Ordering',
     hint: 'List items in the correct sequence. Drag rows or use arrows to reorder.',
   },
+  {
+    value: 'short',
+    label: 'Short Answer',
+    hint: 'Single-paragraph written response. Graded manually by the teacher.',
+  },
+  {
+    value: 'essay',
+    label: 'Essay',
+    hint: 'Multi-paragraph written response with rich text. Graded manually.',
+  },
 ];
 
 /** Stable empty array reused as the matchingDistractors fallback. */
@@ -70,6 +80,8 @@ const TYPE_BADGE: Record<QuizQuestionType, string> = {
   FIB: 'bg-amber-100 text-amber-800',
   Matching: 'bg-purple-100 text-purple-700',
   Ordering: 'bg-teal-100 text-teal-700',
+  short: 'bg-rose-100 text-rose-700',
+  essay: 'bg-rose-100 text-rose-700',
 };
 
 const labelClass =
@@ -317,14 +329,19 @@ export const QuizEditorDetailPane: React.FC<PaneProps> = ({ state }) => {
             <label className={labelClass}>Type</label>
             <select
               value={q.type}
-              onChange={(e) =>
+              onChange={(e) => {
+                const nextType = e.target.value as QuizQuestionType;
+                const isWritten = nextType === 'short' || nextType === 'essay';
                 updateQuestion(q.id, {
-                  type: e.target.value as QuizQuestionType,
-                  incorrectAnswers: e.target.value === 'MC' ? ['', ''] : [],
+                  type: nextType,
+                  incorrectAnswers: nextType === 'MC' ? ['', ''] : [],
                   correctAnswer: '',
                   matchingDistractors: undefined,
-                })
-              }
+                  // Reset written-specific fields when switching off written types
+                  placeholder: isWritten ? q.placeholder : undefined,
+                  maxWords: isWritten ? q.maxWords : undefined,
+                });
+              }}
               className={`${inputClass} appearance-none`}
             >
               {QUESTION_TYPES.map((t) => (
@@ -426,6 +443,62 @@ export const QuizEditorDetailPane: React.FC<PaneProps> = ({ state }) => {
               updateQuestion(q.id, { correctAnswer })
             }
           />
+        ) : q.type === 'short' || q.type === 'essay' ? (
+          <div className="space-y-3">
+            <div className="flex gap-2 p-2.5 bg-rose-50 border border-rose-200 text-rose-800 rounded-lg">
+              <AlertCircle className="w-4 h-4 shrink-0 mt-0.5" />
+              <p className="text-xs">
+                {q.type === 'short'
+                  ? 'Students answer in a single short paragraph. '
+                  : 'Students write a multi-paragraph response with rich text. '}
+                Responses are <strong>graded manually</strong> — open the
+                results panel after the quiz ends to award points.
+              </p>
+            </div>
+            <div>
+              <label className={labelClass}>Placeholder (optional)</label>
+              <input
+                type="text"
+                value={q.placeholder ?? ''}
+                onChange={(e) =>
+                  updateQuestion(q.id, {
+                    placeholder: e.target.value || undefined,
+                  })
+                }
+                placeholder="e.g. Cite at least two pieces of evidence."
+                className={inputClass}
+              />
+            </div>
+            <div>
+              <label className={labelClass}>Word Cap (optional)</label>
+              <div className="relative">
+                <input
+                  type="number"
+                  min={0}
+                  max={5000}
+                  value={q.maxWords ?? ''}
+                  onChange={(e) => {
+                    const raw = parseInt(e.target.value, 10);
+                    updateQuestion(q.id, {
+                      maxWords:
+                        Number.isFinite(raw) && raw > 0
+                          ? Math.min(5000, raw)
+                          : undefined,
+                    });
+                  }}
+                  placeholder="No cap"
+                  className={`${inputClass} pr-16`}
+                />
+                <span className="absolute right-3 top-1/2 -translate-y-1/2 text-slate-400 font-bold text-xxs uppercase tracking-wider">
+                  Words
+                </span>
+              </div>
+              <p className="text-xs text-slate-500 mt-1">
+                Shown to students as a soft warning. Not enforced — students can
+                exceed it.
+              </p>
+            </div>
+          </div>
         ) : (
           <div>
             <label className="block font-bold text-emerald-700 mb-1 text-xs uppercase tracking-wider">

--- a/components/widgets/QuizWidget/components/QuizEditorModal.tsx
+++ b/components/widgets/QuizWidget/components/QuizEditorModal.tsx
@@ -43,7 +43,9 @@ const questionsEqual = (a: QuizQuestion[], b: QuizQuestion[]): boolean => {
       qa.timeLimit !== qb.timeLimit ||
       (qa.points ?? 1) !== (qb.points ?? 1) ||
       (qa.allowPartialCredit === true) !== (qb.allowPartialCredit === true) ||
-      qa.incorrectAnswers.length !== qb.incorrectAnswers.length
+      qa.incorrectAnswers.length !== qb.incorrectAnswers.length ||
+      (qa.placeholder ?? '') !== (qb.placeholder ?? '') ||
+      (qa.maxWords ?? 0) !== (qb.maxWords ?? 0)
     ) {
       return false;
     }
@@ -110,7 +112,10 @@ export const QuizEditorModal: React.FC<QuizEditorModalProps> = ({
     if (questions.length === 0) errors.push('Add at least one question');
     questions.forEach((q, i) => {
       if (!q.text.trim()) errors.push(`Question ${i + 1}: text is required`);
-      if (!q.correctAnswer.trim())
+      // Written response types (short/essay) have no correct answer — they
+      // are manually graded by the teacher after the quiz closes.
+      const isWritten = q.type === 'short' || q.type === 'essay';
+      if (!isWritten && !q.correctAnswer.trim())
         errors.push(`Question ${i + 1}: correct answer is required`);
     });
     if (errors.length > 0) {

--- a/components/widgets/QuizWidget/components/QuizResults.tsx
+++ b/components/widgets/QuizWidget/components/QuizResults.tsx
@@ -354,9 +354,12 @@ export const QuizResults: React.FC<QuizResultsProps> = ({
     return m;
   }, [responses, pinToName, byStudentUid]);
 
-  // Save a manual grade for a single response/question pair. Writes the
-  // entire response.grading map (Firestore arrays/maps don't support
-  // partial nested updates without dot-paths and field-path escaping).
+  // Save a manual grade for a single response/question pair. Uses
+  // Firestore's dotted-field-path syntax so concurrent grades on
+  // different questions of the same response don't clobber each other
+  // (which would happen if we read-modify-wrote the whole `grading`
+  // map). Field-path updates merge atomically at the map-key level on
+  // the server.
   const saveWrittenGrade = useCallback(
     async (
       responseKey: string,
@@ -369,16 +372,6 @@ export const QuizResults: React.FC<QuizResultsProps> = ({
           'Cannot save grade: no active session in scope. Reopen the quiz results and try again.'
         );
       }
-      const target = responses.find(
-        (r) => (r._responseKey ?? r.studentUid) === responseKey
-      );
-      if (!target) {
-        throw new Error('Response no longer exists in this session.');
-      }
-      const nextGrading = {
-        ...(target.grading ?? {}),
-        [questionId]: grade,
-      };
       const ref = doc(
         db,
         QUIZ_SESSIONS_COLLECTION,
@@ -386,9 +379,10 @@ export const QuizResults: React.FC<QuizResultsProps> = ({
         RESPONSES_COLLECTION,
         responseKey
       );
-      await updateDoc(ref, { grading: nextGrading });
+      // Bracket-notation field path so Firestore merges this key only.
+      await updateDoc(ref, { [`grading.${questionId}`]: grade });
     },
-    [responses, session?.id]
+    [session?.id]
   );
 
   // Auto-publish this teacher's contribution to the PLC results aggregate.

--- a/components/widgets/QuizWidget/components/QuizResults.tsx
+++ b/components/widgets/QuizWidget/components/QuizResults.tsx
@@ -61,6 +61,14 @@ import { resolveResponseDisplayName } from '../utils/resolveDisplayName';
 import { useClickOutside } from '@/hooks/useClickOutside';
 import { useAssignmentPseudonyms } from '@/hooks/useAssignmentPseudonyms';
 import { PlcTab } from '@/components/common/library/PlcTab';
+import { WrittenResponseGrader } from './WrittenResponseGrader';
+import { doc, updateDoc } from 'firebase/firestore';
+import { db } from '@/config/firebase';
+import {
+  QUIZ_SESSIONS_COLLECTION,
+  RESPONSES_COLLECTION,
+} from '@/hooks/useQuizSession';
+import { Pencil } from 'lucide-react';
 
 /**
  * Export-error banner state. Generic errors render as a plain message; a
@@ -240,6 +248,7 @@ export const QuizResults: React.FC<QuizResultsProps> = ({
   }
   const [updatingSheet, setUpdatingSheet] = useState(false);
   const [exportError, setExportError] = useState<ExportErrorState | null>(null);
+  const [showGrader, setShowGrader] = useState(false);
   const [activeTab, setActiveTab] = useState<
     'overview' | 'questions' | 'students' | 'plc'
   >('overview');
@@ -322,6 +331,65 @@ export const QuizResults: React.FC<QuizResultsProps> = ({
     [rosters, resolvedPeriods]
   );
   const hasNames = Object.keys(pinToName).length > 0;
+
+  // Whether the underlying quiz contains any manual-grade question
+  // types. Used to surface the "Grade Written" entry-point only when
+  // it's actually useful.
+  const hasWrittenQuestions = useMemo(
+    () => quiz.questions.some((q) => q.type === 'short' || q.type === 'essay'),
+    [quiz.questions]
+  );
+
+  // Build a display-name lookup keyed by the response's deterministic
+  // doc key so the grader can show a real student name in its header
+  // rather than the raw uid/pin.
+  const displayNameByResponseKey = useMemo(() => {
+    const m = new Map<string, string>();
+    responses.forEach((r) => {
+      const key = r._responseKey ?? r.studentUid;
+      if (!key) return;
+      const name = resolveResponseDisplayName(r, pinToName, byStudentUid);
+      if (name) m.set(key, name);
+    });
+    return m;
+  }, [responses, pinToName, byStudentUid]);
+
+  // Save a manual grade for a single response/question pair. Writes the
+  // entire response.grading map (Firestore arrays/maps don't support
+  // partial nested updates without dot-paths and field-path escaping).
+  const saveWrittenGrade = useCallback(
+    async (
+      responseKey: string,
+      questionId: string,
+      grade: import('@/types').WrittenAnswerGrade
+    ) => {
+      const sessionId = session?.id;
+      if (!sessionId) {
+        throw new Error(
+          'Cannot save grade: no active session in scope. Reopen the quiz results and try again.'
+        );
+      }
+      const target = responses.find(
+        (r) => (r._responseKey ?? r.studentUid) === responseKey
+      );
+      if (!target) {
+        throw new Error('Response no longer exists in this session.');
+      }
+      const nextGrading = {
+        ...(target.grading ?? {}),
+        [questionId]: grade,
+      };
+      const ref = doc(
+        db,
+        QUIZ_SESSIONS_COLLECTION,
+        sessionId,
+        RESPONSES_COLLECTION,
+        responseKey
+      );
+      await updateDoc(ref, { grading: nextGrading });
+    },
+    [responses, session?.id]
+  );
 
   // Auto-publish this teacher's contribution to the PLC results aggregate.
   // Replaces the old "everyone must export to a shared Google Sheet" dance:
@@ -956,6 +1024,27 @@ export const QuizResults: React.FC<QuizResultsProps> = ({
           </p>
         </div>
 
+        {hasWrittenQuestions && (
+          <button
+            onClick={() => setShowGrader(true)}
+            className="flex items-center bg-rose-600 hover:bg-rose-700 text-white font-bold rounded-xl transition-all shadow-md active:scale-95 shrink-0"
+            style={{
+              gap: 'min(6px, 1.5cqmin)',
+              padding: 'min(8px, 2cqmin) min(12px, 3cqmin)',
+              fontSize: 'min(11px, 3.5cqmin)',
+            }}
+            title="Open the manual grading view for short-answer and essay responses."
+          >
+            <Pencil
+              style={{
+                width: 'min(14px, 4cqmin)',
+                height: 'min(14px, 4cqmin)',
+              }}
+            />
+            GRADE WRITTEN
+          </button>
+        )}
+
         {completed.length > 0 && (
           <div className="relative shrink-0">
             <button
@@ -1328,6 +1417,17 @@ export const QuizResults: React.FC<QuizResultsProps> = ({
           </div>
         </>
       )}
+
+      {showGrader && session?.id && user?.uid && (
+        <WrittenResponseGrader
+          quiz={quiz}
+          responses={responses}
+          displayNameByResponseKey={displayNameByResponseKey}
+          teacherUid={user.uid}
+          onSaveGrade={saveWrittenGrade}
+          onClose={() => setShowGrader(false)}
+        />
+      )}
     </div>
   );
 };
@@ -1492,7 +1592,15 @@ const QuestionsTab: React.FC<{
 
         if (qStats && q) {
           qStats.answered++;
-          if (gradeAnswer(q, a.answer).isCorrect) {
+          // Written types pass through `gradeAnswer` with the response's
+          // manual grade (if any) so awarded == max still counts as
+          // correct in the accuracy widget. Ungraded written responses
+          // count toward `answered` but not `correct`.
+          const manualGrade =
+            q.type === 'short' || q.type === 'essay'
+              ? r.grading?.[q.id]
+              : undefined;
+          if (gradeAnswer(q, a.answer, manualGrade).isCorrect) {
             qStats.correct++;
           }
         }
@@ -1523,12 +1631,22 @@ const QuestionsTab: React.FC<{
               >
                 Question {i + 1}
               </div>
-              <div
-                className="font-black text-brand-blue-dark"
-                style={{ fontSize: 'min(12px, 4cqmin)' }}
-              >
-                {pct}% Accuracy
-              </div>
+              {q.type === 'short' || q.type === 'essay' ? (
+                <div
+                  className="font-black text-rose-700 bg-rose-50 border border-rose-200 rounded px-2 py-0.5"
+                  style={{ fontSize: 'min(10px, 3cqmin)' }}
+                  title="Written responses are graded manually by the teacher."
+                >
+                  Manual grading
+                </div>
+              ) : (
+                <div
+                  className="font-black text-brand-blue-dark"
+                  style={{ fontSize: 'min(12px, 4cqmin)' }}
+                >
+                  {pct}% Accuracy
+                </div>
+              )}
             </div>
 
             <p

--- a/components/widgets/QuizWidget/components/WrittenResponseGrader.tsx
+++ b/components/widgets/QuizWidget/components/WrittenResponseGrader.tsx
@@ -19,7 +19,7 @@ import {
   X,
 } from 'lucide-react';
 import { QuizData, QuizResponse, WrittenAnswerGrade } from '@/types';
-import { sanitizeHtml } from '@/utils/security';
+import { sanitizeQuizResponse } from '@/utils/security';
 
 interface WrittenResponseGraderProps {
   quiz: QuizData;
@@ -87,7 +87,13 @@ export const WrittenResponseGrader: React.FC<WrittenResponseGraderProps> = ({
 
   const response = gradeableResponses[studentIdx];
   const question = writtenQuestions[questionIdx];
-  const responseKey = response?._responseKey;
+  // Match the keying scheme used by the parent's `displayNameByResponseKey`
+  // map and the `saveWrittenGrade` callback (`_responseKey ?? studentUid`).
+  // Without the fallback, any response written before deterministic keying
+  // shipped (where `_responseKey` is missing but `studentUid` is set) would
+  // silently fail to save here while the parent's lookup would have
+  // succeeded.
+  const responseKey = response?._responseKey ?? response?.studentUid;
 
   const studentLabel = useMemo(() => {
     if (!response) return '';
@@ -116,22 +122,45 @@ export const WrittenResponseGrader: React.FC<WrittenResponseGraderProps> = ({
     setSaveError(null);
   }
 
+  // Are there unsaved edits in the form? `savedGrade` is the persisted
+  // value; comparing string projections handles the "empty input vs.
+  // never-saved" case correctly. Used to warn the teacher before they
+  // navigate away from a row they were typing into.
+  const savedPointsStr =
+    savedGrade != null ? String(savedGrade.pointsAwarded) : '';
+  const savedCommentStr = savedGrade?.overallComment ?? '';
+  const isDirty = pointsInput !== savedPointsStr || comment !== savedCommentStr;
+
+  const confirmDiscardIfDirty = useCallback((): boolean => {
+    if (!isDirty) return true;
+    // Browser confirm is intentionally minimal — Phase 1 doesn't ship a
+    // custom modal-on-modal flow. Teachers rarely navigate away
+    // mid-edit; the warning is a safety net for accidental clicks.
+    return window.confirm(
+      'You have unsaved grade edits. Discard them and navigate anyway?'
+    );
+  }, [isDirty]);
+
   const goPrevStudent = useCallback(() => {
+    if (!confirmDiscardIfDirty()) return;
     setStudentIdx((i) => Math.max(0, i - 1));
-  }, []);
+  }, [confirmDiscardIfDirty]);
   const goNextStudent = useCallback(() => {
+    if (!confirmDiscardIfDirty()) return;
     setStudentIdx((i) =>
       Math.min(Math.max(0, gradeableResponses.length - 1), i + 1)
     );
-  }, [gradeableResponses.length]);
+  }, [gradeableResponses.length, confirmDiscardIfDirty]);
   const goPrevQuestion = useCallback(() => {
+    if (!confirmDiscardIfDirty()) return;
     setQuestionIdx((i) => Math.max(0, i - 1));
-  }, []);
+  }, [confirmDiscardIfDirty]);
   const goNextQuestion = useCallback(() => {
+    if (!confirmDiscardIfDirty()) return;
     setQuestionIdx((i) =>
       Math.min(Math.max(0, writtenQuestions.length - 1), i + 1)
     );
-  }, [writtenQuestions.length]);
+  }, [writtenQuestions.length, confirmDiscardIfDirty]);
 
   // Keyboard navigation. Only active when no input has focus — we don't
   // want left/right inside the points input to jump students.
@@ -162,7 +191,12 @@ export const WrittenResponseGrader: React.FC<WrittenResponseGraderProps> = ({
 
   const handleSave = useCallback(async () => {
     if (!response || !question || !responseKey) return;
-    const parsed = Number(pointsInput);
+    const trimmed = pointsInput.trim();
+    if (trimmed === '') {
+      setSaveError('Enter a numeric score.');
+      return;
+    }
+    const parsed = Number(trimmed);
     if (!Number.isFinite(parsed)) {
       setSaveError('Enter a numeric score.');
       return;
@@ -241,6 +275,7 @@ export const WrittenResponseGrader: React.FC<WrittenResponseGraderProps> = ({
     response.answers.find((a) => a.questionId === question.id)?.answer ?? '';
   const tabSwitches = response.tabSwitchWarnings ?? 0;
   const fullyGradedForThisQ = !!savedGrade;
+  const isLastStudent = studentIdx >= gradeableResponses.length - 1;
 
   return (
     <ModalShell onClose={onClose}>
@@ -343,7 +378,7 @@ export const WrittenResponseGrader: React.FC<WrittenResponseGraderProps> = ({
             <article
               className="bg-white border border-slate-200 rounded-lg p-5 text-sm leading-relaxed text-slate-800 prose prose-sm max-w-none"
               dangerouslySetInnerHTML={{
-                __html: sanitizeHtml(studentAnswer),
+                __html: sanitizeQuizResponse(studentAnswer),
               }}
             />
           ) : (
@@ -411,6 +446,8 @@ export const WrittenResponseGrader: React.FC<WrittenResponseGraderProps> = ({
           >
             {saving ? (
               <Loader2 className="w-4 h-4 animate-spin" />
+            ) : isLastStudent ? (
+              'Save grade'
             ) : (
               <>
                 Save &amp; next <ChevronRight className="w-4 h-4" />
@@ -432,10 +469,20 @@ const ModalShell: React.FC<{
   onClose: () => void;
   children: React.ReactNode;
 }> = ({ onClose, children }) => (
-  <div className="fixed inset-0 z-overlay flex items-center justify-center bg-slate-900/70 backdrop-blur-sm p-4">
-    <button
-      type="button"
-      aria-label="Close grader backdrop"
+  <div
+    role="dialog"
+    aria-modal="true"
+    aria-label="Grade written responses"
+    className="fixed inset-0 z-overlay flex items-center justify-center bg-slate-900/70 backdrop-blur-sm p-4"
+  >
+    {/*
+      Backdrop is a non-focusable div so Tab can't escape into it and so a
+      stray Space/Enter while focus is elsewhere doesn't close the modal.
+      Click-to-dismiss is preserved via onClick. Esc-to-close is wired in
+      the modal body's keydown listener.
+    */}
+    <div
+      aria-hidden
       className="absolute inset-0 cursor-default"
       onClick={onClose}
     />

--- a/components/widgets/QuizWidget/components/WrittenResponseGrader.tsx
+++ b/components/widgets/QuizWidget/components/WrittenResponseGrader.tsx
@@ -1,0 +1,448 @@
+/**
+ * WrittenResponseGrader — teacher-facing modal for manually grading
+ * `short` / `essay` quiz responses. Phase 1 surface: prev/next student
+ * navigation, points input, optional overall comment.
+ *
+ * Annotations (Phase 2) and rubric scoring (Phase 3) are out of scope
+ * here; the storage shape (`WrittenAnswerGrade.annotations`,
+ * `rubricScores`) is already reserved on the type so this component can
+ * grow into those features without a schema migration.
+ */
+
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  ChevronLeft,
+  ChevronRight,
+  CheckCircle2,
+  Loader2,
+  ShieldAlert,
+  X,
+} from 'lucide-react';
+import { QuizData, QuizResponse, WrittenAnswerGrade } from '@/types';
+import { sanitizeHtml } from '@/utils/security';
+
+interface WrittenResponseGraderProps {
+  quiz: QuizData;
+  responses: QuizResponse[];
+  /** Map from a response's deterministic doc key to a display name. */
+  displayNameByResponseKey?: Map<string, string>;
+  /**
+   * Persist a grade to Firestore. Receives the response's doc key (NOT
+   * `studentUid` — keys are pin-derived for anonymous joiners), the
+   * question id, and the full grade object. Caller is responsible for
+   * the Firestore write — keeps the modal pure / testable.
+   */
+  onSaveGrade: (
+    responseKey: string,
+    questionId: string,
+    grade: WrittenAnswerGrade
+  ) => Promise<void>;
+  /** Current teacher uid, stamped as `gradedBy` on each grade. */
+  teacherUid: string;
+  onClose: () => void;
+}
+
+export const WrittenResponseGrader: React.FC<WrittenResponseGraderProps> = ({
+  quiz,
+  responses,
+  displayNameByResponseKey,
+  onSaveGrade,
+  teacherUid,
+  onClose,
+}) => {
+  // Surface only the questions that actually need manual grading.
+  const writtenQuestions = useMemo(
+    () =>
+      quiz.questions.filter((q) => q.type === 'short' || q.type === 'essay'),
+    [quiz.questions]
+  );
+
+  // Drop responses that have no written answer at all — there's nothing
+  // to grade. Keep responses that have at least one written answer or
+  // already-graded entries (so a teacher can revise prior grades).
+  const gradeableResponses = useMemo(() => {
+    const ids = new Set(writtenQuestions.map((q) => q.id));
+    return responses.filter(
+      (r) =>
+        r.answers.some((a) => ids.has(a.questionId)) ||
+        (r.grading && Object.keys(r.grading).some((qid) => ids.has(qid)))
+    );
+  }, [responses, writtenQuestions]);
+
+  const [studentIdx, setStudentIdx] = useState(0);
+  const [questionIdx, setQuestionIdx] = useState(0);
+  const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+
+  // Clamp indices if the response/question list shrinks mid-session.
+  if (
+    studentIdx >= gradeableResponses.length &&
+    gradeableResponses.length > 0
+  ) {
+    setStudentIdx(0);
+  }
+  if (questionIdx >= writtenQuestions.length && writtenQuestions.length > 0) {
+    setQuestionIdx(0);
+  }
+
+  const response = gradeableResponses[studentIdx];
+  const question = writtenQuestions[questionIdx];
+  const responseKey = response?._responseKey;
+
+  const studentLabel = useMemo(() => {
+    if (!response) return '';
+    const fromMap = responseKey
+      ? displayNameByResponseKey?.get(responseKey)
+      : undefined;
+    if (fromMap) return fromMap;
+    if (response.pin) return `PIN ${response.pin}`;
+    return response.studentUid?.slice(0, 8) ?? 'Student';
+  }, [response, displayNameByResponseKey, responseKey]);
+
+  // Local draft state for the form, hydrated from the saved grade on
+  // every student/question change so unsaved edits don't bleed across
+  // students.
+  const savedGrade = response?.grading?.[question?.id ?? ''];
+  const maxPoints = question?.points ?? 1;
+  const [pointsInput, setPointsInput] = useState<string>('');
+  const [comment, setComment] = useState<string>('');
+  const [hydrationKey, setHydrationKey] = useState<string>('');
+
+  const targetKey = `${responseKey ?? ''}::${question?.id ?? ''}`;
+  if (targetKey !== hydrationKey) {
+    setHydrationKey(targetKey);
+    setPointsInput(savedGrade != null ? String(savedGrade.pointsAwarded) : '');
+    setComment(savedGrade?.overallComment ?? '');
+    setSaveError(null);
+  }
+
+  const goPrevStudent = useCallback(() => {
+    setStudentIdx((i) => Math.max(0, i - 1));
+  }, []);
+  const goNextStudent = useCallback(() => {
+    setStudentIdx((i) =>
+      Math.min(Math.max(0, gradeableResponses.length - 1), i + 1)
+    );
+  }, [gradeableResponses.length]);
+  const goPrevQuestion = useCallback(() => {
+    setQuestionIdx((i) => Math.max(0, i - 1));
+  }, []);
+  const goNextQuestion = useCallback(() => {
+    setQuestionIdx((i) =>
+      Math.min(Math.max(0, writtenQuestions.length - 1), i + 1)
+    );
+  }, [writtenQuestions.length]);
+
+  // Keyboard navigation. Only active when no input has focus — we don't
+  // want left/right inside the points input to jump students.
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        onClose();
+        return;
+      }
+      const target = e.target as HTMLElement | null;
+      const inField =
+        target instanceof HTMLInputElement ||
+        target instanceof HTMLTextAreaElement ||
+        target?.isContentEditable;
+      if (inField) return;
+      if (e.key === 'ArrowLeft' || e.key === 'k') {
+        e.preventDefault();
+        goPrevStudent();
+      } else if (e.key === 'ArrowRight' || e.key === 'j') {
+        e.preventDefault();
+        goNextStudent();
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [goPrevStudent, goNextStudent, onClose]);
+
+  const handleSave = useCallback(async () => {
+    if (!response || !question || !responseKey) return;
+    const parsed = Number(pointsInput);
+    if (!Number.isFinite(parsed)) {
+      setSaveError('Enter a numeric score.');
+      return;
+    }
+    if (parsed < 0 || parsed > maxPoints) {
+      setSaveError(`Score must be between 0 and ${maxPoints}.`);
+      return;
+    }
+    const grade: WrittenAnswerGrade = {
+      pointsAwarded: parsed,
+      overallComment: comment.trim() || undefined,
+      gradedBy: teacherUid,
+      gradedAt: Date.now(),
+    };
+    setSaving(true);
+    setSaveError(null);
+    try {
+      await onSaveGrade(responseKey, question.id, grade);
+      // After a successful save, advance to the next student to keep the
+      // teacher in flow. If we're on the last student, stay put.
+      if (studentIdx < gradeableResponses.length - 1) {
+        setStudentIdx(studentIdx + 1);
+      }
+    } catch (err) {
+      setSaveError(
+        err instanceof Error ? err.message : 'Failed to save grade.'
+      );
+    } finally {
+      setSaving(false);
+    }
+  }, [
+    response,
+    question,
+    responseKey,
+    pointsInput,
+    maxPoints,
+    comment,
+    teacherUid,
+    onSaveGrade,
+    studentIdx,
+    gradeableResponses.length,
+  ]);
+
+  if (writtenQuestions.length === 0) {
+    return (
+      <ModalShell onClose={onClose}>
+        <div className="p-10 text-center text-slate-600">
+          <p className="text-lg font-bold">
+            No written questions in this quiz.
+          </p>
+          <p className="text-sm text-slate-500 mt-2">
+            Manual grading is only available for short-answer and essay
+            questions.
+          </p>
+        </div>
+      </ModalShell>
+    );
+  }
+
+  if (gradeableResponses.length === 0 || !response || !question) {
+    return (
+      <ModalShell onClose={onClose}>
+        <div className="p-10 text-center text-slate-600">
+          <p className="text-lg font-bold">
+            No written responses to grade yet.
+          </p>
+          <p className="text-sm text-slate-500 mt-2">
+            Students haven&apos;t submitted any short-answer or essay responses.
+          </p>
+        </div>
+      </ModalShell>
+    );
+  }
+
+  const studentAnswer =
+    response.answers.find((a) => a.questionId === question.id)?.answer ?? '';
+  const tabSwitches = response.tabSwitchWarnings ?? 0;
+  const fullyGradedForThisQ = !!savedGrade;
+
+  return (
+    <ModalShell onClose={onClose}>
+      {/* Header */}
+      <header className="flex items-center justify-between px-5 py-3 border-b border-slate-200 bg-white">
+        <div className="flex items-center gap-3 min-w-0">
+          <button
+            onClick={goPrevStudent}
+            disabled={studentIdx === 0}
+            className="p-1.5 rounded text-slate-500 hover:bg-slate-100 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+            aria-label="Previous student (←)"
+            title="Previous student (←)"
+          >
+            <ChevronLeft className="w-5 h-5" />
+          </button>
+          <div className="min-w-0">
+            <div className="text-xs text-slate-500 font-bold uppercase tracking-wider">
+              Student {studentIdx + 1} of {gradeableResponses.length}
+            </div>
+            <div className="text-sm font-bold text-slate-900 truncate">
+              {studentLabel}
+              {fullyGradedForThisQ && (
+                <span className="ml-2 inline-flex items-center gap-1 px-1.5 py-0.5 rounded bg-emerald-100 text-emerald-700 text-xxs uppercase tracking-wider">
+                  <CheckCircle2 className="w-3 h-3" />
+                  Graded
+                </span>
+              )}
+              {tabSwitches > 0 && (
+                <span
+                  className="ml-2 inline-flex items-center gap-1 px-1.5 py-0.5 rounded bg-amber-100 text-amber-700 text-xxs uppercase tracking-wider"
+                  title={`${tabSwitches} tab switch warning${tabSwitches === 1 ? '' : 's'} during the assessment`}
+                >
+                  <ShieldAlert className="w-3 h-3" />
+                  {tabSwitches} tab switch{tabSwitches === 1 ? '' : 'es'}
+                </span>
+              )}
+            </div>
+          </div>
+          <button
+            onClick={goNextStudent}
+            disabled={studentIdx >= gradeableResponses.length - 1}
+            className="p-1.5 rounded text-slate-500 hover:bg-slate-100 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+            aria-label="Next student (→)"
+            title="Next student (→)"
+          >
+            <ChevronRight className="w-5 h-5" />
+          </button>
+        </div>
+        <button
+          onClick={onClose}
+          className="p-1.5 rounded text-slate-500 hover:bg-slate-100 transition-colors"
+          aria-label="Close grader"
+          title="Close (Esc)"
+        >
+          <X className="w-5 h-5" />
+        </button>
+      </header>
+
+      {/* Question switcher (only if there's more than one written Q) */}
+      {writtenQuestions.length > 1 && (
+        <div className="flex items-center gap-2 px-5 py-2 border-b border-slate-200 bg-slate-50">
+          <button
+            onClick={goPrevQuestion}
+            disabled={questionIdx === 0}
+            className="p-1 rounded text-slate-500 hover:bg-slate-200 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+            aria-label="Previous question"
+          >
+            <ChevronLeft className="w-4 h-4" />
+          </button>
+          <div className="text-xs text-slate-600">
+            Question {questionIdx + 1} of {writtenQuestions.length}
+            <span className="ml-2 text-slate-400">·</span>
+            <span className="ml-2 capitalize">{question.type}</span>
+          </div>
+          <button
+            onClick={goNextQuestion}
+            disabled={questionIdx >= writtenQuestions.length - 1}
+            className="p-1 rounded text-slate-500 hover:bg-slate-200 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+            aria-label="Next question"
+          >
+            <ChevronRight className="w-4 h-4" />
+          </button>
+        </div>
+      )}
+
+      {/* Body */}
+      <div className="flex-1 grid grid-cols-[1fr_320px] min-h-0">
+        <section className="overflow-y-auto p-6 bg-slate-50">
+          <h3 className="text-sm font-bold uppercase tracking-wider text-slate-500 mb-2">
+            Question
+          </h3>
+          <p className="text-base font-bold text-slate-900 mb-6 leading-snug">
+            {question.text}
+          </p>
+
+          <h3 className="text-sm font-bold uppercase tracking-wider text-slate-500 mb-2">
+            Student response
+          </h3>
+          {studentAnswer ? (
+            <article
+              className="bg-white border border-slate-200 rounded-lg p-5 text-sm leading-relaxed text-slate-800 prose prose-sm max-w-none"
+              dangerouslySetInnerHTML={{
+                __html: sanitizeHtml(studentAnswer),
+              }}
+            />
+          ) : (
+            <div className="bg-white border border-slate-200 rounded-lg p-5 text-sm text-slate-500 italic">
+              The student didn&apos;t answer this question.
+            </div>
+          )}
+        </section>
+
+        <aside className="border-l border-slate-200 bg-white p-5 flex flex-col gap-4 overflow-y-auto">
+          <div>
+            <label
+              htmlFor="grade-points"
+              className="block text-xs font-bold uppercase tracking-wider text-slate-500 mb-1"
+            >
+              Points awarded
+            </label>
+            <div className="flex items-baseline gap-2">
+              <input
+                id="grade-points"
+                type="number"
+                inputMode="decimal"
+                step="0.5"
+                min={0}
+                max={maxPoints}
+                value={pointsInput}
+                onChange={(e) => setPointsInput(e.target.value)}
+                className="w-24 px-3 py-2 bg-white border-2 border-emerald-500/30 rounded-lg text-emerald-800 font-bold focus:outline-none focus:border-emerald-500 text-base"
+                placeholder="0"
+                autoFocus
+              />
+              <span className="text-sm text-slate-500 font-mono">
+                / {maxPoints}
+              </span>
+            </div>
+          </div>
+
+          <div>
+            <label
+              htmlFor="grade-comment"
+              className="block text-xs font-bold uppercase tracking-wider text-slate-500 mb-1"
+            >
+              Overall comment (optional)
+            </label>
+            <textarea
+              id="grade-comment"
+              value={comment}
+              onChange={(e) => setComment(e.target.value)}
+              rows={6}
+              placeholder="Feedback for this student…"
+              className="w-full px-3 py-2 bg-white border border-slate-300 rounded-lg text-slate-900 placeholder:text-slate-400 focus:outline-none focus:ring-2 focus:ring-brand-blue-primary/40 focus:border-brand-blue-primary text-sm resize-none"
+            />
+          </div>
+
+          {saveError && (
+            <div className="p-2.5 bg-brand-red-lighter/40 border border-brand-red-primary/20 rounded-lg text-xs text-brand-red-dark font-bold">
+              {saveError}
+            </div>
+          )}
+
+          <button
+            onClick={() => void handleSave()}
+            disabled={saving}
+            className="w-full py-2.5 bg-brand-blue-primary hover:bg-brand-blue-dark disabled:opacity-50 disabled:cursor-not-allowed text-white font-bold rounded-lg flex items-center justify-center gap-2 transition-colors"
+          >
+            {saving ? (
+              <Loader2 className="w-4 h-4 animate-spin" />
+            ) : (
+              <>
+                Save &amp; next <ChevronRight className="w-4 h-4" />
+              </>
+            )}
+          </button>
+
+          <p className="text-xs text-slate-500 leading-relaxed">
+            ← / → switch students. Esc closes the grader. Phase 2 will add
+            inline highlights and margin comments; Phase 3 adds rubric scoring.
+          </p>
+        </aside>
+      </div>
+    </ModalShell>
+  );
+};
+
+const ModalShell: React.FC<{
+  onClose: () => void;
+  children: React.ReactNode;
+}> = ({ onClose, children }) => (
+  <div className="fixed inset-0 z-overlay flex items-center justify-center bg-slate-900/70 backdrop-blur-sm p-4">
+    <button
+      type="button"
+      aria-label="Close grader backdrop"
+      className="absolute inset-0 cursor-default"
+      onClick={onClose}
+    />
+    <div className="relative bg-white rounded-2xl shadow-2xl w-full max-w-6xl h-[90vh] flex flex-col overflow-hidden">
+      {children}
+    </div>
+  </div>
+);
+
+export default WrittenResponseGrader;

--- a/components/widgets/QuizWidget/utils/quizScoreboard.ts
+++ b/components/widgets/QuizWidget/utils/quizScoreboard.ts
@@ -62,7 +62,14 @@ export function getEarnedPoints(
     const q = qMap.get(ans.questionId);
     if (!q) continue;
 
-    const grade = gradeAnswer(q, ans.answer);
+    // Written types (`short`/`essay`) get their points from the response's
+    // top-level `grading` map. Without this thread-through, scoreboard
+    // totals and streaks treat every essay as 0 points / incorrect, which
+    // would break a student's streak any time their quiz mixes auto-graded
+    // and written items.
+    const manualGrade =
+      q.type === 'short' || q.type === 'essay' ? r.grading?.[q.id] : undefined;
+    const grade = gradeAnswer(q, ans.answer, manualGrade);
 
     if (grade.pointsEarned <= 0) {
       streak = 0;

--- a/context/DashboardContext.tsx
+++ b/context/DashboardContext.tsx
@@ -357,18 +357,29 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
 
   // Same-device cache invalidation across user accounts. The dock cache in
   // localStorage is keyed by the uid that last wrote it; on mount we only
-  // trust the cache when its uid matches the currently signed-in user.
-  // Mismatch → return defaults, so user B doesn't briefly see user A's
-  // layout while waiting for Firestore hydration. DashboardProvider is only
-  // mounted when `user` is truthy (see App.tsx), so a sign-out → sign-in as
-  // a different user remounts this component with a fresh user value.
+  // trust the cache when its uid matches the currently signed-in user or
+  // when no uid has been recorded yet (legacy migration: data was written
+  // by code before the cache-UID feature existed, so it belongs to whoever
+  // is currently signed in). DashboardProvider is only mounted when `user`
+  // is truthy (see App.tsx), so a sign-out → sign-in as a different user
+  // remounts this component with a fresh user value.
   const dockCacheUidRaw =
     typeof window !== 'undefined'
       ? localStorage.getItem('classroom_dock_cache_uid')
       : null;
+  // Trust localStorage when the recorded uid matches the current user OR
+  // when no uid is recorded at all (legacy / first run of the cache-UID
+  // feature). The latter is the migration path that lets long-time users
+  // keep their hand-curated docks on first load of the new Firestore-sync
+  // code instead of having them wiped.
   const dockCacheMatchesUser = user
-    ? dockCacheUidRaw === user.uid
+    ? dockCacheUidRaw === null || dockCacheUidRaw === user.uid
     : dockCacheUidRaw === null;
+  // True only when localStorage was explicitly written by a *different*
+  // user — the cross-account-leak case where we must wipe before mounting.
+  // Legacy null-uid data is preserved (see comment above).
+  const dockCacheBelongsToOtherUser =
+    !!user && dockCacheUidRaw !== null && dockCacheUidRaw !== user.uid;
 
   const [isDockInitialized, setIsDockInitialized] = useState<boolean>(() => {
     if (!dockCacheMatchesUser) return false;
@@ -611,8 +622,12 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
       }).map((tool) => tool.type);
     }
 
+    // Union dock defaults across *all* of the user's selected buildings.
+    // A teacher with both "high" and "middle" selected should see widgets
+    // marked as default for either — picking just `selectedBuildings[0]`
+    // dropped half the relevant defaults and was a frequent cause of
+    // near-empty docks on first sign-in.
     const tools: (WidgetType | InternalToolType)[] = [];
-    const buildingId = selectedBuildings[0];
 
     (featurePermissions ?? []).forEach((perm) => {
       const rawDockDefaults = perm.config?.dockDefaults as
@@ -620,7 +635,7 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
         | undefined;
 
       // Canonicalize stored keys so legacy IDs (`orono-high-school`) still
-      // match the canonical `buildingId` (`high`). Without this, every
+      // match the canonical buildingIds (`high`). Without this, every
       // teacher would fall through to the `time-tool` fallback below,
       // because admin-panel writes from before canonicalization landed
       // are keyed on legacy IDs and `selectedBuildings` is always
@@ -629,9 +644,10 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
         ? canonicalizeBuildingKeyedRecord(rawDockDefaults)
         : undefined;
 
-      const isDefaultForBuilding =
-        dockDefaults !== undefined && dockDefaults[buildingId] === true;
-      if (!isDefaultForBuilding) return;
+      const isDefaultForAnyBuilding =
+        dockDefaults !== undefined &&
+        selectedBuildings.some((bid) => dockDefaults[bid] === true);
+      if (!isDefaultForAnyBuilding) return;
 
       // Only include tools that the current user can actually access,
       // mirroring the same checks performed by canAccessWidget / the dock.
@@ -666,13 +682,29 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
 
     if (hasPersistedDockState) {
       try {
-        // Validate saved dock state before marking initialization complete.
-        // visibleTools/dockItems are already hydrated by their useState initializers.
+        // Re-hydrate state explicitly from localStorage rather than
+        // trusting the useState initializers — the initializers gate on
+        // `dockCacheMatchesUser`, and a future tightening of that check
+        // could leave state empty here without this fallback. Belt-and-
+        // suspenders: the initializers normally cover this, but the cost
+        // of an extra setState call is negligible and the cost of an
+        // empty dock is a user-visible regression.
         if (savedDockRaw !== null) {
-          JSON.parse(savedDockRaw);
-        }
-        if (savedVisibleToolsRaw !== null) {
-          JSON.parse(savedVisibleToolsRaw);
+          const parsedDock = JSON.parse(savedDockRaw) as DockItem[];
+          setDockItems(parsedDock);
+          // Derive visibleTools from dockItems so the two stores stay in
+          // sync — folder items count as visible too.
+          const derivedVisible = parsedDock.flatMap((item) =>
+            item.type === 'tool' ? item.toolType : item.folder.items
+          );
+          setVisibleTools(derivedVisible);
+        } else if (savedVisibleToolsRaw !== null) {
+          const parsedTools = JSON.parse(savedVisibleToolsRaw) as (
+            | WidgetType
+            | InternalToolType
+          )[];
+          setVisibleTools(parsedTools);
+          setDockItems(migrateToDockItems(parsedTools));
         }
         setIsDockInitialized(true);
         localStorage.setItem('classroom_dock_initialized', 'true');
@@ -895,12 +927,15 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
     };
   }, [user, dockHydrationOk, isDockInitialized, dockItems, libraryOrder]);
 
-  // Drop any stale dock localStorage entries left behind by a previous user
-  // on this device. We can't do this in the useState initializers because
-  // they shouldn't have side effects, so this runs once on mount when the
-  // cache uid sentinel doesn't match. Cache invalidation across accounts is
-  // primarily handled by the uid-gated useState initializers above; this
-  // just keeps localStorage tidy. A second user-switch in the same tab
+  // Drop any stale dock localStorage entries left behind by a *previous
+  // user* on this device. Legacy localStorage with no recorded uid is
+  // preserved — those entries belong to the currently signed-in user (they
+  // were written by code that predates the cache-UID feature) and the
+  // initializers will have already loaded them into state.
+  //
+  // Cross-user leak protection is primarily handled by the uid-gated
+  // initializers above; this just keeps localStorage tidy and claims the
+  // cache for the current user. A second user-switch in the same tab
   // session is impossible because DashboardProvider is conditionally
   // mounted on `user` (App.tsx) and remounts on each sign-in.
   const dockCacheCleanedRef = useRef(false);
@@ -908,20 +943,19 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
     if (isAuthBypass) return;
     if (dockCacheCleanedRef.current) return;
     dockCacheCleanedRef.current = true;
-    if (dockCacheMatchesUser) return;
-    localStorage.removeItem('classroom_dock_items');
-    localStorage.removeItem('classroom_visible_tools');
-    localStorage.removeItem('classroom_dock_initialized');
-    localStorage.removeItem('spartboard_library_order');
-    // Persist the new owner so subsequent reloads from cache succeed. The
-    // hydration/persistence effects below also keep this in sync on every
-    // write — this is just the initial claim.
-    if (user) {
-      localStorage.setItem('classroom_dock_cache_uid', user.uid);
-    } else {
-      localStorage.removeItem('classroom_dock_cache_uid');
+    if (!user) return;
+    if (dockCacheBelongsToOtherUser) {
+      localStorage.removeItem('classroom_dock_items');
+      localStorage.removeItem('classroom_visible_tools');
+      localStorage.removeItem('classroom_dock_initialized');
+      localStorage.removeItem('spartboard_library_order');
     }
-  }, [dockCacheMatchesUser, user]);
+    // Claim the cache for this user so subsequent reloads trust the
+    // localStorage cache and skip straight to the cloud-synced state. The
+    // hydration/persistence effects below keep this in sync on every
+    // write — this is just the initial claim.
+    localStorage.setItem('classroom_dock_cache_uid', user.uid);
+  }, [dockCacheBelongsToOtherUser, user]);
 
   // --- ROSTER LOGIC ---
   const {

--- a/docs/written-response-quiz-questions.md
+++ b/docs/written-response-quiz-questions.md
@@ -1,0 +1,416 @@
+# Written-Response Quiz Questions — Design Proposal
+
+**Status:** Draft for review
+**Author:** ops-pivers + Claude
+**Branch:** `claude/add-essay-quiz-questions-xNaoz`
+
+Adds short-answer and essay question types to the SpartBoard quiz, plus the
+teacher grading flow needed to make them usable: prev/next response navigation,
+inline highlights + margin comments, structured rubrics with a CSV import
+template, and pause/resume + tab-switch flagging for a more secure in-class
+assessment environment.
+
+---
+
+## 1. Goals & non-goals
+
+**Goals**
+
+- Students can answer short-answer (single line, rich-ish) and essay
+  (multi-paragraph, rich text) questions with autosave so a paused quiz can
+  resume the next class period exactly where the student left off.
+- Teachers can grade those responses one student at a time with prev/next
+  navigation, applying a structured rubric (criteria × performance levels) for
+  consistent scoring, and leaving inline highlights + margin comments visible
+  to students when scores are published.
+- Soft secure-assessment posture: visibility/focus tracking surfaced to the
+  teacher; no aggressive lockdown attempts.
+
+**Non-goals (explicit)**
+
+- AI-assisted grading suggestions. _(Not in this proposal. Worth a follow-up
+  once the manual flow is shipped.)_
+- File/image attachments in student responses.
+- Plagiarism detection.
+- Hard kiosk-mode lockdown (fullscreen API, copy/paste block). Brittle and
+  easy to defeat; not the right tradeoff.
+
+---
+
+## 2. Grounding: how the quiz works today
+
+Anchors from the current codebase (not speculation):
+
+- **Question types live in** `types.ts:2246-2276` — `'MC' | 'FIB' | 'Matching'
+| 'Ordering'`. Each `QuizQuestion` carries `id, timeLimit, text, type,
+correctAnswer, incorrectAnswers[], points?, allowPartialCredit?`.
+- **Response answers** are `QuizResponseAnswer` at `types.ts:2558-2572`:
+  `{questionId, answer, answeredAt, isCorrect?, speedBonus?}`. The `answer`
+  field is intentionally permissive (string today).
+- **Response status lifecycle** (`types.ts:2574`): `joined → in-progress →
+completed`. Transitions are rule-enforced; `completedAttempts` is
+  append-only (`firestore.rules:1822-1840`).
+- **Autosave precedent**: `components/plc/bodies/NotesBody.tsx` uses a
+  ~500ms debounce + flush-on-unmount pattern. We reuse this.
+- **Tab-switch tracking already exists**: `QuizStudentApp.tsx:230-370`
+  listens to `visibilitychange` and `blur`, increments
+  `tabSwitchWarnings` on the response doc, and surfaces a 3-strike modal.
+  Gated by `tabWarningsEnabled` (`types.ts:2352`). Teacher has an
+  `unlockStudentAttempt` escape hatch (`useQuizSession.ts:498`).
+- **Auto-grading happens client-side** in `gradeAnswer`
+  (`useQuizSession.ts:191-251`) and `QuizResults`. There is **no manual
+  grading UI today** — written responses force us to build one.
+- **No rich-text editor exists anywhere** in the repo. `dompurify@3.4.2` is
+  already a dep, which we'll need.
+- **No text-annotation pattern exists**. The `annotation` color on
+  `DraggableWindow` is unrelated (widget chrome). This is greenfield.
+
+---
+
+## 3. Question-type additions
+
+Add to `WidgetType`-style discriminant in `types.ts`:
+
+```ts
+type QuestionType = 'MC' | 'FIB' | 'Matching' | 'Ordering' | 'short' | 'essay';
+```
+
+|            | `short`                                                                    | `essay`                                                                      |
+| ---------- | -------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
+| Editor     | Single-paragraph TipTap (no enter-for-newline; bold/italic/underline only) | Full TipTap (paragraphs, lists, bold/italic/underline, optional inline code) |
+| Word cap   | Optional `maxWords` (config)                                               | Optional `maxWords`                                                          |
+| Time limit | Per-question allowed (existing field)                                      | Per-question allowed; typically left unset on essay                          |
+| Auto-grade | None — always manual                                                       | None — always manual                                                         |
+| Rubric     | Optional                                                                   | Optional but recommended                                                     |
+
+**Storage shape** (extension to `QuizResponseAnswer`):
+
+```ts
+type QuizResponseAnswer = {
+  questionId: string;
+  answer: string; // existing — for written, this is a serialized TipTap JSON doc
+  answeredAt: number;
+  isCorrect?: boolean; // unused for written
+  speedBonus?: number; // unused for written
+  // NEW (optional, only present for written responses):
+  written?: {
+    docVersion: 1; // schema version for forward-compat
+    plainText: string; // sanitized text, used for word-count, search, exports
+    wordCount: number;
+    lastEditedAt: number;
+  };
+  grading?: {
+    // populated by teacher
+    pointsAwarded: number;
+    rubricScores?: RubricScore[]; // see §6
+    annotations?: Annotation[]; // see §5
+    overallComment?: string; // teacher's summary note
+    gradedBy: string; // teacher uid
+    gradedAt: number;
+  };
+};
+```
+
+`answer` continues to be a string field at the Firestore level (the TipTap
+JSON serialized) so rules stay simple. The `written.plainText` mirror is
+what we sanitize and read for word counts / Drive exports.
+
+---
+
+## 4. Rich text editor
+
+**Recommendation: TipTap (ProseMirror under the hood).**
+
+Why:
+
+- Annotations are first-class via ProseMirror **marks** — exactly what we
+  need for highlights tied to ranges (see §5 recommendation).
+- StarterKit + a handful of extensions covers everything we need;
+  lazy-loaded on the quiz route, bundle impact is ~80-120 KB gzipped and only
+  paid when a written question is rendered.
+- Document is serialized as JSON, sanitized via `dompurify` on render. We
+  already have `dompurify@3.4.2`.
+
+**Student editor surface** (kept deliberately minimal):
+
+- Bold, Italic, Underline
+- Bulleted list, Numbered list (essay only)
+- Undo/Redo
+- Live word count (if `maxWords` set, soft warning past the cap, never a
+  hard block — teachers can decide whether to penalize)
+
+**No** image upload, no tables, no link insertion (link autocompletion turned
+off — pasting plain text only by default). The student editor is a writing
+surface, not a publishing tool.
+
+**Autosave**: 500ms debounce mirroring `NotesBody.tsx`; on unmount, on
+`visibilitychange:hidden`, and on the existing pause action, flush
+synchronously. Writes go to the same response doc the existing `submitAnswer`
+path already touches — no new collection needed.
+
+---
+
+## 5. Annotations (highlights + margin comments)
+
+### Recommendation
+
+**Store annotations as ProseMirror marks inside the student's document.**
+Reason: marks move with the text. If the response gets edited in a future
+"request revisions" flow, a comment anchored to a sentence travels with that
+sentence; sidecar-by-offset comments would drift the moment anyone touches
+the doc.
+
+To make this work cleanly, the student's submitted document is **frozen** at
+grading time (status becomes `completed` and a serialized snapshot is what
+the teacher annotates). If teachers later allow revisions, we copy
+annotations onto the new doc as best-effort — but that's a future-phase
+concern, not Phase 2.
+
+### Annotation shape
+
+```ts
+type Annotation = {
+  id: string; // uuid
+  range: { from: number; to: number }; // ProseMirror positions in the snapshot doc
+  highlightColor: 'yellow' | 'green' | 'pink' | 'blue';
+  comment?: string; // optional margin note; an annotation can be a bare highlight
+  authorUid: string;
+  createdAt: number;
+};
+```
+
+Rendered as:
+
+- A `highlight` mark with `data-annotation-id` on the marked text.
+- A right-rail margin column showing comments anchored to their highlights.
+  Hovering a highlight scrolls/focuses the corresponding margin note and
+  vice versa.
+
+### Student view of annotations
+
+When the teacher publishes scores (`scoreVisibility` already exists in
+`QuizAssignment`), the student score-review screen renders the same snapshot
+in a **read-only** TipTap instance with highlight marks + margin comments
+visible. No editing surface, no reply (Phase 4 if we want a back-and-forth).
+
+---
+
+## 6. Rubric (structured)
+
+### Data model
+
+A rubric is a teacher-owned, reusable object. Recommendation:
+
+```
+/users/{teacherUid}/rubrics/{rubricId}
+```
+
+```ts
+type Rubric = {
+  id: string;
+  title: string; // "AP Lang DBQ Rubric"
+  description?: string;
+  criteria: RubricCriterion[];
+  createdAt: number;
+  updatedAt: number;
+};
+
+type RubricCriterion = {
+  id: string;
+  name: string; // "Thesis & Argument"
+  description?: string;
+  levels: RubricLevel[]; // ordered low → high
+};
+
+type RubricLevel = {
+  id: string;
+  label: string; // "Exceeds", "Meets", "Approaching", "Below"
+  points: number; // 4, 3, 2, 1
+  description?: string;
+};
+```
+
+A `QuizQuestion` of type `essay` or `short` gets an optional
+`rubricId` (referencing the teacher's saved rubric) or an inline rubric
+snapshot embedded in the question (so the rubric is stable even if the
+teacher later edits the saved version — important for past assignments).
+
+### Grading capture
+
+```ts
+type RubricScore = {
+  criterionId: string;
+  levelId: string;
+  points: number; // snapshot for resilience
+  note?: string; // optional per-criterion comment
+};
+```
+
+Total points for the question = sum of `RubricScore.points`, capped at the
+question's `points` value. (Or weighted; that's a future-phase enhancement.)
+
+### CSV import template
+
+A downloadable starter CSV (`rubric-template.csv`) shipped under
+`public/templates/` and linked from the rubric builder modal:
+
+```csv
+Criterion,Description,Level 1 Label,Level 1 Points,Level 1 Description,Level 2 Label,Level 2 Points,Level 2 Description,Level 3 Label,Level 3 Points,Level 3 Description,Level 4 Label,Level 4 Points,Level 4 Description
+Thesis & Argument,The clarity and defensibility of the thesis,Below,1,No clear thesis,Approaching,2,Implied thesis,Meets,3,Clear defensible thesis,Exceeds,4,Sophisticated nuanced thesis
+Evidence,Use of textual evidence,Below,1,No evidence,Approaching,2,Minimal evidence,Meets,3,Sufficient relevant evidence,Exceeds,4,Rich varied evidence
+```
+
+Parser: standard CSV (use `papaparse`, already commonly used or we add it
+~13 KB). Up to 6 levels supported on import; UI builder allows 2-6 levels.
+
+Export: the same shape — teachers can round-trip rubrics, share them with
+PLC peers via the existing `shared_assignments` pattern.
+
+---
+
+## 7. Teacher grading UI
+
+A new modal/page reached from `QuizResults`: **"Grade written responses."**
+Opens to the first ungraded response.
+
+**Layout (desktop):**
+
+```
+┌───────────────────────────────────────────────────────────────────────┐
+│  ← Prev student   Student 7 of 24 — Maya Chen  [Ungraded▾]  Next →    │
+├──────────────────────────────────────────────┬────────────────────────┤
+│  Question 3 of 5: "Explain the role of..."   │  RUBRIC                │
+│                                              │  ─ Thesis              │
+│  [TipTap snapshot of student's response,     │    ○ Below     1 pt    │
+│   read-only, highlight toolbar on selection] │    ● Approaching 2 pt  │
+│                                              │    ○ Meets     3 pt    │
+│  [margin comments column on the right of     │    ○ Exceeds   4 pt    │
+│   the response]                              │  ─ Evidence  ...        │
+│                                              │  Total: 7 / 16          │
+│                                              │  Overall comment: [   ] │
+├──────────────────────────────────────────────┴────────────────────────┤
+│  [Save & next ungraded]  [Save]  [Skip]                                │
+└───────────────────────────────────────────────────────────────────────┘
+```
+
+Keyboard:
+
+- `J` / `K` or `←` / `→` — prev / next student
+- `Cmd/Ctrl+S` — save current grading
+- Select text → highlight palette appears inline; pressing `C` opens a
+  comment input on the selection.
+
+**Status tracking**: each response carries a per-question `grading` block.
+A response is "fully graded" when every written question has a `grading`
+entry. The header chip shows `Ungraded / Partially graded / Graded`.
+
+---
+
+## 8. Pause / resume & soft lockdown
+
+Mostly free, given what's already there:
+
+- **Pause**: `QuizAssignment.status` already supports `'active' | 'paused' |
+'inactive'` (`types.ts:2936-3010`). Student client checks the parent
+  session status on each tick and, when `paused`, freezes the editor in a
+  read-only state with a "Paused by teacher — your work is saved" overlay.
+  No new fields needed.
+- **Resume next day**: because the response doc persists `answers[]` keyed by
+  `questionId`, the student re-joins via the same deterministic
+  `_responseKey` (`useQuizSession.ts:317-325`), the editor rehydrates from
+  the TipTap JSON in `answer`, and cursor lands at end-of-doc.
+- **Tab-switch flagging (already implemented)**: `tabWarningsEnabled` gates
+  the existing visibility/blur listeners (`QuizStudentApp.tsx:230-370`). We
+  surface counts more prominently in the teacher's monitor for written
+  responses — a chip like "⚠ 2 tab switches" next to each student in the
+  grading nav. No new client-side enforcement; warnings are signal, not
+  punishment.
+
+Explicitly out of scope: fullscreen-API enforcement, copy/paste blocking,
+right-click suppression.
+
+---
+
+## 9. Firestore rules — required changes
+
+Minimal. The response doc shape stays the same at the rule level (we're just
+storing a larger string + an optional `grading` field).
+
+Adds needed in `firestore.rules`:
+
+1. Allow teacher (`teacherUid == request.auth.uid` on the parent session) to
+   write the `grading` field on a response doc. Currently student-only.
+   This needs careful merge-path rules so teacher writes can't reset
+   `answers` or `tabSwitchWarnings`.
+2. New collection `/users/{userId}/rubrics/{rubricId}` — owner-only
+   read/write, mirroring the existing per-user collection patterns
+   (`firestore.rules:508-518` is the right template).
+3. PLC sharing of rubrics piggybacks on the existing `shared_assignments`
+   collection model — Phase 3 only.
+
+The append-only `tabSwitchWarnings` / `completedAttempts` constraints stay
+exactly as they are.
+
+---
+
+## 10. Open questions
+
+1. **Submission finality.** Today, a `completed` response can be unlocked by
+   the teacher via `unlockStudentAttempt`. For multi-day essays, do we want
+   a separate "submitted for grading" state distinct from `completed`, or
+   does `completed` cover both? _Leaning: reuse `completed`; pause/resume is
+   the multi-day mechanism, and `completed` means "I'm done writing."_
+2. **Rubric edit vs snapshot.** When a teacher edits a saved rubric after
+   it's been used to grade past quizzes — do past grades update? _Leaning:
+   no, embed a snapshot on the question at assignment time._
+3. **Where rubrics live in the UI.** Inside Quiz settings only? Or a
+   top-level "Rubrics" admin area surfaced from the dashboard? _Leaning:
+   start inside Quiz settings; promote later if usage warrants it._
+4. **Anonymous grading.** Some teachers prefer to grade without seeing
+   student names (bias mitigation). Worth a toggle in the grader header?
+5. **Drive export for written responses.** `QuizResults` exports to Google
+   Sheets today. Long essay text will look awful in a spreadsheet cell —
+   should we also support a Google Docs export with one section per student?
+
+---
+
+## 11. Phased PR plan
+
+- **Phase 1 — Foundation (this design's scope to start)**
+  - `short` and `essay` question types in `types.ts`, builder UI in
+    `QuizEditor`, default config in `config/widgetDefaults.ts` if applicable.
+  - TipTap student editor, lazy-loaded on quiz route.
+  - Autosave to `answers[].answer` (TipTap JSON) + `written.plainText`.
+  - Pause/resume rehydration (mostly works already; verify with E2E).
+  - Manual grading modal with prev/next nav, points-only entry (no rubric,
+    no annotations yet).
+  - Teacher rule allowing `grading` field write.
+  - Soft-lockdown polish: surface tab-switch count in grading header.
+
+- **Phase 2 — Annotations**
+  - Highlight marks + margin comments in the grader.
+  - Read-only student score-review screen with highlights/comments.
+  - Snapshot-at-grading-time behavior.
+
+- **Phase 3 — Rubrics**
+  - Rubric data model + per-user collection + rules.
+  - Builder UI, CSV import/export template at
+    `public/templates/rubric-template.csv`.
+  - Rubric scoring panel in grader; embedded snapshot on question.
+  - PLC sharing.
+
+- **Phase 4 (optional)** — AI-assisted draft grading, revision requests with
+  annotation migration, anonymous-grading toggle, Docs export.
+
+---
+
+## 12. Testing checklist (per phase)
+
+- **Phase 1**: unit tests for TipTap JSON ↔ plainText conversion, autosave
+  debounce, word-count cap behavior; E2E for pause-then-resume-next-day
+  scenario using Playwright; rules tests asserting teacher-write-only of
+  `grading` field and student-write-only of everything else.
+- **Phase 2**: annotation range survives sanitization round-trip; student
+  read-only render shows highlights at correct offsets.
+- **Phase 3**: CSV import round-trips losslessly; rubric snapshot doesn't
+  change when source rubric is edited; total points capping works.

--- a/docs/written-response-quiz-questions.md
+++ b/docs/written-response-quiz-questions.md
@@ -83,53 +83,95 @@ type QuestionType = 'MC' | 'FIB' | 'Matching' | 'Ordering' | 'short' | 'essay';
 | Auto-grade | None — always manual                                                       | None — always manual                                                         |
 | Rubric     | Optional                                                                   | Optional but recommended                                                     |
 
-**Storage shape** (extension to `QuizResponseAnswer`):
+**Storage shape** (revised after Gemini review feedback — keeps grading
+**off** the `answers[]` array for security and document-size reasons):
 
 ```ts
+// Existing array entry — unchanged shape for written responses. The
+// `answer` string is now the (sanitized) HTML body of the student's
+// rich-text response. No plainText mirror — plain text is derived
+// on the fly when needed (word counts, exports).
 type QuizResponseAnswer = {
   questionId: string;
-  answer: string; // existing — for written, this is a serialized TipTap JSON doc
+  answer: string; // for written: sanitized HTML body
   answeredAt: number;
-  isCorrect?: boolean; // unused for written
+  isCorrect?: boolean; // unused for written (see note below)
   speedBonus?: number; // unused for written
-  // NEW (optional, only present for written responses):
-  written?: {
-    docVersion: 1; // schema version for forward-compat
-    plainText: string; // sanitized text, used for word-count, search, exports
-    wordCount: number;
-    lastEditedAt: number;
-  };
-  grading?: {
-    // populated by teacher
-    pointsAwarded: number;
-    rubricScores?: RubricScore[]; // see §6
-    annotations?: Annotation[]; // see §5
-    overallComment?: string; // teacher's summary note
-    gradedBy: string; // teacher uid
-    gradedAt: number;
-  };
+};
+
+// NEW top-level map on the response doc, keyed by questionId. Lives
+// outside `answers[]` so teacher writes are granular and never need to
+// rewrite the student's answer array.
+type QuizResponse = {
+  // ...existing fields...
+  grading?: { [questionId: string]: WrittenAnswerGrade };
+};
+
+type WrittenAnswerGrade = {
+  pointsAwarded: number; // 0..question.points
+  overallComment?: string; // teacher's summary note
+  rubricScores?: RubricScore[]; // Phase 3
+  annotations?: Annotation[]; // Phase 2 — see §5 open question
+  gradedBy: string; // teacher uid
+  gradedAt: number;
 };
 ```
 
-`answer` continues to be a string field at the Firestore level (the TipTap
-JSON serialized) so rules stay simple. The `written.plainText` mirror is
-what we sanitize and read for word counts / Drive exports.
+**Why grading lives outside `answers[]`** (response to Gemini review of
+2026-05-13):
+
+- Firestore rules can already deny student writes to `grading` for free
+  via the existing student `changedKeys().hasOnly([...])` whitelist at
+  `firestore.rules:1814` — `grading` simply isn't in the list.
+- The teacher branch (`request.auth.uid == sessionTeacherUid()`) is
+  unrestricted today, so teachers can write `grading` without needing
+  CEL gymnastics to validate the student's `answer` text was untouched.
+  Putting `grading` inside the answers array would require either
+  rewriting the array as a Map keyed by questionId or moving answers
+  to a subcollection — large breaking changes outside Phase 1 scope.
+- Phase 1 keeps the existing `answers[]` array shape exactly as-is for
+  the four legacy question types.
+
+**Why no `plainText` mirror**:
+
+- Doubles per-response payload for long essays and pushes harder against
+  the 1 MB Firestore doc limit.
+- Easy to derive on demand: `domparser → textContent` on render, plus
+  a small helper in `utils/` for Drive export.
+- Word counts run in the editor against the live document; nothing in
+  Firestore needs them.
+
+**Note on `isCorrect`**: written responses do not set `isCorrect` at the
+student-submission boundary (same as today). Downstream reporting
+(`QuizResults`) derives correctness for written responses as
+`grading.pointsAwarded === pointsMax` when a grade is present, and treats
+the question as "ungraded" until then.
 
 ---
 
 ## 4. Rich text editor
 
-**Recommendation: TipTap (ProseMirror under the hood).**
+**Phase 1 implementation: `contenteditable` + DOMPurify.** No new
+dependency, sanitized HTML in/out, ~5 KB of widget code rather than
+~100 KB of editor framework. Sufficient for the bold/italic/list/word-
+count needs of Phase 1.
 
-Why:
+**Phase 2 swap: TipTap (ProseMirror).** Bringing TipTap in is justified
+the moment we want annotations as first-class ProseMirror **marks**
+(see §5). Until then it's not worth the bundle hit. The schema (sanitized
+HTML in `answer`) stays compatible — TipTap can `setContent(html)` to
+hydrate from existing responses.
 
-- Annotations are first-class via ProseMirror **marks** — exactly what we
-  need for highlights tied to ranges (see §5 recommendation).
-- StarterKit + a handful of extensions covers everything we need;
-  lazy-loaded on the quiz route, bundle impact is ~80-120 KB gzipped and only
-  paid when a written question is rendered.
-- Document is serialized as JSON, sanitized via `dompurify` on render. We
-  already have `dompurify@3.4.2`.
+Why this split:
+
+- The student-facing editor in Phase 1 is a writing surface, not a
+  publishing tool. A toolbar of bold/italic/lists over a sanitized
+  contenteditable handles the bulk of what teachers actually want.
+- ProseMirror's value (real document model, marks, immutable transforms,
+  collaborative editing primitives) pays off when we build annotations
+  on top of student documents. We can defer that bundle cost.
+- `dompurify@3.4.2` already ships in the bundle, so sanitization on
+  every read/write is free.
 
 **Student editor surface** (kept deliberately minimal):
 
@@ -150,21 +192,25 @@ path already touches — no new collection needed.
 
 ---
 
-## 5. Annotations (highlights + margin comments)
+## 5. Annotations (highlights + margin comments) — Phase 2
 
-### Recommendation
-
-**Store annotations as ProseMirror marks inside the student's document.**
-Reason: marks move with the text. If the response gets edited in a future
-"request revisions" flow, a comment anchored to a sentence travels with that
-sentence; sidecar-by-offset comments would drift the moment anyone touches
-the doc.
-
-To make this work cleanly, the student's submitted document is **frozen** at
-grading time (status becomes `completed` and a serialized snapshot is what
-the teacher annotates). If teachers later allow revisions, we copy
-annotations onto the new doc as best-effort — but that's a future-phase
-concern, not Phase 2.
+> **Open question flagged by Gemini review (2026-05-13):** there is a
+> real technical tension between two of the goals stated below — "marks
+> move with the text" vs. "teacher must not modify the student's
+> `answer` JSON." The pragmatic resolution is one of:
+>
+> 1. **Snapshot the document at grading time** to a teacher-owned
+>    `gradingSnapshot` field, and store marks _on the snapshot_. The
+>    student's `answer` stays untouched. Annotations only travel with
+>    the snapshot — fine, because revisions are a Phase 4 concern.
+> 2. **Sidecar offsets** stored under `grading[questionId].annotations`,
+>    with a deterministic re-mapping pass if the student ever revises
+>    the doc later.
+>
+> Phase 2 will pick one. The doc below originally argued for marks-in-
+> document, but that conflicts with the security-first stance that
+> teachers don't rewrite student `answer` text. Decision deferred to
+> Phase 2 design.
 
 ### Annotation shape
 
@@ -333,23 +379,31 @@ right-click suppression.
 
 ## 9. Firestore rules — required changes
 
-Minimal. The response doc shape stays the same at the rule level (we're just
-storing a larger string + an optional `grading` field).
+After the schema revision (grading lives in a top-level `grading` map,
+not inside `answers[]`), Phase 1 needs **zero new permissive rules**:
 
-Adds needed in `firestore.rules`:
+1. **Teachers can already write `grading`** — the existing teacher
+   branch on `match /responses/{responseKey}` is
+   `request.auth.uid == sessionTeacherUid() || isAdmin()` with no
+   field restrictions (`firestore.rules:1773-1775`). Adding the new
+   `grading` field is permitted automatically.
+2. **Students cannot write `grading`** — the student-update branch at
+   `firestore.rules:1814` already locks writes to a strict whitelist:
+   `changedKeys().hasOnly(['answers', 'status', 'submittedAt',
+'tabSwitchWarnings', 'completedAttempts', 'classPeriod', 'score',
+'preSyncVersion', 'unlocked'])`. `grading` is not in that list, so
+   any student write including it is rejected by default. No rule
+   change needed for student-side protection.
+3. **Rubrics collection (Phase 3 only)**: `/users/{userId}/rubrics/{rubricId}`
+   — owner-only read/write, mirroring `firestore.rules:508-518`.
 
-1. Allow teacher (`teacherUid == request.auth.uid` on the parent session) to
-   write the `grading` field on a response doc. Currently student-only.
-   This needs careful merge-path rules so teacher writes can't reset
-   `answers` or `tabSwitchWarnings`.
-2. New collection `/users/{userId}/rubrics/{rubricId}` — owner-only
-   read/write, mirroring the existing per-user collection patterns
-   (`firestore.rules:508-518` is the right template).
-3. PLC sharing of rubrics piggybacks on the existing `shared_assignments`
-   collection model — Phase 3 only.
+The append-only `tabSwitchWarnings` / `completedAttempts` constraints
+stay exactly as they are.
 
-The append-only `tabSwitchWarnings` / `completedAttempts` constraints stay
-exactly as they are.
+(Phase 2 will add tighter rules around what teachers can write to
+`grading[questionId]` — e.g., capping `pointsAwarded` at the question's
+point value once we model the question key in rules — but Phase 1 trusts
+the existing teacher-owns-everything model.)
 
 ---
 
@@ -379,12 +433,16 @@ exactly as they are.
 - **Phase 1 — Foundation (this design's scope to start)**
   - `short` and `essay` question types in `types.ts`, builder UI in
     `QuizEditor`, default config in `config/widgetDefaults.ts` if applicable.
-  - TipTap student editor, lazy-loaded on quiz route.
-  - Autosave to `answers[].answer` (TipTap JSON) + `written.plainText`.
+  - `contenteditable` + DOMPurify rich-text editor (lazy chunk on quiz
+    route). No new dependency.
+  - Autosave to `answers[].answer` as sanitized HTML. No plainText
+    mirror — derived on demand.
   - Pause/resume rehydration (mostly works already; verify with E2E).
+  - Top-level `grading` map on the response doc, keyed by questionId.
   - Manual grading modal with prev/next nav, points-only entry (no rubric,
     no annotations yet).
-  - Teacher rule allowing `grading` field write.
+  - No rule changes needed — existing student whitelist already locks
+    `grading` out of student writes; teacher branch is unrestricted.
   - Soft-lockdown polish: surface tab-switch count in grading header.
 
 - **Phase 2 — Annotations**
@@ -406,10 +464,10 @@ exactly as they are.
 
 ## 12. Testing checklist (per phase)
 
-- **Phase 1**: unit tests for TipTap JSON ↔ plainText conversion, autosave
-  debounce, word-count cap behavior; E2E for pause-then-resume-next-day
-  scenario using Playwright; rules tests asserting teacher-write-only of
-  `grading` field and student-write-only of everything else.
+- **Phase 1**: unit tests for HTML sanitization round-trip + word
+  count from HTML; autosave debounce; rules tests asserting student
+  writes including `grading` are rejected and teacher writes are
+  accepted. E2E for pause-then-resume-next-day using Playwright.
 - **Phase 2**: annotation range survives sanitization round-trip; student
   read-only render shows highlights at correct offsets.
 - **Phase 3**: CSV import round-trips losslessly; rubric snapshot doesn't

--- a/firestore.rules
+++ b/firestore.rules
@@ -784,6 +784,92 @@ service cloud.firestore {
         (resource.data.get('originalAuthor', null) == request.auth.uid || isAdmin());
     }
 
+    // Shared Activity Wall galleries — view-only published copy of an
+    // Activity Wall session's submissions. The teacher creates the share
+    // doc; viewers land at /activity-wall/gallery/{shareId} and read the
+    // doc to discover the underlying sessionId + gallery toggles
+    // (allowComments / allowCommentResponses / allowLikes). Reads are
+    // permitted for any signed-in caller (including anonymous gallery
+    // viewers) so an unauthenticated student can open the link.
+    match /shared_activity_walls/{shareId} {
+      allow read: if request.auth != null;
+
+      allow create: if request.auth != null &&
+        request.auth.token.firebase.sign_in_provider != 'anonymous' &&
+        request.resource.data.originalAuthor == request.auth.uid &&
+        request.resource.data.id is string &&
+        request.resource.data.sessionId is string &&
+        request.resource.data.title is string &&
+        request.resource.data.prompt is string &&
+        request.resource.data.mode in ['text', 'photo'] &&
+        request.resource.data.identificationMode in ['anonymous', 'name', 'pin', 'name-pin'] &&
+        request.resource.data.allowComments is bool &&
+        request.resource.data.allowCommentResponses is bool &&
+        request.resource.data.allowLikes is bool &&
+        request.resource.data.createdAt is int &&
+        (request.resource.data.expiresAt == null || request.resource.data.expiresAt is int);
+
+      allow update, delete: if request.auth != null &&
+        (resource.data.get('originalAuthor', null) == request.auth.uid || isAdmin());
+
+      // Comments — any authenticated viewer (incl. anonymous) can create.
+      // Parent share must allow comments; replies (parentCommentId != null)
+      // additionally require allowCommentResponses == true.
+      match /comments/{commentId} {
+        function parentShare() {
+          return get(/databases/$(database)/documents/shared_activity_walls/$(shareId)).data;
+        }
+        allow read: if request.auth != null;
+        allow create: if request.auth != null &&
+          parentShare().get('revoked', false) == false &&
+          parentShare().get('allowComments', false) == true &&
+          (
+            request.resource.data.get('parentCommentId', null) == null ||
+            parentShare().get('allowCommentResponses', false) == true
+          ) &&
+          request.resource.data.id is string &&
+          request.resource.data.submissionId is string &&
+          request.resource.data.content is string &&
+          request.resource.data.content.size() > 0 &&
+          request.resource.data.content.size() <= 2000 &&
+          request.resource.data.participantLabel is string &&
+          request.resource.data.authorUid == request.auth.uid &&
+          request.resource.data.createdAt is int;
+        // Commenter can delete their own comment; share owner / admin can
+        // moderate any comment.
+        allow delete: if request.auth != null &&
+          (
+            resource.data.get('authorUid', null) == request.auth.uid ||
+            parentShare().get('originalAuthor', null) == request.auth.uid ||
+            isAdmin()
+          );
+        allow update: if false;
+      }
+
+      // Likes — deterministic doc id (`{submissionId}__{authorUid}`) caps
+      // each viewer to one like per submission. Toggling off is a delete.
+      match /likes/{likeId} {
+        function parentShare() {
+          return get(/databases/$(database)/documents/shared_activity_walls/$(shareId)).data;
+        }
+        allow read: if request.auth != null;
+        allow create: if request.auth != null &&
+          parentShare().get('revoked', false) == false &&
+          parentShare().get('allowLikes', false) == true &&
+          request.resource.data.submissionId is string &&
+          request.resource.data.authorUid == request.auth.uid &&
+          request.resource.data.createdAt is int &&
+          likeId == request.resource.data.submissionId + '__' + request.auth.uid;
+        allow delete: if request.auth != null &&
+          (
+            resource.data.get('authorUid', null) == request.auth.uid ||
+            parentShare().get('originalAuthor', null) == request.auth.uid ||
+            isAdmin()
+          );
+        allow update: if false;
+      }
+    }
+
     // Synced quiz groups — canonical, mutable record of a quiz shared
     // across PLC peers. The group id is an unguessable v4 UUID, so reads
     // are gated only on auth (matches the `shared_assignments` posture).
@@ -2515,8 +2601,16 @@ service cloud.firestore {
           !('driveFileId' in request.resource.data) &&
           !('archiveError' in request.resource.data) &&
           !('archivedAt' in request.resource.data);
-        // Only teacher and admins can read or delete submissions.
-        allow read, delete: if request.auth != null &&
+        // Only teacher and admins can read or delete submissions —
+        // EXCEPT when the parent session has been published as a view-only
+        // gallery (`publiclyShared == true`), in which case any
+        // authenticated caller (including anonymous gallery viewers) can
+        // read the approved submissions. Delete remains teacher/admin-only.
+        allow read: if request.auth != null &&
+                            (isAdmin() ||
+                             sessionId.matches(request.auth.uid + '_.*') ||
+                             get(/databases/$(database)/documents/activity_wall_sessions/$(sessionId)).data.get('publiclyShared', false) == true);
+        allow delete: if request.auth != null &&
                             (isAdmin() || sessionId.matches(request.auth.uid + '_.*'));
         allow update: if request.auth != null &&
                             (isAdmin() || sessionId.matches(request.auth.uid + '_.*')) &&

--- a/hooks/useQuizAssignments.ts
+++ b/hooks/useQuizAssignments.ts
@@ -1875,7 +1875,16 @@ export const useQuizAssignments = (
             void _stale;
             return rest;
           }
-          const result = gradeAnswer(q, a.answer);
+          // Pull manual grades for written types so a teacher's stored
+          // grade survives the archive snapshot. Without this, archiving
+          // a quiz that contained essays would freeze them at 0 points
+          // and the archive would silently disagree with the live results
+          // view forever after.
+          const manualGrade =
+            q.type === 'short' || q.type === 'essay'
+              ? data.grading?.[q.id]
+              : undefined;
+          const result = gradeAnswer(q, a.answer, manualGrade);
           pointsEarned += result.pointsEarned;
           pointsMax += result.pointsMax;
           return { ...a, isCorrect: result.isCorrect };

--- a/hooks/useQuizSession.ts
+++ b/hooks/useQuizSession.ts
@@ -123,6 +123,10 @@ export function toPublicQuestion(q: QuizQuestion): QuizPublicQuestion {
     // a student pop devtools and read off exactly which entries are wrong.
   } else if (q.type === 'Ordering') {
     base.orderingItems = fisherYatesShuffle(q.correctAnswer.split('|'));
+  } else if (q.type === 'short' || q.type === 'essay') {
+    if (q.placeholder) base.placeholder = q.placeholder;
+    if (q.maxWords && q.maxWords > 0) base.maxWords = q.maxWords;
+    if (q.points && q.points > 0) base.points = q.points;
   }
   return base;
 }
@@ -190,10 +194,33 @@ function longestOrderedSubsequenceLength(
 
 export function gradeAnswer(
   question: QuizQuestion,
-  studentAnswer: string
+  studentAnswer: string,
+  /**
+   * Optional teacher-written manual grade for the response — pulled from
+   * `QuizResponse.grading[question.id]`. Only consulted for written
+   * question types (`short`, `essay`); ignored for auto-graded types.
+   */
+  manualGrade?: import('@/types').WrittenAnswerGrade
 ): GradeResult {
   const max = question.points ?? 1;
   const partial = question.allowPartialCredit === true;
+
+  // Written question types are graded manually by the teacher. If no
+  // grade has been entered yet, the answer is reported as "not yet
+  // graded" — zero points awarded, isCorrect=false — so downstream stats
+  // (which weight by isCorrect) don't credit ungraded essays as correct.
+  if (question.type === 'short' || question.type === 'essay') {
+    if (!manualGrade) {
+      return { isCorrect: false, pointsEarned: 0, pointsMax: max };
+    }
+    const awarded = Math.min(max, Math.max(0, manualGrade.pointsAwarded));
+    return {
+      isCorrect: awarded === max && max > 0,
+      pointsEarned: awarded,
+      pointsMax: max,
+    };
+  }
+
   const correct = normalizeAnswer(question.correctAnswer);
   const given = normalizeAnswer(studentAnswer);
 

--- a/scripts/backfill-user-dock-items.js
+++ b/scripts/backfill-user-dock-items.js
@@ -1,0 +1,453 @@
+/**
+ * One-shot backfill: seed `userProfile.profile.dockItems` for users whose
+ * profile is missing it.
+ *
+ * BACKGROUND
+ *   PR #1615 introduced cross-device dock sync by mirroring `dockItems`,
+ *   `libraryOrder`, and `dockInitialized` from the client to
+ *   `/users/{uid}/userProfile/profile`. A migration bug (since fixed in
+ *   PR #1618) wiped legacy localStorage dock state on the first load of
+ *   the new code WITHOUT first copying it to the cloud, leaving affected
+ *   users with no `dockItems` in Firestore. On their next sign-in the
+ *   client now self-heals — the seeding effect computes building-aware
+ *   defaults and persists them — but this script lets us populate the
+ *   defaults proactively so the cloud has the data ready before users
+ *   reload.
+ *
+ * WHAT THIS SCRIPT DOES
+ *   - Loads every feature_permission and indexes `config.dockDefaults`
+ *     keyed by widgetType (canonicalizing legacy building IDs).
+ *   - Loads /admins/* to determine which users are admins (for filtering
+ *     admin-level widgets).
+ *   - Sweeps `userProfile` via collectionGroup query.
+ *   - For each profile MISSING `dockItems`, computes the same default
+ *     toolset that `getDefaultDockTools()` in DashboardContext would
+ *     produce on the client:
+ *       - selectedBuildings empty → all enabled widgets the user can
+ *         access (public, plus beta-listed and admin-tier if applicable)
+ *       - selectedBuildings non-empty → union of widgets whose
+ *         dockDefaults match ANY of the user's buildings, filtered the
+ *         same way; fallback to ['time-tool'] when the union is empty.
+ *   - Writes `dockItems` (as `[{type:'tool', toolType: <type>}]`) and
+ *     `dockInitialized: true`. Does NOT write `libraryOrder` — the
+ *     client populates it from the TOOLS array on first hydration.
+ *
+ * WHAT THIS SCRIPT DOES NOT DO
+ *   - Does NOT touch profiles that already have a `dockItems` field
+ *     (including empty arrays — those signal "user actively cleared
+ *     their dock" and shouldn't be re-seeded against their wishes).
+ *   - Does NOT modify `libraryOrder` — left for the client to seed.
+ *   - Does NOT touch /admins/* or feature_permissions.
+ *
+ * SAFETY
+ *   - --dry-run logs every planned write without committing.
+ *   - Uses { merge: true } so existing profile fields are preserved.
+ *
+ * Usage:
+ *   node scripts/backfill-user-dock-items.js [--dry-run] [--verbose]
+ *
+ * Credentials resolution (same order as backfill-user-building-ids.js):
+ *   1. FIREBASE_SERVICE_ACCOUNT env var (JSON) — used by CI
+ *   2. scripts/service-account-key.json — used by local dev
+ *   3. applicationDefault() via GOOGLE_APPLICATION_CREDENTIALS or
+ *      `gcloud auth application-default login`
+ */
+
+import { initializeApp, applicationDefault, cert } from 'firebase-admin/app';
+import { getFirestore } from 'firebase-admin/firestore';
+import { getAuth } from 'firebase-admin/auth';
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const PROJECT_ID = 'spartboard';
+
+/**
+ * Legacy → canonical building-id map. Keep in sync with
+ * BUILDING_ID_ALIASES in config/buildings.ts.
+ */
+const BUILDING_ID_LEGACY_TO_CANONICAL = {
+  'orono-high-school': 'high',
+  'orono-middle-school': 'middle',
+  'orono-intermediate-school': 'intermediate',
+  'schumann-elementary': 'schumann',
+};
+
+function canonicalBuildingId(id) {
+  return BUILDING_ID_LEGACY_TO_CANONICAL[id] ?? id;
+}
+
+function canonicalizeBuildingKeyedRecord(record) {
+  if (!record || typeof record !== 'object') return record;
+  const out = Object.create(null);
+  for (const [rawKey, value] of Object.entries(record)) {
+    out[canonicalBuildingId(rawKey)] = value;
+  }
+  return out;
+}
+
+function canonicalizeBuildingIds(ids) {
+  if (!Array.isArray(ids)) return [];
+  const seen = new Set();
+  const out = [];
+  for (const raw of ids) {
+    if (typeof raw !== 'string') continue;
+    const c = canonicalBuildingId(raw);
+    if (!seen.has(c)) {
+      seen.add(c);
+      out.push(c);
+    }
+  }
+  return out;
+}
+
+function parseArgs(argv) {
+  const args = { dryRun: false, verbose: false, help: false };
+  for (const a of argv) {
+    if (a === '--dry-run' || a === '-n') args.dryRun = true;
+    else if (a === '--verbose' || a === '-v') args.verbose = true;
+    else if (a === '--help' || a === '-h') args.help = true;
+  }
+  return args;
+}
+
+function printHelp() {
+  console.log(
+    'Usage: node scripts/backfill-user-dock-items.js [--dry-run] [--verbose]'
+  );
+}
+
+function loadCredentials() {
+  const envJson = process.env.FIREBASE_SERVICE_ACCOUNT;
+  if (envJson) {
+    return {
+      source: 'FIREBASE_SERVICE_ACCOUNT env',
+      creds: JSON.parse(envJson),
+      useApplicationDefault: false,
+    };
+  }
+  const keyPath = join(__dirname, 'service-account-key.json');
+  try {
+    const raw = readFileSync(keyPath, 'utf8');
+    return {
+      source: 'scripts/service-account-key.json',
+      creds: JSON.parse(raw),
+      useApplicationDefault: false,
+    };
+  } catch {
+    // Fall through to ADC.
+  }
+  if (process.env.GOOGLE_APPLICATION_CREDENTIALS) {
+    return {
+      source:
+        'GOOGLE_APPLICATION_CREDENTIALS=' +
+        process.env.GOOGLE_APPLICATION_CREDENTIALS,
+      creds: null,
+      useApplicationDefault: true,
+    };
+  }
+  return {
+    source: 'applicationDefault()',
+    creds: null,
+    useApplicationDefault: true,
+  };
+}
+
+/**
+ * Computes the default dock toolset for a user, mirroring
+ * `getDefaultDockTools()` in context/DashboardContext.tsx.
+ */
+function computeDefaultDockTools(
+  featurePermissions,
+  selectedBuildings,
+  userEmail,
+  isAdmin,
+  allToolTypes
+) {
+  const isPermAccessible = (perm) => {
+    const isEnabled = perm.enabled !== false;
+    const isAccessibleByRole = perm.accessLevel !== 'admin' || isAdmin === true;
+    const isBetaAccessible =
+      perm.accessLevel !== 'beta' ||
+      (Array.isArray(perm.betaUsers) && perm.betaUsers.includes(userEmail));
+    return isEnabled && isAccessibleByRole && isBetaAccessible;
+  };
+
+  const permByType = new Map(featurePermissions.map((p) => [p.widgetType, p]));
+
+  // No building selected → "show all content": return all accessible
+  // tools from the TOOLS list. Widgets without a permission record are
+  // public by default.
+  if (selectedBuildings.length === 0) {
+    return allToolTypes.filter((type) => {
+      const perm = permByType.get(type);
+      if (!perm) return true;
+      return isPermAccessible(perm);
+    });
+  }
+
+  const tools = [];
+  for (const perm of featurePermissions) {
+    const rawDockDefaults = perm.config?.dockDefaults;
+    if (!rawDockDefaults) continue;
+    const dockDefaults = canonicalizeBuildingKeyedRecord(rawDockDefaults);
+    const isDefaultForAnyBuilding = selectedBuildings.some(
+      (bid) => dockDefaults[bid] === true
+    );
+    if (!isDefaultForAnyBuilding) continue;
+    if (isPermAccessible(perm)) {
+      tools.push(perm.widgetType);
+    }
+  }
+
+  if (tools.length === 0) {
+    tools.push('time-tool');
+  }
+
+  return tools;
+}
+
+/**
+ * The full WidgetType + InternalToolType union. Kept in sync with
+ * `TOOLS` in config/tools.ts. New widgets added in the future will be
+ * picked up automatically by the client-side WidgetLibrary's auto-merge
+ * of TOOLS into `libraryOrder` (see WidgetLibrary.tsx). For the "no
+ * building selected" code path here we only use this list as the
+ * starting set to filter; missing future entries would just mean the
+ * backfilled dock lacks them until the user reorders their library.
+ */
+const TOOL_TYPES = [
+  'url',
+  'soundboard',
+  'clock',
+  'time-tool',
+  'traffic',
+  'text',
+  'checklist',
+  'random',
+  'dice',
+  'sound',
+  'drawing',
+  'qr',
+  'embed',
+  'poll',
+  'activity-wall',
+  'webcam',
+  'scoreboard',
+  'expectations',
+  'weather',
+  'schedule',
+  'specialist-schedule',
+  'graphic-organizer',
+  'calendar',
+  'lunchCount',
+  'classes',
+  'car-rider-pro',
+  'blending-board',
+  'first-5',
+  'instructionalRoutines',
+  'miniApp',
+  'materials',
+  'stickers',
+  'seating-chart',
+  'catalyst',
+  'smartNotebook',
+  'recessGear',
+  'pdf',
+  'quiz',
+  'talking-tool',
+  'breathing',
+  'mathTools',
+  'nextUp',
+  'numberLine',
+  'music',
+  'record',
+  'magic',
+  'remote',
+  'reveal-grid',
+  'syntax-framer',
+  'hotspot-image',
+  'concept-web',
+  'starter-pack',
+  'video-activity',
+  'guided-learning',
+  'countdown',
+  'work-symbols',
+  'blooms-taxonomy',
+  'need-do-put-then',
+  'stations',
+];
+
+async function loadFeaturePermissions(db) {
+  const snap = await db.collection('feature_permissions').get();
+  return snap.docs.map((d) => ({
+    widgetType: d.id,
+    ...d.data(),
+  }));
+}
+
+async function loadAdminEmails(db) {
+  const snap = await db.collection('admins').get();
+  return new Set(snap.docs.map((d) => d.id.toLowerCase()));
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    printHelp();
+    return;
+  }
+
+  const cred = loadCredentials();
+  console.log(`[backfill-user-dock-items] credentials: ${cred.source}`);
+  initializeApp({
+    credential: cred.useApplicationDefault
+      ? applicationDefault()
+      : cert(cred.creds),
+    projectId: PROJECT_ID,
+  });
+
+  const db = getFirestore();
+  const auth = getAuth();
+
+  console.log('[backfill-user-dock-items] loading feature_permissions...');
+  const featurePermissions = await loadFeaturePermissions(db);
+  console.log(
+    `[backfill-user-dock-items] loaded ${featurePermissions.length} feature_permissions`
+  );
+
+  console.log('[backfill-user-dock-items] loading admins...');
+  const adminEmails = await loadAdminEmails(db);
+  console.log(
+    `[backfill-user-dock-items] loaded ${adminEmails.size} admin emails`
+  );
+
+  console.log(
+    '[backfill-user-dock-items] sweeping userProfile collectionGroup...'
+  );
+  const profiles = await db.collectionGroup('userProfile').get();
+  console.log(
+    `[backfill-user-dock-items] found ${profiles.size} userProfile docs`
+  );
+
+  let plannedWrites = 0;
+  let skippedAlreadyHasDock = 0;
+  let skippedNotProfileDoc = 0;
+  let skippedNoUidPath = 0;
+  let writeFailures = 0;
+  let writeSuccesses = 0;
+
+  for (const profileDoc of profiles.docs) {
+    // Only target the canonical `userProfile/profile` doc — there are
+    // other docs in the userProfile subcollection we don't want to
+    // touch.
+    if (profileDoc.id !== 'profile') {
+      skippedNotProfileDoc++;
+      continue;
+    }
+
+    const data = profileDoc.data();
+    if (Object.prototype.hasOwnProperty.call(data, 'dockItems')) {
+      skippedAlreadyHasDock++;
+      if (args.verbose) {
+        console.log(`  SKIP (already has dockItems): ${profileDoc.ref.path}`);
+      }
+      continue;
+    }
+
+    // Path is /users/{uid}/userProfile/profile — extract uid.
+    const pathParts = profileDoc.ref.path.split('/');
+    const usersIdx = pathParts.indexOf('users');
+    if (usersIdx < 0 || pathParts.length < usersIdx + 2) {
+      skippedNoUidPath++;
+      console.warn(
+        `  SKIP (unexpected path, can't extract uid): ${profileDoc.ref.path}`
+      );
+      continue;
+    }
+    const uid = pathParts[usersIdx + 1];
+
+    // Look up the user's email to evaluate beta-access permissions, and
+    // their admin status to evaluate admin-tier widgets.
+    let userEmail = '';
+    let isAdmin = false;
+    try {
+      const userRecord = await auth.getUser(uid);
+      userEmail = (userRecord.email ?? '').toLowerCase();
+      isAdmin = adminEmails.has(userEmail);
+    } catch (err) {
+      // User may have been deleted but their profile lingers — fall
+      // back to public-only widget defaults (no email = no beta, no
+      // admin).
+      if (args.verbose) {
+        console.warn(
+          `  WARN: getUser(${uid}) failed (${err.code ?? err.message}), proceeding with no email/admin`
+        );
+      }
+    }
+
+    const rawSelectedBuildings = Array.isArray(data.selectedBuildings)
+      ? data.selectedBuildings
+      : [];
+    const selectedBuildings = canonicalizeBuildingIds(rawSelectedBuildings);
+
+    const defaultTools = computeDefaultDockTools(
+      featurePermissions,
+      selectedBuildings,
+      userEmail,
+      isAdmin,
+      TOOL_TYPES
+    );
+    const dockItems = defaultTools.map((type) => ({
+      type: 'tool',
+      toolType: type,
+    }));
+
+    plannedWrites++;
+    const summary = `uid=${uid} email=${userEmail || '<unknown>'} admin=${isAdmin} buildings=[${selectedBuildings.join(',')}] tools=${dockItems.length}`;
+
+    if (args.dryRun) {
+      console.log(`  DRY-RUN: would write ${summary}`);
+      if (args.verbose) {
+        console.log(`           dockItems=${JSON.stringify(defaultTools)}`);
+      }
+      continue;
+    }
+
+    try {
+      await profileDoc.ref.set(
+        {
+          dockItems,
+          dockInitialized: true,
+        },
+        { merge: true }
+      );
+      writeSuccesses++;
+      console.log(`  WROTE: ${summary}`);
+    } catch (err) {
+      writeFailures++;
+      console.error(
+        `  WRITE FAILED for ${profileDoc.ref.path}: ${err.message ?? err}`
+      );
+    }
+  }
+
+  console.log('\n[backfill-user-dock-items] summary');
+  console.log(`  profiles scanned:          ${profiles.size}`);
+  console.log(`  skipped (not profile doc): ${skippedNotProfileDoc}`);
+  console.log(`  skipped (no uid in path):  ${skippedNoUidPath}`);
+  console.log(`  skipped (already has):     ${skippedAlreadyHasDock}`);
+  console.log(`  planned writes:            ${plannedWrites}`);
+  if (!args.dryRun) {
+    console.log(`  writes succeeded:          ${writeSuccesses}`);
+    console.log(`  writes failed:             ${writeFailures}`);
+  }
+}
+
+main().catch((err) => {
+  console.error('[backfill-user-dock-items] FAILED:', err);
+  process.exit(1);
+});

--- a/storage.rules
+++ b/storage.rules
@@ -115,10 +115,19 @@ service firebase.storage {
     // these rules, so <img> display works without SDK read permission.
     // SDK-level read/list is limited to the owning teacher and admins.
     match /activity_wall_photos/{sessionId}/{fileName} {
-      // Only the teacher who owns the session (sessionId prefix = their uid) or an admin
-      // can list/download via the SDK.
+      // Owning teacher / admin can list/download via the SDK. Additionally,
+      // when the session has been published as a view-only gallery
+      // (`publiclyShared == true` on the parent session doc), any
+      // authenticated caller — including anonymous gallery viewers — can
+      // download a photo so the gallery page can render it.
       allow read: if request.auth != null &&
-        (isAdmin() || sessionId.matches(request.auth.uid + '_.*'));
+        (
+          isAdmin() ||
+          sessionId.matches(request.auth.uid + '_.*') ||
+          firestore.get(
+            /databases/(default)/documents/activity_wall_sessions/$(sessionId)
+          ).data.get('publiclyShared', false) == true
+        );
       // Any authenticated user (including anonymous students) may upload a new image,
       // but only if the target session exists in Firestore (guards against DoS uploads
       // to guessed sessionIds).

--- a/tests/components/widgets/QuizResults.autoPublish.test.tsx
+++ b/tests/components/widgets/QuizResults.autoPublish.test.tsx
@@ -31,6 +31,7 @@ vi.mock('@/hooks/usePlcs', () => ({
 }));
 vi.mock('@/hooks/useAssignmentPseudonyms', () => ({
   useAssignmentPseudonyms: () => ({ byStudentUid: new Map() }),
+  formatStudentName: () => '',
 }));
 vi.mock('@/hooks/useClickOutside', () => ({ useClickOutside: vi.fn() }));
 

--- a/tests/components/widgets/QuizResults.regenerate.test.tsx
+++ b/tests/components/widgets/QuizResults.regenerate.test.tsx
@@ -54,6 +54,7 @@ vi.mock('@/hooks/usePlcs', () => ({
 }));
 vi.mock('@/hooks/useAssignmentPseudonyms', () => ({
   useAssignmentPseudonyms: () => ({ byStudentUid: new Map() }),
+  formatStudentName: () => '',
 }));
 vi.mock('@/hooks/useClickOutside', () => ({ useClickOutside: vi.fn() }));
 

--- a/tests/components/widgets/QuizResults.schemaMismatch.test.tsx
+++ b/tests/components/widgets/QuizResults.schemaMismatch.test.tsx
@@ -33,6 +33,7 @@ vi.mock('@/hooks/usePlcs', () => ({
 }));
 vi.mock('@/hooks/useAssignmentPseudonyms', () => ({
   useAssignmentPseudonyms: () => ({ byStudentUid: new Map() }),
+  formatStudentName: () => '',
 }));
 vi.mock('@/hooks/useClickOutside', () => ({ useClickOutside: vi.fn() }));
 

--- a/types.ts
+++ b/types.ts
@@ -2241,9 +2241,25 @@ export interface RecessGearConfig {
 /**
  * Question types supported in the quiz widget.
  * MC = Multiple Choice, FIB = Fill in the Blank,
- * Matching = Match left to right, Ordering = Place items in correct sequence.
+ * Matching = Match left to right, Ordering = Place items in correct sequence,
+ * short = single-paragraph written response (manually graded),
+ * essay = multi-paragraph written response (manually graded).
  */
-export type QuizQuestionType = 'MC' | 'FIB' | 'Matching' | 'Ordering';
+export type QuizQuestionType =
+  | 'MC'
+  | 'FIB'
+  | 'Matching'
+  | 'Ordering'
+  | 'short'
+  | 'essay';
+
+/**
+ * True iff the question type requires manual teacher grading
+ * (i.e. there is no auto-grader for student responses).
+ */
+export function isWrittenQuestionType(type: QuizQuestionType): boolean {
+  return type === 'short' || type === 'essay';
+}
 
 export interface QuizQuestion {
   id: string;
@@ -2255,6 +2271,7 @@ export interface QuizQuestion {
    * MC/FIB: the correct answer text.
    * Matching: pipe-separated pairs "term1:def1|term2:def2"
    * Ordering: pipe-separated items in correct order "item1|item2|item3"
+   * short/essay: always empty string (no key — graded manually).
    */
   correctAnswer: string;
   /** MC only: up to 4 incorrect answer choices */
@@ -2270,9 +2287,20 @@ export interface QuizQuestion {
   matchingDistractors?: string[];
   /**
    * Per-question opt-in for partial credit on Matching/Ordering. Ignored
-   * for MC/FIB. Defaults to false.
+   * for MC/FIB/short/essay. Defaults to false.
    */
   allowPartialCredit?: boolean;
+  /**
+   * short/essay only. Optional placeholder shown inside the student's
+   * editor (e.g. "Cite at least two pieces of evidence.").
+   */
+  placeholder?: string;
+  /**
+   * short/essay only. Soft cap shown in the editor's word counter.
+   * Not enforced server-side; the student can exceed it. Undefined or 0
+   * means no cap is displayed.
+   */
+  maxWords?: number;
 }
 
 /**
@@ -2405,6 +2433,12 @@ export interface QuizPublicQuestion {
   matchingRight?: string[];
   /** Ordering only: items to sequence, pre-shuffled */
   orderingItems?: string[];
+  /** short/essay only: optional editor placeholder */
+  placeholder?: string;
+  /** short/essay only: optional soft word cap shown in the editor */
+  maxWords?: number;
+  /** short/essay only: max points the teacher can award. */
+  points?: number;
 }
 
 export interface QuizLeaderboardEntry {
@@ -2670,6 +2704,71 @@ export interface QuizResponse {
   unlocked?: boolean;
   /** Client timestamp (ms) when the teacher unlocked the attempt. */
   unlockedAt?: number;
+  /**
+   * Teacher-written manual grades for written question types
+   * (`short`, `essay`). Keyed by `QuizQuestion.id`. Lives outside the
+   * `answers[]` array so teacher writes don't need to rewrite the
+   * student's answer payload, and so Firestore rules can lock students
+   * out of grading via the existing `changedKeys().hasOnly([...])`
+   * whitelist — `grading` is simply not in the list, so any student
+   * write that includes it is rejected.
+   *
+   * Auto-graded question types (MC/FIB/Matching/Ordering) do not use
+   * this map; their correctness is recomputed on the fly by `gradeAnswer`.
+   */
+  grading?: { [questionId: string]: WrittenAnswerGrade };
+}
+
+/**
+ * Per-question manual grade record for written-response questions.
+ * Stored under `QuizResponse.grading[questionId]`.
+ */
+export interface WrittenAnswerGrade {
+  /**
+   * Points awarded. Clamped client-side to `0 <= pointsAwarded <=
+   * (question.points ?? 1)`. Phase 2/3 will add a server-side cap
+   * in Firestore rules once rules can look up the question by id.
+   */
+  pointsAwarded: number;
+  /** Optional summary comment the teacher leaves on the response. */
+  overallComment?: string;
+  /** Phase 2 (annotations). Empty/undefined in Phase 1. */
+  annotations?: WrittenAnswerAnnotation[];
+  /** Phase 3 (rubrics). Empty/undefined in Phase 1. */
+  rubricScores?: WrittenAnswerRubricScore[];
+  /** Teacher's auth uid that wrote the grade. */
+  gradedBy: string;
+  /** Client timestamp (ms) when the grade was saved. */
+  gradedAt: number;
+}
+
+/**
+ * Phase 2 annotation shape. Reserved here so we don't churn the type
+ * later. The exact storage model (marks-in-document vs sidecar offsets)
+ * is an open question deferred to Phase 2 design.
+ */
+export interface WrittenAnswerAnnotation {
+  id: string;
+  /** Inclusive start offset into the sanitized plaintext projection. */
+  from: number;
+  /** Exclusive end offset. */
+  to: number;
+  highlightColor?: 'yellow' | 'green' | 'pink' | 'blue';
+  comment?: string;
+  authorUid: string;
+  createdAt: number;
+}
+
+/**
+ * Phase 3 rubric score shape. Reserved here so we don't churn the type
+ * later.
+ */
+export interface WrittenAnswerRubricScore {
+  criterionId: string;
+  levelId: string;
+  /** Snapshot for resilience against later rubric edits. */
+  points: number;
+  note?: string;
 }
 
 /**

--- a/types.ts
+++ b/types.ts
@@ -1267,6 +1267,86 @@ export interface ActivityWallSession {
   updatedAt: number;
   /** See `ActivityWallActivity.classId` — omitted for code/PIN-only launches. */
   classId?: string;
+  /**
+   * When `true`, a `shared_activity_walls/{shareId}` doc references this
+   * session as a view-only gallery. The Firestore rules use this flag to
+   * unlock anonymous read access on submissions so gallery viewers can see
+   * the work without joining the live session.
+   */
+  publiclyShared?: boolean;
+}
+
+/**
+ * Firestore document shape for `shared_activity_walls/{shareId}`.
+ *
+ * Created by the teacher when they want to publish a view-only gallery
+ * link to the submissions of an existing Activity Wall session. The
+ * gallery viewer is unauthenticated (uses anonymous Firebase Auth) so the
+ * doc carries everything the viewer needs to render the page without
+ * touching the owning user's `/users/{uid}/...` collections.
+ */
+export interface SharedActivityWall {
+  id: string;
+  /** Activity wall session id (`${teacherUid}_${activityId}`). */
+  sessionId: string;
+  /** Teacher uid — used to gate update/delete. */
+  originalAuthor: string;
+  /** Snapshot of the activity's title at share time. */
+  title: string;
+  /** Snapshot of the activity's prompt at share time. */
+  prompt: string;
+  mode: ActivityWallMode;
+  /**
+   * Inherited from the parent activity. Gallery commenters identify
+   * themselves the same way the original submitters did.
+   */
+  identificationMode: ActivityWallIdentificationMode;
+  allowComments: boolean;
+  allowCommentResponses: boolean;
+  allowLikes: boolean;
+  /** Millis epoch — `null` means the link never expires. */
+  expiresAt: number | null;
+  createdAt: number;
+  /**
+   * Teacher can revoke a link without deleting the doc, which keeps
+   * existing comments/likes intact in case they want to re-enable later.
+   */
+  revoked?: boolean;
+}
+
+/**
+ * Comment posted by a gallery viewer on a specific submission.
+ * Lives at `shared_activity_walls/{shareId}/comments/{commentId}`.
+ */
+export interface ActivityWallComment {
+  id: string;
+  /** Submission this comment is attached to. */
+  submissionId: string;
+  /**
+   * Parent comment id when this is a reply, or `null` for a top-level
+   * comment. Replies are only allowed when the share has
+   * `allowCommentResponses === true`.
+   */
+  parentCommentId: string | null;
+  content: string;
+  /** Display label built from the share's `identificationMode`. */
+  participantLabel: string;
+  /** Firebase auth uid of the commenter (anonymous uid for viewers). */
+  authorUid: string;
+  createdAt: number;
+}
+
+/**
+ * Like on a submission within a shared gallery. Lives at
+ * `shared_activity_walls/{shareId}/likes/{submissionId}__{authorUid}` —
+ * the deterministic doc id enforces one-like-per-viewer-per-submission
+ * without a separate counter document.
+ */
+export interface ActivityWallLike {
+  id: string;
+  submissionId: string;
+  authorUid: string;
+  createdAt: number;
 }
 
 export interface WebcamConfig {

--- a/utils/assignmentExportShared.ts
+++ b/utils/assignmentExportShared.ts
@@ -69,7 +69,14 @@ export function buildResultsSheetData<
 >(
   responses: R[],
   questions: Q[],
-  gradeFn: (question: Q, studentAnswer: string) => GradeResult,
+  /**
+   * Per-row grader. Receives the response as the optional third argument so
+   * widget-specific graders that need per-response state (e.g. Quiz's manual
+   * grades for `short`/`essay` questions, read from
+   * `response.grading[questionId]`) can plumb it through. Auto-grading
+   * widgets (or VA's grader) can ignore it.
+   */
+  gradeFn: (question: Q, studentAnswer: string, response?: R) => GradeResult,
   options?: BuildResultsSheetDataOptions
 ): { headers: string[]; dataRows: string[][] } {
   const pinToName = options?.pinToName ?? {};
@@ -124,7 +131,7 @@ export function buildResultsSheetData<
     for (const q of questions) {
       const ans = answerMap.get(q.id);
       if (!ans) continue;
-      grades.set(q.id, gradeFn(q, ans.answer));
+      grades.set(q.id, gradeFn(q, ans.answer, r));
     }
     const answerCols = questions.map((q) => {
       const grade = grades.get(q.id);

--- a/utils/plcContributions.ts
+++ b/utils/plcContributions.ts
@@ -92,7 +92,16 @@ function buildContributionResponse(
   for (const q of questions) {
     const answer = answerByQuestionId.get(q.id);
     if (answer === undefined) continue;
-    const grade = gradeAnswer(q, answer);
+    // Written types (`short`/`essay`) carry their points on the response's
+    // top-level `grading` map; passing it in here keeps the PLC
+    // contribution's per-question points and aggregate score in sync with
+    // the teacher's manual grading. Ungraded written questions fall back to
+    // zero points until the teacher enters a grade.
+    const manualGrade =
+      q.type === 'short' || q.type === 'essay'
+        ? response.grading?.[q.id]
+        : undefined;
+    const grade = gradeAnswer(q, answer, manualGrade);
     pointsByQuestionId[q.id] = grade.pointsEarned;
     pointsEarned += grade.pointsEarned;
   }

--- a/utils/quizDriveService.ts
+++ b/utils/quizDriveService.ts
@@ -20,6 +20,28 @@ import { APP_NAME } from '../config/constants';
 import { authError } from './driveAuthErrors';
 import { buildResultsSheetData as buildResultsSheetDataShared } from '@/utils/assignmentExportShared';
 
+/**
+ * Quiz's grader wrapper for `buildResultsSheetData`. Routes per-question
+ * manual grades (written types only) from the response's top-level
+ * `grading` map into `gradeAnswer`. Without this, `short`/`essay`
+ * questions would always export as 0 points regardless of what the
+ * teacher graded them.
+ *
+ * Defined at module scope so it has stable identity — `buildResultsSheetData`
+ * is allocation-sensitive on big PLC exports.
+ */
+function quizGradeFnWithManualGrades(
+  question: QuizQuestion,
+  studentAnswer: string,
+  response?: QuizResponse
+) {
+  const manualGrade =
+    (question.type === 'short' || question.type === 'essay') && response
+      ? response.grading?.[question.id]
+      : undefined;
+  return gradeAnswer(question, studentAnswer, manualGrade);
+}
+
 const DRIVE_API_URL = 'https://www.googleapis.com/drive/v3';
 const UPLOAD_API_URL = 'https://www.googleapis.com/upload/drive/v3';
 const SHEETS_API_URL = 'https://sheets.googleapis.com/v4/spreadsheets';
@@ -518,7 +540,7 @@ export class QuizDriveService {
     return buildResultsSheetDataShared<QuizQuestion, QuizResponse>(
       responses,
       questions,
-      gradeAnswer,
+      quizGradeFnWithManualGrades,
       options
     );
   }
@@ -622,16 +644,24 @@ export class QuizDriveService {
       plcMode?: boolean;
       plcSheetUrl?: string;
       /**
-       * Optional grader override. Defaults to Quiz's `gradeAnswer`. Video
+       * Optional grader override. Defaults to Quiz's wrapper that threads
+       * per-response manual grades through (for `short`/`essay`). Video
        * Activity passes `gradeVideoActivityAnswer` so MA / FIB-with-variants
-       * grade correctly in the export — Quiz's grader has no `'MA'` case
-       * and otherwise returns 0 points for those columns. Fixes the TODO
-       * PR2a left at `Results.tsx:170`.
+       * grade correctly in the export — VA's grader signature ignores the
+       * optional third `response` argument it receives.
        */
-      gradeFn?: typeof gradeAnswer;
+      gradeFn?: (
+        question: QuizQuestion,
+        studentAnswer: string,
+        response?: QuizResponse
+      ) => import('../types').GradeResult;
     }
   ): Promise<string> {
-    const gradeFn = options?.gradeFn ?? gradeAnswer;
+    // Quiz's grader threads per-response manual grades through for
+    // `short` / `essay` types; callers that pass their own `gradeFn`
+    // (Video Activity) opt out automatically since their wrapper ignores
+    // the optional third argument.
+    const gradeFn = options?.gradeFn ?? quizGradeFnWithManualGrades;
     const { headers, dataRows } = buildResultsSheetDataShared<
       QuizQuestion,
       QuizResponse
@@ -680,7 +710,7 @@ export class QuizDriveService {
         if (!q) continue;
 
         answeredSet.add(a.questionId);
-        if (gradeFn(q, a.answer).isCorrect) {
+        if (gradeFn(q, a.answer, r).isCorrect) {
           correctSet.add(a.questionId);
         }
       }

--- a/utils/security.ts
+++ b/utils/security.ts
@@ -3,6 +3,13 @@ import DOMPurify from 'dompurify';
 /**
  * Robust HTML sanitizer to prevent XSS.
  * Uses DOMPurify to remove dangerous tags and attributes.
+ *
+ * This profile is the legacy TextWidget profile — it allows `<font>`,
+ * `<span>`, `<div>`, `<img>`, `<a>` and inline `style`/`color`
+ * attributes so the rich-text TextWidget can paste styled content. Do
+ * NOT use this for student-authored content where styling can leak
+ * teacher intent or where the document size matters (essay responses).
+ * Use `sanitizeQuizResponse` instead for student-written quiz answers.
  */
 export const sanitizeHtml = (html: string): string => {
   if (!html) return '';
@@ -43,5 +50,38 @@ export const sanitizeHtml = (html: string): string => {
     ADD_DATA_URI_TAGS: ['img'],
     // ALLOWED_URI_REGEXP intentionally omitted: DOMPurify's built-in default
     // already restricts dangerous protocols and is kept up to date upstream.
+  });
+};
+
+/**
+ * Stricter sanitizer for student-authored quiz responses.
+ *
+ * `WrittenResponseEditor` uses `document.execCommand` (the only path
+ * Phase 1 chose to avoid pulling TipTap into the bundle), and browsers
+ * inject inconsistent wrappers — e.g. Safari/older Chromium can emit
+ * `<font color="red">` or `<span style="font-weight:bold">` when the
+ * user toggles bold, and a determined student could programmatically
+ * insert styled HTML via the contenteditable surface.
+ *
+ * This profile strips ALL formatting wrappers (`font`, `span`, `div`,
+ * `style`, `color`, `class`, etc.) and keeps only the small set of
+ * semantic tags needed for legitimate essay formatting: bold, italic,
+ * underline, line/paragraph breaks, and lists. The teacher's grader
+ * uses the same profile when rendering the response so a stale
+ * pre-sanitization payload from an older client also can't leak styled
+ * content into the teacher's view.
+ *
+ * Links (`<a>`), images, and external URIs are intentionally absent —
+ * Phase 1 student responses are plain prose, not publishable
+ * documents.
+ */
+export const sanitizeQuizResponse = (html: string): string => {
+  if (!html) return '';
+
+  return DOMPurify.sanitize(html, {
+    ALLOWED_TAGS: ['b', 'strong', 'i', 'em', 'u', 'p', 'br', 'ul', 'ol', 'li'],
+    // No `style`, `color`, `class`, `href`, `src` — formatting comes
+    // only from the semantic tags above.
+    ALLOWED_ATTR: [],
   });
 };


### PR DESCRIPTION
## Summary
Existing users were losing their hand-curated docks on first load of the new Firestore-sync code. Three interacting bugs caused the dock to either reset or fail to seed:

1. **State initializers refused to read localStorage when `classroom_dock_cache_uid` was missing** — true for every user who had a dock before the cache-UID feature shipped.
2. **The cache-cleanup effect then wiped that same localStorage** as if it were leaked data from a different account, leaving nothing to migrate to the cloud.
3. **`getDefaultDockTools` only checked `selectedBuildings[0]`** against admin `dockDefaults`, so teachers in multiple buildings (high + middle) dropped most of their seeded widgets and fell through to the lone `time-tool` fallback.

## Fix
- Treat a missing cache uid as *"legacy data belongs to the current user, claim it"* rather than *"stale data from someone else, wipe it"*. Initializers and the cleanup effect now distinguish those two cases via a new `dockCacheBelongsToOtherUser` predicate.
- The seeding effect's preserve-localStorage branch now re-hydrates state from localStorage defensively (calling `setDockItems` / `setVisibleTools` explicitly) instead of relying on the initializers having already done so.
- The default-seed path unions `dockDefaults` across every entry in `selectedBuildings`, not just the first.

## Test plan
- [x] `pnpm type-check` clean
- [x] `pnpm lint` clean
- [x] `pnpm format:check` clean
- [x] `pnpm test` — 2394/2394 pass
- [ ] Manual: refresh dev preview on a teacher account with a pre-existing dock — dock should remain populated and write to Firestore
- [ ] Manual: sign out / sign in as a second user on the same device — second user's dock should not show first user's items

🤖 Generated with [Claude Code](https://claude.com/claude-code)