### PR TITLE
feat(random): manual editing, lock + remove for randomizer groups

### DIFF
--- a/components/widgets/random/RandomGroups.tsx
+++ b/components/widgets/random/RandomGroups.tsx
@@ -1,12 +1,19 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { Users } from 'lucide-react';
+import { useDroppable } from '@dnd-kit/core';
 import { RandomGroup, SharedGroup } from '@/types';
+import { StudentChip } from './StudentChip';
 
 interface RandomGroupsProps {
   displayResult: string | string[] | string[][] | RandomGroup[] | null;
   sharedGroups?: SharedGroup[];
   /** Default group name prefix when a group has no shared-groups entry. */
   groupNamePrefix?: string;
+  /** When true, render chips as draggable + lock/remove and groups as drop zones. */
+  editable?: boolean;
+  lockedNames?: string[];
+  onToggleLock?: (name: string) => void;
+  onRemove?: (name: string) => void;
 }
 
 const computeColumnCount = (
@@ -45,10 +52,61 @@ const computeColumnCount = (
   return bestCols;
 };
 
+interface GroupDropZoneProps {
+  groupId: string;
+  groupName: string;
+  children: React.ReactNode;
+  editable: boolean;
+}
+
+const GroupDropZone: React.FC<GroupDropZoneProps> = ({
+  groupId,
+  groupName,
+  children,
+  editable,
+}) => {
+  const dropId = `group:${groupId}`;
+  const { isOver, setNodeRef } = useDroppable({
+    id: dropId,
+    disabled: !editable,
+  });
+
+  return (
+    <div
+      ref={editable ? setNodeRef : null}
+      className={`border rounded-xl flex flex-col shadow-sm overflow-hidden min-w-0 min-h-0 transition-colors ${
+        isOver
+          ? 'bg-brand-blue-light/15 border-brand-blue-primary/60'
+          : 'bg-blue-50 border-blue-200'
+      }`}
+      style={{
+        padding: 'clamp(8px, 3.5cqmin, 20px)',
+        containerType: 'size',
+      }}
+    >
+      <div
+        className="uppercase text-brand-blue-primary tracking-widest opacity-80 font-black truncate flex-shrink-0"
+        style={{
+          fontSize: 'clamp(11px, 8cqmin, 24px)',
+          marginBottom: 'clamp(4px, 2.5cqmin, 10px)',
+        }}
+        title={groupName}
+      >
+        {groupName}
+      </div>
+      {children}
+    </div>
+  );
+};
+
 export const RandomGroups: React.FC<RandomGroupsProps> = ({
   displayResult,
   sharedGroups,
   groupNamePrefix = 'Group',
+  editable = false,
+  lockedNames,
+  onToggleLock,
+  onRemove,
 }) => {
   const groups = useMemo(() => {
     if (
@@ -65,6 +123,7 @@ export const RandomGroups: React.FC<RandomGroupsProps> = ({
   const showEmptyState =
     !displayResult ||
     !Array.isArray(displayResult) ||
+    displayResult.length === 0 ||
     (displayResult.length > 0 &&
       !Array.isArray(displayResult[0]) &&
       typeof displayResult[0] !== 'object');
@@ -99,6 +158,7 @@ export const RandomGroups: React.FC<RandomGroupsProps> = ({
 
   const cols = computeColumnCount(groups.length, dims.w, dims.h, maxNameLen);
   const rows = groups.length > 0 ? Math.ceil(groups.length / cols) : 1;
+  const lockedSet = useMemo(() => new Set(lockedNames ?? []), [lockedNames]);
 
   return (
     <div
@@ -126,25 +186,44 @@ export const RandomGroups: React.FC<RandomGroupsProps> = ({
 
         if (!groupNames) return null;
 
-        return (
-          <div
-            key={!Array.isArray(groupItem) && groupItem.id ? groupItem.id : i}
-            className="bg-blue-50 border border-blue-200 rounded-xl flex flex-col shadow-sm overflow-hidden min-w-0 min-h-0"
-            style={{
-              padding: 'clamp(8px, 3.5cqmin, 20px)',
-              containerType: 'size',
-            }}
-          >
+        // Stable key — prefer the group's persistent id over index so React
+        // doesn't blow away droppable refs on every re-randomize.
+        const key = groupId ?? `${groupNamePrefix}-${i}`;
+        // Use the group's real id (or a synthetic fallback) as the droppable
+        // id. Empty-state groups created by the widget always have an id.
+        const dropZoneId = groupId ?? `__no_id__:${i}`;
+
+        const body =
+          editable && onToggleLock && onRemove ? (
             <div
-              className="uppercase text-brand-blue-primary tracking-widest opacity-80 font-black truncate flex-shrink-0"
-              style={{
-                fontSize: 'clamp(11px, 8cqmin, 24px)',
-                marginBottom: 'clamp(4px, 2.5cqmin, 10px)',
-              }}
-              title={groupName}
+              className="flex-1 min-h-0 flex flex-wrap content-start overflow-hidden"
+              style={{ gap: 'clamp(3px, 1.2cqmin, 8px)' }}
             >
-              {groupName}
+              {groupNames.length === 0 ? (
+                <div
+                  className="w-full text-slate-400/80 italic text-center"
+                  style={{
+                    fontSize: 'clamp(10px, 3cqmin, 14px)',
+                    padding: 'clamp(6px, 2cqmin, 14px) 0',
+                  }}
+                >
+                  Drop students here
+                </div>
+              ) : (
+                groupNames.map((name) => (
+                  <StudentChip
+                    key={name}
+                    name={name}
+                    dragId={`chip:${dropZoneId}:${name}`}
+                    sourceZoneId={dropZoneId}
+                    locked={lockedSet.has(name)}
+                    onToggleLock={onToggleLock}
+                    onRemove={onRemove}
+                  />
+                ))
+              )}
             </div>
+          ) : (
             <div
               className="flex-1 min-h-0 flex flex-col justify-center overflow-hidden"
               style={{ gap: 'clamp(3px, 1.5cqmin, 10px)' }}
@@ -176,7 +255,17 @@ export const RandomGroups: React.FC<RandomGroupsProps> = ({
                 ));
               })()}
             </div>
-          </div>
+          );
+
+        return (
+          <GroupDropZone
+            key={key}
+            groupId={dropZoneId}
+            groupName={groupName}
+            editable={editable}
+          >
+            {body}
+          </GroupDropZone>
         );
       })}
       {showEmptyState && (

--- a/components/widgets/random/RandomWidget.tsx
+++ b/components/widgets/random/RandomWidget.tsx
@@ -1,4 +1,10 @@
-import React, { useState, useMemo, useRef, useEffect } from 'react';
+import React, {
+  useState,
+  useMemo,
+  useRef,
+  useEffect,
+  useCallback,
+} from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDashboard } from '@/context/useDashboard';
 import {
@@ -28,9 +34,22 @@ import {
   Sparkles,
 } from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
+import {
+  DndContext,
+  DragEndEvent,
+  DragStartEvent,
+  PointerSensor,
+  TouchSensor,
+  KeyboardSensor,
+  useSensor,
+  useSensors,
+  pointerWithin,
+} from '@dnd-kit/core';
+import { sortableKeyboardCoordinates } from '@dnd-kit/sortable';
 import { getAudioCtx, playTick, playWinner } from './audioUtils';
 import { getLocalIsoDate } from '@/utils/localDate';
 import { logError } from '@/utils/logError';
+import { beginWidgetDrag, endWidgetDrag } from '@/utils/widgetDragFlag';
 import {
   makeJigsawExpertGroups,
   makeNameGroups,
@@ -38,6 +57,14 @@ import {
   makeRestrictedGroups,
   makeRestrictedGroupsByCount,
 } from './groupMaker';
+import {
+  UNASSIGNED_ZONE_ID,
+  toggleLockedName,
+  clearLockedNames,
+  moveNameToGroup,
+  mergeLockedWithFresh,
+  shuffleWithLocks,
+} from './randomEditHelpers';
 
 import { SCOREBOARD_COLORS as TEAM_COLORS } from '@/config/scoreboard';
 import { RandomWheel } from './RandomWheel';
@@ -45,6 +72,8 @@ import { RandomSlots } from './RandomSlots';
 import { RandomFlash } from './RandomFlash';
 import { RandomGroups } from './RandomGroups';
 import { GroupSizeStepper } from './GroupSizeStepper';
+import { UnassignedTray } from './UnassignedTray';
+import { ShuffleList } from './ShuffleList';
 
 import { WidgetLayout } from '../WidgetLayout';
 
@@ -109,6 +138,24 @@ export const RandomWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
     numExpertGroups: configNumExpertGroups,
     numHomeGroups: configNumHomeGroups,
   } = config;
+  const lockedNames = useMemo(
+    () => (Array.isArray(config.lockedNames) ? config.lockedNames : []),
+    [config.lockedNames]
+  );
+  const unassignedNames = useMemo(
+    () => (Array.isArray(config.unassignedNames) ? config.unassignedNames : []),
+    [config.unassignedNames]
+  );
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
+    useSensor(TouchSensor, {
+      activationConstraint: { delay: 120, tolerance: 8 },
+    }),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    })
+  );
   // Classic jigsaw is "4 home groups of 4 → 4 expert groups of 4", so default
   // to 4 in jigsaw mode when the user hasn't explicitly set a size. Other
   // modes keep the historical default of 3. An explicit user choice always
@@ -210,7 +257,9 @@ export const RandomWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
         config.lastResult != null ||
         (config.remainingStudents?.length ?? 0) > 0 ||
         (config.jigsawHomeGroups?.length ?? 0) > 0 ||
-        (config.jigsawExpertGroups?.length ?? 0) > 0;
+        (config.jigsawExpertGroups?.length ?? 0) > 0 ||
+        (config.lockedNames?.length ?? 0) > 0 ||
+        (config.unassignedNames?.length ?? 0) > 0;
       if (hasTransientState) {
         spinGenRef.current += 1;
         const update: Partial<RandomConfig> = {
@@ -219,6 +268,8 @@ export const RandomWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
           jigsawHomeGroups: null,
           jigsawExpertGroups: null,
           jigsawView: 'home',
+          lockedNames: [],
+          unassignedNames: [],
         };
         updateWidget(widget.id, { config: update as WidgetConfig });
         setLocalJigsaw(null);
@@ -313,6 +364,36 @@ export const RandomWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
     });
   };
 
+  // ───────── Manual editing state (locks, unassigned, placeholders) ─────────
+  //
+  // When mode is groups/jigsaw and no result exists yet, we still want to
+  // show empty group cards so teachers can manually drag students into them.
+  // Placeholders are kept in component state with stable UUIDs so chip
+  // dragIds and droppable zone ids don't churn across renders. They only
+  // regenerate when the desired count (group size / number of home groups /
+  // student count) changes.
+  const desiredPlaceholderCount = useMemo(() => {
+    if (mode === 'jigsaw') return Math.max(1, displayNumHomeGroups);
+    if (mode === 'groups') return Math.max(1, estimatedHomeGroupCount);
+    return 0;
+  }, [mode, displayNumHomeGroups, estimatedHomeGroupCount]);
+
+  const buildPlaceholders = (count: number): RandomGroup[] =>
+    Array.from({ length: count }, () => ({
+      id: crypto.randomUUID(),
+      names: [],
+    }));
+
+  const [placeholderGroups, setPlaceholderGroups] = useState<RandomGroup[]>(
+    () => buildPlaceholders(desiredPlaceholderCount)
+  );
+  const [prevDesiredPlaceholderCount, setPrevDesiredPlaceholderCount] =
+    useState(desiredPlaceholderCount);
+  if (prevDesiredPlaceholderCount !== desiredPlaceholderCount) {
+    setPrevDesiredPlaceholderCount(desiredPlaceholderCount);
+    setPlaceholderGroups(buildPlaceholders(desiredPlaceholderCount));
+  }
+
   const absentCount = useMemo(() => {
     if (rosterMode !== 'class' || !activeRoster) return 0;
     const today = getLocalIsoDate();
@@ -339,6 +420,8 @@ export const RandomWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
       jigsawHomeGroups: null,
       jigsawExpertGroups: null,
       jigsawView: 'home',
+      lockedNames: [],
+      unassignedNames: [],
     };
     updateWidget(widget.id, { config: update as WidgetConfig });
     setLocalJigsaw(null);
@@ -363,6 +446,8 @@ export const RandomWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
       jigsawHomeGroups: null,
       jigsawExpertGroups: null,
       jigsawView: 'home',
+      lockedNames: [],
+      unassignedNames: [],
     };
     updateWidget(widget.id, { config: update as WidgetConfig });
     setLocalJigsaw(null);
@@ -394,6 +479,297 @@ export const RandomWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
   const hasJigsawGroups =
     (renderedHomeGroups?.length ?? 0) > 0 ||
     (renderedExpertGroups?.length ?? 0) > 0;
+
+  // ───────── Editable groups + unassigned tray plumbing ─────────
+  //
+  // currentGroups is whatever the user is currently looking at and may edit:
+  //  • mode 'groups' with a result   → displayResult as RandomGroup[]
+  //  • mode 'groups' empty           → placeholder groups (committed on first edit)
+  //  • mode 'jigsaw' home view       → renderedHomeGroups, or placeholders
+  //  • mode 'jigsaw' expert view     → renderedExpertGroups (no placeholder
+  //                                    — expert groups are derived, so the
+  //                                    "fresh" empty state happens only on
+  //                                    the home tab)
+  //  • mode 'shuffle' / 'single'     → null (handled elsewhere)
+  const groupsFromDisplay = useMemo<RandomGroup[] | null>(() => {
+    if (
+      Array.isArray(displayResult) &&
+      displayResult.length > 0 &&
+      typeof displayResult[0] === 'object' &&
+      displayResult[0] !== null &&
+      'names' in (displayResult[0] as RandomGroup)
+    ) {
+      return displayResult as RandomGroup[];
+    }
+    return null;
+  }, [displayResult]);
+
+  const currentGroups = useMemo<RandomGroup[] | null>(() => {
+    if (mode === 'groups') return groupsFromDisplay ?? placeholderGroups;
+    if (mode === 'jigsaw') {
+      if (jigsawView === 'expert') {
+        return renderedExpertGroups ?? null;
+      }
+      return renderedHomeGroups ?? placeholderGroups;
+    }
+    return null;
+  }, [
+    mode,
+    jigsawView,
+    groupsFromDisplay,
+    renderedHomeGroups,
+    renderedExpertGroups,
+    placeholderGroups,
+  ]);
+
+  // Names that the result currently places into some group (or shuffle slot).
+  const namesInResult = useMemo<Set<string>>(() => {
+    const set = new Set<string>();
+    if (currentGroups) {
+      for (const g of currentGroups) for (const n of g.names) set.add(n);
+    } else if (
+      mode === 'shuffle' &&
+      Array.isArray(displayResult) &&
+      displayResult.length > 0 &&
+      typeof displayResult[0] === 'string'
+    ) {
+      for (const n of displayResult as string[]) set.add(n);
+    }
+    return set;
+  }, [currentGroups, displayResult, mode]);
+
+  // Names to show in the Unassigned tray. Combines:
+  //  • Explicit unassigned (persisted) — students the teacher removed
+  //  • Roster students not currently in any group/slot (covers the
+  //    "manual creation from empty" case and post-randomize gaps)
+  // Restricted to the active student pool so absent / removed-from-roster
+  // names don't linger.
+  const unassignedDisplay = useMemo<string[]>(() => {
+    const studentSet = new Set(students);
+    const out: string[] = [];
+    const seen = new Set<string>();
+    for (const n of unassignedNames) {
+      if (studentSet.has(n) && !namesInResult.has(n) && !seen.has(n)) {
+        out.push(n);
+        seen.add(n);
+      }
+    }
+    for (const n of students) {
+      if (!namesInResult.has(n) && !seen.has(n)) {
+        out.push(n);
+        seen.add(n);
+      }
+    }
+    return out;
+  }, [students, namesInResult, unassignedNames]);
+
+  const isEditableMode =
+    mode === 'groups' || mode === 'jigsaw' || mode === 'shuffle';
+
+  // Commit a fresh groups array back to config under the right field for
+  // the current mode/view. Mirrors the original handlePick `performUpdate`
+  // shape but doesn't trigger any of the sound/effect/sharedGroups logic.
+  const commitGroups = useCallback(
+    (nextGroups: RandomGroup[], extra?: Partial<RandomConfig>) => {
+      let update: Partial<RandomConfig> = { ...(extra ?? {}) };
+      if (mode === 'groups') {
+        update = { ...update, lastResult: nextGroups };
+        setDisplayResult(nextGroups);
+      } else if (mode === 'jigsaw') {
+        if (jigsawView === 'expert') {
+          update = { ...update, jigsawExpertGroups: nextGroups };
+          setLocalJigsaw((prev) =>
+            prev ? { ...prev, expert: nextGroups } : null
+          );
+        } else {
+          // Editing home groups invalidates the previously-derived expert
+          // groups — teachers expect to re-launch jigsaw after a manual
+          // home edit. Clear expert so the next Randomize regenerates it.
+          update = {
+            ...update,
+            jigsawHomeGroups: nextGroups,
+            lastResult: nextGroups,
+            jigsawExpertGroups: null,
+          };
+          setLocalJigsaw({ home: nextGroups, expert: [] });
+        }
+      }
+      updateWidget(widget.id, { config: update as WidgetConfig });
+    },
+    [mode, jigsawView, updateWidget, widget.id]
+  );
+
+  const handleToggleLock = useCallback(
+    (name: string) => {
+      const next = toggleLockedName(lockedNames, name);
+      updateWidget(widget.id, {
+        config: { lockedNames: next } as WidgetConfig,
+      });
+    },
+    [lockedNames, updateWidget, widget.id]
+  );
+
+  const handleRemoveFromResult = useCallback(
+    (name: string) => {
+      const nextUnassigned = unassignedNames.includes(name)
+        ? unassignedNames
+        : [...unassignedNames, name];
+      const nextLocked = clearLockedNames(lockedNames, [name]);
+
+      if (mode === 'shuffle') {
+        const current = Array.isArray(displayResult)
+          ? (displayResult as string[])
+          : [];
+        const nextShuffle = current.filter((n) => n !== name);
+        setDisplayResult(nextShuffle);
+        updateWidget(widget.id, {
+          config: {
+            lastResult: nextShuffle,
+            unassignedNames: nextUnassigned,
+            lockedNames: nextLocked,
+          } as WidgetConfig,
+        });
+        return;
+      }
+      if (!currentGroups) return;
+      const nextGroups = currentGroups.map((g) => ({
+        ...g,
+        names: g.names.filter((n) => n !== name),
+      }));
+      commitGroups(nextGroups, {
+        unassignedNames: nextUnassigned,
+        lockedNames: nextLocked,
+      });
+    },
+    [
+      mode,
+      currentGroups,
+      displayResult,
+      unassignedNames,
+      lockedNames,
+      commitGroups,
+      updateWidget,
+      widget.id,
+    ]
+  );
+
+  const handleDragStart = useCallback((_event: DragStartEvent) => {
+    beginWidgetDrag();
+  }, []);
+
+  const handleDragCancel = useCallback(() => {
+    endWidgetDrag();
+  }, []);
+
+  const handleDragEnd = useCallback(
+    (event: DragEndEvent) => {
+      endWidgetDrag();
+      const { active, over } = event;
+      if (!over) return;
+      const data = active.data.current as
+        | { name?: string; sourceZoneId?: string }
+        | undefined;
+      const name = data?.name;
+      const sourceZoneId = data?.sourceZoneId;
+      if (!name || !sourceZoneId) return;
+
+      const rawTargetId = String(over.id);
+      // Resolve the target zone id (group id, '__unassigned__', or
+      // 'shuffle-row:N'). We pass the raw id through for shuffle so the
+      // insert position is preserved.
+      let targetZoneId: string;
+      if (rawTargetId === UNASSIGNED_ZONE_ID) {
+        targetZoneId = UNASSIGNED_ZONE_ID;
+      } else if (rawTargetId.startsWith('group:')) {
+        targetZoneId = rawTargetId.slice('group:'.length);
+      } else if (rawTargetId.startsWith('shuffle-row:')) {
+        targetZoneId = rawTargetId;
+      } else if (rawTargetId === 'shuffle-list') {
+        targetZoneId = 'shuffle-list';
+      } else {
+        return;
+      }
+      if (sourceZoneId === targetZoneId) return;
+
+      // Shuffle: list + per-row drop targets.
+      if (mode === 'shuffle') {
+        const current = Array.isArray(displayResult)
+          ? [...(displayResult as string[])]
+          : [];
+        const filtered = current.filter((n) => n !== name);
+        let nextShuffle = filtered;
+        let nextUnassigned = unassignedNames.slice();
+        let nextLocked = lockedNames.slice();
+
+        if (targetZoneId === UNASSIGNED_ZONE_ID) {
+          if (!nextUnassigned.includes(name)) nextUnassigned.push(name);
+          nextLocked = clearLockedNames(lockedNames, [name]);
+        } else if (targetZoneId.startsWith('shuffle-row:')) {
+          const targetIdx = parseInt(
+            targetZoneId.slice('shuffle-row:'.length),
+            10
+          );
+          const clamped = Math.max(
+            0,
+            Math.min(
+              filtered.length,
+              Number.isFinite(targetIdx) ? targetIdx : filtered.length
+            )
+          );
+          nextShuffle = [
+            ...filtered.slice(0, clamped),
+            name,
+            ...filtered.slice(clamped),
+          ];
+          nextUnassigned = nextUnassigned.filter((n) => n !== name);
+        } else if (targetZoneId === 'shuffle-list') {
+          nextShuffle = [...filtered, name];
+          nextUnassigned = nextUnassigned.filter((n) => n !== name);
+        }
+
+        setDisplayResult(nextShuffle);
+        updateWidget(widget.id, {
+          config: {
+            lastResult: nextShuffle,
+            unassignedNames: nextUnassigned,
+            lockedNames: nextLocked,
+          } as WidgetConfig,
+        });
+        return;
+      }
+
+      // Groups / jigsaw
+      if (!currentGroups) return;
+      if (targetZoneId === UNASSIGNED_ZONE_ID) {
+        const nextGroups = currentGroups.map((g) => ({
+          ...g,
+          names: g.names.filter((n) => n !== name),
+        }));
+        const nextUnassigned = unassignedNames.includes(name)
+          ? unassignedNames
+          : [...unassignedNames, name];
+        const nextLocked = clearLockedNames(lockedNames, [name]);
+        commitGroups(nextGroups, {
+          unassignedNames: nextUnassigned,
+          lockedNames: nextLocked,
+        });
+      } else {
+        const nextGroups = moveNameToGroup(currentGroups, name, targetZoneId);
+        const nextUnassigned = unassignedNames.filter((n) => n !== name);
+        commitGroups(nextGroups, { unassignedNames: nextUnassigned });
+      }
+    },
+    [
+      mode,
+      currentGroups,
+      displayResult,
+      unassignedNames,
+      lockedNames,
+      commitGroups,
+      updateWidget,
+      widget.id,
+    ]
+  );
 
   const handleSendToScoreboard = () => {
     // 1. Normalize current groups from displayResult
@@ -692,13 +1068,35 @@ export const RandomWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
           setIsSpinning(false);
           return;
         }
+        const lockedSet = new Set(lockedNames);
+        const unassignedSet = new Set(unassignedNames);
+        const includeName = (name: string) =>
+          !unassignedSet.has(name) && !lockedSet.has(name);
+        const existingHome = renderedHomeGroups;
+        const useLockPath =
+          lockedSet.size > 0 &&
+          Array.isArray(existingHome) &&
+          existingHome.length > 0;
+
         let homeGroups: RandomGroup[];
         if (rosterMode === 'class' && activeRoster) {
-          const { groups, unsatisfied } = makeRestrictedGroupsByCount(
-            presentClassStudents,
-            displayNumHomeGroups
+          const poolStudents = presentClassStudents.filter((s) =>
+            includeName(`${s.firstName} ${s.lastName}`.trim())
           );
-          homeGroups = groups;
+          const targetCount = useLockPath
+            ? existingHome.length
+            : displayNumHomeGroups;
+          const { groups, unsatisfied } = makeRestrictedGroupsByCount(
+            poolStudents,
+            targetCount
+          );
+          homeGroups = useLockPath
+            ? mergeLockedWithFresh({
+                currentGroups: existingHome,
+                lockedNames,
+                freshGroups: groups,
+              })
+            : groups;
           if (unsatisfied > 0) {
             addToast(
               t('widgets.random.restrictionsUnsatisfied', {
@@ -709,7 +1107,18 @@ export const RandomWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
             );
           }
         } else {
-          homeGroups = makeNameGroupsByCount(students, displayNumHomeGroups);
+          const pool = students.filter(includeName);
+          const targetCount = useLockPath
+            ? existingHome.length
+            : displayNumHomeGroups;
+          const fresh = makeNameGroupsByCount(pool, targetCount);
+          homeGroups = useLockPath
+            ? mergeLockedWithFresh({
+                currentGroups: existingHome,
+                lockedNames,
+                freshGroups: fresh,
+              })
+            : fresh;
         }
         const numExpertGroups =
           configNumExpertGroups ??
@@ -811,26 +1220,90 @@ export const RandomWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
           setIsSpinning(false);
           return;
         }
+        const lockedSet = new Set(lockedNames);
+        const unassignedSet = new Set(unassignedNames);
+        const includeName = (name: string) =>
+          !unassignedSet.has(name) && !lockedSet.has(name);
+
         let result: string[] | RandomGroup[];
         if (mode === 'shuffle') {
-          result = shuffle(students);
-        } else if (rosterMode === 'class' && activeRoster) {
-          const { groups, unsatisfied } = makeRestrictedGroups(
-            presentClassStudents,
-            groupSize
-          );
-          result = groups;
-          if (unsatisfied > 0) {
-            addToast(
-              t('widgets.random.restrictionsUnsatisfied', {
-                defaultValue:
-                  "Couldn't satisfy all restrictions — try again or adjust group size.",
-              }),
-              'warning'
-            );
+          const existing =
+            Array.isArray(displayResult) &&
+            displayResult.length > 0 &&
+            typeof displayResult[0] === 'string'
+              ? (displayResult as string[])
+              : null;
+          if (existing && lockedSet.size > 0) {
+            // Lock-aware: keep locked names at their current indices,
+            // shuffle the rest. Drop any unassigned names that slipped in.
+            const filtered = existing.filter((n) => !unassignedSet.has(n));
+            result = shuffleWithLocks(filtered, lockedNames);
+          } else {
+            const pool = students.filter((n) => !unassignedSet.has(n));
+            result = shuffle(pool);
           }
         } else {
-          result = makeNameGroups(students, groupSize);
+          const existingGroups = groupsFromDisplay;
+          const useLockPath =
+            lockedSet.size > 0 &&
+            Array.isArray(existingGroups) &&
+            existingGroups.length > 0;
+
+          if (rosterMode === 'class' && activeRoster) {
+            const poolStudents = presentClassStudents.filter((s) =>
+              includeName(`${s.firstName} ${s.lastName}`.trim())
+            );
+            if (useLockPath) {
+              const targetCount = existingGroups.length;
+              const { groups, unsatisfied } = makeRestrictedGroupsByCount(
+                poolStudents,
+                targetCount
+              );
+              result = mergeLockedWithFresh({
+                currentGroups: existingGroups,
+                lockedNames,
+                freshGroups: groups,
+              });
+              if (unsatisfied > 0) {
+                addToast(
+                  t('widgets.random.restrictionsUnsatisfied', {
+                    defaultValue:
+                      "Couldn't satisfy all restrictions — try again or adjust group size.",
+                  }),
+                  'warning'
+                );
+              }
+            } else {
+              const { groups, unsatisfied } = makeRestrictedGroups(
+                poolStudents,
+                groupSize
+              );
+              result = groups;
+              if (unsatisfied > 0) {
+                addToast(
+                  t('widgets.random.restrictionsUnsatisfied', {
+                    defaultValue:
+                      "Couldn't satisfy all restrictions — try again or adjust group size.",
+                  }),
+                  'warning'
+                );
+              }
+            }
+          } else {
+            const pool = students.filter((n) => !unassignedSet.has(n));
+            if (useLockPath) {
+              const targetCount = existingGroups.length;
+              const unlockedPool = pool.filter((n) => !lockedSet.has(n));
+              const fresh = makeNameGroupsByCount(unlockedPool, targetCount);
+              result = mergeLockedWithFresh({
+                currentGroups: existingGroups,
+                lockedNames,
+                freshGroups: fresh,
+              });
+            } else {
+              result = makeNameGroups(pool, groupSize);
+            }
+          }
         }
         setDisplayResult(result);
         if (soundEnabled) playWinner();
@@ -1100,129 +1573,84 @@ export const RandomWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
           </div>
         }
         content={
-          <div
-            className={`flex-1 flex flex-col w-full h-full self-stretch min-h-0 overflow-hidden ${
-              mode === 'single' ? 'items-center justify-center' : ''
-            }`}
-          >
-            {mode === 'single' ? (
-              renderSinglePick()
-            ) : mode === 'jigsaw' ? (
-              <div
-                className="w-full flex-1 min-h-0 flex flex-col"
-                style={{ padding: '0 min(8px, 2cqmin)' }}
-              >
-                <RandomGroups
-                  displayResult={
-                    jigsawView === 'expert'
-                      ? renderedExpertGroups
-                      : renderedHomeGroups
-                  }
-                  sharedGroups={activeDashboard?.sharedGroups}
-                  groupNamePrefix={
-                    jigsawView === 'expert' ? 'Expert Group' : 'Home Group'
-                  }
-                />
-              </div>
-            ) : (
-              <div
-                className="w-full flex-1 min-h-0 flex flex-col"
-                style={{ padding: '0 min(8px, 2cqmin)' }}
-              >
-                {mode === 'shuffle' ? (
-                  (() => {
-                    const shuffleNames =
-                      Array.isArray(displayResult) &&
-                      (displayResult.length === 0 ||
-                        !Array.isArray(displayResult[0]))
-                        ? (displayResult as string[])
-                        : [];
-                    if (shuffleNames.length === 0) {
-                      return (
-                        <div
-                          className="flex-1 flex flex-col items-center justify-center text-slate-300 italic"
-                          style={{
-                            padding: 'min(40px, 8cqmin) 0',
-                            gap: 'min(8px, 2cqmin)',
-                          }}
-                        >
-                          <Layers
-                            className="opacity-20"
-                            style={{
-                              width: 'min(32px, 8cqmin)',
-                              height: 'min(32px, 8cqmin)',
-                            }}
-                          />
-                          <span
-                            className="font-bold"
-                            style={{ fontSize: 'min(14px, 3.5cqmin)' }}
-                          >
-                            {t('widgets.random.shuffleHint', {
-                              defaultValue: 'Click Randomize to Shuffle',
-                            })}
-                          </span>
-                        </div>
-                      );
+          mode === 'single' ? (
+            <div className="flex-1 flex flex-col w-full h-full self-stretch min-h-0 overflow-hidden items-center justify-center">
+              {renderSinglePick()}
+            </div>
+          ) : (
+            <DndContext
+              sensors={sensors}
+              collisionDetection={pointerWithin}
+              onDragStart={handleDragStart}
+              onDragEnd={handleDragEnd}
+              onDragCancel={handleDragCancel}
+            >
+              <div className="flex-1 flex flex-col w-full h-full self-stretch min-h-0 overflow-hidden">
+                <div
+                  className="w-full flex-1 min-h-0 flex flex-col"
+                  style={{ padding: '0 min(8px, 2cqmin)' }}
+                >
+                  <UnassignedTray
+                    names={unassignedDisplay}
+                    lockedNames={lockedNames}
+                    onToggleLock={handleToggleLock}
+                    onRemove={handleRemoveFromResult}
+                    alwaysVisible={
+                      unassignedDisplay.length === 0 &&
+                      isEditableMode &&
+                      lockedNames.length > 0
                     }
-                    return (
-                      <div
-                        className="flex-1 overflow-y-auto overflow-x-hidden w-full"
-                        style={{
-                          // CSS multi-column layout: browser fits as many ~200px
-                          // columns as the container allows. column-fill: auto
-                          // fills column 1 top-to-bottom, then column 2, etc. —
-                          // the column-first reading order we want for a numbered
-                          // list. Vertical overflow scrolls; breakInside on each
-                          // row keeps cards intact across column boundaries.
-                          columnWidth: 'clamp(160px, 36cqmin, 240px)',
-                          columnFill: 'auto',
-                          columnGap: 'clamp(6px, 1.5cqmin, 12px)',
-                          padding: 'clamp(2px, 1cqmin, 6px) 0',
-                        }}
-                      >
-                        {shuffleNames.map((name: string, i: number) => (
-                          <div
-                            key={i}
-                            className="flex items-center bg-white rounded-xl border border-slate-200 shadow-sm overflow-hidden"
-                            style={{
-                              gap: 'clamp(8px, 2.5cqmin, 14px)',
-                              padding:
-                                'clamp(4px, 1.2cqmin, 10px) clamp(10px, 2.5cqmin, 16px)',
-                              marginBottom: 'clamp(3px, 1cqmin, 8px)',
-                              minHeight: 'clamp(28px, 6cqmin, 48px)',
-                              breakInside: 'avoid',
-                            }}
-                          >
-                            <span
-                              className="font-mono font-black text-slate-400 flex-shrink-0 tabular-nums"
-                              style={{
-                                fontSize: 'clamp(11px, 3.2cqmin, 18px)',
-                              }}
-                            >
-                              {i + 1}
-                            </span>
-                            <span
-                              className="leading-tight font-bold text-slate-700 truncate min-w-0"
-                              style={{
-                                fontSize: 'clamp(13px, 4cqmin, 22px)',
-                              }}
-                            >
-                              {name}
-                            </span>
-                          </div>
-                        ))}
-                      </div>
-                    );
-                  })()
-                ) : (
-                  <RandomGroups
-                    displayResult={displayResult}
-                    sharedGroups={activeDashboard?.sharedGroups}
+                    emptyHint={
+                      mode === 'shuffle'
+                        ? 'Drop a student here to remove them from the list.'
+                        : 'Drop a student here to remove them from a group.'
+                    }
                   />
-                )}
+                  {mode === 'jigsaw' ? (
+                    <RandomGroups
+                      displayResult={
+                        jigsawView === 'expert'
+                          ? renderedExpertGroups
+                          : (renderedHomeGroups ?? placeholderGroups)
+                      }
+                      sharedGroups={activeDashboard?.sharedGroups}
+                      groupNamePrefix={
+                        jigsawView === 'expert' ? 'Expert Group' : 'Home Group'
+                      }
+                      editable
+                      lockedNames={lockedNames}
+                      onToggleLock={handleToggleLock}
+                      onRemove={handleRemoveFromResult}
+                    />
+                  ) : mode === 'shuffle' ? (
+                    <ShuffleList
+                      names={
+                        Array.isArray(displayResult) &&
+                        (displayResult.length === 0 ||
+                          !Array.isArray(displayResult[0])) &&
+                        (displayResult.length === 0 ||
+                          typeof displayResult[0] === 'string')
+                          ? (displayResult as string[])
+                          : []
+                      }
+                      lockedNames={lockedNames}
+                      onToggleLock={handleToggleLock}
+                      onRemove={handleRemoveFromResult}
+                    />
+                  ) : (
+                    <RandomGroups
+                      displayResult={groupsFromDisplay ?? placeholderGroups}
+                      sharedGroups={activeDashboard?.sharedGroups}
+                      editable
+                      lockedNames={lockedNames}
+                      onToggleLock={handleToggleLock}
+                      onRemove={handleRemoveFromResult}
+                    />
+                  )}
+                </div>
               </div>
-            )}
-          </div>
+            </DndContext>
+          )
         }
         footer={
           mode === 'jigsaw' && hasJigsawGroups ? (

--- a/components/widgets/random/ShuffleList.tsx
+++ b/components/widgets/random/ShuffleList.tsx
@@ -1,0 +1,137 @@
+import React from 'react';
+import { useDroppable } from '@dnd-kit/core';
+import { Layers } from 'lucide-react';
+import { StudentChip } from './StudentChip';
+
+const SHUFFLE_LIST_ZONE_ID = 'shuffle-list';
+
+interface ShuffleRowProps {
+  name: string;
+  index: number;
+  locked: boolean;
+  onToggleLock: (name: string) => void;
+  onRemove: (name: string) => void;
+}
+
+const ShuffleRow: React.FC<ShuffleRowProps> = ({
+  name,
+  index,
+  locked,
+  onToggleLock,
+  onRemove,
+}) => {
+  // Each row is a droppable insertion point. Drop on row N → insert before N.
+  // Source id of any chip rendered inside this row is `shuffle-list`, not
+  // the row id, so the drag-end handler can tell "moved within shuffle" from
+  // "moved from unassigned".
+  const dropId = `shuffle-row:${index}`;
+  const { isOver, setNodeRef } = useDroppable({ id: dropId });
+
+  return (
+    <div
+      ref={setNodeRef}
+      className={`flex items-center rounded-xl border shadow-sm overflow-hidden transition-colors ${
+        isOver
+          ? 'bg-brand-blue-light/15 border-brand-blue-primary/60'
+          : 'bg-white border-slate-200'
+      }`}
+      style={{
+        gap: 'clamp(6px, 2cqmin, 12px)',
+        padding: 'clamp(3px, 1cqmin, 8px) clamp(8px, 2cqmin, 14px)',
+        marginBottom: 'clamp(3px, 1cqmin, 8px)',
+        minHeight: 'clamp(28px, 6cqmin, 48px)',
+        breakInside: 'avoid',
+      }}
+    >
+      <span
+        className="font-mono font-black text-slate-400 flex-shrink-0 tabular-nums"
+        style={{ fontSize: 'clamp(11px, 3.2cqmin, 18px)' }}
+      >
+        {index + 1}
+      </span>
+      <StudentChip
+        name={name}
+        dragId={`chip:${SHUFFLE_LIST_ZONE_ID}:${name}`}
+        sourceZoneId={SHUFFLE_LIST_ZONE_ID}
+        locked={locked}
+        onToggleLock={onToggleLock}
+        onRemove={onRemove}
+        fontSize="clamp(12px, 3.5cqmin, 18px)"
+      />
+    </div>
+  );
+};
+
+interface ShuffleListProps {
+  names: string[];
+  lockedNames: string[];
+  onToggleLock: (name: string) => void;
+  onRemove: (name: string) => void;
+}
+
+export const ShuffleList: React.FC<ShuffleListProps> = ({
+  names,
+  lockedNames,
+  onToggleLock,
+  onRemove,
+}) => {
+  const lockedSet = React.useMemo(() => new Set(lockedNames), [lockedNames]);
+  const { isOver, setNodeRef } = useDroppable({ id: SHUFFLE_LIST_ZONE_ID });
+
+  if (names.length === 0) {
+    return (
+      <div
+        ref={setNodeRef}
+        className={`flex-1 flex flex-col items-center justify-center italic rounded-xl border border-dashed transition-colors ${
+          isOver
+            ? 'bg-brand-blue-light/10 border-brand-blue-primary/60 text-brand-blue-dark'
+            : 'text-slate-300 border-slate-200/60'
+        }`}
+        style={{
+          padding: 'min(40px, 8cqmin) 0',
+          gap: 'min(8px, 2cqmin)',
+        }}
+      >
+        <Layers
+          className="opacity-30"
+          style={{
+            width: 'min(32px, 8cqmin)',
+            height: 'min(32px, 8cqmin)',
+          }}
+        />
+        <span
+          className="font-bold text-center"
+          style={{ fontSize: 'min(14px, 3.5cqmin)' }}
+        >
+          Drag students here, or click Randomize
+        </span>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      ref={setNodeRef}
+      className={`flex-1 overflow-y-auto overflow-x-hidden w-full rounded-xl transition-colors ${
+        isOver ? 'bg-brand-blue-light/5' : ''
+      }`}
+      style={{
+        columnWidth: 'clamp(160px, 36cqmin, 240px)',
+        columnFill: 'auto',
+        columnGap: 'clamp(6px, 1.5cqmin, 12px)',
+        padding: 'clamp(2px, 1cqmin, 6px) 0',
+      }}
+    >
+      {names.map((name, i) => (
+        <ShuffleRow
+          key={`${name}-${i}`}
+          name={name}
+          index={i}
+          locked={lockedSet.has(name)}
+          onToggleLock={onToggleLock}
+          onRemove={onRemove}
+        />
+      ))}
+    </div>
+  );
+};

--- a/components/widgets/random/StudentChip.tsx
+++ b/components/widgets/random/StudentChip.tsx
@@ -1,0 +1,132 @@
+import React from 'react';
+import { Lock, LockOpen, X } from 'lucide-react';
+import { useDraggable } from '@dnd-kit/core';
+
+interface StudentChipProps {
+  name: string;
+  /** Stable id for the drag source. Format: `chip:<zoneId>:<name>`. */
+  dragId: string;
+  /** Source zone id passed through dnd-kit `data` to the drop handler. */
+  sourceZoneId: string;
+  locked: boolean;
+  onToggleLock: (name: string) => void;
+  onRemove: (name: string) => void;
+  /** Optional override for chip font sizing (used in shuffle's column layout). */
+  fontSize?: string;
+  /** When true, chip is rendered as a translucent ghost (drag source). */
+  isDragOverlay?: boolean;
+}
+
+export const StudentChip: React.FC<StudentChipProps> = ({
+  name,
+  dragId,
+  sourceZoneId,
+  locked,
+  onToggleLock,
+  onRemove,
+  fontSize,
+  isDragOverlay,
+}) => {
+  const { attributes, listeners, setNodeRef, transform, isDragging } =
+    useDraggable({
+      id: dragId,
+      data: { name, sourceZoneId },
+    });
+
+  const style: React.CSSProperties = {
+    fontSize: fontSize ?? 'clamp(11px, 4cqmin, 18px)',
+    gap: 'clamp(4px, 1.2cqmin, 8px)',
+    padding: 'clamp(2px, 0.8cqmin, 6px) clamp(6px, 1.6cqmin, 12px)',
+    transform: transform
+      ? `translate3d(${transform.x}px, ${transform.y}px, 0)`
+      : undefined,
+    touchAction: 'none',
+  };
+
+  const baseClasses = locked
+    ? 'bg-brand-blue-light/15 border border-brand-blue-primary/40 text-brand-blue-dark'
+    : 'bg-white border border-slate-200 text-slate-700 hover:border-slate-300';
+
+  const dragClasses = isDragging
+    ? 'opacity-40 grayscale cursor-grabbing'
+    : 'cursor-grab';
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      className={`group/chip inline-flex items-center rounded-lg shadow-sm font-bold leading-tight whitespace-nowrap overflow-hidden min-w-0 ${baseClasses} ${
+        isDragOverlay ? 'shadow-lg ring-2 ring-brand-blue-primary/40' : ''
+      } ${dragClasses}`}
+      {...listeners}
+      {...attributes}
+    >
+      <button
+        type="button"
+        onClick={(e) => {
+          e.stopPropagation();
+          onToggleLock(name);
+        }}
+        onPointerDown={(e) => {
+          // Stop the drag listeners from claiming this pointer down so the
+          // click reliably reaches the lock toggle.
+          e.stopPropagation();
+        }}
+        className={`shrink-0 rounded-full transition-colors ${
+          locked
+            ? 'text-brand-blue-primary hover:text-brand-blue-dark'
+            : 'text-slate-300 hover:text-slate-500'
+        }`}
+        style={{
+          padding: 'clamp(1px, 0.5cqmin, 4px)',
+        }}
+        aria-label={locked ? `Unlock ${name}` : `Lock ${name}`}
+        title={
+          locked
+            ? `Unlock ${name} (will move on Randomize)`
+            : `Lock ${name} in this group`
+        }
+      >
+        {locked ? (
+          <Lock
+            style={{
+              width: 'clamp(10px, 3cqmin, 16px)',
+              height: 'clamp(10px, 3cqmin, 16px)',
+            }}
+          />
+        ) : (
+          <LockOpen
+            style={{
+              width: 'clamp(10px, 3cqmin, 16px)',
+              height: 'clamp(10px, 3cqmin, 16px)',
+            }}
+          />
+        )}
+      </button>
+      <span className="truncate min-w-0">{name}</span>
+      <button
+        type="button"
+        onClick={(e) => {
+          e.stopPropagation();
+          onRemove(name);
+        }}
+        onPointerDown={(e) => {
+          e.stopPropagation();
+        }}
+        className="shrink-0 rounded-full text-slate-300 hover:text-brand-red-primary opacity-0 group-hover/chip:opacity-100 focus:opacity-100 transition-opacity"
+        style={{
+          padding: 'clamp(1px, 0.5cqmin, 4px)',
+        }}
+        aria-label={`Remove ${name} from groups`}
+        title={`Remove ${name} (send to Unassigned)`}
+      >
+        <X
+          style={{
+            width: 'clamp(10px, 3cqmin, 16px)',
+            height: 'clamp(10px, 3cqmin, 16px)',
+          }}
+        />
+      </button>
+    </div>
+  );
+};

--- a/components/widgets/random/UnassignedTray.tsx
+++ b/components/widgets/random/UnassignedTray.tsx
@@ -1,0 +1,88 @@
+import React from 'react';
+import { useDroppable } from '@dnd-kit/core';
+import { UserMinus } from 'lucide-react';
+import { StudentChip } from './StudentChip';
+import { UNASSIGNED_ZONE_ID } from './randomEditHelpers';
+
+interface UnassignedTrayProps {
+  names: string[];
+  lockedNames: string[];
+  onToggleLock: (name: string) => void;
+  onRemove: (name: string) => void;
+  /** Hint text shown when the tray is empty but still rendered (e.g. drop target). */
+  emptyHint?: string;
+  /** When true, render an empty tray as a drop hint (used while dragging). */
+  alwaysVisible?: boolean;
+}
+
+export const UnassignedTray: React.FC<UnassignedTrayProps> = ({
+  names,
+  lockedNames,
+  onToggleLock,
+  onRemove,
+  emptyHint,
+  alwaysVisible,
+}) => {
+  const { isOver, setNodeRef } = useDroppable({ id: UNASSIGNED_ZONE_ID });
+  const lockedSet = new Set(lockedNames);
+
+  if (names.length === 0 && !alwaysVisible) return null;
+
+  return (
+    <div
+      ref={setNodeRef}
+      className={`w-full rounded-xl border border-dashed transition-colors ${
+        isOver
+          ? 'bg-brand-blue-light/10 border-brand-blue-primary/60'
+          : 'bg-slate-50/60 border-slate-300/70'
+      }`}
+      style={{
+        padding: 'clamp(6px, 1.5cqmin, 12px) clamp(8px, 2cqmin, 16px)',
+        marginBottom: 'clamp(4px, 1cqmin, 10px)',
+      }}
+    >
+      <div
+        className="flex items-center text-slate-500 uppercase tracking-widest font-black"
+        style={{
+          fontSize: 'clamp(9px, 2.6cqmin, 13px)',
+          gap: 'clamp(4px, 1cqmin, 8px)',
+          marginBottom:
+            names.length > 0 ? 'clamp(4px, 1cqmin, 8px)' : undefined,
+        }}
+      >
+        <UserMinus
+          style={{
+            width: 'clamp(10px, 2.8cqmin, 14px)',
+            height: 'clamp(10px, 2.8cqmin, 14px)',
+          }}
+        />
+        <span>Unassigned{names.length > 0 ? ` (${names.length})` : ''}</span>
+      </div>
+      {names.length === 0 ? (
+        <div
+          className="italic text-slate-400"
+          style={{ fontSize: 'clamp(10px, 2.8cqmin, 13px)' }}
+        >
+          {emptyHint ?? 'Drop a student here to remove them from a group.'}
+        </div>
+      ) : (
+        <div
+          className="flex flex-wrap"
+          style={{ gap: 'clamp(4px, 1.2cqmin, 10px)' }}
+        >
+          {names.map((name) => (
+            <StudentChip
+              key={name}
+              name={name}
+              dragId={`chip:${UNASSIGNED_ZONE_ID}:${name}`}
+              sourceZoneId={UNASSIGNED_ZONE_ID}
+              locked={lockedSet.has(name)}
+              onToggleLock={onToggleLock}
+              onRemove={onRemove}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/components/widgets/random/randomEditHelpers.test.ts
+++ b/components/widgets/random/randomEditHelpers.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect } from 'vitest';
+import {
+  UNASSIGNED_ZONE_ID,
+  toggleLockedName,
+  clearLockedNames,
+  moveNameToGroup,
+  mergeLockedWithFresh,
+  shuffleWithLocks,
+  findGroupIdForName,
+  collectGroupNames,
+} from './randomEditHelpers';
+import type { RandomGroup } from '@/types';
+
+const makeGroups = (data: Record<string, string[]>): RandomGroup[] =>
+  Object.entries(data).map(([id, names]) => ({ id, names }));
+
+describe('toggleLockedName', () => {
+  it('adds a name when not present', () => {
+    expect(toggleLockedName([], 'Alice')).toEqual(['Alice']);
+    expect(toggleLockedName(['Bob'], 'Alice')).toEqual(['Bob', 'Alice']);
+  });
+
+  it('removes a name when present', () => {
+    expect(toggleLockedName(['Alice', 'Bob'], 'Alice')).toEqual(['Bob']);
+  });
+
+  it('treats undefined as empty', () => {
+    expect(toggleLockedName(undefined, 'Alice')).toEqual(['Alice']);
+  });
+});
+
+describe('clearLockedNames', () => {
+  it('removes the requested names', () => {
+    expect(clearLockedNames(['Alice', 'Bob', 'Carol'], ['Bob'])).toEqual([
+      'Alice',
+      'Carol',
+    ]);
+  });
+
+  it('returns empty for missing input', () => {
+    expect(clearLockedNames(undefined, ['Alice'])).toEqual([]);
+    expect(clearLockedNames([], ['Alice'])).toEqual([]);
+  });
+});
+
+describe('moveNameToGroup', () => {
+  it('moves a name from one group to another', () => {
+    const groups = makeGroups({ A: ['Alice', 'Bob'], B: ['Carol'] });
+    const next = moveNameToGroup(groups, 'Alice', 'B');
+    expect(next).toEqual([
+      { id: 'A', names: ['Bob'] },
+      { id: 'B', names: ['Carol', 'Alice'] },
+    ]);
+  });
+
+  it('removes a name when target is the unassigned zone', () => {
+    const groups = makeGroups({ A: ['Alice', 'Bob'] });
+    const next = moveNameToGroup(groups, 'Alice', UNASSIGNED_ZONE_ID);
+    expect(next).toEqual([{ id: 'A', names: ['Bob'] }]);
+  });
+
+  it('dedupes when target already contains the name', () => {
+    const groups = makeGroups({ A: ['Alice'], B: ['Alice'] });
+    const next = moveNameToGroup(groups, 'Alice', 'B');
+    expect(next).toEqual([
+      { id: 'A', names: [] },
+      { id: 'B', names: ['Alice'] },
+    ]);
+  });
+});
+
+describe('findGroupIdForName', () => {
+  it('returns the id of the holding group', () => {
+    const groups = makeGroups({ A: ['Alice'], B: ['Bob'] });
+    expect(findGroupIdForName(groups, 'Bob')).toBe('B');
+  });
+
+  it('returns null when not found', () => {
+    expect(findGroupIdForName(makeGroups({ A: ['Alice'] }), 'Bob')).toBeNull();
+    expect(findGroupIdForName(null, 'Bob')).toBeNull();
+  });
+});
+
+describe('collectGroupNames', () => {
+  it('flattens names across groups in order', () => {
+    const groups = makeGroups({ A: ['Alice', 'Bob'], B: ['Carol'] });
+    expect(collectGroupNames(groups)).toEqual(['Alice', 'Bob', 'Carol']);
+  });
+});
+
+describe('mergeLockedWithFresh', () => {
+  it('keeps locked names in their groups and fills with fresh', () => {
+    const currentGroups = makeGroups({
+      A: ['Alice', 'Bob'],
+      B: ['Carol', 'Dave'],
+    });
+    const freshGroups = makeGroups({
+      X: ['Eve', 'Frank'],
+      Y: ['Grace', 'Heidi'],
+    });
+    const merged = mergeLockedWithFresh({
+      currentGroups,
+      lockedNames: ['Alice', 'Dave'],
+      freshGroups,
+    });
+    expect(merged).toEqual([
+      { id: 'A', names: ['Alice', 'Eve', 'Frank'] },
+      { id: 'B', names: ['Dave', 'Grace', 'Heidi'] },
+    ]);
+  });
+
+  it('preserves group ids so dashboard links survive', () => {
+    const currentGroups = makeGroups({ G1: ['Alice'] });
+    const freshGroups = makeGroups({ X: ['Bob'] });
+    const merged = mergeLockedWithFresh({
+      currentGroups,
+      lockedNames: ['Alice'],
+      freshGroups,
+    });
+    expect(merged[0].id).toBe('G1');
+  });
+
+  it('handles missing fresh groups (fewer fresh than skeleton)', () => {
+    const currentGroups = makeGroups({
+      A: ['Alice'],
+      B: ['Bob'],
+      C: ['Carol'],
+    });
+    const freshGroups = makeGroups({ X: ['Eve'] });
+    const merged = mergeLockedWithFresh({
+      currentGroups,
+      lockedNames: ['Alice', 'Bob', 'Carol'],
+      freshGroups,
+    });
+    // Locked names preserved, fresh distributed by index, empty otherwise
+    expect(merged).toEqual([
+      { id: 'A', names: ['Alice', 'Eve'] },
+      { id: 'B', names: ['Bob'] },
+      { id: 'C', names: ['Carol'] },
+    ]);
+  });
+});
+
+describe('shuffleWithLocks', () => {
+  it('keeps locked names at their original indices', () => {
+    const current = ['Alice', 'Bob', 'Carol', 'Dave'];
+    const shuffled = shuffleWithLocks(current, ['Bob', 'Dave']);
+    expect(shuffled[1]).toBe('Bob');
+    expect(shuffled[3]).toBe('Dave');
+    // Same name set
+    expect([...shuffled].sort()).toEqual([...current].sort());
+  });
+
+  it('reshuffles only unlocked positions', () => {
+    // With every name locked, the shuffle is a no-op.
+    const current = ['Alice', 'Bob', 'Carol'];
+    expect(shuffleWithLocks(current, ['Alice', 'Bob', 'Carol'])).toEqual(
+      current
+    );
+  });
+
+  it('handles empty input', () => {
+    expect(shuffleWithLocks([], [])).toEqual([]);
+  });
+
+  it('produces no holes when no names are locked', () => {
+    const current = ['A', 'B', 'C', 'D'];
+    const next = shuffleWithLocks(current, []);
+    expect(next).toHaveLength(4);
+    expect([...next].sort()).toEqual([...current].sort());
+  });
+});

--- a/components/widgets/random/randomEditHelpers.ts
+++ b/components/widgets/random/randomEditHelpers.ts
@@ -1,0 +1,144 @@
+import { RandomGroup } from '@/types';
+
+export const UNASSIGNED_ZONE_ID = '__unassigned__';
+
+/** Append a name to a group, deduping (drag from same group → no-op). */
+function appendToGroup(group: RandomGroup, name: string): RandomGroup {
+  if (group.names.includes(name)) return group;
+  return { ...group, names: [...group.names, name] };
+}
+
+/** Remove a name from a group's `names` array. */
+function removeFromGroup(group: RandomGroup, name: string): RandomGroup {
+  if (!group.names.includes(name)) return group;
+  return { ...group, names: group.names.filter((n) => n !== name) };
+}
+
+/** Find the group id that currently holds `name`, or null if unassigned. */
+export function findGroupIdForName(
+  groups: RandomGroup[] | null | undefined,
+  name: string
+): string | null {
+  if (!groups) return null;
+  for (const g of groups) {
+    if (g.names.includes(name)) return g.id ?? null;
+  }
+  return null;
+}
+
+/**
+ * Move a name into the target zone, removing it from any other group.
+ * `targetGroupId === UNASSIGNED_ZONE_ID` means the unassigned tray; the
+ * unassigned list is managed separately, so for that case we just drop the
+ * name from its current group and let the caller union it into `unassigned`.
+ */
+export function moveNameToGroup(
+  groups: RandomGroup[],
+  name: string,
+  targetGroupId: string
+): RandomGroup[] {
+  const cleaned = groups.map((g) => removeFromGroup(g, name));
+  if (targetGroupId === UNASSIGNED_ZONE_ID) return cleaned;
+  return cleaned.map((g) =>
+    g.id === targetGroupId ? appendToGroup(g, name) : g
+  );
+}
+
+/** Toggle membership of `name` in `lockedNames`. */
+export function toggleLockedName(
+  lockedNames: string[] | undefined,
+  name: string
+): string[] {
+  const current = lockedNames ?? [];
+  return current.includes(name)
+    ? current.filter((n) => n !== name)
+    : [...current, name];
+}
+
+/** Remove names from `lockedNames` (e.g. when a student is sent to the tray). */
+export function clearLockedNames(
+  lockedNames: string[] | undefined,
+  names: string[]
+): string[] {
+  if (!lockedNames || lockedNames.length === 0) return [];
+  const drop = new Set(names);
+  return lockedNames.filter((n) => !drop.has(n));
+}
+
+export interface RebalanceArgs {
+  /** Existing groups whose ids/order are preserved. Locked names stay put. */
+  currentGroups: RandomGroup[];
+  /** Names that should stay in their current group. */
+  lockedNames: string[];
+  /** Freshly generated groups containing the unlocked pool. */
+  freshGroups: RandomGroup[];
+}
+
+/**
+ * Merge freshly randomized unlocked-students into the existing group
+ * skeleton, keeping locked names in their original groups (and preserving
+ * each group's `id` so dashboard.sharedGroups / Scoreboard linkages hold).
+ *
+ * Strategy: for each existing group, keep only its locked names. Then
+ * distribute the names from `freshGroups[i]` into existing group `i`,
+ * padding by index. If `freshGroups` has fewer groups than `currentGroups`
+ * (e.g. all students were locked) any unmatched current groups just keep
+ * their locked-only contents.
+ */
+export function mergeLockedWithFresh({
+  currentGroups,
+  lockedNames,
+  freshGroups,
+}: RebalanceArgs): RandomGroup[] {
+  const lockedSet = new Set(lockedNames);
+  return currentGroups.map((g, i) => {
+    const kept = g.names.filter((n) => lockedSet.has(n));
+    const fresh = freshGroups[i]?.names ?? [];
+    // Dedupe: if a fresh name somehow matches a locked name (shouldn't,
+    // since the caller excludes locked from the pool) keep the locked-side
+    // appearance.
+    const deduped = fresh.filter((n) => !kept.includes(n));
+    return { ...g, names: [...kept, ...deduped] };
+  });
+}
+
+/**
+ * Shuffle re-randomize that preserves locked indices. Locked names keep
+ * their position; unlocked names get shuffled among the remaining slots.
+ */
+export function shuffleWithLocks(
+  current: string[],
+  lockedNames: string[]
+): string[] {
+  const lockedSet = new Set(lockedNames);
+  const lockedSlots = new Map<number, string>();
+  const unlocked: string[] = [];
+  current.forEach((name, i) => {
+    if (lockedSet.has(name)) {
+      lockedSlots.set(i, name);
+    } else {
+      unlocked.push(name);
+    }
+  });
+  for (let i = unlocked.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [unlocked[i], unlocked[j]] = [unlocked[j], unlocked[i]];
+  }
+  const result: string[] = [];
+  let unlockedIdx = 0;
+  for (let i = 0; i < current.length; i++) {
+    if (lockedSlots.has(i)) {
+      result.push(lockedSlots.get(i) as string);
+    } else {
+      result.push(unlocked[unlockedIdx++]);
+    }
+  }
+  return result;
+}
+
+/** Collect all names currently appearing across a list of groups. */
+export function collectGroupNames(groups: RandomGroup[]): string[] {
+  const out: string[] = [];
+  for (const g of groups) out.push(...g.names);
+  return out;
+}

--- a/types.ts
+++ b/types.ts
@@ -1040,6 +1040,14 @@ export interface RandomConfig {
    *  `makeRestrictedGroupsByCount` (greedy smallest-safe-bucket) for
    *  class mode where restriction-aware placement matters. */
   numHomeGroups?: number;
+  /** Manual editing: names pinned to their current group/index. Locked names
+   *  stay put when Randomize is hit again; other students reshuffle around
+   *  them. Can still be moved manually by drag. */
+  lockedNames?: string[];
+  /** Manual editing: names removed from the result and parked in the
+   *  Unassigned tray. Excluded from re-randomize until dragged back into a
+   *  group/list. */
+  unassignedNames?: string[];
 }
 
 export interface DiceConfig {


### PR DESCRIPTION
## Summary

Teachers can now tweak randomizer output instead of rerunning until they get an acceptable split.

- **Drag chips between groups** (or to/from a new **Unassigned** tray) in shuffle, groups, and jigsaw modes — both home and expert views.
- **Lock icon** on each chip pins a student to their current group/index when Randomize is hit again; the rest reshuffle around them. Manual drag still works on locked chips.
- **Remove icon** sends a student to the Unassigned tray, where they sit out future re-randomizes until dragged back.
- Empty groups render as drop placeholders so manual creation from scratch works without a first Randomize.

Lock-aware re-randomize lives in `handlePick`: it regenerates only the unlocked pool and merges into the existing group skeleton via `mergeLockedWithFresh`, preserving each group's id so `dashboard.sharedGroups` and Scoreboard linkages survive. Shuffle uses `shuffleWithLocks` to keep locked indices fixed.

Mode cycling, reset, and roster swap all clear `lockedNames` / `unassignedNames` to avoid stale state carrying into a different class.

### Files

- `types.ts` — added `lockedNames?` and `unassignedNames?` to `RandomConfig`.
- `components/widgets/random/RandomWidget.tsx` — DnD context, edit handlers, lock-aware re-randomize, empty-state, roster/mode/reset cleanup.
- `components/widgets/random/RandomGroups.tsx` — editable mode with droppable group cards + draggable chips.
- New: `StudentChip.tsx`, `UnassignedTray.tsx`, `ShuffleList.tsx`, `randomEditHelpers.ts` (+ tests).

## Test plan

- [x] `pnpm run validate` — type-check, lint (zero warnings), format, 2412/2412 unit tests pass.
- [x] New unit tests for `randomEditHelpers`: 18/18 pass (lock toggle, move-to-group, merge-locked-with-fresh keeps group ids, shuffle-with-locks preserves locked indices).
- [ ] Manual smoke: groups mode — randomize, lock two students, re-randomize → locked pair stays in same group while others reshuffle.
- [ ] Manual smoke: drag a student from group 1 to group 3 → persists after refresh.
- [ ] Manual smoke: click remove → student appears in Unassigned tray, can be dragged back into any group.
- [ ] Manual smoke: jigsaw — lock in home, switch to expert, Randomize → home stickiness holds, expert redistributes.
- [ ] Manual smoke: shuffle — lock student at index 3, randomize → stays at index 3.
- [ ] Manual smoke: empty state — drag students from tray into empty groups; verify state survives refresh.
- [ ] Manual smoke: Scoreboard — send manually edited groups; team names update to reflect edits.

https://claude.ai/code/session_01B3uGuMJJPp5ns2PTC6SL61

---
_Generated by [Claude Code](https://claude.ai/code/session_01B3uGuMJJPp5ns2PTC6SL61)_