### PR TITLE
fix(text-widget): keep editor structure uniform during live editing

### DIFF
--- a/components/widgets/TextWidget/Widget.test.tsx
+++ b/components/widgets/TextWidget/Widget.test.tsx
@@ -113,6 +113,42 @@ describe('TextWidget', () => {
     expect(screen.queryByTitle('Bold')).not.toBeInTheDocument();
   });
 
+  it('does not bubble pointerdown from the formatting toolbar to ancestor handlers', async () => {
+    // The toolbar renders to document.body via createPortal, but React
+    // synthetic events still bubble through the COMPONENT tree — meaning a
+    // pointerdown on a toolbar button reaches DraggableWindow's
+    // `handlePointerDown` ancestor in production. That handler calls
+    // `.focus()` on the widget chrome whenever the target isn't inside a
+    // contentEditable, which fires the editor's `onBlur` and drops the
+    // live selection. execCommand calls (lists, foreColor, …) then run
+    // against a stale collapsed selection and silently no-op.
+    //
+    // The fix attaches `onPointerDown={(e) => e.stopPropagation()}` on the
+    // toolbar's portal wrapper. This test guards that regression by
+    // mounting an ancestor pointerdown handler around TextWidget and
+    // verifying it does NOT fire when a toolbar button is pressed.
+    (useDashboard as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+      ...mockDashboardContext,
+      selectedWidgetId: 'test-widget',
+    });
+
+    const ancestorPointerDown = vi.fn();
+    render(
+      <div onPointerDown={ancestorPointerDown}>
+        <TextWidget widget={mockWidget} />
+      </div>
+    );
+
+    // Toolbar renders via portal + RAF position tracking — wait for it.
+    await waitFor(() => {
+      expect(screen.getByTitle('Bold')).toBeInTheDocument();
+    });
+
+    fireEvent.pointerDown(screen.getByTitle('Bold'));
+
+    expect(ancestorPointerDown).not.toHaveBeenCalled();
+  });
+
   it('triggers hyperlink prompt on Control+K', async () => {
     mockShowPrompt.mockResolvedValue('https://test.com');
     render(<TextWidget widget={mockWidget} />);
@@ -343,8 +379,8 @@ describe('TextWidget', () => {
     const lastCall = mockUpdateWidget.mock.lastCall;
     expect(lastCall).toBeDefined();
     if (lastCall) {
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-      const savedContent = lastCall[1].config.content as string;
+      const payload = lastCall[1] as { config: TextConfig };
+      const savedContent = payload.config.content ?? '';
       expect(savedContent).not.toMatch(/^First</); // bare-text prefix is gone
       expect(savedContent).toContain('<div>First</div>');
       expect(savedContent).toContain('<div>Second</div>');

--- a/components/widgets/TextWidget/Widget.test.tsx
+++ b/components/widgets/TextWidget/Widget.test.tsx
@@ -308,6 +308,65 @@ describe('TextWidget', () => {
     });
   });
 
+  it('normalizes mixed bare-text-then-<div> structure during live editing', () => {
+    // Reproduces the exact shape Chrome produces while typing: the user
+    // types "First", hits Enter (Chrome creates `<div><br></div>` for the
+    // new line), then types "Second" — leaving the first line as a bare
+    // text node. Without input-time normalization the editor is stuck in
+    // a mixed structure that breaks drag-selection across the boundary
+    // and confuses list commands. handleInput should rewrite the structure
+    // to uniform block children on the same event.
+    const { container } = render(<TextWidget widget={mockWidget} />);
+    const editableDiv = container.querySelector(
+      'div[contentEditable="true"]'
+    ) as HTMLElement;
+    expect(editableDiv).not.toBeNull();
+
+    editableDiv.innerHTML = 'First<div>Second</div>';
+    fireEvent.input(editableDiv);
+
+    // After normalization every top-level child is a block element.
+    const childTags = Array.from(editableDiv.childNodes).map((n) =>
+      n.nodeType === Node.ELEMENT_NODE
+        ? (n as HTMLElement).tagName
+        : n.nodeType === Node.TEXT_NODE
+          ? '#text'
+          : '#other'
+    );
+    expect(childTags.every((t) => t !== '#text' && t !== 'BR')).toBe(true);
+    expect(editableDiv.children.length).toBe(2);
+    expect(editableDiv.textContent).toBe('FirstSecond');
+
+    // Saved content reflects the normalized structure (so the same
+    // mixed shape doesn't re-appear after a save → external sync round
+    // trip).
+    const lastCall = mockUpdateWidget.mock.lastCall;
+    expect(lastCall).toBeDefined();
+    if (lastCall) {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      const savedContent = lastCall[1].config.content as string;
+      expect(savedContent).not.toMatch(/^First</); // bare-text prefix is gone
+      expect(savedContent).toContain('<div>First</div>');
+      expect(savedContent).toContain('<div>Second</div>');
+    }
+  });
+
+  it('leaves already-uniform block structure alone on input', () => {
+    // The normalizer only rewrites mixed structures. Pure-block content is
+    // a no-op so steady-state typing inside an existing paragraph doesn't
+    // shuffle node identity (which would invalidate the caret) on every
+    // keystroke.
+    const { container } = render(<TextWidget widget={mockWidget} />);
+    const editableDiv = container.querySelector(
+      'div[contentEditable="true"]'
+    ) as HTMLElement;
+
+    editableDiv.innerHTML = '<div>One</div><div>Two</div>';
+    fireEvent.input(editableDiv);
+
+    expect(editableDiv.innerHTML).toBe('<div>One</div><div>Two</div>');
+  });
+
   it('wraps loose top-level text in a <div> on mount so drag-selection works across paragraphs', () => {
     const mixedWidget: WidgetData = {
       ...mockWidget,

--- a/components/widgets/TextWidget/Widget.tsx
+++ b/components/widgets/TextWidget/Widget.tsx
@@ -12,7 +12,10 @@ import { Z_INDEX } from '@/config/zIndex';
 import { WidgetLayout } from '@/components/widgets/WidgetLayout';
 import { FormattingToolbar } from './FormattingToolbar';
 import { PLACEHOLDER_TEXT } from './constants';
-import { normalizeEditorBlocks } from './normalizeBlocks';
+import {
+  needsBlockNormalization,
+  normalizeEditorBlocks,
+} from './normalizeBlocks';
 
 /** Gap (px) between the toolbar and the widget edge. */
 const TOOLBAR_GAP = 8;
@@ -200,6 +203,18 @@ export const TextWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
     // Skip save when the toolbar is performing a multi-step DOM mutation
     // (e.g. execCommand + span replacement for font-size changes).
     if (suppressInputRef.current) return;
+    // Re-normalize the live editor structure so drag-selection and list
+    // commands keep working as the user edits. Chrome leaves the FIRST line
+    // as a bare text node and only wraps subsequent Enter-separated lines in
+    // <div> blocks — that mixed `text<div>line</div>` shape collapses drag
+    // selections at the paragraph boundary and makes `insertUnorderedList`/
+    // `insertOrderedList` apply to only one line instead of the visible
+    // paragraph the cursor sits in. The helper is a fast no-op for already-
+    // uniform structures, and only moves nodes (never clones), so live Range
+    // references — including the caret — survive per the DOM spec.
+    if (editorRef.current && needsBlockNormalization(editorRef.current)) {
+      normalizeEditorBlocks(editorRef.current);
+    }
     // Save on every input for immediate persistence (debounced by DashboardContext)
     const content = readEditorContent();
     lastExternalContent.current = content;
@@ -275,6 +290,19 @@ export const TextWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
               <div
                 ref={toolbarPortalRef}
                 data-click-outside-ignore="true"
+                // The toolbar lives in a portal but React events still bubble
+                // through the component tree to the DraggableWindow ancestor,
+                // whose `handlePointerDown` calls `.focus()` on the widget
+                // chrome whenever the pointerdown target isn't inside a
+                // contentEditable. That focus shift pulls focus out of the
+                // editor mid-click, fires `onBlur`, and drops the live
+                // selection — execCommand calls (bold/italic, lists,
+                // foreColor) then run against a collapsed/stale selection and
+                // appear to do nothing. Stopping pointerdown propagation here
+                // keeps the editor focused while the toolbar's own
+                // `onMouseDown preventDefault` handlers (on the buttons)
+                // still prevent the click from changing focus to the button.
+                onPointerDown={(e) => e.stopPropagation()}
                 style={{
                   position: 'fixed',
                   // Position above the widget; if not enough space, show below.


### PR DESCRIPTION
## Summary

Fixes two related Text widget bugs that show up the moment a user presses Enter:

- **Drag-selecting across paragraphs collapsed at the boundary.** Highlighting from the end of line 2 back up through line 1 stopped at the start of line 2 (Ctrl+A still worked).
- **Bulleted/Numbered list buttons appeared not to work** on multi-line content — the list only ever applied to a single block, leaving the other line as bare text.

### Root cause

Chrome leaves the **first** line of a contenteditable as a bare text node and only wraps subsequent Enter-separated lines in `<div>` blocks. After typing `First`, Enter, `Second`, the editor DOM is:

```
"First"            ← bare text node
<div>Second</div>  ← block element
```

That mixed `text<div>line</div>` shape:
- collapses drag-selections at the implicit paragraph break, and
- makes `execCommand('insertUnorderedList'/'insertOrderedList')` only format the block the cursor sits in, so the bare-text first line gets left out.

`normalizeEditorBlocks` already existed and handled this exact shape, but it only ran on **mount** and on **external sync** — never during live editing — so the bug only appeared once a user pressed Enter and kept typing.

### Fix

1. **`Widget.tsx` — normalize on input.** `handleInput` now calls `normalizeEditorBlocks` whenever `needsBlockNormalization` returns true. The helper is a fast no-op for already-uniform structures, and only **moves** nodes (never clones), so live `Range` references — including the caret — survive per the DOM spec.
2. **`Widget.tsx` — stop pointerdown on the toolbar portal wrapper.** The formatting toolbar renders to `document.body`, but its React events bubble through the component tree to `DraggableWindow`'s `handlePointerDown`, which `.focus()`es the widget chrome whenever the pointerdown target isn't inside a contenteditable. That focus shift pulled focus out of the editor mid-click and dropped the live selection, so list/bold/color commands ran against a stale selection. Stopping pointerdown propagation at the portal wrapper keeps the editor focused; the buttons' own `onMouseDown preventDefault` handlers still prevent click-to-focus on the buttons.

Verified the mixed structure with Playwright in a real Chromium build, then verified the same flow with the normalize-on-input fix produces uniform `<div>First</div><div>Second</div>` after `First`/Enter/`Second`.

## Test plan

- [x] `pnpm vitest run components/widgets/TextWidget/` — 57 tests pass (added 2 new tests covering input-time normalization and the no-op pure-block case).
- [x] `pnpm vitest run` — all 2580 tests pass.
- [x] `pnpm run type-check` — clean.
- [x] `pnpm run lint` — clean (`--max-warnings 0`).
- [x] `pnpm run format:check` — clean.
- [ ] Manual verification on the dev preview URL: type a sentence, hit Enter, type another sentence, drag-select from the end of the second sentence back through the first — selection should now extend across the paragraph boundary.
- [ ] Manual verification on the dev preview URL: with multi-line content, click the Bulleted List / Numbered List toolbar buttons and confirm the formatting applies as expected.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FseuxBqaAeJzDu9aWiZzXn)_