### PR TITLE
fix(activity-wall-gallery): let viewers scroll past the viewport

### DIFF
--- a/components/activityWall/ActivityWallGalleryView.tsx
+++ b/components/activityWall/ActivityWallGalleryView.tsx
@@ -416,7 +416,11 @@ const GalleryReady: React.FC<GalleryReadyProps> = ({
   }, [comments]);
 
   return (
-    <div className="min-h-screen bg-slate-100">
+    // Outer wrapper owns the scroll: body has `overflow: hidden` globally
+    // (index.css), so a `min-h-screen` child can't trigger document scroll
+    // when submissions overflow the viewport. Give the outer an explicit
+    // viewport height + `overflow-y-auto` so the gallery list scrolls.
+    <div className="h-screen overflow-y-auto bg-slate-100">
       <header className="bg-brand-blue-primary text-white">
         <div className="max-w-5xl mx-auto px-5 py-6">
           <p className="text-xs uppercase tracking-widest font-bold opacity-90">

--- a/components/activityWall/ActivityWallGalleryView.tsx
+++ b/components/activityWall/ActivityWallGalleryView.tsx
@@ -420,7 +420,10 @@ const GalleryReady: React.FC<GalleryReadyProps> = ({
     // (index.css), so a `min-h-screen` child can't trigger document scroll
     // when submissions overflow the viewport. Give the outer an explicit
     // viewport height + `overflow-y-auto` so the gallery list scrolls.
-    <div className="h-screen overflow-y-auto bg-slate-100">
+    // `h-dvh` follows `h-screen` so the dynamic viewport unit wins on
+    // browsers that support it — keeps iOS Safari from clipping the
+    // bottom row under the collapsing URL bar.
+    <div className="h-screen h-dvh overflow-y-auto bg-slate-100">
       <header className="bg-brand-blue-primary text-white">
         <div className="max-w-5xl mx-auto px-5 py-6">
           <p className="text-xs uppercase tracking-widest font-bold opacity-90">


### PR DESCRIPTION
## Summary

- The Activity Wall "Share Gallery" link opened a page where the viewport was locked, so submissions past the fold were unreachable.
- Root cause: `body` has `overflow: hidden` globally (index.css line 44) to keep the teacher dashboard surface from scrolling. The gallery's `GalleryReady` outer wrapper used `min-h-screen`, which can't trigger document scroll when the body is locked — content past 100vh just got clipped.
- Fix: swap the wrapper to `h-screen overflow-y-auto`, the same pattern already used by `ActivityWallStudentApp` and `QuizStudentApp` (which call this out in a comment around `QuizStudentApp.tsx:431`).

## Test plan

- [ ] Open a Share Gallery link with enough submissions to overflow the viewport — verify the page scrolls vertically and every submission is reachable.
- [ ] Test on mobile-sized viewport where even a few submissions overflow.
- [ ] Verify the header still stays at the top of the page (no longer sticky was never the behavior, just confirm visual parity with before).
- [ ] Verify the loading / expired / revoked / not-found short states still render centered (they use their own `min-h-screen` containers and weren't changed).

https://claude.ai/code/session_011V2L8ft3gfJRE8ae2KthxZ

---
_Generated by [Claude Code](https://claude.ai/code/session_011V2L8ft3gfJRE8ae2KthxZ)_