### PR TITLE
Quiz results screenshot protection

### DIFF
--- a/components/common/library/AssignmentArchiveCard.tsx
+++ b/components/common/library/AssignmentArchiveCard.tsx
@@ -277,14 +277,25 @@ export function AssignmentArchiveCard<TAssignment>({
             >
               {PrimaryIcon && <PrimaryIcon size={12} className="shrink-0" />}
               <span>{primaryAction.label}</span>
+              {/* Screen-reader copy of the badge count — the visible pill is a
+                  sibling of the button (so it can render *outside* the button's
+                  layout bounds) and therefore isn't part of the button's
+                  accessible name. This sr-only node appends the count to the
+                  label so a focused screen reader hears "Monitor, 3 students
+                  locked" rather than just "Monitor". */}
+              {typeof primaryAction.badgeCount === 'number' &&
+                primaryAction.badgeCount > 0 && (
+                  <span className="sr-only">
+                    {', '}
+                    {primaryAction.badgeAriaLabel ??
+                      `${primaryAction.badgeCount} item${primaryAction.badgeCount === 1 ? '' : 's'} need attention`}
+                  </span>
+                )}
             </button>
             {typeof primaryAction.badgeCount === 'number' &&
               primaryAction.badgeCount > 0 && (
                 <span
-                  aria-label={
-                    primaryAction.badgeAriaLabel ??
-                    `${primaryAction.badgeCount} item${primaryAction.badgeCount === 1 ? '' : 's'} need attention`
-                  }
+                  aria-hidden="true"
                   className="pointer-events-none absolute -right-1.5 -top-1.5 inline-flex h-4 min-w-4 items-center justify-center rounded-full bg-rose-500 px-1 text-[10px] font-bold leading-none text-white shadow-sm ring-1 ring-white"
                 >
                   {primaryAction.badgeCount}

--- a/components/common/library/AssignmentArchiveCard.tsx
+++ b/components/common/library/AssignmentArchiveCard.tsx
@@ -259,20 +259,38 @@ export function AssignmentArchiveCard<TAssignment>({
         </div>
 
         {/* Primary action — omitted on archived view-only cards where the
-            link is dead and a Copy button would be misleading. */}
+            link is dead and a Copy button would be misleading. The wrapper
+            is `relative` so an optional badge can absolutely-position over
+            the top-right corner without disturbing the button's own layout. */}
         {primaryAction && (
-          <button
-            type="button"
-            onClick={primaryAction.onClick}
-            disabled={primaryAction.disabled}
-            title={
-              primaryAction.disabled ? primaryAction.disabledReason : undefined
-            }
-            className="flex items-center gap-1 shrink-0 px-2.5 py-1 bg-brand-blue-primary hover:bg-brand-blue-dark text-white text-xs font-bold rounded-lg transition-all active:scale-95 disabled:opacity-50 disabled:cursor-not-allowed"
-          >
-            {PrimaryIcon && <PrimaryIcon size={12} className="shrink-0" />}
-            <span>{primaryAction.label}</span>
-          </button>
+          <div className="relative shrink-0">
+            <button
+              type="button"
+              onClick={primaryAction.onClick}
+              disabled={primaryAction.disabled}
+              title={
+                primaryAction.disabled
+                  ? primaryAction.disabledReason
+                  : undefined
+              }
+              className="flex items-center gap-1 px-2.5 py-1 bg-brand-blue-primary hover:bg-brand-blue-dark text-white text-xs font-bold rounded-lg transition-all active:scale-95 disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {PrimaryIcon && <PrimaryIcon size={12} className="shrink-0" />}
+              <span>{primaryAction.label}</span>
+            </button>
+            {typeof primaryAction.badgeCount === 'number' &&
+              primaryAction.badgeCount > 0 && (
+                <span
+                  aria-label={
+                    primaryAction.badgeAriaLabel ??
+                    `${primaryAction.badgeCount} attention`
+                  }
+                  className="pointer-events-none absolute -right-1.5 -top-1.5 inline-flex h-4 min-w-4 items-center justify-center rounded-full bg-rose-500 px-1 text-[10px] font-bold leading-none text-white shadow-sm ring-1 ring-white"
+                >
+                  {primaryAction.badgeCount}
+                </span>
+              )}
+          </div>
         )}
 
         {/* Overflow menu */}

--- a/components/common/library/AssignmentArchiveCard.tsx
+++ b/components/common/library/AssignmentArchiveCard.tsx
@@ -283,7 +283,7 @@ export function AssignmentArchiveCard<TAssignment>({
                 <span
                   aria-label={
                     primaryAction.badgeAriaLabel ??
-                    `${primaryAction.badgeCount} attention`
+                    `${primaryAction.badgeCount} item${primaryAction.badgeCount === 1 ? '' : 's'} need attention`
                   }
                   className="pointer-events-none absolute -right-1.5 -top-1.5 inline-flex h-4 min-w-4 items-center justify-center rounded-full bg-rose-500 px-1 text-[10px] font-bold leading-none text-white shadow-sm ring-1 ring-white"
                 >

--- a/components/common/library/PublishScoresModal.tsx
+++ b/components/common/library/PublishScoresModal.tsx
@@ -122,9 +122,27 @@ export const PublishScoresModal: React.FC<PublishScoresModalProps> = ({
   const [protection, setProtection] = useState<ResultsProtection>(
     () => initialProtection ?? RESULTS_PROTECTION_DEFAULTS
   );
+  // Raw input value for the threshold field so the input can be transiently
+  // empty (or otherwise invalid) while the user is editing without snapping
+  // the persisted `protection.tabWarningThreshold` back to defaults.
+  // Clamp + commit happens on blur and at submit time.
+  const [thresholdInputValue, setThresholdInputValue] = useState<string>(() =>
+    String(
+      (initialProtection ?? RESULTS_PROTECTION_DEFAULTS).tabWarningThreshold
+    )
+  );
 
   const isPublished =
     currentVisibility !== undefined && currentVisibility !== 'none';
+
+  const clampThreshold = (raw: string): number | null => {
+    const parsed = Number.parseInt(raw, 10);
+    if (!Number.isFinite(parsed)) return null;
+    return Math.min(
+      RESULTS_TAB_WARNING_THRESHOLD_MAX,
+      Math.max(RESULTS_TAB_WARNING_THRESHOLD_MIN, parsed)
+    );
+  };
 
   const handleConfirm = async (visibility: PublishScoresVisibility) => {
     if (submitting) return;
@@ -133,7 +151,14 @@ export const PublishScoresModal: React.FC<PublishScoresModalProps> = ({
       // Only forward protection when the caller wired the fieldset — VA/GL
       // stay on the original two-arg signature.
       if (showProtection) {
-        await onConfirm(visibility, protection);
+        // Force a final clamp from the input string so the user's last
+        // keystrokes are honored even if they never blurred the field.
+        const clamped = clampThreshold(thresholdInputValue);
+        const finalProtection: ResultsProtection = {
+          ...protection,
+          tabWarningThreshold: clamped ?? protection.tabWarningThreshold,
+        };
+        await onConfirm(visibility, finalProtection);
       } else {
         await onConfirm(visibility);
       }
@@ -143,14 +168,25 @@ export const PublishScoresModal: React.FC<PublishScoresModalProps> = ({
   };
 
   const handleThresholdChange = (raw: string) => {
-    const parsed = Number.parseInt(raw, 10);
-    const clamped = Number.isFinite(parsed)
-      ? Math.min(
-          RESULTS_TAB_WARNING_THRESHOLD_MAX,
-          Math.max(RESULTS_TAB_WARNING_THRESHOLD_MIN, parsed)
-        )
-      : RESULTS_PROTECTION_DEFAULTS.tabWarningThreshold;
-    setProtection((p) => ({ ...p, tabWarningThreshold: clamped }));
+    // Allow free-form editing — including transiently empty values. Clamp
+    // happens on blur (and as a safety net at submit time).
+    setThresholdInputValue(raw);
+  };
+
+  const handleThresholdBlur = () => {
+    const clamped = clampThreshold(thresholdInputValue);
+    const next = clamped ?? RESULTS_PROTECTION_DEFAULTS.tabWarningThreshold;
+    setProtection((p) => ({ ...p, tabWarningThreshold: next }));
+    setThresholdInputValue(String(next));
+  };
+
+  const handleTabWarningToggle = (enabled: boolean) => {
+    setProtection((p) => ({ ...p, tabWarningEnabled: enabled }));
+    if (enabled) {
+      // Re-sync the input string with the current persisted threshold so the
+      // field shows a sensible value when it reappears.
+      setThresholdInputValue(String(protection.tabWarningThreshold));
+    }
   };
 
   return (
@@ -269,12 +305,7 @@ export const PublishScoresModal: React.FC<PublishScoresModalProps> = ({
               <input
                 type="checkbox"
                 checked={protection.tabWarningEnabled}
-                onChange={(e) =>
-                  setProtection((p) => ({
-                    ...p,
-                    tabWarningEnabled: e.target.checked,
-                  }))
-                }
+                onChange={(e) => handleTabWarningToggle(e.target.checked)}
                 disabled={submitting}
                 className="mt-0.5 h-4 w-4 rounded border-slate-300 text-brand-blue-primary focus:ring-brand-blue-primary/40"
               />
@@ -297,8 +328,9 @@ export const PublishScoresModal: React.FC<PublishScoresModalProps> = ({
                   type="number"
                   min={RESULTS_TAB_WARNING_THRESHOLD_MIN}
                   max={RESULTS_TAB_WARNING_THRESHOLD_MAX}
-                  value={protection.tabWarningThreshold}
+                  value={thresholdInputValue}
                   onChange={(e) => handleThresholdChange(e.target.value)}
+                  onBlur={handleThresholdBlur}
                   disabled={submitting}
                   className="w-16 rounded-md border border-slate-300 bg-white px-2 py-1 text-sm text-slate-900 focus:outline-none focus:ring-2 focus:ring-brand-blue-primary/40"
                 />

--- a/components/common/library/PublishScoresModal.tsx
+++ b/components/common/library/PublishScoresModal.tsx
@@ -31,10 +31,14 @@ import {
   X,
 } from 'lucide-react';
 import { Modal } from '@/components/common/Modal';
-import type {
-  GuidedLearningScoreVisibility,
-  QuizScoreVisibility,
-  VideoActivityScoreVisibility,
+import {
+  RESULTS_PROTECTION_DEFAULTS,
+  RESULTS_TAB_WARNING_THRESHOLD_MAX,
+  RESULTS_TAB_WARNING_THRESHOLD_MIN,
+  type GuidedLearningScoreVisibility,
+  type QuizScoreVisibility,
+  type ResultsProtection,
+  type VideoActivityScoreVisibility,
 } from '@/types';
 
 /**
@@ -53,7 +57,22 @@ interface PublishScoresModalProps {
   /** Currently-published level (or 'none' / undefined when nothing is published yet). */
   currentVisibility: PublishScoresVisibility | undefined;
   onClose: () => void;
-  onConfirm: (visibility: PublishScoresVisibility) => Promise<void> | void;
+  onConfirm: (
+    visibility: PublishScoresVisibility,
+    protection?: ResultsProtection
+  ) => Promise<void> | void;
+  /**
+   * Quiz-only opt-in: when true, render the anti-screenshot protection
+   * fieldset (watermark + tab-switch warning) below the visibility picker.
+   * VA and GL pass nothing and the fieldset stays hidden.
+   */
+  showProtection?: boolean;
+  /**
+   * Initial protection state. Caller (Quiz Widget) pre-fills this from
+   * `appSettings.lastResultsProtection ?? RESULTS_PROTECTION_DEFAULTS` so
+   * the teacher's last choice is remembered across publishes.
+   */
+  initialProtection?: ResultsProtection;
 }
 
 interface VisibilityOption {
@@ -89,6 +108,8 @@ export const PublishScoresModal: React.FC<PublishScoresModalProps> = ({
   currentVisibility,
   onClose,
   onConfirm,
+  showProtection = false,
+  initialProtection,
 }) => {
   // Default the picker to whatever the assignment is currently set to (or
   // 'score-only' on first publish — the calmest non-empty choice).
@@ -98,6 +119,9 @@ export const PublishScoresModal: React.FC<PublishScoresModalProps> = ({
       : 'score-only';
   const [selected, setSelected] = useState<PublishScoresVisibility>(initial);
   const [submitting, setSubmitting] = useState(false);
+  const [protection, setProtection] = useState<ResultsProtection>(
+    () => initialProtection ?? RESULTS_PROTECTION_DEFAULTS
+  );
 
   const isPublished =
     currentVisibility !== undefined && currentVisibility !== 'none';
@@ -106,10 +130,27 @@ export const PublishScoresModal: React.FC<PublishScoresModalProps> = ({
     if (submitting) return;
     setSubmitting(true);
     try {
-      await onConfirm(visibility);
+      // Only forward protection when the caller wired the fieldset — VA/GL
+      // stay on the original two-arg signature.
+      if (showProtection) {
+        await onConfirm(visibility, protection);
+      } else {
+        await onConfirm(visibility);
+      }
     } finally {
       setSubmitting(false);
     }
+  };
+
+  const handleThresholdChange = (raw: string) => {
+    const parsed = Number.parseInt(raw, 10);
+    const clamped = Number.isFinite(parsed)
+      ? Math.min(
+          RESULTS_TAB_WARNING_THRESHOLD_MAX,
+          Math.max(RESULTS_TAB_WARNING_THRESHOLD_MIN, parsed)
+        )
+      : RESULTS_PROTECTION_DEFAULTS.tabWarningThreshold;
+    setProtection((p) => ({ ...p, tabWarningThreshold: clamped }));
   };
 
   return (
@@ -195,6 +236,76 @@ export const PublishScoresModal: React.FC<PublishScoresModalProps> = ({
             );
           })}
         </div>
+
+        {showProtection && (
+          <fieldset className="rounded-xl border border-slate-200 bg-slate-50/60 px-4 py-3 space-y-2">
+            <legend className="px-1 text-xs font-bold uppercase tracking-wide text-slate-500">
+              Protection
+            </legend>
+            <label className="flex items-start gap-3 cursor-pointer">
+              <input
+                type="checkbox"
+                checked={protection.watermarkEnabled}
+                onChange={(e) =>
+                  setProtection((p) => ({
+                    ...p,
+                    watermarkEnabled: e.target.checked,
+                  }))
+                }
+                disabled={submitting}
+                className="mt-0.5 h-4 w-4 rounded border-slate-300 text-brand-blue-primary focus:ring-brand-blue-primary/40"
+              />
+              <span className="flex-1">
+                <span className="block text-sm font-semibold text-slate-900">
+                  Watermark
+                </span>
+                <span className="block text-xs text-slate-600 leading-relaxed">
+                  Overlay each result page with the student&apos;s name and the
+                  publish timestamp to discourage screenshots.
+                </span>
+              </span>
+            </label>
+            <label className="flex items-start gap-3 cursor-pointer">
+              <input
+                type="checkbox"
+                checked={protection.tabWarningEnabled}
+                onChange={(e) =>
+                  setProtection((p) => ({
+                    ...p,
+                    tabWarningEnabled: e.target.checked,
+                  }))
+                }
+                disabled={submitting}
+                className="mt-0.5 h-4 w-4 rounded border-slate-300 text-brand-blue-primary focus:ring-brand-blue-primary/40"
+              />
+              <span className="flex-1">
+                <span className="block text-sm font-semibold text-slate-900">
+                  Tab-switch warning
+                </span>
+                <span className="block text-xs text-slate-600 leading-relaxed">
+                  Warn students when they leave the results tab; lock access
+                  after the threshold is reached.
+                </span>
+              </span>
+            </label>
+            {protection.tabWarningEnabled && (
+              <label className="flex items-center gap-3 pl-7">
+                <span className="text-xs text-slate-700">
+                  Warnings before lockout
+                </span>
+                <input
+                  type="number"
+                  min={RESULTS_TAB_WARNING_THRESHOLD_MIN}
+                  max={RESULTS_TAB_WARNING_THRESHOLD_MAX}
+                  value={protection.tabWarningThreshold}
+                  onChange={(e) => handleThresholdChange(e.target.value)}
+                  disabled={submitting}
+                  className="w-16 rounded-md border border-slate-300 bg-white px-2 py-1 text-sm text-slate-900 focus:outline-none focus:ring-2 focus:ring-brand-blue-primary/40"
+                />
+              </label>
+            )}
+          </fieldset>
+        )}
 
         <div className="pt-2 flex flex-col-reverse sm:flex-row gap-2 sm:justify-between">
           {isPublished ? (

--- a/components/common/library/types.ts
+++ b/components/common/library/types.ts
@@ -79,6 +79,19 @@ export interface LibraryPrimaryAction {
   onClick: () => void;
   disabled?: boolean;
   disabledReason?: string;
+  /**
+   * Optional count rendered as a small rose-coloured badge over the top-right
+   * corner of the button. Hidden when undefined or `<= 0`. Used to surface
+   * attention-needing state, e.g. number of quiz students whose results are
+   * currently locked out and awaiting teacher action.
+   */
+  badgeCount?: number;
+  /**
+   * Accessible label override for the badge. Required when `badgeCount` is
+   * set so screen readers get a meaningful announcement (e.g. "3 students
+   * locked") rather than just the raw count.
+   */
+  badgeAriaLabel?: string;
 }
 
 /**

--- a/components/quiz/QuizStudentApp.tsx
+++ b/components/quiz/QuizStudentApp.tsx
@@ -2572,19 +2572,13 @@ const PublishedScoreReview: React.FC<{
   // informational — its job is to discourage shared screenshots, not to
   // authenticate.
   const watermarkEnabled = session.protection?.watermarkEnabled === true;
-  // Snapshot `Date.now()` once per mount when the session has no
-  // `scorePublishedAt` (legacy / mid-publish). Calling `Date.now()` directly
-  // in render is impure and trips react-hooks/purity. Wrapping in `useMemo`
-  // with a stable dep makes the fallback deterministic for the lifetime of
-  // this view — a tiny inaccuracy on the watermark stamp vs. the eventual
-  // real publish time, which the listener will update naturally on the next
-  // render once the field arrives.
-  const sessionPublishedAt = session.scorePublishedAt;
-  // Lazy-init via `useState` keeps the fallback timestamp stable across
-  // re-renders without calling `Date.now()` in render (which would violate
-  // react-hooks/purity). `useState(fn)` runs `fn` exactly once at mount.
+  // When the session has no `scorePublishedAt` (legacy or mid-publish), fall
+  // back to a per-mount snapshot of `Date.now()`. `useState(fn)` runs `fn`
+  // exactly once at mount, giving us a stable timestamp without calling
+  // `Date.now()` in render (which would violate react-hooks/purity). The
+  // listener will swap in the real publish time on its next snapshot.
   const [fallbackPublishedAt] = useState(() => Date.now());
-  const publishedAt = sessionPublishedAt ?? fallbackPublishedAt;
+  const publishedAt = session.scorePublishedAt ?? fallbackPublishedAt;
   // Treat blank/whitespace-only displayName as missing so we still fall through
   // to the PIN label when an SSO provider returns an empty string.
   const trimmedDisplayName = auth.currentUser?.displayName?.trim() ?? '';

--- a/components/quiz/QuizStudentApp.tsx
+++ b/components/quiz/QuizStudentApp.tsx
@@ -72,6 +72,8 @@ import { OrderingResponseInput } from './OrderingResponseInput';
 import { TeacherPreviewBanner } from '@/components/student/TeacherPreviewBanner';
 import { usePreviewMode } from '@/hooks/usePreviewMode';
 import { ResultsWatermark } from './ResultsWatermark';
+import { ResultsTabWarningModal } from './ResultsTabWarningModal';
+import { useResultsTabWarnings } from '@/hooks/useResultsTabWarnings';
 import {
   getScoreSuffix,
   isGamificationActive,
@@ -2589,6 +2591,53 @@ const PublishedScoreReview: React.FC<{
         ? `PIN ${pin}`
         : 'Student';
 
+  // ─── Tab-switch warning protection ─────────────────────────────────────────
+  // Listens for visibility/focus loss; each return increments the warning
+  // counter on the response doc and (at threshold) flips `resultsLockedOut`
+  // true. The modal pops only when the count goes UP while the student is
+  // viewing this page — we seed `shownForCount` from the persisted value at
+  // mount so a stale count from a previous session doesn't auto-pop the modal
+  // on first render. Lockout flips trigger a redirect to /my-assignments,
+  // where the row will render in its locked state.
+  const tabWarningEnabled = session.protection?.tabWarningEnabled === true;
+  const threshold = session.protection?.tabWarningThreshold ?? 3;
+  const currentWarnings = myResponse.resultsTabWarnings ?? 0;
+  const lockedOut = myResponse.resultsLockedOut === true;
+
+  const [shownForCount, setShownForCount] = useState(() => currentWarnings);
+  const modalOpen =
+    tabWarningEnabled && currentWarnings > shownForCount && !lockedOut;
+
+  // `myResponse._responseKey` is the Firestore doc id, populated at read time
+  // by the session-student listener (see `useQuizSession.ts` L1065). The path
+  // mirrors how the response listener constructs its doc ref.
+  const responseKey = myResponse._responseKey;
+  useResultsTabWarnings({
+    enabled: tabWarningEnabled && Boolean(responseKey),
+    threshold,
+    currentWarnings,
+    lockedOut,
+    responseDocPath: responseKey
+      ? `quiz_sessions/${session.id}/responses/${responseKey}`
+      : '',
+  });
+
+  // Lockout → redirect. The MyAssignments page will show the locked card.
+  // We set the saved filter to 'completed' first so the student lands on the
+  // tab that actually contains the locked row (active-tab would hide it).
+  // No react-router in this app — match the existing `window.location.assign`
+  // pattern used by `ReturnToAssignmentsButton`.
+  useEffect(() => {
+    if (!lockedOut) return;
+    try {
+      window.sessionStorage.setItem('sb_my_assignments_filter', 'completed');
+    } catch {
+      // sessionStorage may be disabled (privacy mode); the page will just
+      // open on its default filter, which is fine.
+    }
+    window.location.assign('/my-assignments');
+  }, [lockedOut]);
+
   // Per-question cards dominate this view (snapshot + teacher
   // annotations + score + comment block), so the container is sized
   // generously — written-response reviews benefit much more from
@@ -2604,6 +2653,12 @@ const PublishedScoreReview: React.FC<{
           publishedAt={publishedAt}
         />
       )}
+      <ResultsTabWarningModal
+        open={modalOpen}
+        warningCount={currentWarnings}
+        threshold={threshold}
+        onDismiss={() => setShownForCount(currentWarnings)}
+      />
       <div className="mx-auto w-full max-w-6xl">
         <header className="mb-6 flex flex-col items-center text-center">
           <Trophy className="mb-4 h-12 w-12 text-amber-400" />

--- a/components/quiz/QuizStudentApp.tsx
+++ b/components/quiz/QuizStudentApp.tsx
@@ -71,6 +71,7 @@ import { MatchingResponseInput } from './MatchingResponseInput';
 import { OrderingResponseInput } from './OrderingResponseInput';
 import { TeacherPreviewBanner } from '@/components/student/TeacherPreviewBanner';
 import { usePreviewMode } from '@/hooks/usePreviewMode';
+import { ResultsWatermark } from './ResultsWatermark';
 import {
   getScoreSuffix,
   isGamificationActive,
@@ -2561,6 +2562,39 @@ const PublishedScoreReview: React.FC<{
     (a) => autoGradedQuestionIds.has(a.questionId) && a.isCorrect === true
   ).length;
 
+  // Watermark overlay — rendered above content via fixed positioning, below
+  // any future modal dialogs (z-50, well below `Z_INDEX.modal`/`Z_INDEX.toast`
+  // from `config/zIndex.ts`). Strictly decorative + pointer-events-none, so
+  // it doesn't interfere with scrolling, focus, or selection beneath it.
+  // Student display name is best-effort: SSO joiners carry an
+  // `auth.currentUser.displayName`; anonymous PIN joiners fall back to their
+  // PIN; otherwise we use a generic 'Student' label. The watermark is
+  // informational — its job is to discourage shared screenshots, not to
+  // authenticate.
+  const watermarkEnabled = session.protection?.watermarkEnabled === true;
+  // Snapshot `Date.now()` once per mount when the session has no
+  // `scorePublishedAt` (legacy / mid-publish). Calling `Date.now()` directly
+  // in render is impure and trips react-hooks/purity. Wrapping in `useMemo`
+  // with a stable dep makes the fallback deterministic for the lifetime of
+  // this view — a tiny inaccuracy on the watermark stamp vs. the eventual
+  // real publish time, which the listener will update naturally on the next
+  // render once the field arrives.
+  const sessionPublishedAt = session.scorePublishedAt;
+  // Lazy-init via `useState` keeps the fallback timestamp stable across
+  // re-renders without calling `Date.now()` in render (which would violate
+  // react-hooks/purity). `useState(fn)` runs `fn` exactly once at mount.
+  const [fallbackPublishedAt] = useState(() => Date.now());
+  const publishedAt = sessionPublishedAt ?? fallbackPublishedAt;
+  // Treat blank/whitespace-only displayName as missing so we still fall through
+  // to the PIN label when an SSO provider returns an empty string.
+  const trimmedDisplayName = auth.currentUser?.displayName?.trim() ?? '';
+  const watermarkStudentName =
+    trimmedDisplayName.length > 0
+      ? trimmedDisplayName
+      : pin
+        ? `PIN ${pin}`
+        : 'Student';
+
   // Per-question cards dominate this view (snapshot + teacher
   // annotations + score + comment block), so the container is sized
   // generously — written-response reviews benefit much more from
@@ -2570,6 +2604,12 @@ const PublishedScoreReview: React.FC<{
   // active-quiz screen uses — see comment there for why.
   return (
     <div className="h-screen overflow-y-auto overflow-x-hidden bg-slate-900 px-4 py-8 sm:px-6 sm:py-12">
+      {watermarkEnabled && (
+        <ResultsWatermark
+          studentName={watermarkStudentName}
+          publishedAt={publishedAt}
+        />
+      )}
       <div className="mx-auto w-full max-w-6xl">
         <header className="mb-6 flex flex-col items-center text-center">
           <Trophy className="mb-4 h-12 w-12 text-amber-400" />

--- a/components/quiz/ResultsTabWarningModal.tsx
+++ b/components/quiz/ResultsTabWarningModal.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Z_INDEX } from '@/config/zIndex';
 
 interface ResultsTabWarningModalProps {
   /** Visible only when the student just returned from a tab switch. */
@@ -12,6 +13,11 @@ interface ResultsTabWarningModalProps {
  * Shown after the student returns to the results tab. Modal copy reveals the
  * current count and threshold ("Warning 2 of 3") so the student can self-correct
  * rather than treating lockout as a black-box gotcha.
+ *
+ * Backdrop click does NOT dismiss — the student must acknowledge the warning by
+ * clicking the button. Focus trap is deliberately omitted (this is a notice-style
+ * modal with nothing dangerous behind it), but the dismiss button receives
+ * initial focus so keyboard users can confirm with Enter immediately.
  */
 export const ResultsTabWarningModal: React.FC<ResultsTabWarningModalProps> = ({
   open,
@@ -19,20 +25,19 @@ export const ResultsTabWarningModal: React.FC<ResultsTabWarningModalProps> = ({
   threshold,
   onDismiss,
 }) => {
+  const titleId = React.useId();
   if (!open) return null;
   const remaining = Math.max(0, threshold - warningCount);
   return (
     <div
       role="dialog"
       aria-modal="true"
-      aria-labelledby="results-tab-warning-title"
-      className="fixed inset-0 z-[100] flex items-center justify-center bg-black/60 backdrop-blur-sm"
+      aria-labelledby={titleId}
+      className="fixed inset-0 flex items-center justify-center bg-black/60 backdrop-blur-sm"
+      style={{ zIndex: Z_INDEX.modal }}
     >
       <div className="mx-4 max-w-md rounded-xl border border-white/20 bg-slate-900 p-6 shadow-2xl">
-        <h2
-          id="results-tab-warning-title"
-          className="text-lg font-semibold text-white"
-        >
+        <h2 id={titleId} className="text-lg font-semibold text-white">
           Stay on this tab
         </h2>
         <p className="mt-3 text-sm text-white/80">
@@ -46,6 +51,7 @@ export const ResultsTabWarningModal: React.FC<ResultsTabWarningModalProps> = ({
         </p>
         <button
           type="button"
+          autoFocus
           onClick={onDismiss}
           className="mt-5 w-full rounded-lg bg-brand-blue-primary px-4 py-2 text-sm font-medium text-white hover:bg-brand-blue-dark"
         >

--- a/components/quiz/ResultsTabWarningModal.tsx
+++ b/components/quiz/ResultsTabWarningModal.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+
+interface ResultsTabWarningModalProps {
+  /** Visible only when the student just returned from a tab switch. */
+  open: boolean;
+  warningCount: number;
+  threshold: number;
+  onDismiss: () => void;
+}
+
+/**
+ * Shown after the student returns to the results tab. Modal copy reveals the
+ * current count and threshold ("Warning 2 of 3") so the student can self-correct
+ * rather than treating lockout as a black-box gotcha.
+ */
+export const ResultsTabWarningModal: React.FC<ResultsTabWarningModalProps> = ({
+  open,
+  warningCount,
+  threshold,
+  onDismiss,
+}) => {
+  if (!open) return null;
+  const remaining = Math.max(0, threshold - warningCount);
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="results-tab-warning-title"
+      className="fixed inset-0 z-[100] flex items-center justify-center bg-black/60 backdrop-blur-sm"
+    >
+      <div className="mx-4 max-w-md rounded-xl border border-white/20 bg-slate-900 p-6 shadow-2xl">
+        <h2
+          id="results-tab-warning-title"
+          className="text-lg font-semibold text-white"
+        >
+          Stay on this tab
+        </h2>
+        <p className="mt-3 text-sm text-white/80">
+          You left the results page. Your teacher is tracking this.
+        </p>
+        <p className="mt-2 text-sm font-medium text-amber-300">
+          Warning {warningCount} of {threshold}
+          {remaining > 0
+            ? ` — ${remaining} more will lock you out.`
+            : ' — next time you leave, you will be locked out.'}
+        </p>
+        <button
+          type="button"
+          onClick={onDismiss}
+          className="mt-5 w-full rounded-lg bg-brand-blue-primary px-4 py-2 text-sm font-medium text-white hover:bg-brand-blue-dark"
+        >
+          I understand
+        </button>
+      </div>
+    </div>
+  );
+};

--- a/components/quiz/ResultsWatermark.tsx
+++ b/components/quiz/ResultsWatermark.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+
+interface ResultsWatermarkProps {
+  /** Display name shown in the watermark. Sanitized via React text node interpolation. */
+  studentName: string;
+  /** ms timestamp of when the teacher published — formatted to locale string. */
+  publishedAt: number;
+}
+
+/**
+ * Repeating diagonal low-opacity SVG watermark overlaid on the published-quiz
+ * results view. Rotates the pattern at -30deg and tiles it across the entire
+ * viewport. Strictly decorative — `pointer-events-none` + `aria-hidden` so it
+ * does not interfere with focus, screen readers, or interaction.
+ *
+ * Why SVG <pattern> over CSS-grid tiles: pattern with `patternTransform` rotates
+ * the tile (not just each label), so the diagonal repeat is seamless across the
+ * full page regardless of viewport size. CSS-grid would clip the rotation at
+ * the container edges.
+ */
+export const ResultsWatermark: React.FC<ResultsWatermarkProps> = ({
+  studentName,
+  publishedAt,
+}) => {
+  const patternId = React.useId();
+  const label = `${studentName} • ${new Date(publishedAt).toLocaleString()}`;
+  return (
+    <svg
+      role="presentation"
+      aria-hidden="true"
+      className="pointer-events-none fixed inset-0 z-50 h-full w-full select-none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <defs>
+        <pattern
+          id={patternId}
+          x="0"
+          y="0"
+          width="360"
+          height="120"
+          patternUnits="userSpaceOnUse"
+          patternTransform="rotate(-30)"
+        >
+          <text
+            x="0"
+            y="60"
+            fontFamily="ui-monospace, SFMono-Regular, Menlo, monospace"
+            fontSize="14"
+            fill="currentColor"
+            opacity="0.12"
+          >
+            {label}
+          </text>
+        </pattern>
+      </defs>
+      <rect width="100%" height="100%" fill={`url(#${patternId})`} />
+    </svg>
+  );
+};

--- a/components/quiz/ResultsWatermark.tsx
+++ b/components/quiz/ResultsWatermark.tsx
@@ -28,7 +28,7 @@ export const ResultsWatermark: React.FC<ResultsWatermarkProps> = ({
     <svg
       role="presentation"
       aria-hidden="true"
-      className="pointer-events-none fixed inset-0 z-50 h-full w-full select-none"
+      className="pointer-events-none fixed inset-0 z-50 h-full w-full select-none text-white"
       xmlns="http://www.w3.org/2000/svg"
     >
       <defs>
@@ -44,7 +44,7 @@ export const ResultsWatermark: React.FC<ResultsWatermarkProps> = ({
           <text
             x="0"
             y="60"
-            fontFamily="ui-monospace, SFMono-Regular, Menlo, monospace"
+            fontFamily="'Roboto Mono', ui-monospace, SFMono-Regular, Menlo, monospace"
             fontSize="14"
             fill="currentColor"
             opacity="0.12"

--- a/components/student/AssignmentListItem.tsx
+++ b/components/student/AssignmentListItem.tsx
@@ -228,7 +228,11 @@ export const AssignmentListItem: React.FC<AssignmentListItemProps> = ({
 
   return (
     <a
-      href={assignment.openHref}
+      // Omit href entirely when locked so middle-click, cmd-click, ctrl-click,
+      // and shift-click can't bypass the onClick guard (which only blocks
+      // primary-button left clicks). An hrefless <a> is non-navigable in all
+      // click modes, making aria-disabled semantically truthful.
+      href={lockedOut ? undefined : assignment.openHref}
       onClick={handleClick}
       aria-busy={isPending ? true : undefined}
       aria-disabled={lockedOut ? true : undefined}
@@ -283,14 +287,19 @@ export const AssignmentListItem: React.FC<AssignmentListItemProps> = ({
         </span>
       )}
 
-      <span
-        className={`hidden shrink-0 rounded-lg px-3 py-1.5 text-xs font-semibold transition sm:inline-flex ${getChipClass(
-          { isPending, isCompleted, isGraded }
-        )}`}
-        aria-hidden="true"
-      >
-        {getChipLabel({ isPending, isCompleted, isGraded })}
-      </span>
+      {/* Suppress the right-side status chip when locked so the "Locked" pill
+          is the single, dominant signal on a locked row — otherwise the chip
+          (e.g. "View results") contradicts the badge. */}
+      {!lockedOut && (
+        <span
+          className={`hidden shrink-0 rounded-lg px-3 py-1.5 text-xs font-semibold transition sm:inline-flex ${getChipClass(
+            { isPending, isCompleted, isGraded }
+          )}`}
+          aria-hidden="true"
+        >
+          {getChipLabel({ isPending, isCompleted, isGraded })}
+        </span>
+      )}
     </a>
   );
 };

--- a/components/student/AssignmentListItem.tsx
+++ b/components/student/AssignmentListItem.tsx
@@ -1,13 +1,14 @@
 import React, { useEffect, useState } from 'react';
 import { doc, getDoc } from 'firebase/firestore';
 import { httpsCallable } from 'firebase/functions';
-import { CheckCircle2, Loader2 } from 'lucide-react';
+import { CheckCircle2, Loader2, Lock } from 'lucide-react';
 import { db, functions } from '@/config/firebase';
 import {
   KIND_CONFIG,
   type AssignmentSummary,
 } from '@/hooks/useStudentAssignments';
 import type { ClassDirectoryEntry } from '@/hooks/useStudentClassDirectory';
+import { useDialog } from '@/context/useDialog';
 
 /**
  * Lazy completion check — same pattern as the previous AssignmentCard but
@@ -140,6 +141,11 @@ export const AssignmentListItem: React.FC<AssignmentListItemProps> = ({
   pendingVerification,
 }) => {
   const [completion, setCompletion] = useState<CompletionState>('unknown');
+  // Only the quiz kind has `resultsLockedOut` on its response doc. Other
+  // assignment kinds don't carry this field — strict equality below means a
+  // missing/undefined field never trips the locked state.
+  const [lockedOut, setLockedOut] = useState(false);
+  const { showAlert } = useDialog();
   const config = KIND_CONFIG[assignment.kind];
   const responseSub = RESPONSE_SUBCOLLECTION[assignment.kind];
   const docIdStrategy = DOC_ID_STRATEGY[assignment.kind];
@@ -171,6 +177,12 @@ export const AssignmentListItem: React.FC<AssignmentListItemProps> = ({
           ? 'completed'
           : 'not-completed';
         setCompletion(next);
+        // Quiz-only: surface the teacher-controlled lockout flag so the row
+        // can render a Locked badge and intercept the tap. Strict equality
+        // keeps legacy responses (no field) out of the locked state.
+        if (assignment.kind === 'quiz' && snap.exists()) {
+          setLockedOut(snap.data()?.resultsLockedOut === true);
+        }
         onCompletionResolved?.(assignment.sessionId, assignment.kind, next);
       } catch {
         // Silent: a failed completion check shouldn't block the student
@@ -201,10 +213,25 @@ export const AssignmentListItem: React.FC<AssignmentListItemProps> = ({
 
   const isGraded = assignment.gradingState === 'graded';
 
+  const handleClick = (e: React.MouseEvent<HTMLAnchorElement>): void => {
+    if (!lockedOut) return;
+    // Quiz results have been locked by the teacher (Task 10). Block the
+    // navigation and explain what happened — the student can still see the
+    // row in their list, but can't open the results view.
+    e.preventDefault();
+    e.stopPropagation();
+    void showAlert('Locked by your teacher. Ask them to unlock your results.', {
+      title: 'Results locked',
+      variant: 'warning',
+    });
+  };
+
   return (
     <a
       href={assignment.openHref}
+      onClick={handleClick}
       aria-busy={isPending ? true : undefined}
+      aria-disabled={lockedOut ? true : undefined}
       className={`group flex items-center gap-3 rounded-xl border px-4 py-3 transition focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue-primary focus-visible:ring-offset-2 ${
         isPending
           ? 'border-dashed border-slate-200 bg-slate-50'
@@ -245,6 +272,16 @@ export const AssignmentListItem: React.FC<AssignmentListItemProps> = ({
           <span>{config.label}</span>
         </p>
       </div>
+
+      {lockedOut && (
+        <span
+          aria-label="Results locked by your teacher"
+          className="inline-flex shrink-0 items-center gap-1 rounded-full bg-rose-500/15 px-2 py-0.5 text-xs font-medium text-rose-600"
+        >
+          <Lock className="h-3 w-3" />
+          Locked
+        </span>
+      )}
 
       <span
         className={`hidden shrink-0 rounded-lg px-3 py-1.5 text-xs font-semibold transition sm:inline-flex ${getChipClass(

--- a/components/student/AssignmentListItem.tsx
+++ b/components/student/AssignmentListItem.tsx
@@ -213,17 +213,70 @@ export const AssignmentListItem: React.FC<AssignmentListItemProps> = ({
 
   const isGraded = assignment.gradingState === 'graded';
 
-  const handleClick = (e: React.MouseEvent<HTMLAnchorElement>): void => {
-    if (!lockedOut) return;
-    // Quiz results have been locked by the teacher (Task 10). Block the
-    // navigation and explain what happened — the student can still see the
-    // row in their list, but can't open the results view.
-    e.preventDefault();
-    e.stopPropagation();
+  /**
+   * Re-check the live `resultsLockedOut` state from Firestore before either
+   * blocking the click or surfacing the alert. Our row-level `lockedOut`
+   * comes from a one-shot `getDoc` during the completion check and never
+   * subscribes to changes — so if the teacher has unlocked the response
+   * since the page rendered, the stale flag would otherwise strand the
+   * student behind a "Locked" badge until they refreshed. On any error
+   * (network, missing doc, etc.) we fall through to the alert as if still
+   * locked — failing closed is safer than allowing access on an unknown.
+   */
+  const recheckLockAndProceed = async (): Promise<void> => {
+    if (!responseSub || docIdStrategy === 'none' || !pseudonymUid) {
+      void showAlert(
+        'Locked by your teacher. Ask them to unlock your results.',
+        { title: 'Results locked', variant: 'warning' }
+      );
+      return;
+    }
+    try {
+      const docId =
+        docIdStrategy === 'assignment-pseudonym'
+          ? await getCachedPseudonym(assignment.sessionId, pseudonymUid)
+          : pseudonymUid;
+      const snap = await getDoc(
+        doc(db, config.collectionName, assignment.sessionId, responseSub, docId)
+      );
+      const stillLocked =
+        snap.exists() && snap.data()?.resultsLockedOut === true;
+      if (!stillLocked) {
+        setLockedOut(false);
+        // Teacher has unlocked since our initial check. Since we stripped
+        // `href` to defeat middle-click bypass, navigate programmatically.
+        window.location.assign(assignment.openHref);
+        return;
+      }
+    } catch {
+      // Fall through to alert — treat unknown as still locked.
+    }
     void showAlert('Locked by your teacher. Ask them to unlock your results.', {
       title: 'Results locked',
       variant: 'warning',
     });
+  };
+
+  const handleClick = (e: React.MouseEvent<HTMLAnchorElement>): void => {
+    if (!lockedOut) return;
+    // Quiz results have been locked by the teacher (Task 10). Block the
+    // default navigation, then re-check the live state — the teacher may
+    // have unlocked since the row's initial completion check resolved.
+    e.preventDefault();
+    e.stopPropagation();
+    void recheckLockAndProceed();
+  };
+
+  // An <a> without href is no longer in the natural tab order. To keep the
+  // locked row reachable by keyboard, we force `tabIndex={0}` and handle
+  // Enter / Space ourselves so screen-reader / keyboard users get the same
+  // re-check-and-alert behavior as mouse users.
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLAnchorElement>): void => {
+    if (!lockedOut) return;
+    if (e.key !== 'Enter' && e.key !== ' ') return;
+    e.preventDefault();
+    e.stopPropagation();
+    void recheckLockAndProceed();
   };
 
   return (
@@ -231,9 +284,14 @@ export const AssignmentListItem: React.FC<AssignmentListItemProps> = ({
       // Omit href entirely when locked so middle-click, cmd-click, ctrl-click,
       // and shift-click can't bypass the onClick guard (which only blocks
       // primary-button left clicks). An hrefless <a> is non-navigable in all
-      // click modes, making aria-disabled semantically truthful.
+      // click modes, making aria-disabled semantically truthful. We then
+      // restore keyboard focusability via tabIndex={0} so the row stays
+      // reachable by Tab — see handleKeyDown for Enter/Space handling.
       href={lockedOut ? undefined : assignment.openHref}
       onClick={handleClick}
+      onKeyDown={handleKeyDown}
+      tabIndex={lockedOut ? 0 : undefined}
+      role={lockedOut ? 'button' : undefined}
       aria-busy={isPending ? true : undefined}
       aria-disabled={lockedOut ? true : undefined}
       className={`group flex items-center gap-3 rounded-xl border px-4 py-3 transition focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue-primary focus-visible:ring-offset-2 ${

--- a/components/widgets/QuizWidget/Widget.tsx
+++ b/components/widgets/QuizWidget/Widget.tsx
@@ -40,7 +40,7 @@ import { QuizResults } from './components/QuizResults';
 import { QuizAssignmentSettingsModal } from './components/QuizAssignmentSettingsModal';
 import { QuizAssignmentImportSetupModal } from '@/components/quiz/QuizAssignmentImportSetupModal';
 import { PublishScoresModal } from '@/components/common/library/PublishScoresModal';
-import type { QuizAssignment } from '@/types';
+import { RESULTS_PROTECTION_DEFAULTS, type QuizAssignment } from '@/types';
 import {
   buildPinToNameMap,
   buildScoreboardTeams,
@@ -98,7 +98,14 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
     pendingAssignmentEditId,
     clearPendingAssignmentEdit,
   } = useDashboard();
-  const { user, googleAccessToken, orgId, getAssignmentMode } = useAuth();
+  const {
+    user,
+    googleAccessToken,
+    orgId,
+    getAssignmentMode,
+    appSettings,
+    updateAppSettings,
+  } = useAuth();
   const quizAssignmentMode = getAssignmentMode('quiz');
   const { showConfirm } = useDialog();
   const config = widget.config as QuizConfig;
@@ -1910,8 +1917,12 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
         <PublishScoresModal
           assignmentTitle={publishingAssignment.quizTitle}
           currentVisibility={publishingAssignment.scoreVisibility}
+          showProtection
+          initialProtection={
+            appSettings?.lastResultsProtection ?? RESULTS_PROTECTION_DEFAULTS
+          }
           onClose={() => setPublishingAssignment(null)}
-          onConfirm={async (visibility) => {
+          onConfirm={async (visibility, protection) => {
             // `'none'` routes to the dedicated `unpublishAssignmentScores`
             // (no Drive lookup, no grading). Other levels resolve the
             // canonical quiz from Drive so the score computation has
@@ -1938,8 +1949,17 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
               const result = await publishAssignmentScores(
                 target.id,
                 data,
-                visibility
+                visibility,
+                protection
               );
+              // Persist the teacher's last protection choice so the next
+              // publish dialog opens pre-filled. Only runs on successful
+              // publish — sequential await is intentional.
+              if (protection) {
+                await updateAppSettings({
+                  lastResultsProtection: protection,
+                });
+              }
               addToast(
                 result.responsesUpdated > 0
                   ? `Scores published to ${result.responsesUpdated} student${result.responsesUpdated === 1 ? '' : 's'}.`

--- a/components/widgets/QuizWidget/Widget.tsx
+++ b/components/widgets/QuizWidget/Widget.tsx
@@ -140,6 +140,16 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
     hideAnswer,
   } = useQuizSessionTeacher(config.activeAssignmentId);
 
+  // Count of students in the active session whose results view is locked
+  // out (tab-warning threshold breached). Surfaced on the Monitor button
+  // in QuizManager so teachers see attention-needing state without opening
+  // the live monitor. Derived from the same `responses` snapshot that
+  // QuizLiveMonitor consumes — no second listener.
+  const activeAssignmentLockedCount = useMemo(
+    () => responses.filter((r) => r.resultsLockedOut === true).length,
+    [responses]
+  );
+
   // Assignment archive — per-teacher list of past/current assignments.
   const {
     assignments,
@@ -1528,6 +1538,7 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
         onTabChange={(tab) => handleUpdateQuizConfig({ managerTab: tab })}
         assignments={assignments}
         assignmentsLoading={assignmentsLoading}
+        activeAssignmentLockedCount={activeAssignmentLockedCount}
         onArchiveCopyUrl={(a) => {
           const url = `${window.location.origin}/quiz?code=${a.code}`;
           if (typeof navigator !== 'undefined' && navigator.clipboard) {

--- a/components/widgets/QuizWidget/Widget.tsx
+++ b/components/widgets/QuizWidget/Widget.tsx
@@ -135,6 +135,7 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
     endQuizSession,
     removeStudent,
     unlockStudentAttempt,
+    unlockResultsForStudent,
     revealAnswer,
     hideAnswer,
   } = useQuizSessionTeacher(config.activeAssignmentId);
@@ -989,6 +990,7 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
         onUpdateConfig={handleUpdateQuizConfig}
         onRemoveStudent={removeStudent}
         onUnlockStudent={unlockStudentAttempt}
+        onUnlockResultsForStudent={unlockResultsForStudent}
         onRevealAnswer={revealAnswer}
         onHideAnswer={hideAnswer}
         onBack={() => {

--- a/components/widgets/QuizWidget/components/QuizLiveMonitor.tsx
+++ b/components/widgets/QuizWidget/components/QuizLiveMonitor.tsx
@@ -106,6 +106,13 @@ interface QuizLiveMonitorProps {
    * Pass `response._responseKey` (snapshot doc id), NOT `studentUid`.
    */
   onUnlockStudent?: (responseKey: string) => Promise<void>;
+  /**
+   * Unlock a student's results-view lockout (triggered when the
+   * `resultsTabWarnings` threshold was hit while viewing published results).
+   * Decrements warnings by 1 and clears the lockout. Pass
+   * `response._responseKey` (snapshot doc id), NOT `studentUid`.
+   */
+  onUnlockResultsForStudent?: (responseKey: string) => Promise<void>;
   onRevealAnswer?: (questionId: string, correctAnswer: string) => Promise<void>;
   onHideAnswer?: (questionId: string) => Promise<void>;
   /** Navigate back to the manager view without ending the quiz. */
@@ -279,6 +286,7 @@ export const QuizLiveMonitor: React.FC<QuizLiveMonitorProps> = ({
   onUpdateConfig,
   onRemoveStudent,
   onUnlockStudent,
+  onUnlockResultsForStudent,
   onRevealAnswer,
   onHideAnswer,
   onBack,
@@ -355,6 +363,13 @@ export const QuizLiveMonitor: React.FC<QuizLiveMonitorProps> = ({
   // normal monitoring and only meaningful for assessments. Teachers can
   // surface them on demand from the roster toolbar.
   const [showTabWarnings, setShowTabWarnings] = useState(false);
+
+  // Results-view tab-warning threshold. Mirrored from
+  // `QuizAssignment.protection` to the session at publish time; falls back
+  // to 3 (the UI default) for legacy sessions published before the
+  // feature shipped.
+  const resultsTabWarningThreshold =
+    session.protection?.tabWarningThreshold ?? 3;
 
   // Session-local approval gate for revealing student performance on the
   // monitor. Defaults to false so a fresh open never shows scores or
@@ -540,6 +555,26 @@ export const QuizLiveMonitor: React.FC<QuizLiveMonitorProps> = ({
       }
     },
     [onUnlockStudent, showConfirm, addToast]
+  );
+
+  const handleUnlockResultsForStudent = useCallback(
+    async (responseKey: string, displayName: string) => {
+      if (!onUnlockResultsForStudent) return;
+      try {
+        await onUnlockResultsForStudent(responseKey);
+        addToast(
+          `${displayName} can view results again — one more tab-switch will re-lock them.`,
+          'success'
+        );
+      } catch (err) {
+        logError('QuizLiveMonitor.unlockResultsForStudent', err);
+        addToast(
+          `Could not unlock ${displayName}'s results — try again or check your connection.`,
+          'error'
+        );
+      }
+    },
+    [onUnlockResultsForStudent, addToast]
   );
 
   const handleToggleColors = useCallback(() => {
@@ -1694,6 +1729,18 @@ export const QuizLiveMonitor: React.FC<QuizLiveMonitorProps> = ({
                                       )
                                   : undefined
                               }
+                              onUnlockResults={
+                                onUnlockResultsForStudent
+                                  ? (displayName) =>
+                                      void handleUnlockResultsForStudent(
+                                        rowKey,
+                                        displayName
+                                      )
+                                  : undefined
+                              }
+                              resultsTabWarningThreshold={
+                                resultsTabWarningThreshold
+                              }
                               pinToName={pinToName}
                               byStudentUid={byStudentUid}
                             />
@@ -2112,6 +2159,18 @@ export const QuizLiveMonitor: React.FC<QuizLiveMonitorProps> = ({
                                         displayName
                                       )
                                   : undefined
+                              }
+                              onUnlockResults={
+                                onUnlockResultsForStudent
+                                  ? (displayName) =>
+                                      void handleUnlockResultsForStudent(
+                                        rowKey,
+                                        displayName
+                                      )
+                                  : undefined
+                              }
+                              resultsTabWarningThreshold={
+                                resultsTabWarningThreshold
                               }
                               pinToName={pinToName}
                               byStudentUid={byStudentUid}
@@ -2553,6 +2612,12 @@ const StudentRow: React.FC<{
   /** Invoked with the resolved roster display name so the confirm dialog
       can use a friendly phrasing without re-resolving inside the row. */
   onUnlock?: (displayName: string) => void;
+  /** Unlock a student's results-view lockout. Receives resolved display name
+      so the toast can use friendly phrasing without re-resolving inside the row. */
+  onUnlockResults?: (displayName: string) => void;
+  /** Session-published results-protection threshold (`tabWarningThreshold`).
+      Used by the results-locked badge to display "{warnings}/{threshold}". */
+  resultsTabWarningThreshold: number;
   pinToName: Record<string, string>;
   byStudentUid?: Map<
     string,
@@ -2571,6 +2636,8 @@ const StudentRow: React.FC<{
   onConfirmRemoveToggle,
   onRemove,
   onUnlock,
+  onUnlockResults,
+  resultsTabWarningThreshold,
   pinToName,
   byStudentUid,
 }) => {
@@ -2817,6 +2884,33 @@ const StudentRow: React.FC<{
           }
           return null;
         })()}
+
+        {/* Results-view lockout indicator + unlock action. A row enters this
+            state when the student crossed `protection.tabWarningThreshold`
+            tab-switches while viewing published results — the student app
+            redirects them out and writes `resultsLockedOut: true`. The
+            teacher's unlock here decrements warnings by 1 (so a single
+            additional tab-switch re-locks them) and clears the flag. */}
+        {response.resultsLockedOut === true && (
+          <span
+            aria-label="Results locked"
+            className="flex items-center gap-0.5 bg-rose-100 text-rose-800 rounded uppercase font-black shrink-0"
+            style={{
+              fontSize: 'min(9px, 2.5cqmin)',
+              padding: 'min(2px, 0.5cqmin) min(6px, 1.5cqmin)',
+            }}
+            title={`Results locked after ${response.resultsTabWarnings ?? 0} of ${resultsTabWarningThreshold} tab-switch warnings`}
+          >
+            <Lock
+              style={{
+                width: 'min(12px, 3cqmin)',
+                height: 'min(12px, 3cqmin)',
+              }}
+            />
+            Results locked ({response.resultsTabWarnings ?? 0}/
+            {resultsTabWarningThreshold})
+          </span>
+        )}
       </span>
       {pillText !== null && (
         <span
@@ -2825,6 +2919,27 @@ const StudentRow: React.FC<{
         >
           {pillText}
         </span>
+      )}
+      {/* Unlock-results action — only when the student is currently locked
+          out of viewing published results. Decrements warnings by 1 and
+          clears the lockout (one more tab-switch will re-lock them). */}
+      {response.resultsLockedOut === true && onUnlockResults && (
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation();
+            onUnlockResults(displayName);
+          }}
+          className="bg-amber-400 hover:bg-amber-300 text-slate-900 font-bold rounded-md transition-colors shrink-0"
+          style={{
+            padding: 'min(4px, 1cqmin) min(8px, 2cqmin)',
+            fontSize: 'min(10px, 3cqmin)',
+          }}
+          title="Decrement warnings by 1 and reopen the results view for this student"
+          aria-label={`Unlock results for ${displayName}`}
+        >
+          Unlock results
+        </button>
       )}
       {/* Remove button — always visible. Hover-only discoverability
           failed on touch devices and made the action effectively

--- a/components/widgets/QuizWidget/components/QuizManager.tsx
+++ b/components/widgets/QuizWidget/components/QuizManager.tsx
@@ -386,6 +386,16 @@ interface QuizManagerProps {
   /** Org-wide assignment mode. Drives Assign-vs-Share button labels and the
    *  In-Progress-vs-Shared tab label. Defaults to `'submissions'`. */
   assignmentMode?: AssignmentMode;
+  /**
+   * Number of students in the currently-active assignment's session whose
+   * results view is locked out (`response.resultsLockedOut === true`).
+   * When `> 0`, the Monitor primary action on the matching assignment's
+   * row renders a small rose badge so teachers see the attention-needing
+   * count without opening the monitor. Only the active assignment's count
+   * is available because we reuse the existing teacher session listener —
+   * other assignments are not subscribed to.
+   */
+  activeAssignmentLockedCount?: number;
 }
 
 /* ─── Status resolver for archive cards ───────────────────────────────────── */
@@ -519,6 +529,7 @@ export const QuizManager: React.FC<QuizManagerProps> = ({
   onSyncAssignment,
   assignmentMode = 'submissions',
   onCreateViewOnlyShare,
+  activeAssignmentLockedCount = 0,
 }) => {
   const isViewOnly = assignmentMode === 'view-only';
   const primaryActionLabel = isViewOnly ? 'Share' : 'Assign';
@@ -894,6 +905,8 @@ export const QuizManager: React.FC<QuizManagerProps> = ({
       label: string;
       icon: React.ComponentType<{ size?: number; className?: string }>;
       onClick: () => void;
+      badgeCount?: number;
+      badgeAriaLabel?: string;
     } | null;
     secondaries: LibraryMenuAction[];
   } => {
@@ -976,12 +989,33 @@ export const QuizManager: React.FC<QuizManagerProps> = ({
     }
 
     if (mode === 'active') {
+      // Surface a rose badge on the Monitor button when the currently-
+      // active assignment's session has students whose results view is
+      // locked out. Only the active assignment carries a live `responses`
+      // subscription (via `useQuizSessionTeacher` in Widget.tsx), so the
+      // badge is gated on `a.id === config.activeAssignmentId` — other
+      // rows have no count to display. The badge auto-clears when the
+      // teacher unlocks the last student because the same Firestore
+      // listener that drives the per-row monitor view also drives this
+      // count.
+      const showMonitorBadge =
+        isActive &&
+        a.id === config.activeAssignmentId &&
+        activeAssignmentLockedCount > 0;
       // Primary: Monitor (active) or Start (paused)
       const primary = isActive
         ? {
             label: 'Monitor',
             icon: Monitor,
             onClick: () => void (onArchiveMonitor ?? noop)(a),
+            ...(showMonitorBadge
+              ? {
+                  badgeCount: activeAssignmentLockedCount,
+                  badgeAriaLabel: `${activeAssignmentLockedCount} student${
+                    activeAssignmentLockedCount === 1 ? '' : 's'
+                  } locked`,
+                }
+              : {}),
           }
         : {
             label: 'Start',
@@ -1923,6 +1957,8 @@ const AssignmentsList: React.FC<{
       label: string;
       icon: React.ComponentType<{ size?: number; className?: string }>;
       onClick: () => void;
+      badgeCount?: number;
+      badgeAriaLabel?: string;
     } | null;
     secondaries: LibraryMenuAction[];
   };
@@ -1991,6 +2027,8 @@ interface QuizArchiveRowProps {
       label: string;
       icon: React.ComponentType<{ size?: number; className?: string }>;
       onClick: () => void;
+      badgeCount?: number;
+      badgeAriaLabel?: string;
     } | null;
     secondaries: LibraryMenuAction[];
   };
@@ -2132,6 +2170,8 @@ const QuizArchiveRow: React.FC<QuizArchiveRowProps> = ({
               label: primary.label,
               icon: primary.icon,
               onClick: primary.onClick,
+              badgeCount: primary.badgeCount,
+              badgeAriaLabel: primary.badgeAriaLabel,
             }
           : undefined
       }

--- a/firestore.rules
+++ b/firestore.rules
@@ -2015,7 +2015,15 @@ service cloud.firestore {
            // a student from adding/changing `pin` or `joinedAt`.
            request.resource.data.get('pin', null) == resource.data.get('pin', null) &&
            request.resource.data.get('joinedAt', null) == resource.data.get('joinedAt', null) &&
-           request.resource.data.score == null &&
+           // Score may stay unchanged OR transition to null (rejoin reset).
+           // Students can never write a non-null score they didn't already
+           // have — blocks score forgery while allowing both mid-quiz writes
+           // (score is null on both sides → diff doesn't touch it) and
+           // post-publish results-protection writes (score unchanged from
+           // the graded value). The earlier blanket `score == null` check
+           // rejected results-view writes against scored docs.
+           (!request.resource.data.diff(resource.data).affectedKeys().hasAny(['score']) ||
+            request.resource.data.score == null) &&
            // Students may only ever write `0` to `preSyncVersion`. The
            // rejoin path resets it to 0 so a previously-tagged response
            // re-enters the "untagged" pool that

--- a/firestore.rules
+++ b/firestore.rules
@@ -2045,8 +2045,13 @@ service cloud.firestore {
            // snapshots under the same key — they inherit the same
            // student-side protection by construction. See
            // docs/written-response-quiz-questions.md §9.
+           // Use `affectedKeys()` (added ∪ removed ∪ changed), not
+           // `changedKeys()` — the latter only covers keys that exist on
+           // BOTH sides with different values, so a smuggled NEW field
+           // (e.g. `somethingElse: 'hack'`) would land in `addedKeys` and
+           // bypass the whitelist entirely.
            request.resource.data.diff(resource.data)
-             .changedKeys().hasOnly(['answers', 'status', 'submittedAt', 'tabSwitchWarnings', 'completedAttempts', 'classPeriod', 'score', 'preSyncVersion', 'unlocked', 'resultsTabWarnings', 'resultsLockedOut', 'resultsLockedOutAt']) &&
+             .affectedKeys().hasOnly(['answers', 'status', 'submittedAt', 'tabSwitchWarnings', 'completedAttempts', 'classPeriod', 'score', 'preSyncVersion', 'unlocked', 'resultsTabWarnings', 'resultsLockedOut', 'resultsLockedOutAt']) &&
            // Students may only ever CLEAR the unlock flag (write `false`)
            // — never set it to true. The teacher's unlock action sets
            // `unlocked: true`; `completeQuiz` clears it back to false

--- a/firestore.rules
+++ b/firestore.rules
@@ -2038,7 +2038,7 @@ service cloud.firestore {
            // student-side protection by construction. See
            // docs/written-response-quiz-questions.md §9.
            request.resource.data.diff(resource.data)
-             .changedKeys().hasOnly(['answers', 'status', 'submittedAt', 'tabSwitchWarnings', 'completedAttempts', 'classPeriod', 'score', 'preSyncVersion', 'unlocked']) &&
+             .changedKeys().hasOnly(['answers', 'status', 'submittedAt', 'tabSwitchWarnings', 'completedAttempts', 'classPeriod', 'score', 'preSyncVersion', 'unlocked', 'resultsTabWarnings', 'resultsLockedOut', 'resultsLockedOutAt']) &&
            // Students may only ever CLEAR the unlock flag (write `false`)
            // — never set it to true. The teacher's unlock action sets
            // `unlocked: true`; `completeQuiz` clears it back to false
@@ -2049,6 +2049,21 @@ service cloud.firestore {
             request.resource.data.tabSwitchWarnings >= resource.data.get('tabSwitchWarnings', 0)) &&
            (!request.resource.data.diff(resource.data).affectedKeys().hasAny(['completedAttempts']) ||
             request.resource.data.get('completedAttempts', 0) >= resource.data.get('completedAttempts', 0)) &&
+           // Results-view screenshot-protection guards (Task 11). The student
+           // app's `useResultsTabWarnings` hook increments
+           // `resultsTabWarnings` (via `increment(1)`) on each visibility/blur
+           // round-trip on the published-results screen, and flips
+           // `resultsLockedOut` true (+ stamps `resultsLockedOutAt`) once the
+           // threshold is reached. Both monotonic from the student side; only
+           // the teacher (via `unlockResultsForStudent` — built in Task 12)
+           // can decrement warnings or clear the lockout.
+           (!request.resource.data.diff(resource.data).affectedKeys().hasAny(['resultsTabWarnings']) ||
+            request.resource.data.get('resultsTabWarnings', 0) >= resource.data.get('resultsTabWarnings', 0)) &&
+           // `resultsLockedOut` may only stay the same OR transition false→true.
+           // A student-side write of `true→false` (self-unlock) is rejected.
+           (!request.resource.data.diff(resource.data).affectedKeys().hasAny(['resultsLockedOut']) ||
+            (resource.data.get('resultsLockedOut', false) == false ||
+             request.resource.data.get('resultsLockedOut', false) == true)) &&
            // Attempt-cap enforcement. completedAttempts may not exceed the
            // session's attemptLimit. attemptLimit == null means unlimited.
            // Without this rule a hostile client could call completeQuiz N

--- a/firestore.rules
+++ b/firestore.rules
@@ -2085,7 +2085,13 @@ service cloud.firestore {
            // rule because the new status is not 'completed'). The case
            // this blocks is 'completed' → 'completed', which only happens
            // via a race or bug.
-           (resource.data.get('status', '') != 'completed' ||
+           //
+           // Only fires when the update actually touches `status`. Writes
+           // that leave status alone (tab-warning increments during the
+           // quiz, results-protection writes after publish) need to be
+           // allowed even when the doc is already in the 'completed' state.
+           (!request.resource.data.diff(resource.data).affectedKeys().hasAny(['status']) ||
+            resource.data.get('status', '') != 'completed' ||
             request.resource.data.get('status', '') != 'completed'))
         );
         allow delete: if request.auth != null &&

--- a/hooks/useQuizAssignments.ts
+++ b/hooks/useQuizAssignments.ts
@@ -48,6 +48,7 @@ import type {
   QuizResponseAnswer,
   QuizScoreVisibility,
   QuizSession,
+  ResultsProtection,
   SharedQuizAssignment,
 } from '../types';
 import type { SessionTargets } from '../utils/resolveAssignmentTargets';
@@ -359,7 +360,8 @@ export interface UseQuizAssignmentsResult {
   publishAssignmentScores: (
     assignmentId: string,
     quizData: QuizData,
-    visibility: Exclude<QuizScoreVisibility, 'none'>
+    visibility: Exclude<QuizScoreVisibility, 'none'>,
+    protection?: ResultsProtection
   ) => Promise<{ responsesUpdated: number }>;
   /**
    * Revoke published score visibility for an assignment. Clears
@@ -1831,6 +1833,11 @@ export const useQuizAssignments = (
       batch.update(assignmentRef, {
         scoreVisibility: deleteField(),
         scorePublishedAt: deleteField(),
+        // Clear results-protection settings alongside the publication flags.
+        // Leaving stale `protection` on disk after unpublish would let the
+        // next publish silently inherit old watermark/tab-warning config
+        // the teacher may have already disabled.
+        protection: deleteField(),
         updatedAt: now,
       });
       batch.update(sessionRef, {
@@ -1840,6 +1847,10 @@ export const useQuizAssignments = (
         // see a stale timestamp lingering after unpublish.
         scorePublishedAt: deleteField(),
         revealedAnswers: deleteField(),
+        // The student app reads protection from the session doc, so it
+        // must be cleared here too — otherwise watermark/tab-warning
+        // would keep rendering against a no-longer-published result set.
+        protection: deleteField(),
       });
       await batch.commit();
     },
@@ -1849,7 +1860,7 @@ export const useQuizAssignments = (
   const publishAssignmentScores = useCallback<
     UseQuizAssignmentsResult['publishAssignmentScores']
   >(
-    async (assignmentId, quizData, visibility) => {
+    async (assignmentId, quizData, visibility, protection) => {
       if (!userId) throw new Error('Not authenticated');
       // Belt-and-suspenders against a future caller that bypasses the
       // type-level `Exclude<…, 'none'>`. The unpublish path lives in
@@ -1955,9 +1966,18 @@ export const useQuizAssignments = (
       // safely overwrites — the operation is idempotent.
       const MAX_BATCH_WRITES = 400;
       const firstBatch = writeBatch(db);
+      // When the caller omits protection (older sites that haven't been
+      // wired up yet, or an explicit "no protection" publish), write
+      // `deleteField()` so any prior protection on the doc is wiped. This
+      // matches the unpublish semantics: republishing without protection
+      // must NOT silently re-apply settings from a stale prior publish.
+      const protectionWrite:
+        | ResultsProtection
+        | ReturnType<typeof deleteField> = protection ?? deleteField();
       firstBatch.update(assignmentRef, {
         scoreVisibility: visibility,
         scorePublishedAt: now,
+        protection: protectionWrite,
         updatedAt: now,
       });
       const sessionPatch: Record<string, unknown> = {
@@ -1969,6 +1989,11 @@ export const useQuizAssignments = (
         // writing it only on the teacher-owned assignment doc (the prior
         // behavior) silently left every student stuck on "Not graded".
         scorePublishedAt: now,
+        // Mirror protection onto the session doc too — the student app
+        // only subscribes to the session, so watermark + tab-warning
+        // settings have to live here for the student review screen to
+        // honor them.
+        protection: protectionWrite,
       };
       // Populate `revealedAnswers` only when the teacher chose to share
       // correct-answer text. The other two visibility levels deliberately

--- a/hooks/useQuizSession.ts
+++ b/hooks/useQuizSession.ts
@@ -523,6 +523,15 @@ export interface UseQuizSessionTeacherResult {
    * without showing the "Warning N of 3" modal.
    */
   unlockStudentAttempt: (responseKey: string) => Promise<void>;
+  /**
+   * Unlock a student's results-view lockout (triggered when their
+   * `resultsTabWarnings` count hit the session's `protection.tabWarningThreshold`
+   * while viewing published results). Decrements `resultsTabWarnings` by 1
+   * (floored at 0) and clears the `resultsLockedOut` flag + `resultsLockedOutAt`
+   * timestamp. The decrement is intentional: one more tab-switch will re-lock
+   * the student, giving zero grace warnings post-unlock.
+   */
+  unlockResultsForStudent: (responseKey: string) => Promise<void>;
   /** Reveal the correct answer for a question (writes to session doc) */
   revealAnswer: (questionId: string, correctAnswer: string) => Promise<void>;
   /** Hide a previously revealed answer (removes from session doc) */
@@ -746,6 +755,37 @@ export const useQuizSessionTeacher = (
     [sessionId, responses, session?.quizId]
   );
 
+  const unlockResultsForStudent = useCallback(
+    async (responseKey: string) => {
+      if (!sessionId) {
+        throw new Error('No active session — cannot unlock results.');
+      }
+      const responseRef = doc(
+        db,
+        QUIZ_SESSIONS_COLLECTION,
+        sessionId,
+        RESPONSES_COLLECTION,
+        responseKey
+      );
+      const snap = await getDoc(responseRef);
+      if (!snap.exists()) {
+        throw new Error(
+          'Student response not found — they may have already been removed or rejoined.'
+        );
+      }
+      const data = snap.data() as Partial<QuizResponse> | undefined;
+      const prev = data?.resultsTabWarnings ?? 0;
+      // Decrement by 1, floored at 0. One more tab-switch re-locks them
+      // (zero grace warnings post-unlock — intentional).
+      await updateDoc(responseRef, {
+        resultsTabWarnings: Math.max(0, prev - 1),
+        resultsLockedOut: false,
+        resultsLockedOutAt: deleteField(),
+      });
+    },
+    [sessionId]
+  );
+
   const revealAnswer = useCallback(
     async (questionId: string, correctAnswer: string) => {
       if (!sessionId) return;
@@ -891,6 +931,7 @@ export const useQuizSessionTeacher = (
     endQuizSession,
     removeStudent,
     unlockStudentAttempt,
+    unlockResultsForStudent,
     revealAnswer,
     hideAnswer,
   };

--- a/hooks/useQuizSession.ts
+++ b/hooks/useQuizSession.ts
@@ -777,6 +777,13 @@ export const useQuizSessionTeacher = (
       const prev = data?.resultsTabWarnings ?? 0;
       // Decrement by 1, floored at 0. One more tab-switch re-locks them
       // (zero grace warnings post-unlock — intentional).
+      //
+      // Read-modify-write race: if the student's hook fires `increment(1)`
+      // between our `getDoc` and `updateDoc` (a ~100ms window), the student's
+      // increment is silently lost. Accepted intentionally — the collision is
+      // rare, the stakes are low (one extra warning at most), and the lockout
+      // will re-fire on the very next event anyway since `currentWarnings + 1
+      // >= threshold` still holds.
       await updateDoc(responseRef, {
         resultsTabWarnings: Math.max(0, prev - 1),
         resultsLockedOut: false,

--- a/hooks/useResultsTabWarnings.ts
+++ b/hooks/useResultsTabWarnings.ts
@@ -1,0 +1,86 @@
+import { useEffect, useRef } from 'react';
+import { doc, updateDoc } from 'firebase/firestore';
+import { db } from '@/config/firebase';
+
+interface UseResultsTabWarningsArgs {
+  /** True only when the session has tab-warning protection enabled AND student isn't already locked. */
+  enabled: boolean;
+  /** session.protection.tabWarningThreshold */
+  threshold: number;
+  /** response.resultsTabWarnings (current count) */
+  currentWarnings: number;
+  /** response.resultsLockedOut */
+  lockedOut?: boolean;
+  /** Firestore path: `quiz_sessions/{sessionId}/responses/{responseKey}` */
+  responseDocPath: string;
+}
+
+/**
+ * Listens to visibility/focus loss on the published-results view and increments
+ * the student's `resultsTabWarnings` counter on each return. Flips
+ * `resultsLockedOut` true when the threshold is reached. No-op once locked out
+ * (further events are suppressed; the redirect-to-list logic owns the UX from
+ * here).
+ *
+ * Note: warnings persist server-side per response doc, so closing/reopening
+ * the tab does NOT reset the count within the same assignment (resets only
+ * happen when teacher unlocks, decrementing by 1).
+ */
+export function useResultsTabWarnings({
+  enabled,
+  threshold,
+  currentWarnings,
+  lockedOut,
+  responseDocPath,
+}: UseResultsTabWarningsArgs): void {
+  const wasHiddenRef = useRef(document.visibilityState === 'hidden');
+
+  useEffect(() => {
+    if (!enabled || lockedOut) return undefined;
+
+    const incrementOnce = async () => {
+      const next = currentWarnings + 1;
+      const update: Record<string, unknown> = { resultsTabWarnings: next };
+      if (next >= threshold) {
+        update.resultsLockedOut = true;
+        update.resultsLockedOutAt = Date.now();
+      }
+      try {
+        await updateDoc(doc(db, responseDocPath), update);
+      } catch (e) {
+        console.error('[useResultsTabWarnings] update failed', e);
+      }
+    };
+
+    const handleVisibility = () => {
+      const hidden = document.visibilityState === 'hidden';
+      if (hidden) {
+        wasHiddenRef.current = true;
+        return;
+      }
+      if (wasHiddenRef.current) {
+        wasHiddenRef.current = false;
+        void incrementOnce();
+      }
+    };
+
+    const handleBlur = () => {
+      wasHiddenRef.current = true;
+    };
+    const handleFocus = () => {
+      if (wasHiddenRef.current) {
+        wasHiddenRef.current = false;
+        void incrementOnce();
+      }
+    };
+
+    document.addEventListener('visibilitychange', handleVisibility);
+    window.addEventListener('blur', handleBlur);
+    window.addEventListener('focus', handleFocus);
+    return () => {
+      document.removeEventListener('visibilitychange', handleVisibility);
+      window.removeEventListener('blur', handleBlur);
+      window.removeEventListener('focus', handleFocus);
+    };
+  }, [enabled, lockedOut, threshold, currentWarnings, responseDocPath]);
+}

--- a/hooks/useResultsTabWarnings.ts
+++ b/hooks/useResultsTabWarnings.ts
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from 'react';
-import { doc, updateDoc } from 'firebase/firestore';
+import { doc, increment, updateDoc } from 'firebase/firestore';
 import { db } from '@/config/firebase';
 
 interface UseResultsTabWarningsArgs {
@@ -33,15 +33,28 @@ export function useResultsTabWarnings({
   lockedOut,
   responseDocPath,
 }: UseResultsTabWarningsArgs): void {
-  const wasHiddenRef = useRef(document.visibilityState === 'hidden');
+  const wasHiddenRef = useRef(false);
 
   useEffect(() => {
     if (!enabled || lockedOut) return undefined;
+    // Seed for THIS activation — `false` instead of "current visibility state"
+    // avoids spurious increments if the hook mounts while the tab is hidden
+    // (the first visible event would otherwise count an exit we never observed).
+    wasHiddenRef.current = false;
 
     const incrementOnce = async () => {
-      const next = currentWarnings + 1;
-      const update: Record<string, unknown> = { resultsTabWarnings: next };
-      if (next >= threshold) {
+      const update: Partial<{
+        resultsTabWarnings: ReturnType<typeof increment>;
+        resultsLockedOut: boolean;
+        resultsLockedOutAt: number;
+      }> = {
+        resultsTabWarnings: increment(1),
+      };
+      // Best-effort lockout flip based on the latest snapshot. If a rapid second
+      // event races, this still computes against the same stale snapshot — but the
+      // increment itself is atomic via `increment(1)`, so the count is preserved
+      // and the lockout will flip on the next event at the latest.
+      if (currentWarnings + 1 >= threshold) {
         update.resultsLockedOut = true;
         update.resultsLockedOutAt = Date.now();
       }

--- a/tests/components/common/library/PublishScoresModal.protection.test.tsx
+++ b/tests/components/common/library/PublishScoresModal.protection.test.tsx
@@ -76,23 +76,83 @@ describe('PublishScoresModal — protection toggles', () => {
     expect(threshold).toHaveValue(3);
   });
 
-  it('clamps the threshold value to [1, 10] on change', () => {
+  it('clamps the threshold value to [1, 10] on blur', () => {
     renderWithProtection();
 
     fireEvent.click(screen.getByLabelText(/tab.?switch warning/i));
     const threshold = screen.getByLabelText(/warnings before lockout/i);
 
-    // Above max -> clamped to 10
+    // Above max -> clamped to 10 on blur
     fireEvent.change(threshold, { target: { value: '99' } });
+    fireEvent.blur(threshold);
     expect(threshold).toHaveValue(10);
 
-    // Below min -> clamped to 1
+    // Below min -> clamped to 1 on blur
     fireEvent.change(threshold, { target: { value: '0' } });
+    fireEvent.blur(threshold);
     expect(threshold).toHaveValue(1);
 
     // In range -> kept as typed
     fireEvent.change(threshold, { target: { value: '5' } });
+    fireEvent.blur(threshold);
     expect(threshold).toHaveValue(5);
+  });
+
+  it('lets the user clear the threshold input mid-edit without snapping back to default', () => {
+    renderWithProtection();
+
+    fireEvent.click(screen.getByLabelText(/tab.?switch warning/i));
+    const threshold = screen.getByLabelText(/warnings before lockout/i);
+
+    // Initial value should be the default (3)
+    expect(threshold).toHaveValue(3);
+
+    // User backspaces the value to empty — must NOT snap back to default.
+    fireEvent.change(threshold, { target: { value: '' } });
+    // A number input with an empty string reports null via .value (HTML spec),
+    // which testing-library surfaces as null for toHaveValue().
+    expect(threshold).toHaveValue(null);
+  });
+
+  it('submitting without blurring still honors the user’s last typed threshold', async () => {
+    const onConfirm = vi.fn(() => undefined);
+    renderWithProtection({ onConfirm });
+
+    // Enable tab warning, type a fresh value, do NOT blur.
+    fireEvent.click(screen.getByLabelText(/tab.?switch warning/i));
+    const threshold = screen.getByLabelText(/warnings before lockout/i);
+    fireEvent.change(threshold, { target: { value: '5' } });
+    // No blur here — straight to Publish.
+
+    fireEvent.click(screen.getByRole('button', { name: /publish/i }));
+
+    await waitFor(() => {
+      expect(onConfirm).toHaveBeenCalledTimes(1);
+    });
+    expect(onConfirm).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ tabWarningThreshold: 5 })
+    );
+  });
+
+  it('submitting without blurring still clamps an out-of-range typed value', async () => {
+    const onConfirm = vi.fn(() => undefined);
+    renderWithProtection({ onConfirm });
+
+    fireEvent.click(screen.getByLabelText(/tab.?switch warning/i));
+    const threshold = screen.getByLabelText(/warnings before lockout/i);
+    // Type a number above the max — no blur — submit.
+    fireEvent.change(threshold, { target: { value: '99' } });
+
+    fireEvent.click(screen.getByRole('button', { name: /publish/i }));
+
+    await waitFor(() => {
+      expect(onConfirm).toHaveBeenCalledTimes(1);
+    });
+    expect(onConfirm).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ tabWarningThreshold: 10 })
+    );
   });
 
   it('passes protection to onConfirm when publishing', async () => {

--- a/tests/components/common/library/PublishScoresModal.protection.test.tsx
+++ b/tests/components/common/library/PublishScoresModal.protection.test.tsx
@@ -1,0 +1,155 @@
+/**
+ * PublishScoresModal — protection toggles
+ *
+ * Covers the new Quiz-only protection fieldset added below the visibility
+ * picker. The modal stays score-visibility-only for VA/GL; protection only
+ * renders when the `showProtection` slot is wired by the caller (Quiz Widget).
+ *
+ * Pattern mirrors the other library-modal tests: render the component, drive
+ * interactions via react-testing-library, query through accessible labels.
+ */
+
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { PublishScoresModal } from '@/components/common/library/PublishScoresModal';
+import { RESULTS_PROTECTION_DEFAULTS, type ResultsProtection } from '@/types';
+
+describe('PublishScoresModal — protection toggles', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  function renderWithProtection(
+    opts: {
+      initialProtection?: ResultsProtection;
+      onConfirm?: (
+        visibility: string,
+        protection?: ResultsProtection
+      ) => Promise<void> | void;
+    } = {}
+  ) {
+    const onConfirm = opts.onConfirm ?? vi.fn(() => undefined);
+    render(
+      <PublishScoresModal
+        assignmentTitle="Test Quiz"
+        currentVisibility={undefined}
+        onClose={() => undefined}
+        onConfirm={onConfirm}
+        initialProtection={
+          opts.initialProtection ?? RESULTS_PROTECTION_DEFAULTS
+        }
+        showProtection
+      />
+    );
+    return { onConfirm };
+  }
+
+  it('renders both toggles defaulting from RESULTS_PROTECTION_DEFAULTS', () => {
+    renderWithProtection();
+
+    const watermark = screen.getByLabelText(/watermark/i);
+    const tabWarning = screen.getByLabelText(/tab.?switch warning/i);
+
+    expect(watermark).toBeChecked();
+    expect(tabWarning).not.toBeChecked();
+  });
+
+  it('hides the threshold input when tab-warning toggle is off', () => {
+    renderWithProtection();
+
+    expect(
+      screen.queryByLabelText(/warnings before lockout/i)
+    ).not.toBeInTheDocument();
+  });
+
+  it('shows threshold input bounded [1, 10] when tab-warning enabled', () => {
+    renderWithProtection();
+
+    fireEvent.click(screen.getByLabelText(/tab.?switch warning/i));
+
+    const threshold = screen.getByLabelText(/warnings before lockout/i);
+
+    expect(threshold).toBeInTheDocument();
+    expect(threshold).toHaveAttribute('min', '1');
+    expect(threshold).toHaveAttribute('max', '10');
+    expect(threshold).toHaveValue(3);
+  });
+
+  it('clamps the threshold value to [1, 10] on change', () => {
+    renderWithProtection();
+
+    fireEvent.click(screen.getByLabelText(/tab.?switch warning/i));
+    const threshold = screen.getByLabelText(/warnings before lockout/i);
+
+    // Above max -> clamped to 10
+    fireEvent.change(threshold, { target: { value: '99' } });
+    expect(threshold).toHaveValue(10);
+
+    // Below min -> clamped to 1
+    fireEvent.change(threshold, { target: { value: '0' } });
+    expect(threshold).toHaveValue(1);
+
+    // In range -> kept as typed
+    fireEvent.change(threshold, { target: { value: '5' } });
+    expect(threshold).toHaveValue(5);
+  });
+
+  it('passes protection to onConfirm when publishing', async () => {
+    const onConfirm = vi.fn(() => undefined);
+    renderWithProtection({ onConfirm });
+
+    // Pick a non-default visibility to drive a real submit
+    fireEvent.click(screen.getByRole('radio', { name: /score only/i }));
+
+    // Enable tab warning, set threshold to 5
+    fireEvent.click(screen.getByLabelText(/tab.?switch warning/i));
+    const threshold = screen.getByLabelText(/warnings before lockout/i);
+    fireEvent.change(threshold, { target: { value: '5' } });
+
+    fireEvent.click(screen.getByRole('button', { name: /publish/i }));
+
+    await waitFor(() => {
+      expect(onConfirm).toHaveBeenCalledTimes(1);
+    });
+    expect(onConfirm).toHaveBeenCalledWith('score-only', {
+      watermarkEnabled: true,
+      tabWarningEnabled: true,
+      tabWarningThreshold: 5,
+    });
+  });
+
+  it('pre-fills from initialProtection prop when present', () => {
+    renderWithProtection({
+      initialProtection: {
+        watermarkEnabled: false,
+        tabWarningEnabled: true,
+        tabWarningThreshold: 7,
+      },
+    });
+
+    const watermark = screen.getByLabelText(/watermark/i);
+    const tabWarning = screen.getByLabelText(/tab.?switch warning/i);
+    const threshold = screen.getByLabelText(/warnings before lockout/i);
+
+    expect(watermark).not.toBeChecked();
+    expect(tabWarning).toBeChecked();
+    expect(threshold).toHaveValue(7);
+  });
+
+  it('does NOT render the protection fieldset when showProtection is not set', () => {
+    render(
+      <PublishScoresModal
+        assignmentTitle="VA Activity"
+        currentVisibility={undefined}
+        onClose={() => undefined}
+        onConfirm={vi.fn()}
+      />
+    );
+
+    expect(screen.queryByLabelText(/watermark/i)).not.toBeInTheDocument();
+    expect(
+      screen.queryByLabelText(/tab.?switch warning/i)
+    ).not.toBeInTheDocument();
+  });
+});

--- a/tests/components/quiz/ResultsTabWarningModal.test.tsx
+++ b/tests/components/quiz/ResultsTabWarningModal.test.tsx
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ResultsTabWarningModal } from '@/components/quiz/ResultsTabWarningModal';
+
+describe('ResultsTabWarningModal', () => {
+  it('renders nothing when open=false', () => {
+    const { container } = render(
+      <ResultsTabWarningModal
+        open={false}
+        warningCount={1}
+        threshold={3}
+        onDismiss={vi.fn()}
+      />
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders "Warning N of M" with remaining-warnings copy when below threshold', () => {
+    render(
+      <ResultsTabWarningModal
+        open
+        warningCount={1}
+        threshold={3}
+        onDismiss={vi.fn()}
+      />
+    );
+    expect(screen.getByText(/Warning 1 of 3/)).toBeInTheDocument();
+    expect(screen.getByText(/2 more will lock you out/)).toBeInTheDocument();
+  });
+
+  it('renders final-warning copy on the last warning', () => {
+    render(
+      <ResultsTabWarningModal
+        open
+        warningCount={3}
+        threshold={3}
+        onDismiss={vi.fn()}
+      />
+    );
+    expect(screen.getByText(/Warning 3 of 3/)).toBeInTheDocument();
+    expect(
+      screen.getByText(/next time you leave, you will be locked out/)
+    ).toBeInTheDocument();
+  });
+
+  it('calls onDismiss when the button is clicked', () => {
+    const onDismiss = vi.fn();
+    render(
+      <ResultsTabWarningModal
+        open
+        warningCount={1}
+        threshold={3}
+        onDismiss={onDismiss}
+      />
+    );
+    fireEvent.click(screen.getByRole('button', { name: /I understand/i }));
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses dialog semantics for accessibility', () => {
+    render(
+      <ResultsTabWarningModal
+        open
+        warningCount={1}
+        threshold={3}
+        onDismiss={vi.fn()}
+      />
+    );
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toHaveAttribute('aria-modal', 'true');
+    expect(dialog).toHaveAttribute(
+      'aria-labelledby',
+      'results-tab-warning-title'
+    );
+  });
+});

--- a/tests/components/quiz/ResultsTabWarningModal.test.tsx
+++ b/tests/components/quiz/ResultsTabWarningModal.test.tsx
@@ -68,9 +68,23 @@ describe('ResultsTabWarningModal', () => {
     );
     const dialog = screen.getByRole('dialog');
     expect(dialog).toHaveAttribute('aria-modal', 'true');
-    expect(dialog).toHaveAttribute(
-      'aria-labelledby',
-      'results-tab-warning-title'
+    const labelledBy = dialog.getAttribute('aria-labelledby');
+    expect(labelledBy).toBeTruthy();
+    // The id must resolve to a real element inside the dialog.
+    expect(dialog.querySelector(`#${labelledBy}`)).toHaveTextContent(
+      /Stay on this tab/
     );
+  });
+
+  it('autofocuses the dismiss button so keyboard users can press Enter immediately', () => {
+    render(
+      <ResultsTabWarningModal
+        open
+        warningCount={1}
+        threshold={3}
+        onDismiss={vi.fn()}
+      />
+    );
+    expect(screen.getByRole('button', { name: /I understand/i })).toHaveFocus();
   });
 });

--- a/tests/components/quiz/ResultsWatermark.test.tsx
+++ b/tests/components/quiz/ResultsWatermark.test.tsx
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { ResultsWatermark } from '@/components/quiz/ResultsWatermark';
+
+describe('ResultsWatermark', () => {
+  it('renders the student name and a formatted timestamp inside an SVG pattern', () => {
+    render(
+      <ResultsWatermark
+        studentName="Ada Lovelace"
+        publishedAt={1715731200000}
+      />
+    );
+    const svg = screen.getByRole('presentation', { hidden: true });
+    expect(svg).toBeInTheDocument();
+    // The text node lives inside <pattern><text>...</text></pattern>
+    const text = svg.querySelector('text');
+    expect(text?.textContent).toContain('Ada Lovelace');
+    expect(text?.textContent).toMatch(/\d{4}|2024|2025|2026/); // date present
+  });
+
+  it('does not capture pointer events', () => {
+    render(<ResultsWatermark studentName="Ada" publishedAt={0} />);
+    const svg = screen.getByRole('presentation', { hidden: true });
+    expect(svg).toHaveClass('pointer-events-none');
+  });
+
+  it('escapes special characters in the student name (no SVG injection)', () => {
+    render(
+      <ResultsWatermark
+        studentName={'<script>alert(1)</script>'}
+        publishedAt={0}
+      />
+    );
+    const svg = screen.getByRole('presentation', { hidden: true });
+    expect(svg.innerHTML).not.toContain('<script>');
+  });
+});

--- a/tests/context/AuthContext.appSettings.test.tsx
+++ b/tests/context/AuthContext.appSettings.test.tsx
@@ -1,0 +1,290 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, act, waitFor } from '@testing-library/react';
+import * as firebaseAuth from 'firebase/auth';
+import * as firestore from 'firebase/firestore';
+import type { User } from 'firebase/auth';
+import { auth } from '@/config/firebase';
+import { AuthProvider } from '@/context/AuthContext';
+import { useAuth } from '@/context/useAuth';
+import type { AuthContextType } from '@/context/AuthContextValue';
+import type { AppSettings, ResultsProtection } from '@/types';
+
+/**
+ * Tests for `updateAppSettings` persistence of the `lastResultsProtection`
+ * field added to AppSettings for the quiz results-protection feature.
+ *
+ * The expectation is that `updateAppSettings` is a generic `Partial<AppSettings>`
+ * Firestore merge — it does NOT have a per-field allowlist — so once
+ * `lastResultsProtection` is added to the type it flows through with zero
+ * additional code changes. This test pins that contract:
+ *
+ *   1. The Firestore write fires against `admin_settings/app_settings`
+ *      with `merge: true` and a payload containing only the supplied field.
+ *   2. The onSnapshot-driven appSettings state surfaces the new field
+ *      to consumers without clobbering pre-existing fields like
+ *      `geminiDailyLimit`.
+ */
+
+vi.mock('firebase/auth', async () => {
+  const actual =
+    await vi.importActual<typeof import('firebase/auth')>('firebase/auth');
+  return {
+    ...actual,
+    onAuthStateChanged: vi.fn(),
+    signInWithPopup: vi.fn(),
+    signInAnonymously: vi.fn(),
+    signOut: vi.fn().mockResolvedValue(undefined),
+  };
+});
+
+vi.mock('firebase/firestore', () => ({
+  doc: vi.fn((_db: unknown, ...segments: string[]) => ({
+    __path: segments.join('/'),
+  })),
+  collection: vi.fn((_db: unknown, ...segments: string[]) => ({
+    __path: segments.join('/'),
+  })),
+  query: vi.fn((collectionRef: unknown) => collectionRef),
+  limit: vi.fn(() => ({})),
+  getDoc: vi.fn(),
+  getDocs: vi.fn(),
+  setDoc: vi.fn().mockResolvedValue(undefined),
+  onSnapshot: vi.fn(() => () => undefined),
+}));
+
+interface DocRef {
+  __path: string;
+}
+
+const ctxHolder: { current: AuthContextType | null } = { current: null };
+
+const Probe: React.FC = () => {
+  const ctx = useAuth();
+  React.useEffect(() => {
+    ctxHolder.current = ctx;
+  });
+  return null;
+};
+
+function getCtx(): AuthContextType {
+  if (!ctxHolder.current) {
+    throw new Error('AuthContext was never captured by the Probe');
+  }
+  return ctxHolder.current;
+}
+
+function buildFakeUser(uid = 'test-uid', email = 'admin@example.com'): User {
+  return {
+    uid,
+    email,
+    displayName: 'Admin',
+    photoURL: null,
+    emailVerified: true,
+    isAnonymous: false,
+    providerData: [],
+    refreshToken: '',
+    metadata: {} as User['metadata'],
+    providerId: 'firebase',
+    tenantId: null,
+    delete: vi.fn(),
+    getIdToken: vi.fn().mockResolvedValue('mock-id-token'),
+    getIdTokenResult: vi.fn().mockResolvedValue({
+      claims: {},
+      authTime: '',
+      issuedAtTime: '',
+      expirationTime: '',
+      signInProvider: '',
+      signInSecondFactor: null,
+      token: 'mock-id-token',
+    }),
+    reload: vi.fn(),
+    toJSON: () => ({}),
+    phoneNumber: null,
+  } as unknown as User;
+}
+
+type DocSnap = Awaited<ReturnType<typeof firestore.getDoc>>;
+type QuerySnap = Awaited<ReturnType<typeof firestore.getDocs>>;
+
+/**
+ * Sets up Firestore mocks so the mounted user resolves as an admin (which is
+ * the gate `updateAppSettings` enforces) and the app_settings onSnapshot
+ * subscription delivers a seeded AppSettings doc that we can drive updates
+ * through.
+ *
+ * Returns the captured app_settings snapshot callback so the test can simulate
+ * Firestore echoing the merge back to the client.
+ */
+function installAdminFirestore(initialAppSettings: AppSettings): {
+  pushAppSettings: (data: AppSettings) => void;
+} {
+  // /admins/{email} must exist for isAdmin to resolve true. Profile and the
+  // root /users/{uid} doc are fine as non-existent — those paths only affect
+  // the setup-wizard heuristic, which is irrelevant here.
+  vi.mocked(firestore.getDoc).mockImplementation((ref) => {
+    const path = (ref as unknown as DocRef).__path ?? '';
+    if (path.startsWith('admins/')) {
+      return Promise.resolve({
+        exists: () => true,
+        data: () => ({}),
+      } as unknown as DocSnap);
+    }
+    return Promise.resolve({
+      exists: () => false,
+      data: () => undefined,
+    } as unknown as DocSnap);
+  });
+
+  vi.mocked(firestore.getDocs).mockResolvedValue({
+    empty: true,
+    size: 0,
+  } as unknown as QuerySnap);
+
+  // Capture the app_settings snapshot listener so we can drive it from the
+  // test (initial delivery + a post-write echo). Other onSnapshot subscriptions
+  // (user_roles, members, org buildings, feature_permissions, etc.) are no-ops.
+  let appSettingsListener: ((snap: unknown) => void) | null = null;
+  vi.mocked(firestore.onSnapshot).mockImplementation(
+    (refOrQuery: unknown, ...rest: unknown[]) => {
+      const path = (refOrQuery as DocRef).__path ?? '';
+      if (path === 'admin_settings/app_settings') {
+        appSettingsListener = rest[0] as (snap: unknown) => void;
+        // Deliver the seed asynchronously so the calling effect's setup
+        // completes first. The `void` makes the intentionally-fire-and-forget
+        // promise explicit (eslint no-floating-promises would flag it otherwise).
+        void Promise.resolve().then(() => {
+          if (appSettingsListener) {
+            appSettingsListener({
+              exists: () => true,
+              data: () => initialAppSettings,
+            });
+          }
+        });
+      }
+      return () => undefined;
+    }
+  );
+
+  return {
+    pushAppSettings: (data: AppSettings): void => {
+      if (!appSettingsListener) {
+        throw new Error(
+          'app_settings onSnapshot listener never registered — admin gate may not have opened'
+        );
+      }
+      appSettingsListener({
+        exists: () => true,
+        data: () => data,
+      });
+    },
+  };
+}
+
+async function mountAsAdmin(
+  initialAppSettings: AppSettings
+): Promise<{ pushAppSettings: (data: AppSettings) => void }> {
+  ctxHolder.current = null;
+  const handle = installAdminFirestore(initialAppSettings);
+
+  const onAuthMock = vi.mocked(firebaseAuth.onAuthStateChanged);
+  onAuthMock.mockImplementation(() => () => undefined);
+
+  render(
+    <AuthProvider>
+      <Probe />
+    </AuthProvider>
+  );
+
+  const lastCall = onAuthMock.mock.calls[onAuthMock.mock.calls.length - 1];
+  if (!lastCall) {
+    throw new Error(
+      'onAuthStateChanged was never called — provider failed to mount'
+    );
+  }
+  const listener = lastCall[1] as (u: User | null) => void;
+  const user = buildFakeUser();
+  Object.defineProperty(auth, 'currentUser', {
+    configurable: true,
+    writable: true,
+    value: user,
+  });
+
+  act(() => {
+    listener(user);
+  });
+
+  // Wait for the admin check + app_settings snapshot delivery to settle.
+  // Once isAdmin === true the app_settings listener attaches and the initial
+  // snapshot we queued in `installAdminFirestore` flushes through.
+  await waitFor(() => {
+    expect(ctxHolder.current?.isAdmin).toBe(true);
+    expect(ctxHolder.current?.appSettings?.geminiDailyLimit).toBe(
+      initialAppSettings.geminiDailyLimit
+    );
+  });
+
+  return handle;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  ctxHolder.current = null;
+  window.localStorage.clear();
+  vi.mocked(firestore.setDoc).mockResolvedValue(undefined);
+});
+
+describe('AuthContext — updateAppSettings with lastResultsProtection', () => {
+  it('persists lastResultsProtection through the generic Partial<AppSettings> merge', async () => {
+    const { pushAppSettings } = await mountAsAdmin({
+      geminiDailyLimit: 50,
+    });
+
+    // No app_settings writes from provider hydration — only the one we drive
+    // below should appear in the assertion.
+    vi.mocked(firestore.setDoc).mockClear();
+
+    const protection: ResultsProtection = {
+      watermarkEnabled: true,
+      tabWarningEnabled: true,
+      tabWarningThreshold: 5,
+    };
+
+    await act(async () => {
+      await getCtx().updateAppSettings({ lastResultsProtection: protection });
+    });
+
+    // The write must target admin_settings/app_settings with merge:true and a
+    // payload containing only the new field. If a per-field allowlist ever
+    // sneaks in, this assertion fails because the payload arg won't match.
+    const appSettingsWrites = vi
+      .mocked(firestore.setDoc)
+      .mock.calls.filter(
+        ([ref]) =>
+          (ref as unknown as DocRef).__path === 'admin_settings/app_settings'
+      );
+
+    expect(appSettingsWrites).toHaveLength(1);
+    const [, payload, options] = appSettingsWrites[0];
+    expect(payload).toEqual({ lastResultsProtection: protection });
+    expect(options).toEqual({ merge: true });
+
+    // Simulate Firestore's merged echo so the onSnapshot listener fires the
+    // way it would in production: geminiDailyLimit preserved + new field
+    // surfaced. This is what consumers (the publish-dialog pre-fill) read.
+    act(() => {
+      pushAppSettings({
+        geminiDailyLimit: 50,
+        lastResultsProtection: protection,
+      });
+    });
+
+    await waitFor(() => {
+      expect(getCtx().appSettings?.lastResultsProtection).toEqual(protection);
+      // Pre-existing field must still be present — guards against an
+      // accidental setAppSettings(updates) instead of the snapshot-driven
+      // merge.
+      expect(getCtx().appSettings?.geminiDailyLimit).toBe(50);
+    });
+  });
+});

--- a/tests/hooks/useQuizAssignments.publishProtection.test.ts
+++ b/tests/hooks/useQuizAssignments.publishProtection.test.ts
@@ -1,0 +1,205 @@
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+import {
+  collection,
+  doc,
+  getDocs,
+  onSnapshot,
+  writeBatch,
+} from 'firebase/firestore';
+import { useQuizAssignments } from '@/hooks/useQuizAssignments';
+import type { QuizData, ResultsProtection } from '@/types';
+
+// `deleteField()` returns a Firestore sentinel; the production code stores
+// the sentinel in the patch object and Firestore SDK interprets it on the
+// wire. For tests we use a unique branded marker so assertions can verify
+// the sentinel landed in the right field without depending on the real SDK.
+const DELETE_FIELD_SENTINEL = Symbol('test:deleteField()');
+vi.mock('firebase/firestore', () => ({
+  collection: vi.fn(),
+  deleteField: vi.fn(() => DELETE_FIELD_SENTINEL),
+  doc: vi.fn(),
+  getDoc: vi.fn(),
+  getDocs: vi.fn(),
+  onSnapshot: vi.fn(),
+  addDoc: vi.fn(),
+  query: vi.fn(),
+  where: vi.fn(),
+  orderBy: vi.fn(),
+  updateDoc: vi.fn(),
+  writeBatch: vi.fn(),
+}));
+
+vi.mock('@/hooks/useSyncedQuizGroups', () => ({
+  callJoinSyncedQuizGroup: vi.fn(),
+  callLeaveSyncedQuizGroup: vi.fn(),
+  createSyncedQuizGroup: vi.fn(),
+  pullSyncedQuizContent: vi.fn(),
+  publishSyncedQuiz: vi.fn(),
+  useSyncedQuizGroupsByIds: vi.fn(() => ({
+    groups: new Map(),
+    loading: false,
+  })),
+  SyncedQuizVersionConflictError: class extends Error {},
+}));
+
+const authMock: {
+  currentUser: { displayName?: string; email?: string } | null;
+} = {
+  currentUser: null,
+};
+vi.mock('@/config/firebase', () => ({
+  db: {},
+  get auth() {
+    return authMock;
+  },
+}));
+
+vi.mock('@/hooks/usePlcAssignmentIndex', () => ({
+  writePlcAssignmentIndexEntry: vi.fn().mockResolvedValue(undefined),
+  mirrorPlcAssignmentStatus: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('@/hooks/usePlcAssignments', () => ({
+  writePlcAssignmentTemplate: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('@/utils/plcContributions', () => ({
+  deletePlcContribution: vi.fn().mockResolvedValue(undefined),
+}));
+
+const mockCollection = collection as Mock;
+const mockDoc = doc as Mock;
+const mockOnSnapshot = onSnapshot as Mock;
+const mockWriteBatch = writeBatch as Mock;
+const mockGetDocs = getDocs as Mock;
+
+const TEACHER_UID = 'teacher-1';
+const ASSIGNMENT_ID = 'assignment-1';
+
+// Minimal canonical quiz fixture — one MC question is enough; the
+// protection plumbing doesn't depend on quiz content.
+const quizData = {
+  id: 'quiz-1',
+  title: 'Test Quiz',
+  questions: [
+    {
+      id: 'q0',
+      text: 'Q0',
+      type: 'MC' as const,
+      correctAnswer: 'a',
+      incorrectAnswers: ['b', 'c', 'd'],
+      timeLimit: 30,
+      points: 1,
+    },
+  ],
+  createdAt: 0,
+  updatedAt: 0,
+} satisfies QuizData;
+
+describe('useQuizAssignments — publishAssignmentScores protection mirroring', () => {
+  const batchUpdate = vi.fn();
+  const batchCommit = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDoc.mockImplementation((_db: unknown, ...segs: string[]) =>
+      segs.join('/')
+    );
+    mockCollection.mockImplementation((_db: unknown, ...segs: string[]) =>
+      segs.join('/')
+    );
+    mockOnSnapshot.mockReturnValue(() => undefined);
+    batchUpdate.mockReset();
+    batchCommit.mockReset().mockResolvedValue(undefined);
+    mockWriteBatch.mockReturnValue({
+      update: batchUpdate,
+      commit: batchCommit,
+    });
+    // No responses — keep these tests focused on the assignment + session
+    // doc writes, where the protection field is mirrored.
+    mockGetDocs.mockResolvedValue({ docs: [] });
+  });
+
+  function findAssignmentPatch(): Record<string, unknown> {
+    const call = batchUpdate.mock.calls.find(
+      ([ref]) =>
+        typeof ref === 'string' &&
+        ref.startsWith(`users/${TEACHER_UID}/quiz_assignments/`)
+    );
+    if (!call) throw new Error('expected batch.update on assignment doc');
+    return call[1] as Record<string, unknown>;
+  }
+
+  function findSessionPatch(): Record<string, unknown> {
+    const call = batchUpdate.mock.calls.find(
+      ([ref]) => typeof ref === 'string' && ref.startsWith('quiz_sessions/')
+    );
+    if (!call) throw new Error('expected batch.update on session doc');
+    return call[1] as Record<string, unknown>;
+  }
+
+  it('writes protection to both assignment and session docs when supplied', async () => {
+    const protection: ResultsProtection = {
+      watermarkEnabled: true,
+      tabWarningEnabled: true,
+      tabWarningThreshold: 2,
+    };
+
+    const { result } = renderHook(() => useQuizAssignments(TEACHER_UID));
+    await act(async () => {
+      await result.current.publishAssignmentScores(
+        ASSIGNMENT_ID,
+        quizData,
+        'score-responses-and-answers',
+        protection
+      );
+    });
+
+    // The student app only reads the session doc, so the protection settings
+    // MUST mirror onto the session — otherwise watermark + tab-warning
+    // configuration is invisible to students. The teacher's archive view
+    // reads the assignment doc, so it lives there too.
+    expect(findAssignmentPatch()).toMatchObject({ protection });
+    expect(findSessionPatch()).toMatchObject({ protection });
+  });
+
+  it('writes deleteField() for protection on both docs when caller omits it (back-compat + stale-settings clearing)', async () => {
+    // Older publish callers won't supply protection. Re-publishing without
+    // protection must wipe any prior protection settings rather than
+    // silently leaving the stale values in place. `deleteField()` is the
+    // Firestore sentinel that removes a field; we test for the test-only
+    // marker the firebase/firestore mock returns.
+    const { result } = renderHook(() => useQuizAssignments(TEACHER_UID));
+    await act(async () => {
+      await result.current.publishAssignmentScores(
+        ASSIGNMENT_ID,
+        quizData,
+        'score-only'
+      );
+    });
+
+    expect(findAssignmentPatch()).toMatchObject({
+      protection: DELETE_FIELD_SENTINEL,
+    });
+    expect(findSessionPatch()).toMatchObject({
+      protection: DELETE_FIELD_SENTINEL,
+    });
+  });
+
+  it('unpublishAssignmentScores clears protection on both docs', async () => {
+    // Unpublish is the "wipe everything related to publication" exit;
+    // protection settings are part of that surface and must go with it.
+    const { result } = renderHook(() => useQuizAssignments(TEACHER_UID));
+    await act(async () => {
+      await result.current.unpublishAssignmentScores(ASSIGNMENT_ID);
+    });
+
+    expect(findAssignmentPatch()).toMatchObject({
+      protection: DELETE_FIELD_SENTINEL,
+    });
+    expect(findSessionPatch()).toMatchObject({
+      protection: DELETE_FIELD_SENTINEL,
+    });
+  });
+});

--- a/tests/hooks/useQuizSession.test.ts
+++ b/tests/hooks/useQuizSession.test.ts
@@ -1685,6 +1685,92 @@ describe('useQuizSessionTeacher — removeStudent / revealAnswer / hideAnswer', 
   });
 });
 
+describe('useQuizSessionTeacher — unlockResultsForStudent', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setupTeacherMocks();
+  });
+
+  it('decrements resultsTabWarnings by 1, clears the lockout, and removes resultsLockedOutAt', async () => {
+    // The teacher unlock is deliberately a *decrement*, not a full reset:
+    // a single additional tab-switch post-unlock should re-lock the
+    // student. Stub the response read so the hook sees prior warnings.
+    (
+      firestore.getDoc as unknown as ReturnType<typeof vi.fn>
+    ).mockResolvedValueOnce({
+      exists: () => true,
+      data: () => ({ resultsTabWarnings: 3, resultsLockedOut: true }),
+    });
+
+    const { result } = renderHook(() => useQuizSessionTeacher('sess-1'));
+
+    await act(async () => {
+      await result.current.unlockResultsForStudent('pin-period_1-9999');
+    });
+
+    expect(firestore.updateDoc).toHaveBeenCalledTimes(1);
+    const updatePayload = (
+      firestore.updateDoc as unknown as ReturnType<typeof vi.fn>
+    ).mock.calls[0][1];
+    expect(updatePayload).toEqual({
+      resultsTabWarnings: 2,
+      resultsLockedOut: false,
+      resultsLockedOutAt: DELETE_FIELD_SENTINEL,
+    });
+  });
+
+  it('floors resultsTabWarnings at 0 when the prior value is already 0 or missing', async () => {
+    // Defensive case: rules + UI shouldn't ever leave us here, but if the
+    // read returns no warnings at all the decrement must not produce -1.
+    (
+      firestore.getDoc as unknown as ReturnType<typeof vi.fn>
+    ).mockResolvedValueOnce({
+      exists: () => true,
+      data: () => ({}),
+    });
+
+    const { result } = renderHook(() => useQuizSessionTeacher('sess-1'));
+
+    await act(async () => {
+      await result.current.unlockResultsForStudent('pin-period_1-9999');
+    });
+
+    const updatePayload = (
+      firestore.updateDoc as unknown as ReturnType<typeof vi.fn>
+    ).mock.calls[0][1];
+    expect(updatePayload).toMatchObject({
+      resultsTabWarnings: 0,
+      resultsLockedOut: false,
+      resultsLockedOutAt: DELETE_FIELD_SENTINEL,
+    });
+  });
+
+  it('throws when the response doc no longer exists (snapshot races with student removal)', async () => {
+    (
+      firestore.getDoc as unknown as ReturnType<typeof vi.fn>
+    ).mockResolvedValueOnce({
+      exists: () => false,
+    });
+
+    const { result } = renderHook(() => useQuizSessionTeacher('sess-1'));
+
+    await expect(
+      result.current.unlockResultsForStudent('pin-period_1-9999')
+    ).rejects.toThrow(/Student response not found/);
+    expect(firestore.updateDoc).not.toHaveBeenCalled();
+  });
+
+  it('is a no-op when sessionId is null', async () => {
+    const { result } = renderHook(() => useQuizSessionTeacher(null));
+
+    await expect(
+      result.current.unlockResultsForStudent('pin-period_1-9999')
+    ).rejects.toThrow(/No active session/);
+    expect(firestore.getDoc).not.toHaveBeenCalled();
+    expect(firestore.updateDoc).not.toHaveBeenCalled();
+  });
+});
+
 describe('useQuizSessionTeacher — endQuizSession', () => {
   let env: TeacherMockEnv;
 

--- a/tests/hooks/useResultsTabWarnings.test.ts
+++ b/tests/hooks/useResultsTabWarnings.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useResultsTabWarnings } from '@/hooks/useResultsTabWarnings';
+
+const updateDoc = vi.fn();
+const docRef = { __mockRef: true };
+vi.mock('firebase/firestore', async (orig) => {
+  const actual = await (
+    orig as () => Promise<typeof import('firebase/firestore')>
+  )();
+  return {
+    ...actual,
+    doc: vi.fn(() => docRef),
+    updateDoc: (...args: unknown[]): unknown => updateDoc(...args) as unknown,
+  };
+});
+
+describe('useResultsTabWarnings', () => {
+  beforeEach(() => {
+    updateDoc.mockReset().mockResolvedValue(undefined);
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('does nothing when enabled=false', () => {
+    renderHook(() =>
+      useResultsTabWarnings({
+        enabled: false,
+        threshold: 3,
+        currentWarnings: 0,
+        responseDocPath: '/quiz_sessions/x/responses/y',
+      })
+    );
+    document.dispatchEvent(new Event('visibilitychange'));
+    expect(updateDoc).not.toHaveBeenCalled();
+  });
+
+  it('increments warnings on visibility hide → show transition', async () => {
+    Object.defineProperty(document, 'visibilityState', {
+      value: 'hidden',
+      configurable: true,
+    });
+    renderHook(() =>
+      useResultsTabWarnings({
+        enabled: true,
+        threshold: 3,
+        currentWarnings: 0,
+        responseDocPath: '/quiz_sessions/x/responses/y',
+      })
+    );
+    await act(() => {
+      Object.defineProperty(document, 'visibilityState', {
+        value: 'visible',
+        configurable: true,
+      });
+      document.dispatchEvent(new Event('visibilitychange'));
+      return Promise.resolve();
+    });
+    expect(updateDoc).toHaveBeenCalledTimes(1);
+    expect(updateDoc.mock.calls[0][1]).toMatchObject({
+      resultsTabWarnings: 1,
+    });
+  });
+
+  it('flips resultsLockedOut=true when warnings reach threshold', async () => {
+    Object.defineProperty(document, 'visibilityState', {
+      value: 'hidden',
+      configurable: true,
+    });
+    renderHook(() =>
+      useResultsTabWarnings({
+        enabled: true,
+        threshold: 3,
+        currentWarnings: 2,
+        responseDocPath: '/quiz_sessions/x/responses/y',
+      })
+    );
+    await act(() => {
+      Object.defineProperty(document, 'visibilityState', {
+        value: 'visible',
+        configurable: true,
+      });
+      document.dispatchEvent(new Event('visibilitychange'));
+      return Promise.resolve();
+    });
+    expect(updateDoc.mock.calls[0][1]).toMatchObject({
+      resultsTabWarnings: 3,
+      resultsLockedOut: true,
+      resultsLockedOutAt: expect.any(Number) as unknown,
+    });
+  });
+
+  it('does not increment further once already locked out', () => {
+    renderHook(() =>
+      useResultsTabWarnings({
+        enabled: true,
+        threshold: 3,
+        currentWarnings: 3,
+        lockedOut: true,
+        responseDocPath: '/quiz_sessions/x/responses/y',
+      })
+    );
+    document.dispatchEvent(new Event('visibilitychange'));
+    expect(updateDoc).not.toHaveBeenCalled();
+  });
+});

--- a/tests/hooks/useResultsTabWarnings.test.ts
+++ b/tests/hooks/useResultsTabWarnings.test.ts
@@ -3,6 +3,7 @@ import { renderHook, act } from '@testing-library/react';
 import { useResultsTabWarnings } from '@/hooks/useResultsTabWarnings';
 
 const updateDoc = vi.fn();
+const docMock = vi.fn();
 const docRef = { __mockRef: true };
 const incrementSentinel = (value: number) => ({ __increment: value });
 vi.mock('firebase/firestore', async (orig) => {
@@ -11,7 +12,10 @@ vi.mock('firebase/firestore', async (orig) => {
   )();
   return {
     ...actual,
-    doc: vi.fn(() => docRef),
+    doc: (...args: unknown[]): unknown => {
+      docMock(...args);
+      return docRef;
+    },
     updateDoc: (...args: unknown[]): unknown => updateDoc(...args) as unknown,
     increment: (value: number) => incrementSentinel(value),
   };
@@ -20,6 +24,7 @@ vi.mock('firebase/firestore', async (orig) => {
 describe('useResultsTabWarnings', () => {
   beforeEach(() => {
     updateDoc.mockReset().mockResolvedValue(undefined);
+    docMock.mockReset();
   });
   afterEach(() => {
     vi.restoreAllMocks();
@@ -31,7 +36,7 @@ describe('useResultsTabWarnings', () => {
         enabled: false,
         threshold: 3,
         currentWarnings: 0,
-        responseDocPath: '/quiz_sessions/x/responses/y',
+        responseDocPath: 'quiz_sessions/x/responses/y',
       })
     );
     document.dispatchEvent(new Event('visibilitychange'));
@@ -48,7 +53,7 @@ describe('useResultsTabWarnings', () => {
         enabled: true,
         threshold: 3,
         currentWarnings: 0,
-        responseDocPath: '/quiz_sessions/x/responses/y',
+        responseDocPath: 'quiz_sessions/x/responses/y',
       })
     );
     // First go hidden so the hook observes the exit…
@@ -73,6 +78,12 @@ describe('useResultsTabWarnings', () => {
     expect(updateDoc.mock.calls[0][1]).toMatchObject({
       resultsTabWarnings: { __increment: 1 },
     });
+    // Pin the path forwarding — production callers build the path without a
+    // leading slash, matching the Firestore `doc(db, path)` contract.
+    expect(docMock).toHaveBeenCalledWith(
+      expect.anything(),
+      'quiz_sessions/x/responses/y'
+    );
   });
 
   it('flips resultsLockedOut=true when warnings reach threshold', async () => {
@@ -85,7 +96,7 @@ describe('useResultsTabWarnings', () => {
         enabled: true,
         threshold: 3,
         currentWarnings: 2,
-        responseDocPath: '/quiz_sessions/x/responses/y',
+        responseDocPath: 'quiz_sessions/x/responses/y',
       })
     );
     await act(() => {
@@ -118,7 +129,7 @@ describe('useResultsTabWarnings', () => {
         threshold: 3,
         currentWarnings: 3,
         lockedOut: true,
-        responseDocPath: '/quiz_sessions/x/responses/y',
+        responseDocPath: 'quiz_sessions/x/responses/y',
       })
     );
     document.dispatchEvent(new Event('visibilitychange'));

--- a/tests/hooks/useResultsTabWarnings.test.ts
+++ b/tests/hooks/useResultsTabWarnings.test.ts
@@ -4,6 +4,7 @@ import { useResultsTabWarnings } from '@/hooks/useResultsTabWarnings';
 
 const updateDoc = vi.fn();
 const docRef = { __mockRef: true };
+const incrementSentinel = (value: number) => ({ __increment: value });
 vi.mock('firebase/firestore', async (orig) => {
   const actual = await (
     orig as () => Promise<typeof import('firebase/firestore')>
@@ -12,6 +13,7 @@ vi.mock('firebase/firestore', async (orig) => {
     ...actual,
     doc: vi.fn(() => docRef),
     updateDoc: (...args: unknown[]): unknown => updateDoc(...args) as unknown,
+    increment: (value: number) => incrementSentinel(value),
   };
 });
 
@@ -38,7 +40,7 @@ describe('useResultsTabWarnings', () => {
 
   it('increments warnings on visibility hide → show transition', async () => {
     Object.defineProperty(document, 'visibilityState', {
-      value: 'hidden',
+      value: 'visible',
       configurable: true,
     });
     renderHook(() =>
@@ -49,6 +51,16 @@ describe('useResultsTabWarnings', () => {
         responseDocPath: '/quiz_sessions/x/responses/y',
       })
     );
+    // First go hidden so the hook observes the exit…
+    await act(() => {
+      Object.defineProperty(document, 'visibilityState', {
+        value: 'hidden',
+        configurable: true,
+      });
+      document.dispatchEvent(new Event('visibilitychange'));
+      return Promise.resolve();
+    });
+    // …then back to visible to trigger the increment.
     await act(() => {
       Object.defineProperty(document, 'visibilityState', {
         value: 'visible',
@@ -59,13 +71,13 @@ describe('useResultsTabWarnings', () => {
     });
     expect(updateDoc).toHaveBeenCalledTimes(1);
     expect(updateDoc.mock.calls[0][1]).toMatchObject({
-      resultsTabWarnings: 1,
+      resultsTabWarnings: { __increment: 1 },
     });
   });
 
   it('flips resultsLockedOut=true when warnings reach threshold', async () => {
     Object.defineProperty(document, 'visibilityState', {
-      value: 'hidden',
+      value: 'visible',
       configurable: true,
     });
     renderHook(() =>
@@ -78,6 +90,14 @@ describe('useResultsTabWarnings', () => {
     );
     await act(() => {
       Object.defineProperty(document, 'visibilityState', {
+        value: 'hidden',
+        configurable: true,
+      });
+      document.dispatchEvent(new Event('visibilitychange'));
+      return Promise.resolve();
+    });
+    await act(() => {
+      Object.defineProperty(document, 'visibilityState', {
         value: 'visible',
         configurable: true,
       });
@@ -85,7 +105,7 @@ describe('useResultsTabWarnings', () => {
       return Promise.resolve();
     });
     expect(updateDoc.mock.calls[0][1]).toMatchObject({
-      resultsTabWarnings: 3,
+      resultsTabWarnings: { __increment: 1 },
       resultsLockedOut: true,
       resultsLockedOutAt: expect.any(Number) as unknown,
     });

--- a/tests/rules/resultsProtection.test.ts
+++ b/tests/rules/resultsProtection.test.ts
@@ -1,0 +1,374 @@
+// Firestore security-rules tests for the results-view screenshot-protection
+// fields on quiz response docs (Task 11).
+//
+// Contract:
+//   - Students may only INCREMENT `resultsTabWarnings` (monotonic) on their
+//     own response doc — decrementing is rejected.
+//   - Students may transition `resultsLockedOut` from `false → true` (the
+//     auto-lockout when threshold is reached) but never `true → false`
+//     (self-unlock is rejected).
+//   - Students may set/update `resultsLockedOutAt` (timestamp goes with the
+//     lockout flip).
+//   - Students writing these fields together with any field outside the
+//     existing allowed whitelist (e.g. `score`) must be rejected — the
+//     existing `changedKeys().hasOnly([...])` whitelist enforces this.
+//   - Teachers (session owner) can write any of the three fields freely,
+//     including DECREMENTING `resultsTabWarnings` and clearing
+//     `resultsLockedOut` back to false. This is what powers the Task 12
+//     teacher unlock affordance.
+//
+// Requires a running Firestore emulator. Invoke via:
+//   pnpm run test:rules
+
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { afterAll, beforeAll, beforeEach, describe, it } from 'vitest';
+import {
+  initializeTestEnvironment,
+  assertSucceeds,
+  assertFails,
+  type RulesTestEnvironment,
+} from '@firebase/rules-unit-testing';
+import { setDoc, updateDoc, doc } from 'firebase/firestore';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const PROJECT_ID = 'spartboard-results-protection-test';
+const SESSION_ID = 'session-results-protection';
+const TEACHER_UID = 'teacher-uid-results';
+const STUDENT_A_UID = 'student-a-anon';
+const STUDENT_B_UID = 'student-b-anon';
+const CLASS_ID = 'class-results';
+
+// Anonymous PIN-derived response keys follow the
+// `pin-{encodedPeriod}-{encodedPin}` shape enforced by the create rule.
+// For UPDATE tests the key shape doesn't matter (only the studentUid field
+// check does), but we keep it well-formed for realism.
+const RESPONSE_A_KEY = `pin-period_1-01`;
+const RESPONSE_B_KEY = `pin-period_1-02`;
+
+const RULES_PATH = fileURLToPath(
+  new URL('../../firestore.rules', import.meta.url)
+);
+
+let testEnv: RulesTestEnvironment;
+
+// ---------------------------------------------------------------------------
+// Auth contexts — match the claim shape used by other rules tests so the
+// emulator doesn't throw on undefined-claim reads inside helper functions.
+// ---------------------------------------------------------------------------
+
+const asTeacher = () =>
+  testEnv
+    .authenticatedContext(TEACHER_UID, {
+      email: 'teacher@school.edu',
+      studentRole: false,
+      classIds: [],
+      firebase: { sign_in_provider: 'google.com' },
+    })
+    .firestore();
+
+const asStudentA = () =>
+  testEnv
+    .authenticatedContext(STUDENT_A_UID, {
+      email: '',
+      studentRole: false,
+      classIds: [],
+      firebase: { sign_in_provider: 'anonymous' },
+    })
+    .firestore();
+
+const asStudentB = () =>
+  testEnv
+    .authenticatedContext(STUDENT_B_UID, {
+      email: '',
+      studentRole: false,
+      classIds: [],
+      firebase: { sign_in_provider: 'anonymous' },
+    })
+    .firestore();
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+beforeAll(async () => {
+  testEnv = await initializeTestEnvironment({
+    projectId: PROJECT_ID,
+    firestore: {
+      rules: readFileSync(RULES_PATH, 'utf8'),
+      host: process.env.FIRESTORE_EMULATOR_HOST?.split(':')[0] ?? '127.0.0.1',
+      port: Number(
+        process.env.FIRESTORE_EMULATOR_HOST?.split(':')[1] ?? '8080'
+      ),
+    },
+  });
+});
+
+afterAll(async () => {
+  await testEnv?.cleanup();
+});
+
+// Seed one session and one response per student before each test. Using
+// `withSecurityRulesDisabled` so the seed doesn't have to satisfy the
+// create-time constraints.
+async function seedSessionAndResponses(
+  opts: {
+    warnings?: number;
+    lockedOut?: boolean;
+    lockedOutAt?: number;
+  } = {}
+) {
+  const { warnings, lockedOut, lockedOutAt } = opts;
+  await testEnv.withSecurityRulesDisabled(async (ctx) => {
+    const db = ctx.firestore();
+    await setDoc(doc(db, `quiz_sessions/${SESSION_ID}`), {
+      teacherUid: TEACHER_UID,
+      status: 'active',
+      code: 'RPTEST',
+      classId: CLASS_ID,
+      classIds: [CLASS_ID],
+      mode: 'submissions',
+    });
+    const baseResponse = {
+      studentUid: STUDENT_A_UID,
+      pin: '01',
+      classPeriod: 'period_1',
+      joinedAt: 1000,
+      score: 80,
+      answers: [],
+      status: 'completed',
+      completedAttempts: 1,
+      preSyncVersion: 0,
+      tabSwitchWarnings: 0,
+      ...(warnings !== undefined ? { resultsTabWarnings: warnings } : {}),
+      ...(lockedOut !== undefined ? { resultsLockedOut: lockedOut } : {}),
+      ...(lockedOutAt !== undefined ? { resultsLockedOutAt: lockedOutAt } : {}),
+    };
+    await setDoc(
+      doc(db, `quiz_sessions/${SESSION_ID}/responses/${RESPONSE_A_KEY}`),
+      baseResponse
+    );
+    await setDoc(
+      doc(db, `quiz_sessions/${SESSION_ID}/responses/${RESPONSE_B_KEY}`),
+      {
+        ...baseResponse,
+        studentUid: STUDENT_B_UID,
+        pin: '02',
+      }
+    );
+  });
+}
+
+beforeEach(async () => {
+  await testEnv.clearFirestore();
+});
+
+// ---------------------------------------------------------------------------
+// Student-side rules
+// ---------------------------------------------------------------------------
+
+describe('results-protection — student writes', () => {
+  it('student CAN increment resultsTabWarnings on their own response', async () => {
+    await seedSessionAndResponses({ warnings: 1 });
+    await assertSucceeds(
+      updateDoc(
+        doc(
+          asStudentA(),
+          `quiz_sessions/${SESSION_ID}/responses/${RESPONSE_A_KEY}`
+        ),
+        { resultsTabWarnings: 2 }
+      )
+    );
+  });
+
+  it('student CAN keep resultsTabWarnings unchanged (no-op update)', async () => {
+    await seedSessionAndResponses({ warnings: 1 });
+    // Update a different allowed field — the rule should accept it because
+    // resultsTabWarnings stays the same.
+    await assertSucceeds(
+      updateDoc(
+        doc(
+          asStudentA(),
+          `quiz_sessions/${SESSION_ID}/responses/${RESPONSE_A_KEY}`
+        ),
+        { resultsTabWarnings: 1 }
+      )
+    );
+  });
+
+  it('student CANNOT decrement resultsTabWarnings', async () => {
+    await seedSessionAndResponses({ warnings: 3 });
+    await assertFails(
+      updateDoc(
+        doc(
+          asStudentA(),
+          `quiz_sessions/${SESSION_ID}/responses/${RESPONSE_A_KEY}`
+        ),
+        { resultsTabWarnings: 2 }
+      )
+    );
+  });
+
+  it('student CAN transition resultsLockedOut from false → true (auto-lockout flip)', async () => {
+    await seedSessionAndResponses({ warnings: 2, lockedOut: false });
+    // Mirror what useResultsTabWarnings writes when threshold is reached.
+    await assertSucceeds(
+      updateDoc(
+        doc(
+          asStudentA(),
+          `quiz_sessions/${SESSION_ID}/responses/${RESPONSE_A_KEY}`
+        ),
+        {
+          resultsTabWarnings: 3,
+          resultsLockedOut: true,
+          resultsLockedOutAt: 1700000000000,
+        }
+      )
+    );
+  });
+
+  it('student CANNOT self-unlock (resultsLockedOut: true → false)', async () => {
+    await seedSessionAndResponses({
+      warnings: 3,
+      lockedOut: true,
+      lockedOutAt: 1000,
+    });
+    await assertFails(
+      updateDoc(
+        doc(
+          asStudentA(),
+          `quiz_sessions/${SESSION_ID}/responses/${RESPONSE_A_KEY}`
+        ),
+        { resultsLockedOut: false }
+      )
+    );
+  });
+
+  it("student CANNOT write protection fields on another student's response", async () => {
+    await seedSessionAndResponses({ warnings: 1, lockedOut: false });
+    // Student B tries to bump warnings on Student A's doc.
+    await assertFails(
+      updateDoc(
+        doc(
+          asStudentB(),
+          `quiz_sessions/${SESSION_ID}/responses/${RESPONSE_A_KEY}`
+        ),
+        { resultsTabWarnings: 2 }
+      )
+    );
+  });
+
+  it('student CANNOT smuggle a score change inside a protection-field update', async () => {
+    // The existing changedKeys().hasOnly([...]) whitelist guards the field
+    // surface — score is allowed (students can null it on rejoin) but only
+    // ever as `null`. A non-null score must still be rejected even when
+    // packaged with a legit protection-field increment.
+    await seedSessionAndResponses({ warnings: 1 });
+    await assertFails(
+      updateDoc(
+        doc(
+          asStudentA(),
+          `quiz_sessions/${SESSION_ID}/responses/${RESPONSE_A_KEY}`
+        ),
+        { resultsTabWarnings: 2, score: 100 }
+      )
+    );
+  });
+
+  it('student CANNOT mix protection-field writes with a non-whitelisted field', async () => {
+    // `studentUid` is not in the whitelist — the existing hasOnly() must
+    // catch any attempt to add an arbitrary field alongside protection ones.
+    await seedSessionAndResponses({ warnings: 1 });
+    await assertFails(
+      updateDoc(
+        doc(
+          asStudentA(),
+          `quiz_sessions/${SESSION_ID}/responses/${RESPONSE_A_KEY}`
+        ),
+        { resultsTabWarnings: 2, somethingElse: 'hack' }
+      )
+    );
+  });
+
+  it('student CAN write resultsTabWarnings on a doc that previously had no such field (legacy default 0)', async () => {
+    // Legacy responses created before the feature have no
+    // resultsTabWarnings field. The `.get('resultsTabWarnings', 0)` default
+    // in the rule must allow the first increment (0 → 1).
+    await seedSessionAndResponses({}); // no warnings/lockout fields seeded
+    await assertSucceeds(
+      updateDoc(
+        doc(
+          asStudentA(),
+          `quiz_sessions/${SESSION_ID}/responses/${RESPONSE_A_KEY}`
+        ),
+        { resultsTabWarnings: 1 }
+      )
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Teacher-side rules — the teacher branch on the response update rule is
+// unrestricted. These tests pin that contract so a future tightening of
+// the teacher branch doesn't accidentally break the Task 12 unlock flow.
+// ---------------------------------------------------------------------------
+
+describe('results-protection — teacher writes', () => {
+  it('teacher CAN decrement resultsTabWarnings (Task 12 unlock affordance)', async () => {
+    await seedSessionAndResponses({
+      warnings: 3,
+      lockedOut: true,
+      lockedOutAt: 1000,
+    });
+    await assertSucceeds(
+      updateDoc(
+        doc(
+          asTeacher(),
+          `quiz_sessions/${SESSION_ID}/responses/${RESPONSE_A_KEY}`
+        ),
+        { resultsTabWarnings: 2 }
+      )
+    );
+  });
+
+  it('teacher CAN clear resultsLockedOut from true → false', async () => {
+    await seedSessionAndResponses({
+      warnings: 3,
+      lockedOut: true,
+      lockedOutAt: 1000,
+    });
+    await assertSucceeds(
+      updateDoc(
+        doc(
+          asTeacher(),
+          `quiz_sessions/${SESSION_ID}/responses/${RESPONSE_A_KEY}`
+        ),
+        { resultsLockedOut: false }
+      )
+    );
+  });
+
+  it('teacher CAN write all three protection fields together in one update', async () => {
+    await seedSessionAndResponses({
+      warnings: 3,
+      lockedOut: true,
+      lockedOutAt: 1000,
+    });
+    await assertSucceeds(
+      updateDoc(
+        doc(
+          asTeacher(),
+          `quiz_sessions/${SESSION_ID}/responses/${RESPONSE_A_KEY}`
+        ),
+        {
+          resultsTabWarnings: 0,
+          resultsLockedOut: false,
+          resultsLockedOutAt: 0,
+        }
+      )
+    );
+  });
+});

--- a/types.ts
+++ b/types.ts
@@ -2681,6 +2681,12 @@ export interface QuizSession {
    * canonical answer in one batch.
    */
   scoreVisibility?: QuizScoreVisibility;
+  /**
+   * Mirror of QuizAssignment.protection so the student app — which only reads
+   * /quiz_sessions — can decide whether to mount watermark + tab-warning UI.
+   * Cleared by `unpublishAssignmentScores`.
+   */
+  protection?: ResultsProtection;
 }
 
 export interface QuizResponseAnswer {
@@ -2771,6 +2777,22 @@ export interface QuizResponse {
    * Used for maintaining quiz integrity.
    */
   tabSwitchWarnings?: number;
+  /**
+   * Number of tab-switch / focus-loss events the student has accumulated while
+   * viewing **published results**. Distinct from `tabSwitchWarnings`, which
+   * tracks tab switches during the active quiz-taking attempt. Server-rule
+   * enforced to only ever increase from a student write — teacher writes (via
+   * `unlockResultsForStudent`) can decrement.
+   */
+  resultsTabWarnings?: number;
+  /**
+   * True once `resultsTabWarnings` reaches `session.protection.tabWarningThreshold`.
+   * Read by the student app to redirect to My Assignments, and by the teacher's
+   * monitor to surface the lock badge + unlock affordance.
+   */
+  resultsLockedOut?: boolean;
+  /** Wall-clock ms when `resultsLockedOut` last flipped from false → true. */
+  resultsLockedOutAt?: number;
   /** Which class period the student selected when joining (multi-class support). */
   classPeriod?: string;
   /**
@@ -3075,6 +3097,34 @@ export type QuizScoreVisibility =
   | 'score-responses-and-answers';
 
 /**
+ * Anti-screenshot protections applied to a student's view of published quiz
+ * results. Mirrored from QuizAssignment → QuizSession at publish time so the
+ * student app (which only reads sessions) can render protection without
+ * needing access to the teacher's assignment doc.
+ */
+export interface ResultsProtection {
+  /** Show a repeating low-opacity overlay with student name + publish timestamp. */
+  watermarkEnabled: boolean;
+  /** Detect visibility/focus changes and warn → lock student when threshold hit. */
+  tabWarningEnabled: boolean;
+  /**
+   * Number of warnings before lockout. 1–10 inclusive. Only meaningful when
+   * `tabWarningEnabled` is true. Defaults to 3 in the UI but persisted
+   * explicitly so historical assignments stay accurate after the default changes.
+   */
+  tabWarningThreshold: number;
+}
+
+export const RESULTS_PROTECTION_DEFAULTS: ResultsProtection = {
+  watermarkEnabled: true,
+  tabWarningEnabled: false,
+  tabWarningThreshold: 3,
+};
+
+export const RESULTS_TAB_WARNING_THRESHOLD_MIN = 1;
+export const RESULTS_TAB_WARNING_THRESHOLD_MAX = 10;
+
+/**
  * PLC linkage for a quiz assignment. Present iff the assignment is in PLC
  * mode (the originator opted into "Share with PLC" at create time, or the
  * importer is a member of the originator's PLC). The presence of this
@@ -3220,6 +3270,12 @@ export interface QuizAssignment extends QuizAssignmentSettings {
    * `QuizSession` doc by `publishAssignmentScores`.
    */
   scoreVisibility?: QuizScoreVisibility;
+  /**
+   * Anti-screenshot protections applied when results are visible to students.
+   * `undefined` = no protection (legacy assignments pre-feature). Mirrored to
+   * the session doc by `publishAssignmentScores`.
+   */
+  protection?: ResultsProtection;
   /**
    * Timestamp of the most recent `publishAssignmentScores` call. Used by
    * the archive UI to surface "Published <date>" text on cards whose
@@ -5166,6 +5222,13 @@ export type AssignmentModesConfig = Partial<
 export interface AppSettings {
   geminiDailyLimit: number;
   logoUrl?: string;
+  /**
+   * The protection settings the teacher last published with. Used as the
+   * pre-fill for the next "Publish Results" dialog so teachers don't have to
+   * re-pick on every publish. Initialised from `RESULTS_PROTECTION_DEFAULTS`
+   * if unset.
+   */
+  lastResultsProtection?: ResultsProtection;
 }
 
 /**

--- a/types.ts
+++ b/types.ts
@@ -2687,6 +2687,14 @@ export interface QuizSession {
    * Cleared by `unpublishAssignmentScores`.
    */
   protection?: ResultsProtection;
+  /**
+   * Server-set timestamp for the most recent `publishAssignmentScores` call.
+   * Mirrored from the assignment doc so the student app (which only reads
+   * `/quiz_sessions`) can stamp the watermark with a publish time without
+   * needing access to the teacher's assignment doc. Cleared by
+   * `unpublishAssignmentScores`.
+   */
+  scorePublishedAt?: number;
 }
 
 export interface QuizResponseAnswer {


### PR DESCRIPTION
## Summary

Adds opt-in anti-screenshot protections on published quiz results:

- **Watermark overlay** — repeating diagonal low-opacity SVG pattern with the student's name + publish timestamp, rendered on the student's `PublishedScoreReview`. Personal identifier deters sharing without harming readability.
- **Tab-switch warning system** — configurable threshold (1–10, default 3). When students tab away on the results view, the count increments atomically via Firestore `increment(1)`. At threshold, `resultsLockedOut` flips true and the student is redirected to My Assignments → Completed where the row shows a `Locked` pill.
- **Teacher monitor** — per-student lock badge `Results locked (N/M)` plus an `Unlock results` button. Unlock decrements warnings by 1 (zero grace post-unlock — one more tab switch re-locks).
- **Monitor button badge** — rose count badge on the active assignment's Monitor button shows the number of locked students in real time.
- **Remember-last-used** — teacher's most recent protection settings persist via `AppSettings.lastResultsProtection` so re-publishing matches their habit.

Both toggles default to opt-in (watermark on, tab-warning off, threshold 3) and are surfaced in the shared `PublishScoresModal` only for the Quiz widget — Video Activity and Guided Learning publish flows are unaffected.

## Implementation notes

- **Architecture:** `ResultsProtection` mirrored from `QuizAssignment` → `QuizSession` at publish time. Student app reads the session doc; per-response state (`resultsTabWarnings`, `resultsLockedOut`, `resultsLockedOutAt`) lives on `QuizResponse`.
- **Firestore rules:** students can only monotonically increment warnings and transition lockout `false → true`. Teachers retain full write access for the unlock affordance. 11 rules tests pin the contract (machine has JDK 17; rules tests will run on CI which has JDK 21+).
- **Race safety:** `increment(1)` on the student side keeps the counter atomic across rapid tab switches. Teacher unlock's `getDoc → updateDoc` cycle has a small documented RMW window — accepted intentionally (worst case is one extra strike).
- **No new Firestore listeners:** monitor badge derives from the existing `useQuizSessionTeacher` `responses` subscription.

## Test plan

- [x] Unit (added): `ResultsWatermark` (3), `useResultsTabWarnings` (4), `ResultsTabWarningModal` (6), `PublishScoresModal.protection` (10), `useQuizAssignments.publishProtection` (3), `useQuizSession.unlockResultsForStudent` (4), `AuthContext.appSettings.lastResultsProtection` (1)
- [x] Rules (added): `tests/rules/resultsProtection.test.ts` — 11 scenarios covering increment/decrement/cross-student/teacher decrement/legacy-doc default
- [x] Regression: full validate clean — **2633 root tests + 290 functions tests pass**, type-check + lint + format clean
- [ ] **E2E (deferred):** plan included a Playwright spec but the project's E2E config forces `VITE_AUTH_BYPASS='true'` with Firestore stubbed (`db = {}`), making multi-user authenticated flows infeasible without standing up the emulator + auth fixtures. Recommend splitting into a follow-up infrastructure ticket.
- [ ] **Manual verification:** preview URL — verify (1) watermark legibility, (2) lockout redirect lands on Completed tab, (3) monitor badge updates in real time, (4) post-unlock single tab-switch re-locks.

## Deferred / out of scope

- Browser enforcement (Chrome-only gate) — discussed during design, parked as a separate ticket.
- Multi-assignment monitor badging — current design badges only the currently-active monitored assignment. Cross-assignment awareness would need a denormalized `lockedCount` on the session doc.
- E2E test — see test plan above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)