### PR TITLE
feat(drive-auth): backend refresh-token flow + reconnect signal

### DIFF
--- a/components/layout/sidebar/SidebarBackgrounds.tsx
+++ b/components/layout/sidebar/SidebarBackgrounds.tsx
@@ -15,6 +15,7 @@ import {
 } from 'lucide-react';
 import { useBackgrounds } from '@/hooks/useBackgrounds';
 import { useGoogleDrive } from '@/hooks/useGoogleDrive';
+import { useDriveReconnected } from '@/hooks/useDriveReconnected';
 import { useDashboard } from '@/context/useDashboard';
 import { extractYouTubeId } from '@/utils/youtube';
 import { isCustomBackground } from '@/utils/backgrounds';
@@ -215,6 +216,15 @@ export const SidebarBackgrounds: React.FC<SidebarBackgroundsProps> = ({
     getUserBackgroundsFromDrive,
     addToast,
   ]);
+
+  // After a Drive reconnect (toast "Connect" or sidebar "Refresh"), clear
+  // the one-shot fetch latch so the next "My Uploads" tab visit re-pulls
+  // from Drive. Without this, a failed initial fetch leaves
+  // `hasFetchedDrive=true` and the panel keeps showing whatever it
+  // managed to load (often nothing) even after the token comes back.
+  useDriveReconnected(() => {
+    setHasFetchedDrive(false);
+  });
 
   const handleFileUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];

--- a/context/AuthContext.tsx
+++ b/context/AuthContext.tsx
@@ -52,6 +52,12 @@ import {
 } from '../config/buildings';
 import i18n from '../i18n';
 import { GoogleDriveService } from '../utils/googleDriveService';
+import { onDriveTokenChange } from '../utils/driveAuthErrors';
+import {
+  refreshAccessTokenViaBackend,
+  requestAndExchangeAuthCode,
+  revokeBackendRefreshToken,
+} from '../utils/googleOAuthRefresh';
 import { stripTransientKeys } from '../utils/widgetConfigPersistence';
 import { parseAssignmentModesConfig } from '../utils/assignmentModesConfig';
 import {
@@ -391,18 +397,65 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
 
         // GIS succeeded — return immediately.
         if (gisToken) return gisToken;
-
-        // GIS failed (e.g. domain not in authorized JavaScript origins).
-        // For silent background refreshes, give up here to avoid unexpected popups.
-        // For explicit user-triggered reconnects (silent=false), fall through to
-        // the Firebase popup below, which uses the already-authorized Firebase
-        // OAuth client and avoids redirect_uri_mismatch errors.
-        if (silent) return null;
       }
 
-      // Fallback: re-run Firebase popup sign-in to get a fresh access token.
-      // Skip when called silently (e.g. from the background interval) — browsers
-      // block popups that are not triggered by a direct user gesture.
+      // Phase-B fallback BEFORE the Firebase popup: ask the backend for a
+      // fresh access_token using the user's stored refresh_token. This is
+      // what makes Drive auth survive the user's Google session expiring
+      // (closed browser, signed out of Google in another tab, etc.) — the
+      // refresh_token lives server-side and isn't tied to the browser's
+      // Google session at all. Safe to attempt in silent mode because the
+      // callable runs without any UI surface.
+      const backendOutcome = await refreshAccessTokenViaBackend();
+      if (backendOutcome.status === 'ok') {
+        const expiryMs = Date.now() + (backendOutcome.expiresIn || 3600) * 1000;
+        localStorage.setItem(GOOGLE_ACCESS_TOKEN_KEY, backendOutcome.token);
+        localStorage.setItem(GOOGLE_TOKEN_EXPIRY_KEY, expiryMs.toString());
+        setGoogleAccessToken(backendOutcome.token);
+        return backendOutcome.token;
+      }
+
+      // Backend reported the refresh_token is missing or revoked. For a
+      // user-triggered (non-silent) call we can escalate to the auth-code
+      // flow, which captures a fresh refresh_token via GIS popup. Silent
+      // calls bail rather than popping unexpected consent dialogs.
+      if (backendOutcome.status === 'needs-consent' && !silent) {
+        const clientId = import.meta.env.VITE_GOOGLE_CLIENT_ID as
+          | string
+          | undefined;
+        if (clientId) {
+          try {
+            const exchanged = await requestAndExchangeAuthCode(
+              clientId,
+              email ?? undefined
+            );
+            if (exchanged?.accessToken) {
+              const expiryMs =
+                Date.now() + (exchanged.expiresIn || 3600) * 1000;
+              localStorage.setItem(
+                GOOGLE_ACCESS_TOKEN_KEY,
+                exchanged.accessToken
+              );
+              localStorage.setItem(
+                GOOGLE_TOKEN_EXPIRY_KEY,
+                expiryMs.toString()
+              );
+              setGoogleAccessToken(exchanged.accessToken);
+              return exchanged.accessToken;
+            }
+          } catch (err) {
+            console.warn(
+              '[AuthContext] Auth-code re-consent flow failed; falling back to Firebase popup:',
+              err
+            );
+          }
+        }
+      }
+
+      // For silent background refreshes, give up here to avoid unexpected popups.
+      // For explicit user-triggered reconnects (silent=false), fall through to
+      // the Firebase popup below, which uses the already-authorized Firebase
+      // OAuth client and avoids redirect_uri_mismatch errors.
       if (silent) return null;
 
       try {
@@ -526,6 +579,12 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
     localStorage.removeItem(GOOGLE_ACCESS_TOKEN_KEY);
     localStorage.removeItem(GOOGLE_TOKEN_EXPIRY_KEY);
     setGoogleAccessToken(null);
+    // Also revoke + drop the server-side refresh_token. Fire-and-forget:
+    // the local state change above is the load-bearing UX signal, and the
+    // helper logs failures rather than throwing. Without this, "Disconnect"
+    // would only clear the client token while the backend would silently
+    // reconnect the user on the next refresh attempt.
+    void revokeBackendRefreshToken();
   }, []);
 
   // Persist googleAccessToken to localStorage
@@ -536,6 +595,18 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
     } else {
       localStorage.removeItem(GOOGLE_ACCESS_TOKEN_KEY);
     }
