### PR TITLE
feat(quiz): inline annotations + snapshot for written responses (Phase 2)

### DIFF
--- a/components/quiz/QuizStudentApp.tsx
+++ b/components/quiz/QuizStudentApp.tsx
@@ -2592,25 +2592,26 @@ export const WrittenAnswerReview: React.FC<{
     return null;
   }
   const hasGrade = !!grade;
-  const hasAnnotations = !!grade?.annotations && grade.annotations.length > 0;
-  const snapshot =
-    grade?.gradingSnapshot ??
-    (studentAnswer ? sanitizeQuizResponse(studentAnswer) : '');
+  const annotations = grade?.annotations ?? [];
+  // When a grade exists, the snapshot is the source of truth — it
+  // froze what the teacher saw. When there's no grade yet, fall back
+  // to the student's live answer so they can still see what they
+  // submitted (and the caption below makes the live-vs-snapshot
+  // distinction explicit).
+  const snapshot = hasGrade
+    ? (grade?.gradingSnapshot ?? '')
+    : studentAnswer
+      ? sanitizeQuizResponse(studentAnswer)
+      : '';
+  const showingLiveAnswer = !hasGrade && !!studentAnswer;
   return (
     <div className="space-y-2">
       {snapshot ? (
-        hasAnnotations ? (
-          <AnnotatedResponseView
-            mode="read"
-            snapshot={snapshot}
-            annotations={grade?.annotations ?? []}
-          />
-        ) : (
-          <article
-            className="rounded-xl border border-slate-700 bg-slate-800/60 p-3 text-sm leading-relaxed text-slate-100 prose prose-sm prose-invert max-w-none"
-            dangerouslySetInnerHTML={{ __html: snapshot }}
-          />
-        )
+        <AnnotatedResponseView
+          mode="read"
+          snapshot={snapshot}
+          annotations={annotations}
+        />
       ) : (
         <p className="text-xs text-slate-500 italic">— no response</p>
       )}
@@ -2632,11 +2633,16 @@ export const WrittenAnswerReview: React.FC<{
           )}
         </div>
       )}
-      {!hasGrade && (
-        <p className="text-[11px] text-slate-500 italic">
-          Not yet graded by your teacher.
-        </p>
-      )}
+      {!hasGrade &&
+        (showingLiveAnswer ? (
+          <p className="text-[11px] text-slate-500 italic">
+            Showing your latest response — not yet graded by your teacher.
+          </p>
+        ) : (
+          <p className="text-[11px] text-slate-500 italic">
+            Not yet graded by your teacher.
+          </p>
+        ))}
     </div>
   );
 };

--- a/components/quiz/QuizStudentApp.tsx
+++ b/components/quiz/QuizStudentApp.tsx
@@ -55,7 +55,12 @@ import {
   shufflePublicQuestions,
   shuffleQuestionForStudent,
 } from '@/utils/quizShuffle';
-import { QuizSession, QuizPublicQuestion, WrittenAnswerGrade } from '@/types';
+import {
+  QuizSession,
+  QuizPublicQuestion,
+  WrittenAnswerGrade,
+  isWrittenQuestionType,
+} from '@/types';
 import { sanitizeQuizResponse } from '@/utils/security';
 import { AnnotatedResponseView } from '@/components/widgets/QuizWidget/components/AnnotatedResponseView';
 import { useDialog } from '@/context/useDialog';
