### PR TITLE
feat(publish-scores): add unpublish kebab + extend full flow to GuidedLearning

### DIFF
--- a/components/common/library/PublishScoresModal.tsx
+++ b/components/common/library/PublishScoresModal.tsx
@@ -32,17 +32,20 @@ import {
 } from 'lucide-react';
 import { Modal } from '@/components/common/Modal';
 import type {
+  GuidedLearningScoreVisibility,
   QuizScoreVisibility,
   VideoActivityScoreVisibility,
 } from '@/types';
 
 /**
- * Score-visibility level. Quiz and VA both define the same string-literal
- * union; either resolves to the same shape at the call site.
+ * Score-visibility level. Quiz, VA, and GL all define the same
+ * string-literal union; any of them resolves to the same shape at the
+ * call site.
  */
 export type PublishScoresVisibility =
   | QuizScoreVisibility
-  | VideoActivityScoreVisibility;
+  | VideoActivityScoreVisibility
+  | GuidedLearningScoreVisibility;
 
 interface PublishScoresModalProps {
   /** Assignment title — sub-line so the teacher knows which assignment they're publishing. */

--- a/components/guidedLearning/GuidedLearningStudentApp.tsx
+++ b/components/guidedLearning/GuidedLearningStudentApp.tsx
@@ -144,6 +144,13 @@ const StudentExperience: React.FC<{ anonymousUid: string }> = ({
   const [myResponseLoading, setMyResponseLoading] = useState(
     shouldSubscribeResponse
   );
+  // A non-null value here means the listener failed for a real reason
+  // (permission-denied, network outage, rule rejection) — NOT just "doc
+  // doesn't exist," which `onSnapshot` reports as a successful snapshot
+  // with `snap.exists() === false`. We surface a soft banner instead of
+  // silently treating a failed read as "no submission exists" — that
+  // would invite a student who already submitted to resubmit.
+  const [myResponseError, setMyResponseError] = useState<string | null>(null);
   // Adjust-state-while-rendering pattern (avoids set-state-in-effect):
   // when the subscription gating flips (e.g., session loads as view-only),
   // sync the loading flag to match without a cascading render.
@@ -152,28 +159,37 @@ const StudentExperience: React.FC<{ anonymousUid: string }> = ({
   if (shouldSubscribeResponse !== prevShouldSubscribeResponse) {
     setPrevShouldSubscribeResponse(shouldSubscribeResponse);
     setMyResponseLoading(shouldSubscribeResponse);
-    if (!shouldSubscribeResponse) setMyResponse(null);
+    if (!shouldSubscribeResponse) {
+      setMyResponse(null);
+      setMyResponseError(null);
+    }
   }
   useEffect(() => {
     if (!shouldSubscribeResponse) return;
     const unsub = onSnapshot(
       doc(db, GL_SESSIONS_COLLECTION, sessionId, 'responses', anonymousUid),
       (snap) => {
+        // `snap.exists() === false` is the normal "first visit, no
+        // submission yet" path — not an error. Clearing `myResponseError`
+        // here lets a transient listener failure self-heal once the
+        // backend recovers.
         setMyResponse(
           snap.exists() ? (snap.data() as GuidedLearningResponse) : null
         );
+        setMyResponseError(null);
         setMyResponseLoading(false);
       },
       (err) => {
-        // Firestore rules may reject the read for a brand-new student
-        // who hasn't joined yet — treat as "no response" rather than
-        // surfacing a scary error.
-        console.warn(
-          '[GuidedLearningStudentApp] response listener error:',
-          err
-        );
-        setMyResponse(null);
-        setMyResponseLoading(false);
+        // Real listener failures (permission-denied / unavailable /
+        // network) only. Do NOT zero out `myResponse` here — if we had
+        // already received a snapshot, keeping the last-known data
+        // avoids flicker, and if we hadn't, the parent gate will keep
+        // `myResponseLoading: true` so the Player UI doesn't render
+        // (which would silently invite a duplicate submission).
+        logError('GuidedLearningStudentApp.responseListener', err, {
+          sessionId,
+        });
+        setMyResponseError('listener-failed');
       }
     );
     return unsub;
@@ -250,6 +266,17 @@ const StudentExperience: React.FC<{ anonymousUid: string }> = ({
   if (loading) return <FullPageLoader />;
   if (error) return <ErrorScreen message={error} />;
   if (!session) return <ErrorScreen message="Session not found." />;
+
+  // Response-listener failure on a submissions-mode session — we can't
+  // safely show the start screen (a returning student would silently
+  // resubmit) and we can't show the review (no data). Surface a refresh
+  // prompt instead. `completed` short-circuits so a just-submitted
+  // student isn't blocked by a stale error.
+  if (!completed && !isViewOnly && myResponseError && !myResponse) {
+    return (
+      <ErrorScreen message="Couldn't load your submission status. Please refresh and try again." />
+    );
+  }
 
   // Returning student case — a response already exists in Firestore. Show
   // either the published review or a "wait for teacher" placeholder
@@ -630,7 +657,7 @@ const CompletionScreen: React.FC<{
 // only writer for those fields, so a stale-cache device can't manufacture
 // a "correct" badge that isn't on the authoritative response doc.
 
-const PublishedGLReview: React.FC<{
+export const PublishedGLReview: React.FC<{
   session: GuidedLearningSession;
   myResponse: GuidedLearningResponse;
   visibility: NonNullable<GuidedLearningSession['scoreVisibility']>;
@@ -733,15 +760,27 @@ const PublishedGLReview: React.FC<{
 };
 
 /** Stringify a stored student answer for display. Mirrors the format used
- *  by `revealedAnswers` so matching / sorting reads consistently. */
-function formatStudentAnswer(answer: string | string[] | undefined): string {
+ *  by `revealedAnswers` so matching / sorting reads consistently.
+ *  Exported alongside `PublishedGLReview` so the test harness can exercise
+ *  the colon-split regression case without rendering the full review.
+ */
+// eslint-disable-next-line react-refresh/only-export-components
+export function formatStudentAnswer(
+  answer: string | string[] | undefined
+): string {
   if (answer === undefined) return '';
   if (typeof answer === 'string') return answer;
   if (answer.length === 0) return '';
-  // Matching is stored as "left:right" strings; expand the colon to an
-  // arrow for readability and join with newlines so list-shaped answers
-  // (sorting items) also render legibly.
+  // Matching is stored as `"${left}:${right}"` strings (see
+  // `isAnswerCorrect`), so split on the FIRST colon — `pair.left` or
+  // `pair.right` may legitimately contain colons themselves (e.g.
+  // "Ratio: 3"). `String#replace(":")` is first-match-only too, but it
+  // doesn't split, so multi-colon strings render with a trailing
+  // colon-bearing fragment. `indexOf` + `slice` is unambiguous.
   return answer
-    .map((a) => (a.includes(':') ? a.replace(':', ' → ') : a))
+    .map((a) => {
+      const i = a.indexOf(':');
+      return i < 0 ? a : `${a.slice(0, i)} → ${a.slice(i + 1)}`;
+    })
     .join('\n');
 }

--- a/components/guidedLearning/GuidedLearningStudentApp.tsx
+++ b/components/guidedLearning/GuidedLearningStudentApp.tsx
@@ -21,8 +21,15 @@ import {
   CheckCircle2,
   RefreshCw,
   Trophy,
+  XCircle,
 } from 'lucide-react';
-import { addDoc, collection, serverTimestamp } from 'firebase/firestore';
+import {
+  addDoc,
+  collection,
+  doc,
+  onSnapshot,
+  serverTimestamp,
+} from 'firebase/firestore';
 import { auth, db } from '@/config/firebase';
 import { logError } from '@/utils/logError';
 import { useGuidedLearningSessionStudent } from '@/hooks/useGuidedLearningSession';
@@ -124,6 +131,53 @@ const StudentExperience: React.FC<{ anonymousUid: string }> = ({
   const [completed, setCompleted] = useState(false);
   const [score, setScore] = useState<number | null>(null);
   const [answers, setAnswers] = useState<GuidedLearningResponse['answers']>([]);
+  // Realtime listener on /guided_learning_sessions/{id}/responses/{uid}
+  // so a returning student gets their published score + per-step
+  // `isCorrect` flags, and a teacher unpublish (which clears
+  // `session.revealedAnswers` + flips `scoreVisibility` to 'none')
+  // propagates without a refresh. View-only shares never persist
+  // responses, so the subscription is gated on `shouldSubscribeResponse`.
+  const shouldSubscribeResponse = !!sessionId && !!anonymousUid && !isViewOnly;
+  const [myResponse, setMyResponse] = useState<GuidedLearningResponse | null>(
+    null
+  );
+  const [myResponseLoading, setMyResponseLoading] = useState(
+    shouldSubscribeResponse
+  );
+  // Adjust-state-while-rendering pattern (avoids set-state-in-effect):
+  // when the subscription gating flips (e.g., session loads as view-only),
+  // sync the loading flag to match without a cascading render.
+  const [prevShouldSubscribeResponse, setPrevShouldSubscribeResponse] =
+    useState(shouldSubscribeResponse);
+  if (shouldSubscribeResponse !== prevShouldSubscribeResponse) {
+    setPrevShouldSubscribeResponse(shouldSubscribeResponse);
+    setMyResponseLoading(shouldSubscribeResponse);
+    if (!shouldSubscribeResponse) setMyResponse(null);
+  }
+  useEffect(() => {
+    if (!shouldSubscribeResponse) return;
+    const unsub = onSnapshot(
+      doc(db, GL_SESSIONS_COLLECTION, sessionId, 'responses', anonymousUid),
+      (snap) => {
+        setMyResponse(
+          snap.exists() ? (snap.data() as GuidedLearningResponse) : null
+        );
+        setMyResponseLoading(false);
+      },
+      (err) => {
+        // Firestore rules may reject the read for a brand-new student
+        // who hasn't joined yet — treat as "no response" rather than
+        // surfacing a scary error.
+        console.warn(
+          '[GuidedLearningStudentApp] response listener error:',
+          err
+        );
+        setMyResponse(null);
+        setMyResponseLoading(false);
+      }
+    );
+    return unsub;
+  }, [sessionId, anonymousUid, shouldSubscribeResponse]);
   // Bumped when the user clicks "Replay from beginning" on a view-only
   // completion screen. Used as the React key on the player so its
   // internal state (currentIdx, activeStepId, image index, etc.) fully
@@ -197,12 +251,41 @@ const StudentExperience: React.FC<{ anonymousUid: string }> = ({
   if (error) return <ErrorScreen message={error} />;
   if (!session) return <ErrorScreen message="Session not found." />;
 
+  // Returning student case — a response already exists in Firestore. Show
+  // either the published review or a "wait for teacher" placeholder
+  // rather than dropping them back onto the start screen (which would
+  // imply they could submit again). `completed` short-circuits this
+  // branch so the just-submitted screen still wins immediately after
+  // `handleComplete` flips the local state.
+  if (!completed && !isViewOnly && !myResponseLoading && myResponse) {
+    const visibility = session.scoreVisibility ?? 'none';
+    if (visibility !== 'none') {
+      return (
+        <PublishedGLReview
+          session={session}
+          myResponse={myResponse}
+          visibility={visibility}
+        />
+      );
+    }
+    return (
+      <CompletionScreen
+        session={session}
+        score={null}
+        isViewOnly={false}
+        visibility="none"
+        onReplay={() => undefined}
+      />
+    );
+  }
+
   if (completed) {
     return (
       <CompletionScreen
         session={session}
         score={score}
         isViewOnly={isViewOnly}
+        visibility={session.scoreVisibility ?? 'none'}
         onReplay={() => {
           // Drop responses + bump key so the player fully remounts with
           // fresh state at step 0 / image 0. Keep `started` true so the
@@ -428,13 +511,21 @@ const CompletionScreen: React.FC<{
   score: number | null;
   isViewOnly: boolean;
   /**
+   * Teacher's current score-visibility setting on the session.
+   * `'none'` ⇒ render the neutral "submitted, ask your teacher"
+   * placeholder; any other value ⇒ keep the gamified Trophy framing.
+   * The actual score / per-step results live on the response doc and
+   * are surfaced by `PublishedGLReview`, not here.
+   */
+  visibility: NonNullable<GuidedLearningSession['scoreVisibility']>;
+  /**
    * View-only "Replay from beginning" handler. Resets state so the
    * player remounts at step 0. Not shown for response-tracked sessions
    * (those have already submitted — replay would imply submitting
    * twice).
    */
   onReplay: () => void;
-}> = ({ session, score, isViewOnly, onReplay }) => {
+}> = ({ session, score, isViewOnly, visibility, onReplay }) => {
   // View-only completion is purely informational — there's no "score",
   // no "you finished an assignment" framing, just "you reached the end
   // of this resource". Suppress the gamified Trophy / Complete! styling
@@ -464,7 +555,36 @@ const CompletionScreen: React.FC<{
     );
   }
 
-  // Response-tracked completion — keep the achievement framing.
+  // Response-tracked completion. When the teacher hasn't published
+  // results yet (`visibility === 'none'`, the default), drop the
+  // gamified Trophy framing in favor of a neutral "submitted" placeholder
+  // — promising "Complete!" on a screen that can't show a score reads as
+  // a missing feature. Once the teacher publishes, the parent component
+  // routes returning students to `PublishedGLReview` instead, so the
+  // Trophy variant below is only reached on the immediate post-submit
+  // render when the teacher had already pre-published at create time
+  // (uncommon but supported).
+  if (visibility === 'none') {
+    return (
+      <div className="h-screen overflow-y-auto bg-slate-950">
+        <div className="min-h-full flex items-center justify-center p-6">
+          <div className="bg-slate-900 border border-white/10 rounded-2xl p-8 max-w-sm w-full text-center shadow-2xl">
+            <CheckCircle2 className="w-10 h-10 text-emerald-400 mx-auto mb-3" />
+            <h1 className="text-white font-bold text-xl mb-1">
+              {session.title}
+            </h1>
+            <p className="text-slate-300 text-sm mb-4">
+              Your responses have been submitted.
+            </p>
+            <p className="text-slate-500 text-xs">
+              Ask your teacher to see your results.
+            </p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div className="h-screen overflow-y-auto bg-slate-950">
       <div className="min-h-full flex items-center justify-center p-6">
@@ -489,3 +609,139 @@ const CompletionScreen: React.FC<{
     </div>
   );
 };
+
+// ─── Published-score review ──────────────────────────────────────────────────
+//
+// Rendered for a returning student whose teacher has flipped
+// `scoreVisibility` on the session via the archive's "Publish scores"
+// kebab action. The three modes are progressive disclosure:
+//
+//   - score-only: just the percentage tally.
+//   - score-and-responses: above + per-step rows tagging each of the
+//     student's answers correct or incorrect, but never the canonical
+//     correct answer.
+//   - score-responses-and-answers: above + the canonical correct answer
+//     under each row, sourced from `session.revealedAnswers` (populated
+//     atomically by `publishAssignmentScores`).
+//
+// All data the screen needs lives on `myResponse` (score + per-answer
+// `isCorrect`) and `session` (publicSteps, revealedAnswers). We don't
+// recompute correctness client-side — the teacher's publish step is the
+// only writer for those fields, so a stale-cache device can't manufacture
+// a "correct" badge that isn't on the authoritative response doc.
+
+const PublishedGLReview: React.FC<{
+  session: GuidedLearningSession;
+  myResponse: GuidedLearningResponse;
+  visibility: NonNullable<GuidedLearningSession['scoreVisibility']>;
+}> = ({ session, myResponse, visibility }) => {
+  const showResponses =
+    visibility === 'score-and-responses' ||
+    visibility === 'score-responses-and-answers';
+  const showAnswers = visibility === 'score-responses-and-answers';
+
+  const gradableSteps = session.publicSteps.filter((s) => !!s.question);
+  const answersByStep = new Map(
+    myResponse.answers.map((a) => [a.stepId, a] as const)
+  );
+
+  const score = myResponse.score ?? 0;
+  const correctCount = myResponse.answers.filter(
+    (a) => a.isCorrect === true
+  ).length;
+  const totalGradable = gradableSteps.length;
+
+  return (
+    <div className="h-screen overflow-y-auto bg-slate-950">
+      <div className="min-h-full flex items-start justify-center p-6">
+        <div className="w-full max-w-md flex flex-col gap-4">
+          <div className="bg-slate-900 border border-white/10 rounded-2xl p-6 text-center shadow-2xl">
+            <Trophy className="w-10 h-10 text-yellow-400 mx-auto mb-2" />
+            <h1 className="text-white font-bold text-xl mb-1">
+              {session.title}
+            </h1>
+            <p className="text-slate-400 text-xs mb-4">Your results</p>
+            <p className="text-5xl font-black text-white mb-1">{score}%</p>
+            {totalGradable > 0 && (
+              <p className="text-slate-400 text-sm">
+                {correctCount} of {totalGradable} correct
+              </p>
+            )}
+          </div>
+
+          {showResponses && totalGradable > 0 && (
+            <div className="bg-slate-900 border border-white/10 rounded-2xl p-4 shadow-2xl">
+              <ul className="flex flex-col gap-3">
+                {gradableSteps.map((step, idx) => {
+                  const ans = answersByStep.get(step.id);
+                  const isCorrect = ans?.isCorrect === true;
+                  const canonical = showAnswers
+                    ? session.revealedAnswers?.[step.id]
+                    : undefined;
+                  const studentAnswer = formatStudentAnswer(ans?.answer);
+                  return (
+                    <li
+                      key={step.id}
+                      className="border border-white/10 rounded-xl p-3 bg-slate-950/40"
+                    >
+                      <div className="flex items-start gap-2">
+                        {isCorrect ? (
+                          <CheckCircle2 className="w-5 h-5 text-emerald-400 shrink-0 mt-0.5" />
+                        ) : (
+                          <XCircle className="w-5 h-5 text-rose-400 shrink-0 mt-0.5" />
+                        )}
+                        <div className="flex-1 min-w-0">
+                          <p className="text-white text-sm font-semibold mb-1">
+                            Step {idx + 1}
+                            {step.label ? ` · ${step.label}` : ''}
+                          </p>
+                          {step.question?.text && (
+                            <p className="text-slate-400 text-xs mb-2">
+                              {step.question.text}
+                            </p>
+                          )}
+                          <p className="text-slate-200 text-sm">
+                            <span className="text-slate-500">
+                              Your answer:{' '}
+                            </span>
+                            {studentAnswer || (
+                              <span className="italic text-slate-500">
+                                No answer
+                              </span>
+                            )}
+                          </p>
+                          {showAnswers && !isCorrect && canonical && (
+                            <p className="text-slate-200 text-sm mt-1 whitespace-pre-line">
+                              <span className="text-slate-500">
+                                Correct answer:{' '}
+                              </span>
+                              {canonical}
+                            </p>
+                          )}
+                        </div>
+                      </div>
+                    </li>
+                  );
+                })}
+              </ul>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+/** Stringify a stored student answer for display. Mirrors the format used
+ *  by `revealedAnswers` so matching / sorting reads consistently. */
+function formatStudentAnswer(answer: string | string[] | undefined): string {
+  if (answer === undefined) return '';
+  if (typeof answer === 'string') return answer;
+  if (answer.length === 0) return '';
+  // Matching is stored as "left:right" strings; expand the colon to an
+  // arrow for readability and join with newlines so list-shaped answers
+  // (sorting items) also render legibly.
+  return answer
+    .map((a) => (a.includes(':') ? a.replace(':', ' → ') : a))
+    .join('\n');
+}

--- a/components/widgets/GuidedLearning/Widget.tsx
+++ b/components/widgets/GuidedLearning/Widget.tsx
@@ -96,6 +96,7 @@ export const GuidedLearningWidget: React.FC<{ widget: WidgetData }> = ({
     unarchiveAssignment,
     deleteAssignment,
     publishAssignmentScores,
+    unpublishAssignmentScores,
   } = useGuidedLearningAssignments(user?.uid);
 
   // Local component state
@@ -720,23 +721,11 @@ export const GuidedLearningWidget: React.FC<{ widget: WidgetData }> = ({
                   setPublishingAssignment(a);
                 }}
                 onAssignmentUnpublishScores={async (a) => {
-                  // One-click unpublish — the hook's `'none'` branch
-                  // skips set lookup (no grading needed for a flag
-                  // flip), so we can pass an empty placeholder set.
+                  // One-click unpublish — `unpublishAssignmentScores`
+                  // is a cheap two-write batch (no set lookup, no
+                  // grading).
                   try {
-                    await publishAssignmentScores(
-                      a.id,
-                      {
-                        id: a.setId,
-                        title: a.setTitle,
-                        imageUrls: [],
-                        steps: [],
-                        mode: 'guided',
-                        createdAt: 0,
-                        updatedAt: 0,
-                      },
-                      'none'
-                    );
+                    await unpublishAssignmentScores(a.id);
                     addToast('Scores unpublished.', 'success');
                   } catch (err) {
                     addToast(
@@ -918,20 +907,9 @@ export const GuidedLearningWidget: React.FC<{ widget: WidgetData }> = ({
             const target = publishingAssignment;
             try {
               if (visibility === 'none') {
-                // Mirror Quiz/VA: skip set lookup for the flag-flip.
-                await publishAssignmentScores(
-                  target.id,
-                  {
-                    id: target.setId,
-                    title: target.setTitle,
-                    imageUrls: [],
-                    steps: [],
-                    mode: 'guided',
-                    createdAt: 0,
-                    updatedAt: 0,
-                  },
-                  'none'
-                );
+                // Mirror Quiz/VA: route through the dedicated unpublish
+                // method (no set lookup needed for a flag-flip).
+                await unpublishAssignmentScores(target.id);
                 addToast('Scores unpublished.', 'success');
                 setPublishingAssignment(null);
                 return;

--- a/components/widgets/GuidedLearning/Widget.tsx
+++ b/components/widgets/GuidedLearning/Widget.tsx
@@ -19,6 +19,7 @@ import { useFolders } from '@/hooks/useFolders';
 import { useBusyIdSet } from '@/hooks/useBusyIdSet';
 import { WidgetLayout } from '@/components/widgets/WidgetLayout';
 import { AssignModal, ViewOnlyShareModal } from '@/components/common/library';
+import { PublishScoresModal } from '@/components/common/library/PublishScoresModal';
 import { AssignClassPicker } from '@/components/common/AssignClassPicker';
 import {
   makeEmptyPickerValue,
@@ -94,6 +95,7 @@ export const GuidedLearningWidget: React.FC<{ widget: WidgetData }> = ({
     archiveAssignment,
     unarchiveAssignment,
     deleteAssignment,
+    publishAssignmentScores,
   } = useGuidedLearningAssignments(user?.uid);
 
   // Local component state
@@ -127,6 +129,10 @@ export const GuidedLearningWidget: React.FC<{ widget: WidgetData }> = ({
   const [assignTarget, setAssignTarget] = useState<AssignDialogTarget | null>(
     null
   );
+  // Ephemeral modal state for the per-assignment "Publish Scores" picker.
+  // Mirrors the QuizWidget / VideoActivityWidget pattern.
+  const [publishingAssignment, setPublishingAssignment] =
+    useState<GuidedLearningAssignment | null>(null);
   const [pickerValue, setPickerValue] = useState<AssignClassPickerValue>(() =>
     makeEmptyPickerValue()
   );
@@ -710,6 +716,37 @@ export const GuidedLearningWidget: React.FC<{ widget: WidgetData }> = ({
                 onAssignmentDelete={(a) => {
                   void handleAssignmentDelete(a);
                 }}
+                onAssignmentPublishScores={(a) => {
+                  setPublishingAssignment(a);
+                }}
+                onAssignmentUnpublishScores={async (a) => {
+                  // One-click unpublish — the hook's `'none'` branch
+                  // skips set lookup (no grading needed for a flag
+                  // flip), so we can pass an empty placeholder set.
+                  try {
+                    await publishAssignmentScores(
+                      a.id,
+                      {
+                        id: a.setId,
+                        title: a.setTitle,
+                        imageUrls: [],
+                        steps: [],
+                        mode: 'guided',
+                        createdAt: 0,
+                        updatedAt: 0,
+                      },
+                      'none'
+                    );
+                    addToast('Scores unpublished.', 'success');
+                  } catch (err) {
+                    addToast(
+                      err instanceof Error
+                        ? err.message
+                        : 'Failed to unpublish scores',
+                      'error'
+                    );
+                  }
+                }}
                 initialLibraryViewMode={config.libraryViewMode}
                 onLibraryViewModeChange={(mode) => {
                   updateWidget(widget.id, {
@@ -869,6 +906,74 @@ export const GuidedLearningWidget: React.FC<{ widget: WidgetData }> = ({
           error={viewOnlyShareError}
           onConfirm={() => void handleConfirmViewOnlyShare()}
           onClose={closeViewOnlyShareModal}
+        />
+      )}
+
+      {publishingAssignment && (
+        <PublishScoresModal
+          assignmentTitle={publishingAssignment.setTitle}
+          currentVisibility={publishingAssignment.scoreVisibility}
+          onClose={() => setPublishingAssignment(null)}
+          onConfirm={async (visibility) => {
+            const target = publishingAssignment;
+            try {
+              if (visibility === 'none') {
+                // Mirror Quiz/VA: skip set lookup for the flag-flip.
+                await publishAssignmentScores(
+                  target.id,
+                  {
+                    id: target.setId,
+                    title: target.setTitle,
+                    imageUrls: [],
+                    steps: [],
+                    mode: 'guided',
+                    createdAt: 0,
+                    updatedAt: 0,
+                  },
+                  'none'
+                );
+                addToast('Scores unpublished.', 'success');
+                setPublishingAssignment(null);
+                return;
+              }
+              // Resolve the canonical set so the grader sees the full
+              // `correctAnswer` / `matchingPairs` / `sortingItems` —
+              // `session.publicSteps` strips them for student safety.
+              const personalMeta = sets.find((s) => s.id === target.setId);
+              const buildingSet = buildingSets.find(
+                (s) => s.id === target.setId
+              );
+              const data = await loadSet(
+                target.setId,
+                personalMeta?.driveFileId,
+                buildingSet
+              );
+              if (!data) {
+                addToast(
+                  'Set is no longer in your library — cannot publish scores.',
+                  'error'
+                );
+                return;
+              }
+              const result = await publishAssignmentScores(
+                target.id,
+                data,
+                visibility
+              );
+              addToast(
+                result.responsesUpdated > 0
+                  ? `Scores published to ${result.responsesUpdated} student${result.responsesUpdated === 1 ? '' : 's'}.`
+                  : 'Scores published. Students will see results once they submit.',
+                'success'
+              );
+              setPublishingAssignment(null);
+            } catch (err) {
+              addToast(
+                err instanceof Error ? err.message : 'Failed to publish scores',
+                'error'
+              );
+            }
+          }}
         />
       )}
     </>

--- a/components/widgets/GuidedLearning/components/GuidedLearningManager.tsx
+++ b/components/widgets/GuidedLearning/components/GuidedLearningManager.tsx
@@ -35,6 +35,8 @@ import {
   Copy,
   ExternalLink,
   CheckSquare,
+  EyeOff,
+  Send,
 } from 'lucide-react';
 import type {
   AssignmentMode,
@@ -188,6 +190,22 @@ export interface GuidedLearningManagerProps {
   onAssignmentArchive: (assignment: GuidedLearningAssignment) => void;
   onAssignmentUnarchive: (assignment: GuidedLearningAssignment) => void;
   onAssignmentDelete: (assignment: GuidedLearningAssignment) => void;
+  /**
+   * Open the publish-scores picker modal for an archived assignment. Set
+   * ⇒ the archive kebab gains a "Publish scores" / "Update published
+   * scores" entry. Submission-mode assignments only — view-only shares
+   * have no responses to grade.
+   */
+  onAssignmentPublishScores?: (
+    assignment: GuidedLearningAssignment
+  ) => void | Promise<void>;
+  /**
+   * Revoke published score visibility in one click (skips the picker
+   * modal). Only surfaced when `assignment.scoreVisibility` is published.
+   */
+  onAssignmentUnpublishScores?: (
+    assignment: GuidedLearningAssignment
+  ) => void | Promise<void>;
 
   /** Persisted library grid/list toggle (from widget config). */
   initialLibraryViewMode?: 'grid' | 'list';
@@ -357,6 +375,8 @@ export const GuidedLearningManager: React.FC<GuidedLearningManagerProps> = ({
   onAssignmentArchive,
   onAssignmentUnarchive,
   onAssignmentDelete,
+  onAssignmentPublishScores,
+  onAssignmentUnpublishScores,
   initialLibraryViewMode,
   onLibraryViewModeChange,
   assignmentMode = 'submissions',
@@ -377,6 +397,12 @@ export const GuidedLearningManager: React.FC<GuidedLearningManagerProps> = ({
   const [previewEntryId, setPreviewEntryId] = React.useState<string | null>(
     null
   );
+  // Two-click confirmation for the destructive "Unpublish scores" kebab
+  // entry. First click flips the label to "Confirm unpublish"; second
+  // click on the same row triggers the hook. Mirrors the local Delete
+  // pattern used by VideoActivityManager.
+  const [confirmUnpublishAssignmentId, setConfirmUnpublishAssignmentId] =
+    React.useState<string | null>(null);
   const [prevTab, setPrevTab] = React.useState(tab);
   if (prevTab !== tab) {
     setPrevTab(tab);
@@ -878,6 +904,42 @@ export const GuidedLearningManager: React.FC<GuidedLearningManagerProps> = ({
         label: 'Move to In Progress',
         icon: RotateCcw,
         onClick: () => onAssignmentUnarchive(a),
+      });
+    }
+
+    // Publish / Unpublish scores — archive tab, submissions only.
+    // View-only shares have no responses to grade.
+    if (mode === 'archive' && !isViewOnly && onAssignmentPublishScores) {
+      const isPublished =
+        a.scoreVisibility !== undefined && a.scoreVisibility !== 'none';
+      secondary.push({
+        id: 'publish-scores',
+        label: isPublished ? 'Update published scores' : 'Publish scores',
+        icon: Send,
+        onClick: () => void onAssignmentPublishScores(a),
+      });
+    }
+    if (
+      mode === 'archive' &&
+      !isViewOnly &&
+      onAssignmentUnpublishScores &&
+      a.scoreVisibility !== undefined &&
+      a.scoreVisibility !== 'none'
+    ) {
+      const awaitingConfirm = confirmUnpublishAssignmentId === a.id;
+      secondary.push({
+        id: 'unpublish-scores',
+        label: awaitingConfirm ? 'Confirm unpublish' : 'Unpublish scores',
+        icon: EyeOff,
+        destructive: awaitingConfirm,
+        onClick: () => {
+          if (awaitingConfirm) {
+            setConfirmUnpublishAssignmentId(null);
+            void onAssignmentUnpublishScores(a);
+          } else {
+            setConfirmUnpublishAssignmentId(a.id);
+          }
+        },
       });
     }
 

--- a/components/widgets/GuidedLearning/components/GuidedLearningManager.tsx
+++ b/components/widgets/GuidedLearning/components/GuidedLearningManager.tsx
@@ -51,6 +51,7 @@ import { LibraryItemCard } from '@/components/common/library/LibraryItemCard';
 import { ViewCountBadge } from '@/components/common/library/ViewCountBadge';
 import { useSessionViewCount } from '@/hooks/useSessionViewCount';
 import { useAuth } from '@/context/useAuth';
+import { useDialog } from '@/context/useDialog';
 import { FolderSidebar } from '@/components/common/library/FolderSidebar';
 import { FolderPickerPopover } from '@/components/common/library/FolderPickerPopover';
 import { buildMoveToFolderAction } from '@/components/common/library/folderMenuAction';
@@ -397,12 +398,7 @@ export const GuidedLearningManager: React.FC<GuidedLearningManagerProps> = ({
   const [previewEntryId, setPreviewEntryId] = React.useState<string | null>(
     null
   );
-  // Two-click confirmation for the destructive "Unpublish scores" kebab
-  // entry. First click flips the label to "Confirm unpublish"; second
-  // click on the same row triggers the hook. Mirrors the local Delete
-  // pattern used by VideoActivityManager.
-  const [confirmUnpublishAssignmentId, setConfirmUnpublishAssignmentId] =
-    React.useState<string | null>(null);
+  const { showConfirm } = useDialog();
   const [prevTab, setPrevTab] = React.useState(tab);
   if (prevTab !== tab) {
     setPrevTab(tab);
@@ -926,19 +922,20 @@ export const GuidedLearningManager: React.FC<GuidedLearningManagerProps> = ({
       a.scoreVisibility !== undefined &&
       a.scoreVisibility !== 'none'
     ) {
-      const awaitingConfirm = confirmUnpublishAssignmentId === a.id;
       secondary.push({
         id: 'unpublish-scores',
-        label: awaitingConfirm ? 'Confirm unpublish' : 'Unpublish scores',
+        label: 'Unpublish scores',
         icon: EyeOff,
-        destructive: awaitingConfirm,
-        onClick: () => {
-          if (awaitingConfirm) {
-            setConfirmUnpublishAssignmentId(null);
-            void onAssignmentUnpublishScores(a);
-          } else {
-            setConfirmUnpublishAssignmentId(a.id);
-          }
+        onClick: async () => {
+          const ok = await showConfirm(
+            'Students will no longer be able to see their scores or responses. You can republish anytime.',
+            {
+              title: 'Unpublish scores',
+              variant: 'danger',
+              confirmLabel: 'Unpublish',
+            }
+          );
+          if (ok) await onAssignmentUnpublishScores(a);
         },
       });
     }

--- a/components/widgets/QuizWidget/Widget.tsx
+++ b/components/widgets/QuizWidget/Widget.tsx
@@ -149,6 +149,7 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
     setAssignmentExportedResponseIds,
     shareAssignment,
     publishAssignmentScores,
+    unpublishAssignmentScores,
     syncAssignmentToLatest,
   } = useQuizAssignments(user?.uid);
 
@@ -1663,23 +1664,10 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
           setPublishingAssignment(a);
         }}
         onArchiveUnpublishScores={async (a) => {
-          // One-click unpublish: the `'none'` branch of
-          // `publishAssignmentScores` skips the Drive quiz lookup
-          // and just flips `scoreVisibility` + clears
-          // `revealedAnswers` on both the assignment and session
-          // docs, so we can pass an empty QuizData placeholder.
+          // One-click unpublish — `unpublishAssignmentScores` is a
+          // cheap two-write batch (no Drive lookup, no grading).
           try {
-            await publishAssignmentScores(
-              a.id,
-              {
-                id: a.quizId,
-                title: a.quizTitle,
-                questions: [],
-                createdAt: 0,
-                updatedAt: 0,
-              },
-              'none'
-            );
+            await unpublishAssignmentScores(a.id);
             addToast('Scores unpublished.', 'success');
           } catch (err) {
             addToast(
@@ -1924,28 +1912,15 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
           currentVisibility={publishingAssignment.scoreVisibility}
           onClose={() => setPublishingAssignment(null)}
           onConfirm={async (visibility) => {
-            // Resolve the canonical quiz from Drive so the score
-            // computation has access to every question's correctAnswer
-            // (the session's `publicQuestions` strips them for student
-            // safety). When unpublishing the quiz lookup is skipped —
-            // the hook's `'none'` path doesn't read questions.
+            // `'none'` routes to the dedicated `unpublishAssignmentScores`
+            // (no Drive lookup, no grading). Other levels resolve the
+            // canonical quiz from Drive so the score computation has
+            // access to every question's `correctAnswer` — the session's
+            // `publicQuestions` strips them for student safety.
             const target = publishingAssignment;
             try {
               if (visibility === 'none') {
-                await publishAssignmentScores(
-                  target.id,
-                  // Empty placeholder QuizData — the 'none' branch never
-                  // reads it. Cheaper than re-loading the quiz from Drive
-                  // for a flag-flip.
-                  {
-                    id: target.quizId,
-                    title: target.quizTitle,
-                    questions: [],
-                    createdAt: 0,
-                    updatedAt: 0,
-                  },
-                  visibility
-                );
+                await unpublishAssignmentScores(target.id);
                 addToast('Scores unpublished.', 'success');
                 setPublishingAssignment(null);
                 return;

--- a/components/widgets/QuizWidget/Widget.tsx
+++ b/components/widgets/QuizWidget/Widget.tsx
@@ -1662,6 +1662,32 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
         onArchivePublishScores={(a) => {
           setPublishingAssignment(a);
         }}
+        onArchiveUnpublishScores={async (a) => {
+          // One-click unpublish: the `'none'` branch of
+          // `publishAssignmentScores` skips the Drive quiz lookup
+          // and just flips `scoreVisibility` + clears
+          // `revealedAnswers` on both the assignment and session
+          // docs, so we can pass an empty QuizData placeholder.
+          try {
+            await publishAssignmentScores(
+              a.id,
+              {
+                id: a.quizId,
+                title: a.quizTitle,
+                questions: [],
+                createdAt: 0,
+                updatedAt: 0,
+              },
+              'none'
+            );
+            addToast('Scores unpublished.', 'success');
+          } catch (err) {
+            addToast(
+              err instanceof Error ? err.message : 'Failed to unpublish scores',
+              'error'
+            );
+          }
+        }}
         onArchivePauseResume={async (a) => {
           try {
             if (a.status === 'paused') {

--- a/components/widgets/QuizWidget/components/QuizManager.tsx
+++ b/components/widgets/QuizWidget/components/QuizManager.tsx
@@ -25,6 +25,7 @@ import {
   Trash2,
   BarChart3,
   Eye,
+  EyeOff,
   Link2,
   User,
   Zap,
@@ -336,6 +337,13 @@ interface QuizManagerProps {
    * kebab affordance.
    */
   onArchivePublishScores?: (assignment: QuizAssignment) => void | Promise<void>;
+  /**
+   * Revoke published score visibility in one click (skips the picker
+   * modal). Only surfaced when `assignment.scoreVisibility` is published.
+   */
+  onArchiveUnpublishScores?: (
+    assignment: QuizAssignment
+  ) => void | Promise<void>;
   onArchivePauseResume?: (assignment: QuizAssignment) => void | Promise<void>;
   onArchiveDeactivate?: (assignment: QuizAssignment) => void | Promise<void>;
   /** Reopen an ended assignment back to a paused state. */
@@ -498,6 +506,7 @@ export const QuizManager: React.FC<QuizManagerProps> = ({
   onArchiveEditSettings,
   onArchiveShare,
   onArchivePublishScores,
+  onArchiveUnpublishScores,
   onArchivePauseResume,
   onArchiveDeactivate,
   onArchiveReopen,
@@ -1134,6 +1143,28 @@ export const QuizManager: React.FC<QuizManagerProps> = ({
             : 'Publish scores',
         icon: Send,
         onClick: () => void onArchivePublishScores(a),
+      });
+    }
+    if (
+      onArchiveUnpublishScores &&
+      a.scoreVisibility &&
+      a.scoreVisibility !== 'none'
+    ) {
+      secondaries.push({
+        id: 'unpublish-scores',
+        label: 'Unpublish scores',
+        icon: EyeOff,
+        onClick: async () => {
+          const ok = await showConfirm(
+            'Students will no longer be able to see their scores or responses. You can republish anytime.',
+            {
+              title: 'Unpublish scores',
+              variant: 'danger',
+              confirmLabel: 'Unpublish',
+            }
+          );
+          if (ok) await onArchiveUnpublishScores(a);
+        },
       });
     }
     secondaries.push({

--- a/components/widgets/VideoActivityWidget/Widget.tsx
+++ b/components/widgets/VideoActivityWidget/Widget.tsx
@@ -121,6 +121,7 @@ export const VideoActivityWidget: React.FC<{ widget: WidgetData }> = ({
     deleteAssignment,
     shareAssignment,
     publishAssignmentScores,
+    unpublishAssignmentScores,
   } = useVideoActivityAssignments(user?.uid);
 
   const [publishingAssignment, setPublishingAssignment] =
@@ -839,23 +840,10 @@ export const VideoActivityWidget: React.FC<{ widget: WidgetData }> = ({
           setPublishingAssignment(assignment)
         }
         onArchiveUnpublishScores={async (assignment) => {
-          // One-click unpublish — mirrors the modal's 'none' branch
-          // (above) but without re-opening the picker. The hook's
-          // 'none' path skips the Drive lookup, so an empty
-          // placeholder VideoActivityData is sufficient.
+          // One-click unpublish — `unpublishAssignmentScores` is a cheap
+          // two-write batch (no Drive lookup, no grading).
           try {
-            await publishAssignmentScores(
-              assignment.id,
-              {
-                id: assignment.activityId,
-                title: assignment.activityTitle,
-                youtubeUrl: '',
-                questions: [],
-                createdAt: 0,
-                updatedAt: 0,
-              },
-              'none'
-            );
+            await unpublishAssignmentScores(assignment.id);
             addToast('Scores unpublished.', 'success');
           } catch (err) {
             addToast(
@@ -892,21 +880,7 @@ export const VideoActivityWidget: React.FC<{ widget: WidgetData }> = ({
             const target = publishingAssignment;
             try {
               if (visibility === 'none') {
-                await publishAssignmentScores(
-                  target.id,
-                  // Empty placeholder VideoActivityData — the 'none' branch
-                  // never reads it. Cheaper than re-loading from Drive for
-                  // a flag flip.
-                  {
-                    id: target.activityId,
-                    title: target.activityTitle,
-                    youtubeUrl: '',
-                    questions: [],
-                    createdAt: 0,
-                    updatedAt: 0,
-                  },
-                  visibility
-                );
+                await unpublishAssignmentScores(target.id);
                 addToast('Scores unpublished.', 'success');
                 setPublishingAssignment(null);
                 return;

--- a/components/widgets/VideoActivityWidget/Widget.tsx
+++ b/components/widgets/VideoActivityWidget/Widget.tsx
@@ -838,6 +838,32 @@ export const VideoActivityWidget: React.FC<{ widget: WidgetData }> = ({
         onArchivePublishScores={(assignment) =>
           setPublishingAssignment(assignment)
         }
+        onArchiveUnpublishScores={async (assignment) => {
+          // One-click unpublish — mirrors the modal's 'none' branch
+          // (above) but without re-opening the picker. The hook's
+          // 'none' path skips the Drive lookup, so an empty
+          // placeholder VideoActivityData is sufficient.
+          try {
+            await publishAssignmentScores(
+              assignment.id,
+              {
+                id: assignment.activityId,
+                title: assignment.activityTitle,
+                youtubeUrl: '',
+                questions: [],
+                createdAt: 0,
+                updatedAt: 0,
+              },
+              'none'
+            );
+            addToast('Scores unpublished.', 'success');
+          } catch (err) {
+            addToast(
+              err instanceof Error ? err.message : 'Failed to unpublish scores',
+              'error'
+            );
+          }
+        }}
         initialLibraryViewMode={config.libraryViewMode}
         onLibraryViewModeChange={(mode) => {
           updateWidget(widget.id, {

--- a/components/widgets/VideoActivityWidget/components/VideoActivityManager.tsx
+++ b/components/widgets/VideoActivityWidget/components/VideoActivityManager.tsx
@@ -54,6 +54,7 @@ import { AssignmentArchiveCard } from '@/components/common/library/AssignmentArc
 import { ViewCountBadge } from '@/components/common/library/ViewCountBadge';
 import { useSessionViewCount } from '@/hooks/useSessionViewCount';
 import { useAuth } from '@/context/useAuth';
+import { useDialog } from '@/context/useDialog';
 import { FolderSidebar } from '@/components/common/library/FolderSidebar';
 import { FolderPickerPopover } from '@/components/common/library/FolderPickerPopover';
 import { buildMoveToFolderAction } from '@/components/common/library/folderMenuAction';
@@ -450,6 +451,7 @@ export const VideoActivityManager: React.FC<VideoActivityManagerProps> = ({
   lastClassIdByActivityId,
   assignmentMode = 'submissions',
 }) => {
+  const { showConfirm } = useDialog();
   const isViewOnly = assignmentMode === 'view-only';
   const primaryActionLabel = isViewOnly ? 'Share' : 'Assign';
   const [tab, setTab] = useState<LibraryTab>('library');
@@ -526,11 +528,6 @@ export const VideoActivityManager: React.FC<VideoActivityManagerProps> = ({
   const [confirmDeleteAssignmentId, setConfirmDeleteAssignmentId] = useState<
     string | null
   >(null);
-  // Two-click confirmation for the destructive "Unpublish scores" kebab
-  // entry. First click flips the label to "Confirm unpublish"; second
-  // click within the same kebab session actually calls the hook.
-  const [confirmUnpublishAssignmentId, setConfirmUnpublishAssignmentId] =
-    useState<string | null>(null);
 
   /* ─── Folder navigation (Wave 3-B-3) ──────────────────────────────────── */
   const folderState = useFolders(userId, 'video_activity');
@@ -1154,19 +1151,20 @@ export const VideoActivityManager: React.FC<VideoActivityManagerProps> = ({
       assignment.scoreVisibility !== undefined &&
       assignment.scoreVisibility !== 'none'
     ) {
-      const awaitingConfirm = confirmUnpublishAssignmentId === assignment.id;
       actions.push({
         id: 'unpublish-scores',
-        label: awaitingConfirm ? 'Confirm unpublish' : 'Unpublish scores',
+        label: 'Unpublish scores',
         icon: EyeOff,
-        destructive: awaitingConfirm,
-        onClick: () => {
-          if (awaitingConfirm) {
-            setConfirmUnpublishAssignmentId(null);
-            void onArchiveUnpublishScores(assignment);
-          } else {
-            setConfirmUnpublishAssignmentId(assignment.id);
-          }
+        onClick: async () => {
+          const ok = await showConfirm(
+            'Students will no longer be able to see their scores or responses. You can republish anytime.',
+            {
+              title: 'Unpublish scores',
+              variant: 'danger',
+              confirmLabel: 'Unpublish',
+            }
+          );
+          if (ok) await onArchiveUnpublishScores(assignment);
         },
       });
     }

--- a/components/widgets/VideoActivityWidget/components/VideoActivityManager.tsx
+++ b/components/widgets/VideoActivityWidget/components/VideoActivityManager.tsx
@@ -26,6 +26,7 @@ import {
   CheckSquare,
   Copy,
   Edit2,
+  EyeOff,
   FileUp,
   Link2,
   Loader2,
@@ -207,6 +208,13 @@ export interface VideoActivityManagerProps {
    * `useVideoActivityAssignments.publishAssignmentScores` hook.
    */
   onArchivePublishScores?: (assignment: VideoActivityAssignment) => void;
+  /**
+   * Revoke published score visibility in one click (skips the picker
+   * modal). Only surfaced when `assignment.scoreVisibility` is published.
+   */
+  onArchiveUnpublishScores?: (
+    assignment: VideoActivityAssignment
+  ) => void | Promise<void>;
 
   /** Persisted library grid/list toggle (from widget config). */
   initialLibraryViewMode?: 'grid' | 'list';
@@ -433,6 +441,7 @@ export const VideoActivityManager: React.FC<VideoActivityManagerProps> = ({
   onArchiveShare,
   onArchiveMonitor,
   onArchivePublishScores,
+  onArchiveUnpublishScores,
   initialLibraryViewMode,
   onLibraryViewModeChange,
   rosters,
@@ -517,6 +526,11 @@ export const VideoActivityManager: React.FC<VideoActivityManagerProps> = ({
   const [confirmDeleteAssignmentId, setConfirmDeleteAssignmentId] = useState<
     string | null
   >(null);
+  // Two-click confirmation for the destructive "Unpublish scores" kebab
+  // entry. First click flips the label to "Confirm unpublish"; second
+  // click within the same kebab session actually calls the hook.
+  const [confirmUnpublishAssignmentId, setConfirmUnpublishAssignmentId] =
+    useState<string | null>(null);
 
   /* ─── Folder navigation (Wave 3-B-3) ──────────────────────────────────── */
   const folderState = useFolders(userId, 'video_activity');
@@ -1132,6 +1146,28 @@ export const VideoActivityManager: React.FC<VideoActivityManagerProps> = ({
         label: isPublished ? 'Update published scores' : 'Publish scores',
         icon: Send,
         onClick: () => onArchivePublishScores(assignment),
+      });
+    }
+    if (
+      onArchiveUnpublishScores &&
+      !assignmentIsViewOnly &&
+      assignment.scoreVisibility !== undefined &&
+      assignment.scoreVisibility !== 'none'
+    ) {
+      const awaitingConfirm = confirmUnpublishAssignmentId === assignment.id;
+      actions.push({
+        id: 'unpublish-scores',
+        label: awaitingConfirm ? 'Confirm unpublish' : 'Unpublish scores',
+        icon: EyeOff,
+        destructive: awaitingConfirm,
+        onClick: () => {
+          if (awaitingConfirm) {
+            setConfirmUnpublishAssignmentId(null);
+            void onArchiveUnpublishScores(assignment);
+          } else {
+            setConfirmUnpublishAssignmentId(assignment.id);
+          }
+        },
       });
     }
 

--- a/firestore.rules
+++ b/firestore.rules
@@ -2625,12 +2625,15 @@ service cloud.firestore {
       allow create: if request.auth != null &&
         request.auth.token.firebase.sign_in_provider != 'anonymous' &&
         request.resource.data.teacherUid == request.auth.uid;
-      // Sessions are otherwise immutable; only the owning teacher (or admin)
-      // may delete — used by the Wave 2-GL "Delete permanently" action in the
-      // Assignment archive to clean up the session along with the per-teacher
-      // assignment doc.
-      allow update: if false;
-      allow delete: if request.auth != null &&
+      // The owning teacher (or admin) may update the session — used by
+      // `publishAssignmentScores` to mirror `scoreVisibility` +
+      // `revealedAnswers` onto the session doc so the student listener can
+      // gate its review screen without subscribing to teacher-owned docs.
+      // Mirrors the Quiz session rule (`quiz_sessions/{sessionId}` allow
+      // update). Only the owning teacher (or admin) may delete — used by
+      // the Wave 2-GL "Delete permanently" action in the Assignment archive
+      // to clean up the session along with the per-teacher assignment doc.
+      allow update, delete: if request.auth != null &&
         (resource.data.teacherUid == request.auth.uid || isAdmin());
 
       match /responses/{studentUid} {
@@ -2639,6 +2642,9 @@ service cloud.firestore {
         }
         function glSessionClassIds() {
           return get(/databases/$(database)/documents/guided_learning_sessions/$(sessionId)).data.get('classIds', []);
+        }
+        function glSessionTeacherUid() {
+          return get(/databases/$(database)/documents/guided_learning_sessions/$(sessionId)).data.teacherUid;
         }
         // Defense in depth — block response writes on view-only sessions.
         // GuidedLearningSession.mode already names the play-mode
@@ -2664,17 +2670,36 @@ service cloud.firestore {
           passesStudentClassGateCompat(glSessionClassIds(), glSessionClassId()) &&
           // Block submissions on view-only sessions (mode is frozen at creation)
           glSessionMode() == 'submissions';
-        // Students can update only their own response to add answers or set completedAt;
-        // identity fields and score are immutable from the client
-        allow update: if request.auth != null &&
-          studentUid == request.auth.uid &&
-          passesStudentClassGateCompat(glSessionClassIds(), glSessionClassId()) &&
-          request.resource.data.studentAnonymousId == resource.data.studentAnonymousId &&
-          request.resource.data.sessionId == resource.data.sessionId &&
-          request.resource.data.startedAt == resource.data.startedAt &&
-          request.resource.data.score == resource.data.score &&
-          request.resource.data.diff(resource.data).affectedKeys().hasOnly(['answers', 'completedAt', 'pin']) &&
-          request.resource.data.answers.size() >= resource.data.answers.size();
+        // Two disjoint branches:
+        //
+        //   TEACHER branch — the owning teacher (or admin) writes `score` and
+        //   per-answer `isCorrect` when they call `publishAssignmentScores`,
+        //   and clears those on unpublish. The session's `teacherUid` is the
+        //   sole ownership gate; we deliberately don't constrain
+        //   `request.resource.data` further so future publish-flow fields
+        //   don't require a rules edit. Mirrors the Quiz / VA response
+        //   update pattern.
+        //
+        //   STUDENT branch — append answers / set completedAt on their own
+        //   response, with `score` locked immutable from the client. Branch
+        //   mutual exclusivity is by intent: a student calling update() will
+        //   fail the teacher disjunct (uid != teacherUid) and fall through
+        //   to the student branch's full append-only invariants.
+        allow update: if request.auth != null && (
+          // Teacher branch.
+          (request.auth.uid == glSessionTeacherUid() || isAdmin()) ||
+          // Student branch — unchanged.
+          (
+            studentUid == request.auth.uid &&
+            passesStudentClassGateCompat(glSessionClassIds(), glSessionClassId()) &&
+            request.resource.data.studentAnonymousId == resource.data.studentAnonymousId &&
+            request.resource.data.sessionId == resource.data.sessionId &&
+            request.resource.data.startedAt == resource.data.startedAt &&
+            request.resource.data.score == resource.data.score &&
+            request.resource.data.diff(resource.data).affectedKeys().hasOnly(['answers', 'completedAt', 'pin']) &&
+            request.resource.data.answers.size() >= resource.data.answers.size()
+          )
+        );
         // Owning teacher (or admin) may delete responses — used when the
         // teacher permanently deletes an assignment.
         allow delete: if request.auth != null && (

--- a/hooks/useGuidedLearningAssignments.ts
+++ b/hooks/useGuidedLearningAssignments.ts
@@ -15,6 +15,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import {
   collection,
+  deleteField,
   doc,
   getDocs,
   onSnapshot,
@@ -26,15 +27,44 @@ import {
 } from 'firebase/firestore';
 import { db } from '@/config/firebase';
 import { invalidateSessionViewCount } from './useSessionViewCount';
+import { isAnswerCorrect } from './useGuidedLearningSession';
 import type {
   AssignmentMode,
   GuidedLearningAssignment,
   GuidedLearningAssignmentStatus,
+  GuidedLearningResponse,
+  GuidedLearningScoreVisibility,
+  GuidedLearningSet,
+  GuidedLearningStep,
 } from '@/types';
 
 const GL_ASSIGNMENTS_COLLECTION = 'guided_learning_assignments';
 const GL_SESSIONS_COLLECTION = 'guided_learning_sessions';
 const GL_SESSION_RESPONSES_SUBCOLLECTION = 'responses';
+
+/**
+ * Stringify a step's canonical correct answer for `session.revealedAnswers`.
+ * `revealedAnswers` is `Record<stepId, string>` (mirrors Quiz/VA), so the
+ * array-shaped answers for matching and sorting are flattened into a
+ * human-readable string for the student review screen. Returns `null` for
+ * steps that don't have a gradable question (info hotspots, etc.).
+ */
+function formatCanonicalAnswer(step: GuidedLearningStep): string | null {
+  const q = step.question;
+  if (!q) return null;
+  if (q.type === 'multiple-choice') {
+    return q.correctAnswer ?? null;
+  }
+  if (q.type === 'matching') {
+    if (!q.matchingPairs?.length) return null;
+    return q.matchingPairs.map((p) => `${p.left} → ${p.right}`).join('\n');
+  }
+  if (q.type === 'sorting') {
+    if (!q.sortingItems?.length) return null;
+    return q.sortingItems.join(' → ');
+  }
+  return null;
+}
 
 export interface CreateAssignmentInput {
   /** The session id (also becomes the assignment id). */
@@ -68,6 +98,23 @@ export interface UseGuidedLearningAssignmentsResult {
   unarchiveAssignment: (assignmentId: string) => Promise<void>;
   /** Delete assignment + session + all responses permanently. */
   deleteAssignment: (assignmentId: string) => Promise<void>;
+  /**
+   * Publish (or unpublish) student-facing score visibility for an
+   * archived assignment. Mirrors the Quiz/VA `publishAssignmentScores`
+   * contract: `'none'` unpublishes (cheap flag-flip + revealed-answer
+   * wipe); other levels recompute per-response `isCorrect` + `score`,
+   * mirror the visibility flag onto session, and populate
+   * `revealedAnswers` iff the teacher chose to share answer keys.
+   * Pre-existing per-response `score` / `isCorrect` values are
+   * overwritten so the operation is idempotent and self-correcting
+   * (responses submitted in student-mode may have been written with
+   * `isCorrect: null`).
+   */
+  publishAssignmentScores: (
+    assignmentId: string,
+    glData: GuidedLearningSet,
+    visibility: GuidedLearningScoreVisibility
+  ) => Promise<{ responsesUpdated: number }>;
 }
 
 export const useGuidedLearningAssignments = (
@@ -223,6 +270,151 @@ export const useGuidedLearningAssignments = (
     [userId]
   );
 
+  const publishAssignmentScores = useCallback<
+    UseGuidedLearningAssignmentsResult['publishAssignmentScores']
+  >(
+    async (assignmentId, glData, visibility) => {
+      if (!userId) throw new Error('Not authenticated');
+
+      const now = Date.now();
+      const assignmentRef = doc(
+        db,
+        'users',
+        userId,
+        GL_ASSIGNMENTS_COLLECTION,
+        assignmentId
+      );
+      const sessionRef = doc(db, GL_SESSIONS_COLLECTION, assignmentId);
+
+      // Unpublish path — flip visibility flag on both docs and wipe the
+      // revealed-answers map. Leave per-response `score` / `isCorrect`
+      // intact: the student app gates on `session.scoreVisibility`, so
+      // numbers behind a closed gate are harmless and a re-publish at
+      // the same level avoids a multi-batch recompute.
+      if (visibility === 'none') {
+        const batch = writeBatch(db);
+        batch.update(assignmentRef, {
+          scoreVisibility: 'none',
+          scorePublishedAt: deleteField(),
+          updatedAt: now,
+        });
+        batch.update(sessionRef, {
+          scoreVisibility: 'none',
+          revealedAnswers: deleteField(),
+        });
+        await batch.commit();
+        return { responsesUpdated: 0 };
+      }
+
+      // Index steps by id for O(1) grading lookups. `glData.steps` is the
+      // canonical set loaded by the caller — `session.publicSteps` strips
+      // answer keys for student safety, so we can't grade off the session.
+      const stepsById = new Map<string, GuidedLearningStep>();
+      for (const s of glData.steps) {
+        stepsById.set(s.id, s);
+      }
+      const gradableStepIds = new Set<string>();
+      for (const s of glData.steps) {
+        if (s.question) gradableStepIds.add(s.id);
+      }
+
+      const responsesSnap = await getDocs(
+        collection(
+          db,
+          GL_SESSIONS_COLLECTION,
+          assignmentId,
+          GL_SESSION_RESPONSES_SUBCOLLECTION
+        )
+      );
+
+      interface ResponseUpdate {
+        ref: ReturnType<typeof doc>;
+        patch: {
+          score: number;
+          answers: GuidedLearningResponse['answers'];
+        };
+      }
+      const updates: ResponseUpdate[] = [];
+      for (const d of responsesSnap.docs) {
+        const data = d.data() as GuidedLearningResponse;
+        const answers = Array.isArray(data.answers) ? data.answers : [];
+        let correctCount = 0;
+        const gradedAnswers: GuidedLearningResponse['answers'] = answers.map(
+          (a) => {
+            const step = stepsById.get(a.stepId);
+            if (!step || !step.question) {
+              // Step deleted or no longer gradable — clear any stale
+              // `isCorrect` so the response doesn't carry a value the
+              // canonical set no longer supports.
+              return { ...a, isCorrect: null };
+            }
+            const correct = isAnswerCorrect(step, a.answer);
+            if (correct) correctCount += 1;
+            return { ...a, isCorrect: correct };
+          }
+        );
+        // Denominator: every gradable step in the canonical set. Counting
+        // unanswered gradable steps toward the total means a blank
+        // submission scores 0%, not undefined.
+        const denom = gradableStepIds.size;
+        const score =
+          denom === 0 ? 0 : Math.round((correctCount / denom) * 100);
+        updates.push({
+          ref: d.ref,
+          patch: { score, answers: gradedAnswers },
+        });
+      }
+
+      // First batch carries the assignment + session writes so the
+      // visibility flip lands atomically with at least the first chunk
+      // of response updates. Subsequent chunks are independent; a
+      // re-publish safely overwrites if any chunk fails.
+      const MAX_BATCH_WRITES = 400;
+      const firstBatch = writeBatch(db);
+      firstBatch.update(assignmentRef, {
+        scoreVisibility: visibility,
+        scorePublishedAt: now,
+        updatedAt: now,
+      });
+      const sessionPatch: Record<string, unknown> = {
+        scoreVisibility: visibility,
+      };
+      if (visibility === 'score-responses-and-answers') {
+        const revealedAnswers: Record<string, string> = {};
+        for (const s of glData.steps) {
+          const formatted = formatCanonicalAnswer(s);
+          if (formatted !== null) revealedAnswers[s.id] = formatted;
+        }
+        sessionPatch.revealedAnswers = revealedAnswers;
+      } else {
+        sessionPatch.revealedAnswers = deleteField();
+      }
+      firstBatch.update(sessionRef, sessionPatch);
+
+      const firstChunkSize = Math.min(updates.length, MAX_BATCH_WRITES - 2);
+      for (let i = 0; i < firstChunkSize; i++) {
+        firstBatch.update(updates[i].ref, updates[i].patch);
+      }
+      await firstBatch.commit();
+
+      for (
+        let cursor = firstChunkSize;
+        cursor < updates.length;
+        cursor += MAX_BATCH_WRITES
+      ) {
+        const chunk = updates.slice(cursor, cursor + MAX_BATCH_WRITES);
+        const chunkBatch = writeBatch(db);
+        for (const u of chunk) {
+          chunkBatch.update(u.ref, u.patch);
+        }
+        await chunkBatch.commit();
+      }
+
+      return { responsesUpdated: updates.length };
+    },
+    [userId]
+  );
+
   return {
     assignments,
     loading,
@@ -231,5 +423,6 @@ export const useGuidedLearningAssignments = (
     archiveAssignment,
     unarchiveAssignment,
     deleteAssignment,
+    publishAssignmentScores,
   };
 };

--- a/hooks/useGuidedLearningAssignments.ts
+++ b/hooks/useGuidedLearningAssignments.ts
@@ -48,22 +48,30 @@ const GL_SESSION_RESPONSES_SUBCOLLECTION = 'responses';
  * array-shaped answers for matching and sorting are flattened into a
  * human-readable string for the student review screen. Returns `null` for
  * steps that don't have a gradable question (info hotspots, etc.).
+ *
+ * Exhaustive over `GuidedLearningQuestionType`: a new type added to the
+ * union surfaces as a TypeScript error on the `_exhaustiveCheck: never`
+ * assignment, so callers can't silently drop coverage for a new question
+ * shape.
  */
-function formatCanonicalAnswer(step: GuidedLearningStep): string | null {
+export function formatCanonicalAnswer(step: GuidedLearningStep): string | null {
   const q = step.question;
   if (!q) return null;
-  if (q.type === 'multiple-choice') {
-    return q.correctAnswer ?? null;
+  switch (q.type) {
+    case 'multiple-choice':
+      return q.correctAnswer ?? null;
+    case 'matching':
+      if (!q.matchingPairs?.length) return null;
+      return q.matchingPairs.map((p) => `${p.left} → ${p.right}`).join('\n');
+    case 'sorting':
+      if (!q.sortingItems?.length) return null;
+      return q.sortingItems.join(' → ');
+    default: {
+      const _exhaustiveCheck: never = q.type;
+      void _exhaustiveCheck;
+      return null;
+    }
   }
-  if (q.type === 'matching') {
-    if (!q.matchingPairs?.length) return null;
-    return q.matchingPairs.map((p) => `${p.left} → ${p.right}`).join('\n');
-  }
-  if (q.type === 'sorting') {
-    if (!q.sortingItems?.length) return null;
-    return q.sortingItems.join(' → ');
-  }
-  return null;
 }
 
 export interface CreateAssignmentInput {
@@ -99,22 +107,33 @@ export interface UseGuidedLearningAssignmentsResult {
   /** Delete assignment + session + all responses permanently. */
   deleteAssignment: (assignmentId: string) => Promise<void>;
   /**
-   * Publish (or unpublish) student-facing score visibility for an
-   * archived assignment. Mirrors the Quiz/VA `publishAssignmentScores`
-   * contract: `'none'` unpublishes (cheap flag-flip + revealed-answer
-   * wipe); other levels recompute per-response `isCorrect` + `score`,
-   * mirror the visibility flag onto session, and populate
-   * `revealedAnswers` iff the teacher chose to share answer keys.
-   * Pre-existing per-response `score` / `isCorrect` values are
-   * overwritten so the operation is idempotent and self-correcting
-   * (responses submitted in student-mode may have been written with
-   * `isCorrect: null`).
+   * Publish student-facing score visibility for an archived assignment.
+   * Mirrors `useQuizAssignments.publishAssignmentScores`: recomputes
+   * per-response `isCorrect` + `score`, mirrors the visibility flag onto
+   * the session doc, and populates `session.revealedAnswers` iff the
+   * teacher chose `'score-responses-and-answers'`. Pre-existing
+   * per-response values are overwritten so the operation is idempotent
+   * and self-correcting (responses submitted in student-mode are
+   * written with `isCorrect: null`).
+   *
+   * The signature deliberately excludes `'none'` — use
+   * {@link UseGuidedLearningAssignmentsResult.unpublishAssignmentScores}
+   * for the rollback path, which is a cheap two-write batch that
+   * doesn't require fabricating a placeholder `GuidedLearningSet`.
    */
   publishAssignmentScores: (
     assignmentId: string,
     glData: GuidedLearningSet,
-    visibility: GuidedLearningScoreVisibility
+    visibility: Exclude<GuidedLearningScoreVisibility, 'none'>
   ) => Promise<{ responsesUpdated: number }>;
+  /**
+   * Revoke published score visibility for an assignment. Clears
+   * `scoreVisibility` + `scorePublishedAt` on the assignment doc (via
+   * `deleteField()`) and wipes `revealedAnswers` on the mirrored
+   * session doc. Per-response `score` / `isCorrect` are left intact —
+   * student-side rendering gates on `session.scoreVisibility`.
+   */
+  unpublishAssignmentScores: (assignmentId: string) => Promise<void>;
 }
 
 export const useGuidedLearningAssignments = (
@@ -270,11 +289,53 @@ export const useGuidedLearningAssignments = (
     [userId]
   );
 
+  const unpublishAssignmentScores = useCallback<
+    UseGuidedLearningAssignmentsResult['unpublishAssignmentScores']
+  >(
+    async (assignmentId) => {
+      if (!userId) throw new Error('Not authenticated');
+      const now = Date.now();
+      const assignmentRef = doc(
+        db,
+        'users',
+        userId,
+        GL_ASSIGNMENTS_COLLECTION,
+        assignmentId
+      );
+      const sessionRef = doc(db, GL_SESSIONS_COLLECTION, assignmentId);
+      // Wipe visibility flags via deleteField on both docs and clear
+      // the revealed-answers map. Per-response `score` / `isCorrect`
+      // are left intact: the student app gates on
+      // `session.scoreVisibility`, so numbers behind a closed gate are
+      // harmless and a re-publish at the same level avoids a multi-
+      // batch recompute.
+      const batch = writeBatch(db);
+      batch.update(assignmentRef, {
+        scoreVisibility: deleteField(),
+        scorePublishedAt: deleteField(),
+        updatedAt: now,
+      });
+      batch.update(sessionRef, {
+        scoreVisibility: deleteField(),
+        revealedAnswers: deleteField(),
+      });
+      await batch.commit();
+    },
+    [userId]
+  );
+
   const publishAssignmentScores = useCallback<
     UseGuidedLearningAssignmentsResult['publishAssignmentScores']
   >(
     async (assignmentId, glData, visibility) => {
       if (!userId) throw new Error('Not authenticated');
+      // Belt-and-suspenders against a future caller bypassing the
+      // type-level `Exclude<…, 'none'>` (matches Quiz/VA pattern).
+      if ((visibility as string) === 'none') {
+        throw new Error(
+          'publishAssignmentScores: visibility "none" is not allowed — use unpublishAssignmentScores instead.'
+        );
+      }
 
       const now = Date.now();
       const assignmentRef = doc(
@@ -285,26 +346,6 @@ export const useGuidedLearningAssignments = (
         assignmentId
       );
       const sessionRef = doc(db, GL_SESSIONS_COLLECTION, assignmentId);
-
-      // Unpublish path — flip visibility flag on both docs and wipe the
-      // revealed-answers map. Leave per-response `score` / `isCorrect`
-      // intact: the student app gates on `session.scoreVisibility`, so
-      // numbers behind a closed gate are harmless and a re-publish at
-      // the same level avoids a multi-batch recompute.
-      if (visibility === 'none') {
-        const batch = writeBatch(db);
-        batch.update(assignmentRef, {
-          scoreVisibility: 'none',
-          scorePublishedAt: deleteField(),
-          updatedAt: now,
-        });
-        batch.update(sessionRef, {
-          scoreVisibility: 'none',
-          revealedAnswers: deleteField(),
-        });
-        await batch.commit();
-        return { responsesUpdated: 0 };
-      }
 
       // Index steps by id for O(1) grading lookups. `glData.steps` is the
       // canonical set loaded by the caller — `session.publicSteps` strips
@@ -396,18 +437,32 @@ export const useGuidedLearningAssignments = (
         firstBatch.update(updates[i].ref, updates[i].patch);
       }
       await firstBatch.commit();
+      let responsesCommitted = firstChunkSize;
 
-      for (
-        let cursor = firstChunkSize;
-        cursor < updates.length;
-        cursor += MAX_BATCH_WRITES
-      ) {
-        const chunk = updates.slice(cursor, cursor + MAX_BATCH_WRITES);
-        const chunkBatch = writeBatch(db);
-        for (const u of chunk) {
-          chunkBatch.update(u.ref, u.patch);
+      // Mirror Quiz/VA chunked-failure recovery: if a subsequent chunk
+      // fails partway, the visibility flag is already flipped — some
+      // students will see graded reviews while the remaining responses
+      // still carry pre-publish state. Throw a structured error so the
+      // caller can tell the teacher "X of Y graded, re-run Publish."
+      try {
+        for (
+          let cursor = firstChunkSize;
+          cursor < updates.length;
+          cursor += MAX_BATCH_WRITES
+        ) {
+          const chunk = updates.slice(cursor, cursor + MAX_BATCH_WRITES);
+          const chunkBatch = writeBatch(db);
+          for (const u of chunk) {
+            chunkBatch.update(u.ref, u.patch);
+          }
+          await chunkBatch.commit();
+          responsesCommitted += chunk.length;
         }
-        await chunkBatch.commit();
+      } catch (err) {
+        const cause = err instanceof Error ? err.message : String(err);
+        throw new Error(
+          `Partial publish: ${responsesCommitted} of ${updates.length} student responses graded. Re-run "Publish scores" to finish. (${cause})`
+        );
       }
 
       return { responsesUpdated: updates.length };
@@ -424,5 +479,6 @@ export const useGuidedLearningAssignments = (
     unarchiveAssignment,
     deleteAssignment,
     publishAssignmentScores,
+    unpublishAssignmentScores,
   };
 };

--- a/hooks/useGuidedLearningSession.ts
+++ b/hooks/useGuidedLearningSession.ts
@@ -14,7 +14,6 @@ import {
   collection,
   doc,
   setDoc,
-  getDoc,
   onSnapshot,
   query,
   orderBy,
@@ -335,10 +334,16 @@ export const useGuidedLearningSessionStudent = (
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    const load = async () => {
-      try {
-        const snap = await getDoc(doc(db, GL_SESSIONS_COLLECTION, sessionId));
+    // Realtime listener so a teacher publish/unpublish flips the
+    // student-visible `scoreVisibility` + `revealedAnswers` in place
+    // without the student needing to refresh. The session doc is
+    // already small and world-readable, so a per-student listener is
+    // cheap.
+    const unsub = onSnapshot(
+      doc(db, GL_SESSIONS_COLLECTION, sessionId),
+      (snap) => {
         if (!snap.exists()) {
+          setSession(null);
           setError('This guided learning session was not found.');
         } else {
           const raw = snap.data() as GuidedLearningSession & {
@@ -365,15 +370,17 @@ export const useGuidedLearningSessionStudent = (
               showOverlay: step.showOverlay ?? 'none',
             })),
           });
+          setError(null);
         }
-      } catch (err) {
-        console.error('[useGuidedLearningSession] Load error:', err);
+        setLoading(false);
+      },
+      (err) => {
+        console.error('[useGuidedLearningSession] Snapshot error:', err);
         setError('Failed to load the session. Please try again.');
-      } finally {
         setLoading(false);
       }
-    };
-    void load();
+    );
+    return unsub;
   }, [sessionId]);
 
   const submitResponse = useCallback(

--- a/hooks/useGuidedLearningSession.ts
+++ b/hooks/useGuidedLearningSession.ts
@@ -375,8 +375,19 @@ export const useGuidedLearningSessionStudent = (
         setLoading(false);
       },
       (err) => {
+        // Firestore's onSnapshot retries internally on recoverable
+        // failures, so a transient blip (WiFi drop, brief unavailable)
+        // doesn't justify ejecting the student onto a permanent
+        // ErrorScreen — especially if we already have data on hand.
+        // Only surface a hard error before the first successful
+        // snapshot; after that, swallow and let the listener self-heal.
         console.error('[useGuidedLearningSession] Snapshot error:', err);
-        setError('Failed to load the session. Please try again.');
+        setSession((prev) => {
+          if (prev === null) {
+            setError('Failed to load the session. Please try again.');
+          }
+          return prev;
+        });
         setLoading(false);
       }
     );

--- a/hooks/useQuizAssignments.ts
+++ b/hooks/useQuizAssignments.ts
@@ -337,7 +337,7 @@ export interface UseQuizAssignmentsResult {
   /**
    * Publish (or unpublish) score visibility for an archived assignment.
    *
-   * For visibility levels other than `'none'`, this:
+   * Publishes scores at the given visibility level:
    *   1. Computes each student's percentage score from the live response
    *      docs using `gradeAnswer` against the canonical `quizData`, and
    *      writes the resulting `score` + per-answer `isCorrect` flags onto
@@ -349,19 +349,29 @@ export interface UseQuizAssignmentsResult {
    *      `session.revealedAnswers` with every question's canonical answer
    *      so the student review screen can render the correct answer text.
    *
-   * Passing `'none'` clears the visibility flags (and `revealedAnswers`)
-   * so a teacher who published in error can roll back without deleting
-   * the assignment. Already-written `score` / `isCorrect` fields on
-   * responses are left in place — re-publishing simply overwrites them.
+   * Returns the number of responses whose score was (re)computed.
    *
-   * Returns the number of responses whose score was (re)computed; `0`
-   * when `'none'`.
+   * The signature deliberately excludes `'none'` — callers wishing to
+   * unpublish must use {@link UseQuizAssignmentsResult.unpublishAssignmentScores}
+   * instead, which is a cheap two-write batch that doesn't require
+   * fabricating a placeholder `QuizData` to satisfy the type.
    */
   publishAssignmentScores: (
     assignmentId: string,
     quizData: QuizData,
-    visibility: QuizScoreVisibility
+    visibility: Exclude<QuizScoreVisibility, 'none'>
   ) => Promise<{ responsesUpdated: number }>;
+  /**
+   * Revoke published score visibility for an assignment. Clears
+   * `scoreVisibility` + `scorePublishedAt` on the assignment doc (via
+   * `deleteField()`, so the unpublished and never-published states are
+   * indistinguishable on disk) and wipes `revealedAnswers` on the
+   * mirrored session doc. Already-written per-response `score` /
+   * `isCorrect` fields are left intact — student-side rendering gates
+   * on `session.scoreVisibility`, and re-publishing safely overwrites
+   * them.
+   */
+  unpublishAssignmentScores: (assignmentId: string) => Promise<void>;
 }
 
 /**
@@ -1795,11 +1805,58 @@ export const useQuizAssignments = (
     [userId]
   );
 
+  const unpublishAssignmentScores = useCallback<
+    UseQuizAssignmentsResult['unpublishAssignmentScores']
+  >(
+    async (assignmentId) => {
+      if (!userId) throw new Error('Not authenticated');
+      const now = Date.now();
+      const assignmentRef = doc(
+        db,
+        'users',
+        userId,
+        QUIZ_ASSIGNMENTS_COLLECTION,
+        assignmentId
+      );
+      const sessionRef = doc(db, QUIZ_SESSIONS_COLLECTION, assignmentId);
+      // Wipe the visibility flags on both docs and the revealed-answers
+      // map on the session. Already-written `score` and per-answer
+      // `isCorrect` fields on response docs are left in place: the
+      // reader gates on `scoreVisibility`, so leaving the numbers
+      // behind is harmless and avoids a multi-batch wipe on a gesture
+      // the teacher may immediately undo. Using `deleteField()` for
+      // `scoreVisibility` on both docs collapses the "unpublished" and
+      // "never published" states into a single shape on disk.
+      const batch = writeBatch(db);
+      batch.update(assignmentRef, {
+        scoreVisibility: deleteField(),
+        scorePublishedAt: deleteField(),
+        updatedAt: now,
+      });
+      batch.update(sessionRef, {
+        scoreVisibility: deleteField(),
+        revealedAnswers: deleteField(),
+      });
+      await batch.commit();
+    },
+    [userId]
+  );
+
   const publishAssignmentScores = useCallback<
     UseQuizAssignmentsResult['publishAssignmentScores']
   >(
     async (assignmentId, quizData, visibility) => {
       if (!userId) throw new Error('Not authenticated');
+      // Belt-and-suspenders against a future caller that bypasses the
+      // type-level `Exclude<…, 'none'>`. The unpublish path lives in
+      // `unpublishAssignmentScores` and has different semantics
+      // (deleteField vs. mirroring); routing 'none' here would write
+      // the literal string and break the gradingStateFrom rule.
+      if ((visibility as string) === 'none') {
+        throw new Error(
+          'publishAssignmentScores: visibility "none" is not allowed — use unpublishAssignmentScores instead.'
+        );
+      }
 
       const now = Date.now();
       const assignmentRef = doc(
@@ -1810,28 +1867,6 @@ export const useQuizAssignments = (
         assignmentId
       );
       const sessionRef = doc(db, QUIZ_SESSIONS_COLLECTION, assignmentId);
-
-      // Unpublish path — clear the visibility flags on assignment + session
-      // and wipe the revealed-answers map so the student review screen
-      // falls back to "scores not yet published". Already-written `score`
-      // and per-answer `isCorrect` fields on response docs are left in
-      // place: the reader gates on `scoreVisibility`, so leaving the
-      // numbers behind is harmless and avoids a multi-batch wipe on a
-      // gesture the teacher may immediately undo.
-      if (visibility === 'none') {
-        const batch = writeBatch(db);
-        batch.update(assignmentRef, {
-          scoreVisibility: 'none',
-          scorePublishedAt: deleteField(),
-          updatedAt: now,
-        });
-        batch.update(sessionRef, {
-          scoreVisibility: 'none',
-          revealedAnswers: deleteField(),
-        });
-        await batch.commit();
-        return { responsesUpdated: 0 };
-      }
 
       // Index questions by id for O(1) grading lookups. Use the canonical
       // `quizData.questions` (loaded from Drive on the teacher side) so
@@ -1946,20 +1981,38 @@ export const useQuizAssignments = (
         firstBatch.update(updates[i].ref, updates[i].patch);
       }
       await firstBatch.commit();
+      let responsesCommitted = firstChunkSize;
 
       // Remaining responses in subsequent batches (assignments with > ~398
-      // submissions across a PLC). Each batch is independently committed.
-      for (
-        let cursor = firstChunkSize;
-        cursor < updates.length;
-        cursor += MAX_BATCH_WRITES
-      ) {
-        const chunk = updates.slice(cursor, cursor + MAX_BATCH_WRITES);
-        const chunkBatch = writeBatch(db);
-        for (const u of chunk) {
-          chunkBatch.update(u.ref, u.patch);
+      // submissions across a PLC). Each chunk is independently committed.
+      // If a chunk fails partway, the assignment + session visibility
+      // flags are already published (committed in `firstBatch`) — students
+      // will start seeing the review screen for already-graded responses,
+      // while the remaining `updates.length - responsesCommitted` rows
+      // still carry whatever `score`/`isCorrect` they had pre-publish.
+      // Re-running publish is safe and idempotent (the chunk reconstructs
+      // every patch from scratch), so we throw a structured error the
+      // caller can surface verbatim — "X of Y graded, re-run Publish to
+      // finish" — instead of a generic "Failed to publish."
+      try {
+        for (
+          let cursor = firstChunkSize;
+          cursor < updates.length;
+          cursor += MAX_BATCH_WRITES
+        ) {
+          const chunk = updates.slice(cursor, cursor + MAX_BATCH_WRITES);
+          const chunkBatch = writeBatch(db);
+          for (const u of chunk) {
+            chunkBatch.update(u.ref, u.patch);
+          }
+          await chunkBatch.commit();
+          responsesCommitted += chunk.length;
         }
-        await chunkBatch.commit();
+      } catch (err) {
+        const cause = err instanceof Error ? err.message : String(err);
+        throw new Error(
+          `Partial publish: ${responsesCommitted} of ${updates.length} student responses graded. Re-run "Publish scores" to finish. (${cause})`
+        );
       }
 
       return { responsesUpdated: updates.length };
@@ -1986,5 +2039,6 @@ export const useQuizAssignments = (
     importSharedAssignment,
     syncAssignmentToLatest,
     publishAssignmentScores,
+    unpublishAssignmentScores,
   };
 };

--- a/hooks/useStudentAssignments.ts
+++ b/hooks/useStudentAssignments.ts
@@ -216,7 +216,27 @@ export const KIND_CONFIG: Record<SessionKind, KindConfig> = {
         : 'Guided learning',
     hrefFrom: (sessionId) =>
       `/guided-learning/${encodeURIComponent(sessionId)}`,
-    gradingStateFrom: () => 'not-graded',
+    gradingStateFrom: (data) => {
+      // Mirrors the Quiz rule above — GL gained `scoreVisibility` +
+      // `scorePublishedAt` when the teacher publish/unpublish flow
+      // shipped. Both must be present (and visibility !== 'none') for
+      // the student row to render "View results" instead of "Not graded".
+      if (!data || typeof data !== 'object') return 'not-graded';
+      const visibility = (data as Record<string, unknown>).scoreVisibility;
+      const publishedAt = (data as Record<string, unknown>).scorePublishedAt;
+      if (
+        (visibility !== undefined && typeof visibility !== 'string') ||
+        (publishedAt !== undefined && typeof publishedAt !== 'number')
+      ) {
+        console.warn(
+          '[useStudentAssignments] malformed guided-learning publication fields',
+          { scoreVisibility: visibility, scorePublishedAt: publishedAt }
+        );
+      }
+      const isVisible = typeof visibility === 'string' && visibility !== 'none';
+      const isPublished = typeof publishedAt === 'number';
+      return isVisible && isPublished ? 'graded' : 'not-graded';
+    },
   },
   'mini-app': {
     collectionName: 'mini_app_sessions',

--- a/hooks/useStudentAssignments.ts
+++ b/hooks/useStudentAssignments.ts
@@ -121,6 +121,45 @@ interface KindConfig {
   gradingStateFrom: (data: DocumentData) => 'not-graded' | 'graded';
 }
 
+/**
+ * Shared publication-field parser for Quiz / GL `gradingStateFrom`.
+ * Returns 'graded' iff `scoreVisibility` is a non-'none' string AND
+ * `scorePublishedAt` is a number — matching the contract that
+ * `publishAssignmentScores` writes both atomically.
+ *
+ * Malformed snapshots (wrong types) are warned at most once per
+ * `kind:sessionVisibility:sessionPublishedAt` shape signature. Without
+ * this throttle, a single bad doc would `console.warn` on every
+ * snapshot delivery and drown out real errors — `gradingStateFrom` is
+ * called per assignment per snapshot.
+ */
+const warnedPublicationKeys = new Set<string>();
+/** @internal — exported only for the test harness. */
+export function parsePublicationFields(
+  kind: string,
+  data: DocumentData
+): 'not-graded' | 'graded' {
+  if (!data || typeof data !== 'object') return 'not-graded';
+  const visibility = (data as Record<string, unknown>).scoreVisibility;
+  const publishedAt = (data as Record<string, unknown>).scorePublishedAt;
+  if (
+    (visibility !== undefined && typeof visibility !== 'string') ||
+    (publishedAt !== undefined && typeof publishedAt !== 'number')
+  ) {
+    const key = `${kind}:${typeof visibility}:${typeof publishedAt}`;
+    if (!warnedPublicationKeys.has(key)) {
+      warnedPublicationKeys.add(key);
+      console.warn(
+        `[useStudentAssignments] malformed ${kind} publication fields`,
+        { scoreVisibility: visibility, scorePublishedAt: publishedAt }
+      );
+    }
+  }
+  const isVisible = typeof visibility === 'string' && visibility !== 'none';
+  const isPublished = typeof publishedAt === 'number';
+  return isVisible && isPublished ? 'graded' : 'not-graded';
+}
+
 export const KIND_CONFIG: Record<SessionKind, KindConfig> = {
   quiz: {
     collectionName: 'quiz_sessions',
@@ -144,34 +183,7 @@ export const KIND_CONFIG: Record<SessionKind, KindConfig> = {
           : sessionId;
       return `/quiz?code=${encodeURIComponent(code)}`;
     },
-    gradingStateFrom: (data) => {
-      // Quiz uses `scoreVisibility` ('none' = hidden) plus a
-      // `scorePublishedAt` timestamp to mark when grades go live to the
-      // student. Both must be present for the student to see results.
-      // Guard the cast — Firestore can hand back partial/empty snapshots
-      // during deletion races, and a runtime TypeError here would crash
-      // the whole assignment list instead of just dropping one row.
-      if (!data || typeof data !== 'object') return 'not-graded';
-      const visibility = (data as Record<string, unknown>).scoreVisibility;
-      const publishedAt = (data as Record<string, unknown>).scorePublishedAt;
-      // Surface data-shape mismatches — if one field is present but the
-      // other has the wrong type, the student silently sees "Not graded"
-      // on a session the teacher believes they published. This is the
-      // kind of "support ticket with no traces in the data" bug worth a
-      // console.warn so it shows up in error reporting.
-      if (
-        (visibility !== undefined && typeof visibility !== 'string') ||
-        (publishedAt !== undefined && typeof publishedAt !== 'number')
-      ) {
-        console.warn(
-          '[useStudentAssignments] malformed quiz publication fields',
-          { scoreVisibility: visibility, scorePublishedAt: publishedAt }
-        );
-      }
-      const isVisible = typeof visibility === 'string' && visibility !== 'none';
-      const isPublished = typeof publishedAt === 'number';
-      return isVisible && isPublished ? 'graded' : 'not-graded';
-    },
+    gradingStateFrom: (data) => parsePublicationFields('quiz', data),
   },
   'video-activity': {
     collectionName: 'video_activity_sessions',
@@ -216,27 +228,7 @@ export const KIND_CONFIG: Record<SessionKind, KindConfig> = {
         : 'Guided learning',
     hrefFrom: (sessionId) =>
       `/guided-learning/${encodeURIComponent(sessionId)}`,
-    gradingStateFrom: (data) => {
-      // Mirrors the Quiz rule above — GL gained `scoreVisibility` +
-      // `scorePublishedAt` when the teacher publish/unpublish flow
-      // shipped. Both must be present (and visibility !== 'none') for
-      // the student row to render "View results" instead of "Not graded".
-      if (!data || typeof data !== 'object') return 'not-graded';
-      const visibility = (data as Record<string, unknown>).scoreVisibility;
-      const publishedAt = (data as Record<string, unknown>).scorePublishedAt;
-      if (
-        (visibility !== undefined && typeof visibility !== 'string') ||
-        (publishedAt !== undefined && typeof publishedAt !== 'number')
-      ) {
-        console.warn(
-          '[useStudentAssignments] malformed guided-learning publication fields',
-          { scoreVisibility: visibility, scorePublishedAt: publishedAt }
-        );
-      }
-      const isVisible = typeof visibility === 'string' && visibility !== 'none';
-      const isPublished = typeof publishedAt === 'number';
-      return isVisible && isPublished ? 'graded' : 'not-graded';
-    },
+    gradingStateFrom: (data) => parsePublicationFields('guided-learning', data),
   },
   'mini-app': {
     collectionName: 'mini_app_sessions',

--- a/hooks/useVideoActivityAssignments.ts
+++ b/hooks/useVideoActivityAssignments.ts
@@ -177,30 +177,39 @@ export interface UseVideoActivityAssignmentsResult {
     options: ImportSharedAssignmentOptions
   ) => Promise<{ assignmentId: string; activityId: string }>;
   /**
-   * Publish (or unpublish) per-student scores for an assignment. Mirrors
+   * Publish per-student scores for an assignment. Mirrors
    * `useQuizAssignments.publishAssignmentScores`. Grades every response
    * via `gradeVideoActivityAnswer` (handles MA / FIB-with-variants — the
    * Quiz grader's `'MA'` blind spot is irrelevant here), writes the
    * computed `score` + per-answer `isCorrect` flags onto each response,
    * and mirrors the visibility flag onto the assignment + session docs.
    *
-   * `'none'` is the unpublish path: clears `scoreVisibility` on assignment
-   * + session and wipes `revealedAnswers`. Already-written `score` /
-   * `isCorrect` are left in place — the reader gates on `scoreVisibility`,
-   * so this is harmless and avoids a multi-batch wipe on a gesture the
-   * teacher may immediately undo.
-   *
    * `'score-responses-and-answers'` populates `session.revealedAnswers`
    * (id → correctAnswer) so the student review screen can show the
    * canonical correct answer for each question — VA's session strips
    * correct answers from `publicQuestions` for the in-progress flow,
    * mirroring Quiz's student-safety pattern.
+   *
+   * The signature deliberately excludes `'none'` — use
+   * {@link UseVideoActivityAssignmentsResult.unpublishAssignmentScores}
+   * for the rollback path, which is a cheap two-write batch that
+   * doesn't require fabricating a placeholder `VideoActivityData`.
    */
   publishAssignmentScores: (
     assignmentId: string,
     activityData: VideoActivityData,
-    visibility: VideoActivityScoreVisibility
+    visibility: Exclude<VideoActivityScoreVisibility, 'none'>
   ) => Promise<{ responsesUpdated: number }>;
+  /**
+   * Revoke published score visibility for an assignment. Clears
+   * `scoreVisibility` + `scorePublishedAt` on the assignment doc (via
+   * `deleteField()`) and wipes `revealedAnswers` on the mirrored
+   * session doc. Already-written per-response `score` / `isCorrect`
+   * fields are left intact — student-side rendering gates on
+   * `session.scoreVisibility`, and re-publishing safely overwrites
+   * them.
+   */
+  unpublishAssignmentScores: (assignmentId: string) => Promise<void>;
 }
 
 export interface ImportSharedAssignmentOptions {
@@ -885,11 +894,58 @@ export const useVideoActivityAssignments = (
     [userId, peekSharedAssignment, createAssignment]
   );
 
+  const unpublishAssignmentScores = useCallback<
+    UseVideoActivityAssignmentsResult['unpublishAssignmentScores']
+  >(
+    async (assignmentId) => {
+      if (!userId) throw new Error('Not authenticated');
+      const now = Date.now();
+      const assignmentRef = doc(
+        db,
+        'users',
+        userId,
+        VIDEO_ACTIVITY_ASSIGNMENTS_COLLECTION,
+        assignmentId
+      );
+      const sessionRef = doc(
+        db,
+        VIDEO_ACTIVITY_SESSIONS_COLLECTION,
+        assignmentId
+      );
+      // Wipe visibility flags via deleteField on both docs (so the
+      // "unpublished" and "never published" states share a single
+      // shape on disk) and clear the revealed-answers map. Per-response
+      // `score` / `isCorrect` are left intact — student-side rendering
+      // gates on `session.scoreVisibility`, and re-publishing safely
+      // overwrites them.
+      const batch = writeBatch(db);
+      batch.update(assignmentRef, {
+        scoreVisibility: deleteField(),
+        scorePublishedAt: deleteField(),
+        updatedAt: now,
+      });
+      batch.update(sessionRef, {
+        scoreVisibility: deleteField(),
+        revealedAnswers: deleteField(),
+      });
+      await batch.commit();
+    },
+    [userId]
+  );
+
   const publishAssignmentScores = useCallback<
     UseVideoActivityAssignmentsResult['publishAssignmentScores']
   >(
     async (assignmentId, activityData, visibility) => {
       if (!userId) throw new Error('Not authenticated');
+      // Belt-and-suspenders against a future caller that bypasses the
+      // type-level `Exclude<…, 'none'>` (see Quiz hook for the same
+      // assert and rationale).
+      if ((visibility as string) === 'none') {
+        throw new Error(
+          'publishAssignmentScores: visibility "none" is not allowed — use unpublishAssignmentScores instead.'
+        );
+      }
 
       const now = Date.now();
       const assignmentRef = doc(
@@ -904,21 +960,6 @@ export const useVideoActivityAssignments = (
         VIDEO_ACTIVITY_SESSIONS_COLLECTION,
         assignmentId
       );
-
-      if (visibility === 'none') {
-        const batch = writeBatch(db);
-        batch.update(assignmentRef, {
-          scoreVisibility: 'none',
-          scorePublishedAt: deleteField(),
-          updatedAt: now,
-        });
-        batch.update(sessionRef, {
-          scoreVisibility: 'none',
-          revealedAnswers: deleteField(),
-        });
-        await batch.commit();
-        return { responsesUpdated: 0 };
-      }
 
       const questionsById = new Map(
         activityData.questions.map((q) => [q.id, q])
@@ -1006,18 +1047,32 @@ export const useVideoActivityAssignments = (
         firstBatch.update(updates[i].ref, updates[i].patch);
       }
       await firstBatch.commit();
+      let responsesCommitted = firstChunkSize;
 
-      for (
-        let cursor = firstChunkSize;
-        cursor < updates.length;
-        cursor += MAX_BATCH_WRITES
-      ) {
-        const chunk = updates.slice(cursor, cursor + MAX_BATCH_WRITES);
-        const chunkBatch = writeBatch(db);
-        for (const u of chunk) {
-          chunkBatch.update(u.ref, u.patch);
+      // Mirror Quiz's chunked-failure recovery: if a subsequent chunk
+      // fails partway, the visibility flag is already flipped — students
+      // will see graded responses while ungraded ones still carry
+      // pre-publish state. Throw a structured error the caller can
+      // surface verbatim so the teacher knows to re-run Publish.
+      try {
+        for (
+          let cursor = firstChunkSize;
+          cursor < updates.length;
+          cursor += MAX_BATCH_WRITES
+        ) {
+          const chunk = updates.slice(cursor, cursor + MAX_BATCH_WRITES);
+          const chunkBatch = writeBatch(db);
+          for (const u of chunk) {
+            chunkBatch.update(u.ref, u.patch);
+          }
+          await chunkBatch.commit();
+          responsesCommitted += chunk.length;
         }
-        await chunkBatch.commit();
+      } catch (err) {
+        const cause = err instanceof Error ? err.message : String(err);
+        throw new Error(
+          `Partial publish: ${responsesCommitted} of ${updates.length} student responses graded. Re-run "Publish scores" to finish. (${cause})`
+        );
       }
 
       return { responsesUpdated: updates.length };
@@ -1040,5 +1095,6 @@ export const useVideoActivityAssignments = (
     peekSharedAssignment,
     importSharedAssignment,
     publishAssignmentScores,
+    unpublishAssignmentScores,
   };
 };

--- a/tests/components/guidedLearning/PublishedGLReview.test.tsx
+++ b/tests/components/guidedLearning/PublishedGLReview.test.tsx
@@ -1,0 +1,179 @@
+/**
+ * Covers the progressive-disclosure contract for the student-facing
+ * published-score review screen. The three visibility levels MUST gate
+ * what the student sees on the `/my-assignments` Completed surface:
+ *
+ *   - score-only:                show percentage, hide per-step answers
+ *   - score-and-responses:       show percentage + per-step student answers
+ *                                tagged correct/incorrect, but NEVER the
+ *                                canonical correct answer.
+ *   - score-responses-and-answers: above + canonical correct answers
+ *                                from session.revealedAnswers
+ *
+ * Without this test, a regression that swaps a `||` for `&&` (or that
+ * accidentally renders revealedAnswers under score-and-responses) silently
+ * leaks correct answers to students.
+ */
+
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import {
+  PublishedGLReview,
+  formatStudentAnswer,
+} from '@/components/guidedLearning/GuidedLearningStudentApp';
+import type { GuidedLearningSession, GuidedLearningResponse } from '@/types';
+
+function fixture(overrides: {
+  visibility: NonNullable<GuidedLearningSession['scoreVisibility']>;
+  studentAnswer?: string | string[];
+  isCorrect?: boolean | null;
+  revealedAnswers?: Record<string, string>;
+}): {
+  session: GuidedLearningSession;
+  myResponse: GuidedLearningResponse;
+} {
+  const session: GuidedLearningSession = {
+    id: 'session-1',
+    title: 'Photosynthesis review',
+    mode: 'guided',
+    imageUrls: [],
+    publicSteps: [
+      {
+        id: 'step-mc',
+        xPct: 0,
+        yPct: 0,
+        imageIndex: 0,
+        label: 'Stage 1',
+        interactionType: 'question',
+        question: {
+          type: 'multiple-choice',
+          text: 'Which produces oxygen?',
+          choices: ['Chlorophyll', 'Mitochondria'],
+        },
+      },
+    ],
+    teacherUid: 'teacher-1',
+    createdAt: 0,
+    scoreVisibility: overrides.visibility,
+    revealedAnswers: overrides.revealedAnswers,
+  };
+  const myResponse: GuidedLearningResponse = {
+    sessionId: 'session-1',
+    studentAnonymousId: 'student-1',
+    startedAt: 1,
+    completedAt: 2,
+    score: 50,
+    answers: [
+      {
+        stepId: 'step-mc',
+        answer: overrides.studentAnswer ?? 'Mitochondria',
+        isCorrect: overrides.isCorrect ?? false,
+      },
+    ],
+  };
+  return { session, myResponse };
+}
+
+describe('PublishedGLReview', () => {
+  it("'score-only' shows just the percentage and hides per-step rows", () => {
+    const { session, myResponse } = fixture({ visibility: 'score-only' });
+    render(
+      <PublishedGLReview
+        session={session}
+        myResponse={myResponse}
+        visibility="score-only"
+      />
+    );
+    expect(screen.getByText('50%')).toBeInTheDocument();
+    // No per-step row — the student answer must NOT appear in the DOM.
+    expect(screen.queryByText(/Mitochondria/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Your answer/)).not.toBeInTheDocument();
+  });
+
+  it("'score-and-responses' shows the student's answer + correct/incorrect, hides canonical answer", () => {
+    const { session, myResponse } = fixture({
+      visibility: 'score-and-responses',
+      revealedAnswers: { 'step-mc': 'Chlorophyll' },
+    });
+    render(
+      <PublishedGLReview
+        session={session}
+        myResponse={myResponse}
+        visibility="score-and-responses"
+      />
+    );
+    expect(screen.getByText('50%')).toBeInTheDocument();
+    // Student answer is visible.
+    expect(screen.getByText('Mitochondria')).toBeInTheDocument();
+    // Canonical correct answer must NOT leak — even though it lives in
+    // the fixture, the visibility level forbids rendering it.
+    expect(screen.queryByText('Chlorophyll')).not.toBeInTheDocument();
+    expect(screen.queryByText(/Correct answer/)).not.toBeInTheDocument();
+  });
+
+  it("'score-responses-and-answers' surfaces the canonical correct answer", () => {
+    const { session, myResponse } = fixture({
+      visibility: 'score-responses-and-answers',
+      revealedAnswers: { 'step-mc': 'Chlorophyll' },
+    });
+    render(
+      <PublishedGLReview
+        session={session}
+        myResponse={myResponse}
+        visibility="score-responses-and-answers"
+      />
+    );
+    expect(screen.getByText('50%')).toBeInTheDocument();
+    expect(screen.getByText('Mitochondria')).toBeInTheDocument();
+    expect(screen.getByText('Chlorophyll')).toBeInTheDocument();
+    expect(screen.getByText(/Correct answer/)).toBeInTheDocument();
+  });
+
+  it('does not show the canonical answer for steps the student got right (no need)', () => {
+    const { session, myResponse } = fixture({
+      visibility: 'score-responses-and-answers',
+      studentAnswer: 'Chlorophyll',
+      isCorrect: true,
+      revealedAnswers: { 'step-mc': 'Chlorophyll' },
+    });
+    render(
+      <PublishedGLReview
+        session={session}
+        myResponse={myResponse}
+        visibility="score-responses-and-answers"
+      />
+    );
+    // The student's correct answer shows; the "Correct answer:" reveal
+    // label is reserved for the incorrect case.
+    expect(screen.getByText('Chlorophyll')).toBeInTheDocument();
+    expect(screen.queryByText(/Correct answer/)).not.toBeInTheDocument();
+  });
+});
+
+describe('formatStudentAnswer', () => {
+  it('renders string answers verbatim', () => {
+    expect(formatStudentAnswer('My answer')).toBe('My answer');
+  });
+
+  it('returns empty string for undefined / empty', () => {
+    expect(formatStudentAnswer(undefined)).toBe('');
+    expect(formatStudentAnswer([])).toBe('');
+  });
+
+  it('splits matching pairs on the FIRST colon (not every colon)', () => {
+    // Regression: previously `.replace(':')` swapped only the first ":"
+    // but for "Ratio: 3:4" the first colon belongs to "Ratio:" — split
+    // on indexOf so multi-colon labels stay legible.
+    expect(formatStudentAnswer(['Ratio: 3:4'])).toBe('Ratio →  3:4');
+    expect(formatStudentAnswer(['left:right'])).toBe('left → right');
+  });
+
+  it('joins multi-entry answers (sorting, matching) with newlines', () => {
+    expect(formatStudentAnswer(['a:1', 'b:2'])).toBe('a → 1\nb → 2');
+    // Sorting items don't contain colons and are joined verbatim.
+    expect(formatStudentAnswer(['first', 'second', 'third'])).toBe(
+      'first\nsecond\nthird'
+    );
+  });
+});

--- a/tests/hooks/useGuidedLearningAssignments.test.ts
+++ b/tests/hooks/useGuidedLearningAssignments.test.ts
@@ -1,0 +1,525 @@
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+import {
+  collection,
+  doc,
+  getDocs,
+  onSnapshot,
+  writeBatch,
+} from 'firebase/firestore';
+import {
+  useGuidedLearningAssignments,
+  formatCanonicalAnswer,
+} from '@/hooks/useGuidedLearningAssignments';
+import type {
+  GuidedLearningSet,
+  GuidedLearningStep,
+  GuidedLearningQuestion,
+} from '@/types';
+
+// Mirror the Quiz test's sentinel pattern so we can assert deleteField()
+// landed in the right column without a real Firestore SDK in scope.
+const DELETE_FIELD_SENTINEL = Symbol('test:deleteField()');
+
+vi.mock('firebase/firestore', () => ({
+  collection: vi.fn(),
+  deleteField: vi.fn(() => DELETE_FIELD_SENTINEL),
+  doc: vi.fn(),
+  getDocs: vi.fn(),
+  onSnapshot: vi.fn(),
+  query: vi.fn(),
+  orderBy: vi.fn(),
+  setDoc: vi.fn(),
+  updateDoc: vi.fn(),
+  writeBatch: vi.fn(),
+}));
+
+vi.mock('@/config/firebase', () => ({
+  db: {},
+}));
+
+vi.mock('./useSessionViewCount', () => ({
+  invalidateSessionViewCount: vi.fn(),
+}));
+
+// `isAnswerCorrect` is re-exported by the assignments module from
+// useGuidedLearningSession; the test imports the real implementation
+// (the question-type branches are pure functions of the answer key).
+vi.mock('./useGuidedLearningSession', async () => {
+  const actual = await vi.importActual<
+    typeof import('@/hooks/useGuidedLearningSession')
+  >('@/hooks/useGuidedLearningSession');
+  return { isAnswerCorrect: actual.isAnswerCorrect };
+});
+
+const TEACHER_UID = 'teacher-1';
+const ASSIGNMENT_ID = 'assignment-xyz';
+
+const mockDoc = doc as Mock;
+const mockCollection = collection as Mock;
+const mockOnSnapshot = onSnapshot as Mock;
+const mockWriteBatch = writeBatch as Mock;
+const mockGetDocs = getDocs as Mock;
+
+// Tiny test-data factory: a 2-step MC set so the publish math is easy
+// to assert (two questions, both 1 point, total = 2 → percentage easy).
+function mcStep(
+  id: string,
+  correct: string,
+  choices: string[]
+): GuidedLearningStep {
+  return {
+    id,
+    xPct: 0,
+    yPct: 0,
+    imageIndex: 0,
+    interactionType: 'question',
+    question: {
+      type: 'multiple-choice',
+      text: `Question ${id}`,
+      choices,
+      correctAnswer: correct,
+    },
+  };
+}
+
+function mcSet(steps: GuidedLearningStep[]): GuidedLearningSet {
+  return {
+    id: 'set-1',
+    title: 'Test Set',
+    imageUrls: [],
+    steps,
+    mode: 'guided',
+    createdAt: 0,
+    updatedAt: 0,
+  };
+}
+
+describe('useGuidedLearningAssignments — publish / unpublish', () => {
+  const batchUpdate = vi.fn();
+  const batchCommit = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDoc.mockImplementation((_db: unknown, ...segs: string[]) =>
+      segs.join('/')
+    );
+    mockCollection.mockImplementation((_db: unknown, ...segs: string[]) =>
+      segs.join('/')
+    );
+    // The assignments-list listener fires once during render with an
+    // empty snapshot so the hook reaches "loaded" state without us
+    // having to set up dashboard data.
+    mockOnSnapshot.mockImplementation(
+      (_q: unknown, onNext: (snap: { docs: [] }) => void) => {
+        onNext({ docs: [] });
+        return () => undefined;
+      }
+    );
+    batchUpdate.mockReset();
+    batchCommit.mockReset().mockResolvedValue(undefined);
+    mockWriteBatch.mockReturnValue({
+      update: batchUpdate,
+      commit: batchCommit,
+    });
+  });
+
+  it('unpublishAssignmentScores clears flags via deleteField on both docs', async () => {
+    const { result } = renderHook(() =>
+      useGuidedLearningAssignments(TEACHER_UID)
+    );
+    await act(async () => {
+      await result.current.unpublishAssignmentScores(ASSIGNMENT_ID);
+    });
+
+    // Single batch (assignment + session) — no response reads on unpublish.
+    expect(mockGetDocs).not.toHaveBeenCalled();
+    expect(batchCommit).toHaveBeenCalledTimes(1);
+
+    const assignmentCall = batchUpdate.mock.calls.find(
+      ([ref]) =>
+        typeof ref === 'string' &&
+        ref.startsWith(`users/${TEACHER_UID}/guided_learning_assignments/`)
+    );
+    if (!assignmentCall)
+      throw new Error('expected batch.update on assignment doc');
+    expect(assignmentCall[1]).toMatchObject({
+      scoreVisibility: DELETE_FIELD_SENTINEL,
+      scorePublishedAt: DELETE_FIELD_SENTINEL,
+    });
+
+    const sessionCall = batchUpdate.mock.calls.find(
+      ([ref]) =>
+        typeof ref === 'string' && ref.startsWith('guided_learning_sessions/')
+    );
+    if (!sessionCall) throw new Error('expected batch.update on session doc');
+    expect(sessionCall[1]).toMatchObject({
+      scoreVisibility: DELETE_FIELD_SENTINEL,
+      revealedAnswers: DELETE_FIELD_SENTINEL,
+    });
+  });
+
+  it('unpublishAssignmentScores is idempotent', async () => {
+    const { result } = renderHook(() =>
+      useGuidedLearningAssignments(TEACHER_UID)
+    );
+    await act(async () => {
+      await result.current.unpublishAssignmentScores(ASSIGNMENT_ID);
+      await result.current.unpublishAssignmentScores(ASSIGNMENT_ID);
+    });
+    expect(mockGetDocs).not.toHaveBeenCalled();
+    expect(batchCommit).toHaveBeenCalledTimes(2);
+  });
+
+  it("publishAssignmentScores rejects visibility 'none' at runtime", async () => {
+    const { result } = renderHook(() =>
+      useGuidedLearningAssignments(TEACHER_UID)
+    );
+    await act(async () => {
+      await expect(
+        (
+          result.current.publishAssignmentScores as unknown as (
+            id: string,
+            data: unknown,
+            v: string
+          ) => Promise<unknown>
+        )(ASSIGNMENT_ID, mcSet([]), 'none')
+      ).rejects.toThrow(/unpublishAssignmentScores/);
+    });
+    expect(batchCommit).not.toHaveBeenCalled();
+  });
+
+  it('grades responses and writes per-step isCorrect on score-only publish', async () => {
+    const set = mcSet([
+      mcStep('s0', 'a', ['a', 'b']),
+      mcStep('s1', 'b', ['a', 'b']),
+    ]);
+    const refPerfect = { id: 'r-perfect' };
+    const refPartial = { id: 'r-partial' };
+    const refBlank = { id: 'r-blank' };
+    mockGetDocs.mockResolvedValueOnce({
+      docs: [
+        {
+          ref: refPerfect,
+          data: () => ({
+            studentAnonymousId: 'u1',
+            startedAt: 1,
+            completedAt: 2,
+            score: null,
+            answers: [
+              { stepId: 's0', answer: 'a', isCorrect: null },
+              { stepId: 's1', answer: 'b', isCorrect: null },
+            ],
+          }),
+        },
+        {
+          ref: refPartial,
+          data: () => ({
+            studentAnonymousId: 'u2',
+            startedAt: 1,
+            completedAt: 2,
+            score: null,
+            answers: [
+              { stepId: 's0', answer: 'a', isCorrect: null },
+              { stepId: 's1', answer: 'wrong', isCorrect: null },
+            ],
+          }),
+        },
+        // Student who joined but never answered — both gradable steps
+        // count toward the denominator so the score is 0%.
+        {
+          ref: refBlank,
+          data: () => ({
+            studentAnonymousId: 'u3',
+            startedAt: 1,
+            completedAt: 2,
+            score: null,
+            answers: [],
+          }),
+        },
+      ],
+    });
+
+    const { result } = renderHook(() =>
+      useGuidedLearningAssignments(TEACHER_UID)
+    );
+    await act(async () => {
+      const outcome = await result.current.publishAssignmentScores(
+        ASSIGNMENT_ID,
+        set,
+        'score-only'
+      );
+      expect(outcome).toEqual({ responsesUpdated: 3 });
+    });
+
+    expect(batchCommit).toHaveBeenCalledTimes(1);
+
+    // Session patch should NOT carry revealedAnswers on 'score-only'.
+    const sessionCall = batchUpdate.mock.calls.find(
+      ([ref]) =>
+        typeof ref === 'string' && ref.startsWith('guided_learning_sessions/')
+    );
+    if (!sessionCall) throw new Error('expected session update');
+    expect(sessionCall[1]).toMatchObject({
+      scoreVisibility: 'score-only',
+      revealedAnswers: DELETE_FIELD_SENTINEL,
+    });
+
+    const perfectCall = batchUpdate.mock.calls.find(
+      ([ref]) => ref === refPerfect
+    );
+    const partialCall = batchUpdate.mock.calls.find(
+      ([ref]) => ref === refPartial
+    );
+    const blankCall = batchUpdate.mock.calls.find(([ref]) => ref === refBlank);
+    if (!perfectCall || !partialCall || !blankCall) {
+      throw new Error('expected updates on all three response refs');
+    }
+    expect(perfectCall[1]).toMatchObject({ score: 100 });
+    expect(
+      (perfectCall[1] as { answers: { isCorrect: boolean }[] }).answers
+    ).toEqual([
+      expect.objectContaining({ stepId: 's0', isCorrect: true }),
+      expect.objectContaining({ stepId: 's1', isCorrect: true }),
+    ]);
+    expect(partialCall[1]).toMatchObject({ score: 50 });
+    expect(
+      (partialCall[1] as { answers: { isCorrect: boolean }[] }).answers
+    ).toEqual([
+      expect.objectContaining({ stepId: 's0', isCorrect: true }),
+      expect.objectContaining({ stepId: 's1', isCorrect: false }),
+    ]);
+    expect(blankCall[1]).toMatchObject({ score: 0, answers: [] });
+  });
+
+  it('populates revealedAnswers on score-responses-and-answers, formatting matching/sorting too', async () => {
+    const matching: GuidedLearningQuestion = {
+      type: 'matching',
+      text: 'Match',
+      matchingPairs: [
+        { left: 'A', right: '1' },
+        { left: 'B', right: '2' },
+      ],
+    };
+    const sorting: GuidedLearningQuestion = {
+      type: 'sorting',
+      text: 'Sort',
+      sortingItems: ['x', 'y', 'z'],
+    };
+    const set = mcSet([
+      mcStep('s0', 'a', ['a', 'b']),
+      {
+        id: 's1',
+        xPct: 0,
+        yPct: 0,
+        imageIndex: 0,
+        interactionType: 'question',
+        question: matching,
+      },
+      {
+        id: 's2',
+        xPct: 0,
+        yPct: 0,
+        imageIndex: 0,
+        interactionType: 'question',
+        question: sorting,
+      },
+      // Info hotspot (no question) — must NOT appear in revealedAnswers.
+      {
+        id: 's3-info',
+        xPct: 0,
+        yPct: 0,
+        imageIndex: 0,
+        interactionType: 'text-popover',
+      },
+    ]);
+    mockGetDocs.mockResolvedValueOnce({ docs: [] });
+
+    const { result } = renderHook(() =>
+      useGuidedLearningAssignments(TEACHER_UID)
+    );
+    await act(async () => {
+      await result.current.publishAssignmentScores(
+        ASSIGNMENT_ID,
+        set,
+        'score-responses-and-answers'
+      );
+    });
+
+    const sessionCall = batchUpdate.mock.calls.find(
+      ([ref]) =>
+        typeof ref === 'string' && ref.startsWith('guided_learning_sessions/')
+    );
+    if (!sessionCall) throw new Error('expected session update');
+    expect(sessionCall[1]).toMatchObject({
+      scoreVisibility: 'score-responses-and-answers',
+      revealedAnswers: {
+        s0: 'a',
+        s1: 'A → 1\nB → 2',
+        s2: 'x → y → z',
+      },
+    });
+    // Info hotspot is omitted.
+    expect(
+      (sessionCall[1] as { revealedAnswers: Record<string, string> })
+        .revealedAnswers['s3-info']
+    ).toBeUndefined();
+  });
+
+  it('clears stale isCorrect when a step no longer exists', async () => {
+    const set = mcSet([mcStep('s-keep', 'a', ['a', 'b'])]);
+    const refStale = { id: 'r-stale' };
+    mockGetDocs.mockResolvedValueOnce({
+      docs: [
+        {
+          ref: refStale,
+          data: () => ({
+            studentAnonymousId: 'u',
+            startedAt: 1,
+            completedAt: 2,
+            score: 100,
+            answers: [
+              { stepId: 's-keep', answer: 'a', isCorrect: true },
+              // Step that was removed from the canonical set after submission.
+              { stepId: 's-deleted', answer: 'whatever', isCorrect: true },
+            ],
+          }),
+        },
+      ],
+    });
+
+    const { result } = renderHook(() =>
+      useGuidedLearningAssignments(TEACHER_UID)
+    );
+    await act(async () => {
+      await result.current.publishAssignmentScores(
+        ASSIGNMENT_ID,
+        set,
+        'score-and-responses'
+      );
+    });
+
+    const staleCall = batchUpdate.mock.calls.find(([ref]) => ref === refStale);
+    if (!staleCall) throw new Error('expected update on stale response');
+    expect(
+      (staleCall[1] as { answers: { stepId: string; isCorrect: unknown }[] })
+        .answers
+    ).toEqual([
+      expect.objectContaining({ stepId: 's-keep', isCorrect: true }),
+      // Stale step's correctness must be cleared (null) so the response
+      // doesn't carry a claim the canonical set no longer supports.
+      expect.objectContaining({ stepId: 's-deleted', isCorrect: null }),
+    ]);
+  });
+
+  it('surfaces a structured "partial publish" error if a chunk batch fails', async () => {
+    // 500 responses → first batch holds 398, second chunk holds 102.
+    // Force the second commit to reject and assert the error message
+    // calls out how many were graded so the teacher knows to re-run.
+    const set = mcSet([mcStep('s0', 'a', ['a', 'b'])]);
+    const responseDocs = Array.from({ length: 500 }, (_, i) => ({
+      ref: { id: `r${i}` },
+      data: () => ({
+        studentAnonymousId: `u${i}`,
+        startedAt: 1,
+        completedAt: 2,
+        score: null,
+        answers: [{ stepId: 's0', answer: 'a', isCorrect: null }],
+      }),
+    }));
+    mockGetDocs.mockResolvedValueOnce({ docs: responseDocs });
+    batchCommit.mockReset();
+    batchCommit
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new Error('quota exceeded'));
+
+    const { result } = renderHook(() =>
+      useGuidedLearningAssignments(TEACHER_UID)
+    );
+    await act(async () => {
+      await expect(
+        result.current.publishAssignmentScores(ASSIGNMENT_ID, set, 'score-only')
+      ).rejects.toThrow(/Partial publish: \d+ of 500/);
+    });
+  });
+});
+
+describe('formatCanonicalAnswer', () => {
+  it('returns the correctAnswer for multiple-choice', () => {
+    expect(
+      formatCanonicalAnswer(mcStep('s', 'banana', ['apple', 'banana']))
+    ).toBe('banana');
+  });
+
+  it('joins matching pairs with " → " and newline separators', () => {
+    expect(
+      formatCanonicalAnswer({
+        id: 's',
+        xPct: 0,
+        yPct: 0,
+        imageIndex: 0,
+        interactionType: 'question',
+        question: {
+          type: 'matching',
+          text: 'Match',
+          matchingPairs: [
+            { left: 'cat', right: 'meow' },
+            { left: 'dog', right: 'bark' },
+          ],
+        },
+      })
+    ).toBe('cat → meow\ndog → bark');
+  });
+
+  it('joins sorting items with " → "', () => {
+    expect(
+      formatCanonicalAnswer({
+        id: 's',
+        xPct: 0,
+        yPct: 0,
+        imageIndex: 0,
+        interactionType: 'question',
+        question: {
+          type: 'sorting',
+          text: 'Sort',
+          sortingItems: ['first', 'second', 'third'],
+        },
+      })
+    ).toBe('first → second → third');
+  });
+
+  it('returns null for steps without a question (info hotspots)', () => {
+    expect(
+      formatCanonicalAnswer({
+        id: 's',
+        xPct: 0,
+        yPct: 0,
+        imageIndex: 0,
+        interactionType: 'question',
+      })
+    ).toBeNull();
+  });
+
+  it('returns null for matching with no pairs and sorting with no items', () => {
+    expect(
+      formatCanonicalAnswer({
+        id: 's',
+        xPct: 0,
+        yPct: 0,
+        imageIndex: 0,
+        interactionType: 'question',
+        question: { type: 'matching', text: '', matchingPairs: [] },
+      })
+    ).toBeNull();
+    expect(
+      formatCanonicalAnswer({
+        id: 's',
+        xPct: 0,
+        yPct: 0,
+        imageIndex: 0,
+        interactionType: 'question',
+        question: { type: 'sorting', text: '', sortingItems: [] },
+      })
+    ).toBeNull();
+  });
+});

--- a/tests/hooks/useQuizAssignments.test.ts
+++ b/tests/hooks/useQuizAssignments.test.ts
@@ -1133,18 +1133,14 @@ describe('useQuizAssignments - publishAssignmentScores', () => {
     });
   });
 
-  it("clears flags and skips response writes when visibility is 'none'", async () => {
+  it('unpublishAssignmentScores clears flags via deleteField on both docs', async () => {
     const { result } = renderHook(() => useQuizAssignments(TEACHER_UID));
     await act(async () => {
-      const outcome = await result.current.publishAssignmentScores(
-        ASSIGNMENT_ID,
-        quizData,
-        'none'
-      );
-      expect(outcome).toEqual({ responsesUpdated: 0 });
+      await result.current.unpublishAssignmentScores(ASSIGNMENT_ID);
     });
 
-    // Exactly one batch (assignment + session) — no response queries.
+    // Exactly one batch (assignment + session) — no response queries
+    // (the unpublish path leaves per-response scores intact).
     expect(mockGetDocs).not.toHaveBeenCalled();
     expect(batchCommit).toHaveBeenCalledTimes(1);
 
@@ -1157,7 +1153,7 @@ describe('useQuizAssignments - publishAssignmentScores', () => {
       throw new Error('expected batch.update on assignment doc');
     }
     expect(assignmentCall[1]).toMatchObject({
-      scoreVisibility: 'none',
+      scoreVisibility: DELETE_FIELD_SENTINEL,
       scorePublishedAt: DELETE_FIELD_SENTINEL,
     });
 
@@ -1168,9 +1164,37 @@ describe('useQuizAssignments - publishAssignmentScores', () => {
       throw new Error('expected batch.update on session doc');
     }
     expect(sessionCall[1]).toMatchObject({
-      scoreVisibility: 'none',
+      scoreVisibility: DELETE_FIELD_SENTINEL,
       revealedAnswers: DELETE_FIELD_SENTINEL,
     });
+  });
+
+  it('unpublishAssignmentScores is idempotent — second call still writes the same patch', async () => {
+    const { result } = renderHook(() => useQuizAssignments(TEACHER_UID));
+    await act(async () => {
+      await result.current.unpublishAssignmentScores(ASSIGNMENT_ID);
+      await result.current.unpublishAssignmentScores(ASSIGNMENT_ID);
+    });
+    // Two commits, no response reads in either pass.
+    expect(mockGetDocs).not.toHaveBeenCalled();
+    expect(batchCommit).toHaveBeenCalledTimes(2);
+  });
+
+  it("publishAssignmentScores rejects visibility 'none' at runtime", async () => {
+    const { result } = renderHook(() => useQuizAssignments(TEACHER_UID));
+    await act(async () => {
+      await expect(
+        // Bypass the `Exclude<…, 'none'>` type guard at runtime.
+        (
+          result.current.publishAssignmentScores as unknown as (
+            id: string,
+            data: unknown,
+            v: string
+          ) => Promise<unknown>
+        )(ASSIGNMENT_ID, quizData, 'none')
+      ).rejects.toThrow(/unpublishAssignmentScores/);
+    });
+    expect(batchCommit).not.toHaveBeenCalled();
   });
 
   it('grades responses and writes per-answer isCorrect on score-only publish', async () => {

--- a/tests/hooks/useStudentAssignments.parsePublicationFields.test.ts
+++ b/tests/hooks/useStudentAssignments.parsePublicationFields.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Unit coverage for the shared `parsePublicationFields` helper that drives
+ * both Quiz and Guided Learning `gradingStateFrom` rules. The rule decides
+ * whether the student's `/my-assignments` row renders "View results" (graded)
+ * or "Not graded" — getting it wrong means students either silently miss a
+ * published score or click into an empty review.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { parsePublicationFields } from '@/hooks/useStudentAssignments';
+
+describe('parsePublicationFields', () => {
+  let warnSpy: ReturnType<typeof vi.spyOn<typeof console, 'warn'>>;
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  it("returns 'graded' when scoreVisibility is non-'none' AND scorePublishedAt is a number", () => {
+    expect(
+      parsePublicationFields('quiz', {
+        scoreVisibility: 'score-only',
+        scorePublishedAt: 1234567890,
+      })
+    ).toBe('graded');
+    expect(
+      parsePublicationFields('guided-learning', {
+        scoreVisibility: 'score-responses-and-answers',
+        scorePublishedAt: 1,
+      })
+    ).toBe('graded');
+  });
+
+  it("returns 'not-graded' when scoreVisibility is 'none' regardless of timestamp", () => {
+    // The unpublish branch leaves the doc with `scoreVisibility: deleteField()`
+    // on Firestore (so the field is absent on disk) — but a stale snapshot
+    // or a mid-migration doc could still carry the literal 'none'. Both
+    // paths must downgrade to 'not-graded'.
+    expect(
+      parsePublicationFields('quiz', {
+        scoreVisibility: 'none',
+        scorePublishedAt: 1234,
+      })
+    ).toBe('not-graded');
+  });
+
+  it("returns 'not-graded' when scorePublishedAt is missing even if visibility is set", () => {
+    expect(
+      parsePublicationFields('quiz', {
+        scoreVisibility: 'score-only',
+      })
+    ).toBe('not-graded');
+  });
+
+  it("returns 'not-graded' and console.warns when fields have the wrong type", () => {
+    expect(
+      parsePublicationFields('quiz', {
+        scoreVisibility: 42, // wrong type
+        scorePublishedAt: 'not-a-number', // wrong type
+      })
+    ).toBe('not-graded');
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0][0]).toMatch(/malformed quiz/);
+  });
+
+  it("returns 'not-graded' for null / non-object data without crashing the row", () => {
+    // Firestore can briefly hand back partial snapshots during deletion
+    // races. A runtime TypeError here would crash the whole assignments
+    // list, not just drop one row — this guard is load-bearing.
+    expect(
+      parsePublicationFields(
+        'quiz',
+        null as unknown as Parameters<typeof parsePublicationFields>[1]
+      )
+    ).toBe('not-graded');
+    expect(
+      parsePublicationFields(
+        'quiz',
+        undefined as unknown as Parameters<typeof parsePublicationFields>[1]
+      )
+    ).toBe('not-graded');
+  });
+
+  it('only warns once per (kind, visibility-type, publishedAt-type) signature', () => {
+    // Three repeats of the same malformed shape => exactly one warn.
+    const bad = {
+      scoreVisibility: 99,
+      scorePublishedAt: 'string',
+    };
+    parsePublicationFields('guided-learning', bad);
+    parsePublicationFields('guided-learning', bad);
+    parsePublicationFields('guided-learning', bad);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/hooks/useStudentAssignments.parsePublicationFields.test.ts
+++ b/tests/hooks/useStudentAssignments.parsePublicationFields.test.ts
@@ -10,15 +10,21 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { parsePublicationFields } from '@/hooks/useStudentAssignments';
 
 describe('parsePublicationFields', () => {
-  let warnSpy: ReturnType<typeof vi.spyOn<typeof console, 'warn'>>;
-
+  // `vi.spyOn` with an explicit `typeof console` generic tripped vitest 4's
+  // `Methods<Required<T>>` constraint under the CI tsc ("warn" does not
+  // satisfy the constraint '"Console"'). `vi.mocked(console.warn)` after
+  // setup is the type-safe way to grab the spy in each test without
+  // storing it in a typed `let` — matches the rest of the codebase's
+  // spy patterns.
   beforeEach(() => {
-    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined);
   });
 
   afterEach(() => {
-    warnSpy.mockRestore();
+    vi.restoreAllMocks();
   });
+
+  const warnSpy = () => vi.mocked(console.warn);
 
   it("returns 'graded' when scoreVisibility is non-'none' AND scorePublishedAt is a number", () => {
     expect(
@@ -63,8 +69,8 @@ describe('parsePublicationFields', () => {
         scorePublishedAt: 'not-a-number', // wrong type
       })
     ).toBe('not-graded');
-    expect(warnSpy).toHaveBeenCalledTimes(1);
-    expect(warnSpy.mock.calls[0][0]).toMatch(/malformed quiz/);
+    expect(warnSpy()).toHaveBeenCalledTimes(1);
+    expect(warnSpy().mock.calls[0][0]).toMatch(/malformed quiz/);
   });
 
   it("returns 'not-graded' for null / non-object data without crashing the row", () => {
@@ -94,6 +100,6 @@ describe('parsePublicationFields', () => {
     parsePublicationFields('guided-learning', bad);
     parsePublicationFields('guided-learning', bad);
     parsePublicationFields('guided-learning', bad);
-    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy()).toHaveBeenCalledTimes(1);
   });
 });

--- a/types.ts
+++ b/types.ts
@@ -4199,6 +4199,18 @@ export type GuidedLearningQuestionType =
   | 'matching'
   | 'sorting';
 
+/**
+ * Score-visibility levels for a Guided Learning assignment. Structurally
+ * identical to {@link QuizScoreVisibility} and
+ * {@link VideoActivityScoreVisibility} so the shared `PublishScoresModal`
+ * picker works across all three widgets.
+ */
+export type GuidedLearningScoreVisibility =
+  | 'none'
+  | 'score-only'
+  | 'score-and-responses'
+  | 'score-responses-and-answers';
+
 export interface GuidedLearningQuestion {
   type: GuidedLearningQuestionType;
   text: string;
@@ -4426,6 +4438,21 @@ export interface GuidedLearningSession {
   welcomeEnabled?: boolean;
   /** Mirrors `GuidedLearningSet.welcomeMessage`. */
   welcomeMessage?: string;
+  /**
+   * Mirror of {@link GuidedLearningAssignment.scoreVisibility} for the
+   * student-facing `/my-assignments` Completed review screen. Absent /
+   * `'none'` ⇒ the student app shows the "Ask your teacher" placeholder
+   * instead of the score/Trophy screen. Realtime via `onSnapshot`, so
+   * teacher unpublish propagates instantly.
+   */
+  scoreVisibility?: GuidedLearningScoreVisibility;
+  /**
+   * Canonical correct answer per step, keyed by `stepId`. Populated only
+   * when `scoreVisibility === 'score-responses-and-answers'`; cleared
+   * (via `deleteField`) on unpublish so unpublished sessions never leak
+   * answer keys to the client.
+   */
+  revealedAnswers?: Record<string, string>;
 }
 
 /** Per-student response in /guided_learning_sessions/{id}/responses/{studentUid} */
@@ -5917,6 +5944,17 @@ export interface GuidedLearningAssignment {
    *  Stored under `assignmentMode` (not `mode`) to avoid colliding with the
    *  GL session's existing play-mode field. Absent on pre-feature assignments. */
   assignmentMode?: AssignmentMode;
+  /**
+   * Teacher-controlled gate on what students see on the `/my-assignments`
+   * Completed review screen. Absent / `'none'` ⇒ unpublished (Quiz/VA
+   * parity). Set by `publishAssignmentScores`. Mirrored onto
+   * {@link GuidedLearningSession.scoreVisibility} so the realtime student
+   * listener can react without subscribing to teacher-owned docs.
+   */
+  scoreVisibility?: GuidedLearningScoreVisibility;
+  /** Epoch ms of the most recent `publishAssignmentScores` call. Cleared
+   *  (via `deleteField`) on unpublish. */
+  scorePublishedAt?: number;
 }
 
 // === Library folders (Wave 3) ===


### PR DESCRIPTION
## Summary

- Quiz/VA archive cards expose a dedicated **Unpublish scores** kebab item — bypasses the picker modal, flips `scoreVisibility` to `'none'` in one click. Quiz uses the existing `showConfirm` dialog; VA uses its local two-click "Confirm unpublish" pattern that matches Delete.
- **GuidedLearning** gets the full publish/unpublish flow modeled on Quiz/VA — new `scoreVisibility` / `scorePublishedAt` / `revealedAnswers` fields, batched per-response grading via the existing `isAnswerCorrect` helper, manager kebab items, modal wiring, and a student-side `PublishedGLReview` with progressive disclosure across the three visibility levels.
- GL student app upgraded to `onSnapshot` on session + response so teacher unpublish propagates in realtime; returning students no longer get dropped onto the start screen.
- `useStudentAssignments.gradingStateFrom` for GL mirrors the Quiz rule so `/my-assignments` rows flip between "Not graded" and "View results" as the teacher publishes/unpublishes.

## Out of scope

- **MiniApp**: submissions are opaque iframe payloads with no score concept and no student-side review surface to gate, so there is nothing to publish or unpublish. Confirmed with @OPS-PIvers before scoping the plan.
- **Screenshot prevention**: not solvable in a web browser (no API blocks OS Print Screen, second monitors, OBS, phone cameras). Deferred per discussion.

## Test plan

Validation gates all pass locally:

- [x] `pnpm run type-check` — clean
- [x] `pnpm run lint` — clean (`--max-warnings 0`)
- [x] `pnpm run format:check` — clean
- [x] `pnpm run test` — 247 files, 2550 tests pass

Manual click-through (needs real Firestore data with archived assignments + student responses, so it's deferred to reviewer):

- [ ] **Quiz unpublish via kebab**: archive a quiz with responses → publish at `score-and-responses` → kebab → "Unpublish scores" → confirm dialog. Student `/my-assignments` row flips from "View results" to "Not graded" within ~1s (Firestore listener).
- [ ] **VA unpublish via kebab**: same flow as Quiz, with the two-click "Confirm unpublish" pattern.
- [ ] **GL publish (new flow)**: archive a GL set with responses → kebab → "Publish scores" → choose `score-responses-and-answers`. Returning student lands on `PublishedGLReview` with score + per-step responses + canonical answers.
- [ ] **GL unpublish**: kebab → "Unpublish scores" → two-click confirm. Student flips back to "Submitted! Ask your teacher to see your results."
- [ ] **GL re-publish at a different level**: e.g. `score-only` → student review shows only the percentage, no per-step detail.
- [ ] **Backwards compat**: open a GL assignment created before this change. Kebab should show "Publish scores" (not "Update"). Student completion screen should show the neutral "submitted" placeholder, not the unconditional Trophy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)