### PR TITLE
Refactor agent skills management and enhance publish/unpublish flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,14 @@ eslint-output.txt
 .claude/worktrees/
 .claude/settings.local.json
 
+# Agent skills installed via the `skills` CLI (project scope).
+# Project-committed skills (e.g. admin-widget-config, new-widget) are re-included below.
+.agents/
+skills-lock.json
+.claude/skills/*
+!.claude/skills/admin-widget-config/
+!.claude/skills/new-widget/
+
 # Playwright MCP scratch
 .playwright-mcp/
 

--- a/components/activityWall/ActivityWallGalleryView.tsx
+++ b/components/activityWall/ActivityWallGalleryView.tsx
@@ -416,7 +416,14 @@ const GalleryReady: React.FC<GalleryReadyProps> = ({
   }, [comments]);
 
   return (
-    <div className="min-h-screen bg-slate-100">
+    // Outer wrapper owns the scroll: body has `overflow: hidden` globally
+    // (index.css), so a `min-h-screen` child can't trigger document scroll
+    // when submissions overflow the viewport. Give the outer an explicit
+    // viewport height + `overflow-y-auto` so the gallery list scrolls.
+    // `h-dvh` follows `h-screen` so the dynamic viewport unit wins on
+    // browsers that support it — keeps iOS Safari from clipping the
+    // bottom row under the collapsing URL bar.
+    <div className="h-screen h-dvh overflow-y-auto bg-slate-100">
       <header className="bg-brand-blue-primary text-white">
         <div className="max-w-5xl mx-auto px-5 py-6">
           <p className="text-xs uppercase tracking-widest font-bold opacity-90">

--- a/components/common/library/PublishScoresModal.tsx
+++ b/components/common/library/PublishScoresModal.tsx
@@ -32,17 +32,20 @@ import {
 } from 'lucide-react';
 import { Modal } from '@/components/common/Modal';
 import type {
+  GuidedLearningScoreVisibility,
   QuizScoreVisibility,
   VideoActivityScoreVisibility,
 } from '@/types';
 
 /**
- * Score-visibility level. Quiz and VA both define the same string-literal
- * union; either resolves to the same shape at the call site.
+ * Score-visibility level. Quiz, VA, and GL all define the same
+ * string-literal union; any of them resolves to the same shape at the
+ * call site.
  */
 export type PublishScoresVisibility =
   | QuizScoreVisibility