+  }, [googleAccessToken]);
+
+  // Broadcast token rotations to any subscriber that needs to refetch.
+  //
+  // Lives in AuthContext (the source of truth for `googleAccessToken`)
+  // rather than relying on `useGoogleDrive` to fan it out — that hook is
+  // only mounted inside DashboardProvider, so widgets/hooks that read the
+  // token directly from AuthContext would otherwise miss the signal.
+  // `onDriveTokenChange` deduplicates on `lastSeenToken`, so the parallel
+  // call from `useGoogleDrive` is a harmless no-op once we fire first.
+  useEffect(() => {
+    onDriveTokenChange(googleAccessToken);
   }, [googleAccessToken]);
 
   // Listen to user roles + app settings.

--- a/context/DashboardContext.tsx
+++ b/context/DashboardContext.tsx
@@ -56,6 +56,7 @@ import {
 } from '../utils/dashboardPII';
 import { useRosters } from '../hooks/useRosters';
 import { useGoogleDrive } from '../hooks/useGoogleDrive';
+import { useDriveReconnected } from '../hooks/useDriveReconnected';
 import { setDriveAuthErrorHandler } from '../utils/driveAuthErrors';
 import {
   setAiModelConfigFallbackHandler,
@@ -2107,6 +2108,15 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
   // names (PII) from the Drive PII supplement file. Firestore only stores the
   // scrubbed version; Drive is the authoritative source of PII fields.
   const lastPiiRestoredIdRef = useRef<string | null>(null);
+
+  // After a Drive reconnect, clear the one-shot latch so a previously-failed
+  // PII restore retries with the fresh token. Otherwise a teacher who saw
+  // their custom widget names disappear (scrubbed Firestore copy with no
+  // PII supplement loaded) keeps seeing the scrubbed version until they
+  // switch dashboards and back. Mirrors the reset in SidebarBackgrounds.
+  useDriveReconnected(() => {
+    lastPiiRestoredIdRef.current = null;
+  });
 
   useEffect(() => {
     if (!driveService || !activeId || loading) return;

--- a/firestore.rules
+++ b/firestore.rules
@@ -527,6 +527,18 @@ service cloud.firestore {
       allow read, write: if request.auth != null && request.auth.uid == userId;
     }
 
+    // Private server-managed credentials (e.g. encrypted Google OAuth
+    // refresh_token written by `exchangeGoogleAuthCode` and read by
+    // `refreshGoogleAccessToken`). DENY ALL client access — the Admin SDK
+    // from Cloud Functions bypasses rules and is the only path that
+    // should read or write here. Default-deny would cover this too, but
+    // an explicit rule documents the intent and protects against any
+    // future permissive `users/{userId}/{document=**}` rule accidentally
+    // exposing the refresh_token.
+    match /users/{userId}/private/{document=**} {
+      allow read, write: if false;
+    }
+
     // Starter Packs
     match /artifacts/{appId}/public/data/starterPacks/{packId} {
       allow read: if request.auth != null;

--- a/functions/src/googleOAuth.ts
+++ b/functions/src/googleOAuth.ts
@@ -223,10 +223,28 @@ export const refreshGoogleAccessToken = onCall(
       );
     }
     const stored = snap.data() as StoredGoogleAuth;
-    const refreshToken = decryptRefreshToken(
-      stored.encryptedRefreshToken,
-      GOOGLE_OAUTH_REFRESH_TOKEN_KEY.value()
-    );
+    let refreshToken: string;
+    try {
+      refreshToken = decryptRefreshToken(
+        stored.encryptedRefreshToken,
+        GOOGLE_OAUTH_REFRESH_TOKEN_KEY.value()
+      );
+    } catch (err) {
+      // Decryption failed — the most likely cause is rotation of
+      // GOOGLE_OAUTH_REFRESH_TOKEN_KEY, which makes every previously-stored
+      // ciphertext undecryptable. Drop the stored doc and signal
+      // needs-consent so the client routes the user through the
+      // auth-code flow instead of looping on a useless popup retry.
+      console.warn(
+        '[refreshGoogleAccessToken] Failed to decrypt stored refresh token; dropping doc and prompting re-consent.',
+        err
+      );
+      await ref.delete().catch(() => undefined);
+      throw new HttpsError(
+        'failed-precondition',
+        'needs-consent: stored refresh token could not be decrypted (key may have rotated).'
+      );
+    }
 
     try {
       const res = await axios.post<GoogleTokenResponse>(

--- a/functions/src/googleOAuth.ts
+++ b/functions/src/googleOAuth.ts
@@ -1,0 +1,311 @@
+/**
+ * Server-side Google OAuth refresh-token flow.
+ *
+ * Phase A — toast "Connect" + sidebar "Refresh" only refresh the
+ * client-side access_token via GIS silent refresh, which fails the moment
+ * the user's Google browser session expires. The user then sees the
+ * disconnect banner and has to re-consent, which is the maddening
+ * frequency the teacher complaint describes.
+ *
+ * Phase B (this module) — at sign-in time, the client captures a Google
+ * **authorization code** via the GIS code flow with `access_type=offline`.
+ * `exchangeGoogleAuthCode` swaps that code for an access_token + a
+ * long-lived refresh_token. The refresh_token is encrypted with an
+ * application-managed secret and stored at
+ * `/users/{uid}/private/googleAuth` (Firestore rules deny all client
+ * reads/writes — only Admin SDK from this function touches it).
+ *
+ * From then on, `refreshGoogleAccessToken` is the resilient fallback
+ * for the client's `refreshGoogleToken` helper: GIS silent first
+ * (instant, free), then this callable (survives Google-session
+ * expiry), then the Firebase popup (last resort when the refresh_token
+ * is itself revoked).
+ *
+ * Security:
+ * - The refresh_token NEVER leaves the server. Even the client
+ *   doesn't see it after the initial exchange.
+ * - The encryption secret (`GOOGLE_OAUTH_REFRESH_TOKEN_KEY`) is a
+ *   Cloud-Functions-managed secret, distinct from
+ *   `GOOGLE_OAUTH_CLIENT_SECRET`. Rotating either is a separate
+ *   operational concern.
+ * - `invalid_grant` from Google (revoked grant) deletes the stored
+ *   refresh_token and signals the client to re-consent rather than
+ *   loop on a dead token.
+ */
+
+import { onCall, HttpsError } from 'firebase-functions/v2/https';
+import { defineSecret } from 'firebase-functions/params';
+import * as admin from 'firebase-admin';
+import * as CryptoJS from 'crypto-js';
+import axios, { AxiosError } from 'axios';
+
+if (!admin.apps.length) {
+  admin.initializeApp();
+}
+
+// Google's standard OAuth 2.0 token endpoint.
+const GOOGLE_TOKEN_ENDPOINT = 'https://oauth2.googleapis.com/token';
+
+// Where the encrypted refresh_token lives. Firestore rules MUST deny
+// client read/write on this path — see firestore.rules `/users/{uid}/private/**`.
+const PRIVATE_DOC_PATH = (uid: string) =>
+  `users/${uid}/private/googleAuth` as const;
+
+// Cloud Functions secrets. `_CLIENT_ID` already exists for other flows; the
+// `_CLIENT_SECRET` and `_REFRESH_TOKEN_KEY` are new — both need to be set via
+// `firebase functions:secrets:set` before deploying.
+const GOOGLE_OAUTH_CLIENT_ID = defineSecret('GOOGLE_OAUTH_CLIENT_ID');
+const GOOGLE_OAUTH_CLIENT_SECRET = defineSecret('GOOGLE_OAUTH_CLIENT_SECRET');
+const GOOGLE_OAUTH_REFRESH_TOKEN_KEY = defineSecret(
+  'GOOGLE_OAUTH_REFRESH_TOKEN_KEY'
+);
+
+interface GoogleTokenResponse {
+  access_token: string;
+  expires_in: number;
+  refresh_token?: string;
+  scope: string;
+  token_type: string;
+}
+
+interface StoredGoogleAuth {
+  /** AES-encrypted refresh_token. Plaintext NEVER persisted. */
+  encryptedRefreshToken: string;
+  /** ISO timestamp of last successful refresh — diagnostic, not load-bearing. */
+  updatedAt: string;
+  /** Scope string Google returned at the last exchange. */
+  scope: string;
+}
+
+/** AES-256 encrypt with the function-managed secret. */
+function encryptRefreshToken(plaintext: string, key: string): string {
+  return CryptoJS.AES.encrypt(plaintext, key).toString();
+}
+
+/** AES-256 decrypt with the function-managed secret. */
+function decryptRefreshToken(ciphertext: string, key: string): string {
+  const decrypted = CryptoJS.AES.decrypt(ciphertext, key).toString(
+    CryptoJS.enc.Utf8
+  );
+  if (!decrypted) {
+    throw new HttpsError(
+      'internal',
+      'Failed to decrypt stored refresh token. The encryption key may have rotated.'
+    );
+  }
+  return decrypted;
+}
+
+function requireAuthUid(authUid: string | undefined): string {
+  if (!authUid) {
+    throw new HttpsError(
+      'unauthenticated',
+      'Must be signed in to manage Google OAuth state.'
+    );
+  }
+  return authUid;
+}
+
+/**
+ * Exchange a Google authorization code for tokens, then persist the
+ * refresh_token. Called once at sign-in (and again any time the user
+ * re-consents after a revocation).
+ *
+ * Inputs:
+ * - `code` — the authorization code from `google.accounts.oauth2.initCodeClient`
+ * - `redirectUri` — must match the redirect_uri the client passed when
+ *   requesting the code (Google enforces strict equality)
+ *
+ * Returns the access_token + expires_in so the client can use it
+ * immediately without a second round-trip.
+ */
+export const exchangeGoogleAuthCode = onCall(
+  {
+    secrets: [
+      GOOGLE_OAUTH_CLIENT_ID,
+      GOOGLE_OAUTH_CLIENT_SECRET,
+      GOOGLE_OAUTH_REFRESH_TOKEN_KEY,
+    ],
+  },
+  async (req) => {
+    const uid = requireAuthUid(req.auth?.uid);
+    const raw = (req.data ?? {}) as Record<string, unknown>;
+    const code = typeof raw.code === 'string' ? raw.code : '';
+    const redirectUri =
+      typeof raw.redirectUri === 'string' ? raw.redirectUri : '';
+    if (!code) {
+      throw new HttpsError('invalid-argument', 'code is required.');
+    }
+    if (!redirectUri) {
+      throw new HttpsError('invalid-argument', 'redirectUri is required.');
+    }
+
+    let tokens: GoogleTokenResponse;
+    try {
+      const res = await axios.post<GoogleTokenResponse>(
+        GOOGLE_TOKEN_ENDPOINT,
+        new URLSearchParams({
+          code,
+          client_id: GOOGLE_OAUTH_CLIENT_ID.value(),
+          client_secret: GOOGLE_OAUTH_CLIENT_SECRET.value(),
+          redirect_uri: redirectUri,
+          grant_type: 'authorization_code',
+        }).toString(),
+        { headers: { 'Content-Type': 'application/x-www-form-urlencoded' } }
+      );
+      tokens = res.data;
+    } catch (err) {
+      const axiosErr = err as AxiosError<{ error?: string }>;
+      const googleErr = axiosErr.response?.data?.error ?? axiosErr.message;
+      throw new HttpsError(
+        'failed-precondition',
+        `Google token exchange failed: ${googleErr}`
+      );
+    }
+
+    if (!tokens.access_token) {
+      throw new HttpsError(
+        'failed-precondition',
+        'Google did not return an access_token. Re-consent may be required.'
+      );
+    }
+
+    // Google only issues a refresh_token on the FIRST consent (or when
+    // `prompt=consent` is forced). If we don't get one, leave the
+    // existing stored token in place (if any) — this exchange was a
+    // re-authorization that doesn't re-issue the refresh leg.
+    if (tokens.refresh_token) {
+      const encrypted = encryptRefreshToken(
+        tokens.refresh_token,
+        GOOGLE_OAUTH_REFRESH_TOKEN_KEY.value()
+      );
+      const stored: StoredGoogleAuth = {
+        encryptedRefreshToken: encrypted,
+        updatedAt: new Date().toISOString(),
+        scope: tokens.scope ?? '',
+      };
+      await admin.firestore().doc(PRIVATE_DOC_PATH(uid)).set(stored);
+    }
+
+    return {
+      accessToken: tokens.access_token,
+      expiresIn: tokens.expires_in,
+      hasRefreshToken: Boolean(tokens.refresh_token),
+    };
+  }
+);
+
+/**
+ * Exchange the stored refresh_token for a fresh access_token.
+ *
+ * Returns `{ accessToken, expiresIn }` on success.
+ * Throws `failed-precondition` with code `needs-consent` if no refresh
+ * token is stored or Google returns `invalid_grant` (revoked) — the
+ * client should then route the user through the auth-code flow again.
+ */
+export const refreshGoogleAccessToken = onCall(
+  {
+    secrets: [
+      GOOGLE_OAUTH_CLIENT_ID,
+      GOOGLE_OAUTH_CLIENT_SECRET,
+      GOOGLE_OAUTH_REFRESH_TOKEN_KEY,
+    ],
+  },
+  async (req) => {
+    const uid = requireAuthUid(req.auth?.uid);
+    const db = admin.firestore();
+    const ref = db.doc(PRIVATE_DOC_PATH(uid));
+    const snap = await ref.get();
+    if (!snap.exists) {
+      throw new HttpsError(
+        'failed-precondition',
+        'needs-consent: no refresh token stored for this user.'
+      );
+    }
+    const stored = snap.data() as StoredGoogleAuth;
+    const refreshToken = decryptRefreshToken(
+      stored.encryptedRefreshToken,
+      GOOGLE_OAUTH_REFRESH_TOKEN_KEY.value()
+    );
+
+    try {
+      const res = await axios.post<GoogleTokenResponse>(
+        GOOGLE_TOKEN_ENDPOINT,
+        new URLSearchParams({
+          client_id: GOOGLE_OAUTH_CLIENT_ID.value(),
+          client_secret: GOOGLE_OAUTH_CLIENT_SECRET.value(),
+          refresh_token: refreshToken,
+          grant_type: 'refresh_token',
+        }).toString(),
+        { headers: { 'Content-Type': 'application/x-www-form-urlencoded' } }
+      );
+      return {
+        accessToken: res.data.access_token,
+        expiresIn: res.data.expires_in,
+      };
+    } catch (err) {
+      const axiosErr = err as AxiosError<{ error?: string }>;
+      const googleErr = axiosErr.response?.data?.error;
+      if (googleErr === 'invalid_grant') {
+        // Refresh token revoked (user disconnected at myaccount.google.com,
+        // password reset, etc.). Drop the stored token so the next refresh
+        // call surfaces `needs-consent` cleanly and the client re-routes
+        // through the code flow rather than looping on a dead token.
+        await ref.delete().catch(() => undefined);
+        throw new HttpsError(
+          'failed-precondition',
+          'needs-consent: stored refresh token was revoked.'
+        );
+      }
+      throw new HttpsError(
+        'internal',
+        `Google refresh failed: ${googleErr ?? axiosErr.message}`
+      );
+    }
+  }
+);
+
+/**
+ * Explicit revoke — used by the "Disconnect Google Drive" action in the
+ * sidebar. Drops the stored refresh_token and best-effort tells Google
+ * to invalidate it. Idempotent: a missing doc is a no-op success.
+ */
+export const revokeGoogleRefreshToken = onCall(
+  {
+    secrets: [GOOGLE_OAUTH_REFRESH_TOKEN_KEY],
+  },
+  async (req) => {
+    const uid = requireAuthUid(req.auth?.uid);
+    const ref = admin.firestore().doc(PRIVATE_DOC_PATH(uid));
+    const snap = await ref.get();
+    if (!snap.exists) {
+      return { revoked: false, reason: 'no-stored-token' };
+    }
+    const stored = snap.data() as StoredGoogleAuth;
+    let plaintext: string | null = null;
+    try {
+      plaintext = decryptRefreshToken(
+        stored.encryptedRefreshToken,
+        GOOGLE_OAUTH_REFRESH_TOKEN_KEY.value()
+      );
+    } catch {
+      // Encryption key rotated and we can no longer decrypt — still drop
+      // the stored doc so future calls don't keep failing on it.
+      plaintext = null;
+    }
+    if (plaintext) {
+      await axios
+        .post(
+          'https://oauth2.googleapis.com/revoke',
+          new URLSearchParams({ token: plaintext }).toString(),
+          { headers: { 'Content-Type': 'application/x-www-form-urlencoded' } }
+        )
+        .catch(() => {
+          // Google may have already invalidated the token; deleting the
+          // stored copy is the load-bearing step regardless.
+        });
+    }
+    await ref.delete();
+    return { revoked: true };
+  }
+);

--- a/functions/src/googleOAuth.ts
+++ b/functions/src/googleOAuth.ts
@@ -37,7 +37,7 @@ import { onCall, HttpsError } from 'firebase-functions/v2/https';
 import { defineSecret } from 'firebase-functions/params';
 import * as admin from 'firebase-admin';
 import * as CryptoJS from 'crypto-js';
-import axios, { AxiosError } from 'axios';
+import axios from 'axios';
 
 if (!admin.apps.length) {
   admin.initializeApp();
@@ -71,8 +71,8 @@ interface GoogleTokenResponse {
 interface StoredGoogleAuth {
   /** AES-encrypted refresh_token. Plaintext NEVER persisted. */
   encryptedRefreshToken: string;
-  /** ISO timestamp of last successful refresh — diagnostic, not load-bearing. */
-  updatedAt: string;
+  /** Numeric epoch (ms) of last successful refresh — diagnostic, not load-bearing. */
+  updatedAt: number;
   /** Scope string Google returned at the last exchange. */
   scope: string;
 }
@@ -155,8 +155,16 @@ export const exchangeGoogleAuthCode = onCall(
       );
       tokens = res.data;
     } catch (err) {
-      const axiosErr = err as AxiosError<{ error?: string }>;
-      const googleErr = axiosErr.response?.data?.error ?? axiosErr.message;
+      // Narrow via `axios.isAxiosError` so we only reach for `.response.data`
+      // when the error genuinely came from axios. A bare assertion would
+      // silently work via optional chaining but mask any non-axios failures
+      // (e.g. a TypeError thrown by surrounding code) behind a misleading
+      // "Google token exchange failed: undefined" message.
+      const googleErr = axios.isAxiosError(err)
+        ? ((err.response?.data as { error?: string })?.error ?? err.message)
+        : err instanceof Error
+          ? err.message
+          : String(err);
       throw new HttpsError(
         'failed-precondition',
         `Google token exchange failed: ${googleErr}`
@@ -181,7 +189,7 @@ export const exchangeGoogleAuthCode = onCall(
       );
       const stored: StoredGoogleAuth = {
         encryptedRefreshToken: encrypted,
-        updatedAt: new Date().toISOString(),
+        updatedAt: Date.now(),
         scope: tokens.scope ?? '',
       };
       await admin.firestore().doc(PRIVATE_DOC_PATH(uid)).set(stored);
@@ -262,22 +270,31 @@ export const refreshGoogleAccessToken = onCall(
         expiresIn: res.data.expires_in,
       };
     } catch (err) {
-      const axiosErr = err as AxiosError<{ error?: string }>;
-      const googleErr = axiosErr.response?.data?.error;
-      if (googleErr === 'invalid_grant') {
-        // Refresh token revoked (user disconnected at myaccount.google.com,
-        // password reset, etc.). Drop the stored token so the next refresh
-        // call surfaces `needs-consent` cleanly and the client re-routes
-        // through the code flow rather than looping on a dead token.
-        await ref.delete().catch(() => undefined);
+      // Narrow via `axios.isAxiosError` before reading `.response.data` so a
+      // non-axios failure (e.g. a TypeError from surrounding code) doesn't
+      // get misclassified as a Google API error. Only axios errors carry
+      // the `invalid_grant` signal we need to recognize.
+      if (axios.isAxiosError(err)) {
+        const googleErr = (err.response?.data as { error?: string })?.error;
+        if (googleErr === 'invalid_grant') {
+          // Refresh token revoked (user disconnected at myaccount.google.com,
+          // password reset, etc.). Drop the stored token so the next refresh
+          // call surfaces `needs-consent` cleanly and the client re-routes
+          // through the code flow rather than looping on a dead token.
+          await ref.delete().catch(() => undefined);
+          throw new HttpsError(
+            'failed-precondition',
+            'needs-consent: stored refresh token was revoked.'
+          );
+        }
         throw new HttpsError(
-          'failed-precondition',
-          'needs-consent: stored refresh token was revoked.'
+          'internal',
+          `Google refresh failed: ${googleErr ?? err.message}`
         );
       }
       throw new HttpsError(
         'internal',
-        `Google refresh failed: ${googleErr ?? axiosErr.message}`
+        `Google refresh failed: ${err instanceof Error ? err.message : String(err)}`
       );
     }
   }

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -38,6 +38,11 @@ export { joinPlcAssignmentSyncGroup } from './plcAssignmentSyncJoin';
 export { joinPlcVideoActivitySyncGroup } from './plcVideoActivitySyncJoin';
 export { recomputeAdminAnalytics } from './adminAnalyticsSnapshot';
 export { expireSubShares } from './expireSubShares';
+export {
+  exchangeGoogleAuthCode,
+  refreshGoogleAccessToken,
+  revokeGoogleRefreshToken,
+} from './googleOAuth';
 
 setGlobalOptions({ region: 'us-central1' });
 

--- a/hooks/useDriveReconnected.ts
+++ b/hooks/useDriveReconnected.ts
@@ -1,0 +1,34 @@
+import { useEffect, useRef } from 'react';
+import { subscribeDriveReconnected } from '@/utils/driveAuthErrors';
+
+/**
+ * Subscribe to "Google Drive token just rotated to a new value" events.
+ *
+ * Designed for widgets and hooks whose data loaders are gated behind
+ * non-token state (Firestore listeners, route params, mount-only effects).
+ * Those loaders normally won't re-run when `googleAccessToken` flips from
+ * stale to fresh — the user clicks "Connect" in the disconnect toast, the
+ * token lands, but the widget keeps showing whatever it last managed to
+ * load (often nothing). Subscribing here gives them a chance to retry.
+ *
+ * The callback is stored in a ref so subscribers don't have to memoize it
+ * with `useCallback` to avoid resubscribe churn. The subscription itself
+ * mounts once per consumer.
+ */
+export const useDriveReconnected = (callback: () => void): void => {
+  const callbackRef = useRef(callback);
+
+  // Sync the latest callback into the ref AFTER render so the lint rule
+  // about "Cannot update ref during render" stays happy. The cost is one
+  // extra effect run per render, which is negligible — the subscription
+  // itself only mounts once via the empty-deps effect below.
+  useEffect(() => {
+    callbackRef.current = callback;
+  });
+
+  useEffect(() => {
+    return subscribeDriveReconnected(() => {
+      callbackRef.current();
+    });
+  }, []);
+};

--- a/tests/utils/driveAuthErrors.test.ts
+++ b/tests/utils/driveAuthErrors.test.ts
@@ -6,6 +6,8 @@ import {
   onDriveTokenChange,
   authError,
   DriveAuthError,
+  subscribeDriveReconnected,
+  notifyDriveReconnected,
   __resetDriveAuthErrorsForTests,
 } from '@/utils/driveAuthErrors';
 
@@ -136,6 +138,93 @@ describe('driveAuthErrors', () => {
       // the new session toasts again.
       onDriveTokenChange('token-1');
       reportDriveAuthError(new Error('Google Drive access expired'));
+      expect(handler).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('drive-reconnected pub/sub', () => {
+    it('fans out a notify to every subscriber', () => {
+      const a = vi.fn();
+      const b = vi.fn();
+      subscribeDriveReconnected(a);
+      subscribeDriveReconnected(b);
+      notifyDriveReconnected();
+      expect(a).toHaveBeenCalledTimes(1);
+      expect(b).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns an unsubscribe function that detaches the handler', () => {
+      const handler = vi.fn();
+      const unsubscribe = subscribeDriveReconnected(handler);
+      unsubscribe();
+      notifyDriveReconnected();
+      expect(handler).not.toHaveBeenCalled();
+    });
+
+    it('emits exactly once on a real token rotation (null → token)', () => {
+      const handler = vi.fn();
+      subscribeDriveReconnected(handler);
+      onDriveTokenChange('token-1');
+      expect(handler).toHaveBeenCalledTimes(1);
+    });
+
+    it('emits exactly once on a token-to-different-token rotation', () => {
+      const handler = vi.fn();
+      onDriveTokenChange('token-1'); // initial — subscribed AFTER, so missed.
+      subscribeDriveReconnected(handler);
+      onDriveTokenChange('token-2');
+      expect(handler).toHaveBeenCalledTimes(1);
+    });
+
+    it('does NOT emit when the same token replays (consumer-mount no-op)', () => {
+      const handler = vi.fn();
+      onDriveTokenChange('token-1');
+      subscribeDriveReconnected(handler);
+      onDriveTokenChange('token-1');
+      onDriveTokenChange('token-1');
+      expect(handler).not.toHaveBeenCalled();
+    });
+
+    it('does NOT emit on sign-out (token → null)', () => {
+      const handler = vi.fn();
+      onDriveTokenChange('token-1');
+      subscribeDriveReconnected(handler);
+      onDriveTokenChange(null);
+      expect(handler).not.toHaveBeenCalled();
+    });
+
+    it('keeps fanning out to remaining handlers when one throws', () => {
+      const thrower = vi.fn(() => {
+        throw new Error('boom');
+      });
+      const other = vi.fn();
+      subscribeDriveReconnected(thrower);
+      subscribeDriveReconnected(other);
+      // Swallow the expected console.error noise from the in-flight handler.
+      const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {
+        /* swallow */
+      });
+      notifyDriveReconnected();
+      expect(thrower).toHaveBeenCalledTimes(1);
+      expect(other).toHaveBeenCalledTimes(1);
+      errSpy.mockRestore();
+    });
+
+    it('tolerates a handler unsubscribing itself mid-fanout', () => {
+      const handler = vi.fn();
+      let unsubscribeSelf: (() => void) | null = null;
+      const selfRemoving = vi.fn(() => {
+        unsubscribeSelf?.();
+      });
+      unsubscribeSelf = subscribeDriveReconnected(selfRemoving);
+      subscribeDriveReconnected(handler);
+      notifyDriveReconnected();
+      // Both fire on this fanout (the snapshot is taken before iteration).
+      expect(selfRemoving).toHaveBeenCalledTimes(1);
+      expect(handler).toHaveBeenCalledTimes(1);
+      // On the next fanout, only the still-subscribed handler fires.
+      notifyDriveReconnected();
+      expect(selfRemoving).toHaveBeenCalledTimes(1);
       expect(handler).toHaveBeenCalledTimes(2);
     });
   });

--- a/utils/driveAuthErrors.ts
+++ b/utils/driveAuthErrors.ts
@@ -135,24 +135,84 @@ export const authError = (message: string): DriveAuthError => {
  * Sign-out (`token === null`) also resets the latch so a subsequent sign-in
  * with the same cached token (rare but possible: re-entering an unexpired
  * session) re-arms the toast for that session's first stale episode.
+ *
+ * Side effect: a real token rotation (null → token, or tokenA → tokenB)
+ * also fans out a "drive-reconnected" notification so widgets whose
+ * effects don't naturally observe `googleAccessToken` can subscribe via
+ * `subscribeDriveReconnected` and re-run their loaders. Token-on-mount
+ * (first-ever sign-in) and unchanged-token replays don't fire — only true
+ * rotations do.
  */
 export const onDriveTokenChange = (token: string | null): void => {
   if (token && token !== lastSeenToken) {
+    const isFreshSession = lastSeenToken === null;
     lastSeenToken = token;
     driveAuthErrorLatched = false;
+    // Notify on every real rotation, including the null → token transition
+    // that fires when the toast "Connect" button succeeds. Widgets that
+    // failed to load while disconnected need that signal to retry.
+    void isFreshSession;
+    notifyDriveReconnected();
   } else if (!token) {
     lastSeenToken = null;
     driveAuthErrorLatched = false;
   }
 };
 
+type DriveReconnectedHandler = () => void;
+
+const driveReconnectedHandlers = new Set<DriveReconnectedHandler>();
+
 /**
- * Test-only: clear all module-level state (handler, latch, last-seen token)
- * so unit tests don't leak state across cases. Production code should use
- * `setDriveAuthErrorHandler(null)` + a fresh token signal instead.
+ * Subscribe to "Drive token rotated to a new value" notifications. Used by
+ * widgets and hooks whose data fetches are gated behind non-token state
+ * (Firestore listeners, route params, etc.) and therefore don't naturally
+ * re-run when `googleAccessToken` changes.
+ *
+ * Returns an unsubscribe function. Multiple subscribers are supported; a
+ * single token rotation fans out to all of them.
+ *
+ * Handlers are invoked synchronously inside `notifyDriveReconnected`.
+ * They should be cheap — typically just enqueue a refetch — and must not
+ * throw, or other subscribers in the same fan-out will be skipped.
+ */
+export const subscribeDriveReconnected = (
+  handler: DriveReconnectedHandler
+): (() => void) => {
+  driveReconnectedHandlers.add(handler);
+  return () => {
+    driveReconnectedHandlers.delete(handler);
+  };
+};
+
+/**
+ * Dispatch the "drive-reconnected" signal to every subscriber. Called from
+ * `onDriveTokenChange` whenever a real token rotation lands. Exported so
+ * tests can drive the signal directly without faking a token transition.
+ */
+export const notifyDriveReconnected = (): void => {
+  // Snapshot the set so a handler that unsubscribes mid-fanout doesn't
+  // mutate the iteration. Handlers that throw shouldn't take down the
+  // rest of the fanout — log and continue.
+  const snapshot = Array.from(driveReconnectedHandlers);
+  for (const handler of snapshot) {
+    try {
+      handler();
+    } catch (err) {
+      console.error('[driveAuthErrors] reconnect handler threw:', err);
+    }
+  }
+};
+
+/**
+ * Test-only: clear all module-level state (handler, latch, last-seen token,
+ * reconnect subscribers) so unit tests don't leak state across cases.
+ * Production code should use `setDriveAuthErrorHandler(null)` + a fresh
+ * token signal instead.
  */
 export const __resetDriveAuthErrorsForTests = (): void => {
   driveAuthErrorHandler = null;
   driveAuthErrorLatched = false;
   lastSeenToken = null;
+  driveReconnectedHandlers.clear();
 };

--- a/utils/driveAuthErrors.ts
+++ b/utils/driveAuthErrors.ts
@@ -136,22 +136,20 @@ export const authError = (message: string): DriveAuthError => {
  * with the same cached token (rare but possible: re-entering an unexpired
  * session) re-arms the toast for that session's first stale episode.
  *
- * Side effect: a real token rotation (null → token, or tokenA → tokenB)
- * also fans out a "drive-reconnected" notification so widgets whose
+ * Side effect: any `token !== lastSeenToken` transition (including the
+ * initial null → token at sign-in, and subsequent tokenA → tokenB
+ * rotations) fans out a "drive-reconnected" notification so widgets whose
  * effects don't naturally observe `googleAccessToken` can subscribe via
- * `subscribeDriveReconnected` and re-run their loaders. Token-on-mount
- * (first-ever sign-in) and unchanged-token replays don't fire — only true
- * rotations do.
+ * `subscribeDriveReconnected` and re-run their loaders. Unchanged-token
+ * replays from multiple consumers mounting and sign-out (token → null)
+ * do NOT fire — only real rotations do. Firing on null → token is the
+ * critical path the toast "Connect" button depends on: widgets that
+ * failed to load while disconnected need the signal to retry.
  */
 export const onDriveTokenChange = (token: string | null): void => {
   if (token && token !== lastSeenToken) {
-    const isFreshSession = lastSeenToken === null;
     lastSeenToken = token;
     driveAuthErrorLatched = false;
-    // Notify on every real rotation, including the null → token transition
-    // that fires when the toast "Connect" button succeeds. Widgets that
-    // failed to load while disconnected need that signal to retry.
-    void isFreshSession;
     notifyDriveReconnected();
   } else if (!token) {
     lastSeenToken = null;

--- a/utils/googleOAuthRefresh.ts
+++ b/utils/googleOAuthRefresh.ts
@@ -1,0 +1,184 @@
+/**
+ * Client-side glue for the Phase-B server-side refresh-token flow.
+ *
+ * Three operations sit behind this module:
+ * 1. `requestAndExchangeAuthCode` — drives the GIS code client to capture
+ *    a one-time authorization code, then calls the `exchangeGoogleAuthCode`
+ *    Cloud Function to swap it for tokens. The refresh_token never reaches
+ *    the browser; only a fresh access_token comes back.
+ * 2. `refreshAccessTokenViaBackend` — asks the backend for a fresh
+ *    access_token using the stored refresh_token. Returns null + the
+ *    needs-consent flag when there's no usable refresh_token, so callers
+ *    can decide whether to escalate to the code flow.
+ * 3. `revokeBackendRefreshToken` — drops the stored token (both locally
+ *    on Google's side and in our private Firestore path). Wired into
+ *    the sidebar "Disconnect" button.
+ *
+ * All three are no-ops in `isAuthBypass` mode — the mock user never
+ * touches real Google APIs.
+ */
+
+import { httpsCallable } from 'firebase/functions';
+import {
+  functions,
+  isAuthBypass,
+  GOOGLE_OAUTH_SCOPES,
+} from '@/config/firebase';
+
+/** Matches the Cloud Function's exchange response. */
+export interface ExchangeAuthCodeResult {
+  accessToken: string;
+  expiresIn: number;
+  hasRefreshToken: boolean;
+}
+
+/** Matches the Cloud Function's refresh response. */
+export interface BackendRefreshResult {
+  accessToken: string;
+  expiresIn: number;
+}
+
+/** Outcome of the backend refresh path, distinguishing success from re-consent. */
+export type BackendRefreshOutcome =
+  | { status: 'ok'; token: string; expiresIn: number }
+  | { status: 'needs-consent' }
+  | { status: 'error'; message: string };
+
+/**
+ * Drive the GIS auth-code flow in popup mode and return the captured code.
+ *
+ * The redirect_uri Google uses internally for `ux_mode: 'popup'` is its own
+ * `postmessage` endpoint — there is no external redirect URL to configure
+ * in the Cloud Console. The function callable receives `redirectUri:
+ * 'postmessage'` literally; Google's token endpoint accepts that as a
+ * sentinel for the popup variant.
+ */
+const POPUP_REDIRECT_URI = 'postmessage';
+
+const ensureGis = (): typeof google => {
+  if (typeof window === 'undefined' || typeof window.google === 'undefined') {
+    throw new Error(
+      'Google Identity Services script has not loaded yet. Retry once the page settles.'
+    );
+  }
+  return window.google;
+};
+
+/**
+ * Show the GIS consent popup, capture the resulting authorization code,
+ * and hand it to the Cloud Function for exchange. Returns the fresh
+ * access_token directly so the caller can install it without a second
+ * round-trip.
+ *
+ * Resolves to null if the user dismisses the consent popup.
+ */
+export const requestAndExchangeAuthCode = async (
+  clientId: string,
+  hintEmail: string | undefined
+): Promise<ExchangeAuthCodeResult | null> => {
+  if (isAuthBypass) return null;
+
+  const gis = ensureGis();
+  const code = await new Promise<string | null>((resolve) => {
+    const codeClient = gis.accounts?.oauth2?.initCodeClient({
+      client_id: clientId,
+      scope: GOOGLE_OAUTH_SCOPES.join(' '),
+      ux_mode: 'popup',
+      hint: hintEmail,
+      // `access_type` is what makes Google issue a refresh_token. Without it
+      // we'd be right back at the 1-hour TTL with no offline recovery path.
+      // `prompt: 'consent'` forces the consent screen so the refresh_token
+      // is reliably included (Google omits it on subsequent consents to the
+      // same scopes otherwise).
+      callback: (response: { code?: string; error?: string }) => {
+        if (response.error || !response.code) {
+          resolve(null);
+          return;
+        }
+        resolve(response.code);
+      },
+      error_callback: () => resolve(null),
+    } as Parameters<typeof gis.accounts.oauth2.initCodeClient>[0] & {
+      access_type?: string;
+      prompt?: string;
+    });
+    if (!codeClient) {
+      resolve(null);
+      return;
+    }
+    // `requestCode` is on the code-client surface but isn't typed in older
+    // GIS @types — cast to a structural shape that exposes it.
+    (codeClient as unknown as { requestCode: () => void }).requestCode();
+  });
+
+  if (!code) return null;
+
+  const callable = httpsCallable<
+    { code: string; redirectUri: string },
+    ExchangeAuthCodeResult
+  >(functions, 'exchangeGoogleAuthCode');
+  const result = await callable({ code, redirectUri: POPUP_REDIRECT_URI });
+  return result.data;
+};
+
+/**
+ * Ask the backend for a fresh access_token. The backend uses the
+ * stored refresh_token internally — never round-trips it to the client.
+ *
+ * Distinguishes:
+ * - `ok` — fresh access_token in `token`
+ * - `needs-consent` — no usable refresh_token; caller should escalate
+ *   to the auth-code flow
+ * - `error` — transient/unknown failure; caller may fall back to popup
+ */
+export const refreshAccessTokenViaBackend =
+  async (): Promise<BackendRefreshOutcome> => {
+    if (isAuthBypass) return { status: 'error', message: 'auth-bypass' };
+
+    try {
+      const callable = httpsCallable<void, BackendRefreshResult>(
+        functions,
+        'refreshGoogleAccessToken'
+      );
+      const res = await callable();
+      if (!res.data?.accessToken) {
+        return { status: 'error', message: 'no-token-in-response' };
+      }
+      return {
+        status: 'ok',
+        token: res.data.accessToken,
+        expiresIn: res.data.expiresIn,
+      };
+    } catch (err) {
+      // Firebase callable errors come back as { code, message } where code is
+      // the HttpsError code string. Our backend uses `failed-precondition`
+      // plus a `needs-consent:` message prefix for the re-consent path so the
+      // client can react without ambiguity.
+      const message = err instanceof Error ? err.message : String(err);
+      if (message.includes('needs-consent')) {
+        return { status: 'needs-consent' };
+      }
+      return { status: 'error', message };
+    }
+  };
+
+/**
+ * Revoke and forget the stored refresh_token. Fire-and-forget from the
+ * sidebar Disconnect button — failures are logged but don't block UI
+ * state changes (we still want the client-side token cleared regardless).
+ */
+export const revokeBackendRefreshToken = async (): Promise<void> => {
+  if (isAuthBypass) return;
+  try {
+    const callable = httpsCallable<void, { revoked: boolean }>(
+      functions,
+      'revokeGoogleRefreshToken'
+    );
+    await callable();
+  } catch (err) {
+    console.warn(
+      '[googleOAuthRefresh] revokeGoogleRefreshToken failed (non-fatal):',
+      err
+    );
+  }
+};

--- a/utils/googleOAuthRefresh.ts
+++ b/utils/googleOAuthRefresh.ts
@@ -85,11 +85,15 @@ export const requestAndExchangeAuthCode = async (
       scope: GOOGLE_OAUTH_SCOPES.join(' '),
       ux_mode: 'popup',
       hint: hintEmail,
-      // `access_type` is what makes Google issue a refresh_token. Without it
-      // we'd be right back at the 1-hour TTL with no offline recovery path.
-      // `prompt: 'consent'` forces the consent screen so the refresh_token
-      // is reliably included (Google omits it on subsequent consents to the
-      // same scopes otherwise).
+      // `access_type: 'offline'` is what makes Google issue a refresh_token.
+      // Without it we'd be right back at the 1-hour TTL with no offline
+      // recovery path. `prompt: 'consent'` forces the consent screen so the
+      // refresh_token is reliably included (Google omits it on subsequent
+      // consents to the same scopes otherwise). Both fields are valid on
+      // `initCodeClient` config but aren't in older @types/google.accounts;
+      // the cast below widens the parameter type to accept them.
+      access_type: 'offline',
+      prompt: 'consent',
       callback: (response: { code?: string; error?: string }) => {
         if (response.error || !response.code) {
           resolve(null);
@@ -99,8 +103,8 @@ export const requestAndExchangeAuthCode = async (
       },
       error_callback: () => resolve(null),
     } as Parameters<typeof gis.accounts.oauth2.initCodeClient>[0] & {
-      access_type?: string;
-      prompt?: string;
+      access_type: string;
+      prompt: string;
     });
     if (!codeClient) {
       resolve(null);


### PR DESCRIPTION
## Summary

Two-part fix for the Drive reconnect frustration:
- **Part A** — adds a reconnect pub/sub so widgets actually re-fetch when the toast "Connect" button (or sidebar "Refresh") lands a fresh token. Audited every Drive/Sheets/Calendar consumer; patched two real bugs (DashboardContext PII restore latch, SidebarBackgrounds `hasFetchedDrive` latch) and confirmed the rest already react correctly via `driveService`/`calendarService` memo deps.
- **Part B** — server-side OAuth refresh-token flow via new Cloud Functions. `refreshGoogleToken` now tries: GIS silent → backend callable (uses encrypted refresh_token stored in Firestore) → auth-code re-consent → Firebase popup. Survives the user's Google session expiring, which is the real reason Drive auth feels so flaky today.

## Why

User report: "many times data is not properly displaying on users' boards and when they go to sidebar > google drive > refresh, then it fetches the appropriate data...despite having clicked the blue 'Connect' button on that toast message." Plus a deeper "no other app I use requires reconnecting Drive this often" complaint.

Diagnosis confirmed:
- Toast Connect and Sidebar Refresh DO funnel into the same `refreshGoogleToken()`, so the perceived difference wasn't in the buttons — it was that some widget effects don't re-fire on token rotation. Part A fixes that.
- The 1-hour expiry is Google's TTL, but the app currently has no `access_type=offline` flow and stores no refresh_token, so every renewal depends on the user's Google session staying alive. Part B replaces that with a server-stored refresh_token that survives session loss.

## Deploy notes

Two new Secret Manager secrets have been set in `spartboard`:
- `GOOGLE_OAUTH_CLIENT_SECRET` — from the existing OAuth client (added via "Add Secret"; old secret left active for rotation)
- `GOOGLE_OAUTH_REFRESH_TOKEN_KEY` — random 32-byte AES key for encrypting stored refresh_tokens

The CI `firebase-dev-deploy.yml` workflow handles `functions,firestore,storage` deploy automatically on push to this branch, so no manual deploy needed for review.

## Regression risk

- Active users with valid tokens: **zero observable change** (new backend path only runs when GIS silent fails).
- Existing users on next token-expiry incident after deploy: one-time consent popup to capture the refresh_token (same UX as today's "Connect" popup). Every subsequent expiry is silent.
- New firestore.rules deny on `/users/{uid}/private/**` — no existing code writes that path (verified by grep). Pure defense in depth.

## Test plan

- [x] `pnpm run validate` — type-check, lint, format-check all pass
- [x] All 2503 unit tests pass (7 new cases for the reconnect pub/sub)
- [x] `pnpm -C functions run build` compiles cleanly
- [x] Dev server HMR'd cleanly, dashboard rendered without new errors
- [ ] On preview URL: force-expire token (clear `spart_google_access_token` + `spart_google_token_expiry`), click toast Connect, verify widgets re-fetch immediately
- [ ] On preview URL: leave session idle past 1h, verify silent refresh continues without showing the disconnect toast
- [ ] On preview URL: sign out of Google in another tab, return to SpartBoard, verify backend refresh succeeds without popup
- [ ] On preview URL: revoke SpartBoard's access from Google account settings, verify `invalid_grant` triggers re-consent gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)