### PR TITLE
fix(video-activity): preserve leading zeros in template timestamp column

### DIFF
--- a/utils/quizDriveService.ts
+++ b/utils/quizDriveService.ts
@@ -1304,7 +1304,49 @@ export class QuizDriveService {
       throw new Error('Failed to create template spreadsheet');
     }
 
-    const sheet = (await createRes.json()) as { spreadsheetUrl: string };
+    const sheet = (await createRes.json()) as {
+      spreadsheetId: string;
+      spreadsheetUrl: string;
+      sheets?: { properties?: { sheetId?: number } }[];
+    };
+
+    // Force column A (Timestamp) to plain-text format. Sheets' default
+    // auto-format treats "01:30" as a duration value and strips the leading
+    // zero on display (and can further mutate the value on CSV export),
+    // confusing teachers building the template. Plain-text preserves
+    // exactly what the user typed.
+    const sheetId = sheet.sheets?.[0]?.properties?.sheetId ?? 0;
+    const formatRes = await fetch(
+      `${SHEETS_API_URL}/${sheet.spreadsheetId}:batchUpdate`,
+      {
+        method: 'POST',
+        headers: this.jsonHeaders,
+        body: JSON.stringify({
+          requests: [
+            {
+              repeatCell: {
+                range: {
+                  sheetId,
+                  startColumnIndex: 0,
+                  endColumnIndex: 1,
+                },
+                cell: {
+                  userEnteredFormat: { numberFormat: { type: 'TEXT' } },
+                },
+                fields: 'userEnteredFormat.numberFormat',
+              },
+            },
+          ],
+        }),
+      }
+    );
+
+    if (!formatRes.ok) {
+      const err = await formatRes.text();
+      console.error('Sheets format timestamp column error:', err);
+      throw new Error('Failed to format template timestamp column');
+    }
+
     return sheet.spreadsheetUrl;
   }
 

--- a/utils/quizDriveService.ts
+++ b/utils/quizDriveService.ts
@@ -1315,7 +1315,12 @@ export class QuizDriveService {
     // zero on display (and can further mutate the value on CSV export),
     // confusing teachers building the template. Plain-text preserves
     // exactly what the user typed.
-    const sheetId = sheet.sheets?.[0]?.properties?.sheetId ?? 0;
+    const sheetId = sheet.sheets?.[0]?.properties?.sheetId;
+    if (sheetId === undefined) {
+      throw new Error(
+        'Failed to read sheetId from created template spreadsheet'
+      );
+    }
     const formatRes = await fetch(
       `${SHEETS_API_URL}/${sheet.spreadsheetId}:batchUpdate`,
       {


### PR DESCRIPTION
## Summary

The Video Activity import template Google Sheet leaves the Timestamp column in Sheets' default auto-format. When a teacher types `01:30` into a cell, Sheets auto-parses it as a duration value and renders it as `1:30` (and can further mutate the value on CSV export), even though the column header advertises `MM:SS`. Less technical users see a mismatch between the documented format and what Sheets shows, and have no obvious way to fix it.

## Fix

After creating the template spreadsheet, send a follow-up `batchUpdate` (`repeatCell`) that sets **column A** to plain-text format (`numberFormat.type: 'TEXT'`) across the entire column. Cells now store exactly what the teacher types — leading zeros preserved — and CSV export matches what they see.

- One file changed: `utils/quizDriveService.ts` (`createVideoActivityTemplate`).
- No parser changes needed: `mmSsToSeconds` already accepts both `M:SS` and `MM:SS` (covered by existing tests in `videoActivityImportAdapter.test.ts`).
- No UI/wording changes: the `Timestamp (MM:SS)` header is now actually enforceable.
- If the follow-up format call fails, the function throws (same pattern as the existing create failure) — we don't want to hand back a half-formatted template, which is the bug we're fixing.

## Test plan

- [x] `pnpm run type-check` — clean
- [x] `pnpm run lint` — clean (zero warnings)
- [x] `pnpm run format:check` — clean
- [x] `pnpm exec vitest run components/widgets/VideoActivityWidget/adapters/videoActivityImportAdapter.test.ts` — 21/21 pass
- [ ] Manual: open the Video Activity Creator → Import step → click "Create template Sheet" → type `01:30` in A2, `02:25` in A3 → confirm both display verbatim with leading zeros preserved
- [ ] Manual: download the template as CSV → confirm column A values export as `01:30` / `02:25` (not `1:30:00`, etc.) and the import flow succeeds end-to-end

https://claude.ai/code/session_01Rej1pRsMPg3JyPBAkEfXSd

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rej1pRsMPg3JyPBAkEfXSd)_