-  | VideoActivityScoreVisibility;
+  | VideoActivityScoreVisibility
+  | GuidedLearningScoreVisibility;
 
 interface PublishScoresModalProps {
   /** Assignment title — sub-line so the teacher knows which assignment they're publishing. */

--- a/components/guidedLearning/GuidedLearningStudentApp.tsx
+++ b/components/guidedLearning/GuidedLearningStudentApp.tsx
@@ -21,8 +21,15 @@ import {
   CheckCircle2,
   RefreshCw,
   Trophy,
+  XCircle,
 } from 'lucide-react';
-import { addDoc, collection, serverTimestamp } from 'firebase/firestore';
+import {
+  addDoc,
+  collection,
+  doc,
+  onSnapshot,
+  serverTimestamp,
+} from 'firebase/firestore';
 import { auth, db } from '@/config/firebase';
 import { logError } from '@/utils/logError';
 import { useGuidedLearningSessionStudent } from '@/hooks/useGuidedLearningSession';
@@ -124,6 +131,69 @@ const StudentExperience: React.FC<{ anonymousUid: string }> = ({
   const [completed, setCompleted] = useState(false);
   const [score, setScore] = useState<number | null>(null);
   const [answers, setAnswers] = useState<GuidedLearningResponse['answers']>([]);
+  // Realtime listener on /guided_learning_sessions/{id}/responses/{uid}
+  // so a returning student gets their published score + per-step
+  // `isCorrect` flags, and a teacher unpublish (which clears
+  // `session.revealedAnswers` + flips `scoreVisibility` to 'none')
+  // propagates without a refresh. View-only shares never persist
+  // responses, so the subscription is gated on `shouldSubscribeResponse`.
+  const shouldSubscribeResponse = !!sessionId && !!anonymousUid && !isViewOnly;
+  const [myResponse, setMyResponse] = useState<GuidedLearningResponse | null>(
+    null
+  );
+  const [myResponseLoading, setMyResponseLoading] = useState(
+    shouldSubscribeResponse
+  );
+  // A non-null value here means the listener failed for a real reason
+  // (permission-denied, network outage, rule rejection) — NOT just "doc
+  // doesn't exist," which `onSnapshot` reports as a successful snapshot
+  // with `snap.exists() === false`. We surface a soft banner instead of
+  // silently treating a failed read as "no submission exists" — that
+  // would invite a student who already submitted to resubmit.
+  const [myResponseError, setMyResponseError] = useState<string | null>(null);
+  // Adjust-state-while-rendering pattern (avoids set-state-in-effect):
+  // when the subscription gating flips (e.g., session loads as view-only),
+  // sync the loading flag to match without a cascading render.
+  const [prevShouldSubscribeResponse, setPrevShouldSubscribeResponse] =
+    useState(shouldSubscribeResponse);
+  if (shouldSubscribeResponse !== prevShouldSubscribeResponse) {
+    setPrevShouldSubscribeResponse(shouldSubscribeResponse);
+    setMyResponseLoading(shouldSubscribeResponse);
+    if (!shouldSubscribeResponse) {
+      setMyResponse(null);
+      setMyResponseError(null);
+    }
+  }
+  useEffect(() => {
+    if (!shouldSubscribeResponse) return;
+    const unsub = onSnapshot(
+      doc(db, GL_SESSIONS_COLLECTION, sessionId, 'responses', anonymousUid),
+      (snap) => {
+        // `snap.exists() === false` is the normal "first visit, no
+        // submission yet" path — not an error. Clearing `myResponseError`
+        // here lets a transient listener failure self-heal once the
+        // backend recovers.
+        setMyResponse(
+          snap.exists() ? (snap.data() as GuidedLearningResponse) : null
+        );
+        setMyResponseError(null);
+        setMyResponseLoading(false);
+      },
+      (err) => {
+        // Real listener failures (permission-denied / unavailable /
+        // network) only. Do NOT zero out `myResponse` here — if we had
+        // already received a snapshot, keeping the last-known data
+        // avoids flicker, and if we hadn't, the parent gate will keep
+        // `myResponseLoading: true` so the Player UI doesn't render
+        // (which would silently invite a duplicate submission).
+        logError('GuidedLearningStudentApp.responseListener', err, {
+          sessionId,
+        });
+        setMyResponseError('listener-failed');
+      }
+    );
+    return unsub;
+  }, [sessionId, anonymousUid, shouldSubscribeResponse]);
   // Bumped when the user clicks "Replay from beginning" on a view-only
   // completion screen. Used as the React key on the player so its
   // internal state (currentIdx, activeStepId, image index, etc.) fully
@@ -197,12 +267,52 @@ const StudentExperience: React.FC<{ anonymousUid: string }> = ({
   if (error) return <ErrorScreen message={error} />;
   if (!session) return <ErrorScreen message="Session not found." />;
 
+  // Response-listener failure on a submissions-mode session — we can't
+  // safely show the start screen (a returning student would silently
+  // resubmit) and we can't show the review (no data). Surface a refresh
+  // prompt instead. `completed` short-circuits so a just-submitted
+  // student isn't blocked by a stale error.
+  if (!completed && !isViewOnly && myResponseError && !myResponse) {
+    return (
+      <ErrorScreen message="Couldn't load your submission status. Please refresh and try again." />
+    );
+  }
+
+  // Returning student case — a response already exists in Firestore. Show
+  // either the published review or a "wait for teacher" placeholder
+  // rather than dropping them back onto the start screen (which would
+  // imply they could submit again). `completed` short-circuits this
+  // branch so the just-submitted screen still wins immediately after
+  // `handleComplete` flips the local state.
+  if (!completed && !isViewOnly && !myResponseLoading && myResponse) {
+    const visibility = session.scoreVisibility ?? 'none';
+    if (visibility !== 'none') {
+      return (
+        <PublishedGLReview
+          session={session}
+          myResponse={myResponse}
+          visibility={visibility}
+        />
+      );
+    }
+    return (
+      <CompletionScreen
+        session={session}
+        score={null}
+        isViewOnly={false}
+        visibility="none"
+        onReplay={() => undefined}
+      />
+    );
+  }
+
   if (completed) {
     return (
       <CompletionScreen
         session={session}
         score={score}
         isViewOnly={isViewOnly}
+        visibility={session.scoreVisibility ?? 'none'}
         onReplay={() => {
           // Drop responses + bump key so the player fully remounts with
           // fresh state at step 0 / image 0. Keep `started` true so the
@@ -428,13 +538,21 @@ const CompletionScreen: React.FC<{
   score: number | null;
   isViewOnly: boolean;
   /**
+   * Teacher's current score-visibility setting on the session.
+   * `'none'` ⇒ render the neutral "submitted, ask your teacher"
+   * placeholder; any other value ⇒ keep the gamified Trophy framing.
+   * The actual score / per-step results live on the response doc and
+   * are surfaced by `PublishedGLReview`, not here.
+   */
+  visibility: NonNullable<GuidedLearningSession['scoreVisibility']>;
+  /**
    * View-only "Replay from beginning" handler. Resets state so the
    * player remounts at step 0. Not shown for response-tracked sessions
    * (those have already submitted — replay would imply submitting
    * twice).
    */
   onReplay: () => void;
-}> = ({ session, score, isViewOnly, onReplay }) => {
+}> = ({ session, score, isViewOnly, visibility, onReplay }) => {
   // View-only completion is purely informational — there's no "score",
   // no "you finished an assignment" framing, just "you reached the end
   // of this resource". Suppress the gamified Trophy / Complete! styling
@@ -464,7 +582,36 @@ const CompletionScreen: React.FC<{
     );
   }
 
-  // Response-tracked completion — keep the achievement framing.
+  // Response-tracked completion. When the teacher hasn't published
+  // results yet (`visibility === 'none'`, the default), drop the
+  // gamified Trophy framing in favor of a neutral "submitted" placeholder
+  // — promising "Complete!" on a screen that can't show a score reads as
+  // a missing feature. Once the teacher publishes, the parent component
+  // routes returning students to `PublishedGLReview` instead, so the
+  // Trophy variant below is only reached on the immediate post-submit
+  // render when the teacher had already pre-published at create time
+  // (uncommon but supported).
+  if (visibility === 'none') {
+    return (
+      <div className="h-screen overflow-y-auto bg-slate-950">
+        <div className="min-h-full flex items-center justify-center p-6">
+          <div className="bg-slate-900 border border-white/10 rounded-2xl p-8 max-w-sm w-full text-center shadow-2xl">
+            <CheckCircle2 className="w-10 h-10 text-emerald-400 mx-auto mb-3" />
+            <h1 className="text-white font-bold text-xl mb-1">
+              {session.title}
+            </h1>
+            <p className="text-slate-300 text-sm mb-4">
+              Your responses have been submitted.
+            </p>
+            <p className="text-slate-500 text-xs">
+              Ask your teacher to see your results.
+            </p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div className="h-screen overflow-y-auto bg-slate-950">
       <div className="min-h-full flex items-center justify-center p-6">
@@ -489,3 +636,151 @@ const CompletionScreen: React.FC<{
     </div>
   );
 };
+
+// ─── Published-score review ──────────────────────────────────────────────────
+//
+// Rendered for a returning student whose teacher has flipped
+// `scoreVisibility` on the session via the archive's "Publish scores"
+// kebab action. The three modes are progressive disclosure:
+//
+//   - score-only: just the percentage tally.
+//   - score-and-responses: above + per-step rows tagging each of the
+//     student's answers correct or incorrect, but never the canonical
+//     correct answer.
+//   - score-responses-and-answers: above + the canonical correct answer
+//     under each row, sourced from `session.revealedAnswers` (populated
+//     atomically by `publishAssignmentScores`).
+//
+// All data the screen needs lives on `myResponse` (score + per-answer
+// `isCorrect`) and `session` (publicSteps, revealedAnswers). We don't
+// recompute correctness client-side — the teacher's publish step is the
+// only writer for those fields, so a stale-cache device can't manufacture
+// a "correct" badge that isn't on the authoritative response doc.
+
+export const PublishedGLReview: React.FC<{
+  session: GuidedLearningSession;
+  myResponse: GuidedLearningResponse;
+  visibility: NonNullable<GuidedLearningSession['scoreVisibility']>;
+}> = ({ session, myResponse, visibility }) => {
+  const showResponses =
+    visibility === 'score-and-responses' ||
+    visibility === 'score-responses-and-answers';
+  const showAnswers = visibility === 'score-responses-and-answers';
+
+  const gradableSteps = session.publicSteps.filter((s) => !!s.question);
+  const answersByStep = new Map(
+    myResponse.answers.map((a) => [a.stepId, a] as const)
+  );
+
+  const score = myResponse.score ?? 0;
+  const correctCount = myResponse.answers.filter(
+    (a) => a.isCorrect === true
+  ).length;
+  const totalGradable = gradableSteps.length;
+
+  return (
+    <div className="h-screen overflow-y-auto bg-slate-950">
+      <div className="min-h-full flex items-start justify-center p-6">
+        <div className="w-full max-w-md flex flex-col gap-4">
+          <div className="bg-slate-900 border border-white/10 rounded-2xl p-6 text-center shadow-2xl">
+            <Trophy className="w-10 h-10 text-yellow-400 mx-auto mb-2" />
+            <h1 className="text-white font-bold text-xl mb-1">
+              {session.title}
+            </h1>
+            <p className="text-slate-400 text-xs mb-4">Your results</p>
+            <p className="text-5xl font-black text-white mb-1">{score}%</p>
+            {totalGradable > 0 && (
+              <p className="text-slate-400 text-sm">
+                {correctCount} of {totalGradable} correct
+              </p>
+            )}
+          </div>
+
+          {showResponses && totalGradable > 0 && (
+            <div className="bg-slate-900 border border-white/10 rounded-2xl p-4 shadow-2xl">
+              <ul className="flex flex-col gap-3">
+                {gradableSteps.map((step, idx) => {
+                  const ans = answersByStep.get(step.id);
+                  const isCorrect = ans?.isCorrect === true;
+                  const canonical = showAnswers
+                    ? session.revealedAnswers?.[step.id]
+                    : undefined;
+                  const studentAnswer = formatStudentAnswer(ans?.answer);
+                  return (
+                    <li
+                      key={step.id}
+                      className="border border-white/10 rounded-xl p-3 bg-slate-950/40"
+                    >
+                      <div className="flex items-start gap-2">
+                        {isCorrect ? (
+                          <CheckCircle2 className="w-5 h-5 text-emerald-400 shrink-0 mt-0.5" />
+                        ) : (
+                          <XCircle className="w-5 h-5 text-rose-400 shrink-0 mt-0.5" />
+                        )}
+                        <div className="flex-1 min-w-0">
+                          <p className="text-white text-sm font-semibold mb-1">
+                            Step {idx + 1}
+                            {step.label ? ` · ${step.label}` : ''}
+                          </p>
+                          {step.question?.text && (
+                            <p className="text-slate-400 text-xs mb-2">
+                              {step.question.text}
+                            </p>
+                          )}
+                          <p className="text-slate-200 text-sm">
+                            <span className="text-slate-500">
+                              Your answer:{' '}
+                            </span>
+                            {studentAnswer || (
+                              <span className="italic text-slate-500">
+                                No answer
+                              </span>
+                            )}
+                          </p>
+                          {showAnswers && !isCorrect && canonical && (
+                            <p className="text-slate-200 text-sm mt-1 whitespace-pre-line">
+                              <span className="text-slate-500">
+                                Correct answer:{' '}
+                              </span>
+                              {canonical}
+                            </p>
+                          )}
+                        </div>
+                      </div>
+                    </li>
+                  );
+                })}
+              </ul>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+/** Stringify a stored student answer for display. Mirrors the format used
+ *  by `revealedAnswers` so matching / sorting reads consistently.
+ *  Exported alongside `PublishedGLReview` so the test harness can exercise
+ *  the colon-split regression case without rendering the full review.
+ */
+// eslint-disable-next-line react-refresh/only-export-components
+export function formatStudentAnswer(
+  answer: string | string[] | undefined
+): string {
+  if (answer === undefined) return '';
+  if (typeof answer === 'string') return answer;
+  if (answer.length === 0) return '';
+  // Matching is stored as `"${left}:${right}"` strings (see
+  // `isAnswerCorrect`), so split on the FIRST colon — `pair.left` or
+  // `pair.right` may legitimately contain colons themselves (e.g.
+  // "Ratio: 3"). `String#replace(":")` is first-match-only too, but it
+  // doesn't split, so multi-colon strings render with a trailing
+  // colon-bearing fragment. `indexOf` + `slice` is unambiguous.
+  return answer
+    .map((a) => {
+      const i = a.indexOf(':');
+      return i < 0 ? a : `${a.slice(0, i)} → ${a.slice(i + 1)}`;
+    })
+    .join('\n');
+}

--- a/components/quiz/QuizStudentApp.tsx
+++ b/components/quiz/QuizStudentApp.tsx
@@ -1132,6 +1132,14 @@ const ActiveQuiz: React.FC<{
   const fibAnswerRef = useRef(fibAnswer);
   const draftMcAnswerRef = useRef(draftMcAnswer);
   const onAnswerRef = useRef(onAnswer);
+  // Mirror of `myResponse.status` for the visibility/unmount flush
+  // handlers (which are scoped to `[]` deps and can't read state
+  // directly). Used to short-circuit the flush after the student has
+  // already submitted — without this, the cleanup flush at unmount
+  // re-writes the answer with `status: 'draft'`, downgrading the parent
+  // response from `'completed'` back to `'in-progress'` and silently
+  // breaking the teacher's "Finished" counter.
+  const myResponseStatusRef = useRef(myResponse?.status);
   // Live serialized answer for Matching/Ordering, written by the child
   // StructuredQuestionInput on every drag/tap so timer auto-submit can
   // capture partial placements instead of submitting the empty string.
@@ -1144,6 +1152,7 @@ const ActiveQuiz: React.FC<{
     draftMcAnswerRef.current = draftMcAnswer;
     onAnswerRef.current = onAnswer;
     writtenAnswerRef.current = writtenAnswer;
+    myResponseStatusRef.current = myResponse?.status;
   }, [
     currentQuestion,
     selectedAnswer,
@@ -1151,6 +1160,7 @@ const ActiveQuiz: React.FC<{
     draftMcAnswer,
     onAnswer,
     writtenAnswer,
+    myResponse?.status,
   ]);
 
   // Reset the structured answer ref when the question changes so a stale
@@ -1271,6 +1281,14 @@ const ActiveQuiz: React.FC<{
   // the page tears down is the best-effort flush we can do.
   useEffect(() => {
     const flush = () => {
+      // Bail if the response has already been finalized. The cleanup
+      // flush runs on unmount, which is triggered by `myResponse.status`
+      // flipping to `'completed'` — without this guard, the flush would
+      // re-write the answer with `status: 'draft'`, downgrading the
+      // parent doc from `'completed'` back to `'in-progress'` and
+      // breaking the teacher's results view ("0 finished", "in
+      // progress" badge, score distribution empty).
+      if (myResponseStatusRef.current === 'completed') return;
       const qid = currentQuestionRef.current?.id;
       const type = currentQuestionRef.current?.type;
       if (type !== 'short' && type !== 'essay') return;
@@ -2218,13 +2236,26 @@ const QuizCompleteCard: React.FC = () => (
   </div>
 );
 
-const ReturnToAssignmentsButton: React.FC = () => (
+/**
+ * Inline CTA used after submission. `variant="card"` matches the existing
+ * full-width pill that sits inside the answer card on the active quiz
+ * screen; `variant="standalone"` is a compact pill sized to its label —
+ * used on the full-screen `QuizSubmittedWaitScreen` so it doesn't stretch
+ * edge-to-edge.
+ */
+const ReturnToAssignmentsButton: React.FC<{
+  variant?: 'card' | 'standalone';
+}> = ({ variant = 'card' }) => (
   <button
     type="button"
     onClick={() => {
       window.location.assign('/my-assignments');
     }}
-    className="w-full py-3 bg-brand-blue-primary hover:bg-brand-blue-dark text-white font-bold rounded-2xl flex items-center justify-center gap-2 transition-colors shadow-sm shadow-brand-blue-primary/20"
+    className={
+      variant === 'standalone'
+        ? 'inline-flex items-center gap-2 px-5 py-2.5 bg-brand-blue-primary hover:bg-brand-blue-dark text-white text-sm font-bold rounded-full transition-colors'
+        : 'w-full py-3 bg-brand-blue-primary hover:bg-brand-blue-dark text-white font-bold rounded-2xl flex items-center justify-center gap-2 transition-colors shadow-sm shadow-brand-blue-primary/20'
+    }
   >
     Back to my assignments <ArrowRight className="w-4 h-4" />
   </button>
@@ -2816,7 +2847,7 @@ const QuizSubmittedWaitScreen: React.FC<{
       */}
       {!pin && (
         <div className="mt-6">
-          <ReturnToAssignmentsButton />
+          <ReturnToAssignmentsButton variant="standalone" />
         </div>
       )}
     </div>

--- a/components/quiz/QuizStudentApp.tsx
+++ b/components/quiz/QuizStudentApp.tsx
@@ -1550,7 +1550,14 @@ const ActiveQuiz: React.FC<{
     currentQuestion.type === 'MC' ? (currentQuestion.choices ?? []) : [];
 
   return (
-    <div className="h-screen overflow-y-auto bg-slate-900 relative">
+    // `overflow-x-hidden` is a defensive backstop so an oversized child
+    // (a long unbreakable token in a student answer, a misconfigured
+    // grid below a fold, a future refactor that adds a fixed-width
+    // element) can never produce a horizontal scrollbar on an 11"
+    // Chromebook. The max-width caps above keep content well-anchored
+    // on widescreens; this guarantees the narrow-viewport path stays
+    // scroll-free regardless of what's rendered inside.
+    <div className="h-screen overflow-y-auto overflow-x-hidden bg-slate-900 relative">
       {/* The "your teacher unlocked your attempt" prompt — covers the quiz
           UI on first render after a teacher unlock so the student knows
           what happened before they touch anything. */}
@@ -1627,11 +1634,22 @@ const ActiveQuiz: React.FC<{
 
       <div
         className={`flex flex-col p-6 mx-auto w-full ${
+          // Per-type width caps. Tuned for the personal-device viewport
+          // a student actually uses (laptop / Chromebook / tablet), not
+          // a projector:
+          //   essay     → max-w-7xl  ~1280px. Long-form writing benefits
+          //                from elbow room more than line-length
+          //                discipline; the editor wraps its own prose.
+          //   short     → max-w-5xl  ~1024px. Paragraph-length answers
+          //                still want room without becoming sprawling.
+          //   MC/FIB/   → max-w-2xl   ~672px. Short answer options and
+          //   Matching/   structured inputs read worse when stretched
+          //   Ordering    across a widescreen — keep them compact.
           currentQuestion.type === 'essay'
-            ? 'max-w-5xl'
+            ? 'max-w-7xl'
             : currentQuestion.type === 'short'
-              ? 'max-w-3xl'
-              : 'max-w-lg'
+              ? 'max-w-5xl'
+              : 'max-w-2xl'
         }`}
       >
         {/* Header */}
@@ -1689,7 +1707,7 @@ const ActiveQuiz: React.FC<{
         </div>
 
         {/* Question */}
-        <h2 className="text-xl font-bold text-white mb-8 leading-snug">
+        <h2 className="text-xl font-bold text-white mb-8 leading-snug break-words">
           {currentQuestion.text}
         </h2>
 
@@ -2543,9 +2561,16 @@ const PublishedScoreReview: React.FC<{
     (a) => autoGradedQuestionIds.has(a.questionId) && a.isCorrect === true
   ).length;
 
+  // Per-question cards dominate this view (snapshot + teacher
+  // annotations + score + comment block), so the container is sized
+  // generously — written-response reviews benefit much more from
+  // horizontal room than from a tight prose column. The annotation
+  // engine inside each card handles its own internal line lengths.
+  // `overflow-x-hidden` is the same horizontal-scroll backstop the
+  // active-quiz screen uses — see comment there for why.
   return (
-    <div className="h-screen overflow-y-auto bg-slate-900 px-4 py-8 sm:px-6 sm:py-12">
-      <div className="mx-auto w-full max-w-2xl">
+    <div className="h-screen overflow-y-auto overflow-x-hidden bg-slate-900 px-4 py-8 sm:px-6 sm:py-12">
+      <div className="mx-auto w-full max-w-6xl">
         <header className="mb-6 flex flex-col items-center text-center">
           <Trophy className="mb-4 h-12 w-12 text-amber-400" />
           <h1 className="text-2xl font-black text-white sm:text-3xl">
@@ -2632,7 +2657,7 @@ const PublishedScoreReview: React.FC<{
                       <span className="mt-0.5 inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-slate-700 font-mono text-[11px] font-bold text-slate-200">
                         {idx + 1}
                       </span>
-                      <p className="flex-1 text-sm font-semibold text-slate-100">
+                      <p className="flex-1 min-w-0 break-words text-sm font-semibold text-slate-100">
                         {q.text}
                       </p>
                       {isCorrect && (

--- a/components/quiz/QuizStudentApp.tsx
+++ b/components/quiz/QuizStudentApp.tsx
@@ -60,6 +60,7 @@ import {
   QuizPublicQuestion,
   WrittenAnswerGrade,
   isWrittenQuestionType,
+  isAnswerSubmitted,
 } from '@/types';
 import { sanitizeQuizResponse } from '@/utils/security';
 import { AnnotatedResponseView } from '@/components/widgets/QuizWidget/components/AnnotatedResponseView';
@@ -397,12 +398,17 @@ const QuizJoinFlow: React.FC<{ isStudentRole: boolean }> = ({
   }, [isViewOnly, session?.id, authedUid]);
 
   const handleAnswer = useCallback(
-    async (questionId: string, answer: string, speedBonus?: number) => {
+    async (
+      questionId: string,
+      answer: string,
+      speedBonus?: number,
+      opts?: { isDraft?: boolean }
+    ) => {
       // View-only shares never persist responses — the Firestore rule
       // rejects the write defense-in-depth, but skip it client-side too so
       // the console stays clean.
       if (isViewOnly) return;
-      await submitAnswer(questionId, answer, speedBonus);
+      await submitAnswer(questionId, answer, speedBonus, opts);
     },
     [submitAnswer, isViewOnly]
   );
@@ -676,8 +682,13 @@ const QuizJoinFlow: React.FC<{ isStudentRole: boolean }> = ({
       );
     }
 
+    // Drafts (debounced autosaves of written responses) don't count as
+    // "answered" — the student is still typing. The completion gate only
+    // fires on an explicit Submit, which writes `status: 'submitted'`.
     const alreadyAnswered = currentQ
-      ? myResponse.answers.some((a) => a.questionId === currentQ.id)
+      ? myResponse.answers.some(
+          (a) => a.questionId === currentQ.id && isAnswerSubmitted(a)
+        )
       : false;
 
     return (
@@ -743,7 +754,12 @@ const ActiveQuiz: React.FC<{
   currentQuestion: QuizPublicQuestion | undefined;
   alreadyAnswered: boolean;
   myResponse: ReturnType<typeof useQuizSessionStudent>['myResponse'];
-  onAnswer: (qId: string, answer: string, speedBonus?: number) => Promise<void>;
+  onAnswer: (
+    qId: string,
+    answer: string,
+    speedBonus?: number,
+    opts?: { isDraft?: boolean }
+  ) => Promise<void>;
   onComplete: () => Promise<void>;
   reportTabSwitch: () => Promise<number>;
   warningCount: number;
@@ -949,9 +965,12 @@ const ActiveQuiz: React.FC<{
     return shuffleQuestionForStudent(baseQuestion, studentShuffleSeed);
   }, [baseQuestion, answerOptionShuffleEnabled, studentShuffleSeed]);
 
+  // Drafts don't count: a debounced autosave of a written-response in
+  // progress must not flip `submitted` true and shouldn't trigger
+  // `QuizCompleteCard`. Only explicit Submit writes `status: 'submitted'`.
   const alreadyAnswered = isStudentPaced
     ? (myResponse?.answers ?? []).some(
-        (a) => a.questionId === currentQuestion?.id
+        (a) => a.questionId === currentQuestion?.id && isAnswerSubmitted(a)
       )
     : sessionAnswered;
 
@@ -1223,11 +1242,13 @@ const ActiveQuiz: React.FC<{
     }
     const draft = writtenAnswer;
     writtenAutosaveTimer.current = setTimeout(() => {
-      void onAnswerRef.current(qid, draft).catch((err: unknown) => {
-        logError('QuizStudentApp.writtenAutosave', err, {
-          questionId: qid,
+      void onAnswerRef
+        .current(qid, draft, undefined, { isDraft: true })
+        .catch((err: unknown) => {
+          logError('QuizStudentApp.writtenAutosave', err, {
+            questionId: qid,
+          });
         });
-      });
     }, 500);
 
     return () => {
@@ -1260,11 +1281,13 @@ const ActiveQuiz: React.FC<{
         clearTimeout(writtenAutosaveTimer.current);
         writtenAutosaveTimer.current = null;
       }
-      void onAnswerRef.current(qid, draft).catch((err: unknown) => {
-        logError('QuizStudentApp.writtenAutosaveFlush', err, {
-          questionId: qid,
+      void onAnswerRef
+        .current(qid, draft, undefined, { isDraft: true })
+        .catch((err: unknown) => {
+          logError('QuizStudentApp.writtenAutosaveFlush', err, {
+            questionId: qid,
+          });
         });
-      });
     };
     const onVisibilityChange = () => {
       if (document.visibilityState === 'hidden') flush();
@@ -1586,9 +1609,11 @@ const ActiveQuiz: React.FC<{
 
       <div
         className={`flex flex-col p-6 mx-auto w-full ${
-          currentQuestion.type === 'short' || currentQuestion.type === 'essay'
-            ? 'max-w-3xl'
-            : 'max-w-lg'
+          currentQuestion.type === 'essay'
+            ? 'max-w-5xl'
+            : currentQuestion.type === 'short'
+              ? 'max-w-3xl'
+              : 'max-w-lg'
         }`}
       >
         {/* Header */}

--- a/components/quiz/QuizStudentApp.tsx
+++ b/components/quiz/QuizStudentApp.tsx
@@ -2527,10 +2527,21 @@ const PublishedScoreReview: React.FC<{
   for (const a of myResponse.answers) {
     answerById.set(a.questionId, a);
   }
+  // "Fully correct" only makes sense for auto-graded types. Counting an
+  // essay or short-answer against this tally produces a misleading "0 of
+  // 1 fully correct" beneath a 70% score for partial-credit work. Count
+  // and label against auto-graded questions only; suppress the line
+  // entirely when the quiz has no auto-graded questions at all.
+  const publicQuestions = session.publicQuestions ?? [];
+  const autoGradedQuestionIds = new Set(
+    publicQuestions
+      .filter((q) => !isWrittenQuestionType(q.type))
+      .map((q) => q.id)
+  );
+  const autoGradedCount = autoGradedQuestionIds.size;
   const correctCount = myResponse.answers.filter(
-    (a) => a.isCorrect === true
+    (a) => autoGradedQuestionIds.has(a.questionId) && a.isCorrect === true
   ).length;
-  const total = session.totalQuestions;
 
   return (
     <div className="h-screen overflow-y-auto bg-slate-900 px-4 py-8 sm:px-6 sm:py-12">
@@ -2555,16 +2566,18 @@ const PublishedScoreReview: React.FC<{
               <p className="text-5xl font-black text-white sm:text-6xl">
                 {scorePercent}%
               </p>
-              {/* Per-question tally counts only fully-correct answers, so it
-                  can lag the percentage on quizzes that award partial credit
-                  (Matching/Ordering with `allowPartialCredit`) or use non-1
-                  point values. The "fully correct" qualifier makes the
-                  potential gap between this line and the percentage above
-                  legible to the student rather than appearing to contradict
-                  it. */}
-              <p className="mt-2 text-sm text-slate-400">
-                {correctCount} of {total} fully correct
-              </p>
+              {/* Per-question tally counts only fully-correct answers, so
+                  it can lag the percentage on quizzes that award partial
+                  credit (Matching/Ordering with `allowPartialCredit`) or
+                  use non-1 point values — and it doesn't apply at all to
+                  written-response questions where "fully correct" is a
+                  category error. Hide the line on essay-only quizzes; on
+                  mixed quizzes it counts only the auto-graded subset. */}
+              {autoGradedCount > 0 && (
+                <p className="mt-2 text-sm text-slate-400">
+                  {correctCount} of {autoGradedCount} fully correct
+                </p>
+              )}
             </>
           ) : (
             <p className="text-sm text-slate-300">
@@ -2586,23 +2599,22 @@ const PublishedScoreReview: React.FC<{
                 const writtenGrade = isWritten
                   ? myResponse.grading?.[q.id]
                   : undefined;
-                // Match `gradeAnswer`'s default: a missing `points`
-                // means 1, not 0. The old `q.points &&` short-circuited
-                // when `points` was unset, so a full-credit grade on a
-                // default-points question never showed the ✓.
+                // Written-response questions don't have a binary
+                // right/wrong outcome — a 7/10 essay is partial credit,
+                // not "incorrect". Suppress the red-X / red-border
+                // treatment entirely for written types. A full-credit
+                // essay still shows the ✓ as a positive ack, but never
+                // a red mark for anything below 100%.
                 const writtenMaxPoints = q.points ?? 1;
                 const writtenIsCorrect =
                   writtenGrade != null &&
                   writtenMaxPoints > 0 &&
                   writtenGrade.pointsAwarded === writtenMaxPoints;
-                const writtenIsIncorrect =
-                  writtenGrade != null &&
-                  writtenGrade.pointsAwarded < writtenMaxPoints;
                 const isCorrect = isWritten
                   ? writtenIsCorrect
                   : ans?.isCorrect === true;
                 const isIncorrect = isWritten
-                  ? writtenIsIncorrect
+                  ? false
                   : ans?.isCorrect === false;
                 const correctAnswer = session.revealedAnswers?.[q.id];
                 return (
@@ -2713,7 +2725,7 @@ export const WrittenAnswerReview: React.FC<{
     (studentAnswer ? sanitizeQuizResponse(studentAnswer) : '');
   const showingLiveAnswer = !hasGrade && !!studentAnswer;
   return (
-    <div className="space-y-2">
+    <div className="space-y-3">
       {snapshot ? (
         <AnnotatedResponseView
           mode="read"
@@ -2724,22 +2736,30 @@ export const WrittenAnswerReview: React.FC<{
         <p className="text-xs text-slate-500 italic">— no response</p>
       )}
       {hasGrade && (
-        <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1 text-xs text-slate-400">
-          <span>
-            Score:{' '}
-            <span className="font-mono text-slate-100">
+        <>
+          {grade.overallComment && (
+            // Promoted from a tiny footnote to a violet-accented card so
+            // the teacher's written feedback is the most visible thing
+            // after the student's own answer — it's the part students
+            // most need to read.
+            <div className="rounded-lg border border-violet-400/40 bg-violet-500/10 px-3 py-2.5">
+              <p className="text-[10px] font-black uppercase tracking-wider text-violet-300 mb-1">
+                Teacher Comment
+              </p>
+              <p className="text-sm text-slate-100 leading-relaxed whitespace-pre-wrap">
+                {grade.overallComment}
+              </p>
+            </div>
+          )}
+          <div className="flex items-baseline justify-between gap-2 pt-1 border-t border-slate-700/60">
+            <span className="text-[10px] font-bold uppercase tracking-wider text-slate-500">
+              Score
+            </span>
+            <span className="font-mono text-base font-black text-slate-100">
               {grade.pointsAwarded} / {maxPoints}
             </span>
-          </span>
-          {grade.overallComment && (
-            <span className="basis-full text-slate-300">
-              <span className="font-bold uppercase tracking-wider text-[10px] text-slate-500">
-                Teacher comment:
-              </span>{' '}
-              {grade.overallComment}
-            </span>
-          )}
-        </div>
+          </div>
+        </>
       )}
       {!hasGrade &&
         (showingLiveAnswer ? (

--- a/components/widgets/GuidedLearning/Widget.tsx
+++ b/components/widgets/GuidedLearning/Widget.tsx
@@ -19,6 +19,7 @@ import { useFolders } from '@/hooks/useFolders';
 import { useBusyIdSet } from '@/hooks/useBusyIdSet';
 import { WidgetLayout } from '@/components/widgets/WidgetLayout';
 import { AssignModal, ViewOnlyShareModal } from '@/components/common/library';
+import { PublishScoresModal } from '@/components/common/library/PublishScoresModal';
 import { AssignClassPicker } from '@/components/common/AssignClassPicker';
 import {
   makeEmptyPickerValue,
@@ -94,6 +95,8 @@ export const GuidedLearningWidget: React.FC<{ widget: WidgetData }> = ({
     archiveAssignment,
     unarchiveAssignment,
     deleteAssignment,
+    publishAssignmentScores,
+    unpublishAssignmentScores,
   } = useGuidedLearningAssignments(user?.uid);
 
   // Local component state
@@ -127,6 +130,10 @@ export const GuidedLearningWidget: React.FC<{ widget: WidgetData }> = ({
   const [assignTarget, setAssignTarget] = useState<AssignDialogTarget | null>(
     null
   );
+  // Ephemeral modal state for the per-assignment "Publish Scores" picker.
+  // Mirrors the QuizWidget / VideoActivityWidget pattern.
+  const [publishingAssignment, setPublishingAssignment] =
+    useState<GuidedLearningAssignment | null>(null);
   const [pickerValue, setPickerValue] = useState<AssignClassPickerValue>(() =>
     makeEmptyPickerValue()
   );
@@ -710,6 +717,25 @@ export const GuidedLearningWidget: React.FC<{ widget: WidgetData }> = ({
                 onAssignmentDelete={(a) => {
                   void handleAssignmentDelete(a);
                 }}
+                onAssignmentPublishScores={(a) => {
+                  setPublishingAssignment(a);
+                }}
+                onAssignmentUnpublishScores={async (a) => {
+                  // One-click unpublish — `unpublishAssignmentScores`
+                  // is a cheap two-write batch (no set lookup, no
+                  // grading).
+                  try {
+                    await unpublishAssignmentScores(a.id);
+                    addToast('Scores unpublished.', 'success');
+                  } catch (err) {
+                    addToast(
+                      err instanceof Error
+                        ? err.message
+                        : 'Failed to unpublish scores',
+                      'error'
+                    );
+                  }
+                }}
                 initialLibraryViewMode={config.libraryViewMode}
                 onLibraryViewModeChange={(mode) => {
                   updateWidget(widget.id, {
@@ -869,6 +895,63 @@ export const GuidedLearningWidget: React.FC<{ widget: WidgetData }> = ({
           error={viewOnlyShareError}
           onConfirm={() => void handleConfirmViewOnlyShare()}
           onClose={closeViewOnlyShareModal}
+        />
+      )}
+
+      {publishingAssignment && (
+        <PublishScoresModal
+          assignmentTitle={publishingAssignment.setTitle}
+          currentVisibility={publishingAssignment.scoreVisibility}
+          onClose={() => setPublishingAssignment(null)}
+          onConfirm={async (visibility) => {
+            const target = publishingAssignment;
+            try {
+              if (visibility === 'none') {
+                // Mirror Quiz/VA: route through the dedicated unpublish
+                // method (no set lookup needed for a flag-flip).
+                await unpublishAssignmentScores(target.id);
+                addToast('Scores unpublished.', 'success');
+                setPublishingAssignment(null);
+                return;
+              }
+              // Resolve the canonical set so the grader sees the full
+              // `correctAnswer` / `matchingPairs` / `sortingItems` —
+              // `session.publicSteps` strips them for student safety.
+              const personalMeta = sets.find((s) => s.id === target.setId);
+              const buildingSet = buildingSets.find(
+                (s) => s.id === target.setId
+              );
+              const data = await loadSet(
+                target.setId,
+                personalMeta?.driveFileId,
+                buildingSet
+              );
+              if (!data) {
+                addToast(
+                  'Set is no longer in your library — cannot publish scores.',
+                  'error'
+                );
+                return;
+              }
+              const result = await publishAssignmentScores(
+                target.id,
+                data,
+                visibility
+              );
+              addToast(
+                result.responsesUpdated > 0
+                  ? `Scores published to ${result.responsesUpdated} student${result.responsesUpdated === 1 ? '' : 's'}.`
+                  : 'Scores published. Students will see results once they submit.',
+                'success'
+              );
+              setPublishingAssignment(null);
+            } catch (err) {
+              addToast(
+                err instanceof Error ? err.message : 'Failed to publish scores',
+                'error'
+              );
+            }
+          }}
         />
       )}
     </>

--- a/components/widgets/GuidedLearning/components/GuidedLearningManager.tsx
+++ b/components/widgets/GuidedLearning/components/GuidedLearningManager.tsx
@@ -35,6 +35,8 @@ import {
   Copy,
   ExternalLink,
   CheckSquare,
+  EyeOff,
+  Send,
 } from 'lucide-react';
 import type {
   AssignmentMode,
@@ -49,6 +51,7 @@ import { LibraryItemCard } from '@/components/common/library/LibraryItemCard';
 import { ViewCountBadge } from '@/components/common/library/ViewCountBadge';
 import { useSessionViewCount } from '@/hooks/useSessionViewCount';
 import { useAuth } from '@/context/useAuth';
+import { useDialog } from '@/context/useDialog';
 import { FolderSidebar } from '@/components/common/library/FolderSidebar';
 import { FolderPickerPopover } from '@/components/common/library/FolderPickerPopover';
 import { buildMoveToFolderAction } from '@/components/common/library/folderMenuAction';
@@ -188,6 +191,22 @@ export interface GuidedLearningManagerProps {
   onAssignmentArchive: (assignment: GuidedLearningAssignment) => void;
   onAssignmentUnarchive: (assignment: GuidedLearningAssignment) => void;
   onAssignmentDelete: (assignment: GuidedLearningAssignment) => void;
+  /**
+   * Open the publish-scores picker modal for an archived assignment. Set
+   * ⇒ the archive kebab gains a "Publish scores" / "Update published
+   * scores" entry. Submission-mode assignments only — view-only shares
+   * have no responses to grade.
+   */
+  onAssignmentPublishScores?: (
+    assignment: GuidedLearningAssignment
+  ) => void | Promise<void>;
+  /**
+   * Revoke published score visibility in one click (skips the picker
+   * modal). Only surfaced when `assignment.scoreVisibility` is published.
+   */
+  onAssignmentUnpublishScores?: (
+    assignment: GuidedLearningAssignment
+  ) => void | Promise<void>;
 
   /** Persisted library grid/list toggle (from widget config). */
   initialLibraryViewMode?: 'grid' | 'list';
@@ -357,6 +376,8 @@ export const GuidedLearningManager: React.FC<GuidedLearningManagerProps> = ({
   onAssignmentArchive,
   onAssignmentUnarchive,
   onAssignmentDelete,
+  onAssignmentPublishScores,
+  onAssignmentUnpublishScores,
   initialLibraryViewMode,
   onLibraryViewModeChange,
   assignmentMode = 'submissions',
@@ -377,6 +398,7 @@ export const GuidedLearningManager: React.FC<GuidedLearningManagerProps> = ({
   const [previewEntryId, setPreviewEntryId] = React.useState<string | null>(
     null
   );
+  const { showConfirm } = useDialog();
   const [prevTab, setPrevTab] = React.useState(tab);
   if (prevTab !== tab) {
     setPrevTab(tab);
@@ -878,6 +900,43 @@ export const GuidedLearningManager: React.FC<GuidedLearningManagerProps> = ({
         label: 'Move to In Progress',
         icon: RotateCcw,
         onClick: () => onAssignmentUnarchive(a),
+      });
+    }
+
+    // Publish / Unpublish scores — archive tab, submissions only.
+    // View-only shares have no responses to grade.
+    if (mode === 'archive' && !isViewOnly && onAssignmentPublishScores) {
+      const isPublished =
+        a.scoreVisibility !== undefined && a.scoreVisibility !== 'none';
+      secondary.push({
+        id: 'publish-scores',
+        label: isPublished ? 'Update published scores' : 'Publish scores',
+        icon: Send,
+        onClick: () => void onAssignmentPublishScores(a),
+      });
+    }
+    if (
+      mode === 'archive' &&
+      !isViewOnly &&
+      onAssignmentUnpublishScores &&
+      a.scoreVisibility !== undefined &&
+      a.scoreVisibility !== 'none'
+    ) {
+      secondary.push({
+        id: 'unpublish-scores',
+        label: 'Unpublish scores',
+        icon: EyeOff,
+        onClick: async () => {
+          const ok = await showConfirm(
+            'Students will no longer be able to see their scores or responses. You can republish anytime.',
+            {
+              title: 'Unpublish scores',
+              variant: 'danger',
+              confirmLabel: 'Unpublish',
+            }
+          );
+          if (ok) await onAssignmentUnpublishScores(a);
+        },
       });
     }
 

--- a/components/widgets/QuizWidget/Widget.tsx
+++ b/components/widgets/QuizWidget/Widget.tsx
@@ -149,6 +149,7 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
     setAssignmentExportedResponseIds,
     shareAssignment,
     publishAssignmentScores,
+    unpublishAssignmentScores,
     syncAssignmentToLatest,
   } = useQuizAssignments(user?.uid);
 
@@ -1662,6 +1663,19 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
         onArchivePublishScores={(a) => {
           setPublishingAssignment(a);
         }}
+        onArchiveUnpublishScores={async (a) => {
+          // One-click unpublish — `unpublishAssignmentScores` is a
+          // cheap two-write batch (no Drive lookup, no grading).
+          try {
+            await unpublishAssignmentScores(a.id);
+            addToast('Scores unpublished.', 'success');
+          } catch (err) {
+            addToast(
+              err instanceof Error ? err.message : 'Failed to unpublish scores',
+              'error'
+            );
+          }
+        }}
         onArchivePauseResume={async (a) => {
           try {
             if (a.status === 'paused') {
@@ -1898,28 +1912,15 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
           currentVisibility={publishingAssignment.scoreVisibility}
           onClose={() => setPublishingAssignment(null)}
           onConfirm={async (visibility) => {
-            // Resolve the canonical quiz from Drive so the score
-            // computation has access to every question's correctAnswer
-            // (the session's `publicQuestions` strips them for student
-            // safety). When unpublishing the quiz lookup is skipped —
-            // the hook's `'none'` path doesn't read questions.
+            // `'none'` routes to the dedicated `unpublishAssignmentScores`
+            // (no Drive lookup, no grading). Other levels resolve the
+            // canonical quiz from Drive so the score computation has
+            // access to every question's `correctAnswer` — the session's
+            // `publicQuestions` strips them for student safety.
             const target = publishingAssignment;
             try {
               if (visibility === 'none') {
-                await publishAssignmentScores(
-                  target.id,
-                  // Empty placeholder QuizData — the 'none' branch never
-                  // reads it. Cheaper than re-loading the quiz from Drive
-                  // for a flag-flip.
-                  {
-                    id: target.quizId,
-                    title: target.quizTitle,
-                    questions: [],
-                    createdAt: 0,
-                    updatedAt: 0,
-                  },
-                  visibility
-                );
+                await unpublishAssignmentScores(target.id);
                 addToast('Scores unpublished.', 'success');
                 setPublishingAssignment(null);
                 return;

--- a/components/widgets/QuizWidget/components/AnnotatedResponseView.tsx
+++ b/components/widgets/QuizWidget/components/AnnotatedResponseView.tsx
@@ -42,6 +42,7 @@ import type { WrittenAnswerAnnotation } from '@/types';
 import {
   getPlainTextOffsetFromRange,
   parseSnapshotRoot,
+  PREVIEW_ANNOTATION_ID,
   renderAnnotatedSnapshot,
 } from '@/utils/writtenAnnotations';
 
@@ -424,9 +425,34 @@ const EditView: React.FC<EditProps> = ({
   // `annotations` mutates per keypress and would otherwise re-
   // DOMParse the whole snapshot each time.
   const parsedRoot = useMemo(() => parseSnapshotRoot(snapshot), [snapshot]);
+  // While the teacher is mid-selection (pending state), inject a
+  // synthetic annotation so the renderer shows a preview mark over
+  // the drag range. The textarea's autoFocus collapses the native
+  // browser selection an instant after mouseup, so without this
+  // visual the teacher loses all feedback about what they highlighted
+  // until they pick a color. The synthetic annotation is never
+  // persisted — `commitPending` builds the real one from the same
+  // offsets when a color is clicked.
+  const annotationsForRender = useMemo<WrittenAnswerAnnotation[]>(() => {
+    if (!pendingSelection) return annotations;
+    return [
+      ...annotations,
+      {
+        id: PREVIEW_ANNOTATION_ID,
+        from: pendingSelection.from,
+        to: pendingSelection.to,
+        authorUid,
+        createdAt: 0,
+      },
+    ];
+  }, [annotations, pendingSelection, authorUid]);
   const tree = useMemo(
-    () => renderAnnotatedSnapshot({ root: parsedRoot, annotations }),
-    [parsedRoot, annotations]
+    () =>
+      renderAnnotatedSnapshot({
+        root: parsedRoot,
+        annotations: annotationsForRender,
+      }),
+    [parsedRoot, annotationsForRender]
   );
 
   // Compute the plaintext offsets of the current text selection and
@@ -552,14 +578,16 @@ const EditView: React.FC<EditProps> = ({
       const mark = (e.target as HTMLElement).closest('mark');
       if (mark) {
         const id = mark.getAttribute('data-annotation-id');
-        if (id) {
-          setPendingSelection(null);
-          setPendingComment('');
-          onActiveIdChange(id);
-          // Clear any selection so a stray mouseup doesn't immediately
-          // open the pending-selection popover.
-          window.getSelection()?.removeAllRanges();
-        }
+        // Clicks on the synthetic preview mark are no-ops — the user
+        // is just clicking on their own pending selection, the
+        // popover is already open for it.
+        if (!id || id === PREVIEW_ANNOTATION_ID) return;
+        setPendingSelection(null);
+        setPendingComment('');
+        onActiveIdChange(id);
+        // Clear any selection so a stray mouseup doesn't immediately
+        // open the pending-selection popover.
+        window.getSelection()?.removeAllRanges();
         return;
       }
       // Bare-text click — only dismiss if a popover is open and the

--- a/components/widgets/QuizWidget/components/AnnotatedResponseView.tsx
+++ b/components/widgets/QuizWidget/components/AnnotatedResponseView.tsx
@@ -391,6 +391,13 @@ const EditView: React.FC<EditProps> = ({
   const articleRef = useRef<HTMLElement | null>(null);
   const containerRef = useRef<HTMLDivElement | null>(null);
   const reactId = useId();
+  // True between a drag-completing `mouseup` and the synthetic `click`
+  // that browsers fire on the same gesture. The popover's textarea
+  // `autoFocus`-es when it mounts, which collapses the text selection
+  // before our `click` handler runs — without this flag, the
+  // bare-text click would interpret the collapsed selection as "user
+  // clicked away" and dismiss the popover the mouseup just opened.
+  const justOpenedPendingRef = useRef(false);
 
   // Pending text selection waiting for the teacher to pick a color.
   // Until they do, the annotation does NOT exist — the popover is
@@ -460,6 +467,17 @@ const EditView: React.FC<EditProps> = ({
       to: offsets.to,
       placement,
     });
+    // The synthetic `click` that follows this drag-completing mouseup
+    // will see the textarea's autoFocus-collapsed selection — flag the
+    // next click as "from this gesture" so handleArticleClick skips its
+    // dismiss path. The setTimeout(0) clears the flag after the
+    // immediate event-loop tick so a mouseup that never produces a
+    // matching click (e.g. drag ends outside the article) doesn't
+    // swallow a future, unrelated click.
+    justOpenedPendingRef.current = true;
+    setTimeout(() => {
+      justOpenedPendingRef.current = false;
+    }, 0);
   }, [onActiveIdChange]);
 
   // Commit a pending selection as a new annotation. Called when the
@@ -522,6 +540,15 @@ const EditView: React.FC<EditProps> = ({
 
   const handleArticleClick = useCallback(
     (e: React.MouseEvent<HTMLElement>) => {
+      // Swallow the synthetic click that follows a drag-completing
+      // mouseup. The selection is briefly collapsed by the textarea's
+      // autoFocus, which would otherwise look like "user clicked
+      // outside their selection" and dismiss the popover we just
+      // opened.
+      if (justOpenedPendingRef.current) {
+        justOpenedPendingRef.current = false;
+        return;
+      }
       const mark = (e.target as HTMLElement).closest('mark');
       if (mark) {
         const id = mark.getAttribute('data-annotation-id');
@@ -535,10 +562,8 @@ const EditView: React.FC<EditProps> = ({
         }
         return;
       }
-      // Bare-text click — only dismiss if this is a true click (no
-      // active selection). Without this guard, finishing a drag-
-      // selection lands a `click` event on bare text and would close
-      // the popover the mouseup handler just opened.
+      // Bare-text click — only dismiss if a popover is open and the
+      // user isn't mid-selection.
       if (!activeId && !pendingSelection) return;
       const sel = window.getSelection();
       if (sel && !sel.isCollapsed) return;

--- a/components/widgets/QuizWidget/components/AnnotatedResponseView.tsx
+++ b/components/widgets/QuizWidget/components/AnnotatedResponseView.tsx
@@ -272,7 +272,7 @@ const ReadOnlyView: React.FC<ReadProps> = ({ snapshot, annotations }) => {
       <div className="flex flex-col gap-3">
         <article
           ref={articleRef}
-          className="rounded-xl border border-slate-700 bg-slate-800/60 p-4 text-sm leading-relaxed text-slate-100 max-w-none [&_mark]:transition-colors"
+          className="rounded-xl border border-slate-700 bg-slate-800/60 p-4 text-sm leading-relaxed text-slate-100 max-w-none min-w-0 break-words [&_mark]:transition-colors"
           onMouseOver={(e) => {
             const t = (e.target as HTMLElement).closest('mark');
             if (t) setHoveredId(t.getAttribute('data-annotation-id'));
@@ -703,7 +703,7 @@ const EditView: React.FC<EditProps> = ({
     <div ref={containerRef} className="relative">
       <article
         ref={articleRef}
-        className="rounded-xl border border-slate-200 bg-white p-6 text-base leading-relaxed text-slate-800 max-w-none cursor-text select-text"
+        className="rounded-xl border border-slate-200 bg-white p-6 text-base leading-relaxed text-slate-800 max-w-none min-w-0 break-words cursor-text select-text"
         onMouseUp={handleMouseUp}
         onClick={handleArticleClick}
       >

--- a/components/widgets/QuizWidget/components/AnnotatedResponseView.tsx
+++ b/components/widgets/QuizWidget/components/AnnotatedResponseView.tsx
@@ -5,17 +5,16 @@
  *  - Renders the frozen `gradingSnapshot` with existing marks via
  *    `renderAnnotatedSnapshot` (offsets computed against the snapshot's
  *    plaintext projection).
- *  - On mouseup with a non-empty selection, the annotation is created
- *    immediately (default yellow highlight) and the editor popover opens
- *    anchored next to the new mark — same UI the teacher gets when they
- *    click an existing highlight. From there they can change color,
- *    add a margin comment, or dismiss.
- *  - When an annotation is active (selected by the teacher or just
- *    created), renders an editor popover anchored next to the
- *    highlighted mark so the comment input is visible exactly
- *    where the teacher is looking. The teacher's right-side annotations
- *    list lives in the parent grader sidebar — clicking a list item
- *    sets `activeId` here and the popover opens at the mark.
+ *  - On mouseup with a non-empty selection, the editor popover opens
+ *    anchored to the selection — but the annotation is NOT created
+ *    until the teacher picks a color. Picking a color commits the
+ *    highlight (carrying any text already typed into the comment
+ *    textarea) and the popover stays open so the teacher can keep
+ *    typing or change the color.
+ *  - The same popover opens when the teacher clicks an existing
+ *    highlight, anchored next to its `<mark>`.
+ *  - Popover dismisses via X, Esc, Ctrl/Cmd+Enter inside the textarea,
+ *    or clicking outside on bare text.
  *
  * In `mode="read"` (student review surface after publish):
  *  - Same snapshot rendered read-only.
@@ -393,6 +392,25 @@ const EditView: React.FC<EditProps> = ({
   const containerRef = useRef<HTMLDivElement | null>(null);
   const reactId = useId();
 
+  // Pending text selection waiting for the teacher to pick a color.
+  // Until they do, the annotation does NOT exist — the popover is
+  // shown anchored to the selection rect, and the teacher can type
+  // into the comment textarea ahead of picking a color. The first
+  // color click commits both the highlight and the typed draft as a
+  // new annotation, then the popover transitions to "editing an
+  // existing annotation" mode.
+  const [pendingSelection, setPendingSelection] = useState<{
+    x: number;
+    y: number;
+    from: number;
+    to: number;
+    placement: 'below' | 'above';
+  } | null>(null);
+  // Comment text typed before a color is picked. Carried into the
+  // annotation when the teacher commits a color. Cleared when the
+  // popover dismisses or after a successful commit.
+  const [pendingComment, setPendingComment] = useState('');
+
   // Same memoization split as ReadOnlyView: parse once per snapshot,
   // re-walk on annotation changes. Critical in edit mode because the
   // popover comment editor calls `onChange` on every keystroke, so
@@ -405,12 +423,13 @@ const EditView: React.FC<EditProps> = ({
   );
 
   // Compute the plaintext offsets of the current text selection and
-  // immediately create a yellow-default annotation, then open the
-  // editor popover anchored to the new mark. The editor lets the
-  // teacher change the color, add a margin comment, or dismiss —
-  // collapsing the previous two-step palette → editor flow into one.
+  // open the editor popover anchored to the selection rect. The
+  // annotation is NOT created here — it's deferred until the teacher
+  // picks a color, so the popover acts as a single point-of-decision
+  // for color + comment instead of forcing a two-step (palette → edit)
+  // flow.
   const handleMouseUp = useCallback(() => {
-    if (!articleRef.current) return;
+    if (!articleRef.current || !containerRef.current) return;
     const selection = window.getSelection();
     if (!selection || selection.isCollapsed) return;
     const range = selection.getRangeAt(0);
@@ -426,20 +445,61 @@ const EditView: React.FC<EditProps> = ({
     }
     const rect = range.getBoundingClientRect();
     if (rect.width === 0 && rect.height === 0) return;
-
-    const id = `${reactId}-${Date.now()}-${++annotationSeq}`;
-    const next: WrittenAnswerAnnotation = {
-      id,
+    const containerRect = containerRef.current.getBoundingClientRect();
+    const x = rect.left - containerRect.left + rect.width / 2;
+    const below = rect.bottom - containerRect.top + 8;
+    const above = rect.top - containerRect.top - 8;
+    const placement: 'below' | 'above' =
+      below + 220 > containerRect.height && above > 120 ? 'above' : 'below';
+    onActiveIdChange(null);
+    setPendingComment('');
+    setPendingSelection({
+      x,
+      y: placement === 'below' ? below : above,
       from: offsets.from,
       to: offsets.to,
-      highlightColor: 'yellow',
+      placement,
+    });
+  }, [onActiveIdChange]);
+
+  // Commit a pending selection as a new annotation. Called when the
+  // teacher picks the first color in the popover; carries any text
+  // already typed in the textarea into the annotation's comment.
+  const commitPending = useCallback(
+    (color: Color) => {
+      if (!pendingSelection) return;
+      const id = `${reactId}-${Date.now()}-${++annotationSeq}`;
+      const next: WrittenAnswerAnnotation = {
+        id,
+        from: pendingSelection.from,
+        to: pendingSelection.to,
+        highlightColor: color,
+        authorUid,
+        createdAt: Date.now(),
+        ...(pendingComment.trim() ? { comment: pendingComment.trim() } : {}),
+      };
+      onChange([...annotations, next]);
+      onActiveIdChange(id);
+      setPendingSelection(null);
+      setPendingComment('');
+      window.getSelection()?.removeAllRanges();
+    },
+    [
+      pendingSelection,
+      pendingComment,
+      reactId,
       authorUid,
-      createdAt: Date.now(),
-    };
-    onChange([...annotations, next]);
-    onActiveIdChange(id);
-    selection.removeAllRanges();
-  }, [reactId, authorUid, onChange, annotations, onActiveIdChange]);
+      onChange,
+      annotations,
+      onActiveIdChange,
+    ]
+  );
+
+  const closePopover = useCallback(() => {
+    setPendingSelection(null);
+    setPendingComment('');
+    onActiveIdChange(null);
+  }, [onActiveIdChange]);
 
   // Dismiss the popover on Escape. Listener is scoped to the container
   // so an Escape pressed inside the grading sidebar (Points input,
@@ -450,15 +510,15 @@ const EditView: React.FC<EditProps> = ({
     if (!containerEl) return;
     const onKey = (e: KeyboardEvent) => {
       if (e.key !== 'Escape') return;
-      if (!activeId) return;
-      onActiveIdChange(null);
+      if (!activeId && !pendingSelection) return;
+      closePopover();
       // Only stop propagation when we actually handled the key, so the
       // parent modal can still close via Esc when nothing's open here.
       e.stopPropagation();
     };
     containerEl.addEventListener('keydown', onKey);
     return () => containerEl.removeEventListener('keydown', onKey);
-  }, [activeId, onActiveIdChange]);
+  }, [activeId, pendingSelection, closePopover]);
 
   const handleArticleClick = useCallback(
     (e: React.MouseEvent<HTMLElement>) => {
@@ -466,23 +526,25 @@ const EditView: React.FC<EditProps> = ({
       if (mark) {
         const id = mark.getAttribute('data-annotation-id');
         if (id) {
+          setPendingSelection(null);
+          setPendingComment('');
           onActiveIdChange(id);
           // Clear any selection so a stray mouseup doesn't immediately
-          // create a new annotation.
+          // open the pending-selection popover.
           window.getSelection()?.removeAllRanges();
         }
         return;
       }
-      // Bare-text click — only dismiss the popover if this is a true
-      // click (no active selection). Without this guard, finishing a
-      // drag-selection lands a `click` event on bare text and would
-      // close the popover the create-on-mouseup flow just opened.
-      if (!activeId) return;
+      // Bare-text click — only dismiss if this is a true click (no
+      // active selection). Without this guard, finishing a drag-
+      // selection lands a `click` event on bare text and would close
+      // the popover the mouseup handler just opened.
+      if (!activeId && !pendingSelection) return;
       const sel = window.getSelection();
       if (sel && !sel.isCollapsed) return;
-      onActiveIdChange(null);
+      closePopover();
     },
-    [activeId, onActiveIdChange]
+    [activeId, pendingSelection, onActiveIdChange, closePopover]
   );
 
   const updateActiveAnnotation = useCallback(
@@ -565,6 +627,25 @@ const EditView: React.FC<EditProps> = ({
     );
   }, [activeId, tree]);
 
+  // Pending state owns its own coordinates (from the selection rect);
+  // active state uses the mark-anchored position computed above. Only
+  // one is ever non-null at a time.
+  const popover = pendingSelection
+    ? {
+        kind: 'pending' as const,
+        x: pendingSelection.x,
+        y: pendingSelection.y,
+        placement: pendingSelection.placement,
+      }
+    : active && popoverPos
+      ? {
+          kind: 'active' as const,
+          x: popoverPos.x,
+          y: popoverPos.y,
+          placement: popoverPos.placement,
+        }
+      : null;
+
   return (
     <div ref={containerRef} className="relative">
       <article
@@ -575,22 +656,35 @@ const EditView: React.FC<EditProps> = ({
       >
         {tree}
       </article>
-      {active && popoverPos && (
-        // `key={active.id}` remounts the popover for each annotation, so
-        // its internal `commentDraft` state is reset cleanly without
-        // having to track a `prevActiveId` reset pattern in the parent.
+      {popover && (
+        // `key` remounts the popover when transitioning between
+        // pending → editing or between two different active annotations,
+        // so the internal `commentDraft` state resets cleanly without
+        // a prop-sync dance in the parent. `popover.kind === 'active'`
+        // statically narrows `active` to non-null (the popover memo
+        // only sets `active` when `active && popoverPos`).
         <AnchoredAnnotationEditor
-          key={active.id}
-          annotation={active}
-          x={popoverPos.x}
-          y={popoverPos.y}
-          placement={popoverPos.placement}
+          key={popover.kind === 'active' && active ? active.id : 'pending'}
+          annotation={popover.kind === 'active' ? active : null}
+          pendingCommentDraft={
+            popover.kind === 'pending' ? pendingComment : undefined
+          }
+          onPendingCommentChange={
+            popover.kind === 'pending' ? setPendingComment : undefined
+          }
+          x={popover.x}
+          y={popover.y}
+          placement={popover.placement}
           onCommentChange={(v) =>
             updateActiveAnnotation({ comment: v.trim() || undefined })
           }
-          onColorChange={(c) => updateActiveAnnotation({ highlightColor: c })}
+          onColorChange={(c) =>
+            popover.kind === 'pending'
+              ? commitPending(c)
+              : updateActiveAnnotation({ highlightColor: c })
+          }
           onDelete={deleteActive}
-          onClose={() => onActiveIdChange(null)}
+          onClose={closePopover}
         />
       )}
     </div>
@@ -598,24 +692,46 @@ const EditView: React.FC<EditProps> = ({
 };
 
 /**
- * Editor popover anchored to the active mark. Auto-focuses its textarea on
- * mount (parent uses `key={annotation.id}` to remount per annotation, which
- * also resets the internal `commentDraft`). Uses `role="group"` rather than
- * `role="dialog"` to communicate "non-modal inline editor" — there's no
- * focus trap, the document under it is still interactive, and the parent
- * scopes its own Escape handler.
+ * Editor popover for annotations. Two modes:
+ *
+ *  - **Pending** (`annotation === null`): renders for an in-progress text
+ *    selection that hasn't been committed yet. No color is selected
+ *    initially; clicking any color commits the highlight (carrying any
+ *    text already typed into the textarea, via the parent's
+ *    `pendingCommentDraft` / `onPendingCommentChange`). Delete is
+ *    hidden.
+ *  - **Active** (`annotation !== null`): renders for an existing
+ *    annotation; current color is highlighted, comment textarea is
+ *    hydrated, delete is available.
+ *
+ * Auto-focuses the textarea on mount; parent uses `key` to remount on
+ * transitions so the internal draft resets cleanly. `role="group"`
+ * communicates "non-modal inline editor" — no focus trap, document
+ * under it is still interactive, parent scopes the Escape handler.
+ *
+ * Ctrl/Cmd+Enter inside the textarea dismisses the popover so the
+ * teacher can rapid-fire highlights without reaching for the X.
  */
 const AnchoredAnnotationEditor: React.FC<{
-  annotation: WrittenAnswerAnnotation;
+  /** Existing annotation in edit mode; `null` in pending-selection mode. */
+  annotation: WrittenAnswerAnnotation | null;
+  /** Parent-owned textarea state for pending mode (so it survives commit). */
+  pendingCommentDraft?: string;
+  onPendingCommentChange?: (v: string) => void;
   x: number;
   y: number;
   placement: 'below' | 'above';
+  /** Edit-mode only — committed comment writes pass through here. */
   onCommentChange: (v: string) => void;
+  /** Color click. In pending mode this commits; in active mode it updates. */
   onColorChange: (c: Color) => void;
+  /** Edit-mode only. Not rendered in pending mode. */
   onDelete: () => void;
   onClose: () => void;
 }> = ({
   annotation,
+  pendingCommentDraft,
+  onPendingCommentChange,
   x,
   y,
   placement,
@@ -625,12 +741,12 @@ const AnchoredAnnotationEditor: React.FC<{
   onClose,
 }) => {
   const labelId = useId();
-  // Local draft state. Initialized from the annotation that mounted the
-  // editor; reset is handled by the parent via `key`, so we never have to
-  // sync to incoming prop changes ourselves.
-  const [commentDraft, setCommentDraft] = useState<string>(
-    annotation.comment ?? ''
-  );
+  const isPending = annotation === null;
+  // Edit-mode local draft. Pending mode uses the parent-owned draft via
+  // `pendingCommentDraft` so the value survives the commit transition
+  // (parent remounts this component with `key='pending' → key=<newId>`).
+  const [editDraft, setEditDraft] = useState<string>(annotation?.comment ?? '');
+  const commentValue = isPending ? (pendingCommentDraft ?? '') : editDraft;
   return (
     <div
       role="group"
@@ -640,12 +756,12 @@ const AnchoredAnnotationEditor: React.FC<{
       } w-72 rounded-xl border border-violet-300 bg-white p-3 shadow-xl flex flex-col gap-2`}
       style={{ left: x, top: y }}
       // Block clicks inside the popover from bubbling to the article
-      // (which would clear activeId via `handleArticleClick`).
+      // (which would close it via `handleArticleClick`).
       onClick={(e) => e.stopPropagation()}
       onMouseUp={(e) => e.stopPropagation()}
     >
       <span id={labelId} className="sr-only">
-        Edit annotation
+        {isPending ? 'Choose highlight color' : 'Edit annotation'}
       </span>
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-1">
@@ -657,23 +773,25 @@ const AnchoredAnnotationEditor: React.FC<{
               title={c.label}
               onClick={() => onColorChange(c.id)}
               className={`w-5 h-5 rounded-full ${c.swatch} ${
-                annotation.highlightColor === c.id
+                !isPending && annotation.highlightColor === c.id
                   ? 'ring-2 ring-violet-600'
-                  : 'ring-1 ring-slate-300'
+                  : 'ring-1 ring-slate-300 hover:ring-2 hover:ring-violet-400'
               } transition`}
             />
           ))}
         </div>
         <div className="flex items-center gap-0.5">
-          <button
-            type="button"
-            aria-label="Delete annotation"
-            title="Delete"
-            onClick={onDelete}
-            className="p-1 rounded text-slate-500 hover:bg-brand-red-lighter/40 hover:text-brand-red-dark transition-colors"
-          >
-            <Trash2 className="w-4 h-4" />
-          </button>
+          {!isPending && (
+            <button
+              type="button"
+              aria-label="Delete annotation"
+              title="Delete"
+              onClick={onDelete}
+              className="p-1 rounded text-slate-500 hover:bg-brand-red-lighter/40 hover:text-brand-red-dark transition-colors"
+            >
+              <Trash2 className="w-4 h-4" />
+            </button>
+          )}
           <button
             type="button"
             aria-label="Close annotation editor"
@@ -687,14 +805,30 @@ const AnchoredAnnotationEditor: React.FC<{
       </div>
       <textarea
         autoFocus
-        value={commentDraft}
+        value={commentValue}
         onChange={(e) => {
           const next = e.target.value;
-          setCommentDraft(next);
-          onCommentChange(next);
+          if (isPending) {
+            onPendingCommentChange?.(next);
+          } else {
+            setEditDraft(next);
+            onCommentChange(next);
+          }
+        }}
+        onKeyDown={(e) => {
+          // Ctrl/Cmd+Enter dismisses the popover so the teacher can
+          // rapid-fire highlights without reaching for the X.
+          if (e.key === 'Enter' && (e.ctrlKey || e.metaKey)) {
+            e.preventDefault();
+            onClose();
+          }
         }}
         rows={3}
-        placeholder="Margin comment (optional)"
+        placeholder={
+          isPending
+            ? 'Margin comment (optional) — pick a color to commit'
+            : 'Margin comment (optional)'
+        }
         className="w-full px-2 py-1.5 bg-white border border-slate-300 rounded text-sm text-slate-800 placeholder:text-slate-400 focus:outline-none focus:ring-2 focus:ring-violet-400/40 focus:border-violet-400 resize-none"
       />
     </div>

--- a/components/widgets/QuizWidget/components/AnnotatedResponseView.tsx
+++ b/components/widgets/QuizWidget/components/AnnotatedResponseView.tsx
@@ -5,13 +5,14 @@
  *  - Renders the frozen `gradingSnapshot` with existing marks via
  *    `renderAnnotatedSnapshot` (offsets computed against the snapshot's
  *    plaintext projection).
- *  - On mouseup with a non-empty selection, surfaces a small floating
- *    palette anchored to the selection's bounding rect; choosing a color
- *    creates an annotation. Choosing the comment icon also creates an
- *    annotation and selects it.
+ *  - On mouseup with a non-empty selection, the annotation is created
+ *    immediately (default yellow highlight) and the editor popover opens
+ *    anchored next to the new mark — same UI the teacher gets when they
+ *    click an existing highlight. From there they can change color,
+ *    add a margin comment, or dismiss.
  *  - When an annotation is active (selected by the teacher or just
- *    created via comment-icon), renders an editor popover anchored next
- *    to the highlighted mark so the comment input is visible exactly
+ *    created), renders an editor popover anchored next to the
+ *    highlighted mark so the comment input is visible exactly
  *    where the teacher is looking. The teacher's right-side annotations
  *    list lives in the parent grader sidebar — clicking a list item
  *    sets `activeId` here and the popover opens at the mark.
@@ -37,7 +38,7 @@ import React, {
   useRef,
   useState,
 } from 'react';
-import { MessageSquare, Trash2, X } from 'lucide-react';
+import { Trash2, X } from 'lucide-react';
 import type { WrittenAnswerAnnotation } from '@/types';
 import {
   getPlainTextOffsetFromRange,
@@ -391,12 +392,6 @@ const EditView: React.FC<EditProps> = ({
   const articleRef = useRef<HTMLElement | null>(null);
   const containerRef = useRef<HTMLDivElement | null>(null);
   const reactId = useId();
-  const [palette, setPalette] = useState<{
-    x: number;
-    y: number;
-    from: number;
-    to: number;
-  } | null>(null);
 
   // Same memoization split as ReadOnlyView: parse once per snapshot,
   // re-walk on annotation changes. Critical in edit mode because the
@@ -409,68 +404,61 @@ const EditView: React.FC<EditProps> = ({
     [parsedRoot, annotations]
   );
 
-  // Compute the rectangle of the current text selection inside the
-  // article and convert it to plaintext offsets. If nothing's selected
-  // (or the selection is outside the article), close the palette.
+  // Compute the plaintext offsets of the current text selection and
+  // immediately create a yellow-default annotation, then open the
+  // editor popover anchored to the new mark. The editor lets the
+  // teacher change the color, add a margin comment, or dismiss —
+  // collapsing the previous two-step palette → editor flow into one.
   const handleMouseUp = useCallback(() => {
-    if (!articleRef.current || !containerRef.current) return;
+    if (!articleRef.current) return;
     const selection = window.getSelection();
-    if (!selection || selection.isCollapsed) {
-      setPalette(null);
-      return;
-    }
+    if (!selection || selection.isCollapsed) return;
     const range = selection.getRangeAt(0);
     const offsets = getPlainTextOffsetFromRange(articleRef.current, range);
     if (!offsets) {
-      // Surface this — a silently-dismissed palette looks like the
-      // feature is broken. Common cause: the selection straddles the
-      // article and an adjacent element.
-      if (!selection.isCollapsed) {
-        console.warn(
-          '[AnnotatedResponseView] selection could not be resolved to a snapshot offset (does it escape the response?)'
-        );
-      }
-      setPalette(null);
+      // Surface this — a silently-no-op selection looks like the feature
+      // is broken. Common cause: the selection straddles the article
+      // and an adjacent element.
+      console.warn(
+        '[AnnotatedResponseView] selection could not be resolved to a snapshot offset (does it escape the response?)'
+      );
       return;
     }
     const rect = range.getBoundingClientRect();
-    if (rect.width === 0 && rect.height === 0) {
-      setPalette(null);
-      return;
-    }
-    const containerRect = containerRef.current.getBoundingClientRect();
-    setPalette({
-      x: rect.left - containerRect.left + rect.width / 2,
-      y: rect.top - containerRect.top - 8,
+    if (rect.width === 0 && rect.height === 0) return;
+
+    const id = `${reactId}-${Date.now()}-${++annotationSeq}`;
+    const next: WrittenAnswerAnnotation = {
+      id,
       from: offsets.from,
       to: offsets.to,
-    });
-    onActiveIdChange(null);
-  }, [onActiveIdChange]);
+      highlightColor: 'yellow',
+      authorUid,
+      createdAt: Date.now(),
+    };
+    onChange([...annotations, next]);
+    onActiveIdChange(id);
+    selection.removeAllRanges();
+  }, [reactId, authorUid, onChange, annotations, onActiveIdChange]);
 
-  // Dismiss the palette / popover on Escape. Listener is scoped to the
-  // container so an Escape pressed inside the grading sidebar (Points
-  // input, Overall comment textarea) still bubbles to the parent modal's
-  // close handler.
+  // Dismiss the popover on Escape. Listener is scoped to the container
+  // so an Escape pressed inside the grading sidebar (Points input,
+  // Overall comment textarea) still bubbles to the parent modal's close
+  // handler.
   useEffect(() => {
     const containerEl = containerRef.current;
     if (!containerEl) return;
     const onKey = (e: KeyboardEvent) => {
       if (e.key !== 'Escape') return;
-      if (palette) {
-        setPalette(null);
-      } else if (activeId) {
-        onActiveIdChange(null);
-      } else {
-        return;
-      }
+      if (!activeId) return;
+      onActiveIdChange(null);
       // Only stop propagation when we actually handled the key, so the
       // parent modal can still close via Esc when nothing's open here.
       e.stopPropagation();
     };
     containerEl.addEventListener('keydown', onKey);
     return () => containerEl.removeEventListener('keydown', onKey);
-  }, [palette, activeId, onActiveIdChange]);
+  }, [activeId, onActiveIdChange]);
 
   const handleArticleClick = useCallback(
     (e: React.MouseEvent<HTMLElement>) => {
@@ -479,9 +467,8 @@ const EditView: React.FC<EditProps> = ({
         const id = mark.getAttribute('data-annotation-id');
         if (id) {
           onActiveIdChange(id);
-          setPalette(null);
-          // Clear any selection so the palette doesn't immediately
-          // reopen on mouseup.
+          // Clear any selection so a stray mouseup doesn't immediately
+          // create a new annotation.
           window.getSelection()?.removeAllRanges();
         }
         return;
@@ -489,35 +476,13 @@ const EditView: React.FC<EditProps> = ({
       // Bare-text click — only dismiss the popover if this is a true
       // click (no active selection). Without this guard, finishing a
       // drag-selection lands a `click` event on bare text and would
-      // close the popover the teacher just opened via the palette.
+      // close the popover the create-on-mouseup flow just opened.
       if (!activeId) return;
       const sel = window.getSelection();
       if (sel && !sel.isCollapsed) return;
       onActiveIdChange(null);
     },
     [activeId, onActiveIdChange]
-  );
-
-  const createAnnotation = useCallback(
-    (color: Color, withCommentInput: boolean) => {
-      if (!palette) return;
-      const id = `${reactId}-${Date.now()}-${++annotationSeq}`;
-      const next: WrittenAnswerAnnotation = {
-        id,
-        from: palette.from,
-        to: palette.to,
-        highlightColor: color,
-        authorUid,
-        createdAt: Date.now(),
-      };
-      onChange([...annotations, next]);
-      setPalette(null);
-      if (withCommentInput) {
-        onActiveIdChange(id);
-      }
-      window.getSelection()?.removeAllRanges();
-    },
-    [palette, reactId, authorUid, onChange, annotations, onActiveIdChange]
   );
 
   const updateActiveAnnotation = useCallback(
@@ -610,38 +575,6 @@ const EditView: React.FC<EditProps> = ({
       >
         {tree}
       </article>
-      {palette && (
-        <div
-          role="toolbar"
-          aria-label="Annotation palette"
-          className="absolute z-popover -translate-x-1/2 -translate-y-full flex items-center gap-1 px-1.5 py-1 bg-slate-900 text-white rounded-lg shadow-xl"
-          style={{ left: palette.x, top: palette.y }}
-          // Prevent the article's mouseup from clearing the selection
-          // before we read it; the palette handles its own clicks.
-          onMouseDown={(e) => e.preventDefault()}
-        >
-          {COLORS.map((c) => (
-            <button
-              key={c.id}
-              type="button"
-              aria-label={c.label}
-              title={c.label}
-              onClick={() => createAnnotation(c.id, false)}
-              className={`w-5 h-5 rounded-full ${c.swatch} ring-1 ring-white/40 hover:ring-2 hover:ring-white transition`}
-            />
-          ))}
-          <div className="w-px h-4 bg-slate-700 mx-0.5" />
-          <button
-            type="button"
-            aria-label="Add comment"
-            title="Add comment"
-            onClick={() => createAnnotation('yellow', true)}
-            className="p-1 rounded text-slate-300 hover:bg-slate-800 hover:text-white transition-colors"
-          >
-            <MessageSquare className="w-4 h-4" />
-          </button>
-        </div>
-      )}
       {active && popoverPos && (
         // `key={active.id}` remounts the popover for each annotation, so
         // its internal `commentDraft` state is reset cleanly without

--- a/components/widgets/QuizWidget/components/QuizManager.tsx
+++ b/components/widgets/QuizWidget/components/QuizManager.tsx
@@ -25,6 +25,7 @@ import {
   Trash2,
   BarChart3,
   Eye,
+  EyeOff,
   Link2,
   User,
   Zap,
@@ -336,6 +337,13 @@ interface QuizManagerProps {
    * kebab affordance.
    */
   onArchivePublishScores?: (assignment: QuizAssignment) => void | Promise<void>;
+  /**
+   * Revoke published score visibility in one click (skips the picker
+   * modal). Only surfaced when `assignment.scoreVisibility` is published.
+   */
+  onArchiveUnpublishScores?: (
+    assignment: QuizAssignment
+  ) => void | Promise<void>;
   onArchivePauseResume?: (assignment: QuizAssignment) => void | Promise<void>;
   onArchiveDeactivate?: (assignment: QuizAssignment) => void | Promise<void>;
   /** Reopen an ended assignment back to a paused state. */
@@ -498,6 +506,7 @@ export const QuizManager: React.FC<QuizManagerProps> = ({
   onArchiveEditSettings,
   onArchiveShare,
   onArchivePublishScores,
+  onArchiveUnpublishScores,
   onArchivePauseResume,
   onArchiveDeactivate,
   onArchiveReopen,
@@ -1134,6 +1143,28 @@ export const QuizManager: React.FC<QuizManagerProps> = ({
             : 'Publish scores',
         icon: Send,
         onClick: () => void onArchivePublishScores(a),
+      });
+    }
+    if (
+      onArchiveUnpublishScores &&
+      a.scoreVisibility &&
+      a.scoreVisibility !== 'none'
+    ) {
+      secondaries.push({
+        id: 'unpublish-scores',
+        label: 'Unpublish scores',
+        icon: EyeOff,
+        onClick: async () => {
+          const ok = await showConfirm(
+            'Students will no longer be able to see their scores or responses. You can republish anytime.',
+            {
+              title: 'Unpublish scores',
+              variant: 'danger',
+              confirmLabel: 'Unpublish',
+            }
+          );
+          if (ok) await onArchiveUnpublishScores(a);
+        },
       });
     }
     secondaries.push({

--- a/components/widgets/QuizWidget/components/QuizResults.tsx
+++ b/components/widgets/QuizWidget/components/QuizResults.tsx
@@ -1627,15 +1627,19 @@ const QuestionsTab: React.FC<{
   questions: QuizData['questions'];
   responses: QuizResponse[];
 }> = ({ questions, responses }) => {
-  // ⚡ Bolt: Pre-calculate counts of "answered" and "correct" per question.
-  // This avoids O(Q*R*A) iteration inside `questions.map` loop and instead
-  // uses a single O(R*A) pass with O(Q) rendering.
+  // ⚡ Bolt: Pre-calculate counts per question in a single pass.
+  // Auto-graded types track answered/correct; written types track
+  // answered/graded so partial credit (7/10 essay) isn't bucketed as
+  // "Missed" — graders found that misleading.
   const questionStats = React.useMemo(() => {
-    const stats: Record<string, { answered: number; correct: number }> = {};
+    const stats: Record<
+      string,
+      { answered: number; correct: number; graded: number }
+    > = {};
     const questionsById: Record<string, QuizQuestion> = {};
 
     questions.forEach((q) => {
-      stats[q.id] = { answered: 0, correct: 0 };
+      stats[q.id] = { answered: 0, correct: 0, graded: 0 };
       questionsById[q.id] = q;
     });
 
@@ -1646,15 +1650,11 @@ const QuestionsTab: React.FC<{
 
         if (qStats && q) {
           qStats.answered++;
-          // Written types pass through `gradeAnswer` with the response's
-          // manual grade (if any) so awarded == max still counts as
-          // correct in the accuracy widget. Ungraded written responses
-          // count toward `answered` but not `correct`.
-          const manualGrade =
-            q.type === 'short' || q.type === 'essay'
-              ? r.grading?.[q.id]
-              : undefined;
-          if (gradeAnswer(q, a.answer, manualGrade).isCorrect) {
+          const isWritten = q.type === 'short' || q.type === 'essay';
+          const manualGrade = isWritten ? r.grading?.[q.id] : undefined;
+          if (isWritten) {
+            if (manualGrade) qStats.graded++;
+          } else if (gradeAnswer(q, a.answer, manualGrade).isCorrect) {
             qStats.correct++;
           }
         }
@@ -1667,10 +1667,18 @@ const QuestionsTab: React.FC<{
   return (
     <div className="space-y-3">
       {questions.map((q, i) => {
-        const stats = questionStats[q.id] || { answered: 0, correct: 0 };
+        const stats = questionStats[q.id] || {
+          answered: 0,
+          correct: 0,
+          graded: 0,
+        };
+        const isWritten = q.type === 'short' || q.type === 'essay';
         const pct =
           stats.answered > 0
-            ? Math.round((stats.correct / stats.answered) * 100)
+            ? Math.round(
+                ((isWritten ? stats.graded : stats.correct) / stats.answered) *
+                  100
+              )
             : 0;
 
         return (
@@ -1721,7 +1729,8 @@ const QuestionsTab: React.FC<{
                     height: 'min(14px, 4cqmin)',
                   }}
                 />
-                {stats.correct} Correct
+                {isWritten ? stats.graded : stats.correct}{' '}
+                {isWritten ? 'Graded' : 'Correct'}
               </div>
               <div
                 className="flex items-center gap-1.5 text-brand-red-primary font-bold"
@@ -1733,7 +1742,8 @@ const QuestionsTab: React.FC<{
                     height: 'min(14px, 4cqmin)',
                   }}
                 />
-                {stats.answered - stats.correct} Missed
+                {stats.answered - (isWritten ? stats.graded : stats.correct)}{' '}
+                {isWritten ? 'Ungraded' : 'Missed'}
               </div>
             </div>
 

--- a/components/widgets/QuizWidget/components/WrittenResponseGrader.tsx
+++ b/components/widgets/QuizWidget/components/WrittenResponseGrader.tsx
@@ -19,9 +19,7 @@ import {
   ChevronLeft,
   ChevronRight,
   CheckCircle2,
-  Loader2,
   ShieldAlert,
-  X,
 } from 'lucide-react';
 import {
   QuizData,
@@ -32,6 +30,7 @@ import {
 import { sanitizeQuizResponse } from '@/utils/security';
 import { AnnotatedResponseView } from './AnnotatedResponseView';
 import { highlightClass, htmlToPlainText } from '@/utils/writtenAnnotations';
+import { EditorModalShell } from '@/components/common/EditorModalShell';
 
 interface WrittenResponseGraderProps {
   quiz: QuizData;
@@ -321,32 +320,23 @@ export const WrittenResponseGrader: React.FC<WrittenResponseGraderProps> = ({
 
   if (writtenQuestions.length === 0) {
     return (
-      <ModalShell onClose={onClose}>
-        <div className="p-10 text-center text-slate-600">
-          <p className="text-lg font-bold">
-            No written questions in this quiz.
-          </p>
-          <p className="text-sm text-slate-500 mt-2">
-            Manual grading is only available for short-answer and essay
-            questions.
-          </p>
-        </div>
-      </ModalShell>
+      <EmptyStateShell onClose={onClose}>
+        <p className="text-lg font-bold">No written questions in this quiz.</p>
+        <p className="text-sm text-slate-500 mt-2">
+          Manual grading is only available for short-answer and essay questions.
+        </p>
+      </EmptyStateShell>
     );
   }
 
   if (gradeableResponses.length === 0 || !response || !question) {
     return (
-      <ModalShell onClose={onClose}>
-        <div className="p-10 text-center text-slate-600">
-          <p className="text-lg font-bold">
-            No written responses to grade yet.
-          </p>
-          <p className="text-sm text-slate-500 mt-2">
-            Students haven&apos;t submitted any short-answer or essay responses.
-          </p>
-        </div>
-      </ModalShell>
+      <EmptyStateShell onClose={onClose}>
+        <p className="text-lg font-bold">No written responses to grade yet.</p>
+        <p className="text-sm text-slate-500 mt-2">
+          Students haven&apos;t submitted any short-answer or essay responses.
+        </p>
+      </EmptyStateShell>
     );
   }
 
@@ -356,125 +346,140 @@ export const WrittenResponseGrader: React.FC<WrittenResponseGraderProps> = ({
   const fullyGradedForThisQ = !!savedGrade;
   const isLastStudent = studentIdx >= gradeableResponses.length - 1;
 
-  return (
-    <ModalShell onClose={onClose}>
-      {/* Header */}
-      <header className="flex items-center justify-between px-5 py-3 border-b border-slate-200 bg-white">
-        <div className="flex items-center gap-3 min-w-0">
-          <button
-            onClick={goPrevStudent}
-            disabled={studentIdx === 0 || saving}
-            className="p-1.5 rounded text-slate-500 hover:bg-slate-100 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
-            aria-label="Previous student (←)"
-            title="Previous student (←)"
-          >
-            <ChevronLeft className="w-5 h-5" />
-          </button>
-          <div className="min-w-0">
-            <div className="text-xs text-slate-500 font-bold uppercase tracking-wider">
-              Student {studentIdx + 1} of {gradeableResponses.length}
-            </div>
-            <div className="text-sm font-bold text-slate-900 truncate">
-              {studentLabel}
-              {fullyGradedForThisQ && (
-                <span className="ml-2 inline-flex items-center gap-1 px-1.5 py-0.5 rounded bg-emerald-100 text-emerald-700 text-xxs uppercase tracking-wider">
-                  <CheckCircle2 className="w-3 h-3" />
-                  Graded
-                </span>
-              )}
-              {tabSwitches > 0 && (
-                <span
-                  className="ml-2 inline-flex items-center gap-1 px-1.5 py-0.5 rounded bg-amber-100 text-amber-700 text-xxs uppercase tracking-wider"
-                  title={`${tabSwitches} tab switch warning${tabSwitches === 1 ? '' : 's'} during the assessment`}
-                >
-                  <ShieldAlert className="w-3 h-3" />
-                  {tabSwitches} tab switch{tabSwitches === 1 ? '' : 'es'}
-                </span>
-              )}
-            </div>
-          </div>
-          <button
-            onClick={goNextStudent}
-            disabled={studentIdx >= gradeableResponses.length - 1 || saving}
-            className="p-1.5 rounded text-slate-500 hover:bg-slate-100 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
-            aria-label="Next student (→)"
-            title="Next student (→)"
-          >
-            <ChevronRight className="w-5 h-5" />
-          </button>
-        </div>
-        <button
-          onClick={onClose}
-          className="p-1.5 rounded text-slate-500 hover:bg-slate-100 transition-colors"
-          aria-label="Close grader"
-          title="Close (Esc)"
-        >
-          <X className="w-5 h-5" />
-        </button>
-      </header>
-
-      {/* Question switcher (only if there's more than one written Q) */}
-      {writtenQuestions.length > 1 && (
-        <div className="flex items-center gap-2 px-5 py-2 border-b border-slate-200 bg-slate-50">
-          <button
-            onClick={goPrevQuestion}
-            disabled={questionIdx === 0 || saving}
-            className="p-1 rounded text-slate-500 hover:bg-slate-200 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
-            aria-label="Previous question"
-          >
-            <ChevronLeft className="w-4 h-4" />
-          </button>
-          <div className="text-xs text-slate-600">
-            Question {questionIdx + 1} of {writtenQuestions.length}
-            <span className="ml-2 text-slate-400">·</span>
-            <span className="ml-2 capitalize">{question.type}</span>
-          </div>
-          <button
-            onClick={goNextQuestion}
-            disabled={questionIdx >= writtenQuestions.length - 1 || saving}
-            className="p-1 rounded text-slate-500 hover:bg-slate-200 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
-            aria-label="Next question"
-          >
-            <ChevronRight className="w-4 h-4" />
-          </button>
-        </div>
+  const subtitle = (
+    <span className="flex items-center gap-2 flex-wrap">
+      <span>
+        Student {studentIdx + 1} of {gradeableResponses.length}
+        <span className="mx-1.5 text-slate-300">·</span>
+        <span className="font-semibold text-slate-700">{studentLabel}</span>
+      </span>
+      {fullyGradedForThisQ && (
+        <span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded bg-emerald-100 text-emerald-700 text-xxs uppercase tracking-wider">
+          <CheckCircle2 className="w-3 h-3" />
+          Graded
+        </span>
       )}
+      {tabSwitches > 0 && (
+        <span
+          className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded bg-amber-100 text-amber-700 text-xxs uppercase tracking-wider"
+          title={`${tabSwitches} tab switch warning${tabSwitches === 1 ? '' : 's'} during the assessment`}
+        >
+          <ShieldAlert className="w-3 h-3" />
+          {tabSwitches} tab switch{tabSwitches === 1 ? '' : 'es'}
+        </span>
+      )}
+      {writtenQuestions.length > 1 && (
+        <span>
+          <span className="mx-1.5 text-slate-300">·</span>
+          Question {questionIdx + 1} of {writtenQuestions.length}
+          <span className="mx-1.5 text-slate-300">·</span>
+          <span className="capitalize">{question.type}</span>
+        </span>
+      )}
+    </span>
+  );
 
-      {/* Body — 2-pane: response article (flex-1) + grading sidebar (~400px) */}
-      <div className="flex-1 grid grid-cols-[1fr_400px] min-h-0">
-        <section className="overflow-y-auto p-8 bg-slate-50">
-          <h3 className="text-sm font-bold uppercase tracking-wider text-slate-500 mb-2">
-            Question
-          </h3>
-          <p className="text-lg font-bold text-slate-900 mb-8 leading-snug">
-            {question.text}
-          </p>
+  const headerExtras = (
+    <>
+      <button
+        onClick={goPrevStudent}
+        disabled={studentIdx === 0 || saving}
+        className="p-1.5 rounded text-slate-500 hover:bg-slate-100 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+        aria-label="Previous student (←)"
+        title="Previous student (←)"
+      >
+        <ChevronLeft className="w-5 h-5" />
+      </button>
+      <button
+        onClick={goNextStudent}
+        disabled={studentIdx >= gradeableResponses.length - 1 || saving}
+        className="p-1.5 rounded text-slate-500 hover:bg-slate-100 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+        aria-label="Next student (→)"
+        title="Next student (→)"
+      >
+        <ChevronRight className="w-5 h-5" />
+      </button>
+    </>
+  );
 
-          <h3 className="text-sm font-bold uppercase tracking-wider text-slate-500 mb-2">
-            Student response
-          </h3>
-          {studentAnswer ? (
-            <AnnotatedResponseView
-              mode="edit"
-              // Once we've saved annotations, the snapshot is the
-              // source of truth; until then, default to the live
-              // sanitized answer so a teacher can start selecting text
-              // even on a never-graded response.
-              snapshot={
-                savedGrade?.gradingSnapshot ??
-                sanitizeQuizResponse(studentAnswer)
-              }
-              annotations={draftAnnotations}
-              authorUid={teacherUid}
-              onChange={setDraftAnnotations}
-              activeId={activeAnnotationId}
-              onActiveIdChange={setActiveAnnotationId}
-            />
-          ) : (
-            <div className="bg-white border border-slate-200 rounded-lg p-5 text-sm text-slate-500 italic">
-              The student didn&apos;t answer this question.
+  return (
+    <EditorModalShell
+      isOpen
+      title="Grade written responses"
+      subtitle={subtitle}
+      headerExtras={headerExtras}
+      isDirty={isDirty}
+      isSaving={saving}
+      saveLabel={isLastStudent ? 'Save grade' : 'Save & next'}
+      onSave={handleSave}
+      onClose={onClose}
+      confirmDiscardMessage="You have unsaved grade edits. Discard them?"
+      confirmDiscardTitle="Discard grade edits?"
+      bodyClassName="!p-0 !overflow-hidden"
+      saveErrorMessage={false}
+    >
+      <div className="h-full grid grid-cols-[2fr_1fr] min-h-0">
+        <section className="overflow-y-auto bg-slate-50">
+          {writtenQuestions.length > 1 && (
+            <div className="flex items-center gap-2 px-6 py-2 border-b border-slate-200 bg-slate-50 sticky top-0 z-20">
+              <button
+                onClick={goPrevQuestion}
+                disabled={questionIdx === 0 || saving}
+                className="p-1 rounded text-slate-500 hover:bg-slate-200 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+                aria-label="Previous question"
+              >
+                <ChevronLeft className="w-4 h-4" />
+              </button>
+              <button
+                onClick={goNextQuestion}
+                disabled={questionIdx >= writtenQuestions.length - 1 || saving}
+                className="p-1 rounded text-slate-500 hover:bg-slate-200 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+                aria-label="Next question"
+              >
+                <ChevronRight className="w-4 h-4" />
+              </button>
             </div>
           )}
+          {/*
+            Slim sticky question prompt — gives the teacher the question
+            text at a glance without dominating vertical space. The
+            student's writing below is the dominant element.
+          */}
+          <div className="sticky top-0 z-10 bg-slate-50/95 backdrop-blur border-b border-slate-200 px-8 py-3">
+            <div className="text-[10px] font-bold uppercase tracking-wider text-slate-500 mb-1">
+              Question
+            </div>
+            <p className="text-sm font-semibold text-slate-900 leading-snug">
+              {question.text}
+            </p>
+          </div>
+          <div className="p-8">
+            <h3 className="text-sm font-bold uppercase tracking-wider text-slate-500 mb-3">
+              Student response
+            </h3>
+            {studentAnswer ? (
+              <AnnotatedResponseView
+                mode="edit"
+                // Once we've saved annotations, the snapshot is the
+                // source of truth; until then, default to the live
+                // sanitized answer so a teacher can start selecting text
+                // even on a never-graded response.
+                snapshot={
+                  savedGrade?.gradingSnapshot ??
+                  sanitizeQuizResponse(studentAnswer)
+                }
+                annotations={draftAnnotations}
+                authorUid={teacherUid}
+                onChange={setDraftAnnotations}
+                activeId={activeAnnotationId}
+                onActiveIdChange={setActiveAnnotationId}
+              />
+            ) : (
+              <div className="bg-white border border-slate-200 rounded-lg p-5 text-sm text-slate-500 italic">
+                The student didn&apos;t answer this question.
+              </div>
+            )}
+          </div>
         </section>
 
         <aside className="border-l border-slate-200 bg-white p-6 flex flex-col gap-5 overflow-y-auto">
@@ -537,36 +542,20 @@ export const WrittenResponseGrader: React.FC<WrittenResponseGraderProps> = ({
             />
           </div>
 
+          <p className="text-xs text-slate-500 leading-relaxed mt-auto">
+            ← / → switch students. Esc closes the grader. Select text in the
+            response to highlight; click an existing highlight to edit its
+            comment.
+          </p>
+
           {saveError && (
             <div className="p-2.5 bg-brand-red-lighter/40 border border-brand-red-primary/20 rounded-lg text-xs text-brand-red-dark font-bold">
               {saveError}
             </div>
           )}
-
-          <button
-            onClick={() => void handleSave()}
-            disabled={saving}
-            className="w-full py-3 bg-brand-blue-primary hover:bg-brand-blue-dark disabled:opacity-50 disabled:cursor-not-allowed text-white font-bold rounded-lg flex items-center justify-center gap-2 transition-colors"
-          >
-            {saving ? (
-              <Loader2 className="w-4 h-4 animate-spin" />
-            ) : isLastStudent ? (
-              'Save grade'
-            ) : (
-              <>
-                Save &amp; next <ChevronRight className="w-4 h-4" />
-              </>
-            )}
-          </button>
-
-          <p className="text-xs text-slate-500 leading-relaxed">
-            ← / → switch students. Esc closes the grader. Select text in the
-            response to highlight; click an existing highlight to edit its
-            comment.
-          </p>
         </aside>
       </div>
-    </ModalShell>
+    </EditorModalShell>
   );
 };
 
@@ -661,7 +650,13 @@ const AnnotationsList: React.FC<{
   );
 };
 
-const ModalShell: React.FC<{
+/**
+ * Lightweight modal used by the empty-state branches (no written questions,
+ * or no responses to grade yet). Keeps the same overlay treatment as the
+ * grader proper, but skips the EditorModalShell Save/Cancel chrome since
+ * there's nothing to save.
+ */
+const EmptyStateShell: React.FC<{
   onClose: () => void;
   children: React.ReactNode;
 }> = ({ onClose, children }) => (
@@ -671,22 +666,20 @@ const ModalShell: React.FC<{
     aria-label="Grade written responses"
     className="fixed inset-0 z-overlay flex items-center justify-center bg-slate-900/70 backdrop-blur-sm p-4"
   >
-    {/*
-      Backdrop is a non-focusable div so Tab can't escape into it and so a
-      stray Space/Enter while focus is elsewhere doesn't close the modal.
-      Click-to-dismiss is preserved via onClick. Esc-to-close is wired in
-      the modal body's keydown listener.
-    */}
     <div
       aria-hidden
       className="absolute inset-0 cursor-default"
       onClick={onClose}
     />
-    <div
-      className="relative bg-white rounded-2xl shadow-2xl w-full max-w-[1400px] h-[92vh] flex flex-col overflow-hidden"
-      style={{ maxWidth: 'min(95vw, 1400px)' }}
-    >
+    <div className="relative bg-white rounded-2xl shadow-2xl w-full max-w-lg p-10 text-center text-slate-600">
       {children}
+      <button
+        type="button"
+        onClick={onClose}
+        className="mt-6 px-4 py-2 text-sm font-bold text-slate-700 hover:bg-slate-100 rounded-xl transition-colors"
+      >
+        Close
+      </button>
     </div>
   </div>
 );

--- a/components/widgets/TextWidget/Widget.test.tsx
+++ b/components/widgets/TextWidget/Widget.test.tsx
@@ -113,6 +113,42 @@ describe('TextWidget', () => {
     expect(screen.queryByTitle('Bold')).not.toBeInTheDocument();
   });
 
+  it('does not bubble pointerdown from the formatting toolbar to ancestor handlers', async () => {
+    // The toolbar renders to document.body via createPortal, but React
+    // synthetic events still bubble through the COMPONENT tree — meaning a
+    // pointerdown on a toolbar button reaches DraggableWindow's
+    // `handlePointerDown` ancestor in production. That handler calls
+    // `.focus()` on the widget chrome whenever the target isn't inside a
+    // contentEditable, which fires the editor's `onBlur` and drops the
+    // live selection. execCommand calls (lists, foreColor, …) then run
+    // against a stale collapsed selection and silently no-op.
+    //
+    // The fix attaches `onPointerDown={(e) => e.stopPropagation()}` on the
+    // toolbar's portal wrapper. This test guards that regression by
+    // mounting an ancestor pointerdown handler around TextWidget and
+    // verifying it does NOT fire when a toolbar button is pressed.
+    (useDashboard as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+      ...mockDashboardContext,
+      selectedWidgetId: 'test-widget',
+    });
+
+    const ancestorPointerDown = vi.fn();
+    render(
+      <div onPointerDown={ancestorPointerDown}>
+        <TextWidget widget={mockWidget} />
+      </div>
+    );
+
+    // Toolbar renders via portal + RAF position tracking — wait for it.
+    await waitFor(() => {
+      expect(screen.getByTitle('Bold')).toBeInTheDocument();
+    });
+
+    fireEvent.pointerDown(screen.getByTitle('Bold'));
+
+    expect(ancestorPointerDown).not.toHaveBeenCalled();
+  });
+
   it('triggers hyperlink prompt on Control+K', async () => {
     mockShowPrompt.mockResolvedValue('https://test.com');
     render(<TextWidget widget={mockWidget} />);
@@ -306,6 +342,65 @@ describe('TextWidget', () => {
     expect(mockUpdateWidget).toHaveBeenCalledWith('test-widget', {
       config: { ...mockConfig, content: 'Immediate Save' },
     });
+  });
+
+  it('normalizes mixed bare-text-then-<div> structure during live editing', () => {
+    // Reproduces the exact shape Chrome produces while typing: the user
+    // types "First", hits Enter (Chrome creates `<div><br></div>` for the
+    // new line), then types "Second" — leaving the first line as a bare
+    // text node. Without input-time normalization the editor is stuck in
+    // a mixed structure that breaks drag-selection across the boundary
+    // and confuses list commands. handleInput should rewrite the structure
+    // to uniform block children on the same event.
+    const { container } = render(<TextWidget widget={mockWidget} />);
+    const editableDiv = container.querySelector(
+      'div[contentEditable="true"]'
+    ) as HTMLElement;
+    expect(editableDiv).not.toBeNull();
+
+    editableDiv.innerHTML = 'First<div>Second</div>';
+    fireEvent.input(editableDiv);
+
+    // After normalization every top-level child is a block element.
+    const childTags = Array.from(editableDiv.childNodes).map((n) =>
+      n.nodeType === Node.ELEMENT_NODE
+        ? (n as HTMLElement).tagName
+        : n.nodeType === Node.TEXT_NODE
+          ? '#text'
+          : '#other'
+    );
+    expect(childTags.every((t) => t !== '#text' && t !== 'BR')).toBe(true);
+    expect(editableDiv.children.length).toBe(2);
+    expect(editableDiv.textContent).toBe('FirstSecond');
+
+    // Saved content reflects the normalized structure (so the same
+    // mixed shape doesn't re-appear after a save → external sync round
+    // trip).
+    const lastCall = mockUpdateWidget.mock.lastCall;
+    expect(lastCall).toBeDefined();
+    if (lastCall) {
+      const payload = lastCall[1] as { config: TextConfig };
+      const savedContent = payload.config.content ?? '';
+      expect(savedContent).not.toMatch(/^First</); // bare-text prefix is gone
+      expect(savedContent).toContain('<div>First</div>');
+      expect(savedContent).toContain('<div>Second</div>');
+    }
+  });
+
+  it('leaves already-uniform block structure alone on input', () => {
+    // The normalizer only rewrites mixed structures. Pure-block content is
+    // a no-op so steady-state typing inside an existing paragraph doesn't
+    // shuffle node identity (which would invalidate the caret) on every
+    // keystroke.
+    const { container } = render(<TextWidget widget={mockWidget} />);
+    const editableDiv = container.querySelector(
+      'div[contentEditable="true"]'
+    ) as HTMLElement;
+
+    editableDiv.innerHTML = '<div>One</div><div>Two</div>';
+    fireEvent.input(editableDiv);
+
+    expect(editableDiv.innerHTML).toBe('<div>One</div><div>Two</div>');
   });
 
   it('wraps loose top-level text in a <div> on mount so drag-selection works across paragraphs', () => {

--- a/components/widgets/TextWidget/Widget.tsx
+++ b/components/widgets/TextWidget/Widget.tsx
@@ -12,7 +12,10 @@ import { Z_INDEX } from '@/config/zIndex';
 import { WidgetLayout } from '@/components/widgets/WidgetLayout';
 import { FormattingToolbar } from './FormattingToolbar';
 import { PLACEHOLDER_TEXT } from './constants';
-import { normalizeEditorBlocks } from './normalizeBlocks';
+import {
+  needsBlockNormalization,
+  normalizeEditorBlocks,
+} from './normalizeBlocks';
 
 /** Gap (px) between the toolbar and the widget edge. */
 const TOOLBAR_GAP = 8;
@@ -200,6 +203,18 @@ export const TextWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
     // Skip save when the toolbar is performing a multi-step DOM mutation
     // (e.g. execCommand + span replacement for font-size changes).
     if (suppressInputRef.current) return;
+    // Re-normalize the live editor structure so drag-selection and list
+    // commands keep working as the user edits. Chrome leaves the FIRST line
+    // as a bare text node and only wraps subsequent Enter-separated lines in
+    // <div> blocks — that mixed `text<div>line</div>` shape collapses drag
+    // selections at the paragraph boundary and makes `insertUnorderedList`/
+    // `insertOrderedList` apply to only one line instead of the visible
+    // paragraph the cursor sits in. The helper is a fast no-op for already-
+    // uniform structures, and only moves nodes (never clones), so live Range
+    // references — including the caret — survive per the DOM spec.
+    if (editorRef.current && needsBlockNormalization(editorRef.current)) {
+      normalizeEditorBlocks(editorRef.current);
+    }
     // Save on every input for immediate persistence (debounced by DashboardContext)
     const content = readEditorContent();
     lastExternalContent.current = content;
@@ -275,6 +290,19 @@ export const TextWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
               <div
                 ref={toolbarPortalRef}
                 data-click-outside-ignore="true"
+                // The toolbar lives in a portal but React events still bubble
+                // through the component tree to the DraggableWindow ancestor,
+                // whose `handlePointerDown` calls `.focus()` on the widget
+                // chrome whenever the pointerdown target isn't inside a
+                // contentEditable. That focus shift pulls focus out of the
+                // editor mid-click, fires `onBlur`, and drops the live
+                // selection — execCommand calls (bold/italic, lists,
+                // foreColor) then run against a collapsed/stale selection and
+                // appear to do nothing. Stopping pointerdown propagation here
+                // keeps the editor focused while the toolbar's own
+                // `onMouseDown preventDefault` handlers (on the buttons)
+                // still prevent the click from changing focus to the button.
+                onPointerDown={(e) => e.stopPropagation()}
                 style={{
                   position: 'fixed',
                   // Position above the widget; if not enough space, show below.

--- a/components/widgets/VideoActivityWidget/Widget.tsx
+++ b/components/widgets/VideoActivityWidget/Widget.tsx
@@ -121,6 +121,7 @@ export const VideoActivityWidget: React.FC<{ widget: WidgetData }> = ({
     deleteAssignment,
     shareAssignment,
     publishAssignmentScores,
+    unpublishAssignmentScores,
   } = useVideoActivityAssignments(user?.uid);
 
   const [publishingAssignment, setPublishingAssignment] =
@@ -838,6 +839,19 @@ export const VideoActivityWidget: React.FC<{ widget: WidgetData }> = ({
         onArchivePublishScores={(assignment) =>
           setPublishingAssignment(assignment)
         }
+        onArchiveUnpublishScores={async (assignment) => {
+          // One-click unpublish — `unpublishAssignmentScores` is a cheap
+          // two-write batch (no Drive lookup, no grading).
+          try {
+            await unpublishAssignmentScores(assignment.id);
+            addToast('Scores unpublished.', 'success');
+          } catch (err) {
+            addToast(
+              err instanceof Error ? err.message : 'Failed to unpublish scores',
+              'error'
+            );
+          }
+        }}
         initialLibraryViewMode={config.libraryViewMode}
         onLibraryViewModeChange={(mode) => {
           updateWidget(widget.id, {
@@ -866,21 +880,7 @@ export const VideoActivityWidget: React.FC<{ widget: WidgetData }> = ({
             const target = publishingAssignment;
             try {
               if (visibility === 'none') {
-                await publishAssignmentScores(
-                  target.id,
-                  // Empty placeholder VideoActivityData — the 'none' branch
-                  // never reads it. Cheaper than re-loading from Drive for
-                  // a flag flip.
-                  {
-                    id: target.activityId,
-                    title: target.activityTitle,
-                    youtubeUrl: '',
-                    questions: [],
-                    createdAt: 0,
-                    updatedAt: 0,
-                  },
-                  visibility
-                );
+                await unpublishAssignmentScores(target.id);
                 addToast('Scores unpublished.', 'success');
                 setPublishingAssignment(null);
                 return;

--- a/components/widgets/VideoActivityWidget/components/VideoActivityManager.tsx
+++ b/components/widgets/VideoActivityWidget/components/VideoActivityManager.tsx
@@ -26,6 +26,7 @@ import {
   CheckSquare,
   Copy,
   Edit2,
+  EyeOff,
   FileUp,
   Link2,
   Loader2,
@@ -53,6 +54,7 @@ import { AssignmentArchiveCard } from '@/components/common/library/AssignmentArc
 import { ViewCountBadge } from '@/components/common/library/ViewCountBadge';
 import { useSessionViewCount } from '@/hooks/useSessionViewCount';
 import { useAuth } from '@/context/useAuth';
+import { useDialog } from '@/context/useDialog';
 import { FolderSidebar } from '@/components/common/library/FolderSidebar';
 import { FolderPickerPopover } from '@/components/common/library/FolderPickerPopover';
 import { buildMoveToFolderAction } from '@/components/common/library/folderMenuAction';
@@ -207,6 +209,13 @@ export interface VideoActivityManagerProps {
    * `useVideoActivityAssignments.publishAssignmentScores` hook.
    */
   onArchivePublishScores?: (assignment: VideoActivityAssignment) => void;
+  /**
+   * Revoke published score visibility in one click (skips the picker
+   * modal). Only surfaced when `assignment.scoreVisibility` is published.
+   */
+  onArchiveUnpublishScores?: (
+    assignment: VideoActivityAssignment
+  ) => void | Promise<void>;
 
   /** Persisted library grid/list toggle (from widget config). */
   initialLibraryViewMode?: 'grid' | 'list';
@@ -433,6 +442,7 @@ export const VideoActivityManager: React.FC<VideoActivityManagerProps> = ({
   onArchiveShare,
   onArchiveMonitor,
   onArchivePublishScores,
+  onArchiveUnpublishScores,
   initialLibraryViewMode,
   onLibraryViewModeChange,
   rosters,
@@ -441,6 +451,7 @@ export const VideoActivityManager: React.FC<VideoActivityManagerProps> = ({
   lastClassIdByActivityId,
   assignmentMode = 'submissions',
 }) => {
+  const { showConfirm } = useDialog();
   const isViewOnly = assignmentMode === 'view-only';
   const primaryActionLabel = isViewOnly ? 'Share' : 'Assign';
   const [tab, setTab] = useState<LibraryTab>('library');
@@ -1132,6 +1143,29 @@ export const VideoActivityManager: React.FC<VideoActivityManagerProps> = ({
         label: isPublished ? 'Update published scores' : 'Publish scores',
         icon: Send,
         onClick: () => onArchivePublishScores(assignment),
+      });
+    }
+    if (
+      onArchiveUnpublishScores &&
+      !assignmentIsViewOnly &&
+      assignment.scoreVisibility !== undefined &&
+      assignment.scoreVisibility !== 'none'
+    ) {
+      actions.push({
+        id: 'unpublish-scores',
+        label: 'Unpublish scores',
+        icon: EyeOff,
+        onClick: async () => {
+          const ok = await showConfirm(
+            'Students will no longer be able to see their scores or responses. You can republish anytime.',
+            {
+              title: 'Unpublish scores',
+              variant: 'danger',
+              confirmLabel: 'Unpublish',
+            }
+          );
+          if (ok) await onArchiveUnpublishScores(assignment);
+        },
       });
     }
 

--- a/firestore.rules
+++ b/firestore.rules
@@ -2625,12 +2625,15 @@ service cloud.firestore {
       allow create: if request.auth != null &&
         request.auth.token.firebase.sign_in_provider != 'anonymous' &&
         request.resource.data.teacherUid == request.auth.uid;
-      // Sessions are otherwise immutable; only the owning teacher (or admin)
-      // may delete — used by the Wave 2-GL "Delete permanently" action in the
-      // Assignment archive to clean up the session along with the per-teacher
-      // assignment doc.
-      allow update: if false;
-      allow delete: if request.auth != null &&
+      // The owning teacher (or admin) may update the session — used by
+      // `publishAssignmentScores` to mirror `scoreVisibility` +
+      // `revealedAnswers` onto the session doc so the student listener can
+      // gate its review screen without subscribing to teacher-owned docs.
+      // Mirrors the Quiz session rule (`quiz_sessions/{sessionId}` allow
+      // update). Only the owning teacher (or admin) may delete — used by
+      // the Wave 2-GL "Delete permanently" action in the Assignment archive
+      // to clean up the session along with the per-teacher assignment doc.
+      allow update, delete: if request.auth != null &&
         (resource.data.teacherUid == request.auth.uid || isAdmin());
 
       match /responses/{studentUid} {
@@ -2639,6 +2642,9 @@ service cloud.firestore {
         }
         function glSessionClassIds() {
           return get(/databases/$(database)/documents/guided_learning_sessions/$(sessionId)).data.get('classIds', []);
+        }
+        function glSessionTeacherUid() {
+          return get(/databases/$(database)/documents/guided_learning_sessions/$(sessionId)).data.teacherUid;
         }
         // Defense in depth — block response writes on view-only sessions.
         // GuidedLearningSession.mode already names the play-mode
@@ -2664,17 +2670,36 @@ service cloud.firestore {
           passesStudentClassGateCompat(glSessionClassIds(), glSessionClassId()) &&
           // Block submissions on view-only sessions (mode is frozen at creation)
           glSessionMode() == 'submissions';
-        // Students can update only their own response to add answers or set completedAt;
-        // identity fields and score are immutable from the client
-        allow update: if request.auth != null &&
-          studentUid == request.auth.uid &&
-          passesStudentClassGateCompat(glSessionClassIds(), glSessionClassId()) &&
-          request.resource.data.studentAnonymousId == resource.data.studentAnonymousId &&
-          request.resource.data.sessionId == resource.data.sessionId &&
-          request.resource.data.startedAt == resource.data.startedAt &&
-          request.resource.data.score == resource.data.score &&
-          request.resource.data.diff(resource.data).affectedKeys().hasOnly(['answers', 'completedAt', 'pin']) &&
-          request.resource.data.answers.size() >= resource.data.answers.size();
+        // Two disjoint branches:
+        //
+        //   TEACHER branch — the owning teacher (or admin) writes `score` and
+        //   per-answer `isCorrect` when they call `publishAssignmentScores`,
+        //   and clears those on unpublish. The session's `teacherUid` is the
+        //   sole ownership gate; we deliberately don't constrain
+        //   `request.resource.data` further so future publish-flow fields
+        //   don't require a rules edit. Mirrors the Quiz / VA response
+        //   update pattern.
+        //
+        //   STUDENT branch — append answers / set completedAt on their own
+        //   response, with `score` locked immutable from the client. Branch
+        //   mutual exclusivity is by intent: a student calling update() will
+        //   fail the teacher disjunct (uid != teacherUid) and fall through
+        //   to the student branch's full append-only invariants.
+        allow update: if request.auth != null && (
+          // Teacher branch.
+          (request.auth.uid == glSessionTeacherUid() || isAdmin()) ||
+          // Student branch — unchanged.
+          (
+            studentUid == request.auth.uid &&
+            passesStudentClassGateCompat(glSessionClassIds(), glSessionClassId()) &&
+            request.resource.data.studentAnonymousId == resource.data.studentAnonymousId &&
+            request.resource.data.sessionId == resource.data.sessionId &&
+            request.resource.data.startedAt == resource.data.startedAt &&
+            request.resource.data.score == resource.data.score &&
+            request.resource.data.diff(resource.data).affectedKeys().hasOnly(['answers', 'completedAt', 'pin']) &&
+            request.resource.data.answers.size() >= resource.data.answers.size()
+          )
+        );
         // Owning teacher (or admin) may delete responses — used when the
         // teacher permanently deletes an assignment.
         allow delete: if request.auth != null && (

--- a/hooks/useGuidedLearningAssignments.ts
+++ b/hooks/useGuidedLearningAssignments.ts
@@ -317,6 +317,10 @@ export const useGuidedLearningAssignments = (
       });
       batch.update(sessionRef, {
         scoreVisibility: deleteField(),
+        // Mirror `scorePublishedAt` removal on the session so the student's
+        // `parsePublicationFields` (which requires BOTH fields) doesn't
+        // see a stale timestamp lingering after unpublish.
+        scorePublishedAt: deleteField(),
         revealedAnswers: deleteField(),
       });
       await batch.commit();
@@ -419,6 +423,11 @@ export const useGuidedLearningAssignments = (
       });
       const sessionPatch: Record<string, unknown> = {
         scoreVisibility: visibility,
+        // Mirror `scorePublishedAt` onto the session so the student's
+        // `/my-assignments` row can flip from "Not graded" to
+        // "View results". `parsePublicationFields` requires BOTH fields,
+        // and the student listener only subscribes to the session doc.
+        scorePublishedAt: now,
       };
       if (visibility === 'score-responses-and-answers') {
         const revealedAnswers: Record<string, string> = {};

--- a/hooks/useGuidedLearningAssignments.ts
+++ b/hooks/useGuidedLearningAssignments.ts
@@ -15,6 +15,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import {
   collection,
+  deleteField,
   doc,
   getDocs,
   onSnapshot,
@@ -26,15 +27,52 @@ import {
 } from 'firebase/firestore';
 import { db } from '@/config/firebase';
 import { invalidateSessionViewCount } from './useSessionViewCount';
+import { isAnswerCorrect } from './useGuidedLearningSession';
 import type {
   AssignmentMode,
   GuidedLearningAssignment,
   GuidedLearningAssignmentStatus,
+  GuidedLearningResponse,
+  GuidedLearningScoreVisibility,
+  GuidedLearningSet,
+  GuidedLearningStep,
 } from '@/types';
 
 const GL_ASSIGNMENTS_COLLECTION = 'guided_learning_assignments';
 const GL_SESSIONS_COLLECTION = 'guided_learning_sessions';
 const GL_SESSION_RESPONSES_SUBCOLLECTION = 'responses';
+
+/**
+ * Stringify a step's canonical correct answer for `session.revealedAnswers`.
+ * `revealedAnswers` is `Record<stepId, string>` (mirrors Quiz/VA), so the
+ * array-shaped answers for matching and sorting are flattened into a
+ * human-readable string for the student review screen. Returns `null` for
+ * steps that don't have a gradable question (info hotspots, etc.).
+ *
+ * Exhaustive over `GuidedLearningQuestionType`: a new type added to the
+ * union surfaces as a TypeScript error on the `_exhaustiveCheck: never`
+ * assignment, so callers can't silently drop coverage for a new question
+ * shape.
+ */
+export function formatCanonicalAnswer(step: GuidedLearningStep): string | null {
+  const q = step.question;
+  if (!q) return null;
+  switch (q.type) {
+    case 'multiple-choice':
+      return q.correctAnswer ?? null;
+    case 'matching':
+      if (!q.matchingPairs?.length) return null;
+      return q.matchingPairs.map((p) => `${p.left} → ${p.right}`).join('\n');
+    case 'sorting':
+      if (!q.sortingItems?.length) return null;
+      return q.sortingItems.join(' → ');
+    default: {
+      const _exhaustiveCheck: never = q.type;
+      void _exhaustiveCheck;
+      return null;
+    }
+  }
+}
 
 export interface CreateAssignmentInput {
   /** The session id (also becomes the assignment id). */
@@ -68,6 +106,34 @@ export interface UseGuidedLearningAssignmentsResult {
   unarchiveAssignment: (assignmentId: string) => Promise<void>;
   /** Delete assignment + session + all responses permanently. */
   deleteAssignment: (assignmentId: string) => Promise<void>;
+  /**
+   * Publish student-facing score visibility for an archived assignment.
+   * Mirrors `useQuizAssignments.publishAssignmentScores`: recomputes
+   * per-response `isCorrect` + `score`, mirrors the visibility flag onto
+   * the session doc, and populates `session.revealedAnswers` iff the
+   * teacher chose `'score-responses-and-answers'`. Pre-existing
+   * per-response values are overwritten so the operation is idempotent
+   * and self-correcting (responses submitted in student-mode are
+   * written with `isCorrect: null`).
+   *
+   * The signature deliberately excludes `'none'` — use
+   * {@link UseGuidedLearningAssignmentsResult.unpublishAssignmentScores}
+   * for the rollback path, which is a cheap two-write batch that
+   * doesn't require fabricating a placeholder `GuidedLearningSet`.
+   */
+  publishAssignmentScores: (
+    assignmentId: string,
+    glData: GuidedLearningSet,
+    visibility: Exclude<GuidedLearningScoreVisibility, 'none'>
+  ) => Promise<{ responsesUpdated: number }>;
+  /**
+   * Revoke published score visibility for an assignment. Clears
+   * `scoreVisibility` + `scorePublishedAt` on the assignment doc (via
+   * `deleteField()`) and wipes `revealedAnswers` on the mirrored
+   * session doc. Per-response `score` / `isCorrect` are left intact —
+   * student-side rendering gates on `session.scoreVisibility`.
+   */
+  unpublishAssignmentScores: (assignmentId: string) => Promise<void>;
 }
 
 export const useGuidedLearningAssignments = (
@@ -223,6 +289,187 @@ export const useGuidedLearningAssignments = (
     [userId]
   );
 
+  const unpublishAssignmentScores = useCallback<
+    UseGuidedLearningAssignmentsResult['unpublishAssignmentScores']
+  >(
+    async (assignmentId) => {
+      if (!userId) throw new Error('Not authenticated');
+      const now = Date.now();
+      const assignmentRef = doc(
+        db,
+        'users',
+        userId,
+        GL_ASSIGNMENTS_COLLECTION,
+        assignmentId
+      );
+      const sessionRef = doc(db, GL_SESSIONS_COLLECTION, assignmentId);
+      // Wipe visibility flags via deleteField on both docs and clear
+      // the revealed-answers map. Per-response `score` / `isCorrect`
+      // are left intact: the student app gates on
+      // `session.scoreVisibility`, so numbers behind a closed gate are
+      // harmless and a re-publish at the same level avoids a multi-
+      // batch recompute.
+      const batch = writeBatch(db);
+      batch.update(assignmentRef, {
+        scoreVisibility: deleteField(),
+        scorePublishedAt: deleteField(),
+        updatedAt: now,
+      });
+      batch.update(sessionRef, {
+        scoreVisibility: deleteField(),
+        revealedAnswers: deleteField(),
+      });
+      await batch.commit();
+    },
+    [userId]
+  );
+
+  const publishAssignmentScores = useCallback<
+    UseGuidedLearningAssignmentsResult['publishAssignmentScores']
+  >(
+    async (assignmentId, glData, visibility) => {
+      if (!userId) throw new Error('Not authenticated');
+      // Belt-and-suspenders against a future caller bypassing the
+      // type-level `Exclude<…, 'none'>` (matches Quiz/VA pattern).
+      if ((visibility as string) === 'none') {
+        throw new Error(
+          'publishAssignmentScores: visibility "none" is not allowed — use unpublishAssignmentScores instead.'
+        );
+      }
+
+      const now = Date.now();
+      const assignmentRef = doc(
+        db,
+        'users',
+        userId,
+        GL_ASSIGNMENTS_COLLECTION,
+        assignmentId
+      );
+      const sessionRef = doc(db, GL_SESSIONS_COLLECTION, assignmentId);
+
+      // Index steps by id for O(1) grading lookups. `glData.steps` is the
+      // canonical set loaded by the caller — `session.publicSteps` strips
+      // answer keys for student safety, so we can't grade off the session.
+      const stepsById = new Map<string, GuidedLearningStep>();
+      for (const s of glData.steps) {
+        stepsById.set(s.id, s);
+      }
+      const gradableStepIds = new Set<string>();
+      for (const s of glData.steps) {
+        if (s.question) gradableStepIds.add(s.id);
+      }
+
+      const responsesSnap = await getDocs(
+        collection(
+          db,
+          GL_SESSIONS_COLLECTION,
+          assignmentId,
+          GL_SESSION_RESPONSES_SUBCOLLECTION
+        )
+      );
+
+      interface ResponseUpdate {
+        ref: ReturnType<typeof doc>;
+        patch: {
+          score: number;
+          answers: GuidedLearningResponse['answers'];
+        };
+      }
+      const updates: ResponseUpdate[] = [];
+      for (const d of responsesSnap.docs) {
+        const data = d.data() as GuidedLearningResponse;
+        const answers = Array.isArray(data.answers) ? data.answers : [];
+        let correctCount = 0;
+        const gradedAnswers: GuidedLearningResponse['answers'] = answers.map(
+          (a) => {
+            const step = stepsById.get(a.stepId);
+            if (!step || !step.question) {
+              // Step deleted or no longer gradable — clear any stale
+              // `isCorrect` so the response doesn't carry a value the
+              // canonical set no longer supports.
+              return { ...a, isCorrect: null };
+            }
+            const correct = isAnswerCorrect(step, a.answer);
+            if (correct) correctCount += 1;
+            return { ...a, isCorrect: correct };
+          }
+        );
+        // Denominator: every gradable step in the canonical set. Counting
+        // unanswered gradable steps toward the total means a blank
+        // submission scores 0%, not undefined.
+        const denom = gradableStepIds.size;
+        const score =
+          denom === 0 ? 0 : Math.round((correctCount / denom) * 100);
+        updates.push({
+          ref: d.ref,
+          patch: { score, answers: gradedAnswers },
+        });
+      }
+
+      // First batch carries the assignment + session writes so the
+      // visibility flip lands atomically with at least the first chunk
+      // of response updates. Subsequent chunks are independent; a
+      // re-publish safely overwrites if any chunk fails.
+      const MAX_BATCH_WRITES = 400;
+      const firstBatch = writeBatch(db);
+      firstBatch.update(assignmentRef, {
+        scoreVisibility: visibility,
+        scorePublishedAt: now,
+        updatedAt: now,
+      });
+      const sessionPatch: Record<string, unknown> = {
+        scoreVisibility: visibility,
+      };
+      if (visibility === 'score-responses-and-answers') {
+        const revealedAnswers: Record<string, string> = {};
+        for (const s of glData.steps) {
+          const formatted = formatCanonicalAnswer(s);
+          if (formatted !== null) revealedAnswers[s.id] = formatted;
+        }
+        sessionPatch.revealedAnswers = revealedAnswers;
+      } else {
+        sessionPatch.revealedAnswers = deleteField();
+      }
+      firstBatch.update(sessionRef, sessionPatch);
+
+      const firstChunkSize = Math.min(updates.length, MAX_BATCH_WRITES - 2);
+      for (let i = 0; i < firstChunkSize; i++) {
+        firstBatch.update(updates[i].ref, updates[i].patch);
+      }
+      await firstBatch.commit();
+      let responsesCommitted = firstChunkSize;
+
+      // Mirror Quiz/VA chunked-failure recovery: if a subsequent chunk
+      // fails partway, the visibility flag is already flipped — some
+      // students will see graded reviews while the remaining responses
+      // still carry pre-publish state. Throw a structured error so the
+      // caller can tell the teacher "X of Y graded, re-run Publish."
+      try {
+        for (
+          let cursor = firstChunkSize;
+          cursor < updates.length;
+          cursor += MAX_BATCH_WRITES
+        ) {
+          const chunk = updates.slice(cursor, cursor + MAX_BATCH_WRITES);
+          const chunkBatch = writeBatch(db);
+          for (const u of chunk) {
+            chunkBatch.update(u.ref, u.patch);
+          }
+          await chunkBatch.commit();
+          responsesCommitted += chunk.length;
+        }
+      } catch (err) {
+        const cause = err instanceof Error ? err.message : String(err);
+        throw new Error(
+          `Partial publish: ${responsesCommitted} of ${updates.length} student responses graded. Re-run "Publish scores" to finish. (${cause})`
+        );
+      }
+
+      return { responsesUpdated: updates.length };
+    },
+    [userId]
+  );
+
   return {
     assignments,
     loading,
@@ -231,5 +478,7 @@ export const useGuidedLearningAssignments = (
     archiveAssignment,
     unarchiveAssignment,
     deleteAssignment,
+    publishAssignmentScores,
+    unpublishAssignmentScores,
   };
 };

--- a/hooks/useGuidedLearningSession.ts
+++ b/hooks/useGuidedLearningSession.ts
@@ -14,7 +14,6 @@ import {
   collection,
   doc,
   setDoc,
-  getDoc,
   onSnapshot,
   query,
   orderBy,
@@ -335,10 +334,16 @@ export const useGuidedLearningSessionStudent = (
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    const load = async () => {
-      try {
-        const snap = await getDoc(doc(db, GL_SESSIONS_COLLECTION, sessionId));
+    // Realtime listener so a teacher publish/unpublish flips the
+    // student-visible `scoreVisibility` + `revealedAnswers` in place
+    // without the student needing to refresh. The session doc is
+    // already small and world-readable, so a per-student listener is
+    // cheap.
+    const unsub = onSnapshot(
+      doc(db, GL_SESSIONS_COLLECTION, sessionId),
+      (snap) => {
         if (!snap.exists()) {
+          setSession(null);
           setError('This guided learning session was not found.');
         } else {
           const raw = snap.data() as GuidedLearningSession & {
@@ -365,15 +370,28 @@ export const useGuidedLearningSessionStudent = (
               showOverlay: step.showOverlay ?? 'none',
             })),
           });
+          setError(null);
         }
-      } catch (err) {
-        console.error('[useGuidedLearningSession] Load error:', err);
-        setError('Failed to load the session. Please try again.');
-      } finally {
+        setLoading(false);
+      },
+      (err) => {
+        // Firestore's onSnapshot retries internally on recoverable
+        // failures, so a transient blip (WiFi drop, brief unavailable)
+        // doesn't justify ejecting the student onto a permanent
+        // ErrorScreen — especially if we already have data on hand.
+        // Only surface a hard error before the first successful
+        // snapshot; after that, swallow and let the listener self-heal.
+        console.error('[useGuidedLearningSession] Snapshot error:', err);
+        setSession((prev) => {
+          if (prev === null) {
+            setError('Failed to load the session. Please try again.');
+          }
+          return prev;
+        });
         setLoading(false);
       }
-    };
-    void load();
+    );
+    return unsub;
   }, [sessionId]);
 
   const submitResponse = useCallback(

--- a/hooks/useQuizAssignments.ts
+++ b/hooks/useQuizAssignments.ts
@@ -1835,6 +1835,10 @@ export const useQuizAssignments = (
       });
       batch.update(sessionRef, {
         scoreVisibility: deleteField(),
+        // Mirror `scorePublishedAt` removal on the session so the student's
+        // `parsePublicationFields` (which requires BOTH fields) doesn't
+        // see a stale timestamp lingering after unpublish.
+        scorePublishedAt: deleteField(),
         revealedAnswers: deleteField(),
       });
       await batch.commit();
@@ -1958,6 +1962,13 @@ export const useQuizAssignments = (
       });
       const sessionPatch: Record<string, unknown> = {
         scoreVisibility: visibility,
+        // Mirror `scorePublishedAt` onto the session so the student's
+        // `/my-assignments` row can flip from "Not graded" to
+        // "View results". `parsePublicationFields` requires BOTH fields,
+        // and the student listener only subscribes to the session doc —
+        // writing it only on the teacher-owned assignment doc (the prior
+        // behavior) silently left every student stuck on "Not graded".
+        scorePublishedAt: now,
       };
       // Populate `revealedAnswers` only when the teacher chose to share
       // correct-answer text. The other two visibility levels deliberately

--- a/hooks/useQuizAssignments.ts
+++ b/hooks/useQuizAssignments.ts
@@ -337,7 +337,7 @@ export interface UseQuizAssignmentsResult {
   /**
    * Publish (or unpublish) score visibility for an archived assignment.
    *
-   * For visibility levels other than `'none'`, this:
+   * Publishes scores at the given visibility level:
    *   1. Computes each student's percentage score from the live response
    *      docs using `gradeAnswer` against the canonical `quizData`, and
    *      writes the resulting `score` + per-answer `isCorrect` flags onto
@@ -349,19 +349,29 @@ export interface UseQuizAssignmentsResult {
    *      `session.revealedAnswers` with every question's canonical answer
    *      so the student review screen can render the correct answer text.
    *
-   * Passing `'none'` clears the visibility flags (and `revealedAnswers`)
-   * so a teacher who published in error can roll back without deleting
-   * the assignment. Already-written `score` / `isCorrect` fields on
-   * responses are left in place — re-publishing simply overwrites them.
+   * Returns the number of responses whose score was (re)computed.
    *
-   * Returns the number of responses whose score was (re)computed; `0`
-   * when `'none'`.
+   * The signature deliberately excludes `'none'` — callers wishing to
+   * unpublish must use {@link UseQuizAssignmentsResult.unpublishAssignmentScores}
+   * instead, which is a cheap two-write batch that doesn't require
+   * fabricating a placeholder `QuizData` to satisfy the type.
    */
   publishAssignmentScores: (
     assignmentId: string,
     quizData: QuizData,
-    visibility: QuizScoreVisibility
+    visibility: Exclude<QuizScoreVisibility, 'none'>
   ) => Promise<{ responsesUpdated: number }>;
+  /**
+   * Revoke published score visibility for an assignment. Clears
+   * `scoreVisibility` + `scorePublishedAt` on the assignment doc (via
+   * `deleteField()`, so the unpublished and never-published states are
+   * indistinguishable on disk) and wipes `revealedAnswers` on the
+   * mirrored session doc. Already-written per-response `score` /
+   * `isCorrect` fields are left intact — student-side rendering gates
+   * on `session.scoreVisibility`, and re-publishing safely overwrites
+   * them.
+   */
+  unpublishAssignmentScores: (assignmentId: string) => Promise<void>;
 }
 
 /**
@@ -1795,11 +1805,58 @@ export const useQuizAssignments = (
     [userId]
   );
 
+  const unpublishAssignmentScores = useCallback<
+    UseQuizAssignmentsResult['unpublishAssignmentScores']
+  >(
+    async (assignmentId) => {
+      if (!userId) throw new Error('Not authenticated');
+      const now = Date.now();
+      const assignmentRef = doc(
+        db,
+        'users',
+        userId,
+        QUIZ_ASSIGNMENTS_COLLECTION,
+        assignmentId
+      );
+      const sessionRef = doc(db, QUIZ_SESSIONS_COLLECTION, assignmentId);
+      // Wipe the visibility flags on both docs and the revealed-answers
+      // map on the session. Already-written `score` and per-answer
+      // `isCorrect` fields on response docs are left in place: the
+      // reader gates on `scoreVisibility`, so leaving the numbers
+      // behind is harmless and avoids a multi-batch wipe on a gesture
+      // the teacher may immediately undo. Using `deleteField()` for
+      // `scoreVisibility` on both docs collapses the "unpublished" and
+      // "never published" states into a single shape on disk.
+      const batch = writeBatch(db);
+      batch.update(assignmentRef, {
+        scoreVisibility: deleteField(),
+        scorePublishedAt: deleteField(),
+        updatedAt: now,
+      });
+      batch.update(sessionRef, {
+        scoreVisibility: deleteField(),
+        revealedAnswers: deleteField(),
+      });
+      await batch.commit();
+    },
+    [userId]
+  );
+
   const publishAssignmentScores = useCallback<
     UseQuizAssignmentsResult['publishAssignmentScores']
   >(
     async (assignmentId, quizData, visibility) => {
       if (!userId) throw new Error('Not authenticated');
+      // Belt-and-suspenders against a future caller that bypasses the
+      // type-level `Exclude<…, 'none'>`. The unpublish path lives in
+      // `unpublishAssignmentScores` and has different semantics
+      // (deleteField vs. mirroring); routing 'none' here would write
+      // the literal string and break the gradingStateFrom rule.
+      if ((visibility as string) === 'none') {
+        throw new Error(
+          'publishAssignmentScores: visibility "none" is not allowed — use unpublishAssignmentScores instead.'
+        );
+      }
 
       const now = Date.now();
       const assignmentRef = doc(
@@ -1810,28 +1867,6 @@ export const useQuizAssignments = (
         assignmentId
       );
       const sessionRef = doc(db, QUIZ_SESSIONS_COLLECTION, assignmentId);
-
-      // Unpublish path — clear the visibility flags on assignment + session
-      // and wipe the revealed-answers map so the student review screen
-      // falls back to "scores not yet published". Already-written `score`
-      // and per-answer `isCorrect` fields on response docs are left in
-      // place: the reader gates on `scoreVisibility`, so leaving the
-      // numbers behind is harmless and avoids a multi-batch wipe on a
-      // gesture the teacher may immediately undo.
-      if (visibility === 'none') {
-        const batch = writeBatch(db);
-        batch.update(assignmentRef, {
-          scoreVisibility: 'none',
-          scorePublishedAt: deleteField(),
-          updatedAt: now,
-        });
-        batch.update(sessionRef, {
-          scoreVisibility: 'none',
-          revealedAnswers: deleteField(),
-        });
-        await batch.commit();
-        return { responsesUpdated: 0 };
-      }
 
       // Index questions by id for O(1) grading lookups. Use the canonical
       // `quizData.questions` (loaded from Drive on the teacher side) so
@@ -1946,20 +1981,38 @@ export const useQuizAssignments = (
         firstBatch.update(updates[i].ref, updates[i].patch);
       }
       await firstBatch.commit();
+      let responsesCommitted = firstChunkSize;
 
       // Remaining responses in subsequent batches (assignments with > ~398
-      // submissions across a PLC). Each batch is independently committed.
-      for (
-        let cursor = firstChunkSize;
-        cursor < updates.length;
-        cursor += MAX_BATCH_WRITES
-      ) {
-        const chunk = updates.slice(cursor, cursor + MAX_BATCH_WRITES);
-        const chunkBatch = writeBatch(db);
-        for (const u of chunk) {
-          chunkBatch.update(u.ref, u.patch);
+      // submissions across a PLC). Each chunk is independently committed.
+      // If a chunk fails partway, the assignment + session visibility
+      // flags are already published (committed in `firstBatch`) — students
+      // will start seeing the review screen for already-graded responses,
+      // while the remaining `updates.length - responsesCommitted` rows
+      // still carry whatever `score`/`isCorrect` they had pre-publish.
+      // Re-running publish is safe and idempotent (the chunk reconstructs
+      // every patch from scratch), so we throw a structured error the
+      // caller can surface verbatim — "X of Y graded, re-run Publish to
+      // finish" — instead of a generic "Failed to publish."
+      try {
+        for (
+          let cursor = firstChunkSize;
+          cursor < updates.length;
+          cursor += MAX_BATCH_WRITES
+        ) {
+          const chunk = updates.slice(cursor, cursor + MAX_BATCH_WRITES);
+          const chunkBatch = writeBatch(db);
+          for (const u of chunk) {
+            chunkBatch.update(u.ref, u.patch);
+          }
+          await chunkBatch.commit();
+          responsesCommitted += chunk.length;
         }
-        await chunkBatch.commit();
+      } catch (err) {
+        const cause = err instanceof Error ? err.message : String(err);
+        throw new Error(
+          `Partial publish: ${responsesCommitted} of ${updates.length} student responses graded. Re-run "Publish scores" to finish. (${cause})`
+        );
       }
 
       return { responsesUpdated: updates.length };
@@ -1986,5 +2039,6 @@ export const useQuizAssignments = (
     importSharedAssignment,
     syncAssignmentToLatest,
     publishAssignmentScores,
+    unpublishAssignmentScores,
   };
 };

--- a/hooks/useQuizSession.ts
+++ b/hooks/useQuizSession.ts
@@ -954,7 +954,8 @@ export interface UseQuizSessionStudentResult {
   submitAnswer: (
     questionId: string,
     answer: string,
-    speedBonus?: number
+    speedBonus?: number,
+    opts?: { isDraft?: boolean }
   ) => Promise<void>;
   completeQuiz: () => Promise<void>;
   /**
@@ -1682,7 +1683,12 @@ export const useQuizSessionStudent = (): UseQuizSessionStudentResult => {
   );
 
   const submitAnswer = useCallback(
-    async (questionId: string, answer: string, speedBonus?: number) => {
+    async (
+      questionId: string,
+      answer: string,
+      speedBonus?: number,
+      opts?: { isDraft?: boolean }
+    ) => {
       const sessionId = sessionIdRef.current;
       const responseKey = responseKeyRef.current;
       if (!sessionId || !responseKey) return;
@@ -1690,10 +1696,16 @@ export const useQuizSessionStudent = (): UseQuizSessionStudentResult => {
       // isCorrect is intentionally not written by the student to prevent
       // client-side forgery. It is computed by the teacher's results view
       // using gradeAnswer() against the full quiz data loaded from Drive.
+      //
+      // `status` distinguishes a debounced autosave draft (written-response
+      // only) from an explicit submit. The student's `alreadyAnswered` gate
+      // checks for `'submitted'` so a draft autosave doesn't masquerade as
+      // a final answer and prematurely fire the completion card.
       const newAnswer: QuizResponseAnswer = {
         questionId,
         answer,
         answeredAt: Date.now(),
+        status: opts?.isDraft ? 'draft' : 'submitted',
         ...(speedBonus != null && speedBonus > 0
           ? { speedBonus: Math.min(50, Math.max(0, speedBonus)) }
           : {}),

--- a/hooks/useQuizSession.ts
+++ b/hooks/useQuizSession.ts
@@ -1717,6 +1717,18 @@ export const useQuizSessionStudent = (): UseQuizSessionStudentResult => {
         newAnswer,
       ];
 
+      // Don't downgrade a finalized response: if `completeQuiz` already
+      // flipped the doc to `'completed'`, a late autosave/draft write
+      // arriving here (visibility-hidden flush, beforeunload, retry on
+      // a quiz the student already finished) must not revert to
+      // `'in-progress'`. Treats client-side `myResponseRef` as the
+      // freshest signal; it's updated by the `onSnapshot` listener so
+      // it reflects the post-completeQuiz state in the same tab.
+      const nextStatus =
+        myResponseRef.current?.status === 'completed'
+          ? 'completed'
+          : 'in-progress';
+
       await updateDoc(
         doc(
           db,
@@ -1725,7 +1737,7 @@ export const useQuizSessionStudent = (): UseQuizSessionStudentResult => {
           RESPONSES_COLLECTION,
           responseKey
         ),
-        { status: 'in-progress', answers: updated }
+        { status: nextStatus, answers: updated }
       );
     },
     []

--- a/hooks/useStudentAssignments.ts
+++ b/hooks/useStudentAssignments.ts
@@ -121,6 +121,45 @@ interface KindConfig {
   gradingStateFrom: (data: DocumentData) => 'not-graded' | 'graded';
 }
 
+/**
+ * Shared publication-field parser for Quiz / GL `gradingStateFrom`.
+ * Returns 'graded' iff `scoreVisibility` is a non-'none' string AND
+ * `scorePublishedAt` is a number — matching the contract that
+ * `publishAssignmentScores` writes both atomically.
+ *
+ * Malformed snapshots (wrong types) are warned at most once per
+ * `kind:sessionVisibility:sessionPublishedAt` shape signature. Without
+ * this throttle, a single bad doc would `console.warn` on every
+ * snapshot delivery and drown out real errors — `gradingStateFrom` is
+ * called per assignment per snapshot.
+ */
+const warnedPublicationKeys = new Set<string>();
+/** @internal — exported only for the test harness. */
+export function parsePublicationFields(
+  kind: string,
+  data: DocumentData
+): 'not-graded' | 'graded' {
+  if (!data || typeof data !== 'object') return 'not-graded';
+  const visibility = (data as Record<string, unknown>).scoreVisibility;
+  const publishedAt = (data as Record<string, unknown>).scorePublishedAt;
+  if (
+    (visibility !== undefined && typeof visibility !== 'string') ||
+    (publishedAt !== undefined && typeof publishedAt !== 'number')
+  ) {
+    const key = `${kind}:${typeof visibility}:${typeof publishedAt}`;
+    if (!warnedPublicationKeys.has(key)) {
+      warnedPublicationKeys.add(key);
+      console.warn(
+        `[useStudentAssignments] malformed ${kind} publication fields`,
+        { scoreVisibility: visibility, scorePublishedAt: publishedAt }
+      );
+    }
+  }
+  const isVisible = typeof visibility === 'string' && visibility !== 'none';
+  const isPublished = typeof publishedAt === 'number';
+  return isVisible && isPublished ? 'graded' : 'not-graded';
+}
+
 export const KIND_CONFIG: Record<SessionKind, KindConfig> = {
   quiz: {
     collectionName: 'quiz_sessions',
@@ -144,34 +183,7 @@ export const KIND_CONFIG: Record<SessionKind, KindConfig> = {
           : sessionId;
       return `/quiz?code=${encodeURIComponent(code)}`;
     },
-    gradingStateFrom: (data) => {
-      // Quiz uses `scoreVisibility` ('none' = hidden) plus a
-      // `scorePublishedAt` timestamp to mark when grades go live to the
-      // student. Both must be present for the student to see results.
-      // Guard the cast — Firestore can hand back partial/empty snapshots
-      // during deletion races, and a runtime TypeError here would crash
-      // the whole assignment list instead of just dropping one row.
-      if (!data || typeof data !== 'object') return 'not-graded';
-      const visibility = (data as Record<string, unknown>).scoreVisibility;
-      const publishedAt = (data as Record<string, unknown>).scorePublishedAt;
-      // Surface data-shape mismatches — if one field is present but the
-      // other has the wrong type, the student silently sees "Not graded"
-      // on a session the teacher believes they published. This is the
-      // kind of "support ticket with no traces in the data" bug worth a
-      // console.warn so it shows up in error reporting.
-      if (
-        (visibility !== undefined && typeof visibility !== 'string') ||
-        (publishedAt !== undefined && typeof publishedAt !== 'number')
-      ) {
-        console.warn(
-          '[useStudentAssignments] malformed quiz publication fields',
-          { scoreVisibility: visibility, scorePublishedAt: publishedAt }
-        );
-      }
-      const isVisible = typeof visibility === 'string' && visibility !== 'none';
-      const isPublished = typeof publishedAt === 'number';
-      return isVisible && isPublished ? 'graded' : 'not-graded';
-    },
+    gradingStateFrom: (data) => parsePublicationFields('quiz', data),
   },
   'video-activity': {
     collectionName: 'video_activity_sessions',
@@ -216,7 +228,7 @@ export const KIND_CONFIG: Record<SessionKind, KindConfig> = {
         : 'Guided learning',
     hrefFrom: (sessionId) =>
       `/guided-learning/${encodeURIComponent(sessionId)}`,
-    gradingStateFrom: () => 'not-graded',
+    gradingStateFrom: (data) => parsePublicationFields('guided-learning', data),
   },
   'mini-app': {
     collectionName: 'mini_app_sessions',

--- a/hooks/useVideoActivityAssignments.ts
+++ b/hooks/useVideoActivityAssignments.ts
@@ -177,30 +177,39 @@ export interface UseVideoActivityAssignmentsResult {
     options: ImportSharedAssignmentOptions
   ) => Promise<{ assignmentId: string; activityId: string }>;
   /**
-   * Publish (or unpublish) per-student scores for an assignment. Mirrors
+   * Publish per-student scores for an assignment. Mirrors
    * `useQuizAssignments.publishAssignmentScores`. Grades every response
    * via `gradeVideoActivityAnswer` (handles MA / FIB-with-variants — the
    * Quiz grader's `'MA'` blind spot is irrelevant here), writes the
    * computed `score` + per-answer `isCorrect` flags onto each response,
    * and mirrors the visibility flag onto the assignment + session docs.
    *
-   * `'none'` is the unpublish path: clears `scoreVisibility` on assignment
-   * + session and wipes `revealedAnswers`. Already-written `score` /
-   * `isCorrect` are left in place — the reader gates on `scoreVisibility`,
-   * so this is harmless and avoids a multi-batch wipe on a gesture the
-   * teacher may immediately undo.
-   *
    * `'score-responses-and-answers'` populates `session.revealedAnswers`
    * (id → correctAnswer) so the student review screen can show the
    * canonical correct answer for each question — VA's session strips
    * correct answers from `publicQuestions` for the in-progress flow,
    * mirroring Quiz's student-safety pattern.
+   *
+   * The signature deliberately excludes `'none'` — use
+   * {@link UseVideoActivityAssignmentsResult.unpublishAssignmentScores}
+   * for the rollback path, which is a cheap two-write batch that
+   * doesn't require fabricating a placeholder `VideoActivityData`.
    */
   publishAssignmentScores: (
     assignmentId: string,
     activityData: VideoActivityData,
-    visibility: VideoActivityScoreVisibility
+    visibility: Exclude<VideoActivityScoreVisibility, 'none'>
   ) => Promise<{ responsesUpdated: number }>;
+  /**
+   * Revoke published score visibility for an assignment. Clears
+   * `scoreVisibility` + `scorePublishedAt` on the assignment doc (via
+   * `deleteField()`) and wipes `revealedAnswers` on the mirrored
+   * session doc. Already-written per-response `score` / `isCorrect`
+   * fields are left intact — student-side rendering gates on
+   * `session.scoreVisibility`, and re-publishing safely overwrites
+   * them.
+   */
+  unpublishAssignmentScores: (assignmentId: string) => Promise<void>;
 }
 
 export interface ImportSharedAssignmentOptions {
@@ -885,11 +894,58 @@ export const useVideoActivityAssignments = (
     [userId, peekSharedAssignment, createAssignment]
   );
 
+  const unpublishAssignmentScores = useCallback<
+    UseVideoActivityAssignmentsResult['unpublishAssignmentScores']
+  >(
+    async (assignmentId) => {
+      if (!userId) throw new Error('Not authenticated');
+      const now = Date.now();
+      const assignmentRef = doc(
+        db,
+        'users',
+        userId,
+        VIDEO_ACTIVITY_ASSIGNMENTS_COLLECTION,
+        assignmentId
+      );
+      const sessionRef = doc(
+        db,
+        VIDEO_ACTIVITY_SESSIONS_COLLECTION,
+        assignmentId
+      );
+      // Wipe visibility flags via deleteField on both docs (so the
+      // "unpublished" and "never published" states share a single
+      // shape on disk) and clear the revealed-answers map. Per-response
+      // `score` / `isCorrect` are left intact — student-side rendering
+      // gates on `session.scoreVisibility`, and re-publishing safely
+      // overwrites them.
+      const batch = writeBatch(db);
+      batch.update(assignmentRef, {
+        scoreVisibility: deleteField(),
+        scorePublishedAt: deleteField(),
+        updatedAt: now,
+      });
+      batch.update(sessionRef, {
+        scoreVisibility: deleteField(),
+        revealedAnswers: deleteField(),
+      });
+      await batch.commit();
+    },
+    [userId]
+  );
+
   const publishAssignmentScores = useCallback<
     UseVideoActivityAssignmentsResult['publishAssignmentScores']
   >(
     async (assignmentId, activityData, visibility) => {
       if (!userId) throw new Error('Not authenticated');
+      // Belt-and-suspenders against a future caller that bypasses the
+      // type-level `Exclude<…, 'none'>` (see Quiz hook for the same
+      // assert and rationale).
+      if ((visibility as string) === 'none') {
+        throw new Error(
+          'publishAssignmentScores: visibility "none" is not allowed — use unpublishAssignmentScores instead.'
+        );
+      }
 
       const now = Date.now();
       const assignmentRef = doc(
@@ -904,21 +960,6 @@ export const useVideoActivityAssignments = (
         VIDEO_ACTIVITY_SESSIONS_COLLECTION,
         assignmentId
       );
-
-      if (visibility === 'none') {
-        const batch = writeBatch(db);
-        batch.update(assignmentRef, {
-          scoreVisibility: 'none',
-          scorePublishedAt: deleteField(),
-          updatedAt: now,
-        });
-        batch.update(sessionRef, {
-          scoreVisibility: 'none',
-          revealedAnswers: deleteField(),
-        });
-        await batch.commit();
-        return { responsesUpdated: 0 };
-      }
 
       const questionsById = new Map(
         activityData.questions.map((q) => [q.id, q])
@@ -1006,18 +1047,32 @@ export const useVideoActivityAssignments = (
         firstBatch.update(updates[i].ref, updates[i].patch);
       }
       await firstBatch.commit();
+      let responsesCommitted = firstChunkSize;
 
-      for (
-        let cursor = firstChunkSize;
-        cursor < updates.length;
-        cursor += MAX_BATCH_WRITES
-      ) {
-        const chunk = updates.slice(cursor, cursor + MAX_BATCH_WRITES);
-        const chunkBatch = writeBatch(db);
-        for (const u of chunk) {
-          chunkBatch.update(u.ref, u.patch);
+      // Mirror Quiz's chunked-failure recovery: if a subsequent chunk
+      // fails partway, the visibility flag is already flipped — students
+      // will see graded responses while ungraded ones still carry
+      // pre-publish state. Throw a structured error the caller can
+      // surface verbatim so the teacher knows to re-run Publish.
+      try {
+        for (
+          let cursor = firstChunkSize;
+          cursor < updates.length;
+          cursor += MAX_BATCH_WRITES
+        ) {
+          const chunk = updates.slice(cursor, cursor + MAX_BATCH_WRITES);
+          const chunkBatch = writeBatch(db);
+          for (const u of chunk) {
+            chunkBatch.update(u.ref, u.patch);
+          }
+          await chunkBatch.commit();
+          responsesCommitted += chunk.length;
         }
-        await chunkBatch.commit();
+      } catch (err) {
+        const cause = err instanceof Error ? err.message : String(err);
+        throw new Error(
+          `Partial publish: ${responsesCommitted} of ${updates.length} student responses graded. Re-run "Publish scores" to finish. (${cause})`
+        );
       }
 
       return { responsesUpdated: updates.length };
@@ -1040,5 +1095,6 @@ export const useVideoActivityAssignments = (
     peekSharedAssignment,
     importSharedAssignment,
     publishAssignmentScores,
+    unpublishAssignmentScores,
   };
 };

--- a/tests/components/guidedLearning/PublishedGLReview.test.tsx
+++ b/tests/components/guidedLearning/PublishedGLReview.test.tsx
@@ -1,0 +1,179 @@
+/**
+ * Covers the progressive-disclosure contract for the student-facing
+ * published-score review screen. The three visibility levels MUST gate
+ * what the student sees on the `/my-assignments` Completed surface:
+ *
+ *   - score-only:                show percentage, hide per-step answers
+ *   - score-and-responses:       show percentage + per-step student answers
+ *                                tagged correct/incorrect, but NEVER the
+ *                                canonical correct answer.
+ *   - score-responses-and-answers: above + canonical correct answers
+ *                                from session.revealedAnswers
+ *
+ * Without this test, a regression that swaps a `||` for `&&` (or that
+ * accidentally renders revealedAnswers under score-and-responses) silently
+ * leaks correct answers to students.
+ */
+
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import {
+  PublishedGLReview,
+  formatStudentAnswer,
+} from '@/components/guidedLearning/GuidedLearningStudentApp';
+import type { GuidedLearningSession, GuidedLearningResponse } from '@/types';
+
+function fixture(overrides: {
+  visibility: NonNullable<GuidedLearningSession['scoreVisibility']>;
+  studentAnswer?: string | string[];
+  isCorrect?: boolean | null;
+  revealedAnswers?: Record<string, string>;
+}): {
+  session: GuidedLearningSession;
+  myResponse: GuidedLearningResponse;
+} {
+  const session: GuidedLearningSession = {
+    id: 'session-1',
+    title: 'Photosynthesis review',
+    mode: 'guided',
+    imageUrls: [],
+    publicSteps: [
+      {
+        id: 'step-mc',
+        xPct: 0,
+        yPct: 0,
+        imageIndex: 0,
+        label: 'Stage 1',
+        interactionType: 'question',
+        question: {
+          type: 'multiple-choice',
+          text: 'Which produces oxygen?',
+          choices: ['Chlorophyll', 'Mitochondria'],
+        },
+      },
+    ],
+    teacherUid: 'teacher-1',
+    createdAt: 0,
+    scoreVisibility: overrides.visibility,
+    revealedAnswers: overrides.revealedAnswers,
+  };
+  const myResponse: GuidedLearningResponse = {
+    sessionId: 'session-1',
+    studentAnonymousId: 'student-1',
+    startedAt: 1,
+    completedAt: 2,
+    score: 50,
+    answers: [
+      {
+        stepId: 'step-mc',
+        answer: overrides.studentAnswer ?? 'Mitochondria',
+        isCorrect: overrides.isCorrect ?? false,
+      },
+    ],
+  };
+  return { session, myResponse };
+}
+
+describe('PublishedGLReview', () => {
+  it("'score-only' shows just the percentage and hides per-step rows", () => {
+    const { session, myResponse } = fixture({ visibility: 'score-only' });
+    render(
+      <PublishedGLReview
+        session={session}
+        myResponse={myResponse}
+        visibility="score-only"
+      />
+    );
+    expect(screen.getByText('50%')).toBeInTheDocument();
+    // No per-step row — the student answer must NOT appear in the DOM.
+    expect(screen.queryByText(/Mitochondria/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Your answer/)).not.toBeInTheDocument();
+  });
+
+  it("'score-and-responses' shows the student's answer + correct/incorrect, hides canonical answer", () => {
+    const { session, myResponse } = fixture({
+      visibility: 'score-and-responses',
+      revealedAnswers: { 'step-mc': 'Chlorophyll' },
+    });
+    render(
+      <PublishedGLReview
+        session={session}
+        myResponse={myResponse}
+        visibility="score-and-responses"
+      />
+    );
+    expect(screen.getByText('50%')).toBeInTheDocument();
+    // Student answer is visible.
+    expect(screen.getByText('Mitochondria')).toBeInTheDocument();
+    // Canonical correct answer must NOT leak — even though it lives in
+    // the fixture, the visibility level forbids rendering it.
+    expect(screen.queryByText('Chlorophyll')).not.toBeInTheDocument();
+    expect(screen.queryByText(/Correct answer/)).not.toBeInTheDocument();
+  });
+
+  it("'score-responses-and-answers' surfaces the canonical correct answer", () => {
+    const { session, myResponse } = fixture({
+      visibility: 'score-responses-and-answers',
+      revealedAnswers: { 'step-mc': 'Chlorophyll' },
+    });
+    render(
+      <PublishedGLReview
+        session={session}
+        myResponse={myResponse}
+        visibility="score-responses-and-answers"
+      />
+    );
+    expect(screen.getByText('50%')).toBeInTheDocument();
+    expect(screen.getByText('Mitochondria')).toBeInTheDocument();
+    expect(screen.getByText('Chlorophyll')).toBeInTheDocument();
+    expect(screen.getByText(/Correct answer/)).toBeInTheDocument();
+  });
+
+  it('does not show the canonical answer for steps the student got right (no need)', () => {
+    const { session, myResponse } = fixture({
+      visibility: 'score-responses-and-answers',
+      studentAnswer: 'Chlorophyll',
+      isCorrect: true,
+      revealedAnswers: { 'step-mc': 'Chlorophyll' },
+    });
+    render(
+      <PublishedGLReview
+        session={session}
+        myResponse={myResponse}
+        visibility="score-responses-and-answers"
+      />
+    );
+    // The student's correct answer shows; the "Correct answer:" reveal
+    // label is reserved for the incorrect case.
+    expect(screen.getByText('Chlorophyll')).toBeInTheDocument();
+    expect(screen.queryByText(/Correct answer/)).not.toBeInTheDocument();
+  });
+});
+
+describe('formatStudentAnswer', () => {
+  it('renders string answers verbatim', () => {
+    expect(formatStudentAnswer('My answer')).toBe('My answer');
+  });
+
+  it('returns empty string for undefined / empty', () => {
+    expect(formatStudentAnswer(undefined)).toBe('');
+    expect(formatStudentAnswer([])).toBe('');
+  });
+
+  it('splits matching pairs on the FIRST colon (not every colon)', () => {
+    // Regression: previously `.replace(':')` swapped only the first ":"
+    // but for "Ratio: 3:4" the first colon belongs to "Ratio:" — split
+    // on indexOf so multi-colon labels stay legible.
+    expect(formatStudentAnswer(['Ratio: 3:4'])).toBe('Ratio →  3:4');
+    expect(formatStudentAnswer(['left:right'])).toBe('left → right');
+  });
+
+  it('joins multi-entry answers (sorting, matching) with newlines', () => {
+    expect(formatStudentAnswer(['a:1', 'b:2'])).toBe('a → 1\nb → 2');
+    // Sorting items don't contain colons and are joined verbatim.
+    expect(formatStudentAnswer(['first', 'second', 'third'])).toBe(
+      'first\nsecond\nthird'
+    );
+  });
+});

--- a/tests/components/quiz/QuizStudentApp.selfPaced.test.tsx
+++ b/tests/components/quiz/QuizStudentApp.selfPaced.test.tsx
@@ -276,7 +276,12 @@ describe('QuizStudentApp — self-paced flow', () => {
 
     // submitAnswer was invoked once with the chosen answer for Q1.
     expect(mockSubmitAnswer).toHaveBeenCalledTimes(1);
-    expect(mockSubmitAnswer).toHaveBeenCalledWith('q1', '4', undefined);
+    expect(mockSubmitAnswer).toHaveBeenCalledWith(
+      'q1',
+      '4',
+      undefined,
+      undefined
+    );
   });
 
   it('shows a back button when self-paced and not on the first question', async () => {
@@ -346,7 +351,12 @@ describe('QuizStudentApp — self-paced flow', () => {
 
     // submitAnswer fired twice total: q1='4', then q1='5'.
     expect(mockSubmitAnswer).toHaveBeenCalledTimes(2);
-    expect(mockSubmitAnswer).toHaveBeenLastCalledWith('q1', '5', undefined);
+    expect(mockSubmitAnswer).toHaveBeenLastCalledWith(
+      'q1',
+      '5',
+      undefined,
+      undefined
+    );
   });
 
   it('hydrates the saved answer when myResponse arrives after the initial mount (page refresh mid-quiz)', async () => {
@@ -462,7 +472,8 @@ describe('QuizStudentApp — self-paced flow', () => {
       expect(mockSubmitAnswer).toHaveBeenCalledWith(
         'qm-timer',
         'France:Paris|Germany:',
-        0
+        0,
+        undefined
       );
     } finally {
       vi.useRealTimers();
@@ -513,7 +524,8 @@ describe('QuizStudentApp — self-paced flow', () => {
       expect(mockSubmitAnswer).toHaveBeenCalledWith(
         'qo-timer',
         'First|Second|',
-        0
+        0,
+        undefined
       );
     } finally {
       vi.useRealTimers();
@@ -632,6 +644,7 @@ describe('QuizStudentApp — self-paced flow', () => {
     expect(mockSubmitAnswer).toHaveBeenLastCalledWith(
       'qm',
       'France:Paris|Germany:Berlin|Spain:Madrid',
+      undefined,
       undefined
     );
   });
@@ -673,6 +686,7 @@ describe('QuizStudentApp — self-paced flow', () => {
     expect(mockSubmitAnswer).toHaveBeenLastCalledWith(
       'qo',
       'Fourth|Third|Second|First',
+      undefined,
       undefined
     );
   });

--- a/tests/components/quiz/WrittenResponseGrader.annotations.test.tsx
+++ b/tests/components/quiz/WrittenResponseGrader.annotations.test.tsx
@@ -1,5 +1,17 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent, act } from '@testing-library/react';
+
+// EditorModalShell calls these hooks unconditionally. Stub them so the
+// grader can render outside a full provider tree.
+vi.mock('@/context/useDashboard', () => ({
+  useDashboard: () => ({ addToast: vi.fn() }),
+}));
+vi.mock('@/context/useDialog', () => ({
+  useDialog: () => ({
+    showConfirm: vi.fn().mockResolvedValue(true),
+  }),
+}));
+
 import { WrittenResponseGrader } from '@/components/widgets/QuizWidget/components/WrittenResponseGrader';
 import type {
   QuizData,

--- a/tests/hooks/useGuidedLearningAssignments.test.ts
+++ b/tests/hooks/useGuidedLearningAssignments.test.ts
@@ -1,0 +1,525 @@
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+import {
+  collection,
+  doc,
+  getDocs,
+  onSnapshot,
+  writeBatch,
+} from 'firebase/firestore';
+import {
+  useGuidedLearningAssignments,
+  formatCanonicalAnswer,
+} from '@/hooks/useGuidedLearningAssignments';
+import type {
+  GuidedLearningSet,
+  GuidedLearningStep,
+  GuidedLearningQuestion,
+} from '@/types';
+
+// Mirror the Quiz test's sentinel pattern so we can assert deleteField()
+// landed in the right column without a real Firestore SDK in scope.
+const DELETE_FIELD_SENTINEL = Symbol('test:deleteField()');
+
+vi.mock('firebase/firestore', () => ({
+  collection: vi.fn(),
+  deleteField: vi.fn(() => DELETE_FIELD_SENTINEL),
+  doc: vi.fn(),
+  getDocs: vi.fn(),
+  onSnapshot: vi.fn(),
+  query: vi.fn(),
+  orderBy: vi.fn(),
+  setDoc: vi.fn(),
+  updateDoc: vi.fn(),
+  writeBatch: vi.fn(),
+}));
+
+vi.mock('@/config/firebase', () => ({
+  db: {},
+}));
+
+vi.mock('./useSessionViewCount', () => ({
+  invalidateSessionViewCount: vi.fn(),
+}));
+
+// `isAnswerCorrect` is re-exported by the assignments module from
+// useGuidedLearningSession; the test imports the real implementation
+// (the question-type branches are pure functions of the answer key).
+vi.mock('./useGuidedLearningSession', async () => {
+  const actual = await vi.importActual<
+    typeof import('@/hooks/useGuidedLearningSession')
+  >('@/hooks/useGuidedLearningSession');
+  return { isAnswerCorrect: actual.isAnswerCorrect };
+});
+
+const TEACHER_UID = 'teacher-1';
+const ASSIGNMENT_ID = 'assignment-xyz';
+
+const mockDoc = doc as Mock;
+const mockCollection = collection as Mock;
+const mockOnSnapshot = onSnapshot as Mock;
+const mockWriteBatch = writeBatch as Mock;
+const mockGetDocs = getDocs as Mock;
+
+// Tiny test-data factory: a 2-step MC set so the publish math is easy
+// to assert (two questions, both 1 point, total = 2 → percentage easy).
+function mcStep(
+  id: string,
+  correct: string,
+  choices: string[]
+): GuidedLearningStep {
+  return {
+    id,
+    xPct: 0,
+    yPct: 0,
+    imageIndex: 0,
+    interactionType: 'question',
+    question: {
+      type: 'multiple-choice',
+      text: `Question ${id}`,
+      choices,
+      correctAnswer: correct,
+    },
+  };
+}
+
+function mcSet(steps: GuidedLearningStep[]): GuidedLearningSet {
+  return {
+    id: 'set-1',
+    title: 'Test Set',
+    imageUrls: [],
+    steps,
+    mode: 'guided',
+    createdAt: 0,
+    updatedAt: 0,
+  };
+}
+
+describe('useGuidedLearningAssignments — publish / unpublish', () => {
+  const batchUpdate = vi.fn();
+  const batchCommit = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDoc.mockImplementation((_db: unknown, ...segs: string[]) =>
+      segs.join('/')
+    );
+    mockCollection.mockImplementation((_db: unknown, ...segs: string[]) =>
+      segs.join('/')
+    );
+    // The assignments-list listener fires once during render with an
+    // empty snapshot so the hook reaches "loaded" state without us
+    // having to set up dashboard data.
+    mockOnSnapshot.mockImplementation(
+      (_q: unknown, onNext: (snap: { docs: [] }) => void) => {
+        onNext({ docs: [] });
+        return () => undefined;
+      }
+    );
+    batchUpdate.mockReset();
+    batchCommit.mockReset().mockResolvedValue(undefined);
+    mockWriteBatch.mockReturnValue({
+      update: batchUpdate,
+      commit: batchCommit,
+    });
+  });
+
+  it('unpublishAssignmentScores clears flags via deleteField on both docs', async () => {
+    const { result } = renderHook(() =>
+      useGuidedLearningAssignments(TEACHER_UID)
+    );
+    await act(async () => {
+      await result.current.unpublishAssignmentScores(ASSIGNMENT_ID);
+    });
+
+    // Single batch (assignment + session) — no response reads on unpublish.
+    expect(mockGetDocs).not.toHaveBeenCalled();
+    expect(batchCommit).toHaveBeenCalledTimes(1);
+
+    const assignmentCall = batchUpdate.mock.calls.find(
+      ([ref]) =>
+        typeof ref === 'string' &&
+        ref.startsWith(`users/${TEACHER_UID}/guided_learning_assignments/`)
+    );
+    if (!assignmentCall)
+      throw new Error('expected batch.update on assignment doc');
+    expect(assignmentCall[1]).toMatchObject({
+      scoreVisibility: DELETE_FIELD_SENTINEL,
+      scorePublishedAt: DELETE_FIELD_SENTINEL,
+    });
+
+    const sessionCall = batchUpdate.mock.calls.find(
+      ([ref]) =>
+        typeof ref === 'string' && ref.startsWith('guided_learning_sessions/')
+    );
+    if (!sessionCall) throw new Error('expected batch.update on session doc');
+    expect(sessionCall[1]).toMatchObject({
+      scoreVisibility: DELETE_FIELD_SENTINEL,
+      revealedAnswers: DELETE_FIELD_SENTINEL,
+    });
+  });
+
+  it('unpublishAssignmentScores is idempotent', async () => {
+    const { result } = renderHook(() =>
+      useGuidedLearningAssignments(TEACHER_UID)
+    );
+    await act(async () => {
+      await result.current.unpublishAssignmentScores(ASSIGNMENT_ID);
+      await result.current.unpublishAssignmentScores(ASSIGNMENT_ID);
+    });
+    expect(mockGetDocs).not.toHaveBeenCalled();
+    expect(batchCommit).toHaveBeenCalledTimes(2);
+  });
+
+  it("publishAssignmentScores rejects visibility 'none' at runtime", async () => {
+    const { result } = renderHook(() =>
+      useGuidedLearningAssignments(TEACHER_UID)
+    );
+    await act(async () => {
+      await expect(
+        (
+          result.current.publishAssignmentScores as unknown as (
+            id: string,
+            data: unknown,
+            v: string
+          ) => Promise<unknown>
+        )(ASSIGNMENT_ID, mcSet([]), 'none')
+      ).rejects.toThrow(/unpublishAssignmentScores/);
+    });
+    expect(batchCommit).not.toHaveBeenCalled();
+  });
+
+  it('grades responses and writes per-step isCorrect on score-only publish', async () => {
+    const set = mcSet([
+      mcStep('s0', 'a', ['a', 'b']),
+      mcStep('s1', 'b', ['a', 'b']),
+    ]);
+    const refPerfect = { id: 'r-perfect' };
+    const refPartial = { id: 'r-partial' };
+    const refBlank = { id: 'r-blank' };
+    mockGetDocs.mockResolvedValueOnce({
+      docs: [
+        {
+          ref: refPerfect,
+          data: () => ({
+            studentAnonymousId: 'u1',
+            startedAt: 1,
+            completedAt: 2,
+            score: null,
+            answers: [
+              { stepId: 's0', answer: 'a', isCorrect: null },
+              { stepId: 's1', answer: 'b', isCorrect: null },
+            ],
+          }),
+        },
+        {
+          ref: refPartial,
+          data: () => ({
+            studentAnonymousId: 'u2',
+            startedAt: 1,
+            completedAt: 2,
+            score: null,
+            answers: [
+              { stepId: 's0', answer: 'a', isCorrect: null },
+              { stepId: 's1', answer: 'wrong', isCorrect: null },
+            ],
+          }),
+        },
+        // Student who joined but never answered — both gradable steps
+        // count toward the denominator so the score is 0%.
+        {
+          ref: refBlank,
+          data: () => ({
+            studentAnonymousId: 'u3',
+            startedAt: 1,
+            completedAt: 2,
+            score: null,
+            answers: [],
+          }),
+        },
+      ],
+    });
+
+    const { result } = renderHook(() =>
+      useGuidedLearningAssignments(TEACHER_UID)
+    );
+    await act(async () => {
+      const outcome = await result.current.publishAssignmentScores(
+        ASSIGNMENT_ID,
+        set,
+        'score-only'
+      );
+      expect(outcome).toEqual({ responsesUpdated: 3 });
+    });
+
+    expect(batchCommit).toHaveBeenCalledTimes(1);
+
+    // Session patch should NOT carry revealedAnswers on 'score-only'.
+    const sessionCall = batchUpdate.mock.calls.find(
+      ([ref]) =>
+        typeof ref === 'string' && ref.startsWith('guided_learning_sessions/')
+    );
+    if (!sessionCall) throw new Error('expected session update');
+    expect(sessionCall[1]).toMatchObject({
+      scoreVisibility: 'score-only',
+      revealedAnswers: DELETE_FIELD_SENTINEL,
+    });
+
+    const perfectCall = batchUpdate.mock.calls.find(
+      ([ref]) => ref === refPerfect
+    );
+    const partialCall = batchUpdate.mock.calls.find(
+      ([ref]) => ref === refPartial
+    );
+    const blankCall = batchUpdate.mock.calls.find(([ref]) => ref === refBlank);
+    if (!perfectCall || !partialCall || !blankCall) {
+      throw new Error('expected updates on all three response refs');
+    }
+    expect(perfectCall[1]).toMatchObject({ score: 100 });
+    expect(
+      (perfectCall[1] as { answers: { isCorrect: boolean }[] }).answers
+    ).toEqual([
+      expect.objectContaining({ stepId: 's0', isCorrect: true }),
+      expect.objectContaining({ stepId: 's1', isCorrect: true }),
+    ]);
+    expect(partialCall[1]).toMatchObject({ score: 50 });
+    expect(
+      (partialCall[1] as { answers: { isCorrect: boolean }[] }).answers
+    ).toEqual([
+      expect.objectContaining({ stepId: 's0', isCorrect: true }),
+      expect.objectContaining({ stepId: 's1', isCorrect: false }),
+    ]);
+    expect(blankCall[1]).toMatchObject({ score: 0, answers: [] });
+  });
+
+  it('populates revealedAnswers on score-responses-and-answers, formatting matching/sorting too', async () => {
+    const matching: GuidedLearningQuestion = {
+      type: 'matching',
+      text: 'Match',
+      matchingPairs: [
+        { left: 'A', right: '1' },
+        { left: 'B', right: '2' },
+      ],
+    };
+    const sorting: GuidedLearningQuestion = {
+      type: 'sorting',
+      text: 'Sort',
+      sortingItems: ['x', 'y', 'z'],
+    };
+    const set = mcSet([
+      mcStep('s0', 'a', ['a', 'b']),
+      {
+        id: 's1',
+        xPct: 0,
+        yPct: 0,
+        imageIndex: 0,
+        interactionType: 'question',
+        question: matching,
+      },
+      {
+        id: 's2',
+        xPct: 0,
+        yPct: 0,
+        imageIndex: 0,
+        interactionType: 'question',
+        question: sorting,
+      },
+      // Info hotspot (no question) — must NOT appear in revealedAnswers.
+      {
+        id: 's3-info',
+        xPct: 0,
+        yPct: 0,
+        imageIndex: 0,
+        interactionType: 'text-popover',
+      },
+    ]);
+    mockGetDocs.mockResolvedValueOnce({ docs: [] });
+
+    const { result } = renderHook(() =>
+      useGuidedLearningAssignments(TEACHER_UID)
+    );
+    await act(async () => {
+      await result.current.publishAssignmentScores(
+        ASSIGNMENT_ID,
+        set,
+        'score-responses-and-answers'
+      );
+    });
+
+    const sessionCall = batchUpdate.mock.calls.find(
+      ([ref]) =>
+        typeof ref === 'string' && ref.startsWith('guided_learning_sessions/')
+    );
+    if (!sessionCall) throw new Error('expected session update');
+    expect(sessionCall[1]).toMatchObject({
+      scoreVisibility: 'score-responses-and-answers',
+      revealedAnswers: {
+        s0: 'a',
+        s1: 'A → 1\nB → 2',
+        s2: 'x → y → z',
+      },
+    });
+    // Info hotspot is omitted.
+    expect(
+      (sessionCall[1] as { revealedAnswers: Record<string, string> })
+        .revealedAnswers['s3-info']
+    ).toBeUndefined();
+  });
+
+  it('clears stale isCorrect when a step no longer exists', async () => {
+    const set = mcSet([mcStep('s-keep', 'a', ['a', 'b'])]);
+    const refStale = { id: 'r-stale' };
+    mockGetDocs.mockResolvedValueOnce({
+      docs: [
+        {
+          ref: refStale,
+          data: () => ({
+            studentAnonymousId: 'u',
+            startedAt: 1,
+            completedAt: 2,
+            score: 100,
+            answers: [
+              { stepId: 's-keep', answer: 'a', isCorrect: true },
+              // Step that was removed from the canonical set after submission.
+              { stepId: 's-deleted', answer: 'whatever', isCorrect: true },
+            ],
+          }),
+        },
+      ],
+    });
+
+    const { result } = renderHook(() =>
+      useGuidedLearningAssignments(TEACHER_UID)
+    );
+    await act(async () => {
+      await result.current.publishAssignmentScores(
+        ASSIGNMENT_ID,
+        set,
+        'score-and-responses'
+      );
+    });
+
+    const staleCall = batchUpdate.mock.calls.find(([ref]) => ref === refStale);
+    if (!staleCall) throw new Error('expected update on stale response');
+    expect(
+      (staleCall[1] as { answers: { stepId: string; isCorrect: unknown }[] })
+        .answers
+    ).toEqual([
+      expect.objectContaining({ stepId: 's-keep', isCorrect: true }),
+      // Stale step's correctness must be cleared (null) so the response
+      // doesn't carry a claim the canonical set no longer supports.
+      expect.objectContaining({ stepId: 's-deleted', isCorrect: null }),
+    ]);
+  });
+
+  it('surfaces a structured "partial publish" error if a chunk batch fails', async () => {
+    // 500 responses → first batch holds 398, second chunk holds 102.
+    // Force the second commit to reject and assert the error message
+    // calls out how many were graded so the teacher knows to re-run.
+    const set = mcSet([mcStep('s0', 'a', ['a', 'b'])]);
+    const responseDocs = Array.from({ length: 500 }, (_, i) => ({
+      ref: { id: `r${i}` },
+      data: () => ({
+        studentAnonymousId: `u${i}`,
+        startedAt: 1,
+        completedAt: 2,
+        score: null,
+        answers: [{ stepId: 's0', answer: 'a', isCorrect: null }],
+      }),
+    }));
+    mockGetDocs.mockResolvedValueOnce({ docs: responseDocs });
+    batchCommit.mockReset();
+    batchCommit
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new Error('quota exceeded'));
+
+    const { result } = renderHook(() =>
+      useGuidedLearningAssignments(TEACHER_UID)
+    );
+    await act(async () => {
+      await expect(
+        result.current.publishAssignmentScores(ASSIGNMENT_ID, set, 'score-only')
+      ).rejects.toThrow(/Partial publish: \d+ of 500/);
+    });
+  });
+});
+
+describe('formatCanonicalAnswer', () => {
+  it('returns the correctAnswer for multiple-choice', () => {
+    expect(
+      formatCanonicalAnswer(mcStep('s', 'banana', ['apple', 'banana']))
+    ).toBe('banana');
+  });
+
+  it('joins matching pairs with " → " and newline separators', () => {
+    expect(
+      formatCanonicalAnswer({
+        id: 's',
+        xPct: 0,
+        yPct: 0,
+        imageIndex: 0,
+        interactionType: 'question',
+        question: {
+          type: 'matching',
+          text: 'Match',
+          matchingPairs: [
+            { left: 'cat', right: 'meow' },
+            { left: 'dog', right: 'bark' },
+          ],
+        },
+      })
+    ).toBe('cat → meow\ndog → bark');
+  });
+
+  it('joins sorting items with " → "', () => {
+    expect(
+      formatCanonicalAnswer({
+        id: 's',
+        xPct: 0,
+        yPct: 0,
+        imageIndex: 0,
+        interactionType: 'question',
+        question: {
+          type: 'sorting',
+          text: 'Sort',
+          sortingItems: ['first', 'second', 'third'],
+        },
+      })
+    ).toBe('first → second → third');
+  });
+
+  it('returns null for steps without a question (info hotspots)', () => {
+    expect(
+      formatCanonicalAnswer({
+        id: 's',
+        xPct: 0,
+        yPct: 0,
+        imageIndex: 0,
+        interactionType: 'question',
+      })
+    ).toBeNull();
+  });
+
+  it('returns null for matching with no pairs and sorting with no items', () => {
+    expect(
+      formatCanonicalAnswer({
+        id: 's',
+        xPct: 0,
+        yPct: 0,
+        imageIndex: 0,
+        interactionType: 'question',
+        question: { type: 'matching', text: '', matchingPairs: [] },
+      })
+    ).toBeNull();
+    expect(
+      formatCanonicalAnswer({
+        id: 's',
+        xPct: 0,
+        yPct: 0,
+        imageIndex: 0,
+        interactionType: 'question',
+        question: { type: 'sorting', text: '', sortingItems: [] },
+      })
+    ).toBeNull();
+  });
+});

--- a/tests/hooks/useQuizAssignments.test.ts
+++ b/tests/hooks/useQuizAssignments.test.ts
@@ -1133,18 +1133,14 @@ describe('useQuizAssignments - publishAssignmentScores', () => {
     });
   });
 
-  it("clears flags and skips response writes when visibility is 'none'", async () => {
+  it('unpublishAssignmentScores clears flags via deleteField on both docs', async () => {
     const { result } = renderHook(() => useQuizAssignments(TEACHER_UID));
     await act(async () => {
-      const outcome = await result.current.publishAssignmentScores(
-        ASSIGNMENT_ID,
-        quizData,
-        'none'
-      );
-      expect(outcome).toEqual({ responsesUpdated: 0 });
+      await result.current.unpublishAssignmentScores(ASSIGNMENT_ID);
     });
 
-    // Exactly one batch (assignment + session) — no response queries.
+    // Exactly one batch (assignment + session) — no response queries
+    // (the unpublish path leaves per-response scores intact).
     expect(mockGetDocs).not.toHaveBeenCalled();
     expect(batchCommit).toHaveBeenCalledTimes(1);
 
@@ -1157,7 +1153,7 @@ describe('useQuizAssignments - publishAssignmentScores', () => {
       throw new Error('expected batch.update on assignment doc');
     }
     expect(assignmentCall[1]).toMatchObject({
-      scoreVisibility: 'none',
+      scoreVisibility: DELETE_FIELD_SENTINEL,
       scorePublishedAt: DELETE_FIELD_SENTINEL,
     });
 
@@ -1168,9 +1164,37 @@ describe('useQuizAssignments - publishAssignmentScores', () => {
       throw new Error('expected batch.update on session doc');
     }
     expect(sessionCall[1]).toMatchObject({
-      scoreVisibility: 'none',
+      scoreVisibility: DELETE_FIELD_SENTINEL,
       revealedAnswers: DELETE_FIELD_SENTINEL,
     });
+  });
+
+  it('unpublishAssignmentScores is idempotent — second call still writes the same patch', async () => {
+    const { result } = renderHook(() => useQuizAssignments(TEACHER_UID));
+    await act(async () => {
+      await result.current.unpublishAssignmentScores(ASSIGNMENT_ID);
+      await result.current.unpublishAssignmentScores(ASSIGNMENT_ID);
+    });
+    // Two commits, no response reads in either pass.
+    expect(mockGetDocs).not.toHaveBeenCalled();
+    expect(batchCommit).toHaveBeenCalledTimes(2);
+  });
+
+  it("publishAssignmentScores rejects visibility 'none' at runtime", async () => {
+    const { result } = renderHook(() => useQuizAssignments(TEACHER_UID));
+    await act(async () => {
+      await expect(
+        // Bypass the `Exclude<…, 'none'>` type guard at runtime.
+        (
+          result.current.publishAssignmentScores as unknown as (
+            id: string,
+            data: unknown,
+            v: string
+          ) => Promise<unknown>
+        )(ASSIGNMENT_ID, quizData, 'none')
+      ).rejects.toThrow(/unpublishAssignmentScores/);
+    });
+    expect(batchCommit).not.toHaveBeenCalled();
   });
 
   it('grades responses and writes per-answer isCorrect on score-only publish', async () => {

--- a/tests/hooks/useQuizAssignments.test.ts
+++ b/tests/hooks/useQuizAssignments.test.ts
@@ -1165,6 +1165,7 @@ describe('useQuizAssignments - publishAssignmentScores', () => {
     }
     expect(sessionCall[1]).toMatchObject({
       scoreVisibility: DELETE_FIELD_SENTINEL,
+      scorePublishedAt: DELETE_FIELD_SENTINEL,
       revealedAnswers: DELETE_FIELD_SENTINEL,
     });
   });
@@ -1259,6 +1260,13 @@ describe('useQuizAssignments - publishAssignmentScores', () => {
       scoreVisibility: 'score-only',
       revealedAnswers: DELETE_FIELD_SENTINEL,
     });
+    // `scorePublishedAt` must mirror onto the session doc — the
+    // student's `parsePublicationFields` rule requires BOTH fields,
+    // and the student listener only sees the session doc. Skipping
+    // this mirror leaves every student stuck on "Not graded".
+    expect(
+      (sessionCall[1] as { scorePublishedAt?: unknown }).scorePublishedAt
+    ).toBeTypeOf('number');
 
     // Per-response patches carry the computed score plus answers with
     // isCorrect tagged. Locate by ref so the order in mock.calls

--- a/tests/hooks/useStudentAssignments.parsePublicationFields.test.ts
+++ b/tests/hooks/useStudentAssignments.parsePublicationFields.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Unit coverage for the shared `parsePublicationFields` helper that drives
+ * both Quiz and Guided Learning `gradingStateFrom` rules. The rule decides
+ * whether the student's `/my-assignments` row renders "View results" (graded)
+ * or "Not graded" — getting it wrong means students either silently miss a
+ * published score or click into an empty review.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { parsePublicationFields } from '@/hooks/useStudentAssignments';
+
+describe('parsePublicationFields', () => {
+  // `vi.spyOn` with an explicit `typeof console` generic tripped vitest 4's
+  // `Methods<Required<T>>` constraint under the CI tsc ("warn" does not
+  // satisfy the constraint '"Console"'). `vi.mocked(console.warn)` after
+  // setup is the type-safe way to grab the spy in each test without
+  // storing it in a typed `let` — matches the rest of the codebase's
+  // spy patterns.
+  beforeEach(() => {
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const warnSpy = () => vi.mocked(console.warn);
+
+  it("returns 'graded' when scoreVisibility is non-'none' AND scorePublishedAt is a number", () => {
+    expect(
+      parsePublicationFields('quiz', {
+        scoreVisibility: 'score-only',
+        scorePublishedAt: 1234567890,
+      })
+    ).toBe('graded');
+    expect(
+      parsePublicationFields('guided-learning', {
+        scoreVisibility: 'score-responses-and-answers',
+        scorePublishedAt: 1,
+      })
+    ).toBe('graded');
+  });
+
+  it("returns 'not-graded' when scoreVisibility is 'none' regardless of timestamp", () => {
+    // The unpublish branch leaves the doc with `scoreVisibility: deleteField()`
+    // on Firestore (so the field is absent on disk) — but a stale snapshot
+    // or a mid-migration doc could still carry the literal 'none'. Both
+    // paths must downgrade to 'not-graded'.
+    expect(
+      parsePublicationFields('quiz', {
+        scoreVisibility: 'none',
+        scorePublishedAt: 1234,
+      })
+    ).toBe('not-graded');
+  });
+
+  it("returns 'not-graded' when scorePublishedAt is missing even if visibility is set", () => {
+    expect(
+      parsePublicationFields('quiz', {
+        scoreVisibility: 'score-only',
+      })
+    ).toBe('not-graded');
+  });
+
+  it("returns 'not-graded' and console.warns when fields have the wrong type", () => {
+    expect(
+      parsePublicationFields('quiz', {
+        scoreVisibility: 42, // wrong type
+        scorePublishedAt: 'not-a-number', // wrong type
+      })
+    ).toBe('not-graded');
+    expect(warnSpy()).toHaveBeenCalledTimes(1);
+    expect(warnSpy().mock.calls[0][0]).toMatch(/malformed quiz/);
+  });
+
+  it("returns 'not-graded' for null / non-object data without crashing the row", () => {
+    // Firestore can briefly hand back partial snapshots during deletion
+    // races. A runtime TypeError here would crash the whole assignments
+    // list, not just drop one row — this guard is load-bearing.
+    expect(
+      parsePublicationFields(
+        'quiz',
+        null as unknown as Parameters<typeof parsePublicationFields>[1]
+      )
+    ).toBe('not-graded');
+    expect(
+      parsePublicationFields(
+        'quiz',
+        undefined as unknown as Parameters<typeof parsePublicationFields>[1]
+      )
+    ).toBe('not-graded');
+  });
+
+  it('only warns once per (kind, visibility-type, publishedAt-type) signature', () => {
+    // Three repeats of the same malformed shape => exactly one warn.
+    const bad = {
+      scoreVisibility: 99,
+      scorePublishedAt: 'string',
+    };
+    parsePublicationFields('guided-learning', bad);
+    parsePublicationFields('guided-learning', bad);
+    parsePublicationFields('guided-learning', bad);
+    expect(warnSpy()).toHaveBeenCalledTimes(1);
+  });
+});

--- a/types.ts
+++ b/types.ts
@@ -4199,6 +4199,18 @@ export type GuidedLearningQuestionType =
   | 'matching'
   | 'sorting';
 
+/**
+ * Score-visibility levels for a Guided Learning assignment. Structurally
+ * identical to {@link QuizScoreVisibility} and
+ * {@link VideoActivityScoreVisibility} so the shared `PublishScoresModal`
+ * picker works across all three widgets.
+ */
+export type GuidedLearningScoreVisibility =
+  | 'none'
+  | 'score-only'
+  | 'score-and-responses'
+  | 'score-responses-and-answers';
+
 export interface GuidedLearningQuestion {
   type: GuidedLearningQuestionType;
   text: string;
@@ -4426,6 +4438,21 @@ export interface GuidedLearningSession {
   welcomeEnabled?: boolean;
   /** Mirrors `GuidedLearningSet.welcomeMessage`. */
   welcomeMessage?: string;
+  /**
+   * Mirror of {@link GuidedLearningAssignment.scoreVisibility} for the
+   * student-facing `/my-assignments` Completed review screen. Absent /
+   * `'none'` ⇒ the student app shows the "Ask your teacher" placeholder
+   * instead of the score/Trophy screen. Realtime via `onSnapshot`, so
+   * teacher unpublish propagates instantly.
+   */
+  scoreVisibility?: GuidedLearningScoreVisibility;
+  /**
+   * Canonical correct answer per step, keyed by `stepId`. Populated only
+   * when `scoreVisibility === 'score-responses-and-answers'`; cleared
+   * (via `deleteField`) on unpublish so unpublished sessions never leak
+   * answer keys to the client.
+   */
+  revealedAnswers?: Record<string, string>;
 }
 
 /** Per-student response in /guided_learning_sessions/{id}/responses/{studentUid} */
@@ -5917,6 +5944,17 @@ export interface GuidedLearningAssignment {
    *  Stored under `assignmentMode` (not `mode`) to avoid colliding with the
    *  GL session's existing play-mode field. Absent on pre-feature assignments. */
   assignmentMode?: AssignmentMode;
+  /**
+   * Teacher-controlled gate on what students see on the `/my-assignments`
+   * Completed review screen. Absent / `'none'` ⇒ unpublished (Quiz/VA
+   * parity). Set by `publishAssignmentScores`. Mirrored onto
+   * {@link GuidedLearningSession.scoreVisibility} so the realtime student
+   * listener can react without subscribing to teacher-owned docs.
+   */
+  scoreVisibility?: GuidedLearningScoreVisibility;
+  /** Epoch ms of the most recent `publishAssignmentScores` call. Cleared
+   *  (via `deleteField`) on unpublish. */
+  scorePublishedAt?: number;
 }
 
 // === Library folders (Wave 3) ===

--- a/types.ts
+++ b/types.ts
@@ -2697,6 +2697,22 @@ export interface QuizResponseAnswer {
   isCorrect?: boolean;
   /** Percentage speed bonus earned from answering quickly (0–50 means +0% to +50%). */
   speedBonus?: number;
+  /**
+   * Distinguishes a debounced autosave draft (written-response only) from an
+   * explicit submit. Missing on legacy docs written before drafts existed and
+   * on MC/FIB/Matching/Ordering answers (those have no autosave path) —
+   * treat missing as `'submitted'` via {@link isAnswerSubmitted}.
+   */
+  status?: 'draft' | 'submitted';
+}
+
+/**
+ * True when the answer should be treated as the student's final submission.
+ * Returns `true` for legacy rows missing the `status` field — they predate
+ * draft autosave and were always explicit submits.
+ */
+export function isAnswerSubmitted(a: QuizResponseAnswer): boolean {
+  return a.status !== 'draft';
 }
 
 export type QuizResponseStatus = 'joined' | 'in-progress' | 'completed';

--- a/utils/writtenAnnotations.ts
+++ b/utils/writtenAnnotations.ts
@@ -254,6 +254,7 @@ const sliceTextWithAnnotations = (
     }
     const primary = active[0];
     const overlapIds = active.map((a) => a.id).join(',');
+    const isPreview = primary.id === PREVIEW_ANNOTATION_ID;
     out.push(
       React.createElement(
         'mark',
@@ -261,8 +262,12 @@ const sliceTextWithAnnotations = (
           key: `m${ctx.keyCounter++}`,
           'data-annotation-id': primary.id,
           'data-overlap-ids': overlapIds,
-          'data-color': primary.highlightColor ?? 'yellow',
-          className: highlightClass(primary.highlightColor),
+          'data-color': isPreview
+            ? 'preview'
+            : (primary.highlightColor ?? 'yellow'),
+          className: isPreview
+            ? PREVIEW_HIGHLIGHT_CLASS
+            : highlightClass(primary.highlightColor),
         },
         chunk
       )
@@ -270,6 +275,26 @@ const sliceTextWithAnnotations = (
   }
   return out;
 };
+
+/**
+ * Reserved annotation id for the "pending selection" preview mark
+ * rendered while the teacher has drag-selected text but not yet picked
+ * a color. The edit surface injects a synthetic annotation with this
+ * id into the rendered list so the user keeps visual feedback even
+ * after the textarea's autoFocus collapses the native browser
+ * selection. Never persisted — `EditView` swaps it for a real
+ * annotation on the first color click.
+ */
+export const PREVIEW_ANNOTATION_ID = '__preview__';
+
+/**
+ * Distinctive style for the pending-selection preview mark. Soft
+ * violet tint + dashed outline communicates "you've selected this,
+ * pick a color to commit" without claiming one of the real
+ * highlight-color slots.
+ */
+export const PREVIEW_HIGHLIGHT_CLASS =
+  'bg-violet-200/50 outline-dashed outline-1 outline-violet-400 text-inherit rounded-sm px-0.5';
 
 // The four `<mark>` background classes shipped by `highlightClass`.
 // Exported so `tailwind.config.js` can spread them into its `safelist`
@@ -282,6 +307,11 @@ export const HIGHLIGHT_BG_CLASSES = [
   'bg-emerald-300/60',
   'bg-pink-300/60',
   'bg-sky-300/60',
+  // Preview mark for the pending-selection state — see
+  // `PREVIEW_HIGHLIGHT_CLASS`. Kept in the same safelist so a
+  // content-glob regression can't strip just the preview style.
+  'bg-violet-200/50',
+  'outline-violet-400',
 ] as const;
 
 /**


### PR DESCRIPTION
This pull request introduces several improvements and new features to the student experience for Guided Learning and Quiz flows. The changes focus on enhancing real-time response handling, improving score publishing and review, and refining the quiz answer submission logic to better distinguish between drafts and final submissions.

**Guided Learning: Real-time Response Handling and Published Score Review**

* Added a real-time Firestore listener to the Guided Learning student app to track a student's submission and its published status, including error handling for listener failures. This ensures returning students see their results or appropriate messaging without needing to refresh. [[1]](diffhunk://#diff-6eb81c445f0c1403dfb5572c2acc79eac604d350ea45be356a570dd108ede59eR134-R196) [[2]](diffhunk://#diff-6eb81c445f0c1403dfb5572c2acc79eac604d350ea45be356a570dd108ede59eR270-R315)
* Implemented a new `PublishedGLReview` component that displays detailed published results to students, including per-step correctness and, when allowed, canonical answers. Also added a `formatStudentAnswer` helper for consistent answer display. [[1]](diffhunk://#diff-6eb81c445f0c1403dfb5572c2acc79eac604d350ea45be356a570dd108ede59eR540-R555) [[2]](diffhunk://#diff-6eb81c445f0c1403dfb5572c2acc79eac604d350ea45be356a570dd108ede59eR639-R786)
* Updated the completion screen logic to show a neutral "submitted, ask your teacher" placeholder when scores are not yet published, and only show the gamified trophy framing when results are available. [[1]](diffhunk://#diff-6eb81c445f0c1403dfb5572c2acc79eac604d350ea45be356a570dd108ede59eL467-R614) [[2]](diffhunk://#diff-6eb81c445f0c1403dfb5572c2acc79eac604d350ea45be356a570dd108ede59eR540-R555)
* Extended score visibility types to include Guided Learning, ensuring the modal and type unions handle all assignment types.

**Quiz Flow: Draft Handling and Answer Submission Logic**

* Updated the quiz answer submission and completion logic to distinguish between draft (autosaved) and submitted answers, ensuring only final submissions count towards completion and are displayed as answered. This prevents drafts from mistakenly marking a question as answered or triggering completion. [[1]](diffhunk://#diff-dbd9ffbe5b7988c98b32c403ce62e4d1503ec19276c7fb79004788bbf1f1ecb8L400-R411) [[2]](diffhunk://#diff-dbd9ffbe5b7988c98b32c403ce62e4d1503ec19276c7fb79004788bbf1f1ecb8R685-R691) [[3]](diffhunk://#diff-dbd9ffbe5b7988c98b32c403ce62e4d1503ec19276c7fb79004788bbf1f1ecb8L746-R762) [[4]](diffhunk://#diff-dbd9ffbe5b7988c98b32c403ce62e4d1503ec19276c7fb79004788bbf1f1ecb8R968-R973)
* Added internal refs to track response status across unmounts, preventing draft status from overwriting completed submissions during cleanup. [[1]](diffhunk://#diff-dbd9ffbe5b7988c98b32c403ce62e4d1503ec19276c7fb79004788bbf1f1ecb8R1135-R1142) [[2]](diffhunk://#diff-dbd9ffbe5b7988c98b32c403ce62e4d1503ec19276c7fb79004788bbf1f1ecb8R1155-R1163)

**UI/UX and Accessibility Improvements**

* Updated the gallery view's outer wrapper to use explicit viewport height and scrolling, fixing document scroll issues on mobile browsers like iOS Safari.

**Technical and Dependency Updates**

* Added missing imports and type references for new features and error handling. [[1]](diffhunk://#diff-6eb81c445f0c1403dfb5572c2acc79eac604d350ea45be356a570dd108ede59eR24-R32) [[2]](diffhunk://#diff-dbd9ffbe5b7988c98b32c403ce62e4d1503ec19276c7fb79004788bbf1f1ecb8R63)

These changes collectively improve the robustness and clarity of the student experience in both Guided Learning and Quiz modules, especially around submission, review, and published results.