### PR TITLE
feat(quiz-written): UX overhaul for essay/short responses + fix yellow-only highlight bug

### DIFF
--- a/components/quiz/QuizStudentApp.tsx
+++ b/components/quiz/QuizStudentApp.tsx
@@ -1584,7 +1584,13 @@ const ActiveQuiz: React.FC<{
         />
       </div>
 
-      <div className="flex flex-col p-6 max-w-lg mx-auto w-full">
+      <div
+        className={`flex flex-col p-6 mx-auto w-full ${
+          currentQuestion.type === 'short' || currentQuestion.type === 'essay'
+            ? 'max-w-3xl'
+            : 'max-w-lg'
+        }`}
+      >
         {/* Header */}
         <div className="flex items-center justify-between mb-6">
           <div className="flex items-center gap-2">
@@ -1886,7 +1892,7 @@ const ActiveQuiz: React.FC<{
 
         {(currentQuestion.type === 'short' ||
           currentQuestion.type === 'essay') && (
-          <div className="space-y-4 flex-1">
+          <div className="space-y-4">
             <React.Suspense
               fallback={
                 <div className="h-48 bg-slate-800 border border-slate-700 rounded-2xl flex items-center justify-center">
@@ -1911,15 +1917,15 @@ const ActiveQuiz: React.FC<{
               />
             </React.Suspense>
 
-            <div className="animate-in fade-in slide-in-from-bottom-2 space-y-3">
+            {/*
+              Sticky CTA: the editor can grow up to ~70vh tall, so without
+              `sticky bottom-0` the Submit button rides below the fold and
+              students miss it.
+            */}
+            <div className="animate-in fade-in slide-in-from-bottom-2 space-y-3 sticky bottom-0 z-10 bg-slate-900/85 backdrop-blur-sm pt-3 pb-2 -mx-2 px-2 rounded-xl">
               {isStudentPaced ? (
                 submitted && currentIndex >= session.totalQuestions - 1 ? (
-                  <div className="p-4 bg-emerald-500/15 border border-emerald-500/30 rounded-2xl flex items-center justify-center gap-3">
-                    <CheckCircle2 className="w-5 h-5 text-emerald-400 shrink-0" />
-                    <p className="text-emerald-300 text-sm font-bold">
-                      Quiz complete!
-                    </p>
-                  </div>
+                  <QuizCompleteCard />
                 ) : (
                   <>
                     {saveError && <SaveErrorBanner message={saveError} />}
@@ -1957,14 +1963,9 @@ const ActiveQuiz: React.FC<{
                   )}
                 </button>
               ) : (
-                <div className="p-4 bg-emerald-500/15 border border-emerald-500/30 rounded-2xl flex items-center justify-center gap-3">
-                  <CheckCircle2 className="w-5 h-5 text-emerald-400 shrink-0" />
-                  <p className="text-emerald-300 text-sm font-bold">
-                    {currentIndex < session.totalQuestions - 1
-                      ? 'Waiting for teacher…'
-                      : 'Response submitted — your teacher will grade this.'}
-                  </p>
-                </div>
+                <WrittenSubmittedCard
+                  isWaiting={currentIndex < session.totalQuestions - 1}
+                />
               )}
             </div>
           </div>
@@ -2157,6 +2158,51 @@ const SaveErrorBanner: React.FC<{ message: string }> = ({ message }) => (
     <AlertCircle className="w-4 h-4 shrink-0" />
     <span>{message}</span>
   </div>
+);
+
+// ─── Written-response post-submit cards ──────────────────────────────────────
+//
+// Reused in two places: between essay questions (waiting state) and after
+// the final question lands (`isWaiting=false`). The "Back to my
+// assignments" CTA is what stops students from feeling stranded on the
+// submitted screen with no way out.
+
+const WrittenSubmittedCard: React.FC<{ isWaiting: boolean }> = ({
+  isWaiting,
+}) => (
+  <div className="flex flex-col gap-3">
+    <div className="p-4 bg-emerald-500/15 border border-emerald-500/30 rounded-2xl flex items-center justify-center gap-3">
+      <CheckCircle2 className="w-5 h-5 text-emerald-400 shrink-0" />
+      <p className="text-emerald-300 text-sm font-bold">
+        {isWaiting
+          ? 'Waiting for teacher…'
+          : 'Response submitted — your teacher will grade this.'}
+      </p>
+    </div>
+    {!isWaiting && <ReturnToAssignmentsButton />}
+  </div>
+);
+
+const QuizCompleteCard: React.FC = () => (
+  <div className="flex flex-col gap-3">
+    <div className="p-4 bg-emerald-500/15 border border-emerald-500/30 rounded-2xl flex items-center justify-center gap-3">
+      <CheckCircle2 className="w-5 h-5 text-emerald-400 shrink-0" />
+      <p className="text-emerald-300 text-sm font-bold">Quiz complete!</p>
+    </div>
+    <ReturnToAssignmentsButton />
+  </div>
+);
+
+const ReturnToAssignmentsButton: React.FC = () => (
+  <button
+    type="button"
+    onClick={() => {
+      window.location.assign('/my-assignments');
+    }}
+    className="w-full py-3 bg-brand-blue-primary hover:bg-brand-blue-dark text-white font-bold rounded-2xl flex items-center justify-center gap-2 transition-colors shadow-sm shadow-brand-blue-primary/20"
+  >
+    Back to my assignments <ArrowRight className="w-4 h-4" />
+  </button>
 );
 
 // ─── Answer feedback banner ──────────────────────────────────────────────────
@@ -2736,6 +2782,18 @@ const QuizSubmittedWaitScreen: React.FC<{
         <Loader2 className="w-4 h-4 animate-spin" />
         Waiting for teacher to end the quiz and show final results…
       </div>
+
+      {/*
+        Pseudonym students (no PIN) reached this from /my-assignments and
+        would otherwise be stranded waiting for the teacher to end the
+        quiz. PIN-based students joined by code and have nowhere to go
+        back to — skip the CTA for them.
+      */}
+      {!pin && (
+        <div className="mt-6">
+          <ReturnToAssignmentsButton />
+        </div>
+      )}
     </div>
   );
 };

--- a/components/quiz/WrittenResponseEditor.tsx
+++ b/components/quiz/WrittenResponseEditor.tsx
@@ -154,6 +154,21 @@ const WrittenResponseEditorInner: React.FC<
     }
   };
 
+  // If the student shrinks the browser window after dragging the editor
+  // taller than the new max, the stored height stays stale until the next
+  // interaction — leaving the editor visibly taller than 70vh allows.
+  // Re-clamp on viewport resize so the cap stays honest. Floored at
+  // `minHeight` because a viewport smaller than the editor's minimum is
+  // a worse problem than ignoring this clamp.
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const onResize = () => {
+      setHeightPx((h) => Math.max(minHeight, Math.min(h, maxHeight())));
+    };
+    window.addEventListener('resize', onResize, { passive: true });
+    return () => window.removeEventListener('resize', onResize);
+  }, [minHeight]);
+
   // Seed innerHTML once on mount. Subsequent edits are driven by the
   // contenteditable element itself — re-writing innerHTML on every value
   // change would reset the caret on every keystroke.

--- a/components/quiz/WrittenResponseEditor.tsx
+++ b/components/quiz/WrittenResponseEditor.tsx
@@ -16,7 +16,14 @@
  */
 
 import React, { useEffect, useRef, useState } from 'react';
-import { Bold, Italic, List, ListOrdered, Underline } from 'lucide-react';
+import {
+  Bold,
+  GripHorizontal,
+  Italic,
+  List,
+  ListOrdered,
+  Underline,
+} from 'lucide-react';
 import { sanitizeQuizResponse } from '@/utils/security';
 
 interface WrittenResponseEditorProps {
@@ -67,12 +74,74 @@ const countWords = (html: string): number => {
   return text.split(' ').length;
 };
 
+const ESSAY_MIN_HEIGHT_PX = 352; // ~22rem — comfortable on a laptop
+const SHORT_MIN_HEIGHT_PX = 128; // ~8rem
+const MAX_HEIGHT_PX_CAP = 900; // hard cap so the editor can't push the page
+const KEYBOARD_RESIZE_STEP_PX = 32;
+
 const WrittenResponseEditorInner: React.FC<
   Omit<WrittenResponseEditorProps, 'questionKey'>
 > = ({ value, onChange, placeholder, maxWords, disabled, isEssay }) => {
   const editorRef = useRef<HTMLDivElement | null>(null);
+  const containerRef = useRef<HTMLDivElement | null>(null);
   const [wordCount, setWordCount] = useState(() => countWords(value));
   const [isEmpty, setIsEmpty] = useState(() => !value.trim());
+
+  // Student-controlled editor height. Starts at the per-question default;
+  // they can drag the bottom-right grip to enlarge it (or use ↑/↓ when the
+  // handle has keyboard focus). Resets on remount per question via the
+  // `questionKey` wrapper.
+  const minHeight = isEssay ? ESSAY_MIN_HEIGHT_PX : SHORT_MIN_HEIGHT_PX;
+  const [heightPx, setHeightPx] = useState<number>(minHeight);
+  // Cap at the smaller of 70vh and MAX_HEIGHT_PX_CAP so very tall windows
+  // can't stretch the editor past a reasonable working size.
+  const maxHeight = (): number => {
+    if (typeof window === 'undefined') return MAX_HEIGHT_PX_CAP;
+    return Math.min(MAX_HEIGHT_PX_CAP, Math.round(window.innerHeight * 0.7));
+  };
+
+  // Pointer-drag resize. `pointer-events: none` on body during drag would
+  // be cleaner, but we only need to track the y delta and clamp.
+  const dragStateRef = useRef<{ startY: number; startHeight: number } | null>(
+    null
+  );
+  const handlePointerDown = (e: React.PointerEvent<HTMLButtonElement>) => {
+    if (disabled) return;
+    dragStateRef.current = {
+      startY: e.clientY,
+      startHeight: heightPx,
+    };
+    (e.currentTarget as Element).setPointerCapture(e.pointerId);
+  };
+  const handlePointerMove = (e: React.PointerEvent<HTMLButtonElement>) => {
+    const state = dragStateRef.current;
+    if (!state) return;
+    const delta = e.clientY - state.startY;
+    const next = Math.max(
+      minHeight,
+      Math.min(maxHeight(), state.startHeight + delta)
+    );
+    setHeightPx(next);
+  };
+  const handlePointerUp = (e: React.PointerEvent<HTMLButtonElement>) => {
+    if (dragStateRef.current) {
+      try {
+        (e.currentTarget as Element).releasePointerCapture(e.pointerId);
+      } catch {
+        // releasePointerCapture throws if not currently captured — ignore.
+      }
+      dragStateRef.current = null;
+    }
+  };
+  const handleHandleKeyDown = (e: React.KeyboardEvent<HTMLButtonElement>) => {
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      setHeightPx((h) => Math.min(maxHeight(), h + KEYBOARD_RESIZE_STEP_PX));
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      setHeightPx((h) => Math.max(minHeight, h - KEYBOARD_RESIZE_STEP_PX));
+    }
+  };
 
   // Seed innerHTML once on mount. Subsequent edits are driven by the
   // contenteditable element itself — re-writing innerHTML on every value
@@ -118,7 +187,7 @@ const WrittenResponseEditorInner: React.FC<
   const overCap = !!maxWords && maxWords > 0 && wordCount > maxWords;
 
   return (
-    <div className="flex flex-col gap-2 w-full">
+    <div className="flex flex-col gap-2 w-full" ref={containerRef}>
       <div className="flex items-center gap-1 px-2 py-1.5 bg-slate-800 border border-slate-700 rounded-t-2xl">
         <ToolbarButton
           label="Bold"
@@ -194,10 +263,12 @@ const WrittenResponseEditorInner: React.FC<
             disabled
               ? 'border-slate-700 text-slate-400 cursor-not-allowed'
               : 'border-slate-700 text-white focus:outline-none focus:border-violet-500 focus-visible:ring-2 focus-visible:ring-violet-400'
-          } rounded-b-2xl text-sm leading-relaxed overflow-y-auto ${
-            isEssay ? 'min-h-[18rem]' : 'min-h-[6rem]'
-          }`}
-          style={{ wordBreak: 'break-word' }}
+          } rounded-b-2xl text-sm leading-relaxed overflow-y-auto`}
+          style={{
+            wordBreak: 'break-word',
+            height: `${heightPx}px`,
+            minHeight: `${minHeight}px`,
+          }}
         />
         {isEmpty && placeholder && (
           <div
@@ -206,6 +277,21 @@ const WrittenResponseEditorInner: React.FC<
           >
             {placeholder}
           </div>
+        )}
+        {!disabled && (
+          <button
+            type="button"
+            aria-label="Drag to resize response area (or use up and down arrow keys)"
+            title="Drag to resize"
+            onPointerDown={handlePointerDown}
+            onPointerMove={handlePointerMove}
+            onPointerUp={handlePointerUp}
+            onPointerCancel={handlePointerUp}
+            onKeyDown={handleHandleKeyDown}
+            className="absolute bottom-1.5 right-2 flex items-center justify-center w-7 h-5 rounded text-slate-500 hover:text-slate-300 hover:bg-slate-700/70 cursor-ns-resize touch-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-violet-400"
+          >
+            <GripHorizontal className="w-4 h-4" />
+          </button>
         )}
       </div>
 

--- a/components/quiz/WrittenResponseEditor.tsx
+++ b/components/quiz/WrittenResponseEditor.tsx
@@ -127,8 +127,19 @@ const WrittenResponseEditorInner: React.FC<
     if (dragStateRef.current) {
       try {
         (e.currentTarget as Element).releasePointerCapture(e.pointerId);
-      } catch {
-        // releasePointerCapture throws if not currently captured — ignore.
+      } catch (err) {
+        // `releasePointerCapture` throws `InvalidStateError` if the capture
+        // was already released (e.g. by `pointercancel` firing before
+        // `pointerup`). Anything else is unexpected — surface it instead
+        // of swallowing the whole class of DOM errors silently.
+        if (
+          !(err instanceof DOMException && err.name === 'InvalidStateError')
+        ) {
+          console.warn(
+            '[WrittenResponseEditor] unexpected releasePointerCapture error',
+            err
+          );
+        }
       }
       dragStateRef.current = null;
     }

--- a/components/student/AssignmentFilterTabs.tsx
+++ b/components/student/AssignmentFilterTabs.tsx
@@ -1,19 +1,17 @@
 import React from 'react';
 
-export type AssignmentFilterMode = 'all' | 'active' | 'completed';
+export type AssignmentFilterMode = 'active' | 'completed';
 
 interface AssignmentFilterTabsProps {
   value: AssignmentFilterMode;
   onChange: (mode: AssignmentFilterMode) => void;
   counts?: {
-    all?: number;
     active?: number;
     completed?: number;
   };
 }
 
 const TABS: ReadonlyArray<{ id: AssignmentFilterMode; label: string }> = [
-  { id: 'all', label: 'All' },
   { id: 'active', label: 'Active' },
   { id: 'completed', label: 'Completed' },
 ];

--- a/components/student/AssignmentListItem.tsx
+++ b/components/student/AssignmentListItem.tsx
@@ -197,7 +197,9 @@ export const AssignmentListItem: React.FC<AssignmentListItemProps> = ({
   // check confirms participation the row re-renders with the standard
   // "completed" treatment; if it confirms non-participation the parent
   // drops the row from its partition entirely.
-  const isPending = pendingVerification && !isCompleted;
+  const isPending: boolean = !!pendingVerification && !isCompleted;
+
+  const isGraded = assignment.gradingState === 'graded';
 
   return (
     <a
@@ -206,7 +208,7 @@ export const AssignmentListItem: React.FC<AssignmentListItemProps> = ({
       className={`group flex items-center gap-3 rounded-xl border px-4 py-3 transition focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue-primary focus-visible:ring-offset-2 ${
         isPending
           ? 'border-dashed border-slate-200 bg-slate-50'
-          : `border-slate-200 bg-white hover:border-slate-300 hover:shadow-sm ${isCompleted ? 'opacity-80' : ''}`
+          : 'border-slate-200 bg-white hover:border-slate-300 hover:shadow-sm'
       }`}
     >
       <span
@@ -226,11 +228,7 @@ export const AssignmentListItem: React.FC<AssignmentListItemProps> = ({
       <div className="min-w-0 flex-1">
         <p
           className={`truncate text-sm font-semibold sm:text-base ${
-            isCompleted
-              ? 'text-slate-500 line-through'
-              : isPending
-                ? 'text-slate-500'
-                : 'text-slate-800'
+            isPending ? 'text-slate-500' : 'text-slate-800'
           }`}
         >
           {assignment.title}
@@ -249,17 +247,54 @@ export const AssignmentListItem: React.FC<AssignmentListItemProps> = ({
       </div>
 
       <span
-        className={`hidden shrink-0 rounded-lg px-3 py-1.5 text-xs font-semibold transition sm:inline-flex ${
-          isCompleted
-            ? 'bg-slate-100 text-slate-500 group-hover:bg-slate-200'
-            : isPending
-              ? 'bg-slate-100 text-slate-400'
-              : 'bg-brand-blue-primary text-white shadow-sm shadow-brand-blue-primary/20 group-hover:bg-brand-blue-dark'
-        }`}
+        className={`hidden shrink-0 rounded-lg px-3 py-1.5 text-xs font-semibold transition sm:inline-flex ${getChipClass(
+          { isPending, isCompleted, isGraded }
+        )}`}
         aria-hidden="true"
       >
-        {isCompleted ? 'Review' : isPending ? 'Checking…' : 'Open'}
+        {getChipLabel({ isPending, isCompleted, isGraded })}
       </span>
     </a>
   );
 };
+
+/**
+ * Status chip wording per row state.
+ *  - Active row → "Open" (primary CTA)
+ *  - Completed row, grades not published → "Not graded"
+ *  - Completed row, grades published → "View results"
+ *  - Optimistically-surfaced row whose completion check hasn't resolved →
+ *    "Checking…"
+ */
+function getChipLabel({
+  isPending,
+  isCompleted,
+  isGraded,
+}: {
+  isPending: boolean;
+  isCompleted: boolean;
+  isGraded: boolean;
+}): string {
+  if (isPending) return 'Checking…';
+  if (!isCompleted) return 'Open';
+  return isGraded ? 'View results' : 'Not graded';
+}
+
+function getChipClass({
+  isPending,
+  isCompleted,
+  isGraded,
+}: {
+  isPending: boolean;
+  isCompleted: boolean;
+  isGraded: boolean;
+}): string {
+  if (isPending) return 'bg-slate-100 text-slate-400';
+  if (!isCompleted) {
+    return 'bg-brand-blue-primary text-white shadow-sm shadow-brand-blue-primary/20 group-hover:bg-brand-blue-dark';
+  }
+  if (isGraded) {
+    return 'bg-brand-blue-primary text-white shadow-sm shadow-brand-blue-primary/20 group-hover:bg-brand-blue-dark';
+  }
+  return 'bg-slate-100 text-slate-500 group-hover:bg-slate-200';
+}

--- a/components/student/AssignmentListItem.tsx
+++ b/components/student/AssignmentListItem.tsx
@@ -280,6 +280,9 @@ function getChipLabel({
   return isGraded ? 'View results' : 'Not graded';
 }
 
+const PRIMARY_CTA_CLASS =
+  'bg-brand-blue-primary text-white shadow-sm shadow-brand-blue-primary/20 group-hover:bg-brand-blue-dark';
+
 function getChipClass({
   isPending,
   isCompleted,
@@ -290,11 +293,9 @@ function getChipClass({
   isGraded: boolean;
 }): string {
   if (isPending) return 'bg-slate-100 text-slate-400';
-  if (!isCompleted) {
-    return 'bg-brand-blue-primary text-white shadow-sm shadow-brand-blue-primary/20 group-hover:bg-brand-blue-dark';
-  }
-  if (isGraded) {
-    return 'bg-brand-blue-primary text-white shadow-sm shadow-brand-blue-primary/20 group-hover:bg-brand-blue-dark';
-  }
+  // Active rows AND completed-with-published-results both invite a click
+  // ("Open" / "View results"), so they share the primary brand-blue style.
+  // Completed-not-yet-graded is a muted status indicator, not a CTA.
+  if (!isCompleted || isGraded) return PRIMARY_CTA_CLASS;
   return 'bg-slate-100 text-slate-500 group-hover:bg-slate-200';
 }

--- a/components/student/AssignmentSections.tsx
+++ b/components/student/AssignmentSections.tsx
@@ -41,8 +41,6 @@ interface AssignmentSectionsProps {
    * Drives the muted "Checking…" visual on the matching list rows.
    */
   pendingVerificationKeys?: ReadonlySet<string>;
-  /** Optional override for the all-empty state (mode='all', both sections empty). */
-  emptyAll?: React.ReactNode;
 }
 
 export const AssignmentSections: React.FC<AssignmentSectionsProps> = ({
@@ -54,90 +52,58 @@ export const AssignmentSections: React.FC<AssignmentSectionsProps> = ({
   hideClassName,
   onCompletionResolved,
   pendingVerificationKeys,
-  emptyAll,
 }) => {
-  const showActive = mode === 'all' || mode === 'active';
-  const showCompleted = mode === 'all' || mode === 'completed';
-
-  // All-empty fallback for mode='all' so the page reads as "you're all caught
-  // up" instead of two empty headers.
-  if (mode === 'all' && active.length === 0 && completed.length === 0) {
+  if (mode === 'active') {
     return (
-      <>
-        {emptyAll ?? (
+      <Section
+        label="Active"
+        count={active.length}
+        empty={
           <CalmEmpty
             title="All caught up"
-            body="You're all caught up — nothing active or completed yet."
+            body="You're all caught up — no active assignments right now."
           />
-        )}
-      </>
+        }
+      >
+        {active.map((a) => (
+          <AssignmentListItem
+            key={a.compositeId}
+            assignment={a}
+            pseudonymUid={pseudonymUid}
+            classEntry={
+              a.classIds[0] ? directoryById[a.classIds[0]] : undefined
+            }
+            hideClassName={hideClassName}
+            onCompletionResolved={onCompletionResolved}
+          />
+        ))}
+      </Section>
     );
   }
 
   return (
-    <div className="flex flex-col gap-8">
-      {showActive && (
-        <Section
-          label="Active"
-          count={active.length}
-          empty={
-            mode === 'all' ? (
-              <p className="text-sm text-slate-500">
-                Nothing active right now.
-              </p>
-            ) : (
-              <CalmEmpty
-                title="All caught up"
-                body="You're all caught up — no active assignments right now."
-              />
-            )
-          }
-        >
-          {active.map((a) => (
-            <AssignmentListItem
-              key={a.compositeId}
-              assignment={a}
-              pseudonymUid={pseudonymUid}
-              classEntry={
-                a.classIds[0] ? directoryById[a.classIds[0]] : undefined
-              }
-              hideClassName={hideClassName}
-              onCompletionResolved={onCompletionResolved}
-            />
-          ))}
-        </Section>
-      )}
-      {showCompleted && (
-        <Section
-          label="Completed"
-          count={completed.length}
-          empty={
-            mode === 'all' ? (
-              <p className="text-sm text-slate-500">Nothing completed yet.</p>
-            ) : (
-              <CalmEmpty
-                title="Nothing completed yet"
-                body="Once you finish an assignment, it'll show up here."
-              />
-            )
-          }
-        >
-          {completed.map((a) => (
-            <AssignmentListItem
-              key={a.compositeId}
-              assignment={a}
-              pseudonymUid={pseudonymUid}
-              classEntry={
-                a.classIds[0] ? directoryById[a.classIds[0]] : undefined
-              }
-              hideClassName={hideClassName}
-              onCompletionResolved={onCompletionResolved}
-              pendingVerification={pendingVerificationKeys?.has(a.compositeId)}
-            />
-          ))}
-        </Section>
-      )}
-    </div>
+    <Section
+      label="Completed"
+      count={completed.length}
+      empty={
+        <CalmEmpty
+          title="Nothing completed yet"
+          body="Once you finish an assignment, it'll show up here."
+        />
+      }
+    >
+      {completed.map((a) => (
+        <AssignmentListItem
+          key={a.compositeId}
+          assignment={a}
+          pseudonymUid={pseudonymUid}
+          classEntry={a.classIds[0] ? directoryById[a.classIds[0]] : undefined}
+          hideClassName={hideClassName}
+          onCompletionResolved={onCompletionResolved}
+          pendingVerification={pendingVerificationKeys?.has(a.compositeId)}
+        />
+      ))}
+    </Section>
   );
 };
 

--- a/components/student/MyAssignmentsPage.tsx
+++ b/components/student/MyAssignmentsPage.tsx
@@ -51,7 +51,7 @@ import type { CompletionState } from './AssignmentListItem';
 const FILTER_STORAGE_KEY = 'sb_my_assignments_filter';
 
 const isFilterMode = (v: unknown): v is AssignmentFilterMode =>
-  v === 'all' || v === 'active' || v === 'completed';
+  v === 'active' || v === 'completed';
 
 const formatTodayLong = (now: Date): string =>
   now.toLocaleDateString(undefined, {
@@ -123,12 +123,12 @@ const MyAssignmentsPage: React.FC = () => {
   // Filter mode persists to sessionStorage so a refresh keeps it but the
   // choice never follows the student onto a shared device.
   const [filterMode, setFilterMode] = useState<AssignmentFilterMode>(() => {
-    if (typeof window === 'undefined') return 'all';
+    if (typeof window === 'undefined') return 'active';
     try {
       const raw = window.sessionStorage.getItem(FILTER_STORAGE_KEY);
-      return isFilterMode(raw) ? raw : 'all';
+      return isFilterMode(raw) ? raw : 'active';
     } catch {
-      return 'all';
+      return 'active';
     }
   });
   useEffect(() => {

--- a/components/student/StudentClassView.tsx
+++ b/components/student/StudentClassView.tsx
@@ -74,7 +74,6 @@ export const StudentClassView: React.FC<StudentClassViewProps> = ({
           value={filterMode}
           onChange={onFilterChange}
           counts={{
-            all: active.length + completed.length,
             active: active.length,
             completed: completed.length,
           }}

--- a/components/student/StudentOverview.tsx
+++ b/components/student/StudentOverview.tsx
@@ -60,7 +60,6 @@ export const StudentOverview: React.FC<StudentOverviewProps> = ({
           value={filterMode}
           onChange={onFilterChange}
           counts={{
-            all: total,
             active: active.length,
             completed: completed.length,
           }}

--- a/components/widgets/QuizWidget/components/AnnotatedResponseView.tsx
+++ b/components/widgets/QuizWidget/components/AnnotatedResponseView.tsx
@@ -240,19 +240,17 @@ const ReadOnlyView: React.FC<ReadProps> = ({ snapshot, annotations }) => {
     return () => ro.disconnect();
   }, []);
 
-  // Pulse-timeout cleanup. Without this, a click that triggers a pulse
-  // followed by an unmount within 1.2s would call setPulsedId on a dead
-  // component. React 19 silently no-ops the state update but the
-  // outstanding timer is still a (tiny) leak.
-  const pulseTimerRef = useRef<number | null>(null);
-  useEffect(
-    () => () => {
-      if (pulseTimerRef.current !== null) {
-        window.clearTimeout(pulseTimerRef.current);
-      }
-    },
-    []
-  );
+  // Auto-clear the pulse after the animation finishes so a second click
+  // on the same mark visibly re-triggers it. Watching `pulsedId` directly
+  // means: (a) the cleanup function clears the timer on unmount, (b)
+  // changing pulsedId mid-pulse (clicking a different mark) cleanly
+  // cancels the previous timer via cleanup, (c) the click handler stays
+  // a pure setter — no manual timer bookkeeping at the call site.
+  useEffect(() => {
+    if (!pulsedId) return;
+    const t = window.setTimeout(() => setPulsedId(null), 1200);
+    return () => window.clearTimeout(t);
+  }, [pulsedId]);
 
   const handleMarkClick = useCallback(
     (e: React.MouseEvent<HTMLElement>) => {
@@ -263,15 +261,6 @@ const ReadOnlyView: React.FC<ReadProps> = ({ snapshot, annotations }) => {
       const a = annotations.find((x) => x.id === id);
       if (!a?.comment?.trim()) return;
       setPulsedId(id);
-      // Auto-clear the pulse after the animation finishes so a second
-      // click on the same mark visibly re-triggers it.
-      if (pulseTimerRef.current !== null) {
-        window.clearTimeout(pulseTimerRef.current);
-      }
-      pulseTimerRef.current = window.setTimeout(() => {
-        setPulsedId((prev) => (prev === id ? null : prev));
-        pulseTimerRef.current = null;
-      }, 1200);
     },
     [annotations]
   );

--- a/components/widgets/QuizWidget/components/AnnotatedResponseView.tsx
+++ b/components/widgets/QuizWidget/components/AnnotatedResponseView.tsx
@@ -1,20 +1,27 @@
 /**
  * Phase 2 surface for written-response annotations.
  *
- * In `mode="edit"` (teacher's grader) the component:
+ * In `mode="edit"` (teacher's grader):
  *  - Renders the frozen `gradingSnapshot` with existing marks via
  *    `renderAnnotatedSnapshot` (offsets computed against the snapshot's
  *    plaintext projection).
  *  - On mouseup with a non-empty selection, surfaces a small floating
  *    palette anchored to the selection's bounding rect; choosing a color
- *    creates an annotation. Choosing the comment icon opens an inline
- *    comment input docked in the right rail.
- *  - Clicking an existing mark opens that annotation in the rail for
- *    color/comment edits and exposes a delete button.
+ *    creates an annotation. Choosing the comment icon also creates an
+ *    annotation and selects it.
+ *  - When an annotation is active (selected by the teacher or just
+ *    created via comment-icon), renders an editor popover anchored next
+ *    to the highlighted mark so the comment input is visible exactly
+ *    where the teacher is looking. The teacher's right-side annotations
+ *    list lives in the parent grader sidebar — clicking a list item
+ *    sets `activeId` here and the popover opens at the mark.
  *
- * In `mode="read"` (student review surface after publish) the component
- * renders the same snapshot read-only, with the right-rail margin column
- * showing the teacher's comments. No selection palette, no edit handles.
+ * In `mode="read"` (student review surface after publish):
+ *  - Same snapshot rendered read-only.
+ *  - Comments appear pinned in the right margin at the same vertical
+ *    level as their highlight (with a simple collision-avoidance pass).
+ *  - On narrow viewports the margin column stacks below the article as a
+ *    plain list.
  *
  * The student's live `answer` field is never read here — the snapshot is
  * the only source of truth, which keeps annotation offsets stable even
@@ -25,6 +32,7 @@ import React, {
   useCallback,
   useEffect,
   useId,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -33,7 +41,6 @@ import { MessageSquare, Trash2, X } from 'lucide-react';
 import type { WrittenAnswerAnnotation } from '@/types';
 import {
   getPlainTextOffsetFromRange,
-  highlightClass,
   parseSnapshotRoot,
   renderAnnotatedSnapshot,
 } from '@/utils/writtenAnnotations';
@@ -67,6 +74,14 @@ interface EditProps extends BaseProps {
   authorUid: string;
   /** Called with the next annotation list whenever it changes. */
   onChange: (next: WrittenAnswerAnnotation[]) => void;
+  /**
+   * Controlled active-annotation id. The annotation editor popover renders
+   * next to this mark; if `null`, no popover is open. The parent grader
+   * sidebar drives this when the teacher clicks an annotation list item.
+   */
+  activeId: string | null;
+  /** Called when the active annotation changes (click on mark, popover close, create-with-comment). */
+  onActiveIdChange: (id: string | null) => void;
 }
 
 interface ReadProps extends BaseProps {
@@ -84,9 +99,37 @@ export const AnnotatedResponseView: React.FC<Props> = (props) => {
 
 // ─── Read-only (student review) ─────────────────────────────────────────────
 
+const COMMENT_CHIP_MIN_HEIGHT = 56;
+const COMMENT_CHIP_GAP = 8;
+const COMMENT_COLUMN_WIDTH_PX = 240;
+
 const ReadOnlyView: React.FC<ReadProps> = ({ snapshot, annotations }) => {
+  const containerRef = useRef<HTMLDivElement | null>(null);
   const articleRef = useRef<HTMLElement | null>(null);
   const [hoveredId, setHoveredId] = useState<string | null>(null);
+  // The mark/chip pair currently being pulsed after a click. Cleared a
+  // short moment after the click so the highlight feels intentional
+  // without lingering forever.
+  const [pulsedId, setPulsedId] = useState<string | null>(null);
+  // Position of each comment chip in the right margin. Recomputed when
+  // the article reflows.
+  const [pinnedTops, setPinnedTops] = useState<Record<string, number>>({});
+  // `useMediaQuery` would be cleaner, but a one-off matchMedia read
+  // avoids pulling in another hook. Mobile (<= md) falls back to a
+  // stacked list because absolute-pinning has nowhere to anchor.
+  const [isWide, setIsWide] = useState<boolean>(() => {
+    if (typeof window === 'undefined') return true;
+    if (typeof window.matchMedia !== 'function') return true;
+    return window.matchMedia('(min-width: 768px)').matches;
+  });
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    if (typeof window.matchMedia !== 'function') return;
+    const mq = window.matchMedia('(min-width: 768px)');
+    const onChange = () => setIsWide(mq.matches);
+    mq.addEventListener('change', onChange);
+    return () => mq.removeEventListener('change', onChange);
+  }, []);
 
   // Parse the snapshot once per `snapshot` and re-walk only when
   // `annotations` change. Hover-induced state changes (and the
@@ -98,36 +141,153 @@ const ReadOnlyView: React.FC<ReadProps> = ({ snapshot, annotations }) => {
     [parsedRoot, annotations]
   );
 
-  const commented = annotations.filter((a) => a.comment?.trim());
+  const commented = useMemo(
+    () => annotations.filter((a) => a.comment?.trim()),
+    [annotations]
+  );
 
+  // Measure each commented mark's vertical position relative to the
+  // article and run a collision-avoidance pass so chips never overlap.
+  const recomputePinnedTops = useCallback(() => {
+    if (!isWide) return;
+    if (!articleRef.current) return;
+    const article = articleRef.current;
+    const rows: { id: string; top: number }[] = [];
+    for (const a of commented) {
+      const mark = article.querySelector(
+        `mark[data-annotation-id="${CSS.escape(a.id)}"]`
+      );
+      if (!mark) continue;
+      const markRect = (mark as HTMLElement).getBoundingClientRect();
+      const articleRect = article.getBoundingClientRect();
+      rows.push({ id: a.id, top: markRect.top - articleRect.top });
+    }
+    rows.sort((a, b) => a.top - b.top);
+    // Push down rows that would overlap the previous one.
+    const next: Record<string, number> = {};
+    let cursor = 0;
+    for (const r of rows) {
+      const top = Math.max(r.top, cursor);
+      next[r.id] = top;
+      cursor = top + COMMENT_CHIP_MIN_HEIGHT + COMMENT_CHIP_GAP;
+    }
+    setPinnedTops(next);
+  }, [commented, isWide]);
+
+  // Measure the rendered article once it's in the DOM. The setState
+  // inside `recomputePinnedTops` is the standard DOM-measurement pattern
+  // (read layout in useLayoutEffect, project it into state) — there's no
+  // external system to synchronize, so the lint rule fires a false
+  // positive here.
+  useLayoutEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    recomputePinnedTops();
+  }, [recomputePinnedTops, tree]);
+
+  // Re-measure when the article box itself changes size (font load,
+  // viewport resize, content reflow inside the prose container).
+  useEffect(() => {
+    if (typeof ResizeObserver === 'undefined') return;
+    const article = articleRef.current;
+    if (!article) return;
+    const ro = new ResizeObserver(() => recomputePinnedTops());
+    ro.observe(article);
+    return () => ro.disconnect();
+  }, [recomputePinnedTops]);
+
+  const handleMarkClick = useCallback(
+    (e: React.MouseEvent<HTMLElement>) => {
+      const mark = (e.target as HTMLElement).closest('mark');
+      if (!mark) return;
+      const id = mark.getAttribute('data-annotation-id');
+      if (!id) return;
+      const a = annotations.find((x) => x.id === id);
+      if (!a?.comment?.trim()) return;
+      setPulsedId(id);
+      // Auto-clear the pulse after the animation finishes so a second
+      // click on the same mark visibly re-triggers it.
+      window.setTimeout(() => {
+        setPulsedId((prev) => (prev === id ? null : prev));
+      }, 1200);
+    },
+    [annotations]
+  );
+
+  // Stacked (mobile or no-comments) fallback layout.
+  if (!isWide || commented.length === 0) {
+    return (
+      <div className="flex flex-col gap-3">
+        <article
+          ref={articleRef}
+          className="rounded-xl border border-slate-700 bg-slate-800/60 p-4 text-sm leading-relaxed text-slate-100 max-w-none [&_mark]:transition-colors"
+          onMouseOver={(e) => {
+            const t = (e.target as HTMLElement).closest('mark');
+            if (t) setHoveredId(t.getAttribute('data-annotation-id'));
+          }}
+          onMouseOut={() => setHoveredId(null)}
+          onClick={handleMarkClick}
+        >
+          {tree}
+        </article>
+        {commented.length > 0 && (
+          <aside className="flex flex-col gap-2">
+            <h4 className="text-[10px] font-bold uppercase tracking-wider text-slate-400">
+              Teacher notes
+            </h4>
+            {commented.map((a) => (
+              <CommentChip
+                key={a.id}
+                annotation={a}
+                highlighted={hoveredId === a.id || pulsedId === a.id}
+                onHover={(on) => setHoveredId(on ? a.id : null)}
+              />
+            ))}
+          </aside>
+        )}
+      </div>
+    );
+  }
+
+  // Wide layout: comments pinned in the right margin, vertically aligned
+  // with their highlight. Note the column is `relative` so absolute-pinned
+  // chips position against it.
   return (
-    <div className="grid grid-cols-1 md:grid-cols-[1fr_220px] gap-3">
+    <div
+      ref={containerRef}
+      className="grid grid-cols-[1fr_auto] gap-4"
+      style={{ gridTemplateColumns: `1fr ${COMMENT_COLUMN_WIDTH_PX}px` }}
+    >
       <article
         ref={articleRef}
-        className="rounded-xl border border-slate-700 bg-slate-800/60 p-4 text-sm leading-relaxed text-slate-100 prose prose-sm prose-invert max-w-none [&_mark]:transition-colors"
+        className="rounded-xl border border-slate-700 bg-slate-800/60 p-4 text-sm leading-relaxed text-slate-100 max-w-none [&_mark]:transition-colors"
         onMouseOver={(e) => {
           const t = (e.target as HTMLElement).closest('mark');
           if (t) setHoveredId(t.getAttribute('data-annotation-id'));
         }}
         onMouseOut={() => setHoveredId(null)}
+        onClick={handleMarkClick}
       >
         {tree}
       </article>
-      {commented.length > 0 && (
-        <aside className="flex flex-col gap-2">
-          <h4 className="text-[10px] font-bold uppercase tracking-wider text-slate-400">
-            Teacher notes
-          </h4>
-          {commented.map((a) => (
-            <CommentChip
-              key={a.id}
-              annotation={a}
-              highlighted={hoveredId === a.id}
-              onHover={(on) => setHoveredId(on ? a.id : null)}
-            />
-          ))}
-        </aside>
-      )}
+      <aside
+        className="relative"
+        style={{ minHeight: '100%' }}
+        aria-label="Teacher notes"
+      >
+        <h4 className="text-[10px] font-bold uppercase tracking-wider text-slate-400 mb-2">
+          Teacher notes
+        </h4>
+        {commented.map((a) => (
+          <CommentChip
+            key={a.id}
+            annotation={a}
+            highlighted={hoveredId === a.id || pulsedId === a.id}
+            pinned
+            top={pinnedTops[a.id] ?? 0}
+            onHover={(on) => setHoveredId(on ? a.id : null)}
+          />
+        ))}
+      </aside>
     </div>
   );
 };
@@ -136,13 +296,17 @@ const CommentChip: React.FC<{
   annotation: WrittenAnswerAnnotation;
   highlighted: boolean;
   onHover: (on: boolean) => void;
-}> = ({ annotation, highlighted, onHover }) => (
+  /** When pinned, the chip uses absolute positioning at the supplied top. */
+  pinned?: boolean;
+  top?: number;
+}> = ({ annotation, highlighted, onHover, pinned, top }) => (
   <div
     className={`rounded-lg border p-2.5 text-xs leading-relaxed transition-colors ${
       highlighted
-        ? 'border-violet-400/60 bg-violet-500/10 text-slate-100'
+        ? 'border-violet-400/60 bg-violet-500/10 text-slate-100 shadow-lg shadow-violet-500/10'
         : 'border-slate-700 bg-slate-800/60 text-slate-300'
-    }`}
+    } ${pinned ? 'absolute left-0 right-0' : ''}`}
+    style={pinned ? { top: `${top ?? 0}px` } : undefined}
     onMouseEnter={() => onHover(true)}
     onMouseLeave={() => onHover(false)}
   >
@@ -169,8 +333,11 @@ const EditView: React.FC<EditProps> = ({
   annotations,
   authorUid,
   onChange,
+  activeId,
+  onActiveIdChange,
 }) => {
   const articleRef = useRef<HTMLElement | null>(null);
+  const containerRef = useRef<HTMLDivElement | null>(null);
   const reactId = useId();
   const [palette, setPalette] = useState<{
     x: number;
@@ -178,12 +345,21 @@ const EditView: React.FC<EditProps> = ({
     from: number;
     to: number;
   } | null>(null);
-  const [activeId, setActiveId] = useState<string | null>(null);
   const [commentDraft, setCommentDraft] = useState<string>('');
+
+  // Keep `commentDraft` in sync with whichever annotation is active. We use
+  // the "adjusting state while rendering" pattern (track previous activeId)
+  // so the reset happens without an extra effect/render cycle.
+  const [prevActiveId, setPrevActiveId] = useState<string | null>(activeId);
+  if (prevActiveId !== activeId) {
+    setPrevActiveId(activeId);
+    const a = activeId ? annotations.find((x) => x.id === activeId) : null;
+    setCommentDraft(a?.comment ?? '');
+  }
 
   // Same memoization split as ReadOnlyView: parse once per snapshot,
   // re-walk on annotation changes. Critical in edit mode because the
-  // margin-comment editor calls `onChange` on every keystroke, so
+  // popover comment editor calls `onChange` on every keystroke, so
   // `annotations` mutates per keypress and would otherwise re-
   // DOMParse the whole snapshot each time.
   const parsedRoot = useMemo(() => parseSnapshotRoot(snapshot), [snapshot]);
@@ -196,7 +372,7 @@ const EditView: React.FC<EditProps> = ({
   // article and convert it to plaintext offsets. If nothing's selected
   // (or the selection is outside the article), close the palette.
   const handleMouseUp = useCallback(() => {
-    if (!articleRef.current) return;
+    if (!articleRef.current || !containerRef.current) return;
     const selection = window.getSelection();
     if (!selection || selection.isCollapsed) {
       setPalette(null);
@@ -207,7 +383,7 @@ const EditView: React.FC<EditProps> = ({
     if (!offsets) {
       // Surface this — a silently-dismissed palette looks like the
       // feature is broken. Common cause: the selection straddles the
-      // article and an adjacent element (e.g. the margin column).
+      // article and an adjacent element.
       if (!selection.isCollapsed) {
         console.warn(
           '[AnnotatedResponseView] selection could not be resolved to a snapshot offset (does it escape the response?)'
@@ -221,29 +397,34 @@ const EditView: React.FC<EditProps> = ({
       setPalette(null);
       return;
     }
-    const articleRect = articleRef.current.getBoundingClientRect();
+    const containerRect = containerRef.current.getBoundingClientRect();
     setPalette({
-      x: rect.left - articleRect.left + rect.width / 2,
-      y: rect.top - articleRect.top - 8,
+      x: rect.left - containerRect.left + rect.width / 2,
+      y: rect.top - containerRect.top - 8,
       from: offsets.from,
       to: offsets.to,
     });
-    setActiveId(null);
-  }, []);
+    onActiveIdChange(null);
+  }, [onActiveIdChange]);
 
-  // Dismiss the palette on Escape so a teacher mid-selection can bail
-  // without closing the entire modal.
+  // Dismiss the palette / popover on Escape so a teacher mid-selection can
+  // bail without closing the entire modal.
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape' && palette) {
-        // Don't stopPropagation — the modal still wants Esc-to-close
-        // when nothing's selected. We intentionally let both run.
+      if (e.key !== 'Escape') return;
+      if (palette) {
         setPalette(null);
+      } else if (activeId) {
+        onActiveIdChange(null);
+      } else {
+        return;
       }
+      // Stop the event so the parent modal doesn't also close.
+      e.stopPropagation();
     };
-    window.addEventListener('keydown', onKey);
-    return () => window.removeEventListener('keydown', onKey);
-  }, [palette]);
+    window.addEventListener('keydown', onKey, true);
+    return () => window.removeEventListener('keydown', onKey, true);
+  }, [palette, activeId, onActiveIdChange]);
 
   const handleArticleClick = useCallback(
     (e: React.MouseEvent<HTMLElement>) => {
@@ -251,9 +432,7 @@ const EditView: React.FC<EditProps> = ({
       if (mark) {
         const id = mark.getAttribute('data-annotation-id');
         if (id) {
-          const a = annotations.find((x) => x.id === id);
-          setActiveId(id);
-          setCommentDraft(a?.comment ?? '');
+          onActiveIdChange(id);
           setPalette(null);
           // Clear any selection so the palette doesn't immediately
           // reopen on mouseup.
@@ -261,10 +440,10 @@ const EditView: React.FC<EditProps> = ({
         }
         return;
       }
-      // Click on bare text — dismiss the active editor panel.
-      setActiveId(null);
+      // Click on bare text — dismiss any open popover.
+      if (activeId) onActiveIdChange(null);
     },
-    [annotations]
+    [activeId, onActiveIdChange]
   );
 
   const createAnnotation = useCallback(
@@ -282,12 +461,11 @@ const EditView: React.FC<EditProps> = ({
       onChange([...annotations, next]);
       setPalette(null);
       if (withCommentInput) {
-        setActiveId(id);
-        setCommentDraft('');
+        onActiveIdChange(id);
       }
       window.getSelection()?.removeAllRanges();
     },
-    [palette, reactId, authorUid, onChange, annotations]
+    [palette, reactId, authorUid, onChange, annotations, onActiveIdChange]
   );
 
   const updateActiveAnnotation = useCallback(
@@ -303,112 +481,119 @@ const EditView: React.FC<EditProps> = ({
   const deleteActive = useCallback(() => {
     if (!activeId) return;
     onChange(annotations.filter((a) => a.id !== activeId));
-    setActiveId(null);
-    setCommentDraft('');
-  }, [activeId, annotations, onChange]);
+    onActiveIdChange(null);
+  }, [activeId, annotations, onChange, onActiveIdChange]);
 
   const active = activeId
     ? (annotations.find((a) => a.id === activeId) ?? null)
     : null;
 
-  return (
-    <div className="grid grid-cols-1 md:grid-cols-[1fr_240px] gap-3">
-      <div className="relative">
-        <article
-          ref={articleRef}
-          className="rounded-xl border border-slate-200 bg-white p-4 text-sm leading-relaxed text-slate-800 prose prose-sm max-w-none cursor-text select-text"
-          onMouseUp={handleMouseUp}
-          onClick={handleArticleClick}
-        >
-          {tree}
-        </article>
-        {palette && (
-          <div
-            role="toolbar"
-            aria-label="Annotation palette"
-            className="absolute z-10 -translate-x-1/2 -translate-y-full flex items-center gap-1 px-1.5 py-1 bg-slate-900 text-white rounded-lg shadow-xl"
-            style={{ left: palette.x, top: palette.y }}
-            // Prevent the article's mouseup from clearing the selection
-            // before we read it; the palette handles its own clicks.
-            onMouseDown={(e) => e.preventDefault()}
-          >
-            {COLORS.map((c) => (
-              <button
-                key={c.id}
-                type="button"
-                aria-label={c.label}
-                title={c.label}
-                onClick={() => createAnnotation(c.id, false)}
-                className={`w-5 h-5 rounded-full ${c.swatch} ring-1 ring-white/40 hover:ring-2 hover:ring-white transition`}
-              />
-            ))}
-            <div className="w-px h-4 bg-slate-700 mx-0.5" />
-            <button
-              type="button"
-              aria-label="Add comment"
-              title="Add comment"
-              onClick={() => createAnnotation('yellow', true)}
-              className="p-1 rounded text-slate-300 hover:bg-slate-800 hover:text-white transition-colors"
-            >
-              <MessageSquare className="w-4 h-4" />
-            </button>
-          </div>
-        )}
-      </div>
+  // Position the comment popover beneath the active mark (or above if it
+  // would overflow the container bottom). Recomputes when the active id,
+  // snapshot, or annotation list changes (the latter so the popover
+  // re-aligns if the user types and the mark's box shifts).
+  const [popoverPos, setPopoverPos] = useState<{
+    x: number;
+    y: number;
+    placement: 'below' | 'above';
+  } | null>(null);
+  useLayoutEffect(() => {
+    if (!activeId || !articleRef.current || !containerRef.current) {
+      setPopoverPos(null);
+      return;
+    }
+    const mark = articleRef.current.querySelector(
+      `mark[data-annotation-id="${CSS.escape(activeId)}"]`
+    );
+    if (!mark) {
+      setPopoverPos(null);
+      return;
+    }
+    const markRect = (mark as HTMLElement).getBoundingClientRect();
+    const containerRect = containerRef.current.getBoundingClientRect();
+    const x = markRect.left - containerRect.left + markRect.width / 2;
+    const below = markRect.bottom - containerRect.top + 8;
+    const above = markRect.top - containerRect.top - 8;
+    // Prefer below; flip if the popover would render past the container.
+    const placement: 'below' | 'above' =
+      below + 200 > containerRect.height && above > 100 ? 'above' : 'below';
+    setPopoverPos({ x, y: placement === 'below' ? below : above, placement });
+  }, [activeId, annotations, tree]);
 
-      <aside className="flex flex-col gap-2">
-        <h4 className="text-[10px] font-bold uppercase tracking-wider text-slate-500">
-          Annotations ({annotations.length})
-        </h4>
-        {annotations.length === 0 && (
-          <p className="text-xs text-slate-500 italic leading-relaxed">
-            Select text in the response to add a highlight or margin comment.
-          </p>
-        )}
-        {active ? (
-          <ActiveAnnotationEditor
-            annotation={active}
-            commentDraft={commentDraft}
-            onCommentChange={(v) => {
-              setCommentDraft(v);
-              updateActiveAnnotation({ comment: v.trim() || undefined });
-            }}
-            onColorChange={(c) => updateActiveAnnotation({ highlightColor: c })}
-            onDelete={deleteActive}
-            onClose={() => setActiveId(null)}
-          />
-        ) : (
-          annotations.map((a) => (
+  return (
+    <div ref={containerRef} className="relative">
+      <article
+        ref={articleRef}
+        className="rounded-xl border border-slate-200 bg-white p-6 text-base leading-relaxed text-slate-800 max-w-none cursor-text select-text"
+        onMouseUp={handleMouseUp}
+        onClick={handleArticleClick}
+      >
+        {tree}
+      </article>
+      {palette && (
+        <div
+          role="toolbar"
+          aria-label="Annotation palette"
+          className="absolute z-popover -translate-x-1/2 -translate-y-full flex items-center gap-1 px-1.5 py-1 bg-slate-900 text-white rounded-lg shadow-xl"
+          style={{ left: palette.x, top: palette.y }}
+          // Prevent the article's mouseup from clearing the selection
+          // before we read it; the palette handles its own clicks.
+          onMouseDown={(e) => e.preventDefault()}
+        >
+          {COLORS.map((c) => (
             <button
-              key={a.id}
+              key={c.id}
               type="button"
-              onClick={() => {
-                setActiveId(a.id);
-                setCommentDraft(a.comment ?? '');
-              }}
-              className="text-left rounded-lg border border-slate-200 bg-slate-50 hover:bg-slate-100 p-2 text-xs leading-relaxed transition-colors"
-            >
-              <span
-                className={`inline-block px-1.5 rounded ${highlightClass(a.highlightColor)} pointer-events-none`}
-              >
-                highlight
-              </span>
-              {a.comment ? (
-                <span className="ml-2 text-slate-700">{a.comment}</span>
-              ) : (
-                <span className="ml-2 text-slate-400 italic">(no comment)</span>
-              )}
-            </button>
-          ))
-        )}
-      </aside>
+              aria-label={c.label}
+              title={c.label}
+              onClick={() => createAnnotation(c.id, false)}
+              className={`w-5 h-5 rounded-full ${c.swatch} ring-1 ring-white/40 hover:ring-2 hover:ring-white transition`}
+            />
+          ))}
+          <div className="w-px h-4 bg-slate-700 mx-0.5" />
+          <button
+            type="button"
+            aria-label="Add comment"
+            title="Add comment"
+            onClick={() => createAnnotation('yellow', true)}
+            className="p-1 rounded text-slate-300 hover:bg-slate-800 hover:text-white transition-colors"
+          >
+            <MessageSquare className="w-4 h-4" />
+          </button>
+        </div>
+      )}
+      {active && popoverPos && (
+        <AnchoredAnnotationEditor
+          annotation={active}
+          commentDraft={commentDraft}
+          x={popoverPos.x}
+          y={popoverPos.y}
+          placement={popoverPos.placement}
+          onCommentChange={(v) => {
+            setCommentDraft(v);
+            updateActiveAnnotation({ comment: v.trim() || undefined });
+          }}
+          onColorChange={(c) => updateActiveAnnotation({ highlightColor: c })}
+          onDelete={deleteActive}
+          onClose={() => onActiveIdChange(null)}
+        />
+      )}
     </div>
   );
 };
 
-const ActiveAnnotationEditor: React.FC<{
+/**
+ * Editor popover anchored to the active mark inside the article. Auto-focuses
+ * the textarea on mount so the teacher can start typing immediately — that's
+ * the bug we're fixing (the previous sidebar editor was technically present
+ * but easy to miss).
+ */
+const AnchoredAnnotationEditor: React.FC<{
   annotation: WrittenAnswerAnnotation;
   commentDraft: string;
+  x: number;
+  y: number;
+  placement: 'below' | 'above';
   onCommentChange: (v: string) => void;
   onColorChange: (c: Color) => void;
   onDelete: () => void;
@@ -416,58 +601,79 @@ const ActiveAnnotationEditor: React.FC<{
 }> = ({
   annotation,
   commentDraft,
+  x,
+  y,
+  placement,
   onCommentChange,
   onColorChange,
   onDelete,
   onClose,
-}) => (
-  <div className="rounded-lg border border-violet-400/60 bg-violet-50 p-2.5 flex flex-col gap-2">
-    <div className="flex items-center justify-between">
-      <div className="flex items-center gap-1">
-        {COLORS.map((c) => (
+}) => {
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+  useEffect(() => {
+    textareaRef.current?.focus();
+  }, [annotation.id]);
+  return (
+    <div
+      role="dialog"
+      aria-label="Annotation editor"
+      className={`absolute z-popover -translate-x-1/2 ${
+        placement === 'above' ? '-translate-y-full' : ''
+      } w-72 rounded-xl border border-violet-300 bg-white p-3 shadow-xl flex flex-col gap-2`}
+      style={{ left: x, top: y }}
+      // Block clicks inside the popover from bubbling to the article
+      // (which would clear activeId via `handleArticleClick`).
+      onClick={(e) => e.stopPropagation()}
+      onMouseUp={(e) => e.stopPropagation()}
+    >
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-1">
+          {COLORS.map((c) => (
+            <button
+              key={c.id}
+              type="button"
+              aria-label={c.label}
+              title={c.label}
+              onClick={() => onColorChange(c.id)}
+              className={`w-5 h-5 rounded-full ${c.swatch} ${
+                annotation.highlightColor === c.id
+                  ? 'ring-2 ring-violet-600'
+                  : 'ring-1 ring-slate-300'
+              } transition`}
+            />
+          ))}
+        </div>
+        <div className="flex items-center gap-0.5">
           <button
-            key={c.id}
             type="button"
-            aria-label={c.label}
-            title={c.label}
-            onClick={() => onColorChange(c.id)}
-            className={`w-4 h-4 rounded-full ${c.swatch} ${
-              annotation.highlightColor === c.id
-                ? 'ring-2 ring-violet-600'
-                : 'ring-1 ring-slate-300'
-            } transition`}
-          />
-        ))}
+            aria-label="Delete annotation"
+            title="Delete"
+            onClick={onDelete}
+            className="p-1 rounded text-slate-500 hover:bg-brand-red-lighter/40 hover:text-brand-red-dark transition-colors"
+          >
+            <Trash2 className="w-4 h-4" />
+          </button>
+          <button
+            type="button"
+            aria-label="Close annotation editor"
+            title="Close"
+            onClick={onClose}
+            className="p-1 rounded text-slate-500 hover:bg-slate-200 transition-colors"
+          >
+            <X className="w-4 h-4" />
+          </button>
+        </div>
       </div>
-      <div className="flex items-center gap-0.5">
-        <button
-          type="button"
-          aria-label="Delete annotation"
-          title="Delete"
-          onClick={onDelete}
-          className="p-1 rounded text-slate-500 hover:bg-brand-red-lighter/40 hover:text-brand-red-dark transition-colors"
-        >
-          <Trash2 className="w-3.5 h-3.5" />
-        </button>
-        <button
-          type="button"
-          aria-label="Close annotation editor"
-          title="Close"
-          onClick={onClose}
-          className="p-1 rounded text-slate-500 hover:bg-slate-200 transition-colors"
-        >
-          <X className="w-3.5 h-3.5" />
-        </button>
-      </div>
+      <textarea
+        ref={textareaRef}
+        value={commentDraft}
+        onChange={(e) => onCommentChange(e.target.value)}
+        rows={3}
+        placeholder="Margin comment (optional)"
+        className="w-full px-2 py-1.5 bg-white border border-slate-300 rounded text-sm text-slate-800 placeholder:text-slate-400 focus:outline-none focus:ring-2 focus:ring-violet-400/40 focus:border-violet-400 resize-none"
+      />
     </div>
-    <textarea
-      value={commentDraft}
-      onChange={(e) => onCommentChange(e.target.value)}
-      rows={3}
-      placeholder="Margin comment (optional)"
-      className="w-full px-2 py-1.5 bg-white border border-slate-300 rounded text-xs text-slate-800 placeholder:text-slate-400 focus:outline-none focus:ring-2 focus:ring-violet-400/40 focus:border-violet-400 resize-none"
-    />
-  </div>
-);
+  );
+};
 
 export default AnnotatedResponseView;

--- a/components/widgets/QuizWidget/components/AnnotatedResponseView.tsx
+++ b/components/widgets/QuizWidget/components/AnnotatedResponseView.tsx
@@ -157,8 +157,25 @@ const ReadOnlyView: React.FC<ReadProps> = ({ snapshot, annotations }) => {
       const mark = article.querySelector(
         `mark[data-annotation-id="${CSS.escape(a.id)}"]`
       );
-      if (!mark) continue;
-      const markRect = (mark as HTMLElement).getBoundingClientRect();
+      if (!mark) {
+        // The annotation has a comment but no <mark> rendered for it —
+        // either offsets pointed past the snapshot's plaintext length or
+        // a future renderer change dropped it. Either way the comment
+        // would silently disappear from the margin; surface it.
+        console.warn(
+          '[AnnotatedResponseView] commented annotation has no <mark> in DOM',
+          a.id
+        );
+        continue;
+      }
+      // Use the first client rect so a mark that wraps to a new line
+      // anchors its comment to the FIRST visual line. The bounding rect
+      // would span both lines and place the chip in the gap between.
+      const rects = (mark as HTMLElement).getClientRects();
+      const markRect = rects.length > 0 ? rects[0] : null;
+      if (!markRect || (markRect.width === 0 && markRect.height === 0)) {
+        continue;
+      }
       const articleRect = article.getBoundingClientRect();
       rows.push({ id: a.id, top: markRect.top - articleRect.top });
     }
@@ -171,29 +188,71 @@ const ReadOnlyView: React.FC<ReadProps> = ({ snapshot, annotations }) => {
       next[r.id] = top;
       cursor = top + COMMENT_CHIP_MIN_HEIGHT + COMMENT_CHIP_GAP;
     }
-    setPinnedTops(next);
+    // Skip the setState entirely when the result is identical so a
+    // grader-side annotations array mutation that doesn't shift any
+    // mark's position doesn't trigger a render cascade.
+    setPinnedTops((prev) => {
+      const prevKeys = Object.keys(prev);
+      const nextKeys = Object.keys(next);
+      if (prevKeys.length === nextKeys.length) {
+        let same = true;
+        for (const k of nextKeys) {
+          if (prev[k] !== next[k]) {
+            same = false;
+            break;
+          }
+        }
+        if (same) return prev;
+      }
+      return next;
+    });
   }, [commented, isWide]);
 
+  // Hold the latest measurement callback in a ref so the long-lived
+  // ResizeObserver effect below can invoke the current closure without
+  // having to depend on `recomputePinnedTops` itself — depending on it
+  // would re-create the observer on every annotation change.
+  const recomputePinnedTopsRef = useRef(recomputePinnedTops);
+  useEffect(() => {
+    recomputePinnedTopsRef.current = recomputePinnedTops;
+  }, [recomputePinnedTops]);
+
   // Measure the rendered article once it's in the DOM. The setState
-  // inside `recomputePinnedTops` is the standard DOM-measurement pattern
-  // (read layout in useLayoutEffect, project it into state) — there's no
-  // external system to synchronize, so the lint rule fires a false
-  // positive here.
+  // inside `recomputePinnedTops` is the standard DOM-measurement
+  // pattern (read layout in useLayoutEffect, project it into state) —
+  // there's no external system to synchronize, so the lint rule fires
+  // a false positive here.
   useLayoutEffect(() => {
     // eslint-disable-next-line react-hooks/set-state-in-effect
     recomputePinnedTops();
   }, [recomputePinnedTops, tree]);
 
   // Re-measure when the article box itself changes size (font load,
-  // viewport resize, content reflow inside the prose container).
+  // viewport resize, content reflow). Observe once per mounted article;
+  // the callback ref keeps the listener pointing at the latest closure
+  // without churning observer subscriptions.
   useEffect(() => {
     if (typeof ResizeObserver === 'undefined') return;
     const article = articleRef.current;
     if (!article) return;
-    const ro = new ResizeObserver(() => recomputePinnedTops());
+    const ro = new ResizeObserver(() => recomputePinnedTopsRef.current());
     ro.observe(article);
     return () => ro.disconnect();
-  }, [recomputePinnedTops]);
+  }, []);
+
+  // Pulse-timeout cleanup. Without this, a click that triggers a pulse
+  // followed by an unmount within 1.2s would call setPulsedId on a dead
+  // component. React 19 silently no-ops the state update but the
+  // outstanding timer is still a (tiny) leak.
+  const pulseTimerRef = useRef<number | null>(null);
+  useEffect(
+    () => () => {
+      if (pulseTimerRef.current !== null) {
+        window.clearTimeout(pulseTimerRef.current);
+      }
+    },
+    []
+  );
 
   const handleMarkClick = useCallback(
     (e: React.MouseEvent<HTMLElement>) => {
@@ -206,8 +265,12 @@ const ReadOnlyView: React.FC<ReadProps> = ({ snapshot, annotations }) => {
       setPulsedId(id);
       // Auto-clear the pulse after the animation finishes so a second
       // click on the same mark visibly re-triggers it.
-      window.setTimeout(() => {
+      if (pulseTimerRef.current !== null) {
+        window.clearTimeout(pulseTimerRef.current);
+      }
+      pulseTimerRef.current = window.setTimeout(() => {
         setPulsedId((prev) => (prev === id ? null : prev));
+        pulseTimerRef.current = null;
       }, 1200);
     },
     [annotations]
@@ -345,17 +408,6 @@ const EditView: React.FC<EditProps> = ({
     from: number;
     to: number;
   } | null>(null);
-  const [commentDraft, setCommentDraft] = useState<string>('');
-
-  // Keep `commentDraft` in sync with whichever annotation is active. We use
-  // the "adjusting state while rendering" pattern (track previous activeId)
-  // so the reset happens without an extra effect/render cycle.
-  const [prevActiveId, setPrevActiveId] = useState<string | null>(activeId);
-  if (prevActiveId !== activeId) {
-    setPrevActiveId(activeId);
-    const a = activeId ? annotations.find((x) => x.id === activeId) : null;
-    setCommentDraft(a?.comment ?? '');
-  }
 
   // Same memoization split as ReadOnlyView: parse once per snapshot,
   // re-walk on annotation changes. Critical in edit mode because the
@@ -407,9 +459,13 @@ const EditView: React.FC<EditProps> = ({
     onActiveIdChange(null);
   }, [onActiveIdChange]);
 
-  // Dismiss the palette / popover on Escape so a teacher mid-selection can
-  // bail without closing the entire modal.
+  // Dismiss the palette / popover on Escape. Listener is scoped to the
+  // container so an Escape pressed inside the grading sidebar (Points
+  // input, Overall comment textarea) still bubbles to the parent modal's
+  // close handler.
   useEffect(() => {
+    const containerEl = containerRef.current;
+    if (!containerEl) return;
     const onKey = (e: KeyboardEvent) => {
       if (e.key !== 'Escape') return;
       if (palette) {
@@ -419,11 +475,12 @@ const EditView: React.FC<EditProps> = ({
       } else {
         return;
       }
-      // Stop the event so the parent modal doesn't also close.
+      // Only stop propagation when we actually handled the key, so the
+      // parent modal can still close via Esc when nothing's open here.
       e.stopPropagation();
     };
-    window.addEventListener('keydown', onKey, true);
-    return () => window.removeEventListener('keydown', onKey, true);
+    containerEl.addEventListener('keydown', onKey);
+    return () => containerEl.removeEventListener('keydown', onKey);
   }, [palette, activeId, onActiveIdChange]);
 
   const handleArticleClick = useCallback(
@@ -440,8 +497,14 @@ const EditView: React.FC<EditProps> = ({
         }
         return;
       }
-      // Click on bare text — dismiss any open popover.
-      if (activeId) onActiveIdChange(null);
+      // Bare-text click — only dismiss the popover if this is a true
+      // click (no active selection). Without this guard, finishing a
+      // drag-selection lands a `click` event on bare text and would
+      // close the popover the teacher just opened via the palette.
+      if (!activeId) return;
+      const sel = window.getSelection();
+      if (sel && !sel.isCollapsed) return;
+      onActiveIdChange(null);
     },
     [activeId, onActiveIdChange]
   );
@@ -489,9 +552,12 @@ const EditView: React.FC<EditProps> = ({
     : null;
 
   // Position the comment popover beneath the active mark (or above if it
-  // would overflow the container bottom). Recomputes when the active id,
-  // snapshot, or annotation list changes (the latter so the popover
-  // re-aligns if the user types and the mark's box shifts).
+  // would overflow the container bottom). Recomputes when the active id
+  // changes or the article reflows; uses the first client rect so a
+  // line-wrapped mark anchors to its first visual line (a single
+  // bounding rect would span both lines and place the popover in dead
+  // space). Skips the setState when the result is unchanged so
+  // keystrokes in the textarea don't flicker the popover.
   const [popoverPos, setPopoverPos] = useState<{
     x: number;
     y: number;
@@ -499,17 +565,34 @@ const EditView: React.FC<EditProps> = ({
   } | null>(null);
   useLayoutEffect(() => {
     if (!activeId || !articleRef.current || !containerRef.current) {
-      setPopoverPos(null);
+      setPopoverPos((prev) => (prev === null ? prev : null));
       return;
     }
     const mark = articleRef.current.querySelector(
       `mark[data-annotation-id="${CSS.escape(activeId)}"]`
     );
     if (!mark) {
-      setPopoverPos(null);
+      // The annotation exists in props but no <mark> rendered for it —
+      // shouldn't happen after `renderAnnotatedSnapshot`, but if it
+      // does the popover would silently disappear without explanation.
+      console.warn(
+        '[AnnotatedResponseView] active annotation has no <mark> in DOM',
+        activeId
+      );
+      setPopoverPos((prev) => (prev === null ? prev : null));
       return;
     }
-    const markRect = (mark as HTMLElement).getBoundingClientRect();
+    // `getClientRects()` returns one rect per line for a wrapped mark;
+    // we use the first so the popover anchors to the first visible line
+    // rather than spanning the gap between two. In environments where
+    // layout isn't computed (e.g. jsdom in unit tests) the list is empty
+    // and we fall back to the single bounding rect so the popover still
+    // renders.
+    const rects = (mark as HTMLElement).getClientRects();
+    const markRect =
+      rects.length > 0
+        ? rects[0]
+        : (mark as HTMLElement).getBoundingClientRect();
     const containerRect = containerRef.current.getBoundingClientRect();
     const x = markRect.left - containerRect.left + markRect.width / 2;
     const below = markRect.bottom - containerRect.top + 8;
@@ -517,8 +600,16 @@ const EditView: React.FC<EditProps> = ({
     // Prefer below; flip if the popover would render past the container.
     const placement: 'below' | 'above' =
       below + 200 > containerRect.height && above > 100 ? 'above' : 'below';
-    setPopoverPos({ x, y: placement === 'below' ? below : above, placement });
-  }, [activeId, annotations, tree]);
+    const next = { x, y: placement === 'below' ? below : above, placement };
+    setPopoverPos((prev) =>
+      prev &&
+      prev.x === next.x &&
+      prev.y === next.y &&
+      prev.placement === next.placement
+        ? prev
+        : next
+    );
+  }, [activeId, tree]);
 
   return (
     <div ref={containerRef} className="relative">
@@ -563,16 +654,18 @@ const EditView: React.FC<EditProps> = ({
         </div>
       )}
       {active && popoverPos && (
+        // `key={active.id}` remounts the popover for each annotation, so
+        // its internal `commentDraft` state is reset cleanly without
+        // having to track a `prevActiveId` reset pattern in the parent.
         <AnchoredAnnotationEditor
+          key={active.id}
           annotation={active}
-          commentDraft={commentDraft}
           x={popoverPos.x}
           y={popoverPos.y}
           placement={popoverPos.placement}
-          onCommentChange={(v) => {
-            setCommentDraft(v);
-            updateActiveAnnotation({ comment: v.trim() || undefined });
-          }}
+          onCommentChange={(v) =>
+            updateActiveAnnotation({ comment: v.trim() || undefined })
+          }
           onColorChange={(c) => updateActiveAnnotation({ highlightColor: c })}
           onDelete={deleteActive}
           onClose={() => onActiveIdChange(null)}
@@ -583,14 +676,15 @@ const EditView: React.FC<EditProps> = ({
 };
 
 /**
- * Editor popover anchored to the active mark inside the article. Auto-focuses
- * the textarea on mount so the teacher can start typing immediately — that's
- * the bug we're fixing (the previous sidebar editor was technically present
- * but easy to miss).
+ * Editor popover anchored to the active mark. Auto-focuses its textarea on
+ * mount (parent uses `key={annotation.id}` to remount per annotation, which
+ * also resets the internal `commentDraft`). Uses `role="group"` rather than
+ * `role="dialog"` to communicate "non-modal inline editor" — there's no
+ * focus trap, the document under it is still interactive, and the parent
+ * scopes its own Escape handler.
  */
 const AnchoredAnnotationEditor: React.FC<{
   annotation: WrittenAnswerAnnotation;
-  commentDraft: string;
   x: number;
   y: number;
   placement: 'below' | 'above';
@@ -600,7 +694,6 @@ const AnchoredAnnotationEditor: React.FC<{
   onClose: () => void;
 }> = ({
   annotation,
-  commentDraft,
   x,
   y,
   placement,
@@ -609,14 +702,17 @@ const AnchoredAnnotationEditor: React.FC<{
   onDelete,
   onClose,
 }) => {
-  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
-  useEffect(() => {
-    textareaRef.current?.focus();
-  }, [annotation.id]);
+  const labelId = useId();
+  // Local draft state. Initialized from the annotation that mounted the
+  // editor; reset is handled by the parent via `key`, so we never have to
+  // sync to incoming prop changes ourselves.
+  const [commentDraft, setCommentDraft] = useState<string>(
+    annotation.comment ?? ''
+  );
   return (
     <div
-      role="dialog"
-      aria-label="Annotation editor"
+      role="group"
+      aria-labelledby={labelId}
       className={`absolute z-popover -translate-x-1/2 ${
         placement === 'above' ? '-translate-y-full' : ''
       } w-72 rounded-xl border border-violet-300 bg-white p-3 shadow-xl flex flex-col gap-2`}
@@ -626,6 +722,9 @@ const AnchoredAnnotationEditor: React.FC<{
       onClick={(e) => e.stopPropagation()}
       onMouseUp={(e) => e.stopPropagation()}
     >
+      <span id={labelId} className="sr-only">
+        Edit annotation
+      </span>
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-1">
           {COLORS.map((c) => (
@@ -665,9 +764,13 @@ const AnchoredAnnotationEditor: React.FC<{
         </div>
       </div>
       <textarea
-        ref={textareaRef}
+        autoFocus
         value={commentDraft}
-        onChange={(e) => onCommentChange(e.target.value)}
+        onChange={(e) => {
+          const next = e.target.value;
+          setCommentDraft(next);
+          onCommentChange(next);
+        }}
         rows={3}
         placeholder="Margin comment (optional)"
         className="w-full px-2 py-1.5 bg-white border border-slate-300 rounded text-sm text-slate-800 placeholder:text-slate-400 focus:outline-none focus:ring-2 focus:ring-violet-400/40 focus:border-violet-400 resize-none"

--- a/components/widgets/QuizWidget/components/WrittenResponseGrader.tsx
+++ b/components/widgets/QuizWidget/components/WrittenResponseGrader.tsx
@@ -31,7 +31,7 @@ import {
 } from '@/types';
 import { sanitizeQuizResponse } from '@/utils/security';
 import { AnnotatedResponseView } from './AnnotatedResponseView';
-import { highlightClass } from '@/utils/writtenAnnotations';
+import { highlightClass, htmlToPlainText } from '@/utils/writtenAnnotations';
 
 interface WrittenResponseGraderProps {
   quiz: QuizData;
@@ -610,6 +610,13 @@ const AnnotationsList: React.FC<{
   activeId: string | null;
   onSelect: (id: string) => void;
 }> = ({ annotations, snapshot, activeId, onSelect }) => {
+  // Project the snapshot to plaintext through `htmlToPlainText`, NOT
+  // `textContent`. Annotation offsets are produced against `htmlToPlainText`'s
+  // projection (block tags + `<br>` insert `\n`), so a `textContent`-based
+  // slice drifts by one char per preceding block — every snippet past the
+  // first paragraph would render the wrong text. Memoized on `snapshot` so
+  // keystrokes in the popover textarea don't re-DOMParse.
+  const plaintext = useMemo(() => htmlToPlainText(snapshot), [snapshot]);
   if (annotations.length === 0) {
     return (
       <p className="text-xs text-slate-500 italic leading-relaxed">
@@ -617,19 +624,6 @@ const AnnotationsList: React.FC<{
       </p>
     );
   }
-  // Project the snapshot to plaintext once so we can show a short snippet
-  // of the highlighted text in each list row — without forcing the parent
-  // to maintain its own plaintext copy.
-  const plaintext =
-    typeof DOMParser !== 'undefined'
-      ? (() => {
-          const doc = new DOMParser().parseFromString(
-            `<div>${snapshot}</div>`,
-            'text/html'
-          );
-          return doc.body.textContent ?? '';
-        })()
-      : '';
   return (
     <div className="flex flex-col gap-1.5">
       {annotations.map((a) => {

--- a/components/widgets/QuizWidget/components/WrittenResponseGrader.tsx
+++ b/components/widgets/QuizWidget/components/WrittenResponseGrader.tsx
@@ -31,6 +31,7 @@ import {
 } from '@/types';
 import { sanitizeQuizResponse } from '@/utils/security';
 import { AnnotatedResponseView } from './AnnotatedResponseView';
+import { highlightClass } from '@/utils/writtenAnnotations';
 
 interface WrittenResponseGraderProps {
   quiz: QuizData;
@@ -126,6 +127,9 @@ export const WrittenResponseGrader: React.FC<WrittenResponseGraderProps> = ({
   const [draftAnnotations, setDraftAnnotations] = useState<
     WrittenAnswerAnnotation[]
   >([]);
+  const [activeAnnotationId, setActiveAnnotationId] = useState<string | null>(
+    null
+  );
   const [hydrationKey, setHydrationKey] = useState<string>('');
 
   const targetKey = `${responseKey ?? ''}::${question?.id ?? ''}`;
@@ -134,6 +138,7 @@ export const WrittenResponseGrader: React.FC<WrittenResponseGraderProps> = ({
     setPointsInput(savedGrade != null ? String(savedGrade.pointsAwarded) : '');
     setComment(savedGrade?.overallComment ?? '');
     setDraftAnnotations(savedGrade?.annotations ?? []);
+    setActiveAnnotationId(null);
     setSaveError(null);
   }
 
@@ -435,13 +440,13 @@ export const WrittenResponseGrader: React.FC<WrittenResponseGraderProps> = ({
         </div>
       )}
 
-      {/* Body */}
-      <div className="flex-1 grid grid-cols-[1fr_320px] min-h-0">
-        <section className="overflow-y-auto p-6 bg-slate-50">
+      {/* Body — 2-pane: response article (flex-1) + grading sidebar (~400px) */}
+      <div className="flex-1 grid grid-cols-[1fr_400px] min-h-0">
+        <section className="overflow-y-auto p-8 bg-slate-50">
           <h3 className="text-sm font-bold uppercase tracking-wider text-slate-500 mb-2">
             Question
           </h3>
-          <p className="text-base font-bold text-slate-900 mb-6 leading-snug">
+          <p className="text-lg font-bold text-slate-900 mb-8 leading-snug">
             {question.text}
           </p>
 
@@ -462,6 +467,8 @@ export const WrittenResponseGrader: React.FC<WrittenResponseGraderProps> = ({
               annotations={draftAnnotations}
               authorUid={teacherUid}
               onChange={setDraftAnnotations}
+              activeId={activeAnnotationId}
+              onActiveIdChange={setActiveAnnotationId}
             />
           ) : (
             <div className="bg-white border border-slate-200 rounded-lg p-5 text-sm text-slate-500 italic">
@@ -470,11 +477,11 @@ export const WrittenResponseGrader: React.FC<WrittenResponseGraderProps> = ({
           )}
         </section>
 
-        <aside className="border-l border-slate-200 bg-white p-5 flex flex-col gap-4 overflow-y-auto">
+        <aside className="border-l border-slate-200 bg-white p-6 flex flex-col gap-5 overflow-y-auto">
           <div>
             <label
               htmlFor="grade-points"
-              className="block text-xs font-bold uppercase tracking-wider text-slate-500 mb-1"
+              className="block text-sm font-bold uppercase tracking-wider text-slate-500 mb-2"
             >
               Points awarded
             </label>
@@ -488,11 +495,11 @@ export const WrittenResponseGrader: React.FC<WrittenResponseGraderProps> = ({
                 max={maxPoints}
                 value={pointsInput}
                 onChange={(e) => setPointsInput(e.target.value)}
-                className="w-24 px-3 py-2 bg-white border-2 border-emerald-500/30 rounded-lg text-emerald-800 font-bold focus:outline-none focus:border-emerald-500 text-base"
+                className="w-28 px-3 py-2 bg-white border-2 border-emerald-500/30 rounded-lg text-emerald-800 font-bold focus:outline-none focus:border-emerald-500 text-lg"
                 placeholder="0"
                 autoFocus
               />
-              <span className="text-sm text-slate-500 font-mono">
+              <span className="text-base text-slate-500 font-mono">
                 / {maxPoints}
               </span>
             </div>
@@ -501,7 +508,7 @@ export const WrittenResponseGrader: React.FC<WrittenResponseGraderProps> = ({
           <div>
             <label
               htmlFor="grade-comment"
-              className="block text-xs font-bold uppercase tracking-wider text-slate-500 mb-1"
+              className="block text-sm font-bold uppercase tracking-wider text-slate-500 mb-2"
             >
               Overall comment (optional)
             </label>
@@ -509,9 +516,24 @@ export const WrittenResponseGrader: React.FC<WrittenResponseGraderProps> = ({
               id="grade-comment"
               value={comment}
               onChange={(e) => setComment(e.target.value)}
-              rows={6}
+              rows={5}
               placeholder="Feedback for this student…"
               className="w-full px-3 py-2 bg-white border border-slate-300 rounded-lg text-slate-900 placeholder:text-slate-400 focus:outline-none focus:ring-2 focus:ring-brand-blue-primary/40 focus:border-brand-blue-primary text-sm resize-none"
+            />
+          </div>
+
+          <div className="pt-2 border-t border-slate-200">
+            <h4 className="text-sm font-bold uppercase tracking-wider text-slate-500 mb-2">
+              Highlights &amp; comments ({draftAnnotations.length})
+            </h4>
+            <AnnotationsList
+              annotations={draftAnnotations}
+              snapshot={
+                savedGrade?.gradingSnapshot ??
+                (studentAnswer ? sanitizeQuizResponse(studentAnswer) : '')
+              }
+              activeId={activeAnnotationId}
+              onSelect={setActiveAnnotationId}
             />
           </div>
 
@@ -524,7 +546,7 @@ export const WrittenResponseGrader: React.FC<WrittenResponseGraderProps> = ({
           <button
             onClick={() => void handleSave()}
             disabled={saving}
-            className="w-full py-2.5 bg-brand-blue-primary hover:bg-brand-blue-dark disabled:opacity-50 disabled:cursor-not-allowed text-white font-bold rounded-lg flex items-center justify-center gap-2 transition-colors"
+            className="w-full py-3 bg-brand-blue-primary hover:bg-brand-blue-dark disabled:opacity-50 disabled:cursor-not-allowed text-white font-bold rounded-lg flex items-center justify-center gap-2 transition-colors"
           >
             {saving ? (
               <Loader2 className="w-4 h-4 animate-spin" />
@@ -539,8 +561,8 @@ export const WrittenResponseGrader: React.FC<WrittenResponseGraderProps> = ({
 
           <p className="text-xs text-slate-500 leading-relaxed">
             ← / → switch students. Esc closes the grader. Select text in the
-            response to add a highlight or margin comment. Rubric scoring is
-            coming in Phase 3.
+            response to highlight; click an existing highlight to edit its
+            comment.
           </p>
         </aside>
       </div>
@@ -575,6 +597,76 @@ const annotationListsEqual = (
   return true;
 };
 
+/**
+ * Scannable list of every annotation on the active question. Clicking a row
+ * sets `activeId` on the parent, which drives the popover anchored next to
+ * the corresponding mark inside the response article. The teacher's eye
+ * stays in one place — list ↔ article — instead of bouncing to a sidebar
+ * editor that they previously couldn't find.
+ */
+const AnnotationsList: React.FC<{
+  annotations: WrittenAnswerAnnotation[];
+  snapshot: string;
+  activeId: string | null;
+  onSelect: (id: string) => void;
+}> = ({ annotations, snapshot, activeId, onSelect }) => {
+  if (annotations.length === 0) {
+    return (
+      <p className="text-xs text-slate-500 italic leading-relaxed">
+        Select text in the response to add a highlight or margin comment.
+      </p>
+    );
+  }
+  // Project the snapshot to plaintext once so we can show a short snippet
+  // of the highlighted text in each list row — without forcing the parent
+  // to maintain its own plaintext copy.
+  const plaintext =
+    typeof DOMParser !== 'undefined'
+      ? (() => {
+          const doc = new DOMParser().parseFromString(
+            `<div>${snapshot}</div>`,
+            'text/html'
+          );
+          return doc.body.textContent ?? '';
+        })()
+      : '';
+  return (
+    <div className="flex flex-col gap-1.5">
+      {annotations.map((a) => {
+        const snippet = plaintext.slice(a.from, a.to);
+        const truncated =
+          snippet.length > 60 ? `${snippet.slice(0, 60)}…` : snippet;
+        const isActive = a.id === activeId;
+        return (
+          <button
+            key={a.id}
+            type="button"
+            onClick={() => onSelect(a.id)}
+            className={`text-left rounded-lg border p-2 text-xs leading-relaxed transition-colors ${
+              isActive
+                ? 'border-violet-400 bg-violet-50'
+                : 'border-slate-200 bg-slate-50 hover:bg-slate-100'
+            }`}
+          >
+            <span
+              className={`inline-block px-1.5 rounded ${highlightClass(a.highlightColor)} pointer-events-none`}
+            >
+              {truncated || 'highlight'}
+            </span>
+            {a.comment ? (
+              <span className="mt-1 block text-slate-700">{a.comment}</span>
+            ) : (
+              <span className="mt-1 block text-slate-400 italic">
+                (no comment yet — click to add)
+              </span>
+            )}
+          </button>
+        );
+      })}
+    </div>
+  );
+};
+
 const ModalShell: React.FC<{
   onClose: () => void;
   children: React.ReactNode;
@@ -596,7 +688,10 @@ const ModalShell: React.FC<{
       className="absolute inset-0 cursor-default"
       onClick={onClose}
     />
-    <div className="relative bg-white rounded-2xl shadow-2xl w-full max-w-6xl h-[90vh] flex flex-col overflow-hidden">
+    <div
+      className="relative bg-white rounded-2xl shadow-2xl w-full max-w-[1400px] h-[92vh] flex flex-col overflow-hidden"
+      style={{ maxWidth: 'min(95vw, 1400px)' }}
+    >
       {children}
     </div>
   </div>

--- a/hooks/useStudentAssignments.ts
+++ b/hooks/useStudentAssignments.ts
@@ -150,6 +150,20 @@ export const KIND_CONFIG: Record<SessionKind, KindConfig> = {
       // student. Both must be present for the student to see results.
       const visibility = (data as Record<string, unknown>).scoreVisibility;
       const publishedAt = (data as Record<string, unknown>).scorePublishedAt;
+      // Surface data-shape mismatches — if one field is present but the
+      // other has the wrong type, the student silently sees "Not graded"
+      // on a session the teacher believes they published. This is the
+      // kind of "support ticket with no traces in the data" bug worth a
+      // console.warn so it shows up in error reporting.
+      if (
+        (visibility !== undefined && typeof visibility !== 'string') ||
+        (publishedAt !== undefined && typeof publishedAt !== 'number')
+      ) {
+        console.warn(
+          '[useStudentAssignments] malformed quiz publication fields',
+          { scoreVisibility: visibility, scorePublishedAt: publishedAt }
+        );
+      }
       const isVisible = typeof visibility === 'string' && visibility !== 'none';
       const isPublished = typeof publishedAt === 'number';
       return isVisible && isPublished ? 'graded' : 'not-graded';

--- a/hooks/useStudentAssignments.ts
+++ b/hooks/useStudentAssignments.ts
@@ -148,6 +148,10 @@ export const KIND_CONFIG: Record<SessionKind, KindConfig> = {
       // Quiz uses `scoreVisibility` ('none' = hidden) plus a
       // `scorePublishedAt` timestamp to mark when grades go live to the
       // student. Both must be present for the student to see results.
+      // Guard the cast — Firestore can hand back partial/empty snapshots
+      // during deletion races, and a runtime TypeError here would crash
+      // the whole assignment list instead of just dropping one row.
+      if (!data || typeof data !== 'object') return 'not-graded';
       const visibility = (data as Record<string, unknown>).scoreVisibility;
       const publishedAt = (data as Record<string, unknown>).scorePublishedAt;
       // Surface data-shape mismatches — if one field is present but the

--- a/hooks/useStudentAssignments.ts
+++ b/hooks/useStudentAssignments.ts
@@ -72,6 +72,14 @@ export interface AssignmentSummary {
   classIds: string[];
   createdAt?: number;
   endedAt?: number;
+  /**
+   * Whether the teacher has published grades / made results visible to the
+   * student. Drives the Completed-row status chip ("Not graded" vs "View
+   * results"). For kinds without an explicit publish step, this stays
+   * 'not-graded' — the student still sees their submission; the chip just
+   * doesn't promise a score is waiting.
+   */
+  gradingState: 'not-graded' | 'graded';
 }
 
 export type LoadState = 'loading' | 'ready';
@@ -104,6 +112,13 @@ interface KindConfig {
   accent: string;
   titleFrom: (data: DocumentData) => string;
   hrefFrom: (sessionId: string, data: DocumentData) => string;
+  /**
+   * Derive whether grades / results have been published to the student from
+   * the session document. Each kind decides its own publish signal — quiz
+   * uses `scoreVisibility` + `scorePublishedAt`; other kinds default to
+   * 'not-graded' until they grow an explicit publish step.
+   */
+  gradingStateFrom: (data: DocumentData) => 'not-graded' | 'graded';
 }
 
 export const KIND_CONFIG: Record<SessionKind, KindConfig> = {
@@ -128,6 +143,16 @@ export const KIND_CONFIG: Record<SessionKind, KindConfig> = {
           ? data.code
           : sessionId;
       return `/quiz?code=${encodeURIComponent(code)}`;
+    },
+    gradingStateFrom: (data) => {
+      // Quiz uses `scoreVisibility` ('none' = hidden) plus a
+      // `scorePublishedAt` timestamp to mark when grades go live to the
+      // student. Both must be present for the student to see results.
+      const visibility = (data as Record<string, unknown>).scoreVisibility;
+      const publishedAt = (data as Record<string, unknown>).scorePublishedAt;
+      const isVisible = typeof visibility === 'string' && visibility !== 'none';
+      const isPublished = typeof publishedAt === 'number';
+      return isVisible && isPublished ? 'graded' : 'not-graded';
     },
   },
   'video-activity': {
@@ -155,6 +180,7 @@ export const KIND_CONFIG: Record<SessionKind, KindConfig> = {
       return 'Video activity';
     },
     hrefFrom: (sessionId) => `/activity/${encodeURIComponent(sessionId)}`,
+    gradingStateFrom: () => 'not-graded',
   },
   'guided-learning': {
     collectionName: 'guided_learning_sessions',
@@ -172,6 +198,7 @@ export const KIND_CONFIG: Record<SessionKind, KindConfig> = {
         : 'Guided learning',
     hrefFrom: (sessionId) =>
       `/guided-learning/${encodeURIComponent(sessionId)}`,
+    gradingStateFrom: () => 'not-graded',
   },
   'mini-app': {
     collectionName: 'mini_app_sessions',
@@ -195,6 +222,7 @@ export const KIND_CONFIG: Record<SessionKind, KindConfig> = {
       return 'Mini app';
     },
     hrefFrom: (sessionId) => `/miniapp/${encodeURIComponent(sessionId)}`,
+    gradingStateFrom: () => 'not-graded',
   },
   'activity-wall': {
     collectionName: 'activity_wall_sessions',
@@ -211,6 +239,7 @@ export const KIND_CONFIG: Record<SessionKind, KindConfig> = {
         ? data.title
         : 'Activity wall',
     hrefFrom: (sessionId) => `/activity-wall/${encodeURIComponent(sessionId)}`,
+    gradingStateFrom: () => 'not-graded',
   },
 };
 
@@ -392,6 +421,7 @@ export function useStudentAssignments({
         classIds: intersected,
         createdAt: typeof createdAtRaw === 'number' ? createdAtRaw : undefined,
         endedAt: typeof endedAtRaw === 'number' ? endedAtRaw : undefined,
+        gradingState: config.gradingStateFrom(data),
       };
     };
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -7,7 +7,7 @@ export default {
     './components/**/*.{js,ts,jsx,tsx}',
     './context/**/*.{js,ts,jsx,tsx}',
     './hooks/**/*.{js,ts,jsx,tsx}',
-    './utils/**/*.{js,ts}',
+    './utils/**/*.{js,ts,jsx,tsx}',
     './*.{js,ts,jsx,tsx}',
     './config/**/*.ts',
   ],

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,4 +1,5 @@
 import { Z_INDEX } from './config/zIndex';
+import { HIGHLIGHT_BG_CLASSES } from './utils/writtenAnnotations';
 
 /** @type {import('tailwindcss').Config} */
 export default {
@@ -17,15 +18,13 @@ export default {
       pattern:
         /^font-(sans|serif|mono|handwritten|rounded|fun|comic|slab|retro|marker|cursive)$/,
     },
-    // Quiz written-response highlight colors. Defined in utils/writtenAnnotations.ts
-    // and applied to <mark> elements at runtime. Without this safelist (and
-    // without scanning utils/), Tailwind would purge these and <mark> would
-    // fall back to the browser default (yellow) regardless of the teacher's
-    // color choice — the symptom of the "all highlights look yellow" bug.
-    'bg-amber-300/60',
-    'bg-emerald-300/60',
-    'bg-pink-300/60',
-    'bg-sky-300/60',
+    // Quiz written-response highlight colors. Sourced from
+    // utils/writtenAnnotations.ts so the list can't drift from
+    // `highlightClass`. Without this safelist (and without scanning
+    // utils/), Tailwind would purge these and <mark> would fall back to
+    // the browser default (yellow) regardless of the teacher's color
+    // choice — the symptom of the "all highlights look yellow" bug.
+    ...HIGHLIGHT_BG_CLASSES,
     'bg-blue-500',
     'bg-red-500',
     'bg-amber-500',

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -7,6 +7,7 @@ export default {
     './components/**/*.{js,ts,jsx,tsx}',
     './context/**/*.{js,ts,jsx,tsx}',
     './hooks/**/*.{js,ts,jsx,tsx}',
+    './utils/**/*.{js,ts}',
     './*.{js,ts,jsx,tsx}',
     './config/**/*.ts',
   ],
@@ -16,6 +17,15 @@ export default {
       pattern:
         /^font-(sans|serif|mono|handwritten|rounded|fun|comic|slab|retro|marker|cursive)$/,
     },
+    // Quiz written-response highlight colors. Defined in utils/writtenAnnotations.ts
+    // and applied to <mark> elements at runtime. Without this safelist (and
+    // without scanning utils/), Tailwind would purge these and <mark> would
+    // fall back to the browser default (yellow) regardless of the teacher's
+    // color choice — the symptom of the "all highlights look yellow" bug.
+    'bg-amber-300/60',
+    'bg-emerald-300/60',
+    'bg-pink-300/60',
+    'bg-sky-300/60',
     'bg-blue-500',
     'bg-red-500',
     'bg-amber-500',

--- a/tests/components/quiz/AnnotatedResponseView.test.tsx
+++ b/tests/components/quiz/AnnotatedResponseView.test.tsx
@@ -98,7 +98,7 @@ describe('AnnotatedResponseView — edit mode', () => {
       />
     );
     expect(
-      screen.queryByRole('dialog', { name: /annotation editor/i })
+      screen.queryByRole('group', { name: /edit annotation/i })
     ).not.toBeInTheDocument();
     // The article content renders.
     expect(screen.getByText(/hello/)).toBeInTheDocument();
@@ -119,7 +119,7 @@ describe('AnnotatedResponseView — edit mode', () => {
     fireEvent.click(mark);
     // Popover renders with the comment pre-filled.
     expect(
-      screen.getByRole('dialog', { name: /annotation editor/i })
+      screen.getByRole('group', { name: /edit annotation/i })
     ).toBeInTheDocument();
     expect(screen.getByPlaceholderText(/margin comment/i)).toHaveValue('note');
   });

--- a/tests/components/quiz/AnnotatedResponseView.test.tsx
+++ b/tests/components/quiz/AnnotatedResponseView.test.tsx
@@ -1,7 +1,35 @@
+import React from 'react';
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { AnnotatedResponseView } from '@/components/widgets/QuizWidget/components/AnnotatedResponseView';
 import type { WrittenAnswerAnnotation } from '@/types';
+
+/**
+ * Controlled wrapper for the edit-mode tests. The component now requires
+ * the parent to own `activeId`; this harness handles that so tests can
+ * focus on observable behavior (popover open/close, comment edits).
+ */
+const EditHarness: React.FC<{
+  snapshot: string;
+  annotations: WrittenAnswerAnnotation[];
+  onChange: (next: WrittenAnswerAnnotation[]) => void;
+  initialActiveId?: string | null;
+}> = ({ snapshot, annotations, onChange, initialActiveId = null }) => {
+  const [activeId, setActiveId] = React.useState<string | null>(
+    initialActiveId
+  );
+  return (
+    <AnnotatedResponseView
+      mode="edit"
+      snapshot={snapshot}
+      annotations={annotations}
+      authorUid="teacher-1"
+      onChange={onChange}
+      activeId={activeId}
+      onActiveIdChange={setActiveId}
+    />
+  );
+};
 
 const ann = (
   from: number,
@@ -61,105 +89,82 @@ describe('AnnotatedResponseView — read mode', () => {
 });
 
 describe('AnnotatedResponseView — edit mode', () => {
-  it('renders an empty-state hint when no annotations exist', () => {
+  it('renders the article without a popover when no annotation is active', () => {
     render(
-      <AnnotatedResponseView
-        mode="edit"
+      <EditHarness
         snapshot="<p>hello world</p>"
         annotations={[]}
-        authorUid="teacher-1"
         onChange={vi.fn()}
       />
     );
     expect(
-      screen.getByText(/select text in the response/i)
-    ).toBeInTheDocument();
+      screen.queryByRole('dialog', { name: /annotation editor/i })
+    ).not.toBeInTheDocument();
+    // The article content renders.
+    expect(screen.getByText(/hello/)).toBeInTheDocument();
   });
 
-  it('renders one row per saved annotation', () => {
+  it('opens an anchored popover when an existing mark is clicked', () => {
     render(
-      <AnnotatedResponseView
-        mode="edit"
+      <EditHarness
         snapshot="<p>hello world</p>"
-        annotations={[
-          ann(0, 5, { id: 'a1', comment: 'First' }),
-          ann(6, 11, { id: 'a2' }),
-        ]}
-        authorUid="teacher-1"
+        annotations={[ann(0, 5, { id: 'a1', comment: 'note' })]}
         onChange={vi.fn()}
       />
     );
-    expect(screen.getByText(/Annotations \(2\)/)).toBeInTheDocument();
-    expect(screen.getByText('First')).toBeInTheDocument();
-  });
-
-  it('opens the editor panel when an annotation row is clicked', () => {
-    const onChange = vi.fn();
-    render(
-      <AnnotatedResponseView
-        mode="edit"
-        snapshot="<p>hello world</p>"
-        annotations={[ann(0, 5, { id: 'a1', comment: 'note' })]}
-        authorUid="teacher-1"
-        onChange={onChange}
-      />
-    );
-    const row = screen.getByText('note').closest('button');
-    if (!row) throw new Error('Expected annotation row button');
-    fireEvent.click(row);
-    // Active-editor textarea pre-fills with the comment.
+    // Click the highlighted mark in the article — the parent harness
+    // surfaces the popover.
+    const mark = document.querySelector('mark[data-annotation-id="a1"]');
+    if (!mark) throw new Error('Expected a <mark> for the annotation');
+    fireEvent.click(mark);
+    // Popover renders with the comment pre-filled.
+    expect(
+      screen.getByRole('dialog', { name: /annotation editor/i })
+    ).toBeInTheDocument();
     expect(screen.getByPlaceholderText(/margin comment/i)).toHaveValue('note');
   });
 
-  it('updates the annotation list when the active comment changes', () => {
+  it('updates the annotation list when the popover textarea changes', () => {
     const onChange = vi.fn();
     render(
-      <AnnotatedResponseView
-        mode="edit"
+      <EditHarness
         snapshot="<p>hello world</p>"
         annotations={[ann(0, 5, { id: 'a1', comment: '' })]}
-        authorUid="teacher-1"
         onChange={onChange}
+        initialActiveId="a1"
       />
     );
-    fireEvent.click(screen.getByRole('button', { name: /highlight/i }));
     const ta = screen.getByPlaceholderText(/margin comment/i);
     fireEvent.change(ta, { target: { value: 'edited' } });
     const last = onChange.mock.calls.at(-1)?.[0] as WrittenAnswerAnnotation[];
     expect(last[0].comment).toBe('edited');
   });
 
-  it('deletes an annotation via the active-editor trash button', () => {
+  it('deletes the active annotation via the trash button', () => {
     const onChange = vi.fn();
     render(
-      <AnnotatedResponseView
-        mode="edit"
+      <EditHarness
         snapshot="<p>hello world</p>"
         annotations={[ann(0, 5, { id: 'a1', comment: 'x' })]}
-        authorUid="teacher-1"
         onChange={onChange}
+        initialActiveId="a1"
       />
     );
-    const row = screen.getByText('x').closest('button');
-    if (!row) throw new Error('Expected annotation row button');
-    fireEvent.click(row);
     fireEvent.click(screen.getByRole('button', { name: /delete annotation/i }));
     const last = onChange.mock.calls.at(-1)?.[0] as WrittenAnswerAnnotation[];
     expect(last).toEqual([]);
   });
 
-  it('changes color when a swatch is clicked in the active editor', () => {
+  it('changes color when a swatch is clicked in the popover', () => {
     const onChange = vi.fn();
     render(
-      <AnnotatedResponseView
-        mode="edit"
+      <EditHarness
         snapshot="<p>hello</p>"
         annotations={[ann(0, 5, { id: 'a1', highlightColor: 'yellow' })]}
-        authorUid="teacher-1"
         onChange={onChange}
+        initialActiveId="a1"
       />
     );
-    fireEvent.click(screen.getAllByRole('button', { name: /highlight/i })[0]);
     fireEvent.click(screen.getByRole('button', { name: /pink highlight/i }));
     const last = onChange.mock.calls.at(-1)?.[0] as WrittenAnswerAnnotation[];
     expect(last[0].highlightColor).toBe('pink');

--- a/tests/components/quiz/WrittenResponseGrader.annotations.test.tsx
+++ b/tests/components/quiz/WrittenResponseGrader.annotations.test.tsx
@@ -158,7 +158,7 @@ describe('WrittenResponseGrader — annotations + snapshot', () => {
         onClose={vi.fn()}
       />
     );
-    expect(screen.getByText(/Annotations \(1\)/)).toBeInTheDocument();
+    expect(screen.getByText(/Highlights & comments \(1\)/)).toBeInTheDocument();
     expect(screen.getByText('A note')).toBeInTheDocument();
   });
 });

--- a/utils/writtenAnnotations.ts
+++ b/utils/writtenAnnotations.ts
@@ -271,6 +271,19 @@ const sliceTextWithAnnotations = (
   return out;
 };
 
+// The four `<mark>` background classes shipped by `highlightClass`.
+// Exported so `tailwind.config.js` can spread them into its `safelist`
+// without duplicating the list — these classes live in this file, which
+// Tailwind already scans via the `utils/` content glob, but the safelist
+// is a belt-and-braces guarantee against future content-glob regressions
+// and needs to stay in lockstep with the switch below.
+export const HIGHLIGHT_BG_CLASSES = [
+  'bg-amber-300/60',
+  'bg-emerald-300/60',
+  'bg-pink-300/60',
+  'bg-sky-300/60',
+] as const;
+
 /**
  * Tailwind classes for each highlight color. Kept here so the same
  * palette is used by both the teacher's edit surface (live marks) and
@@ -280,16 +293,17 @@ const sliceTextWithAnnotations = (
 export const highlightClass = (
   color: WrittenAnswerAnnotation['highlightColor']
 ): string => {
+  const base = 'text-inherit rounded-sm px-0.5 cursor-pointer';
   switch (color) {
     case 'green':
-      return 'bg-emerald-300/60 text-inherit rounded-sm px-0.5 cursor-pointer';
+      return `bg-emerald-300/60 ${base}`;
     case 'pink':
-      return 'bg-pink-300/60 text-inherit rounded-sm px-0.5 cursor-pointer';
+      return `bg-pink-300/60 ${base}`;
     case 'blue':
-      return 'bg-sky-300/60 text-inherit rounded-sm px-0.5 cursor-pointer';
+      return `bg-sky-300/60 ${base}`;
     case 'yellow':
     default:
-      return 'bg-amber-300/60 text-inherit rounded-sm px-0.5 cursor-pointer';
+      return `bg-amber-300/60 ${base}`;
   }
 };
 


### PR DESCRIPTION
## Summary

UX overhaul for the recently-added short-answer and essay quiz question types, addressing concrete issues reported by Paul during testing on both the student and teacher surfaces. Also fixes a build-time Tailwind purge bug that made every highlight render yellow regardless of the teacher's color choice.

## Student-facing

- **Wider essay container** — `max-w-lg` (512px) → `max-w-3xl` (768px) for `short`/`essay` only; other question types unchanged. ([QuizStudentApp.tsx:1587](components/quiz/QuizStudentApp.tsx))
- **Resizable editor** — drag-to-resize grip in the bottom-right of [WrittenResponseEditor](components/quiz/WrittenResponseEditor.tsx) with keyboard `↑/↓` fallback. Defaults: 22rem essay / 8rem short, capped at 70vh.
- **Sticky Submit + Return-to-assignments CTA** — Submit area is `sticky bottom-0` so it never scrolls off-screen; submitted state now offers a primary "Back to my assignments" button instead of stranding the student. Also wired into `QuizSubmittedWaitScreen` for pseudonym students. ([QuizStudentApp.tsx](components/quiz/QuizStudentApp.tsx))
- **Two-tab my-assignments** — dropped "All", default is **Active**. Completed rows no longer use strikethrough/opacity-80; they show a status chip:
  - `Not graded` (muted slate) when `scoreVisibility` is hidden or `scorePublishedAt` is missing
  - `View results` (brand-blue, same as "Open") when grades are published
  - Per-kind derivation via new `gradingStateFrom` on `KIND_CONFIG`; only `quiz` lights up "View results" today — other kinds default to `not-graded` until they grow an explicit publish step.
- **Margin-pinned comments** — `AnnotatedResponseView` read-mode now positions comment chips at the same vertical level as their highlight, with a collision-avoidance pass and `ResizeObserver` recompute. Mobile falls back to the stacked list. Click-on-highlight pulses the matching chip.

## Teacher-facing

- **Wider grader modal** — `max-w-6xl h-[90vh]` → `min(95vw, 1400px) × 92vh`. ([WrittenResponseGrader.tsx](components/widgets/QuizWidget/components/WrittenResponseGrader.tsx))
- **2-pane layout** — response article fills the left pane; right sidebar (400px) combines points + overall comment + annotations list. The nested 3-column inside `AnnotatedResponseView` is gone.
- **Anchored comment popover** — clicking the comment icon (or an existing mark) now opens a popover next to the highlighted text, with an **auto-focused** textarea. Fixes the "there's nowhere to type a comment" bug. ([AnnotatedResponseView.tsx](components/widgets/QuizWidget/components/AnnotatedResponseView.tsx))
- **`activeId` lifted to grader** — sidebar list click + popover focus share one state.

## Bug fix: all highlights render yellow on the student side

Root cause was a Tailwind purge issue. The four highlight color classes (`bg-amber-300/60`, `bg-emerald-300/60`, `bg-pink-300/60`, `bg-sky-300/60`) lived only in `utils/writtenAnnotations.ts`, which wasn't in `tailwind.config.js`'s `content` scan paths. All four were purged from the production CSS, so `<mark>` fell back to the browser-default yellow regardless of the teacher's color choice.

Fix: added `./utils/**/*.{js,ts}` to `content` and explicitly safelisted the four classes (belt-and-braces — these are load-bearing). Verified live in the browser: all four colors now produce their correct RGBs.

## Test plan

- [x] `pnpm run type-check` clean
- [x] `pnpm run lint` clean (0 errors, 0 warnings under `--max-warnings 0`)
- [x] `pnpm run format:check` clean
- [x] `pnpm run test` — 2500/2500 passing (including 11 rewritten annotation tests)
- [x] `pnpm run build` succeeds
- [x] In the live preview, confirmed `bg-{amber,emerald,pink,sky}-300/60` now produce real backgrounds, not the browser-default yellow
- [ ] Manual end-to-end on the dev preview URL: essay quiz creation → student submission → teacher grading (mixed-color highlights + comments) → publish → student review

🤖 Generated with [Claude Code](https://claude.com/claude-code)