@@ -2465,20 +2470,25 @@ const PublishedScoreReview: React.FC<{
               {(session.publicQuestions ?? []).map((q, idx) => {
                 const ans = answerById.get(q.id);
                 const studentAnswer = ans?.answer ?? '';
-                const isWritten = q.type === 'short' || q.type === 'essay';
+                const isWritten = isWrittenQuestionType(q.type);
                 const writtenGrade = isWritten
                   ? myResponse.grading?.[q.id]
                   : undefined;
+                // Match `gradeAnswer`'s default: a missing `points`
+                // means 1, not 0. The old `q.points &&` short-circuited
+                // when `points` was unset, so a full-credit grade on a
+                // default-points question never showed the ✓.
+                const writtenMaxPoints = q.points ?? 1;
                 const writtenIsCorrect =
-                  writtenGrade &&
-                  q.points &&
-                  writtenGrade.pointsAwarded === q.points;
-                const isCorrect =
-                  ans?.isCorrect === true || writtenIsCorrect === true;
+                  writtenGrade != null &&
+                  writtenMaxPoints > 0 &&
+                  writtenGrade.pointsAwarded === writtenMaxPoints;
+                const isCorrect = ans?.isCorrect === true || writtenIsCorrect;
                 const writtenIsIncorrect =
-                  writtenGrade && writtenGrade.pointsAwarded < (q.points ?? 1);
+                  writtenGrade != null &&
+                  writtenGrade.pointsAwarded < writtenMaxPoints;
                 const isIncorrect =
-                  ans?.isCorrect === false || writtenIsIncorrect === true;
+                  ans?.isCorrect === false || writtenIsIncorrect;
                 const correctAnswer = session.revealedAnswers?.[q.id];
                 return (
                   <article

--- a/components/quiz/QuizStudentApp.tsx
+++ b/components/quiz/QuizStudentApp.tsx
@@ -55,7 +55,9 @@ import {
   shufflePublicQuestions,
   shuffleQuestionForStudent,
 } from '@/utils/quizShuffle';
-import { QuizSession, QuizPublicQuestion } from '@/types';
+import { QuizSession, QuizPublicQuestion, WrittenAnswerGrade } from '@/types';
+import { sanitizeQuizResponse } from '@/utils/security';
+import { AnnotatedResponseView } from '@/components/widgets/QuizWidget/components/AnnotatedResponseView';
 import { useDialog } from '@/context/useDialog';
 import { StudentLeaderboard } from './StudentLeaderboard';
 import { QuizPausedPlaceholder } from './QuizPausedPlaceholder';
@@ -2463,8 +2465,20 @@ const PublishedScoreReview: React.FC<{
               {(session.publicQuestions ?? []).map((q, idx) => {
                 const ans = answerById.get(q.id);
                 const studentAnswer = ans?.answer ?? '';
-                const isCorrect = ans?.isCorrect === true;
-                const isIncorrect = ans?.isCorrect === false;
+                const isWritten = q.type === 'short' || q.type === 'essay';
+                const writtenGrade = isWritten
+                  ? myResponse.grading?.[q.id]
+                  : undefined;
+                const writtenIsCorrect =
+                  writtenGrade &&
+                  q.points &&
+                  writtenGrade.pointsAwarded === q.points;
+                const isCorrect =
+                  ans?.isCorrect === true || writtenIsCorrect === true;
+                const writtenIsIncorrect =
+                  writtenGrade && writtenGrade.pointsAwarded < (q.points ?? 1);
+                const isIncorrect =
+                  ans?.isCorrect === false || writtenIsIncorrect === true;
                 const correctAnswer = session.revealedAnswers?.[q.id];
                 return (
                   <article
@@ -2484,37 +2498,48 @@ const PublishedScoreReview: React.FC<{
                       <p className="flex-1 text-sm font-semibold text-slate-100">
                         {q.text}
                       </p>
-                      {ans?.isCorrect === true && (
+                      {isCorrect && (
                         <Check className="h-5 w-5 shrink-0 text-emerald-400" />
                       )}
-                      {ans?.isCorrect === false && (
+                      {isIncorrect && (
                         <XIcon className="h-5 w-5 shrink-0 text-red-400" />
                       )}
                     </header>
                     <div className="ml-7 space-y-1.5">
-                      <p className="text-xs text-slate-400">
-                        Your answer:{' '}
-                        <span
-                          className={`font-mono ${
-                            isCorrect
-                              ? 'text-emerald-300'
-                              : isIncorrect
-                                ? 'text-red-300'
-                                : 'text-slate-200'
-                          }`}
-                        >
-                          {studentAnswer
-                            ? formatAnswerForDisplay(studentAnswer, q.type)
-                            : '— no response'}
-                        </span>
-                      </p>
-                      {showAnswers && correctAnswer && (
-                        <p className="text-xs text-slate-400">
-                          Correct answer:{' '}
-                          <span className="font-mono text-emerald-300">
-                            {formatAnswerForDisplay(correctAnswer, q.type)}
-                          </span>
-                        </p>
+                      {isWritten ? (
+                        <WrittenAnswerReview
+                          studentAnswer={studentAnswer}
+                          grade={writtenGrade}
+                          showResponse={showResponses}
+                          maxPoints={q.points ?? 1}
+                        />
+                      ) : (
+                        <>
+                          <p className="text-xs text-slate-400">
+                            Your answer:{' '}
+                            <span
+                              className={`font-mono ${
+                                isCorrect
+                                  ? 'text-emerald-300'
+                                  : isIncorrect
+                                    ? 'text-red-300'
+                                    : 'text-slate-200'
+                              }`}
+                            >
+                              {studentAnswer
+                                ? formatAnswerForDisplay(studentAnswer, q.type)
+                                : '— no response'}
+                            </span>
+                          </p>
+                          {showAnswers && correctAnswer && (
+                            <p className="text-xs text-slate-400">
+                              Correct answer:{' '}
+                              <span className="font-mono text-emerald-300">
+                                {formatAnswerForDisplay(correctAnswer, q.type)}
+                              </span>
+                            </p>
+                          )}
+                        </>
                       )}
                     </div>
                   </article>
@@ -2531,6 +2556,77 @@ const PublishedScoreReview: React.FC<{
           </p>
         )}
       </div>
+    </div>
+  );
+};
+
+/**
+ * Per-question review surface for written-response questions on the
+ * student score-review screen. Shows three things when present:
+ *  1. The teacher's frozen snapshot of the student's answer with
+ *     highlight marks + margin comments (Phase 2).
+ *  2. The points awarded (e.g. "7 / 10").
+ *  3. The teacher's overall comment.
+ *
+ * Falls back to a sanitized render of the student's live answer when
+ * the question hasn't been graded yet — useful for self-paced quizzes
+ * where the teacher publishes scores in chunks.
+ */
+export const WrittenAnswerReview: React.FC<{
+  studentAnswer: string;
+  grade: WrittenAnswerGrade | undefined;
+  showResponse: boolean;
+  maxPoints: number;
+}> = ({ studentAnswer, grade, showResponse, maxPoints }) => {
+  if (!showResponse) {
+    return null;
+  }
+  const hasGrade = !!grade;
+  const hasAnnotations = !!grade?.annotations && grade.annotations.length > 0;
+  const snapshot =
+    grade?.gradingSnapshot ??
+    (studentAnswer ? sanitizeQuizResponse(studentAnswer) : '');
+  return (
+    <div className="space-y-2">
+      {snapshot ? (
+        hasAnnotations ? (
+          <AnnotatedResponseView
+            mode="read"
+            snapshot={snapshot}
+            annotations={grade?.annotations ?? []}
+          />
+        ) : (
+          <article
+            className="rounded-xl border border-slate-700 bg-slate-800/60 p-3 text-sm leading-relaxed text-slate-100 prose prose-sm prose-invert max-w-none"
+            dangerouslySetInnerHTML={{ __html: snapshot }}
+          />
+        )
+      ) : (
+        <p className="text-xs text-slate-500 italic">— no response</p>
+      )}
+      {hasGrade && (
+        <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1 text-xs text-slate-400">
+          <span>
+            Score:{' '}
+            <span className="font-mono text-slate-100">
+              {grade.pointsAwarded} / {maxPoints}
+            </span>
+          </span>
+          {grade.overallComment && (
+            <span className="basis-full text-slate-300">
+              <span className="font-bold uppercase tracking-wider text-[10px] text-slate-500">
+                Teacher comment:
+              </span>{' '}
+              {grade.overallComment}
+            </span>
+          )}
+        </div>
+      )}
+      {!hasGrade && (
+        <p className="text-[11px] text-slate-500 italic">
+          Not yet graded by your teacher.
+        </p>
+      )}
     </div>
   );
 };

--- a/components/widgets/QuizWidget/components/AnnotatedResponseView.tsx
+++ b/components/widgets/QuizWidget/components/AnnotatedResponseView.tsx
@@ -34,6 +34,7 @@ import type { WrittenAnswerAnnotation } from '@/types';
 import {
   getPlainTextOffsetFromRange,
   highlightClass,
+  parseSnapshotRoot,
   renderAnnotatedSnapshot,
 } from '@/utils/writtenAnnotations';
 
@@ -78,9 +79,14 @@ const ReadOnlyView: React.FC<ReadProps> = ({ snapshot, annotations }) => {
   const articleRef = useRef<HTMLElement | null>(null);
   const [hoveredId, setHoveredId] = useState<string | null>(null);
 
+  // Parse the snapshot once per `snapshot` and re-walk only when
+  // `annotations` change. Hover-induced state changes (and the
+  // student's own `setHoveredId` updates) would otherwise re-DOMParse
+  // the whole snapshot on every render.
+  const parsedRoot = useMemo(() => parseSnapshotRoot(snapshot), [snapshot]);
   const tree = useMemo(
-    () => renderAnnotatedSnapshot({ html: snapshot, annotations }),
-    [snapshot, annotations]
+    () => renderAnnotatedSnapshot({ root: parsedRoot, annotations }),
+    [parsedRoot, annotations]
   );
 
   const commented = annotations.filter((a) => a.comment?.trim());
@@ -166,9 +172,15 @@ const EditView: React.FC<EditProps> = ({
   const [activeId, setActiveId] = useState<string | null>(null);
   const [commentDraft, setCommentDraft] = useState<string>('');
 
+  // Same memoization split as ReadOnlyView: parse once per snapshot,
+  // re-walk on annotation changes. Critical in edit mode because the
+  // margin-comment editor calls `onChange` on every keystroke, so
+  // `annotations` mutates per keypress and would otherwise re-
+  // DOMParse the whole snapshot each time.
+  const parsedRoot = useMemo(() => parseSnapshotRoot(snapshot), [snapshot]);
   const tree = useMemo(
-    () => renderAnnotatedSnapshot({ html: snapshot, annotations }),
-    [snapshot, annotations]
+    () => renderAnnotatedSnapshot({ root: parsedRoot, annotations }),
+    [parsedRoot, annotations]
   );
 
   // Compute the rectangle of the current text selection inside the

--- a/components/widgets/QuizWidget/components/AnnotatedResponseView.tsx
+++ b/components/widgets/QuizWidget/components/AnnotatedResponseView.tsx
@@ -196,6 +196,14 @@ const EditView: React.FC<EditProps> = ({
     const range = selection.getRangeAt(0);
     const offsets = getPlainTextOffsetFromRange(articleRef.current, range);
     if (!offsets) {
+      // Surface this — a silently-dismissed palette looks like the
+      // feature is broken. Common cause: the selection straddles the
+      // article and an adjacent element (e.g. the margin column).
+      if (!selection.isCollapsed) {
+        console.warn(
+          '[AnnotatedResponseView] selection could not be resolved to a snapshot offset (does it escape the response?)'
+        );
+      }
       setPalette(null);
       return;
     }

--- a/components/widgets/QuizWidget/components/AnnotatedResponseView.tsx
+++ b/components/widgets/QuizWidget/components/AnnotatedResponseView.tsx
@@ -1,0 +1,444 @@
+/**
+ * Phase 2 surface for written-response annotations.
+ *
+ * In `mode="edit"` (teacher's grader) the component:
+ *  - Renders the frozen `gradingSnapshot` with existing marks via
+ *    `renderAnnotatedSnapshot` (offsets computed against the snapshot's
+ *    plaintext projection).
+ *  - On mouseup with a non-empty selection, surfaces a small floating
+ *    palette anchored to the selection's bounding rect; choosing a color
+ *    creates an annotation. Choosing the comment icon opens an inline
+ *    comment input docked in the right rail.
+ *  - Clicking an existing mark opens that annotation in the rail for
+ *    color/comment edits and exposes a delete button.
+ *
+ * In `mode="read"` (student review surface after publish) the component
+ * renders the same snapshot read-only, with the right-rail margin column
+ * showing the teacher's comments. No selection palette, no edit handles.
+ *
+ * The student's live `answer` field is never read here — the snapshot is
+ * the only source of truth, which keeps annotation offsets stable even
+ * if the teacher later unlocks the attempt and the student edits.
+ */
+
+import React, {
+  useCallback,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import { MessageSquare, Trash2, X } from 'lucide-react';
+import type { WrittenAnswerAnnotation } from '@/types';
+import {
+  getPlainTextOffsetFromRange,
+  highlightClass,
+  renderAnnotatedSnapshot,
+} from '@/utils/writtenAnnotations';
+
+type Color = NonNullable<WrittenAnswerAnnotation['highlightColor']>;
+
+const COLORS: { id: Color; label: string; swatch: string }[] = [
+  { id: 'yellow', label: 'Yellow highlight', swatch: 'bg-amber-300' },
+  { id: 'green', label: 'Green highlight', swatch: 'bg-emerald-300' },
+  { id: 'pink', label: 'Pink highlight', swatch: 'bg-pink-300' },
+  { id: 'blue', label: 'Blue highlight', swatch: 'bg-sky-300' },
+];
+
+interface BaseProps {
+  snapshot: string;
+  annotations: WrittenAnswerAnnotation[];
+}
+
+interface EditProps extends BaseProps {
+  mode: 'edit';
+  /** Teacher uid stamped on every new annotation. */
+  authorUid: string;
+  /** Called with the next annotation list whenever it changes. */
+  onChange: (next: WrittenAnswerAnnotation[]) => void;
+}
+
+interface ReadProps extends BaseProps {
+  mode: 'read';
+}
+
+type Props = EditProps | ReadProps;
+
+export const AnnotatedResponseView: React.FC<Props> = (props) => {
+  if (props.mode === 'read') {
+    return <ReadOnlyView {...props} />;
+  }
+  return <EditView {...props} />;
+};
+
+// ─── Read-only (student review) ─────────────────────────────────────────────
+
+const ReadOnlyView: React.FC<ReadProps> = ({ snapshot, annotations }) => {
+  const articleRef = useRef<HTMLElement | null>(null);
+  const [hoveredId, setHoveredId] = useState<string | null>(null);
+
+  const tree = useMemo(
+    () => renderAnnotatedSnapshot({ html: snapshot, annotations }),
+    [snapshot, annotations]
+  );
+
+  const commented = annotations.filter((a) => a.comment?.trim());
+
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-[1fr_220px] gap-3">
+      <article
+        ref={articleRef}
+        className="rounded-xl border border-slate-700 bg-slate-800/60 p-4 text-sm leading-relaxed text-slate-100 prose prose-sm prose-invert max-w-none [&_mark]:transition-colors"
+        onMouseOver={(e) => {
+          const t = (e.target as HTMLElement).closest('mark');
+          if (t) setHoveredId(t.getAttribute('data-annotation-id'));
+        }}
+        onMouseOut={() => setHoveredId(null)}
+      >
+        {tree}
+      </article>
+      {commented.length > 0 && (
+        <aside className="flex flex-col gap-2">
+          <h4 className="text-[10px] font-bold uppercase tracking-wider text-slate-400">
+            Teacher notes
+          </h4>
+          {commented.map((a) => (
+            <CommentChip
+              key={a.id}
+              annotation={a}
+              highlighted={hoveredId === a.id}
+              onHover={(on) => setHoveredId(on ? a.id : null)}
+            />
+          ))}
+        </aside>
+      )}
+    </div>
+  );
+};
+
+const CommentChip: React.FC<{
+  annotation: WrittenAnswerAnnotation;
+  highlighted: boolean;
+  onHover: (on: boolean) => void;
+}> = ({ annotation, highlighted, onHover }) => (
+  <div
+    className={`rounded-lg border p-2.5 text-xs leading-relaxed transition-colors ${
+      highlighted
+        ? 'border-violet-400/60 bg-violet-500/10 text-slate-100'
+        : 'border-slate-700 bg-slate-800/60 text-slate-300'
+    }`}
+    onMouseEnter={() => onHover(true)}
+    onMouseLeave={() => onHover(false)}
+  >
+    <span
+      aria-hidden
+      className={`inline-block w-2 h-2 rounded-full mr-1.5 ${
+        annotation.highlightColor === 'green'
+          ? 'bg-emerald-400'
+          : annotation.highlightColor === 'pink'
+            ? 'bg-pink-400'
+            : annotation.highlightColor === 'blue'
+              ? 'bg-sky-400'
+              : 'bg-amber-400'
+      }`}
+    />
+    {annotation.comment}
+  </div>
+);
+
+// ─── Edit (teacher grader) ──────────────────────────────────────────────────
+
+const EditView: React.FC<EditProps> = ({
+  snapshot,
+  annotations,
+  authorUid,
+  onChange,
+}) => {
+  const articleRef = useRef<HTMLElement | null>(null);
+  const reactId = useId();
+  const [palette, setPalette] = useState<{
+    x: number;
+    y: number;
+    from: number;
+    to: number;
+  } | null>(null);
+  const [activeId, setActiveId] = useState<string | null>(null);
+  const [commentDraft, setCommentDraft] = useState<string>('');
+
+  const tree = useMemo(
+    () => renderAnnotatedSnapshot({ html: snapshot, annotations }),
+    [snapshot, annotations]
+  );
+
+  // Compute the rectangle of the current text selection inside the
+  // article and convert it to plaintext offsets. If nothing's selected
+  // (or the selection is outside the article), close the palette.
+  const handleMouseUp = useCallback(() => {
+    if (!articleRef.current) return;
+    const selection = window.getSelection();
+    if (!selection || selection.isCollapsed) {
+      setPalette(null);
+      return;
+    }
+    const range = selection.getRangeAt(0);
+    const offsets = getPlainTextOffsetFromRange(articleRef.current, range);
+    if (!offsets) {
+      setPalette(null);
+      return;
+    }
+    const rect = range.getBoundingClientRect();
+    if (rect.width === 0 && rect.height === 0) {
+      setPalette(null);
+      return;
+    }
+    const articleRect = articleRef.current.getBoundingClientRect();
+    setPalette({
+      x: rect.left - articleRect.left + rect.width / 2,
+      y: rect.top - articleRect.top - 8,
+      from: offsets.from,
+      to: offsets.to,
+    });
+    setActiveId(null);
+  }, []);
+
+  // Dismiss the palette on Escape so a teacher mid-selection can bail
+  // without closing the entire modal.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape' && palette) {
+        // Don't stopPropagation — the modal still wants Esc-to-close
+        // when nothing's selected. We intentionally let both run.
+        setPalette(null);
+      }
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [palette]);
+
+  const handleArticleClick = useCallback(
+    (e: React.MouseEvent<HTMLElement>) => {
+      const mark = (e.target as HTMLElement).closest('mark');
+      if (mark) {
+        const id = mark.getAttribute('data-annotation-id');
+        if (id) {
+          const a = annotations.find((x) => x.id === id);
+          setActiveId(id);
+          setCommentDraft(a?.comment ?? '');
+          setPalette(null);
+          // Clear any selection so the palette doesn't immediately
+          // reopen on mouseup.
+          window.getSelection()?.removeAllRanges();
+        }
+        return;
+      }
+      // Click on bare text — dismiss the active editor panel.
+      setActiveId(null);
+    },
+    [annotations]
+  );
+
+  const createAnnotation = useCallback(
+    (color: Color, withCommentInput: boolean) => {
+      if (!palette) return;
+      const id = `${reactId}-${Date.now()}`;
+      const next: WrittenAnswerAnnotation = {
+        id,
+        from: palette.from,
+        to: palette.to,
+        highlightColor: color,
+        authorUid,
+        createdAt: Date.now(),
+      };
+      onChange([...annotations, next]);
+      setPalette(null);
+      if (withCommentInput) {
+        setActiveId(id);
+        setCommentDraft('');
+      }
+      window.getSelection()?.removeAllRanges();
+    },
+    [palette, reactId, authorUid, onChange, annotations]
+  );
+
+  const updateActiveAnnotation = useCallback(
+    (patch: Partial<WrittenAnswerAnnotation>) => {
+      if (!activeId) return;
+      onChange(
+        annotations.map((a) => (a.id === activeId ? { ...a, ...patch } : a))
+      );
+    },
+    [activeId, annotations, onChange]
+  );
+
+  const deleteActive = useCallback(() => {
+    if (!activeId) return;
+    onChange(annotations.filter((a) => a.id !== activeId));
+    setActiveId(null);
+    setCommentDraft('');
+  }, [activeId, annotations, onChange]);
+
+  const active = activeId
+    ? (annotations.find((a) => a.id === activeId) ?? null)
+    : null;
+
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-[1fr_240px] gap-3">
+      <div className="relative">
+        <article
+          ref={articleRef}
+          className="rounded-xl border border-slate-200 bg-white p-4 text-sm leading-relaxed text-slate-800 prose prose-sm max-w-none cursor-text select-text"
+          onMouseUp={handleMouseUp}
+          onClick={handleArticleClick}
+        >
+          {tree}
+        </article>
+        {palette && (
+          <div
+            role="toolbar"
+            aria-label="Annotation palette"
+            className="absolute z-10 -translate-x-1/2 -translate-y-full flex items-center gap-1 px-1.5 py-1 bg-slate-900 text-white rounded-lg shadow-xl"
+            style={{ left: palette.x, top: palette.y }}
+            // Prevent the article's mouseup from clearing the selection
+            // before we read it; the palette handles its own clicks.
+            onMouseDown={(e) => e.preventDefault()}
+          >
+            {COLORS.map((c) => (
+              <button
+                key={c.id}
+                type="button"
+                aria-label={c.label}
+                title={c.label}
+                onClick={() => createAnnotation(c.id, false)}
+                className={`w-5 h-5 rounded-full ${c.swatch} ring-1 ring-white/40 hover:ring-2 hover:ring-white transition`}
+              />
+            ))}
+            <div className="w-px h-4 bg-slate-700 mx-0.5" />
+            <button
+              type="button"
+              aria-label="Add comment"
+              title="Add comment"
+              onClick={() => createAnnotation('yellow', true)}
+              className="p-1 rounded text-slate-300 hover:bg-slate-800 hover:text-white transition-colors"
+            >
+              <MessageSquare className="w-4 h-4" />
+            </button>
+          </div>
+        )}
+      </div>
+
+      <aside className="flex flex-col gap-2">
+        <h4 className="text-[10px] font-bold uppercase tracking-wider text-slate-500">
+          Annotations ({annotations.length})
+        </h4>
+        {annotations.length === 0 && (
+          <p className="text-xs text-slate-500 italic leading-relaxed">
+            Select text in the response to add a highlight or margin comment.
+          </p>
+        )}
+        {active ? (
+          <ActiveAnnotationEditor
+            annotation={active}
+            commentDraft={commentDraft}
+            onCommentChange={(v) => {
+              setCommentDraft(v);
+              updateActiveAnnotation({ comment: v.trim() || undefined });
+            }}
+            onColorChange={(c) => updateActiveAnnotation({ highlightColor: c })}
+            onDelete={deleteActive}
+            onClose={() => setActiveId(null)}
+          />
+        ) : (
+          annotations.map((a) => (
+            <button
+              key={a.id}
+              type="button"
+              onClick={() => {
+                setActiveId(a.id);
+                setCommentDraft(a.comment ?? '');
+              }}
+              className="text-left rounded-lg border border-slate-200 bg-slate-50 hover:bg-slate-100 p-2 text-xs leading-relaxed transition-colors"
+            >
+              <span
+                className={`inline-block px-1.5 rounded ${highlightClass(a.highlightColor)} pointer-events-none`}
+              >
+                highlight
+              </span>
+              {a.comment ? (
+                <span className="ml-2 text-slate-700">{a.comment}</span>
+              ) : (
+                <span className="ml-2 text-slate-400 italic">(no comment)</span>
+              )}
+            </button>
+          ))
+        )}
+      </aside>
+    </div>
+  );
+};
+
+const ActiveAnnotationEditor: React.FC<{
+  annotation: WrittenAnswerAnnotation;
+  commentDraft: string;
+  onCommentChange: (v: string) => void;
+  onColorChange: (c: Color) => void;
+  onDelete: () => void;
+  onClose: () => void;
+}> = ({
+  annotation,
+  commentDraft,
+  onCommentChange,
+  onColorChange,
+  onDelete,
+  onClose,
+}) => (
+  <div className="rounded-lg border border-violet-400/60 bg-violet-50 p-2.5 flex flex-col gap-2">
+    <div className="flex items-center justify-between">
+      <div className="flex items-center gap-1">
+        {COLORS.map((c) => (
+          <button
+            key={c.id}
+            type="button"
+            aria-label={c.label}
+            title={c.label}
+            onClick={() => onColorChange(c.id)}
+            className={`w-4 h-4 rounded-full ${c.swatch} ${
+              annotation.highlightColor === c.id
+                ? 'ring-2 ring-violet-600'
+                : 'ring-1 ring-slate-300'
+            } transition`}
+          />
+        ))}
+      </div>
+      <div className="flex items-center gap-0.5">
+        <button
+          type="button"
+          aria-label="Delete annotation"
+          title="Delete"
+          onClick={onDelete}
+          className="p-1 rounded text-slate-500 hover:bg-brand-red-lighter/40 hover:text-brand-red-dark transition-colors"
+        >
+          <Trash2 className="w-3.5 h-3.5" />
+        </button>
+        <button
+          type="button"
+          aria-label="Close annotation editor"
+          title="Close"
+          onClick={onClose}
+          className="p-1 rounded text-slate-500 hover:bg-slate-200 transition-colors"
+        >
+          <X className="w-3.5 h-3.5" />
+        </button>
+      </div>
+    </div>
+    <textarea
+      value={commentDraft}
+      onChange={(e) => onCommentChange(e.target.value)}
+      rows={3}
+      placeholder="Margin comment (optional)"
+      className="w-full px-2 py-1.5 bg-white border border-slate-300 rounded text-xs text-slate-800 placeholder:text-slate-400 focus:outline-none focus:ring-2 focus:ring-violet-400/40 focus:border-violet-400 resize-none"
+    />
+  </div>
+);
+
+export default AnnotatedResponseView;

--- a/components/widgets/QuizWidget/components/AnnotatedResponseView.tsx
+++ b/components/widgets/QuizWidget/components/AnnotatedResponseView.tsx
@@ -47,6 +47,15 @@ const COLORS: { id: Color; label: string; swatch: string }[] = [
   { id: 'blue', label: 'Blue highlight', swatch: 'bg-sky-300' },
 ];
 
+// Module-level monotonic counter so back-to-back highlight actions
+// inside the same millisecond can't collide on `id`. `useId()` makes
+// the prefix unique across React component instances, but two
+// annotations in the same modal share the same prefix — without a
+// counter, two clicks within one ms would produce identical ids and
+// silently overwrite each other in `annotationListsEqual`'s id Map
+// and in the renderer's React keys.
+let annotationSeq = 0;
+
 interface BaseProps {
   snapshot: string;
   annotations: WrittenAnswerAnnotation[];
@@ -261,7 +270,7 @@ const EditView: React.FC<EditProps> = ({
   const createAnnotation = useCallback(
     (color: Color, withCommentInput: boolean) => {
       if (!palette) return;
-      const id = `${reactId}-${Date.now()}`;
+      const id = `${reactId}-${Date.now()}-${++annotationSeq}`;
       const next: WrittenAnswerAnnotation = {
         id,
         from: palette.from,

--- a/components/widgets/QuizWidget/components/WrittenResponseGrader.tsx
+++ b/components/widgets/QuizWidget/components/WrittenResponseGrader.tsx
@@ -167,26 +167,34 @@ export const WrittenResponseGrader: React.FC<WrittenResponseGraderProps> = ({
     );
   }, [isDirty]);
 
+  // Gate all navigation on `saving` to prevent a race: an in-flight
+  // `onSaveGrade` reads the captured `studentIdx` and auto-advances on
+  // resolve, so if the teacher manually navigates while the save is
+  // pending the auto-advance can jump past where they expected to land.
   const goPrevStudent = useCallback(() => {
+    if (saving) return;
     if (!confirmDiscardIfDirty()) return;
     setStudentIdx((i) => Math.max(0, i - 1));
-  }, [confirmDiscardIfDirty]);
+  }, [confirmDiscardIfDirty, saving]);
   const goNextStudent = useCallback(() => {
+    if (saving) return;
     if (!confirmDiscardIfDirty()) return;
     setStudentIdx((i) =>
       Math.min(Math.max(0, gradeableResponses.length - 1), i + 1)
     );
-  }, [gradeableResponses.length, confirmDiscardIfDirty]);
+  }, [gradeableResponses.length, confirmDiscardIfDirty, saving]);
   const goPrevQuestion = useCallback(() => {
+    if (saving) return;
     if (!confirmDiscardIfDirty()) return;
     setQuestionIdx((i) => Math.max(0, i - 1));
-  }, [confirmDiscardIfDirty]);
+  }, [confirmDiscardIfDirty, saving]);
   const goNextQuestion = useCallback(() => {
+    if (saving) return;
     if (!confirmDiscardIfDirty()) return;
     setQuestionIdx((i) =>
       Math.min(Math.max(0, writtenQuestions.length - 1), i + 1)
     );
-  }, [writtenQuestions.length, confirmDiscardIfDirty]);
+  }, [writtenQuestions.length, confirmDiscardIfDirty, saving]);
 
   // Keyboard navigation. Only active when no input has focus — we don't
   // want left/right inside the points input to jump students.
@@ -216,7 +224,17 @@ export const WrittenResponseGrader: React.FC<WrittenResponseGraderProps> = ({
   }, [goPrevStudent, goNextStudent, onClose]);
 
   const handleSave = useCallback(async () => {
-    if (!response || !question || !responseKey) return;
+    if (!response || !question) return;
+    if (!responseKey) {
+      // Should be unreachable for any response that joined a live
+      // session (both `_responseKey` and `studentUid` are set on
+      // create), but surface it explicitly rather than no-op'ing the
+      // save click — silent no-ops on the grader are confusing.
+      setSaveError(
+        'Cannot save: this response is missing its identifier. Reload the quiz results and try again.'
+      );
+      return;
+    }
     const trimmed = pointsInput.trim();
     if (trimmed === '') {
       setSaveError('Enter a numeric score.');
@@ -240,6 +258,20 @@ export const WrittenResponseGrader: React.FC<WrittenResponseGraderProps> = ({
     const existingSnapshot = savedGrade?.gradingSnapshot;
     const studentAnswerForSnapshot =
       response.answers.find((a) => a.questionId === question.id)?.answer ?? '';
+    // Annotations on an empty answer would point into nothing — the
+    // palette can't surface here in normal flow (selection requires
+    // text), but if we ever get into this state via a bug or drag-and-
+    // drop, fail loudly instead of writing dead annotations.
+    if (
+      hasAnnotations &&
+      !existingSnapshot &&
+      !studentAnswerForSnapshot.trim()
+    ) {
+      setSaveError(
+        "Cannot save annotations on an empty response — the student didn't answer this question."
+      );
+      return;
+    }
     const gradingSnapshot = hasAnnotations
       ? (existingSnapshot ?? sanitizeQuizResponse(studentAnswerForSnapshot))
       : existingSnapshot;
@@ -326,7 +358,7 @@ export const WrittenResponseGrader: React.FC<WrittenResponseGraderProps> = ({
         <div className="flex items-center gap-3 min-w-0">
           <button
             onClick={goPrevStudent}
-            disabled={studentIdx === 0}
+            disabled={studentIdx === 0 || saving}
             className="p-1.5 rounded text-slate-500 hover:bg-slate-100 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
             aria-label="Previous student (←)"
             title="Previous student (←)"
@@ -358,7 +390,7 @@ export const WrittenResponseGrader: React.FC<WrittenResponseGraderProps> = ({
           </div>
           <button
             onClick={goNextStudent}
-            disabled={studentIdx >= gradeableResponses.length - 1}
+            disabled={studentIdx >= gradeableResponses.length - 1 || saving}
             className="p-1.5 rounded text-slate-500 hover:bg-slate-100 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
             aria-label="Next student (→)"
             title="Next student (→)"
@@ -381,7 +413,7 @@ export const WrittenResponseGrader: React.FC<WrittenResponseGraderProps> = ({
         <div className="flex items-center gap-2 px-5 py-2 border-b border-slate-200 bg-slate-50">
           <button
             onClick={goPrevQuestion}
-            disabled={questionIdx === 0}
+            disabled={questionIdx === 0 || saving}
             className="p-1 rounded text-slate-500 hover:bg-slate-200 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
             aria-label="Previous question"
           >
@@ -394,7 +426,7 @@ export const WrittenResponseGrader: React.FC<WrittenResponseGraderProps> = ({
           </div>
           <button
             onClick={goNextQuestion}
-            disabled={questionIdx >= writtenQuestions.length - 1}
+            disabled={questionIdx >= writtenQuestions.length - 1 || saving}
             className="p-1 rounded text-slate-500 hover:bg-slate-200 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
             aria-label="Next question"
           >
@@ -517,11 +549,11 @@ export const WrittenResponseGrader: React.FC<WrittenResponseGraderProps> = ({
 };
 
 /**
- * Field-level equality on two annotation lists. Insensitive to key
- * insertion order (so a Firestore-loaded annotation and a locally-built
- * one with the same fields compare equal), and treats `undefined` and
- * `missing` color/comment the same — avoids false-positive dirty
- * states from `JSON.stringify` ordering quirks.
+ * Field-level equality on two annotation lists. Insensitive to BOTH
+ * key insertion order (so Firestore-loaded annotations compare equal
+ * to locally-built ones with the same fields) AND list order — looks
+ * the annotations up by `id` so reordering doesn't trip a spurious
+ * dirty state. Treats `undefined` and missing color/comment the same.
  */
 const annotationListsEqual = (
   a: WrittenAnswerAnnotation[],
@@ -529,10 +561,11 @@ const annotationListsEqual = (
 ): boolean => {
   const right = b ?? [];
   if (a.length !== right.length) return false;
-  for (let i = 0; i < a.length; i++) {
-    const x = a[i];
-    const y = right[i];
-    if (x.id !== y.id) return false;
+  const byId = new Map<string, WrittenAnswerAnnotation>();
+  for (const x of right) byId.set(x.id, x);
+  for (const x of a) {
+    const y = byId.get(x.id);
+    if (!y) return false;
     if (x.from !== y.from || x.to !== y.to) return false;
     if ((x.highlightColor ?? 'yellow') !== (y.highlightColor ?? 'yellow'))
       return false;

--- a/components/widgets/QuizWidget/components/WrittenResponseGrader.tsx
+++ b/components/widgets/QuizWidget/components/WrittenResponseGrader.tsx
@@ -1,12 +1,17 @@
 /**
  * WrittenResponseGrader — teacher-facing modal for manually grading
- * `short` / `essay` quiz responses. Phase 1 surface: prev/next student
- * navigation, points input, optional overall comment.
+ * `short` / `essay` quiz responses.
  *
- * Annotations (Phase 2) and rubric scoring (Phase 3) are out of scope
- * here; the storage shape (`WrittenAnswerGrade.annotations`,
- * `rubricScores`) is already reserved on the type so this component can
- * grow into those features without a schema migration.
+ * Phase 1 shipped points entry, an optional overall comment, and
+ * prev/next student navigation. Phase 2 adds inline highlights + margin
+ * comments via `AnnotatedResponseView`. Annotations are stored as
+ * plaintext offsets into a frozen `gradingSnapshot` of the student's
+ * answer, so highlights stay anchored even if the teacher later unlocks
+ * the attempt and the student edits.
+ *
+ * Rubric scoring (Phase 3) is still out of scope; the storage shape
+ * (`WrittenAnswerGrade.rubricScores`) is already reserved on the type so
+ * this component can grow into it without a schema migration.
  */
 
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
@@ -18,8 +23,14 @@ import {
   ShieldAlert,
   X,
 } from 'lucide-react';
-import { QuizData, QuizResponse, WrittenAnswerGrade } from '@/types';
+import {
+  QuizData,
+  QuizResponse,
+  WrittenAnswerAnnotation,
+  WrittenAnswerGrade,
+} from '@/types';
 import { sanitizeQuizResponse } from '@/utils/security';
+import { AnnotatedResponseView } from './AnnotatedResponseView';
 
 interface WrittenResponseGraderProps {
   quiz: QuizData;
@@ -112,6 +123,9 @@ export const WrittenResponseGrader: React.FC<WrittenResponseGraderProps> = ({
   const maxPoints = question?.points ?? 1;
   const [pointsInput, setPointsInput] = useState<string>('');
   const [comment, setComment] = useState<string>('');
+  const [draftAnnotations, setDraftAnnotations] = useState<
+    WrittenAnswerAnnotation[]
+  >([]);
   const [hydrationKey, setHydrationKey] = useState<string>('');
 
   const targetKey = `${responseKey ?? ''}::${question?.id ?? ''}`;
@@ -119,6 +133,7 @@ export const WrittenResponseGrader: React.FC<WrittenResponseGraderProps> = ({
     setHydrationKey(targetKey);
     setPointsInput(savedGrade != null ? String(savedGrade.pointsAwarded) : '');
     setComment(savedGrade?.overallComment ?? '');
+    setDraftAnnotations(savedGrade?.annotations ?? []);
     setSaveError(null);
   }
 
@@ -129,7 +144,12 @@ export const WrittenResponseGrader: React.FC<WrittenResponseGraderProps> = ({
   const savedPointsStr =
     savedGrade != null ? String(savedGrade.pointsAwarded) : '';
   const savedCommentStr = savedGrade?.overallComment ?? '';
-  const isDirty = pointsInput !== savedPointsStr || comment !== savedCommentStr;
+  const savedAnnotationsJSON = JSON.stringify(savedGrade?.annotations ?? []);
+  const draftAnnotationsJSON = JSON.stringify(draftAnnotations);
+  const isDirty =
+    pointsInput !== savedPointsStr ||
+    comment !== savedCommentStr ||
+    draftAnnotationsJSON !== savedAnnotationsJSON;
 
   const confirmDiscardIfDirty = useCallback((): boolean => {
     if (!isDirty) return true;
@@ -205,9 +225,23 @@ export const WrittenResponseGrader: React.FC<WrittenResponseGraderProps> = ({
       setSaveError(`Score must be between 0 and ${maxPoints}.`);
       return;
     }
+    // Snapshot the student's answer the first time we save annotations,
+    // and keep that snapshot frozen forever after. This is what makes
+    // annotation offsets stable: even if the teacher later unlocks the
+    // attempt and the student edits, the snapshot the offsets index
+    // into is unchanged.
+    const hasAnnotations = draftAnnotations.length > 0;
+    const existingSnapshot = savedGrade?.gradingSnapshot;
+    const studentAnswerForSnapshot =
+      response.answers.find((a) => a.questionId === question.id)?.answer ?? '';
+    const gradingSnapshot = hasAnnotations
+      ? (existingSnapshot ?? sanitizeQuizResponse(studentAnswerForSnapshot))
+      : existingSnapshot;
     const grade: WrittenAnswerGrade = {
       pointsAwarded: parsed,
       overallComment: comment.trim() || undefined,
+      annotations: hasAnnotations ? draftAnnotations : undefined,
+      gradingSnapshot,
       gradedBy: teacherUid,
       gradedAt: Date.now(),
     };
@@ -234,6 +268,8 @@ export const WrittenResponseGrader: React.FC<WrittenResponseGraderProps> = ({
     pointsInput,
     maxPoints,
     comment,
+    draftAnnotations,
+    savedGrade,
     teacherUid,
     onSaveGrade,
     studentIdx,
@@ -375,11 +411,19 @@ export const WrittenResponseGrader: React.FC<WrittenResponseGraderProps> = ({
             Student response
           </h3>
           {studentAnswer ? (
-            <article
-              className="bg-white border border-slate-200 rounded-lg p-5 text-sm leading-relaxed text-slate-800 prose prose-sm max-w-none"
-              dangerouslySetInnerHTML={{
-                __html: sanitizeQuizResponse(studentAnswer),
-              }}
+            <AnnotatedResponseView
+              mode="edit"
+              // Once we've saved annotations, the snapshot is the
+              // source of truth; until then, default to the live
+              // sanitized answer so a teacher can start selecting text
+              // even on a never-graded response.
+              snapshot={
+                savedGrade?.gradingSnapshot ??
+                sanitizeQuizResponse(studentAnswer)
+              }
+              annotations={draftAnnotations}
+              authorUid={teacherUid}
+              onChange={setDraftAnnotations}
             />
           ) : (
             <div className="bg-white border border-slate-200 rounded-lg p-5 text-sm text-slate-500 italic">
@@ -456,8 +500,9 @@ export const WrittenResponseGrader: React.FC<WrittenResponseGraderProps> = ({
           </button>
 
           <p className="text-xs text-slate-500 leading-relaxed">
-            ← / → switch students. Esc closes the grader. Phase 2 will add
-            inline highlights and margin comments; Phase 3 adds rubric scoring.
+            ← / → switch students. Esc closes the grader. Select text in the
+            response to add a highlight or margin comment. Rubric scoring is
+            coming in Phase 3.
           </p>
         </aside>
       </div>

--- a/components/widgets/QuizWidget/components/WrittenResponseGrader.tsx
+++ b/components/widgets/QuizWidget/components/WrittenResponseGrader.tsx
@@ -144,12 +144,18 @@ export const WrittenResponseGrader: React.FC<WrittenResponseGraderProps> = ({
   const savedPointsStr =
     savedGrade != null ? String(savedGrade.pointsAwarded) : '';
   const savedCommentStr = savedGrade?.overallComment ?? '';
-  const savedAnnotationsJSON = JSON.stringify(savedGrade?.annotations ?? []);
-  const draftAnnotationsJSON = JSON.stringify(draftAnnotations);
+  // Stable equality on the annotation list. `JSON.stringify` would
+  // false-positive when Firestore-loaded annotations and locally-built
+  // ones disagree on key insertion order, even when the fields match.
+  // Compare the canonical fields explicitly instead.
+  const annotationsEqual = annotationListsEqual(
+    draftAnnotations,
+    savedGrade?.annotations
+  );
   const isDirty =
     pointsInput !== savedPointsStr ||
     comment !== savedCommentStr ||
-    draftAnnotationsJSON !== savedAnnotationsJSON;
+    !annotationsEqual;
 
   const confirmDiscardIfDirty = useCallback((): boolean => {
     if (!isDirty) return true;
@@ -508,6 +514,32 @@ export const WrittenResponseGrader: React.FC<WrittenResponseGraderProps> = ({
       </div>
     </ModalShell>
   );
+};
+
+/**
+ * Field-level equality on two annotation lists. Insensitive to key
+ * insertion order (so a Firestore-loaded annotation and a locally-built
+ * one with the same fields compare equal), and treats `undefined` and
+ * `missing` color/comment the same — avoids false-positive dirty
+ * states from `JSON.stringify` ordering quirks.
+ */
+const annotationListsEqual = (
+  a: WrittenAnswerAnnotation[],
+  b: WrittenAnswerAnnotation[] | undefined
+): boolean => {
+  const right = b ?? [];
+  if (a.length !== right.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    const x = a[i];
+    const y = right[i];
+    if (x.id !== y.id) return false;
+    if (x.from !== y.from || x.to !== y.to) return false;
+    if ((x.highlightColor ?? 'yellow') !== (y.highlightColor ?? 'yellow'))
+      return false;
+    if ((x.comment ?? '') !== (y.comment ?? '')) return false;
+    if (x.authorUid !== y.authorUid) return false;
+  }
+  return true;
 };
 
 const ModalShell: React.FC<{

--- a/docs/written-response-quiz-questions.md
+++ b/docs/written-response-quiz-questions.md
@@ -194,50 +194,70 @@ path already touches — no new collection needed.
 
 ## 5. Annotations (highlights + margin comments) — Phase 2
 
-> **Open question flagged by Gemini review (2026-05-13):** there is a
-> real technical tension between two of the goals stated below — "marks
-> move with the text" vs. "teacher must not modify the student's
-> `answer` JSON." The pragmatic resolution is one of:
->
-> 1. **Snapshot the document at grading time** to a teacher-owned
->    `gradingSnapshot` field, and store marks _on the snapshot_. The
->    student's `answer` stays untouched. Annotations only travel with
->    the snapshot — fine, because revisions are a Phase 4 concern.
-> 2. **Sidecar offsets** stored under `grading[questionId].annotations`,
->    with a deterministic re-mapping pass if the student ever revises
->    the doc later.
->
-> Phase 2 will pick one. The doc below originally argued for marks-in-
-> document, but that conflicts with the security-first stance that
-> teachers don't rewrite student `answer` text. Decision deferred to
-> Phase 2 design.
+**Design decision (resolved 2026-05-13):** snapshot-at-grading-time +
+sidecar plaintext offsets, rendered to JSX via the shared walker in
+[`utils/writtenAnnotations.ts`](../utils/writtenAnnotations.ts). The
+student's `answer` JSON is **never** mutated. The chosen option mirrors
+proposal (1) from the original Gemini review note.
+
+**Why we picked snapshot-at-grading-time:**
+
+- Phase 1 already guarantees the student's `answer` is never rewritten.
+  Annotations need a stable anchor; a frozen snapshot gives us one
+  without breaking that invariant.
+- The teacher-unlock flow (`unlockStudentAttempt`) lets a student
+  resume and edit after grading. If annotations indexed into the live
+  answer, offsets would silently drift on every edit. The snapshot
+  freezes the document at annotation time so highlights stay anchored.
+- No schema churn for the open question — the existing
+  `WrittenAnswerAnnotation.from`/`to` fields are already documented as
+  plaintext offsets, so we layered on a `gradingSnapshot` field and a
+  shared walker that defines what "plaintext offset" means
+  deterministically.
+- Rejected alternative (marks-in-document) would have required either
+  widening `sanitizeQuizResponse` to allow `<mark data-id="…">`
+  (loosens the Phase 1 anti-styling profile) or rewriting the
+  student's `answer` field (breaks the security stance).
 
 ### Annotation shape
 
+The existing `WrittenAnswerAnnotation` interface (`types.ts:2830`)
+captures everything we need:
+
 ```ts
-type Annotation = {
-  id: string; // uuid
-  range: { from: number; to: number }; // ProseMirror positions in the snapshot doc
-  highlightColor: 'yellow' | 'green' | 'pink' | 'blue';
-  comment?: string; // optional margin note; an annotation can be a bare highlight
+interface WrittenAnswerAnnotation {
+  id: string;
+  /** Inclusive start offset into the snapshot's plaintext projection. */
+  from: number;
+  /** Exclusive end offset. */
+  to: number;
+  highlightColor?: 'yellow' | 'green' | 'pink' | 'blue';
+  comment?: string;
   authorUid: string;
   createdAt: number;
-};
+}
 ```
+
+Plus the new `WrittenAnswerGrade.gradingSnapshot?: string` (Phase 2
+addition): the sanitized HTML the teacher annotated, frozen on first
+save with annotations, immutable afterwards.
 
 Rendered as:
 
-- A `highlight` mark with `data-annotation-id` on the marked text.
-- A right-rail margin column showing comments anchored to their highlights.
-  Hovering a highlight scrolls/focuses the corresponding margin note and
-  vice versa.
+- A `<mark>` wrapper with `data-annotation-id` and `data-color` on the
+  marked text, emitted by `renderAnnotatedSnapshot` directly into a
+  React tree (no HTML string concat, no re-sanitization step).
+- A right-rail margin column showing comments anchored to their
+  highlights. Hovering a highlight cross-highlights the corresponding
+  margin chip and vice versa.
 
 ### Student view of annotations
 
 When the teacher publishes scores (`scoreVisibility` already exists in
-`QuizAssignment`), the student score-review screen renders the same snapshot
-in a **read-only** TipTap instance with highlight marks + margin comments
-visible. No editing surface, no reply (Phase 4 if we want a back-and-forth).
+`QuizAssignment`), the student score-review screen renders the same
+snapshot in `AnnotatedResponseView`'s `mode="read"` surface with
+highlight marks + margin comments visible. No editing surface, no
+reply (Phase 4 if we want a back-and-forth).
 
 ---
 
@@ -472,3 +492,72 @@ the existing teacher-owns-everything model.)
   read-only render shows highlights at correct offsets.
 - **Phase 3**: CSV import round-trips losslessly; rubric snapshot doesn't
   change when source rubric is edited; total points capping works.
+
+---
+
+## 13. Phase 1 — Implementation Log
+
+**Shipped** in commits `b3efd5d5` (`feat(quiz): short-answer and essay
+question types (Phase 1)`) and `fccba247` (`fix(quiz): address PR
+review feedback on written-response Phase 1`), merged via PR #1614 to
+`dev-paul`.
+
+| Area                    | File(s)                                                                                                                                                                                                                                                                                                                   | Notes                                                                                                                                                                                                                                                           |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Question types          | [types.ts:2328-2334](../types.ts)                                                                                                                                                                                                                                                                                         | `'short'` and `'essay'` added to `QuizQuestionType`; helper `isWrittenQuestionType()` at line 2340.                                                                                                                                                             |
+| Top-level `grading` map | [types.ts:2799](../types.ts), [types.ts:2806](../types.ts)                                                                                                                                                                                                                                                                | `QuizResponse.grading?: { [qid]: WrittenAnswerGrade }`; `WrittenAnswerGrade` reserves `annotations`/`rubricScores`/`gradingSnapshot` for future phases.                                                                                                         |
+| Student editor          | [components/quiz/WrittenResponseEditor.tsx](../components/quiz/WrittenResponseEditor.tsx)                                                                                                                                                                                                                                 | `contenteditable` + DOMPurify; bold/italic/underline (+ lists on essay); word counter with soft cap warning; `questionKey` remount handles pause/resume.                                                                                                        |
+| Student app wiring      | [components/quiz/QuizStudentApp.tsx](../components/quiz/QuizStudentApp.tsx)                                                                                                                                                                                                                                               | 500 ms debounced autosave; flush on visibility-hidden, `beforeunload`, unmount, and the `spartboard:quiz:flush-written` event (dispatched before strike-3 tab-switch auto-submit).                                                                              |
+| Builder UI              | [components/widgets/QuizWidget/components/QuizEditor.tsx](../components/widgets/QuizWidget/components/QuizEditor.tsx)                                                                                                                                                                                                     | Type picker exposes both new types; `placeholder` and `maxWords` config fields appear conditionally.                                                                                                                                                            |
+| Manual grader           | [components/widgets/QuizWidget/components/WrittenResponseGrader.tsx](../components/widgets/QuizWidget/components/WrittenResponseGrader.tsx)                                                                                                                                                                               | Modal opened from `QuizResults`; prev/next student nav (←/→/j/k); points entry; overall comment; dirty-tracking + confirm-on-nav prompt; per-question `grading.<qid>` field-path write so concurrent grades on different questions don't clobber.               |
+| Auto-grader awareness   | [hooks/useQuizSession.ts:212-221](../hooks/useQuizSession.ts)                                                                                                                                                                                                                                                             | `gradeAnswer` treats written types as ungraded by default; reads awarded points from `grading[qid]` when present; clamps to `[0, question.points]`.                                                                                                             |
+| Reporting threading     | [components/widgets/QuizWidget/components/QuizResults.tsx:1595](../components/widgets/QuizWidget/components/QuizResults.tsx), [utils/assignmentExportShared.ts](../utils/assignmentExportShared.ts), [utils/plcContributions.ts](../utils/plcContributions.ts), [utils/quizDriveService.ts](../utils/quizDriveService.ts) | Grades surface in stats, PLC contribution publishing, Drive sheet export, scoreboard/streaks, and the assignment archive — without each call site having to know about the new map.                                                                             |
+| Sanitizer               | [utils/security.ts:78-87](../utils/security.ts)                                                                                                                                                                                                                                                                           | New `sanitizeQuizResponse` profile: whitelist `b/strong/i/em/u/p/br/ul/ol/li`, zero attributes, defangs `<font>`/`<span style>` styling that browsers inject from `execCommand`.                                                                                |
+| Firestore rules         | [firestore.rules:1901](../firestore.rules)                                                                                                                                                                                                                                                                                | No new permissive rules. Existing student `changedKeys().hasOnly([...])` whitelist already excludes `grading`; comment added in this round to document that `gradingSnapshot` / `annotations` / `rubricScores` all inherit the same protection by construction. |
+
+**Tests added in this round (Phase 1 §12 gap-fill):**
+
+- [tests/utils/sanitizeQuizResponse.test.ts](../tests/utils/sanitizeQuizResponse.test.ts) — 12 tests covering whitelist, strip cases, idempotency.
+- [tests/components/quiz/WrittenResponseEditor.test.tsx](../tests/components/quiz/WrittenResponseEditor.test.tsx) — 9 tests covering hydration, sanitized onChange, word cap, pause/resume remount, disabled state.
+- [tests/hooks/useQuizSession.gradeAnswer.test.ts](../tests/hooks/useQuizSession.gradeAnswer.test.ts) — 8 tests covering ungraded default, manual-grade pickup, clamping, MC pass-through.
+
+**Carry-overs (still deferred):**
+
+- Firestore rules tests for student-rejection on `grading` writes — would
+  need the emulator suite, gated to a separate CI job; flagged for the
+  Phase 3 PR which already touches rules.
+- Playwright E2E for the pause-then-resume-next-day flow — current
+  Phase 1 unit tests cover the `questionKey` remount mechanism; a true
+  cross-day E2E needs deterministic time-mocking we don't have yet.
+
+---
+
+## 14. Phase 2 — Implementation Log
+
+**Design decision (recorded in §5):** snapshot-at-grading-time +
+sidecar plaintext offsets, rendered to JSX. Highlight `<mark>` elements
+are emitted directly into the React tree rather than being baked into a
+sanitized HTML string, so the Phase 1 sanitizer profile stays exactly
+as-is and the student's `answer` JSON is never mutated.
+
+| Area                 | File(s)                                                                                                                                                    | Notes                                                                                                                                                                                                                                                                                                                                                                        |
+| -------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Type                 | [types.ts:2815-2823](../types.ts)                                                                                                                          | Added `WrittenAnswerGrade.gradingSnapshot?: string`. Frozen on first save with annotations; immutable afterwards. Optional so Phase 1 grades remain valid.                                                                                                                                                                                                                   |
+| Offset/render walker | [utils/writtenAnnotations.ts](../utils/writtenAnnotations.ts) (new)                                                                                        | `htmlToPlainText`, `renderAnnotatedSnapshot`, `getPlainTextOffsetFromRange`. One walker drives both directions of the offset math so the teacher's selection → offset conversion and the renderer's offset → DOM mapping can never disagree. Block tags (`<p>`/`<li>`) and `<br>` each contribute exactly one newline character.                                             |
+| Annotation surface   | [components/widgets/QuizWidget/components/AnnotatedResponseView.tsx](../components/widgets/QuizWidget/components/AnnotatedResponseView.tsx) (new)          | Two modes: `edit` (teacher) surfaces a 4-color palette anchored to the live selection rect plus a margin column with delete/edit affordances; `read` (student) renders the same snapshot with comment chips, no palette, no edit handles.                                                                                                                                    |
+| Grader integration   | [components/widgets/QuizWidget/components/WrittenResponseGrader.tsx](../components/widgets/QuizWidget/components/WrittenResponseGrader.tsx)                | Replaces the `dangerouslySetInnerHTML` read-only block with `<AnnotatedResponseView mode="edit">`. Threads `draftAnnotations` through hydration + dirty-tracking. On save: snapshot frozen via `sanitizeQuizResponse(studentAnswer)` the first time annotations land; reused on every subsequent save so a post-unlock student edit can never reshape the teacher's anchors. |
+| Student score-review | [components/quiz/QuizStudentApp.tsx](../components/quiz/QuizStudentApp.tsx) — new `WrittenAnswerReview` sub-component, branching in `PublishedScoreReview` | Written-type questions render the frozen snapshot via `AnnotatedResponseView` (read mode) when annotations exist, or a sanitized HTML rendering of the snapshot when only points/comment exist. Falls back to the live sanitized answer when no grade yet. Visibility-gated by `session.scoreVisibility` like the rest of the review screen.                                 |
+| Firestore rules      | [firestore.rules:1901](../firestore.rules)                                                                                                                 | Comment-only change to make the teacher-only invariant for `grading.*` (including `gradingSnapshot`, `annotations`, `rubricScores`) explicit. No new rule clauses — the existing `hasOnly([...])` whitelist already locks students out by construction.                                                                                                                      |
+
+**Tests added (Phase 2 §12):**
+
+- [tests/utils/writtenAnnotations.test.tsx](../tests/utils/writtenAnnotations.test.tsx) — 15 tests covering plaintext extraction across nested/block/list/`<br>` cases, mark wrapping invariants (single range, partial text node, paragraph-spanning, inline-tag-preservation, multiple non-overlapping), offset round-trip with `htmlToPlainText`, and `getPlainTextOffsetFromRange` behavior (basic, collapsed, escaping the root).
+- [tests/components/quiz/AnnotatedResponseView.test.tsx](../tests/components/quiz/AnnotatedResponseView.test.tsx) — 9 tests covering read mode (no margin column without comments, comment chip rendering, no palette in read mode) and edit mode (empty hint, row hydration, click-to-open editor, comment edit, delete, color change).
+- [tests/components/quiz/WrittenResponseGrader.annotations.test.tsx](../tests/components/quiz/WrittenResponseGrader.annotations.test.tsx) — 3 tests covering: (a) points-only save does NOT bake a `gradingSnapshot`; (b) snapshot stays frozen even when the student's live answer has diverged; (c) saved annotations rehydrate the draft on mount.
+- [tests/components/quiz/PublishedScoreReview.annotations.test.tsx](../tests/components/quiz/PublishedScoreReview.annotations.test.tsx) — 5 tests covering visibility gating, ungraded fallback, snapshot-wins-over-live-answer rendering, mark wrapping on the student side, and "no response" empty state.
+
+**Deferred to follow-ups:**
+
+- **Overlapping annotation UX** — the renderer correctly handles overlap (primary color wins, all overlap ids exposed on `data-overlap-ids`), but the editor surface picks only the primary on click; a "split into N marks" hover affordance is out of scope.
+- **Margin chip vertical anchoring** under reflow — Phase 2 lists comments in author order; pinning chips to the y-coordinate of their highlight (à la Google Docs) is a polish pass.
+- **Phase 4 carry-overs** — revision-aware offset remapping if the snapshot ever needs to be regenerated; anonymous-grading toggle; AI-assisted draft grading; Docs export for long essays.

--- a/firestore.rules
+++ b/firestore.rules
@@ -1897,6 +1897,17 @@ service cloud.firestore {
            // tagging, mirroring the create-time constraint above.
            (!request.resource.data.diff(resource.data).affectedKeys().hasAny(['preSyncVersion']) ||
             request.resource.data.preSyncVersion == 0) &&
+           // NOTE: `grading` (and everything under it — `gradingSnapshot`,
+           // `annotations`, `rubricScores`, `overallComment`, `pointsAwarded`,
+           // `gradedBy`, `gradedAt`) is deliberately ABSENT from this
+           // whitelist. The teacher branch above is unrestricted, so
+           // teachers write `grading.<questionId>` via dotted field
+           // paths; any student write that touches `grading.*` is
+           // rejected by this `hasOnly([...])` check. Phase 2 of the
+           // written-response feature adds annotations and grading
+           // snapshots under the same key — they inherit the same
+           // student-side protection by construction. See
+           // docs/written-response-quiz-questions.md §9.
            request.resource.data.diff(resource.data)
              .changedKeys().hasOnly(['answers', 'status', 'submittedAt', 'tabSwitchWarnings', 'completedAttempts', 'classPeriod', 'score', 'preSyncVersion', 'unlocked']) &&
            // Students may only ever CLEAR the unlock flag (write `false`)

--- a/tests/components/quiz/AnnotatedResponseView.test.tsx
+++ b/tests/components/quiz/AnnotatedResponseView.test.tsx
@@ -1,0 +1,167 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { AnnotatedResponseView } from '@/components/widgets/QuizWidget/components/AnnotatedResponseView';
+import type { WrittenAnswerAnnotation } from '@/types';
+
+const ann = (
+  from: number,
+  to: number,
+  overrides: Partial<WrittenAnswerAnnotation> = {}
+): WrittenAnswerAnnotation => ({
+  id: `a-${from}-${to}`,
+  from,
+  to,
+  highlightColor: 'yellow',
+  authorUid: 'teacher',
+  createdAt: 0,
+  ...overrides,
+});
+
+describe('AnnotatedResponseView — read mode', () => {
+  it('renders the snapshot with no margin column when no comments exist', () => {
+    render(
+      <AnnotatedResponseView
+        mode="read"
+        snapshot="<p>hello world</p>"
+        annotations={[ann(0, 5)]}
+      />
+    );
+    expect(screen.queryByText('Teacher notes')).not.toBeInTheDocument();
+    // The highlighted text is present.
+    expect(screen.getByText(/hello/)).toBeInTheDocument();
+  });
+
+  it('shows the margin column only for annotations with comments', () => {
+    render(
+      <AnnotatedResponseView
+        mode="read"
+        snapshot="<p>alpha beta gamma</p>"
+        annotations={[
+          ann(0, 5, { id: 'a1', comment: 'Good word' }),
+          ann(6, 10), // no comment
+        ]}
+      />
+    );
+    expect(screen.getByText('Teacher notes')).toBeInTheDocument();
+    expect(screen.getByText('Good word')).toBeInTheDocument();
+  });
+
+  it('renders no palette in read mode', () => {
+    render(
+      <AnnotatedResponseView
+        mode="read"
+        snapshot="<p>hello</p>"
+        annotations={[]}
+      />
+    );
+    expect(
+      screen.queryByRole('toolbar', { name: /annotation palette/i })
+    ).not.toBeInTheDocument();
+  });
+});
+
+describe('AnnotatedResponseView — edit mode', () => {
+  it('renders an empty-state hint when no annotations exist', () => {
+    render(
+      <AnnotatedResponseView
+        mode="edit"
+        snapshot="<p>hello world</p>"
+        annotations={[]}
+        authorUid="teacher-1"
+        onChange={vi.fn()}
+      />
+    );
+    expect(
+      screen.getByText(/select text in the response/i)
+    ).toBeInTheDocument();
+  });
+
+  it('renders one row per saved annotation', () => {
+    render(
+      <AnnotatedResponseView
+        mode="edit"
+        snapshot="<p>hello world</p>"
+        annotations={[
+          ann(0, 5, { id: 'a1', comment: 'First' }),
+          ann(6, 11, { id: 'a2' }),
+        ]}
+        authorUid="teacher-1"
+        onChange={vi.fn()}
+      />
+    );
+    expect(screen.getByText(/Annotations \(2\)/)).toBeInTheDocument();
+    expect(screen.getByText('First')).toBeInTheDocument();
+  });
+
+  it('opens the editor panel when an annotation row is clicked', () => {
+    const onChange = vi.fn();
+    render(
+      <AnnotatedResponseView
+        mode="edit"
+        snapshot="<p>hello world</p>"
+        annotations={[ann(0, 5, { id: 'a1', comment: 'note' })]}
+        authorUid="teacher-1"
+        onChange={onChange}
+      />
+    );
+    const row = screen.getByText('note').closest('button');
+    if (!row) throw new Error('Expected annotation row button');
+    fireEvent.click(row);
+    // Active-editor textarea pre-fills with the comment.
+    expect(screen.getByPlaceholderText(/margin comment/i)).toHaveValue('note');
+  });
+
+  it('updates the annotation list when the active comment changes', () => {
+    const onChange = vi.fn();
+    render(
+      <AnnotatedResponseView
+        mode="edit"
+        snapshot="<p>hello world</p>"
+        annotations={[ann(0, 5, { id: 'a1', comment: '' })]}
+        authorUid="teacher-1"
+        onChange={onChange}
+      />
+    );
+    fireEvent.click(screen.getByRole('button', { name: /highlight/i }));
+    const ta = screen.getByPlaceholderText(/margin comment/i);
+    fireEvent.change(ta, { target: { value: 'edited' } });
+    const last = onChange.mock.calls.at(-1)?.[0] as WrittenAnswerAnnotation[];
+    expect(last[0].comment).toBe('edited');
+  });
+
+  it('deletes an annotation via the active-editor trash button', () => {
+    const onChange = vi.fn();
+    render(
+      <AnnotatedResponseView
+        mode="edit"
+        snapshot="<p>hello world</p>"
+        annotations={[ann(0, 5, { id: 'a1', comment: 'x' })]}
+        authorUid="teacher-1"
+        onChange={onChange}
+      />
+    );
+    const row = screen.getByText('x').closest('button');
+    if (!row) throw new Error('Expected annotation row button');
+    fireEvent.click(row);
+    fireEvent.click(screen.getByRole('button', { name: /delete annotation/i }));
+    const last = onChange.mock.calls.at(-1)?.[0] as WrittenAnswerAnnotation[];
+    expect(last).toEqual([]);
+  });
+
+  it('changes color when a swatch is clicked in the active editor', () => {
+    const onChange = vi.fn();
+    render(
+      <AnnotatedResponseView
+        mode="edit"
+        snapshot="<p>hello</p>"
+        annotations={[ann(0, 5, { id: 'a1', highlightColor: 'yellow' })]}
+        authorUid="teacher-1"
+        onChange={onChange}
+      />
+    );
+    fireEvent.click(screen.getAllByRole('button', { name: /highlight/i })[0]);
+    fireEvent.click(screen.getByRole('button', { name: /pink highlight/i }));
+    const last = onChange.mock.calls.at(-1)?.[0] as WrittenAnswerAnnotation[];
+    expect(last[0].highlightColor).toBe('pink');
+  });
+});

--- a/tests/components/quiz/PublishedScoreReview.annotations.test.tsx
+++ b/tests/components/quiz/PublishedScoreReview.annotations.test.tsx
@@ -1,0 +1,110 @@
+/**
+ * Phase 2 — student-facing review surface for written-response questions.
+ *
+ * `PublishedScoreReview` itself is private to QuizStudentApp.tsx (the
+ * full screen wires Firestore listeners + auth + URL params); the
+ * essential per-question rendering lives in `WrittenAnswerReview`,
+ * which is exported for direct testing. The branch logic in
+ * PublishedScoreReview ("written types → WrittenAnswerReview; auto-
+ * graded types → plain text") is exercised at the parent level via
+ * QuizStudentApp E2E.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { WrittenAnswerReview } from '@/components/quiz/QuizStudentApp';
+import type { WrittenAnswerGrade } from '@/types';
+
+describe('WrittenAnswerReview', () => {
+  it('renders nothing when showResponse is false', () => {
+    const { container } = render(
+      <WrittenAnswerReview
+        studentAnswer="<p>hi</p>"
+        grade={undefined}
+        showResponse={false}
+        maxPoints={5}
+      />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('shows the sanitized live answer when no grade yet', () => {
+    const { container } = render(
+      <WrittenAnswerReview
+        studentAnswer="<p>hello world</p>"
+        grade={undefined}
+        showResponse={true}
+        maxPoints={5}
+      />
+    );
+    expect(container.textContent).toContain('hello world');
+    expect(screen.getByText(/Not yet graded/i)).toBeInTheDocument();
+  });
+
+  it('shows the snapshot (NOT the live answer) when a grade exists', () => {
+    const grade: WrittenAnswerGrade = {
+      pointsAwarded: 4,
+      overallComment: 'Nice work',
+      gradedBy: 't',
+      gradedAt: 0,
+      gradingSnapshot: '<p>FROZEN</p>',
+    };
+    const { container } = render(
+      <WrittenAnswerReview
+        studentAnswer="<p>student edited later</p>"
+        grade={grade}
+        showResponse={true}
+        maxPoints={5}
+      />
+    );
+    expect(container.textContent).toContain('FROZEN');
+    expect(container.textContent).not.toContain('student edited later');
+    expect(screen.getByText(/Nice work/)).toBeInTheDocument();
+    expect(screen.getByText(/4 \/ 5/)).toBeInTheDocument();
+  });
+
+  it('renders highlight marks when annotations exist', () => {
+    const grade: WrittenAnswerGrade = {
+      pointsAwarded: 3,
+      gradedBy: 't',
+      gradedAt: 0,
+      gradingSnapshot: '<p>alpha beta</p>',
+      annotations: [
+        {
+          id: 'a1',
+          from: 0,
+          to: 5,
+          highlightColor: 'green',
+          authorUid: 't',
+          createdAt: 0,
+          comment: 'thesis',
+        },
+      ],
+    };
+    const { container } = render(
+      <WrittenAnswerReview
+        studentAnswer=""
+        grade={grade}
+        showResponse={true}
+        maxPoints={5}
+      />
+    );
+    const mark = container.querySelector('mark');
+    expect(mark).not.toBeNull();
+    expect(mark?.textContent).toBe('alpha');
+    expect(mark?.getAttribute('data-color')).toBe('green');
+    expect(screen.getByText('thesis')).toBeInTheDocument();
+  });
+
+  it('shows "no response" when the student never answered AND no grade exists', () => {
+    render(
+      <WrittenAnswerReview
+        studentAnswer=""
+        grade={undefined}
+        showResponse={true}
+        maxPoints={5}
+      />
+    );
+    expect(screen.getByText(/no response/i)).toBeInTheDocument();
+  });
+});

--- a/tests/components/quiz/WrittenResponseEditor.test.tsx
+++ b/tests/components/quiz/WrittenResponseEditor.test.tsx
@@ -1,0 +1,152 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { WrittenResponseEditor } from '@/components/quiz/WrittenResponseEditor';
+
+const getEditor = (): HTMLElement => {
+  const editor = screen.getByRole('textbox', { name: /your response/i });
+  return editor;
+};
+
+describe('WrittenResponseEditor', () => {
+  it('renders placeholder text when empty', () => {
+    render(
+      <WrittenResponseEditor
+        value=""
+        onChange={vi.fn()}
+        placeholder="Type your answer…"
+        questionKey="q1"
+      />
+    );
+    expect(screen.getByText('Type your answer…')).toBeInTheDocument();
+  });
+
+  it('seeds contenteditable from `value` prop on mount', () => {
+    render(
+      <WrittenResponseEditor
+        value="<b>hello</b> world"
+        onChange={vi.fn()}
+        questionKey="q1"
+      />
+    );
+    const editor = getEditor();
+    expect(editor.innerHTML).toContain('<b>hello</b>');
+    expect(editor.textContent).toContain('hello world');
+  });
+
+  it('fires sanitized onChange when content changes', () => {
+    const onChange = vi.fn();
+    render(
+      <WrittenResponseEditor value="" onChange={onChange} questionKey="q1" />
+    );
+    const editor = getEditor();
+    // Simulate paste-style input — set innerHTML directly then fire `input`.
+    // The editor sanitizes on each input event and reports the cleaned HTML.
+    editor.innerHTML = '<span style="color:red">x</span>';
+    fireEvent.input(editor);
+    expect(onChange).toHaveBeenCalled();
+    const lastCall = onChange.mock.calls.at(-1)?.[0] as string;
+    expect(lastCall).not.toContain('<span');
+    expect(lastCall).toContain('x');
+  });
+
+  it('shows a word count and updates with text length', () => {
+    render(
+      <WrittenResponseEditor
+        value="one two three"
+        onChange={vi.fn()}
+        questionKey="q1"
+      />
+    );
+    expect(screen.getByText(/3 \/?\s*words?/i)).toBeInTheDocument();
+  });
+
+  it('warns past maxWords cap', () => {
+    render(
+      <WrittenResponseEditor
+        value="one two three four five"
+        onChange={vi.fn()}
+        maxWords={3}
+        questionKey="q1"
+      />
+    );
+    expect(
+      screen.getByText(/past the suggested word cap/i)
+    ).toBeInTheDocument();
+  });
+
+  it('does NOT warn when at or below maxWords', () => {
+    render(
+      <WrittenResponseEditor
+        value="one two three"
+        onChange={vi.fn()}
+        maxWords={5}
+        questionKey="q1"
+      />
+    );
+    expect(
+      screen.queryByText(/past the suggested word cap/i)
+    ).not.toBeInTheDocument();
+  });
+
+  it('remounts and reseeds when questionKey changes (pause/resume)', () => {
+    const { rerender } = render(
+      <WrittenResponseEditor
+        value="first answer"
+        onChange={vi.fn()}
+        questionKey="q1"
+      />
+    );
+    expect(getEditor().textContent).toContain('first answer');
+    rerender(
+      <WrittenResponseEditor
+        value="second answer"
+        onChange={vi.fn()}
+        questionKey="q2"
+      />
+    );
+    expect(getEditor().textContent).toContain('second answer');
+  });
+
+  it('shows list controls only in essay mode', () => {
+    const { rerender } = render(
+      <WrittenResponseEditor
+        value=""
+        onChange={vi.fn()}
+        questionKey="q1"
+        isEssay={false}
+      />
+    );
+    expect(
+      screen.queryByRole('button', { name: /bulleted list/i })
+    ).not.toBeInTheDocument();
+    rerender(
+      <WrittenResponseEditor
+        value=""
+        onChange={vi.fn()}
+        questionKey="q1"
+        isEssay={true}
+      />
+    );
+    expect(
+      screen.getByRole('button', { name: /bulleted list/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /numbered list/i })
+    ).toBeInTheDocument();
+  });
+
+  it('disables editing and tab focus when disabled', () => {
+    render(
+      <WrittenResponseEditor
+        value=""
+        onChange={vi.fn()}
+        questionKey="q1"
+        disabled
+      />
+    );
+    const editor = getEditor();
+    expect(editor.getAttribute('contenteditable')).toBe('false');
+    expect(editor.getAttribute('tabindex')).toBe('-1');
+    expect(editor.getAttribute('aria-disabled')).toBe('true');
+  });
+});

--- a/tests/components/quiz/WrittenResponseGrader.annotations.test.tsx
+++ b/tests/components/quiz/WrittenResponseGrader.annotations.test.tsx
@@ -1,0 +1,164 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import { WrittenResponseGrader } from '@/components/widgets/QuizWidget/components/WrittenResponseGrader';
+import type {
+  QuizData,
+  QuizResponse,
+  WrittenAnswerAnnotation,
+  WrittenAnswerGrade,
+} from '@/types';
+
+const quiz: QuizData = {
+  id: 'quiz-1',
+  title: 'Quiz',
+  createdAt: 0,
+  updatedAt: 0,
+  questions: [
+    {
+      id: 'q1',
+      type: 'essay',
+      text: 'Write something.',
+      timeLimit: 0,
+      correctAnswer: '',
+      incorrectAnswers: [],
+      points: 10,
+    },
+  ],
+};
+
+const responseFor = (
+  studentUid: string,
+  answer: string,
+  grading?: { [k: string]: WrittenAnswerGrade }
+): QuizResponse => ({
+  studentUid,
+  _responseKey: studentUid,
+  pin: '1234',
+  answers: [
+    {
+      questionId: 'q1',
+      answer,
+      answeredAt: 0,
+    },
+  ],
+  status: 'completed',
+  joinedAt: 0,
+  submittedAt: 0,
+  score: 0,
+  tabSwitchWarnings: 0,
+  completedAttempts: 1,
+  grading,
+});
+
+describe('WrittenResponseGrader — annotations + snapshot', () => {
+  it('saves a points-only grade without setting gradingSnapshot when no annotations exist', async () => {
+    const onSaveGrade = vi
+      .fn<(rk: string, qid: string, g: WrittenAnswerGrade) => Promise<void>>()
+      .mockResolvedValue(undefined);
+    render(
+      <WrittenResponseGrader
+        quiz={quiz}
+        responses={[responseFor('uid-a', '<p>hello world</p>')]}
+        teacherUid="teacher-1"
+        onSaveGrade={onSaveGrade}
+        onClose={vi.fn()}
+      />
+    );
+    const pts = screen.getByLabelText(/points awarded/i);
+    fireEvent.change(pts, { target: { value: '7' } });
+    await act(() => {
+      fireEvent.click(screen.getByRole('button', { name: /save grade/i }));
+      return Promise.resolve();
+    });
+    expect(onSaveGrade).toHaveBeenCalledTimes(1);
+    const [, , grade] = onSaveGrade.mock.calls[0];
+    expect(grade.pointsAwarded).toBe(7);
+    expect(grade.gradingSnapshot).toBeUndefined();
+    expect(grade.annotations).toBeUndefined();
+  });
+
+  it('preserves a previously-frozen gradingSnapshot on subsequent saves', async () => {
+    const existing: WrittenAnswerGrade = {
+      pointsAwarded: 5,
+      gradedBy: 'teacher-1',
+      gradedAt: 1000,
+      gradingSnapshot: '<p>FROZEN SNAPSHOT</p>',
+      annotations: [
+        {
+          id: 'a1',
+          from: 0,
+          to: 6,
+          highlightColor: 'yellow',
+          authorUid: 'teacher-1',
+          createdAt: 1000,
+        },
+      ],
+    };
+    const onSaveGrade = vi
+      .fn<(rk: string, qid: string, g: WrittenAnswerGrade) => Promise<void>>()
+      .mockResolvedValue(undefined);
+    // Note the live answer is DIFFERENT from the snapshot — this is
+    // exactly the case where Phase 2 must not re-snapshot.
+    render(
+      <WrittenResponseGrader
+        quiz={quiz}
+        responses={[
+          responseFor('uid-b', '<p>student edited after unlock</p>', {
+            q1: existing,
+          }),
+        ]}
+        teacherUid="teacher-1"
+        onSaveGrade={onSaveGrade}
+        onClose={vi.fn()}
+      />
+    );
+    const pts = screen.getByLabelText(/points awarded/i);
+    fireEvent.change(pts, { target: { value: '9' } });
+    await act(() => {
+      fireEvent.click(screen.getByRole('button', { name: /save grade/i }));
+      return Promise.resolve();
+    });
+    expect(onSaveGrade).toHaveBeenCalledTimes(1);
+    const [, , grade] = onSaveGrade.mock.calls[0];
+    expect(grade.pointsAwarded).toBe(9);
+    // Snapshot must remain frozen at the original value, NOT re-snapshot
+    // the student's edited answer.
+    expect(grade.gradingSnapshot).toBe('<p>FROZEN SNAPSHOT</p>');
+    // Annotations carry over unchanged (we didn't edit them in the UI).
+    expect(grade.annotations).toEqual(existing.annotations);
+  });
+
+  it('hydrates draftAnnotations from the saved grade on mount', () => {
+    const annotations: WrittenAnswerAnnotation[] = [
+      {
+        id: 'a1',
+        from: 0,
+        to: 5,
+        highlightColor: 'pink',
+        authorUid: 'teacher-1',
+        createdAt: 1,
+        comment: 'A note',
+      },
+    ];
+    const existing: WrittenAnswerGrade = {
+      pointsAwarded: 5,
+      gradedBy: 'teacher-1',
+      gradedAt: 1,
+      gradingSnapshot: '<p>hello world</p>',
+      annotations,
+    };
+    render(
+      <WrittenResponseGrader
+        quiz={quiz}
+        responses={[
+          responseFor('uid-c', '<p>hello world</p>', { q1: existing }),
+        ]}
+        teacherUid="teacher-1"
+        onSaveGrade={vi.fn().mockResolvedValue(undefined)}
+        onClose={vi.fn()}
+      />
+    );
+    expect(screen.getByText(/Annotations \(1\)/)).toBeInTheDocument();
+    expect(screen.getByText('A note')).toBeInTheDocument();
+  });
+});

--- a/tests/hooks/useQuizSession.gradeAnswer.test.ts
+++ b/tests/hooks/useQuizSession.gradeAnswer.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from 'vitest';
+import { gradeAnswer } from '@/hooks/useQuizSession';
+import type { QuizQuestion, WrittenAnswerGrade } from '@/types';
+
+const q = (overrides: Partial<QuizQuestion> = {}): QuizQuestion => ({
+  id: 'q1',
+  text: 'Explain photosynthesis.',
+  timeLimit: 0,
+  type: 'essay',
+  correctAnswer: '',
+  incorrectAnswers: [],
+  points: 10,
+  ...overrides,
+});
+
+const grade = (
+  overrides: Partial<WrittenAnswerGrade> = {}
+): WrittenAnswerGrade => ({
+  pointsAwarded: 0,
+  gradedBy: 'teacher-uid',
+  gradedAt: 0,
+  ...overrides,
+});
+
+describe('gradeAnswer — written types', () => {
+  it('returns ungraded (0 points, isCorrect=false) when no manual grade exists for an essay', () => {
+    const result = gradeAnswer(q({ type: 'essay', points: 10 }), '<p>...</p>');
+    expect(result).toEqual({
+      isCorrect: false,
+      pointsEarned: 0,
+      pointsMax: 10,
+    });
+  });
+
+  it('returns ungraded when no manual grade exists for a short-answer', () => {
+    const result = gradeAnswer(q({ type: 'short', points: 5 }), 'my answer');
+    expect(result).toEqual({ isCorrect: false, pointsEarned: 0, pointsMax: 5 });
+  });
+
+  it('returns awarded points when a manual grade is supplied', () => {
+    const result = gradeAnswer(
+      q({ type: 'essay', points: 10 }),
+      '<p>...</p>',
+      grade({ pointsAwarded: 7 })
+    );
+    expect(result.pointsEarned).toBe(7);
+    expect(result.pointsMax).toBe(10);
+  });
+
+  it('flags isCorrect when awarded points equal max', () => {
+    const result = gradeAnswer(
+      q({ type: 'short', points: 4 }),
+      'answer',
+      grade({ pointsAwarded: 4 })
+    );
+    expect(result.isCorrect).toBe(true);
+    expect(result.pointsEarned).toBe(4);
+  });
+
+  it('does NOT flag isCorrect when awarded < max', () => {
+    const result = gradeAnswer(
+      q({ type: 'short', points: 4 }),
+      'answer',
+      grade({ pointsAwarded: 3 })
+    );
+    expect(result.isCorrect).toBe(false);
+    expect(result.pointsEarned).toBe(3);
+  });
+
+  it('clamps awarded points to question max', () => {
+    const result = gradeAnswer(
+      q({ type: 'essay', points: 5 }),
+      '<p>...</p>',
+      grade({ pointsAwarded: 99 })
+    );
+    expect(result.pointsEarned).toBe(5);
+    expect(result.pointsMax).toBe(5);
+    expect(result.isCorrect).toBe(true);
+  });
+
+  it('clamps negative awarded points to zero', () => {
+    const result = gradeAnswer(
+      q({ type: 'essay', points: 5 }),
+      '<p>...</p>',
+      grade({ pointsAwarded: -3 })
+    );
+    expect(result.pointsEarned).toBe(0);
+    expect(result.isCorrect).toBe(false);
+  });
+
+  it('ignores manualGrade for auto-graded MC questions', () => {
+    const result = gradeAnswer(
+      q({ type: 'MC', correctAnswer: 'A', points: 2 }),
+      'A',
+      grade({ pointsAwarded: 0 })
+    );
+    expect(result.isCorrect).toBe(true);
+    expect(result.pointsEarned).toBe(2);
+  });
+});

--- a/tests/utils/sanitizeQuizResponse.test.ts
+++ b/tests/utils/sanitizeQuizResponse.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from 'vitest';
+import { sanitizeQuizResponse } from '@/utils/security';
+
+describe('sanitizeQuizResponse', () => {
+  it('returns empty string for empty input', () => {
+    expect(sanitizeQuizResponse('')).toBe('');
+  });
+
+  it('preserves whitelisted semantic tags', () => {
+    const html =
+      '<p><b>bold</b> <strong>strong</strong> <i>i</i> <em>em</em> <u>u</u></p>';
+    expect(sanitizeQuizResponse(html)).toContain('<b>bold</b>');
+    expect(sanitizeQuizResponse(html)).toContain('<strong>strong</strong>');
+    expect(sanitizeQuizResponse(html)).toContain('<em>em</em>');
+    expect(sanitizeQuizResponse(html)).toContain('<u>u</u>');
+  });
+
+  it('preserves lists and line breaks', () => {
+    const html = '<ul><li>one</li><li>two</li></ul><br><ol><li>a</li></ol>';
+    const out = sanitizeQuizResponse(html);
+    expect(out).toContain('<ul>');
+    expect(out).toContain('<li>one</li>');
+    expect(out).toContain('<ol>');
+    expect(out).toContain('<br>');
+  });
+
+  it('strips <span> wrappers but keeps text', () => {
+    const out = sanitizeQuizResponse(
+      '<span style="color:red">hello</span> world'
+    );
+    expect(out).not.toContain('<span');
+    expect(out).not.toContain('style');
+    expect(out).toContain('hello');
+    expect(out).toContain('world');
+  });
+
+  it('strips <font> tags (execCommand byproduct) but keeps text', () => {
+    const out = sanitizeQuizResponse('<font color="red">hello</font>');
+    expect(out).not.toContain('<font');
+    expect(out).not.toContain('color');
+    expect(out).toContain('hello');
+  });
+
+  it('strips <div> wrappers', () => {
+    const out = sanitizeQuizResponse('<div>x</div>');
+    expect(out).not.toContain('<div');
+    expect(out).toContain('x');
+  });
+
+  it('strips <script> tags entirely', () => {
+    const out = sanitizeQuizResponse('<script>alert(1)</script><b>safe</b>');
+    expect(out).not.toContain('<script');
+    expect(out).not.toContain('alert');
+    expect(out).toContain('<b>safe</b>');
+  });
+
+  it('strips event-handler attributes', () => {
+    const out = sanitizeQuizResponse('<b onclick="alert(1)">x</b>');
+    expect(out).not.toContain('onclick');
+    expect(out).toContain('<b>');
+    expect(out).toContain('x');
+  });
+
+  it('strips class and style attributes', () => {
+    const out = sanitizeQuizResponse(
+      '<p class="rich" style="font-weight:bold">x</p>'
+    );
+    expect(out).not.toContain('class=');
+    expect(out).not.toContain('style=');
+    expect(out).toContain('<p>x</p>');
+  });
+
+  it('strips anchor tags and their hrefs', () => {
+    const out = sanitizeQuizResponse(
+      '<a href="https://example.com">link</a> text'
+    );
+    expect(out).not.toContain('<a ');
+    expect(out).not.toContain('href');
+    expect(out).toContain('link');
+    expect(out).toContain('text');
+  });
+
+  it('strips img tags entirely', () => {
+    const out = sanitizeQuizResponse('<img src="x" onerror="alert(1)">caption');
+    expect(out).not.toContain('<img');
+    expect(out).not.toContain('onerror');
+    expect(out).toContain('caption');
+  });
+
+  it('round-trips already-sanitized HTML idempotently', () => {
+    const clean = '<p><b>hello</b> world</p>';
+    expect(sanitizeQuizResponse(sanitizeQuizResponse(clean))).toBe(
+      sanitizeQuizResponse(clean)
+    );
+  });
+});

--- a/tests/utils/writtenAnnotations.test.tsx
+++ b/tests/utils/writtenAnnotations.test.tsx
@@ -194,6 +194,51 @@ describe('getPlainTextOffsetFromRange', () => {
     expect(offsets).toBeNull();
   });
 
+  it('resolves element-anchored offsets across block boundaries (regression: PR #1620 review)', () => {
+    // Reviewer flagged: when a Range anchors on an element node with a
+    // child-index offset (e.g. clicking past the last character of a
+    // paragraph), the old `childrenPlaintextLength` helper computed
+    // preceding-sibling lengths in isolation and missed the `\n` that
+    // joins consecutive block elements. This regression test pins the
+    // integrated-walk behavior.
+    const div = document.createElement('div');
+    div.innerHTML = '<p>abc</p><p>def</p>';
+    document.body.appendChild(div);
+    // Anchor range on the outer div with startOffset=0 (before <p>abc</p>)
+    // and endOffset=2 (after both <p> children). Plaintext is "abc\ndef"
+    // so the expected end offset is 7 — every character + the block-
+    // boundary newline.
+    const range = document.createRange();
+    range.setStart(div, 0);
+    range.setEnd(div, 2);
+    const offsets = getPlainTextOffsetFromRange(div, range);
+    document.body.removeChild(div);
+    expect(offsets).toEqual({ from: 0, to: 7 });
+  });
+
+  it('resolves an element-anchored offset that sits between sibling blocks', () => {
+    // startOffset=1 on the outer div means "between <p>abc</p> and
+    // <p>def</p>". In the integrated walk, that anchor is resolved as
+    // "after the first block's text, BEFORE the boundary newline that
+    // joins the next block" — i.e. offset 3, not 4. The newline only
+    // exists in the plaintext projection because two blocks are
+    // adjacent; the DOM has no separate "between blocks" position, so
+    // we collapse the boundary onto its trailing side. Pinned here so
+    // the choice is intentional, not accidental.
+    const div = document.createElement('div');
+    div.innerHTML = '<p>abc</p><p>def</p>';
+    document.body.appendChild(div);
+    const secondP = div.querySelectorAll('p')[1];
+    if (!secondP?.firstChild) throw new Error('Expected second <p> text');
+    const text = secondP.firstChild as Text;
+    const range = document.createRange();
+    range.setStart(div, 1);
+    range.setEnd(text, 3);
+    const offsets = getPlainTextOffsetFromRange(div, range);
+    document.body.removeChild(div);
+    expect(offsets).toEqual({ from: 3, to: 7 });
+  });
+
   it('returns null when the range escapes the root', () => {
     const inside = document.createElement('div');
     inside.innerHTML = '<p>a</p>';

--- a/tests/utils/writtenAnnotations.test.tsx
+++ b/tests/utils/writtenAnnotations.test.tsx
@@ -1,0 +1,216 @@
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import {
+  htmlToPlainText,
+  renderAnnotatedSnapshot,
+  getPlainTextOffsetFromRange,
+} from '@/utils/writtenAnnotations';
+import type { WrittenAnswerAnnotation } from '@/types';
+
+const ann = (
+  from: number,
+  to: number,
+  id = 'a1',
+  color: WrittenAnswerAnnotation['highlightColor'] = 'yellow'
+): WrittenAnswerAnnotation => ({
+  id,
+  from,
+  to,
+  highlightColor: color,
+  authorUid: 'teacher',
+  createdAt: 0,
+});
+
+describe('htmlToPlainText', () => {
+  it('returns empty for empty input', () => {
+    expect(htmlToPlainText('')).toBe('');
+  });
+
+  it('strips inline tags and keeps text', () => {
+    expect(htmlToPlainText('<b>hello</b> <i>world</i>')).toBe('hello world');
+  });
+
+  it('emits a single newline between paragraphs', () => {
+    expect(htmlToPlainText('<p>one</p><p>two</p>')).toBe('one\ntwo');
+  });
+
+  it('treats <br> as a single newline', () => {
+    expect(htmlToPlainText('line<br>two')).toBe('line\ntwo');
+  });
+
+  it('treats list items as newline-separated', () => {
+    expect(htmlToPlainText('<ul><li>a</li><li>b</li></ul>')).toBe('a\nb');
+  });
+});
+
+describe('renderAnnotatedSnapshot', () => {
+  it('renders without annotations as plain DOM', () => {
+    const { container } = render(
+      <div>
+        {renderAnnotatedSnapshot({
+          html: '<p>hello <b>world</b></p>',
+          annotations: [],
+        })}
+      </div>
+    );
+    expect(container.querySelector('mark')).toBeNull();
+    expect(container.textContent).toBe('hello world');
+  });
+
+  it('wraps the annotated range in a <mark>', () => {
+    // Plaintext: "hello world" → annotate "hello" (0..5)
+    const { container } = render(
+      <div>
+        {renderAnnotatedSnapshot({
+          html: '<p>hello world</p>',
+          annotations: [ann(0, 5)],
+        })}
+      </div>
+    );
+    const marks = container.querySelectorAll('mark');
+    expect(marks.length).toBe(1);
+    expect(marks[0].textContent).toBe('hello');
+    expect(marks[0].getAttribute('data-annotation-id')).toBe('a1');
+    expect(marks[0].getAttribute('data-color')).toBe('yellow');
+  });
+
+  it('splits a text node when an annotation covers only part of it', () => {
+    const { container } = render(
+      <div>
+        {renderAnnotatedSnapshot({
+          html: '<p>alphabet soup</p>',
+          // Plaintext: "alphabet soup" — annotate "soup" (9..13).
+          annotations: [ann(9, 13)],
+        })}
+      </div>
+    );
+    expect(container.querySelector('mark')?.textContent).toBe('soup');
+    expect(container.textContent).toBe('alphabet soup');
+  });
+
+  it('renders marks across paragraph boundaries correctly', () => {
+    // Plaintext: "abc\ndef" — annotate "c\nd" (2..5)
+    const { container } = render(
+      <div>
+        {renderAnnotatedSnapshot({
+          html: '<p>abc</p><p>def</p>',
+          annotations: [ann(2, 5)],
+        })}
+      </div>
+    );
+    const marks = container.querySelectorAll('mark');
+    expect(marks.length).toBeGreaterThanOrEqual(1);
+    const totalMarkText = Array.from(marks)
+      .map((m) => m.textContent)
+      .join('');
+    expect(totalMarkText.replace(/\s+/g, '')).toBe('cd');
+  });
+
+  it('preserves inline styling tags around marks', () => {
+    const { container } = render(
+      <div>
+        {renderAnnotatedSnapshot({
+          html: '<p><b>bold</b> text</p>',
+          annotations: [ann(0, 4)], // "bold"
+        })}
+      </div>
+    );
+    expect(container.querySelector('b')).not.toBeNull();
+    expect(container.querySelector('mark')?.textContent).toBe('bold');
+  });
+
+  it('handles multiple non-overlapping annotations', () => {
+    const { container } = render(
+      <div>
+        {renderAnnotatedSnapshot({
+          html: '<p>red and blue</p>',
+          // "red" (0..3), "blue" (8..12)
+          annotations: [ann(0, 3, 'a1', 'pink'), ann(8, 12, 'a2', 'blue')],
+        })}
+      </div>
+    );
+    const marks = container.querySelectorAll('mark');
+    expect(marks.length).toBe(2);
+    expect(marks[0].textContent).toBe('red');
+    expect(marks[0].getAttribute('data-color')).toBe('pink');
+    expect(marks[1].textContent).toBe('blue');
+    expect(marks[1].getAttribute('data-color')).toBe('blue');
+  });
+
+  it('offsets agree with htmlToPlainText (round-trip invariant)', () => {
+    const html = '<p>hello <b>brave</b> new</p><p>world</p>';
+    const plain = htmlToPlainText(html);
+    // Annotate "brave new\nworld" — choose a non-trivial range that
+    // spans an inline tag, a paragraph boundary, and lands inside the
+    // second paragraph.
+    const from = plain.indexOf('brave');
+    const to = plain.indexOf('world') + 'world'.length;
+    const { container } = render(
+      <div>
+        {renderAnnotatedSnapshot({
+          html,
+          annotations: [ann(from, to)],
+        })}
+      </div>
+    );
+    const marked = Array.from(container.querySelectorAll('mark'))
+      .map((m) => m.textContent)
+      .join('');
+    // Newlines between blocks are NOT in marks (they're structural, not
+    // text content). What matters is that the visible characters of the
+    // marked range are present.
+    expect(marked.replace(/\s+/g, '')).toBe('bravenewworld');
+  });
+});
+
+describe('getPlainTextOffsetFromRange', () => {
+  it('returns plaintext offsets for a selection inside a single text node', () => {
+    const div = document.createElement('div');
+    div.innerHTML = '<p>hello world</p>';
+    document.body.appendChild(div);
+    const p = div.querySelector('p');
+    if (!p?.firstChild) throw new Error('Expected paragraph text node');
+    const text = p.firstChild as Text;
+    const range = document.createRange();
+    range.setStart(text, 6);
+    range.setEnd(text, 11);
+    const offsets = getPlainTextOffsetFromRange(div, range);
+    document.body.removeChild(div);
+    expect(offsets).toEqual({ from: 6, to: 11 });
+  });
+
+  it('returns null for a collapsed range', () => {
+    const div = document.createElement('div');
+    div.innerHTML = '<p>x</p>';
+    document.body.appendChild(div);
+    const p = div.querySelector('p');
+    if (!p?.firstChild) throw new Error('Expected paragraph text node');
+    const text = p.firstChild as Text;
+    const range = document.createRange();
+    range.setStart(text, 0);
+    range.setEnd(text, 0);
+    const offsets = getPlainTextOffsetFromRange(div, range);
+    document.body.removeChild(div);
+    expect(offsets).toBeNull();
+  });
+
+  it('returns null when the range escapes the root', () => {
+    const inside = document.createElement('div');
+    inside.innerHTML = '<p>a</p>';
+    const outside = document.createElement('p');
+    outside.textContent = 'b';
+    document.body.appendChild(inside);
+    document.body.appendChild(outside);
+    const insideP = inside.querySelector('p');
+    if (!insideP?.firstChild) throw new Error('Expected inside text node');
+    const insideText = insideP.firstChild as Text;
+    const outsideText = outside.firstChild as Text;
+    const range = document.createRange();
+    range.setStart(insideText, 0);
+    range.setEnd(outsideText, 1);
+    const offsets = getPlainTextOffsetFromRange(inside, range);
+    document.body.removeChild(inside);
+    document.body.removeChild(outside);
+    expect(offsets).toBeNull();
+  });
+});

--- a/types.ts
+++ b/types.ts
@@ -2812,7 +2812,17 @@ export interface WrittenAnswerGrade {
   pointsAwarded: number;
   /** Optional summary comment the teacher leaves on the response. */
   overallComment?: string;
-  /** Phase 2 (annotations). Empty/undefined in Phase 1. */
+  /**
+   * Phase 2: sanitized HTML snapshot of the student's `answer` captured the
+   * first time the teacher saves a grade carrying annotations. Frozen and
+   * immutable from that point on. Annotation `from`/`to` offsets index into
+   * the plaintext projection of THIS snapshot — not the student's live
+   * `answer` text — so annotations stay anchored even if the teacher later
+   * unlocks the attempt and the student edits. Optional so Phase 1 grades
+   * (no annotations) remain valid.
+   */
+  gradingSnapshot?: string;
+  /** Phase 2 (annotations). Empty/undefined when no highlights were added. */
   annotations?: WrittenAnswerAnnotation[];
   /** Phase 3 (rubrics). Empty/undefined in Phase 1. */
   rubricScores?: WrittenAnswerRubricScore[];

--- a/utils/writtenAnnotations.ts
+++ b/utils/writtenAnnotations.ts
@@ -105,24 +105,48 @@ const walkPlaintext = (
  */
 export const renderAnnotatedSnapshot = ({
   html,
+  root,
   annotations,
 }: {
-  html: string;
+  /** Raw sanitized HTML. Parsed on every call — prefer `root` in hot paths. */
+  html?: string;
+  /**
+   * Pre-parsed DOM root (typically the wrapping `<div>`). Lets callers
+   * memoize the parse once per snapshot and re-walk on annotation
+   * changes without re-DOMParsing — important for the live editor
+   * where margin-comment keystrokes change `annotations` on every
+   * keypress.
+   */
+  root?: Element | null;
   annotations: WrittenAnswerAnnotation[];
 }): React.ReactNode => {
+  let actualRoot = root ?? null;
+  if (!actualRoot && html) {
+    actualRoot = parseSnapshotRoot(html);
+  }
+  if (!actualRoot) return null;
+
+  const sorted = [...annotations].sort((a, b) => a.from - b.from);
+  const ctx = { offset: 0, atBlockStart: true, keyCounter: 0 };
+
+  return renderChildren(actualRoot, sorted, ctx);
+};
+
+/**
+ * Parse a sanitized snapshot HTML string into the wrapping `<div>`
+ * `Element`. Returns null in non-DOM environments (e.g. SSR). Hot-path
+ * callers should memoize the returned node and pass it back to
+ * `renderAnnotatedSnapshot` as `root` so per-keystroke annotation
+ * changes don't re-DOMParse the whole snapshot.
+ */
+export const parseSnapshotRoot = (html: string): Element | null => {
   if (!html) return null;
   if (typeof DOMParser === 'undefined') return null;
   const doc = new DOMParser().parseFromString(
     `<div>${html}</div>`,
     'text/html'
   );
-  const root = doc.body.firstChild as Element | null;
-  if (!root) return null;
-
-  const sorted = [...annotations].sort((a, b) => a.from - b.from);
-  const ctx = { offset: 0, atBlockStart: true, keyCounter: 0 };
-
-  return renderChildren(root, sorted, ctx);
+  return (doc.body.firstChild as Element | null) ?? null;
 };
 
 interface RenderCtx {
@@ -186,10 +210,11 @@ const renderChildren = (
  * a `<mark>` wrapping a string, depending on which annotations cover it.
  *
  * For overlapping annotations (a fairly uncommon teacher action), the
- * outermost-by-color-priority annotation's id ends up on `data-id`, but
- * all overlapping ids are stored on `data-overlap-ids` so the editing
- * surface can still resolve clicks. Phase 2 ships with a simple "first
- * annotation wins" pick — multi-color overlap UX is a follow-up.
+ * earliest-by-`from` annotation in `active` (the input is sorted by
+ * `from` in the caller) ends up on `data-annotation-id`, and all
+ * overlapping ids are stored on `data-overlap-ids` so the editor
+ * surface can still resolve clicks against any of them. Multi-color
+ * overlap UX (e.g. split-into-N-marks) is a follow-up.
  */
 const sliceTextWithAnnotations = (
   text: string,
@@ -198,10 +223,19 @@ const sliceTextWithAnnotations = (
   annotations: WrittenAnswerAnnotation[],
   ctx: RenderCtx
 ): React.ReactNode[] => {
-  // Collect the offsets where coverage changes within this text node.
-  const boundaries = new Set<number>([start, end]);
+  // Pre-filter annotations that actually overlap this text node, then
+  // do all subsequent work against the smaller set. The previous
+  // implementation re-scanned the full `annotations` array once per
+  // segment, making rendering scale as O(segments × annotations) even
+  // when only one annotation touched the current text node.
+  const local: WrittenAnswerAnnotation[] = [];
   for (const a of annotations) {
     if (a.to <= start || a.from >= end) continue;
+    local.push(a);
+  }
+  // Collect the offsets where coverage changes within this text node.
+  const boundaries = new Set<number>([start, end]);
+  for (const a of local) {
     boundaries.add(Math.max(start, a.from));
     boundaries.add(Math.min(end, a.to));
   }
@@ -213,7 +247,7 @@ const sliceTextWithAnnotations = (
     const segTo = sorted[i + 1];
     if (segFrom === segTo) continue;
     const chunk = text.slice(segFrom - start, segTo - start);
-    const active = annotations.filter((a) => a.from < segTo && a.to > segFrom);
+    const active = local.filter((a) => a.from < segTo && a.to > segFrom);
     if (active.length === 0) {
       out.push(chunk);
       continue;
@@ -285,6 +319,15 @@ export const getPlainTextOffsetFromRange = (
     to: null,
   };
 
+  // Single-pass walk. Both text-node offsets and element-node offsets
+  // (where `range.startOffset` is a child index, e.g. when a user
+  // clicks past the last character of a paragraph) are resolved
+  // inline against the same monotonically-advancing `offset` and
+  // `atBlockStart` state, so block-boundary newlines stay consistent
+  // with `htmlToPlainText`'s projection. The previous version
+  // recomputed preceding-sibling lengths via `htmlToPlainText` per
+  // call — O(N²) and ignored `atBlockStart`, producing off-by-one
+  // offsets near block boundaries.
   let offset = 0;
   let atBlockStart = true;
 
@@ -306,6 +349,12 @@ export const getPlainTextOffsetFromRange = (
     const el = node as Element;
     const tag = el.tagName.toUpperCase();
     if (tag === 'BR') {
+      if (node === range.startContainer && result.from == null) {
+        result.from = offset;
+      }
+      if (node === range.endContainer && result.to == null) {
+        result.to = offset;
+      }
       offset += 1;
       atBlockStart = true;
       return;
@@ -316,28 +365,44 @@ export const getPlainTextOffsetFromRange = (
       }
       atBlockStart = true;
     }
-    // Range may land on an element node (e.g. clicking past the last
-    // character of a paragraph). When that happens, the offset is a
-    // child index — sum the plaintext length of preceding children.
+    // Range may anchor on this element with `range.startOffset` as a
+    // child-index. We resolve it by checking before each child:
+    // if the index equals `i`, the offset point is "just before
+    // child i" and we capture the current cumulative `offset`.
+    const children = el.childNodes;
+    for (let i = 0; i < children.length; i++) {
+      if (
+        node === range.startContainer &&
+        result.from == null &&
+        range.startOffset === i
+      ) {
+        result.from = offset;
+      }
+      if (
+        node === range.endContainer &&
+        result.to == null &&
+        range.endOffset === i
+      ) {
+        result.to = offset;
+      }
+      visit(children[i]);
+      if (result.from != null && result.to != null) return;
+    }
+    // Trailing boundary: range.{start,end}Offset === children.length
+    // means the anchor sits after the last child.
     if (
       node === range.startContainer &&
       result.from == null &&
-      node.nodeType === Node.ELEMENT_NODE
+      range.startOffset === children.length
     ) {
-      const before = childrenPlaintextLength(el, range.startOffset);
-      result.from = offset + before;
+      result.from = offset;
     }
     if (
       node === range.endContainer &&
       result.to == null &&
-      node.nodeType === Node.ELEMENT_NODE
+      range.endOffset === children.length
     ) {
-      const before = childrenPlaintextLength(el, range.endOffset);
-      result.to = offset + before;
-    }
-    for (const child of Array.from(el.childNodes)) {
-      visit(child);
-      if (result.from != null && result.to != null) return;
+      result.to = offset;
     }
   };
   visit(root);
@@ -347,28 +412,4 @@ export const getPlainTextOffsetFromRange = (
   return result.from < result.to
     ? { from: result.from, to: result.to }
     : { from: result.to, to: result.from };
-};
-
-const childrenPlaintextLength = (parent: Element, count: number): number => {
-  let len = 0;
-  const children = Array.from(parent.childNodes).slice(0, count);
-  for (const child of children) {
-    if (child.nodeType === Node.TEXT_NODE) {
-      len += (child.nodeValue ?? '').length;
-    } else if (child.nodeType === Node.ELEMENT_NODE) {
-      const el = child as Element;
-      const tag = el.tagName.toUpperCase();
-      if (tag === 'BR') {
-        len += 1;
-      } else if (BLOCK_TAGS.has(tag)) {
-        len += htmlToPlainText(el.innerHTML).length;
-        // Block boundaries contribute a newline only between blocks. We
-        // don't double-count for a leading block — htmlToPlainText
-        // handles that case the same way.
-      } else {
-        len += htmlToPlainText(el.innerHTML).length;
-      }
-    }
-  }
-  return len;
 };

--- a/utils/writtenAnnotations.ts
+++ b/utils/writtenAnnotations.ts
@@ -1,0 +1,374 @@
+/**
+ * Phase 2 utilities for the written-response annotation system.
+ *
+ * The teacher annotates a frozen sanitized-HTML snapshot of the student's
+ * answer. Annotations are stored as plaintext offsets into the snapshot's
+ * `textContent` projection — NOT against the student's live answer doc —
+ * so highlights stay anchored even if the student later edits after a
+ * teacher-initiated unlock.
+ *
+ * One walker drives both directions of the offset math:
+ * - `htmlToPlainText` is the canonical "what does this HTML look like
+ *   as plaintext for annotation offsets" function.
+ * - `renderAnnotatedSnapshot` walks the SAME parsed DOM in the SAME
+ *   order, splitting text nodes at annotation boundaries and emitting a
+ *   React tree with `<mark>` wraps.
+ *
+ * Block-level tags (`<p>`, `<li>`, `<br>`) contribute a single `\n` to
+ * the plaintext so the offsets agree with what a teacher visually
+ * perceives when selecting across paragraph boundaries.
+ */
+
+import React from 'react';
+import type { WrittenAnswerAnnotation } from '@/types';
+
+const BLOCK_TAGS = new Set(['P', 'LI', 'UL', 'OL', 'DIV']);
+
+/**
+ * Deterministically project a sanitized HTML string to plaintext.
+ *
+ * Mirrors the walker in `renderAnnotatedSnapshot`: each `<br>` and each
+ * block-level container contributes exactly one newline character. The
+ * result MUST match the offsets the renderer computes; both sides use
+ * `walkPlaintext` so they can never drift apart.
+ *
+ * Returns '' in non-DOM environments (e.g. SSR). Callers in JSX shouldn't
+ * hit that path, but the guard keeps unit tests / Node usage safe.
+ */
+export const htmlToPlainText = (html: string): string => {
+  if (!html) return '';
+  if (typeof DOMParser === 'undefined') return '';
+  const doc = new DOMParser().parseFromString(
+    `<div>${html}</div>`,
+    'text/html'
+  );
+  const root = doc.body.firstChild as Element | null;
+  if (!root) return '';
+  let out = '';
+  walkPlaintext(root, (chunk) => {
+    out += chunk;
+  });
+  return out;
+};
+
+const walkPlaintext = (
+  node: Node,
+  emit: (chunk: string) => void,
+  ctx: { atBlockStart: boolean } = { atBlockStart: true }
+): void => {
+  for (const child of Array.from(node.childNodes)) {
+    if (child.nodeType === Node.TEXT_NODE) {
+      const text = child.nodeValue ?? '';
+      if (text.length > 0) {
+        emit(text);
+        ctx.atBlockStart = false;
+      }
+      continue;
+    }
+    if (child.nodeType !== Node.ELEMENT_NODE) continue;
+    const el = child as Element;
+    const tag = el.tagName.toUpperCase();
+    if (tag === 'BR') {
+      emit('\n');
+      ctx.atBlockStart = true;
+      continue;
+    }
+    if (BLOCK_TAGS.has(tag)) {
+      // Insert a leading newline between consecutive blocks, but not
+      // before the very first block of the document.
+      if (!ctx.atBlockStart) {
+        emit('\n');
+        ctx.atBlockStart = true;
+      }
+      walkPlaintext(el, emit, ctx);
+      continue;
+    }
+    walkPlaintext(el, emit, ctx);
+  }
+};
+
+/**
+ * Build the React node tree for the snapshot with mark wrappers at
+ * annotation boundaries.
+ *
+ * The renderer makes the same plaintext walk as `htmlToPlainText`, but
+ * for each text node it knows its absolute plaintext offset range and
+ * can split it at every annotation boundary inside that range. The
+ * resulting segments are wrapped in `<mark>` elements with stable
+ * `data-annotation-id` so the parent component can attach interaction
+ * handlers (hover, click-to-edit).
+ *
+ * Block-level newlines from `<p>`, `<li>`, `<br>` are NOT rendered into
+ * the React tree — the original DOM structure already gives the browser
+ * the right line breaks. The newlines are purely an offset-bookkeeping
+ * device shared with `htmlToPlainText`.
+ */
+export const renderAnnotatedSnapshot = ({
+  html,
+  annotations,
+}: {
+  html: string;
+  annotations: WrittenAnswerAnnotation[];
+}): React.ReactNode => {
+  if (!html) return null;
+  if (typeof DOMParser === 'undefined') return null;
+  const doc = new DOMParser().parseFromString(
+    `<div>${html}</div>`,
+    'text/html'
+  );
+  const root = doc.body.firstChild as Element | null;
+  if (!root) return null;
+
+  const sorted = [...annotations].sort((a, b) => a.from - b.from);
+  const ctx = { offset: 0, atBlockStart: true, keyCounter: 0 };
+
+  return renderChildren(root, sorted, ctx);
+};
+
+interface RenderCtx {
+  offset: number;
+  atBlockStart: boolean;
+  keyCounter: number;
+}
+
+const renderChildren = (
+  node: Node,
+  annotations: WrittenAnswerAnnotation[],
+  ctx: RenderCtx
+): React.ReactNode[] => {
+  const out: React.ReactNode[] = [];
+  for (const child of Array.from(node.childNodes)) {
+    if (child.nodeType === Node.TEXT_NODE) {
+      const text = child.nodeValue ?? '';
+      if (text.length === 0) continue;
+      const start = ctx.offset;
+      const end = start + text.length;
+      ctx.offset = end;
+      ctx.atBlockStart = false;
+      out.push(...sliceTextWithAnnotations(text, start, end, annotations, ctx));
+      continue;
+    }
+    if (child.nodeType !== Node.ELEMENT_NODE) continue;
+    const el = child as Element;
+    const tag = el.tagName.toUpperCase();
+    if (tag === 'BR') {
+      ctx.offset += 1;
+      ctx.atBlockStart = true;
+      out.push(React.createElement('br', { key: `n${ctx.keyCounter++}` }));
+      continue;
+    }
+    if (BLOCK_TAGS.has(tag)) {
+      if (!ctx.atBlockStart) {
+        ctx.offset += 1;
+      }
+      ctx.atBlockStart = true;
+      const innerKey = `n${ctx.keyCounter++}`;
+      const inner = renderChildren(el, annotations, ctx);
+      out.push(
+        React.createElement(tag.toLowerCase(), { key: innerKey }, ...inner)
+      );
+      continue;
+    }
+    // Inline element (b, i, em, strong, u). Recurse, then wrap in the
+    // same tag — this preserves bold/italic styling around annotations.
+    const innerKey = `n${ctx.keyCounter++}`;
+    const inner = renderChildren(el, annotations, ctx);
+    out.push(
+      React.createElement(tag.toLowerCase(), { key: innerKey }, ...inner)
+    );
+  }
+  return out;
+};
+
+/**
+ * Split a text node's [start, end) range at every annotation boundary
+ * inside it. Each resulting sub-segment becomes either a bare string or
+ * a `<mark>` wrapping a string, depending on which annotations cover it.
+ *
+ * For overlapping annotations (a fairly uncommon teacher action), the
+ * outermost-by-color-priority annotation's id ends up on `data-id`, but
+ * all overlapping ids are stored on `data-overlap-ids` so the editing
+ * surface can still resolve clicks. Phase 2 ships with a simple "first
+ * annotation wins" pick — multi-color overlap UX is a follow-up.
+ */
+const sliceTextWithAnnotations = (
+  text: string,
+  start: number,
+  end: number,
+  annotations: WrittenAnswerAnnotation[],
+  ctx: RenderCtx
+): React.ReactNode[] => {
+  // Collect the offsets where coverage changes within this text node.
+  const boundaries = new Set<number>([start, end]);
+  for (const a of annotations) {
+    if (a.to <= start || a.from >= end) continue;
+    boundaries.add(Math.max(start, a.from));
+    boundaries.add(Math.min(end, a.to));
+  }
+  const sorted = Array.from(boundaries).sort((a, b) => a - b);
+
+  const out: React.ReactNode[] = [];
+  for (let i = 0; i < sorted.length - 1; i++) {
+    const segFrom = sorted[i];
+    const segTo = sorted[i + 1];
+    if (segFrom === segTo) continue;
+    const chunk = text.slice(segFrom - start, segTo - start);
+    const active = annotations.filter((a) => a.from < segTo && a.to > segFrom);
+    if (active.length === 0) {
+      out.push(chunk);
+      continue;
+    }
+    const primary = active[0];
+    const overlapIds = active.map((a) => a.id).join(',');
+    out.push(
+      React.createElement(
+        'mark',
+        {
+          key: `m${ctx.keyCounter++}`,
+          'data-annotation-id': primary.id,
+          'data-overlap-ids': overlapIds,
+          'data-color': primary.highlightColor ?? 'yellow',
+          className: highlightClass(primary.highlightColor),
+        },
+        chunk
+      )
+    );
+  }
+  return out;
+};
+
+/**
+ * Tailwind classes for each highlight color. Kept here so the same
+ * palette is used by both the teacher's edit surface (live marks) and
+ * the student's read-only review. Background uses the brand-style soft
+ * tint; text stays on `currentColor` so dark/light contexts both work.
+ */
+export const highlightClass = (
+  color: WrittenAnswerAnnotation['highlightColor']
+): string => {
+  switch (color) {
+    case 'green':
+      return 'bg-emerald-300/60 text-inherit rounded-sm px-0.5 cursor-pointer';
+    case 'pink':
+      return 'bg-pink-300/60 text-inherit rounded-sm px-0.5 cursor-pointer';
+    case 'blue':
+      return 'bg-sky-300/60 text-inherit rounded-sm px-0.5 cursor-pointer';
+    case 'yellow':
+    default:
+      return 'bg-amber-300/60 text-inherit rounded-sm px-0.5 cursor-pointer';
+  }
+};
+
+/**
+ * Convert a live DOM Range inside the rendered snapshot to plaintext
+ * offsets. Returns null if the range falls outside the snapshot root or
+ * is collapsed (no text selected).
+ *
+ * Implementation: walk every text node of `root` in document order;
+ * track cumulative plaintext offset including block-boundary newlines;
+ * when we reach the range's start container, add the in-node offset;
+ * same for end.
+ */
+export const getPlainTextOffsetFromRange = (
+  root: Element,
+  range: Range
+): { from: number; to: number } | null => {
+  if (range.collapsed) return null;
+  if (
+    !root.contains(range.startContainer) ||
+    !root.contains(range.endContainer)
+  ) {
+    return null;
+  }
+  const result: { from: number | null; to: number | null } = {
+    from: null,
+    to: null,
+  };
+
+  let offset = 0;
+  let atBlockStart = true;
+
+  const visit = (node: Node): void => {
+    if (result.from != null && result.to != null) return;
+    if (node.nodeType === Node.TEXT_NODE) {
+      const text = node.nodeValue ?? '';
+      if (node === range.startContainer && result.from == null) {
+        result.from = offset + range.startOffset;
+      }
+      if (node === range.endContainer && result.to == null) {
+        result.to = offset + range.endOffset;
+      }
+      offset += text.length;
+      if (text.length > 0) atBlockStart = false;
+      return;
+    }
+    if (node.nodeType !== Node.ELEMENT_NODE) return;
+    const el = node as Element;
+    const tag = el.tagName.toUpperCase();
+    if (tag === 'BR') {
+      offset += 1;
+      atBlockStart = true;
+      return;
+    }
+    if (BLOCK_TAGS.has(tag)) {
+      if (!atBlockStart) {
+        offset += 1;
+      }
+      atBlockStart = true;
+    }
+    // Range may land on an element node (e.g. clicking past the last
+    // character of a paragraph). When that happens, the offset is a
+    // child index — sum the plaintext length of preceding children.
+    if (
+      node === range.startContainer &&
+      result.from == null &&
+      node.nodeType === Node.ELEMENT_NODE
+    ) {
+      const before = childrenPlaintextLength(el, range.startOffset);
+      result.from = offset + before;
+    }
+    if (
+      node === range.endContainer &&
+      result.to == null &&
+      node.nodeType === Node.ELEMENT_NODE
+    ) {
+      const before = childrenPlaintextLength(el, range.endOffset);
+      result.to = offset + before;
+    }
+    for (const child of Array.from(el.childNodes)) {
+      visit(child);
+      if (result.from != null && result.to != null) return;
+    }
+  };
+  visit(root);
+
+  if (result.from == null || result.to == null) return null;
+  if (result.from === result.to) return null;
+  return result.from < result.to
+    ? { from: result.from, to: result.to }
+    : { from: result.to, to: result.from };
+};
+
+const childrenPlaintextLength = (parent: Element, count: number): number => {
+  let len = 0;
+  const children = Array.from(parent.childNodes).slice(0, count);
+  for (const child of children) {
+    if (child.nodeType === Node.TEXT_NODE) {
+      len += (child.nodeValue ?? '').length;
+    } else if (child.nodeType === Node.ELEMENT_NODE) {
+      const el = child as Element;
+      const tag = el.tagName.toUpperCase();
+      if (tag === 'BR') {
+        len += 1;
+      } else if (BLOCK_TAGS.has(tag)) {
+        len += htmlToPlainText(el.innerHTML).length;
+        // Block boundaries contribute a newline only between blocks. We
+        // don't double-count for a leading block — htmlToPlainText
+        // handles that case the same way.
+      } else {
+        len += htmlToPlainText(el.innerHTML).length;
+      }
+    }
+  }
+  return len;
+};


### PR DESCRIPTION
## Summary

- **Phase 2 — Annotations**: highlight marks + margin comments in the written-response grader; read-only annotated view on the student score-review screen; snapshot-at-grading-time semantics so the student's `answer` text is never mutated.
- **Phase 1 §12 testing gap closed** in the same PR: 29 new tests covering the Phase 1 sanitizer, the contenteditable editor, and the written-type branch of `gradeAnswer`.

Implements [docs/written-response-quiz-questions.md](https://github.com/OPS-PIvers/SpartBoard/blob/claude/determined-herschel-659b8c/docs/written-response-quiz-questions.md) Phase 2; design decision recorded in §5 (chose snapshot+offsets over marks-in-document) and implementation logs appended as §13 (Phase 1) and §14 (Phase 2).

## Design decision

**Snapshot-at-grading-time + sidecar plaintext offsets, rendered to JSX.**

- `WrittenAnswerGrade.gradingSnapshot` freezes the sanitized HTML the teacher annotated; offsets index into its plaintext projection. Frozen on first save with annotations and reused on every subsequent save, so a post-unlock student edit can never drift the anchors.
- One walker in `utils/writtenAnnotations.ts` drives both `htmlToPlainText` and `renderAnnotatedSnapshot`, so the teacher's selection→offset conversion and the renderer's offset→DOM mapping can never disagree.
- `<mark>` elements are emitted directly into the React tree — the Phase 1 sanitizer profile stays exactly as-is and no HTML string concat / re-sanitization is needed.

Rejected: marks-in-document (would require widening the Phase 1 sanitizer to allow `<mark data-id>` or mutating the student's `answer` field). Live-answer offsets (would drift on post-unlock student edits).

## Files

**New code**
- `utils/writtenAnnotations.ts` — plaintext walker + JSX renderer + selection→offset converter
- `components/widgets/QuizWidget/components/AnnotatedResponseView.tsx` — two-mode (`edit` / `read`) annotation surface with 4-color palette, margin column, cross-highlighting

**Wired**
- `types.ts` — added `WrittenAnswerGrade.gradingSnapshot?: string` (optional, so Phase 1 grades remain valid)
- `components/widgets/QuizWidget/components/WrittenResponseGrader.tsx` — uses the edit view; freezes snapshot once on first annotation; dirty-tracking widened to annotation edits
- `components/quiz/QuizStudentApp.tsx` — new `WrittenAnswerReview` sub-component branched into `PublishedScoreReview` for written-type questions; renders read-mode annotated view when annotations exist, sanitized snapshot HTML otherwise, with score + teacher comment chips
- `firestore.rules` — comment-only change documenting that `grading.*` (incl. `gradingSnapshot`, `annotations`) is teacher-only by construction (existing student-write `hasOnly([...])` whitelist already excludes the whole map)

## Tests

60 new tests, full suite **2455 passing across 238 files**:

| Suite | Count | Covers |
|---|---|---|
| `tests/utils/sanitizeQuizResponse.test.ts` | 12 | Phase 1 sanitizer whitelist, strip cases, idempotency |
| `tests/components/quiz/WrittenResponseEditor.test.tsx` | 9 | Hydration, sanitized onChange, word cap, pause/resume remount, disabled state |
| `tests/hooks/useQuizSession.gradeAnswer.test.ts` | 8 | Written-type ungraded default, manual-grade pickup, clamping, MC pass-through |
| `tests/utils/writtenAnnotations.test.tsx` | 15 | Plaintext extraction, mark wrapping invariants, offset round-trip, range→offset |
| `tests/components/quiz/AnnotatedResponseView.test.tsx` | 9 | Read/edit modes, palette gating, comment edit/delete, color change |
| `tests/components/quiz/WrittenResponseGrader.annotations.test.tsx` | 3 | Snapshot freeze invariant, points-only save, draft rehydration |
| `tests/components/quiz/PublishedScoreReview.annotations.test.tsx` | 5 | Visibility gating, ungraded fallback, snapshot-wins, mark wrapping, empty state |

## Test plan

- [x] `pnpm run type-check` — clean
- [x] `pnpm run lint` — zero errors, zero warnings (`--max-warnings 0`)
- [x] `pnpm run format:check` — clean
- [x] `pnpm run test` — 2455 / 2455 pass
- [ ] **Manual E2E on the preview deployment** — author/student split-browser walkthrough:
  - Build a quiz with one short-answer + one essay question
  - Submit as a student, leave the live tab
  - Teacher opens results → GRADE WRITTEN → select a sentence → pick a color → add comment → save
  - Confirm `grading.<qid>` in Firestore has `gradingSnapshot`, `annotations[]`, `overallComment`, `pointsAwarded`
  - Publish at `score-responses-and-answers` → student review surface shows the snapshot with highlights + margin comments
  - Reload the grader: marks persist; clicking a mark surfaces the edit panel pre-filled
  - Edge case: pause-resume-resubmit-regrade — confirm snapshot freezes at the first annotation and stays stable across student edits

## Out of scope (deferred follow-ups)

- Overlapping annotation UX — renderer handles overlap correctly (`data-overlap-ids`), but the editor surface picks the primary on click; multi-color overlap chrome is a polish pass
- Margin chip vertical anchoring to highlight y-coordinate (Google Docs-style)
- Phase 3 (rubrics) and Phase 4 (AI draft grading, anonymous toggle, Docs export)

🤖 Generated with [Claude Code](https://claude.com/claude-code)