### PR TITLE
fix(number-line): scale hover hint with container query units

### DIFF
--- a/components/widgets/NumberLine/Widget.tsx
+++ b/components/widgets/NumberLine/Widget.tsx
@@ -336,7 +336,14 @@ export const NumberLineWidget: React.FC<{ widget: WidgetData }> = ({
           </div>
 
           {/* Helpful tooltip/legend */}
-          <div className="absolute bottom-2 left-4 text-xs text-slate-400 pointer-events-none opacity-0 group-hover:opacity-100 transition-opacity">
+          <div
+            className="absolute text-slate-400 pointer-events-none opacity-0 group-hover:opacity-100 transition-opacity"
+            style={{
+              bottom: 'min(8px, 4cqmin)',
+              left: 'min(16px, 8cqmin)',
+              fontSize: 'min(12px, 6cqmin)',
+            }}
+          >
             Click axis to add markers. Use settings to add jumps.
           </div>
         </div>

--- a/docs/scheduled-tasks/css-scaling.md
+++ b/docs/scheduled-tasks/css-scaling.md
@@ -3,7 +3,7 @@
 _Audit model: claude-sonnet-4-6_
 _Action model: claude-opus-4-6_
 _Audit cadence: daily_
-_Last audited: 2026-05-15_
+_Last audited: 2026-05-16_
 _Last action: 2026-04-25_
 
 ---
@@ -21,6 +21,8 @@ _Nothing currently in progress._
 ---
 
 ## Open
+
+_2026-05-16: Scanned all Widget.tsx / index.tsx files for anti-patterns. New commits since 2026-05-15: fix(activity-wall-gallery) 6b6b77c1, fix(text-widget) f4a8315b, fix(embed) 1894d043, fix(subs) 08f13588, feat(Collections+Boards) f691e285, quiz/grader fixes. ActivityWall `max-h-[75vh]` at lines 2101/2107/2110 re-examined — these are inside a fullscreen submission-preview overlay shown at the teacher level, rendered outside the widget canvas container query context; viewport-height units remain correct for this use case (confirmed 2026-05-14 investigation). Embed fix (1894d043) added provider-allowlist logic; the existing portaled zoom toolbar open item unchanged. All pre-existing open items remain valid. No new anti-patterns detected._
 
 _2026-05-15: Scanned all Widget.tsx / index.tsx files for anti-patterns. NEW LOW item detected: MiniApp portaled active-app toolbar (lines 1054–1191, rendered via createPortal to document.body) introduced in `feat(library): preview pane + Duplicate polish` (2026-05-12, f043df3e) — uses hardcoded `text-xs`, `h-8`, `w-3.5 h-3.5` icon sizes in a portaled element outside the container query context. See new open item below. Also: RandomWidget redesign (`feat(random)` commits b0b11656, f8fb1e6b) converted all previously-tracked hardcoded spacing to `cqmin` — random/RandomWidget.tsx entries removed from the group item. Existing open MiniApp item line numbers are stale (save form shifted from lines 848–874 to 1191–1228 as file grew — same UI, different lines). SpecialistSchedule new timer-launch icon (1b946b67) correctly uses `cqmin`. All other existing open items remain valid._
 

--- a/docs/scheduled-tasks/css-scaling.md
+++ b/docs/scheduled-tasks/css-scaling.md
@@ -4,7 +4,7 @@ _Audit model: claude-sonnet-4-6_
 _Action model: claude-opus-4-6_
 _Audit cadence: daily_
 _Last audited: 2026-05-16_
-_Last action: 2026-04-25_
+_Last action: 2026-05-16_
 
 ---
 
@@ -86,16 +86,17 @@ _2026-05-05: New widgets from dev-paul merge audited — BlendingBoard/Widget.ts
 - **Detail:** The widget has two internal overlay dialogs rendered inside the container-query context: (1) the "Start Live Session" / "Share Link" dialog shown when the user launches a live session (lines 120–260), and (2) the "Save to Library" overlay shown when pasting HTML into the widget (lines 848–880). Both use hardcoded Tailwind classes `text-base`, `text-sm`, `text-xs` on labels, body text, code blocks, and buttons. Widget has `skipScaling: true`. At small widget sizes these overlays will show unscaled text and potentially overflow the widget bounds. The prior 2026-04-14 completion entry "MiniAppWidget uses hardcoded Tailwind text sizes — Resolved outside journal workflow" was inaccurate; these overlay states were not assessed.
 - **Fix:** For both overlay dialogs, replace `text-base` → `style={{ fontSize: 'min(16px, 6cqmin)' }}`, `text-sm` → `style={{ fontSize: 'min(14px, 5.5cqmin)' }}`, `text-xs` → `style={{ fontSize: 'min(11px, 4cqmin)' }}`. Also convert any `w-4 h-4` icon sizes and `gap-2`, `p-3`/`p-5` spacing to `cqmin` equivalents.
 
-### LOW NumberLineWidget hover hint `text-xs` still present — prior completion was inaccurate
-
-- **Detected:** 2026-04-26 (re-flagged; originally detected 2026-04-12, incorrectly closed 2026-04-14)
-- **File:** components/widgets/NumberLine/Widget.tsx:339
-- **Detail:** `className="absolute bottom-2 left-4 text-xs text-slate-400 pointer-events-none opacity-0 group-hover:opacity-100 transition-opacity"` is still present. The 2026-04-14 completion note "Resolved outside journal workflow. 2026-04-14 audit confirmed widget is clean" was inaccurate — the `text-xs` at line 339 was never removed. The hint is invisible by default (opacity-0) and only visible on hover, so impact is very low, but the pattern is inconsistent for a `skipScaling: true` widget.
-- **Fix:** Replace `text-xs` with `style={{ fontSize: 'min(12px, 6cqmin)' }}` on the hint div and remove the `bottom-2 left-4` Tailwind positional classes, replacing them with equivalent inline styles `style={{ bottom: 'min(8px, 4cqmin)', left: 'min(16px, 8cqmin)' }}`. (cqmin percentages chosen to reach the px caps at the widget's default size of 700×200, where `cqmin = 2px`; this preserves the original Tailwind dimensions at default size and only shrinks if the widget is sized smaller.)
-
 ---
 
 ## Completed
+
+### LOW NumberLineWidget hover hint `text-xs` still present — prior completion was inaccurate
+
+- **Detected:** 2026-04-26 (re-flagged; originally detected 2026-04-12, incorrectly closed 2026-04-14)
+- **Completed:** 2026-05-16
+- **File:** components/widgets/NumberLine/Widget.tsx:339
+- **Detail:** The hover-visible tooltip hint at the bottom-left of the number-line content area used `text-xs` plus `bottom-2 left-4` as hardcoded Tailwind classes inside a `skipScaling: true` widget — they did not respond to widget size. The 2026-04-14 completion was inaccurate; the classes were never removed.
+- **Resolution:** Replaced the hardcoded Tailwind sizing classes with inline `cqmin` styles per the journal entry: `text-xs` → `fontSize: 'min(12px, 6cqmin)'`, `bottom-2` → `bottom: 'min(8px, 4cqmin)'`, `left-4` → `left: 'min(16px, 8cqmin)'`. Other Tailwind utility classes (`absolute`, `text-slate-400`, `pointer-events-none`, `opacity-0`, `group-hover:opacity-100`, `transition-opacity`) were preserved on `className` — they don't carry pixel sizing. `pnpm exec tsc --noEmit`, `pnpm exec eslint components/widgets/NumberLine/Widget.tsx --max-warnings 0`, and `pnpm exec prettier --check` on the changed files all clean.
 
 ### MEDIUM StarterPackWidget has hardcoded icon size and spacing in addition to text sizes
 

--- a/docs/scheduled-tasks/typescript-eslint.md
+++ b/docs/scheduled-tasks/typescript-eslint.md
@@ -3,7 +3,7 @@
 _Audit model: claude-sonnet-4-6_
 _Action model: claude-opus-4-6_
 _Audit cadence: daily_
-_Last audited: 2026-05-15_
+_Last audited: 2026-05-16_
 _Last action: never_
 
 ---
@@ -15,6 +15,8 @@ _Nothing currently in progress._
 ---
 
 ## Open
+
+_No open items. Both `pnpm type-check` and `pnpm lint` pass cleanly as of 2026-05-16. TypeScript: 0 errors. ESLint: 0 errors, 0 warnings (`--max-warnings 0`). Codebase clean after: feat(Collections+Boards) f691e285 (new Dashboard collection types, boards modal), fix(editors) d50460d0/2a2ba441 (drag-select + toggleList), fix(activity-wall-gallery) 6b6b77c1, fix(text-widget) f4a8315b, fix(quiz-student/quiz/grader) dc682704/e49bf415/e5b63444/fa928a62/d9f2ed10/361dda84/e15bde39, feat(publish-scores) c6edb29c, fix(embed) 1894d043 (provider allowlist), fix(subs) 08f13588. All commits type-safe and lint-clean._
 
 _No open items. Both `pnpm type-check` and `pnpm lint` pass cleanly as of 2026-05-15. TypeScript: 0 errors. ESLint: 0 errors, 0 warnings (`--max-warnings 0`). Codebase clean after: random widget redesign (b0b11656, f8fb1e6b), substitute share Phase 1 (c42faa9d), quiz-written UX overhaul (7de28fe7), ai-draft per-type question mix fix (7125a4c6), results-UI hardening (0ac2e042), drive-auth OAuth hardening (0ebb4a0a), Re-Export Sheet solo button (442886da), multi-class student name resolution (0f8466f8), subs+scoreboard silent failure fixes (95b569e5), text-widget paragraph normalization (54eac967), specialist-schedule timer-launch icon (1b946b67). All 14 commits on dev-paul since 2026-05-14 audit verified type-safe and lint-clean._
 

--- a/docs/scheduled-tasks/widget-registry.md
+++ b/docs/scheduled-tasks/widget-registry.md
@@ -3,7 +3,7 @@
 _Audit model: claude-sonnet-4-6_
 _Action model: claude-opus-4-6_
 _Audit cadence: daily_
-_Last audited: 2026-05-15_
+_Last audited: 2026-05-16_
 _Last action: 2026-05-15_
 
 ---
@@ -15,6 +15,8 @@ _Nothing currently in progress._
 ---
 
 ## Open
+
+_2026-05-16: Full audit of all 63 WidgetType values. types.ts WidgetType union unchanged (still 63 types). Recent commits since 2026-05-15: feat(Collections+Boards) f691e285, fix(editors) d50460d0/2a2ba441, fix(activity-wall-gallery) 6b6b77c1, fix(text-widget) f4a8315b, fix(quiz-student/quiz/grader) dc682704/e49bf415/e5b63444/fa928a62/d9f2ed10, feat(grader) 361dda84, feat(quiz) e15bde39, feat(publish-scores) c6edb29c, fix(embed) 1894d043, fix(subs) 08f13588. None touched WidgetRegistry.ts, widgetDefaults.ts, tools.ts, or widgetGradeLevels.ts. Zero new gaps. All lazyNamed() export names remain correct. No open items._
 
 _2026-05-15: Full audit of all 63 WidgetType values. types.ts WidgetType union unchanged (still 63 types, lines 1–64). No new widget types or registry entries added. Recent commits verified: random redesign (`feat(random)` ×2, `b0b11656`, `f8fb1e6b`) added new sub-components (RandomGroups, StudentChip, UnassignedTray, GroupSizeStepper) but no new WidgetType — `RandomWidget` and `RandomSettings` export names in lazyNamed() still match source. Substitute share (`c42faa9d`) added `SubstituteShareFields` and `substitute` to `SharedBoardIntendedMode` — no WidgetType change. Quiz-written overhaul (`7de28fe7`) and other commits: no new widget types. WidgetRegistry.ts, widgetDefaults.ts, tools.ts, widgetGradeLevels.ts all unchanged since 2026-05-14 audit. Two existing LOW open items remain valid._
 


### PR DESCRIPTION
## Summary

Closes the LOW css-scaling journal item from 2026-04-26 (re-flagged after the incorrect 2026-04-14 closure).

The hover-visible tooltip hint at the bottom-left of the NumberLine widget used hardcoded `text-xs` and `bottom-2 left-4` Tailwind classes inside a `skipScaling: true` widget, so the size and offset did not respond to widget size.

## Changes

- `components/widgets/NumberLine/Widget.tsx:339` — replaced hardcoded Tailwind sizing with inline `cqmin` styles per the journal recommendation:
  - `text-xs` → `fontSize: 'min(12px, 6cqmin)'`
  - `bottom-2` → `bottom: 'min(8px, 4cqmin)'`
  - `left-4` → `left: 'min(16px, 8cqmin)'`
  - Non-sizing utility classes preserved on `className` (`absolute`, color, pointer-events, hover transition).
- `docs/scheduled-tasks/css-scaling.md` — moved entry from Open to Completed; updated Last action date.

## Test plan

- [x] `pnpm exec tsc --noEmit` — clean
- [x] `pnpm exec eslint components/widgets/NumberLine/Widget.tsx --max-warnings 0` — clean
- [x] `pnpm exec prettier --check` on changed files — clean
- [ ] Visual: hover over a number-line widget at default size — hint should appear in the same position as before; at smaller widget sizes the hint should now shrink proportionally instead of remaining a fixed 12px label.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BgUc5WsHysrwbWD2brrocV)_